### PR TITLE
Promote Player to a real C++ class deriving from Actor

### DIFF
--- a/include/Actor.h
+++ b/include/Actor.h
@@ -71,25 +71,33 @@ struct Actor : ActorDerived {
     s32 mCamSpacePosX;      /* 0x074 */
     s32 mCamSpacePosY;      /* 0x078 */
     s32 mCamSpacePosZ;      /* 0x07c */
-    u8  pad_080[0xc];
+    /* 0x080..0x08b and the 0x098..0x0ab block below were bare padding and u8
+       placeholders here, while Player.h -- describing the same bytes -- named
+       them and typed them s32. Player is right, and the evidence is outside
+       Player: BooCage::InitResources and MadPiano::InitResources write -0x4000
+       and -0x2000 to 0x09c and -0x46000 / -0x3c000 to 0x0a0, which are fix12
+       gravity and terminal velocity, not bytes. Player::St_Walk_Main passes
+       0x098 as a 32-bit argument.
+
+       These were deliberately left wrong until now: nothing compiled against
+       Actor's copies, so no gate could prove a change either way. Now that
+       Player inherits them, 62 files using mHorzSpeed and 49 using mVertSpeed
+       resolve through this header, and a wrong width fails immediately. */
+    s32 mScaleX;            /* 0x080 */
+    s32 mScaleY;            /* 0x084 */
+    s32 mScaleZ;            /* 0x088 */
     s16 mAngleX;            /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     s16 mAngleZ;            /* 0x090 */
     s16 mPrevAngleX;            /* 0x092 */
     s16 mPrevAngleY;            /* 0x094 */
     s16 mPrevAngleZ;            /* 0x096 */
-    u8  unk_098;            /* 0x098 */
-    u8  pad_099[0x3];
-    u8  unk_09c;            /* 0x09c */
-    u8  pad_09d[0x3];
-    u8  unk_0a0;            /* 0x0a0 */
-    u8  pad_0a1[0x3];
-    u8  unk_0a4;            /* 0x0a4 */
-    u8  pad_0a5[0x3];
-    u8  unk_0a8;            /* 0x0a8 */
-    u8  pad_0a9[0x3];
-    u8  unk_0ac;            /* 0x0ac */
-    u8  pad_0ad[0x3];
+    s32 mHorzSpeed;         /* 0x098 */
+    s32 mVertAccel;         /* 0x09c -- fix12, negative (gravity) */
+    s32 mTerminalVelocity;  /* 0x0a0 -- fix12, negative */
+    u8  pad_0a4[0x4];       /* likely the same physics block; unproven */
+    s32 mVertSpeed;         /* 0x0a8 */
+    u8  pad_0ac[0x4];       /* likely the same physics block; unproven */
     u32 mFlags;             /* 0x0b0 -- bit 0x10000 suppresses behaviour */
     s32 unk_0b4;            /* 0x0b4 */
     s32 unk_0b8;            /* 0x0b8 -- clip radius; 0 skips the camera transform */
@@ -167,25 +175,21 @@ struct Actor {
     s32 mCamSpacePosX;      /* 0x074 */
     s32 mCamSpacePosY;
     s32 mCamSpacePosZ;
-    u8  pad_080[0xc];
+    s32 mScaleX;            /* 0x080 */
+    s32 mScaleY;
+    s32 mScaleZ;
     s16 mAngleX;            /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     s16 mAngleZ;            /* 0x090 */
     s16 mPrevAngleX;        /* 0x092 */
     s16 mPrevAngleY;        /* 0x094 */
     s16 mPrevAngleZ;        /* 0x096 */
-    u8  unk_098;
-    u8  pad_099[0x3];
-    u8  unk_09c;
-    u8  pad_09d[0x3];
-    u8  unk_0a0;
-    u8  pad_0a1[0x3];
-    u8  unk_0a4;
-    u8  pad_0a5[0x3];
-    u8  unk_0a8;
-    u8  pad_0a9[0x3];
-    u8  unk_0ac;
-    u8  pad_0ad[0x3];
+    s32 mHorzSpeed;         /* 0x098 */
+    s32 mVertAccel;         /* 0x09c */
+    s32 mTerminalVelocity;  /* 0x0a0 */
+    u8  pad_0a4[0x4];
+    s32 mVertSpeed;         /* 0x0a8 */
+    u8  pad_0ac[0x4];
     u32 mFlags;             /* 0x0b0 */
     s32 unk_0b4;
     s32 unk_0b8;

--- a/include/Player.h
+++ b/include/Player.h
@@ -16,6 +16,7 @@
 #ifndef PLAYER_H
 #define PLAYER_H
 #include "types.h"
+#include "Actor.h"
 
 /* fwd */
 struct Actor;
@@ -47,55 +48,12 @@ struct pos_;
 struct v;
 struct v_;
 struct x;
-struct Player {
-    u8  pad_000[0x8];
-    s32 mParam;            /* 0x008 */
-    /* 0x00c..0x05b. unk_00c, unk_030 and mModelAnim1 used to be named in here.
-       Their only evidence was src/_ZN6Player6ST_OWLE.c, which is ov006 code
-       carrying a Player name -- it reads 0x08/0x0c as a fix12 2D coordinate
-       pair, which cannot be ActorBase's param1 and actorID. That file now uses
-       its own local struct, and nothing else referenced these three. */
-    u8  pad_00c[0x50];
-    s32 mPosX;            /* 0x05c */
-    s32 mPosY;            /* 0x060 */
-    s32 mPosZ;            /* 0x064 */
-    u8  pad_068[0xc];
-    /* 0x074..0x07f is a Vector3, not a byte plus padding: 13 files take
-       &mCamSpacePosX and cast it to Vector3* for Sound::PlayCharVoice and
-       friends. Named to match Actor.h, which decomposes the same bytes into
-       mCamSpacePosX / Y / Z. */
-    s32 mCamSpacePosX;      /* 0x074 */
-    s32 mCamSpacePosY;      /* 0x078 */
-    s32 mCamSpacePosZ;      /* 0x07c */
-    s32 mScaleX;            /* 0x080 */
-    s32 mScaleY;            /* 0x084 */
-    s32 mScaleZ;            /* 0x088 */
-    s16 mAngleX;            /* 0x08c */
-    s16 mAngleY;            /* 0x08e */
-    s16 mAngleZ;            /* 0x090 */
-    /* 0x092..0x097 is a prev-angle triple. 0x094 was called mTargetAngleY here
-       and mPrevAngleY in Actor.h; the two had to agree before Player can
-       inherit these bytes. Renamed to mPrevAngleY on the structural argument:
-       its siblings at 0x092 and 0x096 are unambiguously mPrevAngleX/Z, and
-       Player uses 0x094 exactly as it uses them -- `mPrevAngleY = mAngleY` to
-       save and `mAngleY = mPrevAngleY` to restore, mirroring
-       `mAngleX = mPrevAngleX`. It is also assigned from mDesiredAngleY, which
-       reads as a target, but a previous-angle slot being reused to stage a
-       desired angle is ordinary; a prev-triple with a target in the middle is
-       not. Names cannot change codegen, so this is reversible. */
-    s16 mPrevAngleX;        /* 0x092 */
-    s16 mPrevAngleY;        /* 0x094 */
-    s16 mPrevAngleZ;        /* 0x096 */
-    s32 mHorzSpeed;            /* 0x098 */
-    s32 mVertAccel;            /* 0x09c */
-    s32 mTerminalVelocity;            /* 0x0a0 */
-    u8  pad_0a4[0x4];
-    s32 mVertSpeed;            /* 0x0a8 */
-    u8  pad_0ac[0x4];
-    u32 mFlags;             /* 0x0b0 -- bitwise: `&= ~0x80`, `& 0x10` */
-    u8  pad_0b4[0x18];
-    s8  mAreaId;            /* 0x0cc */
-    u8  pad_0cd[0x3];
+struct Player : Actor {
+    /* 0x000..0x0cf is Actor's, inherited rather than duplicated. It used to be
+       written out inline here -- mParam at 0x008 was ActorBase's param1, mPosX
+       at 0x05c was Actor's, and so on. The names were reconciled first so that
+       deleting the block is all that happens here. sizeof(Actor) is 0xd0, so
+       Player's own fields start exactly where the base ends. */
     s32 mEatingPlayer;            /* 0x0d0 */
     u8  pad_0d4[0x8];
     u8  mBodyModels;            /* 0x0dc */
@@ -339,14 +297,36 @@ struct Player {
     u8  unk_764;            /* 0x764 */
     u8  pad_765[0x1];
     s16 unk_766;            /* 0x766 */
-#ifdef __cplusplus
     /* methods */
+    /* --- vtable. _ZTV6Player (0x0210a83c, ov002) is Actor's 31 slots with
+           eight overridden and NO new virtuals; see notes/actor-vtables.md.
+
+           The destructor is declared FIRST on purpose. CW 1.2 emits the vtable
+           into the translation unit that DEFINES the first non-inline virtual
+           declared -- the key function -- and that copy collides with the one
+           the module's gap object supplies from ROM data. Because Player only
+           overrides, an override takes its base's slot wherever it is declared,
+           so putting ~Player first costs nothing and pins the key function to
+           the destructor, which is only ever defined as an extern "C" free
+           function in D0Ev/D2Ev, never as Player::~Player.
+
+           So: ~Player must never be defined ANYWHERE, including inline. An
+           inline definition would shift key-function status to Behavior, which
+           IS a real method, and emit a duplicate vtable. --- */
+    virtual ~Player();                  /* slots 16, 17 */
+    virtual s32  InitResources();       /* slot  0 */
+    virtual s32  CleanupResources();    /* slot  3 */
+    virtual s32  Behavior();            /* slot  6 */
+    virtual s32  Render();              /* slot  9 */
+    virtual void OnPendingDestroy();    /* slot 12 */
+    virtual int  OnYoshiTryEat();       /* slot 18 -- int, not u32: it overrides
+                                           Actor::OnYoshiTryEat and CW rejects a
+                                           mismatched return type on an override */
+
     int * TryExitCharacterDoorWithIntro();
-    int Behavior();
     int Burn();
     int CanPause();
     int CanWarp();
-    int CleanupResources();
     int DropActor();
     int FinishedAnim();
     int GetHealth();
@@ -368,7 +348,6 @@ struct Player {
     int IsStateEnteringLevel();
     int JumpIntoBooCage(Vector3 & v_);
     int LostGrabbedObject();
-    int Render();
     int SetNoControlState(unsigned char a_, int b, unsigned char c_);
     int Shock(unsigned int j);
     int ShowMessage(ActorBase & a_, unsigned int b, const Vector3 * v, unsigned int d_, unsigned int e_);
@@ -532,7 +511,6 @@ struct Player {
     s32 St_LevelEnter_Cleanup();
     s32 St_Null_Cleanup();
     s32 St_Null_Main();
-    u32 OnYoshiTryEat();
     unsigned int GetBodyModelID(unsigned int a, bool b_) const;
     void BlowAway(short v);
     void EnterWhirlpool();
@@ -542,7 +520,6 @@ struct Player {
     void InitMetalWario();
     void InitVanishLuigi();
     void InitWingFeathers(bool b_);
-    void OnPendingDestroy();
     void OpenBigDoor();
     void PlayMammaMiaSound();
     void RegisterEggCoinCount(unsigned int count, bool b2, bool b3);
@@ -554,7 +531,6 @@ struct Player {
     void St_WallJump_Init();
     void TurnOffToonShading(unsigned int j);
     void Unk_020ca488();
-#endif
 };
 
 /* Offsets seen through this-pointer but far outside the object - almost

--- a/src/_ZN6Player12FinishedAnimEv.cpp
+++ b/src/_ZN6Player12FinishedAnimEv.cpp
@@ -7,7 +7,7 @@ extern "C" int _ZN9Animation8FinishedEv(char*);
 
 int Player::FinishedAnim()
 {
-  unsigned int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam&0xff, 0);
+  unsigned int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1&0xff, 0);
   char* m = *(char**)(((char*)this) + id*4 + 0xdc);
   return _ZN9Animation8FinishedEv(m+0x50) != 0;
 }

--- a/src/_ZN6Player12St_Bonk_MainEv.cpp
+++ b/src/_ZN6Player12St_Bonk_MainEv.cpp
@@ -64,7 +64,7 @@ int Player::St_Bonk_Main()
     }
 willhit:
     {
-        u32 arg = (u8)mParam;
+        u32 arg = (u8)param1;
         int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
         char* anim = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
         if (_ZNK9Animation12WillHitFrameEi(anim, 0x2e) != 0) {

--- a/src/_ZN6Player12St_Hurt_InitEv.cpp
+++ b/src/_ZN6Player12St_Hurt_InitEv.cpp
@@ -16,7 +16,7 @@ int Player::St_Hurt_Init()
     char* m;
     u8 old;
     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a6d4[mStateStep & 7], 0x40000000, 0x1000, 0);
-    mid = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+    mid = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
     m = *(char**)(((char*)this) + mid*4 + 0xdc);
     m = (char*)(((unsigned int)m + 0x50) & 0xFFFFFFFFU);
     *(int*)(m + 8) = 0;

--- a/src/_ZN6Player12St_Jump_MainEv.cpp
+++ b/src/_ZN6Player12St_Jump_MainEv.cpp
@@ -51,7 +51,7 @@ int Player::St_Jump_Main()
       }
 
       {
-        u32 id = _ZNK6Player14GetBodyModelIDEjb(((void*)this), *(u32*)((char*)&mParam) & 0xff, 0);
+        u32 id = _ZNK6Player14GetBodyModelIDEjb(((void*)this), *(u32*)((char*)&param1) & 0xff, 0);
         void* anim = *(void**)((char*)((void*)this) + (id << 2) + 0xdc);
         u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50))) + 8);
         u16 t = (u16)(w >> 12);
@@ -60,7 +60,7 @@ int Player::St_Jump_Main()
         }
       }
     } else {
-      int idx = *(int*)((char*)&mParam);
+      int idx = *(int*)((char*)&param1);
       if (*(u8*)((char*)&mIsMega) != 0) {
         idx = 0;
       }

--- a/src/_ZN6Player12St_Wait_MainEv.cpp
+++ b/src/_ZN6Player12St_Wait_MainEv.cpp
@@ -55,7 +55,7 @@ int Player::St_Wait_Main()
 
     case 8: {
         if (!(*(unsigned short*)(data_0209f49c+data_020a0e40*0x18) & 0x800) &&
-            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0)) {
+            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0)<<2)+0xdc))+0x50, 0)) {
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2c, ((char*)this)+0x74);
         }
     }
@@ -124,7 +124,7 @@ int Player::St_Wait_Main()
             mStateStep = 2;
         }
         {
-        unsigned int x1 = mParam;
+        unsigned int x1 = param1;
         switch (x1) {
         default:
             break;
@@ -133,8 +133,8 @@ int Player::St_Wait_Main()
             void* animA = *(void**)(((char*)this)+(idA<<2)+0xdc);
             if (_ZNK9Animation12WillHitFrameEi((char*)animA+0x50, 0x5a)) {
                 _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2d, ((char*)this)+0x74);
-            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x3a)
-                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x44)) {
+            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0)<<2)+0xdc))+0x50, 0x3a)
+                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0)<<2)+0xdc))+0x50, 0x44)) {
                 _ZN5Sound9PlayBank0EjRK7Vector3(4, ((char*)this)+0x74);
             }
             break;
@@ -145,7 +145,7 @@ int Player::St_Wait_Main()
             if (_ZNK9Animation12WillHitFrameEi((char*)animD+0x50, 0x6e)) {
                 _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2d, ((char*)this)+0x74);
             } else {
-                int idE = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam&0xff, 0);
+                int idE = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1&0xff, 0);
                 void* animE = *(void**)(((char*)this)+(idE<<2)+0xdc);
                 if (_ZNK9Animation12WillHitFrameEi((char*)animE+0x50, 0x32)) {
                     _ZN5Sound9PlayBank0EjRK7Vector3(0xb1, ((char*)this)+0x74);
@@ -158,8 +158,8 @@ int Player::St_Wait_Main()
             void* animF = *(void**)(((char*)this)+(idF<<2)+0xdc);
             if (_ZNK9Animation12WillHitFrameEi((char*)animF+0x50, 0x20)) {
                 _ZN5Sound9PlayBank0EjRK7Vector3(2, ((char*)this)+0x74);
-            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x47)
-                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x60)) {
+            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0)<<2)+0xdc))+0x50, 0x47)
+                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0)<<2)+0xdc))+0x50, 0x60)) {
                 _ZN5Sound9PlayBank0EjRK7Vector3(3, ((char*)this)+0x74);
             }
             break;
@@ -183,7 +183,7 @@ int Player::St_Wait_Main()
 
     case 2: {
         if (unk_723==0 &&
-            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 1)) {
+            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0)<<2)+0xdc))+0x50, 1)) {
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2a, ((char*)this)+0x74);
         }
         {
@@ -244,7 +244,7 @@ int Player::St_Wait_Main()
         if (unk_6e6 == 0) {
             func_ov002_020d2f24(((char*)this));
             if (unk_723==0 &&
-                _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0xd)) {
+                _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0)<<2)+0xdc))+0x50, 0xd)) {
                 _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2b, ((char*)this)+0x74);
             }
         }

--- a/src/_ZN6Player12St_Walk_InitEv.cpp
+++ b/src/_ZN6Player12St_Walk_InitEv.cpp
@@ -96,7 +96,7 @@ merge:
         }
     }
 
-    if (mParam == 1) {
+    if (param1 == 1) {
         if (mIsInShallowWater == 0) {
             unk_6ec = 1;
         }

--- a/src/_ZN6Player12St_Walk_MainEv.cpp
+++ b/src/_ZN6Player12St_Walk_MainEv.cpp
@@ -93,7 +93,7 @@ label_1f0:
     if (_ZN6Player12FinishedAnimEv(((char*)this))) goto label_27c;
 
     {
-        u32 arg = (u8)mParam;
+        u32 arg = (u8)param1;
         int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
         char* anim = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
         if (_ZN9Animation8GetFlagsEv(anim)) goto end;

--- a/src/_ZN6Player13OnYoshiTryEatEv.cpp
+++ b/src/_ZN6Player13OnYoshiTryEatEv.cpp
@@ -3,13 +3,17 @@
 // @symbol _ZN6Player13OnYoshiTryEatEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-/* Player::OnYoshiTryEat() at 0x020e69b8 (ov002) -- vtable slot 17.
- * Overrides Actor's slot 17; returns an OnYoshiEatReturnVal of 1
- * (Yoshi cannot eat the Player). The implicit Player* this is unused.
+/* Player::OnYoshiTryEat() at 0x020e69b8 (ov002) -- vtable slot 18, not 17.
+ * Slot 17 is _ZN6PlayerD0Ev; slot 18 is the first of Actor's own virtuals.
+ * See notes/actor-vtables.md, which was read out of _ZTV6Player.
+ *
+ * Returns an OnYoshiEatReturnVal of 1 (Yoshi cannot eat the Player). The
+ * implicit Player* this is unused.
+ *
+ * Returns int rather than u32 to match Actor::OnYoshiTryEat -- CW rejects an
+ * override whose return type differs from the base declaration.
  */
-struct Player;
-
-u32 Player::OnYoshiTryEat()
+int Player::OnYoshiTryEat()
 {
     (void)this;
     return 1;

--- a/src/_ZN6Player13St_Crawl_MainEv.cpp
+++ b/src/_ZN6Player13St_Crawl_MainEv.cpp
@@ -43,14 +43,14 @@ int Player::St_Crawl_Main()
         int off = idx * 0x18;
         s16 val1 = *(s16*)((char*)data_0209f4a0 + off);
         if (val1 >= 0x200 && ((*(u16*)((char*)data_0209f49c + off) & 0x400) != 0 || func_ov002_020d1164(((char*)this)) != 0)) {
-            int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+            int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
             char* anim = (char*)((int*)((char*)&mBodyModels))[id] + 0x50;
             if (_ZNK9Animation12WillHitFrameEi(anim, 0xe) ||
-                _ZNK9Animation12WillHitFrameEi((char*)((int*)((char*)&mBodyModels))[_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0)] + 0x50, 0x1c)) {
+                _ZNK9Animation12WillHitFrameEi((char*)((int*)((char*)&mBodyModels))[_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0)] + 0x50, 0x1c)) {
                 _ZN5Sound9PlayBank0EjRK7Vector3(mGroundSoundType + 0xc0, ((char*)this) + 0x74);
             }
             int shifted = mHorzSpeed >> 2;
-            int id3 = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+            int id3 = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
             char* anim3 = (char*)(((long long)(int)((char*)((int*)((char*)&mBodyModels))[id3] + 0x50)));
             *(int*)(anim3 + 0xc) = shifted;
             if (func_ov002_020d36d8(((char*)this), 1))

--- a/src/_ZN6Player13St_Throw_MainEv.cpp
+++ b/src/_ZN6Player13St_Throw_MainEv.cpp
@@ -25,7 +25,7 @@ int Player::St_Throw_Main()
   }
   if(*(char**)((char*)&mHeldObj)){
     int r4 = 5;
-    int id=_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0);
+    int id=_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0);
     void* anim=*(void**)(((char*)this)+(id<<2)+0xdc);
     if(_ZNK9Animation12WillHitFrameEi((char*)anim+0x50,0)){
       if(func_ov002_020c19d0(((char*)this),0x40,0x32)) r4=0;
@@ -45,7 +45,7 @@ int Player::St_Throw_Main()
       if(b) r4=0xd;
     }
   Ld0:
-    int id2=_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0);
+    int id2=_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0);
     void* anim2=*(void**)(((char*)this)+(id2<<2)+0xdc);
     if(_ZNK9Animation12WillHitFrameEi((char*)anim2+0x50,r4)){
       int b2=(*(int*)(*(char**)((char*)&mHeldObj)+0xb0)&0x200)?1:0;

--- a/src/_ZN6Player14InitMetalWarioEv.cpp
+++ b/src/_ZN6Player14InitMetalWarioEv.cpp
@@ -27,13 +27,13 @@ void Player::InitMetalWario()
         _ZN6Player18TurnOffToonShadingEj(((char *)this), b);
         _ZN6Player18TurnOffToonShadingEj(((char *)this), unk_6dc);
         unk_73c = 0;
-        mParam = mHatCharacter;
+        param1 = mHatCharacter;
         unk_71a = 0;
     }
 
     mIsMetal = 1;
 
-    v = mParam;
+    v = param1;
     id = _ZNK6Player14GetBodyModelIDEjb(((char *)this), v & 0xff, 0);
     _ZN10ModelAnim24CopyERKS_Pcj(
         *(void **)(((char *)this) + id * 4 + 0xdc),

--- a/src/_ZN6Player14St_OnWall_InitEv.cpp
+++ b/src/_ZN6Player14St_OnWall_InitEv.cpp
@@ -11,7 +11,7 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned i
 int Player::St_OnWall_Init()
 {
   int r3=0x1000;
-  if(mParam==2){
+  if(param1==2){
     if(mStateStep==2) r3=0x2000;
   }
   _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_020ff164[mStateStep], 0, r3, 0);

--- a/src/_ZN6Player15St_DeadHit_MainEv.cpp
+++ b/src/_ZN6Player15St_DeadHit_MainEv.cpp
@@ -43,7 +43,7 @@ int Player::St_DeadHit_Main()
     switch (mStateWork) {
     case 0:
         if (_ZNK9Animation12WillHitFrameEi(
-                (void *)(((s32 *)((char *)&mBodyModels))[_ZNK6Player14GetBodyModelIDEjb(((char *)this), mParam & 0xff, 0)] + 0x50),
+                (void *)(((s32 *)((char *)&mBodyModels))[_ZNK6Player14GetBodyModelIDEjb(((char *)this), param1 & 0xff, 0)] + 0x50),
                 data_ov002_02109db8[mStateStep & 1]) != 0)
             mStateWork = 1;
         break;

--- a/src/_ZN6Player15St_Grabbed_MainEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_MainEv.cpp
@@ -38,13 +38,13 @@ int Player::St_Grabbed_Main()
     }
 
     if (mStateTimer != 0) {
-        id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
         model = *(char**)(((char*)this) + (id << 2) + 0xdc);
         pRate = (int*)(model + 0x50);
         pRate = (int*)((char*)pRate + 0xc);
         *pRate = 0x4000;
     } else {
-        id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
         model = *(char**)(((char*)this) + (id << 2) + 0xdc);
         pRate = (int*)(model + 0x50);
         pRate = (int*)((char*)pRate + 0xc);

--- a/src/_ZN6Player15St_Swallow_MainEv.cpp
+++ b/src/_ZN6Player15St_Swallow_MainEv.cpp
@@ -22,11 +22,11 @@ int Player::St_Swallow_Main()
 {
     void* p360;
 
-    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc)) + 0x50, 3)) {
+    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc)) + 0x50, 3)) {
         func_ov002_020d71a0(((char*)this));
         goto L65ec;
     }
-    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc)) + 0x50, 7) == 0) {
+    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc)) + 0x50, 7) == 0) {
         goto L65ec;
     }
 

--- a/src/_ZN6Player16CleanupResourcesEv.cpp
+++ b/src/_ZN6Player16CleanupResourcesEv.cpp
@@ -102,7 +102,7 @@ int Player::CleanupResources()
         if (q != 0)
             func_0203cbc0(q);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[mCharFileBase + (mParam & 3)]);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[mCharFileBase + (param1 & 3)]);
     b = data_0209f2d8;
     b = b == 1;
     if (b != false_)
@@ -228,7 +228,7 @@ int Player::CleanupResources()
     }
     if (mLoadedResourceFlags & 0x40) {
         u32 idx = mHatCharacter;
-        if (idx == (u32)mParam)
+        if (idx == (u32)param1)
             idx = unk_6dc;
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[mCharFileBase + idx]);
     }

--- a/src/_ZN6Player16InitWingFeathersEb.cpp
+++ b/src/_ZN6Player16InitWingFeathersEb.cpp
@@ -16,7 +16,7 @@ void Player::InitWingFeathers(bool b_)
 
     int t0 = (data_0209f2d8[0] == 1);
     if (!t0) {
-        if (mParam != 0) return;
+        if (param1 != 0) return;
     }
     func_ov002_020bdd2c(((char*)this));
     mHasWings = 1;

--- a/src/_ZN6Player16SetRealCharacterEj.cpp
+++ b/src/_ZN6Player16SetRealCharacterEj.cpp
@@ -22,23 +22,23 @@ void Player::SetRealCharacter(unsigned int chr_)
 {
     u32 chr = (u32)chr_;
 
-    u32 cur = mParam;
+    u32 cur = param1;
     u32 base = mCharFileBase;
     u32 m1, m2;
 
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[base + (cur & 3)]);
     _ZN6Player18SetNewHatCharacterEjjb(((char *)this), chr, 0, 1);
-    mParam = chr;
+    param1 = chr;
     mCharacter = (u8)chr;
-    data_02092128[mPlayerNo] = (u8)mParam;
-    data_0209caa0[0x41] = (u8)mParam;
-    _ZN9Animation8LoadFileER13SharedFilePtr(*data_ov002_020ff480[mCharFileBase + (mParam & 3)]);
+    data_02092128[mPlayerNo] = (u8)param1;
+    data_0209caa0[0x41] = (u8)param1;
+    _ZN9Animation8LoadFileER13SharedFilePtr(*data_ov002_020ff480[mCharFileBase + (param1 & 3)]);
     func_ov002_020e6330(((char *)this));
     _ZN6Player4HealEi(((char *)this), 0x880);
     unk_73c = 0;
 
     m1 = _ZNK6Player14GetBodyModelIDEjb(((char *)this), chr, 0);
-    m2 = _ZNK6Player14GetBodyModelIDEjb(((char *)this), mParam & 0xff, 0);
+    m2 = _ZNK6Player14GetBodyModelIDEjb(((char *)this), param1 & 0xff, 0);
     _ZN10ModelAnim24CopyERKS_Pcj(
         *(void **)(((char *)this) + m1 * 4 + 0xdc),
         *(void **)(((char *)this) + m2 * 4 + 0xdc),

--- a/src/_ZN6Player16St_BackFlip_InitEv.cpp
+++ b/src/_ZN6Player16St_BackFlip_InitEv.cpp
@@ -23,7 +23,7 @@ int Player::St_BackFlip_Init()
   *(char*)((char*)&mLandSoundPlayed)=0;
   _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), 0x2a, 0x40000000, 0x1000, 0);
   *(int*)((char*)&mVertSpeed)=0x3e000;
-  if (*(int*)((char*)&mParam)==1) *(int*)((char*)&mVertSpeed)=0x4c000;
+  if (*(int*)((char*)&param1)==1) *(int*)((char*)&mVertSpeed)=0x4c000;
   func_ov002_020e2ad0(((void*)this));
   *(int*)((char*)&mHorzSpeed)=0x10000;
   *(short*)((char*)&mPrevAngleY) = *(short*)((char*)&mAngleY) + 0x8000;

--- a/src/_ZN6Player16St_SideFlip_MainEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_MainEv.cpp
@@ -67,7 +67,7 @@ int Player::St_SideFlip_Main()
                 mVertAccel = -0x3400;
             }
         } else {
-            if (mParam == 1
+            if (param1 == 1
                 && _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211052c)) {
                 unk_6e6 = 0;
                 _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110454);
@@ -76,7 +76,7 @@ int Player::St_SideFlip_Main()
         }
 
         if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021101e4)) {
-            int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+            int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
             void* anim = *(void**)(((char*)this) + (id << 2) + 0xdc);
             u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50))) + 8);
             if ((u16)(w >> 12) == 0x10) {

--- a/src/_ZN6Player16St_WallJump_MainEv.cpp
+++ b/src/_ZN6Player16St_WallJump_MainEv.cpp
@@ -31,7 +31,7 @@ int Player::St_WallJump_Main()
     }
     if (func_ov002_020e2664(((void*)this))) return 1;
     {
-      int idx = *(int*)((char*)&mParam);
+      int idx = *(int*)((char*)&param1);
       int* row = &data_ov002_0211073c[idx*2];
       int v = row[1];
       void* p = (char*)((void*)this) + (v>>1);

--- a/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
@@ -44,7 +44,7 @@ int Player::St_HoldHeavy_Main()
             if (_ZN6Player12FinishedAnimEv(((char*)this))) {
                 mStateStep = 1;
             } else {
-                u32 arg = (u8)mParam;
+                u32 arg = (u8)param1;
                 int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
                 char* animPtr = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
                 if (_ZNK9Animation12WillHitFrameEi(animPtr, 6)) {
@@ -78,7 +78,7 @@ int Player::St_HoldHeavy_Main()
             s16 t = *(s16*)((char*)data_0209f4a0 + off);
             if (t != 0) {
                 ApproachAngle((short*)((char*)&mPrevAngleY), mDesiredAngleY, 8, 0x1000, 0x400);
-                var_r1 = data_ov002_020ff1d0[mParam];
+                var_r1 = data_ov002_020ff1d0[param1];
             }
         }
     }
@@ -97,7 +97,7 @@ int Player::St_HoldHeavy_Main()
 
     if (mHorzSpeed == 0) {
         mAngleY = mPrevAngleY;
-    } else if (mParam == 1) {
+    } else if (param1 == 1) {
         ApproachAngle((short*)((char*)&mAngleY), mPrevAngleY, 0x10, 0x1000, 0x100);
     } else {
         ApproachAngle((short*)((char*)&mAngleY), mPrevAngleY, 8, 0x2000, 0x400);
@@ -106,7 +106,7 @@ int Player::St_HoldHeavy_Main()
     if (mHorzSpeed == 0) {
         if (_ZN6Player12FinishedAnimEv(((char*)this)) ||
             !_ZN9Animation8GetFlagsEv(
-                *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4 + 0xdc) + 0x50)) {
+                *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)param1, 0) * 4 + 0xdc) + 0x50)) {
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_020ff254[mStateWork + 2], 0, 0x1000, 0);
         }
     } else {

--- a/src/_ZN6Player17St_HoldLight_InitEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_InitEv.cpp
@@ -18,7 +18,7 @@ int Player::St_HoldLight_Init()
       int b = (int)((*(int*)(o+0xb0) & 0x8000) != 0);
       if(b != 0){
         anim = 0x86;
-        if(mParam == 2){
+        if(param1 == 2){
           if((int)(*(unsigned short*)(o+0xc) == 0xce) != 0) anim = 0x2f;
         }
       }

--- a/src/_ZN6Player17St_HoldLight_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_MainEv.cpp
@@ -55,7 +55,7 @@ int Player::St_HoldLight_Main()
                 mHorzSpeed = 0;
                 mStateStep = 1;
             } else {
-                u32 arg = (u8)mParam;
+                u32 arg = (u8)param1;
                 int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
                 char* anim = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
                 if (_ZNK9Animation12WillHitFrameEi(anim, 6)) {
@@ -88,7 +88,7 @@ int Player::St_HoldLight_Main()
             mStateArg = 0;
         }
         ApproachAngle((short*)((char*)&mPrevAngleY), t, 4, 0x2000, 0x800);
-        var_r4 = data_ov002_020ff1c0[mParam];
+        var_r4 = data_ov002_020ff1c0[param1];
     }
 
     if (*((u8*)data_0209f4ac + data_020a0e40 * 0x18) == 0) {
@@ -139,14 +139,14 @@ int Player::St_HoldLight_Main()
     if (mHorzSpeed == 0) {
         if (_ZN6Player12FinishedAnimEv(((char*)this)) ||
             !_ZN9Animation8GetFlagsEv(
-                *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4 + 0xdc) + 0x50)) {
+                *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)param1, 0) * 4 + 0xdc) + 0x50)) {
             int* light = *(int**)((char*)&mHeldObj);
             u32 animId = 0x33;
             if (light != 0) {
                 int b = (*(int*)((char*)light + 0xb0) & 0x8000) != 0;
                 if (b) {
                     animId = 0x87;
-                    if (mParam == 2) {
+                    if (param1 == 2) {
                         int b2 = (*(u16*)((char*)light + 0xc) == 0xce);
                         if (b2) {
                             animId = 0x33;

--- a/src/_ZN6Player17St_LedgeGrab_MainEv.cpp
+++ b/src/_ZN6Player17St_LedgeGrab_MainEv.cpp
@@ -19,7 +19,7 @@ int Player::St_LedgeGrab_Main()
   if(_ZN6Player12FinishedAnimEv(((char*)this)))
     _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211013c);
   if(_ZN6Player6IsAnimEj(((char*)this),0x20)){
-    int id=_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0);
+    int id=_ZNK6Player14GetBodyModelIDEjb(((char*)this),param1&0xff,0);
     void* anim=*(void**)(((char*)this)+(id<<2)+0xdc);
     if(_ZNK9Animation12WillHitFrameEi((char*)anim+0x50,0x1e))
       _ZN5Sound9PlayBank0EjRK7Vector3(mGroundSoundType+0x40,((char*)this)+0x74);

--- a/src/_ZN6Player17St_NoControl_MainEv.cpp
+++ b/src/_ZN6Player17St_NoControl_MainEv.cpp
@@ -108,7 +108,7 @@ int Player::St_NoControl_Main()
         }
         break;
     case 23: {
-        int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
         char* anim = (char*)((int*)((char*)&mBodyModels))[id] + 0x50;
         if (_ZNK9Animation12WillHitFrameEi(anim, 0x1c))
             unk_71a = 0;

--- a/src/_ZN6Player17St_SlideKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_MainEv.cpp
@@ -90,7 +90,7 @@ L14c:
 
 L18c:
     {
-        int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0);
         void* anim = *(void**)(((char*)this) + (id << 2) + 0xdc);
         u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50))) + 8);
         if ((u16)(w >> 12) < 4)

--- a/src/_ZN6Player17St_SlopeJump_MainEv.cpp
+++ b/src/_ZN6Player17St_SlopeJump_MainEv.cpp
@@ -22,7 +22,7 @@ int Player::St_SlopeJump_Main()
   if(*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 1){
     mPrevAngleY=mAngleY;
     if(mIsMega==0){
-      if(mParam==3){
+      if(param1==3){
         _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_02110034);
       }else{
         _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_021105bc);

--- a/src/_ZN6Player18SetNewHatCharacterEjjb.cpp
+++ b/src/_ZN6Player18SetNewHatCharacterEjjb.cpp
@@ -19,7 +19,7 @@ void func_ov002_020e6350(char* c);
 
 void Player::SetNewHatCharacter(unsigned int p1, unsigned int p2, bool p3)
 {
-  unsigned int old = mParam;
+  unsigned int old = param1;
   if (p1 == old) return;
   unk_6dc = (unsigned char)old;
   mHatCharacter = (unsigned char)p1;
@@ -38,7 +38,7 @@ void Player::SetNewHatCharacter(unsigned int p1, unsigned int p2, bool p3)
     if (p1 != mCharacter) func_02012790(0xb);
     else func_02012790(0xc);
   }
-  mParam = mHatCharacter;
+  param1 = mHatCharacter;
   func_ov002_020e6350(((char*)this));
-  mParam = unk_6dc;
+  param1 = unk_6dc;
 }

--- a/src/_ZN6Player18St_LevelEnter_InitEv.cpp
+++ b/src/_ZN6Player18St_LevelEnter_InitEv.cpp
@@ -46,10 +46,10 @@ int Player::St_LevelEnter_Init()
     u8 st = mStateStep;
     if (st != 3 && st != 0xa && st != 0) {
         _ZN9Animation8SetFlagsEi(
-            *(char**)((((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4)) + 0xdc) + 0x50,
+            *(char**)((((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)param1, 0) * 4)) + 0xdc) + 0x50,
             0x40000000);
         if (mStateStep == 2) {
-            char* p = *(char**)((((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4)) + 0xdc) + 0x50;
+            char* p = *(char**)((((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)param1, 0) * 4)) + 0xdc) + 0x50;
             *(int*)(p + 8) = 0x14000;
         }
     }
@@ -133,7 +133,7 @@ int Player::St_LevelEnter_Init()
         break;
     }
     case 2:
-        if (mParam != 0) {
+        if (param1 != 0) {
             mStateStep = 0xa;
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a7e8[mStateStep], 0, 0x1000, 0);
         } else {

--- a/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
@@ -63,7 +63,7 @@ int Player::St_CeilingGrate_Main()
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[mStateWork & 1], 0, 0x1000, 0);
         }
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)));
+            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc) + 0x50)));
             if ((u32)(*(int*)(anim + 8) << 4) >> 0x10 < 0x21)
                 break;
         }
@@ -84,7 +84,7 @@ int Player::St_CeilingGrate_Main()
         if (spd < 0x800)
             spd = 0x800;
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)));
+            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc) + 0x50)));
             *(int*)(anim + 0xc) = spd;
         }
         if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {

--- a/src/_ZN6Player20St_StomachSlide_MainEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_MainEv.cpp
@@ -152,7 +152,7 @@ int Player::St_StomachSlide_Main()
                 int b1 = (*(int*)((char*)light + 0xb0) & 0x8000) != 0;
                 if (b1) {
                     animId = 0x8b;
-                    if (mParam == 2) {
+                    if (param1 == 2) {
                         int b2 = (*(u16*)((char*)light + 0xc) == 0xce);
                         if (b2) {
                             animId = 0x18;

--- a/src/_ZN6Player21St_StuckInGround_MainEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_MainEv.cpp
@@ -42,7 +42,7 @@ int Player::St_StuckInGround_Main()
         break;
     case 2:
         {
-            void* anim = *(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc);
+            void* anim = *(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc);
             if (_ZNK9Animation12WillHitFrameEi((char*)anim + 0x50, data_ov002_020ff0ec[mStateStep])) {
                 func_ov002_020c5444(((char*)this));
                 _ZN5Sound9PlayBank0EjRK7Vector3(0xb4, ((char*)this) + 0x74);

--- a/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
+++ b/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
@@ -80,10 +80,10 @@ int Player::St_MetalWaterGround_Main()
         _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x48, 0, 0x1000, 0);
         int r5 = (int)((((long long)mHorzSpeed << 9) + 0x800) >> 12);
         if(r5 < 0x400) r5 = 0x400;
-        char* anim = *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50;
+        char* anim = *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)param1, 0) * 4 + 0xdc) + 0x50;
         *(int*)(anim + 0xc) = r5;
-        if(_ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50), 4) != 0
-           || _ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50), 0x13) != 0){
+        if(_ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)param1, 0) * 4 + 0xdc) + 0x50), 4) != 0
+           || _ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)param1, 0) * 4 + 0xdc) + 0x50), 0x13) != 0){
             func_0201251c(0, 0xaa, (void*)((char*)&mCamSpacePosX), mHorzSpeed);
         }
     }

--- a/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
+++ b/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
@@ -35,7 +35,7 @@ extern "C" int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(struct Player *self, void
 
     hasCap = _ZN6Player8HasNoCapEv(((char*)self));
     if (hasCap != 0) goto L88;
-    if (self->mCharacter == self->mParam) goto L88;
+    if (self->mCharacter == self->param1) goto L88;
     if (self->mIsMetal != 0) goto L88;
     if (b == 0) goto L88;
 
@@ -80,7 +80,7 @@ L9c:
 
     if (b != 0) {
         int neq = 0;
-        if (self->mCharacter != self->mParam) neq = 1;
+        if (self->mCharacter != self->param1) neq = 1;
         if (neq) self->mStateStep = 2;
     }
     if ((int)b > 1) {
@@ -102,7 +102,7 @@ L9c:
     }
 
     if (arg4 == 1) {
-        u16 tv = data_ov002_020ff128[self->mParam];
+        u16 tv = data_ov002_020ff128[self->param1];
         dmg = (dmg * tv) / 100;
     }
     self->mHorzSpeed = dmg;

--- a/src/_ZN6Player6IsAnimEj.cpp
+++ b/src/_ZN6Player6IsAnimEj.cpp
@@ -7,7 +7,7 @@ extern int data_ov002_020ff480[];
 
 int Player::IsAnim(unsigned int a)
 {
-  int ip = mParam;
+  int ip = param1;
   int* p = (int*)data_ov002_020ff480[ip + a*4];
   int v = p[1];
   unsigned int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), ip&0xff, 0);

--- a/src/_ZN6Player6RenderEv.cpp
+++ b/src/_ZN6Player6RenderEv.cpp
@@ -64,7 +64,7 @@ int Player::Render()
             {
                 int t2 = (data_0209f2d8 == 1);
                 if (t2 != false) {
-                    if (mParam == 3) {
+                    if (param1 == 3) {
                         int* p = (int*)AT(bodyMdl, 8);
                         char* hdr = (char*)p[0];
                         char* rec = (char*)p[1];
@@ -77,7 +77,7 @@ int Player::Render()
                 }
             }
             _ZN5Model6RenderEPK7Vector3(bodyMdl, ((char*)this) + 0x80);
-            if (mParam == 1) {
+            if (param1 == 1) {
                 _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x254, *(char**)((char*)&unk_0e0) + 8);
                 unk_25c = unk_6fc << 12;
             }
@@ -105,7 +105,7 @@ int Player::Render()
                 {
                     int t3 = (data_0209f2d8 == 1);
                     if (t3 != false) {
-                        if (mParam == 3) {
+                        if (param1 == 3) {
                             int* p = (int*)AT(*(char**)(((char*)this) + 0x154 + i * 4), 8);
                             char* hdr = (char*)p[0];
                             char* rec = (char*)p[1];
@@ -126,7 +126,7 @@ int Player::Render()
                     *(M34*)dst = *(M34*)src;
                     ((VObj*)*(char**)(((char*)this) + 0x154 + i * 4))->m14((char*)&mScaleX);
                 }
-                if (mParam == 1) {
+                if (param1 == 1) {
                     _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x268, *(char**)((char*)&unk_158) + 8);
                     unk_270 = unk_6fc << 12;
                 }

--- a/src/_ZN6Player8BehaviorEv.cpp
+++ b/src/_ZN6Player8BehaviorEv.cpp
@@ -304,7 +304,7 @@ after_player_slot:
     }
 
     data_0209f254 = 0;
-    if (mParam == 3) {
+    if (param1 == 3) {
         void *p = *(void **)(*(void **)((char *)&mHeldObjQueue));
         if (p != 0)
             data_0209f254 = *(u8 *)((char *)p + 0x428);

--- a/src/_ZN6Player8HasNoCapEv.cpp
+++ b/src/_ZN6Player8HasNoCapEv.cpp
@@ -23,7 +23,7 @@ int Player::HasNoCap()
             }
         }
     }
-    if(mParam == 3) return 0;
+    if(param1 == 3) return 0;
     r = unk_71a != 0;
     return r;
 }


### PR DESCRIPTION
Completes the chain: `ActorBase -> ActorDerived -> Actor -> Player`. **Stacked on #990** —
until that merges, this PR shows its commit too.

`Player.h` described bytes 0x000..0x0cf itself instead of inheriting them, and carried no
base class and no representation of its 31-slot vtable. Because #990 reconciled the
overlapping names first, the layout change here is just a deletion — 0x000..0x0cf comes from
Actor, and Player's own fields start at 0x0d0, exactly `sizeof(Actor)`.

## Actor.h adopts Player's types — the change that couldn't be made earlier

0x080..0x08b was bare padding and 0x098..0x0ab six `u8` placeholders in `Actor.h`, while
`Player.h` — describing the same bytes — named them and typed them `s32`. Player was right,
on evidence from outside Player:

- `BooCage::InitResources` and `MadPiano::InitResources` write `-0x4000`/`-0x2000` to 0x09c
  and `-0x46000`/`-0x3c000` to 0x0a0 — fix12 gravity and terminal velocity, not bytes.
- `Player::St_Walk_Main` passes 0x098 as a 32-bit argument.

Those fields were **deliberately left wrong** through #987/#988/#990: nothing compiled
against Actor's copies, so no gate could prove a change either way. Now that Player inherits
them, **62 files using `mHorzSpeed` and 49 using `mVertSpeed`** resolve through `Actor.h`,
and a wrong width fails immediately. The change lands where something can check it.

## Vtable

`_ZTV6Player` (0x0210a83c, ov002) is Actor's 31 slots with eight overridden — 0, 3, 6, 9,
12, 16, 17, 18 — and **no new virtuals**.

`~Player` is declared **first** so it becomes the key function. CW 1.2 emits the vtable into
the TU that *defines* the first non-inline virtual declared, and that copy collides with the
gap object's ROM-supplied one. An override takes its base's slot wherever it's declared, so
this costs nothing — and `~Player` is only ever defined as an `extern "C"` free function in
`D0Ev`/`D2Ev`.

The header records the constraint that keeps it true: **`~Player` must never be defined
anywhere, including inline**, or key-function status shifts to `Behavior` — a real method —
and emits a duplicate vtable. That's the collision #974 hit.

## Two things the switch caught

**`mParam` at 0x008** was Player's name for ActorBase's `param1`. It sits inside the deleted
prefix, so nothing flagged it until the field vanished — 38 files.

**`OnYoshiTryEat` defined `u32`** while overriding Actor's `int`, which CW rejects outright.
Its comment also claimed vtable slot 17; the ROM says **18**, since 17 is `D0`. Both fixed.

## Header guard dropped

`Player.h` loses its `#ifdef __cplusplus` guard around the methods. #987 detached the last C
translation unit that included this header, so the guard has no remaining purpose — and a
dual-view header is exactly what silently split in #980 when a rename landed on one side
only.

## Verification

- Player **212/247** and Actor **79/81** — both unchanged from before this commit. The
  failures are pre-existing near-misses, untouched here.
- `Player.h` includers **172/197**.
- Full ROM build links with **no duplicate-vtable error**: 9,116/9,116 reproducing, module
  fidelity **106/106 exact**, ROM-build analysis PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
