### PR TITLE
readable: promote CylinderClsn to a real polymorphic class

### DIFF
--- a/config/arm9/symbols.txt
+++ b/config/arm9/symbols.txt
@@ -3579,6 +3579,7 @@ data_0208e698 kind:data(any) addr:0x0208e698
 data_0208e6a4 kind:data(any) addr:0x0208e6a4
 _ZTV19CylinderClsnWithPos kind:data(any) addr:0x0208e6bc
 _ZTV18MovingCylinderClsn kind:data(any) addr:0x0208e6d4
+_ZTV12CylinderClsn kind:data(any) addr:0x0208e6ec
 data_0208e6ec kind:data(any) addr:0x0208e6ec
 _ZTV25MovingCylinderClsnWithPos kind:data(any) addr:0x0208e704
 data_0208e714 kind:data(any) addr:0x0208e714

--- a/include/CylinderClsn.h
+++ b/include/CylinderClsn.h
@@ -1,30 +1,98 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class CylinderClsn: 7 matched functions, 10 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef CYLINDERCLSN_H
 #define CYLINDERCLSN_H
+
 #include "types.h"
 
-struct CylinderClsn {
-    u8  unk_000;            /* 0x000 */
-    u8  pad_001[0xb];
-    s32 unk_00c;            /* 0x00c */
-    s32 unk_010;            /* 0x010 */
-    s32 unk_014;            /* 0x014 */
-    s32 unk_018;            /* 0x018 */
-    u8  unk_01c;            /* 0x01c */
-    u8  pad_01d[0x3];
-    s32 unk_020;            /* 0x020 */
-    s32 unk_024;            /* 0x024 */
-    u8  unk_028;            /* 0x028 */
-    u8  pad_029[0x3];
-    u8  unk_02c;            /* 0x02c */
+/* The cylinder-collision root, vtable _ZTV12CylinderClsn at 0x0208e6ec
+ * (also reachable as data_0208e6ec, kept as an alias so existing consumers
+ * and their relocations stay untouched -- the #972 pattern).
+ *
+ * VTABLE, 4 slots, read out of the ROM:
+ *
+ *   slot 0  0x020150a8  ~CylinderClsn (D1)
+ *   slot 1  0x0201507c  ~CylinderClsn (D0)
+ *   slot 2  0x00000000  null - pure; GetPos() in every derived table
+ *   slot 3  0x00000000  null - pure; GetOwnerID() in every derived table
+ *
+ * A ROOT, not a derived class. Its typeinfo at 0x0208e660 is the 8-byte
+ * __class_type_info kind, which carries no base pointer; the ROM's own name
+ * for it is dCc_c. The three children are __si_class_type_info records
+ * pointing back at it: dCcPos_c (CylinderClsnWithPos), dCcAc_c
+ * (MovingCylinderClsn) and, one level further down, dCcAcPos_c
+ * (MovingCylinderClsnWithPos, based on dCcAc_c).
+ *
+ * THE DESTRUCTOR IS DECLARED FIRST AND NEVER DEFINED AS A METHOD -- the
+ * key-function arrangement from include/ModelBase.h. D0/D1/D2 stay
+ * self-contained translation units.
+ *
+ * func_02014fa4 IS NOT A BASE DESTRUCTOR, whatever the old comments in the
+ * D1/D2 files said. There is no base. It is the intrusive-list unlink that
+ * D0/D1/D2 all tail into, and its body says so:
+ *
+ *   ldr r2,[r0,#0x28] / strne r1,[r2,#0x2c]   prev->next = next
+ *   ldr r2,[r0,#0x2c] / strne r1,[r2,#0x28]   next->prev = prev
+ *
+ * with the list head at data_0209cee8 patched when this node is the head,
+ * then both links zeroed.
+ *
+ * Update() is the matching link-in: it stores the old head into next, points
+ * the old head's prev back at this, and makes this the new head. C2 zeroes
+ * both links, which is what an unlinked node looks like.
+ *
+ * LAYOUT is 0x30 bytes. Offsets come from Init (0x04/0x08/0x18/0x1c), Clear
+ * (0x0c/0x10/0x14/0x20/0x24), Update and the unlink above (0x28/0x2c), and
+ * the derived classes start their own fields at exactly 0x30.
+ *
+ * Field NAMES below are the ones Process() had already recovered and carried
+ * as a local struct; hoisting them here is what removes that duplicate. The
+ * names are a reading, not pinned by the ROM the way the offsets are.
+ */
+
 #ifdef __cplusplus
-    /* methods */
+
+struct CylinderClsn {
+    /* 0x00 is the vptr, placed implicitly by the first virtual declaration. */
+    Fix12i radius;          /* 0x04 - Init arg 1 */
+    Fix12i height;          /* 0x08 - Init arg 2 */
+    Vector3 pushback;       /* 0x0c - cleared by Clear */
+    u32 flags;              /* 0x18 - Init arg 3; bit 0 makes Update bail */
+    u32 vulnFlags;          /* 0x1c - Init arg 4 */
+    u32 hitFlags;           /* 0x20 - cleared by Clear */
+    u32 otherOwner;         /* 0x24 - cleared by Clear */
+    CylinderClsn *prev;     /* 0x28 - intrusive list, zeroed by C2 */
+    CylinderClsn *next;     /* 0x2c - intrusive list, zeroed by C2 */
+
+    /* --- vtable, in ROM order. Do not reorder. --- */
+    virtual ~CylinderClsn();            /* slots 0 (D1), 1 (D0) */
+    virtual Vector3 &GetPos() = 0;      /* slot 2 - null in the ROM table */
+    virtual u32 GetOwnerID() = 0;       /* slot 3 - null in the ROM table */
+
+    /* --- non-virtual --- */
+    void Init(Fix12i radius, Fix12i height, u32 flags, u32 vulnFlags);
     void Clear();
     void Update();
-#endif
+    static void Process();
 };
 
-#endif
+typedef char CylinderClsn_size_must_be_0x30[sizeof(CylinderClsn) == 0x30 ? 1 : -1];
+
+#else
+
+struct CylinderClsn {
+    void **vtable;             /* 0x00 */
+    s32 radius;                /* 0x04 */
+    s32 height;                /* 0x08 */
+    s32 pushbackX;             /* 0x0c */
+    s32 pushbackY;             /* 0x10 */
+    s32 pushbackZ;             /* 0x14 */
+    u32 flags;                 /* 0x18 */
+    u32 vulnFlags;             /* 0x1c */
+    u32 hitFlags;              /* 0x20 */
+    u32 otherOwner;            /* 0x24 */
+    struct CylinderClsn *prev; /* 0x28 */
+    struct CylinderClsn *next; /* 0x2c */
+};
+
+#endif /* __cplusplus */
+
+#endif /* CYLINDERCLSN_H */

--- a/src/_ZN12CylinderClsn4InitE5Fix12IiES1_jj.cpp
+++ b/src/_ZN12CylinderClsn4InitE5Fix12IiES1_jj.cpp
@@ -2,9 +2,12 @@
 // @symbol _ZN12CylinderClsn4InitE5Fix12IiES1_jj
 /* recovered: named members + shared header */
 #include "CylinderClsn.h"
+/* Stays a mangled free definition: the real signature carries Fix12<int> and
+   wall 6az (notes/mwccarm-codegen.md) homes class-typed by-value parameters.
+   The declaration in CylinderClsn.h is the real one and callers may use it. */
 extern "C" void _ZN12CylinderClsn4InitE5Fix12IiES1_jj(struct CylinderClsn *self, int a, int b, unsigned d, unsigned e) {
-  ((int*)self)[1]=a;
-  ((int*)self)[2]=b;
-  *(int*)((char*)&self->unk_018)=d;
-  *(int*)((char*)&self->unk_01c)=e;
+  *(int*)&self->radius=a;
+  *(int*)&self->height=b;
+  *(int*)&self->flags=d;
+  *(int*)&self->vulnFlags=e;
 }

--- a/src/_ZN12CylinderClsn5ClearEv.cpp
+++ b/src/_ZN12CylinderClsn5ClearEv.cpp
@@ -6,9 +6,9 @@
 
 void CylinderClsn::Clear()
 {
-    unk_00c = 0;
-    unk_010 = 0;
-    unk_014 = 0;
-    unk_024 = 0;
-    unk_020 = 0;
+    pushback.x = 0;
+    pushback.y = 0;
+    pushback.z = 0;
+    otherOwner = 0;
+    hitFlags = 0;
 }

--- a/src/_ZN12CylinderClsn6UpdateEv.cpp
+++ b/src/_ZN12CylinderClsn6UpdateEv.cpp
@@ -7,11 +7,13 @@
 extern "C" {
 }
 
+/* Link this node in at the head of the active list. The mirror of the unlink
+   that the destructors run; see include/CylinderClsn.h. */
 void CylinderClsn::Update()
 {
-  if(unk_018 & 1) return;
+  if(flags & 1) return;
   void* h = data_0209cee8;
-  *(void**)((char*)&unk_02c) = h;
+  *(void**)&next = h;
   if(data_0209cee8) *(void**)((char*)data_0209cee8+0x28) = ((char*)this);
   data_0209cee8 = ((char*)this);
 }

--- a/src/_ZN12CylinderClsn7ProcessEv.cpp
+++ b/src/_ZN12CylinderClsn7ProcessEv.cpp
@@ -1,28 +1,7 @@
 //cpp
-typedef int Fix12i;
-typedef unsigned int u32;
-
-struct Vector3 { Fix12i x, y, z; };
-
-struct CylinderClsn
-{
-    virtual int v0();
-    virtual int v1();
-    virtual Vector3& GetPos();      // vt+0x08
-    virtual u32 GetOwnerID();       // vt+0x0C
-
-    Fix12i radius;       // 0x04
-    Fix12i height;       // 0x08
-    Vector3 pushback;    // 0x0C
-    u32 flags;           // 0x18
-    u32 vulnFlags;       // 0x1C
-    u32 hitFlags;        // 0x20
-    u32 otherOwner;      // 0x24
-    u32 unk28;           // 0x28
-    CylinderClsn* next;  // 0x2C
-
-    static void Process();
-};
+// @symbol _ZN12CylinderClsn7ProcessEv
+/* recovered: named members + shared header, real C++ method */
+#include "CylinderClsn.h"
 
 extern "C" {
 extern CylinderClsn* data_0209cee8;
@@ -199,7 +178,7 @@ void CylinderClsn::Process()
 
         {
             CylinderClsn* nxt = data_0209cee8->next;
-            data_0209cee8->unk28 = 0;
+            data_0209cee8->prev = 0;
             data_0209cee8->next = 0;
             data_0209cee8 = nxt;
         }

--- a/src/_ZN12CylinderClsnC2Ev.cpp
+++ b/src/_ZN12CylinderClsnC2Ev.cpp
@@ -5,9 +5,10 @@
 /* recovered: named members + shared header */
 #include "CylinderClsn.h"
 extern "C" {
+/* Sets the vptr, then zeroes both intrusive-list links: an unlinked node. */
 void _ZN12CylinderClsnC2Ev(struct CylinderClsn *self) {
-  *(int*)((char*)&self->unk_000)=(int)data_0208e6ec;
-  *(int*)((char*)&self->unk_028)=0;
-  *(int*)((char*)&self->unk_02c)=0;
+  *(int*)self=(int)data_0208e6ec;
+  *(int*)&self->prev=0;
+  *(int*)&self->next=0;
 }
 }

--- a/src/_ZN12CylinderClsnD1Ev.c
+++ b/src/_ZN12CylinderClsnD1Ev.c
@@ -2,12 +2,15 @@
 /* recovered: named members + shared header */
 #include "CylinderClsn.h"
 /* CylinderClsn::~CylinderClsn() at 0x020150a8
- * Complete-object destructor (D1). Installs the CylinderClsn vtable, then runs
- * the base subobject destructor (func_02014fa4). Returns this.
+ * Complete-object destructor (D1), vtable slot 0. Installs the CylinderClsn
+ * vtable, then unlinks this node from the active list. Returns this.
+ *
+ * func_02014fa4 is NOT a base destructor -- CylinderClsn is a root, its
+ * typeinfo is the baseless __class_type_info kind. See include/CylinderClsn.h.
  */
 
 extern int data_0208e6ec[];   // vtable (wildcard reloc, not byte-verified)
-extern void func_02014fa4(void* self); // base subobject destructor
+extern void func_02014fa4(void* self); // intrusive-list unlink
 
 void* _ZN12CylinderClsnD1Ev(void* self)
 {

--- a/src/_ZN12CylinderClsnD2Ev.c
+++ b/src/_ZN12CylinderClsnD2Ev.c
@@ -2,12 +2,16 @@
 /* recovered: named members + shared header */
 #include "CylinderClsn.h"
 /* CylinderClsn::~CylinderClsn() at 0x02015058
- * Base-object destructor (D2). Installs the CylinderClsn vtable, then runs the
- * base subobject destructor (func_02014fa4). Returns this.
+ * Base-object destructor (D2), reached by direct call from derived
+ * destructors, never through a vtable. Installs the CylinderClsn vtable,
+ * then unlinks this node from the active list. Returns this.
+ *
+ * func_02014fa4 is NOT a base destructor -- CylinderClsn is a root, its
+ * typeinfo is the baseless __class_type_info kind. See include/CylinderClsn.h.
  */
 
 extern int data_0208e6ec[];   // vtable (wildcard reloc, not byte-verified)
-extern void func_02014fa4(void* self); // base subobject destructor
+extern void func_02014fa4(void* self); // intrusive-list unlink
 
 void* _ZN12CylinderClsnD2Ev(void* self)
 {


### PR DESCRIPTION
First half of what remains in the collision-chain claim. **8 converted definitions byte-match; 7/7 fan-out linkcheck VERIFIED, zero warnings.** The class is now declared once instead of three times.

## What the bytes taught this time

- **CylinderClsn is a ROOT, and `func_02014fa4` is not a base destructor.** The D1/D2 comments both said it was. The typeinfo at 0x0208e660 is the 8-byte `__class_type_info` kind, which carries no base pointer at all, and the ROM names the class `dCc_c`. `func_02014fa4` is the intrusive-list unlink the destructors tail into — `prev->next = next`, `next->prev = prev`, patch the head at `data_0209cee8` when this node is it, then zero both links. `Update()` is the matching link-in, and `C2` zeroes both links, which is exactly what an unlinked node looks like.
- **The vtable is four slots, two of them pure.** `[D1, D0, null, null]` at 0x0208e6ec. Every derived table fills slots 2 and 3 with `GetPos` and `GetOwnerID`.
- **The RTTI states the whole family.** `dCc_c` is the root; `dCcPos_c` (CylinderClsnWithPos) and `dCcAc_c` (MovingCylinderClsn) are `__si_class_type_info` records based on it, and `dCcAcPos_c` (MovingCylinderClsnWithPos) is based on `dCcAc_c`. Derived by following vtable → typeinfo at V-4 → name at T+4, not by adjacency.
- **Offset 0x28 was `unk28`; the unlink proves it is the `prev` link.**

## Where the field names came from

`Process()` had been carrying its own private copy of the class — the one place field names had actually been recovered. Those names (`radius`, `height`, `pushback`, `flags`, `vulnFlags`, `hitFlags`, `otherOwner`) are hoisted into the header and the duplicate deleted, which is most of the readability win here. The offsets are pinned by Init, Clear, Update and the unlink; the names are a reading and the header says so.

`data_0208e6ec` gains the `_ZTV12CylinderClsn` name alongside its `data_` alias — the #972 pattern — so existing consumers and their relocations stay untouched.

## Deliberately not converted

`Init` keeps its mangled free definition: the real signature carries `Fix12<int>` and wall 6az homes class-typed by-value parameters. Same call as the Model and mesh-collider chains made.

## Next

`CylinderClsnWithPos`, `MovingCylinderClsn` and `MovingCylinderClsnWithPos` derive from this and follow in a separate PR. One thing already found for it: `MovingCylinderClsnWithPos` vtable slot 3 holds `func_02014a20`, a 12-byte interworking veneer whose literal is `_ZN18MovingCylinderClsn10GetOwnerIDEv` — so it **inherits** GetOwnerID and must not declare an override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4AidgdRte1dimzRraAuS9