### PR TITLE
readable: promote the three derived cylinder colliders

### DIFF
--- a/include/CylinderClsnWithPos.h
+++ b/include/CylinderClsnWithPos.h
@@ -1,19 +1,55 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class CylinderClsnWithPos: 6 matched functions, 1 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef CYLINDERCLSNWITHPOS_H
 #define CYLINDERCLSNWITHPOS_H
-#include "types.h"
 
-struct CylinderClsnWithPos {
-    u8  pad_000[0x30];
-    u8  unk_030;            /* 0x030 */
+#include "types.h"
+#include "CylinderClsn.h"
+
+/* A cylinder that carries its own position, vtable _ZTV19CylinderClsnWithPos
+ * at 0x0208e6bc.
+ *
+ * VTABLE, 4 slots, read out of the ROM:
+ *
+ *   slot 0  0x02014854  ~CylinderClsnWithPos (D1)
+ *   slot 1  0x02014828  ~CylinderClsnWithPos (D0)
+ *   slot 2  0x02014820  GetPos()      - returns this->pos
+ *   slot 3  0x02014818  GetOwnerID()  - `mov r0,#0; bx lr'
+ *
+ * Derives from CylinderClsn: its typeinfo at 0x0208e68c is the 12-byte
+ * __si_class_type_info kind whose base pointer resolves to dCc_c, and the
+ * ROM's own name for this class is dCcPos_c. C1 confirms it from the other
+ * side -- it calls CylinderClsn's C2 and then stores this vtable.
+ *
+ * THE DESTRUCTOR IS DECLARED FIRST AND NEVER DEFINED AS A METHOD -- see
+ * include/ModelBase.h.
+ *
+ * LAYOUT: the base is 0x30, and pos starts at exactly 0x30 (GetPos is
+ * `add r0, r0, #0x30'), so the object is 0x3c.
+ *
+ * Having no owning Actor is what slot 3 encodes: GetOwnerID is a constant 0,
+ * where MovingCylinderClsn's reads through its owner pointer.
+ */
+
 #ifdef __cplusplus
-    /* methods */
-    struct Vector3* GetPos();
-    u32 GetOwnerID();
-#endif
+
+struct CylinderClsnWithPos : CylinderClsn {
+    Vector3 pos;            /* 0x30 */
+
+    /* --- vtable, in ROM order. Do not reorder. --- */
+    virtual ~CylinderClsnWithPos();     /* slots 0 (D1), 1 (D0) */
+    virtual Vector3 &GetPos();          /* slot 2 */
+    virtual u32 GetOwnerID();           /* slot 3 - always 0 */
 };
 
-#endif
+typedef char CylinderClsnWithPos_size_must_be_0x3c[
+    sizeof(CylinderClsnWithPos) == 0x3c ? 1 : -1];
+
+#else
+
+struct CylinderClsnWithPos {
+    struct CylinderClsn base; /* 0x00 */
+    Vector3 pos;              /* 0x30 */
+};
+
+#endif /* __cplusplus */
+
+#endif /* CYLINDERCLSNWITHPOS_H */

--- a/include/MovingCylinderClsn.h
+++ b/include/MovingCylinderClsn.h
@@ -1,19 +1,59 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class MovingCylinderClsn: 8 matched functions, 1 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef MOVINGCYLINDERCLSN_H
 #define MOVINGCYLINDERCLSN_H
-#include "types.h"
 
-struct MovingCylinderClsn {
-    u8  pad_000[0x30];
-    u8  unk_030;            /* 0x030 */
+#include "types.h"
+#include "CylinderClsn.h"
+
+/* A cylinder attached to an Actor, vtable _ZTV18MovingCylinderClsn at
+ * 0x0208e6d4.
+ *
+ * VTABLE, 4 slots, read out of the ROM:
+ *
+ *   slot 0  0x020149a4  ~MovingCylinderClsn (D1)
+ *   slot 1  0x02014978  ~MovingCylinderClsn (D0)
+ *   slot 2  0x02014948  GetPos()      - `ldr r0,[r0,#0x30]' then + 0x5c
+ *   slot 3  0x0201493c  GetOwnerID()  - `ldr r0,[r0,#0x30]; ldr r0,[r0,#4]'
+ *
+ * Derives from CylinderClsn: its typeinfo at 0x0208e698 is the 12-byte
+ * __si_class_type_info kind whose base pointer resolves to dCc_c, and the
+ * ROM names this class dCcAc_c. C2 confirms it -- it calls CylinderClsn's C2,
+ * stores this vtable, then nulls the owner.
+ *
+ * THE DESTRUCTOR IS DECLARED FIRST AND NEVER DEFINED AS A METHOD -- see
+ * include/ModelBase.h.
+ *
+ * LAYOUT: the base is 0x30 and owner sits at 0x30, so the object is 0x34 --
+ * which is where MovingCylinderClsnWithPos starts its own field.
+ *
+ * BOTH VIRTUALS READ THROUGH owner. GetOwnerID loads owner->uniqueID at
+ * Actor + 4, the same offset MeshColliderBase uses. GetPos does NOT return a
+ * field of this object at all: it returns the owner's position at Actor +
+ * 0x5c, so a moving cylinder tracks its Actor rather than storing a copy.
+ */
+
 #ifdef __cplusplus
-    /* methods */
-    int GetOwnerID();
-    void * GetPos();
-#endif
+
+struct Actor;
+
+struct MovingCylinderClsn : CylinderClsn {
+    Actor *owner;           /* 0x30 - nulled by C2 */
+
+    /* --- vtable, in ROM order. Do not reorder. --- */
+    virtual ~MovingCylinderClsn();      /* slots 0 (D1), 1 (D0) */
+    virtual Vector3 &GetPos();          /* slot 2 - the owner's pos, not ours */
+    virtual u32 GetOwnerID();           /* slot 3 - owner->uniqueID */
 };
 
-#endif
+typedef char MovingCylinderClsn_size_must_be_0x34[
+    sizeof(MovingCylinderClsn) == 0x34 ? 1 : -1];
+
+#else
+
+struct MovingCylinderClsn {
+    struct CylinderClsn base; /* 0x00 */
+    struct Actor *owner;      /* 0x30 */
+};
+
+#endif /* __cplusplus */
+
+#endif /* MOVINGCYLINDERCLSN_H */

--- a/include/MovingCylinderClsnWithPos.h
+++ b/include/MovingCylinderClsnWithPos.h
@@ -1,18 +1,65 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class MovingCylinderClsnWithPos: 6 matched functions, 1 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef MOVINGCYLINDERCLSNWITHPOS_H
 #define MOVINGCYLINDERCLSNWITHPOS_H
-#include "types.h"
 
-struct MovingCylinderClsnWithPos {
-    u8  pad_000[0x34];
-    u8  unk_034;            /* 0x034 */
+#include "types.h"
+#include "MovingCylinderClsn.h"
+
+/* An Actor-attached cylinder that keeps its own position, vtable
+ * _ZTV25MovingCylinderClsnWithPos at 0x0208e704.
+ *
+ * VTABLE, 4 slots, read out of the ROM:
+ *
+ *   slot 0  0x02014a60  ~MovingCylinderClsnWithPos (D1)
+ *   slot 1  0x02014a34  ~MovingCylinderClsnWithPos (D0)
+ *   slot 2  0x02014a2c  GetPos()     - `add r0, r0, #0x34', this->pos
+ *   slot 3  0x02014a20  INHERITED, see below
+ *
+ * Derives from MovingCylinderClsn, not from CylinderClsn directly: its
+ * typeinfo at 0x0208e680 is the 12-byte __si_class_type_info kind whose base
+ * pointer resolves to dCcAc_c, and the ROM names this class dCcAcPos_c. C1
+ * agrees -- it calls MovingCylinderClsn's C2, then stores this vtable.
+ *
+ * SLOT 3 IS NOT AN OVERRIDE. func_02014a20 is a 12-byte interworking veneer,
+ * `ldr ip,[pc]; bx ip; .word 0x0201493c', and that literal is
+ * _ZN18MovingCylinderClsn10GetOwnerIDEv -- the parent's body. The linker put
+ * the veneer there; the class inherits GetOwnerID unchanged, so it is
+ * deliberately NOT redeclared below. Declaring it would invent an override
+ * the ROM does not have.
+ *
+ * THE DESTRUCTOR IS DECLARED FIRST AND NEVER DEFINED AS A METHOD -- see
+ * include/ModelBase.h.
+ *
+ * LAYOUT: MovingCylinderClsn is 0x34 and pos starts at exactly 0x34, so the
+ * object is 0x40.
+ *
+ * GetPos here shadows the parent's: MovingCylinderClsn returns the owner's
+ * position, this one returns its own field.
+ */
+
 #ifdef __cplusplus
-    /* methods */
-    struct Vector3* GetPos();
-#endif
+
+struct MovingCylinderClsnWithPos : MovingCylinderClsn {
+    Vector3 pos;            /* 0x34 */
+
+    /* --- vtable, in ROM order. Do not reorder. --- */
+    virtual ~MovingCylinderClsnWithPos();   /* slots 0 (D1), 1 (D0) */
+    virtual Vector3 &GetPos();              /* slot 2 - our pos, not the owner's */
+    /* slot 3 GetOwnerID is inherited through a linker veneer; see above. */
+
+    /* --- non-virtual --- */
+    void SetPosRelativeToActor(const Vector3 &offset);
 };
 
-#endif
+typedef char MovingCylinderClsnWithPos_size_must_be_0x40[
+    sizeof(MovingCylinderClsnWithPos) == 0x40 ? 1 : -1];
+
+#else
+
+struct MovingCylinderClsnWithPos {
+    struct MovingCylinderClsn base; /* 0x00 */
+    Vector3 pos;                    /* 0x34 */
+};
+
+#endif /* __cplusplus */
+
+#endif /* MOVINGCYLINDERCLSNWITHPOS_H */

--- a/src/_ZN18MovingCylinderClsn10GetOwnerIDEv.cpp
+++ b/src/_ZN18MovingCylinderClsn10GetOwnerIDEv.cpp
@@ -4,8 +4,10 @@
 #include "MovingCylinderClsn.h"
 
 
-int MovingCylinderClsn::GetOwnerID()
+/* Slot 3. owner->uniqueID, at Actor + 4 -- the same offset MeshColliderBase
+   reads for its own ownerUniqueID. */
+u32 MovingCylinderClsn::GetOwnerID()
 {
-    char *q = *(char **)((char *)&unk_030);
-    return *(int *)(q + 4);
+    char *q = *(char **)&owner;
+    return *(u32 *)(q + 4);
 }

--- a/src/_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj.c
+++ b/src/_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj.c
@@ -8,6 +8,6 @@ struct Actor { void* vtable; };
 
 
 void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(struct MovingCylinderClsn *self, struct Actor* actor, Fix12i radius, Fix12i height, u32 flags, u32 vulnFlags) {
-    *((struct Actor**)((char*)&self->unk_030)) = actor;
+    self->owner = actor;
     _ZN12CylinderClsn4InitE5Fix12IiES1_jj(((void*)self), radius, height, flags, vulnFlags);
 }

--- a/src/_ZN18MovingCylinderClsn6GetPosEv.cpp
+++ b/src/_ZN18MovingCylinderClsn6GetPosEv.cpp
@@ -4,8 +4,10 @@
 #include "MovingCylinderClsn.h"
 
 
-void * MovingCylinderClsn::GetPos()
+/* Slot 2. Returns the OWNER's position (Actor + 0x5c), not a field of this
+   object -- a moving cylinder tracks its Actor instead of storing a copy. */
+Vector3 & MovingCylinderClsn::GetPos()
 {
-    char *q = *(char **)((char *)&unk_030);
-    return q + 0x5c;
+    char *q = *(char **)&owner;
+    return *(Vector3 *)(q + 0x5c);
 }


### PR DESCRIPTION
**Stacked on #996** — review/merge that first; this targets its branch, not `main`.

Completes the cylinder half of the collision-chain claim. **6 converted definitions byte-match; 9 fan-out sources checked, 0 blocking.** The 3 remaining warnings are pre-existing `BLIND-2` symbol-coverage gaps on the `MovingCylinderClsn`/`MovingCylinderClsnWithPos` destructors — I re-ran them against `main`'s headers and they warn identically there, so this PR does not cause them.

## What the bytes taught this time

- **`MovingCylinderClsnWithPos` does NOT override `GetOwnerID`.** Its vtable slot 3 holds `func_02014a20`, which is a 12-byte interworking veneer — `ldr ip,[pc]; bx ip; .word 0x0201493c` — and that literal is `_ZN18MovingCylinderClsn10GetOwnerIDEv`, the parent's body. The linker put the veneer there; the class inherits the method. The header records this instead of declaring an override the ROM does not have. Same trap as the phantom `Virtual0C` override in the mesh-collider chain.
- **`MovingCylinderClsn::GetPos` returns no field of its own.** It hands back the owner's position at `Actor + 0x5c`, so a moving cylinder tracks its Actor rather than storing a copy. `MovingCylinderClsnWithPos` is precisely the variant that does keep one, and its `GetPos` (`add r0, r0, #0x34`) shadows the parent's.
- **`GetOwnerID` reads `owner->uniqueID` at `Actor + 4`** — the same offset `MeshColliderBase` uses for its `ownerUniqueID`, which corroborates both.
- **The inheritance shape is the ROM's own statement.** `dCcPos_c` and `dCcAc_c` are `__si_class_type_info` records based on `dCc_c`; `dCcAcPos_c` is based on `dCcAc_c`, *not* on the root. Every constructor agrees from the other side — each calls its immediate parent's C2, then stores its own vtable.

## A latent inconsistency this fixes

The auto-generated headers disagreed with the base on return types — `Vector3 *` against `Vector3 &`, `int` against `u32`. No override could have satisfied both. They agree now, which is what let these become real overrides rather than unrelated same-named methods.

## Sizes

Each follows from where the child starts its own fields, and each is static-asserted: `CylinderClsnWithPos` 0x3c, `MovingCylinderClsn` 0x34, `MovingCylinderClsnWithPos` 0x40.

## Remaining in the claim

`WithMeshClsn` — the last piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4AidgdRte1dimzRraAuS9