### PR TITLE
tools: three places that reported a negative they never earned, and a re-measured arm9 endgame

### DIFF
--- a/notes/arm9-endgame.md
+++ b/notes/arm9-endgame.md
@@ -14,6 +14,45 @@ functions this file had recorded as merely having a stale draft. Read the gotcha
 bottom before trusting a negative anywhere else in this file: two of the three have now
 been shown to be measurement artifacts rather than properties of the functions.
 
+## STATUS 2026-08-02: most of this file is out of date -- re-measured
+
+Everything below was written on 2026-07-28 and has not been re-measured since. It has, so
+here is what every function in the three groups does today, compiled against **all 25
+installed mwccarm builds** (the sweep used to cover only 12 -- see `tools/match.py`).
+
+**Four functions of the twenty still do not reproduce.** Not twenty, and not the group
+split below.
+
+| group | note said | reproduces today |
+|---|---|---|
+| A -- "believed impossible, do not spend" | 6 impossible | **3 of 6 match** |
+| B -- "mid-divergence" | 7 open | **7 of 7 match** |
+| C -- "structurally wrong, needs real decompilation" | 7 open | **6 of 7 match** |
+
+Still unmatched across all 25 builds, and these are the real arm9 endgame:
+
+```
+_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii     _ZN5Stage13InitResourcesEv
+func_0202ffec                                   func_02009e70
+```
+
+Four of the matches are **2004/b56 only**: `_ZN12WithMeshClsn20UpdateExtraContinousEv`,
+`func_020412f0`, `func_0206f46c`, `func_0206e4a4`. The rest match on the 1.2 trio and b56.
+
+Two consequences worth acting on:
+
+* **Group C's advice is wrong now.** "Permuting these is wasted budget; they need someone
+  reading the ROM disassembly and writing correct C" -- six of the seven were matched
+  between 2026-07-28 and 2026-08-01, mostly by the readable-conversion passes. Do not
+  route work by this file without re-measuring first.
+* **Group A's "do not spend" is now better evidenced for the three that remain**, since a
+  25-build sweep failing is a stronger negative than the 12-build sweep the original
+  measurement had. `_ZN5Stage13InitResourcesEv` in particular keeps its worked example
+  below, which is still the best description of that wall in the tree.
+
+The rest of the file is left as written -- its mechanisms, worked examples and gotchas are
+still the most useful part, and only the status is stale.
+
 ## Route first, grind second
 
 The 22 split into three groups that want completely different treatment. Sending the

--- a/tools/match.py
+++ b/tools/match.py
@@ -42,12 +42,43 @@ INCLUDE = REPO / "include"
 # on a successful compile. See notes/mwccarm-codegen.md 6as.
 DEFAULT_FLAGS = ("-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e "
                  "-gccext,on -msgstyle gcc -w illpragmas")
-SWEEP = [
-         # Canonical matching compiler first (see notes/rom-build.md, notes 6ai):
-         "2004/b56",
-         "1.2/base", "1.2/sp2", "1.2/sp2p3", "1.2/sp3", "1.2/sp4",
-         "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3"]
-# The CodeWarrior 1.2 trio (codegen-identical to each other). Used by --trio only.
+# The builds --all sweeps. This was a hand-written list of 12 while 25 mwccarm.exe were
+# installed, so `--all` ("sweep every known version") silently skipped 13 -- including
+# 2.0/sp1p5, sp1p6, sp1p7 and sp2p4, service packs of a family it already swept. Every
+# "a full version sweep found nothing" negative recorded against that list was really a
+# 12-of-25 sweep, so those negatives are weaker than they read.
+#
+# Derived from disk instead, so adding a compiler to tools/mwccarm/ puts it in the sweep.
+# _PREFERRED goes first because a sweep reports its matches in order; the rest follow
+# sorted. Anything installed but absent from _PREFERRED is still swept -- that is the
+# whole point.
+#
+# 2004/b56 leads _PREFERRED, not trails it. It is the canonical matching compiler (see
+# notes/rom-build.md, notes 6ai), and because a sweep reports in order, putting it later
+# makes an earlier version win ties and get recorded as "the" match. That misreporting is
+# real: a 711-file reconciliation first read as "672 under 1.2/base" purely from iteration
+# order, and became 699 under 2004/b56 once the canonical build was tried first.
+_PREFERRED = [# Canonical matching compiler first:
+              "2004/b56",
+              "1.2/base", "1.2/sp2", "1.2/sp2p3", "1.2/sp3", "1.2/sp4",
+              "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3"]
+
+
+def installed_versions():
+    """Every mwccarm build present under tools/mwccarm, as version strings."""
+    if not MW.is_dir():
+        return []
+    return sorted(p.parent.relative_to(MW).as_posix() for p in MW.rglob("mwccarm.exe"))
+
+
+def _sweep_list():
+    found = installed_versions()
+    return [v for v in _PREFERRED if v in found] + [v for v in found if v not in _PREFERRED]
+
+
+SWEEP = _sweep_list()
+# The CodeWarrior 1.2 trio that survived version-pinning (codegen-identical to each
+# other). Used by --trio only.
 PINNED = ["1.2/base", "1.2/sp2", "1.2/sp2p3"]
 # Canonical single-compile default for matching. 2004 build 0056 reproduces more of
 # this corpus than the 1.2 service packs (notes/rom-build.md). Ships mwccarm only —


### PR DESCRIPTION
Independent of #992 and #995 — different part of `match.py`, no conflict, merges on its own.

## `--all` swept 12 of 25 installed compilers

`SWEEP` was a hand-written list of 12 while **25** `mwccarm.exe` were installed, so `--all` — documented as *"sweep every known version"* — silently skipped 13:

```
2.0/sp1p5  2.0/sp1p6  2.0/sp1p7  2.0/sp2p4
dsi/1.1  dsi/1.1p1  dsi/1.2  dsi/1.2p1  dsi/1.2p2  dsi/1.3  dsi/1.3p1  dsi/1.6sp1  dsi/1.6sp2
```

The first four are service packs of a family the list **already swept**, not some unrelated toolchain. So every *"a full version sweep found nothing"* negative recorded against that list was really a 12-of-25 sweep, and reads stronger than it was.

`SWEEP` is now derived from disk, so dropping a compiler into `tools/mwccarm/` puts it in the sweep. The old list survives as `_PREFERRED` purely to fix reporting order; anything installed but absent from it is still swept, which is the point.

## Re-measuring the arm9 endgame against all 25

This is the part that matters more than the fix, because `notes/arm9-endgame.md` is what routes work — and it has gone badly stale since it was written on 2026-07-28:

| group | the note says | reproduces today |
|---|---|---|
| A — "believed impossible, do not spend" | 6 impossible | **3 of 6 match** |
| B — "mid-divergence" | 7 open | **7 of 7 match** |
| C — "structurally wrong, needs real decompilation" | 7 open | **6 of 7 match** |

**Four functions of the twenty still do not reproduce**, and they are the real arm9 endgame:

```
_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii     _ZN5Stage13InitResourcesEv
func_0202ffec                                   func_02009e70
```

Four of the matches are **2004/b56 only**: `_ZN12WithMeshClsn20UpdateExtraContinousEv`, `func_020412f0`, `func_0206f46c`, `func_0206e4a4`. The rest match on the 1.2 trio and b56.

Group C's advice is the actively harmful part — *"permuting these is wasted budget; they need someone reading the ROM disassembly and writing correct C"* — when six of its seven were matched between 2026-07-28 and 2026-08-01, mostly by the readable-conversion passes.

A dated status header now says all this at the top of the file. **The rest of the file is untouched** — its mechanisms, worked examples and gotchas are still the best description of these walls in the tree, and only the status was stale.

## Honest scope

The sweep fix did **not** produce any of those matches. They were already reachable on builds the old list covered; the file simply was never re-measured. What the fix buys is that the four remaining negatives are now 25-build negatives rather than 12-build ones — and that future sweeps mean what they say.

Suite: 87 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011geKcos2TuNYwHEXV9Ye7d