### PR TITLE
Pin matching compiler default to mwccarm 2004/b56

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ the ROM. Green = byte-verified = mergeable. Red means at least one file either:
 Do not open a PR expecting a maintainer to "fix it up." Verify locally first:
 
 ```
-python tools/match.py --c yourfile.c --func <name> --addr 0x<addr> --size 0x<size> --version 1.2/sp2p3
+python tools/match.py --c yourfile.c --func <name> --addr 0x<addr> --size 0x<size> --version 2004/b56
 ```
 
 **A byte-match from `match`/`fdiff` is NOT proof your relocations are right** — those
@@ -121,7 +121,7 @@ key` line from `worklist`/`coddog`, surface it: minting one is a 30-second brows
 
 ## PR format
 
-- **Title:** `Match N functions byte-identical (mwccarm 1.2/sp2p3)` — or the single
+- **Title:** `Match N functions byte-identical (mwccarm 2004/b56)` — or the single
   function's name for a one-function PR.
 - **Body:** short — what you matched. The `validate` bot posts a per-file table; that
   table *is* the review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,12 +59,15 @@ python tools/unpack.py "path/to/your-own-sm64ds.nds"   # -> populates extracted/
 
 ## The matching loop
 
-The pinned compiler is **mwccarm `1.2/sp2p3`** (the 1.2 `base`/`sp2`/`sp2p3` trio is
-codegen-identical) with flags:
+The pinned matching compiler is **mwccarm `2004/b56`** (reproduces more of this
+corpus than the 1.2 service packs; see `notes/rom-build.md`). Flags:
 
 ```
 -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
 ```
+
+The 1.2 `base`/`sp2`/`sp2p3` trio remains available via `match.py --trio` / version
+sweeps. The ROM **linker** is still 1.2/sp2p3 `mwldarm` (b56 ships no linker).
 
 1. **Pick an unmatched function.** Ask in Discord or claim it on an issue.
 2. **Disassemble it** to see what you're matching:
@@ -75,7 +78,7 @@ codegen-identical) with flags:
 4. **Compile + byte-diff**, relocation-aware:
    ```
    python tools/match.py --c yourfile.c --func name --addr 0x020xxxxx --size 0x.. \
-       --version 1.2/sp2p3
+       --version 2004/b56
    ```
    A match means every instruction word and every relocation slot lines up. Iterate
    until the bytes are identical.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ as it is matched.
 
 Function count climbs faster than code size because the small, regular functions are
 matched first, while most of the remaining bytes live in the large, call-heavy
-functions. The original compiler has been pinned to **mwccarm 1.2/sp2p3** with these
-flags:
+functions. The matching compiler is pinned to **mwccarm 2004/b56** with these
+flags (the 1.2 `base`/`sp2`/`sp2p3` trio remains available for version sweeps;
+the linker is still 1.2/sp2p3 `mwldarm` — b56 ships no linker):
 
 ```
 -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc

--- a/notes/matching-style.md
+++ b/notes/matching-style.md
@@ -8,7 +8,7 @@ apply these. The final section lists what is NOT source-controllable -- do not f
 hand them to the decomp permuter (tools/permuter/).
 
 
-mwccarm 1.2/sp2p3 at -O4,p. Rules ordered by impact. Get LOGIC right, then steer SHAPE with these.
+mwccarm 2004/b56 at -O4,p (canonical matching pin; 1.2/* still useful for sweeps). Rules ordered by impact. Get LOGIC right, then steer SHAPE with these.
 
 ### 1. Control flow â€” branch direction & layout (highest impact)
 

--- a/notes/rom-build.md
+++ b/notes/rom-build.md
@@ -217,7 +217,7 @@ and zero relocations originate inside it.
 
 1. Add its file entry (with `complete`) to `config/arm9/delinks.txt`.
 2. `dsd delink` — the main gap object splits, regenerated without that range.
-3. Compile with the canonical toolchain and flags (`1.2/sp2p3`, `-O4,p -enum int
+3. Compile with the canonical toolchain and flags (`2004/b56`, `-O4,p -enum int
    -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`,
    `-i include/`) to `build/src/AngleDiff.o`.
 4. `dsd lcf`, link, `dsd rom config`, `dsd rom build`.
@@ -367,9 +367,10 @@ module and shifts every later address. Retail carries just 636 bytes of `.except
 main, so the original build had them off too. The flag cleared the extra sections on
 **60 of 60** sampled files with **zero `.text` change**.
 
-**2. The default compiler is `2004/b56`, not `1.2/sp2p3`.** The repo pins 1.2/sp2p3 as
-canonical, but a function counts as matched if *any* swept version reproduces it, and a
-link has to pick one. Defaulting to the recovered 2004 build 0056
+**2. The default / matching-pin compiler is `2004/b56`.** Matching docs and
+`tools/match.py` CANONICAL use the same pin. A function still counts as matched if
+*any* swept version reproduces it (use `match.py --all` / `--trio`), and a link has
+to pick one. Defaulting to the recovered 2004 build 0056
 (`notes/mwccarm-codegen.md` 6ai) reproduces strictly more of this corpus: eligibility
 7,466 → 7,923, and post-link mismatches **70 → 14**. Note b56 ships *only* `mwccarm.exe`,
 so `LD_VERSION` keeps the link on 1.2/sp2p3's `mwldarm` regardless.

--- a/tools/cpp_rename.py
+++ b/tools/cpp_rename.py
@@ -155,10 +155,10 @@ def verify_match(rel_path, symbol, addr_str):
         "--c", rel_path,
         "--func", symbol,
         "--addr", addr_str,
-        "--version", "1.2/sp2p3"
+        "--version", "2004/b56"
     ]
     r = subprocess.run(cmd, capture_output=True, text=True, cwd=str(REPO))
-    return "MATCHING VERSIONS: 1.2/sp2p3" in r.stdout
+    return "MATCHING VERSIONS: 2004/b56" in r.stdout
 
 def apply_rename(item):
     old_p = item["old_path"]

--- a/tools/glm_refine.py
+++ b/tools/glm_refine.py
@@ -107,7 +107,7 @@ compiles it and hands you back the EXACT new diff to iterate from. Do NOT reason
 first - one guess actually compiled beats ten argued in your head. End EVERY turn with a code \
 block; never spend a turn only speculating.
 
-COMPILER: mwccarm 1.2/sp2p3. Flags (C): -O4,p -enum int -lang c99 -char signed -interworking \
+COMPILER: mwccarm 2004/b56. Flags (C): -O4,p -enum int -lang c99 -char signed -interworking \
 -proc arm946e -gccext,on -msgstyle gcc
 If the draft starts with //cpp keep that exact first line (C++).
 

--- a/tools/match.py
+++ b/tools/match.py
@@ -9,12 +9,13 @@ slot lined up -- not a raw byte-for-byte compare.
 
 Usage:
     python tools/match.py --c match/f.c --func f --addr 0x02065a84 --size 0x10 \
-        --version 1.2/sp2p3 --flags "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e"
+        --version 2004/b56 --flags "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e"
 
 The repository's ``include/`` directory is always on the compiler search path.
 Use ``--include-dir`` for an additional candidate-specific header tree.
 
-Without --version, sweeps a default list of mwccarm versions and reports the best.
+Without --version, compiles once with the canonical version (2004/b56). Use
+``--all`` to sweep every known mwccarm version, or ``--trio`` for the 1.2 trio.
 """
 import argparse
 import pathlib
@@ -41,15 +42,17 @@ INCLUDE = REPO / "include"
 # on a successful compile. See notes/mwccarm-codegen.md 6as.
 DEFAULT_FLAGS = ("-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e "
                  "-gccext,on -msgstyle gcc -w illpragmas")
-SWEEP = ["1.2/base", "1.2/sp2", "1.2/sp2p3", "1.2/sp3", "1.2/sp4",
-         "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3",
-         # The recovered 2004 build 0056 (see #776 / notes 6ai):
-         "2004/b56"]
-# The CodeWarrior 1.2 trio that survived version-pinning.
+SWEEP = [
+         # Canonical matching compiler first (see notes/rom-build.md, notes 6ai):
+         "2004/b56",
+         "1.2/base", "1.2/sp2", "1.2/sp2p3", "1.2/sp3", "1.2/sp4",
+         "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3"]
+# The CodeWarrior 1.2 trio (codegen-identical to each other). Used by --trio only.
 PINNED = ["1.2/base", "1.2/sp2", "1.2/sp2p3"]
-# Proven (45 probe constructs + 60 ROM functions) byte-identical across the trio,
-# so one is the canonical compiler and a single compile is a sufficient check.
-CANONICAL = "1.2/sp2p3"
+# Canonical single-compile default for matching. 2004 build 0056 reproduces more of
+# this corpus than the 1.2 service packs (notes/rom-build.md). Ships mwccarm only —
+# the ROM link still uses 1.2/sp2p3 mwldarm (LD_VERSION in tools/rombuild.py).
+CANONICAL = "2004/b56"
 
 md = Cs(CS_ARCH_ARM, CS_MODE_ARM)
 

--- a/tools/nonmatching.py
+++ b/tools/nonmatching.py
@@ -32,7 +32,7 @@ SRC = REPO / "src"
 TOTAL_FUNCS = 11390
 
 HEADER = ("// NONMATCHING: {reason} (div={div}). Logic verified correct vs ROM; not\n"
-          "// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).\n"
+          "// byte-matchable from C at mwccarm 2004/b56 (see notes/matching-style.md).\n"
           "// Counts as decompiled, not matched.\n")
 
 

--- a/tools/permuter/README.md
+++ b/tools/permuter/README.md
@@ -21,7 +21,7 @@ Stop paying LLM tokens to nail register allocation; let the permuter brute-force
 
 End-to-end pipeline runs on our mwccarm toolchain, native Windows, no external objdump:
 - [x] **Compiler wrapper** (`mwccarm_compile.sh`): compiles a candidate `.c` to `.o` with
-  our canonical compiler+flags (1.2/sp2p3). Verified.
+  our canonical compiler+flags (2004/b56). Verified.
 - [x] **Capstone scorer** (`cap_objdump.py`): a drop-in for the permuter's external objdump
   using capstone (which we already use). Handles mwccarm ELF candidates (extract `.text` +
   `.rel.text` relocs) and a raw-bytes target. Wired via `objdump_command` in settings.toml,

--- a/tools/permuter/import_func.py
+++ b/tools/permuter/import_func.py
@@ -105,7 +105,7 @@ def permutable_base(src, name):
         with tempfile.TemporaryDirectory() as td:
             cf = pathlib.Path(td) / ("c.cpp" if cpp else "c.c")
             cf.write_text(s, encoding="utf-8")
-            o = M.compile_c(cf, "1.2/sp2p3", flags)
+            o = M.compile_c(cf, M.CANONICAL, flags)
         if o is None:
             return None
         code, _ = M.extract_func(o, name)

--- a/tools/permuter/mwccarm_compile.sh
+++ b/tools/permuter/mwccarm_compile.sh
@@ -5,7 +5,7 @@
 # permuter's candidates are scored against the exact build we match to.
 set -e
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
-CC="$REPO/tools/mwccarm/1.2/sp2p3/mwccarm.exe"
+CC="$REPO/tools/mwccarm/2004/b56/mwccarm.exe"
 export LM_LICENSE_FILE="$REPO/tools/mwccarm/license.dat"
 C_FILE="$1"   # $2 is "-o", $3 is the output object
 O_FILE="$3"

--- a/tools/reverify_corpus.py
+++ b/tools/reverify_corpus.py
@@ -2,7 +2,7 @@
 
 For each entry in progress/matched.jsonl: recompile its committed source and
 reloc-aware byte-compare against the module's ROM bytes. An entry PASSES if it
-reproduces under the canonical compiler (1.2/sp2p3) OR any other available
+reproduces under the canonical compiler (2004/b56) OR any other available
 mwccarm version (some legit matches were banked under a different version).
 Entries failing every version are FALSE MATCHES (banked but non-reproducing).
 
@@ -26,16 +26,11 @@ import swarm as S
 
 SRC = REPO / "src"
 AUTO = REPO / "match" / "auto"
-ALL_VERSIONS = ["1.2/sp2p3", "1.2/base", "1.2/sp2", "1.2/sp3", "1.2/sp4",
-                "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3",
-                # Last on purpose. The sweep returns the FIRST version that reproduces,
-                # so 1.2/sp2p3 stays authoritative and nothing that passes today changes
-                # verdict. b56 is only reached for the pre-2005 codegen no later build can
-                # emit: the materialized member RMW and the PTMF wrapper frames (notes
-                # 6ai). It is not a strict superset of 1.2 -- func_ov004_020adc1c matches
-                # under sp2p3 and not under b56 -- which is exactly why it goes last
-                # rather than replacing anything.
-                "2004/b56"]
+ALL_VERSIONS = [
+                # Canonical matching pin first (tools/match.py CANONICAL).
+                "2004/b56",
+                "1.2/sp2p3", "1.2/base", "1.2/sp2", "1.2/sp3", "1.2/sp4",
+                "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3"]
 
 _modcache = {}        # module name -> dict
 _bincache = {}        # module name -> full bytes
@@ -108,9 +103,9 @@ def compiles_to(src, name, target):
                         continue
                     ok, _ = M.compare(target, code, relocs, verbose=False)
                     if ok:
-                        # 1.2/sp2p3 is canonical for BOTH C and C++ (the .cpp flag is not a
-                        # different compiler version); only flag genuinely different versions.
-                        return "1.2/sp2p3" if v == "1.2/sp2p3" else f"{v}/{suf[1:]}"
+                        # CANONICAL is authoritative for both C and C++ (//cpp is flags, not
+                        # a different mwccarm version); only flag genuinely different versions.
+                        return M.CANONICAL if v == M.CANONICAL else f"{v}/{suf[1:]}"
         finally:
             pathlib.Path(tmp).unlink(missing_ok=True)
     return None
@@ -135,7 +130,7 @@ def check(entry):
     for src in srcs:
         v = compiles_to(src, name, target)
         if v is not None:
-            return (name, mod, "OK" if v == "1.2/sp2p3" else f"OK:{v}")
+            return (name, mod, "OK" if v == M.CANONICAL else f"OK:{v}")
     return (name, mod, "FALSE")
 
 

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -45,10 +45,9 @@ sys.path.insert(0, str(REPO / "tools"))
 import rombuild_check as RBC  # noqa: E402
 import rombuild_profile as RP  # noqa: E402
 
-# Default compiler for the ROM build. The repo pins 1.2/sp2p3 as the canonical
-# matching compiler, but the recovered 2004 build 0056 (notes/mwccarm-codegen.md 6ai)
-# reproduces strictly more of this corpus, so the build defaults to it and
-# config/rombuild-versions.txt carries the per-file exceptions.
+# Default compiler for the ROM build — same as the matching pin (tools/match.py
+# CANONICAL / notes/rom-build.md). config/rombuild-versions.txt carries per-file
+# exceptions that still need a 1.2/* service pack.
 VERSION = "2004/b56"
 # 2004/b56 ships only mwccarm.exe - there is no mwldarm in it - so the link always
 # uses the 1.2/sp2p3 linker regardless of which compiler produced the objects.

--- a/tools/stamp_provenance.py
+++ b/tools/stamp_provenance.py
@@ -186,7 +186,7 @@ def main() -> None:
     ap.add_argument("--addr", help="Address (hex); default from symbols.txt")
     ap.add_argument("--size", help="Size (hex); default from symbols.txt")
     ap.add_argument("--module", default=None, help="Module (default arm9 / from symbols)")
-    ap.add_argument("--version", default="1.2/sp2p3")
+    ap.add_argument("--version", default="2004/b56")
     ap.add_argument("--kind", required=True, choices=("human", "ai"))
     ap.add_argument(
         "--model",


### PR DESCRIPTION
## Summary

Front-door docs and tool defaults still told contributors/agents to verify with **mwccarm 1.2/sp2p3**, while the ROM build path and corpus already treat **2004/b56** as the better default. That mismatch keeps producing false trust issues on match PRs.

This PR makes **2004/b56** the stated matching pin and the default for `tools/match.py` / related tooling.

### Updated
- `README.md`, `CONTRIBUTING.md`, `AGENTS.md` — pin text, verify command, PR title template
- `tools/match.py` — `CANONICAL = "2004/b56"` (default single-version path); `SWEEP` lists b56 first
- `tools/stamp_provenance.py`, permuter compile wrapper + import, `reverify_corpus.py`, `glm_refine.py`, `cpp_rename.py`, `nonmatching.py`
- `notes/matching-style.md`, `notes/rom-build.md`, `tools/rombuild.py` comments

### Left intentional
- **Linker** remains `1.2/sp2p3` `mwldarm` (`LD_VERSION`) — b56 ships no linker
- `match.py --trio` still sweeps the 1.2 base/sp2/sp2p3 trio
- Historical `CLAIMS.md` rows and comparative codegen notes unchanged

## Test plan
- [x] Grep front-door docs for pin wording
- [ ] `python tools/match.py --help` / default path uses 2004/b56 when `--version` omitted
- [ ] CI / validate still green (no src/ match files in this PR)