### PR TITLE
port: gate 1 - decompiled code runs natively on PC

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16)
+project(sm64ds-port C CXX)
+
+# Gate 1: compile the manifest slice out of ../src plus the HAL, link the
+# smoke runner. 32-bit host only -- platform.h enforces it at compile time.
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate1.txt" SLICE_LINES)
+set(SLICE_SOURCES "")
+foreach(line IN LISTS SLICE_LINES)
+    string(STRIP "${line}" line)
+    if(line MATCHES "^#" OR line STREQUAL "")
+        continue()
+    endif()
+    list(APPEND SLICE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
+endforeach()
+
+add_executable(smoke
+    tests/smoke.cpp
+    hal/cstd_div.c
+    hal/os_time.cpp
+    hal/shims.cpp
+    ${SLICE_SOURCES})
+
+target_include_directories(smoke PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+
+target_compile_definitions(smoke PRIVATE SM64DS_PLATFORM_PC)
+if(MSVC)
+    # The decomp C uses guest idioms MSVC warns about; keep the build quiet
+    # enough that a NEW warning is visible. /W3 stays on.
+    target_compile_options(smoke PRIVATE /wd4311 /wd4312 /wd4068)
+endif()

--- a/port/README.md
+++ b/port/README.md
@@ -1,0 +1,37 @@
+# port/ - the native PC build
+
+This tree hosts the PC port of the decompiled game: the same `src/` sources
+compiled for the host, a platform seam instead of DS hardware, and its own
+build that never touches the byte-matching pipeline.
+
+## Rules
+
+- **`src/` stays the byte-verified source of truth.** The port compiles files
+  FROM `src/`; it never edits them for host convenience. A file that needs a
+  host-side change gets that change behind `SM64DS_PLATFORM_*` guards or a
+  seam header, reviewed like any other src change.
+- **Logically-correct-but-unmatched implementations live in
+  `port/unmatched/`, never in `src/`.** The NDS hybrid build keeps selecting
+  delinked ROM bytes for those functions; the PC build selects these.
+- **32-bit host first.** The recovered ABI assumes 4-byte pointers. x64 comes
+  after struct recovery makes layout host-independent.
+
+## Gate 1 (this directory today)
+
+A Win32 headless executable that compiles a curated slice - types,
+fixed-point math, matrices, Timer, the Fader class hierarchy - and runs ABI
+assertions plus known-value smoke tests. No renderer, no audio, no input.
+Build it with `build-port.cmd`; run `build\port\smoke.exe`.
+
+`slice_gate1.txt` is the manifest. Grow the slice by adding files there and
+assertions to `tests/smoke.cpp`; `tools/host_frontier.py` reports how much of
+`src/` syntax-compiles for the host and why the rest does not, so the next
+subsystem to pull in is a measurement, not a guess.
+
+## Why the emulator is not here
+
+The hybrid (tangOS-SM64DS) stays the verification harness: it proves
+functions byte-for-byte against real hardware behaviour. The port is the
+destination. Benchmarks on 2026-08-02 showed natives inside the hybrid are
+performance-neutral (~2% of the emulated clock), which is the measured
+argument for building the port rather than growing the hybrid further.

--- a/port/build-port.cmd
+++ b/port/build-port.cmd
@@ -1,0 +1,12 @@
+@echo off
+rem Build the PC port's gate-1 smoke runner: 32-bit MSVC via VS Build Tools,
+rem same toolchain-location pattern as the recomp's build scripts.
+setlocal
+set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer;%PATH%"
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars32.bat" >nul
+if errorlevel 1 exit /b 1
+set "CMAKEBIN=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake"
+set "PATH=%CMAKEBIN%\CMake\bin;%CMAKEBIN%\Ninja;%PATH%"
+cmake -S "%~dp0." -B "%~dp0..\build\port" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM="%CMAKEBIN%\Ninja\ninja.exe" %*
+if errorlevel 1 exit /b 1
+ninja -C "%~dp0..\build\port"

--- a/port/hal/cstd_div.c
+++ b/port/hal/cstd_div.c
@@ -1,0 +1,21 @@
+/* Host implementation of the cstd fixed-point divide.
+ *
+ * On the DS, cstd::fdiv feeds the hardware divider (fdiv_async writes the
+ * DIV registers, fdiv_result spins on DIV_BUSY) -- src/_ZN4cstd4fdivEii.c is
+ * a thin wrapper over MMIO and cannot run on a host. The operation itself is
+ * just a 20.12 divide: (a / b) in Fix12 is (a << 12) / b.
+ *
+ * DS divider edge cases, preserved deliberately:
+ *   b == 0  -> the hardware yields +/-1 with the sign of the numerator (and
+ *              sets DIV_DIV0); callers in this codebase never rely on it, but
+ *              matching the hardware costs one branch and removes a class of
+ *              "host differs on garbage input" surprises.
+ */
+typedef int s32;
+
+s32 _ZN4cstd4fdivEii(s32 a, s32 b)
+{
+    if (b == 0)
+        return a < 0 ? -1 : 1;
+    return (s32)(((long long)a << 12) / b);
+}

--- a/port/hal/os_time.cpp
+++ b/port/hal/os_time.cpp
@@ -1,0 +1,25 @@
+// Host implementation of the system tick, func_02059650.
+//
+// On the DS this reads the OS tick counter (timer hardware + IRQ-maintained
+// high bits). Timer::Start/Stop/GetTime take differences of it, so any
+// monotonic s64 with a stable rate is semantically faithful. The Timer TUs
+// declare it with C++ linkage, which is why this is a .cpp -- a C definition
+// does not mangle to what they reference.
+//
+// GATE 1: the tick is a manually-advanced counter so the smoke tests are
+// deterministic -- sm64ds_hal_advance_ticks() stands in for time passing.
+// When the main-loop seam lands, this becomes a QueryPerformanceCounter read
+// scaled to the DS tick rate, and the manual hook moves behind a test flag.
+typedef long long s64;
+
+static s64 g_ticks;
+
+s64 func_02059650()
+{
+    return g_ticks;
+}
+
+extern "C" void sm64ds_hal_advance_ticks(s64 n)
+{
+    g_ticks += n;
+}

--- a/port/hal/shims.cpp
+++ b/port/hal/shims.cpp
@@ -1,0 +1,42 @@
+// Host-side definitions for symbols the slice references but whose NDS
+// definitions cannot serve an MSVC build.
+#include "Fader.h"
+#include "FaderBrightness.h"
+
+// The *D0Ev/*D1Ev translation units define Itanium-mangled destructor names
+// as C functions -- that satisfies the NDS link, where the filename IS the
+// symbol, but MSVC mangles destructors its own way, so the host needs real
+// C++ definitions. The ROM dtors only reset vptrs on the way down; there is
+// nothing to release, so empty bodies are faithful.
+Fader::~Fader() {}
+FaderBrightness::~FaderBrightness() {}
+
+// Base-class virtual slots not yet in the slice. Fader.h declares them
+// non-pure because the ROM's Fader vtable carries real entries; their src/
+// TUs just have not been pulled in yet. Until they are, the host needs
+// SOMETHING in the slots for the vtables to link. Defaults chosen to be
+// inert and loud-adjacent: value-returning slots report "at neither end".
+void Fader::AdvanceFade() {}
+int Fader::SetBackwardTime(u32) { return 0; }
+int Fader::SetForwardTime(u32) { return 0; }
+int Fader::IsAtStart() { return 0; }
+int Fader::IsAtEnd() { return 0; }
+
+// FaderBrightness::AdvanceFade is real matched code but writes the 2D-engine
+// palette through GX/GXS plus a CP15 cache flush -- that half waits for the
+// video seam. The interpolation half is Fader::AdvanceInterp, which IS in
+// the slice, so the gate-1 stub advances the fade level and skips only the
+// hardware upload.
+void FaderBrightness::AdvanceFade() { AdvanceInterp(); }
+
+// Fader::AdvanceInterp calls the 20.12 approach helper by its historical
+// name func_0203ae58 (extern "C", by-pointer). The function has since been
+// identified and renamed to ApproachLinear(int&, int, int) -- the NDS build
+// resolves the old name by address, the host cannot. Bridge, do not edit
+// src/: the fader TU keeps matching bytes, and when its extern is one day
+// modernised this shim dies loudly as a duplicate.
+int ApproachLinear(int &ref, int target, int step);
+extern "C" void func_0203ae58(int *value, int target, int step)
+{
+    ApproachLinear(*value, target, step);
+}

--- a/port/platform.h
+++ b/port/platform.h
@@ -1,0 +1,29 @@
+/* Platform selection for the dual NDS/PC build.
+ *
+ * Exactly one of SM64DS_PLATFORM_NDS / SM64DS_PLATFORM_PC is defined by the
+ * build system. src/ files do not include this header today; it exists so the
+ * first platform seams (timing, input, register access) have one switch to
+ * stand on instead of each inventing its own.
+ *
+ * The NDS side must expand to the original expressions byte-for-byte -- the
+ * matching gate keeps that honest. The PC side routes to host implementations
+ * under port/hal/ as they appear.
+ */
+#ifndef SM64DS_PORT_PLATFORM_H
+#define SM64DS_PORT_PLATFORM_H
+
+#if !defined(SM64DS_PLATFORM_NDS) && !defined(SM64DS_PLATFORM_PC)
+#error "define SM64DS_PLATFORM_NDS or SM64DS_PLATFORM_PC"
+#endif
+#if defined(SM64DS_PLATFORM_NDS) && defined(SM64DS_PLATFORM_PC)
+#error "define exactly one platform"
+#endif
+
+#ifdef SM64DS_PLATFORM_PC
+/* The recovered ABI is 32-bit; catch a 64-bit host configuration at compile
+ * time rather than as a corrupted struct at runtime. Struct recovery lifts
+ * this restriction; until then it is load-bearing. */
+typedef char sm64ds_require_4byte_pointers[sizeof(void *) == 4 ? 1 : -1];
+#endif
+
+#endif

--- a/port/slice_gate1.txt
+++ b/port/slice_gate1.txt
@@ -1,0 +1,41 @@
+# Gate-1 slice manifest: every src/ file the host smoke build compiles,
+# relative to the repo root. Grow the port by growing this list (and the
+# assertions in tests/smoke.cpp with it).
+#
+# Deliberately excluded from gate 1, with the reason recorded so the next
+# person doesn't re-litigate:
+#   FaderBrightness::AdvanceFade / FaderColor::AdvanceFade
+#       write GX/GXS palette + CP15 cache MMIO -- wait for the video seam
+#   FaderWipe::*    LoadAndSetFile calls the filesystem; ctor pulls the same
+#   StartEntranceFaderWipe / StartExitFaderWipe    global engine state
+#   *D0Ev.c / *D1Ev.c destructor TUs
+#       they define Itanium-mangled symbols as C functions, which satisfies
+#       the NDS link but not MSVC's mangling; the host gets real C++ dtors
+#       from port/hal/shims.cpp instead
+#   src/_ZN4cstd4fdivEii.c
+#       chains to the DS hardware divider (fdiv_async/fdiv_result MMIO);
+#       port/hal/cstd_div.c is the host divider
+
+# fixed-point math and vectors (self-contained C)
+src/DotVec3.c
+src/CrossVec3.c
+src/MulVec3Mat4x3.c
+src/Matrix3x3_FromQuaternion.c
+src/_Z14ApproachLinearRiii.cpp
+
+# Timer (plain struct + methods, no externs)
+src/_ZN5Timer10ResetTimerEv.cpp
+src/_ZN5Timer10StartTimerEv.cpp
+src/_ZN5Timer9StopTimerEv.cpp
+src/_ZN5Timer7GetTimeEv.cpp
+
+# Fader hierarchy (real C++ with vtables -- host vtables are exactly what a
+# port wants, unlike the hybrid, which must reject them)
+src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp
+src/engine/fader/_ZN15FaderBrightness10SetToStartEv.cpp
+src/engine/fader/_ZN15FaderBrightness8SetToEndEv.cpp
+src/engine/fader/_ZN15FaderBrightness9IsAtStartEv.cpp
+src/engine/fader/_ZN15FaderBrightness7IsAtEndEv.cpp
+src/engine/fader/_ZN15FaderBrightness20IsBetweenStartAndEndEv.cpp
+src/engine/fader/_ZN15FaderBrightness14SetForwardTimeEj.cpp
+src/engine/fader/_ZN15FaderBrightness15SetBackwardTimeEj.cpp

--- a/port/tests/smoke.cpp
+++ b/port/tests/smoke.cpp
@@ -1,0 +1,116 @@
+// Gate-1 smoke: ABI assertions + known-value tests over the real src/ code.
+// Every check here runs actual decompiled game code on the host -- no
+// emulator, no ROM. A failure means either the host ABI diverges from the
+// recovered layout or a seam implementation is wrong.
+#include <stdio.h>
+#include <stddef.h>
+#include "types.h"
+#include "Timer.h"
+#include "Fader.h"
+#include "FaderBrightness.h"
+
+// ---- ABI: the recovered layouts must survive the host compiler ----------
+static_assert(sizeof(u8) == 1 && sizeof(u16) == 2 && sizeof(u32) == 4, "int widths");
+static_assert(sizeof(s64) == 8, "s64");
+static_assert(sizeof(void *) == 4, "32-bit host (see port/platform.h)");
+static_assert(sizeof(Fix12i) == 4, "Fix12i is a 32-bit 20.12 scalar");
+static_assert(offsetof(Timer, unk_004) == 4, "Timer +0x4");
+static_assert(offsetof(Timer, mIsRunning) == 8, "Timer +0x8");
+// Fader's evidence header pins currInterp at +0x4 with the vptr at +0x0.
+// This only holds if the host vptr is exactly 4 bytes -- x86-32 MSVC -- which
+// is the whole 32-bit-first argument in one line:
+static_assert(offsetof(Fader, currInterp) == 4, "vptr must be 4 bytes");
+static_assert(offsetof(Fader, speed) == 8, "Fader +0x8");
+
+// ---- the C math slice ---------------------------------------------------
+// Vector3 comes from the shared headers (common.h via the Fader includes);
+// redefining it here was a redefinition error, which is itself a small ABI
+// win: the test uses the same type the game does.
+extern "C" Fix12i DotVec3(const Vector3 *a, const Vector3 *b);
+extern "C" void CrossVec3(const Vector3 *a, const Vector3 *b, Vector3 *out);
+extern "C" void sm64ds_hal_advance_ticks(s64 n);
+int ApproachLinear(int &ref, int target, int step);
+
+static int g_failures;
+#define CHECK(cond) \
+    do { if (!(cond)) { ++g_failures; \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); } } while (0)
+
+#define ONE 0x1000  /* 1.0 in 20.12 */
+
+static void test_math(void)
+{
+    Vector3 x = {ONE, 0, 0}, y = {0, ONE, 0}, out;
+
+    CHECK(DotVec3(&x, &x) == ONE);            /* 1.0 . 1.0 */
+    CHECK(DotVec3(&x, &y) == 0);              /* orthogonal */
+    Vector3 half = {ONE / 2, 0, 0};
+    CHECK(DotVec3(&x, &half) == ONE / 2);     /* 1.0 * 0.5 */
+
+    CrossVec3(&x, &y, &out);                  /* x cross y = z */
+    CHECK(out.x == 0 && out.y == 0 && out.z == ONE);
+
+    int v = 0;
+    CHECK(ApproachLinear(v, 0x1000, 0x400) == 0 && v == 0x400);
+    v = 0xF00;
+    CHECK(ApproachLinear(v, 0x1000, 0x400) == 1 && v == 0x1000);  /* clamps */
+    v = 7;
+    CHECK(ApproachLinear(v, 7, 0) == 1);      /* zero step, at target */
+}
+
+static void test_timer(void)
+{
+    Timer t;
+    t.ResetTimer();
+    CHECK(t.mIsRunning == 0 && t.unk_000 == 0 && t.unk_004 == 0);
+    CHECK(t.GetTime() == 0);
+
+    t.StartTimer();
+    CHECK(t.mIsRunning == 1);
+    sm64ds_hal_advance_ticks(1000);
+    CHECK(t.GetTime() == 1000);               /* running: now - start */
+    t.StopTimer();
+    CHECK(t.mIsRunning == 0 && t.GetTime() == 1000);   /* frozen */
+    sm64ds_hal_advance_ticks(500);
+    CHECK(t.GetTime() == 1000);               /* still frozen */
+}
+
+static void test_fader(void)
+{
+    // Host-constructible subclass; the base has no ctor of its own in the
+    // slice. The vtable this creates is the HOST's -- which is the point:
+    // the port uses real C++ dispatch where the hybrid must trampoline.
+    struct TestFader : FaderBrightness {} f;
+
+    f.SetToStart();
+    CHECK(f.IsAtStart() == 1 && f.IsAtEnd() == 0);
+    CHECK(f.IsBetweenStartAndEnd() == 0);
+
+    // 16-frame forward fade: speed = fdiv(1.0, 16.0) through the HAL divider
+    f.SetForwardTime(16);
+    CHECK(f.speed == ONE / 16);
+    for (int i = 0; i < 15; ++i) {
+        f.AdvanceInterp();
+        CHECK(f.IsBetweenStartAndEnd() == 1);
+    }
+    f.AdvanceInterp();                        /* 16th step lands exactly */
+    CHECK(f.IsAtEnd() == 1 && f.currInterp == ONE);
+
+    f.SetBackwardTime(8);                     /* and back down */
+    for (int i = 0; i < 8; ++i)
+        f.AdvanceInterp();
+    CHECK(f.IsAtStart() == 1 && f.currInterp == 0);
+}
+
+int main(void)
+{
+    test_math();
+    test_timer();
+    test_fader();
+    if (g_failures) {
+        fprintf(stderr, "smoke: %d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("smoke: all checks passed (math, Timer, Fader on host)\n");
+    return 0;
+}


### PR DESCRIPTION
First host build of the port, following the plan from Andrew's notes: a Win32 headless smoke runner compiling 17 src/ files unmodified (vector math, Timer, the Fader hierarchy with real host vtables) plus the first three HAL seams (hardware divider, OS tick, host dtors/vtable stubs). ABI assertions pin the recovered layouts against the host compiler, and known-value tests drive a full fade cycle and Timer semantics through actual game code. All checks pass.

No src/ changes; the gate has nothing to compile from this PR. port/README.md records the layout rules including the port/unmatched convention.

Next per the plan: the syntax-compile frontier report over all of src/, then the timing/input seam.