### PR TITLE
port: classify asm-hatch TUs as HAL-owned in the frontier

### DIFF
--- a/port/README.md
+++ b/port/README.md
@@ -42,9 +42,16 @@ First full sweep of `tools/host_frontier.py` (cl /Zs, 32-bit, all of src/):
 
     compiles for host: 11,005 / 11,222  (98.1%)
 
-217 failures, largest buckets: C2054 x98 (one idiom, worth one targeted
-fix), generic syntax errors x44, C2732 linkage contradictions x19, the rest
-single digits. The takeaway: the decomp's C is already overwhelmingly
-host-clean, so the port's work is platform seams and link closure, not mass
-source repair. Re-run the sweep after each seam lands; the number should
-only go up.
+Refined the same day: the C2054 x98 bucket decoded as the asm-hatch TUs
+(`asm void`, mwccarm syntax) -- DS hardware operations that SHOULD not
+compile on a host. CP15 cache management is a host no-op, block copy/fill is
+memcpy, context switch is the threads seam. The tool now classifies them as
+HAL-owned rather than as syntax defects, which makes the honest frontier:
+
+    compiles for host: 11,005 / 11,125  (98.9%)   + 97 asm TUs -> HAL backlog
+
+120 real failures remain: generic syntax x44, C2732 extern-C linkage
+contradictions x19, undeclared identifiers x13, unknown types x11, the rest
+single digits. The takeaway stands, stronger: the port's work is platform
+seams and link closure, not mass source repair. Re-run after each seam
+lands; the number should only go up.

--- a/port/tools/host_frontier.py
+++ b/port/tools/host_frontier.py
@@ -122,6 +122,23 @@ def main():
 
     files = sorted(p for p in SRC.rglob("*") if p.suffix in (".c", ".cpp"))
     print(f"host frontier: {len(files)} source files, cl /Zs, 32-bit")
+
+    # asm-hatch TUs (`asm void f(...) { ... }`, mwccarm syntax) can never
+    # compile on a host and SHOULD not: they are DS hardware operations --
+    # CP15 cache management (host no-op), block copy/fill (memcpy), context
+    # switch (threads seam). Classify them as HAL-owned up front instead of
+    # letting them read as 98 syntax defects; they are the HAL backlog.
+    hal_owned = []
+    rest = []
+    asm_re = re.compile(r"^\s*asm\s+\w", re.M)
+    for f in files:
+        try:
+            head = f.read_text(errors="replace")
+        except OSError:
+            rest.append(f)
+            continue
+        (hal_owned if asm_re.search(head) else rest).append(f)
+    files = rest
     env = vc_env()
 
     batches = [files[i:i + args.batch] for i in range(0, len(files), args.batch)]
@@ -143,8 +160,11 @@ def main():
         buckets[b] += 1
         members[b].append(f)
 
+    total = len(files) + len(hal_owned)
     pct = 100.0 * len(ok) / len(files) if files else 0
-    print(f"\ncompiles for host: {len(ok)} / {len(files)}  ({pct:.1f}%)\n")
+    print(f"\ncompiles for host: {len(ok)} / {len(files)}  ({pct:.1f}%)"
+          f"   [+ {len(hal_owned)} asm-hatch TUs, HAL-owned on host, "
+          f"excluded from the denominator]\n")
     for b, n in buckets.most_common():
         print(f"  {n:6}  {b}")
 


### PR DESCRIPTION
The C2054 x98 bucket decoded as the asm hatches, which should never compile on a host - they are the HAL backlog (cache no-ops, memcpy, threads seam). Frontier refined to 98.9% with 120 real failures ranked. Port-only.