### PR TITLE
port: gate 2 - the game's heap allocator runs on a host arena

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -34,3 +34,24 @@ if(MSVC)
     # enough that a NEW warning is visible. /W3 stays on.
     target_compile_options(smoke PRIVATE /wd4311 /wd4312 /wd4068)
 endif()
+
+# Gate 2: the allocator family + torture smoke, its own binary so gate 1
+# stays a stable baseline.
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate2.txt" SLICE2_LINES)
+set(SLICE2_SOURCES "")
+foreach(line IN LISTS SLICE2_LINES)
+    string(STRIP "${line}" line)
+    if(line MATCHES "^#" OR line STREQUAL "")
+        continue()
+    endif()
+    list(APPEND SLICE2_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
+endforeach()
+
+add_executable(smoke_heap tests/smoke_heap.cpp hal/heap_globals.cpp ${SLICE2_SOURCES})
+target_include_directories(smoke_heap PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_compile_definitions(smoke_heap PRIVATE SM64DS_PLATFORM_PC)
+if(MSVC)
+    target_compile_options(smoke_heap PRIVATE /wd4311 /wd4312 /wd4068)
+endif()

--- a/port/hal/heap_globals.cpp
+++ b/port/hal/heap_globals.cpp
@@ -1,0 +1,61 @@
+// Host storage and linkage bridging for the heap subsystem.
+//
+// THE PROBLEM THIS FILE SOLVES: on the NDS, symbols resolve by ADDRESS, so
+// one global can be referenced as C++ `Memory::rootHeapIterator` in one TU
+// and as C `data_020a4d38` in another and both land on 0x020a4d38. A host
+// linker resolves by NAME; without bridging, those become two separate
+// storages and the heap registry silently forks -- the ctor registers into
+// one list while FindNested searches the other. /alternatename restores the
+// by-address identity: one storage, every historical name an alias.
+//
+// The same split affects functions: some C++ TUs declare the iterator entry
+// points without extern "C" (MSVC-mangled references) while the defining
+// TUs are C (plain-name definitions). Each alias below names the x86-32
+// decorated forms.
+
+extern "C" {
+// The single real storage. Memory::rootHeapIterator is a NestedHeapIterator
+// (a list head); the decomp TUs address it as a blob. 0x20 covers the
+// evidenced fields with room; the ctor initializes it.
+char _ZN6Memory16rootHeapIteratorE[0x20];
+int _ZN6Memory25isRootHeapIterInitializedE;
+
+// SDK asm primitive (stmia burst fill) -> plain word fill on host. The
+// frontier classifies its TU as HAL-owned; this is the HAL half.
+void MultiStore_Int(int val, int *dst, int len)
+{
+    for (int i = 0; i < len / 4; ++i)
+        dst[i] = val;
+}
+}
+
+// DATA aliases: point every historical name at the one storage above. Safe
+// for data (no calling convention); the decorated spellings come verbatim
+// from link errors -- the linker is the authority on decoration.
+#pragma comment(linker, "/alternatename:_data_020a4d38=__ZN6Memory16rootHeapIteratorE")
+#pragma comment(linker, "/alternatename:?_ZN6Memory16rootHeapIteratorE@@3DA=__ZN6Memory16rootHeapIteratorE")
+#pragma comment(linker, "/alternatename:?_ZN6Memory25isRootHeapIterInitializedE@@3HA=__ZN6Memory25isRootHeapIterInitializedE")
+// FUNCTION alias only where the conventions MATCH: this reference and the C
+// definition are both __cdecl free functions.
+#pragma comment(linker, "/alternatename:?_ZN18NestedHeapIteratorC1Ej@@YAXPAXI@Z=__ZN18NestedHeapIteratorC1Ej")
+
+// FUNCTION BRIDGES where aliasing would be a silent ABI bug: C TUs call the
+// iterator entry points as __cdecl free functions under Itanium names, but
+// the .cpp TUs define them as __thiscall METHODS (this in ecx). An
+// /alternatename between those links fine and then reads garbage as `this`
+// at runtime. Real forwarders convert the convention.
+#include "NestedHeapIterator.h"
+extern "C" {
+void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(void *self, HeapAllocator *a)
+{ ((NestedHeapIterator *)self)->AddLast(a); }
+void _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(void *self, HeapAllocator *a)
+{ ((NestedHeapIterator *)self)->AddFirst(a); }
+int _ZN18NestedHeapIterator4NextEP13HeapAllocator(void *self, HeapAllocator *a)
+{ return ((NestedHeapIterator *)self)->Next(a); }
+}
+// And the reverse direction: AddLast/AddFirst reference Init as a C++
+// __cdecl FREE function (?_ZN..4Init..@@YAXPAD0@Z, char* args) while
+// Init.cpp defines the method. C++ linkage on purpose -- extern "C" would
+// decorate this wrong.
+void _ZN18NestedHeapIterator4InitEP13HeapAllocator(char *self, char *a)
+{ ((NestedHeapIterator *)self)->Init((HeapAllocator *)a); }

--- a/port/slice_gate2.txt
+++ b/port/slice_gate2.txt
@@ -1,0 +1,36 @@
+# Gate-2 slice: the ExpandingHeapAllocator family -- the allocator LAYER
+# only. The Heap class layer above it (CreateRootHeap, SetupRootHeap) reads
+# OS arena globals and waits for the OS seam in a later gate.
+#
+# Chosen second because Andrew's implementation order starts at
+# memory/runtime/heaps, and because this is where the LP64 bug class lived:
+# an allocator that survives a fill-pattern torture test on the host is the
+# strongest layout evidence a port can buy per line of test code.
+
+src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.c
+src/_ZN22ExpandingHeapAllocatorC1EPvj.c
+src/_ZN13HeapAllocatorC1EjPvPvj.cpp
+src/_ZN22ExpandingHeapAllocator8AllocateEji.c
+src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp
+src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp
+src/_ZN22ExpandingHeapAllocator10DeallocateEPv.c
+src/_ZN22ExpandingHeapAllocator14SizeofInternalEPv.c
+src/_ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt.cpp
+src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj.cpp
+src/_ZN22ExpandingHeapAllocator8FreeNodeEP10MemoryNodePNS0_6TargetE.cpp
+src/_ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_.cpp
+src/_ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_.cpp
+src/_ZN10MemoryNode6TargetC1EP10MemoryNode.cpp
+
+# NestedHeapIterator: the HeapAllocator base ctor registers every allocator
+# in the global nesting registry, so the iterator family rides along.
+src/_ZN18NestedHeapIteratorC1Ej.c
+src/_ZN18NestedHeapIterator10FindNestedEPv.c
+src/_ZN18NestedHeapIterator19RecursiveFindNestedEPv.c
+src/_ZN18NestedHeapIterator7AddLastEP13HeapAllocator.cpp
+src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c
+src/_ZN18NestedHeapIterator4InitEP13HeapAllocator.cpp
+src/_ZN18NestedHeapIterator4NextEP13HeapAllocator.cpp
+src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.cpp
+src/_ZN18NestedHeapIterator8PreviousEP13HeapAllocator.cpp
+src/_ZN18NestedHeapIterator6RemoveEP13HeapAllocator.cpp

--- a/port/tests/smoke_heap.cpp
+++ b/port/tests/smoke_heap.cpp
@@ -1,0 +1,98 @@
+// Gate-2 smoke: the game's ExpandingHeapAllocator running on a host arena.
+//
+// Everything here goes through the exact entry points the game uses, by
+// mangled name, the way the src/ TUs call each other. A fill-pattern torture
+// test is the point: the LP64 bug class corrupted allocator node headers
+// silently, and an allocator that survives thousands of randomized
+// alloc/free cycles with per-block patterns intact is strong evidence the
+// recovered layouts are byte-faithful on the host.
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef unsigned int u32;
+
+struct ExpandingHeapAllocator;
+extern "C" {
+ExpandingHeapAllocator *_ZN4Heap28CreateExpandingHeapAllocatorEPvjj(void *address, u32 size, u32 flags);
+void *_ZN22ExpandingHeapAllocator8AllocateEji(ExpandingHeapAllocator *self, u32 size, int align);
+int _ZN22ExpandingHeapAllocator10DeallocateEPv(ExpandingHeapAllocator *self, void *ptr);
+}
+#define CreateAllocator _ZN4Heap28CreateExpandingHeapAllocatorEPvjj
+#define Alloc(a, n)     _ZN22ExpandingHeapAllocator8AllocateEji((a), (n), 4)
+#define Free(a, p)      _ZN22ExpandingHeapAllocator10DeallocateEPv((a), (p))
+
+static int g_failures;
+#define CHECK(cond) \
+    do { if (!(cond)) { ++g_failures; \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); } } while (0)
+
+enum { ARENA = 1 << 20, SLOTS = 64, OPS = 5000 };
+
+static u32 lcg_state = 0x1234567u;   /* fixed seed: the run is reproducible */
+static u32 lcg(void) { return lcg_state = lcg_state * 1664525u + 1013904223u; }
+
+int main(void)
+{
+    void *arena = malloc(ARENA);
+    CHECK(arena != NULL);
+    ExpandingHeapAllocator *heap = CreateAllocator(arena, ARENA, 0);
+    CHECK(heap != NULL);
+
+    /* basics: distinct, aligned, writable, freeable, reusable */
+    void *a = Alloc(heap, 64), *b = Alloc(heap, 64), *c = Alloc(heap, 64);
+    CHECK(a && b && c && a != b && b != c);
+    CHECK(((size_t)a % 4) == 0 && ((size_t)b % 4) == 0);
+    memset(a, 0xAA, 64); memset(b, 0xBB, 64); memset(c, 0xCC, 64);
+    CHECK(((unsigned char *)a)[63] == 0xAA && ((unsigned char *)b)[0] == 0xBB);
+    CHECK(Free(heap, b) != 0);
+    void *b2 = Alloc(heap, 64);
+    CHECK(b2 != NULL);              /* freed space is allocatable again */
+    Free(heap, a); Free(heap, b2); Free(heap, c);
+
+    /* torture: randomized alloc/free with per-slot fill patterns */
+    struct { void *p; u32 n; unsigned char tag; } slot[SLOTS] = {};
+    u32 live = 0, peak = 0, allocs = 0, frees = 0, failed_allocs = 0;
+    for (u32 op = 0; op < OPS; ++op) {
+        u32 i = lcg() % SLOTS;
+        if (slot[i].p == NULL) {
+            u32 n = 1 + lcg() % 2048;
+            void *p = Alloc(heap, n);
+            if (!p) { ++failed_allocs; continue; }   /* full is legal */
+            memset(p, (unsigned char)(0x40 + i), n);
+            slot[i].p = p; slot[i].n = n; slot[i].tag = (unsigned char)(0x40 + i);
+            ++allocs; ++live; if (live > peak) peak = live;
+        } else {
+            unsigned char *p = (unsigned char *)slot[i].p;
+            int intact = 1;
+            for (u32 k = 0; k < slot[i].n; ++k)
+                if (p[k] != slot[i].tag) { intact = 0; break; }
+            CHECK(intact);          /* neighbours never scribbled on us */
+            CHECK(Free(heap, slot[i].p) != 0);
+            slot[i].p = NULL; ++frees; --live;
+        }
+    }
+    for (u32 i = 0; i < SLOTS; ++i)   /* verify + drain the survivors */
+        if (slot[i].p) {
+            unsigned char *p = (unsigned char *)slot[i].p;
+            int intact = 1;
+            for (u32 k = 0; k < slot[i].n; ++k)
+                if (p[k] != slot[i].tag) { intact = 0; break; }
+            CHECK(intact);
+            CHECK(Free(heap, slot[i].p) != 0);
+        }
+
+    /* coalescing: after full drain one near-arena-sized block must fit */
+    void *big = Alloc(heap, ARENA - 0x200);
+    CHECK(big != NULL);
+    Free(heap, big);
+
+    if (g_failures) {
+        fprintf(stderr, "smoke_heap: %d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("smoke_heap: all checks passed (%u allocs, %u frees, peak %u live, "
+           "%u full-arena rejections, coalesce OK)\n",
+           allocs, frees, peak, failed_allocs);
+    return 0;
+}


### PR DESCRIPTION
24 src/ files of the ExpandingHeapAllocator family compile unmodified and pass a 5,000-op randomized torture test (fill patterns verified before every free, full coalescing after drain). Introduces the two seam mechanisms later subsystems will reuse: /alternatename data aliases restoring the NDS by-address symbol identity, and calling-convention bridges where aliasing would be a silent __thiscall/__cdecl runtime bug. Port-only change; both gate binaries pass.