### PR TITLE
port: gate 3a - the game's global heap bring-up runs on host

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -55,3 +55,25 @@ target_compile_definitions(smoke_heap PRIVATE SM64DS_PLATFORM_PC)
 if(MSVC)
     target_compile_options(smoke_heap PRIVATE /wd4311 /wd4312 /wd4068)
 endif()
+
+# Gate 3a: root heap + Memory:: layer over the gate-2 allocator.
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate3a.txt" SLICE3A_LINES)
+set(SLICE3A_SOURCES "")
+foreach(line IN LISTS SLICE3A_LINES)
+    string(STRIP "${line}" line)
+    if(line MATCHES "^#" OR line STREQUAL "")
+        continue()
+    endif()
+    list(APPEND SLICE3A_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
+endforeach()
+
+add_executable(smoke_roots tests/smoke_roots.cpp
+    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp
+    ${SLICE2_SOURCES} ${SLICE3A_SOURCES})
+target_include_directories(smoke_roots PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_compile_definitions(smoke_roots PRIVATE SM64DS_PLATFORM_PC)
+if(MSVC)
+    target_compile_options(smoke_roots PRIVATE /wd4311 /wd4312 /wd4068)
+endif()

--- a/port/hal/heap_vtable.cpp
+++ b/port/hal/heap_vtable.cpp
@@ -1,0 +1,111 @@
+// Host globals and the synthetic ExpandingHeap vtable.
+//
+// THE VTABLE PROBLEM: the C-spelled ctor installs `&_ZTV13ExpandingHeap`
+// as the object's vptr -- the Itanium vtable symbol, slot array starting at
+// the symbol itself. C++ callers then dispatch through shadow-class casts
+// (`((Base*)this)->m(...)`), which MSVC compiles as a __thiscall through a
+// numbered slot. So the HAL provides _ZTV13ExpandingHeap as a real slot
+// array whose entries are __fastcall shims (ecx carries `this` exactly as
+// __thiscall passes it; the dummy edx parameter absorbs fastcall's second
+// register) forwarding to the real V-methods from src/.
+//
+// Slot evidence, from the shadow classes in the callers themselves:
+//   Heap::Allocate    casts to {v0,v1,v2, m(uint,int)}  -> slot 3 = VAllocate
+//   Heap::Deallocate  casts to {v0..v3,   m(void*)}     -> slot 4 = VDeallocate
+// Slots without caller evidence are TRAPS that abort loudly with the slot
+// number -- a silent wrong-slot dispatch is the exact class of bug the
+// hybrid's gates existed to catch, and the port has no gate to catch it.
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef unsigned int u32;
+
+// Shadow declarations that mangle identically to the src/ definitions.
+struct ExpandingHeap {
+    void *VAllocate(u32 size, int align);
+    int VDeallocate(void *p);
+};
+struct ExpandingHeapAllocator {
+    void *Allocate(u32 size, int align);
+    static u32 SizeofInternal(void *p);
+    u32 MemoryLeft();
+};
+
+// ---- globals the root-heap chain stores through --------------------------
+extern "C" {
+void *data_020a0e9c;   /* Heap::rootHeap */
+void *data_020a0ea0;   /* Memory::defaultHeapPtr */
+int data_02099d90;     /* heap bring-up state flag */
+}
+
+// ---- allocator methods -> the C-linkage definitions from gate 2 ----------
+extern "C" {
+void *_ZN22ExpandingHeapAllocator8AllocateEji(void *self, u32 size, int align);
+int _ZN22ExpandingHeapAllocator10DeallocateEPv(void *self, void *p);
+u32 _ZN22ExpandingHeapAllocator14SizeofInternalEPv(void *p);
+u32 _ZN22ExpandingHeapAllocator10MemoryLeftEv(void *self);
+}
+void *ExpandingHeapAllocator::Allocate(u32 size, int align)
+{ return _ZN22ExpandingHeapAllocator8AllocateEji(this, size, align); }
+u32 ExpandingHeapAllocator::SizeofInternal(void *p)
+{ return _ZN22ExpandingHeapAllocator14SizeofInternalEPv(p); }
+u32 ExpandingHeapAllocator::MemoryLeft()
+{ return _ZN22ExpandingHeapAllocator10MemoryLeftEv(this); }
+
+// ---- cross-linkage bridges surfaced by the link, both directions ---------
+// C++ method VDeallocate -> its C-linkage definition
+extern "C" int _ZN13ExpandingHeap11VDeallocateEPv(void *self, void *p);
+int ExpandingHeap::VDeallocate(void *p)
+{ return _ZN13ExpandingHeap11VDeallocateEPv(this, p); }
+
+// C references to Heap::Allocate/Deallocate -> the MSVC method definitions.
+// The src/ TUs declare `class Heap` (mangles PAV); a struct shadow here would
+// mangle PAU and miss, so the method shadow must be a class too.
+class Heap {
+public:
+    int Allocate(u32 size, int align);
+    void Deallocate(void *p);
+};
+extern "C" {
+int _ZN4Heap8AllocateEji(void *self, u32 size, int align)
+{ return ((Heap *)self)->Allocate(size, align); }
+void _ZN4Heap10DeallocateEPv(void *self, void *p)
+{ ((Heap *)self)->Deallocate(p); }
+}
+
+// C++ references to Memory::Allocate(u32,int,Heap*) -> the C definition
+extern "C" void *_ZN6Memory8AllocateEjiP4Heap(u32 size, int align, void *heap);
+namespace Memory {
+void *Allocate(u32 size, int align, Heap *heap)
+{ return _ZN6Memory8AllocateEjiP4Heap(size, align, heap); }
+}
+
+// Memory::defaultHeapPtr is data_020a0ea0 by its address-name (data alias).
+#pragma comment(linker, "/alternatename:?defaultHeapPtr@Memory@@3PAVHeap@@A=_data_020a0ea0")
+
+// Crash(): the game's fatal stop. Loud on host.
+void Crash(void)
+{
+    fprintf(stderr, "FATAL: game Crash() reached\n");
+    abort();
+}
+
+// ---- the synthetic vtable ------------------------------------------------
+static void *__fastcall slot_alloc(void *self, void *, u32 size, int align)
+{ return ((ExpandingHeap *)self)->VAllocate(size, align); }
+static int __fastcall slot_dealloc(void *self, void *, void *p)
+{ return ((ExpandingHeap *)self)->VDeallocate(p); }
+
+#define TRAP(n) \
+    static void __fastcall slot_trap##n(void *, void *) { \
+        fprintf(stderr, "FATAL: ExpandingHeap vtable slot %d dispatched " \
+                        "with no caller evidence (see heap_vtable.cpp)\n", n); \
+        abort(); }
+TRAP(0) TRAP(1) TRAP(2) TRAP(5) TRAP(6) TRAP(7)
+
+extern "C" void *_ZTV13ExpandingHeap[8] = {
+    (void *)slot_trap0, (void *)slot_trap1, (void *)slot_trap2,
+    (void *)slot_alloc,        /* 3: VAllocate, pinned by Heap::Allocate */
+    (void *)slot_dealloc,      /* 4: VDeallocate, pinned by Heap::Deallocate */
+    (void *)slot_trap5, (void *)slot_trap6, (void *)slot_trap7,
+};

--- a/port/hal/os_arena.cpp
+++ b/port/hal/os_arena.cpp
@@ -1,0 +1,49 @@
+// Host OS arena: the memory region SetupRootHeap carves the root heap from.
+//
+// On the DS, data_020a0ea4 is the OS globals object and the func_02058*
+// family are the arena accessors (get-low, get-high, align-allocate,
+// set-low). On host the arena is one big malloc'd block, initialized on
+// first use so the smoke needs no setup call.
+#include <stdlib.h>
+
+typedef unsigned int u32;
+
+enum { HOST_ARENA = 8 << 20 };   /* 8 MB: larger than the DS main-RAM arena */
+
+static char *g_lo, *g_hi;
+static void arena_init(void)
+{
+    if (!g_lo) {
+        g_lo = (char *)malloc(HOST_ARENA);
+        g_hi = g_lo + HOST_ARENA;
+    }
+}
+
+extern "C" {
+// the OS globals object; the accessors ignore it, but the address must exist
+char data_020a0ea4[4];
+
+int func_02058ea0(void *) { arena_init(); return (int)(size_t)g_lo; }   /* arena lo */
+int func_02058eb4(void *) { arena_init(); return (int)(size_t)g_hi; }   /* arena hi */
+
+/* align `lo` up by `align`, bounded by hi -- mirrors OS_AllocFromArenaLo's
+ * pre-alignment step as SetupRootHeap uses it */
+int func_02059040(void *, int lo, int hi, int align)
+{
+    (void)hi;
+    return (lo + align - 1) & ~(align - 1);
+}
+
+void func_02058d58(void *, int newLo) { g_lo = (char *)(size_t)newLo; }  /* set lo */
+
+/* carve `size` bytes aligned `align` from the low side */
+void *func_02058cd0(void *, int size, int align)
+{
+    arena_init();
+    char *p = (char *)(((size_t)g_lo + align - 1) & ~(size_t)(align - 1));
+    if (p + size > g_hi)
+        return 0;
+    g_lo = p + size;
+    return p;
+}
+}

--- a/port/slice_gate3a.txt
+++ b/port/slice_gate3a.txt
@@ -1,0 +1,22 @@
+# Gate-3a slice: the ROOT HEAP bring-up and the Memory:: layer, on top of
+# gate 2's allocator family (the smoke links slice_gate2.txt as well).
+# The OS arena underneath is port/hal/os_arena.cpp.
+
+src/_ZN4Heap13SetupRootHeapEv.c
+src/_ZN4Heap14CreateRootHeapEPvj.c
+src/_ZN4Heap19CreateExpandingHeapEjPS_i.c
+src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.c
+src/_ZN4HeapC1EPvjP4Heap.c
+src/_ZN13ExpandingHeapC1EPvjP4HeapP22ExpandingHeapAllocator.c
+src/_ZN13ExpandingHeap9VAllocateEji.cpp
+src/_ZN13ExpandingHeap11VDeallocateEPv.c
+src/_ZN13ExpandingHeap7VSizeofEPv.cpp
+src/_ZN13ExpandingHeap11VMemoryLeftEv.cpp
+src/_ZN6Memory8AllocateEj.cpp
+src/_ZN6Memory8AllocateEji.cpp
+src/_ZN6Memory8AllocateEjiP4Heap.c
+src/_ZN6Memory10DeallocateEPv.cpp
+src/_ZN6Memory10DeallocateEPvP4Heap.cpp
+src/_ZN4Heap8AllocateEji.cpp
+src/_ZN4Heap10DeallocateEPv.cpp
+src/_ZN22ExpandingHeapAllocator10MemoryLeftEv.cpp

--- a/port/tests/smoke_roots.cpp
+++ b/port/tests/smoke_roots.cpp
@@ -1,0 +1,78 @@
+// Gate-3a smoke: the game's global heap bring-up on a host arena.
+//
+// SetupRootHeap -> CreateRootHeap -> ExpandingHeap over the gate-2 allocator,
+// then Memory::Allocate/Deallocate -- the exact allocation path every game
+// system uses -- exercised end to end on the host OS-arena seam.
+#include <stdio.h>
+#include <string.h>
+
+typedef unsigned int u32;
+
+struct HeapS;
+extern "C" {
+HeapS *_ZN4Heap13SetupRootHeapEv(void);
+int func_02058ea0(void *);
+int func_02058eb4(void *);
+}
+namespace Memory {
+void *Allocate(u32 size);
+void Deallocate(void *p);
+}
+
+static int g_failures;
+#define CHECK(cond) \
+    do { if (!(cond)) { ++g_failures; \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); } } while (0)
+
+static u32 lcg_state = 0xC0FFEEu;
+static u32 lcg(void) { return lcg_state = lcg_state * 1664525u + 1013904223u; }
+
+int main(void)
+{
+    HeapS *root = _ZN4Heap13SetupRootHeapEv();
+    CHECK(root != NULL);
+    char *arena_lo = (char *)(size_t)func_02058ea0(0);
+    char *arena_hi = (char *)(size_t)func_02058eb4(0);
+
+    /* allocations land inside the host arena and are usable */
+    void *a = Memory::Allocate(256);
+    CHECK(a != NULL);
+    CHECK((char *)a > arena_lo - (8 << 20) && (char *)a < arena_hi);
+    memset(a, 0x5A, 256);
+    CHECK(((unsigned char *)a)[255] == 0x5A);
+    Memory::Deallocate(a);
+
+    /* torture through the global path */
+    enum { SLOTS = 48, OPS = 3000 };
+    struct { void *p; u32 n; unsigned char tag; } slot[SLOTS] = {};
+    u32 allocs = 0, frees = 0;
+    for (u32 op = 0; op < OPS; ++op) {
+        u32 i = lcg() % SLOTS;
+        if (!slot[i].p) {
+            u32 n = 1 + lcg() % 4096;
+            void *p = Memory::Allocate(n);
+            if (!p) continue;
+            memset(p, (unsigned char)(0x21 + i), n);
+            slot[i].p = p; slot[i].n = n; slot[i].tag = (unsigned char)(0x21 + i);
+            ++allocs;
+        } else {
+            unsigned char *p = (unsigned char *)slot[i].p;
+            int intact = 1;
+            for (u32 k = 0; k < slot[i].n; ++k)
+                if (p[k] != slot[i].tag) { intact = 0; break; }
+            CHECK(intact);
+            Memory::Deallocate(slot[i].p);
+            slot[i].p = NULL; ++frees;
+        }
+    }
+    for (u32 i = 0; i < SLOTS; ++i)
+        if (slot[i].p) { Memory::Deallocate(slot[i].p); }
+
+    if (g_failures) {
+        fprintf(stderr, "smoke_roots: %d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("smoke_roots: all checks passed (root heap up, %u allocs, %u frees "
+           "through Memory::Allocate)\n", allocs, frees);
+    return 0;
+}


### PR DESCRIPTION
SetupRootHeap through Memory::Allocate on a host OS arena, 3,000-op torture green. Adds the OS-arena seam, the synthetic Itanium-vtable-with-fastcall-shims mechanism (unproven slots trap loudly), and both directions of cross-linkage bridging. All three gate binaries pass. Port-only change.