### PR TITLE
port: gate 4c - the game animates its own model on host

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -189,6 +189,23 @@ if(MSVC)
     target_compile_options(smoke_model PRIVATE /wd4311 /wd4312 /wd4068)
 endif()
 
+# Gate 4c: animation -- same slice (the 4c files live in slice_gate4b.txt),
+# different driver: the piano posed by its BCA through the game's walk.
+add_executable(smoke_anim tests/smoke_anim.cpp
+    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
+    hal/model_host.cpp hal/gx_upload_bridge.cpp
+    ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES} ${SLICE4B_SOURCES}
+    ${GATE4A_GEN} ${GATE4B_GEN} "${ROMDATA_C}")
+target_include_directories(smoke_anim PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_link_libraries(smoke_anim PRIVATE ntr)
+target_compile_definitions(smoke_anim PRIVATE SM64DS_PLATFORM_PC
+    PORT_REPO_ROOT="${PORT_REPO_ROOT_ABS}")
+if(MSVC)
+    target_compile_options(smoke_anim PRIVATE /wd4311 /wd4312 /wd4068)
+endif()
+
 add_executable(smoke_fs tests/smoke_fs.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
     ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES})

--- a/port/hal/model_host.cpp
+++ b/port/hal/model_host.cpp
@@ -124,6 +124,19 @@ int data_0209b3ec[12];      /* camera Matrix4x3 the render walk composes */
 // anything ever dispatches through them it faults immediately and loudly.
 void *_ZTV5Model[8];
 
+// BSS globals of the render/animation walk (0x02099xxx is past bss_start;
+// their DS values come from init code not yet in any slice):
+// - data_02099f80/f84: 3-byte weight tables for the BCA keyframe samplers.
+//   The interpolation is (lo*frac + hi*rem) over 2^shift steps and frac
+//   starts at b[shift] minus the step remainder, so b[shift] = 1 << shift.
+//   b[0] is unreachable (shift==0 early-returns).
+// - data_02099f88/f94: constants of the texture-matrix material path,
+//   zero until the GX-init that writes them joins a slice.
+unsigned char data_02099f80[4] = { 1, 2, 4, 0 };
+unsigned char data_02099f84[4] = { 1, 2, 4, 0 };
+int data_02099f88[3];
+unsigned short data_02099f94[8];
+
 } /* extern "C" */
 
 // The LoadTex TU declares its globals at C++ linkage; alias them to the

--- a/port/slice_gate4b.txt
+++ b/port/slice_gate4b.txt
@@ -44,3 +44,13 @@ src/DMASyncWordTransfer.c
 src/func_02059fd0.c
 src/func_0203cc0c.c
 src/func_0204605c.c
+
+# gate 4c additions: the animation path (UpdateBones recursion)
+src/_ZN15ModelComponents11UpdateBonesEP8BCA_Filei.cpp
+src/func_020453c0.c
+src/func_0204547c.c
+src/func_020457f0.c
+src/func_020456a0.c
+src/_ZN4cstd3absEi.c
+src/_ZN9Animation8LoadFileER13SharedFilePtr.cpp
+src/_ZN9Animation17UpdateFileOffsetsER8BCA_File.cpp

--- a/port/tests/fault_probe.h
+++ b/port/tests/fault_probe.h
@@ -1,0 +1,29 @@
+// Shared crash probe for the gate smokes: prints the module-relative fault
+// address and a frame-pointer backtrace, resolvable against the /MAP file.
+#ifndef PORT_FAULT_PROBE_H
+#define PORT_FAULT_PROBE_H
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+
+static LONG WINAPI port_fault_probe(EXCEPTION_POINTERS *ep)
+{
+    char *base = (char *)GetModuleHandleA(0);
+    fprintf(stderr, "FAULT code %08lx at +0x%08x accessing %08x\n",
+            ep->ExceptionRecord->ExceptionCode,
+            (unsigned)((char *)ep->ExceptionRecord->ExceptionAddress - base),
+            (unsigned)(ep->ExceptionRecord->NumberParameters > 1
+                       ? ep->ExceptionRecord->ExceptionInformation[1] : 0));
+    void *frames[12];
+    unsigned n = CaptureStackBackTrace(0, 12, frames, 0);
+    for (unsigned i = 0; i < n; ++i)
+        fprintf(stderr, "  frame %u: +0x%08x\n", i,
+                (unsigned)((char *)frames[i] - base));
+    fflush(stderr);
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+#define PORT_INSTALL_FAULT_PROBE() SetUnhandledExceptionFilter(port_fault_probe)
+
+#endif

--- a/port/tests/smoke_anim.cpp
+++ b/port/tests/smoke_anim.cpp
@@ -1,0 +1,142 @@
+// Gate-4c smoke: the game animates its own model on host.
+//
+// The piano (data/enemy/piano) is the model whose bone records are NOT in
+// bone-index order (boneIDs [1,2,0]) -- the case that broke the research
+// harness's linear-pass parser (port/ntr/README.md). The game's own
+// UpdateBones walks the hierarchy RECURSIVELY through the child/sibling
+// links (func_020453c0), so record order never matters. Rendering the
+// piano posed by piano_attack.bca through the game's walk is both the
+// animation gate and the definitive answer to that open bug.
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "Model.h"
+#include "Animation.h"
+
+#include "ntr/gx.h"
+#include "ntr/mmio.h"
+#include "ntr/ppu.h"
+
+extern "C" {
+void _ZN5ModelC1Ev(void *self);
+struct SharedFilePtrC { u16 fileID; u8 numRefs; void *filePtr; };
+SharedFilePtrC *_ZN13SharedFilePtr9ConstructEj(SharedFilePtrC *self, u32 ov0FileID);
+void *_ZN13SharedFilePtr8LoadFileEv(SharedFilePtrC *self);
+void *_ZN4Heap13SetupRootHeapEv(void);
+void _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(void *components, void *bca, int frame);
+void _ZN15ModelComponents21UpdateVertsUsingBonesEv(void *components);
+extern Matrix4x3 data_0209b3ec;
+}
+
+static int g_failures;
+#define CHECK(cond) \
+    do { if (!(cond)) { ++g_failures; \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); } } while (0)
+
+static void ident_fx(void *m)
+{
+    memset(m, 0, 48);
+    ((int *)m)[0] = ((int *)m)[4] = ((int *)m)[8] = 0x1000;
+}
+
+static void reset_scene()
+{
+    ntr::gx_reset();
+    NTR_MMIO(uint32_t, 0x04000440) = 0;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000440) = 1;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000580) = 0u | (0u << 8) | (255u << 16) | (191u << 24);
+    ntr::gx_set_light(0, -0.4f, -0.6f, -0.7f, 0x7FFF);
+    ntr::gx_enable_lights(0x1);
+}
+
+#include "fault_probe.h"
+
+int main(void)
+{
+    PORT_INSTALL_FAULT_PROBE();
+    if (!ntr::io_init()) { fprintf(stderr, "io_init failed\n"); return 2; }
+    CHECK(_ZN4Heap13SetupRootHeapEv() != NULL);
+    ident_fx(&data_0209b3ec);
+
+    /* piano model, handle 1034; its attack animation, handle 1036 */
+    SharedFilePtrC mp;
+    _ZN13SharedFilePtr9ConstructEj(&mp, 1034);
+    static char storage[0x50];
+    Model *model = (Model *)storage;
+    _ZN5ModelC1Ev(storage);
+    void *file = Model::LoadFile(*(SharedFilePtr *)&mp);
+    CHECK(file != NULL);
+    CHECK(model->Model::DoSetFile((char *)file, 0, -1) == 1);
+    ident_fx(&model->mat4x3);
+
+    SharedFilePtrC ap;
+    _ZN13SharedFilePtr9ConstructEj(&ap, 1036);
+    /* the game's loader: SharedFilePtr load + the BCA header rebase */
+    void *bca = Animation::LoadFile(*(SharedFilePtr *)&ap);
+    CHECK(bca != NULL);
+
+    /* the game's per-frame order: pose bones, re-skin, render */
+    _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(&model->data, bca, 0);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv(&model->data);
+
+    reset_scene();
+    model->Model::Render(NULL);
+    size_t tris = 0;
+    const ntr::GxTriangle *tarr = ntr::gx_polygons(tris);
+    printf("  piano triangles, frame 0 of piano_attack: %zu\n", tris);
+    CHECK(tris > 0);
+
+    /* fit and raster, artifact kept for eyeballing the pose */
+    float minx = 1e30f, maxx = -1e30f, miny = 1e30f, maxy = -1e30f;
+    for (size_t i = 0; i < tris; ++i)
+        for (int v = 0; v < 3; ++v) {
+            minx = fminf(minx, tarr[i].v[v].x); maxx = fmaxf(maxx, tarr[i].v[v].x);
+            miny = fminf(miny, tarr[i].v[v].y); maxy = fmaxf(maxy, tarr[i].v[v].y);
+        }
+    CHECK(std::isfinite(minx) && std::isfinite(maxy));
+    {
+        const float cx0 = 2.0f * minx / ntr::SCREEN_W - 1.0f;
+        const float cx1 = 2.0f * maxx / ntr::SCREEN_W - 1.0f;
+        const float cy0 = 1.0f - 2.0f * maxy / ntr::SCREEN_H;
+        const float cy1 = 1.0f - 2.0f * miny / ntr::SCREEN_H;
+        const float w = fmaxf(cx1 - cx0, 1e-6f), h = fmaxf(cy1 - cy0, 1e-6f);
+        const float s = fminf(1.6f / w, 1.6f / h);
+        const float tx = -0.5f * (cx0 + cx1) * s, ty = -0.5f * (cy0 + cy1) * s;
+        const int32_t m[16] = {(int32_t)(s * 4096), 0, 0, 0,
+                               0, (int32_t)(s * 4096), 0, 0,
+                               0, 0, 4096, 0,
+                               (int32_t)(tx * 4096), (int32_t)(ty * 4096), 0, 4096};
+        reset_scene();
+        NTR_MMIO(uint32_t, 0x04000440) = 0;
+        for (int i = 0; i < 16; ++i)
+            NTR_MMIO(uint32_t, 0x04000458) = (uint32_t)m[i];
+        NTR_MMIO(uint32_t, 0x04000440) = 1;
+        NTR_MMIO(uint32_t, 0x04000454) = 0;
+        model->Model::Render(NULL);
+    }
+    ntr::Framebuffer fb;
+    for (int y = 0; y < ntr::SCREEN_H; ++y)
+        for (int x = 0; x < ntr::SCREEN_W; ++x) fb.px[y][x] = 0xFF101820u;
+    ntr::gx_render(fb);
+    int drawn = 0;
+    for (int y = 0; y < ntr::SCREEN_H; ++y)
+        for (int x = 0; x < ntr::SCREEN_W; ++x)
+            if (fb.px[y][x] != 0xFF101820u) ++drawn;
+    printf("  pixels covered: %d (%.1f%%)\n", drawn,
+           100.0 * drawn / (ntr::SCREEN_W * ntr::SCREEN_H));
+    CHECK(drawn > 500);
+    ntr::ppu_write_bmp("smoke_anim.bmp", fb);
+
+    if (g_failures) {
+        fprintf(stderr, "smoke_anim: %d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("smoke_anim: all checks passed (the game posed and rendered the "
+           "piano via its own recursive bone walk: %zu tris, %d px)\n",
+           tris, drawn);
+    return 0;
+}

--- a/port/tools/romdata.py
+++ b/port/tools/romdata.py
@@ -11,23 +11,29 @@ import pathlib
 import struct
 import sys
 
-BASE = 0x02000000
+# The dsd-extracted main module: base 0x02004000, contiguous .text+.data
+# through bss_start (0x02094640). NOT extracted/arm9_dec.bin -- that image
+# disagrees with the section map and served instruction bytes as "data".
+BASE = 0x02004000
+BSS_START = 0x02094640
 
-# (symbol address, byte length, C element type)
+# (symbol address, byte length, C element type). BSS addresses do not belong
+# here -- they are runtime-initialized and live in the HAL as storage.
 TABLES = [
     (0x02082128, 48, "int"),        # Model ctor default Matrix4x3
-    (0x02082190, 48, "int"),        # identity Matrix4x3 (Render's NULL case)
-    (0x02082214, 0x4000, "short"),  # fx16 sin/cos table, 12-bit angle, pairs
-    (0x02099F88, 12, "int"),        # Vec3 constant in the bone walk
-    (0x02099F94, 16, "short"),      # u16[8] texture-matrix constants
+    (0x02082190, 48, "int"),        # matrix Render uses for a NULL argument
+    (0x02082214, 0x4000, "short"),  # s16 trig table the material bind indexes
 ]
 
 
 def main():
     root = pathlib.Path(__file__).resolve().parents[2]
-    img = root / "extracted/arm9_dec.bin"
+    img = root / "extracted/dsd/arm9/arm9.bin"
     if not img.exists():
         sys.exit(f"missing {img} -- extract the ROM first")
+    for addr, length, _ in TABLES:
+        if addr + length > BSS_START:
+            sys.exit(f"{addr:#x}+{length:#x} crosses into BSS -- not file-backed")
     data = img.read_bytes()
     out_path = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else (
         root / "build/port/host-src/romdata.c")


### PR DESCRIPTION
BCA rebase + the recursive UpdateBones walk run verbatim; the Mad Piano (the bone-order counterexample that broke the harness parser) poses correctly at frame 0 of its attack. romdata switched to the section-mapped dsd image after the flat arm9_dec read was caught serving code bytes as data. All seven gate binaries pass. Port-only change.