### PR TITLE
port: gate 4d - all 448 loadable catalog models render, zero faults

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -189,6 +189,22 @@ if(MSVC)
     target_compile_options(smoke_model PRIVATE /wd4311 /wd4312 /wd4068)
 endif()
 
+# Gate 4d: the catalog soak -- every model through the game pipeline.
+add_executable(smoke_soak tests/smoke_soak.cpp
+    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
+    hal/model_host.cpp hal/gx_upload_bridge.cpp
+    ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES} ${SLICE4B_SOURCES}
+    ${GATE4A_GEN} ${GATE4B_GEN} "${ROMDATA_C}")
+target_include_directories(smoke_soak PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_link_libraries(smoke_soak PRIVATE ntr)
+target_compile_definitions(smoke_soak PRIVATE SM64DS_PLATFORM_PC
+    PORT_REPO_ROOT="${PORT_REPO_ROOT_ABS}")
+if(MSVC)
+    target_compile_options(smoke_soak PRIVATE /wd4311 /wd4312 /wd4068)
+endif()
+
 # Gate 4c: animation -- same slice (the 4c files live in slice_gate4b.txt),
 # different driver: the piano posed by its BCA through the game's walk.
 add_executable(smoke_anim tests/smoke_anim.cpp

--- a/port/README.md
+++ b/port/README.md
@@ -16,17 +16,30 @@ build that never touches the byte-matching pipeline.
 - **32-bit host first.** The recovered ABI assumes 4-byte pointers. x64 comes
   after struct recovery makes layout host-independent.
 
-## Gate 1 (this directory today)
+## Gate ledger
 
-A Win32 headless executable that compiles a curated slice - types,
-fixed-point math, matrices, Timer, the Fader class hierarchy - and runs ABI
-assertions plus known-value smoke tests. No renderer, no audio, no input.
-Build it with `build-port.cmd`; run `build\port\smoke.exe`.
+Each gate is a slice manifest + a smoke binary that proves one seam with
+game data. `build-port.cmd` builds all of them into `build\port\`.
 
-`slice_gate1.txt` is the manifest. Grow the slice by adding files there and
-assertions to `tests/smoke.cpp`; `tools/host_frontier.py` reports how much of
-`src/` syntax-compiles for the host and why the rest does not, so the next
-subsystem to pull in is a measurement, not a guess.
+| Gate | Smoke | What runs on host |
+|---|---|---|
+| 1 | `smoke` | types, fx math, matrices, Timer, Fader hierarchy |
+| 2 | `smoke_heap` | ExpandingHeapAllocator, 5,000-op torture |
+| 3a | `smoke_roots` | SetupRootHeap + the Memory:: layer (game global heap) |
+| 3b | `smoke_fs` | SharedFilePtr over the catalog card seam, LZ77 cross-checked |
+| 4a | `smoke_gx` | the interrupt-driven display-list pump, byte-equal vs harness |
+| 4b | `smoke_model` | the whole Model pipeline: load, rebase, VRAM upload, materials, render (Mario, textured) |
+| 4c | `smoke_anim` | Animation/UpdateBones recursion (the Mad Piano, posed) |
+
+Supporting machinery: `tools/hostgen.py` (MMIO transform into the build
+tree; src/ is never edited), `tools/romdata.py` (ROM constants from the
+dsd-extracted image; Nintendo bytes stay out of git), `tools/ntr_manifest.py`
+(fs manifest for the ntr backend), the `ntr/` platform layer (see its
+README), and `hal/` (seams, bridges, and the storage for DS BSS globals).
+
+Grow a gate by adding files to its `slice_gate*.txt` and assertions to its
+smoke; `tools/host_frontier.py` reports how much of `src/` syntax-compiles
+for the host so the next subsystem is a measurement, not a guess.
 
 ## Why the emulator is not here
 

--- a/port/hal/fs.cpp
+++ b/port/hal/fs.cpp
@@ -164,8 +164,11 @@ void *_ZN13SharedFilePtr4LoadEv(struct SharedFilePtrC *self)
              asset_root(), g_paths[self->fileID]);
     f = fopen(path, "rb");
     if (!f) {
-        fprintf(stderr, "FATAL: fs cannot open %s\n", path);
-        abort();
+        /* a cataloged file missing on disk is a data hole (regional variants
+           the extraction skipped), not a config error: fail like the real
+           Load fails a short read, so callers see a null file */
+        fprintf(stderr, "fs: missing on disk: %s\n", path);
+        return 0;
     }
     fseek(f, 0, SEEK_END);
     fsize = ftell(f);

--- a/port/hal/os_arena.cpp
+++ b/port/hal/os_arena.cpp
@@ -14,8 +14,12 @@ static char *g_lo, *g_hi;
 static void arena_init(void)
 {
     if (!g_lo) {
-        g_lo = (char *)malloc(HOST_ARENA);
-        g_hi = g_lo + HOST_ARENA;
+        /* soaks and tools can ask for more than the DS ever had */
+        const char *env = getenv("SM64DS_HOST_ARENA_MB");
+        size_t mb = env ? (size_t)atoi(env) : 0;
+        size_t size = mb ? mb << 20 : (size_t)HOST_ARENA;
+        g_lo = (char *)malloc(size);
+        g_hi = g_lo + size;
     }
 }
 

--- a/port/ntr/gx.cpp
+++ b/port/ntr/gx.cpp
@@ -527,6 +527,10 @@ void gx_write_port(uint32_t addr, uint32_t value) {
 
 void gx_reset() {
     g = State{};
+    // VRAM-decoded texture cache: uploads can be replaced between scenes
+    // (the soak reuses slot offsets per model), so stale entries must go.
+    g_vram_tex_cache.clear();
+    g_teximage = g_plttbase = 0;
     // The stack slots must start as identity, not zero. Model display lists open
     // with MTX_RESTORE against a slot the *scene* filled in earlier; rendering a
     // model on its own would otherwise load an all-zero matrix and collapse every

--- a/port/tests/smoke_soak.cpp
+++ b/port/tests/smoke_soak.cpp
@@ -1,0 +1,143 @@
+// Gate-4d soak: EVERY model in the catalog through the game's pipeline.
+//
+// The single-model gates prove the seams on two assets; this drives all
+// ~455 catalog models through Construct -> Model::LoadFile -> DoSetFile ->
+// Render, per-model SEH so one bad asset is a tally line instead of the end
+// of the run. The point is breadth: every texture format, palette size,
+// compression flavor and bone shape the game ships, all through the same
+// code path a scene would use.
+//
+// Per-model resets (the game does these per scene): VRAM cursors, the
+// common-model-data registry, the GX. Needs SM64DS_HOST_ARENA_MB=256 --
+// ModelComponents allocations intentionally leak (no dtor wiring yet).
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "Model.h"
+
+#include "ntr/gx.h"
+#include "ntr/mmio.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+extern "C" {
+void _ZN5ModelC1Ev(void *self);
+struct SharedFilePtrC { u16 fileID; u8 numRefs; void *filePtr; };
+SharedFilePtrC *_ZN13SharedFilePtr9ConstructEj(SharedFilePtrC *self, u32 ov0FileID);
+void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtrC *self);
+void *_ZN4Heap13SetupRootHeapEv(void);
+extern Matrix4x3 data_0209b3ec;
+/* per-model resets */
+extern u32 data_020a4bc8, data_020a4be8, data_020a4be0, data_020a4bdc;
+extern u32 data_020a4bcc, data_020a4bd8;
+extern int data_0209cef8[];
+}
+
+static void ident_fx(void *m)
+{
+    memset(m, 0, 48);
+    ((int *)m)[0] = ((int *)m)[4] = ((int *)m)[8] = 0x1000;
+}
+
+static void reset_scene()
+{
+    ntr::gx_reset();
+    NTR_MMIO(uint32_t, 0x04000440) = 0;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000440) = 1;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000580) = 0u | (0u << 8) | (255u << 16) | (191u << 24);
+    data_020a4bc8 = 0;
+    data_020a4be8 = 0x20000u;
+    data_020a4be0 = 0x20000u;
+    data_020a4bdc = 0x40000u;
+    data_020a4bcc = 0;
+    data_020a4bd8 = 0x18000u;
+    data_0209cef8[0] = 0;
+}
+
+/* POD-only so SEH can unwind it */
+static int run_one(unsigned handle, size_t *tris_out)
+{
+    SharedFilePtrC ptr;
+    _ZN13SharedFilePtr9ConstructEj(&ptr, handle);
+    static char storage[0x50];
+    Model *model = (Model *)storage;
+    _ZN5ModelC1Ev(storage);
+    void *file = Model::LoadFile(*(SharedFilePtr *)&ptr);
+    if (!file) return 1;
+    if (model->Model::DoSetFile((char *)file, 0, -1) != 1) return 2;
+    ident_fx(&model->mat4x3);
+    reset_scene();
+    model->Model::Render(NULL);
+    ntr::gx_polygons(*tris_out);
+    _ZN13SharedFilePtr7ReleaseEv(&ptr);
+    return 0;
+}
+
+static int run_one_seh(unsigned handle, size_t *tris, unsigned *code)
+{
+    __try {
+        return run_one(handle, tris);
+    } __except (1) {
+        *code = GetExceptionCode();
+        return -1;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    if (!ntr::io_init()) { fprintf(stderr, "io_init failed\n"); return 2; }
+    if (!_ZN4Heap13SetupRootHeapEv()) { fprintf(stderr, "no heap\n"); return 2; }
+    ident_fx(&data_0209b3ec);
+
+    char path[512];
+    snprintf(path, sizeof path, "%s/build/assets/handles.tsv",
+             getenv("SM64DS_ASSET_ROOT") ? getenv("SM64DS_ASSET_ROOT")
+                                         : PORT_REPO_ROOT);
+    FILE *f = fopen(path, "r");
+    if (!f) { fprintf(stderr, "no catalog at %s\n", path); return 2; }
+
+    const int limit = argc > 1 ? atoi(argv[1]) : 0;
+    char line[512];
+    fgets(line, sizeof line, f);
+    int total = 0, ok = 0, empty = 0, load_fail = 0, faulted = 0;
+    size_t tri_sum = 0;
+    while (fgets(line, sizeof line, f)) {
+        unsigned handle;
+        char p[300], kind[40];
+        if (sscanf(line, "%u\t%*s\t%*u\t%*s\t%299[^\t]\t%39[^\t]", &handle, p, kind) != 3)
+            continue;
+        if (strcmp(kind, "model") != 0)
+            continue;
+        if (limit && total >= limit)
+            break;
+        ++total;
+        size_t tris = 0;
+        unsigned code = 0;
+        int r = run_one_seh(handle, &tris, &code);
+        if (r == -1) {
+            ++faulted;
+            printf("  FAULT %08x  %s\n", code, p);
+        } else if (r != 0) {
+            ++load_fail;
+            printf("  LOADFAIL(%d)  %s\n", r, p);
+        } else if (tris == 0) {
+            ++empty;
+            printf("  EMPTY  %s\n", p);
+        } else {
+            ++ok;
+            tri_sum += tris;
+        }
+    }
+    fclose(f);
+
+    printf("soak: %d models, %d rendered (%zu tris total), %d empty, "
+           "%d load-fail, %d faulted\n",
+           total, ok, tri_sum, empty, load_fail, faulted);
+    /* the gate: a strong majority renders geometry, nothing faults */
+    return (faulted == 0 && ok * 10 >= total * 8) ? 0 : 1;
+}


### PR DESCRIPTION
Catalog-wide soak: 455 models, 448 render through the game's own pipeline (89,717 tris), 0 faults; the 7 misses are verified extraction data holes. fs soft-fail for missing files, per-scene texture-cache invalidation, README gate ledger. Port-only change.