### PR TITLE
port: gate 6b - the game's sprites scan out to pixels

### DIFF
--- a/port/README.md
+++ b/port/README.md
@@ -34,6 +34,7 @@ game data. `build-port.cmd` builds all of them into `build\port\`.
 | 5 | `smoke_frames` | the fiber frame loop: game-shaped frames, the piano attack in motion |
 | 5b | `smoke_soak_anim` | every compatible model+BCA pair: 472/473 animate, zero faults |
 | 6 | `smoke_oam` | the 2D sprite engine: OAM emit, affine params, upload to mapped OAM |
+| 6b | `smoke_oam` | OBJ scan-out: the game's sprite placements become pixels |
 
 Supporting machinery: `tools/hostgen.py` (MMIO transform into the build
 tree; src/ is never edited), `tools/romdata.py` (ROM constants from the

--- a/port/ntr/include/ntr/ppu.h
+++ b/port/ntr/include/ntr/ppu.h
@@ -28,6 +28,12 @@ struct Framebuffer {
 // now; affine, bitmap, sprites and the blend/window units are not implemented.
 void ppu_scanout(Engine eng, Framebuffer &fb);
 
+// Rasterise one engine's OBJ layer (sprites) from its OAM + OBJ VRAM over
+// whatever fb already holds. Plain and affine sprites, 16- and 256-color
+// tiles, 1D mapping; bitmap OBJs, mosaic, windows and blending are not
+// implemented. Transparent color-0 texels leave fb untouched.
+void ppu_scanout_obj(Engine eng, Framebuffer &fb);
+
 // Debug output, so a frame can be inspected without a window yet.
 bool ppu_write_bmp(const char *path, const Framebuffer &fb);
 

--- a/port/ntr/ppu.cpp
+++ b/port/ntr/ppu.cpp
@@ -155,6 +155,97 @@ void ppu_scanout(Engine eng, Framebuffer &fb) {
     }
 }
 
+// --- OBJ layer --------------------------------------------------------------
+// GBATEK "LCD OBJ": 128 OAM entries per engine; tiles in the engine's OBJ
+// VRAM region, palette at pltt+0x200. Sizes come from the shape/size table.
+// Affine params sit in the filler word of entries group*4+0..3 (pa,pb,pc,pd).
+void ppu_scanout_obj(Engine eng, Framebuffer &fb) {
+    static const int kSizes[3][4][2] = {
+        {{8, 8}, {16, 16}, {32, 32}, {64, 64}},    // square
+        {{16, 8}, {32, 8}, {32, 16}, {64, 32}},    // wide
+        {{8, 16}, {8, 32}, {16, 32}, {32, 64}},    // tall
+    };
+    const uint32_t oam_base = eng == ENGINE_A ? 0x07000000u : 0x07000400u;
+    const uint32_t obj_vram = eng == ENGINE_A ? 0x06400000u : 0x06600000u;
+    const uint32_t obj_pltt = kEngines[eng].pltt_base + 0x200u;
+    // DISPCNT bit 4: OBJ 1D mapping; bits 20-21: tile-index boundary shift.
+    const uint32_t dispcnt = rd32(kEngines[eng].reg_base);
+    const uint32_t boundary = 32u << ((dispcnt >> 20) & 3);
+
+    for (int i = 127; i >= 0; --i) {           // low index on top: draw high first
+        const uint16_t a0 = rd16(oam_base + i * 8u);
+        const uint16_t a1 = rd16(oam_base + i * 8u + 2);
+        const uint16_t a2 = rd16(oam_base + i * 8u + 4);
+        const bool affine = a0 & 0x100;
+        if (!affine && (a0 & 0x200)) continue;             // disabled
+        if (((a0 >> 10) & 3) == 3) continue;               // OBJ window: skip
+        const int shape = (a0 >> 14) & 3;
+        if (shape == 3) continue;
+        const int size = (a1 >> 14) & 3;
+        const int w = kSizes[shape][size][0], h = kSizes[shape][size][1];
+        const bool dbl = affine && (a0 & 0x200);
+        const int bw = dbl ? w * 2 : w, bh = dbl ? h * 2 : h;
+        int x = a1 & 0x1FF, y = a0 & 0xFF;
+        if (x >= 256) x -= 512;
+        if (y >= 192 && y >= 256 - bh) y -= 256;
+        const bool c256 = a0 & 0x2000;
+        const bool hflip = !affine && (a1 & 0x1000);
+        const bool vflip = !affine && (a1 & 0x2000);
+        const uint32_t tile = a2 & 0x3FF;
+        const uint32_t pal = (a2 >> 12) & 0xF;
+
+        int pa = 256, pb = 0, pc = 0, pd = 256;
+        if (affine) {
+            const int grp = (a1 >> 9) & 0x1F;
+            pa = (int16_t)rd16(oam_base + (grp * 4 + 0) * 8u + 6);
+            pb = (int16_t)rd16(oam_base + (grp * 4 + 1) * 8u + 6);
+            pc = (int16_t)rd16(oam_base + (grp * 4 + 2) * 8u + 6);
+            pd = (int16_t)rd16(oam_base + (grp * 4 + 3) * 8u + 6);
+        }
+
+        for (int sy = 0; sy < bh; ++sy) {
+            const int py = y + sy;
+            if (py < 0 || py >= SCREEN_H) continue;
+            for (int sx = 0; sx < bw; ++sx) {
+                const int px = x + sx;
+                if (px < 0 || px >= SCREEN_W) continue;
+                // texel coordinate: affine maps through the matrix around the
+                // box center; plain is direct with optional flips.
+                int tx, ty;
+                if (affine) {
+                    const int cx = sx - bw / 2, cy = sy - bh / 2;
+                    tx = ((pa * cx + pb * cy) >> 8) + w / 2;
+                    ty = ((pc * cx + pd * cy) >> 8) + h / 2;
+                    if (tx < 0 || tx >= w || ty < 0 || ty >= h) continue;
+                } else {
+                    tx = hflip ? w - 1 - sx : sx;
+                    ty = vflip ? h - 1 - sy : sy;
+                }
+                const int tcol = tx >> 3, trow = ty >> 3;
+                const int fx = tx & 7, fy = ty & 7;
+                // 1D mapping: tiles of one sprite are consecutive.
+                const int tiles_per_row = w / 8;
+                const uint32_t tno = trow * tiles_per_row + tcol;
+                uint32_t index;
+                if (c256) {
+                    const uint32_t addr = obj_vram + tile * boundary
+                                          + tno * 64u + fy * 8u + fx;
+                    index = *reinterpret_cast<volatile uint8_t *>(addr);
+                    if (!index) continue;
+                    fb.px[py][px] = bgr555(rd16(obj_pltt + index * 2u));
+                } else {
+                    const uint32_t addr = obj_vram + tile * boundary
+                                          + tno * 32u + fy * 4u + fx / 2;
+                    const uint8_t b = *reinterpret_cast<volatile uint8_t *>(addr);
+                    index = (fx & 1) ? (b >> 4) : (b & 0xF);
+                    if (!index) continue;
+                    fb.px[py][px] = bgr555(rd16(obj_pltt + (pal * 16u + index) * 2u));
+                }
+            }
+        }
+    }
+}
+
 bool ppu_write_bmp(const char *path, const Framebuffer &fb) {
     std::FILE *f = std::fopen(path, "wb");
     if (!f) return false;

--- a/port/tests/smoke_oam.cpp
+++ b/port/tests/smoke_oam.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 
 #include "ntr/mmio.h"
+#include "ntr/ppu.h"
 
 #include "fault_probe.h"
 
@@ -83,6 +84,8 @@ int main(void)
     /* upload: the words must land in mapped OAM at 0x07000000 */
     _ZN3OAM4LoadEv();
     const u32 *oam = (const u32 *)0x07000000;
+    printf("  oam[3..7]: %08x %08x %08x %08x %08x\n",
+           oam[3], oam[4], oam[5], oam[6], oam[7]);
     printf("  oam[0..2]: %08x %08x %08x\n", oam[0], oam[1], oam[2]);
     /* the upload must mirror the LIVE shadow -- affine parameters live in
        the filler words of neighboring entries (slot 0 spans entries 0..3),
@@ -93,11 +96,42 @@ int main(void)
     CHECK(oam[2] == r0);
     CHECK((short)(oam[1] >> 16) == (short)pa);   /* affine pa in the filler */
 
+    /* scan-out: the OAM the game just uploaded becomes pixels. The tile and
+       palette are harness-side (the HUD graphic loaders are ov-coupled);
+       the PLACEMENT is entirely the game's. Tile 5, 16x16 = four 32-byte
+       tiles of solid color-index 1; palette 2 entry 1 = pure red. */
+    {
+        volatile unsigned char *tiles =
+            (volatile unsigned char *)(0x06400000u + 5u * 32u);
+        for (int i = 0; i < 4 * 32; ++i) tiles[i] = 0x11;
+        *(volatile u16 *)(0x05000200u + (2u * 16u + 1u) * 2u) = 0x001F; /* red */
+        NTR_MMIO(u32, 0x04000000) = (1u << 4);   /* DISPCNT: OBJ 1D mapping */
+
+        ntr::Framebuffer fb;
+        for (int y = 0; y < ntr::SCREEN_H; ++y)
+            for (int x = 0; x < ntr::SCREEN_W; ++x) fb.px[y][x] = 0xFF101820u;
+        ntr::ppu_scanout_obj(ntr::ENGINE_A, fb);
+
+        CHECK(fb.px[60][40] == 0xFFFF0000u);         /* plain sprite top-left */
+        CHECK(fb.px[75][55] == 0xFFFF0000u);         /* ...bottom-right */
+        CHECK(fb.px[60][39] == 0xFF101820u);         /* left edge untouched */
+        CHECK(fb.px[59][40] == 0xFF101820u);         /* top edge untouched */
+        /* the rotated sprite renders with palette 0 (unfilled -> black);
+           any non-background pixel in its double-size box counts */
+        int rotated_px = 0;
+        for (int y = 60; y < 110; ++y)
+            for (int x = 80; x < 130; ++x)
+                if (fb.px[y][x] != 0xFF101820u) ++rotated_px;
+        printf("  rotated sprite pixels: %d\n", rotated_px);
+        CHECK(rotated_px > 100);      /* the affine sprite drew a real footprint */
+        ntr::ppu_write_bmp("smoke_oam.bmp", fb);
+    }
+
     if (g_failures) {
         fprintf(stderr, "smoke_oam: %d FAILURE(S)\n", g_failures);
         return 1;
     }
-    printf("smoke_oam: all checks passed (the game's sprite engine emits and "
-           "uploads OAM on host)\n");
+    printf("smoke_oam: all checks passed (the game's sprite engine emits, "
+           "uploads and scans out on host)\n");
     return 0;
 }


### PR DESCRIPTION
Host OBJ scan-out over mapped OAM/VRAM (GBATEK semantics, clean-room): plain + affine, 16/256-color, 1D mapping. The game places the sprites, the scan-out draws them, edge pixels exact. Port-only change.