### PR TITLE
port: gate 7 - the game owns frame progression

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -222,6 +222,32 @@ if(MSVC)
     target_compile_options(smoke_soak PRIVATE /wd4311 /wd4312 /wd4068)
 endif()
 
+# Gate 7: ModelAnim -- the game owns frame progression.
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate7.txt" SLICE7_LINES)
+set(SLICE7_SOURCES "")
+foreach(line IN LISTS SLICE7_LINES)
+    string(STRIP "${line}" line)
+    if(line MATCHES "^#" OR line STREQUAL "")
+        continue()
+    endif()
+    list(APPEND SLICE7_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
+endforeach()
+
+add_executable(smoke_modelanim tests/smoke_modelanim.cpp
+    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
+    hal/model_host.cpp hal/gx_upload_bridge.cpp hal/anim_bridge.cpp
+    ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES} ${SLICE4B_SOURCES}
+    ${SLICE7_SOURCES} ${GATE4A_GEN} ${GATE4B_GEN} "${ROMDATA_C}")
+target_include_directories(smoke_modelanim PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_link_libraries(smoke_modelanim PRIVATE ntr)
+target_compile_definitions(smoke_modelanim PRIVATE SM64DS_PLATFORM_PC
+    PORT_REPO_ROOT="${PORT_REPO_ROOT_ABS}")
+if(MSVC)
+    target_compile_options(smoke_modelanim PRIVATE /wd4311 /wd4312 /wd4068)
+endif()
+
 # Gate 6: the 2D sprite engine's software side. OAM::Load reads POWCNT
 # textually -> hostgen; the rest of the slice is plain.
 set(GATE6_SYMS _ZN3OAM4LoadEv)

--- a/port/README.md
+++ b/port/README.md
@@ -35,6 +35,7 @@ game data. `build-port.cmd` builds all of them into `build\port\`.
 | 5b | `smoke_soak_anim` | every compatible model+BCA pair: 472/473 animate, zero faults |
 | 6 | `smoke_oam` | the 2D sprite engine: OAM emit, affine params, upload to mapped OAM |
 | 6b | `smoke_oam` | OBJ scan-out: the game's sprite placements become pixels |
+| 7 | `smoke_modelanim` | ModelAnim: the game owns frame progression (speed, loop wrap) |
 
 Supporting machinery: `tools/hostgen.py` (MMIO transform into the build
 tree; src/ is never edited), `tools/romdata.py` (ROM constants from the

--- a/port/hal/anim_bridge.cpp
+++ b/port/hal/anim_bridge.cpp
@@ -1,0 +1,10 @@
+// Gate-7-only bridge: the C reference to Animation::SetFlags forwards to
+// the MSVC method definition. Lives apart from gx_upload_bridge because
+// only targets that carry the gate-7 slice have the method to forward to.
+struct Animation {
+    void SetFlags(int flags);
+};
+extern "C" void _ZN9Animation8SetFlagsEi(void *self, int flags)
+{
+    ((Animation *)self)->SetFlags(flags);
+}

--- a/port/hal/gx_upload_bridge.cpp
+++ b/port/hal/gx_upload_bridge.cpp
@@ -44,13 +44,21 @@ void SharedFilePtr::LoadFile() { _ZN13SharedFilePtr8LoadFileEv(this); }
 // optimization). Skipped on host: the image simply stays at load size.
 void SharedFilePtr::ReallocateModelFile() {}
 
+struct BCA_File;
 struct ModelComponents {
     void UpdateVertsUsingBones();
+    void UpdateBones(BCA_File *file, int frame);
 };
 void ModelComponents::UpdateVertsUsingBones()
 {
     _ZN15ModelComponents21UpdateVertsUsingBonesEv(this);
 }
+extern "C" void _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(void *, void *, int);
+void ModelComponents::UpdateBones(BCA_File *file, int frame)
+{
+    _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(this, file, frame);
+}
+
 
 // The compressed-texture loader keeps its C-named terminal-floor definition.
 // That draft is typed void (the ARM contract returned the block offset in a

--- a/port/hal/model_host.cpp
+++ b/port/hal/model_host.cpp
@@ -142,6 +142,11 @@ int data_0209b3ec[12];      /* camera Matrix4x3 the render walk composes */
 // every method non-virtually (qualified), so plain zero slots are fine; if
 // anything ever dispatches through them it faults immediately and loudly.
 void *_ZTV5Model[8];
+// Same story for the animated-model hierarchy: primary vtables plus the
+// multiple-inheritance thunk table the ModelAnim ctor installs at +0x50.
+void *_ZTV9Animation[8];
+void *_ZTV9ModelAnim[10];
+void *VTable_Animation_ModelAnimThunk[8];
 
 // BSS globals of the render/animation walk (0x02099xxx is past bss_start;
 // their DS values come from init code not yet in any slice):

--- a/port/slice_gate7.txt
+++ b/port/slice_gate7.txt
@@ -1,0 +1,18 @@
+# Gate-7 slice: ModelAnim -- the game's own animated-model class, where
+# Animation::Advance owns frame progression (speed, loop/clamp mode bits)
+# instead of a harness counter. Sits on the gate-4/5 stack.
+
+src/_ZN9ModelAnimC1Ev.c
+src/_ZN9ModelAnimC2Ev.c
+src/_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj.c
+src/_ZN9ModelAnim11UpdateVertsEv.cpp
+src/_ZN9ModelAnim6RenderEPK7Vector3.cpp
+src/_ZN9ModelAnim9Virtual10ER9Matrix4x3.cpp
+src/_ZN9AnimationC1Ev.cpp
+src/_ZN9AnimationC2Ev.cpp
+src/_ZN9Animation12SetAnimationEti5Fix12IiEt.cpp
+src/_ZN9Animation8SetFlagsEi.cpp
+src/_ZN9Animation7AdvanceEv.cpp
+src/_ZN9Animation8FinishedEv.cpp
+src/_ZN9Animation8GetFlagsEv.cpp
+src/_ZN5Model9Virtual10ER9Matrix4x3.cpp

--- a/port/tests/smoke_modelanim.cpp
+++ b/port/tests/smoke_modelanim.cpp
@@ -1,0 +1,149 @@
+// Gate-7 smoke: the game owns frame progression.
+//
+// Gates 4c/5 posed the piano by handing UpdateBones a loop counter; here
+// ModelAnim runs the show: SetAnim installs the animation with the game's
+// flag/speed packing, Animation::Advance steps currFrame each fiber frame
+// (fx12 speed, loop-mode modulo), and ModelAnim::UpdateVerts converts the
+// fx frame to the sampler index exactly as every actor does. The wrap
+// check is the point: after numFrames advances at speed 1.0 the game's
+// modulo lands back on frame 0, and the pose there must hash equal to the
+// first frame's pose -- loop closure through the game's own arithmetic.
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "Model.h"
+#include "Animation.h"
+#include "ModelAnim.h"
+
+#include "ntr/gx.h"
+#include "ntr/mmio.h"
+#include "ntr/rt.h"
+
+#include "fault_probe.h"
+
+extern "C" {
+void *_ZN9ModelAnimC1Ev(void *self);
+struct SharedFilePtrC { u16 fileID; u8 numRefs; void *filePtr; };
+SharedFilePtrC *_ZN13SharedFilePtr9ConstructEj(SharedFilePtrC *self, u32 ov0FileID);
+void *_ZN4Heap13SetupRootHeapEv(void);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca,
+                                                 int flags, int speed, u16 start);
+extern Matrix4x3 data_0209b3ec;
+}
+
+enum { NUM_FRAMES = 15 };   /* piano_attack.bca */
+
+static int g_failures;
+#define CHECK(cond) \
+    do { if (!(cond)) { ++g_failures; \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); } } while (0)
+
+static ModelAnim *g_ma;
+static unsigned g_hash[NUM_FRAMES + 1];
+static int g_frames_run;
+
+static void ident_fx(void *m)
+{
+    memset(m, 0, 48);
+    ((int *)m)[0] = ((int *)m)[4] = ((int *)m)[8] = 0x1000;
+}
+
+static void reset_scene()
+{
+    ntr::gx_reset();
+    NTR_MMIO(uint32_t, 0x04000440) = 0;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000440) = 1;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000580) = 0u | (0u << 8) | (255u << 16) | (191u << 24);
+    ntr::gx_set_light(0, -0.4f, -0.6f, -0.7f, 0x7FFF);
+    ntr::gx_enable_lights(0x1);
+}
+
+static unsigned tri_hash()
+{
+    size_t n = 0;
+    const ntr::GxTriangle *t = ntr::gx_polygons(n);
+    unsigned h = 2166136261u;
+    const unsigned char *b = (const unsigned char *)t;
+    for (size_t i = 0; i < n * sizeof(ntr::GxTriangle); ++i)
+        h = (h ^ b[i]) * 16777619u;
+    return n ? h : 0;
+}
+
+// The game-shaped loop: the actor pattern verbatim -- advance the
+// animation, re-skin, render, block at VBlank.
+static void game_main()
+{
+    for (int i = 0; i <= NUM_FRAMES; ++i) {
+        g_ma->ModelAnim::UpdateVerts();
+        reset_scene();
+        g_ma->Model::Render(NULL);
+        g_hash[i] = tri_hash();
+        ++g_frames_run;
+        g_ma->Animation::Advance();
+        ntr::rt_vblank_wait();
+    }
+}
+
+static bool frame_hook(uint64_t) { return true; }
+
+int main(void)
+{
+    PORT_INSTALL_FAULT_PROBE();
+    if (!ntr::io_init()) { fprintf(stderr, "io_init failed\n"); return 2; }
+    CHECK(_ZN4Heap13SetupRootHeapEv() != NULL);
+    ident_fx(&data_0209b3ec);
+
+    SharedFilePtrC mp;
+    _ZN13SharedFilePtr9ConstructEj(&mp, 1034);          /* piano.bmd */
+    static char storage[0x70];
+    g_ma = (ModelAnim *)storage;
+    _ZN9ModelAnimC1Ev(storage);
+    void *file = Model::LoadFile(*(SharedFilePtr *)&mp);
+    CHECK(file != NULL);
+    CHECK(g_ma->Model::DoSetFile((char *)file, 0, -1) == 1);
+    ident_fx(&g_ma->mat4x3);
+
+    SharedFilePtrC ap;
+    _ZN13SharedFilePtr9ConstructEj(&ap, 1036);          /* piano_attack.bca */
+    void *bca = Animation::LoadFile(*(SharedFilePtr *)&ap);
+    CHECK(bca != NULL);
+
+    /* the game's install: loop mode (flags 0), speed 1.0 (fx12), frame 0 */
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(g_ma, bca, 0, 0x1000, 0);
+    CHECK(g_ma->currFrame == 0);
+    CHECK((g_ma->numFramesAndFlags & ~0xc0000000) == (NUM_FRAMES << 12));
+
+    const uint64_t frames = ntr::rt_run(game_main, frame_hook, NUM_FRAMES + 2);
+    printf("  fiber frames: %llu, poses rendered: %d\n",
+           (unsigned long long)frames, g_frames_run);
+    CHECK(g_frames_run == NUM_FRAMES + 1);
+
+    /* poses vary across the cycle... */
+    int distinct = 1;
+    for (int i = 1; i < NUM_FRAMES; ++i)
+        if (g_hash[i] != g_hash[0]) { distinct = 1; break; }
+    int varying = 0;
+    for (int i = 1; i < NUM_FRAMES; ++i)
+        if (g_hash[i] != g_hash[i - 1]) ++varying;
+    printf("  varying transitions: %d/%d\n", varying, NUM_FRAMES - 1);
+    CHECK(varying > NUM_FRAMES / 2);
+    (void)distinct;
+
+    /* ...and the game's modulo closes the loop: pose[15] == pose[0] */
+    printf("  wrap: pose[0] %08x, pose[%d] %08x\n", g_hash[0], NUM_FRAMES,
+           g_hash[NUM_FRAMES]);
+    CHECK(g_hash[NUM_FRAMES] == g_hash[0]);
+    CHECK(g_ma->currFrame == 0x1000);   /* advanced once past the wrap */
+
+    if (g_failures) {
+        fprintf(stderr, "smoke_modelanim: %d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("smoke_modelanim: all checks passed (the game advanced, wrapped "
+           "and re-posed its own animation)\n");
+    return 0;
+}


### PR DESCRIPTION
ModelAnim/Animation run verbatim: the game's fx12 frame stepping, speed, and loop modulo drive the piano attack through a full wrap, with pose[wrap] hash-equal to pose[0]. Ten gate binaries pass. Port-only change.