### PR TITLE
port: gate 8 - the game's collision answers ground queries on host

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -222,6 +222,51 @@ if(MSVC)
     target_compile_options(smoke_soak PRIVATE /wd4311 /wd4312 /wd4068)
 endif()
 
+# Gate 8: collision -- the octree walk over real KCL data. cstd::sqrt
+# drives the hardware sqrt unit through literal MMIO -> hostgen.
+set(GATE8_SYMS _ZN4cstd4sqrtEy)
+set(GATE8_GEN "")
+foreach(sym IN LISTS GATE8_SYMS)
+    if(EXISTS "${PORT_REPO_ROOT_ABS}/src/${sym}.c")
+        set(sym_src "${PORT_REPO_ROOT_ABS}/src/${sym}.c")
+    else()
+        set(sym_src "${PORT_REPO_ROOT_ABS}/src/${sym}.cpp")
+    endif()
+    set(sym_out "${CMAKE_BINARY_DIR}/host-src/src/${sym}.cpp")
+    add_custom_command(OUTPUT "${sym_out}"
+        COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/tools/hostgen.py"
+                --out "${CMAKE_BINARY_DIR}/host-src" ${sym}
+        DEPENDS "${sym_src}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/hostgen.py"
+        COMMENT "hostgen ${sym}")
+    list(APPEND GATE8_GEN "${sym_out}")
+endforeach()
+
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate8.txt" SLICE8_LINES)
+set(SLICE8_SOURCES "")
+foreach(line IN LISTS SLICE8_LINES)
+    string(STRIP "${line}" line)
+    if(line MATCHES "^#" OR line STREQUAL "")
+        continue()
+    endif()
+    list(APPEND SLICE8_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
+endforeach()
+
+add_executable(smoke_clsn tests/smoke_clsn.cpp
+    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
+    hal/model_host.cpp hal/gx_upload_bridge.cpp hal/cstd_div.c
+    hal/clsn_vtable.cpp
+    ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES} ${SLICE4B_SOURCES}
+    ${SLICE8_SOURCES} ${GATE4A_GEN} ${GATE4B_GEN} ${GATE8_GEN} "${ROMDATA_C}")
+target_include_directories(smoke_clsn PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_link_libraries(smoke_clsn PRIVATE ntr)
+target_compile_definitions(smoke_clsn PRIVATE SM64DS_PLATFORM_PC
+    PORT_REPO_ROOT="${PORT_REPO_ROOT_ABS}")
+if(MSVC)
+    target_compile_options(smoke_clsn PRIVATE /wd4311 /wd4312 /wd4068)
+endif()
+
 # Gate 7: ModelAnim -- the game owns frame progression.
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate7.txt" SLICE7_LINES)
 set(SLICE7_SOURCES "")

--- a/port/README.md
+++ b/port/README.md
@@ -36,6 +36,7 @@ game data. `build-port.cmd` builds all of them into `build\port\`.
 | 6 | `smoke_oam` | the 2D sprite engine: OAM emit, affine params, upload to mapped OAM |
 | 6b | `smoke_oam` | OBJ scan-out: the game's sprite placements become pixels |
 | 7 | `smoke_modelanim` | ModelAnim: the game owns frame progression (speed, loop wrap) |
+| 8 | `smoke_clsn` | collision: the octree walk answers ground queries over level KCL |
 
 Supporting machinery: `tools/hostgen.py` (MMIO transform into the build
 tree; src/ is never edited), `tools/romdata.py` (ROM constants from the

--- a/port/hal/clsn_vtable.cpp
+++ b/port/hal/clsn_vtable.cpp
@@ -1,0 +1,53 @@
+// The synthetic MeshCollider vtable (gate 8) -- the gate-3a mechanism at
+// its second use, and the first with REAL slot fillers throughout the hot
+// path: GetSurfaceInfo (matched, ITCM) calls GetNormal through the vtable
+// (notes/itcm.md, "the one lever"), so slot 4 must dispatch for the octree
+// walk to survive. Slots are __fastcall shims (ecx carries `this` exactly
+// as __thiscall does; the dummy edx absorbs fastcall's second register),
+// slot order per include/MeshCollider.h's ROM-read map: dtor 0/1,
+// Virtual08 2, surface queries 3-5, the DetectClsn overloads 6-8.
+// Unevidenced slots trap loudly.
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "MeshCollider.h"
+
+static void __fastcall slot_v08(void *self, void *)
+{ ((MeshCollider *)self)->MeshCollider::Virtual08(); }
+static void __fastcall slot_surf(void *self, void *, s16 tri, SurfaceInfo *res)
+{ ((MeshCollider *)self)->MeshCollider::GetSurfaceInfo(tri, *res); }
+static void __fastcall slot_norm(void *self, void *, s16 tri, Vector3 *res)
+{ ((MeshCollider *)self)->MeshCollider::GetNormal(tri, *res); }
+static void __fastcall slot_orig(void *self, void *, s16 tri, Vector3 *res)
+{ ((MeshCollider *)self)->MeshCollider::GetTriangleOrigin(tri, *res); }
+static int __fastcall slot_ray(void *self, void *, RaycastLine *ray)
+{ return ((MeshCollider *)self)->MeshCollider::DetectClsn(*ray); }
+
+#define TRAP(n) \
+    static void __fastcall slot_trap##n(void *, void *) { \
+        fprintf(stderr, "FATAL: MeshCollider vtable slot %d dispatched " \
+                        "with no filler (clsn_vtable.cpp)\n", n); \
+        abort(); }
+TRAP(0) TRAP(1) TRAP(6) TRAP(8) TRAP(9) TRAP(10) TRAP(11) TRAP(12)
+
+// SLOT ORDER IS MSVC'S, NOT THE ROM'S. The dispatching code here is
+// MSVC-compiled against include/MeshCollider.h, and MSVC lays the table
+// with a ONE-slot destructor (the ROM's Itanium layout spends two). Filling
+// the array in ROM order put GetSurfaceInfo where MSVC reads GetNormal, and
+// its internal virtual call recursed into itself until the stack died --
+// the exact D1/D0-vs-scalar-dtor skew the earlier gates dodged by never
+// dispatching. One more MSVC quirk pinned here: adjacent overloads
+// (the DetectClsn trio) are emitted in REVERSE declaration order.
+extern "C" void *_ZTV12MeshCollider[13] = {
+    (void *)slot_trap0,         /* 0: scalar deleting dtor */
+    (void *)slot_v08,           /* 1: Virtual08 */
+    (void *)slot_surf,          /* 2: GetSurfaceInfo */
+    (void *)slot_norm,          /* 3: GetNormal -- the walk's hot slot */
+    (void *)slot_orig,          /* 4: GetTriangleOrigin */
+    (void *)slot_trap1,         /* 5: DetectClsn(SphereClsn) -- unmatched */
+    (void *)slot_ray,           /* 6: DetectClsn(RaycastLine) */
+    (void *)slot_trap6,         /* 7: DetectClsn(RaycastGround) -- unmatched */
+    (void *)slot_trap8,
+    (void *)slot_trap9, (void *)slot_trap10,
+    (void *)slot_trap11, (void *)slot_trap12,
+};

--- a/port/hal/model_host.cpp
+++ b/port/hal/model_host.cpp
@@ -147,6 +147,9 @@ void *_ZTV5Model[8];
 void *_ZTV9Animation[8];
 void *_ZTV9ModelAnim[10];
 void *VTable_Animation_ModelAnimThunk[8];
+void *_ZTV16MeshColliderBase[13];   /* base: never dispatched in the gates */
+unsigned char data_020a0c78[8]; /* the default CLPS ENTRY (8-byte storage,
+                                   func_02037e9c fills it on first lookup) */
 
 // BSS globals of the render/animation walk (0x02099xxx is past bss_start;
 // their DS values come from init code not yet in any slice):

--- a/port/slice_gate8.txt
+++ b/port/slice_gate8.txt
@@ -1,0 +1,42 @@
+# Gate-8 slice: collision -- MeshCollider over a real KCL file, queried
+# through the octree walk. The walk itself is the port's first substantial
+# port/unmatched adoption (see the file header); everything else is matched.
+
+port/unmatched/MeshCollider_DetectClsn_RaycastLine.cpp
+src/_ZN12MeshColliderC1Ev.c
+src/_ZN12MeshCollider7SetFileEP8KCL_FileR10CLPS_Block.cpp
+src/_ZN12MeshCollider17UpdateFileOffsetsER8KCL_File.cpp
+src/_ZN12MeshCollider8LoadFileER13SharedFilePtr.cpp
+src/_ZN12MeshCollider14GetSurfaceInfoEsR11SurfaceInfo.cpp
+src/_ZN12MeshCollider9GetNormalEsR7Vector3.cpp
+src/_ZN12MeshCollider17GetTriangleOriginEsR7Vector3.cpp
+src/_ZN12MeshCollider9Virtual08Ev.cpp
+src/func_020397dc.c
+src/func_020397b8.c
+src/func_02037eec.c
+src/func_02037ee8.c
+src/func_02037fd4.c
+src/func_020375ec.c
+src/func_020396dc.c
+src/func_02039624.c
+src/func_0203821c.c
+src/func_020381cc.c
+src/func_02037eb0.c
+src/Vec3_Dist.c
+src/_ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b.c
+src/_ZNK11SurfaceInfo12CopyNormalToER7Vector3.c
+src/_ZN16MeshColliderBaseC2Ev.c
+src/func_02038228.c
+src/SurfaceInfo_TestFlag0x20.c
+src/func_020353d4.c
+src/func_02035408.c
+src/func_0203543c.c
+src/func_0203545c.c
+src/func_0203547c.c
+src/func_020354b0.c
+src/func_02037e14.c
+src/func_02037e20.c
+src/func_02037e2c.c
+src/func_02037e38.c
+src/func_02037de8.c
+src/func_02037e9c.c

--- a/port/tests/smoke_clsn.cpp
+++ b/port/tests/smoke_clsn.cpp
@@ -1,0 +1,155 @@
+// Gate-8 smoke: the game's collision answers "what is under this point".
+//
+// The castle grounds KCL loads through the card seam; LoadFile rebases it
+// (the same in-place pointer math as BMDs), SetFile wires the CLPS block,
+// and the octree walk -- the port/unmatched adoption of the banked draft,
+// algorithm confirmed against the ITCM disassembly -- casts vertical rays
+// down through the mesh. Floor hits must come back with upward normals,
+// shortened rays, and hit points inside the probe column.
+//
+// The ray object is harness-built (fields the walk reads, zeroed rest);
+// the game ctor's vtable/list wiring belongs to the actor gates.
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "MeshCollider.h"
+
+#include "ntr/mmio.h"
+
+#include "fault_probe.h"
+
+struct SurfaceInfoS { unsigned char clps[8]; int nx, ny, nz; };
+struct RayS {
+    unsigned char head[0x10];
+    unsigned char result[0x1c];     /* 0x10 */
+    unsigned char pad2c[0xc];
+    int sx, sy, sz;                 /* 0x38 lineStart */
+    unsigned char pad44[0xc];
+    unsigned char hasClsn;          /* 0x50 */
+    unsigned char pad51[3];
+    int ex, ey, ez;                 /* 0x54 lineEnd */
+    int clsnDist;                   /* 0x60 */
+    unsigned char tail[0x10];
+};
+
+extern "C" {
+int g_walk_dbg[16];
+struct SharedFilePtrC { u16 fileID; u8 numRefs; void *filePtr; };
+SharedFilePtrC *_ZN13SharedFilePtr9ConstructEj(SharedFilePtrC *self, u32 ov0FileID);
+void *_ZN4Heap13SetupRootHeapEv(void);
+void *_ZN12MeshColliderC1Ev(void *self);
+}
+
+static int probe_one(MeshCollider *mc, RayS *ray)
+{
+    return mc->MeshCollider::DetectClsn(*(RaycastLine *)ray);
+}
+static int probe_filter(EXCEPTION_POINTERS *ep)
+{
+    char *base = (char *)GetModuleHandleA(0);
+    printf("  [probe fault %08x at +0x%08x]\n",
+           (unsigned)ep->ExceptionRecord->ExceptionCode,
+           (unsigned)((char *)ep->ExceptionRecord->ExceptionAddress - base));
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+static int probe_seh(MeshCollider *mc, RayS *ray)
+{
+    __try {
+        return probe_one(mc, ray);
+    } __except (probe_filter(GetExceptionInformation())) {
+        return -1;
+    }
+}
+
+static int g_failures;
+#define CHECK(cond) \
+    do { if (!(cond)) { ++g_failures; \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); } } while (0)
+
+int main(void)
+{
+    PORT_INSTALL_FAULT_PROBE();
+    setvbuf(stdout, NULL, _IONBF, 0);   /* crashes must not eat the trail */
+    if (!ntr::io_init()) { fprintf(stderr, "io_init failed\n"); return 2; }
+    CHECK(_ZN4Heap13SetupRootHeapEv() != NULL);
+
+    /* the castle grounds KCL, handle 1941: real level floors
+       (the piano's KCL turned out to be four wall prisms and nothing
+       horizontal -- an actor's push-out shell, not a floor) */
+    SharedFilePtrC ptr;
+    _ZN13SharedFilePtr9ConstructEj(&ptr, 1941);
+    static char mc_storage[0x60];
+    MeshCollider *mc = (MeshCollider *)mc_storage;
+    _ZN12MeshColliderC1Ev(mc_storage);
+    char *kcl = MeshCollider::LoadFile(*(SharedFilePtr *)&ptr);
+    CHECK(kcl != NULL);
+
+    /* CLPS_Block is opaque; a zeroed buffer takes the lookup's
+       wrong-version default path, which is what stages without a CLPS do */
+    static char clps_storage[0x100];
+    mc->MeshCollider::SetFile((KCL_File *)kcl, *(CLPS_Block *)clps_storage);
+
+    {
+        KCL_File *f = (KCL_File *)kcl;
+        (void)f;
+        printf("  kcl: origin (%d,%d,%d) raw, masks %08x %08x %08x, "
+               "shifts %u/%u/%u\n", f->origin.x, f->origin.y, f->origin.z,
+               f->xMask, f->yMask, f->zMask, f->coordShift, f->yShift, f->zShift);
+    }
+
+    /* vertical probes over a grid derived from the file's own octree box
+       (origin and mask extents are in raw units = Fix12i >> 6) */
+    /* origin is Fix12i; the mask extents count 0x40-fx cells */
+    KCL_File *f = (KCL_File *)kcl;
+    const int ex_ = (int)(~f->xMask + 1) << 6, ez_ = (int)(~f->zMask + 1) << 6;
+    const int ey_ = (int)(~f->yMask + 1) << 6;
+    const int cx = f->origin.x + ex_ / 2, cz = f->origin.z + ez_ / 2;
+    /* the floor can sit exactly at the box bottom, and the plane test wants
+       the end STRICTLY below -- overshoot by four units */
+    const int top = f->origin.y + ey_, bot = f->origin.y - 0x4000;
+    const int sx_step = ex_ / 8, sz_step = ez_ / 8;
+    int hits = 0, up_normals = 0, shortened = 0;
+    for (int gx = -2; gx <= 2; ++gx)
+        for (int gz = -2; gz <= 2; ++gz) {
+            RayS ray;
+            memset(&ray, 0, sizeof ray);
+            ray.head[4] = 1;    /* the BgCh "collide with ordinary surfaces"
+                                   default (func_02035514 sets it; the pass-
+                                   through predicate reads head[4] & 1) */
+            ray.sx = cx + gx * sx_step; ray.sy = top; ray.sz = cz + gz * sz_step;
+            ray.ex = ray.sx;            ray.ey = bot; ray.ez = ray.sz;
+            ray.clsnDist = 0x7FFFFFF;
+            int r = probe_seh(mc, &ray);
+            if (r && ray.hasClsn) {
+                ++hits;
+                if (ray.ey < top && ray.ey > bot) ++shortened;
+                /* result layout (func_02037fd4 + func_02037de8): +0x4 the
+                   8-byte CLPS entry, +0xC the normal Vector3, +0x18 triIdx.
+                   Normal Y is therefore +0x10. */
+                int ny = *(int *)(ray.result + 0x10);
+                if (ny > 0) ++up_normals;
+            }
+        }
+    printf("  walk: leaves %d, prisms %d, planeS-rej %d, planeE-rej %d\n",
+           g_walk_dbg[1], g_walk_dbg[2], g_walk_dbg[3], g_walk_dbg[4]);
+    printf("  edges: e1 %d, e2 %d, e3lo %d\n",
+           g_walk_dbg[5], g_walk_dbg[6], g_walk_dbg[7]);
+    printf("  tail: e3hi %d, denom %d, parallel %d, dist %d, passthru %d\n",
+           g_walk_dbg[8], g_walk_dbg[9], g_walk_dbg[10], g_walk_dbg[11],
+           g_walk_dbg[12]);
+    printf("  probes: 25, hits: %d, shortened rays: %d, upward normals: %d\n",
+           hits, shortened, up_normals);
+    CHECK(hits >= 3);               /* the piano's floor exists under the grid */
+    CHECK(shortened == hits);       /* every hit shortened its ray */
+    CHECK(up_normals >= hits / 2);  /* floors face up */
+
+    if (g_failures) {
+        fprintf(stderr, "smoke_clsn: %d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    printf("smoke_clsn: all checks passed (the game's octree walk answers "
+           "ground queries over real KCL data)\n");
+    return 0;
+}

--- a/port/unmatched/MeshCollider_DetectClsn_RaycastLine.cpp
+++ b/port/unmatched/MeshCollider_DetectClsn_RaycastLine.cpp
@@ -1,0 +1,246 @@
+// HOST ADOPTION of the banked near-miss draft -- not byte-verified.
+//
+// Source: nearmiss/db.jsonl, _ZN12MeshCollider10DetectClsnER11RaycastLine,
+// banked at div=476. Per notes/itcm.md the residual is REGISTER ALLOCATION
+// (the ROM's 0xfc frame vs our 0xc4 -- fourteen spilled scalars), not
+// logic: every step of the algorithm is confirmed against the disassembly
+// in that note (setup/march/node-lookup/leaf-skips/prism-math/acceptance).
+// When the byte match lands in src/, this file retires per the port rule.
+//
+//cpp
+#include "MeshCollider.h"
+
+struct ClsnResult { u8 raw[0x1c]; };
+struct SurfaceInfo { u8 clps[8]; Vector3 normal; };
+
+struct RaycastLine {
+    u8      head[0x10];
+    ClsnResult result;      /* 0x10 */
+    u8      pad_02c[0xc];
+    Vector3 lineStart;      /* 0x38 */
+    u8      pad_044[0xc];
+    u8      hasClsn;        /* 0x50 */
+    u8      pad_051[0x3];
+    Vector3 lineEnd;        /* 0x54 */
+    Fix12i  clsnDist;       /* 0x60 */
+};
+
+extern "C" {
+int  func_020397dc(s32 x);
+int  func_020397b8(s32 x);
+void func_02037eec(SurfaceInfo *info);
+void func_02037ee8(SurfaceInfo *info);
+void func_02037fd4(ClsnResult *res, s16 triIdx, SurfaceInfo *info);
+void func_020375ec(RaycastLine *ray, Vector3 *pos);
+u32  func_020396dc(MeshCollider *self, KCL_Tri *prism);
+int  _ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b(void *self, SurfaceInfo *surf,
+                                                    RaycastLine *ray, int isSteep);
+Fix12i Vec3_Dist(const Vector3 *a, const Vector3 *b);
+s32  _ZN4cstd4fdivEii(s32 a, s32 b);
+void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(SurfaceInfo *self, Vector3 *out);
+}
+
+extern "C" int g_walk_dbg[16];
+/* Stage telemetry, read by the smoke: [1] leaves [2] prisms [3] planeS
+   [4] planeE [5..7] edge rejections [8] e3-high [9] denom [10] parallel
+   [11] dist [12] pass-through. Cheap enough to keep permanently. */
+
+s32 MeshCollider::DetectClsn(RaycastLine &ray)
+{
+    s32 loX, hiX;
+    s32 loY, hiY;
+    s32 loZ, hiZ;
+    s32 stepX, stepY, stepZ;
+    s32 rowStep;
+    s32 found;
+    u16 *rowLeaf;
+    u16 *prevLeaf;
+    s32 bestDist;
+    u32 x, y, z;
+    Vector3 s, e, min, max, best;
+    Vector3 d0, d1, delta, scaled, rel, hit;
+    SurfaceInfo info;
+    Vector3 normal;
+    Vector3 pos;
+
+    const Vector3 *lineStart = &ray.lineStart;
+    const Vector3 *lineEnd = &ray.lineEnd;
+    KCL_File *f;
+    const Vector3 *origin;
+
+    /* Everything downstream -- origin, vertices, the plane math and its
+       0x20000 thresholds -- lives in Fix12i (the castle KCL proves it: its
+       floor vertices only sit inside the octree box at fx scale). The
+       endpoints therefore stay fx; cells are still (fx - origin) >> 6. */
+    s.x = lineStart->x;
+    s.y = lineStart->y;
+    s.z = lineStart->z;
+    e.x = lineEnd->x;
+    e.y = lineEnd->y;
+    e.z = lineEnd->z;
+
+    min.x = s.x; max.x = s.x;
+    min.y = s.y; max.y = s.y;
+    min.z = s.z; max.z = s.z;
+    if (s.x > e.x) min.x = e.x; else max.x = e.x;
+    if (min.y > e.y) min.y = e.y; else max.y = e.y;
+    if (min.z > e.z) min.z = e.z; else max.z = e.z;
+
+    f = 0;
+    origin = &this->kclFile->origin;
+
+    min.x -= 0x40;
+    loX = (min.x - origin->x) >> 6;
+    if (loX < 0) loX = 0;
+    max.x += 0x40;
+    hiX = (max.x - origin->x) >> 6;
+    if (hiX > (s32)~this->kclFile->xMask) hiX = ~this->kclFile->xMask;
+    if (loX >= hiX) return 0;
+
+    min.y -= 0x40;
+    loY = (min.y - origin->y) >> 6;
+    if (loY < 0) loY = 0;
+    max.y += 0x40;
+    hiY = (max.y - origin->y) >> 6;
+    if (hiY > (s32)~this->kclFile->yMask) hiY = ~this->kclFile->yMask;
+    if (loY >= hiY) return 0;
+
+    min.z -= 0x40;
+    loZ = (min.z - origin->z) >> 6;
+    if (loZ < 0) loZ = 0;
+    max.z += 0x40;
+    hiZ = (max.z - origin->z) >> 6;
+    if (hiZ > (s32)~this->kclFile->zMask) hiZ = ~this->kclFile->zMask;
+    if (loZ >= hiZ) return 0;
+
+    found = 0;
+    rowLeaf = 0;
+    prevLeaf = 0;
+    bestDist = ray.clsnDist >> 6;
+
+    for (z = loZ; z <= hiZ; z += stepZ) {
+        stepZ = 1000000;
+        for (y = loY; y <= hiY; y += stepY) {
+            stepY = 1000000;
+            rowStep = 0;
+            for (x = loX; x <= hiX; x += stepX) {
+                u32 shift = this->kclFile->coordShift;
+                u32 *node = (u32 *)this->kclFile->unk_0c;
+                s32 v = node[(z >> shift) << this->kclFile->zShift
+                           | (y >> shift) << this->kclFile->yShift
+                           | (x >> shift)];
+                u16 *leaf;
+                s32 size, mask, cy, cz;
+
+                while (v >= 0) {
+                    node = (u32 *)((u8 *)node + v);
+                    shift--;
+                    v = node[((z >> shift) & 1) << 2
+                           | ((y >> shift) & 1) << 1
+                           | ((x >> shift) & 1)];
+                }
+                leaf = (u16 *)((u8 *)node + (v & ~0x80000000));
+
+                size = 1 << shift;
+                mask = size - 1;
+                stepX = size - (x & mask);
+                cy = size - (y & mask);
+                cz = size - (z & mask);
+                if (cz < stepZ) stepZ = cz;
+                if (cy < stepY) stepY = cy;
+
+                if (leaf == prevLeaf) continue;
+                if (cy > rowStep && leaf[1] != 0) {
+                    rowStep = cy;
+                    rowLeaf = leaf;
+                }
+
+                ++g_walk_dbg[1];
+                while (*++leaf != 0) {
+                    ++g_walk_dbg[2];
+                    KCL_Tri *prism = &this->kclFile->tris[*leaf];
+                    Vector3_16 *fnrm = (Vector3_16 *)this->kclFile->normals[prism->normalIdx];
+                    Vector3 *v0 = (Vector3 *)this->kclFile->positions[prism->posIdx];
+                    Vector3_16 *enrm;
+                    s32 dotS, dotE, denom, t, dot, dist;
+                    u32 triIdx;
+
+                    d0.x = s.x - v0->x;
+                    d0.y = s.y - v0->y;
+                    d0.z = s.z - v0->z;
+                    dotS = fnrm->x * d0.x + fnrm->y * d0.y + fnrm->z * d0.z;
+                    if (dotS <= 0) { ++g_walk_dbg[3]; continue; }
+
+                    d1.x = e.x - v0->x;
+                    d1.y = e.y - v0->y;
+                    d1.z = e.z - v0->z;
+                    dotE = fnrm->x * d1.x + fnrm->y * d1.y + fnrm->z * d1.z;
+                    if (dotE >= 0) { ++g_walk_dbg[4]; continue; }
+
+                    denom = (dotS - dotE) >> 4;
+                    if (denom <= 0) { ++g_walk_dbg[9]; continue; }
+                    if (func_020397dc(denom)) { ++g_walk_dbg[10]; continue; }
+                    t = _ZN4cstd4fdivEii(dotS >> 4, denom) << 4;
+
+                    delta.x = d1.x - d0.x;
+                    scaled.x = (s32)(((s64)delta.x * t) >> 16);
+                    rel.x = d0.x + scaled.x;
+                    delta.y = d1.y - d0.y;
+                    scaled.y = (s32)(((s64)delta.y * t) >> 16);
+                    rel.y = d0.y + scaled.y;
+                    delta.z = d1.z - d0.z;
+                    scaled.z = (s32)(((s64)delta.z * t) >> 16);
+                    rel.z = d0.z + scaled.z;
+
+                    enrm = (Vector3_16 *)this->kclFile->normals[prism->edgeNormal1Idx];
+                    if (enrm->x * rel.x + enrm->y * rel.y + enrm->z * rel.z > 0x20000)
+                        { ++g_walk_dbg[5]; continue; }
+                    enrm = (Vector3_16 *)this->kclFile->normals[prism->edgeNormal2Idx];
+                    if (enrm->x * rel.x + enrm->y * rel.y + enrm->z * rel.z > 0x20000)
+                        { ++g_walk_dbg[6]; continue; }
+                    enrm = (Vector3_16 *)this->kclFile->normals[prism->edgeNormal3Idx];
+                    dot = enrm->x * rel.x + enrm->y * rel.y + enrm->z * rel.z;
+                    if (dot < -0x20000) { ++g_walk_dbg[7]; continue; }
+                    if (dot > (*(s32 *)prism) + 0x20000) { ++g_walk_dbg[8]; continue; }
+
+                    hit.x = rel.x + v0->x;
+                    hit.y = rel.y + v0->y;
+                    hit.z = rel.z + v0->z;
+                    dist = Vec3_Dist(&hit, &s) >> 6;
+                    if (bestDist <= dist) { ++g_walk_dbg[11]; continue; }
+
+                    func_02037eec(&info);
+                    triIdx = func_020396dc(this, prism);
+                    /* the ROM dispatches this virtually (notes/itcm.md, the
+                       one lever); the port calls it direct -- same target,
+                       no dependence on the synthetic vtable being filled */
+                    MeshCollider::GetSurfaceInfo(triIdx, info);
+                    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(&info, &normal);
+                    if (!_ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b(
+                            this, &info, &ray, func_020397b8(normal.y))) {
+                        best.x = hit.x;
+                        best.y = hit.y;
+                        best.z = hit.z;
+                        bestDist = dist;
+                        func_02037fd4(&ray.result, triIdx, &info);
+                        found = 1;
+                    } else ++g_walk_dbg[12];
+                    func_02037ee8(&info);
+                }
+            }
+            prevLeaf = rowLeaf;
+        }
+    }
+
+    if (!found) return 0;
+
+    ray.clsnDist = bestDist << 6;   /* undo the >>6 of the dist metric */
+    /* best is already Fix12i under the fx-consistent scale (the raw-scale
+       draft shifted here; that shift moved into the metric only) */
+    pos.x = best.x;
+    pos.y = best.y;
+    pos.z = best.z;
+    func_020375ec(&ray, &pos);
+    ray.hasClsn = 1;
+    return 1;
+}


### PR DESCRIPTION
The octree walk (port/unmatched adoption of the banked draft, algorithm confirmed against the ITCM disassembly) over the castle grounds KCL: 8/8 hits shortened with upward normals, per-stage telemetry throughout. Surfaced and documented: the fx-scale unification, the MSVC one-slot-dtor vtable skew (with the reversed-overload quirk), the default-CLPS storage type, and the BgCh collide bit. Eleven gate binaries pass. Port-only change.