### PR TITLE
Enroll 33 more matched functions into the ROM build

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -70,6 +70,7 @@ src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp:
     .text start:0x02005f0c end:0x02005fa0
 
 src/_ZN8CapEnemy11GetCapStateEv.cpp:
+    complete
     .text start:0x02005fa0 end:0x02006054
 
 src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp:
@@ -2003,6 +2004,7 @@ src/_ZN15TextureSequenceD0Ev.c:
     .text start:0x02015a00 end:0x02015a2c
 
 src/_ZN15TextureSequenceD1Ev.c:
+    complete
     .text start:0x02015a2c end:0x02015a50
 
 src/_ZN15TextureSequenceC1Ev.c:
@@ -2044,6 +2046,7 @@ src/_ZN9AnimationD2Ev.c:
     .text start:0x02015cb4 end:0x02015cc4
 
 src/_ZN9AnimationD0Ev.c:
+    complete
     .text start:0x02015cc4 end:0x02015ce8
 
 src/_ZN9AnimationD1Ev.c:
@@ -2069,12 +2072,6 @@ src/_ZN11ShadowModel8CleanAllEv.cpp:
 src/_ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j.c:
     complete
     .text start:0x02015e64 end:0x02015ebc
-
-src/_ZN11ShadowModel12InitCylinderEv.cpp:
-    .text start:0x02015ebc end:0x02015ed8
-
-src/_ZN11ShadowModel10InitCuboidEv.cpp:
-    .text start:0x02015ed8 end:0x02015ef4
 
 src/_ZN11ShadowModel9DoSetFileEPcii.cpp:
     complete
@@ -2157,9 +2154,11 @@ src/_ZN14BlendModelAnim7AdvanceEv.cpp:
     .text start:0x0201647c end:0x020164b0
 
 src/_ZN14BlendModelAnim9Virtual18EjPK7Vector3.cpp:
+    complete
     .text start:0x020164b0 end:0x020164e4
 
 src/_ZN14BlendModelAnim6RenderEPK7Vector3.cpp:
+    complete
     .text start:0x020164e4 end:0x02016518
 
 src/_ZN14BlendModelAnim9Virtual10ER9Matrix4x3.cpp:
@@ -2182,9 +2181,6 @@ src/_ZN14BlendModelAnimD0Ev.c:
     complete
     .text start:0x02016644 end:0x02016690
 
-src/_ZN14BlendModelAnimD1Ev.c:
-    .text start:0x02016690 end:0x020166d4
-
 src/_ZN14BlendModelAnimC1Ev.c:
     complete
     .text start:0x020166d4 end:0x02016714
@@ -2202,9 +2198,11 @@ src/func_020167a4.c:
     .text start:0x020167a4 end:0x020167c4
 
 src/_ZN9ModelAnim9Virtual18EjPK7Vector3.cpp:
+    complete
     .text start:0x020167c4 end:0x020167f8
 
 src/_ZN9ModelAnim6RenderEPK7Vector3.cpp:
+    complete
     .text start:0x020167f8 end:0x0201682c
 
 src/_ZN9ModelAnim9Virtual10ER9Matrix4x3.cpp:
@@ -2299,15 +2297,9 @@ src/_ZN5Model11UpdateVertsEv.cpp:
     complete
     .text start:0x02016c98 end:0x02016ca8
 
-src/_ZN5ModelD2Ev.c:
-    .text start:0x02016ca8 end:0x02016ce0
-
 src/_ZN5ModelD0Ev.c:
     complete
     .text start:0x02016ce0 end:0x02016d20
-
-src/_ZN5ModelD1Ev.c:
-    .text start:0x02016d20 end:0x02016d58
 
 src/_ZN5ModelC1Ev.c:
     complete
@@ -2316,9 +2308,6 @@ src/_ZN5ModelC1Ev.c:
 src/_ZN5ModelC2Ev.c:
     complete
     .text start:0x02016da8 end:0x02016df8
-
-src/CleanCommonModelDataArr.c:
-    .text start:0x02016df8 end:0x02016e70
 
 src/func_02016e70.c:
     complete
@@ -4488,9 +4477,6 @@ src/func_02031154.c:
 src/func_0203128c.c:
     .text start:0x0203128c end:0x020313d8
 
-src/func_020313d8.c:
-    .text start:0x020313d8 end:0x02031428
-
 src/func_02031428.c:
     complete
     .text start:0x02031428 end:0x020316d8
@@ -5382,6 +5368,7 @@ src/_ZN16MeshColliderBase7DisableEv.cpp:
     .text start:0x02039140 end:0x02039184
 
 src/_ZN16MeshColliderBase6EnableEP5Actor.cpp:
+    complete
     .text start:0x02039184 end:0x020391f0
 
 src/func_020391f0.c:
@@ -7086,6 +7073,7 @@ src/_ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE.cpp:
     .text start:0x02043c88 end:0x02043d48
 
 src/_ZN9ActorBaseD2Ev.c:
+    complete
     .text start:0x02043d48 end:0x02043d78
 
 src/_ZN9ActorBaseD0Ev.c:
@@ -7093,6 +7081,7 @@ src/_ZN9ActorBaseD0Ev.c:
     .text start:0x02043d78 end:0x02043dbc
 
 src/_ZN9ActorBaseD1Ev.c:
+    complete
     .text start:0x02043dbc end:0x02043dec
 
 src/_ZN9ActorBaseC1Ev.cpp:
@@ -7219,6 +7208,7 @@ src/func_020458a8.c:
     .text start:0x020458a8 end:0x020458e0
 
 src/_ZN5Model13LoadTexAndPalER8BMD_File.cpp:
+    complete
     .text start:0x020458e0 end:0x02045a50
 
 src/func_02045a50.c:
@@ -7234,6 +7224,7 @@ src/_ZN5Model17LoadTextureToVramEPcj.cpp:
     .text start:0x02045c10 end:0x02045c60
 
 src/_ZN5Model13GetVramOffsetEj.cpp:
+    complete
     .text start:0x02045c60 end:0x02045ce0
 
 src/func_02045ce0.c:

--- a/config/arm9/itcm/delinks.txt
+++ b/config/arm9/itcm/delinks.txt
@@ -1,34 +1,45 @@
     .text       start:0x01ff8000 end:0x01ffdf3c kind:code align:32
     .bss        start:0x01ffdf40 end:0x01ffdf40 kind:bss align:32
-src/func_01ffb07c.c:
+src/func_01ffb07c.cpp:
+    complete
     .text start:0x01ffb07c end:0x01ffb098
 
-src/func_01ffb098.c:
+src/func_01ffb098.cpp:
+    complete
     .text start:0x01ffb098 end:0x01ffb0a4
 
-src/func_01ffb0a4.c:
+src/func_01ffb0a4.cpp:
+    complete
     .text start:0x01ffb0a4 end:0x01ffb0b0
 
-src/func_01ffb0b0.c:
+src/func_01ffb0b0.cpp:
+    complete
     .text start:0x01ffb0b0 end:0x01ffb0bc
 
-src/func_01ffb0bc.c:
+src/func_01ffb0bc.cpp:
+    complete
     .text start:0x01ffb0bc end:0x01ffb0c8
 
-src/func_01ffb0c8.c:
+src/func_01ffb0c8.cpp:
+    complete
     .text start:0x01ffb0c8 end:0x01ffb0d0
 
 src/_ZNK12MeshCollider13GetUnkOctreeYEv.cpp:
+    complete
     .text start:0x01ffb0d0 end:0x01ffb0ec
 
 src/_ZNK12MeshCollider16GetOctreeOriginYEv.cpp:
+    complete
     .text start:0x01ffb0ec end:0x01ffb0fc
 
 src/_ZN12MeshCollider17GetTriangleOriginEsR7Vector3.cpp:
+    complete
     .text start:0x01ffd890 end:0x01ffd8d8
 
 src/_ZN12MeshCollider9GetNormalEsR7Vector3.cpp:
+    complete
     .text start:0x01ffd8d8 end:0x01ffd920
 
 src/_ZN12MeshCollider14GetSurfaceInfoEsR11SurfaceInfo.cpp:
+    complete
     .text start:0x01ffd920 end:0x01ffd97c

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -2982,6 +2982,7 @@ src/func_ov002_020d5338.cpp:
     .text start:0x020d5338 end:0x020d53ac
 
 src/_ZN6Player16St_BurnFire_MainEv.cpp:
+    complete
     .text start:0x020d53ac end:0x020d5750
 
 src/_ZN6Player16St_BurnFire_InitEv.cpp:
@@ -3079,6 +3080,7 @@ src/func_ov002_020d6c60.cpp:
     .text start:0x020d6c60 end:0x020d6dac
 
 src/func_ov002_020d6dac.c:
+    complete
     .text start:0x020d6dac end:0x020d7030
 
 src/func_ov002_020d7030.cpp:
@@ -3468,6 +3470,7 @@ src/_ZN6Player22St_GroundPound_CleanupEv.cpp:
     .text start:0x020dd9e0 end:0x020dd9f8
 
 src/_ZN6Player19St_GroundPound_MainEv.cpp:
+    complete
     .text start:0x020dd9f8 end:0x020dddf0
 
 src/_ZN6Player19St_GroundPound_InitEv.cpp:
@@ -3583,6 +3586,7 @@ src/func_ov002_020df840.c:
     .text start:0x020df840 end:0x020df8f0
 
 src/func_ov002_020df8f0.c:
+    complete
     .text start:0x020df8f0 end:0x020dfdf0
 
 src/_ZN6Player11St_Fly_MainEv.cpp:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -652,6 +652,9 @@ src/func_ov006_020c7ba4.c:
     complete
     .text start:0x020c7ba4 end:0x020c7c68
 
+src/func_ov006_020c7c68.c:
+    .text start:0x020c7c68 end:0x020c802c
+
 src/func_ov006_020c802c.c:
     complete
     .text start:0x020c802c end:0x020c8048
@@ -800,6 +803,9 @@ src/func_ov006_020c9098.c:
 src/func_ov006_020c91ac.cpp:
     complete
     .text start:0x020c91ac end:0x020c94e0
+
+src/func_ov006_020c94e0.cpp:
+    .text start:0x020c94e0 end:0x020c97bc
 
 src/func_ov006_020c97bc.cpp:
     complete
@@ -1337,6 +1343,7 @@ src/func_ov006_020d11a0.cpp:
     .text start:0x020d11a0 end:0x020d122c
 
 src/func_ov006_020d122c.c:
+    complete
     .text start:0x020d122c end:0x020d1450
 
 src/func_ov006_020d1450.c:
@@ -1379,6 +1386,7 @@ src/func_ov006_020d48dc.cpp:
     .text start:0x020d48dc end:0x020d4b7c
 
 src/func_ov006_020d4b7c.c:
+    complete
     .text start:0x020d4b7c end:0x020d52f0
 
 src/func_ov006_020d52f0.c:
@@ -1593,6 +1601,7 @@ src/func_ov006_020d7778.c:
     .text start:0x020d7778 end:0x020d777c
 
 src/func_ov006_020d777c.c:
+    complete
     .text start:0x020d777c end:0x020d7958
 
 src/func_ov006_020d7958.c:
@@ -3318,6 +3327,7 @@ src/func_ov006_020ef580.c:
     .text start:0x020ef580 end:0x020ef5ac
 
 src/func_ov006_020ef5ac.c:
+    complete
     .text start:0x020ef5ac end:0x020ef768
 
 src/func_ov006_020ef768.c:
@@ -5551,6 +5561,7 @@ src/func_ov006_021126b4.c:
     .text start:0x021126b4 end:0x021128fc
 
 src/func_ov006_021128fc.c:
+    complete
     .text start:0x021128fc end:0x02112ad8
 
 src/func_ov006_02112ad8.c:
@@ -6645,6 +6656,7 @@ src/func_ov006_02123c78.c:
     .text start:0x02123c78 end:0x02123cb4
 
 src/func_ov006_02123cb4.c:
+    complete
     .text start:0x02123cb4 end:0x02124040
 
 src/func_ov006_02124040.c:

--- a/config/arm9/overlays/ov055/delinks.txt
+++ b/config/arm9/overlays/ov055/delinks.txt
@@ -3,9 +3,6 @@
     .ctor       start:0x02111910 end:0x02111914 kind:rodata align:4
     .data       start:0x02111920 end:0x02111b60 kind:data align:32
     .bss        start:0x02111b60 end:0x02111b80 kind:bss align:32
-src/_ZN11MirrorLuigiD1Ev.cpp:
-    .text start:0x021111a0 end:0x021111f8
-
 src/_ZN11MirrorLuigiD0Ev.c:
     complete
     .text start:0x021111f8 end:0x02111264

--- a/config/arm9/overlays/ov058/delinks.txt
+++ b/config/arm9/overlays/ov058/delinks.txt
@@ -2,12 +2,6 @@
     .ctor       start:0x021116e4 end:0x021116e4 kind:rodata align:4
     .data       start:0x02111700 end:0x02111b00 kind:data align:32
     .bss        start:0x02111b00 end:0x02111b00 kind:bss align:32
-src/_ZN15RecRoomCupboardD1Ev.cpp:
-    .text start:0x021111a0 end:0x021111e0
-
-src/_ZN15RecRoomCupboardD0Ev.cpp:
-    .text start:0x021111e0 end:0x02111234
-
 src/_ZN15RecRoomCupboard16CleanupResourcesEv.c:
     complete
     .text start:0x02111234 end:0x0211123c

--- a/config/rombuild-exclude.txt
+++ b/config/rombuild-exclude.txt
@@ -27,3 +27,24 @@ func_0206d8c4
 func_0206d940
 func_0206d9cc
 func_0206da18
+
+# --- rejected by mwldarm despite passing eligibility ---
+# Rule 5 accepts a reference whose name is in config/**/symbols.txt. These name
+# kind:data symbols no object in the link defines: resolvable in config, and
+# still an undefined symbol at link time.
+_ZN11ShadowModel10InitCuboidEv
+_ZN11ShadowModel12InitCylinderEv
+
+# --- linked cleanly but produced the wrong bytes (dsd check modules) ---
+# Eligibility proves an object is the right shape to drop in, never that it is
+# the right content. Mostly C++ destructors differing by a single byte, where a
+# deleting/complete variant resolves differently in a real relink than it does
+# when linkcheck verifies the match in isolation.
+_ZN11MirrorLuigiD1Ev
+_ZN15RecRoomCupboardD1Ev
+_ZN15RecRoomCupboardD0Ev
+_ZN14BlendModelAnimD1Ev
+_ZN5ModelD2Ev
+_ZN5ModelD1Ev
+CleanCommonModelDataArr
+func_020313d8


### PR DESCRIPTION
Source-built code goes **66.75% → 67.20%** (9,116 → 9,149 functions, +10,156 bytes), with the built ROM byte-identical to before — `dsd check modules` reports 106/106 exact, 0 differing bytes, sha256 `ddab9300b24aeae254192c2a30d812b07ece3adff83230e75c865ed915c9de40`.

Config only. No source changes.

## Method

Classified every candidate with `tools/eligible.py`, enrolled every eligible file, then let the build reject what it disagreed with and recorded why. Verified on the build box against this branch's exact tree.

## Why only 33, when 92.3% of code bytes are matched

Worth writing down, because the gap is not what it looks like from the progress bar:

| | Functions | Bytes |
|---|---|---|
| Eligible but not enrolled — config only | 43 | 10,828 |
| **Blocked by eligibility — real work** | **1,951** | **552,224** |

So ~98% of the matched-but-not-built code is blocked, not merely unconfigured. What blocks it:

| Bytes | Fns | Blocker |
|---|---|---|
| 376,352 | 1,456 | undefined reference config does not name |
| 123,672 | 303 | lives in `.init`, not `.text` (hard-excluded by M2b) |
| 29,776 | 81 | object size ≠ declared size |
| 6,088 | 81 | extra `.data` section |
| 11,484 | 13 | multi-`.text` TU (C++ dtors) |
| 248 | 7 | compile failed |

## The ten that passed eligibility and still could not land

Eligibility proves an object is the right **shape** to drop into a gap. It cannot prove it is the right **content**, and in one case it cannot even prove the shape:

- **`ShadowModel::InitCuboid` / `InitCylinder`** reference `data_020ad524` / `data_020ad560`. Both names *are* in `config/arm9/symbols.txt`, so rule 5 passes — but nothing in the link defines them, and `mwldarm` fails with an undefined symbol. **Rule 5 checks a reference is named, not that it is provided.** That looks worth fixing in `eligible.py`, since every future sweep will trip on it.
- **Eight more link cleanly and emit the wrong bytes** — 13 differing bytes total, six of them C++ destructors differing by exactly one byte each. That is the shape of a deleting/complete dtor variant resolving differently in a real relink than when `linkcheck` verifies the match in isolation — the BENIGN class `notes/rom-build.md` already warns about under M2b.

All ten are recorded in `config/rombuild-exclude.txt` with their reason, so the next sweep does not rediscover them. Their ranges stay inside their modules' gap objects, which is what entries in that file have always meant.

## One trap this surfaced

Running the documented `enroll.py --complete-list build/eligible-names.txt` on a clean tree **does not produce a green build today** — that pass list still contains these ten. The referee has to be `dsd check modules`, not the classifier.

## Where the remaining leverage is

The 376KB "undefined reference" bucket is not 1,456 separate problems; it is a short list with large fan-out:

- **`_ZTV10dBgActor_c` — 195 files.** That is Zelda/NSMB naming (`d…_c`), not SM64DS. Likely carried in from another decomp.
- **Double-mangled externs — ~129 files.** `_Z28_ZN13SharedFilePtr7ReleaseEvPv` is `_ZN13SharedFilePtr7ReleaseEv` mangled *again*, i.e. a C++ file declaring an extern by its already-mangled name.
- **Placeholder globals — ~429 files.** `G0` (174), `VT1` (109), `VT0` (55), `VT2` (41), `VT` (25), `HEAP` (25).
- **`_s32_div_f` — 58 files.** The MSL runtime division helper, seemingly just unnamed in config.

Those four gate ~800 of the 1,456 blocked functions.