### PR TITLE
readable: promote four Actor shims, and record why the rest cannot follow

### DIFF
--- a/include/Actor.h
+++ b/include/Actor.h
@@ -143,6 +143,20 @@ struct Actor : ActorDerived {
     int  GetSubtraction(short a, short b);
     void HugeLandingDustAt(Vector3 &pos, bool b);
     void LandingDustAt(Vector3 &pos, bool b);
+    void KillAndTrackInDeathTable();
+    void TrackInDeathTable();
+    void SpawnSoundObj(u32 soundObjParam);
+    s32  GetWaterHeightWDW();
+
+    /* Static: searches the live-actor list rather than acting on an instance. */
+    static Actor *FindWithID(u32 id);
+
+    /* Methods whose mangled names carry a by-value class parameter (5Fix12IiE,
+       and the Vector3 forms) are deliberately NOT declared here as definable
+       methods -- see notes/mwccarm-codegen.md 6az. CW homes class-typed by-value
+       parameters to the stack, costing +0x14, so those keep extern "C"
+       definitions with scalar args. A true-signature declaration for callers is
+       fine and is tracked separately. */
 };
 
 #else

--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -22,7 +22,11 @@ template reconstructed in include/math/Fix12.h - makes mwccarm home the incoming
 register arguments to the stack (`push {r0-r3}`) and reload each use, +0x14 bytes
 on ShadowModel::InitModel. Scalar parameters of identical width stay in registers.
 Identical on 1.2/sp2p3 and 2004/b56; `register`, `const`, and an inline conversion
-operator instead of direct member access change nothing.
+operator instead of direct member access change nothing. Nor does declaring the
+aggregate a `union` rather than a `struct`, or copying each parameter to a local
+before use -- re-measured on Actor::SetRanges (0x02010e08, target 0x24), where every
+aggregate form costs the same +0x14 and only a scalar parameter reproduces. The cost
+is in the parameter passing, not in how the member is reached.
 
 The retail ROM's own `5Fix12IiE` functions read their arguments straight from
 registers, so the original build had a lever we have not found. Until someone

--- a/src/_ZN5Actor10FindWithIDEj.cpp
+++ b/src/_ZN5Actor10FindWithIDEj.cpp
@@ -1,14 +1,22 @@
 //cpp
 // @symbol _ZN5Actor10FindWithIDEj
-/* recovered: named members + shared header */
+/* Actor::FindWithID(u32) at 0x02010c40.
+ *
+ * Static: searches the live-actor list rather than acting on an instance, which
+ * is why it takes no `this`. The list helper returns a node, and the actor
+ * itself hangs off the node at +8.
+ */
 #include "Actor.h"
+
 extern "C" {
-struct Actor;
-extern struct Actor* data_0209b468;
-extern struct Actor* func_02043f98(struct Actor**, unsigned int);
-struct Actor* _ZN5Actor10FindWithIDEj(unsigned int id){
-  struct Actor* p = func_02043f98(&data_0209b468, id);
-  if(p) return *(struct Actor**)((char*)p+8);
-  return 0;
+extern Actor *data_0209b468;
+extern Actor *func_02043f98(Actor **head, unsigned int id);
 }
+
+Actor *Actor::FindWithID(u32 id)
+{
+    Actor *node = func_02043f98(&data_0209b468, id);
+    if (node)
+        return *(Actor **)((char *)node + 8);
+    return 0;
 }

--- a/src/_ZN5Actor13SpawnSoundObjEj.c
+++ b/src/_ZN5Actor13SpawnSoundObjEj.c
@@ -1,28 +1,25 @@
-typedef unsigned int u32;
-typedef signed char s8;
-typedef int s32;
+//cpp
+// @symbol _ZN5Actor13SpawnSoundObjEj
+/* Actor::SpawnSoundObj(u32) at 0x02010bf0.
+ *
+ * Spawns actor 0x167 -- the positional sound emitter -- at this actor's own
+ * position and area, with no rotation and no death-table slot.
+ *
+ * Actor::Spawn is called through its mangled name rather than a declared method
+ * because its signature carries by-value class parameters; see
+ * notes/mwccarm-codegen.md 6az.
+ */
+#include "Actor.h"
 
-typedef struct { s32 x, y, z; } Vector3;
-typedef struct { short x, y, z; } Vector3_16;
+struct Vector3_16 { short x, y, z; };
 
-struct Actor {
-    char pad1[0x5c];
-    Vector3 pos;
-    char pad2[0x64];
-    s8 areaID;
-};
+extern "C" Actor *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+    u32 actorID, u32 param, const void *pos, const Vector3_16 *rot,
+    s32 areaID, s32 deathTableID);
 
-typedef struct Actor Actor;
-
-extern Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 actorID, u32 param1, const Vector3* pos, const Vector3_16* rot, s32 areaID, s32 deathTableID);
-
-void _ZN5Actor13SpawnSoundObjEj(Actor* self, u32 soundObjParam) {
+void Actor::SpawnSoundObj(u32 soundObjParam)
+{
     _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-        0x167,
-        soundObjParam,
-        &self->pos,
-        (const Vector3_16*)0,
-        (s32)self->areaID,
-        -1
-    );
+        0x167, soundObjParam, (const void *)&mPosX, (const Vector3_16 *)0,
+        (s32)mAreaId, -1);
 }

--- a/src/_ZN5Actor17GetWaterHeightWDWEv.c
+++ b/src/_ZN5Actor17GetWaterHeightWDWEv.c
@@ -1,12 +1,26 @@
+//cpp
+// @symbol _ZN5Actor17GetWaterHeightWDWEv
+/* Actor::GetWaterHeightWDW() at 0x02010b70.
+ *
+ * Normally the actor's own Y. In Wet-Dry World (level 0x15) and only for actors
+ * that are not area-bound, the height instead comes from a three-entry table
+ * indexed by the current water level.
+ */
+#include "Actor.h"
+
+extern "C" {
 extern signed char data_0209f2f8[];
 extern unsigned char data_0209f2c0[];
 extern int data_02075244[];
-int _ZN5Actor17GetWaterHeightWDWEv(char *self) {
-  int ret = *(int*)(self+0x60);
-  if (data_0209f2f8[0] == 0x15 && *(signed char*)(self+0xcc) == 0) {
-    unsigned int i = data_0209f2c0[0];
-    if (i >= 3) i = 2;
-    ret = data_02075244[i];
-  }
-  return ret;
+}
+
+s32 Actor::GetWaterHeightWDW()
+{
+    s32 ret = mPosY;
+    if (data_0209f2f8[0] == 0x15 && mAreaId == 0) {
+        unsigned int i = data_0209f2c0[0];
+        if (i >= 3) i = 2;
+        ret = data_02075244[i];
+    }
+    return ret;
 }

--- a/src/_ZN5Actor24KillAndTrackInDeathTableEv.c
+++ b/src/_ZN5Actor24KillAndTrackInDeathTableEv.c
@@ -1,9 +1,14 @@
-typedef struct Actor { char pad[0]; } Actor;
+//cpp
+// @symbol _ZN5Actor24KillAndTrackInDeathTableEv
+/* Actor::KillAndTrackInDeathTable() at 0x0200f9b8.
+ *
+ * Records the actor in the death table, then marks it for destruction through
+ * the ActorBase helper it inherits.
+ */
+#include "Actor.h"
 
-extern void _ZN5Actor17TrackInDeathTableEv(Actor* self);
-extern void _ZN9ActorBase18MarkForDestructionEv(Actor* self);
-
-void _ZN5Actor24KillAndTrackInDeathTableEv(Actor* self) {
-    _ZN5Actor17TrackInDeathTableEv(self);
-    _ZN9ActorBase18MarkForDestructionEv(self);
+void Actor::KillAndTrackInDeathTable()
+{
+    TrackInDeathTable();
+    MarkForDestruction();
 }


### PR DESCRIPTION
Four scalar-parameter shims become real `Actor::` methods. **Byte-neutral** — Actor was 81/81
before and after.

| | was | now |
|---|---|---|
| `KillAndTrackInDeathTable()` | `_ZN9ActorBase18MarkForDestructionEv(self)` via a `struct Actor { char pad[0]; }` stand-in | calls the inherited `MarkForDestruction()` |
| `GetWaterHeightWDW()` | `self+0x60`, `self+0xcc` | `mPosY`, `mAreaId` |
| `FindWithID(u32)` | free function | declared **static** — it searches the live-actor list and never had a `this` |
| `SpawnSoundObj(u32)` | its own `struct Actor { char pad1[0x5c]; Vector3 pos; ... }` | `&mPosX` |

Each was carrying a private struct definition or raw offsets. Those are gone.

## Why the rest stay shims

I audited all 31 Actor and ~40 Player shims expecting a long promotion queue. Most of them
**cannot** be promoted.

`notes/mwccarm-codegen.md` **§6az — the Fix12 wall.** CW homes class-typed by-value parameters
to the stack and reloads each use, costing +0x14. The prescribed shape is an `extern "C"`
mangled free function with scalar args, plus a true-signature declaration in the class header
for callers. `Animation::SetAnimation` already cites it in its own comment.

**So those files are not unfinished work — they are the correct form.** `Actor.h` now says so
at the point of temptation, because the instinct on seeing `Actor::Earthquake` still be a shim
is to finish the job, and that costs +0x14 every time.

## Two new data points on §6az

Re-measured on `Actor::SetRanges` (0x02010e08, target 0x24):

| variant | size vs 0x24 |
|---|---|
| plain `int` | ✅ exact — but mangles to `_ZN5Actor9SetRangesEiiii`, the wrong symbol |
| `struct Fix12 { int val; }` | +0x14 |
| conversion operator | +0x14 |
| **`union Fix12 { int val; }`** | **+0x14** ← new |
| **copy each param to a local first** | **+0x14** ← new |

That isolates the cost to **parameter passing**, not to how the member is reached — worth
recording, since "try a union" is the obvious next idea for anyone who hits this.

The open part is unchanged and genuinely unsolved: the retail ROM's own `5Fix12IiE` functions
read their arguments straight from registers, so the original build had a lever nobody has
found.

## Verification

- Actor **81/81** and its 23 header includers **23/23**, unchanged from clean main — checked
  against a stashed tree rather than from memory, since the baseline moved during this work
  (the two Actor near-misses and 34 Player ones got matched by others).
- Full ROM build: **9,149/9,149 reproducing, module fidelity 106/106 exact, PASS.**
- `tools/prepush_attribution.py`: 0 changed, 0 lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
