### PR TITLE
tools: fdiff must say which compiler it measured with, and let you pick

### DIFF
--- a/tools/fdiff.py
+++ b/tools/fdiff.py
@@ -8,7 +8,14 @@ Usage:
     python tools/fdiff.py --c cand.c --name FUNC --target-hex <hex>
     python tools/fdiff.py --c cand.c --name FUNC --module ov002 --addr 0x.. --size 0x..
 Prints each word: offset | target insn | candidate insn | OK/MISMATCH/reloc, then
-a summary line "RESULT match=<bool> mismatches=<n>/<words>".
+a summary line "RESULT match=<bool> mismatches=<n>/<words> version=<build>".
+
+The build matters: fdiff used to compile with match.CANONICAL unconditionally and
+never said so, and different mwccarm builds emit different code for the same source.
+A function whose cluster reproduces on 1.2/sp2p3 measured under a canonical of
+2004/b56 is scored against the wrong compiler, silently -- that cost real time on
+MeshCollider::DetectClsn(RaycastLine&), where the two builds differ by 8 bytes. Pass
+--version to pin it; every RESULT line now names the build it used.
 """
 import argparse
 import difflib
@@ -88,7 +95,23 @@ def main():
     ap.add_argument("--track", default=None,
                     help="checkpoint prefix: keep <prefix>.best.c at the lowest "
                          "mismatch count ever seen, so a near-miss is never lost")
+    ap.add_argument("--version", default=M.CANONICAL,
+                    help=f"mwccarm build to compile with (default {M.CANONICAL}). A function "
+                         f"whose cluster reproduces on another build must be measured on that "
+                         f"build -- different builds emit different code, so the default can "
+                         f"silently score the wrong thing.")
+    ap.add_argument("--include-dir", action="append", default=[],
+                    help="additional header search dir, checked before repo include/ "
+                         "(repeatable) -- lets a candidate be scored against a proposed "
+                         "header change without editing the tree")
     a = ap.parse_args()
+
+    # An unknown or uninstalled build must not fall through to compile_c's generic
+    # failure, where it is indistinguishable from a candidate that does not compile.
+    installed = M.installed_versions() if hasattr(M, "installed_versions") else []
+    if installed and a.version not in installed:
+        raise SystemExit(f"fdiff: no compiler '{a.version}' under {M.MW}\n"
+                         f"       installed: {', '.join(installed)}")
 
     target = target_from_args(a)
     src = pathlib.Path(a.c).read_text(encoding="utf-8")
@@ -97,13 +120,14 @@ def main():
     with tempfile.TemporaryDirectory() as td:
         cf = pathlib.Path(td) / ("cand.cpp" if cpp else "cand.c")
         cf.write_text(src, encoding="utf-8")
-        obj = M.compile_c(cf, M.CANONICAL, S.CPP_FLAGS if cpp else M.DEFAULT_FLAGS)
+        obj = M.compile_c(cf, a.version, S.CPP_FLAGS if cpp else M.DEFAULT_FLAGS,
+                          include_dirs=a.include_dir)
     if obj is None:
-        print("RESULT match=False mismatches=compile-error")
+        print(f"RESULT match=False mismatches=compile-error version={a.version}")
         return
     code, relocs = M.extract_func(obj, a.name)
     if code is None:
-        print(f"RESULT match=False mismatches=no-symbol:{a.name}")
+        print(f"RESULT match=False mismatches=no-symbol:{a.name} version={a.version}")
         return
     if a.find_candidate:
         pattern = re.compile(a.find_candidate)
@@ -155,7 +179,7 @@ def main():
     ok, ndiff = M.compare(compare_target, compare_code, relocs,
                           verbose=not a.quiet)
     words = max(len(target), len(code)) // 4
-    print(f"RESULT match={ok} mismatches={ndiff}/{words}")
+    print(f"RESULT match={ok} mismatches={ndiff}/{words} version={a.version}")
 
     if a.track:
         score_p = pathlib.Path(a.track + ".best.score")

--- a/tools/test_fdiff_version.py
+++ b/tools/test_fdiff_version.py
@@ -1,0 +1,67 @@
+"""fdiff must say which compiler it measured with, and let you pick.
+
+It used to compile with match.CANONICAL unconditionally and never report it. Different
+mwccarm builds emit different code for the same source, so a function whose cluster
+reproduces on 1.2/sp2p3 scored under a canonical of 2004/b56 is measured against the
+wrong compiler -- silently, and the number looks perfectly ordinary. Observed on
+MeshCollider::DetectClsn(RaycastLine&): the same candidate is 462 words under 2004/b56
+and 464 under 1.2/sp2p3.
+
+The version-rejection path runs before any compile or ROM read, so most of this needs
+neither a compiler nor an extracted ROM.
+"""
+import pathlib
+import subprocess
+import sys
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOLS))
+
+import match as M  # noqa: E402
+
+
+def _run(*args):
+    return subprocess.run([sys.executable, str(TOOLS / "fdiff.py"), *args],
+                          capture_output=True, text=True)
+
+
+def test_default_version_is_the_canonical_build():
+    """Behaviour is unchanged when --version is omitted."""
+    out = _run("--help").stdout
+    assert "--version" in out
+    assert M.CANONICAL in out, "the help should name the default build"
+
+
+def test_unknown_version_is_refused_with_the_installed_list():
+    """Not silently funnelled into compile_c's generic failure, where it would be
+    indistinguishable from a candidate that does not compile."""
+    r = _run("--c", __file__, "--name", "x", "--target-hex", "00", "--version", "9.9/nope")
+    assert r.returncode != 0
+    combined = r.stdout + r.stderr
+    assert "no compiler" in combined
+    assert "9.9/nope" in combined
+    installed = M.installed_versions() if hasattr(M, "installed_versions") else []
+    if installed:
+        assert installed[0] in combined, "the error should list what IS installed"
+
+
+def test_path_style_module_spelling_is_still_rejected_upstream():
+    """Guard the neighbouring trap: the module ID is `itcm`, not the config path."""
+    r = _run("--c", __file__, "--name", "x", "--module", "arm9/itcm",
+             "--addr", "0x01ffb0fc", "--size", "0x10")
+    assert r.returncode != 0 or "not found" in (r.stdout + r.stderr)
+
+
+def test_include_dir_is_accepted_and_repeatable():
+    out = _run("--help").stdout
+    assert "--include-dir" in out
+
+
+def test_every_result_line_names_the_build():
+    """A pasted RESULT must be self-describing -- that is the whole point."""
+    src = TOOLS / "fdiff.py"
+    text = src.read_text(encoding="utf-8")
+    result_lines = [ln for ln in text.splitlines() if "RESULT match=" in ln and "print" in ln]
+    assert result_lines, "expected RESULT prints in fdiff.py"
+    for ln in result_lines:
+        assert "version=" in ln, f"RESULT line without the build: {ln.strip()}"


### PR DESCRIPTION
`fdiff` compiled with `match.CANONICAL` unconditionally and never reported it.

That's fine while one build is canonical for everything, and quietly wrong the moment it isn't. Different mwccarm builds emit different code for the same source, so a function whose cluster reproduces on `1.2/sp2p3`, scored under a canonical of `2004/b56`, is measured against the wrong compiler. Nothing in the output says so, and the number looks perfectly ordinary.

**Not hypothetical.** On `MeshCollider::DetectClsn(RaycastLine&)` the same candidate is:

```
RESULT match=False mismatches=999/462 version=2004/b56     <- the old silent default
RESULT match=False mismatches=999/464 version=1.2/sp2p3    <- the build that cluster verifies on
```

Iterating with the default silently scored the wrong build. It cost real time before anyone noticed, and the only reason it surfaced is that an agent tripped over the 8-byte size difference.

## Changes

- **`--version`** picks the build, defaulting to `match.CANONICAL` so existing invocations behave identically.
- **Every `RESULT` line now ends `version=<build>`** — including the `compile-error` and `no-symbol` paths — so a pasted or logged result is self-describing. I checked: nothing machine-parses those lines today, and the existing prefix is untouched.
- **An unknown or uninstalled build is refused up front**, listing what *is* installed, instead of falling through to `compile_c`'s generic failure where it's indistinguishable from a candidate that doesn't compile. (Same defect family as the strict-reloc and permuter guards in #992 / #998 — a tool reporting a result it didn't earn.)
- **`--include-dir`**, repeatable, matching `match.py`. `fdiff` was the only oracle without it, so scoring a candidate against a *proposed* header change meant editing the tree or writing a private wrapper — one was written during the `DetectClsn(RaycastGround&)` work for exactly this reason.

## Verification

Five tests, none needing a compiler or an extracted ROM — the version-rejection path runs before any compile or ROM read. **Four of the five fail against the pre-fix file**, verified by stashing it and re-running.

`--include-dir` plumbing confirmed end-to-end against a real match. Suite: **116 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011geKcos2TuNYwHEXV9Ye7d