### PR TITLE
readable: promote SharedFilePtr to a real class

### DIFF
--- a/include/SharedFilePtr.h
+++ b/include/SharedFilePtr.h
@@ -1,0 +1,31 @@
+#ifndef SHAREDFILEPTR_H
+#define SHAREDFILEPTR_H
+
+/* A handle to a file shared between actors: callers hold one, ask it to load, and
+ * release it when the actor is cleaned up.
+ *
+ * Declared as the real class rather than as `extern void _ZN13SharedFilePtr7ReleaseEv(
+ * void *)`, which is how most call sites still reach these. That spelling only works by
+ * accident: in a C translation unit the identifier is emitted verbatim, but a file
+ * compiled as C++ mangles it a SECOND time and emits a reference to
+ * _Z28_ZN13SharedFilePtr7ReleaseEvPv, which nothing defines -- so the file matches and
+ * can never be enrolled into the ROM build. Declaring the member lets the compiler
+ * produce _ZN13SharedFilePtr7ReleaseEv the ordinary way.
+ *
+ * No fields, deliberately. The layout is NOT recovered: files that declare this struct
+ * locally disagree about it -- {int a, file;}, {int data[4];}, {int f0; void *f4;} and
+ * {int h;} all appear -- each sized to whatever pointer arithmetic that file needed.
+ * Committing to one here would silently change the others' indexing, so those files
+ * keep their local declaration and are left out of this change until the real layout
+ * is recovered. Callers converted here only call methods through a pointer.
+ */
+struct SharedFilePtr
+{
+    void Construct(unsigned int fileID);
+    void ReallocateModelFile();
+    void Release();
+    void LoadFile();
+    void Load();
+};
+
+#endif

--- a/src/UnloadKeyModels.cpp
+++ b/src/UnloadKeyModels.cpp
@@ -1,12 +1,12 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
-extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void* data_ov089_02132894[];
 extern void* data_ov089_021328b4[];
 void UnloadKeyModels(int i){
   if(i>=8) return;
-  _ZN13SharedFilePtr7ReleaseEv(data_ov089_02132894[i]);
+  ((SharedFilePtr *)(data_ov089_02132894[i]))->Release();
   if(data_ov089_021328b4[i]==0) return;
-  _ZN13SharedFilePtr7ReleaseEv(data_ov089_021328b4[i]);
+  ((SharedFilePtr *)(data_ov089_021328b4[i]))->Release();
 }
 }

--- a/src/_ZN10BrickBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN10BrickBlock16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BrickBlock.h"
-extern int _ZN13SharedFilePtr7ReleaseEv(void*);
+#include "SharedFilePtr.h"
 extern char data_ov002_0210d9d8[];
 extern char data_ov002_0210da30[];
 extern char data_ov002_0210da18[];
@@ -13,9 +13,9 @@ int BrickBlock::CleanupResources()
 {
   int v = unk_00c;
   switch(v){
-  case 0x141: _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9d8); break;
-  case 0x142: _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da30); break;
-  case 0x143: _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da18); break;
+  case 0x141: ((SharedFilePtr *)(data_ov002_0210d9d8))->Release(); break;
+  case 0x142: ((SharedFilePtr *)(data_ov002_0210da30))->Release(); break;
+  case 0x143: ((SharedFilePtr *)(data_ov002_0210da18))->Release(); break;
   case 0x144: UnloadSilverStarAndNumber(); break;
   }
   return 1;

--- a/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
@@ -2,17 +2,17 @@
 // @symbol _ZN10DonutBlock16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "DonutBlock.h"
+#include "SharedFilePtr.h"
 extern "C" {
 extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern int _ZN16MeshColliderBase7DisableEv(void*);
-extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int* data_ov036_02113d78[];
 }
 
 int DonutBlock::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113d78[0]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113d78[1]);
+  ((SharedFilePtr *)(data_ov036_02113d78[0]))->Release();
+  ((SharedFilePtr *)(data_ov036_02113d78[1]))->Release();
   return 1;
 }

--- a/src/_ZN10KoopaShell16CleanupResourcesEv.cpp
+++ b/src/_ZN10KoopaShell16CleanupResourcesEv.cpp
@@ -1,10 +1,10 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
-int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int data_ov102_0214d70c[];
 int _ZN10KoopaShell16CleanupResourcesEv(char* c){
   unsigned char i=*(unsigned char*)(c+0x3c4);
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov102_0214d70c[i]);
+  ((SharedFilePtr *)((void*)data_ov102_0214d70c[i]))->Release();
   return 1;
 }
 }

--- a/src/_ZN10PyramidTop16CleanupResourcesEv.cpp
+++ b/src/_ZN10PyramidTop16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidTop.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov024_02113968[];
 
 int PyramidTop::CleanupResources()
 {
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov024_02113968);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov024_02113960);
+    ((SharedFilePtr *)(data_ov024_02113968))->Release();
+    ((SharedFilePtr *)(data_ov024_02113960))->Release();
     return 1;
 }

--- a/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
+++ b/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
@@ -2,8 +2,8 @@
 // @symbol _ZN10SlidingIce16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingIce.h"
+#include "SharedFilePtr.h"
 extern "C" void _ZN16MeshColliderBase7DisableEv(char*);
-extern "C" void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern char func_ov030_02113be8[];
 extern char data_ov027_02113be0[];
 
@@ -11,7 +11,7 @@ int SlidingIce::CleanupResources()
 {
   unsigned char ok = (mActorID==0x5d);
   if(ok){ _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider); }
-  _ZN13SharedFilePtr7ReleaseEv(func_ov030_02113be8);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov027_02113be0);
+  ((SharedFilePtr *)(func_ov030_02113be8))->Release();
+  ((SharedFilePtr *)(data_ov027_02113be0))->Release();
   return 1;
 }

--- a/src/_ZN10StarMarker16CleanupResourcesEv.cpp
+++ b/src/_ZN10StarMarker16CleanupResourcesEv.cpp
@@ -4,17 +4,17 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "StarMarker.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
+#include "SharedFilePtr.h"
 extern char data_ov002_0211092c;
 extern char data_ov002_0210d9a8;
 
 int StarMarker::CleanupResources()
 {
     if (mState != 0) {
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0211092c);
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210d9a8);
+        ((SharedFilePtr *)(&data_ov002_0211092c))->Release();
+        ((SharedFilePtr *)(&data_ov002_0210d9a8))->Release();
     } else {
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0211093c);
+        ((SharedFilePtr *)(&data_ov002_0211093c))->Release();
     }
     return 1;
 }

--- a/src/_ZN10StarSwitch16CleanupResourcesEv.cpp
+++ b/src/_ZN10StarSwitch16CleanupResourcesEv.cpp
@@ -2,12 +2,12 @@
 // @symbol _ZN10StarSwitch16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "StarSwitch.h"
+#include "SharedFilePtr.h"
 // _ZN10StarSwitch16CleanupResourcesEv at 0x020ba568
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 void _ZN16MeshColliderBase7DisableEv(void*);
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 void UnloadSilverStarAndNumber(void);
 }
 
@@ -21,12 +21,12 @@ int StarSwitch::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(&data_ov002_021098e8 + unk_34c * 0xc));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(&data_ov002_021098ec + unk_34c * 0xc));
+    ((SharedFilePtr *)(*(void**)(&data_ov002_021098e8 + unk_34c * 0xc)))->Release();
+    ((SharedFilePtr *)(*(void**)(&data_ov002_021098ec + unk_34c * 0xc)))->Release();
     t = mActorID == 0xc;
     if (t != false) {
         UnloadSilverStarAndNumber();
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0211092c);
+        ((SharedFilePtr *)(&data_ov002_0211092c))->Release();
     }
     return 1;
 }

--- a/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
+++ b/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CannonHatch.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int CannonHatch::CleanupResources()
@@ -12,7 +12,7 @@ int CannonHatch::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN11CastleWater16CleanupResourcesEv.cpp
+++ b/src/_ZN11CastleWater16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CastleWater.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int CastleWater::CleanupResources()
@@ -12,7 +12,7 @@ int CastleWater::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN11ChiefChilly16CleanupResourcesEv.cpp
+++ b/src/_ZN11ChiefChilly16CleanupResourcesEv.cpp
@@ -1,7 +1,7 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern void UnloadKeyModels(int i);
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void* data_ov073_02123280;
 extern void* data_ov073_021232a0;
 extern void* data_ov073_02123288;
@@ -14,15 +14,15 @@ extern void* data_ov073_02123298;
 
 int _ZN11ChiefChilly16CleanupResourcesEv(void){
   UnloadKeyModels(4);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_02123280);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_021232a0);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_02123288);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_021232a8);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_02123290);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_021232b0);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_021232b8);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da30);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov073_02123298);
+  ((SharedFilePtr *)(&data_ov073_02123280))->Release();
+  ((SharedFilePtr *)(&data_ov073_021232a0))->Release();
+  ((SharedFilePtr *)(&data_ov073_02123288))->Release();
+  ((SharedFilePtr *)(&data_ov073_021232a8))->Release();
+  ((SharedFilePtr *)(&data_ov073_02123290))->Release();
+  ((SharedFilePtr *)(&data_ov073_021232b0))->Release();
+  ((SharedFilePtr *)(&data_ov073_021232b8))->Release();
+  ((SharedFilePtr *)(&data_ov002_0210da30))->Release();
+  ((SharedFilePtr *)(&data_ov073_02123298))->Release();
   return 1;
 }
 }

--- a/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
+++ b/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidStep.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int PyramidStep::CleanupResources()
 {
     _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN12FortressWall16CleanupResourcesEv.cpp
+++ b/src/_ZN12FortressWall16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FortressWall.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern char data_ov079_02128058[];
 extern char data_ov079_0212805c[];
 
@@ -12,7 +12,7 @@ int FortressWall::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov079_02128058 + (unsigned char)((char *)this)[0x31e]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov079_0212805c + (unsigned char)((char *)this)[0x31e]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov079_02128058 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov079_0212805c + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp
+++ b/src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp
@@ -2,8 +2,8 @@
 // @symbol _ZN12PiranhaPlant16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "PiranhaPlant.h"
+#include "SharedFilePtr.h"
 extern "C" {
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void UnloadBlueCoinModel(void*);
 extern int data_ov084_02130dfc;
 extern int* data_ov084_021302f4;
@@ -13,11 +13,11 @@ extern int data_ov002_0210da38;
 int PiranhaPlant::CleanupResources()
 {
   int i;
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130dfc);
+  ((SharedFilePtr *)(&data_ov084_02130dfc))->Release();
   for(i=0;i<6;i++){
-    _ZN13SharedFilePtr7ReleaseEv((&data_ov084_021302f4)[i]);
+    ((SharedFilePtr *)((&data_ov084_021302f4)[i]))->Release();
   }
   UnloadBlueCoinModel(((void*)this));
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
+  ((SharedFilePtr *)(&data_ov002_0210da38))->Release();
   return 1;
 }

--- a/src/_ZN12SwitchPillar16CleanupResourcesEv.cpp
+++ b/src/_ZN12SwitchPillar16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SwitchPillar.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov012_021124d0[];
 
 int SwitchPillar::CleanupResources()
@@ -12,7 +12,7 @@ int SwitchPillar::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov012_021124d0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov012_021124c8);
+    ((SharedFilePtr *)(data_ov012_021124d0))->Release();
+    ((SharedFilePtr *)(data_ov012_021124c8))->Release();
     return 1;
 }

--- a/src/_ZN12WorkElevator16CleanupResourcesEv.cpp
+++ b/src/_ZN12WorkElevator16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "WorkElevator.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov021_021149b8[];
 
 int WorkElevator::CleanupResources()
@@ -17,9 +17,9 @@ int WorkElevator::CleanupResources()
         _ZN16MeshColliderBase7DisableEv(p);
         p += 0x1c8;
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov021_021149b0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov021_021149b8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov021_021149a0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov021_021149a8);
+    ((SharedFilePtr *)(data_ov021_021149b0))->Release();
+    ((SharedFilePtr *)(data_ov021_021149b8))->Release();
+    ((SharedFilePtr *)(data_ov021_021149a0))->Release();
+    ((SharedFilePtr *)(data_ov021_021149a8))->Release();
     return 1;
 }

--- a/src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBrickBlock.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern char data_ov002_02108ab0[];
 extern char data_ov002_02108ab4[];
 
@@ -12,7 +12,7 @@ int BigBrickBlock::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov002_02108ab0 + (unsigned char)((char *)this)[0x32c]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov002_02108ab4 + (unsigned char)((char *)this)[0x32c]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov002_02108ab0 + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov002_02108ab4 + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN13FortressTower16CleanupResourcesEv.cpp
+++ b/src/_ZN13FortressTower16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FortressTower.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern char data_ov102_0214e188[];
 extern char data_ov102_0214e18c[];
 
@@ -12,7 +12,7 @@ int FortressTower::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov102_0214e188 + (unsigned char)((char *)this)[0x31e]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov102_0214e18c + (unsigned char)((char *)this)[0x31e]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov102_0214e188 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov102_0214e18c + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN13OneUpMushroom16CleanupResourcesEv.cpp
+++ b/src/_ZN13OneUpMushroom16CleanupResourcesEv.cpp
@@ -2,8 +2,8 @@
 // @symbol _ZN13OneUpMushroom16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "OneUpMushroom.h"
+#include "SharedFilePtr.h"
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void* fp);
 void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 }
 extern void* data_ov002_0210d9d8;
@@ -14,8 +14,8 @@ int OneUpMushroom::CleanupResources()
   int s = mMushroomType;
   if (s != 0xb && s != 0xc){
     int b = (mActorID == 0x114);
-    if (b != 0) _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210d9d8);
-    else _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da30);
+    if (b != 0) ((SharedFilePtr *)(&data_ov002_0210d9d8))->Release();
+    else ((SharedFilePtr *)(&data_ov002_0210da30))->Release();
   }
   if ((unsigned int)(mMushroomType - 0xb) <= 1)
     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd2, mPosX, mPosY + 0x28000, mPosZ);

--- a/src/_ZN13PoleBillboard16CleanupResourcesEv.cpp
+++ b/src/_ZN13PoleBillboard16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PoleBillboard.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int PoleBillboard::CleanupResources()
@@ -12,7 +12,7 @@ int PoleBillboard::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN13QuestionBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN13QuestionBlock16CleanupResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionBlock.h"
+#include "SharedFilePtr.h"
 extern "C" {
-extern void _ZN13SharedFilePtr7ReleaseEv(void *p);
 extern void _ZN5Actor11UntrackStarERa(void *self, void *p);
 }
 extern char data_ov002_0210da58[];
@@ -30,7 +30,7 @@ int QuestionBlock::CleanupResources()
 
     b = (int)(mActorId == 0x16);
     if (b)
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da58);
+        ((SharedFilePtr *)(data_ov002_0210da58))->Release();
 
     b2 = (int)(mActorId == 0x14);
     if (b2)
@@ -43,57 +43,57 @@ int QuestionBlock::CleanupResources()
             _ZN5Actor11UntrackStarERa(((char *)this), ((char *)this) + 0x3f0);
             break;
         case 3:
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da18);
+            ((SharedFilePtr *)(data_ov002_0210da18))->Release();
             break;
         case 2:
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9d8);
+            ((SharedFilePtr *)(data_ov002_0210d9d8))->Release();
             break;
         case 4:
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da30);
+            ((SharedFilePtr *)(data_ov002_0210da30))->Release();
             break;
         case 7:
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9b0);
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9d0);
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e0);
+            ((SharedFilePtr *)(data_ov002_0210d9b0))->Release();
+            ((SharedFilePtr *)(data_ov002_0210d9d0))->Release();
+            ((SharedFilePtr *)(data_ov002_0210d9e0))->Release();
             break;
         case 5:
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da58);
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9b0);
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9d0);
+            ((SharedFilePtr *)(data_ov002_0210da58))->Release();
+            ((SharedFilePtr *)(data_ov002_0210d9b0))->Release();
+            ((SharedFilePtr *)(data_ov002_0210d9d0))->Release();
             break;
         case 6:
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9b0);
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9d0);
+            ((SharedFilePtr *)(data_ov002_0210d9b0))->Release();
+            ((SharedFilePtr *)(data_ov002_0210d9d0))->Release();
             break;
         }
     }
 
     switch (mActorId - 0x14) {
     case 0:
-        _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e7e8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e808);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e7f8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e0);
+        ((SharedFilePtr *)(data_ov102_0214e7e8))->Release();
+        ((SharedFilePtr *)(data_ov102_0214e808))->Release();
+        ((SharedFilePtr *)(data_ov102_0214e7f8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9e0))->Release();
         break;
     case 1:
     case 2:
-        _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e800);
+        ((SharedFilePtr *)(data_ov102_0214e800))->Release();
         break;
     case 3:
-        _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e7f0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da40);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e0);
+        ((SharedFilePtr *)(data_ov102_0214e7f0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210da40))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9e0))->Release();
         break;
     case 5:
-        _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e7d8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9a0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e0);
+        ((SharedFilePtr *)(data_ov102_0214e7d8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9a0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9e0))->Release();
         break;
     case 4:
-        _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e7e0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9c0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e0);
+        ((SharedFilePtr *)(data_ov102_0214e7e0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9c0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9e0))->Release();
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e7d0);
+    ((SharedFilePtr *)(data_ov102_0214e7d0))->Release();
     return 1;
 }

--- a/src/_ZN13TTC_MovingBar16CleanupResourcesEv.cpp
+++ b/src/_ZN13TTC_MovingBar16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TTC_MovingBar.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 
 int TTC_MovingBar::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov065_0211d35c + (unsigned char)((char *)this)[0x31e]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov065_0211d360 + (unsigned char)((char *)this)[0x31e]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov065_0211d35c + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov065_0211d360 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
+++ b/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "UpDownLiftBbh.h"
+#include "SharedFilePtr.h"
 extern "C" {
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void* data_ov095_02136f68[];
 extern void* data_ov095_02136f74[];
 }
@@ -14,7 +14,7 @@ int UpDownLiftBbh::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f68[*(int*)((char*)&mVariant)]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f74[*(int*)((char*)&mVariant)]);
+  ((SharedFilePtr *)(data_ov095_02136f68[*(int*)((char*)&mVariant)]))->Release();
+  ((SharedFilePtr *)(data_ov095_02136f74[*(int*)((char*)&mVariant)]))->Release();
   return 1;
 }

--- a/src/_ZN13WaterfallMist16CleanupResourcesEv.cpp
+++ b/src/_ZN13WaterfallMist16CleanupResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "WaterfallMist.h"
+#include "SharedFilePtr.h"
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void* fp);
 }
 extern void* data_ov002_0210de50;
 extern void* data_ov002_0210de60;
@@ -25,28 +25,28 @@ int WaterfallMist::CleanupResources()
 {
   int i = mModelIndex;
   if (i >= 3) return 1;
-  _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff0ac[i]);
+  ((SharedFilePtr *)(data_ov002_020ff0ac[i]))->Release();
   switch (mType) {
   case 0xf:
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de50);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de60);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de48);
+    ((SharedFilePtr *)(&data_ov002_0210de50))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de60))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de48))->Release();
     break;
   case 0x14:
   case 0x15:
   case 0x16:
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de28);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de08);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de20);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de40);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de10);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de00);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de58);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de18);
+    ((SharedFilePtr *)(&data_ov002_0210de28))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de08))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de20))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de40))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de10))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de00))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de58))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de18))->Release();
     break;
   default:
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de30);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de38);
+    ((SharedFilePtr *)(&data_ov002_0210de30))->Release();
+    ((SharedFilePtr *)(&data_ov002_0210de38))->Release();
     break;
   }
   return 1;

--- a/src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp
+++ b/src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp
@@ -4,14 +4,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ArrowSignRight.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern char data_ov098_0213c380[];
 
 int ArrowSignRight::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov098_0213c380 + (unsigned char)((char *)this)[0x37c]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov098_0213c384 + (unsigned char)((char *)this)[0x37c]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov098_0213c380 + (unsigned char)((char *)this)[0x37c]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov098_0213c384 + (unsigned char)((char *)this)[0x37c]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp
+++ b/src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp
@@ -4,14 +4,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "KnockDownPlank.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern char data_ov015_02114534[];
 
 int KnockDownPlank::CleanupResources()
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-    _ZN13SharedFilePtr7ReleaseEv(*(void **)(data_ov015_02114534 + mVariant * 0xc));
-    _ZN13SharedFilePtr7ReleaseEv(*(void **)(data_ov015_02114538 + mVariant * 0xc));
+    ((SharedFilePtr *)(*(void **)(data_ov015_02114534 + mVariant * 0xc)))->Release();
+    ((SharedFilePtr *)(*(void **)(data_ov015_02114538 + mVariant * 0xc)))->Release();
     return 1;
 }

--- a/src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MovingBarSmall.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int MovingBarSmall::CleanupResources()
@@ -12,7 +12,7 @@ int MovingBarSmall::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp
+++ b/src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionSwitch.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov002_0210dd60[];
 extern int data_ov002_0210dd68[];
 extern int data_ov002_0210dd58[];
@@ -14,9 +14,9 @@ int QuestionSwitch::CleanupResources()
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&unk_324)) _ZN16MeshColliderBase7DisableEv((char *)&unk_324);
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210dd60);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210dd68);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210dd58);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210dd50);
+    ((SharedFilePtr *)(data_ov002_0210dd60))->Release();
+    ((SharedFilePtr *)(data_ov002_0210dd68))->Release();
+    ((SharedFilePtr *)(data_ov002_0210dd58))->Release();
+    ((SharedFilePtr *)(data_ov002_0210dd50))->Release();
     return 1;
 }

--- a/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
+++ b/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
@@ -2,19 +2,19 @@
 // @symbol _ZN14SquarePathLift16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "SquarePathLift.h"
+#include "SharedFilePtr.h"
 extern "C" {
 struct SFP{int x;};
 extern SFP data_ov052_021125a0[2];
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 void _ZN16MeshColliderBase7DisableEv(void*);
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 }
 
 int SquarePathLift::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov052_021125a0[0].x);
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov052_021125a0[1].x);
+  ((SharedFilePtr *)((void*)data_ov052_021125a0[0].x))->Release();
+  ((SharedFilePtr *)((void*)data_ov052_021125a0[1].x))->Release();
   return 1;
 }

--- a/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
+++ b/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcMovingCubeA.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int TtcMovingCubeA::CleanupResources()
@@ -12,7 +12,7 @@ int TtcMovingCubeA::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN14UnknownVsEntry16CleanupResourcesEv.cpp
+++ b/src/_ZN14UnknownVsEntry16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "UnknownVsEntry.h"
-extern int _ZN13SharedFilePtr7ReleaseEv(void*);
+#include "SharedFilePtr.h"
 extern char data_ov075_0211d404[];
 extern char data_ov075_0211d3c4[];
 extern char data_ov075_0211d414[];
@@ -31,32 +31,32 @@ extern char data_ov075_0211d3e4[];
 int UnknownVsEntry::CleanupResources()
 {
     CleanCommonModelDataArr();
-    _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d404);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3c4);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d414);
+    ((SharedFilePtr *)(data_ov075_0211d404))->Release();
+    ((SharedFilePtr *)(data_ov075_0211d3c4))->Release();
+    ((SharedFilePtr *)(data_ov075_0211d414))->Release();
     if (*(int*)((char*)&mParam) != 1) {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d394);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3cc);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d39c);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3d4);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3a4);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3ec);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d384);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d424);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d42c);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d41c);
+        ((SharedFilePtr *)(data_ov075_0211d394))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3cc))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d39c))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3d4))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3a4))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3ec))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d384))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d424))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d42c))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d41c))->Release();
     } else {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3ac);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3b4);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3f4);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d38c);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3dc);
+        ((SharedFilePtr *)(data_ov075_0211d3ac))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3b4))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3f4))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d38c))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3dc))->Release();
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d40c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3fc);
+    ((SharedFilePtr *)(data_ov075_0211d40c))->Release();
+    ((SharedFilePtr *)(data_ov075_0211d3fc))->Release();
     if (*(int*)((char*)&mParam) != 1) {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3bc);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov075_0211d3e4);
+        ((SharedFilePtr *)(data_ov075_0211d3bc))->Release();
+        ((SharedFilePtr *)(data_ov075_0211d3e4))->Release();
     }
     func_ov075_0211b3b8((char*)&unk_e80);
     return 1;

--- a/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
+++ b/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ChainChompFence.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int ChainChompFence::CleanupResources()
@@ -12,7 +12,7 @@ int ChainChompFence::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FireSeaElevator.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov045_021131b0[];
 
 int FireSeaElevator::CleanupResources()
 {
     _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov045_021131b0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov045_021131a8);
+    ((SharedFilePtr *)(data_ov045_021131b0))->Release();
+    ((SharedFilePtr *)(data_ov045_021131a8))->Release();
     return 1;
 }

--- a/src/_ZN15InvisibleSecret16CleanupResourcesEv.cpp
+++ b/src/_ZN15InvisibleSecret16CleanupResourcesEv.cpp
@@ -2,22 +2,22 @@
 // @symbol _ZN15InvisibleSecret16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "InvisibleSecret.h"
+#include "SharedFilePtr.h"
 extern "C" {
 extern int data_ov002_0210da28[];
 extern int data_ov002_0210da08[];
 extern int data_ov002_0210d9a8[];
 extern int data_ov002_0210d9e8[];
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 }
 
 int InvisibleSecret::CleanupResources()
 {
   if(mParam & 0x10){
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da28);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da08);
+    ((SharedFilePtr *)(data_ov002_0210da28))->Release();
+    ((SharedFilePtr *)(data_ov002_0210da08))->Release();
   } else {
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9a8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e8);
+    ((SharedFilePtr *)(data_ov002_0210d9a8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210d9e8))->Release();
   }
   return 1;
 }

--- a/src/_ZN15RollingIronBall16CleanupResourcesEv.cpp
+++ b/src/_ZN15RollingIronBall16CleanupResourcesEv.cpp
@@ -2,7 +2,7 @@
 // @symbol _ZN15RollingIronBall16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RollingIronBall.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *self);
+#include "SharedFilePtr.h"
 extern char data_ov100_02148668;
 
 int RollingIronBall::CleanupResources()
@@ -13,6 +13,6 @@ int RollingIronBall::CleanupResources()
         (*(unsigned char *)(((int)file + 0x3d2)))--;
     }
 
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov100_02148668);
+    ((SharedFilePtr *)(&data_ov100_02148668))->Release();
     return 1;
 }

--- a/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
+++ b/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
@@ -2,10 +2,10 @@
 // @symbol _ZN15RotatingFirebar16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingFirebar.h"
+#include "SharedFilePtr.h"
 extern "C" {
 int _ZN16MeshColliderBase9IsEnabledEv(void* self);
 void _ZN16MeshColliderBase7DisableEv(void* self);
-void _ZN13SharedFilePtr7ReleaseEv(void* self);
 extern int data_ov064_0211adbc[];
 }
 
@@ -13,7 +13,7 @@ int RotatingFirebar::CleanupResources()
 {
   if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov064_0211adbc[0]);
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov064_0211adbc[1]);
+  ((SharedFilePtr *)((void*)data_ov064_0211adbc[0]))->Release();
+  ((SharedFilePtr *)((void*)data_ov064_0211adbc[1]))->Release();
   return 1;
 }

--- a/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void* self);
+#include "SharedFilePtr.h"
 struct E { void* p; char pad[8]; };
 extern struct E data_ov065_0211cfd0[];
 extern struct E data_ov065_0211cfd4[];
@@ -14,8 +14,8 @@ int TtcRotatingCube::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMovingMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char*)&mMovingMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov065_0211c0a8[unk_377]);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov065_0211cfd0[unk_377].p);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov065_0211cfd4[unk_377].p);
+    ((SharedFilePtr *)(data_ov065_0211c0a8[unk_377]))->Release();
+    ((SharedFilePtr *)(data_ov065_0211cfd0[unk_377].p))->Release();
+    ((SharedFilePtr *)(data_ov065_0211cfd4[unk_377].p))->Release();
     return 1;
 }

--- a/src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingGear.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int TtcRotatingGear::CleanupResources()
@@ -12,7 +12,7 @@ int TtcRotatingGear::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingCogSmall.h"
+#include "SharedFilePtr.h"
 extern "C" {
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern char data_ov035_02112c78[];
 extern char data_ov035_02112c70[];
 extern char data_ov035_02112c60[];
@@ -16,14 +16,14 @@ int RotatingCogSmall::CleanupResources()
   if(mRotationState==0){
     if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider))
       _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c78);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov056_02112c68);
+    ((SharedFilePtr *)(data_ov035_02112c78))->Release();
+    ((SharedFilePtr *)(data_ov056_02112c68))->Release();
   } else {
     int on = (unk_00c==0x79);
     if(on)
-      _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c70);
+      ((SharedFilePtr *)(data_ov035_02112c70))->Release();
     else
-      _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c60);
+      ((SharedFilePtr *)(data_ov035_02112c60))->Release();
   }
   return 1;
 }

--- a/src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp
+++ b/src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingClockHand.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int RotatingClockHand::CleanupResources()
@@ -12,7 +12,7 @@ int RotatingClockHand::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp
+++ b/src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingPlatformWf.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 
 int SlidingPlatformWf::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov091_02135024 + (unsigned char)((char *)this)[0x322]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov091_02135028 + (unsigned char)((char *)this)[0x322]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov091_02135024 + (unsigned char)((char *)this)[0x322]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov091_02135028 + (unsigned char)((char *)this)[0x322]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp
+++ b/src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BowserFireSeaArena.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int BowserFireSeaArena::CleanupResources()
@@ -12,7 +12,7 @@ int BowserFireSeaArena::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider2)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider2);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
+++ b/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BowserPuzzleManager.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern void *data_ov064_0211adc8[];
 
 int BowserPuzzleManager::CleanupResources()
@@ -12,7 +12,7 @@ int BowserPuzzleManager::CleanupResources()
     unsigned char idx;
     _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     idx = *(unsigned char *)((char *)&unk_337);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov064_0211adc8[idx]);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov075_0211c800);
+    ((SharedFilePtr *)(data_ov064_0211adc8[idx]))->Release();
+    ((SharedFilePtr *)(&data_ov075_0211c800))->Release();
     return 1;
 }

--- a/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FirePiranhaPlantBig.h"
+#include "SharedFilePtr.h"
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 void UnloadBlueCoinModel(void*);
 extern int data_ov084_02130dfc;
 extern int data_ov002_0210da38;
@@ -13,11 +13,11 @@ extern int data_ov002_0210da38;
 
 int FirePiranhaPlantBig::CleanupResources()
 {
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130dfc);
+  ((SharedFilePtr *)(&data_ov084_02130dfc))->Release();
   for (int i = 0; i < 6; i++) {
-    _ZN13SharedFilePtr7ReleaseEv(data_ov085_021302f4[i]);
+    ((SharedFilePtr *)(data_ov085_021302f4[i]))->Release();
   }
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
+  ((SharedFilePtr *)(&data_ov002_0210da38))->Release();
   UnloadBlueCoinModel(((void *)this));
   return 1;
 }

--- a/src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp
+++ b/src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FloatingFloorLllBig.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int FloatingFloorLllBig::CleanupResources()
@@ -12,7 +12,7 @@ int FloatingFloorLllBig::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformLll.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov022_02114558[];
 
 int RotatingPlatformLll::CleanupResources()
@@ -12,7 +12,7 @@ int RotatingPlatformLll::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov022_02114558);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov022_02114550);
+    ((SharedFilePtr *)(data_ov022_02114558))->Release();
+    ((SharedFilePtr *)(data_ov022_02114550))->Release();
     return 1;
 }

--- a/src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int RotatingPlatformWdw::CleanupResources()
@@ -12,7 +12,7 @@ int RotatingPlatformWdw::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SwitchActivatedPlank.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int SwitchActivatedPlank::CleanupResources()
@@ -12,7 +12,7 @@ int SwitchActivatedPlank::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcConveyorBeltLarge.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern char data_ov065_0211d194[];
 extern char data_ov065_0211d198[];
 
@@ -12,7 +12,7 @@ int TtcConveyorBeltLarge::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov065_0211d194 + (unsigned char)((char *)this)[0x39e]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov065_0211d198 + (unsigned char)((char *)this)[0x39e]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov065_0211d194 + (unsigned char)((char *)this)[0x39e]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov065_0211d198 + (unsigned char)((char *)this)[0x39e]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
@@ -2,8 +2,8 @@
 // @symbol _ZN22RotatingUpDownPlatform16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatform.h"
+#include "SharedFilePtr.h"
 extern "C" {
-extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int _ZN16MeshColliderBase7DisableEv(void*);
 extern void* data_ov091_021344fc[];
 extern void* data_ov091_021344f4[];
@@ -11,8 +11,8 @@ extern void* data_ov091_021344f4[];
 
 int RotatingUpDownPlatform::CleanupResources()
 {
-  _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344fc[mVariant]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344f4[mVariant]);
+  ((SharedFilePtr *)(data_ov091_021344fc[mVariant]))->Release();
+  ((SharedFilePtr *)(data_ov091_021344f4[mVariant]))->Release();
   _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
   return 1;
 }

--- a/src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp
+++ b/src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnWaterPlatformJrb.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov016_02114e74[];
 
 int FloatOnWaterPlatformJrb::CleanupResources()
@@ -12,7 +12,7 @@ int FloatOnWaterPlatformJrb::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov016_02114e74);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov016_02114e6c);
+    ((SharedFilePtr *)(data_ov016_02114e74))->Release();
+    ((SharedFilePtr *)(data_ov016_02114e6c))->Release();
     return 1;
 }

--- a/src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatformUtm.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 struct SFP { void *a, *b, *c; };
 extern struct SFP data_ov091_02134c30[];
 extern struct SFP data_ov091_02134c34[];
@@ -14,7 +14,7 @@ int RotatingUpDownPlatformUtm::CleanupResources()
   if(mSpawnParam == 0xffff) return 1;
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov091_02134c30[mVariant].a);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov091_02134c34[mVariant].a);
+  ((SharedFilePtr *)(data_ov091_02134c30[mVariant].a))->Release();
+  ((SharedFilePtr *)(data_ov091_02134c34[mVariant].a))->Release();
   return 1;
 }

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnWaterPlatformWdwSquare.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int FloatOnWaterPlatformWdwSquare::CleanupResources()
@@ -12,7 +12,7 @@ int FloatOnWaterPlatformWdwSquare::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN3Key16CleanupResourcesEv.cpp
+++ b/src/_ZN3Key16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Key.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *self);
+#include "SharedFilePtr.h"
 extern void _ZN5Event8ClearBitEj(unsigned int b);
 extern int data_ov002_02110964[];
 extern int data_ov089_02132c60[];
@@ -15,12 +15,12 @@ extern int data_ov089_02132c48[];
 int Key::CleanupResources()
 {
     UnloadKeyModels(*(int *)((char *)&mState));
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_02110964);
+    ((SharedFilePtr *)(data_ov002_02110964))->Release();
     if (*(int *)((char *)&mState) != 7) {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov089_02132c60);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov089_02132c40);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov089_02132c70);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov089_02132c48);
+        ((SharedFilePtr *)(data_ov089_02132c60))->Release();
+        ((SharedFilePtr *)(data_ov089_02132c40))->Release();
+        ((SharedFilePtr *)(data_ov089_02132c70))->Release();
+        ((SharedFilePtr *)(data_ov089_02132c48))->Release();
     }
     _ZN5Event8ClearBitEj(0x1d);
     return 1;

--- a/src/_ZN3MrI16CleanupResourcesEv.cpp
+++ b/src/_ZN3MrI16CleanupResourcesEv.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void *);
 void UnloadBlueCoinModel(void);
 extern int data_ov002_0210da38;
 extern int data_ov071_02123050;
@@ -9,12 +9,12 @@ extern void* data_ov071_021226a0;
 int _ZN3MrI16CleanupResourcesEv(void){
   int i;
   UnloadBlueCoinModel();
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov071_02123050);
+  ((SharedFilePtr *)(&data_ov002_0210da38))->Release();
+  ((SharedFilePtr *)(&data_ov071_02123050))->Release();
   for(i=0;i<2;i++){
-    _ZN13SharedFilePtr7ReleaseEv((&data_ov071_021226a4)[i]);
+    ((SharedFilePtr *)((&data_ov071_021226a4)[i]))->Release();
   }
-  _ZN13SharedFilePtr7ReleaseEv(data_ov071_021226a0);
+  ((SharedFilePtr *)(data_ov071_021226a0))->Release();
   return 1;
 }
 }

--- a/src/_ZN4Toad16CleanupResourcesEv.cpp
+++ b/src/_ZN4Toad16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Toad.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *self);
+#include "SharedFilePtr.h"
 extern int data_ov002_0210da40[];
 extern int data_ov002_0210d9a0[];
 extern int data_ov002_0210d9c0[];
@@ -13,12 +13,12 @@ extern int data_ov085_02130480[];
 int Toad::CleanupResources()
 {
     if (*(unsigned char *)((char *)&unk_20b) == 1) {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da40);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9a0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9c0);
+        ((SharedFilePtr *)(data_ov002_0210da40))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9a0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210d9c0))->Release();
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov085_02130480);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov085_02130488);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov085_02130490);
+    ((SharedFilePtr *)(data_ov085_02130480))->Release();
+    ((SharedFilePtr *)(data_ov085_02130488))->Release();
+    ((SharedFilePtr *)(data_ov085_02130490))->Release();
     return 1;
 }

--- a/src/_ZN5Bully16CleanupResourcesEv.cpp
+++ b/src/_ZN5Bully16CleanupResourcesEv.cpp
@@ -2,16 +2,16 @@
 // @symbol _ZN5Bully16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Bully.h"
+#include "SharedFilePtr.h"
 extern "C" {
-int _ZN13SharedFilePtr7ReleaseEv(void *);
 }
 
 int Bully::CleanupResources()
 {
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+0));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+4));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+8));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+0xc));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+0x10));
+    ((SharedFilePtr *)(*(void**)(*(char**)((char *)&mFileTable)+0)))->Release();
+    ((SharedFilePtr *)(*(void**)(*(char**)((char *)&mFileTable)+4)))->Release();
+    ((SharedFilePtr *)(*(void**)(*(char**)((char *)&mFileTable)+8)))->Release();
+    ((SharedFilePtr *)(*(void**)(*(char**)((char *)&mFileTable)+0xc)))->Release();
+    ((SharedFilePtr *)(*(void**)(*(char**)((char *)&mFileTable)+0x10)))->Release();
     return 1;
 }

--- a/src/_ZN5Crate16CleanupResourcesEv.cpp
+++ b/src/_ZN5Crate16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Crate.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov098_0213c4c8[];
 
 int Crate::CleanupResources()
@@ -15,8 +15,8 @@ int Crate::CleanupResources()
   f = 0;
   if(mActorID == 0xc2) f = data_ov098_0213c4c8;
   if(f){
-    _ZN13SharedFilePtr7ReleaseEv((void*)f[0]);
-    _ZN13SharedFilePtr7ReleaseEv((void*)f[1]);
+    ((SharedFilePtr *)((void*)f[0]))->Release();
+    ((SharedFilePtr *)((void*)f[1]))->Release();
   }
   return 1;
 }

--- a/src/_ZN5Pokey16CleanupResourcesEv.cpp
+++ b/src/_ZN5Pokey16CleanupResourcesEv.cpp
@@ -2,8 +2,8 @@
 // @symbol _ZN5Pokey16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Pokey.h"
+#include "SharedFilePtr.h"
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void *);
 void UnloadBlueCoinModel(void *);
 extern int data_ov096_02137b20[];
 extern int data_ov096_02137b28[];
@@ -15,12 +15,12 @@ int Pokey::CleanupResources()
   int a = (id == 0xf0);
   if (a) {
     UnloadBlueCoinModel(((char *)this));
-    _ZN13SharedFilePtr7ReleaseEv(data_ov096_02137b20);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov096_02137b28);
+    ((SharedFilePtr *)(data_ov096_02137b20))->Release();
+    ((SharedFilePtr *)(data_ov096_02137b28))->Release();
   } else {
     a = (id == 0xf1);
     if (a) {
-      _ZN13SharedFilePtr7ReleaseEv(data_ov096_02137b28);
+      ((SharedFilePtr *)(data_ov096_02137b28))->Release();
     }
   }
   return 1;

--- a/src/_ZN5Stage16CleanupResourcesEv.cpp
+++ b/src/_ZN5Stage16CleanupResourcesEv.cpp
@@ -3,6 +3,7 @@
 // @symbol _ZN5Stage16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
+#include "SharedFilePtr.h"
 /* _ZN5Stage16CleanupResourcesEv @ 0x0202c9a8 (arm9, size 0x264)
  * Releases the level file handles, tears down fader/mesh-collider/message
  * state and unloads the level overlays/archive. Returns 1.
@@ -26,7 +27,6 @@ extern u8 data_0209f244;
 extern u8 data_0209f2b0;
 extern u8 data_0209f20c;
 
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern void _ZN5Sound21ResetPlayerVoiceGroupEv(void);
 extern void EndKuppaScript(void);
 extern void _ZN6Memory16operator_delete2EPv(void *);
@@ -55,7 +55,7 @@ int Stage::CleanupResources()
     u32 i;
 
     for (i = 0; i < 12; i++)
-        _ZN13SharedFilePtr7ReleaseEv(data_020756f0[i]);
+        ((SharedFilePtr *)(data_020756f0[i]))->Release();
 
     {
         int atEnd = (data_0209f2d8 == 2);

--- a/src/_ZN5Whomp16CleanupResourcesEv.cpp
+++ b/src/_ZN5Whomp16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Whomp.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern void data_ov079_02128168(void);
 extern void data_ov079_02128178(void);
 extern void data_ov079_02128170(void);
@@ -15,16 +15,16 @@ int Whomp::CleanupResources()
   int i;
   if(_ZN16MeshColliderBase9IsEnabledEv((unsigned char *)&mMovingMeshCollider))
     _ZN16MeshColliderBase7DisableEv((unsigned char *)&mMovingMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov079_02127bf0[((unsigned char *)this)[0x414]]);
+  ((SharedFilePtr *)(data_ov079_02127bf0[((unsigned char *)this)[0x414]]))->Release();
   if(((unsigned char *)this)[0x414]){
-    _ZN13SharedFilePtr7ReleaseEv((void*)&data_ov079_02128168);
+    ((SharedFilePtr *)((void*)&data_ov079_02128168))->Release();
     for(i=0;i<6;i++)
-      _ZN13SharedFilePtr7ReleaseEv(data_ov079_02127600[i]);
-    _ZN13SharedFilePtr7ReleaseEv((void*)&data_ov079_02128178);
+      ((SharedFilePtr *)(data_ov079_02127600[i]))->Release();
+    ((SharedFilePtr *)((void*)&data_ov079_02128178))->Release();
   } else {
-    _ZN13SharedFilePtr7ReleaseEv((void*)&data_ov079_02128170);
+    ((SharedFilePtr *)((void*)&data_ov079_02128170))->Release();
     for(i=0;i<5;i++)
-      _ZN13SharedFilePtr7ReleaseEv(data_ov079_021275ec[i]);
+      ((SharedFilePtr *)(data_ov079_021275ec[i]))->Release();
   }
   return 1;
 }

--- a/src/_ZN6Coffin16CleanupResourcesEv.cpp
+++ b/src/_ZN6Coffin16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Coffin.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int Coffin::CleanupResources()
@@ -12,7 +12,7 @@ int Coffin::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN6Eyerok16CleanupResourcesEv.cpp
+++ b/src/_ZN6Eyerok16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Eyerok.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern char data_ov066_0211ae6c[];
 extern char data_ov066_0211ae4c[];
 extern char data_ov066_0211aeb4[];
@@ -33,28 +33,28 @@ int Eyerok::CleanupResources()
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&unk_674))
     _ZN16MeshColliderBase7DisableEv((char *)&unk_674);
   if(unk_49c==0){
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae6c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae4c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211aeb4);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211aebc);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae9c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae3c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae2c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae5c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae84);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211aea4);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae8c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae54);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae94);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae64);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae44);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae74);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae7c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae24);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211aeac);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae14);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae1c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov066_0211ae34);
+    ((SharedFilePtr *)(data_ov066_0211ae6c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae4c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211aeb4))->Release();
+    ((SharedFilePtr *)(data_ov066_0211aebc))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae9c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae3c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae2c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae5c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae84))->Release();
+    ((SharedFilePtr *)(data_ov066_0211aea4))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae8c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae54))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae94))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae64))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae44))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae74))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae7c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae24))->Release();
+    ((SharedFilePtr *)(data_ov066_0211aeac))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae14))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae1c))->Release();
+    ((SharedFilePtr *)(data_ov066_0211ae34))->Release();
   }
   return 1;
 }

--- a/src/_ZN6Goomba16CleanupResourcesEv.cpp
+++ b/src/_ZN6Goomba16CleanupResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Goomba.h"
+#include "SharedFilePtr.h"
 extern void UnloadBlueCoinModel(void* p);
-extern void _ZN13SharedFilePtr7ReleaseEv(void* p);
 extern void _ZN8CapEnemy14UnloadCapModelEv(char* c);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern char data_ov084_02130cf8[];
@@ -16,9 +16,9 @@ int Goomba::CleanupResources()
   int i;
   if (mGoombaType == 2)
     UnloadBlueCoinModel(((char*)this));
-  _ZN13SharedFilePtr7ReleaseEv(data_ov084_02130cf8);
+  ((SharedFilePtr *)(data_ov084_02130cf8))->Release();
   for (i = 0; i < 7; ++i)
-    _ZN13SharedFilePtr7ReleaseEv(data_ov084_02130278[i]);
+    ((SharedFilePtr *)(data_ov084_02130278[i]))->Release();
   if ((unsigned char)(unk_464 + 0xff) <= 1)
     UnloadSilverStarAndNumber();
   _ZN8CapEnemy14UnloadCapModelEv(((char*)this));

--- a/src/_ZN6Player16CleanupResourcesEv.cpp
+++ b/src/_ZN6Player16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+#include "SharedFilePtr.h"
 enum { false_, true_ };
 
 struct VB { virtual void v0(); virtual void v1(); };
@@ -20,7 +21,6 @@ void func_ov002_020e032c(char *c);
 void func_0203cbc0(int p);
 void func_020072c0(void);
 void func_02073244(int p, int a, int b, void (*f)(void));
-void _ZN13SharedFilePtr7ReleaseEv(void *p);
 void func_ov002_020bebd4(char *c);
 void UnloadSilverStarAndNumber(void);
 void UnloadKeyModels(int n);
@@ -102,135 +102,135 @@ int Player::CleanupResources()
         if (q != 0)
             func_0203cbc0(q);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[mCharFileBase + (param1 & 3)]);
+    ((SharedFilePtr *)(data_ov002_020ff480[mCharFileBase + (param1 & 3)]))->Release();
     b = data_0209f2d8;
     b = b == 1;
     if (b != false_)
         func_ov002_020bebd4(((char *)this));
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec50);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ebb8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec60);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e818);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e690);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb20);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e758);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec38);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb00);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e790);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e7a8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e7f0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e798);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e4f0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e3d8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb88);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e6c0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb98);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e4c0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e500);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e1c8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e770);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e230);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e288);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e478);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e9d0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ea10);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e538);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eac8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e898);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e9e8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eba8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb70);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eaf0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e640);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e670);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e680);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e438);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e3b0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e3c8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e408);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e400);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ecb8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e8d0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ebd8);
+    ((SharedFilePtr *)(data_ov002_0210ec50))->Release();
+    ((SharedFilePtr *)(data_ov002_0210ebb8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210ec60))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e818))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e690))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eb20))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e758))->Release();
+    ((SharedFilePtr *)(data_ov002_0210ec38))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eb00))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e790))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e7a8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e7f0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e798))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e4f0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e3d8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eb88))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e6c0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eb98))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e4c0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e500))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e1c8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e770))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e230))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e288))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e478))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e9d0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210ea10))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e538))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eac8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e898))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e9e8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eba8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eb70))->Release();
+    ((SharedFilePtr *)(data_ov002_0210eaf0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e640))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e670))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e680))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e438))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e3b0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e3c8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e408))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e400))->Release();
+    ((SharedFilePtr *)(data_ov002_0210ecb8))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e8d0))->Release();
+    ((SharedFilePtr *)(data_ov002_0210ebd8))->Release();
     b = data_0209f2d8;
     b = b == 1;
     if (b == false_) {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9a8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_02110aa4);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da38);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e750);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e588);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e7e8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e450);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e788);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e1e8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e1e0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e4d0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e4e8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e1d0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e800);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e4b8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e270);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e458);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ea70);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e540);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e8e8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eca8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec98);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e600);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ea88);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e910);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e460);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e2f0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e958);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb38);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e660);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ea30);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e3e8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb90);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e6b8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e620);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e6a0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb58);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e3e0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210eb10);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e708);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ebc8);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e6e0);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e430);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec40);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e738);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e250);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec10);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec00);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e728);
+        ((SharedFilePtr *)(data_ov002_0210d9a8))->Release();
+        ((SharedFilePtr *)(data_ov002_02110aa4))->Release();
+        ((SharedFilePtr *)(data_ov002_0210da38))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e750))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e588))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e7e8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e450))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e788))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e1e8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e1e0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e4d0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e4e8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e1d0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e800))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e4b8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e270))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e458))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ea70))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e540))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e8e8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210eca8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ec98))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e600))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ea88))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e910))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e460))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e2f0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e958))->Release();
+        ((SharedFilePtr *)(data_ov002_0210eb38))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e660))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ea30))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e3e8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210eb90))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e6b8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e620))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e6a0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210eb58))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e3e0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210eb10))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e708))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ebc8))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e6e0))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e430))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ec40))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e738))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e250))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ec10))->Release();
+        ((SharedFilePtr *)(data_ov002_0210ec00))->Release();
+        ((SharedFilePtr *)(data_ov002_0210e728))->Release();
     }
     if (mLoadedResourceFlags & 1)
         UnloadSilverStarAndNumber();
     if (mLoadedResourceFlags & 2)
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da40);
+        ((SharedFilePtr *)(data_ov002_0210da40))->Release();
     if (mLoadedResourceFlags & 4)
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9a0);
+        ((SharedFilePtr *)(data_ov002_0210d9a0))->Release();
     if (mLoadedResourceFlags & 8)
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9c0);
+        ((SharedFilePtr *)(data_ov002_0210d9c0))->Release();
     if (mLoadedResourceFlags & 0x10)
         UnloadKeyModels(unk_719);
     b = data_0209f2d8;
     b = b == 1;
     if (b == false_) {
         if (mLoadedResourceFlags & 0x20) {
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e6f8);
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e7b0);
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e780);
+            ((SharedFilePtr *)(data_ov002_0210e6f8))->Release();
+            ((SharedFilePtr *)(data_ov002_0210e7b0))->Release();
+            ((SharedFilePtr *)(data_ov002_0210e780))->Release();
         }
     } else {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e7b0);
+        ((SharedFilePtr *)(data_ov002_0210e7b0))->Release();
     }
     if (mLoadedResourceFlags & 0x40) {
         u32 idx = mHatCharacter;
         if (idx == (u32)param1)
             idx = unk_6dc;
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[mCharFileBase + idx]);
+        ((SharedFilePtr *)(data_ov002_020ff480[mCharFileBase + idx]))->Release();
     }
     return 1;
 }

--- a/src/_ZN6Player16SetRealCharacterEj.cpp
+++ b/src/_ZN6Player16SetRealCharacterEj.cpp
@@ -6,9 +6,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+#include "SharedFilePtr.h"
 struct SharedFilePtr;
 
-extern "C" void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr *self);
 extern "C" void _ZN6Player18SetNewHatCharacterEjjb(void *self, u32 a, u32 b, bool c);
 extern "C" void _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" void _ZN6Player4HealEi(void *self, int hp);
@@ -26,7 +26,7 @@ void Player::SetRealCharacter(unsigned int chr_)
     u32 base = mCharFileBase;
     u32 m1, m2;
 
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[base + (cur & 3)]);
+    ((SharedFilePtr *)(data_ov002_020ff480[base + (cur & 3)]))->Release();
     _ZN6Player18SetNewHatCharacterEjjb(((char *)this), chr, 0, 1);
     param1 = chr;
     mCharacter = (u8)chr;

--- a/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
+++ b/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
@@ -1,11 +1,11 @@
 //cpp
 #include "types.h"
+#include "SharedFilePtr.h"
 #define LAUNDER16(p) ((u16 *)(int)(((long long)(int)(p))))
 extern "C" {
 extern u8 data_0209f2d8;
 extern void *data_ov002_020ff480[];
 extern void *data_ov002_020ff2f0[];
-void _ZN13SharedFilePtr7ReleaseEv(void *thiz);
 void _ZN9Animation8LoadFileER13SharedFilePtr(void *arg);
 int _ZNK6Player14GetBodyModelIDEjb(void *thiz, u32 a, int b);
 void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thiz, void *bcaFile, int b, Fix12i c, u32 d);
@@ -34,7 +34,7 @@ void _ZN6Player7SetAnimEji5Fix12IiEj(char *self, u32 a, int b, Fix12i c, u16 d)
 
     newVal = a << 2;
     if (newVal != *(u32 *)(self + 0x63c)) {
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[*(u32 *)(self + 0x63c) + (*(int *)(self + 8) & 3)]);
+        ((SharedFilePtr *)(data_ov002_020ff480[*(u32 *)(self + 0x63c) + (*(int *)(self + 8) & 3)]))->Release();
         _ZN9Animation8LoadFileER13SharedFilePtr(data_ov002_020ff480[newVal + (*(int *)(self + 8) & 3)]);
 
         id = _ZNK6Player14GetBodyModelIDEjb(self, *(int *)(self + 8) & 0xff, 0);
@@ -46,7 +46,7 @@ void _ZN6Player7SetAnimEji5Fix12IiEj(char *self, u32 a, int b, Fix12i c, u16 d)
             if (charId == *(u32 *)(self + 8))
                 charId = *(u8 *)(self + 0x6dc);
 
-            _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[*(u32 *)(self + 0x63c) + charId]);
+            ((SharedFilePtr *)(data_ov002_020ff480[*(u32 *)(self + 0x63c) + charId]))->Release();
             sfp = data_ov002_020ff480[newVal + charId];
             _ZN9Animation8LoadFileER13SharedFilePtr(sfp);
 

--- a/src/_ZN6ShipUp16CleanupResourcesEv.cpp
+++ b/src/_ZN6ShipUp16CleanupResourcesEv.cpp
@@ -4,15 +4,15 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
+#include "SharedFilePtr.h"
 extern "C" {
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 }
 
 int ShipUp::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136e4[mModelIndex]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136dc[mModelIndex]);
+  ((SharedFilePtr *)(data_ov016_021136e4[mModelIndex]))->Release();
+  ((SharedFilePtr *)(data_ov016_021136dc[mModelIndex]))->Release();
   return 1;
 }

--- a/src/_ZN6Thwomp16CleanupResourcesEv.cpp
+++ b/src/_ZN6Thwomp16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Thwomp.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 
 int Thwomp::CleanupResources()
 {
@@ -13,12 +13,12 @@ int Thwomp::CleanupResources()
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     }
     fp = *(void***)((char *)&mFileTable);
-    _ZN13SharedFilePtr7ReleaseEv(fp[0]);
+    ((SharedFilePtr *)(fp[0]))->Release();
     fp = *(void***)((char *)&mFileTable);
-    _ZN13SharedFilePtr7ReleaseEv(fp[1]);
+    ((SharedFilePtr *)(fp[1]))->Release();
     fp = *(void***)((char *)&mFileTable);
     if (fp[3] != 0) {
-        _ZN13SharedFilePtr7ReleaseEv(fp[3]);
+        ((SharedFilePtr *)(fp[3]))->Release();
     }
     return 1;
 }

--- a/src/_ZN6ToxBox16CleanupResourcesEv.cpp
+++ b/src/_ZN6ToxBox16CleanupResourcesEv.cpp
@@ -2,8 +2,8 @@
 // @symbol _ZN6ToxBox16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "ToxBox.h"
+#include "SharedFilePtr.h"
 extern "C" {
-int _ZN13SharedFilePtr7ReleaseEv(void*);
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov092_02132540[];
@@ -12,8 +12,8 @@ extern int data_ov092_02132548[];
 
 int ToxBox::CleanupResources()
 {
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov092_02132540);
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov092_02132548);
+  ((SharedFilePtr *)((void*)data_ov092_02132540))->Release();
+  ((SharedFilePtr *)((void*)data_ov092_02132548))->Release();
   if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
   return 1;

--- a/src/_ZN8BookShot16CleanupResourcesEv.cpp
+++ b/src/_ZN8BookShot16CleanupResourcesEv.cpp
@@ -2,8 +2,8 @@
 // @symbol _ZN8BookShot16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "BookShot.h"
+#include "SharedFilePtr.h"
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void *);
 void UnloadBlueCoinModel(void *);
 extern int data_ov020_02114aa0;
 extern int data_ov020_02114ab8;
@@ -13,10 +13,10 @@ extern int data_ov020_02114ab0;
 
 int BookShot::CleanupResources()
 {
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114aa0);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114ab8);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114aa8);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114ab0);
+  ((SharedFilePtr *)(&data_ov020_02114aa0))->Release();
+  ((SharedFilePtr *)(&data_ov020_02114ab8))->Release();
+  ((SharedFilePtr *)(&data_ov020_02114aa8))->Release();
+  ((SharedFilePtr *)(&data_ov020_02114ab0))->Release();
   UnloadBlueCoinModel(((void *)this));
   return 1;
 }

--- a/src/_ZN8CccArena16CleanupResourcesEv.cpp
+++ b/src/_ZN8CccArena16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CccArena.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 
 int CccArena::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov073_021231bc + (unsigned char)((char *)this)[0x32c]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov073_021231c0 + (unsigned char)((char *)this)[0x32c]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov073_021231bc + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov073_021231c0 + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN8Goomboss16CleanupResourcesEv.cpp
+++ b/src/_ZN8Goomboss16CleanupResourcesEv.cpp
@@ -4,9 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Goomboss.h"
+#include "SharedFilePtr.h"
 extern "C" {
 int func_ov074_0212229c(int* c);
-void _ZN13SharedFilePtr7ReleaseEv(void* thiz);
 void UnloadKeyModels(int i);
 extern char data_ov002_0210da30;
 extern char data_ov084_02130cf8;
@@ -21,14 +21,14 @@ int Goomboss::CleanupResources()
     if (v == 0x1111) {
         return func_ov074_0212229c(((int*)this));
     }
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da30);
+    ((SharedFilePtr *)(&data_ov002_0210da30))->Release();
     UnloadKeyModels(2);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130cf8);
+    ((SharedFilePtr *)(&data_ov084_02130cf8))->Release();
     for (i = 0; i < 7; i++)
-        _ZN13SharedFilePtr7ReleaseEv(data_ov074_0212292c[i]);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov074_02123000);
+        ((SharedFilePtr *)(data_ov074_0212292c[i]))->Release();
+    ((SharedFilePtr *)(&data_ov074_02123000))->Release();
     for (i = 0; i < 0xc; i++)
-        _ZN13SharedFilePtr7ReleaseEv(data_ov074_02122948[i]);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov074_02123040);
+        ((SharedFilePtr *)(data_ov074_02122948[i]))->Release();
+    ((SharedFilePtr *)(&data_ov074_02123040))->Release();
     return 1;
 }

--- a/src/_ZN8IceBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN8IceBlock16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "IceBlock.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov081_02128fd8[];
 
 int IceBlock::CleanupResources()
@@ -12,7 +12,7 @@ int IceBlock::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov081_02128fd8);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov081_02128fd0);
+    ((SharedFilePtr *)(data_ov081_02128fd8))->Release();
+    ((SharedFilePtr *)(data_ov081_02128fd0))->Release();
     return 1;
 }

--- a/src/_ZN8IceSheet16CleanupResourcesEv.cpp
+++ b/src/_ZN8IceSheet16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int IceSheet::CleanupResources()
@@ -12,7 +12,7 @@ int IceSheet::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN8PoleLift16CleanupResourcesEv.cpp
+++ b/src/_ZN8PoleLift16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PoleLift.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int PoleLift::CleanupResources()
 {
     _ZN16MeshColliderBase7DisableEv((char *)&mCollider);
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN8ShipWing16CleanupResourcesEv.cpp
+++ b/src/_ZN8ShipWing16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWing.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov036_0211408c[];
 
 int ShipWing::CleanupResources()
@@ -12,7 +12,7 @@ int ShipWing::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov036_0211408c);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov036_02114084);
+    ((SharedFilePtr *)(data_ov036_0211408c))->Release();
+    ((SharedFilePtr *)(data_ov036_02114084))->Release();
     return 1;
 }

--- a/src/_ZN8SignPost16CleanupResourcesEv.cpp
+++ b/src/_ZN8SignPost16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SignPost.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int SignPost::CleanupResources()
@@ -12,7 +12,7 @@ int SignPost::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN8Squasher16CleanupResourcesEv.cpp
+++ b/src/_ZN8Squasher16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Squasher.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int Squasher::CleanupResources()
 {
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN8YoshiEgg16CleanupResourcesEv.cpp
+++ b/src/_ZN8YoshiEgg16CleanupResourcesEv.cpp
@@ -2,7 +2,7 @@
 // @symbol _ZN8YoshiEgg16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "YoshiEgg.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
+#include "SharedFilePtr.h"
 extern int func_ov002_020ec628(void*);
 extern void UnloadBlueCoinModel(void*);
 extern char data_ov002_0210e6b0;
@@ -10,8 +10,8 @@ extern char data_ov002_0210eb78;
 
 int YoshiEgg::CleanupResources()
 {
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210e6b0);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210eb78);
+  ((SharedFilePtr *)(&data_ov002_0210e6b0))->Release();
+  ((SharedFilePtr *)(&data_ov002_0210eb78))->Release();
   if (func_ov002_020ec628(((void*)this)) != 0)
     UnloadBlueCoinModel(((void*)this));
   return 1;

--- a/src/_ZN9HugeCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9HugeCover16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "HugeCover.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int HugeCover::CleanupResources()
@@ -12,7 +12,7 @@ int HugeCover::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN9PowerStar16CleanupResourcesEv.cpp
+++ b/src/_ZN9PowerStar16CleanupResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PowerStar.h"
+#include "SharedFilePtr.h"
 extern "C" void _ZN5Actor11UntrackStarERa(void* self, signed char* star);
-extern "C" void _ZN13SharedFilePtr7ReleaseEv(void* p);
 
 extern char data_ov002_02110944;
 extern char data_ov002_02110924;
@@ -26,9 +26,9 @@ int PowerStar::CleanupResources()
         _ZN5Actor11UntrackStarERa(((char*)this), (signed char*)((char*)&unk_498));
         UnloadSilverStarAndNumber();
     }
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_02110944);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_02110924);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_02110964);
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_02110934);
+    ((SharedFilePtr *)(&data_ov002_02110944))->Release();
+    ((SharedFilePtr *)(&data_ov002_02110924))->Release();
+    ((SharedFilePtr *)(&data_ov002_02110964))->Release();
+    ((SharedFilePtr *)(&data_ov002_02110934))->Release();
     return 1;
 }

--- a/src/_ZN9SeesawBob16CleanupResourcesEv.cpp
+++ b/src/_ZN9SeesawBob16CleanupResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SeesawBob.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 
 int SeesawBob::CleanupResources()
 {
   if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
     _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov095_021374a0 + (unsigned char)((char *)this)[0x31e]*0xc));
-  _ZN13SharedFilePtr7ReleaseEv(*(void**)(data_ov095_021374a4 + (unsigned char)((char *)this)[0x31e]*0xc));
+  ((SharedFilePtr *)(*(void**)(data_ov095_021374a0 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
+  ((SharedFilePtr *)(*(void**)(data_ov095_021374a4 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;
 }

--- a/src/_ZN9ShipWater16CleanupResourcesEv.cpp
+++ b/src/_ZN9ShipWater16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWater.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int ShipWater::CleanupResources()
@@ -12,7 +12,7 @@ int ShipWater::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/_ZN9TinyCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9TinyCover16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TinyCover.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int data_ov033_021124f0[];
 
 int TinyCover::CleanupResources()
@@ -12,7 +12,7 @@ int TinyCover::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov033_021124f0);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov033_021124e8);
+    ((SharedFilePtr *)(data_ov033_021124f0))->Release();
+    ((SharedFilePtr *)(data_ov033_021124e8))->Release();
     return 1;
 }

--- a/src/_ZN9TowerStep16CleanupResourcesEv.cpp
+++ b/src/_ZN9TowerStep16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TowerStep.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int TowerStep::CleanupResources()
@@ -12,7 +12,7 @@ int TowerStep::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
     return 1;
 }

--- a/src/actors/Boo/_ZN3Boo16CleanupResourcesEv.cpp
+++ b/src/actors/Boo/_ZN3Boo16CleanupResourcesEv.cpp
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Boo.h"
+#include "SharedFilePtr.h"
 struct Actor;
 extern "C" Actor *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void *self);
 extern "C" void UnloadBlueCoinModel(void *o);
 struct SharedFilePtr;
-extern "C" void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr *self);
 extern "C" void _ZN8CapEnemy14UnloadCapModelEv(void *self);
 
 extern SharedFilePtr data_ov063_0211edec;
@@ -56,19 +56,19 @@ int Boo::CleanupResources()
     if (((O *)this)->f4a0 == 0x122)
         UnloadBlueCoinModel(((O *)this));
     else if (((O *)this)->f4a0 == 0xd4)
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edec);
+        ((SharedFilePtr *)(&data_ov063_0211edec))->Release();
 
     b = (((O *)this)->f0c == 0xd1);
     if (b != 0) {
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edc4);
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211eddc);
+        ((SharedFilePtr *)(&data_ov063_0211edc4))->Release();
+        ((SharedFilePtr *)(&data_ov063_0211eddc))->Release();
     } else {
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edf4);
-        _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211ede4);
+        ((SharedFilePtr *)(&data_ov063_0211edf4))->Release();
+        ((SharedFilePtr *)(&data_ov063_0211ede4))->Release();
         if (((O *)this)->f5cf == 0xf) {
             UnloadKeyModels(3);
-            _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edd4);
-            _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edcc);
+            ((SharedFilePtr *)(&data_ov063_0211edd4))->Release();
+            ((SharedFilePtr *)(&data_ov063_0211edcc))->Release();
         }
     }
     _ZN8CapEnemy14UnloadCapModelEv(((O *)this));

--- a/src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MadPiano.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 extern int G0[];
 
 int MadPiano::CleanupResources()
@@ -12,8 +12,8 @@ int MadPiano::CleanupResources()
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
         _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
-    _ZN13SharedFilePtr7ReleaseEv(G2);
+    ((SharedFilePtr *)(G0))->Release();
+    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(G2))->Release();
     return 1;
 }

--- a/src/actors/MansionSteps/_ZN12MansionSteps16CleanupResourcesEv.cpp
+++ b/src/actors/MansionSteps/_ZN12MansionSteps16CleanupResourcesEv.cpp
@@ -4,14 +4,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MansionSteps.h"
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+#include "SharedFilePtr.h"
 
 int MansionSteps::CleanupResources()
 {
     _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     int idx = *(int*)((char*)&unk_140);
-    _ZN13SharedFilePtr7ReleaseEv((void*)(data_ov063_0211e27c[idx]));
+    ((SharedFilePtr *)((void*)(data_ov063_0211e27c[idx])))->Release();
     idx = *(int*)((char*)&unk_140);
-    _ZN13SharedFilePtr7ReleaseEv((void*)(data_ov063_0211e28c[idx]));
+    ((SharedFilePtr *)((void*)(data_ov063_0211e28c[idx])))->Release();
     return 1;
 }

--- a/src/func_ov002_020b68b0.cpp
+++ b/src/func_ov002_020b68b0.cpp
@@ -1,13 +1,13 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern void _ZN16MeshColliderBase7DisableEv(void*);
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 int func_ov002_020b68b0(void* c, void* r4) {
     if (_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
         _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)r4);
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)((char*)r4+4));
+    ((SharedFilePtr *)(*(void**)r4))->Release();
+    ((SharedFilePtr *)(*(void**)((char*)r4+4)))->Release();
     return 1;
 }
 }

--- a/src/func_ov002_020b6ac8.cpp
+++ b/src/func_ov002_020b6ac8.cpp
@@ -1,13 +1,13 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern void _ZN16MeshColliderBase7DisableEv(void*);
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 int func_ov002_020b6ac8(void* c, void* r4) {
     if (_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
         _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)r4);
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)((char*)r4+4));
+    ((SharedFilePtr *)(*(void**)r4))->Release();
+    ((SharedFilePtr *)(*(void**)((char*)r4+4)))->Release();
     return 1;
 }
 }

--- a/src/func_ov002_020baba8.cpp
+++ b/src/func_ov002_020baba8.cpp
@@ -1,13 +1,13 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern void _ZN16MeshColliderBase7DisableEv(void*);
-extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 int func_ov002_020baba8(char* c, void** p){
   if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
-  _ZN13SharedFilePtr7ReleaseEv(p[0]);
-  _ZN13SharedFilePtr7ReleaseEv(p[1]);
+  ((SharedFilePtr *)(p[0]))->Release();
+  ((SharedFilePtr *)(p[1]))->Release();
   return 1;
 }
 }

--- a/src/func_ov002_020bebd4.cpp
+++ b/src/func_ov002_020bebd4.cpp
@@ -1,14 +1,14 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int data_ov002_020ff480[];
-extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 void func_ov002_020bebd4(void){
   int i;
   for(i=0x44;i<0x1c8;i+=4){
-    _ZN13SharedFilePtr7ReleaseEv((void*)data_ov002_020ff480[i]);
-    _ZN13SharedFilePtr7ReleaseEv((void*)data_ov002_020ff480[i+1]);
-    _ZN13SharedFilePtr7ReleaseEv((void*)data_ov002_020ff480[i+2]);
-    _ZN13SharedFilePtr7ReleaseEv((void*)data_ov002_020ff480[i+3]);
+    ((SharedFilePtr *)((void*)data_ov002_020ff480[i]))->Release();
+    ((SharedFilePtr *)((void*)data_ov002_020ff480[i+1]))->Release();
+    ((SharedFilePtr *)((void*)data_ov002_020ff480[i+2]))->Release();
+    ((SharedFilePtr *)((void*)data_ov002_020ff480[i+3]))->Release();
   }
 }
 }

--- a/src/func_ov002_020f6778.cpp
+++ b/src/func_ov002_020f6778.cpp
@@ -1,9 +1,9 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int data_ov002_0210bcc4[];
 extern int data_ov002_0210bce8[];
 extern int func_020072c0[];
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 void _ZN9ModelAnimD2Ev(void*);
 void __destroy_arr(void*, int, int, void*);
 void _ZN6Memory16operator_delete2EPv(void*);
@@ -14,15 +14,15 @@ void* func_ov002_020f6778(char* c){
   *(int*)c = (int)data_ov002_0210bcc4;
   *(int*)(c+0x50) = (int)data_ov002_0210bce8;
   p = *(void**)(c+0x70);
-  if (p != 0) _ZN13SharedFilePtr7ReleaseEv(p);
+  if (p != 0) ((SharedFilePtr *)(p))->Release();
   for (i = 0; i < *(unsigned char*)(c+0x80); i++) {
     p = (*(void***)(c+0x74))[i];
-    if (p != 0) _ZN13SharedFilePtr7ReleaseEv(p);
+    if (p != 0) ((SharedFilePtr *)(p))->Release();
   }
   if (*(void**)(c+0x7c) != 0) {
     for (i = 0; i < *(unsigned char*)(c+0x81); i++) {
       p = (*(void***)(c+0x78))[i];
-      if (p != 0) _ZN13SharedFilePtr7ReleaseEv(p);
+      if (p != 0) ((SharedFilePtr *)(p))->Release();
     }
     p = *(void**)(c+0x7c);
     if (p != 0) {

--- a/src/func_ov002_020f6870.cpp
+++ b/src/func_ov002_020f6870.cpp
@@ -1,9 +1,9 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int data_ov002_0210bcc4[];
 extern int data_ov002_0210bce8[];
 extern int func_020072c0[];
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 void _ZN9ModelAnimD2Ev(void*);
 void __destroy_arr(void*, int, int, void*);
 typedef void (*VFN)(void*);
@@ -13,15 +13,15 @@ void* func_ov002_020f6870(char* c){
   *(int*)c = (int)data_ov002_0210bcc4;
   *(int*)(c+0x50) = (int)data_ov002_0210bce8;
   p = *(void**)(c+0x70);
-  if (p != 0) _ZN13SharedFilePtr7ReleaseEv(p);
+  if (p != 0) ((SharedFilePtr *)(p))->Release();
   for (i = 0; i < *(unsigned char*)(c+0x80); i++) {
     p = (*(void***)(c+0x74))[i];
-    if (p != 0) _ZN13SharedFilePtr7ReleaseEv(p);
+    if (p != 0) ((SharedFilePtr *)(p))->Release();
   }
   if (*(void**)(c+0x7c) != 0) {
     for (i = 0; i < *(unsigned char*)(c+0x81); i++) {
       p = (*(void***)(c+0x78))[i];
-      if (p != 0) _ZN13SharedFilePtr7ReleaseEv(p);
+      if (p != 0) ((SharedFilePtr *)(p))->Release();
     }
     p = *(void**)(c+0x7c);
     if (p != 0) {

--- a/src/func_ov002_020f69a8.cpp
+++ b/src/func_ov002_020f69a8.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int data_ov002_0210bae4[];
 extern int func_020072c0[];
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 void _ZN5ModelD2Ev(void*);
 void __destroy_arr(void*, int, int, void*);
 void _ZN6Memory16operator_delete2EPv(void*);
@@ -11,7 +11,7 @@ void* func_ov002_020f69a8(char* c){
   *(int*)c = (int)data_ov002_0210bae4;
   p = *(void**)(c+0x5c);
   if(p!=0){
-    _ZN13SharedFilePtr7ReleaseEv(p);
+    ((SharedFilePtr *)(p))->Release();
   }
   _ZN5ModelD2Ev(c);
   __destroy_arr(c+0x50, 1, 0xc, (void*)func_020072c0);

--- a/src/func_ov002_020f6a00.cpp
+++ b/src/func_ov002_020f6a00.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int data_ov002_0210bae4[];
 extern int func_020072c0[];
-void _ZN13SharedFilePtr7ReleaseEv(void*);
 void _ZN5ModelD2Ev(void*);
 void __destroy_arr(void*, int, int, void*);
 void* func_ov002_020f6a00(char* c){
@@ -10,7 +10,7 @@ void* func_ov002_020f6a00(char* c){
   *(int*)c = (int)data_ov002_0210bae4;
   p = *(void**)(c+0x5c);
   if(p!=0){
-    _ZN13SharedFilePtr7ReleaseEv(p);
+    ((SharedFilePtr *)(p))->Release();
   }
   _ZN5ModelD2Ev(c);
   __destroy_arr(c+0x50, 1, 0xc, (void*)func_020072c0);

--- a/src/func_ov006_020c3e70.cpp
+++ b/src/func_ov006_020c3e70.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void* p);
 int SharedFilePtr_Destruct_Anim(int x);
 int func_02017ab4(int x);
 void _ZN9ModelAnimD1Ev(void* p);
@@ -8,12 +8,12 @@ void* __destroy_arr(void* p, int a, int b, void* f);
 }
 extern void* func_ov006_020c3e54;
 extern "C" void* func_ov006_020c3e70(char* c){
-  _ZN13SharedFilePtr7ReleaseEv(c + 0xd7c);
-  _ZN13SharedFilePtr7ReleaseEv(c + 0xd84);
-  _ZN13SharedFilePtr7ReleaseEv(c + 0xd8c);
-  _ZN13SharedFilePtr7ReleaseEv(c + 0xd94);
-  _ZN13SharedFilePtr7ReleaseEv(c + 0xd9c);
-  _ZN13SharedFilePtr7ReleaseEv(c + 0xda4);
+  ((SharedFilePtr *)(c + 0xd7c))->Release();
+  ((SharedFilePtr *)(c + 0xd84))->Release();
+  ((SharedFilePtr *)(c + 0xd8c))->Release();
+  ((SharedFilePtr *)(c + 0xd94))->Release();
+  ((SharedFilePtr *)(c + 0xd9c))->Release();
+  ((SharedFilePtr *)(c + 0xda4))->Release();
   SharedFilePtr_Destruct_Anim((int)(c + 0xda4));
   SharedFilePtr_Destruct_Anim((int)(c + 0xd9c));
   SharedFilePtr_Destruct_Anim((int)(c + 0xd94));

--- a/src/func_ov006_020e7a50.cpp
+++ b/src/func_ov006_020e7a50.cpp
@@ -1,14 +1,14 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern void* data_ov006_02141e94;
 extern void* data_ov006_02141e6c;
-int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void __destroy_arr(void*,int,int,void*);
 void _ZN15MaterialChangerD1Ev(void);
 void _ZN9ModelAnimD1Ev(void);
 void* func_ov006_020e7a50(char* c){
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov006_02141e94);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov006_02141e6c);
+  ((SharedFilePtr *)(&data_ov006_02141e94))->Release();
+  ((SharedFilePtr *)(&data_ov006_02141e6c))->Release();
   __destroy_arr(c+0x12c,3,0x14,(void*)_ZN15MaterialChangerD1Ev);
   __destroy_arr(c,3,0x64,(void*)_ZN9ModelAnimD1Ev);
   return c;

--- a/src/func_ov009_02111bd4.cpp
+++ b/src/func_ov009_02111bd4.cpp
@@ -1,17 +1,17 @@
 //cpp
+#include "SharedFilePtr.h"
 // @symbol func_ov009_02111bd4
 // recovered name: daObjMcWater_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjMcWater_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
-int _ZN13SharedFilePtr7ReleaseEv(void*);
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov009_02113c68[];
 extern int data_ov009_02113c70[];
 int func_ov009_02111bd4(char* c){
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov009_02113c68);
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov009_02113c70);
+  ((SharedFilePtr *)((void*)data_ov009_02113c68))->Release();
+  ((SharedFilePtr *)((void*)data_ov009_02113c70))->Release();
   if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
   return 1;

--- a/src/func_ov010_02111554.cpp
+++ b/src/func_ov010_02111554.cpp
@@ -3,17 +3,17 @@
 // recovered name: daObjC1_Trap_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+#include "SharedFilePtr.h"
 /* recovered: renamed to Class_Method */
 /* daObjC1_Trap_c::CleanupResources - recovered from vtable slot identity */
-extern "C" void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern "C" char data_ov025_02112d08[];
 extern "C" int func_ov010_02111554(char *self){
   if(_ZN16MeshColliderBase9IsEnabledEv(self+0x124)){
     _ZN16MeshColliderBase7DisableEv(self+0x124);
   }
   if((*(unsigned int*)(self+8) & 0xff) != 0xff){
-    _ZN13SharedFilePtr7ReleaseEv(data_ov025_02112d08);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov024_02112d00);
+    ((SharedFilePtr *)(data_ov025_02112d08))->Release();
+    ((SharedFilePtr *)(data_ov024_02112d00))->Release();
   }
   return 1;
 }

--- a/src/func_ov022_0211123c.cpp
+++ b/src/func_ov022_0211123c.cpp
@@ -1,14 +1,14 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void *);
 extern "C" void _ZN16MeshColliderBase7DisableEv(void *);
-extern "C" void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int data_ov022_02113cc8;
 
 extern "C" int func_ov022_0211123c(char *c) {
     if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
         _ZN16MeshColliderBase7DisableEv(c + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv((void *)((int *)&data_ov022_02113cc8)[0]);
-    _ZN13SharedFilePtr7ReleaseEv((void *)((int *)&data_ov022_02113cc8)[1]);
+    ((SharedFilePtr *)((void *)((int *)&data_ov022_02113cc8)[0]))->Release();
+    ((SharedFilePtr *)((void *)((int *)&data_ov022_02113cc8)[1]))->Release();
     return 1;
 }

--- a/src/func_ov025_02111384.cpp
+++ b/src/func_ov025_02111384.cpp
@@ -3,16 +3,16 @@
 // recovered name: daDgr_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+#include "SharedFilePtr.h"
 /* recovered: renamed to Class_Method */
 /* daDgr_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void* self);
 int _ZN16MeshColliderBase9IsEnabledEv(void* self);
 void _ZN16MeshColliderBase7DisableEv(void* self);
 extern int data_ov025_02113a68[];
 int func_ov025_02111384(char* c) {
-  _ZN13SharedFilePtr7ReleaseEv(data_ov025_02113a68);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113a60);
+  ((SharedFilePtr *)(data_ov025_02113a68))->Release();
+  ((SharedFilePtr *)(data_ov036_02113a60))->Release();
   if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
   return 1;

--- a/src/func_ov036_02112318.cpp
+++ b/src/func_ov036_02112318.cpp
@@ -1,18 +1,18 @@
 //cpp
+#include "SharedFilePtr.h"
 extern "C" {
 extern int _ZN16MeshColliderBase9IsEnabledEv(void* m);
 extern void _ZN16MeshColliderBase7DisableEv(void* m);
-extern void _ZN13SharedFilePtr7ReleaseEv(void* f);
 extern int data_ov002_0210d9f0[];
 extern void* data_ov036_02113f58[];
 extern int data_ov036_0211419c[];
 int func_ov036_02112318(char* c){
   if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9f0);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113f58[0]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113f58[1]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov036_0211419c);
+  ((SharedFilePtr *)(data_ov002_0210d9f0))->Release();
+  ((SharedFilePtr *)(data_ov036_02113f58[0]))->Release();
+  ((SharedFilePtr *)(data_ov036_02113f58[1]))->Release();
+  ((SharedFilePtr *)(data_ov036_0211419c))->Release();
   return 1;
 }
 }

--- a/src/func_ov075_0211b458.cpp
+++ b/src/func_ov075_0211b458.cpp
@@ -2,6 +2,7 @@
 // @symbol func_ov075_0211b458
 /* recovered: shared common types */
 #include "common.h"
+#include "SharedFilePtr.h"
 
 struct Foo;
 typedef void (Foo::*PMF)();
@@ -9,7 +10,6 @@ extern "C" {
 extern void* _ZN6Memory13operator_new2Ej(unsigned int sz);
 extern void* func_0201787c(void* sfp);
 extern void func_ov075_0211aa94(void* a, void* b);
-extern void _ZN13SharedFilePtr7ReleaseEv(void* sfp);
 extern void func_ov075_0211aa00(char* r4);
 extern char data_ov075_0211d980;
 }
@@ -21,7 +21,7 @@ extern "C" int func_ov075_0211b458(char* c, int* src, int a2) {
     *(short*)(c + 0xa4) = *(unsigned char*)(c + 0xa6) * *(unsigned char*)(c + 0xa7);
     *(void**)(c + 0x80) = _ZN6Memory13operator_new2Ej(*(unsigned short*)(c + 0xa4) * 0x18);
     func_ov075_0211aa94(c, func_0201787c(&data_ov075_0211d980));
-    _ZN13SharedFilePtr7ReleaseEv(&data_ov075_0211d980);
+    ((SharedFilePtr *)(&data_ov075_0211d980))->Release();
     *(PMF**)(c + 0x84) = &data_ov075_0211d994;
     (((Foo*)c)->**(*(PMF**)(c + 0x84)))();
     *(int*)(c) = src[0];

--- a/src/func_ov100_0214542c.cpp
+++ b/src/func_ov100_0214542c.cpp
@@ -3,29 +3,29 @@
 // recovered name: daDoor_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+#include "SharedFilePtr.h"
 /* recovered: renamed to Class_Method */
 /* daDoor_c::CleanupResources - recovered from vtable slot identity */
 struct V { virtual void v0(); virtual void v1(); };
 struct Elem { void* a; void* b; char pad[8]; };
 extern Elem data_ov100_02148204[];
 extern "C" {
-extern void _ZN13SharedFilePtr7ReleaseEv(void* p);
 extern void* data_ov100_02148744;
 int func_ov100_0214542c(char* c) {
   int idx = *(int*)(c + 8);
   Elem* e = &data_ov100_02148204[idx];
   V* obj;
-  _ZN13SharedFilePtr7ReleaseEv(e->a);
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov100_02148744);
+  ((SharedFilePtr *)(e->a))->Release();
+  ((SharedFilePtr *)(&data_ov100_02148744))->Release();
   obj = (V*)*(void**)(c + 0x138);
   if (obj != 0) {
     if (obj != 0) obj->v1();
-    _ZN13SharedFilePtr7ReleaseEv(e->b);
+    ((SharedFilePtr *)(e->b))->Release();
   }
   if (*(void**)(c + 0x13c) != 0) {
     unsigned int v = *(unsigned int*)(c + 8);
     if (v >= 9 && v <= 0xd) UnloadKeyModels(v - 7);
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(c + 0x13c));
+    ((SharedFilePtr *)(*(void**)(c + 0x13c)))->Release();
   }
   return 1;
 }


### PR DESCRIPTION
Replaces 448 hand-written mangled call sites across 106 files with ordinary method calls, and adds `include/SharedFilePtr.h`.

**Every converted file compiles to byte-identical `.text`** — verified by compiling all 106 against `main` and against this branch and comparing the section: `identical: 106  differing: 0  failed: 0`.

## Why

Most call sites still reach these methods like this:

```cpp
extern void _ZN13SharedFilePtr7ReleaseEv(void *);
_ZN13SharedFilePtr7ReleaseEv(ptr);
```

That only works by accident. In a C translation unit the identifier is emitted verbatim, but a file compiled as C++ (`//cpp`) mangles it a **second** time and emits a reference to `_Z28_ZN13SharedFilePtr7ReleaseEvPv`, which nothing defines. The function still *matches* — `.text` is identical either way — but it can never be **enrolled** into the ROM build, because eligibility requires every reference to name a symbol config defines.

Declaring the real member makes the compiler produce `_ZN13SharedFilePtr7ReleaseEv` the ordinary way:

```
before refs: ['_Z28_ZN13SharedFilePtr7ReleaseEvPv']
after  refs: ['_ZN13SharedFilePtr7ReleaseEv']
```

A non-virtual member call is the same `bl` with `this` in r0 as the free-function call it replaces, which is why the bytes do not move.

`SharedFilePtr::Release` is the single largest blocker in the enrollment backlog — 56 files are blocked by it and nothing else, out of 294 blocked by double-mangling overall.

## The header has no fields, deliberately

The layout is **not recovered**. Files that declare this struct locally disagree about it:

```
{ int a, file; }        { int data[4]; }
{ int f0; void *f4; }   { int h; }
```

Each is sized to whatever pointer arithmetic that file needed. Committing to one here would silently change the others' indexing, so **those 9 files keep their local declaration and are excluded from this change** until the real layout is recovered. Every file converted here only calls methods through a pointer, so no layout is required to compile them.

## Scope

- `//cpp` files only. A `.c` file emits the mangled identifier verbatim and was never affected.
- Redundant local `extern` declarations are removed; the header supplies them.
- The definition of `Release` itself is untouched.

Follow-up, not included: `MeshColliderBase::Disable`/`IsEnabled` block another 73 files by the same mechanism and would be the natural next class.