### PR TITLE
readable: call MeshColliderBase methods instead of their mangled names

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -6,7 +6,13 @@
 
 struct Matrix4x3 { s32 m[12]; };
 /* Vector3 lives in types.h (as {Fix12i x,y,z}); not redefined here. */
+/* Guarded so MeshColliderBase.h, which needs this type and cannot assume common.h
+ * was included first, can define it too without colliding. Both spell the guard
+ * VECTOR3_16_DEFINED; whichever is seen first wins and the other stands down. */
+#ifndef VECTOR3_16_DEFINED
+#define VECTOR3_16_DEFINED
 struct Vector3_16 { s16 x, y, z; };
+#endif
 
 typedef struct Matrix4x3 Matrix4x3;
 typedef struct Vector3_16 Vector3_16;

--- a/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
@@ -3,15 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "DonutBlock.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern int _ZN16MeshColliderBase7DisableEv(void*);
 extern int* data_ov036_02113d78[];
 }
 
 int DonutBlock::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  if(((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled()) ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(data_ov036_02113d78[0]))->Release();
   ((SharedFilePtr *)(data_ov036_02113d78[1]))->Release();
   return 1;

--- a/src/_ZN10PyramidTop13InitResourcesEv.cpp
+++ b/src/_ZN10PyramidTop13InitResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidTop.h"
+#include "MeshColliderBase.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void func_020393d4(void* p, void* v);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void* thiz, void* act);
 extern void _ZN5Event8ClearBitEj(unsigned int n);
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
 }
@@ -25,7 +25,7 @@ int PyramidTop::InitResources()
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
         ((char*)this) + 0x124, mc, ((char*)this) + 0x370, 0x199, mAngleY, data_ov024_021129f0);
     func_020393d4(((char*)this) + 0x124, (void*)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this) + 0x124, ((char*)this));
+    ((MeshColliderBase *)(((char*)this) + 0x124))->Enable((Actor *)(((char*)this)));
     unk_3a0 = mPosX;
     unk_3a4 = mPosY;
     unk_3a8 = mPosZ;

--- a/src/_ZN10PyramidTop16CleanupResourcesEv.cpp
+++ b/src/_ZN10PyramidTop16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidTop.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov024_02113968[];
 
 int PyramidTop::CleanupResources()
 {
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     ((SharedFilePtr *)(data_ov024_02113968))->Release();
     ((SharedFilePtr *)(data_ov024_02113960))->Release();
     return 1;

--- a/src/_ZN10SlidingIce13InitResourcesEv.cpp
+++ b/src/_ZN10SlidingIce13InitResourcesEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MeshColliderBase.h"
 extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
@@ -7,7 +8,6 @@ extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, int, void *, int, int, void *);
 extern void func_020393d4(int *p, int v);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void *, void *);
 extern int func_ov030_02113be8[];
 extern char data_ov027_02113be0[];
 extern char data_ov027_02113108[];
@@ -25,7 +25,7 @@ int _ZN10SlidingIce13InitResourcesEv(char *c){
         c+0x124, *(int*)(data_ov027_02113be0+4), c+0x2ec, 0x1000, *(short*)(c+0x8e), data_ov027_02113108);
     func_020393d4((int*)(c+0x124), (int)_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     *(char*)(c+0x170) = 0;
-    _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
+    ((MeshColliderBase *)(c+0x124))->Enable((Actor *)(c));
     *(int*)(c+0x98) = 0x2d000;
     *(short*)(c+0x31e) = 0x64;
     *(short*)(c+0x94) = -0x4000;

--- a/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
+++ b/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
@@ -3,14 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingIce.h"
 #include "SharedFilePtr.h"
-extern "C" void _ZN16MeshColliderBase7DisableEv(char*);
+#include "MeshColliderBase.h"
 extern char func_ov030_02113be8[];
 extern char data_ov027_02113be0[];
 
 int SlidingIce::CleanupResources()
 {
   unsigned char ok = (mActorID==0x5d);
-  if(ok){ _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider); }
+  if(ok){ ((MeshColliderBase *)((char *)&mMeshCollider))->Disable(); }
   ((SharedFilePtr *)(func_ov030_02113be8))->Release();
   ((SharedFilePtr *)(data_ov027_02113be0))->Release();
   return 1;

--- a/src/_ZN10StarSwitch16CleanupResourcesEv.cpp
+++ b/src/_ZN10StarSwitch16CleanupResourcesEv.cpp
@@ -3,11 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "StarSwitch.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 // _ZN10StarSwitch16CleanupResourcesEv at 0x020ba568
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void*);
-void _ZN16MeshColliderBase7DisableEv(void*);
 void UnloadSilverStarAndNumber(void);
 }
 
@@ -18,8 +17,8 @@ extern char data_ov002_0211092c;
 int StarSwitch::CleanupResources()
 {
     int t;
-    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+    if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(*(void**)(&data_ov002_021098e8 + unk_34c * 0xc)))->Release();
     ((SharedFilePtr *)(*(void**)(&data_ov002_021098ec + unk_34c * 0xc)))->Release();

--- a/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
+++ b/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "CannonHatch.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int CannonHatch::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN11CastleWater16CleanupResourcesEv.cpp
+++ b/src/_ZN11CastleWater16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "CastleWater.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int CastleWater::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN11CastleWater8BehaviorEv.cpp
+++ b/src/_ZN11CastleWater8BehaviorEv.cpp
@@ -4,9 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CastleWater.h"
+#include "MeshColliderBase.h"
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-extern int _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 extern unsigned char data_0209f2d8;
 
@@ -17,8 +17,8 @@ int CastleWater::Behavior()
     _ZN8Platform19UpdateClsnPosAndRotEv(((void*)this));
     b = (int)(data_0209f2d8 == 1);
     if (b != 0) {
-        if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMovingMeshCollider) == 0)
-            _ZN16MeshColliderBase6EnableEP5Actor((char*)((void*)this)+0x124, ((void*)this));
+        if (((MeshColliderBase *)((char*)&mMovingMeshCollider))->IsEnabled() == 0)
+            ((MeshColliderBase *)((char*)((void*)this)+0x124))->Enable((Actor *)(((void*)this)));
     } else {
         _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((void*)this), 0, 0);
     }

--- a/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
+++ b/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidStep.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int PyramidStep::CleanupResources()
 {
-    _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();
     return 1;

--- a/src/_ZN12FortressWall16CleanupResourcesEv.cpp
+++ b/src/_ZN12FortressWall16CleanupResourcesEv.cpp
@@ -5,13 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FortressWall.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern char data_ov079_02128058[];
 extern char data_ov079_0212805c[];
 
 int FortressWall::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov079_02128058 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov079_0212805c + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;

--- a/src/_ZN12SwitchPillar13InitResourcesEv.cpp
+++ b/src/_ZN12SwitchPillar13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SwitchPillar.h"
+#include "MeshColliderBase.h"
 extern "C" {
 int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
@@ -13,7 +14,6 @@ int _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void*,void*,int,int,un
 int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
-int _ZN16MeshColliderBase6EnableEP5Actor(void*,void*);
 extern int data_0209caa0[];
 }
 
@@ -27,7 +27,7 @@ int SwitchPillar::InitResources()
   _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
   _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, data_ov012_021124c8[1], ((char*)this)+0x2ec, 0x1000, mAngleY, data_ov012_02111c90);
-  _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+  ((MeshColliderBase *)(((char*)this)+0x124))->Enable((Actor *)(((char*)this)));
   int v = mPosY - 0x4b0000;
   mLoweredY = v;
   if(data_0209caa0[2] & 0x80000){

--- a/src/_ZN12SwitchPillar16CleanupResourcesEv.cpp
+++ b/src/_ZN12SwitchPillar16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SwitchPillar.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov012_021124d0[];
 
 int SwitchPillar::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(data_ov012_021124d0))->Release();
     ((SharedFilePtr *)(data_ov012_021124c8))->Release();

--- a/src/_ZN12WorkElevator16CleanupResourcesEv.cpp
+++ b/src/_ZN12WorkElevator16CleanupResourcesEv.cpp
@@ -5,16 +5,17 @@
 /* recovered: named members + shared header, real C++ method */
 #include "WorkElevator.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov021_021149b8[];
 
 int WorkElevator::CleanupResources()
 {
     int i;
     char *p = ((char *)this);
-    _ZN16MeshColliderBase7DisableEv(p + 0x124);
+    ((MeshColliderBase *)(p + 0x124))->Disable();
     p += 0x520;
     for (i = 0; i < 4; i++) {
-        _ZN16MeshColliderBase7DisableEv(p);
+        ((MeshColliderBase *)(p))->Disable();
         p += 0x1c8;
     }
     ((SharedFilePtr *)(data_ov021_021149b0))->Release();

--- a/src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp
@@ -5,13 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BigBrickBlock.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern char data_ov002_02108ab0[];
 extern char data_ov002_02108ab4[];
 
 int BigBrickBlock::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov002_02108ab0 + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov002_02108ab4 + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
   return 1;

--- a/src/_ZN13BigBrickBlock8BehaviorEv.cpp
+++ b/src/_ZN13BigBrickBlock8BehaviorEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBrickBlock.h"
+#include "MeshColliderBase.h"
 extern "C" int _ZN5Event6GetBitEj(unsigned int a);
 extern "C" void *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void *after);
 extern "C" void func_020393a4(int *p, int v);
@@ -28,8 +29,8 @@ int BigBrickBlock::Behavior()
         }
 
         if (_ZN5Event6GetBitEj(mEventID) == 0 || unk_31e != 0) {
-            if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider) != 0)
-                _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+            if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled() != 0)
+                ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
         } else {
             func_020393a4((int *)((char *)&mMeshCollider), 0x15e000);
             func_02039394((int *)((char *)&mMeshCollider), 0x64000);

--- a/src/_ZN13FortressTower16CleanupResourcesEv.cpp
+++ b/src/_ZN13FortressTower16CleanupResourcesEv.cpp
@@ -5,13 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FortressTower.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern char data_ov102_0214e188[];
 extern char data_ov102_0214e18c[];
 
 int FortressTower::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov102_0214e188 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov102_0214e18c + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;

--- a/src/_ZN13FortressTower8BehaviorEv.cpp
+++ b/src/_ZN13FortressTower8BehaviorEv.cpp
@@ -2,9 +2,8 @@
 // @symbol _ZN13FortressTower8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "FortressTower.h"
+#include "MeshColliderBase.h"
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void* c);
-void _ZN16MeshColliderBase6EnableEP5Actor(void* c, void* a);
 int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* c, int a, int b);
 extern unsigned char data_0209f2d8[];
 }
@@ -23,8 +22,8 @@ int FortressTower::Behavior()
     }
     int on = (data_0209f2d8[0] == 1);
     if (on) {
-        if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&mMovingMeshCollider))
-            _ZN16MeshColliderBase6EnableEP5Actor((char*)((char*)this)+0x124, ((char*)this));
+        if (!((MeshColliderBase *)((char*)&mMovingMeshCollider))->IsEnabled())
+            ((MeshColliderBase *)((char*)((char*)this)+0x124))->Enable((Actor *)(((char*)this)));
     } else {
         _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(((char*)this), r1, 0);
     }

--- a/src/_ZN13PoleBillboard16CleanupResourcesEv.cpp
+++ b/src/_ZN13PoleBillboard16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "PoleBillboard.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int PoleBillboard::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN13QuestionBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN13QuestionBlock16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionBlock.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
 extern void _ZN5Actor11UntrackStarERa(void *self, void *p);
 }
@@ -25,8 +26,8 @@ extern char data_ov102_0214e7d0[];
 int QuestionBlock::CleanupResources()
 {
     int b, b2, b3;
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
 
     b = (int)(mActorId == 0x16);
     if (b)

--- a/src/_ZN13QuestionBlock8BehaviorEv.cpp
+++ b/src/_ZN13QuestionBlock8BehaviorEv.cpp
@@ -4,11 +4,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionBlock.h"
+#include "MeshColliderBase.h"
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
 extern void func_020393a4(int* p, int v);
 extern void func_02039394(int* p, int v);
 extern void _ZN9Animation7AdvanceEv(void* a);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void* m, void* self);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern int data_0209caa0[];
 extern unsigned char data_0209f2d8;
@@ -26,8 +26,8 @@ int QuestionBlock::Behavior()
     func_020393a4((int*)((char*)&mMeshCollider), 0x8c000);
     func_02039394((int*)((char*)&mMeshCollider), 0x46000);
     if (unk_3e8 != 0) {
-        if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider) != 0) {
-            _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+        if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled() != 0) {
+            ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
         }
         goto end;
     }
@@ -35,8 +35,8 @@ int QuestionBlock::Behavior()
         int b = (int)(mActorId == 0x14);
         if (b != 0) {
             _ZN9Animation7AdvanceEv((char*)&mAnimation);
-            if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider) != 0) {
-                _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+            if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled() != 0) {
+                ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
             }
             goto end;
         }
@@ -44,8 +44,8 @@ int QuestionBlock::Behavior()
     {
         int b = (int)(data_0209f2d8 == 1);
         if (b != 0) {
-            if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider) == 0) {
-                _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+            if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled() == 0) {
+                ((MeshColliderBase *)(((char*)this)+0x124))->Enable((Actor *)(((char*)this)));
             }
             goto end;
         }

--- a/src/_ZN13TTC_MovingBar16CleanupResourcesEv.cpp
+++ b/src/_ZN13TTC_MovingBar16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TTC_MovingBar.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 
 int TTC_MovingBar::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov065_0211d35c + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov065_0211d360 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;

--- a/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
+++ b/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "UpDownLiftBbh.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
 extern void* data_ov095_02136f68[];
 extern void* data_ov095_02136f74[];
@@ -12,8 +13,8 @@ extern void* data_ov095_02136f74[];
 
 int UpDownLiftBbh::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  if(((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(data_ov095_02136f68[*(int*)((char*)&mVariant)]))->Release();
   ((SharedFilePtr *)(data_ov095_02136f74[*(int*)((char*)&mVariant)]))->Release();
   return 1;

--- a/src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp
+++ b/src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ArrowSignRight.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern char data_ov098_0213c380[];
 
 int ArrowSignRight::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov098_0213c380 + (unsigned char)((char *)this)[0x37c]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov098_0213c384 + (unsigned char)((char *)this)[0x37c]*0xc)))->Release();
   return 1;

--- a/src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp
+++ b/src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "KnockDownPlank.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern char data_ov015_02114534[];
 
 int KnockDownPlank::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     ((SharedFilePtr *)(*(void **)(data_ov015_02114534 + mVariant * 0xc)))->Release();
     ((SharedFilePtr *)(*(void **)(data_ov015_02114538 + mVariant * 0xc)))->Release();
     return 1;

--- a/src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "MovingBarSmall.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int MovingBarSmall::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp
+++ b/src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionSwitch.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov002_0210dd60[];
 extern int data_ov002_0210dd68[];
 extern int data_ov002_0210dd58[];
@@ -12,8 +13,8 @@ extern int data_ov002_0210dd50[];
 
 int QuestionSwitch::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&unk_324)) _ZN16MeshColliderBase7DisableEv((char *)&unk_324);
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&unk_324))->IsEnabled()) ((MeshColliderBase *)((char *)&unk_324))->Disable();
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     ((SharedFilePtr *)(data_ov002_0210dd60))->Release();
     ((SharedFilePtr *)(data_ov002_0210dd68))->Release();
     ((SharedFilePtr *)(data_ov002_0210dd58))->Release();

--- a/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
+++ b/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
@@ -3,17 +3,16 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SquarePathLift.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
 struct SFP{int x;};
 extern SFP data_ov052_021125a0[2];
-int _ZN16MeshColliderBase9IsEnabledEv(void*);
-void _ZN16MeshColliderBase7DisableEv(void*);
 }
 
 int SquarePathLift::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  if(((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
   ((SharedFilePtr *)((void*)data_ov052_021125a0[0].x))->Release();
   ((SharedFilePtr *)((void*)data_ov052_021125a0[1].x))->Release();
   return 1;

--- a/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
+++ b/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TtcMovingCubeA.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int TtcMovingCubeA::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
+++ b/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ChainChompFence.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int ChainChompFence::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FireSeaElevator.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov045_021131b0[];
 
 int FireSeaElevator::CleanupResources()
 {
-    _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     ((SharedFilePtr *)(data_ov045_021131b0))->Release();
     ((SharedFilePtr *)(data_ov045_021131a8))->Release();
     return 1;

--- a/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
+++ b/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
@@ -3,16 +3,15 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingFirebar.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void* self);
-void _ZN16MeshColliderBase7DisableEv(void* self);
 extern int data_ov064_0211adbc[];
 }
 
 int RotatingFirebar::CleanupResources()
 {
-  if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
   ((SharedFilePtr *)((void*)data_ov064_0211adbc[0]))->Release();
   ((SharedFilePtr *)((void*)data_ov064_0211adbc[1]))->Release();
   return 1;

--- a/src/_ZN15RotatingFirebar8BehaviorEv.cpp
+++ b/src/_ZN15RotatingFirebar8BehaviorEv.cpp
@@ -6,6 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingFirebar.h"
+#include "MeshColliderBase.h"
 #pragma opt_propagation off
 #pragma opt_dead_assignments off
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
@@ -42,8 +43,8 @@ int RotatingFirebar::Behavior()
 
     b = ((unk_0b0 & 8) != 0) ? 1 : 0;
     if (b) {
-        if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider) != 0) {
-            _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+        if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled() != 0) {
+            ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
         }
         return 1;
     }

--- a/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
@@ -5,14 +5,15 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 struct E { void* p; char pad[8]; };
 extern struct E data_ov065_0211cfd0[];
 extern struct E data_ov065_0211cfd4[];
 
 int TtcRotatingCube::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char*)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char*)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char*)&mMovingMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(data_ov065_0211c0a8[unk_377]))->Release();
     ((SharedFilePtr *)(data_ov065_0211cfd0[unk_377].p))->Release();

--- a/src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingGear.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int TtcRotatingGear::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingCogSmall.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
 extern char data_ov035_02112c78[];
 extern char data_ov035_02112c70[];
@@ -14,8 +15,8 @@ extern char data_ov035_02112c60[];
 int RotatingCogSmall::CleanupResources()
 {
   if(mRotationState==0){
-    if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider))
-      _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if(((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled())
+      ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     ((SharedFilePtr *)(data_ov035_02112c78))->Release();
     ((SharedFilePtr *)(data_ov056_02112c68))->Release();
   } else {

--- a/src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp
+++ b/src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingClockHand.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int RotatingClockHand::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp
+++ b/src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingPlatformWf.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 
 int SlidingPlatformWf::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov091_02135024 + (unsigned char)((char *)this)[0x322]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov091_02135028 + (unsigned char)((char *)this)[0x322]*0xc)))->Release();
   return 1;

--- a/src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp
+++ b/src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BowserFireSeaArena.h"
+#include "MeshColliderBase.h"
 typedef int Fix12;
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int func_020393d4(void*, void*);
-extern int _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
 
 
@@ -24,7 +24,7 @@ int BowserFireSeaArena::InitResources()
   kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov060_0211aff4);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x374, kcl, ((char*)this)+0x2ec, 0x1000, unk_08e, &func_021115bc);
   func_020393d4(((char*)this)+0x374, &_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x374, ((char*)this));
+  ((MeshColliderBase *)(((char*)this)+0x374))->Enable((Actor *)(((char*)this)));
   unk_31e = 0;
   unk_320 = 0;
   unk_322 = 0;

--- a/src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp
+++ b/src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BowserFireSeaArena.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int BowserFireSeaArena::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider2)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider2);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider2))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider2))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
+++ b/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BowserPuzzleManager.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern void *data_ov064_0211adc8[];
 
 int BowserPuzzleManager::CleanupResources()
 {
     unsigned char idx;
-    _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     idx = *(unsigned char *)((char *)&unk_337);
     ((SharedFilePtr *)(data_ov064_0211adc8[idx]))->Release();
     ((SharedFilePtr *)(&data_ov075_0211c800))->Release();

--- a/src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp
+++ b/src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FloatingFloorLllBig.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int FloatingFloorLllBig::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformLll.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov022_02114558[];
 
 int RotatingPlatformLll::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(data_ov022_02114558))->Release();
     ((SharedFilePtr *)(data_ov022_02114550))->Release();

--- a/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
+#include "MeshColliderBase.h"
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void *bmd, void *bta);
@@ -14,7 +15,6 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *mc, void *kcl, void *mtx, int fix, short s, void *clps);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void *mc, void *actor);
 
 extern u8 data_0209f2c0[];
 extern int data_0209f32c;
@@ -44,7 +44,7 @@ int RotatingPlatformWdw::InitResources()
     k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov029_02114304);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
         ((char *)this) + 0x124, k, ((char *)this) + 0x2ec, 0x1000, mAngleY, &data_ov029_02112fec);
-    _ZN16MeshColliderBase6EnableEP5Actor(((char *)this) + 0x124, ((char *)this));
+    ((MeshColliderBase *)(((char *)this) + 0x124))->Enable((Actor *)(((char *)this)));
 
     unk_340 = (u8)mAreaId;
     mAreaId = -1;

--- a/src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int RotatingPlatformWdw::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
@@ -5,8 +5,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
+#include "MeshColliderBase.h"
 extern int IsAreaShowing(int idx);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void *m, void *actor);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, void *pos, unsigned e);
 extern void _ZN9Animation7AdvanceEv(void *a);
 extern s16 data_02082214[];
@@ -23,12 +23,12 @@ int RotatingPlatformWdw::Behavior()
     /* area id at 0x340: ROM does add r0,r4,#0x300; ldrsb r0,[r0,#0x40] */
     if (IsAreaShowing(*(s8 *)((u8 *)(((int)((u8 *)this) + 0x300)) + 0x40)) == 0) {
         mAreaId = *(s8 *)((u8 *)(((unsigned)((u8 *)this) + 0x300)) + 0x40);
-        if (_ZN16MeshColliderBase9IsEnabledEv((u8 *)&mMeshCollider) != 0) {
-            _ZN16MeshColliderBase7DisableEv((u8 *)&mMeshCollider);
+        if (((MeshColliderBase *)((u8 *)&mMeshCollider))->IsEnabled() != 0) {
+            ((MeshColliderBase *)((u8 *)&mMeshCollider))->Disable();
         }
     } else {
-        if (_ZN16MeshColliderBase9IsEnabledEv((u8 *)&mMeshCollider) == 0) {
-            _ZN16MeshColliderBase6EnableEP5Actor(((u8 *)this) + 0x124, ((u8 *)this));
+        if (((MeshColliderBase *)((u8 *)&mMeshCollider))->IsEnabled() == 0) {
+            ((MeshColliderBase *)(((u8 *)this) + 0x124))->Enable((Actor *)(((u8 *)this)));
         }
     }
 

--- a/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SwitchActivatedPlank.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int SwitchActivatedPlank::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
@@ -2,13 +2,12 @@
 // @symbol _ZN20SwitchActivatedPlank8BehaviorEv
 /* recovered: named members + shared header */
 #include "SwitchActivatedPlank.h"
+#include "MeshColliderBase.h"
 extern "C" {
 void func_020393a4(void* p, int v);
 int _ZN5Event6GetBitEj(unsigned int);
-int _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 void func_ov029_021126dc(char* c);
 int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void*, void*, int);
-int _ZN16MeshColliderBase7DisableEv(void*);
 
 #pragma optimize_for_size on
 
@@ -27,7 +26,7 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         *(short*)(((char*)self) + 0x300 + 0xa0) = 0;
         self->unk_3a3 = 1;
 
-        _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
+        ((MeshColliderBase *)(((char*)self)+0x124))->Enable((Actor *)(((char*)self)));
         func_ov029_021126dc(((char*)self));
         _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(((char*)self)+0x124, ((char*)self)+0x370, self->unk_08e);
         break;
@@ -39,7 +38,7 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         }
         *p = *p + 1;
         if (_ZN5Event6GetBitEj(self->unk_3a4) != 0) break;
-        _ZN16MeshColliderBase7DisableEv((char*)&self->mMovingMeshCollider);
+        ((MeshColliderBase *)((char*)&self->mMovingMeshCollider))->Disable();
         self->unk_3a2 = 0;
         self->unk_3a3 = 0;
         break;

--- a/src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp
@@ -5,13 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TtcConveyorBeltLarge.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern char data_ov065_0211d194[];
 extern char data_ov065_0211d198[];
 
 int TtcConveyorBeltLarge::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov065_0211d194 + (unsigned char)((char *)this)[0x39e]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov065_0211d198 + (unsigned char)((char *)this)[0x39e]*0xc)))->Release();
   return 1;

--- a/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
@@ -3,8 +3,8 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatform.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-extern int _ZN16MeshColliderBase7DisableEv(void*);
 extern void* data_ov091_021344fc[];
 extern void* data_ov091_021344f4[];
 }
@@ -13,6 +13,6 @@ int RotatingUpDownPlatform::CleanupResources()
 {
   ((SharedFilePtr *)(data_ov091_021344fc[mVariant]))->Release();
   ((SharedFilePtr *)(data_ov091_021344f4[mVariant]))->Release();
-  _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
   return 1;
 }

--- a/src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp
+++ b/src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnWaterPlatformJrb.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov016_02114e74[];
 
 int FloatOnWaterPlatformJrb::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(data_ov016_02114e74))->Release();
     ((SharedFilePtr *)(data_ov016_02114e6c))->Release();

--- a/src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatformUtm.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 struct SFP { void *a, *b, *c; };
 extern struct SFP data_ov091_02134c30[];
 extern struct SFP data_ov091_02134c34[];
@@ -12,8 +13,8 @@ extern struct SFP data_ov091_02134c34[];
 int RotatingUpDownPlatformUtm::CleanupResources()
 {
   if(mSpawnParam == 0xffff) return 1;
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(data_ov091_02134c30[mVariant].a))->Release();
   ((SharedFilePtr *)(data_ov091_02134c34[mVariant].a))->Release();
   return 1;

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnWaterPlatformWdwSquare.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int FloatOnWaterPlatformWdwSquare::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN5Crate16CleanupResourcesEv.cpp
+++ b/src/_ZN5Crate16CleanupResourcesEv.cpp
@@ -5,13 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Crate.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov098_0213c4c8[];
 
 int Crate::CleanupResources()
 {
   int* f;
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   f = 0;
   if(mActorID == 0xc2) f = data_ov098_0213c4c8;
   if(f){

--- a/src/_ZN5Stage16CleanupResourcesEv.cpp
+++ b/src/_ZN5Stage16CleanupResourcesEv.cpp
@@ -4,6 +4,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 /* _ZN5Stage16CleanupResourcesEv @ 0x0202c9a8 (arm9, size 0x264)
  * Releases the level file handles, tears down fader/mesh-collider/message
  * state and unloads the level overlays/archive. Returns 1.
@@ -34,7 +35,6 @@ extern void _ZN5Scene20SetAndStopColorFaderEv(void);
 extern void func_02073244(void *, int, int, void (*)(void *));
 extern void _ZN9FaderWipeD1Ev(void *);
 extern void CleanCommonModelDataArr(void);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
 extern void _ZN5Stage18ResetMeshCollidersEv(void);
 extern void func_01ffb0c8(void *);
 extern void Deallocate(void);
@@ -96,7 +96,7 @@ int Stage::CleanupResources()
     func_02073244(data_0209f324, 0x60, 8, _ZN9FaderWipeD1Ev);
     data_0209f324 = 0;
     CleanCommonModelDataArr();
-    _ZN16MeshColliderBase7DisableEv((char *)&unk_91c);
+    ((MeshColliderBase *)((char *)&unk_91c))->Disable();
     _ZN5Stage18ResetMeshCollidersEv();
     func_01ffb0c8((char *)&unk_91c);
     Deallocate();

--- a/src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp
+++ b/src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Stage.h"
+#include "MeshColliderBase.h"
 struct KCL_File;
 struct CLPS_Block;
 struct MeshCollider;
@@ -37,7 +38,6 @@ extern void _ZN12MeshCollider17UpdateFileOffsetsER8KCL_File(struct KCL_File* f);
 extern void _ZN12MeshCollider7SetFileEP8KCL_FileR10CLPS_Block(struct MeshCollider* thiz, struct KCL_File* f, struct CLPS_Block* clps);
 extern int _ZNK12MeshCollider16GetOctreeOriginYEv(struct MeshCollider* thiz);
 extern int _ZNK12MeshCollider13GetUnkOctreeYEv(struct MeshCollider* thiz);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(struct MeshCollider* thiz, struct Actor* a);
 extern void _Z11LoadObjectsRN11LVL_Overlay8ObjTableEij(struct ObjTable* t, int i, unsigned int p);
 extern void _ZN12ActorDerived5SpawnEjP9ActorBaseii(unsigned int id, struct ActorBase* parent, int a, int b);
 
@@ -60,7 +60,7 @@ void _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider(struct LVL_Ove
         _ZN12MeshCollider17UpdateFileOffsetsER8KCL_File(f);
         _ZN12MeshCollider7SetFileEP8KCL_FileR10CLPS_Block(mc, f, ovl->clps);
         func_0202a850(_ZNK12MeshCollider16GetOctreeOriginYEv(mc), _ZNK12MeshCollider13GetUnkOctreeYEv(mc));
-        _ZN16MeshColliderBase6EnableEP5Actor(mc, 0);
+        ((MeshColliderBase *)(mc))->Enable((Actor *)(0));
     }
 
     data_ov002_0211118c = 0;

--- a/src/_ZN5Whomp16CleanupResourcesEv.cpp
+++ b/src/_ZN5Whomp16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Whomp.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern void data_ov079_02128168(void);
 extern void data_ov079_02128178(void);
 extern void data_ov079_02128170(void);
@@ -13,8 +14,8 @@ extern void *data_ov079_021275ec[];
 int Whomp::CleanupResources()
 {
   int i;
-  if(_ZN16MeshColliderBase9IsEnabledEv((unsigned char *)&mMovingMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((unsigned char *)&mMovingMeshCollider);
+  if(((MeshColliderBase *)((unsigned char *)&mMovingMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((unsigned char *)&mMovingMeshCollider))->Disable();
   ((SharedFilePtr *)(data_ov079_02127bf0[((unsigned char *)this)[0x414]]))->Release();
   if(((unsigned char *)this)[0x414]){
     ((SharedFilePtr *)((void*)&data_ov079_02128168))->Release();

--- a/src/_ZN6Coffin16CleanupResourcesEv.cpp
+++ b/src/_ZN6Coffin16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Coffin.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int Coffin::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Dorrie.h"
+#include "MeshColliderBase.h"
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
@@ -13,7 +14,6 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, void* kcl, void* mtx, Fix12i r, short s, void* clps);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void* self, void* a);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* a, Fix12i r, Fix12i h, void* p, void* q);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, void* a, void* pos, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
@@ -53,7 +53,7 @@ int Dorrie::InitResources()
                 else
                     func_020393c4(mmc, func_ov065_021195d0);
             }
-            _ZN16MeshColliderBase6EnableEP5Actor(mmc, ((char*)this));
+            ((MeshColliderBase *)(mmc))->Enable((Actor *)(((char*)this)));
             mtx += 0x200;
             mmc += 0x200;
         }

--- a/src/_ZN6Dorrie16CleanupResourcesEv.cpp
+++ b/src/_ZN6Dorrie16CleanupResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Dorrie.h"
+#include "MeshColliderBase.h"
 struct SharedFilePtr { unsigned int data[4]; };
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *);
 extern struct SharedFilePtr data_ov002_0210d9c0;
@@ -18,7 +19,7 @@ int Dorrie::CleanupResources()
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210d9c0);
     p = ((char *)this) + 0x180;
     for (i = 0; i < 7; i++) {
-        _ZN16MeshColliderBase7DisableEv(p);
+        ((MeshColliderBase *)(p))->Disable();
         _ZN13SharedFilePtr7ReleaseEv(data_ov065_0211c08c[i]);
         p += 0x200;
     }

--- a/src/_ZN6Eyerok13InitResourcesEv.cpp
+++ b/src/_ZN6Eyerok13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Eyerok.h"
+#include "MeshColliderBase.h"
 extern int data_ov066_0211ae6c[];
 extern int data_ov066_0211ae4c[];
 extern int data_ov066_0211aeb4[];
@@ -45,7 +46,6 @@ extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 b, Vector3
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, int kcl, void* mtx, s32 fix, s16 s, void* clps);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void* thiz, void* actor);
 
 int Eyerok::InitResources()
 {
@@ -151,7 +151,7 @@ int Eyerok::InitResources()
         _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x674, data_ov066_0211ae24[1], c + 0x83C, 0x199, *(s16*)(c + 0x8E), &func_02112ca8);
         func_020393d4(c + 0x674, &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
         func_020393c4(c + 0x674, &func_ov066_0211a35c);
-        _ZN16MeshColliderBase6EnableEP5Actor(c + 0x674, c);
+        ((MeshColliderBase *)(c + 0x674))->Enable((Actor *)(c));
         *(s16*)(c + 0x4D2) = 0x64;
         func_ov066_02119454(c, data_ov066_0211b09c);
     } else {

--- a/src/_ZN6Eyerok16CleanupResourcesEv.cpp
+++ b/src/_ZN6Eyerok16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Eyerok.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern char data_ov066_0211ae6c[];
 extern char data_ov066_0211ae4c[];
 extern char data_ov066_0211aeb4[];
@@ -30,8 +31,8 @@ extern char data_ov066_0211ae34[];
 
 int Eyerok::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&unk_674))
-    _ZN16MeshColliderBase7DisableEv((char *)&unk_674);
+  if(((MeshColliderBase *)((char *)&unk_674))->IsEnabled())
+    ((MeshColliderBase *)((char *)&unk_674))->Disable();
   if(unk_49c==0){
     ((SharedFilePtr *)(data_ov066_0211ae6c))->Release();
     ((SharedFilePtr *)(data_ov066_0211ae4c))->Release();

--- a/src/_ZN6ShipUp13InitResourcesEv.cpp
+++ b/src/_ZN6ShipUp13InitResourcesEv.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
+#include "MeshColliderBase.h"
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 extern void func_020393d4(int* p, int v);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 extern int IsStarCollected(int a, int b);
 extern void* _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern unsigned char data_0209f220;
@@ -37,7 +37,7 @@ int ShipUp::InitResources()
     if (mModelIndex == 0) {
         func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     }
-    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+    ((MeshColliderBase *)(((char*)this)+0x124))->Enable((Actor *)(((char*)this)));
     unk_324 = 0;
     unk_328 = 0;
     if (data_0209f220 > 1) {

--- a/src/_ZN6ShipUp16CleanupResourcesEv.cpp
+++ b/src/_ZN6ShipUp16CleanupResourcesEv.cpp
@@ -5,13 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
 }
 
 int ShipUp::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  if(((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(data_ov016_021136e4[mModelIndex]))->Release();
   ((SharedFilePtr *)(data_ov016_021136dc[mModelIndex]))->Release();
   return 1;

--- a/src/_ZN6ShipUp8BehaviorEv.cpp
+++ b/src/_ZN6ShipUp8BehaviorEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
-extern int _ZN16MeshColliderBase6EnableEP5Actor(void* m, void* a);
+#include "MeshColliderBase.h"
 extern void func_020393a4(int* p, int v);
 extern int _ZN5Actor13DistToCPlayerEv(void* a);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int e);
@@ -13,8 +13,8 @@ extern short data_02082214[];
 
 int ShipUp::Behavior()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider) == 0){
-    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+  if(((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled() == 0){
+    ((MeshColliderBase *)(((char*)this)+0x124))->Enable((Actor *)(((char*)this)));
   }
   func_020393a4((int*)((char*)&mMeshCollider), 0x2000000);
   if(mModelIndex == 0){

--- a/src/_ZN6Thwomp16CleanupResourcesEv.cpp
+++ b/src/_ZN6Thwomp16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Thwomp.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 
 int Thwomp::CleanupResources()
 {
     void **fp;
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
     fp = *(void***)((char *)&mFileTable);
     ((SharedFilePtr *)(fp[0]))->Release();

--- a/src/_ZN6ToxBox16CleanupResourcesEv.cpp
+++ b/src/_ZN6ToxBox16CleanupResourcesEv.cpp
@@ -3,9 +3,8 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ToxBox.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void*);
-int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov092_02132540[];
 extern int data_ov092_02132548[];
 }
@@ -14,7 +13,7 @@ int ToxBox::CleanupResources()
 {
   ((SharedFilePtr *)((void*)data_ov092_02132540))->Release();
   ((SharedFilePtr *)((void*)data_ov092_02132548))->Release();
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  if(((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
   return 1;
 }

--- a/src/_ZN8CccArena13InitResourcesEv.cpp
+++ b/src/_ZN8CccArena13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CccArena.h"
+#include "MeshColliderBase.h"
 extern int _ZN5Model8LoadFileER13SharedFilePtr(int);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
@@ -11,7 +12,6 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(int);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,short,int);
 extern void func_020393d4(void*,void*);
 extern void func_020393c4(void*,void*);
-extern int _ZN16MeshColliderBase6EnableEP5Actor(void*,void*);
 
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
 
@@ -57,7 +57,7 @@ int CccArena::InitResources()
 
     func_020393d4(((char *)this) + 0x124, _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     func_020393c4(((char *)this) + 0x124, func_ov073_021227d0);
-    _ZN16MeshColliderBase6EnableEP5Actor(((char *)this) + 0x124, ((char *)this));
+    ((MeshColliderBase *)(((char *)this) + 0x124))->Enable((Actor *)(((char *)this)));
 
     unk_338 = 0;
     unk_334 = 0;

--- a/src/_ZN8CccArena16CleanupResourcesEv.cpp
+++ b/src/_ZN8CccArena16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "CccArena.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 
 int CccArena::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov073_021231bc + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov073_021231c0 + (unsigned char)((char *)this)[0x32c]*0xc)))->Release();
   return 1;

--- a/src/_ZN8IceBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN8IceBlock16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "IceBlock.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov081_02128fd8[];
 
 int IceBlock::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(data_ov081_02128fd8))->Release();
     ((SharedFilePtr *)(data_ov081_02128fd0))->Release();

--- a/src/_ZN8IceSheet16CleanupResourcesEv.cpp
+++ b/src/_ZN8IceSheet16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int IceSheet::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN8IceSheet8BehaviorEv.cpp
+++ b/src/_ZN8IceSheet8BehaviorEv.cpp
@@ -2,14 +2,13 @@
 // @symbol _ZN8IceSheet8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
+#include "MeshColliderBase.h"
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void*);
-void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 }
 
 int IceSheet::Behavior()
 {
-  if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&mMovingMeshCollider))
-    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+  if (!((MeshColliderBase *)((char*)&mMovingMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)(((char*)this)+0x124))->Enable((Actor *)(((char*)this)));
   return 1;
 }

--- a/src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp
+++ b/src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp
@@ -4,10 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Platform.h"
+#include "MeshColliderBase.h"
 extern "C" {
 extern void* _ZN5Actor13ClosestPlayerEv(void*);
 extern int Vec3_Dist(void*, void*);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(struct Platform *self, int a, int b) {
   struct Vector3 v;
   v.x = self->mPosX;
@@ -19,12 +19,12 @@ int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(struct Platform *self, int a, int b
   void* p = _ZN5Actor13ClosestPlayerEv(((char*)self));
   int d = Vec3_Dist(&v, (char*)p+0x5c);
   if (d > a) {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
-      _ZN16MeshColliderBase7DisableEv((char*)&self->mMeshCollider);
+    if (((MeshColliderBase *)((char*)&self->mMeshCollider))->IsEnabled())
+      ((MeshColliderBase *)((char*)&self->mMeshCollider))->Disable();
     return 0;
   }
-  if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
-    _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
+  if (!((MeshColliderBase *)((char*)&self->mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)(((char*)self)+0x124))->Enable((Actor *)(((char*)self)));
   return 1;
 }
 }

--- a/src/_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_.cpp
+++ b/src/_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_.cpp
@@ -4,20 +4,20 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Platform.h"
+#include "MeshColliderBase.h"
 extern "C" {
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 extern void* _ZN5Actor13ClosestPlayerEv(void*);
 extern int Vec3_Dist(void*, void*);
 int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(struct Platform *self, int a, int b) {
   int on = (self->unk_0b0 & 8) != 0;
   if (on) {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
-      _ZN16MeshColliderBase7DisableEv((char*)&self->mMeshCollider);
+    if (((MeshColliderBase *)((char*)&self->mMeshCollider))->IsEnabled())
+      ((MeshColliderBase *)((char*)&self->mMeshCollider))->Disable();
     return 0;
   }
   if (a == 0) {
-    if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
-      _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
+    if (!((MeshColliderBase *)((char*)&self->mMeshCollider))->IsEnabled())
+      ((MeshColliderBase *)(((char*)self)+0x124))->Enable((Actor *)(((char*)self)));
     goto done;
   }
   {
@@ -30,12 +30,12 @@ int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(struct Platform *self, int 
   void* p = _ZN5Actor13ClosestPlayerEv(((char*)self));
   int d = Vec3_Dist(&v, (char*)p+0x5c);
   if (d > a) {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
-      _ZN16MeshColliderBase7DisableEv((char*)&self->mMeshCollider);
+    if (((MeshColliderBase *)((char*)&self->mMeshCollider))->IsEnabled())
+      ((MeshColliderBase *)((char*)&self->mMeshCollider))->Disable();
     return 0;
   }
-  if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
-    _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
+  if (!((MeshColliderBase *)((char*)&self->mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)(((char*)self)+0x124))->Enable((Actor *)(((char*)self)));
   }
 done:
   return 1;

--- a/src/_ZN8PoleLift13InitResourcesEv.cpp
+++ b/src/_ZN8PoleLift13InitResourcesEv.cpp
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PoleLift.h"
+#include "MeshColliderBase.h"
 typedef int Fix12;
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
-extern int _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 
 int PoleLift::InitResources()
 {
@@ -23,7 +23,7 @@ int PoleLift::InitResources()
   _ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x158, kcl, ((char*)this)+0x128, 0x1000, unk_08e, data_ov045_021125b0);
   func_020396c0(((char*)this)+0x158, 4);
   unk_1a5 = 1;
-  _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x158, ((char*)this));
+  ((MeshColliderBase *)(((char*)this)+0x158))->Enable((Actor *)(((char*)this)));
   unk_0d4 = 1;
   return 1;
 }

--- a/src/_ZN8PoleLift16CleanupResourcesEv.cpp
+++ b/src/_ZN8PoleLift16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "PoleLift.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int PoleLift::CleanupResources()
 {
-    _ZN16MeshColliderBase7DisableEv((char *)&mCollider);
+    ((MeshColliderBase *)((char *)&mCollider))->Disable();
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();
     return 1;

--- a/src/_ZN8ShipWing16CleanupResourcesEv.cpp
+++ b/src/_ZN8ShipWing16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWing.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov036_0211408c[];
 
 int ShipWing::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(data_ov036_0211408c))->Release();
     ((SharedFilePtr *)(data_ov036_02114084))->Release();

--- a/src/_ZN8ShipWing8BehaviorEv.cpp
+++ b/src/_ZN8ShipWing8BehaviorEv.cpp
@@ -2,13 +2,12 @@
 // @symbol _ZN8ShipWing8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWing.h"
+#include "MeshColliderBase.h"
 void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* clsn);
 void WithMeshClsn_UpdateContinuous_Veneer(void* p);
 int _ZNK12WithMeshClsn10IsOnGroundEv(void* p);
 int _ZN5Actor13DistToCPlayerEv(void* p);
 void _ZN5Actor14TriplePoofDustEv(void* p);
-int _ZN16MeshColliderBase9IsEnabledEv(void* p);
-void _ZN16MeshColliderBase7DisableEv(void* p);
 void _ZN8Platform21UpdateModelPosAndRotYEv(void* p);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* p, int a, int b);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void* p);
@@ -33,7 +32,7 @@ int ShipWing::Behavior()
             if (_ZN5Actor13DistToCPlayerEv(((char*)this)) <= 0x9c4000) break;
         }
         _ZN5Actor14TriplePoofDustEv(((char*)this));
-        if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider) != 0) _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+        if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled() != 0) ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
         mPosX = unk_4dc;
         mPosY = unk_4e0;
         mPosZ = unk_4e4;

--- a/src/_ZN8SignPost16CleanupResourcesEv.cpp
+++ b/src/_ZN8SignPost16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SignPost.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int SignPost::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN8Squasher13InitResourcesEv.cpp
+++ b/src/_ZN8Squasher13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Squasher.h"
+#include "MeshColliderBase.h"
 extern "C" {
 int _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* m, int bmd, int a, int b);
@@ -14,7 +15,6 @@ void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
 int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* f);
 void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* mc, int kcl, struct Matrix4x3* mtx, int scale, short s, void* clps);
 void func_020393d4(int* p, int v);
-void _ZN16MeshColliderBase6EnableEP5Actor(void* mc, void* a);
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
 }
 
@@ -28,7 +28,7 @@ int Squasher::InitResources()
   int kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&_ZN32FloatOnWaterPlatformWdwRectangleD1Ev);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, kcl, (struct Matrix4x3*)((char*)&unk_2ec), 0x1000, mAngleY, &data_ov064_0211ba4c);
   func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+  ((MeshColliderBase *)(((char*)this)+0x124))->Enable((Actor *)(((char*)this)));
   unk_31e = 0;
   unk_320 = 0;
   unk_322 = 0;

--- a/src/_ZN8Squasher16CleanupResourcesEv.cpp
+++ b/src/_ZN8Squasher16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Squasher.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int Squasher::CleanupResources()
 {
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();
     return 1;

--- a/src/_ZN9HugeCover13InitResourcesEv.cpp
+++ b/src/_ZN9HugeCover13InitResourcesEv.cpp
@@ -2,6 +2,7 @@
 // @symbol _ZN9HugeCover13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "HugeCover.h"
+#include "MeshColliderBase.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct BTA_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block; struct Actor;
 struct Model { int d; };
@@ -9,7 +10,6 @@ struct ModelBase { int d; };
 struct TextureTransformer { int d; };
 struct MeshCollider { int d; };
 struct MovingMeshCollider { int d; };
-struct MeshColliderBase { int d; };
 
 extern "C" BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(ModelBase*, BMD_File*, int, int);
@@ -20,7 +20,6 @@ extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern "C" KCL_File* _ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     MovingMeshCollider*, KCL_File*, const Matrix4x3&, Fix12i, short, CLPS_Block&);
-extern "C" void _ZN16MeshColliderBase6EnableEP5Actor(MeshColliderBase*, Actor*);
 extern "C" int _ZN5Event6GetBitEj(unsigned int);
 
 struct D113afc { SharedFilePtr* a; BMD_File* b; };
@@ -47,6 +46,6 @@ int HugeCover::InitResources()
             (MovingMeshCollider*)(c + 0x124), kcl, *(const Matrix4x3*)(c + 0x2ec),
             0x1000, *(short*)(c + 0x8e), data_ov032_02112fb8);
     }
-    _ZN16MeshColliderBase6EnableEP5Actor((MeshColliderBase*)(c + 0x124), (Actor*)c);
+    ((MeshColliderBase *)((MeshColliderBase*)(c + 0x124)))->Enable((Actor *)((Actor*)c));
     return (int)(_ZN5Event6GetBitEj(0xe) == 0);
 }

--- a/src/_ZN9HugeCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9HugeCover16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "HugeCover.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int HugeCover::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN9SeesawBob16CleanupResourcesEv.cpp
+++ b/src/_ZN9SeesawBob16CleanupResourcesEv.cpp
@@ -5,11 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SeesawBob.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 
 int SeesawBob::CleanupResources()
 {
-  if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
-    _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+  if(((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+    ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
   ((SharedFilePtr *)(*(void**)(data_ov095_021374a0 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   ((SharedFilePtr *)(*(void**)(data_ov095_021374a4 + (unsigned char)((char *)this)[0x31e]*0xc)))->Release();
   return 1;

--- a/src/_ZN9SeesawBob8BehaviorEv.cpp
+++ b/src/_ZN9SeesawBob8BehaviorEv.cpp
@@ -2,11 +2,10 @@
 // @symbol _ZN9SeesawBob8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "SeesawBob.h"
+#include "MeshColliderBase.h"
 typedef short s16;
 struct V3 { int x, y, z; };
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void* self);
-void _ZN16MeshColliderBase7DisableEv(void* self);
 int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, void* v, unsigned int d);
 void func_ov095_021358cc(void* c, void* a, void* b, int d, int e, int f, int g);
 void func_ov095_0213597c(char *t);
@@ -18,8 +17,8 @@ int SeesawBob::Behavior()
 {
     int b = (int)((unk_0b0 & 8) != 0);
     if (b != 0) {
-        if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) {
-            _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+        if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled()) {
+            ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
         }
         return 1;
     }

--- a/src/_ZN9ShipWater16CleanupResourcesEv.cpp
+++ b/src/_ZN9ShipWater16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWater.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int ShipWater::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/_ZN9TinyCover13InitResourcesEv.cpp
+++ b/src/_ZN9TinyCover13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TinyCover.h"
+#include "MeshColliderBase.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
@@ -13,7 +14,6 @@ extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* thiz);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void* thiz, void* act);
 extern int _ZN5Event6GetBitEj(unsigned int n);
 }
 
@@ -28,7 +28,7 @@ int TinyCover::InitResources()
     void* mc = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov033_021124e8);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
         ((char*)this) + 0x124, mc, ((char*)this) + 0x2ec, 0x1000, mAngleY, data_ov033_02111c1c);
-    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this) + 0x124, ((char*)this));
+    ((MeshColliderBase *)(((char*)this) + 0x124))->Enable((Actor *)(((char*)this)));
     unk_334 = mPosY - 0x3c000;
     return _ZN5Event6GetBitEj(0xe) == 0;
 }

--- a/src/_ZN9TinyCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9TinyCover16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TinyCover.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int data_ov033_021124f0[];
 
 int TinyCover::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(data_ov033_021124f0))->Release();
     ((SharedFilePtr *)(data_ov033_021124e8))->Release();

--- a/src/_ZN9TowerStep16CleanupResourcesEv.cpp
+++ b/src/_ZN9TowerStep16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TowerStep.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int TowerStep::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp
@@ -5,12 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "MadPiano.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern int G0[];
 
 int MadPiano::CleanupResources()
 {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider)) {
-        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)(G0))->Release();
     ((SharedFilePtr *)(G1))->Release();

--- a/src/actors/MansionSteps/_ZN12MansionSteps16CleanupResourcesEv.cpp
+++ b/src/actors/MansionSteps/_ZN12MansionSteps16CleanupResourcesEv.cpp
@@ -5,10 +5,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "MansionSteps.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 
 int MansionSteps::CleanupResources()
 {
-    _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
+    ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     int idx = *(int*)((char*)&unk_140);
     ((SharedFilePtr *)((void*)(data_ov063_0211e27c[idx])))->Release();
     idx = *(int*)((char*)&unk_140);

--- a/src/func_ov002_020b68b0.cpp
+++ b/src/func_ov002_020b68b0.cpp
@@ -1,11 +1,10 @@
 //cpp
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 int func_ov002_020b68b0(void* c, void* r4) {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
-        _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
+    if (((MeshColliderBase *)((char*)c+0x124))->IsEnabled())
+        ((MeshColliderBase *)((char*)c+0x124))->Disable();
     ((SharedFilePtr *)(*(void**)r4))->Release();
     ((SharedFilePtr *)(*(void**)((char*)r4+4)))->Release();
     return 1;

--- a/src/func_ov002_020b6ac8.cpp
+++ b/src/func_ov002_020b6ac8.cpp
@@ -1,11 +1,10 @@
 //cpp
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 int func_ov002_020b6ac8(void* c, void* r4) {
-    if (_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
-        _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
+    if (((MeshColliderBase *)((char*)c+0x124))->IsEnabled())
+        ((MeshColliderBase *)((char*)c+0x124))->Disable();
     ((SharedFilePtr *)(*(void**)r4))->Release();
     ((SharedFilePtr *)(*(void**)((char*)r4+4)))->Release();
     return 1;

--- a/src/func_ov002_020baba8.cpp
+++ b/src/func_ov002_020baba8.cpp
@@ -1,11 +1,10 @@
 //cpp
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 int func_ov002_020baba8(char* c, void** p){
-  if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
+  if(((MeshColliderBase *)(c+0x124))->IsEnabled())
+    ((MeshColliderBase *)(c+0x124))->Disable();
   ((SharedFilePtr *)(p[0]))->Release();
   ((SharedFilePtr *)(p[1]))->Release();
   return 1;

--- a/src/func_ov002_020bba28.cpp
+++ b/src/func_ov002_020bba28.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MeshColliderBase.h"
 extern "C" void _Z14ApproachLinearRsss(short* cur, short to, short step);
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
 extern "C" void WithMeshClsn_UpdateContinuous_Veneer(void* p);
@@ -6,8 +7,6 @@ extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void* p);
 extern "C" int _ZNK12WithMeshClsn8IsOnWallEv(void* p);
 extern "C" int _ZNK12WithMeshClsn12TouchesWaterEv(void* p);
 extern "C" void func_ov002_020bafc0(void* self);
-extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void* p);
-extern "C" void _ZN16MeshColliderBase7DisableEv(void* p);
 
 struct Obj {
     virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
@@ -31,7 +30,7 @@ extern "C" void func_ov002_020bba28(char* self){
         ((struct Obj*)self)->m();
     } else {
         func_ov002_020bafc0(self);
-        if (_ZN16MeshColliderBase9IsEnabledEv(self + 0x124))
-            _ZN16MeshColliderBase7DisableEv(self + 0x124);
+        if (((MeshColliderBase *)(self + 0x124))->IsEnabled())
+            ((MeshColliderBase *)(self + 0x124))->Disable();
     }
 }

--- a/src/func_ov002_020bbb14.cpp
+++ b/src/func_ov002_020bbb14.cpp
@@ -3,6 +3,7 @@
 // @symbol func_ov002_020bbb14
 /* recovered: shared common types */
 #include "common.h"
+#include "MeshColliderBase.h"
 extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
 extern void WithMeshClsn_UpdateContinuous_Veneer(void* p);
@@ -12,8 +13,6 @@ extern int _ZNK12WithMeshClsn12TouchesWaterEv(void* p);
 extern void* _ZN5Actor10FindWithIDEj(unsigned id);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* thiz, void* v, unsigned a, int b, unsigned c, unsigned d, unsigned e);
 extern void _Z14ApproachLinearRiii(int* p, int a, int b);
-extern int _ZN16MeshColliderBase9IsEnabledEv(void* p);
-extern void _ZN16MeshColliderBase7DisableEv(void* p);
 extern int _ZN5Actor13DistToCPlayerEv(void* self);
 extern void func_ov002_020bae9c(char* c);
 }
@@ -71,8 +70,8 @@ void func_ov002_020bbb14(char* self)
 
     _Z14ApproachLinearRiii((int*)(self + 0x98), 0, 0x555);
 
-    if (_ZN16MeshColliderBase9IsEnabledEv(self + 0x124) != 0) {
-        _ZN16MeshColliderBase7DisableEv(self + 0x124);
+    if (((MeshColliderBase *)(self + 0x124))->IsEnabled() != 0) {
+        ((MeshColliderBase *)(self + 0x124))->Disable();
     }
 
     b = *(int*)(self + 0xb0) & 8;

--- a/src/func_ov002_020bbcb8.cpp
+++ b/src/func_ov002_020bbcb8.cpp
@@ -1,10 +1,9 @@
 //cpp
+#include "MeshColliderBase.h"
 // func_ov002_020bbcb8 at 0x020bbcb8
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 void func_ov002_020bbd5c(void* c, int i);
-int _ZN16MeshColliderBase9IsEnabledEv(void* self);
-void _ZN16MeshColliderBase7DisableEv(void* self);
 }
 
 extern "C" void func_ov002_020bbcb8(char* c)
@@ -27,7 +26,7 @@ extern "C" void func_ov002_020bbcb8(char* c)
         }
     }
 
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    if (((MeshColliderBase *)(c + 0x124))->IsEnabled()) {
+        ((MeshColliderBase *)(c + 0x124))->Disable();
     }
 }

--- a/src/func_ov009_02111bd4.cpp
+++ b/src/func_ov009_02111bd4.cpp
@@ -1,19 +1,18 @@
 //cpp
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 // @symbol func_ov009_02111bd4
 // recovered name: daObjMcWater_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjMcWater_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void*);
-int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov009_02113c68[];
 extern int data_ov009_02113c70[];
 int func_ov009_02111bd4(char* c){
   ((SharedFilePtr *)((void*)data_ov009_02113c68))->Release();
   ((SharedFilePtr *)((void*)data_ov009_02113c70))->Release();
-  if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
+  if(((MeshColliderBase *)(c+0x124))->IsEnabled())
+    ((MeshColliderBase *)(c+0x124))->Disable();
   return 1;
 }
 }

--- a/src/func_ov009_02111c74.cpp
+++ b/src/func_ov009_02111c74.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MeshColliderBase.h"
 // @symbol func_ov009_02111c74
 // recovered name: daObjMcWater_c_InitResources
 /* recovered: renamed to Class_Method */
@@ -16,7 +17,6 @@ void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 struct KCL_File *_ZN12MeshCollider8LoadFileER13SharedFilePtr(struct SharedFilePtr &f);
 void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *self, struct KCL_File *k, struct Matrix4x3 &m, int fx, short s, struct CLPS_Block &c);
-void _ZN16MeshColliderBase6EnableEP5Actor(void* self, void* actor);
 int func_ov009_02111b1c(char* thiz);
 extern unsigned char data_0209f2d8;
 extern int data_0209caa0;
@@ -47,7 +47,7 @@ int func_ov009_02111c74(char *self){
             self + 0x124, kcl, *(struct Matrix4x3 *)(self + 0x2ec), 0x1000,
             *(s16 *)(self + 0x8e), data_ov009_02112c38);
     }
-    _ZN16MeshColliderBase6EnableEP5Actor(self + 0x124, self);
+    ((MeshColliderBase *)(self + 0x124))->Enable((Actor *)(self));
     {
         int v = *(int*)(self + 0x60) - 0x64000;
         if (data_0209f32c > v) data_0209f32c = v;

--- a/src/func_ov010_02111554.cpp
+++ b/src/func_ov010_02111554.cpp
@@ -4,12 +4,13 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 /* recovered: renamed to Class_Method */
 /* daObjC1_Trap_c::CleanupResources - recovered from vtable slot identity */
 extern "C" char data_ov025_02112d08[];
 extern "C" int func_ov010_02111554(char *self){
-  if(_ZN16MeshColliderBase9IsEnabledEv(self+0x124)){
-    _ZN16MeshColliderBase7DisableEv(self+0x124);
+  if(((MeshColliderBase *)(self+0x124))->IsEnabled()){
+    ((MeshColliderBase *)(self+0x124))->Disable();
   }
   if((*(unsigned int*)(self+8) & 0xff) != 0xff){
     ((SharedFilePtr *)(data_ov025_02112d08))->Release();

--- a/src/func_ov022_0211123c.cpp
+++ b/src/func_ov022_0211123c.cpp
@@ -1,12 +1,11 @@
 //cpp
 #include "SharedFilePtr.h"
-extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern "C" void _ZN16MeshColliderBase7DisableEv(void *);
+#include "MeshColliderBase.h"
 extern int data_ov022_02113cc8;
 
 extern "C" int func_ov022_0211123c(char *c) {
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    if (((MeshColliderBase *)(c + 0x124))->IsEnabled()) {
+        ((MeshColliderBase *)(c + 0x124))->Disable();
     }
     ((SharedFilePtr *)((void *)((int *)&data_ov022_02113cc8)[0]))->Release();
     ((SharedFilePtr *)((void *)((int *)&data_ov022_02113cc8)[1]))->Release();

--- a/src/func_ov025_0211123c.cpp
+++ b/src/func_ov025_0211123c.cpp
@@ -2,6 +2,7 @@
 // @symbol func_ov025_0211123c
 /* recovered: shared common types */
 #include "common.h"
+#include "MeshColliderBase.h"
 
 struct Actor {
     virtual void f00(); virtual void f01(); virtual void f02(); virtual void f03();
@@ -16,8 +17,6 @@ struct Actor {
 extern "C" {
 extern void* _ZN5Actor18ClosestWithActorIDEj(void*, unsigned int);
 extern int Vec3_Dist(void*, void*);
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 
 int func_ov025_0211123c(char* c) {
     void* p = _ZN5Actor18ClosestWithActorIDEj(c, 9);
@@ -28,8 +27,8 @@ int func_ov025_0211123c(char* c) {
         v.z = *(int*)(c + 0x64);
         v.y = v.y + ((Actor*)c)->f29();
         if (Vec3_Dist((char*)c + 0x5c, (char*)p + 0x5c) < (*(int*)(c + 0xb8) << 3)) {
-            if (!_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-                _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
+            if (!((MeshColliderBase *)(c + 0x124))->IsEnabled()) {
+                ((MeshColliderBase *)(c + 0x124))->Enable((Actor *)(c));
                 return 1;
             }
         }

--- a/src/func_ov025_02111384.cpp
+++ b/src/func_ov025_02111384.cpp
@@ -4,17 +4,16 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 /* recovered: renamed to Class_Method */
 /* daDgr_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(void* self);
-void _ZN16MeshColliderBase7DisableEv(void* self);
 extern int data_ov025_02113a68[];
 int func_ov025_02111384(char* c) {
   ((SharedFilePtr *)(data_ov025_02113a68))->Release();
   ((SharedFilePtr *)(data_ov036_02113a60))->Release();
-  if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
+  if (((MeshColliderBase *)(c+0x124))->IsEnabled())
+    ((MeshColliderBase *)(c+0x124))->Disable();
   return 1;
 }
 }

--- a/src/func_ov036_02112318.cpp
+++ b/src/func_ov036_02112318.cpp
@@ -1,14 +1,13 @@
 //cpp
 #include "SharedFilePtr.h"
+#include "MeshColliderBase.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void* m);
-extern void _ZN16MeshColliderBase7DisableEv(void* m);
 extern int data_ov002_0210d9f0[];
 extern void* data_ov036_02113f58[];
 extern int data_ov036_0211419c[];
 int func_ov036_02112318(char* c){
-  if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
+  if (((MeshColliderBase *)(c+0x124))->IsEnabled())
+    ((MeshColliderBase *)(c+0x124))->Disable();
   ((SharedFilePtr *)(data_ov002_0210d9f0))->Release();
   ((SharedFilePtr *)(data_ov036_02113f58[0]))->Release();
   ((SharedFilePtr *)(data_ov036_02113f58[1]))->Release();

--- a/src/func_ov060_021182b0.cpp
+++ b/src/func_ov060_021182b0.cpp
@@ -47,7 +47,7 @@ int func_ov060_021182b0(char* self)
     }
     func_020393d4(self + 0x124, (void*)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     func_020393c4(self + 0x124, (void*)&func_ov060_021183f4);
-    ((MeshColliderBase*)(self + 0x124))->Enable((Actor*)self);
+    ((MeshColliderBase*)(self + 0x124))->Enable((Actor *)((Actor*)self));
     *(int*)(self + 0x320) = 0;
     *(unsigned char*)(self + 0x32b) = 0;
     *(unsigned char*)(self + 0x328) = 0;

--- a/src/func_ov066_021166c8.cpp
+++ b/src/func_ov066_021166c8.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "MeshColliderBase.h"
 extern "C" void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *self, void *bca, int a, int b, int fix, unsigned short t);
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, void *btp, int a, int fix, unsigned int b);
-extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void *self);
-extern "C" void _ZN16MeshColliderBase7DisableEv(void *self);
 extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *self, void *kcl, void *mtx, int fix, short s, void *clps);
 extern "C" void func_020393d4(void *p, void *v);
 extern "C" void func_020393c4(void *p, void *v);
 extern "C" void func_020398fc(void *p);
-extern "C" void _ZN16MeshColliderBase6EnableEP5Actor(void *self, void *actor);
 extern "C" int _ZNK9Animation13GetFrameCountEv(void *self);
 
 extern void **data_ov066_0211ae54;
@@ -33,8 +31,8 @@ extern "C" void func_ov066_021166c8(void *thiz)
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x448, (&data_ov066_0211ae9c)[1], 0x40000000, 0x1000, 0);
     }
 
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x674) != 0)
-        _ZN16MeshColliderBase7DisableEv(c + 0x674);
+    if (((MeshColliderBase *)(c + 0x674))->IsEnabled() != 0)
+        ((MeshColliderBase *)(c + 0x674))->Disable();
 
     if (*(int *)(c + 0x49c) == 1) {
         _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x674, (&data_ov066_0211ae34)[1], c + 0x83c, 0x199,
@@ -47,7 +45,7 @@ extern "C" void func_ov066_021166c8(void *thiz)
     func_020393d4(c + 0x674, (void *)func_02112cd8_updatepos);
     func_020393c4(c + 0x674, (void *)func_ov066_0211a35c);
     func_020398fc(c + 0x674);
-    _ZN16MeshColliderBase6EnableEP5Actor(c + 0x674, c);
+    ((MeshColliderBase *)(c + 0x674))->Enable((Actor *)(c));
 
     {
         int n = _ZNK9Animation13GetFrameCountEv(c + 0x3b0);

--- a/src/func_ov079_02123a8c.cpp
+++ b/src/func_ov079_02123a8c.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "MeshColliderBase.h"
 
 
 struct Actor {
@@ -19,7 +20,6 @@ struct Actor {
 };
 
 extern "C" int Vec3_Dist(void* a, void* b);
-extern "C" void _ZN16MeshColliderBase6EnableEP5Actor(void* m, void* actor);
 
 extern "C" int func_ov079_02123a8c(Actor *self)
 {
@@ -36,8 +36,8 @@ extern "C" int func_ov079_02123a8c(Actor *self)
         v.y = v.y + self->vf29();
         int dist = Vec3_Dist(&v, (char*)closest + 0x5c);
         if (dist < (*(int*)((char*)self + 0xb8) << 3)) {
-            if (!_ZN16MeshColliderBase9IsEnabledEv((char*)self + 0x418))
-                _ZN16MeshColliderBase6EnableEP5Actor((char*)self + 0x418, self);
+            if (!((MeshColliderBase *)((char*)self + 0x418))->IsEnabled())
+                ((MeshColliderBase *)((char*)self + 0x418))->Enable((Actor *)(self));
             return 1;
         }
     }

--- a/src/func_ov079_02123e60.cpp
+++ b/src/func_ov079_02123e60.cpp
@@ -3,6 +3,7 @@
 // recovered name: Whomp_OnHitByMegaChar
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+#include "MeshColliderBase.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* daBtn_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern "C" {
@@ -29,7 +30,7 @@ void func_ov079_02123e60(char* c, void* player)
     _ZN5Actor10PoofDustAtERK7Vector3(c, dust);
     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(5, pos.x, pos.y, pos.z);
     _ZN9ActorBase18MarkForDestructionEv(c);
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x418) != 0)
-        _ZN16MeshColliderBase7DisableEv(c + 0x418);
+    if (((MeshColliderBase *)(c + 0x418))->IsEnabled() != 0)
+        ((MeshColliderBase *)(c + 0x418))->Disable();
 }
 }

--- a/src/func_ov091_02132dc0.cpp
+++ b/src/func_ov091_02132dc0.cpp
@@ -2,6 +2,7 @@
 // @symbol func_ov091_02132dc0
 /* recovered: shared common types */
 #include "common.h"
+#include "MeshColliderBase.h"
 
 struct Actor {
     virtual void f00(); virtual void f01(); virtual void f02(); virtual void f03();
@@ -16,8 +17,6 @@ struct Actor {
 extern "C" {
 extern void* _ZN5Actor18ClosestWithActorIDEj(void*, unsigned int);
 extern int Vec3_Dist(void*, void*);
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 
 int func_ov091_02132dc0(char* c) {
     void* p = _ZN5Actor18ClosestWithActorIDEj(c, 9);
@@ -28,8 +27,8 @@ int func_ov091_02132dc0(char* c) {
         v.z = *(int*)(c + 0x64);
         v.y = v.y + ((Actor*)c)->f29();
         if (Vec3_Dist((char*)c + 0x5c, (char*)p + 0x5c) < (*(int*)(c + 0xb8) << 3)) {
-            if (!_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-                _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
+            if (!((MeshColliderBase *)(c + 0x124))->IsEnabled()) {
+                ((MeshColliderBase *)(c + 0x124))->Enable((Actor *)(c));
                 return 1;
             }
         }

--- a/src/func_ov091_02133254.cpp
+++ b/src/func_ov091_02133254.cpp
@@ -2,6 +2,7 @@
 // @symbol func_ov091_02133254
 /* recovered: shared common types */
 #include "common.h"
+#include "MeshColliderBase.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -15,7 +16,6 @@ extern "C" KCL_File *_ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr &
 extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *self, KCL_File *k, void *m, int fix, short s, void *clps);
 extern "C" void func_020393d4(int *p, int v);
-extern "C" void _ZN16MeshColliderBase6EnableEP5Actor(void *self, void *actor);
 extern "C" BTP_File *_ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File &b, BTP_File &t);
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, BTP_File *f, int a, int fix, unsigned int u);
@@ -52,7 +52,7 @@ extern "C" int func_ov091_02133254(char *self)
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
         self + 0x124, kcl, self + 0x2ec, 0x199, *(short *)(self + 0x8e), p8);
     func_020393d4((int *)(self + 0x124), (int)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    _ZN16MeshColliderBase6EnableEP5Actor(self + 0x124, self);
+    ((MeshColliderBase *)(self + 0x124))->Enable((Actor *)(self));
 
     tp = *(void **)(*(char **)(self + 0x320) + 0xc);
     if (tp != 0)

--- a/src/func_ov098_0213814c.cpp
+++ b/src/func_ov098_0213814c.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MeshColliderBase.h"
 extern "C" {
 extern int func_ov098_02138ce0(void*);
 extern int _ZN5Actor13DistToCPlayerEv(void*);
@@ -6,8 +7,6 @@ extern int Crate_SetState(void*, int);
 extern int _ZN12CylinderClsn5ClearEv(void*);
 extern int func_ov098_02139850(void*);
 extern int func_ov098_021397c8(void*);
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern int _ZN16MeshColliderBase7DisableEv(void*);
 void func_ov098_0213814c(char* c){
     func_ov098_02138ce0(c);
     unsigned b = (unsigned)((*(int*)(c+0xb0) & 8) != 0);
@@ -19,7 +18,7 @@ void func_ov098_0213814c(char* c){
     _ZN12CylinderClsn5ClearEv(c+0x5a4);
     func_ov098_02139850(c);
     func_ov098_021397c8(c);
-    if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-        _ZN16MeshColliderBase7DisableEv(c+0x124);
+    if(((MeshColliderBase *)(c+0x124))->IsEnabled())
+        ((MeshColliderBase *)(c+0x124))->Disable();
 }
 }

--- a/src/func_ov098_021384fc.cpp
+++ b/src/func_ov098_021384fc.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MeshColliderBase.h"
 // func_ov098_021384fc at 0x021384fc
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
 extern "C" {
@@ -15,8 +16,6 @@ void _ZN12CylinderClsn6UpdateEv(void *);
 void func_ov098_02139850(void *);
 int _ZNK12WithMeshClsn10IsOnGroundEv(void *);
 void func_ov098_021396a4(void *);
-int _ZN16MeshColliderBase9IsEnabledEv(void *);
-void _ZN16MeshColliderBase7DisableEv(void *);
 }
 
 struct Obj {
@@ -51,7 +50,7 @@ void func_ov098_021384fc(void *c) {
     if (!_ZNK12WithMeshClsn10IsOnGroundEv(b + 0x320)) {
         func_ov098_021396a4(c);
     }
-    if (_ZN16MeshColliderBase9IsEnabledEv(b + 0x124)) {
-        _ZN16MeshColliderBase7DisableEv(b + 0x124);
+    if (((MeshColliderBase *)(b + 0x124))->IsEnabled()) {
+        ((MeshColliderBase *)(b + 0x124))->Disable();
     }
 }

--- a/src/func_ov098_02138734.cpp
+++ b/src/func_ov098_02138734.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MeshColliderBase.h"
 // func_ov098_02138734 at 0x02138734
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
 struct Obj {
@@ -26,8 +27,6 @@ void _ZN12CylinderClsn6UpdateEv(void *cyl);
 void func_ov098_02139850(void *c);
 int _ZNK12WithMeshClsn10IsOnGroundEv(void *p);
 void func_ov098_021396a4(void *c);
-int _ZN16MeshColliderBase9IsEnabledEv(void *p);
-void _ZN16MeshColliderBase7DisableEv(void *p);
 void func_ov098_02138734(char *c);
 }
 
@@ -51,7 +50,7 @@ void func_ov098_02138734(char *c)
     if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x320)) {
         func_ov098_021396a4(c);
     }
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    if (((MeshColliderBase *)(c + 0x124))->IsEnabled()) {
+        ((MeshColliderBase *)(c + 0x124))->Disable();
     }
 }

--- a/src/func_ov098_021388bc.cpp
+++ b/src/func_ov098_021388bc.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MeshColliderBase.h"
 // func_ov098_021388bc at 0x021388bc
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
 struct Obj {
@@ -22,8 +23,6 @@ void Crate_SetState(void *c, int i);
 void _ZN12CylinderClsn5ClearEv(void *p);
 void func_ov098_02139850(void *c);
 void func_ov098_021396a4(void *c);
-int _ZN16MeshColliderBase9IsEnabledEv(void *p);
-void _ZN16MeshColliderBase7DisableEv(void *p);
 }
 
 extern "C" void func_ov098_021388bc(char *c)
@@ -62,7 +61,7 @@ extern "C" void func_ov098_021388bc(char *c)
     _ZN12CylinderClsn5ClearEv(c + 0x564);
     func_ov098_02139850(c);
     func_ov098_021396a4(c);
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    if (((MeshColliderBase *)(c + 0x124))->IsEnabled()) {
+        ((MeshColliderBase *)(c + 0x124))->Disable();
     }
 }

--- a/src/func_ov098_0213a36c.cpp
+++ b/src/func_ov098_0213a36c.cpp
@@ -1,5 +1,6 @@
 //cpp
 #include "types.h"
+#include "MeshColliderBase.h"
 // func_ov098_0213a36c at 0x0213a36c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
 struct CylinderClsn;
@@ -22,8 +23,6 @@ struct Actor {
 extern "C" {
 int DecIfAbove0_Byte(u8 *p);
 int DecIfAbove0_Short(u16 *p);
-int _ZN16MeshColliderBase9IsEnabledEv(void *self);
-void _ZN16MeshColliderBase7DisableEv(void *self);
 void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned id, void *pos);
 void *_ZN5Actor13ClosestPlayerEv(void *self);
 int Vec3_HorzDist(void *a, void *b);
@@ -70,8 +69,8 @@ extern "C" int func_ov098_0213a36c(char *c)
     func_ov098_0213a00c(c);
     if (*(u8 *)(c + 0x33f) != 0) {
         if (DecIfAbove0_Byte((u8 *)BASE(c, 0x33f)) == 0) {
-            if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124) != 0)
-                _ZN16MeshColliderBase7DisableEv(c + 0x124);
+            if (((MeshColliderBase *)(c + 0x124))->IsEnabled() != 0)
+                ((MeshColliderBase *)(c + 0x124))->Disable();
         }
         return 1;
     }
@@ -138,8 +137,8 @@ extern "C" int func_ov098_0213a36c(char *c)
             s16 *p334 = (s16 *)BASE(c, 0x334);
             *p334 = (s16)(*p334 + 0x80);
         } else {
-            if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124) != 0)
-                _ZN16MeshColliderBase7DisableEv(c + 0x124);
+            if (((MeshColliderBase *)(c + 0x124))->IsEnabled() != 0)
+                ((MeshColliderBase *)(c + 0x124))->Disable();
         }
         yaw = *(s16 *)(c + 0x90);
         if (yaw > -0x400) {


### PR DESCRIPTION
Follows #1032, same pattern. Converts the hand-written mangled call sites for `MeshColliderBase::Disable`, `IsEnabled` and `Enable` to ordinary method calls. `include/MeshColliderBase.h` already declares the class with recovered field offsets, so this is call-site work only.

**All 115 converted files compile to byte-identical `.text`** — `identical: 115  differing: 0  failed: 0`, verified by compiling each file against the base and diffing the section, not inferred from the ROM build.

## The interesting part: a pre-existing header defect

`MeshColliderBase.h` needs `Vector3_16` and defines it behind a `VECTOR3_16_DEFINED` guard — but `common.h` defines the same struct **without setting that macro**. So whenever `common.h` was included first, the guard never fired:

```
include/MeshColliderBase.h:63: class 'Vector3_16' redefined
```

That made the header un-includable from most files that need it — 90 of 119 conversions failed on it before I traced it. This PR guards the definition in `common.h` with the same macro, so whichever header is seen first wins and the other stands down. That single line took the conversion from 24 usable files to 115.

Worth knowing independently of this change: the header added in #986 could not actually be included alongside `common.h` until now.

## Why the conversion is safe

A non-virtual member call is the same `bl` with `this` in r0 as the free-function call it replaces, so the bytes do not move. The reference changes from the doubly-mangled `_Z31_ZN16MeshColliderBase7DisableEvPv`, which nothing defines, to the real `_ZN16MeshColliderBase7DisableEv`. These files matched before and still match — they can now also be **enrolled**, which the doubly-mangled reference made impossible.

`Enable` call sites pass a raw `char *`, so they take an explicit `(Actor *)` cast to meet the header's real signature.

## Scope

- `//cpp` files only. A `.c` file emits the identifier verbatim and was never affected.
- Redundant local `struct MeshColliderBase { ... }` declarations are removed; the header supplies the real class.
- **Six files are excluded** and keep their existing spelling: they fail to compile against the real header for reasons specific to each, and forcing them would be guesswork rather than recovery.