### PR TITLE
Compile the two fader wipe starters instead of falling back to ROM bytes

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -3798,14 +3798,16 @@ src/UpdateMinimap.c:
     complete
     .text start:0x02029854 end:0x020298a0
 
-src/engine/fader/StartEntranceFaderWipe.c:
+src/engine/fader/StartEntranceFaderWipe.cpp:
+    complete
     .text start:0x020298a0 end:0x020298d8
 
 src/StartExitCharacterWipe.c:
     complete
     .text start:0x020298d8 end:0x020298fc
 
-src/engine/fader/StartExitFaderWipe.c:
+src/engine/fader/StartExitFaderWipe.cpp:
+    complete
     .text start:0x020298fc end:0x02029934
 
 src/FUN_02029934.cpp:

--- a/src/engine/fader/StartEntranceFaderWipe.cpp
+++ b/src/engine/fader/StartEntranceFaderWipe.cpp
@@ -1,3 +1,4 @@
+//cpp
 #include "types.h"
 struct Fader {
     Fix12i currInterp;
@@ -29,11 +30,11 @@ struct FaderWipe : Fader {
     virtual void SetToStart();
 };
 
-extern FaderWipe* WIPES;
+extern FaderWipe* data_0209f324;
 extern "C" void _ZN5Scene9SetFadersEP15FaderBrightness(FaderWipe* f);
 
 extern "C" void StartEntranceFaderWipe(int index) {
-    FaderWipe* f = &WIPES[index];
+    FaderWipe* f = &data_0209f324[index];
     _ZN5Scene9SetFadersEP15FaderBrightness(f);
     f->SetToEnd();
 }

--- a/src/engine/fader/StartEntranceFaderWipe.cpp
+++ b/src/engine/fader/StartEntranceFaderWipe.cpp
@@ -30,6 +30,11 @@ struct FaderWipe : Fader {
     virtual void SetToStart();
 };
 
+/* The fader wipe array. Stage::InitResources fills this with
+   func_02073470(7, 0x60, 8, &FaderWipeC1, &FaderWipeD1): seven objects of 0x60,
+   which is sizeof(FaderWipe). Stage::CleanupResources tears the array down and
+   zeroes it. Named data_0209f324 because that is the symbol; every other
+   consumer of this address spells it the same way. */
 extern FaderWipe* data_0209f324;
 extern "C" void _ZN5Scene9SetFadersEP15FaderBrightness(FaderWipe* f);
 

--- a/src/engine/fader/StartExitFaderWipe.cpp
+++ b/src/engine/fader/StartExitFaderWipe.cpp
@@ -1,3 +1,4 @@
+//cpp
 #include "types.h"
 struct Fader {
     Fix12i currInterp;
@@ -29,11 +30,11 @@ struct FaderWipe : Fader {
     virtual void SetToStart();
 };
 
-extern FaderWipe* WIPES;
+extern FaderWipe* data_0209f324;
 extern "C" void _ZN5Scene9SetFadersEP15FaderBrightness(FaderWipe* f);
 
 extern "C" void StartExitFaderWipe(int index) {
-    FaderWipe* f = &WIPES[index];
+    FaderWipe* f = &data_0209f324[index];
     _ZN5Scene9SetFadersEP15FaderBrightness(f);
     f->SetToStart();
 }

--- a/src/engine/fader/StartExitFaderWipe.cpp
+++ b/src/engine/fader/StartExitFaderWipe.cpp
@@ -30,6 +30,11 @@ struct FaderWipe : Fader {
     virtual void SetToStart();
 };
 
+/* The fader wipe array. Stage::InitResources fills this with
+   func_02073470(7, 0x60, 8, &FaderWipeC1, &FaderWipeD1): seven objects of 0x60,
+   which is sizeof(FaderWipe). Stage::CleanupResources tears the array down and
+   zeroes it. Named data_0209f324 because that is the symbol; every other
+   consumer of this address spells it the same way. */
 extern FaderWipe* data_0209f324;
 extern "C" void _ZN5Scene9SetFadersEP15FaderBrightness(FaderWipe* f);
 


### PR DESCRIPTION
`src/engine/fader/StartEntranceFaderWipe.c` and `StartExitFaderWipe.c` contain C++ (a base class, virtual members, `extern "C"`) but were named `.c` with no `//cpp` marker. The build selects language from that marker, so both compiled as C99 and failed with `undefined identifier 'virtual'`. Neither entry was marked `complete`, so nothing failed loudly: those two ranges came from retail gap bytes and the files sat in `src/` verified by nothing.

Renamed to `.cpp` with the marker; `delinks.txt` follows.

The extern was also spelled `WIPES`, which no `symbols.txt` defines, so `linkcheck` reported `BLIND-1` on both. It is `data_0209f324`, the bss pointer at that address (`relocs.txt`: `from:0x020298d4 kind:load to:0x0209f324`), already spelled that way by the six other `src/` files that touch it. All 782 `kind:bss` symbols in `config/arm9/symbols.txt` are `data_*` with no named exceptions, so the name stays and the second commit records what the address is in a comment instead. Symbol spelling only, no codegen change.

**Verification**

| | |
|---|---|
| `match.py --all` | both match under `2004/b56`, `1.2/base`, `1.2/sp2`, `1.2/sp2p3` |
| `linkcheck` | `VERIFIED`, 0 blind slots (was `BLIND-1`) |
| `prepush_linkcheck` | 2 checked, 2 verified, 0 warnings, 0 blocking |
| eligibility | passes all five rules of `tools/eligible.py` |
| `rombuild.py` | 106/106 modules exact, 0 differing bytes, 0 mismatching functions |
| enrollment | `complete` count 9,138 to 9,140, exactly these two |

Net effect: two functions move from retail gap bytes to compiled source.

No ledger rows added. The source predates the provenance ledger and this PR did no matching work: it changed a file extension, a marker line, a symbol spelling and two `complete` marks. Stamping it would attribute the match away from its original author.

Found while looking into #821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Lhvo4yBV38fHxhHwvnZ9U