### PR TITLE
Give ROM symbol declarations C linkage, and fix a wrong callee it exposed

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -3528,6 +3528,7 @@ src/_ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb.cpp:
     .text start:0x02022630 end:0x02022640
 
 src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp:
+    complete
     .text start:0x02022640 end:0x02022680
 
 src/_ZN8Particle14SimpleCallbackC2Ev.cpp:
@@ -4101,6 +4102,7 @@ src/CopyTexPalFromLevelModel.c:
     .text start:0x0202b3d8 end:0x0202b534
 
 src/_ZN5Stage23LoadTextureTransformersEv.cpp:
+    complete
     .text start:0x0202b534 end:0x0202b5ec
 
 src/_ZN5Stage9LoadModelEv.cpp:
@@ -4112,6 +4114,7 @@ src/_ZN5Stage9RenderFogEv.cpp:
     .text start:0x0202b67c end:0x0202b710
 
 src/_ZN5Stage7LoadFogEv.cpp:
+    complete
     .text start:0x0202b710 end:0x0202b818
 
 src/_ZN5Stage8CanPauseEv.c:
@@ -7737,6 +7740,7 @@ src/_ZN18NestedHeapIteratorC1Ej.c:
     .text start:0x0204df20 end:0x0204df38
 
 src/_ZN13HeapAllocator6RemoveEv.cpp:
+    complete
     .text start:0x0204df38 end:0x0204df54
 
 src/_ZN13HeapAllocatorC1EjPvPvj.cpp:

--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -11746,70 +11746,93 @@ src/func_020736e4.c:
     .text start:0x020736e4 end:0x020736f4
 
 src/__sinit_02073a24.c:
+    complete
     .init start:0x02073a24 end:0x02073e6c
 
 src/__sinit_02073e6c.c:
+    complete
     .init start:0x02073e6c end:0x02074d90
 
 src/__sinit_02074d90.c:
+    complete
     .init start:0x02074d90 end:0x02074da8
 
 src/__sinit_02074da8.c:
+    complete
     .init start:0x02074da8 end:0x02074dbc
 
 src/__sinit_02074dbc.c:
+    complete
     .init start:0x02074dbc end:0x02074dc0
 
 src/__sinit_02074dc0.c:
+    complete
     .init start:0x02074dc0 end:0x02074dc4
 
 src/__sinit_02074dc4.c:
+    complete
     .init start:0x02074dc4 end:0x02074e0c
 
 src/__sinit_02074e0c.c:
+    complete
     .init start:0x02074e0c end:0x02074e44
 
 src/__sinit_02074e44.c:
+    complete
     .init start:0x02074e44 end:0x02074e80
 
 src/__sinit_02074e80.c:
+    complete
     .init start:0x02074e80 end:0x02074e84
 
 src/__sinit_02074e84.cpp:
+    complete
     .init start:0x02074e84 end:0x02074edc
 
 src/__sinit_02074edc.c:
+    complete
     .init start:0x02074edc end:0x02074f80
 
 src/__sinit_02074f80.c:
+    complete
     .init start:0x02074f80 end:0x02074fb8
 
 src/__sinit_02074fb8.c:
+    complete
     .init start:0x02074fb8 end:0x02074fe4
 
 src/__sinit_02074fe4.c:
+    complete
     .init start:0x02074fe4 end:0x0207501c
 
 src/__sinit_0207501c.c:
+    complete
     .init start:0x0207501c end:0x02075054
 
 src/__sinit_02075054.c:
+    complete
     .init start:0x02075054 end:0x020750b4
 
 src/__sinit_020750b4.c:
+    complete
     .init start:0x020750b4 end:0x020750b8
 
 src/__sinit_020750b8.c:
+    complete
     .init start:0x020750b8 end:0x020750ec
 
 src/__sinit_020750ec.c:
+    complete
     .init start:0x020750ec end:0x0207511c
 
 src/__sinit_0207511c.c:
+    complete
     .init start:0x0207511c end:0x02075150
 
 src/__sinit_02075150.c:
+    complete
     .init start:0x02075150 end:0x02075154
 
 src/__sinit_02075154.c:
+    complete
     .init start:0x02075154 end:0x02075230

--- a/config/arm9/itcm/delinks.txt
+++ b/config/arm9/itcm/delinks.txt
@@ -1,55 +1,73 @@
     .text       start:0x01ff8000 end:0x01ffdf3c kind:code align:32
     .bss        start:0x01ffdf40 end:0x01ffdf40 kind:bss align:32
 src/func_01ffb07c.cpp:
+    complete
     .text start:0x01ffb07c end:0x01ffb098
 
 src/func_01ffb098.cpp:
+    complete
     .text start:0x01ffb098 end:0x01ffb0a4
 
 src/func_01ffb0a4.cpp:
+    complete
     .text start:0x01ffb0a4 end:0x01ffb0b0
 
 src/func_01ffb0b0.cpp:
+    complete
     .text start:0x01ffb0b0 end:0x01ffb0bc
 
 src/func_01ffb0bc.cpp:
+    complete
     .text start:0x01ffb0bc end:0x01ffb0c8
 
 src/func_01ffb0c8.cpp:
+    complete
     .text start:0x01ffb0c8 end:0x01ffb0d0
 
 src/_ZNK12MeshCollider13GetUnkOctreeYEv.cpp:
+    complete
     .text start:0x01ffb0d0 end:0x01ffb0ec
 
 src/_ZNK12MeshCollider16GetOctreeOriginYEv.cpp:
+    complete
     .text start:0x01ffb0ec end:0x01ffb0fc
 
 src/_ZN12MeshCollider10DetectClsnER13RaycastGround.cpp:
+    complete
     .text start:0x01ffd3f8 end:0x01ffd890
 
 src/_ZN12MeshCollider17GetTriangleOriginEsR7Vector3.cpp:
+    complete
     .text start:0x01ffd890 end:0x01ffd8d8
 
 src/_ZN12MeshCollider9GetNormalEsR7Vector3.cpp:
+    complete
     .text start:0x01ffd8d8 end:0x01ffd920
 
 src/_ZN12MeshCollider14GetSurfaceInfoEsR11SurfaceInfo.cpp:
+    complete
     .text start:0x01ffd920 end:0x01ffd97c
 
 src/OSReadROMArea.c:
+    complete
     .text start:0x01ffdbd8 end:0x01ffdd08
 
 src/func_01ffdd08.c:
+    complete
     .text start:0x01ffdd08 end:0x01ffdd98
 
 src/func_01ffdd98.c:
+    complete
     .text start:0x01ffdd98 end:0x01ffde00
 
 src/DMAStartTransferFB.c:
+    complete
     .text start:0x01ffde00 end:0x01ffde50
 
 src/DMAStartTransfer.c:
+    complete
     .text start:0x01ffde50 end:0x01ffde98
 
 src/func_01ffde98.c:
+    complete
     .text start:0x01ffde98 end:0x01ffdf3c

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -617,6 +617,7 @@ src/func_ov002_020b38a0.c:
     .text start:0x020b38a0 end:0x020b3ab0
 
 src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020b3ab0 end:0x020b3b14
 
 src/_ZN13BigBrickBlock6RenderEv.cpp:
@@ -624,6 +625,7 @@ src/_ZN13BigBrickBlock6RenderEv.cpp:
     .text start:0x020b3b14 end:0x020b3c0c
 
 src/_ZN13BigBrickBlock8BehaviorEv.cpp:
+    complete
     .text start:0x020b3c0c end:0x020b3d78
 
 src/_ZN13BigBrickBlock13InitResourcesEv.c:
@@ -786,6 +788,7 @@ src/func_ov002_020b50a0.c:
     .text start:0x020b50a0 end:0x020b512c
 
 src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020b512c end:0x020b51ac
 
 src/_ZN14QuestionSwitch6RenderEv.cpp:
@@ -1720,6 +1723,7 @@ src/_ZN6Player16SetRealCharacterEj.cpp:
     .text start:0x020be1e0 end:0x020be324
 
 src/_ZN6Player18TurnOffToonShadingEj.cpp:
+    complete
     .text start:0x020be324 end:0x020be3b0
 
 src/func_ov002_020be3b0.c:
@@ -2016,6 +2020,7 @@ src/func_ov002_020c3d1c.c:
     .text start:0x020c3d1c end:0x020c3d6c
 
 src/_ZN6Player17St_EndingFly_InitEv.cpp:
+    complete
     .text start:0x020c3d6c end:0x020c3dbc
 
 src/func_ov002_020c3dbc.c:
@@ -2023,6 +2028,7 @@ src/func_ov002_020c3dbc.c:
     .text start:0x020c3dbc end:0x020c3dd0
 
 src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp:
+    complete
     .text start:0x020c3dd0 end:0x020c3e8c
 
 src/func_ov002_020c3e8c.c:
@@ -2034,6 +2040,7 @@ src/func_ov002_020c3ea0.c:
     .text start:0x020c3ea0 end:0x020c3ed8
 
 src/_ZN6Player21St_OpeningWakeUp_InitEv.cpp:
+    complete
     .text start:0x020c3ed8 end:0x020c3f18
 
 src/func_ov002_020c3f18.c:
@@ -2074,6 +2081,7 @@ src/_ZN6Player12St_Talk_MainEv.cpp:
     .text start:0x020c48e0 end:0x020c4bd8
 
 src/_ZN6Player12St_Talk_InitEv.cpp:
+    complete
     .text start:0x020c4bd8 end:0x020c4c60
 
 src/_ZN6Player12ShowMessage2ER9ActorBasejPK7Vector3jj.cpp:
@@ -2120,9 +2128,11 @@ src/_ZN6Player21St_StuckInGround_InitEv.cpp:
     .text start:0x020c54e8 end:0x020c5560
 
 src/_ZN6Player24St_BowserEarthquake_MainEv.cpp:
+    complete
     .text start:0x020c5560 end:0x020c568c
 
 src/_ZN6Player24St_BowserEarthquake_InitEv.cpp:
+    complete
     .text start:0x020c568c end:0x020c56f0
 
 src/func_ov002_020c56f0.c:
@@ -2190,6 +2200,7 @@ src/func_ov002_020c6908.cpp:
     .text start:0x020c6908 end:0x020c69a0
 
 src/_ZN6Player14St_Squish_InitEv.cpp:
+    complete
     .text start:0x020c69a0 end:0x020c6a10
 
 src/_ZN6Player12Unk_020c6a10Ej.cpp:
@@ -2436,6 +2447,7 @@ src/Player_DisableInteraction.c:
     .text start:0x020c9e40 end:0x020c9e5c
 
 src/_ZN6Player12Unk_020c9e5cEh.cpp:
+    complete
     .text start:0x020c9e5c end:0x020ca0f4
 
 src/func_ov002_020ca0f4.c:
@@ -2451,9 +2463,11 @@ src/_ZN6Player11OpenBigDoorEv.cpp:
     .text start:0x020ca144 end:0x020ca150
 
 src/_ZN6Player12Unk_020ca150Eh.cpp:
+    complete
     .text start:0x020ca150 end:0x020ca1b8
 
 src/_ZN6Player17SetNoControlStateEhih.cpp:
+    complete
     .text start:0x020ca1b8 end:0x020ca270
 
 src/func_ov002_020ca270.cpp:
@@ -2469,6 +2483,7 @@ src/_ZN6Player13TryTalkToDoorEh.cpp:
     .text start:0x020ca344 end:0x020ca3d0
 
 src/_ZN6Player21IsOpeningDoorWithStarEv.cpp:
+    complete
     .text start:0x020ca3d0 end:0x020ca410
 
 src/_ZN6Player16TryTalkToKeyDoorEv.cpp:
@@ -2488,6 +2503,7 @@ src/_ZN6Player17PlayMammaMiaSoundEv.cpp:
     .text start:0x020ca708 end:0x020ca724
 
 src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp:
+    complete
     .text start:0x020ca724 end:0x020ca78c
 
 src/func_ov002_020ca78c.c:
@@ -2499,9 +2515,11 @@ src/_ZN6Player16St_DebugFly_MainEv.cpp:
     .text start:0x020ca7f4 end:0x020ca8d0
 
 src/_ZN6Player16St_DebugFly_InitEv.cpp:
+    complete
     .text start:0x020ca8d0 end:0x020ca8f8
 
 src/_ZN6Player12Unk_020ca8f8Ev.cpp:
+    complete
     .text start:0x020ca8f8 end:0x020ca940
 
 src/func_ov002_020ca940.c:
@@ -2555,6 +2573,7 @@ src/_ZN6Player17St_Headstand_MainEv.cpp:
     .text start:0x020cb15c end:0x020cb2f0
 
 src/_ZN6Player17St_Headstand_InitEv.cpp:
+    complete
     .text start:0x020cb2f0 end:0x020cb354
 
 src/func_ov002_020cb354.cpp:
@@ -2570,9 +2589,11 @@ src/func_ov002_020cb474.cpp:
     .text start:0x020cb474 end:0x020cb568
 
 src/_ZN6Player16St_Climb_CleanupEv.cpp:
+    complete
     .text start:0x020cb568 end:0x020cb5bc
 
 src/_ZN6Player13St_Climb_InitEv.cpp:
+    complete
     .text start:0x020cbd34 end:0x020cbea8
 
 src/func_ov002_020cbea8.c:
@@ -2588,6 +2609,7 @@ src/func_ov002_020cc05c.c:
     .text start:0x020cc05c end:0x020cc140
 
 src/_ZN6Player9IsOnShellEv.cpp:
+    complete
     .text start:0x020cc140 end:0x020cc16c
 
 src/func_ov002_020cc16c.c:
@@ -2805,6 +2827,7 @@ src/_ZN6Player17St_LedgeHang_MainEv.cpp:
     .text start:0x020d0a44 end:0x020d0c54
 
 src/_ZN6Player17St_LedgeHang_InitEv.cpp:
+    complete
     .text start:0x020d0c54 end:0x020d0d2c
 
 src/func_ov002_020d0d2c.cpp:
@@ -2858,6 +2881,7 @@ src/_ZN6Player17St_HoldLight_MainEv.cpp:
     .text start:0x020d1a1c end:0x020d1ea0
 
 src/_ZN6Player17St_HoldLight_InitEv.cpp:
+    complete
     .text start:0x020d1ea0 end:0x020d1f78
 
 src/func_ov002_020d1f78.c:
@@ -3253,6 +3277,7 @@ src/_ZN6Player19St_SwingPlayer_InitEv.cpp:
     .text start:0x020da3b0 end:0x020da41c
 
 src/_ZN6Player25St_GrabBowserTail_CleanupEv.cpp:
+    complete
     .text start:0x020da41c end:0x020da438
 
 src/_ZN6Player22St_GrabBowserTail_MainEv.cpp:
@@ -3474,6 +3499,7 @@ src/_ZN6Player19St_GroundPound_MainEv.cpp:
     .text start:0x020dd9f8 end:0x020dddf0
 
 src/_ZN6Player19St_GroundPound_InitEv.cpp:
+    complete
     .text start:0x020dddf0 end:0x020dde74
 
 src/func_ov002_020dde74.cpp:
@@ -3517,6 +3543,7 @@ src/func_ov002_020de968.cpp:
     .text start:0x020de968 end:0x020dea00
 
 src/_ZN6Player16InitBalloonMarioEv.cpp:
+    complete
     .text start:0x020dea00 end:0x020deab8
 
 src/_ZN6Player17St_WindCarry_MainEv.cpp:
@@ -3646,6 +3673,7 @@ src/_ZN6Player22St_CrazedCrate_CleanupEv.cpp:
     .text start:0x020e0d28 end:0x020e0d48
 
 src/_ZN6Player19St_CrazedCrate_MainEv.cpp:
+    complete
     .text start:0x020e0d48 end:0x020e0f38
 
 src/func_ov002_020e0f38.cpp:
@@ -3701,18 +3729,22 @@ src/func_ov002_020e17f8.c:
     .text start:0x020e17f8 end:0x020e18a8
 
 src/_ZN6Player16St_BackFlip_InitEv.cpp:
+    complete
     .text start:0x020e18a8 end:0x020e1990
 
 src/_ZN6Player24St_SlideKickRecover_InitEv.cpp:
+    complete
     .text start:0x020e1990 end:0x020e1a10
 
 src/_ZN6Player16St_SideFlip_InitEv.cpp:
+    complete
     .text start:0x020e1a10 end:0x020e1af8
 
 src/_ZN6Player12St_Fall_MainEv.cpp:
     .text start:0x020e1af8 end:0x020e1b80
 
 src/_ZN6Player12St_Fall_InitEv.cpp:
+    complete
     .text start:0x020e1b80 end:0x020e1c20
 
 src/func_ov002_020e1c20.c:
@@ -4391,6 +4423,7 @@ src/func_ov002_020eddc4.c:
     .text start:0x020eddc4 end:0x020edf54
 
 src/_ZN8YoshiEgg16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020edf54 end:0x020edf98
 
 src/_ZN8YoshiEgg6RenderEv.cpp:
@@ -4427,6 +4460,7 @@ src/func_ov002_020ee5d0.c:
     .text start:0x020ee5d0 end:0x020ee674
 
 src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp:
+    complete
     .text start:0x020ee674 end:0x020ee7cc
 
 src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp:
@@ -4434,12 +4468,15 @@ src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp:
     .text start:0x020ee7cc end:0x020ee830
 
 src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp:
+    complete
     .text start:0x020ee830 end:0x020ee870
 
 src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp:
+    complete
     .text start:0x020ee870 end:0x020ee934
 
 src/_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_.cpp:
+    complete
     .text start:0x020ee934 end:0x020eea50
 
 src/_ZN8PlatformC2Ev.c:
@@ -4635,6 +4672,7 @@ src/_ZN15InvisibleSecret6RenderEv.cpp:
     .text start:0x020f0994 end:0x020f0a60
 
 src/_ZN15InvisibleSecret8BehaviorEv.cpp:
+    complete
     .text start:0x020f0a60 end:0x020f0bd4
 
 src/_ZN15InvisibleSecret13InitResourcesEv.cpp:
@@ -4723,6 +4761,7 @@ src/_ZN12EnemySpawnerD0Ev.c:
     .text start:0x020f1694 end:0x020f16cc
 
 src/_ZN14BlueCoinSwitch16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020f16cc end:0x020f16ec
 
 src/_ZN12EnemySpawner8BehaviorEv.cpp:
@@ -4730,6 +4769,7 @@ src/_ZN12EnemySpawner8BehaviorEv.cpp:
     .text start:0x020f16ec end:0x020f1760
 
 src/_ZN14BlueCoinSwitch8BehaviorEv.cpp:
+    complete
     .text start:0x020f1760 end:0x020f1814
 
 src/_ZN12EnemySpawner16CleanupResourcesEv.c:
@@ -4737,6 +4777,7 @@ src/_ZN12EnemySpawner16CleanupResourcesEv.c:
     .text start:0x020f1814 end:0x020f1838
 
 src/_ZN12EnemySpawner13InitResourcesEv.cpp:
+    complete
     .text start:0x020f1838 end:0x020f1878
 
 src/_ZN14BlueCoinSwitch13InitResourcesEv.cpp:
@@ -5407,6 +5448,7 @@ src/_ZN8Fireball8BehaviorEv.cpp:
     .text start:0x020f8c94 end:0x020f9204
 
 src/_ZN8Fireball13InitResourcesEv.cpp:
+    complete
     .text start:0x020f9204 end:0x020f92e4
 
 src/func_ov002_020f92e4.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -4176,6 +4176,7 @@ src/_ZN10StarMarker16OnPendingDestroyEv.cpp:
     .text start:0x020eab8c end:0x020eabcc
 
 src/_ZN10StarMarker16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020eabcc end:0x020eac18
 
 src/_ZN9PowerStar16CleanupResourcesEv.cpp:
@@ -5689,79 +5690,105 @@ src/Bullet_Spawn.c:
     .text start:0x020fefcc end:0x020ff014
 
 src/__sinit_ov002_02100560.c:
+    complete
     .init start:0x02100560 end:0x02100938
 
 src/__sinit_ov002_02100938.c:
+    complete
     .init start:0x02100938 end:0x02100adc
 
 src/__sinit_ov002_02100adc.c:
+    complete
     .init start:0x02100adc end:0x02100c50
 
 src/__sinit_ov002_02100c50.c:
+    complete
     .init start:0x02100c50 end:0x02100d44
 
 src/__sinit_ov002_02100d44.c:
+    complete
     .init start:0x02100d44 end:0x02100e50
 
 src/__sinit_ov002_02100e50.c:
+    complete
     .init start:0x02100e50 end:0x02100ec4
 
 src/__sinit_ov002_02100ec4.c:
+    complete
     .init start:0x02100ec4 end:0x02100f84
 
 src/__sinit_ov002_02100f84.c:
+    complete
     .init start:0x02100f84 end:0x02101064
 
 src/__sinit_ov002_02101064.c:
+    complete
     .init start:0x02101064 end:0x02101478
 
 src/__sinit_ov002_02101478.c:
+    complete
     .init start:0x02101478 end:0x021014e4
 
 src/__sinit_ov002_021014e4.c:
+    complete
     .init start:0x021014e4 end:0x02101588
 
 src/__sinit_ov002_02101588.c:
+    complete
     .init start:0x02101588 end:0x02101738
 
 src/__sinit_ov002_02101738.c:
+    complete
     .init start:0x02101738 end:0x02101894
 
 src/__sinit_ov002_02101894.c:
+    complete
     .init start:0x02101894 end:0x02101900
 
 src/__sinit_ov002_02101900.c:
+    complete
     .init start:0x02101900 end:0x02101968
 
 src/__sinit_ov002_02101968.c:
+    complete
     .init start:0x02101968 end:0x021019d0
 
 src/__sinit_ov002_021019d0.c:
+    complete
     .init start:0x021019d0 end:0x02106e40
 
 src/__sinit_ov002_02106e40.c:
+    complete
     .init start:0x02106e40 end:0x02107118
 
 src/__sinit_ov002_02107118.c:
+    complete
     .init start:0x02107118 end:0x021071f4
 
 src/__sinit_ov002_021071f4.c:
+    complete
     .init start:0x021071f4 end:0x02107298
 
 src/__sinit_ov002_02107298.c:
+    complete
     .init start:0x02107298 end:0x02107304
 
 src/__sinit_ov002_02107304.c:
+    complete
     .init start:0x02107304 end:0x02107370
 
 src/__sinit_ov002_02107370.c:
+    complete
     .init start:0x02107370 end:0x02107f88
 
 src/__sinit_ov002_02107f88.c:
+    complete
     .init start:0x02107f88 end:0x0210804c
 
 src/__sinit_ov002_0210804c.c:
+    complete
     .init start:0x0210804c end:0x02108094
 
 src/__sinit_ov002_02108094.c:
+    complete
     .init start:0x02108094 end:0x021080d0

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -1071,10 +1071,13 @@ src/func_ov004_020b9430.c:
     .text start:0x020b9430 end:0x020b944c
 
 src/__sinit_ov004_020b948c.c:
+    complete
     .init start:0x020b948c end:0x020b955c
 
 src/__sinit_ov004_020b9ad0.c:
+    complete
     .init start:0x020b9ad0 end:0x020b9b24
 
 src/__sinit_ov004_020b9b24.c:
+    complete
     .init start:0x020b9b24 end:0x020b9de4

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -6958,91 +6958,121 @@ src/func_ov006_0212b88c.c:
     .text start:0x0212b88c end:0x0212b890
 
 src/__sinit_ov006_0212f4c4.c:
+    complete
     .init start:0x0212f4c4 end:0x0212f52c
 
 src/__sinit_ov006_0212f52c.c:
+    complete
     .init start:0x0212f52c end:0x0212f660
 
 src/__sinit_ov006_0212f660.c:
+    complete
     .init start:0x0212f660 end:0x0212f6b4
 
 src/__sinit_ov006_0212f6b4.c:
+    complete
     .init start:0x0212f6b4 end:0x0212fc7c
 
 src/__sinit_ov006_0212fc7c.c:
+    complete
     .init start:0x0212fc7c end:0x0212fd48
 
 src/__sinit_ov006_0212fd48.c:
+    complete
     .init start:0x0212fd48 end:0x021300b0
 
 src/__sinit_ov006_021300b0.c:
+    complete
     .init start:0x021300b0 end:0x0213014c
 
 src/__sinit_ov006_021303d0.c:
+    complete
     .init start:0x021303d0 end:0x021304ac
 
 src/__sinit_ov006_021304ac.c:
+    complete
     .init start:0x021304ac end:0x02130758
 
 src/__sinit_ov006_02130758.c:
+    complete
     .init start:0x02130758 end:0x02130a04
 
 src/__sinit_ov006_02130a04.c:
+    complete
     .init start:0x02130a04 end:0x02130a08
 
 src/__sinit_ov006_02130a08.c:
+    complete
     .init start:0x02130a08 end:0x02130df8
 
 src/__sinit_ov006_02130df8.c:
+    complete
     .init start:0x02130df8 end:0x02130e9c
 
 src/__sinit_ov006_02130e9c.c:
+    complete
     .init start:0x02130e9c end:0x02130f00
 
 src/__sinit_ov006_02130f00.c:
+    complete
     .init start:0x02130f00 end:0x02130f64
 
 src/__sinit_ov006_02130f64.c:
+    complete
     .init start:0x02130f64 end:0x021311c8
 
 src/__sinit_ov006_021311c8.c:
+    complete
     .init start:0x021311c8 end:0x021314e4
 
 src/__sinit_ov006_021314e4.c:
+    complete
     .init start:0x021314e4 end:0x021318a0
 
 src/__sinit_ov006_021318a0.c:
+    complete
     .init start:0x021318a0 end:0x0213195c
 
 src/__sinit_ov006_0213195c.c:
+    complete
     .init start:0x0213195c end:0x02131a38
 
 src/__sinit_ov006_02131a38.c:
+    complete
     .init start:0x02131a38 end:0x02131cd0
 
 src/__sinit_ov006_02131cd0.c:
+    complete
     .init start:0x02131cd0 end:0x02131fa4
 
 src/__sinit_ov006_02131fa4.c:
+    complete
     .init start:0x02131fa4 end:0x021322bc
 
 src/__sinit_ov006_021322bc.c:
+    complete
     .init start:0x021322bc end:0x02132894
 
 src/__sinit_ov006_02132894.c:
+    complete
     .init start:0x02132894 end:0x02132970
 
 src/__sinit_ov006_02132970.c:
+    complete
     .init start:0x02132970 end:0x02132f68
 
 src/__sinit_ov006_02132f68.c:
+    complete
     .init start:0x02132f68 end:0x0213322c
 
 src/__sinit_ov006_0213322c.c:
+    complete
     .init start:0x0213322c end:0x0213326c
 
 src/__sinit_ov006_0213326c.c:
+    complete
     .init start:0x0213326c end:0x021333e0
 
 src/__sinit_ov006_021333e0.c:
+    complete
     .init start:0x021333e0 end:0x0213356c

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -135,13 +135,17 @@ src/Flag_Spawn.c:
     .text start:0x021121f0 end:0x02112228
 
 src/__sinit_ov009_02112458.c:
+    complete
     .init start:0x02112458 end:0x02112524
 
 src/__sinit_ov009_02112524.c:
+    complete
     .init start:0x02112524 end:0x02112a5c
 
 src/__sinit_ov009_02112a5c.c:
+    complete
     .init start:0x02112a5c end:0x02112ac8
 
 src/__sinit_ov009_02112ac8.c:
+    complete
     .init start:0x02112ac8 end:0x02112b34

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -98,6 +98,7 @@ src/_ZN11CastleWater6RenderEv.cpp:
     .text start:0x02111ea8 end:0x02111ed0
 
 src/_ZN11CastleWater8BehaviorEv.cpp:
+    complete
     .text start:0x02111ed0 end:0x02111f40
 
 src/_ZN11CastleWater13InitResourcesEv.cpp:
@@ -128,6 +129,7 @@ src/_ZN8DockPole8BehaviorEv.cpp:
     .text start:0x02112144 end:0x02112190
 
 src/_ZN8DockPole13InitResourcesEv.cpp:
+    complete
     .text start:0x02112190 end:0x021121f0
 
 src/Flag_Spawn.c:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -42,6 +42,7 @@ src/func_ov010_0211146c.c:
     .text start:0x0211146c end:0x02111554
 
 src/func_ov010_02111554.cpp:
+    complete
     .text start:0x02111554 end:0x021115a8
 
 src/func_ov010_021115a8.cpp:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -126,10 +126,13 @@ src/PeachPainting_Spawn.c:
     .text start:0x02112004 end:0x0211203c
 
 src/__sinit_ov010_0211203c.c:
+    complete
     .init start:0x0211203c end:0x0211211c
 
 src/__sinit_ov010_0211211c.c:
+    complete
     .init start:0x0211211c end:0x0211215c
 
 src/__sinit_ov010_0211215c.c:
+    complete
     .init start:0x0211215c end:0x0211219c

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -41,6 +41,7 @@ src/_ZN12SwitchPillarD0Ev.c:
     .text start:0x0211149c end:0x021114fc
 
 src/_ZN12SwitchPillar16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021114fc end:0x02111540
 
 src/_ZN12SwitchPillar6RenderEv.cpp:
@@ -48,6 +49,7 @@ src/_ZN12SwitchPillar6RenderEv.cpp:
     .text start:0x02111540 end:0x02111574
 
 src/_ZN12SwitchPillar8BehaviorEv.cpp:
+    complete
     .text start:0x02111574 end:0x0211164c
 
 src/_ZN12SwitchPillar13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -59,7 +59,9 @@ src/BasementWater_Spawn.c:
     .text start:0x02111730 end:0x02111768
 
 src/__sinit_ov012_02111a88.c:
+    complete
     .init start:0x02111a88 end:0x02111af4
 
 src/__sinit_ov012_02111af4.c:
+    complete
     .init start:0x02111af4 end:0x02111b60

--- a/config/arm9/overlays/ov013/delinks.txt
+++ b/config/arm9/overlays/ov013/delinks.txt
@@ -67,7 +67,9 @@ src/ClockPaintingHandLong_Spawn.c:
     .text start:0x02111674 end:0x021116ac
 
 src/__sinit_ov013_021116b8.c:
+    complete
     .init start:0x021116b8 end:0x021116f8
 
 src/__sinit_ov013_021116f8.c:
+    complete
     .init start:0x021116f8 end:0x02111760

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -160,10 +160,13 @@ src/ChainChompFence_Spawn.c:
     .text start:0x0211307c end:0x021130ac
 
 src/__sinit_ov014_021130ac.c:
+    complete
     .init start:0x021130ac end:0x02113118
 
 src/__sinit_ov014_02113118.c:
+    complete
     .init start:0x02113118 end:0x021132fc
 
 src/__sinit_ov014_021132fc.c:
+    complete
     .init start:0x021132fc end:0x02113368

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -16,6 +16,7 @@ src/_ZN10ShutterBob8BehaviorEv.cpp:
     .text start:0x02111268 end:0x02111294
 
 src/_ZN10ShutterBob13InitResourcesEv.cpp:
+    complete
     .text start:0x02111294 end:0x021112cc
 
 src/ShutterBob_Spawn.c:
@@ -153,6 +154,7 @@ src/_ZN15ChainChompFence8BehaviorEv.cpp:
     .text start:0x02112fc0 end:0x02112ffc
 
 src/_ZN15ChainChompFence13InitResourcesEv.cpp:
+    complete
     .text start:0x02112ffc end:0x0211307c
 
 src/ChainChompFence_Spawn.c:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -256,22 +256,29 @@ src/FallBlockWf_Spawn.c:
     .text start:0x02112dd0 end:0x02112e0c
 
 src/__sinit_ov015_02112f9c.c:
+    complete
     .init start:0x02112f9c end:0x02112fdc
 
 src/__sinit_ov015_02112fdc.c:
+    complete
     .init start:0x02112fdc end:0x02113048
 
 src/__sinit_ov015_02113048.c:
+    complete
     .init start:0x02113048 end:0x02113264
 
 src/__sinit_ov015_02113264.c:
+    complete
     .init start:0x02113264 end:0x021132d0
 
 src/__sinit_ov015_021132d0.c:
+    complete
     .init start:0x021132d0 end:0x0211333c
 
 src/__sinit_ov015_0211333c.c:
+    complete
     .init start:0x0211333c end:0x021133a8
 
 src/__sinit_ov015_021133a8.c:
+    complete
     .init start:0x021133a8 end:0x02113410

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -138,6 +138,7 @@ src/func_ov015_02111fb8.c:
     .text start:0x02111fb8 end:0x02112004
 
 src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112004 end:0x02112068
 
 src/_ZN14KnockDownPlank6RenderEv.cpp:
@@ -213,6 +214,7 @@ src/_ZN9TowerStep6RenderEv.cpp:
     .text start:0x02112a24 end:0x02112a4c
 
 src/_ZN9TowerStep8BehaviorEv.cpp:
+    complete
     .text start:0x02112a4c end:0x02112b04
 
 src/_ZN9TowerStep13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -180,16 +180,21 @@ src/SlidingBox_Spawn.c:
     .text start:0x02113510 end:0x0211354c
 
 src/__sinit_ov016_021136ec.c:
+    complete
     .init start:0x021136ec end:0x021138bc
 
 src/__sinit_ov016_021138bc.c:
+    complete
     .init start:0x021138bc end:0x02113978
 
 src/__sinit_ov016_02113978.c:
+    complete
     .init start:0x02113978 end:0x021139e4
 
 src/__sinit_ov016_021139e4.c:
+    complete
     .init start:0x021139e4 end:0x02113a50
 
 src/__sinit_ov016_02113a50.c:
+    complete
     .init start:0x02113a50 end:0x02113abc

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -90,6 +90,7 @@ src/func_ov016_021126a8.c:
     .text start:0x021126a8 end:0x021126f0
 
 src/_ZN6ShipUp16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021126f0 end:0x02112744
 
 src/_ZN6ShipUp6RenderEv.cpp:
@@ -162,6 +163,7 @@ src/func_ov016_021130a4.c:
     .text start:0x021130a4 end:0x021130ec
 
 src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021130ec end:0x02113130
 
 src/_ZN23FloatOnWaterPlatformJrb6RenderEv.cpp:

--- a/config/arm9/overlays/ov017/delinks.txt
+++ b/config/arm9/overlays/ov017/delinks.txt
@@ -18,6 +18,7 @@ src/_ZN9ShipWater6RenderEv.cpp:
     .text start:0x02111290 end:0x021112c4
 
 src/_ZN9ShipWater8BehaviorEv.cpp:
+    complete
     .text start:0x021112c4 end:0x021113c0
 
 src/_ZN9ShipWater13InitResourcesEv.c:

--- a/config/arm9/overlays/ov017/delinks.txt
+++ b/config/arm9/overlays/ov017/delinks.txt
@@ -29,4 +29,5 @@ src/ShipWater_Spawn.c:
     .text start:0x02111480 end:0x021114b8
 
 src/__sinit_ov017_0211198c.c:
+    complete
     .init start:0x0211198c end:0x021119f8

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -177,6 +177,7 @@ src/_ZN8IceSheet8BehaviorEv.cpp:
     .text start:0x02112990 end:0x021129c0
 
 src/_ZN8IceSheet13InitResourcesEv.cpp:
+    complete
     .text start:0x021129c0 end:0x02112a44
 
 src/IceSheet_Spawn.c:

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -184,10 +184,13 @@ src/IceSheet_Spawn.c:
     .text start:0x02112a44 end:0x02112a74
 
 src/__sinit_ov018_02112c14.c:
+    complete
     .init start:0x02112c14 end:0x02112c80
 
 src/__sinit_ov018_02112c80.cpp:
+    complete
     .init start:0x02112c80 end:0x02112e00
 
 src/__sinit_ov018_02112e00.c:
+    complete
     .init start:0x02112e00 end:0x02112e6c

--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -128,6 +128,7 @@ src/_ZN15IceSlideManagerD0Ev.c:
     .text start:0x02112640 end:0x02112678
 
 src/_ZN15IceSlideManager8BehaviorEv.cpp:
+    complete
     .text start:0x02112678 end:0x0211271c
 
 src/_ZN15IceSlideManager13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -139,7 +139,9 @@ src/IceSlideManager_Spawn.c:
     .text start:0x0211274c end:0x0211277c
 
 src/__sinit_ov019_021127a4.c:
+    complete
     .init start:0x021127a4 end:0x02112b14
 
 src/__sinit_ov019_02112b14.c:
+    complete
     .init start:0x02112b14 end:0x02112b64

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -175,7 +175,9 @@ src/HauntedChair_Spawn.c:
     .text start:0x02113494 end:0x021134e4
 
 src/__sinit_ov020_02113674.c:
+    complete
     .init start:0x02113674 end:0x0211372c
 
 src/__sinit_ov020_0211372c.c:
+    complete
     .init start:0x0211372c end:0x02113768

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -78,6 +78,7 @@ src/_ZN8BookShot16CleanupResourcesEv.cpp:
     .text start:0x02112244 end:0x02112290
 
 src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112290 end:0x021122c4
 
 src/_ZN8BookShot6RenderEv.cpp:
@@ -92,6 +93,7 @@ src/_ZN15BookShotSpawner8BehaviorEv.cpp:
     .text start:0x02112418 end:0x021124e4
 
 src/_ZN8BookShot13InitResourcesEv.cpp:
+    complete
     .text start:0x021124e4 end:0x02112768
 
 src/_ZN15BookShotSpawner13InitResourcesEv.cpp:
@@ -168,6 +170,7 @@ src/_ZN12HauntedChair8BehaviorEv.cpp:
     .text start:0x02113324 end:0x021133b0
 
 src/_ZN12HauntedChair13InitResourcesEv.cpp:
+    complete
     .text start:0x021133b0 end:0x02113494
 
 src/HauntedChair_Spawn.c:

--- a/config/arm9/overlays/ov021/delinks.txt
+++ b/config/arm9/overlays/ov021/delinks.txt
@@ -20,6 +20,7 @@ src/func_ov021_02111434.c:
     .text start:0x02111434 end:0x021115dc
 
 src/_ZN12WorkElevator16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021115dc end:0x02111650
 
 src/_ZN12WorkElevator6RenderEv.cpp:
@@ -135,6 +136,7 @@ src/_ZN10ShutterHmc8BehaviorEv.cpp:
     .text start:0x02112e7c end:0x02112ec0
 
 src/_ZN10ShutterHmc13InitResourcesEv.cpp:
+    complete
     .text start:0x02112ec0 end:0x02112ed4
 
 src/ShutterHmc_Spawn.c:

--- a/config/arm9/overlays/ov021/delinks.txt
+++ b/config/arm9/overlays/ov021/delinks.txt
@@ -141,10 +141,13 @@ src/ShutterHmc_Spawn.c:
     .text start:0x02112ed4 end:0x02112f10
 
 src/__sinit_ov021_02113500.c:
+    complete
     .init start:0x02113500 end:0x02113688
 
 src/__sinit_ov021_02113688.c:
+    complete
     .init start:0x02113688 end:0x021136c8
 
 src/__sinit_ov021_021136c8.c:
+    complete
     .init start:0x021136c8 end:0x02113734

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -258,31 +258,41 @@ src/VolcanoFire_Spawn.c:
     .text start:0x02112918 end:0x02112950
 
 src/__sinit_ov022_02112ca8.c:
+    complete
     .init start:0x02112ca8 end:0x02112d14
 
 src/__sinit_ov022_02112d14.c:
+    complete
     .init start:0x02112d14 end:0x02112d80
 
 src/__sinit_ov022_02112d80.c:
+    complete
     .init start:0x02112d80 end:0x02112dec
 
 src/__sinit_ov022_02112dec.c:
+    complete
     .init start:0x02112dec end:0x02112e58
 
 src/__sinit_ov022_02112e58.c:
+    complete
     .init start:0x02112e58 end:0x02112ec0
 
 src/__sinit_ov022_02112ec0.c:
+    complete
     .init start:0x02112ec0 end:0x02112f78
 
 src/__sinit_ov022_02112f78.c:
+    complete
     .init start:0x02112f78 end:0x02112fe4
 
 src/__sinit_ov022_02112fe4.c:
+    complete
     .init start:0x02112fe4 end:0x02113050
 
 src/__sinit_ov022_02113050.c:
+    complete
     .init start:0x02113050 end:0x021130bc
 
 src/__sinit_ov022_021130bc.c:
+    complete
     .init start:0x021130bc end:0x021130f8

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -61,6 +61,7 @@ src/_ZN19RotatingPlatformLllD0Ev.c:
     .text start:0x02111708 end:0x02111760
 
 src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111760 end:0x021117a4
 
 src/_ZN19RotatingPlatformLll6RenderEv.cpp:
@@ -179,6 +180,7 @@ src/_ZN19FloatingFloorLllBig8BehaviorEv.cpp:
     .text start:0x02112238 end:0x021122ac
 
 src/_ZN19FloatingFloorLllBig13InitResourcesEv.cpp:
+    complete
     .text start:0x021122ac end:0x02112350
 
 src/LavaPlank_Spawn.c:

--- a/config/arm9/overlays/ov023/delinks.txt
+++ b/config/arm9/overlays/ov023/delinks.txt
@@ -38,4 +38,5 @@ src/Squasher_Spawn.c:
     .text start:0x02111728 end:0x02111760
 
 src/__sinit_ov023_02111aa8.c:
+    complete
     .init start:0x02111aa8 end:0x02111b14

--- a/config/arm9/overlays/ov024/delinks.txt
+++ b/config/arm9/overlays/ov024/delinks.txt
@@ -34,6 +34,7 @@ src/func_ov024_021114c4.c:
     .text start:0x021114c4 end:0x02111504
 
 src/_ZN10PyramidTop16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111504 end:0x0211153c
 
 src/_ZN10PyramidTop6RenderEv.cpp:

--- a/config/arm9/overlays/ov024/delinks.txt
+++ b/config/arm9/overlays/ov024/delinks.txt
@@ -63,4 +63,5 @@ src/PyramidTop_Spawn.c:
     .text start:0x02111874 end:0x021118ac
 
 src/__sinit_ov024_02112808.c:
+    complete
     .init start:0x02112808 end:0x02112874

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -23,6 +23,7 @@ src/func_ov025_02111344.c:
     .text start:0x02111344 end:0x02111384
 
 src/func_ov025_02111384.cpp:
+    complete
     .text start:0x02111384 end:0x021113c8
 
 src/func_ov025_021113c8.cpp:
@@ -123,6 +124,7 @@ src/_ZN11PyramidLift8BehaviorEv.cpp:
     .text start:0x02112288 end:0x02112498
 
 src/_ZN11PyramidLift13InitResourcesEv.cpp:
+    complete
     .text start:0x02112498 end:0x021125bc
 
 src/func_ov025_021125bc.cpp:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -138,13 +138,17 @@ src/PyramidLift_Spawn.cpp:
     .text start:0x021125f0 end:0x02112654
 
 src/__sinit_ov025_02112970.c:
+    complete
     .init start:0x02112970 end:0x021129dc
 
 src/__sinit_ov025_021129dc.c:
+    complete
     .init start:0x021129dc end:0x02112a44
 
 src/__sinit_ov025_02112a44.c:
+    complete
     .init start:0x02112a44 end:0x02112aac
 
 src/__sinit_ov025_02112aac.c:
+    complete
     .init start:0x02112aac end:0x02112b18

--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -186,16 +186,21 @@ src/WaterSuction_Spawn.c:
     .text start:0x02112450 end:0x02112490
 
 src/__sinit_ov026_02112b7c.c:
+    complete
     .init start:0x02112b7c end:0x02112bbc
 
 src/__sinit_ov026_02112bbc.c:
+    complete
     .init start:0x02112bbc end:0x02112c28
 
 src/__sinit_ov026_02112c28.c:
+    complete
     .init start:0x02112c28 end:0x02112c94
 
 src/__sinit_ov026_02112c94.c:
+    complete
     .init start:0x02112c94 end:0x02112d68
 
 src/__sinit_ov026_02112d68.c:
+    complete
     .init start:0x02112d68 end:0x02112da4

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -186,13 +186,17 @@ src/SnowmanBreath_Spawn.cpp:
     .text start:0x02112ab4 end:0x02112b14
 
 src/__sinit_ov027_02112cb0.c:
+    complete
     .init start:0x02112cb0 end:0x02112d1c
 
 src/__sinit_ov027_02112d1c.c:
+    complete
     .init start:0x02112d1c end:0x02112df8
 
 src/__sinit_ov027_02112df8.cpp:
+    complete
     .init start:0x02112df8 end:0x02112f70
 
 src/__sinit_ov027_02112f70.c:
+    complete
     .init start:0x02112f70 end:0x02112fc4

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -214,25 +214,33 @@ src/SwitchActivatedPlank_Spawn.c:
     .text start:0x02112964 end:0x0211299c
 
 src/__sinit_ov029_02112b38.c:
+    complete
     .init start:0x02112b38 end:0x02112ba4
 
 src/__sinit_ov029_02112ba4.c:
+    complete
     .init start:0x02112ba4 end:0x02112c10
 
 src/__sinit_ov029_02112c10.c:
+    complete
     .init start:0x02112c10 end:0x02112c4c
 
 src/__sinit_ov029_02112c4c.c:
+    complete
     .init start:0x02112c4c end:0x02112cb8
 
 src/__sinit_ov029_02112cb8.c:
+    complete
     .init start:0x02112cb8 end:0x02112d24
 
 src/__sinit_ov029_02112d24.c:
+    complete
     .init start:0x02112d24 end:0x02112d90
 
 src/__sinit_ov029_02112d90.c:
+    complete
     .init start:0x02112d90 end:0x02112dfc
 
 src/__sinit_ov029_02112dfc.c:
+    complete
     .init start:0x02112dfc end:0x02112e68

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -31,6 +31,7 @@ src/_ZN29FloatOnWaterPlatformWdwSquare6RenderEv.cpp:
     .text start:0x0211145c end:0x02111484
 
 src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp:
+    complete
     .text start:0x02111484 end:0x021115f8
 
 src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -224,10 +224,13 @@ src/UkikiThief_Spawn.c:
     .text start:0x02114638 end:0x02114690
 
 src/__sinit_ov030_0211484c.c:
+    complete
     .init start:0x0211484c end:0x021148b8
 
 src/__sinit_ov030_021148b8.c:
+    complete
     .init start:0x021148b8 end:0x02114924
 
 src/__sinit_ov030_02114924.c:
+    complete
     .init start:0x02114924 end:0x02114dd0

--- a/config/arm9/overlays/ov031/delinks.txt
+++ b/config/arm9/overlays/ov031/delinks.txt
@@ -44,4 +44,5 @@ src/SlideDecorationSilverStar_Spawn.c:
     .text start:0x021113ec end:0x02111424
 
 src/__sinit_ov031_02111434.c:
+    complete
     .init start:0x02111434 end:0x021114ec

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -150,10 +150,13 @@ src/HugeWater_Spawn.c:
     .text start:0x021128b8 end:0x021128f0
 
 src/__sinit_ov032_02112c10.c:
+    complete
     .init start:0x02112c10 end:0x02112dbc
 
 src/__sinit_ov032_02112dbc.c:
+    complete
     .init start:0x02112dbc end:0x02112e28
 
 src/__sinit_ov032_02112e28.c:
+    complete
     .init start:0x02112e28 end:0x02112e94

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -139,6 +139,7 @@ src/_ZN9HugeCover6RenderEv.cpp:
     .text start:0x02112788 end:0x021127bc
 
 src/_ZN9HugeCover8BehaviorEv.cpp:
+    complete
     .text start:0x021127bc end:0x021127f0
 
 src/_ZN9HugeCover13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov033/delinks.txt
+++ b/config/arm9/overlays/ov033/delinks.txt
@@ -41,6 +41,7 @@ src/_ZN9TinyCoverD0Ev.c:
     .text start:0x02111420 end:0x02111480
 
 src/_ZN9TinyCover16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111480 end:0x021114c4
 
 src/_ZN9TinyCover6RenderEv.cpp:

--- a/config/arm9/overlays/ov033/delinks.txt
+++ b/config/arm9/overlays/ov033/delinks.txt
@@ -60,7 +60,9 @@ src/TinyWater_Spawn.c:
     .text start:0x02111690 end:0x021116c8
 
 src/__sinit_ov033_021119e8.c:
+    complete
     .init start:0x021119e8 end:0x02111a54
 
 src/__sinit_ov033_02111a54.c:
+    complete
     .init start:0x02111a54 end:0x02111ac0

--- a/config/arm9/overlays/ov034/delinks.txt
+++ b/config/arm9/overlays/ov034/delinks.txt
@@ -138,4 +138,5 @@ src/Wiggler_Spawn.c:
     .text start:0x021136a4 end:0x02113820
 
 src/__sinit_ov034_021138ec.c:
+    complete
     .init start:0x021138ec end:0x02114078

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -11,6 +11,7 @@ src/_ZN16RotatingCogSmallD0Ev.c:
     .text start:0x021111e4 end:0x0211123c
 
 src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211123c end:0x021112c4
 
 src/_ZN16RotatingCogSmall6RenderEv.cpp:

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -68,7 +68,9 @@ src/SpinningPlatform_Spawn.c:
     .text start:0x02111b98 end:0x02111bd0
 
 src/__sinit_ov035_02111f04.c:
+    complete
     .init start:0x02111f04 end:0x02111fc0
 
 src/__sinit_ov035_02111fc0.c:
+    complete
     .init start:0x02111fc0 end:0x02112028

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -190,22 +190,29 @@ src/FlyingCarpet_Spawn.cpp:
     .text start:0x02112538 end:0x021125b0
 
 src/__sinit_ov036_021125b0.c:
+    complete
     .init start:0x021125b0 end:0x0211261c
 
 src/__sinit_ov036_0211261c.c:
+    complete
     .init start:0x0211261c end:0x02112688
 
 src/__sinit_ov036_02112688.c:
+    complete
     .init start:0x02112688 end:0x021126c8
 
 src/__sinit_ov036_021126c8.c:
+    complete
     .init start:0x021126c8 end:0x02112730
 
 src/__sinit_ov036_02112730.c:
+    complete
     .init start:0x02112730 end:0x0211279c
 
 src/__sinit_ov036_0211279c.c:
+    complete
     .init start:0x0211279c end:0x02112944
 
 src/__sinit_ov036_02112944.c:
+    complete
     .init start:0x02112944 end:0x021129dc

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -71,6 +71,7 @@ src/_ZN18RotatingPlatformRr8BehaviorEv.cpp:
     .text start:0x021116c0 end:0x02111854
 
 src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp:
+    complete
     .text start:0x02111854 end:0x02111904
 
 src/ShipWing_Spawn.c:
@@ -84,6 +85,7 @@ src/_ZN8ShipWingD0Ev.c:
     .text start:0x02111988 end:0x021119e8
 
 src/_ZN8ShipWing16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021119e8 end:0x02111a2c
 
 src/_ZN8ShipWing16OnPendingDestroyEv.c:
@@ -130,6 +132,7 @@ src/_ZN10DonutBlock8BehaviorEv.cpp:
     .text start:0x02111e20 end:0x02111eb0
 
 src/_ZN10DonutBlock13InitResourcesEv.cpp:
+    complete
     .text start:0x02111eb0 end:0x02111f5c
 
 src/ArmedRotatingPlatform_Spawn.c:
@@ -145,9 +148,11 @@ src/_ZN21ArmedRotatingPlatformD0Ev.c:
     .text start:0x0211200c end:0x021120a0
 
 src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021120a0 end:0x021120b4
 
 src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp:
+    complete
     .text start:0x021120b4 end:0x021120c8
 
 src/TrickyTriangles_Spawn.cpp:

--- a/config/arm9/overlays/ov039/delinks.txt
+++ b/config/arm9/overlays/ov039/delinks.txt
@@ -34,4 +34,5 @@ src/Cloud_Spawn.c:
     .text start:0x0211137c end:0x021113b4
 
 src/__sinit_ov039_021113b4.c:
+    complete
     .init start:0x021113b4 end:0x021113f4

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -71,9 +71,11 @@ src/_ZN19RickshawPlatformBdwD0Ev.c:
     .text start:0x021116b0 end:0x02111744
 
 src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111744 end:0x02111758
 
 src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp:
+    complete
     .text start:0x02111758 end:0x0211176c
 
 src/StairsBdw_Spawn.cpp:

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -81,13 +81,17 @@ src/StairsBdw_Spawn.cpp:
     .text start:0x0211176c end:0x021117fc
 
 src/__sinit_ov043_021117fc.c:
+    complete
     .init start:0x021117fc end:0x02111868
 
 src/__sinit_ov043_02111868.c:
+    complete
     .init start:0x02111868 end:0x021118d4
 
 src/__sinit_ov043_021118d4.c:
+    complete
     .init start:0x021118d4 end:0x02111940
 
 src/__sinit_ov043_02111940.c:
+    complete
     .init start:0x02111940 end:0x02111ae8

--- a/config/arm9/overlays/ov044/delinks.txt
+++ b/config/arm9/overlays/ov044/delinks.txt
@@ -31,4 +31,5 @@ src/OrangeBallBillboard_Spawn.c:
     .text start:0x021112dc end:0x02111314
 
 src/__sinit_ov044_02111314.c:
+    complete
     .init start:0x02111314 end:0x02111354

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -45,6 +45,7 @@ src/_ZN15FireSeaElevatorD0Ev.c:
     .text start:0x02111558 end:0x021115b8
 
 src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021115b8 end:0x021115f0
 
 src/_ZN15FireSeaElevator6RenderEv.cpp:
@@ -52,6 +53,7 @@ src/_ZN15FireSeaElevator6RenderEv.cpp:
     .text start:0x021115f0 end:0x02111618
 
 src/_ZN15FireSeaElevator8BehaviorEv.cpp:
+    complete
     .text start:0x02111618 end:0x02111738
 
 src/_ZN15FireSeaElevator13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -145,19 +145,25 @@ src/FallBlockBfs_Spawn.c:
     .text start:0x02111e24 end:0x02111e60
 
 src/__sinit_ov045_021121a8.c:
+    complete
     .init start:0x021121a8 end:0x02112214
 
 src/__sinit_ov045_02112214.c:
+    complete
     .init start:0x02112214 end:0x02112280
 
 src/__sinit_ov045_02112280.c:
+    complete
     .init start:0x02112280 end:0x021122ec
 
 src/__sinit_ov045_021122ec.c:
+    complete
     .init start:0x021122ec end:0x02112358
 
 src/__sinit_ov045_02112358.c:
+    complete
     .init start:0x02112358 end:0x021123c0
 
 src/__sinit_ov045_021123c0.c:
+    complete
     .init start:0x021123c0 end:0x0211242c

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -63,9 +63,11 @@ src/_ZN18RickshawPlatformBsD0Ev.c:
     .text start:0x02111590 end:0x02111624
 
 src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111624 end:0x02111638
 
 src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp:
+    complete
     .text start:0x02111638 end:0x0211164c
 
 src/StairsBs_Spawn.cpp:

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -73,13 +73,17 @@ src/StairsBs_Spawn.cpp:
     .text start:0x0211164c end:0x021116dc
 
 src/__sinit_ov047_021116dc.c:
+    complete
     .init start:0x021116dc end:0x02111748
 
 src/__sinit_ov047_02111748.c:
+    complete
     .init start:0x02111748 end:0x021117b4
 
 src/__sinit_ov047_021117b4.c:
+    complete
     .init start:0x021117b4 end:0x0211181c
 
 src/__sinit_ov047_0211181c.c:
+    complete
     .init start:0x0211181c end:0x021119c4

--- a/config/arm9/overlays/ov052/delinks.txt
+++ b/config/arm9/overlays/ov052/delinks.txt
@@ -56,7 +56,9 @@ src/SquarePathLift_Spawn.c:
     .text start:0x02111830 end:0x02111868
 
 src/__sinit_ov052_02111b64.c:
+    complete
     .init start:0x02111b64 end:0x02111bd0
 
 src/__sinit_ov052_02111bd0.c:
+    complete
     .init start:0x02111bd0 end:0x02111c3c

--- a/config/arm9/overlays/ov055/delinks.txt
+++ b/config/arm9/overlays/ov055/delinks.txt
@@ -46,4 +46,5 @@ src/MirrorLuigi_Spawn.cpp:
     .text start:0x02111860 end:0x021118d4
 
 src/__sinit_ov055_021118d4.c:
+    complete
     .init start:0x021118d4 end:0x02111910

--- a/config/arm9/overlays/ov056/delinks.txt
+++ b/config/arm9/overlays/ov056/delinks.txt
@@ -30,4 +30,5 @@ src/BigMovingIceBlock_Spawn.c:
     .text start:0x02111594 end:0x021115cc
 
 src/__sinit_ov056_02112b48.c:
+    complete
     .init start:0x02112b48 end:0x02112bb4

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -590,19 +590,25 @@ src/BowserShockwaves_Spawn.c:
     .text start:0x021191f4 end:0x02119264
 
 src/__sinit_ov060_021195dc.c:
+    complete
     .init start:0x021195dc end:0x02119df0
 
 src/__sinit_ov060_02119df0.c:
+    complete
     .init start:0x02119df0 end:0x02119f94
 
 src/__sinit_ov060_02119f94.c:
+    complete
     .init start:0x02119f94 end:0x0211a000
 
 src/__sinit_ov060_0211a000.c:
+    complete
     .init start:0x0211a000 end:0x0211a388
 
 src/__sinit_ov060_0211a388.c:
+    complete
     .init start:0x0211a388 end:0x0211a428
 
 src/__sinit_ov060_0211a428.c:
+    complete
     .init start:0x0211a428 end:0x0211a4bc

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -475,16 +475,21 @@ src/Klepto_Spawn.c:
     .text start:0x0211ce80 end:0x0211ced8
 
 src/__sinit_ov062_0211cf30.c:
+    complete
     .init start:0x0211cf30 end:0x0211d2d8
 
 src/__sinit_ov062_0211d2d8.c:
+    complete
     .init start:0x0211d2d8 end:0x0211d4a0
 
 src/__sinit_ov062_0211d4a0.c:
+    complete
     .init start:0x0211d4a0 end:0x0211d690
 
 src/__sinit_ov062_0211d690.c:
+    complete
     .init start:0x0211d690 end:0x0211d6fc
 
 src/__sinit_ov062_0211d6fc.c:
+    complete
     .init start:0x0211d6fc end:0x0211d8cc

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -256,6 +256,7 @@ src/func_ov062_02118de8.cpp:
     .text start:0x02118de8 end:0x02118f04
 
 src/_ZN5Koopa16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02118f04 end:0x02118f80
 
 src/_ZN5Koopa16OnPendingDestroyEv.c:

--- a/config/arm9/overlays/ov063/delinks.txt
+++ b/config/arm9/overlays/ov063/delinks.txt
@@ -534,13 +534,17 @@ src/actors/MadPiano/MadPiano_Spawn.cpp:
     .text start:0x0211e128 end:0x0211e1c0
 
 src/unnamed/ov063/__sinit_ov063_0211e29c.c:
+    complete
     .init start:0x0211e29c end:0x0211e3cc
 
 src/unnamed/ov063/__sinit_ov063_0211e3cc.c:
+    complete
     .init start:0x0211e3cc end:0x0211e590
 
 src/unnamed/ov063/__sinit_ov063_0211e590.c:
+    complete
     .init start:0x0211e590 end:0x0211e5fc
 
 src/actors/MadPiano/__sinit_ov063_0211e5fc.c:
+    complete
     .init start:0x0211e5fc end:0x0211e6fc

--- a/config/arm9/overlays/ov063/delinks.txt
+++ b/config/arm9/overlays/ov063/delinks.txt
@@ -416,6 +416,7 @@ src/unnamed/ov063/func_ov063_0211cc18.c:
     .text start:0x0211cc18 end:0x0211cdec
 
 src/actors/MansionSteps/_ZN12MansionSteps16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211cdec end:0x0211ce30
 
 src/actors/MansionSteps/_ZN12MansionSteps16OnPendingDestroyEv.c:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -131,6 +131,7 @@ src/_ZN5Bully8BehaviorEv.c:
     .text start:0x02117310 end:0x02117424
 
 src/_ZN5Bully13InitResourcesEv.cpp:
+    complete
     .text start:0x02117424 end:0x02117444
 
 src/Bully_Spawn.c:
@@ -251,6 +252,7 @@ src/_ZN15RotatingFirebar8BehaviorEv.cpp:
     .text start:0x02118274 end:0x02118480
 
 src/_ZN15RotatingFirebar13InitResourcesEv.cpp:
+    complete
     .text start:0x02118480 end:0x02118564
 
 src/RotatingFirebar_Spawn.cpp:
@@ -302,6 +304,7 @@ src/_ZN10LavaBubble8BehaviorEv.cpp:
     .text start:0x02118850 end:0x021189d8
 
 src/_ZN10LavaBubble13InitResourcesEv.cpp:
+    complete
     .text start:0x021189d8 end:0x02118b08
 
 src/func_ov064_02118b08.c:
@@ -370,6 +373,7 @@ src/func_ov064_02119010.c:
     .text start:0x02119010 end:0x0211904c
 
 src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211904c end:0x02119088
 
 src/_ZN19BowserPuzzleManager6RenderEv.cpp:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -599,34 +599,45 @@ src/Clam_Spawn.c:
     .text start:0x0211ad70 end:0x0211adb0
 
 src/__sinit_ov064_0211ae00.c:
+    complete
     .init start:0x0211ae00 end:0x0211aee0
 
 src/__sinit_ov064_0211aee0.c:
+    complete
     .init start:0x0211aee0 end:0x0211afc0
 
 src/__sinit_ov064_0211afc0.c:
+    complete
     .init start:0x0211afc0 end:0x0211b078
 
 src/__sinit_ov064_0211b078.c:
+    complete
     .init start:0x0211b078 end:0x0211b0e4
 
 src/__sinit_ov064_0211b0e4.c:
+    complete
     .init start:0x0211b0e4 end:0x0211b150
 
 src/__sinit_ov064_0211b150.c:
+    complete
     .init start:0x0211b150 end:0x0211b1d4
 
 src/__sinit_ov064_0211b1d4.c:
+    complete
     .init start:0x0211b1d4 end:0x0211b4dc
 
 src/__sinit_ov064_0211b4dc.c:
+    complete
     .init start:0x0211b4dc end:0x0211b518
 
 src/__sinit_ov064_0211b518.c:
+    complete
     .init start:0x0211b518 end:0x0211b59c
 
 src/__sinit_ov064_0211b59c.c:
+    complete
     .init start:0x0211b59c end:0x0211b698
 
 src/__sinit_ov064_0211b698.c:
+    complete
     .init start:0x0211b698 end:0x0211b72c

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -508,31 +508,41 @@ src/TTC_MovingBeam_Spawn.c:
     .text start:0x0211c040 end:0x0211c078
 
 src/__sinit_ov065_0211c110.c:
+    complete
     .init start:0x0211c110 end:0x0211c2a8
 
 src/__sinit_ov065_0211c2a8.c:
+    complete
     .init start:0x0211c2a8 end:0x0211c440
 
 src/__sinit_ov065_0211c440.c:
+    complete
     .init start:0x0211c440 end:0x0211c660
 
 src/__sinit_ov065_0211c660.c:
+    complete
     .init start:0x0211c660 end:0x0211c76c
 
 src/__sinit_ov065_0211c76c.c:
+    complete
     .init start:0x0211c76c end:0x0211c7d8
 
 src/__sinit_ov065_0211c7d8.c:
+    complete
     .init start:0x0211c7d8 end:0x0211c890
 
 src/__sinit_ov065_0211c890.c:
+    complete
     .init start:0x0211c890 end:0x0211c8fc
 
 src/__sinit_ov065_0211c8fc.c:
+    complete
     .init start:0x0211c8fc end:0x0211c9b8
 
 src/__sinit_ov065_0211c9b8.c:
+    complete
     .init start:0x0211c9b8 end:0x0211ca74
 
 src/__sinit_ov065_0211ca74.c:
+    complete
     .init start:0x0211ca74 end:0x0211cae0

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -75,6 +75,7 @@ src/_ZN6Snufit8BehaviorEv.cpp:
     .text start:0x02116b84 end:0x02116e10
 
 src/_ZN6Snufit13InitResourcesEv.cpp:
+    complete
     .text start:0x02116e10 end:0x02116f0c
 
 src/func_ov065_02116f0c.c:
@@ -159,6 +160,7 @@ src/_ZN5Swoop8BehaviorEv.cpp:
     .text start:0x02117b64 end:0x02117d80
 
 src/_ZN5Swoop13InitResourcesEv.cpp:
+    complete
     .text start:0x02117d80 end:0x02117eac
 
 src/func_ov065_02117eac.c:
@@ -225,6 +227,7 @@ src/func_ov065_02118cc4.c:
     .text start:0x02118cc4 end:0x02118d04
 
 src/_ZN6Dorrie16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02118d04 end:0x02118d80
 
 src/_ZN6Dorrie6RenderEv.cpp:
@@ -250,6 +253,7 @@ src/_ZN6Dorrie13InitResourcesEv.cpp:
     .text start:0x02119228 end:0x021194e8
 
 src/_ZN9DorrieCap13InitResourcesEv.cpp:
+    complete
     .text start:0x021194e8 end:0x0211956c
 
 src/func_ov065_0211956c.c:
@@ -303,6 +307,7 @@ src/func_ov065_0211990c.c:
     .text start:0x0211990c end:0x02119984
 
 src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02119984 end:0x021199fc
 
 src/_ZN15TtcRotatingCube6RenderEv.cpp:
@@ -364,6 +369,7 @@ src/func_ov065_0211a550.c:
     .text start:0x0211a550 end:0x0211a638
 
 src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211a638 end:0x0211a69c
 
 src/_ZN20TtcConveyorBeltLarge6RenderEv.cpp:
@@ -434,6 +440,7 @@ src/func_ov065_0211b40c.c:
     .text start:0x0211b40c end:0x0211b47c
 
 src/_ZN13TTC_MovingBar16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211b47c end:0x0211b4e0
 
 src/_ZN13TTC_MovingBar6RenderEv.cpp:

--- a/config/arm9/overlays/ov066/delinks.txt
+++ b/config/arm9/overlays/ov066/delinks.txt
@@ -217,6 +217,7 @@ src/func_ov066_021194fc.cpp:
     .text start:0x021194fc end:0x02119654
 
 src/_ZN6Eyerok16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02119654 end:0x021197a0
 
 src/_ZN6Eyerok16OnPendingDestroyEv.c:

--- a/config/arm9/overlays/ov066/delinks.txt
+++ b/config/arm9/overlays/ov066/delinks.txt
@@ -251,4 +251,5 @@ src/Eyerok_Spawn.cpp:
     .text start:0x0211a370 end:0x0211a418
 
 src/__sinit_ov066_0211a418.c:
+    complete
     .init start:0x0211a418 end:0x0211abc0

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -355,13 +355,17 @@ src/FlameChompFire_Spawn.c:
     .text start:0x021221fc end:0x02122244
 
 src/__sinit_ov070_02122afc.c:
+    complete
     .init start:0x02122afc end:0x02122d80
 
 src/__sinit_ov070_02122d80.cpp:
+    complete
     .init start:0x02122d80 end:0x02122f30
 
 src/__sinit_ov070_02122f30.c:
+    complete
     .init start:0x02122f30 end:0x02123030
 
 src/__sinit_ov070_02123030.c:
+    complete
     .init start:0x02123030 end:0x021230a4

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -87,6 +87,7 @@ src/_ZN6FlyGuy8BehaviorEv.cpp:
     .text start:0x02120210 end:0x021203b4
 
 src/_ZN6FlyGuy13InitResourcesEv.cpp:
+    complete
     .text start:0x021203b4 end:0x021204e4
 
 src/func_ov070_021204e4.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -330,12 +330,15 @@ src/Coffin_Spawn.c:
     .text start:0x02122670 end:0x021226a0
 
 src/__sinit_ov071_021226ac.c:
+    complete
     .init start:0x021226ac end:0x021228c8
 
 src/__sinit_ov071_021228c8.c:
+    complete
     .init start:0x021228c8 end:0x02122a1c
 
 src/__sinit_ov071_02122a1c.c:
+    complete
     .init start:0x02122a1c end:0x02122a64
 
 src/__sinit_ov071_02122a64.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -273,6 +273,7 @@ src/_ZN14MrI_Projectile8BehaviorEv.cpp:
     .text start:0x02121d80 end:0x02121eb4
 
 src/_ZN14MrI_Projectile13InitResourcesEv.cpp:
+    complete
     .text start:0x02121eb4 end:0x02121f9c
 
 src/MrI_Projectile_Spawn.c:

--- a/config/arm9/overlays/ov072/delinks.txt
+++ b/config/arm9/overlays/ov072/delinks.txt
@@ -351,13 +351,17 @@ src/BabyPenguin_Spawn.c:
     .text start:0x02121fac end:0x02121ffc
 
 src/__sinit_ov072_02122018.c:
+    complete
     .init start:0x02122018 end:0x021221f8
 
 src/__sinit_ov072_021221f8.c:
+    complete
     .init start:0x021221f8 end:0x02122350
 
 src/__sinit_ov072_02122350.c:
+    complete
     .init start:0x02122350 end:0x02122414
 
 src/__sinit_ov072_02122414.c:
+    complete
     .init start:0x02122414 end:0x02122708

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -180,6 +180,7 @@ src/_ZN11ChiefChilly8BehaviorEv.cpp:
     .text start:0x021218a0 end:0x02121ccc
 
 src/_ZN11ChiefChilly13InitResourcesEv.cpp:
+    complete
     .text start:0x02121ccc end:0x02121ec0
 
 src/func_ov073_02121ec0.c:
@@ -236,6 +237,7 @@ src/func_ov073_021223f4.cpp:
     .text start:0x021223f4 end:0x02122464
 
 src/_ZN8CccArena16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02122464 end:0x021224c8
 
 src/_ZN8CccArena6RenderEv.cpp:

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -269,7 +269,9 @@ src/CccArena_Spawn.c:
     .text start:0x02122844 end:0x02122874
 
 src/__sinit_ov073_02122874.c:
+    complete
     .init start:0x02122874 end:0x02122d48
 
 src/__sinit_ov073_02122d48.c:
+    complete
     .init start:0x02122d48 end:0x02122f34

--- a/config/arm9/overlays/ov074/delinks.txt
+++ b/config/arm9/overlays/ov074/delinks.txt
@@ -201,4 +201,5 @@ src/Goomboss_Spawn.cpp:
     .text start:0x02122838 end:0x0212290c
 
 src/__sinit_ov074_02122978.c:
+    complete
     .init start:0x02122978 end:0x02122d70

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -516,10 +516,13 @@ src/func_ov075_0211b458.cpp:
     .text start:0x0211b458 end:0x0211b524
 
 src/__sinit_ov075_0211b5e0.c:
+    complete
     .init start:0x0211b5e0 end:0x0211bb00
 
 src/__sinit_ov075_0211bb00.c:
+    complete
     .init start:0x0211bb00 end:0x0211c51c
 
 src/__sinit_ov075_0211c51c.c:
+    complete
     .init start:0x0211c51c end:0x0211c5a4

--- a/config/arm9/overlays/ov077/delinks.txt
+++ b/config/arm9/overlays/ov077/delinks.txt
@@ -347,10 +347,13 @@ src/HeaveHo_Spawn.c:
     .text start:0x021271d4 end:0x02127230
 
 src/__sinit_ov077_02127240.c:
+    complete
     .init start:0x02127240 end:0x0212749c
 
 src/__sinit_ov077_0212749c.c:
+    complete
     .init start:0x0212749c end:0x021275fc
 
 src/__sinit_ov077_021275fc.c:
+    complete
     .init start:0x021275fc end:0x021277cc

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -203,4 +203,5 @@ src/KingBobOmb_Spawn.c:
     .text start:0x021265fc end:0x02126660
 
 src/__sinit_ov078_02126660.c:
+    complete
     .init start:0x02126660 end:0x02126cd4

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -255,13 +255,17 @@ src/FortressWallBreakable_Spawn.c:
     .text start:0x021275ac end:0x021275dc
 
 src/__sinit_ov079_02127618.c:
+    complete
     .init start:0x02127618 end:0x021279d4
 
 src/__sinit_ov079_021279d4.c:
+    complete
     .init start:0x021279d4 end:0x02127a10
 
 src/__sinit_ov079_02127a10.c:
+    complete
     .init start:0x02127a10 end:0x02127acc
 
 src/__sinit_ov079_02127acc.c:
+    complete
     .init start:0x02127acc end:0x02127b88

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -17,6 +17,7 @@ src/func_ov079_02123804.c:
     .text start:0x02123804 end:0x02123a8c
 
 src/func_ov079_02123a8c.cpp:
+    complete
     .text start:0x02123a8c end:0x02123b54
 
 src/func_ov079_02123b54.c:
@@ -36,6 +37,7 @@ src/func_ov079_02123d4c.cpp:
     .text start:0x02123d4c end:0x02123e60
 
 src/func_ov079_02123e60.cpp:
+    complete
     .text start:0x02123e60 end:0x02123f34
 
 src/func_ov079_02123f34.c:
@@ -122,6 +124,7 @@ src/func_ov079_02125b44.c:
     .text start:0x02125b44 end:0x02125eb0
 
 src/_ZN5Whomp16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02125eb0 end:0x02125f78
 
 src/_ZN5Whomp6RenderEv.cpp:
@@ -234,6 +237,7 @@ src/func_ov079_021272e0.cpp:
     .text start:0x021272e0 end:0x02127300
 
 src/_ZN12FortressWall16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02127300 end:0x02127364
 
 src/_ZN12FortressWall6RenderEv.cpp:
@@ -244,6 +248,7 @@ src/_ZN12FortressWall8BehaviorEv.cpp:
     .text start:0x021273a4 end:0x02127494
 
 src/_ZN12FortressWall13InitResourcesEv.cpp:
+    complete
     .text start:0x02127494 end:0x0212757c
 
 src/FortressWall_Spawn.c:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -87,6 +87,7 @@ src/_ZN13MontyMoleRock8BehaviorEv.cpp:
     .text start:0x0212459c end:0x0212478c
 
 src/_ZN9MontyMole13InitResourcesEv.cpp:
+    complete
     .text start:0x0212478c end:0x021248b4
 
 src/_ZN13MontyMoleRock13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -325,10 +325,13 @@ src/func_ov080_02127658.c:
     .text start:0x02127658 end:0x0212766c
 
 src/__sinit_ov080_021278c0.c:
+    complete
     .init start:0x021278c0 end:0x02127a60
 
 src/__sinit_ov080_02127a60.c:
+    complete
     .init start:0x02127a60 end:0x02127b2c
 
 src/__sinit_ov080_02127b2c.c:
+    complete
     .init start:0x02127b2c end:0x02127f60

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -397,6 +397,7 @@ src/func_ov081_02127cf4.c:
     .text start:0x02127cf4 end:0x02127d98
 
 src/_ZN8IceBlock16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02127d98 end:0x02127ddc
 
 src/_ZN8IceBlock6RenderEv.cpp:

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -415,16 +415,21 @@ src/IceBlock_Spawn.c:
     .text start:0x021280a0 end:0x021280d8
 
 src/__sinit_ov081_021280e8.c:
+    complete
     .init start:0x021280e8 end:0x02128154
 
 src/__sinit_ov081_02128154.c:
+    complete
     .init start:0x02128154 end:0x021284b4
 
 src/__sinit_ov081_021284b4.c:
+    complete
     .init start:0x021284b4 end:0x021284f0
 
 src/__sinit_ov081_021284f0.c:
+    complete
     .init start:0x021284f0 end:0x021287b8
 
 src/__sinit_ov081_021287b8.c:
+    complete
     .init start:0x021287b8 end:0x02128824

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -397,10 +397,13 @@ src/PiranhaPlant_Spawn.c:
     .text start:0x02130110 end:0x02130174
 
 src/__sinit_ov084_0213035c.c:
+    complete
     .init start:0x0213035c end:0x02130558
 
 src/__sinit_ov084_02130558.c:
+    complete
     .init start:0x02130558 end:0x02130654
 
 src/__sinit_ov084_02130654.c:
+    complete
     .init start:0x02130654 end:0x02130860

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -43,6 +43,7 @@ src/func_ov085_021295bc.c:
     .text start:0x021295bc end:0x021297e8
 
 src/_ZN4Toad16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021297e8 end:0x02129854
 
 src/_ZN4Toad6RenderEv.cpp:
@@ -480,19 +481,25 @@ src/WallSign_Spawn.c:
     .text start:0x0212f244 end:0x0212f27c
 
 src/__sinit_ov085_0212f2a8.c:
+    complete
     .init start:0x0212f2a8 end:0x0212f3a0
 
 src/__sinit_ov085_0212f3a0.c:
+    complete
     .init start:0x0212f3a0 end:0x0212f5ec
 
 src/__sinit_ov085_0212f5ec.c:
+    complete
     .init start:0x0212f5ec end:0x0212f9bc
 
 src/__sinit_ov085_0212f9bc.c:
+    complete
     .init start:0x0212f9bc end:0x0212fa40
 
 src/__sinit_ov085_0212fa40.c:
+    complete
     .init start:0x0212fa40 end:0x0212fdb0
 
 src/__sinit_ov085_0212fdb0.c:
+    complete
     .init start:0x0212fdb0 end:0x0212fdf0

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -319,6 +319,7 @@ src/_ZN9RabbitKey16OnPendingDestroyEv.c:
     .text start:0x0212d398 end:0x0212d39c
 
 src/_ZN9RabbitKey6RenderEv.cpp:
+    complete
     .text start:0x0212d39c end:0x0212d3ec
 
 src/_ZN9RabbitKey8BehaviorEv.cpp:
@@ -474,6 +475,7 @@ src/_ZN8WallSign6RenderEv.cpp:
     .text start:0x0212ee7c end:0x0212eea4
 
 src/_ZN8WallSign13InitResourcesEv.cpp:
+    complete
     .text start:0x0212f1b0 end:0x0212f244
 
 src/WallSign_Spawn.c:

--- a/config/arm9/overlays/ov089/delinks.txt
+++ b/config/arm9/overlays/ov089/delinks.txt
@@ -80,4 +80,5 @@ src/Key_Spawn.c:
     .text start:0x02132828 end:0x02132880
 
 src/__sinit_ov089_021328d4.c:
+    complete
     .init start:0x021328d4 end:0x02132af4

--- a/config/arm9/overlays/ov090/delinks.txt
+++ b/config/arm9/overlays/ov090/delinks.txt
@@ -263,13 +263,17 @@ src/Shark_Spawn.c:
     .text start:0x02133ca0 end:0x02133ce8
 
 src/__sinit_ov090_02133ce8.c:
+    complete
     .init start:0x02133ce8 end:0x02133ea8
 
 src/__sinit_ov090_02133ea8.c:
+    complete
     .init start:0x02133ea8 end:0x02133f4c
 
 src/__sinit_ov090_02133f4c.c:
+    complete
     .init start:0x02133f4c end:0x02134020
 
 src/__sinit_ov090_02134020.c:
+    complete
     .init start:0x02134020 end:0x021340c4

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -29,6 +29,7 @@ src/func_ov091_02131340.c:
     .text start:0x02131340 end:0x02131388
 
 src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02131388 end:0x02131408
 
 src/_ZN25RotatingUpDownPlatformUtm6RenderEv.cpp:
@@ -39,6 +40,7 @@ src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp:
     .text start:0x02131468 end:0x021318f0
 
 src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp:
+    complete
     .text start:0x021318f0 end:0x02131ba4
 
 src/RotatingUpDownPlatformUtm_Spawn.c:
@@ -112,6 +114,7 @@ src/_ZN17SlidingPlatformWfD0Ev.c:
     .text start:0x02132448 end:0x021324a0
 
 src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021324a0 end:0x02132504
 
 src/_ZN17SlidingPlatformWf6RenderEv.cpp:
@@ -119,6 +122,7 @@ src/_ZN17SlidingPlatformWf6RenderEv.cpp:
     .text start:0x02132504 end:0x0213252c
 
 src/_ZN17SlidingPlatformWf8BehaviorEv.cpp:
+    complete
     .text start:0x0213252c end:0x021325d4
 
 src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp:
@@ -171,6 +175,7 @@ src/_ZN6Thwomp8BehaviorEv.cpp:
     .text start:0x02132ab0 end:0x02132c84
 
 src/_ZN6Thwomp13InitResourcesEv.cpp:
+    complete
     .text start:0x02132c84 end:0x02132cb8
 
 src/Thwomp_Spawn.c:
@@ -211,6 +216,7 @@ src/func_ov091_02133098.cpp:
     .text start:0x02133098 end:0x021331b8
 
 src/_ZN6Thwomp16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021331b8 end:0x02133210
 
 src/_ZN6Thwomp6RenderEv.cpp:
@@ -305,6 +311,7 @@ src/func_ov091_02134094.c:
     .text start:0x02134094 end:0x02134108
 
 src/_ZN5Stump16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02134108 end:0x02134180
 
 src/_ZN5Stump16OnPendingDestroyEv.c:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -338,19 +338,25 @@ src/Fwoosh_Spawn.c:
     .text start:0x021344a0 end:0x021344e8
 
 src/__sinit_ov091_02134524.c:
+    complete
     .init start:0x02134524 end:0x021345dc
 
 src/__sinit_ov091_021345dc.c:
+    complete
     .init start:0x021345dc end:0x021346e8
 
 src/__sinit_ov091_021346e8.c:
+    complete
     .init start:0x021346e8 end:0x02134930
 
 src/__sinit_ov091_02134930.c:
+    complete
     .init start:0x02134930 end:0x021349c4
 
 src/__sinit_ov091_021349c4.c:
+    complete
     .init start:0x021349c4 end:0x02134a30
 
 src/__sinit_ov091_02134a30.c:
+    complete
     .init start:0x02134a30 end:0x02134b68

--- a/config/arm9/overlays/ov092/delinks.txt
+++ b/config/arm9/overlays/ov092/delinks.txt
@@ -96,4 +96,5 @@ src/ToxBox_Spawn.c:
     .text start:0x02132018 end:0x02132074
 
 src/__sinit_ov092_021320cc.c:
+    complete
     .init start:0x021320cc end:0x02132210

--- a/config/arm9/overlays/ov094/delinks.txt
+++ b/config/arm9/overlays/ov094/delinks.txt
@@ -90,4 +90,5 @@ src/HootTheOwl_Spawn.c:
     .text start:0x02136798 end:0x021367e8
 
 src/__sinit_ov094_021367e8.c:
+    complete
     .init start:0x021367e8 end:0x021369b8

--- a/config/arm9/overlays/ov094/delinks.txt
+++ b/config/arm9/overlays/ov094/delinks.txt
@@ -83,6 +83,7 @@ src/_ZN10HootTheOwl8BehaviorEv.cpp:
     .text start:0x02136478 end:0x02136634
 
 src/_ZN10HootTheOwl13InitResourcesEv.cpp:
+    complete
     .text start:0x02136634 end:0x02136798
 
 src/HootTheOwl_Spawn.c:

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -150,7 +150,9 @@ src/Flamethrower_Spawn.cpp:
     .text start:0x02136ed4 end:0x02136f58
 
 src/__sinit_ov095_02136fe0.c:
+    complete
     .init start:0x02136fe0 end:0x0213722c
 
 src/__sinit_ov095_0213722c.c:
+    complete
     .init start:0x0213722c end:0x021373b4

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -27,6 +27,7 @@ src/func_ov095_0213597c.c:
     .text start:0x0213597c end:0x021359c4
 
 src/_ZN9SeesawBob16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021359c4 end:0x02135a28
 
 src/_ZN9SeesawBob6RenderEv.cpp:
@@ -103,6 +104,7 @@ src/func_ov095_02136368.c:
     .text start:0x02136368 end:0x0213645c
 
 src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0213645c end:0x021364b0
 
 src/_ZN13UpDownLiftBbh6RenderEv.cpp:
@@ -114,6 +116,7 @@ src/_ZN13UpDownLiftBbh8BehaviorEv.cpp:
     .text start:0x021364d8 end:0x021365d8
 
 src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp:
+    complete
     .text start:0x021365d8 end:0x02136764
 
 src/func_ov095_02136764.cpp:

--- a/config/arm9/overlays/ov096/delinks.txt
+++ b/config/arm9/overlays/ov096/delinks.txt
@@ -183,7 +183,9 @@ src/Tornado_Spawn.c:
     .text start:0x021376bc end:0x0213770c
 
 src/__sinit_ov096_0213770c.c:
+    complete
     .init start:0x0213770c end:0x02137894
 
 src/__sinit_ov096_02137894.c:
+    complete
     .init start:0x02137894 end:0x02137900

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -27,6 +27,7 @@ src/func_ov098_02137d80.c:
     .text start:0x02137d80 end:0x02137dbc
 
 src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02137dbc end:0x02137e20
 
 src/_ZN14ArrowSignRight6RenderEv.cpp:
@@ -164,6 +165,7 @@ src/func_ov098_02139850.c:
     .text start:0x02139850 end:0x02139a50
 
 src/_ZN5Crate16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02139a50 end:0x02139aa8
 
 src/_ZN5Crate6RenderEv.cpp:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -350,13 +350,17 @@ src/WaterBomb_Spawn.c:
     .text start:0x0213bf10 end:0x0213bf60
 
 src/__sinit_ov098_0213bf9c.c:
+    complete
     .init start:0x0213bf9c end:0x0213c058
 
 src/__sinit_ov098_0213c058.c:
+    complete
     .init start:0x0213c058 end:0x0213c214
 
 src/__sinit_ov098_0213c214.c:
+    complete
     .init start:0x0213c214 end:0x0213c2b4
 
 src/__sinit_ov098_0213c2b4.c:
+    complete
     .init start:0x0213c2b4 end:0x0213c33c

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -376,6 +376,7 @@ src/_ZN4Door6RenderEv.c:
     .text start:0x02145fe4 end:0x021460dc
 
 src/_ZN4Door8BehaviorEv.cpp:
+    complete
     .text start:0x021460dc end:0x0214612c
 
 src/_ZN4Door13InitResourcesEv.cpp:
@@ -447,6 +448,7 @@ src/_ZN4Fish8BehaviorEv.cpp:
     .text start:0x02146b38 end:0x02146c68
 
 src/_ZN4Fish13InitResourcesEv.cpp:
+    complete
     .text start:0x02146c68 end:0x02146d38
 
 src/Fish_Spawn.cpp:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -106,6 +106,7 @@ src/func_ov100_02142b90.c:
     .text start:0x02142b90 end:0x02142d1c
 
 src/_ZN15RollingIronBall16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02142d1c end:0x02142d5c
 
 src/_ZN15RollingIronBall6RenderEv.cpp:
@@ -484,22 +485,29 @@ src/PathLift_Spawn.cpp:
     .text start:0x02147328 end:0x021473a4
 
 src/__sinit_ov100_021473bc.c:
+    complete
     .init start:0x021473bc end:0x021474e8
 
 src/__sinit_ov100_021474e8.c:
+    complete
     .init start:0x021474e8 end:0x021475a4
 
 src/__sinit_ov100_021475a4.c:
+    complete
     .init start:0x021475a4 end:0x02147698
 
 src/__sinit_ov100_02147698.c:
+    complete
     .init start:0x02147698 end:0x02147a70
 
 src/__sinit_ov100_02147a70.c:
+    complete
     .init start:0x02147a70 end:0x02147bc0
 
 src/__sinit_ov100_02147bc0.c:
+    complete
     .init start:0x02147bc0 end:0x02147d7c
 
 src/__sinit_ov100_02147d7c.c:
+    complete
     .init start:0x02147d7c end:0x02147de8

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -11,6 +11,7 @@ src/_ZN13FortressTowerD0Ev.c:
     .text start:0x02148ac4 end:0x02148b1c
 
 src/_ZN13FortressTower16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02148b1c end:0x02148b80
 
 src/_ZN13FortressTower6RenderEv.cpp:
@@ -165,6 +166,7 @@ src/func_ov102_02149ff0.c:
     .text start:0x02149ff0 end:0x0214a08c
 
 src/_ZN13QuestionBlock16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0214a08c end:0x0214a2ac
 
 src/_ZN13QuestionBlock6RenderEv.cpp:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -427,13 +427,17 @@ src/KoopaShell_Spawn.c:
     .text start:0x0214d6b4 end:0x0214d70c
 
 src/__sinit_ov102_0214d714.c:
+    complete
     .init start:0x0214d714 end:0x0214d908
 
 src/__sinit_ov102_0214d908.c:
+    complete
     .init start:0x0214d908 end:0x0214de70
 
 src/__sinit_ov102_0214de70.c:
+    complete
     .init start:0x0214de70 end:0x0214dfac
 
 src/__sinit_ov102_0214dfac.c:
+    complete
     .init start:0x0214dfac end:0x0214e0a0

--- a/src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -2,7 +2,9 @@
 namespace LVL_Overlay {
 struct ObjSubTable { int pad0; int* p; };
 }
+extern "C" {
 extern int data_02092134;
+}
 void LoadStarCameraObjects(LVL_Overlay::ObjSubTable& t, int a, unsigned int b) {
     data_02092134 = *t.p;
 }

--- a/src/_ZN10BowserTail8BehaviorEv.cpp
+++ b/src/_ZN10BowserTail8BehaviorEv.cpp
@@ -5,7 +5,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BowserTail.h"
 struct Actor { static Actor* FindWithID(unsigned int); };
+extern "C" {
 extern short data_02082214[];
+}
 
 int BowserTail::Behavior()
 {

--- a/src/_ZN10BrickBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN10BrickBlock16CleanupResourcesEv.cpp
@@ -5,9 +5,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BrickBlock.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern char data_ov002_0210d9d8[];
 extern char data_ov002_0210da30[];
 extern char data_ov002_0210da18[];
+}
 
 int BrickBlock::CleanupResources()
 {

--- a/src/_ZN10DonutBlock13InitResourcesEv.cpp
+++ b/src/_ZN10DonutBlock13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "DonutBlock.h"
 typedef int Fix12;
 typedef short s16;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
@@ -13,6 +14,7 @@ extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CL
 extern int func_020393d4(void*, void*);
 extern void* data_ov036_02113d78[];
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 int DonutBlock::InitResources()
 {

--- a/src/_ZN10FlameChomp13InitResourcesEv.cpp
+++ b/src/_ZN10FlameChomp13InitResourcesEv.cpp
@@ -8,20 +8,26 @@ typedef int Fix12;
 struct RG { char pad[0x44]; int f44; char pad2[8]; };
 struct Blk { int w[12]; };
 
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void* self);
+}
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void* self, void* actor, const struct Vector3* v, Fix12 a, int b, unsigned int c, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(
     void* self, void* actor, Fix12 a, int b, void* v, int c);
+extern "C" {
 extern void _ZN13RaycastGroundC1Ev(struct RG* rg);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RG* rg, const struct Vector3* v, void* a);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RG* rg);
 extern void func_ov070_02121310(void* c);
 extern void _ZN13RaycastGroundD1Ev(struct RG* rg);
+}
 
+extern "C" {
 extern struct Blk data_02082128;
+}
 
 int FlameChomp::InitResources()
 {

--- a/src/_ZN10FlameChomp8BehaviorEv.cpp
+++ b/src/_ZN10FlameChomp8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FlameChomp.h"
+extern "C" {
 extern void func_ov070_02121310(char* c);
+}
 
 int FlameChomp::Behavior()
 {

--- a/src/_ZN10HootTheOwl13InitResourcesEv.cpp
+++ b/src/_ZN10HootTheOwl13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "HootTheOwl.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN11ShadowModel12InitCylinderEv(void*);
@@ -16,6 +17,7 @@ extern void _ZN9ActorBase18MarkForDestructionEv(void*);
 extern void* data_ov094_02136b40;
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
+}
 #define LA(p) ((int*)(unsigned)(((long long)(unsigned)(unsigned)(p))))
 
 int HootTheOwl::InitResources()

--- a/src/_ZN10KingBobOmb13InitResourcesEv.cpp
+++ b/src/_ZN10KingBobOmb13InitResourcesEv.cpp
@@ -10,6 +10,7 @@ typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
 
+extern "C" {
 extern SharedFilePtr data_ov078_02126f38;
 extern SharedFilePtr data_ov078_02126f00;
 extern SharedFilePtr data_ov078_02126f20;
@@ -25,7 +26,9 @@ extern SharedFilePtr data_ov078_02126f28;
 extern SharedFilePtr data_ov078_02126ef8;
 extern int data_0209e650;
 extern PMF data_ov078_0212710c;
+}
 
+extern "C" {
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
@@ -35,6 +38,7 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* sel
 extern unsigned char _ZN5Actor9TrackStarEjj(void* self, unsigned int a, unsigned int b);
 extern int RandomIntInternal(int* seed);
 extern void KingBobOmb_SetState(void* c, PMF* p);
+}
 
 int KingBobOmb::InitResources()
 {

--- a/src/_ZN10KingBobOmb6RenderEv.cpp
+++ b/src/_ZN10KingBobOmb6RenderEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "KingBobOmb.h"
+extern "C" {
 extern int _ZN5Model6RenderEPK7Vector3(void *m, void *v);
+}
 
 int KingBobOmb::Render()
 {

--- a/src/_ZN10LavaBubble13InitResourcesEv.cpp
+++ b/src/_ZN10LavaBubble13InitResourcesEv.cpp
@@ -2,12 +2,14 @@
 // @symbol _ZN10LavaBubble13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "LavaBubble.h"
+extern "C" {
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(char* thiz, char* actor, int b, int d, unsigned int e, unsigned int f);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* thiz, char* actor, int b, int d, void* v, int f);
 extern void _ZN12WithMeshClsn13SetLimMovFlagEv(char* thiz);
 extern void func_ov064_021187ec(char* c, void* p);
 extern char data_ov064_0211c7c8[];
 extern char data_ov064_0211c7b8[];
+}
 
 int LavaBubble::InitResources()
 {

--- a/src/_ZN10MrBlizzard13InitResourcesEv.cpp
+++ b/src/_ZN10MrBlizzard13InitResourcesEv.cpp
@@ -9,6 +9,7 @@
 #include "MrBlizzard.h"
 struct Vec3 { int x, y, z; };
 
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -17,13 +18,17 @@ extern int _ZN5Actor18GetBitInDeathTableEv(void *self);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const void *v, const void *v16, int e, int f);
 extern void _ZN7PathPtrC1Ev(void *self);
 extern void _ZN7PathPtr6FromIDEj(void *self, u32 id);
+}
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void *self, void *actor, const void *v, int d, int e, u32 f, u32 g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(
     void *self, void *actor, int b, int c, void *v16, int e);
+extern "C" {
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, void *v, u32 idx);
 extern void func_ov081_02125488(void *c, void *p);
+}
 
+extern "C" {
 extern void *data_ov081_02128d90;
 extern void *data_ov081_02128d98;
 extern void *data_ov081_02128d88;
@@ -31,6 +36,7 @@ extern void *data_ov081_02128da0;
 extern struct Vec3 data_ov081_02128998;
 extern void *data_ov081_02128e54;
 extern void *data_ov081_02128e84;
+}
 
 int MrBlizzard::InitResources()
 {

--- a/src/_ZN10MrBlizzard6RenderEv.cpp
+++ b/src/_ZN10MrBlizzard6RenderEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_Model.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MrBlizzard.h"
+extern "C" {
 extern void _ZN5Model6RenderEPK7Vector3(void*,void*);
+}
 
 int MrBlizzard::Render()
 {

--- a/src/_ZN10PyramidTop16CleanupResourcesEv.cpp
+++ b/src/_ZN10PyramidTop16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "PyramidTop.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov024_02113968[];
+}
 
 int PyramidTop::CleanupResources()
 {

--- a/src/_ZN10PyramidTop8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTop8BehaviorEv.cpp
@@ -5,8 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidTop.h"
+extern "C" {
 extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void* actor, void* pt);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int bank, void* pos);
+}
 
 int PyramidTop::Behavior()
 {

--- a/src/_ZN10ShutterBob13InitResourcesEv.cpp
+++ b/src/_ZN10ShutterBob13InitResourcesEv.cpp
@@ -8,8 +8,10 @@ public:
     void Enable(Actor *a);
 };
 
+extern "C" {
 extern int func_ov002_020bad10(void *c, void **f);
 extern int data_ov014_021145c4;
+}
 
 int ShutterBob::InitResources()
 {

--- a/src/_ZN10ShutterHmc13InitResourcesEv.cpp
+++ b/src/_ZN10ShutterHmc13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ShutterHmc.h"
+extern "C" {
 extern int func_ov002_020bad10(void *self, void *data);
+}
 
 int ShutterHmc::InitResources()
 {

--- a/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
+++ b/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
@@ -4,8 +4,10 @@
 #include "SlidingIce.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char func_ov030_02113be8[];
 extern char data_ov027_02113be0[];
+}
 
 int SlidingIce::CleanupResources()
 {

--- a/src/_ZN10StarMarker13InitResourcesEv.cpp
+++ b/src/_ZN10StarMarker13InitResourcesEv.cpp
@@ -8,6 +8,7 @@
 struct Vec3 { s32 x, y, z; };
 struct RaycastGround { char pad[0x50]; };
 
+extern "C" {
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, const void *v, int d, int e, u32 f, u32 g);
 extern void _ZN13RaycastGroundC1Ev(void *self);
 extern void _ZN4BgCh19StartDetectingWaterEv(void *self);
@@ -21,11 +22,14 @@ extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern int IsStarCollectedInCurLevel(u8 x);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
 extern int _ZN5Actor18GetBitInDeathTableEv(void *self);
+}
 
+extern "C" {
 extern char data_ov002_0210d9a8;
 extern char data_ov002_0211092c;
 extern u8 data_0209f2d8;
 extern s8 data_0209f2f8;
+}
 
 int StarMarker::InitResources()
 {

--- a/src/_ZN10StarMarker16CleanupResourcesEv.cpp
+++ b/src/_ZN10StarMarker16CleanupResourcesEv.cpp
@@ -5,8 +5,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "StarMarker.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern char data_ov002_0211092c;
 extern char data_ov002_0210d9a8;
+}
 
 int StarMarker::CleanupResources()
 {

--- a/src/_ZN10StarMarker16OnPendingDestroyEv.cpp
+++ b/src/_ZN10StarMarker16OnPendingDestroyEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "StarMarker.h"
+extern "C" {
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+}
 
 void StarMarker::OnPendingDestroy()
 {

--- a/src/_ZN10StarSwitch8BehaviorEv.cpp
+++ b/src/_ZN10StarSwitch8BehaviorEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "StarSwitch.h"
+extern "C" {
 extern unsigned char IsAreaShowing(int idx);
 extern void func_ov002_020ba01c(char *c, int mask, int b, int base, int target);
 extern void func_ov002_020ba4d8(char *c, int i);
@@ -11,8 +12,11 @@ extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(char *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
 extern int _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int id, int vol);
+}
 
+extern "C" {
 extern int data_0209b454;
+}
 
 int StarSwitch::Behavior()
 {

--- a/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
+++ b/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "CannonHatch.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int CannonHatch::CleanupResources()
 {

--- a/src/_ZN11CannonHatch6RenderEv.cpp
+++ b/src/_ZN11CannonHatch6RenderEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN11CannonHatch6RenderEv
 /* recovered: named members + shared header, real C++ method */
 #include "CannonHatch.h"
+extern "C" {
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
+}
 struct Sub {
   virtual void v00(); virtual void v04(); virtual void v08(); virtual void v0c();
   virtual void v10(); virtual void m14(int arg);

--- a/src/_ZN11CastleWater16CleanupResourcesEv.cpp
+++ b/src/_ZN11CastleWater16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "CastleWater.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int CastleWater::CleanupResources()
 {

--- a/src/_ZN11CastleWater8BehaviorEv.cpp
+++ b/src/_ZN11CastleWater8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "CastleWater.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 extern unsigned char data_0209f2d8;
+}
 
 int CastleWater::Behavior()
 {

--- a/src/_ZN11ChiefChilly13InitResourcesEv.cpp
+++ b/src/_ZN11ChiefChilly13InitResourcesEv.cpp
@@ -10,6 +10,7 @@ typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
 
+extern "C" {
 extern SharedFilePtr data_ov073_02123280;
 extern SharedFilePtr data_ov073_021232a0;
 extern SharedFilePtr data_ov073_02123288;
@@ -20,7 +21,9 @@ extern SharedFilePtr data_ov073_021232b8;
 extern SharedFilePtr data_ov002_0210da30;
 extern SharedFilePtr data_ov073_02123298;
 extern PMF data_ov073_02123330;
+}
 
+extern "C" {
 extern void LoadKeyModels(int idx);
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
@@ -30,6 +33,7 @@ extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern short _ZN5Actor18HorzAngleToCPlayerEv(void* self);
 extern int ChiefChilly_ChangeState(void* c, PMF* p);
+}
 
 int ChiefChilly::InitResources()
 {

--- a/src/_ZN11CrazedCrate8BehaviorEv.cpp
+++ b/src/_ZN11CrazedCrate8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CrazedCrate.h"
+extern "C" {
 extern int func_ov080_02124c3c(char *c);
+}
 
 int CrazedCrate::Behavior()
 {

--- a/src/_ZN11PyramidLift13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidLift13InitResourcesEv.cpp
@@ -11,6 +11,7 @@ typedef struct BMD_File BMD_File;
 typedef struct KCL_File KCL_File;
 typedef struct Matrix4x3 Matrix4x3;
 typedef struct CLPS_Block CLPS_Block;
+extern "C" {
 extern SharedFilePtr data_ov025_02113ae0;
 extern SharedFilePtr data_ov002_0210d9f0;
 extern SharedFilePtr data_ov025_02113ad8;
@@ -23,6 +24,7 @@ extern KCL_File* _ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, KCL_File* k, Matrix4x3* m, Fix12 f, short s, CLPS_Block* b);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
+}
 
 int PyramidLift::InitResources()
 {

--- a/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
+++ b/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "PyramidStep.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int PyramidStep::CleanupResources()
 {

--- a/src/_ZN11PyramidStep8BehaviorEv.cpp
+++ b/src/_ZN11PyramidStep8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidStep.h"
+extern "C" {
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* p, int a, int b);
+}
 
 int PyramidStep::Behavior()
 {

--- a/src/_ZN12EnemySpawner13InitResourcesEv.cpp
+++ b/src/_ZN12EnemySpawner13InitResourcesEv.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN12EnemySpawner13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySpawner.h"
+extern "C" {
 extern unsigned int _ZN5Event6GetBitEj(unsigned int bit);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int data_ov002_0210d9e0;
+}
 
 int EnemySpawner::InitResources()
 {

--- a/src/_ZN12FortressWall13InitResourcesEv.cpp
+++ b/src/_ZN12FortressWall13InitResourcesEv.cpp
@@ -3,16 +3,20 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FortressWall.h"
 typedef int Fix12;
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, void *, int, int);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *self, void *kcl, void *mtx, Fix12 f, short s, void *blk);
+}
 struct E12 { void *p; int pad[2]; };
+extern "C" {
 extern struct E12 data_ov079_02128058[];
 extern struct E12 data_ov079_0212805c[];
 extern struct E12 data_ov079_02128060[];
+}
 
 int FortressWall::InitResources()
 {

--- a/src/_ZN12FortressWall16CleanupResourcesEv.cpp
+++ b/src/_ZN12FortressWall16CleanupResourcesEv.cpp
@@ -6,8 +6,10 @@
 #include "FortressWall.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char data_ov079_02128058[];
 extern char data_ov079_0212805c[];
+}
 
 int FortressWall::CleanupResources()
 {

--- a/src/_ZN12HauntedChair13InitResourcesEv.cpp
+++ b/src/_ZN12HauntedChair13InitResourcesEv.cpp
@@ -6,13 +6,17 @@
 /* recovered: named members + shared header, real C++ method */
 #include "HauntedChair.h"
 struct Actor; struct Vector3; struct Vector3_16; struct BMD_File;
+extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(char* self);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* self, struct Actor* a, int r, int h, struct Vector3_16* rot, int f);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, struct Actor* a, struct Vector3* pos, int r, int h, u32 f1, u32 f2);
+}
 struct M48 { int w[12]; };
+extern "C" {
 extern struct M48 data_02082128;
+}
 
 int HauntedChair::InitResources()
 {

--- a/src/_ZN12HauntedChair8BehaviorEv.cpp
+++ b/src/_ZN12HauntedChair8BehaviorEv.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "HauntedChair.h"
+extern "C" {
 extern void func_0200f760(char* a, char* b);
 extern void _ZN12CylinderClsn5ClearEv(char* c);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(char* c, char* v);
 extern void _ZN12CylinderClsn6UpdateEv(char* c);
+}
 
 int HauntedChair::Behavior()
 {

--- a/src/_ZN12PiranhaPlant6RenderEv.cpp
+++ b/src/_ZN12PiranhaPlant6RenderEv.cpp
@@ -11,7 +11,9 @@ struct Obj {
     virtual void m5(void* p);
 };
 struct G2 { int w[2]; };
+extern "C" {
 extern G2 data_ov084_02130df4;
+}
 
 int PiranhaPlant::Render()
 {

--- a/src/_ZN12SwitchPillar16CleanupResourcesEv.cpp
+++ b/src/_ZN12SwitchPillar16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "SwitchPillar.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov012_021124d0[];
+}
 
 int SwitchPillar::CleanupResources()
 {

--- a/src/_ZN12SwitchPillar8BehaviorEv.cpp
+++ b/src/_ZN12SwitchPillar8BehaviorEv.cpp
@@ -2,6 +2,7 @@
 // @symbol _ZN12SwitchPillar8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "SwitchPillar.h"
+extern "C" {
 extern void _ZN5Sound15PlaySecretSoundEP5ActorPt(void* a, unsigned short* p);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int d, void* v, unsigned int e);
 extern void _ZN7Minimap19UpdateLevelSpecificEv(void);
@@ -10,6 +11,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
 extern void _ZN9Animation7AdvanceEv(void* thiz);
 extern int data_0209caa0[];
 extern int data_0209f32c;
+}
 
 int SwitchPillar::Behavior()
 {

--- a/src/_ZN12WorkElevator16CleanupResourcesEv.cpp
+++ b/src/_ZN12WorkElevator16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "WorkElevator.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov021_021149b8[];
+}
 
 int WorkElevator::CleanupResources()
 {

--- a/src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp
@@ -6,8 +6,10 @@
 #include "BigBrickBlock.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char data_ov002_02108ab0[];
 extern char data_ov002_02108ab4[];
+}
 
 int BigBrickBlock::CleanupResources()
 {

--- a/src/_ZN13FortressTower16CleanupResourcesEv.cpp
+++ b/src/_ZN13FortressTower16CleanupResourcesEv.cpp
@@ -6,8 +6,10 @@
 #include "FortressTower.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char data_ov102_0214e188[];
 extern char data_ov102_0214e18c[];
+}
 
 int FortressTower::CleanupResources()
 {

--- a/src/_ZN13HeapAllocator6RemoveEv.cpp
+++ b/src/_ZN13HeapAllocator6RemoveEv.cpp
@@ -15,8 +15,10 @@ struct NestedHeapIteratorT {
     unsigned short linkOffset;
 };
 
+extern "C" {
 extern NestedHeapIteratorT* _ZN18NestedHeapIterator10FindNestedEPv(HeapAllocator* node);
 extern void _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(NestedHeapIteratorT* iter, HeapAllocator* node);
+}
 
 void HeapAllocator::Remove()
 {

--- a/src/_ZN13KoopaTheQuick13InitResourcesEv.cpp
+++ b/src/_ZN13KoopaTheQuick13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 #include "KoopaTheQuick.h"
 typedef short s16;
 
+extern "C" {
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
@@ -16,7 +17,9 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *sel
 extern void _ZN7PathPtr6FromIDEj(void *self, unsigned int id);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, void *v, unsigned int idx);
 extern unsigned char _ZN5Actor9TrackStarEjj(void *self, unsigned int a, unsigned int b);
+}
 
+extern "C" {
 extern char data_ov062_0211e00c[];
 extern char data_ov062_0211e014[];
 extern char data_ov062_0211e024[];
@@ -25,6 +28,7 @@ extern char data_ov062_0211e034[];
 extern char data_ov062_0211e03c[];
 extern char data_ov062_0211e02c[];
 extern char data_ov062_0211e004[];
+}
 
 int KoopaTheQuick::InitResources()
 {

--- a/src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp
+++ b/src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "KoopaTheQuick.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *);
 extern struct SharedFilePtr data_ov062_0211e00c;
 extern struct SharedFilePtr data_ov062_0211e014;
@@ -14,6 +15,7 @@ extern struct SharedFilePtr data_ov062_0211e034;
 extern struct SharedFilePtr data_ov062_0211e03c;
 extern struct SharedFilePtr data_ov062_0211e02c;
 extern struct SharedFilePtr data_ov062_0211e004;
+}
 
 int KoopaTheQuick::CleanupResources()
 {

--- a/src/_ZN13PeachPainting13InitResourcesEv.cpp
+++ b/src/_ZN13PeachPainting13InitResourcesEv.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PeachPainting.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int a, int b);
+}
 
 int PeachPainting::InitResources()
 {

--- a/src/_ZN13PoleBillboard16CleanupResourcesEv.cpp
+++ b/src/_ZN13PoleBillboard16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "PoleBillboard.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int PoleBillboard::CleanupResources()
 {

--- a/src/_ZN13QuestionBlock8BehaviorEv.cpp
+++ b/src/_ZN13QuestionBlock8BehaviorEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionBlock.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
 extern void func_020393a4(int* p, int v);
 extern void func_02039394(int* p, int v);
@@ -13,6 +14,7 @@ extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern int data_0209caa0[];
 extern unsigned char data_0209f2d8;
 extern signed char data_0209f2f8;
+}
 
 int QuestionBlock::Behavior()
 {

--- a/src/_ZN13RacingPenguin8BehaviorEv.cpp
+++ b/src/_ZN13RacingPenguin8BehaviorEv.cpp
@@ -4,9 +4,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RacingPenguin.h"
+extern "C" {
 extern void _ZN9Animation7AdvanceEv(char *c);
 extern void _ZN12CylinderClsn5ClearEv(char *c);
 extern void _ZN12CylinderClsn6UpdateEv(char *c);
+}
 
 int RacingPenguin::Behavior()
 {

--- a/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
+++ b/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
@@ -7,6 +7,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RollingLogTtm.h"
 #define false 0
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int a, int b);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
@@ -18,10 +19,13 @@ extern char *_ZN5Actor13ClosestPlayerEv(void *self);
 extern char *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 param, void *pos, void *rot, int a, int b);
 extern void func_ov030_021141a8(void *self, int a);
 extern void func_ov030_02112094(void *self);
+}
 
+extern "C" {
 extern char data_ov002_0210da40;
 extern char data_ov002_0210d9a0;
 extern char data_ov002_0210d9c0;
+}
 
 int RollingLogTtm::InitResources()
 {

--- a/src/_ZN13SnowmanBreath6RenderEv.cpp
+++ b/src/_ZN13SnowmanBreath6RenderEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SnowmanBreath.h"
+extern "C" {
 extern unsigned char data_0209f2d8[];
+}
 
 int SnowmanBreath::Render()
 {

--- a/src/_ZN13SnowmanBreath8BehaviorEv.cpp
+++ b/src/_ZN13SnowmanBreath8BehaviorEv.cpp
@@ -6,15 +6,21 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SnowmanBreath.h"
+extern "C" {
 extern u8 data_0209f2d8[];
+}
 
+extern "C" {
 extern int _ZN6Player9StartTalkER9ActorBaseb(void *self, void *actor, int b);
+}
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *self, void *actor,
                                                             unsigned int msg,
                                                             const Vector3 *pos,
                                                             unsigned int a,
                                                             unsigned int b);
+extern "C" {
 extern int _ZN6Player12GetTalkStateEv(void *self);
+}
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(int handle, unsigned int a,
                                              unsigned int b, void *pos,
                                              unsigned int c);

--- a/src/_ZN13TTC_MovingBar13InitResourcesEv.cpp
+++ b/src/_ZN13TTC_MovingBar13InitResourcesEv.cpp
@@ -4,20 +4,24 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TTC_MovingBar.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmd, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *fp);
+}
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *self, void *kcl, void *mtx, int fix, short s, void *clps);
+extern "C" {
 extern void func_020393d4(int *p, int v);
 extern void _ZN13RaycastGroundC1Ev(void *self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, void *pos, void *actor);
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
 extern void _ZN13RaycastGroundD1Ev(void *self);
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+}
 
 
 struct Vec3 { int x, y, z; };

--- a/src/_ZN13TreasureChest8BehaviorEv.cpp
+++ b/src/_ZN13TreasureChest8BehaviorEv.cpp
@@ -5,8 +5,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TreasureChest.h"
 struct CylinderClsn { int dummy; };
+extern "C" {
 extern void _ZN12CylinderClsn5ClearEv(struct CylinderClsn *t);
 extern void _ZN12CylinderClsn6UpdateEv(struct CylinderClsn *t);
+}
 
 int TreasureChest::Behavior()
 {

--- a/src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp
+++ b/src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp
@@ -10,6 +10,7 @@
  * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  * natural signed /2 spelling; mwcc synthesizes add/lsr#31/asr#1 itself and
  * self-schedules the byte store into the ROM slot */
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(int sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
@@ -20,6 +21,7 @@ extern void func_020393c4(void *p, void *v);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern int data_ov095_02136f68[];
 extern int data_ov095_02136f74[];
+}
 
 int UpDownLiftBbh::InitResources()
 {

--- a/src/_ZN13WaterfallMist13InitResourcesEv.cpp
+++ b/src/_ZN13WaterfallMist13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "WaterfallMist.h"
+extern "C" {
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *sfp);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *bmd, int a, int b);
@@ -15,7 +16,9 @@ extern int _ZN5Actor13ClosestPlayerEv(void *thiz);
 extern void func_ov002_020b7f2c(void *c, void *p);
 extern void func_ov002_020b7f7c(void *thiz);
 extern void func_ov001_020ab228(void *c, void *a1, int idx, int a3, int a5);
+}
 
+extern "C" {
 extern char data_ov002_0210de50;
 extern char data_ov002_0210de60;
 extern char data_ov002_0210de48;
@@ -30,6 +33,7 @@ extern char data_ov002_0210de18;
 extern char data_ov002_0210de30;
 extern char data_ov002_0210de38;
 extern char data_ov002_0210df54;
+}
 
 int WaterfallMist::InitResources()
 {

--- a/src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp
+++ b/src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "ArrowSignRight.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char data_ov098_0213c380[];
+}
 
 int ArrowSignRight::CleanupResources()
 {

--- a/src/_ZN14BlueCoinSwitch16CleanupResourcesEv.cpp
+++ b/src/_ZN14BlueCoinSwitch16CleanupResourcesEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN14BlueCoinSwitch16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "BlueCoinSwitch.h"
+extern "C" {
 extern int _ZN5Event8ClearBitEj(unsigned int bit);
+}
 
 int BlueCoinSwitch::CleanupResources()
 {

--- a/src/_ZN14BlueCoinSwitch8BehaviorEv.cpp
+++ b/src/_ZN14BlueCoinSwitch8BehaviorEv.cpp
@@ -3,11 +3,13 @@
 // @symbol _ZN14BlueCoinSwitch8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "BlueCoinSwitch.h"
+extern "C" {
 extern void _ZN5Event8ClearBitEj(u32 bit);
 extern void _ZN5Event6SetBitEj(u32 bit);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* p);
 extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
+}
 
 int BlueCoinSwitch::Behavior()
 {

--- a/src/_ZN14EnemySwitchTag13InitResourcesEv.cpp
+++ b/src/_ZN14EnemySwitchTag13InitResourcesEv.cpp
@@ -5,12 +5,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySwitchTag.h"
+extern "C" {
 extern int IsStarCollectedInLevel(s8 levelID, int starID);
 extern s8 data_0209f2f8;
 extern u8 data_0209f220;
 extern u8 data_0209f2d8;
 extern int data_0209caa0[];
 extern int data_0209fc48;
+}
 
 int EnemySwitchTag::InitResources()
 {

--- a/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
+++ b/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
@@ -6,8 +6,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySwitchTag.h"
+extern "C" {
 extern u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, void *v, u32 e);
 extern void *data_0209f318;
+}
 
 int EnemySwitchTag::Behavior()
 {

--- a/src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp
+++ b/src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "KnockDownPlank.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char data_ov015_02114534[];
+}
 
 int KnockDownPlank::CleanupResources()
 {

--- a/src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "MovingBarSmall.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int MovingBarSmall::CleanupResources()
 {

--- a/src/_ZN14MrI_Projectile13InitResourcesEv.cpp
+++ b/src/_ZN14MrI_Projectile13InitResourcesEv.cpp
@@ -3,13 +3,17 @@
 /* recovered: named members + shared header, real C++ method */
 #include "MrI_Projectile.h"
 typedef int Fix12;
+extern "C" {
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern int _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, void *v, Fix12 r, int t1, unsigned int u1, unsigned int u2);
 extern int _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *actor, Fix12 a, int b, void *v, int c);
 extern void func_ov071_02121c6c(char *c);
 extern void *data_ov071_021230b8;
+}
 struct M48 { int w[12]; };
+extern "C" {
 extern struct M48 data_02082128;
+}
 
 int MrI_Projectile::InitResources()
 {

--- a/src/_ZN14QuestionSwitch13InitResourcesEv.cpp
+++ b/src/_ZN14QuestionSwitch13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionSwitch.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int b, int c);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
@@ -13,12 +14,15 @@ extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *self, void *f, void *m, int fix, short sh, void *b);
 extern void func_020393c4(int *p, int v);
 extern void _ZN9Animation7AdvanceEv(void *self);
+}
 
+extern "C" {
 extern int data_ov002_0210dd60;
 extern int data_ov002_0210dd68;
 extern int data_ov002_0210dd58;
 extern int data_ov002_0210dd50;
 extern int data_0209caa0[];
+}
 
 int QuestionSwitch::InitResources()
 {

--- a/src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp
+++ b/src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp
@@ -6,10 +6,12 @@
 #include "QuestionSwitch.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov002_0210dd60[];
 extern int data_ov002_0210dd68[];
 extern int data_ov002_0210dd58[];
 extern int data_ov002_0210dd50[];
+}
 
 int QuestionSwitch::CleanupResources()
 {

--- a/src/_ZN14SquarePathLift8BehaviorEv.cpp
+++ b/src/_ZN14SquarePathLift8BehaviorEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SquarePathLift.h"
 typedef int Fix12;
+extern "C" {
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, void *out, unsigned idx);
 extern void Vec3_Sub(void *out, void *a, void *b);
 extern int LenVec3(void *v);
@@ -14,6 +15,7 @@ extern void SubVec3(void *a, void *b, void *c);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *p);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *p, Fix12 a, int b);
+}
 struct V3 { int x, y, z; };
 
 int SquarePathLift::Behavior()

--- a/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
+++ b/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "TtcMovingCubeA.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int TtcMovingCubeA::CleanupResources()
 {

--- a/src/_ZN14UnknownVsEntry13InitResourcesEv.cpp
+++ b/src/_ZN14UnknownVsEntry13InitResourcesEv.cpp
@@ -6,13 +6,16 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "UnknownVsEntry.h"
+extern "C" {
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void* f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* bca, int a, int fx, unsigned int f);
 extern void func_ov075_021152d4(char* self);
+}
 
+extern "C" {
 extern char data_ov075_0211d3fc;
 extern char data_ov075_0211d3bc;
 extern char data_ov075_0211d3e4;
@@ -36,6 +39,7 @@ extern char data_ov075_0211d38c;
 extern char data_ov075_0211d3dc;
 extern char data_ov075_0211d40c;
 extern char data_020a0e68;
+}
 
 struct M48 { int w[12]; };
 

--- a/src/_ZN14UnknownVsEntry16CleanupResourcesEv.cpp
+++ b/src/_ZN14UnknownVsEntry16CleanupResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "UnknownVsEntry.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern char data_ov075_0211d404[];
 extern char data_ov075_0211d3c4[];
 extern char data_ov075_0211d414[];
@@ -27,6 +28,7 @@ extern char data_ov075_0211d40c[];
 extern char data_ov075_0211d3fc[];
 extern char data_ov075_0211d3bc[];
 extern char data_ov075_0211d3e4[];
+}
 
 int UnknownVsEntry::CleanupResources()
 {

--- a/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
+++ b/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
@@ -5,9 +5,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "UnknownVsEntry.h"
+extern "C" {
 extern void func_ov075_021152d4(void* self);
 extern int _ZN9Animation7AdvanceEv(void* a);
 extern u8 data_0209fc5c;
+}
 
 int UnknownVsEntry::Behavior()
 {

--- a/src/_ZN15BookShotSpawner13InitResourcesEv.cpp
+++ b/src/_ZN15BookShotSpawner13InitResourcesEv.cpp
@@ -4,9 +4,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BookShotSpawner.h"
+extern "C" {
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void LoadBlueCoinModel(void *);
 extern int G0[];
+}
 
 int BookShotSpawner::InitResources()
 {

--- a/src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp
+++ b/src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp
@@ -7,9 +7,11 @@ public:
     void Release();
 };
 
+extern "C" {
 extern void UnloadBlueCoinModel(char *c);
 extern int data_ov020_02114aa0;
 extern int data_ov020_02114ab8;
+}
 
 int BookShotSpawner::CleanupResources()
 {

--- a/src/_ZN15ChainChompFence13InitResourcesEv.cpp
+++ b/src/_ZN15ChainChompFence13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ChainChompFence.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
@@ -12,6 +13,7 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
 extern int data_ov021_021149b8[];
 extern int data_ov022_02114558[];
+}
 
 int ChainChompFence::InitResources()
 {

--- a/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
+++ b/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "ChainChompFence.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int ChainChompFence::CleanupResources()
 {

--- a/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "FireSeaElevator.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov045_021131b0[];
+}
 
 int FireSeaElevator::CleanupResources()
 {

--- a/src/_ZN15FireSeaElevator8BehaviorEv.cpp
+++ b/src/_ZN15FireSeaElevator8BehaviorEv.cpp
@@ -3,12 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FireSeaElevator.h"
 typedef int Fix12;
+extern "C" {
 extern void _ZN12CylinderClsn5ClearEv(void *self);
 extern void _ZN12CylinderClsn6UpdateEv(void *self);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *self, Fix12 a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern short data_02082214[];
+}
 
 int FireSeaElevator::Behavior()
 {

--- a/src/_ZN15IceSlideManager13InitResourcesEv.cpp
+++ b/src/_ZN15IceSlideManager13InitResourcesEv.cpp
@@ -3,7 +3,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "IceSlideManager.h"
 struct S3 { int w0; int w1; int w2; };
+extern "C" {
 extern struct S3 data_ov019_021135d8;
+}
 
 int IceSlideManager::InitResources()
 {

--- a/src/_ZN15IceSlideManager8BehaviorEv.cpp
+++ b/src/_ZN15IceSlideManager8BehaviorEv.cpp
@@ -2,10 +2,12 @@
 // @symbol _ZN15IceSlideManager8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "IceSlideManager.h"
+extern "C" {
 extern int _ZN5Actor13DistToCPlayerEv(void*);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned,unsigned,unsigned,int,int);
 extern int DecIfAbove0_Short(void*);
 extern int _ZN5Actor24KillAndTrackInDeathTableEv(void*);
+}
 
 int IceSlideManager::Behavior()
 {

--- a/src/_ZN15InvisibleSecret8BehaviorEv.cpp
+++ b/src/_ZN15InvisibleSecret8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 #include "InvisibleSecret.h"
 struct V3 { int x, y, z; };
 
+extern "C" {
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void _ZN9ActorBase18MarkForDestructionEv(char *self);
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
+}
 
 int InvisibleSecret::Behavior()
 {

--- a/src/_ZN15RollingIronBall13InitResourcesEv.cpp
+++ b/src/_ZN15RollingIronBall13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RollingIronBall.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -15,10 +16,13 @@ extern int Vec3_Equal(void *a, void *b);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *actor, int a, int b, unsigned int c, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *actor, int a, int b, void *v0, int v1);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+}
 
+extern "C" {
 extern char data_ov100_02148668;
 extern int data_02092138;
 extern signed char data_0209f2f8;
+}
 
 int RollingIronBall::InitResources()
 {

--- a/src/_ZN15RollingIronBall16CleanupResourcesEv.cpp
+++ b/src/_ZN15RollingIronBall16CleanupResourcesEv.cpp
@@ -3,7 +3,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RollingIronBall.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern char data_ov100_02148668;
+}
 
 int RollingIronBall::CleanupResources()
 {

--- a/src/_ZN15RollingIronBall8BehaviorEv.cpp
+++ b/src/_ZN15RollingIronBall8BehaviorEv.cpp
@@ -7,7 +7,9 @@ struct VtEntry {
     int field0;
     int field1;
 };
+extern "C" {
 extern struct VtEntry data_ov100_0214867c[];
+}
 
 int RollingIronBall::Behavior()
 {

--- a/src/_ZN15RotatingFirebar13InitResourcesEv.cpp
+++ b/src/_ZN15RotatingFirebar13InitResourcesEv.cpp
@@ -2,9 +2,12 @@
 // @symbol _ZN15RotatingFirebar13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingFirebar.h"
+extern "C" {
 extern void* data_ov064_0211adbc[];
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
 extern void _ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj(void* thiz, void* v, int f1, int f2, unsigned int a, unsigned int b);
@@ -13,6 +16,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void func_020393d4(int* p, int v);
+}
 
 int RotatingFirebar::InitResources()
 {

--- a/src/_ZN15RotatingFirebar8BehaviorEv.cpp
+++ b/src/_ZN15RotatingFirebar8BehaviorEv.cpp
@@ -13,6 +13,7 @@
 #define LI(v) ((int)(((long long)(v))))
 
 
+extern "C" {
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* c);
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(void* a, void* m, void* b);
@@ -23,8 +24,11 @@ extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* c, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
+}
 
+extern "C" {
 extern int data_020a0e68[];
+}
 
 typedef struct Firebar {
     char pad0[0x320];

--- a/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
@@ -7,8 +7,10 @@
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
 struct E { void* p; char pad[8]; };
+extern "C" {
 extern struct E data_ov065_0211cfd0[];
 extern struct E data_ov065_0211cfd4[];
+}
 
 int TtcRotatingCube::CleanupResources()
 {

--- a/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
@@ -5,14 +5,18 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
+extern "C" {
 extern u16 DecIfAbove0_Short(u16 *p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void *v);
 extern int _Z14ApproachLinearRsss(s16 *val, int target, int step);
 extern int RandomIntInternal(int *seed);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
+}
 
+extern "C" {
 extern u8 data_0209f2c0;
 extern int data_0209e650;
+}
 
 int TtcRotatingCube::Behavior()
 {

--- a/src/_ZN15TtcRotatingGear13InitResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingGear13InitResourcesEv.cpp
@@ -5,17 +5,21 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingGear.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
+}
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void*, void*, void*, Fix12, short, void*);
 
+extern "C" {
 extern unsigned char data_0209f2c0[];
 extern char data_ov065_0211c0d4[];
 extern char data_ov065_0211c0d0[];
+}
 
 int TtcRotatingGear::InitResources()
 {

--- a/src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "TtcRotatingGear.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int TtcRotatingGear::CleanupResources()
 {

--- a/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
@@ -3,17 +3,21 @@
 // @symbol _ZN15TtcRotatingGear8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingGear.h"
+extern "C" {
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern u16 DecIfAbove0_Short(void *p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *cc);
 extern int RandomIntInternal(int *seed);
+}
 
+extern "C" {
 extern u8 data_0209f2c0;
 extern int data_0209e650;
 extern u8 data_ov065_0211c0d4[];
 extern u8 data_ov065_0211c0d0[];
+}
 
 int TtcRotatingGear::Behavior()
 {

--- a/src/_ZN16RotatingCogSmall13InitResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall13InitResourcesEv.cpp
@@ -5,13 +5,16 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingCogSmall.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *sfp);
+}
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *mc, void *kcl, void *mtx, int fix, short s, void *clps);
+extern "C" {
 extern void func_020393d4(void *p, void *v);
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern int data_ov035_02112c78[];
@@ -20,6 +23,7 @@ extern int data_ov035_02112c60[];
 extern u8 data_0209f2c0[];
 extern s16 data_ov035_02111ef4[][4];
 extern s16 data_ov035_02111ef0[];
+}
 
 int RotatingCogSmall::InitResources()
 {

--- a/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
+++ b/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BigMovingIceBlock.h"
 typedef int Fix12;
+extern "C" {
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, void *out, unsigned idx);
 extern void Vec3_Sub(void *out, void *a, void *b);
 extern int LenVec3(void *v);
@@ -14,6 +15,7 @@ extern void SubVec3(void *a, void *b, void *c);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *p);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *p, Fix12 a, int b);
+}
 
 struct V3 { int x, y, z; };
 

--- a/src/_ZN17MgBounceAndPounce21AfterCleanupResourcesEj.cpp
+++ b/src/_ZN17MgBounceAndPounce21AfterCleanupResourcesEj.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MgBounceAndPounce.h"
+extern "C" {
 extern void Ov004_Deallocate(void* x);
 extern void func_ov004_020b0840(void* a, int b);
 extern void* data_ov006_02141a48;
 extern unsigned char data_0209f5f8;
+}
 
 void MgBounceAndPounce::AfterCleanupResources(unsigned int b_)
 {

--- a/src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp
+++ b/src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "RotatingClockHand.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int RotatingClockHand::CleanupResources()
 {

--- a/src/_ZN17RotatingClockHand8BehaviorEv.cpp
+++ b/src/_ZN17RotatingClockHand8BehaviorEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingClockHand.h"
+extern "C" {
 extern int DecIfAbove0_Short(char *p);
 extern int RandomIntInternal(char *p);
 extern void func_020393a4(int *p, int v);
@@ -12,6 +13,7 @@ extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char *c);
 extern unsigned char data_0209f2c0[];
 extern int data_0209e650[];
+}
 
 int RotatingClockHand::Behavior()
 {

--- a/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
+++ b/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
@@ -5,12 +5,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingPlatformWf.h"
+extern "C" {
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* c, void* cc);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(char* c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, Fix12i a, Fix12i b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
+}
 
 int SlidingPlatformWf::Behavior()
 {

--- a/src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp
+++ b/src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp
@@ -6,12 +6,14 @@
 #include "BowserFireSeaArena.h"
 #include "MeshColliderBase.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int func_020393d4(void*, void*);
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 
 int BowserFireSeaArena::InitResources()

--- a/src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp
+++ b/src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "BowserFireSeaArena.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int BowserFireSeaArena::CleanupResources()
 {

--- a/src/_ZN18PoppingLavaBubbles13InitResourcesEv.cpp
+++ b/src/_ZN18PoppingLavaBubbles13InitResourcesEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN18PoppingLavaBubbles13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "PoppingLavaBubbles.h"
+extern "C" {
 extern signed char data_0209f2f8;
+}
 
 int PoppingLavaBubbles::InitResources()
 {

--- a/src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp
+++ b/src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "RickshawPlatformBs.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112508;
+}
 
 int RickshawPlatformBs::InitResources()
 {

--- a/src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp
+++ b/src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "RickshawPlatformBs.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112508;
+}
 
 int RickshawPlatformBs::CleanupResources()
 {

--- a/src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp
+++ b/src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp
@@ -5,8 +5,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformRr.h"
 typedef short s16;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
+}
 
 int RotatingPlatformRr::InitResources()
 {

--- a/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
+++ b/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
@@ -5,8 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformRr.h"
+extern "C" {
 extern s16 data_02082214[];
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
+}
 
 int RotatingPlatformRr::Behavior()
 {

--- a/src/_ZN19AmbientSoundEffects13InitResourcesEv.cpp
+++ b/src/_ZN19AmbientSoundEffects13InitResourcesEv.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "AmbientSoundEffects.h"
+extern "C" {
 extern void* _Znwj(unsigned int);
 extern void _ZN3Fog4InitEt5Fix12IiES1_(void* thiz, unsigned short a, int b, int d);
+}
 
 int AmbientSoundEffects::InitResources()
 {

--- a/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
+++ b/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "BowserPuzzleManager.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void *data_ov064_0211adc8[];
+}
 
 int BowserPuzzleManager::CleanupResources()
 {

--- a/src/_ZN19FloatingFloorLllBig13InitResourcesEv.cpp
+++ b/src/_ZN19FloatingFloorLllBig13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 #include "FloatingFloorLllBig.h"
 typedef int Fix12;
 typedef short s16;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
@@ -14,6 +15,7 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int func_020393d4(void*, void*);
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 int FloatingFloorLllBig::InitResources()
 {

--- a/src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp
+++ b/src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "FloatingFloorLllBig.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int FloatingFloorLllBig::CleanupResources()
 {

--- a/src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp
+++ b/src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "RickshawPlatformBdw.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
 extern struct Arg data_ov043_02112518;
+}
 
 int RickshawPlatformBdw::InitResources()
 {

--- a/src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp
+++ b/src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "RickshawPlatformBdw.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
 extern struct Arg data_ov043_02112518;
+}
 
 int RickshawPlatformBdw::CleanupResources()
 {

--- a/src/_ZN19RotatingPlatformLll13InitResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformLll13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformLll.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
@@ -15,6 +16,7 @@ extern int func_020393d4(void*, void*);
 extern int func_020393c4(void*, void*);
 extern char data_ov022_02114558[];
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 int RotatingPlatformLll::InitResources()
 {

--- a/src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "RotatingPlatformLll.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov022_02114558[];
+}
 
 int RotatingPlatformLll::CleanupResources()
 {

--- a/src/_ZN19RotatingPlatformLll8BehaviorEv.cpp
+++ b/src/_ZN19RotatingPlatformLll8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformLll.h"
+extern "C" {
 extern void func_020393a4(int* p, int v);
+}
 
 int RotatingPlatformLll::Behavior()
 {

--- a/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void *bmd, void *bta);
@@ -13,11 +14,14 @@ extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *tt, void
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *sfp);
+}
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *mc, void *kcl, void *mtx, int fix, short s, void *clps);
 
+extern "C" {
 extern u8 data_0209f2c0[];
 extern int data_0209f32c;
+}
 
 int RotatingPlatformWdw::InitResources()
 {

--- a/src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "RotatingPlatformWdw.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int RotatingPlatformWdw::CleanupResources()
 {

--- a/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
@@ -6,11 +6,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int IsAreaShowing(int idx);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, void *pos, unsigned e);
 extern void _ZN9Animation7AdvanceEv(void *a);
 extern s16 data_02082214[];
 extern int data_0209f32c;
+}
 
 int RotatingPlatformWdw::Behavior()
 {

--- a/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "SwitchActivatedPlank.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int SwitchActivatedPlank::CleanupResources()
 {

--- a/src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp
@@ -6,8 +6,10 @@
 #include "TtcConveyorBeltLarge.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char data_ov065_0211d194[];
 extern char data_ov065_0211d198[];
+}
 
 int TtcConveyorBeltLarge::CleanupResources()
 {

--- a/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
@@ -9,6 +9,7 @@
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
+extern "C" {
 extern void func_020393c4(int* p, int v);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern int _Z14ApproachLinearRiii(int* r, int t, int step);
@@ -16,11 +17,14 @@ extern u16 DecIfAbove0_Short(u16* p);
 extern int RandomIntInternal(int* seed);
 extern void _ZN9Animation7AdvanceEv(void* a);
 extern void* _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int d);
+}
 
+extern "C" {
 extern u8 data_0209f2c0;
 extern int func_ov065_0211aacc;
 extern int data_0209e650;
 extern int data_ov065_0211c0b8[];
+}
 
 int TtcConveyorBeltLarge::Behavior()
 {

--- a/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "ArmedRotatingPlatform.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
 extern struct Arg data_ov036_02113e88;
+}
 
 int ArmedRotatingPlatform::InitResources()
 {

--- a/src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "ArmedRotatingPlatform.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
 extern struct Arg data_ov036_02113e88;
+}
 
 int ArmedRotatingPlatform::CleanupResources()
 {

--- a/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ClockPaintingHandShort.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, int, int, int);
+}
 
 int ClockPaintingHandShort::InitResources()
 {

--- a/src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp
@@ -4,9 +4,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ClockPaintingHandShort.h"
+extern "C" {
 extern int IsAreaShowing(int);
 extern signed char data_02092110[];
 extern unsigned char data_0209f2c0[];
+}
 
 int ClockPaintingHandShort::Behavior()
 {

--- a/src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatform.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* sfp);
@@ -14,10 +15,13 @@ extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
 extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* self, void* out, unsigned int idx);
+}
 
+extern "C" {
 extern int data_ov091_021344fc[];
 extern int data_ov091_021344f4[];
 extern char _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+}
 
 int RotatingUpDownPlatform::InitResources()
 {

--- a/src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp
+++ b/src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "FloatOnWaterPlatformJrb.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov016_02114e74[];
+}
 
 int FloatOnWaterPlatformJrb::CleanupResources()
 {

--- a/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
@@ -8,6 +8,7 @@ enum Bool { FALSE, TRUE };
 
 struct RaycastGround { char buf[0x44]; int f44; char rest[8]; };
 
+extern "C" {
 extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, int a, int b, int c, int d);
 extern int _ZN11ShadowModel10InitCuboidEv(void *self);
 extern void Vec3_Add(Vector3 *out, Vector3 *a, Vector3 *b);
@@ -25,12 +26,15 @@ extern void _ZN13RaycastGroundC1Ev(struct RaycastGround *self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const Vector3 *v, void *a);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround *self);
 extern void _ZN13RaycastGroundD1Ev(struct RaycastGround *self);
+}
 
+extern "C" {
 extern signed char data_0209f2f8;
 extern struct Matrix4x3 data_020a0e68;
 extern void *data_ov091_02134c30[];
 extern void *data_ov091_02134c34[];
 extern void *_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+}
 
 int RotatingUpDownPlatformUtm::InitResources()
 {

--- a/src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp
@@ -7,8 +7,10 @@
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
 struct SFP { void *a, *b, *c; };
+extern "C" {
 extern struct SFP data_ov091_02134c30[];
 extern struct SFP data_ov091_02134c34[];
+}
 
 int RotatingUpDownPlatformUtm::CleanupResources()
 {

--- a/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
@@ -9,6 +9,7 @@
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct RaycastGround { char pad[0x54]; } RaycastGround;
 
+extern "C" {
 extern void *_ZN5Actor15FindWithActorIDEjPS_(u32 id, void *p);
 extern int Vec3_HorzDist(const Vec3 *a, const Vec3 *b);
 extern int _ZN5Actor13DistToCPlayerEv(void *thiz);
@@ -30,8 +31,11 @@ extern void func_02039394(int *p, int v);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *thiz, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *thiz);
 extern void _ZN13RaycastGroundD1Ev(RaycastGround *rc);
+}
 
+extern "C" {
 extern char data_020a0e68[];
+}
 
 int RotatingUpDownPlatformUtm::Behavior()
 {

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "FloatOnWaterPlatformWdwSquare.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int FloatOnWaterPlatformWdwSquare::CleanupResources()
 {

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
@@ -3,11 +3,13 @@
 // @symbol _ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnWaterPlatformWdwSquare.h"
+extern "C" {
 extern void func_02012694(int a, void* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);
 extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
+}
 
 int FloatOnWaterPlatformWdwSquare::Behavior()
 {

--- a/src/_ZN3Key13InitResourcesEv.cpp
+++ b/src/_ZN3Key13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Key.h"
+extern "C" {
 extern void LoadKeyModels(int idx);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
@@ -14,7 +15,9 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thi
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* pos);
 extern int _ZN11ShadowModel12InitCylinderEv(void* thiz);
 extern void _ZN5Event8ClearBitEj(unsigned int n);
+}
 
+extern "C" {
 extern char data_ov002_02110964;
 extern char data_ov002_0211094c;
 extern char data_ov089_02132b40;
@@ -25,6 +28,7 @@ extern char data_ov089_02132c48;
 extern int data_ov089_021328b4[];
 extern char data_ov089_02132ca4;
 extern int data_0209cef0;
+}
 
 int Key::InitResources()
 {

--- a/src/_ZN3Key16CleanupResourcesEv.cpp
+++ b/src/_ZN3Key16CleanupResourcesEv.cpp
@@ -5,12 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Key.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern void _ZN5Event8ClearBitEj(unsigned int b);
 extern int data_ov002_02110964[];
 extern int data_ov089_02132c60[];
 extern int data_ov089_02132c40[];
 extern int data_ov089_02132c70[];
 extern int data_ov089_02132c48[];
+}
 
 int Key::CleanupResources()
 {

--- a/src/_ZN4Door8BehaviorEv.cpp
+++ b/src/_ZN4Door8BehaviorEv.cpp
@@ -8,11 +8,17 @@ struct CallbackNode {
     char pad[8];
     PMF callback;
 };
-extern int func_ov100_02145370(char *c);
+extern "C" {
+extern int func_ov100_02145f00(char *c);
+}
 
+/* Calls func_ov100_02145f00, not func_ov100_02145370. The call is a relocation,
+   which match.py compares as a wildcard, so the byte gate passed the wrong
+   callee happily -- and the ROM link could not see it either until this file
+   became enrollable. */
 int Door::Behavior()
 {
-    int res = func_ov100_02145370(((char *)this));
+    int res = func_ov100_02145f00(((char *)this));
     CallbackNode *node = *(CallbackNode**)((char*)&unk_110);
     if (*(int*)&node->callback != 0) {
         Base *base = (Base*)((char *)this);

--- a/src/_ZN4Fish13InitResourcesEv.cpp
+++ b/src/_ZN4Fish13InitResourcesEv.cpp
@@ -3,6 +3,7 @@
 // @symbol _ZN4Fish13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Fish.h"
+extern "C" {
 extern int _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
@@ -10,6 +11,7 @@ extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigne
 extern int data_ov100_021489cc[];
 extern int* data_ov100_021473a4[];
 extern int* data_ov100_021473b0[];
+}
 
 int Fish::InitResources()
 {

--- a/src/_ZN4Fish16CleanupResourcesEv.cpp
+++ b/src/_ZN4Fish16CleanupResourcesEv.cpp
@@ -5,12 +5,16 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Fish.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+}
 
+extern "C" {
 extern struct SharedFilePtr data_ov100_021489cc;
 extern struct SharedFilePtr *data_ov100_021473a4[];
 extern struct SharedFilePtr *data_ov100_021473b0[];
+}
 
 int Fish::CleanupResources()
 {

--- a/src/_ZN4Toad16CleanupResourcesEv.cpp
+++ b/src/_ZN4Toad16CleanupResourcesEv.cpp
@@ -5,10 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Toad.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern int data_ov002_0210da40[];
 extern int data_ov002_0210d9a0[];
 extern int data_ov002_0210d9c0[];
 extern int data_ov085_02130480[];
+}
 
 int Toad::CleanupResources()
 {

--- a/src/_ZN4Trap13InitResourcesEv.cpp
+++ b/src/_ZN4Trap13InitResourcesEv.cpp
@@ -4,11 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Trap.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern unsigned char NumStars(void);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, int, int, int);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void*, void*, void*, int, int, unsigned int, unsigned int);
 extern int data_0209caa0[];
+}
 
 int Trap::InitResources()
 {

--- a/src/_ZN5Bully13InitResourcesEv.cpp
+++ b/src/_ZN5Bully13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Bully.h"
+extern "C" {
 extern void func_ov064_02116ec0(char* c);
+}
 
 void Bully::InitResources()
 {

--- a/src/_ZN5Crate13InitResourcesEv.cpp
+++ b/src/_ZN5Crate13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Crate.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(char* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* thiz, int f, int a, int b);
 extern void _ZN11ShadowModel10InitCuboidEv(char* thiz);
@@ -13,6 +14,7 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* thi
 extern void _ZN12WithMeshClsn19StartDetectingWaterEv(char* thiz);
 extern void Crate_SetState(char* c, int i);
 extern char data_ov098_0213c4c8[];
+}
 
 int Crate::InitResources()
 {

--- a/src/_ZN5Crate16CleanupResourcesEv.cpp
+++ b/src/_ZN5Crate16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "Crate.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov098_0213c4c8[];
+}
 
 int Crate::CleanupResources()
 {

--- a/src/_ZN5Crate8BehaviorEv.cpp
+++ b/src/_ZN5Crate8BehaviorEv.cpp
@@ -9,6 +9,7 @@
 /* _ZN5Crate8BehaviorEv at 0x02139b0c */
 enum Bool { FALSE, TRUE };
 
+extern "C" {
 extern u32 data_0209b454;
 extern void _ZN6Player9DropActorEv(void* self);
 extern int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
@@ -17,6 +18,7 @@ extern void Crate_SetState(char* c, int i);
 extern u8 DecIfAbove0_Byte(u8* p);
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 a, u32 b, int c, int d, int e, const void* v, void* cb);
 extern void* _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(u32 a, u32 b, int c, int d, int e, const void* v);
+}
 
 int Crate::Behavior()
 {

--- a/src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp
+++ b/src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp
@@ -6,16 +6,20 @@ typedef signed short s16;
 struct Vector3 { s32 x, y, z; };
 struct Actor { char pad[0x100]; };
 
+extern "C" {
 extern void Vec3_Sub(Vector3 *out, const Vector3 *a, const Vector3 *b);
 extern s32 Vec3_HorzLen(const Vector3 *v);
 extern s16 _ZN4cstd5atan2E5Fix12IiES1_(s32 y, s32 x);
 extern s32 *Vec3_AsrInPlace(s32 *v, s32 sh);
+}
 extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int uniqueID, unsigned int effectID,
     s32 x, s32 y, s32 z,
     const void *dir, void *callback);
 
+extern "C" {
 extern s16 data_02082214[];
+}
 
 struct Enemy
 {

--- a/src/_ZN5Koopa13InitResourcesEv.cpp
+++ b/src/_ZN5Koopa13InitResourcesEv.cpp
@@ -9,10 +9,13 @@ typedef struct { int w[2]; } SharedFilePtr;
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 
+extern "C" {
 extern SharedFilePtr* data_ov062_0211cee8[9];
 extern SharedFilePtr* data_ov062_0211ced8[2];
 extern SharedFilePtr* data_ov062_0211cee0[2];
+}
 
+extern "C" {
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
@@ -21,6 +24,7 @@ extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Fix12 q);
 extern void _ZN12WithMeshClsn19StartDetectingWaterEv(void* self);
 extern void LoadBlueCoinModel(void* c);
+}
 
 int Koopa::InitResources()
 {

--- a/src/_ZN5Koopa16CleanupResourcesEv.cpp
+++ b/src/_ZN5Koopa16CleanupResourcesEv.cpp
@@ -6,11 +6,13 @@ struct SharedFilePtr
 {
   unsigned int data[4];
 };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *);
 extern void UnloadBlueCoinModel(void *c);
 extern struct SharedFilePtr *data_ov062_0211cee0[];
 extern struct SharedFilePtr *data_ov062_0211ced8[];
 extern struct SharedFilePtr *data_ov062_0211cee8[];
+}
 
 int Koopa::CleanupResources()
 {

--- a/src/_ZN5Koopa8BehaviorEv.cpp
+++ b/src/_ZN5Koopa8BehaviorEv.cpp
@@ -6,6 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Koopa.h"
+extern "C" {
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void *self, void *wm, void *ma, unsigned int j);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *self, void *c);
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void *self, void *c);
@@ -20,6 +21,7 @@ extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
 extern int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *self, void *wm, int a, s16 b, int c, int d, int e);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *self, void *wm, unsigned int j);
 extern void _ZN5Enemy11UpdateDeathER12WithMeshClsn(void *self, void *wm);
+}
 
 int Koopa::Behavior()
 {

--- a/src/_ZN5Pokey8BehaviorEv.cpp
+++ b/src/_ZN5Pokey8BehaviorEv.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Pokey.h"
+extern "C" {
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void *c, int d);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *c, void *cyl);
+}
 
 int Pokey::Behavior()
 {

--- a/src/_ZN5Stage13UpdateMessageEv.cpp
+++ b/src/_ZN5Stage13UpdateMessageEv.cpp
@@ -1,11 +1,13 @@
 //cpp
 #include "types.h"
+extern "C" {
 extern u8 data_0209d660;
 extern u8 data_0209d654;
 extern s16 data_0209d6d4;
 extern u8 data_0209d67c;
 extern u8 data_0209d670;
 extern s32 data_0208ee44;
+}
 
 struct Message {
     static bool UpdateWindow();

--- a/src/_ZN5Stage16CheckCameraInputEv.cpp
+++ b/src/_ZN5Stage16CheckCameraInputEv.cpp
@@ -18,6 +18,7 @@ struct CamInput {
     u8 f17;
 };
 
+extern "C" {
 extern u8 data_0209f2c4;
 extern u8 data_0209f20c;
 extern u8 data_0209f294;
@@ -29,6 +30,7 @@ extern TouchInfo data_020a0de8[];
 extern CamInput data_0209f498[];
 extern u8* data_0209f318;
 extern u8 data_ov002_02111180;
+}
 
 struct Stage {
     static void CheckCameraInput();

--- a/src/_ZN5Stage20PS_UpdateOptionsMenuEv.cpp
+++ b/src/_ZN5Stage20PS_UpdateOptionsMenuEv.cpp
@@ -2,12 +2,14 @@
 #include "types.h"
 namespace G2S { u16 *GetBG1ScrPtr(); }
 
+extern "C" {
 extern u8 data_0209f2e4;
 extern u16 data_020755c0[];
 extern u8 data_0209f2e0;
 extern u8 data_0209f2cc;
 extern u16 data_020755c4[];
 extern u8 data_0209f2ec;
+}
 
 struct Stage {
     static void PS_UpdateOptionsMenu();

--- a/src/_ZN5Stage23LoadTextureTransformersEv.cpp
+++ b/src/_ZN5Stage23LoadTextureTransformersEv.cpp
@@ -5,11 +5,13 @@
 #include "Stage.h"
 struct Entry { int x; void* bta; char pad[4]; };
 struct Info { char a[0x10]; struct Entry* entries; unsigned char count; };
+extern "C" {
 extern struct Info* data_0209f340;
 extern void* _Znwj(u32);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void* bmd, void* bta);
 extern void* _ZN18TextureTransformerC1Ev(void*);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void* self, void* bta, int a, int b, u32 c);
+}
 
 void Stage::LoadTextureTransformers()
 {

--- a/src/_ZN5Stage7LoadFogEv.cpp
+++ b/src/_ZN5Stage7LoadFogEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
+extern "C" {
 extern void _ZN3Fog4InitEt5Fix12IiES1_(char *self, unsigned short color, int nearv, int farv);
+}
 
 void Stage::LoadFog()
 {

--- a/src/_ZN5Stump13InitResourcesEv.cpp
+++ b/src/_ZN5Stump13InitResourcesEv.cpp
@@ -4,12 +4,15 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Stump.h"
+extern "C" {
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *thiz, void *actor, int fix, int t, unsigned int a, unsigned int b);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *thiz, void *actor, int fix, int t, void *v, int t2);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *f, int a, int b);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *f);
+}
 
+extern "C" {
 extern char data_ov002_0210da40[];
 extern char data_ov002_0210d9a0[];
 extern char data_ov002_0210d9c0[];
@@ -17,6 +20,7 @@ extern char data_ov091_02135674[];
 extern char data_ov091_0213567c[];
 extern char data_ov091_02135684[];
 extern char data_ov091_021356d0[];
+}
 
 int Stump::InitResources()
 {

--- a/src/_ZN5Stump16CleanupResourcesEv.cpp
+++ b/src/_ZN5Stump16CleanupResourcesEv.cpp
@@ -3,6 +3,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Stump.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 extern struct SharedFilePtr data_ov002_0210da40;
 extern struct SharedFilePtr data_ov002_0210d9a0;
@@ -10,6 +11,7 @@ extern struct SharedFilePtr data_ov002_0210d9c0;
 extern struct SharedFilePtr data_ov091_02135674;
 extern struct SharedFilePtr data_ov091_0213567c;
 extern struct SharedFilePtr data_ov091_02135684;
+}
 
 int Stump::CleanupResources()
 {

--- a/src/_ZN5Swoop13InitResourcesEv.cpp
+++ b/src/_ZN5Swoop13InitResourcesEv.cpp
@@ -8,6 +8,7 @@ typedef struct { short x,y,z; } Vector3_16;
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
+extern "C" {
 extern SharedFilePtr data_ov065_0211d698;
 extern SharedFilePtr data_ov065_0211d6a8;
 extern SharedFilePtr data_ov065_0211d690;
@@ -20,6 +21,7 @@ extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern int func_ov065_02117944(void* c, PMF* p);
+}
 
 int Swoop::InitResources()
 {

--- a/src/_ZN5Whomp16CleanupResourcesEv.cpp
+++ b/src/_ZN5Whomp16CleanupResourcesEv.cpp
@@ -6,10 +6,12 @@
 #include "Whomp.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void data_ov079_02128168(void);
 extern void data_ov079_02128178(void);
 extern void data_ov079_02128170(void);
 extern void *data_ov079_021275ec[];
+}
 
 int Whomp::CleanupResources()
 {

--- a/src/_ZN6Bullet13InitResourcesEv.cpp
+++ b/src/_ZN6Bullet13InitResourcesEv.cpp
@@ -8,10 +8,12 @@
 struct Actor;
 struct Vector3_16;
 struct BMD_File;
+extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(char* self, struct Actor* a, int r, int h, u32 f1, u32 f2);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* self, struct Actor* a, int r, int h, struct Vector3_16* rot, int f);
+}
 
 int Bullet::InitResources()
 {

--- a/src/_ZN6Camera10LookAtExitER5Actor.cpp
+++ b/src/_ZN6Camera10LookAtExitER5Actor.cpp
@@ -9,7 +9,9 @@ struct Camera {
     void ChangeState(State *st);
 };
 
+extern "C" {
 extern Camera::State data_0209b0f8;
+}
 
 void Camera::LookAtExit(struct Actor &actor)
 {

--- a/src/_ZN6Coffin16CleanupResourcesEv.cpp
+++ b/src/_ZN6Coffin16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "Coffin.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int Coffin::CleanupResources()
 {

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Dorrie.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
@@ -18,13 +19,18 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* sel
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, void* a, void* pos, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int e, int f);
+}
 
+extern "C" {
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
+extern "C" {
 extern int data_ov065_0211d720;
 extern int data_ov002_0210d9c0;
 extern void* data_ov065_0211c080[];
 extern void* data_ov065_0211c08c[];
+}
 
 int Dorrie::InitResources()
 {

--- a/src/_ZN6Dorrie16CleanupResourcesEv.cpp
+++ b/src/_ZN6Dorrie16CleanupResourcesEv.cpp
@@ -6,11 +6,13 @@
 #include "Dorrie.h"
 #include "MeshColliderBase.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *);
 extern struct SharedFilePtr data_ov002_0210d9c0;
 extern struct SharedFilePtr *data_ov065_0211c08c[];
 extern struct SharedFilePtr *data_ov065_0211c080[];
 extern struct SharedFilePtr data_ov065_0211d720;
+}
 
 int Dorrie::CleanupResources()
 {

--- a/src/_ZN6Eyerok13InitResourcesEv.cpp
+++ b/src/_ZN6Eyerok13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Eyerok.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov066_0211ae6c[];
 extern int data_ov066_0211ae4c[];
 extern int data_ov066_0211aeb4[];
@@ -32,7 +33,9 @@ extern s8 data_ov066_0211abe0;
 extern s8 data_ov066_0211ae04;
 extern s8 data_ov066_0211ae0c;
 extern char _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+}
 
+extern "C" {
 extern u8 _ZN5Actor9TrackStarEjj(void* actor, u32 a, u32 b);
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
@@ -46,6 +49,7 @@ extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 b, Vector3
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, int kcl, void* mtx, s32 fix, s16 s, void* clps);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
+}
 
 int Eyerok::InitResources()
 {

--- a/src/_ZN6Eyerok16CleanupResourcesEv.cpp
+++ b/src/_ZN6Eyerok16CleanupResourcesEv.cpp
@@ -6,6 +6,7 @@
 #include "Eyerok.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern char data_ov066_0211ae6c[];
 extern char data_ov066_0211ae4c[];
 extern char data_ov066_0211aeb4[];
@@ -28,6 +29,7 @@ extern char data_ov066_0211aeac[];
 extern char data_ov066_0211ae14[];
 extern char data_ov066_0211ae1c[];
 extern char data_ov066_0211ae34[];
+}
 
 int Eyerok::CleanupResources()
 {

--- a/src/_ZN6FlyGuy13InitResourcesEv.cpp
+++ b/src/_ZN6FlyGuy13InitResourcesEv.cpp
@@ -8,6 +8,7 @@ typedef struct { short x,y,z; } Vector3_16;
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
+extern "C" {
 extern SharedFilePtr data_ov070_02123530;
 extern SharedFilePtr data_ov070_02123520;
 extern SharedFilePtr data_ov070_02123518;
@@ -23,6 +24,7 @@ extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern int FlyGuy_ChangeState(void* c, PMF* p);
+}
 
 int FlyGuy::InitResources()
 {

--- a/src/_ZN6Goomba16CleanupResourcesEv.cpp
+++ b/src/_ZN6Goomba16CleanupResourcesEv.cpp
@@ -5,11 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Goomba.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern void UnloadBlueCoinModel(void* p);
 extern void _ZN8CapEnemy14UnloadCapModelEv(char* c);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern char data_ov084_02130cf8[];
 extern void* data_ov084_02130278[];
+}
 
 int Goomba::CleanupResources()
 {

--- a/src/_ZN6Goomba8BehaviorEv.cpp
+++ b/src/_ZN6Goomba8BehaviorEv.cpp
@@ -14,8 +14,11 @@ typedef unsigned char u8;
 
 typedef s32 Fix12;
 
+extern "C" {
 extern s8 data_0209f2f8;
+}
 
+extern "C" {
 extern void _ZN5Actor8PoofDustEv(char* c);
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(char* c, Fix12 f);
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(char* c, void* w, void* m, u32 j);
@@ -33,6 +36,7 @@ extern void _ZN12CylinderClsn5ClearEv(void* c);
 extern void _ZN12CylinderClsn6UpdateEv(void* c);
 extern int Vec3_Dist(const Vector3* a, const Vector3* b);
 extern void _ZN5Enemy9SpawnCoinEv(char* c);
+}
 
 int Goomba::Behavior()
 {

--- a/src/_ZN6Klepto13InitResourcesEv.cpp
+++ b/src/_ZN6Klepto13InitResourcesEv.cpp
@@ -8,6 +8,7 @@
 typedef int Fix12;
 typedef struct { int h; } SharedFilePtr;
 
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr *f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -21,7 +22,9 @@ extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsign
 extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, Fix12 a, Fix12 b, Fix12 c, Fix12 d);
 extern void func_ov062_0211c658(void *c, void *p);
 extern short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
+}
 
+extern "C" {
 extern SharedFilePtr data_ov062_0211e0fc;
 extern SharedFilePtr data_ov062_0211e114;
 extern SharedFilePtr data_ov062_0211e10c;
@@ -31,6 +34,7 @@ extern SharedFilePtr data_ov002_0210d9a0;
 extern SharedFilePtr data_ov002_0210d9c0;
 extern char data_ov062_0211e17c;
 extern void *data_0209f394;
+}
 
 int Klepto::InitResources()
 {

--- a/src/_ZN6Player12CanEnterDoorEh.c
+++ b/src/_ZN6Player12CanEnterDoorEh.c
@@ -10,11 +10,13 @@ struct Player {
     int CanEnterDoor(unsigned char);
 };
 
+extern "C" {
 extern State data_ov002_0211022c;
 extern State data_ov002_0211013c;
 extern State data_ov002_02110154;
 extern State data_ov002_0211043c;
 extern State data_ov002_0211004c;
+}
 
 struct DoorObj { int (**vtbl)(DoorObj *); };
 

--- a/src/_ZN6Player12St_Fall_InitEv.cpp
+++ b/src/_ZN6Player12St_Fall_InitEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int _ZN6Player6IsAnimEj(void*, unsigned int);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
+}
 
 int Player::St_Fall_Init()
 {

--- a/src/_ZN6Player12St_Fall_MainEv.cpp
+++ b/src/_ZN6Player12St_Fall_MainEv.cpp
@@ -5,11 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int func_ov002_020e28d4(void*, int, int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
 extern int Player_AdvanceAnims(void*);
 extern Fix12i Player_ScaleByCharFactor(void* c, Fix12i a);
 extern char data_ov002_02110424[];
+}
 
 int Player::St_Fall_Main()
 {

--- a/src/_ZN6Player12St_Hurt_InitEv.cpp
+++ b/src/_ZN6Player12St_Hurt_InitEv.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* thiz, u32 anim, int a, int fix, u32 b);
 extern int _ZNK6Player14GetBodyModelIDEjb(char* thiz, u32 a, int b);
 extern void func_ov002_020d93ac(char* thiz);
 extern char* data_0209f318;
+}
 
 int Player::St_Hurt_Init()
 {

--- a/src/_ZN6Player12St_Talk_InitEv.cpp
+++ b/src/_ZN6Player12St_Talk_InitEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN6Player12St_Talk_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int Player_DisableInteraction(void* c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_Talk_Init()
 {

--- a/src/_ZN6Player12Unk_020c6a10Ej.cpp
+++ b/src/_ZN6Player12Unk_020c6a10Ej.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, void* st);
 extern int func_ov002_020d91e0(void* thiz, u32 a, int b);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, void* st);
+}
 
 int Player::Unk_020c6a10(unsigned int arg_)
 {

--- a/src/_ZN6Player12Unk_020c9e5cEh.cpp
+++ b/src/_ZN6Player12Unk_020c9e5cEh.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern struct State data_ov002_0211022c;
+}
 
 int Player::Unk_020c9e5c(unsigned char h)
 {

--- a/src/_ZN6Player12Unk_020ca150Eh.cpp
+++ b/src/_ZN6Player12Unk_020ca150Eh.cpp
@@ -3,10 +3,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void *c, struct State *s);
 extern struct State data_ov002_0211022c;
 extern struct State data_ov002_0211013c;
+}
 
 int Player::Unk_020ca150(unsigned char a)
 {

--- a/src/_ZN6Player12Unk_020ca8f8Ev.cpp
+++ b/src/_ZN6Player12Unk_020ca8f8Ev.cpp
@@ -3,9 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern struct State data_ov002_0211064c;
 extern struct State data_ov002_02110664;
+}
 
 int Player::Unk_020ca8f8()
 {

--- a/src/_ZN6Player13St_Climb_InitEv.cpp
+++ b/src/_ZN6Player13St_Climb_InitEv.cpp
@@ -5,11 +5,13 @@ struct Vector3 {
     int x, y, z;
 };
 
+extern "C" {
 extern int Player_ReleaseHeldActor(char*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, const Vector3&);
 extern int func_ov002_020e3078(void*, void*);
 extern char data_ov002_021106f4[];
+}
 
 class Player {
 public:

--- a/src/_ZN6Player14St_Squish_InitEv.cpp
+++ b/src/_ZN6Player14St_Squish_InitEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern void Player_ReleaseHeldActor(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
+}
 
 int Player::St_Squish_Init()
 {

--- a/src/_ZN6Player16IncMegaKillCountEv.cpp
+++ b/src/_ZN6Player16IncMegaKillCountEv.cpp
@@ -10,8 +10,10 @@ struct Vec3
   int y;
   int z;
 };
+extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void *v);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vec3 *pos, void *rot, int a, int b);
+}
 
 void Player::IncMegaKillCount()
 {

--- a/src/_ZN6Player16InitBalloonMarioEv.cpp
+++ b/src/_ZN6Player16InitBalloonMarioEv.cpp
@@ -4,14 +4,18 @@
 #include "Player.h"
 struct V3 { int x, y, z; };
 struct State;
+extern "C" {
 extern void func_ov002_020bda48(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, struct State* s);
 extern void func_ov002_020bd9ec(char* c, unsigned int a);
 extern void func_ov002_020c43c4(char* c, int a);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, void* pos);
+}
 
+extern "C" {
 extern struct State data_ov002_0211028c;
+}
 
 void Player::InitBalloonMario()
 {

--- a/src/_ZN6Player16St_BackFlip_InitEv.cpp
+++ b/src/_ZN6Player16St_BackFlip_InitEv.cpp
@@ -3,12 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int func_ov002_020e2be4(void*);
 extern int func_ov002_020e2ba8(void*);
 extern int func_ov002_020e2b6c(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int func_ov002_020e2ad0(void*);
 extern int func_ov002_020e25f0(void*, int);
+}
 
 int Player::St_BackFlip_Init()
 {

--- a/src/_ZN6Player16St_Climb_CleanupEv.cpp
+++ b/src/_ZN6Player16St_Climb_CleanupEv.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int func_ov002_020caf68(void *c);
 extern int data_ov002_021106f4[];
+}
 
 int Player::St_Climb_Cleanup()
 {

--- a/src/_ZN6Player16St_DebugFly_InitEv.cpp
+++ b/src/_ZN6Player16St_DebugFly_InitEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player16St_DebugFly_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void Player_DisableInteraction(void *);
+}
 
 int Player::St_DebugFly_Init()
 {

--- a/src/_ZN6Player16St_SideFlip_InitEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_InitEv.cpp
@@ -3,12 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int func_ov002_020e2be4(void*);
 extern int func_ov002_020e2ba8(void*);
 extern int func_ov002_020e2b6c(void*);
 extern int func_ov002_020e2ad0(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int func_ov002_020e25f0(void*, int);
+}
 
 int Player::St_SideFlip_Init()
 {

--- a/src/_ZN6Player17SetNoControlStateEhih.cpp
+++ b/src/_ZN6Player17SetNoControlStateEhih.cpp
@@ -4,12 +4,16 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State;
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, struct State* s);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, struct State* s);
+}
 
+extern "C" {
 extern struct State data_ov002_0211010c;
 extern struct State data_ov002_02110124;
 extern struct State data_ov002_0211022c;
+}
 
 int Player::SetNoControlState(unsigned char a_, int b, unsigned char c_)
 {

--- a/src/_ZN6Player17St_EndingFly_InitEv.cpp
+++ b/src/_ZN6Player17St_EndingFly_InitEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN6Player17St_EndingFly_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int Player_DisableInteraction(void* c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_EndingFly_Init()
 {

--- a/src/_ZN6Player17St_Headstand_InitEv.cpp
+++ b/src/_ZN6Player17St_Headstand_InitEv.cpp
@@ -3,9 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct Camera;
+extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void *c, unsigned int a, int b, int f, unsigned int d);
 extern void func_0200d580(struct Camera *thiz, int playerID);
 extern struct Camera *data_0209f318;
+}
 
 int Player::St_Headstand_Init()
 {

--- a/src/_ZN6Player17St_HoldLight_InitEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_InitEv.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN6Player17St_HoldLight_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int Player_ScaleByCharFactor(char* c, int a);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, unsigned int anim, int a, int fix, unsigned int z);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, void* v);
+}
 
 int Player::St_HoldLight_Init()
 {

--- a/src/_ZN6Player17St_LedgeHang_InitEv.cpp
+++ b/src/_ZN6Player17St_LedgeHang_InitEv.cpp
@@ -3,9 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct Vec3 { int x, y, z; };
+extern "C" {
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, unsigned int anim, int a, int fix, unsigned int z);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, void* v);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(char* o, struct Vec3* p);
+}
 
 int Player::St_LedgeHang_Init()
 {

--- a/src/_ZN6Player17St_WallSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_WallSlide_MainEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern void func_ov002_020c2f64(void *c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void *p, void *st);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(Fix12i x, Fix12i y, Fix12i z);
@@ -14,6 +15,7 @@ extern unsigned char data_020a0e40;
 extern unsigned char data_0209f49e[];
 extern char data_ov002_0211013c;
 extern char data_ov002_021101b4;
+}
 
 int Player::St_WallSlide_Main()
 {

--- a/src/_ZN6Player18TurnOffToonShadingEj.cpp
+++ b/src/_ZN6Player18TurnOffToonShadingEj.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN6Player18TurnOffToonShadingEj
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZNK6Player14GetBodyModelIDEjb(void*, unsigned int, int);
 extern int _ZN5Model14SetPolygonModeEi(void*, int);
 extern int func_ov002_020e6b74(void*, int);
+}
 
 void Player::TurnOffToonShading(unsigned int j)
 {

--- a/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
@@ -6,6 +6,7 @@ typedef long long s64;
 
 struct Vector3 { int x, y, z; };
 
+extern "C" {
 extern short data_02082214[];
 extern void func_ov002_020e28d4(void*, int, int);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int, int);
@@ -18,6 +19,7 @@ extern void Player_ReleaseHeldActor(void*);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
 extern char data_ov002_0211031c;
+}
 
 class Player {
 public:

--- a/src/_ZN6Player19St_GroundPound_InitEv.cpp
+++ b/src/_ZN6Player19St_GroundPound_InitEv.cpp
@@ -3,9 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int Player_ReleaseHeldActor(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, void*);
+}
 
 int Player::St_GroundPound_Init()
 {

--- a/src/_ZN6Player21IsOpeningDoorWithStarEv.cpp
+++ b/src/_ZN6Player21IsOpeningDoorWithStarEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN6Player21IsOpeningDoorWithStarEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player12Unk_020c9e5cEh(void *c, unsigned char a);
 extern int _ZN6Player12GetTalkStateEv(void *c);
+}
 
 int Player::IsOpeningDoorWithStar()
 {

--- a/src/_ZN6Player21St_OpeningWakeUp_InitEv.cpp
+++ b/src/_ZN6Player21St_OpeningWakeUp_InitEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player21St_OpeningWakeUp_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_OpeningWakeUp_Init()
 {

--- a/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
+++ b/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
@@ -3,9 +3,11 @@
 // @symbol _ZN6Player21St_OpeningWakeUp_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* thiz);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, int a, int b, int c, u32 d);
 extern void Player_AdvanceAnims(void* thiz);
+}
 
 int Player::St_OpeningWakeUp_Main()
 {

--- a/src/_ZN6Player24St_BowserEarthquake_InitEv.cpp
+++ b/src/_ZN6Player24St_BowserEarthquake_InitEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player24St_BowserEarthquake_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_BowserEarthquake_Init()
 {

--- a/src/_ZN6Player24St_BowserEarthquake_MainEv.cpp
+++ b/src/_ZN6Player24St_BowserEarthquake_MainEv.cpp
@@ -2,12 +2,14 @@
 // @symbol _ZN6Player24St_BowserEarthquake_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void _Z14ApproachLinearRiii(int* p, int value, int speed);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* state);
 extern void Player_AdvanceAnims(char* self);
 extern short data_02082214[];
 extern char data_ov002_0211013c[];
+}
 
 int Player::St_BowserEarthquake_Main()
 {

--- a/src/_ZN6Player24St_SlideKickRecover_InitEv.cpp
+++ b/src/_ZN6Player24St_SlideKickRecover_InitEv.cpp
@@ -3,10 +3,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int Player_ReleaseHeldActor(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int func_ov002_020e25f0(void*, int);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, void*);
+}
 
 int Player::St_SlideKickRecover_Init()
 {

--- a/src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp
+++ b/src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp
@@ -3,9 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern int _ZN6Player17SetNoControlStateEhih(void *c, unsigned char a, int b, unsigned char d);
 extern struct State data_ov002_0211022c;
+}
 
 int Player::TryExitWhiteDoorWithStar()
 {

--- a/src/_ZN6Player25St_GrabBowserTail_CleanupEv.cpp
+++ b/src/_ZN6Player25St_GrabBowserTail_CleanupEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player25St_GrabBowserTail_CleanupEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void func_ov002_020daa74(void *);
+}
 
 int Player::St_GrabBowserTail_Cleanup()
 {

--- a/src/_ZN6Player9IsOnShellEv.cpp
+++ b/src/_ZN6Player9IsOnShellEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern struct State data_ov002_02110304;
+}
 
 int Player::IsOnShell()
 {

--- a/src/_ZN6Rabbit13InitResourcesEv.cpp
+++ b/src/_ZN6Rabbit13InitResourcesEv.cpp
@@ -14,11 +14,14 @@ typedef unsigned char u8;
 
 typedef s32 Fix12;
 
+extern "C" {
 extern char data_ov085_021305d0;
 extern int data_0209caa0[];
 extern s8 data_0209f2f8;
 extern int data_0209e650;
+}
 
+extern "C" {
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
@@ -33,6 +36,7 @@ extern void* _ZN5Actor13ClosestPlayerEv(void* c);
 extern u32 RandomIntInternal(int* seed);
 extern u8 NumStars(void);
 extern void func_ov085_0212bc78(void* c, void* p);
+}
 
 int Rabbit::InitResources()
 {

--- a/src/_ZN6ShipUp13InitResourcesEv.cpp
+++ b/src/_ZN6ShipUp13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
@@ -14,6 +15,7 @@ extern void func_020393d4(int* p, int v);
 extern int IsStarCollected(int a, int b);
 extern void* _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern unsigned char data_0209f220;
+}
 
 int ShipUp::InitResources()
 {

--- a/src/_ZN6ShipUp8BehaviorEv.cpp
+++ b/src/_ZN6ShipUp8BehaviorEv.cpp
@@ -5,11 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void func_020393a4(int* p, int v);
 extern int _ZN5Actor13DistToCPlayerEv(void* a);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int e);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void* a);
 extern short data_02082214[];
+}
 
 int ShipUp::Behavior()
 {

--- a/src/_ZN6Snufit13InitResourcesEv.cpp
+++ b/src/_ZN6Snufit13InitResourcesEv.cpp
@@ -8,6 +8,7 @@ typedef struct { short x,y,z; } Vector3_16;
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
+extern "C" {
 extern SharedFilePtr data_ov065_0211d618;
 extern SharedFilePtr data_ov075_0211d610;
 extern SharedFilePtr data_ov065_0211d600;
@@ -20,6 +21,7 @@ extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern int func_ov065_0211691c(void* c, PMF* p);
+}
 
 int Snufit::InitResources()
 {

--- a/src/_ZN6Thwomp13InitResourcesEv.cpp
+++ b/src/_ZN6Thwomp13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Thwomp.h"
+extern "C" {
 extern int func_ov091_02133254(char*);
+}
 
 int Thwomp::InitResources()
 {

--- a/src/_ZN7HeaveHo6RenderEv.cpp
+++ b/src/_ZN7HeaveHo6RenderEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN7HeaveHo6RenderEv
 /* recovered: named members + shared header, real C++ method */
 #include "HeaveHo.h"
+extern "C" {
 extern int data_0209f32c;
+}
 
 struct Cls {
     virtual void method0();

--- a/src/_ZN7Message6UpdateEv.cpp
+++ b/src/_ZN7Message6UpdateEv.cpp
@@ -5,6 +5,7 @@ struct Struct6f0 {
     u16 unk4;
 };
 
+extern "C" {
 extern u8 data_0209d6bc;
 extern u8 data_0209f2d8;
 extern s8 data_0209d65c;
@@ -42,7 +43,9 @@ extern u8 data_0209d6b4;
 extern u8 data_0209d6d0;
 extern u8 data_0209d6c8;
 extern u8 data_0209d6c4;
+}
 
+extern "C" {
 extern void func_0201b6f8(int a);
 extern void* func_0201b7cc(void);
 extern void func_0201b388(int a);
@@ -50,6 +53,7 @@ extern void func_0201adfc(void);
 extern int IsButtonInputValid(void);
 extern void func_02012790(int a);
 extern void* _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int a, void* b, int c, int d, int e, int f, int g, int h, int i, int j);
+}
 
 class Message {
 public:

--- a/src/_ZN7Wiggler13InitResourcesEv.cpp
+++ b/src/_ZN7Wiggler13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Wiggler.h"
+extern "C" {
 extern int _ZN5Actor9TrackStarEjj(void *self, u32 a, u32 b);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *shared);
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void *shared);
@@ -19,9 +20,12 @@ extern void Vec3_Add(void *out, void *a, void *b);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, void *pos, int fix, u32 a, u32 b, u32 cc);
 extern void func_ov034_021125b8(void *c, int i);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *actor, int fix1, int fix2, void *v, int t);
+}
 
+extern "C" {
 extern s32 data_ov034_021138c4[];
 extern s32 data_020a0e68[];
+}
 
 int Wiggler::InitResources()
 {

--- a/src/_ZN8BigBully8BehaviorEv.cpp
+++ b/src/_ZN8BigBully8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBully.h"
+extern "C" {
 extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void* a, u16* p);
 extern int func_ov064_02116d1c(void* c);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void* c, void* clsn, unsigned f);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* c);
+}
 
 int BigBully::Behavior()
 {

--- a/src/_ZN8BookShot13InitResourcesEv.cpp
+++ b/src/_ZN8BookShot13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 struct Actor; struct Vector3; struct Vector3_16; struct BMD_File;
 typedef struct { int w[2]; } SharedFilePtr;
 
+extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* fp);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* fp);
 extern void LoadBlueCoinModel(void* c);
@@ -13,16 +14,21 @@ extern int _ZN11ShadowModel12InitCylinderEv(char* self);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* self, struct Actor* a, int r, int h, struct Vector3_16* rot, int f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, struct Actor* a, struct Vector3* pos, int r, int h, u32 f1, u32 f2);
+}
 
+extern "C" {
 extern SharedFilePtr data_ov020_02114aa0;
 extern SharedFilePtr data_ov020_02114ab8;
 extern SharedFilePtr data_ov020_02114aa8;
 extern SharedFilePtr data_ov020_02114ab0;
+}
 
 #define LDR(p) ((((long long)(int)(p))))
 
 struct M48 { int w[12]; };
+extern "C" {
 extern struct M48 data_02082128;
+}
 
 int BookShot::InitResources()
 {

--- a/src/_ZN8CapEnemy12Unk_02005d94Ev.cpp
+++ b/src/_ZN8CapEnemy12Unk_02005d94Ev.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CapEnemy.h"
+extern "C" {
 extern unsigned char data_0209f2d8;
+}
 
 void CapEnemy::Unk_02005d94()
 {

--- a/src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp
+++ b/src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CapEnemy.h"
+extern "C" {
 extern unsigned char data_0209f2d8;
 extern unsigned char *_ZN5Actor13ClosestPlayerEv(unsigned char *t);
+}
 
 int CapEnemy::DestroyIfCapNotNeeded()
 {

--- a/src/_ZN8CccArena13InitResourcesEv.cpp
+++ b/src/_ZN8CccArena13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "CccArena.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(int);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
@@ -12,8 +13,11 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(int);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,short,int);
 extern void func_020393d4(void*,void*);
 extern void func_020393c4(void*,void*);
+}
 
+extern "C" {
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
+}
 
 int CccArena::InitResources()
 {

--- a/src/_ZN8DockPole13InitResourcesEv.cpp
+++ b/src/_ZN8DockPole13InitResourcesEv.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "DockPole.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
+}
 
 int DockPole::InitResources()
 {

--- a/src/_ZN8Fireball13InitResourcesEv.cpp
+++ b/src/_ZN8Fireball13InitResourcesEv.cpp
@@ -2,10 +2,12 @@
 // @symbol _ZN8Fireball13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Fireball.h"
+extern "C" {
 extern int _ZN11ShadowModel12InitCylinderEv(void* thiz);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* actor, int fix12, int t, unsigned int a, unsigned int b);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thiz, void* actor, int fix12, int t, void* vec, int last);
 extern void _ZN12WithMeshClsn19StartDetectingWaterEv(void* thiz);
+}
 
 int Fireball::InitResources()
 {

--- a/src/_ZN8Goomboss8BehaviorEv.cpp
+++ b/src/_ZN8Goomboss8BehaviorEv.cpp
@@ -6,6 +6,7 @@
 #include "Goomboss.h"
 typedef long long s64;
 
+extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *thiz, void *clsn);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *thiz, void *clsn, unsigned int a);
 extern void _ZN12CylinderClsn5ClearEv(void *c);
@@ -14,8 +15,11 @@ extern void _ZN5Actor17HugeLandingDustAtER7Vector3b(void *thiz, Vector3 *v, int 
 extern void _ZN5Actor13LandingDustAtER7Vector3b(void *thiz, Vector3 *v, int b);
 extern void func_02012694(int a, void *p);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *thiz, Vector3 *v, int f);
+}
 
+extern "C" {
 extern char *data_0209f318;
+}
 
 int Goomboss::Behavior()
 {

--- a/src/_ZN8IceBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN8IceBlock16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "IceBlock.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov081_02128fd8[];
+}
 
 int IceBlock::CleanupResources()
 {

--- a/src/_ZN8IceSheet13InitResourcesEv.cpp
+++ b/src/_ZN8IceSheet13InitResourcesEv.cpp
@@ -5,12 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
+}
 
 int IceSheet::InitResources()
 {

--- a/src/_ZN8IceSheet16CleanupResourcesEv.cpp
+++ b/src/_ZN8IceSheet16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "IceSheet.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int IceSheet::CleanupResources()
 {

--- a/src/_ZN8Moneybag8BehaviorEv.cpp
+++ b/src/_ZN8Moneybag8BehaviorEv.cpp
@@ -4,9 +4,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Moneybag.h"
+extern "C" {
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(char* c, char* clsn);
 extern int _ZNK12WithMeshClsn14GetResultFlag1Ev(char* clsn);
 extern int _ZNK12WithMeshClsn12TouchesWaterEv(char* clsn);
+}
 
 int Moneybag::Behavior()
 {

--- a/src/_ZN8MugenBgm13InitResourcesEv.cpp
+++ b/src/_ZN8MugenBgm13InitResourcesEv.cpp
@@ -19,11 +19,15 @@ struct Obj {
     void *unkE0;
 };
 
+extern "C" {
 extern void *_Znwj(int sz);
+}
 
+extern "C" {
 extern unsigned char data_0209f2d8;
 extern char data_ov002_0211094c;
 extern char data_ov085_0213074c;
+}
 
 int MugenBgm::InitResources()
 {

--- a/src/_ZN8MugenBgm8BehaviorEv.cpp
+++ b/src/_ZN8MugenBgm8BehaviorEv.cpp
@@ -19,6 +19,7 @@ typedef struct
 {
   char pad[0x50];
 } RaycastGround;
+extern "C" {
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void *c, void *cyl);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *cyl);
 extern void _ZN13RaycastGroundC1Ev(RaycastGround *rc);
@@ -30,6 +31,7 @@ extern void Matrix4x3_FromTranslation(Mtx43 *m, s32 x, s32 y, s32 z);
 extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(void *m, s32 x, s32 y, s32 z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, s32 x, s32 y, s32 z);
 extern Mtx43 data_020a0e68;
+}
 
 int MugenBgm::Behavior()
 {

--- a/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
+++ b/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
@@ -1,9 +1,13 @@
 //cpp
 #include "types.h"
 struct SomeGlobal { char pad[4]; void* p; };
+extern "C" {
 extern SomeGlobal* data_0209ee74;
+}
 
+extern "C" {
 extern void func_02049d60(void* x);
+}
 
 namespace Particle {
     struct System {

--- a/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
+++ b/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
@@ -8,11 +8,13 @@ struct Actor {
     void UpdatePos(CylinderClsn* c);
 };
 
+extern "C" {
 extern void Matrix4x3_FromRotationY(Matrix4x3* m, int angle);
 extern void MulVec3Mat4x3(Vector3* v, Matrix4x3* m, Vector3* dst);
 extern void Vec3_Add(Vector3* out, Vector3* a, Vector3* b);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void func_ov002_020ee5d0(unsigned char* self, int arg);
+}
 
 struct RaycastLine {
     RaycastLine();
@@ -34,7 +36,9 @@ struct PlatformVT {
     virtual void v28(); virtual void v29(); virtual void v30(); virtual void v31();
 };
 
+extern "C" {
 extern Matrix4x3 data_020a0e68;
+}
 
 struct Platform {
     char _0[0x5c];

--- a/src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp
+++ b/src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN8Platform21UpdateModelPosAndRotYEv
 /* recovered: named members + shared header, real C++ method */
 #include "Platform.h"
+extern "C" {
 extern void Matrix4x3_FromRotationY(void *, int);
+}
 
 void Platform::UpdateModelPosAndRotY()
 {

--- a/src/_ZN8PoleLift13InitResourcesEv.cpp
+++ b/src/_ZN8PoleLift13InitResourcesEv.cpp
@@ -6,10 +6,12 @@
 #include "PoleLift.h"
 #include "MeshColliderBase.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
+}
 
 int PoleLift::InitResources()
 {

--- a/src/_ZN8PoleLift16CleanupResourcesEv.cpp
+++ b/src/_ZN8PoleLift16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "PoleLift.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int PoleLift::CleanupResources()
 {

--- a/src/_ZN8ShipWing16CleanupResourcesEv.cpp
+++ b/src/_ZN8ShipWing16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "ShipWing.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov036_0211408c[];
+}
 
 int ShipWing::CleanupResources()
 {

--- a/src/_ZN8SignPost16CleanupResourcesEv.cpp
+++ b/src/_ZN8SignPost16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "SignPost.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int SignPost::CleanupResources()
 {

--- a/src/_ZN8Squasher16CleanupResourcesEv.cpp
+++ b/src/_ZN8Squasher16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "Squasher.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int Squasher::CleanupResources()
 {

--- a/src/_ZN8WallSign13InitResourcesEv.cpp
+++ b/src/_ZN8WallSign13InitResourcesEv.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "WallSign.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, void* file, int a, int b);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(char* self);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, char* actor, const struct Vector3* pos, int a, unsigned int b, unsigned int c, unsigned int d);
+}
 
 int WallSign::InitResources()
 {

--- a/src/_ZN8YoshiEgg16CleanupResourcesEv.cpp
+++ b/src/_ZN8YoshiEgg16CleanupResourcesEv.cpp
@@ -3,10 +3,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "YoshiEgg.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern int func_ov002_020ec628(void*);
 extern void UnloadBlueCoinModel(void*);
 extern char data_ov002_0210e6b0;
 extern char data_ov002_0210eb78;
+}
 
 int YoshiEgg::CleanupResources()
 {

--- a/src/_ZN9ArrowLift8BehaviorEv.cpp
+++ b/src/_ZN9ArrowLift8BehaviorEv.cpp
@@ -5,9 +5,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ArrowLift.h"
 typedef short s16;
+extern "C" {
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN12CylinderClsn5ClearEv(void* self);
 extern void _ZN12CylinderClsn6UpdateEv(void* self);
+}
 
 int ArrowLift::Behavior()
 {

--- a/src/_ZN9CameraTag8BehaviorEv.cpp
+++ b/src/_ZN9CameraTag8BehaviorEv.cpp
@@ -7,11 +7,13 @@
 #include "CameraTag.h"
 struct Vec3 { Fix12i x, y, z; };
 
+extern "C" {
 extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
 extern void Vec3_RotateYAndTranslate(struct Vec3* out, void* m, s16 ang, struct Vec3* in);
 extern u8 data_0209f250;
 extern char* data_0209f394[];
 extern char data_020a0ebc;
+}
 
 int CameraTag::Behavior()
 {

--- a/src/_ZN9DorrieCap13InitResourcesEv.cpp
+++ b/src/_ZN9DorrieCap13InitResourcesEv.cpp
@@ -2,11 +2,15 @@
 // @symbol _ZN9DorrieCap13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "DorrieCap.h"
+extern "C" {
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void func_ov001_020ab228(void *a, void *b, int c, int d, int e);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *clsn, void *actor, int a, int b, unsigned int c, unsigned int d);
+}
 struct G { int w[2]; };
+extern "C" {
 extern struct G data_ov002_0210d9c0;
+}
 
 int DorrieCap::InitResources()
 {

--- a/src/_ZN9HugeCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9HugeCover16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "HugeCover.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int HugeCover::CleanupResources()
 {

--- a/src/_ZN9HugeCover8BehaviorEv.cpp
+++ b/src/_ZN9HugeCover8BehaviorEv.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN9HugeCover8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "HugeCover.h"
+extern "C" {
 extern void _ZN9Animation7AdvanceEv(void *);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
+}
 
 int HugeCover::Behavior()
 {

--- a/src/_ZN9KoopaFlag13InitResourcesEv.cpp
+++ b/src/_ZN9KoopaFlag13InitResourcesEv.cpp
@@ -24,8 +24,10 @@ struct MovingCylinderClsn {
     void Init(Actor* a, Fix12 b, Fix12 c, unsigned int d, unsigned int e);
 };
 
+extern "C" {
 extern SharedFilePtr data_ov062_0211e0d4;
 extern SharedFilePtr data_ov062_0211e0dc;
+}
 
 int KoopaFlag::InitResources()
 {

--- a/src/_ZN9KoopaFlag8BehaviorEv.cpp
+++ b/src/_ZN9KoopaFlag8BehaviorEv.cpp
@@ -5,12 +5,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "KoopaFlag.h"
+extern "C" {
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int d, int e);
 extern void _ZN9Animation7AdvanceEv(void *a);
 extern void _ZN12CylinderClsn5ClearEv(void *c);
 extern void _ZN12CylinderClsn6UpdateEv(void *c);
 extern char data_0209d4c8[];
+}
 
 int KoopaFlag::Behavior()
 {

--- a/src/_ZN9MontyMole13InitResourcesEv.cpp
+++ b/src/_ZN9MontyMole13InitResourcesEv.cpp
@@ -9,6 +9,7 @@ typedef struct { int w[2]; } SharedFilePtr;
 typedef struct BMD_File BMD_File;
 typedef struct BCA_File BCA_File;
 typedef struct Actor Actor;
+extern "C" {
 extern SharedFilePtr* data_ov080_0212766c[];
 extern SharedFilePtr data_ov002_0210d9d8;
 extern SharedFilePtr data_ov080_021283c8;
@@ -18,6 +19,7 @@ extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, BCA_File* f, int a, Fix12 b, unsigned int e);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+}
 
 int MontyMole::InitResources()
 {

--- a/src/_ZN9PowerStar13AddStarMarkerEv.cpp
+++ b/src/_ZN9PowerStar13AddStarMarkerEv.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PowerStar.h"
+extern "C" {
 extern void SetStarMarker(int i, int v1, int v2);
 extern int IsStarCollectedInCurLevel(int starID);
 extern int data_0209f40c[];
 extern u8 data_0209f208;
+}
 
 struct Bits {
     u16 b0 : 1;

--- a/src/_ZN9PushBlock13InitResourcesEv.cpp
+++ b/src/_ZN9PushBlock13InitResourcesEv.cpp
@@ -7,6 +7,7 @@
 #include "PushBlock.h"
 typedef int Fix12;
 
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -18,9 +19,12 @@ extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, const
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
 extern void _ZN13RaycastGroundD1Ev(void *self);
+}
 
+extern "C" {
 extern void *data_ov002_0210d9d0[];
 extern void *data_ov002_0210d9b0[];
+}
 
 int PushBlock::InitResources()
 {

--- a/src/_ZN9PushBlock8BehaviorEv.cpp
+++ b/src/_ZN9PushBlock8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PushBlock.h"
+extern "C" {
 extern void _ZN12CylinderClsn5ClearEv(char* t);
 extern void _ZN12CylinderClsn6UpdateEv(char* t);
 extern void _ZN5Actor13SmallPoofDustEv(char* c);
 extern void _ZN9ActorBase18MarkForDestructionEv(char* c);
+}
 
 int PushBlock::Behavior()
 {

--- a/src/_ZN9RabbitKey6RenderEv.cpp
+++ b/src/_ZN9RabbitKey6RenderEv.cpp
@@ -27,7 +27,9 @@ struct Obj {
     void* unk188;         /* 0x188 */
 };
 
+extern "C" {
 extern void func_ov085_0212d2b8(struct Obj* self);
+}
 
 int RabbitKey::Render()
 {

--- a/src/_ZN9SeesawBob13InitResourcesEv.cpp
+++ b/src/_ZN9SeesawBob13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SeesawBob.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(int);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
@@ -11,8 +12,11 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(int);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,short,int);
 extern void func_020393d4(void*,void*);
 extern void func_020393c4(void*,void*);
+}
 
+extern "C" {
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
+}
 
 int SeesawBob::InitResources()
 {

--- a/src/_ZN9ShipWater16CleanupResourcesEv.cpp
+++ b/src/_ZN9ShipWater16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "ShipWater.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int ShipWater::CleanupResources()
 {

--- a/src/_ZN9ShipWater8BehaviorEv.cpp
+++ b/src/_ZN9ShipWater8BehaviorEv.cpp
@@ -2,11 +2,13 @@
 // @symbol _ZN9ShipWater8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWater.h"
+extern "C" {
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char* prev);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int e);
 extern int _ZN9Animation7AdvanceEv(char* t);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(char* t);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(char* t);
+}
 
 int ShipWater::Behavior()
 {

--- a/src/_ZN9Submarine13InitResourcesEv.cpp
+++ b/src/_ZN9Submarine13InitResourcesEv.cpp
@@ -9,17 +9,21 @@ struct BMD_File;
 struct BTA_File;
 struct BCA_File;
 
+extern "C" {
 extern struct BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thisp, struct BMD_File *, int, int);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(struct BMD_File &, struct BTA_File &);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *thisp, struct BTA_File &, int, int, unsigned int);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisp, struct BCA_File *, int, int, unsigned int);
+}
 
 struct FilePtr4 { int a; void *file; };
+extern "C" {
 extern struct FilePtr4 data_ov026_02113f0c;
 extern struct FilePtr4 data_ov026_02113f04;
 extern struct BTA_File data_ov026_02112f40;
+}
 
 int Submarine::InitResources()
 {

--- a/src/_ZN9TinyCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9TinyCover16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "TinyCover.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int data_ov033_021124f0[];
+}
 
 int TinyCover::CleanupResources()
 {

--- a/src/_ZN9TowerStep16CleanupResourcesEv.cpp
+++ b/src/_ZN9TowerStep16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "TowerStep.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int TowerStep::CleanupResources()
 {

--- a/src/_ZN9TowerStep8BehaviorEv.cpp
+++ b/src/_ZN9TowerStep8BehaviorEv.cpp
@@ -2,12 +2,14 @@
 // @symbol _ZN9TowerStep8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "TowerStep.h"
+extern "C" {
 extern int DecIfAbove0_Byte(void*);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned,unsigned,unsigned,void*,unsigned);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int func_020393a4(int*,int);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*,int,int);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
+}
 
 int TowerStep::Behavior()
 {

--- a/src/_ZN9WaterBomb13InitResourcesEv.cpp
+++ b/src/_ZN9WaterBomb13InitResourcesEv.cpp
@@ -24,8 +24,10 @@ struct WithMeshClsn {
     void Init(Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
 };
 
+extern "C" {
 extern SharedFilePtr data_ov002_0210da38;
 extern SharedFilePtr data_ov098_0213c91c;
+}
 
 struct Obj {
     char p0[8];

--- a/src/_ZN9WaterRing13InitResourcesEv.cpp
+++ b/src/_ZN9WaterRing13InitResourcesEv.cpp
@@ -10,14 +10,18 @@ struct BMD_File;
 struct BTA_File;
 
 
+extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(struct BMD_File* f, struct BTA_File* b);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(char* self, struct BTA_File* b, int a, int fix, u32 f);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, struct Actor* a, struct Vector3* v, int r, int h, u32 f1, u32 f2);
+}
 
+extern "C" {
 extern char data_ov002_0210da10[];
 extern int data_ov064_0211c3d0[3];
+}
 
 int WaterRing::InitResources()
 {

--- a/src/__sinit_ov002_021071f4.c
+++ b/src/__sinit_ov002_021071f4.c
@@ -22,13 +22,19 @@ struct Dest {
     Pair p4;   // 0x28
     Pair p5;   // 0x30
 };
-extern struct Dest data_ov002_021097bc;
+extern struct Dest data_ov002_0210af2c;
 
+/* The destination is data_ov002_0210af2c, not data_ov002_021097bc. The ROM
+   materialises the base into r5 from the literal pool and stores through
+   [r5, #off]; those stores carry no relocation, so only the single pool word
+   differed -- and match.py wildcards relocated words, so the per-function gate
+   passed this happily. Only the full ROM link sees it, and it could not see it
+   before either, because .init functions were not enrolled at all. */
 void __sinit_ov002_021071f4(void) {
-    data_ov002_021097bc.p0 = data_ov002_0210aed0;
-    data_ov002_021097bc.p1 = data_ov002_0210aee8;
-    data_ov002_021097bc.p2 = data_ov002_0210aed8;
-    data_ov002_021097bc.p3 = data_ov002_0210aef8;
-    data_ov002_021097bc.p4 = data_ov002_0210aef0;
-    data_ov002_021097bc.p5 = data_ov002_0210aee0;
+    data_ov002_0210af2c.p0 = data_ov002_0210aed0;
+    data_ov002_0210af2c.p1 = data_ov002_0210aee8;
+    data_ov002_0210af2c.p2 = data_ov002_0210aed8;
+    data_ov002_0210af2c.p3 = data_ov002_0210aef8;
+    data_ov002_0210af2c.p4 = data_ov002_0210aef0;
+    data_ov002_0210af2c.p5 = data_ov002_0210aee0;
 }

--- a/src/actors/BooCage/_ZN7BooCage13InitResourcesEv.cpp
+++ b/src/actors/BooCage/_ZN7BooCage13InitResourcesEv.cpp
@@ -5,12 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BooCage.h"
 typedef int Fix12;
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *actor, Fix12 a, int b, unsigned int c, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *actor, Fix12 a, int b, void *v, int c);
 extern void *data_ov063_0211edec;
+}
 
 int BooCage::InitResources()
 {

--- a/src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MadPiano.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, void *, int, int);
 extern void _ZN11ShadowModel10InitCuboidEv(void *);
@@ -15,6 +16,7 @@ extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, void *, void *, int, short, void *);
 extern void func_ov063_0211d5f4(char *);
+}
 
 
 int MadPiano::InitResources()

--- a/src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "MadPiano.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int G0[];
+}
 
 int MadPiano::CleanupResources()
 {

--- a/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
+++ b/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
@@ -9,7 +9,9 @@ void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 void Matrix4x3_ApplyInPlaceToScale(void* m, Fix12i x, Fix12i y, Fix12i z);
 void Matrix4x3_ApplyInPlaceToRotationX(void* m, short ang);
 void _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(void* thiz, void* mtx, void* vec);
+extern "C" {
 extern int data_020a0e68[];
+}
 
 void FaderWipe::AdvanceFade()
 {

--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -89,7 +89,13 @@ def classify(job):
     if r.returncode != 0 or not obj.is_file():
         return rel, name, "compile failed"
 
-    if sec != ".text":
+    # `.init` is buildable now. mwccarm always emits compiled code into `.text`,
+    # whatever the ROM's layout calls it, and dsd's linker script selects these by
+    # name -- `File.o(.init)` -- so the names never matched and ~300 functions were
+    # unreachable. rombuild.retarget_text_section renames the section header in the
+    # object after compiling, in place and without moving a byte. Any OTHER section
+    # is still a rejection: nothing renames those, so the lcf would not find them.
+    if sec not in (".text", ".init"):
         return rel, name, f"lives in {sec}, not .text"
 
     try:

--- a/tools/extern_c_wrap.py
+++ b/tools/extern_c_wrap.py
@@ -1,0 +1,149 @@
+"""Give ROM symbol declarations C linkage in C++ translation units.
+
+A C++ TU that declares a ROM symbol like this:
+
+    extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
+
+gets it mangled *again*, because the declaration has C++ linkage. mwccarm emits a
+reference to `_Z35_ZN5Model8LoadFileER13SharedFilePtrPv`, which exists nowhere. Plain
+names suffer the same way: `extern void Deallocate(void *)` becomes `_Z10DeallocatePv`.
+
+The file still byte-matches, which is why this survives. `match.py` compares the
+relocated word as a wildcard, so the *name* a call resolves to never enters the byte
+verdict -- only the full ROM link cares, and until a function is enrolled the link
+never sees it either. So these read as finished work while referencing symbols that
+do not exist.
+
+`eligible.py` counts them as `unresolvable` and refuses to enroll them, which is the
+visible symptom: 1,454 of them at the time of writing, the largest single blocker to
+building more of the ROM from source.
+
+The fix is linkage, not naming -- the identifiers in the source are already the exact
+symbols the ROM uses. Contiguous runs of file-scope `extern` declarations are wrapped
+in `extern "C" { ... }`.
+
+Every file is byte-verified after the edit and reverted if it stops reproducing, so a
+declaration that genuinely wanted C++ linkage cannot be broken silently.
+
+Usage:
+    python tools/extern_c_wrap.py                 # report only
+    python tools/extern_c_wrap.py --apply
+    python tools/extern_c_wrap.py --apply -j 16
+"""
+import argparse
+import concurrent.futures
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import match as M          # noqa: E402
+import modules as MOD      # noqa: E402
+from enroll import candidates  # noqa: E402
+
+DECL = re.compile(r"^extern\s+[^;{]*;\s*$")
+
+
+def is_cpp(path, text):
+    return path.suffix == ".cpp" or text.startswith("//cpp")
+
+
+def wrap(text):
+    """Wrap contiguous file-scope `extern ...;` runs in extern "C". Returns None if
+    nothing to do."""
+    lines = text.splitlines()
+    out, run, depth, changed = [], [], 0, False
+
+    def flush():
+        nonlocal changed
+        if run:
+            out.append('extern "C" {')
+            out.extend(run)
+            out.append("}")
+            run.clear()
+            changed = True
+
+    for ln in lines:
+        s = ln.strip()
+        # Only at file scope, and never inside an existing extern "C" block.
+        if depth == 0 and DECL.match(s):
+            run.append(ln)
+            continue
+        flush()
+        out.append(ln)
+        depth += ln.count("{") - ln.count("}")
+    flush()
+    return "\n".join(out) + "\n" if changed else None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    args = ap.parse_args()
+
+    info = {}
+    for (d, name, rel, addr, size, sec) in candidates()[0]:
+        info[rel] = (name, addr, size, d)
+    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+
+    targets = []
+    for f in sorted((REPO / "src").rglob("*")):
+        if not f.is_file() or f.suffix not in (".c", ".cpp"):
+            continue
+        t = f.read_text(encoding="utf-8", errors="ignore")
+        if not is_cpp(f, t) or 'extern "C"' in t:
+            continue
+        if wrap(t):
+            targets.append(f)
+
+    print(f"C++ TUs whose ROM declarations lack C linkage: {len(targets)}")
+    if not args.apply:
+        print("\n(report only -- pass --apply to wrap and byte-verify)")
+        return 0
+
+    def one(f):
+        rel = f.relative_to(REPO).as_posix()
+        original = f.read_text(encoding="utf-8", errors="ignore")
+        new = wrap(original)
+        if new is None:
+            return rel, "unchanged"
+        f.write_text(new, encoding="utf-8", newline="\n")
+        if rel not in info:
+            return rel, "wrapped (not enrolled, unverified)"
+        name, addr, size, d = info[rel]
+        label = d.relative_to(REPO / "config").as_posix()
+        label = "arm9" if label == "arm9" else label.split("/")[-1]
+        flags = M.DEFAULT_FLAGS.replace("-lang c99", "-lang c++")
+        tgt = (M.target_bytes(addr, size) if label == "arm9"
+               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
+        for v in M.SWEEP:
+            obj = M.compile_c(f, v, flags)
+            if obj is None:
+                continue
+            code, rl = M.extract_func(obj, name)
+            if code is None:
+                continue
+            ok, _ = M.compare(tgt, code, rl, verbose=False)
+            if ok:
+                return rel, "wrapped"
+        f.write_text(original, encoding="utf-8", newline="\n")
+        return rel, "reverted (stopped matching)"
+
+    counts = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rel, verdict in ex.map(one, targets):
+            counts[verdict] = counts.get(verdict, 0) + 1
+            if verdict.startswith("reverted"):
+                print(f"  {verdict}: {rel}")
+    print()
+    for k, v in sorted(counts.items(), key=lambda kv: -kv[1]):
+        print(f"  {v:5d}  {k}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/meshclsn_methods.py
+++ b/tools/meshclsn_methods.py
@@ -1,0 +1,228 @@
+"""Call MeshColliderBase's methods by name instead of through their mangled symbols.
+
+include/MeshColliderBase.h declares the real class, but 177 call sites still reach it
+through hand-written externs of the mangled names:
+
+    extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
+    ...
+    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
+        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
+
+becomes
+
+    #include "MeshColliderBase.h"
+    ...
+    if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+        ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
+
+Two shapes, because the class has two kinds of member here.
+
+  * The instance methods -- Enable/Disable/IsEnabled -- are called with the collider
+    as the first argument, which is the `this` the mangled name implies.
+
+  * UpdatePosAndAngs and friends are STATIC, and call sites never call them: they take
+    the address and hand it to func_020393d4 to be stored as a BeforeClsn callback.
+    Those are declared `extern int NAME;` -- as a variable, not a function -- and used
+    as `&NAME`, so they become `&MeshColliderBase::UpdatePosWithTransform`.
+
+This is byte-neutral: it changes which spelling produces the symbol, not the symbol.
+Every file is verified after the edit and reverted if it stops reproducing.
+
+Supersedes the hand-written attempt in #1033, which conflicted with #1032 after both
+edited the same lines -- and covered 100 files where the tree now has 177.
+
+Usage:
+    python tools/meshclsn_methods.py                # report only
+    python tools/meshclsn_methods.py --apply
+"""
+import argparse
+import concurrent.futures
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import match as M          # noqa: E402
+import modules as MOD      # noqa: E402
+from enroll import candidates  # noqa: E402
+
+# mangled symbol -> method name, for the instance methods.
+INSTANCE = {
+    "_ZN16MeshColliderBase9IsEnabledEv": "IsEnabled",
+    "_ZN16MeshColliderBase7DisableEv": "Disable",
+    "_ZN16MeshColliderBase6EnableEP5Actor": "Enable",
+}
+# mangled symbol -> method name, for the statics used as callback addresses.
+STATIC = {
+    "_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_":
+        "UpdatePosAndAngs",
+    "_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_":
+        "UpdatePosWithVelocity",
+    "_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_":
+        "UpdatePosWithTransform",
+    "_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_":
+        "UpdateAngsWithAngularVelY",
+}
+
+
+def split_args(s):
+    """Split a call's argument text on top-level commas."""
+    out, depth, cur = [], 0, ""
+    for ch in s:
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth -= 1
+        if ch == "," and depth == 0:
+            out.append(cur.strip())
+            cur = ""
+        else:
+            cur += ch
+    if cur.strip():
+        out.append(cur.strip())
+    return out
+
+
+def call_text(text, sym):
+    """Find `sym(...)` and return (start, end, args) for each, innermost-safe."""
+    hits = []
+    for m in re.finditer(r"\b" + re.escape(sym) + r"\s*\(", text):
+        i = m.end() - 1
+        depth = 0
+        for j in range(i, len(text)):
+            if text[j] == "(":
+                depth += 1
+            elif text[j] == ")":
+                depth -= 1
+                if depth == 0:
+                    hits.append((m.start(), j + 1, text[i + 1:j]))
+                    break
+    return hits
+
+
+def transform(text):
+    """Return the rewritten text, or None if nothing applies."""
+    changed = False
+
+    # Statics first: they are declared as variables and used via &NAME.
+    for sym, method in STATIC.items():
+        if sym not in text:
+            continue
+        # Declared either as a variable (`extern T SYM;`) or as a nullary function
+        # (`extern T SYM();`), and inside an extern "C" block the `extern` keyword is
+        # usually absent. All three shapes have to go, or the rewritten name lands in
+        # a declaration and mwccarm rejects it as an illegal storage class.
+        text = re.sub(r"^[ \t]*(?:extern\s+)?[A-Za-z_][^;{}()]*\b" + re.escape(sym)
+                      + r"\s*(?:\([^;]*\))?\s*;[ \t]*\n?", "", text, flags=re.M)
+        text = re.sub(r"\b" + re.escape(sym) + r"\b",
+                      f"MeshColliderBase::{method}", text)
+        changed = True
+
+    # Instance methods: first argument is the `this` the mangled name implies.
+    for sym, method in INSTANCE.items():
+        if sym not in text:
+            continue
+        # Same shapes as the statics: with or without `extern`, since inside an
+        # extern "C" block the keyword is usually omitted. Leaving one behind clashes
+        # with the header's declaration ("was declared as ... now declared as
+        # extern "C" ...") and the file stops compiling.
+        text = re.sub(r"^[ \t]*(?:extern\s+)?[A-Za-z_][^;{}()]*\b" + re.escape(sym)
+                      + r"\s*\([^;]*\)\s*;[ \t]*\n?", "", text, flags=re.M)
+        while True:
+            hits = call_text(text, sym)
+            if not hits:
+                break
+            start, end, argtext = hits[0]
+            args = split_args(argtext)
+            if not args:
+                break
+            recv, rest = args[0], args[1:]
+            call = f"((MeshColliderBase *)({recv}))->{method}({', '.join(rest)})"
+            text = text[:start] + call + text[end:]
+            changed = True
+
+    if not changed:
+        return None
+    # An emptied `extern "C" { }` block is noise; drop it.
+    text = re.sub(r'extern "C" \{\s*\n\}\n', "", text)
+    if '#include "MeshColliderBase.h"' not in text:
+        m = re.search(r'^#include "[^"]+"\s*$', text, re.M)
+        if m:
+            text = text[:m.end()] + '\n#include "MeshColliderBase.h"' + text[m.end():]
+        else:
+            text = '#include "MeshColliderBase.h"\n' + text
+    return text
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    args = ap.parse_args()
+
+    info = {}
+    for (d, name, rel, addr, size, sec) in candidates()[0]:
+        info[rel] = (name, addr, size, d)
+    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+
+    syms = list(INSTANCE) + list(STATIC)
+    targets = []
+    for f in sorted((REPO / "src").rglob("*")):
+        if not f.is_file() or f.suffix not in (".c", ".cpp"):
+            continue
+        t = f.read_text(encoding="utf-8", errors="ignore")
+        if any(s in t for s in syms) and transform(t):
+            targets.append(f)
+
+    print(f"files calling MeshColliderBase through mangled names: {len(targets)}")
+    if not args.apply:
+        print("\n(report only -- pass --apply to rewrite and byte-verify)")
+        return 0
+
+    def one(f):
+        rel = f.relative_to(REPO).as_posix()
+        original = f.read_text(encoding="utf-8", errors="ignore")
+        new = transform(original)
+        if new is None:
+            return rel, "unchanged"
+        f.write_text(new, encoding="utf-8", newline="\n")
+        if rel not in info:
+            return rel, "rewritten (not enrolled, unverified)"
+        name, addr, size, d = info[rel]
+        label = d.relative_to(REPO / "config").as_posix()
+        label = "arm9" if label == "arm9" else label.split("/")[-1]
+        flags = M.DEFAULT_FLAGS
+        if new.startswith("//cpp") or f.suffix == ".cpp":
+            flags = flags.replace("-lang c99", "-lang c++")
+        tgt = (M.target_bytes(addr, size) if label == "arm9"
+               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
+        for v in M.SWEEP:
+            obj = M.compile_c(f, v, flags)
+            if obj is None:
+                continue
+            code, rl = M.extract_func(obj, name)
+            if code is None:
+                continue
+            ok, _ = M.compare(tgt, code, rl, verbose=False)
+            if ok:
+                return rel, "rewritten"
+        f.write_text(original, encoding="utf-8", newline="\n")
+        return rel, "reverted (stopped matching)"
+
+    counts = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rel, verdict in ex.map(one, targets):
+            counts[verdict] = counts.get(verdict, 0) + 1
+            if verdict.startswith("reverted"):
+                print(f"  {verdict}: {rel}")
+    print()
+    for k, v in sorted(counts.items(), key=lambda kv: -kv[1]):
+        print(f"  {v:5d}  {k}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -206,7 +206,59 @@ def enrolled(config_root=CONFIG_ROOT):
     return checked
 
 
-def compile_one(rel, vers=None, cache=None):
+def init_section_sources():
+    """{rel} for enrolled sources whose function lives in .init rather than .text.
+
+    dsd's linker script selects each object's code by section name -- `File.o(.init)`
+    for these -- but mwccarm always emits compiled code into `.text`, whatever the
+    ROM's own layout calls it. The names never match, so ~300 otherwise-eligible
+    functions, almost all __sinit_* static initialisers, could not be built from
+    source at all.
+    """
+    import enroll as E
+    cands, _ = E.candidates()
+    return {rel for (_d, _name, rel, _addr, _size, sec) in cands if sec == ".init"}
+
+
+def retarget_text_section(obj, section=".init"):
+    """Rename an object's `.text` section header to `section`, in place.
+
+    Only the section-header string is touched. `.text` and `.init` are both five
+    bytes, so the entry is overwritten where it sits and nothing in the file moves.
+    That matters: rewriting the ELF would risk perturbing the very bytes this build
+    exists to compare against the ROM.
+
+    Safe because mwccarm's .shstrtab stores `.text` as its own entry rather than as a
+    suffix of `.rela.text` -- they sit at distinct offsets -- so the overwrite cannot
+    corrupt the relocation section's name. `.rela.text` keeps its own name and finds
+    its target through sh_info, a section index, which is unaffected.
+
+    Idempotent: an object already carrying `section` is left alone, so a cache entry
+    written before this existed gets corrected rather than served stale.
+    """
+    import io
+    from elftools.elf.elffile import ELFFile
+
+    raw = bytearray(obj.read_bytes())
+    elf = ELFFile(io.BytesIO(bytes(raw)))
+    names = [s.name for s in elf.iter_sections()]
+    if section in names:
+        return False                          # already retargeted
+    base = elf.get_section(elf["e_shstrndx"]).header["sh_offset"]
+    want = b".text\x00"
+    for s in elf.iter_sections():
+        if s.name != ".text":
+            continue
+        off = base + s.header["sh_name"]
+        if bytes(raw[off:off + len(want)]) != want:
+            raise RuntimeError(f"{obj}: .shstrtab entry at {off} is not '.text'")
+        raw[off:off + len(section)] = section.encode()
+        obj.write_bytes(bytes(raw))
+        return True
+    return False
+
+
+def compile_one(rel, vers=None, cache=None, init_srcs=None):
     """Compile one enrolled source file to the object path dsd's objects.txt names.
 
     Returns (rel, error-or-None, outcome), where outcome is how the object was
@@ -232,6 +284,8 @@ def compile_one(rel, vers=None, cache=None):
     if key is not None:
         deps = cache.manifest(key)
         if deps is not None and cache.fetch(cache.object_key(key, deps), obj):
+            if init_srcs and rel in init_srcs:
+                retarget_text_section(obj)
             return rel, None, "hit"
 
     # -MD makes mwccarm write out the headers it actually read, which is what lets the
@@ -257,6 +311,10 @@ def compile_one(rel, vers=None, cache=None):
         if r.returncode != 0 or not obj.is_file():
             detail = "\n".join(s for s in (r.stdout.strip(), r.stderr.strip()) if s)
             return rel, detail[:400], "error"
+        # Before caching, so the stored object already carries the right section name
+        # and a later hit needs no fixup.
+        if init_srcs and rel in init_srcs:
+            retarget_text_section(obj)
         if key is None:
             return rel, None, "miss"
         deps = cache.deps_from(scratch)
@@ -338,13 +396,15 @@ def main():
         report["alternateToolchainFiles"] = n_alt
         cache = RBK.ObjectCache(args.cache_dir or (BUILD / "objcache"), REPO,
                                 enabled=not args.no_cache)
+        init_srcs = init_section_sources()
         print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
               + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
         failures = []
         outcomes = {}
         if srcs:
             with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
-                for rel, err, outcome in ex.map(lambda s: compile_one(s, vers, cache), srcs):
+                for rel, err, outcome in ex.map(
+                        lambda s: compile_one(s, vers, cache, init_srcs), srcs):
                     outcomes[outcome] = outcomes.get(outcome, 0) + 1
                     if err:
                         failures.append((rel, err))


### PR DESCRIPTION
**Stacked on #1034.** 88 more functions link from source (9,461 → 9,549; 72.89% → **73.61%**
of code bytes), by fixing 255 C++ translation units that referenced symbols which do not
exist.

## The class

A C++ TU declaring a ROM symbol without C linkage gets it mangled **again**:

```cpp
extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
```

mwccarm emits a reference to `_Z35_ZN5Model8LoadFileER13SharedFilePtrPv`, which exists
nowhere. Plain names go the same way — `extern void Deallocate(void *)` becomes
`_Z10DeallocatePv`, which is why the survey showed that mapping 36 times.

**The fix is linkage, not naming.** The identifiers in the source are already the exact
symbols the ROM uses; contiguous runs of file-scope `extern` declarations are wrapped in
`extern "C"`.

## Why it survived

`match.py` compares the relocated word as a **wildcard**, so which symbol a call resolves to
never enters the byte verdict — every one of these files byte-matched. The ROM link *would*
catch it, but `eligible.py` refuses to enroll a file with unresolvable references, so the
link never saw them either.

The two gates cover for each other and leave the class invisible: 255 files reading as
finished while referencing symbols that aren't there.

## The tool

`tools/extern_c_wrap.py` does the transform and **byte-verifies every file**, reverting any
that stops reproducing — so a declaration that genuinely wanted C++ linkage can't be broken
silently. **253 wrapped and verified, 0 reverted.** Two more were wrapped but aren't
enrolled, so nothing can verify them; they're reported as such rather than counted as done.

## The bug this exposed

Enrolling the newly-resolvable files gave 9,548/9,549 — `Door::Behavior` called
`func_ov100_02145370` where the ROM calls `func_ov100_02145f00`. A branch is a relocation, so
the byte gate wildcarded it, and the link couldn't see it until the file became enrollable.

Same shape as the `__sinit_ov002_021071f4` repoint in #1034, and as #942. That's the **third
wrong-callee bug this session found by linking rather than matching**, which is worth stating
plainly: *enrolling a function is how you find out whether it was ever really matched.*

## Size

255 `src/` files — above the ~175 precedent from #883. It's one transformation and the
enrollment depends on all of it, so splitting would leave each half unverifiable. #1017
should have removed the timeout pressure that made large batches risky; if the worker still
struggles, I can split by module and land the enrollment last.

## Verification

- **9,549/9,549 reproducing, module fidelity 106/106 exact, ROM-build analysis PASS.**
- Every wrapped file byte-verified individually.
- `tools/prepush_attribution.py`: 0 changed, 0 lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
