### PR TITLE
config: name the div helpers the way the compiler calls them

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -1770,6 +1770,7 @@ src/ShowCrashScreen.c:
     .text start:0x02014244 end:0x02014620
 
 src/nds_printt.c:
+    complete
     .text start:0x02014620 end:0x0201470c
 
 src/nds_printf.c:
@@ -2016,6 +2017,7 @@ src/_ZN9Animation4CopyERKS_.cpp:
     .text start:0x02015a7c end:0x02015a98
 
 src/_ZNK9Animation12WillHitFrameEi.cpp:
+    complete
     .text start:0x02015a98 end:0x02015bcc
 
 src/_ZN9Animation8FinishedEv.cpp:
@@ -2039,6 +2041,7 @@ src/_ZN9Animation12SetAnimationEti5Fix12IiEt.cpp:
     .text start:0x02015c20 end:0x02015c3c
 
 src/_ZN9Animation7AdvanceEv.cpp:
+    complete
     .text start:0x02015c3c end:0x02015cb4
 
 src/_ZN9AnimationD2Ev.c:
@@ -3096,6 +3099,7 @@ src/func_0201ab6c.c:
     .text start:0x0201ab6c end:0x0201aca4
 
 src/func_0201aca4.c:
+    complete
     .text start:0x0201aca4 end:0x0201adac
 
 src/func_0201adac.c:
@@ -3220,6 +3224,7 @@ src/func_0201eaac.c:
     .text start:0x0201eaac end:0x0201eb94
 
 src/_ZN7Message13DisplaySavingEt.cpp:
+    complete
     .text start:0x0201eb94 end:0x0201ef38
 
 src/func_0201ef38.c:
@@ -3238,6 +3243,7 @@ src/func_0201f138.cpp:
     .text start:0x0201f138 end:0x0201f32c
 
 src/func_0201f32c.c:
+    complete
     .text start:0x0201f32c end:0x0201fb4c
 
 src/func_0201fb4c.c:
@@ -4130,6 +4136,7 @@ src/_ZN5Stage8BehaviorEv.cpp:
     .text start:0x0202bbbc end:0x0202c2ac
 
 src/_ZN5Stage10CheckInputEv.cpp:
+    complete
     .text start:0x0202c2ac end:0x0202c830
 
 src/_ZN3Fog4InitEt5Fix12IiES1_.cpp:
@@ -4333,9 +4340,11 @@ src/func_0202f58c.c:
     .text start:0x0202f58c end:0x0202f708
 
 src/func_0202f708.c:
+    complete
     .text start:0x0202f708 end:0x0202f928
 
 src/func_0202f928.c:
+    complete
     .text start:0x0202f928 end:0x0202fb30
 
 src/func_0202fb30.c:
@@ -4475,6 +4484,7 @@ src/func_02031154.c:
     .text start:0x02031154 end:0x0203128c
 
 src/func_0203128c.c:
+    complete
     .text start:0x0203128c end:0x020313d8
 
 src/func_02031428.c:
@@ -4510,6 +4520,7 @@ src/func_020321fc.c:
     .text start:0x020321fc end:0x020326ac
 
 src/func_020326ac.c:
+    complete
     .text start:0x020326ac end:0x02032f04
 
 src/_ZN7Message16SetTextGlobalsVSEv.c:
@@ -4583,6 +4594,7 @@ src/func_02034504.c:
     .text start:0x02034504 end:0x020345b0
 
 src/func_020345b0.c:
+    complete
     .text start:0x020345b0 end:0x02034954
 
 src/LoadFont3D.c:
@@ -6628,6 +6640,7 @@ src/func_0203f6e8.c:
     .text start:0x0203f6e8 end:0x0203f714
 
 src/func_0203f714.c:
+    complete
     .text start:0x0203f714 end:0x0203f818
 
 src/func_0203f818.c:
@@ -7418,12 +7431,15 @@ src/func_02048a1c.c:
     .text start:0x02048a1c end:0x02048af4
 
 src/func_02048af4.c:
+    complete
     .text start:0x02048af4 end:0x02048c30
 
 src/func_02048c30.c:
+    complete
     .text start:0x02048c30 end:0x02048d80
 
 src/func_02048d80.c:
+    complete
     .text start:0x02048d80 end:0x02048e54
 
 src/func_02048e54.c:
@@ -7562,6 +7578,7 @@ src/func_0204a5c8.c:
     .text start:0x0204a5c8 end:0x0204a730
 
 src/func_0204a730.c:
+    complete
     .text start:0x0204a730 end:0x0204ae2c
 
 src/func_0204ae2c.c:
@@ -7617,9 +7634,11 @@ src/func_0204c24c.c:
     .text start:0x0204c24c end:0x0204c304
 
 src/func_0204c304.c:
+    complete
     .text start:0x0204c304 end:0x0204c584
 
 src/func_0204c584.c:
+    complete
     .text start:0x0204c584 end:0x0204cd5c
 
 src/func_0204cd5c.c:
@@ -7647,6 +7666,7 @@ src/func_0204d1b4.c:
     .text start:0x0204d1b4 end:0x0204d294
 
 src/func_0204d294.c:
+    complete
     .text start:0x0204d294 end:0x0204d440
 
 src/func_0204d440.c:
@@ -7670,6 +7690,7 @@ src/_ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3.cpp:
     .text start:0x0204d758 end:0x0204d7ec
 
 src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp:
+    complete
     .text start:0x0204d7ec end:0x0204d8b0
 
 src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp:
@@ -8135,6 +8156,7 @@ src/func_02050038.c:
     .text start:0x02050038 end:0x020500a4
 
 src/func_020500a4.c:
+    complete
     .text start:0x020500a4 end:0x020501b8
 
 src/func_020501b8.c:
@@ -8150,6 +8172,7 @@ src/func_020502b8.c:
     .text start:0x020502b8 end:0x020503a4
 
 src/func_020503a4.c:
+    complete
     .text start:0x020503a4 end:0x020506fc
 
 src/func_020506fc.c:
@@ -8424,6 +8447,7 @@ src/func_02052438.c:
     .text start:0x02052438 end:0x02052458
 
 src/func_02052458.c:
+    complete
     .text start:0x02052458 end:0x02052494
 
 src/func_02052494.c:
@@ -9315,9 +9339,11 @@ src/func_020587dc.c:
     .text start:0x020587dc end:0x020587e4
 
 src/func_020587e4.c:
+    complete
     .text start:0x020587e4 end:0x02058894
 
 src/func_02058894.c:
+    complete
     .text start:0x02058894 end:0x02058940
 
 src/func_02058940.c:
@@ -10746,6 +10772,7 @@ src/func_02064554.c:
     .text start:0x02064554 end:0x02064674
 
 src/func_02064674.c:
+    complete
     .text start:0x02064674 end:0x0206470c
 
 src/func_020647a4.c:
@@ -10757,6 +10784,7 @@ src/func_020647d8.c:
     .text start:0x020647d8 end:0x020647fc
 
 src/func_020647fc.c:
+    complete
     .text start:0x020647fc end:0x02064888
 
 src/func_02064888.c:
@@ -10764,6 +10792,7 @@ src/func_02064888.c:
     .text start:0x02064888 end:0x0206491c
 
 src/func_0206491c.c:
+    complete
     .text start:0x0206491c end:0x02064a28
 
 src/func_02064a28.c:
@@ -10887,6 +10916,7 @@ src/func_020659a0.c:
     .text start:0x020659a0 end:0x020659f8
 
 src/func_020659f8.c:
+    complete
     .text start:0x020659f8 end:0x02065a4c
 
 src/func_02065a4c.c:
@@ -11004,6 +11034,7 @@ src/func_0206655c.c:
     .text start:0x0206655c end:0x02066a94
 
 src/func_02066a94.c:
+    complete
     .text start:0x02066a94 end:0x02066fb0
 
 src/func_02066fb0.c:
@@ -11054,6 +11085,7 @@ src/func_02067530.c:
     .text start:0x02067530 end:0x02067604
 
 src/func_02067604.c:
+    complete
     .text start:0x02067604 end:0x020676e0
 
 src/func_020676e0.c:
@@ -11185,6 +11217,7 @@ src/func_02068a74.c:
     .text start:0x02068a74 end:0x02068ae8
 
 src/func_02068ae8.c:
+    complete
     .text start:0x02068ae8 end:0x02068d08
 
 src/func_02068d08.c:
@@ -11483,6 +11516,7 @@ src/func_0206f820.c:
     .text start:0x0206f820 end:0x0206fb08
 
 src/func_0206fb08.c:
+    complete
     .text start:0x0206fb08 end:0x0206fd6c
 
 src/func_0206fd6c.c:

--- a/config/arm9/itcm/symbols.txt
+++ b/config/arm9/itcm/symbols.txt
@@ -12,7 +12,9 @@ __aeabi_uldiv kind:function(arm,size=0xc) addr:0x01ffa9dc
 __aeabi_ulmod kind:function(arm,size=0x4c) addr:0x01ffa9e8
 func_01ffaa34 kind:function(arm,size=0x1b0) addr:0x01ffaa34
 __aeabi_idiv kind:function(arm,size=0x20c) addr:0x01ffabe4
+_s32_div_f kind:function(arm,size=0x20c) addr:0x01ffabe4
 __aeabi_uidiv kind:function(arm,size=0x1e4) addr:0x01ffadf0
+_u32_div_f kind:function(arm,size=0x1e4) addr:0x01ffadf0
 .L_01ffadf8 kind:label(arm) addr:0x01ffadf8
 func_01ffafd4 kind:function(arm,size=0x34) addr:0x01ffafd4
 func_01ffb008 kind:function(arm,size=0x28) addr:0x01ffb008

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -1588,6 +1588,7 @@ src/func_ov002_020bcd18.c:
     .text start:0x020bcd18 end:0x020bcd38
 
 src/func_ov002_020bcd38.c:
+    complete
     .text start:0x020bcd38 end:0x020bcdf0
 
 src/func_ov002_020bcdf0.c:
@@ -1723,6 +1724,7 @@ src/_ZN6Player18TurnOffToonShadingEj.cpp:
     .text start:0x020be324 end:0x020be3b0
 
 src/func_ov002_020be3b0.c:
+    complete
     .text start:0x020be3b0 end:0x020bea7c
 
 src/func_ov002_020bea7c.c:
@@ -3978,6 +3980,7 @@ src/func_ov002_020e7454.c:
     .text start:0x020e7454 end:0x020e7554
 
 src/func_ov002_020e7554.c:
+    complete
     .text start:0x020e7554 end:0x020e763c
 
 src/func_ov002_020e763c.c:
@@ -4103,6 +4106,7 @@ src/func_ov002_020e9464.c:
     .text start:0x020e9464 end:0x020e947c
 
 src/func_ov002_020e947c.c:
+    complete
     .text start:0x020e947c end:0x020e9590
 
 src/func_ov002_020e9590.cpp:
@@ -4506,6 +4510,7 @@ src/func_ov002_020ef57c.c:
     .text start:0x020ef57c end:0x020ef670
 
 src/func_ov002_020ef670.c:
+    complete
     .text start:0x020ef670 end:0x020efa44
 
 src/func_ov002_020efa44.c:
@@ -5473,6 +5478,7 @@ src/_ZN7Minimap8BehaviorEv.cpp:
     .text start:0x020fa690 end:0x020fb38c
 
 src/_ZN7Minimap13InitResourcesEv.cpp:
+    complete
     .text start:0x020fb38c end:0x020fb804
 
 src/_ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_.cpp:
@@ -5496,6 +5502,7 @@ src/_ZN3HUD15RenderTimeTimerEv.cpp:
     .text start:0x020fb96c end:0x020fbdac
 
 src/_ZN3HUD15CalculateDigitsEt.c:
+    complete
     .text start:0x020fbdac end:0x020fbe38
 
 src/_ZN3HUD15RenderLifeCountEv.cpp:

--- a/config/arm9/overlays/ov003/delinks.txt
+++ b/config/arm9/overlays/ov003/delinks.txt
@@ -67,6 +67,7 @@ src/func_ov003_020ae0b0.c:
     .text start:0x020ae0b0 end:0x020ae1a4
 
 src/func_ov003_020ae1a4.c:
+    complete
     .text start:0x020ae1a4 end:0x020ae238
 
 src/func_ov003_020ae238.c:

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -670,6 +670,7 @@ src/func_ov004_020b4cc4.c:
     .text start:0x020b4cc4 end:0x020b4d50
 
 src/func_ov004_020b4d50.c:
+    complete
     .text start:0x020b4d50 end:0x020b4dfc
 
 src/func_ov004_020b4dfc.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -1367,6 +1367,7 @@ src/func_ov006_020d2580.c:
     .text start:0x020d2580 end:0x020d25fc
 
 src/func_ov006_020d25fc.c:
+    complete
     .text start:0x020d25fc end:0x020d27dc
 
 src/func_ov006_020d3624.cpp:
@@ -4790,6 +4791,7 @@ src/func_ov006_02105134.c:
     .text start:0x02105134 end:0x021051dc
 
 src/func_ov006_021051dc.c:
+    complete
     .text start:0x021051dc end:0x021053a8
 
 src/func_ov006_02105670.c:
@@ -4805,6 +4807,7 @@ src/func_ov006_021057f0.cpp:
     .text start:0x021057f0 end:0x02105854
 
 src/func_ov006_02105854.c:
+    complete
     .text start:0x02105854 end:0x02105ab4
 
 src/func_ov006_02105ab4.c:
@@ -4824,6 +4827,7 @@ src/func_ov006_02105d20.c:
     .text start:0x02105d20 end:0x02105de4
 
 src/func_ov006_02105de4.c:
+    complete
     .text start:0x02105de4 end:0x02106048
 
 src/func_ov006_02106048.c:
@@ -4831,6 +4835,7 @@ src/func_ov006_02106048.c:
     .text start:0x02106048 end:0x02106080
 
 src/func_ov006_02106080.c:
+    complete
     .text start:0x02106080 end:0x02106168
 
 src/func_ov006_021063a0.cpp:
@@ -5118,6 +5123,7 @@ src/func_ov006_0210aa60.cpp:
     .text start:0x0210aa60 end:0x0210ab08
 
 src/func_ov006_0210ab08.c:
+    complete
     .text start:0x0210ab08 end:0x0210ab90
 
 src/func_ov006_0210ab90.c:
@@ -5145,9 +5151,11 @@ src/func_ov006_0210b1fc.c:
     .text start:0x0210b1fc end:0x0210b314
 
 src/func_ov006_0210b314.c:
+    complete
     .text start:0x0210b314 end:0x0210b648
 
 src/func_ov006_0210b648.c:
+    complete
     .text start:0x0210b648 end:0x0210bcb0
 
 src/func_ov006_0210bcb0.cpp:
@@ -6314,6 +6322,7 @@ src/func_ov006_0211f6fc.cpp:
     .text start:0x0211f6fc end:0x0211f77c
 
 src/func_ov006_0211f77c.c:
+    complete
     .text start:0x0211f77c end:0x0211f9fc
 
 src/func_ov006_0211fb1c.c:
@@ -6811,6 +6820,7 @@ src/func_ov006_021279b0.cpp:
     .text start:0x021279b0 end:0x02127d10
 
 src/func_ov006_02127d10.c:
+    complete
     .text start:0x02127d10 end:0x021283a4
 
 src/func_ov006_021283a4.c:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -30,6 +30,7 @@ src/func_ov025_021113c8.cpp:
     .text start:0x021113c8 end:0x021113f0
 
 src/func_ov025_021113f0.c:
+    complete
     .text start:0x021113f0 end:0x021117dc
 
 src/func_ov025_021117dc.cpp:

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -264,6 +264,7 @@ src/_ZN10FlameChomp13InitResourcesEv.cpp:
     .text start:0x02121914 end:0x02121a64
 
 src/func_ov070_02121a64.c:
+    complete
     .text start:0x02121a64 end:0x02121ae0
 
 src/func_ov070_02121ae0.c:

--- a/config/arm9/overlays/ov074/delinks.txt
+++ b/config/arm9/overlays/ov074/delinks.txt
@@ -61,6 +61,7 @@ src/func_ov074_0211fd48.c:
     .text start:0x0211fd48 end:0x0211fd74
 
 src/func_ov074_0211fd74.cpp:
+    complete
     .text start:0x0211fd74 end:0x0211ffac
 
 src/func_ov074_0211ffac.c:
@@ -120,6 +121,7 @@ src/func_ov074_02120808.cpp:
     .text start:0x02120808 end:0x0212087c
 
 src/func_ov074_0212087c.c:
+    complete
     .text start:0x0212087c end:0x02120b24
 
 src/func_ov074_02120b24.c:

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -114,6 +114,7 @@ src/func_ov075_02114cd8.cpp:
     .text start:0x02114cd8 end:0x02114ddc
 
 src/func_ov075_02114ddc.cpp:
+    complete
     .text start:0x02114ddc end:0x02114fa8
 
 src/func_ov075_02114fa8.c:

--- a/config/arm9/overlays/ov077/delinks.txt
+++ b/config/arm9/overlays/ov077/delinks.txt
@@ -308,6 +308,7 @@ src/func_ov077_02126a84.c:
     .text start:0x02126a84 end:0x02126ad0
 
 src/func_ov077_02126ad0.c:
+    complete
     .text start:0x02126ad0 end:0x02126cd4
 
 src/func_ov077_02126cd4.cpp:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -53,6 +53,7 @@ src/func_ov080_02124208.c:
     .text start:0x02124208 end:0x02124360
 
 src/func_ov080_02124360.c:
+    complete
     .text start:0x02124360 end:0x021243d8
 
 src/func_ov080_021243d8.c:
@@ -249,6 +250,7 @@ src/func_ov080_021264ec.c:
     .text start:0x021264ec end:0x021265ec
 
 src/func_ov080_021265ec.c:
+    complete
     .text start:0x021265ec end:0x0212677c
 
 src/func_ov080_0212677c.c:

--- a/config/arm9/overlays/ov089/delinks.txt
+++ b/config/arm9/overlays/ov089/delinks.txt
@@ -13,6 +13,7 @@ src/_ZN3KeyD0Ev.c:
     .text start:0x02130f50 end:0x02130fb4
 
 src/func_ov089_02130fb4.c:
+    complete
     .text start:0x02130fb4 end:0x021310cc
 
 src/UnloadKeyModels.cpp:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -58,6 +58,7 @@ src/_ZN9Butterfly8BehaviorEv.cpp:
     .text start:0x02141a40 end:0x02141c6c
 
 src/_ZN9Butterfly13InitResourcesEv.cpp:
+    complete
     .text start:0x02141c6c end:0x02141ea4
 
 src/Butterfly_Spawn.c:
@@ -397,6 +398,7 @@ src/func_ov100_02146280.c:
     .text start:0x02146280 end:0x0214629c
 
 src/func_ov100_0214629c.cpp:
+    complete
     .text start:0x0214629c end:0x0214639c
 
 src/func_ov100_0214639c.c:

--- a/notes/itcm.md
+++ b/notes/itcm.md
@@ -173,6 +173,26 @@ flags leaves undefined references to `_s32_div_f` and `_u32_div_f`, and `%` lowe
 `bl _s32_div_f; mov r0,r1` — confirming the dual `r0`=quotient / `r1`=remainder return. So
 0x01ffabe4 is `_s32_div_f` and 0x01ffadf0 is `_u32_div_f`. There is no original C to recover.
 
+**Both names are now in config, alongside the AAPCS ones (2026-08-03).** Naming these
+`__aeabi_idiv` / `__aeabi_uidiv` was correct about the ABI role and wrong about the toolchain:
+the ROM was built by CodeWarrior, so *nothing* ever references the `__aeabi_` spelling, while
+every source file that writes `/` or `%` on an `int` emits `bl _s32_div_f`. `eligible.py` rule 5
+rejects a file whose undefined references are not named in `config/**/symbols.txt`, so those
+files could byte-match forever and never enrol — the `bl` is a relocation, so the `.text`
+compares equal whether or not the target has a name. Adding the CodeWarrior spelling as a second
+symbol at the same address (the shape `_ZTV5Actor` / `data_0208e3a4` already uses) unblocked 64
+files at once. Do not *rename* `__aeabi_idiv`: `tools/reloc_audit.py` maps the two spellings onto
+each other and wants both.
+
+Do not confuse these with `cstd::div` / `cstd::mod` (0x02052f4c / 0x02052ef4). Those are
+Nintendo's own wrappers over the **hardware divider** — `DIVCNT = 0`, numerator to `DIV_NUMER`,
+denominator to `DIV_DENOM`, spin on bit 15, read `DIV_RESULT` (`cstd::mod` reads `DIVREM_RESULT`
+instead, which is the only thing that distinguishes the two bodies). Game code that wants a
+divide calls those explicitly; `_s32_div_f` is what the *compiler* reaches for on its own. Both
+are in the ROM and they are unrelated code paths. The wider `cstd` divider/sqrt API around
+0x02052ef4–0x02053258 (`fdiv`, `ldiv`, `fdiv_async`, `reciprocal_async`, `fdiv_result`,
+`ldiv_result`) is all hardware-backed and already named.
+
 Four structural facts, each verified on the image:
 
 * **Unguarded computed dispatch.** `add r2,r2,r2,lsl #1` then `add pc,pc,r2,lsl #2` — a 12-byte


### PR DESCRIPTION
## The bug

`config/arm9/itcm/symbols.txt` names the ITCM division routines `__aeabi_idiv` (0x01ffabe4) and `__aeabi_uidiv` (0x01ffadf0). That is right about what they *do* and wrong about what they are *called*. This ROM was built by CodeWarrior, whose runtime spells them **`_s32_div_f`** and **`_u32_div_f`**. Nothing in the tree ever emits the `__aeabi_` spelling.

Compiling a probe at 1.2/sp2p3 with the repo's flags:

```c
int  sd(int a, int b)           { return a / b; }
int  sm(int a, int b)           { return a % b; }
unsigned ud(unsigned, unsigned) { return a / b; }
```
```
undefined: ['_u32_div_f', '_s32_div_f']
```

Both `/` and `%` lower to the same helper (`%` is `bl _s32_div_f; mov r0,r1` — the dual quotient/remainder return `notes/itcm.md` already documents).

## Why it was invisible

`eligible.py` rule 5 rejects any file whose undefined references are not named in `config/**/symbols.txt`. So a file that divides matched the ROM byte-for-byte and still could not be enrolled — and nothing pointed at the cause, because **the `bl` is a relocation**: `.text` compares equal whether or not the branch target has a name. It read like a matching problem and was a naming problem.

Census over all 11,107 enrolled functions:

| | files |
|---|---:|
| reference `_s32_div_f` / `_u32_div_f` | 67 |
| **blocked *solely* by that** | **64** |
| blocked by that *and* something else | 3 |

## The fix

Two lines. A second symbol at the same address, the shape `config/arm9/symbols.txt` already uses for `_ZTV5Actor` / `data_0208e3a4`:

```
 __aeabi_idiv  kind:function(arm,size=0x20c) addr:0x01ffabe4
+_s32_div_f    kind:function(arm,size=0x20c) addr:0x01ffabe4
 __aeabi_uidiv kind:function(arm,size=0x1e4) addr:0x01ffadf0
+_u32_div_f    kind:function(arm,size=0x1e4) addr:0x01ffadf0
```

Aliased rather than renamed on purpose — `tools/reloc_audit.py` maps the two spellings onto each other and wants both names to exist.

## Verified

Full ROM build with the alias and the 64 promotions:

```
[3/6] mwccarm: 9202 enrolled source file(s)
[4/6] mwldarm
[6/6] analyze module and source fidelity
source-built functions: 9,202  (1,523,788 / 2,211,124 code bytes, 68.91%)
  reproducing: 9,202
  mismatching: 0
module fidelity: 106/106 exact, 100.000000% of compared bytes
ROM-build analysis: PASS
```

`sha256(build/sm64ds.nds) = ddab9300b24aeae254192c2a30d812b07ece3adff83230e75c865ed915c9de40` — retail.

`dsd delink` accepts the duplicate symbol and `mwldarm` resolves against it, which were the two things that could have gone wrong.

**67.19% → 68.91% of code bytes**, +38,172 bytes, no source changes.

## Not to be confused with `cstd::div`

While tracking this down I mapped the other divide path, and `notes/itcm.md` now records it so nobody conflates them. `cstd::div` (0x02052f4c) and `cstd::mod` (0x02052ef4) are Nintendo's own wrappers over the **DS hardware divider** — write `DIVCNT = 0`, numerator to `DIV_NUMER`, denominator to `DIV_DENOM`, spin on bit 15, read `DIV_RESULT`; `cstd::mod` reads `DIVREM_RESULT` instead, which is the *only* difference between the two bodies. Game code calls those explicitly. `_s32_div_f` is what the compiler reaches for on its own when you write `/`. Both are in the ROM, both already named, unrelated code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185e4ParpkguZds1DEYw3A5
