### PR TITLE
config: the vtable at 0x0210ae38 is Platform's, not ExclamationSwitch's

### DIFF
--- a/config/arm9/overlays/ov002/symbols.txt
+++ b/config/arm9/overlays/ov002/symbols.txt
@@ -2222,7 +2222,7 @@ data_ov002_0210ad84 kind:data(any) addr:0x0210ad84
 YoshiEgg_SpawnInfo kind:data(any) addr:0x0210ad90
 _ZTV8YoshiEgg kind:data(any) addr:0x0210adb4
 _ZTV8daYegg_c kind:data(any) addr:0x0210adb4
-_ZTV17ExclamationSwitch kind:data(any) addr:0x0210ae38
+_ZTV8Platform kind:data(any) addr:0x0210ae38
 data_ov002_0210aeb8 kind:data(any) addr:0x0210aeb8
 data_ov002_0210aec0 kind:data(any) addr:0x0210aec0
 data_ov002_0210aec8 kind:data(any) addr:0x0210aec8

--- a/src/_ZN11PyramidLiftD0Ev.c
+++ b/src/_ZN11PyramidLiftD0Ev.c
@@ -8,13 +8,13 @@ extern int _ZN5ActorD2Ev(void *p);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int data_ov027_021139d4[];
 extern int func_020072c0[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int *data_020a0eac;
 int _ZN11PyramidLiftD0Ev(struct PyramidLift *self) {
     *(int**)(((char *)self)) = data_ov027_021139d4;
     __destroy_arr(((char *)self)+0x37c, 0xa, 0xc, func_020072c0);
     _ZN5ModelD1Ev((char *)&self->mModel2);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel1);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN11PyramidLiftD1Ev.cpp
+++ b/src/_ZN11PyramidLiftD1Ev.cpp
@@ -10,12 +10,12 @@
 extern "C" {
 extern void __destroy_arr(void*,int,int,void*);
 extern int func_020072c0();
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 void* _ZN11PyramidLiftD1Ev(struct PyramidLift *self) {
   *(int**)((char*)self) = data_ov027_021139d4;
   __destroy_arr(((char*)self)+0x37c, 0xa, 0xc, (void*)func_020072c0);
   _ZN5ModelD1Ev((char*)&self->mModel2);
-  *(int**)((char*)self) = _ZTV17ExclamationSwitch;
+  *(int**)((char*)self) = _ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
   _ZN5ModelD1Ev((char*)&self->mModel1);
   _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN12WorkElevatorD0Ev.c
+++ b/src/_ZN12WorkElevatorD0Ev.c
@@ -7,13 +7,13 @@ extern int _ZN5ModelD1Ev(void *p);
 extern int _ZN5ActorD2Ev(void *p);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int func_ov075_0211478c[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int *data_020a0eac;
 int _ZN12WorkElevatorD0Ev(struct WorkElevator *self) {
     *(int**)(((char *)self)) = func_ov075_0211478c;
     __destroy_arr(((char *)self)+0x520, 4, 0x1c8, _ZN18MovingMeshColliderD1Ev);
     __destroy_arr(((char *)self)+0x320, 4, 0x50, _ZN5ModelD1Ev);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN12WorkElevatorD1Ev.cpp
+++ b/src/_ZN12WorkElevatorD1Ev.cpp
@@ -4,7 +4,7 @@
 #include "WorkElevator.h"
 extern "C" {
 extern void* func_ov075_0211478c;
-extern void* _ZTV17ExclamationSwitch;
+extern void* _ZTV8Platform;
 void __destroy_arr(void*, int, int, void(*)(void*));
 void _ZN18MovingMeshColliderD1Ev(void*);
 void _ZN5ModelD1Ev(void*);
@@ -13,7 +13,7 @@ void* _ZN12WorkElevatorD1Ev(struct WorkElevator *self) {
     *(void**)((char*)self) = &func_ov075_0211478c;
     __destroy_arr(((char*)self)+0x520, 4, 0x1c8, _ZN18MovingMeshColliderD1Ev);
     __destroy_arr(((char*)self)+0x320, 4, 0x50, _ZN5ModelD1Ev);
-    *(void**)((char*)self) = &_ZTV17ExclamationSwitch;
+    *(void**)((char*)self) = &_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
     _ZN5ModelD1Ev((char*)&self->mModel);
     _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN14QuestionSwitchD0Ev.c
+++ b/src/_ZN14QuestionSwitchD0Ev.c
@@ -7,14 +7,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "QuestionSwitch.h"
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern void *data_020a0eac;
 int *_ZN14QuestionSwitchD0Ev(struct QuestionSwitch *self) {
     ((int *)self)[0] = (int)_ZTV14QuestionSwitch;
     _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
     _ZN18MovingMeshColliderD1Ev((char *)&self->unk_324);
-    ((int *)self)[0] = (int)_ZTV17ExclamationSwitch;
+    ((int *)self)[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->unk_124);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((int *)self));

--- a/src/_ZN14QuestionSwitchD1Ev.cpp
+++ b/src/_ZN14QuestionSwitchD1Ev.cpp
@@ -8,13 +8,13 @@ extern int _ZN18MovingMeshColliderD1Ev(char*);
 extern int _ZN5ModelD1Ev(char*);
 extern int _ZN5ActorD2Ev(char*);
 extern int _ZTV14QuestionSwitch[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 char* _ZN14QuestionSwitchD1Ev(struct QuestionSwitch *self) {
   *(int**)((char*)self) = _ZTV14QuestionSwitch;
   _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
   _ZN18MovingMeshColliderD1Ev((char*)&self->unk_324);
-  *(int**)((char*)self) = _ZTV17ExclamationSwitch;
+  *(int**)((char*)self) = _ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->unk_124);
   _ZN5ModelD1Ev((char*)&self->mModel);
   _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN15RotatingFirebarD0Ev.c
+++ b/src/_ZN15RotatingFirebarD0Ev.c
@@ -8,12 +8,12 @@ extern int _ZN5ActorD2Ev(void *p);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int _ZTV15RotatingFirebar[];
 extern int _ZN19CylinderClsnWithPosD1Ev[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int *data_020a0eac;
 int _ZN15RotatingFirebarD0Ev(struct RotatingFirebar *self) {
     *(int**)(((char *)self)) = _ZTV15RotatingFirebar;
     __destroy_arr(((char *)self)+0x360, 8, 0x3c, _ZN19CylinderClsnWithPosD1Ev);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN15RotatingFirebarD1Ev.c
+++ b/src/_ZN15RotatingFirebarD1Ev.c
@@ -8,11 +8,11 @@
 #include "RotatingFirebar.h"
 extern void __destroy_arr(void *arr, int a, int b, void *fn);
 extern void _ZN19CylinderClsnWithPosD1Ev(void *c);
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 int _ZN15RotatingFirebarD1Ev(struct RotatingFirebar *self) {
     *(int**)((char *)self) = (int*)_ZTV15RotatingFirebar;
     __destroy_arr(((char *)self) + 0x360, 8, 0x3c, (void*)_ZN19CylinderClsnWithPosD1Ev);
-    *(int**)((char *)self) = (int*)_ZTV17ExclamationSwitch;
+    *(int**)((char *)self) = (int*)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN18RickshawPlatformBsD0Ev.c
+++ b/src/_ZN18RickshawPlatformBsD0Ev.c
@@ -8,14 +8,14 @@ extern int _ZN5ActorD2Ev(void *p);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int _ZTV18RickshawPlatformBs[];
 extern int data_ov002_02108d94[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int *data_020a0eac;
 int _ZN18RickshawPlatformBsD0Ev(struct RickshawPlatformBs *self) {
     *(int**)(((char *)self)) = _ZTV18RickshawPlatformBs;
     *(int**)(((char *)self)) = data_ov002_02108d94;
     __destroy_arr(((char *)self)+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
     __destroy_arr(((char *)self)+0x320, 5, 0x50, _ZN5ModelD1Ev);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN18RickshawPlatformBsD1Ev.c
+++ b/src/_ZN18RickshawPlatformBsD1Ev.c
@@ -3,7 +3,7 @@
 #include "RickshawPlatformBs.h"
 extern int _ZTV18RickshawPlatformBs[];
 extern int data_ov002_02108d94[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int __destroy_arr(void*,int,int,void*);
 extern int _ZN18MovingMeshColliderD1Ev(void*);
 extern int _ZN5ModelD1Ev(void*);
@@ -13,7 +13,7 @@ int _ZN18RickshawPlatformBsD1Ev(struct RickshawPlatformBs *self) {
   *(int*)((char*)self)=(int)data_ov002_02108d94;
   __destroy_arr(((char*)self)+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
   __destroy_arr(((char*)self)+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
-  *(int*)((char*)self)=(int)_ZTV17ExclamationSwitch;
+  *(int*)((char*)self)=(int)_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
   _ZN5ModelD1Ev((char*)&self->mModel);
   _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN19RickshawPlatformBdwD0Ev.c
+++ b/src/_ZN19RickshawPlatformBdwD0Ev.c
@@ -8,14 +8,14 @@ extern int _ZN5ActorD2Ev(void *p);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int _ZTV19RickshawPlatformBdw[];
 extern int data_ov002_02108d94[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int *data_020a0eac;
 int _ZN19RickshawPlatformBdwD0Ev(struct RickshawPlatformBdw *self) {
     *(int**)(((char *)self)) = _ZTV19RickshawPlatformBdw;
     *(int**)(((char *)self)) = data_ov002_02108d94;
     __destroy_arr(((char *)self)+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
     __destroy_arr(((char *)self)+0x320, 5, 0x50, _ZN5ModelD1Ev);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN19RickshawPlatformBdwD1Ev.cpp
+++ b/src/_ZN19RickshawPlatformBdwD1Ev.cpp
@@ -9,13 +9,13 @@ extern int _ZN5ModelD1Ev(void*);
 extern int _ZN5ActorD2Ev(void*);
 extern int _ZTV19RickshawPlatformBdw[];
 extern int data_ov002_02108d94[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 void* _ZN19RickshawPlatformBdwD1Ev(struct RickshawPlatformBdw *self) {
   *(int**)((char*)self)=_ZTV19RickshawPlatformBdw;
   *(int**)((char*)self)=data_ov002_02108d94;
   __destroy_arr(((char*)self)+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
   __destroy_arr(((char*)self)+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
-  *(int**)((char*)self)=_ZTV17ExclamationSwitch;
+  *(int**)((char*)self)=_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
   _ZN5ModelD1Ev((char*)&self->mModel);
   _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN21ArmedRotatingPlatformD0Ev.c
+++ b/src/_ZN21ArmedRotatingPlatformD0Ev.c
@@ -8,14 +8,14 @@ extern int _ZN5ActorD2Ev(void *p);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int _ZTV21ArmedRotatingPlatform[];
 extern int data_ov002_02108d94[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int *data_020a0eac;
 int _ZN21ArmedRotatingPlatformD0Ev(struct ArmedRotatingPlatform *self) {
     *(int**)(((char *)self)) = _ZTV21ArmedRotatingPlatform;
     *(int**)(((char *)self)) = data_ov002_02108d94;
     __destroy_arr(((char *)self)+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
     __destroy_arr(((char *)self)+0x320, 5, 0x50, _ZN5ModelD1Ev);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN21ArmedRotatingPlatformD1Ev.cpp
+++ b/src/_ZN21ArmedRotatingPlatformD1Ev.cpp
@@ -9,13 +9,13 @@ extern int _ZN5ModelD1Ev(void*);
 extern int _ZN5ActorD2Ev(void*);
 extern int _ZTV21ArmedRotatingPlatform[];
 extern int data_ov002_02108d94[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 void* _ZN21ArmedRotatingPlatformD1Ev(struct ArmedRotatingPlatform *self) {
   *(int**)((char*)self)=_ZTV21ArmedRotatingPlatform;
   *(int**)((char*)self)=data_ov002_02108d94;
   __destroy_arr(((char*)self)+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
   __destroy_arr(((char*)self)+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
-  *(int**)((char*)self)=_ZTV17ExclamationSwitch;
+  *(int**)((char*)self)=_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
   _ZN5ModelD1Ev((char*)&self->mModel);
   _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN5CrateD0Ev.c
+++ b/src/_ZN5CrateD0Ev.c
@@ -10,7 +10,7 @@
 #include "Crate.h"
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern void* _ZTV5Crate;
-extern void* _ZTV17ExclamationSwitch;
+extern void* _ZTV8Platform;
 extern void* data_020a0eac[];
 
 void* _ZN5CrateD0Ev(struct Crate *self) {
@@ -19,7 +19,7 @@ void* _ZN5CrateD0Ev(struct Crate *self) {
     _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos1);
     _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
     _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
-    *(void**)((char*)self) = &_ZTV17ExclamationSwitch;
+    *(void**)((char*)self) = &_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
     _ZN5ModelD1Ev((char*)&self->mModel);
     _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN5CrateD1Ev.cpp
+++ b/src/_ZN5CrateD1Ev.cpp
@@ -10,14 +10,14 @@ void _ZN18MovingMeshColliderD1Ev(void*);
 void _ZN5ModelD1Ev(void*);
 void _ZN5ActorD2Ev(void*);
 extern int _ZTV5Crate[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 void* _ZN5CrateD1Ev(struct Crate *self) {
     *(int*)((char*)self) = (int)_ZTV5Crate;
     _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos2);
     _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos1);
     _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
     _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
-    *(int*)((char*)self) = (int)_ZTV17ExclamationSwitch;
+    *(int*)((char*)self) = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
     _ZN5ModelD1Ev((char*)&self->mModel);
     _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN6EyerokD0Ev.c
+++ b/src/_ZN6EyerokD0Ev.c
@@ -12,7 +12,7 @@ extern void _ZN5ActorD2Ev(void*);
 extern void* _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
 extern int _ZTV6Eyerok[];
 extern int func_020072c0[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern void* data_020a0eac;
 void* _ZN6EyerokD0Ev(struct Eyerok *self) {
     *(int**)((char*)self) = _ZTV6Eyerok;
@@ -23,7 +23,7 @@ void* _ZN6EyerokD0Ev(struct Eyerok *self) {
     _ZN5ModelD1Ev((char*)&self->mModel2);
     _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
     _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
-    *(int**)((char*)self) = _ZTV17ExclamationSwitch;
+    *(int**)((char*)self) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char*)&self->unk_124);
     _ZN5ModelD1Ev((char*)&self->mModel1);
     _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN6EyerokD1Ev.c
+++ b/src/_ZN6EyerokD1Ev.c
@@ -11,7 +11,7 @@
 extern void _ZN15TextureSequenceD1Ev(void* p);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void* p);
 extern int __destroy_arr(void* p, int a, int b, void* fn);
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int func_020072c0[];
 void* _ZN6EyerokD1Ev(struct Eyerok *self) {
     *(void**)((char*)self) = _ZTV6Eyerok;
@@ -22,7 +22,7 @@ void* _ZN6EyerokD1Ev(struct Eyerok *self) {
     _ZN5ModelD1Ev((char*)&self->mModel2);
     _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
     _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
-    *(void**)((char*)self) = _ZTV17ExclamationSwitch;
+    *(void**)((char*)self) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char*)&self->unk_124);
     _ZN5ModelD1Ev((char*)&self->mModel1);
     _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN6ToxBoxD0Ev.cpp
+++ b/src/_ZN6ToxBoxD0Ev.cpp
@@ -11,13 +11,13 @@
 extern "C" {
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern int _ZTV6ToxBox[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern void* data_020a0eac;
 void* _ZN6ToxBoxD0Ev(struct ToxBox *self) {
   *(int**)(((char*)self))=_ZTV6ToxBox;
   _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
   _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
-  *(int**)(((char*)self))=_ZTV17ExclamationSwitch;
+  *(int**)(((char*)self))=_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
   _ZN5ModelD1Ev((char*)&self->mModel);
   _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN6ToxBoxD1Ev.cpp
+++ b/src/_ZN6ToxBoxD1Ev.cpp
@@ -9,12 +9,12 @@ extern int _ZN18MovingMeshColliderD1Ev(void*);
 extern int _ZN5ModelD1Ev(void*);
 extern int _ZN5ActorD2Ev(void*);
 extern void* _ZTV6ToxBox;
-extern void* _ZTV17ExclamationSwitch;
+extern void* _ZTV8Platform;
 void* _ZN6ToxBoxD1Ev(struct ToxBox *self) {
   *(void**)((char*)self) = &_ZTV6ToxBox;
   _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
   _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
-  *(void**)((char*)self) = &_ZTV17ExclamationSwitch;
+  *(void**)((char*)self) = &_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
   _ZN5ModelD1Ev((char*)&self->mModel);
   _ZN5ActorD2Ev(((char*)self));

--- a/src/_ZN8PathLiftD0Ev.c
+++ b/src/_ZN8PathLiftD0Ev.c
@@ -7,12 +7,12 @@ extern int _ZN18MovingMeshColliderD1Ev(void *p);
 extern int _ZN5ActorD2Ev(void *p);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int data_ov002_0210af70[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 extern int *data_020a0eac;
 int _ZN8PathLiftD0Ev(struct PathLift *self) {
     *(int**)(((char *)self)) = data_ov002_0210af70;
     __destroy_arr(((char *)self)+0x320, 3, 0x50, _ZN5ModelD1Ev);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN8PathLiftD2Ev.c
+++ b/src/_ZN8PathLiftD2Ev.c
@@ -6,11 +6,11 @@ extern int _ZN5ModelD1Ev(void *p);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
 extern int _ZN5ActorD2Ev(void *p);
 extern int data_ov002_0210af70[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 int _ZN8PathLiftD2Ev(struct PathLift *self) {
     *(int**)(((char *)self)) = data_ov002_0210af70;
     __destroy_arr(((char *)self)+0x320, 3, 0x50, _ZN5ModelD1Ev);
-    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    *(int**)(((char *)self)) = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
     _ZN5ModelD1Ev((char *)&self->mModel);
     _ZN5ActorD2Ev(((char *)self));

--- a/src/_ZN8PlatformC2Ev.c
+++ b/src/_ZN8PlatformC2Ev.c
@@ -4,12 +4,12 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 /* recovered: named members + shared header, vtable identified, globals resolved */
-/* resolved: VT0 = _ZTV17ExclamationSwitch */
-extern int _ZTV17ExclamationSwitch[];
+/* resolved: VT0 = _ZTV8Platform */
+extern int _ZTV8Platform[];
 int *_ZN8PlatformC2Ev(int *t)
 {
     _ZN5ActorC2Ev(t);
-    t[0] = (int)_ZTV17ExclamationSwitch;
+    t[0] = (int)_ZTV8Platform;
     _ZN5ModelC1Ev((char *)t + 0xd4);
     _ZN18MovingMeshColliderC1Ev((char *)t + 0x124);
     return t;

--- a/src/_ZN8PlatformD2Ev.c
+++ b/src/_ZN8PlatformD2Ev.c
@@ -4,11 +4,11 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 /* recovered: named members + shared header, vtable identified, globals resolved */
-/* resolved: VT0 = _ZTV17ExclamationSwitch */
-extern int _ZTV17ExclamationSwitch[];
+/* resolved: VT0 = _ZTV8Platform */
+extern int _ZTV8Platform[];
 int *_ZN8PlatformD2Ev(int *t)
 {
-    t[0] = (int)_ZTV17ExclamationSwitch;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/actors/MadPiano/_ZN8MadPianoD0Ev.cpp
+++ b/src/actors/MadPiano/_ZN8MadPianoD0Ev.cpp
@@ -14,7 +14,7 @@ extern "C" void _ZN5ActorD2Ev(void *thiz);
 extern "C" void _ZN6Memory10DeallocateEPvP4Heap(void *p, struct Heap *h);
 extern "C" void _ZN25MovingCylinderClsnWithPosD1Ev(void *thiz);
 extern void *_ZTV8MadPiano[];
-extern void *_ZTV17ExclamationSwitch[];
+extern void *_ZTV8Platform[];
 extern struct Heap *data_020a0eac;
 
 extern "C" void *_ZN8MadPianoD0Ev(void *thiz)
@@ -27,7 +27,7 @@ extern "C" void *_ZN8MadPianoD0Ev(void *thiz)
     _ZN11ShadowModelD1Ev(c + 0x3ac);
     _ZN11ShadowModelD1Ev(c + 0x384);
     _ZN9ModelAnimD1Ev(c + 0x320);
-    *(void **)c = _ZTV17ExclamationSwitch;
+    *(void **)c = _ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev(c + 0x124);
     _ZN5ModelD1Ev(c + 0xd4);
     _ZN5ActorD2Ev(c);

--- a/src/actors/MadPiano/_ZN8MadPianoD1Ev.c
+++ b/src/actors/MadPiano/_ZN8MadPianoD1Ev.c
@@ -11,7 +11,7 @@
 extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern void* _ZTV8MadPiano;
-extern void* _ZTV17ExclamationSwitch;
+extern void* _ZTV8Platform;
 void* _ZN8MadPianoD1Ev(struct MadPiano *self) {
   *(void**)((void*)self) = &_ZTV8MadPiano;
   _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
@@ -20,7 +20,7 @@ void* _ZN8MadPianoD1Ev(struct MadPiano *self) {
   _ZN11ShadowModelD1Ev((char*)&self->mShadowModel2);
   _ZN11ShadowModelD1Ev((char*)&self->mShadowModel1);
   _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
-  *(void**)((void*)self) = &_ZTV17ExclamationSwitch;
+  *(void**)((void*)self) = &_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
   _ZN5ModelD1Ev((char*)&self->mModel);
   _ZN5ActorD2Ev(((void*)self));

--- a/src/func_ov002_020b4a70.c
+++ b/src/func_ov002_020b4a70.c
@@ -4,13 +4,13 @@ extern int _ZN5ModelD1Ev(void*);
 extern int _ZN5ActorD2Ev(void*);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
 extern void* data_ov002_02108d94;
-extern void* _ZTV17ExclamationSwitch;
+extern void* _ZTV8Platform;
 extern void* data_020a0eac;
 void* func_ov002_020b4a70(void* c) {
   *(void**)c = &data_ov002_02108d94;
   __destroy_arr((char*)c+0x4b0, 5, 0x1c8, &_ZN18MovingMeshColliderD1Ev);
   __destroy_arr((char*)c+0x320, 5, 0x50, &_ZN5ModelD1Ev);
-  *(void**)c = &_ZTV17ExclamationSwitch;
+  *(void**)c = &_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)c+0x124);
   _ZN5ModelD1Ev((char*)c+0xd4);
   _ZN5ActorD2Ev(c);

--- a/src/func_ov002_020b4af8.c
+++ b/src/func_ov002_020b4af8.c
@@ -3,12 +3,12 @@ extern void _ZN18MovingMeshColliderD1Ev(void*);
 extern void _ZN5ModelD1Ev(void*);
 extern void _ZN5ActorD2Ev(void*);
 extern void* data_ov002_02108d94;
-extern void* _ZTV17ExclamationSwitch;
+extern void* _ZTV8Platform;
 void* func_ov002_020b4af8(void* c) {
   *(void**)c = &data_ov002_02108d94;
   __destroy_arr((char*)c+0x4b0, 5, 0x1c8, (void*)&_ZN18MovingMeshColliderD1Ev);
   __destroy_arr((char*)c+0x320, 5, 0x50, (void*)&_ZN5ModelD1Ev);
-  *(void**)c = &_ZTV17ExclamationSwitch;
+  *(void**)c = &_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev((char*)c+0x124);
   _ZN5ModelD1Ev((char*)c+0xd4);
   _ZN5ActorD2Ev(c);

--- a/src/func_ov036_02112158.cpp
+++ b/src/func_ov036_02112158.cpp
@@ -2,7 +2,7 @@
 extern "C" {
 extern int data_ov036_02113f9c[];
 extern int data_ov002_0210af70[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 void _ZN9ModelAnimD1Ev(void*);
 void __destroy_arr(void*,int,int,void*);
 void _ZN18MovingMeshColliderD1Ev(void*);
@@ -14,7 +14,7 @@ extern "C" int func_ov036_02112158(char* c){
   _ZN9ModelAnimD1Ev(c+0x450);
   *(int**)c=(int*)data_ov002_0210af70;
   __destroy_arr(c+0x320,3,0x50,(void*)_ZN5ModelD1Ev);
-  *(int**)c=(int*)_ZTV17ExclamationSwitch;
+  *(int**)c=(int*)_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev(c+0x124);
   _ZN5ModelD1Ev(c+0xd4);
   _ZN5ActorD2Ev(c);

--- a/src/func_ov036_021121c8.cpp
+++ b/src/func_ov036_021121c8.cpp
@@ -8,7 +8,7 @@ extern void _ZN5ActorD2Ev(void*);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
 extern void* data_ov036_02113f9c[];
 extern void* data_ov002_0210af70[];
-extern void* _ZTV17ExclamationSwitch[];
+extern void* _ZTV8Platform[];
 extern void* data_020a0eac;
 
 
@@ -17,7 +17,7 @@ void* func_ov036_021121c8(char* p){
   _ZN9ModelAnimD1Ev(p+0x450);
   *(void***)p = (void**)data_ov002_0210af70;
   __destroy_arr(p+0x320, 3, 0x50, _ZN5ModelD1Ev);
-  *(void***)p = (void**)_ZTV17ExclamationSwitch;
+  *(void***)p = (void**)_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev(p+0x124);
   _ZN5ModelD1Ev(p+0xd4);
   _ZN5ActorD2Ev(p);

--- a/src/func_ov100_02146d7c.cpp
+++ b/src/func_ov100_02146d7c.cpp
@@ -2,7 +2,7 @@
 extern "C" {
 extern int data_ov100_0214857c[];
 extern int data_ov002_0210af70[];
-extern int _ZTV17ExclamationSwitch[];
+extern int _ZTV8Platform[];
 void _ZN11ShadowModelD1Ev(void*);
 void __destroy_arr(void*,int,int,void*);
 void _ZN18MovingMeshColliderD1Ev(void*);
@@ -14,7 +14,7 @@ extern "C" int func_ov100_02146d7c(char* c){
   _ZN11ShadowModelD1Ev(c+0x450);
   *(int**)c=(int*)data_ov002_0210af70;
   __destroy_arr(c+0x320,3,0x50,(void*)_ZN5ModelD1Ev);
-  *(int**)c=(int*)_ZTV17ExclamationSwitch;
+  *(int**)c=(int*)_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev(c+0x124);
   _ZN5ModelD1Ev(c+0xd4);
   _ZN5ActorD2Ev(c);

--- a/src/func_ov100_02146dec.cpp
+++ b/src/func_ov100_02146dec.cpp
@@ -12,7 +12,7 @@
 extern "C" {
 extern void __destroy_arr(void* arr, int count, int size, void(*dtor)(void*));
 extern void* data_ov002_0210af70[];
-extern void* _ZTV17ExclamationSwitch[];
+extern void* _ZTV8Platform[];
 extern void* data_020a0eac;
 
 
@@ -21,7 +21,7 @@ void* func_ov100_02146dec(char* p){
   _ZN11ShadowModelD1Ev(p+0x450);
   *(void***)p = (void**)data_ov002_0210af70;
   __destroy_arr(p+0x320, 3, 0x50, _ZN5ModelD1Ev);
-  *(void***)p = (void**)_ZTV17ExclamationSwitch;
+  *(void***)p = (void**)_ZTV8Platform;
   _ZN18MovingMeshColliderD1Ev(p+0x124);
   _ZN5ModelD1Ev(p+0xd4);
   _ZN5ActorD2Ev(p);


### PR DESCRIPTION
Found by the PC-port campaign (gate 16). The ROM settles it from three directions:

1. `_ZN8PlatformC2Ev` (0x020eea50) stores 0x0210ae38 into `[this]` from its own literal pool.
2. The table's dtor slots (16/17) are `_ZN8PlatformD2Ev` / `_ZN8PlatformD0Ev`, and the D2 body stores the same address back into the vptr. Every other slot is an inherited Actor/ActorBase default.
3. `ExclamationSwitch_Spawn` calls `_ZN8PlatformC2Ev` and then overwrites the vptr with 0x02109940 -- the identical table `StarSwitch_Spawn` installs. The two switches share one class; `_ZTV10StarSwitch` keeps that name, and `src/ExclamationSwitch_Spawn.c` already references it.

So `_ZTV17ExclamationSwitch` -> `_ZTV8Platform`, plus the 32 src files that spelled the address by the old name (same address before and after; reloc bytes unchanged). `linkcheck --module ov002` before/after is identical: 1248 VERIFIED / 20 BENIGN / 258 BLIND / 4 NO-SRC.

Deliberately not included: the RTTI dual `_ZTV10dBgActor_c` at the same address. A local trial flipped 14 ov002 dtors from BLIND to WRONG -- their src files crossed the placeholder names between the two vptr stores (the ROM's first store is the class's own table, e.g. 0x02108fdc, but the src put `_ZTV10dBgActor_c` there and a blind `VT1` on the Platform slot). ~215 dtors repo-wide share that shape, so the dual needs a corpus-wide store-order audit first; filing that as a follow-up so this stays a pure rename.