### PR TITLE
readable: TextureTransformer::Prepare takes two arguments and no this

### DIFF
--- a/include/TextureTransformer.h
+++ b/include/TextureTransformer.h
@@ -12,8 +12,17 @@
  * THE DESTRUCTOR IS DECLARED FIRST AND NEVER DEFINED AS A METHOD -- see
  * include/ModelBase.h. The structors stay self-contained C files.
  *
- * Prepare's ROM body is a 0xc tail-call veneer into func_02046b64, which is the
- * real (still unnamed) implementation taking (this, &model, &file).
+ * Prepare's ROM body is a 0xc long-call veneer (ldr ip, [pc]; bx ip;
+ * .word func_02046b64) -- no argument shuffling, so the real body's
+ * signature IS the call surface. The matched func_02046b64.c takes TWO
+ * arguments and no this: the BMD's texture-name table and the BTA
+ * object whose name entries it resolves against it. Every matched
+ * caller (Tornado, Submarine, the ov006 users, CastleWater) passes
+ * exactly those two, and the sibling veneers at 0x0201577c
+ * (MaterialChanger) and 0x0201597c (TextureSequence) are called the
+ * same way. Declared static below: a static member mangles identically,
+ * and the earlier "(this, &model, &file)" reading of this comment cost
+ * the PC port a wrong-register hunt.
  * SetFile's definition stays a mangled free function (wall 6az,
  * Fix12<int> in the signature); the declaration below is the real one.
  */
@@ -30,7 +39,7 @@ struct TextureTransformer : Animation {
     virtual ~TextureTransformer();                       /* slots 0 (D1), 1 (D0) */
 
     /* --- non-virtual --- */
-    void Prepare(BMD_File &model, BTA_File &animFile);
+    static void Prepare(BMD_File &model, BTA_File &animFile);
     void Update(ModelComponents &model);
     void SetFile(BTA_File &animFile, int flags, Fix12<int> speed,
                  u32 startFrame);        /* free function, wall 6az */

--- a/src/_ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File.cpp
+++ b/src/_ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File.cpp
@@ -1,11 +1,13 @@
 //cpp
 // @symbol _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File
 #include "TextureTransformer.h"
-extern "C" void func_02046b64(TextureTransformer *self, BMD_File *model, BTA_File *file);
+extern "C" void func_02046b64(BMD_File *model, BTA_File *file);
 
-/* The ROM body is a 0xc tail-call veneer; func_02046b64 is the real,
-   still unnamed implementation. */
+/* The ROM body is a 0xc long-call veneer (ldr ip, [pc]; bx ip); the
+   registers pass through untouched, so the matched func_02046b64.c's
+   own two-argument signature is the call surface. Prepare is static:
+   no this. */
 void TextureTransformer::Prepare(BMD_File &model, BTA_File &animFile)
 {
-    func_02046b64(this, &model, &animFile);
+    func_02046b64(&model, &animFile);
 }


### PR DESCRIPTION
`include/TextureTransformer.h` documented Prepare's 0xc veneer as tail-calling `func_02046b64(this, &model, &file)`. The ROM veneer is `ldr ip, [pc]; bx ip; .word func_02046b64` -- registers pass through untouched -- so the real body's signature IS the call surface, and the matched `func_02046b64.c` takes TWO arguments: the BMD's texture-name table and the BTA object it resolves name entries against. Every matched caller passes exactly those two (Tornado, Submarine, the ov006 users), and the sibling veneers (`MaterialChanger` 0x0201577c, `BTP TextureSequence` 0x0201597c) are called the same two-argument way in matched src.

Changes: the header comment tells the veneer story straight, `Prepare` is declared `static` (a static member mangles identically -- byte-invisible), and the veneer TU forwards two arguments instead of inventing a `this`. The three-argument reading cost the PC port a wrong-register hunt when the castle moat's BTA animation became Prepare's first host caller.

Verified: `linkcheck` on the veneer TU (0x0201587c) and `Update` (0x02015888) -- both VERIFIED, zero blind slots.