### PR TITLE
readable: IsStarCollected takes the s8 courseID its callers always declared

### DIFF
--- a/src/IsStarCollected.c
+++ b/src/IsStarCollected.c
@@ -1,4 +1,14 @@
+#include "types.h"
+/* IsStarCollected at 0x020137e0
+ * Reads the save-slot star bitmask for a course. The signature is the
+ * one every decompiled caller declares: IsStarCollectedInLevel converts
+ * its levelID to an s8 courseID before the call, NumStars walks an s8
+ * loop. The s8 also makes a callee off-ARM extend the byte itself -- as
+ * an int, a byte-laden register indexed data_0209cab4 wild on x86 (the
+ * PC port faulted at data_0209cab4 + 0x75760a00 on its first lookup).
+ */
 extern unsigned char data_0209cab4[];
-int IsStarCollected(int r0, int r1){
-  return ((1 << r1) & data_0209cab4[r0]) & 0xff;
+int IsStarCollected(s8 courseID, s32 starID)
+{
+    return ((1 << starID) & data_0209cab4[courseID]) & 0xff;
 }


### PR DESCRIPTION
The definition said `(int, int)` while both decompiled callers (`IsStarCollectedInLevel`, `NumStars`) declare `(s8 courseID, s32 starID)`. On ARM the disagreement is invisible -- mwcc passes the byte sign-extended either way, and `linkcheck` verifies the s8-signature build byte-identical (0x020137e0, zero blind slots). Off-ARM it is not: with an `int` parameter the callee indexes `data_0209cab4` with whatever the register holds, and the PC port's first star lookup faulted at `data_0209cab4 + 0x75760a00`. An `s8` parameter makes any callee extend the byte itself, which closes that class of bug for every future non-ARM consumer of the tree.

One file: the definition's parameter types and names (plus `types.h` for `s8`/`s32`); the callers' externs already agree.