### PR TITLE
Give the shared declaration headers C linkage

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -56,6 +56,7 @@ src/func_02005a58.c:
     .text start:0x02005a58 end:0x02005d94
 
 src/_ZN8CapEnemy12Unk_02005d94Ev.cpp:
+    complete
     .text start:0x02005d94 end:0x02005e28
 
 src/func_02005e28.c:
@@ -74,6 +75,7 @@ src/_ZN8CapEnemy11GetCapStateEv.cpp:
     .text start:0x02005fa0 end:0x02006054
 
 src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp:
+    complete
     .text start:0x02006054 end:0x020060f4
 
 src/_ZN8CapEnemy16GetCapEatenOffItERK7Vector3.c:
@@ -515,6 +517,7 @@ src/func_0200cb58.c:
     .text start:0x0200cb58 end:0x0200cb70
 
 src/_ZN6Camera11ChangeStateEPNS_5StateE.cpp:
+    complete
     .text start:0x0200cb70 end:0x0200cbe0
 
 src/func_0200cbe0.c:
@@ -570,6 +573,7 @@ src/func_0200d1e4.c:
     .text start:0x0200d1e4 end:0x0200d304
 
 src/_ZN6Camera14GoBehindPlayerEj.cpp:
+    complete
     .text start:0x0200d304 end:0x0200d3f8
 
 src/func_0200d3f8.c:
@@ -680,6 +684,7 @@ src/_ZN6Camera6RenderEv.cpp:
     .text start:0x0200da04 end:0x0200debc
 
 src/_ZN6Camera8BehaviorEv.cpp:
+    complete
     .text start:0x0200debc end:0x0200e338
 
 src/_ZN6Camera13InitResourcesEv.cpp:
@@ -1170,6 +1175,7 @@ src/_ZN5Actor19BeforeInitResourcesEv.c:
     .text start:0x02011268 end:0x020112c8
 
 src/_ZN5ActorD2Ev.cpp:
+    complete
     .text start:0x020112c8 end:0x02011314
 
 src/_ZN5ActorD0Ev.c:
@@ -1177,6 +1183,7 @@ src/_ZN5ActorD0Ev.c:
     .text start:0x02011314 end:0x02011374
 
 src/_ZN5ActorD1Ev.cpp:
+    complete
     .text start:0x02011374 end:0x020113c0
 
 src/_ZN5ActorC1Ev.cpp:
@@ -1700,6 +1707,7 @@ src/_ZN8SaveData16ReadMinigameDataEP16MinigameSaveData.c:
     .text start:0x02013c0c end:0x02013c5c
 
 src/_ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData.cpp:
+    complete
     .text start:0x02013c5c end:0x02013c84
 
 src/func_02013c84.c:
@@ -1719,6 +1727,7 @@ src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp:
     .text start:0x02013d54 end:0x02013dc4
 
 src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp:
+    complete
     .text start:0x02013dc4 end:0x02013e0c
 
 src/_ZN8SaveData16EraseAllSaveDataEv.c:
@@ -2879,12 +2888,15 @@ src/GetSoundMode.c:
     .text start:0x02019574 end:0x02019584
 
 src/_ZN5Timer7GetTimeEv.cpp:
+    complete
     .text start:0x02019584 end:0x020195c0
 
 src/_ZN5Timer9StopTimerEv.cpp:
+    complete
     .text start:0x020195c0 end:0x02019604
 
 src/_ZN5Timer10StartTimerEv.cpp:
+    complete
     .text start:0x02019604 end:0x02019638
 
 src/_ZN5Timer10ResetTimerEv.cpp:
@@ -3149,6 +3161,7 @@ src/func_0201cd08.cpp:
     .text start:0x0201cd08 end:0x0201ce10
 
 src/_ZN7Message21DisplaySaveStatusTextEt.cpp:
+    complete
     .text start:0x0201ce10 end:0x0201cebc
 
 src/func_0201cebc.c:
@@ -3164,6 +3177,7 @@ src/func_0201cfb8.c:
     .text start:0x0201cfb8 end:0x0201d018
 
 src/_ZN7Message22DisplayOptionsMenuTextEt.cpp:
+    complete
     .text start:0x0201d018 end:0x0201d0f8
 
 src/LoadControllerModeText.c:
@@ -3171,6 +3185,7 @@ src/LoadControllerModeText.c:
     .text start:0x0201d0f8 end:0x0201d304
 
 src/_ZN7Message25DisplayControllerModeTextEt.cpp:
+    complete
     .text start:0x0201d304 end:0x0201d418
 
 src/func_0201d418.c:
@@ -3190,9 +3205,11 @@ src/func_0201d850.c:
     .text start:0x0201d850 end:0x0201e044
 
 src/_ZN7Message16DisplayPauseTextEth.cpp:
+    complete
     .text start:0x0201e044 end:0x0201e12c
 
 src/_ZN7Message19DisplayDontSaveTextEt.cpp:
+    complete
     .text start:0x0201e12c end:0x0201e220
 
 src/func_0201e220.cpp:
@@ -3667,6 +3684,7 @@ src/func_02023178.c:
     .text start:0x02023178 end:0x02023194
 
 src/_ZN8Particle10SysTrackerD1Ev.cpp:
+    complete
     .text start:0x02023194 end:0x02023204
 
 src/_ZN8Particle10SysTrackerC1Ev.c:
@@ -4556,6 +4574,7 @@ src/func_020338b0.cpp:
     .text start:0x020338b0 end:0x020339c0
 
 src/_ZN7Message17DisplayVsExitTextEt.cpp:
+    complete
     .text start:0x020339c0 end:0x02033a80
 
 src/func_02033a80.c:
@@ -4583,6 +4602,7 @@ src/func_020341a8.cpp:
     .text start:0x020341a8 end:0x02034358
 
 src/_ZN7Message18DisplayPauseTextVSEt.cpp:
+    complete
     .text start:0x02034358 end:0x02034414
 
 src/func_02034414.cpp:
@@ -4945,9 +4965,11 @@ src/func_02036acc.c:
     .text start:0x02036acc end:0x02036ee4
 
 src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp:
+    complete
     .text start:0x02036ee4 end:0x02037024
 
 src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp:
+    complete
     .text start:0x02037024 end:0x020371b0
 
 src/func_020371b0.c:
@@ -6100,6 +6122,7 @@ src/_ZN4Heap9SetNodeIDEj.cpp:
     .text start:0x0203c408 end:0x0203c428
 
 src/_ZN9SolidHeap7VSizeofEPv.cpp:
+    complete
     .text start:0x0203c428 end:0x0203c444
 
 src/_ZN13ExpandingHeap7VSizeofEPv.cpp:
@@ -6107,9 +6130,11 @@ src/_ZN13ExpandingHeap7VSizeofEPv.cpp:
     .text start:0x0203c444 end:0x0203c454
 
 src/_ZN4Heap6SizeofEPv.cpp:
+    complete
     .text start:0x0203c454 end:0x0203c49c
 
 src/_ZN9SolidHeap14VDeallocateAllEv.cpp:
+    complete
     .text start:0x0203c49c end:0x0203c4b0
 
 src/_ZN13ExpandingHeap14VDeallocateAllEv.cpp:
@@ -6121,6 +6146,7 @@ src/_ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j.cpp:
     .text start:0x0203c4cc end:0x0203c4e4
 
 src/_ZN9SolidHeap11VDeallocateEPv.cpp:
+    complete
     .text start:0x0203c4e4 end:0x0203c50c
 
 src/_ZN13ExpandingHeap11VDeallocateEPv.c:
@@ -6144,6 +6170,7 @@ src/_ZN4Heap10ReallocateEPvj.cpp:
     .text start:0x0203c578 end:0x0203c598
 
 src/_ZN9SolidHeap11VMemoryLeftEv.cpp:
+    complete
     .text start:0x0203c598 end:0x0203c5ac
 
 src/_ZN13ExpandingHeap11VMemoryLeftEv.cpp:
@@ -6151,15 +6178,19 @@ src/_ZN13ExpandingHeap11VMemoryLeftEv.cpp:
     .text start:0x0203c5ac end:0x0203c5bc
 
 src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp:
+    complete
     .text start:0x0203c5bc end:0x0203c5d0
 
 src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp:
+    complete
     .text start:0x0203c5d0 end:0x0203c5e4
 
 src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp:
+    complete
     .text start:0x0203c5e4 end:0x0203c5f8
 
 src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp:
+    complete
     .text start:0x0203c5f8 end:0x0203c60c
 
 src/_ZN4Heap21MaxAllocationUnitSizeEv.cpp:
@@ -6199,6 +6230,7 @@ src/_ZN13ExpandingHeap9VAllocateEji.cpp:
     .text start:0x0203c6bc end:0x0203c6cc
 
 src/_ZN4Heap8AllocateEji.cpp:
+    complete
     .text start:0x0203c6cc end:0x0203c70c
 
 src/_ZN9SolidHeap8VDestroyEv.c:
@@ -6950,6 +6982,7 @@ src/_ZN8SaveData16ReadDataFromCartEPcjj.cpp:
     .text start:0x02042804 end:0x02042c3c
 
 src/_ZN8SaveData14SaveDataToCartEPcjj.cpp:
+    complete
     .text start:0x02042c3c end:0x02042f68
 
 src/func_02042f68.c:
@@ -7005,6 +7038,7 @@ src/func_020433b8.c:
     .text start:0x020433b8 end:0x02043444
 
 src/_ZN9ActorBasenwEj.cpp:
+    complete
     .text start:0x02043444 end:0x02043494
 
 src/_ZN9ActorBase13OnHeapCreatedEv.cpp:
@@ -7063,6 +7097,7 @@ src/_ZN9ActorBase21AfterCleanupResourcesEj.c:
     .text start:0x02043b2c end:0x02043bac
 
 src/_ZN9ActorBase22BeforeCleanupResourcesEv.cpp:
+    complete
     .text start:0x02043bac end:0x02043bf0
 
 src/_ZN9ActorBase16CleanupResourcesEv.cpp:
@@ -7744,9 +7779,11 @@ src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c:
     .text start:0x0204dd98 end:0x0204de0c
 
 src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.cpp:
+    complete
     .text start:0x0204de0c end:0x0204de74
 
 src/_ZN18NestedHeapIterator7AddLastEP13HeapAllocator.cpp:
+    complete
     .text start:0x0204de74 end:0x0204dee0
 
 src/_ZN18NestedHeapIterator4InitEP13HeapAllocator.cpp:

--- a/config/arm9/itcm/delinks.txt
+++ b/config/arm9/itcm/delinks.txt
@@ -1,55 +1,73 @@
     .text       start:0x01ff8000 end:0x01ffdf3c kind:code align:32
     .bss        start:0x01ffdf40 end:0x01ffdf40 kind:bss align:32
 src/func_01ffb07c.cpp:
+    complete
     .text start:0x01ffb07c end:0x01ffb098
 
 src/func_01ffb098.cpp:
+    complete
     .text start:0x01ffb098 end:0x01ffb0a4
 
 src/func_01ffb0a4.cpp:
+    complete
     .text start:0x01ffb0a4 end:0x01ffb0b0
 
 src/func_01ffb0b0.cpp:
+    complete
     .text start:0x01ffb0b0 end:0x01ffb0bc
 
 src/func_01ffb0bc.cpp:
+    complete
     .text start:0x01ffb0bc end:0x01ffb0c8
 
 src/func_01ffb0c8.cpp:
+    complete
     .text start:0x01ffb0c8 end:0x01ffb0d0
 
 src/_ZNK12MeshCollider13GetUnkOctreeYEv.cpp:
+    complete
     .text start:0x01ffb0d0 end:0x01ffb0ec
 
 src/_ZNK12MeshCollider16GetOctreeOriginYEv.cpp:
+    complete
     .text start:0x01ffb0ec end:0x01ffb0fc
 
 src/_ZN12MeshCollider10DetectClsnER13RaycastGround.cpp:
+    complete
     .text start:0x01ffd3f8 end:0x01ffd890
 
 src/_ZN12MeshCollider17GetTriangleOriginEsR7Vector3.cpp:
+    complete
     .text start:0x01ffd890 end:0x01ffd8d8
 
 src/_ZN12MeshCollider9GetNormalEsR7Vector3.cpp:
+    complete
     .text start:0x01ffd8d8 end:0x01ffd920
 
 src/_ZN12MeshCollider14GetSurfaceInfoEsR11SurfaceInfo.cpp:
+    complete
     .text start:0x01ffd920 end:0x01ffd97c
 
 src/OSReadROMArea.c:
+    complete
     .text start:0x01ffdbd8 end:0x01ffdd08
 
 src/func_01ffdd08.c:
+    complete
     .text start:0x01ffdd08 end:0x01ffdd98
 
 src/func_01ffdd98.c:
+    complete
     .text start:0x01ffdd98 end:0x01ffde00
 
 src/DMAStartTransferFB.c:
+    complete
     .text start:0x01ffde00 end:0x01ffde50
 
 src/DMAStartTransfer.c:
+    complete
     .text start:0x01ffde50 end:0x01ffde98
 
 src/func_01ffde98.c:
+    complete
     .text start:0x01ffde98 end:0x01ffdf3c

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -28,6 +28,7 @@ src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp:
     .text start:0x020ae244 end:0x020ae2b8
 
 src/_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_.cpp:
+    complete
     .text start:0x020ae2b8 end:0x020ae454
 
 src/func_ov002_020ae454.cpp:
@@ -267,9 +268,11 @@ src/_ZN13OneUpMushroom6RenderEv.cpp:
     .text start:0x020b0070 end:0x020b00e8
 
 src/_ZN13OneUpMushroom8BehaviorEv.cpp:
+    complete
     .text start:0x020b00e8 end:0x020b01c0
 
 src/_ZN13OneUpMushroom13InitResourcesEv.cpp:
+    complete
     .text start:0x020b01c0 end:0x020b0530
 
 src/MegaMushroom_Spawn.c:
@@ -487,6 +490,7 @@ src/func_ov002_020b20b4.cpp:
     .text start:0x020b20b4 end:0x020b2150
 
 src/func_ov002_020b2150.cpp:
+    complete
     .text start:0x020b2150 end:0x020b2198
 
 src/_ZN4Coin16CleanupResourcesEv.c:
@@ -498,6 +502,7 @@ src/_ZN4Coin6RenderEv.cpp:
     .text start:0x020b2284 end:0x020b2324
 
 src/_ZN4Coin8BehaviorEv.cpp:
+    complete
     .text start:0x020b2324 end:0x020b2508
 
 src/_ZN4Coin13InitResourcesEv.c:
@@ -548,6 +553,7 @@ src/_ZN11WingFeather8BehaviorEv.cpp:
     .text start:0x020b2e9c end:0x020b311c
 
 src/_ZN11WingFeather13InitResourcesEv.cpp:
+    complete
     .text start:0x020b311c end:0x020b3248
 
 src/WingFeather_Spawn.c:
@@ -569,6 +575,7 @@ src/func_ov002_020b3344.c:
     .text start:0x020b3344 end:0x020b33dc
 
 src/func_ov002_020b33dc.cpp:
+    complete
     .text start:0x020b33dc end:0x020b3518
 
 src/func_ov002_020b3518.cpp:
@@ -617,6 +624,7 @@ src/func_ov002_020b38a0.c:
     .text start:0x020b38a0 end:0x020b3ab0
 
 src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020b3ab0 end:0x020b3b14
 
 src/_ZN13BigBrickBlock6RenderEv.cpp:
@@ -624,6 +632,7 @@ src/_ZN13BigBrickBlock6RenderEv.cpp:
     .text start:0x020b3b14 end:0x020b3c0c
 
 src/_ZN13BigBrickBlock8BehaviorEv.cpp:
+    complete
     .text start:0x020b3c0c end:0x020b3d78
 
 src/_ZN13BigBrickBlock13InitResourcesEv.c:
@@ -677,6 +686,7 @@ src/func_ov002_020b42e4.c:
     .text start:0x020b42e4 end:0x020b4394
 
 src/_ZN10BrickBlock16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020b4394 end:0x020b440c
 
 src/_ZN10BrickBlock8BehaviorEv.cpp:
@@ -723,6 +733,7 @@ src/_ZN21MegaMushroomCreateTag16CleanupResourcesEv.c:
     .text start:0x020b482c end:0x020b4850
 
 src/_ZN21MegaMushroomCreateTag8BehaviorEv.cpp:
+    complete
     .text start:0x020b4850 end:0x020b49a8
 
 src/_ZN21MegaMushroomCreateTag13InitResourcesEv.c:
@@ -786,6 +797,7 @@ src/func_ov002_020b50a0.c:
     .text start:0x020b50a0 end:0x020b512c
 
 src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020b512c end:0x020b51ac
 
 src/_ZN14QuestionSwitch6RenderEv.cpp:
@@ -868,6 +880,7 @@ src/func_ov002_020b5c4c.c:
     .text start:0x020b5c4c end:0x020b5e58
 
 src/func_ov002_020b5e58.cpp:
+    complete
     .text start:0x020b5e58 end:0x020b5f9c
 
 src/func_ov002_020b5f9c.c:
@@ -1417,6 +1430,7 @@ src/func_ov002_020bb27c.c:
     .text start:0x020bb27c end:0x020bb374
 
 src/func_ov002_020bb374.cpp:
+    complete
     .text start:0x020bb374 end:0x020bb3b8
 
 src/func_ov002_020bb3b8.cpp:
@@ -1479,6 +1493,7 @@ src/_ZN8SignPost16CleanupResourcesEv.cpp:
     .text start:0x020bbdec end:0x020bbe30
 
 src/_ZN8SignPost6RenderEv.cpp:
+    complete
     .text start:0x020bbe30 end:0x020bbea4
 
 src/_ZN8SignPost8BehaviorEv.cpp:
@@ -1515,6 +1530,7 @@ src/func_ov002_020bc520.c:
     .text start:0x020bc520 end:0x020bc540
 
 src/func_ov002_020bc540.cpp:
+    complete
     .text start:0x020bc540 end:0x020bc5a8
 
 src/Seaweed_Spawn.c:
@@ -1544,6 +1560,7 @@ src/_ZN7Seaweed8BehaviorEv.c:
     .text start:0x020bc6fc end:0x020bc81c
 
 src/_ZN7Seaweed13InitResourcesEv.cpp:
+    complete
     .text start:0x020bc81c end:0x020bc8b4
 
 src/HealingHeart_Spawn.c:
@@ -1619,9 +1636,11 @@ src/func_ov002_020bd438.c:
     .text start:0x020bd438 end:0x020bd45c
 
 src/func_ov002_020bd45c.cpp:
+    complete
     .text start:0x020bd45c end:0x020bd480
 
 src/func_ov002_020bd480.cpp:
+    complete
     .text start:0x020bd480 end:0x020bd4ac
 
 src/func_ov002_020bd4ac.c:
@@ -1695,6 +1714,7 @@ src/func_ov002_020bdd9c.cpp:
     .text start:0x020bdd9c end:0x020bde14
 
 src/_ZN6Player14InitMetalWarioEv.cpp:
+    complete
     .text start:0x020bde14 end:0x020bdef0
 
 src/func_ov002_020bdef0.cpp:
@@ -1718,6 +1738,7 @@ src/_ZN6Player18SetNewHatCharacterEjjb.cpp:
     .text start:0x020be0f8 end:0x020be1e0
 
 src/_ZN6Player16SetRealCharacterEj.cpp:
+    complete
     .text start:0x020be1e0 end:0x020be324
 
 src/_ZN6Player18TurnOffToonShadingEj.cpp:
@@ -1816,6 +1837,7 @@ src/func_ov002_020bf40c.c:
     .text start:0x020bf40c end:0x020bf4e4
 
 src/_ZN6Player4HealEi.cpp:
+    complete
     .text start:0x020bf4e4 end:0x020bf548
 
 src/_ZN6Player9GetHealthEv.cpp:
@@ -2047,6 +2069,7 @@ src/func_ov002_020c3f2c.c:
     .text start:0x020c3f2c end:0x020c3f40
 
 src/_ZN6Player15St_Respawn_MainEv.cpp:
+    complete
     .text start:0x020c3f40 end:0x020c4088
 
 src/_ZN6Player15St_Respawn_InitEv.cpp:
@@ -2073,6 +2096,7 @@ src/func_ov002_020c47f4.cpp:
     .text start:0x020c47f4 end:0x020c48e0
 
 src/_ZN6Player12St_Talk_MainEv.cpp:
+    complete
     .text start:0x020c48e0 end:0x020c4bd8
 
 src/_ZN6Player12St_Talk_InitEv.cpp:
@@ -2111,6 +2135,7 @@ src/_ZN6Player12GetTalkStateEv.cpp:
     .text start:0x020c524c end:0x020c52bc
 
 src/_ZN6Player21St_StuckInGround_MainEv.cpp:
+    complete
     .text start:0x020c52bc end:0x020c5444
 
 src/func_ov002_020c5444.cpp:
@@ -2132,6 +2157,7 @@ src/func_ov002_020c56f0.c:
     .text start:0x020c56f0 end:0x020c5780
 
 src/_ZN6Player15St_DeadPit_MainEv.cpp:
+    complete
     .text start:0x020c5780 end:0x020c59c0
 
 src/_ZN6Player15St_DeadPit_InitEv.cpp:
@@ -2159,9 +2185,11 @@ src/func_ov002_020c5dec.cpp:
     .text start:0x020c5dec end:0x020c5e34
 
 src/_ZN6Player15St_DeadHit_MainEv.cpp:
+    complete
     .text start:0x020c5e34 end:0x020c6010
 
 src/_ZN6Player15St_DeadHit_InitEv.cpp:
+    complete
     .text start:0x020c6010 end:0x020c607c
 
 src/func_ov002_020c607c.cpp:
@@ -2185,6 +2213,7 @@ src/_ZN6Player17St_Squish_CleanupEv.cpp:
     .text start:0x020c65f8 end:0x020c662c
 
 src/_ZN6Player14St_Squish_MainEv.cpp:
+    complete
     .text start:0x020c662c end:0x020c6908
 
 src/func_ov002_020c6908.cpp:
@@ -2202,6 +2231,7 @@ src/func_ov002_020c6adc.cpp:
     .text start:0x020c6adc end:0x020c6b3c
 
 src/_ZN6Player16St_Teleport_MainEv.cpp:
+    complete
     .text start:0x020c6b3c end:0x020c6dc4
 
 src/_ZN6Player16St_Teleport_InitEv.cpp:
@@ -2236,6 +2266,7 @@ src/func_ov002_020c71e0.cpp:
     .text start:0x020c71e0 end:0x020c72a4
 
 src/func_ov002_020c72a4.cpp:
+    complete
     .text start:0x020c72a4 end:0x020c7350
 
 src/func_ov002_020c7350.cpp:
@@ -2278,6 +2309,7 @@ src/_ZN6Player20St_NoControl_CleanupEv.cpp:
     .text start:0x020c8128 end:0x020c816c
 
 src/_ZN6Player17St_NoControl_MainEv.cpp:
+    complete
     .text start:0x020c816c end:0x020c84b0
 
 src/func_ov002_020c84b0.c:
@@ -2554,6 +2586,7 @@ src/func_ov002_020caf98.cpp:
     .text start:0x020caf98 end:0x020cb15c
 
 src/_ZN6Player17St_Headstand_MainEv.cpp:
+    complete
     .text start:0x020cb15c end:0x020cb2f0
 
 src/_ZN6Player17St_Headstand_InitEv.cpp:
@@ -2605,6 +2638,7 @@ src/_ZN6Player16St_Shell_CleanupEv.cpp:
     .text start:0x020cc228 end:0x020cc27c
 
 src/_ZN6Player13St_Shell_MainEv.cpp:
+    complete
     .text start:0x020cc27c end:0x020cc660
 
 src/func_ov002_020cc660.c:
@@ -2620,6 +2654,7 @@ src/_ZN6Player17St_HurtWater_MainEv.cpp:
     .text start:0x020cc7d0 end:0x020cc910
 
 src/_ZN6Player17St_HurtWater_InitEv.cpp:
+    complete
     .text start:0x020cc910 end:0x020cc9c0
 
 src/_ZN6Player23St_MetalWaterWater_MainEv.cpp:
@@ -2631,6 +2666,7 @@ src/_ZN6Player23St_MetalWaterWater_InitEv.cpp:
     .text start:0x020ccc3c end:0x020ccccc
 
 src/_ZN6Player24St_MetalWaterGround_MainEv.cpp:
+    complete
     .text start:0x020ccccc end:0x020cd0d0
 
 src/_ZN6Player24St_MetalWaterGround_InitEv.cpp:
@@ -2694,6 +2730,7 @@ src/func_ov002_020ce324.c:
     .text start:0x020ce324 end:0x020ce550
 
 src/_ZN6Player12St_Swim_InitEv.cpp:
+    complete
     .text start:0x020ce550 end:0x020ce5f8
 
 src/func_ov002_020ce5f8.c:
@@ -2753,9 +2790,11 @@ src/func_ov002_020cf384.c:
     .text start:0x020cf384 end:0x020cf398
 
 src/_ZN6Player20St_CeilingGrate_MainEv.cpp:
+    complete
     .text start:0x020cf398 end:0x020cf6bc
 
 src/_ZN6Player20St_CeilingGrate_InitEv.cpp:
+    complete
     .text start:0x020cf6bc end:0x020cf700
 
 src/func_ov002_020cf700.c:
@@ -2763,6 +2802,7 @@ src/func_ov002_020cf700.c:
     .text start:0x020cf700 end:0x020cf714
 
 src/_ZN6Player14St_OnWall_MainEv.cpp:
+    complete
     .text start:0x020cf714 end:0x020cfa90
 
 src/_ZN6Player14St_OnWall_InitEv.cpp:
@@ -2791,6 +2831,7 @@ src/func_ov002_020d06c0.cpp:
     .text start:0x020d06c0 end:0x020d0824
 
 src/_ZN6Player17St_LedgeGrab_MainEv.cpp:
+    complete
     .text start:0x020d0824 end:0x020d08b0
 
 src/_ZN6Player17St_LedgeGrab_InitEv.cpp:
@@ -2798,12 +2839,14 @@ src/_ZN6Player17St_LedgeGrab_InitEv.cpp:
     .text start:0x020d08b0 end:0x020d092c
 
 src/_ZN6Player20St_LedgeHang_CleanupEv.cpp:
+    complete
     .text start:0x020d092c end:0x020d0948
 
 src/func_ov002_020d0948.c:
     .text start:0x020d0948 end:0x020d0a44
 
 src/_ZN6Player17St_LedgeHang_MainEv.cpp:
+    complete
     .text start:0x020d0a44 end:0x020d0c54
 
 src/_ZN6Player17St_LedgeHang_InitEv.cpp:
@@ -2821,6 +2864,7 @@ src/_ZN6Player17St_WallSlide_InitEv.cpp:
     .text start:0x020d0e8c end:0x020d0ee0
 
 src/_ZN6Player13St_Crawl_MainEv.cpp:
+    complete
     .text start:0x020d0ee0 end:0x020d112c
 
 src/_ZN6Player13St_Crawl_InitEv.cpp:
@@ -2840,12 +2884,15 @@ src/func_ov002_020d12b0.cpp:
     .text start:0x020d12b0 end:0x020d1354
 
 src/_ZN6Player14St_Crouch_MainEv.cpp:
+    complete
     .text start:0x020d1354 end:0x020d15e0
 
 src/_ZN6Player14St_Crouch_InitEv.cpp:
+    complete
     .text start:0x020d15e0 end:0x020d16bc
 
 src/_ZN6Player17St_HoldHeavy_MainEv.cpp:
+    complete
     .text start:0x020d16bc end:0x020d19a8
 
 src/_ZN6Player17St_HoldHeavy_InitEv.cpp:
@@ -2857,6 +2904,7 @@ src/_ZN6Player20St_HoldLight_CleanupEv.cpp:
     .text start:0x020d19fc end:0x020d1a1c
 
 src/_ZN6Player17St_HoldLight_MainEv.cpp:
+    complete
     .text start:0x020d1a1c end:0x020d1ea0
 
 src/_ZN6Player17St_HoldLight_InitEv.cpp:
@@ -2891,6 +2939,7 @@ src/_ZN6Player15St_Wait_CleanupEv.cpp:
     .text start:0x020d2378 end:0x020d2404
 
 src/_ZN6Player12St_Wait_MainEv.cpp:
+    complete
     .text start:0x020d2404 end:0x020d2da0
 
 src/func_ov002_020d2da0.c:
@@ -2918,6 +2967,7 @@ src/func_ov002_020d3498.c:
     .text start:0x020d3498 end:0x020d34bc
 
 src/_ZN6Player18St_TurnAround_MainEv.cpp:
+    complete
     .text start:0x020d34bc end:0x020d369c
 
 src/_ZN6Player18St_TurnAround_InitEv.cpp:
@@ -2929,6 +2979,7 @@ src/func_ov002_020d36d8.c:
     .text start:0x020d36d8 end:0x020d38c0
 
 src/_ZN6Player12St_Walk_MainEv.cpp:
+    complete
     .text start:0x020d38c0 end:0x020d3b9c
 
 src/func_ov002_020d413c.c:
@@ -2936,6 +2987,7 @@ src/func_ov002_020d413c.c:
     .text start:0x020d413c end:0x020d4270
 
 src/_ZN6Player12St_Walk_InitEv.cpp:
+    complete
     .text start:0x020d4270 end:0x020d4540
 
 src/func_ov002_020d4540.c:
@@ -2962,6 +3014,7 @@ src/func_ov002_020d4d88.c:
     .text start:0x020d4d88 end:0x020d4de8
 
 src/_ZN6Player12St_Bonk_MainEv.cpp:
+    complete
     .text start:0x020d4de8 end:0x020d4f8c
 
 src/_ZN6Player12St_Bonk_InitEv.cpp:
@@ -2977,6 +3030,7 @@ src/_ZN6Player16St_BurnLava_MainEv.cpp:
     .text start:0x020d5038 end:0x020d529c
 
 src/_ZN6Player16St_BurnLava_InitEv.cpp:
+    complete
     .text start:0x020d529c end:0x020d5338
 
 src/func_ov002_020d5338.cpp:
@@ -2992,6 +3046,7 @@ src/_ZN6Player16St_BurnFire_InitEv.cpp:
     .text start:0x020d5750 end:0x020d57d8
 
 src/_ZN6Player4BurnEv.cpp:
+    complete
     .text start:0x020d57d8 end:0x020d5834
 
 src/_ZN6Player19St_Electrocute_MainEv.c:
@@ -3003,6 +3058,7 @@ src/_ZN6Player19St_Electrocute_InitEv.cpp:
     .text start:0x020d59b0 end:0x020d5a1c
 
 src/_ZN6Player5ShockEj.cpp:
+    complete
     .text start:0x020d5a1c end:0x020d5ab4
 
 src/func_ov002_020d5ab4.c:
@@ -3042,9 +3098,11 @@ src/func_ov002_020d6084.c:
     .text start:0x020d6084 end:0x020d60b8
 
 src/_ZN6Player20St_InYoshiMouth_MainEv.cpp:
+    complete
     .text start:0x020d60b8 end:0x020d62f8
 
 src/_ZN6Player20St_InYoshiMouth_InitEv.cpp:
+    complete
     .text start:0x020d62f8 end:0x020d6334
 
 src/func_ov002_020d6334.c:
@@ -3056,6 +3114,7 @@ src/func_ov002_020d6368.c:
     .text start:0x020d6368 end:0x020d6474
 
 src/_ZN6Player15St_Swallow_MainEv.cpp:
+    complete
     .text start:0x020d6474 end:0x020d666c
 
 src/_ZN6Player15St_Swallow_InitEv.cpp:
@@ -3106,6 +3165,7 @@ src/func_ov002_020d71ec.c:
     .text start:0x020d71ec end:0x020d736c
 
 src/_ZN6Player21St_YoshiPower_CleanupEv.cpp:
+    complete
     .text start:0x020d736c end:0x020d7430
 
 src/func_ov002_020d7430.cpp:
@@ -3116,6 +3176,7 @@ src/_ZN6Player18St_YoshiPower_MainEv.cpp:
     .text start:0x020d7504 end:0x020d7ed0
 
 src/_ZN6Player18St_YoshiPower_InitEv.cpp:
+    complete
     .text start:0x020d7ed0 end:0x020d80d0
 
 src/func_ov002_020d80d0.c:
@@ -3185,6 +3246,7 @@ src/func_ov002_020d8d10.c:
     .text start:0x020d8d10 end:0x020d8e70
 
 src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp:
+    complete
     .text start:0x020d8e70 end:0x020d91b8
 
 src/func_ov002_020d91b8.c:
@@ -3217,6 +3279,7 @@ src/_ZN6Player12St_Hurt_MainEv.cpp:
     .text start:0x020d966c end:0x020d98b4
 
 src/func_ov002_020d98b4.cpp:
+    complete
     .text start:0x020d98b4 end:0x020d99a4
 
 src/func_ov002_020d99a4.c:
@@ -3262,6 +3325,7 @@ src/_ZN6Player22St_GrabBowserTail_MainEv.cpp:
     .text start:0x020da438 end:0x020da794
 
 src/_ZN6Player22St_GrabBowserTail_InitEv.cpp:
+    complete
     .text start:0x020da794 end:0x020da7f4
 
 src/_ZN6Player9DropActorEv.cpp:
@@ -3293,6 +3357,7 @@ src/func_ov002_020dacb4.c:
     .text start:0x020dacb4 end:0x020dae6c
 
 src/_ZN6Player13St_Throw_MainEv.cpp:
+    complete
     .text start:0x020dae6c end:0x020dafd4
 
 src/_ZN6Player13St_Throw_InitEv.cpp:
@@ -3304,6 +3369,7 @@ src/_ZN6Player17St_Thrown_CleanupEv.cpp:
     .text start:0x020db0a4 end:0x020db0bc
 
 src/_ZN6Player14St_Thrown_MainEv.cpp:
+    complete
     .text start:0x020db0bc end:0x020db2e8
 
 src/_ZN6Player14St_Thrown_InitEv.cpp:
@@ -3315,6 +3381,7 @@ src/_ZN6Player18St_Grabbed_CleanupEv.cpp:
     .text start:0x020db368 end:0x020db3bc
 
 src/_ZN6Player15St_Grabbed_MainEv.cpp:
+    complete
     .text start:0x020db3bc end:0x020db4d8
 
 src/_ZN6Player15St_Grabbed_InitEv.cpp:
@@ -3386,6 +3453,7 @@ src/func_ov002_020dc174.c:
     .text start:0x020dc174 end:0x020dc1d0
 
 src/_ZN6Player17St_SlideKick_MainEv.cpp:
+    complete
     .text start:0x020dc1d0 end:0x020dc3e0
 
 src/_ZN6Player17St_SlideKick_InitEv.cpp:
@@ -3404,6 +3472,7 @@ src/func_ov002_020dc560.c:
     .text start:0x020dc560 end:0x020dc740
 
 src/_ZN6Player17St_ButtSlide_MainEv.cpp:
+    complete
     .text start:0x020dc740 end:0x020dca80
 
 src/_ZN6Player17St_ButtSlide_InitEv.cpp:
@@ -3415,6 +3484,7 @@ src/func_ov002_020dcafc.c:
     .text start:0x020dcafc end:0x020dcc28
 
 src/_ZN6Player20St_StomachSlide_MainEv.cpp:
+    complete
     .text start:0x020dcc28 end:0x020dd104
 
 src/_ZN6Player20St_StomachSlide_InitEv.cpp:
@@ -3442,6 +3512,7 @@ src/func_ov002_020dd2f4.c:
     .text start:0x020dd2f4 end:0x020dd3c4
 
 src/_ZN6Player17St_PunchKick_MainEv.cpp:
+    complete
     .text start:0x020dd3c4 end:0x020dd5ec
 
 src/func_ov002_020dd5ec.c:
@@ -3449,6 +3520,7 @@ src/func_ov002_020dd5ec.c:
     .text start:0x020dd5ec end:0x020dd79c
 
 src/_ZN6Player17St_PunchKick_InitEv.cpp:
+    complete
     .text start:0x020dd79c end:0x020dd824
 
 src/func_ov002_020dd824.cpp:
@@ -3487,6 +3559,7 @@ src/_ZN6Player19St_TornadoSpin_MainEv.cpp:
     .text start:0x020ddfdc end:0x020de2a0
 
 src/_ZN6Player19St_TornadoSpin_InitEv.cpp:
+    complete
     .text start:0x020de2a0 end:0x020de328
 
 src/func_ov002_020de328.c:
@@ -3498,6 +3571,7 @@ src/func_ov002_020de33c.c:
     .text start:0x020de33c end:0x020de3b4
 
 src/_ZN6Player18St_Balloon_CleanupEv.cpp:
+    complete
     .text start:0x020de3b4 end:0x020de3d0
 
 src/func_ov002_020de3d0.c:
@@ -3513,6 +3587,7 @@ src/_ZN6Player15St_Balloon_MainEv.cpp:
     .text start:0x020de45c end:0x020de8ac
 
 src/_ZN6Player15St_Balloon_InitEv.cpp:
+    complete
     .text start:0x020de8ac end:0x020de968
 
 src/func_ov002_020de968.cpp:
@@ -3525,6 +3600,7 @@ src/_ZN6Player17St_WindCarry_MainEv.cpp:
     .text start:0x020deab8 end:0x020dec0c
 
 src/_ZN6Player17St_WindCarry_InitEv.cpp:
+    complete
     .text start:0x020dec0c end:0x020dec70
 
 src/func_ov002_020dec70.c:
@@ -3544,6 +3620,7 @@ src/_ZN6Player17St_Cannon_CleanupEv.cpp:
     .text start:0x020deefc end:0x020def14
 
 src/_ZN6Player14St_Cannon_MainEv.cpp:
+    complete
     .text start:0x020def14 end:0x020df208
 
 src/_ZN6Player14St_Cannon_InitEv.cpp:
@@ -3570,9 +3647,11 @@ src/_ZN6Player14St_Owl_CleanupEv.cpp:
     .text start:0x020df3c8 end:0x020df3ec
 
 src/_ZN6Player11St_Owl_MainEv.cpp:
+    complete
     .text start:0x020df3ec end:0x020df740
 
 src/_ZN6Player11St_Owl_InitEv.cpp:
+    complete
     .text start:0x020df740 end:0x020df7ac
 
 src/func_ov002_020df7ac.c:
@@ -3603,6 +3682,7 @@ src/func_ov002_020e032c.c:
     .text start:0x020e032c end:0x020e03b8
 
 src/_ZN6Player16InitWingFeathersEb.cpp:
+    complete
     .text start:0x020e03b8 end:0x020e0478
 
 src/func_ov002_020e0478.cpp:
@@ -3614,6 +3694,7 @@ src/func_ov002_020e04a4.c:
     .text start:0x020e04a4 end:0x020e04ec
 
 src/_ZN6Player12St_Land_MainEv.cpp:
+    complete
     .text start:0x020e04ec end:0x020e088c
 
 src/_ZN6Player12St_Land_InitEv.cpp:
@@ -3655,6 +3736,7 @@ src/func_ov002_020e0f38.cpp:
     .text start:0x020e0f38 end:0x020e0fac
 
 src/_ZN6Player19St_CrazedCrate_InitEv.cpp:
+    complete
     .text start:0x020e0fac end:0x020e1020
 
 src/_ZN6Player10SpinBounceE5Fix12IiE.cpp:
@@ -3686,6 +3768,7 @@ src/_ZN6Player16St_LongJump_InitEv.cpp:
     .text start:0x020e127c end:0x020e13c0
 
 src/_ZN6Player16St_SideFlip_MainEv.cpp:
+    complete
     .text start:0x020e13c0 end:0x020e162c
 
 src/_ZN6Player17St_WaterJump_InitEv.cpp:
@@ -3697,6 +3780,7 @@ src/_ZN6Player21St_HeadstandJump_InitEv.cpp:
     .text start:0x020e16a4 end:0x020e1714
 
 src/_ZN6Player16St_WallJump_MainEv.cpp:
+    complete
     .text start:0x020e1714 end:0x020e17f8
 
 src/func_ov002_020e17f8.c:
@@ -3730,6 +3814,7 @@ src/func_ov002_020e200c.c:
     .text start:0x020e200c end:0x020e2118
 
 src/_ZN6Player12St_Jump_MainEv.cpp:
+    complete
     .text start:0x020e2118 end:0x020e22c0
 
 src/_ZN6Player12St_Jump_InitEv.cpp:
@@ -3788,6 +3873,7 @@ src/_ZN6Player7IsStateERNS_5StateE.c:
     .text start:0x020e308c end:0x020e30a0
 
 src/_ZN6Player11ChangeStateERNS_5StateE.cpp:
+    complete
     .text start:0x020e30a0 end:0x020e32d4
 
 src/_ZN6Player16CleanupResourcesEv.cpp:
@@ -3798,6 +3884,7 @@ src/_ZN6Player16OnPendingDestroyEv.cpp:
     .text start:0x020e3a04 end:0x020e3a08
 
 src/_ZN6Player6RenderEv.cpp:
+    complete
     .text start:0x020e3a08 end:0x020e3e00
 
 src/func_ov002_020e3e00.cpp:
@@ -3832,6 +3919,7 @@ src/func_ov002_020e4bb8.c:
     .text start:0x020e4bb8 end:0x020e4d24
 
 src/_ZN6Player8BehaviorEv.cpp:
+    complete
     .text start:0x020e4d24 end:0x020e558c
 
 src/_ZN6Player13InitResourcesEv.cpp:
@@ -4180,9 +4268,11 @@ src/_ZN10StarMarker16OnPendingDestroyEv.cpp:
     .text start:0x020eab8c end:0x020eabcc
 
 src/_ZN10StarMarker16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020eabcc end:0x020eac18
 
 src/_ZN9PowerStar16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020eac18 end:0x020eacb8
 
 src/_ZN10StarMarker6RenderEv.cpp:
@@ -4194,9 +4284,11 @@ src/_ZN9PowerStar6RenderEv.cpp:
     .text start:0x020eacf4 end:0x020ead90
 
 src/_ZN10StarMarker8BehaviorEv.cpp:
+    complete
     .text start:0x020ead90 end:0x020eb05c
 
 src/_ZN9PowerStar8BehaviorEv.cpp:
+    complete
     .text start:0x020eb05c end:0x020eb204
 
 src/_ZN10StarMarker13InitResourcesEv.cpp:
@@ -4397,9 +4489,11 @@ src/_ZN8YoshiEgg16CleanupResourcesEv.cpp:
     .text start:0x020edf54 end:0x020edf98
 
 src/_ZN8YoshiEgg6RenderEv.cpp:
+    complete
     .text start:0x020edf98 end:0x020ee010
 
 src/_ZN8YoshiEgg8BehaviorEv.cpp:
+    complete
     .text start:0x020ee010 end:0x020ee144
 
 src/_ZN8YoshiEgg13InitResourcesEv.c:
@@ -4440,9 +4534,11 @@ src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp:
     .text start:0x020ee830 end:0x020ee870
 
 src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp:
+    complete
     .text start:0x020ee870 end:0x020ee934
 
 src/_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_.cpp:
+    complete
     .text start:0x020ee934 end:0x020eea50
 
 src/_ZN8PlatformC2Ev.c:
@@ -4610,6 +4706,7 @@ src/func_ov002_020f069c.c:
     .text start:0x020f069c end:0x020f06c0
 
 src/func_ov002_020f06c0.cpp:
+    complete
     .text start:0x020f06c0 end:0x020f07dc
 
 src/func_ov002_020f07dc.c:
@@ -4806,6 +4903,7 @@ src/_ZN8MugenBgm6RenderEv.c:
     .text start:0x020f1c5c end:0x020f1c64
 
 src/_ZN8MugenBgm8BehaviorEv.cpp:
+    complete
     .text start:0x020f1c64 end:0x020f1eb4
 
 src/_ZN8MugenBgm13InitResourcesEv.cpp:
@@ -5455,6 +5553,7 @@ src/_ZN7MinimapD0Ev.c:
     .text start:0x020f978c end:0x020f97d0
 
 src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp:
+    complete
     .text start:0x020f97d0 end:0x020f99a8
 
 src/_ZN7Minimap19UpdateLevelSpecificEv.cpp:
@@ -5535,9 +5634,11 @@ src/_ZN3HUD13UpdateVsTimerEv.cpp:
     .text start:0x020fce9c end:0x020fcfec
 
 src/_ZN3HUD17RenderHealthMeterEv.cpp:
+    complete
     .text start:0x020fcfec end:0x020fd218
 
 src/_ZN3HUD17UpdateHealthMeterEv.cpp:
+    complete
     .text start:0x020fd218 end:0x020fd5d4
 
 src/_ZN3HUD16CleanupResourcesEv.cpp:
@@ -5563,6 +5664,7 @@ src/_ZN3HUDC1Ev.c:
     .text start:0x020fe154 end:0x020fe190
 
 src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp:
+    complete
     .text start:0x020fe190 end:0x020fe33c
 
 src/_Z11LoadObjectsRN11LVL_Overlay8ObjTableEij.c:
@@ -5686,6 +5788,7 @@ src/_ZN6Bullet6RenderEv.cpp:
     .text start:0x020fee18 end:0x020fee44
 
 src/_ZN6Bullet8BehaviorEv.cpp:
+    complete
     .text start:0x020fee44 end:0x020feef4
 
 src/_ZN6Bullet13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov003/delinks.txt
+++ b/config/arm9/overlays/ov003/delinks.txt
@@ -22,6 +22,7 @@ src/func_ov003_020ad7a4.cpp:
     .text start:0x020ad7a4 end:0x020ad814
 
 src/func_ov003_020ad814.cpp:
+    complete
     .text start:0x020ad814 end:0x020ada80
 
 src/func_ov003_020ada80.c:
@@ -78,6 +79,7 @@ src/func_ov003_020ae6f0.c:
     .text start:0x020ae6f0 end:0x020ae6f4
 
 src/func_ov003_020af86c.cpp:
+    complete
     .text start:0x020af86c end:0x020af8a0
 
 src/StarSelect_Spawn.cpp:
@@ -103,6 +105,7 @@ src/func_ov003_020b0810.c:
     .text start:0x020b0810 end:0x020b0814
 
 src/func_ov003_020b0814.cpp:
+    complete
     .text start:0x020b0814 end:0x020b0894
 
 src/func_ov003_020b0894.c:

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -186,6 +186,7 @@ src/func_ov004_020ae3b4.c:
     .text start:0x020ae3b4 end:0x020ae5c4
 
 src/_ZN5Enemy12KillByAttackER5Actor.cpp:
+    complete
     .text start:0x020aea30 end:0x020aea78
 
 src/func_ov004_020aea78.cpp:
@@ -200,6 +201,7 @@ src/func_ov004_020aeed8.cpp:
     .text start:0x020aeed8 end:0x020af04c
 
 src/func_ov004_020af04c.cpp:
+    complete
     .text start:0x020af04c end:0x020af094
 
 src/func_ov004_020af094.cpp:
@@ -290,6 +292,7 @@ src/func_ov004_020b04ec.c:
     .text start:0x020b04ec end:0x020b04f4
 
 src/func_ov004_020b04f4.cpp:
+    complete
     .text start:0x020b04f4 end:0x020b0618
 
 src/func_ov004_020b0618.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -131,6 +131,7 @@ src/func_ov006_020c1764.cpp:
     .text start:0x020c1764 end:0x020c1804
 
 src/func_ov006_020c1804.cpp:
+    complete
     .text start:0x020c1804 end:0x020c19d0
 
 src/func_ov006_020c19d0.cpp:
@@ -968,6 +969,7 @@ src/func_ov006_020cb838.cpp:
     .text start:0x020cb838 end:0x020cbaec
 
 src/func_ov006_020cbaec.cpp:
+    complete
     .text start:0x020cbaec end:0x020cbd7c
 
 src/func_ov006_020cbd7c.cpp:
@@ -1324,6 +1326,7 @@ src/func_ov006_020d1018.c:
     .text start:0x020d1018 end:0x020d10b8
 
 src/func_ov006_020d10b8.cpp:
+    complete
     .text start:0x020d10b8 end:0x020d116c
 
 src/func_ov006_020d116c.c:
@@ -1721,6 +1724,7 @@ src/func_ov006_020d95a4.cpp:
     .text start:0x020d95a4 end:0x020d9638
 
 src/func_ov006_020d9638.cpp:
+    complete
     .text start:0x020d9638 end:0x020d96e0
 
 src/func_ov006_020d96e0.c:
@@ -1820,6 +1824,7 @@ src/func_ov006_020da994.c:
     .text start:0x020da994 end:0x020da9c4
 
 src/func_ov006_020da9c4.cpp:
+    complete
     .text start:0x020da9c4 end:0x020dabec
 
 src/func_ov006_020dabec.c:
@@ -2090,6 +2095,7 @@ src/func_ov006_020de988.cpp:
     .text start:0x020de988 end:0x020dea1c
 
 src/func_ov006_020dea1c.cpp:
+    complete
     .text start:0x020dea1c end:0x020deac4
 
 src/func_ov006_020deac4.c:
@@ -2196,9 +2202,11 @@ src/func_ov006_020e0068.c:
     .text start:0x020e0068 end:0x020e0204
 
 src/func_ov006_020e0204.cpp:
+    complete
     .text start:0x020e0204 end:0x020e0308
 
 src/func_ov006_020e0308.cpp:
+    complete
     .text start:0x020e0308 end:0x020e0574
 
 src/func_ov006_020e0574.cpp:
@@ -2567,6 +2575,7 @@ src/func_ov006_020e67f0.c:
     .text start:0x020e67f0 end:0x020e683c
 
 src/func_ov006_020e683c.cpp:
+    complete
     .text start:0x020e683c end:0x020e6894
 
 src/func_ov006_020e6894.c:
@@ -2637,12 +2646,15 @@ src/_ZN17MgBounceAndPounce12BeforeRenderEv.cpp:
     .text start:0x020e7040 end:0x020e7074
 
 src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp:
+    complete
     .text start:0x020e7074 end:0x020e70c0
 
 src/_ZN17MgBounceAndPounce18AfterInitResourcesEj.cpp:
+    complete
     .text start:0x020e70c0 end:0x020e70e4
 
 src/_ZN17MgBounceAndPounce19BeforeInitResourcesEv.cpp:
+    complete
     .text start:0x020e70e4 end:0x020e7110
 
 src/func_ov006_020e7110.c:
@@ -2925,9 +2937,11 @@ src/func_ov006_020e9cec.c:
     .text start:0x020e9cec end:0x020e9d1c
 
 src/func_ov006_020e9d1c.cpp:
+    complete
     .text start:0x020e9d1c end:0x020e9e00
 
 src/func_ov006_020e9e00.cpp:
+    complete
     .text start:0x020e9e00 end:0x020e9e70
 
 src/func_ov006_020e9e70.cpp:
@@ -2943,6 +2957,7 @@ src/func_ov006_020ea280.c:
     .text start:0x020ea280 end:0x020ea2c8
 
 src/func_ov006_020ea2c8.cpp:
+    complete
     .text start:0x020ea2c8 end:0x020ea324
 
 src/func_ov006_020ea324.c:
@@ -3112,6 +3127,7 @@ src/func_ov006_020ecee4.c:
     .text start:0x020ecee4 end:0x020ed18c
 
 src/func_ov006_020ed18c.cpp:
+    complete
     .text start:0x020ed18c end:0x020ed270
 
 src/func_ov006_020ed270.c:
@@ -3162,6 +3178,7 @@ src/func_ov006_020eda48.c:
     .text start:0x020eda48 end:0x020edb04
 
 src/func_ov006_020edb04.cpp:
+    complete
     .text start:0x020edb04 end:0x020edcb0
 
 src/func_ov006_020edcb0.c:
@@ -3181,6 +3198,7 @@ src/func_ov006_020edec0.cpp:
     .text start:0x020edec0 end:0x020edf54
 
 src/func_ov006_020edf54.cpp:
+    complete
     .text start:0x020edf54 end:0x020edffc
 
 src/func_ov006_020edffc.c:
@@ -3235,9 +3253,11 @@ src/func_ov006_020ee658.c:
     .text start:0x020ee658 end:0x020ee690
 
 src/func_ov006_020ee690.cpp:
+    complete
     .text start:0x020ee690 end:0x020ee8dc
 
 src/func_ov006_020ee8dc.cpp:
+    complete
     .text start:0x020ee8dc end:0x020ee994
 
 src/MgBounceAndPounce_Spawn.cpp:
@@ -3249,6 +3269,7 @@ src/func_ov006_020eebe8.cpp:
     .text start:0x020eebe8 end:0x020eec9c
 
 src/func_ov006_020eec9c.cpp:
+    complete
     .text start:0x020eec9c end:0x020eed64
 
 src/func_ov006_020eed64.c:
@@ -3344,6 +3365,7 @@ src/func_ov006_020ef7f8.c:
     .text start:0x020ef7f8 end:0x020ef834
 
 src/func_ov006_020ef834.cpp:
+    complete
     .text start:0x020ef834 end:0x020efa84
 
 src/func_ov006_020efa84.c:
@@ -3573,6 +3595,7 @@ src/func_ov006_020f3834.cpp:
     .text start:0x020f3834 end:0x020f3888
 
 src/func_ov006_020f3888.cpp:
+    complete
     .text start:0x020f3888 end:0x020f38f0
 
 src/func_ov006_020f38f0.c:
@@ -3751,6 +3774,7 @@ src/func_ov006_020f5564.cpp:
     .text start:0x020f5564 end:0x020f55b8
 
 src/func_ov006_020f55b8.cpp:
+    complete
     .text start:0x020f55b8 end:0x020f5620
 
 src/func_ov006_020f5620.c:
@@ -3945,6 +3969,7 @@ src/func_ov006_020f7634.cpp:
     .text start:0x020f7634 end:0x020f76a8
 
 src/func_ov006_020f76a8.cpp:
+    complete
     .text start:0x020f76a8 end:0x020f7730
 
 src/func_ov006_020f7730.c:
@@ -4038,6 +4063,7 @@ src/func_ov006_020f8ef4.cpp:
     .text start:0x020f8ef4 end:0x020f8f68
 
 src/func_ov006_020f8f68.cpp:
+    complete
     .text start:0x020f8f68 end:0x020f8ff0
 
 src/func_ov006_020f8ff0.c:
@@ -4105,6 +4131,7 @@ src/func_ov006_020f9fe0.c:
     .text start:0x020f9fe0 end:0x020f9ffc
 
 src/func_ov006_020f9ffc.cpp:
+    complete
     .text start:0x020f9ffc end:0x020fa13c
 
 src/func_ov006_020fa13c.c:
@@ -4112,9 +4139,11 @@ src/func_ov006_020fa13c.c:
     .text start:0x020fa13c end:0x020fa3d0
 
 src/func_ov006_020fa4d4.cpp:
+    complete
     .text start:0x020fa4d4 end:0x020fa56c
 
 src/func_ov006_020fa56c.cpp:
+    complete
     .text start:0x020fa56c end:0x020fa6ac
 
 src/MgPairAGoneAndOn_Spawn.cpp:
@@ -4902,6 +4931,7 @@ src/func_ov006_0210730c.c:
     .text start:0x0210730c end:0x02107358
 
 src/func_ov006_02107358.cpp:
+    complete
     .text start:0x02107358 end:0x021073b0
 
 src/func_ov006_021073b0.c:
@@ -4916,6 +4946,7 @@ src/func_ov006_0210788c.c:
     .text start:0x0210788c end:0x02107920
 
 src/func_ov006_02107920.cpp:
+    complete
     .text start:0x02107920 end:0x021079c8
 
 src/func_ov006_021079c8.c:
@@ -5056,6 +5087,7 @@ src/func_ov006_02109aac.c:
     .text start:0x02109aac end:0x0210a194
 
 src/func_ov006_0210a194.cpp:
+    complete
     .text start:0x0210a194 end:0x0210a400
 
 src/MgMushroomRoulette_Spawn.cpp:
@@ -5091,9 +5123,11 @@ src/func_ov006_0210a664.c:
     .text start:0x0210a664 end:0x0210a698
 
 src/func_ov006_0210a698.cpp:
+    complete
     .text start:0x0210a698 end:0x0210a6e4
 
 src/func_ov006_0210a6e4.cpp:
+    complete
     .text start:0x0210a6e4 end:0x0210a708
 
 src/func_ov006_0210a708.c:
@@ -5109,6 +5143,7 @@ src/func_ov006_0210a954.cpp:
     .text start:0x0210a954 end:0x0210a9a8
 
 src/func_ov006_0210a9a8.cpp:
+    complete
     .text start:0x0210a9a8 end:0x0210aa10
 
 src/func_ov006_0210aa10.c:
@@ -5120,6 +5155,7 @@ src/func_ov006_0210aa3c.c:
     .text start:0x0210aa3c end:0x0210aa60
 
 src/func_ov006_0210aa60.cpp:
+    complete
     .text start:0x0210aa60 end:0x0210ab08
 
 src/func_ov006_0210ab08.c:
@@ -5159,6 +5195,7 @@ src/func_ov006_0210b648.c:
     .text start:0x0210b648 end:0x0210bcb0
 
 src/func_ov006_0210bcb0.cpp:
+    complete
     .text start:0x0210bcb0 end:0x0210bdb0
 
 src/func_ov006_0210bdb0.cpp:
@@ -5254,6 +5291,7 @@ src/func_ov006_0210d740.c:
     .text start:0x0210d740 end:0x0210d7e0
 
 src/func_ov006_0210d7e0.cpp:
+    complete
     .text start:0x0210d7e0 end:0x0210d894
 
 src/func_ov006_0210d894.c:
@@ -5757,6 +5795,7 @@ src/func_ov006_02119904.cpp:
     .text start:0x02119904 end:0x02119958
 
 src/func_ov006_02119958.cpp:
+    complete
     .text start:0x02119958 end:0x021199c0
 
 src/func_ov006_021199c0.c:
@@ -6381,6 +6420,7 @@ src/func_ov006_021207dc.c:
     .text start:0x021207dc end:0x02120880
 
 src/func_ov006_02120880.cpp:
+    complete
     .text start:0x02120880 end:0x02120938
 
 src/func_ov006_02120938.c:
@@ -6475,6 +6515,7 @@ src/func_ov006_021212fc.c:
     .text start:0x021212fc end:0x021214f8
 
 src/func_ov006_021214f8.cpp:
+    complete
     .text start:0x021214f8 end:0x0212157c
 
 src/func_ov006_0212157c.c:
@@ -6533,6 +6574,7 @@ src/func_ov006_02121fa4.c:
     .text start:0x02121fa4 end:0x02122198
 
 src/func_ov006_02122198.cpp:
+    complete
     .text start:0x02122198 end:0x0212231c
 
 src/func_ov006_0212231c.c:
@@ -6552,6 +6594,7 @@ src/func_ov006_021225ac.c:
     .text start:0x021225ac end:0x021226b0
 
 src/func_ov006_021226b0.cpp:
+    complete
     .text start:0x021226b0 end:0x021227c8
 
 src/func_ov006_021227c8.cpp:
@@ -6685,9 +6728,11 @@ src/func_ov006_02124298.c:
     .text start:0x02124298 end:0x021242cc
 
 src/func_ov006_021242cc.cpp:
+    complete
     .text start:0x021242cc end:0x021243ec
 
 src/func_ov006_021243ec.cpp:
+    complete
     .text start:0x021243ec end:0x021245a8
 
 src/func_ov006_021245a8.c:
@@ -6702,6 +6747,7 @@ src/func_ov006_02124908.c:
     .text start:0x02124908 end:0x0212497c
 
 src/func_ov006_0212497c.cpp:
+    complete
     .text start:0x0212497c end:0x02124a04
 
 src/func_ov006_02124a04.c:
@@ -6753,6 +6799,7 @@ src/func_ov006_02125248.c:
     .text start:0x02125248 end:0x0212527c
 
 src/func_ov006_0212527c.cpp:
+    complete
     .text start:0x0212527c end:0x02125364
 
 src/func_ov006_02125364.c:
@@ -6767,6 +6814,7 @@ src/func_ov006_021254c0.cpp:
     .text start:0x021254c0 end:0x0212551c
 
 src/func_ov006_0212551c.cpp:
+    complete
     .text start:0x0212551c end:0x021255f8
 
 src/MgLuckyStars_Spawn.cpp:
@@ -6778,6 +6826,7 @@ src/func_ov006_0212568c.cpp:
     .text start:0x0212568c end:0x0212573c
 
 src/func_ov006_0212573c.cpp:
+    complete
     .text start:0x0212573c end:0x02125800
 
 src/func_ov006_02125800.c:
@@ -6935,6 +6984,7 @@ src/func_ov006_0212a554.c:
     .text start:0x0212a554 end:0x0212a5c8
 
 src/func_ov006_0212a5c8.cpp:
+    complete
     .text start:0x0212a5c8 end:0x0212a650
 
 src/func_ov006_0212a650.c:

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -78,6 +78,7 @@ src/_ZN11CastleWater13InitResourcesEv.cpp:
     .text start:0x02111c74 end:0x02111d8c
 
 src/CastleWater_Spawn.c:
+    complete
     .text start:0x02111d8c end:0x02111dc4
 
 src/_ZN8MetalNetD1Ev.c:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -42,6 +42,7 @@ src/func_ov010_0211146c.c:
     .text start:0x0211146c end:0x02111554
 
 src/func_ov010_02111554.cpp:
+    complete
     .text start:0x02111554 end:0x021115a8
 
 src/func_ov010_021115a8.cpp:
@@ -87,6 +88,7 @@ src/_ZN4Trap6RenderEv.cpp:
     .text start:0x02111ab8 end:0x02111ae0
 
 src/_ZN4Trap8BehaviorEv.cpp:
+    complete
     .text start:0x02111ae0 end:0x02111d20
 
 src/_ZN4Trap13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -41,6 +41,7 @@ src/_ZN12SwitchPillarD0Ev.c:
     .text start:0x0211149c end:0x021114fc
 
 src/_ZN12SwitchPillar16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021114fc end:0x02111540
 
 src/_ZN12SwitchPillar6RenderEv.cpp:

--- a/config/arm9/overlays/ov013/delinks.txt
+++ b/config/arm9/overlays/ov013/delinks.txt
@@ -28,6 +28,7 @@ src/func_ov013_021112a8.c:
     .text start:0x021112a8 end:0x0211133c
 
 src/func_ov013_0211133c.cpp:
+    complete
     .text start:0x0211133c end:0x02111384
 
 src/ClockPaintingPendulum_Spawn.c:

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -10,9 +10,11 @@ src/_ZN10ShutterBobD0Ev.c:
     .text start:0x021111f0 end:0x02111254
 
 src/_ZN10ShutterBob16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111254 end:0x02111268
 
 src/_ZN10ShutterBob8BehaviorEv.cpp:
+    complete
     .text start:0x02111268 end:0x02111294
 
 src/_ZN10ShutterBob13InitResourcesEv.cpp:
@@ -26,6 +28,7 @@ src/_ZN10ChainChompD1Ev.c:
     .text start:0x02111308 end:0x021113bc
 
 src/_ZN10ChainChompD0Ev.cpp:
+    complete
     .text start:0x021113bc end:0x02111484
 
 src/func_ov014_02111484.c:
@@ -127,6 +130,7 @@ src/_ZN10ChainChomp8BehaviorEv.cpp:
     .text start:0x021129ec end:0x02112b14
 
 src/_ZN10ChainChomp13InitResourcesEv.cpp:
+    complete
     .text start:0x02112b14 end:0x02112d1c
 
 src/ChainChomp_Spawn.cpp:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -23,6 +23,7 @@ src/func_ov015_02111278.cpp:
     .text start:0x02111278 end:0x021112a0
 
 src/func_ov015_021112a0.cpp:
+    complete
     .text start:0x021112a0 end:0x021112dc
 
 src/PoleBillboard_Spawn.c:
@@ -138,6 +139,7 @@ src/func_ov015_02111fb8.c:
     .text start:0x02111fb8 end:0x02112004
 
 src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112004 end:0x02112068
 
 src/_ZN14KnockDownPlank6RenderEv.cpp:
@@ -149,6 +151,7 @@ src/_ZN14KnockDownPlank8BehaviorEv.cpp:
     .text start:0x02112090 end:0x021120fc
 
 src/_ZN14KnockDownPlank13InitResourcesEv.cpp:
+    complete
     .text start:0x021120fc end:0x02112230
 
 src/MovingBarBig_Spawn.c:

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -9,6 +9,7 @@ src/_ZN5UnagiD1Ev.c:
     .text start:0x021111a0 end:0x02111208
 
 src/_ZN5UnagiD0Ev.cpp:
+    complete
     .text start:0x02111208 end:0x02111284
 
 src/func_ov016_02111284.c:
@@ -32,6 +33,7 @@ src/func_ov016_02111718.cpp:
     .text start:0x02111718 end:0x02111758
 
 src/func_ov016_02111758.cpp:
+    complete
     .text start:0x02111758 end:0x02111860
 
 src/func_ov016_02111860.cpp:
@@ -39,6 +41,7 @@ src/func_ov016_02111860.cpp:
     .text start:0x02111860 end:0x021118b4
 
 src/func_ov016_021118b4.cpp:
+    complete
     .text start:0x021118b4 end:0x02111994
 
 src/func_ov016_02111994.cpp:
@@ -70,9 +73,11 @@ src/_ZN5Unagi6RenderEv.c:
     .text start:0x02111f84 end:0x02112010
 
 src/_ZN5Unagi8BehaviorEv.cpp:
+    complete
     .text start:0x02112010 end:0x021121c0
 
 src/_ZN5Unagi13InitResourcesEv.cpp:
+    complete
     .text start:0x021121c0 end:0x02112588
 
 src/Unagi_Spawn.c:
@@ -90,6 +95,7 @@ src/func_ov016_021126a8.c:
     .text start:0x021126a8 end:0x021126f0
 
 src/_ZN6ShipUp16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021126f0 end:0x02112744
 
 src/_ZN6ShipUp6RenderEv.cpp:
@@ -162,6 +168,7 @@ src/func_ov016_021130a4.c:
     .text start:0x021130a4 end:0x021130ec
 
 src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021130ec end:0x02113130
 
 src/_ZN23FloatOnWaterPlatformJrb6RenderEv.cpp:
@@ -173,6 +180,7 @@ src/_ZN23FloatOnWaterPlatformJrb8BehaviorEv.c:
     .text start:0x02113158 end:0x02113434
 
 src/_ZN23FloatOnWaterPlatformJrb13InitResourcesEv.cpp:
+    complete
     .text start:0x02113434 end:0x02113510
 
 src/SlidingBox_Spawn.c:

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -124,9 +124,11 @@ src/_ZN7SkiLift6RenderEv.cpp:
     .text start:0x02112454 end:0x02112480
 
 src/_ZN7SkiLift8BehaviorEv.cpp:
+    complete
     .text start:0x02112480 end:0x021124d0
 
 src/_ZN7SkiLift13InitResourcesEv.cpp:
+    complete
     .text start:0x021124d0 end:0x0211267c
 
 src/MotherPenguin_Spawn.c:

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -85,6 +85,7 @@ src/_ZN8BookShot6RenderEv.cpp:
     .text start:0x021122c4 end:0x0211233c
 
 src/_ZN8BookShot8BehaviorEv.cpp:
+    complete
     .text start:0x0211233c end:0x02112418
 
 src/_ZN15BookShotSpawner8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov021/delinks.txt
+++ b/config/arm9/overlays/ov021/delinks.txt
@@ -20,6 +20,7 @@ src/func_ov021_02111434.c:
     .text start:0x02111434 end:0x021115dc
 
 src/_ZN12WorkElevator16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021115dc end:0x02111650
 
 src/_ZN12WorkElevator6RenderEv.cpp:
@@ -128,6 +129,7 @@ src/_ZN10ShutterHmcD0Ev.c:
     .text start:0x02112e04 end:0x02112e68
 
 src/_ZN10ShutterHmc16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112e68 end:0x02112e7c
 
 src/_ZN10ShutterHmc8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -61,6 +61,7 @@ src/_ZN19RotatingPlatformLllD0Ev.c:
     .text start:0x02111708 end:0x02111760
 
 src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111760 end:0x021117a4
 
 src/_ZN19RotatingPlatformLll6RenderEv.cpp:
@@ -214,6 +215,7 @@ src/_ZN12FallBlockLll8BehaviorEv.cpp:
     .text start:0x02112560 end:0x02112590
 
 src/_ZN12FallBlockLll13InitResourcesEv.cpp:
+    complete
     .text start:0x02112590 end:0x021125a4
 
 src/RollingLogLll_Spawn.c:

--- a/config/arm9/overlays/ov024/delinks.txt
+++ b/config/arm9/overlays/ov024/delinks.txt
@@ -34,6 +34,7 @@ src/func_ov024_021114c4.c:
     .text start:0x021114c4 end:0x02111504
 
 src/_ZN10PyramidTop16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111504 end:0x0211153c
 
 src/_ZN10PyramidTop6RenderEv.cpp:
@@ -48,6 +49,7 @@ src/_ZN10PyramidTag8BehaviorEv.cpp:
     .text start:0x02111668 end:0x021116ec
 
 src/_ZN10PyramidTop13InitResourcesEv.cpp:
+    complete
     .text start:0x021116ec end:0x021117c8
 
 src/_ZN10PyramidTag13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -23,6 +23,7 @@ src/func_ov025_02111344.c:
     .text start:0x02111344 end:0x02111384
 
 src/func_ov025_02111384.cpp:
+    complete
     .text start:0x02111384 end:0x021113c8
 
 src/func_ov025_021113c8.cpp:
@@ -34,6 +35,7 @@ src/func_ov025_021113f0.c:
     .text start:0x021113f0 end:0x021117dc
 
 src/func_ov025_021117dc.cpp:
+    complete
     .text start:0x021117dc end:0x02111898
 
 src/func_ov025_02111898.c:
@@ -63,6 +65,7 @@ src/func_ov025_02111a84.cpp:
     .text start:0x02111a84 end:0x02111b64
 
 src/func_ov025_02111b64.cpp:
+    complete
     .text start:0x02111b64 end:0x02111c24
 
 src/func_ov025_02111c24.cpp:
@@ -105,6 +108,7 @@ src/PyramidStep_Spawn.c:
     .text start:0x021120ac end:0x021120e4
 
 src/_ZN11PyramidLiftD1Ev.cpp:
+    complete
     .text start:0x021120e4 end:0x02112148
 
 src/_ZN11PyramidLiftD0Ev.c:

--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -99,6 +99,7 @@ src/func_ov026_02111cb4.c:
     .text start:0x02111cb4 end:0x02111d4c
 
 src/func_ov026_02111d4c.cpp:
+    complete
     .text start:0x02111d4c end:0x02111ed8
 
 src/func_ov026_02111ed8.c:
@@ -126,6 +127,7 @@ src/_ZN9Submarine6RenderEv.cpp:
     .text start:0x02111fd8 end:0x0211200c
 
 src/_ZN9Submarine8BehaviorEv.cpp:
+    complete
     .text start:0x0211200c end:0x021120ec
 
 src/_ZN9Submarine13InitResourcesEv.cpp:
@@ -176,9 +178,11 @@ src/_ZN12WaterSuction6RenderEv.c:
     .text start:0x02112334 end:0x0211233c
 
 src/_ZN12WaterSuction8BehaviorEv.cpp:
+    complete
     .text start:0x0211233c end:0x021123c8
 
 src/_ZN12WaterSuction13InitResourcesEv.cpp:
+    complete
     .text start:0x021123c8 end:0x02112450
 
 src/WaterSuction_Spawn.c:

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -49,6 +49,7 @@ src/func_ov027_02111680.c:
     .text start:0x02111680 end:0x021116f0
 
 src/func_ov027_021116f0.cpp:
+    complete
     .text start:0x021116f0 end:0x02111770
 
 src/func_ov027_02111770.c:
@@ -113,18 +114,22 @@ src/func_ov027_02111e00.cpp:
     .text start:0x02111e00 end:0x02111e34
 
 src/func_ov027_02111e34.cpp:
+    complete
     .text start:0x02111e34 end:0x02111eb4
 
 src/func_ov027_02111eb4.cpp:
+    complete
     .text start:0x02111eb4 end:0x0211207c
 
 src/func_ov027_0211207c.c:
     .text start:0x0211207c end:0x021120c4
 
 src/_ZN13SnowmanBreathD1Ev.cpp:
+    complete
     .text start:0x021120c4 end:0x02112104
 
 src/_ZN13SnowmanBreathD0Ev.cpp:
+    complete
     .text start:0x02112104 end:0x02112158
 
 src/func_ov027_02112158.c:
@@ -172,6 +177,7 @@ src/_ZN13SnowmanBreath16OnPendingDestroyEv.c:
     .text start:0x0211273c end:0x02112740
 
 src/_ZN13SnowmanBreath6RenderEv.cpp:
+    complete
     .text start:0x02112740 end:0x021127a4
 
 src/_ZN13SnowmanBreath8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -106,6 +106,7 @@ src/func_ov029_02111bcc.c:
     .text start:0x02111bcc end:0x02111d6c
 
 src/func_ov029_02111d6c.cpp:
+    complete
     .text start:0x02111d6c end:0x02111e40
 
 src/func_ov029_02111e40.cpp:
@@ -207,6 +208,7 @@ src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp:
     .text start:0x021127cc end:0x021128b0
 
 src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp:
+    complete
     .text start:0x021128b0 end:0x02112964
 
 src/SwitchActivatedPlank_Spawn.c:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -22,6 +22,7 @@ src/func_ov030_02111350.cpp:
     .text start:0x02111350 end:0x02111384
 
 src/func_ov030_02111384.cpp:
+    complete
     .text start:0x02111384 end:0x02111410
 
 src/func_ov030_02111410.cpp:
@@ -206,6 +207,7 @@ src/_ZN13RollingLogTtm6RenderEv.cpp:
     .text start:0x02114230 end:0x02114278
 
 src/_ZN13RollingLogTtm8BehaviorEv.cpp:
+    complete
     .text start:0x02114278 end:0x02114378
 
 src/_ZN13RollingLogTtm13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -41,6 +41,7 @@ src/func_ov032_02111b50.c:
     .text start:0x02111b50 end:0x02111b9c
 
 src/func_ov032_02111b9c.cpp:
+    complete
     .text start:0x02111b9c end:0x02111d58
 
 src/func_ov032_02111d58.c:

--- a/config/arm9/overlays/ov033/delinks.txt
+++ b/config/arm9/overlays/ov033/delinks.txt
@@ -41,6 +41,7 @@ src/_ZN9TinyCoverD0Ev.c:
     .text start:0x02111420 end:0x02111480
 
 src/_ZN9TinyCover16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111480 end:0x021114c4
 
 src/_ZN9TinyCover6RenderEv.cpp:

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -11,6 +11,7 @@ src/_ZN16RotatingCogSmallD0Ev.c:
     .text start:0x021111e4 end:0x0211123c
 
 src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211123c end:0x021112c4
 
 src/_ZN16RotatingCogSmall6RenderEv.cpp:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -84,6 +84,7 @@ src/_ZN8ShipWingD0Ev.c:
     .text start:0x02111988 end:0x021119e8
 
 src/_ZN8ShipWing16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021119e8 end:0x02111a2c
 
 src/_ZN8ShipWing16OnPendingDestroyEv.c:
@@ -98,6 +99,7 @@ src/_ZN8ShipWing8BehaviorEv.cpp:
     .text start:0x02111a64 end:0x02111bb8
 
 src/_ZN8ShipWing13InitResourcesEv.cpp:
+    complete
     .text start:0x02111bb8 end:0x02111ca4
 
 src/func_ov036_02111ca4.cpp:

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -45,6 +45,7 @@ src/_ZN15FireSeaElevatorD0Ev.c:
     .text start:0x02111558 end:0x021115b8
 
 src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021115b8 end:0x021115f0
 
 src/_ZN15FireSeaElevator6RenderEv.cpp:

--- a/config/arm9/overlays/ov055/delinks.txt
+++ b/config/arm9/overlays/ov055/delinks.txt
@@ -32,6 +32,7 @@ src/_ZN11MirrorLuigi16OnPendingDestroyEv.c:
     .text start:0x02111354 end:0x02111358
 
 src/_ZN11MirrorLuigi6RenderEv.cpp:
+    complete
     .text start:0x02111358 end:0x02111508
 
 src/_ZN11MirrorLuigi8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -131,6 +131,7 @@ src/func_ov060_02113b5c.cpp:
     .text start:0x02113b5c end:0x02113d20
 
 src/func_ov060_02113d20.cpp:
+    complete
     .text start:0x02113d20 end:0x02113d8c
 
 src/func_ov060_02113d8c.cpp:
@@ -298,9 +299,11 @@ src/_ZN10BowserTail6RenderEv.c:
     .text start:0x02115f5c end:0x02115f64
 
 src/_ZN6Bowser8BehaviorEv.cpp:
+    complete
     .text start:0x02115f64 end:0x02116078
 
 src/_ZN10BowserTail8BehaviorEv.cpp:
+    complete
     .text start:0x02116078 end:0x02116130
 
 src/_ZN6Bowser13InitResourcesEv.c:
@@ -411,6 +414,7 @@ src/_ZN10BowserFire6RenderEv.c:
     .text start:0x021176cc end:0x021176d4
 
 src/_ZN10BowserFire8BehaviorEv.cpp:
+    complete
     .text start:0x021176d4 end:0x02117790
 
 src/_ZN10BowserFire13InitResourcesEv.cpp:
@@ -447,6 +451,7 @@ src/_ZN18BowserFireSeaArena6RenderEv.cpp:
     .text start:0x02117b9c end:0x02117bc8
 
 src/_ZN18BowserFireSeaArena8BehaviorEv.cpp:
+    complete
     .text start:0x02117bc8 end:0x02117c30
 
 src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp:
@@ -553,9 +558,11 @@ src/_ZN17BowserSkyPlatform6RenderEv.cpp:
     .text start:0x02118ad4 end:0x02118b2c
 
 src/_ZN17BowserSkyPlatform8BehaviorEv.cpp:
+    complete
     .text start:0x02118b2c end:0x02118bb4
 
 src/_ZN17BowserSkyPlatform13InitResourcesEv.cpp:
+    complete
     .text start:0x02118bb4 end:0x02118cbc
 
 src/SpikeBomb_Spawn.c:

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -263,6 +263,7 @@ src/_ZN5Koopa16OnPendingDestroyEv.c:
     .text start:0x02118f80 end:0x02118f84
 
 src/_ZN5Koopa6RenderEv.cpp:
+    complete
     .text start:0x02118f84 end:0x021190ec
 
 src/_ZN5Koopa8BehaviorEv.cpp:
@@ -347,6 +348,7 @@ src/_ZN13KoopaTheQuick6RenderEv.cpp:
     .text start:0x0211ab50 end:0x0211ab88
 
 src/_ZN13KoopaTheQuick8BehaviorEv.cpp:
+    complete
     .text start:0x0211ab88 end:0x0211ac10
 
 src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp:
@@ -434,6 +436,7 @@ src/func_ov062_0211c218.c:
     .text start:0x0211c218 end:0x0211c2f4
 
 src/func_ov062_0211c2f4.cpp:
+    complete
     .text start:0x0211c2f4 end:0x0211c594
 
 src/func_ov062_0211c594.c:

--- a/config/arm9/overlays/ov063/delinks.txt
+++ b/config/arm9/overlays/ov063/delinks.txt
@@ -325,6 +325,7 @@ src/actors/BooCage/_ZN7BooCage16CleanupResourcesEv.c:
     .text start:0x0211ae1c end:0x0211ae40
 
 src/actors/Boo/_ZN3Boo16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211ae40 end:0x0211af6c
 
 src/actors/Boo/_ZN3Boo16OnPendingDestroyEv.c:
@@ -416,6 +417,7 @@ src/unnamed/ov063/func_ov063_0211cc18.c:
     .text start:0x0211cc18 end:0x0211cdec
 
 src/actors/MansionSteps/_ZN12MansionSteps16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211cdec end:0x0211ce30
 
 src/actors/MansionSteps/_ZN12MansionSteps16OnPendingDestroyEv.c:
@@ -427,6 +429,7 @@ src/actors/MansionSteps/_ZN12MansionSteps6RenderEv.cpp:
     .text start:0x0211ce34 end:0x0211ce74
 
 src/actors/MansionSteps/_ZN12MansionSteps8BehaviorEv.cpp:
+    complete
     .text start:0x0211ce74 end:0x0211cf00
 
 src/unnamed/ov063/func_ov063_0211d270.cpp:
@@ -460,9 +463,11 @@ src/actors/FallBlockBbh/_ZN12FallBlockBbhD0Ev.c:
     .text start:0x0211d3f0 end:0x0211d454
 
 src/actors/FallBlockBbh/_ZN12FallBlockBbh16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211d454 end:0x0211d468
 
 src/actors/FallBlockBbh/_ZN12FallBlockBbh13InitResourcesEv.cpp:
+    complete
     .text start:0x0211d468 end:0x0211d47c
 
 src/actors/FallBlockBbh/FallBlockBbh_Spawn.c:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -147,6 +147,7 @@ src/func_ov064_0211755c.c:
     .text start:0x0211755c end:0x021175cc
 
 src/func_ov064_021175cc.cpp:
+    complete
     .text start:0x021175cc end:0x0211764c
 
 src/_ZN8BigBully6RenderEv.cpp:
@@ -370,6 +371,7 @@ src/func_ov064_02119010.c:
     .text start:0x02119010 end:0x0211904c
 
 src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211904c end:0x02119088
 
 src/_ZN19BowserPuzzleManager6RenderEv.cpp:
@@ -385,6 +387,7 @@ src/func_ov064_0211915c.c:
     .text start:0x0211915c end:0x021191a8
 
 src/_ZN19BowserPuzzleManager13InitResourcesEv.cpp:
+    complete
     .text start:0x021191a8 end:0x02119284
 
 src/func_ov064_02119284.c:
@@ -502,6 +505,7 @@ src/_ZN9WaterRing6RenderEv.cpp:
     .text start:0x02119fc8 end:0x02119ffc
 
 src/_ZN9WaterRing8BehaviorEv.cpp:
+    complete
     .text start:0x02119ffc end:0x0211a090
 
 src/_ZN9WaterRing13InitResourcesEv.cpp:
@@ -531,6 +535,7 @@ src/func_ov064_0211a380.c:
     .text start:0x0211a380 end:0x0211a39c
 
 src/func_ov064_0211a39c.cpp:
+    complete
     .text start:0x0211a39c end:0x0211a49c
 
 src/func_ov064_0211a49c.c:
@@ -592,6 +597,7 @@ src/_ZN4Clam8BehaviorEv.c:
     .text start:0x0211aa58 end:0x0211acc4
 
 src/_ZN4Clam13InitResourcesEv.cpp:
+    complete
     .text start:0x0211acc4 end:0x0211ad70
 
 src/Clam_Spawn.c:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -72,6 +72,7 @@ src/_ZN6Snufit6RenderEv.cpp:
     .text start:0x02116b34 end:0x02116b84
 
 src/_ZN6Snufit8BehaviorEv.cpp:
+    complete
     .text start:0x02116b84 end:0x02116e10
 
 src/_ZN6Snufit13InitResourcesEv.cpp:
@@ -156,6 +157,7 @@ src/_ZN5Swoop6RenderEv.cpp:
     .text start:0x02117af0 end:0x02117b64
 
 src/_ZN5Swoop8BehaviorEv.cpp:
+    complete
     .text start:0x02117b64 end:0x02117d80
 
 src/_ZN5Swoop13InitResourcesEv.cpp:
@@ -182,6 +184,7 @@ src/_ZN6DorrieD1Ev.cpp:
     .text start:0x02117f40 end:0x02117fa8
 
 src/_ZN6DorrieD0Ev.cpp:
+    complete
     .text start:0x02117fa8 end:0x02118024
 
 src/_ZN9DorrieCapD1Ev.c:
@@ -240,6 +243,7 @@ src/_ZN6Dorrie8BehaviorEv.cpp:
     .text start:0x02118df0 end:0x021190a8
 
 src/_ZN9DorrieCap8BehaviorEv.cpp:
+    complete
     .text start:0x021190a8 end:0x02119210
 
 src/func_ov065_02119210.c:
@@ -303,6 +307,7 @@ src/func_ov065_0211990c.c:
     .text start:0x0211990c end:0x02119984
 
 src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02119984 end:0x021199fc
 
 src/_ZN15TtcRotatingCube6RenderEv.cpp:
@@ -364,6 +369,7 @@ src/func_ov065_0211a550.c:
     .text start:0x0211a550 end:0x0211a638
 
 src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211a638 end:0x0211a69c
 
 src/_ZN20TtcConveyorBeltLarge6RenderEv.cpp:
@@ -434,6 +440,7 @@ src/func_ov065_0211b40c.c:
     .text start:0x0211b40c end:0x0211b47c
 
 src/_ZN13TTC_MovingBar16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211b47c end:0x0211b4e0
 
 src/_ZN13TTC_MovingBar6RenderEv.cpp:

--- a/config/arm9/overlays/ov066/delinks.txt
+++ b/config/arm9/overlays/ov066/delinks.txt
@@ -217,6 +217,7 @@ src/func_ov066_021194fc.cpp:
     .text start:0x021194fc end:0x02119654
 
 src/_ZN6Eyerok16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02119654 end:0x021197a0
 
 src/_ZN6Eyerok16OnPendingDestroyEv.c:

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -19,6 +19,7 @@ src/func_ov070_0211f100.cpp:
     .text start:0x0211f100 end:0x0211f368
 
 src/func_ov070_0211f368.cpp:
+    complete
     .text start:0x0211f368 end:0x0211f450
 
 src/func_ov070_0211f450.c:
@@ -84,6 +85,7 @@ src/_ZN6FlyGuy6RenderEv.cpp:
     .text start:0x021201c0 end:0x02120210
 
 src/_ZN6FlyGuy8BehaviorEv.cpp:
+    complete
     .text start:0x02120210 end:0x021203b4
 
 src/_ZN6FlyGuy13InitResourcesEv.cpp:
@@ -169,6 +171,7 @@ src/_ZN3Amp6RenderEv.cpp:
     .text start:0x02120e24 end:0x02120e8c
 
 src/_ZN3Amp8BehaviorEv.cpp:
+    complete
     .text start:0x02120e8c end:0x02120eec
 
 src/_ZN3Amp13InitResourcesEv.cpp:
@@ -191,6 +194,7 @@ src/func_ov070_021211bc.c:
     .text start:0x021211bc end:0x021211c4
 
 src/func_ov070_021211c4.cpp:
+    complete
     .text start:0x021211c4 end:0x02121298
 
 src/func_ov070_02121298.cpp:
@@ -299,6 +303,7 @@ src/func_ov070_02121cbc.c:
     .text start:0x02121cbc end:0x02121d50
 
 src/func_ov070_02121d50.cpp:
+    complete
     .text start:0x02121d50 end:0x02121e14
 
 src/func_ov070_02121e14.cpp:
@@ -346,9 +351,11 @@ src/_ZN14FlameChompFire6RenderEv.cpp:
     .text start:0x0212206c end:0x02122104
 
 src/_ZN14FlameChompFire8BehaviorEv.cpp:
+    complete
     .text start:0x02122104 end:0x02122124
 
 src/_ZN14FlameChompFire13InitResourcesEv.cpp:
+    complete
     .text start:0x02122124 end:0x021221fc
 
 src/FlameChompFire_Spawn.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -24,6 +24,7 @@ src/func_ov071_0211f0b4.c:
     .text start:0x0211f0b4 end:0x0211f148
 
 src/func_ov071_0211f148.cpp:
+    complete
     .text start:0x0211f148 end:0x0211f29c
 
 src/func_ov071_0211f29c.cpp:
@@ -62,6 +63,7 @@ src/func_ov071_0211fb0c.c:
     .text start:0x0211fb0c end:0x0211fb24
 
 src/func_ov071_0211fb24.cpp:
+    complete
     .text start:0x0211fb24 end:0x0211fbf4
 
 src/func_ov071_0211fbf4.c:
@@ -133,6 +135,7 @@ src/_ZN10Scuttlebug6RenderEv.cpp:
     .text start:0x0212033c end:0x02120398
 
 src/_ZN10Scuttlebug8BehaviorEv.cpp:
+    complete
     .text start:0x02120398 end:0x021203f8
 
 src/_ZN10Scuttlebug13InitResourcesEv.cpp:
@@ -170,6 +173,7 @@ src/func_ov071_02120a20.c:
     .text start:0x02120a20 end:0x02120a48
 
 src/func_ov071_02120a48.cpp:
+    complete
     .text start:0x02120a48 end:0x02120b14
 
 src/func_ov071_02120b14.cpp:
@@ -270,6 +274,7 @@ src/_ZN14MrI_Projectile6RenderEv.cpp:
     .text start:0x02121d14 end:0x02121d80
 
 src/_ZN14MrI_Projectile8BehaviorEv.cpp:
+    complete
     .text start:0x02121d80 end:0x02121eb4
 
 src/_ZN14MrI_Projectile13InitResourcesEv.cpp:
@@ -290,6 +295,7 @@ src/func_ov071_02122080.c:
     .text start:0x02122080 end:0x021220c8
 
 src/func_ov071_021220c8.cpp:
+    complete
     .text start:0x021220c8 end:0x02122194
 
 src/func_ov071_02122194.c:
@@ -320,6 +326,7 @@ src/_ZN6Coffin6RenderEv.cpp:
     .text start:0x021224a4 end:0x021224cc
 
 src/_ZN6Coffin8BehaviorEv.cpp:
+    complete
     .text start:0x021224cc end:0x0212255c
 
 src/_ZN6Coffin13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov072/delinks.txt
+++ b/config/arm9/overlays/ov072/delinks.txt
@@ -60,6 +60,7 @@ src/func_ov072_0211f804.c:
     .text start:0x0211f804 end:0x0211f81c
 
 src/func_ov072_0211f81c.cpp:
+    complete
     .text start:0x0211f81c end:0x0211f9c4
 
 src/func_ov072_0211f9c4.c:
@@ -107,9 +108,11 @@ src/_ZN11SnowmanBody6RenderEv.cpp:
     .text start:0x0211fcf4 end:0x0211fd24
 
 src/_ZN11SnowmanBody8BehaviorEv.cpp:
+    complete
     .text start:0x0211fd24 end:0x0211fd54
 
 src/_ZN11SnowmanBody13InitResourcesEv.cpp:
+    complete
     .text start:0x0211fd54 end:0x0211fedc
 
 src/SnowmanBody_Spawn.c:
@@ -152,6 +155,7 @@ src/func_ov072_02120430.c:
     .text start:0x02120430 end:0x02120450
 
 src/func_ov072_02120450.cpp:
+    complete
     .text start:0x02120450 end:0x02120514
 
 src/func_ov072_02120514.c:
@@ -183,9 +187,11 @@ src/_ZN11SnowmanHead6RenderEv.cpp:
     .text start:0x02120638 end:0x0212066c
 
 src/_ZN11SnowmanHead8BehaviorEv.cpp:
+    complete
     .text start:0x0212066c end:0x0212069c
 
 src/_ZN11SnowmanHead13InitResourcesEv.cpp:
+    complete
     .text start:0x0212069c end:0x021207d4
 
 src/SnowmanHead_Spawn.c:
@@ -340,6 +346,7 @@ src/_ZN11BabyPenguin8BehaviorEv.cpp:
     .text start:0x02121e08 end:0x02121e84
 
 src/_ZN11BabyPenguin13InitResourcesEv.cpp:
+    complete
     .text start:0x02121e84 end:0x02121fa0
 
 src/func_ov072_02121fa0.c:

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -236,6 +236,7 @@ src/func_ov073_021223f4.cpp:
     .text start:0x021223f4 end:0x02122464
 
 src/_ZN8CccArena16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02122464 end:0x021224c8
 
 src/_ZN8CccArena6RenderEv.cpp:
@@ -243,6 +244,7 @@ src/_ZN8CccArena6RenderEv.cpp:
     .text start:0x021224c8 end:0x021224f0
 
 src/_ZN8CccArena8BehaviorEv.cpp:
+    complete
     .text start:0x021224f0 end:0x02122578
 
 src/_ZN8CccArena13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov074/delinks.txt
+++ b/config/arm9/overlays/ov074/delinks.txt
@@ -169,9 +169,11 @@ src/func_ov074_02121a4c.cpp:
     .text start:0x02121a4c end:0x02121abc
 
 src/_ZN8Goomboss16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02121abc end:0x02121b70
 
 src/_ZN8Goomboss6RenderEv.cpp:
+    complete
     .text start:0x02121b70 end:0x02121bf0
 
 src/_ZN8Goomboss8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x0211c5c0 end:0x0211d380 kind:data align:32
     .bss        start:0x0211d380 end:0x0211d9c0 kind:bss align:32
 src/_ZN14UnknownVsEntryD1Ev.cpp:
+    complete
     .text start:0x02113ee0 end:0x02113f54
 
 src/_ZN14UnknownVsEntryD0Ev.c:
@@ -149,6 +150,7 @@ src/func_ov075_021152d4.cpp:
     .text start:0x021152d4 end:0x02115388
 
 src/_ZN14UnknownVsEntry16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02115388 end:0x021154cc
 
 src/_ZN14UnknownVsEntry6RenderEv.cpp:
@@ -424,6 +426,7 @@ src/func_ov075_0211a268.c:
     .text start:0x0211a268 end:0x0211a26c
 
 src/func_ov075_0211a26c.cpp:
+    complete
     .text start:0x0211a26c end:0x0211a2b8
 
 src/func_ov075_0211a2b8.cpp:
@@ -431,6 +434,7 @@ src/func_ov075_0211a2b8.cpp:
     .text start:0x0211a2b8 end:0x0211a410
 
 src/func_ov075_0211a410.cpp:
+    complete
     .text start:0x0211a410 end:0x0211a734
 
 src/func_ov075_0211a734.c:

--- a/config/arm9/overlays/ov077/delinks.txt
+++ b/config/arm9/overlays/ov077/delinks.txt
@@ -44,6 +44,7 @@ src/func_ov077_02123a74.cpp:
     .text start:0x02123a74 end:0x02123c6c
 
 src/func_ov077_02123c6c.cpp:
+    complete
     .text start:0x02123c6c end:0x02123d40
 
 src/func_ov077_02123d40.cpp:
@@ -114,9 +115,11 @@ src/_ZN6Lakitu6RenderEv.cpp:
     .text start:0x02124828 end:0x021248b8
 
 src/_ZN6Lakitu8BehaviorEv.cpp:
+    complete
     .text start:0x021248b8 end:0x02124908
 
 src/_ZN6Lakitu13InitResourcesEv.cpp:
+    complete
     .text start:0x02124908 end:0x02124aa4
 
 src/func_ov077_02124aa4.cpp:
@@ -151,6 +154,7 @@ src/func_ov077_02124ce4.c:
     .text start:0x02124ce4 end:0x02124d08
 
 src/func_ov077_02124d08.cpp:
+    complete
     .text start:0x02124d08 end:0x02124eb0
 
 src/func_ov077_02124eb0.cpp:
@@ -182,6 +186,7 @@ src/func_ov077_02125480.cpp:
     .text start:0x02125480 end:0x02125550
 
 src/func_ov077_02125550.cpp:
+    complete
     .text start:0x02125550 end:0x021256b4
 
 src/func_ov077_021256b4.c:
@@ -249,6 +254,7 @@ src/_ZN5Spiny8BehaviorEv.cpp:
     .text start:0x02125f68 end:0x02126058
 
 src/_ZN5Spiny13InitResourcesEv.cpp:
+    complete
     .text start:0x02126058 end:0x02126194
 
 src/func_ov077_02126194.cpp:

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -144,6 +144,7 @@ src/func_ov078_021258e4.c:
     .text start:0x021258e4 end:0x02125950
 
 src/func_ov078_02125950.cpp:
+    complete
     .text start:0x02125950 end:0x021259e4
 
 src/func_ov078_021259e4.c:
@@ -189,6 +190,7 @@ src/_ZN10KingBobOmb6RenderEv.cpp:
     .text start:0x021260ac end:0x02126104
 
 src/_ZN10KingBobOmb8BehaviorEv.cpp:
+    complete
     .text start:0x02126104 end:0x02126368
 
 src/_ZN10KingBobOmb13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -17,6 +17,7 @@ src/func_ov079_02123804.c:
     .text start:0x02123804 end:0x02123a8c
 
 src/func_ov079_02123a8c.cpp:
+    complete
     .text start:0x02123a8c end:0x02123b54
 
 src/func_ov079_02123b54.c:
@@ -36,6 +37,7 @@ src/func_ov079_02123d4c.cpp:
     .text start:0x02123d4c end:0x02123e60
 
 src/func_ov079_02123e60.cpp:
+    complete
     .text start:0x02123e60 end:0x02123f34
 
 src/func_ov079_02123f34.c:
@@ -95,6 +97,7 @@ src/func_ov079_0212522c.c:
     .text start:0x0212522c end:0x02125240
 
 src/func_ov079_02125240.cpp:
+    complete
     .text start:0x02125240 end:0x0212538c
 
 src/func_ov079_0212538c.c:
@@ -198,6 +201,7 @@ src/func_ov079_02126e58.cpp:
     .text start:0x02126e58 end:0x02126ecc
 
 src/func_ov079_02126ecc.cpp:
+    complete
     .text start:0x02126ecc end:0x02126f04
 
 src/func_ov079_02126f04.c:
@@ -234,6 +238,7 @@ src/func_ov079_021272e0.cpp:
     .text start:0x021272e0 end:0x02127300
 
 src/_ZN12FortressWall16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02127300 end:0x02127364
 
 src/_ZN12FortressWall6RenderEv.cpp:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -32,6 +32,7 @@ src/func_ov080_02123924.cpp:
     .text start:0x02123924 end:0x02123a34
 
 src/func_ov080_02123a34.cpp:
+    complete
     .text start:0x02123a34 end:0x02123c24
 
 src/func_ov080_02123c24.c:
@@ -173,6 +174,7 @@ src/_ZN11CrazedCrate8BehaviorEv.cpp:
     .text start:0x021251cc end:0x021251ec
 
 src/_ZN11CrazedCrate13InitResourcesEv.cpp:
+    complete
     .text start:0x021251ec end:0x02125318
 
 src/func_ov080_02125318.cpp:
@@ -282,6 +284,7 @@ src/func_ov080_02126c60.cpp:
     .text start:0x02126c60 end:0x02126ca0
 
 src/func_ov080_02126ca0.cpp:
+    complete
     .text start:0x02126ca0 end:0x02126f8c
 
 src/Painting_Spawn.c:

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -36,6 +36,7 @@ src/_ZN9Spindrift6RenderEv.cpp:
     .text start:0x02123c1c end:0x02123c6c
 
 src/_ZN9Spindrift8BehaviorEv.cpp:
+    complete
     .text start:0x02123c6c end:0x02123ed0
 
 src/_ZN9Spindrift13InitResourcesEv.cpp:
@@ -101,6 +102,7 @@ src/func_ov081_02124b08.c:
     .text start:0x02124b08 end:0x02124b98
 
 src/func_ov081_02124b98.cpp:
+    complete
     .text start:0x02124b98 end:0x02124d14
 
 src/func_ov081_02124d14.cpp:
@@ -173,6 +175,7 @@ src/_ZN10MrBlizzard6RenderEv.cpp:
     .text start:0x02125820 end:0x0212588c
 
 src/_ZN10MrBlizzard8BehaviorEv.cpp:
+    complete
     .text start:0x0212588c end:0x02125ba0
 
 src/_ZN10MrBlizzard13InitResourcesEv.cpp:
@@ -227,9 +230,11 @@ src/_ZN8Snowball6RenderEv.cpp:
     .text start:0x021262c0 end:0x021262ec
 
 src/_ZN8Snowball8BehaviorEv.cpp:
+    complete
     .text start:0x021262ec end:0x021263b8
 
 src/_ZN8Snowball13InitResourcesEv.cpp:
+    complete
     .text start:0x021263b8 end:0x021264b4
 
 src/Snowball_Spawn.c:
@@ -295,6 +300,7 @@ src/func_ov081_02127044.c:
     .text start:0x02127044 end:0x02127070
 
 src/func_ov081_02127070.cpp:
+    complete
     .text start:0x02127070 end:0x02127134
 
 src/func_ov081_02127134.c:
@@ -369,6 +375,7 @@ src/_ZN8Moneybag8BehaviorEv.cpp:
     .text start:0x02127854 end:0x021278a8
 
 src/_ZN8Moneybag13InitResourcesEv.cpp:
+    complete
     .text start:0x021278a8 end:0x02127a7c
 
 src/func_ov081_02127a7c.cpp:
@@ -397,6 +404,7 @@ src/func_ov081_02127cf4.c:
     .text start:0x02127cf4 end:0x02127d98
 
 src/_ZN8IceBlock16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02127d98 end:0x02127ddc
 
 src/_ZN8IceBlock6RenderEv.cpp:
@@ -404,6 +412,7 @@ src/_ZN8IceBlock6RenderEv.cpp:
     .text start:0x02127ddc end:0x02127e1c
 
 src/_ZN8IceBlock8BehaviorEv.cpp:
+    complete
     .text start:0x02127e1c end:0x02127ff0
 
 src/_ZN8IceBlock13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -17,6 +17,7 @@ src/func_ov084_021290d4.c:
     .text start:0x021290d4 end:0x02129168
 
 src/func_ov084_02129168.cpp:
+    complete
     .text start:0x02129168 end:0x02129238
 
 src/func_ov084_02129238.cpp:
@@ -108,6 +109,7 @@ src/_ZN6Goomba16OnPendingDestroyEv.c:
     .text start:0x0212b5b8 end:0x0212b5bc
 
 src/_ZN6Goomba6RenderEv.cpp:
+    complete
     .text start:0x0212b5bc end:0x0212b6ec
 
 src/_ZN6Goomba8BehaviorEv.cpp:
@@ -148,6 +150,7 @@ src/func_ov084_0212c4a0.c:
     .text start:0x0212c4a0 end:0x0212c508
 
 src/func_ov084_0212c508.cpp:
+    complete
     .text start:0x0212c508 end:0x0212c89c
 
 src/func_ov084_0212c89c.c:
@@ -210,9 +213,11 @@ src/_ZN11BobOmbBuddy6RenderEv.cpp:
     .text start:0x0212cf40 end:0x0212cf6c
 
 src/_ZN11BobOmbBuddy8BehaviorEv.cpp:
+    complete
     .text start:0x0212cf6c end:0x0212d028
 
 src/_ZN11BobOmbBuddy13InitResourcesEv.cpp:
+    complete
     .text start:0x0212d028 end:0x0212d200
 
 src/BobOmbBuddy_Spawn.c:
@@ -272,6 +277,7 @@ src/_ZN19FirePiranhaPlantBig6RenderEv.cpp:
     .text start:0x0212e5a8 end:0x0212e614
 
 src/_ZN19FirePiranhaPlantBig8BehaviorEv.cpp:
+    complete
     .text start:0x0212e614 end:0x0212e774
 
 src/_ZN19FirePiranhaPlantBig13InitResourcesEv.cpp:
@@ -386,6 +392,7 @@ src/_ZN12PiranhaPlant6RenderEv.cpp:
     .text start:0x0212fcdc end:0x0212fd4c
 
 src/_ZN12PiranhaPlant8BehaviorEv.cpp:
+    complete
     .text start:0x0212fd4c end:0x0212feb4
 
 src/_ZN12PiranhaPlant13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -43,6 +43,7 @@ src/func_ov085_021295bc.c:
     .text start:0x021295bc end:0x021297e8
 
 src/_ZN4Toad16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021297e8 end:0x02129854
 
 src/_ZN4Toad6RenderEv.cpp:
@@ -143,6 +144,7 @@ src/_ZN13PrincessPeach6RenderEv.cpp:
     .text start:0x0212a508 end:0x0212a52c
 
 src/_ZN13PrincessPeach8BehaviorEv.cpp:
+    complete
     .text start:0x0212a52c end:0x0212a588
 
 src/_ZN13PrincessPeach13InitResourcesEv.cpp:
@@ -252,6 +254,7 @@ src/_ZN6Rabbit16OnPendingDestroyEv.c:
     .text start:0x0212c070 end:0x0212c074
 
 src/_ZN6Rabbit6RenderEv.cpp:
+    complete
     .text start:0x0212c074 end:0x0212c150
 
 src/func_ov085_0212c150.cpp:
@@ -384,6 +387,7 @@ src/func_ov085_0212de5c.cpp:
     .text start:0x0212de5c end:0x0212df84
 
 src/func_ov085_0212df84.cpp:
+    complete
     .text start:0x0212df84 end:0x0212e078
 
 src/func_ov085_0212e078.cpp:
@@ -403,6 +407,7 @@ src/func_ov085_0212e2ec.c:
     .text start:0x0212e2ec end:0x0212e310
 
 src/func_ov085_0212e310.cpp:
+    complete
     .text start:0x0212e310 end:0x0212e480
 
 src/func_ov085_0212e480.c:
@@ -449,9 +454,11 @@ src/_ZN9LakituBro6RenderEv.cpp:
     .text start:0x0212ead0 end:0x0212eb18
 
 src/_ZN9LakituBro8BehaviorEv.cpp:
+    complete
     .text start:0x0212eb18 end:0x0212ebec
 
 src/_ZN9LakituBro13InitResourcesEv.cpp:
+    complete
     .text start:0x0212ebec end:0x0212ed54
 
 src/LakituBro_Spawn.c:

--- a/config/arm9/overlays/ov089/delinks.txt
+++ b/config/arm9/overlays/ov089/delinks.txt
@@ -67,6 +67,7 @@ src/_ZN3Key6RenderEv.cpp:
     .text start:0x021320f0 end:0x02132194
 
 src/_ZN3Key8BehaviorEv.cpp:
+    complete
     .text start:0x02132194 end:0x021324a4
 
 src/_ZN3Key13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov090/delinks.txt
+++ b/config/arm9/overlays/ov090/delinks.txt
@@ -202,6 +202,7 @@ src/_ZN10CheepCheep6RenderEv.cpp:
     .text start:0x021333e0 end:0x02133430
 
 src/_ZN10CheepCheep8BehaviorEv.cpp:
+    complete
     .text start:0x02133430 end:0x02133530
 
 src/_ZN10CheepCheep13InitResourcesEv.cpp:
@@ -256,6 +257,7 @@ src/_ZN5Shark8BehaviorEv.cpp:
     .text start:0x021339d8 end:0x02133b98
 
 src/_ZN5Shark13InitResourcesEv.cpp:
+    complete
     .text start:0x02133b98 end:0x02133ca0
 
 src/Shark_Spawn.c:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -18,6 +18,7 @@ src/func_ov091_02131070.cpp:
     .text start:0x02131070 end:0x021310fc
 
 src/func_ov091_021310fc.cpp:
+    complete
     .text start:0x021310fc end:0x02131160
 
 src/func_ov091_02131160.c:
@@ -29,6 +30,7 @@ src/func_ov091_02131340.c:
     .text start:0x02131340 end:0x02131388
 
 src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02131388 end:0x02131408
 
 src/_ZN25RotatingUpDownPlatformUtm6RenderEv.cpp:
@@ -112,6 +114,7 @@ src/_ZN17SlidingPlatformWfD0Ev.c:
     .text start:0x02132448 end:0x021324a0
 
 src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021324a0 end:0x02132504
 
 src/_ZN17SlidingPlatformWf6RenderEv.cpp:
@@ -211,6 +214,7 @@ src/func_ov091_02133098.cpp:
     .text start:0x02133098 end:0x021331b8
 
 src/_ZN6Thwomp16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021331b8 end:0x02133210
 
 src/_ZN6Thwomp6RenderEv.cpp:
@@ -232,6 +236,7 @@ src/func_ov091_02133498.c:
     .text start:0x02133498 end:0x021334b8
 
 src/func_ov091_021334b8.cpp:
+    complete
     .text start:0x021334b8 end:0x021335d4
 
 src/func_ov091_021335d4.c:
@@ -316,6 +321,7 @@ src/_ZN5Stump6RenderEv.cpp:
     .text start:0x02134184 end:0x021341ec
 
 src/_ZN5Stump8BehaviorEv.cpp:
+    complete
     .text start:0x021341ec end:0x02134324
 
 src/_ZN5Stump13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov092/delinks.txt
+++ b/config/arm9/overlays/ov092/delinks.txt
@@ -9,6 +9,7 @@ src/_ZN6ToxBoxD1Ev.cpp:
     .text start:0x02130f00 end:0x02130f5c
 
 src/_ZN6ToxBoxD0Ev.cpp:
+    complete
     .text start:0x02130f5c end:0x02130fcc
 
 src/func_ov092_02130fcc.c:

--- a/config/arm9/overlays/ov094/delinks.txt
+++ b/config/arm9/overlays/ov094/delinks.txt
@@ -80,6 +80,7 @@ src/_ZN10HootTheOwl6RenderEv.cpp:
     .text start:0x0213642c end:0x02136478
 
 src/_ZN10HootTheOwl8BehaviorEv.cpp:
+    complete
     .text start:0x02136478 end:0x02136634
 
 src/_ZN10HootTheOwl13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -27,6 +27,7 @@ src/func_ov095_0213597c.c:
     .text start:0x0213597c end:0x021359c4
 
 src/_ZN9SeesawBob16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021359c4 end:0x02135a28
 
 src/_ZN9SeesawBob6RenderEv.cpp:
@@ -103,6 +104,7 @@ src/func_ov095_02136368.c:
     .text start:0x02136368 end:0x0213645c
 
 src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0213645c end:0x021364b0
 
 src/_ZN13UpDownLiftBbh6RenderEv.cpp:
@@ -137,12 +139,15 @@ src/UpDownLiftBbh_Spawn.c:
     .text start:0x021367fc end:0x0213682c
 
 src/_ZN12FlamethrowerD1Ev.cpp:
+    complete
     .text start:0x0213682c end:0x02136884
 
 src/_ZN12FlamethrowerD0Ev.cpp:
+    complete
     .text start:0x02136884 end:0x021368f0
 
 src/_ZN12Flamethrower13InitResourcesEv.cpp:
+    complete
     .text start:0x02136d60 end:0x02136ed4
 
 src/Flamethrower_Spawn.cpp:

--- a/config/arm9/overlays/ov096/delinks.txt
+++ b/config/arm9/overlays/ov096/delinks.txt
@@ -43,6 +43,7 @@ src/func_ov096_021358c8.cpp:
     .text start:0x021358c8 end:0x02135948
 
 src/func_ov096_02135948.cpp:
+    complete
     .text start:0x02135948 end:0x02135e2c
 
 src/func_ov096_02135e2c.cpp:
@@ -78,6 +79,7 @@ src/func_ov096_0213640c.c:
     .text start:0x0213640c end:0x02136434
 
 src/func_ov096_02136434.cpp:
+    complete
     .text start:0x02136434 end:0x02136534
 
 src/func_ov096_02136534.cpp:
@@ -117,6 +119,7 @@ src/_ZN5Pokey16CleanupResourcesEv.cpp:
     .text start:0x02136944 end:0x021369b0
 
 src/_ZN5Pokey16OnPendingDestroyEv.cpp:
+    complete
     .text start:0x021369b0 end:0x021369fc
 
 src/_ZN5Pokey6RenderEv.cpp:
@@ -173,6 +176,7 @@ src/_ZN7Tornado6RenderEv.cpp:
     .text start:0x02137414 end:0x02137448
 
 src/_ZN7Tornado8BehaviorEv.cpp:
+    complete
     .text start:0x02137448 end:0x02137564
 
 src/_ZN7Tornado13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -27,6 +27,7 @@ src/func_ov098_02137d80.c:
     .text start:0x02137d80 end:0x02137dbc
 
 src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02137dbc end:0x02137e20
 
 src/_ZN14ArrowSignRight6RenderEv.cpp:
@@ -149,6 +150,7 @@ src/func_ov098_021390ec.cpp:
     .text start:0x021390ec end:0x02139228
 
 src/func_ov098_02139228.cpp:
+    complete
     .text start:0x02139228 end:0x021396a4
 
 src/func_ov098_021396a4.cpp:
@@ -164,6 +166,7 @@ src/func_ov098_02139850.c:
     .text start:0x02139850 end:0x02139a50
 
 src/_ZN5Crate16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02139a50 end:0x02139aa8
 
 src/_ZN5Crate6RenderEv.cpp:
@@ -289,6 +292,7 @@ src/_ZN6Cannon8BehaviorEv.cpp:
     .text start:0x0213b26c end:0x0213b2d4
 
 src/_ZN6Cannon13InitResourcesEv.cpp:
+    complete
     .text start:0x0213b2d4 end:0x0213b43c
 
 src/Cannon_Spawn.c:
@@ -340,6 +344,7 @@ src/_ZN9WaterBomb6RenderEv.cpp:
     .text start:0x0213bbe4 end:0x0213bc20
 
 src/_ZN9WaterBomb8BehaviorEv.cpp:
+    complete
     .text start:0x0213bc20 end:0x0213bd14
 
 src/_ZN9WaterBomb13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -19,6 +19,7 @@ src/func_ov100_0214109c.cpp:
     .text start:0x0214109c end:0x0214117c
 
 src/func_ov100_0214117c.cpp:
+    complete
     .text start:0x0214117c end:0x021412d8
 
 src/func_ov100_021412d8.c:
@@ -107,6 +108,7 @@ src/func_ov100_02142b90.c:
     .text start:0x02142b90 end:0x02142d1c
 
 src/_ZN15RollingIronBall16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02142d1c end:0x02142d5c
 
 src/_ZN15RollingIronBall6RenderEv.cpp:
@@ -125,6 +127,7 @@ src/RollingIronBall_Spawn.c:
     .text start:0x0214316c end:0x021431c4
 
 src/_ZN14UnchainedChompD1Ev.cpp:
+    complete
     .text start:0x021431c4 end:0x02143290
 
 src/_ZN14UnchainedChompD0Ev.cpp:
@@ -176,6 +179,7 @@ src/_ZN14UnchainedChomp6RenderEv.cpp:
     .text start:0x02143d0c end:0x02143d64
 
 src/_ZN14UnchainedChomp8BehaviorEv.cpp:
+    complete
     .text start:0x02143d64 end:0x02144088
 
 src/_ZN14UnchainedChomp13InitResourcesEv.cpp:
@@ -290,6 +294,7 @@ src/func_ov100_021453d8.cpp:
     .text start:0x021453d8 end:0x0214542c
 
 src/func_ov100_0214542c.cpp:
+    complete
     .text start:0x0214542c end:0x021454c4
 
 src/func_ov100_021454c4.c:
@@ -321,6 +326,7 @@ src/func_ov100_02145948.c:
     .text start:0x02145948 end:0x02145988
 
 src/func_ov100_02145988.cpp:
+    complete
     .text start:0x02145988 end:0x02145ab4
 
 src/func_ov100_02145ab4.cpp:
@@ -445,6 +451,7 @@ src/_ZN4Fish6RenderEv.cpp:
     .text start:0x02146b04 end:0x02146b38
 
 src/_ZN4Fish8BehaviorEv.cpp:
+    complete
     .text start:0x02146b38 end:0x02146c68
 
 src/_ZN4Fish13InitResourcesEv.cpp:
@@ -459,6 +466,7 @@ src/func_ov100_02146d7c.cpp:
     .text start:0x02146d7c end:0x02146dec
 
 src/func_ov100_02146dec.cpp:
+    complete
     .text start:0x02146dec end:0x02146e70
 
 src/func_ov100_02146e70.c:
@@ -473,6 +481,7 @@ src/func_ov100_02147054.c:
     .text start:0x02147054 end:0x021470a4
 
 src/func_ov100_021470a4.cpp:
+    complete
     .text start:0x021470a4 end:0x021470f4
 
 src/func_ov100_021470f4.cpp:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -11,6 +11,7 @@ src/_ZN13FortressTowerD0Ev.c:
     .text start:0x02148ac4 end:0x02148b1c
 
 src/_ZN13FortressTower16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02148b1c end:0x02148b80
 
 src/_ZN13FortressTower6RenderEv.cpp:
@@ -63,6 +64,7 @@ src/func_ov102_02149100.c:
     .text start:0x02149100 end:0x02149220
 
 src/func_ov102_02149220.cpp:
+    complete
     .text start:0x02149220 end:0x02149288
 
 src/func_ov102_02149288.cpp:
@@ -165,6 +167,7 @@ src/func_ov102_02149ff0.c:
     .text start:0x02149ff0 end:0x0214a08c
 
 src/_ZN13QuestionBlock16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0214a08c end:0x0214a2ac
 
 src/_ZN13QuestionBlock6RenderEv.cpp:
@@ -265,6 +268,7 @@ src/func_ov102_0214b444.cpp:
     .text start:0x0214b444 end:0x0214b53c
 
 src/func_ov102_0214b988.cpp:
+    complete
     .text start:0x0214b988 end:0x0214ba30
 
 src/func_ov102_0214ba30.cpp:

--- a/include/decl_Actor.h
+++ b/include/decl_Actor.h
@@ -4,6 +4,22 @@
 #define DECL_ACTOR_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern char*_ZN5Actor14FarthestPlayerEv(void*);
 extern int _ZN5Actor15IsPlayerInRangeEi(void*, int);
 extern int _ZN5Actor18FindExplosionActorER12CylinderClsn(void*, void*);
@@ -13,5 +29,10 @@ extern void _ZN5Actor17TrackInDeathTableEv(void*);
 extern void _ZN5Actor19DisappearPoofDustAtERK7Vector3(void*, const struct Vector3*);
 extern void _ZN5ActorC2Ev(void*);
 extern void _ZN5ActorD2Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_ActorBase.h
+++ b/include/decl_ActorBase.h
@@ -4,7 +4,28 @@
 #define DECL_ACTORBASE_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN9ActorBase14BeforeBehaviorEv(void*);
 extern void*_ZN9ActorBasenwEj(unsigned);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Animation.h
+++ b/include/decl_Animation.h
@@ -4,6 +4,22 @@
 #define DECL_ANIMATION_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN9Animation8GetFlagsEv(void*);
 extern int _ZNK9Animation12WillHitFrameEi(void*, int);
 extern int _ZNK9Animation13GetFrameCountEv(void*);
@@ -11,5 +27,10 @@ extern void _ZN9Animation17UpdateFileOffsetsER8BCA_File(char*);
 extern void _ZN9Animation4CopyERKS_(void*, const void*);
 extern void _ZN9Animation8SetFlagsEi(void*, int);
 extern void _ZN9AnimationC2Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_BlendModelAnim.h
+++ b/include/decl_BlendModelAnim.h
@@ -4,7 +4,28 @@
 #define DECL_BLENDMODELANIM_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN14BlendModelAnimC1Ev(void*);
 extern void _ZN14BlendModelAnimD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Camera.h
+++ b/include/decl_Camera.h
@@ -4,7 +4,28 @@
 #define DECL_CAMERA_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZNK6Camera12IsUnderwaterEv(void*);
 extern void _ZN6Camera10LookAtExitER5Actor(void*, void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_CapEnemy.h
+++ b/include/decl_CapEnemy.h
@@ -4,11 +4,32 @@
 #define DECL_CAPENEMY_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN8CapEnemy11GetCapStateEv(char*);
 extern int _ZN8CapEnemy21DestroyIfCapNotNeededEv();
 extern int _ZN8CapEnemy6AddCapEj();
 extern void _ZN8CapEnemy12Unk_02005d94Ev(char*);
 extern void _ZN8CapEnemy14RenderCapModelEPK7Vector3(char*, const Vector3*);
 extern void _ZN8CapEnemyC2Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_ClsnResult.h
+++ b/include/decl_ClsnResult.h
@@ -4,6 +4,27 @@
 #define DECL_CLSNRESULT_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZNK10ClsnResult9GetClsnIDEv(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_CylinderClsn.h
+++ b/include/decl_CylinderClsn.h
@@ -4,6 +4,27 @@
 #define DECL_CYLINDERCLSN_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN12CylinderClsn4InitE5Fix12IiES1_jj(void*, Fix12i, Fix12i, u32, u32);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Enemy.h
+++ b/include/decl_Enemy.h
@@ -4,9 +4,30 @@
 #define DECL_ENEMY_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(void*, void*);
 extern void _ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player(void*, Vector3_16*, void*, int);
 extern void _ZN5Enemy22SpawnMegaCharParticlesER5ActorPc(void*, void*, char*);
 extern void _ZN5EnemyC2Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_ExpandingHeapAllocator.h
+++ b/include/decl_ExpandingHeapAllocator.h
@@ -4,9 +4,30 @@
 #define DECL_EXPANDINGHEAPALLOCATOR_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern unsigned int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(void*, int);
 extern void _ZN22ExpandingHeapAllocator10DeallocateEPv(void*, void*);
 extern void*_ZN22ExpandingHeapAllocator16AllocateForwardsEjj(void*, u32, u32);
 extern void*_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj(void*, u32, u32);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_ExtendingMeshCollider.h
+++ b/include/decl_ExtendingMeshCollider.h
@@ -4,8 +4,29 @@
 #define DECL_EXTENDINGMESHCOLLIDER_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN21ExtendingMeshCollider9SetScaleYE5Fix12IiE(void*, int);
 extern void _ZN21ExtendingMeshColliderC1Ev(void*);
 extern void _ZN21ExtendingMeshColliderD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Fader.h
+++ b/include/decl_Fader.h
@@ -4,6 +4,27 @@
 #define DECL_FADER_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN5Fader13AdvanceInterpEv(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_FaderBrightness.h
+++ b/include/decl_FaderBrightness.h
@@ -4,6 +4,27 @@
 #define DECL_FADERBRIGHTNESS_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN15FaderBrightness8SetToEndEv(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_FaderColor.h
+++ b/include/decl_FaderColor.h
@@ -4,7 +4,28 @@
 #define DECL_FADERCOLOR_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN10FaderColor11AdvanceFadeEv(void);
 extern void _ZN10FaderColorD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_FloatOnWaterPlatformWdwRectangle.h
+++ b/include/decl_FloatOnWaterPlatformWdwRectangle.h
@@ -4,6 +4,27 @@
 #define DECL_FLOATONWATERPLATFORMWDWRECTANGLE_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void*_ZN32FloatOnWaterPlatformWdwRectangleD1Ev;
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Heap.h
+++ b/include/decl_Heap.h
@@ -4,8 +4,29 @@
 #define DECL_HEAP_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern u32 _ZN4Heap7_SizeofEPv(void*, void*);
 extern void _ZN4Heap10ReallocateEPvj(void*, void*, unsigned int);
 extern void _ZN4Heap6RescueEv(int);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_HeapAllocator.h
+++ b/include/decl_HeapAllocator.h
@@ -4,6 +4,27 @@
 #define DECL_HEAPALLOCATOR_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN13HeapAllocatorC1EjPvPvj(void*, u32, void*, void*, u32);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_MaterialChanger.h
+++ b/include/decl_MaterialChanger.h
@@ -4,8 +4,29 @@
 #define DECL_MATERIALCHANGER_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File(void*, void*);
 extern void _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
 extern void _ZN15MaterialChangerC1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Message.h
+++ b/include/decl_Message.h
@@ -4,10 +4,31 @@
 #define DECL_MESSAGE_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN7Message11PrepareTalkEv(void);
 extern void _ZN7Message13DisplaySavingEt(unsigned short);
 extern void _ZN7Message15ResetAllGlobalsEv(void);
 extern void _ZN7Message21DisplaySaveStatusTextEt(u16);
 extern void _ZN7Message30DisplayCourseNameForStarSelectEj(u32);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Model.h
+++ b/include/decl_Model.h
@@ -4,6 +4,22 @@
 #define DECL_MODEL_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN5Model13LoadTexAndPalER8BMD_File(void*);
 extern u32 _ZN5Model13GetVramOffsetEj(u32);
 extern void _ZN5Model12HideMaterialEii(void*, int, int);
@@ -11,5 +27,10 @@ extern void _ZN5Model12ShowMaterialEii(void*, int, int);
 extern void _ZN5ModelC1Ev(void*);
 extern void _ZN5ModelC2Ev(void*);
 extern void _ZN5ModelD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_ModelAnim.h
+++ b/include/decl_ModelAnim.h
@@ -4,10 +4,31 @@
 #define DECL_MODELANIM_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN9ModelAnim4CopyERKS_Pc(void*, const void*, void*);
 extern void _ZN9ModelAnim6RenderEPK7Vector3(void*, void*);
 extern void _ZN9ModelAnimC1Ev(void*);
 extern void _ZN9ModelAnimC2Ev(void*);
 extern void _ZN9ModelAnimD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_ModelAnim2.h
+++ b/include/decl_ModelAnim2.h
@@ -4,7 +4,28 @@
 #define DECL_MODELANIM2_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt(void*, u32, int, int, unsigned short);
 extern void _ZN10ModelAnim24CopyERKS_Pcj(void*, void*, char*, u32);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_MontyMoleRock.h
+++ b/include/decl_MontyMoleRock.h
@@ -4,6 +4,27 @@
 #define DECL_MONTYMOLEROCK_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN13MontyMoleRockD0Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_MovingCylinderClsn.h
+++ b/include/decl_MovingCylinderClsn.h
@@ -4,8 +4,29 @@
 #define DECL_MOVINGCYLINDERCLSN_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN18MovingCylinderClsn10GetOwnerIDEv(void);
 extern void _ZN18MovingCylinderClsnC1Ev(void*);
 extern void _ZN18MovingCylinderClsnD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_MovingCylinderClsnWithPos.h
+++ b/include/decl_MovingCylinderClsnWithPos.h
@@ -4,6 +4,27 @@
 #define DECL_MOVINGCYLINDERCLSNWITHPOS_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN25MovingCylinderClsnWithPosC1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_MovingMeshCollider.h
+++ b/include/decl_MovingMeshCollider.h
@@ -4,7 +4,28 @@
 #define DECL_MOVINGMESHCOLLIDER_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN18MovingMeshColliderC1Ev(void*);
 extern void _ZN18MovingMeshColliderD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_NestedHeapIterator.h
+++ b/include/decl_NestedHeapIterator.h
@@ -4,9 +4,30 @@
 #define DECL_NESTEDHEAPITERATOR_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN18NestedHeapIterator4InitEP13HeapAllocator(char*, char*);
 extern void _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(char*, char*);
 extern void _ZN18NestedHeapIteratorC1Ej(void*, u32);
 extern void*_ZN18NestedHeapIterator4NextEP13HeapAllocator(void*, void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_OAM.h
+++ b/include/decl_OAM.h
@@ -4,9 +4,30 @@
 #define DECL_OAM_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN3OAM11GetObjWidthEii(int, int);
 extern int _ZN3OAM12GetObjHeightEii(int, int);
 extern int _ZN3OAM9RenderSubEP7OamAttriiii(int, int, int, int, int);
 extern void _ZN3OAM9RenderSubEP7OamAttrii(void*, int, int);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Particle.h
+++ b/include/decl_Particle.h
@@ -4,6 +4,22 @@
 #define DECL_PARTICLE_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern u32 _ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj(u32, u32, Fix12i, Fix12i, Fix12i, const void*, u8);
 extern u32 _ZN8Particle7Texture12AllocTexVramEjb(const void*, u32);
 extern unsigned int _ZN8Particle7Texture12AllocPalVramEjb(unsigned int, unsigned int);
@@ -11,5 +27,10 @@ extern void _ZN8Particle10SysTracker10InitialiseEv(void*);
 extern void _ZN8Particle14SimpleCallbackC2Ev(char*);
 extern void _ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_(Fix12i, Fix12i, Fix12i);
 extern void _ZN8Particle9RenderAllEv(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_PathPtr.h
+++ b/include/decl_PathPtr.h
@@ -4,7 +4,28 @@
 #define DECL_PATHPTR_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZNK7PathPtr5LoopsEv(void*);
 extern int _ZNK7PathPtr8NumNodesEv(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Platform.h
+++ b/include/decl_Platform.h
@@ -4,8 +4,29 @@
 #define DECL_PLATFORM_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(void*, s16, s16, s16, int);
 extern void _ZN8Platform14KillByMegaCharER6Player(void*, void*);
 extern void _ZN8PlatformC2Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Player.h
+++ b/include/decl_Player.h
@@ -4,6 +4,22 @@
 #define DECL_PLAYER_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN6Player12GetHurtStateEv(void*);
 extern int _ZN6Player12Unk_020c4f40Et(int, u16);
 extern int _ZN6Player13TryTalkToDoorEh(char*, unsigned char);
@@ -20,5 +36,10 @@ extern void _ZN6Player18TurnOffToonShadingEj(char*, u32);
 extern void _ZN6Player4BurnEv(void*);
 extern void _ZN6Player6BounceE5Fix12IiE(void*, int);
 extern void _ZN6Player8BlowAwayEs(void*, short);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_RacingPenguin.h
+++ b/include/decl_RacingPenguin.h
@@ -4,6 +4,27 @@
 #define DECL_RACINGPENGUIN_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN13RacingPenguin16OnPendingDestroyEv(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_SaveData.h
+++ b/include/decl_SaveData.h
@@ -4,11 +4,32 @@
 #define DECL_SAVEDATA_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN8SaveData16HasPlayerLostCapEv(void);
 extern int _ZN8SaveData22NumGlowingRabbitsFoundEv(void);
 extern s32 _ZN8SaveData16ReadDataFromCartEPcjj(char*, u32, u32);
 extern unsigned int _ZN8SaveData26CountStarsCollectedInLevelEj(unsigned int);
 extern void _ZN8SaveData13PlayerLoseCapEv(void);
 extern void _ZN8SaveData16EraseAllSaveDataEv(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Scene.h
+++ b/include/decl_Scene.h
@@ -4,6 +4,22 @@
 #define DECL_SCENE_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN5Scene14BeforeBehaviorEv();
 extern int _ZN5Scene15SetSceneToSpawnEjj(u32, u32);
 extern int _ZN5Scene19BeforeInitResourcesEv(void*);
@@ -11,5 +27,10 @@ extern void _ZN5Scene20Initialise3dGraphicsEv(void);
 extern void _ZN5Scene20SetAndStopColorFaderEv(void);
 extern void _ZN5Scene21AfterCleanupResourcesEj(char*, unsigned int);
 extern void _ZN5Scene9SetFadersEP15FaderBrightness(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_ShadowModel.h
+++ b/include/decl_ShadowModel.h
@@ -4,8 +4,29 @@
 #define DECL_SHADOWMODEL_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN11ShadowModel8CleanAllEv(void);
 extern void _ZN11ShadowModelC1Ev(void*);
 extern void _ZN11ShadowModelD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_SolidHeapAllocator.h
+++ b/include/decl_SolidHeapAllocator.h
@@ -4,11 +4,32 @@
 #define DECL_SOLIDHEAPALLOCATOR_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
 extern void _ZN18SolidHeapAllocator10ResetStartEv(void*);
 extern void _ZN18SolidHeapAllocator5ResetEj(void*, unsigned int);
 extern void _ZN18SolidHeapAllocator8ResetEndEv(void*);
 extern void*_ZN18SolidHeapAllocator16AllocateForwardsEPvjj(void*, u32, u32);
 extern void*_ZN18SolidHeapAllocator17AllocateBackwardsEPvjj(void*, u32, u32);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_SphereClsn.h
+++ b/include/decl_SphereClsn.h
@@ -4,8 +4,29 @@
 #define DECL_SPHERECLSN_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZN10SphereClsn10DetectClsnEv(void*);
 extern void _ZN10SphereClsnC1Ev(void*);
 extern void _ZN10SphereClsnD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Stage.h
+++ b/include/decl_Stage.h
@@ -4,7 +4,28 @@
 #define DECL_STAGE_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN5Stage18ResetMeshCollidersEv(void);
 extern void _ZN5Stage20RenderBouncingArrowsEv(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_TextureSequence.h
+++ b/include/decl_TextureSequence.h
@@ -4,6 +4,27 @@
 #define DECL_TEXTURESEQUENCE_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN15TextureSequenceC1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_TextureTransformer.h
+++ b/include/decl_TextureTransformer.h
@@ -4,7 +4,28 @@
 #define DECL_TEXTURETRANSFORMER_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void _ZN18TextureTransformerC1Ev(void*);
 extern void _ZN18TextureTransformerD1Ev(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_Timer.h
+++ b/include/decl_Timer.h
@@ -4,8 +4,29 @@
 #define DECL_TIMER_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern unsigned long long _ZN5Timer7GetTimeEv(void*);
 extern void _ZN5Timer10StartTimerEv(void*);
 extern void _ZN5Timer9StopTimerEv(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_WithMeshClsn.h
+++ b/include/decl_WithMeshClsn.h
@@ -4,6 +4,22 @@
 #define DECL_WITHMESHCLSN_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int _ZNK12WithMeshClsn15ShouldUpdatePosEv(void*);
 extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void*);
 extern void _ZN12WithMeshClsn12Unk_0203589cEv(void*);
@@ -16,5 +32,10 @@ extern void _ZN12WithMeshClsn22ClearJustHitGroundFlagEv(void*);
 extern void _ZN12WithMeshClsnC1Ev(void*);
 extern void _ZN12WithMeshClsnD1Ev(void*);
 extern void*_ZNK12WithMeshClsn13GetWallResultEv(void*);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/decl_common.h
+++ b/include/decl_common.h
@@ -4,6 +4,22 @@
 #define DECL_COMMON_H
 #include "common.h"
 
+
+/* C linkage. These declare ROM symbols by their exact final names, so a C++
+   translation unit including this header must not mangle them -- a bare
+   `void Foo(int);` seen from C++ emits _Z3Fooi, which exists nowhere. The file
+   still byte-matches, because match.py compares relocated words as wildcards, so
+   nothing catches it until the ROM link -- and eligible.py refuses to enroll a
+   file with unresolvable references, so the link never sees it either.
+
+   Verified safe: of the 1,644 function names declared across the decl_*.h
+   headers, 1,572 are themselves the ROM symbol and 0 exist ONLY in a mangled
+   form, so no declaration here relies on C++ mangling. The remaining 72 resolve
+   to neither spelling and are unresolvable with or without this guard. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern Matrix4x3 data_ov021_02113a60, data_ov021_02113a80;
 extern Vector3 data_ov002_0210af00;
 extern Vector3 data_ov006_0212b890;
@@ -3157,5 +3173,10 @@ extern volatile struct Matrix4x3 data_ov006_0213ad28;
 extern volatile unsigned short data_ov002_0210c208[];
 extern vu16 reg_G2S_DB_BG3PA;
 extern vu32*data_ov006_02137560[];
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/func_ov002_020cede0.cpp
+++ b/src/func_ov002_020cede0.cpp
@@ -17,7 +17,8 @@ extern int data_0209f32c;
 extern signed char data_0209f2f8;
 }
 
-extern "C" int func_ov002_020cede0(char* thiz) {
+extern "C" int func_ov002_020cede0(void* thiz_) {
+    char* thiz = (char*)thiz_;
   Vector3 v;
   char rg[0x54];
   int y = *(int*)(thiz + 0x60);

--- a/src/func_ov004_020b2a18.cpp
+++ b/src/func_ov004_020b2a18.cpp
@@ -9,7 +9,6 @@ extern "C" {
 typedef struct Heap Heap;
 void* func_ov004_020b929c(void* self);
 void _ZN9ActorBaseD2Ev(void* t);
-void _ZN6Memory10DeallocateEPvP4Heap(void* p, Heap* h);
 extern void* data_ov004_020beb68;
 extern void* _ZTV5Scene[];
 extern void* data_0208e4b8;

--- a/src/func_ov062_02116edc.cpp
+++ b/src/func_ov062_02116edc.cpp
@@ -8,7 +8,8 @@ extern "C" {
 int Math_Function_0203b14c(void*, int, int, int, int);
 void* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(void*, int, void*);
 
-void func_ov062_02116edc(char* c){
+void func_ov062_02116edc(void* c_){
+    char* c = (char*)c_;
   int idx = 0;
   if(*(int*)(*(int*)(c+0x3f8) + 8) == 2) idx = 1;
   int k = idx * 0xc;

--- a/src/func_ov072_0211f65c.cpp
+++ b/src/func_ov072_0211f65c.cpp
@@ -15,10 +15,7 @@ void* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void* a);
 void func_0201267c(int a, void* t);
 int _ZNK12WithMeshClsn13JustHitGroundEv(void* self);
 void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, const Vector3* v, int fix);
-void func_ov072_0211f158(void* c);
 void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
-void func_ov072_0211f330(void* c, void* p);
-void func_ov072_0211f280(void* c);
 }
 
 extern "C" int func_ov072_0211f65c(unsigned char* thiz)
@@ -66,9 +63,9 @@ extern "C" int func_ov072_0211f65c(unsigned char* thiz)
         break;
     }
 
-    func_ov072_0211f158(thiz);
+    func_ov072_0211f158((char*)thiz);
     _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, thiz + 0x14c);
-    func_ov072_0211f330(thiz, thiz + 0x180);
-    func_ov072_0211f280(thiz);
+    func_ov072_0211f330((char*)thiz, thiz + 0x180);
+    func_ov072_0211f280((char*)thiz);
     return 1;
 }

--- a/src/func_ov074_0211fd74.cpp
+++ b/src/func_ov074_0211fd74.cpp
@@ -8,7 +8,6 @@
 extern "C" {
     int func_ov074_02121a20(void* c, int idx);
     int func_ov074_021207b8(void* c);
-    void func_ov074_02121a4c(void* c, int i);
     int func_ov074_021206c8(void* c);
     void* _ZN5Actor13ClosestPlayerEv(void* self);
     int _ZN9Animation8FinishedEv(void* anim);
@@ -17,7 +16,6 @@ extern "C" {
     void _ZN5Actor19DisappearPoofDustAtERK7Vector3(void* self, void* v);
     void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, void* pos, void* rot, int e, int f);
     void func_ov084_021296b0(void* a, void* b);
-    void func_ov074_021203e4(void* c, int i);
     int __aeabi_idiv(int a, int b);
 }
 
@@ -28,12 +26,12 @@ extern "C" void func_ov074_0211fd74(void* self)
 
     if (func_ov074_02121a20(self, 6) != 0) {
         if (func_ov074_021207b8(self) == 0) return;
-        func_ov074_02121a4c(self, 0xb);
+        func_ov074_02121a4c((char*)self, 0xb);
         return;
     } else {
         if (func_ov074_02121a20(self, 0xb) != 0) goto L90;
         if (func_ov074_021206c8(self) == 0) return;
-        func_ov074_02121a4c(self, 0xb);
+        func_ov074_02121a4c((char*)self, 0xb);
         return;
     }
 
@@ -80,5 +78,5 @@ L90:;
     if (*(u8*)(c+0x602) % dv == 0) *(s32*)(c+0x268) = 0;
 
     if (*(u8*)(c+0x602) < r5) return;
-    func_ov074_021203e4(self, 3);
+    func_ov074_021203e4((char*)self, 3);
 }

--- a/src/func_ov078_02125f8c.cpp
+++ b/src/func_ov078_02125f8c.cpp
@@ -8,7 +8,8 @@
 
 extern "C" {
 extern struct Matrix4x3* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(void* self, void* player, struct Vector3* pos);
-void func_ov078_02125f8c(char* c){
+void func_ov078_02125f8c(void* c_){
+    char* c = (char*)c_;
     void* player = *(void**)(c+0x494);
     int idx = 0;
     if(player == 0) return;

--- a/src/func_ov085_0212bdbc.cpp
+++ b/src/func_ov085_0212bdbc.cpp
@@ -13,7 +13,8 @@ extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_
 extern int data_020a0e68[];
 
 
-void func_ov085_0212bdbc(char* c){
+void func_ov085_0212bdbc(void* c_){
+    char* c = (char*)c_;
     int idx;
     void* res;
     if (!*(void**)(c + 0x45c)) return;


### PR DESCRIPTION
**381 more functions link from source** — 9,159 → 9,540 enrolled, 67.19% → **72.34%** of code
bytes. Forty-four header lines and six small repairs.

## The defect

`include/decl_*.h` — 44 auto-generated headers included by **1,780** src files — declare
**1,644 ROM functions with no `extern "C"` guard**. Every C++ TU including one therefore
mangles those names: a bare `void Foo(int);` seen from C++ emits `_Z3Fooi`, which exists
nowhere.

Same defect as the per-file `extern "C"` sweep in #1039/#1040, but central and at roughly ten
times the scale: **882** of the repo's unresolvable references trace to these headers against
**89** to per-file declarations.

It hides because the two gates cover for each other. `match.py` compares relocated words as
**wildcards**, so which symbol a call resolves to never enters the byte verdict — every one of
these files byte-matches. The ROM link *would* catch it, but `eligible.py` refuses to enroll a
file with unresolvable references, so the link never sees it.

## Safe by measurement, not assumption

Of the 1,644 function names declared across these headers:

| | |
|---|---:|
| the plain name **is** the ROM symbol | **1,572** |
| exists **only** in a mangled form | **0** |
| neither spelling in `symbols.txt` | 72 |

Nothing here relies on C++ mangling, so giving them C linkage cannot repoint anything. The 72
are unresolvable with or without the guard.

That check is load-bearing: names like `ApproachLinear` and `LoadOrUnloadObjectOverlays` **are**
deliberately mangled — `_Z14ApproachLinearRsss` is the real symbol — and wrapping those would
break them. None appear in these headers.

**Data is left alone deliberately.** mwccarm does not mangle variable references:
`extern int data_x[];` used from C++ emits `UND:data_x` either way. The fix is functions-only.

## Six files needed repair — exposed, not caused

- **Three** declared a function locally that the header also declares, with a different
  parameter spelling. Previously harmless because the header's copy mangled to a *different*
  symbol; now a genuine C-linkage conflict. The local duplicates are dropped — the shared
  header is the source of truth.
- **Four** had their own definition disagreeing with the header on `char*` vs `void*`. They take
  the header's spelling and cast inside, which is codegen-neutral since both are pointers.
- `func_ov072_0211f65c` also needed casts at three call sites where it passes `unsigned char*`.

All six byte-match.

## Verification

- **9,540/9,540 reproducing, module fidelity 106/106 exact, ROM-build analysis PASS.**
- `tools/prepush_attribution.py`: 0 changed, 0 lost.
- 107 in-scope files, under the validator's 200 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
