### PR TITLE
Door::Behavior calls the wrong function; fix it and enroll the file

### DIFF
--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -376,6 +376,7 @@ src/_ZN4Door6RenderEv.c:
     .text start:0x02145fe4 end:0x021460dc
 
 src/_ZN4Door8BehaviorEv.cpp:
+    complete
     .text start:0x021460dc end:0x0214612c
 
 src/_ZN4Door13InitResourcesEv.cpp:

--- a/src/_ZN4Door8BehaviorEv.cpp
+++ b/src/_ZN4Door8BehaviorEv.cpp
@@ -8,11 +8,23 @@ struct CallbackNode {
     char pad[8];
     PMF callback;
 };
-extern int func_ov100_02145370(char *c);
+extern "C" {
+extern int func_ov100_02145f00(char *c);
+}
+
+/* Calls func_ov100_02145f00, not func_ov100_02145370. The call is a
+   relocation in our object, which match.py compares as a wildcard, so the
+   byte gate passed the wrong callee happily. The ROM link could not see it
+   either: the declaration above mangled without C linkage, the reference
+   went unresolvable, and eligible.py refused to enroll the file -- so it
+   never reached the link that would have caught it.
+
+   Verified against the ROM: the single BL at 0x021460e4 is 0xebffff85,
+   which targets 0x02145f00. */
 
 int Door::Behavior()
 {
-    int res = func_ov100_02145370(((char *)this));
+    int res = func_ov100_02145f00(((char *)this));
     CallbackNode *node = *(CallbackNode**)((char*)&unk_110);
     if (*(int*)&node->callback != 0) {
         Base *base = (Base*)((char *)this);


### PR DESCRIPTION
`_ZN4Door8BehaviorEv` called `func_ov100_02145370`. The ROM calls `func_ov100_02145f00`. There is exactly one `BL` in the function's 0x50 bytes, and it settles the question:

```
0x021460e4: ebffff85    BL -> 0x02145f00
```

### Why neither gate caught it

**`match.py` can't see callees.** Our object emits the call as an `R_ARM_PC24` against an undefined symbol, and the byte gate compares relocated words as wildcards. Whichever function is named, the bytes match.

**The ROM link could have, but never saw the file.** The C++ TU declared `func_ov100_02145370` without C linkage, so it mangled to `_Z20func_ov100_02145370Pc`. The reference went unresolvable and `eligible.py` refused to enroll the file.

The two gates covered for each other — the one that can see callees was prevented from running by the very defect it would have caught. That's why this enrolls the file rather than only correcting it: enrollment is what makes the fix verifiable.

### Verified both directions

| | reproducing | module fidelity | verdict |
|---|---:|---|---|
| **this PR** | 9,203 / 9,203 | 106/106 exact | **PASS** |
| old callee restored | 9,202 / 9,203 | 105/106 | **FAIL** — `ov100 _ZN4Door8BehaviorEv 0x021460dc` |

Attribution: 0 changed, 0 lost.

### One note on the baseline

Those numbers use main's committed config, which builds 9,202. A fresh `eligible.py` + `enroll.py` run finds **9,262** — main is carrying ~60 enrollable functions whose `complete` marks were never regenerated. Left alone here; worth a separate regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi