### PR TITLE
Rebuild the mangled-declaration sweep around evidence, not a regex

### DIFF
--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -79,7 +79,7 @@ def classify(job):
         if src.read_text(encoding="utf-8", errors="ignore").startswith("//cpp"):
             flags = flags.replace("-lang c99", "-lang c++")
     except OSError:
-        return rel, name, "unreadable source"
+        return rel, name, "unreadable source", []
 
     cmd = [*os.environ.get("MWCCARM_LAUNCHER", "").split(),
            str(MW / version / "mwccarm.exe"), *flags.split(),
@@ -87,10 +87,10 @@ def classify(job):
     r = subprocess.run(cmd, capture_output=True, text=True,
                        env=dict(os.environ, LM_LICENSE_FILE=str(LICENSE)), cwd=REPO)
     if r.returncode != 0 or not obj.is_file():
-        return rel, name, "compile failed"
+        return rel, name, "compile failed", []
 
     if sec != ".text":
-        return rel, name, f"lives in {sec}, not .text"
+        return rel, name, f"lives in {sec}, not .text", []
 
     try:
         elf = ELFFile(io.BytesIO(obj.read_bytes()))
@@ -109,8 +109,8 @@ def classify(job):
         if len(content) != 1 or content[0] != ".text":
             extra = sorted(set(content) - {".text"})
             if len(content) > 1 and not extra:
-                return rel, name, f"{len(content)} .text sections (multi-function TU)"
-            return rel, name, "extra sections: " + ",".join(extra or content)
+                return rel, name, f"{len(content)} .text sections (multi-function TU)", []
+            return rel, name, "extra sections: " + ",".join(extra or content), []
 
         symtab = elf.get_section_by_name(".symtab")
         defined, undefined, other_defined = [], [], []
@@ -129,22 +129,25 @@ def classify(job):
                 other_defined.append(s.name)
 
         if text_sh_size is not None and text_sh_size != size:
-            return rel, name, f".text section 0x{text_sh_size:x} != declared 0x{size:x}"
+            return rel, name, f".text section 0x{text_sh_size:x} != declared 0x{size:x}", []
         if len(defined) != 1:
-            return rel, name, f"{len(defined)} defined global functions"
+            return rel, name, f"{len(defined)} defined global functions", []
         dname, dsize = defined[0]
         if dname != name:
-            return rel, name, f"defines {dname}, expected {name}"
+            return rel, name, f"defines {dname}, expected {name}", []
         if dsize != size:
-            return rel, name, f"size 0x{dsize:x} != declared 0x{size:x}"
+            return rel, name, f"size 0x{dsize:x} != declared 0x{size:x}", []
         if other_defined:
-            return rel, name, "defines non-function globals: " + ",".join(other_defined[:3])
+            return rel, name, "defines non-function globals: " + ",".join(other_defined[:3]), []
         missing = sorted(set(undefined) - known)
         if missing:
-            return rel, name, "unresolvable: " + ",".join(missing[:3])
+            # `reason` is truncated for the histogram a human reads; `missing` is the
+            # complete list, because a consumer that acts on it needs all of them. A
+            # tool fed only the first three silently leaves the rest behind.
+            return rel, name, "unresolvable: " + ",".join(missing[:3]), missing
     except Exception as e:  # a malformed object is a fail, not a crash
-        return rel, name, f"elf error: {type(e).__name__}"
-    return rel, name, None
+        return rel, name, f"elf error: {type(e).__name__}", []
+    return rel, name, None, []
 
 
 def main():
@@ -163,8 +166,9 @@ def main():
     results, reasons = [], collections.Counter()
     done = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
-        for rel, name, reason in ex.map(classify, jobs):
-            results.append({"file": rel, "name": name, "reason": reason})
+        for rel, name, reason, missing in ex.map(classify, jobs):
+            results.append({"file": rel, "name": name, "reason": reason,
+                            "missing": missing})
             reasons["ELIGIBLE" if reason is None else reason.split(":")[0]] += 1
             done += 1
             if done % 2000 == 0:

--- a/tools/extern_c_wrap.py
+++ b/tools/extern_c_wrap.py
@@ -1,0 +1,234 @@
+"""Give ROM symbol declarations C linkage in C++ translation units.
+
+A C++ TU that declares a ROM symbol like this:
+
+    extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
+
+gets it mangled *again*, because the declaration has C++ linkage. mwccarm emits a
+reference to `_Z35_ZN5Model8LoadFileER13SharedFilePtrPv`, which exists nowhere. Plain
+names suffer the same way: `void Vec3_Sub(Vec3*, Vec3*, Vec3*)` becomes
+`_Z8Vec3_SubP4Vec3S0_S0_`.
+
+The file still byte-matches, which is why this survives. `match.py` compares the
+relocated word as a wildcard, so the *name* a call resolves to never enters the byte
+verdict -- only the full ROM link cares, and until a function is enrolled the link
+never sees it either. So these read as finished work while referencing symbols that
+do not exist.
+
+## What this wraps, and how it decides
+
+Not by pattern-matching declarations, which is guesswork. `eligible.py` already
+records, per file, the exact undefined symbols that failed to resolve. A mangled ROM
+declaration leaves a fingerprint that can be read back:
+
+    _Z8Vec3_SubP4Vec3S0_S0_
+     ^^ ^        ^
+     |  |        `-- argument encoding, ignored
+     |  `----------- 8 characters of name
+     `-------------- length prefix
+
+Decode the length prefix, take that many characters, and ask whether the result is a
+symbol the ROM actually defines. If it is, the declaration wanted C linkage and did
+not get it. That name -- and only that name -- is wrapped.
+
+Three consequences worth stating, because they are what the earlier regex version got
+wrong:
+
+- **Data is never touched.** mwccarm does not mangle data references: `extern int
+  data_x[]` emits `UND:data_x` from C++ with or without the guard, checked by
+  compiling. Only function declarations can have this defect, so only they are
+  considered.
+- **A name absent from `symbols.txt` is left alone.** Wrapping it would not resolve
+  anything; the reference is broken for a different reason and needs a human.
+- **A file that already contains an `extern "C"` block is still processed.** Brace
+  depth already prevents wrapping *inside* one. Skipping such files wholesale, as the
+  first version did, hid most of the remaining work.
+
+Every file is byte-verified after the edit and reverted if it stops reproducing, so a
+declaration that genuinely wanted C++ linkage cannot be broken silently.
+
+Usage:
+    python tools/extern_c_wrap.py                 # report only
+    python tools/extern_c_wrap.py --apply
+    python tools/extern_c_wrap.py --apply -j 16
+    python tools/extern_c_wrap.py --apply --limit 128    # cap for the PR size gate
+"""
+import argparse
+import collections
+import concurrent.futures
+import json
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import match as M          # noqa: E402
+import modules as MOD      # noqa: E402
+import eligible as E       # noqa: E402
+from enroll import candidates  # noqa: E402
+
+ELIGIBILITY = REPO / "build" / "rombuild-eligibility.json"
+
+# _Z<len><name><argument encoding>.  Nested-name forms (_ZN...) and special names
+# (_ZTV...) do not carry a bare length prefix and are correctly not matched here:
+# those are genuine C++ references, not a ROM name that got mangled a second time.
+MANGLED = re.compile(r"^_Z(\d+)(.+)$")
+
+
+def demangled_head(sym):
+    """The ROM name inside a doubly-mangled symbol, or None."""
+    m = MANGLED.match(sym)
+    if not m:
+        return None
+    n, rest = int(m.group(1)), m.group(2)
+    return rest[:n] if len(rest) >= n else None
+
+
+def mangled_targets(known):
+    """{path: {rom names that were mangled}} for files whose *every* missing symbol is
+    a mangled ROM name. A file with any other unresolved reference is left out:
+    wrapping would not make it enrollable, so touching it is churn."""
+    if not ELIGIBILITY.exists():
+        sys.exit(f"missing {ELIGIBILITY} -- run tools/eligible.py first")
+    out = {}
+    for r in json.loads(ELIGIBILITY.read_text()):
+        if not (r.get("reason") or "").startswith("unresolvable"):
+            continue
+        # `missing`, not `reason` -- the reason string is truncated to three symbols
+        # for display, and wrapping only those leaves a file with four still broken.
+        syms = r.get("missing")
+        if syms is None:
+            sys.exit("eligibility report predates the `missing` field -- "
+                     "re-run tools/eligible.py")
+        heads = {s: demangled_head(s) for s in syms}
+        if all(h and h in known for h in heads.values()):
+            out[r["file"].replace("\\", "/")] = set(heads.values())
+    return out
+
+
+def is_cpp(path, text):
+    return path.suffix == ".cpp" or text.startswith("//cpp")
+
+
+def wrap(text, names):
+    """Wrap file-scope declarations of `names` in extern "C". Returns None if nothing
+    to do.
+
+    Brace depth keeps this to file scope, which also means a declaration already
+    inside an `extern "C" { ... }` block is never wrapped twice."""
+    # A declaration of NAME is a statement that calls it out as a function: the
+    # identifier followed by `(`. `= NAME(` or `return NAME(` would be a *use*, but
+    # neither can appear at brace depth 0.
+    pats = {n: re.compile(r"(^|[^\w])" + re.escape(n) + r"\s*\(") for n in names}
+    lines = text.splitlines()
+    out, run, depth, changed = [], [], 0, False
+
+    def flush():
+        nonlocal changed
+        if run:
+            out.append('extern "C" {')
+            out.extend(run)
+            out.append("}")
+            run.clear()
+            changed = True
+
+    for ln in lines:
+        s = ln.strip()
+        decl = (depth == 0 and s.endswith(";") and "{" not in s
+                and any(p.search(s) for p in pats.values()))
+        if decl:
+            run.append(ln)
+            continue
+        flush()
+        out.append(ln)
+        depth += ln.count("{") - ln.count("}")
+    flush()
+    return "\n".join(out) + "\n" if changed else None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    ap.add_argument("--limit", type=int, help="stop after N files were wrapped")
+    args = ap.parse_args()
+
+    known = E.defined_symbols()
+    targets_by_file = mangled_targets(known)
+
+    info = {}
+    for (d, name, rel, addr, size, sec) in candidates()[0]:
+        info[rel.replace("\\", "/")] = (name, addr, size, d)
+    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+
+    targets, skipped = [], collections.Counter()
+    for rel, names in sorted(targets_by_file.items()):
+        f = REPO / rel
+        if not f.is_file():
+            skipped["file missing"] += 1
+            continue
+        t = f.read_text(encoding="utf-8", errors="ignore")
+        if not is_cpp(f, t):
+            skipped["not a C++ TU"] += 1
+            continue
+        if wrap(t, names) is None:
+            skipped["no file-scope declaration found"] += 1
+            continue
+        targets.append((f, names))
+
+    print(f"files blocked only by mangled ROM declarations: {len(targets_by_file)}")
+    print(f"  wrappable                                   : {len(targets)}")
+    for k, v in skipped.most_common():
+        print(f"  skipped, {k:<35}: {v}")
+    if not args.apply:
+        print("\n(report only -- pass --apply to wrap and byte-verify)")
+        return 0
+
+    def one(job):
+        f, names = job
+        rel = f.relative_to(REPO).as_posix()
+        original = f.read_text(encoding="utf-8", errors="ignore")
+        new = wrap(original, names)
+        if new is None:
+            return rel, "unchanged"
+        f.write_text(new, encoding="utf-8", newline="\n")
+        if rel not in info:
+            return rel, "wrapped (not enrolled, unverified)"
+        name, addr, size, d = info[rel]
+        label = d.relative_to(REPO / "config").as_posix()
+        label = "arm9" if label == "arm9" else label.split("/")[-1]
+        flags = M.DEFAULT_FLAGS.replace("-lang c99", "-lang c++")
+        tgt = (M.target_bytes(addr, size) if label == "arm9"
+               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
+        for v in M.SWEEP:
+            obj = M.compile_c(f, v, flags)
+            if obj is None:
+                continue
+            code, rl = M.extract_func(obj, name)
+            if code is None:
+                continue
+            ok, _ = M.compare(tgt, code, rl, verbose=False)
+            if ok:
+                return rel, "wrapped"
+        f.write_text(original, encoding="utf-8", newline="\n")
+        return rel, "reverted (stopped matching)"
+
+    if args.limit:
+        targets = targets[:args.limit]
+    counts = collections.Counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rel, verdict in ex.map(one, targets):
+            counts[verdict] += 1
+            if verdict.startswith("reverted"):
+                print(f"  {verdict}: {rel}")
+    print()
+    for k, v in counts.most_common():
+        print(f"  {v:5d}  {k}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two tools, one bug each — and the second hid work from the first.

## `eligible.py` records every unresolved symbol, not the first three

`classify()` returned `"unresolvable: " + ",".join(missing[:3])`. That truncation is right for the histogram a human reads and wrong for anything that acts on it: a file with four mangled declarations reported three, a consumer fixed those three, and the file stayed unenrollable for a reason nothing had printed.

`reason` keeps its truncation. A new `missing` field carries the complete list.

**Measured cost**, running the sweep below against truncated data: **108 of 219** files were still unresolvable afterwards. It cut the other way too — **7 files** were marked fixable that weren't, because their fourth symbol wasn't a mangled ROM name at all.

## `extern_c_wrap.py` decides from the symbol table

The old matcher was `^extern\s+[^;{]*;$` plus a skip for any file already containing `extern "C"`. Three defects:

- a declaration written without `extern` was invisible
- the file-level skip discarded **78 of 89** remaining declarations — most such files mix wrapped and unwrapped declarations
- any bare identifier got wrapped, ROM symbol or not; the 99 plain names it happened to catch were all real, but by luck rather than by rule

It now reads `missing` and **decodes** each symbol instead of guessing:

```
_Z8Vec3_SubP4Vec3S0_S0_
 ^^ ^        ^
 |  |        `-- argument encoding, ignored
 |  `----------- 8 characters of name
 `-------------- length prefix
```

If the decoded head is a symbol the ROM defines, that declaration wanted C linkage and didn't get it. That name is wrapped; nothing else is. Nested-name (`_ZN...`) and special (`_ZTV...`) forms carry no bare length prefix and are correctly skipped — those are genuine C++ references, not a ROM name mangled twice.

Three consequences worth naming:

- **Data is never touched.** mwccarm doesn't mangle data references — `extern int data_x[]` emits `UND:data_x` from C++ either way, checked by compiling.
- **A name absent from `symbols.txt` is left alone.** Wrapping wouldn't resolve it; it's broken for a different reason and needs a human.
- **Files containing an `extern "C"` block are processed.** Brace depth already prevented wrapping inside one; the wholesale skip only hid work.

Byte verification and revert-on-failure are unchanged. `--limit` is new, for splitting a sweep under the validator's in-scope file cap.

## Effect

Tools only — no `src`/`config`/`include` changes, so nothing here moves the build on its own. Run against post-#1049 main it identifies **212** files and enrolls **+204** of them, verified separately.

`tools/test_rombuild.py` and `tools/test_rombuild_check.py` pass (9 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi