### PR TITLE
Give mangled ROM declarations C linkage (batch 01 of 2)

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -735,6 +735,7 @@ src/ReadUnalignedUshort.c:
     .text start:0x0200e780 end:0x0200e798
 
 src/EndKuppaScript.cpp:
+    complete
     .text start:0x0200e798 end:0x0200e8d4
 
 src/ProcessKuppaScript.cpp:
@@ -4125,6 +4126,7 @@ src/CopyTexPalFromLevelModel.c:
     .text start:0x0202b3d8 end:0x0202b534
 
 src/_ZN5Stage23LoadTextureTransformersEv.cpp:
+    complete
     .text start:0x0202b534 end:0x0202b5ec
 
 src/_ZN5Stage9LoadModelEv.cpp:
@@ -4136,6 +4138,7 @@ src/_ZN5Stage9RenderFogEv.cpp:
     .text start:0x0202b67c end:0x0202b710
 
 src/_ZN5Stage7LoadFogEv.cpp:
+    complete
     .text start:0x0202b710 end:0x0202b818
 
 src/_ZN5Stage8CanPauseEv.c:
@@ -7795,6 +7798,7 @@ src/_ZN18NestedHeapIteratorC1Ej.c:
     .text start:0x0204df20 end:0x0204df38
 
 src/_ZN13HeapAllocator6RemoveEv.cpp:
+    complete
     .text start:0x0204df38 end:0x0204df54
 
 src/_ZN13HeapAllocatorC1EjPvPvj.cpp:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -809,6 +809,7 @@ src/_ZN14QuestionSwitch8BehaviorEv.cpp:
     .text start:0x020b51dc end:0x020b5500
 
 src/_ZN14QuestionSwitch13InitResourcesEv.cpp:
+    complete
     .text start:0x020b5500 end:0x020b567c
 
 src/func_ov002_020b567c.c:
@@ -1355,6 +1356,7 @@ src/_ZN10StarSwitch6RenderEv.cpp:
     .text start:0x020ba5f4 end:0x020ba624
 
 src/_ZN10StarSwitch8BehaviorEv.cpp:
+    complete
     .text start:0x020ba624 end:0x020ba83c
 
 src/_ZN10StarSwitch13InitResourcesEv.cpp:
@@ -4265,6 +4267,7 @@ src/func_ov002_020ea9d0.c:
     .text start:0x020ea9d0 end:0x020eab8c
 
 src/_ZN10StarMarker16OnPendingDestroyEv.cpp:
+    complete
     .text start:0x020eab8c end:0x020eabcc
 
 src/_ZN10StarMarker16CleanupResourcesEv.cpp:
@@ -4292,6 +4295,7 @@ src/_ZN9PowerStar8BehaviorEv.cpp:
     .text start:0x020eb05c end:0x020eb204
 
 src/_ZN10StarMarker13InitResourcesEv.cpp:
+    complete
     .text start:0x020eb204 end:0x020eb63c
 
 src/_ZN9PowerStar13InitResourcesEv.cpp:
@@ -4736,6 +4740,7 @@ src/_ZN15InvisibleSecret6RenderEv.cpp:
     .text start:0x020f0994 end:0x020f0a60
 
 src/_ZN15InvisibleSecret8BehaviorEv.cpp:
+    complete
     .text start:0x020f0a60 end:0x020f0bd4
 
 src/_ZN15InvisibleSecret13InitResourcesEv.cpp:
@@ -4824,6 +4829,7 @@ src/_ZN12EnemySpawnerD0Ev.c:
     .text start:0x020f1694 end:0x020f16cc
 
 src/_ZN14EnemySwitchTag16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020f16cc end:0x020f16ec
 
 src/_ZN12EnemySpawner8BehaviorEv.cpp:
@@ -4831,6 +4837,7 @@ src/_ZN12EnemySpawner8BehaviorEv.cpp:
     .text start:0x020f16ec end:0x020f1760
 
 src/_ZN14EnemySwitchTag8BehaviorEv.cpp:
+    complete
     .text start:0x020f1760 end:0x020f1814
 
 src/_ZN12EnemySpawner16CleanupResourcesEv.c:
@@ -4838,6 +4845,7 @@ src/_ZN12EnemySpawner16CleanupResourcesEv.c:
     .text start:0x020f1814 end:0x020f1838
 
 src/_ZN12EnemySpawner13InitResourcesEv.cpp:
+    complete
     .text start:0x020f1838 end:0x020f1878
 
 src/_ZN14EnemySwitchTag13InitResourcesEv.cpp:
@@ -4871,6 +4879,7 @@ src/_ZN19AmbientSoundEffects6RenderEv.c:
     .text start:0x020f19f4 end:0x020f19fc
 
 src/_ZN19AmbientSoundEffects8BehaviorEv.cpp:
+    complete
     .text start:0x020f19fc end:0x020f1ac4
 
 src/_ZN19AmbientSoundEffects13InitResourcesEv.cpp:
@@ -5471,6 +5480,7 @@ src/_ZN14CutsceneObject6RenderEv.cpp:
     .text start:0x020f80ac end:0x020f81c4
 
 src/_ZN14CutsceneObject8BehaviorEv.cpp:
+    complete
     .text start:0x020f81c4 end:0x020f83a4
 
 src/_ZN14CutsceneObject13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -2636,6 +2636,7 @@ src/func_ov006_020e6e78.cpp:
     .text start:0x020e6e78 end:0x020e6f60
 
 src/_ZN17MgBounceAndPounce21AfterCleanupResourcesEj.cpp:
+    complete
     .text start:0x020e6f60 end:0x020e700c
 
 src/_ZN17MgBounceAndPounce11AfterRenderEj.cpp:

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -129,6 +129,7 @@ src/_ZN4Flag8BehaviorEv.cpp:
     .text start:0x02112144 end:0x02112190
 
 src/_ZN4Flag13InitResourcesEv.cpp:
+    complete
     .text start:0x02112190 end:0x021121f0
 
 src/Flag_Spawn.c:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -92,6 +92,7 @@ src/_ZN4Trap8BehaviorEv.cpp:
     .text start:0x02111ae0 end:0x02111d20
 
 src/_ZN4Trap13InitResourcesEv.cpp:
+    complete
     .text start:0x02111d20 end:0x02111dd0
 
 src/LightBeam_Spawn.c:
@@ -121,6 +122,7 @@ src/_ZN13PeachPainting8BehaviorEv.cpp:
     .text start:0x02111f28 end:0x02111fc0
 
 src/_ZN13PeachPainting13InitResourcesEv.cpp:
+    complete
     .text start:0x02111fc0 end:0x02112004
 
 src/PeachPainting_Spawn.c:

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -49,6 +49,7 @@ src/_ZN12SwitchPillar6RenderEv.cpp:
     .text start:0x02111540 end:0x02111574
 
 src/_ZN12SwitchPillar8BehaviorEv.cpp:
+    complete
     .text start:0x02111574 end:0x0211164c
 
 src/_ZN12SwitchPillar13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov013/delinks.txt
+++ b/config/arm9/overlays/ov013/delinks.txt
@@ -54,9 +54,11 @@ src/_ZN22ClockPaintingHandShort6RenderEv.cpp:
     .text start:0x021114a4 end:0x021114cc
 
 src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp:
+    complete
     .text start:0x021114cc end:0x021115cc
 
 src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp:
+    complete
     .text start:0x021115cc end:0x0211163c
 
 src/ClockPaintingHandShort_Spawn.c:

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -18,6 +18,7 @@ src/_ZN10ShutterBob8BehaviorEv.cpp:
     .text start:0x02111268 end:0x02111294
 
 src/_ZN10ShutterBob13InitResourcesEv.cpp:
+    complete
     .text start:0x02111294 end:0x021112cc
 
 src/ShutterBob_Spawn.c:
@@ -157,6 +158,7 @@ src/_ZN15ChainChompFence8BehaviorEv.cpp:
     .text start:0x02112fc0 end:0x02112ffc
 
 src/_ZN15ChainChompFence13InitResourcesEv.cpp:
+    complete
     .text start:0x02112ffc end:0x0211307c
 
 src/ChainChompFence_Spawn.c:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -188,6 +188,7 @@ src/_ZN14MovingBarSmall6RenderEv.cpp:
     .text start:0x021124a8 end:0x021124d0
 
 src/_ZN14MovingBarSmall13InitResourcesEv.cpp:
+    complete
     .text start:0x0211269c end:0x021128e8
 
 src/func_ov015_021128e8.c:

--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -128,6 +128,7 @@ src/_ZN15IceSlideManagerD0Ev.c:
     .text start:0x02112640 end:0x02112678
 
 src/_ZN15IceSlideManager8BehaviorEv.cpp:
+    complete
     .text start:0x02112678 end:0x0211271c
 
 src/_ZN15IceSlideManager13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -78,6 +78,7 @@ src/_ZN8BookShot16CleanupResourcesEv.cpp:
     .text start:0x02112244 end:0x02112290
 
 src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112290 end:0x021122c4
 
 src/_ZN8BookShot6RenderEv.cpp:
@@ -166,9 +167,11 @@ src/_ZN12HauntedChair6RenderEv.cpp:
     .text start:0x021132fc end:0x02113324
 
 src/_ZN12HauntedChair8BehaviorEv.cpp:
+    complete
     .text start:0x02113324 end:0x021133b0
 
 src/_ZN12HauntedChair13InitResourcesEv.cpp:
+    complete
     .text start:0x021133b0 end:0x02113494
 
 src/HauntedChair_Spawn.c:

--- a/config/arm9/overlays/ov021/delinks.txt
+++ b/config/arm9/overlays/ov021/delinks.txt
@@ -137,6 +137,7 @@ src/_ZN10ShutterHmc8BehaviorEv.cpp:
     .text start:0x02112e7c end:0x02112ec0
 
 src/_ZN10ShutterHmc13InitResourcesEv.cpp:
+    complete
     .text start:0x02112ec0 end:0x02112ed4
 
 src/ShutterHmc_Spawn.c:

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -72,6 +72,7 @@ src/_ZN19RotatingPlatformLll8BehaviorEv.cpp:
     .text start:0x021117cc end:0x02111870
 
 src/_ZN19RotatingPlatformLll13InitResourcesEv.cpp:
+    complete
     .text start:0x02111870 end:0x0211191c
 
 src/func_ov022_0211191c.cpp:
@@ -180,6 +181,7 @@ src/_ZN19FloatingFloorLllBig8BehaviorEv.cpp:
     .text start:0x02112238 end:0x021122ac
 
 src/_ZN19FloatingFloorLllBig13InitResourcesEv.cpp:
+    complete
     .text start:0x021122ac end:0x02112350
 
 src/LavaPlank_Spawn.c:

--- a/config/arm9/overlays/ov024/delinks.txt
+++ b/config/arm9/overlays/ov024/delinks.txt
@@ -42,6 +42,7 @@ src/_ZN10PyramidTop6RenderEv.cpp:
     .text start:0x0211153c end:0x02111568
 
 src/_ZN10PyramidTop8BehaviorEv.cpp:
+    complete
     .text start:0x02111568 end:0x02111668
 
 src/_ZN10PyramidTag8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -97,6 +97,7 @@ src/_ZN11PyramidStep6RenderEv.cpp:
     .text start:0x02111ea8 end:0x02111ed4
 
 src/_ZN11PyramidStep8BehaviorEv.cpp:
+    complete
     .text start:0x02111ed4 end:0x02111fa0
 
 src/_ZN11PyramidStep13InitResourcesEv.cpp:
@@ -128,6 +129,7 @@ src/_ZN11PyramidLift8BehaviorEv.cpp:
     .text start:0x02112288 end:0x02112498
 
 src/_ZN11PyramidLift13InitResourcesEv.cpp:
+    complete
     .text start:0x02112498 end:0x021125bc
 
 src/func_ov025_021125bc.cpp:

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -31,6 +31,7 @@ src/_ZN29FloatOnWaterPlatformWdwSquare6RenderEv.cpp:
     .text start:0x0211145c end:0x02111484
 
 src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp:
+    complete
     .text start:0x02111484 end:0x021115f8
 
 src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp:
@@ -173,6 +174,7 @@ src/_ZN19RotatingPlatformWdw6RenderEv.cpp:
     .text start:0x02112320 end:0x02112354
 
 src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp:
+    complete
     .text start:0x02112354 end:0x021124d0
 
 src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -211,6 +211,7 @@ src/_ZN13RollingLogTtm8BehaviorEv.cpp:
     .text start:0x02114278 end:0x02114378
 
 src/_ZN13RollingLogTtm13InitResourcesEv.cpp:
+    complete
     .text start:0x02114378 end:0x021145d4
 
 src/func_ov030_021145d4.c:

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -59,6 +59,7 @@ src/_ZN17RotatingClockHand6RenderEv.cpp:
     .text start:0x02111934 end:0x0211195c
 
 src/_ZN17RotatingClockHand8BehaviorEv.cpp:
+    complete
     .text start:0x0211195c end:0x02111a98
 
 src/_ZN17RotatingClockHand13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -68,9 +68,11 @@ src/_ZN18RotatingPlatformRr6RenderEv.cpp:
     .text start:0x0211169c end:0x021116c0
 
 src/_ZN18RotatingPlatformRr8BehaviorEv.cpp:
+    complete
     .text start:0x021116c0 end:0x02111854
 
 src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp:
+    complete
     .text start:0x02111854 end:0x02111904
 
 src/ShipWing_Spawn.c:
@@ -132,6 +134,7 @@ src/_ZN10DonutBlock8BehaviorEv.cpp:
     .text start:0x02111e20 end:0x02111eb0
 
 src/_ZN10DonutBlock13InitResourcesEv.cpp:
+    complete
     .text start:0x02111eb0 end:0x02111f5c
 
 src/ArmedRotatingPlatform_Spawn.c:
@@ -147,9 +150,11 @@ src/_ZN21ArmedRotatingPlatformD0Ev.c:
     .text start:0x0211200c end:0x021120a0
 
 src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp:
+    complete
     .text start:0x021120a0 end:0x021120b4
 
 src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp:
+    complete
     .text start:0x021120b4 end:0x021120c8
 
 src/TrickyTriangles_Spawn.cpp:

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -71,9 +71,11 @@ src/_ZN19RickshawPlatformBdwD0Ev.c:
     .text start:0x021116b0 end:0x02111744
 
 src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111744 end:0x02111758
 
 src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp:
+    complete
     .text start:0x02111758 end:0x0211176c
 
 src/StairsBdw_Spawn.cpp:

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -53,6 +53,7 @@ src/_ZN15FireSeaElevator6RenderEv.cpp:
     .text start:0x021115f0 end:0x02111618
 
 src/_ZN15FireSeaElevator8BehaviorEv.cpp:
+    complete
     .text start:0x02111618 end:0x02111738
 
 src/_ZN15FireSeaElevator13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -63,9 +63,11 @@ src/_ZN18RickshawPlatformBsD0Ev.c:
     .text start:0x02111590 end:0x02111624
 
 src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111624 end:0x02111638
 
 src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp:
+    complete
     .text start:0x02111638 end:0x0211164c
 
 src/StairsBs_Spawn.cpp:

--- a/config/arm9/overlays/ov052/delinks.txt
+++ b/config/arm9/overlays/ov052/delinks.txt
@@ -45,6 +45,7 @@ src/_ZN14SquarePathLift6RenderEv.cpp:
     .text start:0x02111524 end:0x0211154c
 
 src/_ZN14SquarePathLift8BehaviorEv.cpp:
+    complete
     .text start:0x0211154c end:0x0211177c
 
 src/_ZN14SquarePathLift13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov056/delinks.txt
+++ b/config/arm9/overlays/ov056/delinks.txt
@@ -19,6 +19,7 @@ src/_ZN17BigMovingIceBlock6RenderEv.cpp:
     .text start:0x02111284 end:0x021112ac
 
 src/_ZN17BigMovingIceBlock8BehaviorEv.cpp:
+    complete
     .text start:0x021112ac end:0x021114e0
 
 src/_ZN17BigMovingIceBlock13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -256,6 +256,7 @@ src/func_ov062_02118de8.cpp:
     .text start:0x02118de8 end:0x02118f04
 
 src/_ZN5Koopa16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02118f04 end:0x02118f80
 
 src/_ZN5Koopa16OnPendingDestroyEv.c:
@@ -267,9 +268,11 @@ src/_ZN5Koopa6RenderEv.cpp:
     .text start:0x02118f84 end:0x021190ec
 
 src/_ZN5Koopa8BehaviorEv.cpp:
+    complete
     .text start:0x021190ec end:0x02119420
 
 src/_ZN5Koopa13InitResourcesEv.cpp:
+    complete
     .text start:0x02119420 end:0x02119608
 
 src/func_ov062_02119608.cpp:
@@ -352,9 +355,11 @@ src/_ZN13KoopaTheQuick8BehaviorEv.cpp:
     .text start:0x0211ab88 end:0x0211ac10
 
 src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211ac10 end:0x0211ac94
 
 src/_ZN13KoopaTheQuick13InitResourcesEv.cpp:
+    complete
     .text start:0x0211ac94 end:0x0211aee0
 
 src/KoopaTheQuick_Spawn.c:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -131,6 +131,7 @@ src/_ZN5Bully8BehaviorEv.c:
     .text start:0x02117310 end:0x02117424
 
 src/_ZN5Bully13InitResourcesEv.cpp:
+    complete
     .text start:0x02117424 end:0x02117444
 
 src/Bully_Spawn.c:
@@ -249,9 +250,11 @@ src/_ZN15RotatingFirebar6RenderEv.cpp:
     .text start:0x0211824c end:0x02118274
 
 src/_ZN15RotatingFirebar8BehaviorEv.cpp:
+    complete
     .text start:0x02118274 end:0x02118480
 
 src/_ZN15RotatingFirebar13InitResourcesEv.cpp:
+    complete
     .text start:0x02118480 end:0x02118564
 
 src/RotatingFirebar_Spawn.cpp:
@@ -303,6 +306,7 @@ src/_ZN10LavaBubble8BehaviorEv.cpp:
     .text start:0x02118850 end:0x021189d8
 
 src/_ZN10LavaBubble13InitResourcesEv.cpp:
+    complete
     .text start:0x021189d8 end:0x02118b08
 
 src/func_ov064_02118b08.c:
@@ -563,6 +567,7 @@ src/_ZN13TreasureChest6RenderEv.cpp:
     .text start:0x0211a7c4 end:0x0211a7ec
 
 src/_ZN13TreasureChest8BehaviorEv.cpp:
+    complete
     .text start:0x0211a7ec end:0x0211a814
 
 src/_ZN13TreasureChest13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -161,6 +161,7 @@ src/_ZN5Swoop8BehaviorEv.cpp:
     .text start:0x02117b64 end:0x02117d80
 
 src/_ZN5Swoop13InitResourcesEv.cpp:
+    complete
     .text start:0x02117d80 end:0x02117eac
 
 src/func_ov065_02117eac.c:
@@ -315,6 +316,7 @@ src/_ZN15TtcRotatingCube6RenderEv.cpp:
     .text start:0x021199fc end:0x02119a50
 
 src/_ZN15TtcRotatingCube8BehaviorEv.cpp:
+    complete
     .text start:0x02119a50 end:0x02119c38
 
 src/_ZN15TtcRotatingCube13InitResourcesEv.cpp:
@@ -377,6 +379,7 @@ src/_ZN20TtcConveyorBeltLarge6RenderEv.cpp:
     .text start:0x0211a69c end:0x0211a6d0
 
 src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp:
+    complete
     .text start:0x0211a6d0 end:0x0211a870
 
 src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -262,6 +262,7 @@ src/_ZN10FlameChomp6RenderEv.cpp:
     .text start:0x021218c4 end:0x021218f4
 
 src/_ZN10FlameChomp8BehaviorEv.cpp:
+    complete
     .text start:0x021218f4 end:0x02121914
 
 src/_ZN10FlameChomp13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -278,6 +278,7 @@ src/_ZN14MrI_Projectile8BehaviorEv.cpp:
     .text start:0x02121d80 end:0x02121eb4
 
 src/_ZN14MrI_Projectile13InitResourcesEv.cpp:
+    complete
     .text start:0x02121eb4 end:0x02121f9c
 
 src/MrI_Projectile_Spawn.c:

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -180,6 +180,7 @@ src/_ZN11ChiefChilly8BehaviorEv.cpp:
     .text start:0x021218a0 end:0x02121ccc
 
 src/_ZN11ChiefChilly13InitResourcesEv.cpp:
+    complete
     .text start:0x02121ccc end:0x02121ec0
 
 src/func_ov073_02121ec0.c:

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -158,9 +158,11 @@ src/_ZN14UnknownVsEntry6RenderEv.cpp:
     .text start:0x021154cc end:0x0211555c
 
 src/_ZN14UnknownVsEntry8BehaviorEv.cpp:
+    complete
     .text start:0x0211555c end:0x021156e0
 
 src/_ZN14UnknownVsEntry13InitResourcesEv.cpp:
+    complete
     .text start:0x021156e0 end:0x021159f4
 
 src/UnknownVsEntry_Spawn.cpp:

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -187,6 +187,7 @@ src/_ZN10KingBobOmb16OnPendingDestroyEv.c:
     .text start:0x021260a8 end:0x021260ac
 
 src/_ZN10KingBobOmb6RenderEv.cpp:
+    complete
     .text start:0x021260ac end:0x02126104
 
 src/_ZN10KingBobOmb8BehaviorEv.cpp:
@@ -194,6 +195,7 @@ src/_ZN10KingBobOmb8BehaviorEv.cpp:
     .text start:0x02126104 end:0x02126368
 
 src/_ZN10KingBobOmb13InitResourcesEv.cpp:
+    complete
     .text start:0x02126368 end:0x021265f4
 
 src/func_ov078_021265f4.c:

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -125,6 +125,7 @@ src/func_ov079_02125b44.c:
     .text start:0x02125b44 end:0x02125eb0
 
 src/_ZN5Whomp16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02125eb0 end:0x02125f78
 
 src/_ZN5Whomp6RenderEv.cpp:
@@ -249,6 +250,7 @@ src/_ZN12FortressWall8BehaviorEv.cpp:
     .text start:0x021273a4 end:0x02127494
 
 src/_ZN12FortressWall13InitResourcesEv.cpp:
+    complete
     .text start:0x02127494 end:0x0212757c
 
 src/FortressWall_Spawn.c:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -171,6 +171,7 @@ src/_ZN11CrazedCrate6RenderEv.cpp:
     .text start:0x02125180 end:0x021251cc
 
 src/_ZN11CrazedCrate8BehaviorEv.cpp:
+    complete
     .text start:0x021251cc end:0x021251ec
 
 src/_ZN11CrazedCrate13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -172,6 +172,7 @@ src/_ZN10MrBlizzard16OnPendingDestroyEv.c:
     .text start:0x0212581c end:0x02125820
 
 src/_ZN10MrBlizzard6RenderEv.cpp:
+    complete
     .text start:0x02125820 end:0x0212588c
 
 src/_ZN10MrBlizzard8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov089/delinks.txt
+++ b/config/arm9/overlays/ov089/delinks.txt
@@ -60,6 +60,7 @@ src/func_ov089_02131f54.cpp:
     .text start:0x02131f54 end:0x02132084
 
 src/_ZN3Key16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02132084 end:0x021320f0
 
 src/_ZN3Key6RenderEv.cpp:
@@ -71,6 +72,7 @@ src/_ZN3Key8BehaviorEv.cpp:
     .text start:0x02132194 end:0x021324a4
 
 src/_ZN3Key13InitResourcesEv.cpp:
+    complete
     .text start:0x021324a4 end:0x021327d0
 
 src/LastStar_Spawn.c:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -38,9 +38,11 @@ src/_ZN25RotatingUpDownPlatformUtm6RenderEv.cpp:
     .text start:0x02131408 end:0x02131468
 
 src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp:
+    complete
     .text start:0x02131468 end:0x021318f0
 
 src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp:
+    complete
     .text start:0x021318f0 end:0x02131ba4
 
 src/RotatingUpDownPlatformUtm_Spawn.c:
@@ -122,9 +124,11 @@ src/_ZN17SlidingPlatformWf6RenderEv.cpp:
     .text start:0x02132504 end:0x0213252c
 
 src/_ZN17SlidingPlatformWf8BehaviorEv.cpp:
+    complete
     .text start:0x0213252c end:0x021325d4
 
 src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp:
+    complete
     .text start:0x021325d4 end:0x021327e8
 
 src/SlidingPlatformWf_Spawn.c:
@@ -310,6 +314,7 @@ src/func_ov091_02134094.c:
     .text start:0x02134094 end:0x02134108
 
 src/_ZN5Stump16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02134108 end:0x02134180
 
 src/_ZN5Stump16OnPendingDestroyEv.c:
@@ -325,6 +330,7 @@ src/_ZN5Stump8BehaviorEv.cpp:
     .text start:0x021341ec end:0x02134324
 
 src/_ZN5Stump13InitResourcesEv.cpp:
+    complete
     .text start:0x02134324 end:0x02134484
 
 src/func_ov091_02134484.c:

--- a/config/arm9/overlays/ov094/delinks.txt
+++ b/config/arm9/overlays/ov094/delinks.txt
@@ -84,6 +84,7 @@ src/_ZN10HootTheOwl8BehaviorEv.cpp:
     .text start:0x02136478 end:0x02136634
 
 src/_ZN10HootTheOwl13InitResourcesEv.cpp:
+    complete
     .text start:0x02136634 end:0x02136798
 
 src/HootTheOwl_Spawn.c:

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -116,6 +116,7 @@ src/_ZN13UpDownLiftBbh8BehaviorEv.cpp:
     .text start:0x021364d8 end:0x021365d8
 
 src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp:
+    complete
     .text start:0x021365d8 end:0x02136764
 
 src/func_ov095_02136764.cpp:

--- a/config/arm9/overlays/ov096/delinks.txt
+++ b/config/arm9/overlays/ov096/delinks.txt
@@ -127,6 +127,7 @@ src/_ZN5Pokey6RenderEv.cpp:
     .text start:0x021369fc end:0x02136a50
 
 src/_ZN5Pokey8BehaviorEv.cpp:
+    complete
     .text start:0x02136a50 end:0x02136ab0
 
 src/_ZN5Pokey13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -174,9 +174,11 @@ src/_ZN5Crate6RenderEv.cpp:
     .text start:0x02139aa8 end:0x02139b0c
 
 src/_ZN5Crate8BehaviorEv.cpp:
+    complete
     .text start:0x02139b0c end:0x02139d14
 
 src/_ZN5Crate13InitResourcesEv.cpp:
+    complete
     .text start:0x02139d14 end:0x02139e44
 
 src/func_ov098_02139e44.cpp:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -441,6 +441,7 @@ src/func_ov100_02146828.c:
     .text start:0x02146828 end:0x02146a98
 
 src/_ZN4Fish16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02146a98 end:0x02146b00
 
 src/_ZN4Fish16OnPendingDestroyEv.c:
@@ -456,6 +457,7 @@ src/_ZN4Fish8BehaviorEv.cpp:
     .text start:0x02146b38 end:0x02146c68
 
 src/_ZN4Fish13InitResourcesEv.cpp:
+    complete
     .text start:0x02146c68 end:0x02146d38
 
 src/Fish_Spawn.cpp:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -175,6 +175,7 @@ src/_ZN13QuestionBlock6RenderEv.cpp:
     .text start:0x0214a2ac end:0x0214a32c
 
 src/_ZN13QuestionBlock8BehaviorEv.cpp:
+    complete
     .text start:0x0214a32c end:0x0214a4a4
 
 src/_ZN13QuestionBlock13InitResourcesEv.c:

--- a/src/EndKuppaScript.cpp
+++ b/src/EndKuppaScript.cpp
@@ -3,9 +3,11 @@ struct ActorBase { void MarkForDestruction(); };
 struct Actor : ActorBase { static Actor *FindWithID(unsigned int); };
 namespace Sound { void UnsetPlayerVoiceGroup(); }
 
+extern "C" {
 extern void func_02011c8c(void);
 extern int GetSoundMode(void);
 extern void SetSoundMode(int);
+}
 
 extern int data_0209fc48;
 extern int data_020890a0;

--- a/src/_ZN10CheepCheep13InitResourcesEv.cpp
+++ b/src/_ZN10CheepCheep13InitResourcesEv.cpp
@@ -10,9 +10,11 @@ struct BCA_File;
 struct Actor;
 struct Vector3_16;
 
+extern "C" {
 extern struct BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thisp, struct BMD_File *, int, int);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
+}
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void *thisp, struct Actor *, struct Vector3 const &, int, int, unsigned int, unsigned int);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(

--- a/src/_ZN10DonutBlock13InitResourcesEv.cpp
+++ b/src/_ZN10DonutBlock13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "DonutBlock.h"
 typedef int Fix12;
 typedef short s16;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
@@ -11,8 +12,11 @@ extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int func_020393d4(void*, void*);
+}
 extern void* data_ov036_02113d78[];
+extern "C" {
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 int DonutBlock::InitResources()
 {

--- a/src/_ZN10FlameChomp13InitResourcesEv.cpp
+++ b/src/_ZN10FlameChomp13InitResourcesEv.cpp
@@ -8,18 +8,22 @@ typedef int Fix12;
 struct RG { char pad[0x44]; int f44; char pad2[8]; };
 struct Blk { int w[12]; };
 
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void* self);
+}
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void* self, void* actor, const struct Vector3* v, Fix12 a, int b, unsigned int c, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(
     void* self, void* actor, Fix12 a, int b, void* v, int c);
+extern "C" {
 extern void _ZN13RaycastGroundC1Ev(struct RG* rg);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RG* rg, const struct Vector3* v, void* a);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RG* rg);
 extern void func_ov070_02121310(void* c);
 extern void _ZN13RaycastGroundD1Ev(struct RG* rg);
+}
 
 extern struct Blk data_02082128;
 

--- a/src/_ZN10FlameChomp8BehaviorEv.cpp
+++ b/src/_ZN10FlameChomp8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FlameChomp.h"
+extern "C" {
 extern void func_ov070_02121310(char* c);
+}
 
 int FlameChomp::Behavior()
 {

--- a/src/_ZN10HootTheOwl13InitResourcesEv.cpp
+++ b/src/_ZN10HootTheOwl13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "HootTheOwl.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN11ShadowModel12InitCylinderEv(void*);
@@ -13,6 +14,7 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void*, vo
 extern int func_ov094_02136188(void*, void*);
 extern int IsStarCollectedInCurLevel(int);
 extern void _ZN9ActorBase18MarkForDestructionEv(void*);
+}
 extern void* data_ov094_02136b40;
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;

--- a/src/_ZN10KingBobOmb13InitResourcesEv.cpp
+++ b/src/_ZN10KingBobOmb13InitResourcesEv.cpp
@@ -26,6 +26,7 @@ extern SharedFilePtr data_ov078_02126ef8;
 extern int data_0209e650;
 extern PMF data_ov078_0212710c;
 
+extern "C" {
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
@@ -35,6 +36,7 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* sel
 extern unsigned char _ZN5Actor9TrackStarEjj(void* self, unsigned int a, unsigned int b);
 extern int RandomIntInternal(int* seed);
 extern void KingBobOmb_SetState(void* c, PMF* p);
+}
 
 int KingBobOmb::InitResources()
 {

--- a/src/_ZN10KingBobOmb6RenderEv.cpp
+++ b/src/_ZN10KingBobOmb6RenderEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "KingBobOmb.h"
+extern "C" {
 extern int _ZN5Model6RenderEPK7Vector3(void *m, void *v);
+}
 
 int KingBobOmb::Render()
 {

--- a/src/_ZN10LavaBubble13InitResourcesEv.cpp
+++ b/src/_ZN10LavaBubble13InitResourcesEv.cpp
@@ -2,10 +2,12 @@
 // @symbol _ZN10LavaBubble13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "LavaBubble.h"
+extern "C" {
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(char* thiz, char* actor, int b, int d, unsigned int e, unsigned int f);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* thiz, char* actor, int b, int d, void* v, int f);
 extern void _ZN12WithMeshClsn13SetLimMovFlagEv(char* thiz);
 extern void func_ov064_021187ec(char* c, void* p);
+}
 extern char data_ov064_0211c7c8[];
 extern char data_ov064_0211c7b8[];
 

--- a/src/_ZN10MrBlizzard13InitResourcesEv.cpp
+++ b/src/_ZN10MrBlizzard13InitResourcesEv.cpp
@@ -9,6 +9,7 @@
 #include "MrBlizzard.h"
 struct Vec3 { int x, y, z; };
 
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -17,12 +18,15 @@ extern int _ZN5Actor18GetBitInDeathTableEv(void *self);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const void *v, const void *v16, int e, int f);
 extern void _ZN7PathPtrC1Ev(void *self);
 extern void _ZN7PathPtr6FromIDEj(void *self, u32 id);
+}
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void *self, void *actor, const void *v, int d, int e, u32 f, u32 g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(
     void *self, void *actor, int b, int c, void *v16, int e);
+extern "C" {
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, void *v, u32 idx);
 extern void func_ov081_02125488(void *c, void *p);
+}
 
 extern void *data_ov081_02128d90;
 extern void *data_ov081_02128d98;

--- a/src/_ZN10MrBlizzard6RenderEv.cpp
+++ b/src/_ZN10MrBlizzard6RenderEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_Model.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MrBlizzard.h"
+extern "C" {
 extern void _ZN5Model6RenderEPK7Vector3(void*,void*);
+}
 
 int MrBlizzard::Render()
 {

--- a/src/_ZN10PyramidTop8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTop8BehaviorEv.cpp
@@ -5,8 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidTop.h"
+extern "C" {
 extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void* actor, void* pt);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int bank, void* pos);
+}
 
 int PyramidTop::Behavior()
 {

--- a/src/_ZN10ShutterBob13InitResourcesEv.cpp
+++ b/src/_ZN10ShutterBob13InitResourcesEv.cpp
@@ -8,7 +8,9 @@ public:
     void Enable(Actor *a);
 };
 
+extern "C" {
 extern int func_ov002_020bad10(void *c, void **f);
+}
 extern int data_ov014_021145c4;
 
 int ShutterBob::InitResources()

--- a/src/_ZN10ShutterHmc13InitResourcesEv.cpp
+++ b/src/_ZN10ShutterHmc13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ShutterHmc.h"
+extern "C" {
 extern int func_ov002_020bad10(void *self, void *data);
+}
 
 int ShutterHmc::InitResources()
 {

--- a/src/_ZN10StarMarker13InitResourcesEv.cpp
+++ b/src/_ZN10StarMarker13InitResourcesEv.cpp
@@ -8,6 +8,7 @@
 struct Vec3 { s32 x, y, z; };
 struct RaycastGround { char pad[0x50]; };
 
+extern "C" {
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, const void *v, int d, int e, u32 f, u32 g);
 extern void _ZN13RaycastGroundC1Ev(void *self);
 extern void _ZN4BgCh19StartDetectingWaterEv(void *self);
@@ -21,6 +22,7 @@ extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern int IsStarCollectedInCurLevel(u8 x);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
 extern int _ZN5Actor18GetBitInDeathTableEv(void *self);
+}
 
 extern char data_ov002_0210d9a8;
 extern char data_ov002_0211092c;

--- a/src/_ZN10StarMarker16OnPendingDestroyEv.cpp
+++ b/src/_ZN10StarMarker16OnPendingDestroyEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "StarMarker.h"
+extern "C" {
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+}
 
 void StarMarker::OnPendingDestroy()
 {

--- a/src/_ZN10StarSwitch8BehaviorEv.cpp
+++ b/src/_ZN10StarSwitch8BehaviorEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "StarSwitch.h"
+extern "C" {
 extern unsigned char IsAreaShowing(int idx);
 extern void func_ov002_020ba01c(char *c, int mask, int b, int base, int target);
 extern void func_ov002_020ba4d8(char *c, int i);
@@ -11,6 +12,7 @@ extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(char *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
 extern int _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int id, int vol);
+}
 
 extern int data_0209b454;
 

--- a/src/_ZN11ChiefChilly13InitResourcesEv.cpp
+++ b/src/_ZN11ChiefChilly13InitResourcesEv.cpp
@@ -21,6 +21,7 @@ extern SharedFilePtr data_ov002_0210da30;
 extern SharedFilePtr data_ov073_02123298;
 extern PMF data_ov073_02123330;
 
+extern "C" {
 extern void LoadKeyModels(int idx);
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
@@ -30,6 +31,7 @@ extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern short _ZN5Actor18HorzAngleToCPlayerEv(void* self);
 extern int ChiefChilly_ChangeState(void* c, PMF* p);
+}
 
 int ChiefChilly::InitResources()
 {

--- a/src/_ZN11CrazedCrate8BehaviorEv.cpp
+++ b/src/_ZN11CrazedCrate8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CrazedCrate.h"
+extern "C" {
 extern int func_ov080_02124c3c(char *c);
+}
 
 int CrazedCrate::Behavior()
 {

--- a/src/_ZN11PyramidLift13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidLift13InitResourcesEv.cpp
@@ -16,6 +16,7 @@ extern SharedFilePtr data_ov002_0210d9f0;
 extern SharedFilePtr data_ov025_02113ad8;
 extern CLPS_Block data_ov025_02112d08;
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+extern "C" {
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
@@ -23,6 +24,7 @@ extern KCL_File* _ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, KCL_File* k, Matrix4x3* m, Fix12 f, short s, CLPS_Block* b);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
+}
 
 int PyramidLift::InitResources()
 {

--- a/src/_ZN11PyramidStep8BehaviorEv.cpp
+++ b/src/_ZN11PyramidStep8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidStep.h"
+extern "C" {
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* p, int a, int b);
+}
 
 int PyramidStep::Behavior()
 {

--- a/src/_ZN12EnemySpawner13InitResourcesEv.cpp
+++ b/src/_ZN12EnemySpawner13InitResourcesEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN12EnemySpawner13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySpawner.h"
+extern "C" {
 extern unsigned int _ZN5Event6GetBitEj(unsigned int bit);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
+}
 extern int data_ov002_0210d9e0;
 
 int EnemySpawner::InitResources()

--- a/src/_ZN12FortressWall13InitResourcesEv.cpp
+++ b/src/_ZN12FortressWall13InitResourcesEv.cpp
@@ -3,12 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FortressWall.h"
 typedef int Fix12;
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, void *, int, int);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *self, void *kcl, void *mtx, Fix12 f, short s, void *blk);
+}
 struct E12 { void *p; int pad[2]; };
 extern struct E12 data_ov079_02128058[];
 extern struct E12 data_ov079_0212805c[];

--- a/src/_ZN12HauntedChair13InitResourcesEv.cpp
+++ b/src/_ZN12HauntedChair13InitResourcesEv.cpp
@@ -6,11 +6,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "HauntedChair.h"
 struct Actor; struct Vector3; struct Vector3_16; struct BMD_File;
+extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(char* self);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* self, struct Actor* a, int r, int h, struct Vector3_16* rot, int f);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, struct Actor* a, struct Vector3* pos, int r, int h, u32 f1, u32 f2);
+}
 struct M48 { int w[12]; };
 extern struct M48 data_02082128;
 

--- a/src/_ZN12HauntedChair8BehaviorEv.cpp
+++ b/src/_ZN12HauntedChair8BehaviorEv.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "HauntedChair.h"
+extern "C" {
 extern void func_0200f760(char* a, char* b);
 extern void _ZN12CylinderClsn5ClearEv(char* c);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(char* c, char* v);
 extern void _ZN12CylinderClsn6UpdateEv(char* c);
+}
 
 int HauntedChair::Behavior()
 {

--- a/src/_ZN12SwitchPillar8BehaviorEv.cpp
+++ b/src/_ZN12SwitchPillar8BehaviorEv.cpp
@@ -2,12 +2,14 @@
 // @symbol _ZN12SwitchPillar8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "SwitchPillar.h"
+extern "C" {
 extern void _ZN5Sound15PlaySecretSoundEP5ActorPt(void* a, unsigned short* p);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int d, void* v, unsigned int e);
 extern void _ZN7Minimap19UpdateLevelSpecificEv(void);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* thiz);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
 extern void _ZN9Animation7AdvanceEv(void* thiz);
+}
 extern int data_0209caa0[];
 extern int data_0209f32c;
 

--- a/src/_ZN13HeapAllocator6RemoveEv.cpp
+++ b/src/_ZN13HeapAllocator6RemoveEv.cpp
@@ -15,8 +15,10 @@ struct NestedHeapIteratorT {
     unsigned short linkOffset;
 };
 
+extern "C" {
 extern NestedHeapIteratorT* _ZN18NestedHeapIterator10FindNestedEPv(HeapAllocator* node);
 extern void _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(NestedHeapIteratorT* iter, HeapAllocator* node);
+}
 
 void HeapAllocator::Remove()
 {

--- a/src/_ZN13KoopaTheQuick13InitResourcesEv.cpp
+++ b/src/_ZN13KoopaTheQuick13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 #include "KoopaTheQuick.h"
 typedef short s16;
 
+extern "C" {
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
@@ -16,6 +17,7 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *sel
 extern void _ZN7PathPtr6FromIDEj(void *self, unsigned int id);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, void *v, unsigned int idx);
 extern unsigned char _ZN5Actor9TrackStarEjj(void *self, unsigned int a, unsigned int b);
+}
 
 extern char data_ov062_0211e00c[];
 extern char data_ov062_0211e014[];

--- a/src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp
+++ b/src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp
@@ -5,7 +5,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "KoopaTheQuick.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *);
+}
 extern struct SharedFilePtr data_ov062_0211e00c;
 extern struct SharedFilePtr data_ov062_0211e014;
 extern struct SharedFilePtr data_ov062_0211e024;

--- a/src/_ZN13PeachPainting13InitResourcesEv.cpp
+++ b/src/_ZN13PeachPainting13InitResourcesEv.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PeachPainting.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int a, int b);
+}
 
 int PeachPainting::InitResources()
 {

--- a/src/_ZN13QuestionBlock8BehaviorEv.cpp
+++ b/src/_ZN13QuestionBlock8BehaviorEv.cpp
@@ -5,11 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionBlock.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
 extern void func_020393a4(int* p, int v);
 extern void func_02039394(int* p, int v);
 extern void _ZN9Animation7AdvanceEv(void* a);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
+}
 extern int data_0209caa0[];
 extern unsigned char data_0209f2d8;
 extern signed char data_0209f2f8;

--- a/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
+++ b/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
@@ -7,6 +7,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RollingLogTtm.h"
 #define false 0
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int a, int b);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
@@ -18,6 +19,7 @@ extern char *_ZN5Actor13ClosestPlayerEv(void *self);
 extern char *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 param, void *pos, void *rot, int a, int b);
 extern void func_ov030_021141a8(void *self, int a);
 extern void func_ov030_02112094(void *self);
+}
 
 extern char data_ov002_0210da40;
 extern char data_ov002_0210d9a0;

--- a/src/_ZN13SnowmanBreath8BehaviorEv.cpp
+++ b/src/_ZN13SnowmanBreath8BehaviorEv.cpp
@@ -8,13 +8,17 @@
 #include "SnowmanBreath.h"
 extern u8 data_0209f2d8[];
 
+extern "C" {
 extern int _ZN6Player9StartTalkER9ActorBaseb(void *self, void *actor, int b);
+}
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *self, void *actor,
                                                             unsigned int msg,
                                                             const Vector3 *pos,
                                                             unsigned int a,
                                                             unsigned int b);
+extern "C" {
 extern int _ZN6Player12GetTalkStateEv(void *self);
+}
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(int handle, unsigned int a,
                                              unsigned int b, void *pos,
                                              unsigned int c);

--- a/src/_ZN13TTC_MovingBar13InitResourcesEv.cpp
+++ b/src/_ZN13TTC_MovingBar13InitResourcesEv.cpp
@@ -4,19 +4,23 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TTC_MovingBar.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmd, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *fp);
+}
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *self, void *kcl, void *mtx, int fix, short s, void *clps);
+extern "C" {
 extern void func_020393d4(int *p, int v);
 extern void _ZN13RaycastGroundC1Ev(void *self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, void *pos, void *actor);
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
 extern void _ZN13RaycastGroundD1Ev(void *self);
+}
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 
 

--- a/src/_ZN13TreasureChest8BehaviorEv.cpp
+++ b/src/_ZN13TreasureChest8BehaviorEv.cpp
@@ -5,8 +5,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "TreasureChest.h"
 struct CylinderClsn { int dummy; };
+extern "C" {
 extern void _ZN12CylinderClsn5ClearEv(struct CylinderClsn *t);
 extern void _ZN12CylinderClsn6UpdateEv(struct CylinderClsn *t);
+}
 
 int TreasureChest::Behavior()
 {

--- a/src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp
+++ b/src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp
@@ -10,6 +10,7 @@
  * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  * natural signed /2 spelling; mwcc synthesizes add/lsr#31/asr#1 itself and
  * self-schedules the byte store into the ROM slot */
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(int sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
@@ -17,6 +18,7 @@ extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(int sfp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *mc, void *kcl, void *mtx, int fix, short s, int clps);
 extern void func_020393d4(void *p, void *v);
 extern void func_020393c4(void *p, void *v);
+}
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern int data_ov095_02136f68[];
 extern int data_ov095_02136f74[];

--- a/src/_ZN14CutsceneObject8BehaviorEv.cpp
+++ b/src/_ZN14CutsceneObject8BehaviorEv.cpp
@@ -19,6 +19,7 @@ typedef struct
 {
   char pad[0x50];
 } RaycastGround;
+extern "C" {
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void *c, void *cyl);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *cyl);
 extern void _ZN13RaycastGroundC1Ev(RaycastGround *rc);
@@ -29,6 +30,7 @@ extern void Vec3_Asr(Vec3 *d, Vec3 *s, int sh);
 extern void Matrix4x3_FromTranslation(Mtx43 *m, s32 x, s32 y, s32 z);
 extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(void *m, s32 x, s32 y, s32 z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, s32 x, s32 y, s32 z);
+}
 extern Mtx43 data_020a0e68;
 
 int CutsceneObject::Behavior()

--- a/src/_ZN14EnemySwitchTag16CleanupResourcesEv.cpp
+++ b/src/_ZN14EnemySwitchTag16CleanupResourcesEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN14EnemySwitchTag16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySwitchTag.h"
+extern "C" {
 extern int _ZN5Event8ClearBitEj(unsigned int bit);
+}
 
 int EnemySwitchTag::CleanupResources()
 {

--- a/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
+++ b/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
@@ -3,11 +3,13 @@
 // @symbol _ZN14EnemySwitchTag8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySwitchTag.h"
+extern "C" {
 extern void _ZN5Event8ClearBitEj(u32 bit);
 extern void _ZN5Event6SetBitEj(u32 bit);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* p);
 extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
+}
 
 int EnemySwitchTag::Behavior()
 {

--- a/src/_ZN14MovingBarSmall13InitResourcesEv.cpp
+++ b/src/_ZN14MovingBarSmall13InitResourcesEv.cpp
@@ -21,8 +21,10 @@ int IsStarCollectedInCurLevel(int a);
 extern void* data_ov015_02114a64;
 extern void* data_ov015_02114a5c;
 extern void* data_ov015_02113594;
+extern "C" {
 extern void _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern void func_ov015_021128f8();
+}
 extern s16 data_02082214[];
 extern signed char data_0209f2f8;
 extern u8 data_0209f220;

--- a/src/_ZN14MrI_Projectile13InitResourcesEv.cpp
+++ b/src/_ZN14MrI_Projectile13InitResourcesEv.cpp
@@ -3,10 +3,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "MrI_Projectile.h"
 typedef int Fix12;
+extern "C" {
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern int _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, void *v, Fix12 r, int t1, unsigned int u1, unsigned int u2);
 extern int _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *actor, Fix12 a, int b, void *v, int c);
 extern void func_ov071_02121c6c(char *c);
+}
 extern void *data_ov071_021230b8;
 struct M48 { int w[12]; };
 extern struct M48 data_02082128;

--- a/src/_ZN14QuestionSwitch13InitResourcesEv.cpp
+++ b/src/_ZN14QuestionSwitch13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "QuestionSwitch.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int b, int c);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
@@ -13,6 +14,7 @@ extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *self, void *f, void *m, int fix, short sh, void *b);
 extern void func_020393c4(int *p, int v);
 extern void _ZN9Animation7AdvanceEv(void *self);
+}
 
 extern int data_ov002_0210dd60;
 extern int data_ov002_0210dd68;

--- a/src/_ZN14SquarePathLift8BehaviorEv.cpp
+++ b/src/_ZN14SquarePathLift8BehaviorEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SquarePathLift.h"
 typedef int Fix12;
+extern "C" {
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, void *out, unsigned idx);
 extern void Vec3_Sub(void *out, void *a, void *b);
 extern int LenVec3(void *v);
@@ -14,6 +15,7 @@ extern void SubVec3(void *a, void *b, void *c);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *p);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *p, Fix12 a, int b);
+}
 struct V3 { int x, y, z; };
 
 int SquarePathLift::Behavior()

--- a/src/_ZN14UnknownVsEntry13InitResourcesEv.cpp
+++ b/src/_ZN14UnknownVsEntry13InitResourcesEv.cpp
@@ -6,12 +6,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "UnknownVsEntry.h"
+extern "C" {
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void* f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* bca, int a, int fx, unsigned int f);
 extern void func_ov075_021152d4(char* self);
+}
 
 extern char data_ov075_0211d3fc;
 extern char data_ov075_0211d3bc;

--- a/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
+++ b/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
@@ -5,8 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "UnknownVsEntry.h"
+extern "C" {
 extern void func_ov075_021152d4(void* self);
 extern int _ZN9Animation7AdvanceEv(void* a);
+}
 extern u8 data_0209fc5c;
 
 int UnknownVsEntry::Behavior()

--- a/src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp
+++ b/src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp
@@ -7,7 +7,9 @@ public:
     void Release();
 };
 
+extern "C" {
 extern void UnloadBlueCoinModel(char *c);
+}
 extern int data_ov020_02114aa0;
 extern int data_ov020_02114ab8;
 

--- a/src/_ZN15ChainChompFence13InitResourcesEv.cpp
+++ b/src/_ZN15ChainChompFence13InitResourcesEv.cpp
@@ -4,12 +4,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ChainChompFence.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
+}
 extern int data_ov021_021149b8[];
 extern int data_ov022_02114558[];
 

--- a/src/_ZN15FireSeaElevator8BehaviorEv.cpp
+++ b/src/_ZN15FireSeaElevator8BehaviorEv.cpp
@@ -3,11 +3,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "FireSeaElevator.h"
 typedef int Fix12;
+extern "C" {
 extern void _ZN12CylinderClsn5ClearEv(void *self);
 extern void _ZN12CylinderClsn6UpdateEv(void *self);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *self, Fix12 a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
+}
 extern short data_02082214[];
 
 int FireSeaElevator::Behavior()

--- a/src/_ZN15IceSlideManager8BehaviorEv.cpp
+++ b/src/_ZN15IceSlideManager8BehaviorEv.cpp
@@ -2,10 +2,12 @@
 // @symbol _ZN15IceSlideManager8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "IceSlideManager.h"
+extern "C" {
 extern int _ZN5Actor13DistToCPlayerEv(void*);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned,unsigned,unsigned,int,int);
 extern int DecIfAbove0_Short(void*);
 extern int _ZN5Actor24KillAndTrackInDeathTableEv(void*);
+}
 
 int IceSlideManager::Behavior()
 {

--- a/src/_ZN15InvisibleSecret8BehaviorEv.cpp
+++ b/src/_ZN15InvisibleSecret8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 #include "InvisibleSecret.h"
 struct V3 { int x, y, z; };
 
+extern "C" {
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void _ZN9ActorBase18MarkForDestructionEv(char *self);
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
+}
 
 int InvisibleSecret::Behavior()
 {

--- a/src/_ZN15RotatingFirebar13InitResourcesEv.cpp
+++ b/src/_ZN15RotatingFirebar13InitResourcesEv.cpp
@@ -3,8 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingFirebar.h"
 extern void* data_ov064_0211adbc[];
+extern "C" {
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
 extern void _ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj(void* thiz, void* v, int f1, int f2, unsigned int a, unsigned int b);
@@ -13,6 +16,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void func_020393d4(int* p, int v);
+}
 
 int RotatingFirebar::InitResources()
 {

--- a/src/_ZN15RotatingFirebar8BehaviorEv.cpp
+++ b/src/_ZN15RotatingFirebar8BehaviorEv.cpp
@@ -13,6 +13,7 @@
 #define LI(v) ((int)(((long long)(v))))
 
 
+extern "C" {
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* c);
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(void* a, void* m, void* b);
@@ -23,6 +24,7 @@ extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* c, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
+}
 
 extern int data_020a0e68[];
 

--- a/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
@@ -5,11 +5,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
+extern "C" {
 extern u16 DecIfAbove0_Short(u16 *p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void *v);
 extern int _Z14ApproachLinearRsss(s16 *val, int target, int step);
 extern int RandomIntInternal(int *seed);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
+}
 
 extern u8 data_0209f2c0;
 extern int data_0209e650;

--- a/src/_ZN16RotatingCogSmall13InitResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall13InitResourcesEv.cpp
@@ -5,14 +5,18 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingCogSmall.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *sfp);
+}
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *mc, void *kcl, void *mtx, int fix, short s, void *clps);
+extern "C" {
 extern void func_020393d4(void *p, void *v);
+}
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern int data_ov035_02112c78[];
 extern int data_ov035_02112c70[];

--- a/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
+++ b/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BigMovingIceBlock.h"
 typedef int Fix12;
+extern "C" {
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, void *out, unsigned idx);
 extern void Vec3_Sub(void *out, void *a, void *b);
 extern int LenVec3(void *v);
@@ -14,6 +15,7 @@ extern void SubVec3(void *a, void *b, void *c);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *p);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *p, Fix12 a, int b);
+}
 
 struct V3 { int x, y, z; };
 

--- a/src/_ZN17MgBounceAndPounce21AfterCleanupResourcesEj.cpp
+++ b/src/_ZN17MgBounceAndPounce21AfterCleanupResourcesEj.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MgBounceAndPounce.h"
+extern "C" {
 extern void Ov004_Deallocate(void* x);
 extern void func_ov004_020b0840(void* a, int b);
+}
 extern void* data_ov006_02141a48;
 extern unsigned char data_0209f5f8;
 

--- a/src/_ZN17RotatingClockHand8BehaviorEv.cpp
+++ b/src/_ZN17RotatingClockHand8BehaviorEv.cpp
@@ -4,12 +4,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingClockHand.h"
+extern "C" {
 extern int DecIfAbove0_Short(char *p);
 extern int RandomIntInternal(char *p);
 extern void func_020393a4(int *p, int v);
 extern void func_02039394(int *p, int v);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char *c);
+}
 extern unsigned char data_0209f2c0[];
 extern int data_0209e650[];
 

--- a/src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp
+++ b/src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp
@@ -19,7 +19,9 @@ extern char data_ov091_02135028[];   // collider sfp table, stride 0xc
 extern char data_ov091_0213502c[];   // clps table, stride 0xc
 extern u16 data_ov091_02134514[];
 extern u16 data_ov091_02134504[];
+extern "C" {
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
+}
 
 int SlidingPlatformWf::InitResources()
 {

--- a/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
+++ b/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
@@ -5,12 +5,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingPlatformWf.h"
+extern "C" {
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* c, void* cc);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(char* c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, Fix12i a, Fix12i b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
+}
 
 int SlidingPlatformWf::Behavior()
 {

--- a/src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp
+++ b/src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp
@@ -5,7 +5,9 @@
 #include "RickshawPlatformBs.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
+}
 extern struct Arg data_ov047_02112508;
 
 int RickshawPlatformBs::InitResources()

--- a/src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp
+++ b/src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp
@@ -5,7 +5,9 @@
 #include "RickshawPlatformBs.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
+}
 extern struct Arg data_ov047_02112508;
 
 int RickshawPlatformBs::CleanupResources()

--- a/src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp
+++ b/src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp
@@ -5,8 +5,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformRr.h"
 typedef short s16;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
+}
 
 int RotatingPlatformRr::InitResources()
 {

--- a/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
+++ b/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
@@ -6,7 +6,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformRr.h"
 extern s16 data_02082214[];
+extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
+}
 
 int RotatingPlatformRr::Behavior()
 {

--- a/src/_ZN19AmbientSoundEffects8BehaviorEv.cpp
+++ b/src/_ZN19AmbientSoundEffects8BehaviorEv.cpp
@@ -6,7 +6,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "AmbientSoundEffects.h"
+extern "C" {
 extern u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, void *v, u32 e);
+}
 extern void *data_0209f318;
 
 int AmbientSoundEffects::Behavior()

--- a/src/_ZN19FloatingFloorLllBig13InitResourcesEv.cpp
+++ b/src/_ZN19FloatingFloorLllBig13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 #include "FloatingFloorLllBig.h"
 typedef int Fix12;
 typedef short s16;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
@@ -14,6 +15,7 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int func_020393d4(void*, void*);
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 int FloatingFloorLllBig::InitResources()
 {

--- a/src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp
+++ b/src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp
@@ -5,7 +5,9 @@
 #include "RickshawPlatformBdw.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
+}
 extern struct Arg data_ov043_02112518;
 
 int RickshawPlatformBdw::InitResources()

--- a/src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp
+++ b/src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp
@@ -5,7 +5,9 @@
 #include "RickshawPlatformBdw.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
+}
 extern struct Arg data_ov043_02112518;
 
 int RickshawPlatformBdw::CleanupResources()

--- a/src/_ZN19RotatingPlatformLll13InitResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformLll13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformLll.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
@@ -13,8 +14,11 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int func_020393d4(void*, void*);
 extern int func_020393c4(void*, void*);
+}
 extern char data_ov022_02114558[];
+extern "C" {
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 int RotatingPlatformLll::InitResources()
 {

--- a/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void *bmd, void *bta);
@@ -13,6 +14,7 @@ extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *tt, void
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *sfp);
+}
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *mc, void *kcl, void *mtx, int fix, short s, void *clps);
 

--- a/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
@@ -6,9 +6,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int IsAreaShowing(int idx);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, void *pos, unsigned e);
 extern void _ZN9Animation7AdvanceEv(void *a);
+}
 extern s16 data_02082214[];
 extern int data_0209f32c;
 

--- a/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
@@ -9,6 +9,7 @@
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
+extern "C" {
 extern void func_020393c4(int* p, int v);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern int _Z14ApproachLinearRiii(int* r, int t, int step);
@@ -16,6 +17,7 @@ extern u16 DecIfAbove0_Short(u16* p);
 extern int RandomIntInternal(int* seed);
 extern void _ZN9Animation7AdvanceEv(void* a);
 extern void* _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int d);
+}
 
 extern u8 data_0209f2c0;
 extern int func_ov065_0211aacc;

--- a/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
@@ -5,7 +5,9 @@
 #include "ArmedRotatingPlatform.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
+}
 extern struct Arg data_ov036_02113e88;
 
 int ArmedRotatingPlatform::InitResources()

--- a/src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp
@@ -5,7 +5,9 @@
 #include "ArmedRotatingPlatform.h"
 struct Arg { void *m[3]; };
 
+extern "C" {
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
+}
 extern struct Arg data_ov036_02113e88;
 
 int ArmedRotatingPlatform::CleanupResources()

--- a/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
@@ -5,8 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ClockPaintingHandShort.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, int, int, int);
+}
 
 int ClockPaintingHandShort::InitResources()
 {

--- a/src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ClockPaintingHandShort.h"
+extern "C" {
 extern int IsAreaShowing(int);
+}
 extern signed char data_02092110[];
 extern unsigned char data_0209f2c0[];
 

--- a/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
@@ -8,6 +8,7 @@ enum Bool { FALSE, TRUE };
 
 struct RaycastGround { char buf[0x44]; int f44; char rest[8]; };
 
+extern "C" {
 extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, int a, int b, int c, int d);
 extern int _ZN11ShadowModel10InitCuboidEv(void *self);
 extern void Vec3_Add(Vector3 *out, Vector3 *a, Vector3 *b);
@@ -25,6 +26,7 @@ extern void _ZN13RaycastGroundC1Ev(struct RaycastGround *self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const Vector3 *v, void *a);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround *self);
 extern void _ZN13RaycastGroundD1Ev(struct RaycastGround *self);
+}
 
 extern signed char data_0209f2f8;
 extern struct Matrix4x3 data_020a0e68;

--- a/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
@@ -9,6 +9,7 @@
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct RaycastGround { char pad[0x54]; } RaycastGround;
 
+extern "C" {
 extern void *_ZN5Actor15FindWithActorIDEjPS_(u32 id, void *p);
 extern int Vec3_HorzDist(const Vec3 *a, const Vec3 *b);
 extern int _ZN5Actor13DistToCPlayerEv(void *thiz);
@@ -30,6 +31,7 @@ extern void func_02039394(int *p, int v);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *thiz, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *thiz);
 extern void _ZN13RaycastGroundD1Ev(RaycastGround *rc);
+}
 
 extern char data_020a0e68[];
 

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
@@ -3,11 +3,13 @@
 // @symbol _ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnWaterPlatformWdwSquare.h"
+extern "C" {
 extern void func_02012694(int a, void* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);
 extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
+}
 
 int FloatOnWaterPlatformWdwSquare::Behavior()
 {

--- a/src/_ZN3Key13InitResourcesEv.cpp
+++ b/src/_ZN3Key13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Key.h"
+extern "C" {
 extern void LoadKeyModels(int idx);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
@@ -14,6 +15,7 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thi
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* pos);
 extern int _ZN11ShadowModel12InitCylinderEv(void* thiz);
 extern void _ZN5Event8ClearBitEj(unsigned int n);
+}
 
 extern char data_ov002_02110964;
 extern char data_ov002_0211094c;

--- a/src/_ZN3Key16CleanupResourcesEv.cpp
+++ b/src/_ZN3Key16CleanupResourcesEv.cpp
@@ -5,7 +5,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Key.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern void _ZN5Event8ClearBitEj(unsigned int b);
+}
 extern int data_ov002_02110964[];
 extern int data_ov089_02132c60[];
 extern int data_ov089_02132c40[];

--- a/src/_ZN4Fish13InitResourcesEv.cpp
+++ b/src/_ZN4Fish13InitResourcesEv.cpp
@@ -3,10 +3,12 @@
 // @symbol _ZN4Fish13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Fish.h"
+extern "C" {
 extern int _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
+}
 extern int data_ov100_021489cc[];
 extern int* data_ov100_021473a4[];
 extern int* data_ov100_021473b0[];

--- a/src/_ZN4Fish16CleanupResourcesEv.cpp
+++ b/src/_ZN4Fish16CleanupResourcesEv.cpp
@@ -5,8 +5,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Fish.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+}
 
 extern struct SharedFilePtr data_ov100_021489cc;
 extern struct SharedFilePtr *data_ov100_021473a4[];

--- a/src/_ZN4Flag13InitResourcesEv.cpp
+++ b/src/_ZN4Flag13InitResourcesEv.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Flag.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
+}
 
 int Flag::InitResources()
 {

--- a/src/_ZN4Trap13InitResourcesEv.cpp
+++ b/src/_ZN4Trap13InitResourcesEv.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Trap.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern unsigned char NumStars(void);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, int, int, int);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void*, void*, void*, int, int, unsigned int, unsigned int);
+}
 extern int data_0209caa0[];
 
 int Trap::InitResources()

--- a/src/_ZN5Bully13InitResourcesEv.cpp
+++ b/src/_ZN5Bully13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Bully.h"
+extern "C" {
 extern void func_ov064_02116ec0(char* c);
+}
 
 void Bully::InitResources()
 {

--- a/src/_ZN5Crate13InitResourcesEv.cpp
+++ b/src/_ZN5Crate13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Crate.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(char* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* thiz, int f, int a, int b);
 extern void _ZN11ShadowModel10InitCuboidEv(char* thiz);
@@ -12,6 +13,7 @@ extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10C
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* thiz, char* actor, int b, int d, void* v, int f);
 extern void _ZN12WithMeshClsn19StartDetectingWaterEv(char* thiz);
 extern void Crate_SetState(char* c, int i);
+}
 extern char data_ov098_0213c4c8[];
 
 int Crate::InitResources()

--- a/src/_ZN5Crate8BehaviorEv.cpp
+++ b/src/_ZN5Crate8BehaviorEv.cpp
@@ -10,6 +10,7 @@
 enum Bool { FALSE, TRUE };
 
 extern u32 data_0209b454;
+extern "C" {
 extern void _ZN6Player9DropActorEv(void* self);
 extern int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
 extern int _ZN5Actor13DistToCPlayerEv(void* self);
@@ -17,6 +18,7 @@ extern void Crate_SetState(char* c, int i);
 extern u8 DecIfAbove0_Byte(u8* p);
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 a, u32 b, int c, int d, int e, const void* v, void* cb);
 extern void* _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(u32 a, u32 b, int c, int d, int e, const void* v);
+}
 
 int Crate::Behavior()
 {

--- a/src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp
+++ b/src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp
@@ -6,10 +6,12 @@ typedef signed short s16;
 struct Vector3 { s32 x, y, z; };
 struct Actor { char pad[0x100]; };
 
+extern "C" {
 extern void Vec3_Sub(Vector3 *out, const Vector3 *a, const Vector3 *b);
 extern s32 Vec3_HorzLen(const Vector3 *v);
 extern s16 _ZN4cstd5atan2E5Fix12IiES1_(s32 y, s32 x);
 extern s32 *Vec3_AsrInPlace(s32 *v, s32 sh);
+}
 extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int uniqueID, unsigned int effectID,
     s32 x, s32 y, s32 z,

--- a/src/_ZN5Koopa13InitResourcesEv.cpp
+++ b/src/_ZN5Koopa13InitResourcesEv.cpp
@@ -13,6 +13,7 @@ extern SharedFilePtr* data_ov062_0211cee8[9];
 extern SharedFilePtr* data_ov062_0211ced8[2];
 extern SharedFilePtr* data_ov062_0211cee0[2];
 
+extern "C" {
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
@@ -21,6 +22,7 @@ extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Fix12 q);
 extern void _ZN12WithMeshClsn19StartDetectingWaterEv(void* self);
 extern void LoadBlueCoinModel(void* c);
+}
 
 int Koopa::InitResources()
 {

--- a/src/_ZN5Koopa16CleanupResourcesEv.cpp
+++ b/src/_ZN5Koopa16CleanupResourcesEv.cpp
@@ -6,8 +6,10 @@ struct SharedFilePtr
 {
   unsigned int data[4];
 };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *);
 extern void UnloadBlueCoinModel(void *c);
+}
 extern struct SharedFilePtr *data_ov062_0211cee0[];
 extern struct SharedFilePtr *data_ov062_0211ced8[];
 extern struct SharedFilePtr *data_ov062_0211cee8[];

--- a/src/_ZN5Koopa8BehaviorEv.cpp
+++ b/src/_ZN5Koopa8BehaviorEv.cpp
@@ -6,6 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Koopa.h"
+extern "C" {
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void *self, void *wm, void *ma, unsigned int j);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *self, void *c);
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void *self, void *c);
@@ -20,6 +21,7 @@ extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
 extern int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *self, void *wm, int a, s16 b, int c, int d, int e);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *self, void *wm, unsigned int j);
 extern void _ZN5Enemy11UpdateDeathER12WithMeshClsn(void *self, void *wm);
+}
 
 int Koopa::Behavior()
 {

--- a/src/_ZN5Pokey8BehaviorEv.cpp
+++ b/src/_ZN5Pokey8BehaviorEv.cpp
@@ -4,8 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Pokey.h"
+extern "C" {
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void *c, int d);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *c, void *cyl);
+}
 
 int Pokey::Behavior()
 {

--- a/src/_ZN5Stage23LoadTextureTransformersEv.cpp
+++ b/src/_ZN5Stage23LoadTextureTransformersEv.cpp
@@ -6,10 +6,12 @@
 struct Entry { int x; void* bta; char pad[4]; };
 struct Info { char a[0x10]; struct Entry* entries; unsigned char count; };
 extern struct Info* data_0209f340;
+extern "C" {
 extern void* _Znwj(u32);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void* bmd, void* bta);
 extern void* _ZN18TextureTransformerC1Ev(void*);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void* self, void* bta, int a, int b, u32 c);
+}
 
 void Stage::LoadTextureTransformers()
 {

--- a/src/_ZN5Stage7LoadFogEv.cpp
+++ b/src/_ZN5Stage7LoadFogEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
+extern "C" {
 extern void _ZN3Fog4InitEt5Fix12IiES1_(char *self, unsigned short color, int nearv, int farv);
+}
 
 void Stage::LoadFog()
 {

--- a/src/_ZN5Stump13InitResourcesEv.cpp
+++ b/src/_ZN5Stump13InitResourcesEv.cpp
@@ -4,11 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Stump.h"
+extern "C" {
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *thiz, void *actor, int fix, int t, unsigned int a, unsigned int b);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *thiz, void *actor, int fix, int t, void *v, int t2);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *f, int a, int b);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *f);
+}
 
 extern char data_ov002_0210da40[];
 extern char data_ov002_0210d9a0[];

--- a/src/_ZN5Stump16CleanupResourcesEv.cpp
+++ b/src/_ZN5Stump16CleanupResourcesEv.cpp
@@ -3,7 +3,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Stump.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
+}
 extern struct SharedFilePtr data_ov002_0210da40;
 extern struct SharedFilePtr data_ov002_0210d9a0;
 extern struct SharedFilePtr data_ov002_0210d9c0;

--- a/src/_ZN5Swoop13InitResourcesEv.cpp
+++ b/src/_ZN5Swoop13InitResourcesEv.cpp
@@ -13,6 +13,7 @@ extern SharedFilePtr data_ov065_0211d6a8;
 extern SharedFilePtr data_ov065_0211d690;
 extern SharedFilePtr data_ov065_0211d6a0;
 extern PMF data_ov065_0211d700;
+extern "C" {
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
@@ -20,6 +21,7 @@ extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern int func_ov065_02117944(void* c, PMF* p);
+}
 
 int Swoop::InitResources()
 {

--- a/src/_ZN5Whomp16CleanupResourcesEv.cpp
+++ b/src/_ZN5Whomp16CleanupResourcesEv.cpp
@@ -6,9 +6,11 @@
 #include "Whomp.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void data_ov079_02128168(void);
 extern void data_ov079_02128178(void);
 extern void data_ov079_02128170(void);
+}
 extern void *data_ov079_021275ec[];
 
 int Whomp::CleanupResources()


### PR DESCRIPTION
A C++ TU that declares a ROM symbol without C linkage gets it mangled a second time, so the reference resolves to nothing:

```cpp
void Vec3_Sub(Vec3*, Vec3*, Vec3*);   //  -->  UND:_Z8Vec3_SubP4Vec3S0_S0_
```

The file still byte-matches, because `match.py` compares the relocated word as a wildcard and never sees which symbol a call resolves to. Only the ROM link does — and `eligible.py` refuses to enroll a file with unresolvable references, so the link never sees it either. **The two gates cover for each other.**

### How the files were chosen

Generated by `tools/extern_c_wrap.py` (rebuilt in #1051), which decides from the symbol table rather than a pattern: each unresolved symbol is decoded back through its length prefix, and a declaration is wrapped only when the decoded name is a symbol the ROM actually defines. Data is never touched — mwccarm doesn't mangle data references.

**98 files, every one byte-verified after the edit, 0 reverted.**

| | |
|---|---|
| enrolled | 9,606 → **9,696** (+90) |
| code bytes built | 68.91% → **75.24%** |
| reproducing | 9,696 / 9,696 |
| module fidelity | 106/106 exact, 100.000000% of compared bytes |
| ROM-build analysis | **PASS** |
| attribution | 0 changed, 0 lost |

98 wrapped but +90 enrolled: the rest clear their mangled references and then fail eligibility for an unrelated reason, which the report now shows per file.

Independent of batch 02 — both are cut from main, so either can land first. Together they enroll **9,810 (76.64%)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi