### PR TITLE
Give mangled ROM declarations C linkage, and fix two wrong callees it exposed (batch 02 of 2)

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -68,6 +68,7 @@ src/func_02005ed8.c:
     .text start:0x02005ed8 end:0x02005f0c
 
 src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp:
+    complete
     .text start:0x02005f0c end:0x02005fa0
 
 src/_ZN8CapEnemy11GetCapStateEv.cpp:
@@ -688,6 +689,7 @@ src/_ZN6Camera8BehaviorEv.cpp:
     .text start:0x0200debc end:0x0200e338
 
 src/_ZN6Camera13InitResourcesEv.cpp:
+    complete
     .text start:0x0200e338 end:0x0200e444
 
 src/_ZN6CameraC1Ev.c:
@@ -2408,6 +2410,7 @@ src/engine/fader/_ZN9FaderWipe14LoadAndSetFileEt.cpp:
     .text start:0x020172c0 end:0x020172d8
 
 src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp:
+    complete
     .text start:0x020172d8 end:0x02017418
 
 src/engine/fader/_ZN9FaderWipeD0Ev.c:
@@ -3147,6 +3150,7 @@ src/_ZN7Message12UpdateWindowEv.cpp:
     .text start:0x0201bbc8 end:0x0201c0b8
 
 src/_ZN7Message6UpdateEv.cpp:
+    complete
     .text start:0x0201c0b8 end:0x0201cb2c
 
 src/engine/message/func_0201cb2c.c:
@@ -3257,6 +3261,7 @@ src/func_0201f108.c:
     .text start:0x0201f108 end:0x0201f138
 
 src/func_0201f138.cpp:
+    complete
     .text start:0x0201f138 end:0x0201f32c
 
 src/func_0201f32c.c:
@@ -3551,6 +3556,7 @@ src/_ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb.cpp:
     .text start:0x02022630 end:0x02022640
 
 src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp:
+    complete
     .text start:0x02022640 end:0x02022680
 
 src/_ZN8Particle14SimpleCallbackC2Ev.cpp:
@@ -9331,6 +9337,7 @@ src/func_0205816c.c:
     .text start:0x0205816c end:0x020581a8
 
 src/func_020581a8.cpp:
+    complete
     .text start:0x020581a8 end:0x02058200
 
 src/func_02058200.c:
@@ -10470,6 +10477,7 @@ src/func_02060228.c:
     .text start:0x02060228 end:0x020602bc
 
 src/func_020602bc.cpp:
+    complete
     .text start:0x020602bc end:0x02060310
 
 src/func_02060310.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -362,6 +362,7 @@ src/_ZN9CameraTag6RenderEv.c:
     .text start:0x020b0860 end:0x020b0868
 
 src/_ZN9CameraTag8BehaviorEv.cpp:
+    complete
     .text start:0x020b0868 end:0x020b0938
 
 src/_ZN9CameraTag13InitResourcesEv.cpp:
@@ -1272,9 +1273,11 @@ src/_ZN9PushBlock6RenderEv.cpp:
     .text start:0x020b9aac end:0x020b9b70
 
 src/_ZN9PushBlock8BehaviorEv.cpp:
+    complete
     .text start:0x020b9b70 end:0x020b9c00
 
 src/_ZN9PushBlock13InitResourcesEv.cpp:
+    complete
     .text start:0x020b9c00 end:0x020b9e04
 
 src/func_ov002_020b9e04.c:
@@ -1312,6 +1315,7 @@ src/func_ov002_020ba0bc.c:
     .text start:0x020ba0bc end:0x020ba0f8
 
 src/func_ov002_020ba0f8.cpp:
+    complete
     .text start:0x020ba0f8 end:0x020ba1ac
 
 src/func_ov002_020ba1ac.c:
@@ -1703,6 +1707,7 @@ src/func_ov002_020bdc18.c:
     .text start:0x020bdc18 end:0x020bdc58
 
 src/_ZN6Player16IncMegaKillCountEv.cpp:
+    complete
     .text start:0x020bdc58 end:0x020bdd2c
 
 src/func_ov002_020bdd2c.c:
@@ -1742,6 +1747,7 @@ src/_ZN6Player16SetRealCharacterEj.cpp:
     .text start:0x020be1e0 end:0x020be324
 
 src/_ZN6Player18TurnOffToonShadingEj.cpp:
+    complete
     .text start:0x020be324 end:0x020be3b0
 
 src/func_ov002_020be3b0.c:
@@ -2040,6 +2046,7 @@ src/func_ov002_020c3d1c.c:
     .text start:0x020c3d1c end:0x020c3d6c
 
 src/_ZN6Player17St_EndingFly_InitEv.cpp:
+    complete
     .text start:0x020c3d6c end:0x020c3dbc
 
 src/func_ov002_020c3dbc.c:
@@ -2047,6 +2054,7 @@ src/func_ov002_020c3dbc.c:
     .text start:0x020c3dbc end:0x020c3dd0
 
 src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp:
+    complete
     .text start:0x020c3dd0 end:0x020c3e8c
 
 src/func_ov002_020c3e8c.c:
@@ -2058,6 +2066,7 @@ src/func_ov002_020c3ea0.c:
     .text start:0x020c3ea0 end:0x020c3ed8
 
 src/_ZN6Player21St_OpeningWakeUp_InitEv.cpp:
+    complete
     .text start:0x020c3ed8 end:0x020c3f18
 
 src/func_ov002_020c3f18.c:
@@ -2100,6 +2109,7 @@ src/_ZN6Player12St_Talk_MainEv.cpp:
     .text start:0x020c48e0 end:0x020c4bd8
 
 src/_ZN6Player12St_Talk_InitEv.cpp:
+    complete
     .text start:0x020c4bd8 end:0x020c4c60
 
 src/_ZN6Player12ShowMessage2ER9ActorBasejPK7Vector3jj.cpp:
@@ -2147,9 +2157,11 @@ src/_ZN6Player21St_StuckInGround_InitEv.cpp:
     .text start:0x020c54e8 end:0x020c5560
 
 src/_ZN6Player24St_BowserEarthquake_MainEv.cpp:
+    complete
     .text start:0x020c5560 end:0x020c568c
 
 src/_ZN6Player24St_BowserEarthquake_InitEv.cpp:
+    complete
     .text start:0x020c568c end:0x020c56f0
 
 src/func_ov002_020c56f0.c:
@@ -2221,9 +2233,11 @@ src/func_ov002_020c6908.cpp:
     .text start:0x020c6908 end:0x020c69a0
 
 src/_ZN6Player14St_Squish_InitEv.cpp:
+    complete
     .text start:0x020c69a0 end:0x020c6a10
 
 src/_ZN6Player12Unk_020c6a10Ej.cpp:
+    complete
     .text start:0x020c6a10 end:0x020c6adc
 
 src/func_ov002_020c6adc.cpp:
@@ -2286,6 +2300,7 @@ src/func_ov002_020c7cbc.c:
     .text start:0x020c7cbc end:0x020c7dd0
 
 src/func_ov002_020c7dd0.cpp:
+    complete
     .text start:0x020c7dd0 end:0x020c7e84
 
 src/_ZN6Player15IsEnteringLevelEv.cpp:
@@ -2336,6 +2351,7 @@ src/func_ov002_020c8b54.c:
     .text start:0x020c8b54 end:0x020c8b78
 
 src/func_ov002_020c8b78.cpp:
+    complete
     .text start:0x020c8b78 end:0x020c8cb0
 
 src/func_ov002_020c8cb0.cpp:
@@ -2470,6 +2486,7 @@ src/Player_DisableInteraction.c:
     .text start:0x020c9e40 end:0x020c9e5c
 
 src/_ZN6Player12Unk_020c9e5cEh.cpp:
+    complete
     .text start:0x020c9e5c end:0x020ca0f4
 
 src/func_ov002_020ca0f4.c:
@@ -2485,9 +2502,11 @@ src/_ZN6Player11OpenBigDoorEv.cpp:
     .text start:0x020ca144 end:0x020ca150
 
 src/_ZN6Player12Unk_020ca150Eh.cpp:
+    complete
     .text start:0x020ca150 end:0x020ca1b8
 
 src/_ZN6Player17SetNoControlStateEhih.cpp:
+    complete
     .text start:0x020ca1b8 end:0x020ca270
 
 src/func_ov002_020ca270.cpp:
@@ -2503,6 +2522,7 @@ src/_ZN6Player13TryTalkToDoorEh.cpp:
     .text start:0x020ca344 end:0x020ca3d0
 
 src/_ZN6Player21IsOpeningDoorWithStarEv.cpp:
+    complete
     .text start:0x020ca3d0 end:0x020ca410
 
 src/_ZN6Player16TryTalkToKeyDoorEv.cpp:
@@ -2522,6 +2542,7 @@ src/_ZN6Player17PlayMammaMiaSoundEv.cpp:
     .text start:0x020ca708 end:0x020ca724
 
 src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp:
+    complete
     .text start:0x020ca724 end:0x020ca78c
 
 src/func_ov002_020ca78c.c:
@@ -2533,9 +2554,11 @@ src/_ZN6Player16St_DebugFly_MainEv.cpp:
     .text start:0x020ca7f4 end:0x020ca8d0
 
 src/_ZN6Player16St_DebugFly_InitEv.cpp:
+    complete
     .text start:0x020ca8d0 end:0x020ca8f8
 
 src/_ZN6Player12Unk_020ca8f8Ev.cpp:
+    complete
     .text start:0x020ca8f8 end:0x020ca940
 
 src/func_ov002_020ca940.c:
@@ -2590,6 +2613,7 @@ src/_ZN6Player17St_Headstand_MainEv.cpp:
     .text start:0x020cb15c end:0x020cb2f0
 
 src/_ZN6Player17St_Headstand_InitEv.cpp:
+    complete
     .text start:0x020cb2f0 end:0x020cb354
 
 src/func_ov002_020cb354.cpp:
@@ -2605,9 +2629,11 @@ src/func_ov002_020cb474.cpp:
     .text start:0x020cb474 end:0x020cb568
 
 src/_ZN6Player16St_Climb_CleanupEv.cpp:
+    complete
     .text start:0x020cb568 end:0x020cb5bc
 
 src/_ZN6Player13St_Climb_InitEv.cpp:
+    complete
     .text start:0x020cbd34 end:0x020cbea8
 
 src/func_ov002_020cbea8.c:
@@ -2623,6 +2649,7 @@ src/func_ov002_020cc05c.c:
     .text start:0x020cc05c end:0x020cc140
 
 src/_ZN6Player9IsOnShellEv.cpp:
+    complete
     .text start:0x020cc140 end:0x020cc16c
 
 src/func_ov002_020cc16c.c:
@@ -2850,6 +2877,7 @@ src/_ZN6Player17St_LedgeHang_MainEv.cpp:
     .text start:0x020d0a44 end:0x020d0c54
 
 src/_ZN6Player17St_LedgeHang_InitEv.cpp:
+    complete
     .text start:0x020d0c54 end:0x020d0d2c
 
 src/func_ov002_020d0d2c.cpp:
@@ -2857,6 +2885,7 @@ src/func_ov002_020d0d2c.cpp:
     .text start:0x020d0d2c end:0x020d0d78
 
 src/_ZN6Player17St_WallSlide_MainEv.cpp:
+    complete
     .text start:0x020d0d78 end:0x020d0e8c
 
 src/_ZN6Player17St_WallSlide_InitEv.cpp:
@@ -2908,6 +2937,7 @@ src/_ZN6Player17St_HoldLight_MainEv.cpp:
     .text start:0x020d1a1c end:0x020d1ea0
 
 src/_ZN6Player17St_HoldLight_InitEv.cpp:
+    complete
     .text start:0x020d1ea0 end:0x020d1f78
 
 src/func_ov002_020d1f78.c:
@@ -3265,9 +3295,11 @@ src/_ZN6Player6BounceE5Fix12IiE.cpp:
     .text start:0x020d932c end:0x020d93ac
 
 src/func_ov002_020d93ac.cpp:
+    complete
     .text start:0x020d93ac end:0x020d94cc
 
 src/func_ov002_020d94cc.cpp:
+    complete
     .text start:0x020d94cc end:0x020d9654
 
 src/_ZN6Player15St_Hurt_CleanupEv.cpp:
@@ -3295,6 +3327,7 @@ src/func_ov002_020d9aac.c:
     .text start:0x020d9aac end:0x020d9b68
 
 src/_ZN6Player12St_Hurt_InitEv.cpp:
+    complete
     .text start:0x020d9b68 end:0x020d9c44
 
 src/_ZN6Player12GetHurtStateEv.cpp:
@@ -3318,6 +3351,7 @@ src/_ZN6Player19St_SwingPlayer_InitEv.cpp:
     .text start:0x020da3b0 end:0x020da41c
 
 src/_ZN6Player25St_GrabBowserTail_CleanupEv.cpp:
+    complete
     .text start:0x020da41c end:0x020da438
 
 src/_ZN6Player22St_GrabBowserTail_MainEv.cpp:
@@ -3548,6 +3582,7 @@ src/_ZN6Player19St_GroundPound_MainEv.cpp:
     .text start:0x020dd9f8 end:0x020dddf0
 
 src/_ZN6Player19St_GroundPound_InitEv.cpp:
+    complete
     .text start:0x020dddf0 end:0x020dde74
 
 src/func_ov002_020dde74.cpp:
@@ -3594,6 +3629,7 @@ src/func_ov002_020de968.cpp:
     .text start:0x020de968 end:0x020dea00
 
 src/_ZN6Player16InitBalloonMarioEv.cpp:
+    complete
     .text start:0x020dea00 end:0x020deab8
 
 src/_ZN6Player17St_WindCarry_MainEv.cpp:
@@ -3729,6 +3765,7 @@ src/_ZN6Player22St_CrazedCrate_CleanupEv.cpp:
     .text start:0x020e0d28 end:0x020e0d48
 
 src/_ZN6Player19St_CrazedCrate_MainEv.cpp:
+    complete
     .text start:0x020e0d48 end:0x020e0f38
 
 src/func_ov002_020e0f38.cpp:
@@ -3787,18 +3824,23 @@ src/func_ov002_020e17f8.c:
     .text start:0x020e17f8 end:0x020e18a8
 
 src/_ZN6Player16St_BackFlip_InitEv.cpp:
+    complete
     .text start:0x020e18a8 end:0x020e1990
 
 src/_ZN6Player24St_SlideKickRecover_InitEv.cpp:
+    complete
     .text start:0x020e1990 end:0x020e1a10
 
 src/_ZN6Player16St_SideFlip_InitEv.cpp:
+    complete
     .text start:0x020e1a10 end:0x020e1af8
 
 src/_ZN6Player12St_Fall_MainEv.cpp:
+    complete
     .text start:0x020e1af8 end:0x020e1b80
 
 src/_ZN6Player12St_Fall_InitEv.cpp:
+    complete
     .text start:0x020e1b80 end:0x020e1c20
 
 src/func_ov002_020e1c20.c:
@@ -4159,6 +4201,7 @@ src/func_ov002_020e8c34.c:
     .text start:0x020e8c34 end:0x020e8ca0
 
 src/_ZN9PowerStar13AddStarMarkerEv.cpp:
+    complete
     .text start:0x020e8ca0 end:0x020e8dd8
 
 src/func_ov002_020e8dd8.c:
@@ -4486,6 +4529,7 @@ src/func_ov002_020eddc4.c:
     .text start:0x020eddc4 end:0x020edf54
 
 src/_ZN8YoshiEgg16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020edf54 end:0x020edf98
 
 src/_ZN8YoshiEgg6RenderEv.cpp:
@@ -4524,6 +4568,7 @@ src/func_ov002_020ee5d0.c:
     .text start:0x020ee5d0 end:0x020ee674
 
 src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp:
+    complete
     .text start:0x020ee674 end:0x020ee7cc
 
 src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp:
@@ -4531,6 +4576,7 @@ src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp:
     .text start:0x020ee7cc end:0x020ee830
 
 src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp:
+    complete
     .text start:0x020ee830 end:0x020ee870
 
 src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp:
@@ -4622,6 +4668,7 @@ src/_ZN8PathLift12BaseBehaviorEv.cpp:
     .text start:0x020efaa0 end:0x020efaf0
 
 src/func_ov002_020efaf0.cpp:
+    complete
     .text start:0x020efaf0 end:0x020efbdc
 
 src/func_ov002_020efbdc.c:
@@ -5509,6 +5556,7 @@ src/_ZN8Fireball8BehaviorEv.cpp:
     .text start:0x020f8c94 end:0x020f9204
 
 src/_ZN8Fireball13InitResourcesEv.cpp:
+    complete
     .text start:0x020f9204 end:0x020f92e4
 
 src/func_ov002_020f92e4.c:

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -456,6 +456,7 @@ src/func_ov004_020b29a0.cpp:
     .text start:0x020b29a0 end:0x020b29c0
 
 src/func_ov004_020b29c0.cpp:
+    complete
     .text start:0x020b29c0 end:0x020b2a18
 
 src/func_ov004_020b2a18.cpp:
@@ -463,6 +464,7 @@ src/func_ov004_020b2a18.cpp:
     .text start:0x020b2a18 end:0x020b2a84
 
 src/func_ov004_020b2a84.cpp:
+    complete
     .text start:0x020b2a84 end:0x020b2adc
 
 src/func_ov004_020b2adc.c:
@@ -733,6 +735,7 @@ src/func_ov004_020b53f0.c:
     .text start:0x020b53f0 end:0x020b556c
 
 src/func_ov004_020b556c.cpp:
+    complete
     .text start:0x020b556c end:0x020b56c8
 
 src/func_ov004_020b56c8.c:
@@ -748,6 +751,7 @@ src/func_ov004_020b586c.cpp:
     .text start:0x020b586c end:0x020b58c4
 
 src/func_ov004_020b58c4.cpp:
+    complete
     .text start:0x020b58c4 end:0x020b5a54
 
 src/func_ov004_020b5a54.cpp:
@@ -755,9 +759,11 @@ src/func_ov004_020b5a54.cpp:
     .text start:0x020b5a54 end:0x020b5aac
 
 src/func_ov004_020b5aac.cpp:
+    complete
     .text start:0x020b5aac end:0x020b5c18
 
 src/func_ov004_020b5c18.cpp:
+    complete
     .text start:0x020b5c18 end:0x020b5d74
 
 src/func_ov004_020b5d74.c:
@@ -785,6 +791,7 @@ src/func_ov004_020b612c.c:
     .text start:0x020b612c end:0x020b6234
 
 src/func_ov004_020b6234.cpp:
+    complete
     .text start:0x020b6234 end:0x020b6324
 
 src/func_ov004_020b6324.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -828,6 +828,7 @@ src/func_ov006_020c9e7c.c:
     .text start:0x020c9e7c end:0x020c9efc
 
 src/func_ov006_020c9efc.cpp:
+    complete
     .text start:0x020c9efc end:0x020c9fe4
 
 src/func_ov006_020c9fe4.cpp:
@@ -1021,6 +1022,7 @@ src/func_ov006_020cc9b8.c:
     .text start:0x020cc9b8 end:0x020cc9fc
 
 src/func_ov006_020cc9fc.cpp:
+    complete
     .text start:0x020cc9fc end:0x020ccae0
 
 src/func_ov006_020ccae0.c:
@@ -2305,6 +2307,7 @@ src/func_ov006_020e1680.c:
     .text start:0x020e1680 end:0x020e17f8
 
 src/_ZN6Player16St_WallJump_InitEv.cpp:
+    complete
     .text start:0x020e17f8 end:0x020e1854
 
 src/func_ov006_020e1b54.c:
@@ -6740,6 +6743,7 @@ src/func_ov006_021245a8.c:
     .text start:0x021245a8 end:0x0212471c
 
 src/func_ov006_021248a8.cpp:
+    complete
     .text start:0x021248a8 end:0x02124908
 
 src/func_ov006_02124908.c:

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -774,6 +774,7 @@ src/func_ov007_020bbc08.c:
     .text start:0x020bbc08 end:0x020bbd24
 
 src/func_ov007_020bbd24.cpp:
+    complete
     .text start:0x020bbd24 end:0x020bbe60
 
 src/func_ov007_020bbe60.c:
@@ -865,6 +866,7 @@ src/func_ov007_020bcdb8.cpp:
     .text start:0x020bcdb8 end:0x020bce70
 
 src/func_ov007_020bce70.cpp:
+    complete
     .text start:0x020bce70 end:0x020bcf90
 
 src/func_ov007_020bcf90.c:
@@ -1064,6 +1066,7 @@ src/func_ov007_020c0078.c:
     .text start:0x020c0078 end:0x020c0128
 
 src/func_ov007_020c0128.cpp:
+    complete
     .text start:0x020c0128 end:0x020c020c
 
 src/func_ov007_020c020c.c:

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -99,6 +99,7 @@ src/_ZN8MetalNet6RenderEv.cpp:
     .text start:0x02111ea8 end:0x02111ed0
 
 src/_ZN8MetalNet8BehaviorEv.cpp:
+    complete
     .text start:0x02111ed0 end:0x02111f40
 
 src/_ZN8MetalNet13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -216,6 +216,7 @@ src/_ZN9TowerStep6RenderEv.cpp:
     .text start:0x02112a24 end:0x02112a4c
 
 src/_ZN9TowerStep8BehaviorEv.cpp:
+    complete
     .text start:0x02112a4c end:0x02112b04
 
 src/_ZN9TowerStep13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -103,9 +103,11 @@ src/_ZN6ShipUp6RenderEv.cpp:
     .text start:0x02112744 end:0x0211276c
 
 src/_ZN6ShipUp8BehaviorEv.cpp:
+    complete
     .text start:0x0211276c end:0x0211283c
 
 src/_ZN6ShipUp13InitResourcesEv.cpp:
+    complete
     .text start:0x0211283c end:0x021129a0
 
 src/ShipUp_Spawn.c:

--- a/config/arm9/overlays/ov017/delinks.txt
+++ b/config/arm9/overlays/ov017/delinks.txt
@@ -18,6 +18,7 @@ src/_ZN9ShipWater6RenderEv.cpp:
     .text start:0x02111290 end:0x021112c4
 
 src/_ZN9ShipWater8BehaviorEv.cpp:
+    complete
     .text start:0x021112c4 end:0x021113c0
 
 src/_ZN9ShipWater13InitResourcesEv.c:

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -179,6 +179,7 @@ src/_ZN8IceSheet8BehaviorEv.cpp:
     .text start:0x02112990 end:0x021129c0
 
 src/_ZN8IceSheet13InitResourcesEv.cpp:
+    complete
     .text start:0x021129c0 end:0x02112a44
 
 src/IceSheet_Spawn.c:

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -93,6 +93,7 @@ src/_ZN15BookShotSpawner8BehaviorEv.cpp:
     .text start:0x02112418 end:0x021124e4
 
 src/_ZN8BookShot13InitResourcesEv.cpp:
+    complete
     .text start:0x021124e4 end:0x02112768
 
 src/_ZN15BookShotSpawner13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -131,6 +131,7 @@ src/_ZN9Submarine8BehaviorEv.cpp:
     .text start:0x0211200c end:0x021120ec
 
 src/_ZN9Submarine13InitResourcesEv.cpp:
+    complete
     .text start:0x021120ec end:0x021121bc
 
 src/Whirlpool_Spawn.c:

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -77,6 +77,7 @@ src/_ZN9ArrowLift6RenderEv.cpp:
     .text start:0x0211192c end:0x02111954
 
 src/_ZN9ArrowLift8BehaviorEv.cpp:
+    complete
     .text start:0x02111954 end:0x02111a04
 
 src/_ZN9ArrowLift13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -140,6 +140,7 @@ src/_ZN9HugeCover6RenderEv.cpp:
     .text start:0x02112788 end:0x021127bc
 
 src/_ZN9HugeCover8BehaviorEv.cpp:
+    complete
     .text start:0x021127bc end:0x021127f0
 
 src/_ZN9HugeCover13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov034/delinks.txt
+++ b/config/arm9/overlays/ov034/delinks.txt
@@ -132,6 +132,7 @@ src/_ZN7Wiggler6RenderEv.cpp:
     .text start:0x02112af4 end:0x02112b5c
 
 src/_ZN7Wiggler13InitResourcesEv.cpp:
+    complete
     .text start:0x0211323c end:0x021136a4
 
 src/Wiggler_Spawn.c:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -96,6 +96,7 @@ src/_ZN8ShipWing6RenderEv.cpp:
     .text start:0x02111a30 end:0x02111a64
 
 src/_ZN8ShipWing8BehaviorEv.cpp:
+    complete
     .text start:0x02111a64 end:0x02111bb8
 
 src/_ZN8ShipWing13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -94,6 +94,7 @@ src/_ZN8PoleLift8BehaviorEv.cpp:
     .text start:0x021119c0 end:0x02111a30
 
 src/_ZN8PoleLift13InitResourcesEv.cpp:
+    complete
     .text start:0x02111a30 end:0x02111ad4
 
 src/ExtendingPlatform_Spawn.c:

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -347,6 +347,7 @@ src/func_ov060_021167ec.c:
     .text start:0x021167ec end:0x021168c4
 
 src/func_ov060_021168c4.cpp:
+    complete
     .text start:0x021168c4 end:0x021169b0
 
 src/func_ov060_021169b0.c:

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -381,6 +381,7 @@ src/_ZN9KoopaFlag6RenderEv.cpp:
     .text start:0x0211b030 end:0x0211b05c
 
 src/_ZN9KoopaFlag8BehaviorEv.cpp:
+    complete
     .text start:0x0211b05c end:0x0211b168
 
 src/_ZN9KoopaFlag13InitResourcesEv.cpp:
@@ -467,6 +468,7 @@ src/_ZN6Klepto8BehaviorEv.cpp:
     .text start:0x0211c94c end:0x0211cb4c
 
 src/_ZN6Klepto13InitResourcesEv.cpp:
+    complete
     .text start:0x0211cb4c end:0x0211ce78
 
 src/func_ov062_0211ce78.c:

--- a/config/arm9/overlays/ov063/delinks.txt
+++ b/config/arm9/overlays/ov063/delinks.txt
@@ -92,6 +92,7 @@ src/unnamed/ov063/func_ov063_02116e14.cpp:
     .text start:0x02116e14 end:0x02116f48
 
 src/unnamed/ov063/func_ov063_02116f48.cpp:
+    complete
     .text start:0x02116f48 end:0x02116fac
 
 src/unnamed/ov063/func_ov063_02116fac.c:
@@ -347,6 +348,7 @@ src/actors/Boo/_ZN3Boo13InitResourcesEv.c:
     .text start:0x0211b9bc end:0x0211c35c
 
 src/actors/BooCage/_ZN7BooCage13InitResourcesEv.cpp:
+    complete
     .text start:0x0211c35c end:0x0211c444
 
 src/actors/BigBooIcon/_ZN10BigBooIcon13InitResourcesEv.cpp:
@@ -532,6 +534,7 @@ src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp:
     .text start:0x0211deb8 end:0x0211dfac
 
 src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp:
+    complete
     .text start:0x0211dfac end:0x0211e128
 
 src/actors/MadPiano/MadPiano_Spawn.cpp:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -155,6 +155,7 @@ src/_ZN8BigBully6RenderEv.cpp:
     .text start:0x0211764c end:0x02117684
 
 src/_ZN8BigBully8BehaviorEv.cpp:
+    complete
     .text start:0x02117684 end:0x02117784
 
 src/_ZN8BigBully13InitResourcesEv.cpp:
@@ -202,6 +203,7 @@ src/func_ov064_02117d24.c:
     .text start:0x02117d24 end:0x02117e44
 
 src/func_ov064_02117e44.cpp:
+    complete
     .text start:0x02117e44 end:0x02117fb4
 
 src/func_ov064_02117fb4.cpp:
@@ -509,6 +511,7 @@ src/_ZN9WaterRing8BehaviorEv.cpp:
     .text start:0x02119ffc end:0x0211a090
 
 src/_ZN9WaterRing13InitResourcesEv.cpp:
+    complete
     .text start:0x0211a090 end:0x0211a1b0
 
 src/WaterRing_Spawn.c:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -76,6 +76,7 @@ src/_ZN6Snufit8BehaviorEv.cpp:
     .text start:0x02116b84 end:0x02116e10
 
 src/_ZN6Snufit13InitResourcesEv.cpp:
+    complete
     .text start:0x02116e10 end:0x02116f0c
 
 src/func_ov065_02116f0c.c:
@@ -228,6 +229,7 @@ src/func_ov065_02118cc4.c:
     .text start:0x02118cc4 end:0x02118d04
 
 src/_ZN6Dorrie16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02118d04 end:0x02118d80
 
 src/_ZN6Dorrie6RenderEv.cpp:
@@ -251,9 +253,11 @@ src/func_ov065_02119210.c:
     .text start:0x02119210 end:0x02119228
 
 src/_ZN6Dorrie13InitResourcesEv.cpp:
+    complete
     .text start:0x02119228 end:0x021194e8
 
 src/_ZN9DorrieCap13InitResourcesEv.cpp:
+    complete
     .text start:0x021194e8 end:0x0211956c
 
 src/func_ov065_0211956c.c:

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -89,6 +89,7 @@ src/_ZN6FlyGuy8BehaviorEv.cpp:
     .text start:0x02120210 end:0x021203b4
 
 src/_ZN6FlyGuy13InitResourcesEv.cpp:
+    complete
     .text start:0x021203b4 end:0x021204e4
 
 src/func_ov070_021204e4.c:

--- a/config/arm9/overlays/ov072/delinks.txt
+++ b/config/arm9/overlays/ov072/delinks.txt
@@ -295,6 +295,7 @@ src/func_ov072_02121758.c:
     .text start:0x02121758 end:0x021217ac
 
 src/func_ov072_021217ac.cpp:
+    complete
     .text start:0x021217ac end:0x02121890
 
 src/func_ov072_02121890.c:

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -248,6 +248,7 @@ src/_ZN8CccArena8BehaviorEv.cpp:
     .text start:0x021224f0 end:0x02122578
 
 src/_ZN8CccArena13InitResourcesEv.cpp:
+    complete
     .text start:0x02122578 end:0x02122730
 
 src/func_ov073_02122730.c:

--- a/config/arm9/overlays/ov074/delinks.txt
+++ b/config/arm9/overlays/ov074/delinks.txt
@@ -177,6 +177,7 @@ src/_ZN8Goomboss6RenderEv.cpp:
     .text start:0x02121b70 end:0x02121bf0
 
 src/_ZN8Goomboss8BehaviorEv.cpp:
+    complete
     .text start:0x02121bf0 end:0x02121e98
 
 src/_ZN8Goomboss13InitResourcesEv.c:

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -329,6 +329,7 @@ src/func_ov075_02118bf8.c:
     .text start:0x02118bf8 end:0x02118c80
 
 src/func_ov075_02118c80.cpp:
+    complete
     .text start:0x02118c80 end:0x02118cd0
 
 src/func_ov075_02118cd0.c:

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -137,6 +137,7 @@ src/func_ov078_02125734.c:
     .text start:0x02125734 end:0x02125790
 
 src/func_ov078_02125790.cpp:
+    complete
     .text start:0x02125790 end:0x021258e4
 
 src/func_ov078_021258e4.c:
@@ -156,6 +157,7 @@ src/func_ov078_021259ec.c:
     .text start:0x021259ec end:0x02125bc8
 
 src/func_ov078_02125bc8.cpp:
+    complete
     .text start:0x02125bc8 end:0x02125c24
 
 src/func_ov078_02125c24.c:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -89,6 +89,7 @@ src/_ZN13MontyMoleRock8BehaviorEv.cpp:
     .text start:0x0212459c end:0x0212478c
 
 src/_ZN9MontyMole13InitResourcesEv.cpp:
+    complete
     .text start:0x0212478c end:0x021248b4
 
 src/_ZN13MontyMoleRock13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -372,6 +372,7 @@ src/_ZN8Moneybag6RenderEv.cpp:
     .text start:0x021277e0 end:0x02127854
 
 src/_ZN8Moneybag8BehaviorEv.cpp:
+    complete
     .text start:0x02127854 end:0x021278a8
 
 src/_ZN8Moneybag13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -102,6 +102,7 @@ src/func_ov084_0212b344.cpp:
     .text start:0x0212b344 end:0x0212b510
 
 src/_ZN6Goomba16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0212b510 end:0x0212b5b8
 
 src/_ZN6Goomba16OnPendingDestroyEv.c:
@@ -113,6 +114,7 @@ src/_ZN6Goomba6RenderEv.cpp:
     .text start:0x0212b5bc end:0x0212b6ec
 
 src/_ZN6Goomba8BehaviorEv.cpp:
+    complete
     .text start:0x0212b6ec end:0x0212bc30
 
 src/_ZN6Goomba13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -266,6 +266,7 @@ src/_ZN6Rabbit8BehaviorEv.c:
     .text start:0x0212c230 end:0x0212c7fc
 
 src/_ZN6Rabbit13InitResourcesEv.cpp:
+    complete
     .text start:0x0212c7fc end:0x0212cc18
 
 src/func_ov085_0212cc18.c:
@@ -321,6 +322,7 @@ src/_ZN9RabbitKey16OnPendingDestroyEv.c:
     .text start:0x0212d398 end:0x0212d39c
 
 src/_ZN9RabbitKey6RenderEv.cpp:
+    complete
     .text start:0x0212d39c end:0x0212d3ec
 
 src/_ZN9RabbitKey8BehaviorEv.cpp:
@@ -480,6 +482,7 @@ src/_ZN8WallSign6RenderEv.cpp:
     .text start:0x0212ee7c end:0x0212eea4
 
 src/_ZN8WallSign13InitResourcesEv.cpp:
+    complete
     .text start:0x0212f1b0 end:0x0212f244
 
 src/WallSign_Spawn.c:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -174,6 +174,7 @@ src/_ZN6Thwomp8BehaviorEv.cpp:
     .text start:0x02132ab0 end:0x02132c84
 
 src/_ZN6Thwomp13InitResourcesEv.cpp:
+    complete
     .text start:0x02132c84 end:0x02132cb8
 
 src/Thwomp_Spawn.c:

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -39,6 +39,7 @@ src/_ZN9SeesawBob8BehaviorEv.cpp:
     .text start:0x02135a50 end:0x02135b74
 
 src/_ZN9SeesawBob13InitResourcesEv.cpp:
+    complete
     .text start:0x02135b74 end:0x02135cdc
 
 src/func_ov095_02135cdc.c:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -260,6 +260,7 @@ src/func_ov100_02144f84.c:
     .text start:0x02144f84 end:0x02144fcc
 
 src/func_ov100_02144fcc.cpp:
+    complete
     .text start:0x02144fcc end:0x02145014
 
 src/func_ov100_02145014.c:
@@ -306,6 +307,7 @@ src/func_ov100_021454c8.cpp:
     .text start:0x021454c8 end:0x02145550
 
 src/func_ov100_02145550.cpp:
+    complete
     .text start:0x02145550 end:0x021455a0
 
 src/func_ov100_021455a0.c:

--- a/src/_ZN6Camera13InitResourcesEv.cpp
+++ b/src/_ZN6Camera13InitResourcesEv.cpp
@@ -31,7 +31,9 @@ extern void func_0200d0ac(Camera *thiz, u8 id);
 }
 
 extern struct Camera_State data_0209b008[];
+extern "C" {
 extern int _ZN6Camera11ChangeStateEPNS_5StateE(Camera *thiz, Camera_State *s);
+}
 
 int Camera::InitResources()
 {

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Dorrie.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
@@ -18,8 +19,11 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* sel
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, void* a, void* pos, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int e, int f);
+}
 
+extern "C" {
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
 extern int data_ov065_0211d720;
 extern int data_ov002_0210d9c0;

--- a/src/_ZN6Dorrie16CleanupResourcesEv.cpp
+++ b/src/_ZN6Dorrie16CleanupResourcesEv.cpp
@@ -6,7 +6,9 @@
 #include "Dorrie.h"
 #include "MeshColliderBase.h"
 struct SharedFilePtr { unsigned int data[4]; };
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *);
+}
 extern struct SharedFilePtr data_ov002_0210d9c0;
 extern struct SharedFilePtr *data_ov065_0211c08c[];
 extern struct SharedFilePtr *data_ov065_0211c080[];

--- a/src/_ZN6FlyGuy13InitResourcesEv.cpp
+++ b/src/_ZN6FlyGuy13InitResourcesEv.cpp
@@ -16,6 +16,7 @@ extern SharedFilePtr data_ov070_02123528;
 extern SharedFilePtr data_ov070_02123508;
 extern SharedFilePtr data_ov070_02123500;
 extern PMF data_ov070_0212359c;
+extern "C" {
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
@@ -23,6 +24,7 @@ extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern int FlyGuy_ChangeState(void* c, PMF* p);
+}
 
 int FlyGuy::InitResources()
 {

--- a/src/_ZN6Goomba16CleanupResourcesEv.cpp
+++ b/src/_ZN6Goomba16CleanupResourcesEv.cpp
@@ -5,9 +5,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Goomba.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern void UnloadBlueCoinModel(void* p);
 extern void _ZN8CapEnemy14UnloadCapModelEv(char* c);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
+}
 extern char data_ov084_02130cf8[];
 extern void* data_ov084_02130278[];
 

--- a/src/_ZN6Goomba8BehaviorEv.cpp
+++ b/src/_ZN6Goomba8BehaviorEv.cpp
@@ -16,6 +16,7 @@ typedef s32 Fix12;
 
 extern s8 data_0209f2f8;
 
+extern "C" {
 extern void _ZN5Actor8PoofDustEv(char* c);
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(char* c, Fix12 f);
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(char* c, void* w, void* m, u32 j);
@@ -33,6 +34,7 @@ extern void _ZN12CylinderClsn5ClearEv(void* c);
 extern void _ZN12CylinderClsn6UpdateEv(void* c);
 extern int Vec3_Dist(const Vector3* a, const Vector3* b);
 extern void _ZN5Enemy9SpawnCoinEv(char* c);
+}
 
 int Goomba::Behavior()
 {

--- a/src/_ZN6Klepto13InitResourcesEv.cpp
+++ b/src/_ZN6Klepto13InitResourcesEv.cpp
@@ -8,6 +8,7 @@
 typedef int Fix12;
 typedef struct { int h; } SharedFilePtr;
 
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr *f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -21,6 +22,7 @@ extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsign
 extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, Fix12 a, Fix12 b, Fix12 c, Fix12 d);
 extern void func_ov062_0211c658(void *c, void *p);
 extern short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
+}
 
 extern SharedFilePtr data_ov062_0211e0fc;
 extern SharedFilePtr data_ov062_0211e114;

--- a/src/_ZN6Player12St_Fall_InitEv.cpp
+++ b/src/_ZN6Player12St_Fall_InitEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int _ZN6Player6IsAnimEj(void*, unsigned int);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
+}
 
 int Player::St_Fall_Init()
 {

--- a/src/_ZN6Player12St_Fall_MainEv.cpp
+++ b/src/_ZN6Player12St_Fall_MainEv.cpp
@@ -5,10 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int func_ov002_020e28d4(void*, int, int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
 extern int Player_AdvanceAnims(void*);
 extern Fix12i Player_ScaleByCharFactor(void* c, Fix12i a);
+}
 extern char data_ov002_02110424[];
 
 int Player::St_Fall_Main()

--- a/src/_ZN6Player12St_Hurt_InitEv.cpp
+++ b/src/_ZN6Player12St_Hurt_InitEv.cpp
@@ -5,9 +5,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* thiz, u32 anim, int a, int fix, u32 b);
 extern int _ZNK6Player14GetBodyModelIDEjb(char* thiz, u32 a, int b);
 extern void func_ov002_020d93ac(char* thiz);
+}
 extern char* data_0209f318;
 
 int Player::St_Hurt_Init()

--- a/src/_ZN6Player12St_Talk_InitEv.cpp
+++ b/src/_ZN6Player12St_Talk_InitEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN6Player12St_Talk_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int Player_DisableInteraction(void* c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_Talk_Init()
 {

--- a/src/_ZN6Player12Unk_020c6a10Ej.cpp
+++ b/src/_ZN6Player12Unk_020c6a10Ej.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, void* st);
 extern int func_ov002_020d91e0(void* thiz, u32 a, int b);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, void* st);
+}
 
 int Player::Unk_020c6a10(unsigned int arg_)
 {

--- a/src/_ZN6Player12Unk_020c9e5cEh.cpp
+++ b/src/_ZN6Player12Unk_020c9e5cEh.cpp
@@ -3,7 +3,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
+}
 extern struct State data_ov002_0211022c;
 
 int Player::Unk_020c9e5c(unsigned char h)

--- a/src/_ZN6Player12Unk_020ca150Eh.cpp
+++ b/src/_ZN6Player12Unk_020ca150Eh.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void *c, struct State *s);
+}
 extern struct State data_ov002_0211022c;
 extern struct State data_ov002_0211013c;
 

--- a/src/_ZN6Player12Unk_020ca8f8Ev.cpp
+++ b/src/_ZN6Player12Unk_020ca8f8Ev.cpp
@@ -3,7 +3,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
+}
 extern struct State data_ov002_0211064c;
 extern struct State data_ov002_02110664;
 

--- a/src/_ZN6Player13St_Climb_InitEv.cpp
+++ b/src/_ZN6Player13St_Climb_InitEv.cpp
@@ -5,10 +5,12 @@ struct Vector3 {
     int x, y, z;
 };
 
+extern "C" {
 extern int Player_ReleaseHeldActor(char*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, const Vector3&);
 extern int func_ov002_020e3078(void*, void*);
+}
 extern char data_ov002_021106f4[];
 
 class Player {

--- a/src/_ZN6Player14St_Squish_InitEv.cpp
+++ b/src/_ZN6Player14St_Squish_InitEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern void Player_ReleaseHeldActor(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
+}
 
 int Player::St_Squish_Init()
 {

--- a/src/_ZN6Player16IncMegaKillCountEv.cpp
+++ b/src/_ZN6Player16IncMegaKillCountEv.cpp
@@ -10,8 +10,10 @@ struct Vec3
   int y;
   int z;
 };
+extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void *v);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vec3 *pos, void *rot, int a, int b);
+}
 
 void Player::IncMegaKillCount()
 {

--- a/src/_ZN6Player16InitBalloonMarioEv.cpp
+++ b/src/_ZN6Player16InitBalloonMarioEv.cpp
@@ -4,12 +4,14 @@
 #include "Player.h"
 struct V3 { int x, y, z; };
 struct State;
+extern "C" {
 extern void func_ov002_020bda48(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, struct State* s);
 extern void func_ov002_020bd9ec(char* c, unsigned int a);
 extern void func_ov002_020c43c4(char* c, int a);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, void* pos);
+}
 
 extern struct State data_ov002_0211028c;
 

--- a/src/_ZN6Player16St_BackFlip_InitEv.cpp
+++ b/src/_ZN6Player16St_BackFlip_InitEv.cpp
@@ -3,12 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int func_ov002_020e2be4(void*);
 extern int func_ov002_020e2ba8(void*);
 extern int func_ov002_020e2b6c(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int func_ov002_020e2ad0(void*);
 extern int func_ov002_020e25f0(void*, int);
+}
 
 int Player::St_BackFlip_Init()
 {

--- a/src/_ZN6Player16St_Climb_CleanupEv.cpp
+++ b/src/_ZN6Player16St_Climb_CleanupEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int func_ov002_020caf68(void *c);
+}
 extern int data_ov002_021106f4[];
 
 int Player::St_Climb_Cleanup()

--- a/src/_ZN6Player16St_DebugFly_InitEv.cpp
+++ b/src/_ZN6Player16St_DebugFly_InitEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player16St_DebugFly_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void Player_DisableInteraction(void *);
+}
 
 int Player::St_DebugFly_Init()
 {

--- a/src/_ZN6Player16St_SideFlip_InitEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_InitEv.cpp
@@ -3,12 +3,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int func_ov002_020e2be4(void*);
 extern int func_ov002_020e2ba8(void*);
 extern int func_ov002_020e2b6c(void*);
 extern int func_ov002_020e2ad0(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int func_ov002_020e25f0(void*, int);
+}
 
 int Player::St_SideFlip_Init()
 {

--- a/src/_ZN6Player16St_WallJump_InitEv.cpp
+++ b/src/_ZN6Player16St_WallJump_InitEv.cpp
@@ -10,7 +10,9 @@
  * Detached from Player.h; see _ZN6Player23St_InYoshiMouth_CleanupEv.cpp.
  */
 #include "decl_common.h"
+extern "C" {
 extern int func_ov004_020afdd0(int a, int b, int c, int d, int e);
+}
 
 extern "C" void _ZN6Player16St_WallJump_InitEv(char *self)
 {

--- a/src/_ZN6Player17SetNoControlStateEhih.cpp
+++ b/src/_ZN6Player17SetNoControlStateEhih.cpp
@@ -4,8 +4,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State;
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, struct State* s);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, struct State* s);
+}
 
 extern struct State data_ov002_0211010c;
 extern struct State data_ov002_02110124;

--- a/src/_ZN6Player17St_EndingFly_InitEv.cpp
+++ b/src/_ZN6Player17St_EndingFly_InitEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN6Player17St_EndingFly_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int Player_DisableInteraction(void* c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_EndingFly_Init()
 {

--- a/src/_ZN6Player17St_Headstand_InitEv.cpp
+++ b/src/_ZN6Player17St_Headstand_InitEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct Camera;
+extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void *c, unsigned int a, int b, int f, unsigned int d);
 extern void func_0200d580(struct Camera *thiz, int playerID);
+}
 extern struct Camera *data_0209f318;
 
 int Player::St_Headstand_Init()

--- a/src/_ZN6Player17St_HoldLight_InitEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_InitEv.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN6Player17St_HoldLight_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int Player_ScaleByCharFactor(char* c, int a);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, unsigned int anim, int a, int fix, unsigned int z);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, void* v);
+}
 
 int Player::St_HoldLight_Init()
 {

--- a/src/_ZN6Player17St_LedgeHang_InitEv.cpp
+++ b/src/_ZN6Player17St_LedgeHang_InitEv.cpp
@@ -3,9 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct Vec3 { int x, y, z; };
+extern "C" {
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, unsigned int anim, int a, int fix, unsigned int z);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, void* v);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(char* o, struct Vec3* p);
+}
 
 int Player::St_LedgeHang_Init()
 {

--- a/src/_ZN6Player17St_WallSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_WallSlide_MainEv.cpp
@@ -5,11 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern void func_ov002_020c2f64(void *c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void *p, void *st);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(Fix12i x, Fix12i y, Fix12i z);
 extern int func_0201226c(int a0, int a1, int a2, int a3, int a4, short a5);
 extern void Player_AdvanceAnims(void *p);
+}
 extern unsigned char data_020a0e40;
 extern unsigned char data_0209f49e[];
 extern char data_ov002_0211013c;

--- a/src/_ZN6Player18TurnOffToonShadingEj.cpp
+++ b/src/_ZN6Player18TurnOffToonShadingEj.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN6Player18TurnOffToonShadingEj
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZNK6Player14GetBodyModelIDEjb(void*, unsigned int, int);
 extern int _ZN5Model14SetPolygonModeEi(void*, int);
 extern int func_ov002_020e6b74(void*, int);
+}
 
 void Player::TurnOffToonShading(unsigned int j)
 {

--- a/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
@@ -7,6 +7,7 @@ typedef long long s64;
 struct Vector3 { int x, y, z; };
 
 extern short data_02082214[];
+extern "C" {
 extern void func_ov002_020e28d4(void*, int, int);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int, int);
 extern int AngleDiff(int, int);
@@ -17,6 +18,7 @@ extern void func_ov002_020d718c(void*);
 extern void Player_ReleaseHeldActor(void*);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
+}
 extern char data_ov002_0211031c;
 
 class Player {

--- a/src/_ZN6Player19St_GroundPound_InitEv.cpp
+++ b/src/_ZN6Player19St_GroundPound_InitEv.cpp
@@ -3,9 +3,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int Player_ReleaseHeldActor(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, void*);
+}
 
 int Player::St_GroundPound_Init()
 {

--- a/src/_ZN6Player21IsOpeningDoorWithStarEv.cpp
+++ b/src/_ZN6Player21IsOpeningDoorWithStarEv.cpp
@@ -2,8 +2,10 @@
 // @symbol _ZN6Player21IsOpeningDoorWithStarEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player12Unk_020c9e5cEh(void *c, unsigned char a);
 extern int _ZN6Player12GetTalkStateEv(void *c);
+}
 
 int Player::IsOpeningDoorWithStar()
 {

--- a/src/_ZN6Player21St_OpeningWakeUp_InitEv.cpp
+++ b/src/_ZN6Player21St_OpeningWakeUp_InitEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player21St_OpeningWakeUp_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_OpeningWakeUp_Init()
 {

--- a/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
+++ b/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
@@ -3,9 +3,11 @@
 // @symbol _ZN6Player21St_OpeningWakeUp_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* thiz);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, int a, int b, int c, u32 d);
 extern void Player_AdvanceAnims(void* thiz);
+}
 
 int Player::St_OpeningWakeUp_Main()
 {

--- a/src/_ZN6Player24St_BowserEarthquake_InitEv.cpp
+++ b/src/_ZN6Player24St_BowserEarthquake_InitEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player24St_BowserEarthquake_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int f, unsigned int g);
+}
 
 int Player::St_BowserEarthquake_Init()
 {

--- a/src/_ZN6Player24St_BowserEarthquake_MainEv.cpp
+++ b/src/_ZN6Player24St_BowserEarthquake_MainEv.cpp
@@ -2,10 +2,12 @@
 // @symbol _ZN6Player24St_BowserEarthquake_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void _Z14ApproachLinearRiii(int* p, int value, int speed);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* state);
 extern void Player_AdvanceAnims(char* self);
+}
 extern short data_02082214[];
 extern char data_ov002_0211013c[];
 

--- a/src/_ZN6Player24St_SlideKickRecover_InitEv.cpp
+++ b/src/_ZN6Player24St_SlideKickRecover_InitEv.cpp
@@ -3,10 +3,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 typedef int Fix12i;
+extern "C" {
 extern int Player_ReleaseHeldActor(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int func_ov002_020e25f0(void*, int);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, void*);
+}
 
 int Player::St_SlideKickRecover_Init()
 {

--- a/src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp
+++ b/src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern int _ZN6Player17SetNoControlStateEhih(void *c, unsigned char a, int b, unsigned char d);
+}
 extern struct State data_ov002_0211022c;
 
 int Player::TryExitWhiteDoorWithStar()

--- a/src/_ZN6Player25St_GrabBowserTail_CleanupEv.cpp
+++ b/src/_ZN6Player25St_GrabBowserTail_CleanupEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN6Player25St_GrabBowserTail_CleanupEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
+extern "C" {
 extern void func_ov002_020daa74(void *);
+}
 
 int Player::St_GrabBowserTail_Cleanup()
 {

--- a/src/_ZN6Player9IsOnShellEv.cpp
+++ b/src/_ZN6Player9IsOnShellEv.cpp
@@ -3,7 +3,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 struct State { int a; int b; };
+extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
+}
 extern struct State data_ov002_02110304;
 
 int Player::IsOnShell()

--- a/src/_ZN6Rabbit13InitResourcesEv.cpp
+++ b/src/_ZN6Rabbit13InitResourcesEv.cpp
@@ -19,6 +19,7 @@ extern int data_0209caa0[];
 extern s8 data_0209f2f8;
 extern int data_0209e650;
 
+extern "C" {
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
@@ -33,6 +34,7 @@ extern void* _ZN5Actor13ClosestPlayerEv(void* c);
 extern u32 RandomIntInternal(int* seed);
 extern u8 NumStars(void);
 extern void func_ov085_0212bc78(void* c, void* p);
+}
 
 int Rabbit::InitResources()
 {

--- a/src/_ZN6ShipUp13InitResourcesEv.cpp
+++ b/src/_ZN6ShipUp13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
@@ -12,6 +13,7 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 extern void func_020393d4(int* p, int v);
 extern int IsStarCollected(int a, int b);
+}
 extern void* _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern unsigned char data_0209f220;
 

--- a/src/_ZN6ShipUp8BehaviorEv.cpp
+++ b/src/_ZN6ShipUp8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipUp.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern void func_020393a4(int* p, int v);
 extern int _ZN5Actor13DistToCPlayerEv(void* a);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int e);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void* a);
+}
 extern short data_02082214[];
 
 int ShipUp::Behavior()

--- a/src/_ZN6Snufit13InitResourcesEv.cpp
+++ b/src/_ZN6Snufit13InitResourcesEv.cpp
@@ -13,6 +13,7 @@ extern SharedFilePtr data_ov075_0211d610;
 extern SharedFilePtr data_ov065_0211d600;
 extern SharedFilePtr data_ov075_0211d608;
 extern PMF data_ov065_0211d670;
+extern "C" {
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
@@ -20,6 +21,7 @@ extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
 extern int func_ov065_0211691c(void* c, PMF* p);
+}
 
 int Snufit::InitResources()
 {

--- a/src/_ZN6Thwomp13InitResourcesEv.cpp
+++ b/src/_ZN6Thwomp13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Thwomp.h"
+extern "C" {
 extern int func_ov091_02133254(char*);
+}
 
 int Thwomp::InitResources()
 {

--- a/src/_ZN7Message6UpdateEv.cpp
+++ b/src/_ZN7Message6UpdateEv.cpp
@@ -43,6 +43,7 @@ extern u8 data_0209d6d0;
 extern u8 data_0209d6c8;
 extern u8 data_0209d6c4;
 
+extern "C" {
 extern void func_0201b6f8(int a);
 extern void* func_0201b7cc(void);
 extern void func_0201b388(int a);
@@ -50,6 +51,7 @@ extern void func_0201adfc(void);
 extern int IsButtonInputValid(void);
 extern void func_02012790(int a);
 extern void* _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int a, void* b, int c, int d, int e, int f, int g, int h, int i, int j);
+}
 
 class Message {
 public:

--- a/src/_ZN7Wiggler13InitResourcesEv.cpp
+++ b/src/_ZN7Wiggler13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Wiggler.h"
+extern "C" {
 extern int _ZN5Actor9TrackStarEjj(void *self, u32 a, u32 b);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *shared);
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void *shared);
@@ -19,6 +20,7 @@ extern void Vec3_Add(void *out, void *a, void *b);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, void *pos, int fix, u32 a, u32 b, u32 cc);
 extern void func_ov034_021125b8(void *c, int i);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *actor, int fix1, int fix2, void *v, int t);
+}
 
 extern s32 data_ov034_021138c4[];
 extern s32 data_020a0e68[];

--- a/src/_ZN8BigBully8BehaviorEv.cpp
+++ b/src/_ZN8BigBully8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBully.h"
+extern "C" {
 extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void* a, u16* p);
 extern int func_ov064_02116d1c(void* c);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void* c, void* clsn, unsigned f);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* c);
+}
 
 int BigBully::Behavior()
 {

--- a/src/_ZN8BookShot13InitResourcesEv.cpp
+++ b/src/_ZN8BookShot13InitResourcesEv.cpp
@@ -6,6 +6,7 @@
 struct Actor; struct Vector3; struct Vector3_16; struct BMD_File;
 typedef struct { int w[2]; } SharedFilePtr;
 
+extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* fp);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* fp);
 extern void LoadBlueCoinModel(void* c);
@@ -13,6 +14,7 @@ extern int _ZN11ShadowModel12InitCylinderEv(char* self);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(char* self, struct Actor* a, int r, int h, struct Vector3_16* rot, int f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, struct Actor* a, struct Vector3* pos, int r, int h, u32 f1, u32 f2);
+}
 
 extern SharedFilePtr data_ov020_02114aa0;
 extern SharedFilePtr data_ov020_02114ab8;

--- a/src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp
+++ b/src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp
@@ -5,7 +5,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "CapEnemy.h"
 extern unsigned char data_0209f2d8;
+extern "C" {
 extern unsigned char *_ZN5Actor13ClosestPlayerEv(unsigned char *t);
+}
 
 int CapEnemy::DestroyIfCapNotNeeded()
 {

--- a/src/_ZN8CccArena13InitResourcesEv.cpp
+++ b/src/_ZN8CccArena13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "CccArena.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(int);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
@@ -12,6 +13,7 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(int);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,short,int);
 extern void func_020393d4(void*,void*);
 extern void func_020393c4(void*,void*);
+}
 
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
 

--- a/src/_ZN8Fireball13InitResourcesEv.cpp
+++ b/src/_ZN8Fireball13InitResourcesEv.cpp
@@ -2,10 +2,12 @@
 // @symbol _ZN8Fireball13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Fireball.h"
+extern "C" {
 extern int _ZN11ShadowModel12InitCylinderEv(void* thiz);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* actor, int fix12, int t, unsigned int a, unsigned int b);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thiz, void* actor, int fix12, int t, void* vec, int last);
 extern void _ZN12WithMeshClsn19StartDetectingWaterEv(void* thiz);
+}
 
 int Fireball::InitResources()
 {

--- a/src/_ZN8Goomboss8BehaviorEv.cpp
+++ b/src/_ZN8Goomboss8BehaviorEv.cpp
@@ -6,6 +6,7 @@
 #include "Goomboss.h"
 typedef long long s64;
 
+extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *thiz, void *clsn);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *thiz, void *clsn, unsigned int a);
 extern void _ZN12CylinderClsn5ClearEv(void *c);
@@ -14,6 +15,7 @@ extern void _ZN5Actor17HugeLandingDustAtER7Vector3b(void *thiz, Vector3 *v, int 
 extern void _ZN5Actor13LandingDustAtER7Vector3b(void *thiz, Vector3 *v, int b);
 extern void func_02012694(int a, void *p);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *thiz, Vector3 *v, int f);
+}
 
 extern char *data_0209f318;
 

--- a/src/_ZN8IceSheet13InitResourcesEv.cpp
+++ b/src/_ZN8IceSheet13InitResourcesEv.cpp
@@ -5,12 +5,14 @@
 /* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
+}
 
 int IceSheet::InitResources()
 {

--- a/src/_ZN8MetalNet8BehaviorEv.cpp
+++ b/src/_ZN8MetalNet8BehaviorEv.cpp
@@ -5,9 +5,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "MetalNet.h"
 #include "MeshColliderBase.h"
+extern "C" {
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
+}
 extern unsigned char data_0209f2d8;
 
 int MetalNet::Behavior()

--- a/src/_ZN8Moneybag8BehaviorEv.cpp
+++ b/src/_ZN8Moneybag8BehaviorEv.cpp
@@ -4,9 +4,11 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Moneybag.h"
+extern "C" {
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(char* c, char* clsn);
 extern int _ZNK12WithMeshClsn14GetResultFlag1Ev(char* clsn);
 extern int _ZNK12WithMeshClsn12TouchesWaterEv(char* clsn);
+}
 
 int Moneybag::Behavior()
 {

--- a/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
+++ b/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
@@ -3,7 +3,9 @@
 struct SomeGlobal { char pad[4]; void* p; };
 extern SomeGlobal* data_0209ee74;
 
+extern "C" {
 extern void func_02049d60(void* x);
+}
 
 namespace Particle {
     struct System {

--- a/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
+++ b/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
@@ -8,11 +8,13 @@ struct Actor {
     void UpdatePos(CylinderClsn* c);
 };
 
+extern "C" {
 extern void Matrix4x3_FromRotationY(Matrix4x3* m, int angle);
 extern void MulVec3Mat4x3(Vector3* v, Matrix4x3* m, Vector3* dst);
 extern void Vec3_Add(Vector3* out, Vector3* a, Vector3* b);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void func_ov002_020ee5d0(unsigned char* self, int arg);
+}
 
 struct RaycastLine {
     RaycastLine();

--- a/src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp
+++ b/src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp
@@ -2,7 +2,9 @@
 // @symbol _ZN8Platform21UpdateModelPosAndRotYEv
 /* recovered: named members + shared header, real C++ method */
 #include "Platform.h"
+extern "C" {
 extern void Matrix4x3_FromRotationY(void *, int);
+}
 
 void Platform::UpdateModelPosAndRotY()
 {

--- a/src/_ZN8PoleLift13InitResourcesEv.cpp
+++ b/src/_ZN8PoleLift13InitResourcesEv.cpp
@@ -6,10 +6,12 @@
 #include "PoleLift.h"
 #include "MeshColliderBase.h"
 typedef int Fix12;
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
+}
 
 int PoleLift::InitResources()
 {

--- a/src/_ZN8ShipWing8BehaviorEv.cpp
+++ b/src/_ZN8ShipWing8BehaviorEv.cpp
@@ -3,6 +3,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWing.h"
 #include "MeshColliderBase.h"
+extern "C" {
 void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* clsn);
 void WithMeshClsn_UpdateContinuous_Veneer(void* p);
 int _ZNK12WithMeshClsn10IsOnGroundEv(void* p);
@@ -11,6 +12,7 @@ void _ZN5Actor14TriplePoofDustEv(void* p);
 void _ZN8Platform21UpdateModelPosAndRotYEv(void* p);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* p, int a, int b);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void* p);
+}
 
 int ShipWing::Behavior()
 {

--- a/src/_ZN8WallSign13InitResourcesEv.cpp
+++ b/src/_ZN8WallSign13InitResourcesEv.cpp
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "WallSign.h"
+extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, void* file, int a, int b);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(char* self);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, char* actor, const struct Vector3* pos, int a, unsigned int b, unsigned int c, unsigned int d);
+}
 
 int WallSign::InitResources()
 {

--- a/src/_ZN8YoshiEgg16CleanupResourcesEv.cpp
+++ b/src/_ZN8YoshiEgg16CleanupResourcesEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method */
 #include "YoshiEgg.h"
 #include "SharedFilePtr.h"
+extern "C" {
 extern int func_ov002_020ec628(void*);
 extern void UnloadBlueCoinModel(void*);
+}
 extern char data_ov002_0210e6b0;
 extern char data_ov002_0210eb78;
 

--- a/src/_ZN9ArrowLift8BehaviorEv.cpp
+++ b/src/_ZN9ArrowLift8BehaviorEv.cpp
@@ -5,9 +5,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ArrowLift.h"
 typedef short s16;
+extern "C" {
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN12CylinderClsn5ClearEv(void* self);
 extern void _ZN12CylinderClsn6UpdateEv(void* self);
+}
 
 int ArrowLift::Behavior()
 {

--- a/src/_ZN9CameraTag8BehaviorEv.cpp
+++ b/src/_ZN9CameraTag8BehaviorEv.cpp
@@ -7,8 +7,10 @@
 #include "CameraTag.h"
 struct Vec3 { Fix12i x, y, z; };
 
+extern "C" {
 extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
 extern void Vec3_RotateYAndTranslate(struct Vec3* out, void* m, s16 ang, struct Vec3* in);
+}
 extern u8 data_0209f250;
 extern char* data_0209f394[];
 extern char data_020a0ebc;

--- a/src/_ZN9DorrieCap13InitResourcesEv.cpp
+++ b/src/_ZN9DorrieCap13InitResourcesEv.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN9DorrieCap13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "DorrieCap.h"
+extern "C" {
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void func_ov001_020ab228(void *a, void *b, int c, int d, int e);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *clsn, void *actor, int a, int b, unsigned int c, unsigned int d);
+}
 struct G { int w[2]; };
 extern struct G data_ov002_0210d9c0;
 

--- a/src/_ZN9HugeCover8BehaviorEv.cpp
+++ b/src/_ZN9HugeCover8BehaviorEv.cpp
@@ -2,9 +2,11 @@
 // @symbol _ZN9HugeCover8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "HugeCover.h"
+extern "C" {
 extern void _ZN9Animation7AdvanceEv(void *);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
+}
 
 int HugeCover::Behavior()
 {

--- a/src/_ZN9KoopaFlag8BehaviorEv.cpp
+++ b/src/_ZN9KoopaFlag8BehaviorEv.cpp
@@ -5,11 +5,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "KoopaFlag.h"
+extern "C" {
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int d, int e);
 extern void _ZN9Animation7AdvanceEv(void *a);
 extern void _ZN12CylinderClsn5ClearEv(void *c);
 extern void _ZN12CylinderClsn6UpdateEv(void *c);
+}
 extern char data_0209d4c8[];
 
 int KoopaFlag::Behavior()

--- a/src/_ZN9MontyMole13InitResourcesEv.cpp
+++ b/src/_ZN9MontyMole13InitResourcesEv.cpp
@@ -13,11 +13,13 @@ extern SharedFilePtr* data_ov080_0212766c[];
 extern SharedFilePtr data_ov002_0210d9d8;
 extern SharedFilePtr data_ov080_021283c8;
 extern SharedFilePtr data_ov080_021283c0;
+extern "C" {
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, BCA_File* f, int a, Fix12 b, unsigned int e);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+}
 
 int MontyMole::InitResources()
 {

--- a/src/_ZN9PowerStar13AddStarMarkerEv.cpp
+++ b/src/_ZN9PowerStar13AddStarMarkerEv.cpp
@@ -5,8 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PowerStar.h"
+extern "C" {
 extern void SetStarMarker(int i, int v1, int v2);
 extern int IsStarCollectedInCurLevel(int starID);
+}
 extern int data_0209f40c[];
 extern u8 data_0209f208;
 

--- a/src/_ZN9PushBlock13InitResourcesEv.cpp
+++ b/src/_ZN9PushBlock13InitResourcesEv.cpp
@@ -7,6 +7,7 @@
 #include "PushBlock.h"
 typedef int Fix12;
 
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -18,6 +19,7 @@ extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, const
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
 extern void _ZN13RaycastGroundD1Ev(void *self);
+}
 
 extern void *data_ov002_0210d9d0[];
 extern void *data_ov002_0210d9b0[];

--- a/src/_ZN9PushBlock8BehaviorEv.cpp
+++ b/src/_ZN9PushBlock8BehaviorEv.cpp
@@ -5,10 +5,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PushBlock.h"
+extern "C" {
 extern void _ZN12CylinderClsn5ClearEv(char* t);
 extern void _ZN12CylinderClsn6UpdateEv(char* t);
 extern void _ZN5Actor13SmallPoofDustEv(char* c);
 extern void _ZN9ActorBase18MarkForDestructionEv(char* c);
+}
 
 int PushBlock::Behavior()
 {

--- a/src/_ZN9RabbitKey6RenderEv.cpp
+++ b/src/_ZN9RabbitKey6RenderEv.cpp
@@ -27,7 +27,9 @@ struct Obj {
     void* unk188;         /* 0x188 */
 };
 
+extern "C" {
 extern void func_ov085_0212d2b8(struct Obj* self);
+}
 
 int RabbitKey::Render()
 {

--- a/src/_ZN9SeesawBob13InitResourcesEv.cpp
+++ b/src/_ZN9SeesawBob13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SeesawBob.h"
+extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(int);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
@@ -11,6 +12,7 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(int);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,short,int);
 extern void func_020393d4(void*,void*);
 extern void func_020393c4(void*,void*);
+}
 
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
 

--- a/src/_ZN9ShipWater8BehaviorEv.cpp
+++ b/src/_ZN9ShipWater8BehaviorEv.cpp
@@ -2,11 +2,13 @@
 // @symbol _ZN9ShipWater8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "ShipWater.h"
+extern "C" {
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char* prev);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int e);
 extern int _ZN9Animation7AdvanceEv(char* t);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(char* t);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(char* t);
+}
 
 int ShipWater::Behavior()
 {

--- a/src/_ZN9Submarine13InitResourcesEv.cpp
+++ b/src/_ZN9Submarine13InitResourcesEv.cpp
@@ -9,12 +9,14 @@ struct BMD_File;
 struct BTA_File;
 struct BCA_File;
 
+extern "C" {
 extern struct BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thisp, struct BMD_File *, int, int);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(struct BMD_File &, struct BTA_File &);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *thisp, struct BTA_File &, int, int, unsigned int);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisp, struct BCA_File *, int, int, unsigned int);
+}
 
 struct FilePtr4 { int a; void *file; };
 extern struct FilePtr4 data_ov026_02113f0c;

--- a/src/_ZN9TowerStep8BehaviorEv.cpp
+++ b/src/_ZN9TowerStep8BehaviorEv.cpp
@@ -2,12 +2,14 @@
 // @symbol _ZN9TowerStep8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "TowerStep.h"
+extern "C" {
 extern int DecIfAbove0_Byte(void*);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned,unsigned,unsigned,void*,unsigned);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int func_020393a4(int*,int);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*,int,int);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
+}
 
 int TowerStep::Behavior()
 {

--- a/src/_ZN9WaterRing13InitResourcesEv.cpp
+++ b/src/_ZN9WaterRing13InitResourcesEv.cpp
@@ -10,11 +10,13 @@ struct BMD_File;
 struct BTA_File;
 
 
+extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(struct BMD_File* f, struct BTA_File* b);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(char* self, struct BTA_File* b, int a, int fix, u32 f);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, struct Actor* a, struct Vector3* v, int r, int h, u32 f1, u32 f2);
+}
 
 extern char data_ov002_0210da10[];
 extern int data_ov064_0211c3d0[3];

--- a/src/actors/BooCage/_ZN7BooCage13InitResourcesEv.cpp
+++ b/src/actors/BooCage/_ZN7BooCage13InitResourcesEv.cpp
@@ -5,11 +5,13 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BooCage.h"
 typedef int Fix12;
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *actor, Fix12 a, int b, unsigned int c, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *actor, Fix12 a, int b, void *v, int c);
+}
 extern void *data_ov063_0211edec;
 
 int BooCage::InitResources()

--- a/src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MadPiano.h"
+extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, void *, int, int);
 extern void _ZN11ShadowModel10InitCuboidEv(void *);
@@ -15,6 +16,7 @@ extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, void *, void *, int, short, void *);
 extern void func_ov063_0211d5f4(char *);
+}
 
 
 int MadPiano::InitResources()

--- a/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
+++ b/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
@@ -3,12 +3,14 @@
 // @symbol _ZN9FaderWipe11AdvanceFadeEv
 /* recovered: named members + shared header, real C++ method */
 #include "FaderWipe.h"
+extern "C" {
 void _ZN5Fader13AdvanceInterpEv(void* thiz);
 void _ZN3G2x18SetBlendBrightnessEPVtts(volatile u16* p, u16 a, int b);
 void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 void Matrix4x3_ApplyInPlaceToScale(void* m, Fix12i x, Fix12i y, Fix12i z);
 void Matrix4x3_ApplyInPlaceToRotationX(void* m, short ang);
 void _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(void* thiz, void* mtx, void* vec);
+}
 extern int data_020a0e68[];
 
 void FaderWipe::AdvanceFade()

--- a/src/func_0201f138.cpp
+++ b/src/func_0201f138.cpp
@@ -31,7 +31,9 @@ void MultiStore16(int a, int b, int n);
 void SetBg3Offset(int a, int b);
 }
 
+extern "C" {
 void _ZN7Message6UpdateEv(void);
+}
 
 extern "C" void func_0201f138(void)
 {

--- a/src/func_020581a8.cpp
+++ b/src/func_020581a8.cpp
@@ -8,10 +8,12 @@ struct Obj581 {
     char sub90[4];
 };
 extern "C" void _ZN3IRQ7DisableEv(void);
+extern "C" {
 extern void func_02058a44(struct Obj581 *o);
 extern void func_02058488(int target);
 extern void OS_WakeupThread(void *p);
 extern void func_02057f54(void);
+}
 extern struct Obj581 *data_020a612c;
 extern int data_020a6148[];
 

--- a/src/func_020602bc.cpp
+++ b/src/func_020602bc.cpp
@@ -5,8 +5,10 @@ extern char data_020a8180[];
 void OS_SleepThread(void *p);
 }
 
+extern "C" {
 u32 _ZN3IRQ7DisableEv(void);
 void _ZN3IRQ7RestoreEj(u32 state);
+}
 
 extern "C" void func_020602bc(void) {
     char *base = data_020a8180;

--- a/src/func_ov002_020ba0f8.cpp
+++ b/src/func_ov002_020ba0f8.cpp
@@ -7,8 +7,10 @@
 
 
 extern "C" void func_ov002_020ba01c(void* c, int a, int b, int d, int e);
+extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int n, struct Vector3* v);
 extern void _ZN5Event8ClearBitEj(unsigned int n);
+}
 extern "C" void func_ov002_020ba4d8(void* c, int i);
 
 extern "C" void func_ov002_020ba0f8(char* c) {

--- a/src/func_ov002_020c7dd0.cpp
+++ b/src/func_ov002_020c7dd0.cpp
@@ -9,8 +9,10 @@ struct Player {
     unsigned char state;
 };
 
+extern "C" {
 extern void _ZN6Player4HealEi(Player* p, int amt);
 extern void _ZN6Player11ChangeStateERNS_5StateE(Player* p, struct State* s);
+}
 
 extern "C" void func_ov002_020c7dd0(Player* p, int i) {
     unsigned char g;

--- a/src/func_ov002_020c8b78.cpp
+++ b/src/func_ov002_020c8b78.cpp
@@ -11,14 +11,20 @@ struct Player : ActorBase {
 };
 
 extern "C" void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int, int);
+extern "C" {
 extern int _ZNK6Player14GetBodyModelIDEjb(Player const *, unsigned int, bool);
 extern int _ZNK9Animation12WillHitFrameEi(Animation const *, int);
+}
 extern "C" void func_02012790(int);
+extern "C" {
 extern int _ZN6Player12FinishedAnimEv(Player *);
+}
 extern "C" void func_020731dc(void *a, void *b, void *node);
 extern "C" void func_020072c0(void);
+extern "C" {
 extern void Vec3_RotateYAndTranslate(Vector3 *, void *, int, void *);
 extern void _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(Player *, ActorBase &, unsigned int, Vector3 const *, unsigned int, unsigned int);
+}
 
 extern "C" int data_ov002_0210e154;
 extern "C" int data_ov002_0210f824[];

--- a/src/func_ov002_020d93ac.cpp
+++ b/src/func_ov002_020d93ac.cpp
@@ -11,9 +11,11 @@ short GetAngleToCamera(int i);
 extern u8 data_0209f2d8;
 
 struct Actor;
+extern "C" {
 extern bool _ZN6Player8HasNoCapEv(char *self);
 extern void _ZN6Player18SetNewHatCharacterEjjb(char *self, u32 a, u32 b, bool c);
 extern char *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const Vector3 &pos, const void *v, int e, int f);
+}
 
 extern "C" int func_ov002_020d93ac(char *self)
 {

--- a/src/func_ov002_020d94cc.cpp
+++ b/src/func_ov002_020d94cc.cpp
@@ -13,8 +13,10 @@ void func_ov002_020e7218(char *a, char *b, int gate);
 extern u8 data_0209f2d8;
 extern s8 data_0209f310;
 
+extern "C" {
 extern char *_ZN5Actor13SpawnSoundObjEj(char *self, u32 a);
 extern char *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const Vector3 &pos, const void *v, int e, int f);
+}
 
 extern "C" int func_ov002_020d94cc(char *self)
 {

--- a/src/func_ov002_020efaf0.cpp
+++ b/src/func_ov002_020efaf0.cpp
@@ -3,7 +3,9 @@ struct BMD_File;
 struct PathStuff { void* a; void* file; };  // data_0210d9f0: load [4]
 
 extern PathStuff data_ov002_0210d9f0;
+extern "C" {
 extern void func_ov002_020eff90(void);
+}
 
 extern "C" {
 void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* thiz, void* file, int b, int d);

--- a/src/func_ov004_020b29c0.cpp
+++ b/src/func_ov004_020b29c0.cpp
@@ -3,9 +3,14 @@ extern int data_ov004_020bc0c0[];
 extern int data_ov004_020beb68[];
 extern int _ZTV5Scene[];
 extern int data_0208e4b8[];
+extern "C" {
 extern void func_ov004_020b929c(void *);
-
-struct ActorBase { virtual ~ActorBase(); };
+/* The ROM calls the base-object destructor D2. The explicit destructor call
+   this replaces compiled to the complete-object destructor D1 instead --
+   0x02043dbc where the ROM branches to 0x02043d48. Same shape as the sibling
+   func_ov004_020b2a18. */
+extern void _ZN9ActorBaseD2Ev(void *);
+}
 
 extern "C" void *func_ov004_020b29c0(void *c) {
     *(int *)c = (int)data_ov004_020bc0c0;
@@ -13,6 +18,6 @@ extern "C" void *func_ov004_020b29c0(void *c) {
     func_ov004_020b929c((char *)c + 0xf4);
     *(int *)c = (int)_ZTV5Scene;
     *(int *)c = (int)data_0208e4b8;
-    ((ActorBase *)c)->ActorBase::~ActorBase();
+    _ZN9ActorBaseD2Ev(c);
     return c;
 }

--- a/src/func_ov004_020b2a84.cpp
+++ b/src/func_ov004_020b2a84.cpp
@@ -3,9 +3,14 @@ extern int data_ov004_020bc0c0[];
 extern int data_ov004_020beb68[];
 extern int _ZTV5Scene[];
 extern int data_0208e4b8[];
+extern "C" {
 extern void func_ov004_020b929c(void *);
-
-struct ActorBase { virtual ~ActorBase(); };
+/* The ROM calls the base-object destructor D2. The explicit destructor call
+   this replaces compiled to the complete-object destructor D1 instead --
+   0x02043dbc where the ROM branches to 0x02043d48. Same shape as the sibling
+   func_ov004_020b2a18. */
+extern void _ZN9ActorBaseD2Ev(void *);
+}
 
 extern "C" void *func_ov004_020b2a84(void *c) {
     *(int *)c = (int)data_ov004_020bc0c0;
@@ -13,6 +18,6 @@ extern "C" void *func_ov004_020b2a84(void *c) {
     func_ov004_020b929c((char *)c + 0xf4);
     *(int *)c = (int)_ZTV5Scene;
     *(int *)c = (int)data_0208e4b8;
-    ((ActorBase *)c)->ActorBase::~ActorBase();
+    _ZN9ActorBaseD2Ev(c);
     return c;
 }

--- a/src/func_ov004_020b556c.cpp
+++ b/src/func_ov004_020b556c.cpp
@@ -1,12 +1,16 @@
 //cpp
 extern int ApproachLinear(int&, int, int);
+extern "C" {
 extern int func_ov004_020b04c0(void);
 extern void func_ov004_020b4b84(char* c, int* in);
+}
 extern char data_ov004_020bfa34;
 extern int data_ov004_020bf9f8;
 extern int data_ov004_020bfa04;
 extern void* data_ov004_020bfa20;
+extern "C" {
 extern void func_ov004_020b53f0(void);
+}
 inline short load_s(short* p) { return *p; }
 struct EI { char* e; int i; };
 

--- a/src/func_ov004_020b58c4.cpp
+++ b/src/func_ov004_020b58c4.cpp
@@ -1,6 +1,8 @@
 //cpp
 extern int ApproachLinear(int&, int, int);
+extern "C" {
 extern void func_ov004_020b4e78(char* c);
+}
 namespace Sound { void PlayBank2_2D(unsigned int); }
 
 extern int data_ov004_020bf9fc;
@@ -13,7 +15,9 @@ extern Obj* data_ov004_020beb68;
 extern int data_ov004_020bfa0c;
 extern unsigned char data_ov004_020bfa56[];
 extern void (*data_ov004_020bfa20)();
+extern "C" {
 extern void func_ov004_020b586c();
+}
 
 extern "C" void func_ov004_020b58c4(void)
 {

--- a/src/func_ov004_020b5aac.cpp
+++ b/src/func_ov004_020b5aac.cpp
@@ -1,6 +1,8 @@
 //cpp
 extern int ApproachLinear(int&, int, int);
+extern "C" {
 extern void func_ov004_020b506c(char* c);
+}
 namespace Sound { void PlayBank2_2D(unsigned int); }
 
 extern int data_ov004_020bf9fc;
@@ -13,7 +15,9 @@ extern Obj* data_ov004_020beb68;
 extern int data_ov004_020bf9f4;
 extern unsigned char data_ov004_020bfa56[];
 extern void (*data_ov004_020bfa20)();
+extern "C" {
 extern void func_ov004_020b5a54();
+}
 
 extern "C" void func_ov004_020b5aac(void)
 {

--- a/src/func_ov004_020b5c18.cpp
+++ b/src/func_ov004_020b5c18.cpp
@@ -1,6 +1,8 @@
 //cpp
 extern int ApproachLinear(int&, int, int);
+extern "C" {
 extern void func_ov004_020b506c(char* c);
+}
 namespace Sound { void PlayBank2_2D(unsigned int); }
 
 extern int data_ov004_020bf9fc;
@@ -13,7 +15,9 @@ extern Obj* data_ov004_020beb68;
 extern int data_ov004_020bfa14;
 extern unsigned char data_ov004_020bfa56[];
 extern void (*data_ov004_020bfa20)();
+extern "C" {
 extern void func_ov004_020b5a54();
+}
 
 extern "C" void func_ov004_020b5c18(void)
 {

--- a/src/func_ov004_020b6234.cpp
+++ b/src/func_ov004_020b6234.cpp
@@ -11,7 +11,9 @@ extern int data_ov004_020bfa18;
 extern int data_ov004_020bfa10;
 extern int data_ov004_020bfa00;
 extern void *data_ov004_020bfa20;
+extern "C" {
 extern void func_ov004_020b5f6c();
+}
 
 extern "C" void func_ov004_020b6234(void) {
     int x;

--- a/src/func_ov006_020c9efc.cpp
+++ b/src/func_ov006_020c9efc.cpp
@@ -1,8 +1,12 @@
 //cpp
 typedef long long s64;
+extern "C" {
 extern void func_ov006_020c8c78(int a, int b);
+}
 extern int ApproachLinear(int &r, int b, int c);
+extern "C" {
 extern void func_ov006_020c9e7c(void* p);
+}
 namespace Sound { void PlayBank2_2D(unsigned int); }
 extern int data_ov006_02140598;
 extern int data_ov006_0213b0f0;

--- a/src/func_ov006_020cc9fc.cpp
+++ b/src/func_ov006_020cc9fc.cpp
@@ -1,5 +1,7 @@
 //cpp
+extern "C" {
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *anim, void *file, int a, int b, unsigned int u);
+}
 struct G2 { int w[2]; };
 extern int data_ov006_021405c8;
 extern struct G2 data_ov006_02140564;

--- a/src/func_ov006_021248a8.cpp
+++ b/src/func_ov006_021248a8.cpp
@@ -2,8 +2,10 @@
 extern "C" void _ZN5ModelC1Ev(void*);
 extern "C" void _ZN18TextureTransformerC1Ev(void*);
 extern "C" void func_020733a8(void*, int, int, void*, void*);
+extern "C" {
 extern void NullDestructor_0203d47c(void);
 extern void func_0203d738(void);
+}
 extern "C" void* func_ov006_021248a8(char* c){
   _ZN5ModelC1Ev(c + 0xa0);
   _ZN5ModelC1Ev(c + 0xf0);

--- a/src/func_ov007_020bbd24.cpp
+++ b/src/func_ov007_020bbd24.cpp
@@ -1,8 +1,10 @@
 //cpp
 namespace cstd { int div(int, int); }
 
+extern "C" {
 extern int func_ov007_020c5014(void *, int);
 extern void func_ov007_020bdbcc(int, int);
+}
 
 struct BA0 { int f0; char pad4[0x18 - 4]; int f18; char pad1c[0x34 - 0x18 - 4]; int f34; int f38; };
 struct B9C_inner { char pad[0x50]; int f50; };

--- a/src/func_ov007_020bce70.cpp
+++ b/src/func_ov007_020bce70.cpp
@@ -18,9 +18,13 @@ extern S* data_ov007_0210342c;
 extern char data_ov007_02102f28[];
 
 extern "C" void func_ov007_020c92d0(Sub* s);
+extern "C" {
 extern void func_ov007_020c940c(void* s);
+}
 namespace cstd { int div(int, int); }
+extern "C" {
 extern void func_ov007_020c93c4(void* a, char* b, char* c, short* d);
+}
 
 extern "C" void func_ov007_020bce70(short n, int m)
 {

--- a/src/func_ov007_020c0128.cpp
+++ b/src/func_ov007_020c0128.cpp
@@ -1,6 +1,8 @@
 //cpp
+extern "C" {
 extern int _ZN4cstd3divEii(int a, int b);
 extern long long _ZN4cstd4ldivEii(int a, int b);
+}
 extern "C" void Matrix4x3_LoadIdentity(void *m);
 extern "C" void func_02052ec8(void *p);
 

--- a/src/func_ov060_021168c4.cpp
+++ b/src/func_ov060_021168c4.cpp
@@ -16,7 +16,9 @@ struct Actor {
 };
 struct ActorBase { void MarkForDestruction(); };
 extern "C" int func_ov060_02116518(char* c, int a, int b, int d);
+extern "C" {
 extern Fix12i Vec3_HorzDist(const Vector3* a, const Vector3* b);
+}
 
 extern "C" void func_ov060_021168c4(char* c)
 {

--- a/src/func_ov064_02117e44.cpp
+++ b/src/func_ov064_02117e44.cpp
@@ -29,7 +29,9 @@ extern "C" void func_ov064_02117a14(char *self, Vector3 *a, Vector3 *b);
 extern SharedFilePtr data_ov064_0211c730;
 extern SharedFilePtr data_ov064_0211c728;
 extern CLPS_Block data_ov064_0211bb6c;
+extern "C" {
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
+}
 
 struct V3 { int x, y, z; };
 

--- a/src/func_ov072_021217ac.cpp
+++ b/src/func_ov072_021217ac.cpp
@@ -6,9 +6,11 @@
 class Actor;
 extern "C" int func_ov072_02121d50(Actor *a);
 extern "C" int func_0201267c(int id, void *p);
+extern "C" {
 extern bool _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(Actor *thiz, Vector3 &a, Vector3 &b, bool c);
 extern void _ZN9Animation7AdvanceEv(void *anim);
 extern void _ZN12CylinderClsn5ClearEv(void *clsn);
+}
 extern "C" int func_ov072_021217ac(Actor *thiz)
 {
     char *c = (char *)thiz;

--- a/src/func_ov075_02118c80.cpp
+++ b/src/func_ov075_02118c80.cpp
@@ -1,6 +1,8 @@
 //cpp
+extern "C" {
 extern void func_ov075_02114fa8(void*);
 extern void func_0203d918(void);
+}
 extern int *data_0209fc68;
 extern char data_0208a0e0[];
 extern "C" void func_ov075_02118c80(char *c) {

--- a/src/func_ov078_02125790.cpp
+++ b/src/func_ov078_02125790.cpp
@@ -7,6 +7,7 @@
 #include "common.h"
 
 
+extern "C" {
 extern int _ZN5Actor18HorzAngleToCPlayerEv(void* a);
 extern void ApproachAngle(short* p, int target, int step, int band, int max);
 extern void func_02012694(int a, void* b);
@@ -15,6 +16,7 @@ extern void Vec3_Lsl(Vector3* d, Vector3* s, int sh);
 extern int _ZN5Actor17HugeLandingDustAtER7Vector3b(void* a, Vector3* v, int b);
 extern int _ZN9Animation8FinishedEv(void* a);
 extern void KingBobOmb_SetState(char* c, void* p);
+}
 extern Matrix4x3 data_020a0e68;
 extern int data_ov078_0212703c;
 

--- a/src/func_ov078_02125bc8.cpp
+++ b/src/func_ov078_02125bc8.cpp
@@ -1,5 +1,7 @@
 //cpp
+extern "C" {
 extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void*, void*, int, int, int, unsigned short);
+}
 extern int data_ov078_02126f30[];
 
 extern "C" int func_ov078_02125bc8(char* c) {

--- a/src/func_ov100_02144fcc.cpp
+++ b/src/func_ov100_02144fcc.cpp
@@ -1,6 +1,8 @@
 //cpp
+extern "C" {
 extern int func_ov100_02145014(void);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int, unsigned int, unsigned int, int, int);
+}
 extern "C" int func_ov100_02144fcc(void) {
   int r = func_ov100_02145014();
   if (r == 0) return 0;

--- a/src/func_ov100_02145550.cpp
+++ b/src/func_ov100_02145550.cpp
@@ -9,7 +9,9 @@ struct CallbackNode {
     char pad[8];
     PMF callback;
 };
+extern "C" {
 extern int func_ov100_02145370(char *c);
+}
 extern "C" int func_ov100_02145550(char *c) {
     int res = func_ov100_02145370(c);
     CallbackNode *node = *(CallbackNode**)((char*)c + 0x140);

--- a/src/unnamed/ov063/func_ov063_02116f48.cpp
+++ b/src/unnamed/ov063/func_ov063_02116f48.cpp
@@ -1,5 +1,7 @@
 //cpp
+extern "C" {
 extern int data_ov066_0211ad00(char *c);
+}
 extern "C" int func_ov063_02116f48(char *c) {
     *(int*)(c+0x490) = 0;
     *(unsigned char*)(c+0x5c9) = 0xff;


### PR DESCRIPTION
Second and final batch of the sweep described in #1052: a C++ TU declaring a ROM symbol without C linkage mangles it again, the reference resolves to nothing, and `eligible.py` refuses to enroll the file — so the ROM link, the only gate that can see *which* symbol a call resolves to, never gets to look at it.

**114 files, every one byte-verified after the edit, 0 reverted.**

## Two wrong callees, caught by the link

Enrolling these files is what let the link see them, and it immediately found two that had never really matched:

```
0x020b29f8:  rom ebfe44d2 -> 0x02043d48    built ebfe44ef -> 0x02043dbc
0x020b2abc:  rom ebfe44a1 -> 0x02043d48    built ebfe44be -> 0x02043dbc
```

Both `func_ov004_020b29c0` and `func_ov004_020b2a84` wrote `((ActorBase *)c)->ActorBase::~ActorBase()`, which compiles to the **complete-object** destructor `_ZN9ActorBaseD1Ev` (`0x02043dbc`). The ROM branches to the **base-object** destructor `_ZN9ActorBaseD2Ev` (`0x02043d48`).

These are near-identical copies of `func_ov004_020b2a18`, which already calls `_ZN9ActorBaseD2Ev` directly — one of three siblings was fixed and two were left behind. They now match it.

The byte gate passed both happily before *and* after: a destructor call is a relocation, and `match.py` compares relocated words as wildcards.

| | |
|---|---|
| enrolled | 9,606 → **9,720** (+114) |
| code bytes built | 68.91% → **75.48%** |
| reproducing | 9,720 / 9,720 |
| module fidelity | 106/106 exact, 100.000000% of compared bytes |
| ROM-build analysis | **PASS** |
| attribution | 0 changed, 0 lost |

Independent of batch 01 — both are cut from main, so either can land first. Together they enroll **9,810 (76.64%)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi