### PR TITLE
layout: make src/ placement a policy instead of a migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ six straight PRs on the `_ZThn80_` thunks).
 
 | You have… | It goes in… |
 |---|---|
-| A **byte-exact match** | one function per file: `src/<symbol>.c` (or `.cpp` for C++ — **first line exactly** `//cpp`). The filename **is** the symbol, e.g. `func_0205c410.c`, `_ZN6Player19St_...Ev.cpp`. |
+| A **byte-exact match** | one function per file, and the filename **is** the symbol: `func_0205c410.c`, `_ZN6Player19St_...Ev.cpp` (`.cpp` for C++ — **first line exactly** `//cpp`). Ask `tools/srcpath.py` for the *directory* rather than assuming `src/` — see below. |
 | **How** it was matched (final) | `config/match_provenance.jsonl` via `tools/stamp_provenance.py` — **commit with the match**. |
 | **Every try** (including dead ends) | `config/match_attempts.jsonl` via `tools/log_attempt.py` — **commit with the PR**. |
 | A **close-but-not-matching** attempt (near-miss) | the near-miss DB: `nearmiss/db.jsonl` via `tools/nearmiss_db.py`. **Not `src/`.** |
@@ -51,6 +51,29 @@ six straight PRs on the `_ZThn80_` thunks).
 **Never commit a non-reproducing file to `src/`.** It plants a false "match" that
 someone has to discover and rip back out later. A near-miss is valuable — it is the
 highest-yield input to the refine tier — but its home is the DB, not `src/`.
+
+### Which directory under `src/`
+
+Most files are in `src/` itself, but that is a fact about the tree, not a rule. Parts of
+it are grouped (`src/engine/fader/`, `src/actors/Boo/`, `src/unnamed/ov063/`), and more
+will be. **Do not compose the path yourself** — ask:
+
+```
+python tools/srcpath.py <symbol>              # where it lives now, if it exists
+```
+
+and in code, `srcpath.new_path_for(symbol, ext)` for a new file, `srcpath.path_for(symbol)`
+for an existing one. Every tool that reads or writes `src/` already goes through it. A
+hand-built `src/<symbol>.c` is not wrong today, but it stops being right the moment that
+symbol's neighbours move, and the failure is silent: `enroll` writes each source's path
+into `config/**/delinks.txt`, so a file the tooling cannot find drops quietly back to ROM
+bytes instead of erroring.
+
+Placement follows migration rather than leading it. A new file goes into a subdirectory
+only when the files it belongs with are already there and agree on which one — a new
+`Boo` method joins the other seven, a new `func_ov063_*` joins `src/unnamed/ov063/`.
+Everything else stays in the root. Nothing relocates on its own; moving a group is a
+deliberate, separate, **rename-only** PR (see #970 and #975).
 
 **Banking a near-miss** (do this instead of committing it to `src/`): write your draft
 to a one-line-per-entry seeds file `{"name": "<symbol>", "c_source": "<the C>"}` and run

--- a/tools/crackloop.py
+++ b/tools/crackloop.py
@@ -193,13 +193,22 @@ def land(a):
                     # first via a matched sibling, so the driver kept wasting attempts faking a MATCH.
                     # A human can unpark (drop the nonmatching row) and fix the reloc by hand.
                     names = {r["name"] for r, _m, _a, _s in wrong}
-                    src_dir = pathlib.Path(__file__).resolve().parent.parent / "src"
+                    # Resolve through srcpath rather than composing src/<name>.<ext>: a file
+                    # banked into a subdirectory would survive a hand-built flat unlink while
+                    # its matched.jsonl row was dropped below, leaving a known-bogus match in
+                    # src/ with nothing left pointing at it. Invalidate first -- these files
+                    # were written moments ago, so a cached scan predates them.
+                    import srcpath as SP
+                    SP.invalidate()
+                    removed = 0
                     for nm in names:
-                        for ext in ("c", "cpp"):
-                            try:
-                                (src_dir / f"{nm}.{ext}").unlink()
-                            except FileNotFoundError:
-                                pass
+                        for p in SP.paths_for(nm):
+                            p.unlink(missing_ok=True)
+                            removed += 1
+                    SP.invalidate()
+                    if removed != len(names):
+                        print(f"    (unbanked {removed} file(s) for {len(names)} wrong-dest "
+                              f"symbol(s) -- check for strays before committing)")
                     try:
                         kept = [ln for ln in L.MATCHED.read_text(encoding="utf-8").splitlines()
                                 if ln.strip() and json.loads(ln).get("name") not in names]

--- a/tools/name_evidence.py
+++ b/tools/name_evidence.py
@@ -33,7 +33,11 @@ def callers(sym):
     """Files that reference sym, excluding its own definition file."""
     out = subprocess.run(["git", "grep", "-l", "-F", sym, "--", "src/"],
                          cwd=REPO, capture_output=True, text=True).stdout
-    return [l for l in out.splitlines() if l.strip() and not l.startswith(f"src/{sym}.")]
+    # Ask srcpath where the definition actually is rather than assuming src/<sym>.<ext>:
+    # once a symbol lives in a subdirectory the flat guess stops matching and the symbol
+    # is reported as a caller of itself.
+    own = {p.relative_to(REPO).as_posix() for p in SP.paths_for(sym)}
+    return [l for l in out.splitlines() if l.strip() and l not in own]
 
 
 def named_callees(text):

--- a/tools/srcpath.py
+++ b/tools/srcpath.py
@@ -30,14 +30,46 @@ the common path rather than the fallback. That is a Phase-3 decision, not this o
 
 Note `symbol_for` is deliberately `Path.stem`, matching what pr_linkcheck already does
 to derive the symbol it link-checks. Keep the two in step.
+
+PLACEMENT FOLLOWS MIGRATION, IT DOES NOT LEAD IT
+------------------------------------------------
+`new_path_for` used to answer `src/<symbol>.ext` unconditionally, which is why #970 and
+#975 did not stick: they moved 164 files into subdirectories, and every match landed
+afterwards went back to the root regardless. Measured over the 30 days to 2026-08-04,
+`src/` grew from 9,102 files to 11,242 and every one of the new ones was flat.
+
+So placement is a rule now, but a deliberately timid one. A new file goes nested only
+when the files it belongs with are ALREADY nested, and only when they agree on where:
+
+  * an address-named symbol (`func_ov063_021160c4`) goes to `src/unnamed/<module>/`
+    **if that directory exists**. Creating it is the migration's explicit opt-in; until
+    then its module's files stay in the root, which is where the rest of them are.
+  * a class-named symbol goes wherever its class already lives, if its existing files
+    occupy exactly one subdirectory. `_ZN3Boo6RenderEv` follows the other seven `Boo`
+    files into `src/actors/Boo/`; a `Player` method stays flat because all 248 of them
+    are still flat.
+  * anything else -- free functions, thunks, plain names -- stays in the root.
+
+Two directories can never be inferred, so a half-migrated class is left alone rather
+than guessed at. The effect is that migrating a module makes it *stay* migrated, and
+nothing moves that a human did not already move.
 """
 import pathlib
+import re
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 SRC = REPO / "src"
 SOURCE_SUFFIXES = (".c", ".cpp")
 
+# src/unnamed/<module>/ -- the bucket #975 established for symbols whose name carries no
+# class, only an address. Spelled once, here, so the convention is one edit to revisit.
+UNNAMED_DIR = "unnamed"
+
+_UNNAMED_RE = re.compile(r"^(?:func|FUN|__sinit)_(?:(ov\d+)_)?[0-9a-fA-F]{8}$")
+_SPAWN_RE = re.compile(r"^(\w+)_Spawn$")
+
 _scan_cache = None
+_cohort_cache = None
 
 
 def symbol_for(path):
@@ -61,8 +93,74 @@ def _scan():
 
 def invalidate():
     """Drop the scan cache. Call after writing or moving files in a long-lived process."""
-    global _scan_cache
+    global _scan_cache, _cohort_cache
     _scan_cache = None
+    _cohort_cache = None
+
+
+def module_of(symbol):
+    """`arm9` or `ovNNN` for an address-named symbol, else None.
+
+    Read off the SYMBOL, never delinks.txt: at the moment a writer asks where a new file
+    goes, the function it holds is not enrolled anywhere yet."""
+    m = _UNNAMED_RE.match(symbol)
+    return (m.group(1) or "arm9") if m else None
+
+
+def class_of(symbol):
+    """The class an Itanium-mangled or `<Class>_Spawn` symbol belongs to, else None.
+
+    The OUTER component, deliberately. `_ZN5Sound6Player19SetPlayableSeqCountEii` is
+    `Sound::Player`, and taking the second component would file it under the unrelated
+    actor `Player`. A bare `_Z<len><name>` is a FREE function with no class at all --
+    29 of those are in the tree, and reading the name as a class invents a directory
+    apiece. `_ZTV`/`_ZTI`/`_ZThn` have no leading length either and fall out here."""
+    m = _SPAWN_RE.match(symbol)
+    if m:
+        return m.group(1)
+    if not symbol.startswith("_ZN"):
+        return None
+    rest = symbol[3:]
+    if rest.startswith("K"):                      # const method: _ZNK...
+        rest = rest[1:]
+    m = re.match(r"(\d+)", rest)
+    if not m:
+        return None
+    n, tail = int(m.group(1)), rest[len(m.group(1)):]
+    return tail[:n] if len(tail) >= n else None
+
+
+def _cohort_index():
+    """class -> {directories holding its files}, off the same single scan."""
+    global _cohort_cache
+    if _cohort_cache is None:
+        idx = {}
+        for stem, paths in _scan().items():
+            cls = class_of(stem)
+            if cls:
+                idx.setdefault(cls, set()).update(p.parent for p in paths)
+        _cohort_cache = idx
+    return _cohort_cache
+
+
+def placement_for(symbol):
+    """The subdirectory a NEW file for ``symbol`` belongs in, or None for the root.
+
+    None is the honest answer for most of the tree today and is not a failure: it means
+    nobody has moved this symbol's neighbours yet, so the root is still where they are."""
+    mod = module_of(symbol)
+    if mod is not None:
+        d = SRC / UNNAMED_DIR / mod
+        return d if d.is_dir() else None
+    cls = class_of(symbol)
+    if cls:
+        # Flat siblings do not vote. The root is the unmigrated default, not a rival
+        # choice, so a partly-moved class still follows the subdirectory it has. Two
+        # subdirectories are real disagreement and are left alone.
+        nested = {d for d in _cohort_index().get(cls, ()) if d != SRC}
+        if len(nested) == 1:
+            return nested.pop()
+    return None
 
 
 def set_root(repo):
@@ -112,7 +210,7 @@ def new_path_for(symbol, ext):
         # Keep a symbol where it already lives; changing the extension is the caller's
         # business, relocating it is not.
         return existing.with_suffix(ext)
-    return SRC / f"{symbol}{ext}"
+    return (placement_for(symbol) or SRC) / f"{symbol}{ext}"
 
 
 def iter_sources():

--- a/tools/test_srcpath.py
+++ b/tools/test_srcpath.py
@@ -78,6 +78,96 @@ class SrcPath(unittest.TestCase):
         with self.assertRaises(ValueError):
             SP.new_path_for("x", "h")
 
+    # --- symbol parsing -----------------------------------------------------
+    def test_module_of_reads_the_symbol_not_the_config(self):
+        self.assertEqual(SP.module_of("func_ov063_021160c4"), "ov063")
+        self.assertEqual(SP.module_of("__sinit_ov002_02100560"), "ov002")
+        self.assertEqual(SP.module_of("func_0205c410"), "arm9")
+        self.assertEqual(SP.module_of("__sinit_02073a24"), "arm9")
+        self.assertIsNone(SP.module_of("_ZN3Boo6RenderEv"))
+        self.assertIsNone(SP.module_of("AngleDiff"))
+
+    def test_class_of_takes_the_outer_component(self):
+        self.assertEqual(SP.class_of("_ZN3Boo6RenderEv"), "Boo")
+        self.assertEqual(SP.class_of("_ZN15FaderBrightness8SetToEndEv"), "FaderBrightness")
+        self.assertEqual(SP.class_of("Boo_Spawn"), "Boo")
+        # const method
+        self.assertEqual(SP.class_of("_ZNK5Actor7GetPosEv"), "Actor")
+
+    def test_class_of_rejects_a_nested_namespaces_inner_name(self):
+        """Sound::Player must not be filed under the unrelated actor Player."""
+        self.assertEqual(SP.class_of("_ZN5Sound6Player19SetPlayableSeqCountEii"), "Sound")
+
+    def test_class_of_rejects_free_functions_and_special_symbols(self):
+        """_Z<len><name> is a free function -- treating its name as a class invents a
+        directory per function (29 of them in the tree)."""
+        self.assertIsNone(SP.class_of("_Z14ApproachLinearRiii"))
+        self.assertIsNone(SP.class_of("_ZTV5Model"))
+        self.assertIsNone(SP.class_of("_ZTI5Model"))
+        self.assertIsNone(SP.class_of("_ZThn80_N9Animation7AdvanceEv"))
+        self.assertIsNone(SP.class_of("func_0205c410"))
+
+    # --- placement: follows migration, never leads it -----------------------
+    def test_unnamed_goes_to_its_module_bucket_once_that_exists(self):
+        self.write("unnamed/ov063/func_ov063_021160c4.c")
+        self.assertEqual(SP.new_path_for("func_ov063_02116190", "c"),
+                         SP.SRC / "unnamed/ov063/func_ov063_02116190.c")
+
+    def test_unnamed_stays_flat_until_its_module_is_migrated(self):
+        self.write("unnamed/ov063/func_ov063_021160c4.c")
+        self.assertEqual(SP.new_path_for("func_0205c410", "c"), SP.SRC / "func_0205c410.c")
+
+    def test_unnamed_ignores_a_hand_placed_subsystem_directory(self):
+        """src/engine/message/ holds two arm9 func_* by deliberate choice. That must not
+        drag every future arm9 function in after them."""
+        self.write("engine/message/func_0201cb2c.c")
+        self.assertEqual(SP.new_path_for("func_02012345", "c"), SP.SRC / "func_02012345.c")
+
+    def test_a_class_follows_its_siblings(self):
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.write("actors/Boo/_ZN3BooD1Ev.c")
+        self.assertEqual(SP.new_path_for("_ZN3Boo6RenderEv", "cpp"),
+                         SP.SRC / "actors/Boo/_ZN3Boo6RenderEv.cpp")
+
+    def test_a_spawn_follows_its_class(self):
+        self.write("actors/MadPiano/_ZN8MadPianoD1Ev.c")
+        self.assertEqual(SP.new_path_for("MadPiano_Spawn", "c"),
+                         SP.SRC / "actors/MadPiano/MadPiano_Spawn.c")
+
+    def test_flat_siblings_do_not_outvote_a_subdirectory(self):
+        """A partly-migrated class keeps going to the subdirectory it has; the root is the
+        unmigrated default, not a rival choice."""
+        self.write("_ZN3BooD0Ev.c")
+        self.write("_ZN3BooD1Ev.c")
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.assertEqual(SP.new_path_for("_ZN3Boo6RenderEv", "cpp"),
+                         SP.SRC / "actors/Boo/_ZN3Boo6RenderEv.cpp")
+
+    def test_two_subdirectories_are_left_alone(self):
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.write("engine/ghosts/_ZN3BooD1Ev.c")
+        self.assertEqual(SP.new_path_for("_ZN3Boo6RenderEv", "cpp"),
+                         SP.SRC / "_ZN3Boo6RenderEv.cpp")
+
+    def test_an_unknown_class_stays_flat(self):
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.assertEqual(SP.new_path_for("_ZN6Player4InitEv", "cpp"),
+                         SP.SRC / "_ZN6Player4InitEv.cpp")
+
+    def test_free_functions_and_plain_names_stay_flat(self):
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.assertEqual(SP.new_path_for("_Z14ApproachLinearRiii", "c"),
+                         SP.SRC / "_Z14ApproachLinearRiii.c")
+        self.assertEqual(SP.new_path_for("AngleDiff", "c"), SP.SRC / "AngleDiff.c")
+
+    def test_placement_never_overrides_where_a_file_already_is(self):
+        """Migration decides; placement only follows. A file that exists is not relocated
+        even when its cohort has since moved elsewhere."""
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.write("_ZN3Boo6RenderEv.c")
+        self.assertEqual(SP.new_path_for("_ZN3Boo6RenderEv", "cpp"),
+                         SP.SRC / "_ZN3Boo6RenderEv.cpp")
+
     # --- bulk ---------------------------------------------------------------
     def test_index_and_iter_cover_nested_files(self):
         self.write("flat.c")


### PR DESCRIPTION
#970 and #975 moved 164 files into subdirectories, and nothing kept them there.
`srcpath.new_path_for` answered `src/<symbol>.ext` unconditionally, so every match
landed afterwards went back to the root. Over the 30 days to 2026-08-04, `src/` grew
9,102 -> 11,242 files and every new one was flat: the two migrations were being diluted
faster than they were made.

**No files move here and no config changes.** This only makes the next migration stick.

## The rule

A new file goes nested only when the files it belongs with are *already* nested and
agree on where:

| Symbol | Goes to | Condition |
|---|---|---|
| `func_ov063_02116abc` | `src/unnamed/ov063/` | that directory exists |
| `_ZN3Boo8BehaviorEv` | `src/actors/Boo/` | its class occupies exactly one subdir |
| `MadPiano_Spawn` | `src/actors/MadPiano/` | same, via `<Class>_Spawn` |
| `_Z14ApproachLinearRiii`, `AngleDiff`, `_ZThn80_...` | `src/` | no class to follow |

Creating `src/unnamed/<module>/` is the migration's explicit opt-in. Module is read off
the **symbol**, never delinks.txt, because when a writer asks where a new file goes the
function is not enrolled anywhere yet.

Two candidate subdirectories are real disagreement and are left alone, so a
half-migrated class is never guessed at. Flat siblings do not vote: the root is the
unmigrated default, not a rival choice.

Class extraction takes the **outer** component. `_ZN5Sound6Player19Set...Eii` is
`Sound::Player`, and reading the second would file it under the unrelated actor
`Player`. A bare `_Z<len><name>` is a free function with no class at all — 29 are in
the tree, and treating the name as a class invents a directory apiece.

## The bypass this had to fix first

`crackloop.py` auto-unbanks WRONG-dest relocs by composing `src/<name>.<ext>` and
swallowing `FileNotFoundError`. The day placement returns a nested path, a bogus match
banked nested survives that unlink while its `matched.jsonl` row is dropped just below —
a known-false match left in `src/` with nothing pointing at it, which AGENTS.md says
must never happen. It resolves through `srcpath` now and reports a count mismatch rather
than failing silently.

`name_evidence.callers` had the same flat assumption and would report a nested symbol as
its own caller.

## Verified against the real tree

| Check | Result |
|---|---|
| existing files resolving anywhere different | **0** of 11,242 |
| flat files that would now be placed nested | **0** of 11,076 |
| leave-one-out agreement with the 166 migrated files | 157 agree, 8 no opinion, **1 disagree** |
| `enroll.py` | 11,107 entries, **delinks.txt files changed: 0** |
| `rombuild.py` | 9,812 functions, **0 mismatching**, 106/106 modules exact |
| `prepush_attribution` | 11,236 tracked, 0 changed, 0 lost |
| `tools/test_srcpath.py` | 13 -> 27 tests; full suite 130 passed, 3 skipped |

The single disagreement is `actors/MadPiano/__sinit_ov063_0211e5fc.c`, where a human
attributed a static initializer to its class. Policy sends new sinits to
`unnamed/<module>/`, since attributing one requires knowing what it initializes. The
existing file is not moved — placement never overrides an existing location.

## Ledger

No provenance or attempt rows: this is a tools/docs change and matched nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Lhvo4yBV38fHxhHwvnZ9U
