### PR TITLE
Resolve recovery-pass placeholder names (batch 01 of 2)

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -5008,6 +5008,7 @@ src/_ZN12WithMeshClsnD1Ev.c:
     .text start:0x020373f8 end:0x02037430
 
 src/_ZN12WithMeshClsnC1Ev.c:
+    complete
     .text start:0x02037430 end:0x02037464
 
 src/func_02037464.c:
@@ -6099,6 +6100,7 @@ src/_ZN4Heap23SetupSolidHeapAsDefaultEjPS_i.c:
     .text start:0x0203c2e4 end:0x0203c324
 
 src/_ZN4Heap10SetDefaultEv.cpp:
+    complete
     .text start:0x0203c324 end:0x0203c33c
 
 src/_ZN9SolidHeap12VResizeToFitEv.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -116,6 +116,7 @@ src/func_ov002_020aed18.c:
     .text start:0x020aed18 end:0x020aed3c
 
 src/_ZN5EnemyD0Ev.c:
+    complete
     .text start:0x020aed3c end:0x020aed74
 
 src/_ZN5EnemyD2Ev.c:
@@ -377,6 +378,7 @@ src/_ZN11VirtualDoorD1Ev.cpp:
     .text start:0x020b09b0 end:0x020b09d4
 
 src/_ZN11VirtualDoorD0Ev.c:
+    complete
     .text start:0x020b09d4 end:0x020b0a0c
 
 src/func_ov002_020b0a0c.c:
@@ -664,6 +666,7 @@ src/_ZN10BrickBlockD1Ev.cpp:
     .text start:0x020b415c end:0x020b4180
 
 src/_ZN10BrickBlockD0Ev.c:
+    complete
     .text start:0x020b4180 end:0x020b41b8
 
 src/func_ov002_020b41b8.c:
@@ -1042,6 +1045,7 @@ src/_ZN18PoppingLavaBubblesD1Ev.cpp:
     .text start:0x020b6e08 end:0x020b6e2c
 
 src/_ZN18PoppingLavaBubblesD0Ev.c:
+    complete
     .text start:0x020b6e2c end:0x020b6e64
 
 src/_ZN18PoppingLavaBubbles8BehaviorEv.cpp:
@@ -1584,6 +1588,7 @@ src/func_ov002_020bc990.c:
     .text start:0x020bc990 end:0x020bc9b0
 
 src/_ZN11CannonHatch16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020bc9b0 end:0x020bc9f4
 
 src/_ZN11CannonHatch6RenderEv.cpp:
@@ -4833,6 +4838,7 @@ src/_ZN14BlueCoinSwitchD1Ev.c:
     .text start:0x020f11b0 end:0x020f11f4
 
 src/_ZN14BlueCoinSwitchD0Ev.c:
+    complete
     .text start:0x020f11f4 end:0x020f124c
 
 src/_ZN14BlueCoinSwitch16CleanupResourcesEv.c:
@@ -4873,6 +4879,7 @@ src/_ZN12EnemySpawnerD1Ev.cpp:
     .text start:0x020f1670 end:0x020f1694
 
 src/_ZN12EnemySpawnerD0Ev.c:
+    complete
     .text start:0x020f1694 end:0x020f16cc
 
 src/_ZN14EnemySwitchTag16CleanupResourcesEv.cpp:
@@ -4911,6 +4918,7 @@ src/_ZN19AmbientSoundEffectsD1Ev.cpp:
     .text start:0x020f198c end:0x020f19b0
 
 src/_ZN19AmbientSoundEffectsD0Ev.c:
+    complete
     .text start:0x020f19b0 end:0x020f19e8
 
 src/_ZN19AmbientSoundEffects16CleanupResourcesEv.c:
@@ -4973,6 +4981,7 @@ src/_ZN14CutsceneObjectD1Ev.cpp:
     .text start:0x020f1f70 end:0x020f1f94
 
 src/_ZN14CutsceneObjectD0Ev.c:
+    complete
     .text start:0x020f1f94 end:0x020f1fcc
 
 src/func_ov002_020f1fcc.c:
@@ -5582,6 +5591,7 @@ src/_ZN11SoundObjectD1Ev.c:
     .text start:0x020f934c end:0x020f9370
 
 src/_ZN11SoundObjectD0Ev.c:
+    complete
     .text start:0x020f9370 end:0x020f93a8
 
 src/func_ov002_020f93a8.cpp:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -867,6 +867,7 @@ src/func_ov006_020ca604.cpp:
     .text start:0x020ca604 end:0x020ca78c
 
 src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp:
+    complete
     .text start:0x020ca78c end:0x020ca7b8
 
 src/func_ov006_020ca7b8.c:

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -55,6 +55,7 @@ src/_ZN11CastleWaterD1Ev.c:
     .text start:0x02111a70 end:0x02111abc
 
 src/_ZN11CastleWaterD0Ev.c:
+    complete
     .text start:0x02111abc end:0x02111b1c
 
 src/func_ov009_02111b1c.cpp:

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -147,6 +147,7 @@ src/func_ov014_02112ea8.cpp:
     .text start:0x02112ea8 end:0x02112f3c
 
 src/_ZN15ChainChompFence16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112f3c end:0x02112f80
 
 src/_ZN15ChainChompFence6RenderEv.cpp:

--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -125,6 +125,7 @@ src/_ZN15IceSlideManagerD1Ev.cpp:
     .text start:0x0211261c end:0x02112640
 
 src/_ZN15IceSlideManagerD0Ev.c:
+    complete
     .text start:0x02112640 end:0x02112678
 
 src/_ZN15IceSlideManager8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -16,6 +16,7 @@ src/_ZN15BookShotSpawnerD1Ev.cpp:
     .text start:0x02111254 end:0x02111278
 
 src/_ZN15BookShotSpawnerD0Ev.c:
+    complete
     .text start:0x02111278 end:0x021112b0
 
 src/func_ov020_021112b0.c:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -90,6 +90,7 @@ src/func_ov025_02111e30.c:
     .text start:0x02111e30 end:0x02111e70
 
 src/_ZN11PyramidStep16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111e70 end:0x02111ea8
 
 src/_ZN11PyramidStep6RenderEv.cpp:

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -24,6 +24,7 @@ src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c:
     .text start:0x021113c0 end:0x02111418
 
 src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111418 end:0x0211145c
 
 src/_ZN29FloatOnWaterPlatformWdwSquare6RenderEv.cpp:
@@ -200,6 +201,7 @@ src/func_ov029_02112710.c:
     .text start:0x02112710 end:0x02112750
 
 src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112750 end:0x02112794
 
 src/_ZN20SwitchActivatedPlank6RenderEv.cpp:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -508,6 +508,7 @@ src/func_ov065_0211bc88.cpp:
     .text start:0x0211bc88 end:0x0211bd20
 
 src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211bd20 end:0x0211bd64
 
 src/_ZN14TtcMovingCubeA6RenderEv.cpp:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -320,6 +320,7 @@ src/func_ov071_02122414.cpp:
     .text start:0x02122414 end:0x02122460
 
 src/_ZN6Coffin16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02122460 end:0x021224a4
 
 src/_ZN6Coffin6RenderEv.cpp:

--- a/src/BigBully_Spawn.c
+++ b/src/BigBully_Spawn.c
@@ -7,6 +7,7 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8BigBully[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV12daBDonketu_c */
 int *BigBully_Spawn(void)
@@ -19,7 +20,7 @@ int *BigBully_Spawn(void)
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);
         _ZN11ShadowModelC1Ev((char *)p + 0x370);
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV8BigBully;
     }
     return p;
 }

--- a/src/Bully_Spawn.c
+++ b/src/Bully_Spawn.c
@@ -7,6 +7,7 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV5Bully[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV11daDonketu_c */
 int *Bully_Spawn(void)
@@ -19,7 +20,7 @@ int *Bully_Spawn(void)
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);
         _ZN11ShadowModelC1Ev((char *)p + 0x370);
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV5Bully;
     }
     return p;
 }

--- a/src/ChillBully_Spawn.c
+++ b/src/ChillBully_Spawn.c
@@ -7,6 +7,7 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov027_02113930[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV12daIDonketu_c */
 int *ChillBully_Spawn(void)
@@ -19,7 +20,7 @@ int *ChillBully_Spawn(void)
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);
         _ZN11ShadowModelC1Ev((char *)p + 0x370);
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov027_02113930;
     }
     return p;
 }

--- a/src/FallBlockBfs_Spawn.c
+++ b/src/FallBlockBfs_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV12FallBlockBfs[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV21daObjKm2_Fall_Block_c */
 int *FallBlockBfs_Spawn(void)
@@ -11,7 +12,7 @@ int *FallBlockBfs_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV21daObjKm2_Fall_Block_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV12FallBlockBfs;
     }
     return p;
 }

--- a/src/FallBlockLll_Spawn.c
+++ b/src/FallBlockLll_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov022_021142c4[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjFl_Fall_Block_c */
 int *FallBlockLll_Spawn(void)
@@ -11,7 +12,7 @@ int *FallBlockLll_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV20daObjFl_Fall_Block_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov022_021142c4;
     }
     return p;
 }

--- a/src/FloatOnWaterPlatformJrb_Spawn.c
+++ b/src/FloatOnWaterPlatformJrb_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov016_02114bcc[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV13daObjKi_Ita_c */
 int *FloatOnWaterPlatformJrb_Spawn(void)
@@ -11,7 +12,7 @@ int *FloatOnWaterPlatformJrb_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV13daObjKi_Ita_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov016_02114bcc;
     }
     return p;
 }

--- a/src/FloatOnWaterPlatformWdwRectangle_Spawn.c
+++ b/src/FloatOnWaterPlatformWdwRectangle_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov029_02113f44[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjWcObj06_c */
 int *FloatOnWaterPlatformWdwRectangle_Spawn(void)
@@ -11,7 +12,7 @@ int *FloatOnWaterPlatformWdwRectangle_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV14daObjWcObj06_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov029_02113f44;
     }
     return p;
 }

--- a/src/FloatOnWaterPlatformWdwSquare_Spawn.c
+++ b/src/FloatOnWaterPlatformWdwSquare_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov029_02113c2c[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjWcObj01_c */
 int *FloatOnWaterPlatformWdwSquare_Spawn(void)
@@ -11,7 +12,7 @@ int *FloatOnWaterPlatformWdwSquare_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV14daObjWcObj01_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov029_02113c2c;
     }
     return p;
 }

--- a/src/FloatingFloorBfs_Spawn.c
+++ b/src/FloatingFloorBfs_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov045_02112f50[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV19daObjKm2_Ukishima_c */
 int *FloatingFloorBfs_Spawn(void)
@@ -11,7 +12,7 @@ int *FloatingFloorBfs_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV19daObjKm2_Ukishima_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov045_02112f50;
     }
     return p;
 }

--- a/src/FloatingFloorLllBig_Spawn.c
+++ b/src/FloatingFloorLllBig_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV21FloatingFloorLllSmall[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c */
 int *FloatingFloorLllBig_Spawn(void)
@@ -11,7 +12,7 @@ int *FloatingFloorLllBig_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV21FloatingFloorLllSmall;
     }
     return p;
 }

--- a/src/FloatingFloorLllSmall_Spawn.c
+++ b/src/FloatingFloorLllSmall_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV21FloatingFloorLllSmall[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c */
 int *FloatingFloorLllSmall_Spawn(void)
@@ -11,7 +12,7 @@ int *FloatingFloorLllSmall_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV21FloatingFloorLllSmall;
     }
     return p;
 }

--- a/src/Grindel_Spawn.c
+++ b/src/Grindel_Spawn.c
@@ -5,6 +5,7 @@
 #include "decl_ShadowModel.h"
 #include "decl_TextureSequence.h"
 #include "decl_common.h"
+extern int data_ov025_02113850[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV7daDkk_c */
 int *Grindel_Spawn(void)
@@ -15,7 +16,7 @@ int *Grindel_Spawn(void)
         p[0] = (int)_ZTV7daDkk_c;
         _ZN15TextureSequenceC1Ev((char *)p + 0x324);
         _ZN11ShadowModelC1Ev((char *)p + 0x338);
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov025_02113850;
     }
     return p;
 }

--- a/src/RickshawBdw_Spawn.c
+++ b/src/RickshawBdw_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov043_0211238c[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV21daObjKm1_Kurumajiku_c */
 int *RickshawBdw_Spawn(void)
@@ -11,7 +12,7 @@ int *RickshawBdw_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV21daObjKm1_Kurumajiku_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov043_0211238c;
     }
     return p;
 }

--- a/src/RickshawBs_Spawn.c
+++ b/src/RickshawBs_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov047_021122a0[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV21daObjKm3_Kurumajiku_c */
 int *RickshawBs_Spawn(void)
@@ -11,7 +12,7 @@ int *RickshawBs_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV21daObjKm3_Kurumajiku_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov047_021122a0;
     }
     return p;
 }

--- a/src/RickshawPlatformBdw_Spawn.c
+++ b/src/RickshawPlatformBdw_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV11RickshawBdw[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c */
 int *RickshawPlatformBdw_Spawn(void)
@@ -11,7 +12,7 @@ int *RickshawPlatformBdw_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV17daObjKm1_Kuruma_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV11RickshawBdw;
     }
     return p;
 }

--- a/src/RickshawPlatformBs_Spawn.c
+++ b/src/RickshawPlatformBs_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov047_0211244c[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjKm3_Kuruma_c */
 int *RickshawPlatformBs_Spawn(void)
@@ -11,7 +12,7 @@ int *RickshawPlatformBs_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV17daObjKm3_Kuruma_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov047_0211244c;
     }
     return p;
 }

--- a/src/RollingLogLll_Spawn.c
+++ b/src/RollingLogLll_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV12FallBlockLll[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjFlMaruta_c */
 int *RollingLogLll_Spawn(void)
@@ -11,7 +12,7 @@ int *RollingLogLll_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV15daObjFlMaruta_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV12FallBlockLll;
     }
     return p;
 }

--- a/src/RollingLogTtm_Spawn.c
+++ b/src/RollingLogTtm_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV9UkikiCage[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjHmMaruta_c */
 int *RollingLogTtm_Spawn(void)
@@ -11,7 +12,7 @@ int *RollingLogTtm_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV15daObjHmMaruta_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV9UkikiCage;
     }
     return p;
 }

--- a/src/RotatingPlatformLll_Spawn.c
+++ b/src/RotatingPlatformLll_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov022_02113de8[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjFl_Koma_D_c */
 int *RotatingPlatformLll_Spawn(void)
@@ -11,7 +12,7 @@ int *RotatingPlatformLll_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV16daObjFl_Koma_D_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov022_02113de8;
     }
     return p;
 }

--- a/src/RotatingPlatformRr_Spawn.c
+++ b/src/RotatingPlatformRr_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov036_02113b74[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV19daObjRc_Kaitendai_c */
 int *RotatingPlatformRr_Spawn(void)
@@ -11,7 +12,7 @@ int *RotatingPlatformRr_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV19daObjRc_Kaitendai_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov036_02113b74;
     }
     return p;
 }

--- a/src/RotatingPlatformWdw_Spawn.c
+++ b/src/RotatingPlatformWdw_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV32FloatOnWaterPlatformWdwRectangle[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c */
 int *RotatingPlatformWdw_Spawn(void)
@@ -11,7 +12,7 @@ int *RotatingPlatformWdw_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV15daObjWc_Obj07_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV32FloatOnWaterPlatformWdwRectangle;
     }
     return p;
 }

--- a/src/RotatingPlatformWf_Spawn.c
+++ b/src/RotatingPlatformWf_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov015_021147e8[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjBk_Ukisima_c */
 int *RotatingPlatformWf_Spawn(void)
@@ -11,7 +12,7 @@ int *RotatingPlatformWf_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV17daObjBk_Ukisima_c;
-        p[0] = (int)VT1;
+        p[0] = (int)data_ov015_021147e8;
     }
     return p;
 }

--- a/src/ShutterBob_Spawn.c
+++ b/src/ShutterBob_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV10ShutterBob[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjBSwdoor_c */
 int *ShutterBob_Spawn(void)
@@ -11,7 +12,7 @@ int *ShutterBob_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV14daObjBSwdoor_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV10ShutterBob;
     }
     return p;
 }

--- a/src/ShutterHmc_Spawn.c
+++ b/src/ShutterHmc_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV10ShutterHmc[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCvShutter_c */
 int *ShutterHmc_Spawn(void)
@@ -11,7 +12,7 @@ int *ShutterHmc_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV16daObjCvShutter_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV10ShutterHmc;
     }
     return p;
 }

--- a/src/Thwomp_Spawn.c
+++ b/src/Thwomp_Spawn.c
@@ -5,6 +5,7 @@
 #include "decl_ShadowModel.h"
 #include "decl_TextureSequence.h"
 #include "decl_common.h"
+extern int _ZTV6Thwomp[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV7daDsn_c */
 int *Thwomp_Spawn(void)
@@ -15,7 +16,7 @@ int *Thwomp_Spawn(void)
         p[0] = (int)_ZTV7daDsn_c;
         _ZN15TextureSequenceC1Ev((char *)p + 0x324);
         _ZN11ShadowModelC1Ev((char *)p + 0x338);
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV6Thwomp;
     }
     return p;
 }

--- a/src/TiltingPlatformBfs_Spawn.c
+++ b/src/TiltingPlatformBfs_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV16FloatingFloorBfs[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c */
 int *TiltingPlatformBfs_Spawn(void)
@@ -11,7 +12,7 @@ int *TiltingPlatformBfs_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV15daObjKm2_Gura_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV16FloatingFloorBfs;
     }
     return p;
 }

--- a/src/TiltingPlatformLll_Spawn.c
+++ b/src/TiltingPlatformLll_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV12MetalNetLift[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjFl_Gura_c */
 int *TiltingPlatformLll_Spawn(void)
@@ -11,7 +12,7 @@ int *TiltingPlatformLll_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV14daObjFl_Gura_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV12MetalNetLift;
     }
     return p;
 }

--- a/src/_ZN10BrickBlockD0Ev.c
+++ b/src/_ZN10BrickBlockD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "BrickBlock.h"
+extern void* data_020a0eac;
+extern int _ZTV10BrickBlock[];
 int *_ZN10BrickBlockD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV10BrickBlock;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN10DonutBlockD0Ev.c
+++ b/src/_ZN10DonutBlockD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV18daObjRc_Guruguru_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN10DonutBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjRc_Guruguru_c;
@@ -14,6 +14,6 @@ int *_ZN10DonutBlockD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN10PyramidTopD0Ev.c
+++ b/src/_ZN10PyramidTopD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjDlPyramid_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN10PyramidTopD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjDlPyramid_c;
@@ -15,6 +15,6 @@ int *_ZN10PyramidTopD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN10RickshawBsD0Ev.c
+++ b/src/_ZN10RickshawBsD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN10RickshawBsD0Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN10RickshawBsD1Ev.c
+++ b/src/_ZN10RickshawBsD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10RickshawBsD1Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10ShutterBobD0Ev.c
+++ b/src/_ZN10ShutterBobD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjBSwdoor_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN10ShutterBobD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjBSwdoor_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN10ShutterBobD1Ev.c
+++ b/src/_ZN10ShutterBobD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjBSwdoor_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10ShutterBobD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjBSwdoor_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10ShutterHmcD0Ev.c
+++ b/src/_ZN10ShutterHmcD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCvShutter_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN10ShutterHmcD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCvShutter_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN10ShutterHmcD1Ev.c
+++ b/src/_ZN10ShutterHmcD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCvShutter_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10ShutterHmcD1Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCvShutter_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10SlidingIceD0Ev.c
+++ b/src/_ZN10SlidingIceD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjSlIceBlock_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN10SlidingIceD0Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjSlIceBlock_c;
@@ -14,6 +14,6 @@ int *_ZN10SlidingIceD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN10StarSwitchD0Ev.c
+++ b/src/_ZN10StarSwitchD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV13daObjSwitch_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN10StarSwitchD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daObjSwitch_c;
@@ -14,6 +14,6 @@ int *_ZN10StarSwitchD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
+++ b/src/_ZN11CannonHatch16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "CannonHatch.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov002_0210e124[];
+extern int data_ov002_0210e12c[];
 
 int CannonHatch::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e12c))->Release();
+    ((SharedFilePtr *)(data_ov002_0210e124))->Release();
     return 1;
 }

--- a/src/_ZN11CannonHatchD0Ev.c
+++ b/src/_ZN11CannonHatchD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjCannonShutter_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN11CannonHatchD0Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjCannonShutter_c;
@@ -14,6 +14,6 @@ int *_ZN11CannonHatchD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN11CastleWaterD0Ev.c
+++ b/src/_ZN11CastleWaterD0Ev.c
@@ -6,17 +6,19 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV11CastleWater[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjMcWater_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN11CastleWaterD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11CastleWater;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
+++ b/src/_ZN11PyramidStep16CleanupResourcesEv.cpp
@@ -6,12 +6,13 @@
 #include "PyramidStep.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov025_02113ab0[];
+extern int data_ov025_02113ab8[];
 
 int PyramidStep::CleanupResources()
 {
     ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov025_02113ab8))->Release();
+    ((SharedFilePtr *)(data_ov025_02113ab0))->Release();
     return 1;
 }

--- a/src/_ZN11PyramidStepD0Ev.c
+++ b/src/_ZN11PyramidStepD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjDpBrock_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN11PyramidStepD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjDpBrock_c;
@@ -15,6 +15,6 @@ int *_ZN11PyramidStepD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN11RickshawBdwD0Ev.c
+++ b/src/_ZN11RickshawBdwD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN11RickshawBdwD0Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjKm1_Kuruma_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN11RickshawBdwD1Ev.c
+++ b/src/_ZN11RickshawBdwD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN11RickshawBdwD1Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjKm1_Kuruma_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11SoundObjectD0Ev.c
+++ b/src/_ZN11SoundObjectD0Ev.c
@@ -3,12 +3,14 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int _ZTV11SoundObject[];
 /* recovered: renamed to Class_Method */
 /* daSoundObj_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *_ZN11SoundObjectD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV11SoundObject;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN11VirtualDoorD0Ev.c
+++ b/src/_ZN11VirtualDoorD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "VirtualDoor.h"
+extern void* data_020a0eac;
+extern int _ZTV11VirtualDoor[];
 int *_ZN11VirtualDoorD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV11VirtualDoor;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN12EnemySpawnerD0Ev.c
+++ b/src/_ZN12EnemySpawnerD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "EnemySpawner.h"
+extern void* data_020a0eac;
+extern int _ZTV12EnemySpawner[];
 int *_ZN12EnemySpawnerD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV12EnemySpawner;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN12FallBlockBfsD0Ev.c
+++ b/src/_ZN12FallBlockBfsD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV21daObjKm2_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN12FallBlockBfsD0Ev(int *t)
 {
     t[0] = (int)_ZTV21daObjKm2_Fall_Block_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN12FallBlockBfsD1Ev.c
+++ b/src/_ZN12FallBlockBfsD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV21daObjKm2_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12FallBlockBfsD1Ev(int *t)
 {
     t[0] = (int)_ZTV21daObjKm2_Fall_Block_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12FallBlockLllD0Ev.c
+++ b/src/_ZN12FallBlockLllD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjFlMaruta_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN12FallBlockLllD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjFlMaruta_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN12FallBlockLllD1Ev.c
+++ b/src/_ZN12FallBlockLllD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjFlMaruta_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12FallBlockLllD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjFlMaruta_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12FortressWallD0Ev.c
+++ b/src/_ZN12FortressWallD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjBk_Kabe_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN12FortressWallD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjBk_Kabe_c;
@@ -14,6 +14,6 @@ int *_ZN12FortressWallD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN12MetalNetLiftD0Ev.c
+++ b/src/_ZN12MetalNetLiftD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjFl_Gura_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN12MetalNetLiftD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjFl_Gura_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN12MetalNetLiftD1Ev.c
+++ b/src/_ZN12MetalNetLiftD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjFl_Gura_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12MetalNetLiftD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjFl_Gura_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12SwitchPillarD0Ev.c
+++ b/src/_ZN12SwitchPillarD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjC0Water_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN12SwitchPillarD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjC0Water_c;
@@ -16,6 +16,6 @@ int *_ZN12SwitchPillarD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN12WithMeshClsnC1Ev.c
+++ b/src/_ZN12WithMeshClsnC1Ev.c
@@ -4,11 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "WithMeshClsn.h"
+extern int data_02099204[];
 extern void func_02035514(void *);
 extern void _ZN11RaycastLineC1Ev(void *);
 int *_ZN12WithMeshClsnC1Ev(struct WithMeshClsn *self) {
     func_02035514(((int *)self));
-    ((int *)self)[0] = (int)VT0;
+    ((int *)self)[0] = (int)data_02099204;
     _ZN10SphereClsnC1Ev((char *)&self->mSphereClsn);
     _ZN11RaycastLineC1Ev((char *)&self->mRaycastLine);
     return ((int *)self);

--- a/src/_ZN13BigBrickBlockD0Ev.c
+++ b/src/_ZN13BigBrickBlockD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV13daObjBlockL_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN13BigBrickBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daObjBlockL_c;
@@ -14,6 +14,6 @@ int *_ZN13BigBrickBlockD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN13FortressTowerD0Ev.c
+++ b/src/_ZN13FortressTowerD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjSimpleBg_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN13FortressTowerD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjSimpleBg_c;
@@ -14,6 +14,6 @@ int *_ZN13FortressTowerD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN13PoleBillboardD0Ev.c
+++ b/src/_ZN13PoleBillboardD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjBk_Botaosi_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN13PoleBillboardD0Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjBk_Botaosi_c;
@@ -16,6 +16,6 @@ int *_ZN13PoleBillboardD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN13QuestionBlockD0Ev.c
+++ b/src/_ZN13QuestionBlockD0Ev.c
@@ -8,7 +8,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV18daObjHatenaBlock_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN13QuestionBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjHatenaBlock_c;
@@ -18,6 +18,6 @@ int *_ZN13QuestionBlockD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN13TTC_MovingBarD0Ev.c
+++ b/src/_ZN13TTC_MovingBarD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV18daObjCtKaitendai_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN13TTC_MovingBarD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjCtKaitendai_c;
@@ -16,6 +16,6 @@ int *_ZN13TTC_MovingBarD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN13UpDownLiftBbhD0Ev.c
+++ b/src/_ZN13UpDownLiftBbhD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10daUdlift_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN13UpDownLiftBbhD0Ev(int *t)
 {
     t[0] = (int)_ZTV10daUdlift_c;
@@ -14,6 +14,6 @@ int *_ZN13UpDownLiftBbhD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN14ArrowSignRightD0Ev.c
+++ b/src/_ZN14ArrowSignRightD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjYajirusi_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN14ArrowSignRightD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjYajirusi_c;
@@ -16,6 +16,6 @@ int *_ZN14ArrowSignRightD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN14BlueCoinSwitchD0Ev.c
+++ b/src/_ZN14BlueCoinSwitchD0Ev.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV14BlueCoinSwitch[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBC_Switch_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN14BlueCoinSwitchD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14BlueCoinSwitch;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN14CutsceneObjectD0Ev.c
+++ b/src/_ZN14CutsceneObjectD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "CutsceneObject.h"
+extern void* data_020a0eac;
+extern int _ZTV14CutsceneObject[];
 int *_ZN14CutsceneObjectD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV14CutsceneObject;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN14KnockDownPlankD0Ev.c
+++ b/src/_ZN14KnockDownPlankD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV19daObjBk_Dossunbar_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN14KnockDownPlankD0Ev(int *t)
 {
     t[0] = (int)_ZTV19daObjBk_Dossunbar_c;
@@ -14,6 +14,6 @@ int *_ZN14KnockDownPlankD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN14MovingBarSmallD0Ev.c
+++ b/src/_ZN14MovingBarSmallD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjBk_Lift_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN14MovingBarSmallD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjBk_Lift_c;
@@ -16,6 +16,6 @@ int *_ZN14MovingBarSmallD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN14SquarePathLiftD0Ev.c
+++ b/src/_ZN14SquarePathLiftD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjEmmYuka_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN14SquarePathLiftD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjEmmYuka_c;
@@ -14,6 +14,6 @@ int *_ZN14SquarePathLiftD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
+++ b/src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "TtcMovingCubeA.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov065_0211d9cc[];
+extern int data_ov065_0211d9d4[];
 
 int TtcMovingCubeA::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov065_0211d9d4))->Release();
+    ((SharedFilePtr *)(data_ov065_0211d9cc))->Release();
     return 1;
 }

--- a/src/_ZN14TtcMovingCubeAD0Ev.c
+++ b/src/_ZN14TtcMovingCubeAD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCtMecha09_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN14TtcMovingCubeAD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha09_c;
@@ -16,6 +16,6 @@ int *_ZN14TtcMovingCubeAD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN15BookShotSpawner13InitResourcesEv.cpp
+++ b/src/_ZN15BookShotSpawner13InitResourcesEv.cpp
@@ -4,15 +4,16 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BookShotSpawner.h"
+extern int data_ov020_02114ab8[];
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void LoadBlueCoinModel(void *);
-extern int G0[];
+extern int data_ov020_02114aa0[];
 
 int BookShotSpawner::InitResources()
 {
     unk_0d4 = 0;
-    _ZN5Model8LoadFileER13SharedFilePtr(G0);
-    _ZN5Model8LoadFileER13SharedFilePtr(G1);
+    _ZN5Model8LoadFileER13SharedFilePtr(data_ov020_02114aa0);
+    _ZN5Model8LoadFileER13SharedFilePtr(data_ov020_02114ab8);
     LoadBlueCoinModel(((char *)this));
     return 1;
 }

--- a/src/_ZN15BookShotSpawnerD0Ev.c
+++ b/src/_ZN15BookShotSpawnerD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "BookShotSpawner.h"
+extern void* data_020a0eac;
+extern int _ZTV15BookShotSpawner[];
 int *_ZN15BookShotSpawnerD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV15BookShotSpawner;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
+++ b/src/_ZN15ChainChompFence16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "ChainChompFence.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov014_021149b8[];
+extern int data_ov014_021149c0[];
 
 int ChainChompFence::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov014_021149c0))->Release();
+    ((SharedFilePtr *)(data_ov014_021149b8))->Release();
     return 1;
 }

--- a/src/_ZN15ChainChompFenceD0Ev.c
+++ b/src/_ZN15ChainChompFenceD0Ev.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN15ChainChompFenceD0Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN15ChainChompFenceD1Ev.c
+++ b/src/_ZN15ChainChompFenceD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN15ChainChompFenceD1Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15FireSeaElevatorD0Ev.c
+++ b/src/_ZN15FireSeaElevatorD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV18daObjKm2_Ami_Bou_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN15FireSeaElevatorD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjKm2_Ami_Bou_c;
@@ -16,6 +16,6 @@ int *_ZN15FireSeaElevatorD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN15IceSlideManagerD0Ev.c
+++ b/src/_ZN15IceSlideManagerD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "IceSlideManager.h"
+extern void* data_020a0eac;
+extern int _ZTV15IceSlideManager[];
 int *_ZN15IceSlideManagerD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV15IceSlideManager;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN15TtcRotatingCubeD0Ev.c
+++ b/src/_ZN15TtcRotatingCubeD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjCtRotateBlock_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN15TtcRotatingCubeD0Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjCtRotateBlock_c;
@@ -17,6 +17,6 @@ int *_ZN15TtcRotatingCubeD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN15TtcRotatingGearD0Ev.c
+++ b/src/_ZN15TtcRotatingGearD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCtMecha08_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN15TtcRotatingGearD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha08_c;
@@ -14,6 +14,6 @@ int *_ZN15TtcRotatingGearD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN16FloatingFloorBfsD0Ev.c
+++ b/src/_ZN16FloatingFloorBfsD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN16FloatingFloorBfsD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjKm2_Gura_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN16FloatingFloorBfsD1Ev.c
+++ b/src/_ZN16FloatingFloorBfsD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN16FloatingFloorBfsD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjKm2_Gura_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN16RotatingCogSmallD0Ev.c
+++ b/src/_ZN16RotatingCogSmallD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCtMecha10_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN16RotatingCogSmallD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha10_c;
@@ -14,6 +14,6 @@ int *_ZN16RotatingCogSmallD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN17BigMovingIceBlockD0Ev.c
+++ b/src/_ZN17BigMovingIceBlockD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV18daObjEwmIceBlock_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN17BigMovingIceBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjEwmIceBlock_c;
@@ -14,6 +14,6 @@ int *_ZN17BigMovingIceBlockD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN17RotatingClockHandD0Ev.c
+++ b/src/_ZN17RotatingClockHandD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCtMecha11_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN17RotatingClockHandD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha11_c;
@@ -16,6 +16,6 @@ int *_ZN17RotatingClockHandD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN17SlidingPlatformWfD0Ev.c
+++ b/src/_ZN17SlidingPlatformWfD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjSimpleLift_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN17SlidingPlatformWfD0Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjSimpleLift_c;
@@ -14,6 +14,6 @@ int *_ZN17SlidingPlatformWfD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN18BowserFireSeaArenaD0Ev.c
+++ b/src/_ZN18BowserFireSeaArenaD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10daKpa2Bg_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN18BowserFireSeaArenaD0Ev(int *t)
 {
     t[0] = (int)_ZTV10daKpa2Bg_c;
@@ -16,6 +16,6 @@ int *_ZN18BowserFireSeaArenaD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN18PoppingLavaBubblesD0Ev.c
+++ b/src/_ZN18PoppingLavaBubblesD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "PoppingLavaBubbles.h"
+extern void* data_020a0eac;
+extern int _ZTV18PoppingLavaBubbles[];
 int *_ZN18PoppingLavaBubblesD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV18PoppingLavaBubbles;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN19AmbientSoundEffectsD0Ev.c
+++ b/src/_ZN19AmbientSoundEffectsD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "AmbientSoundEffects.h"
+extern void* data_020a0eac;
+extern int _ZTV19AmbientSoundEffects[];
 int *_ZN19AmbientSoundEffectsD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV19AmbientSoundEffects;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN19BowserPuzzleManagerD0Ev.c
+++ b/src/_ZN19BowserPuzzleManagerD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjFl_Puzzle_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN19BowserPuzzleManagerD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjFl_Puzzle_c;
@@ -14,6 +14,6 @@ int *_ZN19BowserPuzzleManagerD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN19FloatingFloorLllBigD0Ev.c
+++ b/src/_ZN19FloatingFloorLllBigD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjFl_UkiKi_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN19FloatingFloorLllBigD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjFl_UkiKi_c;
@@ -14,6 +14,6 @@ int *_ZN19FloatingFloorLllBigD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN19RotatingPlatformLllD0Ev.c
+++ b/src/_ZN19RotatingPlatformLllD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjFl_Block_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN19RotatingPlatformLllD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjFl_Block_c;
@@ -14,6 +14,6 @@ int *_ZN19RotatingPlatformLllD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN19RotatingPlatformWdwD0Ev.c
+++ b/src/_ZN19RotatingPlatformWdwD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjWc_Mizu_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN19RotatingPlatformWdwD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjWc_Mizu_c;
@@ -16,6 +16,6 @@ int *_ZN19RotatingPlatformWdwD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "SwitchActivatedPlank.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov029_02114324[];
+extern int data_ov029_0211432c[];
 
 int SwitchActivatedPlank::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov029_0211432c))->Release();
+    ((SharedFilePtr *)(data_ov029_02114324))->Release();
     return 1;
 }

--- a/src/_ZN20SwitchActivatedPlankD0Ev.c
+++ b/src/_ZN20SwitchActivatedPlankD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjWc_Obj04_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN20SwitchActivatedPlankD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjWc_Obj04_c;
@@ -15,6 +15,6 @@ int *_ZN20SwitchActivatedPlankD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN20TtcConveyorBeltLargeD0Ev.c
+++ b/src/_ZN20TtcConveyorBeltLargeD0Ev.c
@@ -8,7 +8,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjCtMecha04_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN20TtcConveyorBeltLargeD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha04_c;
@@ -18,6 +18,6 @@ int *_ZN20TtcConveyorBeltLargeD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN21FloatingFloorLllSmallD0Ev.c
+++ b/src/_ZN21FloatingFloorLllSmallD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN21FloatingFloorLllSmallD0Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN21FloatingFloorLllSmallD1Ev.c
+++ b/src/_ZN21FloatingFloorLllSmallD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN21FloatingFloorLllSmallD1Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN22RotatingUpDownPlatformD0Ev.c
+++ b/src/_ZN22RotatingUpDownPlatformD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV13daLinelift2_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN22RotatingUpDownPlatformD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daLinelift2_c;
@@ -14,6 +14,6 @@ int *_ZN22RotatingUpDownPlatformD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN23FloatOnWaterPlatformJrbD0Ev.c
+++ b/src/_ZN23FloatOnWaterPlatformJrbD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV13daSlide_Box_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN23FloatOnWaterPlatformJrbD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daSlide_Box_c;
@@ -16,6 +16,6 @@ int *_ZN23FloatOnWaterPlatformJrbD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN25RotatingUpDownPlatformUtmD0Ev.c
+++ b/src/_ZN25RotatingUpDownPlatformUtmD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV23daObjRotateUpdownLift_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN25RotatingUpDownPlatformUtmD0Ev(int *t)
 {
     t[0] = (int)_ZTV23daObjRotateUpdownLift_c;
@@ -16,6 +16,6 @@ int *_ZN25RotatingUpDownPlatformUtmD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "FloatOnWaterPlatformWdwSquare.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov029_02114248[];
+extern int data_ov029_02114250[];
 
 int FloatOnWaterPlatformWdwSquare::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov029_02114250))->Release();
+    ((SharedFilePtr *)(data_ov029_02114248))->Release();
     return 1;
 }

--- a/src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjWc_Obj02_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN29FloatOnWaterPlatformWdwSquareD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjWc_Obj02_c;
@@ -14,6 +14,6 @@ int *_ZN29FloatOnWaterPlatformWdwSquareD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c
+++ b/src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN32FloatOnWaterPlatformWdwRectangleD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjWc_Obj07_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c
+++ b/src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN32FloatOnWaterPlatformWdwRectangleD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjWc_Obj07_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN3HUDD0Ev.c
+++ b/src/_ZN3HUDD0Ev.c
@@ -4,12 +4,12 @@
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV8dMeter_c; VT1 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN3HUDD0Ev(int *t)
 {
     t[0] = (int)_ZTV8dMeter_c;
     t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN4Heap10SetDefaultEv.cpp
+++ b/src/_ZN4Heap10SetDefaultEv.cpp
@@ -4,8 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Heap.h"
+extern int data_020a0ea0;
 
 int Heap::SetDefault()
 {
- int old = G; G = ((int)this); return old;
+ int old = data_020a0ea0; data_020a0ea0 = ((int)this); return old;
 }

--- a/src/_ZN5BullyD0Ev.c
+++ b/src/_ZN5BullyD0Ev.c
@@ -5,19 +5,20 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV11daDonketu_c */
 extern void func_ov002_020aed18(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN5BullyD0Ev(int *t)
 {
     t[0] = (int)_ZTV11daDonketu_c;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x174);
     _ZN9ModelAnimD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN5BullyD1Ev.c
+++ b/src/_ZN5BullyD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV11daDonketu_c */
 extern void func_ov002_020aed18(void *);
 int *_ZN5BullyD1Ev(int *t)
 {
     t[0] = (int)_ZTV11daDonketu_c;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x174);

--- a/src/_ZN5EnemyD0Ev.c
+++ b/src/_ZN5EnemyD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Enemy.h"
+extern void* data_020a0eac;
+extern int data_ov002_021081e4[];
 int *_ZN5EnemyD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov002_021081e4;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN6Coffin16CleanupResourcesEv.cpp
+++ b/src/_ZN6Coffin16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "Coffin.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov071_021230d8[];
+extern int data_ov071_021230d0[];
 
 int Coffin::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov071_021230d0))->Release();
+    ((SharedFilePtr *)(data_ov071_021230d8))->Release();
     return 1;
 }

--- a/src/_ZN6CoffinD0Ev.c
+++ b/src/_ZN6CoffinD0Ev.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN6CoffinD0Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN6CoffinD1Ev.c
+++ b/src/_ZN6CoffinD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN6CoffinD1Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp
+++ b/src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp
@@ -11,18 +11,19 @@
  * This file was the only evidence for Player.h's `mModelAnim2` at 0x078, so
  * that field can now be dropped and the offset returned to Actor.
  *
- * The vptr it stores is the invented symbol VT0, which carries no address --
+ * The vptr it stores is the invented symbol data_ov006_0213b2e0, which carries no address --
  * a separate problem, left alone here.
  *
  * Detached from Player.h; see _ZN6Player23St_InYoshiMouth_CleanupEv.cpp.
  */
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov006_0213b2e0[];
 
 extern "C" int *_ZN6Player29TryExitCharacterDoorWithIntroEv(int *self)
 {
     func_ov006_020cd6f4(self);
-    self[0] = (int)VT0;
+    self[0] = (int)data_ov006_0213b2e0;
     _ZN9ModelAnimC1Ev((char *)self + 0x78);
     return self;
 }

--- a/src/_ZN6ShipUpD0Ev.c
+++ b/src/_ZN6ShipUpD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjKi_Fune_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN6ShipUpD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjKi_Fune_c;
@@ -14,6 +14,6 @@ int *_ZN6ShipUpD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }


### PR DESCRIPTION
An earlier automated recovery pass left names it never resolved:

```c
/* vtable identified: VT0 = _ZTV11dCapEnemy_c */
extern void *G0;
_ZN6Memory10DeallocateEPvP4Heap(t, G0);
```

`G0` isn't a symbol the ROM defines, so the reference is unresolvable and `eligible.py` won't enroll the file. It survives because `match.py` compares the relocated word as a wildcard — the byte gate never looks at what a relocation points to.

Generated by `tools/resolve_placeholders.py` (#1058), which reads the answer out of dsd's own analysis rather than disassembling: the compiled object says which byte offset each placeholder patches, `relocs.txt` says what address that relocation targets and which module owns it, and that module's `symbols.txt` supplies the name. The module is load-bearing — overlays are overlaid, and one address names a different symbol in every overlay covering it.

Each rename carries a declaration typed like the placeholder it replaces, since `decl_common.h` declares `VT`/`HEAP` **once** for what turn out to be many different symbols.

**115 files, every one byte-verified after the edit, 0 reverted.**

| | |
|---|---|
| enrolled | 9,812 → **9,834** (+22) |
| code bytes built | 76.13% → **76.71%** |
| reproducing | 9,834 / 9,834 |
| module fidelity | 106/106 exact, 100.000000% of compared bytes |
| ROM-build analysis | **PASS** |
| attribution | 0 changed, 0 lost |

## The evidence is not uniform

This split matters more than usual here:

| | |
|---:|---|
| **22 files** | enrolled — the ROM link checked the resolved symbol against the real ROM word and it agreed |
| **93 files** | byte-verified only — still blocked by something else, so the link hasn't seen them |

Byte matching **cannot** check a relocation target, which is the whole point of this change. The 93 rest on dsd's relocation data being right, and on the same mechanical transform the link confirmed for the other 22.

Independent of batch 02 — both cut from main, either can land first. Together they enroll **9,906 (76.96%)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi