### PR TITLE
Resolve recovery-pass placeholder names (batch 02 of 2)

### DIFF
--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -287,6 +287,7 @@ src/func_ov002_020b05d0.c:
     .text start:0x020b05d0 end:0x020b0600
 
 src/func_ov002_020b0600.c:
+    complete
     .text start:0x020b0600 end:0x020b0644
 
 src/func_ov002_020b0644.c:
@@ -347,6 +348,7 @@ src/_ZN9CameraTagD1Ev.cpp:
     .text start:0x020b07f8 end:0x020b081c
 
 src/_ZN9CameraTagD0Ev.c:
+    complete
     .text start:0x020b081c end:0x020b0854
 
 src/_ZN9CameraTag16CleanupResourcesEv.c:
@@ -565,6 +567,7 @@ src/func_ov002_020b3298.c:
     .text start:0x020b3298 end:0x020b32c8
 
 src/func_ov002_020b32c8.c:
+    complete
     .text start:0x020b32c8 end:0x020b330c
 
 src/func_ov002_020b330c.cpp:
@@ -1024,6 +1027,7 @@ src/func_ov002_020b6d28.c:
     .text start:0x020b6d28 end:0x020b6d4c
 
 src/func_ov002_020b6d4c.c:
+    complete
     .text start:0x020b6d4c end:0x020b6d84
 
 src/func_ov002_020b6d84.c:
@@ -1182,6 +1186,7 @@ src/func_ov002_020b8bf0.c:
     .text start:0x020b8bf0 end:0x020b8c3c
 
 src/func_ov002_020b8c3c.c:
+    complete
     .text start:0x020b8c3c end:0x020b8c9c
 
 src/func_ov002_020b8c9c.cpp:
@@ -1197,6 +1202,7 @@ src/func_ov002_020b8d3c.c:
     .text start:0x020b8d3c end:0x020b8d68
 
 src/func_ov002_020b8d68.c:
+    complete
     .text start:0x020b8d68 end:0x020b8dac
 
 src/func_ov002_020b8dac.cpp:
@@ -1517,6 +1523,7 @@ src/func_ov002_020bc414.c:
     .text start:0x020bc414 end:0x020bc444
 
 src/func_ov002_020bc444.c:
+    complete
     .text start:0x020bc444 end:0x020bc488
 
 src/func_ov002_020bc488.c:
@@ -4396,6 +4403,7 @@ src/func_ov002_020ec388.c:
     .text start:0x020ec388 end:0x020ec3b8
 
 src/func_ov002_020ec3b8.c:
+    complete
     .text start:0x020ec3b8 end:0x020ec3fc
 
 src/func_ov002_020ec3fc.c:
@@ -4739,6 +4747,7 @@ src/func_ov002_020f03c4.c:
     .text start:0x020f03c4 end:0x020f03f4
 
 src/func_ov002_020f03f4.c:
+    complete
     .text start:0x020f03f4 end:0x020f0438
 
 src/func_ov002_020f0438.cpp:
@@ -4940,6 +4949,7 @@ src/_ZN8MugenBgmD1Ev.cpp:
     .text start:0x020f1bc4 end:0x020f1be8
 
 src/_ZN8MugenBgmD0Ev.c:
+    complete
     .text start:0x020f1be8 end:0x020f1c20
 
 src/func_ov002_020f1c20.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -1420,6 +1420,7 @@ src/func_ov006_020d5a54.c:
     .text start:0x020d5a54 end:0x020d5a78
 
 src/func_ov006_020d5a78.c:
+    complete
     .text start:0x020d5a78 end:0x020d5ab0
 
 src/func_ov006_020d5ab0.cpp:
@@ -1863,6 +1864,7 @@ src/func_ov006_020dbe40.c:
     .text start:0x020dbe40 end:0x020dbe64
 
 src/func_ov006_020dbe64.c:
+    complete
     .text start:0x020dbe64 end:0x020dbe9c
 
 src/func_ov006_020dbf7c.c:
@@ -2224,6 +2226,7 @@ src/func_ov006_020e0638.c:
     .text start:0x020e0638 end:0x020e065c
 
 src/func_ov006_020e065c.c:
+    complete
     .text start:0x020e065c end:0x020e0694
 
 src/func_ov006_020e0694.c:
@@ -2396,6 +2399,7 @@ src/func_ov006_020e3854.c:
     .text start:0x020e3854 end:0x020e3878
 
 src/func_ov006_020e3878.c:
+    complete
     .text start:0x020e3878 end:0x020e38b0
 
 src/func_ov006_020e38b0.c:
@@ -3393,6 +3397,7 @@ src/func_ov006_020efc0c.c:
     .text start:0x020efc0c end:0x020efc30
 
 src/func_ov006_020efc30.c:
+    complete
     .text start:0x020efc30 end:0x020efc68
 
 src/func_ov006_020efc68.c:
@@ -4163,6 +4168,7 @@ src/func_ov006_020fa75c.c:
     .text start:0x020fa75c end:0x020fa780
 
 src/func_ov006_020fa780.c:
+    complete
     .text start:0x020fa780 end:0x020fa7b8
 
 src/func_ov006_020fa7b8.cpp:
@@ -4417,6 +4423,7 @@ src/func_ov006_020ff420.c:
     .text start:0x020ff420 end:0x020ff444
 
 src/func_ov006_020ff444.c:
+    complete
     .text start:0x020ff444 end:0x020ff47c
 
 src/func_ov006_020ff47c.c:
@@ -4685,6 +4692,7 @@ src/func_ov006_0210428c.c:
     .text start:0x0210428c end:0x021042b0
 
 src/func_ov006_021042b0.c:
+    complete
     .text start:0x021042b0 end:0x021042e8
 
 src/func_ov006_021042e8.c:
@@ -6118,6 +6126,7 @@ src/func_ov006_0211cbd0.c:
     .text start:0x0211cbd0 end:0x0211cbf4
 
 src/func_ov006_0211cbf4.c:
+    complete
     .text start:0x0211cbf4 end:0x0211cc2c
 
 src/func_ov006_0211cc2c.c:

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -88,6 +88,7 @@ src/_ZN8MetalNetD0Ev.c:
     .text start:0x02111e08 end:0x02111e60
 
 src/_ZN8MetalNet16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02111e60 end:0x02111ea4
 
 src/_ZN8MetalNet16OnPendingDestroyEv.c:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -7,6 +7,7 @@ src/func_ov010_021111a0.c:
     .text start:0x021111a0 end:0x021111ec
 
 src/func_ov010_021111ec.c:
+    complete
     .text start:0x021111ec end:0x0211124c
 
 src/func_ov010_0211124c.c:

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov012_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov012_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov012_0211123c.c:

--- a/config/arm9/overlays/ov013/delinks.txt
+++ b/config/arm9/overlays/ov013/delinks.txt
@@ -9,6 +9,7 @@ src/func_ov013_021111a0.c:
     .text start:0x021111a0 end:0x021111d0
 
 src/func_ov013_021111d0.c:
+    complete
     .text start:0x021111d0 end:0x02111214
 
 src/func_ov013_02111214.c:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov015_021111a0.c:
     .text start:0x021111a0 end:0x021111d0
 
 src/func_ov015_021111d0.c:
+    complete
     .text start:0x021111d0 end:0x02111214
 
 src/func_ov015_02111214.c:
@@ -232,6 +233,7 @@ src/func_ov015_02112bd0.c:
     .text start:0x02112bd0 end:0x02112c20
 
 src/func_ov015_02112c20.c:
+    complete
     .text start:0x02112c20 end:0x02112c84
 
 src/func_ov015_02112c84.c:

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -122,6 +122,7 @@ src/func_ov016_02112a00.c:
     .text start:0x02112a00 end:0x02112a44
 
 src/func_ov016_02112a44.c:
+    complete
     .text start:0x02112a44 end:0x02112a9c
 
 src/func_ov016_02112a9c.c:
@@ -151,6 +152,7 @@ src/func_ov016_02112ef4.c:
     .text start:0x02112ef4 end:0x02112f44
 
 src/func_ov016_02112f44.c:
+    complete
     .text start:0x02112f44 end:0x02112fa8
 
 src/func_ov016_02112fa8.c:

--- a/config/arm9/overlays/ov017/delinks.txt
+++ b/config/arm9/overlays/ov017/delinks.txt
@@ -11,6 +11,7 @@ src/_ZN9ShipWaterD0Ev.c:
     .text start:0x021111ec end:0x0211124c
 
 src/_ZN9ShipWater16CleanupResourcesEv.cpp:
+    complete
     .text start:0x0211124c end:0x02111290
 
 src/_ZN9ShipWater6RenderEv.cpp:

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov018_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov018_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov018_0211123c.cpp:
@@ -140,6 +141,7 @@ src/func_ov018_021126d4.c:
     .text start:0x021126d4 end:0x021126f8
 
 src/func_ov018_021126f8.c:
+    complete
     .text start:0x021126f8 end:0x02112730
 
 src/func_ov018_02112730.cpp:

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -42,6 +42,7 @@ src/func_ov022_021115a8.c:
     .text start:0x021115a8 end:0x021115f8
 
 src/func_ov022_021115f8.c:
+    complete
     .text start:0x021115f8 end:0x0211165c
 
 src/func_ov022_0211165c.c:
@@ -91,6 +92,7 @@ src/func_ov022_02111980.c:
     .text start:0x02111980 end:0x021119c4
 
 src/func_ov022_021119c4.c:
+    complete
     .text start:0x021119c4 end:0x02111a1c
 
 src/func_ov022_02111a1c.c:
@@ -98,6 +100,7 @@ src/func_ov022_02111a1c.c:
     .text start:0x02111a1c end:0x02111a64
 
 src/func_ov022_02111a64.c:
+    complete
     .text start:0x02111a64 end:0x02111aa8
 
 src/func_ov022_02111aa8.cpp:
@@ -119,6 +122,7 @@ src/func_ov022_02111cac.c:
     .text start:0x02111cac end:0x02111cf0
 
 src/func_ov022_02111cf0.c:
+    complete
     .text start:0x02111cf0 end:0x02111d48
 
 src/func_ov022_02111d48.c:
@@ -126,6 +130,7 @@ src/func_ov022_02111d48.c:
     .text start:0x02111d48 end:0x02111d90
 
 src/func_ov022_02111d90.c:
+    complete
     .text start:0x02111d90 end:0x02111dd4
 
 src/func_ov022_02111dd4.cpp:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov025_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov025_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov025_0211123c.cpp:

--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov026_021111a0.c:
     .text start:0x021111a0 end:0x021111e0
 
 src/func_ov026_021111e0.c:
+    complete
     .text start:0x021111e0 end:0x02111234
 
 src/func_ov026_02111234.cpp:
@@ -40,6 +41,7 @@ src/func_ov026_021116c8.c:
     .text start:0x021116c8 end:0x0211170c
 
 src/func_ov026_0211170c.c:
+    complete
     .text start:0x0211170c end:0x02111764
 
 src/func_ov026_02111764.c:
@@ -65,6 +67,7 @@ src/func_ov026_021118b8.c:
     .text start:0x021118b8 end:0x021118fc
 
 src/func_ov026_021118fc.c:
+    complete
     .text start:0x021118fc end:0x02111954
 
 src/func_ov026_02111954.c:

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -42,6 +42,7 @@ src/func_ov027_021115c4.c:
     .text start:0x021115c4 end:0x02111618
 
 src/func_ov027_02111618.c:
+    complete
     .text start:0x02111618 end:0x02111680
 
 src/func_ov027_02111680.c:
@@ -67,6 +68,7 @@ src/func_ov027_021118c8.c:
     .text start:0x021118c8 end:0x02111924
 
 src/func_ov027_02111924.c:
+    complete
     .text start:0x02111924 end:0x02111994
 
 src/func_ov027_02111994.cpp:

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov029_021111a0.c:
     .text start:0x021111a0 end:0x021111f0
 
 src/func_ov029_021111f0.c:
+    complete
     .text start:0x021111f0 end:0x02111254
 
 src/func_ov029_02111254.c:
@@ -93,6 +94,7 @@ src/func_ov029_02111ac4.c:
     .text start:0x02111ac4 end:0x02111b08
 
 src/func_ov029_02111b08.c:
+    complete
     .text start:0x02111b08 end:0x02111b60
 
 src/func_ov029_02111b60.c:
@@ -127,6 +129,7 @@ src/func_ov029_02111ea4.c:
     .text start:0x02111ea4 end:0x02111ef4
 
 src/func_ov029_02111ef4.c:
+    complete
     .text start:0x02111ef4 end:0x02111f58
 
 src/func_ov029_02111f58.c:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov030_021111a0.c:
     .text start:0x021111a0 end:0x021111ec
 
 src/func_ov030_021111ec.c:
+    complete
     .text start:0x021111ec end:0x0211124c
 
 src/func_ov030_0211124c.cpp:
@@ -15,6 +16,7 @@ src/func_ov030_0211124c.cpp:
     .text start:0x0211124c end:0x0211130c
 
 src/func_ov030_0211130c.c:
+    complete
     .text start:0x0211130c end:0x02111350
 
 src/func_ov030_02111350.cpp:

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -104,6 +104,7 @@ src/func_ov032_021124a8.c:
     .text start:0x021124a8 end:0x021124ec
 
 src/func_ov032_021124ec.c:
+    complete
     .text start:0x021124ec end:0x02112544
 
 src/func_ov032_02112544.c:
@@ -133,6 +134,7 @@ src/_ZN9HugeCoverD0Ev.c:
     .text start:0x021126e4 end:0x02112744
 
 src/_ZN9HugeCover16CleanupResourcesEv.cpp:
+    complete
     .text start:0x02112744 end:0x02112788
 
 src/_ZN9HugeCover6RenderEv.cpp:

--- a/config/arm9/overlays/ov033/delinks.txt
+++ b/config/arm9/overlays/ov033/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov033_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov033_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov033_0211123c.c:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -7,6 +7,7 @@ src/func_ov036_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov036_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov036_0211123c.c:
@@ -14,6 +15,7 @@ src/func_ov036_0211123c.c:
     .text start:0x0211123c end:0x02111284
 
 src/func_ov036_02111284.c:
+    complete
     .text start:0x02111284 end:0x021112c8
 
 src/func_ov036_021112c8.cpp:
@@ -35,6 +37,7 @@ src/func_ov036_02111444.c:
     .text start:0x02111444 end:0x02111494
 
 src/func_ov036_02111494.c:
+    complete
     .text start:0x02111494 end:0x021114f8
 
 src/func_ov036_021114f8.c:

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -7,9 +7,11 @@ src/func_ov043_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov043_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov043_0211123c.c:
+    complete
     .text start:0x0211123c end:0x02111280
 
 src/func_ov043_02111280.cpp:
@@ -32,6 +34,7 @@ src/func_ov043_021113fc.c:
     .text start:0x021113fc end:0x0211144c
 
 src/func_ov043_0211144c.c:
+    complete
     .text start:0x0211144c end:0x021114b0
 
 src/func_ov043_021114b0.c:

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov045_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov045_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov045_0211123c.c:
@@ -106,6 +107,7 @@ src/func_ov045_02111b14.c:
     .text start:0x02111b14 end:0x02111b64
 
 src/func_ov045_02111b64.c:
+    complete
     .text start:0x02111b64 end:0x02111bc8
 
 src/func_ov045_02111bc8.c:

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -7,6 +7,7 @@ src/func_ov047_021111a0.c:
     .text start:0x021111a0 end:0x021111f0
 
 src/func_ov047_021111f0.c:
+    complete
     .text start:0x021111f0 end:0x02111254
 
 src/func_ov047_02111254.c:
@@ -41,6 +42,7 @@ src/func_ov047_021113f8.c:
     .text start:0x021113f8 end:0x02111448
 
 src/func_ov047_02111448.c:
+    complete
     .text start:0x02111448 end:0x021114ac
 
 src/func_ov047_021114ac.c:

--- a/config/arm9/overlays/ov052/delinks.txt
+++ b/config/arm9/overlays/ov052/delinks.txt
@@ -8,6 +8,7 @@ src/func_ov052_021111a0.c:
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov052_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov052_0211123c.c:

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -466,6 +466,7 @@ src/func_ov060_02117d1c.c:
     .text start:0x02117d1c end:0x02117d60
 
 src/func_ov060_02117d60.c:
+    complete
     .text start:0x02117d60 end:0x02117db8
 
 src/func_ov060_02117db8.c:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -170,6 +170,7 @@ src/func_ov064_02117978.c:
     .text start:0x02117978 end:0x021179bc
 
 src/func_ov064_021179bc.c:
+    complete
     .text start:0x021179bc end:0x02117a14
 
 src/func_ov064_02117a14.cpp:
@@ -193,6 +194,7 @@ src/func_ov064_02117c24.c:
     .text start:0x02117c24 end:0x02117cc4
 
 src/func_ov064_02117cc4.c:
+    complete
     .text start:0x02117cc4 end:0x02117cfc
 
 src/func_ov064_02117cfc.cpp:
@@ -330,6 +332,7 @@ src/func_ov064_02118bec.c:
     .text start:0x02118bec end:0x02118c10
 
 src/func_ov064_02118c10.c:
+    complete
     .text start:0x02118c10 end:0x02118c48
 
 src/func_ov064_02118c48.c:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -338,6 +338,7 @@ src/func_ov065_02119f3c.c:
     .text start:0x02119f3c end:0x02119f88
 
 src/func_ov065_02119f88.c:
+    complete
     .text start:0x02119f88 end:0x02119fe8
 
 src/func_ov065_02119fe8.cpp:
@@ -349,6 +350,7 @@ src/func_ov065_0211a114.c:
     .text start:0x0211a114 end:0x0211a15c
 
 src/func_ov065_0211a15c.c:
+    complete
     .text start:0x0211a15c end:0x0211a1a0
 
 src/func_ov065_0211a1a0.cpp:
@@ -409,6 +411,7 @@ src/func_ov065_0211ab60.c:
     .text start:0x0211ab60 end:0x0211abac
 
 src/func_ov065_0211abac.c:
+    complete
     .text start:0x0211abac end:0x0211ac0c
 
 src/func_ov065_0211ac0c.c:

--- a/config/arm9/overlays/ov072/delinks.txt
+++ b/config/arm9/overlays/ov072/delinks.txt
@@ -202,6 +202,7 @@ src/func_ov072_02120824.c:
     .text start:0x02120824 end:0x02120874
 
 src/func_ov072_02120874.c:
+    complete
     .text start:0x02120874 end:0x021208d8
 
 src/func_ov072_021208d8.cpp:

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -195,6 +195,7 @@ src/func_ov079_02126dbc.c:
     .text start:0x02126dbc end:0x02126e00
 
 src/func_ov079_02126e00.c:
+    complete
     .text start:0x02126e00 end:0x02126e58
 
 src/func_ov079_02126e58.cpp:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -192,6 +192,7 @@ src/func_ov080_02125404.c:
     .text start:0x02125404 end:0x02125428
 
 src/func_ov080_02125428.c:
+    complete
     .text start:0x02125428 end:0x02125460
 
 src/func_ov080_0212555c.c:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -234,6 +234,7 @@ src/func_ov091_021333fc.c:
     .text start:0x021333fc end:0x02133440
 
 src/func_ov091_02133440.c:
+    complete
     .text start:0x02133440 end:0x02133498
 
 src/func_ov091_02133498.c:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -197,6 +197,7 @@ src/func_ov100_021443f4.c:
     .text start:0x021443f4 end:0x02144424
 
 src/func_ov100_02144424.c:
+    complete
     .text start:0x02144424 end:0x02144468
 
 src/func_ov100_02144468.c:

--- a/src/_ZN6ThwompD0Ev.c
+++ b/src/_ZN6ThwompD0Ev.c
@@ -5,20 +5,21 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV7daDsn_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN6ThwompD0Ev(int *t)
 {
     t[0] = (int)_ZTV7daDsn_c;
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN6ThwompD1Ev.c
+++ b/src/_ZN6ThwompD1Ev.c
@@ -5,6 +5,7 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV7daDsn_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
@@ -14,7 +15,7 @@ int *_ZN6ThwompD1Ev(int *t)
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN7MinimapD0Ev.c
+++ b/src/_ZN7MinimapD0Ev.c
@@ -4,12 +4,12 @@
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV6dMap_c; VT1 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN7MinimapD0Ev(int *t)
 {
     t[0] = (int)_ZTV6dMap_c;
     t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8BigBullyD0Ev.c
+++ b/src/_ZN8BigBullyD0Ev.c
@@ -5,19 +5,20 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV12daBDonketu_c */
 extern void func_ov002_020aed18(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8BigBullyD0Ev(int *t)
 {
     t[0] = (int)_ZTV12daBDonketu_c;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x174);
     _ZN9ModelAnimD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8BigBullyD1Ev.c
+++ b/src/_ZN8BigBullyD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV12daBDonketu_c */
 extern void func_ov002_020aed18(void *);
 int *_ZN8BigBullyD1Ev(int *t)
 {
     t[0] = (int)_ZTV12daBDonketu_c;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x174);

--- a/src/_ZN8CapEnemyD0Ev.c
+++ b/src/_ZN8CapEnemyD0Ev.c
@@ -5,13 +5,13 @@
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV11dCapEnemy_c */
 extern void func_ov002_020aed18(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8CapEnemyD0Ev(int *t)
 {
     t[0] = (int)_ZTV11dCapEnemy_c;
     func_ov001_020ab3a0((char *)t + 0x164);
     _ZN5ModelD1Ev((char *)t + 0x114);
     func_ov002_020aed18(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8CccArenaD0Ev.c
+++ b/src/_ZN8CccArenaD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV13daObjEwbIce_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8CccArenaD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daObjEwbIce_c;
@@ -14,6 +14,6 @@ int *_ZN8CccArenaD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8IceBlockD0Ev.c
+++ b/src/_ZN8IceBlockD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjIceBlock_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8IceBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjIceBlock_c;
@@ -16,6 +16,6 @@ int *_ZN8IceBlockD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8IceSheetD0Ev.c
+++ b/src/_ZN8IceSheetD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjIceBoard_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8IceSheetD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjIceBoard_c;
@@ -14,6 +14,6 @@ int *_ZN8IceSheetD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8MetalNet16CleanupResourcesEv.cpp
+++ b/src/_ZN8MetalNet16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "MetalNet.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov009_02113e88[];
+extern int data_ov009_02113e90[];
 
 int MetalNet::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov009_02113e90))->Release();
+    ((SharedFilePtr *)(data_ov009_02113e88))->Release();
     return 1;
 }

--- a/src/_ZN8MetalNetD0Ev.c
+++ b/src/_ZN8MetalNetD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV18daObjMc_Metalnet_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8MetalNetD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjMc_Metalnet_c;
@@ -14,6 +14,6 @@ int *_ZN8MetalNetD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8MugenBgmD0Ev.c
+++ b/src/_ZN8MugenBgmD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "MugenBgm.h"
+extern void* data_020a0eac;
+extern int _ZTV8MugenBgm[];
 int *_ZN8MugenBgmD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV8MugenBgm;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8PlatformD0Ev.c
+++ b/src/_ZN8PlatformD0Ev.c
@@ -6,13 +6,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8PlatformD0Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8ShipWingD0Ev.c
+++ b/src/_ZN8ShipWingD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjRc_Tikuwa_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8ShipWingD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjRc_Tikuwa_c;
@@ -16,6 +16,6 @@ int *_ZN8ShipWingD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8SignPostD0Ev.c
+++ b/src/_ZN8SignPostD0Ev.c
@@ -9,7 +9,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjTatefuda_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8SignPostD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjTatefuda_c;
@@ -20,6 +20,6 @@ int *_ZN8SignPostD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8SquasherD0Ev.c
+++ b/src/_ZN8SquasherD0Ev.c
@@ -5,17 +5,18 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8SquasherD0Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8SquasherD1Ev.c
+++ b/src/_ZN8SquasherD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN8SquasherD1Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8WallSignD0Ev.c
+++ b/src/_ZN8WallSignD0Ev.c
@@ -7,7 +7,7 @@
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV13daObjKanban_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN8WallSignD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daObjKanban_c;
@@ -16,6 +16,6 @@ int *_ZN8WallSignD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9CameraTagD0Ev.c
+++ b/src/_ZN9CameraTagD0Ev.c
@@ -4,10 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "CameraTag.h"
+extern void* data_020a0eac;
+extern int _ZTV9CameraTag[];
 int *_ZN9CameraTagD0Ev(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)_ZTV9CameraTag;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9HugeCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9HugeCover16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "HugeCover.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov032_02113af4[];
+extern int data_ov032_02113afc[];
 
 int HugeCover::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov032_02113afc))->Release();
+    ((SharedFilePtr *)(data_ov032_02113af4))->Release();
     return 1;
 }

--- a/src/_ZN9HugeCoverD0Ev.c
+++ b/src/_ZN9HugeCoverD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjTdWater_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN9HugeCoverD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjTdWater_c;
@@ -16,6 +16,6 @@ int *_ZN9HugeCoverD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9SeesawBobD0Ev.c
+++ b/src/_ZN9SeesawBobD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV13daObjSeesaw_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN9SeesawBobD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daObjSeesaw_c;
@@ -14,6 +14,6 @@ int *_ZN9SeesawBobD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9ShipWater16CleanupResourcesEv.cpp
+++ b/src/_ZN9ShipWater16CleanupResourcesEv.cpp
@@ -6,14 +6,15 @@
 #include "ShipWater.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern int G0[];
+extern int data_ov017_02111c80[];
+extern int data_ov017_02111c88[];
 
 int ShipWater::CleanupResources()
 {
     if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled()) {
         ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(G0))->Release();
-    ((SharedFilePtr *)(G1))->Release();
+    ((SharedFilePtr *)(data_ov017_02111c88))->Release();
+    ((SharedFilePtr *)(data_ov017_02111c80))->Release();
     return 1;
 }

--- a/src/_ZN9ShipWaterD0Ev.c
+++ b/src/_ZN9ShipWaterD0Ev.c
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjKsWater_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN9ShipWaterD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjKsWater_c;
@@ -16,6 +16,6 @@ int *_ZN9ShipWaterD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9TinyCoverD0Ev.c
+++ b/src/_ZN9TinyCoverD0Ev.c
@@ -5,17 +5,18 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN9TinyCoverD0Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9TinyCoverD1Ev.c
+++ b/src/_ZN9TinyCoverD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN9TinyCoverD1Ev(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9TowerStepD0Ev.c
+++ b/src/_ZN9TowerStepD0Ev.c
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjBk_Rotebar_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN9TowerStepD0Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjBk_Rotebar_c;
@@ -14,6 +14,6 @@ int *_ZN9TowerStepD0Ev(int *t)
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9UkikiCageD0Ev.c
+++ b/src/_ZN9UkikiCageD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjHmMaruta_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN9UkikiCageD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjHmMaruta_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN9UkikiCageD1Ev.c
+++ b/src/_ZN9UkikiCageD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV15daObjHmMaruta_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN9UkikiCageD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjHmMaruta_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/actors/FallBlockBbh/FallBlockBbh_Spawn.c
+++ b/src/actors/FallBlockBbh/FallBlockBbh_Spawn.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV12FallBlockBbh[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjTh_Fall_Block_c */
 int *FallBlockBbh_Spawn(void)
@@ -11,7 +12,7 @@ int *FallBlockBbh_Spawn(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV20daObjTh_Fall_Block_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV12FallBlockBbh;
     }
     return p;
 }

--- a/src/actors/FallBlockBbh/_ZN12FallBlockBbhD0Ev.c
+++ b/src/actors/FallBlockBbh/_ZN12FallBlockBbhD0Ev.c
@@ -4,17 +4,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjTh_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *_ZN12FallBlockBbhD0Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjTh_Fall_Block_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/actors/FallBlockBbh/_ZN12FallBlockBbhD1Ev.c
+++ b/src/actors/FallBlockBbh/_ZN12FallBlockBbhD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjTh_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12FallBlockBbhD1Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjTh_Fall_Block_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b0600.c
+++ b/src/func_ov002_020b0600.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_02108480[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daBar_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b0600(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov002_02108480;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b32c8.c
+++ b/src/func_ov002_020b32c8.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_02108964[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjAbuku_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b32c8(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov002_02108964;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b5a18.c
+++ b/src/func_ov002_020b5a18.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b5a18(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b5a70.c
+++ b/src/func_ov002_020b5a70.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b5a70(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b5fd8.c
+++ b/src/func_ov002_020b5fd8.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b5fd8(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b6030.c
+++ b/src/func_ov002_020b6030.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b6030(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b6388.c
+++ b/src/func_ov002_020b6388.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b6388(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b63e0.c
+++ b/src/func_ov002_020b63e0.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b63e0(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b660c.c
+++ b/src/func_ov002_020b660c.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b660c(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b6664.c
+++ b/src/func_ov002_020b6664.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b6664(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b6814.c
+++ b/src/func_ov002_020b6814.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b6814(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b686c.c
+++ b/src/func_ov002_020b686c.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b686c(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b69e4.c
+++ b/src/func_ov002_020b69e4.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b69e4(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b6a3c.c
+++ b/src/func_ov002_020b6a3c.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b6a3c(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b6d4c.c
+++ b/src/func_ov002_020b6d4c.c
@@ -3,12 +3,14 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov002_021093e0[];
 /* recovered: renamed to Class_Method */
 /* daObjLava_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov002_020b6d4c(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov002_021093e0;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b8c3c.c
+++ b/src/func_ov002_020b8c3c.c
@@ -6,17 +6,19 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov002_021096b0[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjPushblock_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020b8c3c(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov002_021096b0;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020b8d68.c
+++ b/src/func_ov002_020b8d68.c
@@ -2,16 +2,17 @@
 // recovered name: daObjPushblock_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov002_0210df94[];
 /* recovered: renamed to Class_Method */
 /* daObjPushblock_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov002_0210df9c[];
 int func_ov002_020b8d68(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210df9c);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210df94);
     return 1;
 }

--- a/src/func_ov002_020bab0c.c
+++ b/src/func_ov002_020bab0c.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020bab0c(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020bab64.c
+++ b/src/func_ov002_020bab64.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020bab64(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020bc444.c
+++ b/src/func_ov002_020bc444.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov002_02109bb8[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWakame_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020bc444(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov002_02109bb8;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020ec3b8.c
+++ b/src/func_ov002_020ec3b8.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_0210acbc[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daWarpkun_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020ec3b8(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov002_0210acbc;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov002_020f03f4.c
+++ b/src/func_ov002_020f03f4.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_0210b030[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daSCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov002_020f03f4(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov002_0210b030;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_020d5a78.c
+++ b/src/func_ov006_020d5a78.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgBomroom_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213bbb4[];
 /* recovered: renamed to Class_Method */
 /* dScMgBomroom_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_020d5a78(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213bbb4;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_020dbe64.c
+++ b/src/func_ov006_020dbe64.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgCoin_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213bf50[];
 /* recovered: renamed to Class_Method */
 /* dScMgCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_020dbe64(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213bf50;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_020e065c.c
+++ b/src/func_ov006_020e065c.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgCurling_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213c304[];
 /* recovered: renamed to Class_Method */
 /* dScMgCurling_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_020e065c(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213c304;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_020e3878.c
+++ b/src/func_ov006_020e3878.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgCurling2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213c510[];
 /* recovered: renamed to Class_Method */
 /* dScMgCurling2_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_020e3878(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213c510;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_020efc30.c
+++ b/src/func_ov006_020efc30.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgLuigi_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213cf10[];
 /* recovered: renamed to Class_Method */
 /* dScMgLuigi_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_020efc30(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213cf10;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_020fa780.c
+++ b/src/func_ov006_020fa780.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgPachinko_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213d9cc[];
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_020fa780(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213d9cc;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_020ff444.c
+++ b/src/func_ov006_020ff444.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgPachinko2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213dbbc[];
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko2_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_020ff444(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213dbbc;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_021042b0.c
+++ b/src/func_ov006_021042b0.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgPanel_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213e24c[];
 /* recovered: renamed to Class_Method */
 /* dScMgPanel_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_021042b0(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213e24c;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov006_0211cbf4.c
+++ b/src/func_ov006_0211cbf4.c
@@ -2,12 +2,14 @@
 // recovered name: dScMgTeresa_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov006_0213fa0c[];
 /* recovered: renamed to Class_Method */
 /* dScMgTeresa_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov006_0211cbf4(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov006_0213fa0c;
     func_ov004_020b29c0(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov010_021111ec.c
+++ b/src/func_ov010_021111ec.c
@@ -5,17 +5,19 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov010_02112ae4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjC1_Trap_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov010_021111ec(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov010_02112ae4;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov012_021111e4.c
+++ b/src/func_ov012_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov012_02112344[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjC0_Switch_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov012_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov012_02112344;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov013_021111d0.c
+++ b/src/func_ov013_021111d0.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_Model.h"
 #include "decl_common.h"
+extern int data_ov013_02112128[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjClockHuriko_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov013_021111d0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov013_02112128;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov015_021111d0.c
+++ b/src/func_ov015_021111d0.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_Model.h"
 #include "decl_common.h"
+extern int data_ov015_02114360[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBkBillboard_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov015_021111d0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov015_02114360;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov015_02112bd0.c
+++ b/src/func_ov015_02112bd0.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjBk_Ukisima_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov015_02112bd0(int *t)
 {
     t[0] = (int)_ZTV17daObjBk_Ukisima_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov015_02112c20.c
+++ b/src/func_ov015_02112c20.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov015_021147e8[];
+extern int data_ov002_021091d4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBk_Ukisima_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov015_02112c20(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov015_021147e8;
+    t[0] = (int)data_ov002_021091d4;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov016_02112a44.c
+++ b/src/func_ov016_02112a44.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov016_02114b00[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKi_Hasira_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov016_02112a44(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov016_02114b00;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov016_02112ef4.c
+++ b/src/func_ov016_02112ef4.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV13daObjKi_Ita_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov016_02112ef4(int *t)
 {
     t[0] = (int)_ZTV13daObjKi_Ita_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov016_02112f44.c
+++ b/src/func_ov016_02112f44.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov016_02114bcc[];
+extern int data_ov002_02108fdc[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKi_Ita_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov016_02112f44(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov016_02114bcc;
+    t[0] = (int)data_ov002_02108fdc;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov018_021111e4.c
+++ b/src/func_ov018_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov018_021138cc[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjSm_Lift_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov018_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov018_021138cc;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov018_021126f8.c
+++ b/src/func_ov018_021126f8.c
@@ -3,12 +3,14 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov018_02113a74[];
 /* recovered: renamed to Class_Method */
 /* daSCre_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov018_021126f8(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov018_02113a74;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov022_021111a0.c
+++ b/src/func_ov022_021111a0.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov022_021111a0(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov022_021111e4.c
+++ b/src/func_ov022_021111e4.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov022_021111e4(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov022_021115a8.c
+++ b/src/func_ov022_021115a8.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV16daObjFl_Koma_D_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov022_021115a8(int *t)
 {
     t[0] = (int)_ZTV16daObjFl_Koma_D_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov022_021115f8.c
+++ b/src/func_ov022_021115f8.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02113de8[];
+extern int data_ov002_021091d4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_Koma_D_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov022_021115f8(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov022_02113de8;
+    t[0] = (int)data_ov002_021091d4;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov022_021119c4.c
+++ b/src/func_ov022_021119c4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02113f70[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_London_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov022_021119c4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov022_02113f70;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov022_02111a64.c
+++ b/src/func_ov022_02111a64.c
@@ -2,16 +2,17 @@
 // recovered name: daObjFl_London_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov022_02114578[];
 /* recovered: renamed to Class_Method */
 /* daObjFl_London_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov022_02114580[];
 int func_ov022_02111a64(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov022_02114580);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov022_02114578);
     return 1;
 }

--- a/src/func_ov022_02111cf0.c
+++ b/src/func_ov022_02111cf0.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02114034[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_Seesaw_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov022_02111cf0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov022_02114034;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov022_02111d90.c
+++ b/src/func_ov022_02111d90.c
@@ -2,16 +2,17 @@
 // recovered name: daObjFl_Seesaw_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov022_021145a0[];
 /* recovered: renamed to Class_Method */
 /* daObjFl_Seesaw_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov022_021145a8[];
 int func_ov022_02111d90(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov022_021145a8);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov022_021145a0);
     return 1;
 }

--- a/src/func_ov022_02112380.c
+++ b/src/func_ov022_02112380.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjFl_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov022_02112380(int *t)
 {
     t[0] = (int)_ZTV20daObjFl_Fall_Block_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov025_021111e4.c
+++ b/src/func_ov025_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov025_02113760[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daDgr_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov025_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov025_02113760;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov025_021118c8.c
+++ b/src/func_ov025_021118c8.c
@@ -5,6 +5,7 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV7daDkk_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
@@ -14,7 +15,7 @@ int *func_ov025_021118c8(int *t)
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov026_021111e0.c
+++ b/src/func_ov026_021111e0.c
@@ -5,17 +5,18 @@
 #include "decl_Model.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov026_02113ae0[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWlPolelift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov026_021111e0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov026_02113ae0;
     _ZN11ShadowModelD1Ev((char *)t + 0x188);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov026_0211170c.c
+++ b/src/func_ov026_0211170c.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov026_02113ba4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWlKoopaShutter_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov026_0211170c(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov026_02113ba4;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov026_021118fc.c
+++ b/src/func_ov026_021118fc.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov026_02113c6c[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWlSubmarine_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov026_021118fc(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov026_02113c6c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov027_021115c4.c
+++ b/src/func_ov027_021115c4.c
@@ -5,13 +5,14 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV12daIDonketu_c */
 extern void func_ov002_020aed18(void *);
 int *func_ov027_021115c4(int *t)
 {
     t[0] = (int)_ZTV12daIDonketu_c;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x174);

--- a/src/func_ov027_02111618.c
+++ b/src/func_ov027_02111618.c
@@ -6,19 +6,21 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov027_02113930[];
+extern int data_ov064_0211b768[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daIDonketu_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov002_020aed18(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov027_02111618(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov027_02113930;
+    t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x174);
     _ZN9ModelAnimD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov027_02111924.c
+++ b/src/func_ov027_02111924.c
@@ -7,20 +7,22 @@
 #include "decl_MovingCylinderClsn.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov027_02113a90[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daPgDfdr_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov027_02111924(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov027_02113a90;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x398);
     _ZN15TextureSequenceD1Ev((char *)t + 0x384);
     _ZN9ModelAnimD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov029_021111a0.c
+++ b/src/func_ov029_021111a0.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjWcObj01_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov029_021111a0(int *t)
 {
     t[0] = (int)_ZTV14daObjWcObj01_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov029_021111f0.c
+++ b/src/func_ov029_021111f0.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov029_02113c2c[];
+extern int data_ov002_02108fdc[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWcObj01_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov029_021111f0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov029_02113c2c;
+    t[0] = (int)data_ov002_02108fdc;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov029_02111b08.c
+++ b/src/func_ov029_02111b08.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov029_02113e74[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWc_Obj05_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov029_02111b08(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov029_02113e74;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov029_02111ea4.c
+++ b/src/func_ov029_02111ea4.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV14daObjWcObj06_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov029_02111ea4(int *t)
 {
     t[0] = (int)_ZTV14daObjWcObj06_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov029_02111ef4.c
+++ b/src/func_ov029_02111ef4.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov029_02113f44[];
+extern int data_ov002_02108fdc[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWcObj06_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov029_02111ef4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov029_02113f44;
+    t[0] = (int)data_ov002_02108fdc;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov030_021111ec.c
+++ b/src/func_ov030_021111ec.c
@@ -6,17 +6,19 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov030_02115974[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjHmBskt_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov030_021111ec(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov030_02115974;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov030_0211130c.c
+++ b/src/func_ov030_0211130c.c
@@ -2,16 +2,17 @@
 // recovered name: daObjHmBskt_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov030_02115c80[];
 /* recovered: renamed to Class_Method */
 /* daObjHmBskt_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov030_02115c88[];
 int func_ov030_0211130c(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov030_02115c88);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov030_02115c80);
     return 1;
 }

--- a/src/func_ov032_021124ec.c
+++ b/src/func_ov032_021124ec.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov032_021138e0[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjTdFuta_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov032_021124ec(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov032_021138e0;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov033_021111e4.c
+++ b/src/func_ov033_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov033_0211237c[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjTtFuta_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov033_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov033_0211237c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov036_021111e4.c
+++ b/src/func_ov036_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov036_02113a98[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjRcBuranko_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov036_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov036_02113a98;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov036_02111284.c
+++ b/src/func_ov036_02111284.c
@@ -2,16 +2,17 @@
 // recovered name: daObjRcBuranko_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov036_02114020[];
 /* recovered: renamed to Class_Method */
 /* daObjRcBuranko_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov036_02114028[];
 int func_ov036_02111284(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov036_02114028);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov036_02114020);
     return 1;
 }

--- a/src/func_ov036_02111444.c
+++ b/src/func_ov036_02111444.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV19daObjRc_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov036_02111444(int *t)
 {
     t[0] = (int)_ZTV19daObjRc_Kaitendai_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov036_02111494.c
+++ b/src/func_ov036_02111494.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov036_02113b74[];
+extern int data_ov002_021091d4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjRc_Kaitendai_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov036_02111494(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov036_02113b74;
+    t[0] = (int)data_ov002_021091d4;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov043_021111e4.c
+++ b/src/func_ov043_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov043_021122b8[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm1_Ukishima_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov043_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov043_021122b8;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov043_0211123c.c
+++ b/src/func_ov043_0211123c.c
@@ -2,16 +2,17 @@
 // recovered name: daObjKm1_Ukishima_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov043_021125e0[];
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Ukishima_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov043_021125e8[];
 int func_ov043_0211123c(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov043_021125e8);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov043_021125e0);
     return 1;
 }

--- a/src/func_ov043_021113fc.c
+++ b/src/func_ov043_021113fc.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV21daObjKm1_Kurumajiku_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov043_021113fc(int *t)
 {
     t[0] = (int)_ZTV21daObjKm1_Kurumajiku_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov043_0211144c.c
+++ b/src/func_ov043_0211144c.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov043_0211238c[];
+extern int data_ov002_02109320[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm1_Kurumajiku_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov043_0211144c(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov043_0211238c;
+    t[0] = (int)data_ov002_02109320;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov045_021111e4.c
+++ b/src/func_ov045_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov045_02112cf4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm2_Agaru_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov045_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov045_02112cf4;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov045_02111b14.c
+++ b/src/func_ov045_02111b14.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV19daObjKm2_Ukishima_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov045_02111b14(int *t)
 {
     t[0] = (int)_ZTV19daObjKm2_Ukishima_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov045_02111b64.c
+++ b/src/func_ov045_02111b64.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov045_02112f50[];
+extern int data_ov002_0210912c[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm2_Ukishima_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov045_02111b64(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov045_02112f50;
+    t[0] = (int)data_ov002_0210912c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov047_021111a0.c
+++ b/src/func_ov047_021111a0.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV21daObjKm3_Kurumajiku_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov047_021111a0(int *t)
 {
     t[0] = (int)_ZTV21daObjKm3_Kurumajiku_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov047_021111f0.c
+++ b/src/func_ov047_021111f0.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov047_021122a0[];
+extern int data_ov002_02109320[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm3_Kurumajiku_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov047_021111f0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov047_021122a0;
+    t[0] = (int)data_ov002_02109320;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov047_021113bc.c
+++ b/src/func_ov047_021113bc.c
@@ -3,6 +3,7 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int _ZTV10RickshawBs[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c */
 int *func_ov047_021113bc(void)
@@ -11,7 +12,7 @@ int *func_ov047_021113bc(void)
     if (p) {
         _ZN8PlatformC2Ev(p);
         p[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV10RickshawBs;
     }
     return p;
 }

--- a/src/func_ov047_021113f8.c
+++ b/src/func_ov047_021113f8.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV17daObjKm3_Kuruma_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov047_021113f8(int *t)
 {
     t[0] = (int)_ZTV17daObjKm3_Kuruma_c;
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov047_02111448.c
+++ b/src/func_ov047_02111448.c
@@ -5,17 +5,20 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov047_0211244c[];
+extern int data_ov002_02109278[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm3_Kuruma_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov047_02111448(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov047_0211244c;
+    t[0] = (int)data_ov002_02109278;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov052_021111e4.c
+++ b/src/func_ov052_021111e4.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov052_02112520[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjEmmLog_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov052_021111e4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov052_02112520;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov060_02117d60.c
+++ b/src/func_ov060_02117d60.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov060_0211a9b0[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daKpa3Bg_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov060_02117d60(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov060_0211a9b0;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov064_021179bc.c
+++ b/src/func_ov064_021179bc.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov064_0211bc68[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_Amilift_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov064_021179bc(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov064_0211bc68;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov064_02117cc4.c
+++ b/src/func_ov064_02117cc4.c
@@ -2,14 +2,15 @@
 // recovered name: daObjFl_Amilift_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov064_0211c728[];
 /* recovered: renamed to Class_Method */
 /* daObjFl_Amilift_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov064_0211c730[];
 int func_ov064_02117cc4(void *t)
 {
     _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov064_0211c730);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov064_0211c728);
     return 1;
 }

--- a/src/func_ov064_02118c10.c
+++ b/src/func_ov064_02118c10.c
@@ -3,12 +3,14 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov064_0211c1d8[];
 /* recovered: renamed to Class_Method */
 /* daObjFl_Coin_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov064_02118c10(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov064_0211c1d8;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov065_02119f88.c
+++ b/src/func_ov065_02119f88.c
@@ -6,17 +6,19 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov065_0211d0ec[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjCtMecha03_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov065_02119f88(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov065_0211d0ec;
     _ZN11ShadowModelD1Ev((char *)t + 0x330);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov065_0211a15c.c
+++ b/src/func_ov065_0211a15c.c
@@ -2,16 +2,17 @@
 // recovered name: daObjCtMecha03_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+extern int data_ov065_0211d894[];
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha03_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
+extern int data_ov065_0211d88c[];
 int func_ov065_0211a15c(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     }
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov065_0211d88c);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov065_0211d894);
     return 1;
 }

--- a/src/func_ov065_0211abac.c
+++ b/src/func_ov065_0211abac.c
@@ -6,17 +6,19 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov065_0211d2b4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjCtMecha05_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov065_0211abac(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov065_0211d2b4;
     _ZN11ShadowModelD1Ev((char *)t + 0x33c);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov072_02120874.c
+++ b/src/func_ov072_02120874.c
@@ -5,20 +5,21 @@
 #include "decl_Model.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov072_02122978[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daBgSnwmn_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov072_02120874(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov072_02122978;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1b0);
     _ZN11ShadowModelD1Ev((char *)t + 0x188);
     _ZN15TextureSequenceD1Ev((char *)t + 0x174);
     _ZN5ModelD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov079_02126e00.c
+++ b/src/func_ov079_02126e00.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov079_02127fb8[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBkKillerdai_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov079_02126e00(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov079_02127fb8;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov080_02125428.c
+++ b/src/func_ov080_02125428.c
@@ -3,12 +3,14 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
+extern void* data_020a0eac;
+extern int data_ov080_021282b4[];
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::OnYoshiTryEat - recovered from vtable slot identity */
 int *func_ov080_02125428(int *t)
 {
-    t[0] = (int)VT;
+    t[0] = (int)data_ov080_021282b4;
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, HEAP);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov080_02126fbc.c
+++ b/src/func_ov080_02126fbc.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov080_02126fbc(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov080_02127014.c
+++ b/src/func_ov080_02127014.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov080_02127014(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov091_02132d04.c
+++ b/src/func_ov091_02132d04.c
@@ -5,19 +5,20 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov091_02132d04(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov091_02132d6c.c
+++ b/src/func_ov091_02132d6c.c
@@ -5,6 +5,7 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
@@ -13,7 +14,7 @@ int *func_ov091_02132d6c(int *t)
     t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov091_02133440.c
+++ b/src/func_ov091_02133440.c
@@ -5,16 +5,18 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov091_021352bc[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjPile_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov091_02133440(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)data_ov091_021352bc;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov098_02139f70.c
+++ b/src/func_ov098_02139f70.c
@@ -4,16 +4,17 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov098_02139f70(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/func_ov098_02139fc8.c
+++ b/src/func_ov098_02139fc8.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov098_02139fc8(int *t)
 {
     t[0] = (int)_ZTV10dBgActor_c;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov100_02144424.c
+++ b/src/func_ov100_02144424.c
@@ -4,14 +4,15 @@
 #include "decl_Actor.h"
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov100_02148188[];
 /* recovered: vtable identified, renamed to Class_Method */
 /* daDoor_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern void *G0;
+extern void *data_020a0eac;
 int *func_ov100_02144424(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov100_02148188;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }


### PR DESCRIPTION
Second and final batch of the change described in #1059: an automated recovery pass emitted `G0`, `VT1`, `HEAP` and friends for symbols it never resolved, `eligible.py` counts those references as unresolvable, and the file never reaches the ROM link. `match.py` passes them regardless, because it compares relocated words as wildcards and so never looks at what a relocation points to.

Resolved from dsd's own relocation analysis (tool in #1058): the compiled object gives the byte offset each placeholder patches, `relocs.txt` gives the target address and owning module, that module's `symbols.txt` gives the name. Each rename carries a declaration typed like the placeholder it replaces, because `decl_common.h` declares `VT`/`HEAP` once for many different symbols.

**135 files, every one byte-verified after the edit, 0 reverted.**

| | |
|---|---|
| enrolled | 9,812 → **9,884** (+72) |
| code bytes built | 76.13% → **76.90%** |
| reproducing | 9,884 / 9,884 |
| module fidelity | 106/106 exact, 100.000000% of compared bytes |
| ROM-build analysis | **PASS** |
| attribution | 0 changed, 0 lost |

## Evidence split

| | |
|---:|---|
| **72 files** | enrolled — the ROM link checked each resolved symbol against the real ROM word and it agreed |
| **63 files** | byte-verified only — still blocked by something else, so the link hasn't seen them |

Byte matching cannot check a relocation target, which is exactly what this change alters.

Independent of batch 01 — both cut from main, either can land first. Together they enroll **9,906 (76.96%)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi