### PR TITLE
layout: gate every build on the src/ invariants the ROM build cannot check

### DIFF
--- a/config/layout-known-issues.txt
+++ b/config/layout-known-issues.txt
@@ -1,0 +1,28 @@
+# Pre-existing layout violations that tools/layout_check.py tolerates, by check and key.
+# Modelled on config/rombuild-exclude.txt: the gate is real for anything NEW, and the
+# debt already in the tree is written down instead of silently allowed.
+#
+# Format:  <check-code> <key>
+# Lines starting with '#' are comments. This list should only ever shrink.
+
+# --- L2: one symbol, two source files --------------------------------------------
+# Fallout from the .c -> .cpp promotion passes: the old file was never removed. It is
+# not cosmetic. srcpath resolves a symbol .c-before-.cpp, so the .c SHADOWS the .cpp
+# for every tool that asks where a symbol lives, including enroll.
+#
+# _ZN13PoleBillboard8BehaviorEv is the case that shows why this matters. Its .c is a
+# `// NONMATCHING` draft and its .cpp is not marked as one, but neither is enrolled --
+# because enroll resolves the symbol to the .c, sees the NONMATCHING hatch, and skips
+# the symbol without ever considering the .cpp. A real match sitting in that .cpp would
+# be invisible. (Whether it matches is untested here: match.py could not resolve the
+# ov015 overlay base address, so this is an open question, not a known loss.)
+#
+# The other five have the .c enrolled and building, with an unenrolled .cpp duplicate
+# alongside. Clearing these means deciding per symbol which file is real and deleting
+# the other, which is a separate PR with its own verification -- not a layout change.
+L2 _ZN13PoleBillboard8BehaviorEv
+L2 _ZN15TtcRotatingGear8BehaviorEv
+L2 _ZN5Stage7PS_InitEv
+L2 func_ov065_02116364
+L2 func_ov084_021298d0
+L2 func_ov084_0212d564

--- a/tools/actor_names.py
+++ b/tools/actor_names.py
@@ -326,14 +326,23 @@ def main():
                 touched += 1
         print(f"REWROTE references in {touched} src files")
 
-        # keep the src/<symbol>.c invariant: rename files whose stem was renamed
-        moved = 0
+        # keep the src/<symbol>.c invariant: rename files whose stem was renamed.
+        # Ask srcpath for the destination rather than with_name(): a file in
+        # src/unnamed/<mod>/ that gains a class name has to leave that bucket, or it
+        # both misfiles itself and splits its class across two directories, which
+        # disables placement for the whole class.
+        moved = relocated = 0
         for p in list(SP.iter_sources()):
             new = repl_all.get(p.stem)
             if new:
-                p.rename(p.with_name(new + "".join(p.suffixes)))
+                dest = SP.rename_target(p, new)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                p.rename(dest)
                 moved += 1
+                relocated += dest.parent != p.parent
         SP.invalidate()
+        if relocated:
+            print(f"  ({relocated} of them moved directory to follow their new name)")
         print(f"RENAMED {moved} src files")
 
         # sync the local (gitignored) progress ledgers so linkcheck/progress

--- a/tools/cpp_rename.py
+++ b/tools/cpp_rename.py
@@ -107,9 +107,11 @@ def find_renamable_files(target_addr=None):
             new_sym = verified_map[m]
             is_cpp = new_sym.startswith("_Z")
             new_ext = ".cpp" if is_cpp else path.suffix
-            new_filename = f"{new_sym}{new_ext}"
-            # A symbol rename must not flatten an already-organized subsystem.
-            new_path = path.with_name(new_filename)
+            # A symbol rename must not flatten an already-organized subsystem, and must
+            # not strand the file in a bucket its new name no longer belongs to -- a
+            # src/unnamed/<mod>/ file that gains a class name has to leave. srcpath owns
+            # both halves of that decision.
+            new_path = SP.rename_target(path.with_suffix(new_ext), new_sym)
 
             if new_path != path:
                 renames.append({

--- a/tools/layout_check.py
+++ b/tools/layout_check.py
@@ -1,0 +1,202 @@
+"""Assert the invariants that make `src/` trustworthy, not merely tidy.
+
+WHY THIS IS NOT COSMETIC
+------------------------
+One of these checks guards a failure the ROM build cannot catch. `enroll` writes each
+source's path into `config/**/delinks.txt`, and `dsd` supplies retail ROM bytes for every
+range it has no object for. So if a file moves and its delinks entry is not updated, the
+function silently falls back to ROM bytes -- and the build still reports a byte-identical
+ROM, because ROM bytes are correct by construction. Nothing goes red. The only visible
+trace is the source-built function count ticking down by one, which is exactly the kind of
+number nobody diffs.
+
+That is L1 below, and it is the reason this file exists. The rest are ordinary tidiness,
+with one exception: L4 is tidiness that silently disables `srcpath.placement_for`, so
+letting it rot costs future placement rather than a match.
+
+Checks
+------
+  L1  stale path    a delinks.txt names src/X but no file is there      ERROR
+  L2  ambiguous     two source files share a stem                       ERROR
+  L3  misfiled      src/unnamed/<mod>/ holds a symbol that is not an
+                    address-named symbol of <mod>                       ERROR
+  L4  split class   one class occupies two or more subdirectories       ERROR
+  L5  unenrolled    a source file no delinks.txt mentions               INFO
+
+L5 is informational on purpose: a matched function can be legitimately un-enrolled (thumb,
+misaligned stub, on the exclude list), and `enroll` already reports those with reasons.
+Counting them here is a trend line, not a gate.
+
+Usage:
+    python tools/layout_check.py            # human summary, exit 1 on any ERROR
+    python tools/layout_check.py --json     # machine-readable
+    python tools/layout_check.py --quiet    # only failures
+"""
+import argparse
+import collections
+import json
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import srcpath as SP  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+CONFIG = REPO / "config"
+KNOWN = CONFIG / "layout-known-issues.txt"
+
+_ENTRY_RE = re.compile(r"^(\S+):\s*$")
+
+
+def known_issues(path=None):
+    """{(check, key)} the tree is already carrying. See config/layout-known-issues.txt.
+
+    A gate that fails on the day it lands teaches people to pass --no-verify. Recording
+    the existing debt keeps the gate real for anything new, and makes burning the debt
+    down a visible, reviewable diff rather than a silent allowance."""
+    p = path or KNOWN
+    out = set()
+    if p.is_file():
+        for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.split("#", 1)[0].strip()
+            if line:
+                code, _, key = line.partition(" ")
+                out.add((code.strip(), key.strip()))
+    return out
+
+
+def delinks_paths(config=None):
+    """{repo-relative src path: delinks file that names it} across every module."""
+    out = {}
+    for dl in sorted((config or CONFIG).rglob("delinks.txt")):
+        for line in dl.read_text(encoding="utf-8", errors="replace").splitlines():
+            m = _ENTRY_RE.match(line)
+            if m and m.group(1).startswith("src/"):
+                out[m.group(1)] = dl
+    return out
+
+
+def check(config=None, known=None):
+    """Every invariant, as {code: [finding, ...]}. Empty lists are the happy path.
+
+    Each finding carries a ``key``; findings whose (code, key) is in the known-issues
+    list are moved to ``waived`` rather than dropped, so they stay countable."""
+    known = known_issues() if known is None else known
+    findings = collections.defaultdict(list)
+    sources = list(SP.iter_sources())
+    on_disk = {p.relative_to(SP.REPO).as_posix() for p in sources}
+    enrolled = delinks_paths(config)
+
+    # L1 -- the one the ROM build cannot catch.
+    for rel, dl in sorted(enrolled.items()):
+        if rel not in on_disk:
+            where = SP.path_for(pathlib.PurePosixPath(rel).stem)
+            findings["L1"].append({
+                "key": rel,
+                "delinks": dl.relative_to(REPO).as_posix(),
+                "actually_at": where.relative_to(SP.REPO).as_posix() if where else None,
+            })
+
+    # L2 -- srcpath has to pick one, and the build uses whichever delinks names.
+    by_stem = collections.defaultdict(list)
+    for p in sources:
+        by_stem[p.stem].append(p.relative_to(SP.REPO).as_posix())
+    for stem, paths in sorted(by_stem.items()):
+        if len(paths) > 1:
+            findings["L2"].append({"key": stem, "paths": sorted(paths)})
+
+    # L3 -- src/unnamed/<mod>/ is a module bucket; anything else in it is misfiled.
+    unnamed_root = SP.SRC / SP.UNNAMED_DIR
+    for p in sources:
+        try:
+            rest = p.relative_to(unnamed_root)
+        except ValueError:
+            continue
+        if len(rest.parts) < 2:
+            continue
+        bucket = rest.parts[0]
+        mod = SP.module_of(p.stem)
+        if mod is None:
+            findings["L3"].append({"key": p.relative_to(SP.REPO).as_posix(),
+                                   "bucket": bucket, "why": "symbol carries a name, not an address"})
+        elif mod != bucket:
+            findings["L3"].append({"key": p.relative_to(SP.REPO).as_posix(),
+                                   "bucket": bucket, "why": f"symbol belongs to {mod}"})
+
+    # L4 -- two homes for one class is what makes placement_for give up.
+    dirs = collections.defaultdict(set)
+    for p in sources:
+        cls = SP.class_of(p.stem)
+        if cls and p.parent != SP.SRC:
+            dirs[cls].add(p.parent.relative_to(SP.SRC).as_posix())
+    for cls, ds in sorted(dirs.items()):
+        if len(ds) > 1:
+            findings["L4"].append({"key": cls, "dirs": sorted(ds)})
+
+    # L5 -- informational.
+    for rel in sorted(on_disk - set(enrolled)):
+        findings["L5"].append({"key": rel})
+
+    # Always emit every code, empty or not: a caller asking for r["L4"] wants "no split
+    # classes", not a KeyError that reads like the check never ran.
+    out, waived = {}, []
+    for code in ERRORS + ("L5",):
+        keep = []
+        for h in findings.get(code, []):
+            if code in ERRORS and (code, h["key"]) in known:
+                waived.append(dict(h, check=code))
+            else:
+                keep.append(h)
+        out[code] = keep
+    out["waived"] = waived
+    return out
+
+
+ERRORS = ("L1", "L2", "L3", "L4")
+LABEL = {
+    "L1": "delinks names a path with no file there (function silently falls back to ROM bytes)",
+    "L2": "two source files share a symbol",
+    "L3": "misfiled under src/unnamed/",
+    "L4": "one class split across two directories (disables placement for it)",
+    "L5": "source file not enrolled in any delinks.txt",
+}
+
+
+def print_report(findings, quiet=False):
+    failed = False
+    for code in ERRORS + ("L5",):
+        hits = findings.get(code, [])
+        bad = code in ERRORS and hits
+        failed = failed or bool(bad)
+        if quiet and not bad:
+            continue
+        mark = "FAIL" if bad else ("info" if code == "L5" else "ok  ")
+        print(f"[{mark}] {code} {LABEL[code]}: {len(hits)}")
+        for h in hits[:10]:
+            print(f"         {json.dumps(h, sort_keys=True)}")
+        if len(hits) > 10:
+            print(f"         ... and {len(hits) - 10} more")
+    waived = findings.get("waived", [])
+    if waived and not quiet:
+        print(f"[note] {len(waived)} pre-existing violation(s) waived by "
+              f"config/layout-known-issues.txt "
+              f"({', '.join(sorted(set(w['check'] for w in waived)))})")
+    print("layout-check: " + ("FAILED" if failed else "clean"))
+    return failed
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true", help="emit findings as JSON")
+    ap.add_argument("--quiet", action="store_true", help="print only failing checks")
+    a = ap.parse_args()
+    findings = check()
+    if a.json:
+        print(json.dumps(findings, indent=1, sort_keys=True))
+        return 1 if any(findings.get(c) for c in ERRORS) else 0
+    return 1 if print_report(findings, a.quiet) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -51,6 +51,7 @@ BUILD = REPO / "build"
 sys.path.insert(0, str(REPO / "tools"))
 import rombuild_cache as RBK  # noqa: E402
 import rombuild_check as RBC  # noqa: E402
+import layout_check as LAY  # noqa: E402
 import rombuild_profile as RP  # noqa: E402
 
 # Default compiler for the ROM build — same as the matching pin (tools/match.py
@@ -280,6 +281,8 @@ def main():
     ap.add_argument("--report-json",
                     help="structured report (default follows the selected profile)")
     ap.add_argument("--no-rom", action="store_true", help="stop after linking")
+    ap.add_argument("--no-layout-check", action="store_true",
+                    help="skip the src/ layout invariant gate (see tools/layout_check.py)")
     ap.add_argument("--no-check", action="store_true",
                     help="skip module/source fidelity analysis; report status is unchecked")
     ap.add_argument("--arm7-bios", help="passed to dsd rom build if your dump needs it")
@@ -312,6 +315,24 @@ def main():
         if not (REPO / "extracted" / "dsd" / "config.yaml").is_file():
             raise BuildError("preflight", 1,
                              "no extracted ROM - run tools/unpack.py on your own dump first")
+
+        # Layout gate, before the compile rather than after: a delinks.txt naming a path
+        # with no file there does NOT fail this build. dsd fills that range with retail
+        # ROM bytes, so the result is still byte-identical and every check below stays
+        # green -- the only trace is the source-built function count quietly dropping.
+        # That is the one class of breakage this pipeline cannot self-detect, so it is
+        # checked up front where it costs a second instead of a full link.
+        if not args.no_layout_check:
+            layout = LAY.check()
+            report["layout"] = {k: len(v) for k, v in layout.items()}
+            if any(layout[c] for c in LAY.ERRORS):
+                LAY.print_report(layout, quiet=True)
+                raise BuildError("layout", 1,
+                                 "src/ layout invariants violated - see tools/layout_check.py. "
+                                 "Re-run tools/enroll.py if files moved; add a documented "
+                                 "waiver to config/layout-known-issues.txt only if the "
+                                 "violation is genuinely pre-existing.")
+
         profile = RP.prepare_profile(args.profile)
         config_root = profile["configRoot"]
         config_yaml = profile["configYaml"]

--- a/tools/srcpath.py
+++ b/tools/srcpath.py
@@ -163,6 +163,37 @@ def placement_for(symbol):
     return None
 
 
+def _fits(directory, symbol):
+    """Is ``directory`` a legal home for ``symbol``?
+
+    Only the unnamed buckets have a rule strict enough to answer. Every other directory
+    is a human's deliberate choice, so the honest answer there is yes -- leave it be."""
+    try:
+        rest = directory.relative_to(SRC / UNNAMED_DIR)
+    except ValueError:
+        return True
+    return bool(rest.parts) and module_of(symbol) == rest.parts[0]
+
+
+def rename_target(path, new_symbol):
+    """Where a file must live once its symbol is renamed to ``new_symbol``.
+
+    Renaming in place is the norm and stays the norm; this differs only when the old
+    directory would become a lie. A `func_ov006_*` that becomes `_ZN3Boo6RenderEv` cannot
+    stay in `src/unnamed/ov006/`: that directory means "address-named symbols of ov006".
+    Leaving it there misfiles the file and, worse, puts class `Boo` in two directories at
+    once -- which is exactly the state `placement_for` reads as disagreement, so every
+    future `Boo` method silently goes back to landing in the root.
+
+    Renaming is the single most common way a file's correct home changes: 1,282 files
+    went from `func_*` to a real name in the 60 days to 2026-08-04."""
+    suffix = "".join(pathlib.Path(path).suffixes)
+    home = placement_for(new_symbol)
+    if home is None:
+        home = path.parent if _fits(path.parent, new_symbol) else SRC
+    return home / (new_symbol + suffix)
+
+
 def set_root(repo):
     """Resolve against a different checkout. Returns the previous ``(REPO, SRC)``.
 

--- a/tools/test_layout.py
+++ b/tools/test_layout.py
@@ -1,0 +1,119 @@
+"""What layout_check has to catch.
+
+L1 is the one that matters: a delinks.txt naming a path with no file there makes the
+function fall back to retail ROM bytes, so the ROM build still comes out byte-identical
+and nothing goes red. If only one of these tests is ever kept, keep that one."""
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import layout_check as LC  # noqa: E402
+import srcpath as SP  # noqa: E402
+
+
+class LayoutCheck(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name)
+        (self.repo / "src").mkdir()
+        (self.repo / "config" / "m").mkdir(parents=True)
+        self._saved = (SP.REPO, SP.SRC, LC.REPO)
+        SP.REPO, SP.SRC = self.repo, self.repo / "src"
+        LC.REPO = self.repo
+        SP.invalidate()
+
+    def tearDown(self):
+        SP.REPO, SP.SRC, LC.REPO = self._saved
+        SP.invalidate()
+        self.tmp.cleanup()
+
+    def write(self, rel):
+        p = SP.SRC / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("int f(void){return 0;}\n")
+        SP.invalidate()
+        return p
+
+    def delinks(self, *entries):
+        (self.repo / "config" / "m" / "delinks.txt").write_text(
+            "".join(f"{e}:\n    .text start:0x0 end:0x4\n" for e in entries))
+        return self.repo / "config"
+
+    def run_check(self, cfg, known=frozenset()):
+        return LC.check(cfg, known=set(known))
+
+    # --- L1: the silent one -------------------------------------------------
+    def test_L1_catches_a_delinks_path_with_no_file(self):
+        self.write("unnamed/ov006/func_ov006_02100000.c")
+        cfg = self.delinks("src/func_ov006_02100000.c")     # stale flat path
+        r = self.run_check(cfg)
+        self.assertEqual(len(r["L1"]), 1)
+        self.assertEqual(r["L1"][0]["actually_at"],
+                         "src/unnamed/ov006/func_ov006_02100000.c")
+
+    def test_L1_clean_when_delinks_matches_disk(self):
+        self.write("unnamed/ov006/func_ov006_02100000.c")
+        cfg = self.delinks("src/unnamed/ov006/func_ov006_02100000.c")
+        self.assertEqual(self.run_check(cfg)["L1"], [])
+
+    # --- L2 -----------------------------------------------------------------
+    def test_L2_catches_a_symbol_with_two_files(self):
+        self.write("dup.c")
+        self.write("sub/dup.cpp")
+        r = self.run_check(self.delinks())
+        self.assertEqual([h["key"] for h in r["L2"]], ["dup"])
+
+    # --- L3 -----------------------------------------------------------------
+    def test_L3_catches_a_named_symbol_in_an_unnamed_bucket(self):
+        self.write("unnamed/ov006/_ZN3Boo6RenderEv.c")
+        r = self.run_check(self.delinks())
+        self.assertEqual(len(r["L3"]), 1)
+        self.assertIn("not an address", r["L3"][0]["why"])
+
+    def test_L3_catches_the_wrong_module_bucket(self):
+        self.write("unnamed/ov006/func_ov002_02100000.c")
+        r = self.run_check(self.delinks())
+        self.assertEqual(len(r["L3"]), 1)
+        self.assertIn("ov002", r["L3"][0]["why"])
+
+    def test_L3_allows_the_right_module_bucket(self):
+        self.write("unnamed/ov006/func_ov006_02100000.c")
+        self.assertEqual(self.run_check(self.delinks())["L3"], [])
+
+    # --- L4 -----------------------------------------------------------------
+    def test_L4_catches_a_class_split_across_directories(self):
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.write("unnamed/ov006/_ZN3Boo6RenderEv.c")
+        r = self.run_check(self.delinks())
+        self.assertEqual([h["key"] for h in r["L4"]], ["Boo"])
+        self.assertEqual(r["L4"][0]["dirs"], ["actors/Boo", "unnamed/ov006"])
+
+    def test_L4_ignores_flat_files(self):
+        """The root is the unmigrated default, not a second home."""
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        self.write("_ZN3Boo6RenderEv.c")
+        self.assertEqual(self.run_check(self.delinks())["L4"], [])
+
+    # --- waivers ------------------------------------------------------------
+    def test_a_known_issue_is_waived_but_still_counted(self):
+        self.write("dup.c")
+        self.write("sub/dup.cpp")
+        r = self.run_check(self.delinks(), known={("L2", "dup")})
+        self.assertEqual(r["L2"], [])
+        self.assertEqual([w["check"] for w in r["waived"]], ["L2"])
+
+    def test_a_waiver_does_not_leak_across_checks(self):
+        self.write("unnamed/ov006/_ZN3Boo6RenderEv.c")
+        r = self.run_check(self.delinks(), known={("L2", "src/unnamed/ov006/_ZN3Boo6RenderEv.c")})
+        self.assertEqual(len(r["L3"]), 1)
+
+    def test_known_issues_file_parses_comments_and_blanks(self):
+        p = self.repo / "known.txt"
+        p.write_text("# a comment\n\nL2 sym_one\nL4 SomeClass   # trailing\n")
+        self.assertEqual(LC.known_issues(p), {("L2", "sym_one"), ("L4", "SomeClass")})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_srcpath.py
+++ b/tools/test_srcpath.py
@@ -160,6 +160,47 @@ class SrcPath(unittest.TestCase):
                          SP.SRC / "_Z14ApproachLinearRiii.c")
         self.assertEqual(SP.new_path_for("AngleDiff", "c"), SP.SRC / "AngleDiff.c")
 
+    # --- renaming: the commonest way a file's correct home changes -----------
+    def test_rename_in_place_is_still_the_norm(self):
+        p = self.write("func_0205c410.c")
+        self.assertEqual(SP.rename_target(p, "_ZN6Player4InitEv"),
+                         SP.SRC / "_ZN6Player4InitEv.c")
+
+    def test_rename_out_of_an_unnamed_bucket_when_the_name_gains_a_class(self):
+        """The defect this exists for: a named file left in src/unnamed/ov006/ misfiles
+        itself AND splits its class across two directories, which disables placement for
+        every other method of that class."""
+        p = self.write("unnamed/ov006/func_ov006_02100000.c")
+        self.assertEqual(SP.rename_target(p, "_ZN3Boo6RenderEv"),
+                         SP.SRC / "_ZN3Boo6RenderEv.c")
+
+    def test_rename_into_the_classs_existing_home(self):
+        self.write("actors/Boo/Boo_Spawn.cpp")
+        p = self.write("unnamed/ov006/func_ov006_02100000.c")
+        self.assertEqual(SP.rename_target(p, "_ZN3Boo6RenderEv"),
+                         SP.SRC / "actors/Boo/_ZN3Boo6RenderEv.c")
+
+    def test_rename_stays_in_its_bucket_when_still_address_named(self):
+        p = self.write("unnamed/ov006/func_ov006_02100000.c")
+        self.assertEqual(SP.rename_target(p, "func_ov006_02100004"),
+                         SP.SRC / "unnamed/ov006/func_ov006_02100004.c")
+
+    def test_rename_leaves_a_bucket_that_belongs_to_another_module(self):
+        p = self.write("unnamed/ov006/func_ov006_02100000.c")
+        self.assertEqual(SP.rename_target(p, "func_ov002_02100000"),
+                         SP.SRC / "func_ov002_02100000.c")
+
+    def test_rename_does_not_disturb_a_hand_placed_subsystem_directory(self):
+        """engine/message/ is a human's choice; srcpath has no standing to second-guess
+        it, so a rename there stays put."""
+        p = self.write("engine/message/func_0201cb2c.c")
+        self.assertEqual(SP.rename_target(p, "func_0201cb30"),
+                         SP.SRC / "engine/message/func_0201cb30.c")
+
+    def test_rename_keeps_a_multi_suffix_extension(self):
+        p = self.write("unnamed/ov006/func_ov006_02100000.cpp")
+        self.assertEqual(SP.rename_target(p, "_ZN3Boo6RenderEv").suffix, ".cpp")
+
     def test_placement_never_overrides_where_a_file_already_is(self):
         """Migration decides; placement only follows. A file that exists is not relocated
         even when its cohort has since moved elsewhere."""


### PR DESCRIPTION
#1055 made placement a policy. This makes it enforceable — because there is one way to break
the layout that **fails nothing today**.

## The gap

`enroll` writes each source's path into `config/**/delinks.txt`, and `dsd` supplies retail ROM
bytes for every range it has no object for. So if a file moves and its delinks entry is not
updated, that function silently falls back to ROM bytes — and **the build still reports a
byte-identical ROM**, because ROM bytes are correct by construction. Nothing goes red. The
only trace is the source-built function count dropping by one.

`tools/layout_check.py` asserts four invariants and runs *before* the compile, so a stale path
costs a second instead of a full link:

| | Catches |
|---|---|
| **L1** | a delinks.txt names a path with no file there — **the silent one** |
| **L2** | two source files share a symbol |
| **L3** | a file misfiled under `src/unnamed/<module>/` |
| **L4** | one class occupying two subdirectories |

L5 counts sources no delinks.txt mentions, as information rather than a gate — a matched
function can legitimately be un-enrolled, and `enroll` already reports those with reasons.

L4 is not tidiness. Two directories for one class is exactly what `srcpath.placement_for`
reads as disagreement, so letting it rot silently disables placement for that class.

## Which is how renaming broke it

`actor_names` and `cpp_rename` both renamed with `with_name()`, keeping the directory. A
migrated `func_ov006_*` that gains a class name stayed in `src/unnamed/ov006/` — misfiling
itself and splitting its class across two homes, after which every future method of that class
silently lands in the root again. **1,282 files went from `func_*` to a real name in the last
60 days**, so this was not hypothetical. Both now ask `srcpath.rename_target`, which relocates
a file only when its old directory would become a lie.

## Pre-existing debt, written down rather than allowed

The check immediately found **six symbols with both a `.c` and a `.cpp`**. Not cosmetic:
`srcpath` resolves `.c` before `.cpp`, so the `.c` shadows the `.cpp` for every tool that asks
where a symbol lives, including `enroll`.

`_ZN13PoleBillboard8BehaviorEv` shows the cost — its `.c` is a `NONMATCHING` draft, so `enroll`
resolves the symbol to the draft, sees the hatch, skips it, and **never considers the `.cpp` at
all**. Whether that `.cpp` matches is untested: `match.py` could not resolve the ov015 overlay
base address. An open question, not a known loss.

Clearing those means deciding per symbol which file is real and deleting the other — a separate
PR with its own verification. They are recorded in `config/layout-known-issues.txt`, modelled on
`config/rombuild-exclude.txt`, so the gate is real for anything new and the debt is visible.

## Verified

- **Negative control** — moved a file without re-running `enroll`: `rombuild` exits 1 on L1 and
  L3, naming the file's actual location. Restored, build green again.
- `tools/test_layout.py` — 12 tests, each breaking the tree deliberately.
- `tools/test_srcpath.py` — 27 → 33, covering `rename_target`.
- Full suite: **148 passed, 3 skipped**.
- `rombuild`: 9,812 functions, **0 mismatching, 106/106 modules exact**.
- `layout_check` on the tree as it stands: **clean**, 6 waived.

Independent of #1061, which fixes a credit bug in a different layer; they touch no common files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Lhvo4yBV38fHxhHwvnZ9U
