### PR TITLE
Resolve stand-in symbol names, and generalise the rule (batch 01 of 2)

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -7812,6 +7812,7 @@ src/_ZN13HeapAllocator6RemoveEv.cpp:
     .text start:0x0204df38 end:0x0204df54
 
 src/_ZN13HeapAllocatorC1EjPvPvj.cpp:
+    complete
     .text start:0x0204df54 end:0x0204dfe8
 
 src/_ZN18NestedHeapIterator10FindNestedEPv.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -312,6 +312,7 @@ src/func_ov002_020b067c.c:
     .text start:0x020b067c end:0x020b0710
 
 src/InvisiblePole_Spawn.c:
+    complete
     .text start:0x020b0710 end:0x020b0748
 
 src/_ZN13InvisiblePoleD1Ev.cpp:
@@ -589,12 +590,15 @@ src/func_ov002_020b3518.cpp:
     .text start:0x020b3518 end:0x020b3568
 
 src/Bubble_Spawn.c:
+    complete
     .text start:0x020b3568 end:0x020b35a0
 
 src/_ZN13BigBrickBlockD1Ev.c:
+    complete
     .text start:0x020b35a0 end:0x020b35e4
 
 src/_ZN13BigBrickBlockD0Ev.c:
+    complete
     .text start:0x020b35e4 end:0x020b363c
 
 src/func_ov002_020b363c.c:
@@ -1222,6 +1226,7 @@ src/func_ov002_020b8fe0.cpp:
     .text start:0x020b8fe0 end:0x020b910c
 
 src/PushBlock_Spawn.c:
+    complete
     .text start:0x020b910c end:0x020b9148
 
 src/_ZN9PushBlockD1Ev.cpp:
@@ -1300,9 +1305,11 @@ src/PowerFlower_Spawn.c:
     .text start:0x020b9e0c end:0x020b9e64
 
 src/_ZN10StarSwitchD1Ev.c:
+    complete
     .text start:0x020b9e64 end:0x020b9ea8
 
 src/_ZN10StarSwitchD0Ev.c:
+    complete
     .text start:0x020b9ea8 end:0x020b9f00
 
 src/func_ov002_020b9f00.c:
@@ -1551,6 +1558,7 @@ src/func_ov002_020bc540.cpp:
     .text start:0x020bc540 end:0x020bc5a8
 
 src/Seaweed_Spawn.c:
+    complete
     .text start:0x020bc5a8 end:0x020bc5e0
 
 src/_ZN7SeaweedD1Ev.cpp:
@@ -1585,9 +1593,11 @@ src/HealingHeart_Spawn.c:
     .text start:0x020bc8b4 end:0x020bc8f4
 
 src/_ZN11CannonHatchD1Ev.c:
+    complete
     .text start:0x020bc8f4 end:0x020bc938
 
 src/_ZN11CannonHatchD0Ev.c:
+    complete
     .text start:0x020bc938 end:0x020bc990
 
 src/func_ov002_020bc990.c:
@@ -4432,6 +4442,7 @@ src/func_ov002_020ec4c4.c:
     .text start:0x020ec4c4 end:0x020ec534
 
 src/Warp_Spawn.c:
+    complete
     .text start:0x020ec534 end:0x020ec56c
 
 src/_ZN8YoshiEggD1Ev.c:
@@ -4779,6 +4790,7 @@ src/func_ov002_020f07dc.c:
     .text start:0x020f07dc end:0x020f085c
 
 src/InvisibleSecret_Spawn.c:
+    complete
     .text start:0x020f085c end:0x020f0894
 
 src/_ZN15InvisibleSecretD1Ev.cpp:
@@ -4844,6 +4856,7 @@ src/OneUpLogo_Spawn.c:
     .text start:0x020f1170 end:0x020f11b0
 
 src/_ZN14BlueCoinSwitchD1Ev.c:
+    complete
     .text start:0x020f11b0 end:0x020f11f4
 
 src/_ZN14BlueCoinSwitchD0Ev.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -2393,6 +2393,7 @@ src/func_ov006_020e3578.c:
     .text start:0x020e3578 end:0x020e3820
 
 src/MgShuffleShell_Spawn.c:
+    complete
     .text start:0x020e3820 end:0x020e3854
 
 src/func_ov006_020e3854.c:
@@ -3599,6 +3600,7 @@ src/func_ov006_020f3460.c:
     .text start:0x020f3460 end:0x020f3800
 
 src/MgWanted_Spawn.c:
+    complete
     .text start:0x020f3800 end:0x020f3834
 
 src/func_ov006_020f3834.cpp:
@@ -4417,6 +4419,7 @@ src/func_ov006_020fee24.c:
     .text start:0x020fee24 end:0x020fefc0
 
 src/MgBobOmbSquad_Spawn.c:
+    complete
     .text start:0x020ff3ec end:0x020ff420
 
 src/func_ov006_020ff420.c:
@@ -4686,6 +4689,7 @@ src/func_ov006_02103ed0.c:
     .text start:0x02103ed0 end:0x02104258
 
 src/MgLakituLaunch_Spawn.c:
+    complete
     .text start:0x02104258 end:0x0210428c
 
 src/func_ov006_0210428c.c:
@@ -4952,6 +4956,7 @@ src/func_ov006_021073b0.c:
     .text start:0x021073b0 end:0x02107858
 
 src/MgPuzzlePanelPuzzlePanic_Spawn.c:
+    complete
     .text start:0x02107858 end:0x0210788c
 
 src/func_ov006_0210788c.c:
@@ -6427,6 +6432,7 @@ src/func_ov006_021203fc.c:
     .text start:0x021203fc end:0x021207a8
 
 src/MgHideAndBooSeek_Spawn.c:
+    complete
     .text start:0x021207a8 end:0x021207dc
 
 src/func_ov006_021207dc.c:

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -52,6 +52,7 @@ src/Bird_Spawn.c:
     .text start:0x02111a30 end:0x02111a70
 
 src/_ZN11CastleWaterD1Ev.c:
+    complete
     .text start:0x02111a70 end:0x02111abc
 
 src/_ZN11CastleWaterD0Ev.c:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -67,6 +67,7 @@ src/func_ov010_02111984.c:
     .text start:0x02111984 end:0x02111998
 
 src/Trap_Spawn.c:
+    complete
     .text start:0x02111998 end:0x021119d0
 
 src/_ZN4TrapD1Ev.cpp:

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -36,9 +36,11 @@ src/SwitchPillar_Spawn.c:
     .text start:0x02111420 end:0x02111450
 
 src/_ZN12SwitchPillarD1Ev.c:
+    complete
     .text start:0x02111450 end:0x0211149c
 
 src/_ZN12SwitchPillarD0Ev.c:
+    complete
     .text start:0x0211149c end:0x021114fc
 
 src/_ZN12SwitchPillar16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov013/delinks.txt
+++ b/config/arm9/overlays/ov013/delinks.txt
@@ -33,6 +33,7 @@ src/func_ov013_0211133c.cpp:
     .text start:0x0211133c end:0x02111384
 
 src/ClockPaintingPendulum_Spawn.c:
+    complete
     .text start:0x02111384 end:0x021113bc
 
 src/_ZN22ClockPaintingHandShortD1Ev.cpp:

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -4,9 +4,11 @@
     .data       start:0x02113380 end:0x02114940 kind:data align:32
     .bss        start:0x02114940 end:0x021149e0 kind:bss align:32
 src/_ZN10ShutterBobD1Ev.c:
+    complete
     .text start:0x021111a0 end:0x021111f0
 
 src/_ZN10ShutterBobD0Ev.c:
+    complete
     .text start:0x021111f0 end:0x02111254
 
 src/_ZN10ShutterBob16CleanupResourcesEv.cpp:
@@ -22,6 +24,7 @@ src/_ZN10ShutterBob13InitResourcesEv.cpp:
     .text start:0x02111294 end:0x021112cc
 
 src/ShutterBob_Spawn.c:
+    complete
     .text start:0x021112cc end:0x02111308
 
 src/_ZN10ChainChompD1Ev.c:
@@ -138,9 +141,11 @@ src/ChainChomp_Spawn.cpp:
     .text start:0x02112d1c end:0x02112e0c
 
 src/_ZN15ChainChompFenceD1Ev.c:
+    complete
     .text start:0x02112e0c end:0x02112e50
 
 src/_ZN15ChainChompFenceD0Ev.c:
+    complete
     .text start:0x02112e50 end:0x02112ea8
 
 src/func_ov014_02112ea8.cpp:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -28,12 +28,15 @@ src/func_ov015_021112a0.cpp:
     .text start:0x021112a0 end:0x021112dc
 
 src/PoleBillboard_Spawn.c:
+    complete
     .text start:0x021112dc end:0x02111314
 
 src/_ZN13PoleBillboardD1Ev.c:
+    complete
     .text start:0x02111314 end:0x02111360
 
 src/_ZN13PoleBillboardD0Ev.c:
+    complete
     .text start:0x02111360 end:0x021113c0
 
 src/func_ov015_021113c0.cpp:
@@ -68,9 +71,11 @@ src/KnockDownPlank_Spawn.c:
     .text start:0x02111b68 end:0x02111ba0
 
 src/_ZN14KnockDownPlankD1Ev.c:
+    complete
     .text start:0x02111ba0 end:0x02111be4
 
 src/_ZN14KnockDownPlankD0Ev.c:
+    complete
     .text start:0x02111be4 end:0x02111c3c
 
 src/func_ov015_02111c3c.cpp:
@@ -164,9 +169,11 @@ src/MovingBarSmall_Spawn.c:
     .text start:0x02112260 end:0x02112290
 
 src/_ZN14MovingBarSmallD1Ev.c:
+    complete
     .text start:0x02112290 end:0x021122dc
 
 src/_ZN14MovingBarSmallD0Ev.c:
+    complete
     .text start:0x021122dc end:0x0211233c
 
 src/func_ov015_0211233c.cpp:
@@ -244,6 +251,7 @@ src/func_ov015_02112c98.c:
     .text start:0x02112c98 end:0x02112cb8
 
 src/RotatingPlatformWf_Spawn.c:
+    complete
     .text start:0x02112cb8 end:0x02112cf4
 
 src/_ZN11FallBlockWfD1Ev.c:

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -159,6 +159,7 @@ src/func_ov016_02112fa8.c:
     .text start:0x02112fa8 end:0x02112fbc
 
 src/FloatOnWaterPlatformJrb_Spawn.c:
+    complete
     .text start:0x02112fbc end:0x02112ff8
 
 src/_ZN23FloatOnWaterPlatformJrbD1Ev.c:

--- a/config/arm9/overlays/ov021/delinks.txt
+++ b/config/arm9/overlays/ov021/delinks.txt
@@ -123,9 +123,11 @@ src/RollingRock_Spawn.c:
     .text start:0x02112d64 end:0x02112db4
 
 src/_ZN10ShutterHmcD1Ev.c:
+    complete
     .text start:0x02112db4 end:0x02112e04
 
 src/_ZN10ShutterHmcD0Ev.c:
+    complete
     .text start:0x02112e04 end:0x02112e68
 
 src/_ZN10ShutterHmc16CleanupResourcesEv.cpp:
@@ -141,6 +143,7 @@ src/_ZN10ShutterHmc13InitResourcesEv.cpp:
     .text start:0x02112ec0 end:0x02112ed4
 
 src/ShutterHmc_Spawn.c:
+    complete
     .text start:0x02112ed4 end:0x02112f10
 
 src/__sinit_ov021_02113500.c:

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -53,12 +53,15 @@ src/func_ov022_02111670.c:
     .text start:0x02111670 end:0x02111688
 
 src/RotatingPlatformLll_Spawn.c:
+    complete
     .text start:0x02111688 end:0x021116c4
 
 src/_ZN19RotatingPlatformLllD1Ev.c:
+    complete
     .text start:0x021116c4 end:0x02111708
 
 src/_ZN19RotatingPlatformLllD0Ev.c:
+    complete
     .text start:0x02111708 end:0x02111760
 
 src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp:
@@ -163,15 +166,19 @@ src/_ZN21FloatingFloorLllSmall13InitResourcesEv.c:
     .text start:0x02112040 end:0x021120b8
 
 src/FloatingFloorLllSmall_Spawn.c:
+    complete
     .text start:0x021120b8 end:0x021120f4
 
 src/FloatingFloorLllBig_Spawn.c:
+    complete
     .text start:0x021120f4 end:0x02112130
 
 src/_ZN19FloatingFloorLllBigD1Ev.c:
+    complete
     .text start:0x02112130 end:0x02112174
 
 src/_ZN19FloatingFloorLllBigD0Ev.c:
+    complete
     .text start:0x02112174 end:0x021121cc
 
 src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov024/delinks.txt
+++ b/config/arm9/overlays/ov024/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02112880 end:0x02113960 kind:data align:32
     .bss        start:0x02113960 end:0x021139a0 kind:bss align:32
 src/_ZN10PyramidTopD1Ev.c:
+    complete
     .text start:0x021111a0 end:0x021111ec
 
 src/_ZN10PyramidTopD0Ev.c:
+    complete
     .text start:0x021111ec end:0x0211124c
 
 src/_ZN10PyramidTagD1Ev.cpp:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -77,9 +77,11 @@ src/Grindel_Spawn.c:
     .text start:0x02111cf4 end:0x02111d40
 
 src/_ZN11PyramidStepD1Ev.c:
+    complete
     .text start:0x02111d40 end:0x02111d8c
 
 src/_ZN11PyramidStepD0Ev.c:
+    complete
     .text start:0x02111d8c end:0x02111dec
 
 src/func_ov025_02111dec.cpp:

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02112fe0 end:0x02113be0 kind:data align:32
     .bss        start:0x02113be0 end:0x02113d20 kind:bss align:32
 src/_ZN10SlidingIceD1Ev.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/_ZN10SlidingIceD0Ev.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov027_0211123c.cpp:
@@ -62,6 +64,7 @@ src/func_ov027_0211181c.cpp:
     .text start:0x0211181c end:0x0211186c
 
 src/ChillBully_Spawn.c:
+    complete
     .text start:0x0211186c end:0x021118c8
 
 src/func_ov027_021118c8.c:

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -16,6 +16,7 @@ src/func_ov029_02111254.c:
     .text start:0x02111254 end:0x02111340
 
 src/FloatOnWaterPlatformWdwSquare_Spawn.c:
+    complete
     .text start:0x02111340 end:0x0211137c
 
 src/_ZN29FloatOnWaterPlatformWdwSquareD1Ev.c:
@@ -138,6 +139,7 @@ src/func_ov029_02111f58.c:
     .text start:0x02111f58 end:0x02112044
 
 src/FloatOnWaterPlatformWdwRectangle_Spawn.c:
+    complete
     .text start:0x02112044 end:0x02112080
 
 src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c:
@@ -155,12 +157,15 @@ src/_ZN32FloatOnWaterPlatformWdwRectangle13InitResourcesEv.c:
     .text start:0x02112148 end:0x02112168
 
 src/RotatingPlatformWdw_Spawn.c:
+    complete
     .text start:0x02112168 end:0x021121a4
 
 src/_ZN19RotatingPlatformWdwD1Ev.c:
+    complete
     .text start:0x021121a4 end:0x021121f0
 
 src/_ZN19RotatingPlatformWdwD0Ev.c:
+    complete
     .text start:0x021121f0 end:0x02112250
 
 src/func_ov029_02112250.cpp:
@@ -190,9 +195,11 @@ src/WDW_Water_Spawn.c:
     .text start:0x021125f8 end:0x02112630
 
 src/_ZN20SwitchActivatedPlankD1Ev.c:
+    complete
     .text start:0x02112630 end:0x0211267c
 
 src/_ZN20SwitchActivatedPlankD0Ev.c:
+    complete
     .text start:0x0211267c end:0x021126dc
 
 src/func_ov029_021126dc.c:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -32,6 +32,7 @@ src/func_ov030_02111410.cpp:
     .text start:0x02111410 end:0x02111524
 
 src/UkikiCage_Spawn.c:
+    complete
     .text start:0x02111524 end:0x0211155c
 
 src/_ZN9UkikiCageD1Ev.c:

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02112040 end:0x02112c60 kind:data align:32
     .bss        start:0x02112c60 end:0x02112ce0 kind:bss align:32
 src/_ZN16RotatingCogSmallD1Ev.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/_ZN16RotatingCogSmallD0Ev.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp:
@@ -38,9 +40,11 @@ src/RotatingClockHand_Spawn.c:
     .text start:0x021116bc end:0x021116ec
 
 src/_ZN17RotatingClockHandD1Ev.c:
+    complete
     .text start:0x021116ec end:0x02111738
 
 src/_ZN17RotatingClockHandD0Ev.c:
+    complete
     .text start:0x02111738 end:0x02111798
 
 src/func_ov035_02111798.c:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -49,6 +49,7 @@ src/func_ov036_0211150c.c:
     .text start:0x0211150c end:0x02111544
 
 src/RotatingPlatformRr_Spawn.c:
+    complete
     .text start:0x02111544 end:0x02111580
 
 src/_ZN18RotatingPlatformRrD1Ev.cpp:
@@ -121,9 +122,11 @@ src/DonutBlock_Spawn.c:
     .text start:0x02111cd8 end:0x02111d14
 
 src/_ZN10DonutBlockD1Ev.c:
+    complete
     .text start:0x02111d14 end:0x02111d58
 
 src/_ZN10DonutBlockD0Ev.c:
+    complete
     .text start:0x02111d58 end:0x02111db0
 
 src/_ZN10DonutBlock16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -46,12 +46,15 @@ src/func_ov043_021114c4.c:
     .text start:0x021114c4 end:0x021114dc
 
 src/RickshawBdw_Spawn.c:
+    complete
     .text start:0x021114dc end:0x02111518
 
 src/_ZN11RickshawBdwD1Ev.c:
+    complete
     .text start:0x02111518 end:0x02111568
 
 src/_ZN11RickshawBdwD0Ev.c:
+    complete
     .text start:0x02111568 end:0x021115cc
 
 src/_ZN11RickshawBdw16CleanupResourcesEv.c:
@@ -63,6 +66,7 @@ src/_ZN11RickshawBdw13InitResourcesEv.c:
     .text start:0x021115e0 end:0x021115f4
 
 src/RickshawPlatformBdw_Spawn.c:
+    complete
     .text start:0x021115f4 end:0x02111630
 
 src/_ZN19RickshawPlatformBdwD1Ev.cpp:

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -40,9 +40,11 @@ src/FireSeaElevator_Spawn.c:
     .text start:0x021114dc end:0x0211150c
 
 src/_ZN15FireSeaElevatorD1Ev.c:
+    complete
     .text start:0x0211150c end:0x02111558
 
 src/_ZN15FireSeaElevatorD0Ev.c:
+    complete
     .text start:0x02111558 end:0x021115b8
 
 src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp:
@@ -117,12 +119,15 @@ src/func_ov045_02111bdc.c:
     .text start:0x02111bdc end:0x02111bf4
 
 src/FloatingFloorBfs_Spawn.c:
+    complete
     .text start:0x02111bf4 end:0x02111c30
 
 src/_ZN16FloatingFloorBfsD1Ev.c:
+    complete
     .text start:0x02111c30 end:0x02111c80
 
 src/_ZN16FloatingFloorBfsD0Ev.c:
+    complete
     .text start:0x02111c80 end:0x02111ce4
 
 src/_ZN16FloatingFloorBfs16CleanupResourcesEv.c:
@@ -132,6 +137,7 @@ src/_ZN16FloatingFloorBfs13InitResourcesEv.c:
     .text start:0x02111cf8 end:0x02111d0c
 
 src/TiltingPlatformBfs_Spawn.c:
+    complete
     .text start:0x02111d0c end:0x02111d48
 
 src/_ZN12FallBlockBfsD1Ev.c:

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -19,12 +19,15 @@ src/func_ov047_02111268.c:
     .text start:0x02111268 end:0x02111280
 
 src/RickshawBs_Spawn.c:
+    complete
     .text start:0x02111280 end:0x021112bc
 
 src/_ZN10RickshawBsD1Ev.c:
+    complete
     .text start:0x021112bc end:0x0211130c
 
 src/_ZN10RickshawBsD0Ev.c:
+    complete
     .text start:0x0211130c end:0x02111370
 
 src/_ZN10RickshawBs16CleanupResourcesEv.c:
@@ -54,6 +57,7 @@ src/func_ov047_021114c0.c:
     .text start:0x021114c0 end:0x021114d4
 
 src/RickshawPlatformBs_Spawn.c:
+    complete
     .text start:0x021114d4 end:0x02111510
 
 src/_ZN18RickshawPlatformBsD1Ev.c:

--- a/config/arm9/overlays/ov052/delinks.txt
+++ b/config/arm9/overlays/ov052/delinks.txt
@@ -32,9 +32,11 @@ src/func_ov052_02111410.c:
     .text start:0x02111410 end:0x02111440
 
 src/_ZN14SquarePathLiftD1Ev.c:
+    complete
     .text start:0x02111440 end:0x02111484
 
 src/_ZN14SquarePathLiftD0Ev.c:
+    complete
     .text start:0x02111484 end:0x021114dc
 
 src/_ZN14SquarePathLift16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov056/delinks.txt
+++ b/config/arm9/overlays/ov056/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02112bc0 end:0x02113400 kind:data align:32
     .bss        start:0x02113400 end:0x02113440 kind:bss align:32
 src/_ZN17BigMovingIceBlockD1Ev.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/_ZN17BigMovingIceBlockD0Ev.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/_ZN17BigMovingIceBlock16CleanupResourcesEv.c:

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -427,9 +427,11 @@ src/BowserFire_Spawn.c:
     .text start:0x02117938 end:0x02117980
 
 src/_ZN18BowserFireSeaArenaD1Ev.c:
+    complete
     .text start:0x02117980 end:0x021179d4
 
 src/_ZN18BowserFireSeaArenaD0Ev.c:
+    complete
     .text start:0x021179d4 end:0x02117a3c
 
 src/func_ov060_02117a3c.c:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -135,6 +135,7 @@ src/_ZN5Bully13InitResourcesEv.cpp:
     .text start:0x02117424 end:0x02117444
 
 src/Bully_Spawn.c:
+    complete
     .text start:0x02117444 end:0x021174a0
 
 src/_ZN8BigBullyD1Ev.c:
@@ -164,6 +165,7 @@ src/_ZN8BigBully13InitResourcesEv.cpp:
     .text start:0x02117784 end:0x0211791c
 
 src/BigBully_Spawn.c:
+    complete
     .text start:0x0211791c end:0x02117978
 
 src/func_ov064_02117978.c:
@@ -218,12 +220,15 @@ src/func_ov064_02117fd4.c:
     .text start:0x02117fd4 end:0x02117fe8
 
 src/MetalNetLift_Spawn.c:
+    complete
     .text start:0x02117fe8 end:0x02118020
 
 src/_ZN12MetalNetLiftD1Ev.c:
+    complete
     .text start:0x02118020 end:0x02118070
 
 src/_ZN12MetalNetLiftD0Ev.c:
+    complete
     .text start:0x02118070 end:0x021180d4
 
 src/_ZN12MetalNetLift16CleanupResourcesEv.c:
@@ -235,6 +240,7 @@ src/_ZN12MetalNetLift13InitResourcesEv.c:
     .text start:0x021180e8 end:0x021180fc
 
 src/TiltingPlatformLll_Spawn.c:
+    complete
     .text start:0x021180fc end:0x02118138
 
 src/_ZN15RotatingFirebarD1Ev.c:
@@ -322,9 +328,11 @@ src/LavaBubble_Spawn.c:
     .text start:0x02118b10 end:0x02118b50
 
 src/_ZN19BowserPuzzleManagerD1Ev.c:
+    complete
     .text start:0x02118b50 end:0x02118b94
 
 src/_ZN19BowserPuzzleManagerD0Ev.c:
+    complete
     .text start:0x02118b94 end:0x02118bec
 
 src/func_ov064_02118bec.c:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -294,9 +294,11 @@ src/func_ov065_021196bc.c:
     .text start:0x021196bc end:0x021196d8
 
 src/_ZN15TtcRotatingCubeD1Ev.c:
+    complete
     .text start:0x021196d8 end:0x0211972c
 
 src/_ZN15TtcRotatingCubeD0Ev.c:
+    complete
     .text start:0x0211972c end:0x02119794
 
 src/func_ov065_02119794.c:
@@ -370,6 +372,7 @@ src/_ZN20TtcConveyorBeltLargeD1Ev.c:
     .text start:0x0211a494 end:0x0211a4e8
 
 src/_ZN20TtcConveyorBeltLargeD0Ev.c:
+    complete
     .text start:0x0211a4e8 end:0x0211a550
 
 src/func_ov065_0211a550.c:
@@ -437,12 +440,15 @@ src/func_ov065_0211b1d4.cpp:
     .text start:0x0211b1d4 end:0x0211b328
 
 src/TTC_MovingBar_Spawn.c:
+    complete
     .text start:0x0211b328 end:0x0211b360
 
 src/_ZN13TTC_MovingBarD1Ev.c:
+    complete
     .text start:0x0211b360 end:0x0211b3ac
 
 src/_ZN13TTC_MovingBarD0Ev.c:
+    complete
     .text start:0x0211b3ac end:0x0211b40c
 
 src/func_ov065_0211b40c.c:
@@ -473,9 +479,11 @@ src/TtcRotatingGear_Spawn.c:
     .text start:0x0211b7b8 end:0x0211b7f0
 
 src/_ZN15TtcRotatingGearD1Ev.c:
+    complete
     .text start:0x0211b7f0 end:0x0211b834
 
 src/_ZN15TtcRotatingGearD0Ev.c:
+    complete
     .text start:0x0211b834 end:0x0211b88c
 
 src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp:
@@ -501,9 +509,11 @@ src/TtcMovingCubeA_Spawn.c:
     .text start:0x0211bbac end:0x0211bbdc
 
 src/_ZN14TtcMovingCubeAD1Ev.c:
+    complete
     .text start:0x0211bbdc end:0x0211bc28
 
 src/_ZN14TtcMovingCubeAD0Ev.c:
+    complete
     .text start:0x0211bc28 end:0x0211bc88
 
 src/func_ov065_0211bc88.cpp:

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -226,9 +226,11 @@ src/BillBlaster_Spawn.c:
     .text start:0x021271b4 end:0x021271e4
 
 src/_ZN12FortressWallD1Ev.c:
+    complete
     .text start:0x021271e4 end:0x02127228
 
 src/_ZN12FortressWallD0Ev.c:
+    complete
     .text start:0x02127228 end:0x02127280
 
 src/func_ov079_02127280.cpp:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -110,9 +110,11 @@ src/ArrowPathLift_Spawn.c:
     .text start:0x021323cc end:0x02132404
 
 src/_ZN17SlidingPlatformWfD1Ev.c:
+    complete
     .text start:0x02132404 end:0x02132448
 
 src/_ZN17SlidingPlatformWfD0Ev.c:
+    complete
     .text start:0x02132448 end:0x021324a0
 
 src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp:
@@ -182,6 +184,7 @@ src/_ZN6Thwomp13InitResourcesEv.cpp:
     .text start:0x02132c84 end:0x02132cb8
 
 src/Thwomp_Spawn.c:
+    complete
     .text start:0x02132cb8 end:0x02132d04
 
 src/func_ov091_02132d04.c:

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -79,9 +79,11 @@ src/SeesawUtm_Spawn.c:
     .text start:0x02135fc4 end:0x02135ff4
 
 src/_ZN13UpDownLiftBbhD1Ev.c:
+    complete
     .text start:0x02135ff4 end:0x02136038
 
 src/_ZN13UpDownLiftBbhD0Ev.c:
+    complete
     .text start:0x02136038 end:0x02136090
 
 src/func_ov095_02136090.cpp:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x0213c360 end:0x0213c800 kind:data align:32
     .bss        start:0x0213c800 end:0x0213c960 kind:bss align:32
 src/_ZN14ArrowSignRightD1Ev.c:
+    complete
     .text start:0x02137be0 end:0x02137c2c
 
 src/_ZN14ArrowSignRightD0Ev.c:
+    complete
     .text start:0x02137c2c end:0x02137c8c
 
 src/func_ov098_02137c8c.c:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -315,6 +315,7 @@ src/func_ov100_021455a0.c:
     .text start:0x021455a0 end:0x0214589c
 
 src/Door_Spawn.c:
+    complete
     .text start:0x0214589c end:0x021458d4
 
 src/_ZN4DoorD1Ev.cpp:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x0214e0c0 end:0x0214e6e0 kind:data align:32
     .bss        start:0x0214e6e0 end:0x0214eaa0 kind:bss align:32
 src/_ZN13FortressTowerD1Ev.c:
+    complete
     .text start:0x02148a80 end:0x02148ac4
 
 src/_ZN13FortressTowerD0Ev.c:
+    complete
     .text start:0x02148ac4 end:0x02148b1c
 
 src/_ZN13FortressTower16CleanupResourcesEv.cpp:
@@ -50,9 +52,11 @@ src/StaticRock_Spawn.c:
     .text start:0x02148f8c end:0x02148fbc
 
 src/_ZN13QuestionBlockD1Ev.c:
+    complete
     .text start:0x02148fbc end:0x02149010
 
 src/_ZN13QuestionBlockD0Ev.c:
+    complete
     .text start:0x02149010 end:0x02149078
 
 src/func_ov102_02149078.c:

--- a/src/BigBully_Spawn.c
+++ b/src/BigBully_Spawn.c
@@ -7,15 +7,16 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 extern int _ZTV8BigBully[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV12daBDonketu_c */
+/* vtable identified: VT0 = data_ov064_0211b768 */
 int *BigBully_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1024);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)_ZTV12daBDonketu_c;
+        p[0] = (int)data_ov064_0211b768;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);

--- a/src/Bubble_Spawn.c
+++ b/src/Bubble_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_02108964[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV12daObjAbuku_c */
+/* vtable identified: VT0 = data_ov002_02108964 */
 int *Bubble_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(276);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV12daObjAbuku_c;
+        p[0] = (int)data_ov002_02108964;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/Bully_Spawn.c
+++ b/src/Bully_Spawn.c
@@ -7,15 +7,16 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 extern int _ZTV5Bully[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV11daDonketu_c */
+/* vtable identified: VT0 = data_ov064_0211b768 */
 int *Bully_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1024);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)_ZTV11daDonketu_c;
+        p[0] = (int)data_ov064_0211b768;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);

--- a/src/ChillBully_Spawn.c
+++ b/src/ChillBully_Spawn.c
@@ -7,15 +7,16 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov064_0211b768[];
 extern int data_ov027_02113930[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV12daIDonketu_c */
+/* vtable identified: VT0 = data_ov064_0211b768 */
 int *ChillBully_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1020);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)_ZTV12daIDonketu_c;
+        p[0] = (int)data_ov064_0211b768;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);

--- a/src/ClockPaintingPendulum_Spawn.c
+++ b/src/ClockPaintingPendulum_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_Model.h"
 #include "decl_common.h"
+extern int data_ov013_02112128[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjClockHuriko_c */
+/* vtable identified: VT0 = data_ov013_02112128 */
 int *ClockPaintingPendulum_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV18daObjClockHuriko_c;
+        p[0] = (int)data_ov013_02112128;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/Door_Spawn.c
+++ b/src/Door_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov100_02148188[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV8daDoor_c */
+/* vtable identified: VT0 = data_ov100_02148188 */
 int *Door_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(328);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV8daDoor_c;
+        p[0] = (int)data_ov100_02148188;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/FloatOnWaterPlatformJrb_Spawn.c
+++ b/src/FloatOnWaterPlatformJrb_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02108fdc[];
 extern int data_ov016_02114bcc[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjKi_Ita_c */
+/* vtable identified: VT0 = data_ov002_02108fdc */
 int *FloatOnWaterPlatformJrb_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(840);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV13daObjKi_Ita_c;
+        p[0] = (int)data_ov002_02108fdc;
         p[0] = (int)data_ov016_02114bcc;
     }
     return p;

--- a/src/FloatOnWaterPlatformWdwRectangle_Spawn.c
+++ b/src/FloatOnWaterPlatformWdwRectangle_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02108fdc[];
 extern int data_ov029_02113f44[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjWcObj06_c */
+/* vtable identified: VT0 = data_ov002_02108fdc */
 int *FloatOnWaterPlatformWdwRectangle_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(840);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV14daObjWcObj06_c;
+        p[0] = (int)data_ov002_02108fdc;
         p[0] = (int)data_ov029_02113f44;
     }
     return p;

--- a/src/FloatOnWaterPlatformWdwSquare_Spawn.c
+++ b/src/FloatOnWaterPlatformWdwSquare_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02108fdc[];
 extern int data_ov029_02113c2c[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjWcObj01_c */
+/* vtable identified: VT0 = data_ov002_02108fdc */
 int *FloatOnWaterPlatformWdwSquare_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(840);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV14daObjWcObj01_c;
+        p[0] = (int)data_ov002_02108fdc;
         p[0] = (int)data_ov029_02113c2c;
     }
     return p;

--- a/src/FloatingFloorBfs_Spawn.c
+++ b/src/FloatingFloorBfs_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_0210912c[];
 extern int data_ov045_02112f50[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV19daObjKm2_Ukishima_c */
+/* vtable identified: VT0 = data_ov002_0210912c */
 int *FloatingFloorBfs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(812);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV19daObjKm2_Ukishima_c;
+        p[0] = (int)data_ov002_0210912c;
         p[0] = (int)data_ov045_02112f50;
     }
     return p;

--- a/src/FloatingFloorLllBig_Spawn.c
+++ b/src/FloatingFloorLllBig_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_0210912c[];
 extern int _ZTV21FloatingFloorLllSmall[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c */
+/* vtable identified: VT0 = data_ov002_0210912c */
 int *FloatingFloorLllBig_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
+        p[0] = (int)data_ov002_0210912c;
         p[0] = (int)_ZTV21FloatingFloorLllSmall;
     }
     return p;

--- a/src/FloatingFloorLllSmall_Spawn.c
+++ b/src/FloatingFloorLllSmall_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_0210912c[];
 extern int _ZTV21FloatingFloorLllSmall[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c */
+/* vtable identified: VT0 = data_ov002_0210912c */
 int *FloatingFloorLllSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
+        p[0] = (int)data_ov002_0210912c;
         p[0] = (int)_ZTV21FloatingFloorLllSmall;
     }
     return p;

--- a/src/InvisiblePole_Spawn.c
+++ b/src/InvisiblePole_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_02108480[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV7daBar_c */
+/* vtable identified: VT0 = data_ov002_02108480 */
 int *InvisiblePole_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(264);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV7daBar_c;
+        p[0] = (int)data_ov002_02108480;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/InvisibleSecret_Spawn.c
+++ b/src/InvisibleSecret_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_0210b030[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV9daSCoin_c */
+/* vtable identified: VT0 = data_ov002_0210b030 */
 int *InvisibleSecret_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(276);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV9daSCoin_c;
+        p[0] = (int)data_ov002_0210b030;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/MetalNetLift_Spawn.c
+++ b/src/MetalNetLift_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov064_0211bc68[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjFl_Amilift_c */
+/* vtable identified: VT0 = data_ov064_0211bc68 */
 extern void _ZN7PathPtrC1Ev(void *);
 int *MetalNetLift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(872);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV17daObjFl_Amilift_c;
+        p[0] = (int)data_ov064_0211bc68;
         _ZN7PathPtrC1Ev((char *)p + 0x360);
     }
     return p;

--- a/src/MgBobOmbSquad_Spawn.c
+++ b/src/MgBobOmbSquad_Spawn.c
@@ -2,14 +2,15 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int data_ov006_0213d9cc[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV15dScMgPachinko_c */
+/* vtable identified: VT0 = data_ov006_0213d9cc */
 int *MgBobOmbSquad_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(23608);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)_ZTV15dScMgPachinko_c;
+        p[0] = (int)data_ov006_0213d9cc;
     }
     return p;
 }

--- a/src/MgHideAndBooSeek_Spawn.c
+++ b/src/MgHideAndBooSeek_Spawn.c
@@ -2,14 +2,15 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int data_ov006_0213fa0c[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13dScMgTeresa_c */
+/* vtable identified: VT0 = data_ov006_0213fa0c */
 int *MgHideAndBooSeek_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(19496);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)_ZTV13dScMgTeresa_c;
+        p[0] = (int)data_ov006_0213fa0c;
     }
     return p;
 }

--- a/src/MgLakituLaunch_Spawn.c
+++ b/src/MgLakituLaunch_Spawn.c
@@ -2,14 +2,15 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int data_ov006_0213dbbc[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16dScMgPachinko2_c */
+/* vtable identified: VT0 = data_ov006_0213dbbc */
 int *MgLakituLaunch_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(22140);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)_ZTV16dScMgPachinko2_c;
+        p[0] = (int)data_ov006_0213dbbc;
     }
     return p;
 }

--- a/src/MgPuzzlePanelPuzzlePanic_Spawn.c
+++ b/src/MgPuzzlePanelPuzzlePanic_Spawn.c
@@ -2,14 +2,15 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int data_ov006_0213e24c[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV12dScMgPanel_c */
+/* vtable identified: VT0 = data_ov006_0213e24c */
 int *MgPuzzlePanelPuzzlePanic_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(20460);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)_ZTV12dScMgPanel_c;
+        p[0] = (int)data_ov006_0213e24c;
     }
     return p;
 }

--- a/src/MgShuffleShell_Spawn.c
+++ b/src/MgShuffleShell_Spawn.c
@@ -2,14 +2,15 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int data_ov006_0213c304[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14dScMgCurling_c */
+/* vtable identified: VT0 = data_ov006_0213c304 */
 int *MgShuffleShell_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(20204);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)_ZTV14dScMgCurling_c;
+        p[0] = (int)data_ov006_0213c304;
     }
     return p;
 }

--- a/src/MgWanted_Spawn.c
+++ b/src/MgWanted_Spawn.c
@@ -2,14 +2,15 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int data_ov006_0213cf10[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV12dScMgLuigi_c */
+/* vtable identified: VT0 = data_ov006_0213cf10 */
 int *MgWanted_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(21596);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)_ZTV12dScMgLuigi_c;
+        p[0] = (int)data_ov006_0213cf10;
     }
     return p;
 }

--- a/src/PoleBillboard_Spawn.c
+++ b/src/PoleBillboard_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_Model.h"
 #include "decl_common.h"
+extern int data_ov015_02114360[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjBkBillboard_c */
+/* vtable identified: VT0 = data_ov015_02114360 */
 int *PoleBillboard_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(292);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV18daObjBkBillboard_c;
+        p[0] = (int)data_ov015_02114360;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/PushBlock_Spawn.c
+++ b/src/PushBlock_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_Platform.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov002_021096b0[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjPushblock_c */
+/* vtable identified: VT0 = data_ov002_021096b0 */
 int *PushBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1268);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV16daObjPushblock_c;
+        p[0] = (int)data_ov002_021096b0;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/RickshawBdw_Spawn.c
+++ b/src/RickshawBdw_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02109320[];
 extern int data_ov043_0211238c[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV21daObjKm1_Kurumajiku_c */
+/* vtable identified: VT0 = data_ov002_02109320 */
 int *RickshawBdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV21daObjKm1_Kurumajiku_c;
+        p[0] = (int)data_ov002_02109320;
         p[0] = (int)data_ov043_0211238c;
     }
     return p;

--- a/src/RickshawBs_Spawn.c
+++ b/src/RickshawBs_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02109320[];
 extern int data_ov047_021122a0[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV21daObjKm3_Kurumajiku_c */
+/* vtable identified: VT0 = data_ov002_02109320 */
 int *RickshawBs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV21daObjKm3_Kurumajiku_c;
+        p[0] = (int)data_ov002_02109320;
         p[0] = (int)data_ov047_021122a0;
     }
     return p;

--- a/src/RickshawPlatformBdw_Spawn.c
+++ b/src/RickshawPlatformBdw_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02109278[];
 extern int _ZTV11RickshawBdw[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c */
+/* vtable identified: VT0 = data_ov002_02109278 */
 int *RickshawPlatformBdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV17daObjKm1_Kuruma_c;
+        p[0] = (int)data_ov002_02109278;
         p[0] = (int)_ZTV11RickshawBdw;
     }
     return p;

--- a/src/RickshawPlatformBs_Spawn.c
+++ b/src/RickshawPlatformBs_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02109278[];
 extern int data_ov047_0211244c[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjKm3_Kuruma_c */
+/* vtable identified: VT0 = data_ov002_02109278 */
 int *RickshawPlatformBs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV17daObjKm3_Kuruma_c;
+        p[0] = (int)data_ov002_02109278;
         p[0] = (int)data_ov047_0211244c;
     }
     return p;

--- a/src/RotatingPlatformLll_Spawn.c
+++ b/src/RotatingPlatformLll_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_021091d4[];
 extern int data_ov022_02113de8[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjFl_Koma_D_c */
+/* vtable identified: VT0 = data_ov002_021091d4 */
 int *RotatingPlatformLll_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV16daObjFl_Koma_D_c;
+        p[0] = (int)data_ov002_021091d4;
         p[0] = (int)data_ov022_02113de8;
     }
     return p;

--- a/src/RotatingPlatformRr_Spawn.c
+++ b/src/RotatingPlatformRr_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_021091d4[];
 extern int data_ov036_02113b74[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV19daObjRc_Kaitendai_c */
+/* vtable identified: VT0 = data_ov002_021091d4 */
 int *RotatingPlatformRr_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV19daObjRc_Kaitendai_c;
+        p[0] = (int)data_ov002_021091d4;
         p[0] = (int)data_ov036_02113b74;
     }
     return p;

--- a/src/RotatingPlatformWdw_Spawn.c
+++ b/src/RotatingPlatformWdw_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_021091d4[];
 extern int _ZTV32FloatOnWaterPlatformWdwRectangle[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c */
+/* vtable identified: VT0 = data_ov002_021091d4 */
 int *RotatingPlatformWdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV15daObjWc_Obj07_c;
+        p[0] = (int)data_ov002_021091d4;
         p[0] = (int)_ZTV32FloatOnWaterPlatformWdwRectangle;
     }
     return p;

--- a/src/RotatingPlatformWf_Spawn.c
+++ b/src/RotatingPlatformWf_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_021091d4[];
 extern int data_ov015_021147e8[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjBk_Ukisima_c */
+/* vtable identified: VT0 = data_ov002_021091d4 */
 int *RotatingPlatformWf_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV17daObjBk_Ukisima_c;
+        p[0] = (int)data_ov002_021091d4;
         p[0] = (int)data_ov015_021147e8;
     }
     return p;

--- a/src/Seaweed_Spawn.c
+++ b/src/Seaweed_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov002_02109bb8[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjWakame_c */
+/* vtable identified: VT0 = data_ov002_02109bb8 */
 int *Seaweed_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(312);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV13daObjWakame_c;
+        p[0] = (int)data_ov002_02109bb8;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/ShutterBob_Spawn.c
+++ b/src/ShutterBob_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_021099e4[];
 extern int _ZTV10ShutterBob[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjBSwdoor_c */
+/* vtable identified: VT0 = data_ov002_021099e4 */
 int *ShutterBob_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(804);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV14daObjBSwdoor_c;
+        p[0] = (int)data_ov002_021099e4;
         p[0] = (int)_ZTV10ShutterBob;
     }
     return p;

--- a/src/ShutterHmc_Spawn.c
+++ b/src/ShutterHmc_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_021099e4[];
 extern int _ZTV10ShutterHmc[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCvShutter_c */
+/* vtable identified: VT0 = data_ov002_021099e4 */
 int *ShutterHmc_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(804);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV16daObjCvShutter_c;
+        p[0] = (int)data_ov002_021099e4;
         p[0] = (int)_ZTV10ShutterHmc;
     }
     return p;

--- a/src/TTC_MovingBar_Spawn.c
+++ b/src/TTC_MovingBar_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_Platform.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov065_0211d2b4[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha05_c */
+/* vtable identified: VT0 = data_ov065_0211d2b4 */
 int *TTC_MovingBar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(916);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV16daObjCtMecha05_c;
+        p[0] = (int)data_ov065_0211d2b4;
         _ZN11ShadowModelC1Ev((char *)p + 0x33c);
     }
     return p;

--- a/src/Thwomp_Spawn.c
+++ b/src/Thwomp_Spawn.c
@@ -5,15 +5,16 @@
 #include "decl_ShadowModel.h"
 #include "decl_TextureSequence.h"
 #include "decl_common.h"
+extern int data_ov091_021351fc[];
 extern int _ZTV6Thwomp[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV7daDsn_c */
+/* vtable identified: VT0 = data_ov091_021351fc */
 int *Thwomp_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(932);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV7daDsn_c;
+        p[0] = (int)data_ov091_021351fc;
         _ZN15TextureSequenceC1Ev((char *)p + 0x324);
         _ZN11ShadowModelC1Ev((char *)p + 0x338);
         p[0] = (int)_ZTV6Thwomp;

--- a/src/TiltingPlatformBfs_Spawn.c
+++ b/src/TiltingPlatformBfs_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02109084[];
 extern int _ZTV16FloatingFloorBfs[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c */
+/* vtable identified: VT0 = data_ov002_02109084 */
 int *TiltingPlatformBfs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(848);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV15daObjKm2_Gura_c;
+        p[0] = (int)data_ov002_02109084;
         p[0] = (int)_ZTV16FloatingFloorBfs;
     }
     return p;

--- a/src/TiltingPlatformLll_Spawn.c
+++ b/src/TiltingPlatformLll_Spawn.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_02109084[];
 extern int _ZTV12MetalNetLift[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjFl_Gura_c */
+/* vtable identified: VT0 = data_ov002_02109084 */
 int *TiltingPlatformLll_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(848);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV14daObjFl_Gura_c;
+        p[0] = (int)data_ov002_02109084;
         p[0] = (int)_ZTV12MetalNetLift;
     }
     return p;

--- a/src/Trap_Spawn.c
+++ b/src/Trap_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_Model.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov010_02112ae4[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjC1_Trap_c */
+/* vtable identified: VT0 = data_ov010_02112ae4 */
 int *Trap_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(944);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV14daObjC1_Trap_c;
+        p[0] = (int)data_ov010_02112ae4;
         _ZN5ModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/UkikiCage_Spawn.c
+++ b/src/UkikiCage_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_Platform.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov030_02115974[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjHmBskt_c */
+/* vtable identified: VT0 = data_ov030_02115974 */
 int *UkikiCage_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1248);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV13daObjHmBskt_c;
+        p[0] = (int)data_ov030_02115974;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/Warp_Spawn.c
+++ b/src/Warp_Spawn.c
@@ -4,14 +4,15 @@
 #include "decl_ActorBase.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_0210acbc[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV11daWarpkun_c */
+/* vtable identified: VT0 = data_ov002_0210acbc */
 int *Warp_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(264);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV11daWarpkun_c;
+        p[0] = (int)data_ov002_0210acbc;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/_ZN10DonutBlockD0Ev.c
+++ b/src/_ZN10DonutBlockD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10DonutBlock[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjRc_Guruguru_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10DonutBlock; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN10DonutBlockD0Ev(int *t)
 {
-    t[0] = (int)_ZTV18daObjRc_Guruguru_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10DonutBlock;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10DonutBlockD1Ev.c
+++ b/src/_ZN10DonutBlockD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10DonutBlock[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjRc_Guruguru_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10DonutBlock; VT1 = _ZTV8Platform */
 int *_ZN10DonutBlockD1Ev(int *t)
 {
-    t[0] = (int)_ZTV18daObjRc_Guruguru_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10DonutBlock;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10PyramidTopD0Ev.c
+++ b/src/_ZN10PyramidTopD0Ev.c
@@ -4,14 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjDlPyramid_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjDlPyramid_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN10PyramidTopD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjDlPyramid_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10PyramidTopD1Ev.c
+++ b/src/_ZN10PyramidTopD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjDlPyramid_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjDlPyramid_c; VT1 = _ZTV8Platform */
 int *_ZN10PyramidTopD1Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjDlPyramid_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10RickshawBsD0Ev.c
+++ b/src/_ZN10RickshawBsD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10RickshawBs[];
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10RickshawBs; VT1 = data_ov002_021091d4 */
 extern void *data_020a0eac;
 int *_ZN10RickshawBsD0Ev(int *t)
 {
-    t[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10RickshawBs;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10RickshawBsD1Ev.c
+++ b/src/_ZN10RickshawBsD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10RickshawBs[];
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10RickshawBs; VT1 = data_ov002_021091d4 */
 int *_ZN10RickshawBsD1Ev(int *t)
 {
-    t[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10RickshawBs;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10ShutterBobD0Ev.c
+++ b/src/_ZN10ShutterBobD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10ShutterBob[];
+extern int data_ov002_021099e4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjBSwdoor_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10ShutterBob; VT1 = data_ov002_021099e4 */
 extern void *data_020a0eac;
 int *_ZN10ShutterBobD0Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjBSwdoor_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10ShutterBob;
+    t[0] = (int)data_ov002_021099e4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10ShutterBobD1Ev.c
+++ b/src/_ZN10ShutterBobD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10ShutterBob[];
+extern int data_ov002_021099e4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjBSwdoor_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10ShutterBob; VT1 = data_ov002_021099e4 */
 int *_ZN10ShutterBobD1Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjBSwdoor_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10ShutterBob;
+    t[0] = (int)data_ov002_021099e4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10ShutterHmcD0Ev.c
+++ b/src/_ZN10ShutterHmcD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10ShutterHmc[];
+extern int data_ov002_021099e4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCvShutter_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10ShutterHmc; VT1 = data_ov002_021099e4 */
 extern void *data_020a0eac;
 int *_ZN10ShutterHmcD0Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjCvShutter_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10ShutterHmc;
+    t[0] = (int)data_ov002_021099e4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10ShutterHmcD1Ev.c
+++ b/src/_ZN10ShutterHmcD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10ShutterHmc[];
+extern int data_ov002_021099e4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCvShutter_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10ShutterHmc; VT1 = data_ov002_021099e4 */
 int *_ZN10ShutterHmcD1Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjCvShutter_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10ShutterHmc;
+    t[0] = (int)data_ov002_021099e4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10SlidingIceD0Ev.c
+++ b/src/_ZN10SlidingIceD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10SlidingIce[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjSlIceBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10SlidingIce; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN10SlidingIceD0Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjSlIceBlock_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10SlidingIce;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10SlidingIceD1Ev.c
+++ b/src/_ZN10SlidingIceD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10SlidingIce[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjSlIceBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10SlidingIce; VT1 = _ZTV8Platform */
 int *_ZN10SlidingIceD1Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjSlIceBlock_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10SlidingIce;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10StarSwitchD0Ev.c
+++ b/src/_ZN10StarSwitchD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10StarSwitch[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjSwitch_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10StarSwitch; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN10StarSwitchD0Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjSwitch_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10StarSwitch;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10StarSwitchD1Ev.c
+++ b/src/_ZN10StarSwitchD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV10StarSwitch[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjSwitch_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10StarSwitch; VT1 = _ZTV8Platform */
 int *_ZN10StarSwitchD1Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjSwitch_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV10StarSwitch;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11CannonHatchD0Ev.c
+++ b/src/_ZN11CannonHatchD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV11CannonHatch[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV20daObjCannonShutter_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV11CannonHatch; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN11CannonHatchD0Ev(int *t)
 {
-    t[0] = (int)_ZTV20daObjCannonShutter_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV11CannonHatch;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11CannonHatchD1Ev.c
+++ b/src/_ZN11CannonHatchD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV11CannonHatch[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV20daObjCannonShutter_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV11CannonHatch; VT1 = _ZTV8Platform */
 int *_ZN11CannonHatchD1Ev(int *t)
 {
-    t[0] = (int)_ZTV20daObjCannonShutter_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV11CannonHatch;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11CastleWaterD1Ev.c
+++ b/src/_ZN11CastleWaterD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjMcWater_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjMcWater_c; VT1 = _ZTV8Platform */
 int *_ZN11CastleWaterD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjMcWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11PyramidStepD0Ev.c
+++ b/src/_ZN11PyramidStepD0Ev.c
@@ -4,14 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjDpBrock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjDpBrock_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN11PyramidStepD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjDpBrock_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11PyramidStepD1Ev.c
+++ b/src/_ZN11PyramidStepD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjDpBrock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjDpBrock_c; VT1 = _ZTV8Platform */
 int *_ZN11PyramidStepD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjDpBrock_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11RickshawBdwD0Ev.c
+++ b/src/_ZN11RickshawBdwD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV11RickshawBdw[];
+extern int data_ov002_02109278[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV11RickshawBdw; VT1 = data_ov002_02109278 */
 extern void *data_020a0eac;
 int *_ZN11RickshawBdwD0Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjKm1_Kuruma_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV11RickshawBdw;
+    t[0] = (int)data_ov002_02109278;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN11RickshawBdwD1Ev.c
+++ b/src/_ZN11RickshawBdwD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV11RickshawBdw[];
+extern int data_ov002_02109278[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV11RickshawBdw; VT1 = data_ov002_02109278 */
 int *_ZN11RickshawBdwD1Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjKm1_Kuruma_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV11RickshawBdw;
+    t[0] = (int)data_ov002_02109278;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12FortressWallD0Ev.c
+++ b/src/_ZN12FortressWallD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV12FortressWall[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjBk_Kabe_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV12FortressWall; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN12FortressWallD0Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjBk_Kabe_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV12FortressWall;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12FortressWallD1Ev.c
+++ b/src/_ZN12FortressWallD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV12FortressWall[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjBk_Kabe_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV12FortressWall; VT1 = _ZTV8Platform */
 int *_ZN12FortressWallD1Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjBk_Kabe_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV12FortressWall;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12MetalNetLiftD0Ev.c
+++ b/src/_ZN12MetalNetLiftD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV12MetalNetLift[];
+extern int data_ov002_02109084[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjFl_Gura_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV12MetalNetLift; VT1 = data_ov002_02109084 */
 extern void *data_020a0eac;
 int *_ZN12MetalNetLiftD0Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjFl_Gura_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV12MetalNetLift;
+    t[0] = (int)data_ov002_02109084;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12MetalNetLiftD1Ev.c
+++ b/src/_ZN12MetalNetLiftD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV12MetalNetLift[];
+extern int data_ov002_02109084[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjFl_Gura_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV12MetalNetLift; VT1 = data_ov002_02109084 */
 int *_ZN12MetalNetLiftD1Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjFl_Gura_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV12MetalNetLift;
+    t[0] = (int)data_ov002_02109084;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12SwitchPillarD0Ev.c
+++ b/src/_ZN12SwitchPillarD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjC0Water_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjC0Water_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN12SwitchPillarD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjC0Water_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12SwitchPillarD1Ev.c
+++ b/src/_ZN12SwitchPillarD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjC0Water_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjC0Water_c; VT1 = _ZTV8Platform */
 int *_ZN12SwitchPillarD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjC0Water_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13BigBrickBlockD0Ev.c
+++ b/src/_ZN13BigBrickBlockD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV13BigBrickBlock[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjBlockL_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13BigBrickBlock; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN13BigBrickBlockD0Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjBlockL_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV13BigBrickBlock;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13BigBrickBlockD1Ev.c
+++ b/src/_ZN13BigBrickBlockD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV13BigBrickBlock[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjBlockL_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13BigBrickBlock; VT1 = _ZTV8Platform */
 int *_ZN13BigBrickBlockD1Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjBlockL_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV13BigBrickBlock;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13FortressTowerD0Ev.c
+++ b/src/_ZN13FortressTowerD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV13FortressTower[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjSimpleBg_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13FortressTower; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN13FortressTowerD0Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjSimpleBg_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV13FortressTower;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13FortressTowerD1Ev.c
+++ b/src/_ZN13FortressTowerD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV13FortressTower[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjSimpleBg_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13FortressTower; VT1 = _ZTV8Platform */
 int *_ZN13FortressTowerD1Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjSimpleBg_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV13FortressTower;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
+++ b/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
@@ -6,6 +6,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "HeapAllocator.h"
+extern int data_020a4d34;
+extern char data_020a4d38;
 extern "C" {
 extern void* _ZN18NestedHeapIterator10FindNestedEPv(void* ptr);
 extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(void* iter, void* node);
@@ -22,9 +24,9 @@ void _ZN13HeapAllocatorC1EjPvPvj(struct HeapAllocator *self, u32 magic, void* a,
         *p |= (size & 0xffu);
     }
     _ZN18NestedHeapIteratorC1Ej(((char*)self) + 0xc, 4);
-    if (_ZN6Memory25isRootHeapIterInitializedE == 0) {
-        _ZN18NestedHeapIteratorC1Ej(&_ZN6Memory16rootHeapIteratorE, 4);
-        _ZN6Memory25isRootHeapIterInitializedE = 1;
+    if (data_020a4d34 == 0) {
+        _ZN18NestedHeapIteratorC1Ej(&data_020a4d38, 4);
+        data_020a4d34 = 1;
     }
     {
         void* it = _ZN18NestedHeapIterator10FindNestedEPv(((char*)self));

--- a/src/_ZN13PoleBillboardD0Ev.c
+++ b/src/_ZN13PoleBillboardD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjBk_Botaosi_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV17daObjBk_Botaosi_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN13PoleBillboardD0Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjBk_Botaosi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13PoleBillboardD1Ev.c
+++ b/src/_ZN13PoleBillboardD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjBk_Botaosi_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV17daObjBk_Botaosi_c; VT1 = _ZTV8Platform */
 int *_ZN13PoleBillboardD1Ev(int *t)
 {
     t[0] = (int)_ZTV17daObjBk_Botaosi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13QuestionBlockD0Ev.c
+++ b/src/_ZN13QuestionBlockD0Ev.c
@@ -6,15 +6,16 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjHatenaBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjHatenaBlock_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN13QuestionBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjHatenaBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x384);
     _ZN9ModelAnimD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13QuestionBlockD1Ev.c
+++ b/src/_ZN13QuestionBlockD1Ev.c
@@ -6,14 +6,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjHatenaBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjHatenaBlock_c; VT1 = _ZTV8Platform */
 int *_ZN13QuestionBlockD1Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjHatenaBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x384);
     _ZN9ModelAnimD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13TTC_MovingBarD0Ev.c
+++ b/src/_ZN13TTC_MovingBarD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjCtKaitendai_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjCtKaitendai_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN13TTC_MovingBarD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjCtKaitendai_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13TTC_MovingBarD1Ev.c
+++ b/src/_ZN13TTC_MovingBarD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjCtKaitendai_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjCtKaitendai_c; VT1 = _ZTV8Platform */
 int *_ZN13TTC_MovingBarD1Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjCtKaitendai_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13UpDownLiftBbhD0Ev.c
+++ b/src/_ZN13UpDownLiftBbhD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV13UpDownLiftBbh[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10daUdlift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13UpDownLiftBbh; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN13UpDownLiftBbhD0Ev(int *t)
 {
-    t[0] = (int)_ZTV10daUdlift_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV13UpDownLiftBbh;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13UpDownLiftBbhD1Ev.c
+++ b/src/_ZN13UpDownLiftBbhD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV13UpDownLiftBbh[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10daUdlift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13UpDownLiftBbh; VT1 = _ZTV8Platform */
 int *_ZN13UpDownLiftBbhD1Ev(int *t)
 {
-    t[0] = (int)_ZTV10daUdlift_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV13UpDownLiftBbh;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14ArrowSignRightD0Ev.c
+++ b/src/_ZN14ArrowSignRightD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjYajirusi_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjYajirusi_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN14ArrowSignRightD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjYajirusi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14ArrowSignRightD1Ev.c
+++ b/src/_ZN14ArrowSignRightD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjYajirusi_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjYajirusi_c; VT1 = _ZTV8Platform */
 int *_ZN14ArrowSignRightD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjYajirusi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14BlueCoinSwitchD1Ev.c
+++ b/src/_ZN14BlueCoinSwitchD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV14BlueCoinSwitch[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjBC_Switch_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14BlueCoinSwitch; VT1 = _ZTV8Platform */
 int *_ZN14BlueCoinSwitchD1Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjBC_Switch_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV14BlueCoinSwitch;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14KnockDownPlankD0Ev.c
+++ b/src/_ZN14KnockDownPlankD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV14KnockDownPlank[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV19daObjBk_Dossunbar_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14KnockDownPlank; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN14KnockDownPlankD0Ev(int *t)
 {
-    t[0] = (int)_ZTV19daObjBk_Dossunbar_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV14KnockDownPlank;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14KnockDownPlankD1Ev.c
+++ b/src/_ZN14KnockDownPlankD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV14KnockDownPlank[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV19daObjBk_Dossunbar_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14KnockDownPlank; VT1 = _ZTV8Platform */
 int *_ZN14KnockDownPlankD1Ev(int *t)
 {
-    t[0] = (int)_ZTV19daObjBk_Dossunbar_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV14KnockDownPlank;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14MovingBarSmallD0Ev.c
+++ b/src/_ZN14MovingBarSmallD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjBk_Lift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjBk_Lift_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN14MovingBarSmallD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjBk_Lift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14MovingBarSmallD1Ev.c
+++ b/src/_ZN14MovingBarSmallD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjBk_Lift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjBk_Lift_c; VT1 = _ZTV8Platform */
 int *_ZN14MovingBarSmallD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjBk_Lift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14SquarePathLiftD0Ev.c
+++ b/src/_ZN14SquarePathLiftD0Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjEmmYuka_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjEmmYuka_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN14SquarePathLiftD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjEmmYuka_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14SquarePathLiftD1Ev.c
+++ b/src/_ZN14SquarePathLiftD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjEmmYuka_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjEmmYuka_c; VT1 = _ZTV8Platform */
 int *_ZN14SquarePathLiftD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjEmmYuka_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14TtcMovingCubeAD0Ev.c
+++ b/src/_ZN14TtcMovingCubeAD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha09_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha09_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN14TtcMovingCubeAD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha09_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14TtcMovingCubeAD1Ev.c
+++ b/src/_ZN14TtcMovingCubeAD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha09_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha09_c; VT1 = _ZTV8Platform */
 int *_ZN14TtcMovingCubeAD1Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha09_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15ChainChompFenceD0Ev.c
+++ b/src/_ZN15ChainChompFenceD0Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV15ChainChompFence[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15ChainChompFence */
 extern void *data_020a0eac;
 int *_ZN15ChainChompFenceD0Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV15ChainChompFence;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN15ChainChompFenceD1Ev.c
+++ b/src/_ZN15ChainChompFenceD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV15ChainChompFence[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15ChainChompFence */
 int *_ZN15ChainChompFenceD1Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV15ChainChompFence;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN15FireSeaElevatorD0Ev.c
+++ b/src/_ZN15FireSeaElevatorD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingCylinderClsn.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjKm2_Ami_Bou_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjKm2_Ami_Bou_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN15FireSeaElevatorD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjKm2_Ami_Bou_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15FireSeaElevatorD1Ev.c
+++ b/src/_ZN15FireSeaElevatorD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingCylinderClsn.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjKm2_Ami_Bou_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjKm2_Ami_Bou_c; VT1 = _ZTV8Platform */
 int *_ZN15FireSeaElevatorD1Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjKm2_Ami_Bou_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15TtcRotatingCubeD0Ev.c
+++ b/src/_ZN15TtcRotatingCubeD0Ev.c
@@ -5,15 +5,16 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV20daObjCtRotateBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV20daObjCtRotateBlock_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN15TtcRotatingCubeD0Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjCtRotateBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x380);
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15TtcRotatingCubeD1Ev.c
+++ b/src/_ZN15TtcRotatingCubeD1Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV20daObjCtRotateBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV20daObjCtRotateBlock_c; VT1 = _ZTV8Platform */
 int *_ZN15TtcRotatingCubeD1Ev(int *t)
 {
     t[0] = (int)_ZTV20daObjCtRotateBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x380);
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15TtcRotatingGearD0Ev.c
+++ b/src/_ZN15TtcRotatingGearD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV15TtcRotatingGear[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha08_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15TtcRotatingGear; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN15TtcRotatingGearD0Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjCtMecha08_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV15TtcRotatingGear;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15TtcRotatingGearD1Ev.c
+++ b/src/_ZN15TtcRotatingGearD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV15TtcRotatingGear[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha08_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15TtcRotatingGear; VT1 = _ZTV8Platform */
 int *_ZN15TtcRotatingGearD1Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjCtMecha08_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV15TtcRotatingGear;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN16FloatingFloorBfsD0Ev.c
+++ b/src/_ZN16FloatingFloorBfsD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV16FloatingFloorBfs[];
+extern int data_ov002_02109084[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16FloatingFloorBfs; VT1 = data_ov002_02109084 */
 extern void *data_020a0eac;
 int *_ZN16FloatingFloorBfsD0Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjKm2_Gura_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV16FloatingFloorBfs;
+    t[0] = (int)data_ov002_02109084;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN16FloatingFloorBfsD1Ev.c
+++ b/src/_ZN16FloatingFloorBfsD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV16FloatingFloorBfs[];
+extern int data_ov002_02109084[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16FloatingFloorBfs; VT1 = data_ov002_02109084 */
 int *_ZN16FloatingFloorBfsD1Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjKm2_Gura_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV16FloatingFloorBfs;
+    t[0] = (int)data_ov002_02109084;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN16RotatingCogSmallD0Ev.c
+++ b/src/_ZN16RotatingCogSmallD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV16RotatingCogSmall[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha10_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16RotatingCogSmall; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN16RotatingCogSmallD0Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjCtMecha10_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV16RotatingCogSmall;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN16RotatingCogSmallD1Ev.c
+++ b/src/_ZN16RotatingCogSmallD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV16RotatingCogSmall[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha10_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16RotatingCogSmall; VT1 = _ZTV8Platform */
 int *_ZN16RotatingCogSmallD1Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjCtMecha10_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV16RotatingCogSmall;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17BigMovingIceBlockD0Ev.c
+++ b/src/_ZN17BigMovingIceBlockD0Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjEwmIceBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjEwmIceBlock_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN17BigMovingIceBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjEwmIceBlock_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17BigMovingIceBlockD1Ev.c
+++ b/src/_ZN17BigMovingIceBlockD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjEwmIceBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjEwmIceBlock_c; VT1 = _ZTV8Platform */
 int *_ZN17BigMovingIceBlockD1Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjEwmIceBlock_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17RotatingClockHandD0Ev.c
+++ b/src/_ZN17RotatingClockHandD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha11_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha11_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN17RotatingClockHandD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha11_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x328);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17RotatingClockHandD1Ev.c
+++ b/src/_ZN17RotatingClockHandD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha11_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha11_c; VT1 = _ZTV8Platform */
 int *_ZN17RotatingClockHandD1Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha11_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x328);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17SlidingPlatformWfD0Ev.c
+++ b/src/_ZN17SlidingPlatformWfD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV17SlidingPlatformWf[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjSimpleLift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV17SlidingPlatformWf; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN17SlidingPlatformWfD0Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjSimpleLift_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV17SlidingPlatformWf;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17SlidingPlatformWfD1Ev.c
+++ b/src/_ZN17SlidingPlatformWfD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV17SlidingPlatformWf[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjSimpleLift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV17SlidingPlatformWf; VT1 = _ZTV8Platform */
 int *_ZN17SlidingPlatformWfD1Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjSimpleLift_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV17SlidingPlatformWf;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN18BowserFireSeaArenaD0Ev.c
+++ b/src/_ZN18BowserFireSeaArenaD0Ev.c
@@ -4,15 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10daKpa2Bg_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10daKpa2Bg_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN18BowserFireSeaArenaD0Ev(int *t)
 {
     t[0] = (int)_ZTV10daKpa2Bg_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x374);
     _ZN5ModelD1Ev((char *)t + 0x324);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN18BowserFireSeaArenaD1Ev.c
+++ b/src/_ZN18BowserFireSeaArenaD1Ev.c
@@ -4,14 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10daKpa2Bg_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV10daKpa2Bg_c; VT1 = _ZTV8Platform */
 int *_ZN18BowserFireSeaArenaD1Ev(int *t)
 {
     t[0] = (int)_ZTV10daKpa2Bg_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x374);
     _ZN5ModelD1Ev((char *)t + 0x324);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN18MovingCylinderClsnD1Ev.c
+++ b/src/_ZN18MovingCylinderClsnD1Ev.c
@@ -3,6 +3,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "MovingCylinderClsn.h"
+extern void* _ZTV18MovingCylinderClsn[];
 /* _ZN18MovingCylinderClsnD1Ev at 0x020149a4
  * Single-vtable D1/D2 destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call immediate-base destructor, return this.
@@ -12,7 +13,7 @@ struct Obj { void *vtable; };
 extern void base_dtor_MovingCylinderClsn(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN18MovingCylinderClsnD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_MovingCylinderClsn;
+    thiz->vtable = (void *)_ZTV18MovingCylinderClsn;
     base_dtor_MovingCylinderClsn(thiz);
     return thiz;
 }

--- a/src/_ZN18MovingCylinderClsnD2Ev.c
+++ b/src/_ZN18MovingCylinderClsnD2Ev.c
@@ -3,6 +3,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "MovingCylinderClsn.h"
+extern void* _ZTV18MovingCylinderClsn[];
 /* _ZN18MovingCylinderClsnD2Ev at 0x02014954
  * Single-vtable D1/D2 destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call immediate-base destructor, return this.
@@ -12,7 +13,7 @@ struct Obj { void *vtable; };
 extern void base_dtor_MovingCylinderClsn(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN18MovingCylinderClsnD2Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_MovingCylinderClsn;
+    thiz->vtable = (void *)_ZTV18MovingCylinderClsn;
     base_dtor_MovingCylinderClsn(thiz);
     return thiz;
 }

--- a/src/_ZN19BowserPuzzleManagerD0Ev.c
+++ b/src/_ZN19BowserPuzzleManagerD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV19BowserPuzzleManager[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjFl_Puzzle_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV19BowserPuzzleManager; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN19BowserPuzzleManagerD0Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjFl_Puzzle_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV19BowserPuzzleManager;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19BowserPuzzleManagerD1Ev.c
+++ b/src/_ZN19BowserPuzzleManagerD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV19BowserPuzzleManager[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjFl_Puzzle_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV19BowserPuzzleManager; VT1 = _ZTV8Platform */
 int *_ZN19BowserPuzzleManagerD1Ev(int *t)
 {
-    t[0] = (int)_ZTV16daObjFl_Puzzle_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV19BowserPuzzleManager;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19FloatingFloorLllBigD0Ev.c
+++ b/src/_ZN19FloatingFloorLllBigD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV19FloatingFloorLllBig[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjFl_UkiKi_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV19FloatingFloorLllBig; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN19FloatingFloorLllBigD0Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjFl_UkiKi_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV19FloatingFloorLllBig;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19FloatingFloorLllBigD1Ev.c
+++ b/src/_ZN19FloatingFloorLllBigD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV19FloatingFloorLllBig[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjFl_UkiKi_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV19FloatingFloorLllBig; VT1 = _ZTV8Platform */
 int *_ZN19FloatingFloorLllBigD1Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjFl_UkiKi_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV19FloatingFloorLllBig;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19RotatingPlatformLllD0Ev.c
+++ b/src/_ZN19RotatingPlatformLllD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV19RotatingPlatformLll[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjFl_Block_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV19RotatingPlatformLll; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN19RotatingPlatformLllD0Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjFl_Block_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV19RotatingPlatformLll;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19RotatingPlatformLllD1Ev.c
+++ b/src/_ZN19RotatingPlatformLllD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV19RotatingPlatformLll[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjFl_Block_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV19RotatingPlatformLll; VT1 = _ZTV8Platform */
 int *_ZN19RotatingPlatformLllD1Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjFl_Block_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV19RotatingPlatformLll;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19RotatingPlatformWdwD0Ev.c
+++ b/src/_ZN19RotatingPlatformWdwD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjWc_Mizu_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjWc_Mizu_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN19RotatingPlatformWdwD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjWc_Mizu_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19RotatingPlatformWdwD1Ev.c
+++ b/src/_ZN19RotatingPlatformWdwD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjWc_Mizu_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjWc_Mizu_c; VT1 = _ZTV8Platform */
 int *_ZN19RotatingPlatformWdwD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjWc_Mizu_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN20SwitchActivatedPlankD0Ev.c
+++ b/src/_ZN20SwitchActivatedPlankD0Ev.c
@@ -4,14 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj04_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj04_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN20SwitchActivatedPlankD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjWc_Obj04_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN20SwitchActivatedPlankD1Ev.c
+++ b/src/_ZN20SwitchActivatedPlankD1Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj04_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj04_c; VT1 = _ZTV8Platform */
 int *_ZN20SwitchActivatedPlankD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjWc_Obj04_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN20TtcConveyorBeltLargeD0Ev.c
+++ b/src/_ZN20TtcConveyorBeltLargeD0Ev.c
@@ -6,15 +6,16 @@
 #include "decl_ShadowModel.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha04_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha04_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN20TtcConveyorBeltLargeD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha04_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/tools/resolve_placeholders.py
+++ b/tools/resolve_placeholders.py
@@ -58,12 +58,33 @@ from enroll import candidates  # noqa: E402
 
 ELIGIBILITY = REPO / "build" / "rombuild-eligibility.json"
 
-# The exact spellings the recovery pass emitted. Deliberately narrow: a looser
-# pattern would start matching real short symbol names.
-PLACEHOLDER = re.compile(r"^(G|VT|HEAP)\d*$")
+# The spellings the recovery pass invented for symbols it never resolved.
+INVENTED = re.compile(r"^(G|VT|HEAP)\d*$")
+
+
+def is_stand_in(name, header_declared):
+    """Is `name` a stand-in rather than a real symbol?
+
+    Two shapes, and the second is the larger one:
+
+      G0, VT1, HEAP   the pass's own placeholder spellings, declared per-file or
+                      in decl_common.h
+
+      _ZTV10dBgActor_c  a name that *looks* real -- it is declared in a shared
+                      header, so it reads as a proper symbol -- but no module
+                      defines it. 196 files reference that one name, and the
+                      relocations show they mean 196 different symbols. One
+                      declaration standing in for many, exactly like VT, but
+                      spelled plausibly enough that nobody noticed.
+
+    Both are reached the same way: the name resolves to nothing, and the ROM's
+    own relocation says what was meant. A name absent from the headers *and*
+    from the config is left alone -- there is no declaration to carry, and it is
+    likelier to be a genuine gap than a stand-in."""
+    return bool(INVENTED.match(name)) or name in header_declared
 
 def decl_types():
-    """{placeholder: declaration template} read from the headers that declare them.
+    """{name: declaration template} for every name the headers declare.
 
     Read rather than hardcoded: the recovery pass emitted G0, G1, G2, ... as it
     needed them, and a fixed table silently misses whichever it invented last."""
@@ -72,8 +93,10 @@ def decl_types():
         for m in re.finditer(r"^\s*extern\s+([^;=]*?)\b(\w+)\s*(\[\s*\])?\s*;",
                              h.read_text(encoding="utf-8", errors="ignore"), re.M):
             ty, nm, arr = m.group(1).strip(), m.group(2), m.group(3) or ""
-            if PLACEHOLDER.match(nm):
-                out.setdefault(nm, f"extern {ty} @{arr};")
+            # Every declared name, not only the invented spellings: a stand-in
+            # that lives in a shared header needs its template carried across to
+            # the real name just as much as a VT does.
+            out.setdefault(nm, f"extern {ty} @{arr};")
     return out
 
 
@@ -188,9 +211,10 @@ def main():
             continue
         rel = r["file"].replace("\\", "/")
         miss = r.get("missing") or []
-        ph = [s for s in miss if PLACEHOLDER.match(s)]
+        ph = [s for s in miss if is_stand_in(s, declared)]
         if ph and rel in info:
-            jobs.append((rel, ph, [s for s in miss if not PLACEHOLDER.match(s)]))
+            jobs.append((rel, ph,
+                         [s for s in miss if not is_stand_in(s, declared)]))
 
     print(f"files with placeholder references: {len(jobs)}")
     print(f"  of those, blocked ONLY by placeholders: "


### PR DESCRIPTION
The placeholder work (#1058–#1060) resolved the recovery pass's own invented spellings — `G0`, `VT1`, `HEAP`. It stopped there because the rule was a **hardcoded list**, and the larger half of the problem doesn't look like a placeholder at all:

```c
extern int _ZTV10dBgActor_c[];      /* decl_common.h */
```

That reads as a proper symbol. It's declared in a shared header, spelled like a real Itanium-mangled vtable, and nothing about it invites suspicion. But **no module defines it**, and the relocations show that the **196 files** referencing it mean **196 different symbols**.

One declaration standing in for many — exactly what `VT` was doing, spelled plausibly enough that nobody looked.

## The rule, not a list

A name is a stand-in when it **resolves to nothing** and **a shared header declares it**. Resolution then comes from dsd's own relocation data as before: the compiled object gives the byte offset, `relocs.txt` gives the target address and owning module, that module's `symbols.txt` gives the name.

A name absent from the headers *and* the config is left alone — there's no declaration to carry across, and it's likelier to be a genuine config gap than a stand-in.

**125 files, every one byte-verified after the edit, 0 reverted.**

| | |
|---|---|
| enrolled | 9,906 → **10,029** (+123) |
| code bytes built | 76.96% → **77.39%** |
| reproducing | 10,029 / 10,029 |
| module fidelity | 106/106 exact, 100.000000% of compared bytes |
| ROM-build analysis | **PASS** |
| attribution | 0 changed, 0 lost |

## The evidence got stronger, not weaker

Across both batches **256 of 261** rewritten files enroll — so the ROM link checked each resolved symbol against the real ROM word and agreed. Only **5** rest on byte verification alone.

That's a marked improvement on the placeholder batches (94 of 250), and it isn't luck: these files were blocked *only* by stand-ins, so fixing them is sufficient to enroll them, and enrolling them is what proves the fix.

Batch 02 carries the remaining 136. Together they enroll **10,162 (77.85%)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi