### PR TITLE
Resolve stand-in symbol names (batch 02 of 2)

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -3625,6 +3625,7 @@ src/func_02022b04.c:
     .text start:0x02022b04 end:0x02022b58
 
 src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c:
+    complete
     .text start:0x02022b58 end:0x02022bb4
 
 src/_ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -128,9 +128,11 @@ src/_ZN5EnemyC2Ev.cpp:
     .text start:0x020aed98 end:0x020aedbc
 
 src/func_ov002_020aedbc.c:
+    complete
     .text start:0x020aedbc end:0x020aedf4
 
 src/_ZN8CapEnemyD0Ev.c:
+    complete
     .text start:0x020aedf4 end:0x020aee40
 
 src/_ZN13OneUpMushroomD1Ev.c:
@@ -285,6 +287,7 @@ src/OneUpMushroom_Spawn.c:
     .text start:0x020b0580 end:0x020b05d0
 
 src/func_ov002_020b05d0.c:
+    complete
     .text start:0x020b05d0 end:0x020b0600
 
 src/func_ov002_020b0600.c:
@@ -566,6 +569,7 @@ src/WingFeather_Spawn.c:
     .text start:0x020b3248 end:0x020b3298
 
 src/func_ov002_020b3298.c:
+    complete
     .text start:0x020b3298 end:0x020b32c8
 
 src/func_ov002_020b32c8.c:
@@ -863,9 +867,11 @@ src/RedFlame_Spawn.c:
     .text start:0x020b59e0 end:0x020b5a18
 
 src/func_ov002_020b5a18.c:
+    complete
     .text start:0x020b5a18 end:0x020b5a70
 
 src/func_ov002_020b5a70.c:
+    complete
     .text start:0x020b5a70 end:0x020b5ab4
 
 src/func_ov002_020b5ab4.cpp:
@@ -900,9 +906,11 @@ src/func_ov002_020b5fc4.c:
     .text start:0x020b5fc4 end:0x020b5fd8
 
 src/func_ov002_020b5fd8.c:
+    complete
     .text start:0x020b5fd8 end:0x020b6030
 
 src/func_ov002_020b6030.c:
+    complete
     .text start:0x020b6030 end:0x020b6074
 
 src/func_ov002_020b6074.cpp:
@@ -934,9 +942,11 @@ src/func_ov002_020b6374.c:
     .text start:0x020b6374 end:0x020b6388
 
 src/func_ov002_020b6388.c:
+    complete
     .text start:0x020b6388 end:0x020b63e0
 
 src/func_ov002_020b63e0.c:
+    complete
     .text start:0x020b63e0 end:0x020b6424
 
 src/func_ov002_020b6424.c:
@@ -956,9 +966,11 @@ src/func_ov002_020b6584.c:
     .text start:0x020b6584 end:0x020b660c
 
 src/func_ov002_020b660c.c:
+    complete
     .text start:0x020b660c end:0x020b6664
 
 src/func_ov002_020b6664.c:
+    complete
     .text start:0x020b6664 end:0x020b66a8
 
 src/func_ov002_020b66a8.c:
@@ -978,9 +990,11 @@ src/func_ov002_020b676c.cpp:
     .text start:0x020b676c end:0x020b6814
 
 src/func_ov002_020b6814.c:
+    complete
     .text start:0x020b6814 end:0x020b686c
 
 src/func_ov002_020b686c.c:
+    complete
     .text start:0x020b686c end:0x020b68b0
 
 src/func_ov002_020b68b0.cpp:
@@ -1000,9 +1014,11 @@ src/func_ov002_020b6958.c:
     .text start:0x020b6958 end:0x020b69e4
 
 src/func_ov002_020b69e4.c:
+    complete
     .text start:0x020b69e4 end:0x020b6a3c
 
 src/func_ov002_020b6a3c.c:
+    complete
     .text start:0x020b6a3c end:0x020b6a80
 
 src/func_ov002_020b6a80.c:
@@ -1187,6 +1203,7 @@ src/Cap_Spawn.c:
     .text start:0x020b8b98 end:0x020b8bf0
 
 src/func_ov002_020b8bf0.c:
+    complete
     .text start:0x020b8bf0 end:0x020b8c3c
 
 src/func_ov002_020b8c3c.c:
@@ -1394,9 +1411,11 @@ src/ExclamationSwitch_Spawn.c:
     .text start:0x020baadc end:0x020bab0c
 
 src/func_ov002_020bab0c.c:
+    complete
     .text start:0x020bab0c end:0x020bab64
 
 src/func_ov002_020bab64.c:
+    complete
     .text start:0x020bab64 end:0x020baba8
 
 src/func_ov002_020baba8.cpp:
@@ -1416,9 +1435,11 @@ src/func_ov002_020bad10.c:
     .text start:0x020bad10 end:0x020badd0
 
 src/_ZN8SignPostD1Ev.c:
+    complete
     .text start:0x020badd0 end:0x020bae2c
 
 src/_ZN8SignPostD0Ev.c:
+    complete
     .text start:0x020bae2c end:0x020bae9c
 
 src/func_ov002_020bae9c.c:
@@ -1524,6 +1545,7 @@ src/SignPost_Spawn.c:
     .text start:0x020bc3c8 end:0x020bc414
 
 src/func_ov002_020bc414.c:
+    complete
     .text start:0x020bc414 end:0x020bc444
 
 src/func_ov002_020bc444.c:
@@ -4405,6 +4427,7 @@ src/Tree_Spawn.cpp:
     .text start:0x020ec32c end:0x020ec388
 
 src/func_ov002_020ec388.c:
+    complete
     .text start:0x020ec388 end:0x020ec3b8
 
 src/func_ov002_020ec3b8.c:
@@ -4570,6 +4593,7 @@ src/_ZN8PlatformD2Ev.c:
     .text start:0x020ee42c end:0x020ee464
 
 src/_ZN8PlatformD0Ev.c:
+    complete
     .text start:0x020ee464 end:0x020ee4b0
 
 src/_ZN8Platform14KillByMegaCharER6Player.c:
@@ -4749,6 +4773,7 @@ src/func_ov002_020f035c.c:
     .text start:0x020f035c end:0x020f03c4
 
 src/func_ov002_020f03c4.c:
+    complete
     .text start:0x020f03c4 end:0x020f03f4
 
 src/func_ov002_020f03f4.c:
@@ -5625,9 +5650,11 @@ src/SoundObject_Spawn.c:
     .text start:0x020f972c end:0x020f975c
 
 src/_ZN7MinimapD1Ev.c:
+    complete
     .text start:0x020f975c end:0x020f978c
 
 src/_ZN7MinimapD0Ev.c:
+    complete
     .text start:0x020f978c end:0x020f97d0
 
 src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp:
@@ -5667,12 +5694,15 @@ src/_ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_.cpp:
     .text start:0x020fb85c end:0x020fb8bc
 
 src/_ZN7MinimapC1Ev.c:
+    complete
     .text start:0x020fb8bc end:0x020fb8f8
 
 src/_ZN3HUDD1Ev.c:
+    complete
     .text start:0x020fb8f8 end:0x020fb928
 
 src/_ZN3HUDD0Ev.c:
+    complete
     .text start:0x020fb928 end:0x020fb96c
 
 src/_ZN3HUD15RenderTimeTimerEv.cpp:
@@ -5739,6 +5769,7 @@ src/_ZN3HUD13InitResourcesEv.cpp:
     .text start:0x020fda04 end:0x020fe154
 
 src/_ZN3HUDC1Ev.c:
+    complete
     .text start:0x020fe154 end:0x020fe190
 
 src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -1055,6 +1055,7 @@ src/func_ov006_020ccfc8.cpp:
     .text start:0x020ccfc8 end:0x020cd12c
 
 src/func_ov006_020cd12c.c:
+    complete
     .text start:0x020cd12c end:0x020cd158
 
 src/func_ov006_020cd158.c:
@@ -2590,6 +2591,7 @@ src/func_ov006_020e6894.c:
     .text start:0x020e6894 end:0x020e6bf4
 
 src/func_ov006_020e6bf4.c:
+    complete
     .text start:0x020e6bf4 end:0x020e6c28
 
 src/_ZN17MgBounceAndPounceD1Ev.cpp:

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -83,9 +83,11 @@ src/CastleWater_Spawn.c:
     .text start:0x02111d8c end:0x02111dc4
 
 src/_ZN8MetalNetD1Ev.c:
+    complete
     .text start:0x02111dc4 end:0x02111e08
 
 src/_ZN8MetalNetD0Ev.c:
+    complete
     .text start:0x02111e08 end:0x02111e60
 
 src/_ZN8MetalNet16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -4,6 +4,7 @@
     .data       start:0x021121c0 end:0x02112d00 kind:data align:32
     .bss        start:0x02112d00 end:0x02112d80 kind:bss align:32
 src/func_ov010_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111ec
 
 src/func_ov010_021111ec.c:

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02111b80 end:0x021124a0 kind:data align:32
     .bss        start:0x021124a0 end:0x02112500 kind:bss align:32
 src/func_ov012_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov012_021111e4.c:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02113440 end:0x02114960 kind:data align:32
     .bss        start:0x02114960 end:0x02114b00 kind:bss align:32
 src/func_ov015_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111d0
 
 src/func_ov015_021111d0.c:
@@ -205,9 +206,11 @@ src/TowerStep_Spawn.c:
     .text start:0x0211290c end:0x02112944
 
 src/_ZN9TowerStepD1Ev.c:
+    complete
     .text start:0x02112944 end:0x02112988
 
 src/_ZN9TowerStepD0Ev.c:
+    complete
     .text start:0x02112988 end:0x021129e0
 
 src/_ZN9TowerStep16CleanupResourcesEv.cpp:
@@ -230,6 +233,7 @@ src/RotatingBridge_Spawn.c:
     .text start:0x02112ba0 end:0x02112bd0
 
 src/func_ov015_02112bd0.c:
+    complete
     .text start:0x02112bd0 end:0x02112c20
 
 src/func_ov015_02112c20.c:

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -85,9 +85,11 @@ src/Unagi_Spawn.c:
     .text start:0x02112588 end:0x0211260c
 
 src/_ZN6ShipUpD1Ev.c:
+    complete
     .text start:0x0211260c end:0x02112650
 
 src/_ZN6ShipUpD0Ev.c:
+    complete
     .text start:0x02112650 end:0x021126a8
 
 src/func_ov016_021126a8.c:
@@ -119,6 +121,7 @@ src/ShipDown_Spawn.c:
     .text start:0x021129d0 end:0x02112a00
 
 src/func_ov016_02112a00.c:
+    complete
     .text start:0x02112a00 end:0x02112a44
 
 src/func_ov016_02112a44.c:
@@ -149,6 +152,7 @@ src/RockPillar_Spawn.c:
     .text start:0x02112ec4 end:0x02112ef4
 
 src/func_ov016_02112ef4.c:
+    complete
     .text start:0x02112ef4 end:0x02112f44
 
 src/func_ov016_02112f44.c:
@@ -162,9 +166,11 @@ src/FloatOnWaterPlatformJrb_Spawn.c:
     .text start:0x02112fbc end:0x02112ff8
 
 src/_ZN23FloatOnWaterPlatformJrbD1Ev.c:
+    complete
     .text start:0x02112ff8 end:0x02113044
 
 src/_ZN23FloatOnWaterPlatformJrbD0Ev.c:
+    complete
     .text start:0x02113044 end:0x021130a4
 
 src/func_ov016_021130a4.c:

--- a/config/arm9/overlays/ov017/delinks.txt
+++ b/config/arm9/overlays/ov017/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02111a00 end:0x02111c80 kind:data align:32
     .bss        start:0x02111c80 end:0x02111cc0 kind:bss align:32
 src/_ZN9ShipWaterD1Ev.c:
+    complete
     .text start:0x021111a0 end:0x021111ec
 
 src/_ZN9ShipWaterD0Ev.c:
+    complete
     .text start:0x021111ec end:0x0211124c
 
 src/_ZN9ShipWater16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02112e80 end:0x02113bc0 kind:data align:32
     .bss        start:0x02113bc0 end:0x02113cc0 kind:bss align:32
 src/func_ov018_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov018_021111e4.c:
@@ -152,9 +153,11 @@ src/PowerStarCreate_Spawn.c:
     .text start:0x0211278c end:0x021127bc
 
 src/_ZN8IceSheetD1Ev.c:
+    complete
     .text start:0x021127bc end:0x02112800
 
 src/_ZN8IceSheetD0Ev.c:
+    complete
     .text start:0x02112800 end:0x02112858
 
 src/func_ov018_02112858.cpp:

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02113140 end:0x02114500 kind:data align:32
     .bss        start:0x02114500 end:0x021146a0 kind:bss align:32
 src/func_ov022_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov022_021111e4.c:
+    complete
     .text start:0x021111e4 end:0x0211123c
 
 src/func_ov022_0211123c.cpp:
@@ -39,6 +41,7 @@ src/VolcanoRing_Spawn.c:
     .text start:0x02111578 end:0x021115a8
 
 src/func_ov022_021115a8.c:
+    complete
     .text start:0x021115a8 end:0x021115f8
 
 src/func_ov022_021115f8.c:
@@ -89,6 +92,7 @@ src/FloatOnLavaPlatform_Spawn.c:
     .text start:0x02111950 end:0x02111980
 
 src/func_ov022_02111980.c:
+    complete
     .text start:0x02111980 end:0x021119c4
 
 src/func_ov022_021119c4.c:
@@ -119,6 +123,7 @@ src/LavaBridge_Spawn.c:
     .text start:0x02111c7c end:0x02111cac
 
 src/func_ov022_02111cac.c:
+    complete
     .text start:0x02111cac end:0x02111cf0
 
 src/func_ov022_02111cf0.c:
@@ -149,9 +154,11 @@ src/LavaSeesaw_Spawn.c:
     .text start:0x02111f3c end:0x02111f6c
 
 src/_ZN21FloatingFloorLllSmallD1Ev.c:
+    complete
     .text start:0x02111f6c end:0x02111fbc
 
 src/_ZN21FloatingFloorLllSmallD0Ev.c:
+    complete
     .text start:0x02111fbc end:0x02112020
 
 src/_ZN21FloatingFloorLllSmall16CleanupResourcesEv.c:

--- a/config/arm9/overlays/ov023/delinks.txt
+++ b/config/arm9/overlays/ov023/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02111b20 end:0x02112080 kind:data align:32
     .bss        start:0x02112080 end:0x021120c0 kind:bss align:32
 src/_ZN8SquasherD1Ev.c:
+    complete
     .text start:0x021111a0 end:0x021111ec
 
 src/_ZN8SquasherD0Ev.c:
+    complete
     .text start:0x021111ec end:0x0211124c
 
 src/func_ov023_0211124c.c:

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02112b40 end:0x02113a60 kind:data align:32
     .bss        start:0x02113a60 end:0x02113b00 kind:bss align:32
 src/func_ov025_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov025_021111e4.c:

--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02112dc0 end:0x02113ea0 kind:data align:32
     .bss        start:0x02113ea0 end:0x02113f80 kind:bss align:32
 src/func_ov026_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e0
 
 src/func_ov026_021111e0.c:
@@ -35,9 +36,11 @@ src/func_ov026_02111598.cpp:
     .text start:0x02111598 end:0x02111678
 
 src/func_ov026_02111678.c:
+    complete
     .text start:0x02111678 end:0x021116c8
 
 src/func_ov026_021116c8.c:
+    complete
     .text start:0x021116c8 end:0x0211170c
 
 src/func_ov026_0211170c.c:
@@ -64,6 +67,7 @@ src/BowserShutter_Spawn.c:
     .text start:0x02111888 end:0x021118b8
 
 src/func_ov026_021118b8.c:
+    complete
     .text start:0x021118b8 end:0x021118fc
 
 src/func_ov026_021118fc.c:

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -39,6 +39,7 @@ src/SlidingIceSpawner_Spawn.c:
     .text start:0x02111594 end:0x021115c4
 
 src/func_ov027_021115c4.c:
+    complete
     .text start:0x021115c4 end:0x02111618
 
 src/func_ov027_02111618.c:
@@ -65,6 +66,7 @@ src/ChillBully_Spawn.c:
     .text start:0x0211186c end:0x021118c8
 
 src/func_ov027_021118c8.c:
+    complete
     .text start:0x021118c8 end:0x02111924
 
 src/func_ov027_02111924.c:
@@ -124,6 +126,7 @@ src/func_ov027_02111eb4.cpp:
     .text start:0x02111eb4 end:0x0211207c
 
 src/func_ov027_0211207c.c:
+    complete
     .text start:0x0211207c end:0x021120c4
 
 src/_ZN13SnowmanBreathD1Ev.cpp:

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02112ea0 end:0x02114220 kind:data align:32
     .bss        start:0x02114220 end:0x02114360 kind:bss align:32
 src/func_ov029_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111f0
 
 src/func_ov029_021111f0.c:
@@ -19,9 +20,11 @@ src/FloatOnWaterPlatformWdwSquare_Spawn.c:
     .text start:0x02111340 end:0x0211137c
 
 src/_ZN29FloatOnWaterPlatformWdwSquareD1Ev.c:
+    complete
     .text start:0x0211137c end:0x021113c0
 
 src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c:
+    complete
     .text start:0x021113c0 end:0x02111418
 
 src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp:
@@ -92,6 +95,7 @@ src/WaterDiamond_Spawn.c:
     .text start:0x02111a84 end:0x02111ac4
 
 src/func_ov029_02111ac4.c:
+    complete
     .text start:0x02111ac4 end:0x02111b08
 
 src/func_ov029_02111b08.c:
@@ -127,6 +131,7 @@ src/CageLift_Spawn.c:
     .text start:0x02111e74 end:0x02111ea4
 
 src/func_ov029_02111ea4.c:
+    complete
     .text start:0x02111ea4 end:0x02111ef4
 
 src/func_ov029_02111ef4.c:
@@ -141,9 +146,11 @@ src/FloatOnWaterPlatformWdwRectangle_Spawn.c:
     .text start:0x02112044 end:0x02112080
 
 src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c:
+    complete
     .text start:0x02112080 end:0x021120d0
 
 src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c:
+    complete
     .text start:0x021120d0 end:0x02112134
 
 src/_ZN32FloatOnWaterPlatformWdwRectangle16CleanupResourcesEv.c:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02114de0 end:0x02115c80 kind:data align:32
     .bss        start:0x02115c80 end:0x02115ec0 kind:bss align:32
 src/func_ov030_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111ec
 
 src/func_ov030_021111ec.c:

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -101,6 +101,7 @@ src/func_ov032_0211244c.c:
     .text start:0x0211244c end:0x021124a8
 
 src/func_ov032_021124a8.c:
+    complete
     .text start:0x021124a8 end:0x021124ec
 
 src/func_ov032_021124ec.c:
@@ -128,9 +129,11 @@ src/HugeCover_Spawn.c:
     .text start:0x02112668 end:0x02112698
 
 src/_ZN9HugeCoverD1Ev.c:
+    complete
     .text start:0x02112698 end:0x021126e4
 
 src/_ZN9HugeCoverD0Ev.c:
+    complete
     .text start:0x021126e4 end:0x02112744
 
 src/_ZN9HugeCover16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov033/delinks.txt
+++ b/config/arm9/overlays/ov033/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02111ae0 end:0x021124c0 kind:data align:32
     .bss        start:0x021124c0 end:0x02112520 kind:bss align:32
 src/func_ov033_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov033_021111e4.c:
@@ -36,9 +37,11 @@ src/TinyCover_Spawn.c:
     .text start:0x021113a4 end:0x021113d4
 
 src/_ZN9TinyCoverD1Ev.c:
+    complete
     .text start:0x021113d4 end:0x02111420
 
 src/_ZN9TinyCoverD0Ev.c:
+    complete
     .text start:0x02111420 end:0x02111480
 
 src/_ZN9TinyCover16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -4,6 +4,7 @@
     .data       start:0x02112a00 end:0x02114020 kind:data align:32
     .bss        start:0x02114020 end:0x021141e0 kind:bss align:32
 src/func_ov036_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov036_021111e4.c:
@@ -34,6 +35,7 @@ src/SwingingPlatform_Spawn.c:
     .text start:0x02111414 end:0x02111444
 
 src/func_ov036_02111444.c:
+    complete
     .text start:0x02111444 end:0x02111494
 
 src/func_ov036_02111494.c:
@@ -83,9 +85,11 @@ src/ShipWing_Spawn.c:
     .text start:0x02111904 end:0x0211193c
 
 src/_ZN8ShipWingD1Ev.c:
+    complete
     .text start:0x0211193c end:0x02111988
 
 src/_ZN8ShipWingD0Ev.c:
+    complete
     .text start:0x02111988 end:0x021119e8
 
 src/_ZN8ShipWing16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -4,6 +4,7 @@
     .data       start:0x02111b00 end:0x021125e0 kind:data align:32
     .bss        start:0x021125e0 end:0x02112720 kind:bss align:32
 src/func_ov043_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov043_021111e4.c:
@@ -31,6 +32,7 @@ src/DiamondLift_Spawn.c:
     .text start:0x021113cc end:0x021113fc
 
 src/func_ov043_021113fc.c:
+    complete
     .text start:0x021113fc end:0x0211144c
 
 src/func_ov043_0211144c.c:

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02112460 end:0x02113180 kind:data align:32
     .bss        start:0x02113180 end:0x02113280 kind:bss align:32
 src/func_ov045_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov045_021111e4.c:
@@ -104,6 +105,7 @@ src/ExtendingPlatform_Spawn.c:
     .text start:0x02111ad4 end:0x02111b14
 
 src/func_ov045_02111b14.c:
+    complete
     .text start:0x02111b14 end:0x02111b64
 
 src/func_ov045_02111b64.c:

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -4,6 +4,7 @@
     .data       start:0x021119e0 end:0x021125e0 kind:data align:32
     .bss        start:0x021125e0 end:0x02112720 kind:bss align:32
 src/func_ov047_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111f0
 
 src/func_ov047_021111f0.c:
@@ -36,9 +37,11 @@ src/_ZN10RickshawBs13InitResourcesEv.c:
     .text start:0x02111384 end:0x021113bc
 
 src/func_ov047_021113bc.c:
+    complete
     .text start:0x021113bc end:0x021113f8
 
 src/func_ov047_021113f8.c:
+    complete
     .text start:0x021113f8 end:0x02111448
 
 src/func_ov047_02111448.c:

--- a/config/arm9/overlays/ov052/delinks.txt
+++ b/config/arm9/overlays/ov052/delinks.txt
@@ -5,6 +5,7 @@
     .data       start:0x02111c60 end:0x02112680 kind:data align:32
     .bss        start:0x02112680 end:0x021126e0 kind:bss align:32
 src/func_ov052_021111a0.c:
+    complete
     .text start:0x021111a0 end:0x021111e4
 
 src/func_ov052_021111e4.c:

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -463,6 +463,7 @@ src/BowserFireSeaArena_Spawn.c:
     .text start:0x02117cdc end:0x02117d1c
 
 src/func_ov060_02117d1c.c:
+    complete
     .text start:0x02117d1c end:0x02117d60
 
 src/func_ov060_02117d60.c:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -97,9 +97,11 @@ src/func_ov064_02116ec0.cpp:
     .text start:0x02116ec0 end:0x02117070
 
 src/_ZN5BullyD1Ev.c:
+    complete
     .text start:0x02117070 end:0x021170c4
 
 src/_ZN5BullyD0Ev.c:
+    complete
     .text start:0x021170c4 end:0x0211712c
 
 src/func_ov064_0211712c.c:
@@ -138,9 +140,11 @@ src/Bully_Spawn.c:
     .text start:0x02117444 end:0x021174a0
 
 src/_ZN8BigBullyD1Ev.c:
+    complete
     .text start:0x021174a0 end:0x021174f4
 
 src/_ZN8BigBullyD0Ev.c:
+    complete
     .text start:0x021174f4 end:0x0211755c
 
 src/func_ov064_0211755c.c:
@@ -167,6 +171,7 @@ src/BigBully_Spawn.c:
     .text start:0x0211791c end:0x02117978
 
 src/func_ov064_02117978.c:
+    complete
     .text start:0x02117978 end:0x021179bc
 
 src/func_ov064_021179bc.c:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -335,6 +335,7 @@ src/TtcRotatingCube_Spawn.c:
     .text start:0x02119efc end:0x02119f3c
 
 src/func_ov065_02119f3c.c:
+    complete
     .text start:0x02119f3c end:0x02119f88
 
 src/func_ov065_02119f88.c:
@@ -364,9 +365,11 @@ src/func_ov065_0211a358.cpp:
     .text start:0x0211a358 end:0x0211a45c
 
 src/func_ov065_0211a45c.c:
+    complete
     .text start:0x0211a45c end:0x0211a494
 
 src/_ZN20TtcConveyorBeltLargeD1Ev.c:
+    complete
     .text start:0x0211a494 end:0x0211a4e8
 
 src/_ZN20TtcConveyorBeltLargeD0Ev.c:
@@ -408,6 +411,7 @@ src/TtcConveyorBeltSmall_Spawn.c:
     .text start:0x0211ab20 end:0x0211ab60
 
 src/func_ov065_0211ab60.c:
+    complete
     .text start:0x0211ab60 end:0x0211abac
 
 src/func_ov065_0211abac.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -286,9 +286,11 @@ src/MrI_Projectile_Spawn.c:
     .text start:0x02121f9c end:0x02121fe4
 
 src/_ZN6CoffinD1Ev.c:
+    complete
     .text start:0x02121fe4 end:0x02122028
 
 src/_ZN6CoffinD0Ev.c:
+    complete
     .text start:0x02122028 end:0x02122080
 
 src/func_ov071_02122080.c:

--- a/config/arm9/overlays/ov072/delinks.txt
+++ b/config/arm9/overlays/ov072/delinks.txt
@@ -199,6 +199,7 @@ src/SnowmanHead_Spawn.c:
     .text start:0x021207d4 end:0x02120824
 
 src/func_ov072_02120824.c:
+    complete
     .text start:0x02120824 end:0x02120874
 
 src/func_ov072_02120874.c:
@@ -230,6 +231,7 @@ src/func_ov072_02120a44.c:
     .text start:0x02120a44 end:0x02120c00
 
 src/func_ov072_02120c00.c:
+    complete
     .text start:0x02120c00 end:0x02120c58
 
 src/_ZN11BabyPenguinD1Ev.cpp:

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -191,9 +191,11 @@ src/ChiefChilly_Spawn.cpp:
     .text start:0x02121ec8 end:0x02121f90
 
 src/_ZN8CccArenaD1Ev.c:
+    complete
     .text start:0x02121f90 end:0x02121fd4
 
 src/_ZN8CccArenaD0Ev.c:
+    complete
     .text start:0x02121fd4 end:0x0212202c
 
 src/func_ov073_0212202c.c:

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -192,6 +192,7 @@ src/BulletBill_Spawn.c:
     .text start:0x02126d64 end:0x02126dbc
 
 src/func_ov079_02126dbc.c:
+    complete
     .text start:0x02126dbc end:0x02126e00
 
 src/func_ov079_02126e00.c:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -295,9 +295,11 @@ src/Painting_Spawn.c:
     .text start:0x02126f8c end:0x02126fbc
 
 src/func_ov080_02126fbc.c:
+    complete
     .text start:0x02126fbc end:0x02127014
 
 src/func_ov080_02127014.c:
+    complete
     .text start:0x02127014 end:0x02127058
 
 src/func_ov080_02127058.c:

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -389,9 +389,11 @@ src/Moneybag_Spawn.c:
     .text start:0x02127adc end:0x02127b34
 
 src/_ZN8IceBlockD1Ev.c:
+    complete
     .text start:0x02127b34 end:0x02127b80
 
 src/_ZN8IceBlockD0Ev.c:
+    complete
     .text start:0x02127b80 end:0x02127be0
 
 src/func_ov081_02127be0.cpp:

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -468,9 +468,11 @@ src/LakituBro_Spawn.c:
     .text start:0x0212ed54 end:0x0212edac
 
 src/_ZN8WallSignD1Ev.c:
+    complete
     .text start:0x0212edac end:0x0212edf8
 
 src/_ZN8WallSignD0Ev.c:
+    complete
     .text start:0x0212edf8 end:0x0212ee58
 
 src/_ZN8WallSign16CleanupResourcesEv.c:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x02134ba0 end:0x02135440 kind:data align:32
     .bss        start:0x02135440 end:0x021356e0 kind:bss align:32
 src/_ZN25RotatingUpDownPlatformUtmD1Ev.c:
+    complete
     .text start:0x02130f00 end:0x02130f4c
 
 src/_ZN25RotatingUpDownPlatformUtmD0Ev.c:
+    complete
     .text start:0x02130f4c end:0x02130fac
 
 src/func_ov091_02130fac.cpp:
@@ -54,9 +56,11 @@ src/RotatingUpDownPlatform_Spawn.c:
     .text start:0x02131bdc end:0x02131c14
 
 src/_ZN22RotatingUpDownPlatformD1Ev.c:
+    complete
     .text start:0x02131c14 end:0x02131c58
 
 src/_ZN22RotatingUpDownPlatformD0Ev.c:
+    complete
     .text start:0x02131c58 end:0x02131cb0
 
 src/func_ov091_02131cb0.c:
@@ -160,9 +164,11 @@ src/SlidingPlatformBdw_Spawn.c:
     .text start:0x02132908 end:0x02132938
 
 src/_ZN6ThwompD1Ev.c:
+    complete
     .text start:0x02132938 end:0x02132998
 
 src/_ZN6ThwompD0Ev.c:
+    complete
     .text start:0x02132998 end:0x02132a0c
 
 src/func_ov091_02132a0c.c:
@@ -185,9 +191,11 @@ src/Thwomp_Spawn.c:
     .text start:0x02132cb8 end:0x02132d04
 
 src/func_ov091_02132d04.c:
+    complete
     .text start:0x02132d04 end:0x02132d6c
 
 src/func_ov091_02132d6c.c:
+    complete
     .text start:0x02132d6c end:0x02132dc0
 
 src/func_ov091_02132dc0.cpp:
@@ -231,6 +239,7 @@ src/func_ov091_02133254.cpp:
     .text start:0x02133254 end:0x021333fc
 
 src/func_ov091_021333fc.c:
+    complete
     .text start:0x021333fc end:0x02133440
 
 src/func_ov091_02133440.c:

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -5,9 +5,11 @@
     .data       start:0x021373c0 end:0x02137780 kind:data align:32
     .bss        start:0x02137780 end:0x02137940 kind:bss align:32
 src/_ZN9SeesawBobD1Ev.c:
+    complete
     .text start:0x02135700 end:0x02135744
 
 src/_ZN9SeesawBobD0Ev.c:
+    complete
     .text start:0x02135744 end:0x0213579c
 
 src/func_ov095_0213579c.c:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -198,9 +198,11 @@ src/Crate_Spawn.cpp:
     .text start:0x02139f04 end:0x02139f70
 
 src/func_ov098_02139f70.c:
+    complete
     .text start:0x02139f70 end:0x02139fc8
 
 src/func_ov098_02139fc8.c:
+    complete
     .text start:0x02139fc8 end:0x0213a00c
 
 src/func_ov098_0213a00c.cpp:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -194,6 +194,7 @@ src/UnchainedChomp_Spawn.c:
     .text start:0x021442dc end:0x021443f4
 
 src/func_ov100_021443f4.c:
+    complete
     .text start:0x021443f4 end:0x02144424
 
 src/func_ov100_02144424.c:

--- a/src/_ZN20TtcConveyorBeltLargeD1Ev.c
+++ b/src/_ZN20TtcConveyorBeltLargeD1Ev.c
@@ -6,14 +6,15 @@
 #include "decl_ShadowModel.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha04_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha04_c; VT1 = _ZTV8Platform */
 int *_ZN20TtcConveyorBeltLargeD1Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjCtMecha04_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN21FloatingFloorLllSmallD0Ev.c
+++ b/src/_ZN21FloatingFloorLllSmallD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV21FloatingFloorLllSmall[];
+extern int data_ov002_0210912c[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV21FloatingFloorLllSmall; VT1 = data_ov002_0210912c */
 extern void *data_020a0eac;
 int *_ZN21FloatingFloorLllSmallD0Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV21FloatingFloorLllSmall;
+    t[0] = (int)data_ov002_0210912c;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN21FloatingFloorLllSmallD1Ev.c
+++ b/src/_ZN21FloatingFloorLllSmallD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV21FloatingFloorLllSmall[];
+extern int data_ov002_0210912c[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV21FloatingFloorLllSmall; VT1 = data_ov002_0210912c */
 int *_ZN21FloatingFloorLllSmallD1Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV21FloatingFloorLllSmall;
+    t[0] = (int)data_ov002_0210912c;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN22RotatingUpDownPlatformD0Ev.c
+++ b/src/_ZN22RotatingUpDownPlatformD0Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daLinelift2_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13daLinelift2_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN22RotatingUpDownPlatformD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daLinelift2_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN22RotatingUpDownPlatformD1Ev.c
+++ b/src/_ZN22RotatingUpDownPlatformD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daLinelift2_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13daLinelift2_c; VT1 = _ZTV8Platform */
 int *_ZN22RotatingUpDownPlatformD1Ev(int *t)
 {
     t[0] = (int)_ZTV13daLinelift2_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN23FloatOnWaterPlatformJrbD0Ev.c
+++ b/src/_ZN23FloatOnWaterPlatformJrbD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daSlide_Box_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13daSlide_Box_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN23FloatOnWaterPlatformJrbD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daSlide_Box_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x324);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN23FloatOnWaterPlatformJrbD1Ev.c
+++ b/src/_ZN23FloatOnWaterPlatformJrbD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daSlide_Box_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13daSlide_Box_c; VT1 = _ZTV8Platform */
 int *_ZN23FloatOnWaterPlatformJrbD1Ev(int *t)
 {
     t[0] = (int)_ZTV13daSlide_Box_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x324);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN25MovingCylinderClsnWithPosD1Ev.c
+++ b/src/_ZN25MovingCylinderClsnWithPosD1Ev.c
@@ -3,6 +3,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "MovingCylinderClsnWithPos.h"
+extern void* _ZTV25MovingCylinderClsnWithPos[];
 /* _ZN25MovingCylinderClsnWithPosD1Ev at 0x02014a60
  * Single-vtable D1/D2 destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call immediate-base destructor, return this.
@@ -12,7 +13,7 @@ struct Obj { void *vtable; };
 extern void base_dtor_MovingCylinderClsnWithPos(struct Obj *thiz); /* 0x02014954 */
 struct Obj *_ZN25MovingCylinderClsnWithPosD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_MovingCylinderClsnWithPos;
+    thiz->vtable = (void *)_ZTV25MovingCylinderClsnWithPos;
     base_dtor_MovingCylinderClsnWithPos(thiz);
     return thiz;
 }

--- a/src/_ZN25RotatingUpDownPlatformUtmD0Ev.c
+++ b/src/_ZN25RotatingUpDownPlatformUtmD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV23daObjRotateUpdownLift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV23daObjRotateUpdownLift_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN25RotatingUpDownPlatformUtmD0Ev(int *t)
 {
     t[0] = (int)_ZTV23daObjRotateUpdownLift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN25RotatingUpDownPlatformUtmD1Ev.c
+++ b/src/_ZN25RotatingUpDownPlatformUtmD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV23daObjRotateUpdownLift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV23daObjRotateUpdownLift_c; VT1 = _ZTV8Platform */
 int *_ZN25RotatingUpDownPlatformUtmD1Ev(int *t)
 {
     t[0] = (int)_ZTV23daObjRotateUpdownLift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV29FloatOnWaterPlatformWdwSquare[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj02_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV29FloatOnWaterPlatformWdwSquare; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN29FloatOnWaterPlatformWdwSquareD0Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjWc_Obj02_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV29FloatOnWaterPlatformWdwSquare;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN29FloatOnWaterPlatformWdwSquareD1Ev.c
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquareD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV29FloatOnWaterPlatformWdwSquare[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj02_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV29FloatOnWaterPlatformWdwSquare; VT1 = _ZTV8Platform */
 int *_ZN29FloatOnWaterPlatformWdwSquareD1Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjWc_Obj02_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV29FloatOnWaterPlatformWdwSquare;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c
+++ b/src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c
@@ -4,14 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV32FloatOnWaterPlatformWdwRectangle[];
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV32FloatOnWaterPlatformWdwRectangle; VT1 = data_ov002_021091d4 */
 extern void *data_020a0eac;
 int *_ZN32FloatOnWaterPlatformWdwRectangleD0Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjWc_Obj07_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV32FloatOnWaterPlatformWdwRectangle;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c
+++ b/src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV32FloatOnWaterPlatformWdwRectangle[];
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV32FloatOnWaterPlatformWdwRectangle; VT1 = data_ov002_021091d4 */
 int *_ZN32FloatOnWaterPlatformWdwRectangleD1Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjWc_Obj07_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV32FloatOnWaterPlatformWdwRectangle;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN3HUDC1Ev.c
+++ b/src/_ZN3HUDC1Ev.c
@@ -2,16 +2,18 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int _ZTV3HUD[];
+extern int _ZTV12ActorDerived[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV7dBase_c; VT1 = _ZTV8dMeter_c */
+/* vtable identified: VT0 = _ZTV12ActorDerived; VT1 = _ZTV3HUD */
 extern void _ZN9ActorBaseC1Ev(void *);
 int *_ZN3HUDC1Ev(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(124);
     if (p) {
         _ZN9ActorBaseC1Ev(p);
-        p[0] = (int)_ZTV7dBase_c;
-        p[0] = (int)_ZTV8dMeter_c;
+        p[0] = (int)_ZTV12ActorDerived;
+        p[0] = (int)_ZTV3HUD;
     }
     return p;
 }

--- a/src/_ZN3HUDD0Ev.c
+++ b/src/_ZN3HUDD0Ev.c
@@ -1,14 +1,16 @@
 // @symbol _ZN3HUDD0Ev
 /* recovered: named members + shared header, vtable identified, declarations from a shared header */
 #include "decl_common.h"
+extern int _ZTV3HUD[];
+extern int _ZTV12ActorDerived[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV8dMeter_c; VT1 = _ZTV7dBase_c */
+/* vtable identified: VT0 = _ZTV3HUD; VT1 = _ZTV12ActorDerived */
 extern void _ZN9ActorBaseD2Ev(void *);
 extern void *data_020a0eac;
 int *_ZN3HUDD0Ev(int *t)
 {
-    t[0] = (int)_ZTV8dMeter_c;
-    t[0] = (int)_ZTV7dBase_c;
+    t[0] = (int)_ZTV3HUD;
+    t[0] = (int)_ZTV12ActorDerived;
     _ZN9ActorBaseD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;

--- a/src/_ZN3HUDD1Ev.c
+++ b/src/_ZN3HUDD1Ev.c
@@ -1,13 +1,15 @@
 // @symbol _ZN3HUDD1Ev
 /* recovered: named members + shared header, vtable identified, declarations from a shared header */
 #include "decl_common.h"
+extern int _ZTV3HUD[];
+extern int _ZTV12ActorDerived[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV8dMeter_c; VT1 = _ZTV7dBase_c */
+/* vtable identified: VT0 = _ZTV3HUD; VT1 = _ZTV12ActorDerived */
 extern void _ZN9ActorBaseD2Ev(void *);
 int *_ZN3HUDD1Ev(int *t)
 {
-    t[0] = (int)_ZTV8dMeter_c;
-    t[0] = (int)_ZTV7dBase_c;
+    t[0] = (int)_ZTV3HUD;
+    t[0] = (int)_ZTV12ActorDerived;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/_ZN5BullyD0Ev.c
+++ b/src/_ZN5BullyD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV5Bully[];
 extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV11daDonketu_c */
+/* vtable identified: VT0 = _ZTV5Bully */
 extern void func_ov002_020aed18(void *);
 extern void *data_020a0eac;
 int *_ZN5BullyD0Ev(int *t)
 {
-    t[0] = (int)_ZTV11daDonketu_c;
+    t[0] = (int)_ZTV5Bully;
     t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN5BullyD1Ev.c
+++ b/src/_ZN5BullyD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV5Bully[];
 extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV11daDonketu_c */
+/* vtable identified: VT0 = _ZTV5Bully */
 extern void func_ov002_020aed18(void *);
 int *_ZN5BullyD1Ev(int *t)
 {
-    t[0] = (int)_ZTV11daDonketu_c;
+    t[0] = (int)_ZTV5Bully;
     t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN6CoffinD0Ev.c
+++ b/src/_ZN6CoffinD0Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV6Coffin[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV6Coffin */
 extern void *data_020a0eac;
 int *_ZN6CoffinD0Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV6Coffin;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN6CoffinD1Ev.c
+++ b/src/_ZN6CoffinD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV6Coffin[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV6Coffin */
 int *_ZN6CoffinD1Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV6Coffin;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN6ShipUpD0Ev.c
+++ b/src/_ZN6ShipUpD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV6ShipUp[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjKi_Fune_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV6ShipUp; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN6ShipUpD0Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjKi_Fune_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV6ShipUp;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN6ShipUpD1Ev.c
+++ b/src/_ZN6ShipUpD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV6ShipUp[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjKi_Fune_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV6ShipUp; VT1 = _ZTV8Platform */
 int *_ZN6ShipUpD1Ev(int *t)
 {
-    t[0] = (int)_ZTV14daObjKi_Fune_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV6ShipUp;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN6ThwompD0Ev.c
+++ b/src/_ZN6ThwompD0Ev.c
@@ -5,15 +5,17 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov091_021351fc[];
+extern int _ZTV6Thwomp[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV7daDsn_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV6Thwomp; VT1 = data_ov091_021351fc */
 extern void _ZN15TextureSequenceD1Ev(void *);
 extern void *data_020a0eac;
 int *_ZN6ThwompD0Ev(int *t)
 {
-    t[0] = (int)_ZTV7daDsn_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV6Thwomp;
+    t[0] = (int)data_ov091_021351fc;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)_ZTV8Platform;

--- a/src/_ZN6ThwompD1Ev.c
+++ b/src/_ZN6ThwompD1Ev.c
@@ -5,14 +5,16 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov091_021351fc[];
+extern int _ZTV6Thwomp[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV7daDsn_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV6Thwomp; VT1 = data_ov091_021351fc */
 extern void _ZN15TextureSequenceD1Ev(void *);
 int *_ZN6ThwompD1Ev(int *t)
 {
-    t[0] = (int)_ZTV7daDsn_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV6Thwomp;
+    t[0] = (int)data_ov091_021351fc;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)_ZTV8Platform;

--- a/src/_ZN7ClipperD0Ev.c
+++ b/src/_ZN7ClipperD0Ev.c
@@ -3,6 +3,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Clipper.h"
+extern void* _ZTV7Clipper[];
 /* _ZN7ClipperD0Ev at 0x020156fc
  * Single-vtable destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call base/helper destructor, return this.
@@ -12,7 +13,7 @@ struct Obj { void *vtable; };
 extern void base_dtor_Clipper(struct Obj *thiz); /* 0x0203cbcc */
 struct Obj *_ZN7ClipperD0Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_Clipper;
+    thiz->vtable = (void *)_ZTV7Clipper;
     base_dtor_Clipper(thiz);
     return thiz;
 }

--- a/src/_ZN7MinimapC1Ev.c
+++ b/src/_ZN7MinimapC1Ev.c
@@ -2,16 +2,18 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int _ZTV12ActorDerived[];
+extern int _ZTV7Minimap[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV7dBase_c; VT1 = _ZTV6dMap_c */
+/* vtable identified: VT0 = _ZTV12ActorDerived; VT1 = _ZTV7Minimap */
 extern void _ZN9ActorBaseC1Ev(void *);
 int *_ZN7MinimapC1Ev(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(600);
     if (p) {
         _ZN9ActorBaseC1Ev(p);
-        p[0] = (int)_ZTV7dBase_c;
-        p[0] = (int)_ZTV6dMap_c;
+        p[0] = (int)_ZTV12ActorDerived;
+        p[0] = (int)_ZTV7Minimap;
     }
     return p;
 }

--- a/src/_ZN7MinimapD0Ev.c
+++ b/src/_ZN7MinimapD0Ev.c
@@ -1,14 +1,16 @@
 // @symbol _ZN7MinimapD0Ev
 /* recovered: named members + shared header, vtable identified, declarations from a shared header */
 #include "decl_common.h"
+extern int _ZTV12ActorDerived[];
+extern int _ZTV7Minimap[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV6dMap_c; VT1 = _ZTV7dBase_c */
+/* vtable identified: VT0 = _ZTV7Minimap; VT1 = _ZTV12ActorDerived */
 extern void _ZN9ActorBaseD2Ev(void *);
 extern void *data_020a0eac;
 int *_ZN7MinimapD0Ev(int *t)
 {
-    t[0] = (int)_ZTV6dMap_c;
-    t[0] = (int)_ZTV7dBase_c;
+    t[0] = (int)_ZTV7Minimap;
+    t[0] = (int)_ZTV12ActorDerived;
     _ZN9ActorBaseD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;

--- a/src/_ZN7MinimapD1Ev.c
+++ b/src/_ZN7MinimapD1Ev.c
@@ -1,13 +1,15 @@
 // @symbol _ZN7MinimapD1Ev
 /* recovered: named members + shared header, vtable identified, declarations from a shared header */
 #include "decl_common.h"
+extern int _ZTV12ActorDerived[];
+extern int _ZTV7Minimap[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV6dMap_c; VT1 = _ZTV7dBase_c */
+/* vtable identified: VT0 = _ZTV7Minimap; VT1 = _ZTV12ActorDerived */
 extern void _ZN9ActorBaseD2Ev(void *);
 int *_ZN7MinimapD1Ev(int *t)
 {
-    t[0] = (int)_ZTV6dMap_c;
-    t[0] = (int)_ZTV7dBase_c;
+    t[0] = (int)_ZTV7Minimap;
+    t[0] = (int)_ZTV12ActorDerived;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/_ZN8BigBullyD0Ev.c
+++ b/src/_ZN8BigBullyD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8BigBully[];
 extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV12daBDonketu_c */
+/* vtable identified: VT0 = _ZTV8BigBully */
 extern void func_ov002_020aed18(void *);
 extern void *data_020a0eac;
 int *_ZN8BigBullyD0Ev(int *t)
 {
-    t[0] = (int)_ZTV12daBDonketu_c;
+    t[0] = (int)_ZTV8BigBully;
     t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN8BigBullyD1Ev.c
+++ b/src/_ZN8BigBullyD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8BigBully[];
 extern int data_ov064_0211b768[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV12daBDonketu_c */
+/* vtable identified: VT0 = _ZTV8BigBully */
 extern void func_ov002_020aed18(void *);
 int *_ZN8BigBullyD1Ev(int *t)
 {
-    t[0] = (int)_ZTV12daBDonketu_c;
+    t[0] = (int)_ZTV8BigBully;
     t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN8CapEnemyD0Ev.c
+++ b/src/_ZN8CapEnemyD0Ev.c
@@ -2,13 +2,14 @@
 /* recovered: named members + shared header, vtable identified, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_common.h"
+extern int data_ov002_02108284[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV11dCapEnemy_c */
+/* vtable identified: VT0 = data_ov002_02108284 */
 extern void func_ov002_020aed18(void *);
 extern void *data_020a0eac;
 int *_ZN8CapEnemyD0Ev(int *t)
 {
-    t[0] = (int)_ZTV11dCapEnemy_c;
+    t[0] = (int)data_ov002_02108284;
     func_ov001_020ab3a0((char *)t + 0x164);
     _ZN5ModelD1Ev((char *)t + 0x114);
     func_ov002_020aed18(t);

--- a/src/_ZN8CccArenaD0Ev.c
+++ b/src/_ZN8CccArenaD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8CccArena[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjEwbIce_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV8CccArena; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN8CccArenaD0Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjEwbIce_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8CccArena;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8CccArenaD1Ev.c
+++ b/src/_ZN8CccArenaD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8CccArena[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjEwbIce_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV8CccArena; VT1 = _ZTV8Platform */
 int *_ZN8CccArenaD1Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjEwbIce_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8CccArena;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8IceBlockD0Ev.c
+++ b/src/_ZN8IceBlockD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingCylinderClsn.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjIceBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjIceBlock_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN8IceBlockD0Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjIceBlock_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8IceBlockD1Ev.c
+++ b/src/_ZN8IceBlockD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingCylinderClsn.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjIceBlock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjIceBlock_c; VT1 = _ZTV8Platform */
 int *_ZN8IceBlockD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjIceBlock_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8IceSheetD0Ev.c
+++ b/src/_ZN8IceSheetD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8IceSheet[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjIceBoard_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV8IceSheet; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN8IceSheetD0Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjIceBoard_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8IceSheet;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8IceSheetD1Ev.c
+++ b/src/_ZN8IceSheetD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8IceSheet[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjIceBoard_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV8IceSheet; VT1 = _ZTV8Platform */
 int *_ZN8IceSheetD1Ev(int *t)
 {
-    t[0] = (int)_ZTV15daObjIceBoard_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8IceSheet;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8MetalNetD0Ev.c
+++ b/src/_ZN8MetalNetD0Ev.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjMc_Metalnet_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjMc_Metalnet_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN8MetalNetD0Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjMc_Metalnet_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8MetalNetD1Ev.c
+++ b/src/_ZN8MetalNetD1Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjMc_Metalnet_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV18daObjMc_Metalnet_c; VT1 = _ZTV8Platform */
 int *_ZN8MetalNetD1Ev(int *t)
 {
     t[0] = (int)_ZTV18daObjMc_Metalnet_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c
+++ b/src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle.h"
+extern char* data_0209ee74;
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
     Fix12i x, Fix12i y, Fix12i z,
@@ -11,11 +12,11 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(Fix12i x, Fix12i y, Fix12i z)
 {
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x750) =
+    *(u32*)(data_0209ee74 + 0x750) =
         _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-            *(u32*)(PARTICLE_SYS_TRACKER + 0x750),
+            *(u32*)(data_0209ee74 + 0x750),
             0xda,
             x, y, z,
             (void*)0,
-            (void*)(PARTICLE_SYS_TRACKER + 0x754));
+            (void*)(data_0209ee74 + 0x754));
 }

--- a/src/_ZN8PlatformD0Ev.c
+++ b/src/_ZN8PlatformD0Ev.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN8PlatformD0Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8ShipWingD0Ev.c
+++ b/src/_ZN8ShipWingD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjRc_Tikuwa_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjRc_Tikuwa_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN8ShipWingD0Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjRc_Tikuwa_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8ShipWingD1Ev.c
+++ b/src/_ZN8ShipWingD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjRc_Tikuwa_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV16daObjRc_Tikuwa_c; VT1 = _ZTV8Platform */
 int *_ZN8ShipWingD1Ev(int *t)
 {
     t[0] = (int)_ZTV16daObjRc_Tikuwa_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8SignPostD0Ev.c
+++ b/src/_ZN8SignPostD0Ev.c
@@ -7,8 +7,9 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjTatefuda_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjTatefuda_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN8SignPostD0Ev(int *t)
 {
@@ -16,7 +17,7 @@ int *_ZN8SignPostD0Ev(int *t)
     _ZN12WithMeshClsnD1Ev((char *)t + 0x3c8);
     _ZN11ShadowModelD1Ev((char *)t + 0x358);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8SignPostD1Ev.c
+++ b/src/_ZN8SignPostD1Ev.c
@@ -7,15 +7,16 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjTatefuda_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV15daObjTatefuda_c; VT1 = _ZTV8Platform */
 int *_ZN8SignPostD1Ev(int *t)
 {
     t[0] = (int)_ZTV15daObjTatefuda_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x3c8);
     _ZN11ShadowModelD1Ev((char *)t + 0x358);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8SquasherD0Ev.c
+++ b/src/_ZN8SquasherD0Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Squasher[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV8Squasher */
 extern void *data_020a0eac;
 int *_ZN8SquasherD0Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Squasher;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN8SquasherD1Ev.c
+++ b/src/_ZN8SquasherD1Ev.c
@@ -5,12 +5,13 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int _ZTV8Squasher[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV8Squasher */
 int *_ZN8SquasherD1Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Squasher;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN8WallSignD0Ev.c
+++ b/src/_ZN8WallSignD0Ev.c
@@ -4,15 +4,16 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjKanban_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13daObjKanban_c; VT1 = _ZTV8Platform */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void *data_020a0eac;
 int *_ZN8WallSignD0Ev(int *t)
 {
     t[0] = (int)_ZTV13daObjKanban_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8WallSignD1Ev.c
+++ b/src/_ZN8WallSignD1Ev.c
@@ -4,14 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjKanban_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV13daObjKanban_c; VT1 = _ZTV8Platform */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 int *_ZN8WallSignD1Ev(int *t)
 {
     t[0] = (int)_ZTV13daObjKanban_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9HugeCoverD0Ev.c
+++ b/src/_ZN9HugeCoverD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjTdWater_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjTdWater_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN9HugeCoverD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjTdWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9HugeCoverD1Ev.c
+++ b/src/_ZN9HugeCoverD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjTdWater_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjTdWater_c; VT1 = _ZTV8Platform */
 int *_ZN9HugeCoverD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjTdWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9SeesawBobD0Ev.c
+++ b/src/_ZN9SeesawBobD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV9SeesawBob[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjSeesaw_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV9SeesawBob; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN9SeesawBobD0Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjSeesaw_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV9SeesawBob;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9SeesawBobD1Ev.c
+++ b/src/_ZN9SeesawBobD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV9SeesawBob[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjSeesaw_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV9SeesawBob; VT1 = _ZTV8Platform */
 int *_ZN9SeesawBobD1Ev(int *t)
 {
-    t[0] = (int)_ZTV13daObjSeesaw_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV9SeesawBob;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9ShipWaterD0Ev.c
+++ b/src/_ZN9ShipWaterD0Ev.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjKsWater_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjKsWater_c; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN9ShipWaterD0Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjKsWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9ShipWaterD1Ev.c
+++ b/src/_ZN9ShipWaterD1Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjKsWater_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV14daObjKsWater_c; VT1 = _ZTV8Platform */
 int *_ZN9ShipWaterD1Ev(int *t)
 {
     t[0] = (int)_ZTV14daObjKsWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9TinyCoverD0Ev.c
+++ b/src/_ZN9TinyCoverD0Ev.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV9TinyCover[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV9TinyCover */
 extern void *data_020a0eac;
 int *_ZN9TinyCoverD0Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV9TinyCover;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN9TinyCoverD1Ev.c
+++ b/src/_ZN9TinyCoverD1Ev.c
@@ -5,12 +5,13 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_TextureTransformer.h"
 #include "decl_common.h"
+extern int _ZTV9TinyCover[];
 extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV9TinyCover */
 int *_ZN9TinyCoverD1Ev(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV9TinyCover;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN9TowerStepD0Ev.c
+++ b/src/_ZN9TowerStepD0Ev.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV9TowerStep[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjBk_Rotebar_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV9TowerStep; VT1 = _ZTV8Platform */
 extern void *data_020a0eac;
 int *_ZN9TowerStepD0Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjBk_Rotebar_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV9TowerStep;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9TowerStepD1Ev.c
+++ b/src/_ZN9TowerStepD1Ev.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV9TowerStep[];
+extern int _ZTV8Platform[];
 /* recovered: named members + shared header, vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjBk_Rotebar_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = _ZTV9TowerStep; VT1 = _ZTV8Platform */
 int *_ZN9TowerStepD1Ev(int *t)
 {
-    t[0] = (int)_ZTV17daObjBk_Rotebar_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV9TowerStep;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/engine/fader/_ZN5FaderD0Ev.c
+++ b/src/engine/fader/_ZN5FaderD0Ev.c
@@ -3,6 +3,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Fader.h"
+extern void* data_0208eafc[];
 /* _ZN5FaderD0Ev at 0x02017848
  * Single-vtable destructor: write own vtable, call base/helper destructor (0x0203cbcc), return this.
  */
@@ -10,7 +11,7 @@ struct Obj { void *vtable; };
 extern void base_dtor_Fader(struct Obj *thiz); /* 0x0203cbcc */
 struct Obj *_ZN5FaderD0Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_Fader;
+    thiz->vtable = (void *)data_0208eafc;
     base_dtor_Fader(thiz);
     return thiz;
 }

--- a/src/func_ov002_020aedbc.c
+++ b/src/func_ov002_020aedbc.c
@@ -2,12 +2,13 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_common.h"
+extern int data_ov002_02108284[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV11dCapEnemy_c */
+/* vtable identified: VT0 = data_ov002_02108284 */
 extern void func_ov002_020aed18(void *);
 int *func_ov002_020aedbc(int *t)
 {
-    t[0] = (int)_ZTV11dCapEnemy_c;
+    t[0] = (int)data_ov002_02108284;
     func_ov001_020ab3a0((char *)t + 0x164);
     _ZN5ModelD1Ev((char *)t + 0x114);
     func_ov002_020aed18(t);

--- a/src/func_ov002_020b05d0.c
+++ b/src/func_ov002_020b05d0.c
@@ -3,11 +3,12 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_02108480[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV7daBar_c */
+/* vtable identified: VT0 = data_ov002_02108480 */
 int *func_ov002_020b05d0(int *t)
 {
-    t[0] = (int)_ZTV7daBar_c;
+    t[0] = (int)data_ov002_02108480;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020b3298.c
+++ b/src/func_ov002_020b3298.c
@@ -3,11 +3,12 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_02108964[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV12daObjAbuku_c */
+/* vtable identified: VT0 = data_ov002_02108964 */
 int *func_ov002_020b3298(int *t)
 {
-    t[0] = (int)_ZTV12daObjAbuku_c;
+    t[0] = (int)data_ov002_02108964;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020b5a18.c
+++ b/src/func_ov002_020b5a18.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02108fdc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02108fdc */
 extern void *data_020a0eac;
 int *func_ov002_020b5a18(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02108fdc;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b5a70.c
+++ b/src/func_ov002_020b5a70.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02108fdc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02108fdc */
 int *func_ov002_020b5a70(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02108fdc;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b5fd8.c
+++ b/src/func_ov002_020b5fd8.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02109084[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02109084 */
 extern void *data_020a0eac;
 int *func_ov002_020b5fd8(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02109084;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6030.c
+++ b/src/func_ov002_020b6030.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02109084[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02109084 */
 int *func_ov002_020b6030(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02109084;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6388.c
+++ b/src/func_ov002_020b6388.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_0210912c[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_0210912c */
 extern void *data_020a0eac;
 int *func_ov002_020b6388(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_0210912c;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b63e0.c
+++ b/src/func_ov002_020b63e0.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_0210912c[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_0210912c */
 int *func_ov002_020b63e0(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_0210912c;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b660c.c
+++ b/src/func_ov002_020b660c.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_021091d4 */
 extern void *data_020a0eac;
 int *func_ov002_020b660c(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6664.c
+++ b/src/func_ov002_020b6664.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_021091d4 */
 int *func_ov002_020b6664(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6814.c
+++ b/src/func_ov002_020b6814.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02109278[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02109278 */
 extern void *data_020a0eac;
 int *func_ov002_020b6814(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02109278;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b686c.c
+++ b/src/func_ov002_020b686c.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02109278[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02109278 */
 int *func_ov002_020b686c(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02109278;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b69e4.c
+++ b/src/func_ov002_020b69e4.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02109320[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02109320 */
 extern void *data_020a0eac;
 int *func_ov002_020b69e4(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02109320;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6a3c.c
+++ b/src/func_ov002_020b6a3c.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_02109320[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_02109320 */
 int *func_ov002_020b6a3c(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_02109320;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b8bf0.c
+++ b/src/func_ov002_020b8bf0.c
@@ -5,13 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov002_021096b0[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjPushblock_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_021096b0; VT1 = _ZTV8Platform */
 int *func_ov002_020b8bf0(int *t)
 {
-    t[0] = (int)_ZTV16daObjPushblock_c;
+    t[0] = (int)data_ov002_021096b0;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020bab0c.c
+++ b/src/func_ov002_020bab0c.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_021099e4[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_021099e4 */
 extern void *data_020a0eac;
 int *func_ov002_020bab0c(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_021099e4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020bab64.c
+++ b/src/func_ov002_020bab64.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov002_021099e4[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov002_021099e4 */
 int *func_ov002_020bab64(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov002_021099e4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020bc414.c
+++ b/src/func_ov002_020bc414.c
@@ -3,11 +3,12 @@
 #include "decl_Actor.h"
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov002_02109bb8[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjWakame_c */
+/* vtable identified: VT0 = data_ov002_02109bb8 */
 int *func_ov002_020bc414(int *t)
 {
-    t[0] = (int)_ZTV13daObjWakame_c;
+    t[0] = (int)data_ov002_02109bb8;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020ec388.c
+++ b/src/func_ov002_020ec388.c
@@ -3,11 +3,12 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_0210acbc[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV11daWarpkun_c */
+/* vtable identified: VT0 = data_ov002_0210acbc */
 int *func_ov002_020ec388(int *t)
 {
-    t[0] = (int)_ZTV11daWarpkun_c;
+    t[0] = (int)data_ov002_0210acbc;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020f03c4.c
+++ b/src/func_ov002_020f03c4.c
@@ -3,11 +3,12 @@
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
 #include "decl_common.h"
+extern int data_ov002_0210b030[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV9daSCoin_c */
+/* vtable identified: VT0 = data_ov002_0210b030 */
 int *func_ov002_020f03c4(int *t)
 {
-    t[0] = (int)_ZTV9daSCoin_c;
+    t[0] = (int)data_ov002_0210b030;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov006_020cd12c.c
+++ b/src/func_ov006_020cd12c.c
@@ -2,12 +2,13 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov006_0213b2c4[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV18dMgTrmpln3DMario_c */
+/* vtable identified: VT0 = data_ov006_0213b2c4 */
 int *func_ov006_020cd12c(int *t)
 {
     data_ov007_020cd72c(t);
-    t[0] = (int)_ZTV18dMgTrmpln3DMario_c;
+    t[0] = (int)data_ov006_0213b2c4;
     _ZN9ModelAnimC1Ev((char *)t + 0x6c);
     return t;
 }

--- a/src/func_ov006_020e6bf4.c
+++ b/src/func_ov006_020e6bf4.c
@@ -2,14 +2,15 @@
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
 #include "decl_common.h"
+extern int data_ov006_0213c510[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV15dScMgCurling2_c */
+/* vtable identified: VT0 = data_ov006_0213c510 */
 int *func_ov006_020e6bf4(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(21956);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)_ZTV15dScMgCurling2_c;
+        p[0] = (int)data_ov006_0213c510;
     }
     return p;
 }

--- a/src/func_ov010_021111a0.c
+++ b/src/func_ov010_021111a0.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov010_02112ae4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjC1_Trap_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov010_02112ae4; VT1 = _ZTV8Platform */
 int *func_ov010_021111a0(int *t)
 {
-    t[0] = (int)_ZTV14daObjC1_Trap_c;
+    t[0] = (int)data_ov010_02112ae4;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov012_021111a0.c
+++ b/src/func_ov012_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov012_02112344[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjC0_Switch_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov012_02112344; VT1 = _ZTV8Platform */
 int *func_ov012_021111a0(int *t)
 {
-    t[0] = (int)_ZTV16daObjC0_Switch_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov012_02112344;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov015_021111a0.c
+++ b/src/func_ov015_021111a0.c
@@ -3,11 +3,12 @@
 #include "decl_Actor.h"
 #include "decl_Model.h"
 #include "decl_common.h"
+extern int data_ov015_02114360[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjBkBillboard_c */
+/* vtable identified: VT0 = data_ov015_02114360 */
 int *func_ov015_021111a0(int *t)
 {
-    t[0] = (int)_ZTV18daObjBkBillboard_c;
+    t[0] = (int)data_ov015_02114360;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov015_02112bd0.c
+++ b/src/func_ov015_02112bd0.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov015_021147e8[];
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjBk_Ukisima_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov015_021147e8; VT1 = data_ov002_021091d4 */
 int *func_ov015_02112bd0(int *t)
 {
-    t[0] = (int)_ZTV17daObjBk_Ukisima_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov015_021147e8;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov016_02112a00.c
+++ b/src/func_ov016_02112a00.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov016_02114b00[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjKi_Hasira_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov016_02114b00; VT1 = _ZTV8Platform */
 int *func_ov016_02112a00(int *t)
 {
-    t[0] = (int)_ZTV16daObjKi_Hasira_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov016_02114b00;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov016_02112ef4.c
+++ b/src/func_ov016_02112ef4.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov016_02114bcc[];
+extern int data_ov002_02108fdc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjKi_Ita_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov016_02114bcc; VT1 = data_ov002_02108fdc */
 int *func_ov016_02112ef4(int *t)
 {
-    t[0] = (int)_ZTV13daObjKi_Ita_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov016_02114bcc;
+    t[0] = (int)data_ov002_02108fdc;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov018_021111a0.c
+++ b/src/func_ov018_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov018_021138cc[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjSm_Lift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov018_021138cc; VT1 = _ZTV8Platform */
 int *func_ov018_021111a0(int *t)
 {
-    t[0] = (int)_ZTV14daObjSm_Lift_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov018_021138cc;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov022_021111a0.c
+++ b/src/func_ov022_021111a0.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02113d18[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov022_02113d18 */
 int *func_ov022_021111a0(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov022_02113d18;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov022_021111e4.c
+++ b/src/func_ov022_021111e4.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02113d18[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov022_02113d18 */
 extern void *data_020a0eac;
 int *func_ov022_021111e4(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov022_02113d18;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov022_021115a8.c
+++ b/src/func_ov022_021115a8.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02113de8[];
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjFl_Koma_D_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov022_02113de8; VT1 = data_ov002_021091d4 */
 int *func_ov022_021115a8(int *t)
 {
-    t[0] = (int)_ZTV16daObjFl_Koma_D_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov022_02113de8;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov022_02111980.c
+++ b/src/func_ov022_02111980.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02113f70[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjFl_London_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov022_02113f70; VT1 = _ZTV8Platform */
 int *func_ov022_02111980(int *t)
 {
-    t[0] = (int)_ZTV16daObjFl_London_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov022_02113f70;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov022_02111cac.c
+++ b/src/func_ov022_02111cac.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov022_02114034[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjFl_Seesaw_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov022_02114034; VT1 = _ZTV8Platform */
 int *func_ov022_02111cac(int *t)
 {
-    t[0] = (int)_ZTV16daObjFl_Seesaw_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov022_02114034;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov025_021111a0.c
+++ b/src/func_ov025_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int _ZTV8Platform[];
+extern int data_ov025_02113760[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV7daDgr_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov025_02113760; VT1 = _ZTV8Platform */
 int *func_ov025_021111a0(int *t)
 {
-    t[0] = (int)_ZTV7daDgr_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov025_02113760;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov026_021111a0.c
+++ b/src/func_ov026_021111a0.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov026_02113ae0[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjWlPolelift_c */
+/* vtable identified: VT0 = data_ov026_02113ae0 */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 int *func_ov026_021111a0(int *t)
 {
-    t[0] = (int)_ZTV17daObjWlPolelift_c;
+    t[0] = (int)data_ov026_02113ae0;
     _ZN11ShadowModelD1Ev((char *)t + 0x188);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov026_02111678.c
+++ b/src/func_ov026_02111678.c
@@ -6,15 +6,16 @@
 #include "decl_MovingCylinderClsnWithPos.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov026_02113ae0[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjWlPolelift_c */
+/* vtable identified: VT0 = data_ov026_02113ae0 */
 extern void _ZN7PathPtrC1Ev(void *);
 int *func_ov026_02111678(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(484);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV17daObjWlPolelift_c;
+        p[0] = (int)data_ov026_02113ae0;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x124);
         _ZN7PathPtrC1Ev((char *)p + 0x164);

--- a/src/func_ov026_021116c8.c
+++ b/src/func_ov026_021116c8.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov026_02113ba4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV21daObjWlKoopaShutter_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov026_02113ba4; VT1 = _ZTV8Platform */
 int *func_ov026_021116c8(int *t)
 {
-    t[0] = (int)_ZTV21daObjWlKoopaShutter_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov026_02113ba4;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov026_021118b8.c
+++ b/src/func_ov026_021118b8.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov026_02113c6c[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjWlSubmarine_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov026_02113c6c; VT1 = _ZTV8Platform */
 int *func_ov026_021118b8(int *t)
 {
-    t[0] = (int)_ZTV18daObjWlSubmarine_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov026_02113c6c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov027_021115c4.c
+++ b/src/func_ov027_021115c4.c
@@ -5,13 +5,14 @@
 #include "decl_ShadowModel.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov027_02113930[];
 extern int data_ov064_0211b768[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV12daIDonketu_c */
+/* vtable identified: VT0 = data_ov027_02113930 */
 extern void func_ov002_020aed18(void *);
 int *func_ov027_021115c4(int *t)
 {
-    t[0] = (int)_ZTV12daIDonketu_c;
+    t[0] = (int)data_ov027_02113930;
     t[0] = (int)data_ov064_0211b768;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/func_ov027_021118c8.c
+++ b/src/func_ov027_021118c8.c
@@ -6,16 +6,18 @@
 #include "decl_MovingCylinderClsn.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov027_02113a90[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10daPgDfdr_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov027_02113a90; VT1 = _ZTV8Platform */
 extern void _ZN15TextureSequenceD1Ev(void *);
 int *func_ov027_021118c8(int *t)
 {
-    t[0] = (int)_ZTV10daPgDfdr_c;
+    t[0] = (int)data_ov027_02113a90;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x398);
     _ZN15TextureSequenceD1Ev((char *)t + 0x384);
     _ZN9ModelAnimD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov027_0211207c.c
+++ b/src/func_ov027_0211207c.c
@@ -6,14 +6,15 @@
 #include "decl_Platform.h"
 #include "decl_TextureSequence.h"
 #include "decl_common.h"
+extern int data_ov027_02113a90[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10daPgDfdr_c */
+/* vtable identified: VT0 = data_ov027_02113a90 */
 int *func_ov027_0211207c(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(988);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV10daPgDfdr_c;
+        p[0] = (int)data_ov027_02113a90;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN15TextureSequenceC1Ev((char *)p + 0x384);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x398);

--- a/src/func_ov029_021111a0.c
+++ b/src/func_ov029_021111a0.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov029_02113c2c[];
+extern int data_ov002_02108fdc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjWcObj01_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov029_02113c2c; VT1 = data_ov002_02108fdc */
 int *func_ov029_021111a0(int *t)
 {
-    t[0] = (int)_ZTV14daObjWcObj01_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov029_02113c2c;
+    t[0] = (int)data_ov002_02108fdc;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov029_02111ac4.c
+++ b/src/func_ov029_02111ac4.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov029_02113e74[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV15daObjWc_Obj05_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov029_02113e74; VT1 = _ZTV8Platform */
 int *func_ov029_02111ac4(int *t)
 {
-    t[0] = (int)_ZTV15daObjWc_Obj05_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov029_02113e74;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov029_02111ea4.c
+++ b/src/func_ov029_02111ea4.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov029_02113f44[];
+extern int data_ov002_02108fdc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV14daObjWcObj06_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov029_02113f44; VT1 = data_ov002_02108fdc */
 int *func_ov029_02111ea4(int *t)
 {
-    t[0] = (int)_ZTV14daObjWcObj06_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov029_02113f44;
+    t[0] = (int)data_ov002_02108fdc;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov030_021111a0.c
+++ b/src/func_ov030_021111a0.c
@@ -5,13 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
+extern int data_ov030_02115974[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjHmBskt_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov030_02115974; VT1 = _ZTV8Platform */
 int *func_ov030_021111a0(int *t)
 {
-    t[0] = (int)_ZTV13daObjHmBskt_c;
+    t[0] = (int)data_ov030_02115974;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov032_021124a8.c
+++ b/src/func_ov032_021124a8.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov032_021138e0[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjTdFuta_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov032_021138e0; VT1 = _ZTV8Platform */
 int *func_ov032_021124a8(int *t)
 {
-    t[0] = (int)_ZTV13daObjTdFuta_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov032_021138e0;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov033_021111a0.c
+++ b/src/func_ov033_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov033_0211237c[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjTtFuta_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov033_0211237c; VT1 = _ZTV8Platform */
 int *func_ov033_021111a0(int *t)
 {
-    t[0] = (int)_ZTV13daObjTtFuta_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov033_0211237c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov036_021111a0.c
+++ b/src/func_ov036_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov036_02113a98[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjRcBuranko_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov036_02113a98; VT1 = _ZTV8Platform */
 int *func_ov036_021111a0(int *t)
 {
-    t[0] = (int)_ZTV16daObjRcBuranko_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov036_02113a98;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov036_02111444.c
+++ b/src/func_ov036_02111444.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov036_02113b74[];
+extern int data_ov002_021091d4[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV19daObjRc_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov036_02113b74; VT1 = data_ov002_021091d4 */
 int *func_ov036_02111444(int *t)
 {
-    t[0] = (int)_ZTV19daObjRc_Kaitendai_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov036_02113b74;
+    t[0] = (int)data_ov002_021091d4;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov043_021111a0.c
+++ b/src/func_ov043_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov043_021122b8[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV19daObjKm1_Ukishima_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov043_021122b8; VT1 = _ZTV8Platform */
 int *func_ov043_021111a0(int *t)
 {
-    t[0] = (int)_ZTV19daObjKm1_Ukishima_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov043_021122b8;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov043_021113fc.c
+++ b/src/func_ov043_021113fc.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov043_0211238c[];
+extern int data_ov002_02109320[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV21daObjKm1_Kurumajiku_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov043_0211238c; VT1 = data_ov002_02109320 */
 int *func_ov043_021113fc(int *t)
 {
-    t[0] = (int)_ZTV21daObjKm1_Kurumajiku_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov043_0211238c;
+    t[0] = (int)data_ov002_02109320;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov045_021111a0.c
+++ b/src/func_ov045_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov045_02112cf4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjKm2_Agaru_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov045_02112cf4; VT1 = _ZTV8Platform */
 int *func_ov045_021111a0(int *t)
 {
-    t[0] = (int)_ZTV16daObjKm2_Agaru_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov045_02112cf4;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov045_02111b14.c
+++ b/src/func_ov045_02111b14.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov045_02112f50[];
+extern int data_ov002_0210912c[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV19daObjKm2_Ukishima_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov045_02112f50; VT1 = data_ov002_0210912c */
 int *func_ov045_02111b14(int *t)
 {
-    t[0] = (int)_ZTV19daObjKm2_Ukishima_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov045_02112f50;
+    t[0] = (int)data_ov002_0210912c;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov047_021111a0.c
+++ b/src/func_ov047_021111a0.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov047_021122a0[];
+extern int data_ov002_02109320[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV21daObjKm3_Kurumajiku_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov047_021122a0; VT1 = data_ov002_02109320 */
 int *func_ov047_021111a0(int *t)
 {
-    t[0] = (int)_ZTV21daObjKm3_Kurumajiku_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov047_021122a0;
+    t[0] = (int)data_ov002_02109320;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov047_021113bc.c
+++ b/src/func_ov047_021113bc.c
@@ -3,15 +3,16 @@
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
+extern int data_ov002_021091d4[];
 extern int _ZTV10RickshawBs[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c */
+/* vtable identified: VT0 = data_ov002_021091d4 */
 int *func_ov047_021113bc(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
+        p[0] = (int)data_ov002_021091d4;
         p[0] = (int)_ZTV10RickshawBs;
     }
     return p;

--- a/src/func_ov047_021113f8.c
+++ b/src/func_ov047_021113f8.c
@@ -4,13 +4,15 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov047_0211244c[];
+extern int data_ov002_02109278[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjKm3_Kuruma_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov047_0211244c; VT1 = data_ov002_02109278 */
 int *func_ov047_021113f8(int *t)
 {
-    t[0] = (int)_ZTV17daObjKm3_Kuruma_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov047_0211244c;
+    t[0] = (int)data_ov002_02109278;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov052_021111a0.c
+++ b/src/func_ov052_021111a0.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov052_02112520[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV13daObjEmmLog_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov052_02112520; VT1 = _ZTV8Platform */
 int *func_ov052_021111a0(int *t)
 {
-    t[0] = (int)_ZTV13daObjEmmLog_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov052_02112520;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov060_02117d1c.c
+++ b/src/func_ov060_02117d1c.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov060_0211a9b0[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10daKpa3Bg_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov060_0211a9b0; VT1 = _ZTV8Platform */
 int *func_ov060_02117d1c(int *t)
 {
-    t[0] = (int)_ZTV10daKpa3Bg_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov060_0211a9b0;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov064_02117978.c
+++ b/src/func_ov064_02117978.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov064_0211bc68[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV17daObjFl_Amilift_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov064_0211bc68; VT1 = _ZTV8Platform */
 int *func_ov064_02117978(int *t)
 {
-    t[0] = (int)_ZTV17daObjFl_Amilift_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov064_0211bc68;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov065_02119f3c.c
+++ b/src/func_ov065_02119f3c.c
@@ -5,13 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov065_0211d0ec[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha03_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov065_0211d0ec; VT1 = _ZTV8Platform */
 int *func_ov065_02119f3c(int *t)
 {
-    t[0] = (int)_ZTV16daObjCtMecha03_c;
+    t[0] = (int)data_ov065_0211d0ec;
     _ZN11ShadowModelD1Ev((char *)t + 0x330);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov065_0211a45c.c
+++ b/src/func_ov065_0211a45c.c
@@ -4,14 +4,15 @@
 #include "decl_Platform.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov065_0211d0ec[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha03_c */
+/* vtable identified: VT0 = data_ov065_0211d0ec */
 int *func_ov065_0211a45c(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(904);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)_ZTV16daObjCtMecha03_c;
+        p[0] = (int)data_ov065_0211d0ec;
         _ZN11ShadowModelC1Ev((char *)p + 0x330);
     }
     return p;

--- a/src/func_ov065_0211ab60.c
+++ b/src/func_ov065_0211ab60.c
@@ -5,13 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov065_0211d2b4[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV16daObjCtMecha05_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov065_0211d2b4; VT1 = _ZTV8Platform */
 int *func_ov065_0211ab60(int *t)
 {
-    t[0] = (int)_ZTV16daObjCtMecha05_c;
+    t[0] = (int)data_ov065_0211d2b4;
     _ZN11ShadowModelD1Ev((char *)t + 0x33c);
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov072_02120824.c
+++ b/src/func_ov072_02120824.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov072_02122978[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV11daBgSnwmn_c */
+/* vtable identified: VT0 = data_ov072_02122978 */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
 int *func_ov072_02120824(int *t)
 {
-    t[0] = (int)_ZTV11daBgSnwmn_c;
+    t[0] = (int)data_ov072_02122978;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1b0);
     _ZN11ShadowModelD1Ev((char *)t + 0x188);
     _ZN15TextureSequenceD1Ev((char *)t + 0x174);

--- a/src/func_ov072_02120c00.c
+++ b/src/func_ov072_02120c00.c
@@ -7,14 +7,15 @@
 #include "decl_ShadowModel.h"
 #include "decl_TextureSequence.h"
 #include "decl_common.h"
+extern int data_ov072_02122978[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV11daBgSnwmn_c */
+/* vtable identified: VT0 = data_ov072_02122978 */
 int *func_ov072_02120c00(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(496);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)_ZTV11daBgSnwmn_c;
+        p[0] = (int)data_ov072_02122978;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x124);
         _ZN15TextureSequenceC1Ev((char *)p + 0x174);

--- a/src/func_ov079_02126dbc.c
+++ b/src/func_ov079_02126dbc.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov079_02127fb8[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV18daObjBkKillerdai_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov079_02127fb8; VT1 = _ZTV8Platform */
 int *func_ov079_02126dbc(int *t)
 {
-    t[0] = (int)_ZTV18daObjBkKillerdai_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov079_02127fb8;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov080_02126fbc.c
+++ b/src/func_ov080_02126fbc.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov080_02128338[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov080_02128338 */
 extern void *data_020a0eac;
 int *func_ov080_02126fbc(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov080_02128338;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov080_02127014.c
+++ b/src/func_ov080_02127014.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov080_02128338[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov080_02128338 */
 int *func_ov080_02127014(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov080_02128338;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov091_02132d04.c
+++ b/src/func_ov091_02132d04.c
@@ -5,14 +5,15 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov091_021351fc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov091_021351fc */
 extern void _ZN15TextureSequenceD1Ev(void *);
 extern void *data_020a0eac;
 int *func_ov091_02132d04(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov091_021351fc;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)_ZTV8Platform;

--- a/src/func_ov091_02132d6c.c
+++ b/src/func_ov091_02132d6c.c
@@ -5,13 +5,14 @@
 #include "decl_MovingMeshCollider.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
+extern int data_ov091_021351fc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov091_021351fc */
 extern void _ZN15TextureSequenceD1Ev(void *);
 int *func_ov091_02132d6c(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov091_021351fc;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)_ZTV8Platform;

--- a/src/func_ov091_021333fc.c
+++ b/src/func_ov091_021333fc.c
@@ -4,12 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov091_021352bc[];
+extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV11daObjPile_c; VT1 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov091_021352bc; VT1 = _ZTV8Platform */
 int *func_ov091_021333fc(int *t)
 {
-    t[0] = (int)_ZTV11daObjPile_c;
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov091_021352bc;
+    t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov098_02139f70.c
+++ b/src/func_ov098_02139f70.c
@@ -4,13 +4,14 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov098_0213c5bc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov098_0213c5bc */
 extern void *data_020a0eac;
 int *func_ov098_02139f70(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov098_0213c5bc;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov098_02139fc8.c
+++ b/src/func_ov098_02139fc8.c
@@ -4,12 +4,13 @@
 #include "decl_Model.h"
 #include "decl_MovingMeshCollider.h"
 #include "decl_common.h"
+extern int data_ov098_0213c5bc[];
 extern int _ZTV8Platform[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV10dBgActor_c */
+/* vtable identified: VT0 = data_ov098_0213c5bc */
 int *func_ov098_02139fc8(int *t)
 {
-    t[0] = (int)_ZTV10dBgActor_c;
+    t[0] = (int)data_ov098_0213c5bc;
     t[0] = (int)_ZTV8Platform;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov100_021443f4.c
+++ b/src/func_ov100_021443f4.c
@@ -3,11 +3,12 @@
 #include "decl_Actor.h"
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
+extern int data_ov100_02148188[];
 /* recovered: vtable identified */
-/* vtable identified: VT0 = _ZTV8daDoor_c */
+/* vtable identified: VT0 = data_ov100_02148188 */
 int *func_ov100_021443f4(int *t)
 {
-    t[0] = (int)_ZTV8daDoor_c;
+    t[0] = (int)data_ov100_02148188;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;


### PR DESCRIPTION
Second and final batch of the change described in batch 01: a name that resolves to nothing but is declared in a shared header is a **stand-in, not a symbol**, and dsd's relocation data says what each reference actually meant.

**136 files, every one byte-verified after the edit, 0 reverted.**

| | |
|---|---|
| enrolled | 9,906 → **10,039** (+133) |
| code bytes built | 76.96% → **77.42%** |
| reproducing | 10,039 / 10,039 |
| module fidelity | 106/106 exact, 100.000000% of compared bytes |
| ROM-build analysis | **PASS** |
| attribution | 0 changed, 0 lost |

Independent of batch 01 — both cut from main, either can land first. Together they enroll **10,162 (77.85%)**.

The tool change lives in batch 01; this batch is its output only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi