### PR TITLE
Add port_refcheck: reference-integrity gate for port/ into src/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,23 @@ So:
 - Don't add a type to a shared header speculatively. A name in `include/` is a claim that
   every consumer agrees on it; a wrong shared type is far more expensive than a local one.
 
+## `port/` references (renames, `.c`→`.cpp`, file moves)
+
+`port/` builds its own MSVC host executable that points into `src/` by literal path and
+symbol name: `slice_gate*.txt` manifests list `src/` files to compile, `CMakeLists.txt`
+hardcodes hostgen symbol lists resolved against `src/<sym>.c`/`.cpp`, and `port/hal/*.cpp`
+bridges MSVC linkage onto `func_XXXXXXXX`/`data_XXXXXXXX` names via `#pragma alternatename`
+and `extern "C"`. None of that is compiled by the normal decomp toolchain or `tools/cpp_rename.py`,
+so a rename, a `.c`-to-`.cpp` migration, or a file move can silently strand a `port/`
+reference. Before pushing anything that renames or moves a `src/`/`include/` file, run:
+
+```
+python tools/port_refcheck.py
+```
+
+It checks references only (no compiler, no ROM — runs in about a second) and is also
+wired into `tools/hooks/pre-push`.
+
 ## Match logging (WHO / HOW / tries)
 
 | Extra | Store | Rule |

--- a/MERGE.md
+++ b/MERGE.md
@@ -36,6 +36,12 @@ function, follow this.
   not a PR problem** — pull on the box and re-run, never override it.
 - **Near-miss DB / notes / tooling PRs** have no `src` match to byte-check; review for sanity
   and merge.
+- **`port/` reference breaks.** A rename, `.c`-to-`.cpp` migration, or file move in `src/`/
+  `include/` can strand a `port/` reference (`slice_gate*.txt`, `CMakeLists.txt` hostgen
+  symbol lists, `port/hal/*.cpp` linkage bridges) — nothing in `validate` catches this since
+  `port/`'s MSVC build isn't part of the decomp toolchain. `python tools/port_refcheck.py`
+  is the check (also runs in `tools/hooks/pre-push`); treat a report from it like any other
+  bug and fix the `port/` side before merging.
 - **Drafts:** never merge someone else's draft. That is the author saying "not ready."
 
 ## 3. How to merge (preserve attribution)

--- a/notes/pr-validation.md
+++ b/notes/pr-validation.md
@@ -11,6 +11,7 @@ one misleading percentage:
 | Module fidelity | Linked executable-module bytes equal retail | Stock head must pass, unless base and head have the same recorded pre-existing build failure |
 | Contributor lineage | The first matcher still owns a surviving match after moves/renames | Must not change or disappear |
 | Relocations | Affected source reproduces bytes and names the correct destinations | No WRONG or NO-REPRO |
+| Port references | `port/`'s manifests and symbol bridges still name files and symbols that exist | No stale reference (optional phase) |
 
 `tools/rombuild.py` emits the build/fidelity artifact. `tools/validate_merge.py` compares
 two committed revisions, combines the build artifacts with `pr_linkcheck` JSON, and emits
@@ -28,17 +29,22 @@ The compiler and ROM remain on the private worker. For each relay job:
    uncommitted move has no lineage.
 3. Run `python tools/rombuild.py --profile stock --report-json build/head-rom.json`.
 4. Run `python tools/pr_linkcheck.py --base <baseSha> --json build/link.json --md build/link.md`.
-5. Run:
+5. If the PR touched `src/` or `include/`, run
+   `python tools/port_refcheck.py --json build/port.json`. No compiler and no ROM, so
+   it costs about a second. It is optional on both sides: a worker that does not run it,
+   or a base that predates the tool, simply reports no port row.
+6. Run:
 
    ```
    python tools/validate_merge.py --base <baseSha> --head HEAD \
      --require-merge-commit --expected-pr-head <headSha> \
      --base-rom-report build/base-rom.json \
      --head-rom-report build/head-rom.json --link-report build/link.json \
+     --port-refcheck-report build/port.json \
      --out build/validate-report.json --markdown build/validate-report.md
    ```
 
-6. Return `status`, `summary`, `details` (the existing per-file table), and the new
+7. Return `status`, `summary`, `details` (the existing per-file table), and the new
    `reportMarkdown` field to the relay. The public GitHub workflow remains unable to run
    PR code or access ROM material; it only renders the worker's result.
 

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -10,6 +10,11 @@
 # once a PR is open -- and the mistake is invisible in review, because every file still
 # byte-matches. See tools/prepush_attribution.py.
 #
+# It also checks port/'s references into src/ (manifests, hostgen symbol lists, HAL linkage
+# bridges). port/ has its own MSVC build that nothing in the decomp toolchain compiles or
+# links, so a src/ rename can strand a port/ reference with no other gate to catch it. See
+# tools/port_refcheck.py.
+#
 # Install:
 #   cp tools/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 # Bypass once (you had better be sure):
@@ -34,6 +39,12 @@ remote_ref_check() {
 
     echo "pre-push: link-verifying src/ changes in $range"
     if ! python tools/prepush_linkcheck.py --range "$range"; then
+      echo "pre-push: REFUSING to push (see above). Override with --no-verify if you are certain." >&2
+      return 1
+    fi
+
+    echo "pre-push: checking port/ references into src/"
+    if ! python tools/port_refcheck.py; then
       echo "pre-push: REFUSING to push (see above). Override with --no-verify if you are certain." >&2
       return 1
     fi

--- a/tools/port_refcheck.py
+++ b/tools/port_refcheck.py
@@ -1,0 +1,392 @@
+"""Reference-integrity gate for the MSVC port at port/.
+
+WHY THIS EXISTS
+---------------
+port/ builds a standalone MSVC host executable that references decomp src/
+by literal path and symbol name:
+  - port/slice_gate*.txt manifests list src/ (and a couple of port/unmatched)
+    files the host build compiles, one repo-root-relative path per line.
+  - port/CMakeLists.txt hardcodes GATE*_SYMS lists that hostgen.py resolves
+    to src/<sym>.c or src/<sym>.cpp (mirroring the same probe here).
+  - port/hal/*.cpp bridges MSVC linkage onto the decomp's func_XXXXXXXX /
+    data_XXXXXXXX address-based naming through
+    `#pragma comment(linker, "/alternatename:A=B")` and extern "C"
+    declarations of those same names.
+
+None of that is compiled or linked by the normal decomp toolchain (mwccarm,
+the match/linkcheck pipeline), so a rename in src/ -- by hand, by
+tools/cpp_rename.py, or a plain .c-to-.cpp / file-move -- can silently
+strand a port/ reference. Nothing else catches it until someone attempts an
+MSVC build.
+
+This tool checks the port's references against the worktree's own files --
+no compiler, no ROM -- so it runs in about a second and can gate every push.
+
+CHECKS
+------
+1. manifests  - every non-comment, non-blank line in each of
+                 port/slice_gate{1,2,3a,3b,4b,6,7,8,9}.txt names a path that
+                 exists in the repo.
+2. cmake syms - every symbol in port/CMakeLists.txt's hostgen `set(*_SYMS ...)`
+                 lists resolves to src/<sym>.c or src/<sym>.cpp, the same
+                 .c-then-.cpp probe the CMake itself runs at configure time.
+3. hal links  - every func_XXXXXXXX / data_XXXXXXXX name that appears as the
+                 alias or target of a `#pragma comment(linker,
+                 "/alternatename:...")`, or as an extern "C" declaration, in
+                 port/hal/*.cpp still appears (as an identifier) somewhere
+                 under src/ or include/.
+
+Scope note on check 3: only bare func_/data_ address-style names are
+checked (the ones a src/ rename can actually break). Itanium-mangled names
+declared extern "C" (e.g. _ZN6Memory16rootHeapIteratorE) and MSVC C++-mangled
+symbols the pragmas reference (e.g. ?Crash@@YAXXZ) are decomp *identifiers*
+that a rename tool would not touch the address-form of, so they are out of
+scope here -- see AGENTS.md/MERGE.md for the human-facing rule.
+
+Usage:
+  python tools/port_refcheck.py
+  python tools/port_refcheck.py --json
+"""
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+PORT = REPO / "port"
+
+SLICE_GATE_SUFFIXES = ["1", "2", "3a", "3b", "4b", "6", "7", "8", "9"]
+SRC_DIRS = [REPO / "src", REPO / "include"]
+CODE_SUFFIXES = {".c", ".cpp", ".h", ".hpp"}
+
+# func_XXXXXXXX / data_XXXXXXXX, with an optional ovNNN_ overlay qualifier
+# (e.g. data_ov098_0213c380) -- the address-based naming a src/ rename can
+# strand a port/ reference to.
+IDENT_CORE = r"(?:func|data)_(?:ov\d+_)?[0-9a-fA-F]{8}"
+IDENT_FULL_RE = re.compile(r"^" + IDENT_CORE + r"$")
+IDENT_SCAN_RE = re.compile(r"\b" + IDENT_CORE + r"\b")
+
+SET_SYMS_RE = re.compile(r"\bset\(\s*(\w+_SYMS)\b(.*?)\)", re.DOTALL)
+PRAGMA_RE = re.compile(r'#pragma\s+comment\(\s*linker\s*,\s*"(/alternatename:[^"]*)"\s*\)')
+EXTERN_C_RE = re.compile(r'extern\s*"C"')
+
+
+class Failure:
+    def __init__(self, file, line, message):
+        self.file = file
+        self.line = line
+        self.message = message
+
+    def __str__(self):
+        return f"{self.file}:{self.line}: {self.message}"
+
+    def to_dict(self):
+        return {"file": self.file, "line": self.line, "message": self.message}
+
+
+def _line_at(text, pos):
+    return text.count("\n", 0, pos) + 1
+
+
+def _mask_comments(text):
+    """Blank out // and /* */ comment interiors, preserving length and
+    newlines, so brace-matching and keyword search never trip over prose
+    like "the extern \"C\" side of..." inside a comment."""
+    out = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            out.append(" " * (j - i))
+            i = j
+        elif c == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            out.append("".join(ch if ch == "\n" else " " for ch in text[i:j]))
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+# ---- check 1: slice manifests -----------------------------------------------
+
+def check_manifests():
+    """Every path listed in a slice_gate*.txt manifest exists in the repo."""
+    failures = []
+    checked = 0
+    for suffix in SLICE_GATE_SUFFIXES:
+        manifest = PORT / f"slice_gate{suffix}.txt"
+        rel = manifest.relative_to(REPO).as_posix()
+        if not manifest.exists():
+            failures.append(Failure(rel, 0, "manifest file not found"))
+            continue
+        text = manifest.read_text(encoding="utf-8", errors="ignore")
+        for lineno, raw in enumerate(text.splitlines(), start=1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            checked += 1
+            if not (REPO / line).exists():
+                failures.append(Failure(rel, lineno, f"{line} not found (renamed?)"))
+    return checked, failures
+
+
+# ---- check 2: CMake hostgen symbol lists ------------------------------------
+
+def check_cmake_symbols():
+    """Every symbol in a `set(GATE*_SYMS ...)` list resolves to src/<sym>.c
+    or src/<sym>.cpp, mirroring the EXISTS-then-.c-else-.cpp probe the CMake
+    itself runs (port/CMakeLists.txt, one foreach per hostgen gate)."""
+    cmake = PORT / "CMakeLists.txt"
+    rel = cmake.relative_to(REPO).as_posix()
+    if not cmake.exists():
+        return 0, [Failure(rel, 0, "CMakeLists.txt not found")]
+
+    text = cmake.read_text(encoding="utf-8", errors="ignore")
+    masked = _mask_comments(text)
+    failures = []
+    checked = 0
+    for m in SET_SYMS_RE.finditer(masked):
+        list_name = m.group(1)
+        body_start = m.start(2)
+        for tok in re.finditer(r"\S+", m.group(2)):
+            sym = tok.group(0)
+            checked += 1
+            lineno = _line_at(text, body_start + tok.start())
+            if not ((REPO / "src" / f"{sym}.c").exists()
+                    or (REPO / "src" / f"{sym}.cpp").exists()):
+                failures.append(Failure(
+                    rel, lineno,
+                    f"symbol '{sym}' ({list_name}) has no src/{sym}.c or "
+                    f"src/{sym}.cpp (renamed?)"))
+    return checked, failures
+
+
+# ---- check 3: port/hal linkage bridges --------------------------------------
+
+def _strip_decoration(spelling):
+    """Undo one layer of MSVC decoration on an /alternatename spelling and
+    return the bare core name -- or None if it is not a bare identifier
+    (still mangled, still suffixed, etc). Only a name that fully reduces to
+    plain text is a candidate for the func_/data_ pattern check.
+
+    ?data_0209b44c@@3CA          -> data_0209b44c   (C++-mangled variable)
+    _data_020a0e68               -> data_020a0e68   (cdecl decoration)
+    __ZN6Memory...E              -> ZN6Memory...E   (not func_/data_, skipped)
+    _data_0209b44c_c             -> data_0209b44c_c (suffixed local storage,
+                                                       correctly NOT matching
+                                                       the bare pattern)
+    """
+    spelling = spelling.strip()
+    if spelling.startswith("__imp_"):
+        spelling = spelling[len("__imp_"):]
+    if spelling.startswith("?"):
+        at = spelling.find("@")
+        return spelling[1:at] if at != -1 else spelling[1:]
+    return spelling.lstrip("_")
+
+
+def _extern_c_spans(masked_text):
+    """(start, end) character spans covering each `extern "C"` occurrence in
+    `masked_text` through the end of its scope: the whole `{ ... }` block for
+    the block form, or the single declaration (plus its function body, if
+    any) for `extern "C" <decl>;` / `extern "C" <decl> { ... }`."""
+    spans = []
+    n = len(masked_text)
+    for m in EXTERN_C_RE.finditer(masked_text):
+        j = m.end()
+        while j < n and masked_text[j] in " \t\r\n":
+            j += 1
+        if j < n and masked_text[j] == "{":
+            depth, k = 0, j
+            while k < n:
+                if masked_text[k] == "{":
+                    depth += 1
+                elif masked_text[k] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        k += 1
+                        break
+                k += 1
+            spans.append((m.start(), k))
+        else:
+            k = j
+            while k < n and masked_text[k] not in ";{":
+                k += 1
+            if k < n and masked_text[k] == "{":
+                depth = 0
+                while k < n:
+                    if masked_text[k] == "{":
+                        depth += 1
+                    elif masked_text[k] == "}":
+                        depth -= 1
+                        if depth == 0:
+                            k += 1
+                            break
+                    k += 1
+            elif k < n and masked_text[k] == ";":
+                k += 1
+            spans.append((m.start(), k))
+    return spans
+
+
+def _scan_symbol_index():
+    """Pure-Python fallback: every func_/data_ token under src/ or include/,
+    built by reading every file. Correct but slow (~1s+ on this corpus) --
+    only used if git is unavailable."""
+    index = set()
+    for root in SRC_DIRS:
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*"):
+            if p.is_file() and p.suffix.lower() in CODE_SUFFIXES:
+                try:
+                    text = p.read_text(encoding="utf-8", errors="ignore")
+                except OSError:
+                    continue
+                index.update(IDENT_SCAN_RE.findall(text))
+    return index
+
+
+def _present(names):
+    """Which of `names` (func_/data_ identifiers) appear as whole-word text
+    somewhere under src/ or include/. A single `git grep -F -w` pass over the
+    whole tree is ~10x faster than reading and regex-scanning ~11k files in
+    Python (git grep: ~0.15s here vs ~1.2s), so it is tried first; a plain
+    scan is the fallback for a non-git checkout or if git is missing."""
+    names = sorted(set(names))
+    if not names:
+        return set()
+    import subprocess
+    args = ["git", "grep", "--no-color", "-F", "-w", "-h", "-o"]
+    for n in names:
+        args += ["-e", n]
+    args += ["--"] + [d.name for d in SRC_DIRS if d.is_dir()]
+    try:
+        proc = subprocess.run(args, cwd=REPO, capture_output=True, text=True)
+    except (OSError, subprocess.SubprocessError):
+        proc = None
+    if proc is not None and proc.returncode in (0, 1):
+        # 0 = matches found, 1 = git grep ran fine but found nothing
+        found = {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+        return found & set(names)
+    return _scan_symbol_index() & set(names)
+
+
+def check_hal_links():
+    """#pragma alternatename aliases/targets and extern "C" declarations of
+    func_/data_ names in port/hal/*.cpp must still name something that
+    exists in src/ or include/."""
+    hal_dir = PORT / "hal"
+    if not hal_dir.is_dir():
+        return 0, [Failure("port/hal", 0, "hal directory not found")]
+
+    # Pass 1: collect every candidate reference without checking existence
+    # yet, so all the (few hundred) names can be looked up in one batched
+    # `git grep` pass instead of one lookup each.
+    refs = []  # (rel, lineno, name, message)
+    for path in sorted(hal_dir.glob("*.cpp")):
+        rel = path.relative_to(REPO).as_posix()
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        masked = _mask_comments(text)
+
+        for m in PRAGMA_RE.finditer(masked):
+            lineno = _line_at(text, m.start())
+            body = m.group(1)[len("/alternatename:"):]
+            alias, _, target = body.partition("=")
+            for spelling in (alias, target):
+                core = _strip_decoration(spelling)
+                if not core or not IDENT_FULL_RE.match(core):
+                    continue
+                refs.append((rel, lineno, core,
+                              f"alternatename references '{core}' (from "
+                              f"'{spelling.strip()}'), not found in src/ or "
+                              f"include/ (renamed?)"))
+
+        for start, end in _extern_c_spans(masked):
+            for m in IDENT_SCAN_RE.finditer(masked, start, end):
+                name = m.group(0)
+                lineno = _line_at(text, m.start())
+                refs.append((rel, lineno, name,
+                             f'extern "C" declares \'{name}\', not found in '
+                             f"src/ or include/ (renamed?)"))
+
+    # Pass 2: one batched presence check, then report.
+    present = _present(name for _, _, name, _ in refs)
+    failures = []
+    seen = set()  # (file, name) already reported, so a name isn't repeated
+    for rel, lineno, name, message in refs:
+        if name in present:
+            continue
+        key = (rel, name)
+        if key in seen:
+            continue
+        seen.add(key)
+        failures.append(Failure(rel, lineno, message))
+
+    return len(refs), failures
+
+
+CHECKS = [
+    ("manifests", check_manifests),
+    ("cmake-symbols", check_cmake_symbols),
+    ("hal-links", check_hal_links),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Check port/'s literal src/ path and symbol references "
+                     "for staleness left behind by renames.",
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    ap.add_argument("--json", action="store_true", help="emit a JSON report")
+    args = ap.parse_args()
+
+    results = {}
+    all_failures = []
+    total_checked = 0
+    for name, fn in CHECKS:
+        checked, failures = fn()
+        results[name] = {"checked": checked, "failures": [f.to_dict() for f in failures]}
+        total_checked += checked
+        all_failures.extend(failures)
+
+    if args.json:
+        report = {
+            "ok": not all_failures,
+            "checked": total_checked,
+            "failed": len(all_failures),
+            "checks": results,
+        }
+        print(json.dumps(report, indent=2))
+        return 1 if all_failures else 0
+
+    for name, fn in CHECKS:
+        r = results[name]
+        icon = "OK  " if not r["failures"] else "FAIL"
+        print(f"  [{icon}] {name:<14} {r['checked']} reference(s) checked, "
+              f"{len(r['failures'])} stale")
+
+    if all_failures:
+        print("\nport-refcheck: STALE port/ references found:", file=sys.stderr)
+        for f in all_failures:
+            print(f"  {f}", file=sys.stderr)
+        print(f"\nport-refcheck: {total_checked} checked - {len(all_failures)} stale",
+              file=sys.stderr)
+        print("A src/ rename, .c-to-.cpp migration, or file move left port/ "
+              "pointing at a name that no longer exists. Update the "
+              "manifest / CMakeLists.txt / port/hal/*.cpp reference (see "
+              "AGENTS.md), then re-run.", file=sys.stderr)
+        return 1
+
+    print(f"port-refcheck: {total_checked} checked - all references resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/port_refcheck.py
+++ b/tools/port_refcheck.py
@@ -45,7 +45,13 @@ scope here -- see AGENTS.md/MERGE.md for the human-facing rule.
 
 Usage:
   python tools/port_refcheck.py
-  python tools/port_refcheck.py --json
+  python tools/port_refcheck.py --json                 # report on stdout
+  python tools/port_refcheck.py --json build/port.json # report to a file
+
+The JSON report is the stable contract behind tools/validate_merge.py's
+--port-refcheck-report: schemaVersion, ok, checked, failed, a flat
+`failures` list of {check, file, line, message}, and the same failures
+grouped under `checks` for a human reading the file directly.
 """
 import argparse
 import json
@@ -339,35 +345,56 @@ CHECKS = [
 ]
 
 
-def main():
-    ap = argparse.ArgumentParser(
-        description="Check port/'s literal src/ path and symbol references "
-                     "for staleness left behind by renames.",
-        formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
-    ap.add_argument("--json", action="store_true", help="emit a JSON report")
-    args = ap.parse_args()
+def build_report():
+    """Run every check and return the report JSON consumers see.
 
+    `failures` is a flat, check-tagged copy of everything under `checks`, so a
+    consumer that only wants "did it pass, and what broke" -- tools/validate_merge.py
+    -- never has to walk the per-check grouping.
+    """
     results = {}
-    all_failures = []
+    tagged = []
     total_checked = 0
     for name, fn in CHECKS:
         checked, failures = fn()
         results[name] = {"checked": checked, "failures": [f.to_dict() for f in failures]}
         total_checked += checked
-        all_failures.extend(failures)
+        tagged.extend((name, f) for f in failures)
+    return {
+        "schemaVersion": 1,
+        "ok": not tagged,
+        "checked": total_checked,
+        "failed": len(tagged),
+        "failures": [dict(f.to_dict(), check=name) for name, f in tagged],
+        "checks": results,
+    }
 
-    if args.json:
-        report = {
-            "ok": not all_failures,
-            "checked": total_checked,
-            "failed": len(all_failures),
-            "checks": results,
-        }
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Check port/'s literal src/ path and symbol references "
+                     "for staleness left behind by renames.",
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    ap.add_argument("--json", nargs="?", const="-", metavar="PATH",
+                    help="write the JSON report to PATH (stdout if PATH is "
+                         "omitted or '-')")
+    args = ap.parse_args()
+
+    report = build_report()
+    all_failures = report["failures"]
+    total_checked = report["checked"]
+
+    if args.json == "-":
         print(json.dumps(report, indent=2))
         return 1 if all_failures else 0
+    if args.json:
+        # A report file leaves stdout free for the human summary below, which is
+        # all a CI log of this phase would otherwise show.
+        pathlib.Path(args.json).write_text(json.dumps(report, indent=2) + "\n",
+                                           encoding="utf-8", newline="\n")
 
     for name, fn in CHECKS:
-        r = results[name]
+        r = report["checks"][name]
         icon = "OK  " if not r["failures"] else "FAIL"
         print(f"  [{icon}] {name:<14} {r['checked']} reference(s) checked, "
               f"{len(r['failures'])} stale")
@@ -375,7 +402,7 @@ def main():
     if all_failures:
         print("\nport-refcheck: STALE port/ references found:", file=sys.stderr)
         for f in all_failures:
-            print(f"  {f}", file=sys.stderr)
+            print(f"  {f['file']}:{f['line']}: {f['message']}", file=sys.stderr)
         print(f"\nport-refcheck: {total_checked} checked - {len(all_failures)} stale",
               file=sys.stderr)
         print("A src/ rename, .c-to-.cpp migration, or file move left port/ "

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -118,6 +118,38 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(state["tally"], {"WRONG": 1})
         self.assertEqual(len(state["blocking"]), 1)
 
+    def test_port_refcheck_absent_is_neutral_and_stale_refs_are_named(self):
+        # The phase is optional: a worker that never ran it, or a PR that
+        # touches no source, must read exactly like a clean run -- no row, no
+        # reason. When it does fail, the reason has to name the stale
+        # reference, because the PR author never sees the worker's log.
+        neutral = VM.build_report(self.base, "HEAD")
+        self.assertEqual(neutral["portRefcheck"], {"available": False})
+        self.assertNotIn("Port reference check", neutral["reportMarkdown"])
+
+        stale = {"schemaVersion": 1, "ok": False, "checked": 395, "failed": 1,
+                 "failures": [{"check": "manifests", "file": "port/slice_gate8.txt",
+                               "line": 6, "message": "src/Example.c not found (renamed?)"}]}
+        report = VM.build_report(self.base, "HEAD", port_report=stale)
+        self.assertEqual(report["status"], "Failed")
+        self.assertIn("port/slice_gate8.txt:6: src/Example.c not found (renamed?)",
+                      "; ".join(report["reasons"]))
+        self.assertIn("| Port reference check | 395 checked; 1 stale |",
+                      report["reportMarkdown"])
+
+    def test_port_refcheck_report_without_the_flat_failure_list_still_reads(self):
+        # Tolerate a report written by an older port_refcheck that only groups
+        # failures per check, so a base/worker version skew cannot make a real
+        # failure look like a pass.
+        grouped = {"ok": False, "checked": 2, "checks": {
+            "cmake-symbols": {"checked": 2, "failures": [
+                {"file": "port/CMakeLists.txt", "line": 9,
+                 "message": "symbol 'Example' has no src/Example.c"}]}}}
+        state = VM._port_state(grouped)
+        self.assertFalse(state["passed"])
+        self.assertEqual(state["failures"][0]["check"], "cmake-symbols")
+        self.assertTrue(VM._port_state({"ok": True, "checked": 2, "failures": []})["passed"])
+
     def test_committed_test_merge_is_accepted_and_keeps_feature_author_credit(self):
         git(self.repo, "switch", "-q", "-c", "feature")
         (self.repo / "src" / "nested").mkdir()

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -200,10 +200,15 @@ def diff_snapshot(base, head, head_paths):
     return {"files": rows, "perfectRenames": renames, "leftoverOldPaths": leftovers}
 
 
-def _load_json(path):
+def _load_json(path, optional=False):
     if not path:
         return None
-    return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    p = pathlib.Path(path)
+    if optional and not p.exists():
+        # An optional phase that did not run leaves no artifact.  That is "not
+        # checked", not "failed" -- see _port_state.
+        return None
+    return json.loads(p.read_text(encoding="utf-8"))
 
 
 def _rom_state(report):
@@ -267,8 +272,42 @@ def _link_state(rows):
             "rows": flattened}
 
 
+def _port_state(report):
+    """tools/port_refcheck.py's JSON: port/'s literal src/ path and symbol
+    references, checked against the merged tree.
+
+    The phase is optional -- an older worker, a PR that touches no source, or a
+    base that predates the tool all leave no report -- so an absent report is
+    "not run" and never a failure.  `failures` is port_refcheck's flat
+    {check,file,line,message} list; the per-check grouping is accepted as a
+    fallback so a report written by an older copy of the tool still reads.
+    """
+    if report is None:
+        return {"available": False}
+    failures = report.get("failures")
+    if failures is None:
+        failures = [dict(f, check=name)
+                    for name, check in (report.get("checks") or {}).items()
+                    for f in check.get("failures") or []]
+    passed = bool(report.get("ok", not failures)) and not failures
+    return {"available": True, "passed": passed,
+            "checked": report.get("checked", 0), "failures": failures}
+
+
+def _port_reason(port):
+    """Name what broke, not just that something did: a PR author reading the
+    check has to be able to find the stale reference without the worker log."""
+    failures = port["failures"]
+    shown = "; ".join(f"{f.get('file')}:{f.get('line')}: {f.get('message')}"
+                      for f in failures[:3])
+    if len(failures) > 3:
+        shown += f"; +{len(failures) - 3} more"
+    return f"port refcheck: {len(failures)} stale reference(s) ({shown})"
+
+
 def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
-                 require_merge_commit=False, expected_pr_head=None):
+                 require_merge_commit=False, expected_pr_head=None,
+                 port_report=None):
     base_sha, head_sha = resolve_commit(base), resolve_commit(head)
     parents = _git("rev-list", "--parents", "-n", "1", head_sha).split()
     is_merge = len(parents) >= 3
@@ -309,6 +348,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                              and base_rom_state.get("signature")
                              == head_rom_state.get("signature"))
     link = _link_state(link_rows)
+    port = _port_state(port_report)
     reasons = []
     if base_keys - head_keys:
         reasons.append(f"lost {len(base_keys - head_keys)} matched function(s)")
@@ -325,6 +365,8 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append("old source paths remain after rename")
     if link["blocking"]:
         reasons.append(f"{len(link['blocking'])} blocking relocation verdict(s)")
+    if port.get("available") and not port["passed"]:
+        reasons.append(_port_reason(port))
     if rom_regression:
         reasons.append("full-ROM result regressed from the base commit")
     if head_rom_state.get("available") and not head_rom_state.get("passed") \
@@ -376,6 +418,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                         "lost": lost_credit},
         "diff": diff,
         "linkcheck": link,
+        "portRefcheck": port,
         "rom": {"base": base_rom_state, "head": head_rom_state,
                 "regression": rom_regression, "sameBaselineFailure": same_baseline_failure},
     }
@@ -407,6 +450,12 @@ def render_markdown(r):
              f"{len(r['attribution']['changed'])} changed, "
              f"{len(r['attribution']['lost'])} lost |",
              f"| Relocation check | {l['checked']} checked; {relocation_summary} |"]
+    # Optional phase: no row at all when it did not run, so an older worker's
+    # report reads exactly as it did before.
+    port = r.get("portRefcheck") or {}
+    if port.get("available"):
+        lines.append(f"| Port reference check | {port['checked']} checked; "
+                     f"{len(port['failures'])} stale |")
     head_rom = r["rom"]["head"]
     if head_rom.get("analysis"):
         mf = head_rom["analysis"]["moduleFidelity"]
@@ -434,12 +483,16 @@ def main():
     ap.add_argument("--base-rom-report")
     ap.add_argument("--head-rom-report")
     ap.add_argument("--link-report")
+    ap.add_argument("--port-refcheck-report",
+                    help="tools/port_refcheck.py --json output; the check is "
+                         "reported only when this is supplied and exists")
     ap.add_argument("--out", required=True)
     ap.add_argument("--markdown")
     args = ap.parse_args()
     report = build_report(args.base, args.head, _load_json(args.base_rom_report),
                           _load_json(args.head_rom_report), _load_json(args.link_report),
-                          args.require_merge_commit, args.expected_pr_head)
+                          args.require_merge_commit, args.expected_pr_head,
+                          _load_json(args.port_refcheck_report, optional=True))
     pathlib.Path(args.out).write_text(json.dumps(report, indent=2) + "\n",
                                       encoding="utf-8", newline="\n")
     if args.markdown:


### PR DESCRIPTION
Adds `tools/port_refcheck.py`, a fast (~0.7s, stdlib-only) reference-integrity check that validates every port/ reference into the decomp tree: the nine `slice_gate*.txt` manifests, the hostgen symbol lists in `port/CMakeLists.txt`, and the `/alternatename:` + `extern "C"` linkage bridges in `port/hal/`. Renames, moves, and .c-to-.cpp migrations in src/ can strand these references with no other gate to catch them.

- `tools/validate_merge.py` learns `--port-refcheck-report` and folds failures into the PR verdict (the validator worker already ships the matching phase, soft-skipping until this lands).
- Wired into `tools/hooks/pre-push`; notes added to AGENTS.md / MERGE.md.
- Verified: clean-tree pass (395 references), negative tests via `git mv` of manifest-listed files, `tools/test_validate_merge.py` 11/11, and the not-run path byte-identical to the previous merge output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MumV9zcDeB1JeaZhjEynXf