### PR TITLE
rombuild: build the .init functions too, and fix a wrong destination it exposed

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -11835,70 +11835,93 @@ src/func_020736e4.c:
     .text start:0x020736e4 end:0x020736f4
 
 src/__sinit_02073a24.c:
+    complete
     .init start:0x02073a24 end:0x02073e6c
 
 src/__sinit_02073e6c.c:
+    complete
     .init start:0x02073e6c end:0x02074d90
 
 src/__sinit_02074d90.c:
+    complete
     .init start:0x02074d90 end:0x02074da8
 
 src/__sinit_02074da8.c:
+    complete
     .init start:0x02074da8 end:0x02074dbc
 
 src/__sinit_02074dbc.c:
+    complete
     .init start:0x02074dbc end:0x02074dc0
 
 src/__sinit_02074dc0.c:
+    complete
     .init start:0x02074dc0 end:0x02074dc4
 
 src/__sinit_02074dc4.c:
+    complete
     .init start:0x02074dc4 end:0x02074e0c
 
 src/__sinit_02074e0c.c:
+    complete
     .init start:0x02074e0c end:0x02074e44
 
 src/__sinit_02074e44.c:
+    complete
     .init start:0x02074e44 end:0x02074e80
 
 src/__sinit_02074e80.c:
+    complete
     .init start:0x02074e80 end:0x02074e84
 
 src/__sinit_02074e84.cpp:
+    complete
     .init start:0x02074e84 end:0x02074edc
 
 src/__sinit_02074edc.c:
+    complete
     .init start:0x02074edc end:0x02074f80
 
 src/__sinit_02074f80.c:
+    complete
     .init start:0x02074f80 end:0x02074fb8
 
 src/__sinit_02074fb8.c:
+    complete
     .init start:0x02074fb8 end:0x02074fe4
 
 src/__sinit_02074fe4.c:
+    complete
     .init start:0x02074fe4 end:0x0207501c
 
 src/__sinit_0207501c.c:
+    complete
     .init start:0x0207501c end:0x02075054
 
 src/__sinit_02075054.c:
+    complete
     .init start:0x02075054 end:0x020750b4
 
 src/__sinit_020750b4.c:
+    complete
     .init start:0x020750b4 end:0x020750b8
 
 src/__sinit_020750b8.c:
+    complete
     .init start:0x020750b8 end:0x020750ec
 
 src/__sinit_020750ec.c:
+    complete
     .init start:0x020750ec end:0x0207511c
 
 src/__sinit_0207511c.c:
+    complete
     .init start:0x0207511c end:0x02075150
 
 src/__sinit_02075150.c:
+    complete
     .init start:0x02075150 end:0x02075154
 
 src/__sinit_02075154.c:
+    complete
     .init start:0x02075154 end:0x02075230

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -5921,79 +5921,105 @@ src/Bullet_Spawn.c:
     .text start:0x020fefcc end:0x020ff014
 
 src/__sinit_ov002_02100560.c:
+    complete
     .init start:0x02100560 end:0x02100938
 
 src/__sinit_ov002_02100938.c:
+    complete
     .init start:0x02100938 end:0x02100adc
 
 src/__sinit_ov002_02100adc.c:
+    complete
     .init start:0x02100adc end:0x02100c50
 
 src/__sinit_ov002_02100c50.c:
+    complete
     .init start:0x02100c50 end:0x02100d44
 
 src/__sinit_ov002_02100d44.c:
+    complete
     .init start:0x02100d44 end:0x02100e50
 
 src/__sinit_ov002_02100e50.c:
+    complete
     .init start:0x02100e50 end:0x02100ec4
 
 src/__sinit_ov002_02100ec4.c:
+    complete
     .init start:0x02100ec4 end:0x02100f84
 
 src/__sinit_ov002_02100f84.c:
+    complete
     .init start:0x02100f84 end:0x02101064
 
 src/__sinit_ov002_02101064.c:
+    complete
     .init start:0x02101064 end:0x02101478
 
 src/__sinit_ov002_02101478.c:
+    complete
     .init start:0x02101478 end:0x021014e4
 
 src/__sinit_ov002_021014e4.c:
+    complete
     .init start:0x021014e4 end:0x02101588
 
 src/__sinit_ov002_02101588.c:
+    complete
     .init start:0x02101588 end:0x02101738
 
 src/__sinit_ov002_02101738.c:
+    complete
     .init start:0x02101738 end:0x02101894
 
 src/__sinit_ov002_02101894.c:
+    complete
     .init start:0x02101894 end:0x02101900
 
 src/__sinit_ov002_02101900.c:
+    complete
     .init start:0x02101900 end:0x02101968
 
 src/__sinit_ov002_02101968.c:
+    complete
     .init start:0x02101968 end:0x021019d0
 
 src/__sinit_ov002_021019d0.c:
+    complete
     .init start:0x021019d0 end:0x02106e40
 
 src/__sinit_ov002_02106e40.c:
+    complete
     .init start:0x02106e40 end:0x02107118
 
 src/__sinit_ov002_02107118.c:
+    complete
     .init start:0x02107118 end:0x021071f4
 
 src/__sinit_ov002_021071f4.c:
+    complete
     .init start:0x021071f4 end:0x02107298
 
 src/__sinit_ov002_02107298.c:
+    complete
     .init start:0x02107298 end:0x02107304
 
 src/__sinit_ov002_02107304.c:
+    complete
     .init start:0x02107304 end:0x02107370
 
 src/__sinit_ov002_02107370.c:
+    complete
     .init start:0x02107370 end:0x02107f88
 
 src/__sinit_ov002_02107f88.c:
+    complete
     .init start:0x02107f88 end:0x0210804c
 
 src/__sinit_ov002_0210804c.c:
+    complete
     .init start:0x0210804c end:0x02108094
 
 src/__sinit_ov002_02108094.c:
+    complete
     .init start:0x02108094 end:0x021080d0

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -1082,10 +1082,13 @@ src/func_ov004_020b9430.c:
     .text start:0x020b9430 end:0x020b944c
 
 src/__sinit_ov004_020b948c.c:
+    complete
     .init start:0x020b948c end:0x020b955c
 
 src/__sinit_ov004_020b9ad0.c:
+    complete
     .init start:0x020b9ad0 end:0x020b9b24
 
 src/__sinit_ov004_020b9b24.c:
+    complete
     .init start:0x020b9b24 end:0x020b9de4

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -7041,91 +7041,121 @@ src/func_ov006_0212b88c.c:
     .text start:0x0212b88c end:0x0212b890
 
 src/__sinit_ov006_0212f4c4.c:
+    complete
     .init start:0x0212f4c4 end:0x0212f52c
 
 src/__sinit_ov006_0212f52c.c:
+    complete
     .init start:0x0212f52c end:0x0212f660
 
 src/__sinit_ov006_0212f660.c:
+    complete
     .init start:0x0212f660 end:0x0212f6b4
 
 src/__sinit_ov006_0212f6b4.c:
+    complete
     .init start:0x0212f6b4 end:0x0212fc7c
 
 src/__sinit_ov006_0212fc7c.c:
+    complete
     .init start:0x0212fc7c end:0x0212fd48
 
 src/__sinit_ov006_0212fd48.c:
+    complete
     .init start:0x0212fd48 end:0x021300b0
 
 src/__sinit_ov006_021300b0.c:
+    complete
     .init start:0x021300b0 end:0x0213014c
 
 src/__sinit_ov006_021303d0.c:
+    complete
     .init start:0x021303d0 end:0x021304ac
 
 src/__sinit_ov006_021304ac.c:
+    complete
     .init start:0x021304ac end:0x02130758
 
 src/__sinit_ov006_02130758.c:
+    complete
     .init start:0x02130758 end:0x02130a04
 
 src/__sinit_ov006_02130a04.c:
+    complete
     .init start:0x02130a04 end:0x02130a08
 
 src/__sinit_ov006_02130a08.c:
+    complete
     .init start:0x02130a08 end:0x02130df8
 
 src/__sinit_ov006_02130df8.c:
+    complete
     .init start:0x02130df8 end:0x02130e9c
 
 src/__sinit_ov006_02130e9c.c:
+    complete
     .init start:0x02130e9c end:0x02130f00
 
 src/__sinit_ov006_02130f00.c:
+    complete
     .init start:0x02130f00 end:0x02130f64
 
 src/__sinit_ov006_02130f64.c:
+    complete
     .init start:0x02130f64 end:0x021311c8
 
 src/__sinit_ov006_021311c8.c:
+    complete
     .init start:0x021311c8 end:0x021314e4
 
 src/__sinit_ov006_021314e4.c:
+    complete
     .init start:0x021314e4 end:0x021318a0
 
 src/__sinit_ov006_021318a0.c:
+    complete
     .init start:0x021318a0 end:0x0213195c
 
 src/__sinit_ov006_0213195c.c:
+    complete
     .init start:0x0213195c end:0x02131a38
 
 src/__sinit_ov006_02131a38.c:
+    complete
     .init start:0x02131a38 end:0x02131cd0
 
 src/__sinit_ov006_02131cd0.c:
+    complete
     .init start:0x02131cd0 end:0x02131fa4
 
 src/__sinit_ov006_02131fa4.c:
+    complete
     .init start:0x02131fa4 end:0x021322bc
 
 src/__sinit_ov006_021322bc.c:
+    complete
     .init start:0x021322bc end:0x02132894
 
 src/__sinit_ov006_02132894.c:
+    complete
     .init start:0x02132894 end:0x02132970
 
 src/__sinit_ov006_02132970.c:
+    complete
     .init start:0x02132970 end:0x02132f68
 
 src/__sinit_ov006_02132f68.c:
+    complete
     .init start:0x02132f68 end:0x0213322c
 
 src/__sinit_ov006_0213322c.c:
+    complete
     .init start:0x0213322c end:0x0213326c
 
 src/__sinit_ov006_0213326c.c:
+    complete
     .init start:0x0213326c end:0x021333e0
 
 src/__sinit_ov006_021333e0.c:
+    complete
     .init start:0x021333e0 end:0x0213356c

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -2839,6 +2839,9 @@ src/func_ov006_020e8728.c:
     complete
     .text start:0x020e8728 end:0x020e8830
 
+src/func_ov006_020e8830.c:
+    .text start:0x020e8830 end:0x020e8928
+
 src/func_ov006_020e8928.c:
     complete
     .text start:0x020e8928 end:0x020e8a44
@@ -4151,6 +4154,9 @@ src/func_ov006_020f9ffc.cpp:
 src/func_ov006_020fa13c.c:
     complete
     .text start:0x020fa13c end:0x020fa3d0
+
+src/func_ov006_020fa3d0.c:
+    .text start:0x020fa3d0 end:0x020fa4d4
 
 src/func_ov006_020fa4d4.cpp:
     complete
@@ -6713,6 +6719,9 @@ src/func_ov006_0212382c.c:
 src/func_ov006_021238d0.c:
     complete
     .text start:0x021238d0 end:0x02123938
+
+src/func_ov006_02123938.c:
+    .text start:0x02123938 end:0x02123b20
 
 src/func_ov006_02123b20.c:
     complete

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -1007,6 +1007,9 @@ src/func_ov007_020bee14.c:
     complete
     .text start:0x020bee14 end:0x020beeb0
 
+src/func_ov007_020beeb0.c:
+    .text start:0x020beeb0 end:0x020bf304
+
 src/func_ov007_020bf304.c:
     complete
     .text start:0x020bf304 end:0x020bf428

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -143,13 +143,17 @@ src/Flag_Spawn.c:
     .text start:0x021121f0 end:0x02112228
 
 src/__sinit_ov009_02112458.c:
+    complete
     .init start:0x02112458 end:0x02112524
 
 src/__sinit_ov009_02112524.c:
+    complete
     .init start:0x02112524 end:0x02112a5c
 
 src/__sinit_ov009_02112a5c.c:
+    complete
     .init start:0x02112a5c end:0x02112ac8
 
 src/__sinit_ov009_02112ac8.c:
+    complete
     .init start:0x02112ac8 end:0x02112b34

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -133,10 +133,13 @@ src/PeachPainting_Spawn.c:
     .text start:0x02112004 end:0x0211203c
 
 src/__sinit_ov010_0211203c.c:
+    complete
     .init start:0x0211203c end:0x0211211c
 
 src/__sinit_ov010_0211211c.c:
+    complete
     .init start:0x0211211c end:0x0211215c
 
 src/__sinit_ov010_0211215c.c:
+    complete
     .init start:0x0211215c end:0x0211219c

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -65,7 +65,9 @@ src/BasementWater_Spawn.c:
     .text start:0x02111730 end:0x02111768
 
 src/__sinit_ov012_02111a88.c:
+    complete
     .init start:0x02111a88 end:0x02111af4
 
 src/__sinit_ov012_02111af4.c:
+    complete
     .init start:0x02111af4 end:0x02111b60

--- a/config/arm9/overlays/ov013/delinks.txt
+++ b/config/arm9/overlays/ov013/delinks.txt
@@ -72,7 +72,9 @@ src/ClockPaintingHandLong_Spawn.c:
     .text start:0x02111674 end:0x021116ac
 
 src/__sinit_ov013_021116b8.c:
+    complete
     .init start:0x021116b8 end:0x021116f8
 
 src/__sinit_ov013_021116f8.c:
+    complete
     .init start:0x021116f8 end:0x02111760

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -172,10 +172,13 @@ src/ChainChompFence_Spawn.c:
     .text start:0x0211307c end:0x021130ac
 
 src/__sinit_ov014_021130ac.c:
+    complete
     .init start:0x021130ac end:0x02113118
 
 src/__sinit_ov014_02113118.c:
+    complete
     .init start:0x02113118 end:0x021132fc
 
 src/__sinit_ov014_021132fc.c:
+    complete
     .init start:0x021132fc end:0x02113368

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -275,22 +275,29 @@ src/FallBlockWf_Spawn.c:
     .text start:0x02112dd0 end:0x02112e0c
 
 src/__sinit_ov015_02112f9c.c:
+    complete
     .init start:0x02112f9c end:0x02112fdc
 
 src/__sinit_ov015_02112fdc.c:
+    complete
     .init start:0x02112fdc end:0x02113048
 
 src/__sinit_ov015_02113048.c:
+    complete
     .init start:0x02113048 end:0x02113264
 
 src/__sinit_ov015_02113264.c:
+    complete
     .init start:0x02113264 end:0x021132d0
 
 src/__sinit_ov015_021132d0.c:
+    complete
     .init start:0x021132d0 end:0x0211333c
 
 src/__sinit_ov015_0211333c.c:
+    complete
     .init start:0x0211333c end:0x021133a8
 
 src/__sinit_ov015_021133a8.c:
+    complete
     .init start:0x021133a8 end:0x02113410

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -199,16 +199,21 @@ src/SlidingBox_Spawn.c:
     .text start:0x02113510 end:0x0211354c
 
 src/__sinit_ov016_021136ec.c:
+    complete
     .init start:0x021136ec end:0x021138bc
 
 src/__sinit_ov016_021138bc.c:
+    complete
     .init start:0x021138bc end:0x02113978
 
 src/__sinit_ov016_02113978.c:
+    complete
     .init start:0x02113978 end:0x021139e4
 
 src/__sinit_ov016_021139e4.c:
+    complete
     .init start:0x021139e4 end:0x02113a50
 
 src/__sinit_ov016_02113a50.c:
+    complete
     .init start:0x02113a50 end:0x02113abc

--- a/config/arm9/overlays/ov017/delinks.txt
+++ b/config/arm9/overlays/ov017/delinks.txt
@@ -33,4 +33,5 @@ src/ShipWater_Spawn.c:
     .text start:0x02111480 end:0x021114b8
 
 src/__sinit_ov017_0211198c.c:
+    complete
     .init start:0x0211198c end:0x021119f8

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -192,10 +192,13 @@ src/IceSheet_Spawn.c:
     .text start:0x02112a44 end:0x02112a74
 
 src/__sinit_ov018_02112c14.c:
+    complete
     .init start:0x02112c14 end:0x02112c80
 
 src/__sinit_ov018_02112c80.cpp:
+    complete
     .init start:0x02112c80 end:0x02112e00
 
 src/__sinit_ov018_02112e00.c:
+    complete
     .init start:0x02112e00 end:0x02112e6c

--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -141,7 +141,9 @@ src/IceSlideManager_Spawn.c:
     .text start:0x0211274c end:0x0211277c
 
 src/__sinit_ov019_021127a4.c:
+    complete
     .init start:0x021127a4 end:0x02112b14
 
 src/__sinit_ov019_02112b14.c:
+    complete
     .init start:0x02112b14 end:0x02112b64

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -181,7 +181,9 @@ src/HauntedChair_Spawn.c:
     .text start:0x02113494 end:0x021134e4
 
 src/__sinit_ov020_02113674.c:
+    complete
     .init start:0x02113674 end:0x0211372c
 
 src/__sinit_ov020_0211372c.c:
+    complete
     .init start:0x0211372c end:0x02113768

--- a/config/arm9/overlays/ov021/delinks.txt
+++ b/config/arm9/overlays/ov021/delinks.txt
@@ -147,10 +147,13 @@ src/ShutterHmc_Spawn.c:
     .text start:0x02112ed4 end:0x02112f10
 
 src/__sinit_ov021_02113500.c:
+    complete
     .init start:0x02113500 end:0x02113688
 
 src/__sinit_ov021_02113688.c:
+    complete
     .init start:0x02113688 end:0x021136c8
 
 src/__sinit_ov021_021136c8.c:
+    complete
     .init start:0x021136c8 end:0x02113734

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -281,31 +281,41 @@ src/VolcanoFire_Spawn.c:
     .text start:0x02112918 end:0x02112950
 
 src/__sinit_ov022_02112ca8.c:
+    complete
     .init start:0x02112ca8 end:0x02112d14
 
 src/__sinit_ov022_02112d14.c:
+    complete
     .init start:0x02112d14 end:0x02112d80
 
 src/__sinit_ov022_02112d80.c:
+    complete
     .init start:0x02112d80 end:0x02112dec
 
 src/__sinit_ov022_02112dec.c:
+    complete
     .init start:0x02112dec end:0x02112e58
 
 src/__sinit_ov022_02112e58.c:
+    complete
     .init start:0x02112e58 end:0x02112ec0
 
 src/__sinit_ov022_02112ec0.c:
+    complete
     .init start:0x02112ec0 end:0x02112f78
 
 src/__sinit_ov022_02112f78.c:
+    complete
     .init start:0x02112f78 end:0x02112fe4
 
 src/__sinit_ov022_02112fe4.c:
+    complete
     .init start:0x02112fe4 end:0x02113050
 
 src/__sinit_ov022_02113050.c:
+    complete
     .init start:0x02113050 end:0x021130bc
 
 src/__sinit_ov022_021130bc.c:
+    complete
     .init start:0x021130bc end:0x021130f8

--- a/config/arm9/overlays/ov023/delinks.txt
+++ b/config/arm9/overlays/ov023/delinks.txt
@@ -40,4 +40,5 @@ src/Squasher_Spawn.c:
     .text start:0x02111728 end:0x02111760
 
 src/__sinit_ov023_02111aa8.c:
+    complete
     .init start:0x02111aa8 end:0x02111b14

--- a/config/arm9/overlays/ov024/delinks.txt
+++ b/config/arm9/overlays/ov024/delinks.txt
@@ -68,4 +68,5 @@ src/PyramidTop_Spawn.c:
     .text start:0x02111874 end:0x021118ac
 
 src/__sinit_ov024_02112808.c:
+    complete
     .init start:0x02112808 end:0x02112874

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -150,13 +150,17 @@ src/PyramidLift_Spawn.cpp:
     .text start:0x021125f0 end:0x02112654
 
 src/__sinit_ov025_02112970.c:
+    complete
     .init start:0x02112970 end:0x021129dc
 
 src/__sinit_ov025_021129dc.c:
+    complete
     .init start:0x021129dc end:0x02112a44
 
 src/__sinit_ov025_02112a44.c:
+    complete
     .init start:0x02112a44 end:0x02112aac
 
 src/__sinit_ov025_02112aac.c:
+    complete
     .init start:0x02112aac end:0x02112b18

--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -198,16 +198,21 @@ src/WaterSuction_Spawn.c:
     .text start:0x02112450 end:0x02112490
 
 src/__sinit_ov026_02112b7c.c:
+    complete
     .init start:0x02112b7c end:0x02112bbc
 
 src/__sinit_ov026_02112bbc.c:
+    complete
     .init start:0x02112bbc end:0x02112c28
 
 src/__sinit_ov026_02112c28.c:
+    complete
     .init start:0x02112c28 end:0x02112c94
 
 src/__sinit_ov026_02112c94.c:
+    complete
     .init start:0x02112c94 end:0x02112d68
 
 src/__sinit_ov026_02112d68.c:
+    complete
     .init start:0x02112d68 end:0x02112da4

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -200,13 +200,17 @@ src/SnowmanBreath_Spawn.cpp:
     .text start:0x02112ab4 end:0x02112b14
 
 src/__sinit_ov027_02112cb0.c:
+    complete
     .init start:0x02112cb0 end:0x02112d1c
 
 src/__sinit_ov027_02112d1c.c:
+    complete
     .init start:0x02112d1c end:0x02112df8
 
 src/__sinit_ov027_02112df8.cpp:
+    complete
     .init start:0x02112df8 end:0x02112f70
 
 src/__sinit_ov027_02112f70.c:
+    complete
     .init start:0x02112f70 end:0x02112fc4

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -238,25 +238,33 @@ src/SwitchActivatedPlank_Spawn.c:
     .text start:0x02112964 end:0x0211299c
 
 src/__sinit_ov029_02112b38.c:
+    complete
     .init start:0x02112b38 end:0x02112ba4
 
 src/__sinit_ov029_02112ba4.c:
+    complete
     .init start:0x02112ba4 end:0x02112c10
 
 src/__sinit_ov029_02112c10.c:
+    complete
     .init start:0x02112c10 end:0x02112c4c
 
 src/__sinit_ov029_02112c4c.c:
+    complete
     .init start:0x02112c4c end:0x02112cb8
 
 src/__sinit_ov029_02112cb8.c:
+    complete
     .init start:0x02112cb8 end:0x02112d24
 
 src/__sinit_ov029_02112d24.c:
+    complete
     .init start:0x02112d24 end:0x02112d90
 
 src/__sinit_ov029_02112d90.c:
+    complete
     .init start:0x02112d90 end:0x02112dfc
 
 src/__sinit_ov029_02112dfc.c:
+    complete
     .init start:0x02112dfc end:0x02112e68

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -231,10 +231,13 @@ src/UkikiThief_Spawn.c:
     .text start:0x02114638 end:0x02114690
 
 src/__sinit_ov030_0211484c.c:
+    complete
     .init start:0x0211484c end:0x021148b8
 
 src/__sinit_ov030_021148b8.c:
+    complete
     .init start:0x021148b8 end:0x02114924
 
 src/__sinit_ov030_02114924.c:
+    complete
     .init start:0x02114924 end:0x02114dd0

--- a/config/arm9/overlays/ov031/delinks.txt
+++ b/config/arm9/overlays/ov031/delinks.txt
@@ -44,4 +44,5 @@ src/SlideDecorationSilverStar_Spawn.c:
     .text start:0x021113ec end:0x02111424
 
 src/__sinit_ov031_02111434.c:
+    complete
     .init start:0x02111434 end:0x021114ec

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -157,10 +157,13 @@ src/HugeWater_Spawn.c:
     .text start:0x021128b8 end:0x021128f0
 
 src/__sinit_ov032_02112c10.c:
+    complete
     .init start:0x02112c10 end:0x02112dbc
 
 src/__sinit_ov032_02112dbc.c:
+    complete
     .init start:0x02112dbc end:0x02112e28
 
 src/__sinit_ov032_02112e28.c:
+    complete
     .init start:0x02112e28 end:0x02112e94

--- a/config/arm9/overlays/ov033/delinks.txt
+++ b/config/arm9/overlays/ov033/delinks.txt
@@ -65,7 +65,9 @@ src/TinyWater_Spawn.c:
     .text start:0x02111690 end:0x021116c8
 
 src/__sinit_ov033_021119e8.c:
+    complete
     .init start:0x021119e8 end:0x02111a54
 
 src/__sinit_ov033_02111a54.c:
+    complete
     .init start:0x02111a54 end:0x02111ac0

--- a/config/arm9/overlays/ov034/delinks.txt
+++ b/config/arm9/overlays/ov034/delinks.txt
@@ -139,4 +139,5 @@ src/Wiggler_Spawn.c:
     .text start:0x021136a4 end:0x02113820
 
 src/__sinit_ov034_021138ec.c:
+    complete
     .init start:0x021138ec end:0x02114078

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -74,7 +74,9 @@ src/SpinningPlatform_Spawn.c:
     .text start:0x02111b98 end:0x02111bd0
 
 src/__sinit_ov035_02111f04.c:
+    complete
     .init start:0x02111f04 end:0x02111fc0
 
 src/__sinit_ov035_02111fc0.c:
+    complete
     .init start:0x02111fc0 end:0x02112028

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -208,22 +208,29 @@ src/FlyingCarpet_Spawn.cpp:
     .text start:0x02112538 end:0x021125b0
 
 src/__sinit_ov036_021125b0.c:
+    complete
     .init start:0x021125b0 end:0x0211261c
 
 src/__sinit_ov036_0211261c.c:
+    complete
     .init start:0x0211261c end:0x02112688
 
 src/__sinit_ov036_02112688.c:
+    complete
     .init start:0x02112688 end:0x021126c8
 
 src/__sinit_ov036_021126c8.c:
+    complete
     .init start:0x021126c8 end:0x02112730
 
 src/__sinit_ov036_02112730.c:
+    complete
     .init start:0x02112730 end:0x0211279c
 
 src/__sinit_ov036_0211279c.c:
+    complete
     .init start:0x0211279c end:0x02112944
 
 src/__sinit_ov036_02112944.c:
+    complete
     .init start:0x02112944 end:0x021129dc

--- a/config/arm9/overlays/ov039/delinks.txt
+++ b/config/arm9/overlays/ov039/delinks.txt
@@ -34,4 +34,5 @@ src/Cloud_Spawn.c:
     .text start:0x0211137c end:0x021113b4
 
 src/__sinit_ov039_021113b4.c:
+    complete
     .init start:0x021113b4 end:0x021113f4

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -92,13 +92,17 @@ src/StairsBdw_Spawn.cpp:
     .text start:0x0211176c end:0x021117fc
 
 src/__sinit_ov043_021117fc.c:
+    complete
     .init start:0x021117fc end:0x02111868
 
 src/__sinit_ov043_02111868.c:
+    complete
     .init start:0x02111868 end:0x021118d4
 
 src/__sinit_ov043_021118d4.c:
+    complete
     .init start:0x021118d4 end:0x02111940
 
 src/__sinit_ov043_02111940.c:
+    complete
     .init start:0x02111940 end:0x02111ae8

--- a/config/arm9/overlays/ov044/delinks.txt
+++ b/config/arm9/overlays/ov044/delinks.txt
@@ -31,4 +31,5 @@ src/OrangeBallBillboard_Spawn.c:
     .text start:0x021112dc end:0x02111314
 
 src/__sinit_ov044_02111314.c:
+    complete
     .init start:0x02111314 end:0x02111354

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -158,19 +158,25 @@ src/FallBlockBfs_Spawn.c:
     .text start:0x02111e24 end:0x02111e60
 
 src/__sinit_ov045_021121a8.c:
+    complete
     .init start:0x021121a8 end:0x02112214
 
 src/__sinit_ov045_02112214.c:
+    complete
     .init start:0x02112214 end:0x02112280
 
 src/__sinit_ov045_02112280.c:
+    complete
     .init start:0x02112280 end:0x021122ec
 
 src/__sinit_ov045_021122ec.c:
+    complete
     .init start:0x021122ec end:0x02112358
 
 src/__sinit_ov045_02112358.c:
+    complete
     .init start:0x02112358 end:0x021123c0
 
 src/__sinit_ov045_021123c0.c:
+    complete
     .init start:0x021123c0 end:0x0211242c

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -84,13 +84,17 @@ src/StairsBs_Spawn.cpp:
     .text start:0x0211164c end:0x021116dc
 
 src/__sinit_ov047_021116dc.c:
+    complete
     .init start:0x021116dc end:0x02111748
 
 src/__sinit_ov047_02111748.c:
+    complete
     .init start:0x02111748 end:0x021117b4
 
 src/__sinit_ov047_021117b4.c:
+    complete
     .init start:0x021117b4 end:0x0211181c
 
 src/__sinit_ov047_0211181c.c:
+    complete
     .init start:0x0211181c end:0x021119c4

--- a/config/arm9/overlays/ov052/delinks.txt
+++ b/config/arm9/overlays/ov052/delinks.txt
@@ -61,7 +61,9 @@ src/SquarePathLift_Spawn.c:
     .text start:0x02111830 end:0x02111868
 
 src/__sinit_ov052_02111b64.c:
+    complete
     .init start:0x02111b64 end:0x02111bd0
 
 src/__sinit_ov052_02111bd0.c:
+    complete
     .init start:0x02111bd0 end:0x02111c3c

--- a/config/arm9/overlays/ov055/delinks.txt
+++ b/config/arm9/overlays/ov055/delinks.txt
@@ -47,4 +47,5 @@ src/MirrorLuigi_Spawn.cpp:
     .text start:0x02111860 end:0x021118d4
 
 src/__sinit_ov055_021118d4.c:
+    complete
     .init start:0x021118d4 end:0x02111910

--- a/config/arm9/overlays/ov056/delinks.txt
+++ b/config/arm9/overlays/ov056/delinks.txt
@@ -33,4 +33,5 @@ src/BigMovingIceBlock_Spawn.c:
     .text start:0x02111594 end:0x021115cc
 
 src/__sinit_ov056_02112b48.c:
+    complete
     .init start:0x02112b48 end:0x02112bb4

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -602,19 +602,25 @@ src/BowserShockwaves_Spawn.c:
     .text start:0x021191f4 end:0x02119264
 
 src/__sinit_ov060_021195dc.c:
+    complete
     .init start:0x021195dc end:0x02119df0
 
 src/__sinit_ov060_02119df0.c:
+    complete
     .init start:0x02119df0 end:0x02119f94
 
 src/__sinit_ov060_02119f94.c:
+    complete
     .init start:0x02119f94 end:0x0211a000
 
 src/__sinit_ov060_0211a000.c:
+    complete
     .init start:0x0211a000 end:0x0211a388
 
 src/__sinit_ov060_0211a388.c:
+    complete
     .init start:0x0211a388 end:0x0211a428
 
 src/__sinit_ov060_0211a428.c:
+    complete
     .init start:0x0211a428 end:0x0211a4bc

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -485,16 +485,21 @@ src/Klepto_Spawn.c:
     .text start:0x0211ce80 end:0x0211ced8
 
 src/__sinit_ov062_0211cf30.c:
+    complete
     .init start:0x0211cf30 end:0x0211d2d8
 
 src/__sinit_ov062_0211d2d8.c:
+    complete
     .init start:0x0211d2d8 end:0x0211d4a0
 
 src/__sinit_ov062_0211d4a0.c:
+    complete
     .init start:0x0211d4a0 end:0x0211d690
 
 src/__sinit_ov062_0211d690.c:
+    complete
     .init start:0x0211d690 end:0x0211d6fc
 
 src/__sinit_ov062_0211d6fc.c:
+    complete
     .init start:0x0211d6fc end:0x0211d8cc

--- a/config/arm9/overlays/ov063/delinks.txt
+++ b/config/arm9/overlays/ov063/delinks.txt
@@ -542,13 +542,17 @@ src/actors/MadPiano/MadPiano_Spawn.cpp:
     .text start:0x0211e128 end:0x0211e1c0
 
 src/unnamed/ov063/__sinit_ov063_0211e29c.c:
+    complete
     .init start:0x0211e29c end:0x0211e3cc
 
 src/unnamed/ov063/__sinit_ov063_0211e3cc.c:
+    complete
     .init start:0x0211e3cc end:0x0211e590
 
 src/unnamed/ov063/__sinit_ov063_0211e590.c:
+    complete
     .init start:0x0211e590 end:0x0211e5fc
 
 src/actors/MadPiano/__sinit_ov063_0211e5fc.c:
+    complete
     .init start:0x0211e5fc end:0x0211e6fc

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -629,34 +629,45 @@ src/Clam_Spawn.c:
     .text start:0x0211ad70 end:0x0211adb0
 
 src/__sinit_ov064_0211ae00.c:
+    complete
     .init start:0x0211ae00 end:0x0211aee0
 
 src/__sinit_ov064_0211aee0.c:
+    complete
     .init start:0x0211aee0 end:0x0211afc0
 
 src/__sinit_ov064_0211afc0.c:
+    complete
     .init start:0x0211afc0 end:0x0211b078
 
 src/__sinit_ov064_0211b078.c:
+    complete
     .init start:0x0211b078 end:0x0211b0e4
 
 src/__sinit_ov064_0211b0e4.c:
+    complete
     .init start:0x0211b0e4 end:0x0211b150
 
 src/__sinit_ov064_0211b150.c:
+    complete
     .init start:0x0211b150 end:0x0211b1d4
 
 src/__sinit_ov064_0211b1d4.c:
+    complete
     .init start:0x0211b1d4 end:0x0211b4dc
 
 src/__sinit_ov064_0211b4dc.c:
+    complete
     .init start:0x0211b4dc end:0x0211b518
 
 src/__sinit_ov064_0211b518.c:
+    complete
     .init start:0x0211b518 end:0x0211b59c
 
 src/__sinit_ov064_0211b59c.c:
+    complete
     .init start:0x0211b59c end:0x0211b698
 
 src/__sinit_ov064_0211b698.c:
+    complete
     .init start:0x0211b698 end:0x0211b72c

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -540,31 +540,41 @@ src/TTC_MovingBeam_Spawn.c:
     .text start:0x0211c040 end:0x0211c078
 
 src/__sinit_ov065_0211c110.c:
+    complete
     .init start:0x0211c110 end:0x0211c2a8
 
 src/__sinit_ov065_0211c2a8.c:
+    complete
     .init start:0x0211c2a8 end:0x0211c440
 
 src/__sinit_ov065_0211c440.c:
+    complete
     .init start:0x0211c440 end:0x0211c660
 
 src/__sinit_ov065_0211c660.c:
+    complete
     .init start:0x0211c660 end:0x0211c76c
 
 src/__sinit_ov065_0211c76c.c:
+    complete
     .init start:0x0211c76c end:0x0211c7d8
 
 src/__sinit_ov065_0211c7d8.c:
+    complete
     .init start:0x0211c7d8 end:0x0211c890
 
 src/__sinit_ov065_0211c890.c:
+    complete
     .init start:0x0211c890 end:0x0211c8fc
 
 src/__sinit_ov065_0211c8fc.c:
+    complete
     .init start:0x0211c8fc end:0x0211c9b8
 
 src/__sinit_ov065_0211c9b8.c:
+    complete
     .init start:0x0211c9b8 end:0x0211ca74
 
 src/__sinit_ov065_0211ca74.c:
+    complete
     .init start:0x0211ca74 end:0x0211cae0

--- a/config/arm9/overlays/ov066/delinks.txt
+++ b/config/arm9/overlays/ov066/delinks.txt
@@ -252,4 +252,5 @@ src/Eyerok_Spawn.cpp:
     .text start:0x0211a370 end:0x0211a418
 
 src/__sinit_ov066_0211a418.c:
+    complete
     .init start:0x0211a418 end:0x0211abc0

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -365,13 +365,17 @@ src/FlameChompFire_Spawn.c:
     .text start:0x021221fc end:0x02122244
 
 src/__sinit_ov070_02122afc.c:
+    complete
     .init start:0x02122afc end:0x02122d80
 
 src/__sinit_ov070_02122d80.cpp:
+    complete
     .init start:0x02122d80 end:0x02122f30
 
 src/__sinit_ov070_02122f30.c:
+    complete
     .init start:0x02122f30 end:0x02123030
 
 src/__sinit_ov070_02123030.c:
+    complete
     .init start:0x02123030 end:0x021230a4

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -341,12 +341,15 @@ src/Coffin_Spawn.c:
     .text start:0x02122670 end:0x021226a0
 
 src/__sinit_ov071_021226ac.c:
+    complete
     .init start:0x021226ac end:0x021228c8
 
 src/__sinit_ov071_021228c8.c:
+    complete
     .init start:0x021228c8 end:0x02122a1c
 
 src/__sinit_ov071_02122a1c.c:
+    complete
     .init start:0x02122a1c end:0x02122a64
 
 src/__sinit_ov071_02122a64.c:

--- a/config/arm9/overlays/ov072/delinks.txt
+++ b/config/arm9/overlays/ov072/delinks.txt
@@ -362,13 +362,17 @@ src/BabyPenguin_Spawn.c:
     .text start:0x02121fac end:0x02121ffc
 
 src/__sinit_ov072_02122018.c:
+    complete
     .init start:0x02122018 end:0x021221f8
 
 src/__sinit_ov072_021221f8.c:
+    complete
     .init start:0x021221f8 end:0x02122350
 
 src/__sinit_ov072_02122350.c:
+    complete
     .init start:0x02122350 end:0x02122414
 
 src/__sinit_ov072_02122414.c:
+    complete
     .init start:0x02122414 end:0x02122708

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -275,7 +275,9 @@ src/CccArena_Spawn.c:
     .text start:0x02122844 end:0x02122874
 
 src/__sinit_ov073_02122874.c:
+    complete
     .init start:0x02122874 end:0x02122d48
 
 src/__sinit_ov073_02122d48.c:
+    complete
     .init start:0x02122d48 end:0x02122f34

--- a/config/arm9/overlays/ov074/delinks.txt
+++ b/config/arm9/overlays/ov074/delinks.txt
@@ -206,4 +206,5 @@ src/Goomboss_Spawn.cpp:
     .text start:0x02122838 end:0x0212290c
 
 src/__sinit_ov074_02122978.c:
+    complete
     .init start:0x02122978 end:0x02122d70

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -524,10 +524,13 @@ src/func_ov075_0211b458.cpp:
     .text start:0x0211b458 end:0x0211b524
 
 src/__sinit_ov075_0211b5e0.c:
+    complete
     .init start:0x0211b5e0 end:0x0211bb00
 
 src/__sinit_ov075_0211bb00.c:
+    complete
     .init start:0x0211bb00 end:0x0211c51c
 
 src/__sinit_ov075_0211c51c.c:
+    complete
     .init start:0x0211c51c end:0x0211c5a4

--- a/config/arm9/overlays/ov077/delinks.txt
+++ b/config/arm9/overlays/ov077/delinks.txt
@@ -354,10 +354,13 @@ src/HeaveHo_Spawn.c:
     .text start:0x021271d4 end:0x02127230
 
 src/__sinit_ov077_02127240.c:
+    complete
     .init start:0x02127240 end:0x0212749c
 
 src/__sinit_ov077_0212749c.c:
+    complete
     .init start:0x0212749c end:0x021275fc
 
 src/__sinit_ov077_021275fc.c:
+    complete
     .init start:0x021275fc end:0x021277cc

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -209,4 +209,5 @@ src/KingBobOmb_Spawn.c:
     .text start:0x021265fc end:0x02126660
 
 src/__sinit_ov078_02126660.c:
+    complete
     .init start:0x02126660 end:0x02126cd4

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -266,13 +266,17 @@ src/FortressWallBreakable_Spawn.c:
     .text start:0x021275ac end:0x021275dc
 
 src/__sinit_ov079_02127618.c:
+    complete
     .init start:0x02127618 end:0x021279d4
 
 src/__sinit_ov079_021279d4.c:
+    complete
     .init start:0x021279d4 end:0x02127a10
 
 src/__sinit_ov079_02127a10.c:
+    complete
     .init start:0x02127a10 end:0x02127acc
 
 src/__sinit_ov079_02127acc.c:
+    complete
     .init start:0x02127acc end:0x02127b88

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -335,10 +335,13 @@ src/func_ov080_02127658.c:
     .text start:0x02127658 end:0x0212766c
 
 src/__sinit_ov080_021278c0.c:
+    complete
     .init start:0x021278c0 end:0x02127a60
 
 src/__sinit_ov080_02127a60.c:
+    complete
     .init start:0x02127a60 end:0x02127b2c
 
 src/__sinit_ov080_02127b2c.c:
+    complete
     .init start:0x02127b2c end:0x02127f60

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -428,16 +428,21 @@ src/IceBlock_Spawn.c:
     .text start:0x021280a0 end:0x021280d8
 
 src/__sinit_ov081_021280e8.c:
+    complete
     .init start:0x021280e8 end:0x02128154
 
 src/__sinit_ov081_02128154.c:
+    complete
     .init start:0x02128154 end:0x021284b4
 
 src/__sinit_ov081_021284b4.c:
+    complete
     .init start:0x021284b4 end:0x021284f0
 
 src/__sinit_ov081_021284f0.c:
+    complete
     .init start:0x021284f0 end:0x021287b8
 
 src/__sinit_ov081_021287b8.c:
+    complete
     .init start:0x021287b8 end:0x02128824

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -406,10 +406,13 @@ src/PiranhaPlant_Spawn.c:
     .text start:0x02130110 end:0x02130174
 
 src/__sinit_ov084_0213035c.c:
+    complete
     .init start:0x0213035c end:0x02130558
 
 src/__sinit_ov084_02130558.c:
+    complete
     .init start:0x02130558 end:0x02130654
 
 src/__sinit_ov084_02130654.c:
+    complete
     .init start:0x02130654 end:0x02130860

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -492,19 +492,25 @@ src/WallSign_Spawn.c:
     .text start:0x0212f244 end:0x0212f27c
 
 src/__sinit_ov085_0212f2a8.c:
+    complete
     .init start:0x0212f2a8 end:0x0212f3a0
 
 src/__sinit_ov085_0212f3a0.c:
+    complete
     .init start:0x0212f3a0 end:0x0212f5ec
 
 src/__sinit_ov085_0212f5ec.c:
+    complete
     .init start:0x0212f5ec end:0x0212f9bc
 
 src/__sinit_ov085_0212f9bc.c:
+    complete
     .init start:0x0212f9bc end:0x0212fa40
 
 src/__sinit_ov085_0212fa40.c:
+    complete
     .init start:0x0212fa40 end:0x0212fdb0
 
 src/__sinit_ov085_0212fdb0.c:
+    complete
     .init start:0x0212fdb0 end:0x0212fdf0

--- a/config/arm9/overlays/ov089/delinks.txt
+++ b/config/arm9/overlays/ov089/delinks.txt
@@ -84,4 +84,5 @@ src/Key_Spawn.c:
     .text start:0x02132828 end:0x02132880
 
 src/__sinit_ov089_021328d4.c:
+    complete
     .init start:0x021328d4 end:0x02132af4

--- a/config/arm9/overlays/ov090/delinks.txt
+++ b/config/arm9/overlays/ov090/delinks.txt
@@ -265,13 +265,17 @@ src/Shark_Spawn.c:
     .text start:0x02133ca0 end:0x02133ce8
 
 src/__sinit_ov090_02133ce8.c:
+    complete
     .init start:0x02133ce8 end:0x02133ea8
 
 src/__sinit_ov090_02133ea8.c:
+    complete
     .init start:0x02133ea8 end:0x02133f4c
 
 src/__sinit_ov090_02133f4c.c:
+    complete
     .init start:0x02133f4c end:0x02134020
 
 src/__sinit_ov090_02134020.c:
+    complete
     .init start:0x02134020 end:0x021340c4

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -364,19 +364,25 @@ src/Fwoosh_Spawn.c:
     .text start:0x021344a0 end:0x021344e8
 
 src/__sinit_ov091_02134524.c:
+    complete
     .init start:0x02134524 end:0x021345dc
 
 src/__sinit_ov091_021345dc.c:
+    complete
     .init start:0x021345dc end:0x021346e8
 
 src/__sinit_ov091_021346e8.c:
+    complete
     .init start:0x021346e8 end:0x02134930
 
 src/__sinit_ov091_02134930.c:
+    complete
     .init start:0x02134930 end:0x021349c4
 
 src/__sinit_ov091_021349c4.c:
+    complete
     .init start:0x021349c4 end:0x02134a30
 
 src/__sinit_ov091_02134a30.c:
+    complete
     .init start:0x02134a30 end:0x02134b68

--- a/config/arm9/overlays/ov092/delinks.txt
+++ b/config/arm9/overlays/ov092/delinks.txt
@@ -97,4 +97,5 @@ src/ToxBox_Spawn.c:
     .text start:0x02132018 end:0x02132074
 
 src/__sinit_ov092_021320cc.c:
+    complete
     .init start:0x021320cc end:0x02132210

--- a/config/arm9/overlays/ov094/delinks.txt
+++ b/config/arm9/overlays/ov094/delinks.txt
@@ -92,4 +92,5 @@ src/HootTheOwl_Spawn.c:
     .text start:0x02136798 end:0x021367e8
 
 src/__sinit_ov094_021367e8.c:
+    complete
     .init start:0x021367e8 end:0x021369b8

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -161,7 +161,9 @@ src/Flamethrower_Spawn.cpp:
     .text start:0x02136ed4 end:0x02136f58
 
 src/__sinit_ov095_02136fe0.c:
+    complete
     .init start:0x02136fe0 end:0x0213722c
 
 src/__sinit_ov095_0213722c.c:
+    complete
     .init start:0x0213722c end:0x021373b4

--- a/config/arm9/overlays/ov096/delinks.txt
+++ b/config/arm9/overlays/ov096/delinks.txt
@@ -188,7 +188,9 @@ src/Tornado_Spawn.c:
     .text start:0x021376bc end:0x0213770c
 
 src/__sinit_ov096_0213770c.c:
+    complete
     .init start:0x0213770c end:0x02137894
 
 src/__sinit_ov096_02137894.c:
+    complete
     .init start:0x02137894 end:0x02137900

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -361,13 +361,17 @@ src/WaterBomb_Spawn.c:
     .text start:0x0213bf10 end:0x0213bf60
 
 src/__sinit_ov098_0213bf9c.c:
+    complete
     .init start:0x0213bf9c end:0x0213c058
 
 src/__sinit_ov098_0213c058.c:
+    complete
     .init start:0x0213c058 end:0x0213c214
 
 src/__sinit_ov098_0213c214.c:
+    complete
     .init start:0x0213c214 end:0x0213c2b4
 
 src/__sinit_ov098_0213c2b4.c:
+    complete
     .init start:0x0213c2b4 end:0x0213c33c

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -503,22 +503,29 @@ src/PathLift_Spawn.cpp:
     .text start:0x02147328 end:0x021473a4
 
 src/__sinit_ov100_021473bc.c:
+    complete
     .init start:0x021473bc end:0x021474e8
 
 src/__sinit_ov100_021474e8.c:
+    complete
     .init start:0x021474e8 end:0x021475a4
 
 src/__sinit_ov100_021475a4.c:
+    complete
     .init start:0x021475a4 end:0x02147698
 
 src/__sinit_ov100_02147698.c:
+    complete
     .init start:0x02147698 end:0x02147a70
 
 src/__sinit_ov100_02147a70.c:
+    complete
     .init start:0x02147a70 end:0x02147bc0
 
 src/__sinit_ov100_02147bc0.c:
+    complete
     .init start:0x02147bc0 end:0x02147d7c
 
 src/__sinit_ov100_02147d7c.c:
+    complete
     .init start:0x02147d7c end:0x02147de8

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -436,13 +436,17 @@ src/KoopaShell_Spawn.c:
     .text start:0x0214d6b4 end:0x0214d70c
 
 src/__sinit_ov102_0214d714.c:
+    complete
     .init start:0x0214d714 end:0x0214d908
 
 src/__sinit_ov102_0214d908.c:
+    complete
     .init start:0x0214d908 end:0x0214de70
 
 src/__sinit_ov102_0214de70.c:
+    complete
     .init start:0x0214de70 end:0x0214dfac
 
 src/__sinit_ov102_0214dfac.c:
+    complete
     .init start:0x0214dfac end:0x0214e0a0

--- a/src/__sinit_ov002_021071f4.c
+++ b/src/__sinit_ov002_021071f4.c
@@ -1,4 +1,4 @@
-/* __sinit_ov002_021071f4 at 0x021014e4
+/* __sinit_ov002_021071f4 at 0x021071f4
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
  */

--- a/src/__sinit_ov002_021071f4.c
+++ b/src/__sinit_ov002_021071f4.c
@@ -22,13 +22,19 @@ struct Dest {
     Pair p4;   // 0x28
     Pair p5;   // 0x30
 };
-extern struct Dest data_ov002_021097bc;
+extern struct Dest data_ov002_0210af2c;
 
+/* The destination is data_ov002_0210af2c, not data_ov002_021097bc. The ROM
+   materialises the base into r5 from the literal pool and stores through
+   [r5, #off]; those stores carry no relocation, so only the single pool word
+   differed -- and match.py wildcards relocated words, so the per-function gate
+   passed this happily. Only the full ROM link sees it, and it could not see it
+   before either, because .init functions were not enrolled at all. */
 void __sinit_ov002_021071f4(void) {
-    data_ov002_021097bc.p0 = data_ov002_0210aed0;
-    data_ov002_021097bc.p1 = data_ov002_0210aee8;
-    data_ov002_021097bc.p2 = data_ov002_0210aed8;
-    data_ov002_021097bc.p3 = data_ov002_0210aef8;
-    data_ov002_021097bc.p4 = data_ov002_0210aef0;
-    data_ov002_021097bc.p5 = data_ov002_0210aee0;
+    data_ov002_0210af2c.p0 = data_ov002_0210aed0;
+    data_ov002_0210af2c.p1 = data_ov002_0210aee8;
+    data_ov002_0210af2c.p2 = data_ov002_0210aed8;
+    data_ov002_0210af2c.p3 = data_ov002_0210aef8;
+    data_ov002_0210af2c.p4 = data_ov002_0210aef0;
+    data_ov002_0210af2c.p5 = data_ov002_0210aee0;
 }

--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -12,7 +12,12 @@ the module. So this is a whitelist, not a blacklist:
   2. exactly one defined global FUNC symbol, and its `st_size` equals the declared size;
   3. no `.rodata` / `.data` / `.bss` / `.init` / `.ctor` content - the ROM's copy of that
      data stays in the gap object, so ours would be a duplicate that grows the module;
-  4. the function lives in a `.text` range, not `.init`;
+  4. the function lives in a `.text` or `.init` range. `.init` is buildable because
+     `rombuild.retarget_text_section` renames the compiled object's `.text` header to
+     `.init`, so dsd's `File.o(.init)` selector finds it; nothing renames any other
+     section, so every other section is still a rejection. This is the *ROM's* section
+     for the function's address, and is unrelated to rule 3, which is about what the
+     compiled object itself contains;
   5. every undefined reference names a symbol that config/**/symbols.txt actually
      defines - an invented name has no address, and because gap objects import
      carved-out symbols *weakly* it would link silently to 0 rather than error.
@@ -89,7 +94,13 @@ def classify(job):
     if r.returncode != 0 or not obj.is_file():
         return rel, name, "compile failed", []
 
-    if sec != ".text":
+    # `.init` is buildable now. mwccarm always emits compiled code into `.text`,
+    # whatever the ROM's layout calls it, and dsd's linker script selects these by
+    # name -- `File.o(.init)` -- so the names never matched and ~300 functions were
+    # unreachable. rombuild.retarget_text_section renames the section header in the
+    # object after compiling, in place and without moving a byte. Any OTHER section
+    # is still a rejection: nothing renames those, so the lcf would not find them.
+    if sec not in (".text", ".init"):
         return rel, name, f"lives in {sec}, not .text", []
 
     try:

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -207,7 +207,59 @@ def enrolled(config_root=CONFIG_ROOT):
     return checked
 
 
-def compile_one(rel, vers=None, cache=None):
+def init_section_sources():
+    """{rel} for enrolled sources whose function lives in .init rather than .text.
+
+    dsd's linker script selects each object's code by section name -- `File.o(.init)`
+    for these -- but mwccarm always emits compiled code into `.text`, whatever the
+    ROM's own layout calls it. The names never match, so ~300 otherwise-eligible
+    functions, almost all __sinit_* static initialisers, could not be built from
+    source at all.
+    """
+    import enroll as E
+    cands, _ = E.candidates()
+    return {rel for (_d, _name, rel, _addr, _size, sec) in cands if sec == ".init"}
+
+
+def retarget_text_section(obj, section=".init"):
+    """Rename an object's `.text` section header to `section`, in place.
+
+    Only the section-header string is touched. `.text` and `.init` are both five
+    bytes, so the entry is overwritten where it sits and nothing in the file moves.
+    That matters: rewriting the ELF would risk perturbing the very bytes this build
+    exists to compare against the ROM.
+
+    Safe because mwccarm's .shstrtab stores `.text` as its own entry rather than as a
+    suffix of `.rela.text` -- they sit at distinct offsets -- so the overwrite cannot
+    corrupt the relocation section's name. `.rela.text` keeps its own name and finds
+    its target through sh_info, a section index, which is unaffected.
+
+    Idempotent: an object already carrying `section` is left alone, so a cache entry
+    written before this existed gets corrected rather than served stale.
+    """
+    import io
+    from elftools.elf.elffile import ELFFile
+
+    raw = bytearray(obj.read_bytes())
+    elf = ELFFile(io.BytesIO(bytes(raw)))
+    names = [s.name for s in elf.iter_sections()]
+    if section in names:
+        return False                          # already retargeted
+    base = elf.get_section(elf["e_shstrndx"]).header["sh_offset"]
+    want = b".text\x00"
+    for s in elf.iter_sections():
+        if s.name != ".text":
+            continue
+        off = base + s.header["sh_name"]
+        if bytes(raw[off:off + len(want)]) != want:
+            raise RuntimeError(f"{obj}: .shstrtab entry at {off} is not '.text'")
+        raw[off:off + len(section)] = section.encode()
+        obj.write_bytes(bytes(raw))
+        return True
+    return False
+
+
+def compile_one(rel, vers=None, cache=None, init_srcs=None):
     """Compile one enrolled source file to the object path dsd's objects.txt names.
 
     Returns (rel, error-or-None, outcome), where outcome is how the object was
@@ -233,6 +285,8 @@ def compile_one(rel, vers=None, cache=None):
     if key is not None:
         deps = cache.manifest(key)
         if deps is not None and cache.fetch(cache.object_key(key, deps), obj):
+            if init_srcs and rel in init_srcs:
+                retarget_text_section(obj)
             return rel, None, "hit"
 
     # -MD makes mwccarm write out the headers it actually read, which is what lets the
@@ -258,6 +312,10 @@ def compile_one(rel, vers=None, cache=None):
         if r.returncode != 0 or not obj.is_file():
             detail = "\n".join(s for s in (r.stdout.strip(), r.stderr.strip()) if s)
             return rel, detail[:400], "error"
+        # Before caching, so the stored object already carries the right section name
+        # and a later hit needs no fixup.
+        if init_srcs and rel in init_srcs:
+            retarget_text_section(obj)
         if key is None:
             return rel, None, "miss"
         deps = cache.deps_from(scratch)
@@ -359,13 +417,15 @@ def main():
         report["alternateToolchainFiles"] = n_alt
         cache = RBK.ObjectCache(args.cache_dir or (BUILD / "objcache"), REPO,
                                 enabled=not args.no_cache)
+        init_srcs = init_section_sources()
         print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
               + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
         failures = []
         outcomes = {}
         if srcs:
             with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
-                for rel, err, outcome in ex.map(lambda s: compile_one(s, vers, cache), srcs):
+                for rel, err, outcome in ex.map(
+                        lambda s: compile_one(s, vers, cache, init_srcs), srcs):
                     outcomes[outcome] = outcomes.get(outcome, 0) + 1
                     if err:
                         failures.append((rel, err))


### PR DESCRIPTION
Re-opened from #1034 with a fresh base (the old PR's recorded base.sha predated 18 commits of main and poisoned every validation diff).

Enrolls all 302 eligible `.init` static-initializer functions into the source build (10,162 -> 10,464 `complete`), adds the `.text`->`.init` object retarget to rombuild, and fixes the wrong relocation destination the new coverage exposed: `__sinit_ov002_021071f4`'s literal pool pointed at the sibling initializer's table (`0x021097bc`) instead of its own (`0x0210af2c`) - the copy-paste fingerprint is preserved in the fixed file header.

Diff: 71 files (+403/-12) = 68 delinks + 1 src + 2 tools.

Verification (local, canonical toolchain):
- `tools/match.py` on `src/__sinit_ov002_021071f4.c`: MATCHING VERSIONS 2004/b56
- `tools/test_rombuild{,_cache,_check,_profile}.py`: 33 passed, 1 skipped
- `tools/port_refcheck.py`: 395 references, clean
- `tools/rombuild.py --profile stock`, cold cache: 10,464/10,464 reproducing, 0 mismatching, module fidelity 106/106 exact (100.000000%)

Invariants: all 302 delinks ranges equal `symbols.txt` addr/size; no NONMATCHING files enrolled; eligible-but-unenrolled `.init` remainder = 0. Regeneration on the current base emitted 4 eligible-but-unenrolled `.text` functions (`func_ov006_020e8830`, `func_ov006_020fa3d0`, `func_ov006_02123938`, `func_ov007_020beeb0`) - pre-existing main-side debt, deliberately not promoted here; follow-up PR incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MumV9zcDeB1JeaZhjEynXf