### PR TITLE
Resolve references from the ROM's relocations, and ratchet against new ones

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -7,6 +7,7 @@
     .data       start:0x02086bc0 end:0x0209b000 kind:data align:32
     .bss        start:0x0209b000 end:0x020aa420 kind:bss align:32
 src/Entry.c:
+    complete
     .text start:0x02004800 end:0x020048d8
 
 src/func_020048d8.c:
@@ -415,6 +416,7 @@ src/func_020098e0.c:
     .text start:0x020098e0 end:0x02009a8c
 
 src/func_02009a8c.c:
+    complete
     .text start:0x02009a8c end:0x02009aa8
 
 src/func_02009aa8.c:
@@ -1846,6 +1848,7 @@ src/_ZN18MovingCylinderClsn6GetPosEv.cpp:
     .text start:0x02014948 end:0x02014954
 
 src/_ZN18MovingCylinderClsnD2Ev.c:
+    complete
     .text start:0x02014954 end:0x02014978
 
 src/_ZN18MovingCylinderClsnD0Ev.c:
@@ -1853,6 +1856,7 @@ src/_ZN18MovingCylinderClsnD0Ev.c:
     .text start:0x02014978 end:0x020149a4
 
 src/_ZN18MovingCylinderClsnD1Ev.c:
+    complete
     .text start:0x020149a4 end:0x020149c8
 
 src/_ZN18MovingCylinderClsnC1Ev.c:
@@ -1876,6 +1880,7 @@ src/_ZN25MovingCylinderClsnWithPosD0Ev.c:
     .text start:0x02014a34 end:0x02014a60
 
 src/_ZN25MovingCylinderClsnWithPosD1Ev.c:
+    complete
     .text start:0x02014a60 end:0x02014a84
 
 src/_ZN25MovingCylinderClsnWithPosC1Ev.c:
@@ -1891,6 +1896,7 @@ src/func_02014f44.c:
     .text start:0x02014f44 end:0x02014f5c
 
 src/func_02014f5c.c:
+    complete
     .text start:0x02014f5c end:0x02014fa4
 
 src/func_02014fa4.c:
@@ -2443,6 +2449,7 @@ src/engine/fader/_ZN10FaderColorD1Ev.c:
     .text start:0x020175c4 end:0x020175e8
 
 src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp:
+    complete
     .text start:0x020175e8 end:0x02017610
 
 src/engine/fader/_ZN15FaderBrightness10SetToStartEv.cpp:
@@ -4316,6 +4323,7 @@ src/func_0202ec9c.cpp:
     .text start:0x0202ec9c end:0x0202ecfc
 
 src/func_0202ecfc.c:
+    complete
     .text start:0x0202ecfc end:0x0202ed08
 
 src/func_0202ed08.c:
@@ -5635,6 +5643,7 @@ src/_ZN18MovingMeshCollider12TransformPosERK7Vector3RS0_.cpp:
     .text start:0x02039930 end:0x02039970
 
 src/_ZN18MovingMeshCollider10DetectClsnER11RaycastLine.c:
+    complete
     .text start:0x02039970 end:0x02039a3c
 
 src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.c:
@@ -5642,6 +5651,7 @@ src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.c:
     .text start:0x02039a3c end:0x02039cb8
 
 src/_ZN18MovingMeshCollider10DetectClsnER13RaycastGround.c:
+    complete
     .text start:0x02039cb8 end:0x02039db8
 
 src/func_02039db8.c:
@@ -5705,6 +5715,7 @@ src/_ZN21ExtendingMeshCollider9GetNormalEsR7Vector3.cpp:
     .text start:0x0203a4dc end:0x0203a594
 
 src/_ZN21ExtendingMeshCollider10DetectClsnER11RaycastLine.c:
+    complete
     .text start:0x0203a594 end:0x0203a660
 
 src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp:
@@ -7766,6 +7777,7 @@ src/func_0204da4c.c:
     .text start:0x0204da4c end:0x0204dab4
 
 src/func_0204dab4.c:
+    complete
     .text start:0x0204dab4 end:0x0204dc84
 
 src/func_0204dc84.c:
@@ -8333,6 +8345,7 @@ src/func_02051024.c:
     .text start:0x02051024 end:0x02051064
 
 src/func_02051064.c:
+    complete
     .text start:0x02051064 end:0x02051074
 
 src/func_02051074.c:
@@ -8811,6 +8824,7 @@ src/_ZN2GX15SetBankForSubBGEt.c:
     .text start:0x02054384 end:0x02054430
 
 src/func_02054430.c:
+    complete
     .text start:0x02054430 end:0x02054450
 
 src/_ZN2GX17SetBankForTexPlttEt.c:
@@ -9144,27 +9158,35 @@ src/Copy48BytesFixed.c:
     .text start:0x02056c1c end:0x02056c40
 
 src/_ZN3IRQ19Tim3OverflowHandlerEv.cpp:
+    complete
     .text start:0x02056c40 end:0x02056c50
 
 src/_ZN3IRQ19Tim2OverflowHandlerEv.cpp:
+    complete
     .text start:0x02056c50 end:0x02056c60
 
 src/_ZN3IRQ19Tim1OverflowHandlerEv.cpp:
+    complete
     .text start:0x02056c60 end:0x02056c70
 
 src/_ZN3IRQ19Tim0OverflowHandlerEv.cpp:
+    complete
     .text start:0x02056c70 end:0x02056c80
 
 src/_ZN3IRQ11Dma3HandlerEv.cpp:
+    complete
     .text start:0x02056c80 end:0x02056c90
 
 src/_ZN3IRQ11Dma2HandlerEv.cpp:
+    complete
     .text start:0x02056c90 end:0x02056ca0
 
 src/_ZN3IRQ11Dma1HandlerEv.cpp:
+    complete
     .text start:0x02056ca0 end:0x02056cb0
 
 src/_ZN3IRQ11Dma0HandlerEv.cpp:
+    complete
     .text start:0x02056cb0 end:0x02056cc0
 
 src/_ZN3IRQ13DmaTimHandlerEv.c:
@@ -10097,6 +10119,7 @@ src/func_0205cd34.c:
     .text start:0x0205cd34 end:0x0205cd5c
 
 src/func_0205cd5c.c:
+    complete
     .text start:0x0205cd5c end:0x0205cdf4
 
 src/func_0205cdf4.cpp:
@@ -11343,6 +11366,7 @@ src/func_0206a5c0.c:
     .text start:0x0206a5c0 end:0x0206a600
 
 src/func_0206a600.c:
+    complete
     .text start:0x0206a600 end:0x0206a634
 
 src/func_0206a634.c:
@@ -11740,6 +11764,7 @@ src/func_02072014.c:
     .text start:0x02072014 end:0x02072168
 
 src/func_02072168.c:
+    complete
     .text start:0x02072168 end:0x020729f4
 
 src/func_020729f4.c:

--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -1896,7 +1896,6 @@ src/func_02014f44.c:
     .text start:0x02014f44 end:0x02014f5c
 
 src/func_02014f5c.c:
-    complete
     .text start:0x02014f5c end:0x02014fa4
 
 src/func_02014fa4.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -1953,6 +1953,7 @@ src/func_ov002_020c0688.cpp:
     .text start:0x020c0688 end:0x020c06fc
 
 src/func_ov002_020c06fc.c:
+    complete
     .text start:0x020c06fc end:0x020c0cbc
 
 src/func_ov002_020c0cbc.c:
@@ -3326,6 +3327,7 @@ src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp:
     .text start:0x020d8e70 end:0x020d91b8
 
 src/func_ov002_020d91b8.c:
+    complete
     .text start:0x020d91b8 end:0x020d91e0
 
 src/func_ov002_020d91e0.c:

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -76,9 +76,11 @@ src/func_ov004_020adc4c.c:
     .text start:0x020adc4c end:0x020adc5c
 
 src/Ov004_Deallocate.c:
+    complete
     .text start:0x020adc5c end:0x020adc68
 
 src/func_ov004_020adc68.c:
+    complete
     .text start:0x020adc68 end:0x020adc74
 
 src/func_ov004_020adc74.c:
@@ -433,6 +435,7 @@ src/func_ov004_020b290c.c:
     .text start:0x020b290c end:0x020b2980
 
 src/func_ov004_020b2980.c:
+    complete
     .text start:0x020b2980 end:0x020b298c
 
 src/func_ov004_020b298c.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -338,7 +338,6 @@ src/func_ov006_020c3b80.c:
     .text start:0x020c3b80 end:0x020c3bc8
 
 src/func_ov006_020c3bc8.c:
-    complete
     .text start:0x020c3bc8 end:0x020c3bf4
 
 src/func_ov006_020c3bf4.cpp:
@@ -2075,7 +2074,6 @@ src/func_ov006_020de440.cpp:
     .text start:0x020de440 end:0x020de584
 
 src/func_ov006_020de584.c:
-    complete
     .text start:0x020de584 end:0x020de5ac
 
 src/func_ov006_020de5ac.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -338,6 +338,7 @@ src/func_ov006_020c3b80.c:
     .text start:0x020c3b80 end:0x020c3bc8
 
 src/func_ov006_020c3bc8.c:
+    complete
     .text start:0x020c3bc8 end:0x020c3bf4
 
 src/func_ov006_020c3bf4.cpp:
@@ -654,6 +655,7 @@ src/func_ov006_020c7ba4.c:
     .text start:0x020c7ba4 end:0x020c7c68
 
 src/func_ov006_020c7c68.c:
+    complete
     .text start:0x020c7c68 end:0x020c802c
 
 src/func_ov006_020c802c.c:
@@ -806,6 +808,7 @@ src/func_ov006_020c91ac.cpp:
     .text start:0x020c91ac end:0x020c94e0
 
 src/func_ov006_020c94e0.cpp:
+    complete
     .text start:0x020c94e0 end:0x020c97bc
 
 src/func_ov006_020c97bc.cpp:
@@ -1462,9 +1465,11 @@ src/func_ov006_020d5dfc.cpp:
     .text start:0x020d5dfc end:0x020d5e1c
 
 src/func_ov006_020d5e1c.c:
+    complete
     .text start:0x020d5e1c end:0x020d5e3c
 
 src/func_ov006_020d5e3c.c:
+    complete
     .text start:0x020d5e3c end:0x020d5e5c
 
 src/func_ov006_020d5e5c.c:
@@ -2070,6 +2075,7 @@ src/func_ov006_020de440.cpp:
     .text start:0x020de440 end:0x020de584
 
 src/func_ov006_020de584.c:
+    complete
     .text start:0x020de584 end:0x020de5ac
 
 src/func_ov006_020de5ac.c:
@@ -2840,6 +2846,7 @@ src/func_ov006_020e8728.c:
     .text start:0x020e8728 end:0x020e8830
 
 src/func_ov006_020e8830.c:
+    complete
     .text start:0x020e8830 end:0x020e8928
 
 src/func_ov006_020e8928.c:
@@ -3123,6 +3130,7 @@ src/func_ov006_020ec9c0.c:
     .text start:0x020ec9c0 end:0x020ecb80
 
 src/func_ov006_020ecb80.c:
+    complete
     .text start:0x020ecb80 end:0x020ecba4
 
 src/func_ov006_020ecba4.c:
@@ -4156,6 +4164,7 @@ src/func_ov006_020fa13c.c:
     .text start:0x020fa13c end:0x020fa3d0
 
 src/func_ov006_020fa3d0.c:
+    complete
     .text start:0x020fa3d0 end:0x020fa4d4
 
 src/func_ov006_020fa4d4.cpp:
@@ -4278,6 +4287,7 @@ src/func_ov006_020fb8fc.c:
     .text start:0x020fb8fc end:0x020fb97c
 
 src/func_ov006_020fb97c.c:
+    complete
     .text start:0x020fb97c end:0x020fba28
 
 src/func_ov006_020fba28.cpp:
@@ -6563,6 +6573,7 @@ src/func_ov006_02121774.c:
     .text start:0x02121774 end:0x02121778
 
 src/func_ov006_02121778.c:
+    complete
     .text start:0x02121778 end:0x02121848
 
 src/func_ov006_02121848.c:
@@ -6721,6 +6732,7 @@ src/func_ov006_021238d0.c:
     .text start:0x021238d0 end:0x02123938
 
 src/func_ov006_02123938.c:
+    complete
     .text start:0x02123938 end:0x02123b20
 
 src/func_ov006_02123b20.c:
@@ -6728,6 +6740,7 @@ src/func_ov006_02123b20.c:
     .text start:0x02123b20 end:0x02123b24
 
 src/func_ov006_02123b24.c:
+    complete
     .text start:0x02123b24 end:0x02123bf4
 
 src/func_ov006_02123bf4.cpp:
@@ -7036,6 +7049,7 @@ src/func_ov006_0212aacc.c:
     .text start:0x0212aacc end:0x0212ac74
 
 src/func_ov006_0212ac74.c:
+    complete
     .text start:0x0212ac74 end:0x0212b480
 
 src/func_ov006_0212b480.c:

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -870,6 +870,7 @@ src/func_ov007_020bce70.cpp:
     .text start:0x020bce70 end:0x020bcf90
 
 src/func_ov007_020bcf90.c:
+    complete
     .text start:0x020bcf90 end:0x020bd1c0
 
 src/func_ov007_020bd1c0.c:
@@ -1008,6 +1009,7 @@ src/func_ov007_020bee14.c:
     .text start:0x020bee14 end:0x020beeb0
 
 src/func_ov007_020beeb0.c:
+    complete
     .text start:0x020beeb0 end:0x020bf304
 
 src/func_ov007_020bf304.c:
@@ -1129,6 +1131,7 @@ src/func_ov007_020c0a44.c:
     .text start:0x020c0a44 end:0x020c0a9c
 
 src/func_ov007_020c0a9c.c:
+    complete
     .text start:0x020c0a9c end:0x020c0aa8
 
 src/func_ov007_020c0aa8.c:
@@ -1160,6 +1163,7 @@ src/func_ov007_020c1048.c:
     .text start:0x020c1048 end:0x020c105c
 
 src/func_ov007_020c105c.c:
+    complete
     .text start:0x020c105c end:0x020c1068
 
 src/func_ov007_020c1068.c:
@@ -1231,6 +1235,7 @@ src/func_ov007_020c15ec.c:
     .text start:0x020c15ec end:0x020c1620
 
 src/func_ov007_020c1620.c:
+    complete
     .text start:0x020c1620 end:0x020c162c
 
 src/func_ov007_020c162c.c:
@@ -1273,6 +1278,7 @@ src/func_ov007_020c1db0.c:
     .text start:0x020c1db0 end:0x020c2018
 
 src/func_ov007_020c2018.c:
+    complete
     .text start:0x020c2018 end:0x020c2024
 
 src/func_ov007_020c2024.c:
@@ -1292,6 +1298,7 @@ src/func_ov007_020c22a0.c:
     .text start:0x020c22a0 end:0x020c22f8
 
 src/func_ov007_020c22f8.c:
+    complete
     .text start:0x020c22f8 end:0x020c2304
 
 src/func_ov007_020c2304.c:
@@ -1307,6 +1314,7 @@ src/func_ov007_020c2390.c:
     .text start:0x020c2390 end:0x020c2410
 
 src/func_ov007_020c2410.c:
+    complete
     .text start:0x020c2410 end:0x020c241c
 
 src/func_ov007_020c241c.c:
@@ -1402,6 +1410,7 @@ src/func_ov007_020c32e8.cpp:
     .text start:0x020c32e8 end:0x020c338c
 
 src/func_ov007_020c338c.c:
+    complete
     .text start:0x020c338c end:0x020c3398
 
 src/func_ov007_020c3398.c:
@@ -1413,6 +1422,7 @@ src/func_ov007_020c33d0.cpp:
     .text start:0x020c33d0 end:0x020c3544
 
 src/func_ov007_020c3544.c:
+    complete
     .text start:0x020c3544 end:0x020c3550
 
 src/func_ov007_020c3550.c:
@@ -1731,6 +1741,7 @@ src/func_ov007_020c78dc.c:
     .text start:0x020c78dc end:0x020c798c
 
 src/func_ov007_020c798c.c:
+    complete
     .text start:0x020c798c end:0x020c7a84
 
 src/func_ov007_020c7a84.c:
@@ -1754,6 +1765,7 @@ src/func_ov007_020c806c.c:
     .text start:0x020c806c end:0x020c8098
 
 src/func_ov007_020c8098.c:
+    complete
     .text start:0x020c8098 end:0x020c80a4
 
 src/func_ov007_020c80a4.c:
@@ -1777,6 +1789,7 @@ src/func_ov007_020c83fc.c:
     .text start:0x020c83fc end:0x020c8440
 
 src/func_ov007_020c8440.c:
+    complete
     .text start:0x020c8440 end:0x020c844c
 
 src/func_ov007_020c844c.c:
@@ -1800,6 +1813,7 @@ src/func_ov007_020c86c4.c:
     .text start:0x020c86c4 end:0x020c8970
 
 src/func_ov007_020c8970.c:
+    complete
     .text start:0x020c8970 end:0x020c897c
 
 src/func_ov007_020c897c.c:
@@ -1811,6 +1825,7 @@ src/func_ov007_020c8ac0.c:
     .text start:0x020c8ac0 end:0x020c8b04
 
 src/func_ov007_020c8b04.c:
+    complete
     .text start:0x020c8b04 end:0x020c8b10
 
 src/func_ov007_020c8b10.c:
@@ -1834,6 +1849,7 @@ src/func_ov007_020c8de0.c:
     .text start:0x020c8de0 end:0x020c8f58
 
 src/func_ov007_020c8f58.c:
+    complete
     .text start:0x020c8f58 end:0x020c8f64
 
 src/func_ov007_020c8f64.c:
@@ -1845,6 +1861,7 @@ src/func_ov007_020c8f98.c:
     .text start:0x020c8f98 end:0x020c9080
 
 src/func_ov007_020c9080.c:
+    complete
     .text start:0x020c9080 end:0x020c908c
 
 src/func_ov007_020c908c.c:
@@ -1871,6 +1888,7 @@ src/func_ov007_020c9268.c:
     .text start:0x020c9268 end:0x020c92a0
 
 src/func_ov007_020c92a0.c:
+    complete
     .text start:0x020c92a0 end:0x020c92ac
 
 src/func_ov007_020c92ac.c:
@@ -1886,6 +1904,7 @@ src/func_ov007_020c934c.c:
     .text start:0x020c934c end:0x020c937c
 
 src/func_ov007_020c937c.c:
+    complete
     .text start:0x020c937c end:0x020c9388
 
 src/func_ov007_020c9388.c:
@@ -1905,6 +1924,7 @@ src/func_ov007_020c940c.c:
     .text start:0x020c940c end:0x020c9460
 
 src/func_ov007_020c9460.c:
+    complete
     .text start:0x020c9460 end:0x020c946c
 
 src/func_ov007_020c946c.c:
@@ -2060,9 +2080,11 @@ src/func_ov007_020cc600.c:
     .text start:0x020cc600 end:0x020cca68
 
 src/func_ov007_020cca68.c:
+    complete
     .text start:0x020cca68 end:0x020cca74
 
 src/func_ov007_020cca74.c:
+    complete
     .text start:0x020cca74 end:0x020cca80
 
 src/func_ov007_020cca80.c:
@@ -2070,9 +2092,11 @@ src/func_ov007_020cca80.c:
     .text start:0x020cca80 end:0x020cca98
 
 src/func_ov007_020cca98.c:
+    complete
     .text start:0x020cca98 end:0x020ccab4
 
 src/func_ov007_020ccab4.c:
+    complete
     .text start:0x020ccab4 end:0x020ccad0
 
 src/func_ov007_020ccad0.c:

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -870,7 +870,6 @@ src/func_ov007_020bce70.cpp:
     .text start:0x020bce70 end:0x020bcf90
 
 src/func_ov007_020bcf90.c:
-    complete
     .text start:0x020bcf90 end:0x020bd1c0
 
 src/func_ov007_020bd1c0.c:
@@ -1741,7 +1740,6 @@ src/func_ov007_020c78dc.c:
     .text start:0x020c78dc end:0x020c798c
 
 src/func_ov007_020c798c.c:
-    complete
     .text start:0x020c798c end:0x020c7a84
 
 src/func_ov007_020c7a84.c:
@@ -1813,7 +1811,6 @@ src/func_ov007_020c86c4.c:
     .text start:0x020c86c4 end:0x020c8970
 
 src/func_ov007_020c8970.c:
-    complete
     .text start:0x020c8970 end:0x020c897c
 
 src/func_ov007_020c897c.c:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -92,6 +92,7 @@ src/func_ov015_02111ce0.cpp:
     .text start:0x02111ce0 end:0x02111d28
 
 src/func_ov015_02111d28.c:
+    complete
     .text start:0x02111d28 end:0x02111d4c
 
 src/func_ov015_02111d4c.c:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -145,6 +145,7 @@ src/func_ov030_02112da0.c:
     .text start:0x02112da0 end:0x02112ff8
 
 src/func_ov030_02112ff8.c:
+    complete
     .text start:0x02112ff8 end:0x02113094
 
 src/func_ov030_02113094.c:

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -34,6 +34,7 @@ src/func_ov070_0211f5f0.cpp:
     .text start:0x0211f5f0 end:0x0211f62c
 
 src/func_ov070_0211f62c.c:
+    complete
     .text start:0x0211f62c end:0x0211f694
 
 src/func_ov070_0211f694.cpp:

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -49,6 +49,7 @@ src/func_ov075_02114390.c:
     .text start:0x02114390 end:0x021143e4
 
 src/func_ov075_021143e4.cpp:
+    complete
     .text start:0x021143e4 end:0x02114560
 
 src/func_ov075_02114560.cpp:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -220,6 +220,7 @@ src/func_ov080_02125bb0.c:
     .text start:0x02125bb0 end:0x02125cd4
 
 src/func_ov080_02125cd4.c:
+    complete
     .text start:0x02125cd4 end:0x02125d08
 
 src/func_ov080_02125d08.c:

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -379,6 +379,7 @@ src/func_ov084_0212fa7c.c:
     .text start:0x0212fa7c end:0x0212fc10
 
 src/func_ov084_0212fc10.c:
+    complete
     .text start:0x0212fc10 end:0x0212fc84
 
 src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp:

--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,102 +1,106 @@
 {
- "files": {
-  "src/ChainChomp_Spawn.cpp": [
+ "eligible": 10532,
+ "unresolved": {
+  "ChainChomp_Spawn": [
    "func_020aed98"
   ],
-  "src/ChiefChilly_Spawn.cpp": [
+  "ChiefChilly_Spawn": [
    "func_020aed98"
   ],
-  "src/ExplosionGoomba_Spawn.cpp": [
+  "ExplosionGoomba_Spawn": [
    "func_020aed98"
   ],
-  "src/FS_LoadOverlay.c": [
+  "FS_LoadOverlay": [
    "func_020aa420"
   ],
-  "src/FallBlockBfs_Spawn.c": [
+  "FallBlockBbh_Spawn": [
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "FallBlockBfs_Spawn": [
    "_ZTV21daObjKm2_Fall_Block_c"
   ],
-  "src/FallBlockLll_Spawn.c": [
+  "FallBlockLll_Spawn": [
    "_ZTV20daObjFl_Fall_Block_c"
   ],
-  "src/GetSceneOverlayID.c": [
+  "GetSceneOverlayID": [
    "overlay_2",
    "overlay_3",
    "overlay_5",
    "overlay_6",
    "overlay_7"
   ],
-  "src/Goomboss_Spawn.cpp": [
+  "Goomboss_Spawn": [
    "func_020aed98"
   ],
-  "src/Grindel_Spawn.c": [
+  "Grindel_Spawn": [
    "_ZTV7daDkk_c"
   ],
-  "src/RollingLogLll_Spawn.c": [
+  "RollingLogLll_Spawn": [
    "_ZTV15daObjFlMaruta_c"
   ],
-  "src/RollingLogTtm_Spawn.c": [
+  "RollingLogTtm_Spawn": [
    "_ZTV15daObjHmMaruta_c"
   ],
-  "src/UnchainedChomp_Spawn.c": [
+  "UnchainedChomp_Spawn": [
    "func_020aed98"
   ],
-  "src/Wiggler_Spawn.c": [
+  "Wiggler_Spawn": [
    "func_020aed98"
   ],
-  "src/_Z26LoadOrUnloadObjectOverlaysPFviEi.cpp": [
+  "_Z26LoadOrUnloadObjectOverlaysPFviEi": [
    "overlay_102",
    "overlay_60",
    "overlay_98"
   ],
-  "src/_ZN10CheepCheep13InitResourcesEv.cpp": [
+  "_ZN10CheepCheep13InitResourcesEv": [
    "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj"
   ],
-  "src/_ZN10DonutBlock8BehaviorEv.cpp": [
+  "_ZN10DonutBlock8BehaviorEv": [
    "_ZN8Platform13IsClsnInRangeEii"
   ],
-  "src/_ZN10FlameChomp13InitResourcesEv.cpp": [
+  "_ZN10FlameChomp13InitResourcesEv": [
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj"
   ],
-  "src/_ZN10KoopaShell13InitResourcesEv.cpp": [
+  "_ZN10KoopaShell13InitResourcesEv": [
    "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
-  "src/_ZN10MrBlizzard13InitResourcesEv.cpp": [
+  "_ZN10MrBlizzard13InitResourcesEv": [
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj"
   ],
-  "src/_ZN10Scuttlebug13InitResourcesEv.cpp": [
+  "_ZN10Scuttlebug13InitResourcesEv": [
    "AnimLoadFile",
    "ModelLoadFile",
    "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
-  "src/_ZN10SphereClsnD1Ev.c": [
+  "_ZN10SphereClsnD1Ev": [
    "VT0",
    "VT1",
    "VT2"
   ],
-  "src/_ZN11FallBlockWf13InitResourcesEv.c": [
+  "_ZN11FallBlockWf13InitResourcesEv": [
    "func_0213a794"
   ],
-  "src/_ZN11FallBlockWf16CleanupResourcesEv.c": [
+  "_ZN11FallBlockWf16CleanupResourcesEv": [
    "func_0213a2cc"
   ],
-  "src/_ZN11FallBlockWfD0Ev.c": [
+  "_ZN11FallBlockWfD0Ev": [
    "G0",
    "VT1",
    "VT2",
    "_ZTV10dBgActor_c"
   ],
-  "src/_ZN11FallBlockWfD1Ev.c": [
+  "_ZN11FallBlockWfD1Ev": [
    "VT1",
    "VT2",
    "_ZTV10dBgActor_c"
   ],
-  "src/_ZN11MirrorLuigi13InitResourcesEv.cpp": [
+  "_ZN11MirrorLuigi13InitResourcesEv": [
    "Animation_LoadFile",
    "ModelAnim_SetAnim",
    "ModelBase_SetFile",
@@ -105,39 +109,47 @@
    "TextureSequence_Prepare",
    "TextureSequence_SetFile"
   ],
-  "src/_ZN11RaycastLineD1Ev.c": [
+  "_ZN11RaycastLineD1Ev": [
    "VT0",
    "VT1"
   ],
-  "src/_ZN12FallBlockBfs13InitResourcesEv.c": [
+  "_ZN12FallBlockBbhD0Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "_ZN12FallBlockBbhD1Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "_ZN12FallBlockBfs13InitResourcesEv": [
    "func_0213a794"
   ],
-  "src/_ZN12FallBlockBfs16CleanupResourcesEv.c": [
+  "_ZN12FallBlockBfs16CleanupResourcesEv": [
    "func_0213a2cc"
   ],
-  "src/_ZN12FallBlockBfsD0Ev.c": [
+  "_ZN12FallBlockBfsD0Ev": [
    "_ZTV10dBgActor_c",
    "_ZTV21daObjKm2_Fall_Block_c"
   ],
-  "src/_ZN12FallBlockBfsD1Ev.c": [
+  "_ZN12FallBlockBfsD1Ev": [
    "_ZTV10dBgActor_c",
    "_ZTV21daObjKm2_Fall_Block_c"
   ],
-  "src/_ZN12FallBlockLll16CleanupResourcesEv.cpp": [
+  "_ZN12FallBlockLll16CleanupResourcesEv": [
    "func_021270dc"
   ],
-  "src/_ZN12FallBlockLllD0Ev.c": [
+  "_ZN12FallBlockLllD0Ev": [
    "_ZTV10dBgActor_c",
    "_ZTV15daObjFlMaruta_c"
   ],
-  "src/_ZN12FallBlockLllD1Ev.c": [
+  "_ZN12FallBlockLllD1Ev": [
    "_ZTV10dBgActor_c",
    "_ZTV15daObjFlMaruta_c"
   ],
-  "src/_ZN12FortressWall8BehaviorEv.cpp": [
+  "_ZN12FortressWall8BehaviorEv": [
    "_ZN8Platform13IsClsnInRangeEii"
   ],
-  "src/_ZN13FortressTower13InitResourcesEv.cpp": [
+  "_ZN13FortressTower13InitResourcesEv": [
    "MeshCollider_LoadFile",
    "ModelBase_SetFile",
    "Model_LoadFile",
@@ -145,7 +157,7 @@
    "Platform_UpdateClsnPosAndRot",
    "Platform_UpdateModelPosAndRotY"
   ],
-  "src/_ZN13MontyMoleRock8BehaviorEv.cpp": [
+  "_ZN13MontyMoleRock8BehaviorEv": [
    "ActorBase_MarkForDestruction",
    "Actor_FindWithID",
    "Actor_MakeVanishLuigiWork",
@@ -156,20 +168,20 @@
    "Player_Hurt",
    "WithMeshClsn_IsOnGround"
   ],
-  "src/_ZN13PeachPainting8BehaviorEv.cpp": [
+  "_ZN13PeachPainting8BehaviorEv": [
    "_ZN9ModelBase12ApplyOpacityEji"
   ],
-  "src/_ZN13PoleBillboard16CleanupResourcesEv.cpp": [
+  "_ZN13PoleBillboard16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN13PrincessPeach13InitResourcesEv.cpp": [
+  "_ZN13PrincessPeach13InitResourcesEv": [
    "AnimLoadFile",
    "ModelLoadFile",
    "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
-  "src/_ZN13RacingPenguin13InitResourcesEv.cpp": [
+  "_ZN13RacingPenguin13InitResourcesEv": [
    "Actor_TrackStar",
    "Animation_LoadFile",
    "ModelBase_SetFile",
@@ -182,41 +194,42 @@
    "TextureSequence_Prepare",
    "WithMeshClsn_Init"
   ],
-  "src/_ZN13RacingPenguin8BehaviorEv.cpp": [
+  "_ZN13RacingPenguin8BehaviorEv": [
    "_Z23_ZN9Animation7AdvanceEvPc",
    "_Z25_ZN12CylinderClsn5ClearEvPc",
-   "_Z26_ZN12CylinderClsn6UpdateEvPc"
+   "_Z26_ZN12CylinderClsn6UpdateEvPc",
+   "p__sinit_ov031_02111434"
   ],
-  "src/_ZN13RollingLogLll13InitResourcesEv.cpp": [
+  "_ZN13RollingLogLll13InitResourcesEv": [
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
-  "src/_ZN13SnowmanBreath8BehaviorEv.cpp": [
+  "_ZN13SnowmanBreath8BehaviorEv": [
    "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3jijjPvj",
    "_Z48_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jjPvS_jPK7Vector3jj"
   ],
-  "src/_ZN13TTC_MovingBar13InitResourcesEv.cpp": [
+  "_ZN13TTC_MovingBar13InitResourcesEv": [
    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
   ],
-  "src/_ZN14BlueCoinSwitch16CleanupResourcesEv.c": [
+  "_ZN14BlueCoinSwitch16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN14CutsceneObject13InitResourcesEv.cpp": [
+  "_ZN14CutsceneObject13InitResourcesEv": [
    "_Z5_Znwji",
    "func_02113c20"
   ],
-  "src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp": [
+  "_ZN14MovingBarSmall16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN14TtcMovingCubeA13InitResourcesEv.cpp": [
+  "_ZN14TtcMovingCubeA13InitResourcesEv": [
    "func_02112118"
   ],
-  "src/_ZN15BookShotSpawner13InitResourcesEv.cpp": [
+  "_ZN15BookShotSpawner13InitResourcesEv": [
    "_Z17LoadBlueCoinModelPv",
    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv"
   ],
-  "src/_ZN15TtcRotatingGear13InitResourcesEv.cpp": [
+  "_ZN15TtcRotatingGear13InitResourcesEv": [
    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
    "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
@@ -225,40 +238,40 @@
    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
    "func_021121b8"
   ],
-  "src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp": [
+  "_ZN15TtcRotatingGear16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN16BowserShockwaves13InitResourcesEv.cpp": [
+  "_ZN16BowserShockwaves13InitResourcesEv": [
    "func_021115e4",
    "func_021115f4"
   ],
-  "src/_ZN16FloatingFloorBfs13InitResourcesEv.c": [
+  "_ZN16FloatingFloorBfs13InitResourcesEv": [
    "func_020b6244"
   ],
-  "src/_ZN16FloatingFloorBfs16CleanupResourcesEv.c": [
+  "_ZN16FloatingFloorBfs16CleanupResourcesEv": [
    "func_020b60fc"
   ],
-  "src/_ZN16RotatingCogSmall13InitResourcesEv.cpp": [
+  "_ZN16RotatingCogSmall13InitResourcesEv": [
    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
   ],
-  "src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp": [
+  "_ZN17BowserPuzzlePiece13InitResourcesEv": [
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
-  "src/_ZN17MgBounceAndPounce11AfterRenderEj.cpp": [
+  "_ZN17MgBounceAndPounce11AfterRenderEj": [
    "Scene_AfterRender"
   ],
-  "src/_ZN17RotatingClockHand13InitResourcesEv.cpp": [
+  "_ZN17RotatingClockHand13InitResourcesEv": [
    "MeshColliderLoadFile",
    "ModelLoadFile",
    "UpdatePosWithTransformSym",
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
-  "src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp": [
+  "_ZN17RotatingClockHand16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp": [
+  "_ZN18BowserFireSeaArena13InitResourcesEv": [
    "_Z13func_020393d4PvS_",
    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
@@ -267,32 +280,32 @@
    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
    "func_021115bc"
   ],
-  "src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp": [
+  "_ZN18BowserFireSeaArena16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp": [
+  "_ZN19FloatingFloorLllBig16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN19RotatingPlatformLll8BehaviorEv.cpp": [
+  "_ZN19RotatingPlatformLll8BehaviorEv": [
    "Platform_IsClsnInRange",
    "Platform_UpdateClsnPosAndRot",
    "Platform_UpdateModelPosAndRotY",
    "_Z13func_020393a4Pii"
   ],
-  "src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp": [
+  "_ZN19RotatingPlatformWdw13InitResourcesEv": [
    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
   ],
-  "src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp": [
+  "_ZN19RotatingPlatformWdw16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp": [
+  "_ZN20TtcConveyorBeltLarge13InitResourcesEv": [
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
    "_ZN18TextureTransformer7SetFileER8BTA_Fileiij"
   ],
-  "src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp": [
+  "_ZN22RotatingUpDownPlatform13InitResourcesEv": [
    "Vec3_equal",
    "_Z13func_020393c4PvS_",
    "_Z13func_020393d4PvS_",
@@ -304,69 +317,72 @@
    "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
   ],
-  "src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp": [
+  "_ZN22RotatingUpDownPlatform8BehaviorEv": [
    "ApproachLinearI",
    "UpdatePosWithVelocitySym",
    "_ZN8Platform13IsClsnInRangeEii"
   ],
-  "src/_ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3.c": [
+  "_ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3": [
    "_ll_sdiv"
   ],
-  "src/_ZN3HUD15RenderCoinCountEv.cpp": [
+  "_ZN3HUD15RenderCoinCountEv": [
    "func_020ab9c8",
    "func_020aba70",
    "func_020abad8"
   ],
-  "src/_ZN3HUD15RenderLifeCountEv.cpp": [
+  "_ZN3HUD15RenderLifeCountEv": [
    "func_020ab948",
    "func_020ab9c8",
    "func_020aba70"
   ],
-  "src/_ZN3HUD15RenderStarCountEv.cpp": [
+  "_ZN3HUD15RenderStarCountEv": [
    "func_020ab9c8",
    "func_020aba70",
    "func_020abad0"
   ],
-  "src/_ZN3HUD15RenderTimeTimerEv.cpp": [
+  "_ZN3HUD15RenderTimeTimerEv": [
    "_ll_udiv",
    "_ull_mod"
   ],
-  "src/_ZN4Heap18InitializeRootHeapEv.cpp": [
+  "_ZN4Heap18InitializeRootHeapEv": [
    "_ZN6Memory15rootParamOffsetE"
   ],
-  "src/_ZN4Tree13InitResourcesEv.cpp": [
+  "_ZN4Tree13InitResourcesEv": [
    "_ZN19CylinderClsnWithPos4InitERK7Vector3iijj"
   ],
-  "src/_ZN4cstd5atan2E5Fix12IiES1_.c": [
+  "_ZN4cstd5atan2E5Fix12IiES1_": [
    "func_01ff98f4"
   ],
-  "src/_ZN5Actor13LandingDustAtER7Vector3b.cpp": [
+  "_ZN5Actor13LandingDustAtER7Vector3b": [
    "_ZN8Particle6System9NewSimpleEjiii"
   ],
-  "src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp": [
+  "_ZN5Actor17HugeLandingDustAtER7Vector3b": [
    "_ZN8Particle6System9NewSimpleEjiii"
   ],
-  "src/_ZN5Cloud8BehaviorEv.c": [
+  "_ZN5Cloud8BehaviorEv": [
    "FindWithActorID",
    "SetPolygonID"
   ],
-  "src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp": [
+  "_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc": [
    "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv"
   ],
-  "src/_ZN5Stage12RenderNumberEhiibi.cpp": [
+  "_ZN5FaderD0Ev": [
+   "base_dtor_Fader"
+  ],
+  "_ZN5Stage12RenderNumberEhiibi": [
    "func_020aba70"
   ],
-  "src/_ZN5Stage14GraphCallback2EP12SceneRelated.c": [
+  "_ZN5Stage14GraphCallback2EP12SceneRelated": [
    "reg_G2S_DB_BG3PA"
   ],
-  "src/_ZN5Stage20RenderBouncingArrowsEv.cpp": [
+  "_ZN5Stage20RenderBouncingArrowsEv": [
    "func_020abd88"
   ],
-  "src/_ZN5Stage6RenderEv.cpp": [
+  "_ZN5Stage6RenderEv": [
    "func_020ab9c8",
    "func_020abad8"
   ],
-  "src/_ZN5Stage9PS_RenderEv.cpp": [
+  "_ZN5Stage9PS_RenderEv": [
    "func_020ab9c8",
    "func_020abac0",
    "func_020abad8",
@@ -376,28 +392,28 @@
    "func_020acb68",
    "func_020ad04c"
   ],
-  "src/_ZN6BobOmb13InitResourcesEv.cpp": [
+  "_ZN6BobOmb13InitResourcesEv": [
    "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
-  "src/_ZN6BobOmb8BehaviorEv.c": [
+  "_ZN6BobOmb8BehaviorEv": [
    "func_020ada40"
   ],
-  "src/_ZN6Bullet13InitResourcesEv.cpp": [
+  "_ZN6Bullet13InitResourcesEv": [
    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
    "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
    "func_0211d610"
   ],
-  "src/_ZN6Camera6RenderEv.cpp": [
+  "_ZN6Camera6RenderEv": [
    "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
    "_ZN3OAM6RenderEbP7OamAttriiiiiiii"
   ],
-  "src/_ZN6Coffin13InitResourcesEv.cpp": [
+  "_ZN6Coffin13InitResourcesEv": [
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
-  "src/_ZN6Eyerok13InitResourcesEv.cpp": [
+  "_ZN6Eyerok13InitResourcesEv": [
    "_Z13func_020393c4PvS_",
    "_Z13func_020393d4PvS_",
    "_Z22_ZN5Actor9TrackStarEjjPvjj",
@@ -415,532 +431,527 @@
    "func_02112ca8",
    "func_02112d48"
   ],
-  "src/_ZN6Memory10DeallocateEPvP4Heap.cpp": [
+  "_ZN6Memory10DeallocateEPvP4Heap": [
    "_ZN6Memory14defaultHeapPtrE"
   ],
-  "src/_ZN6Player11St_Fly_MainEv.cpp": [
+  "_ZN6Player11St_Fly_MainEv": [
    "_ZN6Player11ChangeStateER5State",
    "_ZN6Player7SetAnimEjiij"
   ],
-  "src/_ZN6Player12St_Land_InitEv.cpp": [
+  "_ZN6Player12St_Land_InitEv": [
    "_ZN6Player7SetAnimEjiij"
   ],
-  "src/_ZN6Player15St_Respawn_InitEv.cpp": [
+  "_ZN6Player15St_Respawn_InitEv": [
    "_ZN6Player7SetAnimEjiij"
   ],
-  "src/_ZN6Player17St_WindCarry_MainEv.cpp": [
+  "_ZN6Player17St_WindCarry_MainEv": [
    "_ZN6Player11ChangeStateER5State",
    "_ZN6Player7SetAnimEjiij"
   ],
-  "src/_ZN6Player18St_CameraZoom_MainEv.cpp": [
+  "_ZN6Player18St_CameraZoom_MainEv": [
    "_ZN6Player11ChangeStateER5State"
   ],
-  "src/_ZN7ClipperD0Ev.c": [
+  "_ZN7ClipperD0Ev": [
    "base_dtor_Clipper"
   ],
-  "src/_ZN7Skeeter8BehaviorEv.cpp": [
+  "_ZN7Skeeter8BehaviorEv": [
    "func_020aea30"
   ],
-  "src/_ZN7Tornado13InitResourcesEv.cpp": [
+  "_ZN7Tornado13InitResourcesEv": [
    "func_02112968"
   ],
-  "src/_ZN8CapEnemy6AddCapEj.c": [
+  "_ZN8CapEnemy6AddCapEj": [
    "func_020ff028"
   ],
-  "src/_ZN8Goomboss13InitResourcesEv.c": [
+  "_ZN8Goomboss13InitResourcesEv": [
    "func_021123f4",
    "func_021124ac"
   ],
-  "src/_ZN8IceSheet16CleanupResourcesEv.cpp": [
+  "_ZN8IceSheet16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN8PoleLift16CleanupResourcesEv.cpp": [
+  "_ZN8MadPiano16CleanupResourcesEv": [
+   "G0",
+   "G1",
+   "G2"
+  ],
+  "_ZN8MadPiano8BehaviorEv": [
+   "_ZN8Platform13IsClsnInRangeEii"
+  ],
+  "_ZN8PoleLift16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN8SignPost13InitResourcesEv.cpp": [
+  "_ZN8SignPost13InitResourcesEv": [
    "MeshColliderLoadFile",
    "ModelLoadFile",
    "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
-  "src/_ZN8SignPost16CleanupResourcesEv.cpp": [
+  "_ZN8SignPost16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN8Squasher16CleanupResourcesEv.cpp": [
+  "_ZN8Squasher16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN9KoopaFlag13InitResourcesEv.cpp": [
+  "_ZN9KoopaFlag13InitResourcesEv": [
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/_ZN9Spindrift13InitResourcesEv.cpp": [
+  "_ZN9Spindrift13InitResourcesEv": [
    "AnimLoadFile",
    "ModelLoadFile",
    "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/_ZN9TowerStep16CleanupResourcesEv.cpp": [
+  "_ZN9TowerStep16CleanupResourcesEv": [
    "G0",
    "G1"
   ],
-  "src/_ZN9UkikiCageD0Ev.c": [
+  "_ZN9UkikiCageD0Ev": [
    "_ZTV10dBgActor_c",
    "_ZTV15daObjHmMaruta_c"
   ],
-  "src/_ZN9UkikiCageD1Ev.c": [
+  "_ZN9UkikiCageD1Ev": [
    "_ZTV10dBgActor_c",
    "_ZTV15daObjHmMaruta_c"
   ],
-  "src/_ZN9WaterBomb13InitResourcesEv.cpp": [
+  "_ZN9WaterBomb13InitResourcesEv": [
    "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
-  "src/_ZdlPv.cpp": [
+  "_ZdlPv": [
    "_ZN6Memory14defaultHeapPtrE"
   ],
-  "src/__sinit_ov071_02122a64.c": [
+  "__sinit_ov071_02122a64": [
    "data_ov071_02122ecc_d"
   ],
-  "src/actors/FallBlockBbh/FallBlockBbh_Spawn.c": [
-   "_ZTV20daObjTh_Fall_Block_c"
-  ],
-  "src/actors/FallBlockBbh/_ZN12FallBlockBbhD0Ev.c": [
-   "_ZTV10dBgActor_c",
-   "_ZTV20daObjTh_Fall_Block_c"
-  ],
-  "src/actors/FallBlockBbh/_ZN12FallBlockBbhD1Ev.c": [
-   "_ZTV10dBgActor_c",
-   "_ZTV20daObjTh_Fall_Block_c"
-  ],
-  "src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp": [
-   "G0",
-   "G1",
-   "G2"
-  ],
-  "src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp": [
-   "_ZN8Platform13IsClsnInRangeEii"
-  ],
-  "src/engine/fader/_ZN5FaderD0Ev.c": [
-   "base_dtor_Fader"
-  ],
-  "src/func_02008b4c.c": [
+  "func_02008b4c": [
    "func_020effb8"
   ],
-  "src/func_02009374.c": [
+  "func_02009374": [
    "STAR_MARKERS",
    "Vec3_DistSq"
   ],
-  "src/func_02019ebc.c": [
+  "func_02014f5c": [
+   "func_020caf98"
+  ],
+  "func_02019ebc": [
    "func_02061128"
   ],
-  "src/func_0201a2f8.c": [
+  "func_0201a2f8": [
    "func_020aa420",
    "overlay_0",
    "overlay_1"
   ],
-  "src/func_0201a458.c": [
+  "func_0201a458": [
    "func_0211d9c0",
    "func_02140d80"
   ],
-  "src/func_0201a614.c": [
+  "func_0201a614": [
    "overlay_75"
   ],
-  "src/func_0201a694.c": [
+  "func_0201a694": [
    "overlay_75"
   ],
-  "src/func_0201a754.c": [
+  "func_0201a754": [
    "overlay_4",
    "overlay_6"
   ],
-  "src/func_0201a798.c": [
+  "func_0201a798": [
    "overlay_4",
    "overlay_6"
   ],
-  "src/func_0201a8b4.c": [
+  "func_0201a8b4": [
    "_ll_udiv"
   ],
-  "src/func_02029408.c": [
+  "func_02029408": [
    "func_020bd828"
   ],
-  "src/func_0202efa0.c": [
+  "func_0202efa0": [
    "_ll_sdiv"
   ],
-  "src/func_02034fbc.c": [
+  "func_02034fbc": [
    "overlay_64",
    "overlay_66"
   ],
-  "src/func_0203c178.c": [
+  "func_0203c178": [
    "func_020527e9"
   ],
-  "src/func_02042784.c": [
+  "func_02042784": [
    "_ll_udiv"
   ],
-  "src/func_020427c4.c": [
+  "func_020427c4": [
    "_ll_udiv"
   ],
-  "src/func_0204da4c.c": [
+  "func_0204da4c": [
    "LCG_STATE_0204da4c"
   ],
-  "src/func_02053130.c": [
+  "func_02053130": [
    "SQRTCNT",
    "SQRT_RESULT"
   ],
-  "src/func_02055454.c": [
+  "func_02055454": [
    "G"
   ],
-  "src/func_020570c0.c": [
+  "func_020570c0": [
    "G"
   ],
-  "src/func_020570d8.c": [
+  "func_020570d8": [
    "G"
   ],
-  "src/func_02057128.c": [
+  "func_02057128": [
    "G"
   ],
-  "src/func_02057140.c": [
+  "func_02057140": [
    "G"
   ],
-  "src/func_02057410.c": [
+  "func_02057410": [
    "_ll_mod",
    "_ll_sdiv"
   ],
-  "src/func_02058308.c": [
+  "func_02058308": [
    "func_00000000",
    "func_00000600"
   ],
-  "src/func_02058df4.c": [
+  "func_02058df4": [
    "func_00000000",
    "func_00000600"
   ],
-  "src/func_02059640.c": [
+  "func_02059640": [
    "G"
   ],
-  "src/func_02059a60.c": [
+  "func_02059a60": [
    "_ll_udiv"
   ],
-  "src/func_02059f48.c": [
+  "func_02059f48": [
    "G"
   ],
-  "src/func_0205f650.c": [
+  "func_0205f650": [
    "G"
   ],
-  "src/func_0206ece0.c": [
+  "func_0206ece0": [
    "func_01ff9e2c"
   ],
-  "src/func_0206f46c.c": [
+  "func_0206f46c": [
    "_deq"
   ],
-  "src/func_0206f820.c": [
+  "func_0206f820": [
    "_ll_udiv",
    "_ull_mod"
   ],
-  "src/func_020708b4.c": [
+  "func_020708b4": [
    "_dadd",
    "_deq",
    "_dmul"
   ],
-  "src/func_02070c68.c": [
+  "func_02070c68": [
    "func_01ff9d40"
   ],
-  "src/func_02071510.c": [
+  "func_02071510": [
    "_ll_udiv",
    "_ull_mod"
   ],
-  "src/func_ov002_020aefb8.c": [
+  "func_ov002_020aefb8": [
    "_ZN5Actor12ReflectAngleEiis"
   ],
-  "src/func_ov002_020b5ab4.cpp": [
+  "func_ov002_020b5ab4": [
    "_ZN13RaycastGround19StartDetectingWaterEv"
   ],
-  "src/func_ov002_020b7e1c.cpp": [
+  "func_ov002_020b7e1c": [
    "_ZN5Actor9SetRangesEiiii"
   ],
-  "src/func_ov002_020bd250.cpp": [
+  "func_ov002_020bd250": [
    "_ZN6Player4HurtERK7Vector3jijjj",
    "_ZN8Particle6System9NewSimpleEjiii"
   ],
-  "src/func_ov002_020c0fb4.c": [
+  "func_ov002_020c0fb4": [
    "_ll_udiv"
   ],
-  "src/func_ov002_020c1234.cpp": [
+  "func_ov002_020c1234": [
    "_ZN5Sound7PlaySubEjjjib"
   ],
-  "src/func_ov002_020c1eb4.cpp": [
+  "func_ov002_020c1eb4": [
    "_ZN8Particle6System3NewEjjiiiPK10Vector3_16PNS_8CallbackE"
   ],
-  "src/func_ov002_020c29d4.cpp": [
+  "func_ov002_020c29d4": [
    "_ZN6Player7IsStateER5State"
   ],
-  "src/func_ov002_020c8a4c.cpp": [
+  "func_ov002_020c8a4c": [
    "_Z13func_020072c0v",
    "_ZN6Player7SetAnimEjiij"
   ],
-  "src/func_ov002_020c8f80.cpp": [
+  "func_ov002_020c8f80": [
    "_ZN6Player7SetAnimEjiij"
   ],
-  "src/func_ov002_020d0580.cpp": [
+  "func_ov002_020d0580": [
    "_ZN6Player11ChangeStateER5State",
    "_ZN6Player7IsStateER5State"
   ],
-  "src/func_ov002_020d06c0.cpp": [
+  "func_ov002_020d06c0": [
    "_ZN6Player11ChangeStateER5State",
    "_ZN6Player7IsStateER5State"
   ],
-  "src/func_ov002_020d4c30.cpp": [
+  "func_ov002_020d4c30": [
    "_ZN8Particle6System9NewSimpleEjiii"
   ],
-  "src/func_ov002_020dc560.c": [
+  "func_ov002_020dc560": [
    "func_01ff98f4",
    "func_01ff99a4"
   ],
-  "src/func_ov002_020df34c.cpp": [
+  "func_ov002_020df34c": [
    "_ZN6Player11ChangeStateER5State",
    "_ZN6Player7IsStateER5State"
   ],
-  "src/func_ov002_020e81e0.cpp": [
+  "func_ov002_020e81e0": [
    "_ZN8Particle6System3NewEjjiiiPK7Vector3PNS_8CallbackE"
   ],
-  "src/func_ov002_020ec670.c": [
+  "func_ov002_020ec670": [
    "func_02123804"
   ],
-  "src/func_ov003_020ad660.c": [
+  "func_ov003_020ad660": [
    "_ZTV10dScTitle_c",
    "_ZTV7dBase_c",
    "_ZTV8dScene_c"
   ],
-  "src/func_ov003_020ad7a4.cpp": [
+  "func_ov003_020ad7a4": [
    "_ZN3OAM12EnableSubOAMEP6OamTmp"
   ],
-  "src/func_ov003_020adfc8.cpp": [
+  "func_ov003_020adfc8": [
    "func_020ab9c8",
    "func_020aba70",
    "func_020abad8"
   ],
-  "src/func_ov003_020ae0b0.c": [
+  "func_ov003_020ae0b0": [
    "func_020ab9c8",
    "func_020aba70",
    "func_020abad0"
   ],
-  "src/func_ov003_020ae238.c": [
+  "func_ov003_020ae238": [
    "func_020ab948",
    "func_020ab9c8",
    "func_020aba70"
   ],
-  "src/func_ov003_020b0580.c": [
+  "func_ov003_020b0580": [
    "_ZTV13dScGameOver_c",
    "_ZTV7dBase_c",
    "_ZTV8dScene_c"
   ],
-  "src/func_ov003_020b05bc.c": [
+  "func_ov003_020b05bc": [
    "G0",
    "VT0",
    "VT1",
    "VT2"
   ],
-  "src/func_ov005_020bfec0.c": [
+  "func_ov005_020bfec0": [
    "_ZTV11dScMiniGm_c",
    "_ZTV7dBase_c",
    "_ZTV8dScene_c"
   ],
-  "src/func_ov006_020c0264.cpp": [
+  "func_ov006_020c0264": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov006_020c0a48.c": [
+  "func_ov006_020c0a48": [
    "g0",
    "g1",
    "g2"
   ],
-  "src/func_ov006_020c0d68.cpp": [
+  "func_ov006_020c0d68": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov006_020c1420.cpp": [
+  "func_ov006_020c1420": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov006_020c14bc.cpp": [
+  "func_ov006_020c14bc": [
    "func_020beb68"
   ],
-  "src/func_ov006_020c1764.cpp": [
+  "func_ov006_020c1764": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov006_020c221c.c": [
+  "func_ov006_020c221c": [
    "g0",
    "g1"
   ],
-  "src/func_ov006_020c6e4c.cpp": [
+  "func_ov006_020c3bc8": [
+   "func_020c3adc"
+  ],
+  "func_ov006_020c6e4c": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020c79a8.cpp": [
+  "func_ov006_020c79a8": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020c8084.cpp": [
+  "func_ov006_020c8084": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020c8f20.cpp": [
+  "func_ov006_020c8f20": [
    "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback"
   ],
-  "src/func_ov006_020c9098.c": [
+  "func_ov006_020c9098": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020c9c8c.c": [
+  "func_ov006_020c9c8c": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020ca3a8.cpp": [
+  "func_ov006_020ca3a8": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020cb030.cpp": [
+  "func_ov006_020cb030": [
    "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback"
   ],
-  "src/func_ov006_020cb1a8.c": [
+  "func_ov006_020cb1a8": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020cb528.c": [
+  "func_ov006_020cb528": [
    "_ZN9ModelAnim7SetAnimEPviij"
   ],
-  "src/func_ov006_020cb690.cpp": [
+  "func_ov006_020cb690": [
    "_ZN9ModelAnim7SetAnimEPviij"
   ],
-  "src/func_ov006_020cecc0.cpp": [
+  "func_ov006_020cecc0": [
    "_ZN18TextureTransformer7SetFileER8BTA_Fileiij"
   ],
-  "src/func_ov006_020db720.c": [
+  "func_ov006_020db720": [
    "func_020beb68"
   ],
-  "src/func_ov006_020db9dc.c": [
+  "func_ov006_020db9dc": [
    "func_020bc7d4"
   ],
-  "src/func_ov006_020dcd74.c": [
+  "func_ov006_020dcd74": [
    "func_020beb68"
   ],
-  "src/func_ov006_020de1d4.c": [
+  "func_ov006_020de1d4": [
    "func_020beb68"
   ],
-  "src/func_ov006_020de26c.cpp": [
+  "func_ov006_020de26c": [
    "func_020beb68"
   ],
-  "src/func_ov006_020de440.cpp": [
+  "func_ov006_020de440": [
    "func_020beb68"
   ],
-  "src/func_ov006_020e3578.c": [
+  "func_ov006_020de584": [
+   "func_020ddd6c"
+  ],
+  "func_ov006_020e3578": [
    "func_020adc74"
   ],
-  "src/func_ov006_020e6894.c": [
+  "func_ov006_020e6894": [
    "func_020adc74"
   ],
-  "src/func_ov006_020e7124.c": [
+  "func_ov006_020e7124": [
    "func_020beb74"
   ],
-  "src/func_ov006_020e7cc0.cpp": [
+  "func_ov006_020e7cc0": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov006_020e989c.cpp": [
+  "func_ov006_020e989c": [
    "func_020beb68"
   ],
-  "src/func_ov006_020e9c20.c": [
+  "func_ov006_020e9c20": [
    "func_020beb68"
   ],
-  "src/func_ov006_020e9cec.c": [
+  "func_ov006_020e9cec": [
    "G0",
    "G1"
   ],
-  "src/func_ov006_020ea3d0.c": [
+  "func_ov006_020ea3d0": [
    "func_020beb68"
   ],
-  "src/func_ov006_020ee2c4.c": [
+  "func_ov006_020ee2c4": [
    "func_020beb68"
   ],
-  "src/func_ov006_020efcf8.c": [
+  "func_ov006_020efcf8": [
    "data_04000006"
   ],
-  "src/func_ov006_020f0274.c": [
+  "func_ov006_020f0274": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f3294.c": [
+  "func_ov006_020f3294": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f3460.c": [
+  "func_ov006_020f3460": [
    "func_020adc74",
    "func_020bc864",
    "func_020bc888"
   ],
-  "src/func_ov006_020f3834.cpp": [
+  "func_ov006_020f3834": [
    "_ZN10SysTrackerD1Ev"
   ],
-  "src/func_ov006_020f4888.c": [
+  "func_ov006_020f4888": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f52c4.c": [
+  "func_ov006_020f52c4": [
    "func_020bc7d4",
    "func_020beb68"
   ],
-  "src/func_ov006_020f53e4.cpp": [
+  "func_ov006_020f53e4": [
    "func_020bc7d4"
   ],
-  "src/func_ov006_020f5564.cpp": [
+  "func_ov006_020f5564": [
    "_ZN10SysTrackerD1Ev"
   ],
-  "src/func_ov006_020f6538.c": [
+  "func_ov006_020f6538": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f7394.c": [
+  "func_ov006_020f7394": [
    "func_020bc7d4",
    "func_020beb68"
   ],
-  "src/func_ov006_020f74b4.cpp": [
+  "func_ov006_020f74b4": [
    "func_020bc7d4"
   ],
-  "src/func_ov006_020f7634.cpp": [
+  "func_ov006_020f7634": [
    "_ZN10SysTrackerD1Ev"
   ],
-  "src/func_ov006_020f7c10.c": [
+  "func_ov006_020f7c10": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f869c.c": [
+  "func_ov006_020f869c": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f8a3c.c": [
+  "func_ov006_020f8a3c": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f8c68.c": [
+  "func_ov006_020f8c68": [
    "func_020bc7d4"
   ],
-  "src/func_ov006_020f8d08.cpp": [
+  "func_ov006_020f8d08": [
    "func_020beb68"
   ],
-  "src/func_ov006_020f8ef4.cpp": [
+  "func_ov006_020f8ef4": [
    "_ZN10SysTrackerD1Ev"
   ],
-  "src/func_ov006_021071fc.c": [
+  "func_ov006_021071fc": [
    "func_020beb68"
   ],
-  "src/func_ov006_02108f2c.c": [
+  "func_ov006_02108f2c": [
    "func_020b9488"
   ],
-  "src/func_ov006_021095cc.c": [
+  "func_ov006_021095cc": [
    "func_020bc7d4",
    "func_020beb68"
   ],
-  "src/func_ov006_02109aac.c": [
+  "func_ov006_02109aac": [
    "func_020beb68"
   ],
-  "src/func_ov006_0210a708.c": [
+  "func_ov006_0210a708": [
    "func_020beb6c"
   ],
-  "src/func_ov006_0210a8c0.c": [
+  "func_ov006_0210a8c0": [
    "func_020ad494"
   ],
-  "src/func_ov006_0210a900.cpp": [
+  "func_ov006_0210a900": [
    "func_020ad494"
   ],
-  "src/func_ov006_0210a954.cpp": [
+  "func_ov006_0210a954": [
    "_ZN10SysTrackerD1Ev"
   ],
-  "src/func_ov006_0210bdb0.cpp": [
+  "func_ov006_0210bdb0": [
    "func_020bc860",
    "func_020bc864",
    "func_020bc878",
@@ -950,10 +961,10 @@
    "func_020bc8b4",
    "func_020bc8b8"
   ],
-  "src/func_ov006_0210c2d4.c": [
+  "func_ov006_0210c2d4": [
    "func_020beb68"
   ],
-  "src/func_ov006_0210d1fc.cpp": [
+  "func_ov006_0210d1fc": [
    "func_020bc860",
    "func_020bc878",
    "func_020bc88c",
@@ -961,213 +972,244 @@
    "func_020bc8b4",
    "func_020bc8b8"
   ],
-  "src/func_ov006_0210d6b8.cpp": [
+  "func_ov006_0210d6b8": [
    "func_020ad494"
   ],
-  "src/func_ov006_02115b0c.c": [
+  "func_ov006_02115b0c": [
    "func_020adc74"
   ],
-  "src/func_ov006_02118488.c": [
+  "func_ov006_02118488": [
    "func_020bc864",
    "func_020bc888"
   ],
-  "src/func_ov006_02119904.cpp": [
+  "func_ov006_02119904": [
    "_ZN10SysTrackerD1Ev"
   ],
-  "src/func_ov006_0211fd44.c": [
+  "func_ov006_0211fd44": [
    "func_020beb68"
   ],
-  "src/func_ov006_021200dc.c": [
+  "func_ov006_021200dc": [
    "func_020beb6c"
   ],
-  "src/func_ov006_021203fc.c": [
+  "func_ov006_021203fc": [
    "func_020bc880",
    "func_020bc884"
   ],
-  "src/func_ov006_02123340.cpp": [
+  "func_ov006_02123340": [
    "_ZN4PSys12FromUniqueIDEj",
    "_ZN4PSys17NewUnkCallback818EjjiiiPv"
   ],
-  "src/func_ov006_02125364.c": [
+  "func_ov006_02125364": [
    "func_020bc7d4"
   ],
-  "src/func_ov006_02129268.c": [
+  "func_ov006_02129268": [
    "func_020adc74"
   ],
-  "src/func_ov006_0212b480.c": [
+  "func_ov006_0212b480": [
    "func_020adc74",
    "func_020bc86c",
    "func_020bc898",
    "func_020bc8a4",
    "func_020bc8a8"
   ],
-  "src/func_ov007_020cc028.c": [
+  "func_ov007_020bcf90": [
+   "func_02055574",
+   "func_020b2160",
+   "func_020b2370",
+   "func_020b2728",
+   "func_020b2cf0",
+   "func_020b413c",
+   "func_020b4464",
+   "func_020b7658",
+   "func_020b7a00",
+   "func_020b7a34",
+   "func_020b8fd4",
+   "func_020b91b4",
+   "func_020bee14",
+   "func_020bfaf0",
+   "func_020c232c",
+   "func_020c2390",
+   "func_020c93b4"
+  ],
+  "func_ov007_020c798c": [
+   "func_020c3df4",
+   "func_020c78b0",
+   "func_020c80a4",
+   "func_020c844c"
+  ],
+  "func_ov007_020c8970": [
+   "func_020c897c"
+  ],
+  "func_ov007_020cc028": [
    "_ZTV7dBase_c",
    "_ZTV8dScene_c",
    "_ZTV9dScDSMT_c"
   ],
-  "src/func_ov007_020cc070.c": [
+  "func_ov007_020cc070": [
    "G0",
    "VT0",
    "VT1",
    "VT2"
   ],
-  "src/func_ov007_020cc2cc.c": [
+  "func_ov007_020cc2cc": [
    "overlay_64",
    "overlay_66"
   ],
-  "src/func_ov007_020cc4c0.cpp": [
+  "func_ov007_020cc4c0": [
    "overlay_100",
    "overlay_102"
   ],
-  "src/func_ov014_02111a6c.cpp": [
+  "func_ov014_02111a6c": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov014_02111e74.cpp": [
+  "func_ov014_02111e74": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov014_02112ea8.cpp": [
+  "func_ov014_02112ea8": [
    "_ZN6ActorS10PoofDustAtERK7Vector3",
    "_ZN8Particle6System9NewSimpleEjiii"
   ],
-  "src/func_ov015_02111d98.cpp": [
+  "func_ov015_02111d98": [
    "_ZN5Actor22UpdatePosWithOnlySpeedEPv"
   ],
-  "src/func_ov015_02112c84.c": [
+  "func_ov015_02112c84": [
    "func_020b66a8"
   ],
-  "src/func_ov016_02112ae4.c": [
+  "func_ov016_02112ae4": [
    "G0",
    "G1"
   ],
-  "src/func_ov016_02112fa8.c": [
+  "func_ov016_02112fa8": [
    "func_020b5e58"
   ],
-  "src/func_ov018_02111d28.cpp": [
+  "func_ov018_02111d28": [
    "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
   ],
-  "src/func_ov018_02111f1c.cpp": [
+  "func_ov018_02111f1c": [
    "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov018_02112730.cpp": [
+  "func_ov018_02112730": [
    "_ZN5Actor18MarkForDestructionEv"
   ],
-  "src/func_ov020_021112b0.c": [
+  "func_ov020_021112b0": [
    "Actor_ClosestPlayer",
    "cstd_atan2"
   ],
-  "src/func_ov022_0211165c.c": [
+  "func_ov022_0211165c": [
    "func_020b66a8"
   ],
-  "src/func_ov022_02111bdc.cpp": [
+  "func_ov022_02111bdc": [
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
-  "src/func_ov022_02111ea0.cpp": [
+  "func_ov022_02111ea0": [
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
-  "src/func_ov022_02112380.c": [
+  "func_ov022_02112380": [
    "_ZTV10dBgActor_c",
    "_ZTV20daObjFl_Fall_Block_c"
   ],
-  "src/func_ov022_02112434.c": [
+  "func_ov022_02112434": [
    "func_0213a2cc"
   ],
-  "src/func_ov022_02112448.c": [
+  "func_ov022_02112448": [
    "func_0213a794"
   ],
-  "src/func_ov025_021118c8.c": [
+  "func_ov025_021118c8": [
    "_ZTV10dBgActor_c",
    "_ZTV7daDkk_c"
   ],
-  "src/func_ov025_02111928.c": [
+  "func_ov025_02111928": [
    "G0",
    "VT0",
    "VT1",
    "VT2"
   ],
-  "src/func_ov026_02111598.cpp": [
+  "func_ov026_02111598": [
    "func_ov053_021112a4"
   ],
-  "src/func_ov026_02111764.c": [
+  "func_ov026_02111764": [
    "G0",
    "G1"
   ],
-  "src/func_ov026_02111954.c": [
+  "func_ov026_02111954": [
    "G0",
    "G1"
   ],
-  "src/func_ov030_02113a80.cpp": [
+  "func_ov030_02113a80": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov036_0211137c.cpp": [
+  "func_ov036_0211137c": [
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
-  "src/func_ov036_0211244c.cpp": [
+  "func_ov036_0211244c": [
    "func_020efaf0"
   ],
-  "src/func_ov045_02111bc8.c": [
+  "func_ov045_02111bc8": [
    "func_020b6424"
   ],
-  "src/func_ov045_02111bdc.c": [
+  "func_ov045_02111bdc": [
    "func_020b6584"
   ],
-  "src/func_ov060_021182b0.cpp": [
+  "func_ov060_021182b0": [
    "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
-  "src/func_ov062_02116010.c": [
+  "func_ov062_02116010": [
    "func_020ada40"
   ],
-  "src/func_ov062_021164e8.cpp": [
+  "func_ov062_021164e8": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov062_02116d28.cpp": [
+  "func_ov062_02116d28": [
    "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
   ],
-  "src/func_ov062_02117c98.c": [
+  "func_ov062_02117c98": [
    "func_020ada40",
    "func_020aea30"
   ],
-  "src/func_ov062_02118004.cpp": [
+  "func_ov062_02118004": [
    "_ZN8Particle20RunningSlidingDustAtEiii"
   ],
-  "src/func_ov062_02119af0.cpp": [
+  "func_ov062_02119af0": [
    "_ZN4cstd5atan2Eii"
   ],
-  "src/func_ov062_0211b880.cpp": [
+  "func_ov062_0211b880": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov062_0211b930.cpp": [
+  "func_ov062_0211b930": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit",
    "_ZN8Particle6System9NewSimpleEjiii"
   ],
-  "src/func_ov062_0211bc54.cpp": [
+  "func_ov062_0211bc54": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov064_021163c0.cpp": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "src/func_ov064_02116460.cpp": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "src/func_ov064_02116754.cpp": [
+  "func_ov063_0211a0dc": [
    "func_020ada40"
   ],
-  "src/func_ov064_02116ec0.cpp": [
+  "func_ov064_021163c0": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "func_ov064_02116460": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "func_ov064_02116754": [
+   "func_020ada40"
+  ],
+  "func_ov064_02116ec0": [
    "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov065_02115ff0.c": [
+  "func_ov065_02115ff0": [
    "func_020ada40",
    "func_020aea30"
   ],
-  "src/func_ov065_0211704c.c": [
+  "func_ov065_0211704c": [
    "func_020ada40",
    "func_020aea30"
   ],
-  "src/func_ov065_0211a358.cpp": [
+  "func_ov065_0211a358": [
    "_Z30_ZN11ShadowModel10InitCuboidEvPv",
    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
    "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
@@ -1177,494 +1219,203 @@
    "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
    "func_02112198"
   ],
-  "src/func_ov065_0211ad04.c": [
+  "func_ov065_0211ad04": [
    "G0",
    "G1"
   ],
-  "src/func_ov065_0211b1d4.cpp": [
+  "func_ov065_0211b1d4": [
    "MeshColliderLoadFile",
    "ModelLoadFile",
    "UpdatePosWithTransformSym",
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
    "func_02112258"
   ],
-  "src/func_ov066_021166c8.cpp": [
+  "func_ov066_021166c8": [
    "_Z13func_02112c88v",
    "_Z13func_02112cc8v",
    "_Z19func_ov066_0211a35cv",
    "_Z23func_02112cd8_updateposv"
   ],
-  "src/func_ov066_02116d14.cpp": [
+  "func_ov066_02116d14": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov066_02116db0.c": [
+  "func_ov066_02116db0": [
    "func_02112c08",
    "func_02112d48"
   ],
-  "src/func_ov066_021175e8.c": [
+  "func_ov066_021175e8": [
    "func_02112c08",
    "func_02112d48"
   ],
-  "src/func_ov066_02117bf0.c": [
+  "func_ov066_02117bf0": [
    "func_02112c08",
    "func_02112d48"
   ],
-  "src/func_ov066_02118188.c": [
+  "func_ov066_02118188": [
    "func_02112c08",
    "func_02112d48"
   ],
-  "src/func_ov070_0211f0a4.cpp": [
+  "func_ov070_0211f0a4": [
    "_ZN5Actor10SpawnCoinsERK7Vector3jis"
   ],
-  "src/func_ov070_0211f100.cpp": [
+  "func_ov070_0211f100": [
    "func_020aea30"
   ],
-  "src/func_ov070_0211f5f0.cpp": [
+  "func_ov070_0211f5f0": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov071_0211f7d4.c": [
+  "func_ov071_0211f7d4": [
    "_ZN13CylinderClsn25ClearEv",
    "_ZN13CylinderClsn26UpdateEv"
   ],
-  "src/func_ov075_02114cd8.cpp": [
+  "func_ov075_02114cd8": [
    "_ZN11ShadowModel9InitModelEP9Matrix4x3iiij"
   ],
-  "src/func_ov075_021152d4.cpp": [
+  "func_ov075_021152d4": [
    "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
    "_ZN7Clipper13Func_020156DCEPviiii"
   ],
-  "src/func_ov075_02116f40.cpp": [
+  "func_ov075_02116f40": [
    "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
    "func_020abd88"
   ],
-  "src/func_ov075_02117590.cpp": [
+  "func_ov075_02117590": [
    "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii"
   ],
-  "src/func_ov075_02117bc4.c": [
+  "func_ov075_02117bc4": [
    "overlay_64",
    "overlay_66"
   ],
-  "src/func_ov075_021194e4.cpp": [
+  "func_ov075_021194e4": [
    "_ZN3OAM6RenderEbP7OamAttriiiiii"
   ],
-  "src/func_ov075_021199d8.cpp": [
+  "func_ov075_021199d8": [
    "_ZN3OAM6RenderEbP7OamAttriiiiii"
   ],
-  "src/func_ov077_021244d4.cpp": [
+  "func_ov077_021244d4": [
    "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov078_02123bc4.cpp": [
+  "func_ov078_02123bc4": [
    "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
-  "src/func_ov079_02126f8c.cpp": [
+  "func_ov079_02126f8c": [
    "_ZN7Actor_s10FindWithIDEj",
    "_ZN7Actor_s13ClosestPlayerEv",
    "_ZN7Actor_s5SpawnEjjRK7Vector3PK10Vector3_16ii",
    "_ZN8Platform13IsClsnInRangeEii",
    "_ZN8Platform20UpdateKillByMegaCharEsssi"
   ],
-  "src/func_ov080_02123ecc.cpp": [
+  "func_ov080_02123ecc": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov081_021243cc.cpp": [
+  "func_ov081_021243cc": [
    "func_020ada40",
    "func_020aea30"
   ],
-  "src/func_ov081_02124d14.cpp": [
+  "func_ov081_02124d14": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov081_02125068.cpp": [
+  "func_ov081_02125068": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov081_02127be0.cpp": [
+  "func_ov081_02127be0": [
    "_ZN5Actor5SpawnEjjRK7Vector3PK16Vector3_16_localii"
   ],
-  "src/func_ov084_02129238.cpp": [
+  "func_ov084_02129238": [
    "_ZN13RaycastGround19StartDetectingToxicEv",
    "_ZN13RaycastGround19StartDetectingWaterEv",
    "_ZN13RaycastGround21StopDetectingOrdinaryEv"
   ],
-  "src/func_ov084_02129a00.c": [
+  "func_ov084_02129a00": [
    "func_020aea30"
   ],
-  "src/func_ov084_02129ed4.c": [
+  "func_ov084_02129ed4": [
    "func_020ada40",
    "func_020aea30"
   ],
-  "src/func_ov084_0212a580.cpp": [
+  "func_ov084_0212a580": [
    "_ZN8CapEnemy12UpdateCapPosERK7Vector3RK16Vector3_16_local"
   ],
-  "src/func_ov084_0212a774.c": [
+  "func_ov084_0212a774": [
    "func_020aea30"
   ],
-  "src/func_ov084_0212c92c.cpp": [
+  "func_ov084_0212c92c": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov085_0212943c.cpp": [
+  "func_ov085_0212943c": [
    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
-  "src/func_ov085_0212bedc.cpp": [
+  "func_ov085_0212bedc": [
    "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
   ],
-  "src/func_ov085_0212de5c.cpp": [
+  "func_ov085_0212de5c": [
    "_ZN5Sound7PlaySubEjjjib"
   ],
-  "src/func_ov089_0213162c.c": [
+  "func_ov089_0213162c": [
    "data_02111b68"
   ],
-  "src/func_ov090_021310b4.c": [
+  "func_ov090_021310b4": [
    "func_020ada40",
    "func_020aea30"
   ],
-  "src/func_ov091_02131070.cpp": [
+  "func_ov091_02131070": [
    "_ZN8Particle6System9NewSimpleEjiii"
   ],
-  "src/func_ov091_021339fc.c": [
+  "func_ov091_021339fc": [
    "func_020aea30"
   ],
-  "src/func_ov098_021390ec.cpp": [
+  "func_ov098_021390ec": [
    "_Z19func_ov002_020ef228Pvi",
    "_ZN5Actor12ReflectAngleEiis"
   ],
-  "src/func_ov100_0214109c.cpp": [
+  "func_ov100_0214109c": [
    "ActorBase_MarkForDestruction"
   ],
-  "src/func_ov100_02141fb0.cpp": [
+  "func_ov100_02141fb0": [
    "func_020ada40"
   ],
-  "src/func_ov100_0214272c.cpp": [
+  "func_ov100_0214272c": [
    "func_020ad660"
   ],
-  "src/func_ov100_02142918.cpp": [
+  "func_ov100_02142918": [
    "func_020ad660"
   ],
-  "src/func_ov100_02145080.c": [
+  "func_ov100_02145080": [
    "func_020ca78c"
   ],
-  "src/func_ov100_02147054.c": [
+  "func_ov100_02147054": [
    "G0",
    "G1",
    "G2"
   ],
-  "src/func_ov100_021470f4.cpp": [
+  "func_ov100_021470f4": [
    "_Z16DecIfAbove0_BytePh",
    "_Z9Vec3_DistPK7Vector3S1_",
    "_ZN16MeshColliderBase6EnableEPv",
    "_ZN9Platform219UpdateClsnPosAndRotEv",
    "_ZN9Platform313IsClsnInRangeEii"
   ],
-  "src/func_ov100_021471e0.cpp": [
+  "func_ov100_021471e0": [
    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
    "func_020efaf0"
   ],
-  "src/func_ov102_02149610.cpp": [
+  "func_ov102_02149610": [
    "_ZN13RaycastGround12SetObjAndPosERK7Vector3Pv"
   ],
-  "src/func_ov102_0214aa18.cpp": [
+  "func_ov102_0214aa18": [
    "_ZNK13WithMeshClsn210IsOnGroundEv",
    "_ZNK13WithMeshClsn213JustHitGroundEv"
   ],
-  "src/func_ov102_0214cbec.cpp": [
+  "func_ov102_0214cbec": [
    "func_020ada40"
   ],
-  "src/func_ov102_0214ce60.cpp": [
+  "func_ov102_0214ce60": [
    "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
   ],
-  "src/main.c": [
+  "main": [
    "__main",
    "_main"
-  ],
-  "src/unnamed/ov063/func_ov063_0211a0dc.cpp": [
-   "func_020ada40"
   ]
- },
- "names": [
-  "ActorBase_MarkForDestruction",
-  "Actor_ClosestPlayer",
-  "Actor_FindWithID",
-  "Actor_MakeVanishLuigiWork",
-  "Actor_TrackStar",
-  "Actor_UpdatePos",
-  "AnimLoadFile",
-  "Animation_LoadFile",
-  "ApproachLinearI",
-  "CylinderClsn_Clear",
-  "CylinderClsn_Update",
-  "Enemy_UpdateWMClsn",
-  "FindWithActorID",
-  "G",
-  "G0",
-  "G1",
-  "G2",
-  "LCG_STATE_0204da4c",
-  "MeshColliderLoadFile",
-  "MeshCollider_LoadFile",
-  "ModelAnim_SetAnim",
-  "ModelBase_SetFile",
-  "ModelLoadFile",
-  "Model_LoadFile",
-  "MovingCylinderClsn_Init",
-  "MovingMeshCollider_SetFile",
-  "PathPtr_FromID",
-  "PathPtr_GetNode",
-  "Platform_IsClsnInRange",
-  "Platform_UpdateClsnPosAndRot",
-  "Platform_UpdateModelPosAndRotY",
-  "Player_Hurt",
-  "SQRTCNT",
-  "SQRT_RESULT",
-  "STAR_MARKERS",
-  "Scene_AfterRender",
-  "SetPolygonID",
-  "ShadowModel_InitCylinder",
-  "TextureSequence_LoadFile",
-  "TextureSequence_Prepare",
-  "TextureSequence_SetFile",
-  "UpdatePosWithTransformSym",
-  "UpdatePosWithVelocitySym",
-  "VT0",
-  "VT1",
-  "VT2",
-  "Vec3_DistSq",
-  "Vec3_equal",
-  "WithMeshClsn_Init",
-  "WithMeshClsn_IsOnGround",
-  "_Z13func_020072c0v",
-  "_Z13func_020393a4Pii",
-  "_Z13func_020393c4PvS_",
-  "_Z13func_020393d4PvS_",
-  "_Z13func_02112c88v",
-  "_Z13func_02112cc8v",
-  "_Z16DecIfAbove0_BytePh",
-  "_Z17LoadBlueCoinModelPv",
-  "_Z19func_ov002_020ef228Pvi",
-  "_Z19func_ov066_0211a35cv",
-  "_Z20_ZN7PathPtr6FromIDEjPvj",
-  "_Z22_ZN5Actor9TrackStarEjjPvjj",
-  "_Z23_ZN9Animation7AdvanceEvPc",
-  "_Z23func_02112cd8_updateposv",
-  "_Z25_ZN12CylinderClsn5ClearEvPc",
-  "_Z26_ZN12CylinderClsn6UpdateEvPc",
-  "_Z30_ZN11ShadowModel10InitCuboidEvPv",
-  "_Z31_ZNK7PathPtr7GetNodeER7Vector3jPvS_j",
-  "_Z32_ZN11ShadowModel12InitCylinderEvPv",
-  "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3jijjPvj",
-  "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
-  "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
-  "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-  "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-  "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
-  "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
-  "_Z37_ZN8Platform21UpdateModelPosAndRotYEvPv",
-  "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
-  "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-  "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
-  "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
-  "_Z44_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16iijjP7Vector3Pvii",
-  "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
-  "_Z48_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jjPvS_jPK7Vector3jj",
-  "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
-  "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
-  "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
-  "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
-  "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
-  "_Z5_Znwji",
-  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj",
-  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
-  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj",
-  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj",
-  "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv",
-  "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-  "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
-  "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
-  "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-  "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-  "_Z9Vec3_DistPK7Vector3S1_",
-  "_ZN10SysTrackerD1Ev",
-  "_ZN11ShadowModel9InitModelEP9Matrix4x3iiij",
-  "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
-  "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
-  "_ZN13CylinderClsn25ClearEv",
-  "_ZN13CylinderClsn26UpdateEv",
-  "_ZN13RaycastGround12SetObjAndPosERK7Vector3Pv",
-  "_ZN13RaycastGround19StartDetectingToxicEv",
-  "_ZN13RaycastGround19StartDetectingWaterEv",
-  "_ZN13RaycastGround21StopDetectingOrdinaryEv",
-  "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit",
-  "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
-  "_ZN16MeshColliderBase6EnableEPv",
-  "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
-  "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-  "_ZN18TextureTransformer7SetFileER8BTA_Fileiij",
-  "_ZN19CylinderClsnWithPos4InitERK7Vector3iijj",
-  "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
-  "_ZN3OAM12EnableSubOAMEP6OamTmp",
-  "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
-  "_ZN3OAM6RenderEbP7OamAttriiiiii",
-  "_ZN3OAM6RenderEbP7OamAttriiiiiiii",
-  "_ZN4PSys12FromUniqueIDEj",
-  "_ZN4PSys17NewUnkCallback818EjjiiiPv",
-  "_ZN4cstd5atan2Eii",
-  "_ZN5Actor10SpawnCoinsERK7Vector3jis",
-  "_ZN5Actor12ReflectAngleEiis",
-  "_ZN5Actor18MarkForDestructionEv",
-  "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij",
-  "_ZN5Actor22UpdatePosWithOnlySpeedEPv",
-  "_ZN5Actor5SpawnEjjRK7Vector3PK16Vector3_16_localii",
-  "_ZN5Actor9SetRangesEiiii",
-  "_ZN5Sound7PlaySubEjjjib",
-  "_ZN6ActorS10PoofDustAtERK7Vector3",
-  "_ZN6Memory14defaultHeapPtrE",
-  "_ZN6Memory15rootParamOffsetE",
-  "_ZN6Player11ChangeStateER5State",
-  "_ZN6Player4HurtERK7Vector3jijjj",
-  "_ZN6Player7IsStateER5State",
-  "_ZN6Player7SetAnimEjiij",
-  "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback",
-  "_ZN7Actor_s10FindWithIDEj",
-  "_ZN7Actor_s13ClosestPlayerEv",
-  "_ZN7Actor_s5SpawnEjjRK7Vector3PK10Vector3_16ii",
-  "_ZN7Clipper13Func_020156DCEPviiii",
-  "_ZN8CapEnemy12UpdateCapPosERK7Vector3RK16Vector3_16_local",
-  "_ZN8Particle20RunningSlidingDustAtEiii",
-  "_ZN8Particle6System3NewEjjiiiPK10Vector3_16PNS_8CallbackE",
-  "_ZN8Particle6System3NewEjjiiiPK7Vector3PNS_8CallbackE",
-  "_ZN8Particle6System9NewSimpleEjiii",
-  "_ZN8Platform13IsClsnInRangeEii",
-  "_ZN8Platform20UpdateKillByMegaCharEsssi",
-  "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij",
-  "_ZN9ModelAnim7SetAnimEPviij",
-  "_ZN9ModelBase12ApplyOpacityEji",
-  "_ZN9Platform219UpdateClsnPosAndRotEv",
-  "_ZN9Platform313IsClsnInRangeEii",
-  "_ZNK13WithMeshClsn210IsOnGroundEv",
-  "_ZNK13WithMeshClsn213JustHitGroundEv",
-  "_ZTV10dBgActor_c",
-  "_ZTV10dScTitle_c",
-  "_ZTV11dScMiniGm_c",
-  "_ZTV13dScGameOver_c",
-  "_ZTV15daObjFlMaruta_c",
-  "_ZTV15daObjHmMaruta_c",
-  "_ZTV20daObjFl_Fall_Block_c",
-  "_ZTV20daObjTh_Fall_Block_c",
-  "_ZTV21daObjKm2_Fall_Block_c",
-  "_ZTV7dBase_c",
-  "_ZTV7daDkk_c",
-  "_ZTV8dScene_c",
-  "_ZTV9dScDSMT_c",
-  "__main",
-  "_dadd",
-  "_deq",
-  "_dmul",
-  "_ll_mod",
-  "_ll_sdiv",
-  "_ll_udiv",
-  "_main",
-  "_ull_mod",
-  "base_dtor_Clipper",
-  "base_dtor_Fader",
-  "cstd_atan2",
-  "data_02111b68",
-  "data_04000006",
-  "data_ov071_02122ecc_d",
-  "func_00000000",
-  "func_00000600",
-  "func_01ff98f4",
-  "func_01ff99a4",
-  "func_01ff9d40",
-  "func_01ff9e2c",
-  "func_020527e9",
-  "func_02061128",
-  "func_020aa420",
-  "func_020ab948",
-  "func_020ab9c8",
-  "func_020aba70",
-  "func_020abac0",
-  "func_020abad0",
-  "func_020abad8",
-  "func_020abd88",
-  "func_020abd98",
-  "func_020ac218",
-  "func_020ac64c",
-  "func_020acb68",
-  "func_020ad04c",
-  "func_020ad494",
-  "func_020ad660",
-  "func_020ada40",
-  "func_020adc74",
-  "func_020aea30",
-  "func_020aed98",
-  "func_020b5e58",
-  "func_020b60fc",
-  "func_020b6244",
-  "func_020b6424",
-  "func_020b6584",
-  "func_020b66a8",
-  "func_020b9488",
-  "func_020bc7d4",
-  "func_020bc860",
-  "func_020bc864",
-  "func_020bc86c",
-  "func_020bc878",
-  "func_020bc880",
-  "func_020bc884",
-  "func_020bc888",
-  "func_020bc88c",
-  "func_020bc890",
-  "func_020bc898",
-  "func_020bc8a4",
-  "func_020bc8a8",
-  "func_020bc8b4",
-  "func_020bc8b8",
-  "func_020bd828",
-  "func_020beb68",
-  "func_020beb6c",
-  "func_020beb74",
-  "func_020ca78c",
-  "func_020efaf0",
-  "func_020effb8",
-  "func_020ff028",
-  "func_021115bc",
-  "func_021115e4",
-  "func_021115f4",
-  "func_02112118",
-  "func_02112198",
-  "func_021121b8",
-  "func_02112258",
-  "func_021123f4",
-  "func_021124ac",
-  "func_02112968",
-  "func_02112c08",
-  "func_02112ca8",
-  "func_02112d48",
-  "func_02113c20",
-  "func_0211d610",
-  "func_0211d9c0",
-  "func_02123804",
-  "func_021270dc",
-  "func_0213a2cc",
-  "func_0213a794",
-  "func_02140d80",
-  "func_ov053_021112a4",
-  "g0",
-  "g1",
-  "g2",
-  "overlay_0",
-  "overlay_1",
-  "overlay_100",
-  "overlay_102",
-  "overlay_2",
-  "overlay_3",
-  "overlay_4",
-  "overlay_5",
-  "overlay_6",
-  "overlay_60",
-  "overlay_64",
-  "overlay_66",
-  "overlay_7",
-  "overlay_75",
-  "overlay_98",
-  "reg_G2S_DB_BG3PA"
- ]
+ }
 }

--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,0 +1,1670 @@
+{
+ "files": {
+  "src/ChainChomp_Spawn.cpp": [
+   "func_020aed98"
+  ],
+  "src/ChiefChilly_Spawn.cpp": [
+   "func_020aed98"
+  ],
+  "src/ExplosionGoomba_Spawn.cpp": [
+   "func_020aed98"
+  ],
+  "src/FS_LoadOverlay.c": [
+   "func_020aa420"
+  ],
+  "src/FallBlockBfs_Spawn.c": [
+   "_ZTV21daObjKm2_Fall_Block_c"
+  ],
+  "src/FallBlockLll_Spawn.c": [
+   "_ZTV20daObjFl_Fall_Block_c"
+  ],
+  "src/GetSceneOverlayID.c": [
+   "overlay_2",
+   "overlay_3",
+   "overlay_5",
+   "overlay_6",
+   "overlay_7"
+  ],
+  "src/Goomboss_Spawn.cpp": [
+   "func_020aed98"
+  ],
+  "src/Grindel_Spawn.c": [
+   "_ZTV7daDkk_c"
+  ],
+  "src/RollingLogLll_Spawn.c": [
+   "_ZTV15daObjFlMaruta_c"
+  ],
+  "src/RollingLogTtm_Spawn.c": [
+   "_ZTV15daObjHmMaruta_c"
+  ],
+  "src/UnchainedChomp_Spawn.c": [
+   "func_020aed98"
+  ],
+  "src/Wiggler_Spawn.c": [
+   "func_020aed98"
+  ],
+  "src/_Z26LoadOrUnloadObjectOverlaysPFviEi.cpp": [
+   "overlay_102",
+   "overlay_60",
+   "overlay_98"
+  ],
+  "src/_ZN10CheepCheep13InitResourcesEv.cpp": [
+   "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj"
+  ],
+  "src/_ZN10DonutBlock8BehaviorEv.cpp": [
+   "_ZN8Platform13IsClsnInRangeEii"
+  ],
+  "src/_ZN10FlameChomp13InitResourcesEv.cpp": [
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj"
+  ],
+  "src/_ZN10KoopaShell13InitResourcesEv.cpp": [
+   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "src/_ZN10MrBlizzard13InitResourcesEv.cpp": [
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj"
+  ],
+  "src/_ZN10Scuttlebug13InitResourcesEv.cpp": [
+   "AnimLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "src/_ZN10SphereClsnD1Ev.c": [
+   "VT0",
+   "VT1",
+   "VT2"
+  ],
+  "src/_ZN11FallBlockWf13InitResourcesEv.c": [
+   "func_0213a794"
+  ],
+  "src/_ZN11FallBlockWf16CleanupResourcesEv.c": [
+   "func_0213a2cc"
+  ],
+  "src/_ZN11FallBlockWfD0Ev.c": [
+   "G0",
+   "VT1",
+   "VT2",
+   "_ZTV10dBgActor_c"
+  ],
+  "src/_ZN11FallBlockWfD1Ev.c": [
+   "VT1",
+   "VT2",
+   "_ZTV10dBgActor_c"
+  ],
+  "src/_ZN11MirrorLuigi13InitResourcesEv.cpp": [
+   "Animation_LoadFile",
+   "ModelAnim_SetAnim",
+   "ModelBase_SetFile",
+   "Model_LoadFile",
+   "ShadowModel_InitCylinder",
+   "TextureSequence_Prepare",
+   "TextureSequence_SetFile"
+  ],
+  "src/_ZN11RaycastLineD1Ev.c": [
+   "VT0",
+   "VT1"
+  ],
+  "src/_ZN12FallBlockBfs13InitResourcesEv.c": [
+   "func_0213a794"
+  ],
+  "src/_ZN12FallBlockBfs16CleanupResourcesEv.c": [
+   "func_0213a2cc"
+  ],
+  "src/_ZN12FallBlockBfsD0Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV21daObjKm2_Fall_Block_c"
+  ],
+  "src/_ZN12FallBlockBfsD1Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV21daObjKm2_Fall_Block_c"
+  ],
+  "src/_ZN12FallBlockLll16CleanupResourcesEv.cpp": [
+   "func_021270dc"
+  ],
+  "src/_ZN12FallBlockLllD0Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjFlMaruta_c"
+  ],
+  "src/_ZN12FallBlockLllD1Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjFlMaruta_c"
+  ],
+  "src/_ZN12FortressWall8BehaviorEv.cpp": [
+   "_ZN8Platform13IsClsnInRangeEii"
+  ],
+  "src/_ZN13FortressTower13InitResourcesEv.cpp": [
+   "MeshCollider_LoadFile",
+   "ModelBase_SetFile",
+   "Model_LoadFile",
+   "MovingMeshCollider_SetFile",
+   "Platform_UpdateClsnPosAndRot",
+   "Platform_UpdateModelPosAndRotY"
+  ],
+  "src/_ZN13MontyMoleRock8BehaviorEv.cpp": [
+   "ActorBase_MarkForDestruction",
+   "Actor_FindWithID",
+   "Actor_MakeVanishLuigiWork",
+   "Actor_UpdatePos",
+   "CylinderClsn_Clear",
+   "CylinderClsn_Update",
+   "Enemy_UpdateWMClsn",
+   "Player_Hurt",
+   "WithMeshClsn_IsOnGround"
+  ],
+  "src/_ZN13PeachPainting8BehaviorEv.cpp": [
+   "_ZN9ModelBase12ApplyOpacityEji"
+  ],
+  "src/_ZN13PoleBillboard16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN13PrincessPeach13InitResourcesEv.cpp": [
+   "AnimLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "src/_ZN13RacingPenguin13InitResourcesEv.cpp": [
+   "Actor_TrackStar",
+   "Animation_LoadFile",
+   "ModelBase_SetFile",
+   "Model_LoadFile",
+   "MovingCylinderClsn_Init",
+   "PathPtr_FromID",
+   "PathPtr_GetNode",
+   "ShadowModel_InitCylinder",
+   "TextureSequence_LoadFile",
+   "TextureSequence_Prepare",
+   "WithMeshClsn_Init"
+  ],
+  "src/_ZN13RacingPenguin8BehaviorEv.cpp": [
+   "_Z23_ZN9Animation7AdvanceEvPc",
+   "_Z25_ZN12CylinderClsn5ClearEvPc",
+   "_Z26_ZN12CylinderClsn6UpdateEvPc"
+  ],
+  "src/_ZN13RollingLogLll13InitResourcesEv.cpp": [
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "src/_ZN13SnowmanBreath8BehaviorEv.cpp": [
+   "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3jijjPvj",
+   "_Z48_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jjPvS_jPK7Vector3jj"
+  ],
+  "src/_ZN13TTC_MovingBar13InitResourcesEv.cpp": [
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "src/_ZN14BlueCoinSwitch16CleanupResourcesEv.c": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN14CutsceneObject13InitResourcesEv.cpp": [
+   "_Z5_Znwji",
+   "func_02113c20"
+  ],
+  "src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN14TtcMovingCubeA13InitResourcesEv.cpp": [
+   "func_02112118"
+  ],
+  "src/_ZN15BookShotSpawner13InitResourcesEv.cpp": [
+   "_Z17LoadBlueCoinModelPv",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv"
+  ],
+  "src/_ZN15TtcRotatingGear13InitResourcesEv.cpp": [
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+   "_Z37_ZN8Platform21UpdateModelPosAndRotYEvPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
+   "func_021121b8"
+  ],
+  "src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN16BowserShockwaves13InitResourcesEv.cpp": [
+   "func_021115e4",
+   "func_021115f4"
+  ],
+  "src/_ZN16FloatingFloorBfs13InitResourcesEv.c": [
+   "func_020b6244"
+  ],
+  "src/_ZN16FloatingFloorBfs16CleanupResourcesEv.c": [
+   "func_020b60fc"
+  ],
+  "src/_ZN16RotatingCogSmall13InitResourcesEv.cpp": [
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp": [
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "src/_ZN17MgBounceAndPounce11AfterRenderEj.cpp": [
+   "Scene_AfterRender"
+  ],
+  "src/_ZN17RotatingClockHand13InitResourcesEv.cpp": [
+   "MeshColliderLoadFile",
+   "ModelLoadFile",
+   "UpdatePosWithTransformSym",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp": [
+   "_Z13func_020393d4PvS_",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
+   "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "func_021115bc"
+  ],
+  "src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN19RotatingPlatformLll8BehaviorEv.cpp": [
+   "Platform_IsClsnInRange",
+   "Platform_UpdateClsnPosAndRot",
+   "Platform_UpdateModelPosAndRotY",
+   "_Z13func_020393a4Pii"
+  ],
+  "src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp": [
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp": [
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+   "_ZN18TextureTransformer7SetFileER8BTA_Fileiij"
+  ],
+  "src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp": [
+   "Vec3_equal",
+   "_Z13func_020393c4PvS_",
+   "_Z13func_020393d4PvS_",
+   "_Z20_ZN7PathPtr6FromIDEjPvj",
+   "_Z31_ZNK7PathPtr7GetNodeER7Vector3jPvS_j",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp": [
+   "ApproachLinearI",
+   "UpdatePosWithVelocitySym",
+   "_ZN8Platform13IsClsnInRangeEii"
+  ],
+  "src/_ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3.c": [
+   "_ll_sdiv"
+  ],
+  "src/_ZN3HUD15RenderCoinCountEv.cpp": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad8"
+  ],
+  "src/_ZN3HUD15RenderLifeCountEv.cpp": [
+   "func_020ab948",
+   "func_020ab9c8",
+   "func_020aba70"
+  ],
+  "src/_ZN3HUD15RenderStarCountEv.cpp": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad0"
+  ],
+  "src/_ZN3HUD15RenderTimeTimerEv.cpp": [
+   "_ll_udiv",
+   "_ull_mod"
+  ],
+  "src/_ZN4Heap18InitializeRootHeapEv.cpp": [
+   "_ZN6Memory15rootParamOffsetE"
+  ],
+  "src/_ZN4Tree13InitResourcesEv.cpp": [
+   "_ZN19CylinderClsnWithPos4InitERK7Vector3iijj"
+  ],
+  "src/_ZN4cstd5atan2E5Fix12IiES1_.c": [
+   "func_01ff98f4"
+  ],
+  "src/_ZN5Actor13LandingDustAtER7Vector3b.cpp": [
+   "_ZN8Particle6System9NewSimpleEjiii"
+  ],
+  "src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp": [
+   "_ZN8Particle6System9NewSimpleEjiii"
+  ],
+  "src/_ZN5Cloud8BehaviorEv.c": [
+   "FindWithActorID",
+   "SetPolygonID"
+  ],
+  "src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp": [
+   "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv"
+  ],
+  "src/_ZN5Stage12RenderNumberEhiibi.cpp": [
+   "func_020aba70"
+  ],
+  "src/_ZN5Stage14GraphCallback2EP12SceneRelated.c": [
+   "reg_G2S_DB_BG3PA"
+  ],
+  "src/_ZN5Stage20RenderBouncingArrowsEv.cpp": [
+   "func_020abd88"
+  ],
+  "src/_ZN5Stage6RenderEv.cpp": [
+   "func_020ab9c8",
+   "func_020abad8"
+  ],
+  "src/_ZN5Stage9PS_RenderEv.cpp": [
+   "func_020ab9c8",
+   "func_020abac0",
+   "func_020abad8",
+   "func_020abd98",
+   "func_020ac218",
+   "func_020ac64c",
+   "func_020acb68",
+   "func_020ad04c"
+  ],
+  "src/_ZN6BobOmb13InitResourcesEv.cpp": [
+   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "src/_ZN6BobOmb8BehaviorEv.c": [
+   "func_020ada40"
+  ],
+  "src/_ZN6Bullet13InitResourcesEv.cpp": [
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
+   "func_0211d610"
+  ],
+  "src/_ZN6Camera6RenderEv.cpp": [
+   "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
+   "_ZN3OAM6RenderEbP7OamAttriiiiiiii"
+  ],
+  "src/_ZN6Coffin13InitResourcesEv.cpp": [
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "src/_ZN6Eyerok13InitResourcesEv.cpp": [
+   "_Z13func_020393c4PvS_",
+   "_Z13func_020393d4PvS_",
+   "_Z22_ZN5Actor9TrackStarEjjPvjj",
+   "_Z32_ZN11ShadowModel12InitCylinderEvPv",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z44_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16iijjP7Vector3Pvii",
+   "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
+   "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
+   "func_02112c08",
+   "func_02112ca8",
+   "func_02112d48"
+  ],
+  "src/_ZN6Memory10DeallocateEPvP4Heap.cpp": [
+   "_ZN6Memory14defaultHeapPtrE"
+  ],
+  "src/_ZN6Player11St_Fly_MainEv.cpp": [
+   "_ZN6Player11ChangeStateER5State",
+   "_ZN6Player7SetAnimEjiij"
+  ],
+  "src/_ZN6Player12St_Land_InitEv.cpp": [
+   "_ZN6Player7SetAnimEjiij"
+  ],
+  "src/_ZN6Player15St_Respawn_InitEv.cpp": [
+   "_ZN6Player7SetAnimEjiij"
+  ],
+  "src/_ZN6Player17St_WindCarry_MainEv.cpp": [
+   "_ZN6Player11ChangeStateER5State",
+   "_ZN6Player7SetAnimEjiij"
+  ],
+  "src/_ZN6Player18St_CameraZoom_MainEv.cpp": [
+   "_ZN6Player11ChangeStateER5State"
+  ],
+  "src/_ZN7ClipperD0Ev.c": [
+   "base_dtor_Clipper"
+  ],
+  "src/_ZN7Skeeter8BehaviorEv.cpp": [
+   "func_020aea30"
+  ],
+  "src/_ZN7Tornado13InitResourcesEv.cpp": [
+   "func_02112968"
+  ],
+  "src/_ZN8CapEnemy6AddCapEj.c": [
+   "func_020ff028"
+  ],
+  "src/_ZN8Goomboss13InitResourcesEv.c": [
+   "func_021123f4",
+   "func_021124ac"
+  ],
+  "src/_ZN8IceSheet16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN8PoleLift16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN8SignPost13InitResourcesEv.cpp": [
+   "MeshColliderLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "src/_ZN8SignPost16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN8Squasher16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN9KoopaFlag13InitResourcesEv.cpp": [
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/_ZN9Spindrift13InitResourcesEv.cpp": [
+   "AnimLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/_ZN9TowerStep16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1"
+  ],
+  "src/_ZN9UkikiCageD0Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjHmMaruta_c"
+  ],
+  "src/_ZN9UkikiCageD1Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjHmMaruta_c"
+  ],
+  "src/_ZN9WaterBomb13InitResourcesEv.cpp": [
+   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "src/_ZdlPv.cpp": [
+   "_ZN6Memory14defaultHeapPtrE"
+  ],
+  "src/__sinit_ov071_02122a64.c": [
+   "data_ov071_02122ecc_d"
+  ],
+  "src/actors/FallBlockBbh/FallBlockBbh_Spawn.c": [
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "src/actors/FallBlockBbh/_ZN12FallBlockBbhD0Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "src/actors/FallBlockBbh/_ZN12FallBlockBbhD1Ev.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "src/actors/MadPiano/_ZN8MadPiano16CleanupResourcesEv.cpp": [
+   "G0",
+   "G1",
+   "G2"
+  ],
+  "src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp": [
+   "_ZN8Platform13IsClsnInRangeEii"
+  ],
+  "src/engine/fader/_ZN5FaderD0Ev.c": [
+   "base_dtor_Fader"
+  ],
+  "src/func_02008b4c.c": [
+   "func_020effb8"
+  ],
+  "src/func_02009374.c": [
+   "STAR_MARKERS",
+   "Vec3_DistSq"
+  ],
+  "src/func_02019ebc.c": [
+   "func_02061128"
+  ],
+  "src/func_0201a2f8.c": [
+   "func_020aa420",
+   "overlay_0",
+   "overlay_1"
+  ],
+  "src/func_0201a458.c": [
+   "func_0211d9c0",
+   "func_02140d80"
+  ],
+  "src/func_0201a614.c": [
+   "overlay_75"
+  ],
+  "src/func_0201a694.c": [
+   "overlay_75"
+  ],
+  "src/func_0201a754.c": [
+   "overlay_4",
+   "overlay_6"
+  ],
+  "src/func_0201a798.c": [
+   "overlay_4",
+   "overlay_6"
+  ],
+  "src/func_0201a8b4.c": [
+   "_ll_udiv"
+  ],
+  "src/func_02029408.c": [
+   "func_020bd828"
+  ],
+  "src/func_0202efa0.c": [
+   "_ll_sdiv"
+  ],
+  "src/func_02034fbc.c": [
+   "overlay_64",
+   "overlay_66"
+  ],
+  "src/func_0203c178.c": [
+   "func_020527e9"
+  ],
+  "src/func_02042784.c": [
+   "_ll_udiv"
+  ],
+  "src/func_020427c4.c": [
+   "_ll_udiv"
+  ],
+  "src/func_0204da4c.c": [
+   "LCG_STATE_0204da4c"
+  ],
+  "src/func_02053130.c": [
+   "SQRTCNT",
+   "SQRT_RESULT"
+  ],
+  "src/func_02055454.c": [
+   "G"
+  ],
+  "src/func_020570c0.c": [
+   "G"
+  ],
+  "src/func_020570d8.c": [
+   "G"
+  ],
+  "src/func_02057128.c": [
+   "G"
+  ],
+  "src/func_02057140.c": [
+   "G"
+  ],
+  "src/func_02057410.c": [
+   "_ll_mod",
+   "_ll_sdiv"
+  ],
+  "src/func_02058308.c": [
+   "func_00000000",
+   "func_00000600"
+  ],
+  "src/func_02058df4.c": [
+   "func_00000000",
+   "func_00000600"
+  ],
+  "src/func_02059640.c": [
+   "G"
+  ],
+  "src/func_02059a60.c": [
+   "_ll_udiv"
+  ],
+  "src/func_02059f48.c": [
+   "G"
+  ],
+  "src/func_0205f650.c": [
+   "G"
+  ],
+  "src/func_0206ece0.c": [
+   "func_01ff9e2c"
+  ],
+  "src/func_0206f46c.c": [
+   "_deq"
+  ],
+  "src/func_0206f820.c": [
+   "_ll_udiv",
+   "_ull_mod"
+  ],
+  "src/func_020708b4.c": [
+   "_dadd",
+   "_deq",
+   "_dmul"
+  ],
+  "src/func_02070c68.c": [
+   "func_01ff9d40"
+  ],
+  "src/func_02071510.c": [
+   "_ll_udiv",
+   "_ull_mod"
+  ],
+  "src/func_ov002_020aefb8.c": [
+   "_ZN5Actor12ReflectAngleEiis"
+  ],
+  "src/func_ov002_020b5ab4.cpp": [
+   "_ZN13RaycastGround19StartDetectingWaterEv"
+  ],
+  "src/func_ov002_020b7e1c.cpp": [
+   "_ZN5Actor9SetRangesEiiii"
+  ],
+  "src/func_ov002_020bd250.cpp": [
+   "_ZN6Player4HurtERK7Vector3jijjj",
+   "_ZN8Particle6System9NewSimpleEjiii"
+  ],
+  "src/func_ov002_020c0fb4.c": [
+   "_ll_udiv"
+  ],
+  "src/func_ov002_020c1234.cpp": [
+   "_ZN5Sound7PlaySubEjjjib"
+  ],
+  "src/func_ov002_020c1eb4.cpp": [
+   "_ZN8Particle6System3NewEjjiiiPK10Vector3_16PNS_8CallbackE"
+  ],
+  "src/func_ov002_020c29d4.cpp": [
+   "_ZN6Player7IsStateER5State"
+  ],
+  "src/func_ov002_020c8a4c.cpp": [
+   "_Z13func_020072c0v",
+   "_ZN6Player7SetAnimEjiij"
+  ],
+  "src/func_ov002_020c8f80.cpp": [
+   "_ZN6Player7SetAnimEjiij"
+  ],
+  "src/func_ov002_020d0580.cpp": [
+   "_ZN6Player11ChangeStateER5State",
+   "_ZN6Player7IsStateER5State"
+  ],
+  "src/func_ov002_020d06c0.cpp": [
+   "_ZN6Player11ChangeStateER5State",
+   "_ZN6Player7IsStateER5State"
+  ],
+  "src/func_ov002_020d4c30.cpp": [
+   "_ZN8Particle6System9NewSimpleEjiii"
+  ],
+  "src/func_ov002_020dc560.c": [
+   "func_01ff98f4",
+   "func_01ff99a4"
+  ],
+  "src/func_ov002_020df34c.cpp": [
+   "_ZN6Player11ChangeStateER5State",
+   "_ZN6Player7IsStateER5State"
+  ],
+  "src/func_ov002_020e81e0.cpp": [
+   "_ZN8Particle6System3NewEjjiiiPK7Vector3PNS_8CallbackE"
+  ],
+  "src/func_ov002_020ec670.c": [
+   "func_02123804"
+  ],
+  "src/func_ov003_020ad660.c": [
+   "_ZTV10dScTitle_c",
+   "_ZTV7dBase_c",
+   "_ZTV8dScene_c"
+  ],
+  "src/func_ov003_020ad7a4.cpp": [
+   "_ZN3OAM12EnableSubOAMEP6OamTmp"
+  ],
+  "src/func_ov003_020adfc8.cpp": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad8"
+  ],
+  "src/func_ov003_020ae0b0.c": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad0"
+  ],
+  "src/func_ov003_020ae238.c": [
+   "func_020ab948",
+   "func_020ab9c8",
+   "func_020aba70"
+  ],
+  "src/func_ov003_020b0580.c": [
+   "_ZTV13dScGameOver_c",
+   "_ZTV7dBase_c",
+   "_ZTV8dScene_c"
+  ],
+  "src/func_ov003_020b05bc.c": [
+   "G0",
+   "VT0",
+   "VT1",
+   "VT2"
+  ],
+  "src/func_ov005_020bfec0.c": [
+   "_ZTV11dScMiniGm_c",
+   "_ZTV7dBase_c",
+   "_ZTV8dScene_c"
+  ],
+  "src/func_ov006_020c0264.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov006_020c0a48.c": [
+   "g0",
+   "g1",
+   "g2"
+  ],
+  "src/func_ov006_020c0d68.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov006_020c1420.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov006_020c14bc.cpp": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020c1764.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov006_020c221c.c": [
+   "g0",
+   "g1"
+  ],
+  "src/func_ov006_020c6e4c.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020c79a8.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020c8084.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020c8f20.cpp": [
+   "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback"
+  ],
+  "src/func_ov006_020c9098.c": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020c9c8c.c": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020ca3a8.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020cb030.cpp": [
+   "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback"
+  ],
+  "src/func_ov006_020cb1a8.c": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020cb528.c": [
+   "_ZN9ModelAnim7SetAnimEPviij"
+  ],
+  "src/func_ov006_020cb690.cpp": [
+   "_ZN9ModelAnim7SetAnimEPviij"
+  ],
+  "src/func_ov006_020cecc0.cpp": [
+   "_ZN18TextureTransformer7SetFileER8BTA_Fileiij"
+  ],
+  "src/func_ov006_020db720.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020db9dc.c": [
+   "func_020bc7d4"
+  ],
+  "src/func_ov006_020dcd74.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020de1d4.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020de26c.cpp": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020de440.cpp": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020e3578.c": [
+   "func_020adc74"
+  ],
+  "src/func_ov006_020e6894.c": [
+   "func_020adc74"
+  ],
+  "src/func_ov006_020e7124.c": [
+   "func_020beb74"
+  ],
+  "src/func_ov006_020e7cc0.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov006_020e989c.cpp": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020e9c20.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020e9cec.c": [
+   "G0",
+   "G1"
+  ],
+  "src/func_ov006_020ea3d0.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020ee2c4.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020efcf8.c": [
+   "data_04000006"
+  ],
+  "src/func_ov006_020f0274.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f3294.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f3460.c": [
+   "func_020adc74",
+   "func_020bc864",
+   "func_020bc888"
+  ],
+  "src/func_ov006_020f3834.cpp": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "src/func_ov006_020f4888.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f52c4.c": [
+   "func_020bc7d4",
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f53e4.cpp": [
+   "func_020bc7d4"
+  ],
+  "src/func_ov006_020f5564.cpp": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "src/func_ov006_020f6538.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f7394.c": [
+   "func_020bc7d4",
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f74b4.cpp": [
+   "func_020bc7d4"
+  ],
+  "src/func_ov006_020f7634.cpp": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "src/func_ov006_020f7c10.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f869c.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f8a3c.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f8c68.c": [
+   "func_020bc7d4"
+  ],
+  "src/func_ov006_020f8d08.cpp": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_020f8ef4.cpp": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "src/func_ov006_021071fc.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_02108f2c.c": [
+   "func_020b9488"
+  ],
+  "src/func_ov006_021095cc.c": [
+   "func_020bc7d4",
+   "func_020beb68"
+  ],
+  "src/func_ov006_02109aac.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_0210a708.c": [
+   "func_020beb6c"
+  ],
+  "src/func_ov006_0210a8c0.c": [
+   "func_020ad494"
+  ],
+  "src/func_ov006_0210a900.cpp": [
+   "func_020ad494"
+  ],
+  "src/func_ov006_0210a954.cpp": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "src/func_ov006_0210bdb0.cpp": [
+   "func_020bc860",
+   "func_020bc864",
+   "func_020bc878",
+   "func_020bc888",
+   "func_020bc88c",
+   "func_020bc890",
+   "func_020bc8b4",
+   "func_020bc8b8"
+  ],
+  "src/func_ov006_0210c2d4.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_0210d1fc.cpp": [
+   "func_020bc860",
+   "func_020bc878",
+   "func_020bc88c",
+   "func_020bc890",
+   "func_020bc8b4",
+   "func_020bc8b8"
+  ],
+  "src/func_ov006_0210d6b8.cpp": [
+   "func_020ad494"
+  ],
+  "src/func_ov006_02115b0c.c": [
+   "func_020adc74"
+  ],
+  "src/func_ov006_02118488.c": [
+   "func_020bc864",
+   "func_020bc888"
+  ],
+  "src/func_ov006_02119904.cpp": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "src/func_ov006_0211fd44.c": [
+   "func_020beb68"
+  ],
+  "src/func_ov006_021200dc.c": [
+   "func_020beb6c"
+  ],
+  "src/func_ov006_021203fc.c": [
+   "func_020bc880",
+   "func_020bc884"
+  ],
+  "src/func_ov006_02123340.cpp": [
+   "_ZN4PSys12FromUniqueIDEj",
+   "_ZN4PSys17NewUnkCallback818EjjiiiPv"
+  ],
+  "src/func_ov006_02125364.c": [
+   "func_020bc7d4"
+  ],
+  "src/func_ov006_02129268.c": [
+   "func_020adc74"
+  ],
+  "src/func_ov006_0212b480.c": [
+   "func_020adc74",
+   "func_020bc86c",
+   "func_020bc898",
+   "func_020bc8a4",
+   "func_020bc8a8"
+  ],
+  "src/func_ov007_020cc028.c": [
+   "_ZTV7dBase_c",
+   "_ZTV8dScene_c",
+   "_ZTV9dScDSMT_c"
+  ],
+  "src/func_ov007_020cc070.c": [
+   "G0",
+   "VT0",
+   "VT1",
+   "VT2"
+  ],
+  "src/func_ov007_020cc2cc.c": [
+   "overlay_64",
+   "overlay_66"
+  ],
+  "src/func_ov007_020cc4c0.cpp": [
+   "overlay_100",
+   "overlay_102"
+  ],
+  "src/func_ov014_02111a6c.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov014_02111e74.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov014_02112ea8.cpp": [
+   "_ZN6ActorS10PoofDustAtERK7Vector3",
+   "_ZN8Particle6System9NewSimpleEjiii"
+  ],
+  "src/func_ov015_02111d98.cpp": [
+   "_ZN5Actor22UpdatePosWithOnlySpeedEPv"
+  ],
+  "src/func_ov015_02112c84.c": [
+   "func_020b66a8"
+  ],
+  "src/func_ov016_02112ae4.c": [
+   "G0",
+   "G1"
+  ],
+  "src/func_ov016_02112fa8.c": [
+   "func_020b5e58"
+  ],
+  "src/func_ov018_02111d28.cpp": [
+   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
+  ],
+  "src/func_ov018_02111f1c.cpp": [
+   "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov018_02112730.cpp": [
+   "_ZN5Actor18MarkForDestructionEv"
+  ],
+  "src/func_ov020_021112b0.c": [
+   "Actor_ClosestPlayer",
+   "cstd_atan2"
+  ],
+  "src/func_ov022_0211165c.c": [
+   "func_020b66a8"
+  ],
+  "src/func_ov022_02111bdc.cpp": [
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "src/func_ov022_02111ea0.cpp": [
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "src/func_ov022_02112380.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjFl_Fall_Block_c"
+  ],
+  "src/func_ov022_02112434.c": [
+   "func_0213a2cc"
+  ],
+  "src/func_ov022_02112448.c": [
+   "func_0213a794"
+  ],
+  "src/func_ov025_021118c8.c": [
+   "_ZTV10dBgActor_c",
+   "_ZTV7daDkk_c"
+  ],
+  "src/func_ov025_02111928.c": [
+   "G0",
+   "VT0",
+   "VT1",
+   "VT2"
+  ],
+  "src/func_ov026_02111598.cpp": [
+   "func_ov053_021112a4"
+  ],
+  "src/func_ov026_02111764.c": [
+   "G0",
+   "G1"
+  ],
+  "src/func_ov026_02111954.c": [
+   "G0",
+   "G1"
+  ],
+  "src/func_ov030_02113a80.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov036_0211137c.cpp": [
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "src/func_ov036_0211244c.cpp": [
+   "func_020efaf0"
+  ],
+  "src/func_ov045_02111bc8.c": [
+   "func_020b6424"
+  ],
+  "src/func_ov045_02111bdc.c": [
+   "func_020b6584"
+  ],
+  "src/func_ov060_021182b0.cpp": [
+   "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "src/func_ov062_02116010.c": [
+   "func_020ada40"
+  ],
+  "src/func_ov062_021164e8.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov062_02116d28.cpp": [
+   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
+  ],
+  "src/func_ov062_02117c98.c": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "src/func_ov062_02118004.cpp": [
+   "_ZN8Particle20RunningSlidingDustAtEiii"
+  ],
+  "src/func_ov062_02119af0.cpp": [
+   "_ZN4cstd5atan2Eii"
+  ],
+  "src/func_ov062_0211b880.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov062_0211b930.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit",
+   "_ZN8Particle6System9NewSimpleEjiii"
+  ],
+  "src/func_ov062_0211bc54.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov064_021163c0.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov064_02116460.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov064_02116754.cpp": [
+   "func_020ada40"
+  ],
+  "src/func_ov064_02116ec0.cpp": [
+   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov065_02115ff0.c": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "src/func_ov065_0211704c.c": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "src/func_ov065_0211a358.cpp": [
+   "_Z30_ZN11ShadowModel10InitCuboidEvPv",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
+   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+   "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "func_02112198"
+  ],
+  "src/func_ov065_0211ad04.c": [
+   "G0",
+   "G1"
+  ],
+  "src/func_ov065_0211b1d4.cpp": [
+   "MeshColliderLoadFile",
+   "ModelLoadFile",
+   "UpdatePosWithTransformSym",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+   "func_02112258"
+  ],
+  "src/func_ov066_021166c8.cpp": [
+   "_Z13func_02112c88v",
+   "_Z13func_02112cc8v",
+   "_Z19func_ov066_0211a35cv",
+   "_Z23func_02112cd8_updateposv"
+  ],
+  "src/func_ov066_02116d14.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov066_02116db0.c": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "src/func_ov066_021175e8.c": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "src/func_ov066_02117bf0.c": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "src/func_ov066_02118188.c": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "src/func_ov070_0211f0a4.cpp": [
+   "_ZN5Actor10SpawnCoinsERK7Vector3jis"
+  ],
+  "src/func_ov070_0211f100.cpp": [
+   "func_020aea30"
+  ],
+  "src/func_ov070_0211f5f0.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov071_0211f7d4.c": [
+   "_ZN13CylinderClsn25ClearEv",
+   "_ZN13CylinderClsn26UpdateEv"
+  ],
+  "src/func_ov075_02114cd8.cpp": [
+   "_ZN11ShadowModel9InitModelEP9Matrix4x3iiij"
+  ],
+  "src/func_ov075_021152d4.cpp": [
+   "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
+   "_ZN7Clipper13Func_020156DCEPviiii"
+  ],
+  "src/func_ov075_02116f40.cpp": [
+   "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
+   "func_020abd88"
+  ],
+  "src/func_ov075_02117590.cpp": [
+   "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii"
+  ],
+  "src/func_ov075_02117bc4.c": [
+   "overlay_64",
+   "overlay_66"
+  ],
+  "src/func_ov075_021194e4.cpp": [
+   "_ZN3OAM6RenderEbP7OamAttriiiiii"
+  ],
+  "src/func_ov075_021199d8.cpp": [
+   "_ZN3OAM6RenderEbP7OamAttriiiiii"
+  ],
+  "src/func_ov077_021244d4.cpp": [
+   "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov078_02123bc4.cpp": [
+   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
+  ],
+  "src/func_ov079_02126f8c.cpp": [
+   "_ZN7Actor_s10FindWithIDEj",
+   "_ZN7Actor_s13ClosestPlayerEv",
+   "_ZN7Actor_s5SpawnEjjRK7Vector3PK10Vector3_16ii",
+   "_ZN8Platform13IsClsnInRangeEii",
+   "_ZN8Platform20UpdateKillByMegaCharEsssi"
+  ],
+  "src/func_ov080_02123ecc.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov081_021243cc.cpp": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "src/func_ov081_02124d14.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov081_02125068.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov081_02127be0.cpp": [
+   "_ZN5Actor5SpawnEjjRK7Vector3PK16Vector3_16_localii"
+  ],
+  "src/func_ov084_02129238.cpp": [
+   "_ZN13RaycastGround19StartDetectingToxicEv",
+   "_ZN13RaycastGround19StartDetectingWaterEv",
+   "_ZN13RaycastGround21StopDetectingOrdinaryEv"
+  ],
+  "src/func_ov084_02129a00.c": [
+   "func_020aea30"
+  ],
+  "src/func_ov084_02129ed4.c": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "src/func_ov084_0212a580.cpp": [
+   "_ZN8CapEnemy12UpdateCapPosERK7Vector3RK16Vector3_16_local"
+  ],
+  "src/func_ov084_0212a774.c": [
+   "func_020aea30"
+  ],
+  "src/func_ov084_0212c92c.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov085_0212943c.cpp": [
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "src/func_ov085_0212bedc.cpp": [
+   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
+  ],
+  "src/func_ov085_0212de5c.cpp": [
+   "_ZN5Sound7PlaySubEjjjib"
+  ],
+  "src/func_ov089_0213162c.c": [
+   "data_02111b68"
+  ],
+  "src/func_ov090_021310b4.c": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "src/func_ov091_02131070.cpp": [
+   "_ZN8Particle6System9NewSimpleEjiii"
+  ],
+  "src/func_ov091_021339fc.c": [
+   "func_020aea30"
+  ],
+  "src/func_ov098_021390ec.cpp": [
+   "_Z19func_ov002_020ef228Pvi",
+   "_ZN5Actor12ReflectAngleEiis"
+  ],
+  "src/func_ov100_0214109c.cpp": [
+   "ActorBase_MarkForDestruction"
+  ],
+  "src/func_ov100_02141fb0.cpp": [
+   "func_020ada40"
+  ],
+  "src/func_ov100_0214272c.cpp": [
+   "func_020ad660"
+  ],
+  "src/func_ov100_02142918.cpp": [
+   "func_020ad660"
+  ],
+  "src/func_ov100_02145080.c": [
+   "func_020ca78c"
+  ],
+  "src/func_ov100_02147054.c": [
+   "G0",
+   "G1",
+   "G2"
+  ],
+  "src/func_ov100_021470f4.cpp": [
+   "_Z16DecIfAbove0_BytePh",
+   "_Z9Vec3_DistPK7Vector3S1_",
+   "_ZN16MeshColliderBase6EnableEPv",
+   "_ZN9Platform219UpdateClsnPosAndRotEv",
+   "_ZN9Platform313IsClsnInRangeEii"
+  ],
+  "src/func_ov100_021471e0.cpp": [
+   "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "func_020efaf0"
+  ],
+  "src/func_ov102_02149610.cpp": [
+   "_ZN13RaycastGround12SetObjAndPosERK7Vector3Pv"
+  ],
+  "src/func_ov102_0214aa18.cpp": [
+   "_ZNK13WithMeshClsn210IsOnGroundEv",
+   "_ZNK13WithMeshClsn213JustHitGroundEv"
+  ],
+  "src/func_ov102_0214cbec.cpp": [
+   "func_020ada40"
+  ],
+  "src/func_ov102_0214ce60.cpp": [
+   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
+  ],
+  "src/main.c": [
+   "__main",
+   "_main"
+  ],
+  "src/unnamed/ov063/func_ov063_0211a0dc.cpp": [
+   "func_020ada40"
+  ]
+ },
+ "names": [
+  "ActorBase_MarkForDestruction",
+  "Actor_ClosestPlayer",
+  "Actor_FindWithID",
+  "Actor_MakeVanishLuigiWork",
+  "Actor_TrackStar",
+  "Actor_UpdatePos",
+  "AnimLoadFile",
+  "Animation_LoadFile",
+  "ApproachLinearI",
+  "CylinderClsn_Clear",
+  "CylinderClsn_Update",
+  "Enemy_UpdateWMClsn",
+  "FindWithActorID",
+  "G",
+  "G0",
+  "G1",
+  "G2",
+  "LCG_STATE_0204da4c",
+  "MeshColliderLoadFile",
+  "MeshCollider_LoadFile",
+  "ModelAnim_SetAnim",
+  "ModelBase_SetFile",
+  "ModelLoadFile",
+  "Model_LoadFile",
+  "MovingCylinderClsn_Init",
+  "MovingMeshCollider_SetFile",
+  "PathPtr_FromID",
+  "PathPtr_GetNode",
+  "Platform_IsClsnInRange",
+  "Platform_UpdateClsnPosAndRot",
+  "Platform_UpdateModelPosAndRotY",
+  "Player_Hurt",
+  "SQRTCNT",
+  "SQRT_RESULT",
+  "STAR_MARKERS",
+  "Scene_AfterRender",
+  "SetPolygonID",
+  "ShadowModel_InitCylinder",
+  "TextureSequence_LoadFile",
+  "TextureSequence_Prepare",
+  "TextureSequence_SetFile",
+  "UpdatePosWithTransformSym",
+  "UpdatePosWithVelocitySym",
+  "VT0",
+  "VT1",
+  "VT2",
+  "Vec3_DistSq",
+  "Vec3_equal",
+  "WithMeshClsn_Init",
+  "WithMeshClsn_IsOnGround",
+  "_Z13func_020072c0v",
+  "_Z13func_020393a4Pii",
+  "_Z13func_020393c4PvS_",
+  "_Z13func_020393d4PvS_",
+  "_Z13func_02112c88v",
+  "_Z13func_02112cc8v",
+  "_Z16DecIfAbove0_BytePh",
+  "_Z17LoadBlueCoinModelPv",
+  "_Z19func_ov002_020ef228Pvi",
+  "_Z19func_ov066_0211a35cv",
+  "_Z20_ZN7PathPtr6FromIDEjPvj",
+  "_Z22_ZN5Actor9TrackStarEjjPvjj",
+  "_Z23_ZN9Animation7AdvanceEvPc",
+  "_Z23func_02112cd8_updateposv",
+  "_Z25_ZN12CylinderClsn5ClearEvPc",
+  "_Z26_ZN12CylinderClsn6UpdateEvPc",
+  "_Z30_ZN11ShadowModel10InitCuboidEvPv",
+  "_Z31_ZNK7PathPtr7GetNodeER7Vector3jPvS_j",
+  "_Z32_ZN11ShadowModel12InitCylinderEvPv",
+  "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3jijjPvj",
+  "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
+  "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
+  "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+  "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+  "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
+  "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+  "_Z37_ZN8Platform21UpdateModelPosAndRotYEvPv",
+  "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
+  "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+  "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
+  "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
+  "_Z44_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16iijjP7Vector3Pvii",
+  "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
+  "_Z48_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jjPvS_jPK7Vector3jj",
+  "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
+  "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
+  "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
+  "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
+  "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
+  "_Z5_Znwji",
+  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj",
+  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
+  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj",
+  "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj",
+  "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv",
+  "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+  "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
+  "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
+  "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+  "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+  "_Z9Vec3_DistPK7Vector3S1_",
+  "_ZN10SysTrackerD1Ev",
+  "_ZN11ShadowModel9InitModelEP9Matrix4x3iiij",
+  "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+  "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+  "_ZN13CylinderClsn25ClearEv",
+  "_ZN13CylinderClsn26UpdateEv",
+  "_ZN13RaycastGround12SetObjAndPosERK7Vector3Pv",
+  "_ZN13RaycastGround19StartDetectingToxicEv",
+  "_ZN13RaycastGround19StartDetectingWaterEv",
+  "_ZN13RaycastGround21StopDetectingOrdinaryEv",
+  "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit",
+  "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
+  "_ZN16MeshColliderBase6EnableEPv",
+  "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+  "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+  "_ZN18TextureTransformer7SetFileER8BTA_Fileiij",
+  "_ZN19CylinderClsnWithPos4InitERK7Vector3iijj",
+  "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
+  "_ZN3OAM12EnableSubOAMEP6OamTmp",
+  "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
+  "_ZN3OAM6RenderEbP7OamAttriiiiii",
+  "_ZN3OAM6RenderEbP7OamAttriiiiiiii",
+  "_ZN4PSys12FromUniqueIDEj",
+  "_ZN4PSys17NewUnkCallback818EjjiiiPv",
+  "_ZN4cstd5atan2Eii",
+  "_ZN5Actor10SpawnCoinsERK7Vector3jis",
+  "_ZN5Actor12ReflectAngleEiis",
+  "_ZN5Actor18MarkForDestructionEv",
+  "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij",
+  "_ZN5Actor22UpdatePosWithOnlySpeedEPv",
+  "_ZN5Actor5SpawnEjjRK7Vector3PK16Vector3_16_localii",
+  "_ZN5Actor9SetRangesEiiii",
+  "_ZN5Sound7PlaySubEjjjib",
+  "_ZN6ActorS10PoofDustAtERK7Vector3",
+  "_ZN6Memory14defaultHeapPtrE",
+  "_ZN6Memory15rootParamOffsetE",
+  "_ZN6Player11ChangeStateER5State",
+  "_ZN6Player4HurtERK7Vector3jijjj",
+  "_ZN6Player7IsStateER5State",
+  "_ZN6Player7SetAnimEjiij",
+  "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback",
+  "_ZN7Actor_s10FindWithIDEj",
+  "_ZN7Actor_s13ClosestPlayerEv",
+  "_ZN7Actor_s5SpawnEjjRK7Vector3PK10Vector3_16ii",
+  "_ZN7Clipper13Func_020156DCEPviiii",
+  "_ZN8CapEnemy12UpdateCapPosERK7Vector3RK16Vector3_16_local",
+  "_ZN8Particle20RunningSlidingDustAtEiii",
+  "_ZN8Particle6System3NewEjjiiiPK10Vector3_16PNS_8CallbackE",
+  "_ZN8Particle6System3NewEjjiiiPK7Vector3PNS_8CallbackE",
+  "_ZN8Particle6System9NewSimpleEjiii",
+  "_ZN8Platform13IsClsnInRangeEii",
+  "_ZN8Platform20UpdateKillByMegaCharEsssi",
+  "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij",
+  "_ZN9ModelAnim7SetAnimEPviij",
+  "_ZN9ModelBase12ApplyOpacityEji",
+  "_ZN9Platform219UpdateClsnPosAndRotEv",
+  "_ZN9Platform313IsClsnInRangeEii",
+  "_ZNK13WithMeshClsn210IsOnGroundEv",
+  "_ZNK13WithMeshClsn213JustHitGroundEv",
+  "_ZTV10dBgActor_c",
+  "_ZTV10dScTitle_c",
+  "_ZTV11dScMiniGm_c",
+  "_ZTV13dScGameOver_c",
+  "_ZTV15daObjFlMaruta_c",
+  "_ZTV15daObjHmMaruta_c",
+  "_ZTV20daObjFl_Fall_Block_c",
+  "_ZTV20daObjTh_Fall_Block_c",
+  "_ZTV21daObjKm2_Fall_Block_c",
+  "_ZTV7dBase_c",
+  "_ZTV7daDkk_c",
+  "_ZTV8dScene_c",
+  "_ZTV9dScDSMT_c",
+  "__main",
+  "_dadd",
+  "_deq",
+  "_dmul",
+  "_ll_mod",
+  "_ll_sdiv",
+  "_ll_udiv",
+  "_main",
+  "_ull_mod",
+  "base_dtor_Clipper",
+  "base_dtor_Fader",
+  "cstd_atan2",
+  "data_02111b68",
+  "data_04000006",
+  "data_ov071_02122ecc_d",
+  "func_00000000",
+  "func_00000600",
+  "func_01ff98f4",
+  "func_01ff99a4",
+  "func_01ff9d40",
+  "func_01ff9e2c",
+  "func_020527e9",
+  "func_02061128",
+  "func_020aa420",
+  "func_020ab948",
+  "func_020ab9c8",
+  "func_020aba70",
+  "func_020abac0",
+  "func_020abad0",
+  "func_020abad8",
+  "func_020abd88",
+  "func_020abd98",
+  "func_020ac218",
+  "func_020ac64c",
+  "func_020acb68",
+  "func_020ad04c",
+  "func_020ad494",
+  "func_020ad660",
+  "func_020ada40",
+  "func_020adc74",
+  "func_020aea30",
+  "func_020aed98",
+  "func_020b5e58",
+  "func_020b60fc",
+  "func_020b6244",
+  "func_020b6424",
+  "func_020b6584",
+  "func_020b66a8",
+  "func_020b9488",
+  "func_020bc7d4",
+  "func_020bc860",
+  "func_020bc864",
+  "func_020bc86c",
+  "func_020bc878",
+  "func_020bc880",
+  "func_020bc884",
+  "func_020bc888",
+  "func_020bc88c",
+  "func_020bc890",
+  "func_020bc898",
+  "func_020bc8a4",
+  "func_020bc8a8",
+  "func_020bc8b4",
+  "func_020bc8b8",
+  "func_020bd828",
+  "func_020beb68",
+  "func_020beb6c",
+  "func_020beb74",
+  "func_020ca78c",
+  "func_020efaf0",
+  "func_020effb8",
+  "func_020ff028",
+  "func_021115bc",
+  "func_021115e4",
+  "func_021115f4",
+  "func_02112118",
+  "func_02112198",
+  "func_021121b8",
+  "func_02112258",
+  "func_021123f4",
+  "func_021124ac",
+  "func_02112968",
+  "func_02112c08",
+  "func_02112ca8",
+  "func_02112d48",
+  "func_02113c20",
+  "func_0211d610",
+  "func_0211d9c0",
+  "func_02123804",
+  "func_021270dc",
+  "func_0213a2cc",
+  "func_0213a794",
+  "func_02140d80",
+  "func_ov053_021112a4",
+  "g0",
+  "g1",
+  "g2",
+  "overlay_0",
+  "overlay_1",
+  "overlay_100",
+  "overlay_102",
+  "overlay_2",
+  "overlay_3",
+  "overlay_4",
+  "overlay_5",
+  "overlay_6",
+  "overlay_60",
+  "overlay_64",
+  "overlay_66",
+  "overlay_7",
+  "overlay_75",
+  "overlay_98",
+  "reg_G2S_DB_BG3PA"
+ ]
+}

--- a/notes/declaration-centralization.md
+++ b/notes/declaration-centralization.md
@@ -1,0 +1,178 @@
+# Centralizing declarations
+
+## What "a declaration" is here, and why there are so many
+
+Every function in this tree lives in its own file, and any file that *calls* something
+outside itself has to tell the compiler that the thing exists. That statement is a
+**declaration**:
+
+```c
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+    u32 id, u32 param, const Vector3 *pos, const Vector3_16 *rot, s32 area, s32 unk);
+```
+
+It says nothing about what the function *does*. It says only: this name exists, it
+takes these types, it returns this type. The compiler needs that to emit a call; the
+linker later fills in the address.
+
+There is no rule saying two files must agree about it. Each file carries its own copy,
+written by whoever recovered that file. So the tree contains:
+
+```
+5,768  files carrying local `extern` declarations
+8,523  distinct names declared
+18,497 declaration lines
+```
+
+The same fact restated 18,497 times for 8,523 facts. `data_020a0eac` is declared
+independently in **339 files**.
+
+## Why they disagree, which is the actual problem
+
+They are not just duplicated. **27% of them contradict each other** — 3,592 of the
+13,279 locally-declared names that exist in `symbols.txt` are declared inconsistently
+across files. `ModelAnim::SetAnim` has **124 distinct spellings**:
+
+```c
+extern "C" int          @(ModelAnim*, BCA_File*, int, int, unsigned int)
+extern "C" int          @(char*, struct BCA_File*, int, int, unsigned int)
+extern "C" int          @(void*, void*, int, int, int)
+extern "C" unsigned int @(ModelAnim* thiz, BCA_File* f, int a, Fix12i b, unsigned int c)
+```
+
+`Actor::Spawn` has 117. `ApproachLinear` has 104.
+
+This is not carelessness, and that matters for how it gets fixed. **The byte gate could
+never object.** `match.py` compares a compiled function to the ROM word by word, but
+every relocated word is a wildcard, because our object holds a placeholder where the
+ROM holds a final address. A wrong parameter type usually does not change the emitted
+instruction at all — a pointer and an `int` are both one register — so a file could
+mistype every external it referenced and still match perfectly.
+
+The per-file declarations were **degrees of freedom the matcher was free to exploit**.
+Nothing ever forced them to converge, so they didn't.
+
+## What it costs
+
+Every naming problem becomes a tree-wide sweep, because the fact being fixed is stored
+in hundreds of places. This session ran five of them:
+
+| problem | scale | how it was fixed |
+|---|---|---|
+| C++ files re-mangling ROM names | 882 refs | 44 shared headers given `extern "C"` |
+| `G0`/`VT1`/`HEAP` placeholders | 250 files | resolved from relocation data |
+| one fake vtable name | **196 files, 196 real symbols** | same |
+| mis-recovered signatures | 106 refs | pending |
+| wrong callees | 3 functions | found only when enrollment forced a link |
+
+The instructive one is the first. Fixing **44 shared headers** enrolled three times as
+many functions as a **255-file** per-file sweep. Centralized facts are cheap to fix;
+scattered ones are not.
+
+## What centralizing means
+
+Instead of each file writing its own declaration, one **generated** header states each
+fact once, and files include it:
+
+```c
+/* include/decl_Actor.h -- generated; do not edit */
+#ifdef __cplusplus
+extern "C" {
+#endif
+void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+    u32, u32, const Vector3 *, const Vector3_16 *, s32, s32);
+#ifdef __cplusplus
+}
+#endif
+```
+
+Generated, not hand-written — a hand-maintained central header is the same unvalidated
+cache with a larger blast radius. The generator's inputs already exist and are already
+authoritative:
+
+- `config/**/symbols.txt` — every name and its address, per module
+- `config/**/relocs.txt` — every cross-reference dsd found in the real ROM
+- the **definition** in `src/` — the one place a signature is not a guess
+
+Then a wrong type is fixed once, and a *new* wrong type has nowhere to live.
+
+44 of these headers already exist (`include/decl_*.h`) and 1,780 files already include
+`decl_common.h`. This is extending something proven, not a new bet.
+
+## Why not do it all at once
+
+Byte-testing 55 real currently-matching files, with local declarations stripped and a
+generated header included instead:
+
+| group | result |
+|---|---|
+| 20 `.c`, declarations agreeing with the header | 14 match, 6 compile-fail |
+| 20 `.c`, non-majority declarations | 10 match, 9 conflicts surfaced, **1 real codegen change** |
+| 15 `.cpp` | **0 match** |
+
+Three things fall out, and each one shapes the plan.
+
+**About 40% need individual reconciliation.** The compile failures are not the tool
+breaking — they are the disagreements finally being forced into the open. Every one is
+a real question that has to be answered by a person: does `func_ov007_020b7948` return
+`void` as its definition says, or `int` as its callers say?
+
+**Declaration form can change codegen.** `src/func_ov002_020f2aec.c` only matches with
+`int` as the last parameter of `_ZN3G2x13SetBlendAlphaEPVttttt`; the header's `u16`
+forces a truncation at the call site and the function grows `0x108 -> 0x110`. Rare —
+1 in 25 — but real. Only the byte gate catches it, so every file must be byte-verified
+individually.
+
+**The `.cpp` half cannot take a shared header yet.** 0 of 15. C-harvested declarations
+are not C++-clean: an unknown type in a parameter list is a warning in C and a hard
+error in C++. That half needs its own approach.
+
+And one rule with evidence behind it: **never generate a signature from what the
+callers say.** 6 of the cleanest 20 failed exactly that way — the callers' majority
+spelling disagreed with the definition. The definition is the only non-guess.
+
+## Plan
+
+**Phase 0 — stop the bleeding first.** Land the reference ratchet (#1071) before any
+of this. Migrating 5,768 files while new inconsistencies are still landing is
+pointless.
+
+**Phase 1 — generate, do not migrate.** Write the generator; emit headers to a scratch
+directory; report how many names it can state confidently (definition available, one
+consistent signature) versus how many need a human. Nothing in `src/` changes. This
+turns "27% disagree" from a statistic into a worklist.
+
+**Phase 2 — migrate the agreeing names, `.c` only.** Strip local declarations where the
+generated header already says the same thing, in byte-verified batches under the
+validator's 200-file cap. Expect ~70% of files to pass mechanically. Reverts are
+information, not failure.
+
+**Phase 3 — reconcile the conflicts, one at a time.** Each is a genuine correctness
+question. Some will change bytes, and the gate will say so. This is the slow part and
+it does not parallelize well.
+
+**Phase 4 — extend the ratchet.** Once a name is centrally declared, forbid re-declaring
+it locally. That is a grep, and it is what makes the migration permanent instead of
+something that silently rots back.
+
+**Phase 5 — `.cpp`, separately, and only afterwards.** Different failure mode, different
+solution, no reason to couple it to the above.
+
+## What not to do
+
+- **No big-bang strip.** ~40% of files need individual attention; one enormous change
+  destroys reviewability, the 200-file validator cap, and attribution lineage, for no
+  extra correctness.
+- **No hand-maintained central header.** Generator output or nothing.
+- **Never generate from caller majority.** Definitions only.
+- **Do not relax the byte gate to ease migration.** It is the only thing that catches
+  the 1-in-25 silent codegen shift, and it is what made this cheap to measure at all.
+- **Do not start porting to real C++ classes first.** Real methods re-mangle and
+  reopen the war the 44 `extern "C"` headers just ended. Readability is the last pass,
+  after the byte war is over.
+
+## The one-sentence version
+
+The tree stores 18,497 copies of 8,523 facts, a quarter of the copies disagree, and
+nothing in the build could ever notice — so every fix costs a tree-wide sweep until the
+facts live in one place.

--- a/notes/overlay-ambiguous-references.md
+++ b/notes/overlay-ambiguous-references.md
@@ -1,0 +1,66 @@
+# 169 references that are ambiguous between overlays
+
+**Status:** open, needs a person. Drafted as a GitHub issue; not yet filed.
+
+169 functions cannot be enrolled because a reference in them targets an address that
+**two or more overlays both define**, and nothing in the data says which one was
+resident when the code ran.
+
+Tooling has taken this as far as it can. `tools/resolve_placeholders.py` resolves a
+reference by joining the call site's own relocation to the owning module and then to
+that module's symbol table:
+
+```
+from:0x021111e8 kind:load to:0x021099e4 module:overlay(2)
+```
+
+That works when dsd names one overlay. For these 169 it names several --
+`module:overlays(0,4)` -- because overlays share address space and dsd could not tell
+them apart either. Where only one candidate defines a symbol at the target address the
+tool settles it automatically. These are the cases where **both candidates define
+something, and the two disagree**:
+
+| references | name in source | candidates |
+|---:|---|---|
+| 22 | `func_020beb68` | `ov000:data_ov000_020beb68` vs `ov004:data_ov004_020beb68` |
+| 9 | `func_020aea30` | `ov002:func_ov002_020aea30` vs `ov004:_ZN5Enemy12KillByAttack...` |
+| 8 | `func_020ada40` | `ov002:func_ov002_020ada40` vs `ov004:_ZN5Enemy20KillByInvincib...` |
+| 6 | `func_020aed98` | `ov002:_ZN5EnemyC2Ev` vs `ov007:func_ov007_020aed98` |
+| 5 | `func_020bc7d4` | `ov000:data_ov000_020bc7d4` vs `ov004:data_ov004_020bc7d4` |
+| 5 | `_ZTV10dBgActor_c` | `ov006:data_ov006_0213c5bc` vs `ov098:data_ov098_0213c5bc` |
+
+A guess here is not cheap. `match.py` compares relocated words as wildcards, so picking
+the wrong overlay still byte-matches -- the mistake would surface only at the ROM link,
+and only for whichever files happen to get enrolled. That is exactly the blind spot
+that hid three wrong-callee bugs already (`Door::Behavior`, `func_ov004_020b29c0`,
+`func_ov004_020b2a84`).
+
+## What would settle it
+
+Any of these, per case:
+
+- **Overlay residency.** Which overlays are loaded together at the point this code
+  runs? If ov002 and ov004 are never resident simultaneously, the referring module's
+  own copy is the answer. An overlay load-order or scene-to-overlay map would resolve
+  most of the table above mechanically, and would keep paying off afterwards.
+- **Emulator trace.** Break on the call site and read the resolved target. See
+  `notes/emu-trace-plan.md`.
+- **Reading the code.** Several pairs are plainly the same function under two names --
+  `_ZN5Enemy12KillByAttack...` in ov004 against an unnamed `func_ov002_...` in ov002.
+  Confirming that also closes a naming gap in `symbols.txt`.
+
+## Reproducing the list
+
+```
+python tools/eligible.py
+python tools/resolve_placeholders.py          # report only; nothing is written
+```
+
+Everything reported as `0x... names {...}` is one of these.
+
+## Related
+
+- #1071 -- the resolver, and the ratchet that keeps new instances out
+- `notes/declaration-centralization.md` -- the larger structural problem behind
+  scattered, disagreeing references
+- `notes/rom-build.md` -- how enrollment and the ROM link fit together

--- a/notes/runbook-reference-repair.md
+++ b/notes/runbook-reference-repair.md
@@ -1,0 +1,170 @@
+# Runbook: repairing references between functions
+
+**Audience:** an agent or contributor picking this up cold. Follow it top to bottom.
+**Scope:** making a reference point at the symbol the ROM actually uses.
+**Not in scope:** parameter types -- see `runbook-type-reconstruction.md`.
+
+---
+
+## 1. The problem, in one paragraph
+
+`tools/match.py` compares a compiled function to the ROM word by word, but every
+**relocated** word is a wildcard: our object holds a placeholder where the ROM holds a
+final address. So on its own the byte gate asks *"is there a call here"* and never *"a call to
+what"*. (`match.py --strict-relocs` is now default-on and does check reloc
+destinations against `relocs.txt` -- but the corpus was matched before that existed, so
+for any file you did not personally re-verify, assume the weaker guarantee.) A file can name a callee that does not exist, or the wrong one, and still match
+perfectly. The ROM link would object, but `tools/eligible.py` refuses to enroll a file
+whose references do not resolve, so a broken file never reaches the link. The two gates
+cover for each other.
+
+**Consequence you must internalise:** a byte match is *not* evidence about references.
+Only enrollment plus the ROM link is.
+
+## 2. The authority
+
+Never guess from the name. The name is what a recovery pass wrote down; it is the thing
+under suspicion. The authority is dsd's analysis of the real ROM:
+
+```
+config/**/relocs.txt     from:0x021111e8 kind:load to:0x021099e4 module:overlay(2)
+config/**/symbols.txt    _ZN5Actor5SpawnEjj... kind:function(arm,size=0x54) addr:0x...
+```
+
+The join is: **compile the file -> read the relocation offsets out of the object ->
+add the function's address -> look up `from:` -> take `to:` and `module:` -> ask that
+module's `symbols.txt` for the name.**
+
+`tools/resolve_placeholders.py` implements exactly this. Do not reimplement it.
+
+## 3. Preconditions
+
+**Cold start:** `tools/mwccarm/**` and `extracted/**` are git-ignored, so a fresh clone
+has neither the 25 compilers nor the extracted ROM, and step 1 fails immediately. See
+`notes/rom-build.md` first.
+
+```sh
+cd <worktree>
+git status --porcelain          # must be clean; a dirty tree poisons the report
+python tools/eligible.py        # ~5 min, compiles ~11,100 files
+```
+
+`eligible.py` writes `build/rombuild-eligibility.json`, stamped with the commit it
+describes. Everything below reads it. **If you change `src/`, it is stale -- re-run it.**
+A stale report is the single easiest way to produce confident nonsense; it has already
+happened twice.
+
+## 4. The loop
+
+```sh
+python tools/resolve_placeholders.py                # report only, writes nothing
+python tools/resolve_placeholders.py --apply -j 16  # rewrite + verify + revert on fail
+```
+
+Read the outcome table before doing anything else. Each outcome means something
+different and only one of them is a fix:
+
+| outcome | meaning | action |
+|---|---|---|
+| `rewritten` | renamed, and it still reproduces the ROM with correct reloc destinations | keep |
+| `partial` | some names in the file are not textual; fixing only the rest leaves it broken | needs a source transform, not a rename |
+| `not textual` | the name is compiler-generated (a member call, or double-mangled) so there is no token to rewrite | needs a source transform |
+| `target unnamed in config` | the address resolves, but only to `func_0208xxxx` | that is a `symbols.txt` gap; name it there first |
+| `unresolved` | the join did not produce one answer | read the printed reason -- see below |
+| `reverted` | the rename stopped it matching | investigate; usually a type clash with a shared header |
+
+`unresolved` covers several distinct reasons; the tool prints which, and they are not
+interchangeable:
+
+- `0x... names {ov000: ..., ov004: ...}` -- two overlays both define it. **Stop**; see
+  `overlay-ambiguous-references.md`.
+- `no reloc recorded at 0x...` -- the value is not a relocation at all (an immediate).
+- `no candidate of [...] defines 0x...` -- a gap in `symbols.txt`, not in the source.
+- `resolves to both X and Y` -- one name used for two different targets in one file;
+  split it by hand.
+- `unparsed module spec` -- a `module:` form the tool does not know; report it.
+
+Report-only mode additionally prints `resolvable` for anything it *would* rewrite, and
+`compile failed` / `function not in object` if it could not get that far.
+
+**Never pass `--allow-generic` to make a number go up.** It trades a wrong name for an
+anonymous one and hides the config gap that caused it.
+
+## 5. Verification, in order
+
+```sh
+python tools/eligible.py                                   # refresh the report
+python tools/enroll.py --complete-list build/eligible-names.txt
+python tools/rombuild.py                                   # the real gate
+python tools/prepush_attribution.py                        # credit must not move
+python tools/check_references.py                           # must not regress
+```
+
+The only line that matters in the build output:
+
+```
+module fidelity: 106/106 exact, 100.000000% of compared bytes
+ROM-build analysis: PASS
+```
+
+Anything less than **106/106 and PASS** means a reference now points somewhere wrong.
+That is the gate doing its job -- read the named function, do not retry blindly.
+
+## 6. Reporting: the evidence split is mandatory
+
+Two different strengths of evidence, and conflating them is the most common way these
+changes get oversold:
+
+- **enrolled** -> the ROM link compared the resolved symbol against the real ROM word
+- **byte-verified only** -> still blocked for another reason; byte matching is blind to
+  relocation targets, i.e. blind to precisely what you changed
+
+Count both and state both. Never write "0 reverted" as though it were proof.
+
+```sh
+python - <<'PY'
+import json, pathlib, subprocess, collections, sys
+sys.path.insert(0,"tools"); import eligible as E
+rs = {r["file"].replace("\\","/"): r["reason"] for r in E.load_report()[0]}
+ch = subprocess.run(["git","diff","--name-only","origin/main","--","src"],
+                    capture_output=True, text=True).stdout.split()
+c = collections.Counter("enrolled (link-verified)" if rs.get(f) is None
+                        else "byte-verified only" for f in ch)
+print(len(ch), "changed:", dict(c))
+PY
+```
+
+## 7. Shipping
+
+- Validator caps **200 in-scope files** across `src include config mods
+  attribution.json`. Enforced server-side, so nothing in-repo will warn you -- count
+  before pushing and split if over.
+- Cut every batch **from `main`**, never stacked on the previous one -- a PR diff is
+  measured against main, so stacking defeats the cap.
+- `config/**/delinks.txt` is generated. If it conflicts, regenerate -- take `main`'s
+  copy, then re-run `python tools/eligible.py && python tools/enroll.py
+  --complete-list build/eligible-names.txt`. Never hand-merge.
+- The pre-push hook runs `port_refcheck.py`. A rename in `src/` can strand a
+  hand-written bridge in `port/`, which nothing else catches.
+
+## 8. Definition of done
+
+- [ ] `ROM-build analysis: PASS`, module fidelity 106/106 exact
+- [ ] attribution 0 changed, 0 lost
+- [ ] `check_references.py` does not regress; run `--update` to bank progress
+- [ ] enrolled vs byte-only split stated in the PR body
+- [ ] in-scope file count under 200
+- [ ] no `--allow-generic`, no hand-edited delinks
+
+## 9. Known dead ends
+
+- **Renaming a member call.** `anim->SetAnim(...)` generates its mangled name from the
+  declaration; there is no token to rewrite. It needs the call rewritten to an
+  `extern "C"` mangled free call with scalar args -- the dominant pattern in the corpus,
+  though I have no exact count and any figure you see quoted for it is unverified. This
+  is the `not textual` bucket.
+- **169 references remain genuinely ambiguous.** Two overlays define the same address.
+  Tooling is finished; these need overlay-residency data or an emulator trace.
+- **`is_misnamed()` returns `True` unconditionally.** That is deliberate: the name is
+  never evidence, so there is nothing to gate on. Narrowing it is how this cost five
+  separate sweeps.

--- a/notes/runbook-type-reconstruction.md
+++ b/notes/runbook-type-reconstruction.md
@@ -1,0 +1,259 @@
+# Runbook: reconstructing types, and migrating a function to real C++
+
+**Audience:** an agent or contributor picking this up cold.
+**Scope:** turning observed offsets into named, typed members, then rewriting a
+function to use them.
+**Not in scope:** which symbol a call targets -- see `runbook-reference-repair.md`.
+
+---
+
+## 1. What is actually wrong
+
+The compiler erased types in 2004 and the ROM is its output. A register holding a
+`Vector3*` and one holding an `int` are bit-identical; `ldr r1,[r0]` does not care what
+`r0` "is". So the ROM records addresses, instructions and relocations -- and no types,
+no signedness, no struct layouts.
+
+Nothing in the build can object to a wrong type, because a wrong type usually emits
+identical instructions. That is why the tree currently holds **18,497 declarations for
+8,523 names, 27% of which contradict each other**. `ModelAnim::SetAnim` has 124
+distinct spellings; `ApproachLinear` has 104. Those were degrees of freedom the matcher
+was free to exploit, and nothing ever forced them to converge.
+
+**The build is correct; the description is not.** All 10,532 *enrolled* functions
+reproduce the ROM byte-for-byte (the tree matches more than it enrolls -- see the README
+for the matched total). The types are wrong as *documentation*, not as *machinery*. This
+runbook is about making the description true.
+
+## 2. The three properties of a field, and how they differ
+
+This distinction is the whole safety model:
+
+| property | where it comes from | changing it |
+|---|---|---|
+| **offset / width** | *observed* from the accesses matched code happens to make | trustworthy, **not** authoritative -- see below |
+| **name** | a human | **always free** -- cannot change codegen |
+| **type** | a human | **never assume safe; byte-verify every time** |
+
+### Equal width is necessary and NOT sufficient
+
+The tempting rule is "same width, safe". It is false under mwccarm at `-O4,p`, and
+measured on this toolchain:
+
+| change | effect |
+|---|---|
+| `s16` -> `u16`, plain load | `ldrsh` (`e1d000f0`) vs `ldrh` (`e1d000b0`) |
+| `s8` -> `u8`, plain load | `ldrsb` vs `ldrb` |
+| `s32` -> `u32`, compared | `movgt/movle` vs `movhi/movls` |
+| `s32` -> `u32`, `>>` | `asr` vs `lsr` |
+| `s32` -> `u32`, `/2` | sign-fixup add disappears; **function shrinks 16 -> 12 bytes** |
+
+**Signedness is part of the type at every sub-word load, comparison, right shift and
+division.** Genuinely inert changes: renaming a field, a typedef alias (`Fix12i` is
+`typedef s32`), 32-bit load/store with no arithmetic, and int-vs-pointer in a parameter.
+
+### "Observed" is not "correct"
+
+The generated width is the width of the access matched code happened to make, not the
+field's real width. In this very family, `include/FaderWipe.h` declares
+`u8 mFadeAmount; /* 0x004 */` where `include/FaderColor.h` declares
+`s32 unk_004; /* 0x004 */` -- the same inherited field. Treat generated offsets as
+strong evidence, then reconcile across the whole hierarchy.
+
+`include/BrickBlock.h` carries the banner of the generator that produced it. **Note
+that generator is no longer in the tree** -- `tools/gen_header.py` does not exist, so
+these headers cannot currently be regenerated and must be edited by hand:
+
+```c
+/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
+ * class BrickBlock: 5 matched functions, 7 evidenced fields.
+ * Offsets/widths are observed, not guessed. Gaps are explicit padding.
+ * Field NAMES are placeholders - renaming cannot change codegen. */
+```
+
+So `s32 unk_008` -> `Fix12i currInterp` is inert (`Fix12i` is a `typedef` of `s32`;
+renaming and aliasing change nothing). `u16 unk_00c` -> `int` is not: it changes
+truncation at every use. There is a real instance in the tree --
+`func_ov002_020f2aec` only matches with `int` as the last parameter of
+`_ZN3G2x13SetBlendAlphaEPVttttt`, and declaring it `u16` forces a truncation at the
+call site that grows the function `0x108 -> 0x110`. **The narrower declaration is the
+broken one**, which is the opposite of the intuition that narrowing is conservative.
+
+Rule: **rename freely, treat every retype as codegen-affecting, and byte-verify.**
+
+## 3. The ladder, with the tree's own before/after
+
+**Rung 0 -- generated skeleton** (`include/BrickBlock.h`, today):
+
+```c
+struct BrickBlock {
+    u8  pad_000[0x8];
+    s32 unk_008;            /* 0x008 */
+    u16 unk_00c;            /* 0x00c */
+    u8  pad_00e[0xc6];
+    ...
+};
+```
+
+**Rung 1 -- reconstructed header** (`include/Fader.h`, fields done, vtable NOT):
+
+```c
+/* currInterp=0x4 and speed=0x8, both 4 bytes.
+ * FIXED POINT. currInterp runs 0..0x1000 -- 0.0..1.0 in 20.12. SetToEnd writes
+ * 0x1000 and SetToStart writes 0; SetForwardTime derives speed as 1.0/frames,
+ * which is why AdvanceInterp picks its target from the sign of speed. */
+struct Fader {
+    Fix12i currInterp;  /* 0x04 -- current fade level, 0..0x1000 */
+    Fix12i speed;       /* 0x08 -- per-frame delta; sign selects the target */
+```
+
+Note what the comment carries: not just names but the *range*, the *encoding*, and
+*why* the code branches the way it does. That is the deliverable. A renamed field with
+no explanation is a smaller lie, not a truth.
+
+**Two warnings this exemplar carries, both worth copying and one worth not copying.**
+
+*Copy this:* the header spells the class twice. Under `#else` (the C side) it declares
+an explicit `void* vtable; /* 0x00 */`, because a C translation unit gets no implicit
+vptr. Migrate one function of a polymorphic class without that and every C-side
+includer's offsets shift by 4.
+
+*Do not copy this:* the vtable half of `Fader.h` is **known wrong**. Dumping the four
+fader vtables out of `extracted/arm9_dec.bin` shows 10 slots each with Fader's slots
+2-9 null -- an abstract base -- while the header declares 7 non-pure virtuals, and
+`FaderBrightness.h` declares three of the missing methods non-virtual. Fields
+reconstructed, hierarchy not. Treat "this header looks finished" as a hypothesis and
+check the ROM's own vtable before building on it.
+
+**Rung 2 -- unmigrated function** (`src/_ZN10BrickBlockD0Ev.c`, today):
+
+```c
+int *_ZN10BrickBlockD0Ev(int *t)
+{
+    t[0] = (int)_ZTV10BrickBlock;
+    _ZN5ActorD2Ev(t);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
+    return t;
+}
+```
+
+`this` is an `int*`, members are array indices, the symbol name is spelled by hand.
+
+**Rung 3 -- migrated function** (`src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp`, done):
+
+```c
+//cpp
+// @symbol _ZN5Fader13AdvanceInterpEv
+#include "Fader.h"
+
+extern "C" void _Z14ApproachLinearRiii(Fix12i* value, Fix12i target, Fix12i step);
+
+/* Step currInterp one frame toward its target. A positive speed fades toward
+   1.0, a negative one toward 0.0; the helper takes an unsigned step. */
+void Fader::AdvanceInterp()
+{
+    Fix12i step = speed;
+    Fix12i target = step >= 0 ? 0x1000 : 0;
+    if (step < 0)
+        step = -step;
+    _Z14ApproachLinearRiii(&currInterp, target, step);
+}
+```
+
+Real method, implicit `this`, named typed members. **The compiler now mangles the
+symbol for you** -- `Fader::AdvanceInterp()` becomes `_ZN5Fader13AdvanceInterpEv`
+without anyone spelling it.
+
+Note the honest leftover: the helper is still called by its raw mangled name. **Migration
+is per-reference, not only per-function.** That line becomes
+`ApproachLinear(currInterp, target, step)` only once `ApproachLinear` has a proper
+declaration.
+
+## 4. How the migration touches files
+
+Nothing merges and nothing accumulates. The binding is one line in a generated file:
+
+```
+src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp:
+    complete
+    .text start:0x020175e8 end:0x02017610
+```
+
+An **address range is bound to a path**. The file must emit that symbol with those
+bytes; its contents are otherwise unconstrained. So migration is an **in-place rewrite**
+of one file, optionally moved into a subdirectory. The old text is replaced, not kept --
+git history is the only copy. Consolidating the ~11,100 one-function files into real TUs
+was measured and declined (byte-safe, worth only 14-19%).
+
+Files touched by one function's migration:
+
+| file | change | risk |
+|---|---|---|
+| `include/<Class>.h` | rename/retype fields, add the method declaration | shared -- affects every includer |
+| `src/<mangled>.cpp` | rewrite body; rename `.c` -> `.cpp` if needed | isolated |
+| `config/**/delinks.txt` | only if the path changed | generated; regenerate, never hand-edit |
+| `attribution.json` | credit follows the file | a move plus a rewrite in one commit breaks lineage |
+
+**The header is the dangerous one.** Retyping a field changes codegen in *every* file
+that touches it, not just the one being migrated. Always re-verify the whole build, not
+the single function.
+
+**One rule with teeth:** a commit may *rewrite* a file or *move* it, never both.
+Attribution pairs same-commit delete+add by stem and cannot follow a file that changed
+in the same commit it moved.
+
+## 5. Procedure
+
+**Cold start:** `tools/mwccarm/**` and `extracted/**` are git-ignored, so a fresh clone
+has neither the compilers nor the ROM and step 1 fails immediately. See
+`notes/rom-build.md` before anything below.
+
+```sh
+git status --porcelain                       # clean
+python tools/eligible.py                     # baseline, ~5 min
+python tools/check_references.py --update    # bank the starting point
+```
+
+1. **Pick a class with several matched functions.** `gen_header.py` needs evidence;
+   a class with one function yields a header of padding.
+2. **Read the existing generated header.** `tools/gen_header.py` is gone, so there is
+   nothing to regenerate -- the committed skeleton is the evidence you have. Cross-check
+   its offsets against every sibling header in the hierarchy before trusting a width.
+3. **Name and type the fields.** Same width unless you intend a codegen change. Write
+   the *why* in a comment -- range, encoding, what selects each branch.
+4. **Migrate one function.** Rung 2 -> rung 3. Keep the `// @symbol` line.
+5. **Byte-verify that function**, then the whole build, because the header is shared:
+
+```sh
+# --addr and --size come from config/**/symbols.txt for that symbol
+python tools/match.py --c src/<file> --func <symbol> --addr 0x... --size 0x... --module <mod>
+python tools/rombuild.py
+python tools/rombuild.py
+```
+
+6. Repeat per function. Move to a subdirectory only in a **separate commit**.
+
+## 6. Definition of done
+
+- [ ] `ROM-build analysis: PASS`, module fidelity 106/106 exact
+- [ ] enrolled count did not fall (`check_references.py`)
+- [ ] attribution 0 changed, 0 lost
+- [ ] every retyped field is same-width, or the width change is deliberate and stated
+- [ ] each field comment says what the value *means*, not just its offset
+- [ ] no commit both moves and rewrites a file
+
+## 7. Known dead ends
+
+- **Do not declare a method whose mangled name carries a by-value class parameter**
+  (`5Fix12IiE`). mwccarm homes `r0-r3` to the stack for any by-value class parameter,
+  costing +0x14. `notes/mwccarm-codegen.md` 6az records two compiler versions; it was
+  re-measured in the session that wrote this runbook across **all 25 versions in
+  `match.SWEEP` and every optimization level** (`-O0`..`-O4`, `,p` and `,s`), plus
+  `-Cpp_exceptions off` / `-RTTI off`, with no combination avoiding it.
+  Callers are affected too: `take_i(h, 0x800)` emits `mov r1,#0x800` while the
+  `Fix12<int>` form emits `ldr` + `ldm`. Keep those as `extern "C"` free functions with
+  scalar args. See `notes/mwccarm-codegen.md` 6az.
+- **Never derive a signature from what callers say.** They disagree 27% of the time.
+  The definition is the only non-guess.
+- **Do not migrate before the types are right.** A real `struct` built on guessed member
+  types is a lie that every later file inherits.

--- a/port/hal/shims.cpp
+++ b/port/hal/shims.cpp
@@ -29,14 +29,11 @@ int Fader::IsAtEnd() { return 0; }
 // hardware upload.
 void FaderBrightness::AdvanceFade() { AdvanceInterp(); }
 
-// Fader::AdvanceInterp calls the 20.12 approach helper by its historical
-// name func_0203ae58 (extern "C", by-pointer). The function has since been
-// identified and renamed to ApproachLinear(int&, int, int) -- the NDS build
-// resolves the old name by address, the host cannot. Bridge, do not edit
-// src/: the fader TU keeps matching bytes, and when its extern is one day
-// modernised this shim dies loudly as a duplicate.
-int ApproachLinear(int &ref, int target, int step);
-extern "C" void func_0203ae58(int *value, int target, int step)
-{
-    ApproachLinear(*value, target, step);
-}
+// The func_0203ae58 bridge that used to live here is gone, on the terms its own
+// comment set out: it existed because Fader::AdvanceInterp called the 20.12
+// approach helper by its historical address-shaped name, which the NDS build
+// resolves by address and the host cannot. That extern has now been modernised
+// to _Z14ApproachLinearRiii -- the real ROM symbol at 0x0203ae58, defined by
+// src/_Z14ApproachLinearRiii.cpp -- which is exactly what a host C++ build emits
+// for ApproachLinear(int&, int, int). The name now resolves on both sides
+// without help, so bridging it would be a duplicate definition.

--- a/src/Entry.c
+++ b/src/Entry.c
@@ -3,17 +3,17 @@
 // mode stacks in DTCM, runs the autoload/segment initializers, clears DTCM/palette/OAM,
 // stores the interrupt-check word, then jumps to the game entry via bx with a hand-loaded
 // lr -- no C compiler emits msr/bx-with-pooled-lr, so there is no C to decompile it to.
-extern void func_020049f0(void);
+extern void _ZN4CP1511SystemSetupEv(void);
 extern void func_020048d8(void);
 extern void func_0200497c(void);
-extern void func_0205a47c(void);
+extern void MultiStore_Int(void);
 extern void func_01ffafd4(void);
 extern void func_02019780(void);
 extern void func_02072f94(void);
 asm void Entry(void) {
     mov     ip, #0x4000000
     str     ip, [ip, #0x208]
-    bl      func_020049f0
+    bl      _ZN4CP1511SystemSetupEv
     mov     r0, #0x13
     msr     cpsr_c, r0
     ldr     r0, =0x023c0000
@@ -37,15 +37,15 @@ asm void Entry(void) {
     mov     r0, #0
     ldr     r1, =0x023c0000
     mov     r2, #0x4000
-    bl      func_0205a47c
+    bl      MultiStore_Int
     mov     r0, #0
     ldr     r1, =0x5000000
     mov     r2, #0x400
-    bl      func_0205a47c
+    bl      MultiStore_Int
     mov     r0, #0x200
     ldr     r1, =0x7000000
     mov     r2, #0x400
-    bl      func_0205a47c
+    bl      MultiStore_Int
     ldr     r1, =0x023c0000
     add     r1, r1, #0x3fc0
     add     r1, r1, #0x3c

--- a/src/Ov004_Deallocate.c
+++ b/src/Ov004_Deallocate.c
@@ -1,2 +1,2 @@
-extern void func_02018144(void);
-void Ov004_Deallocate(void) { func_02018144(); }
+extern void Deallocate(void);
+void Ov004_Deallocate(void) { Deallocate(); }

--- a/src/_ZN13RacingPenguin8BehaviorEv.cpp
+++ b/src/_ZN13RacingPenguin8BehaviorEv.cpp
@@ -15,6 +15,6 @@ int RacingPenguin::Behavior()
     _ZN9Animation7AdvanceEv((char *)&mTextureSequence);
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
-    p__sinit_ov031_02111434(((char *)this));
+    func_ov019_021114ec(((char *)this));
     return 1;
 }

--- a/src/_ZN13RacingPenguin8BehaviorEv.cpp
+++ b/src/_ZN13RacingPenguin8BehaviorEv.cpp
@@ -15,6 +15,6 @@ int RacingPenguin::Behavior()
     _ZN9Animation7AdvanceEv((char *)&mTextureSequence);
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
-    func_ov019_021114ec(((char *)this));
+    p__sinit_ov031_02111434(((char *)this));
     return 1;
 }

--- a/src/_ZN18MovingCylinderClsnD1Ev.c
+++ b/src/_ZN18MovingCylinderClsnD1Ev.c
@@ -10,10 +10,10 @@ extern void* _ZTV18MovingCylinderClsn[];
  * Base dtor call target: 0x02015058
  */
 struct Obj { void *vtable; };
-extern void base_dtor_MovingCylinderClsn(struct Obj *thiz); /* 0x02015058 */
+extern void _ZN12CylinderClsnD2Ev(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN18MovingCylinderClsnD1Ev(struct Obj *thiz)
 {
     thiz->vtable = (void *)_ZTV18MovingCylinderClsn;
-    base_dtor_MovingCylinderClsn(thiz);
+    _ZN12CylinderClsnD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN18MovingCylinderClsnD2Ev.c
+++ b/src/_ZN18MovingCylinderClsnD2Ev.c
@@ -10,10 +10,10 @@ extern void* _ZTV18MovingCylinderClsn[];
  * Base dtor call target: 0x02015058
  */
 struct Obj { void *vtable; };
-extern void base_dtor_MovingCylinderClsn(struct Obj *thiz); /* 0x02015058 */
+extern void _ZN12CylinderClsnD2Ev(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN18MovingCylinderClsnD2Ev(struct Obj *thiz)
 {
     thiz->vtable = (void *)_ZTV18MovingCylinderClsn;
-    base_dtor_MovingCylinderClsn(thiz);
+    _ZN12CylinderClsnD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN18MovingMeshCollider10DetectClsnER11RaycastLine.c
+++ b/src/_ZN18MovingMeshCollider10DetectClsnER11RaycastLine.c
@@ -1,7 +1,7 @@
 extern int func_02039e48(void* a, void* b, void* c);
 extern int _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* o, void* a, void* b, void* c);
 extern int func_02035394(void* o, void* r);
-extern int func_01ffb0fc(void* o, void* p);
+extern int _ZN12MeshCollider10DetectClsnER11RaycastLine(void* o, void* p);
 extern int func_02039e30(void* o, void* a, void* b);
 extern void func_020375ec(int* d, int* s);
 extern int _ZN10ClsnResultaSERKS_(void* d, void* s);
@@ -20,7 +20,7 @@ int _ZN18MovingMeshCollider10DetectClsnER11RaycastLine(char* self, char* ray)
   _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(data_020a0d0c, sp0, sp0xc, 0);
   if (f50) *(unsigned char*)(data_020a0d0c + 0x50) = 1;
   func_02035394(data_020a0d0c, ray);
-  int r = func_01ffb0fc(self, data_020a0d0c);
+  int r = _ZN12MeshCollider10DetectClsnER11RaycastLine(self, data_020a0d0c);
   if (r) {
     int saved = *(int*)(data_020a0d0c + 0x60);
     func_02039e30(self, data_020a0d60, sp0x18);

--- a/src/_ZN18MovingMeshCollider10DetectClsnER13RaycastGround.c
+++ b/src/_ZN18MovingMeshCollider10DetectClsnER13RaycastGround.c
@@ -2,7 +2,7 @@ extern void func_020374b8(int* a, int* b);
 extern int func_02039e48(void* a, void* b, void* c);
 extern int _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* o, void* a, void* b, void* c);
 extern int func_02035394(void* o, void* r);
-extern int func_01ffb0fc(void* o, void* p);
+extern int _ZN12MeshCollider10DetectClsnER11RaycastLine(void* o, void* p);
 extern int func_02039e30(void* o, void* a, void* b);
 extern int _ZN10ClsnResultaSERKS_(void* d, void* s);
 extern char data_020a0d0c[];
@@ -30,7 +30,7 @@ int _ZN18MovingMeshCollider10DetectClsnER13RaycastGround(char* self, char* groun
   func_02039e48(self, sp0x24, sp0x18);
   _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(data_020a0d0c, sp0, sp0x18, 0);
   func_02035394(data_020a0d0c, ground);
-  int r = func_01ffb0fc(self, data_020a0d0c);
+  int r = _ZN12MeshCollider10DetectClsnER11RaycastLine(self, data_020a0d0c);
   if (r) {
     func_02039e30(self, data_020a0d60, sp0x30);
     _ZN10ClsnResultaSERKS_(ground + 0x10, data_020a0d1c);

--- a/src/_ZN21ExtendingMeshCollider10DetectClsnER11RaycastLine.c
+++ b/src/_ZN21ExtendingMeshCollider10DetectClsnER11RaycastLine.c
@@ -10,7 +10,7 @@ extern char data_020a0d1c[];
 extern void func_0203aa74(void* thiz, Vector3* v, Vector3* res);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* line, const Vector3* a, const Vector3* b, struct Actor* act);
 extern void func_02035394(void* line, void* arg);
-extern int func_01ffb0fc(void* thiz, void* line);
+extern int _ZN12MeshCollider10DetectClsnER11RaycastLine(void* thiz, void* line);
 extern void func_0203aa10(void* thiz, const Vector3* v, Vector3* res);
 extern void func_020375ec(int* d, int* s);
 extern void _ZN10ClsnResultaSERKS_(void* dst, const void* src);
@@ -25,7 +25,7 @@ int _ZN21ExtendingMeshCollider10DetectClsnER11RaycastLine(void* thiz, char* line
     if (saved != 0)
         *(char*)(data_020a0d0c + 0x50) = 1;
     func_02035394(data_020a0d0c, line);
-    int r = func_01ffb0fc(thiz, data_020a0d0c);
+    int r = _ZN12MeshCollider10DetectClsnER11RaycastLine(thiz, data_020a0d0c);
     if (r != 0)
     {
         int n = *(int*)(data_020a0d0c + 0x60);

--- a/src/_ZN25MovingCylinderClsnWithPosD1Ev.c
+++ b/src/_ZN25MovingCylinderClsnWithPosD1Ev.c
@@ -10,10 +10,10 @@ extern void* _ZTV25MovingCylinderClsnWithPos[];
  * Base dtor call target: 0x02014954
  */
 struct Obj { void *vtable; };
-extern void base_dtor_MovingCylinderClsnWithPos(struct Obj *thiz); /* 0x02014954 */
+extern void _ZN18MovingCylinderClsnD2Ev(struct Obj *thiz); /* 0x02014954 */
 struct Obj *_ZN25MovingCylinderClsnWithPosD1Ev(struct Obj *thiz)
 {
     thiz->vtable = (void *)_ZTV25MovingCylinderClsnWithPos;
-    base_dtor_MovingCylinderClsnWithPos(thiz);
+    _ZN18MovingCylinderClsnD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN3IRQ11Dma0HandlerEv.cpp
+++ b/src/_ZN3IRQ11Dma0HandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ11Dma0HandlerEv(void)
 {
-    func_02056cc0(0);
+    _ZN3IRQ13DmaTimHandlerEv(0);
 }

--- a/src/_ZN3IRQ11Dma1HandlerEv.cpp
+++ b/src/_ZN3IRQ11Dma1HandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ11Dma1HandlerEv(void)
 {
-    func_02056cc0(1);
+    _ZN3IRQ13DmaTimHandlerEv(1);
 }

--- a/src/_ZN3IRQ11Dma2HandlerEv.cpp
+++ b/src/_ZN3IRQ11Dma2HandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ11Dma2HandlerEv(void)
 {
-    func_02056cc0(2);
+    _ZN3IRQ13DmaTimHandlerEv(2);
 }

--- a/src/_ZN3IRQ11Dma3HandlerEv.cpp
+++ b/src/_ZN3IRQ11Dma3HandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ11Dma3HandlerEv(void)
 {
-    func_02056cc0(3);
+    _ZN3IRQ13DmaTimHandlerEv(3);
 }

--- a/src/_ZN3IRQ19Tim0OverflowHandlerEv.cpp
+++ b/src/_ZN3IRQ19Tim0OverflowHandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ19Tim0OverflowHandlerEv(void)
 {
-    func_02056cc0(4);
+    _ZN3IRQ13DmaTimHandlerEv(4);
 }

--- a/src/_ZN3IRQ19Tim1OverflowHandlerEv.cpp
+++ b/src/_ZN3IRQ19Tim1OverflowHandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ19Tim1OverflowHandlerEv(void)
 {
-    func_02056cc0(5);
+    _ZN3IRQ13DmaTimHandlerEv(5);
 }

--- a/src/_ZN3IRQ19Tim2OverflowHandlerEv.cpp
+++ b/src/_ZN3IRQ19Tim2OverflowHandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ19Tim2OverflowHandlerEv(void)
 {
-    func_02056cc0(6);
+    _ZN3IRQ13DmaTimHandlerEv(6);
 }

--- a/src/_ZN3IRQ19Tim3OverflowHandlerEv.cpp
+++ b/src/_ZN3IRQ19Tim3OverflowHandlerEv.cpp
@@ -1,6 +1,6 @@
 //cpp
-extern "C" void func_02056cc0(int irq);
+extern "C" void _ZN3IRQ13DmaTimHandlerEv(int irq);
 extern "C" void _ZN3IRQ19Tim3OverflowHandlerEv(void)
 {
-    func_02056cc0(7);
+    _ZN3IRQ13DmaTimHandlerEv(7);
 }

--- a/src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp
+++ b/src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp
@@ -3,7 +3,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Fader.h"
 
-extern "C" void func_0203ae58(Fix12i* value, Fix12i target, Fix12i step);
+extern "C" void _Z14ApproachLinearRiii(Fix12i* value, Fix12i target, Fix12i step);
 
 /* Step currInterp one frame toward its target. A positive speed fades toward
    1.0, a negative one toward 0.0; the helper takes an unsigned step. */
@@ -13,5 +13,5 @@ void Fader::AdvanceInterp()
     Fix12i target = step >= 0 ? 0x1000 : 0;
     if (step < 0)
         step = -step;
-    func_0203ae58(&currInterp, target, step);
+    _Z14ApproachLinearRiii(&currInterp, target, step);
 }

--- a/src/func_02009a8c.c
+++ b/src/func_02009a8c.c
@@ -1,8 +1,8 @@
-extern void func_0200cc5c(void);
+extern void _ZN6Camera25SaveCameraStateBeforeTalkEv(void);
 extern int func_02009d30(int arg);
 
 int func_02009a8c(int arg)
 {
-    func_0200cc5c();
+    _ZN6Camera25SaveCameraStateBeforeTalkEv();
     return func_02009d30(arg);
 }

--- a/src/func_02014f5c.c
+++ b/src/func_02014f5c.c
@@ -12,7 +12,7 @@ struct Player {
 };
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
-extern void func_020caf98(struct Player* player, struct Actor* actor);
+extern void func_ov002_020caf98(struct Player* player, struct Actor* actor);
 
 #define PLAYER_ACTOR_ID 0xbf
 
@@ -26,5 +26,5 @@ void func_02014f5c(struct Actor* self, u32 id) {
     isPlayer = (player->actorID == PLAYER_ACTOR_ID) ? 1 : 0;
     if (!isPlayer) return;
 
-    func_020caf98((struct Player*)player, self);
+    func_ov002_020caf98((struct Player*)player, self);
 }

--- a/src/func_02014f5c.c
+++ b/src/func_02014f5c.c
@@ -12,7 +12,7 @@ struct Player {
 };
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
-extern void func_ov002_020caf98(struct Player* player, struct Actor* actor);
+extern void func_020caf98(struct Player* player, struct Actor* actor);
 
 #define PLAYER_ACTOR_ID 0xbf
 
@@ -26,5 +26,5 @@ void func_02014f5c(struct Actor* self, u32 id) {
     isPlayer = (player->actorID == PLAYER_ACTOR_ID) ? 1 : 0;
     if (!isPlayer) return;
 
-    func_ov002_020caf98((struct Player*)player, self);
+    func_020caf98((struct Player*)player, self);
 }

--- a/src/func_0202ecfc.c
+++ b/src/func_0202ecfc.c
@@ -4,4 +4,4 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dWipe_c::SetToStart - recovered from vtable slot identity */
-void func_0202ecfc(void *t) { func_02017610(t); }
+void func_0202ecfc(void *t) { _ZN15FaderBrightness10SetToStartEv(t); }

--- a/src/func_0204dab4.c
+++ b/src/func_0204dab4.c
@@ -23,7 +23,7 @@ struct Entry {
     Node *node;
 };
 
-extern int func_02052f4c(int a, int b);
+extern int _ZN4cstd3divEii(int a, int b);
 extern void func_0204dcc0(int *src, Entry *entry, short *value, int *out);
 
 void func_0204dab4(void *sys, Entry *buf, int count, unsigned int mask, void *cb)
@@ -76,7 +76,7 @@ void func_0204dab4(void *sys, Entry *buf, int count, unsigned int mask, void *cb
             int scale;
 
             scale = 0x1000 -
-                func_02052f4c((int)walk->f2e << 12, walk->f2c);
+                _ZN4cstd3divEii((int)walk->f2e << 12, walk->f2c);
 
             sp[1] = walk->f14 + walk->f8;
             sp[2] = walk->f18 + walk->fc;

--- a/src/func_02051064.c
+++ b/src/func_02051064.c
@@ -1,6 +1,6 @@
-extern int func_0204df20(int a, int b);
+extern int _ZN18NestedHeapIteratorC1Ej(int a, int b);
 
 int func_02051064(int a)
 {
-    return func_0204df20(a, 0);
+    return _ZN18NestedHeapIteratorC1Ej(a, 0);
 }

--- a/src/func_02054430.c
+++ b/src/func_02054430.c
@@ -1,8 +1,8 @@
-extern int func_02054c80(int arg, unsigned short *p);
+extern int Vram__Map(int arg, unsigned short *p);
 
 int func_02054430(int arg)
 {
     unsigned short *p = (unsigned short *)0x020a6088;
     *p |= arg;
-    return func_02054c80(arg, p);
+    return Vram__Map(arg, p);
 }

--- a/src/func_0205cd5c.c
+++ b/src/func_0205cd5c.c
@@ -11,9 +11,9 @@ struct T {
 extern void func_0205c788(void *p, int arg);
 extern int func_0205d044(void *self);
 extern void func_0205cfa4(int x);
-extern u32 func_02059d1c(void);
+extern u32 _ZN3IRQ7DisableEv(void);
 extern void OS_WakeupThread(u16 *p);
-extern void func_02059d30(u32 f);
+extern void _ZN3IRQ7RestoreEj(u32 f);
 
 void func_0205cd5c(struct T *self, int arg)
 {
@@ -38,12 +38,12 @@ void func_0205cd5c(struct T *self, int arg)
     }
     {
         char *p = self->th;
-        u32 irq = func_02059d1c();
+        u32 irq = _ZN3IRQ7DisableEv();
         u32 *f = (u32 *)(((int)self + 0x10));
 
         *(int *)(p + 0x14) = arg;
         *f = *f & ~0x200;
         OS_WakeupThread(&self->pending);
-        func_02059d30(irq);
+        _ZN3IRQ7RestoreEj(irq);
     }
 }

--- a/src/func_0206a600.c
+++ b/src/func_0206a600.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern u32 func_0205b988(u32 a, u32 b, u32 c);
+extern u32 IPCSend(u32 a, u32 b, u32 c);
 extern void Crash(void);
 
 void func_0206a600(void) {
@@ -8,7 +8,7 @@ void func_0206a600(void) {
     u32 r4 = 0;
     u32 r0;
     do {
-        r0 = func_0205b988(r6, r5, r4);
+        r0 = IPCSend(r6, r5, r4);
     } while (r0 != 0);
     Crash();
 }

--- a/src/func_02072168.c
+++ b/src/func_02072168.c
@@ -31,7 +31,7 @@ extern void func_020731fc(void);
 extern void func_02071864(char *c, char *s);
 extern unsigned char *ReadSignedVarInt(unsigned char *p, int *out);
 extern unsigned char *func_02071a50(unsigned char *p, int *out);
-extern int func_01ffadf0(int a, int b);
+extern int __aeabi_uidiv(int a, int b);
 
 void func_02072168(char *c, char *s, char *end) {
     int saved = 0;
@@ -408,7 +408,7 @@ void func_02072168(char *c, char *s, char *end) {
                 else
                     b = *(int *)(*(char **)(c + 0x18) + v1);
                 a += b;
-                n = func_01ffadf0(b, v2);
+                n = __aeabi_uidiv(b, v2);
                 if (n != 0) {
                     do {
                         a -= v2;

--- a/src/func_ov002_020c06fc.c
+++ b/src/func_ov002_020c06fc.c
@@ -7,13 +7,13 @@ extern int func_ov002_020c031c(void *c);
 extern int func_ov002_020f030c(unsigned int sel);
 extern int func_ov002_020f02c8(unsigned int sel);
 extern int func_ov002_020f035c(unsigned int sel, int r1);
-extern int func_0203cf78(void *v);
-extern int func_0203b4dc(int x, int z);
-extern int func_0203b0e8(int a, int b);
-extern void func_020377b0(void *ray);
-extern void func_02037670(void *ray, void *a, void *b, void *actor);
-extern int func_02038638(void *ray);
-extern void func_02037764(void *ray);
+extern int Vec3_HorzLen(void *v);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int x, int z);
+extern int AngleDiff(int a, int b);
+extern void _ZN11RaycastLineC1Ev(void *ray);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void *ray, void *a, void *b, void *actor);
+extern int _ZN11RaycastLine10DetectClsnEv(void *ray);
+extern void _ZN11RaycastLineD1Ev(void *ray);
 extern void ApproachAngle(short *cur, short target, int divisor, int band, int maxStep);
 
 extern unsigned char data_020a0e40;
@@ -89,15 +89,15 @@ int func_ov002_020c06fc(char *c, int arg)
     f.v0.x = FX(v, (int)data_02082214[(*(u16 *)(c + 0x69a) >> 4) * 2]);
     f.v0.z = FX(v, (int)data_02082214[(*(u16 *)(c + 0x69a) >> 4) * 2 + 1]);
     {
-        int len = func_0203cf78(c + 0x554);
+        int len = Vec3_HorzLen(c + 0x554);
         f.v0.x = FX(f.v0.x, len);
         f.v0.z = FX(f.v0.z, len);
     }
 
     if ((*(u8 *)(c + 0x6e9) & 2) != 0 && (u16)(*(u16 *)(c + 0x6ce) & 1) == 0
         && *(int *)(c + 0x98) <= 0x10000) {
-        int r6b = func_0203b4dc(f.v0.x, f.v0.z);
-        func_020377b0(f.ray);
+        int r6b = _ZN4cstd5atan2E5Fix12IiES1_(f.v0.x, f.v0.z);
+        _ZN11RaycastLineC1Ev(f.ray);
         {
             int tz, ty, tx;
             int p5c = *(int *)(c + 0x5c);
@@ -112,12 +112,12 @@ int func_ov002_020c06fc(char *c, int arg)
             ty = *(int *)(c + 0x60) + 0x32000;
             f.v2.x = tx; f.v2.y = ty; f.v2.z = tz;
         }
-        func_02037670(f.ray, &f.v1, &f.v2, c);
-        if (func_02038638(f.ray) != 0) {
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(f.ray, &f.v1, &f.v2, c);
+        if (_ZN11RaycastLine10DetectClsnEv(f.ray) != 0) {
             f.v0.x = 0;
             f.v0.z = 0;
         }
-        func_02037764(f.ray);
+        _ZN11RaycastLineD1Ev(f.ray);
     }
 
     {
@@ -127,15 +127,15 @@ int func_ov002_020c06fc(char *c, int arg)
         int fz = FX(s2, t);
         f.v3.x = fx;
         f.v3.z = fz;
-        ang = func_0203b4dc(fx, fz);
+        ang = _ZN4cstd5atan2E5Fix12IiES1_(fx, fz);
     }
-    *(int *)(c + 0x98) = func_0203cf78(&f.v3);
+    *(int *)(c + 0x98) = Vec3_HorzLen(&f.v3);
     if (*(int *)(c + 0x98) > 0x64000)
         *(int *)(c + 0x98) = 0x64000;
     *(s16 *)(c + 0x94) = (s16)(ang + *(s16 *)(c + 0x69c));
     {
         s16 cur = *(s16 *)(c + 0x94);
-        if (func_0203b0e8(cur, *(s16 *)(c + 0x8e)) >= 0x4000)
+        if (AngleDiff(cur, *(s16 *)(c + 0x8e)) >= 0x4000)
             cur = (s16)(*(s16 *)(c + 0x94) + 0x8000);
         ApproachAngle((s16 *)(c + 0x8e), cur, 8, 0x4000, 0x10);
     }

--- a/src/func_ov002_020d91b8.c
+++ b/src/func_ov002_020d91b8.c
@@ -1,6 +1,6 @@
 extern int data_ov002_020ff120[];
-extern void func_02012154(int a, int b, void *c);
+extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(int a, int b, void *c);
 
 void func_ov002_020d91b8(unsigned char *self, int a) {
-    func_02012154(self[0x6d9], data_ov002_020ff120[a & 1], self + 0x74);
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(self[0x6d9], data_ov002_020ff120[a & 1], self + 0x74);
 }

--- a/src/func_ov004_020adc68.c
+++ b/src/func_ov004_020adc68.c
@@ -1,2 +1,2 @@
-extern void func_0201816c(void);
-void func_ov004_020adc68(void) { func_0201816c(); }
+extern void LoadFile(void);
+void func_ov004_020adc68(void) { LoadFile(); }

--- a/src/func_ov004_020b2980.c
+++ b/src/func_ov004_020b2980.c
@@ -1,2 +1,2 @@
-extern void func_0202e78c(void);
-void func_ov004_020b2980(void) { func_0202e78c(); }
+extern void _ZN2GX15DisableAllBanksEv(void);
+void func_ov004_020b2980(void) { _ZN2GX15DisableAllBanksEv(); }

--- a/src/func_ov006_020c3bc8.c
+++ b/src/func_ov006_020c3bc8.c
@@ -1,4 +1,4 @@
-extern void func_020c3adc(void *);
+extern void func_ov006_020c3adc(void *);
 void func_ov006_020c3bc8(void *a)
 {
   int i = 0;
@@ -8,5 +8,5 @@ void func_ov006_020c3bc8(void *a)
     *((int *) (p + 0x48)) = 0;
     p += 0x98;
   }
-  func_020c3adc(a);
+  func_ov006_020c3adc(a);
 }

--- a/src/func_ov006_020c3bc8.c
+++ b/src/func_ov006_020c3bc8.c
@@ -1,4 +1,4 @@
-extern void func_ov006_020c3adc(void *);
+extern void func_020c3adc(void *);
 void func_ov006_020c3bc8(void *a)
 {
   int i = 0;
@@ -8,5 +8,5 @@ void func_ov006_020c3bc8(void *a)
     *((int *) (p + 0x48)) = 0;
     p += 0x98;
   }
-  func_ov006_020c3adc(a);
+  func_020c3adc(a);
 }

--- a/src/func_ov006_020c7c68.c
+++ b/src/func_ov006_020c7c68.c
@@ -7,7 +7,7 @@ extern void func_ov006_020c8270(char *c);
 extern void func_ov006_020c7ba4(char *c);
 extern void func_ov006_020c79a8(char *c);
 extern void func_ov006_020c85a0(char *c);
-extern void func_ov006_020e6df0(int a0, int a1, int a2);
+extern void Sound_PlayBank1Panned(int a0, int a1, int a2);
 extern void func_02012718(int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisPtr, void *file, int i, int fx, unsigned int flags);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
@@ -79,7 +79,7 @@ void func_ov006_020c7c68(char *c)
                     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xed, *(int *)(c + 0x14) << 3, *(int *)(c + 0x18) << 3, *(int *)(c + 0x1c) << 3);
                     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xee, v[0] << 3, v[1] << 3, v[2] << 3);
                     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xef, v[0] << 3, v[1] << 3, v[2] << 3);
-                    func_ov006_020e6df0(0, *(int *)(c + 0x44), *(int *)(c + 0x14));
+                    Sound_PlayBank1Panned(0, *(int *)(c + 0x44), *(int *)(c + 0x14));
                     func_02012718(0x1c6, *(s16 *)(c + 0x36) << 12);
                     func_ov006_020c85a0(c);
                 }
@@ -100,7 +100,7 @@ void func_ov006_020c7c68(char *c)
                 *(int *)(c + 0x44) = 2;
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x4c, *(void **)data_ov006_0213b098[*(int *)(c + 0x44)], 0x40000000, 0x800, 0);
                 *(int *)(c + 0xa4) = 0;
-                func_ov006_020e6df0(0, *(int *)(c + 0x44), *(int *)(c + 0x14));
+                Sound_PlayBank1Panned(0, *(int *)(c + 0x44), *(int *)(c + 0x14));
             }
         } else if (pos > 0x6c000 && *(int *)(c + 0x20) > 0) {
             *(int *)(c + 0x20) = -(int)(((s64)*(int *)(c + 0x20) * 0xd00 + 0x800) >> 12);
@@ -108,7 +108,7 @@ void func_ov006_020c7c68(char *c)
                 *(int *)(c + 0x44) = 2;
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x4c, *(void **)data_ov006_0213b098[*(int *)(c + 0x44)], 0x40000000, 0x800, 0);
                 *(int *)(c + 0xa4) = 0;
-                func_ov006_020e6df0(0, *(int *)(c + 0x44), *(int *)(c + 0x14));
+                Sound_PlayBank1Panned(0, *(int *)(c + 0x44), *(int *)(c + 0x14));
             }
         }
     }

--- a/src/func_ov006_020c94e0.cpp
+++ b/src/func_ov006_020c94e0.cpp
@@ -11,7 +11,7 @@ int _ZN4cstd4fdivEii(int a, int b);
 void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int fx1, int fx2, int fx3, const void *vec, void *cb);
 void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisPtr, void *file, int i, int fix, unsigned int flags);
-void func_ov006_020e6df0(int a0, int a1, int a2);
+void Sound_PlayBank1Panned(int a0, int a1, int a2);
 int func_ov006_020e6e3c(int a, int b);
 void func_ov006_020c91ac(char *c);
 }
@@ -99,7 +99,7 @@ extern "C" void func_ov006_020c94e0(char *c)
     *(int *)(c + 0x64) = 0;
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void *)(c + 0x78), data_ov006_0214059c, 0x40000000, 0x800, 0);
     *(int *)(c + 0xd0) = 0;
-    func_ov006_020e6df0(0, 4, *(int *)(c + 0x24));
+    Sound_PlayBank1Panned(0, 4, *(int *)(c + 0x24));
     func_ov006_020e6e3c(0x1b5, *(int *)(c + 0x24));
     *(int *)(c + 0x68) = 0;
     {

--- a/src/func_ov006_020d5e1c.c
+++ b/src/func_ov006_020d5e1c.c
@@ -1,6 +1,6 @@
-extern void func_02012754(int);
+extern void _ZN5Sound12PlayBank2_2DEj(int);
 void func_ov006_020d5e1c(void *a)
 {
   *(((unsigned char *) a) + 0x62ac) = 3;
-  func_02012754(0x1e3);
+  _ZN5Sound12PlayBank2_2DEj(0x1e3);
 }

--- a/src/func_ov006_020d5e3c.c
+++ b/src/func_ov006_020d5e3c.c
@@ -1,6 +1,6 @@
-extern void func_02012754(int);
+extern void _ZN5Sound12PlayBank2_2DEj(int);
 void func_ov006_020d5e3c(void *a)
 {
   *(((unsigned char *) a) + 0x62ac) = 1;
-  func_02012754(0x1e2);
+  _ZN5Sound12PlayBank2_2DEj(0x1e2);
 }

--- a/src/func_ov006_020de584.c
+++ b/src/func_ov006_020de584.c
@@ -1,4 +1,4 @@
-extern void func_020ddd6c(void *);
+extern void func_ov006_020ddd6c(void *);
 void func_ov006_020de584(void *a)
 {
   char *p = (char *) a;
@@ -8,5 +8,5 @@ void func_ov006_020de584(void *a)
     *((unsigned char *) (p + 0xc4)) = 1;
     *((short *) (p + 0xc0)) = 0;
   }
-  func_020ddd6c(a);
+  func_ov006_020ddd6c(a);
 }

--- a/src/func_ov006_020de584.c
+++ b/src/func_ov006_020de584.c
@@ -1,4 +1,4 @@
-extern void func_ov006_020ddd6c(void *);
+extern void func_020ddd6c(void *);
 void func_ov006_020de584(void *a)
 {
   char *p = (char *) a;
@@ -8,5 +8,5 @@ void func_ov006_020de584(void *a)
     *((unsigned char *) (p + 0xc4)) = 1;
     *((short *) (p + 0xc0)) = 0;
   }
-  func_ov006_020ddd6c(a);
+  func_020ddd6c(a);
 }

--- a/src/func_ov006_020ecb80.c
+++ b/src/func_ov006_020ecb80.c
@@ -1,6 +1,6 @@
-extern void func_0203adec(short *, short, int);
+extern void _Z14ApproachLinearRsss(short *, short, int);
 void func_ov006_020ecb80(void *a)
 {
   char *p = (char *) a;
-  func_0203adec((short *) (p + 0x7a), (short) ((*((short *) (p + 0x76))) - 0x2000), 0x100);
+  _Z14ApproachLinearRsss((short *) (p + 0x7a), (short) ((*((short *) (p + 0x76))) - 0x2000), 0x100);
 }

--- a/src/func_ov006_020fb97c.c
+++ b/src/func_ov006_020fb97c.c
@@ -1,5 +1,5 @@
 extern unsigned _ZN3G2S13GetBG2CharPtrEv(void);
-extern void func_0205a448(unsigned short val, void* dst, int nbytes);
+extern void MultiStore16(unsigned short val, void* dst, int nbytes);
 extern void func_ov006_020fe1a8(char* p);
 extern void func_ov006_020fc1b4(char* base, int val);
 
@@ -23,7 +23,7 @@ void func_ov006_020fb97c(char* c){
   {
     unsigned r = _ZN3G2S13GetBG2CharPtrEv();
     sp = 0;
-    func_0205a448(sp, (void*)r, 0x6000);
+    MultiStore16(sp, (void*)r, 0x6000);
   }
   *(unsigned char*)(c + 0x5c30) = 0;
   func_ov006_020fe1a8(c);

--- a/src/func_ov006_02121778.c
+++ b/src/func_ov006_02121778.c
@@ -2,7 +2,7 @@ extern unsigned char data_020a0e40[];
 extern unsigned char data_020a0de8[];
 extern unsigned char data_020a0de9[];
 extern int func_02054d88(void);
-extern void func_0205a448(unsigned short a, int b, int c);
+extern void MultiStore16(unsigned short a, int b, int c);
 extern int data_ov006_0213faa8[];
 
 void func_ov006_02121778(char *c)
@@ -23,7 +23,7 @@ void func_ov006_02121778(char *c)
         volatile unsigned short h;
         r = func_02054d88();
         h = 0;
-        func_0205a448(h, r, 0x6000);
+        MultiStore16(h, r, 0x6000);
     }
     *(short *)(c + 0x5dc2) = 1;
     {

--- a/src/func_ov006_02123b24.c
+++ b/src/func_ov006_02123b24.c
@@ -2,7 +2,7 @@ extern unsigned char data_020a0e40[];
 extern unsigned char data_020a0de8[];
 extern unsigned char data_020a0de9[];
 extern int func_02054d88(void);
-extern void func_0205a448(unsigned short a, int b, int c);
+extern void MultiStore16(unsigned short a, int b, int c);
 extern int data_ov006_0213fbd0[];
 
 void func_ov006_02123b24(char *c)
@@ -23,7 +23,7 @@ void func_ov006_02123b24(char *c)
         volatile unsigned short h;
         r = func_02054d88();
         h = 0;
-        func_0205a448(h, r, 0x6000);
+        MultiStore16(h, r, 0x6000);
     }
     *(short *)(c + 0x7ba8) = 1;
     {

--- a/src/func_ov006_0212ac74.c
+++ b/src/func_ov006_0212ac74.c
@@ -77,7 +77,7 @@ int func_ov006_0212ac74(char *c)
                     *(u8 *)(c + i * 0x20 + 0x4f3b) = 1;
                 }
                 self->unk_5fd8 = 0;
-                func_02012754(0x10d);
+                _ZN5Sound12PlayBank2_2DEj(0x10d);
                 FreeGfxSlotsById(0x1d);
             }
         } else if (self->unk_5fc8 < 0) {
@@ -97,7 +97,7 @@ int func_ov006_0212ac74(char *c)
                         Vec2_Sub(&d1, q, (V2 *)(c + 0x5fb8));
                         v = Vec2_Len(&d1) < 0x18000 ? 1 : 0;
                         if (v != 0) {
-                            func_02012754(0x109);
+                            _ZN5Sound12PlayBank2_2DEj(0x109);
                             *(u8 *)(c + ii * 0x20 + 0x4f3a) = 1;
                             *(int *)(c + ii * 0x20 + 0x4f44) = 0;
                             *(int *)(c + ii * 0x20 + 0x4f48) = 0;
@@ -164,7 +164,7 @@ int func_ov006_0212ac74(char *c)
                         FreeGfxSlotsById(0x1d);
                         func_ov004_020b0cac(0x13, 0x80, 0x18, 0, -1, 0xd);
                         self->unk_5fec = 3;
-                        func_02012754(0x104);
+                        _ZN5Sound12PlayBank2_2DEj(0x104);
                     }
                 } else {
                     self->unk_5fcc = 1;
@@ -172,7 +172,7 @@ int func_ov006_0212ac74(char *c)
                         FreeGfxSlotsById(0x1d);
                         func_ov004_020b0cac(0x10, 0x80, 0x18, 0, -1, 0xd);
                         self->unk_5fec = 1;
-                        func_02012754(0x103);
+                        _ZN5Sound12PlayBank2_2DEj(0x103);
                     }
                 }
                 self->unk_5fd0 = 0x3c;
@@ -195,7 +195,7 @@ int func_ov006_0212ac74(char *c)
                 FreeGfxSlotsById(0x1d);
                 if (self->unk_5fe4 > 0x14) {
                     if (self->unk_5fcd == 1) {
-                        func_02012754(0x106);
+                        _ZN5Sound12PlayBank2_2DEj(0x106);
                         self->unk_5fec = 4;
                         self->unk_5fd4 = 0x3c;
                     }
@@ -206,13 +206,13 @@ int func_ov006_0212ac74(char *c)
                     self->unk_5fe0 = 0;
                     if (self->unk_5fdc >= 3) {
                         func_ov004_020b0cac(0x12, 0x80, 0x18, 0, -1, 0xd);
-                        func_02012754(0x107);
+                        _ZN5Sound12PlayBank2_2DEj(0x107);
                         *(int *)LA(c + 0x5ff0) += 3;
                         if (self->unk_5ff0 > 0x270f)
                             self->unk_5ff0 = 0x270f;
                     } else {
                         func_ov004_020b0cac(0x10, 0x80, 0x18, 0, -1, 0xd);
-                        func_02012754(0x108);
+                        _ZN5Sound12PlayBank2_2DEj(0x108);
                         *(int *)LA(c + 0x5ff0) += 1;
                         if (self->unk_5ff0 > 0x270f)
                             self->unk_5ff0 = 0x270f;
@@ -223,10 +223,10 @@ int func_ov006_0212ac74(char *c)
                     self->unk_5fdc = 0;
                     if (self->unk_5fe0 >= 3) {
                         func_ov004_020b0cac(0x11, 0x80, 0x18, 0, -1, 0xd);
-                        func_02012754(0x105);
+                        _ZN5Sound12PlayBank2_2DEj(0x105);
                     } else {
                         func_ov004_020b0cac(0x13, 0x80, 0x18, 0, -1, 0xd);
-                        func_02012754(0x106);
+                        _ZN5Sound12PlayBank2_2DEj(0x106);
                     }
                 }
                 self->unk_5fd4 = 0x3c;

--- a/src/func_ov007_020bcf90.c
+++ b/src/func_ov007_020bcf90.c
@@ -18,25 +18,25 @@ struct Obj
   int m114[24];
 };
 extern struct Obj *data_ov007_0210342c;
-extern void func_020c93b4(int a);
+extern void func_ov007_020c93b4(int a);
 extern void func_020557b4(void);
 extern void func_02055624(void);
-extern void func_02055574(int a, int b, int c, int d, int e);
-extern void func_020b2160(int a);
-extern void func_020b8fd4(int a);
-extern void func_020b413c(int a, int b);
-extern void func_020b2728(void);
-extern int func_020b7a34(void);
-extern void func_020b7a00(void);
-extern void func_020b4464(int a, int b);
-extern void func_020b2cf0(void);
-extern void func_020c2390(int a);
-extern void func_020c232c(int a);
-extern void func_020b91b4(void);
-extern void func_020bee14(void);
-extern void func_020b7658(int a, int b);
-extern void func_020b2370(void);
-extern void func_020bfaf0(int a);
+extern void _ZN3G3X13SetClearColorEtiiib(int a, int b, int c, int d, int e);
+extern void func_ov007_020b2160(int a);
+extern void func_ov007_020b8fd4(int a);
+extern void func_ov007_020b413c(int a, int b);
+extern void func_ov007_020b2728(void);
+extern int func_ov007_020b7a34(void);
+extern void func_ov007_020b7a00(void);
+extern void func_ov007_020b4464(int a, int b);
+extern void func_ov007_020b2cf0(void);
+extern void func_ov007_020c2390(int a);
+extern void func_ov007_020c232c(int a);
+extern void func_ov007_020b91b4(void);
+extern void func_ov007_020bee14(void);
+extern void func_ov007_020b7658(int a, int b);
+extern void func_ov007_020b2370(void);
+extern void func_ov007_020bfaf0(int a);
 void func_ov007_020bcf90(void)
 {
   s16 *pA;
@@ -50,11 +50,11 @@ void func_ov007_020bcf90(void)
   {
     r4 = 0;
   }
-  func_020c93b4(data_ov007_0210342c->m44);
+  func_ov007_020c93b4(data_ov007_0210342c->m44);
   func_020557b4();
   func_02055624();
-  func_02055574(0x7fff, 0, 0x7fff, 0x3f, 1);
-  func_020b2160(1);
+  _ZN3G3X13SetClearColorEtiiib(0x7fff, 0, 0x7fff, 0x3f, 1);
+  func_ov007_020b2160(1);
   switch (*pA)
   {
     case 0:
@@ -63,7 +63,7 @@ void func_ov007_020bcf90(void)
     case 1:
       if ((*pB) == 2)
     {
-      func_020b8fd4(data_ov007_0210342c->m34);
+      func_ov007_020b8fd4(data_ov007_0210342c->m34);
     }
       break;
 
@@ -72,14 +72,14 @@ void func_ov007_020bcf90(void)
     case 3:
 
     case 4:
-      func_020b8fd4(data_ov007_0210342c->m34);
+      func_ov007_020b8fd4(data_ov007_0210342c->m34);
       break;
 
     case 5:
       for (i = 0xe; i <= 0x10; i++)
     {
       s16 *mp = &data_ov007_0210342c->m28[i - 0xe];
-      func_020b413c(data_ov007_0210342c->m114[i], mp[2]);
+      func_ov007_020b413c(data_ov007_0210342c->m114[i], mp[2]);
     }
 
       break;
@@ -91,32 +91,32 @@ void func_ov007_020bcf90(void)
 
   if (r4 != 0)
   {
-    func_020b2728();
+    func_ov007_020b2728();
   }
-  if (func_020b7a34() != 0)
+  if (func_ov007_020b7a34() != 0)
   {
-    func_020b7a00();
+    func_ov007_020b7a00();
   }
   for (j = 0; j < 0x18; j++)
   {
-    func_020b4464(data_ov007_0210342c->m114[j], data_ov007_0210342c->m34);
+    func_ov007_020b4464(data_ov007_0210342c->m114[j], data_ov007_0210342c->m34);
   }
 
-  func_020b2cf0();
-  func_020b2160(0);
-  func_020c2390(data_ov007_0210342c->m38);
-  func_020c232c(data_ov007_0210342c->m38);
+  func_ov007_020b2cf0();
+  func_ov007_020b2160(0);
+  func_ov007_020c2390(data_ov007_0210342c->m38);
+  func_ov007_020c232c(data_ov007_0210342c->m38);
   switch (*pA)
   {
     case 0:
-      func_020c2390(data_ov007_0210342c->m3c);
-      func_020c232c(data_ov007_0210342c->m3c);
+      func_ov007_020c2390(data_ov007_0210342c->m3c);
+      func_ov007_020c232c(data_ov007_0210342c->m3c);
       break;
 
     case 1:
       if ((*pB) == 2)
     {
-      func_020b91b4();
+      func_ov007_020b91b4();
     }
       break;
 
@@ -125,11 +125,11 @@ void func_ov007_020bcf90(void)
     case 3:
 
     case 4:
-      func_020b91b4();
+      func_ov007_020b91b4();
       break;
 
     case 5:
-      func_020bee14();
+      func_ov007_020bee14();
       break;
 
     case 6:
@@ -137,10 +137,10 @@ void func_ov007_020bcf90(void)
 
   }
 
-  func_020b7658(data_ov007_0210342c->m30 + 0x44, 1);
+  func_ov007_020b7658(data_ov007_0210342c->m30 + 0x44, 1);
   if (r4 != 0)
   {
-    func_020b2370();
+    func_ov007_020b2370();
   }
-  func_020bfaf0(data_ov007_0210342c->m30);
+  func_ov007_020bfaf0(data_ov007_0210342c->m30);
 }

--- a/src/func_ov007_020bcf90.c
+++ b/src/func_ov007_020bcf90.c
@@ -18,25 +18,25 @@ struct Obj
   int m114[24];
 };
 extern struct Obj *data_ov007_0210342c;
-extern void func_ov007_020c93b4(int a);
+extern void func_020c93b4(int a);
 extern void func_020557b4(void);
 extern void func_02055624(void);
-extern void _ZN3G3X13SetClearColorEtiiib(int a, int b, int c, int d, int e);
-extern void func_ov007_020b2160(int a);
-extern void func_ov007_020b8fd4(int a);
-extern void func_ov007_020b413c(int a, int b);
-extern void func_ov007_020b2728(void);
-extern int func_ov007_020b7a34(void);
-extern void func_ov007_020b7a00(void);
-extern void func_ov007_020b4464(int a, int b);
-extern void func_ov007_020b2cf0(void);
-extern void func_ov007_020c2390(int a);
-extern void func_ov007_020c232c(int a);
-extern void func_ov007_020b91b4(void);
-extern void func_ov007_020bee14(void);
-extern void func_ov007_020b7658(int a, int b);
-extern void func_ov007_020b2370(void);
-extern void func_ov007_020bfaf0(int a);
+extern void func_02055574(int a, int b, int c, int d, int e);
+extern void func_020b2160(int a);
+extern void func_020b8fd4(int a);
+extern void func_020b413c(int a, int b);
+extern void func_020b2728(void);
+extern int func_020b7a34(void);
+extern void func_020b7a00(void);
+extern void func_020b4464(int a, int b);
+extern void func_020b2cf0(void);
+extern void func_020c2390(int a);
+extern void func_020c232c(int a);
+extern void func_020b91b4(void);
+extern void func_020bee14(void);
+extern void func_020b7658(int a, int b);
+extern void func_020b2370(void);
+extern void func_020bfaf0(int a);
 void func_ov007_020bcf90(void)
 {
   s16 *pA;
@@ -50,11 +50,11 @@ void func_ov007_020bcf90(void)
   {
     r4 = 0;
   }
-  func_ov007_020c93b4(data_ov007_0210342c->m44);
+  func_020c93b4(data_ov007_0210342c->m44);
   func_020557b4();
   func_02055624();
-  _ZN3G3X13SetClearColorEtiiib(0x7fff, 0, 0x7fff, 0x3f, 1);
-  func_ov007_020b2160(1);
+  func_02055574(0x7fff, 0, 0x7fff, 0x3f, 1);
+  func_020b2160(1);
   switch (*pA)
   {
     case 0:
@@ -63,7 +63,7 @@ void func_ov007_020bcf90(void)
     case 1:
       if ((*pB) == 2)
     {
-      func_ov007_020b8fd4(data_ov007_0210342c->m34);
+      func_020b8fd4(data_ov007_0210342c->m34);
     }
       break;
 
@@ -72,14 +72,14 @@ void func_ov007_020bcf90(void)
     case 3:
 
     case 4:
-      func_ov007_020b8fd4(data_ov007_0210342c->m34);
+      func_020b8fd4(data_ov007_0210342c->m34);
       break;
 
     case 5:
       for (i = 0xe; i <= 0x10; i++)
     {
       s16 *mp = &data_ov007_0210342c->m28[i - 0xe];
-      func_ov007_020b413c(data_ov007_0210342c->m114[i], mp[2]);
+      func_020b413c(data_ov007_0210342c->m114[i], mp[2]);
     }
 
       break;
@@ -91,32 +91,32 @@ void func_ov007_020bcf90(void)
 
   if (r4 != 0)
   {
-    func_ov007_020b2728();
+    func_020b2728();
   }
-  if (func_ov007_020b7a34() != 0)
+  if (func_020b7a34() != 0)
   {
-    func_ov007_020b7a00();
+    func_020b7a00();
   }
   for (j = 0; j < 0x18; j++)
   {
-    func_ov007_020b4464(data_ov007_0210342c->m114[j], data_ov007_0210342c->m34);
+    func_020b4464(data_ov007_0210342c->m114[j], data_ov007_0210342c->m34);
   }
 
-  func_ov007_020b2cf0();
-  func_ov007_020b2160(0);
-  func_ov007_020c2390(data_ov007_0210342c->m38);
-  func_ov007_020c232c(data_ov007_0210342c->m38);
+  func_020b2cf0();
+  func_020b2160(0);
+  func_020c2390(data_ov007_0210342c->m38);
+  func_020c232c(data_ov007_0210342c->m38);
   switch (*pA)
   {
     case 0:
-      func_ov007_020c2390(data_ov007_0210342c->m3c);
-      func_ov007_020c232c(data_ov007_0210342c->m3c);
+      func_020c2390(data_ov007_0210342c->m3c);
+      func_020c232c(data_ov007_0210342c->m3c);
       break;
 
     case 1:
       if ((*pB) == 2)
     {
-      func_ov007_020b91b4();
+      func_020b91b4();
     }
       break;
 
@@ -125,11 +125,11 @@ void func_ov007_020bcf90(void)
     case 3:
 
     case 4:
-      func_ov007_020b91b4();
+      func_020b91b4();
       break;
 
     case 5:
-      func_ov007_020bee14();
+      func_020bee14();
       break;
 
     case 6:
@@ -137,10 +137,10 @@ void func_ov007_020bcf90(void)
 
   }
 
-  func_ov007_020b7658(data_ov007_0210342c->m30 + 0x44, 1);
+  func_020b7658(data_ov007_0210342c->m30 + 0x44, 1);
   if (r4 != 0)
   {
-    func_ov007_020b2370();
+    func_020b2370();
   }
-  func_ov007_020bfaf0(data_ov007_0210342c->m30);
+  func_020bfaf0(data_ov007_0210342c->m30);
 }

--- a/src/func_ov007_020c0a9c.c
+++ b/src/func_ov007_020c0a9c.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c0a9c(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c105c.c
+++ b/src/func_ov007_020c105c.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c105c(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c1620.c
+++ b/src/func_ov007_020c1620.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c1620(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c2018.c
+++ b/src/func_ov007_020c2018.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c2018(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c22f8.c
+++ b/src/func_ov007_020c22f8.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c22f8(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c2410.c
+++ b/src/func_ov007_020c2410.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c2410(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c338c.c
+++ b/src/func_ov007_020c338c.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c338c(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c3544.c
+++ b/src/func_ov007_020c3544.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c3544(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c798c.c
+++ b/src/func_ov007_020c798c.c
@@ -7,25 +7,25 @@ struct Thing {
     void *field10;
 };
 
-extern void *func_020c3df4(int heap, int size);
-extern void func_020c78b0(void);
-extern int func_020c844c(int a, void *b);
-extern int func_020c80a4(void);
+extern void *func_ov007_020c3df4(int heap, int size);
+extern void func_ov007_020c78b0(void);
+extern int func_ov007_020c844c(int a, void *b);
+extern int func_ov007_020c80a4(void);
 
 struct Thing *func_ov007_020c798c(void *p0, int p1, void *p2, int p3)
 {
     int i;
     struct Thing *t;
 
-    t = (struct Thing *)func_020c3df4(0, 0x14);
-    func_020c78b0();
+    t = (struct Thing *)func_ov007_020c3df4(0, 0x14);
+    func_ov007_020c78b0();
     t->field10 = p0;
     t->field4 = p1;
     t->fieldC = p3;
-    t->field0 = (int *)func_020c3df4(0, t->field4 * 4);
+    t->field0 = (int *)func_ov007_020c3df4(0, t->field4 * 4);
     if (t->fieldC & 1) {
         for (i = 0; i < t->field4; i++)
-            t->field0[i] = func_020c844c(0, p2);
+            t->field0[i] = func_ov007_020c844c(0, p2);
     }
     if (p1 > 1) {
         int n2;
@@ -33,9 +33,9 @@ struct Thing *func_ov007_020c798c(void *p0, int p1, void *p2, int p3)
             n2 = 0;
         else
             n2 = t->field4 - ((t->fieldC & 2) ? 0 : 1);
-        t->field8 = (int *)func_020c3df4(0, n2 * 4);
+        t->field8 = (int *)func_ov007_020c3df4(0, n2 * 4);
         for (i = 0; i < n2; i++)
-            t->field8[i] = func_020c80a4();
+            t->field8[i] = func_ov007_020c80a4();
     }
     return t;
 }

--- a/src/func_ov007_020c798c.c
+++ b/src/func_ov007_020c798c.c
@@ -7,25 +7,25 @@ struct Thing {
     void *field10;
 };
 
-extern void *func_ov007_020c3df4(int heap, int size);
-extern void func_ov007_020c78b0(void);
-extern int func_ov007_020c844c(int a, void *b);
-extern int func_ov007_020c80a4(void);
+extern void *func_020c3df4(int heap, int size);
+extern void func_020c78b0(void);
+extern int func_020c844c(int a, void *b);
+extern int func_020c80a4(void);
 
 struct Thing *func_ov007_020c798c(void *p0, int p1, void *p2, int p3)
 {
     int i;
     struct Thing *t;
 
-    t = (struct Thing *)func_ov007_020c3df4(0, 0x14);
-    func_ov007_020c78b0();
+    t = (struct Thing *)func_020c3df4(0, 0x14);
+    func_020c78b0();
     t->field10 = p0;
     t->field4 = p1;
     t->fieldC = p3;
-    t->field0 = (int *)func_ov007_020c3df4(0, t->field4 * 4);
+    t->field0 = (int *)func_020c3df4(0, t->field4 * 4);
     if (t->fieldC & 1) {
         for (i = 0; i < t->field4; i++)
-            t->field0[i] = func_ov007_020c844c(0, p2);
+            t->field0[i] = func_020c844c(0, p2);
     }
     if (p1 > 1) {
         int n2;
@@ -33,9 +33,9 @@ struct Thing *func_ov007_020c798c(void *p0, int p1, void *p2, int p3)
             n2 = 0;
         else
             n2 = t->field4 - ((t->fieldC & 2) ? 0 : 1);
-        t->field8 = (int *)func_ov007_020c3df4(0, n2 * 4);
+        t->field8 = (int *)func_020c3df4(0, n2 * 4);
         for (i = 0; i < n2; i++)
-            t->field8[i] = func_ov007_020c80a4();
+            t->field8[i] = func_020c80a4();
     }
     return t;
 }

--- a/src/func_ov007_020c8098.c
+++ b/src/func_ov007_020c8098.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c8098(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c8440.c
+++ b/src/func_ov007_020c8440.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c8440(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c8970.c
+++ b/src/func_ov007_020c8970.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c897c(void);
+extern int func_ov007_020c897c(void);
 
 int func_ov007_020c8970(void)
 {
-    return func_020c897c();
+    return func_ov007_020c897c();
 }

--- a/src/func_ov007_020c8970.c
+++ b/src/func_ov007_020c8970.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_ov007_020c897c(void);
+extern int func_020c897c(void);
 
 int func_ov007_020c8970(void)
 {
-    return func_ov007_020c897c();
+    return func_020c897c();
 }

--- a/src/func_ov007_020c8b04.c
+++ b/src/func_ov007_020c8b04.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c8b04(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c8f58.c
+++ b/src/func_ov007_020c8f58.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c8f58(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c9080.c
+++ b/src/func_ov007_020c9080.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c9080(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c92a0.c
+++ b/src/func_ov007_020c92a0.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c92a0(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c937c.c
+++ b/src/func_ov007_020c937c.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c937c(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020c9460.c
+++ b/src/func_ov007_020c9460.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_020c3d1c(void);
+extern int _ZN6Player17St_EndingFly_MainEv(void);
 
 int func_ov007_020c9460(void)
 {
-    return func_020c3d1c();
+    return _ZN6Player17St_EndingFly_MainEv();
 }

--- a/src/func_ov007_020cca68.c
+++ b/src/func_ov007_020cca68.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_02018144(void);
+extern int Deallocate(void);
 
 int func_ov007_020cca68(void)
 {
-    return func_02018144();
+    return Deallocate();
 }

--- a/src/func_ov007_020cca74.c
+++ b/src/func_ov007_020cca74.c
@@ -1,9 +1,9 @@
 // Long-branch veneer. #pragma long_calls makes mwccarm emit the pooled
 // `ldr ip,[pc]; bx ip` absolute tail-call the ROM uses to reach the target.
 #pragma long_calls on
-extern int func_0201816c(void);
+extern int LoadFile(void);
 
 int func_ov007_020cca74(void)
 {
-    return func_0201816c();
+    return LoadFile();
 }

--- a/src/func_ov007_020cca98.c
+++ b/src/func_ov007_020cca98.c
@@ -1,5 +1,5 @@
-extern int func_0203c280(int, int);
+extern int _ZN4Heap11_DeallocateEPv(int, int);
 extern int data_020a0ea0;
 int func_ov007_020cca98(int a) {
-    return func_0203c280(data_020a0ea0, a);
+    return _ZN4Heap11_DeallocateEPv(data_020a0ea0, a);
 }

--- a/src/func_ov007_020ccab4.c
+++ b/src/func_ov007_020ccab4.c
@@ -1,5 +1,5 @@
-extern int func_0203c28c(int, int);
+extern int _ZN4Heap8AllocateEj(int, int);
 extern int data_020a0ea0;
 int func_ov007_020ccab4(int a) {
-    return func_0203c28c(data_020a0ea0, a);
+    return _ZN4Heap8AllocateEj(data_020a0ea0, a);
 }

--- a/src/func_ov015_02111d28.c
+++ b/src/func_ov015_02111d28.c
@@ -7,5 +7,5 @@
 
 void func_ov015_02111d28(char *self) {
     *(int *)(self + 0xa4) = -0x14000;
-    func_02012664(0xc3, self + 0x74);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0xc3, self + 0x74);
 }

--- a/src/func_ov030_02112ff8.c
+++ b/src/func_ov030_02112ff8.c
@@ -1,20 +1,20 @@
-extern int func_0203cfdc(void *a, void *b);
-extern void func_0200f97c(void *c, int a);
-extern void func_02015024(void *p);
+extern int Vec3_Dist(void *a, void *b);
+extern void _ZN5Actor13SpawnSoundObjEj(void *c, int a);
+extern void _ZN12CylinderClsn5ClearEv(void *p);
 
 int func_ov030_02112ff8(char *c)
 {
     *(int *)(((long long)(int)(c + 0xb0))) &= ~0x80000;
-    if (func_0203cfdc(c + 0x380, c + 0x5c) < 0x514000 &&
+    if (Vec3_Dist(c + 0x380, c + 0x5c) < 0x514000 &&
         *(int *)(c + 0x60) > *(int *)(c + 0x384) - 0x12c000) {
         *(unsigned char *)(c + 0x3c7) = 0;
-        func_0200f97c(c, 1);
+        _ZN5Actor13SpawnSoundObjEj(c, 1);
     } else {
         *(unsigned char *)(c + 0x3c7) = 3;
     }
     *(int *)(c + 0x98) = 0;
     *(unsigned char *)(c + 0x3c6) = 0x3c;
-    func_02015024(c + 0x160);
+    _ZN12CylinderClsn5ClearEv(c + 0x160);
     *(int *)(c + 0x3b8) = *(int *)(c + 0x3b4);
     *(int *)(c + 0x3b4) = 6;
     return 1;

--- a/src/func_ov070_0211f62c.c
+++ b/src/func_ov070_0211f62c.c
@@ -1,11 +1,11 @@
-extern int func_02015bcc(void *p);
+extern int _ZN9Animation8FinishedEv(void *p);
 extern signed char data_0209f2f8;
 extern void FlyGuy_ChangeState(void *c, void *p);
 extern char data_ov070_0212359c;
 
 int func_ov070_0211f62c(char *c)
 {
-    if (func_02015bcc(c + 0x350) != 0) {
+    if (_ZN9Animation8FinishedEv(c + 0x350) != 0) {
         if (data_0209f2f8 != 0x16)
             *(int *)(((long long)(int)(c + 0x3c4))) += 0x12c000;
         *(int *)(c + 0x3d8) = 0;

--- a/src/func_ov075_021143e4.cpp
+++ b/src/func_ov075_021143e4.cpp
@@ -5,7 +5,7 @@ extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void*,void*,int,i
 extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void*,void*);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*,void*,int,int,unsigned int);
 extern int _ZNK9Animation13GetFrameCountEv(void*);
-extern long long func_01ffadf0(unsigned int,int);
+extern long long __aeabi_uidiv(unsigned int,int);
 extern int data_ov075_0211d380[];
 extern int data_0209e650[];
 extern unsigned char data_ov075_0211b524[];
@@ -35,7 +35,7 @@ void func_ov075_021143e4(char*c){
   {
     unsigned int rv=(unsigned int)RandomIntInternal(data_0209e650);
     int fc=_ZNK9Animation13GetFrameCountEv(c+0x50);
-    long long v=func_01ffadf0(rv>>0x10,fc);
+    long long v=__aeabi_uidiv(rv>>0x10,fc);
     *(int*)(c+0xdc)=((unsigned)((int)(v>>32)<<0x10))>>4;
   }
 }

--- a/src/func_ov080_02125cd4.c
+++ b/src/func_ov080_02125cd4.c
@@ -1,8 +1,8 @@
-extern int func_01ffabe4(int, int);
+extern int __aeabi_idiv(int, int);
 int func_ov080_02125cd4(void *c, int n) {
     void *p = *(void **)((char *)c + 0x1ac);
     int r4 = *(int *)p;
     int r1 = *(int *)((char *)p + 0x10);
-    int r = func_01ffabe4(r4, r1);
+    int r = __aeabi_idiv(r4, r1);
     return r4 - r * n;
 }

--- a/src/func_ov084_0212fc10.c
+++ b/src/func_ov084_0212fc10.c
@@ -1,4 +1,4 @@
-extern void func_02016748(void *self, int anim, int a, int speed, int b);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, int anim, int a, int speed, int b);
 extern int data_ov084_02130df4[];
 extern void func_ov084_0212ef00(void *c);
 
@@ -9,7 +9,7 @@ void func_ov084_0212fc10(char *c)
     *(int *)(c + 0x88) = 0x1000;
     *(unsigned char *)(c + 0x45c) = 1;
     *(int *)(((long long)(int)(c + 0xb0))) |= 0x10000000;
-    func_02016748(c + 0x110, data_ov084_02130df4[1], 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x110, data_ov084_02130df4[1], 0, 0x1000, 0);
     if (*(int *)(c + 0x464) < 0x4b0000)
         *(int *)(c + 0x458) = 1;
     func_ov084_0212ef00(c);

--- a/tools/check_references.py
+++ b/tools/check_references.py
@@ -19,113 +19,170 @@ reference bug in this tree has lived:
       3 funcs  outright wrong callees, found only once enrollment forced a link
 
 Each was cleaned up by a sweep over the whole tree. Sweeps remove instances; they
-do not remove the hole that admits them. This closes the hole: a reference that
-resolves to nothing can be *added* only if this check is not run.
+do not remove the hole that admits them. This closes the hole.
 
-## What it checks
+## What it compares, and why keyed that way
 
 `eligible.py` already computes the answer -- it compiles every candidate and records
-each file's unresolved symbols in `build/rombuild-eligibility.json`. This reads that
-report and compares it to a committed baseline, failing on:
+each file's unresolved symbols. This reads that report and compares it to
+`config/unresolved-baseline.json`.
 
-  - a file that resolves today and does not in the report  (regression)
-  - an unresolved symbol name the baseline has never seen  (a new bug class)
+The key is the **function symbol**, never the file path. This project moves files
+between directories and keys contributor lineage on those moves; a path key would
+report every move as a regression and then refuse to let `--update` fix it.
 
-It deliberately does **not** fail on the baseline's own backlog. The tree has a real
-one; blocking every PR until it is empty would just get the check switched off.
-Progress ratchets the baseline down, never up.
+The comparison is **per symbol's full missing-name list**, not a set of keys. An
+earlier version compared only which functions appeared, plus a global set of names,
+and so passed a change that added a *second* bad reference to a function that was
+already in the backlog, as long as the name occurred somewhere else in the tree.
+
+Three ways a check like this fails open, all closed here:
+
+  - **stale report.** `eligible.py` stamps the commit it describes; a report from a
+    different commit, or from a dirty tree, is refused rather than trusted.
+  - **reason-switching.** A file that degrades from `unresolvable` to `compile
+    failed` leaves the unresolved set and would read as a fix. The eligible count is
+    ratcheted too, so trading one failure for another cannot pass.
+  - **a hand-raised baseline.** `--update` only ever lowers it, and `--against`
+    compares to the base branch's copy so raising it in a PR is visible.
+
+The existing backlog is tolerated on purpose. The tree has a real one; blocking
+every PR until it is empty would just get the check switched off.
 
 Usage:
-    python tools/check_references.py                 # verify against the baseline
-    python tools/check_references.py --update        # ratchet the baseline down
-    python tools/check_references.py --report FILE   # use a report from elsewhere
+    python tools/check_references.py                      # verify
+    python tools/check_references.py --update             # bank progress
+    python tools/check_references.py --against origin/main
 """
 import argparse
 import json
 import pathlib
+import subprocess
 import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
-REPORT = REPO / "build" / "rombuild-eligibility.json"
+sys.path.insert(0, str(REPO / "tools"))
+
+import eligible as E  # noqa: E402
+
 BASELINE = REPO / "config" / "unresolved-baseline.json"
 
 
-def load_report(path):
-    if not path.is_file():
+def current(path, require_fresh=True):
+    """{symbol: [missing names]} plus the eligible count, from the report."""
+    try:
+        entries, commit, dirty = E.load_report(path)
+    except FileNotFoundError:
         sys.exit(f"missing {path}\nRun tools/eligible.py first, or pass --report.")
-    out = {}
-    for r in json.loads(path.read_text(encoding="utf-8")):
-        if (r.get("reason") or "").startswith("unresolvable"):
-            out[r["file"].replace("\\", "/")] = sorted(set(r.get("missing") or []))
+    if require_fresh:
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPO,
+                              capture_output=True, text=True).stdout.strip()
+        if commit is None:
+            sys.exit("report carries no commit stamp -- re-run tools/eligible.py")
+        if commit != head:
+            sys.exit(f"report describes {commit[:12]}, HEAD is {head[:12]}\n"
+                     "A stale report would let a bad reference through. Re-run "
+                     "tools/eligible.py.")
+        if dirty:
+            sys.exit("report was produced from a dirty tree -- commit or stash, then "
+                     "re-run tools/eligible.py")
+    unresolved, eligible = {}, 0
+    for r in entries:
+        reason = r.get("reason")
+        if reason is None:
+            eligible += 1
+        elif reason.startswith("unresolvable"):
+            unresolved[r["name"]] = sorted(set(r.get("missing") or []))
+    return unresolved, eligible
+
+
+def load_baseline(ref=None):
+    if ref:
+        out = subprocess.run(["git", "show", f"{ref}:{BASELINE.relative_to(REPO).as_posix()}"],
+                             cwd=REPO, capture_output=True, text=True)
+        return json.loads(out.stdout) if out.returncode == 0 else None
+    return json.loads(BASELINE.read_text(encoding="utf-8")) if BASELINE.is_file() else None
+
+
+def write_baseline(unresolved, eligible):
+    BASELINE.parent.mkdir(parents=True, exist_ok=True)
+    BASELINE.write_text(json.dumps(
+        {"eligible": eligible, "unresolved": dict(sorted(unresolved.items()))},
+        indent=1) + "\n", encoding="utf-8")
+
+
+def worse(cur, base):
+    """Symbols that resolve worse than the baseline allows."""
+    out = []
+    for sym, miss in sorted(cur.items()):
+        was = base.get(sym)
+        if was is None:
+            out.append((sym, miss, "newly unresolvable"))
+        else:
+            added = sorted(set(miss) - set(was))
+            if added:
+                out.append((sym, added, "new unresolved reference"))
     return out
-
-
-def load_baseline():
-    if not BASELINE.is_file():
-        return None
-    return json.loads(BASELINE.read_text(encoding="utf-8"))
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--update", action="store_true",
-                    help="write the current state as the baseline (only ever downward)")
-    ap.add_argument("--report", type=pathlib.Path, default=REPORT)
+    ap.add_argument("--update", action="store_true", help="bank progress (downward only)")
+    ap.add_argument("--against", help="git ref whose baseline to compare against")
+    ap.add_argument("--report", type=pathlib.Path,
+                    default=REPO / "build" / "rombuild-eligibility.json")
+    ap.add_argument("--allow-stale", action="store_true",
+                    help="skip the commit-stamp check (for local iteration only)")
     args = ap.parse_args()
 
-    cur = load_report(args.report)
-    cur_names = {s for v in cur.values() for s in v}
+    cur, eligible = current(args.report, require_fresh=not args.allow_stale)
+    base = load_baseline(args.against)
 
-    if args.update or load_baseline() is None:
-        base = load_baseline()
-        if not args.update:
-            sys.exit(f"no baseline at {BASELINE}\nCreate one with --update.")
-        # Only ratchet downward -- a baseline that can grow is not a baseline. The
-        # first write is the exception: there is nothing yet to ratchet against.
-        grew = [f for f in cur if f not in base["files"]] if base else []
-        new_names = sorted(cur_names - set(base["names"])) if base else []
-        if grew or new_names:
-            print("refusing to update: this would raise the baseline, not lower it")
-            for f in grew[:10]:
-                print(f"  newly unresolved file: {f}")
-            for n in new_names[:10]:
-                print(f"  new unresolved name  : {n}")
-            return 1
-        BASELINE.parent.mkdir(parents=True, exist_ok=True)
-        BASELINE.write_text(json.dumps(
-            {"files": {f: v for f, v in sorted(cur.items())},
-             "names": sorted(cur_names)}, indent=1) + "\n", encoding="utf-8")
-        print(f"baseline updated: {len(cur)} files, {len(cur_names)} distinct names")
+    if args.update:
+        if base is not None:
+            bad = worse(cur, base["unresolved"])
+            if bad or eligible < base.get("eligible", 0):
+                print("refusing to update: this would raise the baseline, not lower it")
+                for sym, names, why in bad[:10]:
+                    print(f"  {why}: {sym}  ({', '.join(names[:3])})")
+                if eligible < base.get("eligible", 0):
+                    print(f"  eligible fell {base['eligible']} -> {eligible}")
+                return 1
+        write_baseline(cur, eligible)
+        print(f"baseline: {len(cur)} unresolved symbols, {eligible} eligible")
         return 0
 
-    base = load_baseline()
-    base_files, base_names = base["files"], set(base["names"])
+    if base is None:
+        sys.exit(f"no baseline at {BASELINE}\nCreate one with --update.")
 
-    regressed = sorted(set(cur) - set(base_files))
-    new_names = sorted(cur_names - base_names)
-    fixed = sorted(set(base_files) - set(cur))
+    bad = worse(cur, base["unresolved"])
+    lost = base.get("eligible", 0) - eligible
+    fixed = sorted(set(base["unresolved"]) - set(cur))
 
-    print(f"unresolved files: {len(cur)}  (baseline {len(base_files)})")
+    print(f"unresolved symbols: {len(cur)}  (baseline {len(base['unresolved'])})")
+    print(f"eligible:           {eligible}  (baseline {base.get('eligible', 0)})")
     if fixed:
         print(f"  {len(fixed)} fixed since the baseline -- run --update to bank it")
 
-    if not regressed and not new_names:
+    if not bad and lost <= 0:
         print("OK: no new unresolvable references")
         return 0
 
     print("\nFAIL: this change adds references that resolve to nothing.")
-    print("Every one of them would pass the byte gate, because match.py compares")
+    print("They would pass the byte gate regardless, because match.py compares")
     print("relocated words as wildcards and never looks at what a call targets.\n")
-    for f in regressed[:25]:
-        print(f"  {f}\n      {', '.join(cur[f][:4])}")
-    if len(regressed) > 25:
-        print(f"  ... and {len(regressed) - 25} more files")
-    for n in new_names[:15]:
-        print(f"  new unresolved name: {n}")
+    for sym, names, why in bad[:25]:
+        print(f"  {why}: {sym}\n      {', '.join(names[:4])}")
+    if len(bad) > 25:
+        print(f"  ... and {len(bad) - 25} more")
+    if lost > 0:
+        print(f"\n  {lost} functions stopped being eligible -- a file that degrades from")
+        print("  'unresolvable' to 'compile failed' leaves the unresolved set entirely,")
+        print("  so the count is ratcheted too and cannot be traded away.")
     print("\nResolve them from the ROM's own relocation data:")
     print("  python tools/resolve_placeholders.py            # report")
-    print("  python tools/resolve_placeholders.py --apply    # rewrite + byte-verify")
+    print("  python tools/resolve_placeholders.py --apply    # rewrite + verify")
     return 1
 
 

--- a/tools/check_references.py
+++ b/tools/check_references.py
@@ -86,14 +86,15 @@ def current(path, require_fresh=True):
         if dirty:
             sys.exit("report was produced from a dirty tree -- commit or stash, then "
                      "re-run tools/eligible.py")
-    unresolved, eligible = {}, 0
+    unresolved, eligible, reasons = {}, 0, {}
     for r in entries:
         reason = r.get("reason")
+        reasons[r["name"]] = reason
         if reason is None:
             eligible += 1
         elif reason.startswith("unresolvable"):
             unresolved[r["name"]] = sorted(set(r.get("missing") or []))
-    return unresolved, eligible
+    return unresolved, eligible, reasons
 
 
 def load_baseline(ref=None):
@@ -136,12 +137,19 @@ def main():
                     help="skip the commit-stamp check (for local iteration only)")
     args = ap.parse_args()
 
-    cur, eligible = current(args.report, require_fresh=not args.allow_stale)
+    cur, eligible, reasons = current(args.report, require_fresh=not args.allow_stale)
     base = load_baseline(args.against)
 
     if args.update:
         if base is not None:
             bad = worse(cur, base["unresolved"])
+            regressed = [s for s in set(base["unresolved"]) - set(cur)
+                         if reasons.get(s, "gone") is not None]
+            if regressed:
+                print("refusing to update: symbols left the backlog by failing differently")
+                for s in regressed[:10]:
+                    print(f"  {s} -> {reasons.get(s, 'no longer a candidate')}")
+                return 1
             if bad or eligible < base.get("eligible", 0):
                 print("refusing to update: this would raise the baseline, not lower it")
                 for sym, names, why in bad[:10]:
@@ -158,14 +166,24 @@ def main():
 
     bad = worse(cur, base["unresolved"])
     lost = base.get("eligible", 0) - eligible
-    fixed = sorted(set(base["unresolved"]) - set(cur))
+    left = set(base["unresolved"]) - set(cur)
+    # Leaving the unresolved set is only progress if the symbol became eligible. A
+    # file that degrades from `unresolvable` to `compile failed` also leaves it, and
+    # would otherwise read as a fix -- trading one failure for a worse one.
+    disguised = sorted(s for s in left if reasons.get(s, "gone") is not None)
+    fixed = sorted(s for s in left if reasons.get(s, "gone") is None)
 
     print(f"unresolved symbols: {len(cur)}  (baseline {len(base['unresolved'])})")
     print(f"eligible:           {eligible}  (baseline {base.get('eligible', 0)})")
     if fixed:
         print(f"  {len(fixed)} fixed since the baseline -- run --update to bank it")
 
-    if not bad and lost <= 0:
+    if disguised:
+        print(f"\n  {len(disguised)} symbols left the unresolved set without becoming")
+        print("  eligible -- they now fail for another reason, which is not a fix:")
+        for s in disguised[:10]:
+            print(f"      {s}  ->  {reasons.get(s, 'no longer a candidate')}")
+    if not bad and lost <= 0 and not disguised:
         print("OK: no new unresolvable references")
         return 0
 

--- a/tools/check_references.py
+++ b/tools/check_references.py
@@ -1,0 +1,133 @@
+"""Fail when a change adds a reference that resolves to nothing.
+
+## Why this exists
+
+`match.py` compares a compiled function to the ROM word by word, but every
+relocated word is a **wildcard** -- our object has a placeholder where the ROM has
+a final address. So the byte gate compares "is there a call here", never "a call to
+what". A file can name a callee that does not exist and still match.
+
+The ROM link *would* object. But `eligible.py` refuses to enroll a file whose
+references do not resolve, so a file with a bad reference never reaches the link.
+The two gates cover for each other, and the gap between them is where every
+reference bug in this tree has lived:
+
+    882 refs   C++ TUs re-mangling ROM names they declared without C linkage
+    250 files  `G0`/`VT1`/`HEAP` placeholders a recovery pass never resolved
+    196 files  `_ZTV10dBgActor_c` -- one plausible-looking name, 196 real symbols
+    106 refs   mangled names built from mis-recovered signatures
+      3 funcs  outright wrong callees, found only once enrollment forced a link
+
+Each was cleaned up by a sweep over the whole tree. Sweeps remove instances; they
+do not remove the hole that admits them. This closes the hole: a reference that
+resolves to nothing can be *added* only if this check is not run.
+
+## What it checks
+
+`eligible.py` already computes the answer -- it compiles every candidate and records
+each file's unresolved symbols in `build/rombuild-eligibility.json`. This reads that
+report and compares it to a committed baseline, failing on:
+
+  - a file that resolves today and does not in the report  (regression)
+  - an unresolved symbol name the baseline has never seen  (a new bug class)
+
+It deliberately does **not** fail on the baseline's own backlog. The tree has a real
+one; blocking every PR until it is empty would just get the check switched off.
+Progress ratchets the baseline down, never up.
+
+Usage:
+    python tools/check_references.py                 # verify against the baseline
+    python tools/check_references.py --update        # ratchet the baseline down
+    python tools/check_references.py --report FILE   # use a report from elsewhere
+"""
+import argparse
+import json
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+REPORT = REPO / "build" / "rombuild-eligibility.json"
+BASELINE = REPO / "config" / "unresolved-baseline.json"
+
+
+def load_report(path):
+    if not path.is_file():
+        sys.exit(f"missing {path}\nRun tools/eligible.py first, or pass --report.")
+    out = {}
+    for r in json.loads(path.read_text(encoding="utf-8")):
+        if (r.get("reason") or "").startswith("unresolvable"):
+            out[r["file"].replace("\\", "/")] = sorted(set(r.get("missing") or []))
+    return out
+
+
+def load_baseline():
+    if not BASELINE.is_file():
+        return None
+    return json.loads(BASELINE.read_text(encoding="utf-8"))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--update", action="store_true",
+                    help="write the current state as the baseline (only ever downward)")
+    ap.add_argument("--report", type=pathlib.Path, default=REPORT)
+    args = ap.parse_args()
+
+    cur = load_report(args.report)
+    cur_names = {s for v in cur.values() for s in v}
+
+    if args.update or load_baseline() is None:
+        base = load_baseline()
+        if not args.update:
+            sys.exit(f"no baseline at {BASELINE}\nCreate one with --update.")
+        # Only ratchet downward -- a baseline that can grow is not a baseline. The
+        # first write is the exception: there is nothing yet to ratchet against.
+        grew = [f for f in cur if f not in base["files"]] if base else []
+        new_names = sorted(cur_names - set(base["names"])) if base else []
+        if grew or new_names:
+            print("refusing to update: this would raise the baseline, not lower it")
+            for f in grew[:10]:
+                print(f"  newly unresolved file: {f}")
+            for n in new_names[:10]:
+                print(f"  new unresolved name  : {n}")
+            return 1
+        BASELINE.parent.mkdir(parents=True, exist_ok=True)
+        BASELINE.write_text(json.dumps(
+            {"files": {f: v for f, v in sorted(cur.items())},
+             "names": sorted(cur_names)}, indent=1) + "\n", encoding="utf-8")
+        print(f"baseline updated: {len(cur)} files, {len(cur_names)} distinct names")
+        return 0
+
+    base = load_baseline()
+    base_files, base_names = base["files"], set(base["names"])
+
+    regressed = sorted(set(cur) - set(base_files))
+    new_names = sorted(cur_names - base_names)
+    fixed = sorted(set(base_files) - set(cur))
+
+    print(f"unresolved files: {len(cur)}  (baseline {len(base_files)})")
+    if fixed:
+        print(f"  {len(fixed)} fixed since the baseline -- run --update to bank it")
+
+    if not regressed and not new_names:
+        print("OK: no new unresolvable references")
+        return 0
+
+    print("\nFAIL: this change adds references that resolve to nothing.")
+    print("Every one of them would pass the byte gate, because match.py compares")
+    print("relocated words as wildcards and never looks at what a call targets.\n")
+    for f in regressed[:25]:
+        print(f"  {f}\n      {', '.join(cur[f][:4])}")
+    if len(regressed) > 25:
+        print(f"  ... and {len(regressed) - 25} more files")
+    for n in new_names[:15]:
+        print(f"  new unresolved name: {n}")
+    print("\nResolve them from the ROM's own relocation data:")
+    print("  python tools/resolve_placeholders.py            # report")
+    print("  python tools/resolve_placeholders.py --apply    # rewrite + byte-verify")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -63,6 +63,18 @@ ANYSYM = re.compile(r"^(\S+)\s+kind:")
 IGNORE_SECTIONS = (".comment", ".debug", ".line", ".note")
 
 
+def load_report(path=None):
+    """The eligibility report, as (entries, commit, dirty).
+
+    Reads both the stamped shape and the bare list the report used to be, so a
+    consumer does not care which vintage it is handed."""
+    path = path or (BUILD / "rombuild-eligibility.json")
+    d = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if isinstance(d, list):
+        return d, None, None
+    return d["files"], d.get("commit"), d.get("dirty")
+
+
 def defined_symbols():
     """Every symbol name config/**/symbols.txt declares, in any module."""
     names = set()
@@ -186,7 +198,19 @@ def main():
                 print(f"  {done}/{len(jobs)}")
 
     BUILD.mkdir(exist_ok=True)
-    (BUILD / "rombuild-eligibility.json").write_text(json.dumps(results, indent=1))
+    # Stamp the tree this describes. A consumer that gates CI on this report must be
+    # able to tell it apart from one left over from an earlier commit; without a stamp
+    # a stale report fails open, which is the worst way for a gate to fail.
+    try:
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPO,
+                              capture_output=True, text=True).stdout.strip() or None
+        dirty = bool(subprocess.run(["git", "status", "--porcelain", "--untracked-files=no",
+                                     "--", "src", "include", "config"], cwd=REPO,
+                                    capture_output=True, text=True).stdout.strip())
+    except Exception:
+        head, dirty = None, True
+    (BUILD / "rombuild-eligibility.json").write_text(json.dumps(
+        {"commit": head, "dirty": dirty, "files": results}, indent=1))
     passed = [r["name"] for r in results if r["reason"] is None]
     (BUILD / "eligible-names.txt").write_text("\n".join(sorted(passed)) + "\n")
 

--- a/tools/extern_c_wrap.py
+++ b/tools/extern_c_wrap.py
@@ -93,7 +93,7 @@ def mangled_targets(known):
     if not ELIGIBILITY.exists():
         sys.exit(f"missing {ELIGIBILITY} -- run tools/eligible.py first")
     out = {}
-    for r in json.loads(ELIGIBILITY.read_text()):
+    for r in E.load_report(ELIGIBILITY)[0]:
         if not (r.get("reason") or "").startswith("unresolvable"):
             continue
         # `missing`, not `reason` -- the reason string is truncated to three symbols

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -13,7 +13,9 @@
 # It also checks port/'s references into src/ (manifests, hostgen symbol lists, HAL linkage
 # bridges). port/ has its own MSVC build that nothing in the decomp toolchain compiles or
 # links, so a src/ rename can strand a port/ reference with no other gate to catch it. See
-# tools/port_refcheck.py.
+# tools/port_refcheck.py. That check, and the unresolved-reference ratchet, run on EVERY
+# push rather than only main-targeted ones: neither needs the ROM, and both catch mistakes
+# that are invisible in review because every byte still matches.
 #
 # Install:
 #   cp tools/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
@@ -43,12 +45,6 @@ remote_ref_check() {
       return 1
     fi
 
-    echo "pre-push: checking port/ references into src/"
-    if ! python tools/port_refcheck.py; then
-      echo "pre-push: REFUSING to push (see above). Override with --no-verify if you are certain." >&2
-      return 1
-    fi
-
     # Attribution is a comparison, so it needs a real base. A brand-new remote branch has
     # nothing to compare against and nothing can have moved yet.
     if [ "$remote_sha" != "0000000000000000000000000000000000000000" ]; then
@@ -61,6 +57,36 @@ remote_ref_check() {
   done
   return 0
 }
+
+# --- checks that run on EVERY push, not only main ---------------------------
+#
+# The gate above only fires for refs/heads/main, because link verification needs
+# the ROM and toolchain and costs minutes. These two need neither, and the
+# mistakes they catch land on feature branches -- which is exactly where they
+# were missed: a src/ rename stranded a port/ bridge, every byte still matched,
+# and only the PR validator noticed.
+
+echo "pre-push: checking port/ references into src/"
+if ! python tools/port_refcheck.py; then
+  echo "pre-push: REFUSING to push (see above). Override with --no-verify if you are certain." >&2
+  exit 1
+fi
+
+# Reference resolvability needs tools/eligible.py, which compiles ~11,100 files and
+# takes minutes -- far too slow for a hook. So this checks only when a report for
+# THIS commit already exists, and otherwise says nothing was checked rather than
+# implying it passed.
+if python tools/check_references.py >/dev/null 2>&1; then
+  echo "pre-push: unresolved references OK"
+elif python tools/check_references.py 2>&1 | grep -q "report describes\|no commit stamp\|missing "; then
+  echo "pre-push: (skipping reference check -- no current eligibility report;"
+  echo "          run 'python tools/eligible.py' to include it)"
+else
+  echo "pre-push: reference check FAILED"
+  python tools/check_references.py
+  echo "pre-push: REFUSING to push (see above). Override with --no-verify if you are certain." >&2
+  exit 1
+fi
 
 remote_ref_check || exit 1
 exit 0

--- a/tools/resolve_placeholders.py
+++ b/tools/resolve_placeholders.py
@@ -62,26 +62,34 @@ ELIGIBILITY = REPO / "build" / "rombuild-eligibility.json"
 INVENTED = re.compile(r"^(G|VT|HEAP)\d*$")
 
 
-def is_stand_in(name, header_declared):
-    """Is `name` a stand-in rather than a real symbol?
+def is_misnamed(name, header_declared):
+    """Is `name` a reference we can hope to correct?
 
-    Two shapes, and the second is the larger one:
+    Every name reaching here is already unresolvable -- `eligible.py` found no
+    module defining it. The question is only whether correcting it is our business,
+    and the answer is yes for all of them, because the authority is never the name:
 
-      G0, VT1, HEAP   the pass's own placeholder spellings, declared per-file or
-                      in decl_common.h
+        the call site's own relocation  ->  target address + owning module
+        that module's symbols.txt       ->  the one name the ROM uses
 
-      _ZTV10dBgActor_c  a name that *looks* real -- it is declared in a shared
-                      header, so it reads as a proper symbol -- but no module
-                      defines it. 196 files reference that one name, and the
-                      relocations show they mean 196 different symbols. One
-                      declaration standing in for many, exactly like VT, but
-                      spelled plausibly enough that nobody noticed.
+    The name we start from contributes nothing to that lookup. It is a label the
+    recovery pass wrote down, and it can be wrong in several ways at once:
 
-    Both are reached the same way: the name resolves to nothing, and the ROM's
-    own relocation says what was meant. A name absent from the headers *and*
-    from the config is left alone -- there is no declaration to carry, and it is
-    likelier to be a genuine gap than a stand-in."""
-    return bool(INVENTED.match(name)) or name in header_declared
+      G0, VT1, HEAP            a placeholder it never resolved
+      _ZTV10dBgActor_c         a plausible-looking name no module defines; 196 files
+                               used it, meaning 196 different symbols
+      func_020c3d1c            an address-shaped guess where the ROM has a real
+                               method name
+      ...SetAnimEP8BCA_Fileiij a mangled name built from a mis-recovered signature
+                               (`int` where the ROM has Fix12<int>)
+
+    All four are the same defect -- a reference that resolves to nothing -- and all
+    four are answered by the same join. Narrowing the predicate to a shape we
+    recognise only means the next shape needs another sweep, which is how this cost
+    five of them. `header_declared` is retained for the caller's declaration
+    bookkeeping, not to gate eligibility."""
+    return True
+
 
 def decl_types():
     """{name: declaration template} for every name the headers declare.
@@ -106,15 +114,45 @@ SYMLINE = re.compile(r"^(\S+)\s+kind:\S*.*?\baddr:(0x[0-9a-fA-F]+)")
 GENERIC = re.compile(r"^(data|func)_(ov\d+_)?[0-9a-f]{8}$")
 
 
-def module_key(spec):
-    """dsd's `module:` field -> the config directory name, or None if it is not a
-    single definite module."""
+def module_keys(spec):
+    """dsd's `module:` field -> the config directory names it could mean.
+
+    Usually one. But overlays share address space, and where dsd could not tell
+    which of several was loaded it says so: `module:overlays(0,4)`. That is not a
+    dead end -- it is a shortlist, and the symbol tables often settle it, because
+    only one of the candidates actually defines anything at the target address."""
     if spec == "main":
-        return "arm9"
+        return ["arm9"]
     if spec in ("itcm", "dtcm"):
-        return spec
+        return [spec]
     m = re.match(r"^overlay\((\d+)\)$", spec)
-    return f"ov{int(m.group(1)):03d}" if m else None
+    if m:
+        return [f"ov{int(m.group(1)):03d}"]
+    m = re.match(r"^overlays\(([\d,]+)\)$", spec)
+    if m:
+        return [f"ov{int(n):03d}" for n in m.group(1).split(",") if n]
+    return []
+
+
+def resolve_in(syms, mods, addr, prefer):
+    """The name at `addr`, given a shortlist of modules that might own it.
+
+    A candidate only counts if it defines a symbol exactly at `addr`. If several do
+    and they disagree, prefer the referring module -- an overlay reaching into
+    itself is likelier than into a sibling that may not even be resident -- and
+    otherwise refuse, because a guess here silently retargets a call."""
+    hits = {}
+    for m in mods:
+        nm, _ = name_at(syms, m, addr)
+        if nm:
+            hits[m] = nm
+    if not hits:
+        return None, f"no candidate of {mods} defines {addr:#010x}"
+    if len(set(hits.values())) == 1:
+        return next(iter(hits.values())), None
+    if prefer in hits:
+        return hits[prefer], None
+    return None, f"{addr:#010x} names {hits}"
 
 
 def load_relocs():
@@ -211,10 +249,10 @@ def main():
             continue
         rel = r["file"].replace("\\", "/")
         miss = r.get("missing") or []
-        ph = [s for s in miss if is_stand_in(s, declared)]
+        ph = [s for s in miss if is_misnamed(s, declared)]
         if ph and rel in info:
             jobs.append((rel, ph,
-                         [s for s in miss if not is_stand_in(s, declared)]))
+                         [s for s in miss if not is_misnamed(s, declared)]))
 
     print(f"files with placeholder references: {len(jobs)}")
     print(f"  of those, blocked ONLY by placeholders: "
@@ -261,11 +299,11 @@ def main():
                 bad.append((sym, f"no reloc recorded at {addr + off:#010x}"))
                 continue
             to, spec = entry
-            mod = module_key(spec)
-            if mod is None:
-                bad.append((sym, f"dsd could not place it: module:{spec}"))
+            cands = module_keys(spec)
+            if not cands:
+                bad.append((sym, f"unparsed module spec: module:{spec}"))
                 continue
-            real, why = name_at(syms, mod, to)
+            real, why = resolve_in(syms, cands, to, label)
             if real is None:
                 bad.append((sym, why))
                 continue
@@ -294,6 +332,14 @@ def main():
             # undeclared variant below is then the only candidate, which is right.
             if not local and old in decl_type:
                 needed.append(decl_type[old].replace("@", real))
+
+        if renamed == original:
+            # The name never appears literally. It was produced by the compiler from
+            # a member call (`anim->SetAnim(...)`) or by mangling a declaration a
+            # second time, so there is no token to rewrite and renaming cannot fix
+            # it. Reporting these as rewritten would claim a repair that did not
+            # happen -- they need a different transform, not this one.
+            return rel, "not textual (needs a source transform, not a rename)", mapping
 
         def with_decls(text, decls):
             if not decls:

--- a/tools/resolve_placeholders.py
+++ b/tools/resolve_placeholders.py
@@ -53,6 +53,7 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 
 import match as M          # noqa: E402
+import eligible as E       # noqa: E402
 import modules as MOD      # noqa: E402
 from enroll import candidates  # noqa: E402
 
@@ -222,6 +223,10 @@ def main():
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("-j", "--jobs", type=int, default=10)
     ap.add_argument("--limit", type=int)
+    ap.add_argument("--allow-generic", action="store_true",
+                    help="apply renames whose target is only an address-shaped name "
+                         "(func_0208xxxx / data_ov004_0208xxxx); off by default because those "
+                         "record a gap in symbols.txt rather than a fix to the source")
     args = ap.parse_args()
 
     if not ELIGIBILITY.exists():
@@ -243,8 +248,16 @@ def main():
         info[rel.replace("\\", "/")] = (name, addr, size, d)
     mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
 
+    strict = None
+    try:
+        import reloc_audit as RA
+        import relocs as RL
+        strict = (RA, RA.build_name_index(), RA.build_config_relocs(), RL.load_all_syms())
+    except Exception as e:
+        print(f"  (reloc-destination check unavailable: {e}; verification is byte-only)")
+
     jobs = []
-    for r in json.loads(ELIGIBILITY.read_text()):
+    for r in E.load_report(ELIGIBILITY)[0]:
         if not (r.get("reason") or "").startswith("unresolvable"):
             continue
         rel = r["file"].replace("\\", "/")
@@ -259,6 +272,13 @@ def main():
           f"{sum(1 for _, _, o in jobs if not o)}")
 
     def verify(f, name, addr, size, label, flags):
+        """Bytes AND relocation destinations.
+
+        A byte compare cannot check this change: `match.py` treats every relocated
+        word as a wildcard, so the one thing a rename alters is the one thing it
+        cannot see. Byte-only agreement here means "still compiles to the same
+        shape", never "now calls the right function". `reloc_audit` is what actually
+        looks at the destination, so a rename is only verified if it passes too."""
         tgt = (M.target_bytes(addr, size) if label == "arm9"
                else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
         for v in M.SWEEP:
@@ -266,7 +286,19 @@ def main():
             if o is None:
                 continue
             code, rr = M.extract_func(o, name)
-            if code is not None and M.compare(tgt, code, rr, verbose=False)[0]:
+            if code is None or not M.compare(tgt, code, rr, verbose=False)[0]:
+                continue
+            if strict is None:
+                return True          # no config data here; byte-only, and said so
+            RA, name_index, config_relocs, sym_index = strict
+            try:
+                rows, _ = RA.check_destinations(o, name, addr, size, label,
+                                                name_index, config_relocs, sym_index)
+            except Exception:
+                rows = None
+            # A check that could not run is not a pass. Treat it like a failure so a
+            # broken lookup can never launder itself into a verified rename.
+            if rows is not None and not [r for r in rows if r["verdict"] == "WRONG-DEST"]:
                 return True
         return False
 
@@ -276,7 +308,8 @@ def main():
         name, addr, size, d = info[rel]
         label = d.relative_to(REPO / "config").as_posix()
         label = "arm9" if label == "arm9" else label.split("/")[-1]
-        original = f.read_text(encoding="utf-8", errors="ignore")
+        original_bytes = f.read_bytes()
+        original = original_bytes.decode("utf-8", "surrogateescape")
         flags = M.DEFAULT_FLAGS
         if f.suffix == ".cpp" or original.startswith("//cpp"):
             flags = flags.replace("-lang c99", "-lang c++")
@@ -312,6 +345,13 @@ def main():
                 continue
             mapping[sym] = real
 
+        # A target that is only an address-shaped name means symbols.txt never named
+        # that function. Renaming to it is not wrong -- it is the right address -- but
+        # it trades a wrong name for an anonymous one and buries the fact that the
+        # config has a gap. Surface it instead of quietly applying it.
+        generic = {o: r for o, r in mapping.items() if GENERIC.match(r)}
+        if generic and not args.allow_generic:
+            return rel, f"target unnamed in config: {sorted(generic.values())[:3]}", mapping
         left = set(ph) - set(mapping)
         if bad or left:
             return rel, f"unresolved: {bad or sorted(left)}", mapping
@@ -333,6 +373,15 @@ def main():
             if not local and old in decl_type:
                 needed.append(decl_type[old].replace("@", real))
 
+        untouched = [o for o in mapping
+                     if not re.search(r"(?<![\w])" + re.escape(o) + r"(?![\w])", original)]
+        if untouched and len(untouched) < len(mapping):
+            # Some names are textual and some are not. Rewriting only the textual ones
+            # leaves the file unresolvable, and calling that "rewritten" is the exact
+            # false success the not-textual outcome was added to stop -- it just
+            # survived in the mixed case.
+            f.write_bytes(original_bytes)
+            return rel, f"partial (not textual: {','.join(sorted(untouched)[:3])})", mapping
         if renamed == original:
             # The name never appears literally. It was produced by the compiler from
             # a member call (`anim->SetAnim(...)`) or by mangling a declaration a
@@ -358,19 +407,6 @@ def main():
                 return rel, "rewritten", mapping
         f.write_text(original, encoding="utf-8", newline="\n")
         return rel, "reverted (stopped matching)", mapping
-        tgt = (M.target_bytes(addr, size) if label == "arm9"
-               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
-        for v in M.SWEEP:
-            o2 = M.compile_c(f, v, flags)
-            if o2 is None:
-                continue
-            code, rr = M.extract_func(o2, name)
-            if code is None:
-                continue
-            if M.compare(tgt, code, rr, verbose=False)[0]:
-                return rel, "rewritten", mapping
-        f.write_text(original, encoding="utf-8", newline="\n")
-        return rel, "reverted (stopped matching)", mapping
 
     if args.limit:
         jobs = jobs[:args.limit]
@@ -382,7 +418,7 @@ def main():
             if key in ("resolvable", "rewritten") and len(samples) < 10:
                 samples.append((rel, mapping))
             elif key == "unresolved":
-                bad[re.sub(r"0x[0-9a-f]+", "0x…", verdict)[:110]] += 1
+                bad[re.sub(r"0x[0-9a-f]+", "0x'", verdict)[:110]] += 1
             elif key.startswith("reverted"):
                 print(f"  {verdict}: {rel}")
     print()


### PR DESCRIPTION
`match.py` compares a compiled function to the ROM word by word, but every **relocated word is a wildcard** — our object holds a placeholder where the ROM holds a final address. So the byte gate asks *"is there a call here"*, never *"a call to what"*. The ROM link would ask, but `eligible.py` won't enroll a file whose references don't resolve, so such a file never reaches the link.

The two gates cover for each other, and every reference bug in this tree has lived in that gap: 882 re-mangled names, 250 placeholder files, one fake vtable name standing in for 196 real symbols, and three outright wrong callees.

## `resolve_placeholders.py` — decide from the relocation, not the name

The trigger used to be a list of shapes we recognised (`G0`, `VT1`, names declared in a shared header). But the name isn't evidence — the call site's own relocation is:

```
from:0x021111e8 kind:load to:0x021099e4 module:overlay(2)
```

So the predicate is now simply *"unresolved"*, and the authority is the join `relocs.txt` → module → `symbols.txt`. Where dsd couldn't place the target (`module:overlays(0,4)`) the candidates' symbol tables settle it when only one defines that address — and it **refuses** when they genuinely disagree.

### Four honesty fixes, each of which was producing a false success

| | |
|---|---|
| **partial rewrites** | a rename leaving other names unfixed is now `partial`, not `rewritten`. The file stays unresolvable; calling it a repair was the same defect the `not textual` outcome was added to stop, surviving in the mixed case. |
| **verification** | now checks reloc destinations, not bytes alone. A byte compare wildcards relocations, so it is blind to precisely what a rename changes — byte agreement meant "same shape", never "right callee". |
| **generic targets** | a target that is only an address-shaped name is refused unless `--allow-generic`. It's the right address, but it trades a wrong name for an anonymous one and hides a gap in `symbols.txt`. |
| **revert** | restores original *bytes*. Writing decoded text back converted 50 CRLF files to LF — invisible under `core.autocrlf`, a dirty tree on the Linux worker. |

**Measured:** 64 rewritten · 126 not textual · 56 targets unnamed in config · 169 ambiguous · 10 reverted · 6 partial.

| | |
|---|---|
| enrolled | 10,468 → **10,532** (+64) |
| code bytes built | 83.71% → **84.03%** |
| reproducing | 10,532 / 10,532 |
| module fidelity | 106/106 exact, 100.000000% |
| ROM-build analysis | **PASS** |

A previous, less careful run reported **+70**. Six of those were the false successes above.

## `check_references.py` — close the hole instead of sweeping it

Sweeps remove instances; they don't stop the next one landing. This compares `eligible.py`'s own report against `config/unresolved-baseline.json` and fails when a change adds a reference that resolves to nothing.

Keyed on the **function symbol, never the path** — this project moves files and keys contributor lineage on those moves, so a path key reports every move as a regression. It compares each symbol's full missing-name list, not a set of keys, so adding a *second* bad reference to a symbol already in the backlog can't slip through.

Four ways such a check fails open, all closed, each with a test:

- **stale report** — `eligible.py` now stamps commit + dirty state; a report describing another commit is refused
- **reason-switching** — a symbol leaving the backlog must have become *eligible*, not merely started failing differently
- **extra references** — per-symbol list comparison
- **raised baseline** — `--update` only lowers; `--against` diffs the base branch's copy

The existing backlog is tolerated deliberately. Blocking every PR until it's empty just gets the check switched off.

**CI placement:** on the validation worker (it already has mwccarm/Wine) — `eligible.py` then `check_references.py`, gated to PRs touching `src/`, `include/`, or `config/`.

Reviewed by a Fable agent, which found the four false-success paths above plus the path-keying deadlock; all verified and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi