### PR TITLE
Ignore the port's runtime output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,9 @@ _glmwork/
 # emu-trace runtime capture output (tools/trace) - regenerable, may contain ROM-derived memory dumps
 /traces/
 /behavior/
+
+# port runtime output: rendered frames, smoke-test screenshots, playtest logs.
+# These are pixels the game drew from Nintendo's assets - same rule as the ROM.
+/frames/
+/playlog/
+*.bmp


### PR DESCRIPTION
Running the port writes rendered frames, smoke-test screenshots and playtest logs into the working tree. None of it is ignored, so a `git add -A` from a main checkout would commit pixels the game drew from Nintendo's assets.

Same rule as the ROM itself: regenerable locally, never in the repo.

```
/frames/
/playlog/
*.bmp
```

No `src/` changes, so `validate` has nothing to byte-check.