### PR TITLE
notes: four documents on references, types, and what is left

### DIFF
--- a/notes/declaration-centralization.md
+++ b/notes/declaration-centralization.md
@@ -1,0 +1,178 @@
+# Centralizing declarations
+
+## What "a declaration" is here, and why there are so many
+
+Every function in this tree lives in its own file, and any file that *calls* something
+outside itself has to tell the compiler that the thing exists. That statement is a
+**declaration**:
+
+```c
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+    u32 id, u32 param, const Vector3 *pos, const Vector3_16 *rot, s32 area, s32 unk);
+```
+
+It says nothing about what the function *does*. It says only: this name exists, it
+takes these types, it returns this type. The compiler needs that to emit a call; the
+linker later fills in the address.
+
+There is no rule saying two files must agree about it. Each file carries its own copy,
+written by whoever recovered that file. So the tree contains:
+
+```
+5,768  files carrying local `extern` declarations
+8,523  distinct names declared
+18,497 declaration lines
+```
+
+The same fact restated 18,497 times for 8,523 facts. `data_020a0eac` is declared
+independently in **339 files**.
+
+## Why they disagree, which is the actual problem
+
+They are not just duplicated. **27% of them contradict each other** — 3,592 of the
+13,279 locally-declared names that exist in `symbols.txt` are declared inconsistently
+across files. `ModelAnim::SetAnim` has **124 distinct spellings**:
+
+```c
+extern "C" int          @(ModelAnim*, BCA_File*, int, int, unsigned int)
+extern "C" int          @(char*, struct BCA_File*, int, int, unsigned int)
+extern "C" int          @(void*, void*, int, int, int)
+extern "C" unsigned int @(ModelAnim* thiz, BCA_File* f, int a, Fix12i b, unsigned int c)
+```
+
+`Actor::Spawn` has 117. `ApproachLinear` has 104.
+
+This is not carelessness, and that matters for how it gets fixed. **The byte gate could
+never object.** `match.py` compares a compiled function to the ROM word by word, but
+every relocated word is a wildcard, because our object holds a placeholder where the
+ROM holds a final address. A wrong parameter type usually does not change the emitted
+instruction at all — a pointer and an `int` are both one register — so a file could
+mistype every external it referenced and still match perfectly.
+
+The per-file declarations were **degrees of freedom the matcher was free to exploit**.
+Nothing ever forced them to converge, so they didn't.
+
+## What it costs
+
+Every naming problem becomes a tree-wide sweep, because the fact being fixed is stored
+in hundreds of places. This session ran five of them:
+
+| problem | scale | how it was fixed |
+|---|---|---|
+| C++ files re-mangling ROM names | 882 refs | 44 shared headers given `extern "C"` |
+| `G0`/`VT1`/`HEAP` placeholders | 250 files | resolved from relocation data |
+| one fake vtable name | **196 files, 196 real symbols** | same |
+| mis-recovered signatures | 106 refs | pending |
+| wrong callees | 3 functions | found only when enrollment forced a link |
+
+The instructive one is the first. Fixing **44 shared headers** enrolled three times as
+many functions as a **255-file** per-file sweep. Centralized facts are cheap to fix;
+scattered ones are not.
+
+## What centralizing means
+
+Instead of each file writing its own declaration, one **generated** header states each
+fact once, and files include it:
+
+```c
+/* include/decl_Actor.h -- generated; do not edit */
+#ifdef __cplusplus
+extern "C" {
+#endif
+void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+    u32, u32, const Vector3 *, const Vector3_16 *, s32, s32);
+#ifdef __cplusplus
+}
+#endif
+```
+
+Generated, not hand-written — a hand-maintained central header is the same unvalidated
+cache with a larger blast radius. The generator's inputs already exist and are already
+authoritative:
+
+- `config/**/symbols.txt` — every name and its address, per module
+- `config/**/relocs.txt` — every cross-reference dsd found in the real ROM
+- the **definition** in `src/` — the one place a signature is not a guess
+
+Then a wrong type is fixed once, and a *new* wrong type has nowhere to live.
+
+44 of these headers already exist (`include/decl_*.h`) and 1,780 files already include
+`decl_common.h`. This is extending something proven, not a new bet.
+
+## Why not do it all at once
+
+Byte-testing 55 real currently-matching files, with local declarations stripped and a
+generated header included instead:
+
+| group | result |
+|---|---|
+| 20 `.c`, declarations agreeing with the header | 14 match, 6 compile-fail |
+| 20 `.c`, non-majority declarations | 10 match, 9 conflicts surfaced, **1 real codegen change** |
+| 15 `.cpp` | **0 match** |
+
+Three things fall out, and each one shapes the plan.
+
+**About 40% need individual reconciliation.** The compile failures are not the tool
+breaking — they are the disagreements finally being forced into the open. Every one is
+a real question that has to be answered by a person: does `func_ov007_020b7948` return
+`void` as its definition says, or `int` as its callers say?
+
+**Declaration form can change codegen.** `src/func_ov002_020f2aec.c` only matches with
+`int` as the last parameter of `_ZN3G2x13SetBlendAlphaEPVttttt`; the header's `u16`
+forces a truncation at the call site and the function grows `0x108 -> 0x110`. Rare —
+1 in 25 — but real. Only the byte gate catches it, so every file must be byte-verified
+individually.
+
+**The `.cpp` half cannot take a shared header yet.** 0 of 15. C-harvested declarations
+are not C++-clean: an unknown type in a parameter list is a warning in C and a hard
+error in C++. That half needs its own approach.
+
+And one rule with evidence behind it: **never generate a signature from what the
+callers say.** 6 of the cleanest 20 failed exactly that way — the callers' majority
+spelling disagreed with the definition. The definition is the only non-guess.
+
+## Plan
+
+**Phase 0 — stop the bleeding first.** Land the reference ratchet (#1071) before any
+of this. Migrating 5,768 files while new inconsistencies are still landing is
+pointless.
+
+**Phase 1 — generate, do not migrate.** Write the generator; emit headers to a scratch
+directory; report how many names it can state confidently (definition available, one
+consistent signature) versus how many need a human. Nothing in `src/` changes. This
+turns "27% disagree" from a statistic into a worklist.
+
+**Phase 2 — migrate the agreeing names, `.c` only.** Strip local declarations where the
+generated header already says the same thing, in byte-verified batches under the
+validator's 200-file cap. Expect ~70% of files to pass mechanically. Reverts are
+information, not failure.
+
+**Phase 3 — reconcile the conflicts, one at a time.** Each is a genuine correctness
+question. Some will change bytes, and the gate will say so. This is the slow part and
+it does not parallelize well.
+
+**Phase 4 — extend the ratchet.** Once a name is centrally declared, forbid re-declaring
+it locally. That is a grep, and it is what makes the migration permanent instead of
+something that silently rots back.
+
+**Phase 5 — `.cpp`, separately, and only afterwards.** Different failure mode, different
+solution, no reason to couple it to the above.
+
+## What not to do
+
+- **No big-bang strip.** ~40% of files need individual attention; one enormous change
+  destroys reviewability, the 200-file validator cap, and attribution lineage, for no
+  extra correctness.
+- **No hand-maintained central header.** Generator output or nothing.
+- **Never generate from caller majority.** Definitions only.
+- **Do not relax the byte gate to ease migration.** It is the only thing that catches
+  the 1-in-25 silent codegen shift, and it is what made this cheap to measure at all.
+- **Do not start porting to real C++ classes first.** Real methods re-mangle and
+  reopen the war the 44 `extern "C"` headers just ended. Readability is the last pass,
+  after the byte war is over.
+
+## The one-sentence version
+
+The tree stores 18,497 copies of 8,523 facts, a quarter of the copies disagree, and
+nothing in the build could ever notice — so every fix costs a tree-wide sweep until the
+facts live in one place.

--- a/notes/overlay-ambiguous-references.md
+++ b/notes/overlay-ambiguous-references.md
@@ -1,0 +1,66 @@
+# 169 references that are ambiguous between overlays
+
+**Status:** open, needs a person. Drafted as a GitHub issue; not yet filed.
+
+169 functions cannot be enrolled because a reference in them targets an address that
+**two or more overlays both define**, and nothing in the data says which one was
+resident when the code ran.
+
+Tooling has taken this as far as it can. `tools/resolve_placeholders.py` resolves a
+reference by joining the call site's own relocation to the owning module and then to
+that module's symbol table:
+
+```
+from:0x021111e8 kind:load to:0x021099e4 module:overlay(2)
+```
+
+That works when dsd names one overlay. For these 169 it names several --
+`module:overlays(0,4)` -- because overlays share address space and dsd could not tell
+them apart either. Where only one candidate defines a symbol at the target address the
+tool settles it automatically. These are the cases where **both candidates define
+something, and the two disagree**:
+
+| references | name in source | candidates |
+|---:|---|---|
+| 22 | `func_020beb68` | `ov000:data_ov000_020beb68` vs `ov004:data_ov004_020beb68` |
+| 9 | `func_020aea30` | `ov002:func_ov002_020aea30` vs `ov004:_ZN5Enemy12KillByAttack...` |
+| 8 | `func_020ada40` | `ov002:func_ov002_020ada40` vs `ov004:_ZN5Enemy20KillByInvincib...` |
+| 6 | `func_020aed98` | `ov002:_ZN5EnemyC2Ev` vs `ov007:func_ov007_020aed98` |
+| 5 | `func_020bc7d4` | `ov000:data_ov000_020bc7d4` vs `ov004:data_ov004_020bc7d4` |
+| 5 | `_ZTV10dBgActor_c` | `ov006:data_ov006_0213c5bc` vs `ov098:data_ov098_0213c5bc` |
+
+A guess here is not cheap. `match.py` compares relocated words as wildcards, so picking
+the wrong overlay still byte-matches -- the mistake would surface only at the ROM link,
+and only for whichever files happen to get enrolled. That is exactly the blind spot
+that hid three wrong-callee bugs already (`Door::Behavior`, `func_ov004_020b29c0`,
+`func_ov004_020b2a84`).
+
+## What would settle it
+
+Any of these, per case:
+
+- **Overlay residency.** Which overlays are loaded together at the point this code
+  runs? If ov002 and ov004 are never resident simultaneously, the referring module's
+  own copy is the answer. An overlay load-order or scene-to-overlay map would resolve
+  most of the table above mechanically, and would keep paying off afterwards.
+- **Emulator trace.** Break on the call site and read the resolved target. See
+  `notes/emu-trace-plan.md`.
+- **Reading the code.** Several pairs are plainly the same function under two names --
+  `_ZN5Enemy12KillByAttack...` in ov004 against an unnamed `func_ov002_...` in ov002.
+  Confirming that also closes a naming gap in `symbols.txt`.
+
+## Reproducing the list
+
+```
+python tools/eligible.py
+python tools/resolve_placeholders.py          # report only; nothing is written
+```
+
+Everything reported as `0x... names {...}` is one of these.
+
+## Related
+
+- #1071 -- the resolver, and the ratchet that keeps new instances out
+- `notes/declaration-centralization.md` -- the larger structural problem behind
+  scattered, disagreeing references
+- `notes/rom-build.md` -- how enrollment and the ROM link fit together

--- a/notes/runbook-reference-repair.md
+++ b/notes/runbook-reference-repair.md
@@ -1,0 +1,170 @@
+# Runbook: repairing references between functions
+
+**Audience:** an agent or contributor picking this up cold. Follow it top to bottom.
+**Scope:** making a reference point at the symbol the ROM actually uses.
+**Not in scope:** parameter types -- see `runbook-type-reconstruction.md`.
+
+---
+
+## 1. The problem, in one paragraph
+
+`tools/match.py` compares a compiled function to the ROM word by word, but every
+**relocated** word is a wildcard: our object holds a placeholder where the ROM holds a
+final address. So on its own the byte gate asks *"is there a call here"* and never *"a call to
+what"*. (`match.py --strict-relocs` is now default-on and does check reloc
+destinations against `relocs.txt` -- but the corpus was matched before that existed, so
+for any file you did not personally re-verify, assume the weaker guarantee.) A file can name a callee that does not exist, or the wrong one, and still match
+perfectly. The ROM link would object, but `tools/eligible.py` refuses to enroll a file
+whose references do not resolve, so a broken file never reaches the link. The two gates
+cover for each other.
+
+**Consequence you must internalise:** a byte match is *not* evidence about references.
+Only enrollment plus the ROM link is.
+
+## 2. The authority
+
+Never guess from the name. The name is what a recovery pass wrote down; it is the thing
+under suspicion. The authority is dsd's analysis of the real ROM:
+
+```
+config/**/relocs.txt     from:0x021111e8 kind:load to:0x021099e4 module:overlay(2)
+config/**/symbols.txt    _ZN5Actor5SpawnEjj... kind:function(arm,size=0x54) addr:0x...
+```
+
+The join is: **compile the file -> read the relocation offsets out of the object ->
+add the function's address -> look up `from:` -> take `to:` and `module:` -> ask that
+module's `symbols.txt` for the name.**
+
+`tools/resolve_placeholders.py` implements exactly this. Do not reimplement it.
+
+## 3. Preconditions
+
+**Cold start:** `tools/mwccarm/**` and `extracted/**` are git-ignored, so a fresh clone
+has neither the 25 compilers nor the extracted ROM, and step 1 fails immediately. See
+`notes/rom-build.md` first.
+
+```sh
+cd <worktree>
+git status --porcelain          # must be clean; a dirty tree poisons the report
+python tools/eligible.py        # ~5 min, compiles ~11,100 files
+```
+
+`eligible.py` writes `build/rombuild-eligibility.json`, stamped with the commit it
+describes. Everything below reads it. **If you change `src/`, it is stale -- re-run it.**
+A stale report is the single easiest way to produce confident nonsense; it has already
+happened twice.
+
+## 4. The loop
+
+```sh
+python tools/resolve_placeholders.py                # report only, writes nothing
+python tools/resolve_placeholders.py --apply -j 16  # rewrite + verify + revert on fail
+```
+
+Read the outcome table before doing anything else. Each outcome means something
+different and only one of them is a fix:
+
+| outcome | meaning | action |
+|---|---|---|
+| `rewritten` | renamed, and it still reproduces the ROM with correct reloc destinations | keep |
+| `partial` | some names in the file are not textual; fixing only the rest leaves it broken | needs a source transform, not a rename |
+| `not textual` | the name is compiler-generated (a member call, or double-mangled) so there is no token to rewrite | needs a source transform |
+| `target unnamed in config` | the address resolves, but only to `func_0208xxxx` | that is a `symbols.txt` gap; name it there first |
+| `unresolved` | the join did not produce one answer | read the printed reason -- see below |
+| `reverted` | the rename stopped it matching | investigate; usually a type clash with a shared header |
+
+`unresolved` covers several distinct reasons; the tool prints which, and they are not
+interchangeable:
+
+- `0x... names {ov000: ..., ov004: ...}` -- two overlays both define it. **Stop**; see
+  `overlay-ambiguous-references.md`.
+- `no reloc recorded at 0x...` -- the value is not a relocation at all (an immediate).
+- `no candidate of [...] defines 0x...` -- a gap in `symbols.txt`, not in the source.
+- `resolves to both X and Y` -- one name used for two different targets in one file;
+  split it by hand.
+- `unparsed module spec` -- a `module:` form the tool does not know; report it.
+
+Report-only mode additionally prints `resolvable` for anything it *would* rewrite, and
+`compile failed` / `function not in object` if it could not get that far.
+
+**Never pass `--allow-generic` to make a number go up.** It trades a wrong name for an
+anonymous one and hides the config gap that caused it.
+
+## 5. Verification, in order
+
+```sh
+python tools/eligible.py                                   # refresh the report
+python tools/enroll.py --complete-list build/eligible-names.txt
+python tools/rombuild.py                                   # the real gate
+python tools/prepush_attribution.py                        # credit must not move
+python tools/check_references.py                           # must not regress
+```
+
+The only line that matters in the build output:
+
+```
+module fidelity: 106/106 exact, 100.000000% of compared bytes
+ROM-build analysis: PASS
+```
+
+Anything less than **106/106 and PASS** means a reference now points somewhere wrong.
+That is the gate doing its job -- read the named function, do not retry blindly.
+
+## 6. Reporting: the evidence split is mandatory
+
+Two different strengths of evidence, and conflating them is the most common way these
+changes get oversold:
+
+- **enrolled** -> the ROM link compared the resolved symbol against the real ROM word
+- **byte-verified only** -> still blocked for another reason; byte matching is blind to
+  relocation targets, i.e. blind to precisely what you changed
+
+Count both and state both. Never write "0 reverted" as though it were proof.
+
+```sh
+python - <<'PY'
+import json, pathlib, subprocess, collections, sys
+sys.path.insert(0,"tools"); import eligible as E
+rs = {r["file"].replace("\\","/"): r["reason"] for r in E.load_report()[0]}
+ch = subprocess.run(["git","diff","--name-only","origin/main","--","src"],
+                    capture_output=True, text=True).stdout.split()
+c = collections.Counter("enrolled (link-verified)" if rs.get(f) is None
+                        else "byte-verified only" for f in ch)
+print(len(ch), "changed:", dict(c))
+PY
+```
+
+## 7. Shipping
+
+- Validator caps **200 in-scope files** across `src include config mods
+  attribution.json`. Enforced server-side, so nothing in-repo will warn you -- count
+  before pushing and split if over.
+- Cut every batch **from `main`**, never stacked on the previous one -- a PR diff is
+  measured against main, so stacking defeats the cap.
+- `config/**/delinks.txt` is generated. If it conflicts, regenerate -- take `main`'s
+  copy, then re-run `python tools/eligible.py && python tools/enroll.py
+  --complete-list build/eligible-names.txt`. Never hand-merge.
+- The pre-push hook runs `port_refcheck.py`. A rename in `src/` can strand a
+  hand-written bridge in `port/`, which nothing else catches.
+
+## 8. Definition of done
+
+- [ ] `ROM-build analysis: PASS`, module fidelity 106/106 exact
+- [ ] attribution 0 changed, 0 lost
+- [ ] `check_references.py` does not regress; run `--update` to bank progress
+- [ ] enrolled vs byte-only split stated in the PR body
+- [ ] in-scope file count under 200
+- [ ] no `--allow-generic`, no hand-edited delinks
+
+## 9. Known dead ends
+
+- **Renaming a member call.** `anim->SetAnim(...)` generates its mangled name from the
+  declaration; there is no token to rewrite. It needs the call rewritten to an
+  `extern "C"` mangled free call with scalar args -- the dominant pattern in the corpus,
+  though I have no exact count and any figure you see quoted for it is unverified. This
+  is the `not textual` bucket.
+- **169 references remain genuinely ambiguous.** Two overlays define the same address.
+  Tooling is finished; these need overlay-residency data or an emulator trace.
+- **`is_misnamed()` returns `True` unconditionally.** That is deliberate: the name is
+  never evidence, so there is nothing to gate on. Narrowing it is how this cost five
+  separate sweeps.

--- a/notes/runbook-type-reconstruction.md
+++ b/notes/runbook-type-reconstruction.md
@@ -1,0 +1,259 @@
+# Runbook: reconstructing types, and migrating a function to real C++
+
+**Audience:** an agent or contributor picking this up cold.
+**Scope:** turning observed offsets into named, typed members, then rewriting a
+function to use them.
+**Not in scope:** which symbol a call targets -- see `runbook-reference-repair.md`.
+
+---
+
+## 1. What is actually wrong
+
+The compiler erased types in 2004 and the ROM is its output. A register holding a
+`Vector3*` and one holding an `int` are bit-identical; `ldr r1,[r0]` does not care what
+`r0` "is". So the ROM records addresses, instructions and relocations -- and no types,
+no signedness, no struct layouts.
+
+Nothing in the build can object to a wrong type, because a wrong type usually emits
+identical instructions. That is why the tree currently holds **18,497 declarations for
+8,523 names, 27% of which contradict each other**. `ModelAnim::SetAnim` has 124
+distinct spellings; `ApproachLinear` has 104. Those were degrees of freedom the matcher
+was free to exploit, and nothing ever forced them to converge.
+
+**The build is correct; the description is not.** All 10,532 *enrolled* functions
+reproduce the ROM byte-for-byte (the tree matches more than it enrolls -- see the README
+for the matched total). The types are wrong as *documentation*, not as *machinery*. This
+runbook is about making the description true.
+
+## 2. The three properties of a field, and how they differ
+
+This distinction is the whole safety model:
+
+| property | where it comes from | changing it |
+|---|---|---|
+| **offset / width** | *observed* from the accesses matched code happens to make | trustworthy, **not** authoritative -- see below |
+| **name** | a human | **always free** -- cannot change codegen |
+| **type** | a human | **never assume safe; byte-verify every time** |
+
+### Equal width is necessary and NOT sufficient
+
+The tempting rule is "same width, safe". It is false under mwccarm at `-O4,p`, and
+measured on this toolchain:
+
+| change | effect |
+|---|---|
+| `s16` -> `u16`, plain load | `ldrsh` (`e1d000f0`) vs `ldrh` (`e1d000b0`) |
+| `s8` -> `u8`, plain load | `ldrsb` vs `ldrb` |
+| `s32` -> `u32`, compared | `movgt/movle` vs `movhi/movls` |
+| `s32` -> `u32`, `>>` | `asr` vs `lsr` |
+| `s32` -> `u32`, `/2` | sign-fixup add disappears; **function shrinks 16 -> 12 bytes** |
+
+**Signedness is part of the type at every sub-word load, comparison, right shift and
+division.** Genuinely inert changes: renaming a field, a typedef alias (`Fix12i` is
+`typedef s32`), 32-bit load/store with no arithmetic, and int-vs-pointer in a parameter.
+
+### "Observed" is not "correct"
+
+The generated width is the width of the access matched code happened to make, not the
+field's real width. In this very family, `include/FaderWipe.h` declares
+`u8 mFadeAmount; /* 0x004 */` where `include/FaderColor.h` declares
+`s32 unk_004; /* 0x004 */` -- the same inherited field. Treat generated offsets as
+strong evidence, then reconcile across the whole hierarchy.
+
+`include/BrickBlock.h` carries the banner of the generator that produced it. **Note
+that generator is no longer in the tree** -- `tools/gen_header.py` does not exist, so
+these headers cannot currently be regenerated and must be edited by hand:
+
+```c
+/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
+ * class BrickBlock: 5 matched functions, 7 evidenced fields.
+ * Offsets/widths are observed, not guessed. Gaps are explicit padding.
+ * Field NAMES are placeholders - renaming cannot change codegen. */
+```
+
+So `s32 unk_008` -> `Fix12i currInterp` is inert (`Fix12i` is a `typedef` of `s32`;
+renaming and aliasing change nothing). `u16 unk_00c` -> `int` is not: it changes
+truncation at every use. There is a real instance in the tree --
+`func_ov002_020f2aec` only matches with `int` as the last parameter of
+`_ZN3G2x13SetBlendAlphaEPVttttt`, and declaring it `u16` forces a truncation at the
+call site that grows the function `0x108 -> 0x110`. **The narrower declaration is the
+broken one**, which is the opposite of the intuition that narrowing is conservative.
+
+Rule: **rename freely, treat every retype as codegen-affecting, and byte-verify.**
+
+## 3. The ladder, with the tree's own before/after
+
+**Rung 0 -- generated skeleton** (`include/BrickBlock.h`, today):
+
+```c
+struct BrickBlock {
+    u8  pad_000[0x8];
+    s32 unk_008;            /* 0x008 */
+    u16 unk_00c;            /* 0x00c */
+    u8  pad_00e[0xc6];
+    ...
+};
+```
+
+**Rung 1 -- reconstructed header** (`include/Fader.h`, fields done, vtable NOT):
+
+```c
+/* currInterp=0x4 and speed=0x8, both 4 bytes.
+ * FIXED POINT. currInterp runs 0..0x1000 -- 0.0..1.0 in 20.12. SetToEnd writes
+ * 0x1000 and SetToStart writes 0; SetForwardTime derives speed as 1.0/frames,
+ * which is why AdvanceInterp picks its target from the sign of speed. */
+struct Fader {
+    Fix12i currInterp;  /* 0x04 -- current fade level, 0..0x1000 */
+    Fix12i speed;       /* 0x08 -- per-frame delta; sign selects the target */
+```
+
+Note what the comment carries: not just names but the *range*, the *encoding*, and
+*why* the code branches the way it does. That is the deliverable. A renamed field with
+no explanation is a smaller lie, not a truth.
+
+**Two warnings this exemplar carries, both worth copying and one worth not copying.**
+
+*Copy this:* the header spells the class twice. Under `#else` (the C side) it declares
+an explicit `void* vtable; /* 0x00 */`, because a C translation unit gets no implicit
+vptr. Migrate one function of a polymorphic class without that and every C-side
+includer's offsets shift by 4.
+
+*Do not copy this:* the vtable half of `Fader.h` is **known wrong**. Dumping the four
+fader vtables out of `extracted/arm9_dec.bin` shows 10 slots each with Fader's slots
+2-9 null -- an abstract base -- while the header declares 7 non-pure virtuals, and
+`FaderBrightness.h` declares three of the missing methods non-virtual. Fields
+reconstructed, hierarchy not. Treat "this header looks finished" as a hypothesis and
+check the ROM's own vtable before building on it.
+
+**Rung 2 -- unmigrated function** (`src/_ZN10BrickBlockD0Ev.c`, today):
+
+```c
+int *_ZN10BrickBlockD0Ev(int *t)
+{
+    t[0] = (int)_ZTV10BrickBlock;
+    _ZN5ActorD2Ev(t);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
+    return t;
+}
+```
+
+`this` is an `int*`, members are array indices, the symbol name is spelled by hand.
+
+**Rung 3 -- migrated function** (`src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp`, done):
+
+```c
+//cpp
+// @symbol _ZN5Fader13AdvanceInterpEv
+#include "Fader.h"
+
+extern "C" void _Z14ApproachLinearRiii(Fix12i* value, Fix12i target, Fix12i step);
+
+/* Step currInterp one frame toward its target. A positive speed fades toward
+   1.0, a negative one toward 0.0; the helper takes an unsigned step. */
+void Fader::AdvanceInterp()
+{
+    Fix12i step = speed;
+    Fix12i target = step >= 0 ? 0x1000 : 0;
+    if (step < 0)
+        step = -step;
+    _Z14ApproachLinearRiii(&currInterp, target, step);
+}
+```
+
+Real method, implicit `this`, named typed members. **The compiler now mangles the
+symbol for you** -- `Fader::AdvanceInterp()` becomes `_ZN5Fader13AdvanceInterpEv`
+without anyone spelling it.
+
+Note the honest leftover: the helper is still called by its raw mangled name. **Migration
+is per-reference, not only per-function.** That line becomes
+`ApproachLinear(currInterp, target, step)` only once `ApproachLinear` has a proper
+declaration.
+
+## 4. How the migration touches files
+
+Nothing merges and nothing accumulates. The binding is one line in a generated file:
+
+```
+src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp:
+    complete
+    .text start:0x020175e8 end:0x02017610
+```
+
+An **address range is bound to a path**. The file must emit that symbol with those
+bytes; its contents are otherwise unconstrained. So migration is an **in-place rewrite**
+of one file, optionally moved into a subdirectory. The old text is replaced, not kept --
+git history is the only copy. Consolidating the ~11,100 one-function files into real TUs
+was measured and declined (byte-safe, worth only 14-19%).
+
+Files touched by one function's migration:
+
+| file | change | risk |
+|---|---|---|
+| `include/<Class>.h` | rename/retype fields, add the method declaration | shared -- affects every includer |
+| `src/<mangled>.cpp` | rewrite body; rename `.c` -> `.cpp` if needed | isolated |
+| `config/**/delinks.txt` | only if the path changed | generated; regenerate, never hand-edit |
+| `attribution.json` | credit follows the file | a move plus a rewrite in one commit breaks lineage |
+
+**The header is the dangerous one.** Retyping a field changes codegen in *every* file
+that touches it, not just the one being migrated. Always re-verify the whole build, not
+the single function.
+
+**One rule with teeth:** a commit may *rewrite* a file or *move* it, never both.
+Attribution pairs same-commit delete+add by stem and cannot follow a file that changed
+in the same commit it moved.
+
+## 5. Procedure
+
+**Cold start:** `tools/mwccarm/**` and `extracted/**` are git-ignored, so a fresh clone
+has neither the compilers nor the ROM and step 1 fails immediately. See
+`notes/rom-build.md` before anything below.
+
+```sh
+git status --porcelain                       # clean
+python tools/eligible.py                     # baseline, ~5 min
+python tools/check_references.py --update    # bank the starting point
+```
+
+1. **Pick a class with several matched functions.** `gen_header.py` needs evidence;
+   a class with one function yields a header of padding.
+2. **Read the existing generated header.** `tools/gen_header.py` is gone, so there is
+   nothing to regenerate -- the committed skeleton is the evidence you have. Cross-check
+   its offsets against every sibling header in the hierarchy before trusting a width.
+3. **Name and type the fields.** Same width unless you intend a codegen change. Write
+   the *why* in a comment -- range, encoding, what selects each branch.
+4. **Migrate one function.** Rung 2 -> rung 3. Keep the `// @symbol` line.
+5. **Byte-verify that function**, then the whole build, because the header is shared:
+
+```sh
+# --addr and --size come from config/**/symbols.txt for that symbol
+python tools/match.py --c src/<file> --func <symbol> --addr 0x... --size 0x... --module <mod>
+python tools/rombuild.py
+python tools/rombuild.py
+```
+
+6. Repeat per function. Move to a subdirectory only in a **separate commit**.
+
+## 6. Definition of done
+
+- [ ] `ROM-build analysis: PASS`, module fidelity 106/106 exact
+- [ ] enrolled count did not fall (`check_references.py`)
+- [ ] attribution 0 changed, 0 lost
+- [ ] every retyped field is same-width, or the width change is deliberate and stated
+- [ ] each field comment says what the value *means*, not just its offset
+- [ ] no commit both moves and rewrites a file
+
+## 7. Known dead ends
+
+- **Do not declare a method whose mangled name carries a by-value class parameter**
+  (`5Fix12IiE`). mwccarm homes `r0-r3` to the stack for any by-value class parameter,
+  costing +0x14. `notes/mwccarm-codegen.md` 6az records two compiler versions; it was
+  re-measured in the session that wrote this runbook across **all 25 versions in
+  `match.SWEEP` and every optimization level** (`-O0`..`-O4`, `,p` and `,s`), plus
+  `-Cpp_exceptions off` / `-RTTI off`, with no combination avoiding it.
+  Callers are affected too: `take_i(h, 0x800)` emits `mov r1,#0x800` while the
+  `Fix12<int>` form emits `ldr` + `ldm`. Keep those as `extern "C"` free functions with
+  scalar args. See `notes/mwccarm-codegen.md` 6az.
+- **Never derive a signature from what callers say.** They disagree 27% of the time.
+  The definition is the only non-guess.
+- **Do not migrate before the types are right.** A real `struct` built on guessed member
+  types is a lie that every later file inherits.


### PR DESCRIPTION
Pure additions. No code, no dependency on anything unlanded.

| file | what it is |
|---|---|
| `runbook-reference-repair.md` | making a reference point at the symbol the ROM actually uses |
| `runbook-type-reconstruction.md` | observed offsets → named typed members → a real C++ method |
| `declaration-centralization.md` | why 18,497 declarations exist for 8,523 names, and 27% disagree |
| `overlay-ambiguous-references.md` | the 169 references tooling cannot settle (filed as #1075) |

Both runbooks are written to be **followed literally** by someone picking the work up cold — exact commands, what each tool outcome means, verification order, definition of done, and the dead ends not worth rediscovering.

## A Fable agent validated these against the tree first

Worth it. The type runbook's first draft would have caused real damage:

- **Its central safety rule was wrong.** I'd written "retyping is safe at equal width." False under mwccarm at `-O4,p` — `s16 → u16` alone turns `ldrsh` into `ldrh`; `s32 → u32` flips `movgt/movle` to `movhi/movls` and `asr` to `lsr`; with a `/2` the sign-fixup vanishes and a function shrinks 16 → 12 bytes. Equal width is necessary, not sufficient.
- **It cited a generator that no longer exists** (`tools/gen_header.py` — I read it off the banner inside a header it produced, without checking).
- **Its one `match.py` invocation would have failed** (needs `--c`, no positional).
- **Its width example taught the inverse of the truth** — `SetBlendAlpha` grows when the parameter is *narrowed*, not widened.
- **Its exemplar header isn't "done"** — `Fader.h`'s fields are reconstructed but the ROM's fader vtables have 10 slots with Fader's 2–9 null (an abstract base) against 7 non-pure virtuals declared.

All corrected and independently re-verified before this PR.

## Why this is split out

Documentation shouldn't queue behind a code review. The README and AGENTS.md setup lines stay in #1071 — they describe the pre-push hook, and that hook calls `tools/check_references.py`, which lands there. Landing them here would leave a hook calling a missing tool and blocking every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi