### PR TITLE
attribution: collapse mitch030504 into mitchellcairns

### DIFF
--- a/attribution.json
+++ b/attribution.json
@@ -5,7 +5,8 @@
     "noreply": "tangosdev",
     "leonard.van.der.plaat": "lplaat",
     "andrew": "andrewboudreau",
-    "mitch.cairns": "mitchellcairns"
+    "mitch.cairns": "mitchellcairns",
+    "mitch030504": "mitchellcairns"
   },
   "overrides": {
     "src/func_02035860.c": "ruspecial",


### PR DESCRIPTION
Mitch's contributions were split across two GitHub accounts, so his total never moved on the contributor chart even though his work was landing.

- `mitchellcairns` (created 2016, "Mitch Cairns") carries the older hand-matched work: #461, #465, #466, #604, #861.
- `mitch030504` (created 2018) authors the tangOS Console PRs: #1054, #1057, #1073.

Three git identities feed those two buckets:

```
Mitch Cairns <mitch.cairns@handheldlegend.com>
Mitch Cairns <mitchellcairns@gmail.com>
mitch030504  <40723072+mitch030504@users.noreply.github.com>
```

The first two already collapse via the existing `mitch.cairns` alias. The third had none, so the chart showed two rows (11 and 6) and neither was his real total.

## The change

One line in `attribution.json`, which is exactly what that file documents itself for ("aliases collapse one person's many git identities into a single canonical GitHub login. Fix names here, never hand-edit contributions.json").

```json
"mitch030504": "mitchellcairns"
```

## Verification

Ran `tools/chaos_db_ci.py` locally against this change:

| | before | after |
|---|---|---|
| `mitchellcairns` | 11 | **17** |
| `mitch030504` | 6 | gone |
| roster size | 11 | 10 |

No other contributor's count changed, and the totals are untouched (11,138 / 11,347 functions either way).

`contributions.json` is deliberately not included. It is generated, and the refresh bot regenerates it from `attribution.json` on its next run.