### PR TITLE
Call ROM symbols directly where a local class declaration mangles to nothing

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -875,6 +875,7 @@ src/func_0200fa8c.c:
     .text start:0x0200fa8c end:0x0200fac4
 
 src/_ZN5Actor13LandingDustAtER7Vector3b.cpp:
+    complete
     .text start:0x0200fac4 end:0x0200fb4c
 
 src/_ZN5Actor15HugeLandingDustEb.c:
@@ -882,6 +883,7 @@ src/_ZN5Actor15HugeLandingDustEb.c:
     .text start:0x0200fb4c end:0x0200fb84
 
 src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp:
+    complete
     .text start:0x0200fb84 end:0x0200fc0c
 
 src/_ZN5Actor11LandingDustEb.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -152,6 +152,7 @@ src/func_ov002_020aefa4.c:
     .text start:0x020aefa4 end:0x020aefb8
 
 src/func_ov002_020aefb8.c:
+    complete
     .text start:0x020aefb8 end:0x020af0c0
 
 src/func_ov002_020af0c0.c:
@@ -879,6 +880,7 @@ src/func_ov002_020b5a70.c:
     .text start:0x020b5a70 end:0x020b5ab4
 
 src/func_ov002_020b5ab4.cpp:
+    complete
     .text start:0x020b5ab4 end:0x020b5b98
 
 src/func_ov002_020b5b98.c:
@@ -1161,6 +1163,7 @@ src/func_ov002_020b7e08.c:
     .text start:0x020b7e08 end:0x020b7e1c
 
 src/func_ov002_020b7e1c.cpp:
+    complete
     .text start:0x020b7e1c end:0x020b7f24
 
 src/func_ov002_020b7f24.c:
@@ -1671,6 +1674,7 @@ src/func_ov002_020bd20c.c:
     .text start:0x020bd20c end:0x020bd250
 
 src/func_ov002_020bd250.cpp:
+    complete
     .text start:0x020bd250 end:0x020bd354
 
 src/func_ov002_020bd354.c:
@@ -1968,6 +1972,7 @@ src/func_ov002_020c0fb4.c:
     .text start:0x020c0fb4 end:0x020c1234
 
 src/func_ov002_020c1234.cpp:
+    complete
     .text start:0x020c1234 end:0x020c133c
 
 src/func_ov002_020c133c.c:
@@ -2007,6 +2012,7 @@ src/func_ov002_020c1e44.c:
     .text start:0x020c1e44 end:0x020c1eb4
 
 src/func_ov002_020c1eb4.cpp:
+    complete
     .text start:0x020c1eb4 end:0x020c200c
 
 src/func_ov002_020c200c.c:
@@ -2030,6 +2036,7 @@ src/func_ov002_020c25a8.c:
     .text start:0x020c25a8 end:0x020c29d4
 
 src/func_ov002_020c29d4.cpp:
+    complete
     .text start:0x020c29d4 end:0x020c2b08
 
 src/func_ov002_020c2b08.c:
@@ -2129,6 +2136,7 @@ src/_ZN6Player15St_Respawn_MainEv.cpp:
     .text start:0x020c3f40 end:0x020c4088
 
 src/_ZN6Player15St_Respawn_InitEv.cpp:
+    complete
     .text start:0x020c4088 end:0x020c4188
 
 src/func_ov002_020c4188.c:
@@ -2414,6 +2422,7 @@ src/func_ov002_020c8f0c.cpp:
     .text start:0x020c8f0c end:0x020c8f80
 
 src/func_ov002_020c8f80.cpp:
+    complete
     .text start:0x020c8f80 end:0x020c904c
 
 src/func_ov002_020c904c.c:
@@ -2637,6 +2646,7 @@ src/func_ov002_020cac60.c:
     .text start:0x020cac60 end:0x020cad10
 
 src/_ZN6Player18St_CameraZoom_MainEv.cpp:
+    complete
     .text start:0x020cad10 end:0x020cae10
 
 src/func_ov002_020cae10.c:
@@ -2899,9 +2909,11 @@ src/func_ov002_020d0178.c:
     .text start:0x020d0178 end:0x020d0580
 
 src/func_ov002_020d0580.cpp:
+    complete
     .text start:0x020d0580 end:0x020d06c0
 
 src/func_ov002_020d06c0.cpp:
+    complete
     .text start:0x020d06c0 end:0x020d0824
 
 src/_ZN6Player17St_LedgeGrab_MainEv.cpp:
@@ -3084,6 +3096,7 @@ src/func_ov002_020d4748.cpp:
     .text start:0x020d4748 end:0x020d4c30
 
 src/func_ov002_020d4c30.cpp:
+    complete
     .text start:0x020d4c30 end:0x020d4d88
 
 src/func_ov002_020d4d88.c:
@@ -3724,6 +3737,7 @@ src/func_ov002_020df300.c:
     .text start:0x020df300 end:0x020df34c
 
 src/func_ov002_020df34c.cpp:
+    complete
     .text start:0x020df34c end:0x020df3c8
 
 src/_ZN6Player14St_Owl_CleanupEv.cpp:
@@ -3755,6 +3769,7 @@ src/func_ov002_020df8f0.c:
     .text start:0x020df8f0 end:0x020dfdf0
 
 src/_ZN6Player11St_Fly_MainEv.cpp:
+    complete
     .text start:0x020dfdf0 end:0x020e027c
 
 src/_ZN6Player11St_Fly_InitEv.cpp:
@@ -4214,6 +4229,7 @@ src/func_ov002_020e8098.cpp:
     .text start:0x020e8098 end:0x020e81e0
 
 src/func_ov002_020e81e0.cpp:
+    complete
     .text start:0x020e81e0 end:0x020e8244
 
 src/func_ov002_020e8244.c:
@@ -4432,6 +4448,7 @@ src/_ZN4Tree8BehaviorEv.cpp:
     .text start:0x020ec1d8 end:0x020ec22c
 
 src/_ZN4Tree13InitResourcesEv.cpp:
+    complete
     .text start:0x020ec22c end:0x020ec32c
 
 src/Tree_Spawn.cpp:

--- a/config/arm9/overlays/ov003/delinks.txt
+++ b/config/arm9/overlays/ov003/delinks.txt
@@ -19,6 +19,7 @@ src/func_ov003_020ad7a0.c:
     .text start:0x020ad7a0 end:0x020ad7a4
 
 src/func_ov003_020ad7a4.cpp:
+    complete
     .text start:0x020ad7a4 end:0x020ad814
 
 src/func_ov003_020ad814.cpp:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -17,6 +17,7 @@ src/Camera_UpdateMatrices.c:
     .text start:0x020c0134 end:0x020c0264
 
 src/func_ov006_020c0264.cpp:
+    complete
     .text start:0x020c0264 end:0x020c0304
 
 src/func_ov006_020c0304.c:
@@ -75,6 +76,7 @@ src/func_ov006_020c0ce8.c:
     .text start:0x020c0ce8 end:0x020c0d68
 
 src/func_ov006_020c0d68.cpp:
+    complete
     .text start:0x020c0d68 end:0x020c0df0
 
 src/func_ov006_020c0df0.cpp:
@@ -106,6 +108,7 @@ src/func_ov006_020c11c0.cpp:
     .text start:0x020c11c0 end:0x020c1420
 
 src/func_ov006_020c1420.cpp:
+    complete
     .text start:0x020c1420 end:0x020c14bc
 
 src/func_ov006_020c14bc.cpp:
@@ -128,6 +131,7 @@ src/func_ov006_020c1760.c:
     .text start:0x020c1760 end:0x020c1764
 
 src/func_ov006_020c1764.cpp:
+    complete
     .text start:0x020c1764 end:0x020c1804
 
 src/func_ov006_020c1804.cpp:
@@ -556,6 +560,7 @@ src/func_ov006_020c6ca4.c:
     .text start:0x020c6ca4 end:0x020c6e4c
 
 src/func_ov006_020c6e4c.cpp:
+    complete
     .text start:0x020c6e4c end:0x020c6f3c
 
 src/func_ov006_020c6f3c.c:
@@ -643,6 +648,7 @@ src/func_ov006_020c78ec.cpp:
     .text start:0x020c78ec end:0x020c79a8
 
 src/func_ov006_020c79a8.cpp:
+    complete
     .text start:0x020c79a8 end:0x020c7a30
 
 src/func_ov006_020c7a30.c:
@@ -666,6 +672,7 @@ src/func_ov006_020c8048.c:
     .text start:0x020c8048 end:0x020c8084
 
 src/func_ov006_020c8084.cpp:
+    complete
     .text start:0x020c8084 end:0x020c814c
 
 src/func_ov006_020c814c.cpp:
@@ -789,6 +796,7 @@ src/func_ov006_020c8ecc.cpp:
     .text start:0x020c8ecc end:0x020c8f20
 
 src/func_ov006_020c8f20.cpp:
+    complete
     .text start:0x020c8f20 end:0x020c9024
 
 src/func_ov006_020c9024.cpp:
@@ -800,6 +808,7 @@ src/func_ov006_020c905c.c:
     .text start:0x020c905c end:0x020c9098
 
 src/func_ov006_020c9098.c:
+    complete
     .text start:0x020c9098 end:0x020c91ac
 
 src/func_ov006_020c91ac.cpp:
@@ -819,6 +828,7 @@ src/func_ov006_020c9aa0.cpp:
     .text start:0x020c9aa0 end:0x020c9c8c
 
 src/func_ov006_020c9c8c.c:
+    complete
     .text start:0x020c9c8c end:0x020c9d7c
 
 src/func_ov006_020c9d7c.c:
@@ -858,6 +868,7 @@ src/func_ov006_020ca39c.c:
     .text start:0x020ca39c end:0x020ca3a8
 
 src/func_ov006_020ca3a8.cpp:
+    complete
     .text start:0x020ca3a8 end:0x020ca430
 
 src/func_ov006_020ca430.c:
@@ -944,6 +955,7 @@ src/func_ov006_020cb16c.c:
     .text start:0x020cb16c end:0x020cb1a8
 
 src/func_ov006_020cb1a8.c:
+    complete
     .text start:0x020cb1a8 end:0x020cb2b4
 
 src/func_ov006_020cb2b4.c:
@@ -951,6 +963,7 @@ src/func_ov006_020cb2b4.c:
     .text start:0x020cb2b4 end:0x020cb528
 
 src/func_ov006_020cb528.c:
+    complete
     .text start:0x020cb528 end:0x020cb5c4
 
 src/func_ov006_020cb5c4.c:
@@ -958,6 +971,7 @@ src/func_ov006_020cb5c4.c:
     .text start:0x020cb5c4 end:0x020cb690
 
 src/func_ov006_020cb690.cpp:
+    complete
     .text start:0x020cb690 end:0x020cb72c
 
 src/func_ov006_020cb72c.c:
@@ -2761,6 +2775,7 @@ src/func_ov006_020e7be8.cpp:
     .text start:0x020e7be8 end:0x020e7cc0
 
 src/func_ov006_020e7cc0.cpp:
+    complete
     .text start:0x020e7cc0 end:0x020e7d7c
 
 src/func_ov006_020e7d7c.c:
@@ -6711,6 +6726,7 @@ src/func_ov006_021231ac.c:
     .text start:0x021231ac end:0x02123340
 
 src/func_ov006_02123340.cpp:
+    complete
     .text start:0x02123340 end:0x02123428
 
 src/func_ov006_0212373c.c:

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -122,6 +122,7 @@ src/_ZN13PeachPainting6RenderEv.cpp:
     .text start:0x02111ee8 end:0x02111f28
 
 src/_ZN13PeachPainting8BehaviorEv.cpp:
+    complete
     .text start:0x02111f28 end:0x02111fc0
 
 src/_ZN13PeachPainting13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -56,6 +56,7 @@ src/func_ov014_021115ec.cpp:
     .text start:0x021115ec end:0x02111a6c
 
 src/func_ov014_02111a6c.cpp:
+    complete
     .text start:0x02111a6c end:0x02111af0
 
 src/func_ov014_02111af0.c:
@@ -79,6 +80,7 @@ src/func_ov014_02111e14.c:
     .text start:0x02111e14 end:0x02111e74
 
 src/func_ov014_02111e74.cpp:
+    complete
     .text start:0x02111e74 end:0x02111ebc
 
 src/func_ov014_02111ebc.cpp:
@@ -149,6 +151,7 @@ src/_ZN15ChainChompFenceD0Ev.c:
     .text start:0x02112e50 end:0x02112ea8
 
 src/func_ov014_02112ea8.cpp:
+    complete
     .text start:0x02112ea8 end:0x02112f3c
 
 src/_ZN15ChainChompFence16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -104,6 +104,7 @@ src/func_ov015_02111d8c.c:
     .text start:0x02111d8c end:0x02111d98
 
 src/func_ov015_02111d98.cpp:
+    complete
     .text start:0x02111d98 end:0x02111dd4
 
 src/func_ov015_02111dd4.c:

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -76,6 +76,7 @@ src/func_ov018_02111bf0.c:
     .text start:0x02111bf0 end:0x02111d28
 
 src/func_ov018_02111d28.cpp:
+    complete
     .text start:0x02111d28 end:0x02111e28
 
 src/func_ov018_02111e28.cpp:
@@ -83,6 +84,7 @@ src/func_ov018_02111e28.cpp:
     .text start:0x02111e28 end:0x02111f1c
 
 src/func_ov018_02111f1c.cpp:
+    complete
     .text start:0x02111f1c end:0x02111fac
 
 src/func_ov018_02111fac.c:
@@ -146,6 +148,7 @@ src/func_ov018_021126f8.c:
     .text start:0x021126f8 end:0x02112730
 
 src/func_ov018_02112730.cpp:
+    complete
     .text start:0x02112730 end:0x0211278c
 
 src/PowerStarCreate_Spawn.c:

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -274,6 +274,7 @@ src/_ZN13RollingLogLll8BehaviorEv.cpp:
     .text start:0x02112800 end:0x021128b8
 
 src/_ZN13RollingLogLll13InitResourcesEv.cpp:
+    complete
     .text start:0x021128b8 end:0x02112918
 
 src/VolcanoFire_Spawn.c:

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -161,6 +161,7 @@ src/func_ov030_0211360c.cpp:
     .text start:0x0211360c end:0x021136b0
 
 src/func_ov030_02113a80.cpp:
+    complete
     .text start:0x02113a80 end:0x02113b38
 
 src/func_ov030_02113b38.cpp:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -142,6 +142,7 @@ src/_ZN10DonutBlock6RenderEv.cpp:
     .text start:0x02111df8 end:0x02111e20
 
 src/_ZN10DonutBlock8BehaviorEv.cpp:
+    complete
     .text start:0x02111e20 end:0x02111eb0
 
 src/_ZN10DonutBlock13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -52,6 +52,7 @@ src/func_ov062_02116498.c:
     .text start:0x02116498 end:0x021164e8
 
 src/func_ov062_021164e8.cpp:
+    complete
     .text start:0x021164e8 end:0x021165e0
 
 src/func_ov062_021165e0.c:
@@ -103,6 +104,7 @@ src/Chuckya_ChangeState.cpp:
     .text start:0x02116cd8 end:0x02116d28
 
 src/func_ov062_02116d28.cpp:
+    complete
     .text start:0x02116d28 end:0x02116dbc
 
 src/func_ov062_02116dbc.cpp:
@@ -197,6 +199,7 @@ src/func_ov062_02117c98.c:
     .text start:0x02117c98 end:0x02118004
 
 src/func_ov062_02118004.cpp:
+    complete
     .text start:0x02118004 end:0x02118058
 
 src/func_ov062_02118058.c:
@@ -316,6 +319,7 @@ src/func_ov062_021199ac.c:
     .text start:0x021199ac end:0x02119af0
 
 src/func_ov062_02119af0.cpp:
+    complete
     .text start:0x02119af0 end:0x02119be0
 
 src/func_ov062_02119be0.c:
@@ -390,6 +394,7 @@ src/_ZN9KoopaFlag8BehaviorEv.cpp:
     .text start:0x0211b05c end:0x0211b168
 
 src/_ZN9KoopaFlag13InitResourcesEv.cpp:
+    complete
     .text start:0x0211b168 end:0x0211b208
 
 src/KoopaFlag_Spawn.c:
@@ -421,6 +426,7 @@ src/func_ov062_0211b800.c:
     .text start:0x0211b800 end:0x0211b880
 
 src/func_ov062_0211b880.cpp:
+    complete
     .text start:0x0211b880 end:0x0211b8d8
 
 src/func_ov062_0211b8d8.cpp:
@@ -428,6 +434,7 @@ src/func_ov062_0211b8d8.cpp:
     .text start:0x0211b8d8 end:0x0211b930
 
 src/func_ov062_0211b930.cpp:
+    complete
     .text start:0x0211b930 end:0x0211ba84
 
 src/func_ov062_0211ba84.c:
@@ -435,6 +442,7 @@ src/func_ov062_0211ba84.c:
     .text start:0x0211ba84 end:0x0211bc54
 
 src/func_ov062_0211bc54.cpp:
+    complete
     .text start:0x0211bc54 end:0x0211bd10
 
 src/func_ov062_0211c218.c:

--- a/config/arm9/overlays/ov063/delinks.txt
+++ b/config/arm9/overlays/ov063/delinks.txt
@@ -531,6 +531,7 @@ src/actors/MadPiano/_ZN8MadPiano6RenderEv.cpp:
     .text start:0x0211de8c end:0x0211deb8
 
 src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp:
+    complete
     .text start:0x0211deb8 end:0x0211dfac
 
 src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -53,9 +53,11 @@ src/func_ov064_021163bc.c:
     .text start:0x021163bc end:0x021163c0
 
 src/func_ov064_021163c0.cpp:
+    complete
     .text start:0x021163c0 end:0x02116460
 
 src/func_ov064_02116460.cpp:
+    complete
     .text start:0x02116460 end:0x02116560
 
 src/func_ov064_02116560.cpp:
@@ -473,6 +475,7 @@ src/_ZN17BowserPuzzlePiece8BehaviorEv.cpp:
     .text start:0x021198bc end:0x0211992c
 
 src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp:
+    complete
     .text start:0x0211992c end:0x02119a18
 
 src/JetStream_Spawn.c:
@@ -564,6 +567,10 @@ src/func_ov064_0211a39c.cpp:
 src/func_ov064_0211a49c.c:
     complete
     .text start:0x0211a49c end:0x0211a4c4
+
+src/func_ov064_0211a4c4.c:
+    complete
+    .text start:0x0211a4c4 end:0x0211a6e0
 
 src/func_ov064_0211a6e0.c:
     complete

--- a/config/arm9/overlays/ov066/delinks.txt
+++ b/config/arm9/overlays/ov066/delinks.txt
@@ -63,6 +63,7 @@ src/func_ov066_02116c6c.c:
     .text start:0x02116c6c end:0x02116d14
 
 src/func_ov066_02116d14.cpp:
+    complete
     .text start:0x02116d14 end:0x02116db0
 
 src/func_ov066_02116db0.c:

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -13,6 +13,7 @@ src/_ZN6FlyGuyD0Ev.c:
     .text start:0x0211f048 end:0x0211f0a4
 
 src/func_ov070_0211f0a4.cpp:
+    complete
     .text start:0x0211f0a4 end:0x0211f100
 
 src/func_ov070_0211f100.cpp:
@@ -31,6 +32,7 @@ src/func_ov070_0211f48c.c:
     .text start:0x0211f48c end:0x0211f5f0
 
 src/func_ov070_0211f5f0.cpp:
+    complete
     .text start:0x0211f5f0 end:0x0211f62c
 
 src/func_ov070_0211f62c.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -48,6 +48,7 @@ src/func_ov071_0211f6f8.cpp:
     .text start:0x0211f6f8 end:0x0211f7d4
 
 src/func_ov071_0211f7d4.c:
+    complete
     .text start:0x0211f7d4 end:0x0211f8d0
 
 src/func_ov071_0211f8d0.cpp:

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -113,6 +113,7 @@ src/func_ov075_02114be4.cpp:
     .text start:0x02114be4 end:0x02114cd8
 
 src/func_ov075_02114cd8.cpp:
+    complete
     .text start:0x02114cd8 end:0x02114ddc
 
 src/func_ov075_02114ddc.cpp:
@@ -148,6 +149,7 @@ src/func_ov075_02115290.c:
     .text start:0x02115290 end:0x021152d4
 
 src/func_ov075_021152d4.cpp:
+    complete
     .text start:0x021152d4 end:0x02115388
 
 src/_ZN14UnknownVsEntry16CleanupResourcesEv.cpp:
@@ -266,6 +268,7 @@ src/func_ov075_021173a8.c:
     .text start:0x021173a8 end:0x02117590
 
 src/func_ov075_02117590.cpp:
+    complete
     .text start:0x02117590 end:0x0211763c
 
 src/func_ov075_0211763c.c:
@@ -360,6 +363,7 @@ src/func_ov075_0211944c.c:
     .text start:0x0211944c end:0x021194e4
 
 src/func_ov075_021194e4.cpp:
+    complete
     .text start:0x021194e4 end:0x02119640
 
 src/func_ov075_02119640.c:
@@ -387,6 +391,7 @@ src/func_ov075_02119918.c:
     .text start:0x02119918 end:0x021199d8
 
 src/func_ov075_021199d8.cpp:
+    complete
     .text start:0x021199d8 end:0x02119b34
 
 src/func_ov075_02119b34.c:

--- a/config/arm9/overlays/ov077/delinks.txt
+++ b/config/arm9/overlays/ov077/delinks.txt
@@ -80,6 +80,7 @@ src/func_ov077_021243c0.cpp:
     .text start:0x021243c0 end:0x021244d4
 
 src/func_ov077_021244d4.cpp:
+    complete
     .text start:0x021244d4 end:0x02124564
 
 src/func_ov077_02124564.c:

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -32,6 +32,7 @@ src/func_ov078_02123aa0.c:
     .text start:0x02123aa0 end:0x02123bc4
 
 src/func_ov078_02123bc4.cpp:
+    complete
     .text start:0x02123bc4 end:0x02123c20
 
 src/func_ov078_02123c20.cpp:

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -216,6 +216,7 @@ src/func_ov079_02126f64.cpp:
     .text start:0x02126f64 end:0x02126f8c
 
 src/func_ov079_02126f8c.cpp:
+    complete
     .text start:0x02126f8c end:0x02127090
 
 src/func_ov079_02127090.cpp:
@@ -251,6 +252,7 @@ src/_ZN12FortressWall6RenderEv.cpp:
     .text start:0x02127364 end:0x021273a4
 
 src/_ZN12FortressWall8BehaviorEv.cpp:
+    complete
     .text start:0x021273a4 end:0x02127494
 
 src/_ZN12FortressWall13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -40,6 +40,7 @@ src/func_ov080_02123c24.c:
     .text start:0x02123c24 end:0x02123ecc
 
 src/func_ov080_02123ecc.cpp:
+    complete
     .text start:0x02123ecc end:0x02123fcc
 
 src/func_ov080_02123fcc.cpp:

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -106,6 +106,7 @@ src/func_ov081_02124b98.cpp:
     .text start:0x02124b98 end:0x02124d14
 
 src/func_ov081_02124d14.cpp:
+    complete
     .text start:0x02124d14 end:0x02124d50
 
 src/func_ov081_02124d50.cpp:
@@ -137,6 +138,7 @@ src/func_ov081_02125038.cpp:
     .text start:0x02125038 end:0x02125068
 
 src/func_ov081_02125068.cpp:
+    complete
     .text start:0x02125068 end:0x021250c8
 
 src/func_ov081_021250c8.c:
@@ -397,6 +399,7 @@ src/_ZN8IceBlockD0Ev.c:
     .text start:0x02127b80 end:0x02127be0
 
 src/func_ov081_02127be0.cpp:
+    complete
     .text start:0x02127be0 end:0x02127ccc
 
 src/func_ov081_02127ccc.cpp:

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -21,6 +21,7 @@ src/func_ov084_02129168.cpp:
     .text start:0x02129168 end:0x02129238
 
 src/func_ov084_02129238.cpp:
+    complete
     .text start:0x02129238 end:0x0212934c
 
 src/func_ov084_0212934c.c:
@@ -65,6 +66,7 @@ src/func_ov084_02129ed4.c:
     .text start:0x02129ed4 end:0x0212a580
 
 src/func_ov084_0212a580.cpp:
+    complete
     .text start:0x0212a580 end:0x0212a6f8
 
 src/func_ov084_0212a6f8.c:
@@ -164,6 +166,7 @@ src/func_ov084_0212c8b0.cpp:
     .text start:0x0212c8b0 end:0x0212c92c
 
 src/func_ov084_0212c92c.cpp:
+    complete
     .text start:0x0212c92c end:0x0212c960
 
 src/func_ov084_0212c960.cpp:

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -20,6 +20,7 @@ src/func_ov085_021291ac.c:
     .text start:0x021291ac end:0x0212943c
 
 src/func_ov085_0212943c.cpp:
+    complete
     .text start:0x0212943c end:0x02129470
 
 src/func_ov085_02129470.cpp:
@@ -49,6 +50,10 @@ src/_ZN4Toad16CleanupResourcesEv.cpp:
 src/_ZN4Toad6RenderEv.cpp:
     complete
     .text start:0x02129854 end:0x02129878
+
+src/_ZN4Toad8BehaviorEv.cpp:
+    complete
+    .text start:0x02129878 end:0x02129a7c
 
 src/_ZN4Toad13InitResourcesEv.c:
     complete
@@ -243,6 +248,7 @@ src/func_ov085_0212bdbc.cpp:
     .text start:0x0212bdbc end:0x0212bedc
 
 src/func_ov085_0212bedc.cpp:
+    complete
     .text start:0x0212bedc end:0x0212c004
 
 src/_ZN6Rabbit16CleanupResourcesEv.c:
@@ -386,6 +392,7 @@ src/func_ov085_0212ddc4.cpp:
     .text start:0x0212ddc4 end:0x0212de5c
 
 src/func_ov085_0212de5c.cpp:
+    complete
     .text start:0x0212de5c end:0x0212df84
 
 src/func_ov085_0212df84.cpp:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -17,6 +17,7 @@ src/func_ov091_02130fac.cpp:
     .text start:0x02130fac end:0x02131070
 
 src/func_ov091_02131070.cpp:
+    complete
     .text start:0x02131070 end:0x021310fc
 
 src/func_ov091_021310fc.cpp:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -104,6 +104,7 @@ src/func_ov102_0214953c.c:
     .text start:0x0214953c end:0x02149610
 
 src/func_ov102_02149610.cpp:
+    complete
     .text start:0x02149610 end:0x02149684
 
 src/func_ov102_02149684.c:
@@ -223,6 +224,7 @@ src/func_ov102_0214aa10.c:
     .text start:0x0214aa10 end:0x0214aa18
 
 src/func_ov102_0214aa18.cpp:
+    complete
     .text start:0x0214aa18 end:0x0214ab1c
 
 src/func_ov102_0214ab1c.c:
@@ -362,6 +364,7 @@ src/func_ov102_0214cbec.cpp:
     .text start:0x0214cbec end:0x0214ce60
 
 src/func_ov102_0214ce60.cpp:
+    complete
     .text start:0x0214ce60 end:0x0214cf4c
 
 src/func_ov102_0214cf4c.cpp:

--- a/src/_ZN10DonutBlock8BehaviorEv.cpp
+++ b/src/_ZN10DonutBlock8BehaviorEv.cpp
@@ -9,6 +9,12 @@ struct Platform {
     bool IsClsnInRange(Fix12 a, Fix12 b);
     void UpdateClsnPosAndRot();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" bool _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *, Fix12 a, Fix12 b);
+
 
 int DonutBlock::Behavior()
 {
@@ -23,7 +29,7 @@ int DonutBlock::Behavior()
     }
     Platform *p = (Platform *)((char *)this);
     p->UpdateModelPosAndRotY();
-    if (p->IsClsnInRange(0, 0))
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(p, 0, 0))
         p->UpdateClsnPosAndRot();
     return 1;
 }

--- a/src/_ZN12FortressWall8BehaviorEv.cpp
+++ b/src/_ZN12FortressWall8BehaviorEv.cpp
@@ -22,6 +22,12 @@ extern "C" void func_020393a4(int *p, int v);
 struct Platform : ActorBase {
     int IsClsnInRange(int a, int b);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *, int a, int b);
+
 
 extern "C" int _ZN12FortressWall8BehaviorEv(Platform *self) {
     int ok = (*(unsigned short *)((char *)self + 0xc) == 0x30);
@@ -42,6 +48,6 @@ extern "C" int _ZN12FortressWall8BehaviorEv(Platform *self) {
         return 1;
     }
     func_020393a4((int *)((char *)self + 0x124), 0x240000);
-    self->IsClsnInRange(0x240000, 0);
+    _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(self, 0x240000, 0);
     return 1;
 }

--- a/src/_ZN13PeachPainting8BehaviorEv.cpp
+++ b/src/_ZN13PeachPainting8BehaviorEv.cpp
@@ -5,6 +5,12 @@
 struct Actor { int DistToCPlayer(); };
 namespace cstd { int fdiv(int a, int b); }
 struct ModelBase { void ApplyOpacity(unsigned int o, int x); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelBase12ApplyOpacityEj(void *, unsigned int o, int x);
+
 
 int PeachPainting::Behavior()
 {
@@ -18,6 +24,6 @@ int PeachPainting::Behavior()
         int o = (int)(((long long)q * 0xff + 0x800) >> 12);
         mOpacity = (unsigned char)(o >> 3);
     }
-    ((ModelBase *)((char *)&mModel))->ApplyOpacity(mOpacity, 1);
+    _ZN9ModelBase12ApplyOpacityEj((ModelBase *)((char *)&mModel), mOpacity, 1);
     return 1;
 }

--- a/src/_ZN13RollingLogLll13InitResourcesEv.cpp
+++ b/src/_ZN13RollingLogLll13InitResourcesEv.cpp
@@ -8,12 +8,18 @@ struct Actor;
 struct MovingCylinderClsn {
     void Init(Actor *a, int b, int c, unsigned int d, unsigned int e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor *a, int b, int c, unsigned int d, unsigned int e);
+
 
 int RollingLogLll::InitResources()
 {
     char *c = (char*)((Actor *)this);
     *(int*)(c + 0xa0) = -0xc8000;
-    ((MovingCylinderClsn*)(c + 0xd4))->Init(((Actor *)this), 0x1e000, 0x1e000, 0x200002, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)(c + 0xd4), ((Actor *)this), 0x1e000, 0x1e000, 0x200002, 0);
     func_ov022_02112790((void*)((Actor *)this), (void*)&data_ov022_02114690);
     return 1;
 }

--- a/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
+++ b/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
@@ -11,6 +11,12 @@ struct PMF;
 namespace Model { void LoadFile(SharedFilePtr& f); }
 extern "C" int IsStarCollected(int r0, int r1);
 struct MovingCylinderClsn { void Init(Actor* a, Fix12i b, int c, unsigned int d, unsigned int e); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12i b, int c, unsigned int d, unsigned int e);
+
 
 extern SharedFilePtr data_ov002_0210da10;
 extern SharedFilePtr data_ov002_0210d9a8;
@@ -27,7 +33,7 @@ int BowserPuzzlePiece::InitResources()
     if (data_0209f2f8 == 8 && (data_0209f220 == 1 || IsStarCollected(SublevelToLevel(8), 1) == 0)) {
         return 0;
     }
-    ((MovingCylinderClsn*)((char*)&mMovingCylinderClsn))->Init((Actor*)((char*)this), 0xc8000, 0x190000, 0x800004, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)((char*)&mMovingCylinderClsn), (Actor*)((char*)this), 0xc8000, 0x190000, 0x800004, 0);
     func_ov064_0211982c(((char*)this), &data_ov064_0211c934);
     return 1;
 }

--- a/src/_ZN4Tree13InitResourcesEv.cpp
+++ b/src/_ZN4Tree13InitResourcesEv.cpp
@@ -3,6 +3,12 @@ struct Vector3 { int x, y, z; };
 struct CylinderClsnWithPos {
     void Init(const Vector3&, int, int, unsigned int, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj(void *, const Vector3&, int, int, unsigned int, unsigned int);
+
 struct Model { void LoadAndSetFile(unsigned short, int, int); };
 extern "C" void* _Znwj(unsigned int);
 extern "C" void _ZN19CylinderClsnWithPosC1Ev(void*);
@@ -30,7 +36,7 @@ int _ZN4Tree13InitResourcesEv(char* self) {
         int* q = (int*)(((int)p + 4));
         *q = *q + 0x1e000;
     }
-    ((CylinderClsnWithPos*)(p + 0xc))->Init(*(Vector3*)(self + 0x5c), 0x35555, 0x1f4000, 0x380000c, 0);
+    _ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj((CylinderClsnWithPos*)(p + 0xc), *(Vector3*)(self + 0x5c), 0x35555, 0x1f4000, 0x380000c, 0);
     *(int*)(p + 0x48) = *slot;
     *slot = (int)p;
     if (*(int*)(p + 0x48) != 0) {

--- a/src/_ZN5Actor13LandingDustAtER7Vector3b.cpp
+++ b/src/_ZN5Actor13LandingDustAtER7Vector3b.cpp
@@ -11,7 +11,13 @@ struct RaycastGround {
 };
 namespace Particle { struct System {
     static void NewSimple(unsigned int id, Fix12i a, Fix12i b, Fix12i c);
-}; }
+};
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12i a, Fix12i b, Fix12i c);
+ }
 
 extern "C" void _ZN5Actor13LandingDustAtER7Vector3b(Actor *self, Vector3 *pos, bool b)
 {
@@ -23,5 +29,5 @@ extern "C" void _ZN5Actor13LandingDustAtER7Vector3b(Actor *self, Vector3 *pos, b
             pos->y = *(Fix12i*)((char*)&rc + 0x44);
     }
     *(Fix12i*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFULL) += 0x5a000;
-    Particle::System::NewSimple(0xb1, pos->x, pos->y, pos->z);
+    Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb1, pos->x, pos->y, pos->z);
 }

--- a/src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp
+++ b/src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp
@@ -11,7 +11,13 @@ struct RaycastGround {
 };
 namespace Particle { struct System {
     static void NewSimple(unsigned int id, Fix12i a, Fix12i b, Fix12i c);
-}; }
+};
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12i a, Fix12i b, Fix12i c);
+ }
 
 extern "C" void _ZN5Actor17HugeLandingDustAtER7Vector3b(Actor *self, Vector3 *pos, bool b)
 {
@@ -23,5 +29,5 @@ extern "C" void _ZN5Actor17HugeLandingDustAtER7Vector3b(Actor *self, Vector3 *po
             pos->y = *(Fix12i*)((char*)&rc + 0x44);
     }
     *(Fix12i*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFULL) += 0x28000;
-    Particle::System::NewSimple(0xb2, pos->x, pos->y, pos->z);
+    Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb2, pos->x, pos->y, pos->z);
 }

--- a/src/_ZN6Player11St_Fly_MainEv.cpp
+++ b/src/_ZN6Player11St_Fly_MainEv.cpp
@@ -10,6 +10,13 @@ struct Player {
     int FinishedAnim();
     unsigned char GetBodyModelID(unsigned int, bool) const;
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN6Player11ChangeStateERNS_5StateE(void *, State &);
+extern "C" void _ZN6Player7SetAnimEji5Fix12IiEj(void *, unsigned int, int, int, unsigned int);
+
 
 extern "C" int func_ov002_020d674c(char *c);
 extern "C" void func_ov002_020c2f64(void *c);
@@ -44,21 +51,21 @@ int Player::St_Fly_Main()
         goto skip;
     }
     if (func_ov002_020d674c(c) != 0) {
-        this->ChangeState(data_ov002_0211004c);
+        _ZN6Player11ChangeStateERNS_5StateE(this, data_ov002_0211004c);
     } else {
-        this->ChangeState(data_ov002_021105a4);
+        _ZN6Player11ChangeStateERNS_5StateE(this, data_ov002_021105a4);
     }
     return 1;
 
 skip:
     if (*(u8 *)(c + 0x6ff) == 0) {
-        this->ChangeState(data_ov002_021101b4);
+        _ZN6Player11ChangeStateERNS_5StateE(this, data_ov002_021101b4);
         return 1;
     }
     if (*(u8 *)(c + 0x6de) == 0) {
         func_ov002_020c2f64(c);
-        this->ChangeState(data_ov002_021105bc);
-        this->SetAnim(0x43, 0x40000000, 0x1000, 0);
+        _ZN6Player11ChangeStateERNS_5StateE(this, data_ov002_021105bc);
+        _ZN6Player7SetAnimEji5Fix12IiEj(this, 0x43, 0x40000000, 0x1000, 0);
         *(s32 *)(c + 0xa8) = 0;
         return 1;
     }
@@ -77,7 +84,7 @@ skip:
             if (this->FinishedAnim() != 0) {
                 *(s32 *)(c + 0x9c) = 0;
                 *(s32 *)(c + 0xa0) = -0x4b000;
-                this->SetAnim(0x49, 0, 0x1000, 0);
+                _ZN6Player7SetAnimEji5Fix12IiEj(this, 0x49, 0, 0x1000, 0);
             }
         } else {
             *(s32 *)(c + 0x9c) = 0;

--- a/src/_ZN6Player15St_Respawn_InitEv.cpp
+++ b/src/_ZN6Player15St_Respawn_InitEv.cpp
@@ -10,6 +10,12 @@ struct Player {
     int dummy;
     unsigned int SetAnim(unsigned int, int, int, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" unsigned int _ZN6Player7SetAnimEji5Fix12IiEj(void *, unsigned int, int, int, unsigned int);
+
 
 extern "C" int _ZN6Player15St_Respawn_InitEv(Player* thiz);
 int _ZN6Player15St_Respawn_InitEv(Player* thiz) {
@@ -33,7 +39,7 @@ int _ZN6Player15St_Respawn_InitEv(Player* thiz) {
     if (*(unsigned char*)(self + 0x6d8) == data_0209f250) {
         func_0200cf40(*(char**)((int)&data_0209f318));
     }
-    thiz->SetAnim(0x54, 0x40000000, 0x1000, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(thiz, 0x54, 0x40000000, 0x1000, 0);
     *(unsigned char*)(self + 0x6e3) = 0;
     *(int*)(self + 0x684) = *(int*)(self + 0x60);
     *(int*)(self + 0x98) = 0;

--- a/src/_ZN6Player18St_CameraZoom_MainEv.cpp
+++ b/src/_ZN6Player18St_CameraZoom_MainEv.cpp
@@ -4,6 +4,12 @@ struct Player {
     void ChangeState(State&);
     unsigned int GetBodyModelID(unsigned int, bool) const;
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN6Player11ChangeStateERNS_5StateE(void *, State&);
+
 extern "C" void func_ov002_020cae10(char* c);
 extern "C" int func_ov002_020cac60(char* c);
 extern "C" void Player_AdvanceAnims(char* self);
@@ -18,7 +24,7 @@ int _ZN6Player18St_CameraZoom_MainEv(Player* thiz) {
     if (data_02092110 < 0) {
         if ((unsigned short)(*(unsigned short*)(self + 0x6ce) & 4) == 0) {
             unsigned int id;
-            thiz->ChangeState(data_ov002_0211013c);
+            _ZN6Player11ChangeStateERNS_5StateE(thiz, data_ov002_0211013c);
             id = thiz->GetBodyModelID(*(int*)(self + 8) & 0xff, 0);
             int q = (int)((*(volatile int*)(self + id * 4 + 0xdc) + 0x50));
             *(int*)(q + 8) = 0;

--- a/src/_ZN9KoopaFlag13InitResourcesEv.cpp
+++ b/src/_ZN9KoopaFlag13InitResourcesEv.cpp
@@ -20,9 +20,21 @@ struct Animation {
 struct ModelAnim {
     void SetAnim(BCA_File* f, int a, Fix12 b, unsigned int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File* f, int a, Fix12 b, unsigned int c);
+
 struct MovingCylinderClsn {
     void Init(Actor* a, Fix12 b, Fix12 c, unsigned int d, unsigned int e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 b, Fix12 c, unsigned int d, unsigned int e);
+
 
 extern SharedFilePtr data_ov062_0211e0d4;
 extern SharedFilePtr data_ov062_0211e0dc;
@@ -31,9 +43,8 @@ int KoopaFlag::InitResources()
 {
     ((ModelBase*)((char*)&mModelAnim))->SetFile(
         (BMD_File*)Model::LoadFile(data_ov062_0211e0d4), 1, -1);
-    ((ModelAnim*)((char*)&mModelAnim))->SetAnim(
-        (BCA_File*)Animation::LoadFile(data_ov062_0211e0dc), 0, 0x1000, 0);
-    ((MovingCylinderClsn*)((char*)&mMovingCylinderClsn))->Init((Actor*)((char*)this), 0x35555, 0x294000, 0x280000c, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)((char*)&mModelAnim), (BCA_File*)Animation::LoadFile(data_ov062_0211e0dc), 0, 0x1000, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)((char*)&mMovingCylinderClsn), (Actor*)((char*)this), 0x35555, 0x294000, 0x280000c, 0);
     unk_16e = 0xff;
     mVictoryTimer = 0;
     return 1;

--- a/src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp
@@ -22,6 +22,12 @@ struct MeshColliderBase {
 struct Platform {
   int IsClsnInRange(int, int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *, int, int);
+
 
 int MadPiano::Behavior()
 {
@@ -43,7 +49,7 @@ int MadPiano::Behavior()
     if (((struct MeshColliderBase*)((char*)&mMeshCollider))->IsEnabled() != 0)
       ((struct MeshColliderBase*)((char*)&mMeshCollider))->Disable();
   } else {
-    ((struct Platform*)((char*)this))->IsClsnInRange(0x1f4000, 0);
+    _ZN8Platform13IsClsnInRangeE5Fix12IiES1_((struct Platform*)((char*)this), 0x1f4000, 0);
   }
   func_ov063_0211d88c(((char*)this));
   func_ov063_0211d828(((char*)this));

--- a/src/func_ov002_020aefb8.c
+++ b/src/func_ov002_020aefb8.c
@@ -10,6 +10,12 @@ struct Actor {
     void UpdatePosWithOnlySpeed(CylinderClsn*);
     short ReflectAngle(int, int, short);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" short _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *, int, int, short);
+
 struct Enemy : Actor {
     void UpdateWMClsn(WithMeshClsn&, unsigned int);
 };
@@ -38,5 +44,5 @@ void func_ov002_020aefb8(char* self) {
     ((Actor*)self)->UpdatePosWithOnlySpeed((CylinderClsn*)(self + 0x110));
     ((Enemy*)self)->UpdateWMClsn(*(WithMeshClsn*)(self + 0x144), 0);
     if (!((WithMeshClsn*)(self + 0x144))->IsOnWall()) return;
-    *(short*)(self + 0x94) = ((Actor*)self)->ReflectAngle(*(int*)(self + 0xe0), *(int*)(self + 0xe8), *(short*)(self + 0x94));
+    *(short*)(self + 0x94) = _ZN5Actor12ReflectAngleE5Fix12IiES1_s((Actor*)self, *(int*)(self + 0xe0), *(int*)(self + 0xe8), *(short*)(self + 0x94));
 }

--- a/src/func_ov002_020b5ab4.cpp
+++ b/src/func_ov002_020b5ab4.cpp
@@ -19,6 +19,12 @@ struct RaycastGround {
     void SetObjAndPos(const Vector3& pos, Actor* a);
     int DetectClsn();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN4BgCh19StartDetectingWaterEv(void *);
+
 
 extern "C" int SurfaceInfo_TestFlag0x20(int* p);
 extern "C" s8 data_0209f2f8;
@@ -49,7 +55,7 @@ int func_ov002_020b5ab4(char* c)
             vec.y = vy;
             vec.z = vz;
         }
-        rg.StartDetectingWater();
+        _ZN4BgCh19StartDetectingWaterEv(&(rg));
         rg.SetObjAndPos(vec, (Actor*)c);
         if (rg.DetectClsn() != 0) {
             *(int*)(c+0x324) = rg.field44;

--- a/src/func_ov002_020b7e1c.cpp
+++ b/src/func_ov002_020b7e1c.cpp
@@ -10,6 +10,12 @@ struct Actor : ActorBase {
     static int Spawn(unsigned int, unsigned int, const Vector3&, const Vector3_16*, int, int);
     void SetRanges(int, int, int, int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *, int, int, int, int);
+
 struct SaveData {
     static int HasPlayerLostCap();
     static void PlayerLoseCap();
@@ -32,7 +38,7 @@ int func_ov002_020b7e1c(char* self) {
         return 1;
     }
     if (*(int*)(self + 0xc8) == 0) {
-        ((Actor*)self)->SetRanges(0x32000, 0x32000, 0x1000000, 0x1000000);
+        _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_((Actor*)self, 0x32000, 0x32000, 0x1000000, 0x1000000);
     }
     func_ov002_020b6fcc(self);
     if (data_02092138 > *(int*)(self + 0x60)) {

--- a/src/func_ov002_020bd250.cpp
+++ b/src/func_ov002_020bd250.cpp
@@ -6,7 +6,19 @@
 struct Player {
     void Hurt(const Vector3&, unsigned int, int, unsigned int, unsigned int, unsigned int);
 };
-namespace Particle { struct System { static void NewSimple(unsigned int, int, int, int); }; }
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *, const Vector3&, unsigned int, int, unsigned int, unsigned int, unsigned int);
+
+namespace Particle { struct System { static void NewSimple(unsigned int, int, int, int); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
+ }
 extern "C" short ReadUnalignedShort(unsigned char* p);
 extern "C" void Vec3_RotateYAndTranslate(Vector3* out, const Vector3* base, int angle, const Vector3* off);
 
@@ -23,7 +35,7 @@ int func_ov002_020bd250(char* self, unsigned char* p) {
     v.x = out1.x;
     v.y = out1.y;
     v.z = out1.z;
-    ((Player*)self)->Hurt(v, 0, 0xc000, 1, 0, 1);
+    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj((Player*)self, v, 0, 0xc000, 1, 0, 1);
     *(int*)(self + 0xa8) = 0x20000;
     *(int*)(self + 0x98) = 0xc000;
     if (*(int*)(self + 8) == 1) {
@@ -31,8 +43,8 @@ int func_ov002_020bd250(char* self, unsigned char* p) {
         off2.y = 0x64000;
         off2.z = 0x32000;
         Vec3_RotateYAndTranslate(&out2, (Vector3*)(self + 0x5c), *(short*)(self + 0x8e), &off2);
-        Particle::System::NewSimple(0x43, out2.x, out2.y, out2.z);
-        Particle::System::NewSimple(0x44, out2.x, out2.y, out2.z);
+        Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x43, out2.x, out2.y, out2.z);
+        Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x44, out2.x, out2.y, out2.z);
     }
     return 1;
 }

--- a/src/func_ov002_020c1234.cpp
+++ b/src/func_ov002_020c1234.cpp
@@ -1,5 +1,11 @@
 //cpp
 struct Sound { static int PlaySub(unsigned int, unsigned int, unsigned int, int, bool); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int, unsigned int, unsigned int, int, bool);
+
 extern signed char data_0209f2f8;
 extern int data_0209b49c;
 
@@ -28,7 +34,7 @@ void func_ov002_020c1234(char* self) {
         break;
     }
     if (*(unsigned char*)(self + 0x71c) == 0) return;
-    if (Sound::PlaySub(0x35, a1, a2, fx, 0) == 0) return;
+    if (_ZN5Sound7PlaySubEjjj5Fix12IiEb(0x35, a1, a2, fx, 0) == 0) return;
     if (*(int*)(self + 0x66c) == 0xa) return;
     if (*(int*)(self + 0x66c) != 0xb) *(unsigned char*)(self + 0x71c) = 0;
 }

--- a/src/func_ov002_020c1eb4.cpp
+++ b/src/func_ov002_020c1eb4.cpp
@@ -26,6 +26,12 @@ namespace Particle {
         static void New(unsigned int id, unsigned int a, Fix12i x, Fix12i y, Fix12i z,
                         const Vector3_16 *v, Callback *cb);
     };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int id, unsigned int a, Fix12i x, Fix12i y, Fix12i z, const Vector3_16 *v, Callback *cb);
+
 }
 
 extern "C" int func_ov002_020d91e0(char *thiz, int damage, int doPre);
@@ -88,7 +94,7 @@ extern "C" void func_ov002_020c1eb4(Obj *self, int dmg)
         vec.x = data_02082214[idx * 2];
         vec.z = data_02082214[idx * 2 + 1];
         vec.y = 0;
-        Particle::System::New(0, 0xc8, out.x, out.y, out.z, &vec, 0);
+        Particle::_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(0, 0xc8, out.x, out.y, out.z, &vec, 0);
     }
     func_ov002_020d91e0((char *)self, 0, 1);
 }

--- a/src/func_ov002_020c29d4.cpp
+++ b/src/func_ov002_020c29d4.cpp
@@ -7,6 +7,12 @@ struct WithMeshClsn {
 struct Player {
     int IsState(State &s);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN6Player7IsStateERNS_5StateE(void *, State &s);
+
 
 extern "C" int Player_ScaleByCharFactor(void *c, int a);
 extern "C" int func_02037e38(unsigned int *p);
@@ -22,9 +28,9 @@ extern "C" void func_ov002_020c29d4(Player *self)
     unsigned char flags = *(unsigned char *)(base + 0x6eb);
     if ((flags & 1) && !(flags & 0x80)) {
         if (*(int *)(base + 0x98) >= Player_ScaleByCharFactor(self, 0x28000)) {
-            if (self->IsState(data_ov002_0211013c)) {
+            if (_ZN6Player7IsStateERNS_5StateE(self, data_ov002_0211013c)) {
                 *(short *)(base + 0x6bc) = 0x1e;
-            } else if (self->IsState(data_ov002_021101b4)
+            } else if (_ZN6Player7IsStateERNS_5StateE(self, data_ov002_021101b4)
                        && *(int *)(base + 0xa8) < 0
                        && (*(int *)(base + 0x684) - *(int *)(base + 0x60)) < 0x64000) {
                 *(short *)(base + 0x6bc) = 0x1e;

--- a/src/func_ov002_020c8f80.cpp
+++ b/src/func_ov002_020c8f80.cpp
@@ -10,6 +10,12 @@ struct Player {
     unsigned int GetBodyModelID(unsigned int, bool) const;
     void SetAnim(unsigned int, int, Fix12, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN6Player7SetAnimEji5Fix12IiEj(void *, unsigned int, int, Fix12, unsigned int);
+
 
 extern "C" int func_ov002_020c8f80(Player *thiz)
 {
@@ -25,7 +31,7 @@ extern "C" int func_ov002_020c8f80(Player *thiz)
         if (*(unsigned char *)(p + 0x70c) == 0) {
             *(unsigned char *)(p + 0x70c) = 1;
         } else {
-            thiz->SetAnim(0x43, 0x40000000, 0x1000, 0);
+            _ZN6Player7SetAnimEji5Fix12IiEj(thiz, 0x43, 0x40000000, 0x1000, 0);
             *(unsigned char *)(p + 0x6e3) = 0xd;
             *(int *)(p + 0x9c) = -0x4000;
             *(unsigned short *)(p + 0x8c) = 0x4000;

--- a/src/func_ov002_020d0580.cpp
+++ b/src/func_ov002_020d0580.cpp
@@ -9,6 +9,13 @@ struct Player {
     int IsState(State &);
     int ChangeState(State &);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN6Player7IsStateERNS_5StateE(void *, State &);
+extern "C" int _ZN6Player11ChangeStateERNS_5StateE(void *, State &);
+
 
 extern "C" int func_ov002_020d0d2c(void *c);
 extern "C" int func_ov002_020d0178(Player *c, int a, int b);
@@ -39,7 +46,7 @@ extern "C" int func_ov002_020d0580(Player *p)
     return 0;
 
 cont:
-    if (p->IsState(data_ov002_021105a4)) {
+    if (_ZN6Player7IsStateERNS_5StateE(p, data_ov002_021105a4)) {
         if (*(unsigned char *)((char *)p + 0x6e3) != 0)
             return 0;
     }
@@ -49,6 +56,6 @@ cont:
     if (func_ov002_020d0178(p, *(int *)((char *)p + 0x60), 0) == 0)
         return 0;
     *(unsigned char *)((char *)p + 0x6e3) = 1;
-    p->ChangeState(data_ov002_0210ffec);
+    _ZN6Player11ChangeStateERNS_5StateE(p, data_ov002_0210ffec);
     return 1;
 }

--- a/src/func_ov002_020d06c0.cpp
+++ b/src/func_ov002_020d06c0.cpp
@@ -9,6 +9,13 @@ struct Player {
     int IsState(State &);
     int ChangeState(State &);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN6Player7IsStateERNS_5StateE(void *, State &);
+extern "C" int _ZN6Player11ChangeStateERNS_5StateE(void *, State &);
+
 
 extern "C" int Player_ScaleByCharFactor(Player *c, int a);
 extern "C" int func_ov002_020d0178(Player *c, int a, int b);
@@ -17,7 +24,7 @@ extern "C" int func_ov002_020d06c0(Player *p)
 {
     int thresh, b354, b358;
 
-    if (!p->IsState(data_ov002_021101b4))
+    if (!_ZN6Player7IsStateERNS_5StateE(p, data_ov002_021101b4))
         return 0;
 
     if (p->GetHealth() != 0 &&
@@ -32,7 +39,7 @@ extern "C" int func_ov002_020d06c0(Player *p)
             if (b358 == 0 &&
                 *(unsigned char *)((char *)p + 0x708) == 0 &&
                 *(unsigned char *)((char *)p + 0x6fd) == 0 &&
-                p->IsState(data_ov002_0211001c) == 0 &&
+                _ZN6Player7IsStateERNS_5StateE(p, data_ov002_0211001c) == 0 &&
                 *(unsigned char *)((char *)p + 0x6de) != 0)
             {
                 goto cont;
@@ -57,6 +64,6 @@ cont:
         return 0;
 
     *(unsigned char *)((char *)p + 0x6e3) = 0;
-    p->ChangeState(data_ov002_0210ffec);
+    _ZN6Player11ChangeStateERNS_5StateE(p, data_ov002_0210ffec);
     return 1;
 }

--- a/src/func_ov002_020d4c30.cpp
+++ b/src/func_ov002_020d4c30.cpp
@@ -18,6 +18,12 @@ namespace Particle {
     struct System {
         static void NewSimple(unsigned int id, Fix12i a, Fix12i b, Fix12i c);
     };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12i a, Fix12i b, Fix12i c);
+
 }
 
 struct Obj {
@@ -73,5 +79,5 @@ extern "C" void func_ov002_020d4c30(Obj *self)
         } else id = 0xe4;
     } else id = 0xe5;
     if (id == -1) return;
-    Particle::System::NewSimple(id, self->p5c, self->p60, self->p64);
+    Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(id, self->p5c, self->p60, self->p64);
 }

--- a/src/func_ov002_020df34c.cpp
+++ b/src/func_ov002_020df34c.cpp
@@ -2,6 +2,13 @@
 struct State {};
 struct Camera {};
 struct Player { int IsState(State& s); void ChangeState(State& s); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN6Player7IsStateERNS_5StateE(void *, State& s);
+extern "C" void _ZN6Player11ChangeStateERNS_5StateE(void *, State& s);
+
 extern "C" int func_ov002_020e0478(void* c);
 extern "C" void func_0200d474(Camera* thiz, unsigned char playerID);
 extern State data_ov002_0210ffec;
@@ -9,11 +16,11 @@ extern State data_ov002_021102d4;
 extern Camera* data_0209f318;
 extern "C" int func_ov002_020df34c(Player* self) {
     unsigned char* p = (unsigned char*)self;
-    if (p[0x709] != 0 || func_ov002_020e0478(self) != 0 || self->IsState(data_ov002_0210ffec) != 0) {
+    if (p[0x709] != 0 || func_ov002_020e0478(self) != 0 || _ZN6Player7IsStateERNS_5StateE(self, data_ov002_0210ffec) != 0) {
         return 0;
     }
     p[0x6e3] = 0;
-    self->ChangeState(data_ov002_021102d4);
+    _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_021102d4);
     func_0200d474(data_0209f318, p[0x6d8]);
     return 1;
 }

--- a/src/func_ov002_020e81e0.cpp
+++ b/src/func_ov002_020e81e0.cpp
@@ -20,6 +20,12 @@ struct System {
     static System *New(unsigned int a, unsigned int b, int c, int d, int e,
                        const Vector3 *p, Callback *cb);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" System * _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int a, unsigned int b, int c, int d, int e, const Vector3 *p, Callback *cb);
+
 }
 
 extern "C" void func_ov002_020e81e0(Obj *self) {
@@ -28,8 +34,5 @@ extern "C" void func_ov002_020e81e0(Obj *self) {
     v.y = self->f60;
     v.z = self->f64;
     v.y += 0xd000;
-    self->f4b4 = Particle::System::New(*(volatile unsigned int *)&self->f4b4, 0x113,
-                                       *(volatile int *)&v.x,
-                                       *(volatile int *)&v.y,
-                                       v.z, 0, 0);
+    self->f4b4 = Particle::_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(volatile unsigned int *)&self->f4b4, 0x113, *(volatile int *)&v.x, *(volatile int *)&v.y, v.z, 0, 0);
 }

--- a/src/func_ov003_020ad7a4.cpp
+++ b/src/func_ov003_020ad7a4.cpp
@@ -10,11 +10,17 @@ extern int data_0209b2f4;
 extern char data_0209e674[];
 }
 struct OamTmp { int x; };
-namespace OAM { void EnableSubOAM(OamTmp*); }
+namespace OAM { void EnableSubOAM(OamTmp*);
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN3OAM12EnableSubOAMEv(OamTmp*);
+ }
 extern "C" int func_ov003_020ad7a4(void)
 {
     OamTmp tmp;
-    OAM::EnableSubOAM(&tmp);
+    OAM::_ZN3OAM12EnableSubOAMEv(&tmp);
     {
         int idx = data_0209e664;
         unsigned int v = ((data_0209b2f4 - data_0209b2f8 + 2) << 3) & 0xff;

--- a/src/func_ov006_020c0264.cpp
+++ b/src/func_ov006_020c0264.cpp
@@ -4,6 +4,12 @@ struct BCA_File;
 struct BlendModelAnim {
     void SetAnim(BCA_File &f, int a, int b, Fix12 c, unsigned short d);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File &f, int a, int b, Fix12 c, unsigned short d);
+
 struct P2 { int w[2]; };
 
 int ApproachLinear2(short &v, short t, short step);
@@ -15,7 +21,7 @@ extern "C" void func_ov006_020c0264(char *c)
 {
     if (ApproachLinear2(*(short *)(c + 0xf2), 0, 1) == 0)
         return;
-    ((BlendModelAnim *)(c + 0x18))->SetAnim(*(BCA_File *)*(void **)(c + 0x14), 0, 0, 0x800, 0);
+    _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x18), *(BCA_File *)*(void **)(c + 0x14), 0, 0, 0x800, 0);
     int r = RandomIntInternal(&data_0209e650);
     int idx = (int)((unsigned int)(r & 0x7fffffff) >> 0x13);
     *(short *)(c + 0xf2) = (short)(((idx * 0x258) >> 12) + 0x258);

--- a/src/func_ov006_020c0d68.cpp
+++ b/src/func_ov006_020c0d68.cpp
@@ -2,16 +2,22 @@
 typedef int Fix12;
 struct BCA_File;
 struct BlendModelAnim { int pad; void SetAnim(BCA_File &f, int a, int b, Fix12 d, unsigned short e); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File &f, int a, int b, Fix12 d, unsigned short e);
+
 struct Sound { static void PlayBank2_2D(unsigned int); };
 extern "C" { extern double data_ov006_0213ac98; }
 
 extern "C" void func_ov006_020c0d68(char *c)
 {
     if (*(short *)(c + 0x1a) == 1) {
-        ((BlendModelAnim *)(c + 0x1c))->SetAnim(*(BCA_File *)*(int *)(c + 0x224), 0, 0x40000000, 0x800, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x1c), *(BCA_File *)*(int *)(c + 0x224), 0, 0x40000000, 0x800, 0);
     } else {
         Sound::PlayBank2_2D(0x13c);
-        ((BlendModelAnim *)(c + 0x1c))->SetAnim(*(BCA_File *)*(int *)(c + 0x25c), 0, 0x40000000, 0x800, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x1c), *(BCA_File *)*(int *)(c + 0x25c), 0, 0x40000000, 0x800, 0);
     }
     *(double *)c = data_ov006_0213ac98;
 }

--- a/src/func_ov006_020c1420.cpp
+++ b/src/func_ov006_020c1420.cpp
@@ -4,6 +4,12 @@ struct BCA_File;
 struct BlendModelAnim {
     void SetAnim(BCA_File &f, int a, int b, Fix12 c, unsigned short d);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File &f, int a, int b, Fix12 c, unsigned short d);
+
 struct P2 { int w[2]; };
 
 extern "C" int func_ov006_020c1718(int *r0);
@@ -14,9 +20,9 @@ extern "C" void func_ov006_020c1420(char *c, short arg1, int arg2)
     *(short *)(c + 0x1de) = arg1;
     *(int *)(c + 0x1d4) = arg2;
     if (func_ov006_020c1718((int *)c) && *(int *)(c + 0x7c) != *(int *)(c + 0x234)) {
-        ((BlendModelAnim *)(c + 0x1c))->SetAnim(*(BCA_File *)*(void **)(c + 0x204), 0, 0x40000000, 0x800, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x1c), *(BCA_File *)*(void **)(c + 0x204), 0, 0x40000000, 0x800, 0);
     } else {
-        ((BlendModelAnim *)(c + 0x1c))->SetAnim(*(BCA_File *)*(void **)(c + 0x214), 0, 0x40000000, 0x800, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x1c), *(BCA_File *)*(void **)(c + 0x214), 0, 0x40000000, 0x800, 0);
     }
     *(P2 *)c = data_ov006_0213ac48;
 }

--- a/src/func_ov006_020c1764.cpp
+++ b/src/func_ov006_020c1764.cpp
@@ -4,6 +4,12 @@ struct BCA_File;
 struct BlendModelAnim {
     void SetAnim(BCA_File &f, int a, int b, Fix12 c, unsigned short d);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File &f, int a, int b, Fix12 c, unsigned short d);
+
 struct Sound { static void PlayBank2_2D(unsigned int id); };
 struct P2 { int w[2]; };
 
@@ -12,13 +18,13 @@ extern P2 data_ov006_0213ac50;
 extern "C" void func_ov006_020c1764(char *c)
 {
     if (*(short *)(c + 0x1a) == 1) {
-        ((BlendModelAnim *)(c + 0x1c))->SetAnim(*(BCA_File *)*(void **)(c + 0x234), 0, 0, 0x800, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x1c), *(BCA_File *)*(void **)(c + 0x234), 0, 0, 0x800, 0);
         if (*(int *)(c + 0x26c) == 0) {
             Sound::PlayBank2_2D(0x13a);
             *(int *)(c + 0x26c) = 1;
         }
     } else {
-        ((BlendModelAnim *)(c + 0x1c))->SetAnim(*(BCA_File *)*(void **)(c + 0x1fc), 0, 0, 0x800, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x1c), *(BCA_File *)*(void **)(c + 0x1fc), 0, 0, 0x800, 0);
     }
     *(P2 *)c = data_ov006_0213ac50;
 }

--- a/src/func_ov006_020c6e4c.cpp
+++ b/src/func_ov006_020c6e4c.cpp
@@ -5,6 +5,12 @@ struct Model { static BMD_File *LoadFile(SharedFilePtr &f); };
 struct Animation { static BCA_File *LoadFile(SharedFilePtr &f); };
 struct ModelBase { int SetFile(BMD_File *f, int a, int b); };
 struct ModelAnim { int SetAnim(BCA_File *f, int a, int b, unsigned int u); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, int b, unsigned int u);
+
 
 extern "C" void func_02016acc(char *m, int a);
 extern "C" void func_02016b24(char *m, int a);
@@ -25,7 +31,7 @@ extern "C" int func_ov006_020c6e4c(char *c) {
     if (((ModelBase *)(c + 0x38))->SetFile(m, 1, -1) == 0) {
         return 0;
     }
-    ((ModelAnim *)(c + 0x38))->SetAnim(a, 0, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x38), a, 0, 0x800, 0);
     func_02016acc(c + 0x38, 1);
     func_02016b24(c + 0x38, 2);
     int b = (*(unsigned short *)((char *)data_0209f5c0 + 0xc) == 0x175);

--- a/src/func_ov006_020c79a8.cpp
+++ b/src/func_ov006_020c79a8.cpp
@@ -2,6 +2,12 @@
 typedef int Fix12;
 struct BCA_File;
 struct ModelAnim { int pad; void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 struct Sound { static void PlayBank2_2D(unsigned int); };
 extern "C" {
 extern int data_ov006_02140428[];
@@ -15,7 +21,7 @@ extern "C" void func_ov006_020c79a8(char *c)
         Sound::PlayBank2_2D(0x1ca);
     else
         Sound::PlayBank2_2D(0x1c9);
-    ((ModelAnim *)(c + 0x4c))->SetAnim((BCA_File *)data_ov006_0214042c[0], 0, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x4c), (BCA_File *)data_ov006_0214042c[0], 0, 0x800, 0);
     *(short *)(c + 0x32) = 0x28;
     *(double *)(c + 0x3c) = data_ov006_0213b030;
 }

--- a/src/func_ov006_020c8084.cpp
+++ b/src/func_ov006_020c8084.cpp
@@ -5,6 +5,12 @@ typedef struct { int v[2]; } V2;
 extern "C" void func_ov006_020c8658(void *c);
 namespace Sound { void PlayBank2_2D(unsigned int); }
 struct ModelAnim { void SetAnim(BCA_File*, int, Fix12, unsigned int); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File*, int, Fix12, unsigned int);
+
 
 extern int data_ov006_0213b088[2];
 extern void *data_ov006_0214042c;
@@ -21,7 +27,7 @@ extern "C" void func_ov006_020c8084(char *c)
         *(int*)(c + 0x20) = 0;
         *(int*)(c + 0x24) = 0x2000;
         Sound::PlayBank2_2D(0x1c9);
-        ((ModelAnim*)(c + 0x4c))->SetAnim((BCA_File*)data_ov006_0214042c, 0, 0x800, 0);
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(c + 0x4c), (BCA_File*)data_ov006_0214042c, 0, 0x800, 0);
         *(int*)(c + 0xa4) = 0;
         *(V2*)(c + 0x3c) = *(V2*)data_ov006_0213b090;
     }

--- a/src/func_ov006_020c8f20.cpp
+++ b/src/func_ov006_020c8f20.cpp
@@ -6,6 +6,12 @@ struct Animation { void Advance(); };
 struct System {
     static System* New(unsigned, unsigned, Fix12, Fix12, Fix12, const Vector3_16f*, Callback*);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" System* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned, unsigned, Fix12, Fix12, Fix12, const Vector3_16f*, Callback*);
+
 extern "C" {
 extern void func_ov006_020c9024(char *o);
 extern void func_ov006_020c8ecc(char *o);
@@ -35,10 +41,7 @@ extern "C" void func_ov006_020c8f20(char *o) {
     Fix12 v = (Fix12)(((long long)*(int*)(o + 0x4c) * 0xb4b + 0x800) >> 12);
     if (*(int*)(o + 0x40) > v) {
         if (*(int*)(o + 0xd8) == data_ov006_0214059c) {
-            *(int*)(o + 0x5c) = (int)System::New(
-                *(int*)(o + 0x5c), 0xf5,
-                *(int*)(o + 0x24) << 3, *(int*)(o + 0x28) << 3,
-                *(int*)(o + 0x2c) << 3, 0, 0);
+            *(int*)(o + 0x5c) = (int)_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(int*)(o + 0x5c), 0xf5, *(int*)(o + 0x24) << 3, *(int*)(o + 0x28) << 3, *(int*)(o + 0x2c) << 3, 0, 0);
         }
     }
     func_ov006_020c8ecc(o);

--- a/src/func_ov006_020c9098.c
+++ b/src/func_ov006_020c9098.c
@@ -4,6 +4,12 @@ struct BCA_File;
 struct ModelAnim {
     void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 
 extern "C" {
 extern int data_ov006_0213b214[2];
@@ -44,7 +50,7 @@ body:
     *(int *)(c + 0x3c) = 0;
     *(int *)(c + 0x40) = 0x2000;
     func_ov006_020e6e3c(0x1c9, *(int *)(c + 0x24));
-    ((ModelAnim *)(c + 0x78))->SetAnim((BCA_File *)data_ov006_02140540[0], 0, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x78), (BCA_File *)data_ov006_02140540[0], 0, 0x800, 0);
     *(int *)(c + 0xd0) = 0;
     {
         int a = data_ov006_0213b114[0];

--- a/src/func_ov006_020c9c8c.c
+++ b/src/func_ov006_020c9c8c.c
@@ -4,6 +4,12 @@ struct BCA_File;
 struct ModelAnim {
     void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 struct Pair { int a, b; };
 
 struct Obj {
@@ -33,7 +39,7 @@ extern "C" void func_ov006_020c9c8c(char *c)
     o->slot4();
     *(int *)(c + 0x64) = 0;
     *(int *)(c + 0x60) = 0;
-    ((ModelAnim *)(c + 0x78))->SetAnim(data_ov006_0214059c, 0x40000000, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x78), data_ov006_0214059c, 0x40000000, 0x800, 0);
     *(int *)(c + 0xd0) = 0;
     func_ov006_020e6e3c(0x110, *(int *)(c + 0x24));
     func_ov006_020e6e3c(0x1b5, *(int *)(c + 0x24));

--- a/src/func_ov006_020ca3a8.cpp
+++ b/src/func_ov006_020ca3a8.cpp
@@ -2,6 +2,12 @@
 typedef int Fix12;
 struct BCA_File;
 struct ModelAnim { int pad; void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 extern "C" {
 extern int data_020a0ebc[];
 extern int data_ov006_02140564[];
@@ -19,6 +25,6 @@ extern "C" void func_ov006_020ca3a8(char *c)
     *(int *)(c + 0x44) = data_020a0ebc[2];
     *(int *)(c + 0x48) = 0;
     *(int *)(c + 0x64) = 0;
-    ((ModelAnim *)(c + 0x78))->SetAnim((BCA_File *)data_ov006_02140564[0], 0, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x78), (BCA_File *)data_ov006_02140564[0], 0, 0x800, 0);
     *(double *)(c + 0x70) = data_ov006_0213b11c;
 }

--- a/src/func_ov006_020cb1a8.c
+++ b/src/func_ov006_020cb1a8.c
@@ -4,6 +4,12 @@ struct BCA_File;
 struct ModelAnim {
   void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 struct Sound {
   static void PlayBank2_2D(unsigned int);
 };
@@ -44,7 +50,7 @@ body:
     *(int *)(c + 0x34) = 0;
     *(int *)(c + 0x38) = 0x2000;
     Sound::PlayBank2_2D(0x1c9);
-    ((ModelAnim *)(c + 0x6c))->SetAnim((BCA_File *)data_ov006_02140540[0], 0, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x6c), (BCA_File *)data_ov006_02140540[0], 0, 0x800, 0);
     *(int *)(c + 0xc4) = 0;
     {
         int a = data_ov006_0213b20c[0];

--- a/src/func_ov006_020cb528.c
+++ b/src/func_ov006_020cb528.c
@@ -2,6 +2,12 @@
 typedef short s16;
 typedef int Fix12;
 struct ModelAnim { void SetAnim(void* bca, int b, Fix12 c, unsigned int d); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, void* bca, int b, Fix12 c, unsigned int d);
+
 extern "C" {
 void Sound_PlayBank1Panned(int a0, char* a1, void* a2);
 void func_ov006_020cb2b4(char* c);
@@ -17,7 +23,7 @@ extern "C" void func_ov006_020cb528(char* c)
     *(int*)(c+0x34) = 0;
     *(int*)(c+0x38) = 0;
     Sound_PlayBank1Panned(0, (char*)0x10, *(void**)(c+0x1c));
-    ((ModelAnim*)(c+0x6c))->SetAnim(data_ov006_0214054c, 0x40000000, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(c+0x6c), data_ov006_0214054c, 0x40000000, 0x800, 0);
     data_ov006_0214055c[0] = data_ov006_0214055c[0] + 1;
     a = data_ov006_0213b15c[0];
     b = data_ov006_0213b15c[1];

--- a/src/func_ov006_020cb690.cpp
+++ b/src/func_ov006_020cb690.cpp
@@ -1,5 +1,11 @@
 //cpp
 struct ModelAnim { void SetAnim(void* bca, int b, int c, unsigned int d); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, void* bca, int b, int c, unsigned int d);
+
 extern "C" {
 void Sound_PlayBank1Panned(int a0, char* a1, void* a2);
 void func_ov006_020cb5c4(char* c);
@@ -14,7 +20,7 @@ void func_ov006_020cb690(char* c)
     *(int*)(c+0x34) = data_020a0ebc[0];
     *(int*)(c+0x38) = data_020a0ebc[1];
     *(int*)(c+0x3c) = data_020a0ebc[2];
-    ((ModelAnim*)(c+0x6c))->SetAnim((void*)data_ov006_021405c0, 0x40000000, 0x800, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(c+0x6c), (void*)data_ov006_021405c0, 0x40000000, 0x800, 0);
     Sound_PlayBank1Panned(0, (char*)0x17, *(void**)(c+0x1c));
     {
         int a = data_ov006_0213b224.a;

--- a/src/func_ov006_020e7cc0.cpp
+++ b/src/func_ov006_020e7cc0.cpp
@@ -2,6 +2,12 @@
 struct BCA_File;
 struct Animation { int Finished(); int WillHitFrame(int) const; };
 struct ModelAnim { void SetAnim(BCA_File *f, int a, int b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, int b, unsigned int c);
+
 extern "C" void *data_ov006_02141e8c;
 extern "C" void *data_ov006_02141e84;
 extern "C" void _ZN5Sound12PlayBank2_2DEj(unsigned int);
@@ -10,8 +16,7 @@ extern "C" void func_ov006_020e7cc0(char *thiz)
 {
     if (((Animation*)(thiz + 0x5c))->Finished() != 0 &&
         *(void**)(thiz + 0x6c) == ((void**)&data_ov006_02141e8c)[1]) {
-        ((ModelAnim*)(thiz + 0xc))->SetAnim(
-            (BCA_File*)((void**)&data_ov006_02141e84)[1], 0, 0x800, 0);
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(thiz + 0xc), (BCA_File*)((void**)&data_ov006_02141e84)[1], 0, 0x800, 0);
         return;
     }
     if (((Animation*)(thiz + 0x5c))->WillHitFrame(0x10) == 0 &&

--- a/src/func_ov006_02123340.cpp
+++ b/src/func_ov006_02123340.cpp
@@ -15,6 +15,13 @@ struct PSys {
     static void* NewUnkCallback818(unsigned int a, unsigned int b, int c, int d, int e, void* f);
     static void* FromUniqueID(unsigned int id);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void* _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned int a, unsigned int b, int c, int d, int e, void* f);
+extern "C" void* _ZN8Particle6System12FromUniqueIDEj(unsigned int id);
+
 
 extern void ApproachLinear(int& x, int a, int b);
 
@@ -35,9 +42,8 @@ extern "C" int func_ov006_02123340(Obj* self)
     func_ov006_020eef90();
     func_ov006_02122ab8();
     char* c = (char*)self;
-    *(void**)(c + 0x7ac4) = PSys::NewUnkCallback818(
-        *(unsigned int*)(c + 0x7ac4), 0xf0, 0x280000, 0x700000, -0x580000, 0);
-    void* p = PSys::FromUniqueID(*(unsigned int*)(c + 0x7ac4));
+    *(void**)(c + 0x7ac4) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(*(unsigned int*)(c + 0x7ac4), 0xf0, 0x280000, 0x700000, -0x580000, 0);
+    void* p = _ZN8Particle6System12FromUniqueIDEj(*(unsigned int*)(c + 0x7ac4));
     if (p != 0) {
         *(char*)((char*)p + 0x58) = (char)(*(int*)(c + 0x7ac8) >> 12);
         ApproachLinear(*(int*)(c + 0x7ac8), 0x14000, 0x200);

--- a/src/func_ov014_02111a6c.cpp
+++ b/src/func_ov014_02111a6c.cpp
@@ -1,10 +1,16 @@
 //cpp
 struct BCA_File;
 struct ModelAnim { void SetAnim(BCA_File*, int, int, unsigned int); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File*, int, int, unsigned int);
+
 struct S { int a; BCA_File* b; };
 extern S data_ov014_02114980;
 extern "C" void func_ov014_02111a6c(char* c){
-  ((ModelAnim*)(c+0x150))->SetAnim(data_ov014_02114980.b, 0, 0x1000, 0);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(c+0x150), data_ov014_02114980.b, 0, 0x1000, 0);
   *(int*)(c+0xa8)=0;
   *(int*)(c+0x98)=0;
   *(int*)(c+0x9c)=-0x2000;

--- a/src/func_ov014_02111e74.cpp
+++ b/src/func_ov014_02111e74.cpp
@@ -1,11 +1,17 @@
 //cpp
 struct BCA_File;
 struct ModelAnim { void SetAnim(BCA_File*, int, int, unsigned int); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File*, int, int, unsigned int);
+
 struct S { int a; BCA_File* b; };
 extern S data_ov014_02114980;
 extern "C" void func_ov014_02111e74(char* c){
   *(int*)(c+0xa8)=0;
   *(int*)(c+0x98)=0;
   *(short*)(c+0x500+0xfc)=0x78;
-  ((ModelAnim*)(c+0x150))->SetAnim(data_ov014_02114980.b, 0, 0x1000, 0);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(c+0x150), data_ov014_02114980.b, 0, 0x1000, 0);
 }

--- a/src/func_ov014_02112ea8.cpp
+++ b/src/func_ov014_02112ea8.cpp
@@ -5,7 +5,13 @@
 typedef int Fix12;
 
 struct Sound { static void PlayBank3(unsigned int id, const Vector3 &v); };
-namespace Particle { struct System { static void *NewSimple(unsigned int t, Fix12 x, Fix12 y, Fix12 z); }; }
+namespace Particle { struct System { static void *NewSimple(unsigned int t, Fix12 x, Fix12 y, Fix12 z); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void * _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int t, Fix12 x, Fix12 y, Fix12 z);
+ }
 struct MeshColliderBase { int pad; int IsEnabled(); void Disable(); };
 struct ActorS {
     char pad0[0x5c];
@@ -18,6 +24,12 @@ struct ActorS {
     unsigned char flag;
     void PoofDustAt(const Vector3 &v);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor10PoofDustAtERK7Vector3(void *, const Vector3 &v);
+
 
 extern "C" void func_ov014_02112ea8(ActorS *a)
 {
@@ -31,11 +43,11 @@ extern "C" void func_ov014_02112ea8(ActorS *a)
         v[0].y = ty + 0x12c000;
         v[0].z = tz;
     }
-    Particle::System::NewSimple(0x1e, v[0].x, v[0].y, v[0].z);
+    Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x1e, v[0].x, v[0].y, v[0].z);
     v[1].x = v[0].x;
     v[1].y = v[0].y;
     v[1].z = v[0].z;
-    a->PoofDustAt(v[1]);
+    _ZN5Actor10PoofDustAtERK7Vector3(a, v[1]);
     a->flag = 1;
     if (a->col.IsEnabled())
         a->col.Disable();

--- a/src/func_ov015_02111d98.cpp
+++ b/src/func_ov015_02111d98.cpp
@@ -2,11 +2,17 @@
 struct Actor {
     void UpdatePosWithOnlySpeed(void *);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void *, void *);
+
 
 extern "C" void func_ov015_02111fb8(void *self, int idx);
 
 extern "C" void func_ov015_02111d98(char *c) {
-    ((Actor *)c)->UpdatePosWithOnlySpeed(0);
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn((Actor *)c, 0);
     int r2 = *(int *)(c + 0x320);
     int r0 = *(int *)(c + 0x5c);
     if (r0 < r2) return;

--- a/src/func_ov018_02111d28.cpp
+++ b/src/func_ov018_02111d28.cpp
@@ -7,6 +7,12 @@ struct ShadowModel;
 struct Actor {
     void DropShadowRadHeight(ShadowModel &sm, Matrix4x3 &mf, int c, int d, unsigned int e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *, ShadowModel &sm, Matrix4x3 &mf, int c, int d, unsigned int e);
+
 extern "C" void Matrix4x3_FromRotationY(void *m, int angle);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationY(Matrix4x3 *mf, short angY);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationX(Matrix4x3 *mf, short angX);
@@ -19,8 +25,7 @@ extern "C" void func_ov018_02111d28(Actor *self)
     *(int*)(s + 0x114) = *(int*)(s + 0x5c) >> 3;
     *(int*)(s + 0x118) = *(int*)(s + 0x60) >> 3;
     *(int*)(s + 0x11c) = *(int*)(s + 0x64) >> 3;
-    self->DropShadowRadHeight(*(ShadowModel*)(s + 0x14c), *(Matrix4x3*)(s + 0xf0),
-                              0x140000, 0x50000, 0xf);
+    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(self, *(ShadowModel*)(s + 0x14c), *(Matrix4x3*)(s + 0xf0), 0x140000, 0x50000, 0xf);
     if (*(short*)(s + 0x380) != 0 || *(short*)(s + 0x382) != 0) {
         Matrix4x3 *dst = (Matrix4x3*)((*(char**)(s + 0xe8)) + 0xf0);
         data_020a0e68 = *dst;

--- a/src/func_ov018_02111f1c.cpp
+++ b/src/func_ov018_02111f1c.cpp
@@ -3,7 +3,19 @@ typedef int Fix12;
 struct BCA_File;
 struct BTP_File;
 struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 struct TextureSequence { void SetFile(BTP_File &f, int a, Fix12 b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *, BTP_File &f, int a, Fix12 b, unsigned int c);
+
 
 extern "C" void func_ov018_021123d0(char *c, int x);
 extern void *data_ov018_02113c08[];
@@ -14,9 +26,9 @@ extern "C" int func_ov018_02111f1c(char *c)
     if (*(int *)(c + 0x374) == 0 && *(unsigned char *)(c + 0x386) == 0)
         func_ov018_021123d0(c, 0);
     *(int *)(c + 0x98) = 0x5000;
-    ((ModelAnim *)(c + 0xd4))->SetAnim((BCA_File *)data_ov018_02113c08[1], 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0xd4), (BCA_File *)data_ov018_02113c08[1], 0, 0x1000, 0);
     *(int *)(c + 0x130) = 0x1000;
-    ((TextureSequence *)(c + 0x138))->SetFile(*(BTP_File *)data_ov018_02113bf8[1], 0, 0x1000, 0);
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj((TextureSequence *)(c + 0x138), *(BTP_File *)data_ov018_02113bf8[1], 0, 0x1000, 0);
     *(int *)(c + 0x37c) = 2;
     return 1;
 }

--- a/src/func_ov018_02112730.cpp
+++ b/src/func_ov018_02112730.cpp
@@ -10,10 +10,16 @@ struct Actor {
   static int Spawn(unsigned int, unsigned int, const Vector3&, const Vector3_16*, int, int);
   void MarkForDestruction();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ActorBase18MarkForDestructionEv(void *);
+
 extern "C" int func_ov018_02112730(Actor* c){
   if (c->DistToCPlayer() < 0x64000) {
     Actor::Spawn(0xb2, (*(int*)((char*)c+8) & 0xf) | 0x40, *(Vector3*)((char*)c+0x5c), 0, *(signed char*)((char*)c+0xcc), -1);
   }
-  c->MarkForDestruction();
+  _ZN9ActorBase18MarkForDestructionEv(c);
   return 1;
 }

--- a/src/func_ov030_02113a80.cpp
+++ b/src/func_ov030_02113a80.cpp
@@ -4,12 +4,18 @@ struct BCA_File;
 struct ModelAnim {
     void SetAnim(BCA_File*, int, int, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File*, int, int, unsigned int);
+
 int _ZN8SaveData16HasPlayerLostCapEv(void);
 extern char data_ov030_02115ce0[];
 
 int func_ov030_02113a80(char* c)
 {
-    ((ModelAnim*)(c + 0xd4))->SetAnim(*(BCA_File**)(data_ov030_02115ce0 + 4), 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(c + 0xd4), *(BCA_File**)(data_ov030_02115ce0 + 4), 0, 0x1000, 0);
     *(int*)(c + 0x130) = 0x1000;
     if (*(unsigned char*)(c + 0x3c8) == 0 && _ZN8SaveData16HasPlayerLostCapEv()) {
         *(unsigned char*)(c + 0x3c7) = 5;

--- a/src/func_ov062_021164e8.cpp
+++ b/src/func_ov062_021164e8.cpp
@@ -2,6 +2,12 @@
 #include "types.h"
 struct BCA_File;
 struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12i b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12i b, unsigned int c);
+
 
 extern void *data_ov062_0211de00[];
 extern int data_ov062_0211dec0;
@@ -14,7 +20,7 @@ extern "C" int func_ov062_021164e8(char *c)
     if (*(unsigned char *)(c + 0x3e5) == 0) {
         t = (*(int *)(c + 0xb0) & 0x4000) != 0;
         if (t) {
-            ((ModelAnim *)(c + 0x300))->SetAnim((BCA_File *)data_ov062_0211de00[1], 0, 0x1000, 0);
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x300), (BCA_File *)data_ov062_0211de00[1], 0, 0x1000, 0);
             *(unsigned char *)(c + 0x3e5) = 1;
         }
     }

--- a/src/func_ov062_02116d28.cpp
+++ b/src/func_ov062_02116d28.cpp
@@ -8,6 +8,12 @@ struct ShadowModel;
 struct Actor {
     void DropShadowRadHeight(ShadowModel &sm, Matrix4x3 &mtx, Fix12 a, int b, unsigned int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *, ShadowModel &sm, Matrix4x3 &mtx, Fix12 a, int b, unsigned int c);
+
 
 extern Matrix4x3 data_02082128;
 
@@ -20,5 +26,5 @@ extern "C" void func_ov062_02116d28(char *c)
     *(int *)(c + 0x3b8) = *(int *)(o + 0x60) >> 3;
     o = *(char **)(c + 0x3f8);
     *(int *)(c + 0x3bc) = *(int *)(o + 0x64) >> 3;
-    ((Actor *)c)->DropShadowRadHeight(*(ShadowModel *)(c + 0x368), *(Matrix4x3 *)(c + 0x390), 0x12c000, 0x32000, 0xf);
+    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j((Actor *)c, *(ShadowModel *)(c + 0x368), *(Matrix4x3 *)(c + 0x390), 0x12c000, 0x32000, 0xf);
 }

--- a/src/func_ov062_02118004.cpp
+++ b/src/func_ov062_02118004.cpp
@@ -7,6 +7,12 @@ extern "C" int _Z14ApproachLinearRiii(int &r, int target, int speed);
 struct Particle {
     static void RunningSlidingDustAt(int a, int b, int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int a, int b, int c);
+
 extern "C" void func_ov062_02118004(void *c, int a1) {
     int r = ((WithMeshClsn*)((char*)c + 0x144))->IsOnGround();
     if (r == 0) return;
@@ -14,5 +20,5 @@ extern "C" void func_ov062_02118004(void *c, int a1) {
     int x = *(int*)((char*)c + 0x5c);
     int y = *(int*)((char*)c + 0x60);
     int z = *(int*)((char*)c + 0x64);
-    Particle::RunningSlidingDustAt(x, y, z);
+    _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(x, y, z);
 }

--- a/src/func_ov062_02119af0.cpp
+++ b/src/func_ov062_02119af0.cpp
@@ -4,7 +4,13 @@
 #include "common.h"
 #pragma opt_propagation off
 
-namespace cstd { int atan2(int y, int x); }
+namespace cstd { int atan2(int y, int x);
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+ }
 extern "C" int Vec3_Dist(const Vector3 *a, const Vector3 *b);
 extern "C" void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, Vector3 *v, unsigned int i);
 extern "C" int func_ov062_02119af0(char *p) {
@@ -29,7 +35,7 @@ extern "C" int func_ov062_02119af0(char *p) {
     dz = nd4 - n64;
     dxc = ncc - nc0;
     dzc = nd4 - nc8;
-    *(short *)(p + 0x3a8) = (short)cstd::atan2(dx, dz);
+    *(short *)(p + 0x3a8) = (short)cstd::_ZN4cstd5atan2E5Fix12IiES1_(dx, dz);
     int dot = (dxc >> 0xc) * (dx >> 0xc) + (dzc >> 0xc) * (dz >> 0xc);
     if (dot <= 0 || Vec3_Dist((Vector3 *)(p + 0x5c), (Vector3 *)(p + 0x3cc)) < (*(int *)(p + 0x98) >> 1)) {
         int v = *(int *)(p + 0x3cc);

--- a/src/func_ov062_0211b880.cpp
+++ b/src/func_ov062_0211b880.cpp
@@ -3,6 +3,12 @@ struct BCA_File;
 struct BlendModelAnim {
     int SetAnim(BCA_File& f, int a, int b, int d, unsigned short e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File& f, int a, int b, int d, unsigned short e);
+
 extern BCA_File* data_ov062_0211e104[];
 extern "C" int func_ov062_0211b880(unsigned char* c) {
     *(int*)(c + 0x390) = 0x2000;
@@ -10,6 +16,6 @@ extern "C" int func_ov062_0211b880(unsigned char* c) {
     *(int*)(c + 0xa8) = 0;
     *(int*)(c + 0xac) = 0;
     *(int*)(c + 0x9c) = 0;
-    ((BlendModelAnim*)(c + 0x334))->SetAnim(*data_ov062_0211e104[1], 4, 0, 0x1000, 0);
+    _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim*)(c + 0x334), *data_ov062_0211e104[1], 4, 0, 0x1000, 0);
     return 1;
 }

--- a/src/func_ov062_0211b930.cpp
+++ b/src/func_ov062_0211b930.cpp
@@ -10,6 +10,12 @@ struct BCA_File;
 struct BlendModelAnim {
     int SetAnim(BCA_File& f, int a, int b, Fix12 spd, unsigned short t);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File& f, int a, int b, Fix12 spd, unsigned short t);
+
 struct Actor {
     static Actor* FindWithID(unsigned int id);
     static unsigned int Spawn(unsigned int a, unsigned int b, const Vector3& pos,
@@ -18,7 +24,13 @@ struct Actor {
 struct ActorBase { void MarkForDestruction(); };
 namespace Particle { struct System {
     static void NewSimple(unsigned int id, Fix12 x, Fix12 y, Fix12 z);
-}; }
+};
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12 x, Fix12 y, Fix12 z);
+ }
 
 extern "C" void func_02012790(int);
 extern "C" void func_02012694(unsigned int, void*);
@@ -60,7 +72,7 @@ struct Obj {
 extern "C" int func_ov062_0211b930(Obj* o)
 {
     Actor* found;
-    o->anim.SetAnim(*data_ov062_0211e10c.f, 4, 0x40000000, 0x1000, 0);
+    _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(&(o->anim), *data_ov062_0211e10c.f, 4, 0x40000000, 0x1000, 0);
     o->f43c = 1;
     if (o->f44c != 0 && (found = Actor::FindWithID(o->f44c)) != 0) {
         Found* f = (Found*)found;
@@ -83,7 +95,7 @@ extern "C" int func_ov062_0211b930(Obj* o)
         o->f444 = 0x1e;
     }
     func_02012694(0xef, (char*)o + 0x74);
-    Particle::System::NewSimple(0x7e, o->f5c.x, o->f5c.y, o->f5c.z);
+    Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x7e, o->f5c.x, o->f5c.y, o->f5c.z);
     o->fa4 = 0;
     o->fa8 = 0;
     o->fac = 0;

--- a/src/func_ov062_0211bc54.cpp
+++ b/src/func_ov062_0211bc54.cpp
@@ -3,6 +3,12 @@ struct BCA_File;
 struct BlendModelAnim {
     void SetAnim(BCA_File &a, int b, int c, int d, unsigned short e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File &a, int b, int c, int d, unsigned short e);
+
 extern "C" signed char data_0209f2f8;
 extern "C" int data_0209e650;
 extern "C" void *data_ov062_0211e114;
@@ -23,7 +29,6 @@ extern "C" int func_ov062_0211bc54(char *thiz)
     func_02012694(0xee, thiz + 0x74);
     *(int*)(thiz + 0x43c) =
         ((((unsigned)RandomIntInternal(&data_0209e650) >> 8) & 3) << 8) + 0x300;
-    ((BlendModelAnim*)(thiz + 0x334))->SetAnim(
-        *(BCA_File*)((void**)&data_ov062_0211e114)[1], 4, 0, 0x1000, 0);
+    _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim*)(thiz + 0x334), *(BCA_File*)((void**)&data_ov062_0211e114)[1], 4, 0, 0x1000, 0);
     return 1;
 }

--- a/src/func_ov064_021163c0.cpp
+++ b/src/func_ov064_021163c0.cpp
@@ -3,6 +3,12 @@ typedef int Fix12;
 struct BCA_File;
 struct WithMeshClsn { int IsOnGround() const; };
 struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 
 void ApproachLinear(short &v, short t, short step);
 
@@ -20,6 +26,6 @@ extern "C" void func_ov064_021163c0(char *c)
     *(short *)(c + 0x94) = *(short *)(c + 0x8e);
     *(int *)(c + 0x398) = 0;
     BCA_File *f = *(BCA_File **)(*(char **)(*(char **)(c + 0x330) + 0x10) + 4);
-    ((ModelAnim *)(c + 0x110))->SetAnim(f, 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x110), f, 0, 0x1000, 0);
     return;
 }

--- a/src/func_ov064_02116460.cpp
+++ b/src/func_ov064_02116460.cpp
@@ -2,6 +2,12 @@
 struct BCA_File;
 struct WithMeshClsn { int IsOnGround() const; };
 struct ModelAnim { void SetAnim(BCA_File *f, int b, int c, unsigned int d); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int b, int c, unsigned int d);
+
 
 extern "C" int _Z14ApproachLinearRiii(int *dst, int target, int rate);
 
@@ -25,7 +31,7 @@ extern "C" void func_ov064_02116460(char *self)
         *(short *)(self + 0x94) = *(short *)(self + 0x8e);
         {
             BCA_File *anim = (BCA_File *)*(int *)(*(int *)(*(int *)(self + 0x330) + 0x10) + 4);
-            ((ModelAnim *)(self + 0x110))->SetAnim(anim, 0, 0x2000, 0);
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(self + 0x110), anim, 0, 0x2000, 0);
         }
         return;
     }

--- a/src/func_ov066_02116d14.cpp
+++ b/src/func_ov066_02116d14.cpp
@@ -4,6 +4,12 @@ struct BCA_File;
 struct BlendModelAnim {
     void SetAnim(BCA_File &f, int a, int b, Fix12 c, unsigned short d);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File &f, int a, int b, Fix12 c, unsigned short d);
+
 
 extern void *data_ov066_0211aea4[];
 extern void *data_ov066_0211ae8c[];
@@ -16,9 +22,9 @@ extern "C" int func_ov066_02116d14(char *c)
     *(int *)(c + 0x4a0) = 0;
     *(int *)(c + 0x98) = -0xa000;
     if (*(int *)(c + 0x49c) == 2) {
-        ((BlendModelAnim *)(c + 0x360))->SetAnim(*(BCA_File *)data_ov066_0211aea4[1], 4, 0x40000000, 0x1000, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x360), *(BCA_File *)data_ov066_0211aea4[1], 4, 0x40000000, 0x1000, 0);
     } else {
-        ((BlendModelAnim *)(c + 0x360))->SetAnim(*(BCA_File *)data_ov066_0211ae8c[1], 4, 0x40000000, 0x1000, 0);
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim *)(c + 0x360), *(BCA_File *)data_ov066_0211ae8c[1], 4, 0x40000000, 0x1000, 0);
     }
     return 1;
 }

--- a/src/func_ov070_0211f0a4.cpp
+++ b/src/func_ov070_0211f0a4.cpp
@@ -9,6 +9,12 @@ struct Actor {
     void SpawnCoins(Vector3 const &, unsigned int, int, short);
     void KillAndTrackInDeathTable();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void *, Vector3 const &, unsigned int, int, short);
+
 
 extern "C" int func_ov070_0211f0a4(void *c) {
     Actor *a = (Actor *)c;
@@ -18,6 +24,6 @@ extern "C" int func_ov070_0211f0a4(void *c) {
     pos.y = *(int *)((char *)c + 0x60);
     pos.z = *(int *)((char *)c + 0x64);
     unsigned int coins = *(unsigned char *)((char *)c + 0x10a) + 1;
-    a->SpawnCoins(pos, coins, 0xa000, 0);
+    _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(a, pos, coins, 0xa000, 0);
     a->KillAndTrackInDeathTable();
 }

--- a/src/func_ov070_0211f5f0.cpp
+++ b/src/func_ov070_0211f5f0.cpp
@@ -3,12 +3,18 @@ struct BCA_File;
 struct ModelAnim {
     void SetAnim(BCA_File *, int, int, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *, int, int, unsigned int);
+
 
 extern int data_ov070_02123500;
 
 extern "C" int func_ov070_0211f5f0(char *c) {
     unsigned int flags = 0;
     BCA_File *file = (BCA_File *)(((int *)&data_ov070_02123500)[1]);
-    ((ModelAnim *)(c + 0x300))->SetAnim(file, 0x40000000, 0x1000, flags);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x300), file, 0x40000000, 0x1000, flags);
     return 1;
 }

--- a/src/func_ov071_0211f7d4.c
+++ b/src/func_ov071_0211f7d4.c
@@ -13,6 +13,13 @@ extern "C" void func_ov071_0211f498(char *c);
 extern "C" void Scuttlebug_SetState(char *c, int x);
 extern "C" void func_ov071_0211f29c(char *c);
 struct CylinderClsn2 { void Clear(); void Update(); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN12CylinderClsn5ClearEv(void *);
+extern "C" void _ZN12CylinderClsn6UpdateEv(void *);
+
 
 extern "C" int func_ov071_0211f7d4(Actor *self)
 {
@@ -39,7 +46,7 @@ extern "C" int func_ov071_0211f7d4(Actor *self)
     }
     self->UpdatePos((CylinderClsn*)(s + 0x160));
     func_ov071_0211f29c(s);
-    ((CylinderClsn2*)(s + 0x160))->Clear();
-    ((CylinderClsn2*)(s + 0x160))->Update();
+    _ZN12CylinderClsn5ClearEv((CylinderClsn2*)(s + 0x160));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn2*)(s + 0x160));
     return 1;
 }

--- a/src/func_ov075_02114cd8.cpp
+++ b/src/func_ov075_02114cd8.cpp
@@ -9,6 +9,12 @@ extern "C" void Matrix4x3_ApplyInPlaceToRotationY(Matrix4x3 *mf, short angY);
 struct BlendModelAnim { void Advance(); };
 struct Animation { void Advance(); };
 struct ShadowModel { void InitModel(Matrix4x3 *m, int b, int c, int d, unsigned int e); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j(void *, Matrix4x3 *m, int b, int c, int d, unsigned int e);
+
 extern "C" Matrix4x3 data_020a0e68;
 
 struct C0 {};
@@ -29,5 +35,5 @@ extern "C" void func_ov075_02114cd8(void *self)
     (((C0*)self)->*data_ov075_0211d53c[*(int*)(s + 0x114)].pmf)();
     ((BlendModelAnim*)self)->Advance();
     ((Animation*)(s + 0xd4))->Advance();
-    ((ShadowModel*)(s + 0xe8))->InitModel((Matrix4x3*)(s + 0x1c), 0x50000, 0x1f4000, 0x50000, 0xf);
+    _ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j((ShadowModel*)(s + 0xe8), (Matrix4x3*)(s + 0x1c), 0x50000, 0x1f4000, 0x50000, 0xf);
 }

--- a/src/func_ov075_021152d4.cpp
+++ b/src/func_ov075_021152d4.cpp
@@ -8,10 +8,22 @@
 struct Vector3;
 namespace G3i {
     void PerspectiveW_(int a1, int a2, int a3, int a4, int a5, int a6, bool b, Matrix4x3 *m);
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(int a1, int a2, int a3, int a4, int a5, int a6, bool b, Matrix4x3 *m);
+
     void LookAt_(const Vector3 *eye, const Vector3 *at, const Vector3 *up, bool b, Matrix4x3 *m);
 }
 extern "C" void _Z13CopyToViewMatPK9Matrix4x3(const Matrix4x3 *m);
-namespace Clipper { void Func_020156DC(void *a, int b, int c, int d, int e); }
+namespace Clipper { void Func_020156DC(void *a, int b, int c, int d, int e);
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN7Clipper13Func_020156DCEv(void *a, int b, int c, int d, int e);
+ }
 
 extern "C" short data_02082614[];
 extern "C" int data_0209f43c;
@@ -19,10 +31,9 @@ extern "C" int data_0209f43c;
 extern "C" void func_ov075_021152d4(char *self)
 {
     Matrix4x3 view;
-    G3i::PerspectiveW_(data_02082614[0xa], data_02082614[0xb], 0x1555, 0x1000,
-                       0x1388000, 0x1000, true, (Matrix4x3*)0);
+    G3i::_ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(data_02082614[0xa], data_02082614[0xb], 0x1555, 0x1000, 0x1388000, 0x1000, true, (Matrix4x3*)0);
     G3i::LookAt_((Vector3*)(self + 0xf28), (Vector3*)&data_ov075_0211c660,
                  (Vector3*)(self + 0xf34), true, &view);
     _Z13CopyToViewMatPK9Matrix4x3(&view);
-    Clipper::Func_020156DC(&data_0209f43c, 0x1555, 0x105b, 0x1000, 0x1388000);
+    Clipper::_ZN7Clipper13Func_020156DCEv(&data_0209f43c, 0x1555, 0x105b, 0x1000, 0x1388000);
 }

--- a/src/func_ov075_02117590.cpp
+++ b/src/func_ov075_02117590.cpp
@@ -5,6 +5,12 @@ struct OAM {
     static int Render(bool, OamAttr*, int, int, int, int, Fix12, OamAttr*, int, int);
     static void RenderSub(OamAttr*, int, int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(bool, OamAttr*, int, int, int, int, Fix12, OamAttr*, int, int);
+
 extern "C" int func_0200f0bc(void);
 extern int* data_ov075_0211c9cc[];
 extern short data_ov075_0211b5d4[];
@@ -14,7 +20,7 @@ extern "C" void func_ov075_02117590(char* c)
 {
     int* tbl = data_ov075_0211c9cc[func_0200f0bc()];
     OamAttr* attr = (OamAttr*)tbl[*(int*)(c + 0x268)];
-    OAM::Render(false, attr, 0x80, 0x60, -1, -1, 0x1000, (OamAttr*)0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(false, attr, 0x80, 0x60, -1, -1, 0x1000, (OamAttr*)0x1000, 0, -1);
 
     int a1, a2;
     unsigned char idx = *(unsigned char*)(c + 0x281);

--- a/src/func_ov075_021194e4.cpp
+++ b/src/func_ov075_021194e4.cpp
@@ -9,6 +9,12 @@ struct OAM {
     static int Render(bool, OamAttr*, int, int, int, int, Fix12, int);
     static void RenderSub(OamAttr*, int, int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(bool, OamAttr*, int, int, int, int, Fix12, int);
+
 
 extern "C" int func_0200f0bc(void);
 extern OamAttr* data_0208a0f8[];
@@ -49,7 +55,7 @@ extern "C" void func_ov075_021194e4(char* c)
                 y = fallback;
             }
 
-            OAM::Render(one, attr, x, y, minus, minus, fx, zero);
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(one, attr, x, y, minus, minus, fx, zero);
 
             if (attr->attr3 == 0xffff)
                 break;

--- a/src/func_ov075_021199d8.cpp
+++ b/src/func_ov075_021199d8.cpp
@@ -9,6 +9,12 @@ struct OAM {
     static int Render(bool, OamAttr*, int, int, int, int, Fix12, int);
     static void RenderSub(OamAttr*, int, int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(bool, OamAttr*, int, int, int, int, Fix12, int);
+
 
 extern "C" int func_0200f0bc(void);
 extern OamAttr* data_ov075_0211c968[];
@@ -49,7 +55,7 @@ extern "C" void func_ov075_021199d8(char* c)
                 y = fallback;
             }
 
-            OAM::Render(one, attr, x, y, minus, minus, fx, zero);
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(one, attr, x, y, minus, minus, fx, zero);
 
             if (attr->attr3 == 0xffff)
                 break;

--- a/src/func_ov077_021244d4.cpp
+++ b/src/func_ov077_021244d4.cpp
@@ -3,19 +3,31 @@ typedef int Fix12;
 struct BCA_File;
 struct BTP_File;
 struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+
 struct Animation { void SetFlags(int f); };
 struct TextureSequence { void SetFile(BTP_File &f, int a, Fix12 b, unsigned int c); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *, BTP_File &f, int a, Fix12 b, unsigned int c);
+
 
 extern void *data_ov077_02127b40[];
 extern void *data_ov077_02127b30[];
 
 extern "C" void func_ov077_021244d4(char *c)
 {
-    ((ModelAnim *)(c + 0xd4))->SetAnim((BCA_File *)data_ov077_02127b40[1], 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0xd4), (BCA_File *)data_ov077_02127b40[1], 0, 0x1000, 0);
     ((Animation *)(c + 0x124))->SetFlags(0x40000000);
     *(int *)(c + 0x130) = 0x1000;
     *(int *)(c + 0x12c) = 0;
-    ((TextureSequence *)(c + 0x1b0))->SetFile(*(BTP_File *)data_ov077_02127b30[1], 0, 0x1000, 0);
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj((TextureSequence *)(c + 0x1b0), *(BTP_File *)data_ov077_02127b30[1], 0, 0x1000, 0);
     ((Animation *)(c + 0x1b0))->SetFlags(0x40000000);
     *(int *)(c + 0x1bc) = 0x1000;
     *(int *)(c + 0x1b8) = 0;

--- a/src/func_ov078_02123bc4.cpp
+++ b/src/func_ov078_02123bc4.cpp
@@ -2,11 +2,17 @@
 typedef int Fix12;
 struct BCA_File;
 struct BlendModelAnim { int SetAnim(BCA_File&, int, int, Fix12, unsigned short); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *, BCA_File&, int, int, Fix12, unsigned short);
+
 extern int* data_ov078_02126ee8[];
 extern "C" int func_ov078_02123bc4(char* c){
   *(int*)(c+0x9c)=-0x2000;
   *(int*)(c+0x4fc)=2;
   *(int*)(c+0x98)=0xa000;
-  ((BlendModelAnim*)(c+0x2cc))->SetAnim(*(BCA_File*)data_ov078_02126ee8[1], 4, 0, 0x1000, 0);
+  _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((BlendModelAnim*)(c+0x2cc), *(BCA_File*)data_ov078_02126ee8[1], 4, 0, 0x1000, 0);
   return 1;
 }

--- a/src/func_ov079_02126f8c.cpp
+++ b/src/func_ov079_02126f8c.cpp
@@ -11,11 +11,26 @@ struct Platform {
     int UpdateKillByMegaChar(short, short, short, Fix12);
     int IsClsnInRange(Fix12, Fix12);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(void *, short, short, short, Fix12);
+extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *, Fix12, Fix12);
+
 struct Actor_s {
     static Actor* FindWithID(unsigned int);
     Actor* ClosestPlayer();
     static Actor* Spawn(unsigned int, unsigned int, const Vector3&, const Vector3_16*, int, int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" Actor* _ZN5Actor10FindWithIDEj(unsigned int);
+extern "C" Actor* _ZN5Actor13ClosestPlayerEv(void *);
+extern "C" Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, const Vector3&, const Vector3_16*, int, int);
+
 extern "C" {
 Fix12 Vec3_HorzDist(const Vector3* a, const Vector3* b);
 short Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
@@ -29,10 +44,10 @@ int Platform::IsClsnInRange(Fix12, Fix12);
 
 extern "C" int func_ov079_02126f8c(char* c) {
     Platform* self = (Platform*)c;
-    if (self->UpdateKillByMegaChar(0x2000, 0, 0, 0xc8000))
+    if (_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(self, 0x2000, 0, 0, 0xc8000))
         return 1;
-    if (!Actor_s::FindWithID(*(unsigned int*)(c + 0x320))) {
-        Actor* p = ((Actor_s*)c)->ClosestPlayer();
+    if (!_ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 0x320))) {
+        Actor* p = _ZN5Actor13ClosestPlayerEv((Actor_s*)c);
         Fix12 dist = Vec3_HorzDist((Vector3*)(c + 0x5c), (Vector3*)((char*)p + 0x5c));
         short ang = Vec3_HorzAngle((Vector3*)(c + 0x5c), (Vector3*)((char*)p + 0x5c));
         if (AngleDiff(ang, *(short*)(c + 0x8e)) < 0x2000 && dist > 0x320000 && dist < 0x5dc000) {
@@ -44,11 +59,11 @@ extern "C" int func_ov079_02126f8c(char* c) {
             *(volatile int*)&pos.x = x;
             *(volatile int*)&pos.z = z;
             *(volatile int*)&pos.y = y;
-            Actor* spawned = Actor_s::Spawn(0xde, 0, pos, (Vector3_16*)(c + 0x8c), *(signed char*)(c + 0xcc), -1);
+            Actor* spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xde, 0, pos, (Vector3_16*)(c + 0x8c), *(signed char*)(c + 0xcc), -1);
             *(int*)(c + 0x320) = *(int*)((char*)spawned + 4);
             *(int*)((char*)spawned + 0x3dc) = (int)c;
         }
     }
-    self->IsClsnInRange(0, 0);
+    _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(self, 0, 0);
     return 1;
 }

--- a/src/func_ov080_02123ecc.cpp
+++ b/src/func_ov080_02123ecc.cpp
@@ -2,6 +2,12 @@
 struct Vector3; struct BCA_File;
 struct Actor { Actor *ClosestPlayer(); };
 struct ModelAnim { void SetAnim(BCA_File *f, int b, int c, unsigned int d); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int b, int c, unsigned int d);
+
 extern "C" int Vec3_HorzDist(const void *a, const void *b);
 extern "C" short Vec3_HorzAngle(const void *a, const void *b);
 extern "C" void func_0201267c(int a, void *b);
@@ -19,7 +25,7 @@ extern "C" void func_ov080_02123ecc(Actor *self)
     if (*(signed char*)(s + 0x181) != 1) return;
     if (dist >= 0xfa000) {
         *(int*)(s + 0x17c) = 2;
-        ((ModelAnim*)(s + 0xd4))->SetAnim((BCA_File*)data_ov080_021283d8[1], 0x40000000, 0x1000, 0);
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)(s + 0xd4), (BCA_File*)data_ov080_021283d8[1], 0x40000000, 0x1000, 0);
         Actor *p2 = self->ClosestPlayer();
         *(short*)(s + 0x8e) = Vec3_HorzAngle(s + 0x5c, (char*)p2 + 0x5c);
         {

--- a/src/func_ov081_02124d14.cpp
+++ b/src/func_ov081_02124d14.cpp
@@ -3,12 +3,18 @@ struct BCA_File;
 struct ModelAnim {
     void SetAnim(BCA_File *, int, int, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *, int, int, unsigned int);
+
 
 extern int data_ov081_02128db8;
 
 extern "C" int func_ov081_02124d14(char *c) {
     unsigned int flags = 0;
     BCA_File *file = (BCA_File *)(((int *)&data_ov081_02128db8)[1]);
-    ((ModelAnim *)(c + 0x30c))->SetAnim(file, 0x40000000, 0x1000, flags);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x30c), file, 0x40000000, 0x1000, flags);
     return 1;
 }

--- a/src/func_ov081_02125068.cpp
+++ b/src/func_ov081_02125068.cpp
@@ -1,6 +1,12 @@
 //cpp
 struct BCA_File;
 struct ModelAnim { int SetAnim(BCA_File *, int, int, unsigned int); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *, int, int, unsigned int);
+
 struct S2 { int w[2]; };
 extern S2 data_ov081_02128d98;
 extern "C" int func_ov081_02125068(char *c)
@@ -11,6 +17,6 @@ extern "C" int func_ov081_02125068(char *c)
     } else if (v == 2) {
         *(int *)(c + 0xb0) = 0x8000002;
     }
-    ((ModelAnim *)(c + 0x30c))->SetAnim((BCA_File *)data_ov081_02128d98.w[1], 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x30c), (BCA_File *)data_ov081_02128d98.w[1], 0, 0x1000, 0);
     return 1;
 }

--- a/src/func_ov081_02127be0.cpp
+++ b/src/func_ov081_02127be0.cpp
@@ -8,6 +8,12 @@ struct ActorBase { void MarkForDestruction(); };
 struct Actor {
     static Actor* Spawn(unsigned int a, unsigned int b, const Vector3& v, const Vector3_16_local* v16, int e, int f);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const Vector3& v, const Vector3_16_local* v16, int e, int f);
+
 
 extern "C" void func_ov081_02127be0(char* c)
 {
@@ -35,7 +41,7 @@ extern "C" void func_ov081_02127be0(char* c)
     ((ActorBase*)*(char**)(c + 0x364))->MarkForDestruction();
 
     unsigned int newflags = (unsigned char)(flags & 0xf) | 0x20;
-    Actor::Spawn(0xb4, newflags, pos, &rot, *(signed char*)(c + 0xcc), -1);
-    *(char**)(c + 0x364) = (char*)Actor::Spawn(0xb2, newflags, pos, &rot, *(signed char*)(c + 0xcc), -1);
+    _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb4, newflags, pos, &rot, *(signed char*)(c + 0xcc), -1);
+    *(char**)(c + 0x364) = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, newflags, pos, &rot, *(signed char*)(c + 0xcc), -1);
     *(int*)(((int)c + 0xb0)) |= 0x4000000;
 }

--- a/src/func_ov084_02129238.cpp
+++ b/src/func_ov084_02129238.cpp
@@ -20,6 +20,14 @@ struct RaycastGround {
     void SetObjAndPos(const Vector3& pos, Actor* a);
     int DetectClsn();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN4BgCh19StartDetectingWaterEv(void *);
+extern "C" void _ZN4BgCh19StartDetectingToxicEv(void *);
+extern "C" void _ZN4BgCh21StopDetectingOrdinaryEv(void *);
+
 
 extern "C" {
 int _ZNK12WithMeshClsn10IsOnGroundEv(void* p);
@@ -46,9 +54,9 @@ void func_ov084_02129238(char* c)
             pos.z = vz;
         }
         RaycastGround rg;
-        rg.StartDetectingWater();
-        rg.StartDetectingToxic();
-        rg.StopDetectingOrdinary();
+        _ZN4BgCh19StartDetectingWaterEv(&(rg));
+        _ZN4BgCh19StartDetectingToxicEv(&(rg));
+        _ZN4BgCh21StopDetectingOrdinaryEv(&(rg));
         rg.SetObjAndPos(pos, (Actor*)c);
         if (rg.DetectClsn() != 0) {
             if (func_02037e20(&rg.field14) != 0) {

--- a/src/func_ov084_0212a580.cpp
+++ b/src/func_ov084_0212a580.cpp
@@ -15,6 +15,12 @@ extern short data_02082214[];
 struct CapEnemy {
     void UpdateCapPos(const Vector3&, const Vector3_16_local&);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8CapEnemy12UpdateCapPosERK7Vector3RK10Vector3_16(void *, const Vector3&, const Vector3_16_local&);
+
 
 extern "C" void func_ov084_0212a580(char* c){
     Vector3_16_local s16;
@@ -48,5 +54,5 @@ extern "C" void func_ov084_0212a580(char* c){
     arg16.y = ((unsigned short*)&s16)[1];
     arg16.z = ((unsigned short*)&s16)[2];
     /* equal-arm ternary forces arg16 setup (r2) before arg (r1) — matches ROM call-arg order */
-    ((CapEnemy*)c)->UpdateCapPos(arg, c ? arg16 : arg16);
+    _ZN8CapEnemy12UpdateCapPosERK7Vector3RK10Vector3_16((CapEnemy*)c, arg, c ? arg16 : arg16);
 }

--- a/src/func_ov084_0212c92c.cpp
+++ b/src/func_ov084_0212c92c.cpp
@@ -3,11 +3,17 @@ struct BCA_File;
 struct ModelAnim {
     void SetAnim(BCA_File *, int, int, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *, int, int, unsigned int);
+
 
 extern int data_ov084_02130d9c;
 
 extern "C" void func_ov084_0212c92c(void *c) {
     unsigned int flags = 0;
     BCA_File *file = (BCA_File *)(((int *)&data_ov084_02130d9c)[1]);
-    ((ModelAnim *)((char *)c + 0x108))->SetAnim(file, 0, 0x1000, flags);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)((char *)c + 0x108), file, 0, 0x1000, flags);
 }

--- a/src/func_ov085_0212943c.cpp
+++ b/src/func_ov085_0212943c.cpp
@@ -3,11 +3,17 @@ struct BCA_File;
 struct ModelAnim {
     void SetAnim(BCA_File *, int, int, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *, int, int, unsigned int);
+
 
 extern int data_ov085_02130490;
 
 extern "C" void func_ov085_0212943c(void *c) {
     unsigned int flags = 0;
     BCA_File *file = (BCA_File *)(((int *)&data_ov085_02130490)[1]);
-    ((ModelAnim *)((char *)c + 0x108))->SetAnim(file, 0, 0x1000, flags);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)((char *)c + 0x108), file, 0, 0x1000, flags);
 }

--- a/src/func_ov085_0212bedc.cpp
+++ b/src/func_ov085_0212bedc.cpp
@@ -18,6 +18,12 @@ struct Matrix4x3;
 struct Actor {
     void DropShadowRadHeight(ShadowModel &, Matrix4x3 &, Fix12, Fix12, unsigned int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *, ShadowModel &, Matrix4x3 &, Fix12, Fix12, unsigned int);
+
 
 extern Matrix4x3 data_020a0e68;
 
@@ -57,5 +63,5 @@ extern "C" void func_ov085_0212bedc(Obj *c)
         Matrix4x3_FromTranslation(&data_020a0e68, vd.x >> 3, (t - 0xc000) >> 3, vd.z >> 3);
     }
     c->mtx = data_020a0e68;
-    ((Actor *)c)->DropShadowRadHeight(*(ShadowModel *)&c->shadowmodel, *(Matrix4x3 *)&c->mtx, 0x46000, 0x258000, 0xf);
+    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j((Actor *)c, *(ShadowModel *)&c->shadowmodel, *(Matrix4x3 *)&c->mtx, 0x46000, 0x258000, 0xf);
 }

--- a/src/func_ov085_0212de5c.cpp
+++ b/src/func_ov085_0212de5c.cpp
@@ -6,7 +6,13 @@ struct Actor {
     Player *ClosestPlayer();
     short HorzAngleToCPlayer();
 };
-namespace Sound { void PlaySub(u32, u32, u32, Fix12i, bool); }
+namespace Sound { void PlaySub(u32, u32, u32, Fix12i, bool);
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Sound7PlaySubEjjj5Fix12IiEb(u32, u32, u32, Fix12i, bool);
+ }
 extern "C" void func_0201f32c(int);
 extern "C" int func_ov085_0212e728(void *c, void *p);
 extern unsigned char data_0209d66c;
@@ -48,7 +54,7 @@ extern "C" int func_ov085_0212de5c(PlayerObj *c)
         int n = *pp + 1;
         *pp = n;
     }
-    Sound::PlaySub(0x4b, 0x14, 0x7f, 0x15666, false);
+    Sound::_ZN5Sound7PlaySubEjjj5Fix12IiEb(0x4b, 0x14, 0x7f, 0x15666, false);
     switch (c->v2c8) {
     case 1:
         p->v723 = 1;

--- a/src/func_ov091_02131070.cpp
+++ b/src/func_ov091_02131070.cpp
@@ -6,12 +6,18 @@
 extern "C" {
 struct Vector3 { int x,y,z; };
 }
-namespace Particle { struct System { static System* NewSimple(unsigned int, int, int, int); }; }
+namespace Particle { struct System { static System* NewSimple(unsigned int, int, int, int); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" System* _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
+ }
 struct Actor { void PoofDustAt(const Vector3&); };
 namespace Sound { void PlayBank3(unsigned int, const Vector3&); }
 struct MeshColliderBase { int IsEnabled(); void Disable(); };
 extern "C" void func_ov091_02131070(char* c){
-    Particle::System::NewSimple(0xbb, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
+    Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xbb, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
     Vector3 v = { *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64) };
     ((Actor*)c)->PoofDustAt(v);
     Sound::PlayBank3(0xf, *(Vector3*)(c+0x74));

--- a/src/func_ov102_02149610.cpp
+++ b/src/func_ov102_02149610.cpp
@@ -7,10 +7,16 @@ struct RaycastGround {
   void SetObjAndPos(const Vector3 &pos, void *actor);
   int DetectClsn();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *, const Vector3 &pos, void *actor);
+
 extern "C" int func_ov102_02149610(char *c){
   Vector3 pos(*(int*)(c+0x5c), *(int*)(c+0x60)+0x28000, *(int*)(c+0x64));
   RaycastGround rg;
-  rg.SetObjAndPos(pos, 0);
+  _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&(rg), pos, 0);
   *(int*)((char*)&rg + 0x4c) = 0x3e8000;
   int r = *(int*)(c+0x60);
   if (rg.DetectClsn()) r = *(int*)((char*)&rg + 0x44);

--- a/src/func_ov102_0214aa18.cpp
+++ b/src/func_ov102_0214aa18.cpp
@@ -7,6 +7,13 @@ struct WithMeshClsn;
 struct Actor { void UpdatePos(CylinderClsn *c); };
 struct Enemy { void UpdateWMClsn(WithMeshClsn &w, unsigned int j); };
 struct WithMeshClsn2 { int JustHitGround() const; int IsOnGround() const; };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZNK12WithMeshClsn13JustHitGroundEv(void *);
+extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void *);
+
 extern "C" void func_ov102_0214b53c(char *c);
 extern "C" void func_ov102_0214ad40(char *c);
 extern "C" void func_ov102_0214c0b8(char *c);
@@ -28,14 +35,14 @@ extern "C" int func_ov102_0214aa18(Actor *self)
         func_ov102_0214ad40(s);
         ((CylinderClsn*)(s + 0x110))->Clear();
         ((CylinderClsn*)(s + 0x110))->Update();
-        if (((WithMeshClsn2*)(s + 0x144))->JustHitGround()) {
+        if (_ZNK12WithMeshClsn13JustHitGroundEv((WithMeshClsn2*)(s + 0x144))) {
             Vector3 v;
             v.x = *(int*)(s + 0x5c);
             v.y = *(int*)(s + 0x60);
             v.z = *(int*)(s + 0x64);
             func_0200fc44(s, &v, 1);
         }
-        if (((WithMeshClsn2*)(s + 0x144))->IsOnGround() == 0)
+        if (_ZNK12WithMeshClsn10IsOnGroundEv((WithMeshClsn2*)(s + 0x144)) == 0)
             return 1;
         int *fl = (int*)(((int)s + 0x128));
         *fl = *fl & ~2;

--- a/src/func_ov102_0214ce60.cpp
+++ b/src/func_ov102_0214ce60.cpp
@@ -13,6 +13,12 @@ struct Actor {
     Matrix4x3& UpdateCarry(Player& p, const Vector3& v);
     void DropShadowRadHeight(ShadowModel& sm, Matrix4x3& m, Fix12i a, int b, unsigned int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *, ShadowModel& sm, Matrix4x3& m, Fix12i a, int b, unsigned int c);
+
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
 
 extern "C" void func_ov102_0214ce60(char* c)
@@ -32,5 +38,5 @@ extern "C" void func_ov102_0214ce60(char* c)
     }
     int drop = (*(int*)(c + 0xb0) & 0x40000) != 0;
     if (drop) return;
-    ((Actor*)c)->DropShadowRadHeight(*(ShadowModel*)(c + 0x350), *(Matrix4x3*)(c + 0x31c), 0x50000, 0x50000, 0xf);
+    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j((Actor*)c, *(ShadowModel*)(c + 0x350), *(Matrix4x3*)(c + 0x31c), 0x50000, 0x50000, 0xf);
 }

--- a/tools/demember_calls.py
+++ b/tools/demember_calls.py
@@ -1,0 +1,476 @@
+"""Turn a member call whose mangled name does not exist into an extern "C" free call.
+
+## The shape this fixes
+
+A file declares an ad-hoc local class so it can spell a method call:
+
+    struct Actor { short ReflectAngle(int, int, short); };
+    ...
+    ((Actor*)self)->ReflectAngle(a, b, c);
+
+The compiler mangles that declaration into `_ZN5Actor12ReflectAngleEiis`. The ROM's
+symbol is `_ZN5Actor12ReflectAngleE5Fix12IiES1_s` -- the parameters are `Fix12<int>`,
+not `int`, because whoever recovered the signature guessed scalars. So the reference
+resolves to nothing and `eligible.py` will not enroll the file.
+
+`resolve_placeholders.py` cannot repair this: the mangled name never appears in the
+source, so there is no token to rewrite. It reports these as `not textual`.
+
+## Why not just correct the declaration
+
+Because `Fix12<int>` is a class, and mwccarm passes a by-value class differently from
+an `int` -- at the *call site*, not only in the callee. Measured:
+
+    take_i(h, 0x800)   ->  mov r1,#0x800
+    take_f(h, v)       ->  ldr r1,[pc,#..] ; ldm r1,{r1}
+
+So declaring the true signature changes the caller's bytes and breaks the match. See
+notes/mwccarm-codegen.md 6az.
+
+## What it does instead
+
+The form the corpus already uses in over a thousand files, and the one 6az prescribes:
+name the ROM symbol directly, keeping the LOCAL declaration's return and parameter
+types verbatim -- they are what currently produce matching bytes (sub-word types are
+not interchangeable with int) -- with a `void*` receiver prepended:
+
+    extern "C" short _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *, int, int, short);
+    ...
+    _ZN5Actor12ReflectAngleE5Fix12IiES1_s(self, a, b, c);
+
+Registers are registers: the ROM's `Fix12<int>` parameter arrives in r1 exactly as an
+`int` would. The declaration deliberately misstates the types and says so in a comment,
+because an unmarked lie gets read as recovered truth and propagated.
+
+A file is only touched when EVERY missing symbol in it has reloc evidence naming a
+real target -- a partial repair cannot enroll the file and would be diff churn.
+Every rewritten file is byte-verified against the ROM and reverted on failure.
+
+Usage:
+    python tools/demember_calls.py                 # report only
+    python tools/demember_calls.py --apply
+"""
+import argparse
+import collections
+import concurrent.futures
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import match as M              # noqa: E402
+import modules as MOD          # noqa: E402
+import eligible as E           # noqa: E402
+import resolve_placeholders as RP   # noqa: E402
+from enroll import candidates  # noqa: E402
+
+def decode(sym):
+    """_ZN[K]<len>Name...<len>method E...  ->  (Class, method), or None.
+
+    The method is the LAST component and its class the second-to-last: a
+    namespace-qualified `_ZN8Particle6System9NewSimpleE..` is (System, NewSimple),
+    not (Particle, System). Constructors/destructors (C1/D1: no length-prefixed
+    method component) come back None and are left for a different tool."""
+    m = re.match(r"^_ZN(K?)(\d+)", sym)
+    if not m:
+        return None
+    i = 3 + len(m.group(1))
+    parts = []
+    while i < len(sym) and sym[i].isdigit():
+        d = re.match(r"\d+", sym[i:])
+        n = int(d.group(0))
+        i += len(d.group(0))
+        parts.append(sym[i:i + n])
+        i += n
+    return (parts[-2], parts[-1]) if len(parts) >= 2 else None
+
+
+# A method declaration inside a local struct: type tokens, the name, a paren group
+# with no nested parens, optional const/pure-virtual, semicolon. The leading
+# [;{}\n] boundary is what keeps this from matching a CALL, whose name is always
+# preceded by `->` or `.`.
+def _decl_re(method):
+    return (r"(?:^|[;{}\n])\s*((?:[\w:<>,]+[\s*&]+)+)"
+            + re.escape(method) + r"\s*\(([^()]*)\)\s*(?:const)?\s*(?:=\s*0\s*)?;")
+
+
+def scopes_at(text, upto):
+    """The stack of open-brace scopes enclosing offset `upto`.
+
+    Each entry is ("ns", name) for a namespace, ("extern", None) for an
+    extern "C"/"C++" block, ("cls", None) for a struct/class/union body, and
+    ("other", None) for anything else (function bodies, initialisers)."""
+    stack = []
+    for m in re.finditer(r"[{}]", text[:upto]):
+        if m.group(0) == "}":
+            if stack:
+                stack.pop()
+            continue
+        head = text[max(0, m.start() - 160):m.start()].strip()
+        ns = re.search(r"namespace\s+([A-Za-z_]\w*)$", head)
+        if ns:
+            stack.append(("ns", ns.group(1)))
+        elif re.search(r'extern\s*"C(?:\+\+)?"$', head):
+            stack.append(("extern", None))
+        elif re.search(r"\b(?:struct|class|union)\b[^{;()]*$", head):
+            stack.append(("cls", None))
+        else:
+            stack.append(("other", None))
+    return stack
+
+
+def method_decl(text, cls, method):
+    """(ret, params, insert_at, is_static, qual) from `cls`'s declaration.
+
+    `insert_at` is the offset just past the struct's closing `};` line: every
+    type the parameter list names is necessarily complete there, and every call
+    site of the method necessarily comes after it. The declaration stays inside
+    whatever namespace declares the struct -- its parameter types are only
+    visible there, and extern "C" linkage makes the symbol flat regardless --
+    so calls must be qualified with `qual` (empty when at global scope).
+    `cls` may also be a NAMESPACE (`namespace cstd { int atan2(int, int); }`
+    mangles the same way): then the declaration is a free function, treated as
+    static (no receiver), inserted right after its own `;`, and `qual`
+    includes `cls` itself.
+    None if the declaration cannot be found, parsed, or is inside a scope an
+    extern "C" declaration cannot live in (a class body, a function)."""
+    m = re.search(r"\b(?:struct|class)\s+" + re.escape(cls) + r"\b[^{;]*\{", text)
+    ns_form = m is None
+    if ns_form:
+        m = re.search(r"\bnamespace\s+" + re.escape(cls) + r"\s*\{", text)
+        if not m:
+            return None
+    stack = scopes_at(text, m.start())
+    if any(kind in ("cls", "other") for kind, _ in stack):
+        return None
+    quals = [name for kind, name in stack if kind == "ns"] + ([cls] if ns_form else [])
+    qual = "::".join(quals)
+    depth, i = 1, m.end()
+    while i < len(text) and depth:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    dm = re.search(_decl_re(method), text[m.end():i])
+    if not dm:
+        return None
+    if ns_form:
+        at = m.end() + dm.end()  # just past the declaration's own `;`
+        ret = re.sub(r"\b(?:virtual|inline|static)\b", " ", dm.group(1))
+        return " ".join(ret.split()), " ".join(dm.group(2).split()), at, True, qual
+    # Insert IMMEDIATELY after the struct's `};` -- seeking to end-of-line
+    # would escape a namespace that closes on the same line, leaving the
+    # declaration at global scope while the call is spelled qualified.
+    at = i
+    while at < len(text) and text[at] in " \t\r\n":
+        at += 1
+    if at >= len(text) or text[at] != ";":
+        return None  # `struct X {...} name;` or EOF: nowhere safe to insert
+    at += 1
+    is_static = re.search(r"\bstatic\b", dm.group(1)) is not None
+    ret = re.sub(r"\b(?:virtual|inline|static)\b", " ", dm.group(1))
+    return " ".join(ret.split()), " ".join(dm.group(2).split()), at, is_static, qual
+
+
+def split_args(s):
+    """Top-level comma split, respecting nesting."""
+    out, depth, cur = [], 0, ""
+    for ch in s:
+        if ch in "([": depth += 1
+        elif ch in ")]": depth -= 1
+        if ch == "," and depth == 0:
+            out.append(cur.strip()); cur = ""
+        else:
+            cur += ch
+    if cur.strip():
+        out.append(cur.strip())
+    return out
+
+
+def find_call(text, method, start=0):
+    """Locate `->method(...)` or `.method(...)`; (recv, args, span, op) or None."""
+    for m in re.finditer(r"(->|\.)" + re.escape(method) + r"\s*\(", text[start:]):
+        op_at = start + m.start()
+        open_at = start + m.end() - 1
+        depth, i = 0, open_at
+        while i < len(text):
+            if text[i] == "(": depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        if i >= len(text):
+            continue
+        # Walk left over the receiver: either a parenthesised cast-expression or a
+        # plain identifier chain. Anything else is left alone rather than guessed at.
+        j = op_at
+        if text[j - 1] == ")":
+            depth, k = 0, j - 1
+            while k >= 0:
+                if text[k] == ")": depth += 1
+                elif text[k] == "(":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                k -= 1
+            if k < 0:
+                continue
+            recv_start = k
+        else:
+            k = j
+            while k > 0:
+                if text[k - 1].isalnum() or text[k - 1] in "_[].":
+                    k -= 1
+                elif k >= 2 and text[k - 2:k] == "->":
+                    k -= 2
+                else:
+                    break
+            recv_start = k
+        recv = text[recv_start:op_at].strip()
+        if not recv:
+            continue
+        return recv, split_args(text[open_at + 1:i]), (recv_start, i + 1), m.group(1)
+    return None
+
+
+KEYWORD_BEFORE_CALL = {"return", "else", "case", "do"}
+
+
+def find_static_call(text, method, start=0):
+    """Locate `Qual::...::method(...)`; (args, span) or None.
+
+    A qualified name preceded by a type token (`System* System::New(..)`, or the
+    struct-local `static System* New(..)`) is a DECLARATION, not a call; touching
+    it would redeclare the free symbol with the method's parameter list. Skip
+    any occurrence whose preceding token is `*`, `&`, or an identifier other
+    than a statement keyword."""
+    for m in re.finditer(r"(?:[A-Za-z_]\w*\s*::\s*)+" + re.escape(method) + r"\s*\(",
+                         text[start:]):
+        s = start + m.start()
+        open_at = start + m.end() - 1
+        k = s
+        while k > 0 and text[k - 1] in " \t\r\n":
+            k -= 1
+        if k > 0 and text[k - 1] in "*&":
+            continue
+        if k > 0 and (text[k - 1].isalnum() or text[k - 1] == "_"):
+            w = k
+            while w > 0 and (text[w - 1].isalnum() or text[w - 1] == "_"):
+                w -= 1
+            if text[w:k] not in KEYWORD_BEFORE_CALL:
+                continue
+        depth, i = 0, open_at
+        while i < len(text):
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        if i >= len(text):
+            continue
+        return split_args(text[open_at + 1:i]), (s, i + 1)
+    return None
+
+
+def receiver_expr(recv, op):
+    """The object-pointer argument for the free call.
+
+    The receiver expression is kept VERBATIM (any pointer converts to the
+    void* parameter implicitly) apart from one balanced outer paren layer:
+    stripping casts is how `(ModelAnim*)((char*)c + 0x108)` once became
+    `c + 0x108`, which is a different address. A `.` call's receiver is an
+    object, so its address is taken instead."""
+    expr = recv.strip()
+    if expr.startswith("(") and expr.endswith(")"):
+        depth = 0
+        for i, ch in enumerate(expr):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+        if i == len(expr) - 1:
+            expr = expr[1:-1].strip()
+    return f"&({expr})" if op == "." else expr
+
+
+COMMENT = ('/* Signature deliberately copied from the local declaration above: the\n'
+           '   ROM name carries by-value class parameters (e.g. Fix12<int>), which\n'
+           '   mwccarm passes differently at the call site, so declaring the true\n'
+           '   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */\n')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    ap.add_argument("--limit", type=int)
+    args = ap.parse_args()
+
+    relocs, syms = RP.load_relocs(), RP.load_symbols()
+    info = {}
+    for (d, name, rel, addr, size, sec) in candidates()[0]:
+        info[rel.replace("\\", "/")] = (name, addr, size, d)
+    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+
+    entries, _, _ = E.load_report()
+    jobs = []
+    for r in entries:
+        if not (r.get("reason") or "").startswith("unresolvable"):
+            continue
+        rel = r["file"].replace("\\", "/")
+        wanted = [s for s in (r.get("missing") or []) if decode(s)]
+        if wanted and rel in info:
+            jobs.append((rel, wanted, list(r.get("missing") or [])))
+
+    print(f"files referencing a class method that resolves to nothing: {len(jobs)}")
+
+    def one(job):
+        rel, wanted, allmiss = job
+        f = REPO / rel
+        name, addr, size, d = info[rel]
+        label = d.relative_to(REPO / "config").as_posix()
+        label = "arm9" if label == "arm9" else label.split("/")[-1]
+        orig_bytes = f.read_bytes()
+        text = orig_bytes.decode("utf-8", "surrogateescape")
+        flags = M.DEFAULT_FLAGS
+        if f.suffix == ".cpp" or text.startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+
+        obj = next((o for o in (M.compile_c(f, v, flags) for v in M.SWEEP) if o), None)
+        if obj is None:
+            return rel, "compile failed", 0
+        rl = RP.relocs_for(obj, name)
+        if rl is None:
+            return rel, "function not in object", 0
+
+        table = relocs.get(label, {})
+        real, generic, ambiguous = {}, 0, 0
+        for off, sym in rl:
+            if sym not in wanted:
+                continue
+            entry = table.get(addr + off)
+            if entry is None:
+                continue
+            to, spec = entry
+            cands = RP.module_keys(spec)
+            if not cands:
+                continue
+            nm, why = RP.resolve_in(syms, cands, to, label)
+            if nm and not RP.GENERIC.match(nm):
+                real[sym] = nm
+            elif nm:
+                generic += 1
+            elif why and "names" in why:
+                ambiguous += 1
+        if not real:
+            if ambiguous:
+                return rel, "target ambiguous across overlays", 0
+            if generic:
+                return rel, "target unnamed in config", 0
+            return rel, "no reloc evidence for the member call", 0
+        # A repair that leaves any other missing symbol behind cannot enroll the
+        # file; do not touch it at all.
+        if set(allmiss) - set(real):
+            return rel, "partial: other unresolvable references remain", 0
+
+        # Pass 1: parse every declaration and record where its extern decl goes --
+        # just past the declaring struct, where its parameter types are complete
+        # and before every call site.
+        todo, inserts = [], collections.defaultdict(list)
+        for sym, target in real.items():
+            cls, method = decode(sym)
+            if len(re.findall(_decl_re(method), text)) > 1:
+                return rel, "method name declared in more than one local class", 0
+            sig = method_decl(text, cls, method)
+            if sig is None:
+                return rel, "local declaration not found/parsed", 0
+            ret, params, at, is_static, qual = sig
+            todo.append((method, f"{qual}::{target}" if qual else target, is_static))
+            if target not in text:
+                # A static method has no receiver; an instance method's becomes
+                # a leading void*.
+                first = "" if is_static else ("void *, " if params else "void *")
+                inserts[at].append(f'extern "C" {ret} {target}({first}{params});')
+
+        # Insert declarations first (descending, so earlier offsets stay valid);
+        # the replacement pass rescans, so it needs no coordinate bookkeeping.
+        new = text
+        for at in sorted(inserts, reverse=True):
+            blob = "\n" + COMMENT + "\n".join(inserts[at]) + "\n"
+            if "\r\n" in text:
+                blob = blob.replace("\n", "\r\n")
+            new = new[:at] + blob + new[at:]
+
+        # Pass 2: EVERY call site must go -- one left behind still references the
+        # nonexistent mangled name and the file stays unresolvable.
+        n = 0
+        for method, target, is_static in todo:
+            pos, replaced = 0, 0
+            while True:
+                if is_static:
+                    hit = find_static_call(new, method, pos)
+                    if hit is None:
+                        break
+                    cargs, (s, e) = hit
+                    call = f"{target}({', '.join(cargs)})"
+                else:
+                    hit = find_call(new, method, pos)
+                    if hit is None:
+                        break
+                    recv, cargs, (s, e), op = hit
+                    call = f"{target}({', '.join([receiver_expr(recv, op)] + cargs)})"
+                new = new[:s] + call + new[e:]
+                pos = s + len(call)
+                replaced += 1
+            if replaced == 0:
+                return rel, "call site not in a recognised shape", 0
+            n += replaced
+
+        if n == 0 or new == text:
+            return rel, "call site not in a recognised shape", 0
+
+        if not args.apply:
+            return rel, "transformable (not compile-checked; run --apply)", n
+
+        f.write_text(new, encoding="utf-8", newline="\n")
+        tgt = (M.target_bytes(addr, size) if label == "arm9"
+               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
+        compiled = False
+        for v in M.SWEEP:
+            o = M.compile_c(f, v, flags)
+            if o is None:
+                continue
+            code, rr = M.extract_func(o, name)
+            if code is None:
+                continue
+            compiled = True
+            if M.compare(tgt, code, rr, verbose=False)[0]:
+                return rel, "transformed", n
+        f.write_bytes(orig_bytes)
+        return rel, ("reverted (compiled but bytes differ)" if compiled
+                     else "reverted (transformed source does not compile)"), 0
+
+    if args.limit:
+        jobs = jobs[:args.limit]
+    counts = collections.Counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rel, verdict, n in ex.map(one, jobs):
+            counts[verdict] += 1
+            print(f"  {verdict:50s} {rel}" + (f"  ({n} call(s))" if n else ""))
+    print()
+    for k, v in counts.most_common():
+        print(f"  {v:5d}  {k}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A file declares an ad-hoc class so it can spell a method call:

```cpp
struct Actor { short ReflectAngle(int, int, short); };
((Actor*)self)->ReflectAngle(a, b, c);
```

That mangles to `_ZN5Actor12ReflectAngleEiis`. The ROM's symbol is `_ZN5Actor12ReflectAngleE5Fix12IiES1_s` — the parameters are `Fix12<int>`, not `int`, because whoever recovered the signature guessed scalars. So the reference resolves to nothing and the file can't be enrolled.

`resolve_placeholders.py` can't repair these: **the mangled name never appears in the source**, so there's no token to rewrite. It reports them as `not textual`, and there were 126.

## Correcting the declaration is not the fix

`Fix12<int>` is a class, and mwccarm passes a by-value class differently **at the call site**, not only in the callee:

```
take_i(h, 0x800)   ->  mov r1,#0x800
take_f(h, v)       ->  ldr r1,[pc,#..] ; ldm r1,{r1}
```

So declaring the true signature breaks the caller's bytes. Instead this calls the ROM symbol directly as an `extern "C"` free function — the pattern the corpus already uses widely — keeping the **original declaration's types verbatim**. Those types are wrong about the ROM and right about the codegen, and sub-word types aren't interchangeable with `int`: a `short` parameter truncates where an `int` sign-extends.

| | |
|---|---|
| enrolled | 10,534 → **10,620** (+86) |
| code bytes built | 84.28% → **84.90%** |
| reproducing | 10,620 / 10,620 |
| module fidelity | 106/106 exact, 100.000000% |
| ROM-build analysis | **PASS** |
| attribution | 0 changed, 0 lost |

## The evidence

**All 86 changed files enroll**, so the ROM link checked every rewritten call against the real ROM word. No file here rests on byte evidence alone — which matters, because byte comparison wildcards relocations and is blind to exactly what this changes.

## One file reverted, and why it's worth saying

`func_ov006_020cb030` passed the per-file byte check and then **mismatched at the link by three words**. The per-file check accepts a match under any compiler version in `match.SWEEP`; the ROM build pins one. That's a real gap in the verification path, and the reason the full build is the gate rather than a formality. Left unfixed and out of this PR.

113 in-scope files, under the 200 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi