### PR TITLE
func_ov006_020cb030 calls the wrong function

### DIFF
--- a/src/func_ov006_020cb030.cpp
+++ b/src/func_ov006_020cb030.cpp
@@ -7,7 +7,10 @@ struct System {
     static System* New(unsigned, unsigned, Fix12, Fix12, Fix12, const Vector3_16f*, Callback*);
 };
 extern "C" {
-extern void func_ov006_020c9024(char *o);
+/* The ROM's relocation at 0x020cb088 targets 0x020cb134, not 0x020c9024.
+   The byte gate could not object: a bl is a relocation, which match.py
+   compares as a wildcard, so either callee passes. */
+extern void func_ov006_020cb134(char *o);
 extern void func_ov006_020cafdc(char *o);
 extern int data_ov006_0214059c;
 }
@@ -31,7 +34,7 @@ extern "C" void func_ov006_020cb030(char *o) {
             fn = (void(*)())cl->off;
         ((void(*)(void*))fn)(tobj);
     }
-    func_ov006_020c9024(o);
+    func_ov006_020cb134(o);
     Fix12 v = (Fix12)(((long long)*(int*)(o + 0x44) * 0xb4b + 0x800) >> 12);
     if (*(int*)(o + 0x38) > v) {
         if (*(int*)(o + 0xcc) == data_ov006_0214059c) {


### PR DESCRIPTION
The source calls `func_ov006_020c9024`. The ROM's own relocation says otherwise:

```
from:0x020cb088 kind:arm_call to:0x020cb134 module:overlay(6)
```

Both are real, distinct, 0x38-byte functions in ov006. The call at `+0x58` goes to `0x020cb134`.

## Nothing could have caught this

A `bl` is a relocation, and `match.py` compares relocated words as **wildcards** — so the byte gate passes either callee. The ROM link would object, but this file isn't enrolled (its `Particle::System::New` call mangles to a name no module defines), so the link never sees it.

Same structure as `Door::Behavior` and the two `ActorBase` destructors: **the gate that can see callees is prevented from running by an unrelated defect in the same file.** That's the fourth instance this session.

## How it surfaced

Not by looking for it. A tool transformed this file, the per-file byte check passed, and the full ROM build reported it mismatching by one word. I assumed the tool was wrong. It wasn't — it had exposed a pre-existing bug, and chasing the verification gap is what found it.

Byte-verified under the build's pinned `2004/b56`: exact, 0 differences.

## What this does not prove

The file stays unenrollable for the separate `Particle::System::New` reason, so the ROM link can't confirm it yet. The evidence here is the ROM's own relocation record — the same authority `tools/resolve_placeholders.py` resolves against — not a link verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi