### PR TITLE
Count itcm in the module universe, from one shared definition

### DIFF
--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -65,39 +65,6 @@ def no_match_needed(head: str) -> dict[str, str] | None:
     return {"bucket": bucket, "reason": reason}
 
 
-def module_universe() -> list[tuple[str, pathlib.Path]]:
-    """Every module the viewer should show, as (label, symbols.txt), from the ONE
-    shared enumerator in relocs.py.
-
-    This used to be a local regex that returned arm9 and ovNNN and silently
-    dropped everything else, which is why the whole itcm module -- 43 functions,
-    including the largest unmatched function in the game -- was invisible in the
-    viewer for as long as the viewer has existed. Nobody could see those
-    functions to claim them, and the percentages read as complete because the
-    denominator was missing too.
-
-    modules.py had the identical bug and was fixed on 2026-08-01 (see
-    notes/itcm.md: the autoloads' absence "reads exactly like clean"). Rather
-    than fix the same bug a third time somewhere else, this defers to relocs.py
-    and then CHECKS ITSELF against the filesystem: any config/**/symbols.txt the
-    enumerator does not yield is a hard failure, not a silent skip. A new module
-    can now be forgotten in exactly one place, and that place fails loudly."""
-    known: dict[pathlib.Path, str] = {}
-    for label, path in RL.iter_symbol_files():
-        if path.is_file():
-            known[path.resolve()] = label
-    missed = sorted(p for p in CONFIG.rglob("symbols.txt")
-                    if p.resolve() not in known)
-    if missed:
-        rels = ", ".join(p.relative_to(REPO).as_posix() for p in missed)
-        raise SystemExit(
-            f"chaos_db_ci: {len(missed)} symbols.txt not covered by "
-            f"relocs.iter_symbol_files(): {rels}\n"
-            "Teach relocs.py about the module rather than filtering it out here. "
-            "A module missing from the viewer looks like completed work.")
-    return sorted(known.items(), key=lambda kv: kv[1])
-
-
 def _handle_from(name: str, email: str) -> str:
     """git identity -> canonical-ish handle: noreply login, else the email local-part
     (stable across author-name typos, usually equals the GitHub handle), else the name."""
@@ -376,7 +343,9 @@ def main():
 
     functions = []
     total_b = matched_b = matched_n = 0
-    for sym, label in module_universe():
+    # Every module, itcm included. relocs.module_universe is the one definition of
+    # what "every module" means, and it fails loudly rather than skipping a new one.
+    for sym, label in RL.module_universe():
         for line in sym.read_text(errors="ignore").splitlines():
             m = FUNC_RE.match(line)
             if not m:

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -32,6 +32,7 @@ CONFIG = REPO / "config"
 SRC = REPO / "src"
 sys.path.insert(0, str(REPO / "tools"))
 import srcpath as SP  # noqa: E402
+import relocs as RL  # noqa: E402
 
 FUNC_RE = re.compile(
     r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
@@ -64,14 +65,37 @@ def no_match_needed(head: str) -> dict[str, str] | None:
     return {"bucket": bucket, "reason": reason}
 
 
-def module_label(sym_path: pathlib.Path) -> str | None:
-    """config/arm9/symbols.txt -> arm9; config/arm9/overlays/ovNNN -> ovNNN.
-    itcm/dtcm are skipped to match the viewer's module universe."""
-    rel = sym_path.parent.relative_to(CONFIG).as_posix()
-    if rel == "arm9":
-        return "arm9"
-    m = re.fullmatch(r"arm9/overlays/(ov\d+)", rel)
-    return m.group(1) if m else None
+def module_universe() -> list[tuple[str, pathlib.Path]]:
+    """Every module the viewer should show, as (label, symbols.txt), from the ONE
+    shared enumerator in relocs.py.
+
+    This used to be a local regex that returned arm9 and ovNNN and silently
+    dropped everything else, which is why the whole itcm module -- 43 functions,
+    including the largest unmatched function in the game -- was invisible in the
+    viewer for as long as the viewer has existed. Nobody could see those
+    functions to claim them, and the percentages read as complete because the
+    denominator was missing too.
+
+    modules.py had the identical bug and was fixed on 2026-08-01 (see
+    notes/itcm.md: the autoloads' absence "reads exactly like clean"). Rather
+    than fix the same bug a third time somewhere else, this defers to relocs.py
+    and then CHECKS ITSELF against the filesystem: any config/**/symbols.txt the
+    enumerator does not yield is a hard failure, not a silent skip. A new module
+    can now be forgotten in exactly one place, and that place fails loudly."""
+    known: dict[pathlib.Path, str] = {}
+    for label, path in RL.iter_symbol_files():
+        if path.is_file():
+            known[path.resolve()] = label
+    missed = sorted(p for p in CONFIG.rglob("symbols.txt")
+                    if p.resolve() not in known)
+    if missed:
+        rels = ", ".join(p.relative_to(REPO).as_posix() for p in missed)
+        raise SystemExit(
+            f"chaos_db_ci: {len(missed)} symbols.txt not covered by "
+            f"relocs.iter_symbol_files(): {rels}\n"
+            "Teach relocs.py about the module rather than filtering it out here. "
+            "A module missing from the viewer looks like completed work.")
+    return sorted(known.items(), key=lambda kv: kv[1])
 
 
 def _handle_from(name: str, email: str) -> str:
@@ -352,10 +376,7 @@ def main():
 
     functions = []
     total_b = matched_b = matched_n = 0
-    for sym in sorted(CONFIG.rglob("symbols.txt")):
-        label = module_label(sym)
-        if label is None:
-            continue
+    for sym, label in module_universe():
         for line in sym.read_text(errors="ignore").splitlines():
             m = FUNC_RE.match(line)
             if not m:
@@ -412,6 +433,11 @@ def main():
           f"{matched_n}/{len(functions)} funcs, {matched_b}/{total_b} bytes, "
           f"{db['stats']['moduleCount']} modules, "
           f"{sum(1 for f in functions if 'author' in f)} authored")
+    # Per-module counts in the log, so a module that stops being emitted shows up in
+    # the CI diff as a line that vanished. The silent version of this cost itcm its
+    # entire visibility; a number that goes to zero is at least readable.
+    per_mod = collections.Counter(f["module"] for f in functions)
+    print("  modules: " + ", ".join(f"{m}={n}" for m, n in sorted(per_mod.items())))
 
     # The single source of truth for the contributor chart: matched-function count per canonical
     # login. Regenerated on every merge (the workflow re-runs this), so "someone's number" is a

--- a/tools/chaosviewer.config.json
+++ b/tools/chaosviewer.config.json
@@ -7,7 +7,7 @@
   "compiler": "mwccarm 1.2/sp2p3. Flags (C): -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc",
   "cppNote": "If a name starts with _Z (C++ mangled), write C++ with the FIRST LINE exactly //cpp",
   "setup": "clone {github} and follow CONTRIBUTING.md (python deps + mwccarm from the DS-decomp Discord + tools/unpack.py on YOUR OWN cartridge dump).",
-  "verifyCommand": "python tools/match.py --c yourfile.c --func {name} --addr 0x{addrHex} --size 0x{sizeHex} --version 1.2/sp2p3",
+  "verifyCommand": "python tools/match.py --c yourfile.c --func {name} --addr 0x{addrHex} --size 0x{sizeHex} --module {module} --version 1.2/sp2p3",
   "readFirst": "notes/mwccarm-codegen.md (esp. sec 6e-6g levers: u64-mask laundering for materialized bases, declaration/statement order for register coloring, //cpp dummy-vtable dispatch, struct-copy interleave) and notes/pret-idioms.md. Coordinate via CLAIMS.md.",
   "rules": "only your own legally dumped ROM; never commit the ROM, its assets, or extracted binaries - the one deliberate exception is the annotated disassembly TEXT of still-unmatched functions, published in the coordination data (chaos-data branch) so contributors can work, the same practice as decomp repos committing .s files; import struct/field knowledge (see CREDITS.md) but write all C from scratch.",
   "discord": "https://discord.gg/YpReERF4e3",

--- a/tools/modules.py
+++ b/tools/modules.py
@@ -55,8 +55,18 @@ def modules():
     for name in ("itcm", "dtcm"):
         d = CFG / name
         syms = d / "symbols.txt"
-        b = BUILD / f"{name}.bin"
-        if not (b.is_file() and syms.is_file()):
+        # config.yaml points dsd at build/build/, but that is a BUILD output: a
+        # contributor who has only run tools/unpack.py does not have it, and the
+        # autoload then dropped out of the registry silently, so `match.py
+        # --module itcm` answered "module itcm not found". dsd also writes the
+        # same image to extracted/dsd/arm9/, which unpack.py does produce, so
+        # fall back to it. Same bytes, same base (itcm.yaml base_address
+        # 33521664 = 0x01ff8000, code_size 24384), just the copy that exists
+        # without a build.
+        b = next((p for p in (BUILD / f"{name}.bin",
+                              EXTRACTED / "dsd" / "arm9" / f"{name}.bin")
+                  if p.is_file()), None)
+        if not (b and syms.is_file()):
             continue
         base = _overlay_base(syms)      # same derivation: the module's lowest symbol
         if base is None:

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -27,6 +27,7 @@ CONFIG = REPO / "config"
 SRC = REPO / "src"
 sys.path.insert(0, str(REPO / "tools"))
 import srcpath as SP  # noqa: E402
+import relocs as RL  # noqa: E402
 MATCHED = REPO / "progress" / "matched.jsonl"
 README = REPO / "README.md"
 README_START = "<!-- progress:start -->"
@@ -62,14 +63,12 @@ def synced_from_src():
     matched if config declares it and src/<name>.c or src/<name>.cpp exists.
     Returns (done_n, done_b, n, total_bytes)."""
     n = total_bytes = done_n = done_b = 0
-    for sym in CONFIG.rglob("symbols.txt"):
-        # Canonical module universe: arm9 main + overlays only. itcm/dtcm are
-        # skipped so this fallback agrees with chaos-db.json / the treemap / the
-        # hosted viewer (see chaos_db_ci.module_label), which all report the same
-        # number. Without this filter itcm/dtcm inflate the denominator.
-        rel = sym.parent.relative_to(CONFIG).as_posix()
-        if rel != "arm9" and not re.fullmatch(r"arm9/overlays/ov\d+", rel):
-            continue
+    # Every module, itcm included, via the one definition in relocs.py. This used
+    # to skip itcm/dtcm to agree with chaos-db and the treemap, which skipped them
+    # too, so all the surfaces agreed on a number that left out 43 real functions
+    # and 24344 bytes of real game code. They agree again, on the honest figure:
+    # counting itcm moves the published rate from 92.480% to 91.580%.
+    for sym, _label in RL.module_universe():
         for line in sym.read_text(errors="ignore").splitlines():
             m = FUNC_NAME_RE.match(line)
             if not m:

--- a/tools/rebuild_ledger.py
+++ b/tools/rebuild_ledger.py
@@ -26,27 +26,19 @@ CONFIG = REPO / "config"
 SRC = REPO / "src"
 sys.path.insert(0, str(REPO / "tools"))
 import srcpath as SP  # noqa: E402
+import relocs as RL  # noqa: E402
 MATCHED = REPO / "progress" / "matched.jsonl"
 
 FUNC_RE = re.compile(
     r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
 
 
-def module_label(sym_path):
-    """config/arm9/symbols.txt -> arm9; config/arm9/overlays/ovNNN -> ovNNN."""
-    rel = sym_path.parent.relative_to(CONFIG).as_posix()
-    if rel == "arm9":
-        return "arm9"
-    m = re.fullmatch(r"arm9/overlays/(ov\d+)", rel)
-    return m.group(1) if m else None
-
-
 def main():
     recs, seen = [], set()
-    for sym in sorted(CONFIG.rglob("symbols.txt")):
-        label = module_label(sym)
-        if label is None:
-            continue
+    # Every module, itcm included. The local module_label here was the fourth copy
+    # of the arm9-plus-overlays filter, and it kept itcm's matches out of the
+    # ledger that the treemap and the local viewer both read.
+    for sym, label in RL.module_universe():
         for line in sym.read_text(errors="ignore").splitlines():
             m = FUNC_RE.match(line)
             if not m:

--- a/tools/relocs.py
+++ b/tools/relocs.py
@@ -60,6 +60,39 @@ def iter_symbol_files(include_itcm_dtcm: bool = True):
             yield normalize_module(path.parent.name), path
 
 
+def module_universe() -> list[tuple[pathlib.Path, str]]:
+    """Every module that exists, as ``(symbols.txt, label)``. THE definition.
+
+    Four tools each grew their own copy of this as a regex over config/, and all
+    four returned arm9 plus ovNNN and silently dropped anything else. The cost
+    was the whole itcm module -- 43 functions, 25 unmatched, including the
+    largest unmatched function in the game -- being invisible in the Chaos
+    Viewer, absent from the ledger, and missing from the denominator, which made
+    the project read as further along than it is. modules.py had the same bug
+    and was fixed alone on 2026-08-01; see notes/itcm.md, where the symptom is
+    described as reading "exactly like clean".
+
+    So this does not filter. It enumerates, and then checks itself against the
+    filesystem: any config/**/symbols.txt this function does not yield is a hard
+    failure at the call site, not a silent skip. Adding a module means teaching
+    iter_symbol_files() about it once, and forgetting to is loud."""
+    known: dict[pathlib.Path, str] = {}
+    for label, path in iter_symbol_files():
+        if path.is_file():
+            known[path.resolve()] = label
+    missed = sorted(p for p in (REPO / "config").rglob("symbols.txt")
+                    if p.resolve() not in known)
+    if missed:
+        rels = ", ".join(p.relative_to(REPO).as_posix() for p in missed)
+        raise SystemExit(
+            f"relocs.module_universe: {len(missed)} symbols.txt not covered by "
+            f"iter_symbol_files(): {rels}\n"
+            "Teach iter_symbol_files about the module rather than filtering it "
+            "out at the call site. A module missing from a count or a viewer "
+            "looks exactly like completed work.")
+    return sorted(known.items(), key=lambda kv: kv[1])
+
+
 def iter_reloc_files(include_itcm_dtcm: bool = True):
     """Yield ``(module, relocs_path)`` for main, overlays, and optionally RAM."""
     yield "arm9", RELOCS


### PR DESCRIPTION
The whole `itcm` module has been invisible in the Chaos Viewer, absent from the
ledger, and missing from the published denominator. That is 43 functions, 25 of
them unmatched over 21,936 bytes, including
`_ZN12MeshCollider10DetectClsnER10SphereClsn` (0x01ffb830, 7112 bytes), the
largest unmatched function in the game. Nobody browsing the atlas could see
those functions, so nobody could claim them.

## Not one filter, four

The same "arm9 plus ovNNN only" filter had been copied into four tools:

- `chaos_db_ci.py` (the hosted viewer's data)
- `progress.py::synced_from_src` (the README and treemap number)
- `rebuild_ledger.py` (the local ledger the treemap reads)
- `modules.py` (already fixed on its own on 2026-08-01, see `notes/itcm.md`)

`progress.py`'s own comment shows how the shape held itself up: it skipped itcm
"so this fallback agrees with chaos-db.json / the treemap / the hosted viewer,
which all report the same number". They did agree, on a number that left out
real game code.

`relocs.module_universe()` is now the single definition. It does not filter, it
enumerates, and then checks itself against the filesystem: any
`config/**/symbols.txt` it does not yield is a hard `SystemExit` at the call
site. A new module can be forgotten in exactly one place, and that place exits
1. Confirmed by dropping a fake module into `config/` and watching the tools
refuse to run.

## Two related bugs, found on the way

`modules.py` resolved the autoloads only from `build/build/`, which is a build
output. A contributor who has only run `tools/unpack.py` does not have it, so
itcm dropped out of the module registry silently and `match.py --module itcm`
answered "module itcm not found". It now falls back to
`extracted/dsd/arm9/itcm.bin`, the copy `unpack.py` produces. Same image, same
base (0x01ff8000, 24384 bytes).

`chaosviewer.config.json` never passed `--module` in its verify command, so the
command the viewer hands a contributor read arm9 bytes for every function
outside arm9. That was wrong for overlays too, not only itcm.

## The published number moves

Counting itcm takes the rate from **92.480% to 91.580%**. The denominator was
missing 43 functions and 24,344 bytes; it no longer is. All the surfaces still
agree with each other, which was the point of the original filter:

```
progress.synced_from_src: 11156/11390 funcs, 2047248/2235468 bytes  91.580%
chaos_db_ci             : 11156/11390 funcs, 2047248/2235468 bytes  91.580%
```

## Verified

- `progress.synced_from_src` and `chaos_db_ci` agree exactly, byte for byte.
- The guard exits 1 on an unknown module, from more than one entry point.
- `match.py --c src/func_01ffb07c.cpp --module itcm` reports `MATCHING
  VERSIONS: 1.2/sp2p3`, which it could not do before.
- All five touched tools compile.

A companion commit on the ChaosViewer repo fixes `parseClaimsMd`, whose module
regex was `ov\d{3}|arm9` and so filed an itcm claim against arm9, leaving the
function it named rendered as unclaimed.
