### PR TITLE
Stop crediting mitch030504's matches to mitchellcairns

### DIFF
--- a/attribution.json
+++ b/attribution.json
@@ -5,8 +5,7 @@
     "noreply": "tangosdev",
     "leonard.van.der.plaat": "lplaat",
     "andrew": "andrewboudreau",
-    "mitch.cairns": "mitchellcairns",
-    "mitch030504": "mitchellcairns"
+    "mitch.cairns": "mitchellcairns"
   },
   "overrides": {
     "src/func_02035860.c": "ruspecial",


### PR DESCRIPTION
Two different people both go by Mitch, and the alias map collapsed them on the
strength of the name. The git identities say otherwise:

```
Mitch Cairns  <mitch.cairns@handheldlegend.com>
Mitch Cairns  <mitchellcairns@gmail.com>
mitch030504   <40723072+mitch030504@users.noreply.github.com>
```

The first two are one person on two machines and do belong together, so that
alias stays. The third is a separate GitHub account whose noreply address
already carries its own login, which is the one case the alias map should never
touch. #1073 is theirs.

Contributor chart after this change:

```
mitch030504      14   (was 0, folded into mitchellcairns)
mitchellcairns   12
```

Nothing else moves. `contributions.json` is regenerated by `chaos_db_ci.py` from
this file, so no hand edit is involved.
