### PR TITLE
Verify rewrites against the compiler the ROM build will use, not any of 25

### DIFF
--- a/tools/build_pin.py
+++ b/tools/build_pin.py
@@ -1,0 +1,328 @@
+"""The compiler the ROM build will actually use for a file -- and a verifier pinned to it.
+
+## The false green this exists to stop
+
+`tools/match.py` sweeps every installed mwccarm (`match.SWEEP`, 25 builds at the time of
+writing) and calls a function matched when ANY of them reproduces it. That is the right
+rule for *matching*: the question there is whether the recovered source is the real
+thing, and a service pack that schedules two independent instructions the other way
+round does not make it less real.
+
+It is the wrong rule for *verifying an edit*. `tools/rombuild.py` compiles each enrolled
+file with exactly ONE compiler -- `rombuild.VERSION`, or the per-file override
+`config/rombuild-versions.txt` records -- so a file that reproduces only under some
+other sweep member links the wrong bytes. A tool that rewrites a file, byte-checks the
+rewrite against the sweep and keeps it has verified nothing the build will honour: the
+gate reports success for something the build then rejects.
+
+Observed: `src/func_ov006_020cb030.cpp` was rewritten by a transform that byte-verified
+it against the sweep. The check passed. The ROM build then reported the overlay
+MISMATCHING by three words -- `module fidelity: 105/106`, `ROM-build analysis: FAIL`.
+
+## The rule
+
+`version_for()` reproduces `rombuild.compile_one`'s lookup exactly, keyed on the FILE
+STEM because that is what the build keys on. `verify()` compiles with that one version
+and with the build's own flags (`rombuild.CFLAGS`, not `match.DEFAULT_FLAGS`): compiling
+the check with different flags than the link uses can bless a version the build then
+breaks on, which is the same defect by another route -- `tools/rombuild_versions.py`
+already had to say so.
+
+Everything fails CLOSED. An unknown pin, a compiler that is not installed, a compile
+error, a symbol missing from the object, a reloc-destination check that could not run --
+all report "not verified" rather than falling back to a sweep. A gate that answers
+"maybe" with "yes" is worse than no gate at all.
+
+Usage:
+    python tools/build_pin.py                      # what the build pins, and why
+    python tools/build_pin.py --audit              # sweep vs pinned over every candidate
+    python tools/build_pin.py --audit --limit 200
+"""
+import argparse
+import collections
+import concurrent.futures
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import match as M                                                    # noqa: E402
+from rombuild import CFLAGS, MW, VERSION, VERSIONS_FILE, versions    # noqa: E402
+
+# The build's default, re-exported so a caller never has to name a version literal.
+DEFAULT_VERSION = VERSION
+
+_pins = None
+_mods = None
+
+
+def pins():
+    """{file stem: mwccarm version} the build overrides, or None if unknowable.
+
+    None when `config/rombuild-versions.txt` is absent: the overrides are then not
+    merely empty but *unknown*, and every answer derived from them has to fail closed.
+    Cached -- this is read once per file in threaded sweeps of eleven thousand.
+    """
+    global _pins
+    if _pins is None:
+        _pins = versions() if VERSIONS_FILE.is_file() else False
+    return None if _pins is False else _pins
+
+
+def modules():
+    """{label: module registry entry}, with the ARM9 module under the name config uses."""
+    global _mods
+    if _mods is None:
+        import modules as MOD
+        _mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+    return _mods
+
+
+def version_for(rel, func=None):
+    """The mwccarm build `rombuild.py` will compile `rel` with, or None if unknown.
+
+    Keyed on the file stem, because `rombuild.compile_one` keys on the file stem
+    (`vers.get(pathlib.Path(rel).stem, VERSION)`) -- not on the symbol. The two
+    normally coincide, this corpus being one function per file named after it, but
+    where they do not it is the stem that decides what the build runs, so it is the
+    stem that has to decide what the verifier runs.
+
+    `func` is not used to look anything up. It is used to detect the one way the two
+    keyings can disagree: an override recorded under a symbol name whose file is named
+    something else is an override the build silently ignores. That is an inconsistent
+    pin, and picking a side would just re-manufacture the false green, so it returns
+    None and the caller reports the file unverified.
+    """
+    table = pins()
+    if table is None:
+        return None
+    stem = pathlib.PurePath(str(rel)).stem
+    pinned = table.get(stem)
+    if pinned is None and func is not None and func != stem and func in table:
+        return None
+    return pinned or DEFAULT_VERSION
+
+
+def compiler_for(rel, func=None):
+    """(version, None) for the build's compiler, or (None, why not)."""
+    v = version_for(rel, func)
+    if v is None:
+        if pins() is None:
+            return None, (f"no pinned build version: {VERSIONS_FILE.name} is missing, so "
+                          f"the per-file overrides cannot be read")
+        return None, (f"inconsistent pin: {VERSIONS_FILE.name} overrides symbol {func!r} "
+                      f"but the build keys on the file stem "
+                      f"{pathlib.PurePath(str(rel)).stem!r} and would ignore it")
+    exe = MW / v / "mwccarm.exe"
+    if not exe.is_file():
+        return None, f"pinned compiler {v} is not installed ({exe})"
+    return v, None
+
+
+def flags_for(path, text=None):
+    """The build's flags for this file: `rombuild.CFLAGS`, C++ when the file says so.
+
+    The `//cpp` first-line marker is the whole test, matching `rombuild.compile_one`.
+    Deliberately NOT `suffix == ".cpp" or ...` as the calling tools used to do: the
+    build does not look at the extension, so neither may a check that claims to predict
+    the build. (Every committed .cpp does carry the marker, and 53 committed .c files
+    carry it too and are compiled as C++ because of it.)
+    """
+    p = pathlib.Path(str(path))
+    if text is None:
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            text = ""
+    return CFLAGS.replace("-lang c99", "-lang c++") if text.startswith("//cpp") else CFLAGS
+
+
+def target_bytes(label, addr, size):
+    """The ROM's bytes for a function, given its config module label."""
+    if label == "arm9":
+        return M.target_bytes(addr, size)
+    mod = modules().get(label)
+    if mod is None:
+        return None
+    return M.target_bytes(addr, size, mod["bin"], mod["base"])
+
+
+def verify(src, func, addr, size, label, strict=None, version=None):
+    """Does `src` reproduce `func` under the compiler the ROM build will use?
+
+    Returns (ok, detail). `ok` is True only when the pinned compiler exists, compiles
+    the file, emits `func`, reproduces every non-relocated word, and -- when `strict`
+    is supplied -- every relocation lands on the destination `config/**/relocs.txt`
+    records. Every other outcome is False with a reason; there is no path that returns
+    True on a question it could not answer.
+
+    `strict`, when given, is the tuple `(reloc_audit, name_index, config_relocs,
+    sym_index)` the callers already build. `version` forces a build for callers that
+    are deliberately measuring a different one (the audit below); leave it None.
+    """
+    src = pathlib.Path(str(src))
+    if version is None:
+        # Absolute or relative is immaterial -- the lookup is on the stem either way.
+        version, why = compiler_for(src, func)
+        if version is None:
+            return False, why
+    tgt = target_bytes(label, addr, size)
+    if tgt is None:
+        return False, f"no module binary for {label!r}"
+    if len(tgt) != size:
+        return False, f"ROM bytes for {func} are out of range for {label}"
+    obj = M.compile_c(src, version, flags_for(src))
+    if obj is None:
+        return False, f"does not compile under {version}"
+    code, relocs = M.extract_func(obj, func)
+    if code is None:
+        return False, f"{func} is not in the object {version} produced"
+    ok, ndiff = M.compare(tgt, code, relocs, verbose=False)
+    if not ok:
+        return False, f"{ndiff} word(s) differ under {version}"
+    if strict is None:
+        return True, version
+    RA, name_index, config_relocs, sym_index = strict
+    try:
+        rows, missing = RA.check_destinations(obj, func, addr, size, label,
+                                              name_index, config_relocs, sym_index)
+    except Exception as e:                                  # noqa: BLE001
+        rows, missing = None, f"reloc-destination check raised: {e}"
+    if rows is None:
+        return False, f"bytes match under {version} but the reloc-destination check " \
+                      f"could not run: {missing}"
+    bad = [r for r in rows if r["verdict"] == "WRONG-DEST"]
+    if bad:
+        return False, (f"bytes match under {version} but {len(bad)} reloc destination(s) "
+                       f"are wrong (first: {bad[0]['cand']} != {bad[0]['cfg']})")
+    return True, version
+
+
+def sweep_version(src, func, addr, size, label, versions_=None):
+    """The first sweep member that reproduces `func`, or None. The OLD rule.
+
+    Kept because it is what the audit below has to compare against: the number that
+    matters is how many files answer "yes" here and "no" to `verify`.
+    """
+    tgt = target_bytes(label, addr, size)
+    if tgt is None:
+        return None
+    for v in (versions_ or M.SWEEP):
+        obj = M.compile_c(src, v, flags_for(src))
+        if obj is None:
+            continue
+        code, relocs = M.extract_func(obj, func)
+        if code is None:
+            continue
+        if M.compare(tgt, code, relocs, verbose=False)[0]:
+            return v
+    return None
+
+
+def _audit(args):
+    """Every candidate source, pinned-verified, and swept only where that fails.
+
+    The sweep is not run up front: it costs 25 compiles per file and its answer is only
+    interesting for a file the pinned build already rejected. A file that fails BOTH is
+    not a false green -- it is just an unfinished function, and this says so separately.
+    """
+    from enroll import candidates
+    import rombuild as RB
+
+    class _Sink:
+        """match.compile_c narrates every failed compile, and a sweep of eleven
+        thousand candidates produces tens of thousands of those lines. Progress goes
+        to the real stdout below; this eats the rest."""
+        def write(self, _s):
+            return 0
+
+        def flush(self):
+            pass
+
+    real, sys.stdout = sys.stdout, _Sink()
+    try:
+        return _audit_inner(args, candidates, RB, real)
+    finally:
+        sys.stdout = real
+
+
+def _audit_inner(args, candidates, RB, out):
+    enrolled = set(RB.enrolled())
+    rows = []
+    for (d, name, rel, addr, size, _sec) in candidates()[0]:
+        rel = rel.replace("\\", "/")
+        label = d.relative_to(REPO / "config").as_posix()
+        label = "arm9" if label == "arm9" else label.split("/")[-1]
+        rows.append((rel, name, addr, size, label))
+    rows.sort()
+    if args.limit:
+        rows = rows[:args.limit]
+    print(f"auditing {len(rows)} candidate source file(s) against the build's pin "
+          f"(default {DEFAULT_VERSION}, {len(pins() or {})} override(s))",
+          flush=True, file=out)
+
+    def one(row):
+        rel, name, addr, size, label = row
+        ok, detail = verify(REPO / rel, name, addr, size, label)
+        if ok:
+            return rel, name, label, "pinned-ok", detail
+        alt = sweep_version(REPO / rel, name, addr, size, label)
+        if alt is None:
+            return rel, name, label, "no-version", detail
+        return rel, name, label, "sweep-only", alt
+
+    counts, false_greens = collections.Counter(), []
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rel, name, label, verdict, detail in ex.map(one, rows):
+            counts[verdict] += 1
+            if verdict == "sweep-only":
+                false_greens.append((rel, name, label, detail, rel in enrolled))
+            done += 1
+            if done % 500 == 0:
+                print(f"  {done}/{len(rows)}  ({counts['sweep-only']} sweep-only so far)",
+                      flush=True, file=out)
+
+    print(file=out)
+    for k in ("pinned-ok", "sweep-only", "no-version"):
+        print(f"  {counts[k]:6d}  {k}", file=out)
+    print("", file=out)
+    print(f"FALSE GREENS -- reproduce under a sweep version the build will never "
+          f"use: {len(false_greens)}", file=out)
+    for rel, name, label, v, is_enrolled in sorted(false_greens):
+        print(f"  {v:12} {label:7} "
+              f"{'ENROLLED' if is_enrolled else 'not enrolled':13} {rel}", file=out)
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--audit", action="store_true",
+                    help="compile every candidate source under its pinned build version "
+                         "and sweep only the ones that fail, to size the false-green surface")
+    ap.add_argument("--limit", type=int)
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    ap.add_argument("files", nargs="*", help="report the pin for these source paths")
+    args = ap.parse_args()
+
+    if args.audit:
+        return _audit(args)
+    table = pins()
+    print(f"default              : {DEFAULT_VERSION}")
+    print(f"overrides            : {VERSIONS_FILE.relative_to(REPO).as_posix()}"
+          f" ({'MISSING -- every pin is unknown' if table is None else f'{len(table)} entries'})")
+    print(f"build flags          : {CFLAGS}")
+    print(f"build flags (//cpp)  : {CFLAGS.replace('-lang c99', '-lang c++')}")
+    print(f"sweep (NOT the pin)  : {len(M.SWEEP)} version(s)")
+    for f in args.files:
+        rel = pathlib.Path(f)
+        rel = rel.relative_to(REPO).as_posix() if rel.is_absolute() else rel.as_posix()
+        v, why = compiler_for(rel, pathlib.PurePath(rel).stem)
+        print(f"  {rel}: {v or 'UNVERIFIABLE -- ' + why}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/demember_calls.py
+++ b/tools/demember_calls.py
@@ -44,7 +44,20 @@ because an unmarked lie gets read as recovered truth and propagated.
 
 A file is only touched when EVERY missing symbol in it has reloc evidence naming a
 real target -- a partial repair cannot enroll the file and would be diff churn.
-Every rewritten file is byte-verified against the ROM and reverted on failure.
+
+Every rewritten file is verified against the ROM and reverted on failure, and that
+check has to be more than a byte compare, because this tool changes WHICH SYMBOL a
+call resolves to and `match.py` compares every relocated word as a wildcard. It is
+therefore blind, by construction, to the only thing being edited. The verification
+below reads the relocation's destination out of `config/**/relocs.txt`, and compiles
+with the one mwccarm `tools/rombuild.py` will build the file with rather than a sweep
+of all 25 installed ones. Both of those are load-bearing:
+
+    src/func_ov006_020cb030.cpp passed the byte-only sweep check this tool shipped
+    with, was enrolled, and the ROM build reported ov006 MISMATCHING --
+    `module fidelity: 105/106`, `ROM-build analysis: FAIL`. The differing word was a
+    `bl` at 0x020cb088 going to func_ov006_020c9024 where the ROM's own relocation
+    records 0x020cb134. A wildcard cannot see that. See tools/build_pin.py.
 
 Usage:
     python tools/demember_calls.py                 # report only
@@ -60,8 +73,8 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 
+import build_pin as BP         # noqa: E402
 import match as M              # noqa: E402
-import modules as MOD          # noqa: E402
 import eligible as E           # noqa: E402
 import resolve_placeholders as RP   # noqa: E402
 from enroll import candidates  # noqa: E402
@@ -319,7 +332,16 @@ def main():
     info = {}
     for (d, name, rel, addr, size, sec) in candidates()[0]:
         info[rel.replace("\\", "/")] = (name, addr, size, d)
-    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+
+    strict = None
+    try:
+        import reloc_audit as RA
+        import relocs as RL
+        strict = (RA, RA.build_name_index(), RA.build_config_relocs(), RL.load_all_syms())
+    except Exception as e:                                          # noqa: BLE001
+        print(f"  (reloc-destination check unavailable: {e}; verification is byte-only "
+              f"-- which is exactly the blind spot this tool has to cover, so treat "
+              f"anything it reports as transformed as UNVERIFIED)")
 
     entries, _, _ = E.load_report()
     jobs = []
@@ -341,13 +363,17 @@ def main():
         label = "arm9" if label == "arm9" else label.split("/")[-1]
         orig_bytes = f.read_bytes()
         text = orig_bytes.decode("utf-8", "surrogateescape")
-        flags = M.DEFAULT_FLAGS
-        if f.suffix == ".cpp" or text.startswith("//cpp"):
-            flags = flags.replace("-lang c99", "-lang c++")
 
-        obj = next((o for o in (M.compile_c(f, v, flags) for v in M.SWEEP) if o), None)
+        # The build's compiler, not the first sweep member that happens to compile:
+        # this object's relocation OFFSETS are added to the function's address to look
+        # the destination up in relocs.txt, so taking them from a compiler that laid
+        # the function out differently resolves the call against the wrong ROM word.
+        version, why = BP.compiler_for(f, name)
+        if version is None:
+            return rel, f"unverifiable: {why}", 0
+        obj = M.compile_c(f, version, BP.flags_for(f, text))
         if obj is None:
-            return rel, "compile failed", 0
+            return rel, f"compile failed under the build's compiler ({version})", 0
         rl = RP.relocs_for(obj, name)
         if rl is None:
             return rel, "function not in object", 0
@@ -442,29 +468,19 @@ def main():
             return rel, "transformable (not compile-checked; run --apply)", n
 
         f.write_text(new, encoding="utf-8", newline="\n")
-        tgt = (M.target_bytes(addr, size) if label == "arm9"
-               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
-        compiled = False
-        for v in M.SWEEP:
-            o = M.compile_c(f, v, flags)
-            if o is None:
-                continue
-            code, rr = M.extract_func(o, name)
-            if code is None:
-                continue
-            compiled = True
-            if M.compare(tgt, code, rr, verbose=False)[0]:
-                return rel, "transformed", n
+        ok, why = BP.verify(f, name, addr, size, label, strict=strict, version=version)
+        if ok:
+            return rel, "transformed", n
         f.write_bytes(orig_bytes)
-        return rel, ("reverted (compiled but bytes differ)" if compiled
-                     else "reverted (transformed source does not compile)"), 0
+        return rel, f"reverted: {why}", 0
 
     if args.limit:
         jobs = jobs[:args.limit]
     counts = collections.Counter()
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
         for rel, verdict, n in ex.map(one, jobs):
-            counts[verdict] += 1
+            # Bucket before the colon: the reasons carry per-file detail now.
+            counts[verdict.split(":")[0]] += 1
             print(f"  {verdict:50s} {rel}" + (f"  ({n} call(s))" if n else ""))
     print()
     for k, v in counts.most_common():

--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -47,8 +47,8 @@ import sys
 from elftools.elf.elffile import ELFFile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import build_pin as BP  # noqa: E402
 from enroll import candidates, CONFIG, REPO  # noqa: E402
-from rombuild import versions  # noqa: E402
 
 MW = REPO / "tools" / "mwccarm"
 LICENSE = MW / "license.dat"
@@ -181,8 +181,12 @@ def main():
 
     known = defined_symbols()
     cands, _ = candidates()
-    vers = versions()
-    jobs = [(rel, name, addr, size, sec, known, vers.get(name, VERSION))
+    # build_pin, not `versions().get(name, VERSION)`: rombuild.compile_one looks the
+    # override up by FILE STEM, so keying this by symbol classifies a file under a
+    # compiler the build would not use for it whenever the two spellings differ. They
+    # coincide today, which is exactly why the divergence would go unnoticed until the
+    # day they did not.
+    jobs = [(rel, name, addr, size, sec, known, BP.version_for(rel, name) or VERSION)
             for (_d, name, rel, addr, size, sec) in cands]
     print(f"classifying {len(jobs)} enrolled functions with -j{args.jobs} ...")
 

--- a/tools/extern_c_wrap.py
+++ b/tools/extern_c_wrap.py
@@ -44,8 +44,12 @@ wrong:
   depth already prevents wrapping *inside* one. Skipping such files wholesale, as the
   first version did, hid most of the remaining work.
 
-Every file is byte-verified after the edit and reverted if it stops reproducing, so a
-declaration that genuinely wanted C++ linkage cannot be broken silently.
+Every file is verified after the edit and reverted if it stops reproducing, so a
+declaration that genuinely wanted C++ linkage cannot be broken silently. That check is
+pinned to the compiler `tools/rombuild.py` will build the file with -- not a sweep of
+every installed mwccarm, which blesses versions the link never runs (see
+tools/build_pin.py) -- and it reads the relocation DESTINATION, because a byte compare
+cannot see the very thing this tool changes.
 
 Usage:
     python tools/extern_c_wrap.py                 # report only
@@ -64,8 +68,7 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 
-import match as M          # noqa: E402
-import modules as MOD      # noqa: E402
+import build_pin as BP     # noqa: E402
 import eligible as E       # noqa: E402
 from enroll import candidates  # noqa: E402
 
@@ -162,7 +165,18 @@ def main():
     info = {}
     for (d, name, rel, addr, size, sec) in candidates()[0]:
         info[rel.replace("\\", "/")] = (name, addr, size, d)
-    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+
+    # This tool exists because a reference resolves to the wrong name, and a byte
+    # compare cannot see a name -- the relocated word is a wildcard. So the check that
+    # decides whether a wrap worked has to be the one that reads the relocation's
+    # DESTINATION. Without it the verification is blind to the only thing being changed.
+    strict = None
+    try:
+        import reloc_audit as RA
+        import relocs as RL
+        strict = (RA, RA.build_name_index(), RA.build_config_relocs(), RL.load_all_syms())
+    except Exception as e:                                          # noqa: BLE001
+        print(f"  (reloc-destination check unavailable: {e}; verification is byte-only)")
 
     targets, skipped = [], collections.Counter()
     for rel, names in sorted(targets_by_file.items()):
@@ -200,30 +214,27 @@ def main():
         name, addr, size, d = info[rel]
         label = d.relative_to(REPO / "config").as_posix()
         label = "arm9" if label == "arm9" else label.split("/")[-1]
-        flags = M.DEFAULT_FLAGS.replace("-lang c99", "-lang c++")
-        tgt = (M.target_bytes(addr, size) if label == "arm9"
-               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
-        for v in M.SWEEP:
-            obj = M.compile_c(f, v, flags)
-            if obj is None:
-                continue
-            code, rl = M.extract_func(obj, name)
-            if code is None:
-                continue
-            ok, _ = M.compare(tgt, code, rl, verbose=False)
-            if ok:
-                return rel, "wrapped"
+        # Pinned to the compiler tools/rombuild.py will build this file with. This
+        # used to accept a match under any member of match.SWEEP, so a wrap could be
+        # kept on the strength of a compiler the link never runs -- see
+        # tools/build_pin.py. Anything the pinned build cannot answer is a revert.
+        ok, why = BP.verify(f, name, addr, size, label, strict=strict)
+        if ok:
+            return rel, "wrapped"
         f.write_text(original, encoding="utf-8", newline="\n")
-        return rel, "reverted (stopped matching)"
+        return rel, f"reverted: {why}"
 
     if args.limit:
         targets = targets[:args.limit]
     counts = collections.Counter()
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
         for rel, verdict in ex.map(one, targets):
-            counts[verdict] += 1
+            # Bucket on the verdict, not on its explanation: every revert now carries
+            # the reason it was rejected, and counting those separately would turn the
+            # summary into one line per file.
+            counts[verdict.split(":")[0]] += 1
             if verdict.startswith("reverted"):
-                print(f"  {verdict}: {rel}")
+                print(f"  {rel}: {verdict}")
     print()
     for k, v in counts.most_common():
         print(f"  {v:5d}  {k}")

--- a/tools/reconcile_names.py
+++ b/tools/reconcile_names.py
@@ -36,9 +36,7 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import srcpath as SP  # noqa: E402
-import match as M           # noqa: E402
-import modules as MOD       # noqa: E402
-from rombuild import VERSION as BUILD_VERSION  # noqa: E402
+import build_pin as BP      # noqa: E402
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 SRC = REPO / "src"
@@ -83,7 +81,6 @@ def main():
     args = ap.parse_args()
 
     info = symbol_info()
-    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
 
     jobs = []
     skipped = collections.Counter()
@@ -121,30 +118,16 @@ def main():
         original = f.read_text(encoding="utf-8", errors="ignore")
         new = rewrite(original, emits, symbol)
         f.write_text(new, encoding="utf-8", newline="\n")
-        flags = M.DEFAULT_FLAGS
-        if new.startswith("//cpp"):
-            flags = flags.replace("-lang c99", "-lang c++")
-        tgt = (M.target_bytes(addr, size) if label == "arm9"
-               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"])
-               if label in mods else None)
-        verdict = "no module binary"
-        if tgt is not None:
-            # Build default first, so the reported version tells you whether the file
-            # needs a config/rombuild-versions.txt override, not just sweep order.
-            for v in [BUILD_VERSION] + [x for x in M.SWEEP if x != BUILD_VERSION]:
-                obj = M.compile_c(f, v, flags)
-                if obj is None:
-                    continue
-                code, relocs = M.extract_func(obj, symbol)
-                if code is None:
-                    continue
-                ok, _ = M.compare(tgt, code, relocs, verbose=False)
-                if ok:
-                    verdict = v
-                    break
-            else:
-                verdict = "no version matches"
-        if verdict.startswith("no ") or not args.apply:
+        # Verified under the compiler the ROM build will use for THIS file, and no
+        # other. The loop this replaces tried the build default first and then the rest
+        # of match.SWEEP, and kept the rename on whichever version happened to answer --
+        # so a file that only reproduced under, say, 1.2/sp4 was applied and reported as
+        # verified while the link would emit different bytes for it. Reporting which
+        # version won does not make that safe: the rename is already on disk by then.
+        # See tools/build_pin.py.
+        ok, why = BP.verify(f, symbol, addr, size, label)
+        verdict = BP.version_for(f, symbol) if ok else f"no match: {why}"
+        if not ok or not args.apply:
             f.write_text(original, encoding="utf-8", newline="\n")
         return f.name, symbol, emits, verdict
 

--- a/tools/resolve_blind.py
+++ b/tools/resolve_blind.py
@@ -20,7 +20,9 @@ Where a canonical symbol exists, the reference is renamed in `src/`. Where the a
 no symbol at all, nothing is renamed and the address is reported — those need a name added
 to `symbols.txt`, which is a config decision rather than a source fix.
 
-Every edit is byte-verified against the ROM before it is kept.
+Every edit is byte-verified against the ROM before it is kept, under the one compiler
+`tools/rombuild.py` will build that file with -- not a sweep of every installed mwccarm,
+which passes files the link then gets wrong (see tools/build_pin.py).
 
 Usage:
     python tools/resolve_blind.py                  # report only
@@ -36,6 +38,7 @@ import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import build_pin as BP         # noqa: E402
 import match as M              # noqa: E402
 import modules as MOD          # noqa: E402
 import reloc_audit as RA       # noqa: E402
@@ -206,28 +209,20 @@ def main():
         if new == original:
             return rel, "unchanged"
         f.write_text(new, encoding="utf-8", newline="\n")
-        flags = CFLAGS
-        if new.startswith("//cpp"):
-            flags = flags.replace("-lang c99", "-lang c++")
         info = next(((a, s) for (d, n, r, a, s, _sec) in cands if r == rel), None)
-        ok = False
-        if info:
-            addr, size = info
-            tgt = (M.target_bytes(addr, size) if label == "arm9"
-                   else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
-            for v in [vers.get(name, VERSION)] + [x for x in M.SWEEP]:
-                o = M.compile_c(f, v, flags)
-                if o is None:
-                    continue
-                code, rl = M.extract_func(o, name)
-                if code is None:
-                    continue
-                ok, _ = M.compare(tgt, code, rl, verbose=False)
-                if ok:
-                    break
+        if info is None:
+            f.write_text(original, encoding="utf-8", newline="\n")
+            return rel, "reverted (not a candidate; there is nothing to verify against)"
+        addr, size = info
+        # The build's compiler ONLY. This started at the pinned version and then fell
+        # through the whole of match.SWEEP, so a rename that stopped reproducing under
+        # the version the link actually uses was still kept whenever any of the other
+        # installed mwccarm builds reproduced it -- a pass the ROM build cannot honour.
+        # See tools/build_pin.py.
+        ok, why = BP.verify(f, name, addr, size, label)
         if not ok:
             f.write_text(original, encoding="utf-8", newline="\n")
-            return rel, "reverted (stopped matching)"
+            return rel, f"reverted ({why})"
         return rel, "renamed"
 
     outcome = collections.Counter()

--- a/tools/resolve_placeholders.py
+++ b/tools/resolve_placeholders.py
@@ -31,7 +31,9 @@ and where dsd itself could not decide it says so -- `module:overlays(2,9,14)` --
 and those are reported rather than guessed at.
 
 Nothing is rewritten unless every placeholder in the file resolves to exactly one
-symbol, and every rewritten file is byte-verified and reverted on failure.
+symbol, and every rewritten file is verified and reverted on failure -- against the
+one compiler `tools/rombuild.py` will build it with, never against a sweep of every
+installed version. See tools/build_pin.py for why the difference is the whole game.
 
 Usage:
     python tools/resolve_placeholders.py                 # report only
@@ -52,9 +54,9 @@ from elftools.elf.elffile import ELFFile
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 
+import build_pin as BP     # noqa: E402
 import match as M          # noqa: E402
 import eligible as E       # noqa: E402
-import modules as MOD      # noqa: E402
 from enroll import candidates  # noqa: E402
 
 ELIGIBILITY = REPO / "build" / "rombuild-eligibility.json"
@@ -246,7 +248,6 @@ def main():
     info = {}
     for (d, name, rel, addr, size, sec) in candidates()[0]:
         info[rel.replace("\\", "/")] = (name, addr, size, d)
-    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
 
     strict = None
     try:
@@ -271,36 +272,21 @@ def main():
     print(f"  of those, blocked ONLY by placeholders: "
           f"{sum(1 for _, _, o in jobs if not o)}")
 
-    def verify(f, name, addr, size, label, flags):
-        """Bytes AND relocation destinations.
+    def verify(f, name, addr, size, label):
+        """Bytes AND relocation destinations, under the compiler the BUILD will use.
 
-        A byte compare cannot check this change: `match.py` treats every relocated
-        word as a wildcard, so the one thing a rename alters is the one thing it
-        cannot see. Byte-only agreement here means "still compiles to the same
-        shape", never "now calls the right function". `reloc_audit` is what actually
-        looks at the destination, so a rename is only verified if it passes too."""
-        tgt = (M.target_bytes(addr, size) if label == "arm9"
-               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
-        for v in M.SWEEP:
-            o = M.compile_c(f, v, flags)
-            if o is None:
-                continue
-            code, rr = M.extract_func(o, name)
-            if code is None or not M.compare(tgt, code, rr, verbose=False)[0]:
-                continue
-            if strict is None:
-                return True          # no config data here; byte-only, and said so
-            RA, name_index, config_relocs, sym_index = strict
-            try:
-                rows, _ = RA.check_destinations(o, name, addr, size, label,
-                                                name_index, config_relocs, sym_index)
-            except Exception:
-                rows = None
-            # A check that could not run is not a pass. Treat it like a failure so a
-            # broken lookup can never launder itself into a verified rename.
-            if rows is not None and not [r for r in rows if r["verdict"] == "WRONG-DEST"]:
-                return True
-        return False
+        A byte compare cannot check this change on its own: `match.py` treats every
+        relocated word as a wildcard, so the one thing a rename alters is the one
+        thing it cannot see. Byte-only agreement here means "still compiles to the
+        same shape", never "now calls the right function". `reloc_audit` is what
+        actually looks at the destination, so a rename is only verified if it passes
+        too -- `build_pin.verify` requires both.
+
+        Pinned, not swept. This used to accept a match under ANY member of
+        `match.SWEEP`, while `rombuild.py` compiles the file with exactly one
+        version, so a rewrite could be blessed under a compiler the build will never
+        run and then link the wrong bytes. See tools/build_pin.py."""
+        return BP.verify(f, name, addr, size, label, strict=strict)
 
     def one(job):
         rel, ph, others = job
@@ -310,14 +296,18 @@ def main():
         label = "arm9" if label == "arm9" else label.split("/")[-1]
         original_bytes = f.read_bytes()
         original = original_bytes.decode("utf-8", "surrogateescape")
-        flags = M.DEFAULT_FLAGS
-        if f.suffix == ".cpp" or original.startswith("//cpp"):
-            flags = flags.replace("-lang c99", "-lang c++")
 
-        obj = next((o for o in (M.compile_c(f, v, flags) for v in M.SWEEP)
-                    if o is not None), None)
+        # The build's compiler, not the first sweep member that happens to compile.
+        # This object is not just a compile check: its relocation OFFSETS are added to
+        # the function's address to look the destination up in relocs.txt, so reading
+        # them out of a different compiler's codegen resolves the placeholder against
+        # whatever the ROM has at some other offset.
+        version, why = BP.compiler_for(f, name)
+        if version is None:
+            return rel, f"unverifiable: {why}", {}
+        obj = M.compile_c(f, version, BP.flags_for(f, original))
         if obj is None:
-            return rel, "compile failed", {}
+            return rel, f"compile failed under the build's compiler ({version})", {}
         rl = relocs_for(obj, name)
         if rl is None:
             return rel, "function not in object", {}
@@ -401,12 +391,14 @@ def main():
         # Whether a resolved name needs declaring depends on which headers *this*
         # file includes, which is not worth modelling -- the compiler already knows.
         # Try it declared and undeclared, and keep whichever byte-matches.
+        why = "no candidate produced"
         for cand in (with_decls(renamed, needed), renamed):
             f.write_text(cand, encoding="utf-8", newline="\n")
-            if verify(f, name, addr, size, label, flags):
+            ok, why = verify(f, name, addr, size, label)
+            if ok:
                 return rel, "rewritten", mapping
         f.write_text(original, encoding="utf-8", newline="\n")
-        return rel, "reverted (stopped matching)", mapping
+        return rel, f"reverted: {why}", mapping
 
     if args.limit:
         jobs = jobs[:args.limit]

--- a/tools/test_build_pin.py
+++ b/tools/test_build_pin.py
@@ -1,0 +1,238 @@
+"""A per-file verifier must ask the question the ROM build will ask.
+
+`tools/match.py` sweeps 25 installed mwccarm builds and calls a function matched when
+any one of them reproduces it. `tools/rombuild.py` compiles each file with exactly one
+-- `rombuild.VERSION`, or the `config/rombuild-versions.txt` override for that file. The
+tools that REWRITE source and keep the rewrite on a byte check used the first rule while
+the build uses the second, so an edit could be verified under a compiler the link never
+runs, and the build then rejected what the gate had passed.
+
+Most of this needs neither a compiler nor an extracted ROM: the pin rules, the
+fail-closed paths and the source-level guard are all static. The two end-to-end cases
+skip themselves when the toolchain is not installed.
+"""
+import pathlib
+import sys
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+REPO = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import build_pin as BP     # noqa: E402
+import match as M          # noqa: E402
+import rombuild as RB      # noqa: E402
+
+# The tools that rewrite a source file and keep the rewrite when a check passes. These
+# are the ones where "any version in the sweep" is a false green rather than a report.
+VERIFY_AND_KEEP = ["resolve_placeholders.py", "extern_c_wrap.py", "resolve_blind.py",
+                   "reconcile_names.py", "demember_calls.py"]
+
+
+def _toolchain():
+    return (M.MW / BP.DEFAULT_VERSION / "mwccarm.exe").is_file() and M.ARM9.is_file()
+
+
+# --------------------------------------------------------------------------- pin rules
+
+def test_default_is_the_build_default_not_the_sweep():
+    assert BP.DEFAULT_VERSION == RB.VERSION
+    assert len(M.SWEEP) > 1, "a one-version sweep would make this whole file vacuous"
+
+
+def test_version_for_reproduces_rombuild_lookup_for_every_enrolled_file():
+    """The property that matters, checked against the real tree rather than a fixture.
+
+    `rombuild.compile_one` picks `vers.get(Path(rel).stem, VERSION)`. Anything else the
+    verifier does is a divergence, and a divergence is exactly the bug."""
+    vers = RB.versions()
+    for rel in RB.enrolled():
+        expected = vers.get(pathlib.Path(rel).stem, RB.VERSION)
+        assert BP.version_for(rel) == expected, rel
+
+
+def test_the_overrides_are_actually_exercised():
+    """Guards the test above from passing because every file takes the default."""
+    overrides = RB.versions()
+    assert overrides, "config/rombuild-versions.txt has no entries; nothing pins anything"
+    assert any(v != RB.VERSION for v in overrides.values())
+    for stem, v in overrides.items():
+        assert BP.version_for(f"src/{stem}.cpp") == v
+
+
+def test_missing_overrides_file_fails_closed(monkeypatch=None):
+    """An unreadable pin is UNKNOWN, not "the default". Falling back would verify the
+    eight override files against a compiler the build will not use for them."""
+    saved_file, saved_cache = BP.VERSIONS_FILE, BP._pins
+    try:
+        BP.VERSIONS_FILE = REPO / "config" / "no-such-versions-file.txt"
+        BP._pins = None
+        assert BP.pins() is None
+        assert BP.version_for("src/func_02062428.c") is None
+        v, why = BP.compiler_for("src/func_02062428.c")
+        assert v is None and "missing" in why
+    finally:
+        BP.VERSIONS_FILE, BP._pins = saved_file, saved_cache
+
+
+def test_override_recorded_under_a_symbol_the_build_cannot_see_fails_closed():
+    """The build looks the FILE STEM up. An override keyed on a symbol whose file is
+    named something else is an override the build silently ignores, so the pin is
+    inconsistent and there is no safe answer -- report it instead of picking a side."""
+    saved = BP._pins
+    try:
+        BP._pins = {"some_other_stem": "1.2/base", "SomeClass__method": "1.2/sp2"}
+        assert BP.version_for("src/renamed.cpp", "SomeClass__method") is None
+        v, why = BP.compiler_for("src/renamed.cpp", "SomeClass__method")
+        assert v is None and "file stem" in why
+        # ... and the ordinary case still answers.
+        assert BP.version_for("src/some_other_stem.c") == "1.2/base"
+    finally:
+        BP._pins = saved
+
+
+def test_uninstalled_pinned_compiler_fails_closed():
+    saved = BP._pins
+    try:
+        BP._pins = {"ghost": "9.9/not-a-build"}
+        v, why = BP.compiler_for("src/ghost.c")
+        assert v is None and "not installed" in why
+    finally:
+        BP._pins = saved
+
+
+# ------------------------------------------------------------------------------ flags
+
+def test_flags_are_the_builds_flags():
+    """`match.DEFAULT_FLAGS` is not the build's flag set -- it lacks `-Cpp_exceptions
+    off`. Checking with different flags than the link compiles with can bless a version
+    the build then breaks on, the same defect by another route."""
+    assert BP.flags_for("x.c", "int f(void);") == RB.CFLAGS
+    assert BP.flags_for("x.cpp", "//cpp\n") == RB.CFLAGS.replace("-lang c99", "-lang c++")
+    # The marker decides, not the extension -- because that is what rombuild does.
+    assert BP.flags_for("x.c", "//cpp\n") == RB.CFLAGS.replace("-lang c99", "-lang c++")
+    assert "-Cpp_exceptions off" in BP.flags_for("x.c", "")
+
+
+# ---------------------------------------------------------------- reloc-destination gate
+
+class _StubAudit:
+    def __init__(self, rows, exc=None):
+        self.rows, self.exc = rows, exc
+
+    def check_destinations(self, *a, **k):
+        if self.exc:
+            raise self.exc
+        return self.rows, 0
+
+
+def _strict(rows=None, exc=None):
+    return (_StubAudit(rows, exc), None, None, None)
+
+
+def test_bytes_matching_is_not_a_pass_when_a_relocation_points_elsewhere():
+    """The observed failure, in miniature. `match.compare` treats every relocated word
+    as a wildcard, so a call to the wrong function compares clean; only the link sees
+    it. src/func_ov006_020cb030.cpp passed a byte-only check, was enrolled, and the ROM
+    build reported ov006 mismatching at a `bl` going to func_ov006_020c9024 where the
+    ROM's relocation records 0x020cb134."""
+    if not _toolchain():
+        return
+    rel = "src/func_ov006_020cb030.cpp"
+    name, addr, size, label = "func_ov006_020cb030", 0x020cb030, 0x104, "ov006"
+    ok, _ = BP.verify(REPO / rel, name, addr, size, label)
+    assert ok, "precondition: this file's BYTES reproduce under the pinned compiler"
+    bad = [{"verdict": "WRONG-DEST", "off": "+0x58", "cand": "func_ov006_020c9024",
+            "cand_addr": "0x020c9024", "cfg": "0x020cb134:ov006"}]
+    ok, why = BP.verify(REPO / rel, name, addr, size, label, strict=_strict(bad))
+    assert not ok and "reloc destination" in why
+
+
+def test_a_destination_check_that_could_not_run_is_not_a_pass():
+    if not _toolchain():
+        return
+    rel = "src/func_ov006_020cb030.cpp"
+    args = ("func_ov006_020cb030", 0x020cb030, 0x104, "ov006")
+    for strict in (_strict(None), _strict(exc=RuntimeError("index unavailable"))):
+        ok, why = BP.verify(REPO / rel, *args, strict=strict)
+        assert not ok and "could not run" in why
+
+
+# --------------------------------------------------------------- the pin is load-bearing
+
+def test_the_pinned_version_is_not_interchangeable_with_the_sweep():
+    """Every file in config/rombuild-versions.txt is there BECAUSE the build default
+    gets it wrong. So for each of them the pin must pass and the default must fail --
+    which is precisely the gap a sweep-based check papers over, using committed data
+    rather than a bug that someone may later fix."""
+    if not _toolchain():
+        return
+    import rombuild_versions as RV
+    info = RV.symbol_info()
+    checked = 0
+    for stem, pinned in RB.versions().items():
+        if pinned == RB.VERSION or stem not in info:
+            continue
+        label, addr, size = info[stem]
+        src = next((REPO / f"src/{stem}{e}" for e in (".c", ".cpp")
+                    if (REPO / f"src/{stem}{e}").is_file()), None)
+        if src is None or BP.target_bytes(label, addr, size) is None:
+            continue
+        ok, why = BP.verify(src, stem, addr, size, label)
+        assert ok, f"{stem} should reproduce under its pin {pinned}: {why}"
+        ok, _ = BP.verify(src, stem, addr, size, label, version=RB.VERSION)
+        assert not ok, (f"{stem} reproduces under {RB.VERSION} too, so it does not "
+                        f"belong in config/rombuild-versions.txt")
+        # And the old rule would have said yes on the strength of the pinned build
+        # alone -- that is the false green, restated.
+        assert BP.sweep_version(src, stem, addr, size, label) is not None
+        checked += 1
+    assert checked, "no override was exercisable; this test proved nothing"
+
+
+# ------------------------------------------------------------------- keep it from coming back
+
+def _reads_the_sweep(path):
+    """Does this module actually EVALUATE match.SWEEP? Parsed, not grepped -- every one
+    of these files now explains the defect in prose, and a substring search cannot tell
+    an explanation from a relapse."""
+    import ast
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return any(isinstance(n, ast.Attribute) and n.attr == "SWEEP"
+               and isinstance(n.value, ast.Name) and n.value.id in ("M", "match")
+               for n in ast.walk(tree))
+
+
+def test_no_verify_and_keep_tool_accepts_a_sweep_again():
+    """A source-level guard, because the defect is a shape: a loop over match.SWEEP
+    around a compare whose success keeps an edit on disk. Nothing in the runtime
+    behaviour of these tools makes that impossible to reintroduce."""
+    for tool in VERIFY_AND_KEEP:
+        p = TOOLS / tool
+        if not p.is_file():
+            continue          # demember_calls.py has not landed everywhere yet
+        assert not _reads_the_sweep(p), (
+            f"{tool} verifies against the sweep again; the ROM build compiles each "
+            f"file with one version (see tools/build_pin.py)")
+        assert "build_pin" in p.read_text(encoding="utf-8"), \
+            f"{tool} should verify through tools/build_pin.py"
+
+
+def test_build_pin_itself_is_allowed_to_name_the_sweep():
+    """Guards the guard: build_pin.sweep_version deliberately implements the old rule so
+    the audit can measure the difference. If that disappeared, the test above would go
+    green by accident rather than by construction."""
+    assert _reads_the_sweep(TOOLS / "build_pin.py")
+
+
+if __name__ == "__main__":
+    fails = 0
+    for nm, fn in sorted(globals().items()):
+        if nm.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  PASS  {nm}")
+            except AssertionError as e:
+                fails += 1
+                print(f"  FAIL  {nm}: {e}")
+    print(f"\n{fails} failure(s)")
+    sys.exit(1 if fails else 0)


### PR DESCRIPTION
Two false-green gaps in the per-file verification path. The second one is what actually broke a build today, and it isn't the one I went looking for.

## Gap 1 — sweep vs pinned

`match.SWEEP` is 25 installed mwccarm builds, and a function counts as matched when **any** of them reproduces it. `rombuild.compile_one` uses exactly one: `rombuild.VERSION` (`2004/b56`) or the per-file override in `config/rombuild-versions.txt`, keyed **by file stem, not symbol**. Five rewrite tools verified against the sweep, so a file could "verify" under a compiler the build will never use. They also compiled with `match.DEFAULT_FLAGS`, which lacks the build's `-Cpp_exceptions off`.

## Gap 2 — no reloc-destination check

`demember_calls.py` and `extern_c_wrap.py` had none. `match.compare` wildcards every relocated word, so a byte-only check is **blind by construction to the one thing a name-rewriting tool changes**.

This was the real cause of `func_ov006_020cb030` passing per-file and then failing the ROM build by three bytes — one word, a `bl` at `0x020cb088` targeting `func_ov006_020c9024` where the ROM's relocation records `0x020cb134`. That turned out to be a genuine pre-existing wrong callee, fixed separately in #1079.

## What changed

**`tools/build_pin.py`** — one answer to *"what will the build do with this file"*: `version_for` (mirrors `compile_one`'s stem lookup), `flags_for` (build CFLAGS, `//cpp` marker only), `verify` (pinned compile + byte compare + destination check). It **fails closed** on unknown pin, missing overrides file, an override keyed on a symbol the build ignores, uninstalled compiler, compile error, missing symbol, or a destination check that couldn't run.

Converted: `resolve_placeholders.py`, `extern_c_wrap.py`, `resolve_blind.py` (had `[pin] + SWEEP` — pinned first, then fell through all 25), `reconcile_names.py`, `demember_calls.py`. The two tools that read relocation *offsets* now take them from the build's compiler too, since a differently-scheduled function resolves against the wrong ROM word. `extern_c_wrap` and `demember_calls` gained the destination check.

## Proof

```
reverted: bytes match under 2004/b56 but 1 reloc destination(s) are wrong
          (first: func_ov006_020c9024 != 0x020cb134:ov006)   src/func_ov006_020cb030.cpp
```

Before: `transformed`, kept. The reason names the exact word the ROM build reported.

## Size of the problem

`python tools/build_pin.py --audit` over all 11,113 candidates: **79 sweep-only false greens**, every one reproducing solely under `1.2/base`. None is enrolled — `eligible.py` was rejecting all 79 on section size — which is why the ROM build stayed green. The fix aligns the verifiers with a gate that was already right; had any been enrolled they'd have failed like the ov006 case.

`tools/test_build_pin.py` — 12 tests. Includes an **AST guard** so no verify-and-keep tool can reach for `match.SWEEP` again, and a test proving the pin is load-bearing from committed data alone: every `config/rombuild-versions.txt` entry must pass under its pin and *fail* under the build default.

Rebased onto main after #1078 landed; the add/add on `tools/demember_calls.py` resolved in favour of this branch's pinned-verify copy. `python tools/rombuild.py` on an unmodified tree: `module fidelity: 106/106 exact` / `PASS`, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi