### PR TITLE
Gate unbannered asm transcriptions out of every count, and fail them in PR validation

### DIFF
--- a/src/ARMProcessorMode.c
+++ b/src/ARMProcessorMode.c
@@ -1,1 +1,5 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CPSR read), so there is no C to decompile it to -- the asm
+// block is the faithful source. Counts as matched (asm-primitive policy), not a
+// C transcription.
 asm void ARMProcessorMode(void) { mrs r0, cpsr; and r0, r0, #0x1f; bx lr }

--- a/src/DecompressLZ16.c
+++ b/src/DecompressLZ16.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK LZ decompressor), so there is no C to decompile it to --
+// the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 asm void DecompressLZ16(void *src, void *dst)
 {
 	stmfd	sp!, {r4,r5,r6,r7,r8,r9,r10,lr}

--- a/src/_ZN4CP1510DisableMPUEv.c
+++ b/src/_ZN4CP1510DisableMPUEv.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU coprocessor op), so there is no C to decompile it
+// to -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 unsigned int _ZN4CP1510DisableMPUEv(void){
     unsigned int v;
     asm { mrc p15,0,v,c1,c0,0 }

--- a/src/_ZN4CP1510EnableDTCMEv.c
+++ b/src/_ZN4CP1510EnableDTCMEv.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU coprocessor op), so there is no C to decompile it
+// to -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 unsigned int _ZN4CP1510EnableDTCMEv(void){
     unsigned int v;
     asm { mrc p15,0,v,c1,c0,0 }

--- a/src/_ZN4CP1514MPUDataRegion1Ej.c
+++ b/src/_ZN4CP1514MPUDataRegion1Ej.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU coprocessor op), so there is no C to decompile it
+// to -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 void _ZN4CP1514MPUDataRegion1Ej(unsigned int x){
     asm { mcr p15,0,x,c6,c1,0 }
 }

--- a/src/_ZN4CP1514MPUDataRegion7Ej.c
+++ b/src/_ZN4CP1514MPUDataRegion7Ej.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU coprocessor op), so there is no C to decompile it
+// to -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 void _ZN4CP1514MPUDataRegion7Ej(unsigned int x){
     asm { mcr p15,0,x,c6,c7,0 }
 }

--- a/src/_ZN4CP1516WaitForInterruptEv.c
+++ b/src/_ZN4CP1516WaitForInterruptEv.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU coprocessor op), so there is no C to decompile it
+// to -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 void _ZN4CP1516WaitForInterruptEv(void){
     unsigned int v = 0;
     asm { mcr p15,0,v,c7,c0,4 }

--- a/src/_ZN4CP1517MPUGetDataRegion7Ev.c
+++ b/src/_ZN4CP1517MPUGetDataRegion7Ev.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU coprocessor op), so there is no C to decompile it
+// to -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 unsigned int _ZN4CP1517MPUGetDataRegion7Ev(void){
     unsigned int v;
     asm { mrc p15,0,v,c6,c7,0 }

--- a/src/_ZN4CP159EnableMPUEv.c
+++ b/src/_ZN4CP159EnableMPUEv.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU coprocessor op), so there is no C to decompile it
+// to -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 unsigned int _ZN4CP159EnableMPUEv(void){
     unsigned int v;
     asm { mrc p15,0,v,c1,c0,0 }

--- a/src/_ZN4cstd14__builtin_trapEv.c
+++ b/src/_ZN4cstd14__builtin_trapEv.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (compiler trap builtin), so there is no C to decompile it to
+// -- the asm block is the faithful source. Counts as matched (asm-primitive
+// policy), not a C transcription.
 void _ZN4cstd14__builtin_trapEv(void){
   asm { dcd 0xe7ffffff }
 }

--- a/tools/asm_policy.py
+++ b/tools/asm_policy.py
@@ -1,0 +1,92 @@
+"""One shared answer to "is this source file an asm transcription?".
+
+Tree policy (notes/asm-policy.md): an asm body in src/ is legitimate only under an
+explicit banner. ``HAND-ASM PRIMITIVE`` says the ORIGINAL was assembly -- a BIOS
+call, coprocessor op, context switch, or SDK primitive that C cannot express -- so
+the asm block is the faithful source and counts as matched. ``NONMATCHING`` says
+the file is a declared draft and does not count. Everything else claiming to be a
+match must be real C.
+
+The failure mode this module exists to catch is the VACUOUS match. mwccarm's
+``dcd 0x...`` directive emits the literal word you type, so a whole-function dcd
+dump assembles to the ROM bytes by definition: the "match" proves only that the
+author copied the disassembly, and counting it puts a lie in the progress bar.
+PR #1072 landed 8 such files as +8 matched functions / +8,208 bytes / contributor
+credit. The byte gate cannot catch these -- byte equality is exactly what they
+game -- so this textual gate is the honesty mechanism.
+
+``classify`` deliberately draws two tiers:
+
+  "transcribed"     -- the file contains ``dcd 0x`` words and NO banner. Demoted
+                       from matched everywhere, and a PR adding or touching one
+                       hard-fails validation. There is no legitimate reason for an
+                       unbannered dcd blob: a hand-asm primitive gets the HAND-ASM
+                       banner, a draft gets NONMATCHING.
+  "unbannered-asm"  -- the file has an asm body (mnemonics, no dcd) and no banner.
+                       WARN only: real C with an embedded asm hatch (CP15
+                       intrinsics inside a C function, e.g.
+                       src/_ZN6Player13InitResourcesEv.cpp) lives in this gray
+                       zone, so demoting it wholesale would rescind legitimate
+                       matches. These are surfaced for a human to banner or
+                       reclassify deliberately.
+  None              -- bannered, or no asm at all.
+
+The banner search runs over the WHOLE file, never a head window: a banner is only
+ever exculpatory here, so a deep mention can excuse a file but can never flip a
+real C match into a fake one.
+
+The asm detection is lifted from tools/dataset/eval_match.py's passthrough
+detector (the training-side guard against the same reward hack) rather than
+invented fresh, so the two gates agree on what "asm" looks like.
+"""
+import re
+
+HAND_BANNER = "HAND-ASM PRIMITIVE"
+DRAFT_BANNER = "NONMATCHING"
+
+# A dcd word is raw ROM data re-spelled; one is enough to make the file suspect.
+_DCD_RE = re.compile(r"\bdcd\s+0x[0-9a-fA-F]")
+
+# High-precision ARM assembly "tells" that essentially never appear in real decompiled C.
+# A passthrough carries dozens; real C carries ~0. Used as a keyword-independent backstop so
+# an asm transcription is caught even if it isn't wrapped in a form the `asm` keyword regex
+# sees. (Lifted from tools/dataset/eval_match.py.)
+_ARM_TELLS = re.compile(r"""
+      \bstm(?:db|ia|fd|ea)\b | \bldm(?:db|ia|fd|ea|ib)\b     # block load/store multiple
+    | \bbx\s+lr\b | \bblx\b | \bbl\s+\w                        # branch-exchange / branch-link
+    | \bsp!                    | \[pc,        | \[sp,          # ARM addressing idioms
+    | \bdcd\b | \bdcw\b                                        # inline data words
+    | \{\s*(?:r\d|lr|sp|pc)                                    # register list  {r4, lr}
+    | \b(?:ldr|str|ldrh|strh|ldrb|strb|mov|cmp|orr|eor|lsl|lsr|asr|msr|mrs)\s+r\d  # op + reg
+    | \bldmia\b | \bstmia\b
+""", re.X)
+
+
+def is_asm_passthrough(code):
+    """True if ``code`` carries an asm body rather than (only) real C.
+
+    Two independent detectors so a novel form can't slip through:
+      1. the `asm` KEYWORD -- mwccarm naked function ``asm <type> name(...) {``,
+         GCC ``asm {`` / ``asm volatile``, or ``__asm``;
+      2. CONTENT -- >=3 ARM-mnemonic tells, which real C never has, catching asm
+         even if it isn't wrapped in a keyword form the regex above recognizes."""
+    if "__asm" in code:
+        return True
+    for m in re.finditer(r"(?<![\w])asm(?![\w])", code):          # `asm` as a standalone token
+        tail = code[m.end():m.end() + 120]
+        # followed by `volatile`, an opening `{`, or a `(...)  {` function signature
+        if re.match(r"\s*(volatile\b|\{|[\w:*&<>\[\], \n]*\([^;{]*\)\s*\{)", tail):
+            return True
+    return len(_ARM_TELLS.findall(code)) >= 3                     # content backstop
+
+
+def classify(text):
+    """"transcribed" (unbannered dcd blob: demote + fail), "unbannered-asm"
+    (asm body, no banner, no dcd: warn only), or None (bannered or no asm)."""
+    if HAND_BANNER in text or DRAFT_BANNER in text:
+        return None
+    if _DCD_RE.search(text):
+        return "transcribed"
+    if is_asm_passthrough(text):
+        return "unbannered-asm"
+    return None

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -31,6 +31,7 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG = REPO / "config"
 SRC = REPO / "src"
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy  # noqa: E402
 import srcpath as SP  # noqa: E402
 import relocs as RL  # noqa: E402
 
@@ -82,6 +83,16 @@ def no_match_needed(head: str) -> dict[str, str] | None:
         return None
     bucket, reason = NOMATCH_REASONS[m.group(1)]
     return {"bucket": bucket, "reason": reason}
+
+
+# An asm-bodied file is countable only under an explicit banner: HAND-ASM PRIMITIVE
+# (policy-matched -- the original really was assembly) or NONMATCHING (draft / hatch).
+# A dcd blob with neither is a transcription: it byte-matches vacuously because it IS
+# the ROM words re-spelled, so counting it as matched puts a lie in the progress bar
+# (PR #1072 landed 8 of these as +8 matches / +8,208 bytes / credit). "transcribed"
+# is demoted from matched; mnemonic asm without a banner is a policy gray zone
+# (embedded hatches inside real C, e.g. CP15 intrinsics) and is only WARNED about.
+# The detector is asm_policy.classify, shared with validate_merge and pr_linkcheck.
 
 
 def _handle_from(name: str, email: str) -> str:
@@ -339,6 +350,8 @@ def main():
     ap.add_argument("--out", default="chaos-db.json")
     ap.add_argument("--contrib-out", default=None,
                     help="path for contributions.json (default: next to --out)")
+    ap.add_argument("--fail-on-transcribed", action="store_true",
+                    help="exit 1 if any unbannered dcd transcription is in the tree")
     args = ap.parse_args()
 
     nm = {}
@@ -362,6 +375,7 @@ def main():
 
     functions = []
     total_b = matched_b = matched_n = 0
+    transcribed_files, unbannered_files = set(), set()
     # Every module, itcm included. relocs.module_universe is the one definition of
     # what "every module" means, and it fails loudly rather than skipping a new one.
     for sym, label in RL.module_universe():
@@ -372,13 +386,20 @@ def main():
             name, size, addr = m.group(1), int(m.group(2), 16), int(m.group(3), 16)
             f = SP.path_for(name)
             src_path = f.relative_to(REPO).as_posix() if f else None
-            head = f.read_text(errors="ignore")[:200] if f else ""
-            matched = bool(src_path) and "NONMATCHING" not in head
+            text = f.read_text(errors="ignore") if f else ""
+            head = text[:200]
+            cls = asm_policy.classify(text) if src_path else None
+            matched = bool(src_path) and "NONMATCHING" not in head and cls != "transcribed"
             total_b += size
             rec = {"id": f"{label}:0x{addr:08x}", "module": label, "name": name,
                    "addr": addr, "size": size, "matched": matched}
             if src_path:
                 rec["srcPath"] = src_path
+                if cls == "transcribed":
+                    rec["transcribed"] = True
+                    transcribed_files.add(src_path)
+                elif cls == "unbannered-asm":
+                    unbannered_files.add(src_path)
                 nomatch = no_match_needed(head)
                 if nomatch:
                     rec["noMatch"] = nomatch
@@ -397,6 +418,18 @@ def main():
                 if r and r.get("divergences") is not None:
                     rec["div"] = r["divergences"]
             functions.append(rec)
+
+    if transcribed_files:
+        print(f"TRANSCRIBED: {len(transcribed_files)} unbannered dcd transcription(s) "
+              f"-- NOT counted as matched:")
+        for p in sorted(transcribed_files):
+            print(f"  {p}")
+    if unbannered_files:
+        print(f"unbannered-asm: {len(unbannered_files)} asm-bodied file(s) with no "
+              f"HAND-ASM PRIMITIVE or NONMATCHING banner -- policy review needed "
+              f"(banner or reclassify):")
+        for p in sorted(unbannered_files):
+            print(f"  {p}")
 
     project = None
     pc = REPO / "tools" / "chaosviewer.config.json"
@@ -457,6 +490,11 @@ def main():
     cpath.write_text(json.dumps(contrib, indent=1), encoding="utf-8")
     print(f"wrote {cpath}: {len(tally)} contributors "
           f"(top: {', '.join(f'{w}={n}' for w, n in tally.most_common(4))})")
+
+    if args.fail_on_transcribed and transcribed_files:
+        print(f"FAILED: {len(transcribed_files)} unbannered dcd transcription(s) in the "
+              f"tree (see the TRANSCRIBED list above)")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -46,6 +46,7 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import affected_src as A  # noqa: E402
+import asm_policy as AP  # noqa: E402
 import linkcheck as LC  # noqa: E402
 
 SRC_SUFFIXES = (".c", ".cpp")
@@ -305,8 +306,11 @@ def main():
     # A PR "passes" only when every changed file reproduces the ROM with correct
     # relocation targets (VERIFIED/BENIGN, or BLIND where a slot is unverifiable).
     # WRONG-DEST *and* a non-reproducing NO-REPRO near-miss are both failures — a
-    # near-miss is not a match and must not land.
-    FAIL = {"WRONG", "NO-REPRO"}
+    # near-miss is not a match and must not land. RAW-ASM is the third failure: an
+    # unbannered dcd transcription byte-matches vacuously (the dcd words ARE the
+    # ROM bytes re-spelled), so its VERIFIED slots prove nothing and the file is
+    # rejected on policy — see notes/asm-policy.md and tools/asm_policy.py.
+    FAIL = {"WRONG", "NO-REPRO", "RAW-ASM"}
     reports, bad = [], []
     for path, rep in zip(files, checked):
         reports.append(rep)
@@ -322,19 +326,22 @@ def main():
         # stop files that CLAIM to be matches from landing red; a declared draft cannot
         # inflate any count. WRONG (a resolvable reloc pointing at the wrong symbol)
         # still fails -- a draft's call graph must be honest even if its bytes differ.
-        declared_draft = False
+        text = ""
         try:
-            head = pathlib.Path(path).read_text(encoding="utf-8", errors="replace")[:200]
-            declared_draft = "NONMATCHING" in head
+            text = pathlib.Path(path).read_text(encoding="utf-8", errors="replace")
         except OSError:
             pass
-        if w == "NO-REPRO" and declared_draft:
+        if w == "NO-REPRO" and "NONMATCHING" in text[:200]:
             rep["worst"] = w = "DRAFT"
+        # The draft downgrade cannot collide with this: a transcription has no banner
+        # by definition (a NONMATCHING banner reclassifies it as an honest draft).
+        if AP.classify(text) == "transcribed":
+            rep["worst"] = w = "RAW-ASM"
         if w in FAIL:
             bad.append((path, w))
         mark = {"WRONG": "WRONG  ", "NO-REPRO": "NOREPRO", "BENIGN": "ok(ben)",
-                "VERIFIED": "ok     ", "BLIND": "ok(bln)",
-                "DRAFT": "ok(drf)"}.get(w, w)
+                "VERIFIED": "ok     ", "BLIND": "ok(bln)", "DRAFT": "ok(drf)",
+                "RAW-ASM": "RAWASM "}.get(w, w)
         npass = sum(1 for r in rep["results"] if r.get("passenger"))
         extra = f", +{npass} passenger" if npass else ""
         print(f"  {mark} {path}  ({len(rep['results'])} slot(s){extra})")
@@ -354,13 +361,15 @@ def main():
 
 
 # Verdict -> a human label for the PR comment. VERIFIED/BENIGN/BLIND are passes;
-# NO-REPRO (near-miss) and WRONG-DEST are the two failures.
+# NO-REPRO (near-miss), WRONG-DEST and RAW-ASM (unbannered transcription) fail.
 _LABEL = {
     "VERIFIED":   "✅ verified",
     "BENIGN":     "✅ benign (equivalent veneer/twin)",
     "BLIND":      "🔶 blind (a reloc slot could not be resolved)",
     "NO-REPRO":   "❌ near-miss (does NOT reproduce the ROM)",
     "WRONG":      "❌ wrong-dest (reloc links to the wrong symbol)",
+    "RAW-ASM":    "🚫 raw-asm (transcription, no banner): dcd words match the ROM "
+                  "vacuously; banner it HAND-ASM PRIMITIVE or NONMATCHING",
     "NO-SYM":     "🔶 no-sym",
     "UNRESOLVED": "🔶 unresolved (symbol not in config/ledger)",
     "DRAFT":      "ok - declared draft (header says NONMATCHING; non-reproduction expected)",

--- a/tools/test_asm_policy.py
+++ b/tools/test_asm_policy.py
@@ -1,0 +1,57 @@
+"""A banner is the only thing that excuses an asm body; a dcd blob without one demotes."""
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import asm_policy  # noqa: E402
+
+DCD_DUMP = ("asm void func_ov002_020cfea4(void) {\n"
+            "    dcd 0xe92d43f0\n"
+            "    dcd 0xe12fff1e\n"
+            "}\n")
+MNEMONIC_ASM = ("asm void Copy32Bytes(void)\n"
+                "{\n"
+                "    ldmia r0!, {r2, r3, ip}\n"
+                "    stmia r1!, {r2, r3, ip}\n"
+                "    bx lr\n"
+                "}\n")
+PLAIN_C = "int Example(void) {\n    return 0;\n}\n"
+
+
+class Classify(unittest.TestCase):
+    def test_unbannered_dcd_dump_is_transcribed(self):
+        self.assertEqual(asm_policy.classify(DCD_DUMP), "transcribed")
+
+    def test_nonmatching_banner_makes_a_dcd_dump_an_honest_draft(self):
+        self.assertIsNone(asm_policy.classify("// NONMATCHING\n" + DCD_DUMP))
+
+    def test_hand_asm_banner_excuses_an_asm_body(self):
+        self.assertIsNone(asm_policy.classify(
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n" + MNEMONIC_ASM))
+
+    def test_mnemonic_asm_without_banner_is_the_warn_tier(self):
+        self.assertEqual(asm_policy.classify(MNEMONIC_ASM), "unbannered-asm")
+
+    def test_plain_c_is_none(self):
+        self.assertIsNone(asm_policy.classify(PLAIN_C))
+
+    def test_embedded_asm_hatch_in_real_c_is_warned_not_demoted(self):
+        # The gray zone: a C function with an inline asm hatch (CP15 intrinsics,
+        # Player::InitResources) must never be swept into "transcribed".
+        hatch = ("unsigned int GetControl(void){\n"
+                 "    unsigned int v;\n"
+                 "    asm { mrc p15,0,v,c1,c0,0 }\n"
+                 "    return v;\n"
+                 "}\n")
+        self.assertEqual(asm_policy.classify(hatch), "unbannered-asm")
+
+    def test_banner_anywhere_in_the_file_is_exculpatory(self):
+        # The banner search is whole-file, not head-200: a banner can only ever
+        # excuse a file, so a deep mention must count.
+        deep = DCD_DUMP + "\n" * 20 + "// NONMATCHING: see the wall analysis above\n"
+        self.assertIsNone(asm_policy.classify(deep))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -195,6 +195,75 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(report["status"], "Failed")
         self.assertIn("function/byte coverage denominator changed", report["reasons"])
 
+    def _declare_symbol(self, name):
+        """Add ``name`` to the base symbol universe (no source yet) and commit,
+        so a later src/ addition changes neither denominator nor matched set."""
+        symbols = self.repo / "config" / "arm9" / "symbols.txt"
+        symbols.write_text(
+            symbols.read_text(encoding="utf-8")
+            + f"{name} kind:function(arm,size=0x4) addr:0x02000004\n",
+            encoding="utf-8")
+        return commit(self.repo, f"declare {name}", "alice")
+
+    def test_unbannered_dcd_transcription_is_demoted_and_fails_the_pr(self):
+        # A dcd dump byte-matches vacuously (it IS the ROM words re-spelled), so
+        # without a banner it must not count as matched at any revision, and a PR
+        # that adds one must fail with a reason that names the file.
+        base = self._declare_symbol("Raw")
+        (self.repo / "src" / "Raw.c").write_text(
+            "asm void Raw(void) {\n    dcd 0xe12fff1e\n}\n", encoding="utf-8")
+        head = commit(self.repo, "transcribe Raw", "bob")
+        snap = VM.function_snapshot(head)
+        self.assertEqual(snap["stats"]["matchedFunctions"], 1)  # Example only
+        self.assertFalse(snap["functions"]["arm9:0x02000004"]["matched"])
+        report = VM.build_report(base, head)
+        self.assertEqual(report["status"], "Failed")
+        self.assertIn("src/Raw.c", "; ".join(report["reasons"]))
+        self.assertTrue(any("asm-transcription" in r for r in report["reasons"]))
+        self.assertEqual(report["asmPolicy"]["transcribed"], ["src/Raw.c"])
+
+    def test_nonmatching_bannered_dcd_stays_on_the_draft_path(self):
+        # The same dcd body under a NONMATCHING banner is an honest draft: not
+        # matched (the established draft rule), and NOT a transcription failure.
+        base = self._declare_symbol("Raw")
+        (self.repo / "src" / "Raw.c").write_text(
+            "// NONMATCHING\nasm void Raw(void) {\n    dcd 0xe12fff1e\n}\n",
+            encoding="utf-8")
+        head = commit(self.repo, "draft Raw", "bob")
+        snap = VM.function_snapshot(head)
+        self.assertEqual(snap["stats"]["matchedFunctions"], 1)
+        report = VM.build_report(base, head)
+        self.assertEqual(report["status"], "Passed")
+        self.assertEqual(report["asmPolicy"]["transcribed"], [])
+
+    def test_hand_asm_primitive_banner_keeps_an_asm_body_matched(self):
+        # The other legitimate tier: the original really was assembly, the banner
+        # says so, and the function counts as matched with no gate reason.
+        base = self._declare_symbol("Prim")
+        (self.repo / "src" / "Prim.c").write_text(
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match (CPSR read).\n"
+            "asm void Prim(void) {\n    mrs r0, cpsr\n    bx lr\n}\n",
+            encoding="utf-8")
+        head = commit(self.repo, "match Prim", "bob")
+        snap = VM.function_snapshot(head)
+        self.assertEqual(snap["stats"]["matchedFunctions"], 2)
+        self.assertTrue(snap["functions"]["arm9:0x02000004"]["matched"])
+        report = VM.build_report(base, head)
+        self.assertEqual(report["status"], "Passed")
+        self.assertEqual(report["asmPolicy"], {"transcribed": [], "unbanneredAsm": []})
+
+    def test_raw_asm_group_verdict_blocks_and_overrides_vacuous_slots(self):
+        # pr_linkcheck stamps RAW-ASM on the group row while the transcription's
+        # per-slot results read VERIFIED (vacuously -- the dcd words ARE the ROM
+        # bytes). Flattening must carry the override or those slots launder it.
+        state = VM._link_state([{
+            "file": "src/Raw.c",
+            "worst": "RAW-ASM",
+            "results": [{"sym": "Raw", "verdict": "VERIFIED"}],
+        }])
+        self.assertEqual(state["tally"], {"RAW-ASM": 1})
+        self.assertEqual(len(state["blocking"]), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -26,6 +26,7 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy as AP  # noqa: E402
 import chaos_db_ci as CHAOS  # noqa: E402
 import rombuild_check as RBC  # noqa: E402
 
@@ -89,6 +90,15 @@ def function_snapshot(rev):
     # marker is a source header and is recognized in the first 200 characters.
     nonmatching = {path for path in candidates
                    if "NONMATCHING" in git_text(rev, path)[:200]}
+    # An unbannered dcd transcription byte-matches vacuously (it IS the ROM words
+    # re-spelled), so it never counts as matched -- see tools/asm_policy.py. Built
+    # the same revision-based way as ``nonmatching``: a cheap fixed-string grep
+    # prefilter, then the shared classifier confirms on the committed blob.
+    grep = _git("grep", "-l", "-F", "dcd 0x", rev, "--", "src/", allow=(0, 1))
+    dcd_candidates = {line.split(":", 1)[1] if ":" in line else line
+                      for line in grep.splitlines()}
+    transcribed = {path for path in dcd_candidates
+                   if AP.classify(git_text(rev, path)) == "transcribed"}
 
     records = {}
     total_bytes = matched_bytes = 0
@@ -103,7 +113,7 @@ def function_snapshot(rev):
             name, size, addr = m.group(1), int(m.group(2), 16), int(m.group(3), 16)
             key = f"{module}:0x{addr:08x}"
             src = sources.get(name)
-            matched = bool(src and src not in nonmatching)
+            matched = bool(src and src not in nonmatching and src not in transcribed)
             records[key] = {"id": key, "module": module, "addr": addr, "name": name,
                             "size": size, "matched": matched, "srcPath": src}
             total_bytes += size
@@ -249,10 +259,18 @@ def _link_state(rows):
                 # per-slot results still say NO-REPRO, so carry it down or the
                 # flattened tally re-blocks what pr_linkcheck already excused.
                 draft = row.get("worst") == "DRAFT"
+                # RAW-ASM is the opposite carry-down: pr_linkcheck stamps an
+                # unbannered dcd transcription on the GROUP row, while the
+                # per-slot results can read VERIFIED -- vacuously, since the
+                # dcd words ARE the ROM bytes. Without the override those
+                # VERIFIED slots would launder the gate at the flattened level.
+                raw_asm = row.get("worst") == "RAW-ASM"
                 for result in row["results"]:
                     flat = {"file": row.get("file"), **result}
                     if draft and str(flat.get("verdict")) == "NO-REPRO":
                         flat["verdict"] = "DRAFT"
+                    if raw_asm:
+                        flat["verdict"] = "RAW-ASM"
                     flattened.append(flat)
             else:
                 flattened.append({"file": row.get("file"),
@@ -266,7 +284,7 @@ def _link_state(rows):
         verdict = str(row.get("verdict", "ERROR"))
         bucket = "BLIND" if verdict.startswith("BLIND") else verdict
         tally[bucket] += 1
-        if bucket in ("WRONG", "NO-REPRO", "ERROR"):
+        if bucket in ("WRONG", "NO-REPRO", "ERROR", "RAW-ASM"):
             blocking.append(row)
     return {"checked": len(flattened), "tally": dict(tally), "blocking": blocking,
             "rows": flattened}
@@ -329,6 +347,17 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     ba, ha = attribution_snapshot(base_sha, bf), attribution_snapshot(head_sha, hf)
     diff = diff_snapshot(base_sha, head_sha, set(tree_paths(head_sha, "src/")))
 
+    # The transcription gate for the PR itself, scoped STRICTLY to the sources this
+    # merge adds or modifies (never renames-only or pre-existing files, so an old
+    # transcription in the tree cannot fail an unrelated PR). Classified from the
+    # committed head blob, same discipline as everything else in this report.
+    changed_src = [row["path"] for row in diff["files"]
+                   if row["status"][:1] in ("A", "M") and row.get("path", "")
+                   .endswith(SOURCE_SUFFIXES)]
+    changed_cls = {p: AP.classify(git_text(head_sha, p)) for p in sorted(changed_src)}
+    new_transcribed = [p for p, c in changed_cls.items() if c == "transcribed"]
+    new_unbannered = [p for p, c in changed_cls.items() if c == "unbannered-asm"]
+
     base_keys, head_keys = set(bf["matched"]), set(hf["matched"])
     common_credit = set(ba["byFunction"]) & set(ha["byFunction"])
     credit_changes = [{"id": k, "before": ba["byFunction"][k], "after": ha["byFunction"][k]}
@@ -363,6 +392,10 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append("the merge introduced an unattributed matched function")
     if diff["leftoverOldPaths"]:
         reasons.append("old source paths remain after rename")
+    if new_transcribed:
+        reasons.append(f"{len(new_transcribed)} asm-transcription file(s) with no "
+                       f"HAND-ASM PRIMITIVE or NONMATCHING banner: "
+                       + ", ".join(new_transcribed))
     if link["blocking"]:
         reasons.append(f"{len(link['blocking'])} blocking relocation verdict(s)")
     if port.get("available") and not port["passed"]:
@@ -376,6 +409,10 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     warnings = []
     if same_baseline_failure:
         warnings.append("base and merge share the same pre-existing ROM-build failure")
+    if new_unbannered:
+        warnings.append(f"{len(new_unbannered)} new/changed file(s) carry an asm body "
+                        f"with no HAND-ASM PRIMITIVE or NONMATCHING banner: "
+                        + ", ".join(new_unbannered))
     if link["tally"].get("BLIND"):
         warnings.append(f"{link['tally']['BLIND']} linkcheck result(s) have unresolved relocations")
     unresolved = sum(link["tally"].get(k, 0) for k in ("UNRESOLVED", "NO-SYM", "NONE"))
@@ -417,6 +454,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                         "added": added_credit, "changed": credit_changes,
                         "lost": lost_credit},
         "diff": diff,
+        "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered},
         "linkcheck": link,
         "portRefcheck": port,
         "rom": {"base": base_rom_state, "head": head_rom_state,


### PR DESCRIPTION
## What

Closes the validation hole PR #1072 walked through: a `src/` file whose body is a raw `asm { dcd 0x... }` transcription of the ROM byte-matches **vacuously** — the file *is* the bytes — so the byte gate, the link check, the progress counts, and contributor credit all report it as a clean match while zero source is recovered. #1072 landed 8 of these as +8 matched functions / +8,208 matched bytes, with credit ([review](https://github.com/tangosdev/sm64ds-decomp/pull/1072#pullrequestreview-4865170219)).

Tree policy already says what an asm body may be: `HAND-ASM PRIMITIVE` (policy-matched — the original really was assembly) or `NONMATCHING` (draft/hatch, does not count). This PR makes the tooling enforce it.

## Changes

- **`tools/asm_policy.py`** (new) — shared detector; tells lifted from `tools/dataset/eval_match.py`, not new regexes. `classify()` → `transcribed` (unbannered `dcd` blob), `unbannered-asm` (mnemonic asm body, no banner), or `None`. Banner search is whole-file: a banner is only ever exculpatory.
- **`tools/validate_merge.py`** — `function_snapshot()` excludes `transcribed` from matched (revision-based, base and head alike; credit follows automatically). `build_report()` hard-fails any **new/changed** transcription, naming the files; new/changed `unbannered-asm` gets a non-fatal warning. Pre-existing files cannot fail unrelated PRs.
- **`tools/pr_linkcheck.py`** — changed transcriptions render `🚫 raw-asm (transcription, no banner)` instead of `✅ verified`, and RAW-ASM blocks (including through `_link_state` flattening, so per-slot VERIFIEDs cannot launder it).
- **`tools/chaos_db_ci.py`** — progress DB demotes transcriptions (`rec["transcribed"]`), prints both lists loudly, adds `--fail-on-transcribed`.
- **Banners added to 10 genuine primitives** (7 CP15/MPU coprocessor ops, `ARMProcessorMode` CPSR read, `cstd::__builtin_trap` trap word, `DecompressLZ16` SDK LZ decompressor) per `notes/asm-policy.md`'s objective test, so the recount is surgical.
- **Tests** — `tools/test_asm_policy.py` (7 cases) + 4 new `test_validate_merge.py` fixtures (demotion + fail reason; NONMATCHING-bannered dcd stays an honest draft; HAND-ASM stays matched; RAW-ASM blocks through flattening).

## Effect (verified locally)

- `chaos_db_ci` on this branch: matched **11,165 → 11,157 (−8, exactly the #1072 files)**, matched bytes **−8,208** — the inflation reversed to the byte. No other count moves.
- 38 files land on the **warn list** (embedded asm hatches inside real C, e.g. `_ZN6Player13InitResourcesEv.cpp`, `func_0205950c.c`) — counts untouched; whether embedded hatches need banners is a policy call this PR deliberately does not make.
- `python -m unittest discover -s tools -p "test_*.py"`: **165 tests, 0 failures** (3 pre-existing environment skips). Not verified here: a live `pr_linkcheck` end-to-end run (needs ROM + compiler); its logic is covered by the flattening tests.

Note: the validator worker runs tools from the **trusted base**, so the gate protects PRs only after this merges. The 8 transcriptions themselves are removed in a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MumV9zcDeB1JeaZhjEynXf
