### PR TITLE
ActorBase ctor: demote mnemonic asm transcription to draft (-1 matched)

### DIFF
--- a/src/_ZN9ActorBaseC1Ev.cpp
+++ b/src/_ZN9ActorBaseC1Ev.cpp
@@ -1,4 +1,9 @@
 //cpp
+// NONMATCHING: hand-written asm, not a C decompilation. Whole-function mnemonic
+// transcription of compiled-C-shaped code (stmdb prolog, plain ldr/str/bl body, ldmia
+// epilog - no C-inexpressible instruction), so the asm-primitive policy does not apply;
+// does NOT count as matched. Reverts to a draft until someone reproduces the bytes from
+// real C++ (ActorBase::ActorBase() - the inheritance chain and callees are already known).
 // @symbol _ZN9ActorBaseC1Ev
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"


### PR DESCRIPTION
`_ZN9ActorBaseC1Ev.cpp` is a whole-function **mnemonic** asm transcription of compiled-C-shaped code (stmdb prolog, plain ldr/str/bl body, ldmia epilog — nothing C-inexpressible), counted as matched since it landed. Same vacuous-match disease as #1072, just wearing mnemonics instead of `dcd` words; it surfaced on the #1091 gate's warn tier during the 38-file audit.

- `NONMATCHING` banner (first 200 bytes) → honest draft, **−1 matched function**
- Demotion automatically puts `ActorBase::ActorBase()` back on the unmatched board for agents to pick up; no near-miss draft existed for it (checked `config/match_attempts.jsonl` and `nearmiss/db.jsonl`)
- The two embedded-hatch files from the same audit (`Player::InitResources`, `func_ov021_02111434`) stay warn-listed by design — per maintainer decision, no hatch-marker convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MumV9zcDeB1JeaZhjEynXf