### PR TITLE
asm detector precision: strip comments, tighten register-list tell; banner 3 hand-asm primitives

### DIFF
--- a/src/_ZN4CP1511SystemSetupEv.c
+++ b/src/_ZN4CP1511SystemSetupEv.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15/MPU system setup: 20+ mrc/mcr p15 coprocessor ops that
+// C cannot express), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
 extern unsigned int data_023c0000;
 
 void _ZN4CP1511SystemSetupEv(void) {

--- a/src/_ZN4CP1518GetDTCMBaseAddressEv.c
+++ b/src/_ZN4CP1518GetDTCMBaseAddressEv.c
@@ -1,1 +1,5 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (CP15 DTCM base read: an mrc p15 coprocessor op no C construct
+// compiles to), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
 unsigned int _ZN4CP1518GetDTCMBaseAddressEv(void){ asm { mrc p15,0,r0,c9,c1,0; ldr r1,=0xfffff000; and r0,r0,r1 } }

--- a/src/func_0205950c.c
+++ b/src/func_0205950c.c
@@ -1,3 +1,7 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (msr cpsr_fsxc: notes/asm-policy.md restored-ten table, 2026-07-25
+// correction), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
 #include "types.h"
 extern void _ZN4CP159EnableMPUEv(void);
 extern void _ZN4CP1510DisableMPUEv(void);

--- a/tools/asm_policy.py
+++ b/tools/asm_policy.py
@@ -51,15 +51,39 @@ _DCD_RE = re.compile(r"\bdcd\s+0x[0-9a-fA-F]")
 # A passthrough carries dozens; real C carries ~0. Used as a keyword-independent backstop so
 # an asm transcription is caught even if it isn't wrapped in a form the `asm` keyword regex
 # sees. (Lifted from tools/dataset/eval_match.py.)
+#
+# The register-list tell must accept real STM/PUSH lists -- ``{r4,r5,lr}``, ``{ r0 - r3 }``,
+# ``{r4-r11,lr}`` -- while rejecting C blocks whose first statement assigns to a local that
+# happens to be named like a register: ``{ r5 = 0x10000;``, ``{ r0->a = 0; }``, ``{ r2c = 0;``.
+# So after the register name we require a word boundary (kills ``r2c``) and then a list
+# continuation: ``,``, the closing ``}``, or a ``-`` range whose right side is another
+# register (kills ``r0->``).
 _ARM_TELLS = re.compile(r"""
       \bstm(?:db|ia|fd|ea)\b | \bldm(?:db|ia|fd|ea|ib)\b     # block load/store multiple
     | \bbx\s+lr\b | \bblx\b | \bbl\s+\w                        # branch-exchange / branch-link
     | \bsp!                    | \[pc,        | \[sp,          # ARM addressing idioms
     | \bdcd\b | \bdcw\b                                        # inline data words
-    | \{\s*(?:r\d|lr|sp|pc)                                    # register list  {r4, lr}
+    | \{\s*(?:r\d+|lr|sp|pc)\b\s*(?:[,}]|-\s*(?:r\d+|ip|lr|sp|pc)\b)  # register list {r4, lr} / { r0 - r3 }
     | \b(?:ldr|str|ldrh|strh|ldrb|strb|mov|cmp|orr|eor|lsl|lsr|asr|msr|mrs)\s+r\d  # op + reg
     | \bldmia\b | \bstmia\b
 """, re.X)
+
+# Comments are stripped before asm DETECTION (never before the banner search: banners live
+# in comments and are only ever exculpatory). Disassembly traces and call-map notes kept as
+# documentation -- ``// mov r0,r2; bl 0x0205a61c`` -- are commentary about asm, not an asm
+# body, and were firing the tells above. String literals are preserved so a ``//`` inside
+# one cannot eat real code (and GCC-style ``__asm__("mrc ...")`` keeps its content).
+_COMMENT_OR_STRING_RE = re.compile(
+    r'"(?:\\.|[^"\\\n])*"'        # string literal (kept)
+    r"|'(?:\\.|[^'\\\n])*'"       # char literal (kept)
+    r"|/\*.*?\*/"                 # block comment (stripped)
+    r"|//[^\n]*",                 # line comment (stripped)
+    re.S)
+
+
+def _strip_comments(code):
+    return _COMMENT_OR_STRING_RE.sub(
+        lambda m: m.group(0) if m.group(0)[0] in "\"'" else " ", code)
 
 
 def is_asm_passthrough(code):
@@ -69,7 +93,12 @@ def is_asm_passthrough(code):
       1. the `asm` KEYWORD -- mwccarm naked function ``asm <type> name(...) {``,
          GCC ``asm {`` / ``asm volatile``, or ``__asm``;
       2. CONTENT -- >=3 ARM-mnemonic tells, which real C never has, catching asm
-         even if it isn't wrapped in a keyword form the regex above recognizes."""
+         even if it isn't wrapped in a keyword form the regex above recognizes.
+
+    Both run on comment-stripped text: a commented-out disassembly trace is
+    documentation, not an asm body (the exculpatory banners are searched on the
+    RAW text by ``classify``, never here)."""
+    code = _strip_comments(code)
     if "__asm" in code:
         return True
     for m in re.finditer(r"(?<![\w])asm(?![\w])", code):          # `asm` as a standalone token

--- a/tools/test_asm_policy.py
+++ b/tools/test_asm_policy.py
@@ -52,6 +52,76 @@ class Classify(unittest.TestCase):
         deep = DCD_DUMP + "\n" * 20 + "// NONMATCHING: see the wall analysis above\n"
         self.assertIsNone(asm_policy.classify(deep))
 
+    # -- precision regressions: the 38-file warn-list audit found 32 false ------
+    # -- positives from register-named locals and disassembly-trace comments ----
+
+    def test_register_named_locals_opening_blocks_are_not_a_register_list(self):
+        # Largest false-positive class (26 files): real C whose locals are named
+        # r0..r8 opening blocks. `{ r5 = ...` is an assignment, not an STM list.
+        c = ("int Setup(void) {\n"
+             "    int r0; int r4; int r5;\n"
+             "    struct Obj* r2;\n"
+             "    { r5 = 0x10000; }\n"
+             "    { r4 = LoadFile(0x30); }\n"
+             "    { r0 = r4 + r5; }\n"
+             "    { r0->a = 0; }\n"
+             "    return r0;\n"
+             "}\n")
+        self.assertIsNone(asm_policy.classify(c))
+
+    def test_r2c_style_prefix_names_are_not_registers(self):
+        # `r2c` starts with `r2`; the word boundary after the register name must
+        # keep the r\d prefix from matching inside a longer identifier.
+        self.assertIsNone(asm_policy.classify(
+            "void f(void) {\n"
+            "    { r2c = 0; }\n"
+            "    { r2c = 0; }\n"
+            "    { r2c = 0; }\n"
+            "}\n"))
+
+    def test_disassembly_trace_comments_do_not_fire_the_backstop(self):
+        # Second false-positive class (6 files): disassembly traces / call maps
+        # kept in comments are documentation ABOUT asm, not an asm body.
+        traced = ("// call map:\n"
+                  "// mov r0,r2; bl 0x0205a61c\n"
+                  "// bl 0x02037764 = RaycastLine::~RaycastLine\n"
+                  "/* ldr r1,[sp,#4]; bx lr */\n"
+                  "int Example(void) {\n"
+                  "    return Helper(2);\n"
+                  "}\n")
+        self.assertIsNone(asm_policy.classify(traced))
+
+    def test_register_list_tell_matches_lists_not_c_blocks(self):
+        # The tightened tell must keep every real STM/PUSH list form and reject
+        # every audited C-block shape.
+        for s in ("{r4,r5,lr}", "{ r0 - r3 }", "{r4-r11,lr}", "{r2, r3, ip}", "{lr}"):
+            self.assertTrue(asm_policy._ARM_TELLS.search(s), s)
+        for s in ("{ r5 = 0x10000;", "{ r4 = LoadFile(0x30);",
+                  "{ r0->a = 0; }", "{ r2c = 0;"):
+            self.assertFalse(asm_policy._ARM_TELLS.search(s), s)
+
+    def test_real_register_lists_in_an_asm_body_are_still_detected(self):
+        # A genuine unbannered transcription must still be caught after the
+        # tightening -- lists and ranges alike, without the `asm` keyword.
+        self.assertEqual(asm_policy.classify(
+            "void func(void) {\n"
+            "    stmdb sp!, {r4 - r6, lr}\n"
+            "    ldmia r0!, {r2, r3, ip}\n"
+            "    ldmia sp!, {r4-r6, pc}\n"
+            "}\n"), "unbannered-asm")
+
+    def test_dcd_dump_with_trace_comments_is_still_transcribed(self):
+        # Comment stripping guards the asm detection; a real dcd blob next to a
+        # commentary line must still demote.
+        self.assertEqual(
+            asm_policy.classify("// raw words follow\n" + DCD_DUMP), "transcribed")
+
+    def test_banner_is_read_from_raw_text_before_comment_stripping(self):
+        # Banners ARE comments and are only exculpatory: the stripping that
+        # guards detection must never run before the banner search.
+        self.assertIsNone(asm_policy.classify(
+            "/* HAND-ASM PRIMITIVE: byte-faithful asm-block match. */\n" + MNEMONIC_ASM))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

An audit of the 38-file `unbannered-asm` warn list found **32 false positives** — only 6 files actually carry an asm construct. Two causes:

- **26 files** — register-named locals opening blocks: the register-list tell `\{\s*(?:r\d|lr|sp|pc)` fires on real C like `{ r5 = 0x10000;`, `{ r4 = LoadFile(0x30);`, `{ r0->a = 0; }`, and even `{ r2c = 0;` (`r2c` matches the `r\d` prefix).
- **6 files** — disassembly traces / call maps kept in comments (`// mov r0,r2; bl 0x0205a61c`, `// bl 0x02037764 = RaycastLine::~...`) firing the `mov`/`bl` tells because comments were never stripped.

## Detector fixes (`tools/asm_policy.py`)

1. **Comment stripping before detection**: `is_asm_passthrough` now strips `//` and `/* */` comments (string literals preserved) before both the keyword and content detectors. The banner search keeps running on the **raw** text — banners ARE comments and are only ever exculpatory.
2. **Tightened register-list tell**: after the register name, require a word boundary and then a list continuation (`,`, `}`, or a `-` range ending in another register). Real `{r4,r5,lr}` / `{ r0 - r3 }` / `{r4-r11,lr}` still match; `{ r5 = ...` / `{ r2c = 0;` / `{ r0->a` do not. `dcd` detection and the explicit `asm` keyword forms are untouched; `classify`'s public API and semantics are otherwise identical.

## Banners (3 of the 6 real asm carriers)

Standard `HAND-ASM PRIMITIVE` banner (Copy32Bytes form, parenthetical adjusted), each inexpressible in C under notes/asm-policy.md's objective test:

- `src/_ZN4CP1511SystemSetupEv.c` — whole-function `__asm__ volatile`, 20+ `mrc`/`mcr` p15 (CP15/MPU system setup)
- `src/_ZN4CP1518GetDTCMBaseAddressEv.c` — one-line `asm { mrc p15, ... }` (CP15 DTCM base read)
- `src/func_0205950c.c` — `msr cpsr_fsxc` hatch; listed in the notes/asm-policy.md restored-ten table (2026-07-25 correction), cited in the banner

## Result

Warn list 38 → **3**, all real and deliberately left pending policy decisions:

```
src/_ZN6Player13InitResourcesEv.cpp
src/_ZN9ActorBaseC1Ev.cpp
src/func_ov021_02111434.c
```

TRANSCRIBED stays empty. **Counts unchanged** — the bannered files were already matched. Stats line identical before and after:

```
11157/11393 funcs, 2047892/2235468 bytes, 74 modules, 11157 authored
```

## Tests

`tools/test_asm_policy.py` gains regression cases for every audited shape: register-named locals opening blocks, `r2c`-style prefix names, disassembly-trace comments, real STM lists/ranges still detected, dcd dump still `transcribed` (with comments present), and a banner inside a block comment still exculpating (raw-text banner search).

```
python -m unittest discover -s tools -p "test_*.py"
Ran 172 tests in 15.110s
OK (skipped=3)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MumV9zcDeB1JeaZhjEynXf
