### PR TITLE
demember_calls: attribute each call to its declaring class

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -684,6 +684,7 @@ src/_ZN6Camera16OnPendingDestroyEv.cpp:
     .text start:0x0200da00 end:0x0200da04
 
 src/_ZN6Camera6RenderEv.cpp:
+    complete
     .text start:0x0200da04 end:0x0200debc
 
 src/_ZN6Camera8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -3695,6 +3695,7 @@ src/_ZN6Player16InitBalloonMarioEv.cpp:
     .text start:0x020dea00 end:0x020deab8
 
 src/_ZN6Player17St_WindCarry_MainEv.cpp:
+    complete
     .text start:0x020deab8 end:0x020dec0c
 
 src/_ZN6Player17St_WindCarry_InitEv.cpp:
@@ -3798,6 +3799,7 @@ src/_ZN6Player12St_Land_MainEv.cpp:
     .text start:0x020e04ec end:0x020e088c
 
 src/_ZN6Player12St_Land_InitEv.cpp:
+    complete
     .text start:0x020e088c end:0x020e0a64
 
 src/func_ov002_020e0a64.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -944,6 +944,7 @@ src/func_ov006_020cafdc.cpp:
     .text start:0x020cafdc end:0x020cb030
 
 src/func_ov006_020cb030.cpp:
+    complete
     .text start:0x020cb030 end:0x020cb134
 
 src/func_ov006_020cb134.cpp:
@@ -1243,6 +1244,7 @@ src/func_ov006_020cecb4.c:
     .text start:0x020cecb4 end:0x020cecc0
 
 src/func_ov006_020cecc0.cpp:
+    complete
     .text start:0x020cecc0 end:0x020ced84
 
 src/func_ov006_020ced84.c:

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -741,6 +741,9 @@ src/func_ov007_020b9fc0.c:
     complete
     .text start:0x020b9fc0 end:0x020ba05c
 
+src/func_ov007_020ba05c.c:
+    .text start:0x020ba05c end:0x020ba2e0
+
 src/func_ov007_020ba2e0.c:
     complete
     .text start:0x020ba2e0 end:0x020ba368

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -119,6 +119,7 @@ src/func_ov022_02111ad0.c:
     .text start:0x02111ad0 end:0x02111bdc
 
 src/func_ov022_02111bdc.cpp:
+    complete
     .text start:0x02111bdc end:0x02111c7c
 
 src/LavaBridge_Spawn.c:
@@ -150,6 +151,7 @@ src/func_ov022_02111dfc.c:
     .text start:0x02111dfc end:0x02111ea0
 
 src/func_ov022_02111ea0.cpp:
+    complete
     .text start:0x02111ea0 end:0x02111f3c
 
 src/LavaSeesaw_Spawn.c:

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -28,6 +28,7 @@ src/func_ov036_021112f0.c:
     .text start:0x021112f0 end:0x0211137c
 
 src/func_ov036_0211137c.cpp:
+    complete
     .text start:0x0211137c end:0x02111414
 
 src/SwingingPlatform_Spawn.c:

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -96,6 +96,7 @@ src/func_ov064_02116d1c.cpp:
     .text start:0x02116d1c end:0x02116ec0
 
 src/func_ov064_02116ec0.cpp:
+    complete
     .text start:0x02116ec0 end:0x02117070
 
 src/_ZN5BullyD1Ev.c:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -395,6 +395,7 @@ src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp:
     .text start:0x0211a6d0 end:0x0211a870
 
 src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp:
+    complete
     .text start:0x0211a870 end:0x0211aa38
 
 src/func_ov065_0211aa38.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -335,6 +335,7 @@ src/_ZN6Coffin8BehaviorEv.cpp:
     .text start:0x021224cc end:0x0212255c
 
 src/_ZN6Coffin13InitResourcesEv.cpp:
+    complete
     .text start:0x0212255c end:0x02122670
 
 src/Coffin_Spawn.c:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -354,6 +354,7 @@ src/_ZN9WaterBomb8BehaviorEv.cpp:
     .text start:0x0213bc20 end:0x0213bd14
 
 src/_ZN9WaterBomb13InitResourcesEv.cpp:
+    complete
     .text start:0x0213bd14 end:0x0213bf10
 
 src/WaterBomb_Spawn.c:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -334,6 +334,7 @@ src/_ZN6BobOmb8BehaviorEv.c:
     .text start:0x0214c1bc end:0x0214c510
 
 src/_ZN6BobOmb13InitResourcesEv.cpp:
+    complete
     .text start:0x0214c510 end:0x0214c6e4
 
 src/func_ov102_0214c6e4.c:
@@ -428,6 +429,7 @@ src/_ZN10KoopaShell8BehaviorEv.cpp:
     .text start:0x0214d2e8 end:0x0214d54c
 
 src/_ZN10KoopaShell13InitResourcesEv.cpp:
+    complete
     .text start:0x0214d54c end:0x0214d6a0
 
 src/func_ov102_0214d6a0.c:

--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,5 +1,5 @@
 {
- "eligible": 10566,
+ "eligible": 10666,
  "unresolved": {
   "ChainChomp_Spawn": [
    "func_020aed98"
@@ -57,16 +57,9 @@
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj"
   ],
-  "_ZN10DonutBlock8BehaviorEv": [
-   "_ZN8Platform13IsClsnInRangeEii"
-  ],
   "_ZN10FlameChomp13InitResourcesEv": [
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj"
-  ],
-  "_ZN10KoopaShell13InitResourcesEv": [
-   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
   "_ZN10MrBlizzard13InitResourcesEv": [
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
@@ -137,9 +130,6 @@
    "_ZTV10dBgActor_c",
    "_ZTV15daObjFlMaruta_c"
   ],
-  "_ZN12FortressWall8BehaviorEv": [
-   "_ZN8Platform13IsClsnInRangeEii"
-  ],
   "_ZN13FortressTower13InitResourcesEv": [
    "MeshCollider_LoadFile",
    "ModelBase_SetFile",
@@ -158,9 +148,6 @@
    "Enemy_UpdateWMClsn",
    "Player_Hurt",
    "WithMeshClsn_IsOnGround"
-  ],
-  "_ZN13PeachPainting8BehaviorEv": [
-   "_ZN9ModelBase12ApplyOpacityEji"
   ],
   "_ZN13PrincessPeach13InitResourcesEv": [
    "AnimLoadFile",
@@ -186,9 +173,6 @@
    "_Z25_ZN12CylinderClsn5ClearEvPc",
    "_Z26_ZN12CylinderClsn6UpdateEvPc",
    "p__sinit_ov031_02111434"
-  ],
-  "_ZN13RollingLogLll13InitResourcesEv": [
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
   "_ZN13SnowmanBreath8BehaviorEv": [
    "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3jijjPvj",
@@ -230,9 +214,6 @@
   "_ZN16RotatingCogSmall13InitResourcesEv": [
    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
   ],
-  "_ZN17BowserPuzzlePiece13InitResourcesEv": [
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
-  ],
   "_ZN17MgBounceAndPounce11AfterRenderEj": [
    "Scene_AfterRender"
   ],
@@ -259,10 +240,6 @@
   ],
   "_ZN19RotatingPlatformWdw13InitResourcesEv": [
    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-  ],
-  "_ZN20TtcConveyorBeltLarge13InitResourcesEv": [
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-   "_ZN18TextureTransformer7SetFileER8BTA_Fileiij"
   ],
   "_ZN22RotatingUpDownPlatform13InitResourcesEv": [
    "Vec3_equal",
@@ -300,17 +277,8 @@
    "_ll_udiv",
    "_ull_mod"
   ],
-  "_ZN4Tree13InitResourcesEv": [
-   "_ZN19CylinderClsnWithPos4InitERK7Vector3iijj"
-  ],
   "_ZN4cstd5atan2E5Fix12IiES1_": [
    "func_01ff98f4"
-  ],
-  "_ZN5Actor13LandingDustAtER7Vector3b": [
-   "_ZN8Particle6System9NewSimpleEjiii"
-  ],
-  "_ZN5Actor17HugeLandingDustAtER7Vector3b": [
-   "_ZN8Particle6System9NewSimpleEjiii"
   ],
   "_ZN5Cloud8BehaviorEv": [
    "FindWithActorID",
@@ -345,10 +313,6 @@
    "func_020acb68",
    "func_020ad04c"
   ],
-  "_ZN6BobOmb13InitResourcesEv": [
-   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
-  ],
   "_ZN6BobOmb8BehaviorEv": [
    "func_020ada40"
   ],
@@ -358,13 +322,6 @@
    "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
    "func_0211d610"
-  ],
-  "_ZN6Camera6RenderEv": [
-   "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
-   "_ZN3OAM6RenderEbP7OamAttriiiiiiii"
-  ],
-  "_ZN6Coffin13InitResourcesEv": [
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
   "_ZN6Eyerok13InitResourcesEv": [
    "_Z13func_020393c4PvS_",
@@ -384,23 +341,6 @@
    "func_02112ca8",
    "func_02112d48"
   ],
-  "_ZN6Player11St_Fly_MainEv": [
-   "_ZN6Player11ChangeStateER5State",
-   "_ZN6Player7SetAnimEjiij"
-  ],
-  "_ZN6Player12St_Land_InitEv": [
-   "_ZN6Player7SetAnimEjiij"
-  ],
-  "_ZN6Player15St_Respawn_InitEv": [
-   "_ZN6Player7SetAnimEjiij"
-  ],
-  "_ZN6Player17St_WindCarry_MainEv": [
-   "_ZN6Player11ChangeStateER5State",
-   "_ZN6Player7SetAnimEjiij"
-  ],
-  "_ZN6Player18St_CameraZoom_MainEv": [
-   "_ZN6Player11ChangeStateER5State"
-  ],
   "_ZN7ClipperD0Ev": [
    "base_dtor_Clipper"
   ],
@@ -417,19 +357,12 @@
    "func_021123f4",
    "func_021124ac"
   ],
-  "_ZN8MadPiano8BehaviorEv": [
-   "_ZN8Platform13IsClsnInRangeEii"
-  ],
   "_ZN8SignPost13InitResourcesEv": [
    "MeshColliderLoadFile",
    "ModelLoadFile",
    "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
    "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-  ],
-  "_ZN9KoopaFlag13InitResourcesEv": [
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
   "_ZN9Spindrift13InitResourcesEv": [
    "AnimLoadFile",
@@ -445,10 +378,6 @@
   "_ZN9UkikiCageD1Ev": [
    "_ZTV10dBgActor_c",
    "_ZTV15daObjHmMaruta_c"
-  ],
-  "_ZN9WaterBomb13InitResourcesEv": [
-   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
   ],
   "__sinit_ov071_02122a64": [
    "data_ov071_02122ecc_d"
@@ -569,65 +498,19 @@
    "_ll_udiv",
    "_ull_mod"
   ],
-  "func_ov002_020aefb8": [
-   "_ZN5Actor12ReflectAngleEiis"
-  ],
-  "func_ov002_020b5ab4": [
-   "_ZN13RaycastGround19StartDetectingWaterEv"
-  ],
-  "func_ov002_020b7e1c": [
-   "_ZN5Actor9SetRangesEiiii"
-  ],
-  "func_ov002_020bd250": [
-   "_ZN6Player4HurtERK7Vector3jijjj",
-   "_ZN8Particle6System9NewSimpleEjiii"
-  ],
   "func_ov002_020c0fb4": [
    "_ll_udiv"
-  ],
-  "func_ov002_020c1234": [
-   "_ZN5Sound7PlaySubEjjjib"
-  ],
-  "func_ov002_020c1eb4": [
-   "_ZN8Particle6System3NewEjjiiiPK10Vector3_16PNS_8CallbackE"
-  ],
-  "func_ov002_020c29d4": [
-   "_ZN6Player7IsStateER5State"
   ],
   "func_ov002_020c8a4c": [
    "_Z13func_020072c0v",
    "_ZN6Player7SetAnimEjiij"
   ],
-  "func_ov002_020c8f80": [
-   "_ZN6Player7SetAnimEjiij"
-  ],
-  "func_ov002_020d0580": [
-   "_ZN6Player11ChangeStateER5State",
-   "_ZN6Player7IsStateER5State"
-  ],
-  "func_ov002_020d06c0": [
-   "_ZN6Player11ChangeStateER5State",
-   "_ZN6Player7IsStateER5State"
-  ],
-  "func_ov002_020d4c30": [
-   "_ZN8Particle6System9NewSimpleEjiii"
-  ],
   "func_ov002_020dc560": [
    "func_01ff98f4",
    "func_01ff99a4"
   ],
-  "func_ov002_020df34c": [
-   "_ZN6Player11ChangeStateER5State",
-   "_ZN6Player7IsStateER5State"
-  ],
-  "func_ov002_020e81e0": [
-   "_ZN8Particle6System3NewEjjiiiPK7Vector3PNS_8CallbackE"
-  ],
   "func_ov002_020ec670": [
    "func_02123804"
-  ],
-  "func_ov003_020ad7a4": [
-   "_ZN3OAM12EnableSubOAMEP6OamTmp"
   ],
   "func_ov003_020adfc8": [
    "func_020ab9c8",
@@ -644,25 +527,13 @@
    "func_020ab9c8",
    "func_020aba70"
   ],
-  "func_ov006_020c0264": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
-  ],
   "func_ov006_020c0a48": [
    "g0",
    "g1",
    "g2"
   ],
-  "func_ov006_020c0d68": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
-  ],
-  "func_ov006_020c1420": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
-  ],
   "func_ov006_020c14bc": [
    "func_020beb68"
-  ],
-  "func_ov006_020c1764": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
   ],
   "func_ov006_020c221c": [
    "g0",
@@ -670,42 +541,6 @@
   ],
   "func_ov006_020c3bc8": [
    "func_020c3adc"
-  ],
-  "func_ov006_020c6e4c": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov006_020c79a8": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov006_020c8084": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov006_020c8f20": [
-   "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback"
-  ],
-  "func_ov006_020c9098": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov006_020c9c8c": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov006_020ca3a8": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov006_020cb030": [
-   "_ZN6System3NewEjjiiiPK11Vector3_16fP8Callback"
-  ],
-  "func_ov006_020cb1a8": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov006_020cb528": [
-   "_ZN9ModelAnim7SetAnimEPviij"
-  ],
-  "func_ov006_020cb690": [
-   "_ZN9ModelAnim7SetAnimEPviij"
-  ],
-  "func_ov006_020cecc0": [
-   "_ZN18TextureTransformer7SetFileER8BTA_Fileiij"
   ],
   "func_ov006_020db720": [
    "func_020beb68"
@@ -736,9 +571,6 @@
   ],
   "func_ov006_020e7124": [
    "func_020beb74"
-  ],
-  "func_ov006_020e7cc0": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
   "func_ov006_020e989c": [
    "func_020beb68"
@@ -886,10 +718,6 @@
    "func_020bc880",
    "func_020bc884"
   ],
-  "func_ov006_02123340": [
-   "_ZN4PSys12FromUniqueIDEj",
-   "_ZN4PSys17NewUnkCallback818EjjiiiPv"
-  ],
   "func_ov006_02125364": [
    "func_020bc7d4"
   ],
@@ -939,34 +767,11 @@
    "overlay_100",
    "overlay_102"
   ],
-  "func_ov014_02111a6c": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov014_02111e74": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov014_02112ea8": [
-   "_ZN6ActorS10PoofDustAtERK7Vector3",
-   "_ZN8Particle6System9NewSimpleEjiii"
-  ],
-  "func_ov015_02111d98": [
-   "_ZN5Actor22UpdatePosWithOnlySpeedEPv"
-  ],
   "func_ov015_02112c84": [
    "func_020b66a8"
   ],
   "func_ov016_02112fa8": [
    "func_020b5e58"
-  ],
-  "func_ov018_02111d28": [
-   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
-  ],
-  "func_ov018_02111f1c": [
-   "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov018_02112730": [
-   "_ZN5Actor18MarkForDestructionEv"
   ],
   "func_ov020_021112b0": [
    "Actor_ClosestPlayer",
@@ -974,12 +779,6 @@
   ],
   "func_ov022_0211165c": [
    "func_020b66a8"
-  ],
-  "func_ov022_02111bdc": [
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-  ],
-  "func_ov022_02111ea0": [
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
   ],
   "func_ov022_02112380": [
    "_ZTV10dBgActor_c",
@@ -1004,12 +803,6 @@
   "func_ov026_02111598": [
    "func_ov053_021112a4"
   ],
-  "func_ov030_02113a80": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov036_0211137c": [
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-  ],
   "func_ov036_0211244c": [
    "func_020efaf0"
   ],
@@ -1026,48 +819,15 @@
   "func_ov062_02116010": [
    "func_020ada40"
   ],
-  "func_ov062_021164e8": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov062_02116d28": [
-   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
-  ],
   "func_ov062_02117c98": [
    "func_020ada40",
    "func_020aea30"
   ],
-  "func_ov062_02118004": [
-   "_ZN8Particle20RunningSlidingDustAtEiii"
-  ],
-  "func_ov062_02119af0": [
-   "_ZN4cstd5atan2Eii"
-  ],
-  "func_ov062_0211b880": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
-  ],
-  "func_ov062_0211b930": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit",
-   "_ZN8Particle6System9NewSimpleEjiii"
-  ],
-  "func_ov062_0211bc54": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
-  ],
   "func_ov063_0211a0dc": [
    "func_020ada40"
   ],
-  "func_ov064_021163c0": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov064_02116460": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
   "func_ov064_02116754": [
    "func_020ada40"
-  ],
-  "func_ov064_02116ec0": [
-   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
   ],
   "func_ov065_02115ff0": [
    "func_020ada40",
@@ -1100,9 +860,6 @@
    "_Z19func_ov066_0211a35cv",
    "_Z23func_02112cd8_updateposv"
   ],
-  "func_ov066_02116d14": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
-  ],
   "func_ov066_02116db0": [
    "func_02112c08",
    "func_02112d48"
@@ -1119,77 +876,20 @@
    "func_02112c08",
    "func_02112d48"
   ],
-  "func_ov070_0211f0a4": [
-   "_ZN5Actor10SpawnCoinsERK7Vector3jis"
-  ],
   "func_ov070_0211f100": [
    "func_020aea30"
-  ],
-  "func_ov070_0211f5f0": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov071_0211f7d4": [
-   "_ZN13CylinderClsn25ClearEv",
-   "_ZN13CylinderClsn26UpdateEv"
-  ],
-  "func_ov075_02114cd8": [
-   "_ZN11ShadowModel9InitModelEP9Matrix4x3iiij"
-  ],
-  "func_ov075_021152d4": [
-   "_ZN3G3i13PerspectiveW_EiiiiiibP9Matrix4x3",
-   "_ZN7Clipper13Func_020156DCEPviiii"
   ],
   "func_ov075_02116f40": [
    "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
    "func_020abd88"
   ],
-  "func_ov075_02117590": [
-   "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii"
-  ],
   "func_ov075_02117bc4": [
    "overlay_64",
    "overlay_66"
   ],
-  "func_ov075_021194e4": [
-   "_ZN3OAM6RenderEbP7OamAttriiiiii"
-  ],
-  "func_ov075_021199d8": [
-   "_ZN3OAM6RenderEbP7OamAttriiiiii"
-  ],
-  "func_ov077_021244d4": [
-   "_ZN15TextureSequence7SetFileER8BTP_Fileiij",
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov078_02123bc4": [
-   "_ZN14BlendModelAnim7SetAnimER8BCA_Fileiiit"
-  ],
-  "func_ov079_02126f8c": [
-   "_ZN7Actor_s10FindWithIDEj",
-   "_ZN7Actor_s13ClosestPlayerEv",
-   "_ZN7Actor_s5SpawnEjjRK7Vector3PK10Vector3_16ii",
-   "_ZN8Platform13IsClsnInRangeEii",
-   "_ZN8Platform20UpdateKillByMegaCharEsssi"
-  ],
-  "func_ov080_02123ecc": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
   "func_ov081_021243cc": [
    "func_020ada40",
    "func_020aea30"
-  ],
-  "func_ov081_02124d14": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov081_02125068": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov081_02127be0": [
-   "_ZN5Actor5SpawnEjjRK7Vector3PK16Vector3_16_localii"
-  ],
-  "func_ov084_02129238": [
-   "_ZN13RaycastGround19StartDetectingToxicEv",
-   "_ZN13RaycastGround19StartDetectingWaterEv",
-   "_ZN13RaycastGround21StopDetectingOrdinaryEv"
   ],
   "func_ov084_02129a00": [
    "func_020aea30"
@@ -1198,23 +898,8 @@
    "func_020ada40",
    "func_020aea30"
   ],
-  "func_ov084_0212a580": [
-   "_ZN8CapEnemy12UpdateCapPosERK7Vector3RK16Vector3_16_local"
-  ],
   "func_ov084_0212a774": [
    "func_020aea30"
-  ],
-  "func_ov084_0212c92c": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov085_0212943c": [
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "func_ov085_0212bedc": [
-   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
-  ],
-  "func_ov085_0212de5c": [
-   "_ZN5Sound7PlaySubEjjjib"
   ],
   "func_ov089_0213162c": [
    "data_02111b68"
@@ -1222,9 +907,6 @@
   "func_ov090_021310b4": [
    "func_020ada40",
    "func_020aea30"
-  ],
-  "func_ov091_02131070": [
-   "_ZN8Particle6System9NewSimpleEjiii"
   ],
   "func_ov091_021339fc": [
    "func_020aea30"
@@ -1264,18 +946,8 @@
    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
    "func_020efaf0"
   ],
-  "func_ov102_02149610": [
-   "_ZN13RaycastGround12SetObjAndPosERK7Vector3Pv"
-  ],
-  "func_ov102_0214aa18": [
-   "_ZNK13WithMeshClsn210IsOnGroundEv",
-   "_ZNK13WithMeshClsn213JustHitGroundEv"
-  ],
   "func_ov102_0214cbec": [
    "func_020ada40"
-  ],
-  "func_ov102_0214ce60": [
-   "_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x3iij"
   ],
   "main": [
    "__main",

--- a/src/_ZN10KoopaShell13InitResourcesEv.cpp
+++ b/src/_ZN10KoopaShell13InitResourcesEv.cpp
@@ -17,10 +17,22 @@ struct ShadowModel {
 struct MovingCylinderClsn {
     void Init(Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
+
 struct WithMeshClsn {
     void Init(Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
     void StartDetectingWater();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *, Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
+
 extern "C" void func_ov102_0214d1f8(void* c, void* p);
 
 extern SharedFilePtr* data_ov102_0214d70c[];
@@ -58,7 +70,7 @@ extern "C" int _ZN10KoopaShell13InitResourcesEv(Obj* o)
         return 0;
     if (((ShadowModel*)&o->f350)->InitCylinder() == 0)
         return 0;
-    ((MovingCylinderClsn*)&o->f110)->Init((Actor*)o, 0x3c000, 0x46000, 0x100004, 0xa083c0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)&o->f110, (Actor*)o, 0x3c000, 0x46000, 0x100004, 0xa083c0);
     o->f3b0 = o->f5c;
     o->f3b4 = o->f60;
     o->f3b8 = o->f64;
@@ -66,7 +78,7 @@ extern "C" int _ZN10KoopaShell13InitResourcesEv(Obj* o)
     o->fa0 = -0x32000;
     o->f100 = 0x14;
     o->f3c0 = 0;
-    ((WithMeshClsn*)&o->f144)->Init((Actor*)o, 0x28000, 0x28000, 0, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((WithMeshClsn*)&o->f144, (Actor*)o, 0x28000, 0x28000, 0, 0);
     ((WithMeshClsn*)&o->f144)->StartDetectingWater();
     func_ov102_0214d1f8(o, &data_ov102_0214ea68);
     o->f3d4 = 0;

--- a/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
@@ -29,6 +29,12 @@ extern "C" void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(
 struct TextureTransformer {
     void SetFile(BTA_File &f, int a, int fix, unsigned int u);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *, BTA_File &f, int a, int fix, unsigned int u);
+
 
 struct Platform {
     void UpdateModelPosAndRotY();
@@ -41,6 +47,12 @@ struct MovingMeshCollider {
     void SetFile(KCL_File *f, const Matrix4x3 &m, int fix, short sh,
                  CLPS_Block &b);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, KCL_File *f, const Matrix4x3 &m, int fix, short sh, CLPS_Block &b);
+
 
 extern "C" void func_020393c4(void *p, void *v);
 
@@ -105,9 +117,7 @@ int TtcConveyorBeltLarge::InitResources()
         *(BMD_File *)*(void **)((char *)data_ov065_0211d194[e].a + 4),
         *(BTA_File *)locbuf[e]);
 
-    ((TextureTransformer *)((char *)&mTextureTransformer))->SetFile(
-        *(BTA_File *)locbuf[mVariant],
-        0, 0x1000, 0);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj((TextureTransformer *)((char *)&mTextureTransformer), *(BTA_File *)locbuf[mVariant], 0, 0x1000, 0);
 
     ((Platform *)((char *)this))->UpdateModelPosAndRotY();
     ((Platform *)((char *)this))->UpdateClsnPosAndRot();
@@ -115,12 +125,7 @@ int TtcConveyorBeltLarge::InitResources()
     e = mVariant;
     kf = _ZN12MeshCollider8LoadFileER13SharedFilePtr(
         data_ov065_0211d198[e].a);
-    ((MovingMeshCollider *)((char *)&mMeshCollider))->SetFile(
-        (KCL_File *)kf,
-        *(Matrix4x3 *)((char *)&unk_2ec),
-        0x199,
-        mAngleY,
-        *(CLPS_Block *)data_ov065_0211d19c[e].a);
+    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((MovingMeshCollider *)((char *)&mMeshCollider), (KCL_File *)kf, *(Matrix4x3 *)((char *)&unk_2ec), 0x199, mAngleY, *(CLPS_Block *)data_ov065_0211d19c[e].a);
 
     func_020393c4(
         ((char *)this) + 0x124,

--- a/src/_ZN6BobOmb13InitResourcesEv.cpp
+++ b/src/_ZN6BobOmb13InitResourcesEv.cpp
@@ -23,10 +23,22 @@ struct ShadowModel {
 struct MovingCylinderClsn {
     void Init(Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
+
 struct WithMeshClsn {
     void Init(Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
     void StartDetectingWater();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *, Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
+
 extern "C" void func_ov102_0214c0b8(void* c);
 
 extern SharedFilePtr data_ov102_0214e9c0;
@@ -86,7 +98,7 @@ int BobOmb::InitResources()
     ((Obj*)this)->f3f5 = (unsigned char)(((Obj*)this)->f8 & 7);
     ((Obj*)this)->f3ec = 0x2000;
     func_ov102_0214c0b8(((Obj*)this));
-    ((MovingCylinderClsn*)&((Obj*)this)->f110)->Init((Actor*)((Obj*)this), 0x3c000, 0x50000, 0x200004, 0xa6d380);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)&((Obj*)this)->f110, (Actor*)((Obj*)this), 0x3c000, 0x50000, 0x200004, 0xa6d380);
     ((Obj*)this)->fa0 = -0x37000;
 
     if (((Obj*)this)->f3f5 == 2) {
@@ -110,7 +122,7 @@ int BobOmb::InitResources()
     ((Obj*)this)->f88 = 0x1000;
     ((Obj*)this)->f390 = 0;
     ((Obj*)this)->f3f2 = 0;
-    ((WithMeshClsn*)&((Obj*)this)->f144)->Init((Actor*)((Obj*)this), 0x32000, 0x32000, 0, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((WithMeshClsn*)&((Obj*)this)->f144, (Actor*)((Obj*)this), 0x32000, 0x32000, 0, 0);
     ((WithMeshClsn*)&((Obj*)this)->f144)->StartDetectingWater();
     ((Obj*)this)->f3f3 = 1;
     ((Obj*)this)->fc8 = 0;

--- a/src/_ZN6Camera6RenderEv.cpp
+++ b/src/_ZN6Camera6RenderEv.cpp
@@ -38,6 +38,12 @@ struct OamAttr;
 struct OAM {
     static void Render(bool, OamAttr *, int, int, int, int, int, int, int, int);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(bool, OamAttr *, int, int, int, int, int, int, int, int);
+
 struct G2x {
     static void SetBlendAlpha(volatile unsigned short *, u16, u16, u16, u16);
 };
@@ -45,6 +51,12 @@ struct G3i {
     static void PerspectiveW_(int, int, int, int, int, int, bool, Matrix4x3 *);
     static void LookAt_(const Vector3 *, const Vector3 *, const Vector3 *, bool, Matrix4x3 *);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(int, int, int, int, int, int, bool, Matrix4x3 *);
+
 
 struct View {
     int render();
@@ -84,14 +96,14 @@ int Camera::Render()
         s32 f = *(s32 *)((char *)self + 0x154);
         if (!(f & 8)) {
             if (*(u8 **)((char *)self + 0x13c) == &data_0208738c) {
-                OAM::Render(0, (OamAttr *)&data_ov002_0210c3b0, 0x80, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
+                _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (OamAttr *)&data_ov002_0210c3b0, 0x80, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
                 G2x::SetBlendAlpha((volatile unsigned short *)0x04000050, 0x10, 0x2f, 0xc, 6);
             } else {
                 if (f & 0x20) {
-                    OAM::Render(0, (OamAttr *)data_ov002_0210c3e0[0], 0x14, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
+                    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (OamAttr *)data_ov002_0210c3e0[0], 0x14, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
                 }
                 if (*(s32 *)((char *)self + 0x154) & 0x40) {
-                    OAM::Render(0, (OamAttr *)data_ov002_0210c3e0[1], 0xec, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
+                    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (OamAttr *)data_ov002_0210c3e0[1], 0xec, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
                 }
             }
             s32 t = *(s32 *)((char *)self + 0x168);
@@ -138,13 +150,7 @@ int Camera::Render()
     }
 
     s32 idx = ((s32)(u16)sp18 >> 4) * 2;
-    G3i::PerspectiveW_(
-        data_02082214[idx],
-        data_02082214[idx + 1],
-        *(s32 *)((char *)self + 0xf8),
-        *(s32 *)((char *)self + 0xfc),
-        *(s32 *)((char *)self + 0x100),
-        var_r6, 1, (Matrix4x3 *)0);
+    _ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(data_02082214[idx], data_02082214[idx + 1], *(s32 *)((char *)self + 0xf8), *(s32 *)((char *)self + 0xfc), *(s32 *)((char *)self + 0x100), var_r6, 1, (Matrix4x3 *)0);
 
     {
         s32 s2 = (s32)(sp[2] + 4) >> 3;

--- a/src/_ZN6Coffin13InitResourcesEv.cpp
+++ b/src/_ZN6Coffin13InitResourcesEv.cpp
@@ -25,6 +25,12 @@ struct MeshCollider {
 struct MovingMeshCollider {
     int SetFile(KCL_File* f, const Matrix4x3& m, Fix12 s, short n, CLPS_Block& c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, KCL_File* f, const Matrix4x3& m, Fix12 s, short n, CLPS_Block& c);
+
 struct Platform {
     void UpdateClsnPosAndRot();
 };
@@ -71,9 +77,7 @@ int Coffin::InitResources()
     mPosZ = res.z;
     func_ov071_02122080(((char*)this));
     ((Platform*)((char*)this))->UpdateClsnPosAndRot();
-    ((MovingMeshCollider*)((char*)&mMeshCollider))->SetFile(
-        MeshCollider::LoadFile(data_ov071_021230d8),
-        *(Matrix4x3*)((char*)&unk_2ec), 0x199, mAngleY, data_ov063_0211ebd8);
+    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((MovingMeshCollider*)((char*)&mMeshCollider), MeshCollider::LoadFile(data_ov071_021230d8), *(Matrix4x3*)((char*)&unk_2ec), 0x199, mAngleY, data_ov063_0211ebd8);
     func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     return 1;
 }

--- a/src/_ZN6Player12St_Land_InitEv.cpp
+++ b/src/_ZN6Player12St_Land_InitEv.cpp
@@ -6,6 +6,12 @@ public:
     int IsAnim(unsigned int anim);
     void SetAnim(unsigned int animID, int a, int b, unsigned int c);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN6Player7SetAnimEji5Fix12IiEj(void *, unsigned int animID, int a, int b, unsigned int c);
+
 
 extern "C" {
     void func_ov002_020c2f64(void* c);
@@ -66,7 +72,7 @@ int Player::St_Land_Init()
         r1 = 0x52;
     }
 
-    SetAnim(r1, 0x40000000, 0x1000, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(this, r1, 0x40000000, 0x1000, 0);
 
     int idx = ((unsigned char*)&data_020a0e40)[0];
     short sval = *(short*)((char*)&data_0209f4a0 + idx * 0x18);

--- a/src/_ZN6Player17St_WindCarry_MainEv.cpp
+++ b/src/_ZN6Player17St_WindCarry_MainEv.cpp
@@ -7,6 +7,13 @@ struct Player {
     int SetAnim(unsigned int a, int b, Fix12i c, unsigned int d);
     int FinishedAnim();
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN6Player11ChangeStateERNS_5StateE(void *, State& st);
+extern "C" int _ZN6Player7SetAnimEji5Fix12IiEj(void *, unsigned int a, int b, Fix12i c, unsigned int d);
+
 
 extern "C" void func_ov002_020c2f64(void* c);
 extern "C" void func_ov002_020e28d4(void* c, int a, int b);
@@ -21,8 +28,8 @@ int Player::St_WindCarry_Main()
 
     if (*(u8*)(c + 0x6de) == 0) {
         func_ov002_020c2f64(c);
-        ChangeState(data_ov002_021105bc);
-        SetAnim(0x43, 0x40000000, 0x1000, 0);
+        _ZN6Player11ChangeStateERNS_5StateE(this, data_ov002_021105bc);
+        _ZN6Player7SetAnimEji5Fix12IiEj(this, 0x43, 0x40000000, 0x1000, 0);
         *(int*)(c + 0xa8) = 0;
         return 1;
     }
@@ -45,7 +52,7 @@ int Player::St_WindCarry_Main()
     }
 
     if (*(u8*)(c + 0x6e3) == 0 && FinishedAnim() != 0) {
-        SetAnim(0x73, 0, 0x1000, 0);
+        _ZN6Player7SetAnimEji5Fix12IiEj(this, 0x73, 0, 0x1000, 0);
         {
             u8* q = (u8*)(((int)c + 0x6e3));
             *q = *q + 1;

--- a/src/_ZN9WaterBomb13InitResourcesEv.cpp
+++ b/src/_ZN9WaterBomb13InitResourcesEv.cpp
@@ -20,9 +20,21 @@ struct ShadowModel {
 struct MovingCylinderClsn {
     void Init(Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
+
 struct WithMeshClsn {
     void Init(Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *, Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
+
 
 extern SharedFilePtr data_ov002_0210da38;
 extern SharedFilePtr data_ov098_0213c91c;
@@ -88,16 +100,16 @@ int WaterBomb::InitResources()
             ((Obj*)this)->f80 = 0x800;
             ((Obj*)this)->f84 = 0x800;
             ((Obj*)this)->f88 = 0x800;
-            ((MovingCylinderClsn*)&((Obj*)this)->f110)->Init((Actor*)((Obj*)this), 0x14000, 0x28000, 0x200004, 0);
-            ((WithMeshClsn*)&((Obj*)this)->f144)->Init((Actor*)((Obj*)this), 0x1e000, 0x1e000, 0, 0);
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)&((Obj*)this)->f110, (Actor*)((Obj*)this), 0x14000, 0x28000, 0x200004, 0);
+            _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((WithMeshClsn*)&((Obj*)this)->f144, (Actor*)((Obj*)this), 0x1e000, 0x1e000, 0, 0);
         }
         else
         {
             ((Obj*)this)->f80 = 0x1000;
             ((Obj*)this)->f84 = 0x1000;
             ((Obj*)this)->f88 = 0x1000;
-            ((MovingCylinderClsn*)&((Obj*)this)->f110)->Init((Actor*)((Obj*)this), 0x28000, 0x50000, 0x204004, 0);
-            ((WithMeshClsn*)&((Obj*)this)->f144)->Init((Actor*)((Obj*)this), 0x32000, 0x32000, 0, 0);
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)&((Obj*)this)->f110, (Actor*)((Obj*)this), 0x28000, 0x50000, 0x204004, 0);
+            _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((WithMeshClsn*)&((Obj*)this)->f144, (Actor*)((Obj*)this), 0x32000, 0x32000, 0, 0);
         }
     }
 

--- a/src/func_ov006_020cb030.cpp
+++ b/src/func_ov006_020cb030.cpp
@@ -6,6 +6,12 @@ struct Animation { void Advance(); };
 struct System {
     static System* New(unsigned, unsigned, Fix12, Fix12, Fix12, const Vector3_16f*, Callback*);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" System* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned, unsigned, Fix12, Fix12, Fix12, const Vector3_16f*, Callback*);
+
 extern "C" {
 /* The ROM's relocation at 0x020cb088 targets 0x020cb134, not 0x020c9024.
    The byte gate could not object: a bl is a relocation, which match.py
@@ -38,10 +44,7 @@ extern "C" void func_ov006_020cb030(char *o) {
     Fix12 v = (Fix12)(((long long)*(int*)(o + 0x44) * 0xb4b + 0x800) >> 12);
     if (*(int*)(o + 0x38) > v) {
         if (*(int*)(o + 0xcc) == data_ov006_0214059c) {
-            *(int*)(o + 0x54) = (int)System::New(
-                *(int*)(o + 0x54), 0xf5,
-                *(int*)(o + 0x1c) << 3, *(int*)(o + 0x20) << 3,
-                *(int*)(o + 0x24) << 3, 0, 0);
+            *(int*)(o + 0x54) = (int)_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(int*)(o + 0x54), 0xf5, *(int*)(o + 0x1c) << 3, *(int*)(o + 0x20) << 3, *(int*)(o + 0x24) << 3, 0, 0);
         }
     }
     func_ov006_020cafdc(o);

--- a/src/func_ov006_020cecc0.cpp
+++ b/src/func_ov006_020cecc0.cpp
@@ -6,6 +6,12 @@ void func_ov006_020cecb4(int *p);
 struct ModelBase { void SetFile(BMD_File*, int, int); };
 struct Model : ModelBase { void SetPolygonID(int); };
 struct TextureTransformer { static void Prepare(BMD_File&, BTA_File&); void SetFile(BTA_File&, int, int, unsigned int); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *, BTA_File&, int, int, unsigned int);
+
 
 struct data_t { int a; BMD_File* f; };
 extern data_t data_ov006_02140850;
@@ -22,6 +28,6 @@ extern "C" void func_ov006_020cecc0(char* c)
     ((Model*)(c+0xf0))->SetPolygonID(2);
     ((Model*)(c+0x140))->SetPolygonID(3);
     TextureTransformer::Prepare(*data_ov006_02140850.f, data_ov006_0213b3a4);
-    ((TextureTransformer*)(c+0x194))->SetFile(data_ov006_0213b3a4, 0, 0x1000, 0);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj((TextureTransformer*)(c+0x194), data_ov006_0213b3a4, 0, 0x1000, 0);
     func_ov006_020cecb4((int*)c);
 }

--- a/src/func_ov022_02111bdc.cpp
+++ b/src/func_ov022_02111bdc.cpp
@@ -20,6 +20,12 @@ struct MeshCollider { static KCL_File *LoadFile(SharedFilePtr &p); };
 struct MovingMeshCollider {
     void SetFile(KCL_File *f, const Matrix4x3 &m, Fix12 a, short b, CLPS_Block &cb);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, KCL_File *f, const Matrix4x3 &m, Fix12 a, short b, CLPS_Block &cb);
+
 
 extern SharedFilePtr data_ov022_02114580;
 extern SharedFilePtr data_ov022_02114578;
@@ -35,7 +41,7 @@ extern "C" int func_ov022_02111bdc(char *c)
     func_ov022_02111a1c(c);
     ((Platform *)c)->UpdateClsnPosAndRot();
     KCL_File *k = MeshCollider::LoadFile(data_ov022_02114578);
-    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov064_0211bb2c);
+    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((MovingMeshCollider *)(c + 0x124), k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov064_0211bb2c);
     func_020393d4((int *)(c + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     self->unk_31f = 0;
     self->unk_31e = 0xf;

--- a/src/func_ov022_02111ea0.cpp
+++ b/src/func_ov022_02111ea0.cpp
@@ -20,6 +20,12 @@ struct MeshCollider { static KCL_File *LoadFile(SharedFilePtr &p); };
 struct MovingMeshCollider {
     void SetFile(KCL_File *f, const Matrix4x3 &m, Fix12 a, short b, CLPS_Block &cb);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, KCL_File *f, const Matrix4x3 &m, Fix12 a, short b, CLPS_Block &cb);
+
 
 extern SharedFilePtr data_ov022_021145a8;
 extern SharedFilePtr data_ov022_021145a0;
@@ -35,7 +41,7 @@ extern "C" int func_ov022_02111ea0(char *c)
     func_ov022_02111d48(c);
     ((Platform *)c)->UpdateClsnPosAndRot();
     KCL_File *k = MeshCollider::LoadFile(data_ov022_021145a0);
-    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov064_0211bacc);
+    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((MovingMeshCollider *)(c + 0x124), k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov064_0211bacc);
     func_020393d4((int *)(c + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     self->unk_31e = -0x10;
     return 1;

--- a/src/func_ov036_0211137c.cpp
+++ b/src/func_ov036_0211137c.cpp
@@ -18,6 +18,12 @@ struct MeshCollider { static KCL_File *LoadFile(SharedFilePtr &p); };
 struct MovingMeshCollider {
     void SetFile(KCL_File *f, const Matrix4x3 &m, Fix12 a, short b, CLPS_Block &cb);
 };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, KCL_File *f, const Matrix4x3 &m, Fix12 a, short b, CLPS_Block &cb);
+
 
 extern SharedFilePtr data_ov036_02114028;
 extern SharedFilePtr data_ov036_02114020;
@@ -35,7 +41,7 @@ extern "C" int func_ov036_0211137c(char *c)
     func_ov036_0211123c(c);
     ((Platform *)c)->UpdateClsnPosAndRot();
     KCL_File *k = MeshCollider::LoadFile(data_ov036_02114020);
-    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov036_02112b68);
+    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((MovingMeshCollider *)(c + 0x124), k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov036_02112b68);
     func_020393d4((int *)(c + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     return 1;
 }

--- a/src/func_ov064_02116ec0.cpp
+++ b/src/func_ov064_02116ec0.cpp
@@ -11,9 +11,27 @@ struct Animation { static void* LoadFile(SharedFilePtr& f); };
 struct Model { static BMD_File* LoadFile(SharedFilePtr& f); };
 struct ModelBase { int SetFile(BMD_File* f, int a, int b); };
 struct ModelAnim { void SetAnim(BCA_File* f, int a, Fix12 t, unsigned int u); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File* f, int a, Fix12 t, unsigned int u);
+
 struct ShadowModel { int InitCylinder(); };
 struct MovingCylinderClsn { void Init(Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
+
 struct WithMeshClsn { void Init(Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e); };
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *, Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
+
 
 struct Desc {
     SharedFilePtr* f0;
@@ -65,8 +83,8 @@ extern "C" int func_ov064_02116ec0(Obj* obj)
         return 0;
     if (((ShadowModel*)&obj->f370)->InitCylinder() == 0)
         return 0;
-    ((ModelAnim*)&obj->f110)->SetAnim((BCA_File*)obj->f330->f10->file, 0, 0x1000, 0);
-    ((MovingCylinderClsn*)&obj->f33c)->Init((Actor*)obj, obj->f330->f14, obj->f330->f18, 0x200000, 0x27c0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)&obj->f110, (BCA_File*)obj->f330->f10->file, 0, 0x1000, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)&obj->f33c, (Actor*)obj, obj->f330->f14, obj->f330->f18, 0x200000, 0x27c0);
     {
         int b = (obj->fc == 0xd9);
         if (b) {
@@ -84,7 +102,7 @@ extern "C" int func_ov064_02116ec0(Obj* obj)
     obj->f3e8 = obj->f330->f1c;
     obj->f3ec = obj->f330->f20;
     obj->f100 = 0;
-    ((WithMeshClsn*)&obj->f174)->Init((Actor*)obj, obj->f330->f24, obj->f330->f24, 0, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((WithMeshClsn*)&obj->f174, (Actor*)obj, obj->f330->f24, obj->f330->f24, 0, 0);
     obj->f3f0 = obj->f330->f28;
     obj->f338 = 0;
     obj->f334 = obj->f338;

--- a/tools/demember_calls.py
+++ b/tools/demember_calls.py
@@ -204,7 +204,12 @@ def split_args(s):
 
 
 def find_call(text, method, start=0):
-    """Locate `->method(...)` or `.method(...)`; (recv, args, span, op) or None."""
+    """Locate `->method(...)` or `.method(...)`; (recv, args, span, op) or None.
+
+    Deliberately NOT class-aware: it finds the next call spelled with this NAME,
+    whichever object it is called on. Attributing that call to a declaring class
+    is `receiver_class`'s job and the caller's decision -- see the replacement
+    pass, which will not rewrite a call it cannot attribute."""
     for m in re.finditer(r"(->|\.)" + re.escape(method) + r"\s*\(", text[start:]):
         op_at = start + m.start()
         open_at = start + m.end() - 1
@@ -254,16 +259,21 @@ KEYWORD_BEFORE_CALL = {"return", "else", "case", "do"}
 
 
 def find_static_call(text, method, start=0):
-    """Locate `Qual::...::method(...)`; (args, span) or None.
+    """Locate `Qual::...::method(...)`; (owner, args, span) or None.
+
+    `owner` is the LAST qualifier component -- the class or namespace the call
+    names -- so the caller can check the call belongs to the declaration it is
+    about to rewrite. `A::run()` and `B::run()` are different symbols.
 
     A qualified name preceded by a type token (`System* System::New(..)`, or the
     struct-local `static System* New(..)`) is a DECLARATION, not a call; touching
     it would redeclare the free symbol with the method's parameter list. Skip
     any occurrence whose preceding token is `*`, `&`, or an identifier other
     than a statement keyword."""
-    for m in re.finditer(r"(?:[A-Za-z_]\w*\s*::\s*)+" + re.escape(method) + r"\s*\(",
+    for m in re.finditer(r"((?:[A-Za-z_]\w*\s*::\s*)+)" + re.escape(method) + r"\s*\(",
                          text[start:]):
         s = start + m.start()
+        owner = re.findall(r"[A-Za-z_]\w*", m.group(1))[-1]
         open_at = start + m.end() - 1
         k = s
         while k > 0 and text[k - 1] in " \t\r\n":
@@ -287,8 +297,45 @@ def find_static_call(text, method, start=0):
             i += 1
         if i >= len(text):
             continue
-        return split_args(text[open_at + 1:i]), (s, i + 1)
+        return owner, split_args(text[open_at + 1:i]), (s, i + 1)
     return None
+
+
+def _unwrap(expr):
+    """`expr` less ONE balanced outer paren layer, if it is wrapped in one.
+
+    `(a) + (b)` starts and ends with a paren without being wrapped in one, so
+    the depth has to come back to zero at the last character and nowhere
+    earlier."""
+    expr = expr.strip()
+    if not (expr.startswith("(") and expr.endswith(")")):
+        return expr
+    depth = 0
+    for i, ch in enumerate(expr):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                break
+    return expr[1:-1].strip() if i == len(expr) - 1 else expr
+
+
+# The cast that says what a receiver IS: `((Actor*)self)->` names Actor. Only a
+# pointer cast counts -- `->` on a non-pointer would not compile.
+_RECV_CAST = re.compile(r"^\(\s*(?:const\s+|volatile\s+|struct\s+|class\s+)*"
+                        r"([A-Za-z_]\w*(?:\s*::\s*[A-Za-z_]\w*)*)\s*\*+\s*\)")
+
+
+def receiver_class(recv):
+    """The class named by the receiver's outermost cast, or None if it says nothing.
+
+    `((Actor*)self)` -> "Actor"; `((Actor*)((char*)c + 0x108))` -> "Actor" (the
+    OUTERMOST cast is the receiver's type, the inner one is address arithmetic);
+    a bare `self` or `obj->field` -> None, because the file does not say there
+    what type it is."""
+    m = _RECV_CAST.match(_unwrap(recv))
+    return re.findall(r"[A-Za-z_]\w*", m.group(1))[-1] if m else None
 
 
 def receiver_expr(recv, op):
@@ -299,19 +346,75 @@ def receiver_expr(recv, op):
     stripping casts is how `(ModelAnim*)((char*)c + 0x108)` once became
     `c + 0x108`, which is a different address. A `.` call's receiver is an
     object, so its address is taken instead."""
-    expr = recv.strip()
-    if expr.startswith("(") and expr.endswith(")"):
-        depth = 0
-        for i, ch in enumerate(expr):
-            if ch == "(":
-                depth += 1
-            elif ch == ")":
-                depth -= 1
-                if depth == 0:
-                    break
-        if i == len(expr) - 1:
-            expr = expr[1:-1].strip()
+    expr = _unwrap(recv)
     return f"&({expr})" if op == "." else expr
+
+
+def rewrite_calls(text, todo):
+    """Point every call site of each `todo` method at its ROM symbol.
+
+    `todo` is a list of `(method, target, is_static, cls, ambiguous)`. Returns
+    `(new_text, n_rewritten, None)`, or `(text, 0, reason)` if the file must not
+    be touched at all.
+
+    Two obligations, and the second is the one with teeth:
+
+    EVERY call site of `cls::method` must go. One left behind still references
+    the mangled name the ROM does not define, so the file stays unresolvable and
+    the edit is pure churn.
+
+    NO call site of anyone else's method may go with it. A call is a relocation,
+    and `match.compare` wildcards every relocated word, so redirecting the wrong
+    call still byte-matches -- the gate downstream is blind, by construction, to
+    this pass being wrong, and so this pass has to be right by construction.
+    Concretely, in `func_ov022_02111bdc.cpp` both `ModelBase::SetFile` and
+    `MovingMeshCollider::SetFile` are declared and called; only the latter is
+    missing from the ROM, and the former is four lines earlier. Rewriting "the
+    next call spelled SetFile" sends a working call to a different function.
+
+    So a call is rewritten only where the source says which class it belongs to:
+    a qualified call names it outright, an instance call names it in the
+    receiver's cast. Where the name is declared only once in the file the
+    receiver need not repeat it, there being nothing else it could mean; where it
+    is declared more than once, a receiver that names nothing is not evidence and
+    the whole file is left alone."""
+    orig, n = text, 0
+    for method, target, is_static, cls, ambiguous in todo:
+        pos, replaced, unattributed = 0, 0, 0
+        while True:
+            if is_static:
+                hit = find_static_call(text, method, pos)
+                if hit is None:
+                    break
+                owner, cargs, (s, e) = hit
+                if owner != cls:
+                    pos = e              # `Other::method(..)` is a different symbol
+                    continue
+                call = f"{target}({', '.join(cargs)})"
+            else:
+                hit = find_call(text, method, pos)
+                if hit is None:
+                    break
+                recv, cargs, (s, e), op = hit
+                rc = receiver_class(recv)
+                if rc is not None and rc != cls:
+                    pos = e              # cast to something else: not this method
+                    continue
+                if rc is None and ambiguous:
+                    unattributed += 1
+                    pos = e
+                    continue
+                call = f"{target}({', '.join([receiver_expr(recv, op)] + cargs)})"
+            text = text[:s] + call + text[e:]
+            pos = s + len(call)
+            replaced += 1
+        if unattributed:
+            return orig, 0, (f"ambiguous: {method} is declared more than once and "
+                             f"{unattributed} call site(s) do not name a class")
+        if replaced == 0:
+            return orig, 0, "call site not in a recognised shape"
+        n += replaced
+    return text, n, None
 
 
 COMMENT = ('/* Signature deliberately copied from the local declaration above: the\n'
@@ -414,13 +517,19 @@ def main():
         todo, inserts = [], collections.defaultdict(list)
         for sym, target in real.items():
             cls, method = decode(sym)
-            if len(re.findall(_decl_re(method), text)) > 1:
-                return rel, "method name declared in more than one local class", 0
             sig = method_decl(text, cls, method)
             if sig is None:
                 return rel, "local declaration not found/parsed", 0
             ret, params, at, is_static, qual = sig
-            todo.append((method, f"{qual}::{target}" if qual else target, is_static))
+            # Is this NAME declared more than once in the file? If it is, a call
+            # spelled `p->method(..)` does not say which declaration it means, and
+            # the replacement pass below demands the receiver name a class. The
+            # count is textual and so over-cautious by design: it can only ask for
+            # more evidence, never less. (`method_decl` above is class-scoped, so
+            # the DECLARATION lookup was never the ambiguous half.)
+            ambiguous = len(re.findall(_decl_re(method), text)) > 1
+            todo.append((method, f"{qual}::{target}" if qual else target,
+                         is_static, cls, ambiguous))
             if target not in text:
                 # A static method has no receiver; an instance method's becomes
                 # a leading void*.
@@ -436,30 +545,10 @@ def main():
                 blob = blob.replace("\n", "\r\n")
             new = new[:at] + blob + new[at:]
 
-        # Pass 2: EVERY call site must go -- one left behind still references the
-        # nonexistent mangled name and the file stays unresolvable.
-        n = 0
-        for method, target, is_static in todo:
-            pos, replaced = 0, 0
-            while True:
-                if is_static:
-                    hit = find_static_call(new, method, pos)
-                    if hit is None:
-                        break
-                    cargs, (s, e) = hit
-                    call = f"{target}({', '.join(cargs)})"
-                else:
-                    hit = find_call(new, method, pos)
-                    if hit is None:
-                        break
-                    recv, cargs, (s, e), op = hit
-                    call = f"{target}({', '.join([receiver_expr(recv, op)] + cargs)})"
-                new = new[:s] + call + new[e:]
-                pos = s + len(call)
-                replaced += 1
-            if replaced == 0:
-                return rel, "call site not in a recognised shape", 0
-            n += replaced
+        # Pass 2 -- see rewrite_calls.
+        new, n, why = rewrite_calls(new, todo)
+        if why is not None:
+            return rel, why, 0
 
         if n == 0 or new == text:
             return rel, "call site not in a recognised shape", 0

--- a/tools/demember_calls.py
+++ b/tools/demember_calls.py
@@ -301,6 +301,95 @@ def find_static_call(text, method, start=0):
     return None
 
 
+def member_bodies(text, cls):
+    """Spans of the body of every `cls::name(..) { .. }` definition in `text`.
+
+    Only a definition whose `)` is followed directly by `{`. That excludes a
+    declaration (`;`), a const member function (`this` would be `const cls*`,
+    which does not convert to the `void*` receiver), and a constructor with an
+    initialiser list -- none of which this tool has any business rewriting."""
+    out = []
+    for m in re.finditer(r"\b" + re.escape(cls) + r"\s*::\s*~?[A-Za-z_]\w*\s*\(", text):
+        depth, i = 0, m.end() - 1
+        while i < len(text):
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        if i >= len(text):
+            continue
+        j = i + 1
+        while j < len(text) and text[j] in " \t\r\n":
+            j += 1
+        if j >= len(text) or text[j] != "{":
+            continue
+        depth, k = 0, j
+        while k < len(text):
+            if text[k] == "{":
+                depth += 1
+            elif text[k] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            k += 1
+        out.append((j, min(k + 1, len(text))))
+    return out
+
+
+def find_implicit_call(text, method, cls, start=0):
+    """Locate an unqualified `method(...)` inside a member function of `cls`.
+
+    (args, span) or None. This is the shape the corpus spells when the file IS a
+    member of the class -- `Player::St_Land_Init` calling its sibling `SetAnim(..)`
+    with no receiver at all, which no amount of looking for `->` will find.
+
+    Attribution here is the strongest of the three, and comes from the language
+    rather than from a cast: inside `cls::f() { .. }` an unqualified `method` is
+    found in class scope, which is searched before namespace scope, so it IS
+    `this->method(..)` and a free function of the same name is hidden. That is
+    also why nothing outside such a body is ever considered -- and why the
+    declaration inside `struct cls { .. }` cannot be mistaken for a call."""
+    bodies = member_bodies(text, cls)
+    if not bodies:
+        return None
+    for m in re.finditer(r"(?<![\w.])" + re.escape(method) + r"\s*\(", text[start:]):
+        s = start + m.start()
+        if not any(a <= s < b for a, b in bodies):
+            continue
+        k = s
+        while k > 0 and text[k - 1] in " \t\r\n":
+            k -= 1
+        # `->m(`, `.m(` and `Q::m(` belong to the other two finders; a preceding
+        # `*`, `&` or identifier is a declaration, not a call.
+        if k >= 2 and text[k - 2:k] in ("->", "::"):
+            continue
+        if k >= 1 and text[k - 1] in ".*&":
+            continue
+        if k >= 1 and (text[k - 1].isalnum() or text[k - 1] == "_"):
+            w = k
+            while w > 0 and (text[w - 1].isalnum() or text[w - 1] == "_"):
+                w -= 1
+            if text[w:k] not in KEYWORD_BEFORE_CALL:
+                continue
+        open_at = start + m.end() - 1
+        depth, i = 0, open_at
+        while i < len(text):
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        if i >= len(text):
+            continue
+        return split_args(text[open_at + 1:i]), (s, i + 1)
+    return None
+
+
 def _unwrap(expr):
     """`expr` less ONE balanced outer paren layer, if it is wrapped in one.
 
@@ -374,7 +463,8 @@ def rewrite_calls(text, todo):
 
     So a call is rewritten only where the source says which class it belongs to:
     a qualified call names it outright, an instance call names it in the
-    receiver's cast. Where the name is declared only once in the file the
+    receiver's cast, and an unqualified call inside `cls::f() { .. }` is named by
+    the function it sits in. Where the name is declared only once in the file the
     receiver need not repeat it, there being nothing else it could mean; where it
     is declared more than once, a receiver that names nothing is not evidence and
     the whole file is left alone."""
@@ -411,6 +501,21 @@ def rewrite_calls(text, todo):
         if unattributed:
             return orig, 0, (f"ambiguous: {method} is declared more than once and "
                              f"{unattributed} call site(s) do not name a class")
+        # ... and the same method called with no receiver at all, from inside a
+        # member function of its own class. A separate sweep rather than a third
+        # branch above: the two shapes are independent, and an explicit rewrite
+        # leaves nothing an unqualified search could pick up by mistake.
+        if not is_static:
+            pos = 0
+            while True:
+                hit = find_implicit_call(text, method, cls, pos)
+                if hit is None:
+                    break
+                cargs, (s, e) = hit
+                call = f"{target}({', '.join(['this'] + cargs)})"
+                text = text[:s] + call + text[e:]
+                pos = s + len(call)
+                replaced += 1
         if replaced == 0:
             return orig, 0, "call site not in a recognised shape"
         n += replaced

--- a/tools/test_demember_calls.py
+++ b/tools/test_demember_calls.py
@@ -166,6 +166,67 @@ def test_a_call_that_never_matched_still_stops_the_file():
     assert new == src
 
 
+# ------------------------------------------------------- the implicit-`this` shape
+
+# src/_ZN6Player12St_Land_InitEv.cpp in miniature: the file IS a Player member, and
+# calls its sibling with no receiver at all.
+IMPLICIT = """\
+struct Player {
+    int St_Land_Init();
+    int IsAnim(unsigned int anim);
+    void SetAnim(unsigned int a, int b, int c, unsigned int d);
+};
+void SetAnim(int wrong);
+int Player::St_Land_Init()
+{
+    SetAnim(0x52, 0x40000000, 0x1000, 0);
+    return IsAnim(0x2b);
+}
+"""
+
+
+def test_an_unqualified_sibling_call_is_found():
+    new, n, why = D.rewrite_calls(IMPLICIT, [("SetAnim", "_ZN6PlayerE_", False,
+                                              "Player", True)])
+    assert why is None and n == 1, (n, why)
+    assert "_ZN6PlayerE_(this, 0x52, 0x40000000, 0x1000, 0);" in new
+    # The free `void SetAnim(int wrong);` is a DECLARATION outside any member body.
+    assert "void SetAnim(int wrong);" in new
+
+
+def test_nothing_outside_a_member_body_is_touched():
+    """The struct's own declaration of the method sits in no member body, and a
+    call in an unrelated function is not this class's."""
+    src = """\
+struct Player { void SetAnim(unsigned int a); };
+void elsewhere(void *p) { SetAnim(1); }
+"""
+    new, n, why = D.rewrite_calls(src, [("SetAnim", "_ZN6PlayerE_", False,
+                                         "Player", False)])
+    assert n == 0 and why == "call site not in a recognised shape"
+    assert new == src
+
+
+def test_member_bodies_skips_declarations_and_const_members():
+    """A `const` member's `this` is a `const Player*` and does not convert to the
+    void* receiver, so those bodies are not offered up in the first place."""
+    assert D.member_bodies("int Player::f();\n", "Player") == []
+    assert D.member_bodies("int Player::f() const { g(); }\n", "Player") == []
+    assert len(D.member_bodies("int Player::f() { g(); }\n", "Player")) == 1
+
+
+def test_an_implicit_and_an_explicit_call_of_the_same_method_both_go():
+    src = """\
+struct Player { void SetAnim(unsigned int a); };
+int Player::f() { SetAnim(1); ((Player*)other)->SetAnim(2); return 0; }
+"""
+    new, n, why = D.rewrite_calls(src, [("SetAnim", "_ZN6PlayerE_", False,
+                                         "Player", False)])
+    assert why is None and n == 2, (n, why)
+    assert "_ZN6PlayerE_(this, 1)" in new and "_ZN6PlayerE_((Player*)other, 2)" in new
+    assert "SetAnim(" not in new.split("struct Player")[1].split("};")[1]
+
+
 def test_a_dot_call_still_passes_the_address():
     src = "struct A { int run(int); };\nvoid f(A a) { a.run(1); }\n"
     new, n, why = D.rewrite_calls(src, [("run", "_ZN1A3runE_", False, "A", False)])

--- a/tools/test_demember_calls.py
+++ b/tools/test_demember_calls.py
@@ -1,0 +1,186 @@
+"""A rewrite that redirects a call cannot be checked by comparing bytes.
+
+`demember_calls.py` changes WHICH SYMBOL a call resolves to. A call is a
+relocation and `match.compare` wildcards every relocated word, so sending a call
+to the wrong function compares clean -- the byte gate is blind, by construction,
+to the one thing this tool edits. `build_pin.verify` closes most of that with a
+reloc-destination check, but only for the function being verified; the pass that
+CHOOSES call sites has to be right on its own.
+
+It was not. `find_call` matches the next call spelled with a given NAME, on any
+object at all, and files routinely declare the same name in two local classes:
+
+    struct ModelBase          { int SetFile(BMD_File*, int, int); };
+    struct MovingMeshCollider { int SetFile(KCL_File*, ...); };
+
+Only the second is missing from the ROM. A guard bailed out of any file where
+the name occurred twice, which was safe and blocked eleven files. These tests
+cover what replaced it: attribute the call to a class, then rewrite only that
+class's. Everything here is text in, text out -- no compiler, no ROM.
+"""
+import pathlib
+import sys
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOLS))
+
+import demember_calls as D     # noqa: E402
+
+
+# ------------------------------------------------------------- attributing a receiver
+
+def test_receiver_class_reads_the_cast():
+    assert D.receiver_class("((Actor*)self)") == "Actor"
+    assert D.receiver_class("((Actor *) self)") == "Actor"
+    assert D.receiver_class("((MovingMeshCollider *)(c + 0x124))") == "MovingMeshCollider"
+    assert D.receiver_class("((const Actor*)self)") == "Actor"
+    assert D.receiver_class("((struct Actor*)self)") == "Actor"
+    assert D.receiver_class("((Ns::Actor*)self)") == "Actor"
+    assert D.receiver_class("((Actor**)self)") == "Actor"
+
+
+def test_the_outermost_cast_is_the_receivers_type():
+    """`((ModelAnim*)((char*)c + 0x108))` is a ModelAnim. The inner cast is
+    address arithmetic and naming it would attribute the call to `char`."""
+    assert D.receiver_class("((ModelAnim*)((char*)c + 0x108))") == "ModelAnim"
+    assert D.receiver_class("((WithMeshClsn*)&((Obj*)this)->f144)") == "WithMeshClsn"
+
+
+def test_a_receiver_that_names_nothing_is_not_evidence():
+    for recv in ("self", "obj->field", "o", "arr[i]", "(*(Actor**)x)", "this"):
+        assert D.receiver_class(recv) is None, recv
+
+
+def test_unwrap_does_not_mistake_two_groups_for_one():
+    """`(a) + (b)` starts and ends with a paren without being wrapped in one."""
+    assert D._unwrap("((Actor*)self)") == "(Actor*)self"
+    assert D._unwrap("(a) + (b)") == "(a) + (b)"
+    assert D._unwrap("self") == "self"
+
+
+def test_find_static_call_reports_the_owner():
+    src = "  OAM::Render(0, 1);\n  View::Render();\n"
+    owner, args, _ = D.find_static_call(src, "Render")
+    assert owner == "OAM" and args == ["0", "1"]
+    owner, _, _ = D.find_static_call(src, "Render", src.index("View"))
+    assert owner == "View"
+    # A qualified name preceded by a type token is a definition, not a call.
+    assert D.find_static_call("System* System::New(unsigned a) { return 0; }", "New") is None
+
+
+# ------------------------------------------------- the property the guard used to buy
+
+# src/func_ov022_02111bdc.cpp in miniature, including the ordering that matters:
+# the call that must NOT move comes first, so "rewrite the next SetFile" is wrong.
+TWO_CLASSES = """\
+struct ModelBase { int SetFile(BMD_File *f, int a, int b); };
+struct MovingMeshCollider { int SetFile(KCL_File *f, const Matrix4x3 &m, int c); };
+
+void f(char *c) {
+    ((ModelBase *)(c + 0xd4))->SetFile(f, 1, -1);
+    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000);
+}
+"""
+
+
+def test_only_the_named_classs_calls_are_rewritten():
+    todo = [("SetFile", "_ZN18MovingMeshCollider7SetFileE_", False,
+             "MovingMeshCollider", True)]
+    new, n, why = D.rewrite_calls(TWO_CLASSES, todo)
+    assert why is None and n == 1, (n, why)
+    assert "((ModelBase *)(c + 0xd4))->SetFile(f, 1, -1);" in new, \
+        "a working call to a different class's method was redirected"
+    assert "_ZN18MovingMeshCollider7SetFileE_((MovingMeshCollider *)(c + 0x124)," in new
+    assert "->SetFile" not in new.split("MovingMeshCollider *)(c + 0x124)")[1]
+
+
+def test_two_classes_of_the_same_name_go_to_two_different_symbols():
+    """src/_ZN9WaterBomb13InitResourcesEv.cpp: `Init` on MovingCylinderClsn and on
+    WithMeshClsn, interleaved. Sending all four to one symbol still byte-matches."""
+    src = """\
+struct MovingCylinderClsn { void Init(Actor *a, int r); };
+struct WithMeshClsn { void Init(Actor *a, int b); };
+void f(void *t) {
+    ((MovingCylinderClsn*)&((Obj*)t)->f110)->Init((Actor*)t, 0x14000);
+    ((WithMeshClsn*)&((Obj*)t)->f144)->Init((Actor*)t, 0x1e000);
+}
+"""
+    todo = [("Init", "_ZN18MovingCylinderClsn4InitE_", False, "MovingCylinderClsn", True),
+            ("Init", "_ZN12WithMeshClsn4InitE_", False, "WithMeshClsn", True)]
+    new, n, why = D.rewrite_calls(src, todo)
+    assert why is None and n == 2, (n, why)
+    assert "_ZN18MovingCylinderClsn4InitE_((MovingCylinderClsn*)&((Obj*)t)->f110, " in new
+    assert "_ZN12WithMeshClsn4InitE_((WithMeshClsn*)&((Obj*)t)->f144, " in new
+    assert "->Init(" not in new
+
+
+def test_a_qualified_call_on_another_class_is_left_alone():
+    """src/_ZN6Camera6RenderEv.cpp: three `OAM::Render(..)` and one `View::Render()`."""
+    src = """\
+struct OAM { static void Render(bool, int); };
+struct View { int Render(); };
+void f() {
+    OAM::Render(0, 1);
+    OAM::Render(0, 2);
+    View::Render();
+}
+"""
+    new, n, why = D.rewrite_calls(src, [("Render", "_ZN3OAM6RenderE_", True, "OAM", True)])
+    assert why is None and n == 2, (n, why)
+    assert "View::Render();" in new, "a base-class call was redirected to OAM's symbol"
+    assert "OAM::Render(" not in new
+
+
+def test_an_unattributable_call_of_an_ambiguous_name_stops_the_file():
+    """Two declarations and a receiver that names neither: there is no evidence
+    which is meant, so the file is not touched -- not guessed at."""
+    src = """\
+struct A { int run(int); };
+struct B { int run(int); };
+void f(void *p) { p->run(1); }
+"""
+    new, n, why = D.rewrite_calls(src, [("run", "_ZN1A3runE_", False, "A", True)])
+    assert n == 0 and why and "ambiguous" in why
+    assert new == src, "the bail path must not leave a half-rewritten file behind"
+
+
+def test_an_unambiguous_name_still_needs_no_cast():
+    """The common case, and the reason the check is not unconditional: one
+    declaration in the file means a bare receiver has only one thing it can mean."""
+    src = """\
+struct Actor { short ReflectAngle(int, int, short); };
+void f(void *self) { self->ReflectAngle(a, b, c); }
+"""
+    new, n, why = D.rewrite_calls(src, [("ReflectAngle", "_ZN5ActorE_", False,
+                                         "Actor", False)])
+    assert why is None and n == 1
+    assert "_ZN5ActorE_(self, a, b, c)" in new
+
+
+def test_a_call_that_never_matched_still_stops_the_file():
+    """Leaving the only call site behind would keep the mangled name the ROM does
+    not define, so the file could not enroll and the edit would be pure churn."""
+    src = "struct A { int run(int); };\nvoid f(A *p) { }\n"
+    new, n, why = D.rewrite_calls(src, [("run", "_ZN1A3runE_", False, "A", False)])
+    assert n == 0 and why == "call site not in a recognised shape"
+    assert new == src
+
+
+def test_a_dot_call_still_passes_the_address():
+    src = "struct A { int run(int); };\nvoid f(A a) { a.run(1); }\n"
+    new, n, why = D.rewrite_calls(src, [("run", "_ZN1A3runE_", False, "A", False)])
+    assert why is None and n == 1 and "_ZN1A3runE_(&(a), 1)" in new
+
+
+if __name__ == "__main__":
+    fails = 0
+    for nm, fn in sorted(globals().items()):
+        if nm.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  PASS  {nm}")
+            except AssertionError as e:
+                fails += 1
+                print(f"  FAIL  {nm}: {e}")
+    print(f"\n{fails} failure(s)")
+    sys.exit(1 if fails else 0)


### PR DESCRIPTION
The tool bailed on any file where a method name appeared in more than one local class — "method name declared in more than one local class" — blocking 11 files. `method_decl()` is already class-scoped, so the guard looked like dead weight.

**It wasn't.** Neither call finder was class-aware:

- `find_call` matched `(->|\.)method\s*\(` and walked left only to *capture* the receiver text — it never inspected what the receiver was cast to.
- `find_static_call` matched a qualifier chain as a wildcard, never comparing it to the declaring class.

So the guard was load-bearing, and removing it alone would have rewritten the wrong call — which **still byte-matches**, because a call is a relocation and `match.compare` wildcards those. Invisible until the ROM link, and only for files that happen to be enrolled.

Proven concretely rather than argued. `src/func_ov022_02111bdc.cpp`:

```cpp
((ModelBase *)(c + 0xd4))->SetFile(f, 1, -1);                    // line 34 — resolves fine
((MovingMeshCollider *)(c + 0x124))->SetFile(k, ..., 0x1000, ...); // line 38 — the broken one
```

Only the second is missing from the ROM, and the *first* is what "rewrite the next call spelled `SetFile`" would have hit. `_ZN9WaterBomb13InitResourcesEv.cpp` is worse — four `Init` calls split 2/2 between `MovingCylinderClsn` and `WithMeshClsn`, all four of which would have gone to one symbol.

## What changed

- **`receiver_class(recv)`** reads the *outermost* cast — `((ModelAnim*)((char*)c+0x108))` is a `ModelAnim`, not a `char`.
- **`find_static_call`** returns its last qualifier component as `owner`.
- **Guard replaced by attribution**: a qualified call must name `cls`; an instance call's cast must name `cls`; a bare receiver is accepted only when the name is declared once in the file, and **bails** when it's ambiguous rather than guessing.
- Replacement pass extracted to module-level `rewrite_calls()` so it's testable. New `tools/test_demember_calls.py` — 16 tests, no toolchain needed — holds both halves of the property.

Also emptied the "call site not in a recognised shape" bucket: two `Player` members calling a `Player` sibling with **no receiver at all** (`SetAnim(r1, ...)`), which none of the finders saw. Attribution there comes from C++ name lookup — inside `cls::f()`, an unqualified `method` *is* `this->method`.

| gate | result |
|---|---|
| enrolled | 10,652 → **10,666** (+14) |
| module fidelity | **106/106 exact**, **PASS** |
| attribution | 0 changed, 0 lost |
| ratchet | 249 → **235** unresolved |
| in-scope files | 26 |

**14 changed → 14 enrolled (link-verified), 0 byte-verified-only.**

## Flagged, not done

The 12 "partial" files were diagnosed by hand: **10 have complete evidence** and are stuck on a *composition deadlock*, not missing data. Each spans three tool shapes at once, and all three tools implement the same correct-in-isolation rule — "only touch a file I can fully fix". Closing it means relaxing three documented safety preconditions and orchestrating the tools with an `eligible.py` refresh between each. That's a design decision with real risk, so it's left for a maintainer. Worth ~10 files.

The other 2 are the known overlay-ambiguity dead end (#1075).

Worth an eye: `func_ov100_021470f4.cpp` declares `Platform2` and `Platform3` as separate local classes that both resolve to the real `Platform` — numbered clones apparently invented to dodge the duplicate-name problem the old guard enforced. Handled correctly now, but a naming artifact rather than recovered truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi