### PR TITLE
Derive overlay residency from the game's own loader

### DIFF
--- a/notes/overlay-ambiguous-references.md
+++ b/notes/overlay-ambiguous-references.md
@@ -1,6 +1,11 @@
 # 169 references that are ambiguous between overlays
 
-**Status:** open, needs a person. Drafted as a GitHub issue; not yet filed.
+**Status:** mostly closed. **See `notes/overlay-residency.md`.** The game's own
+loader answers "which overlay was resident", `tools/overlay_residency.py` encodes
+it, and `resolve_placeholders.py` uses it: of the 137 references that were really
+overlay-ambiguous, **10 remain**. The rest of this note is the original statement of
+the problem, kept because the reasoning about *why a guess is expensive* is still
+the reason the tool refuses the last 10.
 
 169 functions cannot be enrolled because a reference in them targets an address that
 **two or more overlays both define**, and nothing in the data says which one was
@@ -43,6 +48,10 @@ Any of these, per case:
   runs? If ov002 and ov004 are never resident simultaneously, the referring module's
   own copy is the answer. An overlay load-order or scene-to-overlay map would resolve
   most of the table above mechanically, and would keep paying off afterwards.
+  *This is what happened -- `notes/overlay-residency.md`. Every row of the table
+  above is settled: `func_020beb68` -> ov004, `func_020aea30` and `func_020ada40` ->
+  ov002, `func_020aed98` -> ov002 `_ZN5EnemyC2Ev`, `func_020bc7d4` -> ov004,
+  `_ZTV10dBgActor_c` at `0x0213c5bc` -> ov098.*
 - **Emulator trace.** Break on the call site and read the resolved target. See
   `notes/emu-trace-plan.md`.
 - **Reading the code.** Several pairs are plainly the same function under two names --

--- a/notes/overlay-residency.md
+++ b/notes/overlay-residency.md
@@ -1,0 +1,245 @@
+# Which overlays can be resident together
+
+**Status:** answered. The map is code, in `tools/overlay_residency.py`, and
+`resolve_placeholders.py` uses it. This note is the evidence behind it.
+
+`notes/overlay-ambiguous-references.md` said 169 (later 171) references could not be
+resolved because two overlays both define the target address and nothing said which
+was loaded. Something does say: the game's own loader. **127 of the 137 that were
+genuinely overlay-ambiguous are now settled.**
+
+---
+
+## 1. The premise the whole thing rests on
+
+`LoadOverlay` (`src/LoadOverlay.c`) keeps a 12-entry table of resident overlays and
+refuses to create an overlap:
+
+```c
+for (r = data_0209d3c4, i = 0; i < 12; r++, i++)
+  if (r->valid == 0xffffffff) { if (slot == 0) slot = r; }
+  else if (((r->start + r->size) > start) && (end > r->start)) Crash();
+```
+
+`size` is code + bss (`buf+8` plus `buf+0xc`). So: **two overlays whose
+[base, base+code+bss) ranges intersect are never simultaneously resident** -- not as
+a guess about the linker, but because the game panics if you try. Ranges come from
+`extracted/dsd/arm9_overlays/overlays.yaml`.
+
+That is rule **E2**, and everything else narrows it further.
+
+## 2. The layout
+
+`dsd lcf` reconstructs the NitroSDK stacking tree into `build/arm9.lcf`, and it
+matches the level tables in §5 exactly:
+
+```
+OV000 : AFTER(ARM9)                    OV001 : AFTER(ARM9)
+OV002 : AFTER(OV001)   OV003, OV004, OV007 : AFTER(OV001)
+OV005, OV006 : AFTER(OV003, OV004)
+OV008..OV059 : AFTER(OV002, OV003, OV004, OV007)     <- one level slot
+OV060 : AFTER(OV011, OV028, OV037, ... OV057)
+OV061 : AFTER(OV008..OV059)   OV062..OV067 : AFTER(OV061)
+OV068 : AFTER(OV062..OV067)   OV069..OV074 : AFTER(OV068)
+OV076 -> OV077..OV082 -> OV083 -> OV084..OV087 -> OV088 -> OV089..OV092
+      -> OV093 -> OV094..OV097 -> OV098 -> OV099 -> OV100, OV101 -> OV102
+```
+
+Each `AFTER(...)` group is a slot whose members are mutually exclusive. ov061,
+ov068, ov076, ov083, ov088, ov093, ov099 and ov101 are 32-byte spacers that pin the
+next slot's address.
+
+Note what this does **not** say: ov000 ends at `0x020BF4E0` and ov006 starts at
+`0x020BFEC0`, so geometry alone permits them together. §3 is what rules it out.
+
+## 3. ov000 is a boot overlay (**E1**)
+
+`src/func_0201a2f8.c` -- loaded, entered at its own base address, unloaded, all
+before anything else exists:
+
+```c
+LoadOverlay((int)&overlay_0);     /* line 41 */
+func_020aa420();                  /* == ov000's base_address */
+UnloadOverlay((int)&overlay_0);   /* line 43 */
+...
+LoadOverlay((int)&overlay_1);     /* line 49 */
+```
+
+This is exhaustive, not a sample: the ROM reaches `LoadOverlay` (`0x02018028`) and
+`UnloadOverlay` (`0x02017f34`) through exactly **15 calls and 2 function-pointer
+loads** (`config/**/relocs.txt`), every one of those functions is decompiled in
+`src/`, and only this one names overlay 0. There is no `UnloadOverlay(1)` anywhere,
+so ov001 is resident from boot onward.
+
+**So ov000 is never resident alongside another overlay, and the only arm9 code that
+can see it is `func_0201a2f8` itself.** Every `overlays(0,N)` shortlist from an
+overlay means N. That alone answers the note's biggest case -- 22 references to
+`func_020beb68`, which is `ov004`'s bss, referenced 68 more times from inside ov004.
+
+The window matters. `func_0201a2f8`'s own call to `func_020aa420` is the one place
+where ov000 *is* the answer; a module-granular version of this rule got that
+backwards, which is why `possible()` takes the referring function.
+
+## 4. The scene slot (**E3**, **E4**)
+
+`GetSceneOverlayID` (`src/GetSceneOverlayID.c`) is the scene -> overlay map:
+
+| scene | overlay |
+|---|---|
+| 1 | ov007 |
+| 2, 4, 8 | ov003 |
+| 3, 6, 7 | ov002 |
+| 5 | ov005 |
+| 0x169..0x186 (minigames, `IsMinigameActorID`) | ov006 |
+
+`func_0201a694` unloads the previous one before loading the next and tracks it in a
+single word `data_0208ee4c`, so **exactly one of {ov002, ov003, ov005, ov006, ov007}
+is resident**. Scene 6 additionally loads ov075 once (file select).
+
+And `src/func_0201a798.c:8`:
+
+```c
+if (id == (int)&overlay_6) LoadOverlay((int)&overlay_4);
+```
+
+**ov006 always drags ov004 in with it** (`func_0201a754` mirrors the unload). Since
+ov004 overlaps ov000, that is a second, independent proof for the ov006 -> ov004
+family.
+
+## 5. The level tables (**E6**)
+
+`_Z17LoadLevelOverlaysi` and `LoadOrUnloadObjectOverlays` read three tables in
+arm9 `.data`. Decoded from `extracted/dsd/arm9/arm9.bin`:
+
+- `data_020758c8[52]` -- level -> overlay, and it is exactly `level + 8`, i.e. levels
+  0..51 map to ov008..ov059. One level overlay at a time.
+- `data_02075804[7][7]` -- object-overlay groups. **Each group is exactly one slot of
+  the layout in §2**, which is the strongest single confirmation that the model is
+  right:
+
+  | group | ids | slot base |
+  |---|---|---|
+  | 0 | 62..67 | 0x02115EE0 |
+  | 1 | 69..74 | 0x0211F000 |
+  | 2 | 77..82 | 0x02123740 |
+  | 3 | 84..87 | 0x02129020 |
+  | 4 | 89..92 | 0x02130F00 |
+  | 5 | 94..97 | 0x02135700 |
+  | 6 | 100, 101 | 0x02140D80 |
+
+- `data_02075998[52][7]` -- per level, a 1-based index into each group (0 = none).
+  At most one member of a group per level.
+
+Plus a hard-coded tail: levels 0x24/0x26/0x28 load ov060 instead; every other level
+loads ov098 (conditionally) and ov102.
+
+So the resident set for level L is
+`{ov001, ov002, ov(L+8)} u {group[i][idx[L][i]]} u ({ov060} | {ov098, ov102})`,
+and a module in the level system can only reference overlays reachable from some
+level that loads it.
+
+Worked example: `src/_ZN15TtcRotatingGear13InitResourcesEv.cpp` is in ov065, which
+is `group[0][4]`, loaded by levels 13, 27 and 33 -- level overlays ov021, ov035,
+ov041. Its ambiguous target `0x021121b8` listed eleven candidate level overlays;
+exactly one, **ov035**, is in that set.
+
+## 6. Calls prove residency (**E5**)
+
+Where dsd resolved a relocation to a single overlay *and* classified it as a call,
+that BL transferred control, so the target was in memory. Loads do not count: a
+pointer-shaped word can name an address nothing dereferences.
+
+This is what settles the `ov002` vs `ov007` family (`_ZN5EnemyC2Ev` at `0x020aed98`,
+`_ZN8Platform4KillEv` at `0x020ee55c`, 159 sites between them). ov002 and ov007
+share a base so they are exclusive, and the ~30 referring object overlays each have
+an unambiguous *call* into ov002.
+
+A referrer whose own proven set is self-contradictory is loaded in more than one
+configuration and is excluded from this rule -- `arm9` is the case, being always
+resident and calling both ov002 and ov004.
+
+## 7. Falsification
+
+The model is one-sided: it rules candidates out, never in, and a caller only has an
+answer when exactly one survives. It was checked against every verdict dsd reached
+without help:
+
+```
+$ python tools/overlay_residency.py --check
+cross-module unambiguous verdicts: {'call': 2322, 'load': 926}
+forbidden by this model: 10
+calls contradicted: 0
+```
+
+**Zero of 2322 cross-module calls contradict it.** The 10 exceptions are all
+`kind:load` -- pointer-shaped words in ov007 and ov009 naming addresses in overlays
+they cannot coexist with, i.e. constants dsd read as pointers, no control flow.
+
+## 8. What it settled
+
+Of the 171 `resolve_placeholders.py` could not resolve, **137 were actually overlay
+ambiguity** (the other 34 are 26 immediates that are not relocations at all, 6
+`module:none`, and 2 config gaps). After the rules:
+
+| outcome | before | after |
+|---|---|---|
+| unresolved -- overlay-ambiguous | 137 | **10** |
+| resolvable (rename ready) | 56 | 72 |
+| target unnamed in config | 22 | 133 |
+
+**127 settled.** 16 of them are ready to rename now; the other 111 landed on
+`target unnamed in config`, meaning the module is known and `symbols.txt` has only
+an address-shaped name there. That is a naming job with a known answer, not an
+ambiguity -- and it is now the biggest single block of work left.
+
+## 9. The 10 that remain, and what would settle them
+
+| file | referrer | why residency cannot decide |
+|---|---|---|
+| `src/func_ov002_020ec670.c` | ov002 | `0x02123804` -- all four of ov077/078/079/080 hold a real, differently-sized function there. Engine code reaching into a slot; the callee genuinely depends on the level. |
+| `src/_ZN14CutsceneObject13InitResourcesEv.cpp` | ov002 | `0x02113c20` in the level slot; ov002 is resident for every level. |
+| `src/_ZN16BowserShockwaves13InitResourcesEv.cpp` | ov060 | narrowed to the three Bowser levels (ov044/ov046/ov048); all 19 candidate symbols are dsd placeholders. |
+| `src/func_ov089_0213162c.c` | ov089 | ov089 is loaded by many levels. |
+| `src/_ZN6Bullet13InitResourcesEv.cpp` | ov002 | ov065 vs ov075 (see below). |
+| `src/_ZN8CapEnemy6AddCapEj.c` | arm9 | ov002 vs ov007; arm9 spans both. |
+| `src/func_02008b4c.c` | arm9 | ov002 vs ov006; both hold a real function. |
+| `src/func_02029408.c` | arm9 | ov002 `_ZN6Player8CanPauseEv` vs ov004 (see below). |
+| `src/func_0201a458.c` | arm9 | ov062 vs ov065, and ov006 vs ov100 (see below). |
+| `src/func_0201a2f8.c` | arm9 | the one place ov000 *is* the answer. The tool refuses instead of answering ov001, which is the point of passing the function; the source above settles it by inspection. |
+
+Four of these have a second, weaker line of evidence available. **dsd flags a symbol
+`ambiguous` in `symbols.txt` when it invented it only to have a name for a possible
+target of an ambiguous relocation.** Measured across the config: 3137 flagged
+symbols, **all** are targets of some ambiguous relocation, **none** has unambiguous
+evidence, and none is a function -- only `data(any)` or `bss`. So a flagged
+candidate is a placeholder and an unflagged one is a symbol dsd derived
+independently. Where exactly one candidate is unflagged:
+
+- `_ZN6Bullet13InitResourcesEv` `0x0211d610` -> **ov065** (ov075's is flagged)
+- `func_0201a458` `0x0211d9c0` -> **ov065**; `0x02140d80` -> **ov100** (which is what
+  `func_02034fbc` loads immediately before calling it)
+- `func_02029408` `0x020bd828` -> **ov002 `_ZN6Player8CanPauseEv`**
+
+That is weaker than residency and is deliberately **not** wired into the tool. It
+would need someone to decide the flag is trustworthy as evidence rather than as a
+hint.
+
+The remaining six need an emulator trace (`notes/emu-trace-plan.md`) or a reading of
+the call site, and three of them may have no single answer at all -- an engine
+module reaching into a slot means a different callee per level, which is a source
+structure problem, not a lookup.
+
+## 10. A misnaming found on the way
+
+`overlay_64` and `overlay_66` in `src/func_02034fbc.c`, `src/func_ov007_020cc2cc.c`
+and `src/func_ov075_02117bc4.c` are **overlay ids 100 and 102**: the literals in the
+ROM are `0x64` and `0x66` and whoever named them wrote the hex digits as decimal.
+`overlay_75` next to them is genuine decimal 75 (`0x4b`), so the convention is not
+even consistent. Taken literally, ov064 and ov066 overlap and `LoadOverlay` would
+`Crash()`; ov100 and ov102 do not. Renaming them is a separate, easy change.
+
+## Related
+
+- `tools/overlay_residency.py` -- the model, with `--check`
+- `notes/overlay-ambiguous-references.md` -- the problem this closes
+- `notes/runbook-reference-repair.md` -- the loop that consumes it

--- a/notes/runbook-reference-repair.md
+++ b/notes/runbook-reference-repair.md
@@ -95,8 +95,11 @@ different and only one of them is a fix:
 `unresolved` covers several distinct reasons; the tool prints which, and they are not
 interchangeable:
 
-- `0x... names {ov000: ..., ov004: ...}` -- two overlays both define it. **Stop**; see
-  `overlay-ambiguous-references.md`.
+- `0x... names {ov000: ..., ov004: ...} (residency leaves [...])` -- two overlays both
+  define it *and* both could have been in memory. The tool has already applied the
+  residency map (`tools/overlay_residency.py`); `residency leaves` is what survived
+  it. **Stop**; see `notes/overlay-residency.md` §9 -- there are ten of these left and
+  each needs its own argument.
 - `no reloc recorded at 0x...` -- the value is not a relocation at all (an immediate).
 - `no candidate of [...] defines 0x...` -- a gap in `symbols.txt`, not in the source.
 - `resolves to both X and Y` -- one name used for two different targets in one file;
@@ -211,8 +214,11 @@ PY
   failed the ROM build and the tool was innocent: enrolling the file was simply the
   first time anything looked at its callees. Read the named function before assuming
   your change caused it.
-- **169 references remain genuinely ambiguous.** Two overlays define the same address.
-  Tooling is finished; these need overlay-residency data or an emulator trace.
+- **~~169 references remain genuinely ambiguous.~~** Was true; the overlay-residency
+  data existed after all, in the game's own loader. 127 of the 137 real cases are
+  settled -- `notes/overlay-residency.md`. Ten are left and they are listed there.
+  The lesson worth keeping: "tooling is finished" meant "we asked the symbol table
+  and it had no more to say", which is not the same thing.
 - **`is_misnamed()` returns `True` unconditionally.** That is deliberate: the name is
   never evidence, so there is nothing to gate on. Narrowing it is how this cost five
   separate sweeps.

--- a/tools/overlay_residency.py
+++ b/tools/overlay_residency.py
@@ -1,0 +1,251 @@
+"""Which overlays can be resident at the same time.
+
+`dsd` resolves a relocation to a target address and an owning module. Where several
+overlays cover the address and dsd cannot tell them apart it says so --
+`module:overlays(0,4)` -- and `resolve_placeholders.py` refuses rather than guess,
+because a wrong pick still byte-matches (`match.compare` wildcards every relocated
+word) and both candidates share the address, so even the ROM link cannot tell.
+
+That shortlist is only unanswerable if you ask the symbol table. Ask the *loader*
+instead. Overlays are not free to coexist: the game keeps a table of resident ones
+and panics if a new one would overlap. So a candidate that could not have been in
+memory while the referring code ran is not a candidate at all, and the shortlist
+usually collapses to one.
+
+Every rule below is a fact about this ROM, read out of the game's own code and data
+or out of dsd's own unambiguous verdicts. None is an inference from a symbol name.
+
+    E2  overlapping ranges are mutually exclusive
+    E1  ov000 is a boot overlay: loaded, entered, unloaded, before anything else
+    E3  loading ov006 always loads ov004
+    E5  an unambiguous CALL relocation proves its target was resident
+    E6  the level -> overlay tables say which overlays a level loads
+
+`possible()` is deliberately one-sided: it can rule a candidate *out*, never in.
+When the data is missing (a cold clone has no `extracted/`) it rules nothing out,
+so the caller falls back to refusing -- which is the safe direction here.
+
+Validated by falsification: of the 2322 cross-module relocations dsd resolved
+unambiguously to a *call*, this model forbids none. Of the 926 unambiguous
+cross-module *loads* it forbids 10 -- pointer-shaped data words, no control flow.
+Re-run that check with:
+
+    python tools/overlay_residency.py --check
+"""
+import collections
+import pathlib
+import re
+import struct
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+EXTRACTED = REPO / "extracted" / "dsd"
+
+
+# --------------------------------------------------------------------------- E2
+def _load_ranges():
+    """{ov000: (start, end)} covering code *and* bss.
+
+    bss is part of it: `LoadOverlay` adds both before testing for overlap, so two
+    overlays whose code fits but whose bss collides are still exclusive."""
+    p = EXTRACTED / "arm9_overlays" / "overlays.yaml"
+    if not p.is_file():
+        return {}
+    out, cur = {}, None
+    for line in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+        m = re.match(r"\s*-\s*id:\s*(\d+)", line)
+        if m:
+            cur = {"id": int(m.group(1))}
+            out[cur["id"]] = cur
+            continue
+        m = re.match(r"\s+(\w+):\s*(.+)", line)
+        if m and cur is not None:
+            try:
+                cur[m.group(1)] = int(m.group(2).strip())
+            except ValueError:
+                pass
+    return {f"ov{o['id']:03d}": (o["base_address"],
+                                 o["base_address"] + o["code_size"] + o.get("bss_size", 0))
+            for o in out.values() if "base_address" in o}
+
+
+RANGE = _load_ranges()
+
+
+def conflict(a, b):
+    """Can `a` and `b` be resident together?  No, if their ranges intersect.
+
+    `LoadOverlay` (src/LoadOverlay.c) walks the 12-entry resident table
+    `data_0209d3c4` and calls `Crash()` when the incoming overlay's
+    [start, start + code + bss) intersects one already there. The game enforces
+    this itself; it is not an assumption about the linker.
+
+    `arm9`, `itcm` and `dtcm` are always resident and conflict with nothing."""
+    if a == b or a not in RANGE or b not in RANGE:
+        return False
+    (s1, e1), (s2, e2) = RANGE[a], RANGE[b]
+    return s1 < e2 and s2 < e1
+
+
+# --------------------------------------------------------------------------- E1
+# ov000 is loaded, entered at its own base address, and unloaded again inside one
+# function -- src/func_0201a2f8.c:41-43 --
+#
+#     LoadOverlay((int)&overlay_0);
+#     func_020aa420();                 /* == ov000's base address */
+#     UnloadOverlay((int)&overlay_0);
+#     ...
+#     LoadOverlay((int)&overlay_1);    /* line 49, and never unloaded */
+#
+# Those are the ROM's only LoadOverlay(0)/UnloadOverlay(0) sites: all 17
+# Load/UnloadOverlay call sites in the ROM are decompiled in src/ and only this one
+# names overlay 0. So ov000 is never resident alongside another overlay, and the
+# only arm9 code that can see it is func_0201a2f8 itself.
+OV000_MODULE = "arm9"
+OV000_WINDOW = "func_0201a2f8"
+
+# ov001 is loaded on line 49 above and there is no UnloadOverlay(1) anywhere in the
+# ROM, so it is resident from boot onwards. Nothing needs excluding for it -- it
+# overlaps only ov000, which E1 has already dealt with.
+ALWAYS_RESIDENT = {"ov001"}
+
+
+# --------------------------------------------------------------------------- E5
+_RELOC = re.compile(r"^from:0x[0-9a-fA-F]+\s+kind:(\S+)\s+to:0x[0-9a-fA-F]+\s+"
+                    r"module:overlay\((\d+)\)$")
+
+
+def _proven_calls():
+    """{module: overlays it demonstrably calls}.
+
+    A relocation dsd resolved to a single overlay *and* classified as a call is a
+    BL that transfers control there. The target has to have been in memory, so the
+    two modules were resident together. Loads do not count: a pointer-shaped word
+    can name an address nothing ever dereferences."""
+    out = collections.defaultdict(set)
+    for p in (REPO / "config").rglob("relocs.txt"):
+        src = p.parent.name
+        for ln in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = _RELOC.match(ln.strip())
+            if m and "call" in m.group(1):
+                t = f"ov{int(m.group(2)):03d}"
+                if t != src:
+                    out[src].add(t)
+    return out
+
+
+CALLS = _proven_calls()
+
+# A module whose own proven set contradicts itself is loaded in more than one
+# configuration, so the set is a union over configurations and excludes nothing.
+# `arm9` is the obvious case: it is always resident and calls both ov002 and ov004,
+# which are mutually exclusive.
+_SINGLE_CONFIG = {s: not any(conflict(a, b) for a in ts for b in ts if a < b)
+                  for s, ts in CALLS.items()}
+
+
+# --------------------------------------------------------------------------- E6
+def _level_tables():
+    """The three tables `LoadLevelOverlays` and `LoadOrUnloadObjectOverlays` read.
+
+    src/_Z17LoadLevelOverlaysi.cpp        ov = data_020758c8[level]
+    src/_Z26LoadOrUnloadObjectOverlaysPFviEi.cpp
+                                          fn(data_02075804[i].t[data_02075998[idx][i]])
+
+    data_02075804 is 7 groups of 7 overlay ids and each group is exactly one tier of
+    the overlay layout, so at most one member of a group is ever loaded. That is the
+    same exclusion E2 gives, stated by the game."""
+    p = EXTRACTED / "arm9" / "arm9.bin"
+    if not p.is_file():
+        return None
+    b, base = p.read_bytes(), 0x02004000
+
+    def w(a):
+        return struct.unpack_from("<I", b, a - base)[0]
+
+    group = [[w(0x02075804 + g * 28 + i * 4) for i in range(7)] for g in range(7)]
+    level_ov = [w(0x020758c8 + i * 4) for i in range(52)]
+    idx = [[b[0x02075998 + l * 7 + i - base] for i in range(7)] for l in range(52)]
+    resident = []
+    for L in range(52):
+        s = {"ov002", f"ov{level_ov[L]:03d}"}
+        for i in range(7):
+            if idx[L][i]:
+                s.add(f"ov{group[i][idx[L][i]]:03d}")
+        # LoadOrUnloadObjectOverlays' hard-coded tail.
+        s |= {"ov060"} if L in (0x24, 0x26, 0x28) else {"ov098", "ov102"}
+        resident.append(s)
+    system = {f"ov{v:03d}" for g in group for v in g if v}
+    system |= {f"ov{v:03d}" for v in level_ov} | {"ov060", "ov098", "ov102"}
+    reach = {m: set().union(*[r for r in resident if m in r] or [set()]) for m in system}
+    return system, reach
+
+
+_LEVELS = _level_tables()
+LEVEL_SYSTEM, _REACH = _LEVELS if _LEVELS else (set(), {})
+
+
+# ---------------------------------------------------------------------------
+def possible(cand, module, func=None):
+    """Could a reference from `module` (function `func`) mean `cand`?
+
+    False only when something in the ROM says it could not. Never True as a
+    positive claim -- the caller must still find that exactly one candidate
+    survives before it has an answer."""
+    if cand == "ov000" and not (module == OV000_MODULE and func == OV000_WINDOW):
+        # E1. Every other referrer runs after ov000 was unloaded.
+        return False
+    if module == "ov000" and cand in RANGE and cand != "ov000":
+        return False                                            # E1, the other way
+    if conflict(cand, module):
+        return False                                            # E2
+    if module == "ov006" and conflict(cand, "ov004"):
+        return False                                            # E3
+    if _SINGLE_CONFIG.get(module, False) and any(conflict(cand, t) for t in CALLS[module]):
+        return False                                            # E5
+    if (module in LEVEL_SYSTEM and cand in LEVEL_SYSTEM
+            and cand not in _REACH[module]):
+        return False                                            # E6
+    return True
+
+
+def settle(candidates, module, func=None):
+    """The one candidate residency leaves, or None."""
+    left = [c for c in candidates if possible(c, module, func)]
+    return left[0] if len(left) == 1 else None
+
+
+def _check():
+    """Falsify the model against every unambiguous verdict dsd produced."""
+    bad, tot = collections.Counter(), collections.Counter()
+    for p in (REPO / "config").rglob("relocs.txt"):
+        src = p.parent.name
+        for ln in p.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = _RELOC.match(ln.strip())
+            if not m:
+                continue
+            t = f"ov{int(m.group(2)):03d}"
+            if t == src:
+                continue
+            kind = "call" if "call" in m.group(1) else "load"
+            tot[kind] += 1
+            # func is unknown here, so the ov000 window cannot apply; skip ov000.
+            if t != "ov000" and not possible(t, src):
+                bad[(src, t, kind)] += 1
+    print(f"cross-module unambiguous verdicts: {dict(tot)}")
+    print(f"forbidden by this model: {sum(bad.values())}")
+    for k, v in bad.most_common():
+        print(f"   {k}: {v}")
+    calls = sum(v for k, v in bad.items() if k[2] == "call")
+    print(f"\ncalls contradicted: {calls}  <- must be 0")
+    return 0 if calls == 0 else 1
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--check", action="store_true",
+                    help="falsify the model against dsd's unambiguous verdicts")
+    a = ap.parse_args()
+    sys.exit(_check() if a.check else print(__doc__) or 0)

--- a/tools/resolve_placeholders.py
+++ b/tools/resolve_placeholders.py
@@ -57,6 +57,7 @@ sys.path.insert(0, str(REPO / "tools"))
 import build_pin as BP     # noqa: E402
 import match as M          # noqa: E402
 import eligible as E       # noqa: E402
+import overlay_residency as OR  # noqa: E402
 from enroll import candidates  # noqa: E402
 
 ELIGIBILITY = REPO / "build" / "rombuild-eligibility.json"
@@ -137,13 +138,18 @@ def module_keys(spec):
     return []
 
 
-def resolve_in(syms, mods, addr, prefer):
+def resolve_in(syms, mods, addr, prefer, func=None):
     """The name at `addr`, given a shortlist of modules that might own it.
 
     A candidate only counts if it defines a symbol exactly at `addr`. If several do
     and they disagree, prefer the referring module -- an overlay reaching into
-    itself is likelier than into a sibling that may not even be resident -- and
-    otherwise refuse, because a guess here silently retargets a call."""
+    itself is likelier than into a sibling that may not even be resident.
+
+    Failing that, ask which candidates could have been *in memory* while the
+    referring code ran. `overlay_residency` answers that from the game's own loader
+    and level tables, and the shortlist usually collapses to one. Where it does not,
+    refuse: a guess here silently retargets a call and still byte-matches, and both
+    candidates share the address so even the ROM link would not object."""
     hits = {}
     for m in mods:
         nm, _ = name_at(syms, m, addr)
@@ -155,7 +161,11 @@ def resolve_in(syms, mods, addr, prefer):
         return next(iter(hits.values())), None
     if prefer in hits:
         return hits[prefer], None
-    return None, f"{addr:#010x} names {hits}"
+    one = OR.settle(hits, prefer, func)
+    if one:
+        return hits[one], None
+    left = sorted(c for c in hits if OR.possible(c, prefer, func))
+    return None, f"{addr:#010x} names {hits} (residency leaves {left})"
 
 
 def load_relocs():
@@ -326,7 +336,7 @@ def main():
             if not cands:
                 bad.append((sym, f"unparsed module spec: module:{spec}"))
                 continue
-            real, why = resolve_in(syms, cands, to, label)
+            real, why = resolve_in(syms, cands, to, label, name)
             if real is None:
                 bad.append((sym, why))
                 continue


### PR DESCRIPTION
`notes/overlay-ambiguous-references.md` (issue #1075) said 169 references were unsettleable by tooling: two overlays define the same address, and nothing says which was resident. **The data existed** — in the game's loader, not the symbol table.

## The premise, enforced at runtime

`src/LoadOverlay.c` keeps a 12-entry table of resident overlays and calls `Crash()` if a new one's `[base, base+code+bss)` would intersect one already there:

```c
extern struct Region data_0209d3c4[12];
for (r = data_0209d3c4, i = 0; i < 12; r++, i++)
    ... Crash();
```

Overlapping overlays are therefore **never** co-resident. That's a runtime invariant the game enforces, not an assumption about the linker.

From there, five facts, each read out of decompiled code or ROM data:

- **ov000 is a boot overlay** — `func_0201a2f8` loads it, calls its base address, unloads it, *then* loads ov001. The ROM reaches Load/UnloadOverlay through exactly 15 calls + 2 function-pointer loads, all decompiled, and only this one names overlay 0. So ov000 is never resident alongside anything — which answers the note's single biggest case (22 refs to `func_020beb68` → **ov004**) outright.
- Loading ov006 always loads ov004 first.
- Exactly one of {ov002, ov003, ov005, ov006, ov007} at a time.
- An unambiguous *call* relocation proves its target was resident. Loads don't.
- The level tables decode to level → ov(N+8), and each of the seven object-overlay groups is exactly one slot of the layout — the game's own data confirming the geometry.

## Falsification

The model is **one-sided**: it rules candidates out, never in. Checked against every verdict dsd reached unaided — of **2,322 unambiguous cross-module call relocations it forbids zero**. `python tools/overlay_residency.py --check`.

That test caught a real defect mid-flight: a module-granular rule answered `ov001` for `func_0201a2f8`'s own call into ov000 — a wrong answer of exactly the invisible kind. `possible()` now takes the referring *function*, and that case is refused.

## Result

Of the 171, **137 were actually overlay ambiguity** — the other 34 were 26 non-relocation immediates, 6 `module:none`, and 2 config gaps, mislabelled in the note.

| | before | after |
|---|---:|---:|
| unresolved, overlay-ambiguous | 137 | **10** |
| resolvable (rename ready) | 56 | 72 |
| target unnamed in config | 22 | 133 |

**127 settled.** Every row of the note's headline table. Worth noting `func_020aea30`/`func_020ada40` resolve to the *unnamed* ov002 side — the ov004 `Enemy::Kill*` names are a coincidence of address, different sizes.

111 moved to "target unnamed in config": module known, `symbols.txt` has only an address-shaped name. **A naming job, no longer an ambiguity** — and now the largest remaining block.

## What remains, and one thing I did not do

10 files, each with its reason in `notes/overlay-residency.md` §9. Three look genuinely answerless — engine code reaching into a slot means a different callee per level, a source-structure problem.

Four could be settled by a weaker second line: dsd flags a symbol `ambiguous` when it invented the name only to label a possible target. Measured across the config, all 3,137 flagged symbols are targets of some ambiguous reloc, none has unambiguous evidence, none is a function. **Deliberately not wired in** — it needs a human to rule the flag admissible.

## Also found

`overlay_64` / `overlay_66` in `src/` are **overlay ids 100 and 102** — the ROM literals are `0x64`/`0x66`, named as hex digits. Read literally they overlap and `LoadOverlay` would `Crash()`. (`overlay_75` beside them is genuine decimal.) Separate fix.

Tooling and notes only — no `src/`, `include/` or `config/` changes. `module fidelity: 106/106 exact` / `PASS`; attribution 0 changed, 0 lost.

Closes much of #1075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi