### PR TITLE
recover_cw2004: fix fsutil and backslash-basename Windows-isms (Linux support)

### DIFF
--- a/tools/recover_cw2004.py
+++ b/tools/recover_cw2004.py
@@ -112,7 +112,8 @@ def pull_installer(work):
         f.write(packed)
         f.seek(end_abs)
         f.write(end)
-    subprocess.run(["fsutil", "sparse", "setflag", sparse], capture_output=True)
+    if os.name == "nt":
+        subprocess.run(["fsutil", "sparse", "setflag", sparse], capture_output=True)
 
     with py7zr.SevenZipFile(sparse, "r") as z:
         names = z.getnames()
@@ -166,7 +167,8 @@ def split_payload(exe):
         if not fields[3].isdigit():
             return parts
         n = int(fields[3])
-        parts[os.path.basename(fields[1] or fields[0])] = d[pos:pos + n]
+        name = (fields[1] or fields[0]).replace("\\", "/")
+        parts[os.path.basename(name)] = d[pos:pos + n]
         pos += n
     return parts
 


### PR DESCRIPTION
Two small fixes that let `tools/recover_cw2004.py` run end-to-end on Linux (hit while recovering the canonical `2004/b56` compiler for a matching session):

1. `subprocess.run(["fsutil", ...])` raises `FileNotFoundError` on Linux — after the ~2 GB solid-block download has already succeeded. Guarded with `os.name == "nt"`; the `truncate()` already produces a sparse-enough file on POSIX filesystems.
2. The InstallShield payload names use backslashes (`Disk1\data2.cab`), and POSIX `os.path.basename` doesn't split on `\`, so the `data2.cab` lookup found nothing ("data2.cab not found in payload"). Separators are normalized before taking the basename.

Verified on Linux (WSL2): recovery completes, `mwccarm.exe` sha256 equals `EXPECT_SHA256`, banner reports `2.0 build 56` under wibo. The final `-version` self-check still execs the PE directly (fails harmlessly on Linux after the hash-verified artifact is written) — left untouched to keep the diff minimal.

Provenance: ai model=claude-fable-5 reasoning=high harness=claude-code

🤖 Generated with [Claude Code](https://claude.com/claude-code)