### PR TITLE
readable: fix the two base headers that were poisoning 49 descendant fields

### DIFF
--- a/include/CapEnemy.h
+++ b/include/CapEnemy.h
@@ -15,9 +15,16 @@ struct CapEnemy {
     u32 mParam;            /* 0x008 */
     u16 mActorID;            /* 0x00c */
     u8  pad_00e[0x4e];
-    u8  unk_05c;            /* 0x05c */
+    /* 0x05c: NOT a scalar, and deliberately left as a marker. Both evidence passes
+       see only its address taken, never a sized load, and Actor.h:65 puts
+       mPosX/mPosY/mPosZ here -- so this stands over the position triple. One derived
+       header declares s32 at this offset, which describes the X component alone;
+       adopting that would trade an unknown for a narrower wrong answer. */
+    u8  unk_05c;            /* 0x05c -- position triple, 0x05c..0x068 */
     u8  pad_05d[0x2f];
-    u8  unk_08c;            /* 0x08c */
+    /* 0x08c: same shape -- address-only evidence, and Actor.h:89 puts
+       mAngleX/mAngleY/mAngleZ here. Stands over the rotation triple. */
+    u8  unk_08c;            /* 0x08c -- rotation triple, 0x08c..0x092 */
     u8  pad_08d[0x23];
     u32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x18];

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -25,14 +25,21 @@ struct Enemy {
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0x2c];
-    u8  unk_094;            /* 0x094 */
-    u8  pad_095[0xf];
+    /* 0x094 is Actor.h:93 mPrevAngleY. The ROM loads it with a signed halfword
+       load, which is the one thing no source pass can settle -- and 27 derived
+       headers already declare it s16. Was a bare u8 marker. */
+    s16 unk_094;            /* 0x094 */
+    u8  pad_096[0xe];
     u8  unk_0a4;            /* 0x0a4 */
     u8  pad_0a5[0x3];
-    u8  unk_0a8;            /* 0x0a8 */
-    u8  pad_0a9[0x3];
-    u8  unk_0ac;            /* 0x0ac */
-    u8  pad_0ad[0x27];
+    /* 0x0a8 is Actor.h:99 mVertSpeed; 10 derived headers agree, both evidence
+       passes see 4-byte accesses. */
+    s32 unk_0a8;            /* 0x0a8 */
+    /* 0x0ac: no Actor field, but 6 derived headers agree and both passes see
+       4-byte accesses. The marker's span ran to 0x0d4; only its first word is
+       evidenced, so the rest stays padding. */
+    s32 unk_0ac;            /* 0x0ac */
+    u8  pad_0b0[0x24];
     u8  unk_0d4;            /* 0x0d4 */
     u8  pad_0d5[0x3];
     u8  unk_0d8;            /* 0x0d8 */
@@ -48,7 +55,10 @@ struct Enemy {
     u8  unk_106;            /* 0x106 */
     u8  unk_107;            /* 0x107 */
     u8  pad_108[0x4];
-    u8  unk_10c;            /* 0x10c */
+    /* 0x10c: 4 derived headers agree, history sees 4 four-byte accesses and the
+       ROM two. This is the last field, so widening it grows sizeof(Enemy) by 3 --
+       the only site here that is not offset-neutral. */
+    s32 unk_10c;            /* 0x10c */
 #ifdef __cplusplus
     /* methods */
     int AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_);

--- a/notes/plan-base-headers.md
+++ b/notes/plan-base-headers.md
@@ -1,0 +1,129 @@
+# Plan: fix the two base headers that poison their descendants
+
+**Status:** in progress. First change in the gen_header programme that touches `include/`.
+**Depends on:** #1118 (the evidence passes and the differential that found this).
+**Scope:** `include/Enemy.h` and `include/CapEnemy.h`, six field declarations.
+
+---
+
+## 1. What is wrong
+
+`tools/gen_header.py` buckets every field declared in the 241 bannered headers. 49 of
+them conflict with a base class whose **own header is also bannered** -- so the report
+grades them *weak*: two never-verified headers disagreeing is not evidence about which
+is right.
+
+Resolving them turns out to be easy, because all 49 collapse onto **six declarations in
+two headers**:
+
+| base | offset | descendants disagreeing | base says | they say |
+|---|---|---:|---|---|
+| `Enemy` | 0x094 | 27 | `u8` | `s16` (unanimous) |
+| `Enemy` | 0x0a8 | 10 | `u8` | `s32` (unanimous) |
+| `Enemy` | 0x0ac | 6 | `u8` | `s32` (unanimous) |
+| `Enemy` | 0x10c | 4 | `u8` | `s32` (unanimous) |
+| `CapEnemy` | 0x05c | 1 | `u8` | `s32` |
+| `CapEnemy` | 0x08c | 1 | `u8` | `s16` |
+
+In every case the base declares a bare `u8` followed by a pad -- the original
+generator's marker for *"something starts here and I do not know what"* -- and the
+descendants declare a real type. **The base is the wrong one.** The descendants already
+recovered these fields correctly; the base is masking them.
+
+Note what this does *not* mean. `Enemy.h` has **3** includers and `CapEnemy.h` has **4**;
+the 27 descendants carry their own flat headers and never include `Enemy.h`. So this
+change does not propagate a fix to them. It removes 49 false conflicts and makes the two
+headers usable as references, which is what unblocks the rest of the programme.
+
+## 2. Independent evidence, per site
+
+Neither pass was told what the headers claim.
+
+| site | history | ROM | `Actor.h` says |
+|---|---|---|---|
+| `Enemy` 0x094 | 3 x width 2 | 1 x width 2, **signed load** | `s16 mPrevAngleY` (:93) |
+| `Enemy` 0x0a8 | 2 x width 4 | 1 x width 4 | `s32 mVertSpeed` (:99) |
+| `Enemy` 0x0ac | 1 x width 4 | 1 x width 4 | -- |
+| `Enemy` 0x10c | 4 x width 4 | 2 x width 4 | -- |
+| `CapEnemy` 0x05c | address taken x2, **no width** | -- | `s32 mPosX` (:65) |
+| `CapEnemy` 0x08c | address taken x2, **no width** | -- | `s16 mAngleX` (:89) |
+
+Two of the four `Enemy` sites are Actor fields that `Enemy.h` re-declared as markers, and
+`Actor.h` is de-bannered -- hand-reconstructed, the strongest reference in the tree. The
+ROM independently proves 0x094 is **signed**, which no source pass can settle.
+
+## 3. The two sites in CapEnemy are a different thing, and are NOT being retyped
+
+`CapEnemy` 0x05c and 0x08c have **address-only** evidence: the code takes their address
+and never loads a scalar from them. Against `Actor.h`, 0x05c is the start of the position
+triple (`mPosX/mPosY/mPosZ`) and 0x08c the start of the rotation triple
+(`mAngleX/mAngleY/mAngleZ`).
+
+So these markers stand over **objects**, and the lone descendant declaring `s32`/`s16` is
+describing only the first component. Retyping the marker to `s32` would be adopting a
+narrower lie. They stay as markers; the comment is corrected to say what the span is.
+
+This is the distinction the differential exists to make, and it is why "49 conflicts"
+was never "49 retypes."
+
+## 4. Mechanics, and where this can go wrong
+
+Each retype must preserve every following offset. `u8 x; u8 pad[n];` becomes
+`sN x; u8 pad[n - (sizeof(sN) - 1)];`, and the pad is **renamed** to its new offset:
+
+```c
+    u8  unk_094;            /* 0x094 */        ->    s16 unk_094;            /* 0x094 */
+    u8  pad_095[0xf];                                u8  pad_096[0xe];
+```
+
+Checks that must hold at every site:
+
+- **Alignment.** 0x094 is 2-aligned; 0x0a8, 0x0ac, 0x10c are 4-aligned. None forces the
+  compiler to insert padding *before* the field, which would shift everything after it.
+- **Span preserved.** 1 + pad before == sizeof(new) + pad after.
+- **`Enemy` 0x10c is the last field**, with no trailing pad, so retyping it to `s32`
+  grows `sizeof(Enemy)` by 3. Nothing should depend on that, but it is the one site
+  whose effect is not offset-neutral, so it is byte-verified with particular care.
+
+## 5. Verification
+
+A header change affects **every** includer, and `rombuild.py` compiles only *enrolled*
+files while the tree matches more than it enrolls
+(`notes/runbook-reference-repair.md` §1). So the build alone cannot see a file that
+silently stopped matching.
+
+```sh
+python tools/eligible.py                     # BEFORE, on a clean tree
+# ... make the edits ...
+python tools/build_pin.py --verify <each of the 7 includers>
+python tools/rombuild.py                     # 106/106 exact, PASS
+python tools/eligible.py                     # AFTER -- diff against BEFORE
+python tools/prepush_attribution.py          # credit must not move
+python tools/gen_header.py --root . --report # the 49 weak conflicts should be 0
+```
+
+The `eligible.py` bracket is the load-bearing one. A drop in matched files is the failure
+mode this change is most likely to produce, and it is the one the ROM build cannot report.
+
+## 6. Definition of done
+
+- [ ] 4 retypes in `Enemy.h`, spans and alignment preserved
+- [ ] 2 `CapEnemy` markers left as markers, comments corrected
+- [ ] `ROM-build analysis: PASS`, module fidelity 106/106 exact
+- [ ] `eligible.py` before/after: no file lost its match
+- [ ] attribution 0 changed, 0 lost
+- [ ] `base-conflict (weak)` falls 49 -> 0
+- [ ] enrolled vs byte-verified-only split stated in the PR body
+
+## 7. What this deliberately does not do
+
+- **No restructuring to real inheritance.** `Enemy.h` and `CapEnemy.h` duplicate Actor's
+  layout flat rather than inheriting it. Fixing that is the right end state and a much
+  larger change with codegen risk in every includer. Retyping six fields is testable in
+  one batch; rebuilding two class hierarchies is not.
+- **No renaming.** `unk_094` stays `unk_094` even though `Actor.h` calls it
+  `mPrevAngleY`. Renaming is free and cannot change codegen, which is exactly why it
+  belongs in a separate commit -- mixing it in here would make the byte gate's signal
+  unreadable.
+- **No touching the 27 descendants.** They are already right. Their markers are a
+  separate bucket (`marker: scalar-sized, retype`, 72 fields) and a separate batch.


### PR DESCRIPTION
Builds on #1118, which added the evidence passes that found this. Plan: `notes/plan-base-headers.md`.

## What was wrong

The differential flagged **49 fields** where a derived header disagrees with its base about a width — but where the base's own header is *also* bannered. Two never-verified headers disagreeing is not evidence about which is right, so those were graded *weak*.

They collapse onto **six declarations in two headers**, and in every one the base declares a bare `u8` marker where the descendants declare a real type. **The base is the wrong one.** The descendants had already recovered these correctly; the base was masking them.

`Enemy.h` has 3 includers and `CapEnemy.h` has 4 — the 27 descendants carry their own flat headers and never include these. So this doesn't propagate a fix to them. It removes 49 false conflicts and makes the two headers usable as references, which is what unblocks the rest of the programme.

## `Enemy.h` — four retypes

| offset | was | now | evidence |
|---|---|---|---|
| 0x094 | `u8` | `s16` | `Actor.h:93 mPrevAngleY`; **ROM uses a signed halfword load**; 27 derived headers agree |
| 0x0a8 | `u8` | `s32` | `Actor.h:99 mVertSpeed`; 10 derived agree; both passes see 4-byte accesses |
| 0x0ac | `u8` | `s32` | 6 derived agree; both passes see 4-byte accesses |
| 0x10c | `u8` | `s32` | 4 derived agree; history sees four 4-byte accesses, ROM two |

The signedness at 0x094 is the interesting one — it's the single thing no source pass can settle, and it's exactly the kind of error the byte gate can never object to (`ldrsh` vs `ldrh`).

Every following offset is preserved: each pad shrinks by the width gained and is renamed to its new offset. A checker walks both structs and confirms all **26 commented offsets still land where they say**. `sizeof(Enemy)` goes `0x10d → 0x110` because 0x10c is the last field — the one site here that isn't offset-neutral, and byte-verified with that in mind.

## `CapEnemy.h` — deliberately NOT retyped

Both its sites have **address-only** evidence: the code takes their address and never loads a scalar from them. Against `Actor.h`, 0x05c is the position triple (`mPosX/mPosY/mPosZ`) and 0x08c the rotation triple.

So these markers stand over *objects*, and the lone derived header declaring `s32`/`s16` there describes only the X component. Retyping would trade an unknown for a narrower wrong answer. The markers stay; their comments now record what they cover.

This is the distinction the differential exists to make, and it's why "49 conflicts" was never "49 retypes."

## Verification

```
7 includers byte-verified via build_pin.py under their pinned compiler (2004/b56)
eligible.py before/after : 10667 -> 10667, 0 files lost their match
module fidelity          : 106/106 exact, 100.000000%
ROM-build analysis       : PASS
attribution              : 0 changed, 0 lost
base-conflict (weak)     : 49 -> 3
```

**All 7 changed-file effects are enrolled and link-verified** — no byte-verified-only residue, because every includer of both headers is enrolled.

The `eligible.py` bracket is the load-bearing check. `rombuild.py` compiles only *enrolled* files, and the tree matches more than it enrolls, so a header retype can silently un-match a file the ROM build never looks at. 106/106 alone would not have caught that.

## The 3 remaining weak conflicts are correct residue

- **`Bullet.unk_0ac`** — polarity flipped. *Bullet* now holds the marker and `Enemy` correctly says `s32`. A real finding, now pointing at the descendant, where it belongs.
- **`Goomba.mPosX @0x5c`**, **`Goomba.mAngleX @0x8c`** — the two CapEnemy markers left on purpose. Goomba names them `mPosX`/`mAngleX`, matching `Actor.h` exactly, which independently corroborates that those offsets are the position and rotation triples.

## Deliberately out of scope

No restructuring to real inheritance (both headers duplicate Actor's layout flat — right end state, much larger change), no renaming (`unk_094` stays `unk_094` even though Actor calls it `mPrevAngleY` — renaming is free and belongs in its own commit so the byte gate's signal stays readable), and no touching the 27 descendants.

**2 in-scope files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi