### PR TITLE
readable: retype 71 scalar-sized u8 markers to their evidenced width

### DIFF
--- a/include/Camera.h
+++ b/include/Camera.h
@@ -10,34 +10,23 @@
 struct j;
 struct Camera {
     u8  pad_000[0x80];
-    u8  unk_080;            /* 0x080 */
-    u8  pad_081[0x3];
-    u8  unk_084;            /* 0x084 */
-    u8  pad_085[0x3];
-    u8  unk_088;            /* 0x088 */
-    u8  pad_089[0x3];
-    u8  unk_08c;            /* 0x08c */
-    u8  pad_08d[0x3];
-    u8  unk_090;            /* 0x090 */
-    u8  pad_091[0x3];
+    s32 unk_080;            /* 0x080 */
+    s32 unk_084;            /* 0x084 */
+    s32 unk_088;            /* 0x088 */
+    s32 unk_08c;            /* 0x08c */
+    s32 unk_090;            /* 0x090 */
     u8  unk_094;            /* 0x094 */
     u8  pad_095[0x1b];
-    u8  unk_0b0;            /* 0x0b0 */
-    u8  pad_0b1[0x3];
-    u8  unk_0b4;            /* 0x0b4 */
-    u8  pad_0b5[0x3];
-    u8  unk_0b8;            /* 0x0b8 */
-    u8  pad_0b9[0x3];
-    u8  unk_0bc;            /* 0x0bc */
-    u8  pad_0bd[0x3];
-    u8  unk_0c0;            /* 0x0c0 */
-    u8  pad_0c1[0x3];
+    s32 unk_0b0;            /* 0x0b0 */
+    s32 unk_0b4;            /* 0x0b4 */
+    s32 unk_0b8;            /* 0x0b8 */
+    s32 unk_0bc;            /* 0x0bc */
+    s32 unk_0c0;            /* 0x0c0 */
     u8  unk_0c4;            /* 0x0c4 */
     u8  pad_0c5[0x4b];
     s32 unk_110;            /* 0x110 */
     u8  pad_114[0x24];
-    u8  unk_138;            /* 0x138 */
-    u8  pad_139[0x3];
+    s32 unk_138;            /* 0x138 */
     s32 unk_13c;            /* 0x13c */
     u8  pad_140[0x14];
     u32 unk_154;            /* 0x154 */

--- a/include/Clipper.h
+++ b/include/Clipper.h
@@ -9,10 +9,8 @@
 struct Clipper {
     u8  pad_000[0x4c];
     u32 unk_04c;            /* 0x04c */
-    u8  unk_050;            /* 0x050 */
-    u8  pad_051[0x3];
-    u8  unk_054;            /* 0x054 */
-    u8  pad_055[0x3];
+    s32 unk_050;            /* 0x050 */
+    s32 unk_054;            /* 0x054 */
     u16 unk_058;            /* 0x058 */
 };
 

--- a/include/CutsceneObject.h
+++ b/include/CutsceneObject.h
@@ -12,8 +12,7 @@ struct CutsceneObject {
     u8  pad_00c[0x74];
     u8  unk_080;            /* 0x080 */
     u8  pad_081[0x5b];
-    u8  mModel;            /* 0x0dc */
-    u8  pad_0dd[0x3];
+    s32 mModel;            /* 0x0dc */
     u8  unk_0e0;            /* 0x0e0 */
     u8  pad_0e1[0x21];
     u8  unk_102;            /* 0x102 */

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -30,8 +30,7 @@ struct Enemy {
        headers already declare it s16. Was a bare u8 marker. */
     s16 unk_094;            /* 0x094 */
     u8  pad_096[0xe];
-    u8  unk_0a4;            /* 0x0a4 */
-    u8  pad_0a5[0x3];
+    s32 unk_0a4;            /* 0x0a4 */
     /* 0x0a8 is Actor.h:99 mVertSpeed; 10 derived headers agree, both evidence
        passes see 4-byte accesses. */
     s32 unk_0a8;            /* 0x0a8 */
@@ -40,18 +39,15 @@ struct Enemy {
        evidenced, so the rest stays padding. */
     s32 unk_0ac;            /* 0x0ac */
     u8  pad_0b0[0x24];
-    u8  unk_0d4;            /* 0x0d4 */
-    u8  pad_0d5[0x3];
-    u8  unk_0d8;            /* 0x0d8 */
-    u8  pad_0d9[0x3];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x3];
+    s32 unk_0d4;            /* 0x0d4 */
+    s32 unk_0d8;            /* 0x0d8 */
+    s32 unk_0dc;            /* 0x0dc */
     u8  unk_0e0;            /* 0x0e0 */
     u8  pad_0e1[0x7];
     u8  unk_0e8;            /* 0x0e8 */
     u8  pad_0e9[0x19];
-    u8  unk_102;            /* 0x102 */
-    u8  pad_103[0x3];
+    s16 unk_102;            /* 0x102 */
+    u8  pad_104[0x2];
     u8  unk_106;            /* 0x106 */
     u8  unk_107;            /* 0x107 */
     u8  pad_108[0x4];

--- a/include/ExpandingHeapAllocator.h
+++ b/include/ExpandingHeapAllocator.h
@@ -12,16 +12,12 @@ struct ptr;
 struct size_;
 struct ExpandingHeapAllocator {
     u8  pad_000[0xc];
-    u8  unk_00c;            /* 0x00c */
-    u8  pad_00d[0x3];
+    s32 unk_00c;            /* 0x00c */
     u8  unk_010;            /* 0x010 */
     u8  pad_011[0x7];
-    u8  unk_018;            /* 0x018 */
-    u8  pad_019[0x3];
-    u8  unk_01c;            /* 0x01c */
-    u8  pad_01d[0x3];
-    u8  unk_020;            /* 0x020 */
-    u8  pad_021[0x3];
+    s32 unk_018;            /* 0x018 */
+    s32 unk_01c;            /* 0x01c */
+    s32 unk_020;            /* 0x020 */
     u8  unk_024;            /* 0x024 */
     u8  pad_025[0x7];
     u8  unk_02c;            /* 0x02c */

--- a/include/Eyerok.h
+++ b/include/Eyerok.h
@@ -41,8 +41,7 @@ struct Eyerok {
     u8  pad_4b8[0x18];
     u8  unk_4d0;            /* 0x4d0 */
     u8  pad_4d1[0x1];
-    u8  unk_4d2;            /* 0x4d2 */
-    u8  pad_4d3[0x1];
+    s16 unk_4d2;            /* 0x4d2 */
     u16 unk_4d4;            /* 0x4d4 */
     u8  pad_4d6[0x19e];
     u8  unk_674;            /* 0x674 */

--- a/include/FaderWipe.h
+++ b/include/FaderWipe.h
@@ -10,10 +10,8 @@
 struct id;
 struct FaderWipe {
     u8  pad_000[0x4];
-    u8  mFadeAmount;            /* 0x004 */
-    u8  pad_005[0x3];
-    u8  unk_008;            /* 0x008 */
-    u8  pad_009[0x3];
+    s32 mFadeAmount;            /* 0x004 */
+    s32 unk_008;            /* 0x008 */
     u16 unk_00c;            /* 0x00c */
     u8  pad_00e[0x2];
     u8  unk_010;            /* 0x010 */

--- a/include/Heap.h
+++ b/include/Heap.h
@@ -12,12 +12,9 @@ struct a_;
 struct b;
 struct Heap {
     u8  pad_000[0x4];
-    u8  unk_004;            /* 0x004 */
-    u8  pad_005[0x3];
-    u8  unk_008;            /* 0x008 */
-    u8  pad_009[0x3];
-    u8  unk_00c;            /* 0x00c */
-    u8  pad_00d[0x3];
+    s32 unk_004;            /* 0x004 */
+    s32 unk_008;            /* 0x008 */
+    s32 unk_00c;            /* 0x00c */
     u8  unk_010;            /* 0x010 */
 #ifdef __cplusplus
     /* methods */

--- a/include/HeapAllocator.h
+++ b/include/HeapAllocator.h
@@ -8,10 +8,8 @@
 
 struct HeapAllocator {
     u8  pad_000[0x18];
-    u8  unk_018;            /* 0x018 */
-    u8  pad_019[0x3];
-    u8  unk_01c;            /* 0x01c */
-    u8  pad_01d[0x3];
+    s32 unk_018;            /* 0x018 */
+    s32 unk_01c;            /* 0x01c */
     u32 unk_020;            /* 0x020 */
 #ifdef __cplusplus
     /* methods */

--- a/include/HeaveHo.h
+++ b/include/HeaveHo.h
@@ -35,8 +35,7 @@ struct HeaveHo {
     u8  pad_3a0[0x4];
     u8  mShadowModel;            /* 0x3a4 */
     u8  pad_3a5[0x57];
-    u8  unk_3fc;            /* 0x3fc */
-    u8  pad_3fd[0x3];
+    s32 unk_3fc;            /* 0x3fc */
     s32 unk_400;            /* 0x400 */
     s32 unk_404;            /* 0x404 */
     s32 unk_408;            /* 0x408 */

--- a/include/HootTheOwl.h
+++ b/include/HootTheOwl.h
@@ -38,8 +38,7 @@ struct HootTheOwl {
     u8  pad_36c[0x4];
     u8  mShadowModel;            /* 0x370 */
     u8  pad_371[0x57];
-    u8  mCurrentState;            /* 0x3c8 */
-    u8  pad_3c9[0x3];
+    s32 mCurrentState;            /* 0x3c8 */
     s32 unk_3cc;            /* 0x3cc */
     u8  pad_3d0[0x4];
     u8  unk_3d4;            /* 0x3d4 */

--- a/include/IceSlideManager.h
+++ b/include/IceSlideManager.h
@@ -14,8 +14,7 @@ struct IceSlideManager {
     u8  pad_061[0x3];
     u8  unk_064;            /* 0x064 */
     u8  pad_065[0x6f];
-    u8  unk_0d4;            /* 0x0d4 */
-    u8  pad_0d5[0x1];
+    s16 unk_0d4;            /* 0x0d4 */
     u8  unk_0d6;            /* 0x0d6 */
 #ifdef __cplusplus
     /* methods */

--- a/include/Key.h
+++ b/include/Key.h
@@ -35,8 +35,7 @@ struct Key {
     s32 unk_110;            /* 0x110 */
     u8  mModelAnim;            /* 0x114 */
     u8  pad_115[0xf];
-    u8  unk_124;            /* 0x124 */
-    u8  pad_125[0x3];
+    s32 unk_124;            /* 0x124 */
     u8  unk_128;            /* 0x128 */
     u8  pad_129[0x3b];
     u8  mAnimation;            /* 0x164 */

--- a/include/KingBobOmb.h
+++ b/include/KingBobOmb.h
@@ -33,8 +33,7 @@ struct KingBobOmb {
     u8  pad_3bd[0x3b];
     u8  mShadowModel;            /* 0x3f8 */
     u8  pad_3f9[0x9b];
-    u8  unk_494;            /* 0x494 */
-    u8  pad_495[0x3];
+    s32 unk_494;            /* 0x494 */
     u8  unk_498;            /* 0x498 */
     u8  pad_499[0x7];
     s32 unk_4a0;            /* 0x4a0 */

--- a/include/Klepto.h
+++ b/include/Klepto.h
@@ -44,14 +44,13 @@ struct Klepto {
     u8  pad_394[0x10];
     u8  mShadowModel;            /* 0x3a4 */
     u8  pad_3a5[0x87];
-    u8  unk_42c;            /* 0x42c */
-    u8  pad_42d[0x3];
+    s32 unk_42c;            /* 0x42c */
     s32 unk_430;            /* 0x430 */
     s32 unk_434;            /* 0x434 */
     s32 unk_438;            /* 0x438 */
     u8  pad_43c[0x8];
-    u8  unk_444;            /* 0x444 */
-    u8  pad_445[0x3];
+    s16 unk_444;            /* 0x444 */
+    u8  pad_446[0x2];
     u8  unk_448;            /* 0x448 */
     u8  pad_449[0x1];
     s16 unk_44a;            /* 0x44a */

--- a/include/KnockDownPlank.h
+++ b/include/KnockDownPlank.h
@@ -22,12 +22,9 @@ struct KnockDownPlank {
     u8  pad_0d5[0x4f];
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  unk_320;            /* 0x320 */
-    u8  pad_321[0x3];
-    u8  unk_324;            /* 0x324 */
-    u8  pad_325[0x3];
-    u8  unk_328;            /* 0x328 */
-    u8  pad_329[0x3];
+    s32 unk_320;            /* 0x320 */
+    s32 unk_324;            /* 0x324 */
+    s32 unk_328;            /* 0x328 */
     s32 mVariant;            /* 0x32c */
 #ifdef __cplusplus
     /* methods */

--- a/include/KoopaTheQuick.h
+++ b/include/KoopaTheQuick.h
@@ -44,18 +44,13 @@ struct KoopaTheQuick {
     u8  pad_365[0x27];
     s32 unk_38c;            /* 0x38c */
     u8  pad_390[0x4];
-    u8  unk_394;            /* 0x394 */
-    u8  pad_395[0x3];
-    u8  unk_398;            /* 0x398 */
-    u8  pad_399[0x3];
-    u8  unk_39c;            /* 0x39c */
-    u8  pad_39d[0x3];
-    u8  unk_3a0;            /* 0x3a0 */
-    u8  pad_3a1[0x3];
+    s32 unk_394;            /* 0x394 */
+    s32 unk_398;            /* 0x398 */
+    s32 unk_39c;            /* 0x39c */
+    s32 unk_3a0;            /* 0x3a0 */
     u8  unk_3a4;            /* 0x3a4 */
     u8  pad_3a5[0x5];
-    u8  unk_3aa;            /* 0x3aa */
-    u8  pad_3ab[0x1];
+    s16 unk_3aa;            /* 0x3aa */
     u8  unk_3ac;            /* 0x3ac */
     u8  unk_3ad;            /* 0x3ad */
     u8  unk_3ae;            /* 0x3ae */
@@ -67,14 +62,10 @@ struct KoopaTheQuick {
     u8  unk_3b5;            /* 0x3b5 */
     u8  unk_3b6;            /* 0x3b6 */
     u8  pad_3b7[0x1];
-    u8  unk_3b8;            /* 0x3b8 */
-    u8  pad_3b9[0x3];
-    u8  unk_3bc;            /* 0x3bc */
-    u8  pad_3bd[0x3];
-    u8  unk_3c0;            /* 0x3c0 */
-    u8  pad_3c1[0x3];
-    u8  unk_3c4;            /* 0x3c4 */
-    u8  pad_3c5[0x3];
+    s32 unk_3b8;            /* 0x3b8 */
+    s32 unk_3bc;            /* 0x3bc */
+    s32 unk_3c0;            /* 0x3c0 */
+    s32 unk_3c4;            /* 0x3c4 */
     u8  unk_3c8;            /* 0x3c8 */
     u8  pad_3c9[0xf];
     u8  mPathPtr;            /* 0x3d8 */

--- a/include/LavaBubble.h
+++ b/include/LavaBubble.h
@@ -30,8 +30,7 @@ struct LavaBubble {
     u8  pad_138[0xc];
     u8  mWithMeshClsn;            /* 0x144 */
     u8  pad_145[0x1bb];
-    u8  unk_300;            /* 0x300 */
-    u8  pad_301[0x3];
+    s32 unk_300;            /* 0x300 */
     s32 unk_304;            /* 0x304 */
     s32 unk_308;            /* 0x308 */
     s32 unk_30c;            /* 0x30c */

--- a/include/MovingBarSmall.h
+++ b/include/MovingBarSmall.h
@@ -35,8 +35,7 @@ struct MovingBarSmall {
     s32 unk_380;            /* 0x380 */
     s32 unk_384;            /* 0x384 */
     s32 unk_388;            /* 0x388 */
-    u8  unk_38c;            /* 0x38c */
-    u8  pad_38d[0x3];
+    s32 unk_38c;            /* 0x38c */
     u8  unk_390;            /* 0x390 */
     u8  unk_391;            /* 0x391 */
     u8  unk_392;            /* 0x392 */

--- a/include/Particle__EndingStarGlitterCallback.h
+++ b/include/Particle__EndingStarGlitterCallback.h
@@ -8,8 +8,7 @@
 
 struct Particle__EndingStarGlitterCallback {
     u8  pad_000[0x308];
-    u8  unk_308;            /* 0x308 */
-    u8  pad_309[0x3];
+    s32 unk_308;            /* 0x308 */
     u8  unk_30c;            /* 0x30c */
 };
 

--- a/include/Particle__SysTracker.h
+++ b/include/Particle__SysTracker.h
@@ -8,8 +8,7 @@
 
 struct Particle__SysTracker {
     u8  pad_000[0x4];
-    u8  unk_004;            /* 0x004 */
-    u8  pad_005[0x3];
+    s32 unk_004;            /* 0x004 */
     u8  unk_008;            /* 0x008 */
 };
 

--- a/include/PoleBillboard.h
+++ b/include/PoleBillboard.h
@@ -26,8 +26,7 @@ struct PoleBillboard {
     s32 unk_380;            /* 0x380 */
     s32 unk_384;            /* 0x384 */
     s32 unk_388;            /* 0x388 */
-    u8  unk_38c;            /* 0x38c */
-    u8  pad_38d[0x3];
+    s32 unk_38c;            /* 0x38c */
     u16 unk_390;            /* 0x390 */
     s16 unk_392;            /* 0x392 */
     s16 unk_394;            /* 0x394 */

--- a/include/RaycastLine__Line.h
+++ b/include/RaycastLine__Line.h
@@ -8,10 +8,8 @@
 
 struct RaycastLine__Line {
     u8  pad_000[0xc];
-    u8  unk_00c;            /* 0x00c */
-    u8  pad_00d[0x3];
-    u8  unk_010;            /* 0x010 */
-    u8  pad_011[0x3];
+    s32 unk_00c;            /* 0x00c */
+    s32 unk_010;            /* 0x010 */
     u8  unk_014;            /* 0x014 */
 };
 

--- a/include/RotatingUpDownPlatformUtm.h
+++ b/include/RotatingUpDownPlatformUtm.h
@@ -45,10 +45,8 @@ struct RotatingUpDownPlatformUtm {
     u8  mWaypointIndex;            /* 0x394 */
     u8  mVariant;            /* 0x395 */
     u8  pad_396[0x2];
-    u8  mPlatform0;            /* 0x398 */
-    u8  pad_399[0x3];
-    u8  mPlatform1;            /* 0x39c */
-    u8  pad_39d[0x3];
+    s32 mPlatform0;            /* 0x398 */
+    s32 mPlatform1;            /* 0x39c */
     u8  unk_3a0;            /* 0x3a0 */
     u8  pad_3a1[0x1];
     u8  unk_3a2;            /* 0x3a2 */

--- a/include/Shark.h
+++ b/include/Shark.h
@@ -34,8 +34,7 @@ struct Shark {
     u8  pad_151[0x1bb];
     u8  mModelAnim;            /* 0x30c */
     u8  pad_30d[0x63];
-    u8  unk_370;            /* 0x370 */
-    u8  pad_371[0x3];
+    s32 unk_370;            /* 0x370 */
     s32 unk_374;            /* 0x374 */
     s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */

--- a/include/Snowball.h
+++ b/include/Snowball.h
@@ -32,8 +32,7 @@ struct Snowball {
     u8  pad_301[0x4f];
     u8  mShadowModel;            /* 0x350 */
     u8  pad_351[0x27];
-    u8  unk_378;            /* 0x378 */
-    u8  pad_379[0x3];
+    s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */
     s32 unk_380;            /* 0x380 */
     s32 unk_384;            /* 0x384 */

--- a/include/SolidHeapAllocator.h
+++ b/include/SolidHeapAllocator.h
@@ -15,12 +15,9 @@ struct ptr;
 struct size_;
 struct SolidHeapAllocator {
     u8  pad_000[0x18];
-    u8  unk_018;            /* 0x018 */
-    u8  pad_019[0x3];
-    u8  mEnd;            /* 0x01c */
-    u8  pad_01d[0x3];
-    u8  unk_020;            /* 0x020 */
-    u8  pad_021[0x3];
+    s32 unk_018;            /* 0x018 */
+    s32 mEnd;            /* 0x01c */
+    s32 unk_020;            /* 0x020 */
     u8  mFreeRegion;            /* 0x024 */
 #ifdef __cplusplus
     /* methods */

--- a/include/Submarine.h
+++ b/include/Submarine.h
@@ -21,8 +21,7 @@ struct Submarine {
     u8  pad_098[0x68];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  unk_110;            /* 0x110 */
-    u8  pad_111[0x3];
+    s32 unk_110;            /* 0x110 */
     u8  mModelAnim;            /* 0x114 */
     u8  pad_115[0x7];
     u8  unk_11c;            /* 0x11c */

--- a/include/SwitchActivatedPlank.h
+++ b/include/SwitchActivatedPlank.h
@@ -16,8 +16,7 @@ struct SwitchActivatedPlank {
     u8  pad_125[0x1fb];
     u8  mModel2;            /* 0x320 */
     u8  pad_321[0x7f];
-    u8  unk_3a0;            /* 0x3a0 */
-    u8  pad_3a1[0x1];
+    s16 unk_3a0;            /* 0x3a0 */
     u8  unk_3a2;            /* 0x3a2 */
     u8  unk_3a3;            /* 0x3a3 */
     u8  unk_3a4;            /* 0x3a4 */

--- a/include/Tornado.h
+++ b/include/Tornado.h
@@ -32,8 +32,7 @@ struct Tornado {
     u8  pad_315[0x13];
     u8  mTextureTransformer;            /* 0x328 */
     u8  pad_329[0x13];
-    u8  unk_33c;            /* 0x33c */
-    u8  pad_33d[0x3];
+    s32 unk_33c;            /* 0x33c */
     s32 unk_340;            /* 0x340 */
     s32 unk_344;            /* 0x344 */
     s32 unk_348;            /* 0x348 */

--- a/include/TtcConveyorBeltLarge.h
+++ b/include/TtcConveyorBeltLarge.h
@@ -36,8 +36,7 @@ struct TtcConveyorBeltLarge {
     s32 mTargetBeltSpeed;            /* 0x390 */
     s32 unk_394;            /* 0x394 */
     s32 unk_398;            /* 0x398 */
-    u8  unk_39c;            /* 0x39c */
-    u8  pad_39d[0x1];
+    s16 unk_39c;            /* 0x39c */
     u8  mVariant;            /* 0x39e */
 #ifdef __cplusplus
     /* methods */

--- a/include/Unagi.h
+++ b/include/Unagi.h
@@ -33,8 +33,7 @@ struct Unagi {
     u8  pad_151[0x3f];
     u8  mWithMeshClsn;            /* 0x190 */
     u8  pad_191[0x1bb];
-    u8  unk_34c;            /* 0x34c */
-    u8  pad_34d[0x3];
+    s32 unk_34c;            /* 0x34c */
     u8  mBlendModelAnim;            /* 0x350 */
     u8  pad_351[0xf];
     s32 unk_360;            /* 0x360 */

--- a/include/UpDownLiftBbh.h
+++ b/include/UpDownLiftBbh.h
@@ -25,10 +25,8 @@ struct UpDownLiftBbh {
     u16 unk_300;            /* 0x300 */
     u8  pad_302[0x1e];
     s32 unk_320;            /* 0x320 */
-    u8  unk_324;            /* 0x324 */
-    u8  pad_325[0x3];
-    u8  mVariant;            /* 0x328 */
-    u8  pad_329[0x3];
+    s32 unk_324;            /* 0x324 */
+    s32 mVariant;            /* 0x328 */
     s32 mState;            /* 0x32c */
     s32 unk_330;            /* 0x330 */
     u8  unk_334;            /* 0x334 */

--- a/notes/plan-scalar-markers.md
+++ b/notes/plan-scalar-markers.md
@@ -1,0 +1,95 @@
+# The scalar-sized u8 markers
+
+**Status:** done for the 71 mechanical cases. One left for a person (§5).
+**Depends on:** #1118 (the evidence passes), #1121 (the base headers).
+
+---
+
+## 1. What a marker is
+
+The original generator wrote a bare `u8` when it did not know a field's type, and
+padded out to the next thing it did know:
+
+```c
+    u8  unk_0a4;            /* 0x0a4 */
+    u8  pad_0a5[0x3];
+```
+
+That is a marker, not a claim that the field is one byte wide -- reading them as
+width claims produced 229 false positives before `gen_header.py` learned the idiom.
+
+But when the marker plus its pad spans **4 bytes or less** there is no room for an
+object. The marker is standing over a scalar, and both evidence passes see accesses
+of a definite width. Those are the 72 this note is about.
+
+## 2. Evidence
+
+| span | observed width | count | becomes |
+|---:|---:|---:|---|
+| 4 | 4 | 64 | `s32`, pad dropped |
+| 2 | 2 | 5 | `s16`, pad dropped |
+| 4 | 2 | 2 | `s16` + `u8 pad[2]` |
+| 2 | 2 **and** 4 | 1 | **left alone** -- see §5 |
+
+33 of the 71 are backed by both the history pass and the ROM pass independently; the
+rest by one. 34 classes, 121 includer files in `src/`.
+
+## 3. Signedness is not evidenced, and that is measured, not assumed
+
+**Zero of the 72 have an ancestor that declares the same offset**, so the hierarchy
+cannot supply a type. Only **one** has any ROM signedness signal at all -- a 4-byte
+load does not reveal signedness, and 64 of these are 4-byte.
+
+So the `s32`/`s16` spelling is not a finding. To establish what it is, the whole
+batch was applied twice and taken through the full gate both ways:
+
+| spelling | eligible | module fidelity |
+|---|---|---|
+| `s32`/`s16` | 10667 | 106/106 exact, PASS |
+| `u32`/`u16` | 10667 | 106/106 exact, PASS |
+
+**Identical.** No includer uses any of these fields in a way that distinguishes
+signed from unsigned -- no sub-word load, no comparison, no right shift, no division.
+Signedness here is *unobservable*, not merely unknown.
+
+That is worth stating precisely, because the two are not the same:
+
+- the **width** fix is proven -- `u8` contradicted the evidence and now agrees with it
+- the **signedness** is a convention, chosen to match `Actor.h`, and the byte gate
+  cannot confirm or refute it
+
+`runbook-type-reconstruction.md` §2 warns that `s32 -> u32` flips `movgt/movle` to
+`movhi/movls` and `asr` to `lsr`. That is exactly why this had to be measured rather
+than reasoned about: the warning is real, it just does not bite where nothing reads
+the field.
+
+## 4. Preserving offsets
+
+Every retype shrinks the following pad by the width gained and renames it to its new
+offset. `build/check_offsets.py` walks each struct, applies natural alignment, and
+compares every field's computed position against its comment: **562 commented fields
+across 33 headers, 0 mismatched**.
+
+The type column is padded so the field names stay aligned -- a 3-character type takes
+one less space than `u8`.
+
+## 5. The one left for a person
+
+```
+G2x.unk_004 @0x4  span=2  observed widths [2, 4]   include/G2x.h:13
+```
+
+The history pass sees both a 2-byte and a 4-byte access at the same offset, and the
+4-byte one does not fit the 2-byte span. Plan §4 sends conflicting evidence to a
+human rather than resolving it to the widest or the narrowest. Either the span is
+wrong, or two fields overlap, or one access is misattributed.
+
+## 6. What this does not do
+
+- **No renaming.** `unk_0a4` stays `unk_0a4`. Renaming cannot change codegen, which
+  is exactly why it belongs in its own commit -- mixing it in makes the byte gate's
+  signal unreadable.
+- **No touching the 179 object-extent markers.** Those have spans too large to be
+  scalars and mostly address-only evidence; they need types, not widths.
+- **No guessing signedness from a name.** `mAngle*` being signed elsewhere is a
+  pattern, not evidence about these fields.

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -1,0 +1,41 @@
+"""Confirm every field in a struct header lands on the offset its comment claims.
+
+The generated headers encode layout twice: once as a sequence of declarations and
+pads, and once as a `/* 0x0a4 */` comment per field. Retyping a field silently
+breaks the agreement between them unless the following pad is shrunk to match, and
+nothing else in the build would notice -- a header is not compiled on its own, and
+the byte gate cannot see a field no source file happens to read.
+
+This walks the declarations, applies natural alignment, and compares. Used as the
+first gate on any header edit; see notes/plan-scalar-markers.md 4.
+
+    python tools/check_header_offsets.py include/Enemy.h include/Camera.h
+    python tools/check_header_offsets.py $(git diff --name-only include/)
+"""
+import re, sys, pathlib
+SZ = {"u8":1,"s8":1,"char":1,"u16":2,"s16":2,"short":2,"u32":4,"s32":4,"int":4,
+      "Fix12i":4,"float":4,"u64":8,"s64":8}
+DECL = re.compile(r"^\s*(\w+)\s+(\w+)\s*(?:\[\s*(0x[0-9a-fA-F]+|\d+)\s*\])?\s*;(?:\s*/\*\s*(0x[0-9a-fA-F]+))?")
+for path in sys.argv[1:]:
+    txt = pathlib.Path(path).read_text(errors="replace")
+    off, bad, n = 0, 0, 0
+    started = False
+    for line in txt.splitlines():
+        if re.match(r"^\s*struct \w+ \{", line):
+            started = True; continue
+        if not started: continue
+        if re.match(r"^\s*(#|\}|/\* methods)", line): break
+        m = DECL.match(line)
+        if not m: continue
+        typ, name, arr, decl = m.groups()
+        if typ not in SZ: continue
+        w = SZ[typ]
+        if off % w:                       # compiler would insert padding here
+            off += w - (off % w)
+        if decl is not None:
+            n += 1
+            if int(decl, 16) != off:
+                print(f"  MISMATCH {path} {name}: comment {decl}, computed 0x{off:03x}")
+                bad += 1
+        off += w * (int(arr, 0) if arr else 1)
+    print(f"{path}: {n} commented fields, {bad} mismatched, struct spans 0x{off:x}")


### PR DESCRIPTION
Third in the gen_header programme, after #1118 (evidence passes) and #1121 (base headers). Note: `notes/plan-scalar-markers.md`.

## What a marker is

The original generator wrote a bare `u8` whenever it didn't know a field's type, then padded to the next thing it did know:

```c
    u8  unk_0a4;            /* 0x0a4 */
    u8  pad_0a5[0x3];
```

That's a marker, not a one-byte width claim — reading them as claims produced 229 false positives before `gen_header.py` learned the idiom.

But where the marker **plus its pad spans 4 bytes or less**, there's no room for an object. It's standing over a scalar, and both evidence passes see accesses of a definite width.

| span | observed | count | becomes |
|---:|---:|---:|---|
| 4 | 4 | 64 | `s32`, pad dropped |
| 2 | 2 | 5 | `s16`, pad dropped |
| 4 | 2 | 2 | `s16` + `u8 pad[2]` |

33 of the 71 are backed independently by *both* the history and ROM passes.

## Signedness isn't evidenced — and that's measured, not assumed

**Zero** of these have an ancestor declaring the same offset, and a 4-byte load doesn't reveal signedness (64 of 71 are 4-byte). So rather than pick and hope, the whole batch went through the full gate **twice**:

| spelling | eligible | module fidelity |
|---|---|---|
| `s32`/`s16` | 10667 | 106/106 exact, PASS |
| `u32`/`u16` | 10667 | 106/106 exact, PASS |

**Identical.** Nothing reads these fields in a way that distinguishes signed from unsigned — no sub-word load, no comparison, no right shift, no division.

So this PR proves the **width** and does not prove the **signedness**. The `s32`/`s16` spelling is a convention chosen to match `Actor.h`. `runbook-type-reconstruction.md` warns that `s32 → u32` flips `movgt/movle` to `movhi/movls` and `asr` to `lsr` — that warning is real, it just doesn't bite where nothing reads the field. Recorded in the note rather than left for someone to rediscover and mistake for a finding.

## Offset integrity

Each retype shrinks the following pad by the width gained and renames it. That agreement between declarations and `/* 0x0a4 */` comments is invisible to every other gate — a header isn't compiled alone, and the byte gate can't see a field no source file reads.

So this adds **`tools/check_header_offsets.py`**, which walks each struct, applies natural alignment, and compares every field against its comment:

```
562 commented fields across 33 headers, 0 mismatched
```

## Verification

```
eligible.py before/after : 10667 -> 10667, 0 files lost their match
module fidelity          : 106/106 exact, ROM-build analysis PASS
attribution              : 0 changed, 0 lost
marker: scalar-sized     : 72 -> 1
confirmed                : 2052 -> 2123
```

121 files in `src/` include the 33 touched headers; all changed-file effects are enrolled and link-verified.

## One left for a person

```
G2x.unk_004 @0x4  span=2  observed widths [2, 4]   include/G2x.h:13
```

Both a 2-byte and a 4-byte access at one offset, in a 2-byte span. Conflicting evidence goes to a human rather than being resolved to the widest or narrowest — either the span is wrong, two fields overlap, or one access is misattributed.

## Out of scope

No renaming (`unk_0a4` stays `unk_0a4` — free, and belongs in its own commit so the gate's signal stays readable). No touching the 179 object-extent markers, which need types rather than widths.

**33 in-scope files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi