### PR TITLE
tools: split gen_header's "new" bucket, which overstated discovery ~4x

### DIFF
--- a/tools/gen_header.py
+++ b/tools/gen_header.py
@@ -200,12 +200,44 @@ def main():
         if prev is None or (prev["base_cls"] in bannered and c["base_cls"] not in bannered):
             target[key] = c
 
+    # Ancestor lookup, over ALL headers -- the reference (de-bannered) ones like
+    # Actor.h are exactly the ancestors that matter and are not in `headers`.
+    chain_of = {k: v.get("base") for k, v in hier.get("hierarchy", {}).items()}
+    any_fields_cache = {}
+
+    def any_fields(name):
+        if name not in any_fields_cache:
+            p = root / "include" / f"{name}.h"
+            got = {}
+            if p.exists():
+                for ln in p.read_text(errors="replace").splitlines():
+                    g = FIELD.match(ln)
+                    if g and not g.group(3).startswith("pad_"):
+                        got[int(g.group(5), 16)] = g.group(1).strip()
+            any_fields_cache[name] = got
+        return any_fields_cache[name]
+
+    def ancestors(name, _seen=None):
+        _seen = _seen or set()
+        cur = chain_of.get(name)
+        while cur and cur not in _seen:
+            _seen.add(cur)
+            yield cur
+            cur = chain_of.get(cur)
+
     buckets = collections.Counter()
     findings = collections.defaultdict(list)
     per_class = {}
 
     for cls, fields in sorted(headers.items()):
         pc = collections.Counter()
+
+        def ancestor_type(off, _cls=cls):
+            for a in ancestors(_cls):
+                t = any_fields(a).get(off)
+                if t is not None:
+                    return a, t
+            return None
         for off, (typ, ptr, arr, name, where, placeholder, span) in sorted(fields.items()):
             dw = declared_width(typ, ptr, arr)
             obs = widths_for(passes, cls, off)
@@ -281,17 +313,44 @@ def main():
             buckets[bucket] += 1
             pc[bucket] += 1
 
-        # offsets evidence shows that the header does not declare
+        # Offsets evidence reaches that the header does not declare. A bare count of
+        # these badly overstates what has been discovered: most are the vtable slot,
+        # the interior of a field already declared, or an inherited field this flat
+        # header pads over. Split them so "new" means new.
         seen = set()
         for pname, data in passes.items():
             if data:
                 seen |= {int(o, 16) for o in data.get("classes", {}).get(cls, {})}
-        nnew = len(seen - set(fields))
-        buckets["new"] += nnew
-        pc["new"] = nnew
+
+        # what each declared field actually covers
+        extents = []
+        for o, (typ, ptr, arr, name, where, ph, span) in fields.items():
+            if ph and span:
+                extents.append((o, o + span))
+            else:
+                w = declared_width(typ, ptr, arr) or 1
+                n = int(arr.strip("[]"), 0) if arr else 1
+                extents.append((o, o + w * n))
+
+        for off in sorted(seen - set(fields)):
+            if off == 0:
+                b = "new: vtable slot"          # every bannered header pads 0x0
+            elif any(a < off < z for a, z in extents):
+                b = "new: interior to a declared field"
+            elif ancestor_type(off) is not None:
+                b = "new: declared by an ancestor"
+            elif not widths_for(passes, cls, off):
+                b = "new: address-only"
+            else:
+                b = "new: novel field"
+                findings[b].append({
+                    "cls": cls, "offset": hex(off),
+                    "observed": {k: sorted(v) for k, v in widths_for(passes, cls, off).items()}})
+            buckets[b] += 1
+            pc[b] = pc.get(b, 0) + 1
         per_class[cls] = dict(pc)
 
-    total = sum(v for k, v in buckets.items() if k != "new")
+    total = sum(v for k, v in buckets.items() if not k.startswith("new"))
     report = {"passes_run": ran, "passes_missing": missing,
               "buckets": dict(buckets), "total_declared_fields": total,
               "per_class": per_class, "findings": {k: v for k, v in findings.items()}}
@@ -309,12 +368,17 @@ def main():
              "base-sign-conflict", "base-sign-conflict (weak: base unverified)",
              "marker: scalar-sized, retype", "marker: object, extent unknown",
              "offset-corroborated (width unverified)", "unreached by any pass",
-             "unknown-type"]
+             "unknown-type",
+             "new: novel field", "new: declared by an ancestor",
+             "new: interior to a declared field", "new: vtable slot",
+             "new: address-only"]
     for b in order:
         n = buckets.get(b, 0)
-        if n or b in ("confirmed", "unreached by any pass"):
-            print(f"  {b:<26} {n:>6}  ({100*n/max(1,total):5.1f}%)")
-    print(f"  {'new (not in header)':<26} {buckets.get('new', 0):>6}")
+        if b.startswith("new") and n:
+            print(f"  {b:<38} {n:>6}")
+        elif not b.startswith("new") and (n or b in ("confirmed", "unreached by any pass")):
+            print(f"  {b:<38} {n:>6}  ({100*n/max(1,total):5.1f}%)")
+
 
     for b in ("base-conflict", "base-conflict (weak: base unverified)",
               "width-contradicted", "signedness-contradicted",


### PR DESCRIPTION
Follow-up to #1118. Tools only — no `src/`, `include/`, or `config/` changes.

## The problem

The differential ended with `new (not in header): 1290`, which reads naturally as *1,290 fields the headers are missing*. Most of it is nothing of the kind.

| bucket | count | what it is |
|---|---:|---|
| **new: novel field** | **290** | actually new |
| new: declared by an ancestor | 299 | inherited; this flat header pads over it |
| new: interior to a declared field | 359 | inside a field or marker already declared |
| new: vtable slot | 229 | offset 0, which every bannered header pads **on purpose** |
| new: address-only | 113 | address taken, no sized access |

Only the first is a discovery. The vtable slot is deliberate — `runbook-type-reconstruction.md` requires a C-side `void* vtable`, and a header that declared a field there would be the bug. Interiors are sub-object member accesses, not fields. And the ancestor-declared ones are a *different job*: adopting inheritance, not inventing fields.

## Implementation notes

`extents` computes what each declared field actually covers — the marker's full span for placeholders, `width × count` for arrays — so "interior" means genuinely inside something already declared.

The ancestor walk deliberately reads **all** headers, not just the 241 bannered ones. The de-bannered reference headers (`Actor.h`, `ActorBase.h`, `Fader.h`) are precisely the ancestors that matter here, and they are not in the bannered set — restricting to bannered headers would have missed the entire 299.

## Corroboration

An earlier independent review estimated **250–450** genuinely novel, ~228 at offset 0, ~361 interior, ~274 ancestor-declared. This lands at **290 / 229 / 359 / 299** from independently written code. The convergence is the reason to trust the split rather than just the plausibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi