### PR TITLE
fix: correct two false claims in #1129, and the tool bugs behind them

### DIFF
--- a/include/FaderWipe.h
+++ b/include/FaderWipe.h
@@ -10,8 +10,14 @@
 struct id;
 struct FaderWipe {
     u8  pad_000[0x4];
-    s32 mFadeAmount;            /* 0x004 */
-    s32 unk_008;            /* 0x008 */
+    /* These two are Fader's, and include/Fader.h:34-35 already reconstructed them:
+       Fix12i currInterp (0..0x1000, 20.12 fixed point) and Fix12i speed, whose sign
+       selects the fade target. Fix12i is a typedef of s32 -- same bytes, real type
+       named. Not renamed here: renaming cannot change codegen and belongs in its own
+       commit. FaderWipe is one of 7 retyped classes the hierarchy pass cannot place,
+       so "no ancestor declares this offset" was never checkable for it. */
+    Fix12i mFadeAmount;         /* 0x004 -- Fader::currInterp */
+    Fix12i unk_008;             /* 0x008 -- Fader::speed */
     u16 unk_00c;            /* 0x00c */
     u8  pad_00e[0x2];
     u8  unk_010;            /* 0x010 */

--- a/include/HeapAllocator.h
+++ b/include/HeapAllocator.h
@@ -8,8 +8,12 @@
 
 struct HeapAllocator {
     u8  pad_000[0x18];
-    s32 unk_018;            /* 0x018 */
-    s32 unk_01c;            /* 0x01c */
+    /* Pointers, not integers -- the constructor spells it:
+       src/_ZN13HeapAllocatorC1EjPvPvj.cpp stores its two `void*` parameters here as
+       `*(void**)((char*)&self->unk_018) = a;`. Same 4 bytes as s32, so this is
+       byte-identical; it just stops the header under-claiming what the tree proves. */
+    void *unk_018;              /* 0x018 */
+    void *unk_01c;              /* 0x01c */
     u32 unk_020;            /* 0x020 */
 #ifdef __cplusplus
     /* methods */

--- a/notes/plan-scalar-markers.md
+++ b/notes/plan-scalar-markers.md
@@ -34,34 +34,68 @@ of a definite width. Those are the 72 this note is about.
 33 of the 71 are backed by both the history pass and the ROM pass independently; the
 rest by one. 34 classes, 121 includer files in `src/`.
 
-## 3. Signedness is not evidenced, and that is measured, not assumed
+## 3. Signedness is not evidenced -- and two claims made here were wrong
 
-**Zero of the 72 have an ancestor that declares the same offset**, so the hierarchy
-cannot supply a type. Only **one** has any ROM signedness signal at all -- a 4-byte
-load does not reveal signedness, and 64 of these are 4-byte.
+> **Correction.** Two statements in this section and in the #1129 commit message were
+> false. They are struck through below rather than deleted, because the commit message
+> is permanent and someone will read it. Adversarial review caught both.
 
-So the `s32`/`s16` spelling is not a finding. To establish what it is, the whole
-batch was applied twice and taken through the full gate both ways:
+### 3a. "Zero of the 72 have an ancestor that declares the same offset" -- WITHDRAWN
+
+~~Zero of the 72 have an ancestor that declares the same offset.~~
+
+That was a **recall limit reported as a zero** -- exactly the failure this programme
+exists to prevent. The hierarchy pass has no entry at all for 7 of the 34 retyped
+classes, so for those the question was never asked, let alone answered.
+
+`FaderWipe` is the counterexample and it is not a marginal one. ROM RTTI places
+`Fader <- FaderBrightness <- FaderColor <- FaderWipe`, and `include/Fader.h:34-35` --
+de-bannered, hand-reconstructed, the strongest reference in the tree -- declares
+`Fix12i currInterp /* 0x04 */` and `Fix12i speed /* 0x08 */`. Those are precisely the
+two FaderWipe offsets retyped as "no ancestor". The generator's own input at
+`5ddf7d2d~1:src/_ZN9FaderWipeC1Ev.c` names them too.
+
+Both are now declared `Fix12i` (a typedef of `s32`, so byte-identical). So is
+`HeapAllocator` 0x018/0x01c, which its own constructor stores `void*` into.
+
+**A pass that cannot see a class must say so, not return zero.**
+
+### 3b. "No sub-word load" -- WITHDRAWN
+
+~~No includer uses any of these fields in a way that distinguishes signed from
+unsigned -- no sub-word load, no comparison, no right shift, no division.~~
+
+There is a sub-word access: `src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp:35` does an
+`unsigned short*` read-modify-write on retyped `unk_3a0`. The correct statement is
+narrower and is what the experiment actually shows: **no access whose codegen depends
+on the declared type.** Every compiled reference to these fields goes through an
+address-cast (`*(int*)((char*)&self->unk_018)`), and a cast ignores the declaration.
+
+### 3c. What the experiment does and does not prove
+
+The whole batch was applied twice and taken through the full gate both ways:
 
 | spelling | eligible | module fidelity |
 |---|---|---|
 | `s32`/`s16` | 10667 | 106/106 exact, PASS |
 | `u32`/`u16` | 10667 | 106/106 exact, PASS |
 
-**Identical.** No includer uses any of these fields in a way that distinguishes
-signed from unsigned -- no sub-word load, no comparison, no right shift, no division.
-Signedness here is *unobservable*, not merely unknown.
+Review reproduced this at object level, which is stronger: all 119 includers compiled
+under both spellings, **117/117 byte-identical** (2 fail identically before and after),
+plus a positive control -- a scratch TU doing `>> 4` and `/ 2` on these fields *does*
+produce different bytes, so the method detects sign-sensitivity when it exists.
 
-That is worth stating precisely, because the two are not the same:
+What that proves is **harmlessness**, not width:
 
-- the **width** fix is proven -- `u8` contradicted the evidence and now agrees with it
-- the **signedness** is a convention, chosen to match `Actor.h`, and the byte gate
-  cannot confirm or refute it
+- the **width** rests on the evidence passes, not on the gate. After the arm9 base
+  fix (#1132), **52 of 71** are backed independently by both passes, up from the 33
+  published; none lost its backing.
+- the **signedness** is a convention matching `Actor.h`. The gate cannot confirm or
+  refute it, and saying "the gate proved the width" would have been wrong.
 
 `runbook-type-reconstruction.md` §2 warns that `s32 -> u32` flips `movgt/movle` to
-`movhi/movls` and `asr` to `lsr`. That is exactly why this had to be measured rather
-than reasoned about: the warning is real, it just does not bite where nothing reads
-the field.
+`movhi/movls` and `asr` to `lsr`. The warning is real; it does not bite where every
+access is cast anyway.
 
 ## 4. Preserving offsets
 

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -14,28 +14,67 @@ first gate on any header edit; see notes/plan-scalar-markers.md 4.
 """
 import re, sys, pathlib
 SZ = {"u8":1,"s8":1,"char":1,"u16":2,"s16":2,"short":2,"u32":4,"s32":4,"int":4,
-      "Fix12i":4,"float":4,"u64":8,"s64":8}
-DECL = re.compile(r"^\s*(\w+)\s+(\w+)\s*(?:\[\s*(0x[0-9a-fA-F]+|\d+)\s*\])?\s*;(?:\s*/\*\s*(0x[0-9a-fA-F]+))?")
+      "unsigned":4,"long":4,"Fix12i":4,"float":4,"u64":8,"s64":8,"double":8}
+# `void *p;` / `Model* m;` -- any pointer is 4 bytes on this target
+DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*(\**)\s*(\w+)\s*"
+                  r"(?:\[\s*(0x[0-9a-fA-F]+|\d+)\s*\])?\s*;"
+                  r"(?:\s*/\*\s*(0x[0-9a-fA-F]+))?")
+# lines inside a struct body that are legitimately not declarations
+IGNORABLE = re.compile(r"^\s*($|/\*|\*|//|\}|#)")
+
+rc = 0
 for path in sys.argv[1:]:
     txt = pathlib.Path(path).read_text(errors="replace")
-    off, bad, n = 0, 0, 0
-    started = False
-    for line in txt.splitlines():
-        if re.match(r"^\s*struct \w+ \{", line):
-            started = True; continue
-        if not started: continue
-        if re.match(r"^\s*(#|\}|/\* methods)", line): break
+    off, bad, n, skipped = 0, 0, 0, []
+    started = in_comment = unmodelled = False
+    for lineno, line in enumerate(txt.splitlines(), 1):
+        if not started:
+            if re.match(r"^\s*struct \w+ \{", line):
+                started = True
+            continue
+        if in_comment:
+            if "*/" in line:
+                in_comment = False
+            continue
+        if re.match(r"^\s*(#|\}|/\* methods)", line):
+            break
+        if IGNORABLE.match(line):
+            if "/*" in line and "*/" not in line:
+                in_comment = True
+            continue
+        # A polymorphic C++ struct carries an implicit vptr at offset 0 that no
+        # declaration mentions, so the running offset cannot be derived from the text.
+        # Say the struct is unmodelled rather than emit a mismatch per field.
+        if re.match(r"^\s*(virtual\b|[A-Za-z_][\w:<>, &*]*\([^;]*\)\s*(const)?\s*;)", line):
+            unmodelled = True
+            break
         m = DECL.match(line)
-        if not m: continue
-        typ, name, arr, decl = m.groups()
-        if typ not in SZ: continue
-        w = SZ[typ]
+        typ = m.group(1) if m else None
+        w = 4 if (m and m.group(2)) else SZ.get(typ)
+        if w is None:
+            # An unrecognised declaration is NOT harmless: skipping it leaves the
+            # running offset short, so every later field silently "matches" at the
+            # wrong place. Say so rather than quietly carrying on.
+            skipped.append(f"{lineno}: {line.strip()}")
+            continue
+        _, _, name, arr, decl = m.groups()
         if off % w:                       # compiler would insert padding here
             off += w - (off % w)
         if decl is not None:
             n += 1
             if int(decl, 16) != off:
-                print(f"  MISMATCH {path} {name}: comment {decl}, computed 0x{off:03x}")
+                print(f"  MISMATCH {path}:{lineno} {name}: comment {decl}, "
+                      f"computed 0x{off:03x}")
                 bad += 1
         off += w * (int(arr, 0) if arr else 1)
-    print(f"{path}: {n} commented fields, {bad} mismatched, struct spans 0x{off:x}")
+    if unmodelled:
+        # not a failure: this gate is for the generated flat headers, and a
+        # hand-written polymorphic one has layout the text does not determine
+        print(f"{path}: skipped -- polymorphic C++ struct, implicit vptr not modelled")
+        continue
+    for s in skipped:
+        print(f"  UNPARSED {path}:{s}")
+    print(f"{path}: {n} commented fields, {bad} mismatched, "
+          f"{len(skipped)} unparsed, struct spans 0x{off:x}")
+    rc |= bool(bad or skipped)
+sys.exit(rc)

--- a/tools/gen_header.py
+++ b/tools/gen_header.py
@@ -213,7 +213,10 @@ def main():
                 for ln in p.read_text(errors="replace").splitlines():
                     g = FIELD.match(ln)
                     if g and not g.group(3).startswith("pad_"):
-                        got[int(g.group(5), 16)] = g.group(1).strip()
+                        typ, ptr, _nm, arr, off = g.groups()
+                        w = (4 if ptr else DECLARED_WIDTH.get(typ.strip(), 1)) \
+                            * (int(arr.strip("[]"), 0) if arr else 1)
+                        got[int(off, 16)] = (typ.strip(), w)
             any_fields_cache[name] = got
         return any_fields_cache[name]
 
@@ -233,11 +236,26 @@ def main():
         pc = collections.Counter()
 
         def ancestor_type(off, _cls=cls):
+            """Does any ancestor already account for this offset?
+
+            Matched by EXTENT, not by exact start: an offset landing inside an
+            ancestor's `u8 sceneNode[0x14]` is that field's interior, not a discovery.
+            Exact-offset matching filed those as novel.
+            """
             for a in ancestors(_cls):
-                t = any_fields(a).get(off)
+                af = any_fields(a)
+                t = af.get(off)
                 if t is not None:
                     return a, t
+                for ao, (atyp, aw) in af.items():
+                    if ao < off < ao + aw:
+                        return a, atyp
             return None
+
+        # A class the hierarchy pass could not place has NO ancestors to consult, so
+        # "no ancestor declares this" is unasked, not answered. Counted separately --
+        # reporting an unasked question as a zero is how #1129 shipped a false claim.
+        hierarchy_blind = cls not in chain_of
         for off, (typ, ptr, arr, name, where, placeholder, span) in sorted(fields.items()):
             dw = declared_width(typ, ptr, arr)
             obs = widths_for(passes, cls, off)
@@ -282,6 +300,17 @@ def main():
                 bucket = "unknown-type"
                 findings[bucket].append({"cls": cls, "offset": hex(off),
                                          "field": name, "declared": typ, "where": where})
+            elif len(obs) > 1 and len({w for v in obs.values() for w in v}) > 1:
+                # The passes disagree with each other. `dw in allw` unions them, so the
+                # pass that happens to agree wins and the disagreement disappears --
+                # Timer 0x0 was "confirmed" as s32 because the ROM sees the 4-byte
+                # halves of an s64 (ARM has no 64-bit register, so it cannot see
+                # otherwise) while history reads the real s64 from source. Plan 4 sends
+                # conflicting evidence to a person; it must not be resolved by union.
+                bucket = "cross-pass width disagreement"
+                findings[bucket].append({
+                    "cls": cls, "offset": hex(off), "field": name, "declared": typ,
+                    "observed": {k: sorted(v) for k, v in obs.items()}, "where": where})
             elif dw in allw:
                 bucket = "confirmed"
                 # signedness: only a sub-word LOAD proves it, and only ldrs* proves signed
@@ -322,11 +351,14 @@ def main():
             if data:
                 seen |= {int(o, 16) for o in data.get("classes", {}).get(cls, {})}
 
-        # what each declared field actually covers
+        # What each declared field actually covers. A trailing marker (span None) has
+        # no pad because its object runs to the end of the struct -- load_headers says
+        # so explicitly -- so giving it one byte here contradicted this file's own
+        # semantics and pushed ~76 interior offsets into "novel".
         extents = []
         for o, (typ, ptr, arr, name, where, ph, span) in fields.items():
-            if ph and span:
-                extents.append((o, o + span))
+            if ph:
+                extents.append((o, o + span if span else float("inf")))
             else:
                 w = declared_width(typ, ptr, arr) or 1
                 n = int(arr.strip("[]"), 0) if arr else 1
@@ -339,6 +371,8 @@ def main():
                 b = "new: interior to a declared field"
             elif ancestor_type(off) is not None:
                 b = "new: declared by an ancestor"
+            elif hierarchy_blind:
+                b = "new: unresolved (class not placed in hierarchy)"
             elif not widths_for(passes, cls, off):
                 b = "new: address-only"
             else:
@@ -363,15 +397,27 @@ def main():
         print(f"passes MISSING : {', '.join(missing)}   <- results below are partial")
     print(f"headers        : {len(headers)}   declared fields: {total}")
     print()
-    order = ["confirmed", "width-contradicted", "signedness-contradicted",
-             "base-conflict", "base-conflict (weak: base unverified)",
-             "base-sign-conflict", "base-sign-conflict (weak: base unverified)",
-             "marker: scalar-sized, retype", "marker: object, extent unknown",
-             "offset-corroborated (width unverified)", "unreached by any pass",
-             "unknown-type",
-             "new: novel field", "new: declared by an ancestor",
-             "new: interior to a declared field", "new: vtable slot",
-             "new: address-only"]
+    order = [
+        "confirmed",
+        "width-contradicted",
+        "signedness-contradicted",
+        "base-conflict",
+        "base-conflict (weak: base unverified)",
+        "base-sign-conflict",
+        "base-sign-conflict (weak: base unverified)",
+        "cross-pass width disagreement",
+        "marker: scalar-sized, retype",
+        "marker: object, extent unknown",
+        "offset-corroborated (width unverified)",
+        "unreached by any pass",
+        "unknown-type",
+        "new: novel field",
+        "new: unresolved (class not placed in hierarchy)",
+        "new: declared by an ancestor",
+        "new: interior to a declared field",
+        "new: vtable slot",
+        "new: address-only",
+    ]
     for b in order:
         n = buckets.get(b, 0)
         if b.startswith("new") and n:
@@ -380,9 +426,7 @@ def main():
             print(f"  {b:<38} {n:>6}  ({100*n/max(1,total):5.1f}%)")
 
 
-    for b in ("base-conflict", "base-conflict (weak: base unverified)",
-              "width-contradicted", "signedness-contradicted",
-              "marker: scalar-sized, retype"):
+    for b in ("base-conflict", "base-conflict (weak: base unverified)", "width-contradicted", "signedness-contradicted", "cross-pass width disagreement", "marker: scalar-sized, retype"):
         f = findings.get(b)
         if not f:
             continue
@@ -394,6 +438,9 @@ def main():
             elif b == "width-contradicted":
                 print(f"  {x['cls']}.{x['field']} @{x['offset']}: declared {x['declared']} "
                       f"({x['declared_width']}B), observed {x['observed']}  [{x['where']}]")
+            elif b == "cross-pass width disagreement":
+                print(f"  {x['cls']}.{x['field']} @{x['offset']}: declared {x['declared']}, "
+                      f"passes disagree {x['observed']}  [{x['where']}]")
             elif b.startswith("marker:"):
                 print(f"  {x['cls']}.{x['field']} @{x['offset']}: u8 marker spanning "
                       f"{x['span']}B, observed {x['observed']}  [{x['where']}]")


### PR DESCRIPTION
Adversarial review found two statements in #1129 that are **false**. It's merged, so the commit message is permanent — the correction lands here, and `notes/plan-scalar-markers.md` now carries both struck through rather than deleted.

## Withdrawn: "zero of the 72 have an ancestor that declares the same offset"

A **recall limit reported as a zero** — the exact failure this programme exists to prevent. The hierarchy pass has no entry at all for **7 of the 34** retyped classes, so for those the question was never asked, let alone answered.

`FaderWipe` is the counterexample, and not a marginal one:

| source | says |
|---|---|
| ROM RTTI | `Fader ← FaderBrightness ← FaderColor ← FaderWipe` |
| `include/Fader.h:34-35` | `Fix12i currInterp /* 0x04 */`, `Fix12i speed /* 0x08 */` |
| `5ddf7d2d~1:src/_ZN9FaderWipeC1Ev.c` | names both |

Precisely the two offsets I retyped as "no ancestor." Both are now `Fix12i` — a typedef of `s32`, so byte-identical. `HeapAllocator` 0x018/0x01c become `void*`, which its own constructor proves by storing `void*` parameters into them.

## Withdrawn: "no sub-word load"

`src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp:35` does an `unsigned short*` read-modify-write on a retyped field. The true claim is narrower: **no access whose codegen depends on the *declared* type**, because every reference goes through an address cast and a cast ignores the declaration.

So the A/B experiment proved **harmlessness, not width**. Width rests on the evidence passes — **52 of 71** dual-backed after the arm9 base fix (#1132), up from the 33 published, and none lost its backing.

## Four tool bugs, each of which had let a wrong number through

**`gen_header`: a field was "confirmed" if *any* pass matched**, so passes that disagreed with *each other* were silently resolved by union. `Timer` 0x0 was confirmed as `s32` because the ROM sees the two 4-byte halves of an `s64` — ARM has no 64-bit register, so it *cannot* see otherwise — while history reads the real `s64` from source. Now its own bucket: **7 fields**, and `SphereClsn` shows the same pattern already declared correctly.

**`gen_header`: a trailing marker got a 1-byte extent**, contradicting the file's own statement that its object runs to the end of the struct. Cost ~76 interior offsets miscounted as novel.

**`gen_header`: ancestors matched by exact offset**, so an offset inside an ancestor's `u8 sceneNode[0x14]` read as a discovery rather than its interior.

**`gen_header`: an unplaceable class** now reports `unresolved` instead of silently counting as "no ancestor" — the same sin as the withdrawn claim, fixed at the source.

**`check_header_offsets` could not parse pointers at all.** `void **vtable` in `Actor.h` was skipped **without advancing the offset**, so every later field "matched" 4 bytes out of place — and it still printed `0 mismatched`. It now parses pointers, reports unparsed lines **loudly** instead of skipping them, exits non-zero, and declines to model polymorphic C++ structs rather than emitting a mismatch per field for an implicit vptr it can't see.

## Corrected counts

| | was | now |
|---|---:|---:|
| new: novel field | 290 | **176** (+62 unresolved) |
| new: interior to a declared field | 359 | **460** |
| new: address-only | 113 | **64** |
| cross-pass width disagreement | — | **7** |

Review's independent re-derivation predicted ~460 interior and 228 vtable; this lands on 460 and 228.

## Verification

```
eligible.py     : 10669 -> 10669, 0 files lost their match
module fidelity : 106/106 exact, ROM-build analysis PASS
attribution     : 0 changed, 0 lost
```

**2 in-scope files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi