### PR TITLE
docs: setup could not actually get you the pinned compiler (2004/b56)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,15 +35,22 @@ You bring your own copy of the game. Nothing copyrighted lives in this repo.
 1. **Your own SM64DS cartridge dump (`.nds`).** The symbols and addresses here are
    verified against the **EU (Europe) retail build**, so use that build. The ROM and
    anything extracted from it are git-ignored and must never be committed.
-2. **mwccarm** (Metrowerks CodeWarrior ARM). Proprietary but free; it's pinned in
-   the DS-decompilation Discord, not downloadable directly. Full instructions are
-   in [`notes/setup-mwccarm.md`](notes/setup-mwccarm.md). Extract to
-   `tools/mwccarm/` (git-ignored).
+2. **mwccarm** (Metrowerks CodeWarrior ARM). Two parts, and you need both — full
+   instructions in [`notes/setup-mwccarm.md`](notes/setup-mwccarm.md):
+   - the **sweep** (`mwccarm.zip`, 24 versions): proprietary but free, pinned in the
+     DS-decompilation Discord, not downloadable directly. Extract to `tools/mwccarm/`
+     (git-ignored).
+   - the **pinned build `2004/b56`**, which the zip does *not* contain and which is what
+     the build actually honours: `python tools/recover_cw2004.py` recovers and verifies it
+     from public archives. Run it *after* the zip — it borrows that trio's runtime DLLs.
 3. **dsd** (the ds-decomp toolkit): https://github.com/AetiasHax/ds-decomp, it drives
-   the analysis config in `config/` and rebuilds the ROM from objects.
+   the analysis config in `config/` and rebuilds the ROM from objects. Grab the `0.11.0`
+   binary for your platform from the releases page and put it at `tools/bin/dsd.exe`
+   (`tools/bin/` is git-ignored).
 4. **Python 3** plus a few packages:
    ```
-   pip install ndspy capstone pyelftools
+   pip install ndspy capstone pyelftools    # core
+   pip install py7zr pefile                # only for tools/recover_cw2004.py
    ```
 
 ## First-time setup
@@ -51,11 +58,18 @@ You bring your own copy of the game. Nothing copyrighted lives in this repo.
 ```
 git clone https://github.com/tangosdev/sm64ds-decomp
 cd sm64ds-decomp
-pip install ndspy capstone pyelftools
+pip install ndspy capstone pyelftools py7zr pefile
 
-# get mwccarm per notes/setup-mwccarm.md, then:
+# 1. get mwccarm.zip per notes/setup-mwccarm.md and extract to tools/mwccarm/
+# 2. recover the pinned compiler the zip does not carry (verifies by SHA-256):
+python tools/recover_cw2004.py                         # -> tools/mwccarm/2004/b56/
+# 3. put the dsd 0.11.0 binary at tools/bin/dsd.exe
+# 4. extract your own ROM:
 python tools/unpack.py "path/to/your-own-sm64ds.nds"   # -> populates extracted/ (git-ignored)
 ```
+
+Without step 2 nothing can be byte-verified: `rombuild.py` and `build_pin.verify` only
+accept `2004/b56`, so a sweep hit under another version is iteration, never a verdict.
 
 ## The matching loop
 

--- a/notes/setup-mwccarm.md
+++ b/notes/setup-mwccarm.md
@@ -1,33 +1,94 @@
-# Getting mwccarm + NITRO-SDK (the one human-gated step)
+# Getting mwccarm + NITRO-SDK
 
-`mwccarm` (Metrowerks CodeWarrior ARM) is proprietary and not redistributable, so it
-isn't downloadable directly. It's free but lives in the decomp community's Discord.
+Two separate things, and **the pinned compiler is not one of them**. Read §1 first: it is
+the one the build actually honours, and it is fully scripted. The Discord zip in §2 is for
+the version *sweep*, which is iteration, not a verdict.
 
-## Where
-The **DS Decompilation Discord**: https://discord.com/invite/gwN6M3HQrA
-`mwccarm.zip` is in the **resources** channel. The invite is also linked from the dsd
-toolkit's community section (https://github.com/AetiasHax/ds-decomp), and the pret
-Discord servers (pokediamond/pokeheartgold) have the same pinned files.
+## 1. The pinned compiler: mwccarm 2004/b56 — scripted, no Discord needed
 
-## What to grab (from the pinned messages)
-1. **`mwccarm.zip`**, the whole set of CodeWarrior ARM compiler versions. It contains
-   subfolders like `1.2/`, `2.0/` with service-pack subdirs (e.g. `sp1`, `sp2p2`),
-   each holding `mwccarm.exe`, `mwldarm.exe`, `mwasmarm.exe`.
-2. A **NITRO-SDK** archive if pinned (e.g. `NitroSDK-*.7z`), needed later for SDK
-   library headers/objects. Not required just to start matching game functions.
+The build pins **`2004/b56`** (`rombuild.VERSION`, and `match.py`'s `CANONICAL`). That
+binary is **not in `mwccarm.zip`** — no decomp collection carries it; they all floor at the
+1.2 release, build 72, sixteen builds above it. Extracting the zip and stopping there
+leaves you unable to verify anything, because a hit under any other version is iteration
+and never the verdict (runbook §5).
 
-## Where to put it
-- Extract `mwccarm.zip` to: `tools/mwccarm/` in this repo
-  (so paths look like `tools/mwccarm/2.0/sp2p2/mwccarm.exe`).
-  This folder is gitignored (proprietary, not redistributable).
-- Windows bonus: `mwccarm.exe` is a native Windows binary, so no Wine needed.
+It is recovered from public archives, in-process, with nothing executed:
 
-## Which version do we actually need?
-Unknown until we test (see recon notes). SM64DS is Nov 2004, so likely an early
-CodeWarrior 1.x, but the dead matty45 repo guessed 2.0/sp2p2. Plan once the zip is
-here: take one tiny already-identified leaf function, compile a candidate C version
-with each mwccarm version, and byte-diff against the ROM in objdiff/decomp.me until one
-matches. That match pins the version for the whole project.
+```sh
+pip install py7zr pefile
+python tools/recover_cw2004.py          # -> tools/mwccarm/2004/b56/mwccarm.exe
+```
 
-## .gitignore
-`tools/mwccarm/` must never be committed.
+The script range-fetches only the solid block it needs out of a 5.5 GB archive.org item,
+splits the InstallShield payload, carves `mwccarm.exe`, and **verifies it by size and
+SHA-256** before writing. It then borrows the three runtime DLLs from
+`tools/mwccarm/1.2/sp2p3`, so **do §2 first** — the recovery depends on that trio being
+present.
+
+Notes from running it (recovered and verified 2026-08-05):
+
+- **It transfers about 2 GB, not the "~24 MB" the script's own docstring claims.** The
+  three header range-requests are tiny, but the solid block holding the installer is
+  ~1,982 MB. Budget for that on a metered connection. Total runtime was a few minutes.
+- **archive.org rate-limits.** A range request can come back HTTP ≥400 and the script
+  exits with `curl` status 22. It is transient — the same range succeeded on retry — and
+  completed pieces are cached in `.cw2004work/`, so simply re-run; an interrupted big
+  block is not paid for twice.
+- **Confirm it end to end, not just by hash.** The script checks SHA-256 and the
+  `-version` banner (`Version 2.0 build 56`). To prove the result actually reproduces ROM
+  bytes, verify one already-matched function:
+
+  ```sh
+  python - <<'PY'
+  import sys; sys.path.insert(0, "tools"); import build_pin as BP
+  print(BP.verify("src/engine/fader/_ZN5Fader13AdvanceInterpEv.cpp",
+                  "_ZN5Fader13AdvanceInterpEv", 0x020175e8, 0x28, "arm9"))
+  PY
+  # -> (True, '2004/b56')
+  ```
+- **`license.dat` is not required.** The tooling points `LM_LICENSE_FILE` at
+  `tools/mwccarm/license.dat`, but these builds run without it and the file is absent from
+  a normal setup. Do not go hunting for it.
+- `b56` **ships no linker.** The ROM linker stays `1.2/sp2p3` `mwldarm` (`LD_VERSION`).
+
+Why this build: it materializes the address of a member read-modify-write where every
+2005+ build folds it into the addressing mode — the long-standing "materialization wall".
+See `notes/mwccarm-codegen.md` §6ah for what it wins and what it costs.
+
+## 2. The version sweep: mwccarm.zip — still human-gated
+
+`mwccarm` is proprietary but free, and the collection is not downloadable directly; it
+lives in the decomp community's Discord.
+
+- **DS Decompilation Discord**: https://discord.com/invite/gwN6M3HQrA — `mwccarm.zip` is in
+  the **resources** channel. The invite is also linked from the dsd toolkit's community
+  section (https://github.com/AetiasHax/ds-decomp), and the pret servers
+  (pokediamond/pokeheartgold) pin the same files.
+- Extract to `tools/mwccarm/`, so paths read `tools/mwccarm/2.0/sp2p2/mwccarm.exe`. It
+  contains `1.2/` and `2.0/` trees with service-pack subdirs, each holding `mwccarm.exe`,
+  `mwldarm.exe`, `mwasmarm.exe`.
+- `mwccarm.exe` is a native Windows binary — no Wine on Windows.
+- A **NITRO-SDK** archive (e.g. `NitroSDK-*.7z`) if pinned, for SDK headers/objects later.
+  Not needed to start matching game functions.
+
+That gives 24 of the 25 versions in `match.SWEEP`. The 25th is §1.
+
+## 3. Which version do we need? — settled
+
+This section used to say "unknown until we test", and cited the dead matty45 repo's guess
+of `2.0/sp2p2`. Both are history. The answer is pinned:
+
+| role | version |
+|---|---|
+| matching / build compiler | `2004/b56` |
+| ROM linker (`mwldarm`) | `1.2/sp2p3` |
+| sweep | all 25, iteration only |
+
+Flags live in `rombuild.CFLAGS`; `CONTRIBUTING.md` quotes the matching set. Per-symbol
+overrides for functions that need a different compiler live in
+`config/rombuild-versions.txt`.
+
+## 4. .gitignore
+
+`tools/mwccarm/` must never be committed — proprietary, not redistributable. `tools/bin/`
+(where `dsd` goes) and `.cw2004work/` are ignored too.


### PR DESCRIPTION
## The problem

Following `CONTRIBUTING.md` + `notes/setup-mwccarm.md` to the letter leaves you **unable to byte-verify anything**.

Both docs point at the Discord `mwccarm.zip`. That gets you 24 of the 25 versions in `match.SWEEP` — but not **`2004/b56`**, which is the only version `rombuild.py` and `build_pin.verify` honour (`rombuild.VERSION`, `match.CANONICAL`). No decomp collection carries it; they all floor at the 1.2 release, build 72, sixteen builds above it.

So a new contributor completes setup, runs a sweep, gets a hit under some other version, and has no way to know that per `notes/runbook-type-reconstruction.md` §5 this is iteration and never a verdict.

`tools/recover_cw2004.py` has solved this for a while. It was just referenced only from `notes/mwccarm-codegen.md` — neither onboarding doc mentioned it. I hit this wall myself and only got past it when someone pointed me at the script.

## Two further staleness bugs in `setup-mwccarm.md`

- It framed mwccarm as entirely human-gated, which is no longer true of the pinned build.
- Its "Which version do we actually need?" section still read *"Unknown until we test"* and cited the dead matty45 repo's `2.0/sp2p2` guess — long after #1000 pinned `2004/b56` with `1.2/sp2p3` as the linker.

## What this changes

Restructured `setup-mwccarm.md` so §1 is the scripted pinned compiler, §2 is the Discord zip for what it now is (the sweep), §3 states the pin as **settled**. `CONTRIBUTING.md` splits sweep from pinned build, names the `dsd` 0.11.0 binary and its path, and numbers the setup steps.

Three things recorded from running the recovery end to end today, all of which cost me time:

- **It transfers ~1,982 MB, not the "~24 MB" its own docstring claims.** The header range-requests are tiny; the solid block holding the installer is ~2 GB. Worth knowing on a metered connection.
- **archive.org rate-limits mid-run.** A range request returns HTTP ≥400 and the script exits with `curl` status 22. Transient — the identical range succeeded on retry, and completed pieces are cached in `.cw2004work/`, so a re-run does not re-pay for the big block.
- **`license.dat` is not required.** The tooling points `LM_LICENSE_FILE` at `tools/mwccarm/license.dat`, but these builds run fine without it and a normal setup has no such file. Said explicitly to stop the next person hunting for it.

## Verification

Recovery ran clean: SHA-256 matched the expected artifact, banner `Version 2.0 build 56 (build 0056)`, sweep now 25/25 present.

Hash-matching isn't proof the thing compiles, so the doc now includes a `build_pin.verify` one-liner and I confirmed it:

```
(True, '2004/b56')     # _ZN5Fader13AdvanceInterpEv @ 0x020175e8
```

Docs only — no `src/`, `include/`, or `config/` changes, so nothing for `validate` to gate.