### PR TITLE
ci: ratchet the language-mode gap so it cannot grow (#821)

### DIFF
--- a/.github/workflows/langmode-ratchet.yml
+++ b/.github/workflows/langmode-ratchet.yml
@@ -1,0 +1,50 @@
+# Guards the C/C++ language-mode gap against regression (see #821).
+#
+# `tools/langmode_audit.py` counts C++ symbols whose source still spells the mangled
+# name by hand, plus the shadow-declaration and codegen-hack debt around them. Every
+# metric is a DEFECT count, so this gate is a ratchet: the numbers may fall freely and
+# may never rise. `notes/plan-cpp-language-mode.md` is the plan it defends.
+#
+# The headline metric counts a hand-spelled symbol however the file is named, so
+# renaming a `.c` to `.cpp` without migrating it does not buy a green check.
+#
+# This costs nothing to run: pure static analysis over git-tracked files, stdlib only,
+# no compiler and no ROM. That is why it can live in this repo rather than on the
+# private build box that `pr-validate.yml` relays to.
+#
+# When a PR legitimately LOWERS a count, --check still passes, but the baseline is then
+# stale. Re-bank it in the same PR:
+#     python tools/langmode_audit.py --json langmode-baseline.json
+name: langmode ratchet
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "include/**"
+      - "tools/langmode_audit.py"
+      - "tools/demangle.py"
+      - "langmode-baseline.json"
+      - ".github/workflows/langmode-ratchet.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: langmode-ratchet-${{ github.event.pull_request.head.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # No history needed: the audit reads `git ls-files` and the working tree.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Current language-mode state
+        run: python tools/langmode_audit.py
+      - name: "Ratchet: defect counts may fall, never rise"
+        run: python tools/langmode_audit.py --check langmode-baseline.json


### PR DESCRIPTION
Completes **phase 0** of `notes/plan-cpp-language-mode.md`. #1140 landed the metric; this makes it load-bearing. Without a gate it is a tool nobody runs, and the 54% drifts upward quietly.

## What it does

Runs `tools/langmode_audit.py --check langmode-baseline.json` on PRs. Every count the audit reports is a **defect** count, so the gate is one-directional: **numbers may fall freely and may never rise.**

The headline metric counts a hand-spelled mangled symbol **however the file is named**. So renaming a `.c` to `.cpp` without actually migrating it does not buy a green check — which is precisely the non-fix #821 called out (*"your cute little `//cpp` changes nothing"*). Adding a new C++ symbol in a `.c` file, or a new shadow struct declaration, fails.

It also prints the current summary on every relevant PR, so reviewers see the state without running anything.

## Why it lives here and not on the build box

`pr-validate.yml` relays to a private worker because byte-verification needs the compiler and the ROM. This check needs neither: it is pure static analysis over git-tracked files, **stdlib only** (`tools/langmode_audit.py` and `tools/demangle.py` import nothing third-party), so there is no `pip install` step and no secret. That is also why it uses `pull_request` rather than `pull_request_target` — no repo secrets are required, so the safer trigger is the correct one.

Path-filtered to `src/**`, `include/**`, the two tools it depends on, the baseline, and itself. A PR that cannot move a count does not pay for the job.

## Re-banking

A PR that legitimately **lowers** a count still passes — but the baseline is then stale. The workflow's header comment says to re-bank it in the same PR:

```
python tools/langmode_audit.py --json langmode-baseline.json
```

The banked file holds only the metrics `--check` reads (67 lines), so that stays a readable diff.

## Verification

YAML parses; both steps were run locally against this branch:

```
python tools/langmode_audit.py                              # summary, exit 0
python tools/langmode_audit.py --check langmode-baseline.json
# -> langmode ratchet PASS
```

The gate's failure path was tested when the tool landed: a deliberately planted `src/_ZN4Test9RegressEv.c` was caught on all four affected counts, exit 1.

One workflow file. No `src/`, `include/`, or `config/` changes.