### PR TITLE
Name this repo's tools for the jobs tangOS Console drives

### DIFF
--- a/tangos.json
+++ b/tangos.json
@@ -149,6 +149,16 @@
       "description": "Attempt tree + provenance how-records (Console stack)."
     }
   ],
+  "console": {
+    "scheduler": "coddog",
+    "refineScheduler": "refine_wl",
+    "randomScheduler": "worklist",
+    "enrich": "worklist",
+    "driver": "glm_refine",
+    "land": "crackloop_land",
+    "logAttempt": "log_attempt",
+    "verify": "match"
+  },
   "tools": [
     {
       "id": "progress",
@@ -1344,6 +1354,34 @@
         }
       ],
       "command": "{python} tools/stamp_provenance.py {flags}"
+    },
+    {
+      "id": "crackloop_land",
+      "label": "Land a drive's results",
+      "category": "matching",
+      "readOnly": false,
+      "command": "{python} tools/crackloop.py land {flags}",
+      "description": "Bank a finished drive: matched sources into src/, near-misses ingested into the DB, free-tier clone/paramclone post-pass, linkcheck gate over everything banked. Stops before git commit/push - that stays a reviewable step.",
+      "args": [
+        {
+          "name": "out",
+          "type": "string",
+          "description": "The driver's results file.",
+          "flag": "--output"
+        },
+        {
+          "name": "wl",
+          "type": "string",
+          "description": "The worklist the drive ran.",
+          "flag": "--wl"
+        },
+        {
+          "name": "no_claims",
+          "type": "boolean",
+          "flag": "--no-claims",
+          "description": "Skip claiming the landed address ranges. Console sets this when no claims key is available."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Console needs a scheduler, an enrich step, a driver and a land step to run its Controller. It found them by assuming the ids in *this* repo — `coddog`, `refine_wl`, `worklist`, `glm_refine`, `log_attempt`, `match` — which works here and nowhere else. A decomp that named its equivalents anything else got `this repo has no similarity scheduler (coddog) in tangos.json` despite shipping a complete toolchain.

Console now reads a `console` block naming which tool fills each role. This one names the tools already in use, so **nothing changes about how this repo runs**. It just stops being a hardcoded assumption and becomes a declaration, which is what lets the fallback eventually be deleted once the other decomps declare theirs.

```json
"console": {
  "scheduler": "coddog",
  "refineScheduler": "refine_wl",
  "randomScheduler": "worklist",
  "enrich": "worklist",
  "driver": "glm_refine",
  "land": "crackloop_land",
  "logAttempt": "log_attempt",
  "verify": "match"
}
```

Also declares `crackloop_land` as a real tool. Console has always run it after a drive, but synthesized the command instead of reading it from here, so it never appeared in the tool catalog. Its `--no-claims` flag was baked into a command string; that flag is Console's decision (only it knows whether a usable claims key exists for the project), so it is now a declared boolean the caller sets.

## Checked

- `validateDescriptor` passes, and all eight roles resolve to declared tools.
- Diff is 36 insertions, 0 deletions — no reformatting, no unrelated lines.
- Console resolves every role identically with and without this block, since the legacy id fallback covers the same tools.

Needs tangOS Console with the `console` role support to have any effect; harmless on older builds, which ignore the block.