### PR TITLE
readable: type 131 object markers from their destructor relocations (recovered from #1145)

### DIFF
--- a/include/Amp.h
+++ b/include/Amp.h
@@ -5,6 +5,8 @@
 #ifndef AMP_H
 #define AMP_H
 #include "types.h"
+#include "ModelAnim.h"
+#include "Model.h"
 
 struct Amp {
     u8  pad_000[0x8];
@@ -25,10 +27,12 @@ struct Amp {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x63];
-    u8  mModel;            /* 0x138 */
-    u8  pad_139[0x4f];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
+    /* Model member, named by _ZN5ModelD1Ev at +0x138 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x138 */
     u8  mTextureSequence;            /* 0x188 */
     u8  pad_189[0x13];
     u8  mTextureTransformer;            /* 0x19c */

--- a/include/ArrowLift.h
+++ b/include/ArrowLift.h
@@ -5,6 +5,7 @@
 #ifndef ARROWLIFT_H
 #define ARROWLIFT_H
 #include "types.h"
+#include "Model.h"
 
 struct ArrowLift {
     u8  pad_000[0x8];
@@ -14,8 +15,9 @@ struct ArrowLift {
     u8  pad_064[0x2a];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingCylinderClsn;            /* 0x124 */
     u8  pad_125[0x33];
     s32 unk_158;            /* 0x158 */

--- a/include/ArrowSignRight.h
+++ b/include/ArrowSignRight.h
@@ -5,6 +5,7 @@
 #ifndef ARROWSIGNRIGHT_H
 #define ARROWSIGNRIGHT_H
 #include "types.h"
+#include "Model.h"
 
 struct ArrowSignRight {
     u8  pad_000[0xc];
@@ -12,8 +13,9 @@ struct ArrowSignRight {
     u8  pad_00e[0x80];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mShadowModel;            /* 0x320 */

--- a/include/BabyPenguin.h
+++ b/include/BabyPenguin.h
@@ -5,6 +5,7 @@
 #ifndef BABYPENGUIN_H
 #define BABYPENGUIN_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct BabyPenguin {
     u8  pad_000[0x5c];
@@ -20,8 +21,9 @@ struct BabyPenguin {
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x2c];
     s32 mEatingPlayer;            /* 0x0d0 */
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x138 */
     u8  pad_139[0x27];
     u8  mMovingCylinderClsn;            /* 0x160 */

--- a/include/BigBrickBlock.h
+++ b/include/BigBrickBlock.h
@@ -6,6 +6,15 @@
 #define BIGBRICKBLOCK_H
 #include "types.h"
 
+/* Actor is only ever pointed at from here, so a declaration is enough --
+ * no definition is pulled in. The typedef keeps the member spelled the
+ * same in C and in C++; the guard is common.h's idiom for the same job. */
+#ifndef ACTOR_FWD_DECLARED
+#define ACTOR_FWD_DECLARED
+struct Actor;
+typedef struct Actor Actor;
+#endif
+
 struct BigBrickBlock {
     u8  pad_000[0xc];
     u16 mActorId;            /* 0x00c */
@@ -18,7 +27,11 @@ struct BigBrickBlock {
     u8  unk_31f;            /* 0x31f */
     u8  mEventID;            /* 0x320 */
     u8  pad_321[0x3];
-    u8  mSwitch;            /* 0x324 */
+    /* Actor * -- the ROM loads this WORD and passes it to _ZN5Actor15FindWithActorIDEjPS_
+       as that function's `this`, which is an object address, so the word is a Actor *. It
+       says nothing about the rest of the marker's span, which stays explicit padding. Was
+       a u8 marker. */
+    Actor *mSwitch;            /* 0x324 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/BigBully.h
+++ b/include/BigBully.h
@@ -5,6 +5,7 @@
 #ifndef BIGBULLY_H
 #define BIGBULLY_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct BigBully {
     u8  pad_000[0x4];
@@ -22,8 +23,9 @@ struct BigBully {
     u8  pad_0ac[0x20];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x43];
-    u8  mModelAnim;            /* 0x110 */
-    u8  pad_111[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x110 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x110 */
     u8  mWithMeshClsn;            /* 0x174 */
     u8  pad_175[0x1bb];
     u8  unk_330;            /* 0x330 */

--- a/include/BigMovingIceBlock.h
+++ b/include/BigMovingIceBlock.h
@@ -5,6 +5,7 @@
 #ifndef BIGMOVINGICEBLOCK_H
 #define BIGMOVINGICEBLOCK_H
 #include "types.h"
+#include "Model.h"
 
 struct BigMovingIceBlock {
     u8  pad_000[0x8];
@@ -18,8 +19,9 @@ struct BigMovingIceBlock {
     u8  pad_090[0x8];
     s32 mHorzSpeed;            /* 0x098 */
     u8  pad_09c[0x38];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mPath;            /* 0x320 */

--- a/include/Bird.h
+++ b/include/Bird.h
@@ -5,6 +5,7 @@
 #ifndef BIRD_H
 #define BIRD_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Bird {
     u8  pad_000[0x4];
@@ -22,12 +23,12 @@ struct Bird {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x1b];
-    u8  unk_0f0;            /* 0x0f0 */
-    u8  pad_0f1[0x33];
-    u8  mAnimation;            /* 0x124 */
-    u8  pad_125[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_0f0 (+0x1c = mat4x3),
+       mAnimation (+0x50 = the Animation base), which the header declared separately inside
+       it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x138 */
     u8  pad_139[0x27];
     s32 unk_160;            /* 0x160 */

--- a/include/BlendModelAnim.h
+++ b/include/BlendModelAnim.h
@@ -45,6 +45,30 @@ struct BlendModelAnim : ModelAnim {
 
 typedef char BlendModelAnim_size_must_be_0x70[sizeof(BlendModelAnim) == 0x70 ? 1 : -1];
 
+#else
+
+/* The same object for C translation units, both vptrs written out -- the same shape
+ * ModelAnim.h gives its own C fallback, with the blend state appended. */
+struct BlendModelAnim {
+    void **vtable;                     /* 0x00 */
+    struct BMD_File *modelFile;        /* 0x04 */
+    struct ModelComponents data;       /* 0x08 */
+    struct Matrix4x3 mat4x3;           /* 0x1c */
+    void *transformsBuf;               /* 0x4c */
+    void **animVtable;                 /* 0x50 */
+    u32 numFramesAndFlags;             /* 0x54 */
+    s32 currFrame;                     /* 0x58 */
+    s32 speed;                         /* 0x5c */
+    struct BCA_File *file;             /* 0x60 */
+    s32 blendWeight;                   /* 0x64 */
+    s32 blendStep;                     /* 0x68 */
+    void *unk_6c;                      /* 0x6c */
+};
+
+/* So an object header declaring a BlendModelAnim member reads the same in both modes:
+ * C++ gets the class, C gets the flat stand-in above, and neither needs `struct`. */
+typedef struct BlendModelAnim BlendModelAnim;
+
 #endif /* __cplusplus */
 
 #endif /* BLENDMODELANIM_H */

--- a/include/BobOmb.h
+++ b/include/BobOmb.h
@@ -5,6 +5,7 @@
 #ifndef BOBOMB_H
 #define BOBOMB_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct BobOmb {
     u8  pad_000[0x80];
@@ -34,8 +35,9 @@ struct BobOmb {
     u8  pad_138[0xc];
     u8  mWithMeshClsn;            /* 0x144 */
     u8  pad_145[0x1bb];
-    u8  mModelAnim;            /* 0x300 */
-    u8  pad_301[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x300 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x300 */
     u8  mShadowModel;            /* 0x364 */
     u8  pad_365[0x77];
     s32 unk_3dc;            /* 0x3dc */

--- a/include/BobOmbBuddy.h
+++ b/include/BobOmbBuddy.h
@@ -5,6 +5,7 @@
 #ifndef BOBOMBBUDDY_H
 #define BOBOMBBUDDY_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct BobOmbBuddy {
     u8  pad_000[0x8];
@@ -40,12 +41,12 @@ struct BobOmbBuddy {
     u8  pad_0d0[0x4];
     u8  mMovingCylinderClsn;            /* 0x0d4 */
     u8  pad_0d5[0x33];
-    u8  mModelAnim;            /* 0x108 */
-    u8  pad_109[0x4f];
-    u8  mAnimation;            /* 0x158 */
-    u8  pad_159[0x7];
-    s32 unk_160;            /* 0x160 */
-    u8  pad_164[0x8];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x108 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), unk_160 (+0x58 = currFrame), which the header declared separately
+       inside it. */
+    ModelAnim mModelAnim;            /* 0x108 */
     u8  mShadowModel;            /* 0x16c */
     u8  pad_16d[0x2b];
     s32 unk_198;            /* 0x198 */

--- a/include/BooCage.h
+++ b/include/BooCage.h
@@ -5,6 +5,7 @@
 #ifndef BOOCAGE_H
 #define BOOCAGE_H
 #include "types.h"
+#include "Model.h"
 
 struct BooCage {
     u8  pad_000[0x9c];
@@ -15,8 +16,9 @@ struct BooCage {
     u8  pad_111[0x33];
     u8  mWithMeshClsn;            /* 0x144 */
     u8  pad_145[0x1bb];
-    u8  mModel;            /* 0x300 */
-    u8  pad_301[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x300 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x300 */
     u8  mShadowModel;            /* 0x350 */
     u8  pad_351[0x27];
     s32 unk_378;            /* 0x378 */

--- a/include/BookShot.h
+++ b/include/BookShot.h
@@ -5,6 +5,7 @@
 #ifndef BOOKSHOT_H
 #define BOOKSHOT_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct BookShot {
     u8  pad_000[0xc];
@@ -36,8 +37,9 @@ struct BookShot {
     u8  unk_107;            /* 0x107 */
     u8  unk_108;            /* 0x108 */
     u8  pad_109[0x7];
-    u8  mModelAnim;            /* 0x110 */
-    u8  pad_111[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x110 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x110 */
     u8  mModel;            /* 0x174 */
     u8  pad_175[0x4f];
     u8  mShadowModel;            /* 0x1c4 */

--- a/include/BowserFireSeaArena.h
+++ b/include/BowserFireSeaArena.h
@@ -5,6 +5,7 @@
 #ifndef BOWSERFIRESEAARENA_H
 #define BOWSERFIRESEAARENA_H
 #include "types.h"
+#include "Model.h"
 
 struct BowserFireSeaArena {
     u8  pad_000[0x8e];
@@ -17,8 +18,9 @@ struct BowserFireSeaArena {
     s16 unk_31e;            /* 0x31e */
     s16 unk_320;            /* 0x320 */
     s16 unk_322;            /* 0x322 */
-    u8  mModel2;            /* 0x324 */
-    u8  pad_325[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x324 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel2;            /* 0x324 */
     u8  mMovingMeshCollider2;            /* 0x374 */
     u8  pad_375[0x1f7];
     s32 unk_56c;            /* 0x56c */

--- a/include/BowserPuzzleManager.h
+++ b/include/BowserPuzzleManager.h
@@ -5,6 +5,7 @@
 #ifndef BOWSERPUZZLEMANAGER_H
 #define BOWSERPUZZLEMANAGER_H
 #include "types.h"
+#include "Model.h"
 
 struct BowserPuzzleManager {
     u8  pad_000[0x8];
@@ -12,8 +13,9 @@ struct BowserPuzzleManager {
     u8  pad_00c[0x82];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/BowserShockwaves.h
+++ b/include/BowserShockwaves.h
@@ -5,6 +5,7 @@
 #ifndef BOWSERSHOCKWAVES_H
 #define BOWSERSHOCKWAVES_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct BowserShockwaves {
     u8  pad_000[0x5c];
@@ -12,24 +13,24 @@ struct BowserShockwaves {
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0x6c];
-    u8  mModelAnim1;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
-    u8  mAnimation1;            /* 0x124 */
-    u8  pad_125[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_0dc (+0x8 = data),
+       mAnimation1 (+0x50 = the Animation base), which the header declared separately
+       inside it. */
+    ModelAnim mModelAnim1;            /* 0x0d4 */
     u8  mTextureSequence1;            /* 0x138 */
     u8  pad_139[0x13];
     u8  mMaterialChanger1;            /* 0x14c */
     u8  pad_14d[0x13];
     u8  mTextureTransformer1;            /* 0x160 */
     u8  pad_161[0x13];
-    u8  mModelAnim2;            /* 0x174 */
-    u8  pad_175[0x7];
-    u8  unk_17c;            /* 0x17c */
-    u8  pad_17d[0x47];
-    u8  mAnimation2;            /* 0x1c4 */
-    u8  pad_1c5[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x174 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_17c (+0x8 = data),
+       mAnimation2 (+0x50 = the Animation base), which the header declared separately
+       inside it. */
+    ModelAnim mModelAnim2;            /* 0x174 */
     u8  mTextureSequence2;            /* 0x1d8 */
     u8  pad_1d9[0x13];
     u8  mMaterialChanger2;            /* 0x1ec */

--- a/include/Bullet.h
+++ b/include/Bullet.h
@@ -5,6 +5,7 @@
 #ifndef BULLET_H
 #define BULLET_H
 #include "types.h"
+#include "Model.h"
 
 struct Bullet {
     u8  pad_000[0x8];
@@ -28,8 +29,12 @@ struct Bullet {
     u8  pad_111[0x33];
     u8  mWithMeshClsn;            /* 0x144 */
     u8  pad_145[0x1bb];
-    u8  mModel;            /* 0x300 */
-    u8  pad_301[0x57];
+    /* Model member, named by _ZN5ModelD1Ev at +0x300 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad ran 0x8
+       bytes PAST the end of the object; that space is not evidenced and stays explicit
+       padding rather than being folded into the member. */
+    Model mModel;            /* 0x300 */
+    u8  pad_350[0x8];
     s32 unk_358;            /* 0x358 */
 #ifdef __cplusplus
     /* methods */

--- a/include/BulletBill.h
+++ b/include/BulletBill.h
@@ -5,6 +5,7 @@
 #ifndef BULLETBILL_H
 #define BULLETBILL_H
 #include "types.h"
+#include "Model.h"
 
 struct BulletBill {
     u8  pad_000[0x5c];
@@ -36,10 +37,12 @@ struct BulletBill {
     u8  pad_138[0x18];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mModel1;            /* 0x30c */
-    u8  pad_30d[0x4f];
-    u8  mModel2;            /* 0x35c */
-    u8  pad_35d[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x30c -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel1;            /* 0x30c */
+    /* Model member, named by _ZN5ModelD1Ev at +0x35c -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel2;            /* 0x35c */
     u8  mShadowModel;            /* 0x3ac */
     u8  pad_3ad[0x27];
     s32 mState;            /* 0x3d4 */

--- a/include/Bully.h
+++ b/include/Bully.h
@@ -5,6 +5,7 @@
 #ifndef BULLY_H
 #define BULLY_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Bully {
     u8  pad_000[0x5c];
@@ -16,8 +17,9 @@ struct Bully {
     u8  pad_096[0x36];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x43];
-    u8  mModelAnim;            /* 0x110 */
-    u8  pad_111[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x110 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x110 */
     u8  mWithMeshClsn;            /* 0x174 */
     u8  pad_175[0x1bb];
     s32 mFileTable;            /* 0x330 */

--- a/include/Butterfly.h
+++ b/include/Butterfly.h
@@ -5,6 +5,8 @@
 #ifndef BUTTERFLY_H
 #define BUTTERFLY_H
 #include "types.h"
+#include "ModelAnim.h"
+#include "Model.h"
 
 struct Butterfly {
     u8  pad_000[0x80];
@@ -23,16 +25,17 @@ struct Butterfly {
     s32 unk_0a8;            /* 0x0a8 */
     s32 unk_0ac;            /* 0x0ac */
     u8  pad_0b0[0x24];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x1b];
-    u8  unk_0f0;            /* 0x0f0 */
-    u8  pad_0f1[0x33];
-    u8  mAnimation;            /* 0x124 */
-    u8  pad_125[0x13];
-    u8  mModel;            /* 0x138 */
-    u8  pad_139[0x1b];
-    u8  unk_154;            /* 0x154 */
-    u8  pad_155[0x33];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_0f0 (+0x1c = mat4x3),
+       mAnimation (+0x50 = the Animation base), which the header declared separately inside
+       it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
+    /* Model member, named by _ZN5ModelD1Ev at +0x138 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_154 (+0x1c = mat4x3), which
+       the header declared separately inside it. */
+    Model mModel;            /* 0x138 */
     u8  mShadowModel1;            /* 0x188 */
     u8  pad_189[0x27];
     u8  mShadowModel2;            /* 0x1b0 */

--- a/include/CannonHatch.h
+++ b/include/CannonHatch.h
@@ -5,6 +5,7 @@
 #ifndef CANNONHATCH_H
 #define CANNONHATCH_H
 #include "types.h"
+#include "Model.h"
 
 struct CannonHatch {
     u8  pad_000[0x8];
@@ -28,8 +29,9 @@ struct CannonHatch {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/CapEnemy.h
+++ b/include/CapEnemy.h
@@ -5,6 +5,7 @@
 #ifndef CAPENEMY_H
 #define CAPENEMY_H
 #include "types.h"
+#include "Model.h"
 
 /* fwd */
 struct Vector3;
@@ -57,8 +58,9 @@ struct CapEnemy {
     s32 mEatingPlayer;            /* 0x0d0 */
     u8  pad_0d4[0x3f];
     u8  unk_113;            /* 0x113 */
-    u8  mModel;            /* 0x114 */
-    u8  pad_115[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x114 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x114 */
     u8  unk_164;            /* 0x164 */
 #ifdef __cplusplus
     /* methods */

--- a/include/CccArena.h
+++ b/include/CccArena.h
@@ -5,6 +5,7 @@
 #ifndef CCCARENA_H
 #define CCCARENA_H
 #include "types.h"
+#include "Model.h"
 
 struct CccArena {
     u8  pad_000[0xc];
@@ -18,12 +19,12 @@ struct CccArena {
     s16 mAngleY;            /* 0x08e */
     s16 mAngleZ;            /* 0x090 */
     u8  pad_092[0x42];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x3f];
-    s32 unk_114;            /* 0x114 */
-    s32 unk_118;            /* 0x118 */
-    s32 unk_11c;            /* 0x11c */
-    u8  pad_120[0x4];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_114 (+0x40 = mat4x3.t.x),
+       unk_118 (+0x44 = mat4x3.t.y), unk_11c (+0x48 = mat4x3.t.z), which the header
+       declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  unk_320;            /* 0x320 */

--- a/include/ChainChomp.h
+++ b/include/ChainChomp.h
@@ -5,6 +5,7 @@
 #ifndef CHAINCHOMP_H
 #define CHAINCHOMP_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct ChainChomp {
     u8  pad_000[0x60];
@@ -40,8 +41,9 @@ struct ChainChomp {
     u8  pad_0d0[0x40];
     u8  mMovingCylinderClsnWithPos;            /* 0x110 */
     u8  pad_111[0x3f];
-    u8  mModelAnim;            /* 0x150 */
-    u8  pad_151[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x150 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x150 */
     u8  mShadowModel;            /* 0x1b4 */
     u8  pad_1b5[0x43b];
     s32 unk_5f0;            /* 0x5f0 */

--- a/include/ChainChompFence.h
+++ b/include/ChainChompFence.h
@@ -5,13 +5,15 @@
 #ifndef CHAINCHOMPFENCE_H
 #define CHAINCHOMPFENCE_H
 #include "types.h"
+#include "Model.h"
 
 struct ChainChompFence {
     u8  pad_000[0x8e];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     u8  unk_31e;            /* 0x31e */

--- a/include/ChiefChilly.h
+++ b/include/ChiefChilly.h
@@ -5,6 +5,7 @@
 #ifndef CHIEFCHILLY_H
 #define CHIEFCHILLY_H
 #include "types.h"
+#include "BlendModelAnim.h"
 
 struct ChiefChilly {
     u8  pad_000[0x5c];
@@ -27,10 +28,12 @@ struct ChiefChilly {
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mBlendModelAnim;            /* 0x30c */
-    u8  pad_30d[0x5b];
-    s32 unk_368;            /* 0x368 */
-    u8  pad_36c[0x14];
+    /* BlendModelAnim member, named by _ZN14BlendModelAnimD1Ev at +0x30c -- a relocation
+       the ROM build checks. D1 and not D2, so it is this type and not an inlined base. The
+       marker's pad stopped short of the object, so the member also takes over unk_368
+       (+0x5c = speed), which the header declared separately inside it. */
+    BlendModelAnim mBlendModelAnim;            /* 0x30c */
+    u8  pad_37c[0x4];
     u8  mShadowModel;            /* 0x380 */
     u8  pad_381[0x57];
     s32 unk_3d8;            /* 0x3d8 */

--- a/include/Clam.h
+++ b/include/Clam.h
@@ -5,6 +5,7 @@
 #ifndef CLAM_H
 #define CLAM_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Clam {
     u8  pad_000[0x5c];
@@ -12,10 +13,11 @@ struct Clam {
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0x6c];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mAnimation;            /* 0x124 */
-    u8  pad_125[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mMovingCylinderClsn;            /* 0x138 */
     u8  pad_139[0x17];
     u8  unk_150;            /* 0x150 */

--- a/include/ClockPaintingHandShort.h
+++ b/include/ClockPaintingHandShort.h
@@ -5,6 +5,7 @@
 #ifndef CLOCKPAINTINGHANDSHORT_H
 #define CLOCKPAINTINGHANDSHORT_H
 #include "types.h"
+#include "Model.h"
 
 struct ClockPaintingHandShort {
     u8  pad_000[0xc];
@@ -25,8 +26,9 @@ struct ClockPaintingHandShort {
     u8  pad_092[0x3a];
     s8  unk_0cc;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mHandIndex;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/Cloud.h
+++ b/include/Cloud.h
@@ -5,10 +5,15 @@
 #ifndef CLOUD_H
 #define CLOUD_H
 #include "types.h"
+#include "Model.h"
 
 struct Cloud {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. It is the last thing the
+       header declares, so the marker had no pad and the struct simply ends 0x50 further
+       on; nothing beyond it is claimed. */
+    Model mModel;            /* 0x0d4 */
 #ifdef __cplusplus
     /* methods */
     int InitResources();

--- a/include/Coffin.h
+++ b/include/Coffin.h
@@ -5,6 +5,7 @@
 #ifndef COFFIN_H
 #define COFFIN_H
 #include "types.h"
+#include "Model.h"
 
 struct Coffin {
     u8  pad_000[0x5c];
@@ -17,8 +18,9 @@ struct Coffin {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/Crate.h
+++ b/include/Crate.h
@@ -6,6 +6,15 @@
 #define CRATE_H
 #include "types.h"
 
+/* Player is only ever pointed at from here, so a declaration is enough --
+ * no definition is pulled in. The typedef keeps the member spelled the
+ * same in C and in C++; the guard is common.h's idiom for the same job. */
+#ifndef PLAYER_FWD_DECLARED
+#define PLAYER_FWD_DECLARED
+struct Player;
+typedef struct Player Player;
+#endif
+
 struct Crate {
     u8  pad_000[0xc];
     u16 mActorID;            /* 0x00c */
@@ -51,8 +60,12 @@ struct Crate {
     s32 unk_5d8;            /* 0x5d8 */
     s32 unk_5dc;            /* 0x5dc */
     s32 unk_5e0;            /* 0x5e0 */
-    u8  unk_5e4;            /* 0x5e4 */
-    u8  pad_5e5[0xf];
+    /* Player * -- the ROM loads this WORD and passes it to _ZN6Player9DropActorEv as that
+       function's `this`, which is an object address, so the word is a Player *. It says
+       nothing about the rest of the marker's span, which stays explicit padding. Was a u8
+       marker. */
+    Player *unk_5e4;            /* 0x5e4 */
+    u8  pad_5e8[0xc];
     s32 unk_5f4;            /* 0x5f4 */
     u8  pad_5f8[0x4];
     u32 unk_5fc;            /* 0x5fc */

--- a/include/DonutBlock.h
+++ b/include/DonutBlock.h
@@ -5,6 +5,7 @@
 #ifndef DONUTBLOCK_H
 #define DONUTBLOCK_H
 #include "types.h"
+#include "Model.h"
 
 struct DonutBlock {
     u8  pad_000[0x8e];
@@ -13,8 +14,9 @@ struct DonutBlock {
     u8  pad_092[0x1e];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     s16 unk_31e;            /* 0x31e */

--- a/include/Dorrie.h
+++ b/include/Dorrie.h
@@ -5,6 +5,7 @@
 #ifndef DORRIE_H
 #define DORRIE_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Dorrie {
     u8  pad_000[0x8];
@@ -25,8 +26,15 @@ struct Dorrie {
     u8  pad_0e4[0x4];
     u8  unk_0e8;            /* 0x0e8 */
     u8  pad_0e9[0x3];
-    u8  mModelAnim;            /* 0x0ec */
-    u8  pad_0ed[0xe63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xec -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       ran 0xe00 bytes PAST the end of the object; that space is not evidenced and stays
+       explicit padding rather than being folded into the member. The destructor's
+       __destroy_arr((char *)c + 0x150, 7, 0x200, ...) runs over exactly this range -- 7
+       objects of 0x200 bytes, starting where the ModelAnim ends -- so the extent is
+       accounted for even though nothing names the element type. */
+    ModelAnim mModelAnim;            /* 0x0ec */
+    u8  pad_150[0xe00];
     u8  mWithMeshClsn;            /* 0xf50 */
     u8  pad_f51[0x1bb];
     u8  unk_110c;           /* 0x110c */

--- a/include/ExpandingHeap.h
+++ b/include/ExpandingHeap.h
@@ -6,9 +6,22 @@
 #define EXPANDINGHEAP_H
 #include "types.h"
 
+/* ExpandingHeapAllocator is only ever pointed at from here, so a declaration is enough --
+ * no definition is pulled in. The typedef keeps the member spelled the
+ * same in C and in C++; the guard is common.h's idiom for the same job. */
+#ifndef EXPANDINGHEAPALLOCATOR_FWD_DECLARED
+#define EXPANDINGHEAPALLOCATOR_FWD_DECLARED
+struct ExpandingHeapAllocator;
+typedef struct ExpandingHeapAllocator ExpandingHeapAllocator;
+#endif
+
 struct ExpandingHeap {
     u8  pad_000[0x14];
-    u8  unk_014;            /* 0x014 */
+    /* ExpandingHeapAllocator * -- the ROM loads this WORD and passes it to
+       _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi as that function's `this`, which
+       is an object address, so the word is a ExpandingHeapAllocator *. It says nothing
+       about the rest of the marker's span, which stays explicit padding. Was a u8 marker. */
+    ExpandingHeapAllocator *unk_014;            /* 0x014 */
 #ifdef __cplusplus
     /* methods */
     bool VIntact();

--- a/include/Eyerok.h
+++ b/include/Eyerok.h
@@ -5,6 +5,7 @@
 #ifndef EYEROK_H
 #define EYEROK_H
 #include "types.h"
+#include "Model.h"
 
 struct Eyerok {
     u8  pad_000[0x5c];
@@ -25,8 +26,9 @@ struct Eyerok {
     s32 unk_35c;            /* 0x35c */
     u8  mBlendModelAnim;            /* 0x360 */
     u8  pad_361[0x6f];
-    u8  mModel2;            /* 0x3d0 */
-    u8  pad_3d1[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x3d0 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel2;            /* 0x3d0 */
     u8  mShadowModel;            /* 0x420 */
     u8  pad_421[0x27];
     u8  mTextureSequence;            /* 0x448 */

--- a/include/FireSeaElevator.h
+++ b/include/FireSeaElevator.h
@@ -5,6 +5,7 @@
 #ifndef FIRESEAELEVATOR_H
 #define FIRESEAELEVATOR_H
 #include "types.h"
+#include "Model.h"
 
 struct FireSeaElevator {
     u8  pad_000[0x8];
@@ -12,8 +13,9 @@ struct FireSeaElevator {
     u8  pad_00c[0x82];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mMovingCylinderClsn;            /* 0x320 */

--- a/include/Flag.h
+++ b/include/Flag.h
@@ -5,6 +5,7 @@
 #ifndef FLAG_H
 #define FLAG_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Flag {
     u8  pad_000[0x5c];
@@ -14,13 +15,12 @@ struct Flag {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x3f];
-    s32 unk_114;            /* 0x114 */
-    s32 unk_118;            /* 0x118 */
-    s32 unk_11c;            /* 0x11c */
-    u8  pad_120[0x4];
-    u8  mAnimation;            /* 0x124 */
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_114 (+0x40 =
+       mat4x3.t.x), unk_118 (+0x44 = mat4x3.t.y), unk_11c (+0x48 = mat4x3.t.z), mAnimation
+       (+0x50 = the Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/FlameChomp.h
+++ b/include/FlameChomp.h
@@ -5,6 +5,7 @@
 #ifndef FLAMECHOMP_H
 #define FLAMECHOMP_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct FlameChomp {
     u8  pad_000[0x5c];
@@ -19,8 +20,9 @@ struct FlameChomp {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x138 */
     u8  pad_139[0x27];
     u8  mMovingCylinderClsnWithPos;            /* 0x160 */

--- a/include/FloatOnWaterPlatformJrb.h
+++ b/include/FloatOnWaterPlatformJrb.h
@@ -5,6 +5,7 @@
 #ifndef FLOATONWATERPLATFORMJRB_H
 #define FLOATONWATERPLATFORMJRB_H
 #include "types.h"
+#include "Model.h"
 
 struct FloatOnWaterPlatformJrb {
     u8  pad_000[0x5c];
@@ -25,8 +26,9 @@ struct FloatOnWaterPlatformJrb {
     s32 unk_0a8;            /* 0x0a8 */
     s32 unk_0ac;            /* 0x0ac */
     u8  pad_0b0[0x24];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/FloatOnWaterPlatformWdwSquare.h
+++ b/include/FloatOnWaterPlatformWdwSquare.h
@@ -5,13 +5,15 @@
 #ifndef FLOATONWATERPLATFORMWDWSQUARE_H
 #define FLOATONWATERPLATFORMWDWSQUARE_H
 #include "types.h"
+#include "Model.h"
 
 struct FloatOnWaterPlatformWdwSquare {
     u8  pad_000[0x98];
     s32 unk_098;            /* 0x098 */
     u8  pad_09c[0x38];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/FloatingFloorLllBig.h
+++ b/include/FloatingFloorLllBig.h
@@ -5,6 +5,7 @@
 #ifndef FLOATINGFLOORLLLBIG_H
 #define FLOATINGFLOORLLLBIG_H
 #include "types.h"
+#include "Model.h"
 
 struct FloatingFloorLllBig {
     u8  pad_000[0x60];
@@ -13,8 +14,9 @@ struct FloatingFloorLllBig {
     s16 mAngleX;            /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/FortressTower.h
+++ b/include/FortressTower.h
@@ -5,13 +5,15 @@
 #ifndef FORTRESSTOWER_H
 #define FORTRESSTOWER_H
 #include "types.h"
+#include "Model.h"
 
 struct FortressTower {
     u8  pad_000[0xc];
     u16 unk_00c;            /* 0x00c */
     u8  pad_00e[0xc6];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/FortressWall.h
+++ b/include/FortressWall.h
@@ -5,6 +5,7 @@
 #ifndef FORTRESSWALL_H
 #define FORTRESSWALL_H
 #include "types.h"
+#include "Model.h"
 
 struct FortressWall {
     u8  pad_000[0x8];
@@ -32,8 +33,9 @@ struct FortressWall {
     u8  pad_090[0x3c];
     u8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     u8  unk_31e;            /* 0x31e */

--- a/include/HauntedChair.h
+++ b/include/HauntedChair.h
@@ -5,6 +5,7 @@
 #ifndef HAUNTEDCHAIR_H
 #define HAUNTEDCHAIR_H
 #include "types.h"
+#include "Model.h"
 
 struct HauntedChair {
     u8  pad_000[0x5c];
@@ -12,8 +13,9 @@ struct HauntedChair {
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0x6c];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x124 */
     u8  pad_125[0x27];
     u8  unk_14c;            /* 0x14c */

--- a/include/HugeCover.h
+++ b/include/HugeCover.h
@@ -5,13 +5,15 @@
 #ifndef HUGECOVER_H
 #define HUGECOVER_H
 #include "types.h"
+#include "Model.h"
 
 struct HugeCover {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mTextureTransformer;            /* 0x320 */

--- a/include/IceSheet.h
+++ b/include/IceSheet.h
@@ -5,13 +5,15 @@
 #ifndef ICESHEET_H
 #define ICESHEET_H
 #include "types.h"
+#include "Model.h"
 
 struct IceSheet {
     u8  pad_000[0x8e];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/KingBobOmb.h
+++ b/include/KingBobOmb.h
@@ -5,6 +5,7 @@
 #ifndef KINGBOBOMB_H
 #define KINGBOBOMB_H
 #include "types.h"
+#include "BlendModelAnim.h"
 
 struct KingBobOmb {
     u8  pad_000[0x8];
@@ -34,8 +35,9 @@ struct KingBobOmb {
     u8  pad_0d0[0x40];
     u8  mWithMeshClsn;            /* 0x110 */
     u8  pad_111[0x1bb];
-    u8  mBlendModelAnim;            /* 0x2cc */
-    u8  pad_2cd[0x6f];
+    /* BlendModelAnim member, named by _ZN14BlendModelAnimD1Ev at +0x2cc -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    BlendModelAnim mBlendModelAnim;            /* 0x2cc */
     u8  mMovingCylinderClsnWithPos1;            /* 0x33c */
     u8  pad_33d[0x3f];
     u8  mMovingCylinderClsnWithPos2;            /* 0x37c */

--- a/include/Klepto.h
+++ b/include/Klepto.h
@@ -5,6 +5,7 @@
 #ifndef KLEPTO_H
 #define KLEPTO_H
 #include "types.h"
+#include "BlendModelAnim.h"
 
 struct Klepto {
     u8  pad_000[0x8];
@@ -38,10 +39,11 @@ struct Klepto {
     u8  pad_145[0x33];
     u8  mWithMeshClsn;            /* 0x178 */
     u8  pad_179[0x1bb];
-    u8  mBlendModelAnim;            /* 0x334 */
-    u8  pad_335[0x5b];
-    s32 unk_390;            /* 0x390 */
-    u8  pad_394[0x10];
+    /* BlendModelAnim member, named by _ZN14BlendModelAnimD1Ev at +0x334 -- a relocation
+       the ROM build checks. D1 and not D2, so it is this type and not an inlined base. The
+       marker's pad stopped short of the object, so the member also takes over unk_390
+       (+0x5c = speed), which the header declared separately inside it. */
+    BlendModelAnim mBlendModelAnim;            /* 0x334 */
     u8  mShadowModel;            /* 0x3a4 */
     u8  pad_3a5[0x87];
     s32 unk_42c;            /* 0x42c */

--- a/include/KnockDownPlank.h
+++ b/include/KnockDownPlank.h
@@ -5,6 +5,7 @@
 #ifndef KNOCKDOWNPLANK_H
 #define KNOCKDOWNPLANK_H
 #include "types.h"
+#include "Model.h"
 
 struct KnockDownPlank {
     u8  pad_000[0xc];
@@ -40,8 +41,9 @@ struct KnockDownPlank {
     s16 mAngleX;                 /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/KoopaFlag.h
+++ b/include/KoopaFlag.h
@@ -5,6 +5,7 @@
 #ifndef KOOPAFLAG_H
 #define KOOPAFLAG_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct KoopaFlag {
     u8  pad_000[0xd4];
@@ -12,10 +13,11 @@ struct KoopaFlag {
     u8  pad_0d5[0x23];
     u32 unk_0f8;            /* 0x0f8 */
     u8  pad_0fc[0xc];
-    u8  mModelAnim;            /* 0x108 */
-    u8  pad_109[0x4f];
-    u8  mAnimation;            /* 0x158 */
-    u8  pad_159[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x108 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x108 */
     u16 mVictoryTimer;            /* 0x16c */
     u8  unk_16e;            /* 0x16e */
 #ifdef __cplusplus

--- a/include/KoopaTheQuick.h
+++ b/include/KoopaTheQuick.h
@@ -5,6 +5,7 @@
 #ifndef KOOPATHEQUICK_H
 #define KOOPATHEQUICK_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct KoopaTheQuick {
     u8  pad_000[0x8];
@@ -70,10 +71,11 @@ struct KoopaTheQuick {
     u8  pad_111[0x33];
     u8  mWithMeshClsn;            /* 0x144 */
     u8  pad_145[0x1bb];
-    u8  mModelAnim;            /* 0x300 */
-    u8  pad_301[0x4f];
-    u8  unk_350;            /* 0x350 */
-    u8  pad_351[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x300 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_350 (+0x50 = the
+       Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x300 */
     u8  mShadowModel;            /* 0x364 */
     u8  pad_365[0x27];
     s32 unk_38c;            /* 0x38c */

--- a/include/MadPiano.h
+++ b/include/MadPiano.h
@@ -5,6 +5,7 @@
 #ifndef MADPIANO_H
 #define MADPIANO_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct MadPiano {
     u8  pad_000[0x5c];
@@ -24,8 +25,9 @@ struct MadPiano {
     u8  pad_0d5[0x4f];
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mModelAnim;            /* 0x320 */
-    u8  pad_321[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x320 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x320 */
     u8  mShadowModel1;            /* 0x384 */
     u8  pad_385[0x27];
     u8  mShadowModel2;            /* 0x3ac */

--- a/include/MansionSteps.h
+++ b/include/MansionSteps.h
@@ -5,11 +5,13 @@
 #ifndef MANSIONSTEPS_H
 #define MANSIONSTEPS_H
 #include "types.h"
+#include "Model.h"
 
 struct MansionSteps {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     s32 unk_124;            /* 0x124 */
     u8  pad_128[0x18];
     s32 unk_140;            /* 0x140 */

--- a/include/MantaRay.h
+++ b/include/MantaRay.h
@@ -5,6 +5,7 @@
 #ifndef MANTARAY_H
 #define MANTARAY_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct MantaRay {
     u8  pad_000[0x8];
@@ -35,8 +36,9 @@ struct MantaRay {
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mModelAnim;            /* 0x30c */
-    u8  pad_30d[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x30c */
     u8  unk_370;            /* 0x370 */
     u8  pad_371[0xb];
     s32 unk_37c;            /* 0x37c */

--- a/include/MetalNet.h
+++ b/include/MetalNet.h
@@ -5,6 +5,7 @@
 #ifndef METALNET_H
 #define METALNET_H
 #include "types.h"
+#include "Model.h"
 
 struct MetalNet {
     u8  pad_000[0x8];
@@ -12,8 +13,9 @@ struct MetalNet {
     u8  pad_00c[0x82];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/Model.h
+++ b/include/Model.h
@@ -82,6 +82,10 @@ struct Model {
     void *transformsBuf;               /* 0x4c */
 };
 
+/* So an object header declaring a Model member reads the same in both modes: C++
+ * gets the class, C gets the flat stand-in above, and neither needs `struct`. */
+typedef struct Model Model;
+
 #endif /* __cplusplus */
 
 #endif /* MODEL_H */

--- a/include/ModelAnim.h
+++ b/include/ModelAnim.h
@@ -27,9 +27,26 @@
  *
  * Secondary (Animation-in-ModelAnim) vtable at +0x24 of the primary,
  * VTable_Animation_ModelAnimThunk: [_ZThn80_ D1, _ZThn80_ D0, null] -- the
- * inherited pure virtual stays null, so ModelAnim is abstract, which is
- * why only its C2 is ever called from derived constructors and no code
- * instantiates one directly.
+ * inherited slot stays null.
+ *
+ * CORRECTION. That null slot used to be read here as "ModelAnim is abstract,
+ * which is why only its C2 is ever called from derived constructors and no
+ * code instantiates one directly." The ROM refutes it, and not subtly: the
+ * COMPLETE-OBJECT structors exist as symbols --
+ *
+ *   _ZN9ModelAnimC1Ev  0x02016958      _ZN9ModelAnimD1Ev  0x0201691c
+ *
+ * -- and are called from 103 and 131 source files respectively. A compiler
+ * emits C1/D1 only for a type something actually creates; a class that can
+ * only ever be a base gets C2/D2 alone. Those calls land at member offsets
+ * inside other classes (Amp+0xd4, Flag+0xd4, QuestionSwitch+0x6b4, ...),
+ * which is what an embedded member looks like, and they are relocations the
+ * ROM build checks -- not prose.
+ *
+ * So a ModelAnim IS instantiated, overwhelmingly as a member subobject. The
+ * null slot means one inherited virtual is never called, not that the class
+ * cannot be built: it cannot mean abstract while C1 exists and 103 files
+ * call it.
  *
  * THE DESTRUCTOR IS DECLARED FIRST AND NEVER DEFINED AS A METHOD. Both
  * vtables AND the two thunks are emitted with the key function, so the

--- a/include/ModelAnim.h
+++ b/include/ModelAnim.h
@@ -98,6 +98,10 @@ struct ModelAnim {
     struct BCA_File *file;             /* 0x60 */
 };
 
+/* So an object header declaring a ModelAnim member reads the same in both modes: C++
+ * gets the class, C gets the flat stand-in above, and neither needs `struct`. */
+typedef struct ModelAnim ModelAnim;
+
 #endif /* __cplusplus */
 
 #endif /* MODELANIM_H */

--- a/include/MontyMole.h
+++ b/include/MontyMole.h
@@ -5,13 +5,15 @@
 #ifndef MONTYMOLE_H
 #define MONTYMOLE_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct MontyMole {
     u8  pad_000[0x8];
     u32 unk_008;            /* 0x008 */
     u8  pad_00c[0xc8];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mMovingCylinderClsn;            /* 0x138 */
     u8  pad_139[0x33];
     u8  unk_16c;            /* 0x16c */

--- a/include/MontyMoleRock.h
+++ b/include/MontyMoleRock.h
@@ -5,6 +5,7 @@
 #ifndef MONTYMOLEROCK_H
 #define MONTYMOLEROCK_H
 #include "types.h"
+#include "Model.h"
 
 struct MontyMoleRock {
     u8  pad_000[0x8];
@@ -17,8 +18,9 @@ struct MontyMoleRock {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x6c];
-    u8  mModel;            /* 0x110 */
-    u8  pad_111[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x110 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x110 */
     u8  mMovingCylinderClsn;            /* 0x160 */
     u8  pad_161[0x33];
     u8  mWithMeshClsn;            /* 0x194 */

--- a/include/MovingBarSmall.h
+++ b/include/MovingBarSmall.h
@@ -5,6 +5,7 @@
 #ifndef MOVINGBARSMALL_H
 #define MOVINGBARSMALL_H
 #include "types.h"
+#include "Model.h"
 
 struct MovingBarSmall {
     u8  pad_000[0x8];
@@ -24,8 +25,9 @@ struct MovingBarSmall {
     u8  pad_0a4[0x4];
     s32 unk_0a8;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mShadowModel;            /* 0x320 */

--- a/include/MrI.h
+++ b/include/MrI.h
@@ -5,6 +5,7 @@
 #ifndef MRI_H
 #define MRI_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct MrI {
     u8  pad_000[0x8];
@@ -24,10 +25,11 @@ struct MrI {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x5b];
-    s32 unk_130;            /* 0x130 */
-    u8  pad_134[0x4];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_130 (+0x5c = speed),
+       which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mTextureSequence;            /* 0x138 */
     u8  pad_139[0xb];
     s32 unk_144;            /* 0x144 */

--- a/include/OrangeBallBillboard.h
+++ b/include/OrangeBallBillboard.h
@@ -5,10 +5,15 @@
 #ifndef ORANGEBALLBILLBOARD_H
 #define ORANGEBALLBILLBOARD_H
 #include "types.h"
+#include "Model.h"
 
 struct OrangeBallBillboard {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. It is the last thing the
+       header declares, so the marker had no pad and the struct simply ends 0x50 further
+       on; nothing beyond it is claimed. */
+    Model mModel;            /* 0x0d4 */
 #ifdef __cplusplus
     /* methods */
     int InitResources();

--- a/include/PeachPainting.h
+++ b/include/PeachPainting.h
@@ -5,11 +5,13 @@
 #ifndef PEACHPAINTING_H
 #define PEACHPAINTING_H
 #include "types.h"
+#include "Model.h"
 
 struct PeachPainting {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mOpacity;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/Pokey.h
+++ b/include/Pokey.h
@@ -5,6 +5,7 @@
 #ifndef POKEY_H
 #define POKEY_H
 #include "types.h"
+#include "Model.h"
 
 struct Pokey {
     u8  pad_000[0x8];
@@ -23,8 +24,9 @@ struct Pokey {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x124 */
     u8  pad_125[0x27];
     u8  mMovingCylinderClsn;            /* 0x14c */

--- a/include/PoleBillboard.h
+++ b/include/PoleBillboard.h
@@ -5,6 +5,7 @@
 #ifndef POLEBILLBOARD_H
 #define POLEBILLBOARD_H
 #include "types.h"
+#include "Model.h"
 
 struct PoleBillboard {
     u8  pad_000[0x5c];
@@ -15,8 +16,9 @@ struct PoleBillboard {
     s16 mAngleX;            /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mShadowModel;            /* 0x320 */

--- a/include/PoleLift.h
+++ b/include/PoleLift.h
@@ -5,6 +5,7 @@
 #ifndef POLELIFT_H
 #define POLELIFT_H
 #include "types.h"
+#include "Model.h"
 
 struct PoleLift {
     u8  pad_000[0x8e];
@@ -12,8 +13,12 @@ struct PoleLift {
     u8  pad_090[0x44];
     s8  unk_0d4;            /* 0x0d4 */
     u8  pad_0d5[0x3];
-    u8  mModel;            /* 0x0d8 */
-    u8  pad_0d9[0x7f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd8 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad ran 0x30
+       bytes PAST the end of the object; that space is not evidenced and stays explicit
+       padding rather than being folded into the member. */
+    Model mModel;            /* 0x0d8 */
+    u8  pad_128[0x30];
     u8  mCollider;            /* 0x158 */
     u8  pad_159[0x4c];
     u8  unk_1a5;            /* 0x1a5 */

--- a/include/PowerStar.h
+++ b/include/PowerStar.h
@@ -5,6 +5,7 @@
 #ifndef POWERSTAR_H
 #define POWERSTAR_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct PowerStar {
     u8  pad_000[0xc];
@@ -18,10 +19,12 @@ struct PowerStar {
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mModelAnim1;            /* 0x30c */
-    u8  pad_30d[0x63];
-    u8  mModelAnim2;            /* 0x370 */
-    u8  pad_371[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim1;            /* 0x30c */
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x370 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim2;            /* 0x370 */
     u8  mShadowModel;            /* 0x3d4 */
     u8  pad_3d5[0x67];
     s32 unk_43c;            /* 0x43c */

--- a/include/PrincessPeach.h
+++ b/include/PrincessPeach.h
@@ -5,13 +5,15 @@
 #ifndef PRINCESSPEACH_H
 #define PRINCESSPEACH_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct PrincessPeach {
     u8  pad_000[0xd4];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mAnimation;            /* 0x124 */
-    u8  pad_125[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x138 */
     u8  pad_139[0x27];
     u8  mMovingCylinderClsn;            /* 0x160 */

--- a/include/PushBlock.h
+++ b/include/PushBlock.h
@@ -5,6 +5,7 @@
 #ifndef PUSHBLOCK_H
 #define PUSHBLOCK_H
 #include "types.h"
+#include "Model.h"
 
 struct PushBlock {
     u8  pad_000[0x8];
@@ -31,8 +32,9 @@ struct PushBlock {
     u8  pad_0a4[0xc];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel1;            /* 0x0d4 */
     u8  mModel2;            /* 0x124 */
     u8  pad_125[0x4f];
     u8  mShadowModel;            /* 0x174 */

--- a/include/PyramidLift.h
+++ b/include/PyramidLift.h
@@ -5,6 +5,7 @@
 #ifndef PYRAMIDLIFT_H
 #define PYRAMIDLIFT_H
 #include "types.h"
+#include "Model.h"
 
 struct PyramidLift {
     u8  pad_000[0x5c];
@@ -16,8 +17,9 @@ struct PyramidLift {
     u8  pad_090[0x18];
     s32 unk_0a8;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel1;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/PyramidLift.h
+++ b/include/PyramidLift.h
@@ -24,10 +24,11 @@ struct PyramidLift {
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
-    u8  mModel2;            /* 0x320 */
-    u8  pad_321[0x1b];
-    u8  unk_33c;            /* 0x33c */
-    u8  pad_33d[0x33];
+    /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_33c (+0x1c = mat4x3), which
+       the header declared separately inside it. */
+    Model mModel2;            /* 0x320 */
     s32 unk_370;            /* 0x370 */
     s32 unk_374;            /* 0x374 */
     s32 unk_378;            /* 0x378 */

--- a/include/PyramidStep.h
+++ b/include/PyramidStep.h
@@ -5,6 +5,7 @@
 #ifndef PYRAMIDSTEP_H
 #define PYRAMIDSTEP_H
 #include "types.h"
+#include "Model.h"
 
 struct PyramidStep {
     u8  pad_000[0x8];
@@ -18,8 +19,9 @@ struct PyramidStep {
     u8  pad_0d5[0x4f];
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mModel2;            /* 0x320 */
-    u8  pad_321[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel2;            /* 0x320 */
     s16 unk_370;            /* 0x370 */
     u8  unk_372;            /* 0x372 */
     u8  pad_373[0x1];

--- a/include/PyramidTop.h
+++ b/include/PyramidTop.h
@@ -5,6 +5,7 @@
 #ifndef PYRAMIDTOP_H
 #define PYRAMIDTOP_H
 #include "types.h"
+#include "Model.h"
 
 struct PyramidTop {
     u8  pad_000[0x5c];
@@ -27,8 +28,12 @@ struct PyramidTop {
     u8  pad_0d5[0x4f];
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mModel2;            /* 0x320 */
-    u8  pad_321[0x7f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad ran 0x30
+       bytes PAST the end of the object; that space is not evidenced and stays explicit
+       padding rather than being folded into the member. */
+    Model mModel2;            /* 0x320 */
+    u8  pad_370[0x30];
     s32 unk_3a0;            /* 0x3a0 */
     s32 unk_3a4;            /* 0x3a4 */
     s32 unk_3a8;            /* 0x3a8 */

--- a/include/QuestionBlock.h
+++ b/include/QuestionBlock.h
@@ -5,6 +5,7 @@
 #ifndef QUESTIONBLOCK_H
 #define QUESTIONBLOCK_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct QuestionBlock {
     u8  pad_000[0x8];
@@ -27,10 +28,11 @@ struct QuestionBlock {
     u8  pad_0f1[0x33];
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mModelAnim;            /* 0x320 */
-    u8  pad_321[0x4f];
-    u8  mAnimation;            /* 0x370 */
-    u8  pad_371[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x320 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x320 */
     u8  mShadowModel;            /* 0x384 */
     u8  pad_385[0x27];
     u8  unk_3ac;            /* 0x3ac */

--- a/include/QuestionSwitch.h
+++ b/include/QuestionSwitch.h
@@ -5,6 +5,7 @@
 #ifndef QUESTIONSWITCH_H
 #define QUESTIONSWITCH_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct QuestionSwitch {
     u8  pad_000[0x5c];
@@ -23,13 +24,12 @@ struct QuestionSwitch {
     u8  pad_325[0x1c7];
     u8  mMovingMeshCollider;            /* 0x4ec */
     u8  pad_4ed[0x1c7];
-    u8  mModelAnim;            /* 0x6b4 */
-    u8  pad_6b5[0x4f];
-    u8  mAnim;            /* 0x704 */
-    u8  pad_705[0x7];
-    s32 unk_70c;            /* 0x70c */
-    s32 unk_710;            /* 0x710 */
-    u8  pad_714[0x4];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x6b4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnim (+0x50 = the
+       Animation base), unk_70c (+0x58 = currFrame), unk_710 (+0x5c = speed), which the
+       header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x6b4 */
     s8  unk_718;            /* 0x718 */
     u8  pad_719[0x1];
     u8  unk_71a;            /* 0x71a */

--- a/include/RabbitKey.h
+++ b/include/RabbitKey.h
@@ -5,6 +5,7 @@
 #ifndef RABBITKEY_H
 #define RABBITKEY_H
 #include "types.h"
+#include "Model.h"
 
 struct RabbitKey {
     u8  pad_000[0x8];
@@ -26,8 +27,9 @@ struct RabbitKey {
     u8  pad_0b0[0x50];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  mModel;            /* 0x110 */
-    u8  pad_111[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x110 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x110 */
     u8  mShadowModel;            /* 0x160 */
     u8  pad_161[0x27];
     u8  unk_188;            /* 0x188 */

--- a/include/RacingPenguin.h
+++ b/include/RacingPenguin.h
@@ -5,6 +5,7 @@
 #ifndef RACINGPENGUIN_H
 #define RACINGPENGUIN_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct RacingPenguin {
     u8  pad_000[0x80];
@@ -36,10 +37,11 @@ struct RacingPenguin {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x4];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mAnimation;            /* 0x124 */
-    u8  pad_125[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mTextureSequence;            /* 0x138 */
     u8  pad_139[0x13];
     u8  mShadowModel;            /* 0x14c */

--- a/include/RollingIronBall.h
+++ b/include/RollingIronBall.h
@@ -5,6 +5,7 @@
 #ifndef ROLLINGIRONBALL_H
 #define ROLLINGIRONBALL_H
 #include "types.h"
+#include "Model.h"
 
 struct RollingIronBall {
     u8  pad_000[0x8];
@@ -26,8 +27,9 @@ struct RollingIronBall {
     u8  pad_109[0x7];
     u8  mWithMeshClsn;            /* 0x110 */
     u8  pad_111[0x1bb];
-    u8  mModel;            /* 0x2cc */
-    u8  pad_2cd[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x2cc -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x2cc */
     u8  mShadowModel;            /* 0x31c */
     u8  pad_31d[0x57];
     u8  mMovingCylinderClsn;            /* 0x374 */

--- a/include/RollingLogTtm.h
+++ b/include/RollingLogTtm.h
@@ -5,6 +5,7 @@
 #ifndef ROLLINGLOGTTM_H
 #define ROLLINGLOGTTM_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct RollingLogTtm {
     u8  pad_000[0xc];
@@ -25,10 +26,11 @@ struct RollingLogTtm {
     u8  pad_0b4[0x18];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x5b];
-    s32 unk_130;            /* 0x130 */
-    u8  pad_134[0x4];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_130 (+0x5c = speed),
+       which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x138 */
     u8  pad_139[0x27];
     u8  mMovingCylinderClsn;            /* 0x160 */

--- a/include/RollingRock.h
+++ b/include/RollingRock.h
@@ -5,6 +5,7 @@
 #ifndef ROLLINGROCK_H
 #define ROLLINGROCK_H
 #include "types.h"
+#include "Model.h"
 
 struct RollingRock {
     u8  pad_000[0x4];
@@ -29,8 +30,9 @@ struct RollingRock {
     u16 unk_100;            /* 0x100 */
     u8  pad_102[0xa];
     s32 unk_10c;            /* 0x10c */
-    u8  mModel;            /* 0x110 */
-    u8  pad_111[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x110 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x110 */
     u8  mShadowModel;            /* 0x160 */
     u8  pad_161[0x57];
     u8  mMovingCylinderClsnWithPos;            /* 0x1b8 */

--- a/include/RotatingClockHand.h
+++ b/include/RotatingClockHand.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGCLOCKHAND_H
 #define ROTATINGCLOCKHAND_H
 #include "types.h"
+#include "Model.h"
 
 struct RotatingClockHand {
     u8  pad_000[0x5c];
@@ -16,8 +17,9 @@ struct RotatingClockHand {
     u8  pad_090[0x2];
     s16 mPrevAngleX;            /* 0x092 */
     u8  pad_094[0x40];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/RotatingCogSmall.h
+++ b/include/RotatingCogSmall.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGCOGSMALL_H
 #define ROTATINGCOGSMALL_H
 #include "types.h"
+#include "Model.h"
 
 struct RotatingCogSmall {
     u8  pad_000[0xc];
@@ -12,8 +13,9 @@ struct RotatingCogSmall {
     u8  pad_00e[0x80];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     s16 unk_31e;            /* 0x31e */

--- a/include/RotatingFirebar.h
+++ b/include/RotatingFirebar.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGFIREBAR_H
 #define ROTATINGFIREBAR_H
 #include "types.h"
+#include "Model.h"
 
 struct RotatingFirebar {
     u8  pad_000[0x8e];
@@ -12,8 +13,9 @@ struct RotatingFirebar {
     u8  pad_090[0x20];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/RotatingPlatformLll.h
+++ b/include/RotatingPlatformLll.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGPLATFORMLLL_H
 #define ROTATINGPLATFORMLLL_H
 #include "types.h"
+#include "Model.h"
 
 struct RotatingPlatformLll {
     u8  pad_000[0x60];
@@ -12,8 +13,9 @@ struct RotatingPlatformLll {
     u8  pad_064[0x2a];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/RotatingPlatformWdw.h
+++ b/include/RotatingPlatformWdw.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGPLATFORMWDW_H
 #define ROTATINGPLATFORMWDW_H
 #include "types.h"
+#include "Model.h"
 
 struct RotatingPlatformWdw {
     u8  pad_000[0x8];
@@ -18,10 +19,11 @@ struct RotatingPlatformWdw {
     u8  pad_090[0x3c];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mTextureTransformer;            /* 0x320 */

--- a/include/RotatingUpDownPlatform.h
+++ b/include/RotatingUpDownPlatform.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGUPDOWNPLATFORM_H
 #define ROTATINGUPDOWNPLATFORM_H
 #include "types.h"
+#include "Model.h"
 
 struct RotatingUpDownPlatform {
     u8  pad_000[0x8];
@@ -28,8 +29,9 @@ struct RotatingUpDownPlatform {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1ff];
     s32 unk_324;            /* 0x324 */

--- a/include/Scuttlebug.h
+++ b/include/Scuttlebug.h
@@ -5,11 +5,13 @@
 #ifndef SCUTTLEBUG_H
 #define SCUTTLEBUG_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Scuttlebug {
     u8  pad_000[0xd4];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x138 */
     u8  pad_139[0x27];
     u8  mMovingCylinderClsn;            /* 0x160 */

--- a/include/Seaweed.h
+++ b/include/Seaweed.h
@@ -5,6 +5,7 @@
 #ifndef SEAWEED_H
 #define SEAWEED_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Seaweed {
     u8  pad_000[0x74];
@@ -39,12 +40,12 @@ struct Seaweed {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x4];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mAnimation;            /* 0x124 */
-    u8  pad_125[0xb];
-    s32 unk_130;            /* 0x130 */
-    u8  pad_134[0x4];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), unk_130 (+0x5c = speed), which the header declared separately
+       inside it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mMovingCylinderClsn;            /* 0x138 */
     u8  pad_139[0x23];
     s32 unk_15c;            /* 0x15c */

--- a/include/SeesawBob.h
+++ b/include/SeesawBob.h
@@ -5,6 +5,7 @@
 #ifndef SEESAWBOB_H
 #define SEESAWBOB_H
 #include "types.h"
+#include "Model.h"
 
 struct SeesawBob {
     u8  pad_000[0xc];
@@ -15,8 +16,9 @@ struct SeesawBob {
     u8  pad_090[0x20];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/Shark.h
+++ b/include/Shark.h
@@ -5,6 +5,7 @@
 #ifndef SHARK_H
 #define SHARK_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Shark {
     u8  pad_000[0x8];
@@ -44,8 +45,9 @@ struct Shark {
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mModelAnim;            /* 0x30c */
-    u8  pad_30d[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x30c */
     s32 unk_370;            /* 0x370 */
     s32 unk_374;            /* 0x374 */
     s32 unk_378;            /* 0x378 */

--- a/include/ShipUp.h
+++ b/include/ShipUp.h
@@ -5,6 +5,7 @@
 #ifndef SHIPUP_H
 #define SHIPUP_H
 #include "types.h"
+#include "Model.h"
 
 struct ShipUp {
     u8  pad_000[0xc];
@@ -13,8 +14,9 @@ struct ShipUp {
     s16 unk_08c;            /* 0x08c */
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     u8  mModelIndex;            /* 0x31e */

--- a/include/ShipWater.h
+++ b/include/ShipWater.h
@@ -5,6 +5,7 @@
 #ifndef SHIPWATER_H
 #define SHIPWATER_H
 #include "types.h"
+#include "Model.h"
 
 struct ShipWater {
     u8  pad_000[0x60];
@@ -34,10 +35,11 @@ struct ShipWater {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mTextureTransformer;            /* 0x320 */

--- a/include/ShipWing.h
+++ b/include/ShipWing.h
@@ -5,6 +5,7 @@
 #ifndef SHIPWING_H
 #define SHIPWING_H
 #include "types.h"
+#include "Model.h"
 
 struct ShipWing {
     u8  pad_000[0x5c];
@@ -19,8 +20,9 @@ struct ShipWing {
     u8  pad_0a4[0x4];
     s32 unk_0a8;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mWithMeshClsn;            /* 0x320 */

--- a/include/SignPost.h
+++ b/include/SignPost.h
@@ -6,6 +6,15 @@
 #define SIGNPOST_H
 #include "types.h"
 
+/* Player is only ever pointed at from here, so a declaration is enough --
+ * no definition is pulled in. The typedef keeps the member spelled the
+ * same in C and in C++; the guard is common.h's idiom for the same job. */
+#ifndef PLAYER_FWD_DECLARED
+#define PLAYER_FWD_DECLARED
+struct Player;
+typedef struct Player Player;
+#endif
+
 struct SignPost {
     u8  pad_000[0x5c];
     s32 mPosX;            /* 0x05c */
@@ -44,7 +53,11 @@ struct SignPost {
     u8  pad_58f[0x1];
     u8  unk_590;            /* 0x590 */
     u8  pad_591[0xb];
-    u8  unk_59c;            /* 0x59c */
+    /* Player * -- the ROM loads this WORD and passes it to _ZN6Player9DropActorEv as that
+       function's `this`, which is an object address, so the word is a Player *. It says
+       nothing about the rest of the marker's span, which stays explicit padding. Was a u8
+       marker. */
+    Player *unk_59c;            /* 0x59c */
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();

--- a/include/Skeeter.h
+++ b/include/Skeeter.h
@@ -5,6 +5,7 @@
 #ifndef SKEETER_H
 #define SKEETER_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Skeeter {
     u8  pad_000[0x5c];
@@ -31,8 +32,12 @@ struct Skeeter {
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mModelAnim;            /* 0x30c */
-    u8  pad_30d[0x67];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       ran 0x4 bytes PAST the end of the object; that space is not evidenced and stays
+       explicit padding rather than being folded into the member. */
+    ModelAnim mModelAnim;            /* 0x30c */
+    u8  pad_370[0x4];
     s32 unk_374;            /* 0x374 */
     s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */

--- a/include/SkiLift.h
+++ b/include/SkiLift.h
@@ -5,6 +5,7 @@
 #ifndef SKILIFT_H
 #define SKILIFT_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct SkiLift {
     u8  pad_000[0x5c];
@@ -19,12 +20,12 @@ struct SkiLift {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
-    u8  mAnimation;            /* 0x124 */
-    u8  pad_125[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_0dc (+0x8 = data),
+       mAnimation (+0x50 = the Animation base), which the header declared separately inside
+       it. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mTextureSequence;            /* 0x138 */
     u8  pad_139[0x13];
     u8  mShadowModel;            /* 0x14c */

--- a/include/SlideDecorationSilverStar.h
+++ b/include/SlideDecorationSilverStar.h
@@ -5,13 +5,15 @@
 #ifndef SLIDEDECORATIONSILVERSTAR_H
 #define SLIDEDECORATIONSILVERSTAR_H
 #include "types.h"
+#include "Model.h"
 
 struct SlideDecorationSilverStar {
     u8  pad_000[0xc];
     u16 unk_00c;            /* 0x00c */
     u8  pad_00e[0xc6];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     s8  mVariant;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/SlidingIce.h
+++ b/include/SlidingIce.h
@@ -5,6 +5,7 @@
 #ifndef SLIDINGICE_H
 #define SLIDINGICE_H
 #include "types.h"
+#include "Model.h"
 
 struct SlidingIce {
     u8  pad_000[0xc];
@@ -22,8 +23,9 @@ struct SlidingIce {
     u8  pad_09c[0x30];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x4b];
     s8  unk_170;            /* 0x170 */

--- a/include/SlidingPlatformWf.h
+++ b/include/SlidingPlatformWf.h
@@ -5,11 +5,13 @@
 #ifndef SLIDINGPLATFORMWF_H
 #define SLIDINGPLATFORMWF_H
 #include "types.h"
+#include "Model.h"
 
 struct SlidingPlatformWf {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     u8  unk_31e;            /* 0x31e */

--- a/include/Snowball.h
+++ b/include/Snowball.h
@@ -5,6 +5,7 @@
 #ifndef SNOWBALL_H
 #define SNOWBALL_H
 #include "types.h"
+#include "Model.h"
 
 struct Snowball {
     u8  pad_000[0x5c];
@@ -28,8 +29,9 @@ struct Snowball {
     u8  pad_111[0x33];
     u8  mWithMeshClsn;            /* 0x144 */
     u8  pad_145[0x1bb];
-    u8  mModel;            /* 0x300 */
-    u8  pad_301[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x300 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x300 */
     u8  mShadowModel;            /* 0x350 */
     u8  pad_351[0x27];
     s32 unk_378;            /* 0x378 */

--- a/include/SnowmanBody.h
+++ b/include/SnowmanBody.h
@@ -5,6 +5,7 @@
 #ifndef SNOWMANBODY_H
 #define SNOWMANBODY_H
 #include "types.h"
+#include "Model.h"
 
 struct SnowmanBody {
     u8  pad_000[0x8];
@@ -23,8 +24,9 @@ struct SnowmanBody {
     s16 mAngleY;            /* 0x08e */
     s16 mAngleZ;            /* 0x090 */
     u8  pad_092[0x42];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mShadowModel;            /* 0x124 */
     u8  pad_125[0x27];
     u8  mMovingCylinderClsn;            /* 0x14c */

--- a/include/SnowmanBreath.h
+++ b/include/SnowmanBreath.h
@@ -6,6 +6,15 @@
 #define SNOWMANBREATH_H
 #include "types.h"
 
+/* Player is only ever pointed at from here, so a declaration is enough --
+ * no definition is pulled in. The typedef keeps the member spelled the
+ * same in C and in C++; the guard is common.h's idiom for the same job. */
+#ifndef PLAYER_FWD_DECLARED
+#define PLAYER_FWD_DECLARED
+struct Player;
+typedef struct Player Player;
+#endif
+
 struct SnowmanBreath {
     u8  pad_000[0x5c];
     s32 mPosX;            /* 0x05c */
@@ -16,8 +25,12 @@ struct SnowmanBreath {
     u8  pad_090[0x1304];
     u8  unk_1394;           /* 0x1394 */
     u8  pad_1395[0x2f];
-    u8  unk_13c4;           /* 0x13c4 */
-    u8  pad_13c5[0x7];
+    /* Player * -- the ROM loads this WORD and passes it to
+       _ZN6Player9StartTalkER9ActorBaseb as that function's `this`, which is an object
+       address, so the word is a Player *. It says nothing about the rest of the marker's
+       span, which stays explicit padding. Was a u8 marker. */
+    Player *unk_13c4;           /* 0x13c4 */
+    u8  pad_13c8[0x4];
     s32 unk_13cc;           /* 0x13cc */
     u8  unk_13d0;           /* 0x13d0 */
     u8  pad_13d1[0x1];

--- a/include/SnowmanHead.h
+++ b/include/SnowmanHead.h
@@ -5,6 +5,7 @@
 #ifndef SNOWMANHEAD_H
 #define SNOWMANHEAD_H
 #include "types.h"
+#include "Model.h"
 
 struct SnowmanHead {
     u8  pad_000[0x5c];
@@ -16,8 +17,9 @@ struct SnowmanHead {
     s32 mScaleY;            /* 0x084 */
     s32 mScaleZ;            /* 0x088 */
     u8  pad_08c[0x48];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mTextureSequence;            /* 0x124 */
     u8  pad_125[0x13];
     u8  mMovingCylinderClsn;            /* 0x138 */

--- a/include/SolidHeap.h
+++ b/include/SolidHeap.h
@@ -6,12 +6,25 @@
 #define SOLIDHEAP_H
 #include "types.h"
 
+/* SolidHeapAllocator is only ever pointed at from here, so a declaration is enough --
+ * no definition is pulled in. The typedef keeps the member spelled the
+ * same in C and in C++; the guard is common.h's idiom for the same job. */
+#ifndef SOLIDHEAPALLOCATOR_FWD_DECLARED
+#define SOLIDHEAPALLOCATOR_FWD_DECLARED
+struct SolidHeapAllocator;
+typedef struct SolidHeapAllocator SolidHeapAllocator;
+#endif
+
 /* fwd */
 struct a;
 struct id_;
 struct SolidHeap {
     u8  pad_000[0x14];
-    u8  unk_014;            /* 0x014 */
+    /* SolidHeapAllocator * -- the ROM loads this WORD and passes it to
+       _ZN18SolidHeapAllocator10MemoryLeftEi as that function's `this`, which is an object
+       address, so the word is a SolidHeapAllocator *. It says nothing about the rest of
+       the marker's span, which stays explicit padding. Was a u8 marker. */
+    SolidHeapAllocator *unk_014;            /* 0x014 */
 #ifdef __cplusplus
     /* methods */
     bool VIntact();

--- a/include/SquarePathLift.h
+++ b/include/SquarePathLift.h
@@ -5,6 +5,7 @@
 #ifndef SQUAREPATHLIFT_H
 #define SQUAREPATHLIFT_H
 #include "types.h"
+#include "Model.h"
 
 struct SquarePathLift {
     u8  pad_000[0x8];
@@ -18,8 +19,9 @@ struct SquarePathLift {
     u8  pad_090[0x8];
     s32 mMoveSpeed;            /* 0x098 */
     u8  pad_09c[0x38];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mPath;            /* 0x320 */

--- a/include/Squasher.h
+++ b/include/Squasher.h
@@ -5,6 +5,7 @@
 #ifndef SQUASHER_H
 #define SQUASHER_H
 #include "types.h"
+#include "Model.h"
 
 struct Squasher {
     u8  pad_000[0x5c];
@@ -23,8 +24,9 @@ struct Squasher {
     s16 mAngleX;            /* 0x08c */
     u16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/StarMarker.h
+++ b/include/StarMarker.h
@@ -5,6 +5,7 @@
 #ifndef STARMARKER_H
 #define STARMARKER_H
 #include "types.h"
+#include "Model.h"
 
 struct StarMarker {
     u8  pad_000[0x4];
@@ -24,12 +25,12 @@ struct StarMarker {
     s32 unk_0f4;            /* 0x0f4 */
     s32 unk_0f8;            /* 0x0f8 */
     u8  pad_0fc[0x18];
-    u8  mModel;            /* 0x114 */
-    u8  pad_115[0x3f];
-    s32 unk_154;            /* 0x154 */
-    s32 unk_158;            /* 0x158 */
-    s32 unk_15c;            /* 0x15c */
-    u8  pad_160[0x4];
+    /* Model member, named by _ZN5ModelD1Ev at +0x114 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_154 (+0x40 = mat4x3.t.x),
+       unk_158 (+0x44 = mat4x3.t.y), unk_15c (+0x48 = mat4x3.t.z), which the header
+       declared separately inside it. */
+    Model mModel;            /* 0x114 */
     u8  mShadowModel;            /* 0x164 */
     u8  pad_165[0x27];
     u8  unk_18c;            /* 0x18c */

--- a/include/StarSwitch.h
+++ b/include/StarSwitch.h
@@ -5,6 +5,7 @@
 #ifndef STARSWITCH_H
 #define STARSWITCH_H
 #include "types.h"
+#include "Model.h"
 
 struct StarSwitch {
     u8  pad_000[0x8];
@@ -38,8 +39,9 @@ struct StarSwitch {
     u8  pad_0c5[0x7];
     u8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/Submarine.h
+++ b/include/Submarine.h
@@ -5,6 +5,7 @@
 #ifndef SUBMARINE_H
 #define SUBMARINE_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Submarine {
     u8  pad_000[0x5c];
@@ -22,14 +23,12 @@ struct Submarine {
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
     s32 unk_110;            /* 0x110 */
-    u8  mModelAnim;            /* 0x114 */
-    u8  pad_115[0x7];
-    u8  unk_11c;            /* 0x11c */
-    u8  pad_11d[0x47];
-    u8  mAnimation;            /* 0x164 */
-    u8  pad_165[0xb];
-    s32 unk_170;            /* 0x170 */
-    u8  pad_174[0x4];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x114 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_11c (+0x8 = data),
+       mAnimation (+0x50 = the Animation base), unk_170 (+0x5c = speed), which the header
+       declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x114 */
     u8  mTextureTransformer;            /* 0x178 */
     u8  pad_179[0xb];
     s32 unk_184;            /* 0x184 */

--- a/include/SwitchActivatedPlank.h
+++ b/include/SwitchActivatedPlank.h
@@ -5,6 +5,7 @@
 #ifndef SWITCHACTIVATEDPLANK_H
 #define SWITCHACTIVATEDPLANK_H
 #include "types.h"
+#include "Model.h"
 
 struct SwitchActivatedPlank {
     u8  pad_000[0x8e];
@@ -14,8 +15,12 @@ struct SwitchActivatedPlank {
     u8  pad_0d5[0x4f];
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mModel2;            /* 0x320 */
-    u8  pad_321[0x7f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad ran 0x30
+       bytes PAST the end of the object; that space is not evidenced and stays explicit
+       padding rather than being folded into the member. */
+    Model mModel2;            /* 0x320 */
+    u8  pad_370[0x30];
     s16 unk_3a0;            /* 0x3a0 */
     u8  unk_3a2;            /* 0x3a2 */
     u8  unk_3a3;            /* 0x3a3 */

--- a/include/SwitchPillar.h
+++ b/include/SwitchPillar.h
@@ -5,6 +5,7 @@
 #ifndef SWITCHPILLAR_H
 #define SWITCHPILLAR_H
 #include "types.h"
+#include "Model.h"
 
 struct SwitchPillar {
     u8  pad_000[0x60];
@@ -21,10 +22,11 @@ struct SwitchPillar {
     s16 mAngleX;                 /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mTextureTransformer;            /* 0x320 */

--- a/include/TTC_MovingBar.h
+++ b/include/TTC_MovingBar.h
@@ -5,6 +5,7 @@
 #ifndef TTC_MOVINGBAR_H
 #define TTC_MOVINGBAR_H
 #include "types.h"
+#include "Model.h"
 
 struct TTC_MovingBar {
     u8  pad_000[0xc];
@@ -16,8 +17,9 @@ struct TTC_MovingBar {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     u8  unk_31e;            /* 0x31e */

--- a/include/Thwomp.h
+++ b/include/Thwomp.h
@@ -5,11 +5,13 @@
 #ifndef THWOMP_H
 #define THWOMP_H
 #include "types.h"
+#include "Model.h"
 
 struct Thwomp {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 mFileTable;            /* 0x320 */

--- a/include/TinyCover.h
+++ b/include/TinyCover.h
@@ -5,6 +5,7 @@
 #ifndef TINYCOVER_H
 #define TINYCOVER_H
 #include "types.h"
+#include "Model.h"
 
 struct TinyCover {
     u8  pad_000[0x60];
@@ -12,10 +13,11 @@ struct TinyCover {
     u8  pad_064[0x2a];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mTextureTransformer;            /* 0x320 */

--- a/include/Toad.h
+++ b/include/Toad.h
@@ -5,6 +5,7 @@
 #ifndef TOAD_H
 #define TOAD_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Toad {
     u8  pad_000[0x8];
@@ -20,8 +21,9 @@ struct Toad {
     u8  pad_0cd[0x7];
     u8  mMovingCylinderClsn;            /* 0x0d4 */
     u8  pad_0d5[0x33];
-    u8  mModelAnim;            /* 0x108 */
-    u8  pad_109[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x108 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x108 */
     u8  mShadowModel;            /* 0x16c */
     u8  pad_16d[0x87];
     s32 unk_1f4;            /* 0x1f4 */

--- a/include/Tornado.h
+++ b/include/Tornado.h
@@ -5,6 +5,7 @@
 #ifndef TORNADO_H
 #define TORNADO_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Tornado {
     u8  pad_000[0x8];
@@ -36,10 +37,11 @@ struct Tornado {
     u8  pad_0fc[0xc];
     u8  mWithMeshClsn;            /* 0x108 */
     u8  pad_109[0x1bb];
-    u8  mModelAnim;            /* 0x2c4 */
-    u8  pad_2c5[0x4f];
-    u8  mAnimation;            /* 0x314 */
-    u8  pad_315[0x13];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x2c4 -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over mAnimation (+0x50 = the
+       Animation base), which the header declared separately inside it. */
+    ModelAnim mModelAnim;            /* 0x2c4 */
     u8  mTextureTransformer;            /* 0x328 */
     u8  pad_329[0x13];
     s32 unk_33c;            /* 0x33c */

--- a/include/TowerStep.h
+++ b/include/TowerStep.h
@@ -5,6 +5,7 @@
 #ifndef TOWERSTEP_H
 #define TOWERSTEP_H
 #include "types.h"
+#include "Model.h"
 
 struct TowerStep {
     u8  pad_000[0x74];
@@ -21,8 +22,9 @@ struct TowerStep {
     u8  pad_090[0x4];
     s16 unk_094;            /* 0x094 */
     u8  pad_096[0x3e];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     s8  unk_31e;            /* 0x31e */

--- a/include/ToxBox.h
+++ b/include/ToxBox.h
@@ -5,6 +5,7 @@
 #ifndef TOXBOX_H
 #define TOXBOX_H
 #include "types.h"
+#include "Model.h"
 
 struct ToxBox {
     u8  pad_000[0x8];
@@ -18,10 +19,11 @@ struct ToxBox {
     s16 mAngleY;            /* 0x08e */
     s16 mAngleZ;            /* 0x090 */
     u8  pad_092[0x42];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x1b];
-    u8  unk_0f0;            /* 0x0f0 */
-    u8  pad_0f1[0x33];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_0f0 (+0x1c = mat4x3), which
+       the header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/Trap.h
+++ b/include/Trap.h
@@ -5,11 +5,13 @@
 #ifndef TRAP_H
 #define TRAP_H
 #include "types.h"
+#include "Model.h"
 
 struct Trap {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingCylinderClsnWithPos;            /* 0x124 */
     u8  pad_125[0x43];
     u8  unk_168;            /* 0x168 */

--- a/include/TreasureChest.h
+++ b/include/TreasureChest.h
@@ -5,13 +5,15 @@
 #ifndef TREASURECHEST_H
 #define TREASURECHEST_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct TreasureChest {
     u8  pad_000[0x8];
     s32 unk_008;            /* 0x008 */
     u8  pad_00c[0xc8];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x63];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
     u8  mMovingCylinderClsn;            /* 0x138 */
     u8  pad_139[0x39];
     u8  unk_172;            /* 0x172 */

--- a/include/TtcConveyorBeltLarge.h
+++ b/include/TtcConveyorBeltLarge.h
@@ -5,6 +5,7 @@
 #ifndef TTCCONVEYORBELTLARGE_H
 #define TTCCONVEYORBELTLARGE_H
 #include "types.h"
+#include "Model.h"
 
 struct TtcConveyorBeltLarge {
     u8  pad_000[0xc];
@@ -18,10 +19,11 @@ struct TtcConveyorBeltLarge {
     u8  pad_090[0x20];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0x47];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
+       short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/TtcMovingCubeA.h
+++ b/include/TtcMovingCubeA.h
@@ -5,6 +5,7 @@
 #ifndef TTCMOVINGCUBEA_H
 #define TTCMOVINGCUBEA_H
 #include "types.h"
+#include "Model.h"
 
 struct TtcMovingCubeA {
     u8  pad_000[0x8];
@@ -20,8 +21,9 @@ struct TtcMovingCubeA {
     u8  pad_0a4[0x4];
     s32 unk_0a8;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/TtcRotatingCube.h
+++ b/include/TtcRotatingCube.h
@@ -5,6 +5,7 @@
 #ifndef TTCROTATINGCUBE_H
 #define TTCROTATINGCUBE_H
 #include "types.h"
+#include "Model.h"
 
 struct TtcRotatingCube {
     u8  pad_000[0x90];
@@ -22,12 +23,14 @@ struct TtcRotatingCube {
     u8  pad_0ac[0x4];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel1;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mModel2;            /* 0x320 */
-    u8  pad_321[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel2;            /* 0x320 */
     s32 unk_370;            /* 0x370 */
     s16 mWaitTimer;            /* 0x374 */
     u8  unk_376;            /* 0x376 */

--- a/include/TtcRotatingGear.h
+++ b/include/TtcRotatingGear.h
@@ -5,6 +5,7 @@
 #ifndef TTCROTATINGGEAR_H
 #define TTCROTATINGGEAR_H
 #include "types.h"
+#include "Model.h"
 
 struct TtcRotatingGear {
     u8  pad_000[0x5c];
@@ -18,8 +19,9 @@ struct TtcRotatingGear {
     u8  pad_0a4[0x4];
     s32 unk_0a8;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */

--- a/include/UnchainedChomp.h
+++ b/include/UnchainedChomp.h
@@ -5,6 +5,7 @@
 #ifndef UNCHAINEDCHOMP_H
 #define UNCHAINEDCHOMP_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct UnchainedChomp {
     u8  pad_000[0x8];
@@ -29,8 +30,12 @@ struct UnchainedChomp {
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mModelAnim;            /* 0x30c */
-    u8  pad_30d[0x333];
+    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build
+       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       ran 0x2d0 bytes PAST the end of the object; that space is not evidenced and stays
+       explicit padding rather than being folded into the member. */
+    ModelAnim mModelAnim;            /* 0x30c */
+    u8  pad_370[0x2d0];
     u8  mShadowModel;            /* 0x640 */
     u8  pad_641[0x6b];
     s32 unk_6ac;            /* 0x6ac */

--- a/include/UpDownLiftBbh.h
+++ b/include/UpDownLiftBbh.h
@@ -5,6 +5,7 @@
 #ifndef UPDOWNLIFTBBH_H
 #define UPDOWNLIFTBBH_H
 #include "types.h"
+#include "Model.h"
 
 struct UpDownLiftBbh {
     u8  pad_000[0xc];
@@ -63,8 +64,9 @@ struct UpDownLiftBbh {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1db];
     u16 unk_300;            /* 0x300 */

--- a/include/WallSign.h
+++ b/include/WallSign.h
@@ -5,11 +5,13 @@
 #ifndef WALLSIGN_H
 #define WALLSIGN_H
 #include "types.h"
+#include "Model.h"
 
 struct WallSign {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mMovingCylinderClsnWithPos;            /* 0x320 */

--- a/include/WaterBomb.h
+++ b/include/WaterBomb.h
@@ -5,6 +5,7 @@
 #ifndef WATERBOMB_H
 #define WATERBOMB_H
 #include "types.h"
+#include "Model.h"
 
 struct WaterBomb {
     u8  pad_000[0x80];
@@ -42,8 +43,9 @@ struct WaterBomb {
     u8  pad_111[0x33];
     u8  mWithMeshClsn;            /* 0x144 */
     u8  pad_145[0x1bb];
-    u8  mModel;            /* 0x300 */
-    u8  pad_301[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x300 -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x300 */
     u8  mShadowModel;            /* 0x350 */
     u8  pad_351[0x73];
     s32 unk_3c4;            /* 0x3c4 */

--- a/include/WaterRing.h
+++ b/include/WaterRing.h
@@ -5,6 +5,7 @@
 #ifndef WATERRING_H
 #define WATERRING_H
 #include "types.h"
+#include "Model.h"
 
 struct WaterRing {
     u8  pad_000[0x8];
@@ -26,8 +27,9 @@ struct WaterRing {
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1bb];
-    u8  mModel;            /* 0x30c */
-    u8  pad_30d[0x4f];
+    /* Model member, named by _ZN5ModelD1Ev at +0x30c -- a relocation the ROM build checks.
+       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
+    Model mModel;            /* 0x30c */
     u8  mTextureTransformer;            /* 0x35c */
     u8  pad_35d[0xb];
     s32 unk_368;            /* 0x368 */

--- a/include/YoshiEgg.h
+++ b/include/YoshiEgg.h
@@ -6,6 +6,15 @@
 #define YOSHIEGG_H
 #include "types.h"
 
+/* Player is only ever pointed at from here, so a declaration is enough --
+ * no definition is pulled in. The typedef keeps the member spelled the
+ * same in C and in C++; the guard is common.h's idiom for the same job. */
+#ifndef PLAYER_FWD_DECLARED
+#define PLAYER_FWD_DECLARED
+struct Player;
+typedef struct Player Player;
+#endif
+
 struct YoshiEgg {
     u8  pad_000[0x5c];
     s32 mPosX;            /* 0x05c */
@@ -24,8 +33,12 @@ struct YoshiEgg {
     u8  pad_351[0x13];
     u8  mShadowModel;            /* 0x364 */
     u8  pad_365[0x27];
-    u8  mPlayer;            /* 0x38c */
-    u8  pad_38d[0x63];
+    /* Player * -- the ROM loads this WORD and passes it to _ZN6Player16IsInsideOfCannonEv
+       as that function's `this`, which is an object address, so the word is a Player *. It
+       says nothing about the rest of the marker's span, which stays explicit padding. Was
+       a u8 marker. */
+    Player *mPlayer;            /* 0x38c */
+    u8  pad_390[0x60];
     s32 unk_3f0;            /* 0x3f0 */
     u8  pad_3f4[0x2c];
     u8  unk_420;            /* 0x420 */

--- a/include/common.h
+++ b/include/common.h
@@ -4,7 +4,18 @@
 #define COMMON_H
 #include "types.h"
 
+/* Guarded on the same principle as Vector3_16 below: math/Matrix.h defines this
+ * type too, structured as `Matrix3x3 r; Vector3 t;` rather than flat, and any
+ * header reaching Model.h -> ModelBase.h -> math/Matrix.h brings it in. Both
+ * spellings are 0x30 bytes and both are in real use -- Matrix4x3_ApplyInPlace*
+ * wants `m[i]`, the model headers want `.r`/`.t` -- so neither can simply win.
+ * Whichever is seen FIRST in a translation unit stands, and the other stands
+ * down. Without this a TU that reaches both fails outright, which is what blocked
+ * typing Model/ModelAnim members into the actor headers. */
+#ifndef MATRIX4X3_DEFINED
+#define MATRIX4X3_DEFINED
 struct Matrix4x3 { s32 m[12]; };
+#endif
 /* Vector3 lives in types.h (as {Fix12i x,y,z}); not redefined here. */
 /* Guarded so MeshColliderBase.h, which needs this type and cannot assume common.h
  * was included first, can define it too without colliding. Both spell the guard

--- a/include/math/Matrix.h
+++ b/include/math/Matrix.h
@@ -19,10 +19,15 @@ typedef struct Matrix3x3 {
     Fix12i m[9];
 } Matrix3x3;
 
+/* See include/common.h: this type has a second, flat spelling there. Same 0x30
+ * bytes; whichever a translation unit sees first stands. */
+#ifndef MATRIX4X3_DEFINED
+#define MATRIX4X3_DEFINED
 typedef struct Matrix4x3 {
     Matrix3x3 r;   /* 0x00 */
     Vector3   t;   /* 0x24 */
 } Matrix4x3;
+#endif
 
 typedef char Matrix3x3_size_must_be_0x24[
     sizeof(Matrix3x3) == 0x24 ? 1 : -1

--- a/src/_ZN10FlameChomp13InitResourcesEv.cpp
+++ b/src/_ZN10FlameChomp13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FlameChomp.h"
-typedef int Fix12;
+/* was `typedef int Fix12;` -- collides with the real Fix12<> template, which
+   FlameChomp.h now reaches via Model.h. The typedef WAS int, so spelling it
+   int below is byte-neutral. */
 struct RG { char pad[0x44]; int f44; char pad2[8]; };
 struct Blk { int w[12]; };
 
@@ -14,9 +16,9 @@ extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b)
 extern int _ZN11ShadowModel12InitCylinderEv(void* self);
 }
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
-    void* self, void* actor, const struct Vector3* v, Fix12 a, int b, unsigned int c, unsigned int d);
+    void* self, void* actor, const struct Vector3* v, int a, int b, unsigned int c, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(
-    void* self, void* actor, Fix12 a, int b, void* v, int c);
+    void* self, void* actor, int a, int b, void* v, int c);
 extern "C" {
 extern void _ZN13RaycastGroundC1Ev(struct RG* rg);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RG* rg, const struct Vector3* v, void* a);

--- a/src/_ZN10KingBobOmb13InitResourcesEv.cpp
+++ b/src/_ZN10KingBobOmb13InitResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "KingBobOmb.h"
-typedef int Fix12;
-typedef struct { int w[2]; } SharedFilePtr;
+/* SharedFilePtr stays incomplete: Model.h forward-declares it and its layout is
+   deliberately not recovered (include/SharedFilePtr.h). Used only by address here. */
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
@@ -31,8 +31,8 @@ extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
-extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, Actor* a, Vector3* v, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
-extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
+extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, Actor* a, Vector3* v, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
+extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12i r, Fix12i h, Vector3_16* p, Vector3_16* q);
 extern unsigned char _ZN5Actor9TrackStarEjj(void* self, unsigned int a, unsigned int b);
 extern int RandomIntInternal(int* seed);
 extern void KingBobOmb_SetState(void* c, PMF* p);

--- a/src/_ZN10Scuttlebug13InitResourcesEv.cpp
+++ b/src/_ZN10Scuttlebug13InitResourcesEv.cpp
@@ -5,7 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Scuttlebug.h"
 struct BMD_File; struct BCA_File; struct Actor; struct Vector3_16;
-struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
+/* ModelBase is the real class now, through this actor's header. */
 struct ShadowModel { int InitCylinder(); };
 struct MovingCylinderClsn { void Init(Actor *a, int b, int c, unsigned int d, unsigned int e); };
 struct WithMeshClsn { void Init(Actor *a, int b, int c, void *d, int e); void StartDetectingWater(); };

--- a/src/_ZN10StarMarker8BehaviorEv.cpp
+++ b/src/_ZN10StarMarker8BehaviorEv.cpp
@@ -1,9 +1,13 @@
 //cpp
 // @symbol _ZN10StarMarker8BehaviorEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
+/* The class header comes FIRST on purpose: it reaches math/Matrix.h, whose
+   Matrix4x3 is the structured one, and include/common.h's flat spelling stands
+   down behind the guard. mat4x3.t is only nameable this way round, and the two
+   spellings are the same 0x30 bytes. */
 #include "StarMarker.h"
+/* recovered: declarations from a shared header */
+#include "decl_common.h"
 typedef struct Mtx { int m[12]; } Mtx;
 extern "C" {
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
@@ -52,9 +56,9 @@ int StarMarker::Behavior()
     } else {
         *(short *)((((int)((char *)this)) + 0x8e)) += 0x400;
         Matrix4x3_FromRotationY(((char *)this) + 0x130, mAngleY);
-        unk_154 = mPosX >> 3;
-        unk_158 = mPosY >> 3;
-        unk_15c = mPosZ >> 3;
+        mModel.mat4x3.t.x = mPosX >> 3;
+        mModel.mat4x3.t.y = mPosY >> 3;
+        mModel.mat4x3.t.z = mPosZ >> 3;
     }
     if ((unsigned int)(mFlags << 0x1e) >> 0x1f) {
         *(Mtx *)((char *)&unk_18c) = data_02082128;

--- a/src/_ZN11BobOmbBuddy13InitResourcesEv.cpp
+++ b/src/_ZN11BobOmbBuddy13InitResourcesEv.cpp
@@ -5,7 +5,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BobOmbBuddy.h"
-typedef int Fix12;
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 
 extern "C" {
@@ -13,7 +12,7 @@ extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void* fp);
-extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* actor, Fix12 b, Fix12 c, unsigned int d, unsigned int e);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* actor, Fix12i b, Fix12i c, unsigned int d, unsigned int e);
 extern void func_ov084_0212c960(void* c, int i);
 extern void _ZN13RaycastGroundC1Ev(RaycastGround* self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround* self, const Vector3& v, void* actor);

--- a/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
+++ b/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
@@ -27,8 +27,8 @@ int BobOmbBuddy::Behavior()
             _Z14ApproachLinearRsss((short*)((char *)&unk_08e), ang, 0x100);
         }
     }
-    _ZN9Animation7AdvanceEv((char *)&mAnimation);
-    if ((unsigned short)(unk_160 >> 12) == 0)
+    _ZN9Animation7AdvanceEv((char *)(Animation *)&mModelAnim);
+    if ((unsigned short)(mModelAnim.currFrame >> 12) == 0)
         func_02012694(0xd7, ((char *)this) + 0x74);
     func_ov084_0212ce50(((char *)this));
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);

--- a/src/_ZN11ChiefChilly13InitResourcesEv.cpp
+++ b/src/_ZN11ChiefChilly13InitResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ChiefChilly.h"
-typedef int Fix12;
-typedef struct { int w[2]; } SharedFilePtr;
+/* SharedFilePtr stays incomplete: Model.h forward-declares it and its layout is
+   deliberately not recovered (include/SharedFilePtr.h). Used only by address here. */
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
@@ -27,8 +27,8 @@ extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN11ShadowModel12InitCylinderEv(void* self);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
-extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, Actor* a, Vector3* v, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
-extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
+extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, Actor* a, Vector3* v, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
+extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12i r, Fix12i h, Vector3_16* p, Vector3_16* q);
 extern short _ZN5Actor18HorzAngleToCPlayerEv(void* self);
 extern int ChiefChilly_ChangeState(void* c, PMF* p);
 }
@@ -56,7 +56,7 @@ int ChiefChilly::InitResources()
     v.y = data_ov073_02123040.y;
     v.z = data_ov073_02123040.z;
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(((char*)this)+0x110, (Actor*)((char*)this), &v, 0xa4000, 0x1e4000, 0x200000, 0x567f0);
-    unk_368 = 0x2000;
+    mBlendModelAnim.speed = 0x2000;
     _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this)+0x150, (Actor*)((char*)this), 0x96000, 0x94000, 0, 0);
     unk_3d8 = mPosX;
     unk_3dc = mPosY;

--- a/src/_ZN11PyramidLift13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidLift13InitResourcesEv.cpp
@@ -6,7 +6,8 @@
 #include "PyramidLift.h"
 #pragma opt_strength_reduction off
 typedef int Fix12;
-typedef struct { int w[2]; } SharedFilePtr;
+/* SharedFilePtr stays incomplete: Model.h forward-declares it and its layout is
+   deliberately not recovered (include/SharedFilePtr.h). Used only by address here. */
 typedef struct BMD_File BMD_File;
 typedef struct KCL_File KCL_File;
 typedef struct Matrix4x3 Matrix4x3;

--- a/src/_ZN11PyramidLift6RenderEv.cpp
+++ b/src/_ZN11PyramidLift6RenderEv.cpp
@@ -28,7 +28,7 @@ int PyramidLift::Render()
     if (i < 0xa) {
         Elem* e = (Elem*)(((char*)this) + i * 0xc);
         do {
-            Matrix4x3_FromTranslation((Mtx*)((char*)&unk_33c),
+            Matrix4x3_FromTranslation((Mtx*)((char*)&mModel2.mat4x3),
                 e->w[(0x37c)/4] >> 3,
                 e->w[(0x380)/4] >> 3,
                 e->w[(0x384)/4] >> 3);

--- a/src/_ZN13KoopaTheQuick6RenderEv.cpp
+++ b/src/_ZN13KoopaTheQuick6RenderEv.cpp
@@ -2,20 +2,12 @@
 // @symbol _ZN13KoopaTheQuick6RenderEv
 /* recovered: named members + shared header, real C++ method */
 #include "KoopaTheQuick.h"
-struct Model {
-  virtual void v0();
-  virtual void v1();
-  virtual void v2();
-  virtual void v3();
-  virtual void v4();
-  virtual void v5(void* p);
-  void HideMaterial(int a, int b);
-};
+/* Model is the real class now, through KoopaTheQuick.h: HideMaterial is its own
+   non-virtual and the slot-5 virtual is Render, which ModelAnim overrides. */
 
 int KoopaTheQuick::Render()
 {
-  Model* m = (Model*)((char*)&mModelAnim);
-  m->HideMaterial(0, 1);
-  ((Model*)((char*)&mModelAnim))->v5((char*)&mScaleX);
+  mModelAnim.HideMaterial(0, 1);
+  mModelAnim.Render((const Vector3*)((char*)&mScaleX));
   return 1;
 }

--- a/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
+++ b/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
@@ -22,7 +22,7 @@ int KoopaTheQuick::Behavior()
   if(adj&1){ void* vt=*(void**)self; fn=*(void**)((char*)vt + *(int*)ent); }
   else fn=*(void**)ent;
   ((void(*)(char*))fn)(self);
-  _ZN9Animation7AdvanceEv((char*)&unk_350);
+  _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim);
   mAngleY = mPrevAngleY;
   _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), ((char*)this)+0x110);
   _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char*)this), ((char*)this)+0x144, 0);

--- a/src/_ZN13PeachPainting8BehaviorEv.cpp
+++ b/src/_ZN13PeachPainting8BehaviorEv.cpp
@@ -4,8 +4,9 @@
 #include "PeachPainting.h"
 struct Actor { int DistToCPlayer(); };
 namespace cstd { int fdiv(int a, int b); }
-struct ModelBase { void ApplyOpacity(unsigned int o, int x); };
-/* Signature deliberately copied from the local declaration above: the
+/* ModelBase is the real class (include/ModelBase.h), reached through
+   PeachPainting.h -> Model.h. Its ApplyOpacity is declared there with one
+   argument; the ROM's takes two, so the call keeps the mangled spelling:
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */

--- a/src/_ZN13PrincessPeach13InitResourcesEv.cpp
+++ b/src/_ZN13PrincessPeach13InitResourcesEv.cpp
@@ -5,7 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "PrincessPeach.h"
 struct BMD_File; struct Actor; struct Vector3_16;
-struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
+/* ModelBase is the real class now, through PrincessPeach.h. */
 struct ShadowModel { int InitCylinder(); };
 struct MovingCylinderClsn { void Init(Actor *a, int b, int c, unsigned int d, unsigned int e); };
 struct WithMeshClsn { void Init(Actor *a, int b, int c, void *d, int e); };

--- a/src/_ZN13PrincessPeach8BehaviorEv.cpp
+++ b/src/_ZN13PrincessPeach8BehaviorEv.cpp
@@ -17,7 +17,7 @@ int PrincessPeach::Behavior()
     func_ov085_0212a430(((char *)this));
     func_ov085_02129dbc(((char *)this));
     if (unk_354 != 1)
-        _ZN9Animation7AdvanceEv((char *)&mAnimation);
+        _ZN9Animation7AdvanceEv((char *)(Animation *)&mModelAnim);
     ((Sub*)((char *)&mModelAnim))->g3();
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);

--- a/src/_ZN13QuestionBlock8BehaviorEv.cpp
+++ b/src/_ZN13QuestionBlock8BehaviorEv.cpp
@@ -36,7 +36,7 @@ int QuestionBlock::Behavior()
     if ((data_0209caa0[1] & 0x80000000) == 0) {
         int b = (int)(mActorId == 0x14);
         if (b != 0) {
-            _ZN9Animation7AdvanceEv((char*)&mAnimation);
+            _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim);
             if (((MeshColliderBase *)((char*)&mMeshCollider))->IsEnabled() != 0) {
                 ((MeshColliderBase *)((char*)&mMeshCollider))->Disable();
             }

--- a/src/_ZN13RacingPenguin8BehaviorEv.cpp
+++ b/src/_ZN13RacingPenguin8BehaviorEv.cpp
@@ -11,7 +11,7 @@ extern void _ZN12CylinderClsn6UpdateEv(char *c);
 int RacingPenguin::Behavior()
 {
     func_ov019_02112268(((char *)this));
-    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    _ZN9Animation7AdvanceEv((char *)(Animation *)&mModelAnim);
     _ZN9Animation7AdvanceEv((char *)&mTextureSequence);
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);

--- a/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
+++ b/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
@@ -41,7 +41,7 @@ int RollingLogTtm::InitResources()
     if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0)
         return 0;
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *)this) + 0xd4, data_ov030_02115cf0[1], 0, 0x1000, 0);
-    unk_130 = 0x1000;
+    mModelAnim.speed = 0x1000;
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0x160, ((char *)this), 0x28000, 0x64000, 0x800004, 0x49000);
     _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x194, ((char *)this), 0x32000, 0x32000, 0, 0);
     unk_09c = -0x2000;

--- a/src/_ZN14QuestionSwitch13InitResourcesEv.cpp
+++ b/src/_ZN14QuestionSwitch13InitResourcesEv.cpp
@@ -32,7 +32,7 @@ int QuestionSwitch::InitResources()
     f = _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210dd68);
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *)this) + 0x6b4, f, 0, 0x1000, 0);
     _ZN9Animation8SetFlagsEi(((char *)this) + 0x704, 0x40000000);
-    unk_710 = 0x1000;
+    mModelAnim.speed = 0x1000;
     func_ov002_020b50a0(((char *)this));
 
     f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov002_0210dd58);
@@ -47,11 +47,11 @@ int QuestionSwitch::InitResources()
 
     if (data_0209caa0[1] & 0x80000000) {
         mActiveMeshCollider = (int)((char *)&mMovingMeshCollider);
-        unk_70c = _ZNK9Animation13GetFrameCountEv((char *)&mAnim) << 12;
-        _ZN9Animation7AdvanceEv((char *)&mAnim);
+        mModelAnim.currFrame = _ZNK9Animation13GetFrameCountEv((char *)(Animation *)&mModelAnim) << 12;
+        _ZN9Animation7AdvanceEv((char *)(Animation *)&mModelAnim);
     } else {
         mActiveMeshCollider = (int)((char *)&unk_324);
-        unk_70c = 0;
+        mModelAnim.currFrame = 0;
     }
 
     func_ov002_020b503c(((char *)this));

--- a/src/_ZN16BowserShockwaves8BehaviorEv.cpp
+++ b/src/_ZN16BowserShockwaves8BehaviorEv.cpp
@@ -39,11 +39,11 @@ int BowserShockwaves::Behavior()
   _ZN9Animation7AdvanceEv((char*)&mMaterialChanger2);
   _ZN9Animation7AdvanceEv((char*)&mTextureTransformer1);
   _ZN9Animation7AdvanceEv((char*)&mTextureTransformer2);
-  _ZN9Animation7AdvanceEv((char*)&mAnimation1);
-  _ZN9Animation7AdvanceEv((char*)&mAnimation2);
+  _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim1);
+  _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim2);
   Matrix4x3_FromTranslation(((char*)this)+0xf0, mPosX>>3, mPosY>>3, mPosZ>>3);
   Matrix4x3_FromTranslation(((char*)this)+0x190, mPosX>>3, mPosY>>3, mPosZ>>3);
-  if(_ZN9Animation8FinishedEv((char*)&mAnimation1)){
+  if(_ZN9Animation8FinishedEv((char*)(Animation *)&mModelAnim1)){
     _ZN9ActorBase18MarkForDestructionEv(((char*)this));
   }
   return 1;

--- a/src/_ZN17RotatingClockHand13InitResourcesEv.cpp
+++ b/src/_ZN17RotatingClockHand13InitResourcesEv.cpp
@@ -6,7 +6,7 @@
 #include "RotatingClockHand.h"
 struct BMD_File; struct KCL_File; struct Actor; struct Vector3; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr;
-struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
+/* ModelBase is the real class now, through this actor's header. */
 struct ShadowModel { void InitCuboid(); };
 struct Platform { void UpdateClsnPosAndRot(); };
 struct MovingMeshCollider {

--- a/src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp
@@ -6,8 +6,7 @@
 #include "SwitchActivatedPlank.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
-struct Model { int d; };
-struct ModelBase { int d; };
+/* Model and ModelBase are the real classes now, through this actor's header. */
 struct MeshCollider { int d; };
 struct MovingMeshCollider { int d; };
 

--- a/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
@@ -15,9 +15,7 @@ struct SharedFilePtr;
 
 extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 
-struct ModelBase {
-    void SetFile(BMD_File *f, int b, int c);
-};
+/* ModelBase is the real class now, through TtcConveyorBeltLarge.h. */
 
 struct ShadowModel {
     void InitCuboid();

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
@@ -6,8 +6,6 @@
 #include "FloatOnWaterPlatformWdwSquare.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
-struct Model { int d; };
-struct ModelBase { int d; };
 struct MeshCollider { int d; };
 struct MovingMeshCollider { int d; };
 

--- a/src/_ZN4Bird8BehaviorEv.cpp
+++ b/src/_ZN4Bird8BehaviorEv.cpp
@@ -34,8 +34,8 @@ int Bird::Behavior()
   mAngleY = mPrevAngleY;
   Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, mAngleZ);
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, mAngleY);
-  *(struct Mtx*)((char*)&unk_0f0) = data_020a0e68;
+  *(struct Mtx*)((char*)&mModelAnim.mat4x3) = data_020a0e68;
   _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(((char*)this), ((char*)this)+0x138, ((char*)this)+0xf0, 0x1e000, 0x7d0000, 0xf);
-  _ZN9Animation7AdvanceEv((char*)&mAnimation);
+  _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim);
   return 1;
 }

--- a/src/_ZN4Flag8BehaviorEv.cpp
+++ b/src/_ZN4Flag8BehaviorEv.cpp
@@ -9,10 +9,10 @@ extern void Matrix4x3_FromRotationY(void* m, short angle);
 
 int Flag::Behavior()
 {
-  _ZN9Animation7AdvanceEv((char*)&mAnimation);
+  _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim);
   Matrix4x3_FromRotationY(((char*)this)+0xf0, mAngleY);
-  unk_114=mPosX>>3;
-  unk_118=mPosY>>3;
-  unk_11c=mPosZ>>3;
+  mModelAnim.mat4x3.t.x=mPosX>>3;
+  mModelAnim.mat4x3.t.y=mPosY>>3;
+  mModelAnim.mat4x3.t.z=mPosZ>>3;
   return 1;
 }

--- a/src/_ZN6BobOmb13InitResourcesEv.cpp
+++ b/src/_ZN6BobOmb13InitResourcesEv.cpp
@@ -2,42 +2,37 @@
 // @symbol _ZN6BobOmb13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "BobOmb.h"
-typedef int Fix12;
 struct BMD_File;
 struct SharedFilePtr { int h; };
 struct Actor;
 struct Vector3_16;
 
-struct Animation {
-    static void LoadFile(SharedFilePtr& f);
-};
-struct Model {
-    static BMD_File* LoadFile(SharedFilePtr& f);
-};
-struct ModelBase {
-    int SetFile(BMD_File* f, int a, int b);
-};
+/* ModelBase::SetFile is declared void in include/ModelBase.h -- which is what its
+   own matched definition compiles as -- but the ROM leaves DoSetFile's int in r0
+   and this call site reads it, so the value-returning entry keeps the mangled
+   spelling until that signature is settled. */
+extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, BMD_File *f, int a, int b);
 struct ShadowModel {
     int InitCylinder();
 };
 struct MovingCylinderClsn {
-    void Init(Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
+    void Init(Actor* a, Fix12i r, Fix12i h, unsigned int d, unsigned int e);
 };
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12i r, Fix12i h, unsigned int d, unsigned int e);
 
 struct WithMeshClsn {
-    void Init(Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
+    void Init(Actor* a, Fix12i b, Fix12i c, Vector3_16* d, Fix12i e);
     void StartDetectingWater();
 };
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *, Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
+extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *, Actor* a, Fix12i b, Fix12i c, Vector3_16* d, Fix12i e);
 
 extern "C" void func_ov102_0214c0b8(void* c);
 
@@ -89,8 +84,8 @@ int BobOmb::InitResources()
 
     Animation::LoadFile(data_ov102_0214e9c0);
     Animation::LoadFile(data_ov102_0214e9c8);
-    bmd = Model::LoadFile(data_ov002_0210d9e0);
-    if (((ModelBase*)&((Obj*)this)->f300)->SetFile(bmd, 1, -1) == 0)
+    bmd = (BMD_File*)Model::LoadFile(data_ov002_0210d9e0);
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(&((Obj*)this)->f300, bmd, 1, -1) == 0)
         return 0;
     if (((ShadowModel*)&((Obj*)this)->f364)->InitCylinder() == 0)
         return 0;

--- a/src/_ZN6Coffin13InitResourcesEv.cpp
+++ b/src/_ZN6Coffin13InitResourcesEv.cpp
@@ -13,12 +13,6 @@ struct BMD_File;
 struct KCL_File;
 struct CLPS_Block;
 
-struct Model {
-    static BMD_File* LoadFile(SharedFilePtr& f);
-};
-struct ModelBase {
-    int SetFile(BMD_File* f, int a, int b);
-};
 struct MeshCollider {
     static KCL_File* LoadFile(SharedFilePtr& f);
 };
@@ -35,8 +29,6 @@ struct Platform {
     void UpdateClsnPosAndRot();
 };
 
-BMD_File* Model::LoadFile(SharedFilePtr&);
-int ModelBase::SetFile(BMD_File*, int, int);
 KCL_File* MeshCollider::LoadFile(SharedFilePtr&);
 int MovingMeshCollider::SetFile(KCL_File*, const Matrix4x3&, Fix12, short, CLPS_Block&);
 void Platform::UpdateClsnPosAndRot();
@@ -57,7 +49,7 @@ extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResult
 
 int Coffin::InitResources()
 {
-    ((ModelBase*)((char*)&mModel))->SetFile(Model::LoadFile(data_ov071_021230d0), 1, -1);
+    ((ModelBase*)((char*)&mModel))->SetFile((BMD_File*)Model::LoadFile(data_ov071_021230d0), 1, -1);
     unk_09c = -0x2000;
     unk_0a0 = -0x3c000;
     Vector3 in;

--- a/src/_ZN6Klepto13InitResourcesEv.cpp
+++ b/src/_ZN6Klepto13InitResourcesEv.cpp
@@ -5,8 +5,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Klepto.h"
-typedef int Fix12;
-typedef struct { int h; } SharedFilePtr;
+/* SharedFilePtr stays incomplete: Model.h forward-declares it and its layout is
+   deliberately not recovered (include/SharedFilePtr.h). Used only by address here. */
 
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr *f);
@@ -16,10 +16,10 @@ extern void *_ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr *f);
 extern void _ZN7PathPtrC1Ev(void *self);
 extern void _ZN7PathPtr6FromIDEj(void *self, unsigned int id);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, void *v, unsigned int idx);
-extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
-extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *a, Fix12 b, Fix12 c, void *d, void *e);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *a, Fix12i r, Fix12i h, unsigned int d, unsigned int e);
+extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *a, Fix12i b, Fix12i c, void *d, void *e);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void *pos, void *rot, int e, int f);
-extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, Fix12 a, Fix12 b, Fix12 c, Fix12 d);
+extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, Fix12i a, Fix12i b, Fix12i c, Fix12i d);
 extern void func_ov062_0211c658(void *c, void *p);
 extern short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
 }
@@ -83,7 +83,7 @@ int Klepto::InitResources()
     _ZN7PathPtrC1Ev(path2);
     _ZN7PathPtr6FromIDEj(path2, mPathId);
     _ZNK7PathPtr7GetNodeER7Vector3j(path2, ((char *)this) + 0x430, unk_474);
-    unk_390 = 0x1000;
+    mBlendModelAnim.speed = 0x1000;
     mHeldActorID = 0;
 
     if (mCarriedItem == 1) {

--- a/src/_ZN6Klepto8BehaviorEv.cpp
+++ b/src/_ZN6Klepto8BehaviorEv.cpp
@@ -17,8 +17,6 @@ void *_ZN5Actor10FindWithIDEj(unsigned int id);
 void func_02012790(int a, int b);
 void func_ov062_0211c658(void *c, PMF *p);
 void _ZN9ActorBase18MarkForDestructionEv(void *self);
-void _ZN14BlendModelAnim7AdvanceEv(void *self);
-void func_ov062_0211b51c(void *self);
 void _ZN12CylinderClsn5ClearEv(CylinderClsn *self);
 void _ZN12CylinderClsn6UpdateEv(CylinderClsn *self);
 extern char data_ov062_0211e17c[];
@@ -92,7 +90,7 @@ int Klepto::Behavior()
         }
     }
 skip_destroy:
-    _ZN14BlendModelAnim7AdvanceEv((void *)((char *)&mBlendModelAnim));
+    mBlendModelAnim.Advance();
     if (*(void **)((char *)&unk_42c) != (void *)data_ov062_0211e14c) {
         func_ov062_0211b51c(((char *)this));
     }

--- a/src/_ZN7SkiLift8BehaviorEv.cpp
+++ b/src/_ZN7SkiLift8BehaviorEv.cpp
@@ -15,7 +15,7 @@ struct Sub { virtual void m0(); virtual void m1(); virtual void m2(); virtual vo
 int SkiLift::Behavior()
 {
   _ZN13RacingPenguin16OnPendingDestroyEv();
-  _ZN9Animation7AdvanceEv((char*)&mAnimation);
+  _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim);
   _ZN9Animation7AdvanceEv((char*)&mTextureSequence);
   _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
   _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);

--- a/src/_ZN7Tornado8BehaviorEv.cpp
+++ b/src/_ZN7Tornado8BehaviorEv.cpp
@@ -43,7 +43,7 @@ int Tornado::Behavior()
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
     Matrix4x3_FromTranslation(((char *)this) + 0x2e0, mPosX >> 3, mPosY >> 3, mPosZ >> 3);
-    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    _ZN9Animation7AdvanceEv((char *)(Animation *)&mModelAnim);
     _ZN9Animation7AdvanceEv((char *)&mTextureTransformer);
     return 1;
 }

--- a/src/_ZN8BookShot13InitResourcesEv.cpp
+++ b/src/_ZN8BookShot13InitResourcesEv.cpp
@@ -4,7 +4,8 @@
 /* recovered: named members + shared header, real C++ method */
 #include "BookShot.h"
 struct Actor; struct Vector3; struct Vector3_16; struct BMD_File;
-typedef struct { int w[2]; } SharedFilePtr;
+/* SharedFilePtr stays incomplete: Model.h forward-declares it and its layout is
+   deliberately not recovered (include/SharedFilePtr.h). Used only by address here. */
 
 extern "C" {
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* fp);
@@ -53,7 +54,7 @@ int BookShot::InitResources()
     unk_430 = mPosY;
     unk_434 = mPosZ;
 
-    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0x174, (struct BMD_File*)data_ov020_02114ab8.w[1], 1, -1) == 0)
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0x174, (struct BMD_File*)((int*)&data_ov020_02114ab8)[1], 1, -1) == 0)
         return 0;
 
     *(struct M48*)((char*)&unk_1ec) = data_02082128;

--- a/src/_ZN8CccArena13InitResourcesEv.cpp
+++ b/src/_ZN8CccArena13InitResourcesEv.cpp
@@ -1,9 +1,13 @@
 //cpp
 // @symbol _ZN8CccArena13InitResourcesEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
+/* The class header comes FIRST on purpose: it reaches math/Matrix.h, whose
+   Matrix4x3 is the structured one, and include/common.h's flat spelling stands
+   down behind the guard. mat4x3.t is only nameable this way round, and the two
+   spellings are the same 0x30 bytes. */
 #include "CccArena.h"
+/* recovered: declarations from a shared header */
+#include "decl_common.h"
 #include "MeshColliderBase.h"
 extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(int);
@@ -45,9 +49,9 @@ int CccArena::InitResources()
     f = _ZN5Model8LoadFileER13SharedFilePtr(*(int*)(data_ov073_021231bc + idx * 0xc));
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, f, 1, -1);
     Matrix4x3_FromRotationXYZExt(((char *)this) + 0xf0, mAngleX, mAngleY, mAngleZ);
-    unk_114 = mPosX >> 3;
-    unk_118 = mPosY >> 3;
-    unk_11c = mPosZ >> 3;
+    mModel.mat4x3.t.x = mPosX >> 3;
+    mModel.mat4x3.t.y = mPosY >> 3;
+    mModel.mat4x3.t.z = mPosZ >> 3;
     _ZN8Platform19UpdateClsnPosAndRotEv(((char *)this));
 
     {

--- a/src/_ZN8CccArena8BehaviorEv.cpp
+++ b/src/_ZN8CccArena8BehaviorEv.cpp
@@ -1,9 +1,13 @@
 //cpp
 // @symbol _ZN8CccArena8BehaviorEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
+/* The class header comes FIRST on purpose: it reaches math/Matrix.h, whose
+   Matrix4x3 is the structured one, and include/common.h's flat spelling stands
+   down behind the guard. mat4x3.t is only nameable this way round, and the two
+   spellings are the same 0x30 bytes. */
 #include "CccArena.h"
+/* recovered: declarations from a shared header */
+#include "decl_common.h"
 extern "C" {
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
 }
@@ -21,9 +25,9 @@ int CccArena::Behavior()
     ((void(*)(char*))fn)(self);
   }
   Matrix4x3_FromRotationXYZExt(((char*)this)+0xf0, mAngleX, mAngleY, mAngleZ);
-  unk_114 = mPosX >> 3;
-  unk_118 = mPosY >> 3;
-  unk_11c = mPosZ >> 3;
+  mModel.mat4x3.t.x = mPosX >> 3;
+  mModel.mat4x3.t.y = mPosY >> 3;
+  mModel.mat4x3.t.z = mPosZ >> 3;
   _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
   return 1;
 }

--- a/src/_ZN9HugeCover13InitResourcesEv.cpp
+++ b/src/_ZN9HugeCover13InitResourcesEv.cpp
@@ -5,8 +5,7 @@
 #include "MeshColliderBase.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct BTA_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block; struct Actor;
-struct Model { int d; };
-struct ModelBase { int d; };
+/* Model and ModelBase are the real classes now, through HugeCover.h. */
 struct TextureTransformer { int d; };
 struct MeshCollider { int d; };
 struct MovingMeshCollider { int d; };

--- a/src/_ZN9KoopaFlag13InitResourcesEv.cpp
+++ b/src/_ZN9KoopaFlag13InitResourcesEv.cpp
@@ -2,38 +2,27 @@
 // @symbol _ZN9KoopaFlag13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "KoopaFlag.h"
-typedef int Fix12;
 struct SharedFilePtr;
 struct BMD_File;
 struct BCA_File;
 struct Actor;
 
-struct Model {
-    static void* LoadFile(SharedFilePtr& f);
-};
-struct ModelBase {
-    void SetFile(BMD_File* f, int a, int b);
-};
-struct Animation {
-    static void* LoadFile(SharedFilePtr& f);
-};
-struct ModelAnim {
-    void SetAnim(BCA_File* f, int a, Fix12 b, unsigned int c);
-};
+/* Model / ModelBase / Animation / ModelAnim are the real classes now, through
+   this actor's header. */
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File* f, int a, Fix12 b, unsigned int c);
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File* f, int a, Fix12i b, unsigned int c);
 
 struct MovingCylinderClsn {
-    void Init(Actor* a, Fix12 b, Fix12 c, unsigned int d, unsigned int e);
+    void Init(Actor* a, Fix12i b, Fix12i c, unsigned int d, unsigned int e);
 };
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 b, Fix12 c, unsigned int d, unsigned int e);
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12i b, Fix12i c, unsigned int d, unsigned int e);
 
 
 extern SharedFilePtr data_ov062_0211e0d4;

--- a/src/_ZN9KoopaFlag8BehaviorEv.cpp
+++ b/src/_ZN9KoopaFlag8BehaviorEv.cpp
@@ -46,7 +46,7 @@ int KoopaFlag::Behavior()
         }
     }
 
-    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    _ZN9Animation7AdvanceEv((char *)(Animation *)&mModelAnim);
     func_ov062_0211afbc(((char *)this));
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);

--- a/src/_ZN9MontyMole13InitResourcesEv.cpp
+++ b/src/_ZN9MontyMole13InitResourcesEv.cpp
@@ -4,8 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MontyMole.h"
-typedef int Fix12;
-typedef struct { int w[2]; } SharedFilePtr;
+/* SharedFilePtr stays incomplete: Model.h forward-declares it and its layout is
+   deliberately not recovered (include/SharedFilePtr.h). Used only by address here. */
 typedef struct BMD_File BMD_File;
 typedef struct BCA_File BCA_File;
 typedef struct Actor Actor;
@@ -17,8 +17,8 @@ extern "C" {
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
-extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, BCA_File* f, int a, Fix12 b, unsigned int e);
-extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, BCA_File* f, int a, Fix12i b, unsigned int e);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
 }
 
 int MontyMole::InitResources()

--- a/src/_ZN9Submarine13InitResourcesEv.cpp
+++ b/src/_ZN9Submarine13InitResourcesEv.cpp
@@ -34,7 +34,7 @@ int Submarine::InitResources()
     _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(((char *)this) + 0x178, data_ov026_02112f40, 0, 0x1000, 0);
 
     unk_184 = 0x1000;
-    unk_170 = 0x1000;
+    mModelAnim.speed = 0x1000;
 
     unk_1a8 = mPosX;
     unk_1ac = mPosY;

--- a/src/_ZN9Submarine8BehaviorEv.cpp
+++ b/src/_ZN9Submarine8BehaviorEv.cpp
@@ -51,6 +51,6 @@ int Submarine::Behavior()
 
     func_ov026_02111f30(((char*)this));
     _ZN9Animation7AdvanceEv((char*)&mTextureTransformer);
-    _ZN9Animation7AdvanceEv((char*)&mAnimation);
+    _ZN9Animation7AdvanceEv((char*)(Animation *)&mModelAnim);
     return 1;
 }

--- a/src/_ZN9WaterBomb13InitResourcesEv.cpp
+++ b/src/_ZN9WaterBomb13InitResourcesEv.cpp
@@ -8,12 +8,11 @@ struct SharedFilePtr { int h; };
 struct Actor;
 struct Vector3_16;
 
-struct Model {
-    static BMD_File* LoadFile(SharedFilePtr& f);
-};
-struct ModelBase {
-    int SetFile(BMD_File* f, int a, int b);
-};
+/* ModelBase::SetFile is declared void in include/ModelBase.h -- which is what its
+   own matched definition compiles as -- but the ROM leaves DoSetFile's int in r0
+   and this call site reads it, so the value-returning entry keeps the mangled
+   spelling until that signature is settled. */
+extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, BMD_File *f, int a, int b);
 struct ShadowModel {
     int InitCylinder();
 };
@@ -73,15 +72,15 @@ int WaterBomb::InitResources()
 
     if (((Obj*)this)->f3c8 == 2)
     {
-        bmd = Model::LoadFile(data_ov002_0210da38);
-        if (((ModelBase*)&((Obj*)this)->f300)->SetFile(bmd, 1, 0x16) == 0)
+        bmd = (BMD_File*)Model::LoadFile(data_ov002_0210da38);
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(&((Obj*)this)->f300, bmd, 1, 0x16) == 0)
             return 0;
     }
     else
     {
         Model::LoadFile(data_ov002_0210da38);
-        bmd = Model::LoadFile(data_ov098_0213c91c);
-        if (((ModelBase*)&((Obj*)this)->f300)->SetFile(bmd, 1, 0x16) == 0)
+        bmd = (BMD_File*)Model::LoadFile(data_ov098_0213c91c);
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(&((Obj*)this)->f300, bmd, 1, 0x16) == 0)
             return 0;
     }
 

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -22,6 +22,17 @@ DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*(\**)\s*(\w+)\s*"
 # lines inside a struct body that are legitimately not declarations
 IGNORABLE = re.compile(r"^\s*($|/\*|\*|//|\}|#)")
 
+# Class sizes come from the tree's own compile-time assertions:
+#   typedef char ModelAnim_size_must_be_0x64[...]
+# Without these an embedded member is an unknown type, which this checker skips --
+# and skipping without advancing the offset makes every later field mismatch.
+CLASS_SIZES = {}
+for _h in pathlib.Path(__file__).resolve().parents[1].joinpath("include").glob("*.h"):
+    for _m in re.finditer(r"(\w+)_size_must_be_(0x[0-9a-fA-F]+)",
+                          _h.read_text(errors="replace")):
+        CLASS_SIZES[_m.group(1)] = int(_m.group(2), 16)
+SZ.update(CLASS_SIZES)
+
 rc = 0
 for path in sys.argv[1:]:
     txt = pathlib.Path(path).read_text(errors="replace")
@@ -58,8 +69,12 @@ for path in sys.argv[1:]:
             skipped.append(f"{lineno}: {line.strip()}")
             continue
         _, _, name, arr, decl = m.groups()
-        if off % w:                       # compiler would insert padding here
-            off += w - (off % w)
+        # Alignment is the strictest MEMBER alignment, never the type's size: a
+        # 100-byte ModelAnim aligns to 4, not to 100. Aligning to size padded 0xd4
+        # out to 0x12c and made every later field in the header mismatch.
+        align = min(w, 4)
+        if off % align:                   # compiler would insert padding here
+            off += align - (off % align)
         if decl is not None:
             n += 1
             if int(decl, 16) != off:

--- a/tools/evidence_history.py
+++ b/tools/evidence_history.py
@@ -891,6 +891,36 @@ def line_of(nl_positions, pos):
     return bisect.bisect_right(nl_positions, pos) + 1
 
 
+def mangled_param_count(sym):
+    """How many parameters the mangled name encodes, or None if it cannot be read.
+
+    `this` is never encoded for a non-static member function, so this is the number
+    the C definition must exceed by exactly one for the first parameter to BE `this`.
+    Shared with tools/static_symbols.py, which classifies the whole corpus.
+    """
+    try:
+        import demangle
+        sig = demangle.signature(sym)
+    except Exception:
+        return None
+    if not sig or "(" not in sig:
+        # Unreadable must be None, never 0: a 0 would make every zero-argument C
+        # definition look static and delete real evidence.
+        return None
+    a = sig[sig.rfind("(") + 1: sig.rfind(")")].strip()
+    if not a or a == "void":
+        return 0
+    depth, n = 0, 1
+    for ch in a:
+        if ch in "(<":
+            depth += 1
+        elif ch in ")>":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            n += 1
+    return n
+
+
 def extract_file(path, text, stem, cls, method, recall, headers=None):
     """Return {offset:int -> record} of evidence for the class this file defines."""
     code = strip_noncode(text)
@@ -936,6 +966,17 @@ def extract_file(path, text, stem, cls, method, recall, headers=None):
             # almost always a static member function (_ZN5Actor5SpawnEjj... takes
             # `unsigned int` first).  Attributing its offsets would invent fields.
             recall.reasons["file_first_param_not_pointer"] += 1
+            return None
+        # ...but that test cannot see a static whose first argument IS a pointer.
+        # `Stage::GraphCallback2(SceneRelated *)` sails through it, and then every
+        # access it makes is filed against Stage -- which is where the report's only
+        # width-contradiction came from. Ask arity instead, which is decidable: a
+        # non-static method's `this` is implicit and absent from the mangling, so the
+        # C definition carries exactly one parameter MORE than the symbol encodes.
+        # Equal counts mean the first parameter is a real argument, not `this`.
+        n_mangled = mangled_param_count(stem)
+        if n_mangled is not None and len(params) == n_mangled:
+            recall.reasons["file_static_by_arity"] += 1
             return None
         ty, stars, this_id = first
         bases = find_aliases(body, {this_id: (ty, stars)})

--- a/tools/test_gen_header.py
+++ b/tools/test_gen_header.py
@@ -225,6 +225,25 @@ def test_statics_are_classified_by_arity_not_by_mangling():
     assert SS.classify("_ZN5Stage14GraphCallback2EP12SceneRelated", "")[0].startswith("undecided")
 
 
+def test_history_and_statics_agree_on_arity():
+    """Both passes must decide staticness the same way, or one filters a function
+    the other keeps and the report contradicts itself. The pointer heuristic
+    evidence_history had cannot do it: Stage::GraphCallback2(SceneRelated *) has a
+    pointer first parameter and is still static."""
+    import demangle
+    import evidence_history as EH, static_symbols as SS
+    for sym in ("_ZN5Stage14GraphCallback2EP12SceneRelated",
+                "_ZN10BrickBlockD0Ev", "_ZN5Timer7GetTimeEv"):
+        sig = demangle.signature(sym)
+        assert sig, f"demangler regressed on {sym}"
+        assert EH.mangled_param_count(sym) == SS.n_params(sig), sym
+    assert EH.mangled_param_count("_ZN5Timer7GetTimeEv") == 0
+    assert EH.mangled_param_count("_ZN5Stage14GraphCallback2EP12SceneRelated") == 1
+    # an unreadable symbol must yield None, never 0 -- 0 would make every
+    # zero-argument C definition look static and delete real evidence
+    assert EH.mangled_param_count("not a mangled name") is None
+
+
 # ------------------------------------------------------- check_header_offsets
 
 def _check(tmp, text):


### PR DESCRIPTION
**These eight commits were stranded.** #1145 squash-merged as its first commit (the Timer `s64` merge) while these were pushed to the branch afterward, so none of them reached `main` — `Amp.mModelAnim` is still `u8` there, and the `Matrix4x3` guard is absent. Same thing happened to #1138; this is the recovery PR.

Nothing here is new work. It is reviewed, gated, and was reported as landed when it was not.

## What it does

Object markers are `u8 <name>;` + pad with span > 4 — an object of unknown type. The type comes from a **member-destructor relocation** in the class's own destructor:

```c
_ZN9ModelAnimD1Ev((char *)t + 0xd4);
```

That callee is a relocation the ROM build checks, so the type is ROM-backed rather than inferred from the placeholder name. **D1 and never D2** is the soundness argument: a true member calls T's complete-object destructor, while an inlined derived member would call the base's D2 at the same offset. All 455 exact calls behind these are D1.

| commit | what |
|---|---|
| `b929f529` | 8 markers, span == sizeof(T) |
| `f0e1cb74` | **`Matrix4x3` guard** — unblocked 57 more |
| `f7f06068` | 9 the local stand-ins were blocking |
| `84533528` | 7 the transform's own filter was silently skipping |
| `2db95819` | **32 absorbers** — span < sizeof(T), so the member swallows following declarations |
| `3aca5ad8` | 7 span-longer, with the excess left as explicit pad |
| `5f810d80` | 7 that are a 4-byte pointer, not an object |
| `9467eca7` | 2 trailing markers with no pad to consume |

## The `Matrix4x3` guard is the load-bearing one

`struct Matrix4x3` is defined **twice** and neither definition is wrong — flat (`s32 m[12]`) in `common.h`, structured (`Matrix3x3 r; Vector3 t`) in `math/Matrix.h`, both 0x30 bytes, both spellings in real use. There was simply no guard, so any TU reaching both failed. That blocked 66 headers.

`common.h` had already solved this once for `Vector3_16`, three lines below the bug, with the reasoning written out: whichever is seen first stands, the other stands down.

Reviewed by simulation over 11,086 TUs: **205 see both definitions**, and **no TU uses the spelling it didn't get**. The size asserts compile against whichever won, so a divergence would fail loudly.

## Verification (re-run independently, not taken on report)

```
module fidelity : 106/106 exact, ROM-build analysis PASS
eligible.py     : 10672  (+1, explained below), 0 files lost their match
attribution     : 0 changed, 0 lost
langmode ratchet: PASS
test_gen_header : 0 failures
offsets         : 0 mismatched, 0 unparsed on all bannered headers
```

The **+1** is `_ZN6Klepto8BehaviorEv.cpp`, which had been compile-failing on a duplicate `func_ov062_0211b51c` declaration disagreeing with `decl_common.h`. Verified by extracting the baseline tree and reproducing the original error.

Every affected TU byte-verified under its pinned compiler each round.

## Read the count correctly

**131 markers typed against the transform's worklist — not "the object markers are done."** A census reading the tree directly finds **1,096 bare object markers remaining, 515 of them decidable today** with this same D1 evidence across fourteen types. The worklist was scoped to three.

The cause is in `tools/gen_header.py`: it files a marker whose offset the evidence *names* as `confirmed`, so the best-evidenced markers fell off the worklist precisely because the evidence was good. `Goomba.mModelAnim @0x370` — the relocation `notes/plan-gen-header.md` §3 uses as its worked example — is still a bare `u8`.

That correction and the census tooling follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi