### PR TITLE
tools: an object marker is not confirmed by a one-byte observation

### DIFF
--- a/tools/gen_header.py
+++ b/tools/gen_header.py
@@ -326,6 +326,19 @@ def main():
                 findings[bucket].append({
                     "cls": cls, "offset": hex(off), "field": name, "declared": typ,
                     "observed": {k: sorted(v) for k, v in obs.items()}, "where": where})
+            elif placeholder and (span is None or span > 4):
+                # An object marker is NOT confirmed by a 1-byte observation. The `u8` is
+                # a stand-in for a type nobody knew, so a byte access at its offset
+                # satisfies the declaration without saying anything about what lives
+                # there -- and testing `dw in allw` first filed exactly those as
+                # `confirmed`, dropping them off the worklist. The markers with the BEST
+                # evidence went missing precisely because the evidence was good:
+                # Goomba.mModelAnim @0x370 sat here while its own destructor D1-called
+                # _ZN9ModelAnimD1Ev at that offset. See tools/marker_census.py.
+                bucket = "marker: object, extent unknown"
+                findings[bucket].append({
+                    "cls": cls, "offset": hex(off), "field": name, "span": span,
+                    "observed": {k: sorted(v) for k, v in obs.items()}, "where": where})
             elif dw in allw:
                 bucket = "confirmed"
                 # signedness: only a sub-word LOAD proves it, and only ldrs* proves signed


### PR DESCRIPTION
Step 2 of the correction, after #1153 committed the census. Tools only — **0 in-scope files**.

## The bug

`gen_header.py` tested `dw in allw` **before** it tested whether the field was a marker:

```python
elif dw in allw:          # <- ran first
    bucket = "confirmed"
elif placeholder:
    bucket = "marker: object, extent unknown"
```

An object marker is a bare `u8` standing in for a type nobody knew. So **any** byte access at its offset satisfies the declaration, and the field got filed as `confirmed` — off the worklist.

**The markers with the best evidence went missing precisely because the evidence was good.**

`Goomba.mModelAnim @0x370` sat in `confirmed` while `src/_ZN6GoombaD1Ev.c` D1-called `_ZN9ModelAnimD1Ev((char *)t + 0x370)` — the relocation `notes/plan-gen-header.md` §3 uses as its own worked example.

## Effect

```
confirmed  2170 -> 2045     (125 fields that were never confirmed)
```

That is how a worklist reported **131 of 180 complete** while the census, reading the tree instead of the bucket, finds **931 bare markers with 399 decidable** on identical D1 evidence — across **fourteen** types where the worklist had three.

## The two instruments still disagree, by design

`gen_header.py` buckets fields its three evidence passes observed. `marker_census.py` asks a different question: does a destructor name a sized type at this offset? They will not agree, and should not.

**The census is the operative worklist for the marker programme.** This fix stops `gen_header` actively *hiding* the work; it does not make it the planning instrument.

## Scope

No `src/`, `include/`, or `config/` changes. 16 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi