### PR TITLE
langmode_audit: emit the Phase 1 work list with --list layout-free

### DIFF
--- a/notes/plan-cpp-language-mode.md
+++ b/notes/plan-cpp-language-mode.md
@@ -127,8 +127,8 @@ gamed by renaming a `.c` to `.cpp` — a hand-spelled symbol counts however the 
 named. That property is the whole reason this phase came first: it makes the *easy* fake
 progress unrewarding, and it turns the reply to #821 into a number instead of an argument.
 
-Remaining, and the natural next commit: wire `--check` into CI, and re-bank the baseline
-in any commit that legitimately lowers a count.
+`--check` is wired into CI as `.github/workflows/langmode-ratchet.yml`. Re-bank the
+baseline in any commit that legitimately lowers a count.
 
 ### Phase 1 — SDK namespaces *(169 files, 37 namespaces) — zero layout risk*
 

--- a/tools/langmode_audit.py
+++ b/tools/langmode_audit.py
@@ -212,8 +212,9 @@ def audit():
                 excluded.append({"file": p, "by_value": sorted(set(byval))})
             else:
                 cls = info.get("class") or "<free>"
-                pc = per_class.setdefault(cls, {"c_left": 0, "kinds": {}})
+                pc = per_class.setdefault(cls, {"c_left": 0, "kinds": {}, "files": []})
                 pc["c_left"] += 1
+                pc["files"].append(p)
                 pc["kinds"][kind] = pc["kinds"].get(kind, 0) + 1
 
     # No include/<Class>.h AND no ctor/dtor => almost certainly an SDK *namespace*
@@ -349,7 +350,8 @@ def main():
                     help="with --json: include per-class detail and file lists")
     ap.add_argument("--by-class", action="store_true",
                     help="per-class backlog, worst first")
-    ap.add_argument("--list", metavar="WHICH", choices=["c-mangled", "cpp-handspelled", "excluded"],
+    ap.add_argument("--list", metavar="WHICH",
+                    choices=["c-mangled", "cpp-handspelled", "excluded", "layout-free"],
                     help="print a file list and nothing else")
     args = ap.parse_args()
 
@@ -363,6 +365,13 @@ def main():
         return 0
     if args.list == "excluded":
         print("\n".join(r["exclusions"]["files"]))
+        return 0
+    if args.list == "layout-free":
+        # The Phase 1 work list: namespaces with no header and no ctor/dtor, so a
+        # migration cannot shift anyone's offsets. Same predicate and the same files
+        # the headline "layout-free candidates" count is summed from.
+        print("\n".join(sorted(f for c in r["per_class"].values()
+                               if c["layout_free"] for f in c["files"])))
         return 0
 
     if args.json:


### PR DESCRIPTION
`notes/plan-cpp-language-mode.md` Phase 1 says to start with the layout-free namespaces and
warns "do not widen it by eye" — but the set was only ever reported as a **count**. `--full`
printed `layout-free candidates 132 across 34 namespaces` with no way to get the filenames
out, so the two Phase 1 branches so far picked their namespaces by hand.

The predicate already existed (`langmode_audit.py:227` — no `include/<Class>.h` and no
ctor/dtor, so no `this`, no vtable, no layout, and a migration cannot shift anyone's
offsets). `per_class` simply counted files without remembering them. This records the paths
alongside the count and exposes them as a fourth `--list` choice.

The append sits in the same branch as the `c_left` increment, so the list cannot silently
disagree with the headline — both are 132 today.

**Ratchet is unaffected:** plain `--json` output is byte-identical to the banked
`langmode-baseline.json`, `--check` still passes, and `--full` still serializes.

Also drops a stale line in the plan calling "wire `--check` into CI" the natural next commit —
`langmode-ratchet.yml` has run it as its second step for a while.