### PR TITLE
Re-land: 172 object markers and the typing handoff, stranded by #1156's squash merge

### DIFF
--- a/include/Amp.h
+++ b/include/Amp.h
@@ -7,6 +7,11 @@
 #include "types.h"
 #include "ModelAnim.h"
 #include "Model.h"
+#include "TextureSequence.h"
+#include "TextureTransformer.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct Amp {
     u8  pad_000[0x8];
@@ -33,16 +38,26 @@ struct Amp {
     /* Model member, named by _ZN5ModelD1Ev at +0x138 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x138 */
-    u8  mTextureSequence;            /* 0x188 */
-    u8  pad_189[0x13];
-    u8  mTextureTransformer;            /* 0x19c */
-    u8  pad_19d[0x13];
-    u8  mShadowModel;            /* 0x1b0 */
-    u8  pad_1b1[0x27];
-    u8  mMovingCylinderClsnWithPos;            /* 0x1d8 */
-    u8  pad_1d9[0x3f];
-    u8  mWithMeshClsn;            /* 0x218 */
-    u8  pad_219[0x1bb];
+    /* TextureSequence member, named by the class's own destructor calling
+       TextureSequence's D1 at +0x188 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3AmpD0Ev.c] */
+    TextureSequence mTextureSequence;            /* 0x188 */
+    /* TextureTransformer member, named by the class's own destructor calling
+       TextureTransformer's D1 at +0x19c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3AmpD0Ev.c] */
+    TextureTransformer mTextureTransformer;            /* 0x19c */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x1b0 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3AmpD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x1b0 */
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x1d8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3AmpD0Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x1d8 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x218 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3AmpD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x218 */
     u8  unk_3d4;            /* 0x3d4 */
     u8  pad_3d5[0x4b];
     s32 unk_420;            /* 0x420 */

--- a/include/ArrowLift.h
+++ b/include/ArrowLift.h
@@ -6,6 +6,7 @@
 #define ARROWLIFT_H
 #include "types.h"
 #include "Model.h"
+#include "MovingCylinderClsn.h"
 
 struct ArrowLift {
     u8  pad_000[0x8];
@@ -18,8 +19,10 @@ struct ArrowLift {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingCylinderClsn;            /* 0x124 */
-    u8  pad_125[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9ArrowLiftD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x124 */
     s32 unk_158;            /* 0x158 */
     s8  unk_15c;            /* 0x15c */
     u8  unk_15d;            /* 0x15d */

--- a/include/ArrowSignRight.h
+++ b/include/ArrowSignRight.h
@@ -6,6 +6,7 @@
 #define ARROWSIGNRIGHT_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
 
 struct ArrowSignRight {
     u8  pad_000[0xc];
@@ -18,8 +19,10 @@ struct ArrowSignRight {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mShadowModel;            /* 0x320 */
-    u8  pad_321[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x320 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN14ArrowSignRightD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x320 */
     u8  unk_348;            /* 0x348 */
     u8  pad_349[0x33];
     u8  unk_37c;            /* 0x37c */

--- a/include/BabyPenguin.h
+++ b/include/BabyPenguin.h
@@ -6,6 +6,9 @@
 #define BABYPENGUIN_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct BabyPenguin {
     u8  pad_000[0x5c];
@@ -24,12 +27,18 @@ struct BabyPenguin {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x138 */
-    u8  pad_139[0x27];
-    u8  mMovingCylinderClsn;            /* 0x160 */
-    u8  pad_161[0x33];
-    u8  mWithMeshClsn;            /* 0x194 */
-    u8  pad_195[0x1bb];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11BabyPenguinD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x138 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x160 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11BabyPenguinD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x160 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x194 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11BabyPenguinD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x194 */
     s32 unk_350;            /* 0x350 */
     s32 unk_354;            /* 0x354 */
     s32 unk_358;            /* 0x358 */

--- a/include/BigBrickBlock.h
+++ b/include/BigBrickBlock.h
@@ -5,6 +5,7 @@
 #ifndef BIGBRICKBLOCK_H
 #define BIGBRICKBLOCK_H
 #include "types.h"
+#include "Model.h"
 
 /* Actor is only ever pointed at from here, so a declaration is enough --
  * no definition is pulled in. The typedef keeps the member spelled the
@@ -19,8 +20,10 @@ struct BigBrickBlock {
     u8  pad_000[0xc];
     u16 mActorId;            /* 0x00c */
     u8  pad_00e[0xc6];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13BigBrickBlockD1Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1f9];
     u8  unk_31e;            /* 0x31e */

--- a/include/BigBully.h
+++ b/include/BigBully.h
@@ -6,6 +6,8 @@
 #define BIGBULLY_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "WithMeshClsn.h"
+#include "MovingCylinderClsn.h"
 
 struct BigBully {
     u8  pad_000[0x4];
@@ -26,12 +28,16 @@ struct BigBully {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x110 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x110 */
-    u8  mWithMeshClsn;            /* 0x174 */
-    u8  pad_175[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x174 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8BigBullyD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x174 */
     u8  unk_330;            /* 0x330 */
     u8  pad_331[0xb];
-    u8  mMovingCylinderClsn;            /* 0x33c */
-    u8  pad_33d[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x33c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8BigBullyD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x33c */
     u8  mShadowModel;            /* 0x370 */
     u8  pad_371[0x89];
     u16 mSecretSoundCounter;            /* 0x3fa */

--- a/include/Bird.h
+++ b/include/Bird.h
@@ -6,6 +6,7 @@
 #define BIRD_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "ShadowModel.h"
 
 struct Bird {
     u8  pad_000[0x4];
@@ -29,8 +30,10 @@ struct Bird {
        mAnimation (+0x50 = the Animation base), which the header declared separately inside
        it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x138 */
-    u8  pad_139[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN4BirdD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x138 */
     s32 unk_160;            /* 0x160 */
     s32 unk_164;            /* 0x164 */
     s32 unk_168;            /* 0x168 */

--- a/include/BobOmbBuddy.h
+++ b/include/BobOmbBuddy.h
@@ -6,6 +6,7 @@
 #define BOBOMBBUDDY_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsn.h"
 
 struct BobOmbBuddy {
     u8  pad_000[0x8];
@@ -39,8 +40,10 @@ struct BobOmbBuddy {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x4];
-    u8  mMovingCylinderClsn;            /* 0x0d4 */
-    u8  pad_0d5[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11BobOmbBuddyD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x0d4 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x108 -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the

--- a/include/BookShot.h
+++ b/include/BookShot.h
@@ -6,6 +6,9 @@
 #define BOOKSHOT_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "Model.h"
+#include "ShadowModel.h"
+#include "WithMeshClsn.h"
 
 struct BookShot {
     u8  pad_000[0xc];
@@ -40,10 +43,14 @@ struct BookShot {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x110 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x110 */
-    u8  mModel;            /* 0x174 */
-    u8  pad_175[0x4f];
-    u8  mShadowModel;            /* 0x1c4 */
-    u8  pad_1c5[0x27];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x174 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8BookShotD1Ev.c] */
+    Model mModel;            /* 0x174 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x1c4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8BookShotD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x1c4 */
     u8  unk_1ec;            /* 0x1ec */
     u8  pad_1ed[0x2f];
     u8  mMovingCylinderClsnWithPos;            /* 0x21c */
@@ -52,8 +59,10 @@ struct BookShot {
     u8  pad_235[0x3];
     u8  unk_238;            /* 0x238 */
     u8  pad_239[0x23];
-    u8  mWithMeshClsn;            /* 0x25c */
-    u8  pad_25d[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x25c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8BookShotD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x25c */
     s32 unk_418;            /* 0x418 */
     s32 unk_41c;            /* 0x41c */
     s32 unk_420;            /* 0x420 */

--- a/include/BowserFireSeaArena.h
+++ b/include/BowserFireSeaArena.h
@@ -11,8 +11,10 @@ struct BowserFireSeaArena {
     u8  pad_000[0x8e];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN18BowserFireSeaArenaD1Ev.c] */
+    Model mModel1;            /* 0x0d4 */
     u8  mMovingMeshCollider1;            /* 0x124 */
     u8  pad_125[0x1f9];
     s16 unk_31e;            /* 0x31e */

--- a/include/BowserPuzzleManager.h
+++ b/include/BowserPuzzleManager.h
@@ -6,6 +6,7 @@
 #define BOWSERPUZZLEMANAGER_H
 #include "types.h"
 #include "Model.h"
+#include "MovingMeshCollider.h"
 
 struct BowserPuzzleManager {
     u8  pad_000[0x8];
@@ -16,8 +17,10 @@ struct BowserPuzzleManager {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* MovingMeshCollider member, named by the class's own destructor calling
+       MovingMeshCollider's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN19BowserPuzzleManagerD1Ev.c] */
+    MovingMeshCollider mMovingMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x37];
     s32 unk_324;            /* 0x324 */

--- a/include/BowserShockwaves.h
+++ b/include/BowserShockwaves.h
@@ -6,6 +6,9 @@
 #define BOWSERSHOCKWAVES_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "TextureSequence.h"
+#include "MaterialChanger.h"
+#include "TextureTransformer.h"
 
 struct BowserShockwaves {
     u8  pad_000[0x5c];
@@ -19,24 +22,36 @@ struct BowserShockwaves {
        mAnimation1 (+0x50 = the Animation base), which the header declared separately
        inside it. */
     ModelAnim mModelAnim1;            /* 0x0d4 */
-    u8  mTextureSequence1;            /* 0x138 */
-    u8  pad_139[0x13];
-    u8  mMaterialChanger1;            /* 0x14c */
-    u8  pad_14d[0x13];
-    u8  mTextureTransformer1;            /* 0x160 */
-    u8  pad_161[0x13];
+    /* TextureSequence member, named by the class's own destructor calling
+       TextureSequence's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN16BowserShockwavesD1Ev.c] */
+    TextureSequence mTextureSequence1;            /* 0x138 */
+    /* MaterialChanger member, named by the class's own destructor calling
+       MaterialChanger's D1 at +0x14c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN16BowserShockwavesD1Ev.c] */
+    MaterialChanger mMaterialChanger1;            /* 0x14c */
+    /* TextureTransformer member, named by the class's own destructor calling
+       TextureTransformer's D1 at +0x160 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN16BowserShockwavesD1Ev.c] */
+    TextureTransformer mTextureTransformer1;            /* 0x160 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x174 -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        stopped short of the object, so the member also takes over unk_17c (+0x8 = data),
        mAnimation2 (+0x50 = the Animation base), which the header declared separately
        inside it. */
     ModelAnim mModelAnim2;            /* 0x174 */
-    u8  mTextureSequence2;            /* 0x1d8 */
-    u8  pad_1d9[0x13];
-    u8  mMaterialChanger2;            /* 0x1ec */
-    u8  pad_1ed[0x13];
-    u8  mTextureTransformer2;            /* 0x200 */
-    u8  pad_201[0x13];
+    /* TextureSequence member, named by the class's own destructor calling
+       TextureSequence's D1 at +0x1d8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN16BowserShockwavesD1Ev.c] */
+    TextureSequence mTextureSequence2;            /* 0x1d8 */
+    /* MaterialChanger member, named by the class's own destructor calling
+       MaterialChanger's D1 at +0x1ec -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN16BowserShockwavesD1Ev.c] */
+    MaterialChanger mMaterialChanger2;            /* 0x1ec */
+    /* TextureTransformer member, named by the class's own destructor calling
+       TextureTransformer's D1 at +0x200 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN16BowserShockwavesD1Ev.c] */
+    TextureTransformer mTextureTransformer2;            /* 0x200 */
     s16 unk_214;            /* 0x214 */
 #ifdef __cplusplus
     /* methods */

--- a/include/BowserSkyPlatform.h
+++ b/include/BowserSkyPlatform.h
@@ -5,6 +5,7 @@
 #ifndef BOWSERSKYPLATFORM_H
 #define BOWSERSKYPLATFORM_H
 #include "types.h"
+#include "Model.h"
 
 struct BowserSkyPlatform {
     u8  pad_000[0x5c];
@@ -16,8 +17,10 @@ struct BowserSkyPlatform {
     s32 mScaleY;            /* 0x084 */
     s32 mScaleZ;            /* 0x088 */
     u8  pad_08c[0x48];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN17BowserSkyPlatformD0Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingCylinderClsnWithPos;            /* 0x124 */
     u8  pad_125[0x4b];
     s32 unk_170;            /* 0x170 */

--- a/include/BowserTail.h
+++ b/include/BowserTail.h
@@ -5,6 +5,7 @@
 #ifndef BOWSERTAIL_H
 #define BOWSERTAIL_H
 #include "types.h"
+#include "MovingCylinderClsn.h"
 
 struct BowserTail {
     u8  pad_000[0x5c];
@@ -12,8 +13,10 @@ struct BowserTail {
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0x6c];
-    u8  mMovingCylinderClsn;            /* 0x0d4 */
-    u8  pad_0d5[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10BowserTailD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x0d4 */
     u32 unk_108;            /* 0x108 */
 #ifdef __cplusplus
     /* methods */

--- a/include/BulletBill.h
+++ b/include/BulletBill.h
@@ -6,6 +6,8 @@
 #define BULLETBILL_H
 #include "types.h"
 #include "Model.h"
+#include "WithMeshClsn.h"
+#include "ShadowModel.h"
 
 struct BulletBill {
     u8  pad_000[0x5c];
@@ -35,16 +37,20 @@ struct BulletBill {
     s32 unk_130;            /* 0x130 */
     u32 unk_134;            /* 0x134 */
     u8  pad_138[0x18];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10BulletBillD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     /* Model member, named by _ZN5ModelD1Ev at +0x30c -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel1;            /* 0x30c */
     /* Model member, named by _ZN5ModelD1Ev at +0x35c -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel2;            /* 0x35c */
-    u8  mShadowModel;            /* 0x3ac */
-    u8  pad_3ad[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x3ac -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10BulletBillD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x3ac */
     s32 mState;            /* 0x3d4 */
     s32 unk_3d8;            /* 0x3d8 */
 #ifdef __cplusplus

--- a/include/Bully.h
+++ b/include/Bully.h
@@ -6,6 +6,8 @@
 #define BULLY_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "WithMeshClsn.h"
+#include "MovingCylinderClsn.h"
 
 struct Bully {
     u8  pad_000[0x5c];
@@ -20,12 +22,16 @@ struct Bully {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x110 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x110 */
-    u8  mWithMeshClsn;            /* 0x174 */
-    u8  pad_175[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x174 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5BullyD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x174 */
     s32 mFileTable;            /* 0x330 */
     u8  pad_334[0x8];
-    u8  mMovingCylinderClsn;            /* 0x33c */
-    u8  pad_33d[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x33c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5BullyD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x33c */
     u8  mShadowModel;            /* 0x370 */
     u8  pad_371[0x8b];
     s32 unk_3fc;            /* 0x3fc */

--- a/include/Butterfly.h
+++ b/include/Butterfly.h
@@ -7,6 +7,8 @@
 #include "types.h"
 #include "ModelAnim.h"
 #include "Model.h"
+#include "ShadowModel.h"
+#include "WithMeshClsn.h"
 
 struct Butterfly {
     u8  pad_000[0x80];
@@ -36,12 +38,18 @@ struct Butterfly {
        short of the object, so the member also takes over unk_154 (+0x1c = mat4x3), which
        the header declared separately inside it. */
     Model mModel;            /* 0x138 */
-    u8  mShadowModel1;            /* 0x188 */
-    u8  pad_189[0x27];
-    u8  mShadowModel2;            /* 0x1b0 */
-    u8  pad_1b1[0x27];
-    u8  mWithMeshClsn;            /* 0x1d8 */
-    u8  pad_1d9[0x1bb];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x188 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9ButterflyD0Ev.c] */
+    ShadowModel mShadowModel1;            /* 0x188 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x1b0 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9ButterflyD0Ev.c] */
+    ShadowModel mShadowModel2;            /* 0x1b0 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1d8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9ButterflyD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1d8 */
     u8  mMovingCylinderClsnWithPos;            /* 0x394 */
     u8  pad_395[0x4b];
     s32 unk_3e0;            /* 0x3e0 */

--- a/include/Cannon.h
+++ b/include/Cannon.h
@@ -5,11 +5,14 @@
 #ifndef CANNON_H
 #define CANNON_H
 #include "types.h"
+#include "Model.h"
 
 struct Cannon {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6CannonD0Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingCylinderClsn;            /* 0x124 */
     u8  pad_125[0x5b];
     s32 unk_180;            /* 0x180 */

--- a/include/CannonHatch.h
+++ b/include/CannonHatch.h
@@ -6,6 +6,7 @@
 #define CANNONHATCH_H
 #include "types.h"
 #include "Model.h"
+#include "MovingMeshCollider.h"
 
 struct CannonHatch {
     u8  pad_000[0x8];
@@ -32,8 +33,10 @@ struct CannonHatch {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* MovingMeshCollider member, named by the class's own destructor calling
+       MovingMeshCollider's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11CannonHatchD1Ev.c] */
+    MovingMeshCollider mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
     s32 unk_320;            /* 0x320 */

--- a/include/CheepCheep.h
+++ b/include/CheepCheep.h
@@ -5,6 +5,8 @@
 #ifndef CHEEPCHEEP_H
 #define CHEEPCHEEP_H
 #include "types.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct CheepCheep {
     u8  pad_000[0x5c];
@@ -18,10 +20,14 @@ struct CheepCheep {
     u8  pad_096[0x1a];
     u32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x5c];
-    u8  mMovingCylinderClsnWithPos;            /* 0x110 */
-    u8  pad_111[0x3f];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10CheepCheepD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10CheepCheepD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     u8  mModelAnim;            /* 0x30c */
     u8  pad_30d[0x67];
     s32 unk_374;            /* 0x374 */

--- a/include/Coin.h
+++ b/include/Coin.h
@@ -5,6 +5,10 @@
 #ifndef COIN_H
 #define COIN_H
 #include "types.h"
+#include "CommonModel.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct Coin {
     u8  pad_000[0x8];
@@ -45,16 +49,26 @@ struct Coin {
     u8  pad_0cd[0x3];
     s32 mEatingPlayer;            /* 0x0d0 */
     s32 unk_0d4;            /* 0x0d4 */
-    u8  mCommonModel1;            /* 0x0d8 */
-    u8  pad_0d9[0x3b];
-    u8  mCommonModel2;            /* 0x114 */
-    u8  pad_115[0x3b];
-    u8  mShadowModel;            /* 0x150 */
-    u8  pad_151[0x27];
-    u8  mCylinderClsn;            /* 0x178 */
-    u8  pad_179[0x33];
-    u8  mWithMeshClsn;            /* 0x1ac */
-    u8  pad_1ad[0x1bb];
+    /* CommonModel member, named by the class's own destructor calling
+       CommonModel's D1 at +0x0d8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
+    CommonModel mCommonModel1;            /* 0x0d8 */
+    /* CommonModel member, named by the class's own destructor calling
+       CommonModel's D1 at +0x114 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
+    CommonModel mCommonModel2;            /* 0x114 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x150 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x178 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
+    MovingCylinderClsn mCylinderClsn;            /* 0x178 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1ac -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1ac */
     u8  unk_368;            /* 0x368 */
     u8  pad_369[0x2f];
     s32 unk_398;            /* 0x398 */

--- a/include/CrazedCrate.h
+++ b/include/CrazedCrate.h
@@ -5,6 +5,9 @@
 #ifndef CRAZEDCRATE_H
 #define CRAZEDCRATE_H
 #include "types.h"
+#include "Model.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
 
 struct CrazedCrate {
     u8  pad_000[0x5c];
@@ -21,12 +24,18 @@ struct CrazedCrate {
     u8  pad_0a4[0xc];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mShadowModel;            /* 0x124 */
-    u8  pad_125[0x27];
-    u8  mMovingCylinderClsn;            /* 0x14c */
-    u8  pad_14d[0x33];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11CrazedCrateD0Ev.c] */
+    Model mModel;            /* 0x0d4 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11CrazedCrateD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x124 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x14c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11CrazedCrateD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x14c */
     u8  mWithMeshClsn;            /* 0x180 */
     u8  pad_181[0x1f3];
     s32 unk_374;            /* 0x374 */

--- a/include/Dorrie.h
+++ b/include/Dorrie.h
@@ -6,6 +6,9 @@
 #define DORRIE_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "WithMeshClsn.h"
+#include "MovingCylinderClsn.h"
+#include "MovingCylinderClsnWithPos.h"
 
 struct Dorrie {
     u8  pad_000[0x8];
@@ -35,12 +38,18 @@ struct Dorrie {
        accounted for even though nothing names the element type. */
     ModelAnim mModelAnim;            /* 0x0ec */
     u8  pad_150[0xe00];
-    u8  mWithMeshClsn;            /* 0xf50 */
-    u8  pad_f51[0x1bb];
-    u8  unk_110c;           /* 0x110c */
-    u8  pad_110d[0x33];
-    u8  unk_1140;           /* 0x1140 */
-    u8  pad_1141[0x3f];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0xf50 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6DorrieD1Ev.cpp] */
+    WithMeshClsn mWithMeshClsn;            /* 0xf50 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x110c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6DorrieD1Ev.cpp] */
+    MovingCylinderClsn unk_110c;           /* 0x110c */
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x1140 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6DorrieD1Ev.cpp] */
+    MovingCylinderClsnWithPos unk_1140;           /* 0x1140 */
     s32 unk_1180;           /* 0x1180 */
     s32 unk_1184;           /* 0x1184 */
     s32 unk_1188;           /* 0x1188 */

--- a/include/DorrieCap.h
+++ b/include/DorrieCap.h
@@ -5,6 +5,8 @@
 #ifndef DORRIECAP_H
 #define DORRIECAP_H
 #include "types.h"
+#include "Model.h"
+#include "MovingCylinderClsn.h"
 
 struct DorrieCap {
     u8  pad_000[0x5c];
@@ -23,10 +25,14 @@ struct DorrieCap {
     u8  unk_0d4;            /* 0x0d4 */
     u8  pad_0d5[0x1a];
     u8  unk_0ef;            /* 0x0ef */
-    u8  mModel;            /* 0x0f0 */
-    u8  pad_0f1[0x4f];
-    u8  mMovingCylinderClsn;            /* 0x140 */
-    u8  pad_141[0x33];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0f0 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9DorrieCapD1Ev.c] */
+    Model mModel;            /* 0x0f0 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x140 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9DorrieCapD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x140 */
     s32 unk_174;            /* 0x174 */
 #ifdef __cplusplus
     /* methods */

--- a/include/FallBlockBbh.h
+++ b/include/FallBlockBbh.h
@@ -5,11 +5,14 @@
 #ifndef FALLBLOCKBBH_H
 #define FALLBLOCKBBH_H
 #include "types.h"
+#include "Model.h"
 
 struct FallBlockBbh {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12FallBlockBbhD1Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/FallBlockLll.h
+++ b/include/FallBlockLll.h
@@ -5,11 +5,14 @@
 #ifndef FALLBLOCKLLL_H
 #define FALLBLOCKLLL_H
 #include "types.h"
+#include "Model.h"
 
 struct FallBlockLll {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12FallBlockLllD1Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/FireSeaElevator.h
+++ b/include/FireSeaElevator.h
@@ -6,6 +6,7 @@
 #define FIRESEAELEVATOR_H
 #include "types.h"
 #include "Model.h"
+#include "MovingCylinderClsn.h"
 
 struct FireSeaElevator {
     u8  pad_000[0x8];
@@ -18,8 +19,10 @@ struct FireSeaElevator {
     Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mMovingCylinderClsn;            /* 0x320 */
-    u8  pad_321[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x320 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN15FireSeaElevatorD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x320 */
     u16 unk_354;            /* 0x354 */
 #ifdef __cplusplus
     /* methods */

--- a/include/Fireball.h
+++ b/include/Fireball.h
@@ -5,6 +5,7 @@
 #ifndef FIREBALL_H
 #define FIREBALL_H
 #include "types.h"
+#include "WithMeshClsn.h"
 
 struct Fireball {
     u8  pad_000[0x8];
@@ -16,8 +17,10 @@ struct Fireball {
     u8  pad_111[0x1b];
     u8  unk_12c;            /* 0x12c */
     u8  pad_12d[0x17];
-    u8  mWithMeshClsn;            /* 0x144 */
-    u8  pad_145[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8FireballD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x144 */
     u8  mShadowModel;            /* 0x300 */
     u8  pad_301[0x5f];
     s32 unk_360;            /* 0x360 */

--- a/include/FlameChomp.h
+++ b/include/FlameChomp.h
@@ -6,6 +6,9 @@
 #define FLAMECHOMP_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct FlameChomp {
     u8  pad_000[0x5c];
@@ -23,12 +26,18 @@ struct FlameChomp {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x138 */
-    u8  pad_139[0x27];
-    u8  mMovingCylinderClsnWithPos;            /* 0x160 */
-    u8  pad_161[0x3f];
-    u8  mWithMeshClsn;            /* 0x1a0 */
-    u8  pad_1a1[0x1bb];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10FlameChompD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x138 */
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x160 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10FlameChompD0Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x160 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1a0 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10FlameChompD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1a0 */
     u8  unk_35c;            /* 0x35c */
     u8  pad_35d[0x4b];
     s32 unk_3a8;            /* 0x3a8 */

--- a/include/FlameChompFire.h
+++ b/include/FlameChompFire.h
@@ -5,6 +5,9 @@
 #ifndef FLAMECHOMPFIRE_H
 #define FLAMECHOMPFIRE_H
 #include "types.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct FlameChompFire {
     u8  pad_000[0x5c];
@@ -21,12 +24,18 @@ struct FlameChompFire {
     u8  pad_0a4[0xc];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mShadowModel;            /* 0x0d4 */
-    u8  pad_0d5[0x27];
-    u8  mMovingCylinderClsn;            /* 0x0fc */
-    u8  pad_0fd[0x33];
-    u8  mWithMeshClsn;            /* 0x130 */
-    u8  pad_131[0x1bb];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN14FlameChompFireD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x0d4 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x0fc -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN14FlameChompFireD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x0fc */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x130 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN14FlameChompFireD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x130 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x37];
     s32 unk_324;            /* 0x324 */

--- a/include/FloatOnWaterPlatformJrb.h
+++ b/include/FloatOnWaterPlatformJrb.h
@@ -6,6 +6,7 @@
 #define FLOATONWATERPLATFORMJRB_H
 #include "types.h"
 #include "Model.h"
+#include "WithMeshClsn.h"
 
 struct FloatOnWaterPlatformJrb {
     u8  pad_000[0x5c];
@@ -32,8 +33,10 @@ struct FloatOnWaterPlatformJrb {
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */
-    u8  mWithMeshClsn;            /* 0x324 */
-    u8  pad_325[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x324 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN23FloatOnWaterPlatformJrbD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x324 */
     s32 unk_4e0;            /* 0x4e0 */
     s32 unk_4e4;            /* 0x4e4 */
     s32 unk_4e8;            /* 0x4e8 */

--- a/include/HauntedChair.h
+++ b/include/HauntedChair.h
@@ -6,6 +6,9 @@
 #define HAUNTEDCHAIR_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct HauntedChair {
     u8  pad_000[0x5c];
@@ -16,14 +19,20 @@ struct HauntedChair {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x124 */
-    u8  pad_125[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12HauntedChairD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x124 */
     u8  unk_14c;            /* 0x14c */
     u8  pad_14d[0x2f];
-    u8  mMovingCylinderClsnWithPos;            /* 0x17c */
-    u8  pad_17d[0x3f];
-    u8  mWithMeshClsn;            /* 0x1bc */
-    u8  pad_1bd[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x17c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12HauntedChairD0Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x17c */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1bc -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12HauntedChairD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1bc */
     s32 unk_378;            /* 0x378 */
     u8  pad_37c[0x4];
     s32 unk_380;            /* 0x380 */

--- a/include/HeaveHo.h
+++ b/include/HeaveHo.h
@@ -5,6 +5,9 @@
 #ifndef HEAVEHO_H
 #define HEAVEHO_H
 #include "types.h"
+#include "MovingCylinderClsn.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct HeaveHo {
     u8  pad_000[0x5c];
@@ -21,12 +24,18 @@ struct HeaveHo {
     u8  pad_0a4[0x5c];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  mMovingCylinderClsn;            /* 0x110 */
-    u8  pad_111[0x33];
-    u8  mMovingCylinderClsnWithPos;            /* 0x144 */
-    u8  pad_145[0x3f];
-    u8  mWithMeshClsn;            /* 0x184 */
-    u8  pad_185[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7HeaveHoD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x110 */
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7HeaveHoD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x144 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x184 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7HeaveHoD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x184 */
     u8  mModelAnim;            /* 0x340 */
     u8  pad_341[0x4f];
     u8  mAnimation;            /* 0x390 */

--- a/include/HootTheOwl.h
+++ b/include/HootTheOwl.h
@@ -5,6 +5,7 @@
 #ifndef HOOTTHEOWL_H
 #define HOOTTHEOWL_H
 #include "types.h"
+#include "WithMeshClsn.h"
 
 struct HootTheOwl {
     u8  pad_000[0x8c];
@@ -27,8 +28,10 @@ struct HootTheOwl {
     u8  pad_111[0x17];
     u8  unk_128;            /* 0x128 */
     u8  pad_129[0x27];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10HootTheOwlD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     u8  mModelAnim;            /* 0x30c */
     u8  pad_30d[0x4f];
     u8  mAnimation;            /* 0x35c */

--- a/include/IceBlock.h
+++ b/include/IceBlock.h
@@ -5,6 +5,7 @@
 #ifndef ICEBLOCK_H
 #define ICEBLOCK_H
 #include "types.h"
+#include "Model.h"
 
 struct IceBlock {
     u8  pad_000[0x5c];
@@ -14,8 +15,10 @@ struct IceBlock {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8IceBlockD1Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     u8  mMovingCylinderClsn;            /* 0x320 */

--- a/include/Key.h
+++ b/include/Key.h
@@ -5,6 +5,9 @@
 #ifndef KEY_H
 #define KEY_H
 #include "types.h"
+#include "Model.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct Key {
     u8  pad_000[0x8];
@@ -41,14 +44,20 @@ struct Key {
     u8  mAnimation;            /* 0x164 */
     u8  pad_165[0xf];
     s32 unk_174;            /* 0x174 */
-    u8  mModel;            /* 0x178 */
-    u8  pad_179[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x178 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3KeyD1Ev.c] */
+    Model mModel;            /* 0x178 */
     u8  mShadowModel;            /* 0x1c8 */
     u8  pad_1c9[0x57];
-    u8  mMovingCylinderClsnWithPos;            /* 0x220 */
-    u8  pad_221[0x3f];
-    u8  mWithMeshClsn;            /* 0x260 */
-    u8  pad_261[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x220 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3KeyD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x220 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x260 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN3KeyD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x260 */
     s32 unk_41c;            /* 0x41c */
     s32 unk_420;            /* 0x420 */
     s32 unk_424;            /* 0x424 */

--- a/include/KingBobOmb.h
+++ b/include/KingBobOmb.h
@@ -6,6 +6,9 @@
 #define KINGBOBOMB_H
 #include "types.h"
 #include "BlendModelAnim.h"
+#include "WithMeshClsn.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "CommonModel.h"
 
 struct KingBobOmb {
     u8  pad_000[0x8];
@@ -33,17 +36,25 @@ struct KingBobOmb {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x40];
-    u8  mWithMeshClsn;            /* 0x110 */
-    u8  pad_111[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10KingBobOmbD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x110 */
     /* BlendModelAnim member, named by _ZN14BlendModelAnimD1Ev at +0x2cc -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     BlendModelAnim mBlendModelAnim;            /* 0x2cc */
-    u8  mMovingCylinderClsnWithPos1;            /* 0x33c */
-    u8  pad_33d[0x3f];
-    u8  mMovingCylinderClsnWithPos2;            /* 0x37c */
-    u8  pad_37d[0x3f];
-    u8  mCommonModel;            /* 0x3bc */
-    u8  pad_3bd[0x3b];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x33c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10KingBobOmbD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos1;            /* 0x33c */
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x37c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10KingBobOmbD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos2;            /* 0x37c */
+    /* CommonModel member, named by the class's own destructor calling
+       CommonModel's D1 at +0x3bc -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10KingBobOmbD1Ev.c] */
+    CommonModel mCommonModel;            /* 0x3bc */
     u8  mShadowModel;            /* 0x3f8 */
     u8  pad_3f9[0x9b];
     s32 unk_494;            /* 0x494 */

--- a/include/Klepto.h
+++ b/include/Klepto.h
@@ -6,6 +6,8 @@
 #define KLEPTO_H
 #include "types.h"
 #include "BlendModelAnim.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct Klepto {
     u8  pad_000[0x8];
@@ -33,12 +35,18 @@ struct Klepto {
     u8  pad_0cd[0x33];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  mMovingCylinderClsn1;            /* 0x110 */
-    u8  pad_111[0x33];
-    u8  mMovingCylinderClsn2;            /* 0x144 */
-    u8  pad_145[0x33];
-    u8  mWithMeshClsn;            /* 0x178 */
-    u8  pad_179[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6KleptoD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn1;            /* 0x110 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6KleptoD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn2;            /* 0x144 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x178 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6KleptoD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x178 */
     /* BlendModelAnim member, named by _ZN14BlendModelAnimD1Ev at +0x334 -- a relocation
        the ROM build checks. D1 and not D2, so it is this type and not an inlined base. The
        marker's pad stopped short of the object, so the member also takes over unk_390

--- a/include/KoopaTheQuick.h
+++ b/include/KoopaTheQuick.h
@@ -6,6 +6,9 @@
 #define KOOPATHEQUICK_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
+#include "ShadowModel.h"
 
 struct KoopaTheQuick {
     u8  pad_000[0x8];
@@ -67,17 +70,23 @@ struct KoopaTheQuick {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x40];
-    u8  mMovingCylinderClsn;            /* 0x110 */
-    u8  pad_111[0x33];
-    u8  mWithMeshClsn;            /* 0x144 */
-    u8  pad_145[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13KoopaTheQuickD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13KoopaTheQuickD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x144 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x300 -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        stopped short of the object, so the member also takes over unk_350 (+0x50 = the
        Animation base), which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x300 */
-    u8  mShadowModel;            /* 0x364 */
-    u8  pad_365[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x364 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13KoopaTheQuickD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x364 */
     s32 unk_38c;            /* 0x38c */
     u8  pad_390[0x4];
     s32 unk_394;            /* 0x394 */

--- a/include/LavaBubble.h
+++ b/include/LavaBubble.h
@@ -5,6 +5,7 @@
 #ifndef LAVABUBBLE_H
 #define LAVABUBBLE_H
 #include "types.h"
+#include "WithMeshClsn.h"
 
 struct LavaBubble {
     u8  pad_000[0x8];
@@ -28,8 +29,10 @@ struct LavaBubble {
     s32 unk_130;            /* 0x130 */
     u32 unk_134;            /* 0x134 */
     u8  pad_138[0xc];
-    u8  mWithMeshClsn;            /* 0x144 */
-    u8  pad_145[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10LavaBubbleD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x144 */
     s32 unk_300;            /* 0x300 */
     s32 unk_304;            /* 0x304 */
     s32 unk_308;            /* 0x308 */

--- a/include/MetalNet.h
+++ b/include/MetalNet.h
@@ -6,6 +6,7 @@
 #define METALNET_H
 #include "types.h"
 #include "Model.h"
+#include "MovingMeshCollider.h"
 
 struct MetalNet {
     u8  pad_000[0x8];
@@ -16,8 +17,10 @@ struct MetalNet {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* MovingMeshCollider member, named by the class's own destructor calling
+       MovingMeshCollider's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8MetalNetD1Ev.c] */
+    MovingMeshCollider mMovingMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
 #ifdef __cplusplus
     /* methods */

--- a/include/Moneybag.h
+++ b/include/Moneybag.h
@@ -5,6 +5,11 @@
 #ifndef MONEYBAG_H
 #define MONEYBAG_H
 #include "types.h"
+#include "ModelAnim.h"
+#include "Model.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct Moneybag {
     u8  pad_000[0x5c];
@@ -21,16 +26,26 @@ struct Moneybag {
     u8  pad_0a4[0xc];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x63];
-    u8  mModel;            /* 0x138 */
-    u8  pad_139[0x4f];
-    u8  mShadowModel;            /* 0x188 */
-    u8  pad_189[0x27];
-    u8  mMovingCylinderClsn;            /* 0x1b0 */
-    u8  pad_1b1[0x33];
-    u8  mWithMeshClsn;            /* 0x1e4 */
-    u8  pad_1e5[0x1bb];
+    /* ModelAnim member, named by the class's own destructor calling
+       ModelAnim's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8MoneybagD0Ev.c] */
+    ModelAnim mModelAnim;            /* 0x0d4 */
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8MoneybagD0Ev.c] */
+    Model mModel;            /* 0x138 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x188 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8MoneybagD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x188 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x1b0 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8MoneybagD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x1b0 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1e4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8MoneybagD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1e4 */
     u8  unk_3a0;            /* 0x3a0 */
     u8  pad_3a1[0x2f];
     s32 unk_3d0;            /* 0x3d0 */

--- a/include/MontyMole.h
+++ b/include/MontyMole.h
@@ -6,6 +6,7 @@
 #define MONTYMOLE_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsn.h"
 
 struct MontyMole {
     u8  pad_000[0x8];
@@ -14,8 +15,10 @@ struct MontyMole {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mMovingCylinderClsn;            /* 0x138 */
-    u8  pad_139[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9MontyMoleD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x138 */
     u8  unk_16c;            /* 0x16c */
     u8  pad_16d[0xf];
     s32 unk_17c;            /* 0x17c */

--- a/include/MontyMoleRock.h
+++ b/include/MontyMoleRock.h
@@ -6,6 +6,8 @@
 #define MONTYMOLEROCK_H
 #include "types.h"
 #include "Model.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct MontyMoleRock {
     u8  pad_000[0x8];
@@ -21,10 +23,14 @@ struct MontyMoleRock {
     /* Model member, named by _ZN5ModelD1Ev at +0x110 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x110 */
-    u8  mMovingCylinderClsn;            /* 0x160 */
-    u8  pad_161[0x33];
-    u8  mWithMeshClsn;            /* 0x194 */
-    u8  pad_195[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x160 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13MontyMoleRockD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x160 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x194 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13MontyMoleRockD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x194 */
     u8  unk_350;            /* 0x350 */
 #ifdef __cplusplus
     /* methods */

--- a/include/MrBlizzard.h
+++ b/include/MrBlizzard.h
@@ -5,6 +5,9 @@
 #ifndef MRBLIZZARD_H
 #define MRBLIZZARD_H
 #include "types.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
+#include "ModelAnim.h"
 
 struct MrBlizzard {
     u8  pad_000[0x8];
@@ -33,12 +36,18 @@ struct MrBlizzard {
     u8  pad_109[0x1];
     u8  unk_10a;            /* 0x10a */
     u8  pad_10b[0x5];
-    u8  mMovingCylinderClsnWithPos;            /* 0x110 */
-    u8  pad_111[0x3f];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
-    u8  mModelAnim;            /* 0x30c */
-    u8  pad_30d[0x63];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10MrBlizzardD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10MrBlizzardD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
+    /* ModelAnim member, named by the class's own destructor calling
+       ModelAnim's D1 at +0x30c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10MrBlizzardD1Ev.c] */
+    ModelAnim mModelAnim;            /* 0x30c */
     u8  mShadowModel;            /* 0x370 */
     u8  pad_371[0x8b];
     s32 unk_3fc;            /* 0x3fc */

--- a/include/OneUpLogo.h
+++ b/include/OneUpLogo.h
@@ -5,6 +5,7 @@
 #ifndef ONEUPLOGO_H
 #define ONEUPLOGO_H
 #include "types.h"
+#include "TextureSequence.h"
 
 struct OneUpLogo {
     u8  pad_000[0x8];
@@ -23,8 +24,10 @@ struct OneUpLogo {
     u8  pad_0d5[0x1b];
     u8  unk_0f0;            /* 0x0f0 */
     u8  pad_0f1[0x33];
-    u8  mTextureSequence;            /* 0x124 */
-    u8  pad_125[0x13];
+    /* TextureSequence member, named by the class's own destructor calling
+       TextureSequence's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9OneUpLogoD0Ev.c] */
+    TextureSequence mTextureSequence;            /* 0x124 */
     s32 unk_138;            /* 0x138 */
     s32 unk_13c;            /* 0x13c */
     s32 unk_140;            /* 0x140 */

--- a/include/PiranhaPlant.h
+++ b/include/PiranhaPlant.h
@@ -5,6 +5,10 @@
 #ifndef PIRANHAPLANT_H
 #define PIRANHAPLANT_H
 #include "types.h"
+#include "Model.h"
+#include "WithMeshClsn.h"
+#include "MovingCylinderClsn.h"
+#include "MovingCylinderClsnWithPos.h"
 
 struct PiranhaPlant {
     u8  pad_000[0x5c];
@@ -42,16 +46,26 @@ struct PiranhaPlant {
     u8  mAnimation;            /* 0x160 */
     u8  pad_161[0xf];
     s32 unk_170;            /* 0x170 */
-    u8  mModel;            /* 0x174 */
-    u8  pad_175[0x4f];
-    u8  mWithMeshClsn;            /* 0x1c4 */
-    u8  pad_1c5[0x1bb];
-    u8  mMovingCylinderClsn1;            /* 0x380 */
-    u8  pad_381[0x33];
-    u8  mMovingCylinderClsn2;            /* 0x3b4 */
-    u8  pad_3b5[0x33];
-    u8  mMovingCylinderClsnWithPos;            /* 0x3e8 */
-    u8  pad_3e9[0x3f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x174 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12PiranhaPlantD1Ev.c] */
+    Model mModel;            /* 0x174 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1c4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12PiranhaPlantD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1c4 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x380 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12PiranhaPlantD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn1;            /* 0x380 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x3b4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12PiranhaPlantD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn2;            /* 0x3b4 */
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x3e8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12PiranhaPlantD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x3e8 */
     u8  unk_428;            /* 0x428 */
     u8  pad_429[0xb];
     s32 unk_434;            /* 0x434 */

--- a/include/Pokey.h
+++ b/include/Pokey.h
@@ -6,6 +6,9 @@
 #define POKEY_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct Pokey {
     u8  pad_000[0x8];
@@ -27,12 +30,18 @@ struct Pokey {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x124 */
-    u8  pad_125[0x27];
-    u8  mMovingCylinderClsn;            /* 0x14c */
-    u8  pad_14d[0x33];
-    u8  mWithMeshClsn;            /* 0x180 */
-    u8  pad_181[0x1bb];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5PokeyD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x124 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x14c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5PokeyD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x14c */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x180 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5PokeyD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x180 */
     u8  unk_33c;            /* 0x33c */
     u8  pad_33d[0x2f];
     s32 unk_36c;            /* 0x36c */

--- a/include/PowerStar.h
+++ b/include/PowerStar.h
@@ -6,6 +6,8 @@
 #define POWERSTAR_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct PowerStar {
     u8  pad_000[0xc];
@@ -15,10 +17,14 @@ struct PowerStar {
     u8  pad_0b4[0x1c];
     s32 mEatingPlayer;            /* 0x0d0 */
     u8  pad_0d4[0x3c];
-    u8  mCylinderClsn;            /* 0x110 */
-    u8  pad_111[0x3f];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9PowerStarD1Ev.c] */
+    MovingCylinderClsnWithPos mCylinderClsn;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9PowerStarD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim1;            /* 0x30c */

--- a/include/PushBlock.h
+++ b/include/PushBlock.h
@@ -6,6 +6,8 @@
 #define PUSHBLOCK_H
 #include "types.h"
 #include "Model.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct PushBlock {
     u8  pad_000[0x8];
@@ -35,14 +37,20 @@ struct PushBlock {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel1;            /* 0x0d4 */
-    u8  mModel2;            /* 0x124 */
-    u8  pad_125[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9PushBlockD0Ev.c] */
+    Model mModel2;            /* 0x124 */
     u8  mShadowModel;            /* 0x174 */
     u8  pad_175[0x57];
-    u8  mMovingCylinderClsn;            /* 0x1cc */
-    u8  pad_1cd[0x33];
-    u8  mWithMeshClsn;            /* 0x200 */
-    u8  pad_201[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x1cc -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9PushBlockD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x1cc */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x200 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9PushBlockD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x200 */
     s32 unk_3bc;            /* 0x3bc */
     s32 unk_3c0;            /* 0x3c0 */
     u8  pad_3c4[0x6];

--- a/include/PyramidStep.h
+++ b/include/PyramidStep.h
@@ -15,8 +15,10 @@ struct PyramidStep {
     u8  pad_090[0x18];
     s32 unk_0a8;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11PyramidStepD1Ev.c] */
+    Model mModel1;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.

--- a/include/PyramidTop.h
+++ b/include/PyramidTop.h
@@ -24,8 +24,10 @@ struct PyramidTop {
     s16 mAngleX;                 /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10PyramidTopD1Ev.c] */
+    Model mModel1;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.

--- a/include/QuestionBlock.h
+++ b/include/QuestionBlock.h
@@ -6,6 +6,7 @@
 #define QUESTIONBLOCK_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "ShadowModel.h"
 
 struct QuestionBlock {
     u8  pad_000[0x8];
@@ -33,8 +34,10 @@ struct QuestionBlock {
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the
        Animation base), which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x320 */
-    u8  mShadowModel;            /* 0x384 */
-    u8  pad_385[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x384 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13QuestionBlockD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x384 */
     u8  unk_3ac;            /* 0x3ac */
     u8  pad_3ad[0x33];
     s32 unk_3e0;            /* 0x3e0 */

--- a/include/Rabbit.h
+++ b/include/Rabbit.h
@@ -5,6 +5,8 @@
 #ifndef RABBIT_H
 #define RABBIT_H
 #include "types.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct Rabbit {
     u8  pad_000[0x8];
@@ -23,10 +25,14 @@ struct Rabbit {
     u8  pad_0cd[0x3];
     s32 unk_0d0;            /* 0x0d0 */
     u8  pad_0d4[0x3c];
-    u8  mMovingCylinderClsn;            /* 0x110 */
-    u8  pad_111[0x33];
-    u8  mWithMeshClsn;            /* 0x144 */
-    u8  pad_145[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6RabbitD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6RabbitD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x144 */
     u8  mModelAnim;            /* 0x300 */
     u8  pad_301[0x7];
     u8  unk_308;            /* 0x308 */

--- a/include/RabbitKey.h
+++ b/include/RabbitKey.h
@@ -6,6 +6,7 @@
 #define RABBITKEY_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
 
 struct RabbitKey {
     u8  pad_000[0x8];
@@ -30,8 +31,10 @@ struct RabbitKey {
     /* Model member, named by _ZN5ModelD1Ev at +0x110 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x110 */
-    u8  mShadowModel;            /* 0x160 */
-    u8  pad_161[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x160 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9RabbitKeyD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x160 */
     u8  unk_188;            /* 0x188 */
     u8  pad_189[0x7];
     s32 unk_190;            /* 0x190 */

--- a/include/RacingPenguin.h
+++ b/include/RacingPenguin.h
@@ -6,6 +6,9 @@
 #define RACINGPENGUIN_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "TextureSequence.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
 
 struct RacingPenguin {
     u8  pad_000[0x80];
@@ -42,12 +45,18 @@ struct RacingPenguin {
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the
        Animation base), which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mTextureSequence;            /* 0x138 */
-    u8  pad_139[0x13];
-    u8  mShadowModel;            /* 0x14c */
-    u8  pad_14d[0x27];
-    u8  mMovingCylinderClsn;            /* 0x174 */
-    u8  pad_175[0x33];
+    /* TextureSequence member, named by the class's own destructor calling
+       TextureSequence's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13RacingPenguinD0Ev.c] */
+    TextureSequence mTextureSequence;            /* 0x138 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x14c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13RacingPenguinD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x14c */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x174 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13RacingPenguinD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x174 */
     u8  mWithMeshClsn;            /* 0x1a8 */
 #ifdef __cplusplus
     /* methods */

--- a/include/RollingIronBall.h
+++ b/include/RollingIronBall.h
@@ -6,6 +6,8 @@
 #define ROLLINGIRONBALL_H
 #include "types.h"
 #include "Model.h"
+#include "WithMeshClsn.h"
+#include "MovingCylinderClsn.h"
 
 struct RollingIronBall {
     u8  pad_000[0x8];
@@ -25,15 +27,19 @@ struct RollingIronBall {
     u8  pad_102[0x6];
     u8  unk_108;            /* 0x108 */
     u8  pad_109[0x7];
-    u8  mWithMeshClsn;            /* 0x110 */
-    u8  pad_111[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN15RollingIronBallD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x110 */
     /* Model member, named by _ZN5ModelD1Ev at +0x2cc -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x2cc */
     u8  mShadowModel;            /* 0x31c */
     u8  pad_31d[0x57];
-    u8  mMovingCylinderClsn;            /* 0x374 */
-    u8  pad_375[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x374 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN15RollingIronBallD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x374 */
     s32 unk_3a8;            /* 0x3a8 */
     s32 unk_3ac;            /* 0x3ac */
     s32 unk_3b0;            /* 0x3b0 */

--- a/include/RollingLogTtm.h
+++ b/include/RollingLogTtm.h
@@ -6,6 +6,8 @@
 #define ROLLINGLOGTTM_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
 
 struct RollingLogTtm {
     u8  pad_000[0xc];
@@ -31,10 +33,14 @@ struct RollingLogTtm {
        stopped short of the object, so the member also takes over unk_130 (+0x5c = speed),
        which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x138 */
-    u8  pad_139[0x27];
-    u8  mMovingCylinderClsn;            /* 0x160 */
-    u8  pad_161[0x33];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13RollingLogTtmD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x138 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x160 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13RollingLogTtmD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x160 */
     u8  mWithMeshClsn;            /* 0x194 */
     u8  pad_195[0x1eb];
     s32 unk_380;            /* 0x380 */

--- a/include/RollingRock.h
+++ b/include/RollingRock.h
@@ -6,6 +6,8 @@
 #define ROLLINGROCK_H
 #include "types.h"
 #include "Model.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct RollingRock {
     u8  pad_000[0x4];
@@ -35,10 +37,14 @@ struct RollingRock {
     Model mModel;            /* 0x110 */
     u8  mShadowModel;            /* 0x160 */
     u8  pad_161[0x57];
-    u8  mMovingCylinderClsnWithPos;            /* 0x1b8 */
-    u8  pad_1b9[0x3f];
-    u8  mWithMeshClsn;            /* 0x1f8 */
-    u8  pad_1f9[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x1b8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11RollingRockD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x1b8 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1f8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11RollingRockD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1f8 */
     u32 unk_3b4;            /* 0x3b4 */
     u8  pad_3b8[0x6];
     u8  mType;            /* 0x3be */

--- a/include/RotatingPlatformRr.h
+++ b/include/RotatingPlatformRr.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGPLATFORMRR_H
 #define ROTATINGPLATFORMRR_H
 #include "types.h"
+#include "CommonModel.h"
 
 struct RotatingPlatformRr {
     u8  pad_000[0x8];
@@ -14,8 +15,10 @@ struct RotatingPlatformRr {
     s16 unk_08e;            /* 0x08e */
     s16 unk_090;            /* 0x090 */
     u8  pad_092[0x42];
-    u8  mCommonModel;            /* 0x0d4 */
-    u8  pad_0d5[0x3b];
+    /* CommonModel member, named by the class's own destructor calling
+       CommonModel's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN18RotatingPlatformRrD0Ev.c] */
+    CommonModel mCommonModel;            /* 0x0d4 */
     s16 unk_110;            /* 0x110 */
     s16 unk_112;            /* 0x112 */
     s16 unk_114;            /* 0x114 */

--- a/include/RotatingUpDownPlatformUtm.h
+++ b/include/RotatingUpDownPlatformUtm.h
@@ -5,6 +5,7 @@
 #ifndef ROTATINGUPDOWNPLATFORMUTM_H
 #define ROTATINGUPDOWNPLATFORMUTM_H
 #include "types.h"
+#include "Model.h"
 
 struct RotatingUpDownPlatformUtm {
     u8  pad_000[0x8];
@@ -31,8 +32,10 @@ struct RotatingUpDownPlatformUtm {
     u8  pad_0b4[0x18];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN25RotatingUpDownPlatformUtmD1Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1db];
     u8  unk_300;            /* 0x300 */

--- a/include/Shark.h
+++ b/include/Shark.h
@@ -6,6 +6,8 @@
 #define SHARK_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct Shark {
     u8  pad_000[0x8];
@@ -41,10 +43,14 @@ struct Shark {
     u8  pad_0b0[0x50];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  mMovingCylinderClsnWithPos;            /* 0x110 */
-    u8  pad_111[0x3f];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5SharkD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5SharkD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x30c */

--- a/include/ShipWing.h
+++ b/include/ShipWing.h
@@ -6,6 +6,7 @@
 #define SHIPWING_H
 #include "types.h"
 #include "Model.h"
+#include "WithMeshClsn.h"
 
 struct ShipWing {
     u8  pad_000[0x5c];
@@ -25,8 +26,10 @@ struct ShipWing {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mWithMeshClsn;            /* 0x320 */
-    u8  pad_321[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x320 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8ShipWingD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x320 */
     s32 unk_4dc;            /* 0x4dc */
     s32 unk_4e0;            /* 0x4e0 */
     s32 unk_4e4;            /* 0x4e4 */

--- a/include/ShutterBob.h
+++ b/include/ShutterBob.h
@@ -5,11 +5,14 @@
 #ifndef SHUTTERBOB_H
 #define SHUTTERBOB_H
 #include "types.h"
+#include "Model.h"
 
 struct ShutterBob {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10ShutterBobD1Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/ShutterHmc.h
+++ b/include/ShutterHmc.h
@@ -5,11 +5,14 @@
 #ifndef SHUTTERHMC_H
 #define SHUTTERHMC_H
 #include "types.h"
+#include "Model.h"
 
 struct ShutterHmc {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10ShutterHmcD1Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 #ifdef __cplusplus
     /* methods */

--- a/include/Skeeter.h
+++ b/include/Skeeter.h
@@ -6,6 +6,8 @@
 #define SKEETER_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct Skeeter {
     u8  pad_000[0x5c];
@@ -28,10 +30,14 @@ struct Skeeter {
     u8  pad_109[0x1];
     u8  unk_10a;            /* 0x10a */
     u8  pad_10b[0x5];
-    u8  mMovingCylinderClsnWithPos;            /* 0x110 */
-    u8  pad_111[0x3f];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7SkeeterD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7SkeeterD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        ran 0x4 bytes PAST the end of the object; that space is not evidenced and stays

--- a/include/SkiLift.h
+++ b/include/SkiLift.h
@@ -6,6 +6,10 @@
 #define SKILIFT_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "TextureSequence.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct SkiLift {
     u8  pad_000[0x5c];
@@ -26,14 +30,22 @@ struct SkiLift {
        mAnimation (+0x50 = the Animation base), which the header declared separately inside
        it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mTextureSequence;            /* 0x138 */
-    u8  pad_139[0x13];
-    u8  mShadowModel;            /* 0x14c */
-    u8  pad_14d[0x27];
-    u8  mMovingCylinderClsn;            /* 0x174 */
-    u8  pad_175[0x33];
-    u8  mWithMeshClsn;            /* 0x1a8 */
-    u8  pad_1a9[0x1bb];
+    /* TextureSequence member, named by the class's own destructor calling
+       TextureSequence's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7SkiLiftD0Ev.c] */
+    TextureSequence mTextureSequence;            /* 0x138 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x14c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7SkiLiftD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x14c */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x174 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7SkiLiftD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x174 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1a8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7SkiLiftD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1a8 */
     s32 unk_364;            /* 0x364 */
     s32 unk_368;            /* 0x368 */
     s32 unk_36c;            /* 0x36c */

--- a/include/Snowball.h
+++ b/include/Snowball.h
@@ -6,6 +6,9 @@
 #define SNOWBALL_H
 #include "types.h"
 #include "Model.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
+#include "ShadowModel.h"
 
 struct Snowball {
     u8  pad_000[0x5c];
@@ -25,15 +28,21 @@ struct Snowball {
     u8  pad_0b0[0x50];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  mMovingCylinderClsn;            /* 0x110 */
-    u8  pad_111[0x33];
-    u8  mWithMeshClsn;            /* 0x144 */
-    u8  pad_145[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8SnowballD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8SnowballD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x144 */
     /* Model member, named by _ZN5ModelD1Ev at +0x300 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x300 */
-    u8  mShadowModel;            /* 0x350 */
-    u8  pad_351[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x350 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8SnowballD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x350 */
     s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */
     s32 unk_380;            /* 0x380 */

--- a/include/Spiny.h
+++ b/include/Spiny.h
@@ -5,6 +5,11 @@
 #ifndef SPINY_H
 #define SPINY_H
 #include "types.h"
+#include "Model.h"
+#include "ModelAnim.h"
+#include "ShadowModel.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct Spiny {
     u8  pad_000[0x60];
@@ -42,16 +47,26 @@ struct Spiny {
     u8  pad_0cd[0x1];
     s16 unk_0ce;                 /* 0x0ce */
     u8  pad_0d0[0x4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mModelAnim;            /* 0x124 */
-    u8  pad_125[0x63];
-    u8  mShadowModel;            /* 0x188 */
-    u8  pad_189[0x27];
-    u8  mMovingCylinderClsn;            /* 0x1b0 */
-    u8  pad_1b1[0x33];
-    u8  mWithMeshClsn;            /* 0x1e4 */
-    u8  pad_1e5[0x1bb];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5SpinyD0Ev.c] */
+    Model mModel;            /* 0x0d4 */
+    /* ModelAnim member, named by the class's own destructor calling
+       ModelAnim's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5SpinyD0Ev.c] */
+    ModelAnim mModelAnim;            /* 0x124 */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x188 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5SpinyD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x188 */
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x1b0 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5SpinyD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x1b0 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x1e4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5SpinyD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x1e4 */
     u8  unk_3a0;            /* 0x3a0 */
     u8  pad_3a1[0x37];
     s32 unk_3d8;            /* 0x3d8 */

--- a/include/Squasher.h
+++ b/include/Squasher.h
@@ -6,6 +6,7 @@
 #define SQUASHER_H
 #include "types.h"
 #include "Model.h"
+#include "MovingMeshCollider.h"
 
 struct Squasher {
     u8  pad_000[0x5c];
@@ -27,8 +28,10 @@ struct Squasher {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* MovingMeshCollider member, named by the class's own destructor calling
+       MovingMeshCollider's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN8SquasherD1Ev.c] */
+    MovingMeshCollider mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x31];
     s16 unk_31e;            /* 0x31e */

--- a/include/StarMarker.h
+++ b/include/StarMarker.h
@@ -6,6 +6,7 @@
 #define STARMARKER_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
 
 struct StarMarker {
     u8  pad_000[0x4];
@@ -31,8 +32,10 @@ struct StarMarker {
        unk_158 (+0x44 = mat4x3.t.y), unk_15c (+0x48 = mat4x3.t.z), which the header
        declared separately inside it. */
     Model mModel;            /* 0x114 */
-    u8  mShadowModel;            /* 0x164 */
-    u8  pad_165[0x27];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x164 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN10StarMarkerD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x164 */
     u8  unk_18c;            /* 0x18c */
     u8  pad_18d[0x23];
     s32 unk_1b0;            /* 0x1b0 */

--- a/include/Stump.h
+++ b/include/Stump.h
@@ -5,6 +5,8 @@
 #ifndef STUMP_H
 #define STUMP_H
 #include "types.h"
+#include "MovingCylinderClsn.h"
+#include "WithMeshClsn.h"
 
 struct Stump {
     u8  pad_000[0x8];
@@ -14,10 +16,14 @@ struct Stump {
     u8  pad_0a4[0xc];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x5c];
-    u8  mMovingCylinderClsn;            /* 0x110 */
-    u8  pad_111[0x33];
-    u8  mWithMeshClsn;            /* 0x144 */
-    u8  pad_145[0x1bb];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5StumpD1Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN5StumpD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x144 */
     u8  mModelAnim;            /* 0x300 */
     u8  pad_301[0x5b];
     s32 unk_35c;            /* 0x35c */

--- a/include/SwitchActivatedPlank.h
+++ b/include/SwitchActivatedPlank.h
@@ -11,8 +11,10 @@ struct SwitchActivatedPlank {
     u8  pad_000[0x8e];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN20SwitchActivatedPlankD1Ev.c] */
+    Model mModel1;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.

--- a/include/TinyCover.h
+++ b/include/TinyCover.h
@@ -6,6 +6,7 @@
 #define TINYCOVER_H
 #include "types.h"
 #include "Model.h"
+#include "TextureTransformer.h"
 
 struct TinyCover {
     u8  pad_000[0x60];
@@ -20,8 +21,10 @@ struct TinyCover {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mTextureTransformer;            /* 0x320 */
-    u8  pad_321[0x13];
+    /* TextureTransformer member, named by the class's own destructor calling
+       TextureTransformer's D1 at +0x320 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9TinyCoverD1Ev.c] */
+    TextureTransformer mTextureTransformer;            /* 0x320 */
     s32 unk_334;            /* 0x334 */
     u8  pad_338[0x4];
     u8  unk_33c;            /* 0x33c */

--- a/include/Toad.h
+++ b/include/Toad.h
@@ -6,6 +6,7 @@
 #define TOAD_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsn.h"
 
 struct Toad {
     u8  pad_000[0x8];
@@ -19,8 +20,10 @@ struct Toad {
     u8  pad_08e[0x3e];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mMovingCylinderClsn;            /* 0x0d4 */
-    u8  pad_0d5[0x33];
+    /* MovingCylinderClsn member, named by the class's own destructor calling
+       MovingCylinderClsn's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN4ToadD0Ev.c] */
+    MovingCylinderClsn mMovingCylinderClsn;            /* 0x0d4 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x108 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x108 */

--- a/include/Tornado.h
+++ b/include/Tornado.h
@@ -6,6 +6,8 @@
 #define TORNADO_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "WithMeshClsn.h"
+#include "TextureTransformer.h"
 
 struct Tornado {
     u8  pad_000[0x8];
@@ -35,15 +37,19 @@ struct Tornado {
     s32 unk_0f4;            /* 0x0f4 */
     u32 unk_0f8;            /* 0x0f8 */
     u8  pad_0fc[0xc];
-    u8  mWithMeshClsn;            /* 0x108 */
-    u8  pad_109[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x108 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7TornadoD0Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x108 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x2c4 -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the
        Animation base), which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x2c4 */
-    u8  mTextureTransformer;            /* 0x328 */
-    u8  pad_329[0x13];
+    /* TextureTransformer member, named by the class's own destructor calling
+       TextureTransformer's D1 at +0x328 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN7TornadoD0Ev.c] */
+    TextureTransformer mTextureTransformer;            /* 0x328 */
     s32 unk_33c;            /* 0x33c */
     s32 unk_340;            /* 0x340 */
     s32 unk_344;            /* 0x344 */

--- a/include/TtcMovingCubeA.h
+++ b/include/TtcMovingCubeA.h
@@ -6,6 +6,7 @@
 #define TTCMOVINGCUBEA_H
 #include "types.h"
 #include "Model.h"
+#include "MovingMeshCollider.h"
 
 struct TtcMovingCubeA {
     u8  pad_000[0x8];
@@ -24,8 +25,10 @@ struct TtcMovingCubeA {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* MovingMeshCollider member, named by the class's own destructor calling
+       MovingMeshCollider's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN14TtcMovingCubeAD1Ev.c] */
+    MovingMeshCollider mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
     s32 unk_320;            /* 0x320 */

--- a/include/UnchainedChomp.h
+++ b/include/UnchainedChomp.h
@@ -6,6 +6,8 @@
 #define UNCHAINEDCHOMP_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct UnchainedChomp {
     u8  pad_000[0x8];
@@ -26,10 +28,14 @@ struct UnchainedChomp {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x6c];
-    u8  mMovingCylinderClsnWithPos;            /* 0x110 */
-    u8  pad_111[0x3f];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN14UnchainedChompD1Ev.cpp] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN14UnchainedChompD1Ev.cpp] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        ran 0x2d0 bytes PAST the end of the object; that space is not evidenced and stays

--- a/include/WaterRing.h
+++ b/include/WaterRing.h
@@ -6,6 +6,8 @@
 #define WATERRING_H
 #include "types.h"
 #include "Model.h"
+#include "MovingCylinderClsnWithPos.h"
+#include "WithMeshClsn.h"
 
 struct WaterRing {
     u8  pad_000[0x8];
@@ -23,10 +25,14 @@ struct WaterRing {
     u8  pad_098[0x68];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  mMovingCylinderClsnWithPos;            /* 0x110 */
-    u8  pad_111[0x3f];
-    u8  mWithMeshClsn;            /* 0x150 */
-    u8  pad_151[0x1bb];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9WaterRingD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN9WaterRingD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x150 */
     /* Model member, named by _ZN5ModelD1Ev at +0x30c -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x30c */

--- a/include/WaterSuction.h
+++ b/include/WaterSuction.h
@@ -5,6 +5,7 @@
 #ifndef WATERSUCTION_H
 #define WATERSUCTION_H
 #include "types.h"
+#include "MovingCylinderClsnWithPos.h"
 
 struct WaterSuction {
     u8  pad_000[0x8];
@@ -19,8 +20,10 @@ struct WaterSuction {
     u8  pad_098[0x68];
     u8  unk_100;            /* 0x100 */
     u8  pad_101[0xf];
-    u8  mMovingCylinderClsnWithPos;            /* 0x110 */
-    u8  pad_111[0x3f];
+    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
+       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12WaterSuctionD1Ev.c] */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
     u8  mWithMeshClsn;            /* 0x150 */
     u8  pad_151[0x1c3];
     s32 unk_314;            /* 0x314 */

--- a/include/WaterfallMist.h
+++ b/include/WaterfallMist.h
@@ -5,6 +5,7 @@
 #ifndef WATERFALLMIST_H
 #define WATERFALLMIST_H
 #include "types.h"
+#include "WithMeshClsn.h"
 
 struct WaterfallMist {
     u8  pad_000[0x8];
@@ -32,8 +33,10 @@ struct WaterfallMist {
     u8  pad_11c[0x10];
     u8  unk_12c;            /* 0x12c */
     u8  pad_12d[0x17];
-    u8  mWithMeshClsn;            /* 0x144 */
-    u8  pad_145[0x1bb];
+    /* WithMeshClsn member, named by the class's own destructor calling
+       WithMeshClsn's D1 at +0x144 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13WaterfallMistD1Ev.c] */
+    WithMeshClsn mWithMeshClsn;            /* 0x144 */
     u8  mModelAnim;            /* 0x300 */
     u8  pad_301[0x5b];
     s32 unk_35c;            /* 0x35c */

--- a/include/WingFeather.h
+++ b/include/WingFeather.h
@@ -5,6 +5,7 @@
 #ifndef WINGFEATHER_H
 #define WINGFEATHER_H
 #include "types.h"
+#include "Model.h"
 
 struct WingFeather {
     u8  pad_000[0x5c];
@@ -22,8 +23,10 @@ struct WingFeather {
     u8  pad_0a4[0x4];
     s32 unk_0a8;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member, named by the class's own destructor calling
+       Model's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11WingFeatherD0Ev.c] */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingCylinderClsn;            /* 0x124 */
     u8  pad_125[0x23];
     u32 unk_148;            /* 0x148 */

--- a/notes/handoff-marker-typing.md
+++ b/notes/handoff-marker-typing.md
@@ -1,0 +1,174 @@
+# Handoff: object-marker typing
+
+**Written 2026-08-06.** Everything below is checkable; nothing here is a plan you have
+to take on trust. Where a number appears, the command that produces it appears with it.
+
+---
+
+## 1. What this is
+
+241 headers in `include/` carry `AUTO-GENERATED from matched-function evidence by
+tools/gen_header.py`. **No such generator was ever committed** -- `5ddf7d2d` (PR #866)
+added all 368 headers and zero `tools/` files. Nothing had ever checked what they claim.
+
+Where the original generator did not know a field's type it wrote a bare `u8` and padded
+to the next thing it did know:
+
+```c
+u8  mModelAnim;         /* 0x0d4 */
+u8  pad_0d5[0x63];
+```
+
+That is an **object marker**. The `u8` is a stand-in, not a width claim -- reading it as
+one produced 229 false positives early in this programme, and a variant of that mistake
+recurred twice more. Typing them is what turns a byte blob into `ModelAnim mModelAnim;`,
+which is the precondition for writing real C++ methods against it.
+
+## 2. The evidence, and why it is trustworthy
+
+The type comes from a **member-destructor relocation** in the class's own destructor:
+
+```c
+/* src/_ZN3AmpD0Ev.c */
+_ZN9ModelAnimD1Ev((char *)t + 0xd4);
+```
+
+That callee is a relocation `tools/build_pin.py` checks against `config/**/relocs.txt`,
+so the class name is ROM-backed rather than inferred from the placeholder name.
+
+**D1 and never D2 is the soundness argument.** A true member of declared type `T` calls
+`T`'s *complete-object* destructor. An inlined derived member would call the base's `D2`
+at the same offset. Every exact call behind the typed markers is a D1; a review confirmed
+zero D2 and zero C2 across the set.
+
+Corroboration that is real: **constructor `C1` calls at the same offsets**, found
+independently in `*_Spawn.c` files. Corroboration that is **not** real: "the span ends on
+an interior boundary of the class" -- every 4-aligned offset of `Model`/`ModelAnim` is a
+boundary, so the test cannot fail. Do not quote it.
+
+## 3. State
+
+```sh
+python tools/marker_census.py           # the operative worklist
+```
+
+| | |
+|---|---:|
+| markers typed (this programme) | **298** |
+| bare object markers remaining | **767** |
+| decidable today on D1 evidence | **235** |
+| of those, clean swaps (span == sizeof) | 66 |
+| ...all of which are **blocked**, see §5 | |
+
+Merged: **#1151** (131 markers + the `Matrix4x3` guard), **#1153** (census + the
+transforms), plus the earlier programme (#1118, #1121, #1129, #1131, #1132, #1134,
+#1137). Open and green: **#1156** (bucketing fix + 167 markers).
+
+Build state throughout: `106/106 exact, PASS`, eligible **10672**, attribution 0/0.
+
+## 4. Tools
+
+| tool | what it answers |
+|---|---|
+| `tools/marker_census.py` | how many markers are left and how many are decidable **now**. Reads the tree, not a report. **This is the worklist.** |
+| `tools/marker_evidence.py` | full per-marker evidence, all verdicts |
+| `tools/marker_apply.py` | the transform |
+| `tools/gen_header.py` | the bucketed differential. Useful, but see §6 -- it is *not* the worklist |
+| `tools/check_header_offsets.py` | recomputes every field position against its `/* 0x… */` comment |
+
+## 5. The next step, precisely
+
+**All 66 remaining clean swaps sit in 29 classes whose TUs carry local declarations that
+collide once the header pulls in the real definition.** They are not a separate batch --
+applying them costs ~26 files every time. I tried; I reverted it.
+
+The blockers are not all `Model` stand-ins. Sampling the failing TUs:
+
+```
+Base2 (4)  Base1 (3)  Obj (2)  RaycastGround (2)  VB (1)  Model (1)  Base (1)  Scene (1)
+```
+
+These are ad-hoc local classes a recovery pass invented so a file could spell a call.
+Each needs reading and removing individually.
+
+**The worked example is `src/_ZN10FlameChomp13InitResourcesEv.cpp`** (commit on #1151):
+it carried `typedef int Fix12;`, which collided with the real `Fix12<>` template once
+`FlameChomp.h` reached `Model.h`. The typedef *was* `int`, so spelling `int` directly in
+the two extern declarations was byte-neutral. `build_pin.verify` → `(True, '2004/b56')`.
+
+Do that, per class, byte-verifying each. Then re-run the census and the clean swaps land.
+
+The 29: `BobOmb BooCage Bowser BowserFire BowserPuzzlePiece Bullet Coffin FlyGuy Goomba
+Koopa Lakitu LakituBro MadPiano MrI MrI_Projectile OneUpMushroom PrincessPeach
+RotatingClockHand Scuttlebug SignPost SnowmanBody SnowmanHead Snufit Spindrift Stage
+Swoop TtcConveyorBeltLarge WaterBomb YoshiEgg`
+
+## 6. Gates -- run all of them, and know what each cannot see
+
+```sh
+python tools/check_header_offsets.py <changed headers>   # 0 mismatched, 0 unparsed
+python tools/eligible.py                                 # BEFORE and AFTER, diff them
+python tools/rombuild.py                                 # 106/106 exact, PASS
+python tools/check_references.py                         # must say OK
+python tools/prepush_attribution.py                      # 0 changed, 0 lost
+python tools/langmode_audit.py --check langmode-baseline.json
+python tools/test_gen_header.py                          # 17 tests
+```
+
+**`rombuild.py` compiles only *enrolled* files**, and the tree matches more than it
+enrolls. It reported `106/106 PASS` while 237 files were broken.
+
+**`eligible.py`'s before/after bracket** caught 237, then 121, then 26 files. It is the
+load-bearing check for any header change.
+
+**`check_references.py` caught three defects the other two were structurally blind to**,
+every time by noticing a symbol left the unresolved set *without becoming eligible* --
+it changed why it fails, which is not a fix. Files that were never eligible are invisible
+to both gates above. **Keep this one closest.**
+
+## 7. Traps, each of which cost real time here
+
+- **A pass that looks in the wrong place reports like one that found nothing.** A probe
+  matched 3 accesses where ~5,900 existed; `evidence_rom.py` decoded every arm9 function
+  0x4000 bytes off and reported confidently (2.1% plausible prologues against 64.8%).
+  Every pass now prints its own recall. Read it before believing a zero.
+- **`gen_header.py` files a D1-evidenced marker as `confirmed`**, dropping it off the
+  worklist -- the markers with the *best* evidence went missing because the evidence was
+  good. Fixed in #1156, but it is why the census exists and why the census is the worklist.
+- **The worklist was scoped to 3 types when the same evidence names 14.** Do not assume
+  the current scope is the evidence's scope.
+- **Capstone appends condition codes**, so `strhs` prefix-matches `strh`. Match on
+  `insn.id`, never mnemonic text. Same trap for `ble` vs `bl`.
+- **Sweep for duplicate type definitions before a batch**, not after. Doing it first took
+  the collision round from 237 lost files to 26.
+- **Check `git log origin/main..HEAD` after any merge.** Commits were stranded twice by a
+  PR squash-merging while work was pushed to the same branch, and both times the work was
+  reported landed when it was not. Verify by *content*: `git show origin/main:<file>`.
+
+## 8. Deliberately left
+
+- **36 undecided markers**, with reasons in `build/marker_evidence.json`. Honest.
+- **9 "interior to a typed member"** findings -- header self-contradictions, not typing
+  questions. Separate fix.
+- **`Stage.unk_874`** -- rests only on a cast through a locally-declared struct.
+- **`include/G2x.h`** -- describes hardware registers, not an object. Issue **#1148**,
+  someone else is on it. Do not type it.
+- **`ModelBase::SetFile` is declared `void`** but the ROM's call sites consume r0, so it
+  returned a value. Two call sites keep the mangled spelling with a note. Fixing it means
+  a byte-verified change across 216 includers.
+- **`check_header_offsets.py` cannot parse `struct X *p;`** -- it reports 8 mismatched /
+  4 unparsed on the C fallbacks as pure parse artifact. A measured two-line fix takes the
+  tree from 65 to 30 problems; held back so batch numbers stayed comparable. Land it first.
+
+## 9. The honest framing
+
+The ROM has matched at `106/106 exact` throughout, and coverage is unchanged -- this work
+does not add matched functions. It makes the **description** true, which is upstream of
+migration: you cannot write `mModelAnim.SetAnim(...)` until the header says a `ModelAnim`
+is there.
+
+For scale on what remains after this: `python tools/langmode_audit.py` reports **1,341 of
+2,515 mangled-symbol files still unmigrated (53.3%)** and **2,663 local shadow struct
+declarations**. Those shadows are the same thing blocking §5 -- they are the shared
+bottleneck between the header work and the migration work, and every one removed makes
+both cheaper.

--- a/notes/handoff-marker-typing.md
+++ b/notes/handoff-marker-typing.md
@@ -61,8 +61,13 @@ python tools/marker_census.py           # the operative worklist
 | ...all of which are **blocked**, see §5 | |
 
 Merged: **#1151** (131 markers + the `Matrix4x3` guard), **#1153** (census + the
-transforms), plus the earlier programme (#1118, #1121, #1129, #1131, #1132, #1134,
-#1137). Open and green: **#1156** (bucketing fix + 167 markers).
+transforms), **#1156** (the bucketing fix, and *only* that), plus the earlier programme
+(#1118, #1121, #1129, #1131, #1132, #1134, #1137).
+
+The marker batch this note was written alongside, and this note itself, are landing
+separately. They were committed to #1156's branch *after* that PR squash-merged, so they
+never reached main -- the §7 trap, third occurrence, caught by comparing the census
+against this table's own numbers. Read the table as the state after that re-land.
 
 Build state throughout: `106/106 exact, PASS`, eligible **10672**, attribution 0/0.
 


### PR DESCRIPTION
## What this is

A re-land, not new work. Two commits were pushed to `tools/gen-header-bucketing` **after** #1156 squash-merged, so they never reached `main`:

| commit | time | content |
|---|---|---|
| `6823f67c` | 10:04 | bucketing fix — **did** land, as `6e385e20` (#1156) |
| `4186b1aa` | 10:53 | 172 object markers, 82 headers — **stranded** |
| `a850bcd1` | 13:46 | `notes/handoff-marker-typing.md` — **stranded** |

#1156 merged at 10:12. Both later commits are cherry-picked here unmodified, plus one new commit correcting the note's own stale claim that #1156 carried the markers.

This is the third occurrence of the trap the note's §7 documents ("a PR squash-merging while work is pushed to the same branch"). It was caught by comparing `marker_census.py` against the note's §3 table: main read 931 bare markers / 399 decidable, the note claimed 767 / 235, and the 164 delta in both columns was exactly the missing commit.

## Effect

`marker_census.py`, which §4 designates as the operative worklist:

| | main | this branch |
|---|---:|---:|
| bare u8 object markers (span > 4) | 931 | **767** |
| decidable now on D1 evidence | 399 | **235** |

Matches the note's §3 table exactly, which is the check that this restores the intended state.

No coverage change — this makes the *description* true, it does not add matched functions.

## Gates (§6)

| gate | result |
|---|---|
| `check_header_offsets.py` (82 changed headers) | 0 mismatched, 0 unparsed |
| `eligible.py` before/after | 10672 both; **0 lost, 0 gained** compared by name |
| `check_references.py` | OK, no new unresolvable; unresolved 235 = baseline |
| `rombuild.py` | **106/106 exact**, 10,670 reproducing, 0 mismatching, PASS |
| `prepush_attribution.py` | 11251 tracked, 0 changed, 0 lost |
| `langmode_audit.py --check` | ratchet PASS |
| `test_gen_header.py` | 0 failures |

The eligible bracket is by symbol name, not just count — the header change is inert with respect to what compiles.

## Review note

The 82 headers are mechanical output of `marker_apply.py` under D1-relocation evidence (§2). The commit to actually read is the third one, which is prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
