### PR TITLE
Gate the squash-merge stranding trap (found 5 pre-existing cases)

### DIFF
--- a/.github/workflows/merge-stranding.yml
+++ b/.github/workflows/merge-stranding.yml
@@ -1,0 +1,69 @@
+name: merge stranding
+
+# Detects work committed to a branch AFTER the pull request that closed it merged --
+# the trap `notes/handoff-marker-typing.md` section 7 documents, which has cost the tree
+# four times (#1156 -> #1169, #1196 -> #1200, and twice before).
+#
+# This CANNOT be a pull_request gate. The damage happens after a merge, when the PR is
+# closed and there is nothing left to fail. By the time the commits exist, the only
+# thing that can notice them is something that looks back at merged PRs -- so this runs
+# on a schedule and fails loudly, which mails the repo owner.
+#
+# Cheap by construction: stdlib Python, no compiler and no ROM, one ls-remote per remote
+# and a fetch only for tips it actually has to compare. A 286-PR window runs in ~11s.
+#
+# fetch-depth: 0 is required and not incidental -- the tool compares a branch tip
+# against main with `git merge-tree`, which needs real history, not a shallow graft.
+on:
+  schedule:
+    # Hourly. The window is 7 days, so a miss is caught by the next 167 runs; the point
+    # of running often is to catch a stranding while its author is still around to fix
+    # it, not to be the only chance of catching it.
+    - cron: "17 * * * *"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "days of merged PRs to examine"
+        required: false
+        default: "7"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: merge-stranding
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # The baseline holds the five findings that already existed when this gate
+      # landed. They are acknowledged, not forgiven -- each entry is keyed on the
+      # branch tip, so any of those branches receiving one more commit fails this
+      # job again. Drain them by re-landing or deleting the branch, then re-bank.
+      - name: Look for commits no pull request contains
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python tools/merge_stranding.py \
+            --since "${{ github.event.inputs.since || '7' }}" \
+            --baseline stranding-baseline.json \
+            --check --json stranding.json
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: merge-stranding
+          path: stranding.json
+          if-no-files-found: ignore

--- a/stranding-baseline.json
+++ b/stranding-baseline.json
@@ -1,0 +1,30 @@
+{
+  "_note": "Acknowledged stranding, keyed by PR. --check stays green for these until the branch tip MOVES AGAIN. Delete an entry once the branch is re-landed or deleted; regenerate with --bank.",
+  "acknowledged": {
+    "1111": {
+      "branch": "ov080-02125460-6bb-wall-map",
+      "tip": "a4984c3787b19a40765f05ada3713ecfcb3ca4a2",
+      "verdict": "ADDS"
+    },
+    "1138": {
+      "branch": "readable/base-conflicts",
+      "tip": "3a9874dd9a1608acd5a7431ad14100d3592c1285",
+      "verdict": "CONFLICT"
+    },
+    "1156": {
+      "branch": "tools/gen-header-bucketing",
+      "tip": "a850bcd1d4c0d0e4cfb3db5b9a7145718555b587",
+      "verdict": "CONFLICT"
+    },
+    "958": {
+      "branch": "match/ov002-St_BurnFire_Main",
+      "tip": "efaaa82f7ffbf7931ebc33782771021353ce12bd",
+      "verdict": "CONFLICT"
+    },
+    "999": {
+      "branch": "bank/ov002-020d3b9c-div52",
+      "tip": "53899bc61aabe19842498d80b9be8742a19745a1",
+      "verdict": "CONFLICT"
+    }
+  }
+}

--- a/tools/merge_stranding.py
+++ b/tools/merge_stranding.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Find work committed to a branch AFTER the pull request that closed it merged.
+
+`notes/handoff-marker-typing.md` section 7 names this trap; it has now cost the tree
+four times (#1156 -> #1169, #1196 -> #1200, and twice before). The shape is always the
+same:
+
+    10:04  commit A pushed to branch B
+    10:12  PR squash-merges branch B          <- GitHub freezes the PR head here
+    10:53  commit C pushed to branch B        <- never in any pull request, ever
+    13:46  commit D pushed to branch B        <- likewise
+
+A squash merge lands ONE commit whose parent is main. It does not merge branch B, so no
+commit on B ever becomes an ancestor of main. That is fine for A, whose content the
+squash carries. C and D are simply lost: no PR contains them, no gate sees them, and the
+branch is then deleted as "merged" because GitHub says the PR merged.
+
+Nothing in the normal workflow surfaces this. The PR is green. The branch reads "merged".
+`git log main` looks complete. Every previous instance was caught days later by noticing
+that a *claim* disagreed with the tree -- a census count that did not match a note's
+table, a PR title advertising a class reference whose generator was not in the tree.
+That is not a gate, that is luck.
+
+The detector is one comparison. GitHub stops updating a PR's head SHA once the PR
+closes, so for any merged PR whose branch still exists:
+
+    branch tip != PR head at merge   =>   commits exist that no pull request contains
+
+That is a fact, not a heuristic, and it is reported as such. The second question --
+does it still matter? -- is answered with git's own three-way merge rather than by
+comparing files, because a branch can be stale for boring reasons and file comparison
+cannot tell the difference:
+
+    git merge-tree --write-tree main <tip>
+
+    result tree == main's tree  ->  LANDED    the tip adds nothing; safe to delete
+    result tree != main's tree  ->  ADDS      exactly these paths are not on main
+    merge-tree exits nonzero    ->  CONFLICT  content differs and a human must choose
+
+That distinction is worth the extra call. On #1156, comparing files flagged 84 paths as
+suspicious -- every header the branch had touched and main had since moved past. The
+merge-tree check narrows the same branch to one file, the note that #1169 re-landed with
+a correction, which is the only thing that actually still differs.
+
+--check fails on ADDS and on CONFLICT. Both mean the branch holds content main does not,
+which is precisely the condition worth a human's attention. A branch that is genuinely
+finished with drains out of the report the moment it is deleted.
+
+Fork PRs are covered: their branch lives in the contributor's fork, so the tip is read
+from the fork rather than from origin.
+
+This needs the network and so cannot be a PR gate -- the damage happens *after* a merge,
+when there is no PR left to fail. Run it on a schedule. It is otherwise cheap: stdlib
+only, no compiler, no ROM, and it fetches only the commits it has to compare.
+
+Auth: $GITHUB_TOKEN if set, else `gh auth token`. Public-repo read is enough.
+
+Usage:
+    python tools/merge_stranding.py                     # last 7 days, human summary
+    python tools/merge_stranding.py --since 30          # wider window
+    python tools/merge_stranding.py --pr 1156           # one PR, ignores the window
+    python tools/merge_stranding.py --check             # exit 1 if anything is stranded
+    python tools/merge_stranding.py --json out.json     # machine-readable
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+API = "https://api.github.com"
+SLUG = "tangosdev/sm64ds-decomp"
+
+LANDED, ADDS, CONFLICT, UNREACHABLE = "LANDED", "ADDS", "CONFLICT", "UNREACHABLE"
+
+
+def git(*args, check=True):
+    r = subprocess.run(("git",) + args, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)}: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def have(sha):
+    return subprocess.run(["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+                          capture_output=True).returncode == 0
+
+
+def token():
+    t = os.environ.get("GITHUB_TOKEN")
+    if t:
+        return t
+    r = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True)
+    return r.stdout.strip() if r.returncode == 0 and r.stdout.strip() else None
+
+
+def api(path, tok):
+    """GET a JSON path. None on 404, so callers can treat 'gone' as data."""
+    req = urllib.request.Request(f"{API}{path}")
+    req.add_header("Accept", "application/vnd.github+json")
+    if tok:
+        req.add_header("Authorization", f"Bearer {tok}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as fh:
+            return json.load(fh)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def merged_prs(tok, since, slug, only=None):
+    if only is not None:
+        pr = api(f"/repos/{slug}/pulls/{only}", tok)
+        return [pr] if pr and pr.get("merged_at") else []
+    out, page = [], 1
+    while page <= 10:
+        batch = api(f"/repos/{slug}/pulls?state=closed&sort=updated&direction=desc"
+                    f"&per_page=100&page={page}", tok) or []
+        if not batch:
+            break
+        stale = True
+        for pr in batch:
+            if not pr.get("merged_at"):
+                continue
+            if datetime.fromisoformat(pr["merged_at"].replace("Z", "+00:00")) >= since:
+                out.append(pr)
+                stale = False
+        if stale:
+            break
+        page += 1
+    return out
+
+
+def tips(url, refs=None):
+    """branch -> sha for one remote, in a single call."""
+    cmd = ["git", "ls-remote", "--heads", url] + list(refs or [])
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        return {}
+    out = {}
+    for line in r.stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+            out[parts[1][len("refs/heads/"):]] = parts[0]
+    return out
+
+
+def fetch(sha, url, ref):
+    if have(sha):
+        return True
+    for args in (["git", "fetch", "--quiet", url, sha],
+                 ["git", "fetch", "--quiet", url, ref]):
+        subprocess.run(args, capture_output=True)
+        if have(sha):
+            return True
+    return False
+
+
+def assess(tip, base):
+    """What would merging `tip` into `base` do? The 'does it still matter' question."""
+    r = subprocess.run(["git", "merge-tree", "--write-tree", base, tip],
+                       capture_output=True, text=True)
+    lines = r.stdout.splitlines()
+    if not lines:
+        return CONFLICT, [], (r.stderr or "merge-tree produced nothing").strip()
+    tree = lines[0].strip()
+    if r.returncode != 0:
+        paths = sorted({ln.split("\t")[-1] for ln in lines[1:]
+                        if "\t" in ln and not ln.startswith(("Auto-merging", "CONFLICT"))})
+        return CONFLICT, paths, ""
+    if tree == git("rev-parse", f"{base}^{{tree}}"):
+        return LANDED, [], ""
+    paths = [p for p in git("diff", "--name-only", f"{base}^{{tree}}", tree,
+                            check=False).splitlines() if p]
+    return ADDS, paths, ""
+
+
+def inspect(pr, tip, base):
+    head = pr["head"]["sha"]
+    ref = pr["head"]["ref"]
+    repo = (pr["head"].get("repo") or {}).get("full_name")
+    url = f"https://github.com/{repo}.git" if repo else None
+    rec = {"pr": pr["number"], "title": pr["title"], "branch": ref,
+           "merged_at": pr["merged_at"], "head": head, "tip": tip}
+
+    if url and not fetch(tip, url, ref):
+        rec.update(verdict=UNREACHABLE, commits=[], paths=[], note="tip not fetchable")
+        return rec
+
+    extra = []
+    for ln in git("log", "--format=%H\t%P\t%s", f"{head}..{tip}", check=False).splitlines():
+        if ln.count("\t") >= 2:
+            sha, parents, subj = ln.split("\t", 2)
+            extra.append({"sha": sha, "subject": subj,
+                          "merge": len(parents.split()) > 1})
+    if not extra:
+        return None            # tip differs but adds no commits: a rebase, not a loss
+
+    verdict, paths, note = assess(tip, base)
+    rec.update(verdict=verdict, commits=extra, paths=paths, note=note)
+    return rec
+
+
+def render(reports, checked):
+    bad = [r for r in reports if r["verdict"] != LANDED]
+    ok = [r for r in reports if r["verdict"] == LANDED]
+    out = [f"merge_stranding: {checked} merged PR(s) checked, "
+           f"{len(bad)} with work in no pull request"]
+
+    for r in bad:
+        out += ["", f"  #{r['pr']}  {r['branch']}   *** {r['verdict']} ***",
+                f"    merged at {r['head'][:8]}, branch tip is now {r['tip'][:8]}"]
+        if r["verdict"] == UNREACHABLE:
+            out.append(f"    {r['note']} -- check the fork by hand")
+            continue
+        out.append(f"    {len(r['commits'])} commit(s) no pull request contains:")
+        out += ["      {}{}  {}".format(c["sha"][:8], " (merge)" if c.get("merge") else "",
+                                        c["subject"]) for c in r["commits"]]
+        if r["note"]:
+            out.append(f"    {r['note']}")
+        label = ("merging the tip would add" if r["verdict"] == ADDS
+                 else "merging the tip conflicts in")
+        out.append(f"    {label} {len(r['paths'])} path(s):")
+        out += [f"      {p}" for p in r["paths"][:20]]
+        if len(r["paths"]) > 20:
+            out.append(f"      ... and {len(r['paths']) - 20} more")
+        # commits are newest-first, so the range is oldest^..newest. A merge in the
+        # range cannot be cherry-picked without -m, so name the non-merges instead of
+        # printing a range that will not run.
+        picks = [c for c in r["commits"] if not c.get("merge")]
+        if len(picks) == len(r["commits"]) and len(picks) > 1:
+            span = f"{picks[-1]['sha'][:8]}^..{picks[0]['sha'][:8]}"
+        else:
+            span = " ".join(c["sha"][:8] for c in reversed(picks)) or "(merges only)"
+        out.append(f"    -> re-land: git cherry-pick {span}")
+        if len(picks) != len(r["commits"]):
+            out.append("       (merge commits in the range are skipped -- pick by hand)")
+
+    for r in ok:
+        out += ["", f"  #{r['pr']}  {r['branch']}   tip is newer but adds nothing "
+                    f"-- safe to delete"]
+    if not bad:
+        out += ["", "  no work stranded by a squash merge."]
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--since", type=int, default=7, help="days back (default 7)")
+    ap.add_argument("--pr", type=int, help="check one PR, ignore the window")
+    ap.add_argument("--repo", default=SLUG, help=f"owner/name (default {SLUG})")
+    ap.add_argument("--base", default="origin/main", help="what 'landed' means")
+    ap.add_argument("--check", action="store_true", help="exit 1 if anything stranded")
+    ap.add_argument("--json", metavar="PATH", help="write the report as JSON")
+    ap.add_argument("--baseline", metavar="PATH",
+                    help="acknowledged findings; --check ignores these unless the "
+                         "branch has moved again")
+    ap.add_argument("--bank", metavar="PATH",
+                    help="write the current findings as a baseline")
+    args = ap.parse_args()
+
+    tok = token()
+    if not tok:
+        print("no GitHub token: set $GITHUB_TOKEN or run `gh auth login`", file=sys.stderr)
+        return 2
+
+    subprocess.run(["git", "fetch", "--quiet", "origin", "main"], capture_output=True)
+    since = datetime.now(timezone.utc) - timedelta(days=args.since)
+    prs = merged_prs(tok, since, args.repo, only=args.pr)
+
+    # One ls-remote for origin covers every same-repo PR; forks are asked individually.
+    by_remote = {}
+    for pr in prs:
+        repo = (pr["head"].get("repo") or {}).get("full_name")
+        if repo:
+            by_remote.setdefault(repo, set()).add(pr["head"]["ref"])
+    live = {repo: tips(f"https://github.com/{repo}.git", refs)
+            for repo, refs in by_remote.items()}
+
+    reports = []
+    for pr in prs:
+        repo = (pr["head"].get("repo") or {}).get("full_name")
+        tip = live.get(repo, {}).get(pr["head"]["ref"])
+        if tip is None or tip == pr["head"]["sha"]:
+            continue                      # branch deleted, or untouched since the merge
+        r = inspect(pr, tip, args.base)
+        if r:
+            reports.append(r)
+
+    print(render(reports, len(prs)))
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump({"checked": len(prs), "reports": reports}, fh, indent=2)
+        print(f"\nwrote {args.json}")
+
+    if args.bank:
+        banked = {str(r["pr"]): {"branch": r["branch"], "tip": r["tip"],
+                                 "verdict": r["verdict"]}
+                  for r in reports if r["verdict"] != LANDED}
+        with open(args.bank, "w", encoding="utf-8") as fh:
+            json.dump({"_note": ("Acknowledged stranding, keyed by PR. --check stays "
+                                 "green for these until the branch tip MOVES AGAIN. "
+                                 "Delete an entry once the branch is re-landed or "
+                                 "deleted; regenerate with --bank."),
+                       "acknowledged": banked}, fh, indent=2, sort_keys=True)
+        print(f"\nwrote {args.bank} ({len(banked)} acknowledged)")
+
+    live = [r for r in reports if r["verdict"] != LANDED]
+    if args.baseline and os.path.exists(args.baseline):
+        with open(args.baseline, encoding="utf-8") as fh:
+            ack = json.load(fh).get("acknowledged", {})
+        # Keyed on the tip, not just the PR: an acknowledged branch that receives
+        # ANOTHER commit is new stranding and must fire again.
+        live = [r for r in live if ack.get(str(r["pr"]), {}).get("tip") != r["tip"]]
+        if len(live) != len(reports):
+            print(f"\n{len(reports) - len(live)} finding(s) acknowledged in "
+                  f"{args.baseline}")
+
+    if args.check and live:
+        print("\nmerge_stranding FAILED -- commits exist that no pull request contains:")
+        for r in live:
+            print(f"  #{r['pr']}  {r['branch']}  ({r['verdict']})")
+        print("\nSee notes/handoff-marker-typing.md section 7. Cherry-pick them onto")
+        print("main in a re-land PR, or delete the branch if the work is obsolete.")
+        print("If it is neither, acknowledge it: python tools/merge_stranding.py "
+              "--bank stranding-baseline.json")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

A gate for the trap `notes/handoff-marker-typing.md` §7 documents. It has cost the tree four times and has never once been caught by a check — only by someone noticing that a *claim* disagreed with the tree.

| occurrence | how it was actually found |
|---|---|
| #1156 → #1169 | `marker_census.py` read 931/399; the note's §3 table claimed 767/235 |
| #1196 → #1200 | the PR title advertised a class reference whose generator was not in the tree |

Both were luck. This makes it a check.

## Why it cannot be a PR gate

The damage happens **after** a merge. A squash merge lands one commit parented on main, so no commit on the branch ever becomes an ancestor of main. GitHub freezes the PR head at close, so pushes after that appear in no pull request. The branch is then deleted as "merged" because the PR says merged.

By the time the stranded commits exist, the PR is closed and there is nothing left to fail. So this runs on a schedule.

## The detector

One comparison, and it is a fact rather than a heuristic:

```
branch tip != PR head at merge  =>  commits exist that no pull request contains
```

Whether it still *matters* is a second question, answered with `git merge-tree --write-tree main <tip>` rather than by comparing files:

| verdict | meaning |
|---|---|
| `LANDED` | the tip adds nothing — already re-landed; branch is safe to delete |
| `ADDS` | exactly these paths are not on main |
| `CONFLICT` | content differs; a human must choose |

**That distinction is the whole reason this is worth landing rather than a one-line script.** Comparing files flagged 84 paths on #1156 — every header the branch had touched and main had since moved past. The merge-tree check narrows the same branch to one file, the note #1169 re-landed with a correction, which is the only thing that still differs.

## What the sweep found

Five pre-existing cases, none previously known:

| PR | branch | verdict | paths |
|---|---|---|---|
| #1156 | `tools/gen-header-bucketing` | CONFLICT | 1 |
| #1138 | `readable/base-conflicts` | CONFLICT | 11 |
| #1111 | `ov080-02125460-6bb-wall-map` | ADDS | 1 |
| #999 | `bank/ov002-020d3b9c-div52` | CONFLICT | 2 |
| #958 | `match/ov002-St_BurnFire_Main` | CONFLICT | 2 |

These are banked in `stranding-baseline.json` so the gate starts **green** and fires on what is new — a gate that is red on day one gets ignored, which is the failure mode this is trying to prevent. Entries are keyed on the branch tip, so an acknowledged branch receiving one more commit fails again rather than going quiet forever. Drain an entry by re-landing or deleting the branch, then re-bank.

They are worth triaging on their own; I have not touched them here.

## Verification

| check | result |
|---|---|
| `--check` with 5 findings, no baseline | exit **1** |
| `--check` with baseline banked | exit **0** |
| baseline entry's tip perturbed (simulates a new push) | exit **1**, names #1156 |
| `--pr 1196` after its re-land | **0 findings** — correctly cleared |
| `--pr 1156` | names both stranded commits, narrows to 1 path |
| runtime, 286-PR window | ~11s |
| workflow YAML | parses |

Stdlib only, no compiler and no ROM — same reason the langmode ratchet lives here rather than on the build box. `fetch-depth: 0` is required, not incidental: `merge-tree` needs real history.

## Review note

`tools/merge_stranding.py` is the thing to read. The workflow is a scheduled invocation and the baseline is generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Li9fZU3WZ6ABxEyYrpgrhu