### PR TITLE
ci: bank the langmode ratchet on merge, not in every PR

### DIFF
--- a/.github/workflows/langmode-ratchet.yml
+++ b/.github/workflows/langmode-ratchet.yml
@@ -12,8 +12,19 @@
 # no compiler and no ROM. That is why it can live in this repo rather than on the
 # private build box that `pr-validate.yml` relays to.
 #
-# When a PR legitimately LOWERS a count, --check still passes, but the baseline is then
-# stale. Re-bank it in the same PR:
+# When a PR legitimately LOWERS a count, --check still passes against the PR's own
+# baseline, which is then stale-HIGH. Do NOT re-bank it in your PR: `update-chaos-data.yml`
+# re-banks on merge to main. Hand-banking is what made every migration PR conflict with
+# every other one -- four in one session -- because each merge to main re-banked the file
+# under the others. A stale-high baseline is permissive by construction (--check fails only
+# on a RISE), so no intermediate state can go falsely red: an in-flight PR measures against
+# its own older, higher numbers and passes, and the ratchet tightens once CI refreshes main.
+# Same rule as nearmiss/db.jsonl in .gitattributes -- a merge never regresses a tip.
+#
+# A count that RISES is the opposite case and still belongs in the PR: --check fails against
+# the PR's own baseline, so the increase must be banked there, under the naming rule in
+# `notes/plan-cpp-language-mode.md` (Phase 0). That tripwire is the point of the gate and is
+# unchanged -- CI's re-bank runs only after a merge, so it can never launder a rise:
 #     python tools/langmode_audit.py --json langmode-baseline.json
 name: langmode ratchet
 

--- a/.github/workflows/update-chaos-data.yml
+++ b/.github/workflows/update-chaos-data.yml
@@ -1,8 +1,9 @@
 # On every push to main, regenerate all the derived progress views from committed
-# data and land them in ONE commit (README bar + treemap + contributions.json on
-# main; chaos-db.json on the chaos-data branch), so the hosted viewer and charts
-# self-update without spamming the #github channel with a commit per file. details/
-# chunks on the chaos-data branch are preserved (they need the ROM; refreshed locally).
+# data and land them in ONE commit (README bar + treemap + contributions.json +
+# langmode-baseline.json on main; chaos-db.json on the chaos-data branch), so the
+# hosted viewer and charts self-update without spamming the #github channel with a
+# commit per file. details/ chunks on the chaos-data branch are preserved (they need
+# the ROM; refreshed locally).
 name: update-chaos-data
 
 on:
@@ -11,10 +12,16 @@ on:
     paths:
       - "src/**"
       - "config/**"
+      - "include/**"
       - "nearmiss/**"
       - "tools/chaos_db_ci.py"
       - "tools/chaosviewer.config.json"
+      - "tools/langmode_audit.py"
       - "attribution.json"
+      # include/** and tools/langmode_audit.py are here for the langmode re-bank below,
+      # which reads both; neither feeds chaos-db. langmode-baseline.json itself is
+      # deliberately NOT watched -- this job writes it, and watching it would let the
+      # refresh commit retrigger the job on any run where [skip ci] is not honoured.
   workflow_dispatch:
 
 permissions:
@@ -100,6 +107,18 @@ jobs:
         # per (module, addr); the duplicate is transient, cleaned here on the way to the
         # refresh commit below (which already includes nearmiss/db.jsonl).
         run: python tools/nearmiss_db.py dedupe
+      - name: Re-bank the langmode ratchet
+        # The baseline is a generated counter file with no meaningful hand-merge, and
+        # every migration PR that lowered a count used to re-bank it by hand -- so each
+        # merge to main moved it under every other PR in flight, and they all conflicted.
+        # Banking it here instead takes it out of the PR diff entirely for the common
+        # (lowering) case. Safe in the only direction that matters: langmode_audit.py
+        # --check fails on a RISE only, so main carrying a stale-high baseline between a
+        # merge and this refresh is permissive, never falsely red. A PR that legitimately
+        # RAISES a count still banks it itself -- this step runs post-merge and so cannot
+        # be used to launder a rise past the gate.
+        run: python tools/langmode_audit.py --json langmode-baseline.json
+
       - name: Refresh README progress bar
         run: python tools/progress.py --write-readme --from-db _chaos_data/chaos-db.json
       - name: Regenerate treemap (README SVG + Pages HTML)
@@ -108,19 +127,21 @@ jobs:
         # README bar + treemap + contributions in ONE commit, to keep the #github channel
         # from filling with a separate refresh commit per generated file.
         # safe from retrigger loops: no workflow watches README.md, docs/**, or contributions.json
+        # on push, and langmode-baseline.json is watched only by langmode-ratchet.yml, which is
+        # pull_request-only. config/** is the one watched path here, which is what [skip ci] covers.
         run: |
-          if git diff --quiet -- README.md docs/index.html docs/progress-treemap.svg contributions.json config/match_provenance.jsonl config/match_attempts.jsonl nearmiss/db.jsonl; then
+          if git diff --quiet -- README.md docs/index.html docs/progress-treemap.svg contributions.json config/match_provenance.jsonl config/match_attempts.jsonl nearmiss/db.jsonl langmode-baseline.json; then
             echo "progress unchanged"; exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           base=$(git rev-parse HEAD)
-          git add README.md docs/index.html docs/progress-treemap.svg contributions.json config/match_provenance.jsonl config/match_attempts.jsonl nearmiss/db.jsonl
+          git add README.md docs/index.html docs/progress-treemap.svg contributions.json config/match_provenance.jsonl config/match_attempts.jsonl nearmiss/db.jsonl langmode-baseline.json
           # [skip ci] is load-bearing since the push moved to a deploy key. A GITHUB_TOKEN
           # push never triggers workflows, so this commit used to be inert; a deploy-key
           # push is an ordinary push and does trigger them. Without the marker this commit
           # would retrigger this job (it touches config/) and newly fire report.yml.
-          git commit -m "Refresh progress (README, treemap, contributions, provenance) [skip ci]"
+          git commit -m "Refresh progress (README, treemap, contributions, provenance, langmode) [skip ci]"
           # The rebase is not enough on its own: main can move again between it and the push.
           # A rejected push here leaves contributions.json unmoved, and per the coin ledger's
           # contract - it pays the DELTA between that file and what it last paid - a match whose
@@ -131,7 +152,7 @@ jobs:
             if git pull --rebase origin main && git push origin main; then exit 0; fi
             git rebase --abort 2>/dev/null || true
             git fetch -q origin main
-            if ! git diff --quiet "$base" FETCH_HEAD -- README.md docs/index.html docs/progress-treemap.svg contributions.json config/match_provenance.jsonl config/match_attempts.jsonl nearmiss/db.jsonl; then
+            if ! git diff --quiet "$base" FETCH_HEAD -- README.md docs/index.html docs/progress-treemap.svg contributions.json config/match_provenance.jsonl config/match_attempts.jsonl nearmiss/db.jsonl langmode-baseline.json; then
               echo "another refresh already landed these files - standing down"; exit 0
             fi
             echo "main moved under the refresh push - retrying (attempt $attempt)"

--- a/notes/plan-cpp-language-mode.md
+++ b/notes/plan-cpp-language-mode.md
@@ -143,8 +143,14 @@ gamed by renaming a `.c` to `.cpp` — a hand-spelled symbol counts however the 
 named. That property is the whole reason this phase came first: it makes the *easy* fake
 progress unrewarding, and it turns the reply to #821 into a number instead of an argument.
 
-`--check` is wired into CI as `.github/workflows/langmode-ratchet.yml`. Re-bank the
-baseline in any commit that legitimately lowers a count.
+`--check` is wired into CI as `.github/workflows/langmode-ratchet.yml`. **Do not re-bank a
+commit that lowers a count** — `update-chaos-data.yml` re-banks on merge to main. Hand-banking
+was the single largest source of PR conflicts on this workstream (four in one session): the
+baseline is a generated counter with no meaningful hand-merge, so every merge to main moved it
+under every other PR in flight. Leaving it alone is safe in the only direction that matters —
+`--check` fails on a *rise* only, so a stale-**high** baseline is permissive and no intermediate
+state can go falsely red. It is the same rule `.gitattributes` already states for
+`nearmiss/db.jsonl`: a merge never regresses a tip.
 
 **Two corrections to the paragraph above, both measured.**
 
@@ -171,6 +177,14 @@ exemption:
 CI checks a PR against the PR's own baseline, so this needs no tool change — the
 ratchet was never a wall, it is a tripwire that forces the increase to appear as a
 reviewable diff. What was missing was only the written rule.
+
+A rise is now the **only** case in which a PR touches `langmode-baseline.json` at all; a
+lowering slice leaves it to CI (above). The tripwire survives that change intact, because
+`update-chaos-data.yml` re-banks only *after* a merge, and `--check` has already run against
+the PR's own baseline by then — post-merge banking can record a rise, never launder one past
+the gate. The consequence for reviewers is a sharper signal, not a weaker one: a diff that
+touches the baseline is now, by itself, a claim that counts went **up**, and it must carry
+the naming evidence the rule demands.
 
 ### Phase 1 — SDK namespaces *(169 files, 37 namespaces) — zero layout risk*
 

--- a/tools/langmode_audit.py
+++ b/tools/langmode_audit.py
@@ -44,7 +44,12 @@ Usage:
     # CI ratchet: counts may fall, never rise. The baseline lives at the repo root
     # because progress/ is gitignored and CI needs a committed reference point. It holds
     # only the metrics --check reads, so re-banking it stays a small diff.
-    python tools/langmode_audit.py --json langmode-baseline.json    # re-bank after work
+    #
+    # Do NOT re-bank a slice that LOWERS counts: update-chaos-data.yml banks it on merge
+    # to main. Hand-banking made every migration PR conflict with every other one. Only a
+    # PR that RAISES a count banks it itself -- --check fails otherwise -- under the rule
+    # in notes/plan-cpp-language-mode.md (Phase 0).
+    python tools/langmode_audit.py --json langmode-baseline.json    # CI does this for you
     python tools/langmode_audit.py --check langmode-baseline.json   # exit 1 if worse
     python tools/langmode_audit.py --json out.json --full           # + per-class, lists
 """


### PR DESCRIPTION
## What this changes

`langmode-baseline.json` is a generated counter file with no meaningful hand-merge, and the rule was to re-bank it in any PR that lowered a count. So every merge to main re-banked it under every other PR in flight — **four PRs conflicted on this one file in a single session**, each blocking the others for no reviewable reason.

`update-chaos-data.yml` already regenerates derived files and lands them on main in one commit, with the deploy key that bypasses the PR ruleset, the retry/stand-down loop from #1204, and `[skip ci]`. Re-banking there is four lines of wiring, so the file leaves the PR diff entirely for the common case.

### Why this is safe

`langmode_audit.py --check` exits 1 on a count that **rose** and never on one that fell (`tools/langmode_audit.py:479`). A stale-**high** baseline is therefore permissive by construction:

- main, between a merge and the refresh, passes;
- an in-flight PR, measuring against its own older and higher numbers, passes too.

Nothing can go falsely red, and the ratchet tightens as soon as CI refreshes main. It is the same rule `.gitattributes` already states for `nearmiss/db.jsonl`: *a merge never regresses a tip.*

### The tripwire is untouched

A PR that **raises** a count still banks its own baseline, under the naming rule in `notes/plan-cpp-language-mode.md`. CI re-banks only *after* a merge, by which point `--check` has already run against the PR's own baseline — so post-merge banking can record a rise but never launder one past the gate.

Reviewers get a sharper signal out of it: a diff that touches the baseline is now, by itself, a claim that counts went up, and it must carry the naming evidence the rule demands.

### Considered and rejected: a `merge=ours` driver

Worth recording, since it looks like the obvious fix. It does not work:

- **Not built in.** Unlike `union`, `ours` is not one of git's built-in merge drivers — tested on 2.50.1, it conflicts anyway. It needs `git config merge.ours.driver true` in every clone, which `.gitattributes` cannot ship, so any contributor who never ran it keeps hitting the same conflict. The same adoption problem sinks a custom min-merge driver, which is otherwise the semantically correct merge for a monotone ratchet.
- **Wrong in substance.** It keeps the branch's baseline wholesale and discards the counts main lowered, loosening the ratchet's grip in main's area until someone regenerates.

## Verification

No functions matched, so no link gate applies. What was checked:

```
$ python -c "import yaml; ..."          # both workflows parse
YAML OK; watched paths: ['src/**', 'config/**', 'include/**', 'nearmiss/**',
  'tools/chaos_db_ci.py', 'tools/chaosviewer.config.json', 'tools/langmode_audit.py',
  'attribution.json']

$ python tools/langmode_audit.py --check langmode-baseline.json
langmode ratchet PASS

$ python tools/langmode_audit.py --json langmode-baseline.json && git diff --stat -- langmode-baseline.json
(empty)                                 # byte-identical on a clean main
```

That last one is the one that matters: regenerating the baseline on current main produces no diff, so the new step will not churn on the next merge.

## Note on watched paths

`include/**` and `tools/langmode_audit.py` join `update-chaos-data.yml`'s watched paths because the audit reads both. **Cost:** include-only PRs now trigger the full chaos-data job. `langmode-baseline.json` is deliberately *not* watched — this job writes it, and watching it would let the refresh commit retrigger the job on any run where `[skip ci]` is not honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJfu9yyd4wyACnfB1jHCAi
