### PR TITLE
headers: sweep every __cplusplus block through the compiler, and fix the last defect

### DIFF
--- a/include/Scene.h
+++ b/include/Scene.h
@@ -1,19 +1,45 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class Scene: 12 matched functions, 1 evidenced fields.
+/* Hand-edited, against evidence. This file used to carry the
+ * "AUTO-GENERATED ... by tools/gen_header.py" banner, which stopped being true the
+ * moment the __cplusplus block was corrected -- see
+ * notes/runbook-type-reconstruction.md section 2.
+ *
+ * class Scene: 12 matched functions, 1 evidenced field.
  * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
+ * Field NAMES are placeholders - renaming cannot change codegen.
+ *
+ * THE __cplusplus BLOCK BELOW HAD NEVER BEEN COMPILED. It declared
+ *     Bool BeforeInitResources();
+ * and `Bool` is defined nowhere in the tree. The generator lifted the return type
+ * verbatim out of src/_ZN5Scene19BeforeInitResourcesEv.c, which opens with its own
+ * file-local `typedef int Bool;` -- a spelling that exists only inside that one file.
+ * Scene.h is included by two .c files and no .cpp, so the block was always skipped and
+ * the undefined type sat there unnoticed.
+ *
+ * Corrected to `int`, which is exactly what that typedef resolves to, so the meaning
+ * is unchanged. NOT to `bool`: types.h defines `typedef int bool;` only `#ifndef
+ * __cplusplus`, so `bool` is 4 bytes in C and the 1-byte keyword in C++, and using it
+ * here would make the declaration mean two different things depending on the includer.
+ *
+ * Found by sweeping every header through the pinned compiler as C and as C++ (a header
+ * that fails as C++ but passes as C has a broken __cplusplus block). This was the last
+ * of three; the other two were ExpandingHeapAllocator.h's `forwards void* Allocate(...)`
+ * (#1211) and SolidHeapAllocator.h's `call ResetEnd void Reset(...)`. All three are the
+ * same root cause -- the generator copied a token out of a source file without checking
+ * it names anything visible from the header -- in three different disguises: a spilled
+ * parameter-name fragment, scraped comment text, and a file-local typedef.
+ *
+ * The generator also emitted `struct x;` -- a parameter name mistaken for a type name.
+ * No source ever referenced it; dropped. */
 #ifndef SCENE_H
 #define SCENE_H
 #include "types.h"
 
-/* fwd */
-struct x;
 struct Scene {
     u8  pad_000[0x13];
     u8  unk_013;            /* 0x013 */
 #ifdef __cplusplus
     /* methods */
-    Bool BeforeInitResources();
+    int BeforeInitResources();   /* 0 on failure, 1 on success */
     int BeforeRender();
 #endif
 };

--- a/notes/runbook-type-reconstruction.md
+++ b/notes/runbook-type-reconstruction.md
@@ -126,6 +126,39 @@ broken one**, which is the opposite of the intuition that narrowing is conservat
 Rule: **rename freely, treat every retype as codegen-affecting until measured, and
 byte-verify.**
 
+### The `#ifdef __cplusplus` block is dead text until something includes it from C++
+
+A generated header's method block is only parsed when a `.cpp` file includes it. Most
+headers are included exclusively by `.c` files, so for those the block is text nothing
+has ever compiled -- and `gen_header.py` put things in it that are not C++ at all.
+Three existed; all three are the same root cause -- *a token copied out of a source file
+without checking it names anything visible from the header* -- in three disguises:
+
+| header | declared | where the token came from |
+|---|---|---|
+| `ExpandingHeapAllocator.h` | `forwards void* Allocate(u32, int);` | a fragment of the parameter name spilled into the return type (#1211) |
+| `SolidHeapAllocator.h` | `call ResetEnd void Reset(u32);` | scraped out of the comment on `Reset`'s body, *"bit 0: call ResetStart; bit 1: call ResetEnd"* (#1215) |
+| `Scene.h` | `Bool BeforeInitResources();` | a `typedef int Bool;` that is file-local to `src/_ZN5Scene19BeforeInitResourcesEv.c` (#1215) |
+
+**No gate found any of them.** Each surfaced by migrating a method, which compiles the
+block for the first time -- one slice per defect. `tools/header_cpp_sweep.py` finds them
+all in about a minute: it compiles every header standalone **as C and as C++**, because
+that pair is what separates a broken block from a header that merely needs other headers
+first (`fails C++, passes C` is the defect; `fails both` is not). Run it after any
+`gen_header.py` change, and before starting a slice on a class whose header no `.cpp`
+has ever included.
+
+Swept clean at 382 headers, 292 of which carry a block. **Expect the count to stay 0 --
+if it rises, a generator regressed.**
+
+What the sweep does *not* catch: a declaration that compiles both ways but **means**
+different things. `types.h` defines `typedef int bool;` under `#ifndef __cplusplus`, so
+`bool` is 4 bytes in C and the 1-byte keyword in C++. Four headers declare `bool`
+returns inside their block (`Animation.h`, `ExpandingHeap.h`, `Heap.h`, `SolidHeap.h`);
+all four are already included by `.cpp` files without incident, so it is latent, and
+`build_pin.verify` would reject the byte mismatch if a migration ever leaned on it.
+Prefer `int` when correcting a block -- that is what the C spelling already resolved to.
+
 ### "Until measured": the A/B, and what it does not prove
 
 "Until measured" is not a softening. Some retypes are *byte-unobservable*: if every

--- a/tools/header_cpp_sweep.py
+++ b/tools/header_cpp_sweep.py
@@ -1,0 +1,173 @@
+"""Compile every include/*.h standalone, as C and as C++, and report broken blocks.
+
+## The defect this exists to catch
+
+A generated header's `#ifdef __cplusplus` block is only compiled when some `.cpp` file
+includes it. Most headers are included exclusively by `.c` files, so for those the block
+is dead text that nothing has ever parsed -- and the generator has put things in it that
+are not C++ at all. Three found so far, all from `tools/gen_header.py`, all the same root
+cause (a token copied out of a source file without checking it names anything visible
+from the header) wearing three different disguises:
+
+    ExpandingHeapAllocator.h   forwards void* Allocate(unsigned int, int);
+                               ^ a fragment of the parameter name `forwards` spilled
+                                 into the return type                        (#1211)
+
+    SolidHeapAllocator.h       call ResetEnd void Reset(unsigned int);
+                               ^ scraped out of the comment on Reset's body,
+                                 "bit 0: call ResetStart; bit 1: call ResetEnd"
+
+    Scene.h                    Bool BeforeInitResources();
+                               ^ lifted from a `typedef int Bool;` that is file-local
+                                 to src/_ZN5Scene19BeforeInitResourcesEv.c
+
+None was found by a gate. Each was found by migrating a method, which compiles the block
+for the first time -- so the cost of finding them was one slice each. This tool finds
+them all at once, in about a minute, without touching a single source file.
+
+## Why it compiles BOTH ways
+
+Compiling as C++ alone cannot tell a broken block from a header that simply needs other
+headers included first. The pair does:
+
+    fails C++, passes C   -> the __cplusplus block is broken        <- the defect
+    fails both            -> needs other headers first; not this
+    passes both           -> clean
+
+Flags mirror `rombuild.compile_one` exactly -- same CFLAGS, the same `-lang c++` swap
+keyed off the source suffix, the same `-i include` and LM_LICENSE_FILE. A sweep compiled
+differently from the build would prove nothing about the build.
+
+## What this does NOT catch
+
+A declaration that compiles both ways but MEANS different things. `types.h` has
+`typedef int bool;` under `#ifndef __cplusplus`, so a header declaring `bool Foo();` is
+4 bytes wide in C and the 1-byte keyword in C++. Four headers do that today
+(Animation.h, ExpandingHeap.h, Heap.h, SolidHeap.h) and all four are already included by
+.cpp files without incident, so it is latent rather than live -- and `build_pin.verify`
+would reject the byte mismatch if a migration ever leaned on it. Recorded here because
+this is the natural place to look for it, not because it is currently wrong.
+
+Usage:
+    python tools/header_cpp_sweep.py            # report
+    python tools/header_cpp_sweep.py --check    # exit 1 if any header is defective
+    python tools/header_cpp_sweep.py --json out.json
+"""
+import argparse
+import concurrent.futures
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+from rombuild import CFLAGS, INCLUDE, LICENSE, MW, VERSION, launcher  # noqa: E402
+
+EXE = MW / VERSION / "mwccarm.exe"
+
+BANNERS = [
+    ("gen_header.py",   re.compile(r"AUTO-GENERATED.*gen_header\.py", re.S)),
+    ("deepen_rtti.py",  re.compile(r"AUTO-GENERATED.*deepen_rtti\.py", re.S)),
+    ("decl_headers.py", re.compile(r"AUTO-GENERATED.*decl_headers\.py", re.S)),
+    ("hand-edited",     re.compile(r"Hand-edited, against evidence")),
+]
+
+
+def banner_of(text):
+    head = text[:1200]
+    for name, pat in BANNERS:
+        if pat.search(head):
+            return name
+    return "(none)"
+
+
+def _compile(hdr, cpp):
+    """Compile a one-line TU that includes `hdr`. Returns (ok, first error line)."""
+    flags = CFLAGS.replace("-lang c99", "-lang c++") if cpp else CFLAGS
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td) / ("probe.cpp" if cpp else "probe.c")
+        src.write_text('#include "%s"\n' % hdr.name, encoding="utf-8")
+        obj = pathlib.Path(td) / "probe.o"
+        cmd = [*launcher(), str(EXE), *flags.split(),
+               "-i", str(INCLUDE), "-c", str(src), "-o", str(obj)]
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           env=dict(os.environ, LM_LICENSE_FILE=str(LICENSE)), cwd=td)
+        if r.returncode == 0 and obj.is_file():
+            return True, ""
+        out = [ln.strip() for ln in (r.stdout + r.stderr).splitlines() if ln.strip()]
+        # mwccarm prints "<file>:<line>: <message>" then "Errors caused tool to abort."
+        # The first line carrying a colon-line-number is the useful one.
+        for ln in out:
+            if re.search(r"\.h:\d+:", ln):
+                return False, ln
+        return False, (out[0] if out else "?")
+
+
+def probe(hdr):
+    text = hdr.read_text(encoding="utf-8", errors="ignore")
+    ok_c, err_c = _compile(hdr, cpp=False)
+    ok_cpp, err_cpp = _compile(hdr, cpp=True)
+    return {"name": hdr.name, "banner": banner_of(text),
+            "has_cpp_block": "#ifdef __cplusplus" in text,
+            "ok_c": ok_c, "err_c": err_c, "ok_cpp": ok_cpp, "err_cpp": err_cpp}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if any header's __cplusplus block is broken")
+    ap.add_argument("--json", metavar="PATH", help="write the full per-header table")
+    args = ap.parse_args()
+
+    if not EXE.is_file():
+        # Fail closed and say so: a sweep that silently skips is worse than none.
+        print("toolchain not installed (%s) -- nothing swept" % EXE, file=sys.stderr)
+        return 2
+
+    hdrs = sorted((REPO / "include").glob("*.h"))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
+        rows = list(ex.map(probe, hdrs))
+
+    defect = [r for r in rows if not r["ok_cpp"] and r["ok_c"]]
+    both = [r for r in rows if not r["ok_cpp"] and not r["ok_c"]]
+
+    print("headers swept: %d  (compiler %s)" % (len(rows), VERSION))
+    print("  clean as C++                 : %d" % (len(rows) - len(defect) - len(both)))
+    print("  FAIL C++ but PASS C          : %d   <-- __cplusplus block defect" % len(defect))
+    print("  fail both (needs other hdrs) : %d   -- not this defect" % len(both))
+
+    withblk = [r for r in rows if r["has_cpp_block"]]
+    print("\nheaders carrying a __cplusplus block: %d" % len(withblk))
+    pop = {}
+    for r in withblk:
+        pop.setdefault(r["banner"], [0, 0])
+        pop[r["banner"]][0] += 1
+        if not r["ok_cpp"] and r["ok_c"]:
+            pop[r["banner"]][1] += 1
+    for b in sorted(pop, key=lambda k: -pop[k][0]):
+        tot, bad = pop[b]
+        print("  %-16s %3d with block, %3d defective" % (b, tot, bad))
+
+    if defect:
+        print("\nDEFECTIVE -- the __cplusplus block does not compile:")
+        for r in sorted(defect, key=lambda r: r["name"]):
+            print("  %-34s %-15s %s" % (r["name"], r["banner"], r["err_cpp"][:90]))
+
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(rows, indent=1))
+        print("\nwrote %s" % args.json)
+
+    if args.check and defect:
+        print("\nheader-cpp-sweep: FAIL (%d defective)" % len(defect), file=sys.stderr)
+        return 1
+    print("\nheader-cpp-sweep: %s" % ("PASS" if not defect else "reported"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`ExpandingHeapAllocator.h` (#1211) and `SolidHeapAllocator.h` (#1215) each turned out to
carry an `#ifdef __cplusplus` block that **had never been compiled**, one slice apart.
That is a detection problem, not two pieces of bad luck: the block is only parsed when a
`.cpp` includes the header, most headers are included exclusively by `.c` files, and
nothing else ever looks. Both were found by migrating a method — the most expensive
possible way to find them.

## The sweep

`tools/header_cpp_sweep.py` compiles every `include/*.h` standalone, **as C and as C++**,
with `rombuild`'s own flags. The pair is the whole point — compiling as C++ alone cannot
tell a broken block from a header that simply needs other headers included first:

```
fails C++, passes C   ->  the __cplusplus block is broken   <- the defect
fails both            ->  needs other headers; not this
passes both           ->  clean
```

**382 headers swept, 292 carrying a block. Exactly three have ever been defective** — all
from `gen_header.py`, all the same root cause (*a token copied out of a source file
without checking it names anything visible from the header*) in three disguises:

| header | declared | where the token came from |
|---|---|---|
| `ExpandingHeapAllocator.h` | `forwards void* Allocate(u32, int);` | a fragment of the parameter name spilled into the return type — fixed #1211 |
| `SolidHeapAllocator.h` | `call ResetEnd void Reset(u32);` | scraped out of the comment on `Reset`'s body, *"bit 0: call ResetStart; bit 1: call ResetEnd"* — fixed #1215 |
| `Scene.h` | `Bool BeforeInitResources();` | a `typedef int Bool;` **file-local** to `src/_ZN5Scene19BeforeInitResourcesEv.c` — fixed here |

So the tree is now clean, and this is the tool that keeps it that way. `--check` exits 1
on any defect; it is green at 382/382.

## Scene.h

`Bool` is defined nowhere in the tree. `Scene.h` is included by two `.c` files and no
`.cpp`, which is exactly why it survived.

Corrected to `int` — precisely what that file-local typedef resolves to, so the meaning is
unchanged. Deliberately **not** `bool`: `types.h` defines `typedef int bool;` only
`#ifndef __cplusplus`, which would make the declaration 4 bytes wide in C and the 1-byte
keyword in C++.

## The sweep is controlled, not trusted

A sweep reporting "1 defect" means nothing unless it can detect the known ones. Checking
out the pre-fix `ExpandingHeapAllocator.h` and `SolidHeapAllocator.h`:

```
_ctrl_expheap.h       C=True  C++=False   DETECTED as defective
_ctrl_solidheap.h     C=True  C++=False   DETECTED as defective
ExpandingHeapAllocator.h  C=True  C++=True   clean
SolidHeapAllocator.h      C=True  C++=True   clean
```

## What it does NOT catch

A declaration that compiles both ways but **means** different things. Four headers
(`Animation.h`, `ExpandingHeap.h`, `Heap.h`, `SolidHeap.h`) declare `bool` returns inside
their blocks, which is 4 bytes in C and 1 byte in C++. All four are already included by
`.cpp` files without incident, so it is latent rather than live, and `build_pin.verify`
would reject the byte mismatch if a migration ever leaned on it. Recorded in the runbook
rather than churned.

## Gates

| gate | result |
|---|---|
| `header_cpp_sweep --check` | **382/382 clean**, exit 0 |
| `rombuild` | **106/106 exact**, 10,699 reproducing / 0 mismatching |
| `eligible` | 10699 — unchanged |
| `check_references` | 235 unresolved (baseline 235), 0 new |
| `port_refcheck` | 394 checked, 0 stale |
| attribution | 0 changed, 0 lost |

Recorded in `notes/runbook-type-reconstruction.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154eg3RhXQYPyfKyv5t81Fz