### PR TITLE
OamAttr: one 8-byte type for eleven files, and retire the `OamAttri` misspelling

### DIFF
--- a/include/OAM.h
+++ b/include/OAM.h
@@ -16,21 +16,22 @@
  * (+0x14) on all 25 sweep versions at every optimisation level. Those stay
  * extern "C" free functions -- runbook section 7.
  *
- * OamAttr is FORWARD-DECLARED ONLY, deliberately. The tree holds three mutually
- * incompatible spellings of that 8-byte type, and an attempt to centralise it in
- * include/OamAttr.h broke the ROM build:
+ * OamAttr now lives in include/OamAttr.h -- eleven files that each carried their own
+ * copy of the 4 x u16 layout share it, and the `OamAttri` misspelling is retired. See
+ * that header for the field evidence and for why it is deliberately dependency-free.
  *
- *   _ZN3OAM9RenderSub*                4 x u16, unnamed roles
- *   _ZN3OAM16LoadAffineParams*        `unsigned short a, b, c, param` -- names the
- *                                     4th word, which is the affine parameter
- *   _ZN3OAM6Render*P9Matrix2x2        two u32 words decomposed into bitfields
- *                                     (yb, objMode, mode, mosaic, shape, tile...)
+ * THIS HEADER STILL FORWARD-DECLARES IT RATHER THAN INCLUDING IT, and that is load
+ * bearing, not leftover. Two files need bit-level access to the same eight bytes and
+ * keep their own local decompositions:
  *
- * All three agree on the size and disagree on everything else, and each is the view
- * its own function needs. Reconciling them is real work -- one type, one set of
- * field names, every user re-verified -- and it is not a language-mode migration.
- * A pointer parameter needs only the forward declaration, so the methods below can
- * be declared without picking a winner. */
+ *   _ZN3OAM6Render*P9Matrix2x2                bitfields (yb, objMode, mode, mosaic,
+ *                                             shape, xc, aff, size / tile, prio, pal)
+ *   _ZN3OAM6Render*5Fix12IiES3_ii             `u32 a01; u16 a2; u16 a3;`
+ *
+ * The first of those includes THIS header, so if OAM.h pulled in OamAttr.h it would
+ * collide with that file's own definition. A pointer parameter needs only the forward
+ * declaration, so every method below can be declared without forcing a view on anyone;
+ * the 68 files that merely pass an OamAttr* around never need the definition at all. */
 #ifndef OAM_H
 #define OAM_H
 #include "types.h"

--- a/include/OamAttr.h
+++ b/include/OamAttr.h
@@ -1,0 +1,61 @@
+/* Hand-written, from usage evidence. Not generated.
+ *
+ * One OAM sprite attribute entry: four 16-bit words, 8 bytes total.
+ *
+ * DELIBERATELY DEPENDENCY-FREE -- no #include, and `unsigned short` rather than `u16`.
+ * That is not a style choice, it is what makes this header includable everywhere. Five
+ * of the files that need it carry their own `typedef int s32;` / `typedef int Fix12i;`
+ * at file scope, and duplicating a typedef is an error under `-lang c99`, so pulling in
+ * types.h here would break them. An earlier attempt at a shared OamAttr header did
+ * exactly that and broke the ROM build; this is the fix. `u16` IS `unsigned short`, so
+ * the type is identical either way.
+ *
+ * WHY THE NAME MATTERS. Five files used to spell this type `OamAttri`, which does not
+ * exist. It is a mis-parse of the mangled parameter list: `P7OamAttrii` is pointer to a
+ * SEVEN-character class `OamAttr` followed by two ints, and the first `i` was read as
+ * part of the type name. That was harmless only because those files hand-spell their
+ * symbol and the struct tag never reaches the mangler -- the moment one is migrated to
+ * a real C++ method, `OamAttri` mangles to `P8OamAttri...` and the function vanishes
+ * from the object. build_pin.verify would not catch it: a call is a relocation and
+ * match.compare wildcards every relocated word.
+ *
+ * Renaming the type is inert for codegen -- a struct tag cannot change layout -- but
+ * every file was byte-verified under the pinned compiler anyway.
+ *
+ * FIELD EVIDENCE. attr0/attr1/attr2 are the DS hardware attribute words. attr3 carries
+ * two distinct roles depending on which buffer the entry lives in, and both are in the
+ * tree:
+ *
+ *   - In the hardware OAM buffer it is one coefficient of an affine matrix. The four
+ *     coefficients are interleaved across four CONSECUTIVE entries, which is why
+ *     OAM::LoadAffineParams strides `i += 4` and touches only this field, comparing
+ *     e[0..3].attr3 against the four words of a Matrix2x2.
+ *
+ *   - In the sprite-template lists that Render and the ov075 helpers walk, 0xffff in
+ *     this field terminates the list (`if (attr->attr3 == 0xffff) return;`).
+ *
+ * TWO FILES DELIBERATELY DO NOT USE THIS TYPE, and both are correct to opt out. They
+ * need bit-level access to the same 8 bytes and decompose them differently:
+ *
+ *   _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2.c   bitfields (yb, objMode, mode, mosaic,
+ *                                                shape, xc, aff, size / tile, prio,
+ *                                                pal, hi2) -- matching, enrolled
+ *   _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii  `u32 a01; u16 a2; u16 a3;` -- the
+ *                                                32-bit view its bit extraction needs.
+ *                                                NONMATCHING at the terminal compiler
+ *                                                floor with tuned pragmas; not enrolled.
+ *
+ * All three views agree on the size and on the field boundaries they share. Folding
+ * them into one declaration would mean rewriting every bit access in two fragile
+ * functions to buy nothing, so they keep local definitions and say why. */
+#ifndef OAMATTR_H
+#define OAMATTR_H
+
+struct OamAttr {
+    unsigned short attr0;   /* 0x0 */
+    unsigned short attr1;   /* 0x2 */
+    unsigned short attr2;   /* 0x4 */
+    unsigned short attr3;   /* 0x6 -- affine coefficient, or 0xffff list terminator */
+};
+
+#endif

--- a/src/_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2.c
+++ b/src/_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2.c
@@ -1,7 +1,16 @@
 // @symbol _ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2
 /* recovered: named members + shared header */
 #include "OAM.h"
-struct OamAttr { unsigned short a, b, c, param; };
+#include "OamAttr.h"
+
+/* This file used to carry its own `struct OamAttr { unsigned short a, b, c, param; };`
+ * -- the same eight bytes as every other view, under different field names. `param` is
+ * the shared type's `attr3`.
+ *
+ * The stride of 4 is not arbitrary: an affine matrix's four coefficients are stored one
+ * per OAM entry, interleaved across four CONSECUTIVE entries, which is exactly why this
+ * function only ever touches that one field. It is also the evidence that fixes attr3's
+ * role in include/OamAttr.h. */
 
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
@@ -16,18 +25,18 @@ int _ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2(struct OamAttr *oam, int *c
 
     for (i = 0; i < n; i += 4) {
         struct OamAttr *e = &oam[i];
-        if (k0 == e[0].param && k1 == e[1].param &&
-            k2 == e[2].param && k3 == e[3].param)
+        if (k0 == e[0].attr3 && k1 == e[1].attr3 &&
+            k2 == e[2].attr3 && k3 == e[3].attr3)
             return i >> 2;
     }
     if (n >= 0x80)
         return -1;
     {
         struct OamAttr *e = &oam[n];
-        e[0].param = m[0] >> 4;
-        e[1].param = m[1] >> 4;
-        e[2].param = m[2] >> 4;
-        e[3].param = m[3] >> 4;
+        e[0].attr3 = m[0] >> 4;
+        e[1].attr3 = m[1] >> 4;
+        e[2].attr3 = m[2] >> 4;
+        e[3].attr3 = m[3] >> 4;
     }
     {
         int t = *count;

--- a/src/_ZN3OAM9RenderSubEP7OamAttrii.cpp
+++ b/src/_ZN3OAM9RenderSubEP7OamAttrii.cpp
@@ -2,14 +2,7 @@
 // @symbol _ZN3OAM9RenderSubEP7OamAttrii
 #include "OAM.h"
 
-/* NOTE ON THE LOCAL DEFINITION BELOW.
- * It stays, against plan section 6's "no local struct body" rule, and OAM.h
- * forward-declares OamAttr rather than defining it. Centralising the type was tried
- * and reverted: the tree holds three incompatible spellings of this 8-byte type --
- * this one, LoadAffineParams' `a, b, c, param`, and Render's bitfield decomposition
- * -- and a shared include/OamAttr.h broke the ROM build on the other two.
- * Reconciling them is its own change. See include/OAM.h. */
-struct OamAttr { u16 attr0, attr1, attr2, attr3; };
+#include "OamAttr.h"
 
 /* OAM::RenderSub(OamAttr* data, s32 x, s32 y) at 0x0202194c -- static, no `this`.
  *

--- a/src/_ZN3OAM9RenderSubEP7OamAttriiii.cpp
+++ b/src/_ZN3OAM9RenderSubEP7OamAttriiii.cpp
@@ -2,14 +2,7 @@
 // @symbol _ZN3OAM9RenderSubEP7OamAttriiii
 #include "OAM.h"
 
-/* NOTE ON THE LOCAL DEFINITION BELOW.
- * It stays, against plan section 6's "no local struct body" rule, and OAM.h
- * forward-declares OamAttr rather than defining it. Centralising the type was tried
- * and reverted: the tree holds three incompatible spellings of this 8-byte type --
- * this one, LoadAffineParams' `a, b, c, param`, and Render's bitfield decomposition
- * -- and a shared include/OamAttr.h broke the ROM build on the other two.
- * Reconciling them is its own change. See include/OAM.h. */
-struct OamAttr { u16 attr0, attr1, attr2, attr3; };
+#include "OamAttr.h"
 
 /* OAM::RenderSub(OamAttr* data, s32 x, s32 y, s32 palette, s32 priority)
  * at 0x0202199c -- static, no `this`.

--- a/src/func_0203083c.c
+++ b/src/func_0203083c.c
@@ -1,5 +1,5 @@
 /* func_0203083c at 0x0203083c, size=0x6c
- * If data_0209fc68 is non-null, looks up an OamAttri* in a table indexed by
+ * If data_0209fc68 is non-null, looks up an OamAttr* in a table indexed by
  * func_0203d9f4(), then calls OAM::Render(false, oam, 8, 0xb8, ...).
  * Always calls empty stub func_02030838 at end.
  */
@@ -8,16 +8,16 @@ typedef int s32;
 typedef int Fix12i;
 typedef int bool32;
 
-struct OamAttri { unsigned short attr0, attr1, attr2, attr3; };
+#include "OamAttr.h"
 
 extern void *data_0209fc68;             /* 0x0209fc68: global pointer, checked for non-null */
-extern struct OamAttri *data_020927a0[];  /* 0x020927a0: table of OamAttri* */
+extern struct OamAttr *data_020927a0[];  /* 0x020927a0: table of OamAttr* */
 
 extern s32 func_0203d9f4(void);    /* 0x0203d9f4 */
 extern void func_02030838(void);   /* 0x02030838 (empty stub, bx lr) */
 
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-    bool32 sub, struct OamAttri *data,
+    bool32 sub, struct OamAttr *data,
     s32 x, s32 y,
     s32 palette, s32 priority,
     Fix12i scaleX, Fix12i scaleY,
@@ -26,7 +26,7 @@ extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
 void func_0203083c(void)
 {
     if (data_0209fc68 != 0) {
-        struct OamAttri *oam = data_020927a0[func_0203d9f4()];
+        struct OamAttr *oam = data_020927a0[func_0203d9f4()];
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
             0, oam,
             8, 0xb8,

--- a/src/func_ov003_020b0814.cpp
+++ b/src/func_ov003_020b0814.cpp
@@ -9,10 +9,10 @@ extern "C" {
 typedef int s32;
 typedef int Fix12i;
 typedef int bool32;
-struct OamAttri { unsigned short attr0, attr1, attr2, attr3; };
-extern struct OamAttri *data_ov003_020b1824[];
+#include "OamAttr.h"
+extern struct OamAttr *data_ov003_020b1824[];
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-    bool32 sub, struct OamAttri *data, s32 x, s32 y,
+    bool32 sub, struct OamAttr *data, s32 x, s32 y,
     s32 palette, s32 priority, Fix12i scaleX, Fix12i scaleY,
     s32 rotation, s32 mode);
 int func_ov003_020b0814(char *c);

--- a/src/func_ov006_0210ddf0.c
+++ b/src/func_ov006_0210ddf0.c
@@ -1,15 +1,15 @@
 typedef int s32;
 typedef int Fix12i;
 
-struct OamAttri { unsigned short attr0, attr1, attr2, attr3; };
+#include "OamAttr.h"
 
 extern void *data_ov006_02137994[];
-extern struct OamAttri *data_ov006_02137684[];
+extern struct OamAttr *data_ov006_02137684[];
 
 extern void func_ov004_020afdd0(void *a0, int a1, int a2, int a3, int a4);
 
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-    int sub, struct OamAttri *data,
+    int sub, struct OamAttr *data,
     s32 x, s32 y,
     s32 palette, s32 priority,
     Fix12i scaleX, Fix12i scaleY,

--- a/src/func_ov006_0211d7ec.c
+++ b/src/func_ov006_0211d7ec.c
@@ -1,12 +1,12 @@
 typedef int s32;
 typedef int Fix12i;
 
-struct OamAttri { unsigned short attr0, attr1, attr2, attr3; };
+#include "OamAttr.h"
 
-extern struct OamAttri *data_ov006_0213a628[];
+extern struct OamAttr *data_ov006_0213a628[];
 
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-    int sub, struct OamAttri *data,
+    int sub, struct OamAttr *data,
     s32 x, s32 y,
     s32 palette, s32 priority,
     Fix12i scaleX, Fix12i scaleY,

--- a/src/func_ov075_021184b0.c
+++ b/src/func_ov075_021184b0.c
@@ -1,6 +1,6 @@
 //cpp
 #include "types.h"
-struct OamAttr { unsigned short attr0, attr1, attr2, attr3; };
+#include "OamAttr.h"
 extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, OamAttr*, int, int, int, int, int, int, int, int);
 extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(int, OamAttr*, int, int, int, int, int, int);
 extern "C" int func_0203da9c(void);

--- a/src/func_ov075_02118cd0.c
+++ b/src/func_ov075_02118cd0.c
@@ -2,16 +2,16 @@ typedef int s32;
 typedef int Fix12i;
 typedef int bool32;
 
-struct OamAttri { unsigned short attr0, attr1, attr2, attr3; };
+#include "OamAttr.h"
 
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-    bool32 sub, struct OamAttri *data,
+    bool32 sub, struct OamAttr *data,
     s32 x, s32 y,
     s32 palette, s32 priority,
     Fix12i scaleX, Fix12i scaleY,
     s32 rotation, s32 mode);
 
-extern struct OamAttri data_ov075_0211cba4[];
+extern struct OamAttr data_ov075_0211cba4[];
 
 void func_ov075_02118cd0(void)
 {

--- a/src/func_ov075_021194e4.cpp
+++ b/src/func_ov075_021194e4.cpp
@@ -1,9 +1,7 @@
 //cpp
 typedef int Fix12;
 
-struct OamAttr {
-    unsigned short attr0, attr1, attr2, attr3;
-};
+#include "OamAttr.h"
 
 struct OAM {
     static int Render(bool, OamAttr*, int, int, int, int, Fix12, int);

--- a/src/func_ov075_021199d8.cpp
+++ b/src/func_ov075_021199d8.cpp
@@ -1,9 +1,7 @@
 //cpp
 typedef int Fix12;
 
-struct OamAttr {
-    unsigned short attr0, attr1, attr2, attr3;
-};
+#include "OamAttr.h"
 
 struct OAM {
     static int Render(bool, OamAttr*, int, int, int, int, Fix12, int);


### PR DESCRIPTION
`include/OAM.h` forward-declared `OamAttr` and recorded that centralising it had been
tried and reverted, because *"the tree holds three incompatible spellings"*. That was
true but undercounted, and the diagnosis was wrong.

## What is actually there

**Thirteen** files define a struct of this shape, not three. **Eleven are the same 8-byte
layout** — four `u16` — differing only in field names and in whether the tag was spelled
`OamAttr` or `OamAttri`. The original survey missed five of them because it searched for
`struct OamAttr {` and they read `struct OamAttri {`.

Only **two** hold a genuinely different view, and both keep it.

## `OamAttri` is not a type

It is a mis-parse of the mangled parameter list. `P7OamAttrii` is *pointer to a
**seven**-character class* followed by two ints — the leading `i` of those ints was read
as part of the name. Five files carried it.

It was harmless only because each hand-spells its symbol, so the tag never reaches the
mangler. Migrate any one of them to a real C++ method and `OamAttri` mangles to
`P8OamAttri...`, the function vanishes from the object — **and `build_pin.verify` still
passes**, because a call is a relocation and `match.compare` wildcards every relocated
word. This is a latent migration-blocker retired before it fires.

## Why the earlier attempt broke the build

Five of these files carry their own `typedef int s32;` / `typedef int Fix12i;` at file
scope. Duplicating a typedef is an error under `-lang c99`, so any shared header that
pulled in `types.h` could never compile in them.

`include/OamAttr.h` is therefore **dependency-free**: no `#include`, and `unsigned short`
spelled out rather than `u16`. Identical type, no collision.

`OAM.h` still forward-declares rather than including, and that is now load-bearing:
`_ZN3OAM6Render*P9Matrix2x2` includes `OAM.h` **and** defines its own bitfield view, so
pulling `OamAttr.h` in there would collide. The 68 files that only pass an `OamAttr*`
around go on needing nothing.

## The two local views are correct to stay

Both need bit-level access to the same eight bytes:

| file | view | status |
|---|---|---|
| `_ZN3OAM6Render*P9Matrix2x2` | bitfields (`yb, objMode, mode, mosaic, shape, xc, aff, size` / `tile, prio, pal, hi2`) | matching, enrolled |
| `_ZN3OAM6Render*5Fix12IiES3_ii` | `u32 a01; u16 a2; u16 a3;` for shift-and-mask extraction | **NONMATCHING at the terminal compiler floor**, tuned pragmas, not enrolled |

Rewriting either to four `u16` fields means rewriting every bit access in a fragile
function to buy nothing.

## Field evidence

`attr3`'s role is read off `LoadAffineParams`, which strides `i += 4` and touches only
that field: an affine matrix's four coefficients are interleaved one per entry across
four consecutive OAM entries. In the sprite-template lists the same field is the `0xffff`
terminator. Both roles are documented on the field.

## The rename was guarded, not trusted

A blanket `OamAttri` → `OamAttr` corrupts `OamAttriiii` to `OamAttriii` — that mistake has
already been made in this tree, and the byte gate cannot see it. So the rewrite asserts
the mangled-symbol count is identical before and after **each file**, and aborts without
writing otherwise.

Verified — every mangled bucket unchanged:

```
OamAttriiii   238 -> 238      OamAttrii     24 -> 24
OamAttriiiiP  115 -> 115      OamAttrPiP     6 -> 6
OamAttriii      1 -> 1        OamAttri      25 -> 7 (comments only)
```

## Gates

| gate | result |
|---|---|
| `build_pin.verify` @ `2004/b56` | **11/11** |
| `rombuild` | **106/106 exact**, 10,699 reproducing / 0 mismatching |
| `eligible` | 10699 — unchanged |
| `check_references` | 235 unresolved (baseline 235), 0 new |
| `port_refcheck` | 394 checked, 0 stale |
| `langmode_audit --check` | PASS — `local_struct_body` **2652 → 2643** |
| attribution | 0 changed, 0 lost |

Nine of the eleven files are now free of local struct bodies; the two `ov075` ones still
count because they carry an unrelated `struct OAM` and `struct S4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154eg3RhXQYPyfKyv5t81Fz