### PR TITLE
func_0201d850: one declaration, settled on the definition rather than on the bytes

### DIFF
--- a/include/Message.h
+++ b/include/Message.h
@@ -35,11 +35,16 @@ struct Message {
     /* The rest of the display entry points. `Et` is u16, `Eth` is (u16, u8),
        `Ej` is u32 -- all read off the mangled name.
 
-       NOTE the disagreement this exposes: DisplayLevelClearText passes its course
-       to func_0201d850 declared `signed char`, while DisplayPauseText declares the
-       same function `unsigned char`. One function, two signatures, which is the
-       declaration debt notes/declaration-centralization.md measures at 27%. Both
-       reproduce, because the byte gate cannot see it. Not settled here. */
+       The func_0201d850 disagreement this used to record is SETTLED. Both callers
+       declared that one function locally and differently -- `signed char` here,
+       `unsigned char` in DisplayPauseText, both returning `int` -- and neither matched
+       its definition, `void func_0201d850(u32)`. Each local declaration had been shaped
+       to its own call site's argument, so no conversion was ever emitted: all five
+       spellings tested byte-match at both sites, and the byte gate could not decide it.
+       Settled on the definition instead, and moved to decl_common.h so there is one.
+
+       Note the two Message methods' OWN char signedness is not part of that: `Eth` and
+       `Eta` are ROM-mangled truth about these functions and stay exactly as they are. */
     static void DisplayText(u16 msgID);
     static void DisplaySaving(u16 msgID);
     static void DisplayPauseText(u16 msgID, u8 course);

--- a/include/decl_common.h
+++ b/include/decl_common.h
@@ -2051,6 +2051,12 @@ extern void func_0201a428(void);
 extern void func_0201cd08(int);
 extern void func_0201cebc(int);
 extern void func_0201d418(int, int);
+/* Course/star index, 0..0x15. Matches the definition in src/func_0201d850.c, which
+   compares it unsigned (`arg0 < 0xf`, `arg0 >= 0x15`) and uses it as an array index
+   and a multiplier. Its two callers used to declare it locally and disagree -- `int
+   func_0201d850(unsigned char)` in DisplayPauseText, `int func_0201d850(signed char)`
+   in DisplayLevelClearText -- neither matching the definition's return type. */
+extern void func_0201d850(u32 course);
 extern void Message_DrawCenteredLine(int, int);
 extern void func_0201fc88(s16);
 extern void func_0201fe08(void);

--- a/src/_ZN7Message16DisplayPauseTextEth.cpp
+++ b/src/_ZN7Message16DisplayPauseTextEth.cpp
@@ -8,7 +8,10 @@ extern "C" {
 extern short data_0209d6d4;
 extern unsigned char data_0209d6a8;
 extern unsigned char data_0209d668;
-extern int func_0201d850(unsigned char a);
+/* func_0201d850 comes from decl_common.h. It used to be declared here as
+   `int func_0201d850(unsigned char a)` and, in DisplayLevelClearText, as
+   `int func_0201d850(signed char course)` -- one function, two signatures, neither
+   matching the definition's `void func_0201d850(u32)`. */
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);

--- a/src/_ZN7Message21DisplayLevelClearTextEta.cpp
+++ b/src/_ZN7Message21DisplayLevelClearTextEta.cpp
@@ -9,13 +9,20 @@
  * subsystem first -- it primes per-course state at 0x0201d850, then selects the
  * message, raises the window flag and asks for layout style 1.
  *
- * `Eta` is (u16, s8): the course index is a SIGNED byte, which is worth keeping --
- * widening it to int would spell `Eti` and name a different function.
+ * `Eta` is (u16, s8): THIS function's course parameter is a SIGNED byte, which is worth
+ * keeping -- widening it to int would spell `Eti` and name a different function. That is
+ * a fact about DisplayLevelClearText's own ABI and says nothing about the callee's.
+ *
+ * func_0201d850 now comes from decl_common.h. It used to be declared here as
+ * `int func_0201d850(signed char)` and, in DisplayPauseText, as
+ * `int func_0201d850(unsigned char)` -- one function, two signatures, and neither
+ * matched the definition's `void func_0201d850(u32)`. Each local declaration had simply
+ * been shaped to its own call site's argument, so no conversion was ever emitted and
+ * every spelling byte-matched; the bytes could not decide it. See the commit message.
  */
 extern "C" {
 extern unsigned short data_0209d6d4;  /* selected message ID */
 extern unsigned char data_0209d668;   /* window is up */
-int func_0201d850(signed char course);
 }
 
 void Message::DisplayLevelClearText(u16 msgID, s8 course)


### PR DESCRIPTION
The tree carried **three** spellings of one function:

```
src/func_0201d850.c                        void func_0201d850(u32 arg0)   <- definition
_ZN7Message16DisplayPauseTextEth.cpp       int  func_0201d850(unsigned char)
_ZN7Message21DisplayLevelClearTextEta.cpp  int  func_0201d850(signed char)
```

Not two, as `include/Message.h` recorded — the **definition disagrees with both callers on
the return type as well**, and neither caller had noticed because both discard the result.

## The bytes cannot decide this

That is the finding. A narrower parameter declaration normally forces the caller to
extend, which is why the runbook treats every retype as codegen-affecting until measured.
So it was measured — five variants compiled against the ROM at both call sites under the
pinned `2004/b56`:

| declaration | `DisplayPauseText` | `DisplayLevelClearText` |
|---|---|---|
| `int  func_0201d850(own char type)` | MATCH | MATCH |
| `void func_0201d850(own char type)` | MATCH | MATCH |
| `void func_0201d850(u32)` | MATCH | MATCH |
| `void func_0201d850(unsigned int)` | MATCH | MATCH |
| `int  func_0201d850(u32)` | MATCH | MATCH |

**All five reproduce.** Each local declaration had been shaped to its own call site's
argument — `DisplayPauseText` passes a `u8`, `DisplayLevelClearText` an `s8` — so no
conversion was ever emitted, and the two contradictory spellings were each locally
consistent. This is precisely the *byte-unobservable retype* runbook §2 warns about: the
A/B shows nothing, so the bytes are not evidence and the choice must rest elsewhere.

## Settled on the definition

`void func_0201d850(u32)` — the function itself. Its body compares the parameter unsigned
(`arg0 < 0xf`, `arg0 >= 0x15`), uses it as an array index and a multiplier, and returns
nothing. A course/star index in `0..0x15`. Neither `signed char` nor a non-`void` return
survives contact with that.

Moved to `decl_common.h`, where 286 other `func_0*` declarations already live, so there is
exactly one. Both local declarations are gone; each file now records what it used to claim
and why it was wrong.

## What is deliberately NOT changed

The two `Message` methods' own char signedness. `Eth` and `Eta` are ROM-mangled truth
about `DisplayPauseText` and `DisplayLevelClearText` — facts about *their* ABI, saying
nothing about their callee's. Conflating the two is what produced the disagreement in the
first place.

## Gates

| gate | result |
|---|---|
| `build_pin.verify` @ `2004/b56` | 3/3 (both callers + the definition) |
| `rombuild` | **106/106 exact** — verifies all 1,780 files that include `decl_common.h` |
| `eligible` | 10699 — unchanged |
| `check_references` | 235 unresolved (baseline 235), 0 new |
| `port_refcheck` | 394 checked, 0 stale |
| `langmode_audit --check` | PASS |
| attribution | 0 changed, 0 lost |

## Incidental

`decl_common.h`'s *"AUTO-GENERATED by tools/decl_headers.py"* banner is **false** — that
tool has never existed in any branch, the same fabrication runbook §2 already records for
`gen_header.py` and `deepen_rtti.py`. It is a third family, 44 headers. Hand-editing the
file is therefore correct; nothing regenerates it. Not re-bannered here — that is a sweep
of its own and this change should not carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154eg3RhXQYPyfKyv5t81Fz