### PR TITLE
ExpandingHeapAllocator: migrate 6 more methods, and record what blocks the rest

### DIFF
--- a/include/ExpandingHeapAllocator.h
+++ b/include/ExpandingHeapAllocator.h
@@ -16,10 +16,9 @@
 #define EXPANDINGHEAPALLOCATOR_H
 #include "types.h"
 
-/* fwd */
-struct align_;
-struct ptr;
-struct size_;
+/* The generator also emitted `struct align_; struct ptr; struct size_;` as forward
+ * declarations -- parameter names mistaken for type names. No source ever referenced
+ * them; dropped, as in SolidHeapAllocator.h. */
 struct ExpandingHeapAllocator {
     u8  pad_000[0xc];
     s32 unk_00c;            /* 0x00c */
@@ -35,13 +34,28 @@ struct ExpandingHeapAllocator {
     /* methods. Parameter types are read off the mangled name: `Eji` is
        (unsigned int, int), `EPv` is (void*), `Ev` is (). */
     void* Allocate(u32 size, int align);
-    int Deallocate(void* ptr);
-    u32 GetNodeID();
+    int   Deallocate(void* ptr);
+    u32   GetNodeID();
+    int   SetNodeID(u32 id);              /* returns the previous ID */
+    u32   MemoryLeft();                   /* sum of every free node's size */
+    int   MaxAllocatableSize(int align);  /* largest single block, at that alignment */
+
+    /* The two fit searches behind Allocate. `Ejj` is (u32, u32) -- two declared
+       parameters against three body arguments, so the leading one is `this` and
+       these are instance methods. Note SolidHeapAllocator's same-named pair mangles
+       `EPvjj` and IS static: the arity test decides it per class, and the name is
+       no guide at all. */
+    void* AllocateForwards(u32 size, u32 align);
+    void* AllocateBackwards(u32 size, u32 align);
 
     /* Static: the ROM body takes no `this`. SizeofInternal reads the block's
        MemoryNode header, which sits immediately before the user pointer, so it
-       needs no allocator instance. */
-    static u32 SizeofInternal(void* userPtr);
+       needs no allocator instance. InvokeDeallocate declares three parameters
+       (`EPvPS_j`) and its body takes exactly three -- it is the trampoline
+       DeallocateAll hands each block to, so the allocator arrives as an explicit
+       argument rather than as `this`. */
+    static u32  SizeofInternal(void* userPtr);
+    static void InvokeDeallocate(void* ptr, ExpandingHeapAllocator* alloc, u32 size);
 #endif
 };
 

--- a/src/_ZN22ExpandingHeapAllocator10MemoryLeftEv.cpp
+++ b/src/_ZN22ExpandingHeapAllocator10MemoryLeftEv.cpp
@@ -1,13 +1,23 @@
 //cpp
-extern "C" {
-struct EHA;
-unsigned int _ZN22ExpandingHeapAllocator10MemoryLeftEv(EHA* thiz) {
-  void* n = *(void**)((char*)thiz + 0x24);
-  unsigned int total = 0;
-  while (n) {
-    total += *(unsigned int*)((char*)n + 4);
-    n = *(void**)((char*)n + 0xc);
-  }
-  return total;
-}
+// @symbol _ZN22ExpandingHeapAllocator10MemoryLeftEv
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::MemoryLeft() at 0x0204e180 -- uses `this`.
+ *
+ * Total free bytes: walk the free-node list at this+0x24 and sum each node's size
+ * (+4), following the next link (+0xc). This is the sum, NOT the largest allocatable
+ * block -- MaxAllocatableSize answers that, and the two differ by fragmentation.
+ *
+ * The offsets stay raw because the header's padding does not name the node list yet;
+ * naming it is a header job and would let this read `for (n = mFreeList; ...)`.
+ */
+u32 ExpandingHeapAllocator::MemoryLeft()
+{
+    void* n = *(void**)((char*)this + 0x24);
+    unsigned int total = 0;
+    while (n) {
+        total += *(unsigned int*)((char*)n + 4);
+        n = *(void**)((char*)n + 0xc);
+    }
+    return total;
 }

--- a/src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp
@@ -1,4 +1,23 @@
 //cpp
+// @symbol _ZN22ExpandingHeapAllocator16AllocateForwardsEjj
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::AllocateForwards(u32 size, u32 align) at 0x0204e5c8 --
+ * uses `this`.
+ *
+ * `Ejj` is two declared parameters against three body arguments, so the leading one is
+ * `this`. Worth contrasting with SolidHeapAllocator's same-named method, which mangles
+ * `EPvjj` and IS static: the name is no guide, only the arity is.
+ *
+ * Walks the free list forward from the head, aligning each node's data start upward.
+ * Bit 0 of the list's flag word selects the search: clear means FIRST fit (stop at the
+ * first node that fits), set means BEST fit (keep scanning for the smallest). The
+ * `nsize == size` break is an exact-fit shortcut that applies to both.
+ *
+ * AllocateNode still carries its raw mangled name: it takes MemoryNode parameters this
+ * header cannot spell without reconstructing MemoryNode as a class with its nested
+ * Target -- see the commit message. Migration is per-reference.
+ */
 extern "C" {
 
 struct MemoryNode {
@@ -18,8 +37,11 @@ struct NodeList {
 
 void* _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(NodeList* c, MemoryNode* node, void* target, unsigned int size, unsigned int z);
 
-void* _ZN22ExpandingHeapAllocator16AllocateForwardsEjj(void* thiz, unsigned int size, unsigned int align) {
-  NodeList* c = (NodeList*)((char*)thiz + 0x24);
+}
+
+void* ExpandingHeapAllocator::AllocateForwards(u32 size, u32 align)
+{
+  NodeList* c = (NodeList*)((char*)this + 0x24);
   unsigned short flag = c->flag;
   int firstFit = ((unsigned short)(flag & 1) == 0);
   MemoryNode* best = 0;
@@ -45,5 +67,4 @@ void* _ZN22ExpandingHeapAllocator16AllocateForwardsEjj(void* thiz, unsigned int 
   }
   if (best == 0) return 0;
   return _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(c, best, bestTarget, size, 0);
-}
 }

--- a/src/_ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j.cpp
+++ b/src/_ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j.cpp
@@ -1,8 +1,25 @@
 //cpp
-extern "C" {
-extern void _ZN22ExpandingHeapAllocator10DeallocateEPv(void*, void*);
+// @symbol _ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j
+#include "ExpandingHeapAllocator.h"
 
-void _ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j(void* p, void* alloc, unsigned int size) {
-    _ZN22ExpandingHeapAllocator10DeallocateEPv(alloc, p);
-}
+/* ExpandingHeapAllocator::InvokeDeallocate(void*, ExpandingHeapAllocator*, u32)
+ * at 0x0203c4cc -- STATIC.
+ *
+ * The mangled name declares three parameters (`EPvPS_j`, where `S_` is a substitution
+ * for ExpandingHeapAllocator itself) and the ROM body takes exactly three arguments,
+ * leaving no room for a `this`. It is the default trampoline DeallocateAll hands each
+ * live block to, so it has to match that callback's shape -- (block, allocator, arg)
+ * -- which is exactly why the allocator arrives as an ordinary parameter.
+ *
+ * It ignores `size` and forwards to the ordinary Deallocate. Note the argument order
+ * flips: the callback receives (block, allocator) and the method needs (allocator,
+ * block).
+ *
+ * Deallocate is now a real member call, replacing the hand-spelled
+ * `extern void _ZN22ExpandingHeapAllocator10DeallocateEPv(void*, void*)` -- which in a
+ * C++ TU would have mangled a second time.
+ */
+void ExpandingHeapAllocator::InvokeDeallocate(void* p, ExpandingHeapAllocator* alloc, u32 size)
+{
+    alloc->Deallocate(p);
 }

--- a/src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp
@@ -1,4 +1,24 @@
 //cpp
+// @symbol _ZN22ExpandingHeapAllocator17AllocateBackwardsEjj
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::AllocateBackwards(u32 size, u32 align) at 0x0204e504 --
+ * uses `this`. `Ejj` is two declared parameters, three body arguments, so the leading
+ * one is `this`.
+ *
+ * The mirror of AllocateForwards: walks the free list from the TAIL and aligns
+ * DOWNWARD -- `(node->size + data - size) & ~mask` puts the block at the high end of
+ * the node, so the alignment padding lands below it rather than above. The fit test is
+ * therefore `aligned - data >= 0` (did it stay inside the node) rather than a
+ * size-plus-padding comparison.
+ *
+ * Same first-fit/best-fit flag as the forward search, and the same trailing 1 vs 0 to
+ * AllocateNode telling it which end was taken.
+ *
+ * AllocateNode still carries its raw mangled name: it takes MemoryNode parameters this
+ * header cannot spell without reconstructing MemoryNode as a class with its nested
+ * Target -- see the commit message.
+ */
 extern "C" {
 
 struct MemoryNode {
@@ -18,8 +38,11 @@ struct NodeList {
 
 void* _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(NodeList* c, MemoryNode* node, void* target, unsigned int size, unsigned int z);
 
-void* _ZN22ExpandingHeapAllocator17AllocateBackwardsEjj(void* thiz, unsigned int size, unsigned int align) {
-  NodeList* c = (NodeList*)((char*)thiz + 0x24);
+}
+
+void* ExpandingHeapAllocator::AllocateBackwards(u32 size, u32 align)
+{
+  NodeList* c = (NodeList*)((char*)this + 0x24);
   unsigned short flag = c->flag;
   int firstFit = ((unsigned short)(flag & 1) == 0);
   MemoryNode* best = 0;
@@ -45,5 +68,4 @@ void* _ZN22ExpandingHeapAllocator17AllocateBackwardsEjj(void* thiz, unsigned int
   }
   if (best == 0) return 0;
   return _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(c, best, bestTarget, size, 1);
-}
 }

--- a/src/_ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi.cpp
+++ b/src/_ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi.cpp
@@ -1,26 +1,43 @@
 //cpp
-extern "C" {
-int _ZN4cstd3absEi(int);
-struct EHA;
-int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(EHA* thiz, int arg) {
-  int align = _ZN4cstd3absEi(arg);
-  unsigned int bestSize = 0;
-  unsigned int bestOffset = -1;
-  char* n = *(char**)((char*)thiz + 0x24);
-  while (n) {
-    unsigned int base = (unsigned int)(n + 0x10);
-    unsigned int aligned = ((align - 1) + base) & ~(align - 1);
-    unsigned int end = *(int*)(n + 4) + base;
-    if (aligned < end) {
-      unsigned int usable = end - aligned;
-      unsigned int offset = aligned - base;
-      if (bestSize < usable || (bestSize == usable && bestOffset > offset)) {
-        bestSize = usable;
-        bestOffset = offset;
-      }
+// @symbol _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::MaxAllocatableSize(int align) at 0x0204e0f8 -- uses `this`.
+ *
+ * The largest single block still obtainable at this alignment -- NOT the same as
+ * MemoryLeft, which sums every free node. Walks the free list at this+0x24, aligns
+ * each node's data start (node+0x10) upward, and keeps the largest usable remainder;
+ * ties are broken toward the node that wastes least on alignment padding, which is
+ * what `bestOffset` tracks.
+ *
+ * `align` goes through cstd::abs, so the sign convention Allocate uses (negative means
+ * allocate from the high end) is accepted and ignored -- the answer is the same either
+ * way. That extern MUST be `extern "C"`: it is a ROM symbol spelled by hand, and in a
+ * C++ TU a bare declaration mangles a second time to a name that exists nowhere.
+ * build_pin.verify would not catch it -- a call is a relocation and match.compare
+ * wildcards every relocated word. Only the link sees it.
+ */
+extern "C" int _ZN4cstd3absEi(int);
+
+int ExpandingHeapAllocator::MaxAllocatableSize(int arg)
+{
+    int align = _ZN4cstd3absEi(arg);
+    unsigned int bestSize = 0;
+    unsigned int bestOffset = -1;
+    char* n = *(char**)((char*)this + 0x24);
+    while (n) {
+        unsigned int base = (unsigned int)(n + 0x10);
+        unsigned int aligned = ((align - 1) + base) & ~(align - 1);
+        unsigned int end = *(int*)(n + 4) + base;
+        if (aligned < end) {
+            unsigned int usable = end - aligned;
+            unsigned int offset = aligned - base;
+            if (bestSize < usable || (bestSize == usable && bestOffset > offset)) {
+                bestSize = usable;
+                bestOffset = offset;
+            }
+        }
+        n = *(char**)(n + 0xc);
     }
-    n = *(char**)(n + 0xc);
-  }
-  return bestSize;
-}
+    return bestSize;
 }

--- a/src/_ZN22ExpandingHeapAllocator9SetNodeIDEj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator9SetNodeIDEj.cpp
@@ -1,11 +1,26 @@
 //cpp
-extern "C" {
+// @symbol _ZN22ExpandingHeapAllocator9SetNodeIDEj
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::SetNodeID(u32 id) at 0x0204e0e8 -- uses `this`.
+ *
+ * Stamps the ID that subsequently allocated nodes carry, and returns the previous one
+ * so a caller can restore it. The field is a u16 at +0x34, which is why the incoming
+ * u32 is truncated on the way in and the u16 is widened to int on the way out.
+ *
+ * GetNodeID reads the same field and spells it `((u16 *)this)[26]` -- 0x34/2.
+ *
+ * THE TWO-STEP ADDRESSING IS LOAD-BEARING. Reaching the field as `Inner* p = this +
+ * 0x24` then `p->id` is not the same to mwccarm as computing `this + 0x34` directly:
+ * the flattened form differs by three words. Only the receiver is substituted here;
+ * the body is otherwise exactly as recovered.
+ */
 struct Inner { char pad[0x10]; unsigned short id; };
-struct EHA { char pad[0x24]; struct Inner inner; };
-int _ZN22ExpandingHeapAllocator9SetNodeIDEj(struct EHA* thiz, unsigned int id) {
-  struct Inner* p = &thiz->inner;
-  unsigned short old = p->id;
-  p->id = (unsigned short)id;
-  return old;
-}
+
+int ExpandingHeapAllocator::SetNodeID(u32 id)
+{
+    struct Inner* p = (struct Inner*)((char*)this + 0x24);
+    unsigned short old = p->id;
+    p->id = (unsigned short)id;
+    return old;
 }


### PR DESCRIPTION
Rewrite only — every file was **already `.cpp`**, hand-spelling its own mangled symbol
inside `extern "C"`. That is the *"renamed, never migrated"* category the audit counts
separately (285 tree-wide): a `.cpp` extension is not a migration. No file moves, so no
rewrite/move split and attribution is untouched.

| method | address | kind |
|---|---|---|
| `MemoryLeft()` | `0x0204e180` | instance |
| `SetNodeID(u32)` | `0x0204e0e8` | instance |
| `MaxAllocatableSize(int)` | `0x0204e0f8` | instance |
| `AllocateForwards(u32, u32)` | `0x0204e5c8` | instance |
| `AllocateBackwards(u32, u32)` | `0x0204e504` | instance |
| `InvokeDeallocate(void*, ExpandingHeapAllocator*, u32)` | `0x0203c4cc` | **static** |

## Arity decides static-ness, and the name is no guide

`AllocateForwards` here mangles `Ejj` — two declared parameters against three body
arguments, so the leading one is `this`. **SolidHeapAllocator's identically-named method
mangles `EPvjj`, three against three, and is static** (#1215). Same name, opposite
answer, one class apart. Only the count decides.

`InvokeDeallocate` is static for that reason and for an independent one: it is the
trampoline `DeallocateAll` hands each block to, so it must match that callback's
`(block, allocator, arg)` shape — which is exactly why the allocator arrives as an
ordinary parameter rather than as `this`.

## SetNodeID cost a round trip, and that is worth recording

Flattening its two-step addressing — `Inner* p = this + 0x24` then `p->id` — into a
direct `this + 0x34` **diverges by three words**, though both name the same `u16`. The
receiver substitution is the only thing a migration may change; the body stays verbatim.
Caught by `build_pin.verify` before it went anywhere.

## Seven remain, and five are blocked on a type rather than on this phase

`CreateNode`, `UnlinkNode`, `AllocateNode`, `FreeNode` and `LinkNode` take `MemoryNode`
and `MemoryNode::Target` parameters (`P10MemoryNode`, `PNS0_6TargetE`). Declaring them as
members requires `MemoryNode` to exist as a class with a nested `Target` so the mangling
comes out right — a type reconstruction of its own, the OamAttr job one level up.

Every file currently defines its own local `MemoryNode`, **and they disagree**:

```
AllocateForwards/Backwards   { u16 tag;        u16 flags; u32 size; ... }
Reallocate                   { char magic[2];  u16 flags; u32 size; ... }
```

Reconciling that is the prerequisite, and the natural next slice.

`Reallocate` is deferred only for size, not for any blocker. `DeallocateAll` is deferred
for a real discrepancy: it mangles `PPFvPvPS_jE` — pointer to **pointer** to function —
while the recovered body takes a plain function pointer and calls it directly. One of the
two is wrong, and `(*fn)(...)` would emit a load the current body does not, so it needs
measuring rather than assuming.

## Gates

| gate | result |
|---|---|
| `build_pin.verify` @ `2004/b56` | **6/6** |
| `rombuild` | **106/106 exact**, 10,699 reproducing / 0 mismatching |
| `eligible` | 10699 — unchanged |
| `check_references` | 0 new unresolvable |
| `port_refcheck` | 394 checked, 0 stale |
| `langmode_audit --check` | PASS |
| attribution | 0 changed, 0 lost |

The header's `struct align_; struct ptr; struct size_;` forward declarations are dropped
— parameter names mistaken for type names, the same generator artifact removed from
`SolidHeapAllocator.h` in #1215. Nothing referenced them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154eg3RhXQYPyfKyv5t81Fz