### PR TITLE
headers: correct an overstated gate claim, and close the sweep's coverage hole

### DIFF
--- a/include/OamAttr.h
+++ b/include/OamAttr.h
@@ -13,11 +13,29 @@
  * WHY THE NAME MATTERS. Five files used to spell this type `OamAttri`, which does not
  * exist. It is a mis-parse of the mangled parameter list: `P7OamAttrii` is pointer to a
  * SEVEN-character class `OamAttr` followed by two ints, and the first `i` was read as
- * part of the type name. That was harmless only because those files hand-spell their
- * symbol and the struct tag never reaches the mangler -- the moment one is migrated to
- * a real C++ method, `OamAttri` mangles to `P8OamAttri...` and the function vanishes
- * from the object. build_pin.verify would not catch it: a call is a relocation and
- * match.compare wildcards every relocated word.
+ * part of the type name.
+ *
+ * BE PRECISE ABOUT THE CONSEQUENCE -- an earlier draft of this comment overstated it.
+ * Those five are CALLERS of OAM::Render, not definers, so the wrong tag could never
+ * make a definition vanish; the tag only reaches the mangler in a file that DEFINES a
+ * function taking the type, and every such file already spelled it `OamAttr`. What the
+ * misspelling actually buys is an unresolvable REFERENCE the day one of the five is
+ * migrated -- caught by eligible.py, which refuses to enroll a file with unresolvable
+ * references, and by match.py's `--strict-relocs` (default-on) before that. So this was
+ * a failed gate run and ten minutes of diagnosis, not a silent defect. Retired anyway,
+ * because a type name that names nothing is worth nothing.
+ *
+ * And do not repeat the flat claim that the byte gate is blind here. `build_pin.verify`
+ * takes a `strict` tuple and, when given one, fails closed on a relocation that does not
+ * land where the per-module relocs.txt says -- including one that resolves nowhere. It
+ * is blind only when a caller omits `strict`, which the ad-hoc checks in the session
+ * that wrote this header did. See notes/runbook-reference-repair.md section 1: the two
+ * gates cover for each other.
+ *
+ * (The line above used to spell that path with a glob. Inside a C comment the `*` and
+ * `/` of `config/**` close the comment early, and the rest of this paragraph became
+ * code -- which is precisely the defect tools/header_cpp_sweep.py exists to catch, and
+ * it caught this one on the first run after the fails-both bucket was ratcheted.)
  *
  * Renaming the type is inert for codegen -- a struct tag cannot change layout -- but
  * every file was byte-verified under the pinned compiler anyway.

--- a/tools/header_cpp_sweep.py
+++ b/tools/header_cpp_sweep.py
@@ -34,9 +34,18 @@ headers included first. The pair does:
     fails both            -> needs other headers first; not this
     passes both           -> clean
 
-Flags mirror `rombuild.compile_one` exactly -- same CFLAGS, the same `-lang c++` swap
-keyed off the source suffix, the same `-i include` and LM_LICENSE_FILE. A sweep compiled
-differently from the build would prove nothing about the build.
+Flags mirror `rombuild.compile_one` -- same CFLAGS, same `-i include`, same
+LM_LICENSE_FILE. A sweep compiled differently from the build would prove nothing about
+the build.
+
+One deliberate difference, and an earlier version of this docstring described it wrongly.
+The BUILD does not pick the language from the file extension: `rombuild.py:275` and
+`build_pin.py:127-138` both key on a leading `//cpp` marker, and build_pin says outright
+that suffix-keying is the historical mistake ("53 committed .c files carry the marker
+too"). This sweep authors its own one-line TUs, so it selects the language directly
+rather than by either rule. That is correct for the question being asked -- "does this
+header parse as C++?" -- but it is not the build's rule, and nothing here should be cited
+as evidence about how the build chooses.
 
 ## What this does NOT catch
 
@@ -133,13 +142,23 @@ def main():
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
         rows = list(ex.map(probe, hdrs))
 
-    defect = [r for r in rows if not r["ok_cpp"] and r["ok_c"]]
+    # A header that fails C++ but passes C has a broken __cplusplus block -- but only if
+    # it HAS one. Without that conjunct the bucket is mislabelled: a blockless header
+    # that trips some other C++-only rule would be filed under "__cplusplus block
+    # defect". Currently no such header exists, which is why the omission never showed.
+    defect = [r for r in rows if not r["ok_cpp"] and r["ok_c"] and r["has_cpp_block"]]
+    other_cpp_only = [r for r in rows
+                      if not r["ok_cpp"] and r["ok_c"] and not r["has_cpp_block"]]
     both = [r for r in rows if not r["ok_cpp"] and not r["ok_c"]]
 
+    clean = len(rows) - len(defect) - len(other_cpp_only) - len(both)
     print("headers swept: %d  (compiler %s)" % (len(rows), VERSION))
-    print("  clean as C++                 : %d" % (len(rows) - len(defect) - len(both)))
+    print("  clean as C++                 : %d" % clean)
     print("  FAIL C++ but PASS C          : %d   <-- __cplusplus block defect" % len(defect))
-    print("  fail both (needs other hdrs) : %d   -- not this defect" % len(both))
+    print("  FAIL C++ but PASS C, no block: %d   <-- C++-only defect, not in a block"
+          % len(other_cpp_only))
+    print("  fail both                    : %d   <-- NOT a free pass, see below"
+          % len(both))
 
     withblk = [r for r in rows if r["has_cpp_block"]]
     print("\nheaders carrying a __cplusplus block: %d" % len(withblk))
@@ -153,19 +172,31 @@ def main():
         tot, bad = pop[b]
         print("  %-16s %3d with block, %3d defective" % (b, tot, bad))
 
-    if defect:
-        print("\nDEFECTIVE -- the __cplusplus block does not compile:")
-        for r in sorted(defect, key=lambda r: r["name"]):
-            print("  %-34s %-15s %s" % (r["name"], r["banner"], r["err_cpp"][:90]))
+    for label, rowset in (("DEFECTIVE -- the __cplusplus block does not compile:", defect),
+                          ("C++-ONLY FAILURE outside any __cplusplus block:", other_cpp_only),
+                          ("FAILS AS C TOO -- coverage hole, see below:", both)):
+        if rowset:
+            print("\n" + label)
+            for r in sorted(rowset, key=lambda r: r["name"]):
+                print("  %-34s %-15s %s" % (r["name"], r["banner"], r["err_cpp"][:90]))
 
     if args.json:
         pathlib.Path(args.json).write_text(json.dumps(rows, indent=1))
         print("\nwrote %s" % args.json)
 
-    if args.check and defect:
-        print("\nheader-cpp-sweep: FAIL (%d defective)" % len(defect), file=sys.stderr)
+    # THE FAILS-BOTH BUCKET IS NOT A FREE PASS, and the first version of this tool
+    # treated it as one. A header that needs other headers included first AND has a
+    # broken __cplusplus block fails both ways, so it lands in that bucket and this
+    # sweep can say nothing about its block -- forever, and silently. The count is
+    # currently 0, which is what makes the "three defects, ever" claim sound; so it is
+    # ratcheted at 0 rather than baselined. If one appears, either fix the header's
+    # includes so it compiles standalone, or the sweep has stopped covering it.
+    bad = len(defect) + len(other_cpp_only) + len(both)
+    if args.check and bad:
+        print("\nheader-cpp-sweep: FAIL (%d defective, %d C++-only, %d uncoverable)"
+              % (len(defect), len(other_cpp_only), len(both)), file=sys.stderr)
         return 1
-    print("\nheader-cpp-sweep: %s" % ("PASS" if not defect else "reported"))
+    print("\nheader-cpp-sweep: %s" % ("PASS" if not bad else "reported"))
     return 0
 
 


### PR DESCRIPTION
Follow-up to #1216 and #1218 after an adversarial review of both. Three corrections — one
of which the tool caught in itself.

## 1. The "byte gate is blind" narrative was overstated

And #1218 baked it into a header comment, where every future reader would inherit it.

`build_pin.verify` takes a `strict` tuple and, when given one, **fails closed** on a
relocation that does not land where the per-module `relocs.txt` says — including one that
resolves nowhere (`build_pin.py:151-199`). `match.py --strict-relocs` is default-on, and
`eligible.py` refuses to enroll a file with unresolvable references, so a broken file
never reaches the link at all.

The honest claim is narrower: `verify()` is blind to reloc destinations **only when the
caller omits `strict`** — which the ad-hoc checks in that session did. *"Only the link
sees it"* is false as written; `notes/runbook-reference-repair.md` §1 already says the two
gates cover for each other.

**Related, and the sharper error:** for a defect that makes a file drop *out* of
enrollment, `106/106` is not the evidence. The gap object supplies ROM bytes for anything
unenrolled, so the module stays green while the function silently leaves the build. The
load-bearing row is `eligible: 10699 — unchanged`. Every slice reported it; only the
narration pointed at the wrong row.

## 2. The `OamAttri` consequence conflated callers with definers

Those five files **call** `OAM::Render`; they define nothing taking an `OamAttr`, so the
wrong tag could never make a definition vanish from an object. It would have produced an
unresolvable *reference* at migration time — caught by `eligible.py` and by strict-relocs.
Retiring the name was right; the stakes were one failed gate run, not a silent defect.

## 3. The fails-both bucket was a coverage hole, and `--check` exempted it

A header that needs other headers included first **and** has a broken `__cplusplus` block
fails both ways, lands in that bucket, and the sweep says nothing about it — forever, and
silently. That is what made *"exactly three defective, ever"* true only of headers that
compile standalone as C.

The count is 0 today, so it is **ratcheted at 0** rather than baselined: `--check` now
fails on it. The defect filter also now requires `has_cpp_block`, so a blockless header
failing some other C++-only rule gets its own heading instead of being mislabelled.

### The ratchet immediately caught the comment from item 1

The new text spelled a path as `config/**/relocs.txt`. Inside a C comment the `*` and `/`
close it early, and the rest of the paragraph became code. `OamAttr.h` moved straight into
the fails-both bucket — exactly the defect class this tool exists to find, one edit after
the hole was closed.

`rombuild` would also have caught it (eleven files include that header); the sweep was
faster and named the header.

## Also corrected

The docstring claimed the sweep mirrors the build's `-lang c++` swap *"keyed off the
source suffix"*. **The build does not look at the extension** — `rombuild.py:275` and
`build_pin.py:127-138` both key on a leading `//cpp` marker, and `build_pin` names
suffix-keying as the historical mistake (*"53 committed .c files carry the marker too"*).
The sweep authors its own TUs and selects the language directly, which is right for the
question it asks but is not the build's rule and must not be cited as evidence about it.

## Gates

```
sweep    383 headers, 292 with a block — 0 defective / 0 C++-only / 0 uncoverable
rombuild 106/106 exact, 10,699 reproducing / 0 mismatching
refcheck 394 checked, 0 stale
attrib   0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154eg3RhXQYPyfKyv5t81Fz