### PR TITLE
Viewer config: declare our live stream and board id, stop pointing at CLAIMS.md

### DIFF
--- a/tools/chaosviewer.config.json
+++ b/tools/chaosviewer.config.json
@@ -8,10 +8,12 @@
   "cppNote": "If a name starts with _Z (C++ mangled), write C++ with the FIRST LINE exactly //cpp",
   "setup": "clone {github} and follow CONTRIBUTING.md (python deps + mwccarm from the DS-decomp Discord + tools/unpack.py on YOUR OWN cartridge dump).",
   "verifyCommand": "python tools/match.py --c yourfile.c --func {name} --addr 0x{addrHex} --size 0x{sizeHex} --module {module} --version 2004/b56",
-  "readFirst": "notes/mwccarm-codegen.md (esp. sec 6e-6g levers: u64-mask laundering for materialized bases, declaration/statement order for register coloring, //cpp dummy-vtable dispatch, struct-copy interleave) and notes/pret-idioms.md. Coordinate via CLAIMS.md.",
+  "readFirst": "notes/mwccarm-codegen.md (esp. sec 6e-6g levers: u64-mask laundering for materialized bases, declaration/statement order for register coloring, //cpp dummy-vtable dispatch, struct-copy interleave) and notes/pret-idioms.md. Coordinate via the claims API (GET https://tangos.dev/api/claims/instructions).",
   "rules": "only your own legally dumped ROM; never commit the ROM, its assets, or extracted binaries - the one deliberate exception is the annotated disassembly TEXT of still-unmatched functions, published in the coordination data (chaos-data branch) so contributors can work, the same practice as decomp repos committing .s files; import struct/field knowledge (see CREDITS.md) but write all C from scratch.",
   "discord": "https://discord.gg/YpReERF4e3",
   "claimsApi": "https://tangos.dev/api/claims",
+  "projectId": "sm64ds",
+  "liveApi": "https://tangos.dev/api/projects/sm64ds",
   "claimsAuthUrl": "https://tangos.dev/auth/github/start",
   "nearMissNote": "If a function will not fully match after real effort, do not discard your best attempt - it is still valuable. Open a PR anyway with your closest compiling draft as src/<name>.c, headed by one line: // NONMATCHING: <what still differs> (div=N, from the verify output). Near-miss drafts are the highest-yield input to this project's refine tier - most matches now start from someone's stored near-miss, and a close draft is usually finished within a day.",
   "dataUrl": "https://raw.githubusercontent.com/tangosdev/sm64ds-decomp/chaos-data/chaos-db.json"


### PR DESCRIPTION
The published project block comes from this file, not tangos.json, so
the liveApi/projectId added to the descriptor never reached the viewer.
liveApi moves the deployed viewer off the legacy /api/live URL (its
per-project stream reached parity, progress replay included), projectId
names our board on the per-project claims service explicitly, and
readFirst stops telling viewer-prompted agents to coordinate via
CLAIMS.md rows - the API is the register every reader consults now.

(That this file duplicates tangos.json at all is the same registry
smell the data-flow trace counted; folding the generator onto the
descriptor like pictochat's is a cleanup for another day.)
