### PR TITLE
MemoryNode: reconstruct the type, and unblock three of ExpandingHeapAllocator's last five

### DIFF
--- a/include/ExpandingHeapAllocator.h
+++ b/include/ExpandingHeapAllocator.h
@@ -15,6 +15,7 @@
 #ifndef EXPANDINGHEAPALLOCATOR_H
 #define EXPANDINGHEAPALLOCATOR_H
 #include "types.h"
+#include "MemoryNode.h"   /* the five node methods below take it by pointer */
 
 /* The generator also emitted `struct align_; struct ptr; struct size_;` as forward
  * declarations -- parameter names mistaken for type names. No source ever referenced
@@ -56,6 +57,45 @@ struct ExpandingHeapAllocator {
        argument rather than as `this`. */
     static u32  SizeofInternal(void* userPtr);
     static void InvokeDeallocate(void* ptr, ExpandingHeapAllocator* alloc, u32 size);
+
+    /* The node-list layer. These were the last five unmigratable methods of this class:
+       their parameters mangle `P10MemoryNode` and `PNS0_6TargetE`, so they could not be
+       declared as members until MemoryNode existed as a class with a nested Target --
+       see include/MemoryNode.h.
+
+       Four are static by the arity test (declared parameters == body arguments, no room
+       for `this`); FreeNode declares two and takes three, so it is an instance method.
+
+       NOTE the first parameter of the static four is typed MemoryNode* because that is
+       what the ROM's mangled name says, but every caller passes the allocator's embedded
+       node-list at `this + 0x24`, not a real node. The original evidently treated that
+       list head as a sentinel node. The bodies cast it back to the shape they use; the
+       declaration follows the ROM, not the usage. */
+    static void*       CreateNode(MemoryNode::Target* extent, u16 tag);
+    static void*       LinkNode(MemoryNode* list, MemoryNode* node, MemoryNode* prev);
+    static void*       UnlinkNode(MemoryNode* list, MemoryNode* node);
+
+    /* AllocateNode and FreeNode are NOT declared here yet, deliberately. The type no
+       longer blocks them -- both would mangle correctly now -- but AllocateNode does not
+       yet reproduce, and a declared-but-undefined member is a landmine. AllocateNode is
+       ONE WORD off, at +0x10c:
+
+           ROM   e1dd33b8   ldrh r3, [sp, #0x38]
+           ours  e59d3038   ldr  r3, [sp, #0x38]
+
+       Its fifth argument is stack-passed (AAPCS puts args 5+ on the stack), and the ROM
+       reads only its low halfword -- the load width mwccarm picks when the declared type
+       is 16 bit. But the mangled name ends `jj`, fixing both trailing parameters as u32,
+       and a u32 parameter gets a word load. The recovered body squared that circle by
+       declaring the parameter `unsigned short`, which reproduces but cannot be a member
+       signature. Tried and rejected: a truncating local (999 words -- it changes how the
+       argument is homed), `*(unsigned short *)&param` (5 words -- taking the address
+       re-homes it), and casts at the use site (no effect; the load width is chosen from
+       the parameter's declared type, not from what is done with the value).
+
+       So this is the same shape as DeallocateAll's `PPFvPvPS_jE`: the mangled name and
+       the reproducing body disagree about a parameter type, and the ROM's own codegen is
+       the tiebreaker evidence. Worth its own investigation rather than a guess. */
 #endif
 };
 

--- a/include/MemoryNode.h
+++ b/include/MemoryNode.h
@@ -1,0 +1,75 @@
+/* Hand-written, from usage evidence. Not generated.
+ *
+ * One block header in an ExpandingHeapAllocator heap: 0x10 bytes, immediately BEFORE
+ * the user pointer it describes. That offset is why ExpandingHeapAllocator::Deallocate
+ * reaches its header at ptr-0x10 and why SizeofInternal needs no allocator instance --
+ * the header is self-describing.
+ *
+ * WHY THIS TYPE EXISTS AT ALL. Five ExpandingHeapAllocator methods take MemoryNode or
+ * MemoryNode::Target parameters -- `P10MemoryNode`, `PNS0_6TargetE` -- and cannot be
+ * declared as C++ members until those names resolve to a class with that exact nested
+ * shape. Without it the mangling comes out wrong and the ROM symbol is never defined.
+ * Reconstructing it is the whole prerequisite for finishing that class (#1221).
+ *
+ * SEVEN LOCAL COPIES EXISTED AND FIVE DISAGREED -- on names, on signedness, and on
+ * whether offset 0 was a u16 or a 2-char array:
+ *
+ *   u16 tag; u16 flags; u32 size; MemoryNode *prev, *next;   AllocateForwards/Backwards
+ *   char magic[2]; u16 flags; u32 size; ...                  Deallocate, Reallocate
+ *   u16 tag; u16 pad; int size; int prev; int next;          FreeNode
+ *   u16 pad0; u16 bits2; int f4; char rest[8];               Target's constructor
+ *
+ * All seven agree on the OFFSETS, which is what makes this reconcilable. The
+ * disagreements are resolved from the two functions that write the fields rather than
+ * by majority vote:
+ *
+ * OFFSET 0 IS A u16, NOT `char magic[2]`. ExpandingHeapAllocator::CreateNode takes a
+ * `u16` parameter (`...6TargetEt`) and stores it with `*(u16 *)(n + 0) = t` -- a 16-bit
+ * store of a 16-bit argument. A 2-char array was a guess that happens to be the same
+ * width. Whether the value is two ASCII characters is a separate question this header
+ * does not answer.
+ *
+ * OFFSET 2 IS A FLAGS WORD WHOSE BITS 8..14 ARE THE ALIGNMENT PADDING skipped ahead of
+ * this header. MemoryNode::Target's constructor is the evidence:
+ *     start = (char *)node - ((node->flags >> 8) & 0x7f)
+ * so the region the block really occupies begins that many bytes before the header.
+ * CreateNode zeroes the whole word, so an unaligned allocation is the only thing that
+ * ever sets it.
+ *
+ * OFFSET 4 IS THE USER-DATA SIZE, measured from `this + 0x10`, not from the header:
+ * CreateNode stores `end - (n + 0x10)`, and Target's constructor recovers the end as
+ * `node->size + (char *)node + 0x10`. Declared u32 because every consumer that compares
+ * it -- the fit searches in AllocateForwards and AllocateBackwards -- compares unsigned;
+ * only CreateNode's own store treats it as a signed difference, and that store is
+ * byte-identical either way. Verified, not assumed.
+ *
+ * TARGET IS A HALF-OPEN POINTER PAIR describing the block's true extent, padding
+ * included. Its constructor is a C1 and stays a hand-spelled free function -- ctor
+ * migration is Phase 5, and nothing here needs it. Deliberately NOT declared below:
+ * declaring a constructor would remove the implicit default one, and
+ * ExpandingHeapAllocator::Deallocate builds a Target as a plain local before filling it
+ * in. Leaving Target an aggregate keeps that legal. */
+#ifndef MEMORYNODE_H
+#define MEMORYNODE_H
+#include "types.h"
+
+struct MemoryNode {
+    u16 tag;            /* 0x0 -- set once by CreateNode from its u16 argument */
+    u16 flags;          /* 0x2 -- bits 8..14: alignment padding before this header */
+    u32 size;           /* 0x4 -- user bytes, measured from (this + 0x10) */
+    /* `struct MemoryNode *`, not `MemoryNode *`: C has no injected class name, and
+       ExpandingHeapAllocator's constructor is still a .c file that reaches this header
+       through ExpandingHeapAllocator.h. Spelled the C way, it compiles as both. */
+    struct MemoryNode* prev;   /* 0x8 */
+    struct MemoryNode* next;   /* 0xc */
+
+    /* The extent of a block including any alignment padding: [start, end).
+       Nested so that `MemoryNode::Target*` mangles as `PN10MemoryNode6TargetE`, which
+       is what the ROM's ExpandingHeapAllocator symbols require. */
+    struct Target {
+        char* start;
+        char* end;
+    };
+};
+
+#endif

--- a/src/_ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt.cpp
+++ b/src/_ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt.cpp
@@ -1,6 +1,27 @@
 //cpp
-extern "C" {
-void* _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(int* c, unsigned short t) {
+// @symbol _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::CreateNode(MemoryNode::Target*, u16 tag) at 0x0204e8b0 --
+ * STATIC. Two declared parameters (`PN10MemoryNode6TargetE` + `t`) against two body
+ * arguments, so there is no room for a `this`.
+ *
+ * Stamps a fresh header at the start of an extent and returns it. The size it records
+ * is `end - (node + 0x10)` -- user bytes measured from just past the header, not the
+ * extent's own length -- which is the definition MemoryNode::Target's constructor
+ * inverts to recover the end again. The flags word is zeroed here, so the alignment
+ * padding it carries in bits 8..14 is written by whoever placed the node, not by this.
+ *
+ * THE BODY IS VERBATIM apart from the receiver. The extent arrives as `MemoryNode::
+ * Target*` because that is what the ROM's mangled name declares, and is immediately
+ * cast back to the `int*` the recovered body indexes -- `c[0]` is start, `c[1]` is end.
+ * Rewriting those as `extent->start` / `extent->end` is a body change, and this class
+ * has already produced one three-word divergence from exactly that kind of tidying
+ * (SetNodeID, #1221). The declaration follows the ROM; the body is left alone.
+ */
+void* ExpandingHeapAllocator::CreateNode(MemoryNode::Target* extent, u16 t)
+{
+  int* c = (int*)extent;
   char* n = (char*)c[0];
   *(unsigned short*)(n+0) = t;
   *(unsigned short*)(n+2) = 0;
@@ -8,5 +29,4 @@ void* _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(int* c, un
   *(int*)(n+8) = 0;
   *(int*)(n+0xc) = 0;
   return n;
-}
 }

--- a/src/_ZN22ExpandingHeapAllocator10DeallocateEPv.cpp
+++ b/src/_ZN22ExpandingHeapAllocator10DeallocateEPv.cpp
@@ -25,13 +25,9 @@ struct MemoryNodeTarget {
     void *end;
 };
 
-struct MemoryNode {
-    char magic[2];
-    u16 flags;
-    u32 size;
-    struct MemoryNode *prev;
-    struct MemoryNode *next;
-};
+/* MemoryNode now comes from include/MemoryNode.h. The local copy this file carried
+   spelled offset 0 as `char magic[2]`; the shared type calls it a u16 tag, which is
+   what CreateNode stores. Nothing here read the field. */
 
 extern "C" {
 void _ZN10MemoryNode6TargetC1EP10MemoryNode(struct MemoryNodeTarget *t, struct MemoryNode *node);

--- a/src/_ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_.cpp
+++ b/src/_ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_.cpp
@@ -1,7 +1,25 @@
 //cpp
-extern "C" {
+// @symbol _ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::UnlinkNode(MemoryNode* list, MemoryNode* node) at 0x0204e910
+ * -- STATIC. Two declared parameters, two body arguments, no room for a `this`.
+ *
+ * Ordinary doubly-linked-list removal, with the list head and tail written directly
+ * when the node was at either end: c[0] is the head, c[1] the tail. Returns the node's
+ * former predecessor, which is what FreeNode needs in order to decide whether the freed
+ * block can merge backwards.
+ *
+ * `list` is typed MemoryNode* because that is what the ROM's mangled name declares, but
+ * callers pass the allocator's embedded node-list at `this + 0x24`. The body's local
+ * `N` and `int*` views are left exactly as recovered -- only the receiver types moved.
+ */
 struct N { int p0,p1,prev,next; };
-void* _ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(int* c, N* node) {
+
+void* ExpandingHeapAllocator::UnlinkNode(MemoryNode* list, MemoryNode* node_)
+{
+  int* c = (int*)list;
+  N* node = (N*)node_;
   N* r2 = (N*)node->prev;
   N* r1 = (N*)node->next;
   if (r2) r2->next = (int)r1;
@@ -9,5 +27,4 @@ void* _ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(int* c, N* node) 
   if (r1) r1->prev = (int)r2;
   else c[1] = (int)r2;
   return r2;
-}
 }

--- a/src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp
@@ -20,13 +20,8 @@
  */
 extern "C" {
 
-struct MemoryNode {
-  unsigned short tag;
-  unsigned short flags;
-  unsigned int size;
-  MemoryNode* prev;
-  MemoryNode* next;
-};
+/* MemoryNode now comes from include/MemoryNode.h via ExpandingHeapAllocator.h.
+   The local copy this file used to carry was identical to it. */
 
 struct NodeList {
   MemoryNode* head;

--- a/src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp
@@ -21,13 +21,8 @@
  */
 extern "C" {
 
-struct MemoryNode {
-  unsigned short tag;
-  unsigned short flags;
-  unsigned int size;
-  MemoryNode* prev;
-  MemoryNode* next;
-};
+/* MemoryNode now comes from include/MemoryNode.h via ExpandingHeapAllocator.h.
+   The local copy this file used to carry was identical to it. */
 
 struct NodeList {
   MemoryNode* head;

--- a/src/_ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_.cpp
+++ b/src/_ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_.cpp
@@ -1,6 +1,26 @@
 //cpp
-extern "C" {
-void* _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(int* c, int node, int r2) {
+// @symbol _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_
+#include "ExpandingHeapAllocator.h"
+
+/* ExpandingHeapAllocator::LinkNode(MemoryNode* list, MemoryNode* node,
+ * MemoryNode* prev) at 0x0204e8e0 -- STATIC. Three declared parameters, three body
+ * arguments, no room for a `this`.
+ *
+ * Inserts `node` immediately after `prev`, or at the head when `prev` is null, fixing
+ * both neighbours and the list's head/tail (c[0], c[1]). The inverse of UnlinkNode, and
+ * the reason UnlinkNode bothers to return the predecessor: FreeNode unlinks a node,
+ * merges, and links the result back at the same position.
+ *
+ * `list` is typed MemoryNode* because the ROM's mangled name says so; callers pass the
+ * allocator's node-list at `this + 0x24`. `node` and `prev` are handled as raw ints in
+ * the recovered body -- left exactly that way, since every field access here is an
+ * explicit offset and retyping them would change the arithmetic mwccarm emits.
+ */
+void* ExpandingHeapAllocator::LinkNode(MemoryNode* list, MemoryNode* node_, MemoryNode* prev)
+{
+  int* c = (int*)list;
+  int node = (int)node_;
+  int r2 = (int)prev;
   char* n = (char*)node;
   *(int*)(n+8) = r2;
   int r3;
@@ -10,5 +30,4 @@ void* _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(int* c, int node,
   if (r3) { *(int*)((char*)r3+8) = node; }
   else { c[1] = node; }
   return n;
-}
 }


### PR DESCRIPTION
Five `ExpandingHeapAllocator` methods take `MemoryNode` or `MemoryNode::Target`
parameters — `P10MemoryNode`, `PNS0_6TargetE` — and could not be declared as members
until those names resolved to a class with that exact nested shape (#1221). This builds
the type and migrates three of the five.

**`CreateNode`, `LinkNode`, `UnlinkNode` byte-verify at `2004/b56`; ROM build 106/106.**

## Seven local copies existed and five disagreed

On names, on signedness, and on whether offset 0 was a `u16` or a 2-char array. All seven
agreed on the **offsets**, which is what made this reconcilable. The disagreements are
settled from the two functions that *write* the fields, not by majority:

| offset | resolution | evidence |
|---|---|---|
| `0x0` | `u16 tag` — not `char magic[2]` | `CreateNode` does a 16-bit store of a 16-bit argument |
| `0x2` | `u16 flags` | bit 15 = allocated-from-high-end, bits 8..14 = alignment padding, bits 0..7 = node ID — all three assembled in `AllocateNode`; `Target`'s ctor recovers `start = node - ((flags>>8) & 0x7f)` |
| `0x4` | `u32 size`, measured from `this + 0x10` | `CreateNode` stores `end - (n + 0x10)`; `Target`'s ctor inverts it |
| `0x8`, `0xc` | `prev`, `next` | unanimous |

**Both camps were seeing something real.** `AllocateNode`'s tags are `0x4652` = `'FR'`
(free) and `0x5544` = `'UD'` (used) — the *value* is an ASCII pair while the *type* is a
`u16`. That is why the `char magic[2]` guess was so persistent.

`Target` is deliberately left an aggregate with no declared constructor: declaring one
removes the implicit default, and `Deallocate` builds a `Target` as a plain local. Its C1
stays a hand-spelled free function — ctor migration is Phase 5.

## Two problems the byte gate found that review would not have

**The header first spelled the links `MemoryNode* prev`.** C has no injected class name,
and `ExpandingHeapAllocator`'s constructor is still a `.c` file that reaches this header,
so the ROM build failed outright. Spelled `struct MemoryNode *` it compiles both ways.
`tools/header_cpp_sweep.py` exists to catch exactly this and would have, had I run it
before the build rather than after.

**Then `class 'MemoryNode' redefined`** in three files that already included
`ExpandingHeapAllocator.h` and carried their own copies. Removing them is the
reconciliation working as intended; all three still byte-verify. `Reallocate`, `FreeNode`
and `Target`'s constructor keep local copies for now only because they include nothing.

## AllocateNode is one word off and is NOT landed

At `+0x10c` the ROM has `ldrh r3,[sp,#0x38]` where we emit `ldr r3,[sp,#0x38]`.

Its fifth argument is stack-passed (AAPCS puts args 5+ on the stack) and the ROM reads
only the low halfword — the load width mwccarm picks when the declared type is 16-bit.
But the mangled name ends `jj`, fixing both trailing parameters as `u32`, and a `u32`
parameter gets a word load. The recovered body squares that circle by declaring the
parameter `unsigned short`, which reproduces but cannot be a member signature.

Tried and rejected, all measured:

| attempt | result |
|---|---|
| truncating local `unsigned short z = fromHighEnd` | **999 words** — changes how the argument is homed |
| `*(unsigned short *)&param` | **5 words** — taking the address re-homes it |
| casts at the use site | no effect — load width follows the parameter's declared type |

Same shape as `DeallocateAll`'s `PPFvPvPS_jE`: the mangled name and the reproducing body
disagree about a parameter type, and the ROM's own codegen is the tiebreaker evidence.
Recorded in the header and left for a deliberate investigation rather than a guess.
`FreeNode` is unblocked by this type but not attempted here.

## Gates

| gate | result |
|---|---|
| `build_pin.verify` @ `2004/b56` | 6/6 touched functions |
| `rombuild` | **106/106 exact**, 10,699 reproducing / 0 mismatching |
| `eligible` | 10699 — unchanged |
| `port_refcheck` | 394 checked, 0 stale |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154eg3RhXQYPyfKyv5t81Fz