### PR TITLE
notes: where the symbol names came from; and stop verify_mangled crashing on a rebuilt ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,3 +205,8 @@ Do not open the PR with near-misses in `src/` expecting the maintainer to split 
 - [`notes/matching-style.md`](notes/matching-style.md) "Known walls" — patterns proven
   unreachable from source. If your **only** divergence is one of those, it's a wall:
   store the near-miss and hand it to the permuter instead of grinding.
+- [`notes/symbol-name-provenance.md`](notes/symbol-name-provenance.md) — which parts of a
+  mangled name are ROM-proven and which are somebody's assertion. The address and the
+  class name are well attested; **parameter types are not**, and roughly half of all
+  mangled symbols have never been checked by a compiler. Read it before you contort a
+  body to satisfy a signature — the name is sometimes the thing that's wrong.

--- a/notes/symbol-name-provenance.md
+++ b/notes/symbol-name-provenance.md
@@ -1,0 +1,263 @@
+# Where the names came from, and which parts of one to trust
+
+A retail NDS cartridge has no symbol table. **Nothing in `config/**/symbols.txt` was read
+out of a symbol table, because there isn't one.** Every name is either a placeholder, a
+string the ROM genuinely stores, a structure the ROM genuinely proves, or somebody's
+assertion. This note says which is which, and — more usefully — which *parts of a single
+name* are which, because a mangled name is not one claim. It is four or five claims
+welded together, and they have wildly different evidence behind them.
+
+Written after #1226, where two imported names turned out to be asserting parameter types
+the ROM refutes. Neither was a sloppy guess; both were unfalsifiable from where they were
+written. That is the pattern worth internalising.
+
+> **Counts below are measured at `af680244` (main), before #1226 lands.** They drift as
+> migrations land — #1226 alone moves two methods out of the unmigrated column. Re-derive
+> with `tools/langmode_audit.py` before quoting any of them; the *ratios* are the durable
+> part, not the digits.
+
+## The short version
+
+```
+_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjt
+   ^class name          ^method name    ^parameter types
+   RTTI-checkable       a label         WEAKEST LINK
+```
+
+| part of the name | who could have proven it wrong | trust |
+|---|---|---|
+| the **address** it binds to | our own `dsd` analysis — must be an exact function start | **high** |
+| the **class name** | ROM RTTI, where the class has any | **high** where RTTI exists |
+| the **method name** | nothing. It is a label | medium — wrong names are cosmetic |
+| **parameter count** | the arity test against the ROM body | **high** — see below |
+| **parameter types** | only a byte-match of the callee | **low until migrated** |
+
+If you are about to act on a parameter *type* from a name you did not verify, stop and
+read the last three sections.
+
+## The tiers, with counts
+
+Repo-wide: **31,757 symbols across 106 modules.**
+
+| tier | what | count | share |
+|---|---|---|---|
+| E | `func_<addr>` / `data_<addr>` placeholders | 26,162 | 82.4% |
+| D | mangled `_Z…` methods and free functions | 2,663 | 8.4% |
+| — | plain identifiers (SDK signatures + local C-style names) | 1,697 | 5.3% |
+| A | `_ZTI…` type_info records | 426 | 1.3% |
+| A | `_ZTS…` type-name strings | 422 | 1.3% |
+| B | `_ZTV…` vtables | 387 | 1.2% |
+
+### Tier A — read out of the ROM. Trust the string.
+
+The 848 `_ZTS`/`_ZTI` symbols. The suffix on a `_ZTS` name **is the literal byte string
+the ROM stores** — that string *is* the Itanium type name, which is why no re-mangling is
+needed and why nested names and `St` substitutions come out right for free
+(`tools/rtti_symbols.py`). 429 classes and 413 inheritance edges were read this way.
+
+Hard limit: **RTTI gives you class names and nothing else.** No method names, no
+parameter types, no static-vs-instance. If someone cites "the RTTI" for a method
+signature, they are citing something that does not exist.
+
+### Tier B — structurally proven from ROM data. Trust the wiring, not the English.
+
+2,241 actor symbols across 68 modules (#211) came from walking `ACTOR_SPAWN_TABLE`
+(EU `0x02090864`, 391 entries). The table proves *which function spawns which actor*,
+*which vtable belongs to it*, and *which slot is which* — the slot order was validated
+against a byte-matched function on ov056.
+
+But `BigMovingIceBlock` is a drafted label, not a ROM string. `config/rom-name-glossary.json`
+is explicit about this and carries a per-entry confidence, noting: *"nothing in the binary
+says what 'Ukiyuka' means."* So: the *relationship* the name encodes is ROM-proven; the
+English word is a community reading. Renaming one costs nothing; relying on the wiring is
+safe.
+
+### Tier C — SDK/BIOS signatures
+
+`CpuFastSet`, `VBlankIntrWait`, `MIi_CpuClear16`, `G3_MultMtx33` and friends, recognised
+by `dsd` against the known Nintendo SDK. External ground truth, and the signatures come
+with the SDK rather than being reconstructed. High trust.
+
+### Tier D — imported community reconstruction. **This is where the errors live.**
+
+At least **1,349 mangled names are verbatim imports** from
+`reference/DynamicAllocationDecomp/symbols.x`, applied by `tools/import_symbols.py`.
+Broken down:
+
+| kind | imported | not imported |
+|---|---|---|
+| member / free function | 1,164 | 898 |
+| destructor | 99 | 442 |
+| constructor | 53 | 1 |
+| vtable | 33 | 354 |
+
+> **Measurement caveat:** `import_symbols.py` lists four upstream sources but only
+> `DynamicAllocationDecomp` is present in this checkout. The "imported" column is a
+> **lower bound**; some names counted as local may also be imports.
+
+**What that upstream file actually is matters enormously.** DynamicAllocationDecomp is an
+ASM-hack/mod project. For most of these symbols it has no decompiled body — it has a
+hand-written header declaring the function so mod code can *call* into the ROM, plus a
+linker script binding that spelling to an address. Their build links successfully no
+matter what the parameter types say.
+
+What the import process *did* verify: **the address.** `import_symbols.py` refuses any
+name whose address is not an exact function-or-data start in our own analysis; 71.9% of
+upstream's addresses cleared that bar and the rest were dropped. So the address is good
+and the identifier is probably good. **The parameter types were never checked by anything.**
+
+### Tier E — placeholders
+
+`func_02005000`. No claim at all. Not a weak name — an *absent* one. Never cite one as
+evidence of anything.
+
+## Why a caller can never catch a wrong parameter type
+
+This is the mental model that explains every correction in the track record.
+
+Upstream's declarations exist to **call** these functions. Consider the two errors #1226
+fixed:
+
+- `AllocateNode`'s fifth parameter, declared `u32`, is really `u16`. AAPCS widens a
+  sub-word argument to a full word on the way in, so *the caller emits identical
+  instructions either way*. The callee ignores the high half. Nothing observable.
+- `DeallocateAll`'s callback, declared as pointer-to-pointer-to-function, is really a
+  plain function pointer. A function pointer and its address are the same word.
+
+Neither project's build could ever have failed. The types were **unfalsifiable from the
+call site.** They are only observable from *inside the callee*, in the instruction the
+compiler picks — and nobody was looking there until someone tried to declare the function
+as a real C++ member.
+
+> **The rule:** treat an imported parameter type as unverified wherever a member signature
+> cannot reproduce the bytes. When the name and a reproducing body disagree, **the ROM's
+> codegen is the tiebreaker, and the name is the thing that yields.**
+
+## Static-vs-instance is on much firmer ground than the types
+
+Worth stating plainly, because it comes up constantly and the anxiety is misplaced.
+
+**Static-vs-instance comes from the arity test, not from trusting the name.** Count the
+parameters the mangled name declares, count the arguments the ROM body actually uses. Equal
+→ static. Body uses one more → the leading one is `this`.
+
+That test is self-validating. It reads the name's parameter *count* and checks it against
+the ROM. If the count were wrong the test would return nonsense — a negative implied
+parameter, or a `this` never used as one — and you would notice immediately.
+
+And empirically: **every correction so far has been to a parameter's type, never to the
+count.** `Pvjj → Pvjt` preserves arity. `PPFvPvPS_jEj → PFvPvPS_jEj` preserves arity. The
+D1/D2 corrections were identity errors, not signature errors.
+
+So the arity test is sound. What it does *not* license is inheriting a neighbour's answer:
+`ExpandingHeapAllocator::AllocateForwards` mangles `Ejj` and is an **instance** method;
+`SolidHeapAllocator`'s identically-named method mangles `EPvjj` and is **static**. Same
+name, opposite answer, one class apart (#1221, #1215). Run the test per function.
+
+## The one check that actually verifies a signature
+
+Declaring the function as a **real C++ member** and byte-matching it. Parameter types feed
+codegen — load widths, argument homing, whether a call needs an extra indirection — so a
+member declaration that reproduces the ROM has had its types *checked by the compiler
+against the ROM*. A hand-spelled `extern "C"` name has not: the string is whatever you
+typed, and the linker resolves it by address regardless.
+
+`tools/langmode_audit.py` measures exactly this gap:
+
+```
+NOT MIGRATED   1219  of 2525 mangled-symbol files (48.3%)
+    .c extension              943
+    .cpp, symbol hand-spelt   276   renamed, never migrated
+```
+
+**Roughly half of all mangled symbols in this tree have never been checked by a compiler.**
+Per kind (unmigrated / migrated):
+
+| kind | unmigrated | migrated | status |
+|---|---|---|---|
+| method | 693 | 1,229 | mixed |
+| D0 | 258 | 3 | effectively unproven |
+| D1 | 194 | 72 | mixed |
+| D2 | 20 | 0 | **UNPROVEN** |
+| C1 | 41 | 0 | **UNPROVEN** |
+| C2 | 11 | 0 | **UNPROVEN** |
+| C3 | 2 | 0 | **UNPROVEN** |
+
+A `.cpp` extension is **not** evidence of migration — 274 files are `.cpp` while still
+hand-spelling their symbol inside `extern "C"`. Check for a real member definition.
+
+## Grep will miss references. Use the linker.
+
+`langmode_audit.py` also counts **2,643 shadow declarations** — files carrying a local copy
+of a type or class instead of including the shared header — of which **1,626 include
+nothing at all**.
+
+This is not theoretical. In #1226, `ExpandingHeap::VDeallocateAll` carried its own private
+redeclaration of `ExpandingHeapAllocator`, so the wrong symbol `PPFvPvPS_jE` **never
+appeared as a literal string anywhere in the tree**. A repo-wide grep found nothing. It
+surfaced only as an `mwldarm` undefined-symbol error during the ROM build.
+
+> **If you rename a symbol, `tools/rombuild.py` is the check that matters.** Grep is a
+> hint; the linker is the proof.
+
+That file's call site had been carrying the tell all along:
+
+```cpp
+(Visitor*)&ExpandingHeapAllocator::InvokeDeallocate
+```
+
+`&InvokeDeallocate` already *is* a `Visitor`. **A cast whose only purpose is to satisfy a
+signature is evidence against the signature.** Worth grepping your own work for.
+
+## Track record
+
+Imported names have been corrected repeatedly. This is normal, not scandalous — but it
+calibrates how much weight to put on one.
+
+| PR | correction | class of error |
+|---|---|---|
+| #178 | six `_ZThn80` thunks pointed at the wrong classes | identity |
+| #201 | duplicate `_Znwj`; real operator-new was elsewhere | identity |
+| #206 | both `Scene` D0 dtors were false matches | identity |
+| #774 | `Actor` / `ActorBase` D1 and D2 names swapped | identity |
+| #1203 | 7 of 17 "D2" symbols appear in a vtable, so they cannot be D2s | identity |
+| #1226 | `AllocateNode` `Pvjj→Pvjt`; `DeallocateAll` `PPF…→PF…` | **parameter type** |
+
+Note the asymmetry. Identity errors get caught because the link or the byte compare
+screams. **A wrong parameter type is silent until someone tries to migrate the function.**
+Expect more of them, one at a time, at exactly that moment.
+
+## What to do when a member signature won't reproduce
+
+The procedure that worked, in order:
+
+1. **Suspect the name before you contort the body.** If you find yourself adding a
+   truncating local, an address-taken cast, or a use-site cast to force a load width — the
+   declaration is what's wrong. Those were all measured on `AllocateNode` and cost 999, 5
+   and 0 words respectively. None can work, because none changes the declared type.
+2. **Read the divergent instruction as evidence.** `ldrh` vs `ldr` on a parameter is the
+   compiler telling you the declared width. `blx r6` with no preceding `ldr r6,[r6]` is it
+   telling you the thing is a function pointer, not a pointer to one.
+3. **Check the provenance.** Is the name in `reference/*/symbols.x`? Does that project have
+   an actual body for it, or only a calling declaration? If the latter, its parameter types
+   are decoration.
+4. **Change the declaration and let the compiler mangle it.** Do not hand-derive the new
+   mangled string — substitution numbering (`S_`, `S0_`, `S1_`) re-resolves in ways that are
+   easy to get wrong. Compile and read the emitted symbol out of the object.
+5. **Verify with the full build**, not just `match.py` — see the grep warning above.
+
+## Files worth knowing
+
+| path | what it is |
+|---|---|
+| `config/**/symbols.txt` | **what we assert.** The only file that states our claim |
+| `symbols/verified.tsv` | what was **imported**. A record, not an assertion — left stale on purpose |
+| `config/match_attempts.jsonl` | append-only attempt history, keyed on address, never on name |
+| `reference/DynamicAllocationDecomp/symbols.x` | upstream. 25 of its 2,125 entries are commented out, with margin notes like *"this is NOT the start of a function!!!"* — it is honest about being a working artifact |
+| `config/rom-name-glossary.json` | the hand-authored EAD glosses, with per-entry confidence |
+| `notes/cpp-naming-guide.md` | Itanium mangling reference — the type codes (`j` = u32, `t` = u16, …) |
+
+## See also
+
+`notes/actor-naming.md` · `notes/rtti-reconciliation.md` ·
+`notes/runbook-type-reconstruction.md` · `notes/plan-cpp-language-mode.md` · `CREDITS.md`

--- a/tools/verify_mangled.py
+++ b/tools/verify_mangled.py
@@ -4,6 +4,22 @@ Reads progress/matched.jsonl, selects every entry whose first version is a
 "template:..." tag and whose symbol is Itanium-mangled (_Z...), then re-runs the
 canonical single-version match for each and prints a pass/fail summary.
 
+NOT EVERY LEDGER ROW CARRIES VERSION PROVENANCE, and this tool used to crash on the
+ones that do not. progress/matched.jsonl has two writers with different row shapes:
+the banking paths append {"versions": [...]}, while tools/rebuild_ledger.py reconstructs
+the whole file from committed src/ and writes {"tag": "src-rebuild"} instead -- it works
+from what is on disk and genuinely cannot know which compiler version each function was
+matched at. Indexing d["versions"] therefore raised KeyError on every row of a rebuilt
+ledger, which is the normal state after a fresh worktree or a large merge.
+
+Selecting nothing is now reported, not silently treated as success: a ledger with no
+version provenance cannot answer the question this tool asks, and printing "0 pass,
+0 fail" would read as an all-clear. Rebuild provenance by re-banking, or verify the
+functions you care about directly with tools/match.py.
+
+Exit codes: 0 all selected functions matched, 1 at least one failed, 2 nothing could
+be selected (see above).
+
 Usage:
     python tools/verify_mangled.py            # verify all mangled template funcs
     python tools/verify_mangled.py _ZN5Actor  # verify only names matching a substring
@@ -42,12 +58,33 @@ def overlay_bin_and_base(module: str):
 filt = sys.argv[1] if len(sys.argv) > 1 else ""
 
 rows = []
+total = no_provenance = 0
 for line in MATCHED.read_text().splitlines():
     if not line.strip():
         continue
     d = json.loads(line)
-    if "template:" in d["versions"][0] and d["name"].startswith("_Z") and filt in d["name"]:
+    total += 1
+    # rebuild_ledger.py rows carry "tag" instead of "versions" -- see the module docstring.
+    versions = d.get("versions") or []
+    if not versions:
+        no_provenance += 1
+        continue
+    if "template:" in versions[0] and d["name"].startswith("_Z") and filt in d["name"]:
         rows.append(d)
+
+if no_provenance:
+    print(f"note: {no_provenance} of {total} ledger row(s) carry no version provenance "
+          f"(written by rebuild_ledger.py, which cannot know it); skipped.")
+
+if not rows:
+    where = f" matching {filt!r}" if filt else ""
+    if no_provenance == total and total:
+        print(f"\nnothing to verify: the whole ledger was rebuilt from committed src/, so no "
+              f"row records the version it was matched at.\nRe-bank the functions you want "
+              f"tracked, or check one directly with tools/match.py.")
+        sys.exit(2)
+    print(f"\nnothing to verify: no mangled template row{where} in the ledger.")
+    sys.exit(2)
 
 rows.sort(key=lambda d: d["addr"])
 npass = nfail = 0


### PR DESCRIPTION
Two things that fell out of #1226, neither touching `src/` or `config/` — no byte impact,
no coverage change.

## 1. `notes/symbol-name-provenance.md` (+ indexed in AGENTS.md)

A retail NDS cartridge has no symbol table, so nothing in `config/**/symbols.txt` was read
out of one. Every name is a placeholder, a string the ROM genuinely stores, a structure the
ROM genuinely proves, or somebody's assertion. The note says which is which — and more
usefully, **which part of a single name** is which, since a mangled name is four or five
claims welded together with very different evidence behind each.

```
_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjt
   └──────── class ────────┘└─ method ─┘                └ params ┘
   RTTI-checkable           a label                     WEAKEST LINK
```

**The part that keeps getting asked the wrong way round** is static-vs-instance. That comes
from the arity test, not from trusting the name, and the test cross-checks the name against
the ROM — a wrong parameter count would produce visible nonsense. Empirically every
correction so far has been to a parameter's *type*, never the count: `Pvjj → Pvjt` and
`PPFvPvPS_jEj → PFvPvPS_jEj` both preserve arity, and the D1/D2 corrections were identity
errors. The anxiety is usually pointed at the wrong field.

**Two measurements worth having written down**, both from `tools/langmode_audit.py`:

- **1,219 of 2,525 mangled-symbol files (48.3%) are not migrated** — roughly half of all
  mangled symbols have never been checked by a compiler. A declared C++ member that
  byte-matches has had its parameter types verified against the ROM *by codegen*; a
  hand-spelled `extern "C"` name has not. A `.cpp` extension is not evidence of migration
  (276 files are `.cpp` while still hand-spelling the symbol). D2, C1, C2 and C3 have zero
  migrations between them.
- **1,626 files carry a local type declaration with no include at all** — the
  `VDeallocateAll` case from #1226, quantified. The wrong symbol never appeared as a literal
  string anywhere, so grep found nothing and only mwldarm surfaced it. Grep is a hint;
  `rombuild.py` is the proof.

Counts are pinned to `af680244` and the note says so, since they drift as migrations land.
The ratios are the durable part.

## 2. `verify_mangled.py` — two bugs

`python tools/verify_mangled.py <filter>` died with `KeyError: 'versions'` on any tree whose
`progress/matched.jsonl` had been rebuilt — which is the normal state after a fresh worktree
or a large merge, exactly when you most want to re-verify.

**Two writers, two row shapes.** The banking paths append `{"versions": [...]}`;
`rebuild_ledger.py` reconstructs the file from committed `src/` and writes
`{"tag": "src-rebuild"}` instead. That is not an oversight on its part — it works from
what's on disk and genuinely cannot know which compiler version each function was matched
at. Pre-existing since `be353f57`; running the rebuild is just what surfaces it.

**The second half matters more than the crash.** Once the `KeyError` is guarded, the selector
finds no rows and the old code fell through to `0 pass, 0 fail (of 0)` and **exit 0** — a
tool that verified nothing reporting an all-clear. Selecting nothing is now an explicit
outcome with exit 2, and the message distinguishes a ledger with no version provenance from
a filter that simply matched no template row.

Deliberately **not** fixed by having `rebuild_ledger.py` synthesise a `versions` field. It
doesn't have that information, and inventing one would make the ledger assert provenance it
cannot support — the same class of error #1226 is about.

Verified on all three shapes: a fully rebuilt ledger (11,205 rows → clean message, exit 2),
a mixed ledger (notes the skipped rows, verifies the rest), and a selectable pair
(`2 pass, 0 fail`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEerTGbXbeTMpPpviwFEtG
