### PR TITLE
Heap: reconstruct the abstract base from its ROM vtable, and delete nine fake ones

### DIFF
--- a/include/Heap.h
+++ b/include/Heap.h
@@ -1,34 +1,178 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class Heap: 21 matched functions, 4 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
+/* Hand-edited, against evidence. This file used to carry the
+ * "AUTO-GENERATED ... by tools/gen_header.py" banner, which was never true --
+ * see notes/runbook-type-reconstruction.md section 2.
+ *
+ * class Heap: 21 matched functions, 5 fields, 16 vtable slots.
+ *
+ * THE __cplusplus BLOCK BELOW HAD NEVER BEEN COMPILED, and carried the same
+ * generator defect as ExpandingHeapAllocator.h and SolidHeapAllocator.h: it
+ * emitted `struct a; struct a_; struct b;' as forward declarations -- parameter
+ * names mistaken for type names. No source file ever referenced them; dropped.
+ *
+ * THE ROM'S NAME FOR THIS CLASS IS `mHeap::Heap_t'. Its RTTI record at
+ * arm9:0x02099ce4 spells `N5mHeap6Heap_tE', and its two subclasses are
+ * `mHeap::SolidHeap_t' (0x02099cf8) and `mHeap::ExpHeap_t' (0x02099cec). The
+ * tree calls them Heap / SolidHeap / ExpandingHeap, and every symbol in
+ * the config symbols.txt files is spelled that way, so renaming is a whole-tree
+ * change and is deliberately NOT done here. Recorded so the next reader does
+ * not rediscover it.
+ *
+ * ==== LAYOUT: 0x14 bytes, and the evidence for each field ====
+ *
+ * Offsets/widths are observed (evidence_history + evidence_rom, both passes
+ * agreeing on 4-byte accesses at 0x00/0x04/0x08/0x0c/0x10). Names come from the
+ * constructor's own body, not from a guess: _ZN4HeapC1EPvjP4Heap writes start,
+ * size and root into 0x04/0x08/0x0c in that order and then zeroes 0x10.
+ *
+ * TWO CORRECTIONS TO THE SKELETON THIS REPLACES:
+ *
+ *   - `u8 unk_010' was WRONG. Both evidence passes see five 4-byte accesses at
+ *     0x10 and none narrower; the constructor stores the 32-bit constant 0x4000
+ *     there. It is a u32 flag word, and the narrow declaration was the broken
+ *     one -- the same shape of error as include/ChainChomp.h's `u8 mScaleX'
+ *     (runbook section 2, "Observed is not correct").
+ *
+ *   - THERE IS NO FIELD AT 0x14 ON Heap. evidence_rom reports one, from a
+ *     single witness: the *static* Heap::CreateRootHeap (0x0203c8e8), which
+ *     builds an ExpandingHeap in place and therefore writes the derived class's
+ *     field through a pointer the pass attributed to Heap. Both derived
+ *     constructors settle it -- _ZN9SolidHeapC1E... and
+ *     _ZN13ExpandingHeapC1E... each call Heap::Heap(start, size, root), which
+ *     writes 0x00..0x10, and only then write their own `allocator' at 0x14. So
+ *     0x14 belongs to SolidHeap and ExpandingHeap, which are 0x18 bytes; Heap
+ *     is 0x14. The `address-only' evidence at 0x18 is code taking `this + 0x18',
+ *     one past a derived object -- CreateRootHeap does exactly that to find the
+ *     start of the arena it is about to hand out.
+ *
+ * ==== THE VTABLE, READ OUT OF THE ROM ====
+ *
+ * Heap's vtable is at arm9:0x02099d90 and is SIXTEEN slots, of which slots
+ * 2..15 are all NULL. Heap is an ABSTRACT BASE. Do not trust
+ * `rtti_vtables.py --own Heap', which reports "2 slots": it trims trailing
+ * nulls, and for an abstract base the nulls are the whole point. Read the raw
+ * words -- the two tables that follow it, SolidHeap (0x02099d48) and
+ * ExpandingHeap (0x02099dd8), are full 16-slot tables and fix the order:
+ *
+ *   slot  0  ~Heap()  (D1)          slot  8  VReallocate
+ *   slot  1  ~Heap()  (D0)          slot  9  VSizeof
+ *   slot  2  VDestroy               slot 10  VMaxAllocationUnitSize
+ *   slot  3  VAllocate              slot 11  VMaxAllocatableSize
+ *   slot  4  VDeallocate            slot 12  VMemoryLeft
+ *   slot  5  VDeallocateAll         slot 13  VSetNodeID
+ *   slot  6  VIntact                slot 14  VGetNodeID
+ *   slot  7  VRescue                slot 15  VResizeToFit
+ *
+ * Return types are taken from the DEFINITIONS (the ExpandingHeap and SolidHeap
+ * overrides, which are migrated and byte-gated), never from a caller -- callers
+ * disagree 27% of the time and most of these discard the result. Note that
+ * slot 3 is spelled `VAllocate(u32, int)': _ZN13ExpandingHeap9VAllocateEji.
+ * _ZN9SolidHeap9VAllocateEjj claims (u32, u32) for the SAME SLOT, so one of the
+ * two imported names is wrong and it is not this one -- every sibling in the
+ * family (Heap::Allocate, SolidHeapAllocator::Allocate,
+ * ExpandingHeapAllocator::Allocate) spells `Eji'. Tracked separately; correcting
+ * a symbol is its own PR with its own evidence.
+ */
 #ifndef HEAP_H
 #define HEAP_H
 #include "types.h"
 
-/* fwd */
-struct a;
-struct a_;
-struct b;
+/* The class is spelled twice, the way include/Fader.h spells Fader: a C
+ * translation unit gets no implicit vptr, so the C side must declare `vtable'
+ * explicitly or every field below it shifts by 4. Nine .c files include this
+ * header, so that is not hypothetical.
+ *
+ * THE C SPELLING COMES FIRST ON PURPOSE. tools/check_header_offsets.py walks
+ * the first `struct X {' it finds and stops at the first `virtual' line,
+ * reporting the header "skipped -- polymorphic C++ struct". Putting the C
+ * struct first gives that gate a layout it can actually verify: it now reports
+ * 5 fields spanning 0x14 and would fail on a wrong offset. With the C++ struct
+ * first it reported "0 commented fields ... struct spans 0x0" -- which reads
+ * like a pass and checks nothing.
+ *
+ * FIELD MEANINGS ARE DOCUMENTED ON THE C++ SPELLING BELOW. They are kept off
+ * these lines because that gate parses a trailing `/* 0xNN *[/]' and a comment
+ * running onto the next line makes the field unparsed. */
+#ifndef __cplusplus
 struct Heap {
-    u8  pad_000[0x4];
-    s32 unk_004;            /* 0x004 */
-    s32 unk_008;            /* 0x008 */
-    s32 unk_00c;            /* 0x00c */
-    u8  unk_010;            /* 0x010 */
-#ifdef __cplusplus
-    /* methods */
-    bool Intact();
-    int Allocate(unsigned int a, int b);
-    int MaxAllocationUnitSize();
-    int Rescue();
-    int SetDefault();
-    int Sizeof(void * a);
-    void Deallocate(void * a);
-    void Destroy();
-    void Reallocate(void * a, unsigned int b);
-    void SetNodeID(unsigned int a_);
-#endif
+    void* vtable;                   /* 0x00 */
+    void* heapStart;                /* 0x04 */
+    u32   heapSize;                 /* 0x08 */
+    struct Heap* parentHeap;        /* 0x0c */
+    u32   flags;                    /* 0x10 */
 };
+#else
+struct Heap {
+    void* heapStart;                /* 0x04 -- first byte of the arena this heap
+                                       hands out; for a root heap it is the heap
+                                       object's own end, `this + 0x18'. */
+    u32   heapSize;                 /* 0x08 -- arena size in BYTES, not an end
+                                       address. Heap::CreateRootHeap's local
+                                       shadow calls it `heapEnd' and types its
+                                       own parameter `void* end', but its
+                                       mangled name is _ZN4Heap14CreateRootHeapEPvj
+                                       -- `j', a u32 -- and it passes
+                                       `size - 0x18' onward as a size. Three of
+                                       the four hand-written shadows in the tree
+                                       already agreed on heapSize; that fourth
+                                       one is the outlier. */
+    struct Heap* parentHeap;        /* 0x0c -- heap this one was carved out of;
+                                       NULL for the root. Heap::Destroy releases
+                                       the block back through it. */
+    u32   flags;                    /* 0x10 -- bit 0x4000 = fail-fast: when set,
+                                       an allocation that returns NULL, a Sizeof
+                                       that returns -1, or a ResizeToFit that
+                                       returns 0 calls Crash() instead of
+                                       reporting failure to the caller. The
+                                       constructor sets it, so every heap is
+                                       fail-fast unless something clears it. */
+
+    /* THE DESTRUCTOR IS DECLARED FIRST AND MUST NEVER BE DEFINED AS A REAL
+       METHOD. It occupies slots 0/1, which makes it this class's key function;
+       defining it would emit _ZTV4Heap/_ZTI4Heap/_ZTS4Heap into that
+       translation unit and eligible.py would reject the file with "extra
+       sections: .data". include/Actor.h states the same rule and for the same
+       reason: declaring the destructor first pins that role to translation
+       units which by construction never define it. See runbook section 7. */
+    virtual ~Heap();
+
+    /* Pure, because the ROM says so: Heap's own sixteen slots hold code only at
+       0 and 1, and NULL at 2..15. Every one of these is implemented by
+       SolidHeap and by ExpandingHeap. */
+    virtual void  VDestroy() = 0;                       /*  2 */
+    virtual void* VAllocate(u32 size, int align) = 0;   /*  3 */
+    virtual void  VDeallocate(void* ptr) = 0;           /*  4 */
+    virtual void  VDeallocateAll() = 0;                 /*  5 */
+    virtual bool  VIntact() = 0;                        /*  6 */
+    virtual void  VRescue() = 0;                        /*  7 */
+    virtual void* VReallocate(void* ptr, u32 size) = 0; /*  8 */
+    virtual u32   VSizeof(void* ptr) = 0;               /*  9 */
+    virtual u32   VMaxAllocationUnitSize() = 0;         /* 10 */
+    virtual u32   VMaxAllocatableSize() = 0;            /* 11 */
+    virtual u32   VMemoryLeft() = 0;                    /* 12 */
+    virtual void  VSetNodeID(u32 id) = 0;               /* 13 */
+    virtual u32   VGetNodeID() = 0;                     /* 14 */
+    virtual u32   VResizeToFit() = 0;                   /* 15 */
+
+    /* Non-virtual public interface. Each of these is a thin guard around the
+       matching slot: call it, and on failure consult `flags & 0x4000'. Only the
+       ones whose definitions are migrated and byte-verified are declared here;
+       the rest arrive with their own migrations, where a wrong signature stops
+       being unfalsifiable. */
+    void* Allocate(u32 size);                /* forwards with align = 4 */
+    void* Allocate(u32 size, int align);     /* slot  3, Crash() on NULL */
+    void  Deallocate(void* ptr);             /* slot  4 */
+    void  Reallocate(void* ptr, u32 size);   /* slot  8 */
+    int   Sizeof(void* ptr);                 /* slot  9, Crash() on -1 */
+    void  Destroy();                         /* slot  2, then releases 0x0c */
+    bool  Intact();                          /* slot  6 */
+    void  Rescue();                          /* slot  7 */
+    u32   MaxAllocationUnitSize();           /* slot 10 */
+    void  SetNodeID(u32 id);                 /* slot 13 */
+    int   SetDefault();                      /* swaps the global default heap */
+
+    static void InitializeRootHeap();
+    static void SetupRootHeap();
+};
+#endif
 
 #endif

--- a/src/_ZN4Heap10DeallocateEPv.cpp
+++ b/src/_ZN4Heap10DeallocateEPv.cpp
@@ -1,10 +1,14 @@
 //cpp
 // @symbol _ZN4Heap10DeallocateEPv
-/* recovered: named members + shared header, real C++ method */
+/* Heap::Deallocate(void*) at 0x0203c538 -- forwards to the concrete heap's
+ * slot 4. No guard: freeing is the one operation with nothing to fail at.
+ *
+ * Was a cast of `this' to a local `struct Base' with four anonymous virtuals
+ * padding `m' out to index 4; VDeallocate is now Heap's own slot-4 pure
+ * virtual. */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void m(void*); };
 
-void Heap::Deallocate(void * a)
+void Heap::Deallocate(void* ptr)
 {
- ((Base *)this)->m(a);
+    VDeallocate(ptr);
 }

--- a/src/_ZN4Heap10ReallocateEPvj.cpp
+++ b/src/_ZN4Heap10ReallocateEPvj.cpp
@@ -1,10 +1,15 @@
 //cpp
 // @symbol _ZN4Heap10ReallocateEPvj
-/* recovered: named members + shared header, real C++ method */
+/* Heap::Reallocate(void*, u32) at 0x0203c578 -- forwards to slot 8 and drops
+ * the result. The slot returns the new block (ExpandingHeap::VReallocate is
+ * declared void*), but this wrapper is void, so a caller that wants the
+ * pointer has to go through the heap directly.
+ *
+ * Was a cast of `this' to a local `struct Base' with eight anonymous virtuals
+ * padding `m' out to index 8. */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void m(void*,unsigned int); };
 
-void Heap::Reallocate(void * a, unsigned int b)
+void Heap::Reallocate(void* ptr, u32 size)
 {
- ((Base *)this)->m(a,b);
+    VReallocate(ptr, size);
 }

--- a/src/_ZN4Heap18InitializeRootHeapEv.cpp
+++ b/src/_ZN4Heap18InitializeRootHeapEv.cpp
@@ -1,5 +1,5 @@
 //cpp
-#include "types.h"
+// @symbol _ZN4Heap18InitializeRootHeapEv
 /* Heap::InitializeRootHeap() at 0x0203cae8 -- clears ROOT_HEAP_ARENA_ID then
  * tail-calls Heap::SetupRootHeap().
  *
@@ -8,15 +8,13 @@
  * argument to the OS arena calls at 0x02058cd0/0x02058d58/0x02058ea0/
  * 0x02058eb4/0x02059040. Zeroing it here selects OS_ARENA_MAIN. An earlier
  * recovery pass called it `Memory::rootParamOffset', which the callers do
- * not support. */
-extern "C" u32 ROOT_HEAP_ARENA_ID;
+ * not support.
+ *
+ * Both statics used to be declared in a local `class Heap' here instead of
+ * coming from the header. */
+#include "Heap.h"
 
-class Heap
-{
-public:
-    static void SetupRootHeap();
-    static void InitializeRootHeap();
-};
+extern "C" u32 ROOT_HEAP_ARENA_ID;
 
 void Heap::InitializeRootHeap()
 {

--- a/src/_ZN4Heap21MaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN4Heap21MaxAllocationUnitSizeEv.cpp
@@ -1,10 +1,12 @@
 //cpp
 // @symbol _ZN4Heap21MaxAllocationUnitSizeEv
-/* recovered: named members + shared header, real C++ method */
+/* Heap::MaxAllocationUnitSize() at 0x0203c60c -- plain forward to slot 10.
+ *
+ * Was a cast of `this' to a local `struct Base' with ten anonymous virtuals
+ * padding `m' out to index 10. */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual int m(); };
 
-int Heap::MaxAllocationUnitSize()
+u32 Heap::MaxAllocationUnitSize()
 {
- return ((Base *)this)->m();
+    return VMaxAllocationUnitSize();
 }

--- a/src/_ZN4Heap6IntactEv.cpp
+++ b/src/_ZN4Heap6IntactEv.cpp
@@ -1,15 +1,25 @@
 //cpp
 // @symbol _ZN4Heap6IntactEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+/* Heap::Intact() at 0x0203c664. Asks the concrete heap whether its bookkeeping
+ * is still consistent (slot 6), and latches a global the first time one says no.
+ *
+ * This file used to reach the vtable by casting `this' to a locally declared
+ * `struct Base { virtual void v0(); ... virtual bool m(); }' -- six anonymous
+ * slots of padding so that `m' landed on index 6. The cast is gone: Heap now
+ * declares VIntact as its own slot-6 pure virtual, so this is an ordinary
+ * virtual call and the slot index is the header's business, not this file's. */
 #include "decl_common.h"
-/* recovered: named members + shared header, real C++ method */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual bool m(); };
 
 bool Heap::Intact()
 {
-  bool r = ((Base *)this)->m();
-  if (r) return r;
-  if (!data_020a0e98) data_020a0e98 = 1;
-  return r;
+    bool intact = VIntact();
+    if (intact)
+        return intact;
+
+    /* Latched once and never cleared -- the first corrupted heap in the run is
+       the one worth reporting. */
+    if (!data_020a0e98)
+        data_020a0e98 = 1;
+    return intact;
 }

--- a/src/_ZN4Heap6RescueEv.cpp
+++ b/src/_ZN4Heap6RescueEv.cpp
@@ -1,10 +1,17 @@
 //cpp
 // @symbol _ZN4Heap6RescueEv
-/* recovered: named members + shared header, real C++ method */
+/* Heap::Rescue() at 0x0203c634 -- plain forward to slot 7, the concrete heap's
+ * last-ditch recovery. Called from Heap::ResizeToFit just before Crash().
+ *
+ * RETURN TYPE: void, from the definitions. The old shadow here declared its
+ * fake slot as `int m()' and returned it, which is unobservable for a pure
+ * forwarder -- r0 simply carries whatever the callee left -- so it byte-matched
+ * while claiming a result that does not exist. Both overrides are void
+ * (ExpandingHeap::VRescue, SolidHeap::VRescue), and the reconstruction that was
+ * already sitting in _ZN4Heap11ResizeToFitEv.c said `void Rescue()' too. */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual int m(); };
 
-int Heap::Rescue()
+void Heap::Rescue()
 {
- return ((Base *)this)->m();
+    VRescue();
 }

--- a/src/_ZN4Heap6SizeofEPv.cpp
+++ b/src/_ZN4Heap6SizeofEPv.cpp
@@ -1,14 +1,22 @@
 //cpp
 // @symbol _ZN4Heap6SizeofEPv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+/* Heap::Sizeof(void*) at 0x0203c454 -- asks slot 9 how large an allocated block
+ * is, and treats -1 as the failure report.
+ *
+ * The result is held in an `int' on purpose. Slot 9 is declared u32 (that is
+ * what the overrides return), but the guard here is a comparison against -1,
+ * and the ROM does it signed. Widening the local to u32 would turn that into an
+ * unsigned compare and change the instruction.
+ *
+ * Was a cast of `this' to a local `struct Base' with nine anonymous virtuals
+ * padding `m' out to index 9. */
 #include "decl_common.h"
-/* recovered: named members + shared header, real C++ method */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual int m(void*); };
 
-int Heap::Sizeof(void * a)
+int Heap::Sizeof(void* ptr)
 {
-  int r = ((Base *)this)->m(a);
-  if (r == -1 && (*(int*)((char*)&unk_010) & 0x4000)) Crash();
-  return r;
+    int size = VSizeof(ptr);
+    if (size == -1 && (flags & 0x4000))
+        Crash();
+    return size;
 }

--- a/src/_ZN4Heap7DestroyEv.cpp
+++ b/src/_ZN4Heap7DestroyEv.cpp
@@ -1,17 +1,27 @@
 //cpp
 // @symbol _ZN4Heap7DestroyEv
-/* recovered: named members + shared header, real C++ method */
+/* Heap::Destroy() at 0x0203c758 -- tears the heap down: let the concrete heap
+ * release its own bookkeeping (slot 2), forget the arena, then hand the block
+ * back to the heap this one was carved out of.
+ *
+ * Was a cast of `this' to a local `struct Base' for the slot-2 call, plus
+ * address-cast writes through `&unk_004' / `&unk_008' / `&unk_00c' -- the
+ * casts existed because the header declared those fields but nothing would
+ * admit what they were. They are named now, so the writes are plain. */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void m(); };
-extern "C" void _ZN4Heap10DeallocateEPv(void*, void*);
 
 void Heap::Destroy()
 {
-  ((Base *)this)->m();
-  *(int*)((char*)&unk_004)=0;
-  *(int*)((char*)&unk_008)=0;
-  void* p = *(void**)((char*)&unk_00c);
-  if (p==0) return;
-  _ZN4Heap10DeallocateEPv(p, ((Base *)this));
-  *(int*)((char*)&unk_00c)=0;
+    VDestroy();
+
+    heapStart = 0;
+    heapSize = 0;
+
+    /* A root heap has no parent to return the block to. */
+    Heap* parent = parentHeap;
+    if (parent == 0)
+        return;
+
+    parent->Deallocate(this);
+    parentHeap = 0;
 }

--- a/src/_ZN4Heap8AllocateEj.cpp
+++ b/src/_ZN4Heap8AllocateEj.cpp
@@ -1,13 +1,14 @@
 //cpp
-#include "types.h"
-/* Heap::Allocate(unsigned) at 0x0203c28c -- convenience overload that
- * forwards to Heap::Allocate(unsigned, int) with default alignment 4. */
-class Heap
-{
-public:
-    void* Allocate(u32 size);
-    void* Allocate(u32 size, int align);
-};
+// @symbol _ZN4Heap8AllocateEj
+/* Heap::Allocate(u32) at 0x0203c28c -- convenience overload that forwards to
+ * Heap::Allocate(u32, int) with the default alignment of 4.
+ *
+ * This file used to declare its own `class Heap { void* Allocate(u32); void*
+ * Allocate(u32, int); }' rather than include the real header. That local copy
+ * was the only place in the tree that got this overload's return type right --
+ * _ZN4Heap8AllocateEji.cpp declared the very same function `int'. Both now come
+ * from Heap.h and cannot drift apart again. */
+#include "Heap.h"
 
 void* Heap::Allocate(u32 size)
 {

--- a/src/_ZN4Heap8AllocateEji.cpp
+++ b/src/_ZN4Heap8AllocateEji.cpp
@@ -1,14 +1,25 @@
 //cpp
 // @symbol _ZN4Heap8AllocateEji
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+/* Heap::Allocate(u32, int) at 0x0203c6cc -- the allocation entry point: call
+ * slot 3, and if it comes back empty on a fail-fast heap, do not return the
+ * NULL to the caller, Crash() instead.
+ *
+ * RETURN TYPE: void*, from the definition. This file used to declare `int
+ * Heap::Allocate(...)' while _ZN4Heap8AllocateEj.cpp -- the sibling overload,
+ * which forwards to this one -- declared the same function `void*'. Two files
+ * disagreeing about one signature is exactly the debt the shadow structs
+ * create. ExpandingHeap::VAllocate and SolidHeap::VAllocate both return void*,
+ * so void* it is, and the two files now agree because they share a header.
+ *
+ * Was a cast of `this' to a local `struct Base' with three anonymous virtuals
+ * padding `m' out to index 3, plus an address-cast read of `&unk_010'. */
 #include "decl_common.h"
-/* recovered: named members + shared header, real C++ method */
 #include "Heap.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual int m(unsigned int,int); };
 
-int Heap::Allocate(unsigned int a, int b)
+void* Heap::Allocate(u32 size, int align)
 {
-  int r = ((Base *)this)->m(a,b);
-  if (r == 0 && (*(int*)((char*)&unk_010) & 0x4000)) Crash();
-  return r;
+    void* block = VAllocate(size, align);
+    if (block == 0 && (flags & 0x4000))
+        Crash();
+    return block;
 }

--- a/src/_ZN4Heap9SetNodeIDEj.cpp
+++ b/src/_ZN4Heap9SetNodeIDEj.cpp
@@ -1,16 +1,17 @@
 //cpp
 // @symbol _ZN4Heap9SetNodeIDEj
-/* recovered: named members + shared header, real C++ method */
+/* Heap::SetNodeID(u32) at 0x0203c408 -- plain forward to slot 13. The node id
+ * is the tag the allocator stamps on blocks it hands out, so a later sweep can
+ * free everything belonging to one id (see
+ * ExpandingHeapAllocator::DeallocateAll).
+ *
+ * The old shadow declared its slot-13 entry as `v13(void*)' and converted the
+ * incoming id to a pointer to call it -- an invented cast that existed only to
+ * satisfy the invented declaration. Slot 13 takes a u32
+ * (ExpandingHeap::VSetNodeID(u32 id)), so the conversion is gone. */
 #include "Heap.h"
-struct Base {
-    virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();
-    virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7();
-    virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11();
-    virtual void v12(); virtual void v13(void*);
-};
 
-void Heap::SetNodeID(unsigned int a_)
+void Heap::SetNodeID(u32 id)
 {
-    void * a = (void *)a_;
- ((Base *)this)->v13(a);
+    VSetNodeID(id);
 }


### PR DESCRIPTION
`Heap` had a rung-0 skeleton header and nine "migrated" methods that were real C++ in name only: each reached the vtable by casting `this` to a locally declared

```c
struct Base { virtual void v0(); ... virtual bool m(); };
```

where the anonymous `v0..vN` existed purely to push `m` onto the slot index the author had worked out by hand. Real method signature, invented base class. The bytes were right and nothing could tell.

## The ROM settles the hierarchy

Heap's vtable is at `arm9:0x02099d90` and is **sixteen slots, of which 2..15 are NULL** — an abstract base.

Do not trust `rtti_vtables.py --own Heap`, which reports "2 slots": it trims trailing nulls, and for an abstract base the nulls are the entire finding. The tables either side of it, SolidHeap (`0x02099d48`) and ExpandingHeap (`0x02099dd8`), are full 16-slot tables and fix the order. A second, independent derivation already existed in the tree and agrees slot for slot — `_ZN4Heap11ResizeToFitEv.c` has carried the whole reconstructed class in a local shadow for its own use.

Return types come from the **definitions** (the ExpandingHeap/SolidHeap overrides, which are migrated and byte-gated), never from callers, most of which discard the result.

## Corrections to the skeleton

- **`0x10` was `u8 unk_010`.** Both evidence passes see five 4-byte accesses there and none narrower, and the constructor stores `0x4000` into it. It is a u32 flag word; bit `0x4000` means fail-fast, and it is why Allocate, Sizeof and ResizeToFit call `Crash()` instead of reporting failure.
- **There is no field at `0x14`.** `evidence_rom` reports one from a single witness: the *static* `Heap::CreateRootHeap`, which builds an ExpandingHeap in place and so writes the derived class's `allocator` through a pointer the pass attributed to Heap. Both derived constructors settle it — each calls `Heap::Heap(start, size, root)`, which writes `0x00..0x10`, and only then writes `0x14`. Heap is `0x14` bytes; the derived heaps are `0x18`.
- **The `__cplusplus` block had never been compiled** and declared `struct a; struct a_; struct b;` — parameter names mistaken for type names. Same generator defect as ExpandingHeapAllocator.h (#1211) and SolidHeapAllocator.h (#1215), found the same way: by compiling it.

## Three contradictions between files, resolved

None of these could previously have been caught, because a caller cannot observe them:

| | was | is | why |
|---|---|---|---|
| `0x08` | `heapEnd` (an address) | `heapSize` (a byte count) | `CreateRootHeap`'s mangled name is `...EPvj` — `j` — and it passes `size - 0x18` onward as a size |
| `Allocate(u32,int)` | `int` in one file, `void*` in another | `void*` | the two files define and forward to the *same function* |
| `Rescue()` | `int` | `void` | unobservable for a pure forwarder — r0 carries whatever the callee left — so it byte-matched while claiming a result that does not exist |

## Notes

The class is spelled twice, as `include/Fader.h` spells Fader, because a C translation unit gets no implicit vptr and nine `.c` files include this header. **The C spelling comes first** so `check_header_offsets.py` can actually gate it: that tool stops at the first `virtual` line, so with the C++ struct first it reported `0 commented fields ... struct spans 0x0` — which reads like a pass and checks nothing. It now reports 5 fields spanning `0x14`.

The destructor is declared first and must never be defined: it holds slots 0/1, which makes it the key function, and defining it would emit the vtable group and cost the file its enrollment (runbook §7).

**Deliberately not done here:** the ROM's RTTI names these classes `mHeap::Heap_t`, `mHeap::SolidHeap_t`, `mHeap::ExpHeap_t`. Every symbol in `config/` uses Heap/SolidHeap/ExpandingHeap, so renaming is a whole-tree change; it is recorded in the header rather than half-applied.

## Gates

```
build_pin.verify           11/11 (True, '2004/b56')
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10711 / 11159, unchanged from baseline
check_header_offsets.py    5 fields, 0 mismatched, spans 0x14
header_cpp_sweep.py        PASS, 384 headers, 0 defective
port_refcheck.py           PASS, 394 references
langmode_audit.py --check  PASS; shadow struct bodies 2643 -> 2632
prepush_attribution.py     0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS