### PR TITLE
Heap: migrate the five tail-call veneers, and record that veneers can be migrated

### DIFF
--- a/include/Heap.h
+++ b/include/Heap.h
@@ -206,6 +206,15 @@ struct Heap {
     Heap* SetDefault();                      /* installs this as the default
                                                 heap, returns the previous one */
 
+    /* Tail-call veneers. Each is a three-word thunk in the ROM --
+       `ldr ip,[pc] / bx ip / .word target' -- reaching a sibling too far away
+       for a b/bl displacement. They are real members with real names, not
+       compiler-generated stubs, so they are declared here like anything else. */
+    void  _Destroy();                        /* -> Destroy */
+    void* _Allocate(u32 size, int align);    /* -> Allocate */
+    void  _Deallocate(void* ptr);            /* -> Deallocate */
+    int   _Sizeof(void* ptr);                /* -> Sizeof */
+
     /* STATIC -- and that is read off the argument count, not off the mangled
        name. The Itanium ABI does not encode `this' in the parameter list, so a
        static and a non-static member with the same declared parameters mangle
@@ -220,6 +229,8 @@ struct Heap {
     static Heap* CreateExpandingHeap(u32 size, Heap* root, int align);
     static void  InitializeGameHeap(u32 size, Heap* root);
     static void* SetupSolidHeapAsDefault(u32 size, Heap* root, int align);
+    static void* InitializeSolidHeapAsDefault(u32 size, Heap* root, int align);
+                                             /* veneer -> SetupSolidHeapAsDefault */
     static void  RestoreFromTemporary();
 
     /* The two allocator factories. `flags' is the node id the allocator stamps

--- a/notes/runbook-type-reconstruction.md
+++ b/notes/runbook-type-reconstruction.md
@@ -460,3 +460,52 @@ the check the ROM build cannot report**, and it is why the baseline is step 0.
   The definition is the only non-guess.
 - **Do not migrate before the types are right.** A real `struct` built on guessed member
   types is a lie that every later file inherits.
+
+## 8. Not a dead end: tail-call veneers migrate like anything else
+
+**107 files in `src/` are tail-call veneers** -- three-word thunks of the shape
+
+```
+ldr ip, [pc]
+bx  ip
+.word <target>
+```
+
+reaching a sibling function. 82 are `.c`, 25 are `.cpp`, and 38 spell a mangled
+symbol by hand. Every one of them was written the same way:
+
+```cpp
+extern "C" {
+extern void _ZN4Heap10DeallocateEPv(void);
+void _ZN4Heap11_DeallocateEPv(void) { _ZN4Heap10DeallocateEPv(); }
+}
+```
+
+Both functions declared as taking **nothing** -- which reproduces the bytes exactly,
+because a tail call never touches `r0-r3`. That property is the veneer's whole nature,
+and it is also what let a wrong prototype sit in every one of these files unchallenged:
+there is no argument for the declaration to get wrong *in a way the bytes can see*.
+
+**They can be real methods.** Measured on all five of `Heap`'s under `2004/b56`:
+
+```cpp
+void Heap::_Deallocate(void* ptr) { Deallocate(ptr); }
+```
+
+is byte-identical to the `extern "C"` form. So is the static case
+(`Heap::InitializeSolidHeapAsDefault` -> `Heap::SetupSolidHeapAsDefault`). The veneer
+is emitted for the *call*, not for the argument list, so restoring the real signature
+costs nothing.
+
+Two things this does **not** mean:
+
+- It does not tell you what the signature *is*. The bytes are indifferent, so the
+  parameter types must come from the target's own definition -- exactly as
+  section 2 requires. A veneer is the one place where a wrong signature is
+  guaranteed to still match.
+- It is not a licence to declare the veneer's *target* from the veneer. Migrate the
+  target first, then point the veneer at it.
+
+Worth doing because the veneer and its target are the same function to a reader, and
+half of the pair claiming `(void)` is the plainest possible instance of the source
+saying something the ROM does not.

--- a/src/_ZN4Heap11_DeallocateEPv.cpp
+++ b/src/_ZN4Heap11_DeallocateEPv.cpp
@@ -1,10 +1,10 @@
 //cpp
-/* _ZN4Heap11_DeallocateEPv @ 0x203c280 (arm9) -- tail-call veneer to _ZN4Heap10DeallocateEPv (0x203c538).
- * ldr ip, [pc]; bx ip; .word 0x203c538
- */
-extern "C" {
-extern void _ZN4Heap10DeallocateEPv(void);
-void _ZN4Heap11_DeallocateEPv(void) {
-    _ZN4Heap10DeallocateEPv();
-}
+// @symbol _ZN4Heap11_DeallocateEPv
+/* Heap::_Deallocate(void*) at 0x0203c280 -- three-word tail-call veneer to
+ * Heap::Deallocate (0x0203c538): `ldr ip,[pc] / bx ip / .word 0x0203c538'. */
+#include "Heap.h"
+
+void Heap::_Deallocate(void* ptr)
+{
+    Deallocate(ptr);
 }

--- a/src/_ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i.cpp
+++ b/src/_ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i.cpp
@@ -1,10 +1,17 @@
 //cpp
-/* _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i @ 0x203c2d8 (arm9) -- tail-call veneer to _ZN4Heap23SetupSolidHeapAsDefaultEjPS_i (0x203c2e4).
- * ldr ip, [pc]; bx ip; .word 0x203c2e4
- */
-extern "C" {
-extern void _ZN4Heap23SetupSolidHeapAsDefaultEjPS_i(void);
-void _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i(void) {
-    _ZN4Heap23SetupSolidHeapAsDefaultEjPS_i();
-}
+// @symbol _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i
+/* Heap::InitializeSolidHeapAsDefault(u32, Heap*, int) at 0x0203c2d8 --
+ * three-word tail-call veneer to Heap::SetupSolidHeapAsDefault (0x0203c2e4):
+ * `ldr ip,[pc] / bx ip / .word 0x0203c2e4'.
+ *
+ * Static, by the same argument-count test as its target: three declared
+ * parameters, three arguments in the body, no room for a `this'. Note the
+ * veneer sits twelve bytes BEFORE what it jumps to -- the pair is adjacent and
+ * the thunk is still a long-form `ldr/bx', which is what these veneers look
+ * like throughout: they are not distance-driven. */
+#include "Heap.h"
+
+void* Heap::InitializeSolidHeapAsDefault(u32 size, Heap* root, int align)
+{
+    return SetupSolidHeapAsDefault(size, root, align);
 }

--- a/src/_ZN4Heap7_SizeofEPv.cpp
+++ b/src/_ZN4Heap7_SizeofEPv.cpp
@@ -1,10 +1,10 @@
 //cpp
-/* _ZN4Heap7_SizeofEPv @ 0x203c274 (arm9) -- tail-call veneer to _ZN4Heap6SizeofEPv (0x203c454).
- * ldr ip, [pc]; bx ip; .word 0x203c454
- */
-extern "C" {
-extern void _ZN4Heap6SizeofEPv(void);
-void _ZN4Heap7_SizeofEPv(void) {
-    _ZN4Heap6SizeofEPv();
-}
+// @symbol _ZN4Heap7_SizeofEPv
+/* Heap::_Sizeof(void*) at 0x0203c274 -- three-word tail-call veneer to
+ * Heap::Sizeof (0x0203c454): `ldr ip,[pc] / bx ip / .word 0x0203c454'. */
+#include "Heap.h"
+
+int Heap::_Sizeof(void* ptr)
+{
+    return Sizeof(ptr);
 }

--- a/src/_ZN4Heap8_DestroyEv.cpp
+++ b/src/_ZN4Heap8_DestroyEv.cpp
@@ -1,10 +1,17 @@
 //cpp
-/* _ZN4Heap8_DestroyEv @ 0x203c74c (arm9) -- tail-call veneer to _ZN4Heap7DestroyEv (0x203c758).
- * ldr ip, [pc]; bx ip; .word 0x203c758
- */
-extern "C" {
-extern void _ZN4Heap7DestroyEv(void);
-void _ZN4Heap8_DestroyEv(void) {
-    _ZN4Heap7DestroyEv();
-}
+// @symbol _ZN4Heap8_DestroyEv
+/* Heap::_Destroy() at 0x0203c74c -- a three-word tail-call veneer to
+ * Heap::Destroy (0x0203c758): `ldr ip,[pc] / bx ip / .word 0x0203c758'.
+ *
+ * PROBE: can a veneer be a real method? It used to be spelled as an
+ * argument-less extern "C" function calling another argument-less extern "C"
+ * function, both by mangled name -- which reproduces the bytes because a tail
+ * call never touches the arguments, and which is also why the shape survived
+ * unexamined. Written as a real member forwarding real arguments it should emit
+ * the same three words. */
+#include "Heap.h"
+
+void Heap::_Destroy()
+{
+    Destroy();
 }

--- a/src/_ZN4Heap9_AllocateEji.cpp
+++ b/src/_ZN4Heap9_AllocateEji.cpp
@@ -1,10 +1,17 @@
 //cpp
-/* _ZN4Heap9_AllocateEji @ 0x203c29c (arm9) -- tail-call veneer to _ZN4Heap8AllocateEji (0x203c6cc).
- * ldr ip, [pc]; bx ip; .word 0x203c6cc
- */
-extern "C" {
-extern void _ZN4Heap8AllocateEji(void);
-void _ZN4Heap9_AllocateEji(void) {
-    _ZN4Heap8AllocateEji();
-}
+// @symbol _ZN4Heap9_AllocateEji
+/* Heap::_Allocate(u32, int) at 0x0203c29c -- three-word tail-call veneer to
+ * Heap::Allocate(u32, int) (0x0203c6cc):
+ * `ldr ip,[pc] / bx ip / .word 0x0203c6cc'.
+ *
+ * The forwarded arguments are real now. The old spelling declared both this
+ * function and its target as taking NOTHING -- `void f(void)' calling
+ * `void g(void)' -- which reproduces the bytes precisely because a tail call
+ * leaves r0-r3 untouched. That is the veneer's whole nature, and it is also
+ * what let the wrong prototypes sit here unchallenged. */
+#include "Heap.h"
+
+void* Heap::_Allocate(u32 size, int align)
+{
+    return Allocate(size, align);
 }


### PR DESCRIPTION
Stacked on #1236 → #1235 → #1233 → main.

This finishes Heap's methods. What is left of the family is exactly **ten `.c` files** — `C1`/`D0`/`D1`/`D2` across Heap, SolidHeap and ExpandingHeap — all blocked on a delink model that can bind one file to a multi-function address range (runbook §7). Every *method* of all three classes is now real C++.

## What a veneer is, and why nothing ever checked one

A veneer is a three-word thunk — `ldr ip,[pc] / bx ip / .word target` — reaching a sibling. All five of Heap's were spelled the same way, and it is the same way all **107** veneers in the tree are spelled:

```cpp
extern "C" {
extern void _ZN4Heap10DeallocateEPv(void);
void _ZN4Heap11_DeallocateEPv(void) { _ZN4Heap10DeallocateEPv(); }
}
```

Both functions declared as taking **nothing**. That reproduces the bytes exactly, because a tail call never touches `r0-r3` — which is the veneer's whole nature, and also what let a wrong prototype sit in every one of these files unchallenged. *There is no argument for the declaration to get wrong in a way the bytes can see.*

## They migrate

```cpp
void Heap::_Deallocate(void* ptr) { Deallocate(ptr); }
```

is byte-identical to the `extern "C"` form under `2004/b56`, and so is the static case (`InitializeSolidHeapAsDefault` → `SetupSolidHeapAsDefault`). The veneer is emitted for the **call**, not for the argument list, so restoring the real signature costs nothing.

Nothing in the tree had migrated a veneer before, so I verified one as a probe before writing the other four.

## Recorded in the runbook (§8), with its limits

Because this is worth knowing beyond this class — 107 files, 82 `.c` and 25 `.cpp`, 38 hand-spelling a mangled symbol. The two limits matter as much as the result:

- **The bytes are indifferent to the signature**, so parameter types must come from the *target's* definition. A veneer is the one place where a wrong signature is guaranteed to still match.
- **The target must be migrated first**, never inferred from the veneer.

## Gates

```
build_pin.verify           5/5 (True, '2004/b56')
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10712 / 11159, unchanged
check_header_offsets.py    5 fields, 0 mismatched, spans 0x14
header_cpp_sweep.py        PASS
port_refcheck.py           PASS, 393 references, 0 stale
langmode_audit.py --check  PASS; unmigrated 1203 -> 1198
prepush_attribution.py     0 changed, 1 lost (the VAllocate rename inherited from
                           #1235, where the override is recorded)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS