### PR TITLE
IRQ and G3X: migrate six namespace functions, after checking the audit was right

### DIFF
--- a/src/_ZN3G3X11SetFogTableEPv.cpp
+++ b/src/_ZN3G3X11SetFogTableEPv.cpp
@@ -1,8 +1,22 @@
 //cpp
-extern "C" {
-extern void Copy32Bytes(void*, void*);
+// @symbol _ZN3G3X11SetFogTableEPv
+/* G3X::SetFogTable(void*) at 0x020555bc -- upload the 32-entry fog density
+ * table to the 3D engine.
+ *
+ * 0x04000360 is FOG_TABLE in the DS I/O map, and the copy is exactly 32 bytes,
+ * which is the whole table. The destination stays a bare address because the
+ * I/O registers have no header in this tree yet; naming it is a claim of its
+ * own and migration is per-reference.
+ *
+ * Verified layout-free against the ROM, not just against the audit: this
+ * function's address is never stored as a word anywhere in arm9_dec.bin. */
+extern "C" void Copy32Bytes(void* src, void* dst);
 
-void _ZN3G3X11SetFogTableEPv(void* table) {
+namespace G3X {
+
+void SetFogTable(void* table)
+{
     Copy32Bytes(table, (void*)0x4000360);
 }
+
 }

--- a/src/_ZN3IRQ10DisableAllEv.cpp
+++ b/src/_ZN3IRQ10DisableAllEv.cpp
@@ -1,14 +1,30 @@
 //cpp
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
-// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
-// switch, etc.), so there is no C to decompile it to -- the asm block is the
-// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
-extern "C" unsigned int _ZN3IRQ10DisableAllEv(void);
-extern "C" asm unsigned int _ZN3IRQ10DisableAllEv(void)
+// @symbol _ZN3IRQ10DisableAllEv
+/* IRQ::DisableAll(void) at 0x02059d48 -- set both the IRQ and FIQ disable bits (0xc0).
+ *
+ * HAND-ASM PRIMITIVE. `mrs`/`msr` read and write the CPSR and no C construct
+ * compiles to them, so the asm block is the faithful source rather than a
+ * transcription of something lost. The asm-primitive policy is unchanged; what
+ * changes is that the compiler mangles the symbol instead of the file spelling
+ * it by hand.
+ *
+ * The pattern in all five: read CPSR, set or clear the mask bits, write it
+ * back, and return the OLD state of those bits so the caller can restore it.
+ * Bit 0x80 is IRQ, 0x40 is FIQ -- which is the whole difference between the
+ * plain and the `All` variants.
+ *
+ * Verified layout-free against the ROM, not just against the audit: the address
+ * of this function is never stored as a word anywhere in arm9_dec.bin, so it is
+ * in no vtable and no dispatch table. */
+namespace IRQ {
+
+asm unsigned int DisableAll(void)
 {
     mrs r0, cpsr
     orr r1, r0, #0xc0
     msr cpsr_c, r1
     and r0, r0, #0xc0
     bx lr
+}
+
 }

--- a/src/_ZN3IRQ10RestoreAllEj.cpp
+++ b/src/_ZN3IRQ10RestoreAllEj.cpp
@@ -1,10 +1,24 @@
 //cpp
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
-// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
-// switch, etc.), so there is no C to decompile it to -- the asm block is the
-// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
-extern "C" unsigned int _ZN3IRQ10RestoreAllEj(unsigned int);
-extern "C" asm unsigned int _ZN3IRQ10RestoreAllEj(unsigned int)
+// @symbol _ZN3IRQ10RestoreAllEj
+/* IRQ::RestoreAll(unsigned int state) at 0x02059d5c -- put both the IRQ and FIQ bits back.
+ *
+ * HAND-ASM PRIMITIVE. `mrs`/`msr` read and write the CPSR and no C construct
+ * compiles to them, so the asm block is the faithful source rather than a
+ * transcription of something lost. The asm-primitive policy is unchanged; what
+ * changes is that the compiler mangles the symbol instead of the file spelling
+ * it by hand.
+ *
+ * The pattern in all five: read CPSR, set or clear the mask bits, write it
+ * back, and return the OLD state of those bits so the caller can restore it.
+ * Bit 0x80 is IRQ, 0x40 is FIQ -- which is the whole difference between the
+ * plain and the `All` variants.
+ *
+ * Verified layout-free against the ROM, not just against the audit: the address
+ * of this function is never stored as a word anywhere in arm9_dec.bin, so it is
+ * in no vtable and no dispatch table. */
+namespace IRQ {
+
+asm unsigned int RestoreAll(unsigned int state)
 {
     mrs r1, cpsr
     bic r2, r1, #0xc0
@@ -12,4 +26,6 @@ extern "C" asm unsigned int _ZN3IRQ10RestoreAllEj(unsigned int)
     msr cpsr_c, r2
     and r0, r1, #0xc0
     bx lr
+}
+
 }

--- a/src/_ZN3IRQ6EnableEv.cpp
+++ b/src/_ZN3IRQ6EnableEv.cpp
@@ -1,14 +1,31 @@
 //cpp
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
-// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
-// switch, etc.), so there is no C to decompile it to -- the asm block is the
-// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
-extern "C" unsigned int _ZN3IRQ6EnableEv(void);
-extern "C" asm unsigned int _ZN3IRQ6EnableEv(void)
+// @symbol _ZN3IRQ6EnableEv
+/* IRQ::Enable(void) at 0x02059d08 -- clear the IRQ disable bit, returning whether IRQs had been
+ * disabled.
+ *
+ * HAND-ASM PRIMITIVE. `mrs`/`msr` read and write the CPSR and no C construct
+ * compiles to them, so the asm block is the faithful source rather than a
+ * transcription of something lost. The asm-primitive policy is unchanged; what
+ * changes is that the compiler mangles the symbol instead of the file spelling
+ * it by hand.
+ *
+ * The pattern in all five: read CPSR, set or clear the mask bits, write it
+ * back, and return the OLD state of those bits so the caller can restore it.
+ * Bit 0x80 is IRQ, 0x40 is FIQ -- which is the whole difference between the
+ * plain and the `All` variants.
+ *
+ * Verified layout-free against the ROM, not just against the audit: the address
+ * of this function is never stored as a word anywhere in arm9_dec.bin, so it is
+ * in no vtable and no dispatch table. */
+namespace IRQ {
+
+asm unsigned int Enable(void)
 {
     mrs r0, cpsr
     bic r1, r0, #0x80
     msr cpsr_c, r1
     and r0, r0, #0x80
     bx lr
+}
+
 }

--- a/src/_ZN3IRQ7DisableEv.cpp
+++ b/src/_ZN3IRQ7DisableEv.cpp
@@ -1,14 +1,30 @@
 //cpp
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
-// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
-// switch, etc.), so there is no C to decompile it to -- the asm block is the
-// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
-extern "C" unsigned int _ZN3IRQ7DisableEv(void);
-extern "C" asm unsigned int _ZN3IRQ7DisableEv(void)
+// @symbol _ZN3IRQ7DisableEv
+/* IRQ::Disable(void) at 0x02059d1c -- set the IRQ disable bit, returning its previous state.
+ *
+ * HAND-ASM PRIMITIVE. `mrs`/`msr` read and write the CPSR and no C construct
+ * compiles to them, so the asm block is the faithful source rather than a
+ * transcription of something lost. The asm-primitive policy is unchanged; what
+ * changes is that the compiler mangles the symbol instead of the file spelling
+ * it by hand.
+ *
+ * The pattern in all five: read CPSR, set or clear the mask bits, write it
+ * back, and return the OLD state of those bits so the caller can restore it.
+ * Bit 0x80 is IRQ, 0x40 is FIQ -- which is the whole difference between the
+ * plain and the `All` variants.
+ *
+ * Verified layout-free against the ROM, not just against the audit: the address
+ * of this function is never stored as a word anywhere in arm9_dec.bin, so it is
+ * in no vtable and no dispatch table. */
+namespace IRQ {
+
+asm unsigned int Disable(void)
 {
     mrs r0, cpsr
     orr r1, r0, #0x80
     msr cpsr_c, r1
     and r0, r0, #0x80
     bx lr
+}
+
 }

--- a/src/_ZN3IRQ7RestoreEj.cpp
+++ b/src/_ZN3IRQ7RestoreEj.cpp
@@ -1,10 +1,24 @@
 //cpp
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
-// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
-// switch, etc.), so there is no C to decompile it to -- the asm block is the
-// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
-extern "C" unsigned int _ZN3IRQ7RestoreEj(unsigned int);
-extern "C" asm unsigned int _ZN3IRQ7RestoreEj(unsigned int)
+// @symbol _ZN3IRQ7RestoreEj
+/* IRQ::Restore(unsigned int state) at 0x02059d30 -- put the IRQ bit back to a state a previous Disable returned.
+ *
+ * HAND-ASM PRIMITIVE. `mrs`/`msr` read and write the CPSR and no C construct
+ * compiles to them, so the asm block is the faithful source rather than a
+ * transcription of something lost. The asm-primitive policy is unchanged; what
+ * changes is that the compiler mangles the symbol instead of the file spelling
+ * it by hand.
+ *
+ * The pattern in all five: read CPSR, set or clear the mask bits, write it
+ * back, and return the OLD state of those bits so the caller can restore it.
+ * Bit 0x80 is IRQ, 0x40 is FIQ -- which is the whole difference between the
+ * plain and the `All` variants.
+ *
+ * Verified layout-free against the ROM, not just against the audit: the address
+ * of this function is never stored as a word anywhere in arm9_dec.bin, so it is
+ * in no vtable and no dispatch table. */
+namespace IRQ {
+
+asm unsigned int Restore(unsigned int state)
 {
     mrs r1, cpsr
     bic r2, r1, #0x80
@@ -12,4 +26,6 @@ extern "C" asm unsigned int _ZN3IRQ7RestoreEj(unsigned int)
     msr cpsr_c, r2
     and r0, r1, #0x80
     bx lr
+}
+
 }


### PR DESCRIPTION
Independent, off `main`. Sibling of #1239 (CP15).

Six files that had already been renamed `.cpp` and changed nothing else — each still spelled its own mangled symbol in an `extern "C"` block, which is exactly the population issue #821 meant by *"your cute little `//cpp` changes nothing"*. They are `namespace IRQ { }` and `namespace G3X { }` now, and the compiler mangles for us.

The five IRQ functions are hand-asm primitives and stay that way: `mrs`/`msr` read and write the CPSR and no C construct compiles to them. All five share one shape — read CPSR, set or clear the mask bits, write back, return the **old** state so the caller can restore it. Bit `0x80` is IRQ and `0x40` is FIQ, which is the entire difference between the plain and the `All` variants.

## The layout-free claim was checked against the ROM, not just the audit

That turned out to matter, and it is the reason this PR is six files instead of twenty-nine.

`langmode_audit.py` decides `layout_free` from the **outer** mangled prefix — no `include/<Prefix>.h` and no ctor/dtor for `<Prefix>`. For a namespace holding nested **classes** that is not sufficient. Measured over all 84 candidates by looking for each function's address stored as a word anywhere in `arm9_dec.bin` — a function in a vtable or dispatch table is not layout-free by definition:

**27 of 84 are false positives.**

The worst is `Particle`. `Particle::Callback` is a polymorphic base — `SpawnParticles` and `OnUpdate` sit as consecutive words at `0x0208f3b4`/`0x0208f3b8`, and the pair repeats per derived class across `0x0208f3a8`–`0x0208f464` for Bubble, Splash, CheckWater, CheckLava, Clip, Scale, FitWater, FitWaterSimple and EndingStarGlitter. **21 of Particle's 23 candidates have their address taken.** The prefix `Particle` has no header and no ctor/dtor of its own, so all 23 read as layout-free — and migrating them as namespace functions would have manufactured exactly the kind of lie this workstream exists to remove.

Two further false-positive shapes the address test does **not** catch:

- **`_ZNK...` is a const member function** and therefore has a `this`. Two are in the set: `_ZNK11SurfaceInfo12CopyNormalToER7Vector3`, `_ZNK8Particle10SysTracker8Contents8FindDataEj`.
- **Nested-class statics** — `Particle::System::FromUniqueID`, `Sound::InfoSequenceEntry::GetWithID` — are class methods, not namespace functions, and need the class declared.

And one caveat against over-reading the address test, because it is broader than vtable membership: Particle's `{LimitPlane,Turn,Jitter,Acceleration,RadiusConverge,Converge}::Func` cluster at `0x0204a4b0`–`0x0204a4c8` is a function-pointer **dispatch table**, and a static function may legitimately live in one. Consecutive-pair-per-class means vtable; a contiguous single-entry array does not.

These six came back clean on every test: no address taken, no `K`, no nesting. **CP15 (#1239) was re-checked the same way and is 0 of 16.**

The classifier itself is not changed here — `layout_free` feeds `--check`, so moving it is its own PR with its own reasoning.

## Gates

```
build_pin.verify           6/6 (True, '2004/b56')
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10712 / 11159, unchanged
port_refcheck.py           PASS, 393 references, 0 stale
langmode_audit.py --check  PASS; unmigrated 1210 -> 1204
prepush_attribution.py     0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS