### PR TITLE
LVL_Overlay: give the level tables a real header, and migrate six loaders

### DIFF
--- a/include/LVL_Overlay.h
+++ b/include/LVL_Overlay.h
@@ -13,8 +13,13 @@
  *   ObjTable     LoadObjects (ov002:0x020fe33c) reads its count as
  *                `*(unsigned short *)t' -- a 16-bit load at offset 0x00.
  *
- *   ObjSubTable  every sub-table loader reads its count as `*(u8 *)(t + 1)' --
- *                an 8-bit load at offset 0x01.
+ *   ObjSubTable  twelve of the fifteen sub-table loaders read their count as
+ *                `*(u8 *)(t + 1)' -- an 8-bit load at offset 0x01. The other
+ *                three read no count at all: LoadStarCameraObjects and
+ *                LoadUnusedType13Objects each take a single value out of the
+ *                entry array, and LoadPathNodeObjects forwards the array
+ *                pointer without a length. None of the fifteen reads a u16 at
+ *                offset 0x00.
  *
  * Those cannot be the same field. On little-endian, byte 1 of a u16 at 0x00 is
  * the HIGH byte, so a u8 read at 0x01 of a 16-bit count would report zero for
@@ -27,10 +32,16 @@
  *
  * The element type of `entries' is deliberately void*. It differs per category
  * -- LoadDoorObjects walks 12-byte door records, LoadObjects walks 8-byte
- * entries with a packed type in the top three bits of byte 0 -- so the pointer
- * is untyped here and each loader says what it is pointing at. Naming those
- * record types is per-category work, not something to guess once for all of
- * them.
+ * entries whose byte 0 is packed two ways -- so the pointer is untyped here and
+ * each loader says what it is pointing at. Naming those record types is
+ * per-category work, not something to guess once for all of them.
+ *
+ * On that packing, because an earlier revision of this comment had it backwards:
+ * the object TYPE is the LOW FIVE bits (`b & 0x1f'), used to index the handler
+ * table at ov002:0x0210cbb8. The TOP THREE bits (`(b >> 5) & 7') are a filter --
+ * LoadObjects skips the entry unless they are zero or equal to the global byte
+ * at 0x0209f220. Type in the low bits, filter in the high bits, not the other
+ * way round.
  */
 #ifndef LVL_OVERLAY_H
 #define LVL_OVERLAY_H

--- a/include/LVL_Overlay.h
+++ b/include/LVL_Overlay.h
@@ -1,0 +1,79 @@
+/* Hand-written, against evidence. There has never been a header for this type:
+ * every one of the eighteen level-loading functions that takes one declared its
+ * own copy, and they do not agree with each other.
+ *
+ * LVL_Overlay is the parsed form of a level's object data. It holds a table per
+ * object category, and a loader function per category walks it.
+ *
+ * ==== TWO DIFFERENT TABLE TYPES, AND THE EVIDENCE THAT THEY DIFFER ====
+ *
+ * The mangled names distinguish them -- `RN11LVL_Overlay8ObjTableE' versus
+ * `RN11LVL_Overlay11ObjSubTableE' -- and so do the bodies:
+ *
+ *   ObjTable     LoadObjects (ov002:0x020fe33c) reads its count as
+ *                `*(unsigned short *)t' -- a 16-bit load at offset 0x00.
+ *
+ *   ObjSubTable  every sub-table loader reads its count as `*(u8 *)(t + 1)' --
+ *                an 8-bit load at offset 0x01.
+ *
+ * Those cannot be the same field. On little-endian, byte 1 of a u16 at 0x00 is
+ * the HIGH byte, so a u8 read at 0x01 of a 16-bit count would report zero for
+ * every count below 256 -- which is every count. So ObjTable really does carry a
+ * u16 at 0x00, ObjSubTable really does carry a u8 at 0x01, and offset 0x00 of an
+ * ObjSubTable is something else that no loader in this family reads.
+ *
+ * Both are 8 bytes with the entry pointer at 0x04: every loader reaches it as
+ * `*(char **)(t + 4)'.
+ *
+ * The element type of `entries' is deliberately void*. It differs per category
+ * -- LoadDoorObjects walks 12-byte door records, LoadObjects walks 8-byte
+ * entries with a packed type in the top three bits of byte 0 -- so the pointer
+ * is untyped here and each loader says what it is pointing at. Naming those
+ * record types is per-category work, not something to guess once for all of
+ * them.
+ */
+#ifndef LVL_OVERLAY_H
+#define LVL_OVERLAY_H
+#include "types.h"
+
+struct LVL_Overlay {
+#ifdef __cplusplus
+    /* Nested so that the compiler mangles `N11LVL_Overlay8ObjTableE' and
+       `N11LVL_Overlay11ObjSubTableE' -- which is what the ROM's symbols say,
+       and the reason these cannot simply be two top-level structs. */
+    struct ObjTable {
+        u16   count;            /* 0x00 -- 16-bit; see the banner */
+        u8    pad_002[2];
+        void* entries;          /* 0x04 */
+    };
+
+    struct ObjSubTable {
+        u8    unk_000;          /* 0x00 -- not read by any loader in this family */
+        u8    count;            /* 0x01 -- 8-bit; see the banner */
+        u8    pad_002[2];
+        void* entries;          /* 0x04 */
+    };
+#endif
+};
+
+#ifdef __cplusplus
+/* tools/check_header_offsets.py CANNOT GATE THIS HEADER. Its aggregate regex is
+   `struct X { [^{}]* }', which by construction cannot span a nested brace, so it
+   walks the outer LVL_Overlay, finds no fields of its own and reports
+   "0 commented fields, 0 mismatched, struct spans 0x0" -- which reads like a
+   pass and checks nothing. The same shape of silent no-op that putting the C
+   spelling first fixed for include/Heap.h; here there is no reordering that
+   helps, because the types being described ARE the nested ones.
+
+   So the sizes are asserted at compile time instead. This is narrower than the
+   offset gate -- it catches a wrong width or a missing pad, not a wrong order --
+   but it is a real check that fails the build rather than a report that passes
+   without looking. The tree already uses this idiom, and
+   check_header_offsets.py reads these names into its CLASS_SIZES table. */
+typedef char LVL_Overlay_ObjTable_size_must_be_0x8[
+    sizeof(LVL_Overlay::ObjTable) == 0x8 ? 1 : -1];
+typedef char LVL_Overlay_ObjSubTable_size_must_be_0x8[
+    sizeof(LVL_Overlay::ObjSubTable) == 0x8 ? 1 : -1];
+#endif
+
+#endif

--- a/src/_Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadFogObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe5cc -- hand the
+ * category's entry array and count straight to func_0202b060.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b060(void*, unsigned int);
+extern "C" void func_0202b060(void* entries, u32 count);
 
-void _Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadFogObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b060(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadPathObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe6a4 -- hand the
+ * category's entry array and count straight to func_0203aca0.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0203aca0(void*, unsigned int);
+extern "C" void func_0203aca0(void* entries, u32 count);
 
-void _Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadPathObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0203aca0(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadViewObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe690 -- hand the
+ * category's entry array and count straight to func_0202b0c4.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b0c4(void*, unsigned int);
+extern "C" void func_0202b0c4(void* entries, u32 count);
 
-void _Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadViewObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b0c4(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadMinimapTileObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe40c -- hand the
+ * category's entry array and count straight to func_0202b044.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b044(void*, unsigned int);
+extern "C" void func_0202b044(void* entries, u32 count);
 
-void _Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadMinimapTileObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b044(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadMinimapScaleObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe3f8 -- hand the
+ * category's entry array and count straight to func_0202af80.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202af80(void*, unsigned int);
+extern "C" void func_0202af80(void* entries, u32 count);
 
-void _Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadMinimapScaleObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202af80(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadTeleportDestObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe5e0 -- hand the
+ * category's entry array and count straight to func_0202b090.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b090(void*, unsigned int);
+extern "C" void func_0202b090(void* entries, u32 count);
 
-void _Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadTeleportDestObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b090(tbl.entries, tbl.count);
-}
 }


### PR DESCRIPTION
Independent, off `main`. Sibling of #1239 (CP15) and #1240 (IRQ/G3X).

Eighteen functions take an `LVL_Overlay` table and **not one of them had a header** — every file declared its own copy, and they disagree. This adds `include/LVL_Overlay.h` and moves the six identical forwarders onto it.

## Two table types, and they really are different

The mangled names distinguish them — `RN11LVL_Overlay8ObjTableE` vs `RN11LVL_Overlay11ObjSubTableE` — and so do the bodies:

| type | how its count is read | where |
|---|---|---|
| `ObjTable` | `*(unsigned short *)t` — 16-bit at `0x00` | `LoadObjects`, ov002:`0x020fe33c` |
| `ObjSubTable` | `*(u8 *)(t + 1)` — 8-bit at `0x01` | every sub-table loader |

Those **cannot be the same field.** On little-endian, byte 1 of a u16 at `0x00` is the *high* byte, so reading a 16-bit count that way would report zero for every count below 256 — which is every count. `ObjTable` carries a u16 at `0x00`, `ObjSubTable` carries a u8 at `0x01`, and `ObjSubTable`'s byte 0 is something no loader in this family reads. Both are 8 bytes with the entry pointer at `0x04`.

`entries` stays `void*` on purpose. The record type differs per category — `LoadDoorObjects` walks 12-byte door records, `LoadObjects` walks 8-byte entries with a packed type in the top three bits of byte 0 — so each loader says what it points at rather than the header guessing once for all of them.

The two trailing parameters of every forwarder are declared and unused. That is not sloppiness in the recovery: `LoadObjects` dispatches all of these through one function-pointer table, so they share a signature whether they want the arguments or not.

## The header gates itself, because the usual gate cannot

Nested types defeat `check_header_offsets.py`. Its aggregate regex is `struct X { [^{}]* }`, which by construction cannot span a nested brace — so it walks the outer `LVL_Overlay`, finds no fields of its own, and reports:

```
include/LVL_Overlay.h: 0 commented fields, 0 mismatched, 0 unparsed, struct spans 0x0
```

That reads like a pass and checks nothing. Same silent no-op that reordering the two struct spellings fixed for `include/Heap.h` (#1232) — except here no reordering helps, because the types being described **are** the nested ones.

So the sizes are asserted at compile time instead, with the idiom the tree already uses and which `check_header_offsets.py` already reads into its `CLASS_SIZES` table. Narrower than an offset gate — it catches a wrong width or a missing pad, not a wrong order — but it fails the build instead of passing without looking.

**Tested against a planted regression:** asserting `0xc` for `ObjTable` gives `include\LVL_Overlay.h:74: illegal constant expression` and `build_pin` returns `False`. The gate bites.

## Left for later, deliberately

Twelve loaders. Each walks its own record type — doors, exits, entrances, star cameras, the packed standard/simple entries — so each needs a record struct reconstructed before it can stop casting through `char*`. The header they all need exists now.

## Gates

```
build_pin.verify           6/6 (True, '2004/b56', module ov002)
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10712 / 11159, unchanged
header_cpp_sweep.py        PASS
port_refcheck.py           PASS, 393 references, 0 stale
langmode_audit.py --check  PASS; unmigrated 1210 -> 1204, shadows 2630 -> 2624
prepush_attribution.py     0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS