### PR TITLE
Heap.h and runbook 8: correct four statements the ROM does not support

### DIFF
--- a/include/Heap.h
+++ b/include/Heap.h
@@ -84,13 +84,17 @@
  * reason. Making SolidHeap actually derive from Heap forced the question, and
  * on one of the two the ROM says the other side was right:
  *
- *   slot 13  VSetNodeID  -> u32. NOT void, and this one is BYTE-OBSERVABLE.
- *            _ZN9SolidHeap10VSetNodeIDEj (0x0203c3f0) is eight bytes --
- *            `mov r0,#0 / bx lr'. It materializes a return value, and a void
- *            declaration cannot emit that `mov'. ExpandingHeap's override is a
- *            pure forward, so declaring it u32 costs it nothing: a tail call
- *            leaves the callee's r0 in place either way. Both overrides agree
- *            under u32; only one can be right under void.
+ *   slot 13  VSetNodeID  -> u32, NOT void. What the bytes observe is
+ *            NON-VOIDNESS, and only that: _ZN9SolidHeap10VSetNodeIDEj
+ *            (0x0203c3f0) is eight bytes -- `mov r0,#0 / bx lr' -- so it
+ *            materializes a return value that no void body can emit (measured:
+ *            `void f(u32 id){id=0;}' loses the store to dead-code elimination
+ *            at -O4,p and emits `bx lr' alone). `bool' and `int' produce the
+ *            same eight bytes, so the bytes do not pick u32 over them; the
+ *            width comes from ExpandingHeapAllocator::SetNodeID (0x0204e0e8),
+ *            which loads and returns the old id with `ldrh' -- zero-extended,
+ *            hence unsigned. ExpandingHeap's override is a pure forward and
+ *            matches under any of them.
  *
  *   slot  9  VSizeof     -> u32, and this one really is unobservable.
  *            SolidHeap's override returns -1 and ExpandingHeap's forwards;
@@ -102,7 +106,8 @@
  * DEFINITION and observable AT ITS CALLERS. Heap::Reallocate was declared void
  * on the strength of its definition alone; SolidHeap::VResizeToFit then turned
  * out to branch on its result (`if (!Reallocate(...))'), which void cannot even
- * compile. It returns void*, the moved block, like the slot it forwards to.
+ * compile. It returns u32 -- the new SIZE, or 0 -- which is what slot 8 returns;
+ * see the note on VReallocate above.
  */
 #ifndef HEAP_H
 #define HEAP_H

--- a/include/Heap.h
+++ b/include/Heap.h
@@ -212,9 +212,15 @@ struct Heap {
                                                 heap, returns the previous one */
 
     /* Tail-call veneers. Each is a three-word thunk in the ROM --
-       `ldr ip,[pc] / bx ip / .word target' -- reaching a sibling too far away
-       for a b/bl displacement. They are real members with real names, not
-       compiler-generated stubs, so they are declared here like anything else. */
+       `ldr ip,[pc] / bx ip / .word target'. They are real members with real
+       names, not compiler-generated stubs, so they are declared here like
+       anything else.
+
+       NOT distance-driven, despite the shape. An earlier revision of this
+       comment said they reach "a sibling too far away for a b/bl displacement",
+       which is false: b/bl reaches +-32MB and these five span 0xc to 0x430
+       bytes -- InitializeSolidHeapAsDefault sits TWELVE BYTES before the
+       function it jumps to. Whatever produced them, it was not range. */
     void  _Destroy();                        /* -> Destroy */
     void* _Allocate(u32 size, int align);    /* -> Allocate */
     void  _Deallocate(void* ptr);            /* -> Deallocate */

--- a/notes/runbook-type-reconstruction.md
+++ b/notes/runbook-type-reconstruction.md
@@ -463,7 +463,45 @@ the check the ROM build cannot report**, and it is why the baseline is step 0.
 
 ## 8. Not a dead end: tail-call veneers migrate like anything else
 
-**107 files in `src/` are tail-call veneers** -- three-word thunks of the shape
+**58 functions are tail-call veneers, and COUNT THEM THE WAY THIS PARAGRAPH SAYS
+OR YOU WILL GET A DIFFERENT NUMBER.** The definition used here is a ROM property:
+a symbol declared `kind:function(arm,size=0xc)` whose first two words are
+
+```
+ldr ip, [pc, #N]
+bx  ip
+```
+
+That yields **58**, all 58 with a source file -- 37 `.c` and 21 `.cpp` -- of which
+**21 have a mangled stem and all 21 still hand-spell it**. Five of those 21 are
+`Heap`'s and are done.
+
+An earlier revision of this section said 107, which was a fact about the prose
+and not about the ROM: it came from `grep -rl "tail-call veneer" src/`, and that
+comment is applied to more files than carry the strict shape. A reviewer
+scanning the whole image for the byte pattern without the size constraint counted
+163. All three numbers are defensible and none of them is interchangeable, which
+is the point -- section 1 of this runbook says to reproduce a figure before
+quoting it, and this section had to learn it. To reproduce:
+
+```sh
+python - <<'EOF'
+import pathlib, re, struct
+BASE = 0x02004000
+b = pathlib.Path("extracted/arm9_dec.bin").read_bytes()
+n = 0
+for line in pathlib.Path("config/arm9/symbols.txt").read_text().splitlines():
+    m = re.match(r"\s*(\S+)\s+kind:function\(arm,size=0xc\)\s+addr:(0x[0-9a-f]+)", line)
+    if not m: continue
+    off = int(m.group(2), 16) - BASE
+    if not (0 <= off <= len(b) - 12): continue
+    w0, w1 = struct.unpack_from("<II", b, off)
+    if (w0 & 0xfffff000) == 0xe59fc000 and w1 == 0xe12fff1c: n += 1
+print(n)   # arm9 only; overlays add the rest
+EOF
+```
+
+Each is a three-word thunk of the shape
 
 ```
 ldr ip, [pc]
@@ -471,8 +509,7 @@ bx  ip
 .word <target>
 ```
 
-reaching a sibling function. 82 are `.c`, 25 are `.cpp`, and 38 spell a mangled
-symbol by hand. Every one of them was written the same way:
+reaching a sibling function. Every one of them was written the same way:
 
 ```cpp
 extern "C" {


### PR DESCRIPTION
Follow-up to #1235/#1236/#1237, all now merged. **Prose only** — no declaration changes, no byte changes. Every file touching the affected slots re-verifies byte-identical and `rombuild` is 106/106.

All four were found by an adversarial review of the merged slices. Its verdict on the substance was that nothing is a fake match — it independently rebuilt 16 of the migrated files and got `(True, '2004/b56')` on all of them — and that every defect was in the *writing*. Which is the part this workstream claims to be raising the bar on, so they are worth fixing rather than shrugging at.

## 1. `Heap.h` contradicted itself about slot 8

The banner said `Heap::Reallocate` *"returns void\*, the moved block, like the slot it forwards to"* while the declarations twenty lines below said `u32 VReallocate` and `u32 Reallocate`. The u32 side is correct — both allocator definitions return `size`, `0` or `node->size` and never a pointer.

The sentence was a leftover from the **middle step** of the correction, which ran `void` → `void*` → `u32`. Only the first two got written down.

## 2. Slot 13 overclaimed what the bytes show

Calling it *"BYTE-OBSERVABLE [u32]"* is too strong. What the eight bytes of `mov r0,#0 / bx lr` observe is **non-voidness** — `bool` and `int` compile to exactly the same two instructions, so the bytes do not choose `u32` over them.

The width is inferred instead from `ExpandingHeapAllocator::SetNodeID` (`0x0204e0e8`), which returns the old id via `ldrh` — zero-extended, hence unsigned. Conclusion unchanged; the evidence is now stated at its real strength.

The void-side measurement is kept because it is the load-bearing half: `void f(u32 id){id=0;}` loses the store to dead-code elimination at `-O4,p` and emits `bx lr` alone, so no void body reaches those eight bytes.

## 3. The veneer census was a fact about the prose, not the ROM

Runbook §8 said *"107 files in `src/` are tail-call veneers"*. That came from `grep -rl "tail-call veneer" src/` — it counted files whose **comment** says veneer.

Measured as a ROM property instead — a symbol declared `size=0xc` whose first two words are `ldr ip,[pc,#N]` / `bx ip` — the answer is **58**: all 58 with a source file, 37 `.c` and 21 `.cpp`, of which 21 have a mangled stem and all 21 still hand-spell it. A reviewer scanning the whole image for the byte pattern *without* the size constraint counted **163**.

All three numbers are defensible and none is interchangeable. §8 now states its definition, gives the reproduction command, and records the other two counts and why they differ. §1 of the same runbook already says to reproduce a figure before quoting it — this section had to learn it, which is worth leaving in the text.

## 4. The veneer motive was wrong

`Heap.h` said the veneers reach *"a sibling too far away for a b/bl displacement"*. `b`/`bl` reaches ±32MB; these five span `0xc` to `0x430` bytes, and `InitializeSolidHeapAsDefault` sits **twelve bytes** before what it jumps to.

The file for that veneer already said *"they are not distance-driven"* — so the header was contradicting a source file added in the same commit. The shape is recorded now without inventing a reason for it.

## Gates

```
build_pin.verify           _ZN4Heap10ReallocateEPvj, _ZN9SolidHeap10VSetNodeIDEj,
                           _ZN9SolidHeap12VResizeToFitEv, _ZN4Heap8_DestroyEv,
                           _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i
                           all (True, '2004/b56')
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10713 / 11159
prepush_attribution.py     0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS