### PR TITLE
Sound and Memory: four namespace migrations, and a fifth split out for its blast radius

### DIFF
--- a/src/_ZN5Sound9PlayBank0EjRK7Vector3.cpp
+++ b/src/_ZN5Sound9PlayBank0EjRK7Vector3.cpp
@@ -1,8 +1,27 @@
 //cpp
-extern "C" {
-struct Vector3 { int x,y,z; };
-void _ZN5Sound4PlayEjjRK7Vector3(unsigned int bank, unsigned int id, const Vector3* v);
-void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, const Vector3* v) {
-    _ZN5Sound4PlayEjjRK7Vector3(0, id, v);
+// @symbol _ZN5Sound9PlayBank0EjRK7Vector3
+/* Sound::PlayBank0(u32, const Vector3&) at 0x0201264c -- play `id' from bank 0 at
+ * a world position. One of a pair of thin wrappers that exist only to bind the
+ * bank number, so a caller naming a sound does not have to know which bank it
+ * lives in.
+ *
+ * THE PARAMETER IS A REFERENCE, NOT A POINTER, and the mangled name is what
+ * says so: `RK7Vector3' is `const Vector3&'. Every file in this family declared
+ * `const Vector3* v' instead. It is byte-identical -- a reference is an address
+ * in a register either way -- which is exactly why it survived: nothing that
+ * compiles or links can tell the two apart, and only the symbol disagreed.
+ *
+ * Vector3 comes from types.h rather than the three-int shadow this file used to
+ * declare for itself. */
+#include "types.h"
+
+namespace Sound {
+
+extern "C" void _ZN5Sound4PlayEjjRK7Vector3(u32 bank, u32 id, const Vector3& pos);
+
+void PlayBank0(u32 id, const Vector3& pos)
+{
+    _ZN5Sound4PlayEjjRK7Vector3(0, id, pos);
 }
+
 }

--- a/src/_ZN5Sound9PlayBank3EjRK7Vector3.cpp
+++ b/src/_ZN5Sound9PlayBank3EjRK7Vector3.cpp
@@ -1,8 +1,27 @@
 //cpp
-extern "C" {
-struct Vector3 { int x,y,z; };
-void _ZN5Sound4PlayEjjRK7Vector3(unsigned int bank, unsigned int id, const Vector3* v);
-void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3* v) {
-    _ZN5Sound4PlayEjjRK7Vector3(3, id, v);
+// @symbol _ZN5Sound9PlayBank3EjRK7Vector3
+/* Sound::PlayBank3(u32, const Vector3&) at 0x02012664 -- play `id' from bank 3 at
+ * a world position. One of a pair of thin wrappers that exist only to bind the
+ * bank number, so a caller naming a sound does not have to know which bank it
+ * lives in.
+ *
+ * THE PARAMETER IS A REFERENCE, NOT A POINTER, and the mangled name is what
+ * says so: `RK7Vector3' is `const Vector3&'. Every file in this family declared
+ * `const Vector3* v' instead. It is byte-identical -- a reference is an address
+ * in a register either way -- which is exactly why it survived: nothing that
+ * compiles or links can tell the two apart, and only the symbol disagreed.
+ *
+ * Vector3 comes from types.h rather than the three-int shadow this file used to
+ * declare for itself. */
+#include "types.h"
+
+namespace Sound {
+
+extern "C" void _ZN5Sound4PlayEjjRK7Vector3(u32 bank, u32 id, const Vector3& pos);
+
+void PlayBank3(u32 id, const Vector3& pos)
+{
+    _ZN5Sound4PlayEjjRK7Vector3(3, id, pos);
 }
+
 }

--- a/src/_ZN6Memory13operator_new2Ej.cpp
+++ b/src/_ZN6Memory13operator_new2Ej.cpp
@@ -1,10 +1,25 @@
 //cpp
-/* _ZN6Memory13operator_new2Ej @ 0x203cbd8 (arm9) -- tail-call veneer to func_0203cc0c (0x203cc0c).
- * ldr ip, [pc]; bx ip; .word 0x203cc0c
- */
-extern "C" {
-extern void func_0203cc0c(void);
-void _ZN6Memory13operator_new2Ej(void) {
-    func_0203cc0c();
+// @symbol _ZN6Memory13operator_new2Ej
+/* Memory::operator_new2(u32) at 0x0203cbd8 -- a three-word tail-call veneer to
+ * func_0203cc0c: `ldr ip,[pc] / bx ip / .word 0x0203cc0c'.
+ *
+ * Migrated as a real namespace function per runbook section 8: the veneer is
+ * emitted for the CALL, not for the argument list, so restoring the real
+ * signature costs nothing. Its size comes from the mangled name -- `Ej', u32 --
+ * and the file used to declare BOTH this function and its target as taking
+ * nothing at all, which byte-matches because a tail call never touches r0-r3.
+ *
+ * The target keeps its address name. Naming it would be a claim of its own, and
+ * migration is per-reference. */
+#include "types.h"
+
+namespace Memory {
+
+extern "C" void* func_0203cc0c(u32 size);
+
+void* operator_new2(u32 size)
+{
+    return func_0203cc0c(size);
 }
+
 }

--- a/src/_ZN6Memory16operator_delete2EPv.cpp
+++ b/src/_ZN6Memory16operator_delete2EPv.cpp
@@ -1,10 +1,24 @@
 //cpp
-/* _ZN6Memory16operator_delete2EPv @ 0x203cbcc (arm9) -- tail-call veneer to _ZdlPv (0x203cbf0).
- * ldr ip, [pc]; bx ip; .word 0x203cbf0
- */
-extern "C" {
-extern void _ZdlPv(void);
-void _ZN6Memory16operator_delete2EPv(void) {
-    _ZdlPv();
+// @symbol _ZN6Memory16operator_delete2EPv
+/* Memory::operator_delete2(void*) at 0x0203cbcc -- a three-word tail-call veneer
+ * to _ZdlPv, the global `operator delete(void*)', at 0x0203cbf0.
+ *
+ * Migrated as a real namespace function per runbook section 8. Unlike its
+ * new-side twin the target here already has a real C++ name, so the call is
+ * spelled as the operator it is rather than as an address.
+ *
+ * As with every veneer in the tree, this file used to declare both sides as
+ * `void f(void)'. That byte-matches -- a tail call leaves r0-r3 alone -- and is
+ * exactly why the wrong prototype went unchallenged. */
+#include "types.h"
+
+namespace Memory {
+
+extern "C" void _ZdlPv(void* ptr);
+
+void operator_delete2(void* ptr)
+{
+    _ZdlPv(ptr);
 }
+
 }


### PR DESCRIPTION
Independent, off `main`. Follows #1239 (CP15) and #1240 (IRQ/G3X).

Four files from the layout-free set, checked against the ROM rather than the audit's say-so — using the corrected census method from #1240, which reproduces exactly: 14 genuine false positives, 13 "pool only" where the audit was right, 2 const members, 40 clean.

Two are namespace flips, two are tail-call veneers migrated per runbook §8.

## `Sound::PlayBank0` / `PlayBank3` — the parameter is a reference

Both bind a bank number and forward to `Sound::Play`. Their parameter is `const Vector3&` — a **reference** — and the mangled name is the only thing that ever said so: `RK7Vector3`. Both files declared `const Vector3* v`.

That is byte-identical, because a reference is an address in a register either way — which is precisely why it survived. Nothing that compiles or links can tell the two apart; only the symbol disagreed. `Vector3` now comes from `types.h` instead of a three-int shadow declared per file.

## `Memory::operator_new2` / `operator_delete2` — veneers

Three-word thunks. Both had declared **themselves and their targets** as taking nothing — `void f(void)` calling `void g(void)` — which byte-matches because a tail call never touches `r0-r3`. Sizes come from the mangled names (`Ej`, `EPv`). The delete side forwards to `_ZdlPv`, the global `operator delete`, which already has a real C++ name, so it is spelled as the operator it is rather than as an address.

## A fifth file is deliberately not here

`Sound::PlayLong` cannot be migrated without correcting its symbol, and that correction touches **67 files**. Recorded here so the finding is not lost:

`_ZN5Sound8PlayLongEjjjRK7Vector3j` claims `j` — unsigned int — for its fifth parameter. It is a **signed short**, and the ROM says so in one instruction. Arguments five and up are stack-passed (AAPCS), and this one is read as:

```
ldrsh ip, [sp, #0x18]
```

mwccarm takes width *and signedness* from the declared type:

| declared | emits | result |
|---|---|---|
| `u32` | `ldr` | 1 word differs |
| `u16` | `ldrh` | length changes (size mismatch) |
| **`s16`** | **`ldrsh`** | **exact — 0xa0 bytes, ndiff 0**, mangles `...RK7Vector3s` |

Third instance of this defect class here, all found the same way: `AllocateNode`'s `Pvjj`→`Pvjt` by an `ldrh`, `SolidHeap::VAllocate`'s `Ejj`→`Eji` by a signed `blt`. A caller cannot detect an over-wide integer parameter — AAPCS widens it to a word on the way in regardless — so the width is observable only from inside the callee.

**Why it is split out:** unlike `SolidHeap::VAllocate` (a vtable slot with no callers by name), 67 files reference this symbol as a plain extern identifier. Renaming it alone **fails the link** — `mwldarm: Referenced from "func_ov060_0211747c"` — and drops enrolled from 10712 to 10654. That was measured here, then reverted.

## Gates

```
build_pin.verify           4/4 (True, '2004/b56')
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10713 / 11159
port_refcheck.py           PASS, 393 references, 0 stale
langmode_audit.py --check  PASS
prepush_attribution.py     0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS