### PR TITLE
LVL_Overlay: the three loaders that read no count, and what LVL_Overlay actually is

### DIFF
--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -5820,7 +5820,7 @@ src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
     complete
     .text start:0x020fe3cc end:0x020fe3e4
 
-src/_Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij.c:
+src/_Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
     complete
     .text start:0x020fe3e4 end:0x020fe3f8
 

--- a/include/LVL_Overlay.h
+++ b/include/LVL_Overlay.h
@@ -13,8 +13,13 @@
  *   ObjTable     LoadObjects (ov002:0x020fe33c) reads its count as
  *                `*(unsigned short *)t' -- a 16-bit load at offset 0x00.
  *
- *   ObjSubTable  every sub-table loader reads its count as `*(u8 *)(t + 1)' --
- *                an 8-bit load at offset 0x01.
+ *   ObjSubTable  twelve of the fifteen sub-table loaders read their count as
+ *                `*(u8 *)(t + 1)' -- an 8-bit load at offset 0x01. The other
+ *                three read no count at all: LoadStarCameraObjects and
+ *                LoadUnusedType13Objects each take a single value out of the
+ *                entry array, and LoadPathNodeObjects forwards the array
+ *                pointer without a length. None of the fifteen reads a u16 at
+ *                offset 0x00.
  *
  * Those cannot be the same field. On little-endian, byte 1 of a u16 at 0x00 is
  * the HIGH byte, so a u8 read at 0x01 of a 16-bit count would report zero for
@@ -27,10 +32,16 @@
  *
  * The element type of `entries' is deliberately void*. It differs per category
  * -- LoadDoorObjects walks 12-byte door records, LoadObjects walks 8-byte
- * entries with a packed type in the top three bits of byte 0 -- so the pointer
- * is untyped here and each loader says what it is pointing at. Naming those
- * record types is per-category work, not something to guess once for all of
- * them.
+ * entries whose byte 0 is packed two ways -- so the pointer is untyped here and
+ * each loader says what it is pointing at. Naming those record types is
+ * per-category work, not something to guess once for all of them.
+ *
+ * On that packing, because an earlier revision of this comment had it backwards:
+ * the object TYPE is the LOW FIVE bits (`b & 0x1f'), used to index the handler
+ * table at ov002:0x0210cbb8. The TOP THREE bits (`(b >> 5) & 7') are a filter --
+ * LoadObjects skips the entry unless they are zero or equal to the global byte
+ * at 0x0209f220. Type in the low bits, filter in the high bits, not the other
+ * way round.
  */
 #ifndef LVL_OVERLAY_H
 #define LVL_OVERLAY_H

--- a/include/LVL_Overlay.h
+++ b/include/LVL_Overlay.h
@@ -1,0 +1,79 @@
+/* Hand-written, against evidence. There has never been a header for this type:
+ * every one of the eighteen level-loading functions that takes one declared its
+ * own copy, and they do not agree with each other.
+ *
+ * LVL_Overlay is the parsed form of a level's object data. It holds a table per
+ * object category, and a loader function per category walks it.
+ *
+ * ==== TWO DIFFERENT TABLE TYPES, AND THE EVIDENCE THAT THEY DIFFER ====
+ *
+ * The mangled names distinguish them -- `RN11LVL_Overlay8ObjTableE' versus
+ * `RN11LVL_Overlay11ObjSubTableE' -- and so do the bodies:
+ *
+ *   ObjTable     LoadObjects (ov002:0x020fe33c) reads its count as
+ *                `*(unsigned short *)t' -- a 16-bit load at offset 0x00.
+ *
+ *   ObjSubTable  every sub-table loader reads its count as `*(u8 *)(t + 1)' --
+ *                an 8-bit load at offset 0x01.
+ *
+ * Those cannot be the same field. On little-endian, byte 1 of a u16 at 0x00 is
+ * the HIGH byte, so a u8 read at 0x01 of a 16-bit count would report zero for
+ * every count below 256 -- which is every count. So ObjTable really does carry a
+ * u16 at 0x00, ObjSubTable really does carry a u8 at 0x01, and offset 0x00 of an
+ * ObjSubTable is something else that no loader in this family reads.
+ *
+ * Both are 8 bytes with the entry pointer at 0x04: every loader reaches it as
+ * `*(char **)(t + 4)'.
+ *
+ * The element type of `entries' is deliberately void*. It differs per category
+ * -- LoadDoorObjects walks 12-byte door records, LoadObjects walks 8-byte
+ * entries with a packed type in the top three bits of byte 0 -- so the pointer
+ * is untyped here and each loader says what it is pointing at. Naming those
+ * record types is per-category work, not something to guess once for all of
+ * them.
+ */
+#ifndef LVL_OVERLAY_H
+#define LVL_OVERLAY_H
+#include "types.h"
+
+struct LVL_Overlay {
+#ifdef __cplusplus
+    /* Nested so that the compiler mangles `N11LVL_Overlay8ObjTableE' and
+       `N11LVL_Overlay11ObjSubTableE' -- which is what the ROM's symbols say,
+       and the reason these cannot simply be two top-level structs. */
+    struct ObjTable {
+        u16   count;            /* 0x00 -- 16-bit; see the banner */
+        u8    pad_002[2];
+        void* entries;          /* 0x04 */
+    };
+
+    struct ObjSubTable {
+        u8    unk_000;          /* 0x00 -- not read by any loader in this family */
+        u8    count;            /* 0x01 -- 8-bit; see the banner */
+        u8    pad_002[2];
+        void* entries;          /* 0x04 */
+    };
+#endif
+};
+
+#ifdef __cplusplus
+/* tools/check_header_offsets.py CANNOT GATE THIS HEADER. Its aggregate regex is
+   `struct X { [^{}]* }', which by construction cannot span a nested brace, so it
+   walks the outer LVL_Overlay, finds no fields of its own and reports
+   "0 commented fields, 0 mismatched, struct spans 0x0" -- which reads like a
+   pass and checks nothing. The same shape of silent no-op that putting the C
+   spelling first fixed for include/Heap.h; here there is no reordering that
+   helps, because the types being described ARE the nested ones.
+
+   So the sizes are asserted at compile time instead. This is narrower than the
+   offset gate -- it catches a wrong width or a missing pad, not a wrong order --
+   but it is a real check that fails the build rather than a report that passes
+   without looking. The tree already uses this idiom, and
+   check_header_offsets.py reads these names into its CLASS_SIZES table. */
+typedef char LVL_Overlay_ObjTable_size_must_be_0x8[
+    sizeof(LVL_Overlay::ObjTable) == 0x8 ? 1 : -1];
+typedef char LVL_Overlay_ObjSubTable_size_must_be_0x8[
+    sizeof(LVL_Overlay::ObjSubTable) == 0x8 ? 1 : -1];
+#endif
+
+#endif

--- a/src/_Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadFogObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe5cc -- hand the
+ * category's entry array and count straight to func_0202b060.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b060(void*, unsigned int);
+extern "C" void func_0202b060(void* entries, u32 count);
 
-void _Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadFogObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b060(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadPathObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe6a4 -- hand the
+ * category's entry array and count straight to func_0203aca0.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0203aca0(void*, unsigned int);
+extern "C" void func_0203aca0(void* entries, u32 count);
 
-void _Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadPathObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0203aca0(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadViewObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe690 -- hand the
+ * category's entry array and count straight to func_0202b0c4.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b0c4(void*, unsigned int);
+extern "C" void func_0202b0c4(void* entries, u32 count);
 
-void _Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadViewObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b0c4(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,10 +1,23 @@
 //cpp
-#include "types.h"
-/* LoadPathNodeObjects(LVL_Overlay::ObjSubTable&, int, unsigned) @ 0x20fe6b8 (ov002)
- * -- veneer: ldr r0,[r0,#4]; b func_0203accc. */
-extern "C" {
-extern void func_0203accc(void*, int, u32);
-void _Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij(void* a, int b, u32 c) {
-    func_0203accc(*(void**)((char*)a + 4), b, c);
-}
+// @symbol _Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadPathNodeObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe6b8
+ * -- hand the entry array to func_0203accc along with both trailing arguments.
+ *
+ * Four instructions: `ldr r0,[r0,#4]' then a tail call. The odd one out among
+ * the forwarders in this family -- the other six pass `(entries, count)' to a
+ * loader that needs a length, while this one passes `(entries, areaID, param)'
+ * and no count at all, so the callee must find its own end. *
+ * LVL_Overlay IS A CLASS, NOT A NAMESPACE, and the two are indistinguishable in
+ * a mangled name -- `N11LVL_Overlay...E' is emitted for either. What settles it
+ * is _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider, which takes
+ * `LVL_Overlay&': a reference to a namespace does not exist. One of these files
+ * used to declare `namespace LVL_Overlay { struct ObjSubTable ... }' and matched
+ * perfectly, because nothing about the choice reaches the bytes. */
+#include "LVL_Overlay.h"
+
+extern "C" void func_0203accc(void* entries, int areaID, u32 param);
+
+void LoadPathNodeObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
+    func_0203accc(tbl.entries, areaID, param);
 }

--- a/src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,8 +1,22 @@
 //cpp
-namespace LVL_Overlay {
-struct ObjSubTable { int pad0; int* p; };
-}
-extern int data_02092134;
-void LoadStarCameraObjects(LVL_Overlay::ObjSubTable& t, int a, unsigned int b) {
-    data_02092134 = *t.p;
+// @symbol _Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadStarCameraObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe3cc
+ * -- take the first word of the star-camera table and publish it.
+ *
+ * Reads no count, unlike most of this family: it wants one value, not a list, so
+ * the entry array is dereferenced directly. The other two that skip the count
+ * are LoadUnusedType13Objects and LoadPathNodeObjects. *
+ * LVL_Overlay IS A CLASS, NOT A NAMESPACE, and the two are indistinguishable in
+ * a mangled name -- `N11LVL_Overlay...E' is emitted for either. What settles it
+ * is _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider, which takes
+ * `LVL_Overlay&': a reference to a namespace does not exist. One of these files
+ * used to declare `namespace LVL_Overlay { struct ObjSubTable ... }' and matched
+ * perfectly, because nothing about the choice reaches the bytes. */
+#include "LVL_Overlay.h"
+
+extern "C" int data_02092134;
+
+void LoadStarCameraObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
+    data_02092134 = *(int*)tbl.entries;
 }

--- a/src/_Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadMinimapTileObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe40c -- hand the
+ * category's entry array and count straight to func_0202b044.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b044(void*, unsigned int);
+extern "C" void func_0202b044(void* entries, u32 count);
 
-void _Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadMinimapTileObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b044(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadMinimapScaleObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe3f8 -- hand the
+ * category's entry array and count straight to func_0202af80.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202af80(void*, unsigned int);
+extern "C" void func_0202af80(void* entries, u32 count);
 
-void _Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadMinimapScaleObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202af80(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,15 +1,25 @@
 //cpp
-struct ObjSubTable {
-  unsigned char pad0;   // 0
-  unsigned char count;  // 1
-  unsigned char pad2[2];
-  void* entries;        // 4
-};
+// @symbol _Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadTeleportDestObjects(LVL_Overlay::ObjSubTable&, int, u32) at ov002:0x020fe5e0 -- hand the
+ * category's entry array and count straight to func_0202b090.
+ *
+ * A free function, not a member: no `this`, and the mangled name has no class
+ * prefix. The table type is nested, which is why include/LVL_Overlay.h declares
+ * ObjSubTable inside LVL_Overlay rather than beside it -- that nesting is what
+ * makes the compiler emit `RN11LVL_Overlay11ObjSubTableE`.
+ *
+ * The two trailing parameters are declared and unused, here and in every
+ * sibling forwarder. They are part of the shared loader signature: LoadObjects
+ * calls all of these through one function-pointer table, so they take the same
+ * arguments whether they want them or not.
+ *
+ * This file used to carry its own `struct ObjSubTable`. Six of them existed,
+ * character-for-character identical and none of them shared. */
+#include "LVL_Overlay.h"
 
-extern "C" {
-extern void func_0202b090(void*, unsigned int);
+extern "C" void func_0202b090(void* entries, u32 count);
 
-void _Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+void LoadTeleportDestObjects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
     func_0202b090(tbl.entries, tbl.count);
-}
 }

--- a/src/_Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij.c
+++ b/src/_Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij.c
@@ -1,4 +1,0 @@
-extern int data_0209f338[];
-void _Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij(int* p, int b, unsigned int c) {
-  data_0209f338[0] = p[1];
-}

--- a/src/_Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,26 @@
+//cpp
+// @symbol _Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij
+/* LoadUnusedType13Objects(LVL_Overlay::ObjSubTable&, int, u32) at
+ * ov002:0x020fe3e4 -- stash the entry array's ADDRESS and do nothing with it.
+ *
+ * Not a mistake in the recovery: the ROM really does store the pointer rather
+ * than walk it. Object type 13 is unused in the shipped game, so the loader was
+ * evidently reduced to a stub that keeps the table around. It reads no count,
+ * which fits -- there is nothing to iterate.
+ *
+ * The file this replaces reached the field as `p[1]' on an `int*', which is the
+ * same word at offset 4 by arithmetic rather than by name. *
+ * LVL_Overlay IS A CLASS, NOT A NAMESPACE, and the two are indistinguishable in
+ * a mangled name -- `N11LVL_Overlay...E' is emitted for either. What settles it
+ * is _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider, which takes
+ * `LVL_Overlay&': a reference to a namespace does not exist. One of these files
+ * used to declare `namespace LVL_Overlay { struct ObjSubTable ... }' and matched
+ * perfectly, because nothing about the choice reaches the bytes. */
+#include "LVL_Overlay.h"
+
+extern "C" int data_0209f338[];
+
+void LoadUnusedType13Objects(LVL_Overlay::ObjSubTable& tbl, int areaID, u32 param)
+{
+    data_0209f338[0] = (int)tbl.entries;
+}


### PR DESCRIPTION
Stacked on #1241 (both rebased onto current `main`).

Follows the first six. These three are the outliers of the family: **none of them reads a count**, because none of them iterates.

| loader | what it does |
|---|---|
| `LoadStarCameraObjects` | takes the first word of the table and publishes it |
| `LoadUnusedType13Objects` | stores the entry array's **address** and does nothing else — object type 13 is unused in the shipped game, so the loader is a stub that keeps the table around |
| `LoadPathNodeObjects` | forwards `(entries, areaID, param)` and lets the callee find its own end, where the other six forwarders pass `(entries, count)` |

That makes concrete the correction to `include/LVL_Overlay.h`'s *"twelve of the fifteen"* — these are the other three.

## LVL_Overlay is a class, not a namespace

And nothing in a mangled name can tell you: `N11LVL_Overlay11ObjSubTableE` is emitted for either spelling. What settles it is

```
_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider
```

which takes `LVL_Overlay&` — there is no such thing as a reference to a namespace.

`_Z21LoadStarCameraObjects…` had been declaring `namespace LVL_Overlay { struct ObjSubTable … }` and matching perfectly, because the choice never reaches the bytes. The shared header had it right for a different reason (nesting); now it has the evidence.

## Two gate results that looked like defects and were not

Worth recording, because they cost time and will recur:

**Before rebasing, `langmode_audit --check` failed locally and `prepush_attribution` reported `SolidHeap::VAllocateEji` as credit lost.** Neither was real. Both were artifacts of comparing a branch cut from an *older* main against the *current* main: this branch's parent predated the merges of #1235 and #1237, so everything main had gained since read as missing, and every count read as a rise.

Measured directly at the time: `origin/main` 1176 unmigrated, this branch's parent 1204, this commit 1203 — **a fall**, which is what the ratchet actually cares about. CI had agreed all along, because it tests the *merge result* rather than the branch tip (#1241's ratchet check was green throughout).

Rebasing both branches onto current main removes the false signals. **A stale branch makes the local gates lie in the alarming direction while CI stays green** — worth knowing before chasing one.

`enroll.py` also wanted to add an unrelated entry for `src/_ZN6Player12CanEnterDoorEh.c`, drift predating this branch. Removed, as in every previous slice.

## Gates

```
build_pin.verify           3/3 (True, '2004/b56', module ov002)
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10713 / 11159, matching main
port_refcheck.py           PASS, 393 references, 0 stale
langmode_audit --check     PASS (unmigrated 1204 -> 1203, shadows 2624 -> 2623)
prepush_attribution.py     0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS