### PR TITLE
config: regenerate delinks so the committed state matches what enroll.py emits

### DIFF
--- a/config/arm9/itcm/delinks.txt
+++ b/config/arm9/itcm/delinks.txt
@@ -1,5 +1,26 @@
     .text       start:0x01ff8000 end:0x01ffdf3c kind:code align:32
     .bss        start:0x01ffdf40 end:0x01ffdf40 kind:bss align:32
+src/func_01ff859c.c:
+    .text start:0x01ff859c end:0x01ff8708
+
+src/func_01ff97d8.c:
+    .text start:0x01ff97d8 end:0x01ffa344
+
+src/func_01ffa344.c:
+    .text start:0x01ffa344 end:0x01ffa440
+
+src/func_01ffa4bc.c:
+    .text start:0x01ffa4bc end:0x01ffa588
+
+src/func_01ffafd4.c:
+    .text start:0x01ffafd4 end:0x01ffb008
+
+src/func_01ffb008.c:
+    .text start:0x01ffb008 end:0x01ffb030
+
+src/func_01ffb030.c:
+    .text start:0x01ffb030 end:0x01ffb07c
+
 src/func_01ffb07c.cpp:
     complete
     .text start:0x01ffb07c end:0x01ffb098
@@ -47,6 +68,12 @@ src/_ZN12MeshCollider9GetNormalEsR7Vector3.cpp:
 src/_ZN12MeshCollider14GetSurfaceInfoEsR11SurfaceInfo.cpp:
     complete
     .text start:0x01ffd920 end:0x01ffd97c
+
+src/func_01ffd9d4.c:
+    .text start:0x01ffd9d4 end:0x01ffdb28
+
+src/func_01ffdb28.c:
+    .text start:0x01ffdb28 end:0x01ffdbd8
 
 src/OSReadROMArea.c:
     complete

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -2594,6 +2594,9 @@ src/_ZN6Player16TryEnterStarDoorER7Vector3s.cpp:
     complete
     .text start:0x020ca498 end:0x020ca5cc
 
+src/_ZN6Player12CanEnterDoorEh.c:
+    .text start:0x020ca5cc end:0x020ca708
+
 src/_ZN6Player17PlayMammaMiaSoundEv.cpp:
     complete
     .text start:0x020ca708 end:0x020ca724

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -277,6 +277,9 @@ src/func_ov098_0213ad08.c:
     complete
     .text start:0x0213ad08 end:0x0213ade8
 
+src/func_ov098_0213ade8.c:
+    .text start:0x0213ade8 end:0x0213b0a4
+
 src/func_ov098_0213b0a4.cpp:
     complete
     .text start:0x0213b0a4 end:0x0213b15c

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -139,6 +139,9 @@ src/func_ov102_021498c4.c:
     complete
     .text start:0x021498c4 end:0x021498e0
 
+src/func_ov102_021498e0.cpp:
+    .text start:0x021498e0 end:0x02149c78
+
 src/func_ov102_02149c78.c:
     complete
     .text start:0x02149c78 end:0x02149ccc


### PR DESCRIPTION
Config only. Byte-neutral.

Twelve files have existed in `src/` with **no delinks entry at all**. They arrived with recent matching PRs — `1b59ed0f` (Player::CanEnterDoor), `b573429d` (13 functions at 1.2/sp2p3), `84f0aeef` (ov098/ov102 cannon-lid and question-block) — none of which re-ran `enroll.py`, so `config/**/delinks.txt` drifted behind the tree it describes.

The symptom is that **every slice touching delinks has to notice and revert the same unrelated additions.** That happened twice in one session on `src/_ZN6Player12CanEnterDoorEh.c` alone, and reverting drift by hand in each PR is how it stays drift.

```
config/arm9/itcm/delinks.txt             +27   (9 entries)
config/arm9/overlays/ov002/delinks.txt    +3   (1)
config/arm9/overlays/ov098/delinks.txt    +3   (1)
config/arm9/overlays/ov102/delinks.txt    +3   (1)
```

## Byte-neutral, and checked rather than assumed

**Not one added entry carries a `complete` line** — all twelve are `rom-bytes`, so dsd supplies the original ROM bytes and nothing new is compiled. The complete/rom-bytes split is unchanged at `10699/460`, and the ROM build is identical: 106/106 exact, 10,699 reproducing, 0 mismatching.

## Worth attention, and deliberately not done here

**All twelve are in `build/eligible-names.txt`.** They are *eligible but not enrolled* — the build uses ROM bytes for functions whose recovered source is known to reproduce. That is exactly the gap between `eligible: 10713` and `10699 complete`.

Promoting them is a real improvement and `eligible.py` is the gate that decides it, but it changes **what the ROM build compiles**, which is a different decision from making the committed config match its generator. It should be its own PR.

## Gates

```
rombuild.py                106/106 exact, 0 mismatching, PASS
eligible.py                10713 / 11159, unchanged
port_refcheck.py           PASS, 393 references, 0 stale
prepush_attribution.py     0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS