### PR TITLE
enroll: compile the fourteen functions the build was taking from ROM bytes

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -19,6 +19,7 @@ src/AutoloadCallback.c:
     .text start:0x020049ec end:0x020049f0
 
 src/_ZN4CP1511SystemSetupEv.cpp:
+    complete
     .text start:0x020049f0 end:0x02004ad8
 
 src/func_02005000.c:
@@ -6130,6 +6131,7 @@ src/_ZN13ExpandingHeap12VResizeToFitEv.cpp:
     .text start:0x0203c388 end:0x0203c390
 
 src/_ZN4Heap11ResizeToFitEv.cpp:
+    complete
     .text start:0x0203c390 end:0x0203c3d8
 
 src/_ZN9SolidHeap10VGetNodeIDEv.cpp:

--- a/config/arm9/itcm/delinks.txt
+++ b/config/arm9/itcm/delinks.txt
@@ -1,24 +1,31 @@
     .text       start:0x01ff8000 end:0x01ffdf3c kind:code align:32
     .bss        start:0x01ffdf40 end:0x01ffdf40 kind:bss align:32
 src/func_01ff859c.c:
+    complete
     .text start:0x01ff859c end:0x01ff8708
 
 src/func_01ff97d8.c:
+    complete
     .text start:0x01ff97d8 end:0x01ffa344
 
 src/func_01ffa344.c:
+    complete
     .text start:0x01ffa344 end:0x01ffa440
 
 src/func_01ffa4bc.c:
+    complete
     .text start:0x01ffa4bc end:0x01ffa588
 
 src/func_01ffafd4.c:
+    complete
     .text start:0x01ffafd4 end:0x01ffb008
 
 src/func_01ffb008.c:
+    complete
     .text start:0x01ffb008 end:0x01ffb030
 
 src/func_01ffb030.c:
+    complete
     .text start:0x01ffb030 end:0x01ffb07c
 
 src/func_01ffb07c.cpp:
@@ -70,9 +77,11 @@ src/_ZN12MeshCollider14GetSurfaceInfoEsR11SurfaceInfo.cpp:
     .text start:0x01ffd920 end:0x01ffd97c
 
 src/func_01ffd9d4.c:
+    complete
     .text start:0x01ffd9d4 end:0x01ffdb28
 
 src/func_01ffdb28.c:
+    complete
     .text start:0x01ffdb28 end:0x01ffdbd8
 
 src/OSReadROMArea.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -2595,6 +2595,7 @@ src/_ZN6Player16TryEnterStarDoorER7Vector3s.cpp:
     .text start:0x020ca498 end:0x020ca5cc
 
 src/_ZN6Player12CanEnterDoorEh.c:
+    complete
     .text start:0x020ca5cc end:0x020ca708
 
 src/_ZN6Player17PlayMammaMiaSoundEv.cpp:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -278,6 +278,7 @@ src/func_ov098_0213ad08.c:
     .text start:0x0213ad08 end:0x0213ade8
 
 src/func_ov098_0213ade8.c:
+    complete
     .text start:0x0213ade8 end:0x0213b0a4
 
 src/func_ov098_0213b0a4.cpp:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -140,6 +140,7 @@ src/func_ov102_021498c4.c:
     .text start:0x021498c4 end:0x021498e0
 
 src/func_ov102_021498e0.cpp:
+    complete
     .text start:0x021498e0 end:0x02149c78
 
 src/func_ov102_02149c78.c:


### PR DESCRIPTION
Stacked on #1248 — without those twelve delinks entries there is nothing to mark `complete`.

The tree has been carrying a gap between what it **can** build and what it **does** build. `eligible.py` said 10713; `config/**/delinks.txt` marked 10699 `complete`. For the difference the ROM build used dsd's copy of the original bytes — even though the recovered source reproduces them. Verified, and then not used.

| | before | after |
|---|---|---|
| source-built functions | 10,699 | **10,713** |
| code bytes | 1,911,916 | **1,918,584** (+6,668) |
| coverage | 86.47% | **86.77%** |
| rom-bytes entries | 460 | 446 |

## The full ROM build passes, not just `--no-rom`

dsd links and emits `build/sm64ds.nds`, and module fidelity is **106/106 exact at 100.000000% of compared bytes**, with 10,713 reproducing and 0 mismatching. Every newly compiled function produces the bytes it replaced.

## What was promoted

- nine ITCM functions (`func_01ff859c` … `func_01ffdb28`) from `b573429d`, *"Match 13 functions byte-identical"*
- `func_ov098_0213ade8` and `func_ov102_021498e0` from `84f0aeef`, the cannon-lid and question-block states
- `_ZN6Player12CanEnterDoorEh` from `1b59ed0f`
- `_ZN4CP1511SystemSetupEv` and `_ZN4Heap11ResizeToFitEv`

**The last two are worth a note.** Both were migrated to real C++ earlier in this series — SystemSetup in the CP15 slice (#1239), ResizeToFit in the Heap methods slice (#1233) — and both were **already unenrolled before that work started**, at `5f6ce316`. The migrations were improving source the ROM build was not compiling.

Checked rather than assumed: neither entry carried `complete` at `5f6ce316` *or* at current main, so nothing was lost by the migrations. The gap predated them and survived them.

## Why this is its own change

Enrollment is **invisible to a slice's own gates**. `eligible.py` counts what *could* be built, and the byte gate checks one function at a time — so a file can be migrated, verified, landed, and still never compiled, while every count the slice reports stays perfectly honest.

## Gates

```
rombuild.py (full, with ROM)  106/106 exact, 10,713 reproducing, 0 mismatching, PASS
eligible.py                   10713 / 11159
port_refcheck.py              PASS, 393 references, 0 stale
prepush_attribution.py        0 changed, 0 lost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS