### PR TITLE
Fader: the vtable is ten slots, and the family is a chain

### DIFF
--- a/include/Fader.h
+++ b/include/Fader.h
@@ -11,15 +11,39 @@
  * Fader::~Fader stores it into [this+0x0]. So the vptr is at 0x0 and the first
  * data member starts at 0x4. Fader::AdvanceInterp reads a Fix12i at 0x8 and
  * passes &[this+0x4] to the 20.12 approach helper at 0x0203ae58, which pins
- * currInterp=0x4 and speed=0x8, both 4 bytes.
+ * currInterp=0x4 and speed=0x8, both 4 bytes. FaderWipe::FaderWipe writes
+ * 0x1000 to [this+0x4] and 0 to [this+0x8] on the way up the chain, which is
+ * the same two fields seen from the constructor side.
  *
- * VTABLE ORDER. FaderBrightness::IsBetweenStartAndEnd calls two virtuals
- * through slots 5 and 6 and returns true only when both are 0 -- "not at the
- * start and not at the end". With the Itanium ABI's two destructor slots (D1,
- * D0) at 0 and 1, that puts IsAtStart at 5 and IsAtEnd at 6 and leaves 2..4 for
- * AdvanceFade, SetBackwardTime and SetForwardTime. That exact signature list is
- * what src/_ZN15FaderBrightness14SetForwardTimeEj used to reproduce the ROM
- * before this header existed, so the ordering is verified, not merely plausible.
+ * VTABLE: TEN SLOTS, AND THIS HEADER USED TO CLAIM SEVEN. The old text derived
+ * 0..6 from FaderBrightness::IsBetweenStartAndEnd calling slots 5 and 6, and
+ * stopped there because nothing it had looked at reached higher. Slots 7, 8 and
+ * 9 exist, and FaderBrightness declared their functions as ordinary non-virtual
+ * members -- three functions the ROM dispatches through the vtable that no
+ * header said were virtual.
+ *
+ * Read _ZTV5Fader at 0x0208eafc and the table is unambiguous, because eight of
+ * its ten words are zero:
+ *
+ *     0208eafc  0201786c  _ZN5FaderD1Ev          slot 0
+ *     0208eb00  02017848  _ZN5FaderD0Ev          slot 1
+ *     0208eb04..0208eb20  00000000               slots 2..9, all null
+ *
+ * A null slot is a pure virtual, so Fader is ABSTRACT and declares eight of
+ * them -- which is why nothing in the ROM ever instantiates one. The names and
+ * order come from the concrete tables, where every slot resolves:
+ * _ZTV15FaderBrightness (0x0208eacc), _ZTV10FaderColor (0x0208eb2c) and
+ * _ZTV9FaderWipe (0x0208ea9c) are each ten entries long and agree slot for slot.
+ *
+ * THE CHAIN is Fader -> FaderBrightness -> FaderColor -> FaderWipe, and
+ * _ZN9FaderWipeC1Ev (0x02017480) is the single clearest statement of it: it
+ * writes all four vtables into [this+0x0] in that exact order, 0x0208eafc then
+ * 0x0208eacc then 0x0208eb2c then 0x0208ea9c, one per sub-object constructor.
+ * The ROM's own type graph says the same -- tools/rtti_extract.py reads
+ * __si_class_type_info records naming these classes dFader_c, dFdBrightness_c,
+ * dFdColor_c and dFdWipe_c, each pointing at exactly one base, in that chain.
+ * (dFdColor_c has two further children the tree has no name for at all,
+ * dFdDummy_c and dWipe_c. dWipe_c is NOT dFdWipe_c; do not coin "Wipe".)
  *
  * FIXED POINT. currInterp runs 0..0x1000 -- 0.0..1.0 in 20.12. SetToEnd writes
  * 0x1000 and SetToStart writes 0; SetForwardTime derives speed as 1.0/frames
@@ -34,16 +58,27 @@ struct Fader {
     Fix12i currInterp;  /* 0x04 -- current fade level, 0..0x1000 */
     Fix12i speed;       /* 0x08 -- per-frame delta; sign selects the target */
 
-    virtual ~Fader();                          /* vtable slots 0 (D1), 1 (D0) */
-    virtual void AdvanceFade();                /* slot 2 */
-    virtual int SetBackwardTime(u32 frames);   /* slot 3 */
-    virtual int SetForwardTime(u32 frames);    /* slot 4 */
-    virtual int IsAtStart();                   /* slot 5 */
-    virtual int IsAtEnd();                     /* slot 6 */
+    /* Declared first so the destructor is the key function. It is only ever
+       defined as an extern "C" free function, in _ZN5FaderD0Ev.c and
+       _ZN5FaderD1Ev.c, so no translation unit defines it and CW 1.2 emits no
+       vtable group to collide with the ROM's. */
+    virtual ~Fader();                                /* slots 0 (D1), 1 (D0) */
+
+    /* Pure, all eight: the corresponding words in _ZTV5Fader are null. */
+    virtual void AdvanceFade() = 0;                  /* slot 2 */
+    virtual int  SetBackwardTime(u32 frames) = 0;    /* slot 3 */
+    virtual int  SetForwardTime(u32 frames) = 0;     /* slot 4 */
+    virtual int  IsAtStart() = 0;                    /* slot 5 */
+    virtual int  IsAtEnd() = 0;                      /* slot 6 */
+    virtual int  IsBetweenStartAndEnd() = 0;         /* slot 7 */
+    virtual void SetToEnd() = 0;                     /* slot 8 */
+    virtual void SetToStart() = 0;                   /* slot 9 */
 
     /* Steps currInterp toward 1.0 or 0.0 depending on the sign of speed. */
     void AdvanceInterp();
 };
+
+typedef char Fader_size_must_be_0xc[sizeof(Fader) == 0xc ? 1 : -1];
 #else
 /* Same object, spelled for the C destructor translation units: C cannot express
    the virtual functions, so the vptr the compiler would place is explicit. */

--- a/include/FaderBrightness.h
+++ b/include/FaderBrightness.h
@@ -7,20 +7,35 @@
  * interpolator. It adds no members of its own -- FaderBrightness::~FaderBrightness
  * writes the vptr and immediately tail-calls the Fader subobject destructor, so
  * the object is exactly a Fader with a different vtable.
+ *
+ * It is the only concrete implementation in the family: _ZTV15FaderBrightness
+ * (0x0208eacc) fills all eight of the slots Fader leaves null, and both
+ * _ZTV10FaderColor and _ZTV9FaderWipe still point at these functions for
+ * everything except AdvanceFade.
+ *
+ * THREE OF THESE USED TO BE DECLARED NON-VIRTUAL -- IsBetweenStartAndEnd,
+ * SetToEnd and SetToStart. They occupy slots 7, 8 and 9 of every concrete table
+ * in the family, and the ROM calls them through the vtable: Scene::SetFaders
+ * dispatches slot 9 at [vt+0x24] and slot 8 at [vt+0x20] on a fader it has only
+ * as a base pointer, which a non-virtual member makes impossible to express.
  */
 #ifdef __cplusplus
 struct FaderBrightness : Fader {
+    /* Declared first -- key function; only ever defined as an extern "C" free
+       function, in D0Ev.c and D1Ev.c. */
     virtual ~FaderBrightness();
-    virtual void AdvanceFade();
-    virtual int SetBackwardTime(u32 frames);
-    virtual int SetForwardTime(u32 frames);
-    virtual int IsAtStart();
-    virtual int IsAtEnd();
 
-    void SetToStart();
-    void SetToEnd();
-    int IsBetweenStartAndEnd();
+    virtual void AdvanceFade();                 /* slot 2 */
+    virtual int  SetBackwardTime(u32 frames);   /* slot 3 */
+    virtual int  SetForwardTime(u32 frames);    /* slot 4 */
+    virtual int  IsAtStart();                   /* slot 5 */
+    virtual int  IsAtEnd();                     /* slot 6 */
+    virtual int  IsBetweenStartAndEnd();        /* slot 7 */
+    virtual void SetToEnd();                    /* slot 8 */
+    virtual void SetToStart();                  /* slot 9 */
 };
+
+typedef char FaderBrightness_size_must_be_0xc[sizeof(FaderBrightness) == 0xc ? 1 : -1];
 #else
 struct FaderBrightness {
     void*  vtable;      /* 0x00 */

--- a/include/FaderColor.h
+++ b/include/FaderColor.h
@@ -1,20 +1,54 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class FaderColor: 3 matched functions, 2 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef FADERCOLOR_H
 #define FADERCOLOR_H
-#include "types.h"
 
-struct FaderColor {
-    u8  pad_000[0x4];
-    s32 unk_004;            /* 0x004 */
-    u8  pad_008[0x4];
-    u16 unk_00c;            /* 0x00c */
+#include "FaderBrightness.h"
+
+/* Colour fade: same interpolator, driven into BLDY on both engines instead of
+ * MASTER_BRIGHT, with one extra field selecting which direction to blend.
+ *
+ * This header used to be a flat generated struct with no base class, four
+ * fields, and one non-virtual method. Three of those four fields were Fader's:
+ * `unk_004` is currInterp and `pad_008` covered speed. Only the u16 at 0xc is
+ * FaderColor's own.
+ *
+ * DERIVATION. _ZN9FaderWipeC1Ev (0x02017480) writes _ZTV5Fader, then
+ * _ZTV15FaderBrightness, then _ZTV10FaderColor, then _ZTV9FaderWipe, in that
+ * order -- so FaderColor sits between FaderBrightness and FaderWipe. The ROM's
+ * own __si_class_type_info records agree: dFdColor_c's single base is
+ * dFdBrightness_c.
+ *
+ * SIZE 0x10, and the constructor is what fixes it: after the FaderColor part is
+ * initialised (`strh r2,[r4,#0xc]`), FaderWipe's own sub-object constructor is
+ * handed `add r0, r4, #0x10`. The first byte past FaderColor is 0x10.
+ *
+ * VTABLE. _ZTV10FaderColor (0x0208eb2c) is ten slots and overrides exactly one,
+ * slot 2 -- AdvanceFade. Slots 3..9 still point at FaderBrightness's functions.
+ * AdvanceFade is NOT declared first here: the destructor is, so that ~FaderColor
+ * is the key function and no TU defines it. An override takes its base's slot
+ * whatever order it is declared in, so this costs nothing.
+ */
 #ifdef __cplusplus
-    /* methods */
-    void AdvanceFade();
-#endif
+struct FaderColor : FaderBrightness {
+    /* 0x0c. Only its zero/non-zero-ness is observed: AdvanceFade picks a blend
+       step of +0x10 when it is set and -0x10 when it is clear. Kept as unk_00c
+       rather than renamed, because a rename cannot change codegen and belongs in
+       its own commit -- and src/_ZN5Scene14StartSceneFadeEjjt.* names it. */
+    u16 unk_00c;
+
+    virtual ~FaderColor();          /* key function; see above */
+    virtual void AdvanceFade();     /* slot 2 -- the only override */
 };
 
+typedef char FaderColor_size_must_be_0x10[sizeof(FaderColor) == 0x10 ? 1 : -1];
+#else
+/* Spelled for the C destructor translation unit, which cannot express the
+   virtuals and so writes out the vptr the compiler would place. */
+struct FaderColor {
+    void*  vtable;      /* 0x00 */
+    Fix12i currInterp;  /* 0x04 (from Fader) */
+    Fix12i speed;       /* 0x08 (from Fader) */
+    u16    unk_00c;     /* 0x0c */
+};
 #endif
+
+#endif /* FADERCOLOR_H */

--- a/include/FaderWipe.h
+++ b/include/FaderWipe.h
@@ -1,31 +1,56 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class FaderWipe: 5 matched functions, 4 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef FADERWIPE_H
 #define FADERWIPE_H
-#include "types.h"
 
-/* fwd */
-struct id;
-struct FaderWipe {
-    u8  pad_000[0x4];
-    /* These two are Fader's, and include/Fader.h:34-35 already reconstructed them:
-       Fix12i currInterp (0..0x1000, 20.12 fixed point) and Fix12i speed, whose sign
-       selects the fade target. Fix12i is a typedef of s32 -- same bytes, real type
-       named. Not renamed here: renaming cannot change codegen and belongs in its own
-       commit. FaderWipe is one of 7 retyped classes the hierarchy pass cannot place,
-       so "no ancestor declares this offset" was never checkable for it. */
-    Fix12i mFadeAmount;         /* 0x004 -- Fader::currInterp */
-    Fix12i unk_008;             /* 0x008 -- Fader::speed */
-    u16 unk_00c;            /* 0x00c */
-    u8  pad_00e[0x2];
-    u8  unk_010;            /* 0x010 */
+#include "FaderColor.h"
+#include "Model.h"
+
+/* Wipe transition: a FaderColor that also draws a 3D model scaled by the fade
+ * level, so the screen is covered by geometry rather than by a blend register.
+ *
+ * This header used to be a flat generated struct with no base class, and its
+ * own comment recorded the confusion honestly: `mFadeAmount` at 0x004 was
+ * annotated "Fader::currInterp", and 0x008 "Fader::speed", with a note that
+ * "FaderWipe is one of 7 retyped classes the hierarchy pass cannot place, so
+ * 'no ancestor declares this offset' was never checkable for it." It is
+ * checkable now, and the answer is that everything up to 0x10 belongs to
+ * FaderColor and its bases.
+ *
+ * DERIVATION. _ZN9FaderWipeC1Ev (0x02017480) writes four vtables into
+ * [this+0x0] in chain order -- _ZTV5Fader, _ZTV15FaderBrightness,
+ * _ZTV10FaderColor, _ZTV9FaderWipe -- one per sub-object constructor. The ROM's
+ * __si_class_type_info records say the same: dFdWipe_c's single base is
+ * dFdColor_c.
+ *
+ * THE MODEL AT 0x10 is read out of that same constructor. Its last act before
+ * returning is `add r0, r4, #0x10` followed by `bl 0x02016d58`, and 0x02016d58
+ * is _ZN5ModelC1Ev. include/Model.h asserts sizeof(Model) == 0x50, so the whole
+ * object is 0x10 + 0x50 = 0x60. FaderWipe::LoadAndSetFile confirms the offset
+ * independently: it forwards to Model::LoadAndSetFile on `this + 0x10`.
+ *
+ * VTABLE. _ZTV9FaderWipe (0x0208ea9c) is ten slots and overrides exactly one,
+ * slot 2 -- AdvanceFade. Everything else is still FaderBrightness's.
+ * LoadAndSetFile appears in no slot and is non-virtual.
+ */
 #ifdef __cplusplus
-    /* methods */
-    void AdvanceFade();
-    void LoadAndSetFile(unsigned short id);
-#endif
+struct FaderWipe : FaderColor {
+    Model model;                    /* 0x10 -- constructed last by FaderWipe::FaderWipe */
+
+    virtual ~FaderWipe();           /* key function; only defined in D0Ev.c / D1Ev.c */
+    virtual void AdvanceFade();     /* slot 2 -- the only override */
+
+    void LoadAndSetFile(u16 ov0ID);
 };
 
+typedef char FaderWipe_size_must_be_0x60[sizeof(FaderWipe) == 0x60 ? 1 : -1];
+#else
+struct FaderWipe {
+    void*  vtable;      /* 0x00 */
+    Fix12i currInterp;  /* 0x04 (from Fader) */
+    Fix12i speed;       /* 0x08 (from Fader) */
+    u16    unk_00c;     /* 0x0c (from FaderColor) */
+    u8     pad_00e[0x2];
+    u8     model[0x50]; /* 0x10 */
+};
 #endif
+
+#endif /* FADERWIPE_H */

--- a/src/engine/fader/_ZN10FaderColor11AdvanceFadeEv.cpp
+++ b/src/engine/fader/_ZN10FaderColor11AdvanceFadeEv.cpp
@@ -10,13 +10,13 @@ void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short* p, unsigned shor
 
 void FaderColor::AdvanceFade()
 {
-    int old = unk_004;
+    int old = currInterp;
     _ZN5Fader13AdvanceInterpEv(((char*)this));
-    if (unk_004 == old) return;
+    if (currInterp == old) return;
     {
         unsigned short color = unk_00c;
         int m = color ? 0x10 : -0x10;
-        int r = (unk_004 * m) >> 12;
+        int r = (currInterp * m) >> 12;
         if (r != 0) {
             _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short*)0x4000050, 0x3f, r);
             _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short*)0x4001050, 0x3f, r);

--- a/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
+++ b/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
@@ -15,30 +15,30 @@ extern int data_020a0e68[];
 
 void FaderWipe::AdvanceFade()
 {
-    Fix12i old = *(Fix12i*)((char*)&mFadeAmount);
+    Fix12i old = *(Fix12i*)((char*)&currInterp);
     Fix12i cur;
     _ZN5Fader13AdvanceInterpEv(((char*)this));
-    cur = *(Fix12i*)((char*)&mFadeAmount);
+    cur = *(Fix12i*)((char*)&currInterp);
     if (cur == 0 && cur == old) return;
     if (cur == 0x1000) {
         _ZN3G2x18SetBlendBrightnessEPVtts((volatile u16*)0x4000050, 0x3f, -0x10);
     } else {
-        if (*(Fix12i*)((char*)&unk_008) != 0) {
+        if (*(Fix12i*)((char*)&speed) != 0) {
             if (old != 0x1000) *(u16*)0x4000050 = 0;
         }
-        if (*(Fix12i*)((char*)&mFadeAmount) != 0) {
-            Fix12i scale = (Fix12i)(((long long)(0x1000 - *(Fix12i*)((char*)&mFadeAmount)) * 0x20000 + 0x800) >> 12);
+        if (*(Fix12i*)((char*)&currInterp) != 0) {
+            Fix12i scale = (Fix12i)(((long long)(0x1000 - *(Fix12i*)((char*)&currInterp)) * 0x20000 + 0x800) >> 12);
             Matrix4x3_FromTranslation(data_020a0e68, 0, 0, -0x1000);
             Matrix4x3_ApplyInPlaceToScale(data_020a0e68, scale, scale, scale);
             Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, 0x4000);
             _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(((char*)this) + 0x18, data_020a0e68, 0);
         }
     }
-    if (*(Fix12i*)((char*)&mFadeAmount) == old) return;
+    if (*(Fix12i*)((char*)&currInterp) == old) return;
     {
         u16 color = unk_00c;
         int m = color ? 0x10 : -0x10;
-        int prod = *(Fix12i*)((char*)&mFadeAmount) * m;
+        int prod = *(Fix12i*)((char*)&currInterp) * m;
         int r = prod >> 12;
         if (r != 0) {
             _ZN3G2x18SetBlendBrightnessEPVtts((volatile u16*)0x4001050, 0x3f, r);

--- a/src/engine/fader/_ZN9FaderWipe14LoadAndSetFileEt.cpp
+++ b/src/engine/fader/_ZN9FaderWipe14LoadAndSetFileEt.cpp
@@ -2,9 +2,12 @@
 // @symbol _ZN9FaderWipe14LoadAndSetFileEt
 /* recovered: named members + shared header, real C++ method */
 #include "FaderWipe.h"
-extern "C" void _ZN5Model14LoadAndSetFileEtii(void* m, unsigned short id, int a, int b);
 
-void FaderWipe::LoadAndSetFile(unsigned short id)
+/* This used to reach the model as `(char*)this + 0x10` with Model declared
+   nowhere. Going through the member instead is the same bytes and turns the
+   offset into a checkable claim: if `model` were at any other offset, or Model
+   any other size, this would stop matching. */
+void FaderWipe::LoadAndSetFile(u16 ov0ID)
 {
-    _ZN5Model14LoadAndSetFileEtii((char*)((void*)this) + 0x10, id, 0, -1);
+    model.LoadAndSetFile(ov0ID, 0, -1);
 }


### PR DESCRIPTION
`include/Fader.h` claimed **seven** vtable slots. The ROM has **ten**, and the three it was missing were not merely undocumented — `FaderBrightness` declared their functions as ordinary **non-virtual** members, so the tree asserted that three functions the ROM dispatches through the vtable were not virtual at all.

## The vtable

`_ZTV5Fader` (0x0208eafc) settles it, because eight of its ten words are zero:

```
0208eafc  0201786c  _ZN5FaderD1Ev        slot 0
0208eb00  02017848  _ZN5FaderD0Ev        slot 1
0208eb04..0208eb20  00000000             slots 2..9, all null
```

A null slot is a pure virtual. **`Fader` is abstract** with eight of them, which is why nothing in the ROM instantiates one. The names come from the concrete tables — `_ZTV15FaderBrightness`, `_ZTV10FaderColor`, `_ZTV9FaderWipe` — which are ten entries each and agree slot for slot:

| slot | function | | slot | function |
|---|---|---|---|---|
| 0 | `~D1` | | 5 | `IsAtStart` |
| 1 | `~D0` | | 6 | `IsAtEnd` |
| 2 | `AdvanceFade` | | **7** | **`IsBetweenStartAndEnd`** |
| 3 | `SetBackwardTime` | | **8** | **`SetToEnd`** |
| 4 | `SetForwardTime` | | **9** | **`SetToStart`** |

Slots 7–9 in bold are the ones that were declared non-virtual.

## The chain

`Fader → FaderBrightness → FaderColor → FaderWipe`. `_ZN9FaderWipeC1Ev` (0x02017480) is the plainest statement of it: it writes all four vtables into `[this+0x0]` in that exact order, one per sub-object constructor. `tools/rtti_extract.py` agrees from the ROM's own type graph — `__si_class_type_info` records named `dFader_c`, `dFdBrightness_c`, `dFdColor_c`, `dFdWipe_c`, each with exactly one base, in that chain.

(`dFdColor_c` has two more children the tree has no name for: `dFdDummy_c` and `dWipe_c`. **`dWipe_c` is not `dFdWipe_c`** — do not coin "Wipe".)

`FaderColor.h` and `FaderWipe.h` were flat generated structs with no base class, so three of `FaderColor`'s four fields were really `Fader`'s. `FaderWipe.h` said so in its own comment and could not act on it: *"FaderWipe is one of 7 retyped classes the hierarchy pass cannot place, so 'no ancestor declares this offset' was never checkable for it."*

## Sizes

From the same constructor. It initialises the `FaderColor` part with `strh r2,[r4,#0xc]`, then hands `FaderWipe`'s own sub-object constructor `add r0, r4, #0x10` — so `FaderColor` ends at 0x10. That constructor is `_ZN5ModelC1Ev`, and `include/Model.h` already asserts `sizeof(Model) == 0x50`, so `FaderWipe` is 0x60.

`FaderWipe::LoadAndSetFile` now goes through the `model` member instead of `(char*)this + 0x10`, which turns the offset into a claim the compiler checks rather than a literal nobody can contradict.

## Gates

- `rombuild.py`: **106/106 exact, 100.000000% of compared bytes, PASS**
- all **23** fader functions byte-match under 2004/b56, including the two `AdvanceFade` bodies whose field names the inheritance forced to change
- each header carries a compile-time size assertion, tested against planted regressions: `FaderColor` at 0x14 and `FaderWipe` at 0x64 both stop compiling
- `port_refcheck.py` 393/393 · langmode ratchet **PASS**

Deliberately **not** renamed: `FaderColor::unk_00c`. A rename cannot change codegen and belongs in its own commit — `FaderWipe.h`'s own comment already said so — and `src/_ZN5Scene14StartSceneFadeEjjt` names it.

Independent of #1258; touches no Scene file. Next on top of both: `Scene::SetFaders` becomes a real method — it dispatches slots 8 and 9 on a base pointer, which the seven-slot header made impossible to express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS
