### PR TITLE
check_header_offsets: stop silently skipping every derived struct

### DIFF
--- a/include/Actor.h
+++ b/include/Actor.h
@@ -218,4 +218,15 @@ struct Actor {
 
 #endif /* __cplusplus */
 
+/* Outside the split, so the C and C++ spellings cannot drift apart.
+ *
+ * Read what this does and does not claim. 0xd0 is the size this header's own
+ * field list computes -- it is NOT independent ROM evidence that an Actor is
+ * 0xd0 bytes. What it buys is real all the same: the two spellings are held to
+ * each other, a field retyped without shrinking the pad after it stops
+ * compiling, and include/Player.h becomes checkable -- a derived struct's fields
+ * start at its base's size, and tools/check_header_offsets.py will not guess
+ * that number. */
+typedef char Actor_size_must_be_0xd0[sizeof(struct Actor) == 0xd0 ? 1 : -1];
+
 #endif

--- a/include/ActorBase.h
+++ b/include/ActorBase.h
@@ -119,4 +119,11 @@ struct ActorBase {
 
 #endif /* __cplusplus */
 
+/* Outside the __cplusplus split on purpose, so it holds BOTH spellings to the
+   same 0x50 -- the C one writes the vptr out by hand and would otherwise be free
+   to drift from the C++ one. It is also what lets tools/check_header_offsets.py
+   check the classes derived from this: a derived struct's own fields start at the
+   base's size, and the tool refuses to guess it. */
+typedef char ActorBase_size_must_be_0x50[sizeof(struct ActorBase) == 0x50 ? 1 : -1];
+
 #endif

--- a/include/ActorDerived.h
+++ b/include/ActorDerived.h
@@ -47,4 +47,9 @@ struct ActorDerived : ActorBase {
     static void Spawn(u32 actorID, ActorBase *parent, int a, int b);
 };
 
+/* ActorDerived adds no members -- it exists to carry one overridden slot -- so it
+   is exactly ActorBase's 0x50. Asserting it holds that claim, and lets
+   tools/check_header_offsets.py check everything below it. */
+typedef char ActorDerived_size_must_be_0x50[sizeof(ActorDerived) == 0x50 ? 1 : -1];
+
 #endif

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -109,10 +109,27 @@ for path in sys.argv[1:]:
     off, bad, n, skipped, pending = 0, 0, 0, [], []
     trusted = True
     started = in_comment = unmodelled = False
+    unknown_base = derived_from = None
     for lineno, line in enumerate(txt.splitlines(), 1):
         if not started:
-            if re.match(r"^\s*struct \w+ \{", line):
+            # `struct X {` or `struct X : Base {`. Without the second form this
+            # tool never started on a derived struct at all, and reported
+            # "0 commented fields ... struct spans 0x0" -- which reads exactly
+            # like a pass. Every class this repo reconstructs from here on is a
+            # derived struct, so that silence covered the growing majority.
+            m0 = re.match(r"^\s*struct (\w+)\s*(?::\s*(?:public\s+)?(\w+)\s*)?\{", line)
+            if m0:
                 started = True
+                base = m0.group(2)
+                if base is not None:
+                    # A derived struct's own fields do NOT start at 0 -- the base
+                    # sub-object is there. Guessing 0 would mismatch every field,
+                    # so refuse unless the base states its own size.
+                    if base not in SZ:
+                        unknown_base = base
+                        break
+                    off = SZ[base]
+                    derived_from = base
             continue
         if in_comment:
             if "*/" in line:
@@ -128,7 +145,12 @@ for path in sys.argv[1:]:
         # declaration mentions, so the running offset cannot be derived from the text.
         # Say the struct is unmodelled rather than emit a mismatch per field.
         if re.match(r"^\s*(virtual\b|[A-Za-z_][\w:<>, &*]*\([^;]*\)\s*(const)?\s*;)", line):
-            unmodelled = True
+            # ...unless we started from a base whose size is asserted. A derived
+            # class places no vptr of its own -- it inherits the base's, and the
+            # base's asserted size already counts it. The running offset is sound,
+            # so the member functions merely end the field list.
+            if derived_from is None:
+                unmodelled = True
             break
         # A declaration can carry a trailing comment that runs onto later lines:
         #     u8 unk_010;   /* 0x010 - first byte of the 0x28-byte ClsnResult
@@ -177,6 +199,14 @@ for path in sys.argv[1:]:
                                f"computed 0x{off:03x}")
                 bad += 1
         off += w * (int(arr, 0) if arr else 1)
+    if unknown_base:
+        # Not a pass and not a failure: a statement of what is missing. Adding
+        # `typedef char X_size_must_be_0xN[sizeof(X) == 0xN ? 1 : -1];` to the
+        # base's header makes this header checkable AND makes the base's own size
+        # a claim the compiler enforces.
+        print(f"{path}: skipped -- derives from {unknown_base}, whose size is asserted "
+              f"nowhere (add {unknown_base}_size_must_be_0x.. to its header)")
+        continue
     if unmodelled:
         # not a failure: this gate is for the generated flat headers, and a
         # hand-written polymorphic one has layout the text does not determine


### PR DESCRIPTION
`check_header_offsets.py` starts at the first line matching `^\s*struct \w+ \{`. A derived struct is `struct Actor : ActorDerived {`, which does not match — so parsing never started and the tool printed

```
include/Actor.h: 0 commented fields, 0 mismatched, 0 unparsed, struct spans 0x0
```

and exited 0. **That reads exactly like a pass.** It was the same silence for all 24 derived structs in `include/`, and since every class this repo reconstructs from here on is one, the blind spot covered the growing majority of the tree.

## Two changes

1. **Match `struct X : Base {`, and start the running offset at the base's size** rather than at 0. Refuse — with a message naming what's missing — when the base doesn't assert its own size, because guessing would mismatch every field and be worse than not looking.

2. **Don't call a *derived* polymorphic struct unmodelled.** The existing bail-out is right for a root: it carries an implicit vptr at 0x0 that no declaration mentions, so offsets aren't derivable from the text. A derived class places no vptr of its own — it inherits the base's, and the base's asserted size already counts it. The offset is sound; the member functions simply end the field list.

Sizes are asserted for `ActorBase` (0x50), `ActorDerived` (0x50) and `Actor` (0xd0), outside the `__cplusplus` split so the C and C++ spellings of each are held to each other — the C ones write the vptr out by hand and could otherwise drift.

## What this newly checks

**210 fields that were not checked before:**

```
include/Actor.h     33 commented fields, 0 mismatched, spans 0xd0
include/Player.h   177 commented fields, 0 mismatched, spans 0x768
```

`Player.h` is the largest header in the tree and had never been checked at all. Between them, `Actor` and `Player` are the two biggest remaining class backlogs (65 and 48 files).

## On what 0xd0 claims

It is the size `Actor.h`'s own field list computes — **not** independent ROM evidence for `Actor`'s size. It still earns its place: it binds the two spellings together, it fails if a field is retyped without shrinking the pad after it, and it's what makes `Player.h` checkable at all.

## Gates

- tested against a planted regression, **both halves**: mis-commenting `Actor::mPosY` as `0x064` gives `MISMATCH include/Actor.h:66 mPosY: comment 0x064, computed 0x060` and exit 1; asserting a wrong size stops the header compiling
- `rombuild.py`: **106/106 exact, 100.000000% of compared bytes, PASS** — 238 files recompiled, which is every consumer of the three headers
- `port_refcheck.py` 393/393 · langmode ratchet **PASS**
- the tool is invoked by no hook and no workflow, so nothing in CI changes behaviour

Follow-on: `FaderBrightness.h` now reports *"derives from Fader, whose size is asserted nowhere"*. #1259 adds that assertion, so the two compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS
