### PR TITLE
Fader: three of the four vtables have no _ZTV symbol — say so

### DIFF
--- a/include/Fader.h
+++ b/include/Fader.h
@@ -7,8 +7,16 @@
  *
  * Every claim here is read out of the ROM, not guessed:
  *
- * LAYOUT. Fader is polymorphic -- the ROM carries _ZTV5Fader, and
- * Fader::~Fader stores it into [this+0x0]. So the vptr is at 0x0 and the first
+ * A NOTE ON THE VTABLE NAMES BELOW, because an earlier revision of this comment
+ * got them wrong. Three of this family's four vtables have NO _ZTV symbol in
+ * config/arm9/symbols.txt -- they are data_0208eafc (Fader), data_0208eacc
+ * (FaderBrightness) and data_0208eb2c (FaderColor). Only _ZTV9FaderWipe is a
+ * real name. Writing "_ZTV5Fader" reads like a symbol you could grep for and is
+ * really an inference from what the table's entries resolve to. The inference is
+ * sound; the spelling was not, so the addresses are used instead.
+ *
+ * LAYOUT. Fader is polymorphic -- the ROM carries its vtable at data_0208eafc,
+ * and Fader::~Fader stores it into [this+0x0]. So the vptr is at 0x0 and the first
  * data member starts at 0x4. Fader::AdvanceInterp reads a Fix12i at 0x8 and
  * passes &[this+0x4] to the 20.12 approach helper at 0x0203ae58, which pins
  * currInterp=0x4 and speed=0x8, both 4 bytes. FaderWipe::FaderWipe writes
@@ -22,7 +30,7 @@
  * members -- three functions the ROM dispatches through the vtable that no
  * header said were virtual.
  *
- * Read _ZTV5Fader at 0x0208eafc and the table is unambiguous, because eight of
+ * Read the vtable at data_0208eafc and the table is unambiguous, because eight of
  * its ten words are zero:
  *
  *     0208eafc  0201786c  _ZN5FaderD1Ev          slot 0
@@ -31,9 +39,9 @@
  *
  * A null slot is a pure virtual, so Fader is ABSTRACT and declares eight of
  * them -- which is why nothing in the ROM ever instantiates one. The names and
- * order come from the concrete tables, where every slot resolves:
- * _ZTV15FaderBrightness (0x0208eacc), _ZTV10FaderColor (0x0208eb2c) and
- * _ZTV9FaderWipe (0x0208ea9c) are each ten entries long and agree slot for slot.
+ * order come from the concrete tables, where every slot resolves: data_0208eacc,
+ * data_0208eb2c and _ZTV9FaderWipe (0x0208ea9c) are each ten entries long and
+ * agree slot for slot.
  *
  * THE CHAIN is Fader -> FaderBrightness -> FaderColor -> FaderWipe, and
  * _ZN9FaderWipeC1Ev (0x02017480) is the single clearest statement of it: it
@@ -64,7 +72,7 @@ struct Fader {
        vtable group to collide with the ROM's. */
     virtual ~Fader();                                /* slots 0 (D1), 1 (D0) */
 
-    /* Pure, all eight: the corresponding words in _ZTV5Fader are null. */
+    /* Pure, all eight: the corresponding words in data_0208eafc are null. */
     virtual void AdvanceFade() = 0;                  /* slot 2 */
     virtual int  SetBackwardTime(u32 frames) = 0;    /* slot 3 */
     virtual int  SetForwardTime(u32 frames) = 0;     /* slot 4 */

--- a/include/FaderBrightness.h
+++ b/include/FaderBrightness.h
@@ -8,10 +8,11 @@
  * writes the vptr and immediately tail-calls the Fader subobject destructor, so
  * the object is exactly a Fader with a different vtable.
  *
- * It is the only concrete implementation in the family: _ZTV15FaderBrightness
- * (0x0208eacc) fills all eight of the slots Fader leaves null, and both
- * _ZTV10FaderColor and _ZTV9FaderWipe still point at these functions for
- * everything except AdvanceFade.
+ * It is the only concrete implementation in the family: its vtable at
+ * data_0208eacc fills all eight of the slots Fader leaves null, and both
+ * data_0208eb2c (FaderColor's) and _ZTV9FaderWipe still point at these functions
+ * for everything except AdvanceFade. On why three of the four are spelled as
+ * addresses rather than _ZTV names, see include/Fader.h.
  *
  * THREE OF THESE USED TO BE DECLARED NON-VIRTUAL -- IsBetweenStartAndEnd,
  * SetToEnd and SetToStart. They occupy slots 7, 8 and 9 of every concrete table

--- a/include/FaderColor.h
+++ b/include/FaderColor.h
@@ -11,8 +11,8 @@
  * `unk_004` is currInterp and `pad_008` covered speed. Only the u16 at 0xc is
  * FaderColor's own.
  *
- * DERIVATION. _ZN9FaderWipeC1Ev (0x02017480) writes _ZTV5Fader, then
- * _ZTV15FaderBrightness, then _ZTV10FaderColor, then _ZTV9FaderWipe, in that
+ * DERIVATION. _ZN9FaderWipeC1Ev (0x02017480) writes data_0208eafc, then
+ * data_0208eacc, then data_0208eb2c, then _ZTV9FaderWipe, in that
  * order -- so FaderColor sits between FaderBrightness and FaderWipe. The ROM's
  * own __si_class_type_info records agree: dFdColor_c's single base is
  * dFdBrightness_c.
@@ -21,7 +21,7 @@
  * initialised (`strh r2,[r4,#0xc]`), FaderWipe's own sub-object constructor is
  * handed `add r0, r4, #0x10`. The first byte past FaderColor is 0x10.
  *
- * VTABLE. _ZTV10FaderColor (0x0208eb2c) is ten slots and overrides exactly one,
+ * VTABLE. data_0208eb2c is ten slots and overrides exactly one,
  * slot 2 -- AdvanceFade. Slots 3..9 still point at FaderBrightness's functions.
  * AdvanceFade is NOT declared first here: the destructor is, so that ~FaderColor
  * is the key function and no TU defines it. An override takes its base's slot

--- a/include/FaderWipe.h
+++ b/include/FaderWipe.h
@@ -16,8 +16,8 @@
  * FaderColor and its bases.
  *
  * DERIVATION. _ZN9FaderWipeC1Ev (0x02017480) writes four vtables into
- * [this+0x0] in chain order -- _ZTV5Fader, _ZTV15FaderBrightness,
- * _ZTV10FaderColor, _ZTV9FaderWipe -- one per sub-object constructor. The ROM's
+ * [this+0x0] in chain order -- data_0208eafc, data_0208eacc,
+ * data_0208eb2c, _ZTV9FaderWipe -- one per sub-object constructor. The ROM's
  * __si_class_type_info records say the same: dFdWipe_c's single base is
  * dFdColor_c.
  *


### PR DESCRIPTION
#1259's comments wrote `_ZTV5Fader`, `_ZTV15FaderBrightness` and `_ZTV10FaderColor` as though they were symbols. They are not in this tree:

```
grep -c '^_ZTV5Fader '            config/arm9/symbols.txt   -> 0
grep -c '^_ZTV15FaderBrightness ' config/arm9/symbols.txt   -> 0
grep -c '^_ZTV10FaderColor '      config/arm9/symbols.txt   -> 0
grep -c '^_ZTV9FaderWipe '        config/arm9/symbols.txt   -> 1
```

Those three addresses carry the placeholder names `data_0208eafc`, `data_0208eacc` and `data_0208eb2c`. Only FaderWipe's vtable is named.

The inference behind the mangled spellings is sound — each table's entries resolve to that class's functions, and `_ZN9FaderWipeC1Ev` writes them in chain order — but a name that *looks* greppable and isn't costs a reader real time, and this repo has been bitten by exactly that before. The addresses are used instead, with a paragraph in `Fader.h` saying which of the four is real and why the other three are spelled as `data_`.

Comment-only. All 23 fader functions re-verified byte-exact under 2004/b56.

Found by an adversarial review of the neighbouring Scene slice (#1258), which checked every address and symbol name in that diff against the ROM and turned this up in the headers it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS