### PR TITLE
Stage: the ten files that renamed the extension and kept spelling the symbol

### DIFF
--- a/include/Stage.h
+++ b/include/Stage.h
@@ -5,6 +5,8 @@
 
 struct Model;
 struct SceneRelated;
+struct LVL_Overlay;
+struct MeshCollider;
 
 /* The playable level: ActorBase -> ActorDerived -> Scene -> Stage.
  *
@@ -105,6 +107,14 @@ struct Stage : Scene {
 
     /* --- static: reached with no object. The pause-screen and menu group all
            take their first declared argument in r0. --- */
+    static void CheckInput();
+    static void LoadClsnAndObjects(LVL_Overlay &ovl, u32 param, MeshCollider &mc);
+    static void RenderVsModeNewStar();
+    static void RenderVsModeCountdown();
+    static void RenderBouncingArrows();
+    static void VE_Init();
+    static void VE_Update();
+    static void LC_Render();
     /* PS_Init is deliberately NOT declared here. src/_ZN5Stage7PS_InitEv.c
        still hand-spells it, because the tree contains a SECOND file for the same
        symbol -- src/_ZN5Stage7PS_InitEv.cpp -- which delinks.txt does not name

--- a/src/_ZN5Stage10CheckInputEv.cpp
+++ b/src/_ZN5Stage10CheckInputEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Stage.h"
 #include "types.h"
 struct TouchData { u8 touched; u8 tapped; u8 x; u8 y; };
 struct PadData { u16 held; u16 pressed; };
@@ -40,10 +41,9 @@ extern s16 data_020756b0[];
 extern s16 data_02082214[];
 extern u16* data_0209214c[];
 
-void _ZN5Stage10CheckInputEv();
 }
 
-void _ZN5Stage10CheckInputEv()
+void Stage::CheckInput()
 {
     u8 m = data_0209f2d8;
     int b1 = (m == 1);

--- a/src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp
+++ b/src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp
@@ -41,8 +41,10 @@ extern int _ZNK12MeshCollider13GetUnkOctreeYEv(struct MeshCollider* thiz);
 extern void _Z11LoadObjectsRN11LVL_Overlay8ObjTableEij(struct ObjTable* t, int i, unsigned int p);
 extern void _ZN12ActorDerived5SpawnEjP9ActorBaseii(unsigned int id, struct ActorBase* parent, int a, int b);
 
-void _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider(struct LVL_Overlay_s* ovl, unsigned int p, struct MeshCollider* mc)
+void Stage::LoadClsnAndObjects(LVL_Overlay &ovlRef, u32 p, MeshCollider &mcRef)
 {
+    struct LVL_Overlay_s *ovl = (struct LVL_Overlay_s *)&ovlRef;
+    struct MeshCollider *mc = (struct MeshCollider *)&mcRef;
     struct KCL_File* f;
     struct LVL_SubTbl* e;
     signed char i;

--- a/src/_ZN5Stage19BeforeInitResourcesEv.cpp
+++ b/src/_ZN5Stage19BeforeInitResourcesEv.cpp
@@ -1,10 +1,41 @@
 //cpp
-/* _ZN5Stage19BeforeInitResourcesEv @ 0x202ddc8 (arm9) -- tail-call veneer to _ZN5Scene19ResetFadersAndSoundEv (0x202e66c).
- * ldr ip, [pc]; bx ip; .word 0x202e66c
+/* Stage::BeforeInitResources() at 0x0202ddc8, 0xc bytes -- vtable slot 1.
+ *
+ * A tail call to Scene::ResetFadersAndSound (0x0202e66c), emitted as
+ * `ldr ip,[pc]; bx ip; .word` because the build is -interworking; see
+ * src/_ZN5Scene11AfterRenderEj.cpp for why that shape says nothing about branch
+ * range.
+ *
+ * Note what it forwards to: not Scene's BeforeInitResources, but the non-virtual
+ * helper that one calls first. Stage keeps the fader and sound reset and skips
+ * the 3D-graphics reinitialisation its base would also do.
+ *
+ * THE MISSING `return` IS DELIBERATE AND IS THE HONEST SPELLING HERE. Read
+ * before ' fixing' it:
+ *
+ *   - The return type must be `bool`, because ActorBase declares slot 1 that way
+ *     and an override whose return type differs is a nineteenth slot, not an
+ *     override.
+ *   - Scene::ResetFadersAndSound is declared `int`.
+ *   - So `return ResetFadersAndSound();` makes the compiler insert an int->bool
+ *     normalisation, which turns the three-word tail call into a real call with
+ *     a prologue. Measured: both that and `return ... != 0;` diverge from the
+ *     ROM. Only the bare call reproduces it.
+ *
+ * That is not a trick -- it is what a tail call means. The callee's r0 becomes
+ * this function's r0 untouched, and no conversion happens anywhere in the ROM
+ * either. It is runbook section 8's point that a veneer's return type is
+ * unobservable at its own definition, in the one shape where the two ends
+ * genuinely disagree.
+ *
+ * The clean fix is elsewhere: declare Scene::ResetFadersAndSound `bool`, which
+ * is what its body actually returns (mov r0,#1 / moveq r0,#0), and then
+ * `return ResetFadersAndSound();` is both correct and a tail call. That touches
+ * a different class, so it is not in this PR.
  */
-extern "C" {
-extern void _ZN5Scene19ResetFadersAndSoundEv(void);
-void _ZN5Stage19BeforeInitResourcesEv(void) {
-    _ZN5Scene19ResetFadersAndSoundEv();
-}
+#include "Stage.h"
+
+bool Stage::BeforeInitResources()
+{
+    ResetFadersAndSound();
 }

--- a/src/_ZN5Stage19RenderVsModeNewStarEv.cpp
+++ b/src/_ZN5Stage19RenderVsModeNewStarEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Stage.h"
 #include "types.h"
 extern "C" {
 extern u16 data_0209f308;
@@ -15,7 +16,7 @@ extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int b, void* attr, int a
 extern unsigned int func_02012790(unsigned int a);
 }
 
-extern "C" void _ZN5Stage19RenderVsModeNewStarEv(void)
+void Stage::RenderVsModeNewStar()
 {
     u16 timer = data_0209f308;
     if (timer == 0)

--- a/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
+++ b/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Stage.h"
 // _ZN5Stage20RenderBouncingArrowsEv at 0x02023be0
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
 extern "C" {
@@ -11,7 +12,7 @@ extern unsigned char data_0209f248;
 extern void func_020abd88(void);
 int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, void*, int, int, int, int, int, int, int, int);
 
-void _ZN5Stage20RenderBouncingArrowsEv(void) {
+void Stage::RenderBouncingArrows() {
     int r4;
     unsigned char A;
     if (data_0208ee44 == 1) {

--- a/src/_ZN5Stage21RenderVsModeCountdownEv.cpp
+++ b/src/_ZN5Stage21RenderVsModeCountdownEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Stage.h"
 // _ZN5Stage21RenderVsModeCountdownEv at 0x0202a168
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
 struct Base {
@@ -26,7 +27,7 @@ int GetOwnerLanguage(void);
 int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, void*, int, int, int, int, int, int, int, int);
 }
 
-extern "C" void _ZN5Stage21RenderVsModeCountdownEv(void) {
+void Stage::RenderVsModeCountdown() {
     int count = 0;
     int i;
     for (i = 0; i < 4; i++) {

--- a/src/_ZN5Stage7VE_InitEv.cpp
+++ b/src/_ZN5Stage7VE_InitEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Stage.h"
 extern "C" {
 extern unsigned char data_0209d45c[];
 extern unsigned char data_0209d454[];
@@ -16,7 +17,9 @@ extern void SetSubBg0Offset(int a, int b);
 extern void SetSubBg1Offset(int a, int b);
 extern void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short *p, int val, short amt);
 
-void _ZN5Stage7VE_InitEv(void)
+}
+
+void Stage::VE_Init()
 {
     unsigned int a;
     unsigned int b;
@@ -42,5 +45,4 @@ void _ZN5Stage7VE_InitEv(void)
     data_0209f290[0] = 0;
     _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short *)0x4000050, a | 0x20, -7);
     _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short *)0x4001050, b | 0x20, -7);
-}
 }

--- a/src/_ZN5Stage9LC_RenderEv.cpp
+++ b/src/_ZN5Stage9LC_RenderEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Stage.h"
 // _ZN5Stage9LC_RenderEv at 0x02023db8
 
 extern "C" {
@@ -27,7 +28,7 @@ extern unsigned char data_0209f2d4;
 extern void _ZN5Stage20RenderBouncingArrowsEv(void);
 }
 
-extern "C" void _ZN5Stage9LC_RenderEv(void) {
+void Stage::LC_Render() {
     data_0209f2a8 = data_0209f2a8 + data_0208ee44;
     if (data_0209f2a8 >= 0xc)
         data_0209f2a8 = 0;
@@ -81,5 +82,5 @@ extern "C" void _ZN5Stage9LC_RenderEv(void) {
     }
 
     if (data_0209f2d4 == 3)
-        _ZN5Stage20RenderBouncingArrowsEv();
+        RenderBouncingArrows();
 }

--- a/src/_ZN5Stage9LoadModelEv.cpp
+++ b/src/_ZN5Stage9LoadModelEv.cpp
@@ -1,11 +1,12 @@
 //cpp
+#include "Stage.h"
 extern "C" {
 extern char data_0209f340[];
 extern int data_0209f320;
 void _ZN5Model14LoadAndSetFileEtii(char* model, unsigned short id, int b, int c);
-void _ZN5Stage9LoadModelEv(char* self);
 }
-void _ZN5Stage9LoadModelEv(char* self) {
+void Stage::LoadModel() {
+    char *self = (char *)this;
     _ZN5Model14LoadAndSetFileEtii(self + 0x86c, *(unsigned short*)(*(char**)data_0209f340 + 8), 1, -1);
     char* list;
     unsigned int count;

--- a/src/_ZN5Stage9VE_UpdateEv.cpp
+++ b/src/_ZN5Stage9VE_UpdateEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Stage.h"
 #include "types.h"
 extern "C" {
 extern u8 data_0209f244;
@@ -19,7 +20,9 @@ int IsButtonInputValid(void);
 void func_02012790(unsigned int id);
 void _ZN5Scene14StartSceneFadeEjjt(unsigned int a, unsigned int b, unsigned short c);
 
-void _ZN5Stage9VE_UpdateEv(void)
+}
+
+void Stage::VE_Update()
 {
     u8 t = data_0209f244;
     u8 t2;
@@ -98,5 +101,4 @@ void _ZN5Stage9VE_UpdateEv(void)
         break;
     }
     }
-}
 }


### PR DESCRIPTION
Part two of the Stage slice, and the half #821 was actually pointing at — a `.cpp` that still writes `void _ZN5Stage7VE_InitEv(void)` has changed nothing that issue complained about. Ten files; after this, `langmode_audit --list cpp-handspelled | grep Stage` is **empty**.

## Not merely renamed

Three were built against invented types:

- **`CheckInput`** carried a forward declaration of its own mangled name inside an `extern "C"` block.
- **`LoadClsnAndObjects`** took `struct LVL_Overlay_s*` and `struct MeshCollider*` where the mangled name says both are **references**.
- **`LoadModel`** reached the model at +0x86c and the transformer list at +0x874 by casting `this` to `char*`.

Static-or-not is decided at the call sites again: the `VE_`/`LC_` screens and the two vs-mode renderers take no object; `LoadClsnAndObjects` takes its three declared arguments in r0–r2 (`Stage::InitResources` calls it that way); `LoadModel` is a member because it dereferences `this`.

## One file needs its comment read before anyone "fixes" it

`Stage::BeforeInitResources` is vtable slot 1 and a three-word tail call to **`Scene::ResetFadersAndSound`** — not to Scene's `BeforeInitResources`. Stage keeps the fader and sound reset and skips the 3D-graphics reinitialisation its base would also do.

Its return type **must** be `bool`: ActorBase declares slot 1 that way, and an override whose return type differs is a nineteenth slot rather than an override. `ResetFadersAndSound` is declared `int`. So the body is a bare call with **no `return`**, and that is deliberate:

| form | result |
|---|---|
| `return ResetFadersAndSound();` | diverges — int→bool normalisation replaces the tail call |
| `return ResetFadersAndSound() != 0;` | diverges — same reason |
| `ResetFadersAndSound();` | **matches** |

That is what a tail call means: nothing is converted anywhere in the ROM either, and the callee's r0 is already this function's r0. It's runbook §8's "a veneer's return type is unobservable at its own definition", in the one shape where the two ends genuinely disagree.

The clean fix is elsewhere — declare `Scene::ResetFadersAndSound` as `bool`, which is what its body returns (`mov r0,#1` / `moveq r0,#0`). That touches another class, so it isn't here.

## Gates

- `rombuild.py`: **106/106 exact, 100.000000% of compared bytes, PASS**
- all ten byte-match under 2004/b56
- `port_refcheck.py` 393/393 · langmode ratchet **PASS** · unmigrated **1130 → 1120**

Follows #1262 (rebased onto it after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS
