### PR TITLE
Name the credit a merge moved, and let a label accept it

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -11,9 +11,19 @@ name: PR validation
 # for fork PRs. SAFE because this workflow never checks out or runs PR code — it
 # only sends the PR number + immutable head/base SHAs to the relay. The actual validation
 # happens on the self-hosted worker behind the maintainer's NAT, sandboxed there.
+#
+# The attribution-override label is a maintainer's "I know, and I meant it" for a PR
+# that moves contributor credit on purpose — attribution.json pins are exactly that.
+# It is read here, sent with the submission, and turns every attribution finding into
+# a warning on the check instead of a reason the merge cannot land. Only somebody with
+# write access can label a pull request, which is what makes it a safe signal to trust
+# from a pull_request_target workflow.
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    # labeled/unlabeled are here for that one label only — see the job's `if`. Adding it
+    # has to re-submit, because the override travels with the job and the worker reads it
+    # once, when it claims the build.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # No permissions needed. This workflow no longer comments — the app does, under its
 # own identity — so the default read-only token is enough to submit and exit.
@@ -37,6 +47,11 @@ concurrency:
 jobs:
   submit:
     runs-on: ubuntu-latest
+    # Every other label is somebody organising the queue, not asking for an hour of the
+    # worker. Only the override label re-runs validation.
+    if: >-
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+      || github.event.label.name == 'attribution-override'
     steps:
       - name: Submit validation job
         env:
@@ -46,11 +61,13 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          ALLOW_ATTRIBUTION_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'attribution-override') }}
         run: |
           set -euo pipefail
           payload=$(jq -n --arg repo "$REPO" --argjson pr "$PR" \
             --arg sha "$SHA" --arg baseSha "$BASE_SHA" \
-            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha}')
+            --argjson allowAttributionChange "$ALLOW_ATTRIBUTION_CHANGE" \
+            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha,allowAttributionChange:$allowAttributionChange}')
           resp=$(curl -sS -X POST "$RELAY/api/pr-validate" \
             -H "X-Api-Key: $TOKEN" -H "Content-Type: application/json" \
             --data "$payload")

--- a/notes/pr-validation.md
+++ b/notes/pr-validation.md
@@ -9,7 +9,7 @@ one misleading percentage:
 | Coverage denominator | Configured function count and code-byte universe | Must not change silently |
 | Source-built functions and bytes | Code actually linked from our translation units instead of a ROM gap object | Must not regress |
 | Module fidelity | Linked executable-module bytes equal retail | Stock head must pass, unless base and head have the same recorded pre-existing build failure |
-| Contributor lineage | The first matcher still owns a surviving match after moves/renames | Must not change or disappear |
+| Contributor lineage | The first matcher still owns a surviving match after moves/renames | Must not change or disappear, unless the PR carries `attribution-override` |
 | Relocations | Affected source reproduces bytes and names the correct destinations | No WRONG or NO-REPRO |
 | Port references | `port/`'s manifests and symbol bridges still name files and symbols that exist | No stale reference (optional phase) |
 
@@ -51,6 +51,23 @@ The compiler and ROM remain on the private worker. For each relay job:
 A base failure is not hidden. If base and merge fail in the same phase with the same
 failure signature, the report shows a warning and permits a non-regressing PR. If a green
 base becomes red, or the failure changes, validation fails.
+
+## Moving credit on purpose
+
+Some PRs move contributor credit as their whole point — pinning a stem in
+`attribution.json` is exactly that — and the lineage gate is right to notice and wrong to
+block them. Label such a pull request **`attribution-override`**. The workflow re-submits
+on the label, the relay carries it to the worker, and the worker adds
+`--allow-attribution-change` to step 6.
+
+The finding does not go away: the check still names every file whose credit moved, with
+the contributor before and after, and says the label accepted it. Everything else is
+unaffected — a lost match, a changed coverage denominator, or a failed ROM build fails a
+labelled PR exactly as it fails an unlabelled one.
+
+Either way, the check now names the moves rather than counting them. `0 added, 2 changed,
+0 lost` was unactionable for a PR author who cannot read the worker's log: the summary
+names the first few and the check body carries a table of up to 25.
 
 The merge gate always uses the stock profile. `--profile mods` is a developer tool for
 building intentional experiments and is never accepted as reconstruction proof.

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -1,4 +1,5 @@
 """PR reporting is revision-scoped so committed R100 moves preserve credit."""
+import json
 import os
 import pathlib
 import subprocess
@@ -171,6 +172,70 @@ class ValidateMerge(unittest.TestCase):
             VM.build_report(
                 self.base, "HEAD", require_merge_commit=True,
                 expected_pr_head=self.base)
+
+    def test_a_credit_change_names_the_file_and_both_contributors(self):
+        # "2 changed" is unactionable: the PR author cannot see which files moved,
+        # and the worker log they would need is on the maintainer's box.
+        (self.repo / "attribution.json").write_text(
+            '{"overrides": {"src/Example.c": "bob"}}\n', encoding="utf-8")
+        commit(self.repo, "pin credit", "maintainer")
+        report = VM.build_report(self.base, "HEAD")
+        self.assertEqual(report["status"], "Failed")
+        self.assertIn("src/Example.c: alice -> bob", "; ".join(report["reasons"]))
+        self.assertEqual(report["attribution"]["changed"][0]["path"], "src/Example.c")
+        self.assertIn("| `arm9:0x02000000` | `src/Example.c` | alice | bob |",
+                      report["reportMarkdown"])
+
+    def test_attribution_override_reports_the_change_without_failing(self):
+        # The label says "I know, and I meant it" -- so the finding is still computed
+        # and still named, it just stops being a reason the merge cannot land.
+        (self.repo / "attribution.json").write_text(
+            '{"overrides": {"src/Example.c": "bob"}}\n', encoding="utf-8")
+        commit(self.repo, "pin credit", "maintainer")
+        report = VM.build_report(self.base, "HEAD", allow_attribution_change=True)
+        self.assertEqual(report["status"], "Passed")
+        self.assertEqual(report["reasons"], [])
+        self.assertIn("src/Example.c: alice -> bob", "; ".join(report["warnings"]))
+        self.assertIn("(override label)", report["reportMarkdown"])
+        self.assertEqual(len(report["attribution"]["changed"]), 1)
+
+    def test_a_wholesale_credit_move_stays_within_the_relay_summary_limit(self):
+        # The relay rejects a result whose summary runs past 500 characters, and a
+        # rejected result is a job that never reports at all. Naming files is worth
+        # length; a repin sweep must still fit in the reply that carries the verdict.
+        symbols = self.repo / "config" / "arm9" / "symbols.txt"
+        text = symbols.read_text(encoding="utf-8")
+        overrides = {}
+        for i in range(40):
+            name = f"ExtremelyLongMangledFunctionName{i:02d}"
+            text += f"{name} kind:function(arm,size=0x4) addr:0x{0x02000004 + i * 4:08x}\n"
+            (self.repo / "src" / f"{name}.c").write_text(
+                f"int {name}(void) {{ return 0; }}\n")
+            overrides[f"src/{name}.c"] = "bob"
+        symbols.write_text(text, encoding="utf-8")
+        base = commit(self.repo, "more functions", "alice")
+        (self.repo / "attribution.json").write_text(
+            json.dumps({"overrides": overrides}), encoding="utf-8")
+        commit(self.repo, "repin them all", "maintainer")
+
+        report = VM.build_report(base, "HEAD")
+        self.assertEqual(report["status"], "Failed")
+        self.assertEqual(len(report["attribution"]["changed"]), 40)
+        self.assertLessEqual(len(report["summary"]), VM.SUMMARY_LIMIT)
+        self.assertIn("+37 more", "; ".join(report["reasons"]))
+        self.assertIn("+15 more", report["reportMarkdown"])
+
+    def test_override_does_not_excuse_a_non_attribution_failure(self):
+        # Scoped to attribution only: a label about credit must not wave through a
+        # PR that actually lost matched code.
+        (self.repo / "src" / "Example.c").write_text(
+            "// NONMATCHING\nint Example(void) { return 0; }\n")
+        (self.repo / "attribution.json").write_text(
+            '{"overrides": {"src/Example.c": "bob"}}\n', encoding="utf-8")
+        commit(self.repo, "unmatch and repin", "maintainer")
+        report = VM.build_report(self.base, "HEAD", allow_attribution_change=True)
+        self.assertEqual(report["status"], "Failed")
+        self.assertIn("lost 1 matched function(s)", report["reasons"])
 
     def test_identical_base_failure_is_warning_but_changed_failure_blocks(self):
         base_failure = {"status": "error", "failure": {

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -33,6 +33,12 @@ import rombuild_check as RBC  # noqa: E402
 FUNC_RE = re.compile(
     r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
 SOURCE_SUFFIXES = (".c", ".cpp")
+# Credit moves named in the one-line reason, and rows in the check body's table.
+CREDIT_NAMED = 3
+CREDIT_ROWS = 25
+# tangos-backend's /result cap. Kept here so the report clips itself rather than being
+# rejected whole -- see the clamp in build_report.
+SUMMARY_LIMIT = 500
 
 
 def _git(*args, allow=(0,), repo=None):
@@ -183,7 +189,9 @@ def attribution_snapshot(rev, functions):
         if not author:
             continue
         author = canon(author)
-        by_function[key] = author
+        # The source path travels with the author because credit is decided per file:
+        # a report that says only "2 changed" cannot tell a PR author which two.
+        by_function[key] = {"author": author, "path": path}
         counts[author] += 1
         sizes[author] += rec["size"]
     return {"byFunction": by_function,
@@ -323,9 +331,27 @@ def _port_reason(port):
     return f"port refcheck: {len(failures)} stale reference(s) ({shown})"
 
 
+def _credit_detail(changed, lost):
+    """Name whose credit moved, not just how many did: "2 changed" sends a PR author
+    to the worker log to find out which two files and which two contributors.
+
+    Only CREDIT_NAMED of them go inline, because this text reaches the check run's
+    summary and tangos-backend refuses a summary over 500 characters outright -- a
+    long list would cost the whole verdict.  The readable list is the table
+    ``render_markdown`` writes into the check body, and the full one is the JSON
+    report's ``attribution`` section.
+    """
+    moves = ([f"{c['path']}: {c['before']} -> {c['after']}" for c in changed]
+             + [f"{c['path']}: {c['author']} -> nobody" for c in lost])
+    shown = "; ".join(moves[:CREDIT_NAMED])
+    if len(moves) > CREDIT_NAMED:
+        shown += f"; +{len(moves) - CREDIT_NAMED} more"
+    return f"{len(changed)} changed, {len(lost)} lost -- {shown}"
+
+
 def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                  require_merge_commit=False, expected_pr_head=None,
-                 port_report=None):
+                 port_report=None, allow_attribution_change=False):
     base_sha, head_sha = resolve_commit(base), resolve_commit(head)
     parents = _git("rev-list", "--parents", "-n", "1", head_sha).split()
     is_merge = len(parents) >= 3
@@ -359,14 +385,16 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     new_unbannered = [p for p, c in changed_cls.items() if c == "unbannered-asm"]
 
     base_keys, head_keys = set(bf["matched"]), set(hf["matched"])
-    common_credit = set(ba["byFunction"]) & set(ha["byFunction"])
-    credit_changes = [{"id": k, "before": ba["byFunction"][k], "after": ha["byFunction"][k]}
+    bc, hc = ba["byFunction"], ha["byFunction"]
+    common_credit = set(bc) & set(hc)
+    credit_changes = [{"id": k, "path": hc[k]["path"], "basePath": bc[k]["path"],
+                       "before": bc[k]["author"], "after": hc[k]["author"]}
                       for k in sorted(common_credit)
-                      if ba["byFunction"][k] != ha["byFunction"][k]]
-    lost_credit = [{"id": k, "author": ba["byFunction"][k]}
-                   for k in sorted(set(ba["byFunction"]) - set(ha["byFunction"]))]
-    added_credit = [{"id": k, "author": ha["byFunction"][k]}
-                    for k in sorted(set(ha["byFunction"]) - set(ba["byFunction"]))]
+                      if bc[k]["author"] != hc[k]["author"]]
+    lost_credit = [{"id": k, "path": bc[k]["path"], "author": bc[k]["author"]}
+                   for k in sorted(set(bc) - set(hc))]
+    added_credit = [{"id": k, "path": hc[k]["path"], "author": hc[k]["author"]}
+                    for k in sorted(set(hc) - set(bc))]
 
     base_rom_state, head_rom_state = _rom_state(base_rom), _rom_state(head_rom)
     rom_regression = (base_rom_state.get("passed") is True
@@ -386,9 +414,18 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append("function/byte coverage denominator changed")
     if he["stats"]["sourceBytes"] < be["stats"]["sourceBytes"]:
         reasons.append("source-built byte coverage decreased")
-    if credit_changes or lost_credit:
-        reasons.append("contributor attribution changed or was lost")
-    if ha["stats"]["unattributedFunctions"] > ba["stats"]["unattributedFunctions"]:
+    # The attribution-override label (carried on the job by tangos-backend) makes every
+    # attribution finding advisory for this one pull request.  The finding is still
+    # computed and still named -- an override says "I know, and I meant it", not "do not
+    # look" -- it just stops being a reason the merge cannot land.
+    credit_moved = bool(credit_changes or lost_credit)
+    new_unattributed = (ha["stats"]["unattributedFunctions"]
+                        > ba["stats"]["unattributedFunctions"])
+    if credit_moved and not allow_attribution_change:
+        reasons.append("contributor attribution changed or was lost "
+                       f"({_credit_detail(credit_changes, lost_credit)}); label the pull "
+                       "request attribution-override to accept it")
+    if new_unattributed and not allow_attribution_change:
         reasons.append("the merge introduced an unattributed matched function")
     if diff["leftoverOldPaths"]:
         reasons.append("old source paths remain after rename")
@@ -407,6 +444,14 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append("full-ROM validation failed")
 
     warnings = []
+    if allow_attribution_change and credit_moved:
+        warnings.append("attribution-override label: contributor attribution changed or "
+                        f"was lost ({_credit_detail(credit_changes, lost_credit)}), "
+                        "accepted without failing the pull request")
+    if allow_attribution_change and new_unattributed:
+        warnings.append("attribution-override label: the merge introduced an "
+                        "unattributed matched function, accepted without failing "
+                        "the pull request")
     if same_baseline_failure:
         warnings.append("base and merge share the same pre-existing ROM-build failure")
     if new_unbannered:
@@ -437,14 +482,28 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     head_source_stats["sourceBytesPercent"] = (
         100.0 * head_source_stats["sourceBytes"] / hf["stats"]["totalBytes"]
         if hf["stats"]["totalBytes"] else 0.0)
+    if reasons:
+        summary = "Validation failed: " + "; ".join(reasons)
+    elif allow_attribution_change and (credit_moved or new_unattributed):
+        # Passing *because* of the label is not the same verdict as nothing having
+        # moved, and the one-liner is what most people read.
+        summary = ("Committed merge passes; the attribution-override label accepted "
+                   f"{len(credit_changes)} credit change(s), {len(lost_credit)} lost.")
+    else:
+        summary = "Committed merge introduces no reconstruction or attribution regression."
+    # tangos-backend refuses a result whose summary runs past 500 characters, and a refused
+    # result is a job that never reports at all -- the check sits pending until the sweeper
+    # writes it off. Naming what broke is worth the length; losing the verdict is not, and
+    # `reasons` below still carries every reason in full.
+    if len(summary) > SUMMARY_LIMIT:
+        summary = summary[:SUMMARY_LIMIT - 1] + "…"
     report = {
         "schemaVersion": 1,
         "status": "Failed" if reasons else "Passed",
         "baseSha": base_sha,
         "headSha": head_sha,
         "committedMerge": is_merge,
-        "summary": "Validation failed: " + "; ".join(reasons) if reasons
-                   else "Committed merge introduces no reconstruction or attribution regression.",
+        "summary": summary,
         "reasons": reasons,
         "warnings": warnings,
         "coverage": {"base": bf["stats"], "head": hf["stats"], "delta": coverage_delta},
@@ -452,7 +511,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         "attribution": {"base": ba["contributors"], "head": ha["contributors"],
                         "baseStats": ba["stats"], "headStats": ha["stats"],
                         "added": added_credit, "changed": credit_changes,
-                        "lost": lost_credit},
+                        "lost": lost_credit, "overridden": allow_attribution_change},
         "diff": diff,
         "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered},
         "linkcheck": link,
@@ -486,7 +545,8 @@ def render_markdown(r):
              f"| Perfect source moves | {len(r['diff']['perfectRenames'])} R100 |",
              f"| Contributor credit | {len(r['attribution']['added'])} added, "
              f"{len(r['attribution']['changed'])} changed, "
-             f"{len(r['attribution']['lost'])} lost |",
+             f"{len(r['attribution']['lost'])} lost"
+             f"{' (override label)' if r['attribution'].get('overridden') else ''} |",
              f"| Relocation check | {l['checked']} checked; {relocation_summary} |"]
     # Optional phase: no row at all when it did not run, so an older worker's
     # report reads exactly as it did before.
@@ -506,9 +566,36 @@ def render_markdown(r):
         lines.append(f"| Full ROM build | {head_rom['failure'].get('phase')} failed |")
     else:
         lines.append("| Full ROM build | not supplied |")
+    lines += _credit_table(r["attribution"])
     if r["warnings"]:
         lines += ["", "Warnings: " + "; ".join(r["warnings"]) + "."]
     return "\n".join(lines)
+
+
+def _credit_table(a):
+    """Spell out every credit the merge moved or dropped.
+
+    The summary line has room for CREDIT_NAMED of them; this is the check body, where
+    a PR author can actually read the list and see whether the moves are the ones the
+    pull request meant to make.  Added credit is not listed -- new work earning new
+    credit is what a merge is for, and it is never what fails the check.
+    """
+    rows = ([(c["id"], c["path"], c.get("basePath", c["path"]), c["before"], c["after"])
+             for c in a["changed"]]
+            + [(c["id"], c["path"], c["path"], c["author"], "nobody") for c in a["lost"]])
+    if not rows:
+        return []
+    lines = ["", f"#### Contributor credit moved ({len(rows)})", "",
+             "| Function | Source | Before | After |", "|---|---|---|---|"]
+    for fid, path, base_path, before, after in rows[:CREDIT_ROWS]:
+        # A rename that also moves credit is the case worth seeing whole, so the old
+        # path stays visible rather than being silently replaced by the new one.
+        where = path if base_path == path else f"{base_path} -> {path}"
+        lines.append(f"| `{fid}` | `{where}` | {before} | {after} |")
+    if len(rows) > CREDIT_ROWS:
+        lines += ["", f"+{len(rows) - CREDIT_ROWS} more; the full list is in the "
+                      "JSON report's `attribution` section."]
+    return lines
 
 
 def main():
@@ -524,13 +611,18 @@ def main():
     ap.add_argument("--port-refcheck-report",
                     help="tools/port_refcheck.py --json output; the check is "
                          "reported only when this is supplied and exists")
+    ap.add_argument("--allow-attribution-change", action="store_true",
+                    help="report attribution changes as warnings instead of failing "
+                         "the merge; the worker passes this for a pull request "
+                         "carrying the attribution-override label")
     ap.add_argument("--out", required=True)
     ap.add_argument("--markdown")
     args = ap.parse_args()
     report = build_report(args.base, args.head, _load_json(args.base_rom_report),
                           _load_json(args.head_rom_report), _load_json(args.link_report),
                           args.require_merge_commit, args.expected_pr_head,
-                          _load_json(args.port_refcheck_report, optional=True))
+                          _load_json(args.port_refcheck_report, optional=True),
+                          args.allow_attribution_change)
     pathlib.Path(args.out).write_text(json.dumps(report, indent=2) + "\n",
                                       encoding="utf-8", newline="\n")
     if args.markdown:


### PR DESCRIPTION
`Contributor credit | 0 added, 2 changed, 0 lost` is a verdict a PR author cannot act on — it never says which files moved, from whom, to whom, and the worker log that would say is on a box they cannot reach. #1267 is the shape that makes it obvious: it pins eight stems in `attribution.json` on purpose, and the check reports two anonymous changes and blocks.

**The report now names them.** The failure reason names the first few moves as `path: before -> after`, the check body carries a table of up to 25 with the source path and both contributors, and the JSON report keeps the full list. A rename that also moves credit shows both paths.

**And a PR that means to move credit can say so.** Label it `attribution-override`: the workflow re-submits on the label, the relay carries it to the worker ([tangos-backend 34e095c](https://github.com/tangosdev/tangos-backend/commit/34e095c)), and `validate_merge.py --allow-attribution-change` reports every attribution finding as a warning instead of a reason the merge cannot land.

Nothing else is waived — a lost match, a changed coverage denominator or a failed ROM build fails a labelled pull request exactly as it fails an unlabelled one — and the finding is still computed and still named on the check, because an override says "I know, and I meant it", not "do not look". Only somebody with write access can label a pull request, which is what makes the label safe to read from a `pull_request_target` workflow.

The worker probes `--help` before passing the new flag, so a PR whose base predates it validates exactly as before instead of dying on argparse.

Tests: three new cases in `tools/test_validate_merge.py` (names the file and both contributors; the override passes without failing; the override does not excuse a lost match), plus a wholesale-repin case that keeps the summary inside the relay's 500-character cap.