### PR TITLE
Stage::GraphCallback2: extern "C" the G2x call so it resolves to something

### DIFF
--- a/src/_ZN5Stage14GraphCallback2EP12SceneRelated.cpp
+++ b/src/_ZN5Stage14GraphCallback2EP12SceneRelated.cpp
@@ -24,7 +24,16 @@ struct SceneRelated {
     struct Matrix2x2* mat;
 };
 
-extern void _ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii(vu16* reg, struct Matrix2x2* mat, s32 a, s32 b, s32 c, s32 d);
+/* extern "C", and the quotes are the whole point. This is a .cpp file, so a
+   bare `extern` makes the mangled name an ordinary C++ identifier and the
+   compiler mangles it a SECOND time -- the call went out to
+   `_Z40_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiiiPVtP9Matrix2x2iiii`, where the
+   `_Z40` counts the 40 characters of the name being wrapped. Nothing defines
+   that, while the real target sits at 0x02055278 with a source file of its own.
+   The byte gate cannot see this: match.py compares relocated words as
+   wildcards and never looks at what a call targets. tools/check_references.py
+   is what catches it. */
+extern "C" void _ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii(vu16* reg, struct Matrix2x2* mat, s32 a, s32 b, s32 c, s32 d);
 
 /* Static, and the parameter is what the mangled name has always said it is.
    This file used to take `struct Stage *self` and then cast it to SceneRelated*


### PR DESCRIPTION
`src/_ZN5Stage14GraphCallback2EP12SceneRelated.cpp` declared its callee as

```c
extern void _ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii(...);
```

in a `//cpp` translation unit. A bare `extern` there makes the mangled name an
ordinary C++ identifier, so the compiler mangled it a **second** time and the
call went out to

```
_Z40_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiiiPVtP9Matrix2x2iiii
```

where `_Z40` is the length prefix counting the 40 characters of the name being
wrapped. Nothing defines that symbol. The real target was available the whole
time — `0x02055278`, size `0xb4`, with its own delinked source file.

### Why no gate caught it until now

The byte gate is structurally blind to this: `match.py` compares relocated words
as wildcards and never looks at what a call targets, so the file has byte-matched
throughout. `tools/check_references.py` is the gate that sees it, and it has been
failing on `main` since #1262 — `check_references.py --update` **refuses to bank
the baseline**, so the failure reproduces on a clean checkout of `main` with no
branch involved:

```
FAIL: this change adds references that resolve to nothing.
  new unresolved reference: _ZN5Stage14GraphCallback2EP12SceneRelated
      _Z40_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiiiPVtP9Matrix2x2iiii
```

`tools/resolve_placeholders.py` does not cover this case — the symbol appears in
neither its resolvable list nor its "why the rest did not resolve" list.

One line, plus a comment explaining why the quotes matter.

### Gates

- `rombuild.py` **106/106 exact, 100.000000%** of compared bytes, PASS, 0 mismatching
- source-built **10,715**, unchanged
- `Stage::GraphCallback2` still byte-matches under **2004/b56**
- `check_references.py` → `OK: no new unresolvable references` (was FAIL on `main`)
- port-refcheck 393/393, duplicate-sources clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS