### PR TITLE
Actor::OnTurnIntoEgg as a real method -- slot 19 was never blocked

### DIFF
--- a/src/_ZN5Actor13OnTurnIntoEggER6Player.cpp
+++ b/src/_ZN5Actor13OnTurnIntoEggER6Player.cpp
@@ -1,10 +1,33 @@
 //cpp
-/* _ZN5Actor13OnTurnIntoEggER6Player @ 0x2010154 (arm9) -- tail-call veneer to _ZN5Actor24KillAndTrackInDeathTableEv (0x200f9b8).
- * ldr ip, [pc]; bx ip; .word 0x200f9b8
+/* Actor::OnTurnIntoEgg(Player&) at 0x02010154, 0xc bytes -- vtable slot 19.
+ *
+ * A tail-call veneer to Actor::KillAndTrackInDeathTable at 0x0200f9b8:
+ *
+ *     ldr ip, [pc]
+ *     bx  ip
+ *     .word 0x0200f9b8
+ *
+ * The behaviour reads straight off the target once it is named: when Yoshi
+ * swallows an actor and turns it into an egg, the actor removes itself the same
+ * way it would if killed -- record it in the death table so it does not respawn,
+ * then mark it for destruction. Turning into an egg IS dying, as far as the
+ * actor list is concerned. Leaf classes override the slot when they want
+ * something else to happen.
+ *
+ * `player` is unused, and the bytes could not tell you otherwise: a tail call
+ * never touches r0-r3, so the argument list is invisible here (runbook section
+ * 8). The signature comes from the mangled name and include/Actor.h, not from
+ * these three words. r0 still holds `this` when the branch is taken, which is
+ * exactly what the target -- a non-static member taking nothing -- expects.
+ *
+ * The slot is declared `int` in include/Actor.h while the target returns void,
+ * so this cannot `return` its callee. Falling off the end reproduces the
+ * veneer: whatever KillAndTrackInDeathTable leaves in r0 becomes the caller's
+ * answer, which is what a tail call means.
  */
-extern "C" {
-extern void _ZN5Actor24KillAndTrackInDeathTableEv(void);
-void _ZN5Actor13OnTurnIntoEggER6Player(void) {
-    _ZN5Actor24KillAndTrackInDeathTableEv();
-}
+#include "Actor.h"
+
+int Actor::OnTurnIntoEgg(Player &player)
+{
+    KillAndTrackInDeathTable();
 }


### PR DESCRIPTION
> Follow-up to #1273, which deferred this file. **Its stated reason was wrong,
> and the correction is the point of this PR.**

#1273's commit message says `OnTurnIntoEgg`'s veneer targets `0x020009b8` and
that no `symbols.txt` entry exists for it, and deferred slot 19 on that basis.

The word at `0x0201015c` is `b8 f9 00 02` — **`0x0200f9b8`**, a transposed digit.
That address is `_ZN5Actor24KillAndTrackInDeathTableEv`, size `0x1c`, which is
**already a real method and already declared in `include/Actor.h`**. `0x020009b8`
has no symbol because it is not a real address. The source file itself had the
target right all along; only the commit message was wrong.

So runbook §8's "migrate the veneer's target first" was already satisfied when
the deferral was written, and slot 19 migrates like the three `After*` veneers
before it:

```cpp
int Actor::OnTurnIntoEgg(Player &player)
{
    KillAndTrackInDeathTable();
}
```

### What it does, once the target is named

When Yoshi swallows an actor and turns it into an egg, the actor removes itself
exactly as if killed — recorded in the death table so it will not respawn, then
marked for destruction. **Turning into an egg *is* dying**, as far as the actor
list is concerned. Leaf classes override the slot when they want something else.

### Two things the bytes cannot tell you

Stated as inherited rather than derived, per §8:

- `player` is unused, and a tail call never touches r0–r3, so the argument list
  is invisible in these three words. The signature comes from the mangled name
  and the header.
- The slot is declared `int` while the target returns `void`, so this cannot
  `return` its callee. Falling off the end reproduces the veneer — whatever
  `KillAndTrackInDeathTable` leaves in r0 becomes the caller's answer, which is
  what a tail call means.

r0 still holds `this` at the branch, which is what the target — a non-static
member taking nothing — expects.

With this, Actor's vtable is fully migrated apart from the destructor pair
(16/17, blocked per runbook §7) and `OnAimedAtWithEggReturnVec` (30), which
returns a `Vector3` by value while the header declares it `virtual int` — a real
defect needing its own slice.

### Gates

Run in a **clean worktree**, because the authoring checkout carries another
workstream's uncommitted `tools/` changes that alter enrollment and currently
fail the build.

- `rombuild.py` **106/106 exact, 100.000000%** of compared bytes, PASS, 0 mismatching; source-built 10,715
- byte-matches under **2004/b56**
- duplicate-sources 11279 stems, none doubled; port-refcheck 393/393
- `check_references` → `OK: no new unresolvable references`
- langmode ratchet PASS; unmigrated 1087 → **1086**, hand-spelled 240 → 239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS