### PR TITLE
Actor: slot 30 returns a Vector3 by value, not an int

### DIFF
--- a/include/Actor.h
+++ b/include/Actor.h
@@ -136,7 +136,22 @@ struct Actor : ActorDerived {
     virtual int  OnHitByMegaChar(Player &player);      /* slot 27 */
     virtual int  OnHitFromUnderneath(Actor &other);    /* slot 28 */
     virtual int  OnAimedAtWithEgg();                   /* slot 29 */
-    virtual int  OnAimedAtWithEggReturnVec();          /* slot 30 */
+
+    /* slot 30. Returns a Vector3 BY VALUE, and the ROM says so plainly: the
+       definition at 0x020100dc writes x/y/z through r0 and reads every field
+       off r1, which is the AAPCS indirect-return shape -- r0 is the caller's
+       return slot, and `this` has been pushed along to r1. A method returning
+       `int` would have had `this` in r0 and nothing in r1.
+
+       It was declared `virtual int` until the definition was migrated, which is
+       when it became falsifiable: nothing in the tree calls this slot, so no
+       caller could ever have contradicted the wrong type.
+
+       Returning a class by value is NOT the by-value-parameter trap of
+       notes/mwccarm-codegen.md 6az. That one is about mwccarm homing r0-r3 for
+       a by-value class ARGUMENT, costing +0x14. An indirect return costs
+       nothing here and byte-matches -- measured, not assumed. */
+    virtual Vector3 OnAimedAtWithEggReturnVec();       /* slot 30 */
 
     /* --- non-virtual --- */
     /* The player-proximity group. ClosestPlayer does the work: it walks the

--- a/src/_ZN5Actor25OnAimedAtWithEggReturnVecEv.cpp
+++ b/src/_ZN5Actor25OnAimedAtWithEggReturnVecEv.cpp
@@ -1,26 +1,51 @@
 //cpp
-// Actor::OnAimedAtWithEggReturnVec(): returns (sret) the actor position
-// (+0x5c..+0x64) with the vtable+0x74 virtual's result added to y.
-typedef int s32;
+/* Actor::OnAimedAtWithEggReturnVec() at 0x020100dc, 0x48 bytes -- vtable slot 30.
+ *
+ * Where an egg should aim: the actor's own position, raised by the lock-on
+ * radius slot 29 reports. The two slots are a pair -- 29 answers "how far out
+ * will an egg home on me", 30 answers "at what point" -- and 30 asks 29
+ * VIRTUALLY, so a leaf class that widens its radius moves its aim point for
+ * free. That call is now spelled `self->OnAimedAtWithEgg()` and the compiler
+ * emits the same `ldr r1,[r0]; ldr r1,[r1,#0x74]; blx r1` the ROM has, because
+ * 0x74/4 = 29 falls out of include/Actor.h's declaration order.
+ *
+ * IT RETURNS A Vector3 BY VALUE, and include/Actor.h now says so -- it said
+ * `virtual int` until this file was migrated. The ROM is unambiguous: r0 is
+ * written and never read as an input, r1 supplies every field load, and the
+ * three stores go through r0 at +0/+4/+8. That is AAPCS indirect return, with
+ * `this` displaced into r1. Nothing in the tree calls slot 30, so the wrong
+ * type had never been falsifiable; migrating the definition is what exposed it.
+ *
+ * WHY THIS IS STILL AN extern "C" FREE FUNCTION AND NOT A METHOD. The honest
+ * spelling
+ *
+ *     Vector3 Actor::OnAimedAtWithEggReturnVec()
+ *     { Vector3 aim; aim.x = mPosX; ...; aim.y += OnAimedAtWithEgg(); return aim; }
+ *
+ * was written and measured first. mwcc 2004/b56 does not apply the named return
+ * value optimization here: it builds the vector on the stack (`sub sp,#0x10`,
+ * stores to `[sp]`) and copies it into the caller's slot at the end with
+ * `ldm r1,{r0,r1,r2}` -- 0x58 bytes against the ROM's 0x48. There is no portable
+ * way to name the caller's return slot from inside a returning method, so the
+ * pointer-taking form stays, exactly as Actor's destructors stay extern "C"
+ * definitions under their mangled names. The DECLARATION carries the truth; the
+ * definition reproduces the bytes.
+ *
+ * Three shadows died even so. The old file carried a `struct Base` with thirty
+ * declared virtuals whose sole purpose was to land `m74` at vtable+0x74, its own
+ * `Vec`, and a `(long long)(int)` cast on the `+=`. The first two are now the
+ * real Actor and the real Vector3. The cast was measured both ways and is NOT
+ * doing anything -- plain `ret->y +=` is byte-identical across all 0x48 bytes --
+ * so it is gone. Assuming it protected the recomputed-address shape the ROM
+ * uses (`add r2,r4,#4` then a separate load-add-store) would have been wrong;
+ * mwcc emits that either way.
+ */
+#include "Actor.h"
 
-struct Vec { s32 x, y, z; };
-
-struct Base {
-    virtual int v0(); virtual int v1(); virtual int v2(); virtual int v3();
-    virtual int v4(); virtual int v5(); virtual int v6(); virtual int v7();
-    virtual int v8(); virtual int v9(); virtual int v10(); virtual int v11();
-    virtual int v12(); virtual int v13(); virtual int v14(); virtual int v15();
-    virtual int v16(); virtual int v17(); virtual int v18(); virtual int v19();
-    virtual int v20(); virtual int v21(); virtual int v22(); virtual int v23();
-    virtual int v24(); virtual int v25(); virtual int v26(); virtual int v27();
-    virtual int v28(); virtual int m74();
-};
-
-extern "C" void _ZN5Actor25OnAimedAtWithEggReturnVecEv(Vec *ret, Base *self)
+extern "C" void _ZN5Actor25OnAimedAtWithEggReturnVecEv(Vector3 *ret, Actor *self)
 {
-    char *a = (char *)self;
-    ret->x = *(s32 *)(a + 0x5c);
-    ret->y = *(s32 *)(a + 0x60);
-    ret->z = *(s32 *)(a + 0x64);
-    *(s32 *)(((long long)(int)((char *)ret + 4))) += self->m74();
+    ret->x = self->mPosX;
+    ret->y = self->mPosY;
+    ret->z = self->mPosZ;
+    ret->y += self->OnAimedAtWithEgg();
 }


### PR DESCRIPTION
`include/Actor.h` declared vtable slot 30 as `virtual int
OnAimedAtWithEggReturnVec()`. The ROM disagrees, and says so at the calling
boundary. At `0x020100dc`: **r0 is written but never read as an input**, r1
supplies every field load, and the three stores go through r0 at `+0/+4/+8`.
That is the AAPCS indirect-return shape — the caller's return slot arrives in r0
and `this` is displaced into r1. A method returning `int` would have had `this`
in r0 and nothing in r1.

**The slot returns a `Vector3` by value.**

Nothing in the tree calls slot 30, which is why the wrong type survived: no
caller could contradict it. The four files that mention the name are *other
classes'* overrides of the same slot, carrying it in recovered-name comments
only. Migrating the definition is the first thing that could falsify the
declaration — and it did.

This is **not** the by-value trap in `notes/mwccarm-codegen.md` 6az. That one is
about a by-value class *argument*, which mwccarm homes to the stack at `+0x14`.
An indirect *return* costs nothing, and the byte match is the proof.

### The definition stays `extern "C"`, and the reason is measured

The honest spelling was written first and compiles clean:

```cpp
Vector3 Actor::OnAimedAtWithEggReturnVec()
{ Vector3 aim; aim.x = mPosX; /* ... */ aim.y += OnAimedAtWithEgg(); return aim; }
```

But mwcc 2004/b56 does not apply the named return value optimization here. It
builds the vector on the stack (`sub sp,#0x10`, stores through `[sp]`) and copies
it into the caller's slot at the end with `ldm r1,{r0,r1,r2}` — **0x58 bytes
against the ROM's 0x48**. There is no portable way to name the caller's return
slot from inside a returning method, so the pointer-taking form is kept, exactly
as Actor's destructors are kept as `extern "C"` definitions under their mangled
names. **The declaration carries the truth; the definition reproduces the bytes.**

### What this slice does and does not buy

It does **not** move the unmigrated headline — the file still hand-spells its
symbol and stays in the `cpp_still_handspelled` bucket. What it buys:

- a correct type on the slot
- removal of two shadow structs: a `struct Base` carrying **thirty** declared
  virtuals whose sole purpose was to land `m74` at `vtable+0x74`, and a private
  `Vec`. Both are now the real `Actor` and the real `Vector3`, so the virtual
  call is spelled `self->OnAimedAtWithEgg()` and the compiler derives
  `vtable+0x74` from `Actor.h`'s own declaration order.

### A third artifact went too, and my first guess about it was wrong

The `+=` was written `*(s32*)(((long long)(int)((char*)ret + 4))) += ...`. I
assumed the cast was protecting the recomputed-address shape the ROM uses
(`add r2,r4,#4`, then a separate load-add-store) and said so in a draft comment.
Measured both ways: plain `ret->y +=` is **byte-identical across all 0x48 bytes**.
mwcc emits that shape either way, so the cast is gone and the comment now says
the opposite.

### Gates

Run in a **clean worktree**, because the authoring checkout carries another
workstream's uncommitted `tools/` changes that alter enrollment.

- `rombuild.py` **106/106 exact, 100.000000%** of compared bytes, PASS, 0 mismatching; source-built 10,715
- byte-matches under **2004/b56**
- `eligible.py` **bracketed across the header edit** — name sets diff clean, so none of the **245** TUs reaching `Actor.h` was un-matched
- `check_header_offsets` 33 fields, 0 mismatched, span `0xd0`
- duplicate-sources clean; port-refcheck 393/393
- `check_references` → `OK: no new unresolvable references`
- langmode ratchet PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS