### PR TITLE
BeforeBehavior: extern the nine globals it was defining, not declaring

### DIFF
--- a/src/_ZN5Actor14BeforeBehaviorEv.cpp
+++ b/src/_ZN5Actor14BeforeBehaviorEv.cpp
@@ -62,15 +62,24 @@ void MulVec3Mat4x3(Vector3 *v, Matrix4x3 *m, Vector3 *dst);
 int  _ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh(char *thisp, Vector3 *v,
                                                     int radius, u8 *out);
 
-u32       data_0209b458;   /* nearest-player cache, cleared each frame */
-int       data_0209fc68;   /* nonzero forces the actor to think anyway */
-Matrix4x3 data_0209b3ec;   /* world -> camera */
-char      data_0209f43c;   /* the Clipper instance */
-u8        data_0209f274;   /* doubles the far-away threshold when set */
-u8        data_0209f2c4;
-u8        data_0209f20c;
-u8        data_0209f294;
-u32       data_0209b464;   /* flag mask that forces thinking; 0 means "any" */
+/* `extern` on every one of these, and it is load-bearing. Inside
+   `extern "C" { ... }` a variable declaration WITHOUT `extern` is a
+   DEFINITION in C++ -- C's tentative-definition rule does not apply -- so the
+   object would define these nine alongside the ROM's gap object. The same
+   shape in Actor::HorzAngleToFPlayer produced
+   `Multiply-defined: "data_0209b450" ... Previously defined in
+   _dsd_gap@main_40.o` and aborted the link. It did not abort here, which is
+   luck about how mwcc emits each type, not correctness. Function declarations
+   above need no `extern`; only the objects do. */
+extern u32       data_0209b458;   /* nearest-player cache, cleared each frame */
+extern int       data_0209fc68;   /* nonzero forces the actor to think anyway */
+extern Matrix4x3 data_0209b3ec;   /* world -> camera */
+extern char      data_0209f43c;   /* the Clipper instance */
+extern u8        data_0209f274;   /* doubles the far-away threshold when set */
+extern u8        data_0209f2c4;
+extern u8        data_0209f20c;
+extern u8        data_0209f294;
+extern u32       data_0209b464;   /* flag mask that forces thinking; 0 means "any" */
 
 }
 


### PR DESCRIPTION
> Follow-up to **#1275**, which is already merged — hence a new PR rather than a
> push to that branch.

Inside `extern "C" { ... }`, a variable declaration **without** `extern` is a
**definition** in C++ — C's tentative-definition rule does not apply. #1275 wrote
its nine cache globals that way, so the object *defined* all nine alongside the
ROM's gap object instead of importing them.

### Proved at the symbol table, because a byte compare cannot see this

Compiling the file both ways under 2004/b56 and reading `.symtab`:

```
without extern -> DEFINED by this object: 9,  undefined: 0
with    extern -> DEFINED by this object: 0,  undefined: 9
```

The nine: `data_0209b3ec`, `data_0209b458`, `data_0209b464`, `data_0209f20c`,
`data_0209f274`, `data_0209f294`, `data_0209f2c4`, `data_0209f43c`,
`data_0209fc68`. Function declarations in the same block need no `extern` —
only objects do.

### It linked anyway, which is why it merged

That is luck about how mwcc emits each type, not correctness. The **identical
shape** in `Actor::HorzAngleToFPlayer` aborted the link outright:

```
mwldarm.exe: Multiply-defined: "data_0209b450" in _ZN5Actor18HorzAngleToFPlayerEv.o
mwldarm.exe: Previously defined in _dsd_gap@main_40.o
```

Same construct, same file family — one links, one does not. Which side of that
line a given type falls on is not a decision worth making per file.

**The code bytes are untouched.** `BeforeBehavior` still byte-matches under
2004/b56 and the whole build is unchanged. What changes is that the object now
*imports* the ROM's globals rather than offering its own definitions for the
linker to choose between.

### Four more files have the same shape, deliberately not touched here

Kept out so this stays a one-word fix to one file. Happy to sweep them in a
follow-up:

| file | objects |
|---|---|
| `src/_ZN3HUD13InitResourcesEv.cpp` | 6 |
| `src/_ZN6Player13InitResourcesEv.cpp` | 6 |
| `src/_ZN5Sound8PlayLongEjjjRK7Vector3s.cpp` | 1 — `int data_0209b53c[]` |
| `src/func_ov006_020d3ba0.cpp` | 6 — incl. `int data_0209d4b8` |

### Gates

Run in a clean worktree.

- `rombuild.py` **106/106 exact, 100.000000%** of compared bytes, PASS, 0 mismatching; source-built 10,715
- byte-matches under **2004/b56**
- duplicate-sources clean; port-refcheck 393/393
- langmode ratchet PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS