### PR TITLE
Player.h: correct a head note that contradicts the file, and drop 26 non-types

### DIFF
--- a/include/Player.h
+++ b/include/Player.h
@@ -4,12 +4,20 @@
  * improve -- but the OFFSETS and WIDTHS are pinned by the bytes.
  *
  * Player derives from Actor: ActorBase -> ActorDerived -> Actor -> Player.
- * See notes/actor-vtables.md. That is not yet expressed here -- 0x000..0x0cf
- * still duplicates Actor's layout inline rather than inheriting it, and the
- * 31-slot vtable (_ZTV6Player, 0x0210a83c in ov002) is unrepresented. Fields
- * below 0x0d0 are being reconciled with Actor.h/ActorBase.h so that the switch
- * to real inheritance becomes a header change rather than a rewrite of 197
- * files.
+ * See notes/actor-vtables.md. That IS expressed here now: `struct Player :
+ * Actor` inherits 0x000..0x0cf rather than duplicating it, and the 31-slot
+ * vtable (_ZTV6Player, 0x0210a83c in ov002) has seven of its overrides
+ * declared -- the destructor pair plus slots 0, 3, 6, 9, 12 and 18. See the
+ * vtable block above the method list; the key-function rule documented there
+ * is load-bearing, not advisory.
+ *
+ * This header is C++ only. The old #ifndef __cplusplus twin is gone, so a
+ * consumer that still needs the C spelling has none -- 201 files include it.
+ *
+ * NOT yet expressed: the nested type `Player::State`. Both
+ * _ZN6Player7IsStateERNS_5StateE and _ZN6Player11ChangeStateERNS_5StateE take
+ * a `State&`, and every St_*_Init/_Main/_Cleanup handler is reached through
+ * it, so it wants settling before those are migrated.
  *
  * sizeof(Player) is 0x768 -- _ZN6PlayerC3Ev asks operator new for exactly that.
  */
@@ -18,36 +26,14 @@
 #include "types.h"
 #include "Actor.h"
 
-/* fwd */
+/* fwd. Only these three are types. gen_header.py used to emit a `struct X;`
+   for every parameter NAME it could not resolve as well -- 26 of them, `struct
+   a;` through `struct x;` -- which declared nothing any declaration below
+   refers to. Removed; none was used as a type anywhere in src/ or include/. */
 struct Actor;
 struct ActorBase;
 struct Vector3;
-struct a;
-struct a_;
-struct actor_;
-struct amt;
-struct arg_;
-struct b;
-struct b2;
-struct b3;
-struct b_;
-struct c_;
-struct chr_;
-struct count;
-struct d_;
-struct e_;
-struct h;
-struct j;
-struct kind;
-struct msg;
-struct p1;
-struct p2;
-struct p3;
-struct pos;
-struct pos_;
-struct v;
-struct v_;
-struct x;
+
 struct Player : Actor {
     /* 0x000..0x0cf is Actor's, inherited rather than duplicated. It used to be
        written out inline here -- mParam at 0x008 was ActorBase's param1, mPosX


### PR DESCRIPTION
`include/Player.h` opens with a comment that is stale on every one of its
claims, and it is the first thing anyone reads before touching Player — the
next and largest class in the C++ conversion.

| the head note said | the file actually does |
|---|---|
| Player's inheritance from Actor is "not yet expressed here" | `struct Player : Actor` |
| "0x000..0x0cf still duplicates Actor's layout inline" | the inline block is gone; the struct comment says so |
| "the 31-slot vtable … is unrepresented" | seven overrides declared, and the block above the method list documents the slots *and* the key-function rule at length |

A cold reader believes the note and stops there.

Rewritten to describe the file as it is, and to name the one thing that
genuinely is **not** expressed: the nested type `Player::State`. Both
`_ZN6Player7IsStateERNS_5StateE` and `_ZN6Player11ChangeStateERNS_5StateE`
take a `State&`, and every `St_*_Init`/`_Main`/`_Cleanup` handler is reached
through it — so it wants settling before those are migrated, not after.

Also deletes **26 forward declarations**, `struct a;` through `struct x;`,
that `gen_header.py` emitted for parameter *names* it could not resolve as
types. Each appears in this header only as a parameter name (`int
IsAnim(unsigned int a)`, `void BlowAway(short v)`), and none is used as a
type anywhere in `src/` or `include/`, so they declared nothing that any
declaration below refers to. The three real ones — `Actor`, `ActorBase`,
`Vector3` — stay.

## Verification

Comments and unused declarations only, so no codegen change is expected.
Bracketed anyway, because **201 files include this header**.

| gate | result |
|---|---|
| `eligible.py` | 10721 / 11161 before and after — name sets **byte-identical** |
| `rombuild.py -j 16 --no-rom` | **106/106 exact, 100.000000%**; source-built 10,716 |
| `check_header_offsets include/Player.h` | 177 commented fields, 0 mismatched, 0 unparsed, spans 0x768 |
| `port_refcheck.py` | 393 references, 0 stale — all three checks, not the summary line |
| `check_references.py` | 235 unresolved against baseline 235; no new |
| `check_data_definitions.py` | 10971 objects, none define a ROM data symbol |
| `check_duplicate_sources.py` | 11280 stems, none doubled |
| `prepush_attribution.py` | 0 changed, 0 lost (run after committing) |
| langmode ratchet vs banked `chaos-data` | **PASS** — unmigrated unchanged at 1053 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS
