### PR TITLE
Player::State as a real nested type, read off the ROM's pmf call sequence

### DIFF
--- a/include/Player.h
+++ b/include/Player.h
@@ -40,6 +40,52 @@ struct Player : Actor {
        at 0x05c was Actor's, and so on. The names were reconciled first so that
        deleting the block is all that happens here. sizeof(Actor) is 0xd0, so
        Player's own fields start exactly where the base ends. */
+
+    /* One entry of the player state machine. _ZN6Player7IsStateERNS_5StateE
+       and _ZN6Player11ChangeStateERNS_5StateE both take a State&, so the type
+       is nested in Player and is named State; the mangling fixes both facts.
+
+       Each member is a POINTER TO MEMBER FUNCTION, not a plain function
+       pointer. Both callers use the ARM/Itanium pmf sequence verbatim --
+       ChangeState at 0x020e30d4:
+
+           add   r3, r1, #0x10        ; &state->mCleanup
+           ldr   r1, [r3, #4]         ; the adjustment word
+           add   r0, r5, r1, asr #1   ; this + (adj >> 1)
+           ands  r1, r1, #1           ; virtual bit lives in the ADJUSTMENT
+           ldrne r2, [r0]             ; ...virtual: load the vtable
+           ldrne r1, [r3]
+           ldrne r1, [r2, r1]         ; ...and index it by the ptr word
+           ldreq r1, [r3]             ; ...non-virtual: ptr IS the address
+           blx   r1
+
+       so each member occupies two words, {ptr, adj}, and the offsets below
+       are the ptr word. A plain function pointer cannot produce that shape.
+
+       Who calls what, and when:
+         mInit     ChangeState, LAST, on the state being entered (+0x00)
+         mMain     Player::Behavior, per tick, at 0x020e5118       (+0x08)
+         mCleanup  ChangeState, FIRST, on the state being left     (+0x10)
+
+       mCleanup is a veto, not a notification: ChangeState tests its result
+       and returns 0 without transitioning when it is 0. Each of the three is
+       null-checked on its ptr word before the call, so all three are
+       optional -- which is why the symbol table has _Init/_Main/_Cleanup for
+       some states and only _Init/_Main for most.
+
+       The State objects themselves live in ov002's .bss (0x0211013c,
+       0x0211022c, 0x02110364, 0x0211067c, 0x021106ac are the five ChangeState
+       names directly), populated by ov002's static constructors. NOTE: ov006
+       carries _ZN6Player7ST_WAITE and _ZN6Player6ST_OWLE at addresses in the
+       same 0x0211xxxx range. Those are NOT these -- overlays 2 and 6 share
+       that RAM window. relocs.txt tags every ChangeState literal-pool load
+       module:overlay(2), which is what settles it. */
+    struct State {
+        int (Player::*mInit)();       /* 0x00 */
+        int (Player::*mMain)();       /* 0x08 */
+        int (Player::*mCleanup)();    /* 0x10 */
+    };
+
     s32 mEatingPlayer;            /* 0x0d0 */
     u8  pad_0d4[0x8];
     u8  mBodyModels;            /* 0x0dc */
@@ -94,12 +140,16 @@ struct Player : Actor {
     s32 mAttachedActor;            /* 0x364 */
     u8  mTalkActor;            /* 0x368 */
     u8  pad_369[0x7];
-    u8  unk_370;            /* 0x370 */
-    u8  pad_371[0x3];
-    u8  unk_374;            /* 0x374 */
-    u8  pad_375[0x3];
-    u8  unk_378;            /* 0x378 */
-    u8  pad_379[0x3];
+    /* IsState compares this pointer for identity and nothing else:
+       ldr r0,[r0,#0x370] / cmp r0,r1 / moveq #1 / movne #0. */
+    State *mState;            /* 0x370 */
+    /* ChangeState saves the outgoing mState here (ldr ip,[r5,#0x370] then
+       str ip,[r5,#0x374]) immediately before overwriting it. */
+    State *mPrevState;            /* 0x374 */
+    /* Written from the argument on ENTRY to ChangeState, before the cleanup
+       veto can abort the transition -- so it records what was asked for, not
+       what was taken. */
+    State *mRequestedState;            /* 0x378 */
     u8  unk_37c;            /* 0x37c */
     u8  pad_37d[0x3];
     u8  mMeshClsn;            /* 0x380 */
@@ -548,6 +598,14 @@ struct Player : Actor {
     void TurnOffToonShading(unsigned int j);
     void Unk_020ca488();
 };
+
+/* Hold both claims with the compiler rather than a comment. State's 0x18 is
+   the load-bearing one: it is three pointers-to-member at 8 bytes each, and
+   if this toolchain represented a pmf any other way the offsets above --
+   +0x00, +0x08, +0x10, read straight off ChangeState and Behavior -- would
+   not line up and this would refuse to compile. */
+typedef char Player_size_must_be_0x768[sizeof(struct Player) == 0x768 ? 1 : -1];
+typedef char Player_State_size_must_be_0x18[sizeof(Player::State) == 0x18 ? 1 : -1];
 
 /* Offsets seen through this-pointer but far outside the object (sizeof(Player)
  * is 0x768). These are NOT Player fields and must not be typed as such.

--- a/include/Player.h
+++ b/include/Player.h
@@ -4,12 +4,20 @@
  * improve -- but the OFFSETS and WIDTHS are pinned by the bytes.
  *
  * Player derives from Actor: ActorBase -> ActorDerived -> Actor -> Player.
- * See notes/actor-vtables.md. That is not yet expressed here -- 0x000..0x0cf
- * still duplicates Actor's layout inline rather than inheriting it, and the
- * 31-slot vtable (_ZTV6Player, 0x0210a83c in ov002) is unrepresented. Fields
- * below 0x0d0 are being reconciled with Actor.h/ActorBase.h so that the switch
- * to real inheritance becomes a header change rather than a rewrite of 197
- * files.
+ * See notes/actor-vtables.md. That IS expressed here now: `struct Player :
+ * Actor` inherits 0x000..0x0cf rather than duplicating it, and the 31-slot
+ * vtable (_ZTV6Player, 0x0210a83c in ov002) has seven of its overrides
+ * declared -- the destructor pair plus slots 0, 3, 6, 9, 12 and 18. See the
+ * vtable block above the method list; the key-function rule documented there
+ * is load-bearing, not advisory.
+ *
+ * This header is C++ only. The old #ifndef __cplusplus twin is gone, so a
+ * consumer that still needs the C spelling has none -- 201 files include it.
+ *
+ * NOT yet expressed: the nested type `Player::State`. Both
+ * _ZN6Player7IsStateERNS_5StateE and _ZN6Player11ChangeStateERNS_5StateE take
+ * a `State&`, and every St_*_Init/_Main/_Cleanup handler is reached through
+ * it, so it wants settling before those are migrated.
  *
  * sizeof(Player) is 0x768 -- _ZN6PlayerC3Ev asks operator new for exactly that.
  */
@@ -18,36 +26,14 @@
 #include "types.h"
 #include "Actor.h"
 
-/* fwd */
+/* fwd. Only these three are types. gen_header.py used to emit a `struct X;`
+   for every parameter NAME it could not resolve as well -- 26 of them, `struct
+   a;` through `struct x;` -- which declared nothing any declaration below
+   refers to. Removed; none was used as a type anywhere in src/ or include/. */
 struct Actor;
 struct ActorBase;
 struct Vector3;
-struct a;
-struct a_;
-struct actor_;
-struct amt;
-struct arg_;
-struct b;
-struct b2;
-struct b3;
-struct b_;
-struct c_;
-struct chr_;
-struct count;
-struct d_;
-struct e_;
-struct h;
-struct j;
-struct kind;
-struct msg;
-struct p1;
-struct p2;
-struct p3;
-struct pos;
-struct pos_;
-struct v;
-struct v_;
-struct x;
+
 struct Player : Actor {
     /* 0x000..0x0cf is Actor's, inherited rather than duplicated. It used to be
        written out inline here -- mParam at 0x008 was ActorBase's param1, mPosX

--- a/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
+++ b/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
@@ -27,12 +27,12 @@ extern State data_ov002_02110364;
 }
 
 extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *newState) {
-    *(State**)((char *)&self->unk_378) = newState;
+    *(State**)((char *)&self->mRequestedState) = newState;
 
     {
         State *cur;
         int ok;
-        cur = *(State**)((char *)&self->unk_370);
+        cur = *(State**)((char *)&self->mState);
         if (cur == 0) { ok = 1; goto check_ok; }
         if (*(int*)((char*)cur+0x10) == 0) { ok = 1; goto check_ok; }
         ok = (((C3*)((char *)self))->*(cur->onExit))();
@@ -40,7 +40,7 @@ extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *n
         if (!ok) return 0;
     }
 
-    if (*(State**)((char *)&self->unk_370) == &data_ov002_0211022c
+    if (*(State**)((char *)&self->mState) == &data_ov002_0211022c
         && (unsigned short)(self->mStateFlags & 0x400) == 0
         && self->mIsNoControl != 0
         && newState != &data_ov002_0211013c
@@ -66,8 +66,8 @@ extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *n
     self->mParticle2 = self->unk_630;
     self->unk_628 = self->mParticle2;
 
-    *(State**)((char *)&self->unk_374) = *(State**)((char *)&self->unk_370);
-    *(State**)((char *)&self->unk_370) = newState;
+    *(State**)((char *)&self->mPrevState) = *(State**)((char *)&self->mState);
+    *(State**)((char *)&self->mState) = newState;
 
     self->unk_717 = 0;
     self->mIsBodyClsnEnabled = 1;
@@ -111,7 +111,7 @@ extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *n
     }
 
     {
-        State *s = *(State**)((char *)&self->unk_370);
+        State *s = *(State**)((char *)&self->mState);
         if (*(int*)s == 0) return 1;
         return (((C3*)((char *)self))->*(s->onEnter))();
     }

--- a/src/_ZN6Player16St_Climb_CleanupEv.cpp
+++ b/src/_ZN6Player16St_Climb_CleanupEv.cpp
@@ -11,7 +11,7 @@ extern int data_ov002_021106f4[];
 
 int Player::St_Climb_Cleanup()
 {
-  int v = *(int*)((char*)&unk_378);
+  int v = *(int*)((char*)&mRequestedState);
   if(v != (int)data_ov002_021106dc && v != (int)data_ov002_021106f4){
     func_ov002_020caf68(((void *)this));
     *(unsigned short*)((char*)((void *)this)+0x600+0xb6)=8;

--- a/src/_ZN6Player8BehaviorEv.cpp
+++ b/src/_ZN6Player8BehaviorEv.cpp
@@ -7,11 +7,6 @@
 #include "Player.h"
 struct C3;
 typedef int (C3::*PMF)();
-struct State {
-    PMF onEnter;
-    PMF main;
-    PMF onExit;
-};
 struct G_ee90 {
     char pad[0x26c];
     s32 flag26c;
@@ -26,8 +21,8 @@ extern void _ZN12CylinderClsn5ClearEv(void *self);
 extern void _ZN12CylinderClsn6UpdateEv(void *self);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void *self, const Vector3 *v);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 charID, u32 soundID, const Vector3 *pos);
-extern int _ZN6Player11ChangeStateERNS_5StateE(void *self, State *s);
-extern int _ZN6Player7IsStateERNS_5StateE(void *self, State *s);
+extern int _ZN6Player11ChangeStateERNS_5StateE(void *self, Player::State *s);
+extern int _ZN6Player7IsStateERNS_5StateE(void *self, Player::State *s);
 extern void _ZN9Animation7AdvanceEv(void *self);
 extern void func_02035684(void *p, s32 v);
 extern void func_0203568c(void *p, s32 v);
@@ -45,19 +40,19 @@ extern s32 data_0209fc68;
 extern u8 data_020a0e40;
 extern G_ee90 data_0209ee90;
 
-extern State data_ov002_0210ffec;
-extern State data_ov002_021101b4;
-extern State data_ov002_0211031c;
-extern State data_ov002_02110334;
-extern State data_ov002_02110454;
-extern State data_ov002_021104b4;
-extern State data_ov002_021104e4;
-extern State data_ov002_021104fc;
-extern State data_ov002_02110514;
-extern State data_ov002_021105bc;
-extern State data_ov002_0211061c;
-extern State data_ov002_02110634;
-extern State data_ov002_021106f4;
+extern Player::State data_ov002_0210ffec;
+extern Player::State data_ov002_021101b4;
+extern Player::State data_ov002_0211031c;
+extern Player::State data_ov002_02110334;
+extern Player::State data_ov002_02110454;
+extern Player::State data_ov002_021104b4;
+extern Player::State data_ov002_021104e4;
+extern Player::State data_ov002_021104fc;
+extern Player::State data_ov002_02110514;
+extern Player::State data_ov002_021105bc;
+extern Player::State data_ov002_0211061c;
+extern Player::State data_ov002_02110634;
+extern Player::State data_ov002_021106f4;
 }
 
 int Player::Behavior()
@@ -184,9 +179,9 @@ after_player_slot:
     func_ov002_020d8158(((char *)this));
 
     {
-        State *st = *(State **)((char *)&unk_370);
-        if (*(void **)&st->main != 0)
-            (((C3 *)((char *)this))->*(st->main))();
+        State *st = mState;
+        if (*(void **)&st->mMain != 0)
+            (this->*(st->mMain))();
     }
 
     if ((u16)(mStateFlags & 0x80) != 0) {

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -108,7 +108,7 @@ for path in sys.argv[1:]:
     txt = pathlib.Path(path).read_text(errors="replace")
     off, bad, n, skipped, pending = 0, 0, 0, [], []
     trusted = True
-    started = in_comment = unmodelled = False
+    started = in_comment = unmodelled = nested = False
     unknown_base = derived_from = None
     for lineno, line in enumerate(txt.splitlines(), 1):
         if not started:
@@ -134,6 +134,24 @@ for path in sys.argv[1:]:
         if in_comment:
             if "*/" in line:
                 in_comment = False
+            continue
+        # A NESTED type definition -- `struct State { ... };` inside Player -- is a
+        # type, not a field: it occupies no space and advances no offset. Consume it
+        # whole, before the checks below can misread it.
+        #
+        # Two of those checks would, and both fail silently. Its closing `};` matches
+        # the outer-struct terminator on the next line, and a pointer-to-member
+        # declaration (`int (Player::*mInit)();`) matches the member-function pattern
+        # that ends the field list. Either way the walk stopped at the nested type,
+        # and for Player.h that meant "0 commented fields ... struct spans 0xd0" --
+        # the base's size, no fields checked, exit status 0. A header with 177
+        # checkable fields reported exactly like a clean pass.
+        if nested:
+            if re.match(r"^\s*\};", line):
+                nested = False
+            continue
+        if re.match(r"^\s*struct \w+\s*(?::\s*(?:public\s+)?\w+\s*)?\{", line):
+            nested = True
             continue
         if re.match(r"^\s*(#|\}|/\* methods)", line):
             break


### PR DESCRIPTION
> Stacked on #1287. Rebases onto `main` once that merges; the diff here is the one commit.

`include/Player.h` could not describe the player state machine, because the
type it turns on was never declared. `_ZN6Player7IsStateERNS_5StateE` and
`_ZN6Player11ChangeStateERNS_5StateE` both take a `Player::State&`, and all 41
remaining `St_*_Init`/`_Main`/`_Cleanup` handlers are reached through it — so
the type had to be settled **before** any of them could be migrated, not after.

## What the bytes say

`Player::IsState` is five instructions and settles the field: `ldr r0,[r0,#0x370]`
then `cmp r0, r1` — pointer identity, nothing more. (The `moveq #1`/`movne #0`
pair means it genuinely normalises to a truth value, unlike the WithMeshClsn
accessors.)

`Player::ChangeState` calls through the **ARM/Itanium pointer-to-member-function**
sequence verbatim, at `0x020e30d4`:

```
add   r3, r1, #0x10        ; &state->mCleanup
ldr   r1, [r3, #4]         ; adjustment word
add   r0, r5, r1, asr #1   ; this + (adj >> 1)
ands  r1, r1, #1           ; virtual bit lives in the ADJUSTMENT
ldrne r2, [r0]             ; virtual: load the vtable...
ldrne r1, [r3]
ldrne r1, [r2, r1]         ; ...and index it by the ptr word
ldreq r1, [r3]             ; non-virtual: ptr IS the address
blx   r1
```

Only a pmf produces that shape, so each member is `{ptr, adj}` and occupies two
words. `Player::Behavior` runs the identical sequence at `0x020e5118` against
`state+0x08`.

| member | offset | called by |
|---|---|---|
| `mInit` | +0x00 | `ChangeState`, **last**, on the state being entered |
| `mMain` | +0x08 | `Player::Behavior`, per tick |
| `mCleanup` | +0x10 | `ChangeState`, **first**, on the state being left |

`mCleanup` is a **veto**, not a notification — `ChangeState` tests its result and
returns 0 without transitioning. All three are null-checked on their ptr word, so
all three are optional, which is why most states have only `_Init`/`_Main` in the
symbol table.

Three fields fall out, previously `u8 unk_370`/`374`/`378`:

```c
State *mState;           /* 0x370 */
State *mPrevState;       /* 0x374 */  the outgoing mState, saved by ChangeState
State *mRequestedState;  /* 0x378 */  written on ENTRY, before the veto can run
```

**Corroboration, arrived at independently.** The existing decompiled sources
already carry the same shape as shadow structs — `Behavior.cpp` spells it
`struct State { PMF onEnter; PMF main; PMF onExit; }` and `ChangeState.cpp`
`{ PMF onEnter; char pad[8]; PMF onExit; }`. Both agree with the offsets read off
the disassembly.

## Where the State objects live

ov002 `.bss` (base `0x020AD660` + code `0x60380` = `0x0210D9E0`, bss to
`0x021111E0`), populated by ov002's static constructors.

⚠️ ov006 carries `_ZN6Player7ST_WAITE` and `_ZN6Player6ST_OWLE` at addresses in
the same `0x0211xxxx` window, and `0x0211013c + 0x18` lands exactly on `ST_WAIT`.
**Those are not these.** Overlays 2 and 6 share that RAM range — the tree already
diagnoses the same overlap for `St_WallJump_Init`. `relocs.txt` tags every one of
`ChangeState`'s literal-pool loads `module:overlay(2)`, which is what settles it.

## Consequence: nesting shadows

Inside a `Player` method body, unqualified `State` now resolves to `Player::State`
by member lookup, shadowing any file-scope copy. `Behavior.cpp` dereferenced its
own, so its shadow struct is deleted and the pmf call goes through `Player` itself
rather than a fake `struct C3`:

```diff
-   (((C3 *)((char *)this))->*(st->main))();
+   (this->*(st->mMain))();
```

Byte-identical — a pmf call on a polymorphic class emits exactly what the fake
non-polymorphic stand-in did. `build_pin.verify` → `(True, '2004/b56')`.

The other five Player files with a local `struct State` use it as an opaque
`{int a; int b;}` pointer placeholder, never dereferenced. They are untouched and
still exact; retiring them is follow-up, not this slice.

## Gate fix — a silently disabled check

`check_header_offsets.py` could not see past a nested type. Its closing `};`
matched the outer-struct terminator, and a pmf declaration matched the
member-function pattern that ends the field list, so the walk stopped at
`struct State` and reported:

```
include/Player.h: 0 commented fields, 0 mismatched, 0 unparsed, struct spans 0xd0
```

with **exit status 0** — a 177-field header reporting exactly like a clean pass.
Nested definitions are now consumed whole. Verified against a planted regression
on a field *after* the nested struct:

```
MISMATCH include/Player.h:148 mPrevState: comment 0x999, computed 0x374
```

Both sizes are now asserted rather than claimed in prose: `Player` 0x768 and
`Player::State` 0x18 — the latter is itself the check that this toolchain
represents a pmf in two words.

## Verification

| gate | result |
|---|---|
| `rombuild.py -j 16 --no-rom` | **106/106 exact, 100.000000%**; 10,716 source-built, 0 mismatching |
| `build_pin.verify` (Behavior) | `(True, '2004/b56')` |
| `eligible.py` | 10721 / 11161 — name set byte-identical to before |
| `check_header_offsets` | 177 commented fields, 0 mismatched, 0 unparsed, spans 0x768 |
| `check_references.py` | 235 unresolved vs baseline 235; no new |
| `port_refcheck.py` | 393 references, 0 stale (all three checks) |
| `check_data_definitions` / `check_duplicate_sources` | clean |
| `prepush_attribution.py` | 0 changed, 0 lost |
| langmode ratchet vs banked `chaos-data` | **PASS** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS
