### PR TITLE
Retire the last seven Player 'struct State' shadows onto the real type

### DIFF
--- a/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
+++ b/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
@@ -4,43 +4,39 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Player.h"
-struct C3;
-typedef int (C3::*PMF)();
-
-struct State {
-    PMF onEnter;
-    char pad[8];
-    PMF onExit;
-};
-
 extern "C" {
 extern void func_ov002_020d4540(char *p);
 extern void func_ov002_020c9e18(char *c);
 extern void func_0200d81c(void *thiz, int playerID);
 
 extern void *data_0209f318;
-extern State data_ov002_0211022c;
-extern State data_ov002_0211013c;
-extern State data_ov002_0211067c;
-extern State data_ov002_021106ac;
-extern State data_ov002_02110364;
+extern Player::State data_ov002_0211022c;
+extern Player::State data_ov002_0211013c;
+extern Player::State data_ov002_0211067c;
+extern Player::State data_ov002_021106ac;
+extern Player::State data_ov002_02110364;
 }
 
-extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *newState) {
-    *(State**)((char *)&self->mRequestedState) = newState;
+extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, Player::State *newState) {
+    self->mRequestedState = newState;
 
     {
-        State *cur;
+        Player::State *cur;
         int ok;
-        cur = *(State**)((char *)&self->mState);
+        /* The null-checks below stay as raw offset arithmetic on purpose.
+           Spelling either as `*(void**)&cur->mCleanup == 0` costs 4 words:
+           taking the ADDRESS of a pointer-to-member makes mwcc materialise
+           the whole 8-byte pmf first. Reading one to CALL it is free -- the
+           calls below use the named members. Measured both ways. */
+        cur = self->mState;
         if (cur == 0) { ok = 1; goto check_ok; }
         if (*(int*)((char*)cur+0x10) == 0) { ok = 1; goto check_ok; }
-        ok = (((C3*)((char *)self))->*(cur->onExit))();
+        ok = (self->*(cur->mCleanup))();
     check_ok:
         if (!ok) return 0;
     }
 
-    if (*(State**)((char *)&self->mState) == &data_ov002_0211022c
+    if (*(Player::State**)((char *)&self->mState) == &data_ov002_0211022c
         && (unsigned short)(self->mStateFlags & 0x400) == 0
         && self->mIsNoControl != 0
         && newState != &data_ov002_0211013c
@@ -66,8 +62,8 @@ extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *n
     self->mParticle2 = self->unk_630;
     self->unk_628 = self->mParticle2;
 
-    *(State**)((char *)&self->mPrevState) = *(State**)((char *)&self->mState);
-    *(State**)((char *)&self->mState) = newState;
+    *(Player::State**)((char *)&self->mPrevState) = *(Player::State**)((char *)&self->mState);
+    *(Player::State**)((char *)&self->mState) = newState;
 
     self->unk_717 = 0;
     self->mIsBodyClsnEnabled = 1;
@@ -111,8 +107,8 @@ extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *n
     }
 
     {
-        State *s = *(State**)((char *)&self->mState);
+        Player::State *s = *(Player::State**)((char *)&self->mState);
         if (*(int*)s == 0) return 1;
-        return (((C3*)((char *)self))->*(s->onEnter))();
+        return (self->*(s->mInit))();
     }
 }

--- a/src/_ZN6Player12Unk_020c9e5cEh.cpp
+++ b/src/_ZN6Player12Unk_020c9e5cEh.cpp
@@ -2,15 +2,11 @@
 // @symbol _ZN6Player12Unk_020c9e5cEh
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-struct State { int a; int b; };
-extern "C" {
-extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
-}
-extern struct State data_ov002_0211022c;
+extern Player::State data_ov002_0211022c;
 
 int Player::Unk_020c9e5c(unsigned char h)
 {
-  if(!_ZN6Player7IsStateERNS_5StateE(((void *)this), &data_ov002_0211022c)) return 0;
+  if(!IsState(data_ov002_0211022c)) return 0;
   if(*(unsigned char*)((char*)&mNoCtrlKind) != h) return 0;
   switch(h){
   case 0:

--- a/src/_ZN6Player12Unk_020ca150Eh.cpp
+++ b/src/_ZN6Player12Unk_020ca150Eh.cpp
@@ -2,17 +2,15 @@
 // @symbol _ZN6Player12Unk_020ca150Eh
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-struct State { int a; int b; };
 extern "C" {
-extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
-extern int _ZN6Player11ChangeStateERNS_5StateE(void *c, struct State *s);
+extern int _ZN6Player11ChangeStateERNS_5StateE(void *c, Player::State *s);
 }
-extern struct State data_ov002_0211022c;
-extern struct State data_ov002_0211013c;
+extern Player::State data_ov002_0211022c;
+extern Player::State data_ov002_0211013c;
 
 int Player::Unk_020ca150(unsigned char a)
 {
-  if(_ZN6Player7IsStateERNS_5StateE(((void *)this), &data_ov002_0211022c)){
+  if(IsState(data_ov002_0211022c)){
     if(a==4){
       _ZN6Player11ChangeStateERNS_5StateE(((void *)this), &data_ov002_0211013c);
       return 1;

--- a/src/_ZN6Player12Unk_020ca8f8Ev.cpp
+++ b/src/_ZN6Player12Unk_020ca8f8Ev.cpp
@@ -2,16 +2,12 @@
 // @symbol _ZN6Player12Unk_020ca8f8Ev
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-struct State { int a; int b; };
-extern "C" {
-extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
-}
-extern struct State data_ov002_0211064c;
-extern struct State data_ov002_02110664;
+extern Player::State data_ov002_0211064c;
+extern Player::State data_ov002_02110664;
 
 int Player::Unk_020ca8f8()
 {
-  if(_ZN6Player7IsStateERNS_5StateE(((void *)this), &data_ov002_0211064c)) return 1;
-  if(_ZN6Player7IsStateERNS_5StateE(((void *)this), &data_ov002_02110664)) return 2;
+  if(IsState(data_ov002_0211064c)) return 1;
+  if(IsState(data_ov002_02110664)) return 2;
   return 0;
 }

--- a/src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp
+++ b/src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp
@@ -2,16 +2,14 @@
 // @symbol _ZN6Player24TryExitWhiteDoorWithStarEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-struct State { int a; int b; };
 extern "C" {
-extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
 extern int _ZN6Player17SetNoControlStateEhih(void *c, unsigned char a, int b, unsigned char d);
 }
-extern struct State data_ov002_0211022c;
+extern Player::State data_ov002_0211022c;
 
 int Player::TryExitWhiteDoorWithStar()
 {
-  if(_ZN6Player7IsStateERNS_5StateE(((void *)this), &data_ov002_0211022c)){
+  if(IsState(data_ov002_0211022c)){
     if(*(unsigned char*)((char*)&mStateStep)!=0x13 || *(unsigned char*)((char*)&mIsOpeningBigDoor)==0) return 0;
   }
   return _ZN6Player17SetNoControlStateEhih(((void *)this),0x11,-1,1)!=0;

--- a/src/_ZN6Player9IsOnShellEv.cpp
+++ b/src/_ZN6Player9IsOnShellEv.cpp
@@ -2,15 +2,11 @@
 // @symbol _ZN6Player9IsOnShellEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-struct State { int a; int b; };
-extern "C" {
-extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
-}
-extern struct State data_ov002_02110304;
+extern Player::State data_ov002_02110304;
 
 int Player::IsOnShell()
 {
-  if(_ZN6Player7IsStateERNS_5StateE(((void *)this), &data_ov002_02110304)) return 1;
+  if(IsState(data_ov002_02110304)) return 1;
   *(int*)((char*)&mRidingShell)=0;
   return 0;
 }


### PR DESCRIPTION
> Stacked on #1289 → #1288 → #1287. Rebases down onto `main` as those land.

#1288 declared `Player::State` and converted the one file that would not compile
without it. Six more carried their own copy and compiled anyway, so they were
left. This finishes them: **no Player source declares a local `struct State` any
more.**

Five were opaque placeholders — `struct State { int a; int b; };` — used only to
give an address a type: `IsOnShell`, `Unk_020c9e5c`, `Unk_020ca150`,
`Unk_020ca8f8`, `TryExitWhiteDoorWithStar`. Each *also* redeclared `IsState` as
an `extern "C"` symbol. #1289 made `IsState` a real method, so the declaration
and the placeholder both go and the call becomes what it always was:

```diff
-  if(_ZN6Player7IsStateERNS_5StateE(((void *)this), &data_ov002_02110304))
+  if(IsState(data_ov002_02110304))
```

`ChangeState`'s was the real one — `{ PMF onEnter; char pad[8]; PMF onExit; }`
spelled through a fake `struct C3` that existed only to hang a
pointer-to-member off. Both are gone; the calls go through `Player` itself.

## Two measurements worth keeping

**The launder casts on the `State*` fields are _not_ load-bearing.** Both
`self->mRequestedState = newState` and `cur = self->mState` are byte-neutral
against the laundered spelling — individually *and* together. So `ChangeState`
can become a clean real method later; the fields are not what is holding it.

**The pmf null-checks _are_ load-bearing, and this is the useful half.**
Rewriting

```c
if (*(int*)((char*)cur+0x10) == 0)     // matches
if (*(void**)&cur->mCleanup == 0)      // 4 words differ
```

costs 4 words. Taking the **address** of a pointer-to-member makes mwcc
materialise the whole 8-byte pmf before testing it; raw offset arithmetic does
not. **Reading one in order to _call_ it is free** — the calls in this file use
the named members and match exactly.

Isolated by bisecting the four candidate rewrites one at a time (the two direct
field accesses came back clean, which is how the pmf checks were narrowed to).
The surviving offset arithmetic now carries a comment saying why it is
deliberate rather than un-recovered.

## Verification

| gate | result |
|---|---|
| `build_pin.verify` | all six individually — `IsOnShell`, `Unk_020ca8f8`, `Unk_020ca150`, `TryExitWhiteDoorWithStar`, `Unk_020c9e5c`, `ChangeState` → `(True, '2004/b56')` |
| `rombuild.py -j 16 --no-rom` | **106/106 exact, 100.000000%**; 10,716 source-built, 0 mismatching |
| `eligible.py` | 10721 / 11161 |
| `check_header_offsets` | 177 fields, 0 mismatched, spans 0x768 |
| `check_references.py` | 235 unresolved vs baseline 235; no new |
| `port_refcheck.py` | 393 references, 0 stale (all three checks) |
| `check_data_definitions` / `check_duplicate_sources` | clean |
| `prepush_attribution.py` | 0 changed, 0 lost |
| langmode ratchet | **PASS** — `local struct body` **2567 → 2560** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS
