### PR TITLE
Fix cross-overlay resource-table load/release mismatches (KnockDownPlank, Snufit, BowserPuzzleManager)

### DIFF
--- a/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
+++ b/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
@@ -27,7 +27,7 @@ int KnockDownPlank::InitResources()
   _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
   _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
   int j = *(int*)((char*)&mVariant) * 0xc;
-  int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(*(void**)((char*)data_ov034_02114538 + j));
+  int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(*(void**)((char*)data_ov015_02114538 + j));
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((char*)((char*)this)+0x124, k, (char*)((char*)this)+0x2ec, 0x1000, mAngleY, *(void**)((char*)data_ov015_0211453c + j));
   func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
   int tmp[3];

--- a/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
+++ b/src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp
@@ -7,6 +7,7 @@
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
 extern void *data_ov064_0211adc8[];
+extern void *data_ov064_0211c800;
 
 int BowserPuzzleManager::CleanupResources()
 {
@@ -14,6 +15,6 @@ int BowserPuzzleManager::CleanupResources()
     ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     idx = *(unsigned char *)((char *)&unk_337);
     ((SharedFilePtr *)(data_ov064_0211adc8[idx]))->Release();
-    ((SharedFilePtr *)(&data_ov075_0211c800))->Release();
+    ((SharedFilePtr *)(&data_ov064_0211c800))->Release();
     return 1;
 }

--- a/src/_ZN6Snufit13InitResourcesEv.cpp
+++ b/src/_ZN6Snufit13InitResourcesEv.cpp
@@ -9,9 +9,9 @@ typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 typedef struct PMF PMF;
 extern SharedFilePtr data_ov065_0211d618;
-extern SharedFilePtr data_ov075_0211d610;
+extern SharedFilePtr data_ov065_0211d610;
 extern SharedFilePtr data_ov065_0211d600;
-extern SharedFilePtr data_ov075_0211d608;
+extern SharedFilePtr data_ov065_0211d608;
 extern PMF data_ov065_0211d670;
 extern "C" {
 extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
@@ -26,10 +26,10 @@ extern int func_ov065_0211691c(void* c, PMF* p);
 int Snufit::InitResources()
 {
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0x300, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov065_0211d618), 1, -1);
-    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov075_0211d610);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov065_0211d610);
     _ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov065_0211d600);
-    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov075_0211d608);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov065_0211d608);
     unk_0a0 = -0x1e000;
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this)+0x110, (Actor*)((char*)this), 0x38000, 0x7e000, 0x200000, 0x7eff0);
     mAngleY = mPrevAngleY;


### PR DESCRIPTION
## Summary

Three actors' resource load/release calls (InitResources / CleanupResources) referenced a same-window sibling overlay's symbol instead of their own overlay's symbol at the identical address. All pairs are same-window overlapping overlays that can never be co-resident, so the sibling reference could not have been correct.

Part 2 (of 3) of the fix wave for the 81 CONFIRMED-WRONG rows found by the cross-overlay symbol sweep (sample-reviewed 10/10 PASS, see `ovsweep-sample.md`). Propagation is by ADDRESS: each row's own-overlay symbol at the identical address was confirmed directly from `config/arm9/overlays/<ov>/symbols.txt` before editing.

**Scope note:** `_ZN15ChainChompFence13InitResourcesEv.cpp` (originally also in this batch, 3 rows in `full_table.txt`) has been dropped per a coordinator scope correction mid-session — that file is owned end-to-end by another lane with runtime verification and lands through the port gate train instead. Not included here.

| Actor | File | Own overlay | Wrong (sibling) ref | Own symbol at same address |
|---|---|---|---|---|
| KnockDownPlank | `_ZN14KnockDownPlank13InitResourcesEv.cpp` | ov015 | `data_ov034_02114538` | `data_ov015_02114538` |
| Snufit | `_ZN6Snufit13InitResourcesEv.cpp` | ov065 | `data_ov075_0211d610`, `data_ov075_0211d608` | `data_ov065_0211d610`, `data_ov065_0211d608` |
| BowserPuzzleManager | `_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp` | ov064 | `data_ov075_0211c800` | `data_ov064_0211c800` |

No kind mismatches in this batch (all pairs same `bss`/`data(any)` kind on both sides); the fix is address/overlay only.

## Verification (per file, canonical 2004/b56)

```
_ZN14KnockDownPlank13InitResourcesEv      ov015 @0x021120fc size 0x134 -> match.py: MATCH   linkcheck: VERIFIED
_ZN6Snufit13InitResourcesEv               ov065 @0x02116e10 size 0xfc  -> match.py: MATCH   linkcheck: VERIFIED
_ZN19BowserPuzzleManager16CleanupResourcesEv ov064 @0x0211904c size 0x3c -> match.py: MATCH   linkcheck: VERIFIED
```

## Test plan

- [x] `match.py --module <own_ov> --version 2004/b56` MATCH at identical size for all 3 edited functions
- [x] `tools/linkcheck.py --name ... --module <own_ov>` VERIFIED for all 3
- [ ] CI validate (green required before merge; not merging here)