### PR TITLE
Fix data-kind symbols called as functions across overlay boundaries

### DIFF
--- a/src/_ZN13SnowmanBreath6RenderEv.cpp
+++ b/src/_ZN13SnowmanBreath6RenderEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "SnowmanBreath.h"
 extern unsigned char data_0209f2d8[];
+extern "C" void func_ov027_02112424(void*);
 
 int SnowmanBreath::Render()
 {
@@ -15,7 +16,7 @@ int SnowmanBreath::Render()
     int i;
     char* p = ((char*)this) + 0xd4;
     for(i=0;i<0x32;i++){
-      data_ov043_02112424(p);
+      func_ov027_02112424(p);
       p += 0x60;
     }
   }

--- a/src/func_ov006_020cb16c.c
+++ b/src/func_ov006_020cb16c.c
@@ -1,6 +1,6 @@
-extern int data_ov007_020ccd78();
+extern int func_ov006_020ccd78();
 void func_ov006_020cb16c(int *c){
   if(*(int*)((char*)c+0x20) >= -0x120000) return;
   *(int*)((char*)c+0x38)=0;
-  data_ov007_020ccd78();
+  func_ov006_020ccd78();
 }

--- a/src/func_ov027_02112480.cpp
+++ b/src/func_ov027_02112480.cpp
@@ -1,15 +1,15 @@
 //cpp
 extern "C" {
 extern int DecIfAbove0_Byte(void*);
-extern void data_ov053_021123b0(void*);
-extern void data_ov033_0211233c(void*);
+extern void func_ov027_021123b0(void*);
+extern void func_ov027_0211233c(void*);
 extern void func_ov027_02112170(void*);
 extern void _ZN12CylinderClsn5ClearEv(void*);
 extern void _ZN12CylinderClsn6UpdateEv(void*);
 void func_ov027_02112480(char* c){
   if(DecIfAbove0_Byte(c+0x5e)==0) return;
-  data_ov053_021123b0(c);
-  data_ov033_0211233c(c);
+  func_ov027_021123b0(c);
+  func_ov027_0211233c(c);
   func_ov027_02112170(c);
   *(int*)(c+0x30)=*(int*)(c+0x40);
   *(int*)(c+0x34)=*(int*)(c+0x44);

--- a/src/func_ov062_02117acc.c
+++ b/src/func_ov062_02117acc.c
@@ -1,14 +1,14 @@
 extern void func_ov062_02118a00(void *c);
 extern void func_ov062_02118de8(void *c);
-extern void func_ov066_02118cdc(void *c);
+extern void func_ov062_02118cdc(void *c);
 extern void func_ov062_02118b4c(void *c);
-extern void func_ov066_02118a50(void *c);
+extern void func_ov062_02118a50(void *c);
 void func_ov062_02117acc(char *c){
   switch(*(int*)(c+0x38c)){
   case 0: func_ov062_02118a00(c); break;
   case 1: func_ov062_02118de8(c); break;
-  case 2: func_ov066_02118cdc(c); break;
+  case 2: func_ov062_02118cdc(c); break;
   case 3: func_ov062_02118b4c(c); break;
-  case 4: func_ov066_02118a50(c); break;
+  case 4: func_ov062_02118a50(c); break;
   }
 }


### PR DESCRIPTION
## Summary

Four functions called a data-kind symbol as if it were a function -- in every case the symbol was also in a same-window sibling overlay never resident alongside the referring overlay's own copy at the identical address, which is kind:function.

Part 3 (of 3) of the fix wave for the 81 CONFIRMED-WRONG rows found by the cross-overlay symbol sweep (sample-reviewed 10/10 PASS, see `ovsweep-sample.md`; row H in that sample is `func_ov027_02112480.cpp`'s `data_ov053_021123b0` case, reproduced here). Propagation is by ADDRESS: each row's own-overlay symbol at the identical address was confirmed directly from `config/arm9/overlays/<ov>/symbols.txt` before editing.

| File | Own overlay | Wrong (sibling) ref | Own symbol at same address | Kind fix |
|---|---|---|---|---|
| `_ZN13SnowmanBreath6RenderEv.cpp` | ov027 | `data_ov043_02112424` (implicit K&R call, no decl) | `func_ov027_02112424` (function) | yes |
| `func_ov006_020cb16c.c` | ov006 | `data_ov007_020ccd78` (declared as function) | `func_ov006_020ccd78` (function) | yes |
| `func_ov027_02112480.cpp` | ov027 | `data_ov053_021123b0`, `data_ov033_0211233c` (declared as functions) | `func_ov027_021123b0`, `func_ov027_0211233c` (functions) | yes |
| `func_ov062_02117acc.c` | ov062 | `func_ov066_02118cdc`, `func_ov066_02118a50` (already correctly kinded) | `func_ov062_02118cdc`, `func_ov062_02118a50` | no (address only) |

One wrinkle worth flagging: `_ZN13SnowmanBreath6RenderEv.cpp` is a `.cpp` file with no `extern "C"` wrapper. A bare `extern void func_ov027_02112424(void*);` mangles to `_Z19func_ov027_02112424Pv` at compile time, which `tools/linkcheck.py`'s reloc-destination resolver can't match against `symbols.txt` -- the fix uses `extern "C" void func_ov027_02112424(void*);` instead. This was caught by `linkcheck.py` returning `BLIND-1` instead of `VERIFIED` on the first pass; re-checked VERIFIED after the `extern "C"` fix. `match.py` byte output was identical either way (mangling only affects the symbol table, not codegen), so this is a real would-have-been-silent gap in the byte-only gate that link-checking closed.

## Verification (per file, canonical 2004/b56)

```
_ZN13SnowmanBreath6RenderEv  ov027 @0x02112740 size 0x64 -> match.py: MATCH   linkcheck: VERIFIED (BLIND-1 before extern "C" fix)
func_ov006_020cb16c          ov006 @0x020cb16c size 0x3c -> match.py: MATCH   linkcheck: VERIFIED
func_ov027_02112480          ov027 @0x02112480 size 0x64 -> match.py: MATCH   linkcheck: VERIFIED
func_ov062_02117acc          ov062 @0x02117acc size 0x7c -> match.py: MATCH   linkcheck: VERIFIED
```

## Test plan

- [x] `match.py --module <own_ov> --version 2004/b56` MATCH at identical size for all 4 edited functions
- [x] `tools/linkcheck.py --name ... --module <own_ov>` VERIFIED for all 4 (after the extern "C" fix on SnowmanBreath)
- [ ] CI validate (green required before merge; not merging here)