### PR TITLE
Fix cross-overlay symbol references (cluster B: ov003-ov018 func_ files)

### DIFF
--- a/src/func_ov003_020ad6ec.c
+++ b/src/func_ov003_020ad6ec.c
@@ -2,7 +2,7 @@ extern int data_0209b2f4[];
 extern int data_0209b2f8[];
 extern int data_020a0d90[];
 extern void func_ov003_020adcbc(int a, int b, int c);
-extern void func_ov004_020adc74(void* p, int b, int c);
+extern void func_ov003_020adc74(void* p, int b, int c);
 
 void func_ov003_020ad6ec(void)
 {
@@ -24,5 +24,5 @@ void func_ov003_020ad6ec(void)
         func_ov003_020adcbc(j, i, 3);
         j++;
     }
-    func_ov004_020adc74(data_020a0d90, 0, 0);
+    func_ov003_020adc74(data_020a0d90, 0, 0);
 }

--- a/src/func_ov006_020cd12c.c
+++ b/src/func_ov006_020cd12c.c
@@ -3,11 +3,12 @@
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
 extern int data_ov006_0213b2c4[];
+extern void func_ov006_020cd72c(int *c);
 /* recovered: vtable identified */
 /* vtable identified: VT0 = data_ov006_0213b2c4 */
 int *func_ov006_020cd12c(int *t)
 {
-    data_ov007_020cd72c(t);
+    func_ov006_020cd72c(t);
     t[0] = (int)data_ov006_0213b2c4;
     _ZN9ModelAnimC1Ev((char *)t + 0x6c);
     return t;

--- a/src/func_ov006_020cd6f4.c
+++ b/src/func_ov006_020cd6f4.c
@@ -1,7 +1,7 @@
-extern void data_ov007_020cd72c(int *c);
+extern void func_ov006_020cd72c(int *c);
 extern int data_ov006_0213b3e0[];
 int *func_ov006_020cd6f4(int *c){
-  data_ov007_020cd72c(c);
+  func_ov006_020cd72c(c);
   *c=(int)data_ov006_0213b3e0;
   *(short*)((char*)c+0x20)=0;
   return c;

--- a/src/func_ov006_020d5e5c.c
+++ b/src/func_ov006_020d5e5c.c
@@ -1,8 +1,8 @@
 extern int RenderOamMainScreen(int,int,int,int,int);
-extern int data_ov090_021343b0[];
+extern int data_ov006_021343b0[];
 void func_ov006_020d5e5c(int c){
   c += 0x6000;
   if(*(unsigned char*)(c+0x2af)==0) return;
-  RenderOamMainScreen(data_ov090_021343b0[*(unsigned char*)(c+0x2ae)],
+  RenderOamMainScreen(data_ov006_021343b0[*(unsigned char*)(c+0x2ae)],
     *(int*)(c+0x2a0)>>0xc, *(int*)(c+0x2a4)>>0xc, -1, 2);
 }

--- a/src/func_ov006_020e4b78.c
+++ b/src/func_ov006_020e4b78.c
@@ -1,8 +1,8 @@
 extern int func_ov004_020afdd0(int a,int b,int c,int d,int e);
-extern int data_ov098_0213c4f0[];
+extern int data_ov006_0213c4f0[];
 void func_ov006_020e4b78(char*c){
   if(*(unsigned char*)(c+0x55b9)==0) return;
   int x=*(int*)(c+0x5584);
   int y=*(int*)(c+0x5588);
-  func_ov004_020afdd0((int)data_ov098_0213c4f0,(x>>12)-0x20,(y>>12)-8,-1,0);
+  func_ov004_020afdd0((int)data_ov006_0213c4f0,(x>>12)-0x20,(y>>12)-8,-1,0);
 }

--- a/src/func_ov010_02111554.cpp
+++ b/src/func_ov010_02111554.cpp
@@ -7,14 +7,13 @@
 #include "MeshColliderBase.h"
 /* recovered: renamed to Class_Method */
 /* daObjC1_Trap_c::CleanupResources - recovered from vtable slot identity */
-extern "C" char data_ov025_02112d08[];
 extern "C" int func_ov010_02111554(char *self){
   if(((MeshColliderBase *)(self+0x124))->IsEnabled()){
     ((MeshColliderBase *)(self+0x124))->Disable();
   }
   if((*(unsigned int*)(self+8) & 0xff) != 0xff){
-    ((SharedFilePtr *)(data_ov025_02112d08))->Release();
-    ((SharedFilePtr *)(data_ov024_02112d00))->Release();
+    ((SharedFilePtr *)(&data_ov010_02112d08))->Release();
+    ((SharedFilePtr *)(&data_ov010_02112d00))->Release();
   }
   return 1;
 }

--- a/src/func_ov013_0211133c.cpp
+++ b/src/func_ov013_0211133c.cpp
@@ -9,10 +9,11 @@ extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int __sinit_ov045_02112280[];
+extern void func_ov013_02111238(char *t);
 int func_ov013_0211133c(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)__sinit_ov045_02112280);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
-  data_ov054_02111238(c);
+  func_ov013_02111238(c);
   *(short*)(c+0x124)=0x100;
   return 1;
 }

--- a/src/func_ov014_02111af0.c
+++ b/src/func_ov014_02111af0.c
@@ -1,10 +1,10 @@
-extern int func_ov019_02111f54(void*);
+extern int func_ov014_02111f54(void*);
 extern int Math_Function_0203b14c(void*,int,int,int,int);
 extern int DecIfAbove0_Short(void*);
 extern int func_ov014_02111ebc(void*,int);
 extern int _ZN9Animation7AdvanceEv(void*);
 int func_ov014_02111af0(char* c){
-  int r = func_ov019_02111f54(c);
+  int r = func_ov014_02111f54(c);
   if(r) return r;
   if(Math_Function_0203b14c((char*)c+0x5f8, 0x64000, 0x800, 0x10000, 0x800)) goto adv;
   if(DecIfAbove0_Short((char*)c+0x5fc)) goto adv;

--- a/src/func_ov016_02111534.c
+++ b/src/func_ov016_02111534.c
@@ -1,5 +1,5 @@
 typedef short s16;
-extern void func_ov018_02111bf0(void *, void *);
+extern void func_ov016_02111bf0(void *, void *);
 extern int data_ov016_02114d8c[];
 int func_ov016_02111534(char *c)
 {
@@ -11,7 +11,7 @@ int func_ov016_02111534(char *c)
         *(s16 *)(c + 0x8c) = *(s16 *)(c + 0x92);
         *(s16 *)(c + 0x8e) = *(s16 *)(c + 0x94);
         *(s16 *)(c + 0x90) = *(s16 *)(c + 0x96);
-        func_ov018_02111bf0(c, data_ov016_02114d8c);
+        func_ov016_02111bf0(c, data_ov016_02114d8c);
     }
     return 1;
 }

--- a/src/func_ov016_02111758.cpp
+++ b/src/func_ov016_02111758.cpp
@@ -13,6 +13,7 @@ extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(Vector3 *cur, const Vector3
 extern int _ZN9Animation8FinishedEv(void *self);
 extern unsigned char data_0209f220;
 extern struct Matrix4x3 data_020a0e68;
+extern void func_ov016_02111bf0(void *c, void *p);
 
 int func_ov016_02111758(char *c) {
     Vector3 in;
@@ -36,7 +37,7 @@ int func_ov016_02111758(char *c) {
     }
     if (_ZN9Animation8FinishedEv(c + 0x3a0)) {
         *(int*)(c + 0x98) = 0;
-        func_ov018_02111bf0(c, &data_ov016_02114dac);
+        func_ov016_02111bf0(c, &data_ov016_02114dac);
     }
     return 1;
 }

--- a/src/func_ov016_021118b4.cpp
+++ b/src/func_ov016_021118b4.cpp
@@ -14,6 +14,7 @@ extern int Vec3_Dist(const Vector3 *a, const Vector3 *b);
 extern int func_02012694(unsigned int id, void *pos);
 extern struct Matrix4x3 data_020a0e68;
 extern void *data_ov016_02114dbc;
+extern void func_ov016_02111bf0(void *c, void *p);
 
 int func_ov016_021118b4(char *c) {
     Vector3 in;
@@ -30,7 +31,7 @@ int func_ov016_021118b4(char *c) {
     _Z14ApproachLinearR7Vector3RKS_5Fix12IiE((Vector3*)(c + 0x5c), &out, 0x14000);
     if (Vec3_Dist((Vector3*)(c + 0x5c), &out) < 0x14000) {
         func_02012694(0xfa, c + 0x74);
-        func_ov018_02111bf0(c, &data_ov016_02114dbc);
+        func_ov016_02111bf0(c, &data_ov016_02114dbc);
     }
     return 1;
 }

--- a/src/func_ov018_021121dc.cpp
+++ b/src/func_ov018_021121dc.cpp
@@ -1,9 +1,9 @@
 //cpp
 extern "C" {
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
-extern int data_ov027_02113bf0[];
+extern int data_ov018_02113bf0[];
 int func_ov018_021121dc(char* c){
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov027_02113bf0[1], 0, 0x1000, 0);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov018_02113bf0[1], 0, 0x1000, 0);
   *(int*)(c+0x130)=0x1000;
   *(unsigned char*)(c+0x388)=0;
   *(unsigned char*)(c+0x389)=0x3c;

--- a/src/func_ov018_021122ec.c
+++ b/src/func_ov018_021122ec.c
@@ -8,12 +8,13 @@
 /* daObjSm_Lift_c::AfterClsn - recovered from vtable slot identity */
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
 extern int _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
-extern int func_ov030_02113be8[];
+extern int data_ov018_02113be8[];
+extern int data_ov018_02113bf0[];
 int func_ov018_021122ec(char* c){
     struct daObjSm_Lift_c *self = (struct daObjSm_Lift_c *)(void *)c;
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((char*)c+0xd4, data_ov027_02113bf0[1], 0, 0x1000, 0);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((char*)c+0xd4, data_ov018_02113bf0[1], 0, 0x1000, 0);
   self->unk_130=0x1000;
-  _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj((char*)c+0x138, func_ov030_02113be8[1], 0, 0x1000, 0);
+  _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj((char*)c+0x138, data_ov018_02113be8[1], 0, 0x1000, 0);
   self->unk_098=0;
   self->unk_374=0;
   self->unk_37c=0;


### PR DESCRIPTION
## Summary

Continuation of the cross-overlay symbol reference sweep (`ovsweep` /
`full_table.txt` / `ovsweep_final.json`). Same pattern and precedent as
#1294, #1295, and #1296: a function in overlay X calls or references a
symbol whose *name* encodes a different, same-window sibling overlay Y,
at an address where X's own overlay actually has its own distinct
symbol. Since same-window sibling overlays are never co-resident, the
sibling-overlay reference could never have been the intended callee/data
- it's a naming artifact from an earlier automated/semi-automated
symbols.txt pass. Fix: point the C/C++ source at the correct own-overlay
symbol name for that address.

This is cluster B of a 4-lane parallel sweep (62 rows total). All 13
files / 14 sub-fixes below were independently re-verified address by
address against both overlays' `config/arm9/overlays/<ov>/symbols.txt`
before editing - the original worklist was treated as a hypothesis, not
evidence.

## Rows fixed

| # | File | Own overlay | Wrong ref (addr) | Correct own-overlay symbol | Kind | match.py | linkcheck.py |
|---|------|------|------|------|------|------|------|
| 1 | `func_ov003_020ad6ec.c` | ov003 | `func_ov004_020adc74` @ 0x020adc74 | `func_ov003_020adc74` (fn, 0x48) | function/function | MATCH | VERIFIED |
| 2 | `func_ov006_020cd12c.c` | ov006 | `data_ov007_020cd72c` @ 0x020cd72c | `func_ov006_020cd72c` (fn, 0x18) | **data->function** | MATCH | VERIFIED |
| 3 | `func_ov006_020cd6f4.c` | ov006 | `data_ov007_020cd72c` @ 0x020cd72c | `func_ov006_020cd72c` (fn, 0x18) | **data->function** | MATCH | VERIFIED |
| 4 | `func_ov006_020d5e5c.c` | ov006 | `data_ov090_021343b0` @ 0x021343b0 | `data_ov006_021343b0` (data, ~20B) | data/data | MATCH* | VERIFIED |
| 5 | `func_ov006_020e4b78.c` | ov006 | `data_ov098_0213c4f0` @ 0x0213c4f0 | `data_ov006_0213c4f0` (data, ~32B) | data/data | MATCH | VERIFIED |
| 6a | `func_ov010_02111554.cpp` | ov010 | `data_ov025_02112d08` @ 0x02112d08 | `data_ov010_02112d08` (bss, ~8B) | data/data | MATCH | VERIFIED |
| 6b | `func_ov010_02111554.cpp` | ov010 | `data_ov024_02112d00` @ 0x02112d00 | `data_ov010_02112d00` (bss, ~8B) | data/data | MATCH | VERIFIED |
| 7 | `func_ov013_0211133c.cpp` | ov013 | `data_ov054_02111238` @ 0x02111238 | `func_ov013_02111238` (fn, 0x48) | **data->function** | MATCH | VERIFIED |
| 8 | `func_ov014_02111af0.c` | ov014 | `func_ov019_02111f54` @ 0x02111f54 | `func_ov014_02111f54` (fn, 0x64) | function/function | MATCH | VERIFIED |
| 9 | `func_ov016_02111534.c` | ov016 | `func_ov018_02111bf0` @ 0x02111bf0 | `func_ov016_02111bf0` (fn, 0x50) | function/function | MATCH | VERIFIED |
| 10 | `func_ov016_02111758.cpp` | ov016 | `func_ov018_02111bf0` @ 0x02111bf0 | `func_ov016_02111bf0` (fn, 0x50) | function/function | MATCH | VERIFIED |
| 11 | `func_ov016_021118b4.cpp` | ov016 | `func_ov018_02111bf0` @ 0x02111bf0 | `func_ov016_02111bf0` (fn, 0x50) | function/function | MATCH | VERIFIED |
| 12 | `func_ov018_021121dc.cpp` | ov018 | `data_ov027_02113bf0` @ 0x02113bf0 | `data_ov018_02113bf0` (bss, ~8B) | data/data | MATCH | VERIFIED |
| 13a | `func_ov018_021122ec.c` | ov018 | `func_ov030_02113be8` @ 0x02113be8 | `data_ov018_02113be8` (bss, ~8B) | **function->data** | MATCH | VERIFIED |
| 13b | `func_ov018_021122ec.c` | ov018 | `data_ov027_02113bf0` @ 0x02113bf0 | `data_ov018_02113bf0` (bss, ~8B) | data/data | MATCH | VERIFIED |

\* Row 4 (`func_ov006_020d5e5c`): this function is **already non-matching
before this change** for an unrelated reason (candidate size 0x78 vs
target 0x5c, confirmed via `git stash` against the pre-edit tree). The
symbol reference was still objectively wrong (ov090 can never be the
intended overlay for an ov006-owned function) and the fix doesn't
regress anything - `match.py` was `none` before and after, and
`tools/linkcheck.py` reports `VERIFIED` for the corrected reference.
Flagging explicitly rather than silently claiming a byte-identical
match.

## Notable per-file details

- **Rows 2/3/7/13a are kind mismatches**: the wrong sibling-overlay
  symbol was `kind:data` but used as a function call (rows 2, 3, 7), or
  `kind:function` but used as a data pointer (row 13a) - in every case
  the correct own-overlay symbol has the kind that matches actual usage.
- **Row 6** (`func_ov010_02111554.cpp`, `daObjC1_Trap_c::CleanupResources`):
  `data_ov010_02112d00`/`data_ov010_02112d08` are already declared in
  `decl_common.h` as `extern void*` (used by the `InitResources`
  counterpart in `func_ov010_02111654.c` via `&data_ov010_02112d0x`), so
  no new declaration was needed - just switched the two `Release()`
  targets to `&data_ov010_02112d0x` to match that existing pointer-variable
  shape (a bare, non-`&` cast regressed the match; confirmed by testing
  both forms against match.py).
- **Rows 9/10/11** (`func_ov018_02111bf0` -> `func_ov016_02111bf0`):
  `func_ov018_02111bf0` is declared in `decl_common.h` and is a real,
  correctly-used function for ov018's own 3 files (`func_ov018_02111bf0.cpp`
  itself plus two other legitimate ov018 callers) - left untouched there.
  Instead, each of the three ov016 files affected got its own local
  `extern` for the correct `func_ov016_02111bf0` (which already exists
  and is correctly called elsewhere in ov016, e.g.
  `func_ov016_021115c0.c`, `func_ov016_021119ec.c`,
  `_ZN5Unagi13InitResourcesEv.cpp`).
- All `.cpp`-file declarations added here are inside existing
  `extern "C" { ... }` blocks (or a single `extern "C"` decl), avoiding
  the C++ name-mangling trap from the prior rounds. Confirmed via
  `tools/linkcheck.py` VERIFIED (blind: 0) on every row, not just
  byte-match.

## Precedent

- #1294 - cross-overlay vtable-store mislabels
- #1295 - cross-overlay resource-table load/release mismatches
- #1296 - own-overlay kind-mismatch cases (data symbols called as functions)

This PR follows the same fix pattern (own-overlay-address symbol
lookup, no changes to shared headers except where a file-local
declaration was the correct scope) and the same verification bar
(match.py MATCH + linkcheck.py VERIFIED per function, or an explicit
flagged exception like row 4 above).

Not merging - leaving for CI validate + review per repo policy.
