### PR TITLE
Fix cross-overlay symbol references (cluster C: ov020-ov045 func_ files)

### DIFF
--- a/src/func_ov020_02111418.cpp
+++ b/src/func_ov020_02111418.cpp
@@ -1,11 +1,11 @@
 //cpp
 extern "C" {
-extern int data_ov048_021115ac(char *c);
+extern int func_ov020_021115ac(char *c);
 extern void func_ov020_02112110(char *c);
 extern int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *self, void *v, unsigned int a, int fix, unsigned int b, unsigned int d, unsigned int e);
 extern int _ZN6Player6BounceE5Fix12IiE(void *self, int fix);
 int func_ov020_02111418(char *c) {
-    int r = data_ov048_021115ac(c);
+    int r = func_ov020_021115ac(c);
     if (r == 1) { func_ov020_02112110(c); return 1; }
     if (r == 2) {
         int v[3];

--- a/src/func_ov022_0211149c.c
+++ b/src/func_ov022_0211149c.c
@@ -9,7 +9,7 @@ extern void func_020393d4(void *p, void *v);
 extern void func_020393c4(void *p, void *v);
 extern SF3 data_ov022_02113cc8;
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
-extern int data_ov059_02111564[];
+extern void func_ov022_02111564(void*);
 int func_ov022_0211149c(char *c) {
     int f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov022_02113cc8.a);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
@@ -18,7 +18,7 @@ int func_ov022_0211149c(char *c) {
     int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr((void*)data_ov022_02113cc8.b);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x199, *(short*)(c+0x8e), (void*)data_ov022_02113cc8.c);
     func_020393d4(c+0x124, _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    func_020393c4(c+0x124, data_ov059_02111564);
+    func_020393c4(c+0x124, func_ov022_02111564);
     *(short*)(c+0x96) = -0x100;
     if (*(short*)(c+0x90) != 0) *(short*)(c+0x96) = *(short*)(c+0x90);
     return 1;

--- a/src/func_ov022_021126ac.c
+++ b/src/func_ov022_021126ac.c
@@ -5,6 +5,7 @@
 /* recovered: renamed to Class_Method */
 /* daObjFlMaruta_c::AfterClsn - recovered from vtable slot identity */
 extern int _ZN9ActorBase18MarkForDestructionEv(void *c);
+extern int func_ov022_02112654(void *c);
 int func_ov022_021126ac(char *c) {
     int a = *(int*)(c+0x60);
     int b = *(int*)(c+0x118);
@@ -17,6 +18,6 @@ int func_ov022_021126ac(char *c) {
         _ZN9ActorBase18MarkForDestructionEv(c);
         return 1;
     }
-    data_ov025_02112654(c);
+    func_ov022_02112654(c);
     return 1;
 }

--- a/src/func_ov025_02111384.cpp
+++ b/src/func_ov025_02111384.cpp
@@ -9,9 +9,10 @@
 /* daDgr_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
 extern int data_ov025_02113a68[];
+extern int data_ov025_02113a60[];
 int func_ov025_02111384(char* c) {
   ((SharedFilePtr *)(data_ov025_02113a68))->Release();
-  ((SharedFilePtr *)(data_ov036_02113a60))->Release();
+  ((SharedFilePtr *)(data_ov025_02113a60))->Release();
   if (((MeshColliderBase *)(c+0x124))->IsEnabled())
     ((MeshColliderBase *)(c+0x124))->Disable();
   return 1;

--- a/src/func_ov026_02111598.cpp
+++ b/src/func_ov026_02111598.cpp
@@ -14,7 +14,7 @@ extern void _ZN11ShadowModel10InitCuboidEv(void*);
 extern void _ZN7PathPtr6FromIDEj(void*, unsigned int);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void*, void*, V3*, int, int, unsigned int, unsigned int);
 extern int data_0209caa0[];
-extern V3 data_ov032_02113a9c;
+extern void func_ov026_021112a4(char*);
 int func_ov026_02111598(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov026_02113ea0);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
@@ -23,9 +23,9 @@ int func_ov026_02111598(char *c){
   _ZN7PathPtr6FromIDEj(c+0x164, *(unsigned int*)(c+8) & 0xff);
   *(int*)(c+0x16c) = _ZNK7PathPtr8NumNodesEv(c+0x164);
   *(int*)(c+0x180) = 1;
-  V3 g = data_ov032_02113a9c;
+  V3 g = *(V3*)&data_ov026_02113a9c;
   _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c+0x124, c, &g, 0x50000, 0x12c000, 0x80000c, 0);
-  func_ov053_021112a4(c);
+  func_ov026_021112a4(c);
   return 1;
 }
 }

--- a/src/func_ov027_02111d8c.c
+++ b/src/func_ov027_02111d8c.c
@@ -11,7 +11,7 @@ extern void* data_ov027_02113c6c;
 int func_ov027_02111d8c(char* c){
   int i;
   _ZN13SharedFilePtr7ReleaseEv(&data_ov027_02113c7c);
-  for(i=0;i<3;i++) _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112ca4[i]);
+  for(i=0;i<3;i++) _ZN13SharedFilePtr7ReleaseEv(data_ov027_02112ca4[i]);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov027_02113c94);
   if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);

--- a/src/func_ov032_02111d7c.cpp
+++ b/src/func_ov032_02111d7c.cpp
@@ -1,11 +1,11 @@
 //cpp
 extern "C" {
-extern int func_ov047_02111254(void*);
+extern int func_ov032_02111254(void*);
 extern int func_ov032_02111ff4(void*, void*);
 extern int data_ov032_02113aac[];
 extern int data_ov032_02113a8c[];
 int func_ov032_02111d7c(void* c){
-  if(func_ov047_02111254(c)==1){ func_ov032_02111ff4(c, data_ov032_02113aac); return 1; }
+  if(func_ov032_02111254(c)==1){ func_ov032_02111ff4(c, data_ov032_02113aac); return 1; }
   if(*(unsigned short*)((char*)c+0x100)==0){ func_ov032_02111ff4(c, data_ov032_02113a8c); }
   return 1;
 }

--- a/src/func_ov033_02111310.cpp
+++ b/src/func_ov033_02111310.cpp
@@ -13,13 +13,14 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 extern int _ZN5Event6GetBitEj(unsigned int);
+extern int data_ov033_02111bfc[];
 int func_ov033_02111310(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov033_021124c8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   void *k = _ZN12MeshCollider8LoadFileER13SharedFilePtr((void*)data_ov033_021124c0);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov035_02111bfc);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov033_02111bfc);
   return _ZN5Event6GetBitEj(0xe) == 0;
 }
 }

--- a/src/func_ov034_02111588.cpp
+++ b/src/func_ov034_02111588.cpp
@@ -1,7 +1,7 @@
 //cpp
 extern "C" int DecIfAbove0_Byte(void*);
-extern "C" void data_ov052_021125b8(void*, int);
+extern "C" void func_ov034_021125b8(void*, int);
 extern "C" void func_ov034_02111588(char *c){
   if(DecIfAbove0_Byte(c+0x8da)) return;
-  data_ov052_021125b8(c, 0xa);
+  func_ov034_021125b8(c, 0xa);
 }

--- a/src/func_ov034_021119ac.c
+++ b/src/func_ov034_021119ac.c
@@ -1,12 +1,12 @@
 extern int _Z14ApproachLinearRiii(int*,int,int);
 extern int _ZN6Player12GetTalkStateEv(int);
-extern int data_ov052_021125b8();
+extern int func_ov034_021125b8();
 void func_ov034_021119ac(int c){
   _Z14ApproachLinearRiii((int*)((char*)c+0x98),0,0x1000);
   if(_ZN6Player12GetTalkStateEv(*(int*)((char*)c+0x8c8))!=2) return;
   if(*(unsigned char*)((char*)c+0x8db)>1){
-    data_ov052_021125b8(c,3);
+    func_ov034_021125b8(c,3);
     return;
   }
-  data_ov052_021125b8(c,7);
+  func_ov034_021125b8(c,7);
 }

--- a/src/func_ov043_02111320.c
+++ b/src/func_ov043_02111320.c
@@ -14,13 +14,15 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *p, int kcl, void *mtx, int fix, short s, void *clps);
 extern void func_020393d4(void *p, int v);
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
+extern int data_ov043_021125e8[];
+extern int data_ov043_021125e0[];
 int func_ov043_02111320(char *c){
     struct daObjKm1_Ukishima_c *self = (struct daObjKm1_Ukishima_c *)(void *)c;
-  int f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov047_021125e8);
+  int f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov043_021125e8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov047_021125e0);
+  f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov043_021125e0);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     c+0x124, f, c+0x2ec, 0x199, self->unk_08e, data_ov043_02111c00);
   func_020393d4(c+0x124, (int)_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);

--- a/src/func_ov045_021113ec.c
+++ b/src/func_ov045_021113ec.c
@@ -15,6 +15,7 @@ extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10C
 extern void func_020393d4(void *p, int v);
 extern void func_020393c4(void *p, int v);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
+extern void func_ov045_021114c8(void*, int);
 int func_ov045_021113ec(char *c){
     struct daObjKm2_Agaru_c *self = (struct daObjKm2_Agaru_c *)(void *)c;
   int f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov045_02113188);
@@ -25,7 +26,7 @@ int func_ov045_021113ec(char *c){
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     c+0x124, f, c+0x2ec, 0x199, self->unk_08e, data_ov045_021125d0);
   func_020393d4(c+0x124, (int)_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  func_020393c4(c+0x124, (int)data_ov059_021114c8);
+  func_020393c4(c+0x124, (int)func_ov045_021114c8);
   *(short*)(c+0x300+0x24) = 0;
   self->unk_327 = 0;
   self->unk_320 = self->unk_060;


### PR DESCRIPTION
Part of the cross-overlay symbol sweep (ovsweep `full_table.txt` / `ovsweep_final.json`): source files where a function in overlay X calls or references a symbol whose name encodes a different sibling overlay Y, at an address where X's own overlay actually has its own distinct symbol. Same-window sibling overlays overlap in address space and are never co-resident, so the sibling-overlay reference could never have been the intended callee/data.

This is cluster C of the sweep (ov020-ov045 `func_ov*` files). Follows the same fix pattern as the precedent PRs:
- #1294 (vtable-store mislabels: PyramidLift, WorkElevator)
- #1295 (resource-table load/release mismatches: KnockDownPlank, Snufit, BowserPuzzleManager)
- #1296 (own-overlay kind-mismatch cases)

Each row was independently re-verified against both overlays' `config/arm9/overlays/<ov>/symbols.txt` before editing (not trusted from the worklist alone). Where the wrong-overlay symbol was declared in the shared `include/decl_common.h`, that header was left untouched (other files legitimately depend on it); a file-local `extern` was added instead, or the already-correct own-overlay declaration already present in the shared header was reused directly.

| File | Own overlay | Wrong ref (sibling) | Correct own-overlay symbol | Addr | Kind | Verdict |
|---|---|---|---|---|---|---|
| `src/func_ov020_02111418.cpp` | ov020 | `data_ov048_021115ac` | `func_ov020_021115ac` (function, size 0x1a0) | 0x021115ac | mismatch (data->function) | MATCH / VERIFIED |
| `src/func_ov022_0211149c.c` | ov022 | `data_ov059_02111564` | `func_ov022_02111564` (function, size 0x14) | 0x02111564 | mismatch (data->function) | MATCH / VERIFIED |
| `src/func_ov022_021126ac.c` | ov022 | `data_ov025_02112654` | `func_ov022_02112654` (function, size 0x58) | 0x02112654 | mismatch (data->function) | MATCH / VERIFIED |
| `src/func_ov025_02111384.cpp` | ov025 | `data_ov036_02113a60` | `data_ov025_02113a60` (bss) | 0x02113a60 | same kind | MATCH / VERIFIED |
| `src/func_ov026_02111598.cpp` (a) | ov026 | `data_ov032_02113a9c` | `data_ov026_02113a9c` (data, Vector3) | 0x02113a9c | same kind | MATCH / VERIFIED |
| `src/func_ov026_02111598.cpp` (b) | ov026 | `func_ov053_021112a4` | `func_ov026_021112a4` (function, size 0x40) | 0x021112a4 | same kind | MATCH / VERIFIED |
| `src/func_ov027_02111d8c.c` | ov027 | `data_ov035_02112ca4` | `data_ov027_02112ca4` (data) | 0x02112ca4 | same kind | MATCH / VERIFIED |
| `src/func_ov032_02111d7c.cpp` | ov032 | `func_ov047_02111254` | `func_ov032_02111254` (function, size 0xfc) | 0x02111254 | same kind, wrong overlay | MATCH / VERIFIED |
| `src/func_ov033_02111310.cpp` | ov033 | `data_ov035_02111bfc` | `data_ov033_02111bfc` (data, ~32B) | 0x02111bfc | same kind | MATCH / VERIFIED |
| `src/func_ov034_02111588.cpp` | ov034 | `data_ov052_021125b8` | `func_ov034_021125b8` (function, size 0x4c) | 0x021125b8 | mismatch (data->function) | MATCH / VERIFIED |
| `src/func_ov034_021119ac.c` | ov034 | `data_ov052_021125b8` | `func_ov034_021125b8` (function, size 0x4c) | 0x021125b8 | mismatch (data->function) | MATCH / VERIFIED |
| `src/func_ov043_02111320.c` (a) | ov043 | `data_ov047_021125e8` | `data_ov043_021125e8` (bss) | 0x021125e8 | same kind | MATCH / VERIFIED |
| `src/func_ov043_02111320.c` (b) | ov043 | `data_ov047_021125e0` | `data_ov043_021125e0` (bss) | 0x021125e0 | same kind | MATCH / VERIFIED |
| `src/func_ov045_021113ec.c` | ov045 | `data_ov059_021114c8` | `func_ov045_021114c8` (function, size 0x14) | 0x021114c8 | mismatch (data->function) | MATCH / VERIFIED |

12 files, 14 sub-fixes, all byte-identical after the fix (`tools/match.py --version 2004/b56` MATCH) and all link-clean (`tools/linkcheck.py` VERIFIED, 0 blind relocs). No rows were refuted or skipped.

Not merging — leaving for CI validate + main-brain merge.
