### PR TITLE
Fix cross-overlay symbol references (cluster A: named-class methods)

### DIFF
--- a/src/_ZN10HootTheOwl8BehaviorEv.cpp
+++ b/src/_ZN10HootTheOwl8BehaviorEv.cpp
@@ -18,6 +18,7 @@ extern void _ZN12CylinderClsn6UpdateEv(void*);
 
 extern char data_ov094_02136b40[];
 extern char data_ov094_02136b60[];
+extern void func_ov094_021357a4(void*);
 }
 
 int HootTheOwl::Behavior()
@@ -66,7 +67,7 @@ int HootTheOwl::Behavior()
     unk_090 = unk_096;
     func_ov094_021361d8(((char *)this));
     if (*(char**)((char *)&mCurrentState) == data_ov094_02136b60 && unk_3d4 == 2) {
-        func_ov096_021357a4(((char *)this));
+        func_ov094_021357a4(((char *)this));
     }
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsnWithPos);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsnWithPos);

--- a/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
+++ b/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
@@ -4,14 +4,14 @@
 #include "SlidingIce.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-extern char func_ov030_02113be8[];
+extern char data_ov027_02113be8[];
 extern char data_ov027_02113be0[];
 
 int SlidingIce::CleanupResources()
 {
   unsigned char ok = (mActorID==0x5d);
   if(ok){ ((MeshColliderBase *)((char *)&mMeshCollider))->Disable(); }
-  ((SharedFilePtr *)(func_ov030_02113be8))->Release();
+  ((SharedFilePtr *)(data_ov027_02113be8))->Release();
   ((SharedFilePtr *)(data_ov027_02113be0))->Release();
   return 1;
 }

--- a/src/_ZN12FallBlockLll8BehaviorEv.cpp
+++ b/src/_ZN12FallBlockLll8BehaviorEv.cpp
@@ -5,11 +5,11 @@
 extern "C" {
 void func_020393a4(void* p, int v);
 unsigned char func_ov080_0212714c(void* a, void* b);
-extern int data_ov035_02112c98[];
+extern int data_ov022_02112c98[];
 }
 
 int FallBlockLll::Behavior()
 {
   func_020393a4(((char*)this)+0x124, 0x500000);
-  return func_ov080_0212714c(((char*)this), data_ov035_02112c98) & 0xff;
+  return func_ov080_0212714c(((char*)this), data_ov022_02112c98) & 0xff;
 }

--- a/src/_ZN13PeachPainting13InitResourcesEv.cpp
+++ b/src/_ZN13PeachPainting13InitResourcesEv.cpp
@@ -7,6 +7,7 @@
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int a, int b);
+extern void func_ov010_02111e84(void*);
 }
 
 int PeachPainting::InitResources()
@@ -14,6 +15,6 @@ int PeachPainting::InitResources()
     void *file = _ZN5Model8LoadFileER13SharedFilePtr((void*)RollingRock_Spawn);
     _ZN9ModelBase7SetFileEP8BMD_Fileii((char*)((void *)this) + 0xd4, file, 1, -1);
     *(unsigned char*)((char*)&mOpacity) = 0xff;
-    data_ov052_02111e84(((void *)this));
+    func_ov010_02111e84(((void *)this));
     return 1;
 }

--- a/src/_ZN13SnowmanBreathD0Ev.cpp
+++ b/src/_ZN13SnowmanBreathD0Ev.cpp
@@ -9,9 +9,10 @@ extern int data_020a0eac[];
 void __destroy_arr(void*, int, int, void*);
 void _ZN5ActorD2Ev(void*);
 void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
+void func_ov027_02112158(void*);
 void* _ZN13SnowmanBreathD0Ev(char* c){
   *(int*)c = (int)RotatingPlatformRr_SpawnInfo;
-  __destroy_arr(c+0xd4, 0x32, 0x60, (void*)data_ov056_02112158);
+  __destroy_arr(c+0xd4, 0x32, 0x60, (void*)func_ov027_02112158);
   _ZN5ActorD2Ev(c);
   _ZN6Memory10DeallocateEPvP4Heap(c, (void*)data_020a0eac[0]);
   return c;

--- a/src/_ZN13SnowmanBreathD1Ev.cpp
+++ b/src/_ZN13SnowmanBreathD1Ev.cpp
@@ -7,9 +7,10 @@
 #include "SnowmanBreath.h"
 extern "C" {
 extern int __destroy_arr(void*, int, int, void*);
+extern void func_ov027_02112158(void*);
 int _ZN13SnowmanBreathD1Ev(char* c){
   *(int**)c = RotatingPlatformRr_SpawnInfo;
-  __destroy_arr(c+0xd4, 0x32, 0x60, data_ov056_02112158);
+  __destroy_arr(c+0xd4, 0x32, 0x60, (void*)func_ov027_02112158);
   _ZN5ActorD2Ev(c);
   return (int)c;
 }

--- a/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
@@ -18,7 +18,7 @@ int RotatingCogSmall::CleanupResources()
     if(((MeshColliderBase *)((char *)&mMovingMeshCollider))->IsEnabled())
       ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Disable();
     ((SharedFilePtr *)(data_ov035_02112c78))->Release();
-    ((SharedFilePtr *)(data_ov056_02112c68))->Release();
+    ((SharedFilePtr *)(data_ov035_02112c68))->Release();
   } else {
     int on = (unk_00c==0x79);
     if(on)

--- a/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
@@ -9,13 +9,14 @@ extern "C" {
 void UnloadBlueCoinModel(void*);
 extern int data_ov084_02130dfc;
 extern int data_ov002_0210da38;
+extern void *data_ov084_021302f4[];
 }
 
 int FirePiranhaPlantBig::CleanupResources()
 {
   ((SharedFilePtr *)(&data_ov084_02130dfc))->Release();
   for (int i = 0; i < 6; i++) {
-    ((SharedFilePtr *)(data_ov085_021302f4[i]))->Release();
+    ((SharedFilePtr *)(data_ov084_021302f4[i]))->Release();
   }
   ((SharedFilePtr *)(&data_ov002_0210da38))->Release();
   UnloadBlueCoinModel(((void *)this));

--- a/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
@@ -19,7 +19,7 @@ int ClockPaintingHandShort::InitResources()
         *(unsigned char*)((char*)&mHandIndex) = 1;
     {
         unsigned char i = *(unsigned char*)((char*)&mHandIndex);
-        int file = _ZN5Model8LoadFileER13SharedFilePtr(data_ov051_021116b0[i]);
+        int file = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov013_021116b0[i]);
         _ZN9ModelBase7SetFileEP8BMD_Fileii((char*)((void*)this) + 0xd4, file, 1, -1);
     }
     func_ov013_02111430((char*)((void*)this));

--- a/src/_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp
+++ b/src/_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp
@@ -5,7 +5,7 @@
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
-extern void func_ov044_02111214(char*);
+extern void func_ov031_02111214(char*);
 extern int* data_ov031_02111424[];
 }
 
@@ -21,6 +21,6 @@ int SlideDecorationSilverStar::InitResources()
   unsigned char idx = mVariant;
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov031_02111424[idx]);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this)+0xd4, f, 1, -1);
-  func_ov044_02111214(((char *)this));
+  func_ov031_02111214(((char *)this));
   return 1;
 }

--- a/src/_ZN5Cloud13InitResourcesEv.cpp
+++ b/src/_ZN5Cloud13InitResourcesEv.cpp
@@ -6,13 +6,14 @@
 #include "Cloud.h"
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
-extern "C" void func_ov044_02111214(char *t);
+extern "C" void func_ov039_02111214(char *t);
+extern "C" int data_ov039_021118e0;
 
 int Cloud::InitResources()
 {
   void *f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov039_021118e4);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this)+0xd4, f, 1, 2);
-  func_ov044_02111214(((char *)this));
-  data_ov041_021118e0++;
+  func_ov039_02111214(((char *)this));
+  data_ov039_021118e0++;
   return 1;
 }

--- a/src/_ZN6Player16St_BurnLava_InitEv.cpp
+++ b/src/_ZN6Player16St_BurnLava_InitEv.cpp
@@ -8,6 +8,7 @@ extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int func_ov002_020d91e0(void*,int,int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
+extern int func_ov002_020e3078(void*,int*);
 }
 
 int Player::St_BurnLava_Init()
@@ -22,7 +23,7 @@ int Player::St_BurnLava_Init()
   mVertSpeed=0x64000;
   mStateWork=0;
   mStateStep=0;
-  if(func_ov006_020e3078(((char*)this),data_ov002_021100f4)==0){
+  if(func_ov002_020e3078(((char*)this),data_ov002_021100f4)==0){
     mStateArg=0;
   }
   func_ov002_020d91e0(((char*)this),0x300,1);

--- a/src/_ZN6Player17St_HurtWater_MainEv.cpp
+++ b/src/_ZN6Player17St_HurtWater_MainEv.cpp
@@ -9,7 +9,7 @@ extern int func_ov002_020ceaf4(void*);
 extern int _ZN6Player12FinishedAnimEv(void*);
 extern int _ZN6Player9GetHealthEv(void*);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
-extern void func_ov007_020c5dec(void*,int);
+extern void func_ov002_020c5dec(void*,int);
 extern int func_ov002_020ceb7c(void*);
 extern int Player_AdvanceAnims(void*);
 extern int data_ov002_0211067c[];
@@ -37,7 +37,7 @@ int Player::St_HurtWater_Main()
       if(mHurtDamage)
         mInvincibleTimer=0x24;
     }else{
-      func_ov007_020c5dec(((char*)this),8);
+      func_ov002_020c5dec(((char*)this),8);
       return 1;
     }
   }

--- a/src/_ZN6Player21St_WaitQuicksand_MainEv.cpp
+++ b/src/_ZN6Player21St_WaitQuicksand_MainEv.cpp
@@ -6,7 +6,7 @@ extern "C" {
 extern int _ZN6Player7ST_WAITE;
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-extern int func_ov007_020c5dec(void*,int);
+extern int func_ov002_020c5dec(void*,int);
 extern int func_ov002_020d22ec(void*,int);
 extern int Player_AdvanceAnims(void*);
 }
@@ -22,7 +22,7 @@ int Player::St_WaitQuicksand_Main()
     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x82,0,0x1000,0);
   }
   if(mSinkDepth>=0xb4000){
-    if(func_ov007_020c5dec(((char*)this),3)) return 1;
+    if(func_ov002_020c5dec(((char*)this),3)) return 1;
   }
   func_ov002_020d22ec(((char*)this),0);
   Player_AdvanceAnims(((char*)this));

--- a/src/_ZN7SkiLift13InitResourcesEv.cpp
+++ b/src/_ZN7SkiLift13InitResourcesEv.cpp
@@ -18,22 +18,24 @@ extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, void 
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
 extern void func_ov018_02111d28(char *c, int r1);
 extern void _ZN13RaycastGroundD1Ev(void *self);
+extern int data_ov018_02113c00[];
+extern int data_ov018_02112c04[];
 }
 
 int SkiLift::InitResources()
 {
-    void *m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_02113c00);
+    void *m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov018_02113c00);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this)+0xd4, m, 1, 1);
     for (int i = 0; i < 2; i++)
         _ZN9Animation8LoadFileER13SharedFilePtr((void*)data_ov018_02112c0c[i]);
     for (int i = 0; i < 2; i++) {
-        void *t = (void*)data_ov056_02112c04[i];
+        void *t = (void*)data_ov018_02112c04[i];
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(t);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov036_02113c00[1], (void*)((int*)t)[1]);
+        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov018_02113c00[1], (void*)((int*)t)[1]);
     }
     if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0) return 0;
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this)+0x174, ((char *)this), 0x104000, 0x12c000, 0x4800004, 0x900000);
-    func_ov022_021123d0((int*)((char *)this), 0);
+    func_ov018_021123d0((char *)this, 0);
     unk_09c = -0x2000;
     unk_0a0 = -0x3c000;
     mScaleX = 0x1000;

--- a/src/_ZN8Squasher13InitResourcesEv.cpp
+++ b/src/_ZN8Squasher13InitResourcesEv.cpp
@@ -10,7 +10,6 @@ extern "C" {
 int _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* m, int bmd, int a, int b);
 void _ZN11ShadowModel10InitCuboidEv(void* s);
-void func_ov026_02111308(void* d);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
 int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* f);
 void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* mc, int kcl, struct Matrix4x3* mtx, int scale, short s, void* clps);
@@ -23,7 +22,7 @@ int Squasher::InitResources()
   int bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov023_02112088);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, bmd, 1, -1);
   _ZN11ShadowModel10InitCuboidEv((char*)&mShadowModel);
-  func_ov026_02111308(((char*)this));
+  func_ov023_02111308(((char*)this));
   _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
   int kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&_ZN32FloatOnWaterPlatformWdwRectangleD1Ev);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, kcl, (struct Matrix4x3*)((char*)&unk_2ec), 0x1000, mAngleY, &data_ov064_0211ba4c);


### PR DESCRIPTION
## Summary

Part of the cross-overlay symbol sweep (`ovsweep full_table.txt` / `ovsweep_final.json`). Same pattern as the merged precedent PRs #1294 and #1295, and the kind-mismatch precedent #1296: a function in overlay X referenced a symbol whose name encodes a different same-window sibling overlay Y, at an address where X's own overlay actually has its own distinct symbol. Same-window sibling overlays are never co-resident, so the sibling reference could never have been the intended callee/data. Fixed by replacing the wrong reference with the correct own-overlay symbol at the same address, in source only (no symbols.txt changes).

Every row below was independently re-verified against both overlays' `config/arm9/overlays/<ov>/symbols.txt` before editing. All fixes are byte-identical: `match.py` (2004/b56) reports MATCH and `tools/linkcheck.py` reports VERIFIED for every affected function.

## Fixes (16 files, 19 symbol references)

| File | Function (own overlay) | Wrong ref (sibling) | Correct own-overlay symbol | Kind mismatch? |
|---|---|---|---|---|
| `_ZN10HootTheOwl8BehaviorEv.cpp` | ov094 | `func_ov096_021357a4` | `func_ov094_021357a4` (function, 0x110) | no |
| `_ZN10SlidingIce16CleanupResourcesEv.cpp` | ov027 | `func_ov030_02113be8` | `data_ov027_02113be8` (bss) | yes |
| `_ZN12FallBlockLll8BehaviorEv.cpp` | ov022 | `data_ov035_02112c98` | `data_ov022_02112c98` (data) | no |
| `_ZN13PeachPainting13InitResourcesEv.cpp` | ov010 | `data_ov052_02111e84` | `func_ov010_02111e84` (function, 0x40) | yes |
| `_ZN13SnowmanBreathD0Ev.cpp` | ov027 | `data_ov056_02112158` | `func_ov027_02112158` (function, 0x18) | yes |
| `_ZN13SnowmanBreathD1Ev.cpp` | ov027 | `data_ov056_02112158` | `func_ov027_02112158` (function, 0x18) | yes |
| `_ZN16RotatingCogSmall16CleanupResourcesEv.cpp` | ov035 | `data_ov056_02112c68` | `data_ov035_02112c68` (bss) | no |
| `_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp` | ov084 | `data_ov085_021302f4` | `data_ov084_021302f4` (data) | no |
| `_ZN22ClockPaintingHandShort13InitResourcesEv.cpp` | ov013 | `data_ov051_021116b0` | `data_ov013_021116b0` (data) | no |
| `_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp` | ov031 | `func_ov044_02111214` | `func_ov031_02111214` (function, 0x40) | no |
| `_ZN5Cloud13InitResourcesEv.cpp` | ov039 | `func_ov044_02111214` / `data_ov041_021118e0` | `func_ov039_02111214` (function, 0x40) / `data_ov039_021118e0` (bss) | no |
| `_ZN6Player16St_BurnLava_InitEv.cpp` | ov002 | `func_ov006_020e3078` | `func_ov002_020e3078` (function, 0x14) | no |
| `_ZN6Player17St_HurtWater_MainEv.cpp` | ov002 | `func_ov007_020c5dec` | `func_ov002_020c5dec` (function, 0x48) | no |
| `_ZN6Player21St_WaitQuicksand_MainEv.cpp` | ov002 | `func_ov007_020c5dec` | `func_ov002_020c5dec` (function, 0x48) | no |
| `_ZN7SkiLift13InitResourcesEv.cpp` | ov018 | `data_ov036_02113c00` / `data_ov056_02112c04` / `func_ov022_021123d0` | `data_ov018_02113c00` (bss) / `data_ov018_02112c04` (data) / `func_ov018_021123d0` (function, 0x1c) | no |
| `_ZN8Squasher13InitResourcesEv.cpp` | ov023 | `func_ov026_02111308` | `func_ov023_02111308` (function, 0x48) | no |

## Notes on shared-header cases

Several wrong references originated from `include/decl_common.h` (auto-generated, shared across many files). Per the standing rule, the shared header was never edited -- each affected file instead got its own file-local `extern "C"` declaration for the correct symbol (or, where the correct symbol was *already* declared in `decl_common.h` with a compatible signature, the call site was simply repointed at that existing declaration with no new decl added, to avoid an "identifier redeclared" / "illegal function overloading" compile error from a conflicting duplicate).

## Test plan

- [x] Every address pairing re-verified against both overlays' `symbols.txt` independently before editing
- [x] `tools/match.py --version 2004/b56` reports MATCH for all 16 functions after edits
- [x] `tools/linkcheck.py` reports VERIFIED (0 blind) for all 16 functions after edits
- [x] No REFUTED-BY-BYTES or SKIPPED rows in this batch