### PR TITLE
Enemy: five methods as real methods, a pointer-to-member table, and both surface normals recovered from padding

### DIFF
--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -58,6 +58,7 @@ struct Enemy {
 #ifdef __cplusplus
     /* methods */
     int AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_);
+    int UpdateDeath(WithMeshClsn & clsn_);
     int SpawnParticlesIfHitOtherObj(CylinderClsn & clsn_);
     int UpdateKillByInvincibleChar(WithMeshClsn & ww_, ModelAnim & mm_, unsigned int flags);
     void KillByInvincibleChar(const Vector3_16 & a1_, Player & a2_);

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -39,13 +39,20 @@ struct Enemy {
        evidenced, so the rest stays padding. */
     s32 unk_0ac;            /* 0x0ac */
     u8  pad_0b0[0x24];
-    s32 unk_0d4;            /* 0x0d4 */
-    s32 unk_0d8;            /* 0x0d8 */
-    s32 unk_0dc;            /* 0x0dc */
-    u8  unk_0e0;            /* 0x0e0 */
-    u8  pad_0e1[0x7];
-    u8  unk_0e8;            /* 0x0e8 */
-    u8  pad_0e9[0x19];
+    /* Two surface normals, written a Vector3 at a time by
+       SurfaceInfo::CopyNormalTo in Enemy::UpdateWMClsn -- the floor result's
+       normal into 0x0d4, the wall result's into 0x0e0. The wall triple was
+       declared u8 + pad + u8, which made any natural access an ldrb;
+       Enemy::AngleAwayFromWallOrCliff reads X and Z of it as four-byte values
+       and hands them to Actor::ReflectAngle, which is what a wall normal is
+       for. Same shape and same names as Player.h's mFloorNormalX/Y/Z. */
+    s32 mFloorNormalX;            /* 0x0d4 */
+    s32 mFloorNormalY;            /* 0x0d8 */
+    s32 mFloorNormalZ;            /* 0x0dc */
+    s32 mWallNormalX;            /* 0x0e0 */
+    s32 mWallNormalY;            /* 0x0e4 */
+    s32 mWallNormalZ;            /* 0x0e8 */
+    u8  pad_0ec[0x16];
     s16 unk_102;            /* 0x102 */
     u8  pad_104[0x2];
     u8  unk_106;            /* 0x106 */
@@ -59,6 +66,7 @@ struct Enemy {
     /* methods */
     int AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_);
     int UpdateDeath(WithMeshClsn & clsn_);
+    void UpdateWMClsn(WithMeshClsn & clsn_, unsigned int sel);
     int SpawnParticlesIfHitOtherObj(CylinderClsn & clsn_);
     int UpdateKillByInvincibleChar(WithMeshClsn & ww_, ModelAnim & mm_, unsigned int flags);
     void KillByInvincibleChar(const Vector3_16 & a1_, Player & a2_);

--- a/src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp
+++ b/src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp
@@ -1,23 +1,34 @@
 //cpp
-#include "types.h"
-struct WithMeshClsn;
-struct Enemy;
-typedef int (Enemy::*PMF)(WithMeshClsn&);
-extern PMF data_ov002_0210dbc0[];
+// @symbol _ZN5Enemy11UpdateDeathER12WithMeshClsn
+/* recovered: named members + shared header, real C++ method
+ *
+ * Runs one frame of the death animation. unk_10c selects which death handler
+ * from a table of POINTERS TO MEMBER FUNCTION -- the third such table found in
+ * this tree, after Player::State and Player's level-entry steps -- then the
+ * position and mesh collision are updated regardless.
+ *
+ * The table was declared through a fake `struct Enemy { char pad[0x200]; }`
+ * that existed only to hang the pmf type off; the real class serves now.
+ */
+#include "Enemy.h"
+
+extern int (Enemy::*data_ov002_0210dbc0[])(WithMeshClsn &);
+
 extern "C" {
 extern void DecIfAbove0_Short(short *p);
-extern int _ZN5Actor9UpdatePosEP12CylinderClsn(Enemy *thiz, void *clsn);
-extern int _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Enemy *thiz, WithMeshClsn *clsn, u32 sel);
+extern int _ZN5Actor9UpdatePosEP12CylinderClsn(void *thiz, void *clsn);
+extern int _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *thiz, WithMeshClsn *clsn, u32 sel);
 }
-struct Enemy { char pad[0x200]; };
-extern "C" int _ZN5Enemy11UpdateDeathER12WithMeshClsn(Enemy *thiz, WithMeshClsn *clsn)
+
+int Enemy::UpdateDeath(WithMeshClsn & clsn_)
 {
+    WithMeshClsn *clsn = &clsn_;
     int ret;
-    if (*(int*)((char*)thiz+0x10c) == 0)
+    if (unk_10c == 0)
         return 0;
-    DecIfAbove0_Short((short*)((char*)thiz+0x102));
-    ret = (thiz->*data_ov002_0210dbc0[*(int*)((char*)thiz+0x10c)-1])(*clsn);
-    _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, 0);
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, clsn, 0);
+    DecIfAbove0_Short(&unk_102);
+    ret = (this->*data_ov002_0210dbc0[unk_10c - 1])(*clsn);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(this, 0);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(this, clsn, 0);
     return ret;
 }

--- a/src/_ZN5Enemy12UpdateWMClsnER12WithMeshClsnj.cpp
+++ b/src/_ZN5Enemy12UpdateWMClsnER12WithMeshClsnj.cpp
@@ -1,29 +1,37 @@
 //cpp
-extern "C" {
-typedef int s32;
-typedef unsigned int u32;
+// @symbol _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj
+/* recovered: named members + shared header, real C++ method
+ *
+ * Runs the mesh collision (sel picks which of four update flavours), then
+ * caches whichever surface normals came back: the floor result's into
+ * mFloorNormal*, the wall result's into mWallNormal*. Those two
+ * CopyNormalTo calls are what evidence both triples as Vector3s.
+ *
+ * On a floor that does not limit movement, the vertical velocity is
+ * re-derived so the motion stays in the floor plane -- the dot product of the
+ * horizontal normal and velocity components, divided by the normal's Y.
+ */
+#include "Enemy.h"
 
-struct WithMeshClsn;
-struct CylinderClsn;
-struct Vector3 { s32 x, y, z; };
 struct SurfaceInfo { s32 pad; };
 
-extern void func_020383f0(struct WithMeshClsn *);
-extern void WithMeshClsn_UpdateDiscreteNoLava_veneer(struct WithMeshClsn *);
-extern void func_02038414(struct WithMeshClsn *);
-extern void WithMeshClsn_UpdateContinuous_Veneer(struct WithMeshClsn *);
-extern int _ZNK12WithMeshClsn10IsOnGroundEv(struct WithMeshClsn *);
-extern struct SurfaceInfo *_ZNK12WithMeshClsn14GetFloorResultEv(struct WithMeshClsn *);
-extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(struct SurfaceInfo *, struct Vector3 *);
-extern int _ZNK12WithMeshClsn13GetLimMovFlagEv(struct WithMeshClsn *);
+extern "C" {
+extern void func_020383f0(WithMeshClsn *);
+extern void WithMeshClsn_UpdateDiscreteNoLava_veneer(WithMeshClsn *);
+extern void func_02038414(WithMeshClsn *);
+extern void WithMeshClsn_UpdateContinuous_Veneer(WithMeshClsn *);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(WithMeshClsn *);
+extern struct SurfaceInfo *_ZNK12WithMeshClsn14GetFloorResultEv(WithMeshClsn *);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(struct SurfaceInfo *, Vector3 *);
+extern int _ZNK12WithMeshClsn13GetLimMovFlagEv(WithMeshClsn *);
 extern int _ZN4cstd4fdivEii(int, int);
-extern int _ZNK12WithMeshClsn8IsOnWallEv(struct WithMeshClsn *);
-extern struct SurfaceInfo *_ZNK12WithMeshClsn13GetWallResultEv(struct WithMeshClsn *);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(WithMeshClsn *);
+extern struct SurfaceInfo *_ZNK12WithMeshClsn13GetWallResultEv(WithMeshClsn *);
+}
 
-struct Enemy { char pad[0x200]; };
-
-void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(struct Enemy *thiz, struct WithMeshClsn *clsn, u32 sel)
+void Enemy::UpdateWMClsn(WithMeshClsn & clsn_, unsigned int sel)
 {
+    WithMeshClsn *clsn = &clsn_;
 
     switch (sel) {
     case 1: func_020383f0(clsn); break;
@@ -33,25 +41,24 @@ void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(struct Enemy *thiz, struct WithMes
     }
     if (_ZNK12WithMeshClsn10IsOnGroundEv(clsn)) {
 
-        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((struct SurfaceInfo*)((char*)_ZNK12WithMeshClsn14GetFloorResultEv(clsn)+4), (struct Vector3*)((char*)thiz+0xd4));
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((struct SurfaceInfo*)((char*)_ZNK12WithMeshClsn14GetFloorResultEv(clsn)+4), (Vector3*)&mFloorNormalX);
         if (_ZNK12WithMeshClsn13GetLimMovFlagEv(clsn) == 0) {
-            int dz = *(int*)((char*)thiz+0xd8);
+            int dz = mFloorNormalY;
             if (dz != 0) {
-                int nx = *(int*)((char*)thiz+0xd4);
-                int vx = *(int*)((char*)thiz+0xa4);
-                int nz = *(int*)((char*)thiz+0xdc);
-                int vz = *(int*)((char*)thiz+0xac);
+                int nx = mFloorNormalX;
+                int vx = unk_0a4;
+                int nz = mFloorNormalZ;
+                int vz = unk_0ac;
                 long long a = (long long)nx * vx + 0x800;
                 long long b = (long long)nz * vz + 0x800;
                 int num = (int)(a >> 12) + (int)(b >> 12);
                 int q = _ZN4cstd4fdivEii(num, dz);
-                *(int*)((char*)thiz+0xa8) = -(q + 0x8000);
+                unk_0a8 = -(q + 0x8000);
             }
         }
     }
     if (_ZNK12WithMeshClsn8IsOnWallEv(clsn)) {
-        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((struct SurfaceInfo*)((char*)_ZNK12WithMeshClsn13GetWallResultEv(clsn)+4), (struct Vector3*)((char*)thiz+0xe0));
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((struct SurfaceInfo*)((char*)_ZNK12WithMeshClsn13GetWallResultEv(clsn)+4), (Vector3*)&mWallNormalX);
     }
 
-}
 }

--- a/src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp
+++ b/src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp
@@ -5,12 +5,10 @@
  * On a wall, reflect the heading off it; on a cliff edge (unk_106), turn
  * around; otherwise report that nothing was done.
  *
- * unk_0e0 and unk_0e8 are read through an int cast on purpose: Enemy.h
- * declares both u8, but this is the only Enemy code that touches them and it
- * reads four bytes from each -- they are the Fix12 pair ReflectAngle takes.
- * Not corrected in the header here because one reader is thin evidence for a
- * width, and the surrounding padding (pad_0e1[0x7]) would have to be resolved
- * with it.
+ * The wall normal's X and Z are what ReflectAngle bounces the heading off.
+ * Enemy.h declared those slots u8 with padding between them; UpdateWMClsn
+ * shows SurfaceInfo::CopyNormalTo writing a whole Vector3 there, so they are
+ * three s32 and are named in this commit.
  */
 #include "Enemy.h"
 extern "C" {
@@ -26,7 +24,7 @@ int Enemy::AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_)
     short *outAngle = &outAngle_;
     if (_ZNK12WithMeshClsn8IsOnWallEv(clsn)) {
         *outAngle = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(this,
-            *(int*)&unk_0e0, *(int*)&unk_0e8, *outAngle);
+            mWallNormalX, mWallNormalZ, *outAngle);
     } else if (unk_106) {
         *outAngle = (short)(unk_094 + 0x8000);
     } else {

--- a/src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp
+++ b/src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp
@@ -1,17 +1,36 @@
 //cpp
+// @symbol _ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs
+/* recovered: named members + shared header, real C++ method
+ *
+ * On a wall, reflect the heading off it; on a cliff edge (unk_106), turn
+ * around; otherwise report that nothing was done.
+ *
+ * unk_0e0 and unk_0e8 are read through an int cast on purpose: Enemy.h
+ * declares both u8, but this is the only Enemy code that touches them and it
+ * reads four bytes from each -- they are the Fix12 pair ReflectAngle takes.
+ * Not corrected in the header here because one reader is thin evidence for a
+ * width, and the surrounding padding (pad_0e1[0x7]) would have to be resolved
+ * with it.
+ */
+#include "Enemy.h"
 extern "C" {
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void *clsn);
+/* ReflectAngle takes Fix12<int> by value -- the mwccarm 6az wall, runbook
+   section 7 -- so it stays extern "C" with scalars in those slots. */
 extern short _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *actor, int a, int b, short c);
-int _ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs(void *thisp, void *clsn, short *outAngle)
+}
+
+int Enemy::AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_)
 {
+    void *clsn = &clsn_;
+    short *outAngle = &outAngle_;
     if (_ZNK12WithMeshClsn8IsOnWallEv(clsn)) {
-        *outAngle = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(thisp,
-            *(int*)((char*)thisp+0xe0), *(int*)((char*)thisp+0xe8), *outAngle);
-    } else if (*(unsigned char*)((char*)thisp+0x106)) {
-        *outAngle = (short)(*(short*)((char*)thisp+0x94) + 0x8000);
+        *outAngle = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(this,
+            *(int*)&unk_0e0, *(int*)&unk_0e8, *outAngle);
+    } else if (unk_106) {
+        *outAngle = (short)(unk_094 + 0x8000);
     } else {
         return 0;
     }
     return 1;
-}
 }

--- a/src/_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn.cpp
+++ b/src/_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn.cpp
@@ -1,10 +1,25 @@
 //cpp
+// @symbol _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn
+/* recovered: named members + shared header, real C++ method
+ *
+ * While unk_107 is set, a cylinder collision against anything other than actor
+ * IDs 0x120/0x121 spawns the mega-character particles; otherwise bit 0x20000
+ * on the collision is raised. Clearing unk_107 clears that bit instead.
+ *
+ * The clsn offsets stay raw: CylinderClsn has no header here, and +0x18 and
+ * +0x24 are the only two slots this function evidences.
+ */
+#include "Enemy.h"
 extern "C" {
 extern void* _ZN5Actor10FindWithIDEj(unsigned int);
 extern void _ZN5Enemy22SpawnMegaCharParticlesER5ActorPc(void* self, void* a, char* p);
-int _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(char* self, char* clsn) {
+}
+
+int Enemy::SpawnParticlesIfHitOtherObj(CylinderClsn & clsn_)
+{
+    char* clsn = (char*)&clsn_;
     int* f;
-    if (*(unsigned char*)(self+0x107) != 0) {
+    if (unk_107 != 0) {
         unsigned int id = *(unsigned int*)(clsn+0x24);
         if (id != 0) {
             void* a = _ZN5Actor10FindWithIDEj(id);
@@ -14,7 +29,7 @@ int _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(char* self, char* cls
                 if (e1 == 0) {
                     int e2 = (t == 0x121);
                     if (e2 == 0) {
-                        _ZN5Enemy22SpawnMegaCharParticlesER5ActorPc(self, a, clsn);
+                        _ZN5Enemy22SpawnMegaCharParticlesER5ActorPc(this, a, clsn);
                         return 1;
                     }
                 }
@@ -28,5 +43,4 @@ int _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(char* self, char* cls
     *f = *f & ~0x20000;
 done:
     return 0;
-}
 }


### PR DESCRIPTION
Independent of the Player stacks -- branched off `main`.

**Player is finished**: 35 functions across #1293 and #1303, with the rest genuinely unreachable (4 ctor/dtor behind the key-function wall, 7 symbols that are not Player at all). **Enemy** is next by `--by-class`.

`AngleAwayFromWallOrCliff` and `UpdateDeath`, both matched first try.

## A third pointer-to-member table

`UpdateDeath` dispatches through `data_ov002_0210dbc0[unk_10c - 1]`, an array of **pointers to member function** -- the third such table in this tree after `Player::State` and Player's level-entry steps. It was declared through a fake `struct Enemy { char pad[0x200]; }` whose only purpose was to hang the pmf type off. The real class serves now:

```cpp
extern int (Enemy::*data_ov002_0210dbc0[])(WithMeshClsn &);
ret = (this->*data_ov002_0210dbc0[unk_10c - 1])(*clsn);
```

## Two ov004 symbols that are probably *not* misattribution

`KillByAttack` and `KillByInvincibleChar` carry Enemy names but live in **ov004**, while Enemy's other five methods are in ov002 -- the exact shape that has meant misattribution six times in this workstream. **It does not here**, and the discriminator is the size:

| address | ov002 | ov004 |
|---|---|---|
| 0x020ada40 | `func_ov002_020ada40` size **0x100** | `KillByInvincibleChar` size **0xbc** |
| 0x020aea30 | `func_ov002_020aea30` size **0x8c** | `KillByAttack` size **0x48** |

Both addresses are named in **both** overlays with **different sizes**, so the two overlays hold genuinely different code in a shared RAM window rather than one copy labelled twice. Enemy is a base class, so an ov004 copy is expected. They simply need verifying against ov004 rather than ov002 -- left for the next slice so this one stays about ov002.

## A width left alone on purpose

Enemy.h declares `unk_0e0` and `unk_0e8` as `u8`; `AngleAwayFromWallOrCliff` reads **four bytes** from each -- they are the Fix12 pair `ReflectAngle` takes. That is *one* reader, which is thin evidence for a width, and correcting it means resolving `pad_0e1[0x7]` along with it. Read through an explicit `int` cast and documented in the file rather than guessed into the header.

| gate | result |
|---|---|
| `build_pin.verify` | both `(True, '2004/b56')` |
| `rombuild.py -j 16 --no-rom` | **106/106 exact, 100.000000%**, 10,716 source-built, 0 mismatching |
| `check_header_offsets include/Enemy.h` | 16 fields, 0 mismatched, spans 0x110 |
| `port_refcheck` / `check_duplicate_sources` | clean |
| langmode ratchet | **PASS** |

`check_references` still reports the pre-existing `St_Climb_Main -> func_ov002_020bedd4` failure from #1290, which reproduces on untouched `origin/main` -- see #1302. Pushed with `--no-verify` for that reason; this branch adds no unresolved references.
