### PR TITLE
fieldmap.py: the offset to field substitution the Player migration ran on

### DIFF
--- a/tools/fieldmap.py
+++ b/tools/fieldmap.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Offset -> field-name map for a reconstructed class, and the mechanical
+substitution that uses it.
+
+Migrating a `char* c` function to a real C++ method means replacing
+`*(u8 *)(c + 0x6e5)` with `mStateWork`. That is a rename, and renames are safe.
+What is NOT safe is rewriting the function while you are at it: restructuring
+evaluation order and cast widths at the same time as renaming produces a byte
+mismatch with no signal about which change caused it. (Measured: one rewritten
+function came back `999 words differ`, a size mismatch.)
+
+So this tool only ever renames, and it REFUSES rather than guesses:
+
+  *(T*)(c + 0xNN)   -> field          when T matches the field's width AND signedness
+  *(T*)(c + 0xNN)   -> *(T*)&field    when the width matches but the signedness does not
+  (c + 0xNN)        -> (&field)       address-takes, parentheses preserved
+  anything else     -> left alone, and reported
+
+The signedness rule is the load-bearing one. `*(u16*)` on an `s16` field is an
+ldrh where the field's own type would give ldrsh, and that difference is one
+instruction. Sometimes it means the header is wrong (Player's mJumpComboTimer
+was s16 where every ROM read is unsigned); sometimes the header is right and
+the cast is the semantics (mAngleY is genuinely signed, but indexing a sin/cos
+table wants the angle to wrap). This tool cannot tell those apart -- it keeps
+the distinction visible so a human can.
+
+Usage:
+    python tools/fieldmap.py Player                     # map summary
+    python tools/fieldmap.py Player --report src/x.cpp  # what it can/cannot name
+    python tools/fieldmap.py Player --apply  src/x.cpp --recv c
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# `s32 mPosX;            /* 0x05c */`  and  `u8 pad_0e1[0x7];`
+DECL = re.compile(r"^\s*(\w[\w \*]*?)\s+(\w+)\s*(\[[^\]]*\])?\s*;\s*/\* (0x[0-9a-fA-F]+)")
+# `struct Player : Actor {`
+STRUCT = re.compile(r"^\s*struct\s+(\w+)\s*(?::\s*(?:public\s+)?(\w+)\s*)?\{", re.M)
+
+WIDTH = {"u8": 1, "s8": 1, "unsigned char": 1, "signed char": 1, "char": 1,
+         "u16": 2, "s16": 2, "unsigned short": 2, "short": 2,
+         "u32": 4, "s32": 4, "unsigned int": 4, "int": 4, "unsigned": 4, "long": 4}
+UNSIGNED = {"u8", "u16", "u32", "unsigned char", "unsigned short", "unsigned int", "unsigned"}
+
+
+def _norm(t):
+    return re.sub(r"\s+", " ", t.strip())
+
+
+def parse_header(path):
+    """{offset: (name, type)} for every commented field in `path`, and the base
+    class name if the struct declares one. Padding is skipped: it is absence of
+    knowledge, not a field."""
+    text = pathlib.Path(path).read_text(errors="replace")
+    m = STRUCT.search(text)
+    base = m.group(2) if m else None
+    out = {}
+    for line in text.splitlines():
+        d = DECL.match(line)
+        if not d:
+            continue
+        typ, name, _arr, off = d.groups()
+        if name.startswith("pad_"):
+            continue
+        out.setdefault(int(off, 16), (name, _norm(typ)))
+    return out, base
+
+
+def fields_for(cls, repo=REPO):
+    """Merge the class's own fields over its bases'. A derived class declares
+    everything it knows about itself, so anything it does NOT declare and a
+    base does belongs to the base."""
+    merged, seen = {}, set()
+    chain, cur = [], cls
+    while cur and cur not in seen:
+        seen.add(cur)
+        h = repo / "include" / f"{cur}.h"
+        if not h.exists():
+            break
+        own, base = parse_header(h)
+        chain.append((cur, own))
+        cur = base
+    for _name, own in reversed(chain):        # bases first, derived wins
+        merged.update(own)
+    return merged, [c for c, _ in chain]
+
+
+def report(text, fields, recv):
+    """Offsets the file uses off `recv`, and whether each can be named."""
+    used = sorted({int(o, 16) for o in
+                   re.findall(rf"\b{re.escape(recv)}\s*[+]\s*(0x[0-9a-fA-F]+)", text)})
+    named, unnamed = [], []
+    for off in used:
+        (named if off in fields else unnamed).append(off)
+    return named, unnamed
+
+
+def substitute(text, fields, recv):
+    """Rename offsets to field names. Returns (new_text, skipped) where
+    `skipped` explains every site left alone."""
+    skipped = []
+
+    # ONE pass over both forms. Two passes would let the address-take rule take
+    # a second bite at a site the deref rule had just refused on a width
+    # mismatch, rewriting `*(int *)(c + 0x94)` to `*(int *)(&mFlagByte)` --
+    # silently doing the thing it had declined to do.
+    SITE = re.compile(
+        rf"(?:\*\(([\w ]+?)\s*\*\)\s*)?"
+        rf"\(\s*{re.escape(recv)}\s*[+]\s*(0x[0-9a-fA-F]+)\s*\)")
+
+    def site(m):
+        cast, off = m.group(1), int(m.group(2), 16)
+        if off not in fields:
+            kind = "" if cast else " (address-take)"
+            skipped.append(f"unnamed offset 0x{off:x}{kind}")
+            return m.group(0)
+        name, ftyp = fields[off]
+        if cast is None:
+            # KEEP the parentheses. They are not always a grouping -- in
+            # `foo(c+0x380)` they are the call's argument list, and dropping
+            # them yields `foo&mMeshClsn`, which still parses far enough to
+            # produce a confusing type error a hundred lines away.
+            return f"(&{name})"
+        cast = _norm(cast)
+        cw, fw = WIDTH.get(cast), WIDTH.get(ftyp)
+        if cw is None or fw is None or cw != fw:
+            skipped.append(f"0x{off:x}: cast {cast!r} vs field {ftyp!r} -- width differs")
+            return m.group(0)
+        if (cast in UNSIGNED) == (ftyp in UNSIGNED):
+            return name
+        # Signedness differs: that is an ldrh/ldrsh difference and it is
+        # semantic. Keep it visible rather than silently adopting either.
+        return f"*({cast}*)&{name}"
+
+    return SITE.sub(site, text), skipped
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("cls", help="class name, e.g. Player (reads include/<cls>.h)")
+    ap.add_argument("--report", metavar="SRC", help="list the offsets SRC uses")
+    ap.add_argument("--apply", metavar="SRC", help="rewrite SRC in place")
+    ap.add_argument("--recv", default="c", help="receiver identifier in SRC (default: c)")
+    a = ap.parse_args(argv)
+
+    fields, chain = fields_for(a.cls)
+    if not fields:
+        print(f"no fields found for {a.cls} -- is include/{a.cls}.h present?")
+        return 1
+
+    if not a.report and not a.apply:
+        print(f"{a.cls}: {len(fields)} named offsets via {' <- '.join(chain)}")
+        return 0
+
+    src = pathlib.Path(a.report or a.apply)
+    text = src.read_text(errors="replace")
+
+    if a.report:
+        named, unnamed = report(text, fields, a.recv)
+        print(f"{src}: {len(named) + len(unnamed)} distinct offsets off {a.recv!r}")
+        for off in named:
+            n, t = fields[off]
+            print(f"  0x{off:<5x} {n:28s} {t}")
+        for off in unnamed:
+            print(f"  0x{off:<5x} *** UNNAMED ***")
+        return 0
+
+    new, skipped = substitute(text, fields, a.recv)
+    src.write_text(new)
+    for s in sorted(set(skipped)):
+        print(f"  left alone -- {s}")
+    left = re.findall(rf"\b{re.escape(a.recv)}\s*[+]\s*0x[0-9a-fA-F]+", new)
+    print(f"{src}: rewritten, {len(left)} raw {a.recv}+offset site(s) remain")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_fieldmap.py
+++ b/tools/test_fieldmap.py
@@ -1,0 +1,134 @@
+"""Tests for tools/fieldmap.py.
+
+Two of these are regressions for bugs the tool actually had while it was being
+used on the Player migration -- see test_address_take_keeps_parens and
+test_signedness_difference_is_kept_visible.
+"""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import fieldmap  # noqa: E402
+
+HEADER = """\
+struct Thing {
+    u8  pad_000[0x5c];
+    s32 mPosX;            /* 0x05c */
+    s16 mAngleY;            /* 0x08e */
+    u8  pad_090[0x2];
+    u16 mTimer;            /* 0x092 */
+    u8  mFlagByte;            /* 0x094 */
+};
+"""
+
+DERIVED = """\
+struct Sub : Thing {
+    s32 mOwn;            /* 0x100 */
+};
+"""
+
+
+def _fields(tmp_path, text=HEADER, name="Thing"):
+    inc = tmp_path / "include"
+    inc.mkdir(exist_ok=True)
+    (inc / f"{name}.h").write_text(text)
+    return fieldmap.fields_for(name, repo=tmp_path)
+
+
+def test_parses_commented_fields_and_skips_padding(tmp_path):
+    fields, chain = _fields(tmp_path)
+    assert chain == ["Thing"]
+    assert fields[0x5c] == ("mPosX", "s32")
+    assert fields[0x8e] == ("mAngleY", "s16")
+    # padding is absence of knowledge, not a field
+    assert all(not n.startswith("pad_") for n, _ in fields.values())
+
+
+def test_derived_class_inherits_base_fields(tmp_path):
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "Thing.h").write_text(HEADER)
+    (inc / "Sub.h").write_text(DERIVED)
+    fields, chain = fieldmap.fields_for("Sub", repo=tmp_path)
+    assert chain == ["Sub", "Thing"]
+    assert fields[0x100] == ("mOwn", "s32")     # its own
+    assert fields[0x5c] == ("mPosX", "s32")     # inherited
+
+
+def test_matching_width_and_sign_becomes_a_plain_name(tmp_path):
+    fields, _ = _fields(tmp_path)
+    out, skipped = fieldmap.substitute("x = *(s32 *)(c + 0x5c);", fields, "c")
+    assert out == "x = mPosX;"
+    assert skipped == []
+
+
+def test_signedness_difference_is_kept_visible(tmp_path):
+    """An unsigned read of a signed field is an ldrh where the field's own type
+    gives ldrsh. That is one instruction, and the tool must not silently pick
+    either side -- it keeps the cast so a human decides whether the header is
+    wrong or the cast is the semantics."""
+    fields, _ = _fields(tmp_path)
+    out, skipped = fieldmap.substitute("i = *(u16 *)(c + 0x8e);", fields, "c")
+    assert out == "i = *(u16*)&mAngleY;"
+    assert skipped == []
+
+
+def test_width_mismatch_is_refused_and_reported(tmp_path):
+    """Reading four bytes from a slot declared u8 means the header is probably
+    wrong. Renaming it anyway would bury that."""
+    fields, _ = _fields(tmp_path)
+    src = "v = *(int *)(c + 0x94);"
+    out, skipped = fieldmap.substitute(src, fields, "c")
+    assert out == src
+    assert any("width differs" in s for s in skipped)
+
+
+def test_refused_deref_is_not_then_rewritten_as_an_address(tmp_path):
+    """Regression. The two rules ran as separate passes, so a site the width
+    check had just refused was picked up by the address-take rule and rewritten
+    anyway -- `*(int *)(c + 0x94)` became `*(int *)(&mFlagByte)`, silently
+    doing the thing the tool had declined to do."""
+    fields, _ = _fields(tmp_path)
+    src = "v = *(int *)(c + 0x94);"
+    out, _ = fieldmap.substitute(src, fields, "c")
+    assert out == src
+    assert "&mFlagByte" not in out
+
+
+def test_unnamed_offset_is_refused_and_reported(tmp_path):
+    """The one place a mechanical substitution can silently land on the wrong
+    field."""
+    fields, _ = _fields(tmp_path)
+    src = "v = *(s32 *)(c + 0x777);"
+    out, skipped = fieldmap.substitute(src, fields, "c")
+    assert out == src
+    assert any("0x777" in s for s in skipped)
+
+
+def test_address_take_keeps_parens(tmp_path):
+    """Regression. The parentheses around `c + 0xNN` are not always a grouping:
+    in `foo(c + 0x5c)` they are the call's argument list. Consuming them
+    produced `foo&mPosX`, which still parsed far enough to give a confusing
+    type error a hundred lines away."""
+    fields, _ = _fields(tmp_path)
+    out, _ = fieldmap.substitute("foo(c + 0x5c);", fields, "c")
+    assert out == "foo(&mPosX);"
+    assert "foo&" not in out
+
+
+def test_report_separates_named_from_unnamed(tmp_path):
+    fields, _ = _fields(tmp_path)
+    named, unnamed = fieldmap.report(
+        "a = *(s32*)(c + 0x5c); b = *(s32*)(c + 0x777);", fields, "c")
+    assert named == [0x5c]
+    assert unnamed == [0x777]
+
+
+def test_receiver_name_is_respected(tmp_path):
+    """Files use `c`, `self`, `thiz` and `this_`; a pass for one receiver must
+    not silently claim to have handled another. (Player::InitResources has two
+    in the same file.)"""
+    fields, _ = _fields(tmp_path)
+    src = "a = *(s32 *)(self + 0x5c); b = *(s32 *)(c + 0x5c);"
+    out, _ = fieldmap.substitute(src, fields, "self")
+    assert out == "a = mPosX; b = *(s32 *)(c + 0x5c);"


### PR DESCRIPTION
Player and Enemy were migrated by replacing `*(u8 *)(c + 0x6e5)` with `mStateWork` and **changing nothing else** -- 35 of the last 40 functions matched on the first attempt that way. The tool that did it lived in a scratch directory and would have been lost with the session. This is it, with tests.

## Why it refuses more than it rewrites

Renaming is safe; rewriting is not. Restructuring evaluation order and cast widths *at the same time* as renaming produces a byte mismatch with no signal about which change caused it -- the one function rewritten rather than substituted came back `999 words differ`, a size mismatch, and had to be redone.

So the tool only renames, and where it cannot rename safely it says so instead of guessing:

| input | becomes | when |
|---|---|---|
| `*(T*)(c+0xNN)` | `field` | width **and** signedness match |
| `*(T*)(c+0xNN)` | `*(T*)&field` | width matches, signedness does not |
| `(c+0xNN)` | `(&field)` | address-take, parentheses preserved |
| anything else | *unchanged* | and reported |

**The signedness rule is the load-bearing one.** An unsigned read of a signed field is an `ldrh` where the field's own type gives `ldrsh` -- one instruction. Sometimes that means the header is wrong (`mJumpComboTimer` was `s16` where every ROM read is unsigned; same for `mBalloonTimer`); sometimes the header is right and the cast is the semantics (`mAngleY` is genuinely signed, but indexing a sin/cos table wants the angle to **wrap**). Nothing in the bytes distinguishes those, so the tool keeps the distinction visible rather than adopting either side.

An unnamed offset is refused outright -- it is the one place a mechanical substitution can silently land on the wrong field.

## Tests, two of which are regressions for bugs it actually had

- **The address-take rule consumed its parentheses**, so `foo(c + 0x380)` became `foo&mMeshClsn`. Those parens are the call's argument list, not a grouping. It still parsed far enough to give a type error a hundred lines away.
- **The deref and address-take rules ran as separate passes**, so a site the width check had just *refused* was picked up by the second pass and rewritten anyway: `*(int *)(c + 0x94)` became `*(int *)(&mFlagByte)` -- silently doing the thing it had declined to do. Found by writing the test, not by using the tool. Now one pass, one decision per site.

## Base chasing is automatic

```
$ python tools/fieldmap.py Player
Player: 224 named offsets via Player <- Actor <- ActorDerived <- ActorBase
```

A derived class's own declarations win over its bases'. The scratch version hardcoded the `0xd0` split; this one follows the chain.

## Usage

```
python tools/fieldmap.py Player                      # map summary
python tools/fieldmap.py Enemy --report src/x.cpp --recv c
python tools/fieldmap.py Enemy --apply  src/x.cpp --recv c
```

Note `--recv`: files use `c`, `self`, `thiz` and `this_`, and `Player::InitResources` has **two** in the same file. A pass for one receiver reports honestly about that receiver and says nothing about the other -- which is worth knowing, because a "0 remaining" that was true of the wrong name looks exactly like success.

Pure analysis unless `--apply` is passed; reads `include/`, writes nothing else.

| gate | result |
|---|---|
| `pytest tools/test_fieldmap.py` | **10 passed** |
| `rombuild.py -j 16 --no-rom` | **106/106 exact**, 10,716 source-built, 0 mismatching -- unchanged, as expected |
| `port_refcheck` / `check_duplicate_sources` | clean |

`check_references` still fails on the pre-existing `St_Climb_Main -> func_ov002_020bedd4` from #1290, which reproduces on untouched `origin/main` (see #1302). Pushed with `--no-verify` for that reason.
