### PR TITLE
Fix cross-overlay vtable-store mislabels in PyramidLift_Spawn and WorkElevator_Spawn (wave 3, corrected attribution)

### DIFF
--- a/src/PyramidLift_Spawn.cpp
+++ b/src/PyramidLift_Spawn.cpp
@@ -4,14 +4,14 @@ extern void* _ZN9ActorBasenwEj(unsigned int);
 extern void _ZN8PlatformC2Ev(void*);
 extern void _ZN5ModelC1Ev(void*);
 extern int func_020733a8(void*,int,int,void*,void*);
-extern void* data_ov027_021139d4;
+extern void* _ZTV11PyramidLift;
 extern void func_020072c0(void);
 extern void func_0203d384(void);
 void* PyramidLift_Spawn(void){
   char* c=(char*)_ZN9ActorBasenwEj(0x3fc);
   if(c){
     _ZN8PlatformC2Ev(c);
-    *(void**)c=&data_ov027_021139d4;
+    *(void**)c=&_ZTV11PyramidLift;
     _ZN5ModelC1Ev(c+0x320);
     func_020733a8(c+0x37c, 0xa, 0xc, (void*)func_0203d384, (void*)func_020072c0);
   }

--- a/src/WorkElevator_Spawn.cpp
+++ b/src/WorkElevator_Spawn.cpp
@@ -3,7 +3,7 @@ extern "C" {
 extern void* _ZN9ActorBasenwEj(unsigned);
 extern void _ZN8PlatformC2Ev(void*);
 extern void func_020733a8(void*,int,int,void*,void*);
-extern int func_ov075_0211478c[];
+extern int _ZTV12WorkElevator[];
 extern void _ZN5ModelD1Ev(void*);
 extern void _ZN5ModelC1Ev(void*);
 extern void _ZN18MovingMeshColliderD1Ev(void*);
@@ -12,7 +12,7 @@ void* WorkElevator_Spawn(void){
   char* c = (char*)_ZN9ActorBasenwEj(0xc80);
   if(c){
     _ZN8PlatformC2Ev(c);
-    *(int*)c = (int)func_ov075_0211478c;
+    *(int*)c = (int)_ZTV12WorkElevator;
     func_020733a8(c+0x320, 4, 0x50, (void*)_ZN5ModelC1Ev, (void*)_ZN5ModelD1Ev);
     func_020733a8(c+0x520, 4, 0x1c8, (void*)_ZN18MovingMeshColliderC1Ev, (void*)_ZN18MovingMeshColliderD1Ev);
   }


### PR DESCRIPTION
## Summary

Depends on #1307 (`tools/ovsweep.py` attribution fix) for method lineage — third and final slice of the corrected 52-candidate wave-3 set (sinit files in #1308, class methods in #1309).

Companion fix to #1294, which corrected the D0/D1 destructor-side vtable stores for PyramidLift and WorkElevator but left the constructor/Spawn side untouched. Same defect, surfaced by the corrected `tools/ovsweep.py` scan:

- `PyramidLift_Spawn.cpp` set the object's vptr to `data_ov027_021139d4` before the real `_ZTV8Platform` base-class vtable store. PyramidLift is owned by ov025, whose own symbol at that exact address is `_ZTV11PyramidLift` (the class's real vtable) — ov025 and ov027 are same-window overlapping overlays, never co-resident, so the ov027 reference could only be the address-collision mislabel #1294 already fixed on the destructor side.
- `WorkElevator_Spawn.cpp` set the vptr to `func_ov075_0211478c` (a function-shaped name) before the same `_ZTV8Platform` store. WorkElevator is owned by ov021, whose own symbol at that address is `_ZTV12WorkElevator` (data, the real vtable) — ov021 and ov075 are same-window overlapping overlays, never co-resident.

Note: `FallBlockWf_Spawn.c` had the same vtable-store shape in the raw candidate list but is **not** included here — ov015 (its own overlay) has no symbol at all at the flagged address (`0x0213c5bc` falls entirely outside ov015's actual code+bss range), and ov015's real vtable (`_ZTV11FallBlockWf`) lives at a different address (`0x021148dc`). There's no own-overlay symbol to rename to with any confidence, so it's reported as ambiguous rather than guessed.

## Test plan

- [x] `python tools/match.py --c src/<file> --func <name> --addr <addr> --size <size> --module <ovNNN> --version 2004/b56` MATCH for both, byte-identical, per-file temp dirs
- [x] `python tools/linkcheck.py --name <name> --addr <addr> --size <size> --module <ovNNN>` VERIFIED for both
- [x] No merge requested — main brain merges green-validate only