### PR TITLE
St_Climb_Main: name the placeholder callee Player_AdvanceAnims

### DIFF
--- a/src/_ZN6Player13St_Climb_MainEv.cpp
+++ b/src/_ZN6Player13St_Climb_MainEv.cpp
@@ -40,7 +40,7 @@ extern void func_ov002_020bf340(void* c, s32* p, s32 delta, s32 limit);
 extern void func_ov002_020cb400(void* c);
 extern void func_ov002_020cb474(void* c);
 extern int func_ov002_020cbea8(void* c);
-extern void func_ov002_020bedd4(void* c);
+extern void Player_AdvanceAnims(void* c);
 extern void* data_0209f318;
 extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
@@ -254,6 +254,6 @@ tail:
     if (*(s16*)((char*)data_0209f4a4 + (u32)data_020a0e40 * 0x18) == 0) {
         *(u8*)(c + 0x6e5) = 1;
     }
-    func_ov002_020bedd4(c);
+    Player_AdvanceAnims(c);
     return 1;
 }


### PR DESCRIPTION
`_ZN6Player13St_Climb_MainEv` referenced `func_ov002_020bedd4`, a name the ROM defines nowhere. The reference resolved to nothing, so `check_references` failed — **on untouched `origin/main`, since #1290** — which blocks the pre-push hook for every branch, not just the one that introduced it.

### The answer is not a guess

ov002 defines `Player_AdvanceAnims` at exactly `0x020bedd4` (`config/arm9/overlays/ov002/symbols.txt:468`, size `0xf8`), and dsd's own relocation table resolves the call sites there unambiguously:

```
from:0x020c3bc0 kind:arm_call to:0x020bedd4 module:overlay(2)
```

`module:overlay(2)` — no overlay ambiguity to break. The placeholder was simply the unnamed spelling of a function that already has a name. `tools/resolve_placeholders.py` reaches the same answer from the same data.

Renamed in place, keeping the existing declaration's signature rather than synthesising a new one, so nothing about the call changes but the spelling.

### Verification

| gate | result |
|---|---|
| `build_pin.verify` `_ZN6Player13St_Climb_MainEv` | `(True, '2004/b56')` |
| `check_references` | **FAIL → `OK: no new unresolvable references`** |
| unresolved symbols | 235 → **234** |
| eligible | 10722 → **10723** (the file itself now resolves) |

No symbol left the backlog by failing differently.

**Byte gates could never have caught this**: `match.py` compares relocated words as wildcards and never looks at what a call targets. That is exactly why `check_references` exists.

This is the base of a five-PR stack; the four migration PRs on top of it were blocked by this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS