### PR TITLE
KoopaShell: all five methods as real C++, on a new header

### DIFF
--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -420,7 +420,7 @@ src/_ZN10KoopaShell16CleanupResourcesEv.cpp:
     complete
     .text start:0x0214d248 end:0x0214d274
 
-src/_ZN10KoopaShell16OnPendingDestroyEv.c:
+src/_ZN10KoopaShell16OnPendingDestroyEv.cpp:
     complete
     .text start:0x0214d274 end:0x0214d278
 

--- a/include/KoopaShell.h
+++ b/include/KoopaShell.h
@@ -1,0 +1,93 @@
+/* Hand-written from matched-function evidence, not gen_header.py output:
+ * class KoopaShell, 5 matched functions in one clean TU (ov102
+ * 0x0214c748-0x0214d70c, 24 functions, no other class in it -- tu_map.py).
+ * Offsets/widths are observed, not guessed. Gaps are explicit padding.
+ *
+ * KoopaShell derives from Enemy -- Behavior calls Enemy::UpdateYoshiEat and
+ * Enemy::UpdateWMClsn on itself, and Enemy spans exactly 0x110, which is where
+ * this class's own sub-objects start. It is written FLAT anyway, with the
+ * inherited slots restated as padding and named fields, because that is what
+ * every other generated header in this tree does and because Enemy.h asserts
+ * no size for a derived struct to build on. Restating a base is a known cost;
+ * re-basing the whole family is its own slice.
+ *
+ * Field NAMES are placeholders - renaming cannot change codegen.
+ */
+#ifndef KOOPASHELL_H
+#define KOOPASHELL_H
+#include "types.h"
+
+struct KoopaShell {
+    u8  pad_000[0x8];
+    /* Spawn parameter word. InitResources takes bit 0 as the model index into
+       data_ov102_0214d70c and bit 4 as unk_3c5 -- so one spawn word selects
+       both the shell's artwork and a behaviour variant. */
+    u32 mSpawnParam;            /* 0x008 */
+    u8  pad_00c[0x50];
+    s32 mPosX;            /* 0x05c */
+    s32 mPosY;            /* 0x060 */
+    s32 mPosZ;            /* 0x064 */
+    u8  pad_068[0x2c];
+    s16 mPrevAngleY;            /* 0x094 */
+    u8  pad_096[0x6];
+    s32 mSpeed;            /* 0x09c */
+    s32 unk_0a0;            /* 0x0a0 */
+    u8  pad_0a4[0x4];
+    s32 mVertSpeed;            /* 0x0a8 */
+    u8  pad_0ac[0x4];
+    u32 mFlags;            /* 0x0b0 */
+    u8  pad_0b4[0x4c];
+    s16 unk_100;            /* 0x100 */
+    u8  pad_102[0x5];
+    u8  unk_107;            /* 0x107 */
+    u8  pad_108[0x8];
+    /* Sub-objects, kept as byte markers: their sizes are fixed by the NEXT
+       marker's offset, which is what the ROM evidences, and none of the five
+       functions here needs a view into one. 0x110 is initialised as a
+       MovingCylinderClsn and later driven through CylinderClsn::Clear/Update,
+       so the moving flavour derives from the plain one. */
+    u8  mCylinderClsn;            /* 0x110 */
+    u8  pad_111[0x33];
+    u8  mMeshClsn;            /* 0x144 */
+    u8  pad_145[0x1bb];
+    u8  mModel;            /* 0x300 */
+    u8  pad_301[0x4f];
+    u8  mShadowModel;            /* 0x350 */
+    u8  pad_351[0x5b];
+    /* Current state. Behavior compares it against four file-scope state
+       objects by ADDRESS and reads a pointer-to-member at +0x8 out of it, so
+       it points at a record whose third word is the per-state tick. */
+    void* mState;            /* 0x3ac */
+    /* Where it was spawned: InitResources copies mPos here verbatim, and
+       Behavior stashes mPrevAngleY into mSpawnAngleY when the shell is spat
+       back out of Yoshi's mouth. */
+    s32 mSpawnPosX;            /* 0x3b0 */
+    s32 mSpawnPosY;            /* 0x3b4 */
+    s32 mSpawnPosZ;            /* 0x3b8 */
+    s16 mSpawnAngleY;            /* 0x3bc */
+    u8  pad_3be[0x2];
+    s32 unk_3c0;            /* 0x3c0 */
+    /* Model index, 0 or 1, off bit 0 of mSpawnParam. Behavior gives index 0 a
+       per-frame call the other does not get. */
+    u8  mModelIndex;            /* 0x3c4 */
+    u8  unk_3c5;            /* 0x3c5 */
+    /* Despawn countdown, and it only runs in one state. Render blinks the
+       shell while it is below 0x2d by skipping odd values, so the shell
+       flashes out rather than vanishing. */
+    u8  mDespawnTimer;            /* 0x3c6 */
+    u8  pad_3c7[0x1];
+    s32 unk_3c8;            /* 0x3c8 */
+    s32 unk_3cc;            /* 0x3cc */
+    s32 unk_3d0;            /* 0x3d0 */
+    s32 unk_3d4;            /* 0x3d4 */
+#ifdef __cplusplus
+    /* methods */
+    int Behavior();
+    int CleanupResources();
+    int InitResources();
+    void OnPendingDestroy();
+    int Render();
+#endif
+};
+
+#endif

--- a/src/_ZN10KoopaShell13InitResourcesEv.cpp
+++ b/src/_ZN10KoopaShell13InitResourcesEv.cpp
@@ -1,4 +1,24 @@
 //cpp
+// @symbol _ZN10KoopaShell13InitResourcesEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * Builds the shell: model, shadow, both collision volumes, initial motion, and
+ * the starting state. Any failure returns 0 and the spawn is abandoned.
+ *
+ * One spawn word does double duty. mSpawnParam bit 0 picks which of the two
+ * shared model files to load and is kept in mModelIndex so CleanupResources
+ * can release the same one; bit 4 goes to unk_3c5 as a behaviour variant.
+ *
+ * mPos is copied into mSpawnPos here, which is what makes the spawn point
+ * recoverable later.
+ *
+ * The two Init calls keep extern "C" declarations with scalar slots: both
+ * carry Fix12<int> BY VALUE in their real signatures, which mwccarm passes
+ * differently at the call site, so spelling the true types breaks the byte
+ * match -- notes/mwccarm-codegen.md 6az.
+ */
+#include "KoopaShell.h"
+
 typedef int Fix12;
 struct BMD_File;
 struct SharedFilePtr { int h; };
@@ -17,20 +37,12 @@ struct ShadowModel {
 struct MovingCylinderClsn {
     void Init(Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
 };
-/* Signature deliberately copied from the local declaration above: the
-   ROM name carries by-value class parameters (e.g. Fix12<int>), which
-   mwccarm passes differently at the call site, so declaring the true
-   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, Actor* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
 
 struct WithMeshClsn {
     void Init(Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
     void StartDetectingWater();
 };
-/* Signature deliberately copied from the local declaration above: the
-   ROM name carries by-value class parameters (e.g. Fix12<int>), which
-   mwccarm passes differently at the call site, so declaring the true
-   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *, Actor* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
 
 extern "C" void func_ov102_0214d1f8(void* c, void* p);
@@ -38,52 +50,30 @@ extern "C" void func_ov102_0214d1f8(void* c, void* p);
 extern SharedFilePtr* data_ov102_0214d70c[];
 extern void* data_ov102_0214ea68;
 
-struct Obj {
-    char p0[8];
-    unsigned int f8;        /* 0x8 */
-    char gc[0x5c - 0xc];
-    int f5c, f60, f64;      /* 5c,60,64 */
-    char g68[0x9c - 0x68];
-    int f9c, fa0;           /* 9c, a0 */
-    char ga4[0x100 - 0xa4];
-    short f100;             /* 0x100 */
-    char g102[0x110 - 0x102];
-    char f110[0x144 - 0x110];   /* MovingCylinderClsn at 0x110 */
-    char f144[0x300 - 0x144];   /* WithMeshClsn at 0x144 */
-    char f300[0x350 - 0x300];
-    char f350[0x3b0 - 0x350];
-    int f3b0, f3b4, f3b8;   /* 3b0,3b4,3b8 */
-    char g3bc[0x3c0 - 0x3bc];
-    int f3c0;               /* 0x3c0 */
-    unsigned char f3c4, f3c5;   /* 3c4,3c5 */
-    char g3c6[0x3c8 - 0x3c6];
-    int f3c8, f3cc, f3d0, f3d4;  /* 3c8,3cc,3d0,3d4 */
-};
-
-extern "C" int _ZN10KoopaShell13InitResourcesEv(Obj* o)
+int KoopaShell::InitResources()
 {
     BMD_File* bmd;
-    o->f3c4 = (unsigned char)(o->f8 & 1);
-    o->f3c5 = (unsigned char)((o->f8 >> 4) & 1);
-    bmd = Model::LoadFile(*data_ov102_0214d70c[o->f3c4]);
-    if (((ModelBase*)&o->f300)->SetFile(bmd, 1, 1) == 0)
+    mModelIndex = (unsigned char)(mSpawnParam & 1);
+    unk_3c5 = (unsigned char)((mSpawnParam >> 4) & 1);
+    bmd = Model::LoadFile(*data_ov102_0214d70c[mModelIndex]);
+    if (((ModelBase*)&mModel)->SetFile(bmd, 1, 1) == 0)
         return 0;
-    if (((ShadowModel*)&o->f350)->InitCylinder() == 0)
+    if (((ShadowModel*)&mShadowModel)->InitCylinder() == 0)
         return 0;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)&o->f110, (Actor*)o, 0x3c000, 0x46000, 0x100004, 0xa083c0);
-    o->f3b0 = o->f5c;
-    o->f3b4 = o->f60;
-    o->f3b8 = o->f64;
-    o->f9c = -0x2000;
-    o->fa0 = -0x32000;
-    o->f100 = 0x14;
-    o->f3c0 = 0;
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((WithMeshClsn*)&o->f144, (Actor*)o, 0x28000, 0x28000, 0, 0);
-    ((WithMeshClsn*)&o->f144)->StartDetectingWater();
-    func_ov102_0214d1f8(o, &data_ov102_0214ea68);
-    o->f3d4 = 0;
-    o->f3d0 = o->f3d4;
-    o->f3cc = o->f3d0;
-    o->f3c8 = o->f3cc;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj((MovingCylinderClsn*)&mCylinderClsn, (Actor*)this, 0x3c000, 0x46000, 0x100004, 0xa083c0);
+    mSpawnPosX = mPosX;
+    mSpawnPosY = mPosY;
+    mSpawnPosZ = mPosZ;
+    mSpeed = -0x2000;
+    unk_0a0 = -0x32000;
+    unk_100 = 0x14;
+    unk_3c0 = 0;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((WithMeshClsn*)&mMeshClsn, (Actor*)this, 0x28000, 0x28000, 0, 0);
+    ((WithMeshClsn*)&mMeshClsn)->StartDetectingWater();
+    func_ov102_0214d1f8(this, &data_ov102_0214ea68);
+    unk_3d4 = 0;
+    unk_3d0 = unk_3d4;
+    unk_3cc = unk_3d0;
+    unk_3c8 = unk_3cc;
     return 1;
 }

--- a/src/_ZN10KoopaShell16CleanupResourcesEv.cpp
+++ b/src/_ZN10KoopaShell16CleanupResourcesEv.cpp
@@ -1,10 +1,20 @@
 //cpp
+// @symbol _ZN10KoopaShell16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * Releases the shared model file this shell claimed in InitResources, picked
+ * by the same mModelIndex, so the claim and the release stay paired.
+ */
+#include "KoopaShell.h"
 #include "SharedFilePtr.h"
+
 extern "C" {
 extern int data_ov102_0214d70c[];
-int _ZN10KoopaShell16CleanupResourcesEv(char* c){
-  unsigned char i=*(unsigned char*)(c+0x3c4);
+}
+
+int KoopaShell::CleanupResources()
+{
+  unsigned char i = mModelIndex;
   ((SharedFilePtr *)((void*)data_ov102_0214d70c[i]))->Release();
   return 1;
-}
 }

--- a/src/_ZN10KoopaShell16OnPendingDestroyEv.c
+++ b/src/_ZN10KoopaShell16OnPendingDestroyEv.c
@@ -1,3 +1,0 @@
-void _ZN10KoopaShell16OnPendingDestroyEv(void)
-{
-}

--- a/src/_ZN10KoopaShell16OnPendingDestroyEv.cpp
+++ b/src/_ZN10KoopaShell16OnPendingDestroyEv.cpp
@@ -1,0 +1,13 @@
+//cpp
+// @symbol _ZN10KoopaShell16OnPendingDestroyEv
+/* recovered: shared header, real C++ method
+ *
+ * Empty, and that is the finding rather than a stub: the ROM body is a single
+ * `bx lr`. KoopaShell overrides the slot to do NOTHING, which suppresses
+ * whatever the base does on pending destroy.
+ */
+#include "KoopaShell.h"
+
+void KoopaShell::OnPendingDestroy()
+{
+}

--- a/src/_ZN10KoopaShell6RenderEv.cpp
+++ b/src/_ZN10KoopaShell6RenderEv.cpp
@@ -1,4 +1,19 @@
 //cpp
+// @symbol _ZN10KoopaShell6RenderEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * Draws the shell, unless it is being hidden or blinked.
+ *
+ * The blink is the interesting half: while mDespawnTimer is below 0x2d the
+ * shell is skipped on ODD values, so it flashes at half frame rate for the
+ * last 45 frames of its life instead of vanishing. Above 0x2d it draws every
+ * frame, so the flashing starts partway through the countdown rather than at
+ * the beginning.
+ *
+ * Flag 0x40000 suppresses it outright, checked first and unconditionally.
+ */
+#include "KoopaShell.h"
+
 struct Obj {
     virtual void v0();
     virtual void v1();
@@ -8,18 +23,18 @@ struct Obj {
     virtual void m5(int p);
 };
 
-extern "C" int _ZN10KoopaShell6RenderEv(char* c)
+int KoopaShell::Render()
 {
-    int b = (*(int*)(c + 0xb0) & 0x40000) != 0;
+    int b = (mFlags & 0x40000) != 0;
     if (b != 0)
         return 1;
     {
-        unsigned char v = *(unsigned char*)(c + 0x3c6);
+        unsigned char v = mDespawnTimer;
         if (v < 0x2d) {
             if (v & 1)
                 return 1;
         }
     }
-    ((Obj*)(c + 0x300))->m5(0);
+    ((Obj*)&mModel)->m5(0);
     return 1;
 }

--- a/src/_ZN10KoopaShell8BehaviorEv.cpp
+++ b/src/_ZN10KoopaShell8BehaviorEv.cpp
@@ -1,9 +1,30 @@
 //cpp
-#include "types.h"
-/* _ZN10KoopaShell8BehaviorEv @ 0x0214d2e8 (ov102, size 0x264)
- * Enemy main behavior dispatcher: yoshi-eat handling, state PMF call,
- * collision update and ground/wall reactions.
+// @symbol _ZN10KoopaShell8BehaviorEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * One frame of the shell, in five stages: shared enemy pre-pass, Yoshi's
+ * mouth, the despawn countdown, the state tick, then movement and terrain.
+ *
+ * The Yoshi branch is where mSpawnAngleY earns its name: when the shell is
+ * spat back out, the heading it had is stashed there, the state is forced to
+ * data_ov102_0214ea78, and flag 0x80000 is cleared.
+ *
+ * The despawn countdown only runs in ONE state (0214ea68). In any other state
+ * the timer is reset to 0 rather than being left to run, so a shell that is
+ * picked back up stops expiring.
+ *
+ * The state tick is a pointer-to-member read out of the state record at +0x8
+ * and null-checked before the call -- a null tick reads as "keep going", and
+ * any state returning 0 ends the frame early.
+ *
+ * Terrain only matters while mSpeed is non-zero. Hitting a wall in the spat-out
+ * state kills the shell (and returns 0, the one non-1 exit); landing in the
+ * rolling state zeroes both speeds. Two other states are exempt from the
+ * on-ground call entirely.
  */
+#include "types.h"
+#include "KoopaShell.h"
+
 struct C {};
 typedef int (C::*PMF)();
 struct EState {
@@ -35,38 +56,41 @@ extern void _ZN5Actor8PoofDustEv(char *);
 extern void func_ov102_0214c7fc(char *);
 extern void func_ov102_0214c84c(char *);
 extern void _ZN12CylinderClsn6UpdateEv(char *);
+}
 
-int _ZN10KoopaShell8BehaviorEv(char *c)
+int KoopaShell::Behavior()
 {
-    if (func_ov002_020ad660(c, c + 0x144, c + 0x300, 3) != 0)
+    char *c = (char *)this;
+
+    if (func_ov002_020ad660(c, (char *)&mMeshClsn, (char *)&mModel, 3) != 0)
         return 1;
 
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c + 0x144) != 0) {
-        if (*(u8 *)(c + 0x107) != 0) {
-            *(s16 *)(c + 0x3bc) = *(s16 *)(c + 0x94);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, (char *)&mMeshClsn) != 0) {
+        if (unk_107 != 0) {
+            mSpawnAngleY = mPrevAngleY;
             func_ov102_0214d1f8(c, &data_ov102_0214ea78);
-            *(u32 *)(int)(((long long)(int)(c + 0xb0))) &= ~0x80000;
-            *(u8 *)(c + 0x107) = 0;
+            *(u32 *)(int)(((long long)(int)((char *)&mFlags))) &= ~0x80000;
+            unk_107 = 0;
         }
         func_ov102_0214ce60(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x110);
+        _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
         return 1;
     }
 
-    if (*(u8 *)(c + 0x3c6) != 0 &&
-        *(void **)(c + 0x3ac) == (void *)&data_ov102_0214ea68) {
-        if (DecIfAbove0_Byte(c + 0x3c6) == 0) {
+    if (mDespawnTimer != 0 &&
+        mState == (void *)&data_ov102_0214ea68) {
+        if (DecIfAbove0_Byte((char *)&mDespawnTimer) == 0) {
             _ZN9ActorBase18MarkForDestructionEv(c);
             return 1;
         }
     } else {
-        *(u8 *)(c + 0x3c6) = 0;
+        mDespawnTimer = 0;
     }
 
-    DecIfAbove0_Short(c + 0x100);
+    DecIfAbove0_Short((char *)&unk_100);
 
     {
-        EState *st = *(EState **)(c + 0x3ac);
+        EState *st = (EState *)mState;
         int res;
         if (*(int *)&st->fn == 0)
             res = 1;
@@ -78,36 +102,35 @@ int _ZN10KoopaShell8BehaviorEv(char *c)
 
     func_ov102_0214cbec(c);
 
-    if (*(u32 *)(c + 0x9c) != 0) {
-        _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
-        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x144, 0);
-        if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x144) != 0 ||
-            _ZNK12WithMeshClsn8IsOnWallEv(c + 0x144) != 0) {
-            if (_ZNK12WithMeshClsn8IsOnWallEv(c + 0x144) != 0) {
-                if (*(void **)(c + 0x3ac) == (void *)&data_ov102_0214ea78) {
+    if (mSpeed != 0) {
+        _ZN5Actor9UpdatePosEP12CylinderClsn(c, (char *)&mCylinderClsn);
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (char *)&mMeshClsn, 0);
+        if (_ZNK12WithMeshClsn10IsOnGroundEv((char *)&mMeshClsn) != 0 ||
+            _ZNK12WithMeshClsn8IsOnWallEv((char *)&mMeshClsn) != 0) {
+            if (_ZNK12WithMeshClsn8IsOnWallEv((char *)&mMeshClsn) != 0) {
+                if (mState == (void *)&data_ov102_0214ea78) {
                     _ZN5Actor8PoofDustEv(c);
                     _ZN9ActorBase18MarkForDestructionEv(c);
                     return 0;
                 }
             }
-            if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x144) != 0) {
-                if (*(void **)(c + 0x3ac) == (void *)&data_ov102_0214ea68) {
-                    *(u32 *)(c + 0x9c) = 0;
-                    *(u32 *)(c + 0xa8) = 0;
+            if (_ZNK12WithMeshClsn10IsOnGroundEv((char *)&mMeshClsn) != 0) {
+                if (mState == (void *)&data_ov102_0214ea68) {
+                    mSpeed = 0;
+                    mVertSpeed = 0;
                 }
-                if (*(void **)(c + 0x3ac) != (void *)&data_ov102_0214ea48 &&
-                    *(void **)(c + 0x3ac) != (void *)&data_ov102_0214ea58)
+                if (mState != (void *)&data_ov102_0214ea48 &&
+                    mState != (void *)&data_ov102_0214ea58)
                     func_ov102_0214c7fc(c);
             }
         }
     }
 
-    if (*(u8 *)(c + 0x3c4) == 0)
+    if (mModelIndex == 0)
         func_ov102_0214c84c(c);
     func_ov102_0214ce60(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x110);
-    if (*(void **)(c + 0x3ac) != (void *)&data_ov102_0214ea48)
-        _ZN12CylinderClsn6UpdateEv(c + 0x110);
+    _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
+    if (mState != (void *)&data_ov102_0214ea48)
+        _ZN12CylinderClsn6UpdateEv((char *)&mCylinderClsn);
     return 1;
-}
 }


### PR DESCRIPTION
Stacked on #1315. Top of the stack.

The whole class except its structors, taken as one slice **because the ROM says it is one**: `tu_map.py` puts ov102 `0x0214c748-0x0214d70c` at 24 functions with KoopaShell the only class in it, so there is no file here to split.

### include/KoopaShell.h is new

The class had no header at all. Written by hand rather than by `gen_header.py`, whose history/hierarchy/rom passes are not available in this tree (it reports `passes run: NONE`). 28 fields, every offset checked by `check_header_offsets`, struct spans `0x3d8`.

**KoopaShell derives from Enemy** — `Behavior` calls `Enemy::UpdateYoshiEat` and `Enemy::UpdateWMClsn` on itself, and `Enemy` spans exactly `0x110`, which is where this class's own sub-objects begin. The header is still written **flat**, with the inherited slots restated, because that is what every other generated header here does and `Enemy.h` asserts no size for a derived struct to build on. Restating a base is a real cost, recorded in the header; re-basing the family is its own slice.

Four sub-objects are byte markers (`mCylinderClsn` `0x110`, `mMeshClsn` `0x144`, `mModel` `0x300`, `mShadowModel` `0x350`). Their sizes are fixed by the next marker's offset, which is what the ROM evidences, and none of the five functions needs a view into one. `0x110` is initialised as a `MovingCylinderClsn` and later driven through `CylinderClsn::Clear`/`Update`, so the moving flavour derives from the plain one.

### Behaviour recovered while naming the fields

- **One spawn word does double duty** — `mSpawnParam` bit 0 selects which of two shared model files to load (kept in `mModelIndex` so `CleanupResources` releases the same one) and bit 4 becomes a behaviour variant.
- **`Render` blinks rather than hides**: below `0x2d` the shell is skipped on *odd* values of `mDespawnTimer`, so it flashes at half frame rate for its last 45 frames — and the flashing therefore starts partway through the countdown, not at the beginning.
- The despawn countdown runs in **exactly one state**; in any other it is reset to 0, so a shell picked back up stops expiring.
- **`OnPendingDestroy` is empty in the ROM** — a single `bx lr`. The override exists to *suppress* the base's behaviour, so the empty body is the finding, not a stub.

### Verification

Build pin derived for this family, not inherited: all five baseline at `2004/b56` and all five still match there as methods.

| gate | result |
|---|---|
| `build_pin.verify` × 5 | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket | identical set |
| header offsets | 28 fields, 0 mismatched, spans `0x3d8` |
| port_refcheck / dup / data-defs / langmode / attribution | all clean |

Byte-identical on the first attempt; no greedy search needed.

### Stack total

Across #1313–#1316, unmigrated **1013 → 995**, methods **487 → 469**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS