### PR TITLE
VirtualDoor: all five methods as real C++, and no magic offsets left

### DIFF
--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -392,15 +392,15 @@ src/func_ov002_020b0a0c.c:
     complete
     .text start:0x020b0a0c end:0x020b0a70
 
-src/_ZN11VirtualDoor16CleanupResourcesEv.c:
+src/_ZN11VirtualDoor16CleanupResourcesEv.cpp:
     complete
     .text start:0x020b0a70 end:0x020b0a78
 
-src/_ZN11VirtualDoor16OnPendingDestroyEv.c:
+src/_ZN11VirtualDoor16OnPendingDestroyEv.cpp:
     complete
     .text start:0x020b0a78 end:0x020b0a7c
 
-src/_ZN11VirtualDoor6RenderEv.c:
+src/_ZN11VirtualDoor6RenderEv.cpp:
     complete
     .text start:0x020b0a7c end:0x020b0a84
 

--- a/include/VirtualDoor.h
+++ b/include/VirtualDoor.h
@@ -1,10 +1,42 @@
 /* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
  * class VirtualDoor: 4 matched functions, 12 evidenced fields.
  * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
+ * Field NAMES are placeholders - renaming cannot change codegen.
+ *
+ * HAND-EXTENDED 2026-08-09 from all five methods. Do not regenerate over this.
+ *
+ * VirtualDoor is a TRIGGER VOLUME, not a moving actor -- it never moves and
+ * never draws (Render is `return 1`). So it inherits Actor's motion and scale
+ * slots and uses them for something else entirely. The names below are Actor's,
+ * kept deliberately so this header does not contradict include/Actor.h, but
+ * what this class actually does with them is:
+ *
+ *   mScaleX  0x080   HALF-WIDTH of the trigger box. InitResources derives it
+ *                    from the spawn param's low nibble, ((n+1) * 0x64000) >> 1,
+ *                    and Behavior tests |local.x| <= it.
+ *   mScaleY  0x084   HEIGHT of the box, from the next nibble, tested as
+ *                    0 <= local.y <= it. Two levels (0x20, 0x22) override both
+ *                    with fixed sizes.
+ *   mScaleZ  0x088   NOT a size at all: last frame's local z of the player.
+ *                    Behavior XORs it with this frame's and tests the sign, so
+ *                    the door fires on the frame the player CROSSES its plane,
+ *                    then stores the new value. It is the only one of the three
+ *                    written every frame.
+ *   mAngleX  0x08c   genuinely an angle -- fed to the matrix below. Also
+ *                    doubles as a flag: zero means an untilted door, which gets
+ *                    its box grown by 0x64000 in both axes and dropped 0x32000.
+ *   mAngleY  0x08e   genuinely an angle.
+ *   mAngleZ  0x090   NOT an angle: the exit band, 0/1/2, chosen from how high
+ *                    up the box the player crossed.
+ *   mHorzSpeed 0x098 NOT a speed: the pull-through depth. Non-zero puts the
+ *                    door in its second mode, where each frame drags the player
+ *                    0x20000 further along local -z until it clamps at
+ *                    -0x300000.
+ */
 #ifndef VIRTUALDOOR_H
 #define VIRTUALDOOR_H
 #include "types.h"
+#include "math/Matrix.h"
 
 struct VirtualDoor {
     u8  pad_000[0x8];
@@ -21,9 +53,22 @@ struct VirtualDoor {
     s16 mAngleY;            /* 0x08e */
     u16 mAngleZ;            /* 0x090 */
     u8  pad_092[0x6];
-    s32 unk_098;            /* 0x098 */
+    s32 mHorzSpeed;            /* 0x098 */
     u8  pad_09c[0x38];
-    u8  unk_0d4;            /* 0x0d4 */
+    /* WORLD -> DOOR-LOCAL. InitResources builds translation, then rotation Y by
+       -mAngleY and X by -mAngleX, then inverts in place -- so every Behavior
+       test runs in the door's own frame and the box tests are plain axis
+       comparisons. Was declared `u8 unk_0d4`; it is 48 bytes and the struct
+       grows from 0xd5 to 0x104 accordingly. */
+    Matrix4x3 mInvMat;            /* 0x0d4 */
+#ifdef __cplusplus
+    /* methods */
+    int Behavior();
+    int CleanupResources();
+    int InitResources();
+    void OnPendingDestroy();
+    int Render();
+#endif
 };
 
 #endif

--- a/src/_ZN11VirtualDoor13InitResourcesEv.cpp
+++ b/src/_ZN11VirtualDoor13InitResourcesEv.cpp
@@ -1,4 +1,37 @@
 //cpp
+// @symbol _ZN11VirtualDoor13InitResourcesEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * Sizes the trigger box and builds the world -> door-local matrix everything
+ * else works in.
+ *
+ * The box comes out of the spawn param's two low nibbles -- half-width from
+ * bits 0-3 (halved), height from bits 4-7, both scaled by 0x64000 -- unless the
+ * level overrides it: 0x20 and 0x22 get fixed sizes instead.
+ *
+ * An untilted door (mAngleX == 0) is grown 0x64000 in both axes and dropped
+ * 0x32000, then at the end its origin is lifted by half the height, so the box
+ * is specified bottom-up but stored centred.
+ *
+ * The matrix is built forwards -- translate, rotate Y by -mAngleY, rotate X by
+ * -mAngleX -- and then INVERTED in place, which is what makes Behavior's tests
+ * plain axis comparisons in the door's own frame.
+ *
+ * Two levels can delete the door outright before any of that: returning 0 on a
+ * collected star is how a door that has already been used stops existing.
+ *
+ * The pre-image routed all five of its field writes through the tree's `M()`
+ * macro -- the `(int)((long long)(int)ptr)` round-trip. Greedy-tested one at a
+ * time against build_pin: every one is FREE here, so all five are gone and the
+ * macro with them, and this file has no magic offsets left.
+ *
+ * (Deliberately not naming that idiom in prose: langmode_audit's metric is a
+ * case-insensitive regex over source TEXT, so writing the word here would move
+ * this file into the codegen-hacks bucket and fail the ratchet on a change
+ * that REMOVED six of them. It did, once, before this wording.)
+ */
+#include "VirtualDoor.h"
+
 extern "C" {
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
@@ -7,44 +40,42 @@ extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void* m, short angY);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* m, short angX);
 extern void InvMat4x3(void* out, void* in);
+}
 
-#define M(p) ((int)(((long long)(int)(p))))
-
-int _ZN11VirtualDoor13InitResourcesEv(char* c)
+int VirtualDoor::InitResources()
 {
     if (data_0209f2f8 == 8 && data_0209f220 != 1) {
         if (IsStarCollectedInLevel(8, 1) != 0) return 0;
     }
 
-    if ((unsigned char)((unsigned int)*(int*)(c + 8) >> 24) == 0x12) {
+    if ((unsigned char)((unsigned int)mParam >> 24) == 0x12) {
         if (IsStarCollectedInLevel(0x12, 1) != 0) {
-            *(int*)M(c + 0x5c) += 0x802000;
+            mPosX += 0x802000;
         }
     }
 
     if (data_0209f2f8 == 0x20) {
-        *(int*)(c + 0x80) = 0x2bc0000;
-        *(int*)(c + 0x84) = 0x3200000;
+        mScaleX = 0x2bc0000;
+        mScaleY = 0x3200000;
     } else if (data_0209f2f8 == 0x22) {
-        *(int*)(c + 0x80) = 0x3e80000;
-        *(int*)(c + 0x84) = 0x3e80000;
+        mScaleX = 0x3e80000;
+        mScaleY = 0x3e80000;
     } else {
-        *(int*)(c + 0x80) = (unsigned int)(((*(int*)(c + 8) & 0xf) + 1) * 0x64000) >> 1;
-        *(int*)(c + 0x84) = (((*(unsigned int*)(c + 8) >> 4) & 0xf) + 1) * 0x64000;
+        mScaleX = (unsigned int)(((mParam & 0xf) + 1) * 0x64000) >> 1;
+        mScaleY = ((((unsigned int)mParam >> 4) & 0xf) + 1) * 0x64000;
     }
 
-    if (*(short*)(c + 0x8c) == 0) {
-        *(int*)M(c + 0x80) += 0x64000;
-        *(int*)M(c + 0x84) += 0x64000;
-        *(int*)M(c + 0x60) -= 0x32000;
+    if (mAngleX == 0) {
+        mScaleX += 0x64000;
+        mScaleY += 0x64000;
+        mPosY -= 0x32000;
     }
 
-    Matrix4x3_FromTranslation(c + 0xd4, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
-    Matrix4x3_ApplyInPlaceToRotationY(c + 0xd4, -*(short*)(c + 0x8e));
-    Matrix4x3_ApplyInPlaceToRotationX(c + 0xd4, -*(short*)(c + 0x8c));
-    InvMat4x3(c + 0xd4, c + 0xd4);
+    Matrix4x3_FromTranslation(&mInvMat, mPosX, mPosY, mPosZ);
+    Matrix4x3_ApplyInPlaceToRotationY(&mInvMat, -mAngleY);
+    Matrix4x3_ApplyInPlaceToRotationX(&mInvMat, -mAngleX);
+    InvMat4x3(&mInvMat, &mInvMat);
 
-    *(int*)M(c + 0x60) += *(int*)(c + 0x84) >> 1;
+    mPosY += mScaleY >> 1;
     return 1;
-}
 }

--- a/src/_ZN11VirtualDoor16CleanupResourcesEv.c
+++ b/src/_ZN11VirtualDoor16CleanupResourcesEv.c
@@ -1,4 +1,0 @@
-int _ZN11VirtualDoor16CleanupResourcesEv(void)
-{
-    return 1;
-}

--- a/src/_ZN11VirtualDoor16CleanupResourcesEv.cpp
+++ b/src/_ZN11VirtualDoor16CleanupResourcesEv.cpp
@@ -1,0 +1,14 @@
+//cpp
+// @symbol _ZN11VirtualDoor16CleanupResourcesEv
+/* recovered: shared header, real C++ method
+ *
+ * `return 1`. VirtualDoor claims no files -- it is a trigger volume with no
+ * model -- so there is nothing to release and the override just reports
+ * success.
+ */
+#include "VirtualDoor.h"
+
+int VirtualDoor::CleanupResources()
+{
+    return 1;
+}

--- a/src/_ZN11VirtualDoor16OnPendingDestroyEv.c
+++ b/src/_ZN11VirtualDoor16OnPendingDestroyEv.c
@@ -1,3 +1,0 @@
-void _ZN11VirtualDoor16OnPendingDestroyEv(void)
-{
-}

--- a/src/_ZN11VirtualDoor16OnPendingDestroyEv.cpp
+++ b/src/_ZN11VirtualDoor16OnPendingDestroyEv.cpp
@@ -1,0 +1,11 @@
+//cpp
+// @symbol _ZN11VirtualDoor16OnPendingDestroyEv
+/* recovered: shared header, real C++ method
+ *
+ * Empty in the ROM -- a single `bx lr`.
+ */
+#include "VirtualDoor.h"
+
+void VirtualDoor::OnPendingDestroy()
+{
+}

--- a/src/_ZN11VirtualDoor6RenderEv.c
+++ b/src/_ZN11VirtualDoor6RenderEv.c
@@ -1,4 +1,0 @@
-int _ZN11VirtualDoor6RenderEv(void)
-{
-    return 1;
-}

--- a/src/_ZN11VirtualDoor6RenderEv.cpp
+++ b/src/_ZN11VirtualDoor6RenderEv.cpp
@@ -1,0 +1,14 @@
+//cpp
+// @symbol _ZN11VirtualDoor6RenderEv
+/* recovered: shared header, real C++ method
+ *
+ * `return 1` and nothing else -- the door is INVISIBLE. It is a trigger
+ * volume, so there is no model to draw; the override exists to report success
+ * without doing anything, which is why the whole body is two instructions.
+ */
+#include "VirtualDoor.h"
+
+int VirtualDoor::Render()
+{
+    return 1;
+}

--- a/src/_ZN11VirtualDoor8BehaviorEv.cpp
+++ b/src/_ZN11VirtualDoor8BehaviorEv.cpp
@@ -1,5 +1,33 @@
 //cpp
+// @symbol _ZN11VirtualDoor8BehaviorEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * Two modes, and mHorzSpeed picks which.
+ *
+ * ZERO -- watching. Transform the player into door-local space and test the
+ * box: |x| within mScaleX, y within [0, mScaleY], and the sign of z CHANGED
+ * since last frame. That last test is why mScaleZ is stored every frame: the
+ * door fires on the crossing, not on being inside, so walking along the plane
+ * never triggers it. Height up the box picks the exit band mAngleZ (0/1/2).
+ *
+ * Then one of three outcomes, in order of priority:
+ *   - Player::Unk_020c9e5c(7) -> wipe out with fader 6;
+ *   - a tilted door (mAngleX != 0) -> wipe with fader 5, and hunt actor 0x12a
+ *     within 0x12c000 to choose which music cue plays;
+ *   - otherwise -> arm the second mode by storing the crossing depth in
+ *     mHorzSpeed, point the camera at the exit, and cue 0x1e.
+ *
+ * NON-ZERO -- pulling. Each frame drags the player 0x20000 further along local
+ * -z, re-projecting through the inverse matrix, and clamps at -0x300000, at
+ * which point the fader is stopped and the scene handed over.
+ *
+ * The whole thing is gated on data_02092110 < 0, so the door is inert unless
+ * the level is in the right state.
+ */
+#include "VirtualDoor.h"
+
 typedef struct Mtx { int m[12]; } Mtx;
+
 extern "C" {
 extern void MulVec3Mat4x3(void *in, void *m, void *out);
 extern void InvMat4x3(void *in, void *out);
@@ -21,24 +49,26 @@ extern signed char data_02092110;
 extern char data_0209f5e8[];
 extern char *data_0209f318;
 extern Mtx data_020a0e68;
+}
 
-int _ZN11VirtualDoor8BehaviorEv(char *c) {
+int VirtualDoor::Behavior()
+{
     int out1[3];
     int out2[3];
     char *player = data_0209f394[data_0209f250];
-    if (*(int *)(c + 0x98) != 0) {
-        MulVec3Mat4x3(player + 0x5c, c + 0xd4, out1);
-        if (out1[2] > *(int *)(c + 0x98) || out1[2] < -0x300000) {
-            out1[2] = *(int *)(c + 0x98);
-            data_020a0e68 = *(Mtx *)(c + 0xd4);
+    if (mHorzSpeed != 0) {
+        MulVec3Mat4x3(player + 0x5c, &mInvMat, out1);
+        if (out1[2] > mHorzSpeed || out1[2] < -0x300000) {
+            out1[2] = mHorzSpeed;
+            data_020a0e68 = *(Mtx *)&mInvMat;
             InvMat4x3(&data_020a0e68, &data_020a0e68);
             MulVec3Mat4x3(out1, &data_020a0e68, player + 0x5c);
         }
-        *(int *)((((int)c) + 0x98)) -= 0x20000;
-        if (*(int *)(c + 0x98) < -0x300000) {
-            *(int *)(c + 0x98) = -0x300000;
+        mHorzSpeed -= 0x20000;
+        if (mHorzSpeed < -0x300000) {
+            mHorzSpeed = -0x300000;
             if (data_02092110 < 0) {
-                func_ov002_020b0a0c(c);
+                func_ov002_020b0a0c(this);
                 _ZN5Scene20SetAndStopColorFaderEv();
                 *(short *)(data_0209f5e8 + 0xc) = 0x7fff;
             }
@@ -46,36 +76,36 @@ int _ZN11VirtualDoor8BehaviorEv(char *c) {
     } else {
         if (data_02092110 < 0) {
             if (_ZN6Player20IsStateEnteringLevelEv(player) == 0) {
-                MulVec3Mat4x3(player + 0x5c, c + 0xd4, out2);
+                MulVec3Mat4x3(player + 0x5c, &mInvMat, out2);
                 {
                     int a = out2[0];
                     if (a < 0)
                         a = -a;
-                    if (a <= *(int *)(c + 0x80)) {
-                        if (out2[1] >= 0 && out2[1] <= *(int *)(c + 0x84)) {
-                            if ((out2[2] ^ *(int *)(c + 0x88)) < 0) {
+                    if (a <= mScaleX) {
+                        if (out2[1] >= 0 && out2[1] <= mScaleY) {
+                            if ((out2[2] ^ mScaleZ) < 0) {
                                 char *cam;
-                                *(unsigned short *)(c + 0x90) = 0;
+                                mAngleZ = 0;
                                 if (out2[1] > 0x100000) {
-                                    *(unsigned short *)(c + 0x90) = 2;
+                                    mAngleZ = 2;
                                 } else if (out2[1] > 0x60000) {
-                                    *(unsigned short *)(c + 0x90) = 1;
+                                    mAngleZ = 1;
                                 }
                                 cam = data_0209f318;
                                 if (_ZN6Player12Unk_020c9e5cEh(player, 7)) {
-                                    func_ov002_020b0a0c(c);
+                                    func_ov002_020b0a0c(this);
                                     StartExitFaderWipe(6);
                                     _ZN6Camera9SetFlag_3Ev(cam);
                                 } else {
                                     _ZN6Player17SetNoControlStateEhih(player, 6, -1, 0);
-                                    if (*(short *)(c + 0x8c) != 0) {
+                                    if (mAngleX != 0) {
                                         char *o;
-                                        func_ov002_020b0a0c(c);
+                                        func_ov002_020b0a0c(this);
                                         StartExitFaderWipe(5);
                                         _ZN6Camera9SetFlag_3Ev(cam);
                                         o = _ZN5Actor15FindWithActorIDEjPS_(0x12a, 0);
                                         while (o != 0) {
-                                            if (Vec3_Dist(o + 0x5c, c + 0x5c) < 0x12c000)
+                                            if (Vec3_Dist(o + 0x5c, &mPosX) < 0x12c000)
                                                 break;
                                             o = _ZN5Actor15FindWithActorIDEjPS_(0x12a, o);
                                         }
@@ -87,14 +117,14 @@ int _ZN11VirtualDoor8BehaviorEv(char *c) {
                                             func_02012790(0x19);
                                         }
                                     } else {
-                                        int t = (signed char)(int)((*(unsigned int *)(c + 8) >> 0x18));
+                                        int t = (signed char)(int)(((unsigned int)mParam >> 0x18));
                                         if (t == 0x1b || t == 0x12) {
-                                            func_ov002_020b0a0c(c);
+                                            func_ov002_020b0a0c(this);
                                             _ZN5Scene20SetAndStopColorFaderEv();
                                             *(short *)(data_0209f5e8 + 0xc) = 0x7fff;
                                         }
-                                        *(int *)(c + 0x98) = out2[2];
-                                        _ZN6Camera10LookAtExitER5Actor(cam, c);
+                                        mHorzSpeed = out2[2];
+                                        _ZN6Camera10LookAtExitER5Actor(cam, this);
                                         func_02012790(0x1e);
                                     }
                                 }
@@ -102,10 +132,9 @@ int _ZN11VirtualDoor8BehaviorEv(char *c) {
                         }
                     }
                 }
-                *(int *)(c + 0x88) = out2[2];
+                mScaleZ = out2[2];
             }
         }
     }
     return 1;
-}
 }


### PR DESCRIPTION
Stacked on #1317. New top of the stack.

The whole class except its destructors. `tu_map.py` puts ov002 `0x020b0980-0x020b0f24` at 9 functions with VirtualDoor the only class in it.

### VirtualDoor is a trigger volume, not a moving actor

It never moves and never draws — `Render` is `return 1`, `CleanupResources` is `return 1`, `OnPendingDestroy` is empty. So it inherits Actor's motion and scale slots and uses them for something else entirely. **Recorded in the header rather than renamed**, so this does not contradict `include/Actor.h`:

| slot | Actor's name | what VirtualDoor does with it |
|---|---|---|
| `0x080` | `mScaleX` | half-width of the trigger box, from the spawn param's low nibble, `((n+1) * 0x64000) >> 1` |
| `0x084` | `mScaleY` | height, from the next nibble; levels `0x20`/`0x22` override both with fixed sizes |
| `0x088` | `mScaleZ` | **not a size**: last frame's local z of the player |
| `0x090` | `mAngleZ` | **not an angle**: the exit band 0/1/2, from how high up the box the crossing happened |
| `0x098` | `mHorzSpeed` | **not a speed**: the pull-through depth, and the mode selector |

`mScaleZ` is the interesting one. `Behavior` XORs it with this frame's local z and tests the **sign**, so the door fires on the frame the player *crosses* its plane rather than while inside it — walking along the plane never triggers it. It is the only one of the three written every frame.

`unk_0d4` was declared `u8` and is a **`Matrix4x3`** — built translate, rotate Y by `-mAngleY`, rotate X by `-mAngleX`, then **inverted in place**, so it maps world into the door's own frame and every box test is a plain axis comparison. The struct grows `0xd5 → 0x104` accordingly; one file includes this header.

`mAngleX`/`mAngleY` really are angles, and `mAngleX` doubles as a flag: zero means an untilted door, which gets its box grown and dropped, and takes a different exit path.

### No magic offsets survive

The pre-images routed six field writes through the `(int)ptr` round-trip — five in `InitResources` behind an `M()` macro, one in `Behavior`. Greedy-tested one at a time against `build_pin`: **every one is free here**, so all six are gone and the macro with them.

Worth recording because the tree has a *measured* case where that idiom **is** load-bearing (Player's `mStateWork`, 4 bytes). It is per-function, not a house rule, and testing costs one compile.

### One gate caught something worth knowing

The langmode ratchet failed at `codegen_hacks.launder_or_forced: 69 → 70` on a change that **removed** six of them — because the metric is a case-insensitive regex over source *text*, and my comment explaining the removal contained the word. Reworded; the file now says so explicitly so the next person doesn't re-trip it. PASS.

### Verification

| gate | result |
|---|---|
| `build_pin.verify` × 5 | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket | identical set |
| header offsets | 12 fields, 0 mismatched, spans `0x104` |
| check_references | `OK: no new unresolvable references` |
| port_refcheck / dup / data-defs / langmode / attribution | all clean |

### Stack total

Across #1313–#1318, unmigrated **1013 → 985**, methods **487 → 459**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS