### PR TITLE
Skeeter: all four remaining methods as real C++

### DIFF
--- a/config/arm9/overlays/ov090/delinks.txt
+++ b/config/arm9/overlays/ov090/delinks.txt
@@ -66,11 +66,11 @@ src/func_ov090_02131e50.c:
     complete
     .text start:0x02131e50 end:0x02131edc
 
-src/_ZN7Skeeter16CleanupResourcesEv.c:
+src/_ZN7Skeeter16CleanupResourcesEv.cpp:
     complete
     .text start:0x02131edc end:0x02131f30
 
-src/_ZN7Skeeter16OnPendingDestroyEv.c:
+src/_ZN7Skeeter16OnPendingDestroyEv.cpp:
     complete
     .text start:0x02131f30 end:0x02131f34
 

--- a/include/Skeeter.h
+++ b/include/Skeeter.h
@@ -18,18 +18,34 @@ struct Skeeter {
     s32 mScaleX;            /* 0x080 */
     s32 mScaleY;            /* 0x084 */
     s32 mScaleZ;            /* 0x088 */
-    u8  pad_08c[0x2];
+    s16 mAngleX;            /* 0x08c */
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x4];
     s16 mPrevAngleY;            /* 0x094 */
-    u8  pad_096[0x6];
+    u8  pad_096[0x2];
+    s32 unk_098;            /* 0x098 */
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
-    u8  pad_0a4[0x64];
+    s32 unk_0a4;            /* 0x0a4 */
+    s32 unk_0a8;            /* 0x0a8 */
+    s32 unk_0ac;            /* 0x0ac */
+    u32 mFlags;            /* 0x0b0 */
+    u8  pad_0b4[0x18];
+    s8  unk_0cc;            /* 0x0cc */
+    u8  pad_0cd[0x33];
+    u16 unk_100;            /* 0x100 */
+    u8  pad_102[0x2];
+    u16 unk_104;            /* 0x104 */
+    u8  pad_106[0x1];
+    u8  unk_107;            /* 0x107 */
     u8  unk_108;            /* 0x108 */
     u8  pad_109[0x1];
     u8  unk_10a;            /* 0x10a */
-    u8  pad_10b[0x5];
+    u8  pad_10b[0x1];
+    /* Death/hit state. Zero is alive; non-zero routes Behavior into the death
+       branch, and 1 specifically is the state func_020aea30 installs when the
+       skeeter is knocked out over water. */
+    s32 unk_10c;            /* 0x10c */
     /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
        MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN7SkeeterD1Ev.c] */
@@ -43,20 +59,30 @@ struct Skeeter {
        ran 0x4 bytes PAST the end of the object; that space is not evidenced and stays
        explicit padding rather than being folded into the member. */
     ModelAnim mModelAnim;            /* 0x30c */
-    u8  pad_370[0x4];
+    /* Current state: a record whose third word is a pointer-to-member tick,
+       null-checked before the call. func_ov090_02131e00 installs one. */
+    void* mState;            /* 0x370 */
     s32 unk_374;            /* 0x374 */
     s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */
-    u8  pad_380[0x1c];
+    u8  pad_380[0x14];
+    u16 unk_394;            /* 0x394 */
+    u16 unk_396;            /* 0x396 */
+    u16 unk_398;            /* 0x398 */
+    u16 unk_39a;            /* 0x39a */
     u8  unk_39c;            /* 0x39c */
-    u8  pad_39d[0x7];
+    u8  pad_39d[0x4];
+    u8  unk_3a1;            /* 0x3a1 */
+    u8  pad_3a2[0x2];
     s32 unk_3a4;            /* 0x3a4 */
     s32 unk_3a8;            /* 0x3a8 */
     s32 unk_3ac;            /* 0x3ac */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
+    int CleanupResources();
     int InitResources();
+    void OnPendingDestroy();
     int Render();
 #endif
 };

--- a/src/_ZN7Skeeter13InitResourcesEv.cpp
+++ b/src/_ZN7Skeeter13InitResourcesEv.cpp
@@ -1,35 +1,61 @@
 //cpp
-typedef int Fix12;
-typedef struct { int w[2]; } SharedFilePtr;
-typedef struct { short x,y,z; } Vector3_16;
-typedef struct { int x,y,z; } Vector3;
+// @symbol _ZN7Skeeter13InitResourcesEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * Loads the model and four animations, builds both collision volumes, and then
+ * FINDS THE WATER LINE -- which is the part that matters.
+ *
+ * It raycasts straight down from 0x32000 above the spawn point using a local
+ * RaycastGround, and what it does with the hit depends on a surface flag: a
+ * 0x20 surface sets unk_39c and only records the height, while any other
+ * surface records it as both unk_3a8 and unk_3ac. mPosY is then snapped to
+ * unk_3ac, so the skeeter starts exactly on the surface it found.
+ *
+ * Two early exits skip the raycast entirely: one level/mode combination
+ * (0x12 in mode 2) and the flagged-surface case both install a different
+ * starting state and return.
+ *
+ * Otherwise the heading is randomised -- four bits of RandomIntInternal shifted
+ * into the top of a s16 -- and written through mModelAnim's own angle slot
+ * before being published to mPrevAngleY and mAngleY.
+ *
+ * The local typedefs are renamed Loc* rather than deleted: the shared header
+ * supplies the real Fix12/Vector3/SharedFilePtr, but these calls take the ROM's
+ * by-value Fix12<int> signatures, which mwccarm passes differently -- the 6az
+ * wall, notes/mwccarm-codegen.md.
+ */
+#include "Skeeter.h"
+typedef int LocFix12;
+typedef struct { int w[2]; } LocSharedFilePtr;
+typedef struct { short x,y,z; } LocVector3_16;
+typedef struct { int x,y,z; } LocVec3;
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 struct C; typedef int (C::*PMF)();
 struct RG { char a[0x14]; int detect[16]; };
 
 extern "C" {
-BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
+BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(LocSharedFilePtr* f);
 void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
-void _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
-void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, Actor* a, Vector3* v, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
-void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Vector3_16* q);
+void _ZN9Animation8LoadFileER13SharedFilePtr(LocSharedFilePtr* f);
+void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, Actor* a, LocVec3* v, LocFix12 r, LocFix12 h, unsigned int e, unsigned int g);
+void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, LocFix12 r, LocFix12 h, LocVector3_16* p, LocVector3_16* q);
 void func_0203558c(void* self);
 int func_ov090_02131e00(void* c, PMF* p);
 void _ZN13RaycastGroundC1Ev(RG* self);
 void _ZN4BgCh19StartDetectingWaterEv(RG* self);
-void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RG* self, const Vector3* v, Actor* a);
+void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RG* self, const LocVec3* v, Actor* a);
 int _ZN13RaycastGround10DetectClsnEv(RG* self);
 int SurfaceInfo_TestFlag0x20(int* p);
 void _ZN13RaycastGroundD1Ev(RG* self);
 int RandomIntInternal(int* seed);
 
-extern SharedFilePtr data_ov090_021344a0;
-extern SharedFilePtr data_ov090_02134488;
-extern SharedFilePtr data_ov090_02134480;
-extern SharedFilePtr data_ov090_02134490;
-extern SharedFilePtr data_ov090_02134498;
-extern Vector3 data_ov090_0213412c;
+extern LocSharedFilePtr data_ov090_021344a0;
+extern LocSharedFilePtr data_ov090_02134488;
+extern LocSharedFilePtr data_ov090_02134480;
+extern LocSharedFilePtr data_ov090_02134490;
+extern LocSharedFilePtr data_ov090_02134498;
+extern LocVec3 data_ov090_0213412c;
 extern unsigned char data_0209f2d8;
 extern signed char data_0209f2f8;
 extern PMF data_ov090_021344f4;
@@ -38,48 +64,49 @@ extern int data_0209e650;
 extern PMF data_ov090_021344e4;
 }
 
-extern "C" int _ZN7Skeeter13InitResourcesEv(char* c)
+int Skeeter::InitResources()
 {
+    char* c = (char*)this;
     BMD_File* f;
     RG rg;
     int r;
-    Vector3 pos;
-    Vector3 v;
+    LocVec3 pos;
+    LocVec3 v;
 
     f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov090_021344a0);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x30c, f, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(&mModelAnim, f, 1, -1);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov090_02134488);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov090_02134480);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov090_02134490);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov090_02134498);
 
-    *(int*)(c+0xa0) = -0x3c000;
+    unk_0a0 = -0x3c000;
 
     v.x = data_ov090_0213412c.x;
     v.y = data_ov090_0213412c.y;
     v.z = data_ov090_0213412c.z;
-    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c+0x110, (Actor*)c, &v, 0x5a000, 0x5a000, 0x200000, 0x7eff0);
+    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(&mMovingCylinderClsnWithPos, (Actor*)c, &v, 0x5a000, 0x5a000, 0x200000, 0x7eff0);
 
-    *(short*)(c+0x8e) = *(short*)(c+0x94);
-    *(int*)(c+0x3a4) = 0x1000;
-    *(int*)(c+0x80) = 0x1000;
-    *(int*)(c+0x84) = 0x1000;
-    *(int*)(c+0x88) = 0x1000;
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c+0x150, (Actor*)c, 0xc8000, 0, (Vector3_16*)0, (Vector3_16*)0);
-    func_0203558c(c+0x150);
+    mAngleY = mPrevAngleY;
+    unk_3a4 = 0x1000;
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(&mWithMeshClsn, (Actor*)c, 0xc8000, 0, (LocVector3_16*)0, (LocVector3_16*)0);
+    func_0203558c(&mWithMeshClsn);
 
-    *(unsigned char*)(c+0x108) = 1;
-    *(unsigned char*)(c+0x10a) = 2;
-    *(int*)(c+0x9c) = -0x3000;
+    unk_108 = 1;
+    unk_10a = 2;
+    unk_09c = -0x3000;
 
     {
         int b = 1;
         if (data_0209f2d8 != 2) b = 0;
         if (b != 0 && data_0209f2f8 == 0x12) {
-            *(int*)(c+0x3ac) = *(int*)(c+0x60);
-            *(int*)(c+0x374) = *(int*)(c+0x5c);
-            *(int*)(c+0x378) = *(int*)(c+0x60);
-            *(int*)(c+0x37c) = *(int*)(c+0x64);
+            unk_3ac = mPosY;
+            unk_374 = mPosX;
+            unk_378 = mPosY;
+            unk_37c = mPosZ;
             func_ov090_02131e00(c, &data_ov090_021344f4);
             return 1;
         }
@@ -90,32 +117,32 @@ extern "C" int _ZN7Skeeter13InitResourcesEv(char* c)
         *(int*)((char*)&rg + 0x4c) = 0xbb8000;
         _ZN4BgCh19StartDetectingWaterEv(&rg);
         {
-            int py = *(int*)(c+0x60);
-            int pz = *(int*)(c+0x64);
-            int px = *(int*)(c+0x5c);
+            int py = mPosY;
+            int pz = mPosZ;
+            int px = mPosX;
             int ip = py + 0x32000;
             pos.x = px;
             pos.y = ip;
             pos.z = pz;
         }
         _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, &pos, (Actor*)c);
-        *(int*)(c+0x3a8) = data_02092138;
+        unk_3a8 = data_02092138;
         if (_ZN13RaycastGround10DetectClsnEv(&rg) != 0) {
             if (SurfaceInfo_TestFlag0x20(rg.detect) != 0) {
-                *(unsigned char*)(c+0x39c) = 1;
-                *(int*)(c+0x3ac) = rg.detect[12];
+                unk_39c = 1;
+                unk_3ac = rg.detect[12];
             } else {
-                *(int*)(c+0x3a8) = rg.detect[12];
-                *(int*)(c+0x3ac) = rg.detect[12];
+                unk_3a8 = rg.detect[12];
+                unk_3ac = rg.detect[12];
             }
         }
 
-        *(int*)(c+0x60) = *(int*)(c+0x3ac);
-        *(int*)(c+0x374) = *(int*)(c+0x5c);
-        *(int*)(c+0x378) = *(int*)(c+0x60);
-        *(int*)(c+0x37c) = *(int*)(c+0x64);
+        mPosY = unk_3ac;
+        unk_374 = mPosX;
+        unk_378 = mPosY;
+        unk_37c = mPosZ;
 
-        if (*(unsigned char*)(c+0x39c) != 0) {
+        if (unk_39c != 0) {
             func_ov090_02131e00(c, &data_ov090_021344f4);
             _ZN13RaycastGroundD1Ev(&rg);
             return 1;
@@ -124,9 +151,9 @@ extern "C" int _ZN7Skeeter13InitResourcesEv(char* c)
         {
             r = RandomIntInternal(&data_0209e650);
             short ang = (short)((((unsigned int)r >> 8) & 0xf) << 12);
-            *(short*)(c+0x300+0x9a) = ang;
-            *(short*)(c+0x94) = *(short*)(c+0x300+0x9a);
-            *(short*)(c+0x8e) = *(short*)(c+0x94);
+            *(short*)&unk_39a = ang;
+            mPrevAngleY = *(short*)&unk_39a;
+            mAngleY = mPrevAngleY;
         }
         func_ov090_02131e00(c, &data_ov090_021344e4);
         _ZN13RaycastGroundD1Ev(&rg);

--- a/src/_ZN7Skeeter16CleanupResourcesEv.cpp
+++ b/src/_ZN7Skeeter16CleanupResourcesEv.cpp
@@ -1,10 +1,25 @@
+//cpp
+// @symbol _ZN7Skeeter16CleanupResourcesEv
+/* recovered: shared header, real C++ method
+ *
+ * Releases the five shared files InitResources claimed -- one model and four
+ * animations. Not in claim order, but every one is paired.
+ *
+ * TOUCHES NO FIELD. The ROM body takes no `this`; as a method it now receives
+ * one and ignores it, which measured byte-free.
+ */
+#include "Skeeter.h"
+
+extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int data_ov090_021344a0[];
 extern int data_ov090_02134488[];
 extern int data_ov090_02134480[];
 extern int data_ov090_02134490[];
 extern int data_ov090_02134498[];
-int _ZN7Skeeter16CleanupResourcesEv(void)
+}
+
+int Skeeter::CleanupResources()
 {
     _ZN13SharedFilePtr7ReleaseEv(data_ov090_021344a0);
     _ZN13SharedFilePtr7ReleaseEv(data_ov090_02134488);

--- a/src/_ZN7Skeeter16OnPendingDestroyEv.c
+++ b/src/_ZN7Skeeter16OnPendingDestroyEv.c
@@ -1,3 +1,0 @@
-void _ZN7Skeeter16OnPendingDestroyEv(void)
-{
-}

--- a/src/_ZN7Skeeter16OnPendingDestroyEv.cpp
+++ b/src/_ZN7Skeeter16OnPendingDestroyEv.cpp
@@ -1,0 +1,12 @@
+//cpp
+// @symbol _ZN7Skeeter16OnPendingDestroyEv
+/* recovered: shared header, real C++ method
+ *
+ * Empty in the ROM -- a single `bx lr`. The override exists to suppress the
+ * base's behaviour.
+ */
+#include "Skeeter.h"
+
+void Skeeter::OnPendingDestroy()
+{
+}

--- a/src/_ZN7Skeeter8BehaviorEv.cpp
+++ b/src/_ZN7Skeeter8BehaviorEv.cpp
@@ -1,14 +1,30 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
+// @symbol _ZN7Skeeter8BehaviorEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * One frame of the skeeter -- the water strider -- in four mutually exclusive
+ * branches, each returning 1 on its own: in Yoshi's mouth, killed by a mega
+ * character, dying, or the ordinary tail.
+ *
+ * unk_3ac is the WATER LINE, found once in InitResources by raycasting down.
+ * The ordinary path clamps mPosY UP to it every frame, so the skeeter floats
+ * rather than falls. The death branch reuses the same value as a TEST instead:
+ * dying below the line is what pays out coins, so drowning and being squashed
+ * on the surface end differently.
+ *
+ * Two branches share the same trigger check verbatim -- level 0x15, unk_0cc
+ * == 1, and the mesh reporting water -- and both respond by zeroing the four
+ * motion words and setting unk_10c = 1, the knocked-into-water state.
+ *
+ * The final cylinder Update is gated on the closest player's +0x6fb, so the
+ * skeeter stops colliding while that player is in some state of their own.
+ */
+#include "Skeeter.h"
 
-struct Vector3 { s32 x, y, z; };
+struct CoinVec3 { s32 x, y, z; };
 
-class Actor {};
-typedef void (Actor::*ActorFn)();
+class ActorC {};
+typedef void (ActorC::*ActorFn)();
 struct PmfNode { char pad[8]; ActorFn fn; };
 
 extern "C" {
@@ -36,43 +52,43 @@ void func_ov090_021310b4(void* c);
 extern signed char data_0209f2f8;
 }
 
-extern "C" int _ZN7Skeeter8BehaviorEv(void* self)
+int Skeeter::Behavior()
 {
-    char* c = (char*)self;
+    char* c = (char*)this;
 
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c + 0x150)) {
-        _ZN12CylinderClsn5ClearEv(c + 0x110);
-        if (*(u8*)(c + 0x107) != 0 && *(u16*)(c + 0x104) == 0)
-            _ZN12CylinderClsn6UpdateEv(c + 0x110);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, &mWithMeshClsn)) {
+        _ZN12CylinderClsn5ClearEv(&mMovingCylinderClsnWithPos);
+        if (unk_107 != 0 && unk_104 == 0)
+            _ZN12CylinderClsn6UpdateEv(&mMovingCylinderClsnWithPos);
         func_ov090_02131e50(c);
         return 1;
     }
 
-    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x150, c + 0x30c, 3))
+    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, &mWithMeshClsn, &mModelAnim, 3))
         return 1;
 
-    if (*(s32*)(c + 0x10c) != 0) {
-        func_02035684((int*)(c + 0x150), 0xd2000);
-        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x150, 0);
-        if (_ZN5Enemy11UpdateDeathER12WithMeshClsn(c, c + 0x150))
+    if (unk_10c != 0) {
+        func_02035684((int*)(&mWithMeshClsn), 0xd2000);
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, &mWithMeshClsn, 0);
+        if (_ZN5Enemy11UpdateDeathER12WithMeshClsn(c, &mWithMeshClsn))
             return 1;
         func_ov090_02131378(c);
         func_ov090_02131e50(c);
-        if (*(s32*)(c + 0x10c) == 0)
+        if (unk_10c == 0)
             _ZN5Actor8PoofDustEv(c);
-        if (*(u8*)(c + 0x3a1) == 3) {
-            _Z14ApproachLinearRsss((s16*)(c + 0x8c), -32767, 0x500);
-            if (AngleDiff(*(s16*)(c + 0x8c), -32767) < 0x1000) {
-                s16* p8e = (s16*)(((int)c + 0x8e));
+        if (unk_3a1 == 3) {
+            _Z14ApproachLinearRsss(&mAngleX, -32767, 0x500);
+            if (AngleDiff(*&mAngleX, -32767) < 0x1000) {
+                s16* p8e = &mAngleY;
                 *p8e += 0x1000;
             }
         }
-        if (*(s32*)(c + 0x10c) != 1 && *(s32*)(c + 0x60) <= *(s32*)(c + 0x3ac)) {
-            Vector3 v;
-            v.x = *(s32*)(c + 0x5c);
-            v.y = *(s32*)(c + 0x60);
-            v.z = *(s32*)(c + 0x64);
-            _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(c, &v, *(u8*)(c + 0x10a) + 1, 0xa000, 0);
+        if (unk_10c != 1 && mPosY <= unk_3ac) {
+            CoinVec3 v;
+            v.x = mPosX;
+            v.y = mPosY;
+            v.z = mPosZ;
+            _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(c, &v, unk_10a + 1, 0xa000, 0);
             _ZN5Actor8PoofDustEv(c);
             _ZN5Actor24KillAndTrackInDeathTableEv(c);
         }
@@ -80,19 +96,19 @@ extern "C" int _ZN7Skeeter8BehaviorEv(void* self)
     }
 
     {
-    int flag = (*(s32*)(c + 0xb0) & 8) != 0;
+    int flag = (mFlags & 8) != 0;
     if (flag) {
-        *(s32*)(c + 0x98) = 0;
-        _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
+        unk_098 = 0;
+        _ZN5Actor9UpdatePosEP12CylinderClsn(c, &mMovingCylinderClsnWithPos);
         func_ov090_02131378(c);
-        if (data_0209f2f8 == 0x15 && *(signed char*)(c + 0xcc) == 1) {
-            _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x150, 2);
-            if (func_02035638((u8*)(c + 0x150))) {
-                *(s32*)(c + 0x9c) = 0;
-                *(s32*)(c + 0xa4) = 0;
-                *(s32*)(c + 0xa8) = 0;
-                *(s32*)(c + 0xac) = 0;
-                *(s32*)(c + 0x10c) = 1;
+        if (data_0209f2f8 == 0x15 && unk_0cc == 1) {
+            _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, &mWithMeshClsn, 2);
+            if (func_02035638((u8*)(&mWithMeshClsn))) {
+                unk_09c = 0;
+                unk_0a4 = 0;
+                unk_0a8 = 0;
+                unk_0ac = 0;
+                unk_10c = 1;
                 func_020aea30(c, _ZN5Actor13ClosestPlayerEv(c), 0);
                 return 1;
             }
@@ -101,40 +117,46 @@ extern "C" int _ZN7Skeeter8BehaviorEv(void* self)
     }
     }
 
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, &mMovingCylinderClsnWithPos);
     func_ov090_02131378(c);
-    DecIfAbove0_Short((u16*)(c + 0x100));
-    DecIfAbove0_Short((u16*)(c + 0x394));
-    DecIfAbove0_Short((u16*)(c + 0x396));
-    DecIfAbove0_Short((u16*)(c + 0x398));
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x150, 2);
-    if (*(s32*)(c + 0x60) <= *(s32*)(c + 0x3ac))
-        *(s32*)(c + 0x60) = *(s32*)(c + 0x3ac);
-    if (data_0209f2f8 == 0x15 && *(signed char*)(c + 0xcc) == 1 && func_02035638((u8*)(c + 0x150))) {
-        *(s32*)(c + 0x9c) = 0;
-        *(s32*)(c + 0xa4) = 0;
-        *(s32*)(c + 0xa8) = 0;
-        *(s32*)(c + 0xac) = 0;
-        *(s32*)(c + 0x10c) = 1;
+    DecIfAbove0_Short(&unk_100);
+    DecIfAbove0_Short(&unk_394);
+    DecIfAbove0_Short(&unk_396);
+    DecIfAbove0_Short(&unk_398);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, &mWithMeshClsn, 2);
+    if (mPosY <= unk_3ac)
+        mPosY = unk_3ac;
+    if (data_0209f2f8 == 0x15 && unk_0cc == 1 && func_02035638((u8*)(&mWithMeshClsn))) {
+        unk_09c = 0;
+        unk_0a4 = 0;
+        unk_0a8 = 0;
+        unk_0ac = 0;
+        unk_10c = 1;
         func_020aea30(c, _ZN5Actor13ClosestPlayerEv(c), 0);
         return 1;
     }
 
     {
-        PmfNode* n = *(PmfNode**)(c + 0x370);
+        PmfNode* n = (PmfNode*)mState;
         if (n->fn)
-            (((Actor*)c)->*(n->fn))();
+            (((ActorC*)c)->*(n->fn))();
     }
-    *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+    mAngleY = mPrevAngleY;
+    /* MEASURED: these two reach inside mModelAnim (0x368 and 0x35c are its
+       +0x5c and +0x50) and they are the ONLY spelling in this function that is
+       not free. Writing them as `(char*)&mModelAnim + 0x5c` costs bytes --
+       greedy-tested alone against build_pin, everything else here substituted
+       for free. Offsetting from a typed sub-object's address is not the same
+       to mwcc as offsetting from `this`, so these stay as they are. */
     *(s32*)(c + 0x368) = *(s32*)(c + 0x3a4);
     _ZN9Animation7AdvanceEv(c + 0x35c);
     func_ov090_02131e50(c);
     func_ov090_021310b4(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x110);
+    _ZN12CylinderClsn5ClearEv(&mMovingCylinderClsnWithPos);
     {
         void* p = _ZN5Actor13ClosestPlayerEv(c);
         if (p != 0 && *(u8*)((char*)p + 0x6fb) == 0)
-            _ZN12CylinderClsn6UpdateEv(c + 0x110);
+            _ZN12CylinderClsn6UpdateEv(&mMovingCylinderClsnWithPos);
     }
     return 1;
 }


### PR DESCRIPTION
**Branched off `main`, not stacked** — it can land independently of the open slices.

`tu_map.py` puts ov090 `0x02130f00-0x0213269c` at 25 functions with Skeeter the only class in it. `Render` was already migrated; this is the rest except the structors.

`Skeeter.h` gains 18 fields, all offset-neutral (struct still spans `0x3b0`): the motion words `0x9c/0xa4/0xa8/0xac`, `mFlags` `0xb0`, four countdown timers, `mState` `0x370`, and the death state `unk_10c`.

### Two behaviours worth recording

**`unk_3ac` is the water line.** InitResources finds it once, by raycasting down from `0x32000` above the spawn point. Behavior's ordinary path clamps `mPosY` **up** to it every frame — so the skeeter *floats* rather than falls. The death branch reuses the same value as a **test** instead: dying below the line pays out coins, being squashed on the surface does not.

Two of Behavior's four branches carry the same water-trigger check verbatim (level `0x15`, `unk_0cc == 1`, mesh reports water) and both respond by zeroing the four motion words and setting `unk_10c = 1`.

### One spelling costs bytes — measured, not guessed

Behavior reaches inside `mModelAnim` twice (`0x368`/`0x35c` are its `+0x5c`/`+0x50`). Written as `(char*)&mModelAnim + 0x5c` those **cost**; written as `c + 0x368` they are free. **Offsetting from a typed sub-object's address is not the same to mwcc as offsetting from `this`.** Annotated in the file so it doesn't read as un-recovered work.

Every other substitution is free — 24 sites in Behavior, 21 in InitResources.

### How that was found, because the process mattered here

A first pass substituted everything at once and came back **`999 words differ`** — a size mismatch with no signal about which change caused it. Rebuilding **Stage A** from the pre-image (method conversion only, body untouched) matched, and a per-candidate greedy accept then isolated the single load-bearing site in one sweep.

Two guesses I made *before* running it were both wrong: the local `Vector3` and the `(int)c + 0x8e` launder are each **free** here — and that launder is the very idiom this tree has a measured load-bearing case for elsewhere. It is per-function. Measure it.

Local typedefs are renamed `Loc*` rather than deleted: the header now supplies the real `Fix12`/`Vector3`/`SharedFilePtr`, while these calls take the ROM's by-value `Fix12<int>` signatures (the 6az wall). The renames use word boundaries so the mangled symbol strings are untouched — asserted in the edit.

### Verification

Build pin derived for this family, not inherited: all four baseline at `2004/b56` and all four still match there as methods.

| gate | result |
|---|---|
| `build_pin.verify` × 4 | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket vs `main` | identical set |
| header offsets | 39 fields, 0 mismatched, spans `0x3b0` |
| check_references / port_refcheck / dup / data-defs / langmode / attribution | all clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS