### PR TITLE
CastleWater: all four methods as real C++

### DIFF
--- a/include/CastleWater.h
+++ b/include/CastleWater.h
@@ -1,0 +1,63 @@
+/* Hand-written from matched-function evidence:
+ * class CastleWater, ov009 0x02111a70-0x02111dc4 (8 functions, no other class
+ * in the TU -- tu_map.py).
+ *
+ * The ROM knows this class by TWO names. Its symbols mangle from `CastleWater`
+ * (_ZN11CastleWater8BehaviorEv and friends), which is why the struct is spelled
+ * that way here -- the mangling has to come out right. Its RTTI record calls it
+ * `daObjMcWater_c`, EAD's own name, and include/daObjMcWater_c.h is the
+ * generated view under that name. The two describe the same object; this header
+ * is the one methods can be defined against.
+ *
+ * It is a Platform: InitResources calls Platform::UpdateModelPosAndRotY and
+ * Platform::UpdateClsnPosAndRot on itself, and mPos/mAngleY sit at Actor's
+ * offsets. Written FLAT with the inherited slots restated, as every other
+ * generated header here is.
+ *
+ * Field NAMES are placeholders - renaming cannot change codegen.
+ */
+#ifndef CASTLEWATER_H
+#define CASTLEWATER_H
+#include "types.h"
+#include "math/Matrix.h"
+
+struct CastleWater {
+    u8  pad_000[0x5c];
+    s32 mPosX;            /* 0x05c */
+    /* The water plane's height, and it is read by more than this object:
+       InitResources lowers the GLOBAL data_0209f32c to mPosY - 0x64000 if that
+       is lower, so the water publishes a kill/blur plane the rest of the level
+       reads. One level flag also drops the water itself to -0x2bc000. */
+    s32 mPosY;            /* 0x060 */
+    s32 mPosZ;            /* 0x064 */
+    u8  pad_068[0x26];
+    s16 mAngleY;            /* 0x08e */
+    u8  pad_090[0x44];
+    /* Sub-objects, kept as byte markers -- each one's extent is fixed by the
+       next member's offset, and none of the four methods looks inside one. */
+    u8  mModel;            /* 0x0d4 */
+    u8  pad_0d5[0x7];
+    u8  mModelComponents;            /* 0x0dc */
+    u8  pad_0dd[0x47];
+    u8  mMeshCollider;            /* 0x124 */
+    u8  pad_125[0x1c7];
+    /* Real type, not a marker: InitResources hands it to
+       MovingMeshCollider::SetFile through an explicit `Matrix4x3&` cast. */
+    Matrix4x3 mMatrix;            /* 0x2ec */
+    u8  pad_31c[0x4];
+    u8  mTexTransformer;            /* 0x320 */
+    u8  pad_321[0xb];
+    /* Inside the TextureTransformer at its +0xc. Behavior rewrites it to
+       0x1000 EVERY frame before advancing the animation, so the scroll runs at
+       a fixed rate no matter what else touched it. */
+    s32 unk_32c;            /* 0x32c */
+#ifdef __cplusplus
+    /* methods */
+    int Behavior();
+    int CleanupResources();
+    int InitResources();
+    int Render();
+#endif
+};
+
+#endif

--- a/src/_ZN11CastleWater13InitResourcesEv.cpp
+++ b/src/_ZN11CastleWater13InitResourcesEv.cpp
@@ -1,12 +1,27 @@
 //cpp
-#include "MeshColliderBase.h"
 // @symbol _ZN11CastleWater13InitResourcesEv
-// recovered name: daObjMcWater_c_InitResources
-/* recovered: renamed to Class_Method */
-/* daObjMcWater_c::InitResources - recovered from vtable slot identity */
-typedef short s16;
-struct SharedFilePtr { int x; }; struct BMD_File; struct BTA_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
+/* recovered: named members + shared header, real C++ method
+ *
+ * Loads the model and the collision mesh, wires up the texture scroll, places
+ * the platform, and enables the collider.
+ *
+ * Two things reach outside this object. One level flag (bit 0x80000 of
+ * data_0209caa0+8, and only when data_0209f2d8 != 1) DROPS the water to
+ * -0x2bc000 before anything else -- the castle moat lowering. And near the end
+ * it lowers the GLOBAL data_0209f32c to mPosY - 0x64000 if that is lower, so
+ * the water publishes a plane the rest of the level reads rather than keeping
+ * its height to itself.
+ *
+ * The collider is given mMatrix and mAngleY directly, which is why those two
+ * are real members rather than markers.
+ */
+#include "CastleWater.h"
+#include "MeshColliderBase.h"
+
+struct SharedFilePtr { int x; };
+struct BMD_File; struct BTA_File; struct KCL_File; struct CLPS_Block;
 struct DataPtr { int f[2]; };
+
 extern "C" {
 struct BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &f);
 void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, struct BMD_File *f, int a, int b);
@@ -16,7 +31,7 @@ void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 struct KCL_File *_ZN12MeshCollider8LoadFileER13SharedFilePtr(struct SharedFilePtr &f);
 void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-    void *self, struct KCL_File *k, struct Matrix4x3 &m, int fx, short s, struct CLPS_Block &c);
+    void *self, struct KCL_File *k, Matrix4x3 &m, int fx, short s, struct CLPS_Block &c);
 int func_ov009_02111b1c(char* thiz);
 extern unsigned char data_0209f2d8;
 extern int data_0209caa0;
@@ -25,34 +40,35 @@ extern struct BTA_File data_ov009_02112bc4;
 extern struct SharedFilePtr data_ov009_02113c70;
 extern struct CLPS_Block data_ov009_02112c38;
 extern int data_0209f32c;
+}
 
-int _ZN11CastleWater13InitResourcesEv(char *self){
+int CastleWater::InitResources()
+{
+    char *self = (char *)this;
     int b = (int)(data_0209f2d8 == 1);
     if (b == 0) {
         if (*(int*)((char*)&data_0209caa0 + 8) & 0x80000) {
-            *(int*)(self + 0x60) = -0x2bc000;
+            mPosY = -0x2bc000;
         }
     }
     {
         struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(*(struct SharedFilePtr*)&data_ov009_02113c68);
-        _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, bmd, 1, 0x14);
+        _ZN9ModelBase7SetFileEP8BMD_Fileii(&mModel, bmd, 1, 0x14);
     }
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File((void*)data_ov009_02113c68.f[1], data_ov009_02112bc4);
-    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(self + 0x320, data_ov009_02112bc4, 0, 0x1000, 0);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(&mTexTransformer, data_ov009_02112bc4, 0, 0x1000, 0);
     _ZN8Platform21UpdateModelPosAndRotYEv(self);
     _ZN8Platform19UpdateClsnPosAndRotEv(self);
     {
         struct KCL_File *kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov009_02113c70);
         _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-            self + 0x124, kcl, *(struct Matrix4x3 *)(self + 0x2ec), 0x1000,
-            *(s16 *)(self + 0x8e), data_ov009_02112c38);
+            &mMeshCollider, kcl, mMatrix, 0x1000, mAngleY, data_ov009_02112c38);
     }
-    ((MeshColliderBase *)(self + 0x124))->Enable((Actor *)(self));
+    ((MeshColliderBase *)&mMeshCollider)->Enable((Actor *)(self));
     {
-        int v = *(int*)(self + 0x60) - 0x64000;
+        int v = mPosY - 0x64000;
         if (data_0209f32c > v) data_0209f32c = v;
     }
     func_ov009_02111b1c(self);
     return 1;
-}
 }

--- a/src/_ZN11CastleWater16CleanupResourcesEv.cpp
+++ b/src/_ZN11CastleWater16CleanupResourcesEv.cpp
@@ -1,18 +1,24 @@
 //cpp
+// @symbol _ZN11CastleWater16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * Releases the model and collision files, then disables the mesh collider --
+ * but only if it is still enabled, so a second cleanup is harmless.
+ */
+#include "CastleWater.h"
 #include "SharedFilePtr.h"
 #include "MeshColliderBase.h"
-// @symbol _ZN11CastleWater16CleanupResourcesEv
-// recovered name: daObjMcWater_c_CleanupResources
-/* recovered: renamed to Class_Method */
-/* daObjMcWater_c::CleanupResources - recovered from vtable slot identity */
+
 extern "C" {
 extern int data_ov009_02113c68[];
 extern int data_ov009_02113c70[];
-int _ZN11CastleWater16CleanupResourcesEv(char* c){
-  ((SharedFilePtr *)((void*)data_ov009_02113c68))->Release();
-  ((SharedFilePtr *)((void*)data_ov009_02113c70))->Release();
-  if(((MeshColliderBase *)(c+0x124))->IsEnabled())
-    ((MeshColliderBase *)(c+0x124))->Disable();
-  return 1;
 }
+
+int CastleWater::CleanupResources()
+{
+    ((SharedFilePtr *)((void*)data_ov009_02113c68))->Release();
+    ((SharedFilePtr *)((void*)data_ov009_02113c70))->Release();
+    if (((MeshColliderBase *)&mMeshCollider)->IsEnabled())
+        ((MeshColliderBase *)&mMeshCollider)->Disable();
+    return 1;
 }

--- a/src/_ZN11CastleWater6RenderEv.cpp
+++ b/src/_ZN11CastleWater6RenderEv.cpp
@@ -1,9 +1,21 @@
 //cpp
 // @symbol _ZN11CastleWater6RenderEv
-// recovered name: daObjMcWater_c_Render
-/* recovered: renamed to Class_Method */
-/* daObjMcWater_c::Render - recovered from vtable slot identity */
+/* recovered: named members + shared header, real C++ method
+ *
+ * Pushes the texture transform into the model's components, then draws through
+ * the model's own vtable slot 5. The transformer and the components are
+ * separate sub-objects (0x320 and 0x0dc) and this is the only place they meet.
+ */
+#include "CastleWater.h"
+
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
-struct Base { char pad[0xd4]; Sub sub; };
+
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN11CastleWater6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+
+int CastleWater::Render()
+{
+    _ZN18TextureTransformer6UpdateER15ModelComponents(&mTexTransformer, &mModelComponents);
+    Sub *b = (Sub *)&mModel;
+    b->m(0);
+    return 1;
+}

--- a/src/_ZN11CastleWater8BehaviorEv.cpp
+++ b/src/_ZN11CastleWater8BehaviorEv.cpp
@@ -1,18 +1,22 @@
 //cpp
 // @symbol _ZN11CastleWater8BehaviorEv
-/* recovered: renamed to Class_Method, RTTI class fields named */
-#include "daObjMcWater_c.h"
-// recovered name: daObjMcWater_c_Behavior
-/* recovered: renamed to Class_Method */
-/* daObjMcWater_c::Behavior - recovered from vtable slot identity */
+/* recovered: named members + shared header, real C++ method
+ *
+ * The whole frame: force the scroll rate, advance the texture animation.
+ *
+ * unk_32c is rewritten to 0x1000 EVERY frame rather than once at init, so the
+ * scroll runs at a fixed rate regardless of what else touched it.
+ */
+#include "CastleWater.h"
+
 class Animation {
 public:
-void Advance();
+    void Advance();
 };
 
-extern "C" int _ZN11CastleWater8BehaviorEv(char *r0) {
-    struct daObjMcWater_c *self = (struct daObjMcWater_c *)(void *)r0;
-self->unk_32c = 0x1000;
-((Animation *)(r0 + 0x320))->Advance();
-return 1;
+int CastleWater::Behavior()
+{
+    unk_32c = 0x1000;
+    ((Animation *)&mTexTransformer)->Advance();
+    return 1;
 }


### PR DESCRIPTION
**Branched off `main`, not stacked** — lands independently of #1320 / #1321.

`tu_map.py` puts ov009 `0x02111a70-0x02111dc4` at 8 functions with CastleWater the only class in it. This is everything except the structors.

### The ROM knows this class by two names

Its symbols mangle from **`CastleWater`** (`_ZN11CastleWater8BehaviorEv` and friends), so the struct has to be spelled that way for the mangling to come out right. Its **RTTI record calls it `daObjMcWater_c`** — EAD's own name — and `include/daObjMcWater_c.h` is the generated view under that name.

`include/CastleWater.h` is new and is the one methods can be defined against. The RTTI header is left in place (it's generated, and now has no includers), with the relationship written down so the next person doesn't think they're two classes.

It is a **Platform**: `InitResources` calls `Platform::UpdateModelPosAndRotY` and `Platform::UpdateClsnPosAndRot` on itself, and `mPos`/`mAngleY` sit at Actor's offsets. 10 fields, struct spans `0x330`.

### Two behaviours worth recording

**`mPosY` is not private.** `InitResources` lowers the *global* `data_0209f32c` to `mPosY - 0x64000` whenever that is lower — so the water publishes a plane the rest of the level reads rather than keeping its height to itself. A level flag (bit `0x80000` of `data_0209caa0+8`, only when `data_0209f2d8 != 1`) drops the water itself to `-0x2bc000` first: the moat lowering.

**`Behavior` re-forces the scroll rate every frame.** `unk_32c = 0x1000` is rewritten before each `Advance()`, not set once at init — so it's re-asserted rather than configured.

`mMatrix` is a real `Matrix4x3` rather than a marker because `InitResources` hands it to `MovingMeshCollider::SetFile` through an explicit `Matrix4x3&`, and `mAngleY` goes to the same call. The other four sub-objects stay byte markers — nothing here looks inside them.

### Verification

Build pin derived for this family, not inherited: all four baseline at `2004/b56` and all four still match there as methods. Byte-identical on the first attempt; no greedy search needed.

| gate | result |
|---|---|
| `build_pin.verify` × 4 | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket vs `main` | identical set |
| header offsets | 10 fields, 0 mismatched, spans `0x330` |
| check_references / port_refcheck / dup / data-defs / langmode / attribution | all clean |

No delinks changes — all four files were already `.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS