### PR TITLE
Enemy::UpdateKillByInvincibleChar as a real method, on named fields

### DIFF
--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -24,16 +24,25 @@ struct Enemy {
     s32 mPosX;            /* 0x05c */
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
-    u8  pad_068[0x2c];
-    /* 0x094 is Actor.h:93 mPrevAngleY. The ROM loads it with a signed halfword
+    u8  pad_068[0x24];
+    /* 0x08c-0x090 are Actor.h:91-93 mAngleX/Y/Z, the rotation triple.
+       Enemy::UpdateKillByInvincibleChar adds the spin rates at 0x0ec-0x0f0 to
+       these three in ascending order and hands the same three, in the same
+       order, to Matrix4x3_ApplyInPlaceToRotationZXYExt -- consistent with
+       Actor.h's assignment, which is the primary evidence. */
+    s16 mAngleX;            /* 0x08c */
+    s16 mAngleY;            /* 0x08e */
+    s16 mAngleZ;            /* 0x090 */
+    u8  pad_092[0x2];
+    /* 0x094 is Actor.h:95 mPrevAngleY. The ROM loads it with a signed halfword
        load, which is the one thing no source pass can settle -- and 27 derived
        headers already declare it s16. Was a bare u8 marker. */
-    s16 unk_094;            /* 0x094 */
+    s16 mPrevAngleY;            /* 0x094 */
     u8  pad_096[0xe];
     s32 unk_0a4;            /* 0x0a4 */
     /* 0x0a8 is Actor.h:99 mVertSpeed; 10 derived headers agree, both evidence
        passes see 4-byte accesses. */
-    s32 unk_0a8;            /* 0x0a8 */
+    s32 mVertSpeed;            /* 0x0a8 */
     /* 0x0ac: no Actor field, but 6 derived headers agree and both passes see
        4-byte accesses. The marker's span ran to 0x0d4; only its first word is
        evidenced, so the rest stays padding. */
@@ -52,8 +61,21 @@ struct Enemy {
     s32 mWallNormalX;            /* 0x0e0 */
     s32 mWallNormalY;            /* 0x0e4 */
     s32 mWallNormalZ;            /* 0x0e8 */
-    u8  pad_0ec[0x16];
-    s16 unk_102;            /* 0x102 */
+    /* Per-frame spin applied while the enemy is dying. KillByInvincibleChar
+       (ov002 0x020ada40) copies the three s16 of its `const Vector3_16 &`
+       argument straight into these slots; UpdateKillByInvincibleChar then adds
+       them to mAngleX/Y/Z once a frame. Named from that behaviour -- the ROM
+       evidences the widths and the copy, not the intent. */
+    s16 mSpinRateX;            /* 0x0ec */
+    s16 mSpinRateY;            /* 0x0ee */
+    s16 mSpinRateZ;            /* 0x0f0 */
+    u8  pad_0f2[0x10];
+    /* Death timer, counted down a frame at a time. Was s16: every read in the
+       tree is unsigned -- two ldrh in UpdateKillByInvincibleChar, and
+       UpdateDeath's DecIfAbove0_Short is `unsigned short*` in both its source
+       and its ROM bytes (ldrh at 0x0203adbc). No reference reads it signed,
+       so the declared sign was wrong rather than locally over-ridden. */
+    u16 mDeathTimer;            /* 0x102 */
     u8  pad_104[0x2];
     u8  unk_106;            /* 0x106 */
     u8  unk_107;            /* 0x107 */
@@ -61,14 +83,33 @@ struct Enemy {
     /* 0x10c: 4 derived headers agree, history sees 4 four-byte accesses and the
        ROM two. This is the last field, so widening it grows sizeof(Enemy) by 3 --
        the only site here that is not offset-neutral. */
-    s32 unk_10c;            /* 0x10c */
+    s32 mDeathState;            /* 0x10c */
 #ifdef __cplusplus
     /* methods */
     int AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_);
     int UpdateDeath(WithMeshClsn & clsn_);
     void UpdateWMClsn(WithMeshClsn & clsn_, unsigned int sel);
+    /* Already a real method -- its own file builds _ZN5Enemy9SpawnCoinEv from a
+       local `struct Enemy : Actor` shadow. Declared here so callers need not
+       spell the mangled name. */
+    void SpawnCoin();
     int SpawnParticlesIfHitOtherObj(CylinderClsn & clsn_);
     int UpdateKillByInvincibleChar(WithMeshClsn & ww_, ModelAnim & mm_, unsigned int flags);
+    /* PROVISIONAL SIGNATURE -- do not migrate a caller against it yet. Two
+       separate problems, both caller-side:
+
+       (1) This name is currently attached to ov004 0x020ada40, which cannot be
+           this method (it reads only r0 and range-checks it as a scalar). The
+           code that IS this method is ov002 0x020ada40, still carrying the
+           placeholder name func_ov002_020ada40. See notes/overlay-residency.md,
+           which independently resolves this address to ov002.
+
+       (2) The arity below is refuted by three call sites, which materialise a
+           FOURTH argument in r3 with three different Fix12 constants --
+           ov062 0x02117cf0 (0x46000), ov084 0x02129f94 (0x41000) and
+           ov084 0x02129fcc (0x96000) -- with no other consumer before the bl.
+           The ov002 callee ignores r3, so the trailing parameter is accepted
+           and dropped. A two-reference prototype cannot emit those moves. */
     void KillByInvincibleChar(const Vector3_16 & a1_, Player & a2_);
 #endif
 };

--- a/src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp
+++ b/src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp
@@ -15,7 +15,7 @@
 extern int (Enemy::*data_ov002_0210dbc0[])(WithMeshClsn &);
 
 extern "C" {
-extern void DecIfAbove0_Short(short *p);
+extern void DecIfAbove0_Short(unsigned short *p);
 extern int _ZN5Actor9UpdatePosEP12CylinderClsn(void *thiz, void *clsn);
 extern int _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *thiz, WithMeshClsn *clsn, u32 sel);
 }
@@ -24,10 +24,10 @@ int Enemy::UpdateDeath(WithMeshClsn & clsn_)
 {
     WithMeshClsn *clsn = &clsn_;
     int ret;
-    if (unk_10c == 0)
+    if (mDeathState == 0)
         return 0;
-    DecIfAbove0_Short(&unk_102);
-    ret = (this->*data_ov002_0210dbc0[unk_10c - 1])(*clsn);
+    DecIfAbove0_Short(&mDeathTimer);
+    ret = (this->*data_ov002_0210dbc0[mDeathState - 1])(*clsn);
     _ZN5Actor9UpdatePosEP12CylinderClsn(this, 0);
     _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(this, clsn, 0);
     return ret;

--- a/src/_ZN5Enemy12UpdateWMClsnER12WithMeshClsnj.cpp
+++ b/src/_ZN5Enemy12UpdateWMClsnER12WithMeshClsnj.cpp
@@ -53,7 +53,7 @@ void Enemy::UpdateWMClsn(WithMeshClsn & clsn_, unsigned int sel)
                 long long b = (long long)nz * vz + 0x800;
                 int num = (int)(a >> 12) + (int)(b >> 12);
                 int q = _ZN4cstd4fdivEii(num, dz);
-                unk_0a8 = -(q + 0x8000);
+                mVertSpeed = -(q + 0x8000);
             }
         }
     }

--- a/src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp
+++ b/src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp
@@ -26,7 +26,7 @@ int Enemy::AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_)
         *outAngle = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(this,
             mWallNormalX, mWallNormalZ, *outAngle);
     } else if (unk_106) {
-        *outAngle = (short)(unk_094 + 0x8000);
+        *outAngle = (short)(mPrevAngleY + 0x8000);
     } else {
         return 0;
     }

--- a/src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp
+++ b/src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp
@@ -1,19 +1,59 @@
 //cpp
+// @symbol _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj
+/* recovered: named members + shared header, real C++ method
+ *
+ * One frame of the death an invincible (mega) character inflicts.
+ * Enemy::KillByInvincibleChar -- ov002 0x020ada40, still named
+ * func_ov002_020ada40 in this tree -- starts it by writing mDeathState = 8 and
+ * mDeathTimer = 0x1e; this runs only in that state and ends it either when the
+ * timer expires or when the corpse lands (on ground while falling).
+ *
+ * While it runs, the enemy tumbles: the spin rates KillByInvincibleChar copied
+ * out of its `const Vector3_16 &` argument are added to mAngleX/Y/Z once a
+ * frame, and the model matrix is rebuilt around the body's own half-height so
+ * it spins about its middle rather than its feet.
+ *
+ * `flags` is a two-bit selector, not a boolean: bit 0 drops a coin, bit 1
+ * books the kill in the death table.
+ *
+ * Both reference parameters are null-checked. That is not a contradiction --
+ * the compiler emits the test rather than folding it away, so `&ref == 0` is
+ * how the ROM's check is spelled (see the note in include/Actor.h). Measured
+ * under this family's pin, 2004/b56.
+ */
+#include "Enemy.h"
+
 extern "C" {
-extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *o);
-extern int _ZNK12WithMeshClsn8IsOnWallEv(void *o);
-extern void _ZN5Enemy9SpawnCoinEv(void *o);
-extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *o);
-extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *o, void *cc);
-extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *o, void *w, unsigned int j);
-extern short _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *o, int a, int b, short s);
-extern void Vec3_Asr(void *d, const void *s, int sh);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *clsn);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void *clsn);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *actor);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *actor, void *clsn);
+/* ReflectAngle takes Fix12<int> by value -- the mwccarm 6az wall, runbook
+   section 7 -- so it stays extern "C" with scalars in those slots. */
+extern short _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *actor, int a, int b, short s);
+extern void Vec3_Asr(void *dst, const void *src, int sh);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(void *m, int x, int y, int z);
 extern char data_020a0e68;
 }
 
+/* Enemy.h is a flat struct with no base, so the class carries no vtable to call
+   through; this stand-in exists only to reach one slot, and goes away when
+   Enemy is rebased on Actor.
+
+   WHAT that slot is, is left open on purpose. The ROM loads vtable+0x74 -- slot
+   29, since Actor.h pins slot 20 at vtable+0x50 -- and uses the returned int,
+   arithmetic-shifted right by 3, as the Y of a translation applied before the
+   rotation and negated after it. That is the height of the point the model
+   spins about, and nothing more specific is evidenced here.
+
+   Actor.h labels slot 29 `OnAimedAtWithEgg()`, which does not fit that use. The
+   name reached the tree from the dScMgBase_c / dScMgTrampoline2_c scene family
+   ("recovered from vtable slot identity"), which is a different hierarchy, so
+   it may simply not transfer to Actor. Flagged, not resolved -- renaming an
+   Actor vtable slot is its own slice, and guessing one here would be exactly
+   the un-evidenced assertion this file is trying to avoid. */
 struct VB {
     virtual void d00();
     virtual void d01();
@@ -51,51 +91,49 @@ struct M48 { int w[12]; };
 
 #define LAUNDER(p) ((int)(((long long)(int)(p))))
 
-extern "C" int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(
-    void *cc, void *ww, void *mm, unsigned int flags)
+int Enemy::UpdateKillByInvincibleChar(WithMeshClsn & ww_, ModelAnim & mm_, unsigned int flags)
 {
-    char *c = (char *)cc;
-    char *w = (char *)ww;
-    char *m = (char *)mm;
+    WithMeshClsn *clsn = &ww_;
+    ModelAnim *anim = &mm_;
     int v[3];
 
-    if (*(int *)(c + 0x10c) != 8)
+    if (mDeathState != 8)
         return 0;
 
-    if (*(unsigned short *)(c + 0x102) != 0)
-        *(unsigned short *)LAUNDER(c + 0x102) -= 1;
+    if (mDeathTimer != 0)
+        *(unsigned short *)LAUNDER(&mDeathTimer) -= 1;
 
-    if (*(unsigned short *)(c + 0x102) == 0 ||
-        (w != 0 && _ZNK12WithMeshClsn10IsOnGroundEv(w) != 0 && *(int *)(c + 0xa8) < 0)) {
+    if (mDeathTimer == 0 ||
+        (clsn != 0 && _ZNK12WithMeshClsn10IsOnGroundEv(clsn) != 0 && mVertSpeed < 0)) {
         if (flags & 1)
-            _ZN5Enemy9SpawnCoinEv(c);
+            SpawnCoin();
         if (flags & 2)
-            _ZN5Actor24KillAndTrackInDeathTableEv(c);
-        *(int *)(c + 0x10c) = 0;
+            _ZN5Actor24KillAndTrackInDeathTableEv(this);
+        mDeathState = 0;
         return 2;
     }
 
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
-    if (w != 0) {
-        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, w, 0);
-        if (_ZNK12WithMeshClsn8IsOnWallEv(w) != 0)
-            *(short *)(c + 0x94) = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(
-                c, *(int *)(c + 0xe0), *(int *)(c + 0xe8), *(short *)(c + 0x94));
+    _ZN5Actor9UpdatePosEP12CylinderClsn(this, 0);
+    if (clsn != 0) {
+        UpdateWMClsn(*clsn, 0);
+        if (_ZNK12WithMeshClsn8IsOnWallEv(clsn) != 0)
+            mPrevAngleY = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(
+                this, mWallNormalX, mWallNormalZ, mPrevAngleY);
     }
 
-    if (m != 0) {
-        *(short *)LAUNDER(c + 0x8c) += *(short *)(c + 0xec);
-        *(short *)LAUNDER(c + 0x8e) += *(short *)(c + 0xee);
-        *(short *)LAUNDER(c + 0x90) += *(short *)(c + 0xf0);
-        Vec3_Asr(v, c + 0x5c, 3);
+    if (anim != 0) {
+        *(short *)LAUNDER(&mAngleX) += mSpinRateX;
+        *(short *)LAUNDER(&mAngleY) += mSpinRateY;
+        *(short *)LAUNDER(&mAngleZ) += mSpinRateZ;
+        Vec3_Asr(v, &mPosX, 3);
         Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
         Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0,
-            ((VB *)(void *)c)->m29() >> 3, 0);
+            ((VB *)(void *)this)->m29() >> 3, 0);
         Matrix4x3_ApplyInPlaceToRotationZXYExt(&data_020a0e68,
-            *(short *)(c + 0x8c), *(short *)(c + 0x8e), *(short *)(c + 0x90));
+            mAngleX, mAngleY, mAngleZ);
         Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0,
-            (-((VB *)(void *)c)->m29()) >> 3, 0);
-        *(M48 *)(m + 0x1c) = *(M48 *)&data_020a0e68;
+            (-((VB *)(void *)this)->m29()) >> 3, 0);
+        *(M48 *)((char *)anim + 0x1c) = *(M48 *)&data_020a0e68;
     }
     return 1;
 }


### PR DESCRIPTION
The last Enemy method that was genuinely Enemy's and still spelled as an `extern "C"` function over a magic-offset `char*`. Now a real method, with the 13 offsets it touches resolved to named fields.

### Six offsets had no name at all — two triples

| offsets | field | evidence |
|---|---|---|
| `0x08c/0x08e/0x090` | `mAngleX/Y/Z` | `Actor.h:91-93` already assigns these; corroborated by the ascending-order feed into `ApplyInPlaceToRotationZXYExt` |
| `0x0ec/0x0ee/0x0f0` | `mSpinRateX/Y/Z` | `KillByInvincibleChar` copies its `const Vector3_16 &` argument into them; this adds them to the angles once a frame. **Named from behaviour**, and the header says so |

### A width defect: unk_102 was s16 and isn't

**Every read in the tree is unsigned** — two `ldrh` here, and `UpdateDeath`'s `DecIfAbove0_Short` is `unsigned short*` in both its source and its ROM bytes (`ldrh` at `0x0203adbc`). No reference reads it signed, so this is a wrong *declared sign*, not a locally-unsigned use — the third instance of that class after `Player.h`'s `mJumpComboTimer` and `mBalloonTimer`. Now `u16 mDeathTimer`.

`UpdateDeath` also carried a local `extern` declaring that helper `short*` while its real definition says `unsigned short*` — a disagreement `extern "C"` linkage hides from every gate. Corrected.

Renamed alongside, all from evidence the header already recorded: `unk_094` → `mPrevAngleY`, `unk_0a8` → `mVertSpeed`, `unk_10c` → `mDeathState`. `SpawnCoin` is declared in the header now; it was already a real method built through a local shadow struct in its own file.

### Flagged, not changed

The virtual this calls is `vtable+0x74` = **slot 29**, and its return (`asr #3`) is used as the height of the point the model spins about. `Actor.h` labels slot 29 `OnAimedAtWithEgg()`, which does not fit that use — and that name reached the tree from the `dScMgBase_c` scene family, a different hierarchy. Recorded in the source rather than guessed at; an Actor vtable slot rename is its own slice.

**`KillByInvincibleChar`'s declaration carries a provisional-signature warning.** Two separate problems, both caller-side, both written onto the declaration in `Enemy.h`: the name is currently attached to ov004 `0x020ada40`, which cannot be that method; and three call sites materialise a *fourth* argument in r3 with distinct Fix12 constants. Do not migrate a caller against it yet. That correction is its own PR — see the note below.

### Verification

Build pin derived for this family, not inherited: all four baseline at `2004/b56` and all four still match there as methods. Byte-identical on the first attempt; no greedy search needed. Rebased onto current `main` and re-verified before opening.

| gate | result |
|---|---|
| `build_pin.verify` × 4 (fn + 3 siblings the renames touched) | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket vs `main` | identical set |
| header offsets | 23 fields, 0 mismatched, spans `0x110` |
| check_references / port_refcheck / dup / data-defs / langmode / attribution | all clean |

### Follow-up this unblocks

While migrating this I found that **two Enemy symbols in ov004 are misattributed** — `KillByAttack` and `KillByInvincibleChar` name code that lives in ov002 under `func_ov002_*` placeholders. Independently confirmed: the repo's own `notes/overlay-ambiguous-references.md` already records the residency model resolving both addresses to ov002, and a Fable review confirmed all five supporting claims from the bytes. That correction is byte-neutral but is a symbol relocation, so it wants its own two-commit PR rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS