### PR TITLE
objisolate: build C++ destructors into the ROM (tooling)

### DIFF
--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,956 +1,991 @@
 {
-  "eligible": 10666,
-  "unresolved": {
-    "ChainChomp_Spawn": [
-      "func_020aed98"
-    ],
-    "ChiefChilly_Spawn": [
-      "func_020aed98"
-    ],
-    "ExplosionGoomba_Spawn": [
-      "func_020aed98"
-    ],
-    "FS_LoadOverlay": [
-      "func_020aa420"
-    ],
-    "FallBlockBbh_Spawn": [
-      "_ZTV20daObjTh_Fall_Block_c"
-    ],
-    "FallBlockBfs_Spawn": [
-      "_ZTV21daObjKm2_Fall_Block_c"
-    ],
-    "FallBlockLll_Spawn": [
-      "_ZTV20daObjFl_Fall_Block_c"
-    ],
-    "GetSceneOverlayID": [
-      "overlay_2",
-      "overlay_3",
-      "overlay_5",
-      "overlay_6",
-      "overlay_7"
-    ],
-    "Goomboss_Spawn": [
-      "func_020aed98"
-    ],
-    "Grindel_Spawn": [
-      "_ZTV7daDkk_c"
-    ],
-    "RollingLogLll_Spawn": [
-      "_ZTV15daObjFlMaruta_c"
-    ],
-    "RollingLogTtm_Spawn": [
-      "_ZTV15daObjHmMaruta_c"
-    ],
-    "UnchainedChomp_Spawn": [
-      "func_020aed98"
-    ],
-    "Wiggler_Spawn": [
-      "func_020aed98"
-    ],
-    "_Z26LoadOrUnloadObjectOverlaysPFviEi": [
-      "overlay_102",
-      "overlay_60",
-      "overlay_98"
-    ],
-    "_ZN10CheepCheep13InitResourcesEv": [
-      "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
-      "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
-      "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj"
-    ],
-    "_ZN10FlameChomp13InitResourcesEv": [
-      "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
-      "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj"
-    ],
-    "_ZN10MrBlizzard13InitResourcesEv": [
-      "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
-      "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj"
-    ],
-    "_ZN10Scuttlebug13InitResourcesEv": [
-      "AnimLoadFile",
-      "ModelLoadFile",
-      "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
-      "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
-    ],
-    "_ZN11FallBlockWf13InitResourcesEv": [
-      "func_0213a794"
-    ],
-    "_ZN11FallBlockWf16CleanupResourcesEv": [
-      "func_0213a2cc"
-    ],
-    "_ZN11FallBlockWfD0Ev": [
-      "G0",
-      "VT1",
-      "VT2",
-      "_ZTV10dBgActor_c"
-    ],
-    "_ZN11FallBlockWfD1Ev": [
-      "VT1",
-      "VT2",
-      "_ZTV10dBgActor_c"
-    ],
-    "_ZN11MirrorLuigi13InitResourcesEv": [
-      "Animation_LoadFile",
-      "ModelAnim_SetAnim",
-      "ModelBase_SetFile",
-      "Model_LoadFile",
-      "ShadowModel_InitCylinder",
-      "TextureSequence_Prepare",
-      "TextureSequence_SetFile"
-    ],
-    "_ZN12FallBlockBbhD0Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV20daObjTh_Fall_Block_c"
-    ],
-    "_ZN12FallBlockBbhD1Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV20daObjTh_Fall_Block_c"
-    ],
-    "_ZN12FallBlockBfs13InitResourcesEv": [
-      "func_0213a794"
-    ],
-    "_ZN12FallBlockBfs16CleanupResourcesEv": [
-      "func_0213a2cc"
-    ],
-    "_ZN12FallBlockBfsD0Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV21daObjKm2_Fall_Block_c"
-    ],
-    "_ZN12FallBlockBfsD1Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV21daObjKm2_Fall_Block_c"
-    ],
-    "_ZN12FallBlockLll16CleanupResourcesEv": [
-      "func_021270dc"
-    ],
-    "_ZN12FallBlockLllD0Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV15daObjFlMaruta_c"
-    ],
-    "_ZN12FallBlockLllD1Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV15daObjFlMaruta_c"
-    ],
-    "_ZN13FortressTower13InitResourcesEv": [
-      "MeshCollider_LoadFile",
-      "ModelBase_SetFile",
-      "Model_LoadFile",
-      "MovingMeshCollider_SetFile",
-      "Platform_UpdateClsnPosAndRot",
-      "Platform_UpdateModelPosAndRotY"
-    ],
-    "_ZN13MontyMoleRock8BehaviorEv": [
-      "ActorBase_MarkForDestruction",
-      "Actor_FindWithID",
-      "Actor_MakeVanishLuigiWork",
-      "Actor_UpdatePos",
-      "CylinderClsn_Clear",
-      "CylinderClsn_Update",
-      "Enemy_UpdateWMClsn",
-      "Player_Hurt",
-      "WithMeshClsn_IsOnGround"
-    ],
-    "_ZN13PrincessPeach13InitResourcesEv": [
-      "AnimLoadFile",
-      "ModelLoadFile",
-      "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
-      "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
-    ],
-    "_ZN13RacingPenguin13InitResourcesEv": [
-      "Actor_TrackStar",
-      "Animation_LoadFile",
-      "ModelBase_SetFile",
-      "Model_LoadFile",
-      "MovingCylinderClsn_Init",
-      "PathPtr_FromID",
-      "PathPtr_GetNode",
-      "ShadowModel_InitCylinder",
-      "TextureSequence_LoadFile",
-      "TextureSequence_Prepare",
-      "WithMeshClsn_Init"
-    ],
-    "_ZN13RacingPenguin8BehaviorEv": [
-      "_Z23_ZN9Animation7AdvanceEvPc",
-      "_Z25_ZN12CylinderClsn5ClearEvPc",
-      "_Z26_ZN12CylinderClsn6UpdateEvPc",
-      "p__sinit_ov031_02111434"
-    ],
-    "_ZN13SnowmanBreath8BehaviorEv": [
-      "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3sijjPvj"
-    ],
-    "_ZN13TTC_MovingBar13InitResourcesEv": [
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-    ],
-    "_ZN14CutsceneObject13InitResourcesEv": [
-      "_Z5_Znwji",
-      "func_02113c20"
-    ],
-    "_ZN14TtcMovingCubeA13InitResourcesEv": [
-      "func_02112118"
-    ],
-    "_ZN15BookShotSpawner13InitResourcesEv": [
-      "_Z17LoadBlueCoinModelPv",
-      "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv"
-    ],
-    "_ZN15TtcRotatingGear13InitResourcesEv": [
-      "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-      "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-      "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
-      "_Z37_ZN8Platform21UpdateModelPosAndRotYEvPv",
-      "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
-      "func_021121b8"
-    ],
-    "_ZN16BowserShockwaves13InitResourcesEv": [
-      "func_021115e4",
-      "func_021115f4"
-    ],
-    "_ZN16FloatingFloorBfs13InitResourcesEv": [
-      "func_020b6244"
-    ],
-    "_ZN16FloatingFloorBfs16CleanupResourcesEv": [
-      "func_020b60fc"
-    ],
-    "_ZN16RotatingCogSmall13InitResourcesEv": [
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-    ],
-    "_ZN17MgBounceAndPounce11AfterRenderEj": [
-      "Scene_AfterRender"
-    ],
-    "_ZN17RotatingClockHand13InitResourcesEv": [
-      "MeshColliderLoadFile",
-      "ModelLoadFile",
-      "UpdatePosWithTransformSym",
-      "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-    ],
-    "_ZN18BowserFireSeaArena13InitResourcesEv": [
-      "_Z13func_020393d4PvS_",
-      "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-      "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-      "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
-      "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-      "func_021115bc"
-    ],
-    "_ZN19RotatingPlatformLll8BehaviorEv": [
-      "Platform_IsClsnInRange",
-      "Platform_UpdateClsnPosAndRot",
-      "Platform_UpdateModelPosAndRotY",
-      "_Z13func_020393a4Pii"
-    ],
-    "_ZN19RotatingPlatformWdw13InitResourcesEv": [
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-    ],
-    "_ZN22RotatingUpDownPlatform13InitResourcesEv": [
-      "Vec3_equal",
-      "_Z13func_020393c4PvS_",
-      "_Z13func_020393d4PvS_",
-      "_Z20_ZN7PathPtr6FromIDEjPvj",
-      "_Z31_ZNK7PathPtr7GetNodeER7Vector3jPvS_j",
-      "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-      "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-      "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
-      "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-    ],
-    "_ZN22RotatingUpDownPlatform8BehaviorEv": [
-      "ApproachLinearI",
-      "UpdatePosWithVelocitySym",
-      "_ZN8Platform13IsClsnInRangeEii"
-    ],
-    "_ZN3HUD15RenderCoinCountEv": [
-      "func_020ab9c8",
-      "func_020aba70",
-      "func_020abad8"
-    ],
-    "_ZN3HUD15RenderLifeCountEv": [
-      "func_020ab948",
-      "func_020ab9c8",
-      "func_020aba70"
-    ],
-    "_ZN3HUD15RenderStarCountEv": [
-      "func_020ab9c8",
-      "func_020aba70",
-      "func_020abad0"
-    ],
-    "_ZN3HUD15RenderTimeTimerEv": [
-      "_ll_udiv",
-      "_ull_mod"
-    ],
-    "_ZN4cstd5atan2E5Fix12IiES1_": [
-      "func_01ff98f4"
-    ],
-    "_ZN5Cloud8BehaviorEv": [
-      "FindWithActorID",
-      "SetPolygonID"
-    ],
-    "_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc": [
-      "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv"
-    ],
-    "_ZN5FaderD0Ev": [
-      "base_dtor_Fader"
-    ],
-    "_ZN5Stage12RenderNumberEhiibi": [
-      "func_020aba70"
-    ],
-    "_ZN5Stage14GraphCallback2EP12SceneRelated": [
-      "reg_G2S_DB_BG3PA"
-    ],
-    "_ZN5Stage20RenderBouncingArrowsEv": [
-      "func_020abd88"
-    ],
-    "_ZN5Stage6RenderEv": [
-      "func_020ab9c8",
-      "func_020abad8"
-    ],
-    "_ZN5Stage9PS_RenderEv": [
-      "func_020ab9c8",
-      "func_020abac0",
-      "func_020abad8",
-      "func_020abd98",
-      "func_020ac218",
-      "func_020ac64c",
-      "func_020acb68",
-      "func_020ad04c"
-    ],
-    "_ZN6BobOmb8BehaviorEv": [
-      "func_020ada40"
-    ],
-    "_ZN6Bullet13InitResourcesEv": [
-      "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
-      "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-      "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
-      "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
-      "func_0211d610"
-    ],
-    "_ZN6Eyerok13InitResourcesEv": [
-      "_Z13func_020393c4PvS_",
-      "_Z13func_020393d4PvS_",
-      "_Z22_ZN5Actor9TrackStarEjjPvjj",
-      "_Z32_ZN11ShadowModel12InitCylinderEvPv",
-      "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-      "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-      "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
-      "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-      "_Z44_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16iijjP7Vector3Pvii",
-      "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
-      "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
-      "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
-      "func_02112c08",
-      "func_02112ca8",
-      "func_02112d48"
-    ],
-    "_ZN7ClipperD0Ev": [
-      "base_dtor_Clipper"
-    ],
-    "_ZN7Skeeter8BehaviorEv": [
-      "func_020aea30"
-    ],
-    "_ZN7Tornado13InitResourcesEv": [
-      "func_02112968"
-    ],
-    "_ZN8CapEnemy6AddCapEj": [
-      "func_020ff028"
-    ],
-    "_ZN8Goomboss13InitResourcesEv": [
-      "func_021123f4",
-      "func_021124ac"
-    ],
-    "_ZN8SignPost13InitResourcesEv": [
-      "MeshColliderLoadFile",
-      "ModelLoadFile",
-      "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
-      "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
-      "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-    ],
-    "_ZN9Spindrift13InitResourcesEv": [
-      "AnimLoadFile",
-      "ModelLoadFile",
-      "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
-      "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
-      "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-    ],
-    "_ZN9UkikiCageD0Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV15daObjHmMaruta_c"
-    ],
-    "_ZN9UkikiCageD1Ev": [
-      "_ZTV10dBgActor_c",
-      "_ZTV15daObjHmMaruta_c"
-    ],
-    "__sinit_ov071_02122a64": [
-      "data_ov071_02122ecc_d"
-    ],
-    "func_02008b4c": [
-      "func_020effb8"
-    ],
-    "func_02009374": [
-      "Vec3_DistSq"
-    ],
-    "func_02014f5c": [
-      "func_020caf98"
-    ],
-    "func_02019ebc": [
-      "func_02061128"
-    ],
-    "func_0201a2f8": [
-      "func_020aa420",
-      "overlay_0",
-      "overlay_1"
-    ],
-    "func_0201a458": [
-      "func_0211d9c0",
-      "func_02140d80"
-    ],
-    "func_0201a614": [
-      "overlay_75"
-    ],
-    "func_0201a694": [
-      "overlay_75"
-    ],
-    "func_0201a754": [
-      "overlay_4",
-      "overlay_6"
-    ],
-    "func_0201a798": [
-      "overlay_4",
-      "overlay_6"
-    ],
-    "func_0201a8b4": [
-      "_ll_udiv"
-    ],
-    "func_02029408": [
-      "func_020bd828"
-    ],
-    "func_02034fbc": [
-      "overlay_64",
-      "overlay_66"
-    ],
-    "func_0203c178": [
-      "func_020527e9"
-    ],
-    "func_02042784": [
-      "_ll_udiv"
-    ],
-    "func_020427c4": [
-      "_ll_udiv"
-    ],
-    "func_02053130": [
-      "SQRTCNT",
-      "SQRT_RESULT"
-    ],
-    "func_02055454": [
-      "G"
-    ],
-    "func_020570c0": [
-      "G"
-    ],
-    "func_020570d8": [
-      "G"
-    ],
-    "func_02057128": [
-      "G"
-    ],
-    "func_02057140": [
-      "G"
-    ],
-    "func_02057410": [
-      "_ll_mod"
-    ],
-    "func_02058308": [
-      "func_00000000",
-      "func_00000600"
-    ],
-    "func_02058df4": [
-      "func_00000000",
-      "func_00000600"
-    ],
-    "func_02059640": [
-      "G"
-    ],
-    "func_02059a60": [
-      "_ll_udiv"
-    ],
-    "func_02059f48": [
-      "G"
-    ],
-    "func_0205f650": [
-      "G"
-    ],
-    "func_0206ece0": [
-      "func_01ff9e2c"
-    ],
-    "func_0206f46c": [
-      "_deq"
-    ],
-    "func_0206f820": [
-      "_ll_udiv",
-      "_ull_mod"
-    ],
-    "func_020708b4": [
-      "_deq"
-    ],
-    "func_02070c68": [
-      "func_01ff9d40"
-    ],
-    "func_02071510": [
-      "_ll_udiv",
-      "_ull_mod"
-    ],
-    "func_ov002_020c0fb4": [
-      "_ll_udiv"
-    ],
-    "func_ov002_020c8a4c": [
-      "_Z13func_020072c0v",
-      "_ZN6Player7SetAnimEjiij"
-    ],
-    "func_ov002_020dc560": [
-      "func_01ff98f4",
-      "func_01ff99a4"
-    ],
-    "func_ov002_020ec670": [
-      "func_02123804"
-    ],
-    "func_ov003_020adfc8": [
-      "func_020ab9c8",
-      "func_020aba70",
-      "func_020abad8"
-    ],
-    "func_ov003_020ae0b0": [
-      "func_020ab9c8",
-      "func_020aba70",
-      "func_020abad0"
-    ],
-    "func_ov003_020ae238": [
-      "func_020ab948",
-      "func_020ab9c8",
-      "func_020aba70"
-    ],
-    "func_ov006_020c0a48": [
-      "g0",
-      "g1",
-      "g2"
-    ],
-    "func_ov006_020c14bc": [
-      "func_020beb68"
-    ],
-    "func_ov006_020c221c": [
-      "g0",
-      "g1"
-    ],
-    "func_ov006_020c3bc8": [
-      "func_020c3adc"
-    ],
-    "func_ov006_020db720": [
-      "func_020beb68"
-    ],
-    "func_ov006_020db9dc": [
-      "func_020bc7d4"
-    ],
-    "func_ov006_020dcd74": [
-      "func_020beb68"
-    ],
-    "func_ov006_020de1d4": [
-      "func_020beb68"
-    ],
-    "func_ov006_020de26c": [
-      "func_020beb68"
-    ],
-    "func_ov006_020de440": [
-      "func_020beb68"
-    ],
-    "func_ov006_020de584": [
-      "func_020ddd6c"
-    ],
-    "func_ov006_020e3578": [
-      "func_020adc74"
-    ],
-    "func_ov006_020e6894": [
-      "func_020adc74"
-    ],
-    "func_ov006_020e7124": [
-      "func_020beb74"
-    ],
-    "func_ov006_020e989c": [
-      "func_020beb68"
-    ],
-    "func_ov006_020e9c20": [
-      "func_020beb68"
-    ],
-    "func_ov006_020e9cec": [
-      "G0",
-      "G1"
-    ],
-    "func_ov006_020ea3d0": [
-      "func_020beb68"
-    ],
-    "func_ov006_020ee2c4": [
-      "func_020beb68"
-    ],
-    "func_ov006_020efcf8": [
-      "data_04000006"
-    ],
-    "func_ov006_020f0274": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f3294": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f3460": [
-      "func_020adc74",
-      "func_020bc864",
-      "func_020bc888"
-    ],
-    "func_ov006_020f3834": [
-      "_ZN10SysTrackerD1Ev"
-    ],
-    "func_ov006_020f4888": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f52c4": [
-      "func_020bc7d4",
-      "func_020beb68"
-    ],
-    "func_ov006_020f53e4": [
-      "func_020bc7d4"
-    ],
-    "func_ov006_020f5564": [
-      "_ZN10SysTrackerD1Ev"
-    ],
-    "func_ov006_020f6538": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f7394": [
-      "func_020bc7d4",
-      "func_020beb68"
-    ],
-    "func_ov006_020f74b4": [
-      "func_020bc7d4"
-    ],
-    "func_ov006_020f7634": [
-      "_ZN10SysTrackerD1Ev"
-    ],
-    "func_ov006_020f7c10": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f869c": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f8a3c": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f8c68": [
-      "func_020bc7d4"
-    ],
-    "func_ov006_020f8d08": [
-      "func_020beb68"
-    ],
-    "func_ov006_020f8ef4": [
-      "_ZN10SysTrackerD1Ev"
-    ],
-    "func_ov006_021071fc": [
-      "func_020beb68"
-    ],
-    "func_ov006_02108f2c": [
-      "func_020b9488"
-    ],
-    "func_ov006_021095cc": [
-      "func_020bc7d4",
-      "func_020beb68"
-    ],
-    "func_ov006_02109aac": [
-      "func_020beb68"
-    ],
-    "func_ov006_0210a708": [
-      "func_020beb6c"
-    ],
-    "func_ov006_0210a8c0": [
-      "func_020ad494"
-    ],
-    "func_ov006_0210a900": [
-      "func_020ad494"
-    ],
-    "func_ov006_0210a954": [
-      "_ZN10SysTrackerD1Ev"
-    ],
-    "func_ov006_0210bdb0": [
-      "func_020bc860",
-      "func_020bc864",
-      "func_020bc878",
-      "func_020bc888",
-      "func_020bc88c",
-      "func_020bc890",
-      "func_020bc8b4",
-      "func_020bc8b8"
-    ],
-    "func_ov006_0210c2d4": [
-      "func_020beb68"
-    ],
-    "func_ov006_0210d1fc": [
-      "func_020bc860",
-      "func_020bc878",
-      "func_020bc88c",
-      "func_020bc890",
-      "func_020bc8b4",
-      "func_020bc8b8"
-    ],
-    "func_ov006_0210d6b8": [
-      "func_020ad494"
-    ],
-    "func_ov006_02115b0c": [
-      "func_020adc74"
-    ],
-    "func_ov006_02118488": [
-      "func_020bc864",
-      "func_020bc888"
-    ],
-    "func_ov006_02119904": [
-      "_ZN10SysTrackerD1Ev"
-    ],
-    "func_ov006_0211fd44": [
-      "func_020beb68"
-    ],
-    "func_ov006_021200dc": [
-      "func_020beb6c"
-    ],
-    "func_ov006_021203fc": [
-      "func_020bc880",
-      "func_020bc884"
-    ],
-    "func_ov006_02125364": [
-      "func_020bc7d4"
-    ],
-    "func_ov006_02129268": [
-      "func_020adc74"
-    ],
-    "func_ov006_0212b480": [
-      "func_020adc74",
-      "func_020bc86c",
-      "func_020bc898",
-      "func_020bc8a4",
-      "func_020bc8a8"
-    ],
-    "func_ov007_020bcf90": [
-      "func_02055574",
-      "func_020b2160",
-      "func_020b2370",
-      "func_020b2728",
-      "func_020b2cf0",
-      "func_020b413c",
-      "func_020b4464",
-      "func_020b7658",
-      "func_020b7a00",
-      "func_020b7a34",
-      "func_020b8fd4",
-      "func_020b91b4",
-      "func_020bee14",
-      "func_020bfaf0",
-      "func_020c232c",
-      "func_020c2390",
-      "func_020c93b4"
-    ],
-    "func_ov007_020c798c": [
-      "func_020c3df4",
-      "func_020c78b0",
-      "func_020c80a4",
-      "func_020c844c"
-    ],
-    "func_ov007_020c8970": [
-      "func_020c897c"
-    ],
-    "func_ov007_020cc2cc": [
-      "overlay_64",
-      "overlay_66"
-    ],
-    "func_ov007_020cc4c0": [
-      "overlay_100",
-      "overlay_102"
-    ],
-    "func_ov015_02112c84": [
-      "func_020b66a8"
-    ],
-    "func_ov016_02112fa8": [
-      "func_020b5e58"
-    ],
-    "func_ov020_021112b0": [
-      "Actor_ClosestPlayer",
-      "cstd_atan2"
-    ],
-    "func_ov022_0211165c": [
-      "func_020b66a8"
-    ],
-    "func_ov022_02112380": [
-      "_ZTV10dBgActor_c",
-      "_ZTV20daObjFl_Fall_Block_c"
-    ],
-    "func_ov022_02112434": [
-      "func_0213a2cc"
-    ],
-    "func_ov022_02112448": [
-      "func_0213a794"
-    ],
-    "func_ov025_021118c8": [
-      "_ZTV10dBgActor_c",
-      "_ZTV7daDkk_c"
-    ],
-    "func_ov025_02111928": [
-      "G0",
-      "VT0",
-      "VT1",
-      "VT2"
-    ],
-    "func_ov026_02111598": [
-      "func_ov053_021112a4"
-    ],
-    "func_ov036_0211244c": [
-      "func_020efaf0"
-    ],
-    "func_ov045_02111bc8": [
-      "func_020b6424"
-    ],
-    "func_ov045_02111bdc": [
-      "func_020b6584"
-    ],
-    "func_ov060_021182b0": [
-      "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-      "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-    ],
-    "func_ov062_02116010": [
-      "func_020ada40"
-    ],
-    "func_ov062_02117c98": [
-      "func_020ada40",
-      "func_020aea30"
-    ],
-    "func_ov063_0211a0dc": [
-      "func_020ada40"
-    ],
-    "func_ov064_02116754": [
-      "func_020ada40"
-    ],
-    "func_ov065_02115ff0": [
-      "func_020ada40",
-      "func_020aea30"
-    ],
-    "func_ov065_0211704c": [
-      "func_020ada40",
-      "func_020aea30"
-    ],
-    "func_ov065_0211a358": [
-      "_Z30_ZN11ShadowModel10InitCuboidEvPv",
-      "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
-      "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
-      "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
-      "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
-      "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-      "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-      "func_02112198"
-    ],
-    "func_ov065_0211b1d4": [
-      "MeshColliderLoadFile",
-      "ModelLoadFile",
-      "UpdatePosWithTransformSym",
-      "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-      "func_02112258"
-    ],
-    "func_ov066_021166c8": [
-      "_Z13func_02112c88v",
-      "_Z13func_02112cc8v",
-      "_Z19func_ov066_0211a35cv",
-      "_Z23func_02112cd8_updateposv"
-    ],
-    "func_ov066_02116db0": [
-      "func_02112c08",
-      "func_02112d48"
-    ],
-    "func_ov066_021175e8": [
-      "func_02112c08",
-      "func_02112d48"
-    ],
-    "func_ov066_02117bf0": [
-      "func_02112c08",
-      "func_02112d48"
-    ],
-    "func_ov066_02118188": [
-      "func_02112c08",
-      "func_02112d48"
-    ],
-    "func_ov070_0211f100": [
-      "func_020aea30"
-    ],
-    "func_ov075_02116f40": [
-      "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
-      "func_020abd88"
-    ],
-    "func_ov075_02117bc4": [
-      "overlay_64",
-      "overlay_66"
-    ],
-    "func_ov081_021243cc": [
-      "func_020ada40",
-      "func_020aea30"
-    ],
-    "func_ov084_02129a00": [
-      "func_020aea30"
-    ],
-    "func_ov084_02129ed4": [
-      "func_020ada40",
-      "func_020aea30"
-    ],
-    "func_ov084_0212a774": [
-      "func_020aea30"
-    ],
-    "func_ov089_0213162c": [
-      "data_02111b68"
-    ],
-    "func_ov090_021310b4": [
-      "func_020ada40",
-      "func_020aea30"
-    ],
-    "func_ov091_021339fc": [
-      "func_020aea30"
-    ],
-    "func_ov098_021390ec": [
-      "_Z19func_ov002_020ef228Pvi",
-      "_ZN5Actor12ReflectAngleEiis"
-    ],
-    "func_ov100_0214109c": [
-      "ActorBase_MarkForDestruction"
-    ],
-    "func_ov100_02141fb0": [
-      "func_020ada40"
-    ],
-    "func_ov100_0214272c": [
-      "func_020ad660"
-    ],
-    "func_ov100_02142918": [
-      "func_020ad660"
-    ],
-    "func_ov100_02145080": [
-      "func_020ca78c"
-    ],
-    "func_ov100_02147054": [
-      "G0",
-      "G1",
-      "G2"
-    ],
-    "func_ov100_021470f4": [
-      "_Z16DecIfAbove0_BytePh",
-      "_Z9Vec3_DistPK7Vector3S1_",
-      "_ZN16MeshColliderBase6EnableEPv",
-      "_ZN9Platform219UpdateClsnPosAndRotEv",
-      "_ZN9Platform313IsClsnInRangeEii"
-    ],
-    "func_ov100_021471e0": [
-      "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-      "func_020efaf0"
-    ],
-    "func_ov102_0214cbec": [
-      "func_020ada40"
-    ],
-    "main": [
-      "__main",
-      "_main"
-    ]
-  }
+ "eligible": 10666,
+ "unresolved": {
+  "ChainChomp_Spawn": [
+   "func_020aed98"
+  ],
+  "ChiefChilly_Spawn": [
+   "func_020aed98"
+  ],
+  "ExplosionGoomba_Spawn": [
+   "func_020aed98"
+  ],
+  "FS_LoadOverlay": [
+   "func_020aa420"
+  ],
+  "FallBlockBbh_Spawn": [
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "FallBlockBfs_Spawn": [
+   "_ZTV21daObjKm2_Fall_Block_c"
+  ],
+  "FallBlockLll_Spawn": [
+   "_ZTV20daObjFl_Fall_Block_c"
+  ],
+  "GetSceneOverlayID": [
+   "overlay_2",
+   "overlay_3",
+   "overlay_5",
+   "overlay_6",
+   "overlay_7"
+  ],
+  "Goomboss_Spawn": [
+   "func_020aed98"
+  ],
+  "Grindel_Spawn": [
+   "_ZTV7daDkk_c"
+  ],
+  "RollingLogLll_Spawn": [
+   "_ZTV15daObjFlMaruta_c"
+  ],
+  "RollingLogTtm_Spawn": [
+   "_ZTV15daObjHmMaruta_c"
+  ],
+  "UnchainedChomp_Spawn": [
+   "func_020aed98"
+  ],
+  "Wiggler_Spawn": [
+   "func_020aed98"
+  ],
+  "_Z26LoadOrUnloadObjectOverlaysPFviEi": [
+   "overlay_102",
+   "overlay_60",
+   "overlay_98"
+  ],
+  "_ZN10CheepCheep13InitResourcesEv": [
+   "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj"
+  ],
+  "_ZN10FlameChomp13InitResourcesEv": [
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj"
+  ],
+  "_ZN10MrBlizzard13InitResourcesEv": [
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj"
+  ],
+  "_ZN10Scuttlebug13InitResourcesEv": [
+   "AnimLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "_ZN11FallBlockWf13InitResourcesEv": [
+   "func_0213a794"
+  ],
+  "_ZN11FallBlockWf16CleanupResourcesEv": [
+   "func_0213a2cc"
+  ],
+  "_ZN11FallBlockWfD0Ev": [
+   "G0",
+   "VT1",
+   "VT2",
+   "_ZTV10dBgActor_c"
+  ],
+  "_ZN11FallBlockWfD1Ev": [
+   "VT1",
+   "VT2",
+   "_ZTV10dBgActor_c"
+  ],
+  "_ZN11MirrorLuigi13InitResourcesEv": [
+   "Animation_LoadFile",
+   "ModelAnim_SetAnim",
+   "ModelBase_SetFile",
+   "Model_LoadFile",
+   "ShadowModel_InitCylinder",
+   "TextureSequence_Prepare",
+   "TextureSequence_SetFile"
+  ],
+  "_ZN12FallBlockBbhD0Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "_ZN12FallBlockBbhD1Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjTh_Fall_Block_c"
+  ],
+  "_ZN12FallBlockBfs13InitResourcesEv": [
+   "func_0213a794"
+  ],
+  "_ZN12FallBlockBfs16CleanupResourcesEv": [
+   "func_0213a2cc"
+  ],
+  "_ZN12FallBlockBfsD0Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV21daObjKm2_Fall_Block_c"
+  ],
+  "_ZN12FallBlockBfsD1Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV21daObjKm2_Fall_Block_c"
+  ],
+  "_ZN12FallBlockLll16CleanupResourcesEv": [
+   "func_021270dc"
+  ],
+  "_ZN12FallBlockLllD0Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjFlMaruta_c"
+  ],
+  "_ZN12FallBlockLllD1Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjFlMaruta_c"
+  ],
+  "_ZN13FortressTower13InitResourcesEv": [
+   "MeshCollider_LoadFile",
+   "ModelBase_SetFile",
+   "Model_LoadFile",
+   "MovingMeshCollider_SetFile",
+   "Platform_UpdateClsnPosAndRot",
+   "Platform_UpdateModelPosAndRotY"
+  ],
+  "_ZN13MontyMoleRock8BehaviorEv": [
+   "ActorBase_MarkForDestruction",
+   "Actor_FindWithID",
+   "Actor_MakeVanishLuigiWork",
+   "Actor_UpdatePos",
+   "CylinderClsn_Clear",
+   "CylinderClsn_Update",
+   "Enemy_UpdateWMClsn",
+   "Player_Hurt",
+   "WithMeshClsn_IsOnGround"
+  ],
+  "_ZN13PrincessPeach13InitResourcesEv": [
+   "AnimLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+  ],
+  "_ZN13RacingPenguin13InitResourcesEv": [
+   "Actor_TrackStar",
+   "Animation_LoadFile",
+   "ModelBase_SetFile",
+   "Model_LoadFile",
+   "MovingCylinderClsn_Init",
+   "PathPtr_FromID",
+   "PathPtr_GetNode",
+   "ShadowModel_InitCylinder",
+   "TextureSequence_LoadFile",
+   "TextureSequence_Prepare",
+   "WithMeshClsn_Init"
+  ],
+  "_ZN13RacingPenguin8BehaviorEv": [
+   "_Z23_ZN9Animation7AdvanceEvPc",
+   "_Z25_ZN12CylinderClsn5ClearEvPc",
+   "_Z26_ZN12CylinderClsn6UpdateEvPc",
+   "p__sinit_ov031_02111434"
+  ],
+  "_ZN13SnowmanBreath8BehaviorEv": [
+   "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3sijjPvj"
+  ],
+  "_ZN13TTC_MovingBar13InitResourcesEv": [
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "_ZN14CutsceneObject13InitResourcesEv": [
+   "_Z5_Znwji",
+   "func_02113c20"
+  ],
+  "_ZN14TtcMovingCubeA13InitResourcesEv": [
+   "func_02112118"
+  ],
+  "_ZN15BookShotSpawner13InitResourcesEv": [
+   "_Z17LoadBlueCoinModelPv",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv"
+  ],
+  "_ZN15TtcRotatingGear13InitResourcesEv": [
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+   "_Z37_ZN8Platform21UpdateModelPosAndRotYEvPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
+   "func_021121b8"
+  ],
+  "_ZN16BowserShockwaves13InitResourcesEv": [
+   "func_021115e4",
+   "func_021115f4"
+  ],
+  "_ZN16FloatingFloorBfs13InitResourcesEv": [
+   "func_020b6244"
+  ],
+  "_ZN16FloatingFloorBfs16CleanupResourcesEv": [
+   "func_020b60fc"
+  ],
+  "_ZN16RotatingCogSmall13InitResourcesEv": [
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "_ZN17MgBounceAndPounce11AfterRenderEj": [
+   "Scene_AfterRender"
+  ],
+  "_ZN17RotatingClockHand13InitResourcesEv": [
+   "MeshColliderLoadFile",
+   "ModelLoadFile",
+   "UpdatePosWithTransformSym",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "_ZN18BowserFireSeaArena13InitResourcesEv": [
+   "_Z13func_020393d4PvS_",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
+   "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "func_021115bc"
+  ],
+  "_ZN19RotatingPlatformLll8BehaviorEv": [
+   "Platform_IsClsnInRange",
+   "Platform_UpdateClsnPosAndRot",
+   "Platform_UpdateModelPosAndRotY",
+   "_Z13func_020393a4Pii"
+  ],
+  "_ZN19RotatingPlatformWdw13InitResourcesEv": [
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "_ZN22RotatingUpDownPlatform13InitResourcesEv": [
+   "Vec3_equal",
+   "_Z13func_020393c4PvS_",
+   "_Z13func_020393d4PvS_",
+   "_Z20_ZN7PathPtr6FromIDEjPvj",
+   "_Z31_ZNK7PathPtr7GetNodeER7Vector3jPvS_j",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+  ],
+  "_ZN22RotatingUpDownPlatform8BehaviorEv": [
+   "ApproachLinearI",
+   "UpdatePosWithVelocitySym",
+   "_ZN8Platform13IsClsnInRangeEii"
+  ],
+  "_ZN3HUD15RenderCoinCountEv": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad8"
+  ],
+  "_ZN3HUD15RenderLifeCountEv": [
+   "func_020ab948",
+   "func_020ab9c8",
+   "func_020aba70"
+  ],
+  "_ZN3HUD15RenderStarCountEv": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad0"
+  ],
+  "_ZN3HUD15RenderTimeTimerEv": [
+   "_ll_udiv",
+   "_ull_mod"
+  ],
+  "_ZN4cstd5atan2E5Fix12IiES1_": [
+   "func_01ff98f4"
+  ],
+  "_ZN5Cloud8BehaviorEv": [
+   "FindWithActorID",
+   "SetPolygonID"
+  ],
+  "_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc": [
+   "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv"
+  ],
+  "_ZN5FaderD0Ev": [
+   "base_dtor_Fader"
+  ],
+  "_ZN5Stage12RenderNumberEhiibi": [
+   "func_020aba70"
+  ],
+  "_ZN5Stage14GraphCallback2EP12SceneRelated": [
+   "reg_G2S_DB_BG3PA"
+  ],
+  "_ZN5Stage20RenderBouncingArrowsEv": [
+   "func_020abd88"
+  ],
+  "_ZN5Stage6RenderEv": [
+   "func_020ab9c8",
+   "func_020abad8"
+  ],
+  "_ZN5Stage9PS_RenderEv": [
+   "func_020ab9c8",
+   "func_020abac0",
+   "func_020abad8",
+   "func_020abd98",
+   "func_020ac218",
+   "func_020ac64c",
+   "func_020acb68",
+   "func_020ad04c"
+  ],
+  "_ZN6BobOmb8BehaviorEv": [
+   "func_020ada40"
+  ],
+  "_ZN6Bullet13InitResourcesEv": [
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
+   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
+   "func_0211d610"
+  ],
+  "_ZN6Eyerok13InitResourcesEv": [
+   "_Z13func_020393c4PvS_",
+   "_Z13func_020393d4PvS_",
+   "_Z22_ZN5Actor9TrackStarEjjPvjj",
+   "_Z32_ZN11ShadowModel12InitCylinderEvPv",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+   "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+   "_Z44_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16iijjP7Vector3Pvii",
+   "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
+   "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
+   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
+   "func_02112c08",
+   "func_02112ca8",
+   "func_02112d48"
+  ],
+  "_ZN7ClipperD0Ev": [
+   "base_dtor_Clipper"
+  ],
+  "_ZN7Skeeter8BehaviorEv": [
+   "func_020aea30"
+  ],
+  "_ZN7Tornado13InitResourcesEv": [
+   "func_02112968"
+  ],
+  "_ZN8CapEnemy6AddCapEj": [
+   "func_020ff028"
+  ],
+  "_ZN8Goomboss13InitResourcesEv": [
+   "func_021123f4",
+   "func_021124ac"
+  ],
+  "_ZN8SignPost13InitResourcesEv": [
+   "MeshColliderLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "_ZN9ActorBase21AfterCleanupResourcesEj": [
+   "Heap_Destroy",
+   "Memory_Deallocate",
+   "Memory_gameHeapPtr",
+   "gGlobalA",
+   "gGlobalB"
+  ],
+  "_ZN9Spindrift13InitResourcesEv": [
+   "AnimLoadFile",
+   "ModelLoadFile",
+   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+  ],
+  "_ZN9UkikiCageD0Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjHmMaruta_c"
+  ],
+  "_ZN9UkikiCageD1Ev": [
+   "_ZTV10dBgActor_c",
+   "_ZTV15daObjHmMaruta_c"
+  ],
+  "__sinit_ov071_02122a64": [
+   "data_ov071_02122ecc_d"
+  ],
+  "func_02008b4c": [
+   "func_020effb8"
+  ],
+  "func_02009374": [
+   "Vec3_DistSq"
+  ],
+  "func_02014f5c": [
+   "func_020caf98"
+  ],
+  "func_02019ebc": [
+   "func_02061128"
+  ],
+  "func_0201a2f8": [
+   "func_020aa420",
+   "overlay_0",
+   "overlay_1"
+  ],
+  "func_0201a458": [
+   "func_0211d9c0",
+   "func_02140d80"
+  ],
+  "func_0201a614": [
+   "overlay_75"
+  ],
+  "func_0201a694": [
+   "overlay_75"
+  ],
+  "func_0201a754": [
+   "overlay_4",
+   "overlay_6"
+  ],
+  "func_0201a798": [
+   "overlay_4",
+   "overlay_6"
+  ],
+  "func_0201a8b4": [
+   "_ll_udiv"
+  ],
+  "func_02029408": [
+   "func_020bd828"
+  ],
+  "func_02034fbc": [
+   "overlay_64",
+   "overlay_66"
+  ],
+  "func_0203c178": [
+   "func_020527e9"
+  ],
+  "func_02042784": [
+   "_ll_udiv"
+  ],
+  "func_020427c4": [
+   "_ll_udiv"
+  ],
+  "func_02044b30": [
+   "@30"
+  ],
+  "func_02053130": [
+   "SQRTCNT",
+   "SQRT_RESULT"
+  ],
+  "func_02055454": [
+   "G"
+  ],
+  "func_020570c0": [
+   "G"
+  ],
+  "func_020570d8": [
+   "G"
+  ],
+  "func_02057128": [
+   "G"
+  ],
+  "func_02057140": [
+   "G"
+  ],
+  "func_02057410": [
+   "_ll_mod"
+  ],
+  "func_02058308": [
+   "func_00000000",
+   "func_00000600"
+  ],
+  "func_02058df4": [
+   "func_00000000",
+   "func_00000600"
+  ],
+  "func_02059640": [
+   "G"
+  ],
+  "func_02059a60": [
+   "_ll_udiv"
+  ],
+  "func_02059f48": [
+   "G"
+  ],
+  "func_0205f650": [
+   "G"
+  ],
+  "func_0206ece0": [
+   "func_01ff9e2c"
+  ],
+  "func_0206f46c": [
+   "_deq"
+  ],
+  "func_0206f820": [
+   "_ll_udiv",
+   "_ull_mod"
+  ],
+  "func_020708b4": [
+   "_deq"
+  ],
+  "func_02070c68": [
+   "func_01ff9d40"
+  ],
+  "func_02071510": [
+   "_ll_udiv",
+   "_ull_mod"
+  ],
+  "func_ov002_020bd664": [
+   "_ZGVtable$8",
+   "table$8"
+  ],
+  "func_ov002_020c0fb4": [
+   "_ll_udiv"
+  ],
+  "func_ov002_020c8a4c": [
+   "_Z13func_020072c0v",
+   "_ZN6Player7SetAnimEjiij"
+  ],
+  "func_ov002_020dc560": [
+   "func_01ff98f4",
+   "func_01ff99a4"
+  ],
+  "func_ov002_020ec670": [
+   "func_02123804"
+  ],
+  "func_ov002_020f7d74": [
+   "_ZGVdata_ov002_0211104c$8",
+   "data_ov002_0211104c$8"
+  ],
+  "func_ov003_020adfc8": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad8"
+  ],
+  "func_ov003_020ae0b0": [
+   "func_020ab9c8",
+   "func_020aba70",
+   "func_020abad0"
+  ],
+  "func_ov003_020ae238": [
+   "func_020ab948",
+   "func_020ab9c8",
+   "func_020aba70"
+  ],
+  "func_ov004_020b2cb8": [
+   "@7"
+  ],
+  "func_ov004_020b87e0": [
+   "_ZGVtable$6",
+   "table$6"
+  ],
+  "func_ov006_020c0a48": [
+   "g0",
+   "g1",
+   "g2"
+  ],
+  "func_ov006_020c14bc": [
+   "func_020beb68"
+  ],
+  "func_ov006_020c221c": [
+   "g0",
+   "g1"
+  ],
+  "func_ov006_020c3bc8": [
+   "func_020c3adc"
+  ],
+  "func_ov006_020db720": [
+   "func_020beb68"
+  ],
+  "func_ov006_020db9dc": [
+   "func_020bc7d4"
+  ],
+  "func_ov006_020dcd74": [
+   "func_020beb68"
+  ],
+  "func_ov006_020de1d4": [
+   "func_020beb68"
+  ],
+  "func_ov006_020de26c": [
+   "func_020beb68"
+  ],
+  "func_ov006_020de440": [
+   "func_020beb68"
+  ],
+  "func_ov006_020de584": [
+   "func_020ddd6c"
+  ],
+  "func_ov006_020e3578": [
+   "func_020adc74"
+  ],
+  "func_ov006_020e6894": [
+   "func_020adc74"
+  ],
+  "func_ov006_020e7124": [
+   "func_020beb74"
+  ],
+  "func_ov006_020e989c": [
+   "func_020beb68"
+  ],
+  "func_ov006_020e9c20": [
+   "func_020beb68"
+  ],
+  "func_ov006_020e9cec": [
+   "G0",
+   "G1"
+  ],
+  "func_ov006_020ea3d0": [
+   "func_020beb68"
+  ],
+  "func_ov006_020ee2c4": [
+   "func_020beb68"
+  ],
+  "func_ov006_020efcf8": [
+   "data_04000006"
+  ],
+  "func_ov006_020f0274": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f3294": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f3460": [
+   "func_020adc74",
+   "func_020bc864",
+   "func_020bc888"
+  ],
+  "func_ov006_020f3834": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "func_ov006_020f4888": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f52c4": [
+   "func_020bc7d4",
+   "func_020beb68"
+  ],
+  "func_ov006_020f53e4": [
+   "func_020bc7d4"
+  ],
+  "func_ov006_020f5564": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "func_ov006_020f6538": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f7394": [
+   "func_020bc7d4",
+   "func_020beb68"
+  ],
+  "func_ov006_020f74b4": [
+   "func_020bc7d4"
+  ],
+  "func_ov006_020f7634": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "func_ov006_020f7c10": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f869c": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f8a3c": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f8c68": [
+   "func_020bc7d4"
+  ],
+  "func_ov006_020f8d08": [
+   "func_020beb68"
+  ],
+  "func_ov006_020f8ef4": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "func_ov006_021071fc": [
+   "func_020beb68"
+  ],
+  "func_ov006_02108f2c": [
+   "func_020b9488"
+  ],
+  "func_ov006_021095cc": [
+   "func_020bc7d4",
+   "func_020beb68"
+  ],
+  "func_ov006_02109aac": [
+   "func_020beb68"
+  ],
+  "func_ov006_0210a708": [
+   "func_020beb6c"
+  ],
+  "func_ov006_0210a8c0": [
+   "func_020ad494"
+  ],
+  "func_ov006_0210a900": [
+   "func_020ad494"
+  ],
+  "func_ov006_0210a954": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "func_ov006_0210bdb0": [
+   "func_020bc860",
+   "func_020bc864",
+   "func_020bc878",
+   "func_020bc888",
+   "func_020bc88c",
+   "func_020bc890",
+   "func_020bc8b4",
+   "func_020bc8b8"
+  ],
+  "func_ov006_0210c2d4": [
+   "func_020beb68"
+  ],
+  "func_ov006_0210d1fc": [
+   "func_020bc860",
+   "func_020bc878",
+   "func_020bc88c",
+   "func_020bc890",
+   "func_020bc8b4",
+   "func_020bc8b8"
+  ],
+  "func_ov006_0210d6b8": [
+   "func_020ad494"
+  ],
+  "func_ov006_02115b0c": [
+   "func_020adc74"
+  ],
+  "func_ov006_02118488": [
+   "func_020bc864",
+   "func_020bc888"
+  ],
+  "func_ov006_02119904": [
+   "_ZN10SysTrackerD1Ev"
+  ],
+  "func_ov006_0211fd44": [
+   "func_020beb68"
+  ],
+  "func_ov006_021200dc": [
+   "func_020beb6c"
+  ],
+  "func_ov006_021203fc": [
+   "func_020bc880",
+   "func_020bc884"
+  ],
+  "func_ov006_02125364": [
+   "func_020bc7d4"
+  ],
+  "func_ov006_02129268": [
+   "func_020adc74"
+  ],
+  "func_ov006_0212b480": [
+   "func_020adc74",
+   "func_020bc86c",
+   "func_020bc898",
+   "func_020bc8a4",
+   "func_020bc8a8"
+  ],
+  "func_ov007_020bcf90": [
+   "func_02055574",
+   "func_020b2160",
+   "func_020b2370",
+   "func_020b2728",
+   "func_020b2cf0",
+   "func_020b413c",
+   "func_020b4464",
+   "func_020b7658",
+   "func_020b7a00",
+   "func_020b7a34",
+   "func_020b8fd4",
+   "func_020b91b4",
+   "func_020bee14",
+   "func_020bfaf0",
+   "func_020c232c",
+   "func_020c2390",
+   "func_020c93b4"
+  ],
+  "func_ov007_020c798c": [
+   "func_020c3df4",
+   "func_020c78b0",
+   "func_020c80a4",
+   "func_020c844c"
+  ],
+  "func_ov007_020c8970": [
+   "func_020c897c"
+  ],
+  "func_ov007_020cc2cc": [
+   "overlay_64",
+   "overlay_66"
+  ],
+  "func_ov007_020cc4c0": [
+   "overlay_100",
+   "overlay_102"
+  ],
+  "func_ov015_02112c84": [
+   "func_020b66a8"
+  ],
+  "func_ov016_02112fa8": [
+   "func_020b5e58"
+  ],
+  "func_ov020_021112b0": [
+   "Actor_ClosestPlayer",
+   "cstd_atan2"
+  ],
+  "func_ov021_02111434": [
+   "conv_ov021"
+  ],
+  "func_ov022_0211165c": [
+   "func_020b66a8"
+  ],
+  "func_ov022_02112380": [
+   "_ZTV10dBgActor_c",
+   "_ZTV20daObjFl_Fall_Block_c"
+  ],
+  "func_ov022_02112434": [
+   "func_0213a2cc"
+  ],
+  "func_ov022_02112448": [
+   "func_0213a794"
+  ],
+  "func_ov025_021118c8": [
+   "_ZTV10dBgActor_c",
+   "_ZTV7daDkk_c"
+  ],
+  "func_ov025_02111928": [
+   "G0",
+   "VT0",
+   "VT1",
+   "VT2"
+  ],
+  "func_ov026_02111598": [
+   "func_ov053_021112a4"
+  ],
+  "func_ov034_02111788": [
+   "_Z32_ZN5Actor10PoofDustAtERK7Vector3PvPK7Vector3",
+   "_Z45_ZN5Actor19UntrackAndSpawnStarERajRK7Vector3hPvPajPK7Vector3j"
+  ],
+  "func_ov036_0211244c": [
+   "func_020efaf0"
+  ],
+  "func_ov045_02111bc8": [
+   "func_020b6424"
+  ],
+  "func_ov045_02111bdc": [
+   "func_020b6584"
+  ],
+  "func_ov060_021182b0": [
+   "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+  ],
+  "func_ov062_02116010": [
+   "func_020ada40"
+  ],
+  "func_ov062_02117c98": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "func_ov063_0211a0dc": [
+   "func_020ada40"
+  ],
+  "func_ov064_02116754": [
+   "func_020ada40"
+  ],
+  "func_ov065_02115ff0": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "func_ov065_0211704c": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "func_ov065_0211a358": [
+   "_Z30_ZN11ShadowModel10InitCuboidEvPv",
+   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
+   "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
+   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
+   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+   "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "func_02112198"
+  ],
+  "func_ov065_0211b1d4": [
+   "MeshColliderLoadFile",
+   "ModelLoadFile",
+   "UpdatePosWithTransformSym",
+   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+   "func_02112258"
+  ],
+  "func_ov066_021166c8": [
+   "_Z13func_02112c88v",
+   "_Z13func_02112cc8v",
+   "_Z19func_ov066_0211a35cv",
+   "_Z23func_02112cd8_updateposv"
+  ],
+  "func_ov066_02116db0": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "func_ov066_021175e8": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "func_ov066_02117bf0": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "func_ov066_02118188": [
+   "func_02112c08",
+   "func_02112d48"
+  ],
+  "func_ov070_0211f100": [
+   "func_020aea30"
+  ],
+  "func_ov075_02116f40": [
+   "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
+   "func_020abd88"
+  ],
+  "func_ov075_02117bc4": [
+   "overlay_64",
+   "overlay_66"
+  ],
+  "func_ov081_021243cc": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "func_ov084_02129a00": [
+   "func_020aea30"
+  ],
+  "func_ov084_02129ed4": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "func_ov084_0212a774": [
+   "func_020aea30"
+  ],
+  "func_ov085_02129f8c": [
+   "normalize"
+  ],
+  "func_ov089_0213162c": [
+   "data_02111b68"
+  ],
+  "func_ov090_021310b4": [
+   "func_020ada40",
+   "func_020aea30"
+  ],
+  "func_ov091_021339fc": [
+   "func_020aea30"
+  ],
+  "func_ov098_021390ec": [
+   "_Z19func_ov002_020ef228Pvi",
+   "_ZN5Actor12ReflectAngleEiis"
+  ],
+  "func_ov100_0214109c": [
+   "ActorBase_MarkForDestruction"
+  ],
+  "func_ov100_02141fb0": [
+   "func_020ada40"
+  ],
+  "func_ov100_0214272c": [
+   "func_020ad660"
+  ],
+  "func_ov100_02142918": [
+   "func_020ad660"
+  ],
+  "func_ov100_02145080": [
+   "func_020ca78c"
+  ],
+  "func_ov100_02147054": [
+   "G0",
+   "G1",
+   "G2"
+  ],
+  "func_ov100_021470f4": [
+   "_Z16DecIfAbove0_BytePh",
+   "_Z9Vec3_DistPK7Vector3S1_",
+   "_ZN16MeshColliderBase6EnableEPv",
+   "_ZN9Platform219UpdateClsnPosAndRotEv",
+   "_ZN9Platform313IsClsnInRangeEii"
+  ],
+  "func_ov100_021471e0": [
+   "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+   "func_020efaf0"
+  ],
+  "func_ov102_0214cbec": [
+   "func_020ada40"
+  ],
+  "main": [
+   "__main",
+   "_main"
+  ]
+ }
 }

--- a/notes/objisolate.md
+++ b/notes/objisolate.md
@@ -1,0 +1,195 @@
+# Building C++ destructors into the ROM
+
+`tools/objisolate.py`. Why 81 enrolled files could not link, and the four bugs
+between "it compiles" and 106/106.
+
+## The problem
+
+A C++ destructor cannot be compiled alone. `Coin::~Coin()` yields an object with
+**eight** content sections:
+
+```
+.text 0x58   _ZN4CoinD0Ev
+.text 0x50   _ZN4CoinD1Ev      <- the only one this file declares
+.text 0x50   _ZN4CoinD2Ev
+.data 0x10   _ZTV4Coin
+.data 0x6 0x7 0x8 0xc          RTTI record + type-name strings
+```
+
+Under the Itanium ABI the class vtable is emitted into the TU defining its key
+function, and mwcc emits every destructor variant alongside it. dsd's linker script
+selects code by section name — `_ZN4CoinD1Ev.o(.text)` — which matches **all three**
+`.text` sections and would place D0 and D2 at D1's address. So `eligible.py` rejected
+the object, correctly, and 81 files sat at `extra sections: .data`.
+
+The ROM says what to keep. ov002 declares `_ZN4CoinD1Ev` size 0x50 (ours matches),
+`_ZN4CoinD0Ev` size **0x64** (ours is 0x58 — the matching D0 is a separate `.c`
+file), `_ZTV4Coin` at 0x021087ec already carved out as a symbol, and **no D2 at all**.
+
+## The transformation
+
+Keep the declared function's `.text`, zero every other content section's `sh_size`,
+and rebind the survivor's references outward. Header surgery in place, never a
+rewrite — the same discipline as `retarget_text_section`, for the same reason: this
+build exists to compare bytes, so it must not perturb them. Nothing moves, so no
+relocation offset shifts and no symbol index changes.
+
+## The four bugs, in the order they appeared
+
+Each was caught by a different gate, and none by the one before it.
+
+**1. mwldarm: "sum of all symbol sizes exceed section size."** The first version
+externalised only `STB_GLOBAL`/`STB_WEAK`. mwcc had emitted an inline `_ZN4PVecD1Ev`
+under **`STB_LOPROC`**, a Metrowerks binding matching neither name, so its `st_size`
+of 4 survived into a section that had just been zeroed. Fix: sweep every symbol in a
+dropped section, whatever its binding.
+
+**2. A poisoned object cache.** The build stored objects *post*-isolation, and
+`isolate()` is idempotent — so once a buggy version had written an entry, a rebuild
+served it back and declined to re-fix it. Fix: cache the **raw** compile and isolate
+after fetch, plus `rombuild_cache.SCHEMA` 1 → 2 to discard the poisoned entries. Any
+later change to the transformation now needs no bump at all.
+
+**3. The vtable pointer landed 8 bytes high** — 76 functions, 34 modules, and only
+the byte compare could see it:
+
+```
+Coin::~Coin       +0x4c   rom 021087ec   built 021087f4
+CameraTag::~...   +0x20   rom 021085f8   built 02108600
+```
+
+Two conventions for the same name. mwcc's `_ZTV4Coin` addresses the **start** of the
+vtable object, so the store into `this->vptr` relocates against it with an addend of
+**8** to step over offset-to-top and typeinfo. The ROM's symbols.txt uses the other:
+`_ZTV4Coin` **is** the slot array. This tree had already recorded that for
+`_ZTV5Actor` (0x0208e3a4). Rebinding without adjusting adds 8 twice.
+
+Fix: subtract `VTABLE_PREAMBLE` from the addend when externalising a `_ZTV*`
+reference. Surveyed across all 81 candidates first — 69 such relocations, every one
+`R_ARM_ABS32` with addend exactly 8 — and anything outside that shape is a **refusal**
+rather than a guess. A secondary vtable under multiple inheritance would be the
+obvious unseen case; refusing costs one function, guessing corrupts a module.
+
+(The other 6 local references are ordinary PC-relative branches carrying ARM's
+standard `-8` pipeline addend. Those need nothing.)
+
+**4. Isolation applied where it is unsound.** `func_ov002_020bd664.cpp` has a
+function-local static — `table$8` and its guard `_ZGVtable$8`, both **STB_LOCAL** in
+`.bss`, both addressed by the kept function. Zeroing the section while leaving them
+defined pointed those loads at offset 0 of an empty section, which the lcf still
+places *at the function's own address*. The ROM supplies that `.bss` from the gap
+object, so the file simply cannot be isolated.
+
+Fix, in two halves:
+
+* A **referenced** symbol in a dropped section becomes UNDEF regardless of binding.
+* `eligible.py` rule 5 then looks it up in symbols.txt, does not find `table$8`, and
+  rejects — the existing rule doing the work rather than a new special case.
+
+The second half needed its own fix: rule 5 was intersecting the live set with
+`undefined`, which is collected from a `STB_GLOBAL`/`STB_WEAK` loop, so a local never
+reached it. `live` is already "undefined **and** reached by the kept function", so it
+is now used directly. That change alone moved 7 files from wrongly-eligible to
+correctly-rejected.
+
+An **unreferenced** local is neither hazard: nothing outside can see it and nothing
+inside asks for it, so zeroing its size is enough. Marking it undefined would invent
+an import no ROM symbol could satisfy.
+
+## Result
+
+Measured against pristine `origin/main` at `c0fb4d17` in the same worktree, with
+`--no-isolate` supplying the before column:
+
+| | before | after |
+|---|---|---|
+| eligible | 10,722 | **10,802** (+80) |
+| of which destructors | 454 | **523** (+69) |
+| `.cpp` destructor files eligible | 30 of 105 | **99 of 105** |
+| `extra sections` rejections | 85 | **4** |
+| enrolled / source-built | 10,716 | **10,802** |
+| module fidelity | 106/106 exact | **106/106 exact** |
+| ROM code built from source | 86.83% | **87.72%** |
+
+An earlier draft of this table read 10,715 -> 10,800 (+85) with 24 of 105 destructor
+files. Those were measured on the tree of August 2026 and did not survive a main
+refresh. The numbers above are re-measured, and the before column is a name-by-name
+diff against a pristine run rather than a count match.
+
+`python tools/eligible.py --no-isolate` reproduces the before column, so the effect
+is a measurement rather than a claim. It is not a build option: rombuild always
+isolates, so classifying without it describes an object the build will not produce.
+
+## What the independent review added
+
+The −8 argument was verified far harder than the original 81-file survey managed:
+**all 387** `_ZTV*` symbols in `config/arm9/**/symbols.txt` (254 distinct addresses), checked against the
+retail images, have word `addr-8` == 0 (offset-to-top) and word `addr-4` pointing at
+a known RTTI record from `build/rtti.json`. 387/387. The slot-array convention holds
+without exception, and no entry labels a secondary vtable — a secondary's non-zero
+offset-to-top would have failed that check.
+
+It also found a real hole. **The guard only inspected relocations for symbols it was
+about to externalise.** A `_ZTV*` reloc whose symbol is UNDEF *from the start* is
+never a candidate, so it was never checked and never corrected. Two realistic shapes
+produce exactly that under 2004/b56:
+
+* a **constructor-only TU** — the vtable's key function is the DESTRUCTOR, so a TU
+  defining only `V::V()` references `_ZTV1V` without defining it, and the implicit
+  vptr store still carries addend 8;
+* a **derived destructor over an inline base destructor** — the object's own `_ZTV1D`
+  gets corrected while the inlined `_ZTV1B` store does not.
+
+Zero instances among the 3,352 enrolled C++ candidates, because their recovered
+sources spell the vptr store explicitly (`extern int _ZTV5Scene[]`, addend 0). Both
+arrive the moment a real-C++ constructor is enrolled — the direction this tree is
+moving. `plan()` now checks **every** `_ZTV`/`_ZTI`/`_ZTS` reference the kept function
+makes, and refuses a nonzero addend on an UNDEF one rather than correcting it: there
+is no enrolled instance to verify a correction against. `tools/test_objisolate.py`
+pins both cases.
+
+Also from the review, and fixed: `isolate` moved inside `classify`'s `try` so a
+malformed object is one file's verdict rather than a traceback; isolation restricted to `src/`
+(the guard is a literal `startswith("src/")`, so it exempts everything outside that
+tree -- today only `mods/`, whose rationale is in the `_isolate` docstring: a mod may
+legitimately carry helpers and data, and stripping them would bind their symbols to 0
+at runtime instead of failing loudly);
+`retarget_text_section` now refuses a multi-`.text` object instead of renaming an
+arbitrary one; and the SCHEMA-2 comment corrected — the cache stores the
+*retargeted* compile, so a change to `retarget_text_section` still needs a bump.
+
+## A follow-up that failed, and why it is worth recording
+
+7 vtable symbols were missing from symbols.txt, blocking 16 files with
+`unresolvable: _ZTV<class>`. `build/rtti.json` knew an address for all 7, and
+rtti.json's addresses agree with symbols.txt in **136/136** cases where both define a
+class — so adding the 7 as aliases looked safe, and 132 addresses in the tree already
+carry both an English and an RTTI name (`_ZTV4Coin` / `_ZTV8daCoin_c`).
+
+It was wrong. The build went to 101/106 with exactly those 16 files mismatching.
+dsd's own reloc table says why:
+
+```
+from:0x021125d8 kind:load to:0x02128338 module:overlays(79,80)
+from:0x02112490 kind:load to:0x0213c5bc module:overlays(6,98)
+```
+
+The vtable those ov022 functions reference lives in **another overlay**, and dsd
+cannot even resolve which one. Those 7 symbols were absent from ov022 *because they
+are cross-module*, and defining them locally made the references resolve to the wrong
+overlay's copy.
+
+The calibration measured the wrong thing. 136/136 agreement on **co-located** records
+established that the two files use the same *address convention*; it said nothing
+about *module attribution*, and the 7 in question were missing precisely because they
+were the non-co-located ones. A control that only covers the cases which already work
+cannot license the cases that do not. Reverted; the 16 files stay blocked, and
+unblocking them means resolving an ambiguous cross-overlay reference, not adding a
+symbol.
+
+## The rule this cost the most to learn
+
+**A clean link is not evidence.** Bug 3 linked perfectly, built a ROM, and wrote a
+vptr one entry past the truth in 34 modules. Only `rombuild.py`'s byte compare
+caught it — which is the same lesson already in the tree as "rombuild is the verdict,
+not build_pin.verify", arriving from a new direction.

--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -48,6 +48,7 @@ from elftools.elf.elffile import ELFFile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import build_pin as BP  # noqa: E402
+import objisolate as OI  # noqa: E402
 from enroll import candidates, CONFIG, REPO  # noqa: E402
 
 MW = REPO / "tools" / "mwccarm"
@@ -87,7 +88,7 @@ def defined_symbols():
 
 
 def classify(job):
-    rel, name, addr, size, sec, known, version = job
+    rel, name, addr, size, sec, known, version, isolate = job
     src = REPO / rel
     obj = BUILD / pathlib.Path(rel).with_suffix(".o")
     obj.parent.mkdir(parents=True, exist_ok=True)
@@ -115,7 +116,25 @@ def classify(job):
     if sec not in (".text", ".init"):
         return rel, name, f"lives in {sec}, not .text", []
 
+    # A C++ destructor cannot be compiled alone: mwcc emits D0/D1/D2 plus the class
+    # vtable and its RTTI into one object, because the Itanium ABI puts the vtable in
+    # the TU defining the key function. That object is not placeable -- the lcf's
+    # `File.o(.text)` matches all three code sections -- so it is reduced to the one
+    # function this file declares before being judged. See tools/objisolate.py; 81
+    # enrolled files sat at "extra sections: .data" for exactly this reason.
+    #
+    # Isolating HERE and in rombuild.compile_one both, from the same module, because a
+    # classifier that judges a different object than the build compiles is worse than
+    # no classifier: it passes files the build then breaks on. Same reason CFLAGS is
+    # imported from rombuild rather than copied.
     try:
+        # Inside the try: a malformed object -- a corrupt cache entry, a compiler that
+        # emitted something unparseable -- must be one file's verdict, not a traceback
+        # that ends the whole classification run.
+        plan = OI.isolate(obj, name) if isolate else {}
+        if plan.get("error") and plan.get("kind") != OI.NOT_A_FUNCTION:
+            return rel, name, f"isolate: {plan['error']}", []
+
         elf = ELFFile(io.BytesIO(obj.read_bytes()))
         content = []
         for s in elf.iter_sections():
@@ -162,7 +181,21 @@ def classify(job):
             return rel, name, f"size 0x{dsize:x} != declared 0x{size:x}", []
         if other_defined:
             return rel, name, "defines non-function globals: " + ",".join(other_defined[:3]), []
-        missing = sorted(set(undefined) - known)
+        # Only the imports the kept function actually reaches. Isolation leaves dead
+        # ones behind -- `_ZN4CoinD2Ev` (the ROM has no D2 variant at all) and the
+        # `abi::__class_type_info` vtables the dropped RTTI records referenced -- and
+        # rule 5's hazard is a weak gap-object import binding to 0, which needs a live
+        # reference to bind. Nothing names these, so nothing can bind to them.
+        # `live` is already "undefined AND reached by the kept function", so it is
+        # used directly rather than intersected with `undefined`. The intersection
+        # silently dropped the case that matters: `undefined` is collected from the
+        # STB_GLOBAL/STB_WEAK loop above, so an isolated function-local static --
+        # `table$8` and its guard in func_ov002_020bd664, both STB_LOCAL -- was never
+        # in it, and the file passed rule 5 while referencing a symbol no ROM module
+        # defines. It linked, and wrote the address of the function itself.
+        live = (OI.referenced_undefined(obj.read_bytes(), name) if isolate
+                else set(undefined))
+        missing = sorted(live - known)
         if missing:
             # `reason` is truncated for the histogram a human reads; `missing` is the
             # complete list, because a consumer that acts on it needs all of them. A
@@ -177,6 +210,12 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("-j", "--jobs", type=int, default=os.cpu_count() or 8)
+    # A/B switch for the isolation step, so its effect on the pass list is a
+    # measurement rather than a claim. Not a build option: rombuild always
+    # isolates, so classifying without it describes an object the build will
+    # not produce.
+    ap.add_argument("--no-isolate", action="store_true",
+                    help="classify raw objects (comparison only, not what rombuild builds)")
     args = ap.parse_args()
 
     known = defined_symbols()
@@ -186,7 +225,8 @@ def main():
     # compiler the build would not use for it whenever the two spellings differ. They
     # coincide today, which is exactly why the divergence would go unnoticed until the
     # day they did not.
-    jobs = [(rel, name, addr, size, sec, known, BP.version_for(rel, name) or VERSION)
+    jobs = [(rel, name, addr, size, sec, known, BP.version_for(rel, name) or VERSION,
+             not args.no_isolate)
             for (_d, name, rel, addr, size, sec) in cands]
     print(f"classifying {len(jobs)} enrolled functions with -j{args.jobs} ...")
 

--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -1,0 +1,329 @@
+"""Reduce a compiled object to the one function the delink entry declares.
+
+A C++ destructor cannot be compiled alone. `Coin::~Coin()` in a `.cpp` yields an
+object carrying *six* content sections -- three `.text` (D0 0x58, D1 0x50, D2 0x50)
+and five `.data` (the vtable plus the RTTI record and its name strings) -- because
+under the Itanium ABI the class's vtable is emitted into the TU that defines its
+key function, and mwcc emits every destructor variant alongside it.
+
+`eligible.py` rejects that object, correctly: dsd's linker script selects an
+object's code by section name (`Coin.o(.text)`), which matches ALL THREE `.text`
+sections and would place D0 and D2 at D1's address, and the `.data` would duplicate
+bytes the ROM's gap object already provides. 81 enrolled files sit at
+"extra sections: .data" for exactly this reason.
+
+The ROM's own layout says what to keep. For Coin, ov002 declares:
+
+    _ZN4CoinD1Ev  size 0x50  addr 0x020b0f54     <- ours, 0x50, keep
+    _ZN4CoinD0Ev  size 0x64  addr 0x020b0fa4     <- ours is 0x58; NOT ours
+    _ZTV4Coin                addr 0x021087ec     <- carved out already; import it
+    (no _ZN4CoinD2Ev anywhere)                   <- the ROM never had one
+
+So: keep D1's `.text`, drop everything else, and rebind D1's reference to the
+vtable from the object's own `.data` to the ROM's carved-out symbol. Surveyed over
+all 81, that is the shape of 69 of them; 11 reference no local symbol at all.
+
+HOW, AND WHY THIS WAY
+---------------------
+Header surgery in place, never a rewrite -- the same discipline as
+`rombuild.retarget_text_section`, and for the same reason: this build exists to
+compare bytes against the ROM, so the one thing it must not do is perturb them.
+Dropping a section means zeroing its `sh_size`; the bytes stay in the file and the
+linker contributes none of them. Nothing moves, so no relocation offset shifts and
+no symbol index changes.
+
+THE ONE DANGEROUS CASE, AND WHY IT DICTATES THE DESIGN
+------------------------------------------------------
+A dropped symbol must become SHN_UNDEF -- an IMPORT -- and never a definition at a
+bogus address. dsd's gap objects import carved-out symbols *weakly*, so if this
+object kept defining `_ZTV4Coin` in a now-empty `.data`, every user of Coin's
+vtable in the ROM would bind to our address 0 instead of 0x021087ec. It would link
+clean and produce a ROM that jumps through a null vtable. Zeroing a section without
+also externalising its symbols is precisely the silent-corruption move, so the two
+steps are one operation here and are not separable.
+
+`_ZN4CoinD2Ev` is the awkward one: the ROM has no such symbol, so importing it
+would be unresolvable. But it is also unreferenced once D0's section is gone --
+verified per-file rather than assumed, via `dead_symbols`, and reported so a caller
+can reject a file where it is not true.
+"""
+import io
+
+from elftools.elf.elffile import ELFFile
+from elftools.elf.relocation import RelocationSection
+
+CONTENT = ("SHT_PROGBITS", "SHT_NOBITS")
+IGNORE = (".comment", ".debug", ".line", ".note")
+
+SHN_UNDEF = 0
+R_ARM_ABS32 = 2
+
+# "There is nothing here to reduce" -- not a failure. An object whose enrolled symbol
+# is not a defined function in it (an assembly stub, a data entry) simply has no
+# section to keep, and the other gates judge it on their own terms.
+#
+# Callers must branch on this, so it is a value rather than a prose match. Both
+# call sites used to compare against the message text -- one with `!=` on the whole
+# formatted string, one with `.endswith` -- so adding a period here would have made
+# eligible.py report a hard reason for every such file while rombuild kept passing
+# them, with the two disagreeing about the same object.
+NOT_A_FUNCTION = "not-a-defined-function"
+
+# The two words of Itanium primary-vtable preamble: offset-to-top, then typeinfo.
+#
+# mwcc's own `_ZTV<C>` symbol addresses the START of the vtable object, so the store
+# into `this->vptr` relocates against it with an addend of 8 to step over those two
+# words. The ROM's symbols.txt uses the other convention -- `_ZTV<C>` IS the slot
+# array, already past the preamble; this tree recorded that for `_ZTV5Actor`
+# (0x0208e3a4) when reading it with a -2/-1 header shifted every slot by two.
+#
+# Rebinding the reloc to the ROM's symbol without adjusting therefore adds 8 twice.
+# It links clean and writes a vptr one entry past the truth: measured as
+# `Coin::~Coin +0x4c  rom 021087ec  built 021087f4` across 76 functions and 34
+# modules. Nothing catches that except the byte compare, which is why the addend is
+# corrected here and an unexpected one is a refusal rather than a guess.
+VTABLE_PREAMBLE = 8
+
+
+def _shdr_offset(elf, index):
+    """File offset of section header `index`."""
+    return elf["e_shoff"] + index * elf["e_shentsize"]
+
+
+def plan(raw, keep_symbol):
+    """What isolation would do, without doing it.
+
+    Returns a dict:
+      keep        section index the wanted function lives in, or None
+      drop        section indices to zero
+      externalise symbol names to turn into imports (referenced by the survivor)
+      dead        symbol names dropped and referenced by nothing
+      error       why isolation is impossible, or None
+      kind        machine-readable tag for an error a caller must branch on;
+                  only NOT_A_FUNCTION today, absent for every other error
+    """
+    elf = ELFFile(io.BytesIO(raw))
+    secs = list(elf.iter_sections())
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return {"error": "no .symtab"}
+
+    keep = None
+    for s in symtab.iter_symbols():
+        if (s.name == keep_symbol and s["st_shndx"] != "SHN_UNDEF"
+                and s["st_info"]["type"] == "STT_FUNC"):
+            keep = s["st_shndx"]
+    if not isinstance(keep, int):
+        return {"error": f"{keep_symbol} is not a defined function here",
+                "kind": NOT_A_FUNCTION}
+
+    drop = [i for i, s in enumerate(secs)
+            if s.header["sh_type"] in CONTENT and s.header["sh_size"]
+            and i != keep and not any(s.name.startswith(p) for p in IGNORE)]
+    dropset = set(drop)
+
+    # Relocation sections that describe dropped sections go too: their targets no
+    # longer exist, and leaving them would have the linker apply fixups into a
+    # zero-length section.
+    drop += [i for i, s in enumerate(secs)
+             if isinstance(s, RelocationSection) and s.header["sh_size"]
+             and s.header["sh_info"] in dropset]
+
+    # What the SURVIVING section still points at decides import-vs-dead.
+    referenced = set()
+    for s in secs:
+        if isinstance(s, RelocationSection) and s.header["sh_info"] == keep:
+            for r in s.iter_relocations():
+                sym = symtab.get_symbol(r["r_info_sym"])
+                if sym.name:
+                    referenced.add(sym.name)
+
+    externalise, dead = [], []
+    for s in symtab.iter_symbols():
+        if not s.name or s.name == keep_symbol:
+            continue
+        if s["st_shndx"] in dropset:
+            (externalise if s.name in referenced else dead).append(s.name)
+
+    # EVERY RTTI-ish reference the kept function makes is checked, not only the ones
+    # being externalised. Checking only the externalised set leaves a hole with a
+    # demonstrated failing input:
+    #
+    #   A vtable symbol can be UNDEF in the object from the start, and then it is
+    #   never a candidate for externalisation and never gets looked at. mwcc emits
+    #   exactly that for a constructor-only TU -- the vtable's key function is the
+    #   DESTRUCTOR, so a TU defining only `V::V()` references `_ZTV1V` without
+    #   defining it -- and the implicit vptr store still carries addend 8. Same shape
+    #   for a derived destructor over an inline base destructor: the object's own
+    #   `_ZTV1D` gets corrected while the inlined `_ZTV1B` store does not.
+    #
+    #   Neither is hypothetical; both were reproduced under 2004/b56. Neither occurs
+    #   in the 3,352 enrolled C++ candidates today, because their recovered sources
+    #   spell the vptr store explicitly (`extern int _ZTV5Scene[]`, addend 0). Both
+    #   arrive the moment a real-C++ constructor is enrolled, which is the direction
+    #   this tree is moving.
+    #
+    # An UNDEF reference must therefore already be addend 0 -- the ROM symbol IS the
+    # slot array, so symbol+0 is the whole address. A nonzero one is refused rather
+    # than corrected: there is no enrolled instance to verify a correction against,
+    # and fail-closed costs one function while fail-open corrupts a module.
+    ext = set(externalise)
+    for s in secs:
+        if not isinstance(s, RelocationSection) or s.header["sh_info"] != keep:
+            continue
+        for r in s.iter_relocations():
+            sym = symtab.get_symbol(r["r_info_sym"])
+            addend = r["r_addend"] if s.is_RELA() else None
+            shndx = sym["st_shndx"]
+
+            # A reloc through a section symbol into a dropped section carries its
+            # target in the addend alone, so externalising cannot preserve it and
+            # nothing would flag the result. Zero instances enrolled; cheap to refuse.
+            if not sym.name and shndx in dropset:
+                return {"error": f"unnamed section-symbol reloc into dropped section "
+                                 f"{secs[shndx].name} at 0x{r['r_offset']:x}"}
+
+            if not sym.name.startswith(("_ZTV", "_ZTI", "_ZTS")):
+                continue
+            if not s.is_RELA():
+                return {"error": f"{sym.name}: RTTI reloc is REL, not RELA"}
+
+            if sym.name in ext:
+                # Being externalised: only the surveyed vtable shape is correctable.
+                want = (R_ARM_ABS32, VTABLE_PREAMBLE) if sym.name.startswith("_ZTV") \
+                    else (R_ARM_ABS32, 0)
+                if (r["r_info_type"], addend) != want:
+                    return {"error": f"{sym.name}: unexpected reloc "
+                                     f"type={r['r_info_type']} addend={addend}"}
+            elif shndx == "SHN_UNDEF" or shndx == SHN_UNDEF:
+                if addend:
+                    return {"error": f"{sym.name}: undefined RTTI reference with "
+                                     f"addend {addend}; the ROM symbol is already the "
+                                     f"slot array, so this would land {addend} past it"}
+
+    return {"keep": keep, "drop": sorted(set(drop)), "externalise": sorted(externalise),
+            "dead": sorted(dead), "referenced": sorted(referenced), "error": None}
+
+
+def referenced_undefined(raw, keep_symbol):
+    """Undefined symbol names the kept function actually references.
+
+    `eligible.py` rule 5 rejects an undefined symbol that config/**/symbols.txt does
+    not define, because gap objects import weakly and an invented name would bind
+    silently to 0. That hazard needs something to bind: after isolation an object
+    carries dead imports (`_ZN4CoinD2Ev`, `_ZTVN3abi17__class_type_infoE`) that no
+    surviving relocation names, and those cannot bind to anything because nothing
+    looks them up. Rule 5 is therefore applied to this set rather than to every
+    undefined symbol in the table."""
+    elf = ELFFile(io.BytesIO(raw))
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return set()
+    keep = None
+    for s in symtab.iter_symbols():
+        if (s.name == keep_symbol and s["st_shndx"] != "SHN_UNDEF"
+                and s["st_info"]["type"] == "STT_FUNC"):
+            keep = s["st_shndx"]
+    out = set()
+    for s in elf.iter_sections():
+        if isinstance(s, RelocationSection) and s.header["sh_info"] == keep:
+            for r in s.iter_relocations():
+                sym = symtab.get_symbol(r["r_info_sym"])
+                if sym.name and sym["st_shndx"] == "SHN_UNDEF":
+                    out.add(sym.name)
+    return out
+
+
+def isolate(obj, keep_symbol):
+    """Apply `plan` to the object file in place. Returns the plan.
+
+    Idempotent: an object with nothing left to drop is rewritten to the same bytes,
+    so a cached object processed by an earlier build is not corrupted by a later
+    one."""
+    raw = bytearray(obj.read_bytes())
+    p = plan(bytes(raw), keep_symbol)
+    if p.get("error"):
+        return p
+    if not p["drop"] and not p["externalise"]:
+        return p
+
+    elf = ELFFile(io.BytesIO(bytes(raw)))
+    endian = "<" if elf.little_endian else ">"
+    import struct
+
+    # sh_size is at +0x14 in a 32-bit Elf32_Shdr.
+    for i in p["drop"]:
+        off = _shdr_offset(elf, i) + 0x14
+        struct.pack_into(endian + "I", raw, off, 0)
+
+    # Elf32_Sym is 16 bytes: name(4) value(4) size(4) info(1) other(1) shndx(2).
+    symtab = elf.get_section_by_name(".symtab")
+    base = symtab.header["sh_offset"]
+    dropset = set(p["drop"])
+    referenced = set(p["externalise"])
+
+    def ext_or_visible(sym):
+        """Names that must become imports: referenced by the survivor, or visible."""
+        if sym.name in referenced:
+            return {sym.name}
+        return {sym.name} if sym["st_info"]["bind"] != "STB_LOCAL" else set()
+
+    for idx, s in enumerate(symtab.iter_symbols()):
+        if s.name == keep_symbol or s["st_shndx"] not in dropset:
+            continue
+        # EVERY symbol in a dropped section, whatever its binding -- not just
+        # STB_GLOBAL/STB_WEAK. Restricting it to those two is what made mwldarm
+        # reject `_ZN6Player18St_YoshiPower_MainEv.o` with "the sum of all symbol
+        # sizes exceed section size": mwcc had emitted an inline `_ZN4PVecD1Ev`
+        # under STB_LOPROC, a Metrowerks binding neither name matches, so its
+        # st_size of 4 survived into a section that had just been zeroed. A symbol
+        # claiming bytes its section no longer has is a malformed object, and the
+        # linker is right to refuse it.
+        ent = base + idx * 16
+        struct.pack_into(endian + "I", raw, ent + 4, 0)          # st_value
+        struct.pack_into(endian + "I", raw, ent + 8, 0)          # st_size
+        # UNDEF unless it is a LOCAL that nothing references.
+        #
+        # Two separate hazards, and a local hits the second one even though it is
+        # invisible to other objects:
+        #
+        #   left defined and externally visible -- it sits at offset 0 of an empty
+        #   section, which the lcf still places at the kept function's address, so a
+        #   weak gap-object import of that name binds there. `_ZN4CoinD0Ev` would
+        #   resolve to Coin's D1.
+        #
+        #   left defined and REFERENCED -- the kept function's own relocation
+        #   resolves to that same wrong address. `func_ov002_020bd664` is the case:
+        #   a function-local static `table$8` and its guard `_ZGVtable$8`, both
+        #   STB_LOCAL in .bss, both addressed by the function. Zeroing the section
+        #   and keeping them defined pointed the loads at the function itself. The
+        #   ROM supplies that .bss from the gap object, so this file simply cannot be
+        #   isolated -- and made UNDEF it says so, because rule 5 then looks
+        #   `table$8` up in symbols.txt, does not find it, and rejects. That is the
+        #   existing rule doing the work rather than a new special case.
+        #
+        # An unreferenced local is neither: nothing outside can see it and nothing
+        # inside asks for it, so zeroing its size is enough. Marking it undefined
+        # would invent an import that no ROM symbol could satisfy.
+        if s.name in ext_or_visible(s):
+            struct.pack_into(endian + "H", raw, ent + 14, SHN_UNDEF)
+
+    # Drop the preamble skip from every externalised vtable reference, now that the
+    # symbol it binds to already points at the slot array. Elf32_Rela is 12 bytes:
+    # r_offset(4) r_info(4) r_addend(4). `plan` has already refused anything whose
+    # type/addend is not the surveyed shape, so this only ever rewrites 8 -> 0.
+    ext = set(p["externalise"])
+    for s in elf.iter_sections():
+        if not isinstance(s, RelocationSection) or s.header["sh_info"] != p["keep"]:
+            continue
+        if not s.is_RELA():
+            continue
+        roff = s.header["sh_offset"]
+        for i, r in enumerate(s.iter_relocations()):
+            sym = symtab.get_symbol(r["r_info_sym"])
+            if sym.name in ext and sym.name.startswith("_ZTV"):
+                struct.pack_into(endian + "i", raw, roff + i * 12 + 8,
+                                 r["r_addend"] - VTABLE_PREAMBLE)
+
+    obj.write_bytes(bytes(raw))
+    return p

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -49,6 +49,7 @@ INCLUDE = REPO / "include"
 CONFIG_ROOT = REPO / "config" / "arm9"
 BUILD = REPO / "build"
 sys.path.insert(0, str(REPO / "tools"))
+import objisolate as OI  # noqa: E402
 import rombuild_cache as RBK  # noqa: E402
 import rombuild_check as RBC  # noqa: E402
 import layout_check as LAY  # noqa: E402
@@ -221,6 +222,55 @@ def init_section_sources():
     return {rel for (_d, _name, rel, _addr, _size, sec) in cands if sec == ".init"}
 
 
+def _isolate(obj, rel, syms):
+    """Reduce a compiled `src/` object to its declared function. Returns an error or None.
+
+    `mods/` is deliberately exempt. A mod is not a recovered ROM function: it may
+    legitimately define helpers and data alongside its entry point, and isolation
+    would strip them and externalise their symbols, which weak gap-object imports
+    then bind to 0 at runtime. Silently producing a mod that jumps through null is
+    far worse than a mod that fails to link, so mods keep the whole object.
+    """
+    if not rel.replace("\\", "/").startswith("src/"):
+        return None
+    plan = OI.isolate(obj, (syms or {}).get(rel, pathlib.Path(rel).stem))
+    if plan.get("kind") == OI.NOT_A_FUNCTION:
+        return None          # nothing to reduce; other gates judge this file
+    return plan.get("error")
+
+
+def _retarget(obj, rel, init_srcs):
+    """retarget_text_section as a per-file verdict. Returns an error or None.
+
+    The helper raises, which is right for a helper -- but these calls run under
+    `ex.map`, where a raise escapes the result loop and ends the whole build with a
+    traceback instead of failing the one file that provoked it. A malformed object
+    is one source's problem; `eligible.py` reaches the same conclusion for the same
+    reason, and the two now agree.
+    """
+    if not (init_srcs and rel in init_srcs):
+        return None
+    try:
+        retarget_text_section(obj)
+    except RuntimeError as e:
+        return str(e)
+    return None
+
+
+def enrolled_symbols():
+    """{rel: symbol} for enrolled sources.
+
+    objisolate needs the symbol to keep, and the file stem is NOT it -- not as a
+    rule. The two coincide for all 11,160 candidates today, which is exactly the
+    condition under which keying on the stem goes unnoticed until it does not; the
+    same divergence build_pin's version lookup already carries. Keying on the
+    enrolled symbol costs one dict and cannot drift.
+    """
+    import enroll as E
+    cands, _ = E.candidates()
+    return {rel: name for (_d, name, rel, _addr, _size, _sec) in cands}
+
+
 def retarget_text_section(obj, section=".init"):
     """Rename an object's `.text` section header to `section`, in place.
 
@@ -245,6 +295,14 @@ def retarget_text_section(obj, section=".init"):
     names = [s.name for s in elf.iter_sections()]
     if section in names:
         return False                          # already retargeted
+    # Renaming the FIRST .text and returning is only correct while there is exactly
+    # one. A multi-.text object -- any C++ destructor -- would get an arbitrary one
+    # renamed, and dsd's `File.o(.init)` selector would then place whichever section
+    # that happened to be. No .init candidate compiles to more than one .text today;
+    # this fails loudly on the day one does rather than mislinking it.
+    if len([n for n in names if n == ".text"]) > 1:
+        raise RuntimeError(f"{obj}: {names.count('.text')} .text sections; "
+                           f"cannot retarget to {section} unambiguously")
     base = elf.get_section(elf["e_shstrndx"]).header["sh_offset"]
     want = b".text\x00"
     for s in elf.iter_sections():
@@ -259,7 +317,7 @@ def retarget_text_section(obj, section=".init"):
     return False
 
 
-def compile_one(rel, vers=None, cache=None, init_srcs=None):
+def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None):
     """Compile one enrolled source file to the object path dsd's objects.txt names.
 
     Returns (rel, error-or-None, outcome), where outcome is how the object was
@@ -285,8 +343,12 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None):
     if key is not None:
         deps = cache.manifest(key)
         if deps is not None and cache.fetch(cache.object_key(key, deps), obj):
-            if init_srcs and rel in init_srcs:
-                retarget_text_section(obj)
+            err = _retarget(obj, rel, init_srcs)
+            if err:
+                return rel, f"retarget: {err}", "error"
+            err = _isolate(obj, rel, syms)
+            if err:
+                return rel, f"isolate: {err}", "error"
             return rel, None, "hit"
 
     # -MD makes mwccarm write out the headers it actually read, which is what lets the
@@ -314,15 +376,23 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None):
             return rel, detail[:400], "error"
         # Before caching, so the stored object already carries the right section name
         # and a later hit needs no fixup.
-        if init_srcs and rel in init_srcs:
-            retarget_text_section(obj)
+        err = _retarget(obj, rel, init_srcs)
+        if err:
+            return rel, f"retarget: {err}", "error"
         if key is None:
-            return rel, None, "miss"
+            err = _isolate(obj, rel, syms)
+            return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
         deps = cache.deps_from(scratch)
         if deps is None:
-            return rel, None, "uncacheable"
+            err = _isolate(obj, rel, syms)
+            return (rel, f"isolate: {err}", "error") if err else (rel, None, "uncacheable")
+        # Cache the RAW object, then isolate the working copy. Storing the reduced
+        # form instead would bake this transformation into every entry, so any later
+        # fix to it would be masked by isolate()'s own idempotence -- which is exactly
+        # how the STB_LOPROC bug survived a rebuild and forced SCHEMA 2.
         cache.put(key, deps, obj)
-        return rel, None, "miss"
+        err = _isolate(obj, rel, syms)
+        return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
     finally:
         if scratch:
             shutil.rmtree(scratch, ignore_errors=True)
@@ -418,6 +488,7 @@ def main():
         cache = RBK.ObjectCache(args.cache_dir or (BUILD / "objcache"), REPO,
                                 enabled=not args.no_cache)
         init_srcs = init_section_sources()
+        syms = enrolled_symbols()
         print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
               + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
         failures = []
@@ -425,7 +496,7 @@ def main():
         if srcs:
             with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
                 for rel, err, outcome in ex.map(
-                        lambda s: compile_one(s, vers, cache, init_srcs), srcs):
+                        lambda s: compile_one(s, vers, cache, init_srcs, syms), srcs):
                     outcomes[outcome] = outcomes.get(outcome, 0) + 1
                     if err:
                         failures.append((rel, err))

--- a/tools/rombuild_cache.py
+++ b/tools/rombuild_cache.py
@@ -55,7 +55,14 @@ import tempfile
 import threading
 
 # Bump when the meaning of a key input changes; every stored entry then misses.
-SCHEMA = 1
+# Bumped to 2 when objisolate landed. Entries written before it were stored
+# post-isolation by a version whose symbol sweep missed STB_LOPROC, and because
+# isolate() is idempotent it declines to re-fix an object that already looks
+# reduced -- so a stale entry would be served broken forever. The cache now stores
+# the compile UN-isolated and applies isolation after fetch, so a later change to
+# objisolate needs no bump. Note it stores the RETARGETED compile -- retarget runs
+# before put -- so a change to retarget_text_section still does.
+SCHEMA = 2
 
 _DRIVE_RE = re.compile(r"^[A-Za-z]:/")
 

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -1,0 +1,141 @@
+"""What objisolate has to refuse.
+
+The vtable-addend case is the one that matters. mwcc's `_ZTV<C>` addresses the start
+of the vtable object, so a vptr store relocates against it with an addend of 8 to
+step over offset-to-top and typeinfo; symbols.txt's `_ZTV<C>` IS the slot array.
+Getting that wrong LINKS CLEANLY and writes a vptr one entry past the truth -- it
+cost 76 functions across 34 modules before the byte compare caught it, and no gate
+earlier than the byte compare can see it. If only one of these tests is ever kept,
+keep the addend ones.
+
+These compile real objects with the pinned mwccarm, because the whole subject is what
+a specific compiler emits; a hand-built ELF fixture would test this file's idea of
+mwcc rather than mwcc. They skip when the compiler is absent, so a checkout without
+tools/mwccarm still runs the rest of the suite.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import objisolate as OI  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MW = REPO / "tools" / "mwccarm"
+
+
+def _compiler():
+    try:
+        from rombuild import VERSION, CFLAGS
+    except Exception:
+        return None
+    exe = MW / VERSION / "mwccarm.exe"
+    return (exe, CFLAGS) if exe.is_file() else None
+
+
+@unittest.skipUnless(_compiler(), "mwccarm not present")
+class Isolate(unittest.TestCase):
+    def build(self, source):
+        exe, cflags = _compiler()
+        d = pathlib.Path(self.tmp.name)
+        src, obj = d / "t.cpp", d / "t.o"
+        src.write_text("//cpp\n" + source, encoding="utf-8")
+        r = subprocess.run(
+            [*os.environ.get("MWCCARM_LAUNCHER", "").split(), str(exe),
+             *cflags.replace("-lang c99", "-lang c++").split(),
+             "-i", str(REPO / "include"), "-c", str(src), "-o", str(obj)],
+            capture_output=True, text=True, cwd=REPO,
+            env=dict(os.environ, LM_LICENSE_FILE=str(MW / "license.dat")))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        return obj
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_plain_destructor_is_isolable(self):
+        """The case the whole pass exists for: D0/D1/D2 + vtable reduced to one."""
+        obj = self.build("struct P { int p[4]; virtual ~P(); virtual void f(); };\n"
+                         "P::~P(){}\n")
+        plan = OI.plan(obj.read_bytes(), "_ZN1PD1Ev")
+        self.assertIsNone(plan["error"])
+        self.assertIn("_ZTV1P", plan["externalise"])
+        self.assertIn("_ZN1PD0Ev", plan["dead"])
+
+    def test_vtable_addend_is_corrected_to_zero(self):
+        """8 -> 0, because the ROM symbol is already past the preamble."""
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+        import io
+        obj = self.build("struct P { int p[4]; virtual ~P(); virtual void f(); };\n"
+                         "P::~P(){}\n")
+        before = self._vtable_addends(obj, "_ZN1PD1Ev")
+        self.assertEqual(before, [8], "mwcc no longer emits the preamble-skip addend; "
+                                      "the -8 correction needs re-deriving")
+        OI.isolate(obj, "_ZN1PD1Ev")
+        self.assertEqual(self._vtable_addends(obj, "_ZN1PD1Ev"), [0])
+        # ...and re-running must not subtract another 8.
+        OI.isolate(obj, "_ZN1PD1Ev")
+        self.assertEqual(self._vtable_addends(obj, "_ZN1PD1Ev"), [0])
+        del ELFFile, RelocationSection, io
+
+    def _vtable_addends(self, obj, keep):
+        import io
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+        elf = ELFFile(io.BytesIO(obj.read_bytes()))
+        st = elf.get_section_by_name(".symtab")
+        idx = [s["st_shndx"] for s in st.iter_symbols()
+               if s.name == keep and s["st_shndx"] != "SHN_UNDEF"]
+        out = []
+        for s in elf.iter_sections():
+            if isinstance(s, RelocationSection) and s.header["sh_info"] in idx:
+                for r in s.iter_relocations():
+                    if st.get_symbol(r["r_info_sym"]).name.startswith("_ZTV"):
+                        out.append(r["r_addend"])
+        return out
+
+    def test_refuses_ctor_only_tu(self):
+        """A constructor's TU references the vtable without defining it.
+
+        The vtable's key function is the DESTRUCTOR, so a TU defining only `V::V()`
+        leaves `_ZTV1V` UNDEF -- which means it is never a candidate for
+        externalisation, and a guard that only inspects externalised symbols never
+        looks at it. The addend is still 8. Refusing keeps this out of the pass list
+        instead of letting it link and write the vptr one slot high."""
+        obj = self.build("struct V { int p[4]; V(); virtual ~V(); virtual void f(); };\n"
+                         "V::V(){}\n")
+        self.assertIn("_ZTV1V", OI.plan(obj.read_bytes(), "_ZN1VC1Ev")["error"])
+
+    def test_refuses_inlined_base_vtable_store(self):
+        """A derived dtor over an INLINE base dtor stores the base's vptr too.
+
+        The object's own `_ZTV1D` is in a dropped section and gets corrected; the
+        inlined `_ZTV1B` store is UNDEF and would not have been."""
+        obj = self.build("struct B { int p[4]; virtual ~B(){} virtual void f(); };\n"
+                         "struct D : B { virtual ~D(); };\n"
+                         "D::~D(){}\n")
+        self.assertIn("_ZTV1B", OI.plan(obj.read_bytes(), "_ZN1DD1Ev")["error"])
+
+    def test_local_static_is_reported_not_silently_dropped(self):
+        """A function-local static cannot be isolated away.
+
+        Its `.bss` comes from the ROM's gap object, and the symbol is STB_LOCAL so
+        nothing outside can supply it. isolate must externalise it anyway, so that
+        eligible.py rule 5 fails to find it in symbols.txt and rejects the file --
+        rather than leaving it defined at offset 0 of an emptied section, which the
+        lcf places at the kept function's own address."""
+        obj = self.build("int f(int);\nint g(int n){ static int t[8]; return t[n&7]+f(n); }\n")
+        plan = OI.plan(obj.read_bytes(), "_Z1gi")
+        self.assertIsNone(plan["error"])
+        self.assertTrue(plan["externalise"],
+                        "the referenced local static must be externalised")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -54,5 +54,58 @@ class RomBuildEnrollment(unittest.TestCase):
         self.assertIn("unsafe complete", raised.exception.output)
 
 
+def _compiler():
+    exe = RB.MW / RB.VERSION / "mwccarm.exe"
+    return exe if exe.is_file() else None
+
+
+@unittest.skipUnless(_compiler(), "mwccarm not present")
+class Retarget(unittest.TestCase):
+    """An object `.init` retargeting cannot handle must fail one file, not the run.
+
+    Real mwcc output rather than a fixture, for the reason test_objisolate gives: a
+    C++ destructor genuinely compiles to three `.text` sections, and renaming an
+    arbitrary one would have dsd's `File.o(.init)` selector place whichever it
+    happened to be.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        d = pathlib.Path(self.tmp.name)
+        self.obj = d / "t.o"
+        src = d / "t.cpp"
+        src.write_text("//cpp\nstruct V { virtual ~V(); int x; };\nV::~V() { x = 0; }\n",
+                       encoding="utf-8")
+        import os
+        import subprocess
+        r = subprocess.run(
+            [*os.environ.get("MWCCARM_LAUNCHER", "").split(), str(_compiler()),
+             *RB.CFLAGS.replace("-lang c99", "-lang c++").split(),
+             "-i", str(RB.INCLUDE), "-c", str(src), "-o", str(self.obj)],
+            capture_output=True, text=True, cwd=RB.REPO,
+            env=dict(os.environ, LM_LICENSE_FILE=str(RB.MW / "license.dat")))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_multi_text_object_is_refused(self):
+        with self.assertRaises(RuntimeError) as raised:
+            RB.retarget_text_section(self.obj)
+        self.assertIn(".text sections", str(raised.exception))
+
+    def test_refusal_becomes_a_per_file_verdict(self):
+        # The point of the wrapper: these calls run under ex.map, where a raise ends
+        # the whole build with a traceback instead of failing the one file.
+        err = RB._retarget(self.obj, "src/t.cpp", {"src/t.cpp"})
+        self.assertIsNotNone(err)
+        self.assertIn(".text sections", err)
+
+    def test_a_file_not_marked_init_is_untouched(self):
+        before = self.obj.read_bytes()
+        self.assertIsNone(RB._retarget(self.obj, "src/t.cpp", set()))
+        self.assertEqual(self.obj.read_bytes(), before)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A C++ destructor cannot be compiled alone. mwcc emits D0/D1/D2 together, and under the Itanium ABI the class vtable lands in the same TU, so the object has up to eight content sections. dsd's linker script selects code by section **name** — `_ZN4CoinD1Ev.o(.text)` — which matches all three `.text` sections and would place D0 and D2 at D1's address. `eligible.py` rejected those objects, correctly, and 85 files sat at `extra sections`.

`tools/objisolate.py` keeps the declared function's `.text`, zeroes every other content section's `sh_size`, and rebinds the survivor's references outward. Header surgery in place, never a rewrite: nothing moves, so no relocation offset shifts and no symbol index changes.

### This commit is the tooling only

It changes what is **eligible** and nothing about what is **enrolled**, so on its own it does not alter a single ROM byte. The enrollment that realises it is #TBD (stacked on this), deliberately separate: this half is independently revertible, and its gate is the exact-set reproduction below rather than the byte compare.

| | before | after |
|---|---|---|
| eligible | 10,724 | **10,804** (+80, of which 69 are D1) |
| eligible **lost** | — | **0** |
| `extra sections` rejections | 85 | **4** |
| `.cpp` destructor files eligible | 30/105 | **99/105** |

**`eligible.py --no-isolate` reproduces the pristine eligible set exactly** — diffed name-by-name against a pristine-`main` run in the same worktree, not count-matched — so the +80 is attributable to isolation alone. It is not a build option: `rombuild` always isolates, so classifying without it describes an object the build will not produce.

### The lesson this cost

`notes/objisolate.md` records four bugs, each caught by a different gate. The one worth repeating: **the vtable pointer landed 8 bytes high in 34 modules, and it linked cleanly.** Only `rombuild`'s byte compare saw it. mwcc's `_ZTV4Coin` addresses the vtable object's start, so the vptr store relocates with addend 8 to step over offset-to-top and typeinfo, while `symbols.txt`'s `_ZTV4Coin` **is** the slot array. A clean link is not evidence.

The −8 correction is licensed by all **387** `_ZTV*` symbols in `config/arm9/**/symbols.txt` having word `addr-8 == 0` and `addr-4` pointing at a known RTTI record — 387/387, re-derived independently during review. Refusing (rather than correcting) a nonzero addend on an **UNDEF** `_ZTV` is deliberate: there is no enrolled instance to byte-verify a correction against, so it fails closed.

### The baseline raise is hand-banked and visible

`config/unresolved-baseline.json` gains 9 entries, added **by hand** rather than with `--update`, which refuses a raise by design (`check_references.py:143-159`).

They are not a regression. Every one is rejected by `eligible.py` both before and after, so none is enrolled and none reaches the link — `check_references` builds its map *only* from files `eligible.py` rejected (`:89-97`), so being in it and being enrolled are mutually exclusive. They surface for two reasons: isolation marks a referenced symbol in a dropped section UNDEF so rule 5 can reject the file (`table$8`, `conv_ov021`, the `@30` jump tables); and for four names it merely **removes an earlier rejection**, so rule 5 finally reads reference rot that was always in the source.

Two of those deserve their own fixes, filed not done: `func_ov034_02111788.cpp` has bare `extern` on already-mangled names (the double-mangling defect — both correct spellings exist in `symbols.txt`, so probably a free +1 eligible), and `_ZN9ActorBase21AfterCleanupResourcesEj.cpp` has `extern "C"` definitions plus invented callee names.

### Verification, re-run against current main

Rebased onto current `main` and fully re-verified before opening — the original numbers were measured against an older tree.

| gate | result |
|---|---|
| `pytest` objisolate + rombuild | **12 passed** |
| `--no-isolate` control | identical to pristine main, name-by-name |
| `check_references` | `OK: no new unresolvable references` (3 fixed since the baseline) |
| port_refcheck / dup-sources / data-defs / langmode / attribution | all clean |

Reviewed by an independent pass which confirmed the ELF surgery is sound and fail-closed, the cache-schema invariant holds, and the refusal set is adequate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS