### PR TITLE
ChiefChilly: the three remaining methods as real C++

### DIFF
--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -167,7 +167,7 @@ src/_ZN11ChiefChilly16CleanupResourcesEv.cpp:
     complete
     .text start:0x021217e0 end:0x0212186c
 
-src/_ZN11ChiefChilly16OnPendingDestroyEv.c:
+src/_ZN11ChiefChilly16OnPendingDestroyEv.cpp:
     complete
     .text start:0x0212186c end:0x02121870
 

--- a/include/ChiefChilly.h
+++ b/include/ChiefChilly.h
@@ -12,7 +12,15 @@ struct ChiefChilly {
     s32 mPosX;            /* 0x05c */
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
-    u8  pad_068[0x18];
+    s32 unk_068;            /* 0x068 */
+    s32 unk_06c;            /* 0x06c */
+    s32 unk_070;            /* 0x070 */
+    /* Camera-space position: Behavior hands `self + 0x74` to func_02012694,
+       which reads a Vector3 there. 0x068-0x070 is the triple it restores mPos
+       FROM when a ground ray misses -- see the .cpp. */
+    s32 mCamSpacePosX;            /* 0x074 */
+    s32 mCamSpacePosY;            /* 0x078 */
+    s32 mCamSpacePosZ;            /* 0x07c */
     s32 mScaleX;            /* 0x080 */
     s32 mScaleY;            /* 0x084 */
     s32 mScaleZ;            /* 0x088 */
@@ -20,10 +28,16 @@ struct ChiefChilly {
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x4];
     s16 mPrevAngleY;            /* 0x094 */
-    u8  pad_096[0x6];
+    u8  pad_096[0x2];
+    s32 unk_098;            /* 0x098 */
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
-    u8  pad_0a4[0x6c];
+    u8  pad_0a4[0x4];
+    s32 unk_0a8;            /* 0x0a8 */
+    s32 unk_0ac;            /* 0x0ac */
+    u8  pad_0b0[0x50];
+    u16 unk_100;            /* 0x100 */
+    u8  pad_102[0xe];
     u8  mMovingCylinderClsnWithPos;            /* 0x110 */
     u8  pad_111[0x3f];
     u8  mWithMeshClsn;            /* 0x150 */
@@ -33,7 +47,11 @@ struct ChiefChilly {
        marker's pad stopped short of the object, so the member also takes over unk_368
        (+0x5c = speed), which the header declared separately inside it. */
     BlendModelAnim mBlendModelAnim;            /* 0x30c */
-    u8  pad_37c[0x4];
+    /* Current state: a record whose second word gates the tick and whose
+       THIRD is the pointer-to-member Behavior calls. Behavior also compares
+       it by ADDRESS against twelve file-scope state objects to gate five
+       separate things. */
+    void* mState;            /* 0x37c */
     u8  mShadowModel;            /* 0x380 */
     u8  pad_381[0x57];
     s32 unk_3d8;            /* 0x3d8 */
@@ -43,11 +61,26 @@ struct ChiefChilly {
     s32 unk_4bc;            /* 0x4bc */
     u8  pad_4c0[0x5];
     u8  unk_4c5;            /* 0x4c5 */
-    u8  pad_4c6[0x5];
+    u8  pad_4c6[0x3];
+    /* Set when a downward ray finds nothing AND the fall is fast enough;
+       cleared whenever the ray hits. */
+    u8  unk_4c9;            /* 0x4c9 */
+    u8  pad_4ca[0x1];
     u8  unk_4cb;            /* 0x4cb */
+    u8  pad_4cc[0x20];
+    /* Last position before a failed ground ray rewound mPos. Written every
+       time the ray misses, so it is the position the rewind came FROM.
+       These three sit PAST where this header used to end (0x4cc); Behavior
+       writes them, so the struct is at least 0x4f8. */
+    s32 unk_4ec;            /* 0x4ec */
+    s32 unk_4f0;            /* 0x4f0 */
+    s32 unk_4f4;            /* 0x4f4 */
 #ifdef __cplusplus
     /* methods */
+    int Behavior();
+    int CleanupResources();
     int InitResources();
+    void OnPendingDestroy();
     int Render();
 #endif
 };

--- a/src/_ZN11ChiefChilly16CleanupResourcesEv.cpp
+++ b/src/_ZN11ChiefChilly16CleanupResourcesEv.cpp
@@ -1,4 +1,16 @@
 //cpp
+// @symbol _ZN11ChiefChilly16CleanupResourcesEv
+/* recovered: shared header, real C++ method
+ *
+ * Releases NINE shared files and unloads the key models -- by far the largest
+ * claim of any class migrated so far, and one of the nine (data_ov002_0210da30)
+ * lives in ov002 rather than this overlay, borrowed from the shared pool and
+ * still released here.
+ *
+ * TOUCHES NO FIELD. The ROM body takes no `this`; as a method it now receives
+ * one and ignores it, which measured byte-free.
+ */
+#include "ChiefChilly.h"
 #include "SharedFilePtr.h"
 extern "C" {
 extern void UnloadKeyModels(int i);
@@ -12,7 +24,9 @@ extern void* data_ov073_021232b8;
 extern void* data_ov002_0210da30;
 extern void* data_ov073_02123298;
 
-int _ZN11ChiefChilly16CleanupResourcesEv(void){
+}
+
+int ChiefChilly::CleanupResources(){
   UnloadKeyModels(4);
   ((SharedFilePtr *)(&data_ov073_02123280))->Release();
   ((SharedFilePtr *)(&data_ov073_021232a0))->Release();
@@ -24,5 +38,4 @@ int _ZN11ChiefChilly16CleanupResourcesEv(void){
   ((SharedFilePtr *)(&data_ov002_0210da30))->Release();
   ((SharedFilePtr *)(&data_ov073_02123298))->Release();
   return 1;
-}
 }

--- a/src/_ZN11ChiefChilly16OnPendingDestroyEv.c
+++ b/src/_ZN11ChiefChilly16OnPendingDestroyEv.c
@@ -1,3 +1,0 @@
-void _ZN11ChiefChilly16OnPendingDestroyEv(void)
-{
-}

--- a/src/_ZN11ChiefChilly16OnPendingDestroyEv.cpp
+++ b/src/_ZN11ChiefChilly16OnPendingDestroyEv.cpp
@@ -1,0 +1,12 @@
+//cpp
+// @symbol _ZN11ChiefChilly16OnPendingDestroyEv
+/* recovered: shared header, real C++ method
+ *
+ * Empty in the ROM -- a single `bx lr`, an override that exists to suppress
+ * the base's behaviour.
+ */
+#include "ChiefChilly.h"
+
+void ChiefChilly::OnPendingDestroy()
+{
+}

--- a/src/_ZN11ChiefChilly8BehaviorEv.cpp
+++ b/src/_ZN11ChiefChilly8BehaviorEv.cpp
@@ -1,6 +1,35 @@
 //cpp
+// @symbol _ZN11ChiefChilly8BehaviorEv
+/* recovered: named members + shared header, real C++ method
+ *
+ * One frame of the boss. Almost everything here is gated on WHICH state is
+ * current, compared by ADDRESS against twelve file-scope state objects, and it
+ * gates five separate things rather than one:
+ *
+ *   three states       use UpdatePosWithOnlySpeed instead of UpdatePos, and
+ *                      apply gravity by hand first: unk_0a8 becomes
+ *                      max(unk_0a0, unk_0a8 + unk_09c)
+ *   two states         at animation frame 7, build a world matrix from the
+ *                      model's own bone and spawn the landing dust there --
+ *                      the impact is tied to the ANIMATION, not to contact
+ *   seven states       skip the ground ray entirely
+ *   one more           is exempt from the rewind below
+ *   two states         get an extra per-frame call
+ *
+ * THE GROUND RAY IS A FALL-THROUGH GUARD. It casts from 0x78000 above the boss
+ * along its heading (reach doubles once unk_4cb > 1) and, when it finds
+ * NOTHING, saves the current position into unk_4ec and rewinds mPos to the
+ * triple at 0x068 -- so the boss cannot leave the arena by falling off it. A
+ * hit clears unk_4c9; a miss while descending faster than 0xa000 sets it.
+ *
+ * The first thing it does is publish itself into the camera at +0x114, so the
+ * camera follows the boss without the boss being asked.
+ *
+ * `#pragma opt_propagation off` is at FILE scope in the pre-image and is kept
+ * there -- it is what stops the many position temporaries being folded.
+ */
 #pragma opt_propagation off
-struct Vector3 { int x, y, z; };
+#include "ChiefChilly.h"
 struct Mat4x3 { int m[12]; };
 
 struct C;
@@ -50,9 +79,10 @@ extern void func_ov073_021215cc(void *self);
 extern void _ZN14BlendModelAnim7AdvanceEv(void *self);
 }
 
-extern "C" int _ZN11ChiefChilly8BehaviorEv(C *c)
+int ChiefChilly::Behavior()
 {
-    char *self = (char *)c;
+    char *self = (char *)this;
+    C *c = (C *)this;
     int angx;
     Vector3 v0;
     RayParams rp;
@@ -62,7 +92,7 @@ extern "C" int _ZN11ChiefChilly8BehaviorEv(C *c)
     int line[0x1f];
 
     *(C **)((char *)data_0209f318 + 0x114) = c;
-    DecIfAbove0_Short((unsigned short *)(self + 0x100));
+    DecIfAbove0_Short(&unk_100);
 
     if (*(void **)((char *)c->pp + 8) != 0) {
         PMF *p = c->pp + 1;
@@ -72,15 +102,15 @@ extern "C" int _ZN11ChiefChilly8BehaviorEv(C *c)
     if ((char *)c->pp != data_ov073_02123400
         && (char *)c->pp != data_ov073_02123320
         && (char *)c->pp != data_ov073_02123340) {
-        _ZN5Actor9UpdatePosEP12CylinderClsn(self, self + 0x110);
+        _ZN5Actor9UpdatePosEP12CylinderClsn(self, &mMovingCylinderClsnWithPos);
     } else {
-        int sum = *(int *)(self + 0xa8) + *(int *)(self + 0x9c);
-        int m = *(int *)(self + 0xa0);
-        int ac = *(int *)(self + 0xac);
+        int sum = unk_0a8 + unk_09c;
+        int m = unk_0a0;
+        int ac = unk_0ac;
         if (sum >= m) m = sum;
-        *(int *)(self + 0xa8) = m;
-        *(int *)(self + 0xac) = ac;
-        _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(self, self + 0x110);
+        unk_0a8 = m;
+        unk_0ac = ac;
+        _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(self, &mMovingCylinderClsnWithPos);
     }
 
     if (((char *)c->pp == data_ov073_02123330 || (char *)c->pp == data_ov073_02123350)
@@ -92,7 +122,7 @@ extern "C" int _ZN11ChiefChilly8BehaviorEv(C *c)
         v0.z = data_020a0e68.m[11];
         Vec3_Lsl(&v3C, &v0, 3);
         v0 = v3C;
-        func_02012694(0x167, self + 0x74);
+        func_02012694(0x167, &mCamSpacePosX);
         v48 = v0;
         _ZN5Actor17HugeLandingDustAtER7Vector3b(self, &v48, 1);
     }
@@ -111,17 +141,17 @@ extern "C" int _ZN11ChiefChilly8BehaviorEv(C *c)
         rp.out.x = 0; rp.out.y = 0; rp.out.z = 0;
         {
             int y;
-            rp.start.x = *(int *)(self + 0x5c);
+            rp.start.x = mPosX;
             angx = 0x2000;
-            y = *(int *)(self + 0x60);
+            y = mPosY;
             rp.start.y = y;
-            rp.start.z = *(int *)(self + 0x64);
+            rp.start.z = mPosZ;
             rp.start.y = y + 0x78000;
-            if (*(unsigned char *)(self + 0x4cb) > 1)
+            if (unk_4cb > 1)
                 rp.in.z = 0x258000;
             else
                 rp.in.z = 0x12c000;
-            Matrix4x3_FromRotationY(&data_020a0e68, *(short *)(self + 0x94));
+            Matrix4x3_FromRotationY(&data_020a0e68, mPrevAngleY);
             Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, angx);
         }
         MulVec3Mat4x3(&rp.in, &data_020a0e68, &rp.out);
@@ -142,36 +172,36 @@ extern "C" int _ZN11ChiefChilly8BehaviorEv(C *c)
         }
         _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(line, &rp.start, &rp.end, self);
         if (_ZN11RaycastLine10DetectClsnEv(line) == 0) {
-            if (*(int *)(self + 0x98) > 0xa000) {
-                *(unsigned char *)(self + 0x4c9) = 1;
+            if (unk_098 > 0xa000) {
+                unk_4c9 = 1;
             }
-            *(int *)(self + 0x4ec) = *(int *)(self + 0x5c);
-            *(int *)(self + 0x4f0) = *(int *)(self + 0x60);
-            *(int *)(self + 0x4f4) = *(int *)(self + 0x64);
+            unk_4ec = mPosX;
+            unk_4f0 = mPosY;
+            unk_4f4 = mPosZ;
             if ((char *)c->pp != data_ov073_021233a0) {
-                *(int *)(self + 0x5c) = *(int *)(self + 0x68);
-                *(int *)(self + 0x60) = *(int *)(self + 0x6c);
-                *(int *)(self + 0x64) = *(int *)(self + 0x70);
-                *(int *)(self + 0x98) = 0;
+                mPosX = unk_068;
+                mPosY = unk_06c;
+                mPosZ = unk_070;
+                unk_098 = 0;
             }
         } else {
-            *(unsigned char *)(self + 0x4c9) = 0;
+            unk_4c9 = 0;
         }
         _ZN11RaycastLineD1Ev(line);
     }
 
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(self, self + 0x150, 0);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(self, &mWithMeshClsn, 0);
 
     v54 = data_ov073_02123040;
-    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(self + 0x110, &v54);
+    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(&mMovingCylinderClsnWithPos, &v54);
 
     if ((char *)c->pp == data_ov073_02123360
         || (char *)c->pp == data_ov073_02123390) {
         func_ov073_0211f61c(self);
     }
-    _ZN12CylinderClsn5ClearEv(self + 0x110);
-    _ZN12CylinderClsn6UpdateEv(self + 0x110);
+    _ZN12CylinderClsn5ClearEv(&mMovingCylinderClsnWithPos);
+    _ZN12CylinderClsn6UpdateEv(&mMovingCylinderClsnWithPos);
     func_ov073_021215cc(self);
-    _ZN14BlendModelAnim7AdvanceEv(self + 0x30c);
+    _ZN14BlendModelAnim7AdvanceEv(&mBlendModelAnim);
     return 1;
 }


### PR DESCRIPTION
Branched off `main`. `tu_map.py` puts ov073 `0x0211f000-0x02121f90` at 47 functions with ChiefChilly the only class in it. `Render` and `InitResources` were already migrated; this is the rest except the structors.

> **Overlay chosen to avoid a conflict.** ov073 is the only candidate outside *both* the 38 `delinks.txt` files #1329 touches and the overlays my other open PRs hold. With objisolate's enrollment in flight, the **module** — not the class — is now the binding constraint on slicing in parallel.

### The header grows past where it ended

`ChiefChilly.h` gains 16 fields and grows `0x4cc → 0x4f8`, because `Behavior` **writes three words past the old struct end** (`0x4ec`/`0x4f0`/`0x4f4`). Everything else is offset-neutral: the motion words, `unk_098`, the timer at `0x100`, the saved position triple at `0x068`, `mCamSpacePos` at `0x074`, `mState` at `0x37c`, and `unk_4c9`.

### Behaviour recovered

**The ground ray is a fall-through guard.** It casts from `0x78000` above the boss along its heading — reach doubling once `unk_4cb > 1` — and when it finds **nothing** it saves the current position into `unk_4ec` and rewinds `mPos` to the triple at `0x068`. The boss cannot leave the arena by falling off it. A hit clears `unk_4c9`; a miss while descending faster than `0xa000` sets it. One state is exempt from the rewind.

**`mState` gates five different things**, all by comparing against twelve file-scope state objects by address:

| gate | effect |
|---|---|
| 3 states | `UpdatePosWithOnlySpeed` instead of `UpdatePos`, with gravity applied by hand as `max(unk_0a0, unk_0a8 + unk_09c)` |
| 2 states | landing dust at animation frame 7 |
| 7 states | skip the ground ray entirely |
| 1 more | exempt from the rewind |
| 2 states | an extra per-frame call |

**The landing dust is tied to the animation, not to contact** — at frame 7 it builds a world matrix from the model's own bone and spawns the dust there.

`Behavior`'s **first act is to publish `this` into the camera** at `+0x114`, so the camera follows the boss without the boss being asked.

`CleanupResources` releases **nine** shared files plus the key models — the largest claim of any class migrated this session — and one of the nine lives in **ov002**, borrowed from the shared pool and still released here.

### Verification

`#pragma opt_propagation off` is at **file** scope in the pre-image and stays there. Stage A from the pre-image matched, and all twelve candidate groups then substituted **free**, including the three fields past the old struct end.

Build pin derived for this family, not inherited: all three baseline at `2004/b56` and all three still match there as methods.

| gate | result |
|---|---|
| `build_pin.verify` × 3 | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket vs `main` | identical set |
| header offsets | 35 fields, 0 mismatched, spans `0x4f8` |
| check_references / port_refcheck / dup / data-defs / langmode / attribution | all clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS