### PR TITLE
Minimap::FixTHIPaintingRoomPos as a real static method

### DIFF
--- a/include/Minimap.h
+++ b/include/Minimap.h
@@ -40,6 +40,12 @@ struct Minimap {
     u8  unk_255;            /* 0x255 */
 #ifdef __cplusplus
     /* methods */
+    int Behavior();
+    /* STATIC -- no `this`. The ROM keeps r0 (the Vector3) in r4 and clobbers r1
+       before any use, so the only incoming pointer is the argument. Staticness
+       is not part of the mangling, so the symbol is unchanged either way; the
+       evidence is the register use. */
+    static void FixTHIPaintingRoomPos(Vector3 & v_);
     int InitResources();
     s32 CleanupResources();
     void OnPendingDestroy();

--- a/src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp
+++ b/src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp
@@ -1,6 +1,21 @@
 //cpp
 // @symbol _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3
-/* recovered: named members + shared header, declarations from a shared header */
+/* recovered: shared header, real C++ method (static)
+ *
+ * Bends a position inside the THI painting room so the minimap draws it in the
+ * right place -- the room's real geometry and its map are not the same shape.
+ *
+ * It only fires on one specific place: level 0x1d, sublevel 5, room 2. Three
+ * guards in a row, and any of them failing leaves the position untouched.
+ *
+ * Two zones, split at p0.z, each anchored on its own reference point and
+ * scaled DIFFERENTLY per axis -- the far zone's x scale is even computed from
+ * how far past the anchor the point is (`0xc00 - depth/-0x2e60`), so the
+ * correction stretches with distance rather than being a fixed factor.
+ *
+ * No `this`: the ROM keeps r0 (the Vector3) in r4 and clobbers r1 before any
+ * use, so the only incoming pointer is the argument. See include/Minimap.h.
+ */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Minimap.h"
@@ -9,9 +24,11 @@ extern "C" {
 extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern signed char data_0209f2f8;
+}
 
-void _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(struct Vector3* v)
+void Minimap::FixTHIPaintingRoomPos(Vector3 & v_)
 {
+    struct Vector3* v = &v_;
     struct Vector3 p0, p1, out, out2;
 
     p0.x = (int)0xfee30000;
@@ -37,5 +54,4 @@ void _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(struct Vector3* v)
         v->x = p1.x + (int)(((long long)out2.x * 0x400 + 0x800) >> 12);
         v->z = p1.z + (int)(((long long)out2.z * 0xe00 + 0x800) >> 12);
     }
-}
 }


### PR DESCRIPTION
Branched off `main`. Chosen for the same reason as #1331 (G2x): both of Minimap's migratable files are **already `.cpp`**, so this needs **no `delinks.txt` edit** and cannot conflict with #1329's 38-file enrollment — even though Minimap lives in ov002, which three open PRs touch.

### Static, read off the ROM rather than assumed

The body uses only its `Vector3` argument. The disassembly settles which register that is:

```
020F97D4  mov r4, r0        <- the argument, kept for the whole function
020F97D8  ldr r1, [pc,#0x1b0]   <- r1 clobbered before any use
```

The only incoming pointer is the argument, not a `this`. Staticness isn't part of the mangling, so the symbol is unchanged either way — the evidence is the register use. Same discrimination as G2x's three in #1331.

### What it does

It bends a position inside the THI painting room so the minimap draws it in the right place, because the room's real geometry and its map are not the same shape.

Three guards — level `0x1d`, sublevel 5, room 2 — and any failing leaves the position untouched. Then two zones split at `p0.z`, each anchored on its own reference point and scaled **differently per axis**. The far zone's x scale is computed from how far past the anchor the point is (`0xc00 - depth/-0x2e60`), so the correction **stretches with distance** rather than being a fixed factor.

### Deliberately left: Minimap::Behavior

`Behavior` (0xcfc, 413 lines) is **not** magic-offset code — it carries a full local **shadow struct**, which is the better shape to migrate but a bigger job than it looks. That shadow is much richer than `Minimap.h`: a dozen arrays (`a70[4]`, `a80[4]`, `aa0[12]`, `ad0[12]`, `a100[9]`, `a124[9]`, `a180[8]`, `a1a0[8]`, `a21e[4]`, `a222[12]`, `a23a[9]`, `a249[8]`) that the header currently covers as flat padding — plus two disagreements to settle: the shadow's `Vector3 v1e0` against three scalars, and `s16 ang` at `0x21c` against the header's `u16`.

That is a header reconstruction, not a substitution pass. It deserves its own slice rather than a rushed one, so it is described here instead of half-done.

### Verification

| gate | result |
|---|---|
| `build_pin.verify` | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket vs `main` | identical set |
| header offsets | 25 fields, 0 mismatched, spans `0x256` |
| check_references / port_refcheck / dup / data-defs / langmode / attribution | all clean |

No `delinks.txt` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS