### PR TITLE
Minimap::Behavior: remove the shadow struct, on the reconstructed header

### DIFF
--- a/include/Minimap.h
+++ b/include/Minimap.h
@@ -40,6 +40,12 @@ struct Minimap {
     u8  unk_255;            /* 0x255 */
 #ifdef __cplusplus
     /* methods */
+    int Behavior();
+    /* STATIC -- no `this`. The ROM keeps r0 (the Vector3) in r4 and clobbers r1
+       before any use, so the only incoming pointer is the argument. Staticness
+       is not part of the mangling, so the symbol is unchanged either way; the
+       evidence is the register use. */
+    static void FixTHIPaintingRoomPos(Vector3 & v_);
     int InitResources();
     s32 CleanupResources();
     void OnPendingDestroy();

--- a/include/Minimap.h
+++ b/include/Minimap.h
@@ -12,20 +12,44 @@ struct Minimap {
     s32 unk_054;            /* 0x054 */
     s32 unk_058;            /* 0x058 */
     s32 mPosX;            /* 0x05c */
-    u8  pad_060[0x30];
+    s32 unk_060;            /* 0x060 */
+    s32 unk_064;            /* 0x064 */
+    u8  pad_068[0x8];
+    /* Minimap::Behavior carries a shadow struct that declares these ranges as
+       ARRAYS and indexes them; the header had them as flat padding, which is
+       why the shadow existed at all. Sizes are the shadow's own, and the
+       reconstruction is offset-neutral -- the struct still spans 0x256. */
+    s32 unk_070[4];            /* 0x070 */
+    s32 unk_080[4];            /* 0x080 */
     s32 unk_090;            /* 0x090 */
     s32 unk_094;            /* 0x094 */
     s32 unk_098;            /* 0x098 */
     s32 unk_09c;            /* 0x09c */
-    u8  pad_0a0[0x134];
+    s32 unk_0a0[12];            /* 0x0a0 */
+    s32 unk_0d0[12];            /* 0x0d0 */
+    s32 unk_100[9];            /* 0x100 */
+    s32 unk_124[9];            /* 0x124 */
+    u8  pad_148[0x30];
+    s32 unk_178;            /* 0x178 */
+    s32 unk_17c;            /* 0x17c */
+    s32 unk_180[8];            /* 0x180 */
+    s32 unk_1a0[8];            /* 0x1a0 */
+    u8  pad_1c0[0x14];
     s32 unk_1d4;            /* 0x1d4 */
     s32 unk_1d8;            /* 0x1d8 */
     s32 unk_1dc;            /* 0x1dc */
+    /* 0x1e0 and 0x1f4 are each a Vector3 in the shadow -- three consecutive
+       words handed to Vec3 helpers as one object. Kept as scalars here so the
+       header does not assert a type the other eight matched functions never
+       see, and taken as `*(Vector3*)&unk_1e0` at the two sites that need it. */
     s32 unk_1e0;            /* 0x1e0 */
     s32 unk_1e4;            /* 0x1e4 */
     s32 unk_1e8;            /* 0x1e8 */
     s32 unk_1ec;            /* 0x1ec */
-    u8  pad_1f0[0x10];
+    s32 unk_1f0;            /* 0x1f0 */
+    s32 unk_1f4;            /* 0x1f4 */
+    s32 unk_1f8;            /* 0x1f8 */
+    s32 unk_1fc;            /* 0x1fc */
     s32 unk_200;            /* 0x200 */
     s32 unk_204;            /* 0x204 */
     s32 unk_208;            /* 0x208 */
@@ -33,10 +57,20 @@ struct Minimap {
     s32 unk_210;            /* 0x210 */
     s32 unk_214;            /* 0x214 */
     s32 unk_218;            /* 0x218 */
+    /* Stays u16. Behavior's shadow spelled it s16 and then cast EVERY read to
+       (u16) -- `(u16)ang >= 0x8000` and `(s32)(u16)ang >> 4` -- so the reads
+       want unsigned and the two spellings mean the same thing. */
     u16 unk_21c;            /* 0x21c */
-    u8  pad_21e[0x33];
+    s8  unk_21e[4];            /* 0x21e */
+    s8  unk_222[12];            /* 0x222 */
+    u8  pad_22e[0xc];
+    s8  unk_23a[9];            /* 0x23a */
+    u8  pad_243[0x5];
+    s8  unk_248;            /* 0x248 */
+    s8  unk_249[8];            /* 0x249 */
     u8  unk_251;            /* 0x251 */
-    u8  pad_252[0x3];
+    u8  pad_252[0x2];
+    u8  unk_254;            /* 0x254 */
     u8  unk_255;            /* 0x255 */
 #ifdef __cplusplus
     /* methods */

--- a/src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp
+++ b/src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp
@@ -1,6 +1,21 @@
 //cpp
 // @symbol _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3
-/* recovered: named members + shared header, declarations from a shared header */
+/* recovered: shared header, real C++ method (static)
+ *
+ * Bends a position inside the THI painting room so the minimap draws it in the
+ * right place -- the room's real geometry and its map are not the same shape.
+ *
+ * It only fires on one specific place: level 0x1d, sublevel 5, room 2. Three
+ * guards in a row, and any of them failing leaves the position untouched.
+ *
+ * Two zones, split at p0.z, each anchored on its own reference point and
+ * scaled DIFFERENTLY per axis -- the far zone's x scale is even computed from
+ * how far past the anchor the point is (`0xc00 - depth/-0x2e60`), so the
+ * correction stretches with distance rather than being a fixed factor.
+ *
+ * No `this`: the ROM keeps r0 (the Vector3) in r4 and clobbers r1 before any
+ * use, so the only incoming pointer is the argument. See include/Minimap.h.
+ */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Minimap.h"
@@ -9,9 +24,11 @@ extern "C" {
 extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern signed char data_0209f2f8;
+}
 
-void _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(struct Vector3* v)
+void Minimap::FixTHIPaintingRoomPos(Vector3 & v_)
 {
+    struct Vector3* v = &v_;
     struct Vector3 p0, p1, out, out2;
 
     p0.x = (int)0xfee30000;
@@ -37,5 +54,4 @@ void _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(struct Vector3* v)
         v->x = p1.x + (int)(((long long)out2.x * 0x400 + 0x800) >> 12);
         v->z = p1.z + (int)(((long long)out2.z * 0xe00 + 0x800) >> 12);
     }
-}
 }

--- a/src/_ZN7Minimap8BehaviorEv.cpp
+++ b/src/_ZN7Minimap8BehaviorEv.cpp
@@ -1,13 +1,29 @@
 //cpp
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
+// @symbol _ZN7Minimap8BehaviorEv
+/* recovered: named members + shared header, real C++ method, shadow struct removed
+ *
+ * One frame of the minimap. This file's whole point is that it no longer
+ * carries its own idea of what a Minimap is: the pre-image declared a private
+ * `struct Minimap` describing the object in full, and every field access went
+ * through it. That shadow is gone and the shared header serves instead.
+ *
+ * The shadow was RICHER than Minimap.h, which is why it existed. It declared
+ * twelve ranges as ARRAYS and indexed them -- 0x070, 0x080, 0x0a0, 0x0d0,
+ * 0x100, 0x124, 0x180, 0x1a0, 0x21e, 0x222, 0x23a, 0x249 -- where the header
+ * had flat padding, so the header simply could not express what this function
+ * does. Those arrays are in the header now and the reconstruction is
+ * offset-neutral: the struct still spans 0x256.
+ *
+ * Two disagreements between the two views, both settled toward the header:
+ *   0x1e0 and 0x1f4  the shadow called each a Vector3; only two sites need
+ *                    that, and they take `(Vector3*)&unk_1f4` rather than the
+ *                    header asserting a type the other eight matched
+ *                    functions never see.
+ *   0x21c            the shadow said s16 and then cast EVERY read to (u16).
+ *                    The header's u16 says the same thing without the casts.
+ */
+#include "Minimap.h"
 typedef int Fix12;
-
-struct Vector3 { s32 x, y, z; };
 
 struct Obj {
     char pad0[0x5c];
@@ -22,44 +38,6 @@ struct Obj {
     s16 f17c;           /* 0x17c */
 };
 
-struct Minimap {
-    char pad0[0x50];
-    s32 f50, f54, f58, f5c, f60, f64;   /* 0x50 */
-    char padA[8];
-    s32 a70[4];         /* 0x70 */
-    s32 a80[4];         /* 0x80 */
-    char pad1[0x10];    /* 0x90 */
-    s32 aa0[12];        /* 0xa0 */
-    s32 ad0[12];        /* 0xd0 */
-    s32 a100[9];        /* 0x100 */
-    s32 a124[9];        /* 0x124 */
-    char pad2[0x178 - 0x148];
-    s32 f178, f17c;     /* 0x178 */
-    s32 a180[8];        /* 0x180 */
-    s32 a1a0[8];        /* 0x1a0 */
-    char pad3[0x1d4 - 0x1c0];
-    Fix12 f1d4;         /* 0x1d4 */
-    s32 f1d8;
-    s32 f1dc;           /* 0x1dc */
-    Vector3 v1e0;       /* 0x1e0 */
-    s32 f1ec;
-    Fix12 f1f0;         /* 0x1f0 */
-    Vector3 v1f4;       /* 0x1f4 */
-    char pad4[0x214 - 0x200];
-    s32 f214;           /* 0x214 */
-    s32 f218;           /* 0x218 */
-    s16 ang;            /* 0x21c */
-    s8 a21e[4];         /* 0x21e */
-    s8 a222[12];        /* 0x222 */
-    char pad5[0x23a - 0x22e];
-    s8 a23a[9];         /* 0x23a */
-    char pad6[0x248 - 0x243];
-    s8 f248;            /* 0x248 */
-    s8 a249[8];         /* 0x249 */
-    char pad7[0x254 - 0x251];
-    u8 f254;            /* 0x254 */
-    u8 f255;            /* 0x255 */
-};
 
 struct VtblOwner;
 struct Vtbl { s32 (*f[8])(void *); };
@@ -120,10 +98,10 @@ extern void UpdateMinimap(s32 *a, s32 b, s32 c, s32 d, s32 e);
 #define F254 (*(u8 *)(((int)self + 0x254)))
 #define FMUL(a, b) ((s32)((((long long)(a) * (b)) + 0x800) >> 12))
 
-extern "C" s32 _ZN7Minimap8BehaviorEv(Minimap *self);
 
-s32 _ZN7Minimap8BehaviorEv(Minimap *self)
+s32 Minimap::Behavior()
 {
+    Minimap *self = this;
     Obj *obj;
     Vector3 v8, v14, v20, v2c, v38;
     Vector3 *op;
@@ -142,7 +120,7 @@ s32 _ZN7Minimap8BehaviorEv(Minimap *self)
     if (data_0209f350[data_0209f250] != 0) goto L274;
     if (_ZN6Player12Unk_020ca8f8Ev(player) == 1) goto L274;
 
-    if (self->f254 != 0) {
+    if (self->unk_254 != 0) {
         F254 -= data_0208ee44;
     }
 
@@ -154,10 +132,10 @@ s32 _ZN7Minimap8BehaviorEv(Minimap *self)
     if (data_0209d660 != 0) goto L200;
     {
         u8 v = data_0209f4ac[data_020a0e40 * 0x18];
-        if (v == 0 && self->f254 == 0) goto L200;
+        if (v == 0 && self->unk_254 == 0) goto L200;
         data_0209d454 |= 4;
         if (v != 0) {
-            self->f254 = 0x1e;
+            self->unk_254 = 0x1e;
             SetSubBg2Offset(0x100 - data_0209f4a8[data_020a0e40 * 0x18],
                             0x80 - data_0209f4a9[data_020a0e40 * 0x18]);
         }
@@ -180,7 +158,7 @@ L200:
             *(volatile s32 *)0x4001000 = (*(volatile s32 *)0x4001000 & ~0x1f00) | (data_0209d454 << 8);
             *(volatile u16 *)0x4001050 = 0;
         }
-        self->f254 = 0;
+        self->unk_254 = 0;
         goto L2a4;
     }
 
@@ -205,17 +183,17 @@ L318:
         s32 b = (data_0209f2d8 == 0);
         if (b == 0) goto L360;
         if (data_0209caa0[2] & 0x80) goto L360;
-        if (self->f255 != 0) goto L360;
+        if (self->unk_255 != 0) goto L360;
     }
 L350:
-    self->ang = 0;
+    self->unk_21c = 0;
     goto L3e0;
 
 L360:
-    if (self->f255 == 0) goto L3a4;
+    if (self->unk_255 == 0) goto L3a4;
     if (data_ov002_0211114c == 0) goto L3e0;
     FANG += 0x40;
-    if ((u16)self->ang >= 0x8000)
+    if ((u16)self->unk_21c >= 0x8000)
         data_ov002_0211114c = 0;
     goto L3e0;
 
@@ -226,7 +204,7 @@ L3a4:
         if (f & 0xc000) goto L3e0;
         if (f & 8) goto L3e0;
     }
-    self->ang = (s16)(cam->f17c & 0xffe0);
+    self->unk_21c = (s16)(cam->f17c & 0xffe0);
 
 L3e0:
     obj = (Obj *)cam->f110;
@@ -234,56 +212,56 @@ L3e0:
 L3e8:
     if (obj == 0) goto Lae4;
 
-    if (self->f255 == 0) goto L44c;
+    if (self->unk_255 == 0) goto L44c;
     if (data_ov002_02111144 == 0) goto L4d8;
     F218 -= 9;
-    if (self->f214 <= self->f218) goto L4d8;
-    self->f218 = self->f214;
+    if (self->unk_214 <= self->unk_218) goto L4d8;
+    self->unk_218 = self->unk_214;
     data_ov002_02111144 = 0;
     data_ov002_0211114c = 1;
     goto L4d8;
 
 L44c:
     if (data_0209d660 == 0) goto L47c;
-    if (self->f218 < 0xbb8)
+    if (self->unk_218 < 0xbb8)
         F218 += 0x1c;
     goto L4d8;
 
 L47c:
-    if (self->f214 <= self->f218) goto L4b0;
+    if (self->unk_214 <= self->unk_218) goto L4b0;
     F218 += 0x1c;
-    if (self->f214 < self->f218)
-        self->f218 = self->f214;
+    if (self->unk_214 < self->unk_218)
+        self->unk_218 = self->unk_214;
     goto L4d8;
 
 L4b0:
-    if (self->f214 >= self->f218) goto L4d8;
+    if (self->unk_214 >= self->unk_218) goto L4d8;
     F218 -= 0x1c;
-    if (self->f214 > self->f218)
-        self->f218 = self->f214;
+    if (self->unk_214 > self->unk_218)
+        self->unk_218 = self->unk_214;
 
 L4d8:
-    self->f1f0 = _ZN4cstd4fdivEii(self->f1d4, self->f218);
-    { s32 s1 = data_02082214[(((s32)(u16)self->ang >> 4) * 2) + 1];
-      self->f50 = FMUL(s1, self->f218); }
-    { s32 s2 = data_02082214[((s32)(u16)self->ang >> 4) * 2];
-      self->f54 = FMUL(s2, self->f218); }
-    self->f58 = -self->f54;
-    self->f5c = self->f50;
-    self->v1f4.x = self->v1e0.x;
-    self->v1f4.y = self->v1e0.y;
-    self->v1f4.z = self->v1e0.z;
-    self->f60 = self->f1dc + ((FMUL(self->v1f4.x, self->f1d4) + 0x800) >> 12);
-    self->f64 = self->f1dc + ((FMUL(self->v1f4.z, self->f1d4) + 0x800) >> 12);
+    self->unk_1f0 = _ZN4cstd4fdivEii(self->unk_1d4, self->unk_218);
+    { s32 s1 = data_02082214[(((s32)(u16)self->unk_21c >> 4) * 2) + 1];
+      self->unk_050 = FMUL(s1, self->unk_218); }
+    { s32 s2 = data_02082214[((s32)(u16)self->unk_21c >> 4) * 2];
+      self->unk_054 = FMUL(s2, self->unk_218); }
+    self->unk_058 = -self->unk_054;
+    self->mPosX = self->unk_050;
+    ((Vector3*)&self->unk_1f4)->x = ((Vector3*)&self->unk_1e0)->x;
+    ((Vector3*)&self->unk_1f4)->y = ((Vector3*)&self->unk_1e0)->y;
+    ((Vector3*)&self->unk_1f4)->z = ((Vector3*)&self->unk_1e0)->z;
+    self->unk_060 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->x, self->unk_1d4) + 0x800) >> 12);
+    self->unk_064 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->z, self->unk_1d4) + 0x800) >> 12);
 
     op = (Vector3 *)(((int)obj + 0x5c));
     v14 = *op;
     _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(&v14);
-    _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v14, &self->v1f4, self->f1f0, self->ang, &v8);
+    _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v14, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
     {
         s32 p = data_0209f250;
-        self->a70[p] = (v8.x + 0x800) >> 12;
-        self->a80[p] = (v8.z + 0x800) >> 12;
+        self->unk_070[p] = (v8.x + 0x800) >> 12;
+        self->unk_080[p] = (v8.z + 0x800) >> 12;
 
         if (SublevelToLevel(data_0209f2f8) != 0x1d) goto B1;
         if (data_0209f2f8 != 1) goto L6a4;
@@ -293,86 +271,86 @@ B1:
         if (SublevelToLevel(data_0209f2f8) != 0x13) goto L6f0;
         if (data_0209f2f8 != 0x2e) goto L6f0;
 L6a4:
-        if (self->a70[p] < 0x60) { v8.x = 0x60000; }
-        else if (self->a70[p] > 0xa0) { v8.x = 0xa0000; }
-        if (self->a80[p] < 0x40) { v8.z = 0x40000; }
-        else if (self->a80[p] > 0x80) { v8.z = 0x80000; }
+        if (self->unk_070[p] < 0x60) { v8.x = 0x60000; }
+        else if (self->unk_070[p] > 0xa0) { v8.x = 0xa0000; }
+        if (self->unk_080[p] < 0x40) { v8.z = 0x40000; }
+        else if (self->unk_080[p] > 0x80) { v8.z = 0x80000; }
         goto L738;
 L6f0:
-        if (self->a70[p] < 0x24) { v8.x = 0x24000; }
-        else if (self->a70[p] > 0xdc) { v8.x = 0xdc000; }
-        if (self->a80[p] < 0x24) { v8.z = 0x24000; }
-        else if (self->a80[p] > 0x9c) { v8.z = 0x9c000; }
+        if (self->unk_070[p] < 0x24) { v8.x = 0x24000; }
+        else if (self->unk_070[p] > 0xdc) { v8.x = 0xdc000; }
+        if (self->unk_080[p] < 0x24) { v8.z = 0x24000; }
+        else if (self->unk_080[p] > 0x9c) { v8.z = 0x9c000; }
     }
 L738:
-    _ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_(&v8, &self->v1f4, self->f1f0, self->ang, &v20);
+    _ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_(&v8, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v20);
     Vec3_Sub(&v38, &v14, &v20);
-    AddVec3(&self->v1f4, &v38, &self->v1f4);
-    self->f60 = self->f1dc + ((FMUL(self->v1f4.x, self->f1d4) + 0x800) >> 12);
-    self->f64 = self->f1dc + ((FMUL(self->v1f4.z, self->f1d4) + 0x800) >> 12);
+    AddVec3((Vector3*)&self->unk_1f4, &v38, (Vector3*)&self->unk_1f4);
+    self->unk_060 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->x, self->unk_1d4) + 0x800) >> 12);
+    self->unk_064 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->z, self->unk_1d4) + 0x800) >> 12);
 
     for (i = 0; i < 4; i++) {
         Obj *o = data_0209f394[i];
         if (o != 0) {
         v2c = *(Vector3 *)(((int)o + 0x5c));
         _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(&v2c);
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v2c, &self->v1f4, self->f1f0, self->ang, &v8);
-        self->a70[i] = (v8.x + 0x800) >> 12;
-        self->a80[i] = (v8.z + 0x800) >> 12;
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v2c, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
+        self->unk_070[i] = (v8.x + 0x800) >> 12;
+        self->unk_080[i] = (v8.z + 0x800) >> 12;
         if (i != data_0209f250)
-            self->a21e[i] = (s8)GetMinimapID(o, -1);
+            self->unk_21e[i] = (s8)GetMinimapID(o, -1);
         else
-            self->a21e[i] = (s8)GetMinimapID(o, data_ov002_02111148);
+            self->unk_21e[i] = (s8)GetMinimapID(o, data_ov002_02111148);
         } else {
-            self->a21e[i] = -1;
+            self->unk_21e[i] = -1;
         }
     }
 
     for (i = 0; i < 0xc; i++) {
         Obj *o = data_0209f40c[i];
         if (o != 0) {
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, &self->v1f4, self->f1f0, self->ang, &v8);
-        self->aa0[i] = (v8.x + 0x800) >> 12;
-        self->ad0[i] = (v8.z + 0x800) >> 12;
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
+        self->unk_0a0[i] = (v8.x + 0x800) >> 12;
+        self->unk_0d0[i] = (v8.z + 0x800) >> 12;
         if (data_0209f37c[i] != 4)
-            self->a222[i] = (s8)GetMinimapID(o, -1);
+            self->unk_222[i] = (s8)GetMinimapID(o, -1);
         else
-            self->a222[i] = 1;
+            self->unk_222[i] = 1;
         } else {
-            self->a222[i] = -1;
+            self->unk_222[i] = -1;
         }
     }
 
     for (i = 0; i < 9; i++) {
         Obj *o = data_0209f3e8[i];
         if (o != 0) {
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, &self->v1f4, self->f1f0, self->ang, &v8);
-        self->a100[i] = (v8.x + 0x800) >> 12;
-        self->a124[i] = (v8.z + 0x800) >> 12;
-        self->a23a[i] = (s8)GetMinimapID(o, -1);
-        } else { self->a23a[i] = -1; }
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
+        self->unk_100[i] = (v8.x + 0x800) >> 12;
+        self->unk_124[i] = (v8.z + 0x800) >> 12;
+        self->unk_23a[i] = (s8)GetMinimapID(o, -1);
+        } else { self->unk_23a[i] = -1; }
     }
 
     if (data_0209caa0[1] & 0x40) goto La64;
     if ((data_0209caa0[2] & 0x20000) == 0) goto La64;
     {
         Obj *o = data_0209f33c;
-        if (o == 0) { self->f248 = -1; goto La64; }
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, &self->v1f4, self->f1f0, self->ang, &v8);
-        self->f178 = (v8.x + 0x800) >> 12;
-        self->f17c = (v8.z + 0x800) >> 12;
-        self->f248 = 1;
+        if (o == 0) { self->unk_248 = -1; goto La64; }
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
+        self->unk_178 = (v8.x + 0x800) >> 12;
+        self->unk_17c = (v8.z + 0x800) >> 12;
+        self->unk_248 = 1;
     }
 
 La64:
     for (i = 0; i < 8; i++) {
         Obj *o = data_0209f3a4[i];
         if (o != 0) {
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, &self->v1f4, self->f1f0, self->ang, &v8);
-        self->a180[i] = (v8.x + 0x800) >> 12;
-        self->a1a0[i] = (v8.z + 0x800) >> 12;
-        self->a249[i] = o->f0cc;
-        } else { self->a249[i] = -1; }
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
+        self->unk_180[i] = (v8.x + 0x800) >> 12;
+        self->unk_1a0[i] = (v8.z + 0x800) >> 12;
+        self->unk_249[i] = o->f0cc;
+        } else { self->unk_249[i] = -1; }
     }
 
 Lae4:
@@ -405,9 +383,9 @@ Lbf0:
 Lc00:
         *(volatile s32 *)0x4001000 = (*(volatile s32 *)0x4001000 & ~0x1f00) | (data_0209d454 << 8);
         data_ov002_02111148 = (s8)id;
-        self->f214 = GetMinimapScale(id);
+        self->unk_214 = GetMinimapScale(id);
     }
 Lc30:
-    UpdateMinimap(&self->f50, self->f60, self->f64, self->f60 - 0x80, self->f64 - 0x60);
+    UpdateMinimap(&self->unk_050, self->unk_060, self->unk_064, self->unk_060 - 0x80, self->unk_064 - 0x60);
     return 1;
 }


### PR DESCRIPTION
Stacked on #1332, so it doesn't add another independent PR to a queue that is already the bottleneck. Needs no `delinks.txt` edit — the file was already `.cpp`.

### This is the shadow-struct case, not the magic-offset one

The pre-image declared its own private `struct Minimap` describing the whole object, and every access went through it. That shadow is gone; the shared header serves.

**The shadow existed because it was richer than `Minimap.h`.** It declared twelve ranges as **arrays** and indexed them — `0x070[4]`, `0x080[4]`, `0x0a0[12]`, `0x0d0[12]`, `0x100[9]`, `0x124[9]`, `0x180[8]`, `0x1a0[8]`, `0x21e[4]`, `0x222[12]`, `0x23a[9]`, `0x249[8]` — where the header had flat padding. The header literally could not express what this function does, so the file kept its own view of the object. Those arrays are in `Minimap.h` now, along with the scalars at `0x060`/`0x064`, `0x178`/`0x17c`, `0x1f0`–`0x1fc`, `0x248` and `0x254`.

**The reconstruction is offset-neutral**: 25 fields → **47**, and the struct still spans `0x256`. Nothing moved — the padding was only ever hiding structure.

### Two disagreements between the views, both settled toward the header

| offset | shadow said | resolution |
|---|---|---|
| `0x1e0` / `0x1f4` | `Vector3` | only two sites need it, so they take `(Vector3*)&unk_1f4` rather than the header asserting a type the other eight matched functions never see |
| `0x21c` | `s16`, then cast **every** read to `(u16)` — `(u16)ang >= 0x8000`, `(s32)(u16)ang >> 4` | the reads want unsigned, so the header's existing `u16` already said it; the casts stay as the ROM spells them |

### Verification

**Byte-identical at Stage A** — the shadow swap alone, no further substitution needed, on a 413-line `0xcfc` function.

| gate | result |
|---|---|
| `build_pin.verify` (Behavior + the sibling the header change touched) | `(True, '2004/b56')` |
| `rombuild.py --no-rom` | **106/106 exact**, PASS |
| `eligible.py` bracket vs parent | identical set |
| header offsets | 47 fields, 0 mismatched, spans `0x256` |
| check_references / port_refcheck / dup / data-defs / langmode / attribution | all clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS