### PR TITLE
Player: the one method that was left, and stop the header claiming five it disowns

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -8179,7 +8179,7 @@ src/func_0204fa3c.c:
     complete
     .text start:0x0204fa3c end:0x0204fadc
 
-src/_ZN5Sound6Player19SetPlayableSeqCountEii.c:
+src/_ZN5Sound6Player19SetPlayableSeqCountEii.cpp:
     complete
     .text start:0x0204fadc end:0x0204fafc
 

--- a/include/Player.h
+++ b/include/Player.h
@@ -415,7 +415,6 @@ struct Player : Actor {
                                            Actor::OnYoshiTryEat and CW rejects a
                                            mismatched return type on an override */
 
-    int * TryExitCharacterDoorWithIntro();
     int Burn();
     int CanEnterDoor(unsigned char door);
     int CanPause();
@@ -639,12 +638,8 @@ struct Player : Actor {
     void OpenBigDoor();
     void PlayMammaMiaSound();
     void RegisterEggCoinCount(unsigned int count, bool b2, bool b3);
-    void ST_WAIT();
     void SetNewHatCharacter(unsigned int p1, unsigned int p2, bool p3);
     void SetRealCharacter(unsigned int chr_);
-    void St_EndingFly_Main();
-    void St_InYoshiMouth_Cleanup();
-    void St_WallJump_Init();
     void TurnOffToonShading(unsigned int j);
     void Unk_020ca488();
 };
@@ -677,11 +672,56 @@ typedef char Player_State_size_must_be_0x18[sizeof(Player::State) == 0x18 ? 1 : 
  *     throughout this overlay.
  *
  *     This is the failure mode described in notes/overlay-ambiguous-references.md.
- *     Fixing it means moving the symbol, not typing these offsets. Until then,
- *     treat the St_WallJump_Init() declaration below as unverified.
+ *     Fixing it means moving the symbol, not typing these offsets.
+ *
+ *     CORROBORATED, and the reading above is now stronger than "almost
+ *     certainly". config/arm9/overlays/ov002/relocs.txt carries TWO
+ *     `kind:load to:0x020e17f8 module:overlay(2)` entries, from 0x0210a33c and
+ *     0x0210a3ec. Those two addresses sit in a run of ov002 data symbols with
+ *     an EIGHT-BYTE stride -- which is the {ptr, adj} shape of a
+ *     pointer-to-member documented at the top of this header, i.e. the
+ *     Player::State tables. ov006's only reference to the same address is a
+ *     `kind:arm_call ... module:overlay(6)` from ov006 code. And
+ *     src/func_ov002_020e17f8.c, the ov002 draft, names its shadow struct
+ *     `Player` and touches nothing above 0x71b -- inside this object, where
+ *     the ov006 file's 0x4eb0 is 0x4700 bytes past its end.
+ *
+ *   St_Null_Init is the SAME DEFECT, found the same way. ov006 carries
+ *     _ZN6Player12St_Null_InitEv at 0x020cac30 size 0x6c and ov002 carries an
+ *     unnamed func_ov002_020cac30 of size 0x8 at the same address. ov002
+ *     reaches it by `kind:load ... module:overlay(2)` from 0x0210a17c -- the
+ *     same pointer-to-member region as above -- while ov006 reaches its own
+ *     copy by two direct arm_calls. An eight-byte body is exactly what a state
+ *     called Null should be. Expect more of these: the whole 0x0210a1xx-0x0210a3xx
+ *     table is Player state pointers, and any ov006 symbol its loads land on
+ *     is a candidate.
  *
  *   0x62ad, 0x62af  -- still unexplained; source not yet traced. Needs semantic
  *     review before they can be typed.
+ */
+
+/* WHY FIVE NAMES ARE NOT DECLARED IN THIS CLASS.
+ *
+ * ST_WAIT, St_EndingFly_Main, St_InYoshiMouth_Cleanup, St_WallJump_Init and
+ * TryExitCharacterDoorWithIntro were declared here until this commit, while
+ * each of their sources already said, in terms, "NOT a Player method" and
+ * "detached from Player.h". The header was the last thing still making the
+ * claim. Nothing called them through the declaration -- every caller in the
+ * tree spells the mangled name in its own `extern` -- so removing them is
+ * codegen-neutral, and the eligible name list is unchanged by it.
+ *
+ * ST_WAIT is a separate and still-open question rather than a settled
+ * misattribution, and it is NOT declared here for that reason. Three sources
+ * disagree about what it even is: this header called it `void ST_WAIT()`,
+ * ov006/symbols.txt calls it `kind:function(size=0x68)` at 0x02110154, and
+ * four migrated Player methods -- CanWarp, TryTalkToDoor, TryTalkToKeyDoor,
+ * St_WaitQuicksand_Main -- use `_ZN6Player7ST_WAITE` as a Player::State
+ * OBJECT, passing its address to Player::IsState alongside
+ * data_ov002_0211013c. 0x02110154 is 0x0211013c + 0x18, exactly one State
+ * apart. Do not resolve this from the arithmetic: ov002 and ov006 share that
+ * RAM window, the byte compare wildcards every relocated word, so both
+ * spellings match whichever is right. It needs the module question answered
+ * first.
  */
 
 #endif

--- a/include/Sound.h
+++ b/include/Sound.h
@@ -1,0 +1,37 @@
+#ifndef SOUND_H
+#define SOUND_H
+
+/* The sound namespace. The tree already spells `namespace Sound { ... }` for
+ * its free functions -- PauseMusic, LoadGroupAndSetBank and a dozen others --
+ * but the classes nested inside it have had nowhere to be declared, so every
+ * one of their methods still hand-spells its own mangled name. This header is
+ * where they go.
+ *
+ * Whether `Sound` is a namespace or a class cannot be read off the mangling:
+ * _ZN5Sound6Player... is identical either way. Namespace is what the existing
+ * sources chose, and this header keeps that choice rather than reopening it.
+ *
+ * NO FIELDS, deliberately, in the SharedFilePtr.h sense. Sound::Player's only
+ * recovered method is static and reaches a file-scope table, so nothing here
+ * evidences an instance layout -- and inventing one would silently retype
+ * whatever else turns out to live at those addresses.
+ */
+
+#ifdef __cplusplus
+
+namespace Sound {
+
+struct Player {
+    /* STATIC, and the bytes are what say so. A non-static member would take
+     * `this` in r0; the ROM body multiplies r0 by 0x1c and uses it as a table
+     * index, so r0 is the first int and there is no this. The mangling cannot
+     * distinguish the two -- _ZN5Sound6Player19SetPlayableSeqCountEii is the
+     * same for both -- so this is settled by the disassembly alone. */
+    static void SetPlayableSeqCount(int index, int count);
+};
+
+}
+
+#endif /* __cplusplus */
+
+#endif /* SOUND_H */

--- a/src/_ZN5Sound6Player19SetPlayableSeqCountEii.c
+++ b/src/_ZN5Sound6Player19SetPlayableSeqCountEii.c
@@ -1,4 +1,0 @@
-extern char data_020a4d84[];
-void _ZN5Sound6Player19SetPlayableSeqCountEii(int a, int b){
-  *(unsigned int*)(data_020a4d84 + a*0x1c) = (unsigned short)b;
-}

--- a/src/_ZN5Sound6Player19SetPlayableSeqCountEii.cpp
+++ b/src/_ZN5Sound6Player19SetPlayableSeqCountEii.cpp
@@ -1,0 +1,30 @@
+//cpp
+// @symbol _ZN5Sound6Player19SetPlayableSeqCountEii
+/* recovered: shared header, real C++ method
+ *
+ * Writes one field of a 0x1c-byte record in the table at data_020a4d84,
+ * selected by `index`. The whole ROM body is six instructions:
+ *
+ *     mov r2, #0x1c        ; record stride
+ *     mul r2, r0, r2       ; r0 is the INDEX, not `this` -- see Sound.h
+ *     lsl r0, r1, #0x10
+ *     ldr r1, [pc, #8]     ; data_020a4d84
+ *     lsr r0, r0, #0x10    ; count, zero-extended to 16 bits
+ *     str r0, [r1, r2]     ; ...stored as a full WORD
+ *
+ * The narrowing and the store width disagree on purpose, and that is the
+ * finding: `count` is truncated to 16 bits and then written as a 32-bit word,
+ * so the two bytes ABOVE the count are always cleared as a side effect. A
+ * `strh` would have left them alone. Whatever shares that word with the count
+ * cannot survive a call to this function.
+ */
+#include "Sound.h"
+
+extern "C" {
+extern char data_020a4d84[];
+}
+
+void Sound::Player::SetPlayableSeqCount(int index, int count)
+{
+    *(unsigned int *)(data_020a4d84 + index * 0x1c) = (unsigned short)count;
+}


### PR DESCRIPTION
#1334 has merged; this is now rebased directly onto `main`.

Player — the actor class — has **no migratable method left**, and this PR makes the header say so instead of contradicting its own sources.

## What was migrated

**`Sound::Player::SetPlayableSeqCount`** — the one file in Player's backlog that is a real method of a real class. A *different* class, in arm9. `include/Sound.h` is new: the tree already spells `namespace Sound { … }` for its free functions, but the classes nested inside it had nowhere to be declared, so every one of their methods still hand-spells its mangled name. No fields, deliberately, in the `SharedFilePtr.h` sense.

**The method is `static`, and the bytes are what say so.** A non-static member takes `this` in `r0`; the ROM body multiplies `r0` by `0x1c` and uses it as a table index. The mangling cannot distinguish the two — `_ZN5Sound6Player19SetPlayableSeqCountEii` is identical for both — so only the disassembly settles it.

It carries a finding worth keeping: `count` is truncated to 16 bits (`lsl`/`lsr`) and then stored as a full **word**, so the two bytes above the count are cleared as a side effect on every call. A `strh` would have left them alone.

## What was removed

`ST_WAIT`, `St_EndingFly_Main`, `St_InYoshiMouth_Cleanup`, `St_WallJump_Init` and `TryExitCharacterDoorWithIntro` were declared in `Player.h` while **each of their own sources already said "NOT a Player method" and "detached from Player.h"** — they read `this+0x4eb0`, `this+0x62ad`, `this+0x62af`, against a `sizeof(Player)` of `0x768`. The header was the last thing still making the claim.

Every caller in the tree spells the mangled name in its own `extern`, so nothing reached them through the declaration. Codegen-neutral, and **the eligible name list is byte-identical before and after**.

## Two findings recorded in the header, neither acted on here

**`St_WallJump_Init`'s misattribution is now corroborated, not "almost certainly".** `ov002/relocs.txt` carries **two** `kind:load to:0x020e17f8 module:overlay(2)` entries, from `0x0210a33c` and `0x0210a3ec` — and those sit in a run of ov002 data symbols with an **eight-byte stride**, which is the `{ptr, adj}` pointer-to-member shape `Player.h` already documents for `Player::State`. ov006 reaches the same address by `arm_call`, `module:overlay(6)`. And the ov002 draft names its own shadow struct `Player` and touches nothing above `0x71b`.

**`St_Null_Init` is the same defect, found the same way.** ov006 has it at `0x020cac30` size `0x6c`; ov002 has an unnamed `func_ov002_020cac30` of size **`0x8`** at the same address, reached by `kind:load module:overlay(2)` from `0x0210a17c` — the same table. An eight-byte body is exactly what a state called *Null* should be.

Fixing either means moving a symbol, which is a config change and wants its own PR. Neither ov002 draft byte-matches yet, so the move is byte-neutral and does not by itself make a method migratable.

## `ST_WAIT` is deliberately not resolved

Three sources disagree about what it even is:

| source | claim |
|---|---|
| `Player.h` (until this PR) | `void ST_WAIT()` — a method |
| `ov006/symbols.txt` | `kind:function(size=0x68)` at `0x02110154` |
| `CanWarp`, `TryTalkToDoor`, `TryTalkToKeyDoor`, `St_WaitQuicksand_Main` | a `Player::State` **object**, address passed to `Player::IsState` next to `data_ov002_0211013c` |

`0x02110154` is `0x0211013c + 0x18` — exactly one `State` apart. **Do not resolve it from that arithmetic**: ov002 and ov006 share the RAM window and the byte compare wildcards every relocated word, so both readings match whichever is right. It needs the module question answered first, so it is documented and left alone.

## Gates

```
rombuild.py -j 16 --no-rom     106/106 exact, PASS (10,804 source-built, 87.81%)
eligible.py                    10804 / 11162, name list IDENTICAL to base
check_header_offsets Player.h  182 fields, 0 mismatched, 0 unparsed, spans 0x768
port_refcheck.py               393 checked, all resolve
check_duplicate_sources.py     clean
check_data_definitions.py      clean
check_references.py            OK, no new unresolvable references
prepush_attribution.py         0 changed, 0 lost
```

Unmigrated 951 → **950**. No `--no-verify`.