### PR TITLE
Player: the last four destructible members, and what the destructor really does

### DIFF
--- a/include/Player.h
+++ b/include/Player.h
@@ -29,6 +29,8 @@
 #include "MovingCylinderClsnWithPos.h"
 #include "WithMeshClsn.h"
 #include "ModelAnim.h"
+#include "TextureSequence.h"
+#include "MaterialChanger.h"
 
 /* fwd. Only these three are types. gen_header.py used to emit a `struct X;`
    for every parameter NAME it could not resolve as well -- 26 of them, `struct
@@ -129,11 +131,14 @@ struct Player : Actor {
        exactly at unk_1d8; mAnimation2 at 0x1c4 was its Animation base. */
     ModelAnim mModelAnim4;            /* 0x174 */
     u8  unk_1d8;            /* 0x1d8 */
-    u8  pad_1d9[0x83];
-    s32 unk_25c;            /* 0x25c */
-    u8  pad_260[0x10];
-    s32 unk_270;            /* 0x270 */
-    u8  pad_274[0x8];
+    u8  pad_1d9[0x3];
+    /* The three __destroy_arr calls in ~Player, in the order it makes them
+       (last array first). Both element types assert 0x14, which is exactly
+       the stride the destructor passes. unk_25c and unk_270 were the
+       currFrame of mTexSeqPlayer[0] and [1] -- +0x08 into each element. */
+    TextureSequence mTexSeqBody[4];            /* 0x1dc */
+    MaterialChanger mMatChanger[2];            /* 0x22c */
+    TextureSequence mTexSeqPlayer[2];            /* 0x254 */
     u8  unk_27c;            /* 0x27c */
     u8  pad_27d[0xf];
     u8  unk_28c;            /* 0x28c */
@@ -141,15 +146,15 @@ struct Player : Actor {
     /* ~Player calls _ZN11ShadowModelD1Ev on this, and ShadowModel asserts
        0x28 -- which closes exactly at mMovingCylinderClsnWithPos. */
     ShadowModel mShadowModel;            /* 0x2ac */
-    u8  mMovingCylinderClsnWithPos;            /* 0x2d4 */
-    u8  pad_2d5[0x3];
-    s32 unk_2d8;            /* 0x2d8 */
-    s32 unk_2dc;            /* 0x2dc */
-    u8  pad_2e0[0xc];
-    u8  mBodyClsnFlags;            /* 0x2ec */
-    u8  pad_2ed[0x3];
-    u8  unk_2f0;            /* 0x2f0 */
-    u8  pad_2f1[0x23];
+    /* ~Player calls _ZN25MovingCylinderClsnWithPosD1Ev on this too, and the
+       0x40 it asserts closes exactly at mAttackClsn. The four markers it
+       absorbs are all CylinderClsn's own, reached through the base:
+       unk_2d8 = radius (+0x04), unk_2dc = height (+0x08),
+       mBodyClsnFlags = flags (+0x18), unk_2f0 = vulnFlags (+0x1c).
+       mBodyClsnFlags in particular was never a Player field -- it is the
+       body collider's flags word, which is why thirteen Player methods
+       set and clear bits in it. */
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x2d4 */
     /* ~Player calls _ZN25MovingCylinderClsnWithPosD1Ev on this, and that
        type asserts 0x40 -- which closes exactly at mRidingShell. */
     MovingCylinderClsnWithPos mAttackClsn;            /* 0x314 */

--- a/src/_ZN6Player14St_Cannon_MainEv.cpp
+++ b/src/_ZN6Player14St_Cannon_MainEv.cpp
@@ -48,7 +48,7 @@ int Player::St_Cannon_Main()
         mStateStep = 2;
         mOpacity = 0x1f;
         mIsBodyClsnEnabled = 1;
-        *(int*)(((long long)(int)((char*)&mBodyClsnFlags))) |= 0x20;
+        *(int*)(((long long)(int)((char*)&mMovingCylinderClsnWithPos.flags))) |= 0x20;
         func_0200d6f0(p, mPlayerNo);
         func_02012694(0x14f, ((char*)this) + 0x74);
         _ZN5Sound9PlayBank0EjRK7Vector3(0xb9, ((char*)this) + 0x74);

--- a/src/_ZN6Player15St_Grabbed_InitEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_InitEv.cpp
@@ -11,7 +11,7 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsign
 int Player::St_Grabbed_Init()
 {
   func_ov002_020da9d4(((char*)this));
-  *(int*)(int)(((unsigned long long)(int)((char*)&mBodyClsnFlags)) & 0xFFFFFFFFFFFFFFFFull) |= 2;
+  *(int*)(int)(((unsigned long long)(int)((char*)&mMovingCylinderClsnWithPos.flags)) & 0xFFFFFFFFFFFFFFFFull) |= 2;
   mIsBodyClsnEnabled = 0;
   unk_716 = 1;
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, (void*)((char*)&mCamSpacePosX));

--- a/src/_ZN6Player15St_Spin_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Spin_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Spin_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x20;
+    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x20;
     return 1;
 }

--- a/src/_ZN6Player17St_Cannon_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Cannon_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Cannon_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x20;
+    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x20;
     return 1;
 }

--- a/src/_ZN6Player17St_Squish_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Squish_CleanupEv.cpp
@@ -14,6 +14,6 @@ int Player::St_Squish_Cleanup()
     mScaleY = val;
     mScaleZ = val;
 
-    *(int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~4;
+    *(int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~4;
     return 1;
 }

--- a/src/_ZN6Player17St_Thrown_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Thrown_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Thrown_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x2000;
+    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x2000;
     return 1;
 }

--- a/src/_ZN6Player18St_Grabbed_CleanupEv.cpp
+++ b/src/_ZN6Player18St_Grabbed_CleanupEv.cpp
@@ -20,7 +20,7 @@ extern void _ZN6Player9DropActorEv(void* a);
 int Player::St_Grabbed_Cleanup()
 {
     void* a;
-    *(u32*)&mBodyClsnFlags &= ~2;
+    *(u32*)&mMovingCylinderClsnWithPos.flags &= ~2;
     a = (void*)unk_35c;
     if (a) {
         int isBob = *(u16*)((char*)a + 0xc) == 0xbf;

--- a/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
@@ -23,6 +23,6 @@ int Player::St_CrazedCrate_Init()
   _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x43, 0x40000000, 0x1000, 0);
   func_ov002_020e0f38(((char*)this), mJumpComboStage);
   mPrevAngleY = mAngleY;
-  *(int*)(((long long)(int)((char*)&mBodyClsnFlags))) |= 0x20;
+  *(int*)(((long long)(int)((char*)&mMovingCylinderClsnWithPos.flags))) |= 0x20;
   return 1;
 }

--- a/src/_ZN6Player19St_GroundPound_MainEv.cpp
+++ b/src/_ZN6Player19St_GroundPound_MainEv.cpp
@@ -68,7 +68,7 @@ int Player::St_GroundPound_Main()
                 func_ov002_020c2f64(this);
                 _ZN6Player7SetAnimEji5Fix12IiEj(this, 0x42, 0x40000000, 0x1000, 0);
                 mStateStep = 0xff;
-                *(u32*)&mBodyClsnFlags &= ~0x20;
+                *(u32*)&mMovingCylinderClsnWithPos.flags &= ~0x20;
             }
             {
                 u16 f = mStateFlags & 1;

--- a/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
@@ -17,7 +17,7 @@ int Player::St_InYoshiMouth_Init()
     r3 = 0;
     mStateWork = (unsigned char)r3;
     unk_6e6 = (unsigned char)r3;
-    slot = (char *)(((long long)(int)((char *)&mBodyClsnFlags)));
+    slot = (char *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags)));
     r1 = *(unsigned int *)slot;
     r1 |= 2u;
     *(unsigned int *)slot = r1;

--- a/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
@@ -66,7 +66,7 @@ int Player::St_InYoshiMouth_Main()
         }
     case 2:
         if (mStateTimer == 0)
-            *(int *)(((long long)(int)((char *)&mBodyClsnFlags))) |= 0x2000;
+            *(int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) |= 0x2000;
         if (_ZN6Player12FinishedAnimEv(((char *)this))) {
             mStateStep = 3;
             mHurtDamage = 1;

--- a/src/_ZN6Player22St_GroundPound_CleanupEv.cpp
+++ b/src/_ZN6Player22St_GroundPound_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_GroundPound_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x20;
+    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x20;
     return 1;
 }

--- a/src/_ZN6Player23St_InYoshiMouth_CleanupEv.cpp
+++ b/src/_ZN6Player23St_InYoshiMouth_CleanupEv.cpp
@@ -9,10 +9,12 @@
  * state being left, and TESTS the result -- a 0 vetoes the transition. So this
  * handler's return value is what lets the player leave Yoshi's mouth at all.
  *
- * mBodyClsnFlags at 0x2ec was already in Player.h, named from other evidence,
- * and this function clearing 0x2000 and 0x2 in it is what a cleanup of a
- * carried state looks like. The other two writes are still unnamed offsets --
- * 0x713 and 0x6f5 -- and are left as such rather than guessed at.
+ * The word at 0x2ec used to be a Player field called mBodyClsnFlags. It is
+ * not one: it is the body collider's own `flags` -- CylinderClsn's, at +0x18
+ * -- reached through mMovingCylinderClsnWithPos now that the member has its
+ * real type. Clearing 0x2000 and 0x2 in it is what a cleanup of a carried
+ * state looks like. The other two writes are still unnamed offsets -- 0x713
+ * and 0x6f5 -- and are left as such rather than guessed at.
  *
  * THE TWO CLEARS DO NOT MERGE. `*p &= ~0x2002` is one instruction shorter and
  * changes the size, so the ROM really does mask twice; measured, not assumed.
@@ -26,7 +28,7 @@
 
 int Player::St_InYoshiMouth_Cleanup()
 {
-    unsigned int *p = (unsigned int *)&mBodyClsnFlags;
+    unsigned int *p = (unsigned int *)&mMovingCylinderClsnWithPos.flags;
     *p &= ~0x2000;
     *p &= ~2;
     *(unsigned char *)((char *)this + 0x713) = 1;

--- a/src/_ZN6Player6RenderEv.cpp
+++ b/src/_ZN6Player6RenderEv.cpp
@@ -79,7 +79,7 @@ int Player::Render()
             _ZN5Model6RenderEPK7Vector3(bodyMdl, ((char*)this) + 0x80);
             if (param1 == 1) {
                 _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x254, *(char**)((char*)&unk_0e0) + 8);
-                unk_25c = unk_6fc << 12;
+                mTexSeqPlayer[0].currFrame = unk_6fc << 12;
             }
             func_ov002_020e3e00(bodyMdl, ((char*)this) + 0x80, mOpacity);
             if (unk_700 != 0) {
@@ -128,7 +128,7 @@ int Player::Render()
                 }
                 if (param1 == 1) {
                     _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x268, *(char**)((char*)&unk_158) + 8);
-                    unk_270 = unk_6fc << 12;
+                    mTexSeqPlayer[1].currFrame = unk_6fc << 12;
                 }
                 if (func_ov002_020bea7c(((char*)this)) == 0) {
                     _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x1dc + unk_6db * 0x14, *(char**)(((char*)this) + 0x154 + i * 4) + 8);

--- a/src/_ZN6Player8BehaviorEv.cpp
+++ b/src/_ZN6Player8BehaviorEv.cpp
@@ -85,7 +85,7 @@ int Player::Behavior()
     temp = (s32)(((s64)r2 * 0x32000 + 0x800) >> 12);
     func_0203568c(((char *)this) + 0x380, temp);
     func_02035684(((char *)this) + 0x380, temp);
-    unk_2d8 = scale * 0x28;
+    mMovingCylinderClsnWithPos.radius = scale * 0x28;
     mul = 0x96;
     if (_ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_021104e4)
         || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_02110514)
@@ -96,12 +96,12 @@ int Player::Behavior()
         || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_02110634)) {
         mul = 0x5a;
     }
-    unk_2dc = mul * scale;
+    mMovingCylinderClsnWithPos.height = mul * scale;
 
     if (mIsMega != 0)
-        *(u32 *)LAU((char *)&mBodyClsnFlags) |= 0x10;
+        *(u32 *)LAU((char *)&mMovingCylinderClsnWithPos.flags) |= 0x10;
     else
-        *(u32 *)LAU((char *)&mBodyClsnFlags) &= ~0x10;
+        *(u32 *)LAU((char *)&mMovingCylinderClsnWithPos.flags) &= ~0x10;
 
     if (data_0209fc68 == 0) {
         if (data_0209fc48 != 0)
@@ -270,9 +270,9 @@ after_player_slot:
         u16 t = mInvincibleTimer;
         if (t != 0) {
             if (t == 1)
-                *(u32 *)LAU((char *)&unk_2f0) |= 0x10000000;
+                *(u32 *)LAU((char *)&mMovingCylinderClsnWithPos.vulnFlags) |= 0x10000000;
             else
-                *(u32 *)LAU((char *)&unk_2f0) &= ~0x10000000;
+                *(u32 *)LAU((char *)&mMovingCylinderClsnWithPos.vulnFlags) &= ~0x10000000;
         }
     }
 

--- a/src/_ZN6PlayerD1Ev.cpp
+++ b/src/_ZN6PlayerD1Ev.cpp
@@ -1,6 +1,37 @@
 //cpp
 // @symbol _ZN6PlayerD1Ev
-/* recovered: named members + shared header */
+/* A REAL `Player::~Player() {}` DOES NOT REPRODUCE THIS FUNCTION, and the way
+ * it fails is worth more than the attempt. It is a FAKEMATCH: byte-comparison
+ * reports 39 words, 0 mismatches, and the two functions still call different
+ * code.
+ *
+ * The compiler-generated destructor is right about everything structural. All
+ * nine destructible members now have real types (see include/Player.h), so it
+ * emits the whole sequence by itself, in reverse declaration order, with an
+ * empty body -- the same instruction encodings, the same registers, the same
+ * three array calls with the 0x14 stride.
+ *
+ * But it calls __cxa_vec_cleanup where the ROM calls __destroy_arr. Three times
+ * each, and zero the other way; read off the compiled object's own relocation
+ * table, not guessed. The ROM was built against a runtime whose array-cleanup
+ * helper is __destroy_arr (0x0207328c); this compiler configuration emits the
+ * Itanium ABI's __cxa_vec_cleanup, which exists nowhere in the ROM.
+ *
+ * WHY THE BYTE CHECK MISSED IT: those three calls are `bl` instructions, so
+ * they are relocated words, and match.compare wildcards every relocated word.
+ * tools/fdiff.py and tools/build_pin.py both said match=True. Only the link
+ * would have caught it -- and the file was never enrolled, so the link never
+ * ran. eligible.py DID catch it, from the other direction, by refusing a file
+ * that references a symbol no symbols.txt defines. That refusal was correct and
+ * is not an objisolate defect; isolation already drops dropped sections'
+ * relocation sections, and this reference is in D1's OWN .text.
+ *
+ * SO THE STRUCTOR BLOCKER IS A RUNTIME-HELPER MISMATCH, and it is specific to
+ * classes with ARRAY members -- which is why objisolate's 69 destructors, none
+ * of which have any, were unaffected. Player has three. Until something
+ * reconciles __destroy_arr with __cxa_vec_cleanup, this file stays the
+ * hand-spelt free function it has always been.
+ */
 #include "Player.h"
 extern "C" {
 extern int _ZN12WithMeshClsnD1Ev(void*);


### PR DESCRIPTION
**Stacked on #1342.** Also carries #1338's three commits — see *Merge order* below.

Finishes the layout reconstruction #1342 started. All nine members named by `_ZN6PlayerD1Ev` now have real types. The destructor experiment that follows produced a **negative result with a precise cause**, and the cause is more useful than a match would have been.

> ⚠️ **Correction.** An earlier revision of this PR claimed `Player::~Player()` reproduced the ROM exactly and blamed objisolate for the enrolment failure. **Both claims were wrong.** The match was a fakematch and objisolate needs no change. Details below; the commit message and `src/_ZN6PlayerD1Ev.cpp` have been corrected too.

## What this types

`TextureSequence mTexSeqBody[4]` `0x1dc` · `MaterialChanger mMatChanger[2]` `0x22c` · `TextureSequence mTexSeqPlayer[2]` `0x254` · `MovingCylinderClsnWithPos mMovingCylinderClsnWithPos` `0x2d4`

Every marker they absorb belongs to the object containing it, and sixteen Player sources now say so instead of reaching past it:

```
unk_2d8        = mMovingCylinderClsnWithPos.radius      (CylinderClsn +0x04)
unk_2dc        = mMovingCylinderClsnWithPos.height      (             +0x08)
mBodyClsnFlags = mMovingCylinderClsnWithPos.flags       (             +0x18)
unk_2f0        = mMovingCylinderClsnWithPos.vulnFlags   (             +0x1c)
unk_25c        = mTexSeqPlayer[0].currFrame             (Animation    +0x08)
unk_270        = mTexSeqPlayer[1].currFrame
```

**`mBodyClsnFlags` was never a Player field.** It is the body collider's `flags` word — which is why thirteen Player methods set and clear bits in it, and why the name already had "ClsnFlags" in it.

## The destructor: a fakematch, and how it was caught

`Player::~Player() {}` compiles to **39 words with 0 mismatches** against the ROM — and still calls different code.

It is right about everything structural: with the members typed it emits the whole sequence itself, reverse declaration order, empty body, same encodings, same registers, three array calls with the `0x14` stride. But it calls **`__cxa_vec_cleanup`** where the ROM calls **`__destroy_arr`** — three times each, zero the other way, read off the compiled object's own relocation table:

```
_ZN6PlayerD1Ev  references __cxa_vec_cleanup x3, __destroy_arr x0
_ZN6PlayerD0Ev  references __cxa_vec_cleanup x3, __destroy_arr x0
_ZN6PlayerD2Ev  references __cxa_vec_cleanup x3, __destroy_arr x0
```

**Why the byte check missed it:** those three calls are `bl` instructions, so they are relocated words, and `match.compare` wildcards every relocated word. `fdiff` and `build_pin.verify` both reported `match=True`. Only the link would have caught it — and the file was never enrolled, so the link never ran.

**`eligible.py` caught it from the other direction**, by refusing a file that references a symbol no `symbols.txt` defines. That refusal was **correct**. My earlier diagnosis — that objisolate leaves dropped sections' relocations behind — was wrong twice over: isolation already drops those relocation sections, and the reference is in **D1's own `.text`**, not a sibling's. No objisolate change is needed or wanted, and the tooling PR I proposed has been dropped.

**So the structor blocker is a runtime-helper mismatch**, specific to classes with **array members**: the ROM was built against a runtime whose array-cleanup helper is `__destroy_arr` (`0x0207328c`); this compiler configuration emits the Itanium ABI's `__cxa_vec_cleanup`. That is why objisolate's 69 destructors — none of which have array members — were unaffected. Player has three.

The finding is recorded in `src/_ZN6PlayerD1Ev.cpp`, which stays the hand-spelt free function so nothing regresses.

## Merge order — please read

This branch **cherry-picks #1338's three commits**. `St_InYoshiMouth_Cleanup` is on a separate line of the stack and its migrated source uses `mBodyClsnFlags`; that name stops existing here. The two branches were **green individually and would have been broken together**. Cherry-picking means the gates ran on the *combination*. They merge as no-ops.

The `2 changed` in `prepush_attribution` is #1338's known contributor pair, inherited — nothing new from this slice, and it already passed real validation on #1338.

## Gates

```
rombuild.py -j 16 --no-rom     106/106 exact, PASS (10,805 source-built, 87.82%)
eligible.py                    10805 / 11162; name list differs from this
                                 branch's base only by #1338's own two lines
check_header_offsets Player.h  176 fields, 0 mismatched, 0 unparsed, spans 0x768
port_refcheck.py               393 checked, all resolve
check_duplicate_sources.py     clean
check_data_definitions.py      clean
check_references.py            OK, no new unresolvable references
langmode ratchet               PASS
```

All fifteen rewritten Player sources byte-verified individually, including `Behavior` (`0x868`) and `Render` (`0x3f8`) — and unlike the destructor those are **enrolled**, so rombuild's link checks their relocation targets for real.