### PR TITLE
Track unresolved references by module and address

### DIFF
--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,991 +1,1703 @@
 {
- "eligible": 10666,
+ "eligible": 10805,
  "unresolved": {
-  "ChainChomp_Spawn": [
-   "func_020aed98"
-  ],
-  "ChiefChilly_Spawn": [
-   "func_020aed98"
-  ],
-  "ExplosionGoomba_Spawn": [
-   "func_020aed98"
-  ],
-  "FS_LoadOverlay": [
-   "func_020aa420"
-  ],
-  "FallBlockBbh_Spawn": [
-   "_ZTV20daObjTh_Fall_Block_c"
-  ],
-  "FallBlockBfs_Spawn": [
-   "_ZTV21daObjKm2_Fall_Block_c"
-  ],
-  "FallBlockLll_Spawn": [
-   "_ZTV20daObjFl_Fall_Block_c"
-  ],
-  "GetSceneOverlayID": [
-   "overlay_2",
-   "overlay_3",
-   "overlay_5",
-   "overlay_6",
-   "overlay_7"
-  ],
-  "Goomboss_Spawn": [
-   "func_020aed98"
-  ],
-  "Grindel_Spawn": [
-   "_ZTV7daDkk_c"
-  ],
-  "RollingLogLll_Spawn": [
-   "_ZTV15daObjFlMaruta_c"
-  ],
-  "RollingLogTtm_Spawn": [
-   "_ZTV15daObjHmMaruta_c"
-  ],
-  "UnchainedChomp_Spawn": [
-   "func_020aed98"
-  ],
-  "Wiggler_Spawn": [
-   "func_020aed98"
-  ],
-  "_Z26LoadOrUnloadObjectOverlaysPFviEi": [
-   "overlay_102",
-   "overlay_60",
-   "overlay_98"
-  ],
-  "_ZN10CheepCheep13InitResourcesEv": [
-   "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
-   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
-   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj"
-  ],
-  "_ZN10FlameChomp13InitResourcesEv": [
-   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
-   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj"
-  ],
-  "_ZN10MrBlizzard13InitResourcesEv": [
-   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
-   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj"
-  ],
-  "_ZN10Scuttlebug13InitResourcesEv": [
-   "AnimLoadFile",
-   "ModelLoadFile",
-   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
-  ],
-  "_ZN11FallBlockWf13InitResourcesEv": [
-   "func_0213a794"
-  ],
-  "_ZN11FallBlockWf16CleanupResourcesEv": [
-   "func_0213a2cc"
-  ],
-  "_ZN11FallBlockWfD0Ev": [
-   "G0",
-   "VT1",
-   "VT2",
-   "_ZTV10dBgActor_c"
-  ],
-  "_ZN11FallBlockWfD1Ev": [
-   "VT1",
-   "VT2",
-   "_ZTV10dBgActor_c"
-  ],
-  "_ZN11MirrorLuigi13InitResourcesEv": [
-   "Animation_LoadFile",
-   "ModelAnim_SetAnim",
-   "ModelBase_SetFile",
-   "Model_LoadFile",
-   "ShadowModel_InitCylinder",
-   "TextureSequence_Prepare",
-   "TextureSequence_SetFile"
-  ],
-  "_ZN12FallBlockBbhD0Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV20daObjTh_Fall_Block_c"
-  ],
-  "_ZN12FallBlockBbhD1Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV20daObjTh_Fall_Block_c"
-  ],
-  "_ZN12FallBlockBfs13InitResourcesEv": [
-   "func_0213a794"
-  ],
-  "_ZN12FallBlockBfs16CleanupResourcesEv": [
-   "func_0213a2cc"
-  ],
-  "_ZN12FallBlockBfsD0Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV21daObjKm2_Fall_Block_c"
-  ],
-  "_ZN12FallBlockBfsD1Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV21daObjKm2_Fall_Block_c"
-  ],
-  "_ZN12FallBlockLll16CleanupResourcesEv": [
-   "func_021270dc"
-  ],
-  "_ZN12FallBlockLllD0Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV15daObjFlMaruta_c"
-  ],
-  "_ZN12FallBlockLllD1Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV15daObjFlMaruta_c"
-  ],
-  "_ZN13FortressTower13InitResourcesEv": [
-   "MeshCollider_LoadFile",
-   "ModelBase_SetFile",
-   "Model_LoadFile",
-   "MovingMeshCollider_SetFile",
-   "Platform_UpdateClsnPosAndRot",
-   "Platform_UpdateModelPosAndRotY"
-  ],
-  "_ZN13MontyMoleRock8BehaviorEv": [
-   "ActorBase_MarkForDestruction",
-   "Actor_FindWithID",
-   "Actor_MakeVanishLuigiWork",
-   "Actor_UpdatePos",
-   "CylinderClsn_Clear",
-   "CylinderClsn_Update",
-   "Enemy_UpdateWMClsn",
-   "Player_Hurt",
-   "WithMeshClsn_IsOnGround"
-  ],
-  "_ZN13PrincessPeach13InitResourcesEv": [
-   "AnimLoadFile",
-   "ModelLoadFile",
-   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
-  ],
-  "_ZN13RacingPenguin13InitResourcesEv": [
-   "Actor_TrackStar",
-   "Animation_LoadFile",
-   "ModelBase_SetFile",
-   "Model_LoadFile",
-   "MovingCylinderClsn_Init",
-   "PathPtr_FromID",
-   "PathPtr_GetNode",
-   "ShadowModel_InitCylinder",
-   "TextureSequence_LoadFile",
-   "TextureSequence_Prepare",
-   "WithMeshClsn_Init"
-  ],
-  "_ZN13RacingPenguin8BehaviorEv": [
-   "_Z23_ZN9Animation7AdvanceEvPc",
-   "_Z25_ZN12CylinderClsn5ClearEvPc",
-   "_Z26_ZN12CylinderClsn6UpdateEvPc",
-   "p__sinit_ov031_02111434"
-  ],
-  "_ZN13SnowmanBreath8BehaviorEv": [
-   "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3sijjPvj"
-  ],
-  "_ZN13TTC_MovingBar13InitResourcesEv": [
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-  ],
-  "_ZN14CutsceneObject13InitResourcesEv": [
-   "_Z5_Znwji",
-   "func_02113c20"
-  ],
-  "_ZN14TtcMovingCubeA13InitResourcesEv": [
-   "func_02112118"
-  ],
-  "_ZN15BookShotSpawner13InitResourcesEv": [
-   "_Z17LoadBlueCoinModelPv",
-   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv"
-  ],
-  "_ZN15TtcRotatingGear13InitResourcesEv": [
-   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
-   "_Z37_ZN8Platform21UpdateModelPosAndRotYEvPv",
-   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
-   "func_021121b8"
-  ],
-  "_ZN16BowserShockwaves13InitResourcesEv": [
-   "func_021115e4",
-   "func_021115f4"
-  ],
-  "_ZN16FloatingFloorBfs13InitResourcesEv": [
-   "func_020b6244"
-  ],
-  "_ZN16FloatingFloorBfs16CleanupResourcesEv": [
-   "func_020b60fc"
-  ],
-  "_ZN16RotatingCogSmall13InitResourcesEv": [
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-  ],
-  "_ZN17MgBounceAndPounce11AfterRenderEj": [
-   "Scene_AfterRender"
-  ],
-  "_ZN17RotatingClockHand13InitResourcesEv": [
-   "MeshColliderLoadFile",
-   "ModelLoadFile",
-   "UpdatePosWithTransformSym",
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-  ],
-  "_ZN18BowserFireSeaArena13InitResourcesEv": [
-   "_Z13func_020393d4PvS_",
-   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
-   "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-   "func_021115bc"
-  ],
-  "_ZN19RotatingPlatformLll8BehaviorEv": [
-   "Platform_IsClsnInRange",
-   "Platform_UpdateClsnPosAndRot",
-   "Platform_UpdateModelPosAndRotY",
-   "_Z13func_020393a4Pii"
-  ],
-  "_ZN19RotatingPlatformWdw13InitResourcesEv": [
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-  ],
-  "_ZN22RotatingUpDownPlatform13InitResourcesEv": [
-   "Vec3_equal",
-   "_Z13func_020393c4PvS_",
-   "_Z13func_020393d4PvS_",
-   "_Z20_ZN7PathPtr6FromIDEjPvj",
-   "_Z31_ZNK7PathPtr7GetNodeER7Vector3jPvS_j",
-   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
-   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-  ],
-  "_ZN22RotatingUpDownPlatform8BehaviorEv": [
-   "ApproachLinearI",
-   "UpdatePosWithVelocitySym",
-   "_ZN8Platform13IsClsnInRangeEii"
-  ],
-  "_ZN3HUD15RenderCoinCountEv": [
-   "func_020ab9c8",
-   "func_020aba70",
-   "func_020abad8"
-  ],
-  "_ZN3HUD15RenderLifeCountEv": [
-   "func_020ab948",
-   "func_020ab9c8",
-   "func_020aba70"
-  ],
-  "_ZN3HUD15RenderStarCountEv": [
-   "func_020ab9c8",
-   "func_020aba70",
-   "func_020abad0"
-  ],
-  "_ZN3HUD15RenderTimeTimerEv": [
-   "_ll_udiv",
-   "_ull_mod"
-  ],
-  "_ZN4cstd5atan2E5Fix12IiES1_": [
-   "func_01ff98f4"
-  ],
-  "_ZN5Cloud8BehaviorEv": [
-   "FindWithActorID",
-   "SetPolygonID"
-  ],
-  "_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc": [
-   "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv"
-  ],
-  "_ZN5FaderD0Ev": [
-   "base_dtor_Fader"
-  ],
-  "_ZN5Stage12RenderNumberEhiibi": [
-   "func_020aba70"
-  ],
-  "_ZN5Stage14GraphCallback2EP12SceneRelated": [
-   "reg_G2S_DB_BG3PA"
-  ],
-  "_ZN5Stage20RenderBouncingArrowsEv": [
-   "func_020abd88"
-  ],
-  "_ZN5Stage6RenderEv": [
-   "func_020ab9c8",
-   "func_020abad8"
-  ],
-  "_ZN5Stage9PS_RenderEv": [
-   "func_020ab9c8",
-   "func_020abac0",
-   "func_020abad8",
-   "func_020abd98",
-   "func_020ac218",
-   "func_020ac64c",
-   "func_020acb68",
-   "func_020ad04c"
-  ],
-  "_ZN6BobOmb8BehaviorEv": [
-   "func_020ada40"
-  ],
-  "_ZN6Bullet13InitResourcesEv": [
-   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
-   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-   "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
-   "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
-   "func_0211d610"
-  ],
-  "_ZN6Eyerok13InitResourcesEv": [
-   "_Z13func_020393c4PvS_",
-   "_Z13func_020393d4PvS_",
-   "_Z22_ZN5Actor9TrackStarEjjPvjj",
-   "_Z32_ZN11ShadowModel12InitCylinderEvPv",
-   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
-   "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-   "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
-   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
-   "_Z44_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16iijjP7Vector3Pvii",
-   "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
-   "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
-   "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
-   "func_02112c08",
-   "func_02112ca8",
-   "func_02112d48"
-  ],
-  "_ZN7ClipperD0Ev": [
-   "base_dtor_Clipper"
-  ],
-  "_ZN7Skeeter8BehaviorEv": [
-   "func_020aea30"
-  ],
-  "_ZN7Tornado13InitResourcesEv": [
-   "func_02112968"
-  ],
-  "_ZN8CapEnemy6AddCapEj": [
-   "func_020ff028"
-  ],
-  "_ZN8Goomboss13InitResourcesEv": [
-   "func_021123f4",
-   "func_021124ac"
-  ],
-  "_ZN8SignPost13InitResourcesEv": [
-   "MeshColliderLoadFile",
-   "ModelLoadFile",
-   "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-  ],
-  "_ZN9ActorBase21AfterCleanupResourcesEj": [
-   "Heap_Destroy",
-   "Memory_Deallocate",
-   "Memory_gameHeapPtr",
-   "gGlobalA",
-   "gGlobalB"
-  ],
-  "_ZN9Spindrift13InitResourcesEv": [
-   "AnimLoadFile",
-   "ModelLoadFile",
-   "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
-   "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
-   "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
-  ],
-  "_ZN9UkikiCageD0Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV15daObjHmMaruta_c"
-  ],
-  "_ZN9UkikiCageD1Ev": [
-   "_ZTV10dBgActor_c",
-   "_ZTV15daObjHmMaruta_c"
-  ],
-  "__sinit_ov071_02122a64": [
-   "data_ov071_02122ecc_d"
-  ],
-  "func_02008b4c": [
-   "func_020effb8"
-  ],
-  "func_02009374": [
-   "Vec3_DistSq"
-  ],
-  "func_02014f5c": [
-   "func_020caf98"
-  ],
-  "func_02019ebc": [
-   "func_02061128"
-  ],
-  "func_0201a2f8": [
-   "func_020aa420",
-   "overlay_0",
-   "overlay_1"
-  ],
-  "func_0201a458": [
-   "func_0211d9c0",
-   "func_02140d80"
-  ],
-  "func_0201a614": [
-   "overlay_75"
-  ],
-  "func_0201a694": [
-   "overlay_75"
-  ],
-  "func_0201a754": [
-   "overlay_4",
-   "overlay_6"
-  ],
-  "func_0201a798": [
-   "overlay_4",
-   "overlay_6"
-  ],
-  "func_0201a8b4": [
-   "_ll_udiv"
-  ],
-  "func_02029408": [
-   "func_020bd828"
-  ],
-  "func_02034fbc": [
-   "overlay_64",
-   "overlay_66"
-  ],
-  "func_0203c178": [
-   "func_020527e9"
-  ],
-  "func_02042784": [
-   "_ll_udiv"
-  ],
-  "func_020427c4": [
-   "_ll_udiv"
-  ],
-  "func_02044b30": [
-   "@30"
-  ],
-  "func_02053130": [
-   "SQRTCNT",
-   "SQRT_RESULT"
-  ],
-  "func_02055454": [
-   "G"
-  ],
-  "func_020570c0": [
-   "G"
-  ],
-  "func_020570d8": [
-   "G"
-  ],
-  "func_02057128": [
-   "G"
-  ],
-  "func_02057140": [
-   "G"
-  ],
-  "func_02057410": [
-   "_ll_mod"
-  ],
-  "func_02058308": [
-   "func_00000000",
-   "func_00000600"
-  ],
-  "func_02058df4": [
-   "func_00000000",
-   "func_00000600"
-  ],
-  "func_02059640": [
-   "G"
-  ],
-  "func_02059a60": [
-   "_ll_udiv"
-  ],
-  "func_02059f48": [
-   "G"
-  ],
-  "func_0205f650": [
-   "G"
-  ],
-  "func_0206ece0": [
-   "func_01ff9e2c"
-  ],
-  "func_0206f46c": [
-   "_deq"
-  ],
-  "func_0206f820": [
-   "_ll_udiv",
-   "_ull_mod"
-  ],
-  "func_020708b4": [
-   "_deq"
-  ],
-  "func_02070c68": [
-   "func_01ff9d40"
-  ],
-  "func_02071510": [
-   "_ll_udiv",
-   "_ull_mod"
-  ],
-  "func_ov002_020bd664": [
-   "_ZGVtable$8",
-   "table$8"
-  ],
-  "func_ov002_020c0fb4": [
-   "_ll_udiv"
-  ],
-  "func_ov002_020c8a4c": [
-   "_Z13func_020072c0v",
-   "_ZN6Player7SetAnimEjiij"
-  ],
-  "func_ov002_020dc560": [
-   "func_01ff98f4",
-   "func_01ff99a4"
-  ],
-  "func_ov002_020ec670": [
-   "func_02123804"
-  ],
-  "func_ov002_020f7d74": [
-   "_ZGVdata_ov002_0211104c$8",
-   "data_ov002_0211104c$8"
-  ],
-  "func_ov003_020adfc8": [
-   "func_020ab9c8",
-   "func_020aba70",
-   "func_020abad8"
-  ],
-  "func_ov003_020ae0b0": [
-   "func_020ab9c8",
-   "func_020aba70",
-   "func_020abad0"
-  ],
-  "func_ov003_020ae238": [
-   "func_020ab948",
-   "func_020ab9c8",
-   "func_020aba70"
-  ],
-  "func_ov004_020b2cb8": [
-   "@7"
-  ],
-  "func_ov004_020b87e0": [
-   "_ZGVtable$6",
-   "table$6"
-  ],
-  "func_ov006_020c0a48": [
-   "g0",
-   "g1",
-   "g2"
-  ],
-  "func_ov006_020c14bc": [
-   "func_020beb68"
-  ],
-  "func_ov006_020c221c": [
-   "g0",
-   "g1"
-  ],
-  "func_ov006_020c3bc8": [
-   "func_020c3adc"
-  ],
-  "func_ov006_020db720": [
-   "func_020beb68"
-  ],
-  "func_ov006_020db9dc": [
-   "func_020bc7d4"
-  ],
-  "func_ov006_020dcd74": [
-   "func_020beb68"
-  ],
-  "func_ov006_020de1d4": [
-   "func_020beb68"
-  ],
-  "func_ov006_020de26c": [
-   "func_020beb68"
-  ],
-  "func_ov006_020de440": [
-   "func_020beb68"
-  ],
-  "func_ov006_020de584": [
-   "func_020ddd6c"
-  ],
-  "func_ov006_020e3578": [
-   "func_020adc74"
-  ],
-  "func_ov006_020e6894": [
-   "func_020adc74"
-  ],
-  "func_ov006_020e7124": [
-   "func_020beb74"
-  ],
-  "func_ov006_020e989c": [
-   "func_020beb68"
-  ],
-  "func_ov006_020e9c20": [
-   "func_020beb68"
-  ],
-  "func_ov006_020e9cec": [
-   "G0",
-   "G1"
-  ],
-  "func_ov006_020ea3d0": [
-   "func_020beb68"
-  ],
-  "func_ov006_020ee2c4": [
-   "func_020beb68"
-  ],
-  "func_ov006_020efcf8": [
-   "data_04000006"
-  ],
-  "func_ov006_020f0274": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f3294": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f3460": [
-   "func_020adc74",
-   "func_020bc864",
-   "func_020bc888"
-  ],
-  "func_ov006_020f3834": [
-   "_ZN10SysTrackerD1Ev"
-  ],
-  "func_ov006_020f4888": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f52c4": [
-   "func_020bc7d4",
-   "func_020beb68"
-  ],
-  "func_ov006_020f53e4": [
-   "func_020bc7d4"
-  ],
-  "func_ov006_020f5564": [
-   "_ZN10SysTrackerD1Ev"
-  ],
-  "func_ov006_020f6538": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f7394": [
-   "func_020bc7d4",
-   "func_020beb68"
-  ],
-  "func_ov006_020f74b4": [
-   "func_020bc7d4"
-  ],
-  "func_ov006_020f7634": [
-   "_ZN10SysTrackerD1Ev"
-  ],
-  "func_ov006_020f7c10": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f869c": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f8a3c": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f8c68": [
-   "func_020bc7d4"
-  ],
-  "func_ov006_020f8d08": [
-   "func_020beb68"
-  ],
-  "func_ov006_020f8ef4": [
-   "_ZN10SysTrackerD1Ev"
-  ],
-  "func_ov006_021071fc": [
-   "func_020beb68"
-  ],
-  "func_ov006_02108f2c": [
-   "func_020b9488"
-  ],
-  "func_ov006_021095cc": [
-   "func_020bc7d4",
-   "func_020beb68"
-  ],
-  "func_ov006_02109aac": [
-   "func_020beb68"
-  ],
-  "func_ov006_0210a708": [
-   "func_020beb6c"
-  ],
-  "func_ov006_0210a8c0": [
-   "func_020ad494"
-  ],
-  "func_ov006_0210a900": [
-   "func_020ad494"
-  ],
-  "func_ov006_0210a954": [
-   "_ZN10SysTrackerD1Ev"
-  ],
-  "func_ov006_0210bdb0": [
-   "func_020bc860",
-   "func_020bc864",
-   "func_020bc878",
-   "func_020bc888",
-   "func_020bc88c",
-   "func_020bc890",
-   "func_020bc8b4",
-   "func_020bc8b8"
-  ],
-  "func_ov006_0210c2d4": [
-   "func_020beb68"
-  ],
-  "func_ov006_0210d1fc": [
-   "func_020bc860",
-   "func_020bc878",
-   "func_020bc88c",
-   "func_020bc890",
-   "func_020bc8b4",
-   "func_020bc8b8"
-  ],
-  "func_ov006_0210d6b8": [
-   "func_020ad494"
-  ],
-  "func_ov006_02115b0c": [
-   "func_020adc74"
-  ],
-  "func_ov006_02118488": [
-   "func_020bc864",
-   "func_020bc888"
-  ],
-  "func_ov006_02119904": [
-   "_ZN10SysTrackerD1Ev"
-  ],
-  "func_ov006_0211fd44": [
-   "func_020beb68"
-  ],
-  "func_ov006_021200dc": [
-   "func_020beb6c"
-  ],
-  "func_ov006_021203fc": [
-   "func_020bc880",
-   "func_020bc884"
-  ],
-  "func_ov006_02125364": [
-   "func_020bc7d4"
-  ],
-  "func_ov006_02129268": [
-   "func_020adc74"
-  ],
-  "func_ov006_0212b480": [
-   "func_020adc74",
-   "func_020bc86c",
-   "func_020bc898",
-   "func_020bc8a4",
-   "func_020bc8a8"
-  ],
-  "func_ov007_020bcf90": [
-   "func_02055574",
-   "func_020b2160",
-   "func_020b2370",
-   "func_020b2728",
-   "func_020b2cf0",
-   "func_020b413c",
-   "func_020b4464",
-   "func_020b7658",
-   "func_020b7a00",
-   "func_020b7a34",
-   "func_020b8fd4",
-   "func_020b91b4",
-   "func_020bee14",
-   "func_020bfaf0",
-   "func_020c232c",
-   "func_020c2390",
-   "func_020c93b4"
-  ],
-  "func_ov007_020c798c": [
-   "func_020c3df4",
-   "func_020c78b0",
-   "func_020c80a4",
-   "func_020c844c"
-  ],
-  "func_ov007_020c8970": [
-   "func_020c897c"
-  ],
-  "func_ov007_020cc2cc": [
-   "overlay_64",
-   "overlay_66"
-  ],
-  "func_ov007_020cc4c0": [
-   "overlay_100",
-   "overlay_102"
-  ],
-  "func_ov015_02112c84": [
-   "func_020b66a8"
-  ],
-  "func_ov016_02112fa8": [
-   "func_020b5e58"
-  ],
-  "func_ov020_021112b0": [
-   "Actor_ClosestPlayer",
-   "cstd_atan2"
-  ],
-  "func_ov021_02111434": [
-   "conv_ov021"
-  ],
-  "func_ov022_0211165c": [
-   "func_020b66a8"
-  ],
-  "func_ov022_02112380": [
-   "_ZTV10dBgActor_c",
-   "_ZTV20daObjFl_Fall_Block_c"
-  ],
-  "func_ov022_02112434": [
-   "func_0213a2cc"
-  ],
-  "func_ov022_02112448": [
-   "func_0213a794"
-  ],
-  "func_ov025_021118c8": [
-   "_ZTV10dBgActor_c",
-   "_ZTV7daDkk_c"
-  ],
-  "func_ov025_02111928": [
-   "G0",
-   "VT0",
-   "VT1",
-   "VT2"
-  ],
-  "func_ov026_02111598": [
-   "func_ov053_021112a4"
-  ],
-  "func_ov034_02111788": [
-   "_Z32_ZN5Actor10PoofDustAtERK7Vector3PvPK7Vector3",
-   "_Z45_ZN5Actor19UntrackAndSpawnStarERajRK7Vector3hPvPajPK7Vector3j"
-  ],
-  "func_ov036_0211244c": [
-   "func_020efaf0"
-  ],
-  "func_ov045_02111bc8": [
-   "func_020b6424"
-  ],
-  "func_ov045_02111bdc": [
-   "func_020b6584"
-  ],
-  "func_ov060_021182b0": [
-   "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
-  ],
-  "func_ov062_02116010": [
-   "func_020ada40"
-  ],
-  "func_ov062_02117c98": [
-   "func_020ada40",
-   "func_020aea30"
-  ],
-  "func_ov063_0211a0dc": [
-   "func_020ada40"
-  ],
-  "func_ov064_02116754": [
-   "func_020ada40"
-  ],
-  "func_ov065_02115ff0": [
-   "func_020ada40",
-   "func_020aea30"
-  ],
-  "func_ov065_0211704c": [
-   "func_020ada40",
-   "func_020aea30"
-  ],
-  "func_ov065_0211a358": [
-   "_Z30_ZN11ShadowModel10InitCuboidEvPv",
-   "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
-   "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
-   "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
-   "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
-   "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-   "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-   "func_02112198"
-  ],
-  "func_ov065_0211b1d4": [
-   "MeshColliderLoadFile",
-   "ModelLoadFile",
-   "UpdatePosWithTransformSym",
-   "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-   "func_02112258"
-  ],
-  "func_ov066_021166c8": [
-   "_Z13func_02112c88v",
-   "_Z13func_02112cc8v",
-   "_Z19func_ov066_0211a35cv",
-   "_Z23func_02112cd8_updateposv"
-  ],
-  "func_ov066_02116db0": [
-   "func_02112c08",
-   "func_02112d48"
-  ],
-  "func_ov066_021175e8": [
-   "func_02112c08",
-   "func_02112d48"
-  ],
-  "func_ov066_02117bf0": [
-   "func_02112c08",
-   "func_02112d48"
-  ],
-  "func_ov066_02118188": [
-   "func_02112c08",
-   "func_02112d48"
-  ],
-  "func_ov070_0211f100": [
-   "func_020aea30"
-  ],
-  "func_ov075_02116f40": [
-   "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
-   "func_020abd88"
-  ],
-  "func_ov075_02117bc4": [
-   "overlay_64",
-   "overlay_66"
-  ],
-  "func_ov081_021243cc": [
-   "func_020ada40",
-   "func_020aea30"
-  ],
-  "func_ov084_02129a00": [
-   "func_020aea30"
-  ],
-  "func_ov084_02129ed4": [
-   "func_020ada40",
-   "func_020aea30"
-  ],
-  "func_ov084_0212a774": [
-   "func_020aea30"
-  ],
-  "func_ov085_02129f8c": [
-   "normalize"
-  ],
-  "func_ov089_0213162c": [
-   "data_02111b68"
-  ],
-  "func_ov090_021310b4": [
-   "func_020ada40",
-   "func_020aea30"
-  ],
-  "func_ov091_021339fc": [
-   "func_020aea30"
-  ],
-  "func_ov098_021390ec": [
-   "_Z19func_ov002_020ef228Pvi",
-   "_ZN5Actor12ReflectAngleEiis"
-  ],
-  "func_ov100_0214109c": [
-   "ActorBase_MarkForDestruction"
-  ],
-  "func_ov100_02141fb0": [
-   "func_020ada40"
-  ],
-  "func_ov100_0214272c": [
-   "func_020ad660"
-  ],
-  "func_ov100_02142918": [
-   "func_020ad660"
-  ],
-  "func_ov100_02145080": [
-   "func_020ca78c"
-  ],
-  "func_ov100_02147054": [
-   "G0",
-   "G1",
-   "G2"
-  ],
-  "func_ov100_021470f4": [
-   "_Z16DecIfAbove0_BytePh",
-   "_Z9Vec3_DistPK7Vector3S1_",
-   "_ZN16MeshColliderBase6EnableEPv",
-   "_ZN9Platform219UpdateClsnPosAndRotEv",
-   "_ZN9Platform313IsClsnInRangeEii"
-  ],
-  "func_ov100_021471e0": [
-   "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-   "func_020efaf0"
-  ],
-  "func_ov102_0214cbec": [
-   "func_020ada40"
-  ],
-  "main": [
-   "__main",
-   "_main"
-  ]
+  "arm9:0x020063b0": {
+   "name": "_ZN8CapEnemy6AddCapEj",
+   "missing": [
+    "func_020ff028"
+   ]
+  },
+  "arm9:0x02008b4c": {
+   "name": "func_02008b4c",
+   "missing": [
+    "func_020effb8"
+   ]
+  },
+  "arm9:0x02009374": {
+   "name": "func_02009374",
+   "missing": [
+    "Vec3_DistSq"
+   ]
+  },
+  "arm9:0x02014f5c": {
+   "name": "func_02014f5c",
+   "missing": [
+    "func_020caf98"
+   ]
+  },
+  "arm9:0x020156fc": {
+   "name": "_ZN7ClipperD0Ev",
+   "missing": [
+    "base_dtor_Clipper"
+   ]
+  },
+  "arm9:0x02017848": {
+   "name": "_ZN5FaderD0Ev",
+   "missing": [
+    "base_dtor_Fader"
+   ]
+  },
+  "arm9:0x02018ad0": {
+   "name": "FS_LoadOverlay",
+   "missing": [
+    "func_020aa420"
+   ]
+  },
+  "arm9:0x02019ebc": {
+   "name": "func_02019ebc",
+   "missing": [
+    "func_02061128"
+   ]
+  },
+  "arm9:0x0201a2f8": {
+   "name": "func_0201a2f8",
+   "missing": [
+    "func_020aa420",
+    "overlay_0",
+    "overlay_1"
+   ]
+  },
+  "arm9:0x0201a458": {
+   "name": "func_0201a458",
+   "missing": [
+    "func_0211d9c0",
+    "func_02140d80"
+   ]
+  },
+  "arm9:0x0201a614": {
+   "name": "func_0201a614",
+   "missing": [
+    "overlay_75"
+   ]
+  },
+  "arm9:0x0201a694": {
+   "name": "func_0201a694",
+   "missing": [
+    "overlay_75"
+   ]
+  },
+  "arm9:0x0201a754": {
+   "name": "func_0201a754",
+   "missing": [
+    "overlay_4",
+    "overlay_6"
+   ]
+  },
+  "arm9:0x0201a798": {
+   "name": "func_0201a798",
+   "missing": [
+    "overlay_4",
+    "overlay_6"
+   ]
+  },
+  "arm9:0x0201a7dc": {
+   "name": "GetSceneOverlayID",
+   "missing": [
+    "overlay_2",
+    "overlay_3",
+    "overlay_5",
+    "overlay_6",
+    "overlay_7"
+   ]
+  },
+  "arm9:0x0201a8b4": {
+   "name": "func_0201a8b4",
+   "missing": [
+    "_ll_udiv"
+   ]
+  },
+  "arm9:0x02023be0": {
+   "name": "_ZN5Stage20RenderBouncingArrowsEv",
+   "missing": [
+    "func_020abd88"
+   ]
+  },
+  "arm9:0x020250d0": {
+   "name": "_ZN5Stage12RenderNumberEhiibi",
+   "missing": [
+    "func_020aba70"
+   ]
+  },
+  "arm9:0x020251d0": {
+   "name": "_ZN5Stage9PS_RenderEv",
+   "missing": [
+    "func_020ab9c8",
+    "func_020abac0",
+    "func_020abad8",
+    "func_020abd98",
+    "func_020ac218",
+    "func_020ac64c",
+    "func_020acb68",
+    "func_020ad04c"
+   ]
+  },
+  "arm9:0x02029408": {
+   "name": "func_02029408",
+   "missing": [
+    "func_020bd828"
+   ]
+  },
+  "arm9:0x020297f4": {
+   "name": "_ZN5Stage14GraphCallback2EP12SceneRelated",
+   "missing": [
+    "reg_G2S_DB_BG3PA"
+   ]
+  },
+  "arm9:0x0202b8a4": {
+   "name": "_ZN5Stage6RenderEv",
+   "missing": [
+    "func_020ab9c8",
+    "func_020abad8"
+   ]
+  },
+  "arm9:0x0202df70": {
+   "name": "_Z26LoadOrUnloadObjectOverlaysPFviEi",
+   "missing": [
+    "overlay_102",
+    "overlay_60",
+    "overlay_98"
+   ]
+  },
+  "arm9:0x02034fbc": {
+   "name": "func_02034fbc",
+   "missing": [
+    "overlay_64",
+    "overlay_66"
+   ]
+  },
+  "arm9:0x0203b4dc": {
+   "name": "_ZN4cstd5atan2E5Fix12IiES1_",
+   "missing": [
+    "func_01ff98f4"
+   ]
+  },
+  "arm9:0x0203c178": {
+   "name": "func_0203c178",
+   "missing": [
+    "func_020527e9"
+   ]
+  },
+  "arm9:0x02042784": {
+   "name": "func_02042784",
+   "missing": [
+    "_ll_udiv"
+   ]
+  },
+  "arm9:0x020427c4": {
+   "name": "func_020427c4",
+   "missing": [
+    "_ll_udiv"
+   ]
+  },
+  "arm9:0x02043b2c": {
+   "name": "_ZN9ActorBase21AfterCleanupResourcesEj",
+   "missing": [
+    "Heap_Destroy",
+    "Memory_Deallocate",
+    "Memory_gameHeapPtr",
+    "gGlobalA",
+    "gGlobalB"
+   ]
+  },
+  "arm9:0x02044b30": {
+   "name": "func_02044b30",
+   "missing": [
+    "@30"
+   ]
+  },
+  "arm9:0x02053130": {
+   "name": "func_02053130",
+   "missing": [
+    "SQRTCNT",
+    "SQRT_RESULT"
+   ]
+  },
+  "arm9:0x02055454": {
+   "name": "func_02055454",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x020570c0": {
+   "name": "func_020570c0",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x020570d8": {
+   "name": "func_020570d8",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x02057128": {
+   "name": "func_02057128",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x02057140": {
+   "name": "func_02057140",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x02057410": {
+   "name": "func_02057410",
+   "missing": [
+    "_ll_mod"
+   ]
+  },
+  "arm9:0x02058308": {
+   "name": "func_02058308",
+   "missing": [
+    "func_00000000",
+    "func_00000600"
+   ]
+  },
+  "arm9:0x02058df4": {
+   "name": "func_02058df4",
+   "missing": [
+    "func_00000000",
+    "func_00000600"
+   ]
+  },
+  "arm9:0x02059640": {
+   "name": "func_02059640",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x02059a60": {
+   "name": "func_02059a60",
+   "missing": [
+    "_ll_udiv"
+   ]
+  },
+  "arm9:0x02059f48": {
+   "name": "func_02059f48",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x0205f650": {
+   "name": "func_0205f650",
+   "missing": [
+    "G"
+   ]
+  },
+  "arm9:0x0206ece0": {
+   "name": "func_0206ece0",
+   "missing": [
+    "func_01ff9e2c"
+   ]
+  },
+  "arm9:0x0206f46c": {
+   "name": "func_0206f46c",
+   "missing": [
+    "_deq"
+   ]
+  },
+  "arm9:0x0206f820": {
+   "name": "func_0206f820",
+   "missing": [
+    "_ll_udiv",
+    "_ull_mod"
+   ]
+  },
+  "arm9:0x020708b4": {
+   "name": "func_020708b4",
+   "missing": [
+    "_deq"
+   ]
+  },
+  "arm9:0x02070c68": {
+   "name": "func_02070c68",
+   "missing": [
+    "func_01ff9d40"
+   ]
+  },
+  "arm9:0x02071510": {
+   "name": "func_02071510",
+   "missing": [
+    "_ll_udiv",
+    "_ull_mod"
+   ]
+  },
+  "ov002:0x020adb40": {
+   "name": "_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc",
+   "missing": [
+    "_Z70_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackEjjiiiPKvPv"
+   ]
+  },
+  "ov002:0x020bc240": {
+   "name": "_ZN8SignPost13InitResourcesEv",
+   "missing": [
+    "MeshColliderLoadFile",
+    "ModelLoadFile",
+    "_ZN12WithMeshClsn4InitEP5ActoriiP10Vector3_16i",
+    "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+   ]
+  },
+  "ov002:0x020bd664": {
+   "name": "func_ov002_020bd664",
+   "missing": [
+    "_ZGVtable$8",
+    "table$8"
+   ]
+  },
+  "ov002:0x020c0fb4": {
+   "name": "func_ov002_020c0fb4",
+   "missing": [
+    "_ll_udiv"
+   ]
+  },
+  "ov002:0x020c8a4c": {
+   "name": "func_ov002_020c8a4c",
+   "missing": [
+    "_Z13func_020072c0v",
+    "_ZN6Player7SetAnimEjiij"
+   ]
+  },
+  "ov002:0x020dc560": {
+   "name": "func_ov002_020dc560",
+   "missing": [
+    "func_01ff98f4",
+    "func_01ff99a4"
+   ]
+  },
+  "ov002:0x020ec670": {
+   "name": "func_ov002_020ec670",
+   "missing": [
+    "func_02123804"
+   ]
+  },
+  "ov002:0x020f7d74": {
+   "name": "func_ov002_020f7d74",
+   "missing": [
+    "_ZGVdata_ov002_0211104c$8",
+    "data_ov002_0211104c$8"
+   ]
+  },
+  "ov002:0x020f83a4": {
+   "name": "_ZN14CutsceneObject13InitResourcesEv",
+   "missing": [
+    "_Z5_Znwji",
+    "func_02113c20"
+   ]
+  },
+  "ov002:0x020fb96c": {
+   "name": "_ZN3HUD15RenderTimeTimerEv",
+   "missing": [
+    "_ll_udiv",
+    "_ull_mod"
+   ]
+  },
+  "ov002:0x020fbe38": {
+   "name": "_ZN3HUD15RenderLifeCountEv",
+   "missing": [
+    "func_020ab948",
+    "func_020ab9c8",
+    "func_020aba70"
+   ]
+  },
+  "ov002:0x020fc458": {
+   "name": "_ZN3HUD15RenderStarCountEv",
+   "missing": [
+    "func_020ab9c8",
+    "func_020aba70",
+    "func_020abad0"
+   ]
+  },
+  "ov002:0x020fc81c": {
+   "name": "_ZN3HUD15RenderCoinCountEv",
+   "missing": [
+    "func_020ab9c8",
+    "func_020aba70",
+    "func_020abad8"
+   ]
+  },
+  "ov002:0x020feef4": {
+   "name": "_ZN6Bullet13InitResourcesEv",
+   "missing": [
+    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
+    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+    "_Z50_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jjPcP5Actoriijj",
+    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PcP5ActoriiP10Vector3_16i",
+    "func_0211d610"
+   ]
+  },
+  "ov003:0x020adfc8": {
+   "name": "func_ov003_020adfc8",
+   "missing": [
+    "func_020ab9c8",
+    "func_020aba70",
+    "func_020abad8"
+   ]
+  },
+  "ov003:0x020ae0b0": {
+   "name": "func_ov003_020ae0b0",
+   "missing": [
+    "func_020ab9c8",
+    "func_020aba70",
+    "func_020abad0"
+   ]
+  },
+  "ov003:0x020ae238": {
+   "name": "func_ov003_020ae238",
+   "missing": [
+    "func_020ab948",
+    "func_020ab9c8",
+    "func_020aba70"
+   ]
+  },
+  "ov004:0x020b2cb8": {
+   "name": "func_ov004_020b2cb8",
+   "missing": [
+    "@7"
+   ]
+  },
+  "ov004:0x020b87e0": {
+   "name": "func_ov004_020b87e0",
+   "missing": [
+    "_ZGVtable$6",
+    "table$6"
+   ]
+  },
+  "ov006:0x020c0a48": {
+   "name": "func_ov006_020c0a48",
+   "missing": [
+    "g0",
+    "g1",
+    "g2"
+   ]
+  },
+  "ov006:0x020c14bc": {
+   "name": "func_ov006_020c14bc",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020c221c": {
+   "name": "func_ov006_020c221c",
+   "missing": [
+    "g0",
+    "g1"
+   ]
+  },
+  "ov006:0x020c3bc8": {
+   "name": "func_ov006_020c3bc8",
+   "missing": [
+    "func_020c3adc"
+   ]
+  },
+  "ov006:0x020db720": {
+   "name": "func_ov006_020db720",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020db9dc": {
+   "name": "func_ov006_020db9dc",
+   "missing": [
+    "func_020bc7d4"
+   ]
+  },
+  "ov006:0x020dcd74": {
+   "name": "func_ov006_020dcd74",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020de1d4": {
+   "name": "func_ov006_020de1d4",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020de26c": {
+   "name": "func_ov006_020de26c",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020de440": {
+   "name": "func_ov006_020de440",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020de584": {
+   "name": "func_ov006_020de584",
+   "missing": [
+    "func_020ddd6c"
+   ]
+  },
+  "ov006:0x020e3578": {
+   "name": "func_ov006_020e3578",
+   "missing": [
+    "func_020adc74"
+   ]
+  },
+  "ov006:0x020e6894": {
+   "name": "func_ov006_020e6894",
+   "missing": [
+    "func_020adc74"
+   ]
+  },
+  "ov006:0x020e7124": {
+   "name": "func_ov006_020e7124",
+   "missing": [
+    "func_020beb74"
+   ]
+  },
+  "ov006:0x020e989c": {
+   "name": "func_ov006_020e989c",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020e9c20": {
+   "name": "func_ov006_020e9c20",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020e9cec": {
+   "name": "func_ov006_020e9cec",
+   "missing": [
+    "G0",
+    "G1"
+   ]
+  },
+  "ov006:0x020ea3d0": {
+   "name": "func_ov006_020ea3d0",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020ee2c4": {
+   "name": "func_ov006_020ee2c4",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020efcf8": {
+   "name": "func_ov006_020efcf8",
+   "missing": [
+    "data_04000006"
+   ]
+  },
+  "ov006:0x020f0274": {
+   "name": "func_ov006_020f0274",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f3294": {
+   "name": "func_ov006_020f3294",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f3460": {
+   "name": "func_ov006_020f3460",
+   "missing": [
+    "func_020adc74",
+    "func_020bc864",
+    "func_020bc888"
+   ]
+  },
+  "ov006:0x020f3834": {
+   "name": "func_ov006_020f3834",
+   "missing": [
+    "_ZN10SysTrackerD1Ev"
+   ]
+  },
+  "ov006:0x020f4888": {
+   "name": "func_ov006_020f4888",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f52c4": {
+   "name": "func_ov006_020f52c4",
+   "missing": [
+    "func_020bc7d4",
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f53e4": {
+   "name": "func_ov006_020f53e4",
+   "missing": [
+    "func_020bc7d4"
+   ]
+  },
+  "ov006:0x020f5564": {
+   "name": "func_ov006_020f5564",
+   "missing": [
+    "_ZN10SysTrackerD1Ev"
+   ]
+  },
+  "ov006:0x020f6538": {
+   "name": "func_ov006_020f6538",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f7394": {
+   "name": "func_ov006_020f7394",
+   "missing": [
+    "func_020bc7d4",
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f74b4": {
+   "name": "func_ov006_020f74b4",
+   "missing": [
+    "func_020bc7d4"
+   ]
+  },
+  "ov006:0x020f7634": {
+   "name": "func_ov006_020f7634",
+   "missing": [
+    "_ZN10SysTrackerD1Ev"
+   ]
+  },
+  "ov006:0x020f7c10": {
+   "name": "func_ov006_020f7c10",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f869c": {
+   "name": "func_ov006_020f869c",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f8a3c": {
+   "name": "func_ov006_020f8a3c",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f8c68": {
+   "name": "func_ov006_020f8c68",
+   "missing": [
+    "func_020bc7d4"
+   ]
+  },
+  "ov006:0x020f8d08": {
+   "name": "func_ov006_020f8d08",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x020f8ef4": {
+   "name": "func_ov006_020f8ef4",
+   "missing": [
+    "_ZN10SysTrackerD1Ev"
+   ]
+  },
+  "ov006:0x021071fc": {
+   "name": "func_ov006_021071fc",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x02108f2c": {
+   "name": "func_ov006_02108f2c",
+   "missing": [
+    "func_020b9488"
+   ]
+  },
+  "ov006:0x021095cc": {
+   "name": "func_ov006_021095cc",
+   "missing": [
+    "func_020bc7d4",
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x02109aac": {
+   "name": "func_ov006_02109aac",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x0210a708": {
+   "name": "func_ov006_0210a708",
+   "missing": [
+    "func_020beb6c"
+   ]
+  },
+  "ov006:0x0210a8c0": {
+   "name": "func_ov006_0210a8c0",
+   "missing": [
+    "func_020ad494"
+   ]
+  },
+  "ov006:0x0210a900": {
+   "name": "func_ov006_0210a900",
+   "missing": [
+    "func_020ad494"
+   ]
+  },
+  "ov006:0x0210a954": {
+   "name": "func_ov006_0210a954",
+   "missing": [
+    "_ZN10SysTrackerD1Ev"
+   ]
+  },
+  "ov006:0x0210bdb0": {
+   "name": "func_ov006_0210bdb0",
+   "missing": [
+    "func_020bc860",
+    "func_020bc864",
+    "func_020bc878",
+    "func_020bc888",
+    "func_020bc88c",
+    "func_020bc890",
+    "func_020bc8b4",
+    "func_020bc8b8"
+   ]
+  },
+  "ov006:0x0210c2d4": {
+   "name": "func_ov006_0210c2d4",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x0210d1fc": {
+   "name": "func_ov006_0210d1fc",
+   "missing": [
+    "func_020bc860",
+    "func_020bc878",
+    "func_020bc88c",
+    "func_020bc890",
+    "func_020bc8b4",
+    "func_020bc8b8"
+   ]
+  },
+  "ov006:0x0210d6b8": {
+   "name": "func_ov006_0210d6b8",
+   "missing": [
+    "func_020ad494"
+   ]
+  },
+  "ov006:0x02115b0c": {
+   "name": "func_ov006_02115b0c",
+   "missing": [
+    "func_020adc74"
+   ]
+  },
+  "ov006:0x02118488": {
+   "name": "func_ov006_02118488",
+   "missing": [
+    "func_020bc864",
+    "func_020bc888"
+   ]
+  },
+  "ov006:0x02119904": {
+   "name": "func_ov006_02119904",
+   "missing": [
+    "_ZN10SysTrackerD1Ev"
+   ]
+  },
+  "ov006:0x0211fd44": {
+   "name": "func_ov006_0211fd44",
+   "missing": [
+    "func_020beb68"
+   ]
+  },
+  "ov006:0x021200dc": {
+   "name": "func_ov006_021200dc",
+   "missing": [
+    "func_020beb6c"
+   ]
+  },
+  "ov006:0x021203fc": {
+   "name": "func_ov006_021203fc",
+   "missing": [
+    "func_020bc880",
+    "func_020bc884"
+   ]
+  },
+  "ov006:0x02125364": {
+   "name": "func_ov006_02125364",
+   "missing": [
+    "func_020bc7d4"
+   ]
+  },
+  "ov006:0x02129268": {
+   "name": "func_ov006_02129268",
+   "missing": [
+    "func_020adc74"
+   ]
+  },
+  "ov006:0x0212b480": {
+   "name": "func_ov006_0212b480",
+   "missing": [
+    "func_020adc74",
+    "func_020bc86c",
+    "func_020bc898",
+    "func_020bc8a4",
+    "func_020bc8a8"
+   ]
+  },
+  "ov007:0x020bcf90": {
+   "name": "func_ov007_020bcf90",
+   "missing": [
+    "func_02055574",
+    "func_020b2160",
+    "func_020b2370",
+    "func_020b2728",
+    "func_020b2cf0",
+    "func_020b413c",
+    "func_020b4464",
+    "func_020b7658",
+    "func_020b7a00",
+    "func_020b7a34",
+    "func_020b8fd4",
+    "func_020b91b4",
+    "func_020bee14",
+    "func_020bfaf0",
+    "func_020c232c",
+    "func_020c2390",
+    "func_020c93b4"
+   ]
+  },
+  "ov007:0x020c798c": {
+   "name": "func_ov007_020c798c",
+   "missing": [
+    "func_020c3df4",
+    "func_020c78b0",
+    "func_020c80a4",
+    "func_020c844c"
+   ]
+  },
+  "ov007:0x020c8970": {
+   "name": "func_ov007_020c8970",
+   "missing": [
+    "func_020c897c"
+   ]
+  },
+  "ov007:0x020cc2cc": {
+   "name": "func_ov007_020cc2cc",
+   "missing": [
+    "overlay_64",
+    "overlay_66"
+   ]
+  },
+  "ov007:0x020cc4c0": {
+   "name": "func_ov007_020cc4c0",
+   "missing": [
+    "overlay_100",
+    "overlay_102"
+   ]
+  },
+  "ov014:0x02112d1c": {
+   "name": "ChainChomp_Spawn",
+   "missing": [
+    "func_020aed98"
+   ]
+  },
+  "ov015:0x02112c84": {
+   "name": "func_ov015_02112c84",
+   "missing": [
+    "func_020b66a8"
+   ]
+  },
+  "ov015:0x02112cf4": {
+   "name": "_ZN11FallBlockWfD1Ev",
+   "missing": [
+    "VT1",
+    "VT2",
+    "_ZTV10dBgActor_c"
+   ]
+  },
+  "ov015:0x02112d44": {
+   "name": "_ZN11FallBlockWfD0Ev",
+   "missing": [
+    "G0",
+    "VT1",
+    "VT2",
+    "_ZTV10dBgActor_c"
+   ]
+  },
+  "ov015:0x02112da8": {
+   "name": "_ZN11FallBlockWf16CleanupResourcesEv",
+   "missing": [
+    "func_0213a2cc"
+   ]
+  },
+  "ov015:0x02112dbc": {
+   "name": "_ZN11FallBlockWf13InitResourcesEv",
+   "missing": [
+    "func_0213a794"
+   ]
+  },
+  "ov016:0x02112fa8": {
+   "name": "func_ov016_02112fa8",
+   "missing": [
+    "func_020b5e58"
+   ]
+  },
+  "ov019:0x02112394": {
+   "name": "_ZN13RacingPenguin8BehaviorEv",
+   "missing": [
+    "_Z23_ZN9Animation7AdvanceEvPc",
+    "_Z25_ZN12CylinderClsn5ClearEvPc",
+    "_Z26_ZN12CylinderClsn6UpdateEvPc",
+    "p__sinit_ov031_02111434"
+   ]
+  },
+  "ov019:0x021123d4": {
+   "name": "_ZN13RacingPenguin13InitResourcesEv",
+   "missing": [
+    "Actor_TrackStar",
+    "Animation_LoadFile",
+    "ModelBase_SetFile",
+    "Model_LoadFile",
+    "MovingCylinderClsn_Init",
+    "PathPtr_FromID",
+    "PathPtr_GetNode",
+    "ShadowModel_InitCylinder",
+    "TextureSequence_LoadFile",
+    "TextureSequence_Prepare",
+    "WithMeshClsn_Init"
+   ]
+  },
+  "ov020:0x021112b0": {
+   "name": "func_ov020_021112b0",
+   "missing": [
+    "Actor_ClosestPlayer",
+    "cstd_atan2"
+   ]
+  },
+  "ov020:0x02112768": {
+   "name": "_ZN15BookShotSpawner13InitResourcesEv",
+   "missing": [
+    "_Z17LoadBlueCoinModelPv",
+    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv"
+   ]
+  },
+  "ov021:0x02111434": {
+   "name": "func_ov021_02111434",
+   "missing": [
+    "conv_ov021"
+   ]
+  },
+  "ov022:0x0211165c": {
+   "name": "func_ov022_0211165c",
+   "missing": [
+    "func_020b66a8"
+   ]
+  },
+  "ov022:0x021117cc": {
+   "name": "_ZN19RotatingPlatformLll8BehaviorEv",
+   "missing": [
+    "Platform_IsClsnInRange",
+    "Platform_UpdateClsnPosAndRot",
+    "Platform_UpdateModelPosAndRotY",
+    "_Z13func_020393a4Pii"
+   ]
+  },
+  "ov022:0x02112380": {
+   "name": "func_ov022_02112380",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV20daObjFl_Fall_Block_c"
+   ]
+  },
+  "ov022:0x02112434": {
+   "name": "func_ov022_02112434",
+   "missing": [
+    "func_0213a2cc"
+   ]
+  },
+  "ov022:0x02112448": {
+   "name": "func_ov022_02112448",
+   "missing": [
+    "func_0213a794"
+   ]
+  },
+  "ov022:0x0211245c": {
+   "name": "FallBlockLll_Spawn",
+   "missing": [
+    "_ZTV20daObjFl_Fall_Block_c"
+   ]
+  },
+  "ov022:0x02112498": {
+   "name": "_ZN12FallBlockLllD1Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV15daObjFlMaruta_c"
+   ]
+  },
+  "ov022:0x021124e8": {
+   "name": "_ZN12FallBlockLllD0Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV15daObjFlMaruta_c"
+   ]
+  },
+  "ov022:0x0211254c": {
+   "name": "_ZN12FallBlockLll16CleanupResourcesEv",
+   "missing": [
+    "func_021270dc"
+   ]
+  },
+  "ov022:0x021125a4": {
+   "name": "RollingLogLll_Spawn",
+   "missing": [
+    "_ZTV15daObjFlMaruta_c"
+   ]
+  },
+  "ov025:0x021118c8": {
+   "name": "func_ov025_021118c8",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV7daDkk_c"
+   ]
+  },
+  "ov025:0x02111928": {
+   "name": "func_ov025_02111928",
+   "missing": [
+    "G0",
+    "VT0",
+    "VT1",
+    "VT2"
+   ]
+  },
+  "ov025:0x02111cf4": {
+   "name": "Grindel_Spawn",
+   "missing": [
+    "_ZTV7daDkk_c"
+   ]
+  },
+  "ov027:0x021127a4": {
+   "name": "_ZN13SnowmanBreath8BehaviorEv",
+   "missing": [
+    "_Z33_ZN5Sound8PlayLongEjjjRK7Vector3sijjPvj"
+   ]
+  },
+  "ov029:0x021124d0": {
+   "name": "_ZN19RotatingPlatformWdw13InitResourcesEv",
+   "missing": [
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+   ]
+  },
+  "ov030:0x0211155c": {
+   "name": "_ZN9UkikiCageD1Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV15daObjHmMaruta_c"
+   ]
+  },
+  "ov030:0x021115ac": {
+   "name": "_ZN9UkikiCageD0Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV15daObjHmMaruta_c"
+   ]
+  },
+  "ov030:0x0211164c": {
+   "name": "RollingLogTtm_Spawn",
+   "missing": [
+    "_ZTV15daObjHmMaruta_c"
+   ]
+  },
+  "ov034:0x02111788": {
+   "name": "func_ov034_02111788",
+   "missing": [
+    "_Z32_ZN5Actor10PoofDustAtERK7Vector3PvPK7Vector3",
+    "_Z45_ZN5Actor19UntrackAndSpawnStarERajRK7Vector3hPvPajPK7Vector3j"
+   ]
+  },
+  "ov034:0x021136a4": {
+   "name": "Wiggler_Spawn",
+   "missing": [
+    "func_020aed98"
+   ]
+  },
+  "ov035:0x021114e0": {
+   "name": "_ZN16RotatingCogSmall13InitResourcesEv",
+   "missing": [
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+   ]
+  },
+  "ov035:0x02111a98": {
+   "name": "_ZN17RotatingClockHand13InitResourcesEv",
+   "missing": [
+    "MeshColliderLoadFile",
+    "ModelLoadFile",
+    "UpdatePosWithTransformSym",
+    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+   ]
+  },
+  "ov036:0x0211244c": {
+   "name": "func_ov036_0211244c",
+   "missing": [
+    "func_020efaf0"
+   ]
+  },
+  "ov039:0x021112a0": {
+   "name": "_ZN5Cloud8BehaviorEv",
+   "missing": [
+    "FindWithActorID",
+    "SetPolygonID"
+   ]
+  },
+  "ov045:0x02111bc8": {
+   "name": "func_ov045_02111bc8",
+   "missing": [
+    "func_020b6424"
+   ]
+  },
+  "ov045:0x02111bdc": {
+   "name": "func_ov045_02111bdc",
+   "missing": [
+    "func_020b6584"
+   ]
+  },
+  "ov045:0x02111ce4": {
+   "name": "_ZN16FloatingFloorBfs16CleanupResourcesEv",
+   "missing": [
+    "func_020b60fc"
+   ]
+  },
+  "ov045:0x02111cf8": {
+   "name": "_ZN16FloatingFloorBfs13InitResourcesEv",
+   "missing": [
+    "func_020b6244"
+   ]
+  },
+  "ov045:0x02111d48": {
+   "name": "_ZN12FallBlockBfsD1Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV21daObjKm2_Fall_Block_c"
+   ]
+  },
+  "ov045:0x02111d98": {
+   "name": "_ZN12FallBlockBfsD0Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV21daObjKm2_Fall_Block_c"
+   ]
+  },
+  "ov045:0x02111dfc": {
+   "name": "_ZN12FallBlockBfs16CleanupResourcesEv",
+   "missing": [
+    "func_0213a2cc"
+   ]
+  },
+  "ov045:0x02111e10": {
+   "name": "_ZN12FallBlockBfs13InitResourcesEv",
+   "missing": [
+    "func_0213a794"
+   ]
+  },
+  "ov045:0x02111e24": {
+   "name": "FallBlockBfs_Spawn",
+   "missing": [
+    "_ZTV21daObjKm2_Fall_Block_c"
+   ]
+  },
+  "ov055:0x02111674": {
+   "name": "_ZN11MirrorLuigi13InitResourcesEv",
+   "missing": [
+    "Animation_LoadFile",
+    "ModelAnim_SetAnim",
+    "ModelBase_SetFile",
+    "Model_LoadFile",
+    "ShadowModel_InitCylinder",
+    "TextureSequence_Prepare",
+    "TextureSequence_SetFile"
+   ]
+  },
+  "ov060:0x02117c30": {
+   "name": "_ZN18BowserFireSeaArena13InitResourcesEv",
+   "missing": [
+    "_Z13func_020393d4PvS_",
+    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+    "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
+    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+    "func_021115bc"
+   ]
+  },
+  "ov060:0x021182b0": {
+   "name": "func_ov060_021182b0",
+   "missing": [
+    "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
+   ]
+  },
+  "ov060:0x02119004": {
+   "name": "_ZN16BowserShockwaves13InitResourcesEv",
+   "missing": [
+    "func_021115e4",
+    "func_021115f4"
+   ]
+  },
+  "ov062:0x02116010": {
+   "name": "func_ov062_02116010",
+   "missing": [
+    "func_020ada40"
+   ]
+  },
+  "ov062:0x02117c98": {
+   "name": "func_ov062_02117c98",
+   "missing": [
+    "func_020ada40",
+    "func_020aea30"
+   ]
+  },
+  "ov063:0x0211a0dc": {
+   "name": "func_ov063_0211a0dc",
+   "missing": [
+    "func_020ada40"
+   ]
+  },
+  "ov063:0x0211d3a0": {
+   "name": "_ZN12FallBlockBbhD1Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV20daObjTh_Fall_Block_c"
+   ]
+  },
+  "ov063:0x0211d3f0": {
+   "name": "_ZN12FallBlockBbhD0Ev",
+   "missing": [
+    "_ZTV10dBgActor_c",
+    "_ZTV20daObjTh_Fall_Block_c"
+   ]
+  },
+  "ov063:0x0211d47c": {
+   "name": "FallBlockBbh_Spawn",
+   "missing": [
+    "_ZTV20daObjTh_Fall_Block_c"
+   ]
+  },
+  "ov064:0x02116754": {
+   "name": "func_ov064_02116754",
+   "missing": [
+    "func_020ada40"
+   ]
+  },
+  "ov065:0x02115ff0": {
+   "name": "func_ov065_02115ff0",
+   "missing": [
+    "func_020ada40",
+    "func_020aea30"
+   ]
+  },
+  "ov065:0x0211704c": {
+   "name": "func_ov065_0211704c",
+   "missing": [
+    "func_020ada40",
+    "func_020aea30"
+   ]
+  },
+  "ov065:0x0211a358": {
+   "name": "func_ov065_0211a358",
+   "missing": [
+    "_Z30_ZN11ShadowModel10InitCuboidEvPv",
+    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
+    "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
+    "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+    "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+    "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+    "func_02112198"
+   ]
+  },
+  "ov065:0x0211b1d4": {
+   "name": "func_ov065_0211b1d4",
+   "missing": [
+    "MeshColliderLoadFile",
+    "ModelLoadFile",
+    "UpdatePosWithTransformSym",
+    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
+    "func_02112258"
+   ]
+  },
+  "ov065:0x0211b640": {
+   "name": "_ZN13TTC_MovingBar13InitResourcesEv",
+   "missing": [
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+   ]
+  },
+  "ov065:0x0211ba88": {
+   "name": "_ZN15TtcRotatingGear13InitResourcesEv",
+   "missing": [
+    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+    "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+    "_Z37_ZN8Platform21UpdateModelPosAndRotYEvPv",
+    "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
+    "func_021121b8"
+   ]
+  },
+  "ov065:0x0211bf04": {
+   "name": "_ZN14TtcMovingCubeA13InitResourcesEv",
+   "missing": [
+    "func_02112118"
+   ]
+  },
+  "ov066:0x021166c8": {
+   "name": "func_ov066_021166c8",
+   "missing": [
+    "_Z13func_02112c88v",
+    "_Z13func_02112cc8v",
+    "_Z19func_ov066_0211a35cv",
+    "_Z23func_02112cd8_updateposv"
+   ]
+  },
+  "ov066:0x02116db0": {
+   "name": "func_ov066_02116db0",
+   "missing": [
+    "func_02112c08",
+    "func_02112d48"
+   ]
+  },
+  "ov066:0x021175e8": {
+   "name": "func_ov066_021175e8",
+   "missing": [
+    "func_02112c08",
+    "func_02112d48"
+   ]
+  },
+  "ov066:0x02117bf0": {
+   "name": "func_ov066_02117bf0",
+   "missing": [
+    "func_02112c08",
+    "func_02112d48"
+   ]
+  },
+  "ov066:0x02118188": {
+   "name": "func_ov066_02118188",
+   "missing": [
+    "func_02112c08",
+    "func_02112d48"
+   ]
+  },
+  "ov066:0x02119ce8": {
+   "name": "_ZN6Eyerok13InitResourcesEv",
+   "missing": [
+    "_Z13func_020393c4PvS_",
+    "_Z13func_020393d4PvS_",
+    "_Z22_ZN5Actor9TrackStarEjjPvjj",
+    "_Z32_ZN11ShadowModel12InitCylinderEvPv",
+    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+    "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
+    "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+    "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
+    "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
+    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
+    "func_02112c08",
+    "func_02112ca8",
+    "func_02112d48"
+   ]
+  },
+  "ov070:0x0211f100": {
+   "name": "func_ov070_0211f100",
+   "missing": [
+    "func_020aea30"
+   ]
+  },
+  "ov070:0x02121914": {
+   "name": "_ZN10FlameChomp13InitResourcesEv",
+   "missing": [
+    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
+    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PK7Vector3iijj"
+   ]
+  },
+  "ov071:0x021203f8": {
+   "name": "_ZN10Scuttlebug13InitResourcesEv",
+   "missing": [
+    "AnimLoadFile",
+    "ModelLoadFile",
+    "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+   ]
+  },
+  "ov071:0x02122a64": {
+   "name": "__sinit_ov071_02122a64",
+   "missing": [
+    "data_ov071_02122ecc_d"
+   ]
+  },
+  "ov073:0x02121ec8": {
+   "name": "ChiefChilly_Spawn",
+   "missing": [
+    "func_020aed98"
+   ]
+  },
+  "ov074:0x02121e98": {
+   "name": "_ZN8Goomboss13InitResourcesEv",
+   "missing": [
+    "func_021123f4",
+    "func_021124ac"
+   ]
+  },
+  "ov074:0x02122764": {
+   "name": "ExplosionGoomba_Spawn",
+   "missing": [
+    "func_020aed98"
+   ]
+  },
+  "ov074:0x02122838": {
+   "name": "Goomboss_Spawn",
+   "missing": [
+    "func_020aed98"
+   ]
+  },
+  "ov075:0x02116f40": {
+   "name": "func_ov075_02116f40",
+   "missing": [
+    "_ZN3OAM6RenderEbP7OamAttriiiiiS1_ii",
+    "func_020abd88"
+   ]
+  },
+  "ov075:0x02117bc4": {
+   "name": "func_ov075_02117bc4",
+   "missing": [
+    "overlay_64",
+    "overlay_66"
+   ]
+  },
+  "ov080:0x0212459c": {
+   "name": "_ZN13MontyMoleRock8BehaviorEv",
+   "missing": [
+    "ActorBase_MarkForDestruction",
+    "Actor_FindWithID",
+    "Actor_MakeVanishLuigiWork",
+    "Actor_UpdatePos",
+    "CylinderClsn_Clear",
+    "CylinderClsn_Update",
+    "Enemy_UpdateWMClsn",
+    "Player_Hurt",
+    "WithMeshClsn_IsOnGround"
+   ]
+  },
+  "ov081:0x02123ed0": {
+   "name": "_ZN9Spindrift13InitResourcesEv",
+   "missing": [
+    "AnimLoadFile",
+    "ModelLoadFile",
+    "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+    "_ZN18MovingCylinderClsn4InitEP5Actoriijj",
+    "_ZN9ModelAnim7SetAnimEP8BCA_Fileiij"
+   ]
+  },
+  "ov081:0x021243cc": {
+   "name": "func_ov081_021243cc",
+   "missing": [
+    "func_020ada40",
+    "func_020aea30"
+   ]
+  },
+  "ov081:0x02125ba0": {
+   "name": "_ZN10MrBlizzard13InitResourcesEv",
+   "missing": [
+    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvS_iiS_i",
+    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_PKviijj"
+   ]
+  },
+  "ov084:0x02129a00": {
+   "name": "func_ov084_02129a00",
+   "missing": [
+    "func_020aea30"
+   ]
+  },
+  "ov084:0x02129ed4": {
+   "name": "func_ov084_02129ed4",
+   "missing": [
+    "func_020ada40",
+    "func_020aea30"
+   ]
+  },
+  "ov084:0x0212a774": {
+   "name": "func_ov084_0212a774",
+   "missing": [
+    "func_020aea30"
+   ]
+  },
+  "ov085:0x02129f8c": {
+   "name": "func_ov085_02129f8c",
+   "missing": [
+    "normalize"
+   ]
+  },
+  "ov085:0x0212a588": {
+   "name": "_ZN13PrincessPeach13InitResourcesEv",
+   "missing": [
+    "AnimLoadFile",
+    "ModelLoadFile",
+    "_ZN12WithMeshClsn4InitEP5ActoriiPvi",
+    "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
+   ]
+  },
+  "ov089:0x0213162c": {
+   "name": "func_ov089_0213162c",
+   "missing": [
+    "data_02111b68"
+   ]
+  },
+  "ov090:0x021310b4": {
+   "name": "func_ov090_021310b4",
+   "missing": [
+    "func_020ada40",
+    "func_020aea30"
+   ]
+  },
+  "ov090:0x02131f88": {
+   "name": "_ZN7Skeeter8BehaviorEv",
+   "missing": [
+    "func_020aea30"
+   ]
+  },
+  "ov090:0x02133530": {
+   "name": "_ZN10CheepCheep13InitResourcesEv",
+   "missing": [
+    "_Z43_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEjPvP8BCA_Fileiij",
+    "_Z58_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_PvP5ActoriiP10Vector3_16i",
+    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvP5ActorRK7Vector3iijj"
+   ]
+  },
+  "ov091:0x02132108": {
+   "name": "_ZN22RotatingUpDownPlatform8BehaviorEv",
+   "missing": [
+    "ApproachLinearI",
+    "UpdatePosWithVelocitySym",
+    "_ZN8Platform13IsClsnInRangeEii"
+   ]
+  },
+  "ov091:0x0213220c": {
+   "name": "_ZN22RotatingUpDownPlatform13InitResourcesEv",
+   "missing": [
+    "Vec3_equal",
+    "_Z13func_020393c4PvS_",
+    "_Z13func_020393d4PvS_",
+    "_Z20_ZN7PathPtr6FromIDEjPvj",
+    "_Z31_ZNK7PathPtr7GetNodeER7Vector3jPvS_j",
+    "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
+    "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
+    "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
+    "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
+    "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
+   ]
+  },
+  "ov091:0x021339fc": {
+   "name": "func_ov091_021339fc",
+   "missing": [
+    "func_020aea30"
+   ]
+  },
+  "ov096:0x02137564": {
+   "name": "_ZN7Tornado13InitResourcesEv",
+   "missing": [
+    "func_02112968"
+   ]
+  },
+  "ov098:0x021390ec": {
+   "name": "func_ov098_021390ec",
+   "missing": [
+    "_Z19func_ov002_020ef228Pvi",
+    "_ZN5Actor12ReflectAngleEiis"
+   ]
+  },
+  "ov100:0x0214109c": {
+   "name": "func_ov100_0214109c",
+   "missing": [
+    "ActorBase_MarkForDestruction"
+   ]
+  },
+  "ov100:0x02141fb0": {
+   "name": "func_ov100_02141fb0",
+   "missing": [
+    "func_020ada40"
+   ]
+  },
+  "ov100:0x0214272c": {
+   "name": "func_ov100_0214272c",
+   "missing": [
+    "func_020ad660"
+   ]
+  },
+  "ov100:0x02142918": {
+   "name": "func_ov100_02142918",
+   "missing": [
+    "func_020ad660"
+   ]
+  },
+  "ov100:0x021442dc": {
+   "name": "UnchainedChomp_Spawn",
+   "missing": [
+    "func_020aed98"
+   ]
+  },
+  "ov100:0x02145080": {
+   "name": "func_ov100_02145080",
+   "missing": [
+    "func_020ca78c"
+   ]
+  },
+  "ov100:0x02147054": {
+   "name": "func_ov100_02147054",
+   "missing": [
+    "G0",
+    "G1",
+    "G2"
+   ]
+  },
+  "ov100:0x021470f4": {
+   "name": "func_ov100_021470f4",
+   "missing": [
+    "_Z16DecIfAbove0_BytePh",
+    "_Z9Vec3_DistPK7Vector3S1_",
+    "_ZN16MeshColliderBase6EnableEPv",
+    "_ZN9Platform219UpdateClsnPosAndRotEv",
+    "_ZN9Platform313IsClsnInRangeEii"
+   ]
+  },
+  "ov100:0x021471e0": {
+   "name": "func_ov100_021471e0",
+   "missing": [
+    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+    "func_020efaf0"
+   ]
+  },
+  "ov102:0x02148c94": {
+   "name": "_ZN13FortressTower13InitResourcesEv",
+   "missing": [
+    "MeshCollider_LoadFile",
+    "ModelBase_SetFile",
+    "Model_LoadFile",
+    "MovingMeshCollider_SetFile",
+    "Platform_UpdateClsnPosAndRot",
+    "Platform_UpdateModelPosAndRotY"
+   ]
+  },
+  "ov102:0x0214c1bc": {
+   "name": "_ZN6BobOmb8BehaviorEv",
+   "missing": [
+    "func_020ada40"
+   ]
+  },
+  "ov102:0x0214cbec": {
+   "name": "func_ov102_0214cbec",
+   "missing": [
+    "func_020ada40"
+   ]
+  }
  }
 }

--- a/tools/check_references.py
+++ b/tools/check_references.py
@@ -27,9 +27,11 @@ do not remove the hole that admits them. This closes the hole.
 each file's unresolved symbols. This reads that report and compares it to
 `config/unresolved-baseline.json`.
 
-The key is the **function symbol**, never the file path. This project moves files
-between directories and keys contributor lineage on those moves; a path key would
-report every move as a regression and then refuse to let `--update` fix it.
+The key is **(module, ROM address)**, never the symbol or file path. Both are mutable:
+readability work renames `func_ov006_020e3578` to a real mangled method and source
+files move between directories. The module is required because overlays reuse RAM
+addresses. The eligibility report carries this identity directly; legacy baselines
+keyed by symbol are resolved through the symbol tables from the same git revision.
 
 The comparison is **per symbol's full missing-name list**, not a set of keys. An
 earlier version compared only which functions appeared, plus a global set of names,
@@ -57,6 +59,7 @@ Usage:
 import argparse
 import json
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -66,10 +69,79 @@ sys.path.insert(0, str(REPO / "tools"))
 import eligible as E  # noqa: E402
 
 BASELINE = REPO / "config" / "unresolved-baseline.json"
+SYMBOL_RE = re.compile(r"^(\S+)\s+kind:function\([^)]*\).*\baddr:0x([0-9a-fA-F]+)")
 
 
-def current(path, require_fresh=True):
-    """{symbol: [missing names]} plus the eligible count, from the report."""
+def make_id(module, addr):
+    addr = int(addr, 0) if isinstance(addr, str) else addr
+    return f"{module}:0x{addr:08x}"
+
+
+def _module_from_symbols_path(path):
+    parts = pathlib.PurePosixPath(path).parts
+    if parts[-1] != "symbols.txt" or "config" not in parts:
+        return None
+    rel = parts[parts.index("config") + 1:-1]
+    if rel == ("arm9",):
+        return "arm9"
+    if len(rel) == 2 and rel[0] == "arm9":
+        return rel[1]                 # itcm / dtcm
+    if len(rel) == 3 and rel[:2] == ("arm9", "overlays"):
+        return rel[2]                 # ovNNN
+    return "/".join(rel) if rel else None
+
+
+def symbol_identities(ref=None):
+    """Unique function symbol -> module:address, optionally from a git revision."""
+    if ref:
+        listing = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", ref, "--", "config"],
+            cwd=REPO, capture_output=True, text=True,
+        )
+        paths = [p for p in listing.stdout.splitlines() if p.endswith("/symbols.txt")]
+
+        def read(path):
+            out = subprocess.run(["git", "show", f"{ref}:{path}"], cwd=REPO,
+                                 capture_output=True, text=True)
+            return out.stdout if out.returncode == 0 else ""
+    else:
+        paths = [p.relative_to(REPO).as_posix()
+                 for p in sorted((REPO / "config").rglob("symbols.txt"))]
+
+        def read(path):
+            return (REPO / path).read_text(encoding="utf-8", errors="ignore")
+
+    found = {}
+    for path in paths:
+        module = _module_from_symbols_path(path)
+        if not module:
+            continue
+        for line in read(path).splitlines():
+            m = SYMBOL_RE.match(line)
+            if m:
+                found.setdefault(m.group(1), set()).add(make_id(module, int(m.group(2), 16)))
+    return {name: next(iter(ids)) for name, ids in found.items() if len(ids) == 1}
+
+
+def normalise_baseline(data, symbols):
+    """Read both legacy name keys and the address-keyed baseline written today."""
+    unresolved, names = {}, {}
+    for key, value in data.get("unresolved", {}).items():
+        if isinstance(value, list):
+            name, missing = key, value
+            identity = symbols.get(name, f"name:{name}")  # unresolved stays fail-closed
+        else:
+            identity = key
+            name = value.get("name", key)
+            missing = value.get("missing", [])
+        unresolved[identity] = sorted(set(missing))
+        names[identity] = name
+    return {"eligible": data.get("eligible", 0), "unresolved": unresolved,
+            "names": names}
+
+
+def current(path, require_fresh=True, symbols=None):
+    """Address-keyed unresolved/reason maps plus names and the eligible count."""
     try:
         entries, commit, dirty = E.load_report(path)
     except FileNotFoundError:
@@ -86,29 +158,39 @@ def current(path, require_fresh=True):
         if dirty:
             sys.exit("report was produced from a dirty tree -- commit or stash, then "
                      "re-run tools/eligible.py")
-    unresolved, eligible, reasons = {}, 0, {}
+    symbols = symbols or symbol_identities()
+    unresolved, eligible, reasons, names = {}, 0, {}, {}
     for r in entries:
+        identity = (make_id(r["module"], r["addr"])
+                    if r.get("module") and r.get("addr") else symbols.get(r["name"]))
+        if identity is None:
+            identity = f"name:{r['name']}"  # legacy report with no resolvable symbol
         reason = r.get("reason")
-        reasons[r["name"]] = reason
+        reasons[identity] = reason
+        names[identity] = r["name"]
         if reason is None:
             eligible += 1
         elif reason.startswith("unresolvable"):
-            unresolved[r["name"]] = sorted(set(r.get("missing") or []))
-    return unresolved, eligible, reasons
+            unresolved[identity] = sorted(set(r.get("missing") or []))
+    return unresolved, eligible, reasons, names
 
 
 def load_baseline(ref=None):
     if ref:
         out = subprocess.run(["git", "show", f"{ref}:{BASELINE.relative_to(REPO).as_posix()}"],
                              cwd=REPO, capture_output=True, text=True)
-        return json.loads(out.stdout) if out.returncode == 0 else None
-    return json.loads(BASELINE.read_text(encoding="utf-8")) if BASELINE.is_file() else None
+        raw = json.loads(out.stdout) if out.returncode == 0 else None
+    else:
+        raw = json.loads(BASELINE.read_text(encoding="utf-8")) if BASELINE.is_file() else None
+    return normalise_baseline(raw, symbol_identities(ref)) if raw is not None else None
 
 
-def write_baseline(unresolved, eligible):
+def write_baseline(unresolved, eligible, names):
     BASELINE.parent.mkdir(parents=True, exist_ok=True)
+    rows = {identity: {"name": names.get(identity, identity), "missing": missing}
+            for identity, missing in sorted(unresolved.items())}
     BASELINE.write_text(json.dumps(
-        {"eligible": eligible, "unresolved": dict(sorted(unresolved.items()))},
+        {"eligible": eligible, "unresolved": rows},
         indent=1) + "\n", encoding="utf-8")
 
 
@@ -126,6 +208,21 @@ def worse(cur, base):
     return out
 
 
+def changes(cur, reasons, base):
+    """(bad references, disguised regressions, genuine fixes), all address-keyed."""
+    bad = worse(cur, base["unresolved"])
+    left = set(base["unresolved"]) - set(cur)
+    disguised = sorted(identity for identity in left
+                        if reasons.get(identity, "gone") is not None)
+    fixed = sorted(identity for identity in left
+                   if reasons.get(identity, "gone") is None)
+    return bad, disguised, fixed
+
+
+def display_name(identity, current_names, base_names):
+    return current_names.get(identity) or base_names.get(identity) or identity
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -137,41 +234,38 @@ def main():
                     help="skip the commit-stamp check (for local iteration only)")
     args = ap.parse_args()
 
-    cur, eligible, reasons = current(args.report, require_fresh=not args.allow_stale)
+    cur, eligible, reasons, names = current(
+        args.report, require_fresh=not args.allow_stale)
     base = load_baseline(args.against)
 
     if args.update:
         if base is not None:
-            bad = worse(cur, base["unresolved"])
-            regressed = [s for s in set(base["unresolved"]) - set(cur)
-                         if reasons.get(s, "gone") is not None]
+            bad, regressed, _fixed = changes(cur, reasons, base)
             if regressed:
                 print("refusing to update: symbols left the backlog by failing differently")
-                for s in regressed[:10]:
-                    print(f"  {s} -> {reasons.get(s, 'no longer a candidate')}")
+                for identity in regressed[:10]:
+                    label = display_name(identity, names, base["names"])
+                    print(f"  {label} ({identity}) -> "
+                          f"{reasons.get(identity, 'no longer a candidate')}")
                 return 1
             if bad or eligible < base.get("eligible", 0):
                 print("refusing to update: this would raise the baseline, not lower it")
-                for sym, names, why in bad[:10]:
-                    print(f"  {why}: {sym}  ({', '.join(names[:3])})")
+                for identity, missing, why in bad[:10]:
+                    label = display_name(identity, names, base["names"])
+                    print(f"  {why}: {label} ({identity})  "
+                          f"({', '.join(missing[:3])})")
                 if eligible < base.get("eligible", 0):
                     print(f"  eligible fell {base['eligible']} -> {eligible}")
                 return 1
-        write_baseline(cur, eligible)
+        write_baseline(cur, eligible, names)
         print(f"baseline: {len(cur)} unresolved symbols, {eligible} eligible")
         return 0
 
     if base is None:
         sys.exit(f"no baseline at {BASELINE}\nCreate one with --update.")
 
-    bad = worse(cur, base["unresolved"])
+    bad, disguised, fixed = changes(cur, reasons, base)
     lost = base.get("eligible", 0) - eligible
-    left = set(base["unresolved"]) - set(cur)
-    # Leaving the unresolved set is only progress if the symbol became eligible. A
-    # file that degrades from `unresolvable` to `compile failed` also leaves it, and
-    # would otherwise read as a fix -- trading one failure for a worse one.
-    disguised = sorted(s for s in left if reasons.get(s, "gone") is not None)
-    fixed = sorted(s for s in left if reasons.get(s, "gone") is None)
 
     print(f"unresolved symbols: {len(cur)}  (baseline {len(base['unresolved'])})")
     print(f"eligible:           {eligible}  (baseline {base.get('eligible', 0)})")
@@ -181,8 +275,10 @@ def main():
     if disguised:
         print(f"\n  {len(disguised)} symbols left the unresolved set without becoming")
         print("  eligible -- they now fail for another reason, which is not a fix:")
-        for s in disguised[:10]:
-            print(f"      {s}  ->  {reasons.get(s, 'no longer a candidate')}")
+        for identity in disguised[:10]:
+            label = display_name(identity, names, base["names"])
+            print(f"      {label} ({identity})  ->  "
+                  f"{reasons.get(identity, 'no longer a candidate')}")
     if not bad and lost <= 0 and not disguised:
         print("OK: no new unresolvable references")
         return 0
@@ -190,8 +286,9 @@ def main():
     print("\nFAIL: this change adds references that resolve to nothing.")
     print("They would pass the byte gate regardless, because match.py compares")
     print("relocated words as wildcards and never looks at what a call targets.\n")
-    for sym, names, why in bad[:25]:
-        print(f"  {why}: {sym}\n      {', '.join(names[:4])}")
+    for identity, missing, why in bad[:25]:
+        label = display_name(identity, names, base["names"])
+        print(f"  {why}: {label} ({identity})\n      {', '.join(missing[:4])}")
     if len(bad) > 25:
         print(f"  ... and {len(bad) - 25} more")
     if lost > 0:

--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -64,6 +64,19 @@ ANYSYM = re.compile(r"^(\S+)\s+kind:")
 IGNORE_SECTIONS = (".comment", ".debug", ".line", ".note")
 
 
+def module_label(module_dir):
+    """Stable public module label for an enroll.candidates() config directory."""
+    rel = pathlib.Path(module_dir).relative_to(CONFIG)
+    parts = rel.parts
+    if parts == ("arm9",):
+        return "arm9"
+    if len(parts) == 2 and parts[0] == "arm9":
+        return parts[1]              # itcm / dtcm
+    if len(parts) == 3 and parts[:2] == ("arm9", "overlays"):
+        return parts[2]              # ovNNN
+    return "/".join(parts)
+
+
 def load_report(path=None):
     """The eligibility report, as (entries, commit, dirty).
 
@@ -228,13 +241,20 @@ def main():
     jobs = [(rel, name, addr, size, sec, known, BP.version_for(rel, name) or VERSION,
              not args.no_isolate)
             for (_d, name, rel, addr, size, sec) in cands]
+    # Do not key this by symbol alone. Overlays occupy the same address window and
+    # may legitimately repeat a symbol spelling; the enrolled source path is the
+    # disambiguator already carried through classify().
+    identities = {(rel, name): (module_label(d), addr)
+                  for (d, name, rel, addr, _size, _sec) in cands}
     print(f"classifying {len(jobs)} enrolled functions with -j{args.jobs} ...")
 
     results, reasons = [], collections.Counter()
     done = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
         for rel, name, reason, missing in ex.map(classify, jobs):
-            results.append({"file": rel, "name": name, "reason": reason,
+            module, addr = identities[(rel, name)]
+            results.append({"file": rel, "name": name, "module": module,
+                            "addr": f"0x{addr:08x}", "reason": reason,
                             "missing": missing})
             reasons["ELIGIBLE" if reason is None else reason.split(":")[0]] += 1
             done += 1

--- a/tools/test_check_references.py
+++ b/tools/test_check_references.py
@@ -1,0 +1,125 @@
+"""Regression tests for address-keyed unresolved-reference tracking."""
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_references as C  # noqa: E402
+
+
+class AddressIdentityTests(unittest.TestCase):
+    def _current(self, rows):
+        with tempfile.TemporaryDirectory() as td:
+            report = pathlib.Path(td) / "report.json"
+            report.write_text(json.dumps(rows), encoding="utf-8")
+            return C.current(report, require_fresh=False, symbols={})
+
+    def test_unresolved_symbol_rename_to_eligible_is_a_fix(self):
+        identity = "ov006:0x020e3578"
+        base = C.normalise_baseline(
+            {"eligible": 10, "unresolved": {"func_ov006_020e3578": ["old_ref"]}},
+            {"func_ov006_020e3578": identity},
+        )
+        cur, eligible, reasons, _names = self._current([{
+            "name": "_ZN14dScMgCurling_c13InitResourcesEv",
+            "module": "ov006", "addr": "0x020e3578",
+            "reason": None, "missing": [],
+        }])
+
+        bad, disguised, fixed = C.changes(cur, reasons, base)
+        self.assertEqual((bad, disguised, fixed), ([], [], [identity]))
+        self.assertEqual(eligible, 1)
+
+    def test_same_address_compile_failure_is_still_disguised_regression(self):
+        identity = "ov006:0x020e3578"
+        base = C.normalise_baseline(
+            {"eligible": 10, "unresolved": {"old": ["old_ref"]}},
+            {"old": identity},
+        )
+        cur, _eligible, reasons, _names = self._current([{
+            "name": "new", "module": "ov006", "addr": "0x020e3578",
+            "reason": "compile failed", "missing": [],
+        }])
+
+        bad, disguised, fixed = C.changes(cur, reasons, base)
+        self.assertEqual((bad, disguised, fixed), ([], [identity], []))
+
+    def test_renamed_function_cannot_add_an_unresolved_reference(self):
+        identity = "ov006:0x020e3578"
+        base = C.normalise_baseline(
+            {"eligible": 10, "unresolved": {"old": ["old_ref"]}},
+            {"old": identity},
+        )
+        cur, _eligible, reasons, _names = self._current([{
+            "name": "new", "module": "ov006", "addr": "0x020e3578",
+            "reason": "unresolvable: old_ref,new_ref",
+            "missing": ["old_ref", "new_ref"],
+        }])
+
+        bad, disguised, fixed = C.changes(cur, reasons, base)
+        self.assertEqual(bad, [(identity, ["new_ref"], "new unresolved reference")])
+        self.assertEqual((disguised, fixed), ([], []))
+
+    def test_overlays_with_the_same_ram_address_are_distinct(self):
+        old_identity = "ov006:0x020e3578"
+        base = C.normalise_baseline(
+            {"eligible": 10, "unresolved": {"old": ["old_ref"]}},
+            {"old": old_identity},
+        )
+        cur, _eligible, reasons, _names = self._current([{
+            "name": "new", "module": "ov007", "addr": "0x020e3578",
+            "reason": None, "missing": [],
+        }])
+
+        _bad, disguised, fixed = C.changes(cur, reasons, base)
+        self.assertEqual(disguised, [old_identity])
+        self.assertEqual(fixed, [])
+
+    def test_new_baseline_schema_keeps_name_as_display_metadata(self):
+        identity = "ov006:0x020e3578"
+        base = C.normalise_baseline({
+            "eligible": 10,
+            "unresolved": {
+                identity: {"name": "old", "missing": ["b", "a", "a"]},
+            },
+        }, {})
+        self.assertEqual(base["unresolved"], {identity: ["a", "b"]})
+        self.assertEqual(base["names"], {identity: "old"})
+
+    def test_symbol_identity_can_be_resolved_from_the_baseline_revision(self):
+        old_repo = C.REPO
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                repo = pathlib.Path(td)
+                symbols = repo / "config/arm9/overlays/ov006/symbols.txt"
+                symbols.parent.mkdir(parents=True)
+                subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+                subprocess.run(["git", "config", "user.email", "test@example.com"],
+                               cwd=repo, check=True)
+                subprocess.run(["git", "config", "user.name", "Test"],
+                               cwd=repo, check=True)
+                symbols.write_text(
+                    "old kind:function(arm,size=0x4) addr:0x020e3578\n",
+                    encoding="utf-8")
+                subprocess.run(["git", "add", "config"], cwd=repo, check=True)
+                subprocess.run(["git", "commit", "-qm", "old name"],
+                               cwd=repo, check=True)
+                symbols.write_text(
+                    "new kind:function(arm,size=0x4) addr:0x020e3578\n",
+                    encoding="utf-8")
+                subprocess.run(["git", "commit", "-qam", "new name"],
+                               cwd=repo, check=True)
+
+                C.REPO = repo
+                identity = "ov006:0x020e3578"
+                self.assertEqual(C.symbol_identities("HEAD~1")["old"], identity)
+                self.assertEqual(C.symbol_identities()["new"], identity)
+        finally:
+            C.REPO = old_repo
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Record each eligibility result with its module and ROM address.
- Key the unresolved-reference baseline by `(module, address)` while retaining symbol names as display metadata.
- Read legacy name-keyed baselines through the symbol tables from the same Git revision.
- Add regression coverage for readable-C++ renames, compile-failure regressions, and overlays that reuse RAM addresses.

## Why

The previous gate used mutable symbol names as identity. Renaming an unresolved placeholder such as `func_ov006_020e3578` to `_ZN14dScMgCurling_c13InitResourcesEv` made the old entry appear to disappear, so the gate reported a disguised regression even when the same function at the same ROM address became eligible. Module plus address is stable across readability renames, and the module keeps overlapping overlay address spaces distinct.

## Validation

- `python -m unittest tools.test_check_references tools.test_rombuild tools.test_rombuild_check tools.test_rombuild_profile tools.test_demember_calls` — 24 tests passed.
- `python tools/eligible.py` — 11,162 classified; 10,805 eligible; 241 unresolved.
- `python tools/check_references.py` — no new unresolvable references.
- Pre-push checks — unresolved references, duplicate sources, and 393 `port/` references all passed.
