### PR TITLE
Player::~Player() is a real destructor: __destroy_arr IS __cxa_vec_cleanup

### DIFF
--- a/config/arm9/symbols.txt
+++ b/config/arm9/symbols.txt
@@ -3048,6 +3048,7 @@ func_0207322c kind:function(arm,size=0xc) addr:0x0207322c
 func_02073238 kind:function(arm,size=0xc) addr:0x02073238
 func_02073244 kind:function(arm,size=0x48) addr:0x02073244
 __destroy_arr kind:function(arm,size=0x5c) addr:0x0207328c
+__cxa_vec_cleanup kind:function(arm,size=0x0) addr:0x0207328c
 func_020732e8 kind:function(arm,size=0x18) addr:0x020732e8
 func_02073300 kind:function(arm,size=0x5c) addr:0x02073300
 func_0207335c kind:function(arm,size=0x4c) addr:0x0207335c

--- a/src/_ZN6PlayerD1Ev.cpp
+++ b/src/_ZN6PlayerD1Ev.cpp
@@ -1,60 +1,35 @@
 //cpp
 // @symbol _ZN6PlayerD1Ev
-/* A REAL `Player::~Player() {}` DOES NOT REPRODUCE THIS FUNCTION, and the way
- * it fails is worth more than the attempt. It is a FAKEMATCH: byte-comparison
- * reports 39 words, 0 mismatches, and the two functions still call different
- * code.
+/* recovered: real C++ destructor -- the compiler emits the whole body
  *
- * The compiler-generated destructor is right about everything structural. All
- * nine destructible members now have real types (see include/Player.h), so it
- * emits the whole sequence by itself, in reverse declaration order, with an
- * empty body -- the same instruction encodings, the same registers, the same
- * three array calls with the 0x14 stride.
+ * This file was the tree's longest-standing structor blocker, and nothing was
+ * ever wrong with the source. The hand-written version had to spell out the
+ * vtable store, nine member destructor calls and three array cleanups, because
+ * it could not be compiled from a declaration: the compiler emits
+ * `__cxa_vec_cleanup` for an array member, and the ROM's runtime helper at
+ * 0x0207328c was recorded under the invented name `__destroy_arr`.
  *
- * But it calls __cxa_vec_cleanup where the ROM calls __destroy_arr. Three times
- * each, and zero the other way; read off the compiled object's own relocation
- * table, not guessed. The ROM was built against a runtime whose array-cleanup
- * helper is __destroy_arr (0x0207328c); this compiler configuration emits the
- * Itanium ABI's __cxa_vec_cleanup, which exists nowhere in the ROM.
+ * Those are the same function. 0x0207328c disassembles to the Itanium
+ * `__cxa_vec_cleanup` contract exactly -- null-destructor guard, count==0
+ * early-out, then a BACKWARDS walk from count-1 calling dtor(base + i*size) --
+ * and it reproduces byte-exactly from the libsupc++ source text at this file's
+ * own pin, 2004/b56. Its catch island at 0x020732e8 is part of the same
+ * function, its 20-byte exception descriptor appears verbatim in the ROM, and
+ * its neighbour at 0x02073300 is `__cxa_vec_dtor` -- the other half of the ABI
+ * pair, differing by exactly what the ABI says separates them.
  *
- * WHY THE BYTE CHECK MISSED IT: those three calls are `bl` instructions, so
- * they are relocated words, and match.compare wildcards every relocated word.
- * tools/fdiff.py and tools/build_pin.py both said match=True. Only the link
- * would have caught it -- and the file was never enrolled, so the link never
- * ran. eligible.py DID catch it, from the other direction, by refusing a file
- * that references a symbol no symbols.txt defines. That refusal was correct and
- * is not an objisolate defect; isolation already drops dropped sections'
- * relocation sections, and this reference is in D1's OWN .text.
+ * `__destroy_arr` was a bulk rename with no recorded evidence. It described
+ * the role correctly and named the function wrongly. config/arm9/symbols.txt
+ * now carries `__cxa_vec_cleanup` as a size-0 alias at the same address, the
+ * mechanism this tree already uses for five ITCM runtime helpers: a relocation
+ * needs a symbol's address, never its size, and the gap object holding this
+ * address has exactly zero slack, so 0x0 is the only size that can link.
  *
- * SO THE STRUCTOR BLOCKER IS A RUNTIME-HELPER MISMATCH, and it is specific to
- * classes with ARRAY members -- which is why objisolate's 69 destructors, none
- * of which have any, were unaffected. Player has three. Until something
- * reconciles __destroy_arr with __cxa_vec_cleanup, this file stays the
- * hand-spelt free function it has always been.
+ * The reverse-order member destruction below is not written anywhere any more.
+ * It is Player.h's declaration order, read backwards by the compiler.
  */
 #include "Player.h"
-extern "C" {
-extern int _ZN12WithMeshClsnD1Ev(void*);
-extern int _ZN25MovingCylinderClsnWithPosD1Ev(void*);
-extern int _ZN11ShadowModelD1Ev(void*);
-extern int __destroy_arr(void*, int, int, void*);
-extern int _ZN9ModelAnimD1Ev(void*);
-extern int _ZN5ActorD2Ev(void*);
-extern void _ZN15TextureSequenceD1Ev(void);
-extern void _ZN15MaterialChangerD1Ev(void);
-extern void* data_ov002_0210a83c[];
-void* _ZN6PlayerD1Ev(struct Player *self) {
-  *(void***)((void*)self) = data_ov002_0210a83c;
-  _ZN12WithMeshClsnD1Ev((char*)&self->mMeshClsn);
-  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mAttackClsn);
-  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
-  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
-  __destroy_arr((char*)((void*)self)+0x254, 2, 0x14, (void*)_ZN15TextureSequenceD1Ev);
-  __destroy_arr((char*)((void*)self)+0x22c, 2, 0x14, (void*)_ZN15MaterialChangerD1Ev);
-  __destroy_arr((char*)((void*)self)+0x1dc, 4, 0x14, (void*)_ZN15TextureSequenceD1Ev);
-  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim4);
-  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim3);
-  _ZN5ActorD2Ev(((void*)self));
-  return ((void*)self);
-}
+
+Player::~Player()
+{
 }


### PR DESCRIPTION
The tree's longest-standing structor blocker. Nothing was ever wrong with the
source.

`Player::~Player()` could not be compiled from a declaration because mwcc emits
`__cxa_vec_cleanup` for an array member, while the ROM's runtime helper at
`0x0207328c` was recorded under the invented name `__destroy_arr`. **They are
the same function**, and this PR proves it rather than assuming it.

## Measured

- `0x0207328c` disassembles to the Itanium `__cxa_vec_cleanup` contract exactly:
  null-destructor guard, `count == 0` early-out, then a **backwards** walk from
  `count-1` calling `dtor(base + i*size)`. All 23 instructions accounted for.
- It **reproduces byte-exactly from the libsupc++ source text** at this file's
  own pin, 2004/b56 — 29 of 29 words. The only two differing words are
  relocations naming `_ZSt9terminatev` and `__end__catch`, whose ROM targets
  were identified independently from their own disassembly.
- The 20-byte exception descriptor the probe emits appears **verbatim** in the
  ROM's `.exception` section at `0x0207372c`.
- `func_020732e8` is not a separate function — it is the same function's catch
  island: same `fp`, same `0x18` frame, same register set.
- The neighbour at `0x02073300` is `__cxa_vec_dtor`, also reproduced
  byte-exactly, differing by precisely what the ABI says separates the pair
  (terminate-on-throw vs destroy-remaining-and-rethrow). The ROM carries both
  halves, adjacent.

`__destroy_arr` entered in #899 as a bulk readable-rename from `func_0207328c`,
with no recorded evidence. It described the role correctly and named the
function wrongly.

## The alias, and why size 0

`config/arm9/symbols.txt` gains `__cxa_vec_cleanup` as a **size-0** alias at the
same address. This is the mechanism the tree already uses for five ITCM runtime
helpers — `_dadd`, `_dmul`, `_ll_sdiv`, `_s32_div_f`, `_u32_div_f` — and commit
`c1916f76` diagnoses this exact failure: *relocations need a symbol's address,
never its size*.

An earlier attempt used `size=0x5c` and `mwldarm` rejected it. The reason is
now measured: the gap object holding this address has `0x310` of section and
`0x310` of symbols — **exactly zero slack** — so it overflowed by exactly
`0x5c`, and `0x0` is the only size that can link here.

## Why this is not a fakematch

This function produced one before. A byte check wildcards relocated words, so a
`bl` to the *wrong* helper still compares equal — which is how the previous
attempt reported `39 words, 0 mismatches` while calling `__cxa_vec_cleanup`
where the ROM called `__destroy_arr`.

All three decisive gates agree this time:

| gate | result |
|---|---|
| `rombuild` (it links, so it checks relocation targets) | **106/106 exact**, 0 mismatching, 10,805 source-built, 87.82% |
| `eligible.py` (refuses undefined references) | accepts `_ZN6PlayerD1Ev` |
| the object's own relocation table | `3 × __cxa_vec_cleanup`, `_ZTV6Player`, `_ZN5ActorD2Ev`, seven member destructors — **13 relocations, matching the ROM's 13 relocated words** |

## Everything else

`Player.h` needed **no change**: it already carried `struct Player : Actor`, the
real member types, the three arrays at `0x1dc`/`0x22c`/`0x254`, and
`virtual ~Player()`. The reverse-order member destruction is no longer written
anywhere — it is the header's declaration order, read backwards by the compiler.

D1 migrated count **72 → 73**.

| gate | result |
|---|---|
| `build_pin.verify` | green under 2004/b56 |
| langmode ratchet | PASS |
| `check_duplicate_sources` | 11281 stems, none doubled |
| `check_data_definitions` | 10984 objects, none define a ROM data symbol |
| `port_refcheck` | 393 references, all resolve |
| `check_references` | OK, no new unresolvable references |
| `prepush_attribution` | 0 changed, 0 lost |

No `--no-verify`.

**Not claimed here:** that this unblocks Player's `C1`, `C3` or `D0`. Those
remain unmigrated and are unproven tree-wide for reasons beyond this helper —
0 of 41 `C1`, 0 of 2 `C3`, 3 of 258 `D0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EHyA1D2dEEZeAuP8BezVS