### PR TITLE
Fix 9 cross-overlay symbol mislabels, and stop ovsweep counting comments

### DIFF
--- a/src/FallBlockWf_Spawn.c
+++ b/src/FallBlockWf_Spawn.c
@@ -1,13 +1,13 @@
 extern void *_ZN9ActorBasenwEj(unsigned);
 extern void _ZN8PlatformC2Ev(void *);
-extern int data_ov006_0213c5bc[];
+extern int data_ov098_0213c5bc[];
 extern int _ZTV11FallBlockWf[];
 int *FallBlockWf_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(844);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)data_ov006_0213c5bc;
+        p[0] = (int)data_ov098_0213c5bc;
         p[0] = (int)_ZTV11FallBlockWf;
     }
     return p;

--- a/src/_ZN10ChainChompD0Ev.cpp
+++ b/src/_ZN10ChainChompD0Ev.cpp
@@ -5,18 +5,19 @@
 #include "decl_ModelAnim.h"
 #include "decl_ShadowModel.h"
 #include "decl_common.h"
-/* recovered: named members + shared header */
+/* recovered: named members + shared header, vtable identified */
+/* resolved: VT0 = _ZTV10ChainChomp */
 #include "ChainChomp.h"
 extern "C" {
 extern int __destroy_arr(void *p, int a, int b, void *fn);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *p);
 extern int _ZN5EnemyD2Ev(int *x);
-extern int data_ov034_021147ec[];
+extern int _ZTV10ChainChomp[];
 extern int func_020072c0(void);
 extern int data_020a0eac;
 
 void *_ZN10ChainChompD0Ev(struct ChainChomp *self) {
-    *(int**)((char *)self) = data_ov034_021147ec;
+    *(int**)((char *)self) = _ZTV10ChainChomp;
     __destroy_arr(((char *)self) + 0x578, 7, 0xc, (void*)func_020072c0);
     __destroy_arr(((char *)self) + 0x524, 7, 0xc, (void*)func_020072c0);
     __destroy_arr(((char *)self) + 0x40c, 7, 0x28, (void*)_ZN11ShadowModelD1Ev);

--- a/src/_ZN10ChainChompD1Ev.c
+++ b/src/_ZN10ChainChompD1Ev.c
@@ -3,16 +3,17 @@
 #include "decl_Model.h"
 #include "decl_ModelAnim.h"
 #include "decl_ShadowModel.h"
-/* recovered: named members + shared header */
+/* recovered: named members + shared header, vtable identified */
+/* resolved: VT0 = _ZTV10ChainChomp */
 #include "ChainChomp.h"
 extern int __destroy_arr(void *arr, int n, int sz, void *dtor);
 extern void func_020072c0(void);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *p);
 extern int _ZN5EnemyD2Ev(int *x);
-extern void *data_ov034_021147ec[];
+extern int _ZTV10ChainChomp[];
 
 void *_ZN10ChainChompD1Ev(struct ChainChomp *self) {
-    *(void**)((char *)self) = data_ov034_021147ec;
+    *(int**)((char *)self) = _ZTV10ChainChomp;
     __destroy_arr(((char *)self) + 0x578, 7, 0xc, (void*)func_020072c0);
     __destroy_arr(((char *)self) + 0x524, 7, 0xc, (void*)func_020072c0);
     __destroy_arr(((char *)self) + 0x40c, 7, 0x28, (void*)_ZN11ShadowModelD1Ev);

--- a/src/_ZN15ChainChompFence13InitResourcesEv.cpp
+++ b/src/_ZN15ChainChompFence13InitResourcesEv.cpp
@@ -12,16 +12,21 @@ extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
 }
-extern int data_ov021_021149b8[];
-extern int data_ov022_02114558[];
+/* These three live in ov014, this file's own overlay. They were named off ov021 and
+ * ov022, which share the same load window and so define their own symbols at the same
+ * addresses -- but never at the same time as ov014, so those names cannot be what this
+ * code reaches. Same address either way, so the bytes never noticed. */
+extern int data_ov014_021149b8[];
+extern int data_ov014_02114558[];
+extern int data_ov014_021149c0[];
 
 int ChainChompFence::InitResources()
 {
-  int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov021_021149c0);
+  int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov014_021149c0);
   _ZN9ModelBase7SetFileEP8BMD_Fileii((char*)((char*)this)+0xd4, m, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
   _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
-  int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov021_021149b8);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((char*)((char*)this)+0x124, k, (char*)((char*)this)+0x2ec, 0x1000, unk_08e, (void*)data_ov022_02114558);
+  int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov014_021149b8);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((char*)((char*)this)+0x124, k, (char*)((char*)this)+0x2ec, 0x1000, unk_08e, (void*)data_ov014_02114558);
   return 1;
 }

--- a/src/_ZN3HUD15RenderTimeTimerEv.cpp
+++ b/src/_ZN3HUD15RenderTimeTimerEv.cpp
@@ -17,7 +17,9 @@ extern struct OamAttr data_ov002_0210ce80;
 extern struct OamAttr _ZN3OAM4TIMEE;
 extern struct OamAttr _ZN3OAM7MINUTESE;
 extern struct OamAttr data_ov002_0210c6c0;
-extern struct OamAttr* data_ov000_020aba70[];
+/* ov001's OAM::NUMBERS, not ov000's -- ov000 shares this load window with ov002 and
+ * so can never be the module this reaches. Sits with OAM::TIME and OAM::MINUTES above. */
+extern struct OamAttr* _ZN3OAM7NUMBERSE[];
 
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int sub, struct OamAttr* attr, int x, int y, int a, int b, int sx, int sy, int c, int d);
 extern void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int sub, struct OamAttr* attr, int x, int y, int a, int b, void* m);
@@ -51,7 +53,7 @@ void HUD::RenderTimeTimer()
         } else {
             _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, &_ZN3OAM4TIMEE, 0xa4, 0x1e, -1, 1, 0x1000, 0x1000, 0, -1);
         }
-        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[min / 10], 0xb8, 0x16, -1, 1, 0);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[min / 10], 0xb8, 0x16, -1, 1, 0);
     } else {
         if (GetOwnerLanguage() == 5 || GetOwnerLanguage() == 4 || GetOwnerLanguage() == 2) {
             _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, &data_ov002_0210ce80, 0xac, 0x1e, -1, 1, 0x1000, 0x1000, 0, -1);
@@ -60,11 +62,11 @@ void HUD::RenderTimeTimer()
         }
     }
 
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[min % 10], 0xc0, 0x16, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[min % 10], 0xc0, 0x16, -1, 1, 0);
     _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM7MINUTESE, 0xc4, 0x1e, -1, 1, 0);
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[sec / 10], 0xcf, 0x16, -1, 1, 0);
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[sec % 10], 0xd7, 0x16, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[sec / 10], 0xcf, 0x16, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[sec % 10], 0xd7, 0x16, -1, 1, 0);
     _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &data_ov002_0210c6c0, 0xdb, 0x1e, -1, 1, 0);
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[centi / 10], 0xe8, 0x16, -1, 1, 0);
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[centi % 10], 0xf0, 0x16, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[centi / 10], 0xe8, 0x16, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[centi % 10], 0xf0, 0x16, -1, 1, 0);
 }

--- a/src/func_ov004_020b9280.c
+++ b/src/func_ov004_020b9280.c
@@ -1,6 +1,6 @@
 void func_ov004_020b9280(void* c){
   extern int data_ov004_020bca7c[];
-  extern int data_ov000_020ad494[];
+  extern int data_ov001_020ad494[];
   *(int*)c=(int)data_ov004_020bca7c;
-  *(int*)c=(int)data_ov000_020ad494;
+  *(int*)c=(int)data_ov001_020ad494;
 }

--- a/src/func_ov004_020b9430.c
+++ b/src/func_ov004_020b9430.c
@@ -1,6 +1,6 @@
 void func_ov004_020b9430(void* c){
-  extern int data_ov000_020ad494[];
+  extern int data_ov001_020ad494[];
   extern int data_ov004_020bca7c[];
-  *(int*)c=(int)data_ov000_020ad494;
+  *(int*)c=(int)data_ov001_020ad494;
   *(int*)c=(int)data_ov004_020bca7c;
 }

--- a/tools/ovsweep.py
+++ b/tools/ovsweep.py
@@ -88,6 +88,9 @@ import re
 import sys
 from collections import Counter
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import delaunder  # noqa: E402  -- for code_mask; comments are not references
+
 REPO = pathlib.Path(__file__).resolve().parent.parent
 CFG_OV = REPO / "config" / "arm9" / "overlays"
 SRC = REPO / "src"
@@ -397,7 +400,13 @@ def scan():
 
     for f, text in all_files_text:
         scanned += 1
-        refs = list(REF_RE.finditer(text))
+        # Comments and string literals are not references. A file that merely NAMES a
+        # sibling overlay's symbol in prose -- "see func_ov006_020d6084.cpp" -- reaches
+        # nothing at runtime, and reporting it as a mislabel sends a reviewer hunting a
+        # defect that is not there. Same mistake the langmode metric made by scanning
+        # source text rather than code.
+        keep = delaunder.code_mask(text)
+        refs = [m for m in REF_RE.finditer(text) if keep[m.start()]]
         if not refs:
             continue
         files_with_refs += 1


### PR DESCRIPTION
## What this changes

**This is the defect class no byte gate can catch.** Two overlays that share a load window are never resident together, but their address ranges overlap, so both symbol tables name something at the same address. Reference the wrong one and it links to the identical word — byte-identical forever, invisible to the wildcarded compare, to strict-relocs, and to `rombuild`'s zero-differing-bytes verdict. Only residency reasoning sees it.

```
ovsweep real candidates: 10 -> 0
```

## The flagship

`ChainChomp`'s own destructors stored a foreign overlay's **bss** symbol into their vptr slot:

```diff
  src/_ZN10ChainChompD1Ev.c
- *(void**)((char *)self) = data_ov034_021147ec;   // ov034 .bss, size 12
+ *(int**)((char *)self)  = _ZTV10ChainChomp;      // ov014 vtable, size 56
```

`ov014/symbols.txt:189` defines `_ZTV10ChainChomp` at exactly `0x021147ec` — the class's own vtable. Its sibling `ChainChomp_Spawn.cpp` **already spelled it correctly**, so the spawner named the class's vtable while its destructors named another overlay's bss. Same twin defect in `D0Ev.cpp`.

## Every replacement was chosen by co-residency, not resemblance

For each site the candidates are every overlay defining a symbol at that address; the answer is the one whose overlay *can* be loaded alongside the file's own, tested with ovsweep's own `conflict()`:

| file | own | was | now |
|---|---|---|---|
| `HUD::RenderTimeTimer` | ov002 | `data_ov000_020aba70` | `_ZN3OAM7NUMBERSE` (ov001) |
| `func_ov004_020b9280` | ov004 | `data_ov000_020ad494` | `data_ov001_020ad494` |
| `func_ov004_020b9430` | ov004 | `data_ov000_020ad494` | `data_ov001_020ad494` |
| `FallBlockWf_Spawn` | ov015 | `data_ov006_0213c5bc` | `data_ov098_0213c5bc` |
| `ChainChompFence::InitResources` ×3 | ov014 | ov021 / ov022 | `data_ov014_*` |

In each case **exactly one** candidate was co-resident, so nothing was guessed.

The `HUD` one corroborates independently: that function already declares `OAM::TIME` and `OAM::MINUTES`, and the mislabeled array is indexed per digit — `NUMBERS[min / 10]`, `NUMBERS[sec % 10]` — straight into `OAM::Render`. It is `OAM::NUMBERS` sitting between its two neighbours.

`ChainChompFence`'s three are declared locally rather than via `decl_common.h`. That shared header declares the ov021 spelling for the benefit of ov021-owned files; editing it would need an `eligible.py` bracket and put every other includer at risk, for no gain here.

## The tenth candidate was not a defect

`func_ov007_020c3d1c.cpp` "references" `func_ov006_020d6084` **in a comment** — `see func_ov006_020d6084.cpp` — and reaches nothing at runtime. `ovsweep` now masks comments and string literals via `delaunder.code_mask` before locating references. Same mistake the langmode metric made by scanning source *text* instead of code, and it costs a reviewer a hunt for a defect that is not there. Files with refs: 7083 → 7076.

## Verification

```
module fidelity: 106/106 exact, 100.000000% of compared bytes
source-built functions: 10,805    reproducing: 10,805    mismatching: 0
ROM-build analysis: PASS

eligible:           10805 / 11162   (baseline 10805, unchanged)
unresolved symbols: 241             (baseline 241)
check_references:   OK - no new unresolvable references

ovsweep scan: real candidates 0
```

Every touched function was also re-verified individually with `build_pin.verify(..., strict=...)` — bytes **and** relocation destinations — before and after.

Depends on `tools/delaunder.py` (#1355, merged).

Provenance: ai model=claude-opus-5 reasoning=high harness=claude-code