### PR TITLE
Remove launder sites the ROM does not need (1/5)

### DIFF
--- a/src/DMAStartTransfer.c
+++ b/src/DMAStartTransfer.c
@@ -30,8 +30,8 @@ extern void _ZN3IRQ7RestoreEj(u32 state);
 void DMAStartTransfer(u32 channel, u32 src, u32 dest, u32 ctrl)
 {
     u32 state = _ZN3IRQ7DisableEv();
-    DMAChannelRegs *reg = (DMAChannelRegs *)(((u32)REG_DMA_BASE +
-        channel * sizeof(DMAChannelRegs)) & 0xFFFFFFFFFFFFFFFFULL);
+    DMAChannelRegs *reg = (DMAChannelRegs *)((u32)REG_DMA_BASE +
+        channel * sizeof(DMAChannelRegs));
 
     reg->src = src;
     reg->dest = dest;

--- a/src/DMASyncFillTransfer.c
+++ b/src/DMASyncFillTransfer.c
@@ -33,7 +33,7 @@ void DMASyncFillTransfer(u32 channel, void *dst, u32 data, u32 size)
     while (*dmaCtrl & DMA_CONTROL_ENABLE)
         ;
 
-    fillReg = (vu32 *)(REG_DMA_FILL_ADDR(channel) & 0xFFFFFFFFFFFFFFFF);
+    fillReg = (vu32 *)(REG_DMA_FILL_ADDR(channel));
     *fillReg = data;
     DMAStartTransferFB(channel, (void *)fillReg, dst,
                        (size >> 2) | DMA_CONTROL_ENABLE |

--- a/src/FS_CloseFile.c
+++ b/src/FS_CloseFile.c
@@ -7,6 +7,6 @@ int FS_CloseFile(char *self)
 
     *(int *)(self + 8) = 0;
     *(int *)(self + 0x10) = 0xc;
-    *(int *)(((long long)(int)(self + 0xc))) &= ~0x30;
+    *(int *)(self + 0xc) &= ~0x30;
     return 1;
 }

--- a/src/MulVec3Mat4x3.c
+++ b/src/MulVec3Mat4x3.c
@@ -6,8 +6,8 @@ void MulVec3Mat4x3(Vector3* v, Matrix4x3* m, Vector3* dst)
     int y = v->y;
     int x = v->x;
     int z = v->z;
-    int* py = (int*)(int)(((long long)(int)((char*)dst + 4)));
-    int* pz = (int*)(int)(((long long)(int)((char*)dst + 8)));
+    int* py = (int*)(int)((char*)dst + 4);
+    int* pz = (int*)(int)((char*)dst + 8);
 
     dst->x = (int)(((long long)x * m->m[0] + (long long)y * m->m[3] + (long long)z * m->m[6]) >> 12);
     dst->x += m->m[9];

--- a/src/Player_DisableInteraction.c
+++ b/src/Player_DisableInteraction.c
@@ -4,7 +4,7 @@ void Player_DisableInteraction(char *self)
     char *slot;
 
     *(unsigned char *)(self + 0x709) = 1;
-    slot = (char *)(((long long)(int)(self + 0x2ec)));
+    slot = (char *)(self + 0x2ec);
     tmp = *(unsigned int *)slot;
     tmp |= 4u;
     *(unsigned int *)slot = tmp;

--- a/src/ShowCrashScreen.c
+++ b/src/ShowCrashScreen.c
@@ -86,7 +86,7 @@ void ShowCrashScreen(void)
             int *tail;
             { i = 0; if (i < 17) do { nds_printf(scr + (i + 3) * 0x40 + 0x28, data_0208e5e4,
                     &buf.c[i * 3], regs[i]); i++; } while (i < 17); }
-            tail = (int *)(int)(((long long)(int)(data_0209cddc + 0x19)));
+            tail = (int *)(int)(data_0209cddc + 0x19);
             nds_printf(scr + 0x528, data_0208e5f0, tail[0]);
             nds_printf(scr + 0x568, data_0208e5fc, tail[1]);
         }

--- a/src/Vec3_AsrInPlace.c
+++ b/src/Vec3_AsrInPlace.c
@@ -1,7 +1,7 @@
 int *Vec3_AsrInPlace(int *v, int sh)
 {
     v[0] >>= sh;
-    *(int *)(((long long)(int)(v + 1))) >>= sh;
-    *(int *)(((long long)(int)(v + 2))) >>= sh;
+    *(int *)(v + 1) >>= sh;
+    *(int *)(v + 2) >>= sh;
     return v;
 }

--- a/src/Vec3_LslInPlace.c
+++ b/src/Vec3_LslInPlace.c
@@ -1,7 +1,7 @@
 int *Vec3_LslInPlace(int *v, int sh)
 {
     v[0] <<= sh;
-    *(int *)(((long long)(int)(v + 1))) <<= sh;
-    *(int *)(((long long)(int)(v + 2))) <<= sh;
+    *(int *)(v + 1) <<= sh;
+    *(int *)(v + 2) <<= sh;
     return v;
 }

--- a/src/_ZN10BowserTail8BehaviorEv.cpp
+++ b/src/_ZN10BowserTail8BehaviorEv.cpp
@@ -13,7 +13,7 @@ int BowserTail::Behavior()
     if (!a) return 1;
 
     int ang = *(short*)((char*)a + 0x94);
-    a = (Actor*)(((int)a + 0x5c) & 0xFFFFFFFFFFFFFFFFull);
+    a = (Actor*)((int)a + 0x5c);
     int x = *(int*)a;
     volatile int v[3];
     v[0] = x;

--- a/src/_ZN10ChainChomp13InitResourcesEv.cpp
+++ b/src/_ZN10ChainChomp13InitResourcesEv.cpp
@@ -90,11 +90,11 @@ int ChainChomp::InitResources()
     *(unsigned char *)((unsigned char *)spawned + 0x320) = (unsigned char)one;
     *(int *)(c + 0x60c) = 0;
 
-    px = (int *)(((long long)(int)(c + 0x5c)));
+    px = (int *)(c + 0x5c);
     *px = *px + 0xc8000;
-    py = (int *)(((long long)(int)(c + 0x60)));
+    py = (int *)(c + 0x60);
     *py = *py + 0xc8000;
-    pz = (int *)(((long long)(int)(c + 0x64)));
+    pz = (int *)(c + 0x64);
     *pz = *pz + 0xc8000;
 
     *(int *)(c + 0x5f8) = 0x50000;

--- a/src/_ZN10HootTheOwl13InitResourcesEv.cpp
+++ b/src/_ZN10HootTheOwl13InitResourcesEv.cpp
@@ -18,7 +18,7 @@ extern void _ZN9ActorBase18MarkForDestructionEv(void*);
 extern void* data_ov094_02136b40;
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
-#define LA(p) ((int*)(unsigned)(((long long)(unsigned)(unsigned)(p))))
+#define LA(p) ((int*)(unsigned)((unsigned)(p)))
 
 int HootTheOwl::InitResources()
 {

--- a/src/_ZN10KingBobOmb13InitResourcesEv.cpp
+++ b/src/_ZN10KingBobOmb13InitResourcesEv.cpp
@@ -92,7 +92,7 @@ int KingBobOmb::InitResources()
     }
     unk_4a0 = ((unsigned int)RandomIntInternal(&data_0209e650) >> 0x1e) & 1;
     {
-        int *p = (int*)(((long long)(int)((char*)&unk_4a0)));
+        int *p = (int*)((char*)&unk_4a0);
         *p = *p + 1;
     }
     *(short*)(((char*)this)+0x400+0xf8) = mAngleY;

--- a/src/_ZN10KoopaShell8BehaviorEv.cpp
+++ b/src/_ZN10KoopaShell8BehaviorEv.cpp
@@ -69,7 +69,7 @@ int KoopaShell::Behavior()
         if (unk_107 != 0) {
             mSpawnAngleY = mPrevAngleY;
             func_ov102_0214d1f8(c, &data_ov102_0214ea78);
-            *(u32 *)(int)(((long long)(int)((char *)&mFlags))) &= ~0x80000;
+            *(u32 *)(int)((char *)&mFlags) &= ~0x80000;
             unk_107 = 0;
         }
         func_ov102_0214ce60(c);

--- a/src/_ZN10LavaBubble13InitResourcesEv.cpp
+++ b/src/_ZN10LavaBubble13InitResourcesEv.cpp
@@ -23,7 +23,7 @@ int LavaBubble::InitResources()
     unk_308 = mPosY;
     unk_30c = mPosZ;
     if (unk_310 == 0) {
-        *(int *)(((long long)(int)((char*)&unk_0b0))) |= 1;
+        *(int *)((char*)&unk_0b0) |= 1;
     } else {
         unk_09c = -0x4000;
         unk_0a0 = -0x3c000;

--- a/src/_ZN10LavaBubble8BehaviorEv.cpp
+++ b/src/_ZN10LavaBubble8BehaviorEv.cpp
@@ -57,7 +57,7 @@ int LavaBubble::Behavior()
                         _ZN6Player4BurnEv(a);
                 }
             } else {
-                *(int*)(((long long)(int)((char*)&unk_128))) |= 1;
+                *(int*)((char*)&unk_128) |= 1;
             }
         }
     }

--- a/src/_ZN10PyramidTop8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTop8BehaviorEv.cpp
@@ -16,7 +16,7 @@ int PyramidTop::Behavior()
     switch (state) {
     case 0:
         if (unk_3b6 == 4) {
-            (*(u8*)(((long long)(int)((char*)&unk_3b7))))++;
+            (*(u8*)((char*)&unk_3b7))++;
         }
         break;
     case 1:
@@ -35,7 +35,7 @@ int PyramidTop::Behavior()
         }
         break;
     }
-    (*(u16*)(((long long)(int)((char*)&unk_3b2))))++;
+    (*(u16*)((char*)&unk_3b2))++;
     if (state != unk_3b7) {
         unk_3b2 = 0;
     }

--- a/src/_ZN10SphereClsn10DetectClsnEv.cpp
+++ b/src/_ZN10SphereClsn10DetectClsnEv.cpp
@@ -77,7 +77,7 @@ int SphereClsn::DetectClsn()
             int active = (info->pB0 & 2) ? 1 : 0;
             if (active != 0) {
                 Vec3 v;
-                Vec3 *src = (Vec3 *)((unsigned long long)(unsigned int)((char *)info + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+                Vec3 *src = (Vec3 *)((char *)info + 0x5c);
                 v.x = src->x;
                 v.y = src->y;
                 v.z = src->z;

--- a/src/_ZN10StarSwitch13InitResourcesEv.cpp
+++ b/src/_ZN10StarSwitch13InitResourcesEv.cpp
@@ -32,7 +32,7 @@ extern "C" int _ZN10StarSwitch13InitResourcesEv(char *c) {
         int b = 0;
         if (*(u16*)(c + 0xc) == 0xc) b = 1;
         if (b) {
-            *(int*)(((long long)(int)(c + 0xb0))) |= 0x4000000;
+            *(int*)(c + 0xb0) |= 0x4000000;
             *(int*)(c + 0x33c) = 2;
             *(u8*)(c + 0x351) = *(unsigned int*)(c + 8);
             if (*(u8*)(c + 0x351) == 0xff)
@@ -68,10 +68,10 @@ extern "C" int _ZN10StarSwitch13InitResourcesEv(char *c) {
         if (h == 0xff || h == 0)
             *(u16*)(c + 0x300 + 0x3a) = 0x190;
         else
-            *(u16*)(((long long)(int)(c + 0x33a))) *= 0xa;
+            *(u16*)(c + 0x33a) *= 0xa;
     }
     *(u8*)(c + 0x34f) = 5;
-    *(int*)(((long long)(int)(c + 0x60))) += 0x5000;
+    *(int*)(c + 0x60) += 0x5000;
     *(u8*)(c + 0x34d) = 1;
     return 1;
 }

--- a/src/_ZN10StarSwitch8BehaviorEv.cpp
+++ b/src/_ZN10StarSwitch8BehaviorEv.cpp
@@ -63,7 +63,7 @@ int StarSwitch::Behavior()
     }
 
     if ((data_0209b454 & 0x4000000) == 0) {
-        unsigned short *p = (unsigned short *)(((long long)(int)((char *)&unk_338)));
+        unsigned short *p = (unsigned short *)((char *)&unk_338);
         *p = *p + 1;
     }
     func_ov002_020ba520(((char *)this));

--- a/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
+++ b/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
@@ -20,7 +20,7 @@ int BobOmbBuddy::Behavior()
     func_ov084_0212c9a8(((char *)this));
     p = (char*)_ZN5Actor13ClosestPlayerEv(((char *)this));
     if (p != 0) {
-        Vector3 *ps = (Vector3 *)(((unsigned long long)(unsigned)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFULL);
+        Vector3 *ps = (Vector3 *)(p + 0x5c);
         v = *ps;
         if (Vec3_HorzDist((Vector3*)((char *)&mPosX), &v) < 0x12c000) {
             short ang = Vec3_HorzAngle((Vector3*)((char *)&mPosX), &v);

--- a/src/_ZN11CommonModel13Func_020160ACEj.cpp
+++ b/src/_ZN11CommonModel13Func_020160ACEj.cpp
@@ -12,7 +12,7 @@ void CommonModel::Func_020160AC(u32 flags)
     for (i = 0; i < n; i++) {
         /* The (long long)(int) launder keeps the ROM's materialized
            address for the read-modify-write. */
-        u32 *f = (u32 *)(((long long)(int)&p->flags));
+        u32 *f = (u32 *)(&p->flags);
         *f |= flags;
         p++;
     }

--- a/src/_ZN11MirrorLuigi6RenderEv.cpp
+++ b/src/_ZN11MirrorLuigi6RenderEv.cpp
@@ -44,12 +44,12 @@ int MirrorLuigi::Render()
     player = data_0209f394[data_0209f250];
     r8res = func_ov002_020e496c(player);
 
-    q = (char*)(int)(((long long)(int)((char*)&unk_0dc)));
+    q = (char*)(int)((char*)&unk_0dc);
     comp = *(char**)q;
     dst = *(Mtx**)(q + 0xc);
     src = *(Mtx**)(r8res + 0x14);
     for (i = 0; i < *(unsigned int*)(comp + 4); i++) {
-        *(Mtx*)(int)(((long long)(int)dst)) = *src;
+        *(Mtx*)(int)((long long)(int)dst) = *src;
         src++;
         dst++;
     }

--- a/src/_ZN11RaycastLine10DetectClsnEv.cpp
+++ b/src/_ZN11RaycastLine10DetectClsnEv.cpp
@@ -73,7 +73,7 @@ int RaycastLine::DetectClsn()
             int active = (info->pB0 & 2) ? 1 : 0;
             if (active != 0) {
                 Vec3 v;
-                Vec3 *src = (Vec3 *)((unsigned long long)(unsigned int)((char *)info + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+                Vec3 *src = (Vec3 *)((char *)info + 0x5c);
                 v.x = src->x;
                 v.y = src->y;
                 v.z = src->z;

--- a/src/_ZN11RollingRock8BehaviorEv.c
+++ b/src/_ZN11RollingRock8BehaviorEv.c
@@ -36,7 +36,7 @@ int _ZN11RollingRock8BehaviorEv(char *c)
         if (*(u8*)(c + 0x3be) != 4) {
             s16 *p8c;
             func_ov021_021127b4(c);
-            p8c = (s16 *)(int)(((long long)(int)(c + 0x8c)));
+            p8c = (s16 *)(int)(c + 0x8c);
             *p8c = (s16)(*p8c + (*(int*)(c + 0x98) >> 12) * 0x43);
             *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
             func_ov021_02112544(c);
@@ -80,7 +80,7 @@ int _ZN11RollingRock8BehaviorEv(char *c)
                 struct Vector3_16 v16;
                 u32 rnd;
                 u8 *p3bf;
-                p3bf = (u8 *)(int)(((long long)(int)(c + 0x3bf)));
+                p3bf = (u8 *)(int)(c + 0x3bf);
                 *p3bf = (u8)(*p3bf + 1);
                 *(u16*)(c + 0x100) = 0;
                 v16 = *(struct Vector3_16*)(c + 0x92);
@@ -100,7 +100,7 @@ int _ZN11RollingRock8BehaviorEv(char *c)
             }
         }
         {
-            u16 *p100 = (u16 *)(int)(((long long)(int)(c + 0x100)));
+            u16 *p100 = (u16 *)(int)(c + 0x100);
             *p100 = (u16)(*p100 + 1);
         }
     }

--- a/src/_ZN11ShadowModel9DoSetFileEPcii.cpp
+++ b/src/_ZN11ShadowModel9DoSetFileEPcii.cpp
@@ -20,7 +20,7 @@ int ShadowModel::DoSetFile(char *file, int a, int b)
         for (i = 0; i < n; i++) {
             /* (long long)(int) launder: keep the ROM's materialized
                address for the read-modify-write. */
-            *(u32 *)(((long long)(int)&mat->flags)) |= 0x8000;
+            *(u32 *)(&mat->flags) |= 0x8000;
             mat = (BMD_Material *)((char *)mat + 0x30);
         }
     }

--- a/src/_ZN12CylinderClsn7ProcessEv.cpp
+++ b/src/_ZN12CylinderClsn7ProcessEv.cpp
@@ -70,8 +70,8 @@ void CylinderClsn::Process()
 
             if (sharedFlags & 0x4000000)
             {
-                u32* pf1 = (u32*)((unsigned long long)(unsigned int)((char*)other + 0x20) & 0xFFFFFFFFFFFFFFFFULL);
-                u32* pf0 = (u32*)((unsigned long long)(unsigned int)((char*)data_0209cee8 + 0x20) & 0xFFFFFFFFFFFFFFFFULL);
+                u32* pf1 = (u32*)((char*)other + 0x20);
+                u32* pf0 = (u32*)((char*)data_0209cee8 + 0x20);
                 *pf0 |= 0x8000000;
                 overlap -= 0x50000;
                 *pf1 |= 0x8000000;

--- a/src/_ZN12PiranhaPlant8BehaviorEv.cpp
+++ b/src/_ZN12PiranhaPlant8BehaviorEv.cpp
@@ -41,13 +41,13 @@ int PiranhaPlant::Behavior()
     old = mState;
     (((Cls*)((char*)this))->*data_ov084_02130e80[old])();
     {
-        unsigned short* p100 = (unsigned short*)(((long long)(int)((char*)&unk_100)));
+        unsigned short* p100 = (unsigned short*)((char*)&unk_100);
         *p100 = (unsigned short)(*p100 + 1);
     }
     cur = mState;
     if (old != cur) {
         if (cur == 5) {
-            int* pb0 = (int*)(((long long)(int)((char*)&unk_0b0)));
+            int* pb0 = (int*)((char*)&unk_0b0);
             *pb0 = *pb0 & ~0x10000000;
         }
         unk_100 = 0;

--- a/src/_ZN12SwitchPillar8BehaviorEv.cpp
+++ b/src/_ZN12SwitchPillar8BehaviorEv.cpp
@@ -22,7 +22,7 @@ int SwitchPillar::Behavior()
     } else if (*(int*)((char*)data_0209caa0 + 8) & 0x80000) {
         unk_338 = _ZN5Sound8PlayLongEjjjRK7Vector3s(
             unk_338, 3, 0x96, (void*)((char*)&unk_074), 0);
-        *(int*)(((long long)(int)((char*)&mPosY))) -= 0x5000;
+        *(int*)((char*)&mPosY) -= 0x5000;
         unk_33e = 1;
         if (mPosY <= mLoweredY) {
             mPosY = mLoweredY;

--- a/src/_ZN12WithMeshClsn13SetGroundFlagEv.cpp
+++ b/src/_ZN12WithMeshClsn13SetGroundFlagEv.cpp
@@ -6,5 +6,5 @@
 
 void WithMeshClsn::SetGroundFlag()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mFlags))) |= 0x10;
+    *(unsigned int *)((char *)&mFlags) |= 0x10;
 }

--- a/src/_ZN12WithMeshClsn13SetLimMovFlagEv.cpp
+++ b/src/_ZN12WithMeshClsn13SetLimMovFlagEv.cpp
@@ -6,5 +6,5 @@
 
 void WithMeshClsn::SetLimMovFlag()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mFlags))) |= 0x80;
+    *(unsigned int *)((char *)&mFlags) |= 0x80;
 }

--- a/src/_ZN12WithMeshClsn15ClearGroundFlagEv.cpp
+++ b/src/_ZN12WithMeshClsn15ClearGroundFlagEv.cpp
@@ -6,5 +6,5 @@
 
 void WithMeshClsn::ClearGroundFlag()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mFlags))) &= ~0x10;
+    *(unsigned int *)((char *)&mFlags) &= ~0x10;
 }

--- a/src/_ZN12WithMeshClsn15ClearLimMovFlagEv.cpp
+++ b/src/_ZN12WithMeshClsn15ClearLimMovFlagEv.cpp
@@ -6,5 +6,5 @@
 
 void WithMeshClsn::ClearLimMovFlag()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mFlags))) &= ~0x80;
+    *(unsigned int *)((char *)&mFlags) &= ~0x80;
 }

--- a/src/_ZN12WithMeshClsn16UpdateContinuousEv.cpp
+++ b/src/_ZN12WithMeshClsn16UpdateContinuousEv.cpp
@@ -7,7 +7,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "WithMeshClsn.h"
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct ClsnResult { char pad[0x28]; } ClsnResult;

--- a/src/_ZN12WithMeshClsn19ClearAllGroundFlagsEv.cpp
+++ b/src/_ZN12WithMeshClsn19ClearAllGroundFlagsEv.cpp
@@ -6,5 +6,5 @@
 
 void WithMeshClsn::ClearAllGroundFlags()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mFlags))) &= ~0x70;
+    *(unsigned int *)((char *)&mFlags) &= ~0x70;
 }

--- a/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
+++ b/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
@@ -42,7 +42,7 @@ void WithMeshClsn::UpdateDiscreteNoLava()
         unk_018, *(void **)((char *)&mActor));
     unk_128 = unk_1b8;
     if (src->y - p68->y > 0) {
-        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags))) |= 0x20;
+        *(unsigned char *)((char *)&mClsnFlags) |= 0x20;
     }
     if (_ZN10SphereClsn10DetectClsnEv((char *)&mSphereClsn)) {
         p6c = (struct Vector3 *)((char *)&unk_06c);
@@ -52,9 +52,9 @@ void WithMeshClsn::UpdateDiscreteNoLava()
         if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char *)this))) {
             src->x += p6c->x;
             if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char *)this))) {
-                *(int *)(((long long)(int)((char *)src + 4))) += p6c->y;
+                *(int *)((char *)src + 4) += p6c->y;
             }
-            *(int *)(((long long)(int)((char *)src + 8))) += p6c->z;
+            *(int *)((char *)src + 8) += p6c->z;
         }
     }
     if (onGround == 0)

--- a/src/_ZN12WithMeshClsn20UpdateExtraContinousEv.cpp
+++ b/src/_ZN12WithMeshClsn20UpdateExtraContinousEv.cpp
@@ -25,10 +25,10 @@ extern u32 data_02099368[];
 #pragma opt_common_subs off
 
 #define V3D(v, p, dy) { s32 _x, _y, _z; _z = (p)->z; _y = (p)->y; _x = (p)->x; _y = _y + (dy); (v).x = _x; (v).y = _y; (v).z = _z; }
-#define FLAGP (*(u8 *)(((long long)(int)(t + 0x90))))
+#define FLAGP (*(u8 *)(t + 0x90))
 #define FLAGQ (*(u8 *)(((long long)(int)(t + 0x90)) | 0LL))
-#define LNDR(T, a) ((T *)(((long long)(int)(a))))
-#define LND32(a)   ((s32)(((long long)(int)(a))))
+#define LNDR(T, a) ((T *)(a))
+#define LND32(a)   ((s32)((long long)(int)(a)))
 #define V3C(v, p) { s32 _x, _y, _z; _z = (p)->z; _y = (p)->y; _x = (p)->x; (v).x = _x; (v).y = _y; (v).z = _z; }
 
 int  func_020355a0(void *);

--- a/src/_ZN12WithMeshClsn22ClearJustHitGroundFlagEv.cpp
+++ b/src/_ZN12WithMeshClsn22ClearJustHitGroundFlagEv.cpp
@@ -6,5 +6,5 @@
 
 void WithMeshClsn::ClearJustHitGroundFlag()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mFlags))) &= ~0x20;
+    *(unsigned int *)((char *)&mFlags) &= ~0x20;
 }

--- a/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.cpp
+++ b/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.cpp
@@ -6,7 +6,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "WithMeshClsn.h"
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct ClsnResult { char pad[0x28]; } ClsnResult;

--- a/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
+++ b/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
@@ -24,7 +24,7 @@ void WithMeshClsn::UpdateDiscreteNoLava_2()
 
     onGround = _ZNK12WithMeshClsn10IsOnGroundEv(((char *)this));
     _ZN12WithMeshClsn19ClearAllGroundFlagsEv(((char *)this));
-    v.x = *(int *)(((long long)(int)src));
+    v.x = *(int *)(src);
     sy = src->y;
     v.y = sy;
     v.z = src->z;
@@ -33,7 +33,7 @@ void WithMeshClsn::UpdateDiscreteNoLava_2()
         unk_018, *(void **)((char *)&mActor));
     unk_128 = unk_1b8;
     if (src->y - *(int *)(obj + 0x6c) > 0) {
-        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags))) |= 0x20;
+        *(unsigned char *)((char *)&mClsnFlags) |= 0x20;
     }
     if (func_02038a38((char *)&mSphereClsn)) {
         p6c = (struct Vector3 *)((char *)&unk_06c);
@@ -43,9 +43,9 @@ void WithMeshClsn::UpdateDiscreteNoLava_2()
         if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char *)this))) {
             src->x += p6c->x;
             if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char *)this))) {
-                *(int *)(((long long)(int)((char *)src + 4))) += p6c->y;
+                *(int *)((char *)src + 4) += p6c->y;
             }
-            *(int *)(((long long)(int)((char *)src + 8))) += p6c->z;
+            *(int *)((char *)src + 8) += p6c->z;
         }
     }
     if (onGround == 0)

--- a/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
+++ b/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
@@ -19,7 +19,7 @@ void _ZN13HeapAllocatorC1EjPvPvj(struct HeapAllocator *self, u32 magic, void* a,
     *(void**)((char*)&self->unk_01c) = b;
     self->unk_020 = 0;
     {
-        u32* p = (u32*)(((long long)(int)((char*)&self->unk_020)));
+        u32* p = (u32*)((char*)&self->unk_020);
         *p &= ~0xffu;
         *p |= (size & 0xffu);
     }

--- a/src/_ZN13OneUpMushroom8BehaviorEv.cpp
+++ b/src/_ZN13OneUpMushroom8BehaviorEv.cpp
@@ -14,7 +14,7 @@ extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(char* c, char* clsn);
 extern void _ZN12CylinderClsn5ClearEv(char* c);
 extern void _ZN12CylinderClsn6UpdateEv(char* c);
 extern PMF data_ov002_0210dc00[];
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 }
 
 int OneUpMushroom::Behavior()

--- a/src/_ZN13PoleBillboard8BehaviorEv.cpp
+++ b/src/_ZN13PoleBillboard8BehaviorEv.cpp
@@ -28,14 +28,14 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
             *(short *)(c + 0x390) = 0;
             *(unsigned char *)(c + 0x397) = 0;
         } else {
-            *(short *)(((int)c + 0x394)) -= 8;
+            *(short *)((int)c + 0x394) -= 8;
         }
-        *(short *)(((int)c + 0x390)) += 0x400;
+        *(short *)((int)c + 0x390) += 0x400;
         break;
     }
     case 2: {
-        short *p392 = (short *)(((long long)(int)(c + 0x392)));
-        short *p8c = (short *)(((long long)(int)(c + 0x8c)));
+        short *p392 = (short *)(c + 0x392);
+        short *p8c = (short *)(c + 0x8c);
         int amt = *(signed char *)(c + 0x396) << 0x17;
         *p392 = *p392 + (amt >> 16);
         *p8c = *p8c + *(short *)(c + 0x300 + 0x92);
@@ -43,7 +43,7 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
             if (*(short *)(c + 0x8c) < -0x4000) {
                 *(short *)(c + 0x8c) = -0x4000;
                 *(short *)(c + 0x392) = 0;
-                (*(unsigned char *)(((int)c + 0x397)))++;
+                (*(unsigned char *)((int)c + 0x397))++;
                 struct Vector3 pos;
                 pos.x = *(int *)(c + 0x5c);
                 pos.y = *(int *)(c + 0x60);
@@ -52,8 +52,8 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
                 _ZN5Sound9PlayBank3EjRK7Vector3(0x44, (struct Vector3 *)(c + 0x74));
             }
         } else {
-            *(int *)(((int)c + 0x38c)) += 0x2000;
-            *(int *)(((int)c + 0x60)) += *(int *)(c + 0x38c);
+            *(int *)((int)c + 0x38c) += 0x2000;
+            *(int *)((int)c + 0x60) += *(int *)(c + 0x38c);
             {
                 int lim = *(int *)(c + 0x388) + 0x46000;
                 if (*(int *)(c + 0x60) > lim) {
@@ -63,7 +63,7 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
             if (*(short *)(c + 0x8c) > 0x4000) {
                 *(short *)(c + 0x8c) = 0x4000;
                 *(short *)(c + 0x392) = 0;
-                (*(unsigned char *)(((int)c + 0x397)))++;
+                (*(unsigned char *)((int)c + 0x397))++;
                 struct Vector3 pos;
                 pos.x = *(int *)(c + 0x5c);
                 pos.y = *(int *)(c + 0x60);

--- a/src/_ZN13RaycastGround10DetectClsnEv.cpp
+++ b/src/_ZN13RaycastGround10DetectClsnEv.cpp
@@ -31,7 +31,7 @@ int RaycastGround::DetectClsn()
         ClsnObj* p = func_020393b4(obj);
         if (func_02035354(this, p) != 0) continue;
         if (p != 0 && ((p->flags & 2) ? flag : 0) != 0) {
-            int* pv = (int*)(((long long)(int)&p->vec[0]));
+            int* pv = (int*)(&p->vec[0]);
             pos.x = pv[0];
             pos.y = pv[1];
             pos.z = pv[2];
@@ -43,7 +43,7 @@ int RaycastGround::DetectClsn()
             } else {
                 pos.y = pos.y + func_0203938c(obj);
             }
-            Vec3* selfpos = (Vec3*)(((long long)(int)&this->f38));
+            Vec3* selfpos = (Vec3*)((long long)(int)&this->f38);
             if (selfpos->y < pos.y - thr) continue;
             if (Vec3_HorzDist(selfpos, &pos) > thr) continue;
         }

--- a/src/_ZN13RollingLogLll16CleanupResourcesEv.c
+++ b/src/_ZN13RollingLogLll16CleanupResourcesEv.c
@@ -8,6 +8,6 @@ int _ZN13RollingLogLll16CleanupResourcesEv(struct RollingLogLll *self)
 {
     char *p = self->sub;
     if (p)
-        *(u16 *)(((long long)(int)(p + 0x324))) -= 1;
+        *(u16 *)(p + 0x324) -= 1;
     return 1;
 }

--- a/src/_ZN13SharedFilePtr7ReleaseEv.c
+++ b/src/_ZN13SharedFilePtr7ReleaseEv.c
@@ -10,7 +10,7 @@ void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self)
     if (self->numRefs == 0)
         return;
 
-    *(unsigned char *)(((long long)(int)((char *)self + 2))) -= 1;
+    *(unsigned char *)((char *)self + 2) -= 1;
 
     if (self->numRefs != 0)
         return;

--- a/src/_ZN13SharedFilePtr8LoadFileEv.c
+++ b/src/_ZN13SharedFilePtr8LoadFileEv.c
@@ -16,6 +16,6 @@ void *_ZN13SharedFilePtr8LoadFileEv(struct SharedFilePtr *self)
         return 0;
     }
 
-    *(unsigned char *)(((long long)(int)((char *)self + 2))) += 1;
+    *(unsigned char *)((char *)self + 2) += 1;
     return self->filePtr;
 }

--- a/src/_ZN14BlendModelAnim7AdvanceEv.cpp
+++ b/src/_ZN14BlendModelAnim7AdvanceEv.cpp
@@ -8,6 +8,6 @@ void BlendModelAnim::Advance()
     if (blendWeight < 0x1000) {
         /* launder: keep the RMW aliasing the member so the compiler
            re-reads it the way the ROM does */
-        *(int *)((long long)(int)&blendWeight) += blendStep;
+        *(int *)(&blendWeight) += blendStep;
     }
 }

--- a/src/_ZN14BlueCoinSwitch13InitResourcesEv.cpp
+++ b/src/_ZN14BlueCoinSwitch13InitResourcesEv.cpp
@@ -100,8 +100,8 @@ set_fa:
     goto done;
 
 multiply:
-    *(unsigned short*)(((int)c + 0x32a) & 0xFFFFFFFFFFFFFFFFULL) =
-        *(unsigned short*)(((int)c + 0x32a) & 0xFFFFFFFFFFFFFFFFULL) * 0xa;
+    *(unsigned short*)((int)c + 0x32a) =
+        *(unsigned short*)((int)c + 0x32a) * 0xa;
 
 done:
     return 1;

--- a/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
+++ b/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
@@ -14,14 +14,14 @@ extern void _ZN12CylinderClsn6UpdateEv(void* p);
 int EnemySwitchTag::Behavior()
 {
     if (unk_10a != 0) {
-        *(u16*)(((int)((char*)this) + 0x10a)) -= 1;
+        *(u16*)((int)((char*)this) + 0x10a) -= 1;
         if (unk_10a == 0) {
-            *(u32*)(((int)((char*)this) + 0xec)) &= ~1;
+            *(u32*)((int)((char*)this) + 0xec) &= ~1;
             _ZN5Event8ClearBitEj(mEventID);
         }
     }
     if (unk_0f8 != 0) {
-        *(u32*)(((long long)(int)((char*)&unk_0ec))) |= 1;
+        *(u32*)((char*)&unk_0ec) |= 1;
         _ZN5Event6SetBitEj(mEventID);
         if (unk_10c != 0) {
             unk_10a = unk_108;

--- a/src/_ZN14SquarePathLift8BehaviorEv.cpp
+++ b/src/_ZN14SquarePathLift8BehaviorEv.cpp
@@ -46,13 +46,13 @@ int SquarePathLift::Behavior()
         SubVec3(((char *)this) + 0x5c, &scaled2, ((char *)this) + 0x5c);
     }
     if (looped) {
-        *(int *)(((int)((char *)this) + 0x328)) += mPathDir;
+        *(int *)((int)((char *)this) + 0x328) += mPathDir;
         if (mNodeIndex < 0) {
             if (_ZNK7PathPtr5LoopsEv((char *)&mPath)) {
                 mNodeIndex = _ZNK7PathPtr8NumNodesEv((char *)&mPath) - 1;
             } else {
                 mPathDir = 1;
-                *(int *)(((unsigned)((char *)this) + 0x328)) += mPathDir * 2;
+                *(int *)((unsigned)((char *)this) + 0x328) += mPathDir * 2;
             }
         }
         if (mNodeIndex >= _ZNK7PathPtr8NumNodesEv((char *)&mPath)) {
@@ -60,7 +60,7 @@ int SquarePathLift::Behavior()
                 mNodeIndex = 0;
             } else {
                 mPathDir = -1;
-                *(int *)(((long long)(int)((char *)&mNodeIndex))) += mPathDir * 2;
+                *(int *)((char *)&mNodeIndex) += mPathDir * 2;
             }
         }
     }

--- a/src/_ZN14UnchainedChomp8BehaviorEv.cpp
+++ b/src/_ZN14UnchainedChomp8BehaviorEv.cpp
@@ -114,7 +114,7 @@ int UnchainedChomp::Behavior()
         Vec3_Sub(&diff, (Vector3 *)(c + 0x5c), &node);
 
         if (LenVec3(&diff) < 0x190000) {
-            *(int *)(((long long)(int)(c + 0x6b4))) += 1;
+            *(int *)(c + 0x6b4) += 1;
             if (*(int *)(c + 0x6b4) >= *(int *)(c + 0x6b0)) {
                 *(int *)(c + 0x6b4) = 0;
             }

--- a/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
+++ b/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
@@ -31,7 +31,7 @@ int UnknownVsEntry::Behavior()
         for (; i < 4; i++, base += 0x158, p += 0x158, g += 1) {
             func_ov075_02114cd8(base);
             if (*(u8*)(p + 0xa75)) {
-                int* q = (int*)(int)(((long long)(int)(base + 0x118)));
+                int* q = (int*)(int)(base + 0x118);
                 int v[3];
                 v[0] = q[0]; v[1] = q[1]; v[2] = q[2];
                 func_ov075_0211ab38(ee, v);

--- a/src/_ZN15BookShotSpawner8BehaviorEv.cpp
+++ b/src/_ZN15BookShotSpawner8BehaviorEv.cpp
@@ -15,7 +15,7 @@ int _ZN15BookShotSpawner8BehaviorEv(char *c)
         if (p != 0) {
 
             Vector3 tmp;
-            Vector3 *ps = (Vector3 *)(((unsigned long long)(unsigned)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFULL);
+            Vector3 *ps = (Vector3 *)(p + 0x5c);
             tmp = *ps;
 
             if (Vec3_HorzDist((Vector3 *)(c + 0x5c), &tmp) < 0x258000) {
@@ -30,7 +30,7 @@ int _ZN15BookShotSpawner8BehaviorEv(char *c)
             }
         }
     } else {
-        unsigned short *pt = (unsigned short *)(((int)c + 0xd4) & 0xFFFFFFFFFFFFFFFFULL);
+        unsigned short *pt = (unsigned short *)((int)c + 0xd4);
         *pt = *pt + 1;
     }
     return 1;

--- a/src/_ZN15InvisibleSecret6RenderEv.cpp
+++ b/src/_ZN15InvisibleSecret6RenderEv.cpp
@@ -35,7 +35,7 @@ int InvisibleSecret::Render()
     }
 
     if (unk_14c != 0) {
-        u16* p = (u16*)(int)(((long long)(int)((char*)&unk_14c)));
+        u16* p = (u16*)(int)((char*)&unk_14c);
         *p = *p - 1;
         return 1;
     }

--- a/src/_ZN15RecRoomCupboard8BehaviorEv.cpp
+++ b/src/_ZN15RecRoomCupboard8BehaviorEv.cpp
@@ -47,7 +47,7 @@ extern "C" int _ZN15RecRoomCupboard8BehaviorEv(char* self)
         v2.x = *(int*)(self + 0x5c) + (int)(((s64)0x5a000 * data_02082214[(*(volatile u16*)(self + 0x8e) >> 4) * 2] + 0x800) >> 12);
         v2.z = *(int*)(self + 0x64) + (int)(((s64)0x5a000 * data_02082214[(*(volatile u16*)(self + 0x8e) >> 4) * 2 + 1] + 0x800) >> 12);
         {
-            struct Vector3* tp = (struct Vector3*)(((int)target + 0x5c) & 0xffffffffffffffffull);
+            struct Vector3* tp = (struct Vector3*)((int)target + 0x5c);
             v3.x = tp->x;
             v3.y = tp->y;
             v3.z = tp->z;
@@ -109,7 +109,7 @@ extern "C" int _ZN15RecRoomCupboard8BehaviorEv(char* self)
                 if (actor) {
                     int isMatch = (*(u16*)(actor + 0xc) == 0xbf);
                     if (isMatch != false) {
-                        struct Vector3* ap = (struct Vector3*)(((int)actor + 0x5c) & 0xffffffffffffffffull);
+                        struct Vector3* ap = (struct Vector3*)((int)actor + 0x5c);
                         short ang;
                         int diff;
                         apos.x = ap->x;

--- a/src/_ZN15RotatingFirebar8BehaviorEv.cpp
+++ b/src/_ZN15RotatingFirebar8BehaviorEv.cpp
@@ -9,8 +9,8 @@
 #include "MeshColliderBase.h"
 #pragma opt_propagation off
 #pragma opt_dead_assignments off
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
-#define LI(v) ((int)(((long long)(v))))
+#define AT(p,off) ((void*)(int)((char*)(p)+(off)))
+#define LI(v) ((int)((long long)(v)))
 
 
 extern "C" {

--- a/src/_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
+++ b/src/_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
@@ -11,11 +11,11 @@ void MeshColliderBase::UpdatePosWithVelocity(MeshColliderBase &clsn, Actor *clsn
     pos.x = pos.x + vel.x;
     {
         /* launder: the ROM re-reads through the materialized addresses */
-        int *py = (int *)(((long long)(int)&pos.y));
+        int *py = (int *)(&pos.y);
         *py = *py + vel.y;
     }
     {
-        int *pz = (int *)(((long long)(int)&pos.z));
+        int *pz = (int *)(&pos.z);
         *pz = *pz + vel.z;
     }
 }

--- a/src/_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
+++ b/src/_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
@@ -8,11 +8,11 @@ void MeshColliderBase::UpdateAngsWithAngularVelY(MeshColliderBase &clsn, Actor *
 {
     int angY = clsn.GetAngularVelY();
     if (ang) {
-        short *py = (short *)(((long long)(int)&ang->y));
+        short *py = (short *)(&ang->y);
         *py = *py + angY;
     }
     if (motionAng) {
-        short *py = (short *)(((long long)(int)&motionAng->y));
+        short *py = (short *)(&motionAng->y);
         *py = *py + angY;
     }
 }

--- a/src/_ZN17BowserSkyPlatform13InitResourcesEv.cpp
+++ b/src/_ZN17BowserSkyPlatform13InitResourcesEv.cpp
@@ -37,12 +37,12 @@ int BowserSkyPlatform::InitResources()
     z.y = 0;
     z.z = 0;
     Vec3_HorzAngle(&z, (const Vector3 *)((char *)&mPosX));
-    p178 = (int *)(((long long)(int)((char *)&unk_178)));
+    p178 = (int *)((char *)&unk_178);
     unk_184 = 0x2ee000;
     t = mPosX;
     /* materialize r0 = ((char *)this)+0x5c between load and store */
     {
-        Vector3 *pos = (Vector3 *)(((long long)(int)((char *)&mPosX)));
+        Vector3 *pos = (Vector3 *)((char *)&mPosX);
         (void)pos;
     }
     unk_174 = t;

--- a/src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.cpp
+++ b/src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.cpp
@@ -96,25 +96,25 @@ int MovingMeshCollider::DetectClsn(SphereClsn & sphere_)
         d[11] = FMUL(d[5], *(int*)&scale);
         func_02037a6c(sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
         _ZN10ClsnResultaSERKS_(&sphere->unk_010, loc.result);
-        *(u8*)(((s64)(int)&sphere->flags)) |= 1;
+        *(u8*)(&sphere->flags) |= 1;
         if (loc.flags & 4) {
             if (sphere->flags & 4) {
                 r &= ~1;
             } else {
                 sphere->SetFloorResult(*(ClsnResult*)loc.floorRes);
             }
-            *(u8*)(((s64)(int)&sphere->flags)) |= 4;
+            *(u8*)(&sphere->flags) |= 4;
             if (sphere->unk_100 < loc.f_100) {
                 func_0203794c(sphere, &loc.f_fc);
             }
         }
         if (loc.flags & 8) {
             func_02037888(sphere, loc.wallRes);
-            *(u8*)(((s64)(int)&sphere->flags)) |= 8;
+            *(u8*)(&sphere->flags) |= 8;
         }
         if (loc.flags & 0x10) {
             func_0203782c(sphere, loc.undRes);
-            *(u8*)(((s64)(int)&sphere->flags)) |= 0x10;
+            *(u8*)(&sphere->flags) |= 0x10;
         }
     }
     _ZN10SphereClsnD1Ev(&loc);

--- a/src/_ZN18NestedHeapIterator4InitEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator4InitEP13HeapAllocator.cpp
@@ -14,5 +14,5 @@ void NestedHeapIterator::Init(HeapAllocator * a_)
   *((int *) new_var) = 0;
   *((int *) ((char *)this)) = (int) a;
   *((int *) ((char *)&mLast)) = (int) a;
-  *(unsigned short *)(((long long)(int)((char *)&unk_008))) += 1;
+  *(unsigned short *)((char *)&unk_008) += 1;
 }

--- a/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c
+++ b/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c
@@ -23,6 +23,6 @@ void _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_(struct NestedHeapIterator
         *(char **)(nlink + 4) = at;
         *(char **)(prev + off + 4) = node;
         *(char **)(at + self->mLinkOffset) = node;
-        *(unsigned short *)(int)(((long long)(int)((char *)&self->unk_008))) += 1;
+        *(unsigned short *)(int)((char *)&self->unk_008) += 1;
     }
 }

--- a/src/_ZN18NestedHeapIterator6RemoveEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator6RemoveEP13HeapAllocator.cpp
@@ -26,5 +26,5 @@ void NestedHeapIterator::Remove(HeapAllocator * node_)
     }
     *(void**)((char*)node + off) = 0;
     *(void**)((char*)node + off + 4) = 0;
-    *(u16 *)(((u32)((struct NHI*)this) + 8) & 0xFFFFFFFFFFFFFFFFULL) -= 1;
+    *(u16 *)((u32)((struct NHI*)this) + 8) -= 1;
 }

--- a/src/_ZN18NestedHeapIterator7AddLastEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator7AddLastEP13HeapAllocator.cpp
@@ -20,6 +20,6 @@ void NestedHeapIterator::AddLast(HeapAllocator * a_)
         last = mLast;
         *(int *)((char *)last + link_off + 4) = (int)a;
         mLast = (int)a;
-        *(unsigned short *)(int)(((long long)(int)((char *)&unk_008))) += 1;
+        *(unsigned short *)(int)((char *)&unk_008) += 1;
     }
 }

--- a/src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.cpp
@@ -5,7 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "NestedHeapIterator.h"
 struct HeapAllocator;
-#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off)))))
+#define AT(p, off) ((void *)(int)((char *)(p) + (off)))
 struct HeapAllocator;
 
 void NestedHeapIterator::AddFirst(HeapAllocator * a_)

--- a/src/_ZN18SolidHeapAllocator10MemoryLeftEi.cpp
+++ b/src/_ZN18SolidHeapAllocator10MemoryLeftEi.cpp
@@ -36,8 +36,8 @@ int SolidHeapAllocator::MemoryLeft(int align)
 
     a = (u32)_ZN4cstd3absEi(align);
     mask = a - 1u;
-    fb = (int *)(((long long)(int)((char *)this + 0x24)));
-    aligned = (mask + (u32)*(int *)(((long long)(int)((char *)this + 0x24)))) & ~(a - 1u);
+    fb = (int *)((char *)this + 0x24);
+    aligned = (mask + (u32)*(int *)((long long)(int)((char *)this + 0x24))) & ~(a - 1u);
     end = (u32)fb[1];
     if (!(a - 1u)) {
     }
@@ -48,5 +48,5 @@ int SolidHeapAllocator::MemoryLeft(int align)
     new_var2 = (char *)this;
     new_var3 = &fb;
     fb = *new_var3;
-    return (int)(end - ((mask + (u32)*(int *)(((long long)(int)(new_var2 + 0x24)))) & ~(a - 1u)));
+    return (int)(end - ((mask + (u32)*(int *)((long long)(int)(new_var2 + 0x24))) & ~(a - 1u)));
 }

--- a/src/_ZN18SolidHeapAllocator10ResetStartEv.cpp
+++ b/src/_ZN18SolidHeapAllocator10ResetStartEv.cpp
@@ -21,6 +21,6 @@ void SolidHeapAllocator::ResetStart()
 
     begin = *(void **)((char *)this + 0x18);
     fl = (struct FreeList *)((char *)this + 0x24);
-    *(void **)(((long long)(int)fl)) = begin;
+    *(void **)(fl) = begin;
     fl->flags = 0;
 }

--- a/src/_ZN18SolidHeapAllocator9SaveStateEj.cpp
+++ b/src/_ZN18SolidHeapAllocator9SaveStateEj.cpp
@@ -39,7 +39,7 @@ int SolidHeapAllocator::SaveState(u32 arg)
     int *p;
 
     fb = inline_fn(this);
-    saved = *(void **)(((long long)(int)fb));
+    saved = *(void **)(fb);
     p = (int *)AllocateForwards(fb, 0x10, 4);
     if (!p)
         return 0;

--- a/src/_ZN18SolidHeapAllocatorC1EPvj.c
+++ b/src/_ZN18SolidHeapAllocatorC1EPvj.c
@@ -12,7 +12,7 @@ void* _ZN18SolidHeapAllocatorC1EPvj(struct SolidHeapAllocator *self, void* ptr, 
 
     fl = (struct FreeList *)((char *)&self->mFreeRegion);
     _ZN13HeapAllocatorC1EjPvPvj(((void*)self), 0x46524d48, (char *)fl + 0xc, ptr, size);
-    *(void **)(((long long)(int)fl)) =
+    *(void **)(fl) =
         *(void **)((char *)&self->unk_018);
     fl->end = *(void **)((char *)&self->mEnd);
     fl->flags = 0;

--- a/src/_ZN19BowserPuzzleManager8BehaviorEv.cpp
+++ b/src/_ZN19BowserPuzzleManager8BehaviorEv.cpp
@@ -27,7 +27,7 @@ int BowserPuzzleManager::Behavior() {
     if (id != 0)
         p = _ZN5Actor10FindWithIDEj(id);
     if (p == 0 || *(unsigned char*)(p + 0xd6) == 0) {
-        unsigned short* ctr = (unsigned short*)(int)(((long long)(int)(cc + 0x334)));
+        unsigned short* ctr = (unsigned short*)(int)(cc + 0x334);
         *ctr = *ctr + 1;
     }
     func_ov064_02119010(cc);

--- a/src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp
+++ b/src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp
@@ -74,25 +74,25 @@ extern "C" int _ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn(char* self, 
         d[11] = FMUL(d[5], *(int*)(self + 0x50));
         func_02037a6c(sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
         _ZN10ClsnResultaSERKS_(sphere + 0x10, loc.result);
-        *(u8*)(((s64)(int)(sphere + 0x70))) |= 1;
+        *(u8*)(sphere + 0x70) |= 1;
         if (loc.flags & 4) {
             if (*(u8*)(sphere + 0x70) & 4) {
                 r &= ~1;
             } else {
                 _ZN10SphereClsn14SetFloorResultERK10ClsnResult(sphere, func_02037938(&loc));
             }
-            *(u8*)(((s64)(int)(sphere + 0x70))) |= 4;
+            *(u8*)(sphere + 0x70) |= 4;
             if (*(int*)(sphere + 0x100) < loc.f_100) {
                 func_0203794c(sphere, &loc.f_fc);
             }
         }
         if (loc.flags & 8) {
             func_02037888(sphere, func_020378dc(&loc));
-            *(u8*)(((s64)(int)(sphere + 0x70))) |= 8;
+            *(u8*)(sphere + 0x70) |= 8;
         }
         if (loc.flags & 0x10) {
             func_0203782c(sphere, func_02037880(&loc));
-            *(u8*)(((s64)(int)(sphere + 0x70))) |= 0x10;
+            *(u8*)(sphere + 0x70) |= 0x10;
         }
     }
     _ZN10SphereClsnD1Ev(&loc);

--- a/src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjt.cpp
+++ b/src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjt.cpp
@@ -101,7 +101,7 @@ void* ExpandingHeapAllocator::AllocateNode(MemoryNode* c, MemoryNode* node, void
     t2.end = t1.start;
     void* allocNode = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t2, 0x5544);
 
-    unsigned short* flagsPtr = (unsigned short*)((long long)(int)((char*)allocNode + 2));
+    unsigned short* flagsPtr = (unsigned short*)((char*)allocNode + 2);
     void* usedList = (char*)c + 8;
     *flagsPtr &= ~0x8000;
     *flagsPtr |= (z & 1) << 15;

--- a/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
+++ b/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
@@ -24,11 +24,11 @@ void *_ZN22ExpandingHeapAllocatorC1EPvj(struct ExpandingHeapAllocator *self, voi
     _ZN13HeapAllocatorC1EjPvPvj(((char *)self), 0x45585048, inner + 0x14, start, size);
     *(u16 *)(inner + 0x10) = 0;
     *(u16 *)(inner + 0x12) = 0;
-    (*(u16 *)((long long)(int)(inner + 0x12))) &= ~1;
+    (*(u16 *)(inner + 0x12)) &= ~1;
     t.start = *(void **)((char *)&self->unk_018);
     t.end = *(void **)((char *)&self->unk_01c);
     node = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t, 0x4652);
-    *(MemoryNode **)((long long)(int)inner) = node;
+    *(MemoryNode **)(inner) = node;
     *(MemoryNode **)(inner + 4) = node;
     *(u32 *)(inner + 8) = 0;
     *(u32 *)(inner + 0xc) = 0;

--- a/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
@@ -163,7 +163,7 @@ int RotatingUpDownPlatformUtm::Behavior()
         mPosY = sp4C.y;
         mPosZ = sp4C.z;
         {
-            s16 *r2 = (s16 *)(((long long)(int)((char *)&unk_3a2)));
+            s16 *r2 = (s16 *)((char *)&unk_3a2);
             s16 *b300 = (s16 *)((char *)&unk_300);
             r6 = 1;
             *r2 = (s16)(*r2 + *(s16 *)((char *)b300 + 0xa4));
@@ -174,7 +174,7 @@ int RotatingUpDownPlatformUtm::Behavior()
     }
 
     if (r6 != 0) {
-        u8 *p394 = (u8 *)(((long long)(int)((char *)&mWaypointIndex)));
+        u8 *p394 = (u8 *)((char *)&mWaypointIndex);
         *p394 = (u8)(*p394 + 1);
         if ((u32)mWaypointIndex >= 0xa) {
             mWaypointIndex = 0;

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
@@ -40,7 +40,7 @@ int FloatOnWaterPlatformWdwSquare::InitResources()
             0x199, *(short*)(c + 0x8e), data_ov029_0211302c);
     }
     {
-        short* p = (short*)(((unsigned long long)((int)c + 0x94)) & 0xFFFFFFFFFFFFFFFFULL);
+        short* p = (short*)((unsigned long long)((int)c + 0x94));
         short val = *p;
         int* arg0_1 = (int*)(c + 0x124);
         int arg1_1 = (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;

--- a/src/_ZN3HUD13UpdateVsTimerEv.cpp
+++ b/src/_ZN3HUD13UpdateVsTimerEv.cpp
@@ -34,7 +34,7 @@ void HUD::UpdateVsTimer()
     if (data_ov002_02111188 == 0)
     {
         data_ov002_02111188 = 0xb4;
-        q = (unsigned short *)(((int)this + 0x60) & 0xFFFFFFFFFFFFFFFFULL);
+        q = (unsigned short *)((int)this + 0x60);
         *q = *q - 1;
         v = *(unsigned short *)((char *)this + 0x60);
         if (v <= 3 && v != 0)
@@ -52,7 +52,7 @@ void HUD::UpdateVsTimer()
         return;
     if (*(unsigned short *)((char *)this + 0x66) < 0x30)
     {
-        q = (unsigned short *)(((int)this + 0x66) & 0xFFFFFFFFFFFFFFFFULL);
+        q = (unsigned short *)((int)this + 0x66);
         *q = *q + 4;
     }
     else

--- a/src/_ZN3HUD8BehaviorEv.cpp
+++ b/src/_ZN3HUD8BehaviorEv.cpp
@@ -63,14 +63,14 @@ body:
                 *(s16 *)((char *)this + 0x6e) = 0x10;
                 flags = 1;
             } else {
-                *(s16 *)(((int)this + 0x6e) & 0xFFFFFFFFFFFFFFFFULL) += 4;
+                *(s16 *)((int)this + 0x6e) += 4;
             }
             if (data_0209f2fc == 1) {
                 if (*(s16 *)((char *)this + 0x70) <= 0xf0) {
                     *(s16 *)((char *)this + 0x70) = 0xf0;
                     flags |= 2;
                 } else {
-                    *(s16 *)(((int)this + 0x70) & 0xFFFFFFFFFFFFFFFFULL) -= 4;
+                    *(s16 *)((int)this + 0x70) -= 4;
                 }
             } else {
                 flags |= 2;
@@ -83,11 +83,11 @@ body:
                 if (*(s16 *)((char *)this + 0x6e) < -0x38) {
                     flags = 1;
                 } else {
-                    *(s16 *)(((int)this + 0x6e) & 0xFFFFFFFFFFFFFFFFULL) -= 4;
+                    *(s16 *)((int)this + 0x6e) -= 4;
                 }
                 if (data_0209f2fc == 1) {
                     if (*(s16 *)((char *)this + 0x70) <= n + 0x120) {
-                        *(s16 *)(((int)this + 0x70) & 0xFFFFFFFFFFFFFFFFULL) += 4;
+                        *(s16 *)((int)this + 0x70) += 4;
                     } else {
                         flags |= 2;
                     }
@@ -103,14 +103,14 @@ body:
                 *(s16 *)((char *)this + 0x6e) = 0x10;
                 flags = 1;
             } else {
-                *(s16 *)(((int)this + 0x6e) & 0xFFFFFFFFFFFFFFFFULL) += 4;
+                *(s16 *)((int)this + 0x6e) += 4;
             }
             if (data_0209f2fc == 1 || *(u8 *)((char *)this + 0x78) != 0) {
                 if (*(s16 *)((char *)this + 0x70) <= 0xf0) {
                     *(s16 *)((char *)this + 0x70) = 0xf0;
                     flags |= 2;
                 } else {
-                    *(s16 *)(((int)this + 0x70) & 0xFFFFFFFFFFFFFFFFULL) -= 4;
+                    *(s16 *)((int)this + 0x70) -= 4;
                 }
             } else {
                 flags |= 2;

--- a/src/_ZN3Key8BehaviorEv.cpp
+++ b/src/_ZN3Key8BehaviorEv.cpp
@@ -29,7 +29,7 @@ extern int data_ov089_02132b40[];
 extern int data_ov089_02132ca4[];
 }
 
-#define LAUNDER(p) ((long long)(int)(p))
+#define LAUNDER(p) (p)
 struct C { virtual void dummy(); };
 typedef void (C::*PMF)();
 struct PmfEntry { PMF pmf; };

--- a/src/_ZN4BgCh18StopDetectingWaterEv.cpp
+++ b/src/_ZN4BgCh18StopDetectingWaterEv.cpp
@@ -6,5 +6,5 @@
 
 void BgCh::StopDetectingWater()
 {
-    *(unsigned char *)(((long long)(int)((char *)&unk_004))) &= ~2;
+    *(unsigned char *)((char *)&unk_004) &= ~2;
 }

--- a/src/_ZN4BgCh19StartDetectingToxicEv.cpp
+++ b/src/_ZN4BgCh19StartDetectingToxicEv.cpp
@@ -6,5 +6,5 @@
 
 void BgCh::StartDetectingToxic()
 {
-    *(unsigned char *)(((long long)(int)((char *)&unk_004))) |= 8;
+    *(unsigned char *)((char *)&unk_004) |= 8;
 }

--- a/src/_ZN4BgCh19StartDetectingWaterEv.cpp
+++ b/src/_ZN4BgCh19StartDetectingWaterEv.cpp
@@ -6,5 +6,5 @@
 
 void BgCh::StartDetectingWater()
 {
-    *(unsigned char *)(((long long)(int)((char *)&unk_004))) |= 2;
+    *(unsigned char *)((char *)&unk_004) |= 2;
 }

--- a/src/_ZN4BgCh21StopDetectingOrdinaryEv.cpp
+++ b/src/_ZN4BgCh21StopDetectingOrdinaryEv.cpp
@@ -6,5 +6,5 @@
 
 void BgCh::StopDetectingOrdinary()
 {
-    *(unsigned char *)(((long long)(int)((char *)&unk_004))) &= ~1;
+    *(unsigned char *)((char *)&unk_004) &= ~1;
 }

--- a/src/_ZN4Clam8BehaviorEv.cpp
+++ b/src/_ZN4Clam8BehaviorEv.cpp
@@ -107,7 +107,7 @@ int Clam::Behavior()
     if (unk_15c != 0) {
         char *touched = _ZN5Actor10FindWithIDEj(unk_15c);
         if (touched != 0) {
-            int isPlayer = (int)(((long long)(int)(*(u16 *)(touched + 0xc) == 0xbf)));
+            int isPlayer = (int)(*(u16 *)(touched + 0xc) == 0xbf);
             if (isPlayer != 0) {
                 u.hurtFrom[0] = mPosX;
                 u.hurtFrom[1] = mPosY;

--- a/src/_ZN4Coin16CleanupResourcesEv.c
+++ b/src/_ZN4Coin16CleanupResourcesEv.c
@@ -22,7 +22,7 @@ int _ZN4Coin16CleanupResourcesEv(char* c)
         int b2 = (int)(*(unsigned short*)(o + 0xc) == 0x4f);
         if (b2 != 0) {
             if (*(unsigned char*)(o + 0xd6) != 0) {
-                unsigned char *p = (unsigned char*)(((int)o + 0xd6) & 0xFFFFFFFFFFFFFFFFULL);
+                unsigned char *p = (unsigned char*)((int)o + 0xd6);
                 *p = *p - 1;
             }
         }

--- a/src/_ZN4Toad13InitResourcesEv.cpp
+++ b/src/_ZN4Toad13InitResourcesEv.cpp
@@ -102,7 +102,7 @@ int Toad::InitResources()
                 goto after_inc;
         }
         {
-            u16 *pm = (u16 *)(((long long)(int)((char *)&unk_208)));
+            u16 *pm = (u16 *)((char *)&unk_208);
             *pm = (u16)(*pm + 1);
         }
     after_inc: ;

--- a/src/_ZN4Toad8BehaviorEv.cpp
+++ b/src/_ZN4Toad8BehaviorEv.cpp
@@ -58,7 +58,7 @@ int Toad::Behavior()
         if (data_0209f2f8 == 0x32)
             threshold = 0x1f4000;
 
-        Vector3 *psrc = (Vector3 *)(((long long)(int)(p + 0x5c)));
+        Vector3 *psrc = (Vector3 *)(p + 0x5c);
         Vector3 v;
         v.x = psrc->x;
         v.y = psrc->y;

--- a/src/_ZN4Trap8BehaviorEv.cpp
+++ b/src/_ZN4Trap8BehaviorEv.cpp
@@ -82,7 +82,7 @@ int Trap::Behavior()
             if (o) {
                 int b = (int)(*(u16*)((char*)o + 0xc) == 0xbf);
                 if (b) {
-                    Vector3* op = (Vector3*)(((int)o + 0x5c) & 0xFFFFFFFFFFFFFFFFull);
+                    Vector3* op = (Vector3*)((int)o + 0x5c);
                     hv = *op;
                     if (AngleDiff(Vec3_HorzAngle(&((Obj*)this)->pos, &hv), ((Obj*)this)->angle_8e) < 0x4000) {
                         if (*(s32*)((char*)o + 0x664) == 0xd) {

--- a/src/_ZN5Actor13LandingDustAtER7Vector3b.cpp
+++ b/src/_ZN5Actor13LandingDustAtER7Vector3b.cpp
@@ -23,11 +23,11 @@ extern "C" void _ZN5Actor13LandingDustAtER7Vector3b(Actor *self, Vector3 *pos, b
 {
     if (b) {
         RaycastGround rc;
-        *(Fix12i*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFULL) += 0x32000;
+        *(Fix12i*)((int)pos + 4) += 0x32000;
         rc.SetObjAndPos(*pos, 0);
         if (rc.DetectClsn())
             pos->y = *(Fix12i*)((char*)&rc + 0x44);
     }
-    *(Fix12i*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFULL) += 0x5a000;
+    *(Fix12i*)((int)pos + 4) += 0x5a000;
     Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb1, pos->x, pos->y, pos->z);
 }

--- a/src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp
+++ b/src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp
@@ -23,11 +23,11 @@ extern "C" void _ZN5Actor17HugeLandingDustAtER7Vector3b(Actor *self, Vector3 *po
 {
     if (b) {
         RaycastGround rc;
-        *(Fix12i*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFULL) += 0x32000;
+        *(Fix12i*)((int)pos + 4) += 0x32000;
         rc.SetObjAndPos(*pos, 0);
         if (rc.DetectClsn())
             pos->y = *(Fix12i*)((char*)&rc + 0x44);
     }
-    *(Fix12i*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFULL) += 0x28000;
+    *(Fix12i*)((int)pos + 4) += 0x28000;
     Particle::_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb2, pos->x, pos->y, pos->z);
 }

--- a/src/_ZN5Actor18AfterInitResourcesEj.cpp
+++ b/src/_ZN5Actor18AfterInitResourcesEj.cpp
@@ -18,5 +18,5 @@ void Actor::AfterInitResources(u32 vfSuccess)
        ROM materialises the address into a register first (`add r1,r4,#0xb0`)
        and then does the read-modify-write through it. Writing `mFlags |= 0x38`
        folds the offset into the ldr/str and comes out 4 bytes short. */
-    *(u32 *)(long long)(int)&mFlags |= 0x38;
+    *(u32 *)&mFlags |= 0x38;
 }

--- a/src/_ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn.cpp
+++ b/src/_ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn.cpp
@@ -24,8 +24,8 @@ struct Actor {
 void Actor::UpdatePosWithOnlySpeed(CylinderClsn *clsn) {
     AddVec3(&pos, &speed, &pos);
     if (clsn != 0) {
-        *(s32 *)(((long long)(int)(&pos.x))) += clsn->dx;
-        *(s32 *)(((long long)(int)(&pos.z))) += clsn->dz;
+        *(s32 *)(&pos.x) += clsn->dx;
+        *(s32 *)(&pos.z) += clsn->dz;
     }
     func_02010da4((int *)this);
 }

--- a/src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp
+++ b/src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp
@@ -89,7 +89,7 @@ struct VB {
 
 struct M48 { int w[12]; };
 
-#define LAUNDER(p) ((int)(((long long)(int)(p))))
+#define LAUNDER(p) ((int)(p))
 
 int Enemy::UpdateKillByInvincibleChar(WithMeshClsn & ww_, ModelAnim & mm_, unsigned int flags)
 {

--- a/src/_ZN5Koopa8BehaviorEv.cpp
+++ b/src/_ZN5Koopa8BehaviorEv.cpp
@@ -35,7 +35,7 @@ int Koopa::Behavior()
     _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(((char *)this), ((char *)this) + 0x110);
 
     if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((char *)this), ((char *)this) + 0x144) != 0) {
-        int *pb0 = (int *)(((long long)(int)((char *)&unk_0b0)));
+        int *pb0 = (int *)((char *)&unk_0b0);
         *pb0 = *pb0 & ~0x10000000;
         if (_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(((char *)this), ((char *)this) + 0x110) != 0) {
             _ZN5Actor8PoofDustEv(((char *)this));
@@ -67,7 +67,7 @@ int Koopa::Behavior()
         {
             int *pb0 = (int *)((char *)&unk_0b0);
             if (unk_3ce != 0)
-                *(u8 *)(((long long)(int)((char *)&unk_3ce))) -= 1;
+                *(u8 *)((char *)&unk_3ce) -= 1;
             *pb0 = *pb0 | 0x10000000;
         }
         func_ov062_02118258(((char *)this), 0x3e8000);
@@ -91,7 +91,7 @@ int Koopa::Behavior()
             int ang = mPrevAngleY;
             mAngleY = (s16)ang;
             {
-                u16 *p100 = (u16 *)(((long long)(int)((char *)&unk_100)));
+                u16 *p100 = (u16 *)((char *)&unk_100);
                 *p100 = (u16)(*p100 + 1);
             }
         }
@@ -122,7 +122,7 @@ int Koopa::Behavior()
             if (unk_3ca == 0) {
                 _ZN12CylinderClsn6UpdateEv((char *)&mCylinderClsn);
             } else {
-                *(u16 *)(((long long)(int)((char *)&unk_3ca))) -= 1;
+                *(u16 *)((char *)&unk_3ca) -= 1;
             }
         }
     } else {

--- a/src/_ZN5Stage10CheckInputEv.cpp
+++ b/src/_ZN5Stage10CheckInputEv.cpp
@@ -183,9 +183,9 @@ main_part:
                         j++;
                     } while (j < 0x10);
                     if (p->mode != 2 && (p->held & 0x300) == 0x300) {
-                        *(u16*)(((int)p + 4) & 0xFFFFFFFFFFFFFFFFull) |= 0x4000;
+                        *(u16*)((int)p + 4) |= 0x4000;
                         if (p->pressed & 0x300) {
-                            *(u16*)(((int)p + 6) & 0xFFFFFFFFFFFFFFFFull) |= 0x4000;
+                            *(u16*)((int)p + 6) |= 0x4000;
                         }
                     }
                 }

--- a/src/_ZN5Stage11RenderModelEv.cpp
+++ b/src/_ZN5Stage11RenderModelEv.cpp
@@ -47,7 +47,7 @@ extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *transfor
 
 void Stage::RenderModel()
 {
-    ModelComponents *mc = (ModelComponents *)(((long long)(int)((char *)&unk_874)));
+    ModelComponents *mc = (ModelComponents *)((char *)&unk_874);
     Inner *inner = *(Inner **)((char *)mc->sub + 8);
     Slot *slot = (Slot *)((char *)&unk_8bc);
     int i;
@@ -64,10 +64,10 @@ void Stage::RenderModel()
                 idx++;
                 u32 flagsTest = *(volatile u32 *)&comp->flags;
                 if ((flagsTest & 0x1f0000) == 0x1f0000) {
-                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)));
+                    u32 *p = (u32 *)((char *)comp + 0x24);
                     *p &= ~0x80000000;
                 } else {
-                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)));
+                    u32 *p = (u32 *)((char *)comp + 0x24);
                     *p |= 0x80000000;
                 }
             }
@@ -78,7 +78,7 @@ void Stage::RenderModel()
             for (j = 0; j < inner->count; j++) {
                 u8 id = *idx;
                 Component *comp = (Component *)((char *)mc->components + id * 0x30);
-                *(u32 *)(((long long)(int)((char *)comp + 0x24))) |= 0x80000000;
+                *(u32 *)((char *)comp + 0x24) |= 0x80000000;
                 idx++;
             }
         }

--- a/src/_ZN5Stage9LoadModelEv.cpp
+++ b/src/_ZN5Stage9LoadModelEv.cpp
@@ -14,7 +14,7 @@ void Stage::LoadModel() {
     unsigned int i;
     char* p;
 
-    p = (char*)(((long long)(int)(self + 0x874)));
+    p = (char*)(self + 0x874);
     list = ((char**)p)[0];
     node = ((char**)p)[1];
     count = *(unsigned int*)(list + 0x24);

--- a/src/_ZN5Stage9PS_UpdateEv.cpp
+++ b/src/_ZN5Stage9PS_UpdateEv.cpp
@@ -108,7 +108,7 @@ extern u8 data_020a0de9[]; /* touch: pressed  [slot*4]   */
 extern volatile u8 data_020a0dea[]; /* touch: x        [slot*4]   */
 extern volatile u8 data_020a0deb[]; /* touch: y        [slot*4]   */
 
-#define DE8P(off) ((u8 *)((long long)(int)(data_020a0de8 + (off))))
+#define DE8P(off) ((u8 *)(data_020a0de8 + (off)))
 #define REG16(a) (*(volatile u16 *)(a))
 #define REG32(a) (*(volatile u32 *)(a))
 

--- a/src/_ZN5StageC3Ev.c
+++ b/src/_ZN5StageC3Ev.c
@@ -1,4 +1,4 @@
-#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off)))))
+#define AT(p, off) ((void *)(int)((char *)(p) + (off)))
 extern int _ZN9ActorBasenwEj(unsigned int);
 extern int _ZN9ActorBaseC1Ev(void *);
 extern int _ZN8Particle10SysTrackerC1Ev(void *);

--- a/src/_ZN5Unagi8BehaviorEv.cpp
+++ b/src/_ZN5Unagi8BehaviorEv.cpp
@@ -24,7 +24,7 @@ struct Disp { int unused[2]; PMF pmf; };
 extern "C" unsigned char data_0209f220;
 extern void* data_ov016_02114dbc;
 
-#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p))))
+#define LA(p) ((void*)(unsigned long)((unsigned long)(p)))
 
 int Unagi::Behavior()
 {

--- a/src/_ZN6Camera8BehaviorEv.cpp
+++ b/src/_ZN6Camera8BehaviorEv.cpp
@@ -42,9 +42,9 @@ int Camera::Behavior()
     *(s32 *)(c + 0xd4) = *(s32 *)(c + 0x8c);
     *(s32 *)(c + 0xd8) = *(s32 *)(c + 0x90);
     *(s32 *)(c + 0xdc) = *(s32 *)(c + 0x94);
-    *(u32 *)(((int)c + 0x154)) &= ~0x1000u;
+    *(u32 *)((int)c + 0x154) &= ~0x1000u;
     if (*(u32 *)(c + 0x140) != (u32)&data_0208733c) {
-        *(u32 *)(((int)c + 0x154)) &= ~0x60u;
+        *(u32 *)((int)c + 0x154) &= ~0x60u;
     }
     temp_r1 = *(s32 *)(c + 0x154);
     if (!(temp_r1 & 8)) {
@@ -53,7 +53,7 @@ int Camera::Behavior()
     } else {
 block_7:
         if (temp_r1 & 0xc000) {
-            *(u32 *)((long long)(int)(c + 0x154)) &= ~0xc000u;
+            *(u32 *)(c + 0x154) &= ~0xc000u;
             _ZN6Camera11ChangeStateEPNS_5StateE(c, &data_0209b008);
         }
         *(s16 *)(c + 0x17c) = Vec3_HorzAngle(c + 0x80, c + 0x8c);
@@ -78,15 +78,15 @@ block_7:
                 if (_Z15ApproachLinear2Rsss(*(short *)(c + 0x18c), 0, 0x10) != 0) {
                     *(s16 *)(c + 0x18a) = 0;
                 } else {
-                    *(s16 *)(((long long)(int)(c + 0x18a))) =
-                        (s16)(*(s16 *)(((long long)(int)(c + 0x18a))) + 0x3000);
+                    *(s16 *)((long long)(int)(c + 0x18a)) =
+                        (s16)(*(s16 *)((long long)(int)(c + 0x18a)) + 0x3000);
                 }
             }
         }
         if (*(s16 *)(c + 0x18e) != 0) {
-            *(s16 *)(((long long)(int)(c + 0x192))) =
-                (s16)(*(s16 *)(((long long)(int)(c + 0x192))) + *(s16 *)(c + 0x194));
-            _Z15ApproachLinear2Rsss(*(short *)(((long long)(int)(c + 0x18e))), 0, *(s16 *)(c + 0x190));
+            *(s16 *)((long long)(int)(c + 0x192)) =
+                (s16)(*(s16 *)((long long)(int)(c + 0x192)) + *(s16 *)(c + 0x194));
+            _Z15ApproachLinear2Rsss(*(short *)(c + 0x18e), 0, *(s16 *)(c + 0x190));
         }
         {
             int condA = 1;
@@ -136,16 +136,16 @@ block_7:
             if (!(*(s32 *)(c + 0x154) & 1)) {
                 if (*(u8 *)(m + 0x706) != 0 || *(u8 *)(m + 0x707) != 0) {
                     if (*(s32 *)(c + 0x90) <= t2) {
-                        *(u32 *)((long long)(int)(c + 0x154)) |= 1u;
+                        *(u32 *)(c + 0x154) |= 1u;
                     }
                 }
             } else if (*(s32 *)(c + 0x90) > t2) {
-                *(u32 *)((long long)(int)(c + 0x154)) &= ~1u;
+                *(u32 *)(c + 0x154) &= ~1u;
             }
         }
     }
     {
-        u32 *pf = (u32 *)(((long long)(int)(c + 0x154)));
+        u32 *pf = (u32 *)(c + 0x154);
         *pf &= 0xfff8fdfbu;
         if (*(s32 *)(c + 0x118) != 0) {
             *(s32 *)(c + 0x118) = 0;

--- a/src/_ZN6Cannon13InitResourcesEv.cpp
+++ b/src/_ZN6Cannon13InitResourcesEv.cpp
@@ -19,7 +19,7 @@ int Cannon::InitResources()
     *(int*)(c + 0x194) = *(int*)(*(int*)(c + 0xe4) + 0x58);
     *(u8*)(c + 0x184) = *(int*)(c + 8) & 3;
     *(int*)(c + 0x174) = 0;
-    *(int*)(((long long)(int)(c + 0x60))) -= 0x50000;
+    *(int*)(c + 0x60) -= 0x50000;
     *(int*)(c + 0x15c) = *(int*)(c + 0x5c);
     *(int*)(c + 0x160) = *(int*)(c + 0x60);
     *(int*)(c + 0x164) = *(int*)(c + 0x64);
@@ -34,11 +34,11 @@ int Cannon::InitResources()
         func_ov098_0213b15c(((void *)this));
         _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x124, ((void *)this), 0xa0000, 0x12c000, 0x800004, 0);
     } else {
-        *(int*)(((long long)(int)(c + 0x60))) -= 0x190000;
+        *(int*)(c + 0x60) -= 0x190000;
         *(short*)(c + 0x17a) = *(short*)(c + 0x90);
         *(short*)(c + 0x178) = 0x2000;
         *(int*)(c + 0x180) = 2;
-        *(int*)(((long long)(int)(c + 0xb0))) &= ~1;
+        *(int*)(c + 0xb0) &= ~1;
         _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x124, ((void *)this), 0x50000, 0x12c000, 0x800004, 0);
     }
     _ZN5Model8LoadFileER13SharedFilePtr(&data_ov098_0213c91c);

--- a/src/_ZN6Eyerok8BehaviorEv.cpp
+++ b/src/_ZN6Eyerok8BehaviorEv.cpp
@@ -135,7 +135,7 @@ extern "C" int _ZN6Eyerok8BehaviorEv(char *c)
 
         {
             int o4d4 = 0x4d4;
-            u16 *p = (u16 *)(((long long)(int)(c + o4d4)));
+            u16 *p = (u16 *)(c + o4d4);
             u16 v = *p;
             char *c400 = c + 0x400;
             *p = (u16)(v + 1);

--- a/src/_ZN6Goomba8BehaviorEv.cpp
+++ b/src/_ZN6Goomba8BehaviorEv.cpp
@@ -47,7 +47,7 @@ int Goomba::Behavior()
     if (r == 0)
         return 1;
     if (r == 1) {
-        *(u32*)(((long long)(int)((char*)&unk_0b0))) |= 0x10000000;
+        *(u32*)((char*)&unk_0b0) |= 0x10000000;
         _ZN5Actor8PoofDustEv(((char*)this));
     }
     if (mGoombaType != 3 && mState != 3 &&
@@ -168,7 +168,7 @@ int Goomba::Behavior()
         int b = (unk_0b0 & 8) ? 1 : 0;
         if (b == 0) {
             if (Vec3_Dist((Vector3*)((char*)&mPosX), (Vector3*)((char*)&unk_428)) < 0xa000) {
-                *(u16*)(((long long)(int)((char*)&mStuckTimer))) += 1;
+                *(u16*)((char*)&mStuckTimer) += 1;
                 if (unk_113 < 6 && mStuckTimer == 0x1e) {
                     func_ov084_02129c9c(((char*)this));
                     unk_458 = 0x5a;

--- a/src/_ZN6Player12St_Dive_InitEv.cpp
+++ b/src/_ZN6Player12St_Dive_InitEv.cpp
@@ -18,7 +18,7 @@ int Player::St_Dive_Init()
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(p[0x6d9], data_ov002_020ff100[(r >> 4) & 1], *(Vector3*)(p + 0x74));
     _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), 0x40, 0x40000000, 0x1000, 0);
     *(unsigned char*)(p + 0x6e3) = 0;
-    int* yv = (int*)(((long long)(int)(p + 0x98)));
+    int* yv = (int*)(p + 0x98);
     *(int*)(p + 0xa8) = 0x1e000;
     yv[0] += 0xf000;
     if (*(int*)(p + 0x98) > 0x28000) *(int*)(p + 0x98) = 0x28000;

--- a/src/_ZN6Player12St_Jump_MainEv.cpp
+++ b/src/_ZN6Player12St_Jump_MainEv.cpp
@@ -25,7 +25,7 @@ int Player::St_Jump_Main()
 
   if (*(u8*)((char*)&mIsAirborne) == 0) {
     if (*(u16*)((char*)&mStateTimer) != 0) {
-      u16* q = (u16*)(((long long)(int)((char*)&mStateFlags)));
+      u16* q = (u16*)((char*)&mStateFlags);
       *q |= 0x100;
     }
     _ZN6Player11ChangeStateERNS_5StateE(((void*)this), data_ov002_02110424);
@@ -53,7 +53,7 @@ int Player::St_Jump_Main()
       {
         u32 id = _ZNK6Player14GetBodyModelIDEjb(((void*)this), *(u32*)((char*)&param1) & 0xff, 0);
         void* anim = *(void**)((char*)((void*)this) + (id << 2) + 0xdc);
-        u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50))) + 8);
+        u32 w = *(u32*)((char*)((long long)(int)((char*)anim + 0x50)) + 8);
         u16 t = (u16)(w >> 12);
         if (t == 4 || t == 0x18 || t == 0x2c) {
           _ZN5Sound9PlayBank0EjRK7Vector3(0xf, (char*)((void*)this) + 0x74);

--- a/src/_ZN6Player12St_Land_MainEv.cpp
+++ b/src/_ZN6Player12St_Land_MainEv.cpp
@@ -42,7 +42,7 @@ int Player::St_Land_Main()
     if ((u16)(temp_r3 & 0x40) == 0) {
         if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2)
             || (u16)(temp_r3 & 0x100) != 0) {
-            *(u16*)(((long long)(int)((char*)&mStateFlags))) &= ~0x100;
+            *(u16*)((char*)&mStateFlags) &= ~0x100;
             if (func_ov002_020e3078(((char*)this), data_ov002_0211055c) != 0
                 && (*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 0x400)
                 && mHorzSpeed >= 0) {
@@ -66,7 +66,7 @@ int Player::St_Land_Main()
             return func_ov002_020dde74(((char*)this));
         }
     } else {
-        *(u16*)(((long long)(int)((char*)&mStateFlags))) &= ~0x100;
+        *(u16*)((char*)&mStateFlags) &= ~0x100;
     }
 
     _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed),

--- a/src/_ZN6Player12St_Spin_InitEv.cpp
+++ b/src/_ZN6Player12St_Spin_InitEv.cpp
@@ -25,7 +25,7 @@ int Player::St_Spin_Init()
     mVertSpeed = 0x50000;
     func_ov002_020e25f0(((char*)this), 2);
   }
-  int* p = (int*)(((int)((char*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFFull);
+  int* p = (int*)((int)((char*)this) + 0x2ec);
   int old = *p;
   int** cam_ptr_ptr = &data_0209f318;
   *p = old | 0x20;

--- a/src/_ZN6Player12St_Swim_MainEv.cpp
+++ b/src/_ZN6Player12St_Swim_MainEv.cpp
@@ -186,7 +186,7 @@ int Player::St_Swim_Main()
         else var_r6 = 0;
         _Z14ApproachLinearRiii((int*)(&mPrevVertSpeed), func_ov002_020cedb0(this, 0x10000), var_r6);
         if (mStateTimer < 0xa && t4 == 0) {
-            *(unsigned char*)(((unsigned int)(char*)this + 0x6e5) & 0xFFFFFFFFFFFFFFFFULL) |= 1;
+            *(unsigned char*)((unsigned int)(char*)this + 0x6e5) |= 1;
         }
         if (mStateTimer == 0 && _ZN6Player6IsAnimEj(this, 0xa9) != 0 && _ZN6Player12FinishedAnimEv(this) != 0) {
             if (!(mStateWork & 1)) {
@@ -236,7 +236,7 @@ int Player::St_Swim_Main()
             if (has != 0) {
                 mStateStep = 8;
                 mStateTimer = 0xf0;
-                p = (int*)(((mHeldObj + 0xb0) & 0xFFFFFFFFFFFFFFFFULL));
+                p = (int*)(mHeldObj + 0xb0);
                 *p |= 0x4000;
                 _ZN6Player7SetAnimEji5Fix12IiEj(this, 0xb0, 0, 0x1000, 0);
             } else {
@@ -255,7 +255,7 @@ int Player::St_Swim_Main()
             mStateStep = 8;
             mStateTimer = 0xf0;
             _ZN6Player7SetAnimEji5Fix12IiEj(this, 0xb0, 0, 0x1000, 0);
-            p = (int*)(((mHeldObj + 0xb0) & 0xFFFFFFFFFFFFFFFFULL));
+            p = (int*)(mHeldObj + 0xb0);
             *p |= 0x4000;
             func_ov002_020bd928(this, 0x33);
             unk_6f7 = 1;
@@ -294,7 +294,7 @@ int Player::St_Swim_Main()
 
     func_ov002_020cd218(this, mPrevVertSpeed, &mHorzSpeed, &mVertSpeed);
     {
-        int* pa8 = (int*)(((unsigned int)(&mVertSpeed)) & 0xFFFFFFFFFFFFFFFFULL);
+        int* pa8 = (int*)((unsigned int)(&mVertSpeed));
         *pa8 = *pa8 + func_ov002_020ceaf4(this);
     }
     if (func_ov002_020ce5f8(this) != 0) return 1;

--- a/src/_ZN6Player12St_Walk_InitEv.cpp
+++ b/src/_ZN6Player12St_Walk_InitEv.cpp
@@ -71,7 +71,7 @@ merge:
     if (mHorzSpeed > Player_ScaleByCharFactor(((char *)this), 0x24000)) {
         mStateArg = 1;
     }
-    *(unsigned short *)(((long long)(int)((char *)&mStateFlags))) &= ~0x100;
+    *(unsigned short *)((char *)&mStateFlags) &= ~0x100;
     mIsUnderwater = 0;
     func_ov002_020d4540(((char *)this));
 

--- a/src/_ZN6Player13InitResourcesEv.cpp
+++ b/src/_ZN6Player13InitResourcesEv.cpp
@@ -157,7 +157,7 @@ Ld0:
             if ((f254 & 0x80) != 0) {
                 if ((mLoadedResourceFlags & 1) == 0) {
                     LoadSilverStarAndNumber();
-                    *(u8*)((int)(((long long)(int)(&mLoadedResourceFlags)) & 0xFFFFFFFFFFFFFFFFLL)) |= 1;
+                    *(u8*)((int)(&mLoadedResourceFlags)) |= 1;
                 }
             }
         }

--- a/src/_ZN6Player13St_Climb_MainEv.cpp
+++ b/src/_ZN6Player13St_Climb_MainEv.cpp
@@ -111,9 +111,9 @@ int Player::St_Climb_Main()
             s32 t = (u16)ang;
             s32 ti = (t >> 4) * 2;
             s16 cosv = data_02082214[ti];
-            *(s32*)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL) += (s32)(((s64)cosv * 0x64000 + 0x800) >> 12);
+            *(s32*)(c + 0x5c) += (s32)(((s64)cosv * 0x64000 + 0x800) >> 12);
             s16 sinv = data_02082214[ti + 1];
-            *(s32*)(((long long)(int)(c + 0x64)) & 0xFFFFFFFFFFFFFFFFLL) += (s32)(((s64)sinv * 0x64000 + 0x800) >> 12);
+            *(s32*)(c + 0x64) += (s32)(((s64)sinv * 0x64000 + 0x800) >> 12);
             _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
             return 1;
         }
@@ -150,7 +150,7 @@ int Player::St_Climb_Main()
                     if (fx2 >= 0x4000) fx2 = 0x4000;
                     {
                         s32 modelIdx = GetBodyModelID((u8)(*(s32*)(c + 8)), 0);
-                        char* p2 = (char*)(((long long)(int)(*(char**)(c + modelIdx * 4 + 0xdc) + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+                        char* p2 = (char*)((long long)(int)(*(char**)(c + modelIdx * 4 + 0xdc) + 0x50));
                         *(s32*)(p2 + 0xc) = fx2;
                     }
                     *(u8*)(c + 0x6e5) = 0;
@@ -171,7 +171,7 @@ int Player::St_Climb_Main()
                     s32 fx = (s32)(((s64)mag * val + 0x800) >> 12);
                     func_ov002_020bf340(c, (s32*)(c + 0xa8), -0x800, fx);
                 }
-                *(s16*)(((long long)(int)(c + 0x69c)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x40;
+                *(s16*)(c + 0x69c) -= 0x40;
                 {
                     u32 idx4 = (u32)data_020a0e40 * 0x18;
                     s16 av = *(s16*)((char*)data_0209f4a4 + idx4);
@@ -236,11 +236,11 @@ tail:
         func_ov002_020cb474(c);
     }
     {
-        s16* p8e = (s16*)(((long long)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL);
+        s16* p8e = (s16*)(c + 0x8e);
         *p8e = (s16)(*p8e + *(s16*)(c + 0x69c));
     }
     {
-        s32* p688 = (s32*)(((long long)(int)(c + 0x688)) & 0xFFFFFFFFFFFFFFFFLL);
+        s32* p688 = (s32*)(c + 0x688);
         *p688 += *(s32*)(c + 0xa8);
     }
     if (func_ov002_020cbea8(c)) {

--- a/src/_ZN6Player13St_Shell_MainEv.cpp
+++ b/src/_ZN6Player13St_Shell_MainEv.cpp
@@ -87,14 +87,14 @@ int Player::St_Shell_Main()
         }
         func_ov002_020c04e0(((char*)this));
         if (mIsAirborne != 0) {
-            (*(u8*)(((long long)(int)((char*)&mStateStep))))++;
+            (*(u8*)((char*)&mStateStep))++;
             mIsAirborne = 1;
             mLandSoundPlayed = 0;
         }
         {
             int off = data_020a0e40 * 0x18;
             if (*(u16*)((char*)data_0209f49e + off) & 2) {
-                (*(u8*)(((long long)(int)((char*)&mStateStep))))++;
+                (*(u8*)((char*)&mStateStep))++;
                 mVertSpeed = (mHorzSpeed >> 2) + 0x2a000;
                 mIsAirborne = 1;
                 mLandSoundPlayed = 0;

--- a/src/_ZN6Player14St_Cannon_MainEv.cpp
+++ b/src/_ZN6Player14St_Cannon_MainEv.cpp
@@ -48,7 +48,7 @@ int Player::St_Cannon_Main()
         mStateStep = 2;
         mOpacity = 0x1f;
         mIsBodyClsnEnabled = 1;
-        *(int*)(((long long)(int)((char*)&mMovingCylinderClsnWithPos.flags))) |= 0x20;
+        *(int*)((char*)&mMovingCylinderClsnWithPos.flags) |= 0x20;
         func_0200d6f0(p, mPlayerNo);
         func_02012694(0x14f, ((char*)this) + 0x74);
         _ZN5Sound9PlayBank0EjRK7Vector3(0xb9, ((char*)this) + 0x74);
@@ -78,7 +78,7 @@ int Player::St_Cannon_Main()
             mStateStep = 3;
             return 1;
         }
-        *(int*)(((long long)(int)((char*)&mHorzSpeed))) -= 0x80;
+        *(int*)((char*)&mHorzSpeed) -= 0x80;
         if (mHorzSpeed < 0xa000)
             mHorzSpeed = 0xa000;
         if (mVertSpeed >= 0)

--- a/src/_ZN6Player14St_Squish_MainEv.cpp
+++ b/src/_ZN6Player14St_Squish_MainEv.cpp
@@ -51,13 +51,13 @@ int Player::St_Squish_Main()
                 }
             } else {
                 mStateTimer = 0xa;
-                (*(u8 *)(int)(((long long)(int)((char *)&mStateStep))))++;
+                (*(u8 *)(int)((char *)&mStateStep))++;
             }
         }
         break;
     case 1:
         if (mStateTimer != 0) {
-            (*(int *)(int)(((long long)(int)((char *)&mScaleY)))) += 0x100;
+            (*(int *)(int)((char *)&mScaleY)) += 0x100;
             if (mScaleY > 0x1000)
                 mScaleY = 0x1000;
         } else {
@@ -73,7 +73,7 @@ int Player::St_Squish_Main()
                 func_ov002_020db8bc(((char *)this), 1);
                 _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0211013c);
             } else {
-                (*(u8 *)(int)(((long long)(int)((char *)&mStateStep))))++;
+                (*(u8 *)(int)((char *)&mStateStep))++;
                 mStateArg = 0;
             }
         }
@@ -92,7 +92,7 @@ int Player::St_Squish_Main()
         if (data_ov002_0211117c != 0)
             break;
         KillPlayer();
-        (*(u8 *)(int)(((long long)(int)((char *)&mStateArg))))++;
+        (*(u8 *)(int)((char *)&mStateArg))++;
         break;
     case 4:
         if (mStateTimer != 0)

--- a/src/_ZN6Player14St_Thrown_MainEv.cpp
+++ b/src/_ZN6Player14St_Thrown_MainEv.cpp
@@ -25,7 +25,7 @@ extern int data_ov002_0211013c[];
 int Player::St_Thrown_Main()
 {
     if (mStateTimer == 1) {
-        *(int*)(((int)((char*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFFULL) |= 0x2000;
+        *(int*)((int)((char*)this) + 0x2ec) |= 0x2000;
     }
     func_ov002_020bf90c(((char*)this));
 
@@ -34,7 +34,7 @@ int Player::St_Thrown_Main()
     case 0:
         if (mIsAirborne == 0) {
             mAngleX = 0;
-            *(int*)(((int)((char*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFFULL) &= ~0x2000;
+            *(int*)((int)((char*)this) + 0x2ec) &= ~0x2000;
             func_ov002_020c06fc(((char*)this), 0x8000);
             if (mStateArg == 0) {
                 mStateArg = 1;

--- a/src/_ZN6Player15St_DeadPit_MainEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_MainEv.cpp
@@ -49,7 +49,7 @@ int Player::St_DeadPit_Main()
     case 3: {
         func_ov002_020c0108(((char*)this), 0);
         u32 snd = _ZN5Sound8PlayLongEjjjRK7Vector3s(mLoopingSoundHandle, 0, 0x10a, (int*)((char*)&mCamSpacePosX), 0);
-        int* p = (int*)(((long long)(int)((char*)&mSinkDepth)));
+        int* p = (int*)((char*)&mSinkDepth);
         mLoopingSoundHandle = snd;
         *p += 0x5000;
         if (mStateWork == 0) {

--- a/src/_ZN6Player15St_Grabbed_InitEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_InitEv.cpp
@@ -11,7 +11,7 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsign
 int Player::St_Grabbed_Init()
 {
   func_ov002_020da9d4(((char*)this));
-  *(int*)(int)(((unsigned long long)(int)((char*)&mMovingCylinderClsnWithPos.flags)) & 0xFFFFFFFFFFFFFFFFull) |= 2;
+  *(int*)(int)((char*)&mMovingCylinderClsnWithPos.flags) |= 2;
   mIsBodyClsnEnabled = 0;
   unk_716 = 1;
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, (void*)((char*)&mCamSpacePosX));

--- a/src/_ZN6Player15St_Grabbed_MainEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_MainEv.cpp
@@ -25,7 +25,7 @@ int Player::St_Grabbed_Main()
         if (isBob != 0) {
             ret = func_ov002_020beb38(((char*)this));
             if (ret != 0) {
-                p = (u8*)(int)(((long long)(int)((char*)&mStateStep)));
+                p = (u8*)(int)((char*)&mStateStep);
                 *p = (u8)(*p + ret);
                 mStateTimer = 6;
                 if ((s16)(mStateStep - ret) < 0) {

--- a/src/_ZN6Player15St_Hurt_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Hurt_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Hurt_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mFlags))) &= ~0x80;
+    *(unsigned int *)((char *)&mFlags) &= ~0x80;
     return 1;
 }

--- a/src/_ZN6Player15St_Spin_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Spin_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Spin_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x20;
+    *(unsigned int *)((char *)&mMovingCylinderClsnWithPos.flags) &= ~0x20;
     return 1;
 }

--- a/src/_ZN6Player15St_Swallow_MainEv.cpp
+++ b/src/_ZN6Player15St_Swallow_MainEv.cpp
@@ -56,7 +56,7 @@ L653c:
         if (b_c2 || *(int*)((char*)data_0209ee90 + 0x238) != 0) {
             flag |= 1;
         }
-        *(unsigned char*)(((long long)(int)((char*)&mEggParams))) |= (flag + 1);
+        *(unsigned char*)((char*)&mEggParams) |= (flag + 1);
     }
     func_ov002_020d6368(((char*)this));
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x100, ((char*)this) + 0x74);
@@ -65,7 +65,7 @@ L65e4:
     *(void**)((char*)&mObjInMouth) = 0;
 L65ec:
     if (mIsUnderwater != 0) {
-        *(int*)(((long long)(int)((char*)&mVertSpeed))) += func_ov002_020ceaf4(((char*)this));
+        *(int*)((char*)&mVertSpeed) += func_ov002_020ceaf4(((char*)this));
     }
     if (_ZN6Player12FinishedAnimEv(((char*)this))) {
         if (mIsUnderwater != 0) {

--- a/src/_ZN6Player15St_Talk_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Talk_CleanupEv.cpp
@@ -23,12 +23,12 @@ int Player::St_Talk_Cleanup()
 {
     void* p = *(void**)((char*)&mTalkActor);
     if (p) {
-        *(u32*)(((long long)(int)((char*)p + 0xb0))) &= ~0x800000;
+        *(u32*)((char*)p + 0xb0) &= ~0x800000;
         *(void**)((char*)&mTalkActor) = 0;
     }
     mFlags &= ~0x800000;
     data_0209b454 &= ~0x800000;
-    *(u32*)(((long long)(int)((char*)data_0209f318 + 0x154))) &= ~8;
+    *(u32*)((char*)data_0209f318 + 0x154) &= ~8;
     if (unk_725) {
         _ZN5Sound22LoadAndSetMusic_Layer1Ei(0x39);
         unk_725 = 0;

--- a/src/_ZN6Player16St_BurnFire_MainEv.cpp
+++ b/src/_ZN6Player16St_BurnFire_MainEv.cpp
@@ -58,7 +58,7 @@ int Player::St_BurnFire_Main()
         }
     }
 
-    *(u8 *)(((long long)(int)&mStateWork) & 0xFFFFFFFFFFFFFFFFLL) += 2;
+    *(u8 *)(&mStateWork) += 2;
 
     {
         struct Info {
@@ -93,13 +93,13 @@ int Player::St_BurnFire_Main()
                integer cast -- (int)this + 0x6e5, rather than
                (int)((char*)this + 0x6e5) -- and naming the field costs 4
                bytes. Both spellings were built and compared. */
-            *(u8 *)(((long long)((int)this + 0x6e5)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+            *(u8 *)((long long)((int)this + 0x6e5)) += 1;
         }
         if (mIsAirborne == 0) {
             mStateStep = 1;
             _ZN6Player7SetAnimEji5Fix12IiEj(this, 0x3f, 0, 0x1000, 0);
             {
-                char *anim = (char *)(((long long)(int)(*(char **)((char *)&mBodyModels + (_ZNK6Player14GetBodyModelIDEjb(this, param1 & 0xff, 0) << 2)) + 0x50)) & 0xffffffffffffffffLL);
+                char *anim = (char *)(*(char **)((char *)&mBodyModels + (_ZNK6Player14GetBodyModelIDEjb(this, param1 & 0xff, 0) << 2)) + 0x50);
                 *(int *)(anim + 0xc) = 0x4000;
             }
         }
@@ -125,7 +125,7 @@ int Player::St_BurnFire_Main()
         }
         _ZN6Player7SetAnimEji5Fix12IiEj(this, 0x3f, 0, 0x1000, 0);
         {
-            char *anim = (char *)(((long long)(int)(*(char **)((char *)&mBodyModels + (_ZNK6Player14GetBodyModelIDEjb(this, param1 & 0xff, 0) << 2)) + 0x50)) & 0xffffffffffffffffLL);
+            char *anim = (char *)(*(char **)((char *)&mBodyModels + (_ZNK6Player14GetBodyModelIDEjb(this, param1 & 0xff, 0) << 2)) + 0x50);
             *(int *)(anim + 0xc) = 0x4000;
         }
         {

--- a/src/_ZN6Player16St_DebugFly_MainEv.cpp
+++ b/src/_ZN6Player16St_DebugFly_MainEv.cpp
@@ -30,9 +30,9 @@ int Player::St_DebugFly_Main()
     idx = data_020a0e40;
     flags = *(u16 *)(data_0209f49c + idx * 0x18);
     if (flags & 2) {
-        *(int *)(((long long)(int)((char *)&mPosY))) += 0x28000;
+        *(int *)((char *)&mPosY) += 0x28000;
     } else if (flags & 1) {
-        *(int *)(((long long)(int)((char *)&mPosY))) -= 0x28000;
+        *(int *)((char *)&mPosY) -= 0x28000;
     }
 
     if (*(u16 *)(data_020a0e5a + idx * 4) & 0x400) {

--- a/src/_ZN6Player17St_Cannon_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Cannon_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Cannon_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x20;
+    *(unsigned int *)((char *)&mMovingCylinderClsnWithPos.flags) &= ~0x20;
     return 1;
 }

--- a/src/_ZN6Player17St_Headstand_MainEv.cpp
+++ b/src/_ZN6Player17St_Headstand_MainEv.cpp
@@ -48,7 +48,7 @@ int Player::St_Headstand_Main()
         }
         func_ov002_020cc05c(((char*)this), mag);
         {
-            s16* p = (s16*)((((long long)(int)((char*)&mAngleY))));
+            s16* p = (s16*)((char*)&mAngleY);
             *p = *p + mAngleYSpeed;
         }
         if (*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) {

--- a/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
@@ -50,7 +50,7 @@ int Player::St_HoldHeavy_Main()
                 if (_ZNK9Animation12WillHitFrameEi(animPtr, 6)) {
                     int* heavy = *(int**)((char*)&mHeldObj);
                     if (heavy != 0) {
-                        *(int*)(((long long)(int)((char*)heavy + 0xb0))) |= 0x4000;
+                        *(int*)((char*)heavy + 0xb0) |= 0x4000;
                     }
                 }
             }

--- a/src/_ZN6Player17St_HoldLight_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_MainEv.cpp
@@ -61,7 +61,7 @@ int Player::St_HoldLight_Main()
                 if (_ZNK9Animation12WillHitFrameEi(anim, 6)) {
                     int* light = *(int**)((char*)&mHeldObj);
                     if (light != 0) {
-                        int* p = (int*)(((long long)(int)((char*)light + 0xb0)));
+                        int* p = (int*)((char*)light + 0xb0);
                         *p |= 0x4000;
                     }
                 }

--- a/src/_ZN6Player17St_PunchKick_MainEv.cpp
+++ b/src/_ZN6Player17St_PunchKick_MainEv.cpp
@@ -37,7 +37,7 @@ int Player::St_PunchKick_Main()
             u8 idx = data_020a0e40;
             u16 flags = *(u16*)((char*)data_0209f49e + idx * 0x18);
             if ((flags & 1) != 0 && mPunchKickStep < 2) {
-                u8* p = (u8*)(((long long)(int)((char*)&mPunchKickStep)));
+                u8* p = (u8*)((char*)&mPunchKickStep);
                 (*p)++;
                 _ZN6Player17St_PunchKick_InitEv(((char*)this));
                 return 1;

--- a/src/_ZN6Player17St_Squish_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Squish_CleanupEv.cpp
@@ -14,6 +14,6 @@ int Player::St_Squish_Cleanup()
     mScaleY = val;
     mScaleZ = val;
 
-    *(int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~4;
+    *(int *)((char *)&mMovingCylinderClsnWithPos.flags) &= ~4;
     return 1;
 }

--- a/src/_ZN6Player17St_Thrown_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Thrown_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Thrown_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x2000;
+    *(unsigned int *)((char *)&mMovingCylinderClsnWithPos.flags) &= ~0x2000;
     return 1;
 }

--- a/src/_ZN6Player18St_LevelEnter_InitEv.cpp
+++ b/src/_ZN6Player18St_LevelEnter_InitEv.cpp
@@ -100,12 +100,12 @@ int Player::St_LevelEnter_Init()
         s32 idx;
         s16 cosv, sinv;
         if (func_ov002_020c7cbc(((char*)this)) != 0) mStateStep = 0x12;
-        *(int*)(((long long)(int)((char*)&mPosY))) += 0x64000;
+        *(int*)((char*)&mPosY) += 0x64000;
         idx = ((s32)(u16)(s16)(mAngleY + 0x8000) >> 4) * 2;
         cosv = data_02082214[idx];
         sinv = data_02082214[idx + 1];
-        *(int*)(((long long)(int)((char*)&mPosX))) += (int)(((s64)0xa0000 * cosv + 0x800) >> 12);
-        *(int*)(((long long)(int)((char*)&mPosZ))) += (int)(((s64)0xa0000 * sinv + 0x800) >> 12);
+        *(int*)((char*)&mPosX) += (int)(((s64)0xa0000 * cosv + 0x800) >> 12);
+        *(int*)((char*)&mPosZ) += (int)(((s64)0xa0000 * sinv + 0x800) >> 12);
         mStateTimer = 0x20;
         mStateArg = 1;
         mVertAccel = 0;

--- a/src/_ZN6Player18St_YoshiPower_MainEv.cpp
+++ b/src/_ZN6Player18St_YoshiPower_MainEv.cpp
@@ -82,7 +82,7 @@ int Player::St_YoshiPower_Main()
             int t4 = (*(int*)((char*)*(void**)(&unk_160) + 0x58) >> 0xc) << 0x10;
             int id0 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
             dp = (char*)*(void**)(c + (id0<<2) + 0xdc);
-            dp = (char*)(((long long)(int)(dp + 0x50)));
+            dp = (char*)(dp + 0x50);
             *(unsigned int*)(dp + 8) = (unsigned int)t4 >> 4;
             mStateArg = 1;
         }
@@ -117,7 +117,7 @@ int Player::St_YoshiPower_Main()
             }
             int id2 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
             if (_ZNK9Animation12WillHitFrameEi((char*)*(void**)(c + (id2<<2) + 0xdc) + 0x50, 0xa) != 0) {
-                Vec3* src = (Vec3*)(((int)c + 0x5c));
+                Vec3* src = (Vec3*)((int)c + 0x5c);
                 dp = (char*)*(void**)(&mObjInMouth);
                 *(int*)(dp+0x5c) = src->x;
                 *(int*)(dp+0x60) = src->y;
@@ -125,13 +125,13 @@ int Player::St_YoshiPower_Main()
                 Obj* o = *(Obj**)(&mObjInMouth);
                 int cond = (*(unsigned short*)((char*)o+0xc) == 0xbf);
                 if (cond != 0) {
-                    *(int*)(((int)o + 0xb0)) &= ~0x20000;
+                    *(int*)((int)o + 0xb0) &= ~0x20000;
                     if (func_ov002_020d5ed0(*(void**)(&mObjInMouth)) == 0) {
                         func_ov002_020d718c(c);
                     }
                 } else {
-                    *(int*)(((int)o + 0xb0)) |= 0x40000;
-                    *(int*)(((int)*(void**)(&mObjInMouth) + 0xb0)) &= ~0x20000;
+                    *(int*)((int)o + 0xb0) |= 0x40000;
+                    *(int*)((int)*(void**)(&mObjInMouth) + 0xb0) &= ~0x20000;
                     if ((*(Obj**)(&mObjInMouth))->v18() == 4 || (*(Obj**)(&mObjInMouth))->v18() == 2) {
                         mStateStep = 3;
                         int f2 = 1;
@@ -189,7 +189,7 @@ int Player::St_YoshiPower_Main()
             return 1;
         }
         int id4 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
-        int* a50b = (int*)(((long long)(int)((char*)*(void**)(c + (id4<<2) + 0xdc) + 0x50)));
+        int* a50b = (int*)((long long)(int)((char*)*(void**)(c + (id4<<2) + 0xdc) + 0x50));
         if ((unsigned short)(a50b[2] >> 0xc) == 0) {
             if (mIsAirborne != 0) {
                 _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021101b4);
@@ -223,7 +223,7 @@ int Player::St_YoshiPower_Main()
             mUseAltBodyModel = z;
             if (mUseAltBodyModel == 0) {
                 int id6 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, z);
-                int* a50c = (int*)(((long long)(int)((char*)*(void**)(c + (id6<<2) + 0xdc) + 0x50)));
+                int* a50c = (int*)((long long)(int)((char*)*(void**)(c + (id6<<2) + 0xdc) + 0x50));
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(&unk_160), (void*)data_ov002_0210e3d8[1], 0x40000000, 0x1000, (unsigned int)(a50c[2] << 4) >> 0x10);
             }
         }
@@ -234,10 +234,10 @@ int Player::St_YoshiPower_Main()
                 int cond3 = (*(unsigned short*)((char*)obj0+0xc) == 0xbf);
                 if (cond3 != 0) {
                     func_ov002_020d5cec(obj0);
-                    *(unsigned short*)(((int)c + 0x6ce)) &= ~2;
+                    *(unsigned short*)((int)c + 0x6ce) &= ~2;
                 } else {
-                    *(int*)(((int)obj0 + 0xb0)) |= 0x80000;
-                    *(int*)(((int)*(void**)(&mObjInMouth) + 0xb0)) &= ~0x40000;
+                    *(int*)((int)obj0 + 0xb0) |= 0x80000;
+                    *(int*)((int)*(void**)(&mObjInMouth) + 0xb0) &= ~0x40000;
                 }
             }
             *(void**)(&mObjInMouth) = 0;
@@ -253,7 +253,7 @@ int Player::St_YoshiPower_Main()
     case 5: {
         if (mStateTimer != 0) {
             int id8 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
-            int* a50d = (int*)(((long long)(int)((char*)*(void**)(c + (id8<<2) + 0xdc) + 0x50)));
+            int* a50d = (int*)((long long)(int)((char*)*(void**)(c + (id8<<2) + 0xdc) + 0x50));
             if (((unsigned int)(a50d[2] << 4) >> 0x10) >= 4) {
                 int i2 = (*(unsigned short*)&mAngleY >> 4) * 2;
                 short* tbl = data_02082214;
@@ -265,7 +265,7 @@ int Player::St_YoshiPower_Main()
                 dir.x = data_02082214[(*(unsigned short*)&mAngleY >> 4) * 2];
                 dir.y = 0;
                 dir.z = data_02082214[(*(unsigned short*)&mAngleY >> 4) * 2 + 1];
-                *(void**)(&unk_628) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(void**)(&unk_628), 0x13c, pos.x, pos.y, pos.z, (Vec3s*)(((int)&dir)), 0);
+                *(void**)(&unk_628) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(void**)(&unk_628), 0x13c, pos.x, pos.y, pos.z, (Vec3s*)((int)&dir), 0);
                 *(void**)(&mParticle2) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(void**)(&mParticle2), 0x13d, pos.x, pos.y, pos.z, &dir, 0);
                 func_ov002_020dc09c(c);
                 _ZN12CylinderClsn5ClearEv(&mAttackClsn);
@@ -274,7 +274,7 @@ int Player::St_YoshiPower_Main()
                     int z2 = 0;
                     mUseAltBodyModel = z2;
                     int id9 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, z2);
-                    int* a50e = (int*)(((long long)(int)((char*)*(void**)(c + (id9<<2) + 0xdc) + 0x50)));
+                    int* a50e = (int*)((long long)(int)((char*)*(void**)(c + (id9<<2) + 0xdc) + 0x50));
                     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(&unk_160), (void*)data_ov002_0210e3d8[1], 0x40000000, 0x1000, (unsigned int)(a50e[2] << 4) >> 0x10);
                 }
                 return 1;

--- a/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
@@ -23,6 +23,6 @@ int Player::St_CrazedCrate_Init()
   _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x43, 0x40000000, 0x1000, 0);
   func_ov002_020e0f38(((char*)this), mJumpComboStage);
   mPrevAngleY = mAngleY;
-  *(int*)(((long long)(int)((char*)&mMovingCylinderClsnWithPos.flags))) |= 0x20;
+  *(int*)((char*)&mMovingCylinderClsnWithPos.flags) |= 0x20;
   return 1;
 }

--- a/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
@@ -38,12 +38,12 @@ int Player::St_CrazedCrate_Main() {
             t += 0x8000;
             *(s16*)(self + 0x8e) = t;
             int half = 0x800;
-            int* xpos = (int*)(int)(((long long)(int)(self + 0x5c)));
+            int* xpos = (int*)(int)(self + 0x5c);
             int* zpos;
             *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);
             *xpos += (int)(((s64)*(int*)(self + 0x98)
                      * data_02082214[(((int)*(u16*)(self + 0x94) >> 4) << 1) + 1] + half) >> 12);
-            zpos = (int*)(int)(((long long)(int)(self + 0x64)));
+            zpos = (int*)(int)(self + 0x64);
             *zpos += (int)(((s64)*(int*)(self + 0x98)
                      * data_02082214[((int)*(u16*)(self + 0x94) >> 4) << 1] + half) >> 12);
         }
@@ -53,7 +53,7 @@ int Player::St_CrazedCrate_Main() {
 
     if (*(u8*)(self + 0x6de) == 0) {
         if (*(u8*)(self + 0x6e1) < 2) {
-            (*(u8*)(int)(((long long)(int)(self + 0x6e1))))++;
+            (*(u8*)(int)(self + 0x6e1))++;
             func_ov002_020e0f38(self, *(u8*)(self + 0x6e1));
         } else {
             if (*(int*)(self + 8) == 3) {

--- a/src/_ZN6Player19St_SwingPlayer_InitEv.cpp
+++ b/src/_ZN6Player19St_SwingPlayer_InitEv.cpp
@@ -15,7 +15,7 @@ int Player::St_SwingPlayer_Init()
   {
     void* obj = *(void**)((char*)&mHeldObj);
     if (obj != 0)
-      *(int*)(((long long)(int)((char*)obj+0xb0))) |= 0x800;
+      *(int*)((char*)obj+0xb0) |= 0x800;
   }
   return 1;
 }

--- a/src/_ZN6Player20RegisterEggCoinCountEjbb.cpp
+++ b/src/_ZN6Player20RegisterEggCoinCountEjbb.cpp
@@ -8,7 +8,7 @@ void Player::RegisterEggCoinCount(unsigned int count, bool b2, bool b3)
 {
 	mEggParams = (count & 0xf) << 2;
 	if (b3)
-		*(unsigned char *)(((long long)(int)((char*)&mEggParams))) |= 0x40;
+		*(unsigned char *)((char*)&mEggParams) |= 0x40;
 	if (b2)
-		*(unsigned char *)(((long long)(int)((char*)&mEggParams))) |= 0x80;
+		*(unsigned char *)((char*)&mEggParams) |= 0x80;
 }

--- a/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
@@ -63,14 +63,14 @@ int Player::St_CeilingGrate_Main()
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[mStateWork & 1], 0, 0x1000, 0);
         }
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc) + 0x50)));
+            char* anim = (char*)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc) + 0x50);
             if ((u32)(*(int*)(anim + 8) << 4) >> 0x10 < 0x21)
                 break;
         }
     case 1:
         func_ov002_020cf384(((char*)this));
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-            *(u8*)(((int)((char*)this) + 0x6e5)) ^= 1;
+            *(u8*)((int)((char*)this) + 0x6e5) ^= 1;
             mStateStep = 2;
             spd = mHorzSpeed >> 3;
             if (spd < 0x800)
@@ -84,13 +84,13 @@ int Player::St_CeilingGrate_Main()
         if (spd < 0x800)
             spd = 0x800;
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc) + 0x50)));
+            char* anim = (char*)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), param1 & 0xff, 0) << 2) + 0xdc) + 0x50);
             *(int*)(anim + 0xc) = spd;
         }
         if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
             _ZN5Sound9PlayBank0EjRK7Vector3(0xb2, ((char*)this) + 0x74);
             if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-                *(u8*)(((int)((char*)this) + 0x6e5)) ^= 1;
+                *(u8*)((int)((char*)this) + 0x6e5) ^= 1;
                 _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[(mStateWork & 1) + 2], 0x40000000, 0x1000, 0);
             } else {
                 mStateStep = 1;

--- a/src/_ZN6Player20St_HoldLight_CleanupEv.cpp
+++ b/src/_ZN6Player20St_HoldLight_CleanupEv.cpp
@@ -8,7 +8,7 @@ int Player::St_HoldLight_Cleanup()
 {
   char* p = *(char**)((char*)&mHeldObj);
   if (p) {
-    *(unsigned int*)(((long long)(int)(p + 0xb0))) |= 0x4000;
+    *(unsigned int*)(p + 0xb0) |= 0x4000;
   }
   return 1;
 }

--- a/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
@@ -17,7 +17,7 @@ int Player::St_InYoshiMouth_Init()
     r3 = 0;
     mStateWork = (unsigned char)r3;
     unk_6e6 = (unsigned char)r3;
-    slot = (char *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags)));
+    slot = (char *)((char *)&mMovingCylinderClsnWithPos.flags);
     r1 = *(unsigned int *)slot;
     r1 |= 2u;
     *(unsigned int *)slot = r1;

--- a/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
@@ -31,7 +31,7 @@ int Player::St_InYoshiMouth_Main()
                     return 1;
             }
             {
-                int *p = (int *)(int)(((long long)(int)(r4 + 0x5c)));
+                int *p = (int *)(int)(r4 + 0x5c);
                 mPosX = p[0];
                 mPosY = p[1];
                 mPosZ = p[2];
@@ -40,7 +40,7 @@ int Player::St_InYoshiMouth_Main()
             t = *(u16 *)(r4 + 0x6c6);
             if (*(u8 *)(r4 + 0x709) == 0 && *(u8 *)(r4 + 0x708) == 0) {
                 t = (u16)(t - d);
-                *(u8 *)(((long long)(int)((char *)&unk_6e6))) += d;
+                *(u8 *)((char *)&unk_6e6) += d;
                 if ((s16)t < 0)
                     t = 0;
             }
@@ -66,7 +66,7 @@ int Player::St_InYoshiMouth_Main()
         }
     case 2:
         if (mStateTimer == 0)
-            *(int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) |= 0x2000;
+            *(int *)((char *)&mMovingCylinderClsnWithPos.flags) |= 0x2000;
         if (_ZN6Player12FinishedAnimEv(((char *)this))) {
             mStateStep = 3;
             mHurtDamage = 1;
@@ -76,7 +76,7 @@ int Player::St_InYoshiMouth_Main()
     case 3:
         {
             int d = func_ov002_020beb38(((char *)this));
-            *(u16 *)(((long long)(int)((char *)&mStateTimer))) -= (d << 2);
+            *(u16 *)((char *)&mStateTimer) -= (d << 2);
             mStateWork = d;
             if ((s16)mStateTimer <= 0) {
                 mStateTimer = 0;

--- a/src/_ZN6Player20St_StomachSlide_MainEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_MainEv.cpp
@@ -40,7 +40,7 @@ int Player::St_StomachSlide_Main()
 {
     void* light0 = *(void**)((char*)&mHeldObj);
     if (light0 != 0) {
-        int* p = (int*)(((long long)(int)((char*)light0 + 0xb0)));
+        int* p = (int*)((char*)light0 + 0xb0);
         *p |= 0x4000;
     }
 
@@ -74,7 +74,7 @@ int Player::St_StomachSlide_Main()
                 goto end;
             }
             {
-                u8* p = (u8*)(((long long)(int)((char*)&mSlideStoppedTimer)));
+                u8* p = (u8*)((char*)&mSlideStoppedTimer);
                 *p = (u8)(*p + 1);
             }
             if (mSlideStoppedTimer >= 0x1e) {
@@ -133,7 +133,7 @@ int Player::St_StomachSlide_Main()
         }
         func_ov002_020dc560(((char*)this));
         {
-            u8* p = (u8*)(((long long)(int)((char*)&mStateStep)));
+            u8* p = (u8*)((char*)&mStateStep);
             *p = (u8)(*p + 1);
         }
         if (mStateStep <= 0x1e) goto end;
@@ -165,7 +165,7 @@ int Player::St_StomachSlide_Main()
             }
             mPrevAngleY = mAngleY;
             {
-                u8* p = (u8*)(((long long)(int)((char*)&mStateStep)));
+                u8* p = (u8*)((char*)&mStateStep);
                 *p = (u8)(*p + 1);
             }
             goto end;

--- a/src/_ZN6Player21St_CameraZoom_CleanupEv.cpp
+++ b/src/_ZN6Player21St_CameraZoom_CleanupEv.cpp
@@ -6,7 +6,7 @@
 
 int Player::St_CameraZoom_Cleanup()
 {
-    *(unsigned short *)(((long long)(int)((char *)&mStateFlags))) &= ~4;
+    *(unsigned short *)((char *)&mStateFlags) &= ~4;
     unk_715 = 0;
     return 1;
 }

--- a/src/_ZN6Player21St_DizzyStars_CleanupEv.cpp
+++ b/src/_ZN6Player21St_DizzyStars_CleanupEv.cpp
@@ -5,6 +5,6 @@ struct Player {
 int Player::St_DizzyStars_Cleanup()
 {
     char *self = (char *)this;
-    *(unsigned int *)(((long long)(int)(self + 0xb0))) &= ~0x80u;
+    *(unsigned int *)(self + 0xb0) &= ~0x80u;
     return 1;
 }

--- a/src/_ZN6Player21St_JumpQuicksand_MainEv.cpp
+++ b/src/_ZN6Player21St_JumpQuicksand_MainEv.cpp
@@ -13,9 +13,9 @@ extern void Player_AdvanceAnims(char *);
 int Player::St_JumpQuicksand_Main()
 {
     u8 t = mStateWork;
-    (*(u8 *)(int)(((long long)(int)((char *)&mStateWork))))++;
+    (*(u8 *)(int)((char *)&mStateWork))++;
     if (t < 6) {
-        (*(int *)(int)(((long long)(int)((char *)&mSinkDepth)))) -=
+        (*(int *)(int)((char *)&mSinkDepth)) -=
             (int)((((7 - mStateWork) << 12) * 0xcccLL + 0x800) >> 12);
         if (mSinkDepth < 0x1000)
             mSinkDepth = 0x1100;

--- a/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
+++ b/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
@@ -15,7 +15,7 @@ int Player::St_OpeningWakeUp_Main()
     case 0:
         if (_ZN6Player12FinishedAnimEv(((char*)this))) {
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xb4, 0, 0x1000, 0);
-            *(u8*)(int)(((long long)(int)((char*)&mStateStep))) += 1;
+            *(u8*)(int)((char*)&mStateStep) += 1;
         }
         break;
     case 1:
@@ -23,7 +23,7 @@ int Player::St_OpeningWakeUp_Main()
     case 2:
         if (_ZN6Player12FinishedAnimEv(((char*)this))) {
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xb5, 0, 0x1000, 0);
-            *(u8*)(int)(((long long)(int)((char*)&mStateStep))) += 1;
+            *(u8*)(int)((char*)&mStateStep) += 1;
         }
         break;
     case 3:

--- a/src/_ZN6Player22St_GroundPound_CleanupEv.cpp
+++ b/src/_ZN6Player22St_GroundPound_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_GroundPound_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&mMovingCylinderClsnWithPos.flags))) &= ~0x20;
+    *(unsigned int *)((char *)&mMovingCylinderClsnWithPos.flags) &= ~0x20;
     return 1;
 }

--- a/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
+++ b/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
@@ -8,7 +8,7 @@ int Player::St_SwingPlayer_Cleanup()
 {
   char* p = *(char**)((char*)&mHeldObj);
   if (p) {
-    *(unsigned int*)(((long long)(int)(p + 0xb0))) &= ~0x800;
+    *(unsigned int*)(p + 0xb0) &= ~0x800;
   }
   mPrevAngleY = mAngleY;
   return 1;

--- a/src/_ZN6Player24St_MetalWaterGround_InitEv.cpp
+++ b/src/_ZN6Player24St_MetalWaterGround_InitEv.cpp
@@ -17,8 +17,8 @@ int Player::St_MetalWaterGround_Init()
             int b2 = (h == 0x10b);
             if (!b2) goto tail;
         }
-        *(int*)(int)(((long long)(int)((char*)p+0xb0))) &= ~0x4000;
-        *(int*)(int)(((long long)(int)((char*)*(int**)((char*)&mHeldObj)+0xb0))) &= ~0x100;
+        *(int*)(int)((char*)p+0xb0) &= ~0x4000;
+        *(int*)(int)((char*)*(int**)((char*)&mHeldObj)+0xb0) &= ~0x100;
         *(int**)((char*)&mHeldObj) = 0;
     }
 tail:

--- a/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
+++ b/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
@@ -58,19 +58,19 @@ L9c:
         int match = (*(u16*)((char*)p360 + 0xc) == 0xbf);
         if (match) {
             func_ov002_020d5cec((char*)p360);
-            *(u16*)(((long long)(int)((char*)&self->mStateFlags))) &= ~2;
+            *(u16*)((char*)&self->mStateFlags) &= ~2;
         }
         self->mUseAltBodyModel = 0;
         {
-            int* p = (int*)(((long long)(int)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0)));
+            int* p = (int*)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0);
             *p |= 0x80000;
         }
         {
-            int* p = (int*)(((long long)(int)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0)));
+            int* p = (int*)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0);
             *p &= ~0x40000;
         }
         {
-            int* p = (int*)(((long long)(int)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0)));
+            int* p = (int*)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0);
             *p &= ~0x20000;
         }
         *(void**)((char*)&self->mObjInMouth) = 0;
@@ -92,7 +92,7 @@ L9c:
 
     ang = Vec3_HorzAngle(((char*)self) + 0x5c, a);
     if (AngleDiff(self->mAngleY, ang) > 0x4000) {
-        *(u8*)(((long long)(int)((char*)&self->mStateStep))) += 1;
+        *(u8*)((char*)&self->mStateStep) += 1;
     }
     self->mPrevAngleY = ang + 0x8000;
     if (self->mStateStep & 1) {
@@ -109,7 +109,7 @@ L9c:
 
     if (arg5 != 0) {
         u8 t = arg5 - 1;
-        *(u8*)(((long long)(int)((char*)&self->mStateStep))) |= 0x10;
+        *(u8*)((char*)&self->mStateStep) |= 0x10;
         self->mStateWork = t;
     }
 
@@ -139,7 +139,7 @@ L9c:
 
         _ZN6Player11ChangeStateERNS_5StateE(((char*)self), &data_ov002_02110094);
         if (func_ov002_020d91e0(((char*)self), b << 8, 1) != 0) {
-            *(u8*)(((long long)(int)((char*)&self->mStateStep))) &= 1;
+            *(u8*)((char*)&self->mStateStep) &= 1;
             _ZN6Player11ChangeStateERNS_5StateE(((char*)self), &data_ov002_0211010c);
         }
     } else {

--- a/src/_ZN6Player6RenderEv.cpp
+++ b/src/_ZN6Player6RenderEv.cpp
@@ -17,7 +17,7 @@ struct VObj {
 
 typedef struct M34 { int m[12]; } M34;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 #pragma opt_common_subs off
 

--- a/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
+++ b/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 #include "SharedFilePtr.h"
-#define LAUNDER16(p) ((u16 *)(int)(((long long)(int)(p))))
+#define LAUNDER16(p) ((u16 *)(int)(p))
 extern "C" {
 extern u8 data_0209f2d8;
 extern void *data_ov002_020ff480[];

--- a/src/_ZN6Player8BehaviorEv.cpp
+++ b/src/_ZN6Player8BehaviorEv.cpp
@@ -12,7 +12,7 @@ struct G_ee90 {
     s32 flag26c;
 };
 
-#define LAU(p) ((long long)(int)(p))
+#define LAU(p) (p)
 
 extern "C" {
 extern u16 DecIfAbove0_Short(u16 *p);

--- a/src/_ZN6Rabbit6RenderEv.cpp
+++ b/src/_ZN6Rabbit6RenderEv.cpp
@@ -32,7 +32,7 @@ int Rabbit::Render()
     unk_084 = unk_088;
 
     {
-        int** base = (int**)(((long long)(int)((char*)&unk_308)));
+        int** base = (int**)((char*)&unk_308);
         int* r3 = base[0];
         char* r1 = (char*)base[1];
         for (unsigned int i = 0; i < *(unsigned int*)((char*)r3 + 0x24); i++) {

--- a/src/_ZN6Rabbit8BehaviorEv.cpp
+++ b/src/_ZN6Rabbit8BehaviorEv.cpp
@@ -160,7 +160,7 @@ int Rabbit::Behavior()
                     } else if (temp_r1 == 1 && _ZN6Player12GetTalkStateEv(temp_r4) == -1) {
                         _ZN6Player9DropActorEv(temp_r4);
                         unk_427 = 2;
-                        *(u16*)(((long long)(int)((char*)temp_r4 + 0x6ce))) |= 0x800;
+                        *(u16*)((char*)temp_r4 + 0x6ce) |= 0x800;
                     }
                 }
             }
@@ -176,7 +176,7 @@ int Rabbit::Behavior()
                 _ZN12CylinderClsn6UpdateEv(&mMovingCylinderClsn);
         }
         if (unk_107 == 1) {
-            *(u8*)(((long long)(int)(c + 0x42a))) = *(u8*)(((long long)(int)(c + 0x42a))) + 1;
+            *(u8*)((long long)(int)(c + 0x42a)) = *(u8*)((long long)(int)(c + 0x42a)) + 1;
             if (unk_42a > 0x96) {
                 unk_107 = 0;
                 unk_42a = 0;

--- a/src/_ZN6ToxBox13InitResourcesEv.c
+++ b/src/_ZN6ToxBox13InitResourcesEv.c
@@ -1,7 +1,7 @@
 typedef struct { int x, y, z; } Vec3;
 typedef struct { int m[12]; } Mtx43;
 
-#define LA(p) (((long long)(int)(p)))
+#define LA(p) (p)
 
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, void *, int, int);

--- a/src/_ZN6ToxBox8BehaviorEv.cpp
+++ b/src/_ZN6ToxBox8BehaviorEv.cpp
@@ -12,7 +12,7 @@ struct ToxBox {
     int state;
 };
 
-#define LA(p) (((long long)(int)(p)))
+#define LA(p) (p)
 
 extern "C" {
 void func_ov092_02131aec(void* c);

--- a/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
+++ b/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
@@ -94,7 +94,7 @@ void Message::DisplayCourseNameForStarSelect(u32 base)
 
     data_0209d6c0 = 1;
     {
-        StarEntry* e = (StarEntry*)(int)(((long long)(int)((char*)data_0209d708 + 0x1470)));
+        StarEntry* e = (StarEntry*)(int)((char*)data_0209d708 + 0x1470);
         data_0209d6f0 = e;
         sum = data_0209d6fc + 0x28;
         sum += data_0209d70c[1];

--- a/src/_ZN7Minimap19UpdateLevelSpecificEv.cpp
+++ b/src/_ZN7Minimap19UpdateLevelSpecificEv.cpp
@@ -163,7 +163,7 @@ void Minimap::UpdateLevelSpecific()
     case 0x19: {
         u16* p;
         if (!Event::GetBit(0xe)) return;
-        p = (u16*)(((int)G2S::GetBG3CharPtr() - 0x712) & 0xFFFFFFFFFFFFFFFFULL);
+        p = (u16*)((int)G2S::GetBG3CharPtr() - 0x712);
         p[0] = 0x3fe;
         p[1] = 0x3ff;
         break;

--- a/src/_ZN8BookShot13InitResourcesEv.cpp
+++ b/src/_ZN8BookShot13InitResourcesEv.cpp
@@ -22,7 +22,7 @@ extern SharedFilePtr data_ov020_02114ab8;
 extern SharedFilePtr data_ov020_02114aa8;
 extern SharedFilePtr data_ov020_02114ab0;
 
-#define LDR(p) ((((long long)(int)(p))))
+#define LDR(p) (p)
 
 struct M48 { int w[12]; };
 extern struct M48 data_02082128;

--- a/src/_ZN8CapEnemy10ReleaseCapERK7Vector3.cpp
+++ b/src/_ZN8CapEnemy10ReleaseCapERK7Vector3.cpp
@@ -48,9 +48,9 @@ struct Actor *CapEnemy::ReleaseCap(const Vector3 & v_)
                 (const struct Vector3_16 *)&unk_08c,
                 mAreaId, -1);
             if (unk_110 != 0) {
-                *(unsigned char *)(((int)c + 0x113) & 0xFFFFFFFFFFFFFFFFull) |= 8;
+                *(unsigned char *)((int)c + 0x113) |= 8;
             } else {
-                *(unsigned char *)(((int)c + 0x113) & 0xFFFFFFFFFFFFFFFFull) |= 0x80;
+                *(unsigned char *)((int)c + 0x113) |= 0x80;
             }
         } else {
             ret = (struct Actor *)c;

--- a/src/_ZN8CapEnemy11GetCapStateEv.cpp
+++ b/src/_ZN8CapEnemy11GetCapStateEv.cpp
@@ -53,7 +53,7 @@ int CapEnemy::GetCapState() {
     }
 
     field_111 = 0;
-    field_b0 = *(int *)(((long long)(int)&field_f4) & 0xFFFFFFFFFFFFFFFFLL);
-    *(unsigned char *)(((int)this + 0x113) & 0xFFFFFFFFFFFFFFFFULL) &= 7;
+    field_b0 = *(int *)((long long)(int)&field_f4);
+    *(unsigned char *)((int)this + 0x113) &= 7;
     return 1;
 }

--- a/src/_ZN8CapEnemy12Unk_02005d94Ev.cpp
+++ b/src/_ZN8CapEnemy12Unk_02005d94Ev.cpp
@@ -17,7 +17,7 @@ void CapEnemy::Unk_02005d94()
         b2 = (q[0] == 1) ? 1 : 0;
         if (b2 == 0) return;
     }
-    *(unsigned char *)(((int)((unsigned char *)this) + 0x113) & 0xFFFFFFFFFFFFFFFFULL) &= 7;
+    *(unsigned char *)((int)((unsigned char *)this) + 0x113) &= 7;
     if (func_02005e28(((unsigned char *)this)))
-        *(unsigned char *)(((int)((unsigned char *)&mCapId)) & 0xFFFFFFFFFFFFFFFFULL) |= 0x80;
+        *(unsigned char *)((int)((unsigned char *)&mCapId)) |= 0x80;
 }

--- a/src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp
+++ b/src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp
@@ -27,7 +27,7 @@ struct Actor * CapEnemy::RespawnIfHasCap()
     *(int *)((char *)r + 0xf4) = *(int *)((char *)r + 0xb0);
     *(unsigned char *)((char *)r + 0x108) = 0;
     {
-        int *p = (int *)((unsigned long long)((char *)r + 0xb0) & 0xFFFFFFFFFFFFFFFFULL);
+        int *p = (int *)((unsigned long long)((char *)r + 0xb0));
         *p &= ~1;
         *p &= ~0x10000000;
     }

--- a/src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -5,7 +5,7 @@
 extern "C" {
 void _ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__Acceleration *self, char* p, int* vec) {
   vec[0] += (int)self->unk_000;
-  *(int*)(((long long)(int)(vec+1))) += (int)self->unk_002;
-  *(int*)(((long long)(int)(vec+2))) += (int)self->unk_004;
+  *(int*)(vec+1) += (int)self->unk_002;
+  *(int*)(vec+2) += (int)self->unk_004;
 }
 }

--- a/src/_ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb.cpp
@@ -17,7 +17,7 @@ int _ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb(char *self, char *sys, int
     int result;
 
     if (*(unsigned char *)(self + 4) == 0) {
-        *(int *)(((long long)(int)(sys + 0x1c))) |= 2;
+        *(int *)(sys + 0x1c) |= 2;
         node = *(char **)(sys + 8);
         while (node != 0) {
             *(unsigned short *)(node + 0x2e) = *(unsigned short *)(node + 0x2c);
@@ -25,7 +25,7 @@ int _ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb(char *self, char *sys, int
         }
         return 1;
     } else {
-        *(int *)(((long long)(int)(sys + 0x1c))) &= ~2;
+        *(int *)(sys + 0x1c) &= ~2;
         node = *(char **)(sys + 8);
         while (node != 0) {
             wp.x = *(int *)(node + 0x14) + *(int *)(node + 0x8);
@@ -45,9 +45,9 @@ int _ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb(char *self, char *sys, int
                         cv.x = (cv.x < 0) ? 0x20000 : -0x20000;
                     }
                     MulVec3Mat4x3(&cv, &data_0209b41c, &out);
-                    *(int *)(((long long)(int)(node + 0x14))) += out.x - wp.x;
-                    *(int *)(((long long)(int)(node + 0x18))) += out.y - wp.y;
-                    *(int *)(((long long)(int)(node + 0x1c))) += out.z - wp.z;
+                    *(int *)(node + 0x14) += out.x - wp.x;
+                    *(int *)(node + 0x18) += out.y - wp.y;
+                    *(int *)(node + 0x1c) += out.z - wp.z;
                 }
             }
             node = *(char **)node;

--- a/src/_ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -4,8 +4,8 @@
 #include "Particle__RadiusConverge.h"
 extern "C" {
 void _ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__RadiusConverge *self, char* p, int* vec) {
-  *(int*)(((long long)(int)(p+0x14))) += (int)((((long long)self->unk_00c * (self->unk_000 - *(int*)(p+0x14))) + 0x800) >> 12);
-  *(int*)(((long long)(int)(p+0x18))) += (int)((((long long)self->unk_00c * (self->unk_004 - *(int*)(p+0x18))) + 0x800) >> 12);
-  *(int*)(((long long)(int)(p+0x1c))) += (int)((((long long)self->unk_00c * (self->unk_008 - *(int*)(p+0x1c))) + 0x800) >> 12);
+  *(int*)(p+0x14) += (int)((((long long)self->unk_00c * (self->unk_000 - *(int*)(p+0x14))) + 0x800) >> 12);
+  *(int*)(p+0x18) += (int)((((long long)self->unk_00c * (self->unk_004 - *(int*)(p+0x18))) + 0x800) >> 12);
+  *(int*)(p+0x1c) += (int)((((long long)self->unk_00c * (self->unk_008 - *(int*)(p+0x1c))) + 0x800) >> 12);
 }
 }

--- a/src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -20,10 +20,10 @@ extern "C" void _ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3(struct Par
     data_020a4d30 = s;
     amp = self->unk_002;
     r = s >> 23;
-    *(int*)(((long long)(int)(v + 1))) += (amp * r - (amp << 8)) >> 8;
+    *(int*)(v + 1) += (amp * r - (amp << 8)) >> 8;
     s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
     data_020a4d30 = s;
     amp = self->unk_004;
     r = s >> 23;
-    *(int*)(((long long)(int)(v + 2))) += (amp * r - (amp << 8)) >> 8;
+    *(int*)(v + 2) += (amp * r - (amp << 8)) >> 8;
 }

--- a/src/_ZN8Particle7Manager9AddSystemEiR7Vector3.c
+++ b/src/_ZN8Particle7Manager9AddSystemEiR7Vector3.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle__Manager.h"
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 
 int _ZN8Particle7Manager9AddSystemEiR7Vector3(struct Particle__Manager *self, int idx, void* v) {
@@ -20,9 +20,9 @@ int _ZN8Particle7Manager9AddSystemEiR7Vector3(struct Particle__Manager *self, in
         p = (u32*)AT(sys, 0x74);
         *p = (*p & ~0x3fu) | (self->unk_02c & 0x3f);
         *p = (*p & ~0xfc0u) | ((self->unk_02e & 0x3f) << 6);
-        lo = (u32)(((long long)(int)(*(u32*)(sys + 0x74) << 26)));
+        lo = (u32)(*(u32*)(sys + 0x74) << 26);
         lo = lo >> 26;
-        *p = (*p & ~0x3f000u) | (((u32)(((long long)(int)lo)) & 0x3f) << 12);
+        *p = (*p & ~0x3f000u) | (((u32)(lo) & 0x3f) << 12);
         *p = *p & 0x3ffff;
         func_0204d9a0(((char*)self) + 4, sys);
         if ((***(u32***)(sys + 0x18) << 17) >> 31) r4 = 0;

--- a/src/_ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -5,7 +5,7 @@
 extern "C" {
 void _ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__Converge *self, char* p, int* vec) {
   vec[0] += (int)self->unk_00c * ((self->unk_000 - *(int*)(p+0x14)) - *(int*)(p+0x20)) >> 12;
-  *(int*)(((long long)(int)(vec+1))) += (int)self->unk_00c * ((self->unk_004 - *(int*)(p+0x18)) - *(int*)(p+0x24)) >> 12;
-  *(int*)(((long long)(int)(vec+2))) += (int)self->unk_00c * ((self->unk_008 - *(int*)(p+0x1c)) - *(int*)(p+0x28)) >> 12;
+  *(int*)(vec+1) += (int)self->unk_00c * ((self->unk_004 - *(int*)(p+0x18)) - *(int*)(p+0x24)) >> 12;
+  *(int*)(vec+2) += (int)self->unk_00c * ((self->unk_008 - *(int*)(p+0x1c)) - *(int*)(p+0x28)) >> 12;
 }
 }

--- a/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
+++ b/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
@@ -74,15 +74,15 @@ int Platform::UpdateKillByMegaChar(short a, short b, short c, Fix12<int> d)
     RaycastLine ray;
     ray.SetObjAndLine(this->pos, vmid, (Actor*)this);
     if (ray.DetectClsn()) {
-        *(short*)((int)(((long long)(int)((char*)this + 0x94)))) =
-            (short)(*(short*)((int)(((long long)(int)((char*)this + 0x94)))) + 0x8000);
+        *(short*)((int)((char*)this + 0x94)) =
+            (short)(*(short*)((int)((char*)this + 0x94)) + 0x8000);
     }
-    *(short*)((int)(((long long)(int)((char*)this + 0x8c)))) =
-        (short)(*(short*)((int)(((long long)(int)((char*)this + 0x8c)))) + a);
-    *(short*)((int)(((long long)(unsigned int)((char*)this + 0x8e)))) =
-        (short)(*(short*)((int)(((long long)(unsigned int)((char*)this + 0x8e)))) + b);
-    *(short*)((int)(((long long)(int)((char*)this + 0x90)))) =
-        (short)(*(short*)((int)(((long long)(int)((char*)this + 0x90)))) + c);
+    *(short*)((int)((char*)this + 0x8c)) =
+        (short)(*(short*)((int)((char*)this + 0x8c)) + a);
+    *(short*)((int)((char*)this + 0x8e)) =
+        (short)(*(short*)((int)((char*)this + 0x8e)) + b);
+    *(short*)((int)((char*)this + 0x90)) =
+        (short)(*(short*)((int)((char*)this + 0x90)) + c);
     ((Actor*)this)->UpdatePos(0);
     if (DecIfAbove0_Byte(&this->f_31d) == 0) {
         ((PlatformVT*)this)->v31();

--- a/src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp
+++ b/src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp
@@ -34,7 +34,7 @@ int SaveData::ReadFileData(u32 fileID, FileSaveData* dest)
         return 0;
     }
     {
-        int* p = (int*)(((long long)(int)(r5 + 0xc)));
+        int* p = (int*)(r5 + 0xc);
         *p = *p & *(int*)((char*)&data_0209caa0 + 0x48);
     }
     return 1;

--- a/src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp
+++ b/src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp
@@ -27,6 +27,6 @@ void SaveData::SetDefaultValues(FileSaveData* fsd_)
     func_0205a588(((void*)this), 0, 0x44);
     *(int*)((void*)this) = 0x30303038;      /* magic8000, via `this` */
     *(unsigned char*)((char*)&unk_041) = 3;
-    *(int*)(((long long)(int)((char*)&flags2))) |= 8;
+    *(int*)((char*)&flags2) |= 8;
     *(unsigned char*)((char*)&unk_042) = 0;
 }

--- a/src/_ZN8SaveData8SaveFileEjP12FileSaveData.cpp
+++ b/src/_ZN8SaveData8SaveFileEjP12FileSaveData.cpp
@@ -18,7 +18,7 @@
  */
 int SaveData::SaveFile(u32 fileID, FileSaveData* data)
 {
-    int* ip = (int*)(((long long)(int)((char*)data + 4)));
+    int* ip = (int*)((char*)data + 4);
     *ip = *ip | 1;
     if (SaveData::SaveDataToCart((char*)data, 0x44, fileID) == 0)
         return 1;

--- a/src/_ZN8SignPost8BehaviorEv.cpp
+++ b/src/_ZN8SignPost8BehaviorEv.cpp
@@ -4,7 +4,7 @@ typedef unsigned char u8;
 
 struct Vector3 { int x, y, z; };
 enum Bool { FALSE, TRUE };
-#define LD(p) ((int)(((long long)(int)(p))))
+#define LD(p) ((int)(p))
 
 extern "C" unsigned int data_0209b454;
 

--- a/src/_ZN8Snowball13InitResourcesEv.cpp
+++ b/src/_ZN8Snowball13InitResourcesEv.cpp
@@ -25,7 +25,7 @@ int Snowball::InitResources()
     unk_37c = mPosX;
     unk_380 = mPosY;
     unk_384 = mPosZ;
-    *(int*)(((long long)(int)((char *)&mPosY))) += 0x32000;
+    *(int*)((char *)&mPosY) += 0x32000;
     mAngleY = mPrevAngleY;
     _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x144, ((char *)this), 0x14000, 0x14000, 0, 0);
 


### PR DESCRIPTION
Chunk 1 of 5 of #1356's delaunder sweep, split so each part lands under the PR validator's 200-file cap and every file gets a real CI byte gate. #1356 as a whole was refused with `refusing to auto-validate 878 source/build-data files (cap 200) -- unusually large, please review by hand`, which meant no byte gate ran on any of it.

176 files. Every site was removed only when the ROM still agreed with the result, one site at a time, via `tools/delaunder.py`.

Independently verified before splitting: all 878 files of #1356's merge result compile and reproduce the ROM byte-for-byte under their pinned compiler with strict relocation-destination checking (`build_pin.verify` with the `(reloc_audit, name_index, config_relocs, sym_index)` tuple), 0 failing, 0 skipped. The chunks are subsets of that verified set, and per-file removals are independent of each other.

Authorship preserved. The remaining chunks follow this one; the #1357 metric restore (#1359) lands last, because the root baseline it banks holds post-sweep numbers (282 files / 566 sites) and only matches once the whole sweep is in.