### PR TITLE
Remove launder sites the ROM does not need (2/5)

### DIFF
--- a/src/_ZN9DorrieCap8BehaviorEv.cpp
+++ b/src/_ZN9DorrieCap8BehaviorEv.cpp
@@ -20,9 +20,9 @@ int DorrieCap::Behavior()
     if(s != 0){
       *(int*)(s+0xd0) = mEatingPlayer;
       *(char**)(*(char**)((char*)&mEatingPlayer)+0x360) = s;
-      int* qs = (int*)(((int)s + 0xb0) & 0xFFFFFFFFFFFFFFFFull);
+      int* qs = (int*)((int)s + 0xb0);
       *qs = *qs | 0x20000;
-      int* qt = (int*)(((int)((char*)this) + 0xb0) & 0xFFFFFFFFFFFFFFFFull);
+      int* qt = (int*)((int)((char*)this) + 0xb0);
       *qt = *qt & ~0x20000;
       mEatingPlayer = 0;
       func_ov001_020ab110((char*)&unk_0d4);
@@ -30,7 +30,7 @@ int DorrieCap::Behavior()
     }
     return 1;
   }
-  p = (char*)(((int)p + 0xd8) & 0xFFFFFFFFFFFFFFFFull);
+  p = (char*)((int)p + 0xd8);
   mPosX = *(int*)p;
   mPosY = *(int*)(p+4);
   mPosZ = *(int*)(p+8);

--- a/src/_ZN9OneUpLogo6RenderEv.cpp
+++ b/src/_ZN9OneUpLogo6RenderEv.cpp
@@ -19,7 +19,7 @@ void _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 int OneUpLogo::Render()
 {
     if (*(u16*)(((char*)this) + 0x100 + 0x4c) != 0) {
-        *(u16*)(((long long)(int)((char*)&unk_14c))) -= 1;
+        *(u16*)((char*)&unk_14c) -= 1;
         return 1;
     }
     _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x124, ((char*)this) + 0xdc);

--- a/src/_ZN9PowerStar13InitResourcesEv.cpp
+++ b/src/_ZN9PowerStar13InitResourcesEv.cpp
@@ -57,8 +57,8 @@ extern s32 _ZN9PowerStar13InitResourcesEv(void *arg0);
 #define S8(o) (*(s8 *)(t + (o)))
 #define U16(o) (*(u16 *)(t + (o)))
 #define S32(o) (*(s32 *)(t + (o)))
-#define LU32(o) (*(u32 *)((int)(((long long)(int)(t + (o))))))
-#define LU16(o) (*(u16 *)((int)(((long long)(int)(t + (o))))))
+#define LU32(o) (*(u32 *)((int)(t + (o))))
+#define LU16(o) (*(u16 *)((int)(t + (o))))
 
 s32 PowerStar::InitResources()
 {
@@ -208,7 +208,7 @@ s32 PowerStar::InitResources()
     S32(0x448) = S32(0x5c);
     S32(0x44c) = S32(0x60);
     S32(0x450) = S32(0x64);
-    q = (s32 *)((int)(((long long)(int)(t + 0x448))));
+    q = (s32 *)((int)(t + 0x448));
     S32(0x454) = q[0];
     S32(0x458) = q[1];
     S32(0x45c) = q[2];

--- a/src/_ZN9PushBlock13InitResourcesEv.cpp
+++ b/src/_ZN9PushBlock13InitResourcesEv.cpp
@@ -72,7 +72,7 @@ int PushBlock::InitResources()
     } else {
         func_ov002_020b9704(((char *)this), 0);
     }
-    angp = (short *)(int)(((long long)(int)((char *)&unk_08e)));
+    angp = (short *)(int)((char *)&unk_08e);
     *angp = *angp - 0x4000;
     _ZN13RaycastGroundD1Ev(ray);
     return 1;

--- a/src/_ZN9RabbitKey6RenderEv.cpp
+++ b/src/_ZN9RabbitKey6RenderEv.cpp
@@ -34,11 +34,11 @@ extern void func_ov085_0212d2b8(struct Obj* self);
 int RabbitKey::Render()
 {
     if (((struct Obj*)this)->unk188 == (void*)&data_ov085_0213072c) {
-        *(s16*)(((long long)(int)((char*)&unk_08e))) += 0x500;
+        *(s16*)((char*)&unk_08e) += 0x500;
     }
     func_ov085_0212d2b8(((struct Obj*)this));
     {
-        struct Sub* s = (struct Sub*)(((long long)(int)((char*)&mModel)));
+        struct Sub* s = (struct Sub*)((char*)&mModel);
         s->vt->fn14(s, 0);
     }
     return 1;

--- a/src/_ZN9ShipWater8BehaviorEv.cpp
+++ b/src/_ZN9ShipWater8BehaviorEv.cpp
@@ -31,7 +31,7 @@ int ShipWater::Behavior()
         if (d < 0x92e000) {
             int* q;
             unk_33c = _ZN5Sound8PlayLongEjjjRK7Vector3s(unk_33c, 3, 0x96, ((char*)this)+0x74, 0);
-            q = (int*)(((long long)(int)((char*)&mPosY)));
+            q = (int*)((char*)&mPosY);
             *q -= 0x5000;
         }
     }

--- a/src/_ZN9Spindrift8BehaviorEv.cpp
+++ b/src/_ZN9Spindrift8BehaviorEv.cpp
@@ -51,7 +51,7 @@ int Spindrift::Behavior()
             _Z14ApproachLinearRiii(((char *)this) + 0x98, 0x4000, 0x1000);
             void *cp = _ZN5Actor13ClosestPlayerEv(((char *)this));
             if (cp != 0) {
-                int *src = (int *)(((int)cp + 0x5c) & 0xFFFFFFFFFFFFFFFFull);
+                int *src = (int *)((int)cp + 0x5c);
                 int v3[3];
                 v3[0] = src[0];
                 v3[1] = src[1];
@@ -70,8 +70,8 @@ int Spindrift::Behavior()
         }
         break;
     case 1:
-        *(unsigned short *)(((int)((char *)this) + 0x100) & 0xFFFFFFFFFFFFFFFFull) += 1;
-        if (*(unsigned short *)(((int)((char *)this) + 0x100) & 0xFFFFFFFFFFFFFFFFull) >= 0x14)
+        *(unsigned short *)((int)((char *)this) + 0x100) += 1;
+        if (*(unsigned short *)((int)((char *)this) + 0x100) >= 0x14)
             unk_39a = 0;
         break;
     }

--- a/src/func_020050dc.c
+++ b/src/func_020050dc.c
@@ -5,6 +5,6 @@ int func_020050dc(void *obj)
 {
     func_0200cb58(obj, 0x1e);
     func_0200cce4(obj);
-    *(int *)(((long long)(int)((char *)obj + 0x154))) |= 0x100;
+    *(int *)((char *)obj + 0x154) |= 0x100;
     return 1;
 }

--- a/src/func_02005418.c
+++ b/src/func_02005418.c
@@ -29,7 +29,7 @@ extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern void func_02012790(int a);
 
-#define LADR(p) ((void *)(unsigned int)(((long long)(int)(p))))
+#define LADR(p) ((void *)(unsigned int)(p))
 
 #pragma opt_common_subs off
 

--- a/src/func_02007484.c
+++ b/src/func_02007484.c
@@ -9,7 +9,7 @@ int func_02007484(char *self)
 
     char *info = *(char **)(self + 0x110);
 
-    int *sub = (int *)(((long long)(int)(info + 0x5c)));
+    int *sub = (int *)(info + 0x5c);
 
     Math_Function_0203b0fc((int *)(self + 0x8c), sub[0], 0x28, 0x7fffffff);
     Math_Function_0203b0fc((int *)(self + 0x94), sub[2], 0x28, 0x7fffffff);

--- a/src/func_020080b0.c
+++ b/src/func_020080b0.c
@@ -4,7 +4,7 @@ extern struct Actor *func_0200e55c(unsigned int ownerID);
 int func_020080b0(char *c)
 {
     struct Actor *obj = func_0200e55c(0x13);
-    char *base = (char *)(((long long)(int)((char *)obj + 0x5c)));
+    char *base = (char *)((char *)obj + 0x5c);
 
     int z = *(int *)(base + 8);
     int y = *(int *)(base + 4) + *(int *)(c + 0x170);

--- a/src/func_020089f8.c
+++ b/src/func_020089f8.c
@@ -10,7 +10,7 @@ void func_020089f8(int *obj)
     if (ptr == 0) {
         return;
     }
-    p = (char *)(((unsigned long long)((char *)ptr + 0x5c)) & 0xFFFFFFFFFFFFFFFFu);
+    p = (char *)((unsigned long long)((char *)ptr + 0x5c));
     obj[0x98 / 4] = *(int *)p;
     obj[0x9c / 4] = *(int *)(p + 4);
     obj[0xa0 / 4] = *(int *)(p + 8);

--- a/src/func_020098e0.c
+++ b/src/func_020098e0.c
@@ -1,5 +1,5 @@
 #include "types.h"
-#define LP(p) ((long long)(int)(p))
+#define LP(p) (p)
 
 extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);
 extern int func_020091f8(void *a, int b, int c, int d);

--- a/src/func_0200af20.c
+++ b/src/func_0200af20.c
@@ -77,5 +77,5 @@ void func_0200af20(char *c, struct Vector3 *v1, struct Vector3 *v2, short *out)
 
     *out = 0xe38;
     _ZN7Clipper13Func_020156DCEv(data_0209f43c, *(int *)(c + 0xf8), *out, *(int *)(c + 0xfc), *(int *)(c + 0x100));
-    *(int *)(int)(((long long)(int)(c + 0x154))) &= ~1;
+    *(int *)(int)(c + 0x154) &= ~1;
 }

--- a/src/func_0200bb28.c
+++ b/src/func_0200bb28.c
@@ -16,10 +16,10 @@ extern void Vec3_RotateYAndTranslate(s32* out, s32* in, s16 ang, s32* src);
 extern s32 Math_Function_0203b14c(s32* p, s32 tgt, s32 rate, s32 lim, s32 step);
 extern s32 _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(s32* v, s32* t, s32 rate);
 
-#define L0(p) ((s32)(((long long)(s32)(p))))
-#define L1(p) ((s32)(((unsigned long long)(unsigned int)(p))))
-#define L2(p) ((s32)((((long long)(s32)(p)) | 0LL)))
-#define L3(p) ((s32)(((unsigned long long)(s32)(p))))
+#define L0(p) ((s32)(p))
+#define L1(p) ((s32)(p))
+#define L2(p) ((s32)((p) | 0LL))
+#define L3(p) ((s32)(p))
 
 
 

--- a/src/func_0200ca14.c
+++ b/src/func_0200ca14.c
@@ -6,7 +6,7 @@ void func_0200ca14(int r0, unsigned int r1, int r2)
         return;
 
     if (r2 == 0)
-        *(unsigned *)(((long long)(int)(r0 + 0x154))) |= 0x20000;
+        *(unsigned *)(r0 + 0x154) |= 0x20000;
     else
-        *(unsigned *)(((long long)(int)(r0 + 0x154))) |= 0x10000;
+        *(unsigned *)(r0 + 0x154) |= 0x10000;
 }

--- a/src/func_0200cbe0.c
+++ b/src/func_0200cbe0.c
@@ -15,7 +15,7 @@ void func_0200cbe0(void *self)
 
     if (r2 != 0) {
         if (r1 != 0) {
-            *(int *)(((long long)(int)((char *)self + 0x154))) &= ~0x8000;
+            *(int *)((char *)self + 0x154) &= ~0x8000;
         }
     }
 

--- a/src/func_0200d0ac.c
+++ b/src/func_0200d0ac.c
@@ -10,7 +10,7 @@ int func_0200d0ac(int a, unsigned int b)
     {
       return 0;
     }
-    *((unsigned int *) ((a + 0x154) & 0xFFFFFFFFFFFFFFFFu)) |= 2u;
+    *((unsigned int *) (a + 0x154)) |= 2u;
     func_02012790(7);
   }
   return 1;

--- a/src/func_0200d1e4.c
+++ b/src/func_0200d1e4.c
@@ -10,7 +10,7 @@ extern s32 data_02086f14[3];
 void func_0200d1e4(char *self)
 {
     char *info = *(char **)(self + 0x110);
-    char *base = (char *)(((long long)(int)(info + 0x5c)));
+    char *base = (char *)(info + 0x5c);
 
     *(s32 *)(self + 0x98) = *(s32 *)(base + 0);
     *(s32 *)(self + 0x9c) = *(s32 *)(base + 4);
@@ -30,7 +30,7 @@ void func_0200d1e4(char *self)
 
     int v2 = *(s32 *)(*(char **)(self + 0x13c) + 0x10);
     unsigned int dResult = func_020093d4(self, v2);
-    *(s32 *)(((long long)(int)(self + 0x84))) += dResult;
+    *(s32 *)(self + 0x84) += dResult;
 
     int v3 = *(s32 *)(*(char **)(self + 0x13c) + 0x20);
     unsigned int r0b = func_020093f4(self, v3);
@@ -44,7 +44,7 @@ void func_0200d1e4(char *self)
     angle = *(short *)(*(char **)(self + 0x110) + 0x8e);
     Vec3_RotateYAndTranslate(self + 0x8c, self + 0x80, angle, temp2);
 
-    *(s32 *)(((long long)(int)(self + 0x90))) += (int)(dResult - 0x8b000);
+    *(s32 *)(self + 0x90) += (int)(dResult - 0x8b000);
 
     *(s32 *)(self + 0xa4) = 0;
     *(s32 *)(self + 0xa8) = 0xc3f9d;

--- a/src/func_0200fc44.c
+++ b/src/func_0200fc44.c
@@ -11,14 +11,14 @@ int func_0200fc44(int a, Vector3* pos, int flag) {
     if (flag) {
         RaycastGround rg;
         _ZN13RaycastGroundC1Ev(&rg);
-        int* yp = (int*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFull);
+        int* yp = (int*)((int)pos + 4);
         *yp += 0x32000;
         _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, pos, 0);
         if (_ZN13RaycastGround10DetectClsnEv(&rg))
             pos->y = rg.resultY;
         _ZN13RaycastGroundD1Ev(&rg);
     }
-    int* yp2 = (int*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFull);
+    int* yp2 = (int*)((int)pos + 4);
     *yp2 += 0x19000;
     return _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb3, pos->x, pos->y, pos->z);
 }

--- a/src/func_02016acc.c
+++ b/src/func_02016acc.c
@@ -6,7 +6,7 @@ void func_02016acc(char *a0, unsigned int mask)
 
     for (unsigned int i = 0; i < n; i++) {
         unsigned int nmask = ~mask;
-        *(unsigned int *)(((long long)(int)(q + 0x24))) &= nmask;
+        *(unsigned int *)(q + 0x24) &= nmask;
         q += 0x30;
     }
 }

--- a/src/func_0201adfc.c
+++ b/src/func_0201adfc.c
@@ -1,5 +1,5 @@
 #include "types.h"
-#define LM(x) ((u32*)(long long)(int)(x))
+#define LM(x) ((u32*)(x))
 
 extern u8 data_0209d698;
 extern u8* data_0209d6f0;

--- a/src/func_02021cd4.c
+++ b/src/func_02021cd4.c
@@ -11,7 +11,7 @@ void func_02021cd4(char *self)
     *(unsigned short *)(elem + 0x28) = val;
 
     char *field = *(char **)(self + 0xc);
-    int *flagAddr = (int *)(((long long)(int)(field + 0x1c)));
+    int *flagAddr = (int *)(field + 0x1c);
     int v = *flagAddr;
     v &= ~1;
     v |= 1;

--- a/src/func_02021d1c.cpp
+++ b/src/func_02021d1c.cpp
@@ -29,7 +29,7 @@ int func_02021d1c(char *self, int a1, int id, void *pos, Vec3s *p5, Callback *p6
     if (id == 0x52 || id == 0x50) {
         if (((struct Bf74 *)((char *)e + 0x74))->a <= 5) {
             if (((struct Bf74 *)((char *)e + 0x74))->b >= 5) {
-                int *cw = (int *)(((unsigned long long)((char *)e + 0x74)) & 0xFFFFFFFFFFFFFFFFULL);
+                int *cw = (int *)((unsigned long long)((char *)e + 0x74));
                 *cw = (*cw & ~0x3f000) | 0x5000;
             }
         }

--- a/src/func_02023624.c
+++ b/src/func_02023624.c
@@ -12,7 +12,7 @@ void* func_02023624(void)
         *(int**)self = data_0208e4b8;
         *(int**)self = _ZTV5Scene;
         {
-            unsigned char* f = (unsigned char*)(((long long)(int)(self + 0x13)));
+            unsigned char* f = (unsigned char*)(self + 0x13);
             *f |= 1;
             *f |= 4;
         }

--- a/src/func_0202f2c4.c
+++ b/src/func_0202f2c4.c
@@ -11,7 +11,7 @@ void func_0202f2c4(void)
 {
     int line;
 
-    *(int *)(((long long)(int)((char *)&data_023c0000 + 0x3ff8))) |= 2;
+    *(int *)((char *)&data_023c0000 + 0x3ff8) |= 2;
 
     line = *(volatile u16 *)0x4000006 + 1;
 

--- a/src/func_0202f428.c
+++ b/src/func_0202f428.c
@@ -20,8 +20,8 @@ void func_0202f428(char *obj)
     case 0:
         return;
     case 1:
-        *(int *)(((long long)(int)(obj + 0x1c))) += self->unk_020;
-        *(int *)(((long long)(int)(obj + 0x20))) += self->unk_024;
+        *(int *)(obj + 0x1c) += self->unk_020;
+        *(int *)(obj + 0x20) += self->unk_024;
         if (self->unk_01c >= 0x200000) {
             self->unk_01c = 0x200000;
             self->unk_00f = 0;
@@ -32,8 +32,8 @@ void func_0202f428(char *obj)
     case 2:
         return;
     case 3:
-        *(int *)(((long long)(int)(obj + 0x1c))) += self->unk_020;
-        *(int *)(((long long)(int)(obj + 0x20))) += self->unk_024;
+        *(int *)(obj + 0x1c) += self->unk_020;
+        *(int *)(obj + 0x20) += self->unk_024;
         if (self->unk_01c <= 0) {
             int b;
             self->unk_01c = 0;

--- a/src/func_0202f708.c
+++ b/src/func_0202f708.c
@@ -48,7 +48,7 @@ int func_0202f708(struct MyFader *self, u32 frames)
             t = (self->type == 0) ? 0x2d : 0x3c;
             self->speed1 = -0x200000 / t;
             self->speed2 = (-self->speed1 << 1) / t;
-            p = (int *)(((int)self + 0x20) & 0xFFFFFFFFFFFFFFFFULL);
+            p = (int *)((int)self + 0x20);
             *p = *p << 1;
         }
 

--- a/src/func_02034b40.c
+++ b/src/func_02034b40.c
@@ -55,14 +55,14 @@ int func_02034b40(char* self)
             } while (1);
 
             if (*(u8*)(self + 0xe) != 0) {
-                *(int*)(((long long)(int)(self + 8))) += (data_0208ee44 << 10);
+                *(int*)(self + 8) += (data_0208ee44 << 10);
                 if (arr[0] == 0)
                     *(u8*)(self + 0xc) = 0x78;
             }
         } else {
             _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, attr, 0x80, 0x80, -1, -1, 0x1000, 0x1000, 0, -1);
             _ZN3OAM9RenderSubEP7OamAttrii(attr, 0x80, 0x80);
-            *(unsigned char*)(((long long)(int)(self + 0xc))) -= data_0208ee44;
+            *(unsigned char*)(self + 0xc) -= data_0208ee44;
             *(int*)(self + 8) = 0;
         }
     }

--- a/src/func_020352b4.c
+++ b/src/func_020352b4.c
@@ -16,13 +16,13 @@ void *func_020352b4(void)
         *(int **)p = data_0208e4b8;
         *(int **)p = _ZTV5Scene;
         {
-            u8 *bp = (u8 *)(((int)p + 0x13) & 0xFFFFFFFFFFFFFFFFULL);
+            u8 *bp = (u8 *)((int)p + 0x13);
             *bp |= 1;
             *bp |= 4;
         }
         *(int **)p = data_020943c4;
         {
-            int *fp = (int *)(((int)p + 0x50) & 0xFFFFFFFFFFFFFFFFULL);
+            int *fp = (int *)((int)p + 0x50);
             fp[0] = (int)data_0208eafc;
             fp[0] = (int)data_0208eacc;
             fp[1] = 0x1000;

--- a/src/func_020353e0.c
+++ b/src/func_020353e0.c
@@ -1,4 +1,4 @@
 void func_020353e0(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4))) &= ~0x40;
+    *(unsigned char *)(self + 4) &= ~0x40;
 }

--- a/src/func_020353f4.c
+++ b/src/func_020353f4.c
@@ -1,4 +1,4 @@
 void func_020353f4(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4))) |= 0x40;
+    *(unsigned char *)(self + 4) |= 0x40;
 }

--- a/src/func_02035414.c
+++ b/src/func_02035414.c
@@ -1,4 +1,4 @@
 void func_02035414(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4))) &= ~0x20;
+    *(unsigned char *)(self + 4) &= ~0x20;
 }

--- a/src/func_02035428.c
+++ b/src/func_02035428.c
@@ -1,4 +1,4 @@
 void func_02035428(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4))) |= 0x20;
+    *(unsigned char *)(self + 4) |= 0x20;
 }

--- a/src/func_02035468.c
+++ b/src/func_02035468.c
@@ -1,4 +1,4 @@
 void func_02035468(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4))) |= 4;
+    *(unsigned char *)(self + 4) |= 4;
 }

--- a/src/func_02035550.c
+++ b/src/func_02035550.c
@@ -1,4 +1,4 @@
 void func_02035550(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x4000;
+    *(unsigned int *)(self + 0x10) |= 0x4000;
 }

--- a/src/func_0203558c.c
+++ b/src/func_0203558c.c
@@ -1,4 +1,4 @@
 void func_0203558c(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x1000;
+    *(unsigned int *)(self + 0x10) |= 0x1000;
 }

--- a/src/func_020355b4.c
+++ b/src/func_020355b4.c
@@ -1,4 +1,4 @@
 void func_020355b4(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x800;
+    *(unsigned int *)(self + 0x10) |= 0x800;
 }

--- a/src/func_020355c8.c
+++ b/src/func_020355c8.c
@@ -1,4 +1,4 @@
 void func_020355c8(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) &= ~0x800;
+    *(unsigned int *)(self + 0x10) &= ~0x800;
 }

--- a/src/func_020355e8.c
+++ b/src/func_020355e8.c
@@ -1,4 +1,4 @@
 void func_020355e8(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) &= ~0x400;
+    *(unsigned int *)(self + 0x10) &= ~0x400;
 }

--- a/src/func_020355fc.c
+++ b/src/func_020355fc.c
@@ -1,4 +1,4 @@
 void func_020355fc(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x400;
+    *(unsigned int *)(self + 0x10) |= 0x400;
 }

--- a/src/func_020356d4.c
+++ b/src/func_020356d4.c
@@ -1,4 +1,4 @@
 void func_020356d4(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x40;
+    *(unsigned int *)(self + 0x10) |= 0x40;
 }

--- a/src/func_0203573c.c
+++ b/src/func_0203573c.c
@@ -1,4 +1,4 @@
 void func_0203573c(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x20;
+    *(unsigned int *)(self + 0x10) |= 0x20;
 }

--- a/src/func_02035770.c
+++ b/src/func_02035770.c
@@ -1,4 +1,4 @@
 void func_02035770(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) &= ~0x200;
+    *(unsigned int *)(self + 0x10) &= ~0x200;
 }

--- a/src/func_02035784.c
+++ b/src/func_02035784.c
@@ -1,4 +1,4 @@
 void func_02035784(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x200;
+    *(unsigned int *)(self + 0x10) |= 0x200;
 }

--- a/src/func_02035860.c
+++ b/src/func_02035860.c
@@ -4,11 +4,11 @@
 void func_02035860(char *o, struct Vector3 *src)
 {
     char *base = *(char **)(o + 0x14);
-    struct Vector3 *d1 = (struct Vector3 *)(((long long)(int)(base + 0x5c)));
+    struct Vector3 *d1 = (struct Vector3 *)(base + 0x5c);
     d1->x = src->x;
     d1->y = src->y;
     d1->z = src->z;
-    struct Vector3 *d2 = (struct Vector3 *)(((long long)(int)(base + 0x68)));
+    struct Vector3 *d2 = (struct Vector3 *)(base + 0x68);
     d2->x = src->x;
     d2->y = src->y;
     d2->z = src->z;

--- a/src/func_02036acc.c
+++ b/src/func_02036acc.c
@@ -1,5 +1,5 @@
 #include "types.h"
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct ClsnResult { char pad[0x28]; } ClsnResult;

--- a/src/func_0203842c.cpp
+++ b/src/func_0203842c.cpp
@@ -60,7 +60,7 @@ extern "C" int func_0203842c(char *self)
             int active = (info->pB0 & 2) ? 1 : 0;
             if (active != 0) {
                 Vector3 v;
-                Vector3 *src = (Vector3 *)((unsigned long long)(unsigned int)((char *)info + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+                Vector3 *src = (Vector3 *)((char *)info + 0x5c);
                 v.x = src->x;
                 v.y = src->y;
                 v.z = src->z;

--- a/src/func_020408b0.c
+++ b/src/func_020408b0.c
@@ -37,7 +37,7 @@ void func_020408b0(unsigned short arg)
         p = (char *)data_020a0f54;
         data_020a0f28 = *(unsigned short *)(p + 0x36);
         p += 0x48;
-        ++*(unsigned short *)(int)(((long long)(int)(p)));
+        ++*(unsigned short *)(int)(p);
     }
     data_020a0f74 = _ZN6Memory8AllocateEji(0x420, 0x20);
     data_020a0f80 = _ZN6Memory8AllocateEji(0x100, 0x20);

--- a/src/func_020412f0.c
+++ b/src/func_020412f0.c
@@ -76,7 +76,7 @@ void func_020412f0(char *thiz)
         char *base = data_020a2400;
         int kind;
 
-        *(int *)(base + r6) = *(int *)((Msg *)((int)m & 0xFFFFFFFFFFFFFFFF));
+        *(int *)(base + r6) = *(int *)((Msg *)((int)m));
         *(int *)(data_020a2404 + r6) = m->w1;
         data_020a2408[r6] = m->b8;
         {
@@ -90,7 +90,7 @@ void func_020412f0(char *thiz)
             d9[2] = m->bb;
         }
 
-        kind = ((Msg *)((int)m & 0xFFFFFFFFFFFFFFFF))->f0;
+        kind = ((Msg *)((int)m))->f0;
 
         switch (kind) {
         case 0: {
@@ -101,21 +101,21 @@ void func_020412f0(char *thiz)
             if (*(int *)(base + 0x2720) != 0 ||
                 val != *(int *)(data_020a1fc0 + 0x28)) {
                 *(int *)(base + 0x2720) = 1;
-                *(int *)(((int)base + 0x2728) & 0xFFFFFFFFFFFFFFFF) |= (1 << sb);
-                *(int *)(((int)base + 0x271c) & 0xFFFFFFFFFFFFFFFF) |= (1 << sb);
+                *(int *)((int)base + 0x2728) |= (1 << sb);
+                *(int *)((int)base + 0x271c) |= (1 << sb);
             } else {
                 void *p = func_02041ce0(base, unk18v, nib1);
 
                 if (p != 0) {
-                    *(int *)(((int)base + 0x270c) & 0xFFFFFFFFFFFFFFFF) |= (1 << sb);
+                    *(int *)((int)base + 0x270c) |= (1 << sb);
                     *(int *)(base + r6 + 4) = *(int *)((char *)p + 0x88);
-                    *(int *)(((int)p + 0x80) & 0xFFFFFFFFFFFFFFFF) += 1;
+                    *(int *)((int)p + 0x80) += 1;
                 } else {
                     void *q = func_02041c64(base, unk18v, nib1);
-                    *(int *)(((int)q + 0x84) & 0xFFFFFFFFFFFFFFFF) |= (1 << sb);
+                    *(int *)((int)q + 0x84) |= (1 << sb);
                 }
 
-                *(int *)(((int)base + 0x271c) & 0xFFFFFFFFFFFFFFFF) |= (1 << sb);
+                *(int *)((int)base + 0x271c) |= (1 << sb);
             }
             break;
         }
@@ -123,11 +123,11 @@ void func_020412f0(char *thiz)
             u32 saved = _ZN3IRQ7DisableEv();
             void *p;
 
-            *(int *)(((int)base + 0x270c) & 0xFFFFFFFFFFFFFFFF) |= (1 << sb);
+            *(int *)((int)base + 0x270c) |= (1 << sb);
             p = func_02041c2c(base, m->w1);
 
             if (p != 0) {
-                *(int *)(((int)p + 0x80) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                *(int *)((int)p + 0x80) -= 1;
                 if (*(int *)((char *)p + 0x80) <= 0) {
                     *(int *)((char *)p + 0x84) = 0;
                     func_020657fc(m->w1);

--- a/src/func_020417d0.c
+++ b/src/func_020417d0.c
@@ -19,7 +19,7 @@ void func_020417d0(char *p)
         return;
     case 9:
         if (*(u32 *)g == 0) return;
-        *(u32 *)(((s32)base + 0x2718) & 0xFFFFFFFFFFFFFFFFull) &= ~(1 << *(u16 *)(p + 0x12));
+        *(u32 *)((s32)base + 0x2718) &= ~(1 << *(u16 *)(p + 0x12));
         return;
     case 0x15: {
         s32 r0 = *(s32 *)(p + 0xc);
@@ -27,7 +27,7 @@ void func_020417d0(char *p)
         if (*(u32 *)g != 0)
         {
             u32 bit = *(u16 *)(p + 0x12);
-            *(u32 *)(((s32)base + 0x2718) & 0xFFFFFFFFFFFFFFFFull) |= (1 << bit);
+            *(u32 *)((s32)base + 0x2718) |= (1 << bit);
             func_020650d8(r0, arg2, bit);
         }
         else

--- a/src/func_02041a94.c
+++ b/src/func_02041a94.c
@@ -5,7 +5,7 @@ void func_02041a94(char *base, char *node)
 {
     int *ctr;
     func_02041bbc((struct ListNode **)(base + 0x2708), (struct ListNode **)(base + 0x2700), (struct ListNode *)node);
-    ctr = (int *)(((long long)(int)(base + 0x2724)));
+    ctr = (int *)(base + 0x2724);
     *(int *)(node + 0x7c) = 0;
     *ctr -= 1;
 }

--- a/src/func_02041b60.c
+++ b/src/func_02041b60.c
@@ -8,7 +8,7 @@ struct ListNode *func_02041b60(char *base)
     node = *(struct ListNode **)((base + 0x2000) + 0x700);
     func_02041bbc((struct ListNode **)(base + 0x2700), (struct ListNode **)(base + 0x2708), node);
     *(int *)((char *)node + 0x7c) = 1;
-    ctr = (int *)(((long long)(int)(base + 0x2724)));
+    ctr = (int *)(base + 0x2724);
     *ctr += 1;
     return node;
 }

--- a/src/func_02041e14.c
+++ b/src/func_02041e14.c
@@ -36,7 +36,7 @@ extern Globals data_020a1fc0;
 
 void func_02041e14(void)
 {
-    Sub *s = (Sub *)(((int)&data_020a1fc0 + 0x440));
+    Sub *s = (Sub *)((int)&data_020a1fc0 + 0x440);
     Cmd cmd;
     Cmd cmd2;
 
@@ -47,10 +47,10 @@ void func_02041e14(void)
         return;
     }
 
-    *(int *)(((int)s + 0x270c)) &= s->f2718;
-    *(int *)(((int)s + 0x2710)) &= s->f2718;
-    *(int *)(((int)s + 0x271c)) &= s->f2718;
-    *(int *)(((int)s + 0x2728)) &= s->f2718;
+    *(int *)((int)s + 0x270c) &= s->f2718;
+    *(int *)((int)s + 0x2710) &= s->f2718;
+    *(int *)((int)s + 0x271c) &= s->f2718;
+    *(int *)((int)s + 0x2728) &= s->f2718;
 
     if (s->f2720 != 0 && s->f2724 == 0) {
         int v = s->f272c;
@@ -129,7 +129,7 @@ void func_02041e14(void)
             break;
         case 2:
             found->kind = 3;
-            *(int *)(((long long)(int)((char *)s + 0x271c))) &= ~mask;
+            *(int *)((char *)s + 0x271c) &= ~mask;
             break;
         }
 
@@ -143,6 +143,6 @@ void func_02041e14(void)
         cmd2.byte8 = (u8)c;
         func_020656d4((u16)mask, &cmd2, 9, (u32)func_02042160);
         s->f2714 = 1;
-        *(int *)(((long long)(int)((char *)s + 0x270c))) &= ~mask;
+        *(int *)((char *)s + 0x270c) &= ~mask;
     }
 }

--- a/src/func_02043880.c
+++ b/src/func_02043880.c
@@ -40,8 +40,8 @@ extern int data_020a4b98;
 extern int data_020a4b88;
 extern int data_020a4ba8;
 
-#define FLAGP(o) ((u8*)(((unsigned long long)(int)((char*)(o) + 0x13)) & 0xFFFFFFFFFFFFFFFFULL))
-#define NODEP(o, OFF) ((Node*)(((unsigned long long)(int)((char*)(o) + (OFF))) & 0xFFFFFFFFFFFFFFFFULL))
+#define FLAGP(o) ((u8*)((char*)(o) + 0x13))
+#define NODEP(o, OFF) ((Node*)((char*)(o) + (OFF)))
 
 
 #pragma opt_common_subs off

--- a/src/func_020453c0.c
+++ b/src/func_020453c0.c
@@ -14,7 +14,7 @@ void func_020453c0(int *a, short *node, int *p2, int p3)
     int mla = idx * 0x24 + r6[5];
     unsigned short *dst;
     func_0204547c(r6, mla, r5, elem);
-    dst = (unsigned short*)(int)(((long long)(int)(elem + 0x18)));
+    dst = (unsigned short*)(int)(elem + 0x18);
     *dst = (unsigned short)(*dst | *(unsigned short*)(elem + node[4] * 0x34 + 0x18));
     if (node[5] != 0)
         func_020453c0(a, (short*)((char*)node + (node[5] << 6)), r6, r5);

--- a/src/func_0204547c.c
+++ b/src/func_0204547c.c
@@ -37,7 +37,7 @@ void func_0204547c(Ctx *ctx, Src *s, int a2, Dst *d)
     u16 *p;
 
     d->f18 = 0;
-    p = (u16 *)(((int)d + 0x18) & 0xFFFFFFFFFFFFFFFFull);
+    p = (u16 *)((int)d + 0x18);
     *p |= s->h2;
     *p |= s->h6;
     *p |= s->hA;

--- a/src/func_02045e44.c
+++ b/src/func_02045e44.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045e44(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
+    unsigned int *flags = (unsigned int *)(&e->flags);
     *flags &= ~0xc0000000;
     *flags |= value << 30;
 }

--- a/src/func_02045ec4.c
+++ b/src/func_02045ec4.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045ec4(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
+    unsigned int *flags = (unsigned int *)(&e->flags);
     *flags &= 0xffff;
     *flags |= value << 16;
 }

--- a/src/func_02045f4c.c
+++ b/src/func_02045f4c.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045f4c(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
+    unsigned int *flags = (unsigned int *)(&e->flags);
     *flags &= 0xffff;
     *flags |= value << 16;
 }

--- a/src/func_02045fd4.c
+++ b/src/func_02045fd4.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045fd4(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
+    unsigned int *flags = (unsigned int *)(&e->flags);
     *flags &= 0xffff8000;
     *flags |= value;
 }

--- a/src/func_0204605c.c
+++ b/src/func_0204605c.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_0204605c(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
+    unsigned int *flags = (unsigned int *)(&e->flags);
     *flags &= ~0x3f000000;
     *flags |= value << 24;
 }

--- a/src/func_02046088.c
+++ b/src/func_02046088.c
@@ -18,7 +18,7 @@ void func_02046088(Obj *self, int a, int b)
 
     for (i = 0; i < n; i++)
     {
-        volatile u32 *p = (volatile u32 *)(((long long)(int)((int)self->data + i * 0x30 + 0x24)));
+        volatile u32 *p = (volatile u32 *)((int)self->data + i * 0x30 + 0x24);
         *p &= 0xc0ffff0f;
         *p |= b << 24;
         *p |= 0x80;

--- a/src/func_02046120.c
+++ b/src/func_02046120.c
@@ -18,7 +18,7 @@ void func_02046120(Obj *self, int a)
 
     for (i = 0; i < n; i++)
     {
-        volatile u32 *p = (volatile u32 *)(((long long)(int)((int)self->data + i * 0x30 + 0x24)));
+        volatile u32 *p = (volatile u32 *)((int)self->data + i * 0x30 + 0x24);
         *p &= 0xc0ffff0f;
         *p |= 0x40;
         *p |= 0x30;

--- a/src/func_02046208.c
+++ b/src/func_02046208.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02046208(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
+    unsigned int *flags = (unsigned int *)(&e->flags);
     *flags &= ~0x1f0000;
     *flags |= value << 16;
 }

--- a/src/func_02046288.c
+++ b/src/func_02046288.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02046288(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
+    unsigned int *flags = (unsigned int *)(&e->flags);
     *flags &= ~0x30;
     *flags |= value << 4;
 }

--- a/src/func_02046bbc.c
+++ b/src/func_02046bbc.c
@@ -84,7 +84,7 @@ void func_02046bbc(struct Ctx *ctx, struct Desc *desc, unsigned int sb)
     idx0 = *((u16 *) (((char *) desc->field4) + (v0 * 8)));
     item = ctx->node->m18 + (idx0 * 0x14);
     *((int *) (dst + 0x1c)) = *((int *) ((((char *) ctx->node->m28) + (e->id * 0x30)) + 0x20));
-    *((int *) (((unsigned int) (dst + 0x1c)) & 0xFFFFFFFFFFFFFFFFULL)) |= *((int *) (item + 0x10));
+    *((int *) ((unsigned int) (dst + 0x1c))) |= *((int *) (item + 0x10));
     flags = ((*((unsigned int *) (item + 0x10))) >> 26) & 7;
     if (desc->field8 != 0)
     {

--- a/src/func_02046e28.c
+++ b/src/func_02046e28.c
@@ -7,7 +7,7 @@ struct Model { u8 pad0[4]; struct Material *materials; };
 
 extern void Crash(void);
 
-#define LAUNDER(p) ((volatile u32 *)(int)(((long long)(int)(p))))
+#define LAUNDER(p) ((volatile u32 *)(int)(p))
 
 void func_02046e28(struct Model *model, struct MatAnimData *anim, short frame)
 {

--- a/src/func_02047218.c
+++ b/src/func_02047218.c
@@ -2,7 +2,7 @@ typedef int fx32;
 typedef long long fx64;
 
 #define FX(a, b) ((fx32)(((fx64)(a) * (b) + 0x800) >> 12))
-#define PTR(base, off) ((fx32*)(int)(((long long)(int)((char*)(base) + (off)))))
+#define PTR(base, off) ((fx32*)(int)((char*)(base) + (off)))
 
 void func_02047218(fx32 *m0, fx32 *m1, fx32 *dst, fx32 t)
 {

--- a/src/func_0204a730.c
+++ b/src/func_0204a730.c
@@ -33,7 +33,7 @@ extern void func_0204d150(void *, void *, u32);
 extern void func_0204d104(void *, void *, u32);
 extern void func_0204d0b8(void *, void *, u32);
 
-#define LP(T, e) ((T *)(int)(((long long)(int)(e))))
+#define LP(T, e) ((T *)(int)(e))
 
 #pragma opt_common_subs off
 

--- a/src/func_0204b028.c
+++ b/src/func_0204b028.c
@@ -93,7 +93,7 @@ void func_0204b028(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *q = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        Cnt74 *q = (Cnt74 *)(u32)((char *)c + 0x74);
         q->count++;
         if (c->cnt.count > c->cnt.limit)
             q->count = c->cnt.start;

--- a/src/func_0204b244.c
+++ b/src/func_0204b244.c
@@ -95,7 +95,7 @@ void func_0204b244(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *q = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        Cnt74 *q = (Cnt74 *)(u32)((char *)c + 0x74);
         q->count++;
         if (c->cnt.count > c->cnt.limit)
             q->count = c->cnt.start;

--- a/src/func_0204b460.c
+++ b/src/func_0204b460.c
@@ -104,7 +104,7 @@ void func_0204b460(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
+        Cnt74 *qq = (Cnt74 *)(u32)((char *)c + 0x74);
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204b81c.c
+++ b/src/func_0204b81c.c
@@ -106,7 +106,7 @@ void func_0204b81c(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
+        Cnt74 *qq = (Cnt74 *)(u32)((char *)c + 0x74);
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204bbd8.c
+++ b/src/func_0204bbd8.c
@@ -92,7 +92,7 @@ void func_0204bbd8(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
+        Cnt74 *qq = (Cnt74 *)(u32)((char *)c + 0x74);
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204be40.c
+++ b/src/func_0204be40.c
@@ -92,7 +92,7 @@ void func_0204be40(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
+        Cnt74 *qq = (Cnt74 *)(u32)((char *)c + 0x74);
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204c304.c
+++ b/src/func_0204c304.c
@@ -110,7 +110,7 @@ void func_0204c304(Particle *self, u8 *mgr, List *freelist)
             p->h3a = self->h3a;
 
         {
-            Bf40 *q = (Bf40 *)(((s64)(int)((u8 *)p + 0x40)));
+            Bf40 *q = (Bf40 *)((u8 *)p + 0x40);
             q->f0 = (u16)((self->bf40.f0 * (self->bf40.f5 + 1)) >> 5);
             q->f5 = 0x1f;
         }

--- a/src/func_0204c584.c
+++ b/src/func_0204c584.c
@@ -216,7 +216,7 @@ void func_0204c584(u8 *self, List *list)
             *(u16 *)(p + 0x3a) = def->tex;
         }
         {
-            u16 *q = (u16 *)(((s64)(int)(p + 0x40)));
+            u16 *q = (u16 *)(p + 0x40);
             *q = (u16)((*q & ~0x1f) | (*(u8 *)(self + 0x59) & 0x1f));
             *q = (u16)((*q & ~0x3e0) | 0x3e0);
         }

--- a/src/func_0204d0b8.c
+++ b/src/func_0204d0b8.c
@@ -1,6 +1,6 @@
 #include "types.h"
 void func_0204d0b8(void *p, int a, int b) {
-    u16 *c = (u16 *)(((long long)(int)((char *)p + 0x40)));
+    u16 *c = (u16 *)((char *)p + 0x40);
     u16 g = ((0xff - b) * 0x1f) / 0xff;
     *c = (*c & ~0x3e0) | ((g & 0x1f) << 5);
 }

--- a/src/func_0204d1b4.c
+++ b/src/func_0204d1b4.c
@@ -53,7 +53,7 @@ void func_0204d1b4(struct Dst *dst, struct Src *src, int t)
     int tmp = __aeabi_idiv((t - 0xff) * d, 0xff - hi);
     r1 = tmp + bb;
   }
-  u16 *p_d = (u16 *) (((unsigned long long) ((unsigned int) (&dst->u40))) & 0xFFFFFFFFFFFFFFFFULL);
+  u16 *p_d = (u16 *) ((unsigned long long) ((unsigned int) (&dst->u40)));
   u32 s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
   data_020a4d30 = s;
   int b = e->field2;

--- a/src/func_0204dab4.c
+++ b/src/func_0204dab4.c
@@ -67,8 +67,7 @@ void func_0204dab4(void *sys, Entry *buf, int count, unsigned int mask, void *cb
         if (slot == 0 && empty != -1 && mask < 4) {
             slot = &buf[empty];
             slot->node = walk;
-            fp6 = (unsigned char *)(((int)slot + 6) &
-                                    0xFFFFFFFFFFFFFFFFULL);
+            fp6 = (unsigned char *)((int)slot + 6);
             *fp6 = (unsigned char)((*fp6 & ~3u) | (mask & 3u));
         }
 
@@ -85,8 +84,7 @@ void func_0204dab4(void *sys, Entry *buf, int count, unsigned int mask, void *cb
             fn(&sp[1], slot, (short *)((char *)slot + 2), &sp[0]);
 
             slot->f4 = (short)(((long long)sp[0] * scale + 0x800) >> 12);
-            fp6 = (unsigned char *)(((int)slot + 6) &
-                                    0xFFFFFFFFFFFFFFFFULL);
+            fp6 = (unsigned char *)((int)slot + 6);
             *fp6 = (unsigned char)(*fp6 | 4u);
         }
 
@@ -106,8 +104,7 @@ tail:
                 p->node = 0;
         }
 
-        fp6 = (unsigned char *)(((int)p + 6) &
-                                0xFFFFFFFFFFFFFFFFULL);
+        fp6 = (unsigned char *)((int)p + 6);
         *fp6 = (unsigned char)(*fp6 & ~4u);
         p++;
     } while (++j < count);

--- a/src/func_0204dc84.c
+++ b/src/func_0204dc84.c
@@ -1,6 +1,6 @@
 void func_0204dc84(char *self)
 {
-    unsigned char *flags6 = (unsigned char *)(((long long)(int)(self + 6)));
+    unsigned char *flags6 = (unsigned char *)(self + 6);
     *flags6 &= ~3;
     *flags6 &= ~4;
     *(short *)(self + 4) = 0;

--- a/src/func_0204fda4.cpp
+++ b/src/func_0204fda4.cpp
@@ -11,7 +11,7 @@ extern "C" void func_0204fda4(char* c)
     int* p;
     func_0204f0b8(*(unsigned int*)(c + 0x28));
     _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(data_020a552c, c);
-    p = (int*)((((long long)(int)(c + 0xc))));
+    p = (int*)(c + 0xc);
     *p &= ~1;
     *p &= ~2;
 }

--- a/src/func_0204ffcc.c
+++ b/src/func_0204ffcc.c
@@ -3,5 +3,5 @@ extern void func_0205ac28(void *a, int b, int c, int d);
 void func_0204ffcc(char *self)
 {
     func_0205ac28(*(void **)(self + 0x2c), 0, 1 << *(int *)(self + 0x28), 0);
-    *(int *)(((long long)(int)(self + 0xc))) |= 2;
+    *(int *)(self + 0xc) |= 2;
 }

--- a/src/func_020503a4.c
+++ b/src/func_020503a4.c
@@ -46,9 +46,9 @@ int func_020503a4(int a, int b, int c, int d, int p5, int p6, int p7, int p8,
     int chunk;
     G *g;
 
-    dd = (int)(((s64)(int)d) & ~0ULL);
-    pp8 = (int)(((s64)(int)p8) & ~0ULL);
-    pp10 = (int)(((s64)(int)p10) & ~0ULL);
+    dd = (int)((d) & ~0ULL);
+    pp8 = (int)((p8) & ~0ULL);
+    pp10 = (int)((p10) & ~0ULL);
 
     handle = -1;
     g = &data_020a5634;

--- a/src/func_020520dc.c
+++ b/src/func_020520dc.c
@@ -6,7 +6,7 @@ void func_020520dc(char *self)
     if (*(int *)(self + 0x100) == 0)
         return;
 
-    *(int *)(((long long)(int)(self + 0x100))) -= 1;
+    *(int *)(self + 0x100) -= 1;
 
     if (*(int *)(self + 0x100) != 0)
         return;

--- a/src/func_020522c4.c
+++ b/src/func_020522c4.c
@@ -25,7 +25,7 @@ void func_020522c4(void)
                     if (*(int *)(r + 0xf8) != 0) {
                         func_0204ffcc(r);
                         {
-                            int *flagsp = (int *)(((long long)(int)(r + 0xf0)));
+                            int *flagsp = (int *)(r + 0xf0);
                             *flagsp |= 2;
                             *flagsp &= ~4;
                         }

--- a/src/func_02052438.c
+++ b/src/func_02052438.c
@@ -1,6 +1,6 @@
 void func_02052438(char *self)
 {
     if (*(int *)(self + 8) < *(int *)(self + 0xc)) {
-        *(int *)(((long long)(int)(self + 8))) += 1;
+        *(int *)(self + 8) += 1;
     }
 }

--- a/src/func_02057d30.c
+++ b/src/func_02057d30.c
@@ -13,5 +13,5 @@ void func_02057d30(RingS *s, const char *src, int len) {
         s->buf[i] = src[i];
     }
     s->count -= n;
-    *(int *)(((long long)(int)((char *)s + 4))) += len;
+    *(int *)((char *)s + 4) += len;
 }

--- a/src/func_02057d94.c
+++ b/src/func_02057d94.c
@@ -13,5 +13,5 @@ void func_02057d94(RingS *s, char c, int len) {
         s->buf[i] = c;
     }
     s->count -= n;
-    *(int *)(((long long)(int)((char *)s + 4))) += len;
+    *(int *)((char *)s + 4) += len;
 }

--- a/src/func_02057e00.c
+++ b/src/func_02057e00.c
@@ -5,5 +5,5 @@ void func_02057e00(char *self, unsigned char value)
         *(int *)self -= 1;
     }
 
-    *(int *)(((long long)(int)(self + 4))) += 1;
+    *(int *)(self + 4) += 1;
 }

--- a/src/func_020587e4.c
+++ b/src/func_020587e4.c
@@ -28,7 +28,7 @@ int func_020587e4(struct MsgQueue *self, u32 *msg, int flags) {
         *msg = self->msgArray[self->firstIndex];
     }
     self->firstIndex = (self->firstIndex + 1) % self->msgCount;
-    *(int *)(((long long)(int)&self->usedCount)) -= 1;
+    *(int *)(&self->usedCount) -= 1;
     OS_WakeupThread(&self->queueSend);
 
     _ZN3IRQ7RestoreEj(enabled);

--- a/src/func_02058a94.c
+++ b/src/func_02058a94.c
@@ -8,7 +8,7 @@ void func_02058a94(char* obj) {
     unsigned int saved = _ZN3IRQ7DisableEv();
     int g = data_020a6134.field8;
     if (*(int*)(obj + 4) == g) {
-        int* cnt = (int*)(((int)(obj + 8)) & 0xFFFFFFFFFFFFFFFFULL);
+        int* cnt = (int*)((int)(obj + 8));
         *cnt = *cnt - 1;
         if (*(int*)(obj + 8) == 0) {
             func_02058988((void*)g, obj);

--- a/src/func_0205929c.c
+++ b/src/func_0205929c.c
@@ -22,7 +22,7 @@ void *func_0205929c(void *ap, void *bp)
     if (cur != 0) {
         cur->prev = b;
         if ((Block *)((char *)b + b->size) == cur) {
-            int *bsize = (int *)(((long long)(int)&b->size));
+            int *bsize = (int *)(&b->size);
             *bsize += cur->size;
             cur = cur->next;
             b->next = cur;
@@ -33,7 +33,7 @@ void *func_0205929c(void *ap, void *bp)
     if (prev != 0) {
         prev->next = b;
         if ((Block *)((char *)prev + prev->size) == b) {
-            int *psize = (int *)(((long long)(int)&prev->size));
+            int *psize = (int *)(&prev->size);
             *psize += b->size;
             prev->next = cur;
             if (cur != 0)

--- a/src/func_02059650.c
+++ b/src/func_02059650.c
@@ -11,5 +11,5 @@ long long func_02059650(void)
     if ((*(volatile u32*)0x4000214 & 8) && !(timer & 0x8000))
         counter = counter + 1;
     _ZN3IRQ7RestoreEj(tok);
-    return ((long long)counter << 16) | (int)(((long long)(int)timer));
+    return ((long long)counter << 16) | (int)(timer);
 }

--- a/src/func_02059f58.c
+++ b/src/func_02059f58.c
@@ -5,7 +5,7 @@ void func_02059f58(int channel)
 {
     unsigned int saved = _ZN3IRQ7DisableEv();
     int idx = channel * 6 + 5;
-    volatile unsigned short *reg = (volatile unsigned short *)(((long long)(int)(0x40000b0 + idx * 2)));
+    volatile unsigned short *reg = (volatile unsigned short *)(0x40000b0 + idx * 2);
     *reg &= ~0x3a00;
     *reg &= ~0x8000;
     (void)*reg;

--- a/src/func_0205a064.c
+++ b/src/func_0205a064.c
@@ -17,13 +17,13 @@ void func_0205a064(u32 ch, u32 src, u32 dst, u32 size, void (*cb)(u32), u32 cbAr
     if (cb != 0)
     {
         func_02056e98(ch, (u32)cb, cbArg);
-        reg = (u32 *)(int)(((long long)(int)(0x040000e0 + ch * 4)));
+        reg = (u32 *)(int)(0x040000e0 + ch * 4);
         *reg = dst;
         DMAStartTransfer(ch, (u32)reg, src, (size >> 2) | 0xc5000000);
     }
     else
     {
-        reg = (u32 *)(int)(((long long)(int)(0x040000e0 + ch * 4)));
+        reg = (u32 *)(int)(0x040000e0 + ch * 4);
         *reg = dst;
         DMAStartTransfer(ch, (u32)reg, src, (size >> 2) | 0x85000000);
     }

--- a/src/func_0205b4d0.c
+++ b/src/func_0205b4d0.c
@@ -8,7 +8,7 @@ extern struct E7f60 data_020a7f60[];
 
 unsigned char func_0205b4d0(int index, void (*fn)(int), int arg) {
     struct E7f60 *e = &data_020a7f60[index];
-    unsigned char *t = (unsigned char *)(((long long)(int)((char *)e + 8)));
+    unsigned char *t = (unsigned char *)((char *)e + 8);
     data_020a7f60[index].fn = fn;
     e->arg = arg;
     (*t)++;

--- a/src/func_0205c264.c
+++ b/src/func_0205c264.c
@@ -34,7 +34,7 @@ int func_0205c264(int *thiz)
         *(short *)(r4 + 6) = 0;
         *(int *)(r4 + 8) = 0;
     } else {
-        unsigned short *q = (unsigned short *)(int)(((long long)(int)((char *)thiz + 0x22)));
+        unsigned short *q = (unsigned short *)(int)((char *)thiz + 0x22);
         *(int *)r4 = thiz[2];
         *(int *)(r4 + 4) = *(unsigned short *)((char *)thiz + 0x22);
         *q = *q + 1;

--- a/src/func_0205c410.c
+++ b/src/func_0205c410.c
@@ -4,6 +4,6 @@ void func_0205c410(char* c)
     unsigned inc = *(unsigned*)(c + 0x34);
     unsigned b = *(unsigned*)(c + 0x28);
     unsigned a = *(unsigned*)(c + 0x2c);
-    *(unsigned*)(((long long)(int)(c + 0x28))) += inc;
+    *(unsigned*)(c + 0x28) += inc;
     (*(void (**)(char*, unsigned, unsigned, unsigned))(obj + 0x40))(obj, a, b, inc);
 }

--- a/src/func_0205c448.c
+++ b/src/func_0205c448.c
@@ -4,6 +4,6 @@ void func_0205c448(char* c)
     unsigned inc = *(unsigned*)(c + 0x34);
     unsigned b = *(unsigned*)(c + 0x28);
     unsigned a = *(unsigned*)(c + 0x2c);
-    *(unsigned*)(((long long)(int)(c + 0x28))) += inc;
+    *(unsigned*)(c + 0x28) += inc;
     (*(void (**)(char*, unsigned, unsigned, unsigned))(obj + 0x3c))(obj, a, b, inc);
 }

--- a/src/func_0205c4e4.c
+++ b/src/func_0205c4e4.c
@@ -2,7 +2,7 @@ extern int func_0205c5e4(void *self, int mode);
 
 void func_0205c4e4(char *self, unsigned short value)
 {
-    *(int *)(((long long)(int)(self + 0xc))) |= 4;
+    *(int *)(self + 0xc) |= 4;
     *(int *)(self + 0x2c) = *(int *)(self + 8);
     *(int *)(self + 0x34) = 0;
     *(unsigned short *)(self + 0x32) = 0;

--- a/src/func_0205c528.cpp
+++ b/src/func_0205c528.cpp
@@ -20,12 +20,12 @@ struct Outer {
 extern "C" void func_0205c528(Outer *thiz, int r1, int r7)
 {
     Obj *o = thiz->obj;
-    *(int *)(((int)o + 0x10) & 0xFFFFFFFFFFFFFFFFULL) |= 0x200;
+    *(int *)((int)o + 0x10) |= 0x200;
     int res = o->m44(o, r1, thiz->f4, r7);
     switch (res) {
     case 0:
     case 1:
-        *(int *)(((long)o + 0x10) & 0xFFFFFFFFFFFFFFFFULL) &= ~0x200;
+        *(int *)((long)o + 0x10) &= ~0x200;
         break;
     case 6: {
         unsigned int saved = (unsigned int)_ZN3IRQ7DisableEv();
@@ -36,5 +36,5 @@ extern "C" void func_0205c528(Outer *thiz, int r1, int r7)
         break;
     }
     }
-    *(int *)(((int)thiz + 4) & 0xFFFFFFFFFFFFFFFFULL) += r7;
+    *(int *)((int)thiz + 4) += r7;
 }

--- a/src/func_0205c5e4.c
+++ b/src/func_0205c5e4.c
@@ -8,8 +8,8 @@ extern unsigned int (*data_02086758[])(char*);
    plain (u32*)(r + off) straight into the ldr/str addressing mode; the ROM
    instead materialises the address into a scratch register first.  Widening
    the address through a 64-bit value forces that explicit base add. */
-#define REG(x) ((unsigned int*)(((long long)(int)(x))))
-#define REGU(x) ((unsigned int*)(long long)(unsigned)(x))
+#define REG(x) ((unsigned int*)(x))
+#define REGU(x) ((unsigned int*)(x))
 
 int func_0205c5e4(char* self, int idx) {
     char* r;

--- a/src/func_0205c788.c
+++ b/src/func_0205c788.c
@@ -5,7 +5,7 @@ extern void OS_WakeupThread(unsigned short *self);
 void func_0205c788(char *self, int arg)
 {
     func_0205d920((struct Node *)self);
-    *(int *)(((long long)(int)(self + 0xc))) &= ~0xf;
+    *(int *)(self + 0xc) &= ~0xf;
     *(int *)(self + 0x14) = arg;
     OS_WakeupThread((unsigned short *)(self + 0x18));
 }

--- a/src/func_0205c7e4.c
+++ b/src/func_0205c7e4.c
@@ -16,7 +16,7 @@ int func_0205c7e4(char* self)
     bit = (enum Bool)((*(int*)(self + 0x10) & 8) != 0);
     notset = (enum Bool)(bit == FALSE);
     if (notset == FALSE) {
-        int *p = (int*)(((unsigned long long)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFULL);
+        int *p = (int*)((unsigned long long)(self + 0x10));
         *p = *p & ~8;
         r = func_0205d044(self);
     }

--- a/src/func_0205c864.c
+++ b/src/func_0205c864.c
@@ -15,13 +15,13 @@ int func_0205c864(int *thiz)
         if (b == 0) {
             goto setflag;
         }
-        *(int *)(((long long)(int)((char*)thiz + 0x10))) |= 0x40;
+        *(int *)((char*)thiz + 0x10) |= 0x40;
         do {
             OS_SleepThread((char*)thiz + 0xe);
         } while ((*(int*)((char*)thiz + 0x10) & 0x40) ? 1 : 0);
         goto done;
     setflag:
-        *(int *)(((long long)(int)((char*)thiz + 0x10))) |= 8;
+        *(int *)((char*)thiz + 0x10) |= 8;
     done:
         ;
     }

--- a/src/func_0205c91c.c
+++ b/src/func_0205c91c.c
@@ -24,7 +24,7 @@ int func_0205c91c(S *s)
     if (((s->f10 & 2) ? 1 : 0) != 0) {
         ret = func_0205c864(s);
         if (((s->f10 & 4) ? 1 : 0) != 0) {
-            *(unsigned int *)(((int)&s->f10) & 0xFFFFFFFFFFFFFFFFu) &= ~4u;
+            *(unsigned int *)((int)&s->f10) &= ~4u;
             r = s->f38;
             s->f38 = 0;
             s->f20 = s->f30;

--- a/src/func_0205cbe4.c
+++ b/src/func_0205cbe4.c
@@ -32,7 +32,7 @@ void func_0205cbe4(Node *node)
     node->f0 = 0;
     node->prev = 0;
     node->next = node->prev;
-    *(u32 *)(((u32)node + 0x10) & 0xFFFFFFFFFFFFFFFFull) &= ~1u;
+    *(u32 *)((u32)node + 0x10) &= ~1u;
     if (data_020a804c.cur == node) {
         data_020a804c.c = 0;
         data_020a804c.b = 0;

--- a/src/func_0205cdf4.cpp
+++ b/src/func_0205cdf4.cpp
@@ -18,7 +18,7 @@ int func_0205cdf4(char *self, int arg1)
 
     *(int *)(self + 0x10) = arg1;
     *(int *)(self + 0x14) = 2;
-    *(int *)(((long long)(int)(self + 0xc))) |= 1;
+    *(int *)(self + 0xc) |= 1;
     saved = _ZN3IRQ7DisableEv();
     if (*(int *)(list + 0x10) & 0x80) {
         func_0205c788(self, 3);
@@ -26,12 +26,12 @@ int func_0205cdf4(char *self, int arg1)
         return 0;
     }
     if (mask & 0x1fc) {
-        *(int *)(((long long)(unsigned int)(self + 0xc))) |= 4;
+        *(int *)(self + 0xc) |= 4;
     }
     func_0205d8d8(self, list + 0x14);
     t = (*(int *)(list + 0x10) & 0x10) != 0;
     if (!t) {
-        *(int *)(((long long)(int)(list + 0x10))) |= 0x10;
+        *(int *)(list + 0x10) |= 0x10;
         _ZN3IRQ7RestoreEj(saved);
         if (*(int *)(list + 0x4c) & 0x200) {
             (*(void (**)(char *, int))(list + 0x48))(self, 9);

--- a/src/func_0205cfa4.c
+++ b/src/func_0205cfa4.c
@@ -25,7 +25,7 @@ void func_0205cfa4(Node *self)
             OS_WakeupThread(&self->f18);
             return;
         }
-        *(u32 *)(((u32)self + 0xc) & 0xFFFFFFFFFFFFFFFFull) |= 8u;
+        *(u32 *)((u32)self + 0xc) |= 8u;
         _ZN3IRQ7RestoreEj(saved);
         if (func_0205c5e4(self, self->f10) == 6) return;
         self = (Node *)func_0205d044(pool);

--- a/src/func_0205d3f4.c
+++ b/src/func_0205d3f4.c
@@ -26,15 +26,15 @@ int func_0205d3f4(Obj *t)
     int woken = 0;
     u32 irq = _ZN3IRQ7DisableEv();
     int busy = (t->flags & 1) ? 1 : 0;
-    if ((int)(((long long)busy)) != 0) {
+    if ((int)((long long)busy) != 0) {
         woken = (t->owner->cur != t) ? 1 : 0;
         if (woken) {
-            *(u32 *)(int)(((long long)(int)((int)t + 0xc))) |= 4;
+            *(u32 *)(int)((int)t + 0xc) |= 4;
         }
         do {
             OS_SleepThread(&t->queue);
             busy = (t->flags & 1) ? 1 : 0;
-        } while ((int)(((long long)busy)) != 0);
+        } while ((int)((long long)busy) != 0);
     }
     _ZN3IRQ7RestoreEj(irq);
     if (woken) {

--- a/src/func_0205d568.c
+++ b/src/func_0205d568.c
@@ -27,7 +27,7 @@ int func_0205d568(Node *node, int b, ...)
             return 0;
         }
     }
-    p = (unsigned int *)(((long long)(int)((char *)node + 0xc)));
+    p = (unsigned int *)((char *)node + 0xc);
     *p |= 0x10;
     *p &= ~0x20;
     return 1;

--- a/src/func_0205d5e8.c
+++ b/src/func_0205d5e8.c
@@ -8,7 +8,7 @@ int func_0205d5e8(char* self, int a1, int a2, int a3, int a4)
     *(int*)(self + 0x2c) = a2;
     *(int*)(self + 0x30) = a3;
     if(func_0205cdf4(self, 7) == 0) return 0;
-    p = (int*)((((long long)(int)(self + 0xc))));
+    p = (int*)(self + 0xc);
     *p |= 0x10;
     *p &= ~0x20;
     return 1;

--- a/src/func_0205dc7c.c
+++ b/src/func_0205dc7c.c
@@ -28,7 +28,7 @@ void func_0205dc7c(u32* q) {
         collected = 0;
         r6 = q[1];
         r5 = q[1] + q[2];
-        r4 = r5 + (u32)((int)(((long long)(int)(q[2] + q[3]))) - q[2]);
+        r4 = r5 + (u32)((int)(q[2] + q[3]) - q[2]);
         tail = 0;
         saved = _ZN3IRQ7DisableEv();
         prev = 0;

--- a/src/func_0205e280.c
+++ b/src/func_0205e280.c
@@ -9,7 +9,7 @@ typedef struct
 
 extern void func_0205e3d4(HashCtx* c);
 
-#define CNT (*(int*)(int)(((long long)(int)((char*)c + 0x1c))))
+#define CNT (*(int*)(int)((char*)c + 0x1c))
 
 void func_0205e280(HashCtx* c)
 {

--- a/src/func_02060228.c
+++ b/src/func_02060228.c
@@ -22,7 +22,7 @@ void func_02060228(void *fn)
     *(void **)(base + 0xd0) = base + 0x3c;
     *(void **)(base + 0x30) = fn;
     {
-        unsigned int *fp = (unsigned int *)(((long long)(int)(base + 0x34)));
+        unsigned int *fp = (unsigned int *)(base + 0x34);
         *fp |= 8;
     }
     func_02058048(base + 0x3c);

--- a/src/func_020603c8.cpp
+++ b/src/func_020603c8.cpp
@@ -28,7 +28,7 @@ extern "C" void func_020603c8(int arg)
             OS_SleepThread(g->sub);
         } while (g->flags & 4);
     }
-    u32* fp = (u32*)(((unsigned long long)((int)g + 0x34)) & 0xFFFFFFFFFFFFFFFFULL);
+    u32* fp = (u32*)((unsigned long long)((int)g + 0x34));
     *fp |= 4;
     IRQ::Restore(irq);
     func_02060364(arg);

--- a/src/func_02060484.c
+++ b/src/func_02060484.c
@@ -7,7 +7,7 @@ int func_0206062c(void* g);
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int flags);
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 int func_02060484(int a, int b, int c, int d, int e, int f)
 {

--- a/src/func_02060558.cpp
+++ b/src/func_02060558.cpp
@@ -32,7 +32,7 @@ extern "C" int func_02060558(int a, int b, int c, int d, int e, int f)
             OS_SleepThread(g->sub);
         } while (g->flags & 4);
     }
-    u32* fp = (u32*)(((unsigned long long)((int)g + 0x34)) & 0xFFFFFFFFFFFFFFFFULL);
+    u32* fp = (u32*)((unsigned long long)((int)g + 0x34));
     *fp |= 4;
     IRQ::Restore(irq);
     g->a = a;

--- a/src/func_0206071c.c
+++ b/src/func_0206071c.c
@@ -21,9 +21,9 @@ void func_0206071c(char *thiz)
     *((unsigned int *)((*((int *)thiz)) + 0x14)) = n;
     if (func_02060f60(thiz, 6, 1) == 0) break;
     CpuCopy8(e0, *((int *)(thiz + 0x1c)), n);
-    *((int *)(((int)thiz + 0x18) & 0xFFFFFFFFFFFFFFFFull)) += n;
-    *((int *)(((int)thiz + 0x1c) & 0xFFFFFFFFFFFFFFFFull)) += n;
-    *((int *)(((int)thiz + 0x20) & 0xFFFFFFFFFFFFFFFFull)) -= n;
+    *((int *)((int)thiz + 0x18)) += n;
+    *((int *)((int)thiz + 0x1c)) += n;
+    *((int *)((int)thiz + 0x20)) -= n;
   }
   while (*((int *)(thiz + 0x20)) != 0);
 

--- a/src/func_02060d1c.c
+++ b/src/func_02060d1c.c
@@ -12,7 +12,7 @@ void func_02060d1c(void)
 {
   DmaCh *new_var;
   char *g = data_020a8180;
-  DmaCh *ch = (DmaCh *) ((0x40000b0 + ((*((u32 *) (g + 0x24))) * 0xc)) & 0xFFFFFFFFFFFFFFFFULL);
+  DmaCh *ch = (DmaCh *) (0x40000b0 + ((*((u32 *) (g + 0x24))) * 0xc));
   u32 v;
   new_var = ch;
   new_var->a = 0x4100010;

--- a/src/func_02060ebc.c
+++ b/src/func_02060ebc.c
@@ -22,10 +22,10 @@ int func_02060ebc(Arg* a)
         int len = 0x200 - off;
         if ((unsigned int)len > (unsigned int)g->f20) len = g->f20;
         CpuCopy8((char*)a + 0x20 + off, (void*)g->f1c, len);
-        int *p18 = (int*)(((int)g + 0x18) & 0xFFFFFFFFFFFFFFFFULL);
-        int *p1c = (int*)(((int)g + 0x1c) & 0xFFFFFFFFFFFFFFFFULL);
+        int *p18 = (int*)((int)g + 0x18);
+        int *p1c = (int*)((int)g + 0x1c);
         *p18 += len;
-        int *p20 = (int*)(((int)g + 0x20) & 0xFFFFFFFFFFFFFFFFULL);
+        int *p20 = (int*)((int)g + 0x20);
         *p1c += len;
         *p20 -= len;
     }

--- a/src/func_020631dc.c
+++ b/src/func_020631dc.c
@@ -14,7 +14,7 @@ extern void func_02062aa4(void);
 
 #define H(o) (*(u16 *)(self + (o)))
 #define H414_LAUNDERED \
-    (*(u16 *)(((int)self + 0x414) & 0xFFFFFFFFFFFFFFFFULL))
+    (*(u16 *)((int)self + 0x414))
 
 int func_020631dc(u8 *self, int unitIdx, int mask, int elemSize, int flag)
 {

--- a/src/func_020647a4.c
+++ b/src/func_020647a4.c
@@ -1,6 +1,6 @@
 void func_020647a4(char *self, int value)
 {
-    *(int *)(((long long)(int)(self + 0x10))) += 1;
+    *(int *)(self + 0x10) += 1;
     *(int *)(self + 0xc) = value;
 
     int *arr = *(int **)(self + 0x14);

--- a/src/func_0206655c.c
+++ b/src/func_0206655c.c
@@ -7,7 +7,7 @@ extern void CpuCopy8(void *dst, void *src, int n);
 extern int func_02066fec(u32 a, int b, int c);
 extern u16 func_02065ef8(u16 a, u16 b);
 
-#define LD(t, x) ((t *)((((long long)(int)(x)))))
+#define LD(t, x) ((t *)(x))
 
 void func_0206655c(void *arg0, u32 arg1)
 {

--- a/src/func_02066a94.c
+++ b/src/func_02066a94.c
@@ -45,15 +45,15 @@ void func_02066a94(int arg0, char *arg1)
                 if (slot != -1) {
                     u32 off = (u8)slot * 0x5c4;
                     u32 mask = ~(1 << id);
-                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d46))) &= mask;
-                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d48))) |= (1 << id);
+                    *(u16 *)(data_020a9db8 + off + 0x1d46) &= mask;
+                    *(u16 *)(data_020a9db8 + off + 0x1d48) |= (1 << id);
                     *(s8 *)(data_020a9db8 + (id - 1) + 0x1526) = -1;
-                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d44))) &= mask;
+                    *(u16 *)(data_020a9db8 + off + 0x1d44) &= mask;
                 }
             }
             if (*(u16 *)(data_020a9db8 + 0x1536) & (1 << *(u16 *)(arg1 + 0x10))) {
-                *(u8 *)(((long long)(int)(data_020a9db8 + 0x1535))) -= 1;
-                *(u16 *)(((long long)(int)(data_020a9db8 + 0x1536))) &= ~(1 << *(u16 *)(arg1 + 0x10));
+                *(u8 *)(data_020a9db8 + 0x1535) -= 1;
+                *(u16 *)(data_020a9db8 + 0x1536) &= ~(1 << *(u16 *)(arg1 + 0x10));
             }
             {
                 u16 id2 = *(u16 *)(arg1 + 0x10);

--- a/src/func_02067bfc.c
+++ b/src/func_02067bfc.c
@@ -68,7 +68,7 @@ int func_02067bfc(Ctx *a, Ctx *b, unsigned int c)
             a = (Ctx *)localbuf;
             base = localbuf[10] - localbuf[8];
             CpuCopy8(ctx, cur, 0x160);
-            *(unsigned int *)((long long)(int)(cur + 0x60)) |= 0x406000;
+            *(unsigned int *)(cur + 0x60) |= 0x406000;
         }
 
         threshold = ctx->f2c + 0x160 + ctx->f3c;

--- a/src/func_0206853c.c
+++ b/src/func_0206853c.c
@@ -12,5 +12,5 @@ void func_0206853c(char *self, void *src, unsigned int flags, int s)
     *(unsigned char *)(self + 0x358) = (unsigned char)cnt;
     *(short *)(self + 0x35a) = (short)(flags | 1);
     *(short *)(self + 0x35c) = (short)s;
-    *(unsigned char *)(((long long)(int)(self + 0x4ac))) += 1;
+    *(unsigned char *)(self + 0x4ac) += 1;
 }

--- a/src/func_0206c8b4.c
+++ b/src/func_0206c8b4.c
@@ -4,14 +4,14 @@ int func_0206c8b4(double x)
     int hi, lo;
     int a, b, p;
 
-    a = (int)((long long)(int)&x);
+    a = (int)(&x);
     p = (int)((long long)(a + 7));
     if (p & 1)
         hi = (*(unsigned short *)(p - 1) & 0xff00) >> 8;
     else
         hi = *(unsigned short *)p & 0xff;
 
-    b = (int)((long long)(int)&x);
+    b = (int)(&x);
     p = (int)((long long)(b + 6));
     if (p & 1)
         lo = (*(unsigned short *)(p - 1) & 0xff00) >> 8;

--- a/src/func_0206df90.c
+++ b/src/func_0206df90.c
@@ -24,7 +24,7 @@ int func_0206df90(char *thiz, int *out)
       return r;
     }
     new_var = thiz + 0x18;
-    *(int *)(((unsigned long long)(int)new_var) & 0xFFFFFFFFFFFFFFFFULL) += *((int *) (thiz + 0x28));
+    *(int *)(new_var) += *((int *) (thiz + 0x28));
   }
   func_0206e030(thiz);
   return 0;

--- a/src/func_0206e030.c
+++ b/src/func_0206e030.c
@@ -2,7 +2,7 @@ void func_0206e030(char *self)
 {
     *(int *)(self + 0x24) = *(int *)(self + 0x1c);
     *(int *)(self + 0x28) = *(int *)(self + 0x20);
-    *(int *)(((long long)(int)(self + 0x28))) -=
+    *(int *)(self + 0x28) -=
         (*(int *)(self + 0x18) & *(int *)(self + 0x2c));
     *(int *)(self + 0x34) = *(int *)(self + 0x18);
 }

--- a/src/func_0206e450.c
+++ b/src/func_0206e450.c
@@ -8,7 +8,7 @@ int func_0206e450(char* obj, const void* src, unsigned int n)
         n = len - off;
     func_0206e310(*(char**)(obj) + off, src, n);
     {
-        int* p = (int*)(((long long)(int)(obj + 8)));
+        int* p = (int*)(obj + 8);
         *p = *p + n;
     }
     return 1;

--- a/src/func_0206f338.c
+++ b/src/func_0206f338.c
@@ -57,7 +57,7 @@ void func_0206f338(struct S *s, int p)
     }
 
     if (carry != 0) {
-        short *pc = (short *)(((int)s + 2) & 0xFFFFFFFFFFFFFFFFULL);
+        short *pc = (short *)((int)s + 2);
         *pc = *pc + 1;
         s->len = 1;
         s->digits[0] = 0x31;

--- a/src/func_0206fd6c.c
+++ b/src/func_0206fd6c.c
@@ -50,7 +50,7 @@ unsigned char *func_0206fd6c(unsigned char *format_string, char **arg, print_for
     f.field_width           = 0;
     f.precision             = 0;
 
-    s = (unsigned char *)(((long long)(int)(format_string + 1)));
+    s = (unsigned char *)(format_string + 1);
     if ((c = *s) == '%') {
         f.conversion_char = (unsigned char)c;
         *format = f;

--- a/src/func_020707cc.c
+++ b/src/func_020707cc.c
@@ -1,6 +1,6 @@
 double func_020707cc(double x)
 {
-    int a = (int)((long long)(int)&x);
+    int a = (int)(&x);
     int *p = (int *)((long long)(a + 4));
     *p &= 0x7fffffff;
     return x;

--- a/src/func_02071364.c
+++ b/src/func_02071364.c
@@ -54,7 +54,7 @@ void func_02071364(Decimal *result, const Decimal *x, const Decimal *y)
     result->exp = (short)(x->exp + y->exp);
 
     if (accumulator) {
-        short *exp = (short *)(int)(((long long)(int)((char *)result + 2)));
+        short *exp = (short *)(int)((char *)result + 2);
         *--ip = (unsigned char)accumulator;
         *exp = *exp + 1;
     }

--- a/src/func_02071864.c
+++ b/src/func_02071864.c
@@ -36,7 +36,7 @@ void func_02071864(Obj *t, Wrap *w)
     t->b6c = (f80 != 0);
     t->h68 = data[1] << 4;
     p = data + 2;
-    *(u16 *)(int)(((long long)(int)((int)t + 0x68))) |= 0x4000;
+    *(u16 *)(int)((int)t + 0x68) |= 0x4000;
     p = func_02071a50(p, &t->w60);
     if (f40) {
         p = func_02071a50(p, &t->w64);

--- a/src/func_02072168.c
+++ b/src/func_02072168.c
@@ -55,7 +55,7 @@ void func_02072168(char *c, char *s, char *end) {
         case 1: {
             int v0;
             ReadSignedVarInt(p + 1, &v0);
-            (*(int *)(((long long)(int)(s + 8)) & 0xFFFFFFFFFFFFFFFFLL)) += v0;
+            (*(int *)(s + 8)) += v0;
             break;
         }
         case 2: {

--- a/src/func_ov001_020aa420.c
+++ b/src/func_ov001_020aa420.c
@@ -70,7 +70,7 @@ void func_ov001_020aa420(void) {
         if (reqFlag == 0) {
             if (node != 0) {
                 do {
-                    *(u8 *)(((long long)(int)((char *)node + 0x1b))) &= ~2;
+                    *(u8 *)((char *)node + 0x1b) &= ~2;
                     if (node->field19 == 1) {
                         *flagByte = 1;
                     }
@@ -97,7 +97,7 @@ void func_ov001_020aa420(void) {
                     if (node->flags.b0) {
                         if (node->soundHandle == -1) {
                             node->soundHandle = func_0202a8e0(node->field4, node->field18);
-                            *(u8 *)(((long long)(int)((char *)node + 0x1b))) |= 2;
+                            *(u8 *)((char *)node + 0x1b) |= 2;
                             func_ov001_020aa6b0(node, 1);
                         }
                         handled = 1;
@@ -111,7 +111,7 @@ void func_ov001_020aa420(void) {
                         if (node->flags.b3) {
                             best = node;
                         } else {
-                            *(u8 *)(((long long)(int)((char *)node + 0x1b))) |= 8;
+                            *(u8 *)((char *)node + 0x1b) |= 8;
                         }
                     }
                 } else {
@@ -122,7 +122,7 @@ void func_ov001_020aa420(void) {
         }
 
         if (func_ov001_020aa7b8(i, best) != 0) {
-            *(u8 *)(((long long)(int)((char *)best + 0x1b))) |= 2;
+            *(u8 *)((char *)best + 0x1b) |= 2;
             best->soundHandle = func_0202a8e0(best->field4, best->field18);
             func_ov001_020aa6b0(best, 1);
             func_ov001_020aa6e4(i, best->field19, best);

--- a/src/func_ov001_020aadac.c
+++ b/src/func_ov001_020aadac.c
@@ -10,7 +10,7 @@ extern int data_0209f3e8[];
 extern unsigned char data_ov001_020ad62c[];
 extern int* data_ov001_020ad634[];
 
-#define LAUNDER_U8_PTR(p) ((unsigned char*)(((long long)(int)(p))))
+#define LAUNDER_U8_PTR(p) ((unsigned char*)(p))
 
 void func_ov001_020aadac(void) {
     char* fp = data_0209f394;

--- a/src/func_ov001_020aaf40.c
+++ b/src/func_ov001_020aaf40.c
@@ -27,7 +27,7 @@ void func_ov001_020aaf40(void)
             while (node) {
                 if (*(int*)(node + 0x14) != -1 && *(unsigned char*)(node + 0x1a) != 0) {
                     int v;
-                    *(unsigned char *)(int)(((long long)(int)(node + 0x1a))) -= 1;
+                    *(unsigned char *)(int)(node + 0x1a) -= 1;
                     v = *(unsigned char*)(node + 0x1a);
                     if (v == 0) {
                         func_ov001_020aa6b0(node, 1);

--- a/src/func_ov001_020ab228.c
+++ b/src/func_ov001_020ab228.c
@@ -18,7 +18,7 @@ void func_ov001_020ab228(char* c, char* a1, int idx, int a3, unsigned char a5){
     *(unsigned char*)(c+0x1a) = 0;
     *(unsigned char*)(c+0x1b) = 0;
     {
-        unsigned char *p1b = (unsigned char *)(int)(((long long)(int)(c + 0x1b)));
+        unsigned char *p1b = (unsigned char *)(int)(c + 0x1b);
         *p1b = (*p1b & ~1) | (a5 & 1);
     }
     if(a5!=0 || a3==3) func_ov001_020aa6cc(idx);

--- a/src/func_ov001_020ab3c4.c
+++ b/src/func_ov001_020ab3c4.c
@@ -6,6 +6,6 @@ void *func_ov001_020ab3c4(void *r0) {
     *(int *)(ptr + 0xc) = 0;
     *(int *)(ptr + 0x10) = 0;
 
-    *(unsigned char *)(int)(((long long)(int)(ptr + 0x1b))) |= 4;
+    *(unsigned char *)(int)(ptr + 0x1b) |= 4;
     return r0;
 }

--- a/src/func_ov002_020ad660.cpp
+++ b/src/func_ov002_020ad660.cpp
@@ -51,7 +51,7 @@ struct VB {
 
 
 
-#define LAUNDER(p) ((int)(((long long)(int)(p))))
+#define LAUNDER(p) ((int)(p))
 
 extern "C" int func_ov002_020ad660(void *cc, void *pp, void *r5p, int flags)
 {

--- a/src/func_ov002_020ae9f8.c
+++ b/src/func_ov002_020ae9f8.c
@@ -5,5 +5,5 @@ void func_ov002_020ae9f8(char *self)
     *(unsigned int *)(self + 0x98) = 0;
     *(unsigned int *)(self + 0xa8) = 0;
     *(unsigned short *)(self + 0x102) = 0xf;
-    *(unsigned int *)(((long long)(int)(self + 0xb0))) &= ~0x1;
+    *(unsigned int *)(self + 0xb0) &= ~0x1;
 }

--- a/src/func_ov002_020aea30.cpp
+++ b/src/func_ov002_020aea30.cpp
@@ -18,9 +18,9 @@ struct C {
 };
 extern "C" void func_ov002_020aea30(C* c, int a, int b) {
   if (c->f10c == 0) return;
-  (*(unsigned int*)((long long)(int)((char*)c + 0xb0))) &= ~0x10000000;
+  (*(unsigned int*)((char*)c + 0xb0)) &= ~0x10000000;
   c->f102 = 0;
   (c->*data_ov002_0210db80[c->f10c - 1])(a, b);
   c->f9c = -0x2000;
-  (*(unsigned int*)((unsigned long long)(unsigned int)((char*)c + 0xb0))) &= ~0x10000000;
+  (*(unsigned int*)((char*)c + 0xb0)) &= ~0x10000000;
 }

--- a/src/func_ov002_020aefa4.c
+++ b/src/func_ov002_020aefa4.c
@@ -1,4 +1,4 @@
 void func_ov002_020aefa4(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x12c))) |= 0x8000;
+    *(unsigned int *)(self + 0x12c) |= 0x8000;
 }

--- a/src/func_ov002_020aefb8.cpp
+++ b/src/func_ov002_020aefb8.cpp
@@ -27,9 +27,9 @@ void func_ov002_020aefb8(char* self) {
     int *pz;
     ((Actor*)self)->UpdatePosWithHorzSpeedAndAng();
     if (((WithMeshClsn*)(self + 0x144))->IsOnGround()) {
-        px = (int*)(int)(((long long)(int)(self + 0xa4)));
+        px = (int*)(int)(self + 0xa4);
         *px += *(int*)(self + 0xd4) * 0xa;
-        pz = (int*)(int)(((long long)(int)(self + 0xac)));
+        pz = (int*)(int)(self + 0xac);
         *pz += *(int*)(self + 0xdc) * 0xa;
         if (((WithMeshClsn*)(self + 0x144))->JustHitGround()) {
             *(int*)(self + 0xa8) = -(*(int*)(self + 0xa8) << 2) / 10;

--- a/src/func_ov002_020af0c0.c
+++ b/src/func_ov002_020af0c0.c
@@ -1,5 +1,5 @@
 typedef struct Vector3 { int x, y, z; } Vector3;
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
+#define AT(p,off) ((void*)(int)((char*)(p)+(off)))
 extern short data_02082214[];
 #define SINE_TABLE data_02082214
 extern char* _ZN5Actor13ClosestPlayerEv(void*);

--- a/src/func_ov002_020af474.c
+++ b/src/func_ov002_020af474.c
@@ -11,7 +11,7 @@ void func_ov002_020af474(char* o)
     }
 
     {
-        s16* p = (s16*)(((long long)(int)(o + 0x92)));
+        s16* p = (s16*)(o + 0x92);
         *p = *p - 0x1000;
     }
 

--- a/src/func_ov002_020af7cc.c
+++ b/src/func_ov002_020af7cc.c
@@ -2,7 +2,7 @@ void func_ov002_020af7cc(char* c)
 {
     *(unsigned char*)(c + 0x38e) = 1;
     if (*(int*)(c + 0x60) >= *(int*)(c + 0x37c) + 0x64000) return;
-    *(int*)(((long long)(int)(c + 0x60))) += 0x5000;
+    *(int*)(c + 0x60) += 0x5000;
     if (*(int*)(c + 0x60) < *(int*)(c + 0x37c) + 0x64000) return;
     *(int*)(c + 0x60) = *(int*)(c + 0x37c) + 0x64000;
     *(int*)(c + 0x384) = 0;

--- a/src/func_ov002_020af908.c
+++ b/src/func_ov002_020af908.c
@@ -1,6 +1,6 @@
 extern void func_ov002_020af924(char *self);
 
 void func_ov002_020af908(char *self) {
-    *(short *)(int)(((long long)(int)(self + 0x8e))) += 0xc00;
+    *(short *)(int)(self + 0x8e) += 0xc00;
     func_ov002_020af924(self);
 }

--- a/src/func_ov002_020af950.c
+++ b/src/func_ov002_020af950.c
@@ -19,7 +19,7 @@ void func_ov002_020af950(char *self)
       *((unsigned char *)(self + 0x38e)) = 1;
       func_ov002_020aefa4(self);
       _ZN5Sound9PlayBank3EjRK7Vector3(0x68, self + 0x74);
-      *((unsigned int *)(((long long)(int)(self + 0xb0)))) &= ~1;
+      *((unsigned int *)(self + 0xb0)) &= ~1;
       return;
 
     case 1:
@@ -35,7 +35,7 @@ void func_ov002_020af950(char *self)
       if (*((unsigned short *)(self + 0x100)) != 0x25)
         return;
 
-      *((unsigned int *)(((long long)(int)(self + 0x128)))) &= ~1;
+      *((unsigned int *)(self + 0x128)) &= ~1;
       *((int *)(self + 0x388)) = 1;
       *((int *)(self + 0x9c)) = 0;
       *((int *)(self + 0x98)) = 0xa000;

--- a/src/func_ov002_020afa50.c
+++ b/src/func_ov002_020afa50.c
@@ -6,6 +6,6 @@
 /* dCapEnemy_c::Kill - recovered from vtable slot identity */
 
 void func_ov002_020afa50(char *self) {
-    *(short *)(int)(((long long)(int)(self + 0x8e))) += 0xc00;
+    *(short *)(int)(self + 0x8e) += 0xc00;
     func_ov002_020afa6c(self);
 }

--- a/src/func_ov002_020afa98.c
+++ b/src/func_ov002_020afa98.c
@@ -19,7 +19,7 @@ void func_ov002_020afa98(char *c)
         *(u8 *)(c + 0x38e) = 1;
         func_ov002_020aefa4(c);
         _ZN5Sound9PlayBank3EjRK7Vector3(0x68, (struct Vector3 *)(c + 0x74));
-        *(u32 *)(((long long)(int)(c + 0xb0))) &= ~1;
+        *(u32 *)(c + 0xb0) &= ~1;
         return;
     case 1:
         func_ov002_020aefb8(c);
@@ -39,7 +39,7 @@ void func_ov002_020afa98(char *c)
         func_ov002_020af474(c);
         if (*(u16 *)(c + 0x100) != 0x25)
             return;
-        *(u32 *)(((long long)(int)(c + 0x128))) &= ~1;
+        *(u32 *)(c + 0x128) &= ~1;
         *(s32 *)(c + 0x388) = 1;
         *(u32 *)(c + 0x98) = 0x8000;
         return;

--- a/src/func_ov002_020b12ec.c
+++ b/src/func_ov002_020b12ec.c
@@ -17,7 +17,7 @@ int func_ov002_020b12ec(char *self)
     }
     r3 = 0;
     *(unsigned int *)(self + 0xd0) = r3;
-    slot = (char *)(((long long)(int)(self + 0xb0)));
+    slot = (char *)(self + 0xb0);
     r1 = *(unsigned int *)slot;
     r1 &= ~0xe0000u;
     *(unsigned int *)slot = r1;

--- a/src/func_ov002_020b16c4.c
+++ b/src/func_ov002_020b16c4.c
@@ -19,7 +19,7 @@ extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16as(unsigned int id, unsig
                                                           int e, int f);
 extern void _ZN9PowerStar13AddStarMarkerEv(void *o);
 
-#define LAUNDER(p) ((int)(((long long)(int)(p))))
+#define LAUNDER(p) ((int)(p))
 
 void func_ov002_020b16c4(void *cc, void *pp)
 {

--- a/src/func_ov002_020b18f0.c
+++ b/src/func_ov002_020b18f0.c
@@ -22,7 +22,7 @@ void func_ov002_020b18f0(char* c)
     if (SublevelToLevel(data_0209f2f8) >= 0xf) return;
     if (c == 0) return;
     if (data_0209f358[*(unsigned char*)(c + 0x6d8)] < 0x64) return;
-    p = (struct Vector3*)(((long long)(int)(c + 0x5c)));
+    p = (struct Vector3*)(c + 0x5c);
     vec.x = p->x;
     y = p->y;
     vec.y = y;

--- a/src/func_ov002_020b1ad4.c
+++ b/src/func_ov002_020b1ad4.c
@@ -29,7 +29,7 @@ void func_ov002_020b1ad4(char *self)
         if (data_0209f2f8 == 0xb) v <<= 1;
         *(int *)(self + 0x98) = v;
         *(int *)(self + 0xa8) = 0x14000;
-        ((struct Bits3ae *)(int)(((long long)(int)(self + 0x3ae))))->field++;
+        ((struct Bits3ae *)(int)(self + 0x3ae))->field++;
         _ZN12WithMeshClsn13SetLimMovFlagEv(self + 0x1ac);
         *(short *)(self + 0x3a8) = 0x1c2;
     }

--- a/src/func_ov002_020b20b4.cpp
+++ b/src/func_ov002_020b20b4.cpp
@@ -12,9 +12,9 @@ void func_ov002_020b20b4(char* c){
   func_ov002_020b1008(c);
   if (((struct BF3ae*)(c+0x3ae))->b0) return;
   if (_ZN5Event6GetBitEj(*(unsigned char*)(c+0x3ab)) == 0) return;
-  ((struct BF3ae*)(int)(((long long)(int)((int)c + 0x3ae))))->b0 = 1;
+  ((struct BF3ae*)(int)((int)c + 0x3ae))->b0 = 1;
   *(int*)(c+0x3a4) = 4;
-  *(int*)(int)(((long long)(int)((int)c + 0x190))) &= ~1;
+  *(int*)(int)((int)c + 0x190) &= ~1;
   char* found = (char*)_ZN5Actor15FindWithActorIDEjPS_(0xa, 0);
   if (found) {
     *(short*)(c+0x3a8) = *(unsigned short*)(found+0x32a);

--- a/src/func_ov002_020b2a34.c
+++ b/src/func_ov002_020b2a34.c
@@ -9,7 +9,7 @@ void func_ov002_020b2a34(char* c, char* p)
 {
     int state = *(int*)(c + 0x3a0);
     if (state == 1) {
-        *(int*)(((long long)(int)(c + 0x60))) += 0x50000;
+        *(int*)(c + 0x60) += 0x50000;
         func_ov002_020b16c4(c, p);
         return;
     }

--- a/src/func_ov002_020b4714.c
+++ b/src/func_ov002_020b4714.c
@@ -14,7 +14,7 @@ void func_ov002_020b4714(char* a) {
             struct Vector3 v;
             struct Vector3* p;
             char* spawned;
-            p = (struct Vector3*)(((long long)(int)(b + 0x5c)));
+            p = (struct Vector3*)(b + 0x5c);
             v.x = p->x;
             v.y = p->y;
             v.z = p->z;

--- a/src/func_ov002_020b4bfc.c
+++ b/src/func_ov002_020b4bfc.c
@@ -4,7 +4,7 @@ extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 extern void _ZN16MeshColliderBase7DisableEv(void*);
 
-#define LD(p) ((int)(((long long)(int)(p))))
+#define LD(p) ((int)(p))
 
 int func_ov002_020b4bfc(char* c)
 {

--- a/src/func_ov002_020b5c4c.c
+++ b/src/func_ov002_020b5c4c.c
@@ -29,7 +29,7 @@ int func_ov002_020b5c4c(char *c)
     if (func_ov002_020b5ab4(c) != 0) {
         if (_Z14ApproachLinearRiii((int *)(c + 0x330),
                 *(void **)(c + 0x33c) != 0 ? -0x28000 : 0, 0x5000) != 0) {
-            short *ctr = (short *)((long long)(int)(c + 0x338));
+            short *ctr = (short *)(c + 0x338);
             short cval = *ctr;
             char *st = c + 0x300;
             *ctr = (short)(cval + 0xa00);
@@ -43,7 +43,7 @@ int func_ov002_020b5c4c(char *c)
             val1 = val2;
         } else {
             char *target = *(char **)(c + 0x33c);
-            struct Vector3 *tp = (struct Vector3 *)((long long)(int)(target + 0x5c));
+            struct Vector3 *tp = (struct Vector3 *)(target + 0x5c);
             tpos.x = tp->x;
             tpos.y = tp->y;
             tpos.z = tp->z;

--- a/src/func_ov002_020b6718.cpp
+++ b/src/func_ov002_020b6718.cpp
@@ -4,7 +4,7 @@ extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 int func_ov002_020b6718(char* c) {
-    short* p=(short*)(((long long)(int)(c+0x94)));
+    short* p=(short*)(c+0x94);
     *p = *p + *(short*)(c+0x96);
     *(short*)(c+0x8e) = *(short*)(c+0x94);
     _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov002_020b6b38.c
+++ b/src/func_ov002_020b6b38.c
@@ -33,7 +33,7 @@ int func_ov002_020b6b38(struct Obj* c)
     int i;
     Vector3 mid;
     Vector3 res;
-    short* rzp = (short*)((long long)(int)((char*)c + 0x90));
+    short* rzp = (short*)((char*)c + 0x90);
     *rzp = *rzp + 0x100;
     {
         int b = (int)((c->flags & 8) != 0);

--- a/src/func_ov002_020b6c54.c
+++ b/src/func_ov002_020b6c54.c
@@ -22,7 +22,7 @@ int func_ov002_020b6c54(char* sb, char** arg, unsigned int actorID){
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(sb+0x124, m, sb+0x2ec, 0x199, *(short*)(sb+0x8e), arg[2]);
   for(i = 0; i < 4; i++){
     char* sp;
-    *(int*)(sb + (int)((unsigned long long)i & 0xFFFFFFFFFFFFFFFFull)*4 + 0x320) = 0;
+    *(int*)(sb + (int)((unsigned long long)i)*4 + 0x320) = 0;
     sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16as(actorID, 0, (struct Vector3*)(sb+0x5c), 0, *(signed char*)(sb+0xcc), -1);
     if(sp != 0) *(int*)(sb + i*4 + 0x320) = *(int*)(sp+4);
   }

--- a/src/func_ov002_020b7200.c
+++ b/src/func_ov002_020b7200.c
@@ -11,8 +11,8 @@ int func_ov002_020b7200(char* c)
 
     if (*(int*)(c + 0x3f0) == 0xa || *(int*)(c + 0x3f0) == 0xf) {
         if (*(int*)(c + 0x3c0) != 0) {
-            sp = (short*)((long long)(int)(
-                (char*)*(int*)(c + 0x3c0) + 0x8c));
+            sp = (short*)(
+                (char*)*(int*)(c + 0x3c0) + 0x8c);
             *(short*)(c + 0x92) = sp[0];
             *(short*)(c + 0x94) = sp[1];
             *(short*)(c + 0x96) = sp[2];
@@ -20,8 +20,8 @@ int func_ov002_020b7200(char* c)
             *(short*)(c + 0x8e) = *(short*)(c + 0x94);
             *(short*)(c + 0x90) = *(short*)(c + 0x96);
 
-            ip = (int*)((long long)(int)(
-                (char*)*(int*)(c + 0x3c0) + 0x5c));
+            ip = (int*)(
+                (char*)*(int*)(c + 0x3c0) + 0x5c);
             *(int*)(c + 0x5c) = ip[0];
             *(int*)(c + 0x60) = ip[1];
             *(int*)(c + 0x64) = ip[2];

--- a/src/func_ov002_020b7330.c
+++ b/src/func_ov002_020b7330.c
@@ -22,7 +22,7 @@ int func_ov002_020b7330(char* self)
     if (state == 0xa || state == 0xf) {
         char* closest = (char*)_ZN5Actor13ClosestPlayerEv(self);
         if (closest != 0) {
-            s16* src = (s16*)((long long)(int)(closest + 0x8c));
+            s16* src = (s16*)(closest + 0x8c);
             *(s16*)(self + 0x92) = src[0];
             *(s16*)(self + 0x94) = src[1];
             *(s16*)(self + 0x96) = src[2];

--- a/src/func_ov002_020b7b70.c
+++ b/src/func_ov002_020b7b70.c
@@ -27,7 +27,7 @@ int func_ov002_020b7b70(char* c)
         *(u16*)(c + 0x404) = *(u16*)(c + 0x100);
     }
 
-    p = (int *)((unsigned long long)(c + 0x12c) & 0xFFFFFFFFFFFFFFFFULL);
+    p = (int *)((unsigned long long)(c + 0x12c));
     val = *p;
     ret = 1;
     val |= 0x8000;

--- a/src/func_ov002_020b7c30.c
+++ b/src/func_ov002_020b7c30.c
@@ -11,7 +11,7 @@ int func_ov002_020b7c30(void* c) {
   if (*(int*)((char*)c + 0x9c) != 0) {
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, (char*)c + 0x110);
     _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (char*)c + 0x144, 0);
-    *(unsigned*)(((long long)(int)((char*)c + 0x12c))) |= 0x8000;
+    *(unsigned*)((char*)c + 0x12c) |= 0x8000;
     if (_ZNK12WithMeshClsn10IsOnGroundEv((char*)c + 0x144)) {
       *(int*)((char*)c + 0x98) = 0;
       func_ov002_020b6fcc(c);

--- a/src/func_ov002_020b94c4.c
+++ b/src/func_ov002_020b94c4.c
@@ -47,9 +47,9 @@ void func_ov002_020b94c4(char* c)
     if (X > 0)
         delta += X;
     if (a > 0)
-        *(s16*)(((long long)(int)(c + 0x8e))) += delta;
+        *(s16*)(c + 0x8e) += delta;
     else
-        *(s16*)(((long long)(int)(c + 0x8e))) -= delta;
+        *(s16*)(c + 0x8e) -= delta;
 
     func_0203568c((int*)(c + 0x200), 0x3c000);
     func_02035684((int*)(c + 0x200), 0x3c000);

--- a/src/func_ov002_020bac18.c
+++ b/src/func_ov002_020bac18.c
@@ -6,9 +6,9 @@ extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int bankId, const Vector3 *pos);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *thiz);
 
-#define LM(p) ((u8*)(int)(((long long)(int)(p))))
-#define LMS(p) ((short*)(int)(((long long)(int)(p))))
-#define LMI(p) ((int*)(int)(((long long)(int)(p))))
+#define LM(p) ((u8*)(int)(p))
+#define LMS(p) ((short*)(int)(p))
+#define LMI(p) ((int*)(int)(p))
 
 int func_ov002_020bac18(char *c)
 {

--- a/src/func_ov002_020bb27c.c
+++ b/src/func_ov002_020bb27c.c
@@ -11,7 +11,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
 /* The ROM materializes `self + off` into a scratch register instead of folding the
    offset into the ldr/str. The 64-bit identity mask launders the address so mwccarm
    emits `add rN, self, #off` + `ldr/str [rN]`. */
-#define LD(p) ((int)(((long long)(int)(p))))
+#define LD(p) ((int)(p))
 
 void func_ov002_020bb27c(char* self, char* arg){
   if (*(u8*)(self+0x58e) == 0) return;

--- a/src/func_ov002_020bbac8.c
+++ b/src/func_ov002_020bbac8.c
@@ -27,8 +27,8 @@ void func_ov002_020bbac8(struct Obj* self)
     self->unk98 = 0;
     self->unkA8 = 0;
     other = self->unk59C;
-    py = (int*)(((long long)(int)((char*)self + 0x60)));
-    src = (Vec3*)(((long long)(int)((char*)other + 0x5c)));
+    py = (int*)((char*)self + 0x60);
+    src = (Vec3*)((char*)other + 0x5c);
     self->pos.x = src->x;
     self->pos.y = src->y;
     self->pos.z = src->z;


### PR DESCRIPTION
Chunk 2 of 5 of #1356's delaunder sweep, split so each part lands under the PR validator's 200-file cap and every file gets a real CI byte gate. #1356 as a whole was refused with `refusing to auto-validate 878 source/build-data files (cap 200) -- unusually large, please review by hand`, so no byte gate ran on any of it.

176 files. Every site was removed only when the ROM still agreed with the result, one site at a time, via `tools/delaunder.py`.

Independently verified before splitting: all 878 files of #1356's merge result compile and reproduce the ROM byte-for-byte under their pinned compiler with strict relocation-destination checking, 0 failing, 0 skipped. The chunks are disjoint subsets of that verified set, and per-file removals are independent of each other.

Authorship preserved. The #1357 metric restore (#1359) lands after all five, because the root baseline it banks holds post-sweep numbers (282 files / 566 sites).