### PR TITLE
Remove launder sites the ROM does not need (4/5)

### DIFF
--- a/src/func_ov006_020ec2bc.c
+++ b/src/func_ov006_020ec2bc.c
@@ -59,7 +59,7 @@ void func_ov006_020ec2bc(struct C* c)
     g.y = -0x10000;
     c->s7a[0] = (s16)(c->s7a[1] + (((c->s7a[1] - c->s7a[2]) << 14) >> 16));
     func_0203d388(&g, c->s7a[0]);
-    func_0203d704(&h, (V2*)((long long)(int)c->v18) + 1, &g);
+    func_0203d704(&h, (V2*)(c->v18) + 1, &g);
     c->v18[0].x = h.x;
     c->v18[0].y = h.y;
 }

--- a/src/func_ov006_020ec458.c
+++ b/src/func_ov006_020ec458.c
@@ -20,11 +20,11 @@ void func_ov006_020ec458(Obj* self) {
     s16 v = self->unk76;
     if (v < 0 && self->entries[0].val < -0x60000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((long long)(int)((char*)self + (i << 3) + 0x18)))) += 0x170000;
+            (*(int*)((char*)self + (i << 3) + 0x18)) += 0x170000;
         return;
     }
     if (v > 0 && self->entries[0].val > 0x160000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((unsigned long long)(unsigned int)((char*)self + (i << 3) + 0x18)))) -= 0x170000;
+            (*(int*)((char*)self + (i << 3) + 0x18)) -= 0x170000;
     }
 }

--- a/src/func_ov006_020ec6e8.c
+++ b/src/func_ov006_020ec6e8.c
@@ -39,7 +39,7 @@ void func_ov006_020ec6e8(char *c)
         int rb;
         s16 a;
         s16 d;
-        *(s16*)(int)(((long long)(int)(c + 0x78))) -= 1;
+        *(s16*)(int)(c + 0x78) -= 1;
         if (*(s16*)(c + 0x78) >= 0) return;
         *(s16*)(c + 0x78) = (s16)((((int)((unsigned int)(RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 19) * 0x1e) >> 12) + 0x3c);
         ra = RandomIntInternal(&data_0209e650);

--- a/src/func_ov006_020ec93c.c
+++ b/src/func_ov006_020ec93c.c
@@ -20,11 +20,11 @@ void func_ov006_020ec93c(Obj* self) {
     s16 v = self->unk76;
     if (v < 0 && self->entries[0].val < -0x60000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((long long)(int)((char*)self + (i << 3) + 0x18)))) += 0x170000;
+            (*(int*)((char*)self + (i << 3) + 0x18)) += 0x170000;
         return;
     }
     if (v > 0 && self->entries[0].val > 0x160000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((unsigned long long)(unsigned int)((char*)self + (i << 3) + 0x18)))) -= 0x170000;
+            (*(int*)((char*)self + (i << 3) + 0x18)) -= 0x170000;
     }
 }

--- a/src/func_ov006_020ecee4.c
+++ b/src/func_ov006_020ecee4.c
@@ -13,8 +13,8 @@ extern void func_ov004_020b2220(int a, int b, void *c, int d, int e, int f, int 
 
 typedef struct { int a; int b; } Pair;
 
-#define PAIR0(s) ((Pair *)(int)(((long long)(int)((char *)(s) + 0x4660)) & 0xFFFFFFFFFFFFFFFFLL))
-#define PAIR1(s) ((Pair *)(int)(((unsigned long long)(unsigned int)((char *)(s) + 0x4660)) & 0xFFFFFFFFFFFFFFFFULL))
+#define PAIR0(s) ((Pair *)(int)((char *)(s) + 0x4660))
+#define PAIR1(s) ((Pair *)(int)((char *)(s) + 0x4660))
 
 extern Pair data_ov006_0213c9ac;
 extern Pair data_ov006_0213c994;

--- a/src/func_ov006_020ed494.c
+++ b/src/func_ov006_020ed494.c
@@ -48,7 +48,7 @@ void func_ov006_020ed494(char *c)
         a.x = data_020a0dea[(unsigned int)idx * 4] << 12;
         a.y = data_020a0deb[(unsigned int)idx * 4] << 12;
         p = *(Thing **)(c + 0x4f60);
-        src = (V2 *)(int)(((long long)(int)((char *)p + 0x18)));
+        src = (V2 *)(int)((char *)p + 0x18);
         vec[0] = src->x;
         vec[1] = src->y;
 
@@ -116,7 +116,7 @@ void func_ov006_020ed494(char *c)
                         ptr2 = (Thing *)(c + 0x4678);
                         do
                         {
-                            V2 *s2 = (V2 *)(int)(((long long)(int)((char *)ptr2 + 0x18)));
+                            V2 *s2 = (V2 *)(int)((char *)ptr2 + 0x18);
                             vec[0] = s2->x;
                             vec[1] = s2->y;
                             func_ov006_020eb9dc(ptr2, func_0203d5dc(vec, &a));
@@ -129,7 +129,7 @@ void func_ov006_020ed494(char *c)
 
                 func_02012790(0xe);
                 {
-                    V2 *s3 = (V2 *)(int)(((long long)(int)((char *)sel + 0x18)));
+                    V2 *s3 = (V2 *)(int)((char *)sel + 0x18);
                     vec[2] = s3->x;
                     vec[3] = s3->y;
                 }

--- a/src/func_ov006_020ee034.c
+++ b/src/func_ov006_020ee034.c
@@ -82,7 +82,7 @@ int func_ov006_020ee034(void *self)
         *(int *)((char *)p + 0x18) = *(int *)(c + 0x500c);
 
         {
-            void *obj2 = (void *)(((long long)(int)(c + 0x501c)));
+            void *obj2 = (void *)(c + 0x501c);
             ((void (**)(void *, void *))(*(int *)obj2))[5](obj2, &t);
         }
     }

--- a/src/func_ov006_020ee5b8.c
+++ b/src/func_ov006_020ee5b8.c
@@ -7,7 +7,7 @@ void func_ov006_020c42bc(void);
 #pragma optimize_for_size on
 void func_ov006_020ee5b8(char* c){
     int v;
-    short* d = (short*)(((unsigned long long)(c+0x5014)) & 0xFFFFFFFFFFFFFFFFull);
+    short* d = (short*)((unsigned long long)(c+0x5014));
     char* base = c + 0x5000;
     *d = *d - 1;
     v = *(short*)(base + 0x14);

--- a/src/func_ov006_020ef148.c
+++ b/src/func_ov006_020ef148.c
@@ -38,7 +38,7 @@ int func_ov006_020ef148(char* self)
     }
     *(int*)((char*)p + 0x18) = *(int*)(self + 0x5a64);
     {
-        void** vobj = (void**)(((long long)(int)(self + 0x5a14)));
+        void** vobj = (void**)(self + 0x5a14);
         (*(void(**)(void*, void*))((char*)*vobj + 0x14))((void*)vobj, &local);
     }
 

--- a/src/func_ov006_020ef4ec.c
+++ b/src/func_ov006_020ef4ec.c
@@ -11,7 +11,7 @@ struct G2
 extern struct G2 data_ov006_0213cc8c;
 void func_ov006_020ef4ec(char *c)
 {
-  int *p = (int *) (((unsigned long long) (c + 0x5a64)) & 0xFFFFFFFFFFFFFFFFULL);
+  int *p = (int *) ((unsigned long long) (c + 0x5a64));
   char *b = c + 0x5000;
   *p = (*p) + ((*((int *) (b + 0xa68))) >> 12);
   if ((*((int *) ((c + 0x5000) + 0xa64))) > 0x1000)

--- a/src/func_ov006_020ef5ac.c
+++ b/src/func_ov006_020ef5ac.c
@@ -21,7 +21,7 @@ void func_ov006_020ef5ac(char *self0)
     s16 flag;
     char *self = self0;
     int saved = data_ov006_02140308;
-    int *vp = (int *)(((int)self + 0x5a64) & 0xFFFFFFFFFFFFFFFFLL);
+    int *vp = (int *)((int)self + 0x5a64);
     int c;
 
     *vp += *(int *)(self + 0x5a68) >> 12;

--- a/src/func_ov006_020f1fcc.c
+++ b/src/func_ov006_020f1fcc.c
@@ -54,7 +54,7 @@ void func_ov006_020f1fcc(char *c)
 
         for (i = 0; i < 0x78; i++) {
             if (*(u8 *)(c + i + 0x52ed) == 1) {
-                u8 *p = (u8 *)(((long long)(int)(c + i + off)));
+                u8 *p = (u8 *)(c + i + off);
                 if (*p != 9) {
                     int dx2 = data_020a0de8[idx][2] - (((int *)(c + 0x47f8))[i] >> 12);
                     int dy2 = data_020a0de8[idx][3] - (((int *)(c + 0x49d8))[i] >> 12);

--- a/src/func_ov006_020f3964.c
+++ b/src/func_ov006_020f3964.c
@@ -4,14 +4,14 @@ void func_ov006_020f3964(char* c)
         return;
 
     {
-        unsigned short* e = (unsigned short*)(((long long)(int)(c + 0x530c)));
+        unsigned short* e = (unsigned short*)(c + 0x530c);
         *e = *e + 1;
         if (*e < 0x14)
             return;
         *e = 0;
     }
     {
-        unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x5311)));
+        unsigned char* p = (unsigned char*)(c + 0x5311);
         *p = *p + 1;
         *p = *p & 1;
     }

--- a/src/func_ov006_020f456c.c
+++ b/src/func_ov006_020f456c.c
@@ -44,7 +44,7 @@ void func_ov006_020f456c(Ctx *c)
 
     if (c->h5322 != 0)
     {
-        p = (u16 *)(int)(((long long)(int)((char *)c + 0x5322)));
+        p = (u16 *)(int)((char *)c + 0x5322);
         *p = (u16)(*p - 1);
         return;
     }

--- a/src/func_ov006_020f47d8.c
+++ b/src/func_ov006_020f47d8.c
@@ -13,7 +13,7 @@ void func_ov006_020f47d8(char *c)
   struct S5300 *s;
   if (((struct S5300 *) (c + 0x5300))->timer != 0)
   {
-    unsigned short *ptr = (unsigned short *) ((((int) c) + 0x5322) & 0xFFFFFFFFFFFFFFFFULL);
+    unsigned short *ptr = (unsigned short *) (((int) c) + 0x5322);
     *ptr = (*ptr) - 1;
     if (((struct S5300 *) (c + 0x5300))->timer != 0)
     {

--- a/src/func_ov006_020f4b30.c
+++ b/src/func_ov006_020f4b30.c
@@ -27,7 +27,7 @@ void func_ov006_020f4b30(char* c)
     if (w->ready < 2)
         return;
     w->slots[0xb - w->count].done = 1;
-    (*(short*)((long long)(int)(c + 0x5328)))++;
+    (*(short*)(c + 0x5328))++;
     mode = w->mode;
     if (mode == 1) {
         if (w->count >= 10)

--- a/src/func_ov006_020f50c0.c
+++ b/src/func_ov006_020f50c0.c
@@ -6,5 +6,5 @@ void func_ov006_020f50c0(char *self)
 {
     func_ov006_020f3f10(self);
     if (*(unsigned short *)(self + 0x5322))
-        *(unsigned short *)(((long long)(int)(self + 0x5322))) -= 1;
+        *(unsigned short *)(self + 0x5322) -= 1;
 }

--- a/src/func_ov006_020f5694.c
+++ b/src/func_ov006_020f5694.c
@@ -1,13 +1,13 @@
 void func_ov006_020f5694(char* c) {
   if (*(unsigned char*)(c + 0x5000 + 0x3d0) == 0) return;
   {
-    unsigned short* h = (unsigned short*)(((long long)(int)(c + 0x53cc)));
+    unsigned short* h = (unsigned short*)(c + 0x53cc);
     *h = *h + 1;
     if (*h < 0x14) return;
     *h = 0;
   }
   {
-    unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x53d1)));
+    unsigned char* p = (unsigned char*)(c + 0x53d1);
     *p = *p + 1;
     *p = *p & 1;
   }

--- a/src/func_ov006_020f5f0c.c
+++ b/src/func_ov006_020f5f0c.c
@@ -40,7 +40,7 @@ void func_ov006_020f5f0c(char *self, int idx)
     *(u8*)(self + 0x53ee + e) = *(u8*)(self + 0x51b8 + n);
     *(u8*)(self + 0x53f0 + *(u8*)(self + 0x5406)) = (u8)idx;
     {
-        u8 *pc = (u8*)((long long)(int)(self + 0x5406));
+        u8 *pc = (u8*)(self + 0x5406);
         *pc = *pc + 1;
     }
     *(u8*)(self + 0x51bc + n) = 3;
@@ -48,7 +48,7 @@ void func_ov006_020f5f0c(char *self, int idx)
 
     if (*(u8*)(self + 0x540c) != 0) return;
     {
-        u8 *pd = (u8*)((long long)(int)(self + 0x540c));
+        u8 *pd = (u8*)(self + 0x540c);
         *pd = *pd + 1;
     }
     func_ov004_020ad79c(*(int*)(self + 0xa8), *(int*)(self + 0xb4));

--- a/src/func_ov006_020f6230.c
+++ b/src/func_ov006_020f6230.c
@@ -24,7 +24,7 @@ void func_ov006_020f6230(char *p)
     func_ov006_020f5694(p);
 
     if (*(unsigned short *)(p + 0x53e2) != 0) {
-        q = (unsigned short *)(unsigned int)(unsigned long long)(unsigned int)(p + 0x53e2);
+        q = (unsigned short *)(unsigned int)(p + 0x53e2);
         *q = *q - 1;
         return;
     }

--- a/src/func_ov006_020f6488.c
+++ b/src/func_ov006_020f6488.c
@@ -3,7 +3,7 @@ extern short data_ov004_020bf9e4;
 
 void func_ov006_020f6488(char *c) {
     if (*((unsigned short *)(c + 0x5300 + 0xE2)) != 0) {
-        unsigned short *ptr = (unsigned short *)((((int)c) + 0x53E2) & 0xFFFFFFFFFFFFFFFFULL);
+        unsigned short *ptr = (unsigned short *)(((int)c) + 0x53E2);
         *ptr = *ptr - 1;
         if (*((unsigned short *)(c + 0x5300 + 0xE2)) != 0) {
             return;

--- a/src/func_ov006_020f6a78.c
+++ b/src/func_ov006_020f6a78.c
@@ -31,7 +31,7 @@ void func_ov006_020f6a78(char* c)
     if (w->ready < 3)
         return;
     w->slots[w->total * 2 - 1 - w->count].done = 1;
-    (*(short*)((long long)(int)(c + 0x53e8)))++;
+    (*(short*)(c + 0x53e8))++;
     mode = w->mode;
     if (w->count < data_ov006_0212e93c[mode])
         return;

--- a/src/func_ov006_020f6c90.c
+++ b/src/func_ov006_020f6c90.c
@@ -18,7 +18,7 @@ void func_ov006_020f6c90(char *c)
             u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 8 >> 15);
             u8 *entry;
         check0:
-            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)));
+            entry = (u8 *)(c + idx + 0x53f2);
             if (*entry < 2) {
                 *(u8 *)(p + 0x51b8) = idx;
                 (*entry)++;
@@ -45,7 +45,7 @@ void func_ov006_020f6c90(char *c)
             u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 9 >> 15);
             u8 *entry;
         check1:
-            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)));
+            entry = (u8 *)(c + idx + 0x53f2);
             if (*entry < 2) {
                 *(u8 *)(p + 0x51b8) = idx;
                 (*entry)++;
@@ -72,7 +72,7 @@ void func_ov006_020f6c90(char *c)
             u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 10 >> 15);
             u8 *entry;
         check2:
-            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)));
+            entry = (u8 *)(c + idx + 0x53f2);
             if (*entry < 2) {
                 *(u8 *)(p + 0x51b8) = idx;
                 (*entry)++;

--- a/src/func_ov006_020f7190.c
+++ b/src/func_ov006_020f7190.c
@@ -6,5 +6,5 @@ void func_ov006_020f7190(char *self)
 {
     func_ov006_020f5c40(self);
     if (*(unsigned short *)(self + 0x53e2))
-        *(unsigned short *)(((long long)(int)(self + 0x53e2))) -= 1;
+        *(unsigned short *)(self + 0x53e2) -= 1;
 }

--- a/src/func_ov006_020f9994.c
+++ b/src/func_ov006_020f9994.c
@@ -18,7 +18,7 @@ void func_ov006_020f9994(char *c, int b)
     switch (*(unsigned char *)(c + 0x2d)) {
     case 0:
         {
-            short *p = (short *)(((long long)(int)(c + 0x28)));
+            short *p = (short *)(c + 0x28);
             short v = *(short *)p;
             *(short *)p = (short)(v - 1);
         }

--- a/src/func_ov006_020fa844.c
+++ b/src/func_ov006_020fa844.c
@@ -1,5 +1,5 @@
 #include "types.h"
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 extern s32 data_ov006_0212eb44[];
 

--- a/src/func_ov006_020fb7e0.c
+++ b/src/func_ov006_020fb7e0.c
@@ -6,8 +6,8 @@ extern void func_ov006_020fbb2c(char *c, int idx, unsigned short val);
 
 /* Distinct 64-bit masks force independent RMW base materialization (add+pool).
  * Plain *(b+0x5960) for the compare/zero reloads folds to add #0x5900 + #0x60. */
-#define M1(a) (((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL)
-#define M2(a) (((long long)(unsigned)(a)) & 0xFFFFFFFFFFFFFFFFLL)
+#define M1(a) (a)
+#define M2(a) (a)
 
 void func_ov006_020fb7e0(char *thiz)
 {

--- a/src/func_ov006_020fd2d8.c
+++ b/src/func_ov006_020fd2d8.c
@@ -5,8 +5,8 @@ typedef unsigned short u16;
 typedef int s32;
 typedef unsigned int u32;
 
-#define ATI(p, off) ((char *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
-#define ATU(p, off) ((char *)(unsigned int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define ATI(p, off) ((char *)(int)((char *)(p) + (off)))
+#define ATU(p, off) ((char *)(unsigned int)((char *)(p) + (off)))
 
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
@@ -47,7 +47,7 @@ void func_ov006_020fd2d8(char *o, int i)
             *(unsigned char *)(o + idx + 0x4691) = 0;
         }
         *(unsigned short *)((ATI(o, 0) + idx) + 0x4688) =
-            (((((((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) << 5) >> 0xf) << 3)) + 0x20;
+            ((((((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) << 5) >> 0xf) << 3) + 0x20;
     }
     else
     {

--- a/src/func_ov006_020fe2bc.c
+++ b/src/func_ov006_020fe2bc.c
@@ -1,5 +1,5 @@
 void func_ov006_020fe2bc(char *c)
 {
     if (*(unsigned char *)(c + 0x5000 + 0xc32) == 0)
-        *(unsigned char *)(((long long)(int)(c + 0x5c32))) += 1;
+        *(unsigned char *)(c + 0x5c32) += 1;
 }

--- a/src/func_ov006_020fee24.c
+++ b/src/func_ov006_020fee24.c
@@ -37,7 +37,7 @@ s32 func_ov006_020fee24(char *c)
         }
         if (*(u16 *)(c + 0x5c2a) != 0) {
             func_ov006_020fb7e0(c);
-            (*(u16 *)(((long long)(int)(c + 0x5c2a))))--;
+            (*(u16 *)(c + 0x5c2a))--;
         } else {
             func_ov006_020fdd40(c);
             func_ov006_020fe2bc(c);
@@ -54,7 +54,7 @@ s32 func_ov006_020fee24(char *c)
         break;
     case 2:
         if (*(u16 *)(c + 0x5c18) != 0) {
-            (*(u16 *)(((long long)(int)(c + 0x5c18))))--;
+            (*(u16 *)(c + 0x5c18))--;
             if (*(s16 *)(c + 0x5c18) <= 0) {
                 func_ov004_020b0a54((void *)0x10);
                 *(u8 *)(c + 0xc3) = 0;

--- a/src/func_ov006_02100278.c
+++ b/src/func_ov006_02100278.c
@@ -5,7 +5,7 @@ void func_ov006_02100278(char *c, int r1, int r2, int r3)
     for (i = 0; i < 0x10; i++, p += 0x18) {
         if (*(unsigned char *)(p + 0x54b4) == 0) {
             int off = i * 0x18;
-            char *q = (char *)(((int)c + off) & 0xFFFFFFFFFFFFFFFFull);
+            char *q = (char *)((int)c + off);
             *(unsigned char *)(q + 0x54b4) = 1;
             *(unsigned char *)(q + 0x54b5) = 1;
             if (r1 >= 0x80000)
@@ -13,7 +13,7 @@ void func_ov006_02100278(char *c, int r1, int r2, int r3)
             else
                 *(int *)(q + 0x54a0) = 0x5c000;
             {
-                char *w = (char *)(int)((long long)(int)(c + off) & 0xFFFFFFFFFFFFFFFFLL);
+                char *w = (char *)(int)(c + off);
                 *(int *)(w + 0x54a4) = r2 + 0x48000;
                 *(int *)(w + 0x54ac) = 0;
                 *(int *)(w + 0x54a8) = 0;

--- a/src/func_ov006_02100380.c
+++ b/src/func_ov006_02100380.c
@@ -16,10 +16,10 @@ void func_ov006_02100380(char* c)
     for (i = 0; i < 16; i++, c += 0x18) {
         if (((View*)c)->active == 0)
             continue;
-        (*(u16*)((long long)(int)(c + 0x5330)))++;
+        (*(u16*)(c + 0x5330))++;
         if (((View*)c)->timer < 8)
             continue;
-        (*(u8*)((long long)(int)(c + 0x5335)))++;
+        (*(u8*)(c + 0x5335))++;
         if (((View*)c)->stage >= 4) {
             ((View*)c)->active = 0;
             ((View*)c)->stage = 0;

--- a/src/func_ov006_02102ef4.c
+++ b/src/func_ov006_02102ef4.c
@@ -4,7 +4,7 @@ void func_ov006_02102ef4(unsigned char *r0) {
     r0[0x5679] = 0;
     r0[0x567a] = 1;
     {
-        unsigned char *p = (unsigned char *)(((long long)(int)(r0 + 0x5678)));
+        unsigned char *p = (unsigned char *)(r0 + 0x5678);
         *p += 1;
     }
 }

--- a/src/func_ov006_02103d78.c
+++ b/src/func_ov006_02103d78.c
@@ -53,7 +53,7 @@ s32 func_ov006_02103d78(char *c)
         func_ov006_020fff84(c);
         func_ov006_021001ac(c);
         if (*(u16 *)(c + 0x566e) != 0) {
-            *(u16 *)(u32)(unsigned long long)(u32)(c + 0x566e) -= 1;
+            *(u16 *)(u32)(c + 0x566e) -= 1;
             if (*(s16 *)(c + 0x566e) <= 0) {
                 func_ov004_020b0a54((void *)0x10);
                 *(u8 *)(c + 0xc3) = 0;

--- a/src/func_ov006_02104c08.c
+++ b/src/func_ov006_02104c08.c
@@ -1,10 +1,10 @@
 void func_ov006_02104c08(char* c) {
-  unsigned short* h = (unsigned short*)(((long long)(int)(c + 0x4682)));
+  unsigned short* h = (unsigned short*)(c + 0x4682);
   *h = *h + 1;
   if (*(unsigned short*)(c + 0x4600 + 0x82) < 4) return;
   *(unsigned short*)(c + 0x4600 + 0x82) = 0;
   {
-    int* w = (int*)(((long long)(int)(c + 0x467c)));
+    int* w = (int*)(c + 0x467c);
     *w = *w - 0x4000;
   }
   *(unsigned char*)(c + 0x4000 + 0x686) = 1;

--- a/src/func_ov006_02104e80.c
+++ b/src/func_ov006_02104e80.c
@@ -4,5 +4,5 @@
 void func_ov006_02104e80(char *self)
 {
     if (*(unsigned char *)(self + 0x4677))
-        *(unsigned char *)(((long long)(int)(self + 0x4677))) -= 1;
+        *(unsigned char *)(self + 0x4677) -= 1;
 }

--- a/src/func_ov006_02104fb4.c
+++ b/src/func_ov006_02104fb4.c
@@ -1,7 +1,7 @@
 void func_ov006_02104fb4(unsigned char* c){
   unsigned char* slot = c + 0x4600;
   if(*(unsigned short*)(slot + 0x70) != 0){
-    unsigned short* p = (unsigned short*)((long long)(int)(c + 0x4670));
+    unsigned short* p = (unsigned short*)(c + 0x4670);
     *p = *p - 1;
     if(*(short*)(slot + 0x70) < 0) *(unsigned short*)(slot + 0x70) = 0;
   } else {

--- a/src/func_ov006_021051dc.c
+++ b/src/func_ov006_021051dc.c
@@ -13,7 +13,7 @@ void func_ov006_021051dc(char *c)
     int x;
 
     if (*(u16 *)(c + 0x4ec4) != 0) {
-        (*(u16 *)(int)(((long long)(int)(c + 0x4ec4))))--;
+        (*(u16 *)(int)(c + 0x4ec4))--;
         if (*(s16 *)(c + 0x4ec4) < 0)
             *(u16 *)(c + 0x4ec4) = 0;
         return;
@@ -49,7 +49,7 @@ void func_ov006_021051dc(char *c)
             int cell = *(int *)(c + 0x4cbc) * (row + y) + (col + x);
 
             *(u8 *)(c + cell + 0x4efa) = 1;
-            (*(u8 *)(int)(((long long)(int)(c + cell + 0x4f1e)))) ^= 1;
+            (*(u8 *)(int)(c + cell + 0x4f1e)) ^= 1;
             *(u16 *)(c + cell * 2 + 0x4e78) = 8;
         }
     }
@@ -57,5 +57,5 @@ void func_ov006_021051dc(char *c)
     func_ov006_02104cfc(c, idx);
     *(u16 *)(c + idx * 2 + 0x4e78) = 0;
     *(u16 *)(c + 0x4ec4) = 0x30;
-    (*(u8 *)(int)(((long long)(int)(c + 0x4fe5))))++;
+    (*(u8 *)(int)(c + 0x4fe5))++;
 }

--- a/src/func_ov006_02105670.c
+++ b/src/func_ov006_02105670.c
@@ -2,7 +2,7 @@ void func_ov006_02105670(char *p)
 {
     if (((unsigned short *)(p + 0x4e00))[0x62] != 0)
     {
-        (*(unsigned short *)(((long long)(int)(p + 0x4ec4))))--;
+        (*(unsigned short *)(p + 0x4ec4))--;
         if (((short *)(p + 0x4e00))[0x62] < 0)
         {
             ((short *)(p + 0x4e00))[0x62] = 0;
@@ -15,7 +15,7 @@ void func_ov006_02105670(char *p)
         for (k = 0; k < *(int *)(p + 0x4cb8); k++)
         {
             *(unsigned char *)(p + k + 0x4efa) = 1;
-            *(unsigned char *)(((long long)(int)(p + k + 0x4f1e))) ^= 1;
+            *(unsigned char *)(p + k + 0x4f1e) ^= 1;
             *(unsigned char *)(p + k + 0x4f8a) = 1;
         }
         *(unsigned char *)(p + 0x4fe0) = 2;

--- a/src/func_ov006_02105854.c
+++ b/src/func_ov006_02105854.c
@@ -6,7 +6,7 @@ extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 void func_ov006_02105854(char *c)
 {
     if (*(u16 *)(c + 0x4ec4) != 0) {
-        (*(u16 *)(int)(((long long)(int)(c + 0x4ec4))))--;
+        (*(u16 *)(int)(c + 0x4ec4))--;
         if (*(s16 *)(c + 0x4ec4) < 0)
             *(u16 *)(c + 0x4ec4) = 0;
         return;
@@ -34,7 +34,7 @@ void func_ov006_02105854(char *c)
         return;
     }
 
-    (*(u8 *)(int)(((long long)(int)(c + 0x4fe4))))--;
+    (*(u8 *)(int)(c + 0x4fe4))--;
 
     if (*(u8 *)(c + 0x4fe4) == 0xff) {
         *(u8 *)(c + 0x4fe4) = 0;
@@ -69,7 +69,7 @@ void func_ov006_02105854(char *c)
             for (x = x0; x < wq; x++) {
                 int cell = *(int *)(c + 0x4cbc) * (row + y) + (col + x);
                 *(u8 *)(c + cell + 0x4efa) = 1;
-                (*(u8 *)(int)(((long long)(int)(c + cell + 0x4f1e)))) ^= 1;
+                (*(u8 *)(int)(c + cell + 0x4f1e)) ^= 1;
                 *(u16 *)(c + cell * 2 + 0x4e78) = 8;
                 *(u8 *)(c + cell + 0x4f8a) = 1;
             }

--- a/src/func_ov006_02105de4.c
+++ b/src/func_ov006_02105de4.c
@@ -58,7 +58,7 @@ void func_ov006_02105de4(char *c)
             int w, col, row;
 
             *(u8 *)(c + *(u8 *)(c + 0x4fe4) + 0x4fce) = i;
-            (*(u8 *)(int)(((long long)(int)(c + 0x4fe4))))++;
+            (*(u8 *)(int)(c + 0x4fe4))++;
             w = *(int *)(c + 0x4cbc);
             col = i % w;
             row = i / w;
@@ -81,7 +81,7 @@ void func_ov006_02105de4(char *c)
                     for (x = x0; x < wq; x++) {
                         int idx = *(int *)(c + 0x4cbc) * (row + y) + (col + x);
                         *(u8 *)(c + idx + 0x4efa) = 1;
-                        (*(u8 *)(int)(((long long)(int)(c + idx + 0x4f1e)))) ^= 1;
+                        (*(u8 *)(int)(c + idx + 0x4f1e)) ^= 1;
                         *(u16 *)(c + idx * 2 + 0x4e78) = 8;
                     }
                 }
@@ -89,7 +89,7 @@ void func_ov006_02105de4(char *c)
 
             *(u16 *)(c + i * 2 + 0x4e78) = 0;
             *(u8 *)(c + 0x4feb) = 0x28;
-            (*(u8 *)(int)(((long long)(int)(c + 0x4fe1))))++;
+            (*(u8 *)(int)(c + 0x4fe1))++;
             _ZN5Sound12PlayBank2_2DEj(0x1fa);
             func_ov006_02104e80(c);
             return;

--- a/src/func_ov006_021063a0.cpp
+++ b/src/func_ov006_021063a0.cpp
@@ -1,6 +1,6 @@
 //cpp
 #include "types.h"
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
+#define AT(p,off) ((void*)(int)((char*)(p)+(off)))
 #define RND ((((u32)RandomIntInternal(&data_0209d4b8)) >> 16) & 0x7fff)
 
 struct O

--- a/src/func_ov006_02106a08.c
+++ b/src/func_ov006_02106a08.c
@@ -1,20 +1,20 @@
 void func_ov006_02106a08(char *p, int idx)
 {
-    unsigned short *c = (unsigned short *)(int)(((long long)(int)(p + 0x4e30)));
+    unsigned short *c = (unsigned short *)(int)(p + 0x4e30);
     unsigned char *q;
     c[idx] = c[idx] + 1;
     if ((((int)*(unsigned short *)(p + idx * 2 + 0x4e30) >> 3) & 1) != 0)
     {
-        q = (unsigned char *)(int)(((long long)(int)(p + 0x4f66)));
+        q = (unsigned char *)(int)(p + 0x4f66);
         q[idx] = 1;
     }
     else
     {
-        q = (unsigned char *)(int)(((long long)(int)(p + 0x4f66)));
+        q = (unsigned char *)(int)(p + 0x4f66);
         q[idx] = 0;
     }
     {
-        int idxL = (int)(((long long)idx));
+        int idxL = (int)((long long)idx);
         char *b = p + idxL * 2;
         b += 0x4e00;
         if (((unsigned short *)b)[0x18] < 0x40)

--- a/src/func_ov006_02106bc0.c
+++ b/src/func_ov006_02106bc0.c
@@ -22,7 +22,7 @@ void func_ov006_02106bc0(char *c) {
         fn(thisp, i);
     }
     if (*(unsigned short *)(c + 0x4ec0) == 0) return;
-    *(unsigned short *)(((long long)(int)(c + 0x4ec0))) -= 1;
+    *(unsigned short *)(c + 0x4ec0) -= 1;
     if (*(short *)(c + 0x4ec0) > 0) return;
     *(unsigned short *)(c + 0x4ec0) = 0;
     func_ov004_020b0a54(0x12);

--- a/src/func_ov006_02107d20.c
+++ b/src/func_ov006_02107d20.c
@@ -1,7 +1,7 @@
 void func_ov006_02107d20(int *p, int val)
 {
     int i;
-    *(short *)(((long long)(int)((char *)p + 0x16))) += 1;
+    *(short *)((char *)p + 0x16) += 1;
     for (i = 0; i < 5; i++) {
         if (p[i] == 0) {
             p[i] = val;

--- a/src/func_ov006_021082c4.c
+++ b/src/func_ov006_021082c4.c
@@ -3,7 +3,7 @@ extern struct Pair data_ov006_0213e2f8;
 
 void func_ov006_021082c4(char *p)
 {
-    *(int *)(((long long)(int)(p + 0xb8))) += 0x140;
+    *(int *)(p + 0xb8) += 0x140;
     *(short *)(p + 0xc4) = -*(short *)(p + 0xc2);
     *(struct Pair *)p = data_ov006_0213e2f8;
 }

--- a/src/func_ov006_021096c8.c
+++ b/src/func_ov006_021096c8.c
@@ -16,25 +16,25 @@ int func_ov006_021096c8(char *self)
     case 5:
         FreeGfxSlotsById(0x1d);
         if (func_ov006_02107a6c() != 0)
-            (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
+            (*(s16 *)(self + 0x53e6))++;
         break;
     case 6:
         if (func_ov006_020c1718(self + 0x4f38) != 0) {
             *(u16 *)(self + 0x53e8) = 0x3c;
             *(int *)(self + 0x53f8) = 0;
-            (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
+            (*(s16 *)(self + 0x53e6))++;
         }
         break;
     case 7:
-        (*(s16 *)(((long long)(int)(self + 0x53e8))))--;
+        (*(s16 *)(self + 0x53e8))--;
         if (*(s16 *)(self + 0x53e8) == 0) {
             if (*(s16 *)(self + 0x53f2) != 0)
                 func_ov004_020b56c8();
-            (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
+            (*(s16 *)(self + 0x53e6))++;
         }
         break;
     case 8:
-        (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
+        (*(s16 *)(self + 0x53e6))++;
         /* fall through */
     case 9:
     default:

--- a/src/func_ov006_0210b314.c
+++ b/src/func_ov006_0210b314.c
@@ -25,9 +25,9 @@ void func_ov006_0210b314(char *c, int mode)
         func_ov004_020b0cac(0xd, 0x80, 0xa8, 1, -1, 0xd);
     } else if (mode == 4) {
         if (*(int *)(c + 0x5004) < 5) {
-            *(int *)(int)(((long long)(int)(c + 0x5004))) += 1;
+            *(int *)(int)(c + 0x5004) += 1;
         }
-        *(int *)(int)(((long long)(int)(c + 0xbc))) += 1;
+        *(int *)(int)(c + 0xbc) += 1;
         if (*(u32 *)(c + 0xbc) > 0x270e) {
             *(int *)(c + 0xbc) = 0x270e;
         }

--- a/src/func_ov006_0210bcb0.cpp
+++ b/src/func_ov006_0210bcb0.cpp
@@ -35,14 +35,14 @@ extern "C" int func_ov006_0210bcb0(Obj *self) {
 
     (self->*data_ov006_02142bdc[self->idx])();
 
-    pc = (unsigned char *)(((long long)(int)((char *)self + 0x503f)));
+    pc = (unsigned char *)((char *)self + 0x503f);
     *pc = *pc + 1;
     func_ov006_020c2144((char *)self + 0x4f38);
 
     for (i = 0; i < 3; i++) {
         if (self->idx == 1) {
-            ph1 = (unsigned short *)(((long long)(int)((char *)self + 0x5018)));
-            ph2 = (unsigned short *)(((long long)(int)((char *)self + 0x501a)));
+            ph1 = (unsigned short *)((char *)self + 0x5018);
+            ph2 = (unsigned short *)((char *)self + 0x501a);
             *ph1 = *ph1 - 0x200;
             *ph2 = *ph2 - 0x400;
             break;

--- a/src/func_ov006_0210c500.c
+++ b/src/func_ov006_0210c500.c
@@ -40,7 +40,7 @@ int func_ov006_0210c500(struct T *p)
     }
     if (ok) {
         if (p->f708 < 2) {
-            u8 *q = (u8 *)(int)(((long long)(int)((u8 *)p + 0x4708)));
+            u8 *q = (u8 *)(int)((u8 *)p + 0x4708);
             *q = *q + 1;
         }
         p->f709 = first;

--- a/src/func_ov006_0210e014.c
+++ b/src/func_ov006_0210e014.c
@@ -22,10 +22,10 @@ void func_ov006_0210e014(Obj* self) {
     self->x14 = self->xc;
     if (self->x44 != 1 && self->x40 > 0) {
         if (self->x32 < 0x3000) {
-            (*(s16*)(((long long)(int)((char*)self + 0x32)))) += 0x200;
+            (*(s16*)((char*)self + 0x32)) += 0x200;
             if (self->x32 >= 0x3000) self->x32 = 0x3000;
         } else {
-            (*(s16*)(((unsigned long long)(unsigned int)((char*)self + 0x32)))) -= 0x200;
+            (*(s16*)((char*)self + 0x32)) -= 0x200;
             if (self->x32 < 0x3000) self->x32 = 0x3000;
         }
     }

--- a/src/func_ov006_0210e3e8.c
+++ b/src/func_ov006_0210e3e8.c
@@ -5,7 +5,7 @@ void func_ov006_0210e3e8(int *self) {
     self[4] = self[2];
     self[5] = self[3];
     if (self[0xd] > 0) {
-        *(int *)(((long long)(int)(b + 0x34))) -= 1;
+        *(int *)(b + 0x34) -= 1;
     }
     if (b[0x31] != 1) return;
     if (func_ov006_0210e120(self)) {

--- a/src/func_ov006_0211192c.c
+++ b/src/func_ov006_0211192c.c
@@ -51,7 +51,7 @@ void func_ov006_0211192c(C* c)
             c->f3c = 4;
     } else if (c->f3c > 0) {
         {
-            int* p = (int*)((long long)(int)&c->f3c);
+            int* p = (int*)(&c->f3c);
             *p = *p - 1;
         }
         if (c->f3c < 4) {
@@ -81,12 +81,12 @@ void func_ov006_0211192c(C* c)
 done:
     if (c->f34 == 1) {
         if (c->f3c <= 0) {
-            int* p = (int*)((long long)(int)&c->f28);
+            int* p = (int*)(&c->f28);
             *p += 0x1000;
             if (c->f28 > 0x7000)
                 c->f28 = 0x7000;
         } else {
-            int* p = (int*)((long long)(int)&c->f28);
+            int* p = (int*)(&c->f28);
             *p -= 0x1000;
             if (c->f28 < 0)
                 c->f28 = 0;

--- a/src/func_ov006_02112ad8.c
+++ b/src/func_ov006_02112ad8.c
@@ -99,9 +99,9 @@ extern int data_0209d4b8;
 
 #define FIX_MUL(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
 #define FIX_MUL_SU(a, b) \
-    ((int)(((s64)((u64)(s64)(a) * (u64)(u32)(b)) + 0x800) >> 12))
+    ((int)(((s64)((u64)(s64)(a) * (b)) + 0x800) >> 12))
 #define FIX_MUL_US(a, b) \
-    ((int)(((s64)((u64)(u32)(a) * (u64)(s64)(b)) + 0x800) >> 12))
+    ((int)(((s64)((a) * (u64)(s64)(b)) + 0x800) >> 12))
 
 static void *GetEntity(Mgr *mgr, int i)
 {
@@ -450,9 +450,8 @@ final_checks:
             V2 *position = (V2 *)self->pos;
             Obj *owner = position
                 ? self : self;
-            int *pz = (int *)(((int)owner + 0xc) &
-                0xffffffffffffffffULL);
-            *(int *)(((int)position) & 0xffffffffffffffffLL) -=
+            int *pz = (int *)((int)owner + 0xc);
+            *(int *)((int)position) -=
                 normal.x;
             *pz -= normal.z;
             Vec2_Sub(&moveDelta, position,
@@ -509,7 +508,7 @@ final_checks:
             responseScale += FIX_MUL_SU(responseScale, randomScale >> 6);
             randomAngle = (u32)RandomIntInternal(&data_0209d4b8);
             func_0203d388(&response,
-                (s16)((((((randomAngle >> 16) & 0x7fff) << 12) >> 15)) - 0x800));
+                (s16)(((((randomAngle >> 16) & 0x7fff) << 12) >> 15) - 0x800));
         } else if (state.flags[3] == 1) {
             u32 randomScale;
             u32 randomAngle;
@@ -521,7 +520,7 @@ final_checks:
             responseScale += FIX_MUL_US(randomScale >> 5, -0x2000);
             randomAngle = (u32)RandomIntInternal(&data_0209d4b8);
             func_0203d388(&response,
-                (s16)((((((randomAngle >> 16) & 0x7fff) << 12) >> 15)) - 0x800));
+                (s16)(((((randomAngle >> 16) & 0x7fff) << 12) >> 15) - 0x800));
         } else if (state.flags[2] == 1) {
             u32 randomScale;
             responseScale = FIX_MUL(dot, 0x1a00);
@@ -536,10 +535,10 @@ final_checks:
             responseScale = FIX_MUL(dot, 0x1200);
         }
         velXPtr = (int *)(int)
-            ((u64)(int)&self->velX & 0xffffffffffffffffULL);
+            (&self->velX);
         *velXPtr -= FIX_MUL(responseScale, response.x);
         velZPtr = (int *)(int)
-            ((u64)(int)&self->velZ & 0xffffffffffffffffULL);
+            (&self->velZ);
         *velZPtr -= FIX_MUL(responseScale, response.z);
     }
 
@@ -647,10 +646,10 @@ final_checks:
                 correctionX = correction.x;
                 correctionZ = correction.z;
                 velXPtr = (int *)(int)
-                    ((u64)(int)&self->velX & 0xffffffffffffffffULL);
+                    (&self->velX);
                 *velXPtr -= correctionX;
                 velZPtr = (int *)(int)
-                    ((u64)(int)&self->velZ & 0xffffffffffffffffULL);
+                    (&self->velZ);
                 *velZPtr -= correction.z;
                 return;
             }

--- a/src/func_ov006_02113f1c.c
+++ b/src/func_ov006_02113f1c.c
@@ -16,7 +16,7 @@ extern void func_ov006_02111e48(char *c);
 extern void func_ov006_021128fc(char *c);
 extern void func_ov006_02112ad8(char *c);
 
-#define LAUNDER(p) ((int)((long long)(int)(p)))
+#define LAUNDER(p) ((int)(p))
 
 void func_ov006_02113f1c(char *c)
 {

--- a/src/func_ov006_02114f98.c
+++ b/src/func_ov006_02114f98.c
@@ -3,5 +3,5 @@
 // the ROM instead of splitting the large offset.
 void func_ov006_02114f98(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x5994))) += 1;
+    *(unsigned int *)(self + 0x5994) += 1;
 }

--- a/src/func_ov006_02114fd0.c
+++ b/src/func_ov006_02114fd0.c
@@ -1,5 +1,5 @@
 void func_ov006_02114fd0(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5984)));
+    int *a = (int *)(p + 0x5984);
     *a = *a + 1;
 }

--- a/src/func_ov006_02114fec.c
+++ b/src/func_ov006_02114fec.c
@@ -1,5 +1,5 @@
 void func_ov006_02114fec(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5980)));
+    int *a = (int *)(p + 0x5980);
     *a = *a + 1;
 }

--- a/src/func_ov006_02115008.c
+++ b/src/func_ov006_02115008.c
@@ -1,5 +1,5 @@
 void func_ov006_02115008(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x597c)));
+    int *a = (int *)(p + 0x597c);
     *a = *a + 1;
 }

--- a/src/func_ov006_02115024.c
+++ b/src/func_ov006_02115024.c
@@ -1,5 +1,5 @@
 void func_ov006_02115024(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5978)));
+    int *a = (int *)(p + 0x5978);
     *a = *a + 1;
 }

--- a/src/func_ov006_02115060.c
+++ b/src/func_ov006_02115060.c
@@ -1,5 +1,5 @@
 void func_ov006_02115060(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5964)));
+    int *a = (int *)(p + 0x5964);
     *a = *a + 1;
 }

--- a/src/func_ov006_02115150.c
+++ b/src/func_ov006_02115150.c
@@ -8,10 +8,10 @@ void func_ov006_02115150(char* self)
     int i;
     char* obj = self + 0x48d4;
     for (i = 0; i < 0x10; i++) {
-        unsigned char* flag = (unsigned char*)(int)(((long long)(int)(self + i + 0x4804)));
+        unsigned char* flag = (unsigned char*)(int)(self + i + 0x4804);
         if (*flag != 0) {
-            *(int*)(((int)(self + i*8) + 0x4854)) += *(int*)(self + i*8 + 0x48d4);
-            *(int*)(((int)(self + i*8) + 0x4858)) += *(int*)(self + i*8 + 0x48d8);
+            *(int*)((int)(self + i*8) + 0x4854) += *(int*)(self + i*8 + 0x48d4);
+            *(int*)((int)(self + i*8) + 0x4858) += *(int*)(self + i*8 + 0x48d8);
             {
                 int m = Vec2_Len(obj) * 6 / 8;
                 if (func_0203d434(obj)) {
@@ -19,7 +19,7 @@ void func_ov006_02115150(char* self)
                 }
             }
             {
-                int* counter = (int*)(int)(((long long)(int)(self + i*4 + 0x4814)));
+                int* counter = (int*)(int)(self + i*4 + 0x4814);
                 *counter += 1;
                 if (*counter >= 0xf) {
                     *flag = 0;

--- a/src/func_ov006_02115a5c.c
+++ b/src/func_ov006_02115a5c.c
@@ -9,7 +9,7 @@ void func_ov006_02115a5c(char *p)
     int i, j;
     for (i = 0; i < n; i++) {
         for (j = 0; j < n; j++) {
-            int a = (i >= 13) ? 0 : *(int *)(int)(((long long)(int)(p + i * 4 + 0x4688)));
+            int a = (i >= 13) ? 0 : *(int *)(int)(p + i * 4 + 0x4688);
             int b = (j >= 13) ? 0 : *(int *)(p + j * 4 + 0x4688);
             func_ov006_02115830(p, i, j, a, b);
             n = *(int *)(p + 0x4668);

--- a/src/func_ov006_021173c8.cpp
+++ b/src/func_ov006_021173c8.cpp
@@ -50,7 +50,7 @@ extern int data_ov006_02138a88[];
 
 #define I(off) (*(int *)(g + (off)))
 #define UC(off) (*(unsigned char *)(g + (off)))
-#define LP(e) ((int *)(((long long)(int)(e)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LP(e) ((int *)(e))
 
 extern "C" int func_ov006_021173c8(void *this_)
 {
@@ -142,7 +142,7 @@ extern "C" int func_ov006_021173c8(void *this_)
         /* Loop G: rows with per-row multiplier */
         limG = col * 0x14;
         for (j = 0; j < 3; j++) {
-            slot[1] = (int *)(((long long)(int)(g + j * 4 + 0x5988)) & 0xFFFFFFFFFFFFFFFFLL);
+            slot[1] = (int *)(g + j * 4 + 0x5988);
             if (*slot[1] > 0 && I(0x5960) >= limG) {
                 int mult;
                 switch (j) {
@@ -247,7 +247,7 @@ extern "C" int func_ov006_021173c8(void *this_)
                     int *px = LP(g + sb * 8 + 0x47c8);
                     func_ov004_020b1ea4((*px >> 12) - 0x10, *py >> 12, cnt, -1, 0, 0, 0);
                     nd = 0;
-                    u = (unsigned int)*(int *)(((int)g + sb * 4 + 0x478c) & 0xFFFFFFFFFFFFFFFFLL);
+                    u = (unsigned int)*(int *)((int)g + sb * 4 + 0x478c);
                     if (u != 0) {
                         do {
                             u /= 10;

--- a/src/func_ov006_0211944c.c
+++ b/src/func_ov006_0211944c.c
@@ -16,7 +16,7 @@ void func_ov006_0211944c(char *c, int mode)
         return;
 
     for (int i = 0; i < 0xd; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4688)));
+        int **slot = (int **)(c + i * 4 + 0x4688);
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -30,7 +30,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x668) = 0;
 
     for (int i = 0; i < 0x19; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x46bc)));
+        int **slot = (int **)(c + i * 4 + 0x46bc);
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -44,7 +44,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x670) = 0;
 
     for (int i = 0; i < 8; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4720)));
+        int **slot = (int **)(c + i * 4 + 0x4720);
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -70,7 +70,7 @@ void func_ov006_0211944c(char *c, int mode)
     }
 
     for (int i = 0; i < 3; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4740)));
+        int **slot = (int **)(c + i * 4 + 0x4740);
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -83,7 +83,7 @@ void func_ov006_0211944c(char *c, int mode)
     }
 
     for (int i = 0; i < 6; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x474c)));
+        int **slot = (int **)(c + i * 4 + 0x474c);
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -97,7 +97,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x678) = 0;
 
     for (int i = 0; i < 3; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4764)));
+        int **slot = (int **)(c + i * 4 + 0x4764);
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -111,7 +111,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x67c) = 0;
 
     for (int i = 0; i < 2; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4770)));
+        int **slot = (int **)(c + i * 4 + 0x4770);
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {

--- a/src/func_ov006_02119a18.c
+++ b/src/func_ov006_02119a18.c
@@ -1,4 +1,4 @@
-#define A(p) ((int)(((long long)(int)(p))))
+#define A(p) ((int)(p))
 extern unsigned short data_ov006_0212ee38[];
 
 void func_ov006_02119a18(char *b)

--- a/src/func_ov006_0211bf44.c
+++ b/src/func_ov006_0211bf44.c
@@ -57,7 +57,7 @@ void func_ov006_0211bf44(char* base, int slot)
     *(u16*)(entry + 0xf0) = 0;
     *(u8*)(entry + 0xf7) = 0;
     {
-        u8* counter = (u8*)(int)(((long long)(int)(base + 0x5624)));
+        u8* counter = (u8*)(int)(base + 0x5624);
         *counter = *counter + 1;
     }
     _ZN5Sound12PlayBank2_2DEj(0x201);

--- a/src/func_ov006_0211c080.c
+++ b/src/func_ov006_0211c080.c
@@ -9,7 +9,7 @@ extern int data_ov006_0212efb0[];
 extern u16 *data_ov006_0213f6fc[];
 
 #define RND (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff)
-#define LAUNDER(p) ((int)((long long)(int)(p)))
+#define LAUNDER(p) ((int)(p))
 
 void func_ov006_0211c080(char *o)
 {

--- a/src/func_ov006_0211c720.c
+++ b/src/func_ov006_0211c720.c
@@ -23,7 +23,7 @@ int func_ov006_0211c720(char *c)
         break;
     case 1:
         if (*(u16 *)(c + 0x5618) != 0) {
-            (*(u16 *)(int)(((long long)(int)(c + 0x5618))))--;
+            (*(u16 *)(int)(c + 0x5618))--;
             if (*(u16 *)(c + 0x5618) == 0) {
                 FreeGfxSlotsById(0x1d);
                 if (*(u8 *)(c + 0xc4) == 0) {
@@ -42,7 +42,7 @@ int func_ov006_0211c720(char *c)
         func_ov006_0211b954(c);
         func_ov006_0211b5e0(c);
         if (*(u16 *)(c + 0x5616) != 0) {
-            (*(u16 *)(int)(((long long)(int)(c + 0x5616))))--;
+            (*(u16 *)(int)(c + 0x5616))--;
             if (*(u16 *)(c + 0x5616) == 0) {
                 if (*(u8 *)(c + 0x5626) != 0) {
                     *(int *)(c + 0x50e0) = 0;
@@ -54,7 +54,7 @@ int func_ov006_0211c720(char *c)
                         char *g = data_ov004_020beb68;
                         if (g != 0) {
                             if (*(int *)(g + 0xb4) < 9999)
-                                (*(int *)(int)(((long long)(int)(g + 0xb4))))++;
+                                (*(int *)(int)(g + 0xb4))++;
                             if (*(int *)(g + 0xb4) > *(int *)(g + 0xb8))
                                 *(int *)(g + 0xb8) = *(int *)(g + 0xb4);
                         }
@@ -78,7 +78,7 @@ int func_ov006_0211c720(char *c)
         func_ov006_0211b954(c);
         func_ov006_0211b5e0(c);
         if (*(u16 *)(c + 0x5616) != 0) {
-            (*(u16 *)(int)(((long long)(int)(c + 0x5616))))--;
+            (*(u16 *)(int)(c + 0x5616))--;
             if (*(s16 *)(c + 0x5616) <= 0) {
                 *(int *)(c + 0x50e0) = 0;
                 func_ov006_020c2440(c + 0x4f38);

--- a/src/func_ov006_0211d69c.c
+++ b/src/func_ov006_0211d69c.c
@@ -7,10 +7,10 @@ void func_ov006_0211d69c(char *obj)
     {
         return;
     }
-    (*(unsigned short *)(((long long)(int)(obj + 0x4c18))))++;
+    (*(unsigned short *)(obj + 0x4c18))++;
     if (*(unsigned short *)(obj + 0x4c18) >= data_ov006_0212efdc[*(unsigned char *)(obj + 0x4c24)])
     {
-        (*(unsigned char *)(((long long)(int)(obj + 0x4c24))))++;
+        (*(unsigned char *)(obj + 0x4c24))++;
         *(unsigned short *)(obj + 0x4c18) = 0;
         if (*(unsigned char *)(obj + 0x4c24) & 1)
         {

--- a/src/func_ov006_0211d924.c
+++ b/src/func_ov006_0211d924.c
@@ -1,6 +1,6 @@
 #include "types.h"
 #pragma opt_common_subs off
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
+#define AT(p,off) ((void*)(int)((char*)(p)+(off)))
 
 void func_ov006_0211d924(char* p, int i)
 {

--- a/src/func_ov006_0211dec0.c
+++ b/src/func_ov006_0211dec0.c
@@ -11,7 +11,7 @@ void func_ov006_0211dec0(void *arg) {
         v = *(unsigned char *)(p + 0x4a73);
         if (v == 0) {
             if (*(int *)(p + 0x4a6c) != 0) {
-                *(int *)(((long long)(int)(p + 0x4a6c))) -= 1;
+                *(int *)(p + 0x4a6c) -= 1;
                 if ((short)*(int *)(p + 0x4a6c) < 0) {
                     *(int *)(p + 0x4a6c) = 0;
                 }
@@ -19,20 +19,20 @@ void func_ov006_0211dec0(void *arg) {
                 _ZN5Sound12PlayBank2_2DEj(0x1bc);
                 *(int *)(p + 0x4a68) = -0x400;
                 *(int *)(p + 0x4a6c) = 0x10;
-                *(unsigned char *)(((long long)(int)(p + 0x4a73))) += 1;
+                *(unsigned char *)(p + 0x4a73) += 1;
                 *(unsigned char *)(p + 0x4a71) = 1;
             }
         } else if (v == 1) {
-            *(int *)(((long long)(int)(p + 0x4a64))) += *(int *)(p + 0x4a68);
-            *(int *)(((long long)(int)(p + 0x4a68))) -= 0x80;
+            *(int *)(p + 0x4a64) += *(int *)(p + 0x4a68);
+            *(int *)(p + 0x4a68) -= 0x80;
             if (*(int *)(p + 0x4a6c) != 0) {
-                *(int *)(((long long)(int)(p + 0x4a6c))) -= 1;
+                *(int *)(p + 0x4a6c) -= 1;
                 if ((short)*(int *)(p + 0x4a6c) < 0) {
                     *(int *)(p + 0x4a6c) = 0;
                 }
             } else {
                 *(int *)(p + 0x4a6c) = 0x18;
-                *(unsigned char *)(((long long)(int)(p + 0x4a73))) += 1;
+                *(unsigned char *)(p + 0x4a73) += 1;
             }
         }
     }

--- a/src/func_ov006_0211e184.c
+++ b/src/func_ov006_0211e184.c
@@ -1,5 +1,5 @@
-#define LI(i) ((int)(((long long)(i))) * 0x10)
-#define A(p) ((int)(((long long)(int)(p))))
+#define LI(i) ((int)((long long)(i)) * 0x10)
+#define A(p) ((int)(p))
 
 void func_ov006_0211e184(char *base)
 {

--- a/src/func_ov006_0211e4e0.c
+++ b/src/func_ov006_0211e4e0.c
@@ -1,4 +1,4 @@
-#define A(p) ((unsigned char *)(int)(((long long)(int)(p))))
+#define A(p) ((unsigned char *)(int)(p))
 
 void func_ov006_0211e4e0(char *base)
 {

--- a/src/func_ov006_0211e5cc.c
+++ b/src/func_ov006_0211e5cc.c
@@ -34,5 +34,5 @@ void func_ov006_0211e5cc(char* c)
     if (found != 0)
         return;
     FreeGfxSlotsById(0xc);
-    (*(u8*)((long long)(int)(c + 0x4c20)))++;
+    (*(u8*)(c + 0x4c20))++;
 }

--- a/src/func_ov006_0211e8a8.c
+++ b/src/func_ov006_0211e8a8.c
@@ -5,7 +5,7 @@ extern int* _ZN3G2S13GetBG0CharPtrEv(void);
 extern void func_ov006_0211e55c(char* c, int idx);
 extern void func_02012718(void* a, int b);
 
-#define A(a) (*(u8*)(((long long)(int)(a))))
+#define A(a) (*(u8*)(a))
 
 void func_ov006_0211e8a8(char* c, int idx)
 {

--- a/src/func_ov006_0211fb1c.c
+++ b/src/func_ov006_0211fb1c.c
@@ -1,5 +1,5 @@
 #include "types.h"
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+#define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];

--- a/src/func_ov006_0211fe78.c
+++ b/src/func_ov006_0211fe78.c
@@ -18,7 +18,7 @@ void func_ov006_0211fe78(char *c)
     func_ov006_0211f9fc(c);
     if (*(u16 *)(c + 0x4c0c) != 0) {
         {
-            u16 *p = (u16 *)(((int)c + 0x4c0c) & 0xFFFFFFFFFFFFFFFFULL);
+            u16 *p = (u16 *)((int)c + 0x4c0c);
             *p = *p - 1;
         }
         if (*(s16 *)(c + 0x4c0c) > 0)
@@ -40,7 +40,7 @@ void func_ov006_0211fe78(char *c)
     if (*(u16 *)(c + 0x4c0e) != 0) {
         func_ov006_0211d69c(c);
         {
-            u16 *q = (u16 *)(((int)c + 0x4c0e) & 0xFFFFFFFFFFFFFFFFULL);
+            u16 *q = (u16 *)((int)c + 0x4c0e);
             *q = *q - 1;
         }
         if (*(s16 *)(c + 0x4c0e) < 0)

--- a/src/func_ov006_02121778.c
+++ b/src/func_ov006_02121778.c
@@ -8,7 +8,7 @@ extern int data_ov006_0213faa8[];
 void func_ov006_02121778(char *c)
 {
     int idx, b;
-    *(int *)(((long long)(int)(c + 0x5d90))) -= 1;
+    *(int *)(c + 0x5d90) -= 1;
     if (*(int *)(c + 0x5000 + 0xd90) != 0)
     {
         idx = data_020a0e40[0];

--- a/src/func_ov006_02121d64.cpp
+++ b/src/func_ov006_02121d64.cpp
@@ -24,7 +24,7 @@ extern "C" void func_ov006_02121d64(char *c)
     int counter;
 
     func_ov006_020d0ac0();
-    *(int *)(((long long)(int)(c + 0x5d90))) -= 1;
+    *(int *)(c + 0x5d90) -= 1;
     counter = *(int *)(c + 0x5d90);
 
     if (counter == 0) {
@@ -56,7 +56,7 @@ extern "C" void func_ov006_02121d64(char *c)
         *(s16 *)(c + 0x5db0) = (s16)(mixRaw >> 12);
         *(s16 *)(c + 0x5db2) = data_ov006_0212e048;
 
-        *(s16 *)(((long long)(int)(c + 0x5db2))) +=
+        *(s16 *)(c + 0x5db2) +=
             ((((int)((unsigned int)(RandomIntInternal(&data_0209e650) &
                               ~0x80000000) >> 19) -
                0x800) << 2) >> 12);

--- a/src/func_ov006_0212287c.c
+++ b/src/func_ov006_0212287c.c
@@ -6,7 +6,7 @@ extern void _Z15ApproachLinear2Rsss(short* a, short b, short c);
 extern void AddVec3(struct Vector3* a, struct Vector3* b, struct Vector3* c);
 void func_ov006_0212287c(unsigned char* o){
   _Z15ApproachLinear2Rsss((short*)(o+0x76), 0, 1);
-  short* p = (short*)(((int)o + 0x74) & 0xFFFFFFFFFFFFFFFFULL);
+  short* p = (short*)((int)o + 0x74);
   *p = *p + 0x400;
   AddVec3((struct Vector3*)(o+0x5c), (struct Vector3*)(o+0x68), (struct Vector3*)(o+0x5c));
 }

--- a/src/func_ov006_021228bc.cpp
+++ b/src/func_ov006_021228bc.cpp
@@ -42,15 +42,15 @@ void func_ov006_021228bc(char* r0, int r1) {
     *(int*)(r5 + 0x6c) = r1_9;
     *(int*)(r5 + 0x70) = 0;
     unsigned int rnd2 = (unsigned int)RandomIntInternal(data_0209e650);
-    int* p1 = (int*)(((unsigned long long)(unsigned int)(r5 + 0x5c)) & 0xffffffffffffffffULL);
+    int* p1 = (int*)(r5 + 0x5c);
     int v1 = *p1 + ((((rnd2 & 0x7fffffff) >> 0x13) - 0x800) * 0x40);
     *p1 = v1;
     int rnd3 = RandomIntInternal(data_0209e650);
-    int* p2 = (int*)(((unsigned long long)(unsigned int)(r5 + 0x68)) & 0xffffffffffffffffULL);
+    int* p2 = (int*)(r5 + 0x68);
     int adj3 = (int)(((unsigned int)rnd3 & 0x7fffffff) >> 0x13);
     *p2 -= adj3 >> 1;
     int rnd4 = RandomIntInternal(data_0209e650);
-    int* p3 = (int*)(((unsigned long long)(unsigned int)(r5 + 0x6c)) & 0xffffffffffffffffULL);
+    int* p3 = (int*)(r5 + 0x6c);
     int adj4 = (int)(((unsigned int)rnd4 & 0x7fffffff) >> 0x13);
     *p3 -= adj4 >> 1;
     func_02016a14(r5, 0);

--- a/src/func_ov006_02123b24.c
+++ b/src/func_ov006_02123b24.c
@@ -8,7 +8,7 @@ extern int data_ov006_0213fbd0[];
 void func_ov006_02123b24(char *c)
 {
     int idx, b;
-    *(int *)(((long long)(int)(c + 0x7b84))) -= 1;
+    *(int *)(c + 0x7b84) -= 1;
     if (*(int *)(c + 0x7000 + 0xb84) != 0)
     {
         idx = data_020a0e40[0];

--- a/src/func_ov006_02123cb4.c
+++ b/src/func_ov006_02123cb4.c
@@ -60,7 +60,7 @@ void func_ov006_02123cb4(char *c)
         unsigned int v;
         func_ov006_020ca8e0();
         {
-            int *p = (int *)(((int)c + 0xbc) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p = (int *)((int)c + 0xbc);
             *p = *p + 1;
         }
         if (*(unsigned int *)(c + 0xbc) > 0x270e)

--- a/src/func_ov006_02124088.c
+++ b/src/func_ov006_02124088.c
@@ -21,7 +21,7 @@ void func_ov006_02124088(char *c)
     int counter;
 
     func_ov006_020d0ac0();
-    *(int *)(((long long)(int)(c + 0x7b84))) -= 1;
+    *(int *)(c + 0x7b84) -= 1;
     counter = *(int *)(c + 0x7b84);
 
     if (counter == 0) {
@@ -51,7 +51,7 @@ void func_ov006_02124088(char *c)
         *(s16 *)(c + 0x7b9c) = (s16)(mixRaw >> 12);
         *(s16 *)(c + 0x7b9e) = data_ov006_0212e048;
 
-        *(s16 *)(((long long)(int)(c + 0x7b9e))) +=
+        *(s16 *)(c + 0x7b9e) +=
             ((((int)((unsigned int)(RandomIntInternal(&data_0209e650) & ~0x80000000) >> 19) - 0x800) << 2) >> 12);
 
         func_ov004_020ae5c4(c, old9c, old9e, *(s16 *)(c + 0x7b9c), *(s16 *)(c + 0x7b9e), 2, 0xc);

--- a/src/func_ov006_02124fd8.c
+++ b/src/func_ov006_02124fd8.c
@@ -38,5 +38,5 @@ void func_ov006_02124fd8(char *c)
 after_loop:
   if (fp < 2)
     return;
-  (*(int *)(((int)c + 0x51b8) & 0xFFFFFFFFFFFFFFFFULL))++;
+  (*(int *)((int)c + 0x51b8))++;
 }

--- a/src/func_ov006_021279b0.cpp
+++ b/src/func_ov006_021279b0.cpp
@@ -44,7 +44,7 @@ extern s32 data_02092768[4];
 #define I(o) (*(s32 *)(c + (o)))
 #define H(o) (*(u16 *)(c + (o)))
 #define B(o) (*(u8 *)(c + (o)))
-#define AT(p, o) ((void *)(int)(((long long)(int)((char *)(p) + (o)))))
+#define AT(p, o) ((void *)(int)((char *)(p) + (o)))
 
 extern "C" void func_ov006_021279b0(char *c)
 {

--- a/src/func_ov006_02127d10.c
+++ b/src/func_ov006_02127d10.c
@@ -22,7 +22,7 @@ int func_ov006_02127d10(char *c)
     int m[3];
     int vecArr[3];
 
-    *(int*)(((long long)(int)(c + 0xb9d8))) = *(int*)(((long long)(int)(c + 0xb9d8))) + 1;
+    *(int*)((long long)(int)(c + 0xb9d8)) = *(int*)((long long)(int)(c + 0xb9d8)) + 1;
     if (self->unk_b9d8 >= 0x20) {
         self->unk_b9d8 = 0;
     }
@@ -51,7 +51,7 @@ int func_ov006_02127d10(char *c)
         vecArr[1] = t;
         vecArr[2] = t;
         if (self->unk_aba0 > 0) {
-            void *self = (void*)(((long long)(int)(c + 0xaba4)));
+            void *self = (void*)(c + 0xaba4);
             void (*fn)(void*, int*) = *(void(**)(void*, int*))((char*)(*(void**)self) + 0x14);
             fn(self, vecArr);
         }
@@ -63,7 +63,7 @@ int func_ov006_02127d10(char *c)
         char *p = c + i1;
         if (*(u8*)(p + 0xac58) == 1) {
             int t6 = self->unk_ab6c;
-            int t5 = *(int*)(((long long)(int)(c + i1 * 8 + 0xacdc)));
+            int t5 = *(int*)((long long)(int)(c + i1 * 8 + 0xacdc));
             if (t5 >= t6 - 0x20000 && t5 < t6 + 0x1a0000 + (func_ov004_020b04c0() << 0xc)) {
                 if (*(int*)(c + i1 * 4 + 0xb0d8) == 1) {
                     int cnt = self->unk_b9d8;
@@ -84,7 +84,7 @@ int func_ov006_02127d10(char *c)
     for (int i2 = 0; i2 < 0x80; i2++) {
         if (*(u8*)(c + i2 + 0xb358) == 1) {
             int t7 = self->unk_ab6c;
-            int t6 = *(int*)(((long long)(int)(c + i2 * 8 + 0xb5dc)));
+            int t6 = *(int*)((long long)(int)(c + i2 * 8 + 0xb5dc));
             if (t6 >= t7 - 0x40000 && t6 < t7 + 0x1c0000 + (func_ov004_020b04c0() << 0xc)) {
                 switch (*(int*)(c + i2 * 4 + 0xb3d8)) {
                 case 0:

--- a/src/func_ov006_021283a4.c
+++ b/src/func_ov006_021283a4.c
@@ -19,10 +19,10 @@ extern unsigned char data_020a0de9[];
 extern unsigned char data_020a0dea[];
 extern unsigned char data_020a0deb[];
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
-#define LNDR(e) ((int)(((long long)(e))))
-#define C1 ((char*)(void*)(int)(((long long)(int)(c))))
-#define C2 ((char*)(void*)(int)(((long long)(int)(C1))))
+#define AT(p,off) ((void*)(int)((char*)(p)+(off)))
+#define LNDR(e) ((int)((long long)(e)))
+#define C1 ((char*)(void*)(int)(c))
+#define C2 ((char*)(void*)(int)(C1))
 #define ATS(off) AT(C1,off)
 #define ATI(off) AT(C2,off)
 #define I(o) (*(int*)(c + (o)))
@@ -149,7 +149,7 @@ int func_ov006_021283a4(char *c) {
             I(0xaba0) = 0x37000;
         Vec2_Sub(s.b, (int*)AT(C1,0xab38), (int*)AT(c,0xab50));
         gate = (Vec2_Len(s.b) >= 0x30000) ? 1 : 0;
-        if ((int)(((long long)gate)) != 0) {
+        if ((int)((long long)gate) != 0) {
             I(0xab50) = I(0xab38);
             I(0xab54) = I(0xab3c);
             if (I(0xaba0) < 0x10000)

--- a/src/func_ov006_0212aa74.c
+++ b/src/func_ov006_0212aa74.c
@@ -20,7 +20,7 @@
 void func_ov006_0212aa74(char *self)
 {
     if (*(int *)(self + 0x5fe4) <= 0x14) {
-        (*(volatile int *)(((long long)(int)(self + 0x5fe4))))++;
+        (*(volatile int *)(self + 0x5fe4))++;
     } else {
         *(int *)(self + 0x5fe4) = 0;
     }

--- a/src/func_ov006_0212aacc.c
+++ b/src/func_ov006_0212aacc.c
@@ -19,7 +19,7 @@ int func_ov006_0212aacc(char* self)
     int (*iarr)[8] = (int (*)[8])self;
     u16 (*harr)[0x10] = (u16 (*)[0x10])self;
 
-    *(u16*)(((long long)(int)(self + 0x5ff4))) += 0xc0;
+    *(u16*)(self + 0x5ff4) += 0xc0;
     {
         int v = data_02082214[(*(u16*)(self + 0x5ff4) >> 4) << 1];
         int t = v + 0x80;

--- a/src/func_ov006_0212ac74.c
+++ b/src/func_ov006_0212ac74.c
@@ -27,8 +27,8 @@ extern u8 data_020a0de9[];
 extern u8 data_020a0dea[];
 extern u8 data_020a0deb[];
 
-#define LB(p) ((int)((unsigned long long)(u32)(int)(p) & 0xffffffffffffffffULL))
-#define LA(p) ((int)((long long)(int)(p) & 0xffffffffffffffffLL))
+#define LB(p) ((int)((int)(p)))
+#define LA(p) ((int)(p))
 
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off

--- a/src/func_ov007_020aebac.c
+++ b/src/func_ov007_020aebac.c
@@ -3,7 +3,7 @@ extern char *data_ov007_0210342c;
 int func_ov007_020aebac(void)
 {
     char *q = *(char **)(*(char **)(data_ov007_0210342c + 0x28));
-    unsigned char *b = (unsigned char *)(((long long)(int)(q + 0xb)));
+    unsigned char *b = (unsigned char *)(q + 0xb);
     if (b[0] == 0 && b[1] == 0 && b[2] == 0 && *(int *)(q + 4) == 0)
         return 1;
     return 0;

--- a/src/func_ov007_020b0da0.c
+++ b/src/func_ov007_020b0da0.c
@@ -43,7 +43,7 @@ void func_ov007_020b0da0(void* arg0) {
                 if (a >= 0x60 && a <= 0xa0) {
                     int b = *(u16*)(rp + 0xa);
                     if (b >= 0x40 && b <= 0x80) {
-                        int* pflag = (int*)(((long long)(int)(st + 4)));
+                        int* pflag = (int*)(st + 4);
                         *pflag |= 2;
                         data_ov007_02103340 = counter;
                         func_ov007_020bdeb0(0x34);

--- a/src/func_ov007_020b2370.cpp
+++ b/src/func_ov007_020b2370.cpp
@@ -5,7 +5,7 @@ void func_ov007_020be9ac(void* a, void* b, void* c);
 void func_ov007_020bbff0(void* c);
 }
 extern char* data_ov007_0210342c;
-#define LAUNDER(x) ((char*)(int)(((long long)(int)(x))))
+#define LAUNDER(x) ((char*)(int)(x))
 
 extern "C" void func_ov007_020b2370(void){
   char* g = *(char**)&data_ov007_0210342c;

--- a/src/func_ov007_020b413c.c
+++ b/src/func_ov007_020b413c.c
@@ -27,8 +27,8 @@ typedef struct G2 {
     R8 *f17c;
 } G2;
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
-#define MASK(p) ((void*)(int)(((long long)(int)(p))))
+#define AT(p,off) ((void*)(int)((char*)(p)+(off)))
+#define MASK(p) ((void*)(int)(p))
 
 extern G2 *data_ov007_0210342c;
 extern unsigned char data_ov007_020d7610[];

--- a/src/func_ov007_020b4c04.c
+++ b/src/func_ov007_020b4c04.c
@@ -67,7 +67,7 @@ void *func_ov007_020b4c04(int arg0)
             if (arg0 != 0) {
                 *(s16 *)(r6 + 0xc) = 0x48;
             } else {
-                s32 *p = (s32 *)(((long long)(int)(r6 + 0x10)));
+                s32 *p = (s32 *)(r6 + 0x10);
                 *p = *p + 0xc;
             }
         }

--- a/src/func_ov007_020b7708.c
+++ b/src/func_ov007_020b7708.c
@@ -19,6 +19,6 @@ void func_ov007_020b7708(int idx, void* pos)
         struct PtclSys* s;
         data_ov007_02103450[idx] = _ZN8Particle7Manager9AddSystemEiR7Vector3(data_ov007_0210344c, 0, pos);
         s = data_ov007_02103450[idx];
-        *(u32*)(((long long)(int)((char*)s + 0x1c))) |= 2;
+        *(u32*)((char*)s + 0x1c) |= 2;
     }
 }

--- a/src/func_ov007_020b8690.c
+++ b/src/func_ov007_020b8690.c
@@ -9,8 +9,8 @@ extern int func_ov007_020c44c4(char* p);
 
 #pragma opt_propagation off
 void func_ov007_020b8690(void) {
-    int *pa = (int *)(int)((long long)(int)&data_ov007_0210345c);
-    short *pb = (short *)(int)((long long)(int)&data_ov007_02103458);
+    int *pa = (int *)(int)(&data_ov007_0210345c);
+    short *pb = (short *)(int)(&data_ov007_02103458);
     int v = 0;
     *pa = v;
     *pb = v;

--- a/src/func_ov007_020b8d48.c
+++ b/src/func_ov007_020b8d48.c
@@ -72,7 +72,7 @@ void func_ov007_020b8d48(int a, int c)
         u32 s = *src++ & palmask;
         *dst = (*dst & mask) | (s << shift);
         if (rem != 0) {
-            u32 *d2 = (u32 *)(int)(((long long)(int)(dst + 8)));
+            u32 *d2 = (u32 *)(int)(dst + 8);
             *d2 = (*d2 & ~mask) | (s >> rshift);
         }
         dst++;

--- a/src/func_ov007_020b9ca8.c
+++ b/src/func_ov007_020b9ca8.c
@@ -85,6 +85,6 @@ void func_ov007_020b9ca8(void)
         *(u16 *)(*(char **)(data_ov007_0210342c + 0x54)) != 0) {
         *(int *)(data_ov007_02104ba0 + 0x28) = 0;
     } else {
-        (*(int *)(int)(((long long)(int)(data_ov007_02104ba0 + 0x28))))++;
+        (*(int *)(int)(data_ov007_02104ba0 + 0x28))++;
     }
 }

--- a/src/func_ov007_020b9fc0.c
+++ b/src/func_ov007_020b9fc0.c
@@ -7,7 +7,7 @@ int func_ov007_020b9fc0(void) {
     char *p1 = *(char **)(base + 4);
     char *p2 = *(char **)(base + 8);
     int *addr4 = (int *)(p2 + 0x50);
-    int *addr1 = (int *)(((long long)(int)(p1 + 0x50)));
+    int *addr1 = (int *)(p1 + 0x50);
 
     if (*addr1 < 0x1f000) {
         char *c = (char *)data_ov007_02104ba0;

--- a/src/func_ov007_020ba2e0.c
+++ b/src/func_ov007_020ba2e0.c
@@ -43,6 +43,6 @@ void func_ov007_020ba2e0(void)
     data_ov007_02104ba0->x40 = 0x1000;
     data_ov007_02104ba0->x44->x18 = 0x800;
     data_ov007_02104ba0->x3c = data_ov007_02104ba0->x44->x18;
-    (*(int *)((long long)(int)((char *)data_ov007_02104ba0 + 0x24))) += 1;
+    (*(int *)((char *)data_ov007_02104ba0 + 0x24)) += 1;
     data_ov007_02104ba0->f8->f2 = 5;
 }

--- a/src/func_ov007_020ba368.c
+++ b/src/func_ov007_020ba368.c
@@ -28,7 +28,7 @@ int func_ov007_020ba368(int t)
     }
 
     if (t == 0) {
-        int *p = (int *)(((s64)(int)(*(char **)data_ov007_02104ba0 + 0x20)));
+        int *p = (int *)(*(char **)data_ov007_02104ba0 + 0x20);
         *p += 1;
         if (*(int *)(*(char **)data_ov007_02104ba0 + 0x20) >= 5) {
             *(int *)(*(char **)data_ov007_02104ba0 + 0x20) = 0;

--- a/src/func_ov007_020bb09c.c
+++ b/src/func_ov007_020bb09c.c
@@ -122,8 +122,8 @@ int func_ov007_020bb09c(void)
             if (n <= 0) return n;
             {
                 char* e = *(char**)(*(char**)(r5 + 0x38) + (n - 1) * 4);
-                int* p14 = (int*)(((long long)(int)(r5 + 0x14)));
-                int* p8 = (int*)(((long long)(int)(r5 + 8)));
+                int* p14 = (int*)(r5 + 0x14);
+                int* p8 = (int*)(r5 + 8);
                 *p14 = *p14 - *(unsigned short*)(e + 0xa);
                 *p8 = *p8 - 1;
                 *(short*)(*(char**)((char*)BA0 + 8) + 2) = 6;
@@ -145,8 +145,8 @@ int func_ov007_020bb09c(void)
         if (n >= lim) return lim;
         {
             char* e = *(char**)(*(char**)(r5 + 0x38) + n * 4);
-            int* p14 = (int*)(((long long)(int)(r5 + 0x14)));
-            int* p8 = (int*)(((long long)(int)(r5 + 8)));
+            int* p14 = (int*)(r5 + 0x14);
+            int* p8 = (int*)(r5 + 8);
             *p14 = *p14 + *(unsigned short*)(e + 0xa);
             *p8 = *p8 + 1;
             *(short*)(*(char**)(*(char* volatile*)&data_ov007_02104ba0 + 8) + 2) = 7;

--- a/src/func_ov007_020bc7dc.c
+++ b/src/func_ov007_020bc7dc.c
@@ -22,7 +22,7 @@ void func_ov007_020bc7dc(char* c)
     if (*(int*)(c + 0x98) == 0)
         return;
 
-    *(short*)(((long long)(int)(c + 0x8c))) -= 1;
+    *(short*)(c + 0x8c) -= 1;
     if (*(short*)(c + 0x8c) <= 0)
         *(short*)(c + 0x8c) = 0;
 }

--- a/src/func_ov007_020beb80.c
+++ b/src/func_ov007_020beb80.c
@@ -10,14 +10,14 @@ extern void func_02053380(void *a, void *b);
 void func_ov007_020beb80(char *self) {
     char *B = *(char **)(*(char **)(self + 4));
     char *P = *(char **)(B + 0xc);
-    int *q = (int *)(int)(((long long)(unsigned)(P + 0x18)));
+    int *q = (int *)(int)(P + 0x18);
     int r;
     Vec3s dd;
     char *e;
     int frames;
     int vel;
     int sc;
-    Vec3i *tp = (Vec3i *)(int)(((long long)(int)(P + 0x24)));
+    Vec3i *tp = (Vec3i *)(int)(P + 0x24);
     r = func_020538b8(q[0], q[2]);
     dd.x = (short)(tp->x - *(int *)(self + 0xc));
     dd.y = (short)(tp->y - *(int *)(self + 0x10));
@@ -48,10 +48,10 @@ void func_ov007_020beb80(char *self) {
             }
             *(u8 *)(e + 0x58) = (u8)(((frames << 2) >> 12) + 1);
             *(int *)(e + 0x4c) = vel;
-            *(int *)(((int)e + 0x1c)) &= ~2;
+            *(int *)((int)e + 0x1c) &= ~2;
             *(Vec3i *)(e + 0x20) = *tp;
         } else {
-            *(int *)(((int)e + 0x1c)) |= 2;
+            *(int *)((int)e + 0x1c) |= 2;
         }
     }
 }

--- a/src/func_ov007_020c03b0.c
+++ b/src/func_ov007_020c03b0.c
@@ -28,12 +28,12 @@ void func_ov007_020c03b0(Arg *arg) {
     int bit1, bit2;
     int f;
 
-    pa = (Node *volatile *)(((long long)(int)arr_a));
+    pa = (Node *volatile *)(arr_a);
     pa[0] = 0;
     pa[1] = 0;
     pa[2] = 0;
     pa[3] = 0;
-    pb = (int *)(((long long)(int)arr_b));
+    pb = (int *)(arr_b);
     pb[0] = 0;
     pb[1] = 0;
     pb[2] = 0;

--- a/src/func_ov007_020c0d70.c
+++ b/src/func_ov007_020c0d70.c
@@ -16,7 +16,7 @@ struct AnimData {
     u32 count;      /* 0xc */
 };
 
-#define AT16(p, off) (*(short *)(int)(((long long)(int)((char *)(p) + (off)))))
+#define AT16(p, off) (*(short *)(int)((char *)(p) + (off)))
 
 void func_ov007_020c0d70(struct Anim *a, struct AnimData *d)
 {

--- a/src/func_ov007_020c4128.c
+++ b/src/func_ov007_020c4128.c
@@ -4,7 +4,7 @@ extern void func_ov007_020c4388(char* r0, int r1);
 extern void SubVec3(Vec3 *a, Vec3 *b, Vec3 *c);
 extern void func_ov007_020c421c(char *r4);
 
-#define ADDR(p) ((int *)(((long long)(int)(p))))
+#define ADDR(p) ((int *)(p))
 
 void func_ov007_020c4128(char *self, char *dest, int arg2)
 {

--- a/src/func_ov007_020c44e4.c
+++ b/src/func_ov007_020c44e4.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
+#define AT(p,off) ((void*)(int)((char*)(p)+(off)))
 
 
 

--- a/src/func_ov007_020c5014.c
+++ b/src/func_ov007_020c5014.c
@@ -1,6 +1,6 @@
 extern int _ZN4cstd3divEii(int, int);
 
-#define AMAT(p) (*(int*)((long long)(int)(p)))
+#define AMAT(p) (*(int*)(p))
 
 #pragma opt_common_subs off
 int func_ov007_020c5014(char* c, int x) {

--- a/src/func_ov007_020c56bc.c
+++ b/src/func_ov007_020c56bc.c
@@ -42,7 +42,7 @@ void func_ov007_020c56bc(char* sl, int sb, int r2, int r3, int p4, int fp)
                         {
                             int* q;
                             r6[0] = r6[0] + r5;
-                            q = (int*)(int)(((long long)(int)((char*)r6 + 4)));
+                            q = (int*)(int)((char*)r6 + 4);
                             *q = *q + r0v;
                         }
                         break;

--- a/src/func_ov007_020c5948.c
+++ b/src/func_ov007_020c5948.c
@@ -1,6 +1,6 @@
 struct Vec3 { int x; int y; int z; };
 
-#define LAUNDER(p) ((long long)(int)(p))
+#define LAUNDER(p) (p)
 
 extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
 

--- a/src/func_ov007_020c6550.c
+++ b/src/func_ov007_020c6550.c
@@ -12,7 +12,7 @@ int func_ov007_020c6550(char *c)
     } else {
         func_ov007_020c6d20(c, left);
         {
-            int *p = (int *)(((unsigned int)c + 8) & 0xFFFFFFFFFFFFFFFFULL);
+            int *p = (int *)((unsigned int)c + 8);
             *p = *p + 1;
         }
         if (*(int *)(c + 8) >= *(int *)(c + 0xc))

--- a/src/func_ov007_020c684c.c
+++ b/src/func_ov007_020c684c.c
@@ -14,7 +14,7 @@ void func_ov007_020c684c(char *o)
     *(int *)(o + 0x88) = *(int *)(o + 0x8c);
     *(Vec3 *)(o + 0x7c) = *(Vec3 *)(o + 0x70);
     *(Vec3 *)(o + 0x98) = *(Vec3 *)(o + 0x70);
-    tp = (Vec3 *)(((long long)(int)&tmp));
+    tp = (Vec3 *)(&tmp);
     tp->a = 0;
     tp->b = 0;
     tp->c = 0;

--- a/src/func_ov007_020c704c.c
+++ b/src/func_ov007_020c704c.c
@@ -46,9 +46,9 @@ int func_ov007_020c704c(S *self, Vec3 *b, int r2arg, int r3arg, int radius)
         spd = func_020531a4(sum);
         ratio = _ZN4cstd4fdivEii(r2arg, spd);
 
-        q = (int *)(int)(((s64)(int)((char *)self + 0x10)));
+        q = (int *)(int)((char *)self + 0x10);
         *q = *q + (int)((ratio * sdx + 0x800) >> 12);
-        self = (S *)(int)(((s64)(int)((char *)self + 0x14)));
+        self = (S *)(int)((char *)self + 0x14);
         *(int *)self = *(int *)self + (int)((ratio * sdy + 0x800) >> 12);
         return 1;
     }

--- a/src/func_ov007_020c7a84.c
+++ b/src/func_ov007_020c7a84.c
@@ -5,12 +5,12 @@ void func_ov007_020c7a84(char *p, int f1, int f2)
     int m1 = (int)(((long long)f1 * t + 0x800) >> 12);
     int m2 = (int)(((long long)f2 * *(int *)(a + 0xc) + 0x800) >> 12);
     int nm1 = -m1;
-    int *pa18 = (int *)(int)(((long long)(int)(a + 0x18)));
+    int *pa18 = (int *)(int)(a + 0x18);
     *pa18 = *pa18 + (nm1 - m2);
     {
         char *b = *(char **)(p + 4);
         int m3 = (int)(((long long)f2 * *(int *)(b + 0xc) + 0x800) >> 12);
-        int *pb18 = (int *)(int)(((long long)(int)(b + 0x18)));
+        int *pb18 = (int *)(int)(b + 0x18);
         *pb18 = *pb18 - (nm1 + m3);
     }
 }

--- a/src/func_ov007_020c7b2c.c
+++ b/src/func_ov007_020c7b2c.c
@@ -5,7 +5,7 @@ struct B { struct P *p; int f4; int f8; int fc; int f10; int f14; };
 struct J { struct B *a; struct B *b; int f8; int fc; int f10; };
 
 #define FXM(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
-#define AT(p, off) (*(int *)(int)(((long long)(int)((char *)(p) + (off)))))
+#define AT(p, off) (*(int *)(int)((char *)(p) + (off)))
 
 void func_ov007_020c7b2c(struct J *self, int m1, int m2)
 {

--- a/src/func_ov007_020c80c8.c
+++ b/src/func_ov007_020c80c8.c
@@ -3,21 +3,21 @@ void func_ov007_020c80c8(char *o, int a, int s)
     if (!(*(int *)(o + 0x20) & 1)) {
         if (*(short *)(o + 0x1c) == 0x1000) {
             int m = (int)(((long long)a * *(int *)(o + 0xc) + 0x800) >> 12);
-            int *p = (int *)(int)(((long long)(int)(o + 0xc)));
+            int *p = (int *)(int)(o + 0xc);
             *p += (*(int *)(o + 0x18) - m) >> s;
         } else {
             int m = (int)(((long long)a * *(int *)(o + 0xc) + 0x800) >> 12);
-            int *p18 = (int *)(int)(((long long)(int)(o + 0x18)));
+            int *p18 = (int *)(int)(o + 0x18);
             int m2;
             int *p0c;
             *p18 -= m;
             m2 = (int)(((long long)*(int *)(o + 0x18) * (*(short *)(o + 0x1c) >> s) + 0x800) >> 12);
-            p0c = (int *)(int)(((long long)(int)((char *)o + 0xc)));
+            p0c = (int *)(int)((char *)o + 0xc);
             *p0c += m2;
         }
         {
             int *base = *(int **)o;
-            int *q = (int *)(int)(((long long)(int)((char *)base + 8)));
+            int *q = (int *)(int)((char *)base + 8);
             *q += *(int *)(o + 0xc) >> s;
         }
     }

--- a/src/func_ov007_020c8498.c
+++ b/src/func_ov007_020c8498.c
@@ -24,7 +24,7 @@ void func_ov007_020c8498(char* r5)
     if(*(int*)(r5 + 8) == 0) return;
 
     if(*(int*)(r5 + 8) == 1){
-        int* v14 = (int*)((((long long)(int)(r5 + 0x14))));
+        int* v14 = (int*)(r5 + 0x14);
         *v14 += *(int*)(r5 + 0x18);
         if(*(int*)(r5 + 0x14) > 0x1000){
             *(int*)(r5 + 0x14) = 0x1000;

--- a/src/func_ov007_020ccad0.c
+++ b/src/func_ov007_020ccad0.c
@@ -20,7 +20,7 @@ int *func_ov007_020ccad0(void)
         _ZN9ActorBaseC1Ev(p);
         p[0] = (int)data_0208e4b8;
         p[0] = (int)_ZTV5Scene;
-        f = (unsigned char *)((long long)(int)((char *)p + 0x13));
+        f = (unsigned char *)((char *)p + 0x13);
         *f |= 1;
         *f |= 4;
         p[0] = (int)data_ov007_021032e8;

--- a/src/func_ov010_021112b4.c
+++ b/src/func_ov010_021112b4.c
@@ -1,6 +1,6 @@
 extern char *func_ov010_0211139c(char *c);
 
-#define LAUNDER_ADDR(x) ((int)(((long long)(int)(x))))
+#define LAUNDER_ADDR(x) ((int)(x))
 
 void func_ov010_021112b4(char *c)
 {

--- a/src/func_ov012_0211123c.c
+++ b/src/func_ov012_0211123c.c
@@ -10,7 +10,7 @@ void func_ov012_0211123c(char* c) {
     int* q;
     char* p;
     if (*(unsigned char*)(c+0x31e)) return;
-    q = (int*)(((long long)(int)(c + 0x60)));
+    q = (int*)(c + 0x60);
     *q -= 0x64000;
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/func_ov012_02111370.c
+++ b/src/func_ov012_02111370.c
@@ -19,7 +19,7 @@ int func_ov012_02111370(char* c){
   mdl = _ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124a8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, mdl, 1, -1);
   if(data_0209caa0[2] & 0x80000){
-    *(int*)(((long long)(int)(c + 0x60))) -= 0x64000;
+    *(int*)(c + 0x60) -= 0x64000;
     *(char*)(c+0x31e) = 1;
   }
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov014_021115ec.cpp
+++ b/src/func_ov014_021115ec.cpp
@@ -27,7 +27,7 @@ extern "C" {
     extern void *data_ov014_02114980[];
 }
 static inline void inc604(u8 *self) {
-    u8 *p = (u8 *)(((long long)(int)(self + 0x604)));
+    u8 *p = (u8 *)(self + 0x604);
     *p = (u8)(*p + 1);
 }
 extern "C" void func_ov014_021115ec(u8 *self)
@@ -37,7 +37,7 @@ extern "C" void func_ov014_021115ec(u8 *self)
     _ZN5Sound15PlaySecretSoundEP5ActorPt(self, (u16 *)(self + 0x5fe));
     r4 = (u8 *)_ZN5Actor10FindWithIDEj(*(unsigned *)(self + 0x60c));
     {
-        s32 *src = (s32 *)(((long long)(int)(r4 + 0x5c)));
+        s32 *src = (s32 *)(r4 + 0x5c);
         s32 fifth = 0x80;
         sp4.x = src[0];
         void *ap = self + 0x8c;
@@ -139,7 +139,7 @@ extern "C" void func_ov014_021115ec(u8 *self)
     case 8:
         if (DecIfAbove0_Short(self + 0x5fc) == 0) {
             {
-                unsigned *flag = (unsigned *)(((long long)(int)(r8 + 0x154)));
+                unsigned *flag = (unsigned *)(r8 + 0x154);
                 *flag &= ~8u;
             }
             if (_ZN6Player12Unk_020ca150Eh(_ZN5Actor13ClosestPlayerEv(self), 4) != 0) {

--- a/src/func_ov016_02111284.c
+++ b/src/func_ov016_02111284.c
@@ -11,7 +11,7 @@ extern unsigned char data_0209f220;
 extern int data_ov016_02114dbc;
 extern int data_020a0e68[];
 
-#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p))))
+#define LA(p) ((void*)(unsigned long)((unsigned long)(p)))
 
 void func_ov016_02111284(char* c)
 {

--- a/src/func_ov016_021115c0.c
+++ b/src/func_ov016_021115c0.c
@@ -20,7 +20,7 @@ extern void func_02012694(int a, void* p);
 
 
 
-#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p))))
+#define LA(p) ((void*)(unsigned long)((unsigned long)(p)))
 
 int func_ov016_021115c0(char* c)
 {

--- a/src/func_ov016_021119ec.c
+++ b/src/func_ov016_021119ec.c
@@ -21,7 +21,7 @@ extern unsigned char data_0209f220;
 extern int data_020a0e68[];
 
 #pragma opt_propagation off
-#define LA(p) ((int*)(unsigned long)(((long long)(int)(unsigned long)(p))))
+#define LA(p) ((int*)(unsigned long)((unsigned long)(p)))
 
 int func_ov016_021119ec(char* c)
 {

--- a/src/func_ov018_02111368.cpp
+++ b/src/func_ov018_02111368.cpp
@@ -108,7 +108,7 @@ extern "C" int func_ov018_02111368(char* self)
         }
 
         if (reached) {
-            int* pIdx = (int*)((long long)(int)(self + 0x33c));
+            int* pIdx = (int*)(self + 0x33c);
             *pIdx = *pIdx + *(int*)(self + 0x34c);
             if (*(int*)(self + 0x33c) < 0) {
                 if (_ZNK7PathPtr5LoopsEv(&path) != 0) {
@@ -117,7 +117,7 @@ extern "C" int func_ov018_02111368(char* self)
                     *(u8*)(self + 0x331) = 0x3c;
                     *(u8*)(self + 0x330) = 0;
                     *(int*)(self + 0x34c) = 1;
-                    int* pIdx2 = (int*)((long long)(unsigned int)(self + 0x33c));
+                    int* pIdx2 = (int*)(self + 0x33c);
                     *pIdx2 = *pIdx2 + (*(int*)(self + 0x34c) * 2);
                 }
             }
@@ -128,7 +128,7 @@ extern "C" int func_ov018_02111368(char* self)
                     *(u8*)(self + 0x331) = 0x3c;
                     *(u8*)(self + 0x330) = 0;
                     *(int*)(self + 0x34c) = -1;
-                    int* pIdx3 = (int*)((long long)(int)((unsigned)(int)self + 0x33c));
+                    int* pIdx3 = (int*)((unsigned)(int)self + 0x33c);
                     *pIdx3 = *pIdx3 + (*(int*)(self + 0x34c) * 2);
                 }
             }

--- a/src/func_ov018_021116b4.cpp
+++ b/src/func_ov018_021116b4.cpp
@@ -42,7 +42,7 @@ int func_ov018_021116b4(char* c){
   self->unk_328 = self->unk_060;
   self->unk_32c = self->unk_064;
   {
-    short* ang = (short*)((long long)(int)(c + 0x8e));
+    short* ang = (short*)(c + 0x8e);
     *ang = *ang - 0x4000;
   }
   _ZN7PathPtrC1Ev(&p);
@@ -50,7 +50,7 @@ int func_ov018_021116b4(char* c){
   self->unk_338 = _ZNK7PathPtr8NumNodesEv(&p);
   self->unk_34c = 1;
   {
-    int* ip = (int*)((long long)(int)(c + 0x33c));
+    int* ip = (int*)(c + 0x33c);
     *ip = *ip + self->unk_34c;
   }
   self->unk_320 = 0;

--- a/src/func_ov018_02111fac.c
+++ b/src/func_ov018_02111fac.c
@@ -15,7 +15,7 @@ extern int func_ov018_021123d0(void *c, int b);
 extern void func_ov018_02111a48(void *c, void *p);
 extern char data_020a0e68[];
 
-#define U8P(base, off) ((u8 *)(((unsigned int)(base) + (off)) & 0xFFFFFFFFFFFFFFFFULL))
+#define U8P(base, off) ((u8 *)((unsigned int)(base) + (off)))
 
 int func_ov018_02111fac(char *c)
 {

--- a/src/func_ov020_02111340.c
+++ b/src/func_ov020_02111340.c
@@ -1,7 +1,7 @@
 // @symbol func_ov020_02111340
 /* recovered: shared common types */
 #include "common.h"
-#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off)))))
+#define AT(p, off) ((void *)(int)((char *)(p) + (off)))
 extern int RandomIntInternal(void *p);
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16as(unsigned int a, unsigned int b, void *pos, void *rot, int e, int f);

--- a/src/func_ov020_021115ac.c
+++ b/src/func_ov020_021115ac.c
@@ -3,7 +3,7 @@
  * reserve it with no emitted code (plain or non-address-taken volatiles are DCE'd before
  * frame layout). The 6g u64-mask launder on &vel forces the ROM's `add r0,r4,#0xa4` base. */
 typedef struct { int x, y, z; } Vec3;
-#define LDR(p) ((int)((((long long)(int)(p)))))
+#define LDR(p) ((int)(p))
 
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern int _ZN5Actor24BumpedUnderneathByPlayerER6Player(void *thiz, void *player);

--- a/src/func_ov020_0211174c.c
+++ b/src/func_ov020_0211174c.c
@@ -7,7 +7,7 @@ extern void func_ov063_0211cae8(void *found, unsigned int mask);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *thiz);
 extern u8 data_ov020_02114828[];
 
-#define LDR(p) ((int)((((long long)(int)(p)))))
+#define LDR(p) ((int)(p))
 
 void func_ov020_0211174c(char *c)
 {

--- a/src/func_ov020_02111aa8.c
+++ b/src/func_ov020_02111aa8.c
@@ -5,14 +5,14 @@ extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *thiz, void *clsn);
 void func_ov020_02111aa8(char *c)
 {
     *(unsigned char *)(c + 0x108) = 0;
-    (*(unsigned short *)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFULL))++;
-    if (*(unsigned short *)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFULL) >= 3) {
+    (*(unsigned short *)((int)c + 0x100))++;
+    if (*(unsigned short *)((int)c + 0x100) >= 3) {
         int *bf;
         int t;
         int sid;
         *(int *)(c + 0x424) = 3;
         *(int *)(c + 0x98) = 0x32000;
-        bf = (int *)((unsigned long long)(unsigned)(c + 0x234) & 0xFFFFFFFFFFFFFFFFULL);
+        bf = (int *)(c + 0x234);
         t = *bf;
         sid = 0x166;
         *bf = t & ~1;

--- a/src/func_ov020_02112e94.c
+++ b/src/func_ov020_02112e94.c
@@ -1,7 +1,7 @@
 // @symbol func_ov020_02112e94
 /* recovered: shared common types */
 #include "common.h"
-#define LAUNDER(p) ((long long)(int)(p))
+#define LAUNDER(p) (p)
 
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern int Vec3_Dist(const void *a, const void *b);

--- a/src/func_ov021_02112544.cpp
+++ b/src/func_ov021_02112544.cpp
@@ -58,8 +58,8 @@ extern "C" void func_ov021_02112544(char* self)
                 *(int*)(self + 0x3b8), 3, 0x8a, self + 0x74, 0);
         }
         {
-            int *pa4 = (int *)(int)(((long long)(int)(self + 0xa4)));
-            int *pac = (int *)(int)(((long long)(int)(self + 0xac)));
+            int *pa4 = (int *)(int)(self + 0xa4);
+            int *pac = (int *)(int)(self + 0xac);
             *pa4 = *pa4 + normal.x * 5;
             *pac = *pac + normal.z * 5;
         }

--- a/src/func_ov022_021112ac.c
+++ b/src/func_ov022_021112ac.c
@@ -59,7 +59,7 @@ int func_ov022_021112ac(void *thiz)
             *(void **)((unsigned char *)s + 0x10c) = c;
             *(int *)((unsigned char *)s + 0x118) = *(int *)(c + 0x60);
             {
-                unsigned short *t = (unsigned short *)((long long)(int)(c + 0x324));
+                unsigned short *t = (unsigned short *)(c + 0x324);
                 *t = *t + 1;
             }
             *(unsigned char *)(c + 0x31f) = 2;
@@ -67,7 +67,7 @@ int func_ov022_021112ac(void *thiz)
         break;
     }
 
-    ip = (short *)((long long)(int)(c + 0x94));
+    ip = (short *)(c + 0x94);
     *ip = (short)(*ip + *(short *)(c + 0x96));
     *(short *)(c + 0x8e) = *(short *)(c + 0x94);
     func_020393a4(c + 0x124, 0x780000);

--- a/src/func_ov022_02111ad0.c
+++ b/src/func_ov022_02111ad0.c
@@ -16,7 +16,7 @@ int func_ov022_02111ad0(char* c)
     struct daObjFl_London_c *self = (struct daObjFl_London_c *)(void *)c;
     if (DecIfAbove0_Byte((unsigned char*)c + 0x31e) == 0) {
         if (self->unk_31f == 0) {
-            short* p = (short*)((long long)(int)(c + 0x96));
+            short* p = (short*)(c + 0x96);
             *p = *p - 0x100;
             if (self->unk_096 <= -0x2000) {
                 self->unk_096 = -0x2000;
@@ -24,7 +24,7 @@ int func_ov022_02111ad0(char* c)
                 self->unk_31f = 1;
             }
         } else {
-            short* p = (short*)((long long)(int)(c + 0x96));
+            short* p = (short*)(c + 0x96);
             *p = *p + 0x100;
             if (self->unk_096 >= 0) {
                 self->unk_096 = 0;

--- a/src/func_ov022_02112710.c
+++ b/src/func_ov022_02112710.c
@@ -9,11 +9,11 @@ int func_ov022_02112710(char *c)
     *(short *)(c + 0x110) = 0x3c;
     *(short *)(c + 0x94) = (short)((r & 0xf) << 0xc);
     *(int *)(c + 0x98) = (r & 0x1f) + 0x14;
-    p98 = (int *)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFULL);
+    p98 = (int *)((int)c + 0x98);
     *p98 = *p98 << 0xc;
     *(int *)(c + 0x9c) = -0x4000;
     *(int *)(c + 0xa8) = (r & 0x3f) + 0x28;
-    pa8 = (int *)(((int)c + 0xa8) & 0xFFFFFFFFFFFFFFFFULL);
+    pa8 = (int *)((int)c + 0xa8);
     *pa8 = *pa8 << 0xc;
     return 1;
 }

--- a/src/func_ov024_02111350.c
+++ b/src/func_ov024_02111350.c
@@ -1,5 +1,5 @@
 #include "types.h"
-#define M(p) ((long long)(int)(p))
+#define M(p) (p)
 
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int c, int d, int e, void* v, void* cb);

--- a/src/func_ov025_021113f0.c
+++ b/src/func_ov025_021113f0.c
@@ -14,7 +14,7 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
     u32 slot, u32 effect, s32 x, s32 y, s32 z, const void *rot, void *cb);
 extern s16 data_02082214[];
 
-#define LAUNDER(p) ((long long)(int)(p))
+#define LAUNDER(p) (p)
 
 int func_ov025_021113f0(char *self)
 {

--- a/src/func_ov026_02111330.cpp
+++ b/src/func_ov026_02111330.cpp
@@ -66,14 +66,14 @@ extern "C" int func_ov026_02111330(void* self)
         }
 
         if (moved) {
-            *(volatile s32*)(((s32)c + 0x170) & 0xFFFFFFFFFFFFFFFFull) += *(s32*)(c + 0x180);
+            *(volatile s32*)((s32)c + 0x170) += *(s32*)(c + 0x180);
             if (*(s32*)(c + 0x170) < 0) {
                 if (_ZNK7PathPtr5LoopsEv(c + 0x164) != 0) {
                     *(s32*)(c + 0x170) = *(s32*)(c + 0x16c) - 1;
                 } else {
                     *(s16*)(c + 0x184) = 0x3c;
                     *(s32*)(c + 0x180) = 1;
-                    *(volatile s32*)(((s32)(c + 0x170)) & 0xFFFFFFFFFFFFFFFFull) += *(s32*)(c + 0x180) << 1;
+                    *(volatile s32*)((s32)(c + 0x170)) += *(s32*)(c + 0x180) << 1;
                 }
             }
             if (*(s32*)(c + 0x170) >= *(s32*)(c + 0x16c)) {
@@ -82,7 +82,7 @@ extern "C" int func_ov026_02111330(void* self)
                 } else {
                     *(s16*)(c + 0x184) = 0x3c;
                     *(s32*)(c + 0x180) = -1;
-                    *(volatile s32*)(((s32)(c + 0x170)) & 0xFFFFFFFFFFFFFFFFull) += *(s32*)(c + 0x180) << 1;
+                    *(volatile s32*)((s32)(c + 0x170)) += *(s32*)(c + 0x180) << 1;
                 }
             }
         }

--- a/src/func_ov026_02111b24.c
+++ b/src/func_ov026_02111b24.c
@@ -37,7 +37,7 @@ int func_ov026_02111b24(char* self)
         _Z14ApproachLinearRiii((int*)(self + 0x198), 0x100, 0x1000);
         _Z14ApproachLinearRiii((int*)(self + 0x194), *(int*)(self + 0x1ac) - 0x64000, 0x4000);
         {
-            s16* q = (s16*)(int)(((long long)(int)(self + 0x1b4)));
+            s16* q = (s16*)(int)(self + 0x1b4);
             *q += *(s16*)(self + 0x1b6);
         }
         v1.y = *(int*)(self + 0x194);
@@ -54,7 +54,7 @@ int func_ov026_02111b24(char* self)
             *(s16*)(player + 0x90) = 0;
         }
         {
-            int* pp = (int*)(int)(((long long)(int)(player + 0x5c)));
+            int* pp = (int*)(int)(player + 0x5c);
             pv.x = pp[0];
             pv.y = pp[1];
             pv.z = pp[2];

--- a/src/func_ov026_02111d4c.cpp
+++ b/src/func_ov026_02111d4c.cpp
@@ -31,7 +31,7 @@ extern "C" int func_ov026_02111d4c(char* c)
     Player* pl = ((Actor*)c)->ClosestPlayer();
     if (pl != 0) {
         Vector3 v;
-        Vector3* p0 = (Vector3*)(((int)pl + 0x5c) & 0xFFFFFFFFFFFFFFFFull);
+        Vector3* p0 = (Vector3*)((int)pl + 0x5c);
         v = *p0;
 
         if (Vec3_HorzDist((Vector3*)(c + 0x1a8), &v) <= 0x12c000) {
@@ -64,7 +64,7 @@ extern "C" int func_ov026_02111d4c(char* c)
                 Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, 0x2000);
                 MulVec3Mat4x3(&m, &data_020a0e68, &out);
 
-                Vector3* p1 = (Vector3*)(((int)(((int)pl) & 0xFFFFFFFFFFFFFFFFull) + 0x5c) & 0xFFFFFFFFFFFFFFFFull);
+                Vector3* p1 = (Vector3*)((int)((int)pl) + 0x5c);
                 m = *p1;
                 m.x += out.x;
                 m.y += out.y;

--- a/src/func_ov030_02111b20.c
+++ b/src/func_ov030_02111b20.c
@@ -23,7 +23,7 @@ int func_ov030_02111b20(char* c) {
   *(s16*)(c+0x94) = *(s16*)(c+0x8e);
   if (d < *(int*)(c+0x98)) {
     n = _ZNK7PathPtr8NumNodesEv(c+0x398);
-    p = (int*)((long long)(int)(c + 0x3a0));
+    p = (int*)(c + 0x3a0);
     n = n - 1;
     *p = *p + 1;
     if (*(int*)(c+0x3a0) >= n) return 1;

--- a/src/func_ov030_02112578.c
+++ b/src/func_ov030_02112578.c
@@ -46,7 +46,7 @@ int func_ov030_02112578(void *arg0)
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov030_02115cd0[1], 0, 0x1000, 0);
             *(s32 *)(c + 0x130) = 0x1000;
             *(s32 *)(c + 0x98) = 0;
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
         func_ov030_02111890(arg0);
         break;
@@ -54,7 +54,7 @@ int func_ov030_02112578(void *arg0)
         _Z14ApproachLinearRsss((s16 *)(c + 0x8e), Vec3_HorzAngle(c + 0x5c, (u8 *)r6 + 0x5c), 0x300);
         if (Vec3_Dist(c + 0x5c, (u8 *)r6 + 0x5c) < 0x96000) {
             if (_ZN6Player9StartTalkER9ActorBaseb(r6, arg0, 1) != 0) {
-                { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+                { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
             }
         }
         func_ov030_02111908(arg0);
@@ -69,7 +69,7 @@ int func_ov030_02112578(void *arg0)
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov030_02115cf8[1], 0, 0x1000, 0);
             _ZN9Animation8SetFlagsEi(c + 0x124, 0);
             func_0201267c(0xd1, c + 0x74);
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
         break;
     }
@@ -77,7 +77,7 @@ int func_ov030_02112578(void *arg0)
         if (_ZN6Player12GetTalkStateEv() == 2) {
             _ZN6Player18HasFinishedTalkingEv(r6);
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov030_02115d18[1], 0, 0x1000, 0);
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
         break;
     case 4:
@@ -87,14 +87,14 @@ int func_ov030_02112578(void *arg0)
             *(s32 *)(c + 0x98) = 0xf000;
             *(s32 *)(c + 0xa8) = 0x2f000;
             func_0201267c(0xf1, c + 0x74);
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
         break;
     case 5:
         if (_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x194) != 0) {
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov030_02115d10[1], 0x40000000, 0x1000, 0);
             *(s32 *)(c + 0x98) = 0;
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
         break;
     case 6:
@@ -104,28 +104,28 @@ int func_ov030_02112578(void *arg0)
             *(s32 *)((u8 *)r4 + 0x98) = 0x400;
             _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x14, 0x7f, 0x15666, 0);
             c[0x3c6] = 0x78;
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
         /* fallthrough */
     case 7: {
-        s32 *pp = (s32 *)(((unsigned int)c + 0x3bc) & 0xFFFFFFFFFFFFFFFFULL);
+        s32 *pp = (s32 *)((unsigned int)c + 0x3bc);
         *pp = *pp + 0x400;
         if (*(s32 *)(c + 0x3bc) > 0x17ffd) {
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
     }
         /* fallthrough */
     case 8:
-        if (DecIfAbove0_Byte((u8 *)(((unsigned int)c + 0x3c6) & 0xFFFFFFFFFFFFFFFFULL)) == 0) {
+        if (DecIfAbove0_Byte((u8 *)((unsigned int)c + 0x3c6)) == 0) {
             _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x7f, 0, 0x15666, 0);
-            { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+            { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         }
         break;
     case 9:
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov030_02115d08[1], 0x40000000, 0x1000, 0);
         *(s32 *)((u8 *)r4 + 0x9c) = -0x2000;
         *(s32 *)((u8 *)r4 + 0xa0) = -0x3c000;
-        { u8 *p = (u8 *)(((unsigned int)c + 0x3c7) & 0xFFFFFFFFFFFFFFFFULL); *p = *p + 1; }
+        { u8 *p = (u8 *)((unsigned int)c + 0x3c7); *p = *p + 1; }
         break;
     case 10:
         if (_ZN5Actor15FindWithActorIDEjPS_(0x67, 0) == 0) {

--- a/src/func_ov030_02112da0.c
+++ b/src/func_ov030_02112da0.c
@@ -11,7 +11,7 @@ extern u8 data_0209d684;
 int func_ov030_02112da0(char *a) {
     int b = (int)((*(u32 *)(a + 0xb0) & 0x40000) != 0);
     if (b != 0) {
-        int p = (int)((long long)(int)(*(char **)(a + 0x3a8) + 0x5c));
+        int p = (int)(*(char **)(a + 0x3a8) + 0x5c);
         *(int *)(a + 0x5c) = *(int *)p;
         *(int *)(a + 0x60) = *(int *)(p + 4);
         *(int *)(a + 0x64) = *(int *)(p + 8);
@@ -32,9 +32,9 @@ int func_ov030_02112da0(char *a) {
             if (b2 != 0) {
                 char *s = *(char **)(a + 0x3a8);
                 int off = 0x3c7;
-                int *p = (int *)((long long)(int)(s + 0x5c));
+                int *p = (int *)(s + 0x5c);
                 int x = *p;
-                u8 *st = (u8 *)(((int)a + off));
+                u8 *st = (u8 *)((int)a + off);
                 *(int *)(a + 0x5c) = x;
                 *(int *)(a + 0x60) = p[1];
                 *(int *)(a + 0x64) = p[2];
@@ -53,13 +53,13 @@ int func_ov030_02112da0(char *a) {
                 *(int *)(a + 0x60) > *(int *)(a + 0x384) - 0x12c000) {
                 if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3hh(*(char **)(a + 0x3a8), a, 0xc1, 0, 0, 0) != 0) {
                     func_0201267c(0xd1, a + 0x74);
-                    (*(u8 *)(((int)a + 0x3c7)))++;
+                    (*(u8 *)((int)a + 0x3c7))++;
                 }
             }
             {
                 char *s = *(char **)(a + 0x3a8);
                 u8 val = 0x3c;
-                int *p = (int *)((long long)(int)(s + 0x5c));
+                int *p = (int *)(s + 0x5c);
                 *(int *)(a + 0x5c) = *p;
                 *(int *)(a + 0x60) = p[1];
                 *(int *)(a + 0x64) = p[2];
@@ -74,12 +74,12 @@ int func_ov030_02112da0(char *a) {
                     *(int *)(a + 0x3b8) = 8;
                     func_ov030_021141a8(a, 7);
                 } else if (g == 2) {
-                    (*(u8 *)(((int)a + 0x3c7)))++;
+                    (*(u8 *)((int)a + 0x3c7))++;
                 }
             }
             break;
         case 3:
-            if (DecIfAbove0_Byte((u8 *)(((int)a + 0x3c6))) == 0) {
+            if (DecIfAbove0_Byte((u8 *)((int)a + 0x3c6)) == 0) {
                 *(u8 *)(a + 0x3c7) = 1;
             }
             break;

--- a/src/func_ov030_02112ff8.c
+++ b/src/func_ov030_02112ff8.c
@@ -4,7 +4,7 @@ extern void _ZN12CylinderClsn5ClearEv(void *p);
 
 int func_ov030_02112ff8(char *c)
 {
-    *(int *)(((long long)(int)(c + 0xb0))) &= ~0x80000;
+    *(int *)(c + 0xb0) &= ~0x80000;
     if (Vec3_Dist(c + 0x380, c + 0x5c) < 0x514000 &&
         *(int *)(c + 0x60) > *(int *)(c + 0x384) - 0x12c000) {
         *(unsigned char *)(c + 0x3c7) = 0;

--- a/src/func_ov030_021132d4.cpp
+++ b/src/func_ov030_021132d4.cpp
@@ -3,7 +3,7 @@ extern "C" {
 extern int _ZN12CylinderClsn5ClearEv(void*);
 extern int _ZN12WithMeshClsn15ClearGroundFlagEv(void*);
 int func_ov030_021132d4(char* c) {
-    int* p = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFULL);
+    int* p = (int*)((int)c + 0xb0);
     int tmp = *p;
     *p = tmp & ~0x80000;
     *(unsigned char*)(c + 0x3c7) = 0;

--- a/src/func_ov030_02113a80.cpp
+++ b/src/func_ov030_02113a80.cpp
@@ -27,7 +27,7 @@ int func_ov030_02113a80(char* c)
             *(unsigned char*)(c + 0x3c7) = 4;
         } else {
             *(unsigned char*)(c + 0x3c7) = 0;
-            unsigned char* f = (unsigned char*)(((unsigned long long)((int)(c) + 0x3c8)) & 0xFFFFFFFFFFFFFFFFULL);
+            unsigned char* f = (unsigned char*)((unsigned long long)((int)(c) + 0x3c8));
             *f ^= 1;
         }
     }

--- a/src/func_ov034_021113d4.c
+++ b/src/func_ov034_021113d4.c
@@ -38,7 +38,7 @@ i = 0;
             func_ov034_021125b8(thiz, 4);
     }
     {
-        unsigned char *t = (unsigned char *)(void *)(unsigned long long)(unsigned)(thiz + 0x8da);
+        unsigned char *t = (unsigned char *)(void *)(thiz + 0x8da);
         *t = (unsigned char)(*t + 1);
     }
     if (*(unsigned char *)(thiz + 0x8da) > 0xc)

--- a/src/func_ov034_021115cc.cpp
+++ b/src/func_ov034_021115cc.cpp
@@ -50,7 +50,7 @@ i = 0;
     }
 
     {
-        unsigned char *t = (unsigned char *)(void *)(unsigned long long)(unsigned)(self + 0x8da);
+        unsigned char *t = (unsigned char *)(void *)(self + 0x8da);
         *t = (unsigned char)(*t + 1);
     }
     if (*(unsigned char *)(self + 0x8da) > 0xc)

--- a/src/func_ov034_02112020.c
+++ b/src/func_ov034_02112020.c
@@ -12,7 +12,7 @@ void func_ov034_02112020(char *c)
 {
     int i;
     for (i = 0; i < 5; i++) {
-        int *p = (int *)(void *)(unsigned long long)(unsigned)(c + (i << 6) + 0x490);
+        int *p = (int *)(void *)(c + (i << 6) + 0x490);
         *p &= ~4;
     }
     *(unsigned char *)(c + 0x8da) = 0;

--- a/src/func_ov034_021120ac.cpp
+++ b/src/func_ov034_021120ac.cpp
@@ -62,7 +62,7 @@ i = 0;
     }
 
     {
-        unsigned char *t = (unsigned char *)(void *)(unsigned long long)(unsigned)(c + 0x8da);
+        unsigned char *t = (unsigned char *)(void *)(c + 0x8da);
         *t = (unsigned char)(*t + 1);
     }
     if (*(unsigned char *)(c + 0x8da) > 0xc)

--- a/src/func_ov034_02112688.c
+++ b/src/func_ov034_02112688.c
@@ -24,7 +24,7 @@ void func_ov034_02112688(char *sl)
         type = *(u16 *)(a + 0xc);
         { int t = (int)(type == 0xbf); flag = t ? one : zero; }
         if (flag == 0) continue;
-        src = (struct Vector3 *)(((long long)(int)(a + 0x5c)));
+        src = (struct Vector3 *)(a + 0x5c);
         v0.x = src->x; v0.y = src->y; v0.z = src->z;
         if (func_ov034_02112650(sl, p, a) != 0) {
             _ZN6Player6BounceE5Fix12IiE(a, 0x28000);

--- a/src/func_ov060_02111f08.c
+++ b/src/func_ov060_02111f08.c
@@ -33,7 +33,7 @@ int func_ov060_02111f08(void* arg0)
     switch (*(unsigned char*)(self + 0x444)) {
     case 0:
         _ZN6Camera9SetFlag_3Ev(cam);
-        pv = (struct Vector3*)(((long long)(int)(player + 0x5c)));
+        pv = (struct Vector3*)(player + 0x5c);
         sp.x = pv->x;
         sp.y = pv->y;
         sp.z = pv->z;
@@ -49,7 +49,7 @@ int func_ov060_02111f08(void* arg0)
         *(int*)(self + 0x43c) = *(int*)(self + 0x60) + 0xc8000;
         *(int*)(self + 0x440) = *(int*)(self + 0x64) + (int)(((long long)v * data_02082214[k * 2 + 1] + 0x800) >> 12);
         _ZN6Camera6SetPosERK7Vector3(cam, (struct Vector3*)(self + 0x438));
-        p = (unsigned char*)(((long long)(int)(self + 0x444)));
+        p = (unsigned char*)(self + 0x444);
         *p = *p + 1;
         break;
     case 1:
@@ -57,16 +57,16 @@ int func_ov060_02111f08(void* arg0)
         if (_ZN6Player7IsInAirEv(player) != 0)
             *(unsigned char*)(self + 0x445) = 0;
         else {
-            p = (unsigned char*)(((long long)(int)(self + 0x445)));
+            p = (unsigned char*)(self + 0x445);
             *p = *p + 1;
         }
         if (*(unsigned char*)(self + 0x445) > 0x1e) {
-            p = (unsigned char*)(((long long)(int)(self + 0x444)));
+            p = (unsigned char*)(self + 0x444);
             *p = *p + 1;
         }
         break;
     case 2:
-        pv = (struct Vector3*)(((long long)(int)(player + 0x5c)));
+        pv = (struct Vector3*)(player + 0x5c);
         sp.x = pv->x;
         sp.y = pv->y;
         sp.z = pv->z;
@@ -83,7 +83,7 @@ int func_ov060_02111f08(void* arg0)
         _Z14ApproachLinearRiii((int*)(self + 0x434), *(int*)(self + 0x64), 0x1e000);
         func_020092c4(cam, (char*)cam + 0x8c, self + 0x438);
         if (func_020092c4(cam, (char*)cam + 0x80, self + 0x42c) != 0) {
-            p = (unsigned char*)(((long long)(int)(self + 0x444)));
+            p = (unsigned char*)(self + 0x444);
             *p = *p + 1;
         }
         break;
@@ -104,7 +104,7 @@ int func_ov060_02111f08(void* arg0)
             return 1;
         break;
     case 4:
-        *(int*)(((long long)(int)((char*)cam + 0x154))) &= ~8;
+        *(int*)((char*)cam + 0x154) &= ~8;
         break;
     default:
         break;

--- a/src/func_ov060_02112434.cpp
+++ b/src/func_ov060_02112434.cpp
@@ -32,15 +32,15 @@ extern "C" void func_ov060_02112434(unsigned char* thiz)
     int s0 = _ZN5Actor14GetSubtractionEss(thiz, *(short*)(thiz + 0x8e), *(short*)(thiz + 0x406));
     int s1 = _ZN5Actor14GetSubtractionEss(thiz, *(short*)(thiz + 0x8e), *(short*)(thiz + 0x408));
 
-    *(int*)(int)(((long long)(int)(thiz + 0x418))) &= ~0xff;
+    *(int*)(int)(thiz + 0x418) &= ~0xff;
     if (s0 < 0x2000)
-        *(int*)(int)(((long long)(int)(thiz + 0x418))) |= 2;
+        *(int*)(int)(thiz + 0x418) |= 2;
     if (s1 < 0x3800)
-        *(int*)(int)(((long long)((int)thiz + 0x418))) |= 4;
+        *(int*)(int)((long long)((int)thiz + 0x418)) |= 4;
     if (*(int*)(thiz + 0x3f4) < 0x3e8000)
-        *(int*)(((int)thiz + 0x418)) |= 0x10;
+        *(int*)((int)thiz + 0x418) |= 0x10;
     if (*(int*)(thiz + 0x3ec) < 0x352000)
-        *(int*)(int)(((unsigned long long)((unsigned)thiz + 0x418))) |= 8;
+        *(int*)(int)((unsigned long long)((unsigned)thiz + 0x418)) |= 8;
 
     (((C*)thiz)->*data_ov060_0211aeb4[*(int*)(thiz + 0x410)].pmf)();
 
@@ -55,8 +55,8 @@ extern "C" void func_ov060_02112434(unsigned char* thiz)
             thiz[0x41c] = 0xff;
             return;
         }
-        *(unsigned char*)(int)(((long long)(int)(thiz + 0x41c))) =
-            *(unsigned char*)(int)(((long long)(int)(thiz + 0x41c))) + 0x14;
+        *(unsigned char*)(int)(thiz + 0x41c) =
+            *(unsigned char*)(int)(thiz + 0x41c) + 0x14;
         return;
     }
     {
@@ -64,8 +64,8 @@ extern "C" void func_ov060_02112434(unsigned char* thiz)
         if (v <= 0) {
             thiz[0x41c] = 0;
         } else {
-            *(unsigned char*)(int)(((long long)((int)thiz + 0x41c))) =
-                *(unsigned char*)(int)(((long long)((int)thiz + 0x41c))) - 0x14;
+            *(unsigned char*)(int)((long long)((int)thiz + 0x41c)) =
+                *(unsigned char*)(int)((long long)((int)thiz + 0x41c)) - 0x14;
         }
     }
 }

--- a/src/func_ov060_021125f0.c
+++ b/src/func_ov060_021125f0.c
@@ -18,7 +18,7 @@ void func_ov060_021125f0(char *c)
     *(unsigned char *)(c + 0x425) = 0;
     *(int *)(c + 0x410) = 0;
     {
-        int *q = (int *)(((long long)(int)(c + 0x378)));
+        int *q = (int *)(c + 0x378);
         *q &= ~1;
     }
     *(int *)(c + 0x40c) = 1;
@@ -35,13 +35,13 @@ void func_ov060_021125f0(char *c)
     if (a != 0) {
         *(int *)(a + 0x110) = 1;
         {
-            char *p = (char *)(((long long)(int)(a + 0x100)));
+            char *p = (char *)(a + 0x100);
             *(short *)(p + 0x14) = 0;
         }
     }
     *(short *)(c + 0x8c) = 0;
     {
-        char *p = (char *)(((long long)(int)(c + 0x300)));
+        char *p = (char *)(c + 0x300);
         *(short *)(p + 0xfc) = 0;
     }
     {

--- a/src/func_ov060_02112ee0.cpp
+++ b/src/func_ov060_02112ee0.cpp
@@ -14,7 +14,7 @@ extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callba
 extern void func_ov060_02113260(void *c);
 }
 
-#define LAUND(p) ((void *)((((long long)(int)(p)))))
+#define LAUND(p) ((void *)(p))
 
 extern "C" int func_ov060_02112ee0(void *cc)
 {

--- a/src/func_ov060_021130c0.c
+++ b/src/func_ov060_021130c0.c
@@ -1,5 +1,5 @@
 #include "types.h"
-#define LAUND(p) ((void*)((((long long)(int)(p)))))
+#define LAUND(p) ((void*)(p))
 
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* player, void* actorBase, int isTalk);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int b);

--- a/src/func_ov060_021132a4.c
+++ b/src/func_ov060_021132a4.c
@@ -3,7 +3,7 @@ typedef struct { int x, y, z; } Vector3;
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int a, unsigned int b, int fix, int t1, int t2, void *v, void *cb);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3s(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int d);
 
-#define M(p) ((long long)(int)(p))
+#define M(p) (p)
 
 int func_ov060_021132a4(char *c)
 {

--- a/src/func_ov060_021135fc.c
+++ b/src/func_ov060_021135fc.c
@@ -17,7 +17,7 @@ void func_ov060_021135fc(char *c)
     py = py + 0x32000;
     base.y = py;
 
-    *(int*)(int)(((long long)(int)(c+0x378))) |= 1;
+    *(int*)(int)(c+0x378) |= 1;
 
     if (*(unsigned char*)(c+0x414) == 2) {
         Vector3 pos;

--- a/src/func_ov060_02113740.c
+++ b/src/func_ov060_02113740.c
@@ -50,7 +50,7 @@ void func_ov060_02113740(char *c)
         _ZN13RaycastGroundD1Ev(&rc);
     }
 
-    *(int*)(((long long)(int)(c + 0x418))) |= 0x10000;
+    *(int*)(c + 0x418) |= 0x10000;
 
     switch (*(u8*)(c + 0x423)) {
     case 0:
@@ -64,7 +64,7 @@ void func_ov060_02113740(char *c)
         *p8c += 0x800;
         *p90 += 0x800;
         if ((*(s16*)(c + 0x8c) & 0xffff) == 0)
-            (*(u8*)(((int)c + 0x423)))++;
+            (*(u8*)((int)c + 0x423))++;
         func_ov060_02113a94(c);
         return;
     }
@@ -78,7 +78,7 @@ void func_ov060_02113740(char *c)
             *(int*)(c + 0x9c) = 0;
             *(u8*)(c + 0x41d) = 0xff;
             *(s16*)(c + 0x3fe) = 0;
-            (*(u8*)(((int)c + 0x423)))++;
+            (*(u8*)((int)c + 0x423))++;
             return;
         }
         func_ov060_02113a94(c);
@@ -101,7 +101,7 @@ void func_ov060_02113740(char *c)
             }
         }
         if (func_ov060_021145d4(c)) {
-            (*(u8*)(((int)c + 0x423)))++;
+            (*(u8*)((int)c + 0x423))++;
             if (hit == 0) {
                 func_ov060_02115b0c(c);
             } else {
@@ -125,7 +125,7 @@ void func_ov060_02113740(char *c)
     case 3:
         if (Bowser_IsAnimAtLastFrame(c) != 0) {
             *(int*)(c + 0x40c) = 0;
-            *(int*)(((int)c + 0x418)) &= ~0x10000;
+            *(int*)((int)c + 0x418) &= ~0x10000;
             *(int*)(c + 0x9c) = -0x2000;
         }
         return;

--- a/src/func_ov060_02113d8c.cpp
+++ b/src/func_ov060_02113d8c.cpp
@@ -32,7 +32,7 @@ extern "C" void func_ov060_02113d8c(char *r4)
         func_ov060_02111cc0(r4, 0x19, 0);
         *(int *)(r4 + 0x98) = 0x2a000;
         if (Bowser_IsAnimAtLastFrame(r4) != 0) {
-            u16 *p = (u16 *)(((long long)(int)(r4 + 0x3fe)));
+            u16 *p = (u16 *)(r4 + 0x3fe);
             *p = *p + 1;
             if (*(u16 *)((r4 + 0x300) + 0xfe) > 0xa)
                 *(u8 *)(r4 + 0x423) = 3;
@@ -65,7 +65,7 @@ extern "C" void func_ov060_02113d8c(char *r4)
                 *(int *)(r4 + 0x3f8) = 0x1000;
             }
             {
-                u16 *p = (u16 *)(((long long)(int)(r4 + 0x3fe)));
+                u16 *p = (u16 *)(r4 + 0x3fe);
                 *p = *p + 1;
             }
         }

--- a/src/func_ov060_021146d0.c
+++ b/src/func_ov060_021146d0.c
@@ -18,7 +18,7 @@ void func_ov060_021146d0(char *c) {
         func_02012694(0xb1, c + 0x74);
     } else {
         if (*(u16*)(c + 0x8c) > 0xc00) {
-            s16 *p8c = (s16*)(((long long)(int)((char*)c + 0x8c)));
+            s16 *p8c = (s16*)((char*)c + 0x8c);
             *p8c = *p8c - 0xc00;
         } else {
             *(u16*)(c + 0x8c) = 0;
@@ -29,7 +29,7 @@ void func_ov060_021146d0(char *c) {
         if (st == 0) {
             func_ov060_02111cc0(c, 1, 0x40000000);
             {
-                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)));
+                u8 *p = (u8*)((char*)c + 0x423);
                 *p = *p + 1;
             }
             *(u16*)(c + 0x300 + 0xfe) = 0;
@@ -43,7 +43,7 @@ void func_ov060_021146d0(char *c) {
             *(int*)(c + 0xa8) = 0;
             *(int*)(c + 0x98) = 0;
             {
-                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)));
+                u8 *p = (u8*)((char*)c + 0x423);
                 *p = *p + 1;
             }
             return;

--- a/src/func_ov060_021151d4.c
+++ b/src/func_ov060_021151d4.c
@@ -39,7 +39,7 @@ setE:
     *(int *)(a + 0x40c) = 0xe;
 tail:
     {
-        unsigned char *p = (unsigned char *)(((long long)(int)(a + 0x415)));
+        unsigned char *p = (unsigned char *)(a + 0x415);
         *p = *p + 1;
     }
     return;

--- a/src/func_ov060_021153f8.c
+++ b/src/func_ov060_021153f8.c
@@ -6,7 +6,7 @@ extern int func_ov060_021156ec(void *c);
 extern void func_ov060_02111cc0(char *c, int idx, int extra);
 extern void func_ov060_02115518(void *c);
 
-#define P423(c) ((u8 *)(((long long)(int)((c) + 0x423))))
+#define P423(c) ((u8 *)((c) + 0x423))
 
 void func_ov060_021153f8(char *c)
 {

--- a/src/func_ov060_02115c1c.c
+++ b/src/func_ov060_02115c1c.c
@@ -35,7 +35,7 @@ void func_ov060_02115c1c(char *self)
 
     if (*(short *)(r1 + 0x600 + 0x9c) != 0) goto set_default;
     if (*(u16 *)(self + 0x100 + 0x16) == 0) goto tail;
-    *(u16 *)(((long long)(int)(self + 0x116))) -= 1;
+    *(u16 *)(self + 0x116) -= 1;
     if (*(u16 *)(self + 0x100 + 0x16) != 0) goto tail;
 
 do_drop:
@@ -50,5 +50,5 @@ set_default:
     *(u16 *)(self + 0x100 + 0x16) = 0x96;
 
 tail:
-    *(int *)(((long long)(int)(self + 0xec))) |= 1;
+    *(int *)(self + 0xec) |= 1;
 }

--- a/src/func_ov060_02116d78.c
+++ b/src/func_ov060_02116d78.c
@@ -6,8 +6,8 @@ extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16as(unsigned int kind, uns
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
 extern short data_02082214[];
 extern int data_0209e650;
-#define ML(p) ((int*)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
-#define MLS(p) ((short*)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define ML(p) ((int*)(int)(p))
+#define MLS(p) ((short*)(int)(p))
 void func_ov060_02116d78(char *c)
 {
 

--- a/src/func_ov060_0211712c.c
+++ b/src/func_ov060_0211712c.c
@@ -4,11 +4,11 @@ void func_ov060_0211712c(char *p)
 {
     short ang = (short)(((*(int *)(p + 0x370) + *(unsigned short *)(p + 0x376)) & 0x3f) << 10);
     int bi = (unsigned short)ang >> 4;
-    int *px = (int *)(((long long)(int)(p + 0x5c)));
+    int *px = (int *)(p + 0x5c);
     int *pz;
     *px = *px + ((data_02082214[((int)*(unsigned short *)(p + 0x94) >> 4) * 2]
                   * data_02082214[bi * 2]) << 2) / 0x1000;
-    pz = (int *)(((long long)(int)(p + 0x64)));
+    pz = (int *)(p + 0x64);
     *pz = *pz + ((data_02082214[((int)*(unsigned short *)(p + 0x94) >> 4) * 2 + 1]
                   * data_02082214[bi * 2 + 1]) << 2) / 0x1000;
 }

--- a/src/func_ov060_02118728.c
+++ b/src/func_ov060_02118728.c
@@ -26,7 +26,7 @@ void func_ov060_02118728(char *c)
     if (player == 0) return;
 
     {
-        struct Vector3 *pp = (struct Vector3 *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+        struct Vector3 *pp = (struct Vector3 *)((int)player + 0x5c);
         v.x = pp->x;
         v.y = pp->y;
         v.z = pp->z;

--- a/src/func_ov060_021188e8.c
+++ b/src/func_ov060_021188e8.c
@@ -19,12 +19,12 @@ void func_ov060_021188e8(char* c)
 {
     Work* w = (Work*)c;
     int scale;
-    (*(u32*)((long long)(int)(c + 0x13c))) |= 1;
+    (*(u32*)(c + 0x13c)) |= 1;
     scale = (w->timer * 9 << 12) / 14 + 0x1000;
     w->scaleX = scale;
     w->scaleY = scale;
     w->scaleZ = scale;
     if (w->timer == 0x1c)
         func_ov060_021184bc(c);
-    (*(u16*)((long long)(int)(c + 0x1ac)))++;
+    (*(u16*)(c + 0x1ac))++;
 }

--- a/src/func_ov062_021161a8.c
+++ b/src/func_ov062_021161a8.c
@@ -19,7 +19,7 @@ int func_ov062_021161a8(char *c)
   }
   if (_ZN9Animation8FinishedEv(c + 0x350))
   {
-    int *q = (int *)(((long long)(int)(c + 0x128)));
+    int *q = (int *)(c + 0x128);
     *q &= ~2;
     Chuckya_ChangeState(c, data_ov062_0211ded0);
   }

--- a/src/func_ov062_02116274.c
+++ b/src/func_ov062_02116274.c
@@ -2,9 +2,9 @@ extern int data_ov062_0211deb0[];
 extern int Chuckya_ChangeState(unsigned char *c, void *p);
 int func_ov062_02116274(unsigned char *c)
 {
-    short *p94 = (short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFFULL);
+    short *p94 = (short *)((int)c + 0x94);
     short val = *p94;
-    unsigned short *p100 = (unsigned short *)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFULL);
+    unsigned short *p100 = (unsigned short *)((int)c + 0x100);
     val += 0x500;
     *p94 = val;
     if (*p100 == 0)


### PR DESCRIPTION
Chunk 4 of 5 of #1356's delaunder sweep, split so each part lands under the PR validator's 200-file cap and every file gets a real CI byte gate. #1356 as a whole was refused with `refusing to auto-validate 878 source/build-data files (cap 200) -- unusually large, please review by hand`, so no byte gate ran on any of it.

176 files. Every site was removed only when the ROM still agreed with the result, one site at a time, via `tools/delaunder.py`.

Independently verified before splitting: all 878 files of #1356's merge result compile and reproduce the ROM byte-for-byte under their pinned compiler with strict relocation-destination checking, 0 failing, 0 skipped. The chunks are disjoint subsets of that verified set, and per-file removals are independent of each other.

Authorship preserved. The #1357 metric restore (#1359) lands after all five, because the root baseline it banks holds post-sweep numbers (282 files / 566 sites).