### PR TITLE
One banner rule instead of three, and let the PR gate fail a file that won't build

### DIFF
--- a/src/func_ov002_020d6c60.cpp
+++ b/src/func_ov002_020d6c60.cpp
@@ -12,7 +12,12 @@ extern "C" void func_ov002_020d71ec(void* c, int x);
 
 
 
-extern "C" int func_ov002_020d6c60(char* p0, char* p1){
+/* Second parameter is void* to agree with decl_common.h:1443. It was char*, which in a
+ * C++ TU is a different overload rather than a redeclaration, so this file has not
+ * compiled since #866 -- silently, because a file that fails to build is graded NO-SYM,
+ * and NO-SYM could not fail the PR gate. */
+extern "C" int func_ov002_020d6c60(char* p0, void* p1v){
+  char* p1 = (char*)p1v;
   Vector3 v;
   int b;
   int y;

--- a/src/func_ov004_020b04f4.cpp
+++ b/src/func_ov004_020b04f4.cpp
@@ -7,9 +7,11 @@
 // recovered name: dScMgBase_c_BeforeRender
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::BeforeRender - recovered from vtable slot identity */
-// NONMATCHING: register allocation (div=17). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+/* The banner this carried was true of the compiler it named and stale for the one the
+ * build uses. It claimed "not byte-matchable from C at mwccarm 1.2/sp2p3"; the pin is
+ * 2004/b56, and under that pin the function reproduces exactly -- bytes and relocation
+ * destinations both. It is enrolled and it ships in the ROM, so the byte gate has in
+ * fact been checking it all along, against a file that told readers not to trust it. */
 typedef short s16;
 
 struct Scene;

--- a/tools/asm_policy.py
+++ b/tools/asm_policy.py
@@ -44,6 +44,42 @@ import re
 HAND_BANNER = "HAND-ASM PRIMITIVE"
 DRAFT_BANNER = "NONMATCHING"
 
+
+def header_region(text):
+    """The file's leading banner block: everything before the first line of real code.
+
+    Comments, blank lines and preprocessor directives are all still "header"; the region
+    ends at the first declaration or definition. Banners live there by convention, after
+    the includes and the `recovered:` provenance lines.
+    """
+    out = []
+    for line in text.splitlines(True):
+        s = line.strip()
+        if s and not s.startswith(("//", "/*", "*", "*/", "#")):
+            break
+        out.append(line)
+    return "".join(out)
+
+
+def has_draft_banner(text):
+    """Does this file declare itself a non-match? THE one rule, because there were three.
+
+    Callers scanned `text[:200]` (chaos_db_ci, cluster_targets, coddog, enroll,
+    pr_linkcheck), `text[:400]` (nearmiss_db, prepush_linkcheck), or the whole file
+    (classify, below). So one file could be a draft to one gate and matched to another,
+    which is exactly what happened: src/func_ov091_021339fc.c says "does NOT count as
+    matched" at byte 246 -- past the 200-byte window -- and the progress bar counted it
+    as matched regardless of what its author wrote.
+
+    A fixed byte count was always going to rot, because the banner did not move; the
+    recovery comments above it grew. The header region is stable against that. Measured
+    when this landed: 200 bytes found 72 files, 400 found 73, header region and whole
+    file both found 74 -- so this is not looser than a whole-file scan, it just also
+    cannot be fooled by the word appearing deep inside a function body.
+    """
+    return DRAFT_BANNER in header_region(text)
+
+
 # A dcd word is raw ROM data re-spelled; one is enough to make the file suspect.
 _DCD_RE = re.compile(r"\bdcd\s+0x[0-9a-fA-F]")
 

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -389,7 +389,8 @@ def main():
             text = f.read_text(errors="ignore") if f else ""
             head = text[:200]
             cls = asm_policy.classify(text) if src_path else None
-            matched = bool(src_path) and "NONMATCHING" not in head and cls != "transcribed"
+            matched = (bool(src_path) and not asm_policy.has_draft_banner(text)
+                       and cls != "transcribed")
             total_b += size
             rec = {"id": f"{label}:0x{addr:08x}", "module": label, "name": name,
                    "addr": addr, "size": size, "matched": matched}

--- a/tools/cluster_targets.py
+++ b/tools/cluster_targets.py
@@ -21,6 +21,7 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM
+import asm_policy  # noqa: E402
 import ledger as L
 import worklist as WL
 
@@ -107,7 +108,7 @@ def main():
         # gitignored). A "// NONMATCHING" draft is NOT matched and stays a valid target,
         # but one settled under the asm-primitive policy is done and must not be offered.
         src = WL.read_src_text(name)
-        if src is not None and ("// NONMATCHING" not in src[:200] or WL.is_policy_done(src)):
+        if src is not None and (not asm_policy.has_draft_banner(src) or WL.is_policy_done(src)):
             continue
         code = a9[ad - BASE: ad - BASE + sz]
         cs = callees(code, ad, sz)

--- a/tools/coddog.py
+++ b/tools/coddog.py
@@ -25,6 +25,7 @@ Usage:
 """
 import argparse, difflib, json, pathlib, sys, time
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import asm_policy  # noqa: E402
 import swarm as S
 import relocs as R
 import modules as MOD
@@ -96,7 +97,7 @@ def build_corpus():
             # A committed src file is only an example-eligible byte-match if it is NOT a
             # "// NONMATCHING" hatch (a decompiled-but-unmatchable draft). The banner is in the
             # committed src, so this is portable and does not need nonmatching.jsonl.
-            hatch = src is not None and "// NONMATCHING" in src[:200]
+            hatch = src is not None and asm_policy.has_draft_banner(src)
             if src is not None and not hatch:
                 rec["src"] = src
                 matched.append(rec)

--- a/tools/enroll.py
+++ b/tools/enroll.py
@@ -34,6 +34,7 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG, SRC = REPO / "config", REPO / "src"
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy  # noqa: E402
 import srcpath as SP  # noqa: E402
 # An intentional divergence from the ROM lives in mods/<symbol>.c and takes precedence
 # over src/<symbol>.c for that one function. Keeping it a file-existence rule (rather
@@ -143,7 +144,8 @@ def candidates():
             # A mod is *meant* to diverge, so the not-a-byte-match hatch does not apply
             # to it; every structural rule still does, because a mod that changes size
             # or emits data would shift the module just as badly as a bad match would.
-            if not is_mod and "NONMATCHING" in f.read_text(encoding="utf-8", errors="ignore")[:200]:
+            if not is_mod and asm_policy.has_draft_banner(
+                    f.read_text(encoding="utf-8", errors="ignore")):
                 skipped["NONMATCHING hatch"] += 1
                 continue
             if len(name_mods[name]) > 1:

--- a/tools/ledger.py
+++ b/tools/ledger.py
@@ -31,6 +31,7 @@ import time
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import srcpath as SP  # noqa: E402
+import asm_policy  # noqa: E402
 
 SRC = REPO / "src"
 MATCHED = REPO / "progress" / "matched.jsonl"
@@ -267,8 +268,8 @@ def bank(record, src_text):
             # also sanctioned: the banner proves it is a hatch even though the
             # local gitignored nonmatching.jsonl never saw it.
             all_hatches = all(
-                "NONMATCHING" in p.read_text(encoding="utf-8",
-                                             errors="replace")[:200]
+                asm_policy.has_draft_banner(
+                    p.read_text(encoding="utf-8", errors="replace"))
                 for p in existing)
             if parked_owner != k and not all_hatches:
                 print(f"ledger: REFUSED to bank {name} at {k}: "

--- a/tools/nearmiss_db.py
+++ b/tools/nearmiss_db.py
@@ -35,6 +35,7 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy  # noqa: E402
 import match as M
 import swarm as S
 import ledger as L
@@ -191,7 +192,7 @@ def ingest(args):
         # symbol (see tools/names.py). Keying the src-file check by the stored name
         # missed renamed matches, resurrecting ghosts prune-matched had dropped.
         stext = WL.read_src_text(NM.name_at(mod, addr) or name)
-        if stext is not None and "NONMATCHING" not in stext[:400]:
+        if stext is not None and not asm_policy.has_draft_banner(stext):
             # matched in committed src/ -- the local matched ledger is stale on
             # multi-contributor checkouts, so without this check a seeds file
             # generated before someone else's match RESURRECTS a ghost entry
@@ -343,7 +344,7 @@ def prune_matched(args):
     db = load_db()
     ghosts = [key for key, r in db.items()
               for text in [WL.read_src_text(NM.name_at(r["module"], r["addr"]) or r["name"])]
-              if text is not None and "NONMATCHING" not in text[:400]]
+              if text is not None and not asm_policy.has_draft_banner(text)]
     if args.dry_run:
         for key in ghosts:
             r = db[key]

--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -310,7 +310,15 @@ def main():
     # unbannered dcd transcription byte-matches vacuously (the dcd words ARE the
     # ROM bytes re-spelled), so its VERIFIED slots prove nothing and the file is
     # rejected on policy — see notes/asm-policy.md and tools/asm_policy.py.
-    FAIL = {"WRONG", "NO-REPRO", "RAW-ASM"}
+    #
+    # NO-SYM is the fourth, and it was missing. A file that does not compile, or compiles
+    # without emitting its symbol, is graded NO-SYM — and NO-SYM was not in this set, so
+    # the worst possible outcome scored as a pass. src/func_ov002_020d6c60.cpp has been
+    # unbuildable since #866 (`illegal function overloading`, its local declaration
+    # disagreeing with decl_common.h), carries no NONMATCHING banner, and was edited by a
+    # merged PR while broken. A gate that cannot fail the file it could not even build is
+    # not gating; a self-declared draft still gets the DRAFT pass below.
+    FAIL = {"WRONG", "NO-REPRO", "RAW-ASM", "NO-SYM"}
     reports, bad = [], []
     for path, rep in zip(files, checked):
         reports.append(rep)
@@ -331,7 +339,7 @@ def main():
             text = pathlib.Path(path).read_text(encoding="utf-8", errors="replace")
         except OSError:
             pass
-        if w == "NO-REPRO" and "NONMATCHING" in text[:200]:
+        if w == "NO-REPRO" and asm_policy.has_draft_banner(text):
             rep["worst"] = w = "DRAFT"
         # The draft downgrade cannot collide with this: a transcription has no banner
         # by definition (a NONMATCHING banner reclassifies it as an honest draft).

--- a/tools/prepush_linkcheck.py
+++ b/tools/prepush_linkcheck.py
@@ -33,13 +33,13 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy  # noqa: E402
 import affected_src as A  # noqa: E402
 
 # Fail closed. WRONG/NO-REPRO are false matches; ERROR means we could not get a verdict at
 # all, and a gate that waves through what it could not check is not a gate. BLIND and NO-SYM
 # stay warnings: those are symbol-coverage gaps, not evidence the bytes are wrong.
 BLOCKING = {"WRONG", "NO-REPRO", "ERROR"}
-NONMATCHING_WINDOW = 400  # bytes of head to scan for the draft banner
 
 
 def _load_symbol(name):
@@ -75,7 +75,7 @@ def is_draft(path):
     p = REPO / path
     if not p.exists():
         return False
-    return "NONMATCHING" in p.read_text(errors="ignore")[:NONMATCHING_WINDOW]
+    return asm_policy.has_draft_banner(p.read_text(errors="ignore"))
 
 
 def _run_linkcheck(module, name, addr, size):

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -18,6 +18,7 @@ fresh checkout with no ROM and no local state - which is what the hosted
 update-progress.yml workflow needs.
 """
 import json
+import asm_policy  # noqa: E402
 import pathlib
 import re
 import sys
@@ -80,7 +81,7 @@ def synced_from_src():
             if f is not None:
                 # a "// NONMATCHING" hatch has a src file but is NOT a byte-match;
                 # do not count it toward matched progress
-                if "NONMATCHING" not in f.read_text(errors="ignore")[:200]:
+                if not asm_policy.has_draft_banner(f.read_text(errors="ignore")):
                     done_n += 1
                     done_b += sz
     return done_n, done_b, n, total_bytes

--- a/tools/rebuild_ledger.py
+++ b/tools/rebuild_ledger.py
@@ -25,7 +25,8 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG = REPO / "config"
 SRC = REPO / "src"
 sys.path.insert(0, str(REPO / "tools"))
-import srcpath as SP  # noqa: E402
+import srcpath as SP
+import asm_policy  # noqa: E402  # noqa: E402
 import relocs as RL  # noqa: E402
 MATCHED = REPO / "progress" / "matched.jsonl"
 
@@ -49,7 +50,7 @@ def main():
             # so never let the first extension found decide it (chaos_db_ci.py has the
             # same .c-first blind spot -- see tools/rebuild_ledger).
             srcs = SP.paths_for(name)
-            if not any("NONMATCHING" not in f.read_text(errors="ignore")[:200]
+            if not any(not asm_policy.has_draft_banner(f.read_text(errors="ignore"))
                        for f in srcs):
                 continue
             key = (label, addr)

--- a/tools/refine_wl.py
+++ b/tools/refine_wl.py
@@ -22,6 +22,7 @@ permuter / hand-fix tiers).
 import argparse, json, pathlib, sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy  # noqa: E402
 import categorize_misses as CAT
 import knowledge as KB
 import ledger as L
@@ -81,7 +82,7 @@ def main():
         # a src file only disqualifies a candidate if it is a real byte-match;
         # a "// NONMATCHING" hatch (PR #84 draft bank) is still fair game
         text = WL.read_src_text(name)
-        return text is None or "NONMATCHING" in text[:200]
+        return text is None or asm_policy.has_draft_banner(text)
 
     pool = [r for r in rows
             if r.get("divergences") and 0 < r["divergences"] <= args.max_div

--- a/tools/sigaudit.py
+++ b/tools/sigaudit.py
@@ -41,6 +41,7 @@ import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import asm_policy  # noqa: E402
 import srcpath as SP  # noqa: E402
 
 CALL_RE = re.compile(r'\b(func_(?:ov\d+_)?[0-9a-f]{8})\s*\(')
@@ -110,7 +111,7 @@ def matched_sources(repo):
             text = path.read_text(encoding='utf-8', errors='ignore')
         except OSError:
             continue
-        if 'NONMATCHING' in text[:400]:
+        if asm_policy.has_draft_banner(text):
             continue                      # not authoritative -- does not reproduce the ROM
         yield path.stem, strip_comments(text)
 

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -95,7 +95,7 @@ def function_snapshot(rev):
     # Match progress.py and the rest of the repo's established hatch rule: the
     # marker is a source header and is recognized in the first 200 characters.
     nonmatching = {path for path in candidates
-                   if "NONMATCHING" in git_text(rev, path)[:200]}
+                   if asm_policy.has_draft_banner(git_text(rev, path))}
     # An unbannered dcd transcription byte-matches vacuously (it IS the ROM words
     # re-spelled), so it never counts as matched -- see tools/asm_policy.py. Built
     # the same revision-based way as ``nonmatching``: a cheap fixed-string grep

--- a/tools/worklist.py
+++ b/tools/worklist.py
@@ -20,6 +20,7 @@ exact oracle / regperm-oracle code.
 """
 import argparse
 import json
+import asm_policy  # noqa: E402
 import pathlib
 import random
 import re
@@ -72,7 +73,7 @@ def read_src_text(name):
     # match over a NONMATCHING draft when both exist.
     texts = [p.read_text(encoding="utf-8") for p in SP.paths_for(name)]
     for t in texts:
-        if "// NONMATCHING" not in t[:200]:
+        if not asm_policy.has_draft_banner(t):
             return t
     return texts[0] if texts else None
 


### PR DESCRIPTION
## What this changes

Two gate defects. Neither is something a byte check could ever notice, and both let a file misrepresent itself.

### 1. "Does this file declare itself a non-match?" had three answers

| rule | callers |
|---|---|
| `text[:200]` | chaos_db_ci, cluster_targets, coddog, enroll, ledger, pr_linkcheck, progress, rebuild_ledger, refine_wl, validate_merge, worklist |
| `text[:400]` | nearmiss_db, prepush_linkcheck, sigaudit |
| whole file | `asm_policy.classify` |

So one file could be a draft to one gate and a match to another. `src/func_ov091_021339fc.c` is what that costs:

```
// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an
// asm hatch on a proven mwccarm 1.2 wall; does NOT count as matched.
```

That sentence begins at **byte 246**. The window ended at 200. The author disclaimed the function in the file, in plain language, and the progress bar counted it as matched anyway — while `asm_policy`, reading the whole file, saw the banner and excused it from the transcription demotion. The two rules disagreed and the file fell through the gap.

A fixed byte count was always going to rot, because the banner did not move — the `recovered:` comments above it grew. `asm_policy.has_draft_banner` now scans the **header region** (everything before the first line of real code, so comments, includes and provenance lines still count as header). All fifteen callers use it; no windowed check remains in `tools/`.

Not looser than a whole-file scan — measured: 200B finds 72 files, 400B finds 73, header region and whole file both find 74. It just also cannot be fooled by the word appearing inside a function body.

**Net effect on the published count: exactly one function moves from matched to not-matched, and it is the one whose author said so.**

### 2. A stale banner on the other side

`src/func_ov004_020b04f4.cpp` claimed *"not byte-matchable from C at mwccarm 1.2/sp2p3"*. The pin is **2004/b56**; under that pin it reproduces exactly — bytes and relocation destinations both — and it is enrolled and ships in the ROM. Its banner was true of a compiler the build no longer uses, so the byte gate has been checking it all along against a file telling readers not to trust it. Banner removed, reason recorded in its place. **Without this, the new rule would have wrongly demoted a genuine match.**

### 3. `NO-SYM` could not fail a PR

`pr_linkcheck`'s failure set was `{WRONG, NO-REPRO, RAW-ASM}`. A file that does not compile is graded `NO-SYM` — so the worst possible outcome scored as a pass.

`src/func_ov002_020d6c60.cpp` has been unbuildable since #866: its local declaration says `(char*, char*)`, `decl_common.h:1443` says `(char*, void*)`, which in a C++ TU is an overload rather than a redeclaration. It carries no banner and was edited by a merged PR while broken. Fixed here to agree with the shared header; `NO-SYM` added to `FAIL`.

## Blast radius — measured, not assumed

Of the 477 files that are bannered drafts or non-enrolled, **25 fail to compile** under the pin:

| | count | |
|---|---|---|
| enrolled | **0** | the ROM cannot be affected |
| self-declared drafts | **0** | no honest draft is newly failed |
| unbannered **and** non-enrolled | **25** | exactly the cohort claiming to be recovered source and isn't |

21 of the 25 are the same defect as the file fixed here. **None is fixed in this PR** — they don't ship, and each needs its own signature reconciliation. The gate can now *see* them, which is the point: a PR touching one will fail until it is fixed or honestly bannered.

<details><summary>The 24 remaining unbuildable files</summary>

```
_ZN15TtcRotatingCube13InitResourcesEv.cpp   func_ov004_020b0930.cpp
_ZN5Whomp13InitResourcesEv.cpp              func_ov006_020e6e78.cpp
_ZN6Player16CleanupResourcesEv.cpp          func_ov007_020ba05c.c
_ZN8Particle10SysTracker10InitialiseEv.cpp  func_ov064_02119afc.cpp
func_020375c0.c                             func_ov071_02121ba4.cpp
func_0203781c.c                             func_ov078_02124cf4.cpp
func_02037d94.c                             func_ov080_02124088.cpp
func_02037db4.c                             func_ov081_02123910.cpp
func_ov002_020cfbdc.cpp                     func_ov085_02129dbc.cpp
func_ov002_020e3e00.cpp                     func_ov096_02137088.cpp
func_ov004_020aeed8.cpp                     func_ov098_0213a794.cpp
func_ov004_020af094.cpp                     func_ov102_0214b248.cpp
func_ov004_020b0620.cpp
```
The four `func_020375*/02037*` `.c` files fail on `virtual` in a C TU; the rest are `illegal function overloading`.
</details>

## Verification

```
module fidelity: 106/106 exact, 100.000000% of compared bytes
source-built functions: 10,805    reproducing: 10,805    mismatching: 0
ROM-build analysis: PASS          <- the enroll rule change is build-neutral

all 15 touched modules import clean
draft files: 72 (old 200B rule) -> 73 (header region)
```

Provenance: ai model=claude-opus-5 reasoning=high harness=claude-code