### PR TITLE
Fix the NameError failing every PR validation

### DIFF
--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -95,7 +95,7 @@ def function_snapshot(rev):
     # Match progress.py and the rest of the repo's established hatch rule: the
     # marker is a source header and is recognized in the first 200 characters.
     nonmatching = {path for path in candidates
-                   if asm_policy.has_draft_banner(git_text(rev, path))}
+                   if AP.has_draft_banner(git_text(rev, path))}
     # An unbannered dcd transcription byte-matches vacuously (it IS the ROM words
     # re-spelled), so it never counts as matched -- see tools/asm_policy.py. Built
     # the same revision-based way as ``nonmatching``: a cheap fixed-string grep


### PR DESCRIPTION
**Every PR validation is currently dying before it produces a report.** The gate surfaces it as `Worker error -- validate_merge produced no report`, which reads like validator infrastructure, but it is a one-word repo bug:

    File "/home/validator/clone/tools/validate_merge.py", line 98, in <setcomp>
        if asm_policy.has_draft_banner(git_text(rev, path))}
    NameError: name 'asm_policy' is not defined

`tools/validate_merge.py:29` imports the module as `import asm_policy as AP`, so the bare name `asm_policy` does not exist. #1367 added the `function_snapshot` draft-banner filter using the un-aliased spelling. It is the only such use in the file; `chaos_db_ci` and `rombuild_check` are both referenced through their aliases correctly.

Why #1367 went green: the crash is in a code path only the validator worker runs, so `submit` and `ratchet` had nothing to say about it, and the byte gate that would have caught it is the very thing that broke.

Verified both directions on this tree rather than by inspection:

- before: `function_snapshot('HEAD')` raises `NameError: name 'asm_policy' is not defined`
- after: returns a dict, 3 entries

Found while chasing #1369, whose validation went from `mwccarm failed` to `Worker error` the moment I merged current main into its branch. #1370 is green only because it was validated before #1367 reached its tree.