### PR TITLE
func_02057410: the digit loop divides unsigned, and the reloc says so

### DIFF
--- a/src/func_02057410.c
+++ b/src/func_02057410.c
@@ -299,9 +299,9 @@ int func_02057410(char *dst, int n, const char *fmt, int *args)
                         cnt = zero;
                         if (v != 0) {
                             do {
-                                int digit = (int)(v % pf[1]);
+                                int digit = (int)((u64)v % (u64)pf[1]);
                                 int dch;
-                                v = v / pf[1];
+                                v = (u64)v / (u64)pf[1];
                                 if (digit < 0xa) dch = digit + 0x30;
                                 else dch = digit + pf[2];
                                 numbuf[cnt] = dch;


### PR DESCRIPTION
A **fakematch**, found by `pr_linkcheck` and not by any byte gate.

## What is wrong

`func_02057410` is a printf-style formatter. At `0x02057b64` its digit loop calls a 64-bit divide helper, and we call the wrong one:

| | word | destination | symbol |
|---|---|---|---|
| **ROM** | `0xebfe8b9c` | `0x01ffa9dc` | `__aeabi_uldiv` — unsigned |
| **ours** | `0xebfe8bb2` | `0x01ffaa34` | `_ll_sdiv` — signed |

The bytes agreed regardless, because a relocated word is a wildcard to the byte comparison. So this has been sitting in the **matched** set with a call that resolves to the wrong function.

## Why unsigned is right

The sign is consumed *above* the loop — the `0x80000000` test emits the minus prefix and negates `v`:

```c
if ((((s64)zero << 32 | (u32)(v >> 32)) & 0x80000000) != 0) {
    prefixbuf[0] = minus;
    v = ~v + 1;            // from here v is a magnitude
    nprefix = one;
}
```

Every division below that point is on a magnitude, so the original divides unsigned. `v` stays `s64` in our source, which selects the signed helper. Casting both operands to `u64` at the two use sites selects the one the ROM uses.

## Verified

| gate | before | after |
|---|---|---|
| `pr_linkcheck --files src/func_02057410.c` | **WRONG** `_ll_sdiv -> 0x01ffaa34` | **ok** (verified, 1 slot) |
| `rombuild.py -j16`, full ROM | 106/106 exact | **106/106 exact**, 10,813 reproducing, 0 mismatching, 87.88% |
| `port_refcheck` | — | 393 checked, 0 stale |

Byte-neutral: the change selects a different relocation target, and the relocated word was never part of the comparison.

## How it surfaced

It blocks #1382, which touches none of this. `pr_linkcheck` expands a changed header through the reverse include graph, so that PR link-checks consumers it never names — including this file, whose blob is identical to main's. The verdict reproduces on a clean `origin/main` worktree, so it is main's defect, not that PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AXm5k53WFPjCYcDHRDX3x