### PR TITLE
TextureSequence::Prepare and MaterialChanger::Prepare are static

### DIFF
--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1399,7 +1399,6 @@
     "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
     "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
     "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
-    "_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii",
     "_Z67_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
     "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
     "func_02112c08",
@@ -1477,7 +1476,6 @@
   "ov079:0x02126164": {
    "name": "_ZN5Whomp13InitResourcesEv",
    "missing": [
-    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
     "func_021135d4"
    ]
   },

--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,5 +1,5 @@
 {
- "eligible": 10805,
+ "eligible": 10813,
  "unresolved": {
   "arm9:0x020063b0": {
    "name": "_ZN8CapEnemy6AddCapEj",
@@ -245,7 +245,8 @@
   "arm9:0x02057410": {
    "name": "func_02057410",
    "missing": [
-    "_ll_mod"
+    "_ll_udiv",
+    "_ull_mod"
    ]
   },
   "arm9:0x02058308": {
@@ -356,7 +357,6 @@
   "ov002:0x020c8a4c": {
    "name": "func_ov002_020c8a4c",
    "missing": [
-    "_Z13func_020072c0v",
     "_ZN6Player7SetAnimEjiij"
    ]
   },
@@ -1474,6 +1474,13 @@
     "overlay_66"
    ]
   },
+  "ov079:0x02126164": {
+   "name": "_ZN5Whomp13InitResourcesEv",
+   "missing": [
+    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
+    "func_021135d4"
+   ]
+  },
   "ov080:0x0212459c": {
    "name": "_ZN13MontyMoleRock8BehaviorEv",
    "missing": [
@@ -1594,12 +1601,6 @@
     "_Z35_ZN8Platform19UpdateClsnPosAndRotEvPv",
     "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
     "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_"
-   ]
-  },
-  "ov091:0x021339fc": {
-   "name": "func_ov091_021339fc",
-   "missing": [
-    "func_020aea30"
    ]
   },
   "ov096:0x02137564": {

--- a/include/MaterialChanger.h
+++ b/include/MaterialChanger.h
@@ -6,15 +6,25 @@
 #include "math/Fix12.h"
 
 /* Animation child that drives BMA-file playback, vtable _ZTV15MaterialChanger at 0x0208e7f4:
- * two slots, the destructor pair, nothing else. Update and Prepare are
- * plain methods.
+ * two slots, the destructor pair, nothing else. Update is a plain method;
+ * Prepare is static, for the reason set out below.
  *
  * THE DESTRUCTOR IS DECLARED FIRST AND D1 IS A REAL METHOD -- see
  * include/ModelBase.h for the key-function rule and the objisolate exemption
  * to it. D0 stays a C file.
  *
- * Prepare's ROM body is a 0xc tail-call veneer into func_020470e8, which is the
- * real (still unnamed) implementation taking (this, &model, &file).
+ * PREPARE IS STATIC, on exactly the evidence set out in TextureSequence.h for
+ * the sibling veneer. Its ROM body is a 0xc long-call veneer (ldr ip, [pc];
+ * bx ip; .word func_020470e8) that shuffles no arguments, and func_020470e8
+ * reads only r0 and r1:
+ *
+ *     push {r4-r7,lr} / sub sp,sp,#4
+ *     mov  r6, r1      <- ldrh [r6,#8] is the loop count,
+ *     mov  r7, r0         ldr  [r6,#0xc] the 0x3c-stride records it walks
+ *
+ * r2 is never touched, so there is no third argument and hence no this; r0 is
+ * the BMD, forwarded to the name-lookup helper. A static member mangles
+ * identically, so the symbol is unchanged.
  * SetFile's definition stays a mangled free function (wall 6az,
  * Fix12<int> in the signature); the declaration below is the real one.
  */
@@ -31,11 +41,12 @@ struct MaterialChanger : Animation {
     virtual ~MaterialChanger();                       /* slots 0 (D1), 1 (D0) */
 
     /* --- non-virtual --- */
-    void Prepare(BMD_File &model, BMA_File &animFile);
     void Update(ModelComponents &model);
     void SetFile(BMA_File &animFile, int flags, Fix12<int> speed,
                  u32 startFrame);        /* free function, wall 6az */
 
+    /* --- static --- */
+    static void Prepare(BMD_File &model, BMA_File &animFile);
 };
 
 typedef char MaterialChanger_size_must_be_0x14[sizeof(MaterialChanger) == 0x14 ? 1 : -1];

--- a/include/TextureSequence.h
+++ b/include/TextureSequence.h
@@ -6,15 +6,31 @@
 #include "math/Fix12.h"
 
 /* Animation child that drives BTP-file playback, vtable _ZTV15TextureSequence at 0x0208e7d4:
- * two slots, the destructor pair, nothing else. Update and Prepare are
- * plain methods.
+ * two slots, the destructor pair, nothing else. Update is a plain method;
+ * Prepare is static, for the reason set out below.
  *
  * THE DESTRUCTOR IS DECLARED FIRST AND D1 IS A REAL METHOD -- see
  * include/ModelBase.h for the key-function rule and the objisolate exemption
  * to it. D0 stays a C file.
  *
- * Prepare's ROM body is a 0xc tail-call veneer into func_02046d50, which is the
- * real (still unnamed) implementation taking (this, &model, &file).
+ * PREPARE IS STATIC. Its ROM body is a 0xc long-call veneer (ldr ip, [pc];
+ * bx ip; .word func_02046d50) that shuffles no arguments, so the real body's
+ * register use IS the call surface -- and func_02046d50 reads only r0 and r1:
+ *
+ *     push {r4-r7,lr} / sub sp,sp,#4
+ *     mov  r6, r1      <- ldrh [r6,#2], ldr [r6,#4], ldrh [r6,#8],
+ *     mov  r7, r0         ldr [r6,#0xc], ldrh [r6,#0x1c], ldr [r6,#0x20]
+ *
+ * r2 is never touched, which rules out three arguments; and the offsets r1 is
+ * read at are exactly BTP_File's fields below, so r1 is the ANIMATION file --
+ * the second argument, not the third. r0 is the BMD, forwarded to the three
+ * name-lookup helpers. Two arguments and no this. The veneer body is a pure
+ * tail jump that reproduces under either signature, so the definition file
+ * never constrained this; the callee and the callers do, and they agree.
+ *
+ * A static member mangles identically, so the symbol is unchanged. This is the
+ * same correction already applied to the sibling TextureTransformer, whose
+ * header names this veneer and MaterialChanger's as called the same way.
  * SetFile's definition stays a mangled free function (wall 6az,
  * Fix12<int> in the signature); the declaration below is the real one.
  */
@@ -47,12 +63,12 @@ struct TextureSequence : Animation {
     virtual ~TextureSequence();                       /* slots 0 (D1), 1 (D0) */
 
     /* --- non-virtual --- */
-    void Prepare(BMD_File &model, BTP_File &animFile);
     void Update(ModelComponents &model);
     void SetFile(BTP_File &animFile, int flags, Fix12<int> speed,
                  u32 startFrame);        /* free function, wall 6az */
 
     /* --- static --- */
+    static void Prepare(BMD_File &model, BTP_File &animFile);
     static void *LoadFile(SharedFilePtr &ptr);
     static void UpdateFileOffsets(BTP_File &file);
 };

--- a/src/_ZN11SnowmanHead13InitResourcesEv.cpp
+++ b/src/_ZN11SnowmanHead13InitResourcesEv.cpp
@@ -6,11 +6,14 @@
 #include "SnowmanHead.h"
 typedef int Fix12;
 
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
+
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *ref);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *base, void *file, int a, int b);
 extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *ref);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *t, void *a, Fix12 b, Fix12 c, unsigned int d, unsigned int e);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *t, void *a, Fix12 b, Fix12 c, void *d, void *e);
 extern void _ZN13RaycastGroundC1Ev(void *t);
@@ -33,8 +36,8 @@ int SnowmanHead::InitResources()
     for (i = 0; i < 2; i++) {
         void *tex = (&data_ov072_02121ffc)[i];
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(tex);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
-            ((void **)&data_ov072_02122bc4)[1], ((void **)tex)[1]);
+        TextureSequence::Prepare(*(BMD_File *)((void **)&data_ov072_02122bc4)[1],
+                                 *(BTP_File *)((void **)tex)[1]);
     }
 
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0x138, ((char *)this), 0x96000, 0x12c000, 0x800004, 0);

--- a/src/_ZN15InvisibleSecret13InitResourcesEv.cpp
+++ b/src/_ZN15InvisibleSecret13InitResourcesEv.cpp
@@ -7,12 +7,12 @@ typedef int Fix12;
 struct SharedFilePtr { void* p; void* file; };
 struct BMD_File;
 struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 
 extern "C" {
     void _ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr& f);
     void* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr& f);
     int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
-    void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* bmd, void* btp);
     void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* self, void* btp, int a, Fix12 b, unsigned int c);
 }
 
@@ -28,8 +28,8 @@ int InvisibleSecret::InitResources()
         void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da28);
         if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1) == 0)
             return 0;
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
-            data_ov002_0210da28.file, data_ov002_0210da08.file);
+        TextureSequence::Prepare(*(BMD_File*)data_ov002_0210da28.file,
+                                 *(BTP_File*)data_ov002_0210da08.file);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
             ((char*)this) + 0x124, data_ov002_0210da08.file, 0x40000000, 0, 0);
         unk_12c = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);
@@ -38,8 +38,8 @@ int InvisibleSecret::InitResources()
         void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9a8);
         if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1) == 0)
             return 0;
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
-            data_ov002_0210d9a8.file, data_ov002_0210d9e8.file);
+        TextureSequence::Prepare(*(BMD_File*)data_ov002_0210d9a8.file,
+                                 *(BTP_File*)data_ov002_0210d9e8.file);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
             ((char*)this) + 0x124, data_ov002_0210d9e8.file, 0x40000000, 0, 0);
         unk_12c = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);

--- a/src/_ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File.cpp
+++ b/src/_ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File.cpp
@@ -1,11 +1,13 @@
 //cpp
 // @symbol _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File
 #include "MaterialChanger.h"
-extern "C" void func_020470e8(MaterialChanger *self, BMD_File *model, BMA_File *file);
+extern "C" void func_020470e8(BMD_File *model, BMA_File *file);
 
-/* The ROM body is a 0xc tail-call veneer; func_020470e8 is the real,
-   still unnamed implementation. */
+/* The ROM body is a 0xc long-call veneer (ldr ip, [pc]; bx ip); the
+   registers pass through untouched, so the matched func_020470e8.c's
+   own two-argument signature is the call surface. Prepare is static:
+   no this. */
 void MaterialChanger::Prepare(BMD_File &model, BMA_File &animFile)
 {
-    func_020470e8(this, &model, &animFile);
+    func_020470e8(&model, &animFile);
 }

--- a/src/_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File.cpp
+++ b/src/_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File.cpp
@@ -1,11 +1,13 @@
 //cpp
 // @symbol _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File
 #include "TextureSequence.h"
-extern "C" void func_02046d50(TextureSequence *self, BMD_File *model, BTP_File *file);
+extern "C" void func_02046d50(BMD_File *model, BTP_File *file);
 
-/* The ROM body is a 0xc tail-call veneer; func_02046d50 is the real,
-   still unnamed implementation. */
+/* The ROM body is a 0xc long-call veneer (ldr ip, [pc]; bx ip); the
+   registers pass through untouched, so the matched func_02046d50.c's
+   own two-argument signature is the call surface. Prepare is static:
+   no this. */
 void TextureSequence::Prepare(BMD_File &model, BTP_File &animFile)
 {
-    func_02046d50(this, &model, &animFile);
+    func_02046d50(&model, &animFile);
 }

--- a/src/_ZN16BowserShockwaves13InitResourcesEv.cpp
+++ b/src/_ZN16BowserShockwaves13InitResourcesEv.cpp
@@ -5,6 +5,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BowserShockwaves.h"
+#include "MaterialChanger.h"
+#include "TextureSequence.h"
 extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
@@ -12,7 +14,6 @@ extern int _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern int _ZN15TextureSequence8LoadFileER13SharedFilePtr(void* sfp);
 extern void func_02016b24(void* thiz, int a);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* a, void* b);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void* a, void* b);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
@@ -33,14 +34,14 @@ int BowserShockwaves::InitResources()
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this) + 0xd4, (void*)data_ov060_0211b1f8[1], 0x40000000, 0x1000, 0);
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this) + 0x174, (void*)data_ov060_0211b1f8[1], 0x40000000, 0x1000, 0);
 
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov060_0211b208[1], (void*)data_ov060_0211b200[1]);
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov060_0211b208[1], (void*)data_ov060_0211b200[1]);
+    TextureSequence::Prepare(*(BMD_File*)data_ov060_0211b208[1], *(BTP_File*)data_ov060_0211b200[1]);
+    TextureSequence::Prepare(*(BMD_File*)data_ov060_0211b208[1], *(BTP_File*)data_ov060_0211b200[1]);
 
     _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(((char*)this) + 0x138, (void*)data_ov060_0211b200[1], 0x40000000, 0x1000, 0);
     _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(((char*)this) + 0x1d8, (void*)data_ov060_0211b200[1], 0x40000000, 0x1000, 0);
 
-    _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File((void*)data_ov060_0211b208[1], func_021115e4);
-    _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File((void*)data_ov060_0211b208[1], func_021115e4);
+    MaterialChanger::Prepare(*(BMD_File*)data_ov060_0211b208[1], *(BMA_File*)func_021115e4);
+    MaterialChanger::Prepare(*(BMD_File*)data_ov060_0211b208[1], *(BMA_File*)func_021115e4);
 
     _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(((char*)this) + 0x14c, func_021115e4, 0x40000000, 0x1000, 0);
     _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(((char*)this) + 0x1ec, func_021115e4, 0x40000000, 0x1000, 0);

--- a/src/_ZN3Amp13InitResourcesEv.cpp
+++ b/src/_ZN3Amp13InitResourcesEv.cpp
@@ -2,9 +2,9 @@
 // @symbol _ZN3Amp13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Amp.h"
+#include "TextureSequence.h"
 struct SharedFilePtr;
 struct BMD_File;
-struct BTP_File;
 struct BTA_File;
 struct Actor;
 struct Vector3;
@@ -14,7 +14,6 @@ extern "C" BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, BMD_File *f, int a, int b);
 extern "C" void *_ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" BTP_File *_ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr &f);
-extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File &a, BTP_File &b);
 extern "C" void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(BMD_File &a, BTA_File &b);
 extern "C" int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(Actor *self, int a, int b, int c, int d);
@@ -48,7 +47,7 @@ int Amp::InitResources()
 
     BMD_File *bmd2 = *(BMD_File **)((char *)&data_ov070_02123604 + 4);
     BTP_File *btp = _ZN15TextureSequence8LoadFileER13SharedFilePtr(data_ov070_021235ec);
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*bmd2, *btp);
+    TextureSequence::Prepare(*bmd2, *btp);
 
     bmd2 = *(BMD_File **)((char *)&data_ov070_02123604 + 4);
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(*bmd2, data_ov070_021231f4);

--- a/src/_ZN3MrI13InitResourcesEv.cpp
+++ b/src/_ZN3MrI13InitResourcesEv.cpp
@@ -9,11 +9,13 @@ struct Actor;
 struct Vector3 { int x, y, z; };
 struct SharedFilePtr { void *hdr; void *ptr; };
 
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 extern "C" void LoadBlueCoinModel(void);
 extern "C" BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, BMD_File *f, int a, int b);
 extern "C" void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr &f);
-extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File &a, BTP_File &b);
 extern "C" void *_ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern "C" void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, Actor *a, Vector3 const &b, int c, int d, unsigned int e, unsigned int f);
@@ -52,7 +54,7 @@ extern "C" int _ZN3MrI13InitResourcesEv(char *c)
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(*seq);
         BMD_File *bmd2 = *(BMD_File **)((char *)&data_ov071_02123050 + 4);
         BTP_File *btp = *(BTP_File **)((char *)seq + 4);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*bmd2, *btp);
+        TextureSequence::Prepare(*bmd2, *btp);
     }
 
     _ZN9Animation8LoadFileER13SharedFilePtr(**(SharedFilePtr **)&data_ov071_021226a0);

--- a/src/_ZN5Whomp13InitResourcesEv.cpp
+++ b/src/_ZN5Whomp13InitResourcesEv.cpp
@@ -45,7 +45,11 @@ extern SFP data_ov079_02128168;
 extern SFP data_ov079_02128178;
 extern void *data_ov079_02128170[];
 extern void *data_ov079_021275ec[];
-extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
+/* extern "C" is load-bearing: this sits OUTSIDE the extern "C" block above, so a
+   bare `extern` mangles the already-mangled name a second time and the address
+   taken below points at a _Z88_ZN16... that does not exist. The byte gate cannot
+   see it -- relocated words are wildcards -- only check_references can. */
+extern "C" void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern u8 data_0209f21c;
 extern s32 data_0209f394[];
 extern signed char data_0209f2f8;

--- a/src/_ZN5Whomp13InitResourcesEv.cpp
+++ b/src/_ZN5Whomp13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Whomp.h"
+#include "TextureSequence.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct BTP_File;
@@ -24,7 +25,6 @@ extern "C" {
     void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *shared);
     void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *shared);
     int _ZN11ShadowModel10InitCuboidEv(void *self);
-    void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
     void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, void *btp, int a, int fix, unsigned int b);
     void _ZN9Animation8SetFlagsEi(void *self, int flags);
     u8 _ZN5Actor9TrackStarEjj(void *self, unsigned int a, unsigned int b);
@@ -106,7 +106,8 @@ int Whomp::InitResources()
 
     if (mIsKing != 0) {
         unk_401 = 3;
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(data_ov079_02128168.unk4, data_ov079_02128178.unk4);
+        TextureSequence::Prepare(*(BMD_File *)data_ov079_02128168.unk4,
+                                 *(BTP_File *)data_ov079_02128178.unk4);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
             ((char *)this) + 0x330, data_ov079_02128178.unk4, 0, 0x1000, 0);
         _ZN9Animation8SetFlagsEi(((char *)this) + 0x330, 0x40000000);

--- a/src/_ZN6Bowser13InitResourcesEv.cpp
+++ b/src/_ZN6Bowser13InitResourcesEv.cpp
@@ -27,13 +27,13 @@
  * only failure path in the function.
  */
 #include "Bowser.h"
+#include "TextureSequence.h"
 
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void *f);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, void *btp, int a, int b, unsigned int d);
 extern void _ZN9Animation8SetFlagsEi(void *self, int flags);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
@@ -77,8 +77,8 @@ int Bowser::InitResources()
 
     func_ov060_02111cc0(this, 0x10, 0);
 
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
-        (void *)data_ov060_0211ac78[1], (void *)data_ov060_0211ac28[1]);
+    TextureSequence::Prepare(*(BMD_File *)data_ov060_0211ac78[1],
+                             *(BTP_File *)data_ov060_0211ac28[1]);
 
     _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
         &this->mTextureSequence, (void *)data_ov060_0211ac28[1], 0, 0x1000, 0);

--- a/src/_ZN6Eyerok13InitResourcesEv.cpp
+++ b/src/_ZN6Eyerok13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Eyerok.h"
+#include "TextureSequence.h"
 #include "MeshColliderBase.h"
 extern int data_ov066_0211ae6c[];
 extern int data_ov066_0211ae4c[];
@@ -39,7 +40,6 @@ extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int 
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* sfp);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(int bmd, int btp);
 extern void _ZN11ShadowModel12InitCylinderEv(void* thiz);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* thiz, void* actor, Vector3* v, s32 f1, s32 f2, u32 a, u32 b);
 /* extern "C" is load-bearing here: without it the name mangles a SECOND time,
@@ -94,14 +94,14 @@ int Eyerok::InitResources()
     case 1:
         if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x360, (void*)data_ov066_0211ae4c[1], 1, -1) == 0)
             return 0;
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(data_ov066_0211ae4c[1], data_ov066_0211aebc[1]);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(data_ov066_0211ae4c[1], data_ov066_0211ae9c[1]);
+        TextureSequence::Prepare(*(BMD_File*)data_ov066_0211ae4c[1], *(BTP_File*)data_ov066_0211aebc[1]);
+        TextureSequence::Prepare(*(BMD_File*)data_ov066_0211ae4c[1], *(BTP_File*)data_ov066_0211ae9c[1]);
         break;
     case 2:
         if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x360, (void*)data_ov066_0211aeb4[1], 1, -1) == 0)
             return 0;
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(data_ov066_0211aeb4[1], data_ov066_0211ae3c[1]);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(data_ov066_0211aeb4[1], data_ov066_0211ae2c[1]);
+        TextureSequence::Prepare(*(BMD_File*)data_ov066_0211aeb4[1], *(BTP_File*)data_ov066_0211ae3c[1]);
+        TextureSequence::Prepare(*(BMD_File*)data_ov066_0211aeb4[1], *(BTP_File*)data_ov066_0211ae2c[1]);
         break;
     }
 

--- a/src/_ZN6Goomba13InitResourcesEv.cpp
+++ b/src/_ZN6Goomba13InitResourcesEv.cpp
@@ -3,6 +3,9 @@ typedef int Fix12;
 
 struct SharedFilePtr { int id; void* file; };
 
+struct BMD_File;
+struct BMA_File;
+struct MaterialChanger { static void Prepare(BMD_File &model, BMA_File &animFile); };
 extern "C" {
 int _ZN5Actor9TrackStarEjj(void* self, unsigned int a, unsigned int b);
 void LoadSilverStarAndNumber(void);
@@ -12,7 +15,6 @@ void _ZN8CapEnemy6AddCapEj(void* self, unsigned int x);
 int _ZN8CapEnemy21DestroyIfCapNotNeededEv(void* self);
 int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 int _ZN11ShadowModel12InitCylinderEv(void* self);
-void _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File(void* bmd, void* bma);
 void _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(void* self, void* bma, int a, Fix12 b, unsigned int cc);
 void LoadBlueCoinModel(void* c);
 void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
@@ -68,7 +70,7 @@ extern "C" int _ZN6Goomba13InitResourcesEv(char* c)
     if (_ZN11ShadowModel12InitCylinderEv(c + 0x3d4) == 0)
         return 0;
 
-    _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File(data_ov084_02130cf8.file, &data_ov084_0213089c);
+    MaterialChanger::Prepare(*(BMD_File*)data_ov084_02130cf8.file, *(BMA_File*)&data_ov084_0213089c);
     _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(c + 0x3fc, &data_ov084_0213089c, 0x40000000, 0x1000, 0);
 
     *(unsigned char*)(c + 0x108) = 1;

--- a/src/_ZN6Lakitu13InitResourcesEv.cpp
+++ b/src/_ZN6Lakitu13InitResourcesEv.cpp
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Lakitu.h"
+#include "TextureSequence.h"
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *f);
 extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *f);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *a, void *v, int b, int c, unsigned int d, unsigned int e);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *a, int b, int c, void *d, void *e);
@@ -31,7 +31,7 @@ int Lakitu::InitResources()
     for (int i = 0; i < 2; i++) {
         void *t = (void *)data_ov077_02127230[i];
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(t);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void *)data_ov077_02127b50[1], (void *)((int *)t)[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov077_02127b50[1], *(BTP_File *)((int *)t)[1]);
     }
     if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0)
         return 0;

--- a/src/_ZN7SkiLift13InitResourcesEv.cpp
+++ b/src/_ZN7SkiLift13InitResourcesEv.cpp
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SkiLift.h"
+#include "TextureSequence.h"
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *f);
 extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *f);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *act, int a, int b, unsigned int c2, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *act, int a, int b, void *c2, void *d);
@@ -31,7 +31,7 @@ int SkiLift::InitResources()
     for (int i = 0; i < 2; i++) {
         void *t = (void*)data_ov018_02112c04[i];
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(t);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov018_02113c00[1], (void*)((int*)t)[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov018_02113c00[1], *(BTP_File *)((int*)t)[1]);
     }
     if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0) return 0;
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this)+0x174, ((char *)this), 0x104000, 0x12c000, 0x4800004, 0x900000);

--- a/src/_ZN7Wiggler13InitResourcesEv.cpp
+++ b/src/_ZN7Wiggler13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Wiggler.h"
+#include "TextureSequence.h"
 extern "C" {
 extern int _ZN5Actor9TrackStarEjj(void *self, u32 a, u32 b);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *shared);
@@ -12,7 +13,6 @@ extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void *shared);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *shared);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *mb, void *bmd, int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *ma, void *bca, int i, int fix, u32 j);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *ts, void *btp, int i, int fix, u32 j);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void MulVec3Mat4x3(void *dst, void *mtx, void *src);
@@ -93,7 +93,7 @@ int Wiggler::InitResources()
         _ZN9Animation8LoadFileER13SharedFilePtr(data_ov034_021138b0[i]);
         _ZN9ModelBase7SetFileEP8BMD_Fileii(r8p, *(void **)((char *)sp18 + 4), sp2C, sp30);
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(r8p, *(void **)((char *)sp1C + 4), sp34, 0x1000, sp34);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*(void **)((char *)sp18 + 4), *(void **)((char *)sp20 + 4));
+        TextureSequence::Prepare(**(BMD_File **)((char *)sp18 + 4), **(BTP_File **)((char *)sp20 + 4));
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(fpp, *(void **)((char *)sp20 + 4), sp38, 0x1000, sp38);
         *(s32 *)(spC + 0x374) = sp3C;
         if (i == 0) {

--- a/src/_ZN8Goomboss13InitResourcesEv.cpp
+++ b/src/_ZN8Goomboss13InitResourcesEv.cpp
@@ -10,6 +10,11 @@ struct Vector3;
 struct Actor;
 struct Vector3_16;
 
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
+struct BMA_File;
+struct MaterialChanger { static void Prepare(BMD_File &model, BMA_File &animFile); };
 extern "C" {
     void func_ov074_02122634(char *self);
     void *_ZN5Model8LoadFileER13SharedFilePtr(void *shared);
@@ -22,8 +27,6 @@ extern "C" {
     void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
         void *self, void *actor, void *pos, s32 fx, s32 fy, u32 a, u32 b);
     void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *f, int a, s32 fix, u32 c);
-    void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
-    void _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File(void *bmd, void *bma);
     void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void *bmd, void *bta);
     void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, void *f, int a, s32 fix, u32 c);
     void _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(void *self, void *f, int a, s32 fix, u32 c);
@@ -121,8 +124,10 @@ extern "C" int _ZN8Goomboss13InitResourcesEv(char *self)
     } while (k < 4);
 
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x210, *((void **)&data_ov074_02123030 + 1), 0, 0x1000, 0);
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*((void **)&data_ov074_02123000 + 1), *((void **)&data_ov074_02123040 + 1));
-    _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File(*((void **)&data_ov074_02123000 + 1), &func_021123f4);
+    TextureSequence::Prepare(**(BMD_File **)((void **)&data_ov074_02123000 + 1),
+                             **(BTP_File **)((void **)&data_ov074_02123040 + 1));
+    MaterialChanger::Prepare(**(BMD_File **)((void **)&data_ov074_02123000 + 1),
+                             *(BMA_File *)&func_021123f4);
 
     i = 0;
     do {

--- a/src/_ZN9LakituBro13InitResourcesEv.cpp
+++ b/src/_ZN9LakituBro13InitResourcesEv.cpp
@@ -10,24 +10,10 @@
 /* SetAnim and SetFile stay mangled because their real signatures carry
    Fix12<int> (wall 6az). Everything else the members' own headers declare.
 
-   PREPARE STAYS MANGLED FOR A DIFFERENT REASON, and it is not a style choice:
-   `mTextureSequence.Prepare(model, file)` compiles, but costs bytes, because
-   the ROM does not pass a `this` here. The call is
-
-       ldr r0,[pc,#0xfc] / ldr r1,[pc,#0x100]   the two SharedFilePtrs
-       ldr r0,[r0,#4]    / ldr r1,[r1,#4]       the two loaded files
-       bl  _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File
-       mov r2,#0                                <- r2 written AFTER the call
-
-   -- exactly two argument registers. All 23 call sites in the tree declare it
-   with two parameters, and a mangled name does not encode staticness, so the
-   symbol is equally the mangling of a STATIC member. TextureSequence.h
-   declaring it non-static is what makes the member form unwritable anywhere.
-   Its 0xc body is `ldr r12,[pc]; bx r12`, a pure tail jump that reproduces for
-   any signature, so the definition file's `this` is unconstrained by the ROM
-   and contradicted by every caller. Fixing that is a shared-header change with
-   23 dependents and belongs in its own commit, not here. */
-extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File& model, BTP_File& file);
+   Prepare is one of those now. It reads as a member call because it is a
+   STATIC member -- the ROM passes it two argument registers and no this,
+   which is why the mangled extern used to be the only spelling that fit.
+   TextureSequence.h carries the disassembly that settles it. */
 extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, BCA_File* f, int a, Fix12i b, u32 c);
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* thiz, BTP_File& f, int a, Fix12i b, u32 c);
 
@@ -46,7 +32,7 @@ int LakituBro::InitResources()
   TextureSequence::LoadFile(*(SharedFilePtr*)data_ov085_0213073c);
   mShadowModel1.InitCylinder();
   mShadowModel2.InitCylinder();
-  _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
+  TextureSequence::Prepare(
       **(BMD_File**)(data_ov085_0213074c + 4), **(BTP_File**)(data_ov085_0213073c + 4));
   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
       &mModelAnim1, *(BCA_File**)(data_ov085_02130744 + 4), 0, 0x1000, 0);

--- a/src/_ZN9OneUpLogo13InitResourcesEv.cpp
+++ b/src/_ZN9OneUpLogo13InitResourcesEv.cpp
@@ -2,6 +2,7 @@
 // @symbol _ZN9OneUpLogo13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "OneUpLogo.h"
+#include "TextureSequence.h"
 extern "C" {
 struct SharedFilePtr { int a, file; };
 extern SharedFilePtr data_ov002_02110a9c;
@@ -9,7 +10,6 @@ extern SharedFilePtr data_ov002_02110aa4;
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* bmd, void* btp);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* self, void* btp, int a, int c, unsigned int n);
 }
 
@@ -23,7 +23,7 @@ int OneUpLogo::InitResources()
   _ZN15TextureSequence8LoadFileER13SharedFilePtr(data_ov002_02110a9c);
   if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_02110aa4), 1, -1) == 0)
     return 0;
-  _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov002_02110aa4.file, (void*)data_ov002_02110a9c.file);
+  TextureSequence::Prepare(*(BMD_File*)data_ov002_02110aa4.file, *(BTP_File*)data_ov002_02110a9c.file);
   _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(((char*)this)+0x124, (void*)data_ov002_02110a9c.file, 0x40000000, 0, n);
   unk_14e = 0;
   unk_13c = mPosX;

--- a/src/func_ov002_020f6618.cpp
+++ b/src/func_ov002_020f6618.cpp
@@ -1,4 +1,7 @@
 //cpp
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 extern "C" {
 struct SharedFilePtr { int a, file; };
 void* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr& f);
@@ -8,7 +11,6 @@ void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* f, int a, int
 void* _Znwj(unsigned int sz);
 void* _ZN15TextureSequenceC1Ev(void* self);
 void* _ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr& f);
-void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* bmd, void* btp);
 void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* self, void* btp, int a, int fx, unsigned int e);
 
 int func_ov002_020f6618(char* self, SharedFilePtr* mdl, int nAnims, SharedFilePtr** anims,
@@ -38,7 +40,7 @@ int func_ov002_020f6618(char* self, SharedFilePtr* mdl, int nAnims, SharedFilePt
         for (i = 0; i < *(unsigned char*)(self + 0x81); i++) {
             void* bmd = (void*)(*(SharedFilePtr**)(self + 0x70))->file;
             void* btp = _ZN15TextureSequence8LoadFileER13SharedFilePtr(*(*(SharedFilePtr***)(self + 0x78))[i]);
-            _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(bmd, btp);
+            TextureSequence::Prepare(*(BMD_File*)bmd, *(BTP_File*)btp);
         }
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(*(void**)(self + 0x7c),
             (void*)(*(*(SharedFilePtr***)(self + 0x78))[0]).file, 0, 0x1000, 0);

--- a/src/func_ov006_020e7fe8.cpp
+++ b/src/func_ov006_020e7fe8.cpp
@@ -1,9 +1,11 @@
 //cpp
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 extern "C" {
 int func_020179b4(void* r0, void* r1, int r2);
 void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void* r);
 void _ZN9Animation8LoadFileER13SharedFilePtr(void* r);
-void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* bmd, void* btp);
 void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* self, void* btp, int a, int b, unsigned int d);
 void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int b, unsigned int d);
 void func_ov006_020e7954(void* c);
@@ -27,7 +29,8 @@ extern "C" int func_ov006_020e7fe8(char* c)
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02141e7c);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02141e8c);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02141e84);
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*((void**)&data_ov006_02141e54 + 1), *((void**)&data_ov006_02141e64 + 1));
+    TextureSequence::Prepare(**(BMD_File**)((void**)&data_ov006_02141e54 + 1),
+                             **(BTP_File**)((void**)&data_ov006_02141e64 + 1));
     _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x70, *((void**)&data_ov006_02141e64 + 1), 0, 0x1000, 0);
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xc, *((void**)&data_ov006_02141e5c + 1), 0x40000000, 0x800, 0);
     func_ov006_020e7954(c + 0x84);

--- a/src/func_ov027_02111eb4.cpp
+++ b/src/func_ov027_02111eb4.cpp
@@ -5,12 +5,14 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daPgDfdr_c::InitResources - recovered from vtable slot identity */
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *o, void *f, int a, int b);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
 extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *fp);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *a, void *b);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *o, void *f, int i, int fx, unsigned j);
 extern void func_ov027_02111994(void *c);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *fp);
@@ -45,7 +47,8 @@ int func_ov027_02111eb4(void *cc)
         _ZN9Animation8LoadFileER13SharedFilePtr(data_ov027_02112ca4[i]);
 
     _ZN15TextureSequence8LoadFileER13SharedFilePtr(&data_ov027_02113c94);
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*(void**)(&data_ov027_02113c7c + 4), *(void**)(&data_ov027_02113c94 + 4));
+    TextureSequence::Prepare(**(BMD_File**)(&data_ov027_02113c7c + 4),
+                             **(BTP_File**)(&data_ov027_02113c94 + 4));
     _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x384, *(void**)(&data_ov027_02113c94 + 4), 0, 0x1000, 0);
 
     *(short*)(c + 0x8e) = (short)0xdd30;

--- a/src/func_ov060_02111cc0.cpp
+++ b/src/func_ov060_02111cc0.cpp
@@ -1,4 +1,7 @@
 //cpp
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 extern "C" {
 struct E { int w[2]; };
 extern int *data_ov060_021192dc[];
@@ -10,7 +13,6 @@ extern E data_ov060_0211abf0;
 extern E data_ov060_0211ac30;
 extern E data_ov060_0211ac28;
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *anim, void *file, int a, int d, unsigned e);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *ts, void *file, int a, int d, unsigned e);
 extern void _ZN9Animation8SetFlagsEi(void *anim, int flags);
 
@@ -20,34 +22,34 @@ void func_ov060_02111cc0(char *c, int idx)
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (void *)data_ov060_021192dc[idx][1], a, 0x1000, 0);
     switch (idx) {
     case 1:
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void *)data_ov060_0211ac78.w[1], (void *)data_ov060_0211ac40.w[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov060_0211ac78.w[1], *(BTP_File *)data_ov060_0211ac40.w[1]);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, (void *)data_ov060_0211ac40.w[1], 0, 0x1000, 0);
         _ZN9Animation8SetFlagsEi(c + 0x138, 0x40000000);
         return;
     case 2:
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void *)data_ov060_0211ac78.w[1], (void *)data_ov060_0211acb8.w[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov060_0211ac78.w[1], *(BTP_File *)data_ov060_0211acb8.w[1]);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, (void *)data_ov060_0211acb8.w[1], 0, 0x1000, 0);
         _ZN9Animation8SetFlagsEi(c + 0x138, 0x40000000);
         return;
     case 3:
     case 5:
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void *)data_ov060_0211ac78.w[1], (void *)data_ov060_0211ac10.w[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov060_0211ac78.w[1], *(BTP_File *)data_ov060_0211ac10.w[1]);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, (void *)data_ov060_0211ac10.w[1], 0, 0x1000, 0);
         _ZN9Animation8SetFlagsEi(c + 0x138, 0);
         return;
     case 14:
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void *)data_ov060_0211ac78.w[1], (void *)data_ov060_0211abf0.w[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov060_0211ac78.w[1], *(BTP_File *)data_ov060_0211abf0.w[1]);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, (void *)data_ov060_0211abf0.w[1], 0, 0x1000, 0);
         _ZN9Animation8SetFlagsEi(c + 0x138, 0);
         return;
     case 10:
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void *)data_ov060_0211ac78.w[1], (void *)data_ov060_0211ac30.w[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov060_0211ac78.w[1], *(BTP_File *)data_ov060_0211ac30.w[1]);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, (void *)data_ov060_0211ac30.w[1], 0, 0x1000, 0);
         _ZN9Animation8SetFlagsEi(c + 0x138, 0x40000000);
         return;
     case 0:
     default:
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void *)data_ov060_0211ac78.w[1], (void *)data_ov060_0211ac28.w[1]);
+        TextureSequence::Prepare(*(BMD_File *)data_ov060_0211ac78.w[1], *(BTP_File *)data_ov060_0211ac28.w[1]);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, (void *)data_ov060_0211ac28.w[1], 0, 0x1000, 0);
         _ZN9Animation8SetFlagsEi(c + 0x138, 0);
         return;

--- a/src/func_ov075_021143e4.cpp
+++ b/src/func_ov075_021143e4.cpp
@@ -1,8 +1,10 @@
 //cpp
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 extern "C" {
 extern int RandomIntInternal(void*);
 extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void*,void*,int,int,int,unsigned short);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void*,void*);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*,void*,int,int,unsigned int);
 extern int _ZNK9Animation13GetFrameCountEv(void*);
 extern long long __aeabi_uidiv(unsigned int,int);
@@ -30,7 +32,7 @@ void func_ov075_021143e4(char*c){
     *(int*)(c+0x110)=9;
     data_ov075_0211d380[0]>>=2;
   }
-  _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov075_0211d3c4[1],r4);
+  TextureSequence::Prepare(*(BMD_File*)data_ov075_0211d3c4[1],*(BTP_File*)r4);
   _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c+0xd4,r4,0,0x1000,0);
   {
     unsigned int rv=(unsigned int)RandomIntInternal(data_0209e650);

--- a/src/func_ov075_02114ddc.cpp
+++ b/src/func_ov075_02114ddc.cpp
@@ -1,9 +1,11 @@
 //cpp
+struct BMD_File;
+struct BTP_File;
+struct TextureSequence { static void Prepare(BMD_File &model, BTP_File &animFile); };
 extern "C" {
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *o, void *f, int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *o, void *f, int a, int fx, unsigned j);
 extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *o, void *f, int a, int b, int fx, unsigned short t);
-extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *a, void *b);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *o, void *f, int a, int fx, unsigned j);
 extern int RandomIntInternal(void *seed);
 extern int _ZNK9Animation13GetFrameCountEv(void *o);
@@ -38,7 +40,7 @@ extern "C" int func_ov075_02114ddc(void *cc, int r6, int r5, int r4)
         *(int*)(c + 0x110) = 7;
     }
 
-    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*(void**)(&data_ov075_0211d3c4 + 4), tex);
+    TextureSequence::Prepare(**(BMD_File**)(&data_ov075_0211d3c4 + 4), *(BTP_File*)tex);
     _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0xd4, tex, 0, 0x1000, 0);
 
     {

--- a/src/func_ov091_02133254.cpp
+++ b/src/func_ov091_02133254.cpp
@@ -3,10 +3,10 @@
 /* recovered: shared common types */
 #include "common.h"
 #include "MeshColliderBase.h"
+#include "TextureSequence.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
-struct BTP_File;
 
 extern "C" BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, BMD_File *f, int a, int b);
@@ -17,7 +17,6 @@ extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEs
     void *self, KCL_File *k, void *m, int fix, short s, void *clps);
 extern "C" void func_020393d4(int *p, int v);
 extern "C" BTP_File *_ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr &f);
-extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File &b, BTP_File &t);
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, BTP_File *f, int a, int fix, unsigned int u);
 extern "C" int _ZN11ShadowModel10InitCuboidEv(void *self);
 
@@ -59,7 +58,7 @@ extern "C" int func_ov091_02133254(char *self)
     {
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(*(SharedFilePtr *)tp);
         p320 = *(void ***)(self + 0x320);
-        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
+        TextureSequence::Prepare(
             *(BMD_File *)*(void **)((char *)*p320 + 4),
             *(BTP_File *)*(void **)((char *)*(p320 + 3) + 4));
         p320 = *(void ***)(self + 0x320);


### PR DESCRIPTION
`TextureSequence::Prepare` and `MaterialChanger::Prepare` were declared as ordinary members and defined as forwarding `(this, &model, &file)`. They take two arguments and no `this`.

## Why the wrong reading survived

Both ROM bodies are `0xc` long-call veneers — `ldr ip,[pc]; bx ip; .word <impl>`. A pure tail jump reproduces under *any* signature, so the definition files never constrained the question. The constraint lives on the two sides nobody had consulted:

**The callee.** `func_02046d50` and `func_020470e8` read only `r0` and `r1`:

```
push {r4-r7,lr} / sub sp,sp,#4
mov  r6, r1      <- ldrh [r6,#2], ldr [r6,#4], ldrh [r6,#8],
mov  r7, r0         ldr [r6,#0xc], ldrh [r6,#0x1c], ldr [r6,#0x20]
```

`r2` is never touched, which rules out a third argument. And the offsets `r1` is read at are exactly `BTP_File`'s declared fields — so `r1` is the *animation file*, the second argument. Under the old reading it would have been the BMD.

**The callers.** Every call site in the tree passes two. So do both matched implementations, `src/func_02046d50.c` and `src/func_020470e8.c`.

A static member mangles identically, so no symbol changes and no config moves.

`TextureTransformer`, the third sibling, was corrected long ago. Its header already names these two veneers as "called the same way" and notes the old reading "cost the PC port a wrong-register hunt" — the follow-up just never happened. This is it.

## What changed

Twenty-two call sites drop the mangled extern for `TextureSequence::Prepare(model, file)`. The six `.c` callers keep theirs — C has no `::`.

`SnowmanHead` and `InvisibleSecret` declare the class locally rather than including `TextureSequence.h`: both carry `typedef int Fix12;`, which collides with the real `math/Fix12.h` template.

Several of the removed externs were a bare `extern` on an already-mangled name inside a `//cpp` file, which mangles a second time. That shows up in the one gate that can see it: `_Z49_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_Fileii` leaves the unresolved backlog. `Eyerok`'s linkcheck improves `BLIND-39 -> BLIND-35` as four call destinations become resolvable.

## The other three commits

**Whomp's `MeshColliderBase` address was double-mangled.** Found while running the gates, in a file this change already touches. The declaration sat *outside* the `extern "C"` block above it, so the address taken pointed at a `_Z88_ZN16...` that does not exist. The byte gate cannot see this — relocated words are wildcards. Linkcheck goes `BLIND-1 -> VERIFIED` and the function still reproduces.

**The unresolved-reference baseline is re-pinned to main.** `config/unresolved-baseline.json` had drifted: it recorded 10805 eligible against main's 10813, and `check_references` fails on clean `origin/main` with no feature branch involved:

```
git checkout origin/main
python tools/eligible.py
python tools/check_references.py            # FAIL
python tools/check_references.py --update
# refusing to update: symbols left the backlog by failing differently
```

The ratchet could not unstick itself. `--update` refuses, correctly, because one symbol left the backlog without being fixed: `func_ov091_021339fc` was deliberately converted to a hand-written asm hatch by an earlier merged PR, which takes it out of `eligible.py`'s candidate set. It did not degrade, it was reclassified — and the reason-switching guard cannot tell those apart, which is exactly why unsticking it has to be a deliberate decision rather than a `--update`.

The other two entries are main's as well, and neither has a correct fix:

- `func_02057410` references `_ll_udiv` / `_ull_mod`, mwccarm's names for the 64-bit division helpers it emits for the `(u64)v / (u64)pf[1]` at `func_02057410.c:304`. The ROM's implementations are `__aeabi_uldiv` / `__aeabi_ulmod` in ITCM (`0x01ffa9dc`, `0x01ffa9e8`), but `check_references` has no alias mechanism, and adding `_ll_udiv` as a second symbol at that address would create the duplicate-address condition that makes CI report lost matched functions.
- `Whomp::InitResources` references `func_021135d4`, which dsd resolves to `module:overlays(9,14,15,16,18,19,20,22,24,25,26,27,29,32,36)`. All fifteen load at `0x021111a0`, so that one instruction targets different data depending on the level and **no single name is correct**.

The baseline was generated on a clean `origin/main` checkout, so it carries nothing from this branch. Verify by checking out `origin/main`, running `tools/eligible.py`, and regenerating — the result is byte-identical.

**Then two fixes are banked back down** with `--update`, which is downward-only: the two double-mangled names above leave the backlog, nothing is added, and the ratchet now refuses to let either come back.

## Gates

- `rombuild` **106/106 exact, 10,813 reproducing, 0 mismatching**
- `eligible` name list byte-identical to main at **10813**
- `check_references` **OK: no new unresolvable references** (pre-push hook passes; no `--no-verify`)
- `prepush_linkcheck` 23 checked, 21 verified, **0 blocking**
- `prepush_attribution` 0 changed / 0 lost · `port_refcheck` 393 resolve · header offsets, data definitions, duplicate sources clean

## Not fixed, stated plainly

`Goomba::InitResources` and `MrI::InitResources` do not reproduce — before or after. Both fail identically on `origin/main` (999 and 7 words), and their compiled bytes are **unchanged** by this branch: 916 → 916 and 664 → 664, identical in both cases. So the edits there are provably neutral, not merely still-failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxDmkQ47fWa3GB6mj8xEQe
