### PR TITLE
Let PR validation grade a failing file instead of dying on it

### DIFF
--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -252,6 +252,33 @@ def warm_shared_indexes():
     RV.mod_for("arm9")
 
 
+def source_policy(worst, text):
+    """Apply the two source-text overrides to a link verdict.
+
+    A file whose head declares "// NONMATCHING" is a self-declared draft: it makes no
+    claim to reproduce the ROM and chaos-db counts it as unmatched, so a NO-REPRO
+    verdict on it is expected, not a gate failure. The gate exists to stop files that
+    CLAIM to be matches from landing red; a declared draft cannot inflate any count.
+    WRONG (a resolvable reloc pointing at the wrong symbol) still fails -- a draft's
+    call graph must be honest even if its bytes differ.
+
+    The draft downgrade cannot collide with the transcription check: a transcription
+    has no banner by definition, because a NONMATCHING banner reclassifies it as an
+    honest draft (asm_policy.classify returns None for it).
+
+    This lives outside main() because it is only reachable when a file FAILS, which is
+    the one path a green CI run never exercises. `asm_policy.has_draft_banner` was
+    spelled against the unaliased module name from #1367 until a PR finally produced a
+    NO-REPRO -- and then the validator died on a NameError mid-loop, reporting "worker
+    error" instead of grading the file. Untestable because inline, so untested.
+    """
+    if worst == "NO-REPRO" and AP.has_draft_banner(text):
+        return "DRAFT"
+    if AP.classify(text) == "transcribed":
+        return "RAW-ASM"
+    return worst
+
+
 def main():
     global _NAME_INDEX
     ap = argparse.ArgumentParser(description=__doc__,
@@ -328,23 +355,12 @@ def main():
             continue
         w = worst(rep["results"])
         rep["worst"] = w
-        # A file whose head declares "// NONMATCHING" is a self-declared draft: it makes
-        # no claim to reproduce the ROM and chaos-db counts it as unmatched, so a
-        # NO-REPRO verdict on it is expected, not a gate failure. The gate exists to
-        # stop files that CLAIM to be matches from landing red; a declared draft cannot
-        # inflate any count. WRONG (a resolvable reloc pointing at the wrong symbol)
-        # still fails -- a draft's call graph must be honest even if its bytes differ.
         text = ""
         try:
             text = pathlib.Path(path).read_text(encoding="utf-8", errors="replace")
         except OSError:
             pass
-        if w == "NO-REPRO" and asm_policy.has_draft_banner(text):
-            rep["worst"] = w = "DRAFT"
-        # The draft downgrade cannot collide with this: a transcription has no banner
-        # by definition (a NONMATCHING banner reclassifies it as an honest draft).
-        if AP.classify(text) == "transcribed":
-            rep["worst"] = w = "RAW-ASM"
+        rep["worst"] = w = source_policy(w, text)
         if w in FAIL:
             bad.append((path, w))
         mark = {"WRONG": "WRONG  ", "NO-REPRO": "NOREPRO", "BENIGN": "ok(ben)",

--- a/tools/test_pr_linkcheck_verdict.py
+++ b/tools/test_pr_linkcheck_verdict.py
@@ -1,0 +1,54 @@
+"""The source-text overrides pr_linkcheck applies to a link verdict.
+
+Regression test for a NameError that sat in this branch from #1367 until a PR finally
+produced a NO-REPRO. The rule reads the module as `asm_policy` while the import binds
+it as `AP`, so the moment the gate had a failing file to grade it raised instead --
+and the validator reported "worker error: pr_linkcheck exited 1 without a report"
+rather than the verdict. Nothing caught it because the branch is only reachable when a
+file fails, which no green run does; these cases drive it directly.
+"""
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import pr_linkcheck as PL  # noqa: E402
+
+DRAFT = "// NONMATCHING\nvoid f(void) { }\n"
+PLAIN = "void f(void) { }\n"
+DCD = ("asm void func_ov002_020cfea4(void) {\n"
+       "    dcd 0xe92d43f0\n"
+       "    dcd 0xe12fff1e\n"
+       "}\n")
+
+
+class SourcePolicy(unittest.TestCase):
+    def test_draft_banner_downgrades_no_repro(self):
+        """The case that raised: a declared draft that does not reproduce."""
+        self.assertEqual(PL.source_policy("NO-REPRO", DRAFT), "DRAFT")
+
+    def test_unbannered_no_repro_still_fails(self):
+        """A file claiming to be a match must not be waved through."""
+        self.assertEqual(PL.source_policy("NO-REPRO", PLAIN), "NO-REPRO")
+
+    def test_draft_banner_does_not_excuse_wrong_dest(self):
+        """A draft's call graph must be honest even when its bytes differ."""
+        self.assertEqual(PL.source_policy("WRONG", DRAFT), "WRONG")
+
+    def test_verified_is_untouched(self):
+        self.assertEqual(PL.source_policy("VERIFIED", PLAIN), "VERIFIED")
+
+    def test_transcription_is_raw_asm(self):
+        self.assertEqual(PL.source_policy("VERIFIED", DCD), "RAW-ASM")
+
+    def test_bannered_transcription_is_a_draft_not_raw_asm(self):
+        """The collision the inline comment claims cannot happen -- pinned here."""
+        self.assertEqual(PL.source_policy("NO-REPRO", "// NONMATCHING\n" + DCD), "DRAFT")
+
+    def test_empty_text_is_inert(self):
+        """check_file passes "" when the path cannot be read; it must not reclassify."""
+        self.assertEqual(PL.source_policy("NO-REPRO", ""), "NO-REPRO")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gate dies exactly when it has something to say

Since #1367 the PR validator has been unable to report on any PR containing a
non-reproducing file. The draft-banner rule reads the module under a name the import
does not bind:

```python
import asm_policy as AP          # line 49
...
if w == "NO-REPRO" and asm_policy.has_draft_banner(text):   # line 342
```

`and` short-circuits, so the line is only evaluated once a file grades `NO-REPRO` —
and then it raises `NameError` in the middle of the classification loop. The worker
reports

```
worker error: pr_linkcheck exited 1 without a report
```

with no verdict for **any** file, including the ones it had already graded. #1390 is
the first PR to hit it.

## What it was hiding

Reproduced locally against #1390's head with the fix applied — 310 files:

| verdict | count |
|---|---|
| VERIFIED | 305 |
| BLIND | 3 |
| DRAFT | 1 |
| NO-SYM | 1 |

The crash file is `src/_ZN3MrI13InitResourcesEv.cpp`, which sorts immediately after
`src/_ZN3Amp8BehaviorEv.cpp` — the last line the validator printed before dying. It
carries a `// NONMATCHING` banner, so the correct verdict is **DRAFT, a pass**. The
rule was written for exactly this file and had never once run.

The `NO-SYM` is real and pre-existing, not from #1390:
`src/_ZN6Player16CleanupResourcesEv.cpp` does not compile on clean `main` either
(identical error, and the PR does not touch it). That is #1367's NO-SYM category doing
its job on the first PR whose fan-out reached the file. Fixed separately in
`fix/player-cleanupresources-compiles`.

## The fix

One word — plus the reason it survived. The rule is only reachable when a file
**fails**, which is the one path a green CI run never exercises, so sitting inline in
`main()` it was untestable and untested. The two source-text overrides move into
`source_policy(worst, text)` and `tools/test_pr_linkcheck_verdict.py` drives them
directly, including the collision the old inline comment asserted could not happen (a
bannered transcription grades DRAFT, not RAW-ASM).

Behaviour is otherwise unchanged: the extracted function preserves the original order,
and a draft banner still does not excuse `WRONG`.

## Verified

- `tools/test_pr_linkcheck_verdict.py` — 7 pass; `test_pr_linkcheck_renames.py` and
  `test_asm_policy.py` still pass (24).
- `pyflakes tools/*.py` in both directions: **one** undefined name on `main`
  (`pr_linkcheck.py:342`), **zero** across all of `tools/` with this applied.
- `pr_linkcheck.py` re-run end-to-end on #1390's head: completes, 310 files graded, no
  crash.
- No `src/` or `config/` change, so the ROM build is untouched.

There is no Python lint step in CI today. Adding one would have caught this on the
commit that introduced it, and the baseline is already clean — but that is a separate
change, not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxDmkQ47fWa3GB6mj8xEQe
