### PR TITLE
Player::CleanupResources compiles again, and it was a match all along

### DIFF
--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -4010,6 +4010,7 @@ src/_ZN6Player11ChangeStateERNS_5StateE.cpp:
     .text start:0x020e30a0 end:0x020e32d4
 
 src/_ZN6Player16CleanupResourcesEv.cpp:
+    complete
     .text start:0x020e32d4 end:0x020e3a04
 
 src/_ZN6Player16OnPendingDestroyEv.cpp:

--- a/src/_ZN6Player16CleanupResourcesEv.cpp
+++ b/src/_ZN6Player16CleanupResourcesEv.cpp
@@ -14,13 +14,15 @@ struct VB { virtual void v0(); virtual void v1(); };
 #pragma opt_strength_reduction off
 
 extern "C" {
-void func_ov002_020bdd2c(char *c);
-void func_ov002_020bdef0(char *c);
-void func_ov002_020bdd9c(char *c);
-void func_ov002_020e032c(char *c);
+/* func_ov002_020bdd2c, _020bdef0, _020bdd9c, _020e032c and func_02073244 come from
+   decl_common.h above. Declaring them again here with `char *` where that header
+   says `void *` is not a redeclaration but an attempt to overload a C-linkage
+   name, which mwccarm rejects outright -- so this file has not compiled since it
+   gained that include. Nothing caught it: a file that will not compile is never
+   enrolled, so every byte gate skips it and the ROM keeps the original bytes for
+   this range. Declare only what decl_common.h does not. */
 void func_0203cbc0(int p);
-void _ZN7Vector3D1Ev(void);
-void func_02073244(int p, int a, int b, void (*f)(void));
+void _ZN7Vector3D1Ev(void *self);
 void func_ov002_020bebd4(char *c);
 void UnloadSilverStarAndNumber(void);
 void UnloadKeyModels(int n);
@@ -94,7 +96,7 @@ int Player::CleanupResources()
     {
         int q = unk_578;
         if (q != 0)
-            func_02073244(q, 0xc, 8, _ZN7Vector3D1Ev);
+            func_02073244((void *)q, 0xc, 8, _ZN7Vector3D1Ev);
         q = unk_57c;
         if (q != 0)
             func_0203cbc0(q);


### PR DESCRIPTION
## A match that has been sitting unreadable in the tree

`src/_ZN6Player16CleanupResourcesEv.cpp` has not compiled since it gained
`#include "decl_common.h"`. That header declares, inside `extern "C"`:

```c
extern void func_ov002_020bdd2c(void*);
extern void func_02073244(void*, int, int, void (*)(void*));
```

and the file then declared the same names again taking `char *` and
`(int, int, int, void (*)(void))`. Same C linkage, different parameter types — so it
is not a redeclaration but an attempt to **overload a C-linkage name**, which mwccarm
rejects outright:

```
src/_ZN6Player16CleanupResourcesEv.cpp:17: illegal function overloading
... :18, :19, :20, :23
Errors caused tool to abort.
```

**Nothing caught it, because the failure removes the file from every gate that could
have.** A file that will not compile is not eligible, so it is not enrolled; its
delinks entry carries no `complete`, so dsd hands the range to the original ROM bytes
and the build stays 106/106 without the source ever being touched. It went unbuilt
through #919, #994, #1032 and #1382 — the last of which edited it.

This is #1367's `NO-SYM` category doing exactly what it was added for. It only
surfaced now because the fan-out of #1390's header change reached the file, and
because #1392 stops the validator crashing before it can say so.

## The function is a byte match

That is the real result. Once it compiles, all **0x730 bytes at `0x020e32d4` in
ov002** reproduce under the pin with correct relocation destinations. Nothing about
the logic needed repair — only the declarations. So it is enrolled here rather than
left as rombytes, and the tree gains a function it has had all along.

The fix is to declare only what `decl_common.h` does not. Three names remain because
that header lacks them; `_ZN7Vector3D1Ev` is spelled with the `this` it actually
takes, which is also what makes the `func_02073244` argument type-correct without a
cast.

## Verified

| gate | result |
|---|---|
| `build_pin` | `(True, '2004/b56')` — 0x020e32d4, size 0x730, ov002 |
| `pr_linkcheck` | `ok`, 1 slot, correct destinations |
| `eligible.py` | **10,814** / 11,162 — main is 10,813, and the diff is this symbol alone |
| `enroll.py` | 1 delinks file changed, 1 line added |
| `rombuild -j16` | **106/106 exact**, 10,814 source-built, 0 mismatching |
| progress | 1,943,084 → **1,944,924** code bytes, 87.88% → **87.96%** |
| `check_data_definitions` | 10,972 objects, none define a ROM data symbol |
| `check_duplicate_sources` | 11,282 stems, none doubled |
| `port_refcheck` | 393 references, all resolve |
| `prepush_attribution` | 11,288 tracked, 0 changed, 0 lost |

## Worth a follow-up

331 delink entries are unbuilt and carry no `NONMATCHING` banner. Most will be
ineligible for ordinary reasons, but this file proves at least one of them was a
finished match held out of the ROM by a declaration mismatch. Sweeping them for the
same signature is a separate change; I have not measured how many are in that state
and am not claiming a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxDmkQ47fWa3GB6mj8xEQe
