### PR TITLE
Guard the tools that guard this repo: fail CI on a name nothing binds

### DIFF
--- a/.github/workflows/python-names.yml
+++ b/.github/workflows/python-names.yml
@@ -1,0 +1,66 @@
+# Guards the tools that guard this repo.
+#
+# `tools/pr_linkcheck.py` shipped in #1367 reading `asm_policy.has_draft_banner` while
+# the import bound the module as `AP`. Because `and` short-circuits, the line only ran
+# once a file graded NO-REPRO -- so the first PR to contain a declared draft got a
+# NameError mid-loop, and the validator reported "worker error: pr_linkcheck exited 1
+# without a report" instead of a verdict for any file. #1392 fixed it. This job is why
+# it cannot happen twice.
+#
+# A gate's failure branch is the one path a green CI run never exercises. No ROM build
+# will ever catch a bug there, because these tools are not compiled into the ROM --
+# only static analysis reaches that code without running it.
+#
+# NARROW ON PURPOSE. Fails on unresolvable names and unparseable files, nothing else.
+# The tree has zero of those and 32 style findings (unused imports, unused locals,
+# f-strings without placeholders); gating on style would have meant landing this red,
+# and a gate that lands red gets switched off. `tools/check_python_names.py` counts the
+# style findings on every run so the number stays visible, and --advisories lists them.
+# Ratcheting them downward the way langmode-ratchet.yml does is a fair follow-up.
+#
+# Costs nothing: pure static analysis over git-tracked files, no compiler and no ROM,
+# which is why it lives here rather than on the private build box pr-validate.yml
+# relays to. Runs in about a second over 184 files.
+#
+# pyflakes is PINNED. A floating version can add a check, and this gate turning red on
+# a PR that touched no Python would be indistinguishable from a real regression -- the
+# exact confusion that cost a session when the reference ratchet went stale.
+name: python names
+
+on:
+  pull_request:
+    paths:
+      - "**.py"
+      - ".github/workflows/python-names.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**.py"
+      - ".github/workflows/python-names.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-names-${{ github.event.pull_request.head.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  names:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # No history needed: the check reads `git ls-files` and the working tree.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pyflakes
+        run: pip install "pyflakes==3.0.1"
+      - name: Unresolvable names and unparseable files
+        run: python tools/check_python_names.py
+      - name: The gate's own tests
+        # Includes the #1367 defect verbatim, so a change that stops detecting it fails
+        # here rather than silently going quiet. stdlib unittest, so the runner needs
+        # no dependency beyond the pinned pyflakes above.
+        run: python -m unittest tools.test_check_python_names -v

--- a/tools/check_python_names.py
+++ b/tools/check_python_names.py
@@ -1,0 +1,145 @@
+"""Fail the build on a Python name that does not exist.
+
+WHY THIS EXISTS. `tools/pr_linkcheck.py` shipped in #1367 with
+
+    import asm_policy as AP
+    ...
+    if w == "NO-REPRO" and asm_policy.has_draft_banner(text):
+
+The module is bound as `AP`, so `asm_policy` is not a name in that scope. `and`
+short-circuits, so the line only evaluated once a file graded NO-REPRO -- and the
+first PR to contain one got `NameError` in the middle of the classification loop.
+The validator reported "worker error: pr_linkcheck exited 1 without a report" and
+threw away the verdicts it had already computed. Fixed in #1392.
+
+**A gate's failure branch is the one path a green CI run never exercises.** That is
+where this class of defect survives, and it is why the tools that guard this repo
+need a guard of their own. Static analysis finds it in under a second; the ROM build
+never will, because a tool is not compiled into the ROM.
+
+WHAT IS FATAL, AND WHY NOT EVERYTHING. Only names that cannot resolve at runtime, plus
+files that will not parse. Those are bugs by construction and the tree has ZERO of
+them today, so this gate starts green and every future red is a real regression.
+
+Pyflakes also reports unused imports, unused locals and placeholder-free f-strings --
+32 of them across the tree when this was written. They are style, not breakage, and
+gating on them would have meant either a 32-file cleanup commit that buries the
+signal, or a gate that lands red and gets switched off within a week. They are
+counted and printed here so nobody has to guess the number, and ratcheting them
+downward the way `langmode_audit.py` does is a reasonable follow-up -- but it needs a
+banked baseline, and this does not.
+
+    python tools/check_python_names.py          # every tracked *.py
+    python tools/check_python_names.py a.py b.py
+    python tools/check_python_names.py --advisories   # also list the style findings
+"""
+import argparse
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+try:
+    from pyflakes import api as pyflakes_api, messages as M
+except ImportError:
+    sys.exit("pyflakes is not installed -- `pip install pyflakes` (CI pins it in "
+             ".github/workflows/python-names.yml)")
+
+# A name that will not resolve, or a file that will not parse. Everything pyflakes
+# reports outside this set is style.
+FATAL = (
+    M.UndefinedName,          # the #1367 defect: reading a name nothing binds
+    M.UndefinedLocal,         # read before assignment in the same scope
+    M.UndefinedExport,        # __all__ naming something that does not exist
+    M.InvalidPrintSyntax,     # `print >>x` under py3 -- a runtime TypeError
+    M.ForwardAnnotationSyntaxError,
+    M.DoctestSyntaxError,
+)
+
+
+class Collector:
+    """Reporter that keeps message objects instead of printing them.
+
+    pyflakes' own reporter writes straight to a stream and loses the type, which is
+    the only thing that separates a broken name from an unused import.
+    """
+
+    def __init__(self):
+        self.messages = []
+        self.errors = []
+
+    def flake(self, message):
+        self.messages.append(message)
+
+    def unexpectedError(self, filename, msg):
+        self.errors.append((filename, msg))
+
+    def syntaxError(self, filename, msg, lineno, offset, text):
+        self.errors.append((filename, f"line {lineno}: {msg}"))
+
+
+def tracked_python_files():
+    out = subprocess.run(["git", "-C", str(REPO), "ls-files", "*.py"],
+                         capture_output=True, text=True, check=True).stdout
+    return [REPO / line for line in out.splitlines() if line.strip()]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("files", nargs="*", help="paths to check (default: every tracked *.py)")
+    ap.add_argument("--advisories", action="store_true",
+                    help="list the style findings as well as counting them")
+    args = ap.parse_args()
+
+    explicit = bool(args.files)
+    files = [pathlib.Path(f) for f in args.files] if explicit else tracked_python_files()
+    collector = Collector()
+    for path in files:
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            collector.errors.append((str(path), str(exc)))
+            continue
+        pyflakes_api.check(source, str(path), collector)
+
+    fatal = [m for m in collector.messages if isinstance(m, FATAL)]
+    advisory = [m for m in collector.messages if not isinstance(m, FATAL)]
+
+    def rel(p):
+        try:
+            return pathlib.Path(p).resolve().relative_to(REPO).as_posix()
+        except ValueError:
+            return str(p)
+
+    scope = "file(s)" if explicit else "tracked file(s)"
+    print(f"python-names: {len(files)} {scope} checked")
+
+    if args.advisories and advisory:
+        print(f"\nadvisory ({len(advisory)}) -- style, not gated:")
+        for m in sorted(advisory, key=lambda m: (m.filename, m.lineno)):
+            print(f"  {rel(m.filename)}:{m.lineno}: {m.message % m.message_args}")
+
+    if collector.errors:
+        print(f"\nFAIL: {len(collector.errors)} file(s) could not be parsed:")
+        for filename, msg in collector.errors:
+            print(f"  {rel(filename)}: {msg}")
+
+    if fatal:
+        print(f"\nFAIL: {len(fatal)} unresolvable name(s):")
+        for m in sorted(fatal, key=lambda m: (m.filename, m.lineno)):
+            print(f"  {rel(m.filename)}:{m.lineno}: {m.message % m.message_args}")
+        print("\nA name nothing binds is a NameError the moment that line runs, and the\n"
+              "branch it sits on may be one no test reaches. Fix it or bind the name.")
+
+    if fatal or collector.errors:
+        return 1
+
+    print(f"  0 unresolvable names, 0 unparseable files, {len(advisory)} advisory finding(s)")
+    print("python-names: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_python_names.py
+++ b/tools/test_check_python_names.py
@@ -1,0 +1,102 @@
+"""What the python-names gate must catch, and what it must not fail on.
+
+The first case is the #1367 defect verbatim -- a module bound as `AP` and read as
+`asm_policy`, on a branch only reachable when a file fails. Static analysis is the
+only thing that was ever going to find it, so it is pinned here.
+
+The negative cases matter as much: this gate is deliberately narrow. If it starts
+failing on unused imports it will be switched off, and then it catches nothing.
+"""
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOL = pathlib.Path(__file__).resolve().parent / "check_python_names.py"
+
+REPRO_1367 = '''import asm_policy as AP
+
+
+def source_policy(worst, text):
+    if worst == "NO-REPRO" and asm_policy.has_draft_banner(text):
+        return "DRAFT"
+    return worst
+'''
+
+FIXED = '''import asm_policy as AP
+
+
+def source_policy(worst, text):
+    if worst == "NO-REPRO" and AP.has_draft_banner(text):
+        return "DRAFT"
+    return worst
+'''
+
+STYLE_ONLY = '''import json
+import os
+
+
+def f():
+    unused = 1
+    return 2
+'''
+
+
+def run(*paths):
+    return subprocess.run([sys.executable, str(TOOL), *map(str, paths)],
+                          capture_output=True, text=True)
+
+
+class Gate(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = pathlib.Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, name, text):
+        p = self.dir / name
+        p.write_text(text, encoding="utf-8")
+        return p
+
+    def test_catches_the_1367_defect(self):
+        r = run(self._write("repro.py", REPRO_1367))
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("undefined name 'asm_policy'", r.stdout)
+
+    def test_passes_once_the_name_is_bound(self):
+        r = run(self._write("fixed.py", FIXED))
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("PASS", r.stdout)
+
+    def test_unparseable_file_fails(self):
+        r = run(self._write("bad.py", "def broken(:\n"))
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("could not be parsed", r.stdout)
+
+    def test_style_findings_do_not_fail_the_gate(self):
+        """The narrowness is the point -- a gate that lands red gets switched off."""
+        r = run(self._write("style.py", STYLE_ONLY))
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("advisory finding(s)", r.stdout)
+
+    def test_advisories_are_counted_not_hidden(self):
+        r = run("--advisories", self._write("style.py", STYLE_ONLY))
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("imported but unused", r.stdout)
+
+    def test_read_before_assignment_fails(self):
+        r = run(self._write("local.py", "def f():\n    print(x)\n    x = 1\n"))
+        self.assertEqual(r.returncode, 1, r.stdout)
+
+    def test_this_repo_is_clean(self):
+        """The baseline claim in the tool's docstring, asserted rather than trusted."""
+        r = run()
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("0 unresolvable names", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Guards the tools that guard this repo

#1392 fixed a `NameError` that had blocked PR validation outright. The module was
bound as `AP` and read as `asm_policy`, on a branch only reachable when a file graded
`NO-REPRO` — so the first PR to contain a declared draft got a traceback instead of a
verdict, and the worker discarded the results it had already computed.

**A gate's failure branch is the one path a green CI run never exercises.** No ROM
build will ever catch a defect there — these tools are not compiled into the ROM — and
only static analysis reaches that code without running it. This is the job that stops
it happening twice. It finds the #1367 defect in under a second across all 186 tracked
Python files.

## Narrow on purpose — this is the part worth arguing with

The gate fails on **unresolvable names** and **unparseable files**, and nothing else.
The tree has **zero** of those, so this lands green and every future red is a real
regression.

It also has **32 style findings** — unused imports, unused locals, f-strings without
placeholders. Gating on those meant one of two bad outcomes: landing this red, or a
32-file cleanup commit in the same PR that buries the actual signal. A gate that lands
red gets switched off, and then it catches nothing at all.

So the style findings are counted on every run, listed under `--advisories`, and not
gated. Ratcheting them downward the way `langmode-ratchet.yml` does is a fair
follow-up — it needs a banked baseline, and this deliberately does not.

`pyflakes` is **pinned to 3.0.1**. A floating version can add a check, and this job
turning red on a PR that touched no Python would be indistinguishable from a real
regression — exactly the confusion a stale ratchet caused earlier this week.

## Verified

- The #1367 defect, reconstructed verbatim, is caught:
  `repro.py:5: undefined name 'asm_policy'` → exit 1.
- An unparseable file is caught, and reported separately from the name check.
- 186 tracked files: **0 unresolvable, 0 unparseable, 32 advisory**.
- 7 tests pass under `python -m unittest tools.test_check_python_names`, which is how
  the workflow runs them — stdlib only, so the runner needs no dependency beyond the
  pinned pyflakes.
- Adds no `src/` or `config/` change, so the ROM build is untouched.

The gate caught its own author on the way in: the first draft imported
`pyflakes.reporter` without using it and pushed the advisory count 32 → 33.

## Run it locally

```
python tools/check_python_names.py               # every tracked *.py
python tools/check_python_names.py --advisories  # also list the style findings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxDmkQ47fWa3GB6mj8xEQe
