### PR TITLE
MgBounceAndPounce: real dScMgBase_c base, and a compiler-inlining correction

### DIFF
--- a/include/MgBounceAndPounce.h
+++ b/include/MgBounceAndPounce.h
@@ -1,28 +1,99 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class MgBounceAndPounce: 7 matched functions, 2 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
+/* class MgBounceAndPounce, real ROM name dScMgD3DBase_c -- confirmed by
+ * tools/rtti_extract.py: dScMgD3DBase_c : dScMgBase_c, single edge, and its
+ * own vtable (ov006:0x0213c62c) is exactly what src/MgBounceAndPounce_Spawn.cpp
+ * writes as `_ZTV17MgBounceAndPounce` -- an English name coined before the
+ * class hierarchy was understood, kept here since it's already the mangled
+ * identity of eight matched functions; renaming it is a separate change.
+ *
+ * NOT A LEAF: it has four RTTI descendants of its own (dScMgJump_c,
+ * dScMgJump2_c, dScMgTrampoline_c, dScMgTrampoline2_c), evidenced two ways --
+ * the RTTI graph, and MgBounceAndPounce_Spawn.cpp's own construction order:
+ * `*(int*)p = _ZTV17MgBounceAndPounce` (THIS class's vtable, mid-construction)
+ * runs BEFORE `*(int*)p = data_ov006_0213cbe4` (dScMgJump_c's own vtable,
+ * confirmed against tools/rtti_vtables.py --own dScMgJump_c's slot-16/17
+ * addresses matching dScMgJump_c's D1/D0) -- base-vtable-then-derived-vtable
+ * is exactly the order a real constructor writes them in.
+ *
+ * THE DESTRUCTOR CASCADES A THIRD LEVEL, same mechanics as Scene's own fix
+ * and dScMgBase_c's (include/Scene.h, include/dScMgBase_c.h). D2/D1 defined
+ * INLINE so the four descendants above can inline them; own copy of
+ * operator delete for the same reason (mwcc only inlines a D0 route through
+ * the class itself or its IMMEDIATE base).
+ *
+ * FIELDS. sizeof is 0x5834, from MgBounceAndPounce_Spawn.cpp's own
+ * `ActorBase::operator new(0x5834)` -- the "second witness" this tree's own
+ * recipe (notes, [[matching-session-workflow]]) always prefers over a field
+ * span. Three members corroborate it independently:
+ *   - mSysTracker at 0x47e4, sizeof 0x81c (Particle::SysTracker, from
+ *     include/Stage.h -- a THIRD class now measuring the same size, after
+ *     Stage.h's own two gen_header.py shadows) -- ends exactly 0x5000,
+ *     which is where the old flat header's own `unk_5000` field sat.
+ *   - mModel at 0x501c, sizeof 0x50 (include/Model.h) -- ends exactly
+ *     0x506c, which is exactly where the first func_020733a8-managed table
+ *     below starts.
+ *   - The two tables end exactly at 0x5834 -- the operator-new literal
+ *     itself, the third and strongest confirmation.
+ * The two tables (3 * 0xb8 at 0x506c, 6 * 0xf0 at 0x5294, both constructed
+ * by a shared helper `func_020733a8(base, count, stride, ctor, dtor)`) are
+ * left as raw bytes: their element type isn't evidenced yet, and inventing
+ * one would be a guess this file's own convention refuses to make.
+ */
 #ifndef MGBOUNCEANDPOUNCE_H
 #define MGBOUNCEANDPOUNCE_H
-#include "types.h"
+#include "dScMgBase_c.h"
+#include "Stage.h"
+#include "Model.h"
 
-/* fwd */
-struct arg;
-struct b_;
-struct MgBounceAndPounce {
-    u8  pad_000[0x47e4];
-    u8  unk_47e4;           /* 0x47e4 */
-    u8  pad_47e5[0x81b];
-    u8  unk_5000;           /* 0x5000 */
-#ifdef __cplusplus
-    /* methods */
-    int AfterInitResources(unsigned int result);
-    int BeforeBehavior();
-    int BeforeInitResources();
-    int BeforeRender();
-    void AfterCleanupResources(unsigned int b_);
-    void AfterRender(unsigned int arg);
-#endif
+extern "C" void func_ov004_020b929c(void *);
+
+struct MgBounceAndPounce : dScMgBase_c {
+    /* Declared first -- see include/Scene.h's KEY FUNCTION note. Overrides
+       slots 16 (D1) and 17 (D0). DEFINED INLINE so the four descendants
+       above can inline it. Body: destroy mSysTracker, then call
+       dScMgBase_c's D2 directly -- exactly src/_ZN17MgBounceAndPounceD1Ev.cpp's
+       existing recovered body, now compiler-generated instead of hand-written. */
+    virtual ~MgBounceAndPounce() {}
+
+    /* Own copy, for the same reason dScMgBase_c has one -- unlocks D0 for
+       the four descendants above. */
+    void operator delete(void *ptr) { _ZN6Memory10DeallocateEPvP4Heap(ptr, data_020a0eac); }
+
+    /* --- overrides. 1, 2, 5, 7, 10 re-override slots dScMgBase_c already
+           gave a body; 11 (AfterRender) is the first override below
+           Scene's own default (dScMgBase_c never touched it). --- */
+    virtual bool BeforeInitResources();                /* slot  1 */
+    virtual void AfterInitResources(u32 vfSuccess);    /* slot  2 */
+    virtual void AfterCleanupResources(u32 vfSuccess); /* slot  5 */
+    virtual int  BeforeBehavior();                     /* slot  7 */
+    virtual int  BeforeRender();                       /* slot 10 */
+    virtual void AfterRender(u32 vfSuccess);           /* slot 11 */
+
+    /* Nine more of dScMgBase_c's own 18 new slots (18-35) are overridden
+       here too (slots 24-31, 33 per tools/rtti_vtables.py --own
+       dScMgD3DBase_c) -- left undeclared, same as dScMgBase_c.h's own
+       slots 18-35: their targets are matched source but dScMgBase_c
+       hasn't named or given signatures to the slots they'd be overriding
+       yet, and a derived override can't be declared before its base is. */
+
+    u8   pad_465d[0x187];             /* dScMgBase_c's own data ends 0x465d; the
+                                          Itanium ABI lets a derived class reuse a
+                                          polymorphic base's tail padding (see
+                                          include/dScMgBase_c.h's size note) */
+    Particle::SysTracker mSysTracker; /* 0x47e4 */
+    u8   pad_5000[0x1c];
+    /* Constructed as a real Model in MgBounceAndPounce_Spawn.cpp
+       (_ZN5ModelC1Ev(p + 0x501c)) but NOT destroyed by ~MgBounceAndPounce --
+       measured directly: a typed `Model mModel` member here made the
+       compiler auto-generate a THIRD destructor call (Model's own D1) that
+       the ROM's actual 0x38-byte body does not have (disassembly showed
+       only two `bl`s -- SysTracker's D1, then dScMgBase_c's D2). Left as
+       raw bytes rather than asserting a destruction the ROM doesn't do;
+       same reasoning dScMgBase_c.h uses for touchIcon_0f4. */
+    u8   mModel[0x50];                /* 0x501c */
+    u8   table1_506c[0x228];          /* 0x506c -- func_020733a8(base,3,0xb8,...), elem type unevidenced */
+    u8   table2_5294[0x5a0];          /* 0x5294 -- func_020733a8(base,6,0xf0,...), elem type unevidenced */
 };
+
+typedef char MgBounceAndPounce_size_must_be_0x5834[sizeof(MgBounceAndPounce) == 0x5834 ? 1 : -1];
 
 #endif

--- a/include/dScMgBase_c.h
+++ b/include/dScMgBase_c.h
@@ -65,15 +65,20 @@ extern "C" void *data_ov004_020beb68;
 
 struct dScMgBase_c : Scene {
     /* Declared first, deliberately -- see include/Scene.h's KEY FUNCTION
-       note for why. Overrides slots 16 (D1) and 17 (D0). DEFINED INLINE so
-       every one of the 32 descendants below can inline it, the same way
-       Stage inlines Scene's. The body replaces the ROM's manual
-       `func_ov004_020b929c(c + 0xf4)` call -- see the file banner for why
-       that stays an explicit call instead of member auto-destruction. */
-    virtual ~dScMgBase_c() {
-        data_ov004_020beb68 = 0;
-        func_ov004_020b929c((char *)this + 0xf4);
-    }
+       note for why. Overrides slots 16 (D1) and 17 (D0).
+       NOT DEFINED INLINE -- unlike Scene's, which is trivial (an empty
+       body) and unconditionally inlined by every child. This body has
+       real work (a global write, a function call), and measured against
+       MgBounceAndPounce -- the first real descendant -- mwcc does NOT
+       inline it: the ROM's own MgBounceAndPounce D1 (0x38 bytes) calls
+       `_ZN11dScMgBase_cD2Ev` as a real `bl`, not a fully-inlined 0x84-byte
+       body (measured directly: compiling MgBounceAndPounce's destructor
+       against an INLINE-defined dScMgBase_c dtor produced exactly 0x84
+       bytes, `999 word(s) differ` against the ROM's 0x38). Defined for
+       real in src/_ZN11dScMgBase_cD1Ev.cpp and .../_D0Ev.cpp instead --
+       same shape Stage.h documents for a leaf, except dScMgBase_c is not
+       a leaf; its descendants simply don't inline a body this size. */
+    virtual ~dScMgBase_c();
 
     /* dScMgBase_c's own copy, for the same reason Scene has one -- see the
        file banner. Unlocks D0 for all 32 descendants below. */
@@ -135,5 +140,16 @@ struct dScMgBase_c : Scene {
     u8  pad_4648[0x14];
     u8  unk_465c;           /* 0x465c */
 };
+
+/* NOT a claim that the object ends here -- dScMgBase_c has 32 RTTI
+   descendants (notes/dscene-c-siblings-census.md), and MgBounceAndPounce
+   (one of them, real ROM class dScMgD3DBase_c) is the first to need a
+   number to start its own fields at. 0x465c is the last field any matched
+   function has observed; asserting its rounded size (0x4660, 4-byte
+   alignment) is the minimum claim that unblocks a derived class -- if it
+   is short, MgBounceAndPounce's own fields would land on the wrong bytes
+   and build_pin would catch it immediately, the same safety net
+   check_header_offsets.py's own DATA_SIZE comment describes. */
+typedef char dScMgBase_c_size_must_be_0x4660[sizeof(dScMgBase_c) == 0x4660 ? 1 : -1];
 
 #endif

--- a/notes/dscene-c-siblings-census.md
+++ b/notes/dscene-c-siblings-census.md
@@ -90,26 +90,52 @@ family, 24 of which already have generated headers waiting in `include/`:
 `dScMgHanachan_c`, `dScMgLuigi_c`, `dScMgPachinko_c`/`_2`, `dScMgPanel_c`,
 `dScMgSlot1_c`, `dScMgSmartball_c`, `dScMgTeresa_c`, `dScMgBomroom_c`, plus two
 abstract intermediates `dScMgD3DBase_c`/`dScMgSingle3DBase_c`) with 17 further
-grandchildren under those two. One direct child already has a COINED name from
-an earlier, separate pass -- `MgBounceAndPounce` (`include/MgBounceAndPounce.h`,
-still Rung 0/flat, calls dScMgBase_c's base methods as plain functions the way
-the ROM's own `bl` sequence does) -- so "32 unnamed" is the RTTI count, not
-literally every one being untouched.
+grandchildren under those two.
 
-**Naming the class itself (PR #1396) is done; naming the 32 descendants is
-still the next slice**, and the groundwork PR #1396 laid down is exactly what
-unlocks it: `dScMgBase_c` now has its own inline D2/D1 and its own
-`operator delete`, which per the same cascading rule Scene's fix documents is
-what a descendant's IMMEDIATE base must carry for the descendant's own D0/D1
-to inline. Before this PR, no child of dScMgBase_c could get a real
-destructor; now they can, the same way Stage/BootScene could only get theirs
-once Scene's was fixed. `include/dScMgBase_c.h` still leaves 18 of its own 28
-override/new-slots undeclared (slots 18-35, ~18 new virtuals beyond
-Scene/ActorBase) -- their targets are matched source but their signatures
-aren't reconstructed; three of the migrated methods reach them through the
-same local by-vtable-position stand-in the recovered sources always used.
-Reconstructing those 18 signatures is likely needed before any descendant's
-OWN overrides of the same slots can become real methods too.
+**Update (2026-08-11, PR #1398): `MgBounceAndPounce` IS `dScMgD3DBase_c`,
+one of the two abstract intermediates above -- NOT a fifteenth direct
+child, as an earlier draft of this note said.** Its coined English name
+predates understanding the hierarchy: whoever named it thought "Bounce and
+Pounce" (a real minigame) when the class it actually names is the shared
+3D-physics base for FOUR minigames (`dScMgJump_c`, `dScMgJump2_c`,
+`dScMgTrampoline_c`, `dScMgTrampoline2_c`). Confirmed two ways:
+`tools/rtti_vtables.py --own` for all 15 TRUE direct children found no
+match for its D1/D0 addresses (it isn't one of them); its own vtable
+address (ov006:0x0213c62c) matches `dScMgD3DBase_c`'s RTTI record exactly,
+and `MgBounceAndPounce_Spawn.cpp`'s construction order corroborates it
+independently -- it writes its OWN vtable mid-construction, then
+`dScMgJump_c`'s vtable (one of its four children) at the very end,
+exactly the base-then-derived order a real constructor produces. **A
+coined name can name the wrong LEVEL of a hierarchy, not just imply the
+wrong class -- don't trust one without an RTTI cross-check, even when it
+already has real matched functions.**
+
+`MgBounceAndPounce`/`dScMgD3DBase_c` is now itself real: `: dScMgBase_c`
+base, real D0/D1, own `operator delete` (unlocking D0 for its own four
+children). See [[destructor-migration-unlocks]] for a real correction
+found doing this -- dScMgBase_c's destructor had to move from
+inline-defined to declared-only-with-real-out-of-line-bodies, because
+mwcc does NOT always inline a non-trivial base destructor into a
+descendant the way it does Scene's trivial one. **This means "inline the
+base's D2/D1" is not a rule to apply blindly at the NEXT level down
+either -- check empirically each time**, the same way this correction had
+to be made for dScMgBase_c itself after Scene's fix suggested it would
+just work.
+
+**Naming the class itself (PR #1396 for dScMgBase_c, PR #1398 for
+dScMgD3DBase_c/MgBounceAndPounce) is done for two of the family; naming
+the other 30 descendants is still the open slice.** `include/dScMgBase_c.h`
+still leaves 18 of its own 28 override/new-slots undeclared (slots 18-35,
+~18 new virtuals beyond Scene/ActorBase) -- their targets are matched
+source but their signatures aren't reconstructed; three of the migrated
+methods reach them through the same local by-vtable-position stand-in the
+recovered sources always used. Reconstructing those 18 signatures is
+likely needed before any descendant's OWN overrides of the same slots can
+become real methods too. `MgBounceAndPounce`/`dScMgD3DBase_c` has its own
+9 undeclared override slots (24-31, 33) for the same reason, one level
+down. Its four real children (`dScMgJump_c` etc.) are untouched but their
+own D0/D1 already exist as matched addresses per the vtable dump -- the
+natural next slice.
 
 ## 3. A tree-wide comment defect, found here, not yet fixed anywhere
 

--- a/src/_ZN11dScMgBase_cD0Ev.cpp
+++ b/src/_ZN11dScMgBase_cD0Ev.cpp
@@ -1,10 +1,10 @@
 //cpp
 // @symbol _ZN11dScMgBase_cD0Ev
-/* Forces the deleting destructor out-of-line. Same reasoning as
-   _ZN11dScMgBase_cD1Ev.cpp; see src/_ZN5SceneD0Ev.cpp for the identical
-   pattern one level up. */
+/* Real out-of-line definition, identical body to _ZN11dScMgBase_cD1Ev.cpp
+   -- see that file's note and dScMgBase_c.h's own note. */
 #include "dScMgBase_c.h"
-void dScMgBase_c_EmitDeletingDestructor(dScMgBase_c *p)
+dScMgBase_c::~dScMgBase_c()
 {
-    delete p;
+    data_ov004_020beb68 = 0;
+    func_ov004_020b929c((char *)this + 0xf4);
 }

--- a/src/_ZN11dScMgBase_cD1Ev.cpp
+++ b/src/_ZN11dScMgBase_cD1Ev.cpp
@@ -1,12 +1,13 @@
 //cpp
 // @symbol _ZN11dScMgBase_cD1Ev
-/* Forces the complete-object destructor out-of-line. ~dScMgBase_c() is
-   defined inline in dScMgBase_c.h (its 32 descendants need to inline it the
-   same way Stage inlines Scene's) -- a bare include emits nothing here, and
-   the definition can no longer live in this file directly. See
-   src/_ZN5SceneD1Ev.cpp for the identical pattern one level up. */
+/* ~dScMgBase_c() is declared, NOT defined inline, in dScMgBase_c.h -- see
+   the header's own note. mwcc doesn't inline a body this size into a
+   descendant (measured against MgBounceAndPounce), so this is a REAL
+   out-of-line definition, same shape Stage.h uses for a leaf -- except
+   here D0Ev.cpp carries an identical copy for its own key-function TU. */
 #include "dScMgBase_c.h"
-void dScMgBase_c_EmitDestructor(dScMgBase_c *p)
+dScMgBase_c::~dScMgBase_c()
 {
-    p->~dScMgBase_c();
+    data_ov004_020beb68 = 0;
+    func_ov004_020b929c((char *)this + 0xf4);
 }

--- a/src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp
+++ b/src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp
@@ -13,6 +13,6 @@ int MgBounceAndPounce::BeforeBehavior()
 {
   if(_ZN11dScMgBase_c14BeforeBehaviorEv(((void*)this))==0) return 0;
   if(data_020a0db0 & 1)
-    _ZN8Particle10SysTracker6UpdateEv((char*)&unk_47e4);
+    _ZN8Particle10SysTracker6UpdateEv((char*)&mSysTracker);
   return 1;
 }

--- a/src/_ZN17MgBounceAndPounce18AfterInitResourcesEj.cpp
+++ b/src/_ZN17MgBounceAndPounce18AfterInitResourcesEj.cpp
@@ -6,8 +6,8 @@
 
 extern "C" int _ZN8Particle10SysTracker10InitialiseEv(void *self);
 
-int MgBounceAndPounce::AfterInitResources(unsigned int)
+void MgBounceAndPounce::AfterInitResources(unsigned int)
 {
     _ZN11dScMgBase_c18AfterInitResourcesEj(this);
-    return _ZN8Particle10SysTracker10InitialiseEv(&unk_47e4);
+    _ZN8Particle10SysTracker10InitialiseEv(&mSysTracker);
 }

--- a/src/_ZN17MgBounceAndPounce19BeforeInitResourcesEv.cpp
+++ b/src/_ZN17MgBounceAndPounce19BeforeInitResourcesEv.cpp
@@ -5,9 +5,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "MgBounceAndPounce.h"
 
-int MgBounceAndPounce::BeforeInitResources()
+bool MgBounceAndPounce::BeforeInitResources()
 {
   if(_ZN11dScMgBase_c19BeforeInitResourcesEv(((void*)this))==0) return 0;
-  *(int*)((char*)&unk_5000)=0;
+  *(int*)pad_5000=0;
   return 1;
 }

--- a/src/_ZN17MgBounceAndPounceD0Ev.cpp
+++ b/src/_ZN17MgBounceAndPounceD0Ev.cpp
@@ -1,18 +1,9 @@
 //cpp
 // @symbol _ZN17MgBounceAndPounceD0Ev
-/* recovered: named members + shared header */
+/* Forces the deleting destructor out-of-line. Same reasoning as
+   _ZN17MgBounceAndPounceD1Ev.cpp. */
 #include "MgBounceAndPounce.h"
-extern "C" {
-extern int _ZN8Particle10SysTrackerD1Ev(void*);
-extern int _ZN11dScMgBase_cD2Ev(void*);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*,void*);
-extern int _ZTV17MgBounceAndPounce[];
-extern void* data_020a0eac[];
-int _ZN17MgBounceAndPounceD0Ev(struct MgBounceAndPounce *self) {
-  *(int*)((char*)self)=(int)_ZTV17MgBounceAndPounce;
-  _ZN8Particle10SysTrackerD1Ev((char*)&self->unk_47e4);
-  _ZN11dScMgBase_cD2Ev(((char*)self));
-  _ZN6Memory10DeallocateEPvP4Heap(((char*)self),data_020a0eac[0]);
-  return (int)((char*)self);
-}
+void MgBounceAndPounce_EmitDeletingDestructor(MgBounceAndPounce *p)
+{
+    delete p;
 }

--- a/src/_ZN17MgBounceAndPounceD1Ev.cpp
+++ b/src/_ZN17MgBounceAndPounceD1Ev.cpp
@@ -1,15 +1,13 @@
 //cpp
 // @symbol _ZN17MgBounceAndPounceD1Ev
-/* recovered: named members + shared header */
+/* Forces the complete-object destructor out-of-line. ~MgBounceAndPounce()
+   is defined inline in MgBounceAndPounce.h (its four descendants need to
+   inline it the same way Stage inlines Scene's) -- a bare include emits
+   nothing here, and the definition can no longer live in this file
+   directly. See src/_ZN5SceneD1Ev.cpp / _ZN11dScMgBase_cD1Ev.cpp for the
+   identical pattern one and two levels up. */
 #include "MgBounceAndPounce.h"
-extern "C" {
-extern int _ZN8Particle10SysTrackerD1Ev(void*);
-extern int _ZN11dScMgBase_cD2Ev(void*);
-extern int _ZTV17MgBounceAndPounce[];
-int _ZN17MgBounceAndPounceD1Ev(struct MgBounceAndPounce *self) {
-  *(int*)((char*)self)=(int)_ZTV17MgBounceAndPounce;
-  _ZN8Particle10SysTrackerD1Ev((char*)&self->unk_47e4);
-  _ZN11dScMgBase_cD2Ev(((char*)self));
-  return (int)((char*)self);
-}
+void MgBounceAndPounce_EmitDestructor(MgBounceAndPounce *p)
+{
+    p->~MgBounceAndPounce();
 }


### PR DESCRIPTION
## Summary

`MgBounceAndPounce` (real ROM name `dScMgD3DBase_c`, confirmed via `tools/rtti_extract.py` — single edge to `dScMgBase_c`, and independently via `MgBounceAndPounce_Spawn.cpp`'s own construction order writing this class's vtable before one of its four descendants') gets a real `: dScMgBase_c` base, real D0/D1, and its own `operator delete` copy (unlocking D0 for its four descendants: `dScMgJump_c`, `dScMgJump2_c`, `dScMgTrampoline_c`, `dScMgTrampoline2_c`). The 6 methods already made real in PR #1396's ripple-fix were re-verified against the rebased header.

**Two compiler-behavior corrections found by measuring, not assuming:**

1. `dScMgBase_c`'s destructor was defined *inline* in PR #1396, on the theory every descendant needs to inline it (mirroring Scene's own fix). Compiling MgBounceAndPounce's destructor against that produced 0x84 bytes where the ROM has 0x38. Disassembling both sides showed why: Scene's destructor is empty and always gets inlined; dScMgBase_c's has real work (a global write, a function call) and mwcc does **not** inline a body that size into a descendant — the ROM calls `_ZN11dScMgBase_cD2Ev` as a real `bl`. Fixed by declaring (not defining) dScMgBase_c's destructor and giving it real out-of-line bodies, same shape Stage.h already uses for a leaf. dScMgBase_c's own D0/D1/D2 re-verified byte-exact after the change. **The general lesson: whether a base's destructor gets inlined is an empirical per-class question, not something to assume holds at every level once decided at the root.**
2. `Model mModel` at 0x501c (real, evidenced by placement construction in the Spawn function) made the compiler auto-generate a Model destructor call the ROM's actual bytes don't have. Left as raw bytes rather than asserting a destruction that doesn't happen — same reasoning `dScMgBase_c.h` already uses for `touchIcon_0f4`.

Fields beyond `mSysTracker`/`mModel`: two `func_020733a8`-managed tables close exactly on the class's own `ActorBase::operator new(0x5834)` literal — a third independent confirmation of the total size. `dScMgBase_c.h` also gained its first size assertion (needed for any derived class to have a starting offset — Stage.h skips this because it's a leaf, dScMgBase_c is not).

## Verification

- `build_pin.verify` byte-exact on all 5 destructor variants + all 6 methods
- `eligible.py` bracketed before/after via a clean stash-based baseline: byte-identical name list, 10816/10816 (no renames this slice)
- `rombuild.py -j16`: **106/106 exact, 100.000000% of compared bytes, 0 mismatches**
- `port_refcheck.py`: 393 references, all resolve
- `prepush_attribution.py`: 0 changed, 0 lost
- `check_header_offsets.py` before/after diff across all of `include/` — the only line that changes anywhere is `MgBounceAndPounce.h` itself

## Test plan

- [x] `build_pin.verify` on every touched/new file
- [x] `eligible.py` bracket, before/after diff (byte-identical name list)
- [x] `rombuild.py -j16` full ROM build, 106/106 exact
- [x] `port_refcheck.py` clean
- [x] `prepush_attribution.py` clean (0 changed, 0 lost)
- [x] `check_header_offsets.py` before/after diff across all of `include/`, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CDXsVxEGLHuhtdpkkn3LE