### PR TITLE
UnchainedChomp derives from Enemy, and its factory joins the build (88.00%)

### DIFF
--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -192,6 +192,7 @@ src/func_ov100_021442d4.c:
     .text start:0x021442d4 end:0x021442dc
 
 src/UnchainedChomp_Spawn.c:
+    complete
     .text start:0x021442dc end:0x021443f4
 
 src/func_ov100_021443f4.c:

--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,5 +1,5 @@
 {
- "eligible": 10817,
+ "eligible": 10819,
  "unresolved": {
   "arm9:0x02008b4c": {
    "name": "func_02008b4c",
@@ -529,13 +529,13 @@
    ]
   },
   "ov006:0x020e3578": {
-   "name": "func_ov006_020e3578",
+   "name": "_ZN14dScMgCurling_c13InitResourcesEv",
    "missing": [
     "func_020adc74"
    ]
   },
   "ov006:0x020e6894": {
-   "name": "func_ov006_020e6894",
+   "name": "_ZN15dScMgCurling2_c13InitResourcesEv",
    "missing": [
     "func_020adc74"
    ]
@@ -596,7 +596,7 @@
    ]
   },
   "ov006:0x020f3460": {
-   "name": "func_ov006_020f3460",
+   "name": "_ZN12dScMgLuigi_c13InitResourcesEv",
    "missing": [
     "func_020adc74",
     "func_020bc864",
@@ -1620,12 +1620,6 @@
    "name": "func_ov100_02142918",
    "missing": [
     "func_020ad660"
-   ]
-  },
-  "ov100:0x021442dc": {
-   "name": "UnchainedChomp_Spawn",
-   "missing": [
-    "func_020aed98"
    ]
   },
   "ov100:0x02145080": {

--- a/include/UnchainedChomp.h
+++ b/include/UnchainedChomp.h
@@ -1,64 +1,63 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class UnchainedChomp: 5 matched functions, 23 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef UNCHAINEDCHOMP_H
 #define UNCHAINEDCHOMP_H
+
 #include "types.h"
+#include "Enemy.h"
+#include "Model.h"
 #include "ModelAnim.h"
 #include "MovingCylinderClsnWithPos.h"
+#include "ShadowModel.h"
 #include "WithMeshClsn.h"
 
-struct UnchainedChomp {
-    u8  pad_000[0x8];
-    s32 mParam;            /* 0x008 */
-    u8  pad_00c[0x50];
-    s32 mPosX;            /* 0x05c */
-    s32 mPosY;            /* 0x060 */
-    s32 mPosZ;            /* 0x064 */
-    u8  pad_068[0x18];
-    s32 mScaleX;            /* 0x080 */
-    s32 mScaleY;            /* 0x084 */
-    s32 mScaleZ;            /* 0x088 */
-    u8  pad_08c[0x2];
-    s16 mAngleY;            /* 0x08e */
-    u8  pad_090[0x4];
-    s16 mPrevAngleY;            /* 0x094 */
-    u8  pad_096[0x6];
-    s32 unk_09c;            /* 0x09c */
-    s32 unk_0a0;            /* 0x0a0 */
-    u8  pad_0a4[0x6c];
-    /* MovingCylinderClsnWithPos member, named by the class's own destructor calling
-       MovingCylinderClsnWithPos's D1 at +0x110 -- a relocation the ROM build
-       checks. Was a u8 marker. [_ZN14UnchainedChompD1Ev.cpp] */
-    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;            /* 0x110 */
-    /* WithMeshClsn member, named by the class's own destructor calling
-       WithMeshClsn's D1 at +0x150 -- a relocation the ROM build
-       checks. Was a u8 marker. [_ZN14UnchainedChompD1Ev.cpp] */
-    WithMeshClsn mWithMeshClsn;            /* 0x150 */
-    /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x30c -- a relocation the ROM build
-       checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
-       ran 0x2d0 bytes PAST the end of the object; that space is not evidenced and stays
-       explicit padding rather than being folded into the member. */
-    ModelAnim mModelAnim;            /* 0x30c */
-    u8  pad_370[0x2d0];
-    u8  mShadowModel;            /* 0x640 */
-    u8  pad_641[0x6b];
-    s32 unk_6ac;            /* 0x6ac */
-    s32 unk_6b0;            /* 0x6b0 */
-    s32 unk_6b4;            /* 0x6b4 */
-    s32 unk_6b8;            /* 0x6b8 */
+/* daWanwan2_c in the ROM's RTTI. Derives from Enemy, and the destructor is an
+ * unusually strong witness because six of the nine members are ARRAYS: __destroy_arr
+ * takes a count and a stride, so it names not just the type at an offset but how many
+ * and how far apart. Six arrays tile 0x370..0x78c with no overlap and no gap:
+ *
+ *     0x370  Model       x6   stride 0x50
+ *     0x550  ShadowModel x6   stride 0x28
+ *     0x640  ShadowModel  1
+ *     0x6d8  Vector3     x6   stride 0x0c
+ *     0x720  Vector3     x6   stride 0x0c
+ *     0x768  Vector3s    x6   stride 0x06   -> ends 0x78c
+ *
+ * UnchainedChomp_Spawn constructs the same six through func_020733a8, which takes the
+ * same counts and strides, and allocates 0x7a4 -- so 0x18 of tail is spare and stays
+ * padding.
+ */
+struct UnchainedChomp : Enemy {
+    MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;  /* 0x110 */
+    WithMeshClsn        mWithMeshClsn;      /* 0x150 */
+    ModelAnim           mModelAnim;         /* 0x30c */
+    Model               mModels[6];         /* 0x370 */
+    ShadowModel         mShadowModels[6];   /* 0x550 */
+    ShadowModel         mShadowModel;       /* 0x640 */
+    /* Behavior loads a pointer from here and calls a member function through it --
+       see the note in _ZN14UnchainedChomp8BehaviorEv.cpp. */
+    void               *unk_668;            /* 0x668 */
+    u8  pad_66c[0x40];
+    s32 unk_6ac;                            /* 0x6ac */
+    s32 unk_6b0;                            /* 0x6b0 */
+    s32 unk_6b4;                            /* 0x6b4 */
+    s32 unk_6b8;                            /* 0x6b8 */
     u8  pad_6bc[0xd];
-    u8  unk_6c9;            /* 0x6c9 */
+    u8  unk_6c9;                            /* 0x6c9 */
     u8  pad_6ca[0x2];
-    s32 unk_6cc;            /* 0x6cc */
-    s32 unk_6d0;            /* 0x6d0 */
-    s32 unk_6d4;            /* 0x6d4 */
-#ifdef __cplusplus
+    s32 unk_6cc;                            /* 0x6cc */
+    s32 unk_6d0;                            /* 0x6d0 */
+    s32 unk_6d4;                            /* 0x6d4 */
+    Vector3             mUnk_6d8[6];        /* 0x6d8 */
+    Vector3             mUnk_720[6];        /* 0x720 */
+    Vector3s            mUnk_768[6];        /* 0x768 */
+    u8  pad_78c[0x18];
+
+    virtual ~UnchainedChomp();
+
     /* methods */
     int Behavior();
     int Render();
-#endif
 };
 
-#endif
+typedef char UnchainedChomp_size_must_be_0x7a4[sizeof(UnchainedChomp) == 0x7a4 ? 1 : -1];
+
+#endif /* UNCHAINEDCHOMP_H */

--- a/src/UnchainedChomp_Spawn.c
+++ b/src/UnchainedChomp_Spawn.c
@@ -1,5 +1,5 @@
 extern void *_ZN9ActorBasenwEj(unsigned int);
-extern void func_020aed98(void);
+extern void _ZN5EnemyC2Ev(void *);
 extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
 extern void _ZN12WithMeshClsnC1Ev(void *);
 extern void _ZN9ModelAnimC1Ev(void *);
@@ -18,7 +18,7 @@ void *UnchainedChomp_Spawn(void)
 {
     char *p = (char *)_ZN9ActorBasenwEj(0x7a4);
     if (p) {
-        func_020aed98();
+        _ZN5EnemyC2Ev(p);
         *(int *)p = (int)&_ZTV14UnchainedChomp;
         _ZN25MovingCylinderClsnWithPosC1Ev(p + 0x110);
         _ZN12WithMeshClsnC1Ev(p + 0x150);

--- a/src/_ZN14UnchainedChomp8BehaviorEv.cpp
+++ b/src/_ZN14UnchainedChomp8BehaviorEv.cpp
@@ -5,8 +5,16 @@
 /* recovered: named members + shared header, real C++ method */
 #include "UnchainedChomp.h"
 struct CylinderClsn;
-struct Actor;
-typedef void (Actor::*PMF)();
+/* NOT the real Actor, and deliberately not named one. This stand-in exists
+   solely to give the pointer-to-member below a representation: a PMF on a
+   non-polymorphic, single-base class is laid out differently from one on the
+   real Actor, so the shape here is codegen, not decoration. Naming it Actor
+   used to work only because this file included no header that defined the
+   real one; with UnchainedChomp.h in scope that became a redefinition, and
+   letting the PMF bind to the real Actor makes mwccarm abort with an
+   internal compiler error rather than a diagnostic. */
+struct ChompPmfSelf;
+typedef void (ChompPmfSelf::*PMF)();
 struct Holder { char pad[8]; PMF fn; };
 
 extern "C" {
@@ -30,11 +38,11 @@ extern void ApproachAngle(short *cur, short target, int step, int a, int b);
 extern unsigned char data_0209f2d8[];
 }
 
-struct Actor { char pad[0x800]; };
+struct ChompPmfSelf { char pad[0x800]; };
 
 int UnchainedChomp::Behavior()
 {
-    char *c = (char *)((Actor *)this);
+    char *c = (char *)((ChompPmfSelf *)this);
     DecIfAbove0_Short((unsigned short *)(c + 0x6ca));
     DecIfAbove0_Short((unsigned short *)(c + 0x6a8));
     if (DecIfAbove0_Short((unsigned short *)(c + 0x6a6)) != 0) {
@@ -57,7 +65,7 @@ int UnchainedChomp::Behavior()
     {
         Holder *q = *(Holder **)(c + 0x668);
         if (q->fn != 0) {
-            (((Actor *)this)->*(q->fn))();
+            (((ChompPmfSelf *)this)->*(q->fn))();
         }
     }
 

--- a/src/_ZN14UnchainedChompD0Ev.cpp
+++ b/src/_ZN14UnchainedChompD0Ev.cpp
@@ -1,6 +1,11 @@
 //cpp
 // @symbol _ZN14UnchainedChompD0Ev
-/* recovered: named members + shared header */
+/* recovered: named members + shared header
+ *
+ * Memory::Deallocate and data_020a0eac are NOT declared here. Enemy.h already
+ * declares both -- as `void` and `void *` -- and a second extern "C" declaration
+ * with a different type is not a redeclaration but an attempt to overload a
+ * C-linkage name, which mwccarm rejects outright. */
 #include "UnchainedChomp.h"
 extern "C" {
 int __destroy_arr(void*, int, int, void*);
@@ -9,12 +14,10 @@ int _ZN9ModelAnimD1Ev(void*);
 int _ZN12WithMeshClsnD1Ev(void*);
 int _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 int _ZN5EnemyD2Ev(void*);
-int _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
 extern int _ZTV14UnchainedChomp[];
 extern void _ZN8Vector3sD1Ev();
 extern void _ZN7Vector3D1Ev();
 extern void _ZN5ModelD1Ev();
-extern int data_020a0eac[];
 void* _ZN14UnchainedChompD0Ev(struct UnchainedChomp *self) {
   *(int**)((char*)self) = _ZTV14UnchainedChomp;
   __destroy_arr(((char*)self)+0x768, 6, 6, (void*)_ZN8Vector3sD1Ev);
@@ -27,7 +30,7 @@ void* _ZN14UnchainedChompD0Ev(struct UnchainedChomp *self) {
   _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
   _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
   _ZN5EnemyD2Ev(((char*)self));
-  _ZN6Memory10DeallocateEPvP4Heap(((char*)self), (void*)data_020a0eac[0]);
+  _ZN6Memory10DeallocateEPvP4Heap(((char*)self), data_020a0eac);
   return ((char*)self);
 }
 }

--- a/src/_ZN14UnchainedChompD1Ev.cpp
+++ b/src/_ZN14UnchainedChompD1Ev.cpp
@@ -1,33 +1,15 @@
 //cpp
 // @symbol _ZN14UnchainedChompD1Ev
-/* recovered: named members + shared header, declarations from a shared header */
-#include "decl_Model.h"
-#include "decl_ModelAnim.h"
-#include "decl_ShadowModel.h"
-#include "decl_WithMeshClsn.h"
-/* recovered: named members + shared header */
+/* recovered: real C++ destructor -- the compiler emits the whole body
+ *
+ * One vtable store and ten teardowns, every one a consequence of
+ * `struct UnchainedChomp : Enemy` and the members that declaration types. Six of
+ * them are arrays, and the compiler's own loops reproduce the ROM's __destroy_arr
+ * calls with the same counts and strides -- which is what makes this body the
+ * evidence for the header rather than a transcription of it.
+ */
 #include "UnchainedChomp.h"
-extern "C" void __destroy_arr(void* p, int n, int sz, void* dtor);
-extern "C" void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
-extern "C" int _ZN5EnemyD2Ev(int* x);
 
-extern int _ZTV14UnchainedChomp;
-extern "C" void _ZN8Vector3sD1Ev(void);
-extern "C" void _ZN7Vector3D1Ev(void);
-
-extern "C" void* _ZN14UnchainedChompD1Ev(char* thiz)
+UnchainedChomp::~UnchainedChomp()
 {
-    char* c = thiz;
-    *(void**)c = &_ZTV14UnchainedChomp;
-    __destroy_arr(c + 0x768, 6, 6, (void*)&_ZN8Vector3sD1Ev);
-    __destroy_arr(c + 0x720, 6, 0xc, (void*)&_ZN7Vector3D1Ev);
-    __destroy_arr(c + 0x6d8, 6, 0xc, (void*)&_ZN7Vector3D1Ev);
-    _ZN11ShadowModelD1Ev(c + 0x640);
-    __destroy_arr(c + 0x550, 6, 0x28, (void*)&_ZN11ShadowModelD1Ev);
-    __destroy_arr(c + 0x370, 6, 0x50, (void*)&_ZN5ModelD1Ev);
-    _ZN9ModelAnimD1Ev(c + 0x30c);
-    _ZN12WithMeshClsnD1Ev(c + 0x150);
-    _ZN25MovingCylinderClsnWithPosD1Ev(c + 0x110);
-    _ZN5EnemyD2Ev((int*)c);
-    return c;
 }


### PR DESCRIPTION
`UnchainedChomp` (`daWanwan2_c`) was the last flat class held back as blocked. It
derives from `Enemy` here, its destructor becomes a real one, and its factory joins the
ROM build — which takes the tree to **88.00%**.

## The destructor is the strongest layout witness in the set

Six of the nine members are **arrays**, and `__destroy_arr` takes a count and a stride —
so it names not just a type at an offset but how many and how far apart. They tile
0x370..0x78c with no overlap and no gap:

```
0x370  Model       x6   stride 0x50
0x550  ShadowModel x6   stride 0x28
0x640  ShadowModel  1
0x6d8  Vector3     x6   stride 0x0c
0x720  Vector3     x6   stride 0x0c
0x768  Vector3s    x6   stride 0x06   -> ends 0x78c
```

`UnchainedChomp_Spawn` constructs the same six through `func_020733a8` with the same
counts and strides, and allocates **0x7a4**, so 0x18 of tail stays padding. Written as
a real `~UnchainedChomp() {}`, the compiler's own array loops reproduce every one of
those calls.

## The blocker was real, but it was not what it looked like

This class was recorded as blocked on a load-bearing pointer-to-member. The shape is
real — `typedef void (Actor::*PMF)()` over `struct Actor { char pad[0x800]; }`, called
as `(((Actor *)this)->*(q->fn))()`. A PMF on a non-polymorphic single-base class is
laid out differently from one on the real polymorphic `Actor`, so completing the type
is a **codegen change, not a cleanup**, and mwccarm answers it with an *internal
compiler error* (`CClass.c line 3328`) rather than a diagnostic.

What the earlier diagnosis missed is that **the stand-in is not Actor and never was**.
It is a local stub that happened to be *named* `Actor`, which worked only while the file
included no header defining the real one. Renaming it to `ChompPmfSelf` — one identifier,
four use sites — dissolves the collision and preserves the representation exactly.
Behavior byte-matches all 0x324 bytes.

No shadow had to be deleted, and nothing had to be worked around. The fix is that a
stand-in should not borrow the name of the thing it stands in for.

## And a third phantom reference — this one had a whole function behind it

`UnchainedChomp_Spawn` called **`func_020aed98`**, which exists nowhere in the tree.
The code at that address is `_ZN5EnemyC2Ev`, the Enemy constructor every other factory
calls by name.

The function byte-matched all 0x118 bytes and had a delink entry, but `eligible.py`
refuses a file whose references it cannot resolve, so it was never enrolled and the ROM
build served the original bytes. Respelt — and given the argument the real signature
takes — the bytes are unchanged and it enrolls. That is the **+1 that crosses 88%**.

This is the third of these found recently (after `func_020ff028` in `CapEnemy::AddCap`
and five in `Spindrift::InitResources`). They share a signature worth recognising:
`match.py` wildcards every relocated word, so a byte match proves nothing about what a
call targets, and only `check_references` sees it.

## One mechanical fix

`_ZN14UnchainedChompD0Ev.cpp` declared `Memory::Deallocate` and `data_020a0eac`
locally, with `int` and `int[]` where `Enemy.h` says `void` and `void *`. A second
`extern "C"` declaration with a different type is not a redeclaration but an attempt to
overload a C-linkage name, which mwccarm rejects. Both local copies deleted; the header
already had them right.

## Verified

| gate | result |
|---|---|
| `rombuild -j16` | **106/106 exact**, 10,817 source-built, 0 mismatching |
| progress | 87.99% → **88.00%** (+280 bytes, +1 function) |
| byte matches | all **8** UnchainedChomp functions reproduce, plus the factory |
| `check_header_offsets` | 18 commented fields, 0 mismatched, spans **0x7a4** |
| `eligible.py` | **10,819** |
| `check_references` | **OK** — 238 unresolved vs baseline 239, one entry **retired** |
| `prepush_attribution` | 11,288 tracked, 0 changed, **0 lost** |
| langmode ratchet | **PASS** |
| `check_data_definitions` | 11,028 objects, none define a ROM data symbol |
| `check_duplicate_sources` | 11,282 stems, none doubled |
| `port_refcheck` | 393 references, all resolve |
| `layout_check` | clean |

The baseline commit also picks up three **name-only** refreshes
(`func_ov006_020e3578` → `_ZN14dScMgCurling_c13InitResourcesEv` and two siblings) that
reflect #1400's already-merged renames; the file simply had not been regenerated since.
No entry is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxDmkQ47fWa3GB6mj8xEQe
