### PR TITLE
Report progress as three tiers: MATCHED, CONVERTED, LINKED

### DIFF
--- a/.github/workflows/update-chaos-data.yml
+++ b/.github/workflows/update-chaos-data.yml
@@ -21,6 +21,10 @@ on:
       - "tools/chaos_db_ci.py"
       - "tools/chaosviewer.config.json"
       - "tools/langmode_audit.py"
+      # tiers.py holds the pinned CONVERTED criteria, so editing it moves a published
+      # percentage and must republish. The LINKED stamp needs no line of its own:
+      # config/** already covers config/port_linkage.json.
+      - "tools/tiers.py"
       - "attribution.json"
       # include/** and tools/langmode_audit.py are here for the langmode re-bank below,
       # which reads both; neither feeds chaos-db. The baseline itself is not listed
@@ -141,6 +145,13 @@ jobs:
         run: python tools/nearmiss_db.py dedupe
       - name: Refresh README progress bar
         run: python tools/progress.py --write-readme --from-db _chaos_data/chaos-db.json
+      - name: Refresh README tier block
+        # MATCHED here reads the same db the bar just used, so the two blocks cannot
+        # drift apart. CONVERTED is rescanned from src/. LINKED is read from the stamp
+        # in config/port_linkage.json and is deliberately NOT recomputed: it needs an
+        # MSVC port build this runner does not have. README.md is already in the
+        # refresh commit's file list below, so that needs no change.
+        run: python tools/tiers.py --write-readme --from-db _chaos_data/chaos-db.json
       - name: Regenerate treemap (README SVG + Pages HTML)
         run: python tools/treemap.py --from-db _chaos_data/chaos-db.json --out docs/index.html --svg docs/progress-treemap.svg
       - name: Commit progress refresh if changed

--- a/.github/workflows/update-chaos-data.yml
+++ b/.github/workflows/update-chaos-data.yml
@@ -5,9 +5,10 @@
 # commit per file. details/ chunks on the chaos-data branch are preserved (they need
 # the ROM; refreshed locally).
 #
-# NOTE: the push to main at the end of this job has been REJECTED since 2026-08-06 --
-# see the ssh-key comment below. Only the chaos-data half currently lands. That is why
-# langmode-baseline.json is banked there and not here.
+# The push to main was rejected between 2026-08-06 and 2026-08-07 and recovered on
+# 2026-08-08 (c23948eef); see the ssh-key comment below. Both halves land normally now.
+# langmode-baseline.json stays banked on chaos-data anyway, for the merge-conflict
+# reason given at its own step, not because this push is broken.
 name: update-chaos-data
 
 on:
@@ -60,18 +61,20 @@ jobs:
           # key. A deploy key can push; it cannot approve or merge a pull request, which
           # is the hole that closes.
           #
-          # BROKEN SINCE 2026-08-06. The paragraph above describes the intent, not the
-          # state. Ruleset "main: review gate" (id 20487553) has bypass_actors: null --
-          # the deploy key is NOT exempt -- so the push to main is rejected:
+          # This broke once and the failure mode is worth keeping. Between 2026-08-06 and
+          # 2026-08-07 the ruleset "main: review gate" (id 20487553) had bypass_actors:
+          # null, so the deploy key was NOT exempt and every push to main was rejected:
           #     GH013 ... - Changes must be made through a pull request.
-          # Every run since has failed on the last step, freezing README/treemap/
-          # contributions.json/provenance on main. contributions.json pays the DELTA
-          # between refreshes, so matches landed since then are uncredited until it lands.
+          # Every run failed on its last step, freezing README/treemap/contributions/
+          # provenance on main for two days. It went unnoticed because everything above
+          # the "Push if changed" step kept working, so the viewer stayed current while
+          # main did not. Fixed by adding a DeployKey bypass actor to that ruleset;
+          # refreshes have landed normally since 2026-08-08 (c23948eef).
           #
-          # The fix is to add a DeployKey bypass actor to that ruleset, which needs repo
-          # ADMIN; andrewboudreau has push but not admin, so it is blocked on the owner
-          # (tangosdev). Everything above the "Push if changed" step still works, which
-          # is why the viewer stayed current and this went unnoticed for two days.
+          # What made it expensive rather than cosmetic: contributions.json pays the
+          # DELTA between refreshes, so every match that landed during the outage was
+          # uncredited until the first successful refresh caught up. If this job starts
+          # failing on its last step again, check that ruleset's bypass_actors first.
           ssh-key: ${{ secrets.CHAOS_PUSH_KEY }}
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,45 @@ by module.
 For an interactive version where you can hover any function for its name, address,
 size, and status, see the [progress treemap on GitHub Pages](https://tangosdev.github.io/sm64ds-decomp/).
 
+## The three tiers
+
+The bar above measures one thing: whether the C compiles to the ROM's exact bytes.
+That is the hardest guarantee to earn and the one the project is named for, but on
+its own it overstates how finished the game is. "Done" means three separate things
+here, and they move independently.
+
+<!-- tiers:start -->
+```
+MATCHED    ██████████████████████████████  98.4%   11,209 / 11,394 functions
+CONVERTED  █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   3.8%   426 / 11,282 files
+LINKED     ████████░░░░░░░░░░░░░░░░░░░░░░  26.5%   2,975 / 11,237 matched TUs
+```
+<!-- tiers:end -->
+
+- **MATCHED** is byte-exact C, verified against the ROM. This is the bar above and
+  the treemap.
+- **CONVERTED** is code a person can read without the ROM open beside them. Matching
+  does not require readable code, so this tier does not move on its own and is by far
+  the furthest behind.
+- **LINKED** is matched code that actually reaches the [PC port](port/)'s binary,
+  replacing the host stand-in that stood there before.
+
+They are not stages of one pipeline. A function can be matched and linked while still
+being unreadable, and converting a file never changes its matched bytes.
+
+CONVERTED is strict on purpose. A file counts only if it passes all five of: a real
+function name, no raw offset arithmetic, no `unk_<off>` fields, no codegen tricks, and
+no calls through mangled names. Most of the tree is partway there rather than nowhere
+near it, which the headline alone hides: 39% of files pass three of the five, and 26%
+pass four. Run `python tools/tiers.py` for the full breakdown and two softer readings
+of the same tree.
+
+LINKED is a stamped measurement, not a live counter. It needs an MSVC build of the
+port, which CI on this branch cannot produce, so it is measured by hand and recorded
+in [config/port_linkage.json](config/port_linkage.json) with the branch and commit it
+came from. Because the port branches are not merged, it is the best single branch and
+so a floor. Reproduce it with `python port/tools/linkage.py` against a port build.
+
 ## What "matching" means
 
 The goal is source code that, when compiled with the original toolchain, produces a

--- a/config/port_linkage.json
+++ b/config/port_linkage.json
@@ -1,0 +1,25 @@
+{
+  "_comment": [
+    "The stamped LINKED tier: how many matched translation units actually reach the",
+    "PC port's binary. This is a STAMP, not a live counter, and it cannot be anything",
+    "else from main: port/tools/linkage.py reads build/port/walk_window.map, which only",
+    "exists after an MSVC build of the port, and CI on main has no such build.",
+    "",
+    "To refresh: build the port, run `python port/tools/linkage.py`, and update the",
+    "numbers below together with branch, commit and measuredAt. Never update the count",
+    "without also moving the provenance fields - tools/tiers.py drops a stamp that is",
+    "missing any of them, which is the intended behaviour for a number nobody can trace.",
+    "",
+    "basis records what the figure is a measurement OF. The port branches are not merged,",
+    "so this is the best single branch rather than a combined total: port-w4-whomp079 and",
+    "port-w4-l7cleanup sit within ~25 TUs of it with mostly DIFFERENT actors linked. The",
+    "published number is therefore a floor, and the direction of the error is known."
+  ],
+  "linkedTus": 2975,
+  "matchedTus": 11237,
+  "measuredAt": "2026-08-07",
+  "branch": "port-infra-consolidated",
+  "commit": "8dc378dcd",
+  "stale": false,
+  "basis": "single-branch floor; port branches unmerged, combined figure is higher"
+}

--- a/port/tools/linkage.py
+++ b/port/tools/linkage.py
@@ -1,0 +1,297 @@
+"""How much of the port is the real decomp, and what is still scaffolding?
+
+The goal for the port is that it IS the decompiled game: every host file under
+port/hal and port/unmatched replaced by the byte-matched translation unit it
+stands in for, step by step, until there is nothing left standing in.
+
+This measures that two ways.
+
+  headline   how many matched TUs from src/ actually reach the binary
+  queue      for every symbol a HOST file defines, whether src/ already has a
+             matched TU defining the same symbol -- those are the direct
+             replacement candidates, the work list for getting to 100%
+
+The queue is the useful half. A host file whose symbols have no matched
+counterpart is genuine host code (the ntr layer, the window, the SDAT host,
+MSVC ABI shims for register ride-throughs and pointer-to-member dispatch) and
+is not a defect. A host file whose symbols DO have matched counterparts is
+scaffolding that outlived its reason, and port_stage_a_boot is the example
+that motivated this file: a hand-written subset of Stage::InitResources, while
+Stage::InitResources sat in src/ decompiled and unlinked.
+
+NOT every queue symbol is scaffolding, though. A matched src TU that is an ARM
+asm primitive, an ARM register ride-through, an mwcc pointer-to-member dispatch,
+or a poke of DS hardware the ntr layer does not model cannot compile-and-behave
+under MSVC no matter how much wiring is added -- the host definition IS the
+faithful stand-in. Those are host-ABI EXCEPTIONS, not unknowns, and this tool
+tells them apart: a host definition carrying a `PORT_HOST_ABI:` tag in the
+comment right above it is a documented exception; one without a tag is real
+replacement work still to be understood. The headline the port drives to zero
+is the UNDOCUMENTED queue, not the raw one.
+
+    python port/tools/linkage.py [repo-root] [--queue] [--exceptions]
+
+  --queue        list every queue symbol with its matched source
+  --exceptions   also print the documented host-ABI exceptions and their reasons
+"""
+import os
+import re
+import sys
+
+HOST_DIRS = ("hal", "unmatched")
+
+# Directories a host object's source may live in, most specific first. fs.cpp
+# exists under both hal/ and ntr/; the queue's plain `fs.cpp.obj` is the hal one
+# and the ntr copy is namespaced (`ntr_2x:runtime.cpp.obj`), so hal wins here.
+HOST_SRC_DIRS = ("port/hal", "port/hal/sdat", "port/unmatched", "port/ntr",
+                 "port/tests")
+
+# A host definition is a documented host-ABI exception when the comment block
+# right above it carries this tag. The text after the colon is the reason;
+# trailing comment punctuation (*/) is stripped off.
+ABI_TAG = re.compile(r"PORT_HOST_ABI:\s*(.+?)\s*(?:\*/\s*)?$")
+
+
+def host_source_for(root, obj):
+    """Resolve a host .obj name to its source file, or None."""
+    # obj is like `cxx_aliases.cpp.obj` or `ntr_2x:runtime.cpp.obj`.
+    base = obj.split(":", 1)[-1]
+    stem = os.path.splitext(os.path.splitext(base)[0])[0]
+    for d in HOST_SRC_DIRS:
+        for ext in (".cpp", ".c"):
+            p = os.path.join(root, d, stem + ext)
+            if os.path.exists(p):
+                return p
+    return None
+
+
+IDENT = re.compile(r"[A-Za-z_]\w*")
+# Type/keyword tokens that share a definition line with the real symbol name.
+_SKIP_IDENT = {"extern", "static", "void", "int", "unsigned", "char", "short",
+               "long", "const", "signed", "struct", "return", "if", "for",
+               "while", "C"}
+
+
+def _is_comment_or_blank(stripped, in_block):
+    """(is_comment_or_blank, new_in_block) for a stripped source line."""
+    if stripped == "":
+        return True, in_block
+    if in_block:
+        # inside /* ... */; the block ends on the line carrying */
+        return True, (not stripped.endswith("*/"))
+    if stripped.startswith("//"):
+        return True, False
+    if stripped.startswith("/*"):
+        # a /* ... */ opener; stays open unless it also closes on this line
+        return True, (not stripped.endswith("*/"))
+    if stripped.startswith("*"):
+        return True, in_block
+    return False, in_block
+
+
+def _reasons_in(source_path):
+    """{symbol: reason} for every PORT_HOST_ABI tag in a host source file.
+
+    A tag documents the DEFINITION right below it. The reason binds to every
+    identifier on the first real code line after the tag -- skipping the rest of
+    the comment block, tracking /* ... */ state so a wrapped prose line does not
+    look like code. The definition may be `extern "C" void foo(...)`, a pointer
+    return `void *foo(...)`, or a plain method; the caller only ever asks about
+    names that are real queue symbols, so recording every identifier is safe.
+    """
+    try:
+        with open(source_path, errors="replace") as f:
+            lines = f.readlines()
+    except (OSError, TypeError):
+        return {}
+    out = {}
+    for i, line in enumerate(lines):
+        m = ABI_TAG.search(line)
+        if not m:
+            continue
+        reason = m.group(1)
+        # Is this tag line itself the tail of an open /* block? Find out by
+        # scanning down for the first genuine code line.
+        in_block = line.strip().startswith(("/*", "*")) and not line.strip().endswith("*/")
+        # If the tag is on a `// ...` line, no block is open.
+        if line.strip().startswith("//"):
+            in_block = False
+        j = i + 1
+        # Bind the reason to every identifier from the tag down to the end of
+        # the definition it documents. `func_02059824`'s definition is preceded
+        # by a forward-declaration of the body it calls, and several tags sit
+        # above a prototype line before the real definition; collecting the
+        # whole run to the opening `{` (or the closing `;` of a one-line body)
+        # catches the real symbol whichever line carries it. Extra prototype
+        # names are harmless -- the caller only ever asks about queue symbols.
+        # A blank line or a new comment block ends the run (the next tagged def).
+        run = 0
+        while j < len(lines) and run < 12:
+            st = lines[j].strip()
+            is_c, in_block = _is_comment_or_blank(st, in_block)
+            if is_c:
+                if st == "" and not in_block:
+                    break
+                j += 1
+                continue
+            for name in IDENT.findall(lines[j]):
+                if name not in _SKIP_IDENT:
+                    out.setdefault(name, reason)
+                    # /alternatename pragmas carry the MSVC `_` prefix the
+                    # map parser strips; bind the stripped form too so a tag
+                    # above an alias documents the symbol the queue asks for.
+                    out.setdefault(name.lstrip("_"), reason)
+            # A `{` opens the definition body -- stop here. A line ending in `;`
+            # is a forward-declaration/prototype the definition sits below;
+            # keep going. `}` closes a one-line body -- stop.
+            if "{" in st or st.endswith("}"):
+                break
+            j += 1
+            run += 1
+    return out
+
+
+_REASON_CACHE = {}
+
+
+def abi_reason(source_path, sym):
+    """The PORT_HOST_ABI reason tagged above sym's definition, or None."""
+    if not source_path:
+        return None
+    reasons = _REASON_CACHE.get(source_path)
+    if reasons is None:
+        reasons = _reasons_in(source_path)
+        _REASON_CACHE[source_path] = reasons
+    return reasons.get(sym)
+
+
+def matched_index(root):
+    """{symbol stem: repo-relative src path} for every matched TU."""
+    out = {}
+    for dirpath, _d, files in os.walk(os.path.join(root, "src")):
+        for fn in files:
+            if fn.endswith((".c", ".cpp")):
+                stem = os.path.splitext(fn)[0]
+                rel = os.path.relpath(os.path.join(dirpath, fn), root)
+                out.setdefault(stem, rel.replace("\\", "/"))
+    return out
+
+
+def map_symbols(mapfile):
+    """[(symbol, objfile)] out of an MSVC /MAP."""
+    out = []
+    with open(mapfile, errors="replace") as f:
+        for line in f:
+            # The flag column between the RVA and the object is `f`, `f i`, or
+            # absent (data rows). A bare \S* placeholder backtracks into the
+            # object name on flagless rows and truncates `ov010_syms.c.obj`
+            # to `c.obj`, so spell the flags out and anchor the object at EOL.
+            m = re.match(
+                r"\s+[0-9a-fA-F]{4}:[0-9a-fA-F]{8}\s+(\S+)\s+[0-9a-fA-F]{8}\s+(?:[fi]\s+)*(\S+\.obj)\s*$",
+                line)
+            if m:
+                out.append((m.group(1).lstrip("_"), m.group(2)))
+    return out
+
+
+def main():
+    positional = [a for a in sys.argv[1:] if not a.startswith("--")]
+    root = positional[0] if positional else "."
+    show_queue = "--queue" in sys.argv
+    show_exceptions = "--exceptions" in sys.argv
+
+    mapfile = os.path.join(root, "build", "port", "walk_window.map")
+    if not os.path.exists(mapfile):
+        print("no %s -- build walk_window first" % mapfile)
+        return 2
+
+    matched = matched_index(root)
+    syms = map_symbols(mapfile)
+
+    linked_stems = set()
+    host_hits = {}
+    for sym, obj in syms:
+        stem = os.path.splitext(os.path.splitext(obj)[0])[0]
+        if stem in matched:
+            linked_stems.add(stem)
+        # a host object is one whose name is not itself a matched TU
+        if stem not in matched and sym in matched:
+            host_hits.setdefault(obj, set()).add(sym)
+
+    total = len(matched)
+    linked = len(linked_stems)
+    print("matched TUs in src/        : %d" % total)
+    print("linked into walk_window    : %d  (%.1f%%)" % (linked, 100.0 * linked / total))
+    print("still unlinked             : %d" % (total - linked))
+    print()
+
+    if not host_hits:
+        print("no host object defines a symbol that src/ also has. Nothing to replace.")
+        return 0
+
+    # Split each host object's symbols into documented host-ABI exceptions
+    # (a PORT_HOST_ABI tag sits above the definition) and undocumented ones.
+    src_cache = {}
+    documented = {}    # obj -> {sym: reason}
+    undocumented = {}  # obj -> set(sym)
+    for obj, s in host_hits.items():
+        source = src_cache.get(obj)
+        if source is None:
+            source = host_source_for(root, obj)
+            if source is None:
+                # A host object with no source under the host dirs is a
+                # generated seat (ovNNN_syms.c.obj). The only way a matched
+                # TU's name lands in one is an /alternatename alias, and
+                # cxx_aliases.cpp is the alias registry -- read the reason
+                # from the tag above the alias.
+                source = os.path.join(root, "port", "hal", "cxx_aliases.cpp")
+            src_cache[obj] = source
+        for sym in s:
+            reason = abi_reason(source, sym)
+            if reason:
+                documented.setdefault(obj, {})[sym] = reason
+            else:
+                undocumented.setdefault(obj, set()).add(sym)
+
+    n_all = sum(len(v) for v in host_hits.values())
+    n_doc = sum(len(v) for v in documented.values())
+    n_undoc = sum(len(v) for v in undocumented.values())
+
+    print("REPLACEMENT QUEUE: %d symbols across %d host objects are defined by a"
+          % (n_all, len(host_hits)))
+    print("host file while src/ carries a matched TU of the same name. Of those,")
+    print("  %d are documented host-ABI exceptions (asm primitives, register"
+          % n_doc)
+    print("     ride-throughs, mwcc pointer-to-member, unmodelled DS hardware)")
+    print("  %d are undocumented -- the real replacement work" % n_undoc)
+    print()
+
+    # The undocumented queue is the work list.
+    if undocumented:
+        print("UNDOCUMENTED QUEUE (%d):" % n_undoc)
+        for obj, s in sorted(undocumented.items(), key=lambda kv: -len(kv[1])):
+            print("  %-40s %d symbol(s)" % (obj, len(s)))
+            if show_queue:
+                for sym in sorted(s):
+                    print("        %-46s %s" % (sym, matched[sym]))
+    else:
+        print("UNDOCUMENTED QUEUE (0): every queue symbol is a documented")
+        print("host-ABI exception. The only way to shrink it further is a")
+        print("toolchain that can run the ROM's ARM asm and hardware pokes.")
+
+    if show_exceptions:
+        print()
+        print("DOCUMENTED HOST-ABI EXCEPTIONS (%d):" % n_doc)
+        for obj, d in sorted(documented.items(), key=lambda kv: -len(kv[1])):
+            print("  %-40s %d symbol(s)" % (obj, len(d)))
+            for sym in sorted(d):
+                print("        %-30s %s" % (sym, d[sym]))
+
+    if not show_queue and not show_exceptions:
+        print()
+        print("re-run with --queue for sources, --exceptions for the reasons")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -34,6 +34,43 @@ sys.path.insert(0, str(REPO / "tools"))
 import asm_policy  # noqa: E402
 import srcpath as SP  # noqa: E402
 import relocs as RL  # noqa: E402
+import tiers as TIERS  # noqa: E402
+
+
+def tier_stats():
+    """The CONVERTED and LINKED tiers, flattened for the stats block.
+
+    Flat rather than nested because the two consumers downstream are a shell
+    script's python one-liner and a C# record, and neither gains anything from
+    nesting. MATCHED is not repeated here; it is already the block above.
+
+    Never raises. This runs inside the generator whose output pays the coin
+    ledger, and a readability scan is not worth killing a refresh over -- a run
+    that dies here would leave contributions.json unmoved and every match landed
+    since the last refresh uncredited. On failure the key is simply absent, and
+    the site falls back to showing MATCHED alone.
+    """
+    try:
+        c = TIERS.converted()
+        k = TIERS.linked()
+    except Exception as e:  # noqa: BLE001 - see docstring
+        print(f"  tiers: SKIPPED ({e})")
+        return None
+    out = {
+        "converted": c["converted"],
+        "convertedOf": c["files"],
+        "convertedPct": c["pct"],
+    }
+    if k:
+        out.update({
+            "linked": k["linked"],
+            "linkedOf": k["matchedTus"],
+            "linkedPct": k["pct"],
+            "linkedMeasuredAt": k["measuredAt"],
+            "linkedBranch": k["branch"],
+            "linkedCommit": k["commit"],
+        })
+    return out
 
 FUNC_RE = re.compile(
     r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
@@ -446,6 +483,13 @@ def main():
             "totalBytes": total_b,
             "matchedBytes": matched_b,
             "moduleCount": len({f["module"] for f in functions}),
+            # The other two tiers ride along here so every consumer reads ONE file.
+            # romstats-sync.sh on the VPS fetches this db and nothing else, and the
+            # backend stores what it is told rather than walking any repository, so a
+            # tier that is not in this block does not reach the site at all. Both are
+            # computed from committed source with no ROM and no build, which is what
+            # keeps this generator CI-safe.
+            "tiers": tier_stats(),
         },
         "functions": functions,
     }

--- a/tools/tiers.py
+++ b/tools/tiers.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""The three tiers: how much of the game is MATCHED, CONVERTED, and LINKED.
+
+One percentage cannot describe this project, because "done" means three
+different things and they move independently:
+
+  MATCHED    the C compiles to the ROM's exact bytes. Provably the original
+             logic. This is the number the README bar and the treemap show.
+  CONVERTED  a person can read that C without the ROM open next to them.
+             Matching does not require readable code, so this tier lags far
+             behind MATCHED and does not move on its own.
+  LINKED     the matched translation unit actually reaches the PC port's
+             binary, replacing the host stand-in that was there before.
+
+They are deliberately not a funnel: a function can be MATCHED and LINKED while
+still being unreadable, and CONVERTED work never changes the matched bytes.
+Reporting only MATCHED overstates how finished the project is, which is the
+whole reason this file exists.
+
+Denominators differ and that is not a bug. MATCHED counts functions against the
+dsd config's function universe. CONVERTED counts source FILES, because
+readability is a property of a file. The tree is close to one function per file
+(11,282 files against 11,394 functions), so the two read on the same scale
+without adjusting, but they are not the same denominator and the JSON says so.
+LINKED counts matched translation units, not all functions.
+
+Usage:
+    python tools/tiers.py                 # human-readable table
+    python tools/tiers.py --json          # machine-readable, for chaos-db
+    python tools/tiers.py --write-readme  # rewrite the block in README.md
+
+MATCHED is read from chaos-db.json when it is present, which is the same file
+the README bar and treemap read, so every surface reports one number. Without
+it, the tiers that need no ROM are still reported and MATCHED is omitted rather
+than guessed.
+"""
+import json
+import os
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+README = REPO / "README.md"
+README_START = "<!-- tiers:start -->"
+README_END = "<!-- tiers:end -->"
+LINKED_STAMP = REPO / "config" / "port_linkage.json"
+
+
+# ---------------------------------------------------------------- CONVERTED
+#
+# Five independent checks, each one a thing a reader needs. A file is CONVERTED
+# only if it passes all five. These regexes are the pinned definition of the
+# tier: changing one silently redefines the published percentage, so change them
+# in a PR that says what moved and why, never as a drive-by.
+#
+# The bar was set on 2026-08-07 and is deliberately strict. Softer readings were
+# considered and rejected: "includes a shared header" scores 28.9% but measures
+# include hygiene rather than readability, and dropping to the two criteria that
+# actually block a reader scores 6.6%. Both are reported below the headline so
+# the strictness is visible instead of being an unexplained low number.
+
+# The symbol this file exists to produce. The `@symbol` marker names it where
+# present; otherwise the filename stem is the same name by construction.
+SYMBOL = re.compile(r"//\s*@symbol\s+(\S+)")
+PLACEHOLDER = re.compile(r"^func_(ov\d+_)?0[0-9a-f]{7}$")
+MANGLED = re.compile(r"^_Z[0-9NK]")
+
+# Raw object-layout arithmetic: a cast-and-offset into an object, in the forms
+# the tree actually uses. The single biggest thing holding this tier down.
+RAW_OFFSET = re.compile(r"""
+    \(\s*(?:unsigned\s+|signed\s+)?\w+\s*\*\s*\)\s*\(\s*\w+\s*\+\s*0x   # *(u32*)(c + 0x74)
+  | \(\s*char\s*\*\s*\)\s*[\w\)\(]+\s*\+\s*0x                            # (char*)self + 0x74
+""", re.VERBOSE)
+UNK_FIELD = re.compile(r"\bunk_[0-9a-fA-F]+\b")
+
+# Codegen steering that exists only to make the compiler emit given bytes.
+LAUNDER = re.compile(r"&\s*0xFFFFFFFFFFFFFFFF")
+VOLATILE = re.compile(r"\bvolatile\b")
+ASM = re.compile(r"\b(__asm|asm\s*\()")
+
+# A call to another function under its mangled name: readable code calls
+# Player::SpinBounce, not _ZN6Player10SpinBounceE5Fix12IiE.
+MANGLED_REF = re.compile(r"\b_Z[0-9NK]\w+")
+SHARED_HEADER = re.compile(r'#include\s+"(decl_|common\.h|[A-Z])')
+
+CRITERIA = ("real_name", "no_raw_offset", "no_unk_field", "no_codegen_trick",
+            "no_mangled_refs")
+CRITERION_LABEL = {
+    "real_name": "Real function name (not func_<addr> or _Z...)",
+    "no_raw_offset": "No raw offset arithmetic (*(u32*)(c + 0x74))",
+    "no_unk_field": "No unk_<off> fields",
+    "no_codegen_trick": "No codegen tricks (launder mask, volatile, asm)",
+    "no_mangled_refs": "Calls things by real names, not mangled _Z",
+}
+
+
+def _defined_symbol(path, text):
+    m = SYMBOL.search(text)
+    if m:
+        return m.group(1)
+    return os.path.splitext(os.path.basename(path))[0]
+
+
+def score_file(path, text):
+    """The five criteria for one source file, plus the header reading."""
+    sym = _defined_symbol(path, text)
+    return {
+        "real_name": not (PLACEHOLDER.match(sym) or MANGLED.match(sym)),
+        "no_raw_offset": not RAW_OFFSET.search(text),
+        "no_unk_field": not UNK_FIELD.search(text),
+        "no_codegen_trick": not (LAUNDER.search(text) or VOLATILE.search(text)
+                                 or ASM.search(text)),
+        "no_mangled_refs": not MANGLED_REF.search(text),
+        "shared_header": bool(SHARED_HEADER.search(text)),
+    }
+
+
+def converted(src_root=None):
+    """Score every source file. Returns the CONVERTED tier plus its breakdown.
+
+    Reads committed source only - no ROM, no build, no local state - so it
+    reproduces on a fresh checkout, which is what CI needs.
+    """
+    root = pathlib.Path(src_root or SRC)
+    files = sorted(str(p) for p in root.rglob("*")
+                   if p.suffix in (".c", ".cpp") and p.is_file())
+    counts = dict.fromkeys(list(CRITERIA) + ["shared_header"], 0)
+    passes_hist = {}
+    readable = core = 0
+
+    for p in files:
+        with open(p, errors="replace") as f:
+            s = score_file(p, f.read())
+        for k in counts:
+            counts[k] += s[k]
+        n_pass = sum(s[k] for k in CRITERIA)
+        passes_hist[n_pass] = passes_hist.get(n_pass, 0) + 1
+        if n_pass == len(CRITERIA):
+            readable += 1
+        # The two criteria that genuinely block a reader, reported as context
+        # for how strict the headline is.
+        if s["real_name"] and s["no_raw_offset"]:
+            core += 1
+
+    total = len(files)
+    return {
+        "files": total,
+        "converted": readable,
+        "pct": round(100.0 * readable / total, 2) if total else 0.0,
+        "criteria": {k: counts[k] for k in CRITERIA},
+        "distribution": {str(k): passes_hist.get(k, 0)
+                         for k in range(len(CRITERIA) + 1)},
+        "alt_core_two": core,
+        "alt_shared_header": counts["shared_header"],
+    }
+
+
+# ------------------------------------------------------------------- LINKED
+#
+# LINKED cannot be computed here and must not pretend otherwise. port/tools/
+# linkage.py reads build/port/walk_window.map, which only exists after an MSVC
+# build of the port, and the port branches are not merged to main. So the number
+# is STAMPED: measured by hand, recorded with the branch and commit it came from,
+# and refreshed when someone runs a port build.
+#
+# A stamp with no provenance is worse than no number, so a stamp missing its
+# branch/commit/date is treated as absent.
+
+
+def linked(stamp_path=None):
+    """The stamped LINKED measurement, or None if there is no usable stamp."""
+    p = pathlib.Path(stamp_path or LINKED_STAMP)
+    if not p.is_file():
+        return None
+    try:
+        d = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not all(d.get(k) for k in ("measuredAt", "branch", "commit")):
+        return None
+    tot = d.get("matchedTus") or 0
+    got = d.get("linkedTus") or 0
+    if not tot:
+        return None
+    return {
+        "linked": got,
+        "matchedTus": tot,
+        "pct": round(100.0 * got / tot, 2),
+        "measuredAt": d["measuredAt"],
+        "branch": d["branch"],
+        "commit": d["commit"],
+        "stale": bool(d.get("stale", False)),
+    }
+
+
+# ------------------------------------------------------------------ MATCHED
+
+
+def matched(db_path=None):
+    """MATCHED from chaos-db.json, the file the bar and treemap also read.
+
+    Returns None when the db is absent rather than recomputing it: a second
+    implementation of the matched rule is a second source of truth, and this
+    repo has already paid for one of those (the itcm undercount).
+    """
+    p = pathlib.Path(db_path) if db_path else (REPO / "chaos-db.json")
+    if not p.is_file():
+        return None
+    try:
+        db = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    st = db.get("stats") or {}
+    tot, got = st.get("totalFunctions"), st.get("matchedFunctions")
+    if not tot:
+        return None
+    return {
+        "matched": got,
+        "functions": tot,
+        "pct": round(100.0 * got / tot, 2),
+        "matchedBytes": st.get("matchedBytes"),
+        "totalBytes": st.get("totalBytes"),
+        "bytePct": (round(100.0 * st["matchedBytes"] / st["totalBytes"], 2)
+                    if st.get("totalBytes") else None),
+    }
+
+
+# ------------------------------------------------------------------- output
+
+
+def collect(db_path=None):
+    return {"matched": matched(db_path), "converted": converted(), "linked": linked()}
+
+
+def bar(done, tot, width=30):
+    filled = round(done / tot * width) if tot else 0
+    if done and filled == 0:
+        filled = 1
+    return "█" * filled + "░" * (width - filled)
+
+
+def bar_block(t):
+    """The fenced block shown under the README "## The three tiers" heading."""
+    rows = []
+    m, c, k = t["matched"], t["converted"], t["linked"]
+    if m:
+        rows.append(f"MATCHED    {bar(m['matched'], m['functions'])}  "
+                    f"{m['pct']:4.1f}%   {m['matched']:,} / {m['functions']:,} functions")
+    rows.append(f"CONVERTED  {bar(c['converted'], c['files'])}  "
+                f"{c['pct']:4.1f}%   {c['converted']:,} / {c['files']:,} files")
+    if k:
+        rows.append(f"LINKED     {bar(k['linked'], k['matchedTus'])}  "
+                    f"{k['pct']:4.1f}%   {k['linked']:,} / {k['matchedTus']:,} matched TUs")
+    return "```\n" + "\n".join(rows) + "\n```"
+
+
+def write_readme(t):
+    text = README.read_text(encoding="utf-8")
+    start = text.index(README_START) + len(README_START)
+    end = text.index(README_END)
+    new_text = text[:start] + "\n" + bar_block(t) + "\n" + text[end:]
+    if new_text != text:
+        README.write_text(new_text, encoding="utf-8")
+        return True
+    return False
+
+
+def report(t):
+    m, c, k = t["matched"], t["converted"], t["linked"]
+    out = []
+    if m:
+        out.append(f"MATCHED    {m['matched']:,} / {m['functions']:,} functions  "
+                   f"{m['pct']:.1f}%   ({m['bytePct']:.1f}% by code bytes)")
+    else:
+        out.append("MATCHED    (no chaos-db.json; run tools/chaos_db_ci.py first)")
+    out.append(f"CONVERTED  {c['converted']:,} / {c['files']:,} files      {c['pct']:.1f}%")
+    if k:
+        flag = "  STALE" if k["stale"] else ""
+        out.append(f"LINKED     {k['linked']:,} / {k['matchedTus']:,} matched TUs  "
+                   f"{k['pct']:.1f}%   (stamped {k['measuredAt']} from {k['branch']}"
+                   f" @ {k['commit']}){flag}")
+    else:
+        out.append("LINKED     (no usable stamp in config/port_linkage.json)")
+
+    out.append("")
+    out.append("CONVERTED breaks down as:")
+    for key in CRITERIA:
+        n = c["criteria"][key]
+        out.append(f"  {CRITERION_LABEL[key]:<52} {n:>6,}  {100.0*n/c['files']:5.1f}%")
+    out.append(f"  {'ALL FIVE':<52} {c['converted']:>6,}  {c['pct']:5.1f}%")
+    out.append("")
+    out.append("Criteria passed, distribution:")
+    for i in range(len(CRITERIA) + 1):
+        n = c["distribution"][str(i)]
+        out.append(f"  {i}/5 : {n:>6,}  ({100.0*n/c['files']:.1f}%)")
+    out.append("")
+    out.append("Other readings of the same tree, for context on how strict the bar is:")
+    out.append(f"  name + no raw offsets only : {c['alt_core_two']:>6,}  "
+               f"({100.0*c['alt_core_two']/c['files']:.1f}%)")
+    out.append(f"  includes a shared header   : {c['alt_shared_header']:>6,}  "
+               f"({100.0*c['alt_shared_header']/c['files']:.1f}%)")
+    return "\n".join(out)
+
+
+def main():
+    db = None
+    if "--from-db" in sys.argv:
+        i = sys.argv.index("--from-db")
+        if i + 1 < len(sys.argv):
+            db = sys.argv[i + 1]
+    t = collect(db)
+
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+    if "--json" in sys.argv:
+        print(json.dumps(t, indent=2))
+        return
+    if "--write-readme" in sys.argv:
+        print(f"README.md {'updated' if write_readme(t) else 'already up to date'}")
+        return
+    if "--bar" in sys.argv:
+        print(bar_block(t))
+        return
+    print(report(t))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
One percentage cannot describe this project. "Done" means three things that move
independently, and publishing only the byte-match number overstates how finished
the game is.

```
MATCHED    ██████████████████████████████  98.4%   11,209 / 11,394 functions
CONVERTED  █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   3.8%   426 / 11,282 files
LINKED     ████████░░░░░░░░░░░░░░░░░░░░░░  26.5%   2,975 / 11,237 matched TUs
```

They are not a funnel. A function can be matched and linked while still being
unreadable, and converting a file never changes its matched bytes.

## What's here

`tools/tiers.py` measures all three, with a README block, `--json`, and a full
breakdown on stdout.

**MATCHED** is read from `chaos-db.json`, not recomputed. A second implementation
of the matched rule is a second source of truth, and this repo has already paid
for one of those.

**CONVERTED** is a scan of committed source: no ROM, no build, reproduces on a
fresh checkout. Five criteria, all of which must pass: a real function name, no
raw offset arithmetic, no `unk_<off>` fields, no codegen tricks, no calls through
mangled names. They are pinned in `tools/tiers.py` and the workflow watches that
file, because editing a criterion moves a published percentage.

The 3.8% is strict on purpose, and the strictness is reported rather than hidden.
Two softer readings of the same tree score 6.6% and 28.9%, and both print under
the headline along with the distribution:

| criteria passed | files | share |
|---|---|---|
| 0 of 5 | 19 | 0.2% |
| 1 of 5 | 528 | 4.7% |
| 2 of 5 | 2,994 | 26.5% |
| 3 of 5 | 4,404 | 39.0% |
| 4 of 5 | 2,911 | 25.8% |
| **5 of 5** | **426** | **3.8%** |

Most of the tree is partway there rather than nowhere near it. The two things
holding it down are raw offset arithmetic (47% of files still have it) and
mangled call names (53% still have them).

**LINKED** cannot be computed from main at all. `port/tools/linkage.py` reads
`build/port/walk_window.map`, which needs an MSVC build of the port. So it is a
stamp in `config/port_linkage.json` carrying the branch, commit and date it came
from, and `tiers.py` drops a stamp missing any of those rather than publish a
number nobody can trace. Because the port branches are unmerged this is the best
single branch, so it is a floor and the direction of the error is known.

`port/tools/linkage.py` is lifted unchanged from `port-infra-consolidated`
(`8dc378dcd`, identical blob) so the tool behind the number is public.

## How it reaches the site

The tiers ride in `chaos-db.json`'s `stats` block, which is the one file
`romstats-sync.sh` fetches. Nothing in the backend walks this repository; it
stores what it is told, which is the rule `docs/architecture.md` sets over there.

`tier_stats()` never raises. That generator's output pays the coin ledger, and a
readability scan is not worth killing a refresh over. On failure the key is
absent and the site shows MATCHED alone.

## Second commit

`update-chaos-data.yml` carried a prominent note saying the refresh push to main
had been rejected since 2026-08-06 and only the chaos-data half was landing. That
stopped being true on 2026-08-08 (`c23948eef`); refreshes have landed every day
since (38 on the 8th, 47 on the 9th, 33 on the 10th). Corrected, keeping the
outage as history because the failure mode is the useful part: the job fails only
on its last step, so the viewer stays current while main freezes.

## Checks

- `tools/check_python_names.py`: PASS, 0 unresolvable, advisories unchanged at 32
- `tools/tiers.py --write-readme` is idempotent, and the committed block is
  byte-identical to what it generates
- `tools/chaos_db_ci.py` runs end to end and emits the block; function and byte
  counts are unchanged from before this PR
