### PR TITLE
prepush_attribution: replay renames in order instead of composing them

### DIFF
--- a/tools/prepush_attribution.py
+++ b/tools/prepush_attribution.py
@@ -129,8 +129,8 @@ def renames_between(base, head):
     reported as changed rather than waved through. Verified by rewriting and moving
     a file in one commit: still 1 lost, still exit 1.
 
-    Renames are collected **per commit and then composed**, not from one base..head
-    diff. That matters for exactly the sequence THE RULE prescribes: rewrite in one
+    Renames are collected **per commit and returned in order**, not from one
+    base..head diff, and are replayed rather than composed -- see project(). That matters for exactly the sequence THE RULE prescribes: rewrite in one
     commit, move in the next. Across the whole range those two show up as a single
     change whose similarity can fall under git's 50% threshold -- which it did for 3
     of 8 real cases, the small files whose comments were rewritten most. Per commit,
@@ -150,17 +150,39 @@ def renames_between(base, head):
             if old != new:
                 steps.append((old, new))
 
-    # Compose chains so A->B->C reports A->C, and stop on cycles defensively.
-    out = {}
+    return steps
+
+
+def project(before_by_name, steps):
+    """Replay `steps` in COMMIT ORDER onto a moving {name: credit} map.
+
+    This used to compose the steps into a single {old: final} map and chase it
+    forward, which is right for a file that really moved A -> B -> C over time and
+    WRONG for a permutation. Renaming a family of classes so each takes the next
+    one's name produces, in this order:
+
+        commit 1   VirtualDoor -> Exit
+        commit 3   CameraTag   -> VirtualDoor
+
+    Chased forward, those compose to `CameraTag -> Exit`: the map says CameraTag's
+    credit ended up on Exit, when Exit's credit is VirtualDoor's and CameraTag's is
+    on VirtualDoor. Every name in the cycle then reads as CREDIT CHANGED even though
+    git recorded an R100 for each step and no author lost anything. Order is the
+    whole point -- step 2 only means what it means because step 1 already vacated
+    the name.
+
+    Replaying is also strictly stricter than composing, not looser: a rewrite-and-
+    move in one commit is still not a rename to git, so it contributes no step, the
+    old name is still projected as present, and it is still reported lost.
+    """
+    state = dict(before_by_name)
+    origin = {name: name for name in state}
     for old, new in steps:
-        out[old] = new
-    for start in list(out):
-        seen, cur = {start}, out[start]
-        while cur in out and cur not in seen:
-            seen.add(cur)
-            cur = out[cur]
-        out[start] = cur
-    return out
+        if old not in state:
+            continue
+        state[new] = state.pop(old)
+        origin[new] = origin.pop(old, old)
+    return state, origin
 
 
 def main():
@@ -184,32 +206,28 @@ def main():
     before_by_name = {basename_key(s): (s, w) for s, w in before.items()}
     after_by_name = {basename_key(s): (s, w) for s, w in after.items()}
 
-    renamed = renames_between(args.base, args.head)
+    steps = renames_between(args.base, args.head)
+    # Where each name's credit SHOULD have ended up, following git's own rename
+    # detection step by step. Comparing `after` against this instead of against
+    # `before` is what lets a deliberate symbol correction pass while a
+    # rewrite-and-move in one commit still fails.
+    projected, origin = project(before_by_name, steps)
 
     changed, lost, moved_ok, renamed_ok = [], [], [], []
     for name, (new_stem, new_who) in after_by_name.items():
-        if name not in before_by_name:
+        if name not in projected:
             continue                                   # genuinely new work
-        old_stem, old_who = before_by_name[name]
+        old_stem, old_who = projected[name]
+        came_from = origin.get(name, name)
         if old_who != new_who:
             changed.append((name, old_stem, new_stem, old_who, new_who))
+        elif came_from != name:
+            renamed_ok.append((came_from, name, old_stem, new_stem, old_who))
         elif old_stem != new_stem:
             moved_ok.append((name, old_stem, new_stem, old_who))
-    for name, (old_stem, old_who) in before_by_name.items():
-        if name in after_by_name:
-            continue
-        # A deliberate symbol correction renames the file. Follow git's own rename
-        # detection rather than calling it a loss -- but only when the credit is
-        # genuinely unchanged; a rename that moved credit is still a failure.
-        target = renamed.get(name)
-        if target and target in after_by_name:
-            new_stem, new_who = after_by_name[target]
-            if new_who == old_who:
-                renamed_ok.append((name, target, old_stem, new_stem, old_who))
-            else:
-                changed.append((name, old_stem, new_stem, old_who, new_who))
-            continue
-        lost.append((name, old_stem, old_who))
+    for name, (old_stem, old_who) in projected.items():
+        if name not in after_by_name:
+            lost.append((origin.get(name, name), old_stem, old_who))
 
     for name, old_stem, new_stem, old_who, new_who in changed:
         print(f"  CREDIT CHANGED  {name}")

--- a/tools/test_attribution.py
+++ b/tools/test_attribution.py
@@ -205,3 +205,89 @@ class Composite(GitFixture):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RenameReplay(GitFixture):
+    """`prepush_attribution.project` must REPLAY renames in commit order.
+
+    The bug these cover: the steps used to be composed into one {old: final} map and
+    chased forward, which is right for a file that really moved A -> B -> C and wrong
+    for a permutation, where step 2 only means what it means because step 1 already
+    vacated the name.
+    """
+
+    def setUp(self):
+        super().setUp()
+        sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+        import prepush_attribution as PA
+        self.PA = PA
+        self._saved_pa = PA.REPO
+        PA.REPO = self.repo
+
+    def tearDown(self):
+        self.PA.REPO = self._saved_pa
+        super().tearDown()
+
+    def steps(self):
+        return self.PA.renames_between("main", "HEAD")
+
+    def test_a_two_class_swap_keeps_every_credit(self):
+        """A -> B while B -> C. Composed, this said A's credit landed on C."""
+        self.write("src/b.c", CLEAN)
+        self.write("src/a.c", CLEAN + "// a\n")
+        self.commit("author", "start")
+        self.git("branch", "base")
+        self.move("src/b.c", "src/c.c")
+        self.commit("renamer", "b -> c")
+        self.move("src/a.c", "src/b.c")
+        self.commit("renamer", "a -> b")
+
+        steps = self.PA.renames_between("base", "HEAD")
+        self.assertEqual(steps, [("b", "c"), ("a", "b")])
+
+        before = {"a": ("src/a", "alice"), "b": ("src/b", "bob")}
+        state, origin = self.PA.project(before, steps)
+        # bob's work is now called c, alice's is now called b, and neither lost credit
+        self.assertEqual(state["c"], ("src/b", "bob"))
+        self.assertEqual(state["b"], ("src/a", "alice"))
+        self.assertNotIn("a", state)
+        self.assertEqual(origin["c"], "b")
+        self.assertEqual(origin["b"], "a")
+
+    def test_composing_would_have_been_wrong(self):
+        """Pin the exact failure: forward-chasing sends a's credit to c."""
+        steps = [("b", "c"), ("a", "b")]
+        composed = {}
+        for old, new in steps:
+            composed[old] = new
+        for start in list(composed):
+            seen, cur = {start}, composed[start]
+            while cur in composed and cur not in seen:
+                seen.add(cur)
+                cur = composed[cur]
+            composed[start] = cur
+        self.assertEqual(composed["a"], "c")          # the bug, preserved as a fact
+        state, _ = self.PA.project({"a": ("src/a", "alice"), "b": ("src/b", "bob")}, steps)
+        self.assertEqual(state["c"], ("src/b", "bob"))   # replay disagrees, and is right
+
+    def test_a_genuine_chain_still_composes_correctly(self):
+        """A -> B -> C in that order really is one file moving twice."""
+        steps = [("a", "b"), ("b", "c")]
+        state, origin = self.PA.project({"a": ("src/a", "alice")}, steps)
+        self.assertEqual(state["c"], ("src/a", "alice"))
+        self.assertEqual(origin["c"], "a")
+        self.assertNotIn("a", state)
+        self.assertNotIn("b", state)
+
+    def test_a_rewrite_and_move_in_one_commit_is_still_a_loss(self):
+        """The gate keeps its teeth: no R record, so no step, so the name is lost."""
+        self.write("src/a.c", CLEAN)
+        self.commit("author", "start")
+        self.git("branch", "base2")
+        (self.repo / "src/a.c").unlink()
+        self.write("src/z.c", "int totally_different(void){return 42;}\n")
+        self.commit("renamer", "rewrite and move at once")
+        steps = self.PA.renames_between("base2", "HEAD")
+        state, _ = self.PA.project({"a": ("src/a", "alice")}, steps)
+        self.assertIn("a", state)          # never vacated -> reported lost
+        self.assertNotIn("z", state)


### PR DESCRIPTION
prepush_attribution: replay renames in order instead of composing them

The gate collapses a **permutation** of names into a wrong mapping and then reports
every name in it as `CREDIT CHANGED`, even though git recorded an R100 for each step
and nobody lost anything. Found while renaming a family of actor classes where each
takes the next one's name (#1418 / #1419 series); it blocks that work and would block
any future class-family rename.

## The bug

`renames_between` collected each commit's renames -- correctly -- and then composed
them into a single `{old: final}` map by chasing forward. For a permutation the steps
arrive in this order:

    commit 1   VirtualDoor -> Exit          (the tail vacates first)
    commit 3   CameraTag   -> VirtualDoor

Chased forward, `CameraTag -> VirtualDoor -> Exit` composes to **`CameraTag -> Exit`**.
That is false: Exit's credit is VirtualDoor's, and CameraTag's is on VirtualDoor.
Composition is only valid when a file really moved A -> B -> C *over time*; here
step 2 only means what it means **because step 1 already vacated the name**, so order
is the whole point and chasing forward inverts it.

Two things then went wrong at once. The composed map sent credit to the wrong name,
and `main`'s first loop never consulted renames at all -- for a name present in both
`before` and `after` it compared authors directly, which under a permutation is
comparing two different functions that happen to share a name.

## The fix

Return the steps **in commit order** and replay them onto a moving `{name: credit}`
map, tracking where each name's credit came from. Compare `after` against that
projection rather than against `before`.

## It is stricter, not looser

A rewrite-and-move in one commit is still not a rename to git, so it contributes no
step, the old name is never vacated in the projection, and it is still reported lost.
That is covered by a test, and the whole point of the gate is preserved.

Checked against real history rather than argued: on `origin/main~6..origin/main` the
old and new code produce **identical** output -- same 10 renamed-with-credit-intact,
same 2 lost, same names. The behaviour only differs where a name is both a rename
source and a rename target in the same range.

## Tests

Four new cases in `tools/test_attribution.py`, built on the existing throwaway-git-repo
fixture:

  - a two-class swap keeps every credit, and `renames_between` really does return
    `[("b","c"), ("a","b")]` in that order
  - the old composition is pinned as a fact: forward-chasing sends a's credit to c,
    and replay disagrees
  - a genuine A -> B -> C chain still resolves to A's author on C
  - a rewrite-and-move in one commit is still a loss

`python -m pytest tools/test_attribution.py` -> 16 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XxDmkQ47fWa3GB6mj8xEQe
