### PR TITLE
The save state captures every hosted DS global, by section

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -121,6 +121,10 @@ add_library(ntr STATIC
     ntr/io.cpp ntr/gx.cpp ntr/texture.cpp ntr/ppu.cpp ntr/ppu_sub.cpp ntr/lz77.cpp
     ntr/rt.cpp ntr/runtime.cpp ntr/fs.cpp ntr/bmd.cpp)
 target_include_directories(ntr PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/ntr/include")
+# ntr/runtime.cpp hosts two DS DMA globals (data_020a60c4/data_020a6460) that
+# are real save state, so it needs hal/dsstate_seg.h. PRIVATE: only this
+# library reads it, consumers keep their own include set.
+target_include_directories(ntr PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 if(MSVC)
     target_compile_options(ntr PRIVATE /wd4311 /wd4312)
 endif()
@@ -131,6 +135,10 @@ add_library(ntr_2x STATIC
     ntr/io.cpp ntr/gx.cpp ntr/texture.cpp ntr/ppu.cpp ntr/ppu_sub.cpp ntr/lz77.cpp
     ntr/rt.cpp ntr/runtime.cpp ntr/fs.cpp ntr/bmd.cpp)
 target_include_directories(ntr_2x PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/ntr/include")
+# ntr/runtime.cpp hosts two DS DMA globals (data_020a60c4/data_020a6460) that
+# are real save state, so it needs hal/dsstate_seg.h. PRIVATE: only this
+# library reads it, consumers keep their own include set.
+target_include_directories(ntr_2x PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_definitions(ntr_2x PUBLIC NTR_HIRES2)
 if(MSVC)
     target_compile_options(ntr_2x PRIVATE /wd4311 /wd4312)
@@ -142,6 +150,10 @@ add_library(ntr_hires STATIC
     ntr/io.cpp ntr/gx.cpp ntr/texture.cpp ntr/ppu.cpp ntr/ppu_sub.cpp ntr/lz77.cpp
     ntr/rt.cpp ntr/runtime.cpp ntr/fs.cpp ntr/bmd.cpp)
 target_include_directories(ntr_hires PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/ntr/include")
+# ntr/runtime.cpp hosts two DS DMA globals (data_020a60c4/data_020a6460) that
+# are real save state, so it needs hal/dsstate_seg.h. PRIVATE: only this
+# library reads it, consumers keep their own include set.
+target_include_directories(ntr_hires PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_definitions(ntr_hires PUBLIC NTR_HIRES)
 if(MSVC)
     target_compile_options(ntr_hires PRIVATE /wd4311 /wd4312)
@@ -565,7 +577,7 @@ endif()
 # Save-state verification (lane lk6): the same actor world as smoke_actor, plus
 # hal/lk6_savestate.cpp, driving save -> diverge -> load -> byte-exact compare.
 add_executable(smoke_savestate tests/smoke_savestate.cpp
-    hal/lk6_savestate.cpp hal/auto_bss.cpp
+    hal/lk6_savestate.cpp hal/dsstate_seg.cpp hal/auto_bss.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
     hal/model_host.cpp hal/gx_upload_bridge.cpp hal/cstd_div.c
     hal/clsn_vtable.cpp hal/actor_vtables.cpp hal/anim_bridge.cpp
@@ -2565,7 +2577,7 @@ add_executable(walk_window tests/walk_window.cpp tests/io_pressure.cpp "${OV002D
     hal/host_settings.cpp
     # in-memory save state (lane lk6): F8/F9 snapshot and restore of the hosted
     # DS arena plus the out-of-arena game globals.
-    hal/lk6_savestate.cpp
+    hal/lk6_savestate.cpp hal/dsstate_seg.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
     hal/model_host.cpp hal/meshcolliderbase_vtable.cpp hal/meshcollider_dtor_seat.cpp hal/lk1_eh_vmax_seat.cpp hal/lk2_platform_dtor_seat.cpp hal/model_dtor_seat.cpp hal/lk4_eh_dtor_seat.cpp hal/lk4_solidheap_seat.cpp hal/gx_upload_bridge.cpp hal/cstd_div.c
     hal/clsn_vtable.cpp hal/actor_vtables.cpp hal/anim_bridge.cpp
@@ -2637,6 +2649,17 @@ if(MSVC)
     target_compile_options(walk_window PRIVATE /wd4311 /wd4312 /wd4068 /wd4576)
 endif()
 
+# The save state captures the whole .dsstate section (hal/dsstate_seg.h). Fail
+# the build if a hosted DS global landed OUTSIDE it: that symbol would not roll
+# back on a restore, which is exactly the class of bug that shipped in 0.2.0
+# (the ANIM_PTRS table crashing Player::SetAnim on a null BCA_File*). The map
+# the guard reads is the one /MAP already writes next to the exe.
+add_custom_command(TARGET walk_window POST_BUILD
+    COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/tools/dsstate_guard.py"
+            "$<TARGET_FILE_DIR:walk_window>/walk_window.map"
+    VERBATIM
+    COMMENT "dsstate_guard: hosted DS globals all inside .dsstate")
+
 # hires clone for screenshot sessions (4x resolution, ~1/16 the fps)
 add_executable(walk_window_hires tests/walk_window.cpp "${OV002DATA_C}" ${LEVEL_OV_DATA}
     # dialogue pipeline (2026-08-08): pump, engine-A compositor, headless probe.
@@ -2645,7 +2668,7 @@ add_executable(walk_window_hires tests/walk_window.cpp "${OV002DATA_C}" ${LEVEL_
     hal/host_settings.cpp
     # in-memory save state (lane lk6): F8/F9 snapshot and restore of the hosted
     # DS arena plus the out-of-arena game globals.
-    hal/lk6_savestate.cpp
+    hal/lk6_savestate.cpp hal/dsstate_seg.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
     hal/model_host.cpp hal/meshcolliderbase_vtable.cpp hal/meshcollider_dtor_seat.cpp hal/lk1_eh_vmax_seat.cpp hal/lk2_platform_dtor_seat.cpp hal/model_dtor_seat.cpp hal/lk4_eh_dtor_seat.cpp hal/lk4_solidheap_seat.cpp hal/gx_upload_bridge.cpp hal/cstd_div.c
     hal/clsn_vtable.cpp hal/actor_vtables.cpp hal/anim_bridge.cpp

--- a/port/hal/actor_classes_bob_enemy.cpp
+++ b/port/hal/actor_classes_bob_enemy.cpp
@@ -36,6 +36,7 @@
 
 #include "Actor.h"
 #include "ActorBase.h"
+#include "dsstate_seg.h"
 
 extern "C" {
 /* the ten shared lifecycle halves, the same functions hal/actor_classes.cpp
@@ -579,7 +580,13 @@ int *func_ov091_021333fc(int *self);            /* D1 */
 void func_ov091_02133648(char *self, void *o);  /* slot 21, its own */
 void func_ov091_021335d4(char *self, void *o);  /* slot 27, its own */
 void _ZN8Platform4KillEv(void *self);           /* slot 31 */
+/* A hosted vtable array, not a ROM constant: hal fills its slots at boot, so
+   it is mutable hosted state and belongs in the captured section along with
+   the /alternatename alias below, which is the same storage under the name
+   the config left unnamed. See hal/dsstate_seg.h. */
+DSSTATE_BEGIN
 void *_ZTV11daObjPile_c[32];
+DSSTATE_END
 }
 /* Stump_Spawn spells the table by the address config left unnamed. */
 #pragma comment(linker, "/alternatename:_data_ov091_021352bc=__ZTV11daObjPile_c")

--- a/port/hal/actor_classes_bob_world.cpp
+++ b/port/hal/actor_classes_bob_world.cpp
@@ -75,6 +75,7 @@
 // with the link closed and only the seat to write. Until then they have no
 // registry row, so the spawn gate names them as skipped instead of dying.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -990,7 +991,9 @@ int *func_ov002_020f03c4(int *self);     /* D1 */
 /* The vtable is HOST STORAGE the registry fills, not mounted ROM bytes, so
    the name dsd gave the address is declared here rather than emitted by
    ovdata. The factory spells it by its RTTI name. */
+DSSTATE_BEGIN
 void *data_ov002_0210b030[31];
+DSSTATE_END
 }
 #pragma comment(linker, "/alternatename:__ZTV9daSCoin_c=_data_ov002_0210b030")
 static int __fastcall is_init(void *s, void *)
@@ -1040,7 +1043,9 @@ int func_ov002_020b0650(void);         /* slot 9  Render */
 void func_ov002_020b064c(void);        /* slot 12 OnPendingDestroy */
 int *func_ov002_020b05d0(int *self);   /* slot 16 D1 */
 int *func_ov002_020b0600(int *self);   /* slot 17 D0 */
+DSSTATE_BEGIN
 void *data_ov002_02108480[31];
+DSSTATE_END
 }
 #pragma comment(linker, "/alternatename:__ZTV7daBar_c=_data_ov002_02108480")
 static int __fastcall ip_init(void *s, void *)
@@ -1369,7 +1374,9 @@ int func_ov002_020ec410(char *self);     /* Behavior */
 int func_ov002_020ec408(char *self);     /* Render */
 void func_ov002_020ec404(char *self);    /* OnPendingDestroy */
 int *func_ov002_020ec388(int *self);     /* D1 */
+DSSTATE_BEGIN
 void *data_ov002_0210acbc[31];
+DSSTATE_END
 }
 #pragma comment(linker, "/alternatename:__ZTV11daWarpkun_c=_data_ov002_0210acbc")
 static int __fastcall warp_init(void *s, void *)

--- a/port/hal/actor_classes_ccm.cpp
+++ b/port/hal/actor_classes_ccm.cpp
@@ -45,6 +45,7 @@
 // unk_05c/060/064 and arms a 0x78-frame timer; Behavior waits for the player
 // within 0x180000, plays a sound, counts the timer down and kills the actor.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -401,7 +402,9 @@ int *PowerStarCreate_Spawn(void);            /* installs data_ov018_02113a74 */
    note here said "the table is 18 words, ends here". The reloc run says 31:
    18..30 are Actor's own list, and slot 31 is _ZTI15daObjIceBoard_c, the RTTI
    record of the NEXT object. A plain Actor table, no Platform Kill. */
+DSSTATE_BEGIN
 int data_ov018_02113a74[31];                 /* the unnamed vtable, host array */
+DSSTATE_END
 }
 /* func_ov018_02112730.cpp (Behavior) declares its OWN local `struct Actor {
    static int Spawn(unsigned, unsigned, const Vector3&, const Vector3_16*,
@@ -824,7 +827,9 @@ int func_ov018_02111368(char *self);            /* slot 6, Behavior */
 int func_ov018_02111340(void *self);             /* slot 9, Render */
 void func_ov018_0211123c(char *self, void *p);  /* slot 27, OnHitByMegaChar */
 void *SkiLift_Spawn(void);                       /* installs data_ov018_021138cc */
+DSSTATE_BEGIN
 int data_ov018_021138cc[32];                     /* the class's own vtable, host array */
+DSSTATE_END
 extern int _ZTV8Platform[];                      /* Platform's own base table, already
                                                       hosted (hal/actor_vtables.cpp) */
 void _ZN18MovingMeshColliderD1Ev(void *);        /* MovingMeshCollider at +0x124 */

--- a/port/hal/actor_classes_jrb.cpp
+++ b/port/hal/actor_classes_jrb.cpp
@@ -97,6 +97,7 @@
 // port/unmatched/Jrb_Renders.cpp and out of slice_gate188.txt. Unagi's Render is
 // NOT a collision (Model::Render by C name) and stays in the slice.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -191,8 +192,12 @@ void _ZN8Platform4KillEv(void *self);       /* slot 31, Platform's own */
 int _ZTV5Unagi[31];
 int _ZTV6ShipUp[32];
 int _ZTV23FloatOnWaterPlatformJrb[37];   /* id 313 SlidingBox (derived) */
+DSSTATE_BEGIN
 int data_ov016_02114b00[32];             /* id 58 RockPillar (daObjKi_Hasira_c) */
+DSSTATE_END
+DSSTATE_BEGIN
 int data_ov016_02114bcc[32];             /* id 60 FloatOnWaterPlatformJrb (daObjKi_Ita_c base) */
+DSSTATE_END
 }
 
 /* Two DISTINCT tables, two RTTI aliases (the decoy inversion, from relocs):

--- a/port/hal/actor_classes_ov012.cpp
+++ b/port/hal/actor_classes_ov012.cpp
@@ -14,6 +14,7 @@
 // RockPillar/SkiLift shape) -- dropped from slice_gate199.txt, byte-locked
 // matched-src proof only.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -52,8 +53,10 @@ int func_ov012_02111324(void *self);       /* slot 9, Render -- HOST COPY,
                                                unmatched/ModelAnim_Renders.cpp */
 void func_ov012_0211123c(char *self);      /* slot 21, own OnGroundPounded */
 void *SwitchPillar_Spawn(void);            /* installs data_ov012_02112344 */
+DSSTATE_BEGIN
 int data_ov012_02112344[32];               /* SwitchPillar's own vtable, unnamed by
                                                dsd -- host array */
+DSSTATE_END
 
 /* BASEMENT_WATER (daObjC0Water_c) own bodies -- misnamed _ZN12SwitchPillar*
    by dsd (the class-identity swap), matched src under those filenames */

--- a/port/hal/actor_classes_ov013.cpp
+++ b/port/hal/actor_classes_ov013.cpp
@@ -28,6 +28,7 @@
 // _ZTV5Model[5] is dual-filled (hal/cxxname_bridge.cpp), the Tree/ov072/l7
 // precedent -- NOT the ModelAnim slot-5 collision.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -65,10 +66,12 @@ int func_ov013_021112a8(char *self);       /* slot 6, Behavior (the swing) */
 int func_ov013_02111280(void *self);       /* slot 9, Render (from src,
                                                plain-Model slot-5) */
 void *ClockPaintingPendulum_Spawn(void);   /* installs data_ov013_02112128 */
+DSSTATE_BEGIN
 int data_ov013_02112128[31];               /* Pendulum's own vtable, unnamed
                                                and five-way split by dsd --
                                                host array spanning
                                                0x02112128..0x021121a4 */
+DSSTATE_END
 
 /* CLOCK_HAND_SHORT/LONG shared own bodies -- real C++ methods against
    ClockPaintingHandShort.h, faced below (Render too: it compiles from src

--- a/port/hal/actor_classes_ov081.cpp
+++ b/port/hal/actor_classes_ov081.cpp
@@ -36,6 +36,8 @@
 // BoB. Declared here as a zero-initialized host global (never written by
 // anything in this build) so those guards see the same zero the ROM's own
 // unmounted-overlay BSS would read.
+#include "dsstate_seg.h"
+DSSTATE_BEGIN
 extern "C" int data_ov004_020beb68;
 int data_ov004_020beb68 = 0;
 /* data_0209b308[2] is read INSIDE the same function, but only after the
@@ -43,6 +45,7 @@ int data_ov004_020beb68 = 0;
    still needs to link. Zero-initialized, never read at runtime. */
 extern "C" int data_0209b308[4];
 int data_0209b308[4] = {0, 0, 0, 0};
+DSSTATE_END
 
 #include <cstdio>
 #include <cstdlib>

--- a/port/hal/actor_classes_painting.cpp
+++ b/port/hal/actor_classes_painting.cpp
@@ -36,6 +36,7 @@
 // and deallocates) -- kept live because the ROM's teardown does call it,
 // unlike the world-file classes whose slot 17 traps.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -74,7 +75,9 @@ int func_ov080_02126c20(void *self);      /* slot 9  Render (PMF dispatch) */
 void func_ov080_02126c1c(void);           /* slot 12 OnPendingDestroy (empty) */
 int func_ov080_02125404(void *self);      /* slot 16 D1 */
 
+DSSTATE_BEGIN
 void *data_ov080_021282b4[33];            /* the host vtable Painting_Spawn installs */
+DSSTATE_END
 
 /* The ROM D0 (func_ov080_02125428) is the D1 body plus one Deallocate against
    the game heap, but its recovered src spells the vtable and the heap through

--- a/port/hal/actor_classes_star.cpp
+++ b/port/hal/actor_classes_star.cpp
@@ -200,11 +200,11 @@ int _ZN5Actor16OnAimedAtWithEggEv(void *self);     /* slot 29 */
    $NNNN contributions to one section, laid out in address order, the same
    idiom romdata.py's CONTIG runs use. A generous 8-byte head keeps room for
    the 4-byte ROM run (f310..f313) plus slack. */
-#pragma section(".hvsstar$0000", read, write)
-#pragma section(".hvsstar$0001", read, write)
+#pragma section(".dsstate$hvsstar0000", read, write)
+#pragma section(".dsstate$hvsstar0001", read, write)
 extern "C" {
-__declspec(allocate(".hvsstar$0000")) signed char data_0209f310[1];
-__declspec(allocate(".hvsstar$0001")) signed char data_0209f311[31];
+__declspec(allocate(".dsstate$hvsstar0000")) signed char data_0209f310[1];
+__declspec(allocate(".dsstate$hvsstar0001")) signed char data_0209f311[31];
 }
 /* func_ov002_020d94cc declares data_0209f310 as a bare `signed char` outside
    extern "C" (a second, C++-mangled spelling); alias it onto the C symbol. */

--- a/port/hal/actor_classes_wf.cpp
+++ b/port/hal/actor_classes_wf.cpp
@@ -65,6 +65,7 @@
 // ActorBase::OnPendingDestroy for all seven (their vtables' slot 12 is the arm9
 // 0x02043ac0), which the shared fill already installs.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -372,7 +373,9 @@ int func_ov015_021112a0(char *self);   /* slot 0  InitResources (.cpp extern C) 
 int func_ov015_02111254(char *self);   /* slot 3  CleanupResources */
 int func_ov015_02111278(char *self);   /* slot 9  Render */
 int *func_ov015_021111a0(int *self);   /* slot 16 D1 */
+DSSTATE_BEGIN
 void *data_ov015_02114360[31];
+DSSTATE_END
 }
 #pragma comment(linker, "/alternatename:__ZTV18daObjBkBillboard_c=_data_ov015_02114360")
 static int __fastcall pb_init(void *s, void *)
@@ -471,7 +474,9 @@ int func_ov015_02112c84(char *self);   /* slot 3  CleanupResources */
 int func_ov002_020b6718(char *self);   /* slot 6  Behavior (ov002 base) */
 int func_ov002_020b66f0(char *self);   /* slot 9  Render (ov002 base) */
 int *func_ov015_02112bd0(int *self);   /* slot 16 D1 */
+DSSTATE_BEGIN
 void *data_ov015_021147e8[32];
+DSSTATE_END
 void *RotatingPlatformWf_Spawn(void);
 }
 #pragma comment(linker, "/alternatename:__ZTV17daObjBk_Ukisima_c=_data_ov015_021147e8")

--- a/port/hal/actor_classes_wf_enemy.cpp
+++ b/port/hal/actor_classes_wf_enemy.cpp
@@ -42,6 +42,7 @@
 // Yoshi egg at anything as Mario. FortressWall is a Platform whose slot 30 is
 // the arm9 base body, filled by the shared pass.
 #include <cstdio>
+#include "dsstate_seg.h"
 #include <cstdlib>
 
 #include "Actor.h"
@@ -331,7 +332,9 @@ int func_ov079_02126e58(char *self);          /* slot 31, its own Kill */
    Declared as bytes rather than void*[] because BillBlaster_Spawn installs it
    through a char* face; the count is the slot count times four, so it moves
    with the slot count. */
+DSSTATE_BEGIN
 unsigned char data_ov079_02127fb8[32 * 4];    /* the host vtable BillBlaster_Spawn installs */
+DSSTATE_END
 }
 
 static int __fastcall blz_init(void *s, void *)

--- a/port/hal/actor_vtables.cpp
+++ b/port/hal/actor_vtables.cpp
@@ -12,6 +12,7 @@
 
 #include "ActorBase.h"
 #include "ArrowSignRight.h"
+#include "dsstate_seg.h"
 
 // The lifecycle definitions are MSVC methods (ArrowSignRight.h/ActorBase.h
 // real classes); InitResources alone is a C-named free function. Every shim
@@ -87,6 +88,7 @@ extern "C" void *_ZTV14ArrowSignRight[32] = {
 };
 
 // Base vtables the ctor chain installs transiently: storage only.
+DSSTATE_BEGIN
 extern "C" {
 /* ov002 0x0210ae38, dBgActor_c in the ROM's RTTI. THIRTY-TWO words: 18..30
    are Actor's own list and 31 is Platform::Kill. It was [20], so a Platform
@@ -482,4 +484,5 @@ int data_0209f5c0[8];
    _ZN11ShadowModel10InitCuboidEv in hal/cxxname_bridge.cpp. */
 int data_020ad560[0x3c / 4];
 }
+DSSTATE_END
 

--- a/port/hal/auto_bss.cpp
+++ b/port/hal/auto_bss.cpp
@@ -1,5 +1,15 @@
 // GENERATED-ACCUMULATED zero storage for gate-10/11 BSS ring symbols.
 // Grown by the link-sweep loop; sizes are generous defaults.
+//
+// These are hosted DS BSS globals -- mutable game state (message and cutscene
+// mode flags, the Process cleanup list, the particle cursors, and much more) --
+// so they are routed into the .dsstate section the save state captures. The
+// DSSTATE_BEGIN/END markers set the default bss/data segment for every global
+// between them; the link-sweep loop that grows this file emits new symbols
+// inside the bracket, so anything it adds is captured with no further work. See
+// hal/dsstate_seg.h.
+#include "dsstate_seg.h"
+DSSTATE_BEGIN
 extern "C" {
 /* MSG_GEN_TEXT_FUNCS is NOT zeroed storage: it is a 3-entry function-pointer
    table func_0201b7cc calls through on a 0xfe message control byte. Seated with
@@ -251,11 +261,13 @@ char data_0209fc64[4];
    called the ROM's own reset. kind:bss, so zero is the boot value. */
 int data_0209cef0;
 }
+DSSTATE_END
 
 /* Sound:: is a NAMESPACE in the TU that calls this one (YAX mangling) */
 namespace Sound { void UnsetPlayerVoiceGroup(); }
 void Sound::UnsetPlayerVoiceGroup() {}
 
+DSSTATE_BEGIN
 /* ---- gate 29: the particle engine's own BSS -------------------------------
    data_0209ee78/7c/80 are the three cursors of the arena SysTracker::
    Initialise carves out (base, end, current) and func_02023178 bump-allocates
@@ -276,6 +288,7 @@ int data_0209ee8c[8];
 int data_020a4d30[8];
 int LCG_STATE_0204da4c;
 }
+DSSTATE_END
 
 /* gate 50: ov080's PAINTING (daPicGate_c, 307) bss is NOT here -- it is
    mounted with the rest of the overlay in ov080_syms.txt so the DATA table

--- a/port/hal/bob_enemy_bridges.cpp
+++ b/port/hal/bob_enemy_bridges.cpp
@@ -15,6 +15,7 @@
 // are, and both are the ROM's own answer rather than a guess.
 #include <cstdio>
 #include <cstdlib>
+#include "dsstate_seg.h"
 
 extern "C" {
 /* the C-named definitions the aliases below land on */
@@ -256,7 +257,9 @@ unsigned char VS_STAR_SPAWN_ORDERS[6][0xC] = {
     { 0, 3, 2, 1, 4, 0, 0, 0, 0, 0, 0, 0 },
     { 0, 3, 1, 2, 4, 0, 0, 0, 0, 0, 0, 0 },
 };
+DSSTATE_BEGIN
 unsigned char *data_0209f344;
+DSSTATE_END
 
 /* the red-coin counter NumRedCoins reads: DEFINED in hal/auto_bss.cpp, where
    this gate's 4-byte sizing was carried over. */

--- a/port/hal/camera_bridges.cpp
+++ b/port/hal/camera_bridges.cpp
@@ -12,6 +12,7 @@
 #include "ActorDerived.h"
 #include "Camera.h"
 #include "PathPtr.h"
+#include "dsstate_seg.h"
 
 /* Camera::Render calls View::Render() as a METHOD (its TU declares a local
    `struct View`); src defines the function at C linkage. Same shape as the
@@ -173,25 +174,25 @@ extern "C" void hal_camera_slots_harness_owned(void)
     unsigned char name[size] = {0}
 
 /* 0x020a1040 .. 0x020a1064: the local record (0x24) */
-COMM(".camcomm$0000", data_020a1040, 4);
-COMM(".camcomm$0001", data_020a1044, 2);
-COMM(".camcomm$0002", data_020a1046, 2);
-COMM(".camcomm$0003", data_020a1048, 4);
-COMM(".camcomm$0004", data_020a104c, 2);
-COMM(".camcomm$0005", data_020a104e, 2);
-COMM(".camcomm$0006", data_020a1050, 2);
-COMM(".camcomm$0007", data_020a1052, 0x12);
+COMM(".dsstate$camcomm0000", data_020a1040, 4);
+COMM(".dsstate$camcomm0001", data_020a1044, 2);
+COMM(".dsstate$camcomm0002", data_020a1046, 2);
+COMM(".dsstate$camcomm0003", data_020a1048, 4);
+COMM(".dsstate$camcomm0004", data_020a104c, 2);
+COMM(".dsstate$camcomm0005", data_020a104e, 2);
+COMM(".dsstate$camcomm0006", data_020a1050, 2);
+COMM(".dsstate$camcomm0007", data_020a1052, 0x12);
 
 /* 0x020a1154 .. 0x020a11e4: four per-player records (0x24 each) */
-COMM(".camrec$0000", data_020a1154, 0xc);
-COMM(".camrec$0001", data_020a1160, 2);
-COMM(".camrec$0002", data_020a1162, 2);
-COMM(".camrec$0003", data_020a1164, 2);
-COMM(".camrec$0004", data_020a1166, 0x12);
-COMM(".camrec$0005", data_020a1178, 4);
-COMM(".camrec$0006", data_020a117c, 0x24);
-COMM(".camrec$0007", data_020a11a0, 0x24);
-COMM(".camrec$0008", data_020a11c4, 0x20);
+COMM(".dsstate$camrec0000", data_020a1154, 0xc);
+COMM(".dsstate$camrec0001", data_020a1160, 2);
+COMM(".dsstate$camrec0002", data_020a1162, 2);
+COMM(".dsstate$camrec0003", data_020a1164, 2);
+COMM(".dsstate$camrec0004", data_020a1166, 0x12);
+COMM(".dsstate$camrec0005", data_020a1178, 4);
+COMM(".dsstate$camrec0006", data_020a117c, 0x24);
+COMM(".dsstate$camrec0007", data_020a11a0, 0x24);
+COMM(".dsstate$camrec0008", data_020a11c4, 0x20);
 
 #undef COMM
 
@@ -238,6 +239,7 @@ int hal_camera_check_layout(void)
    (data_0209f1f8 = 0) InitResources skips its whole scan, and the camera
    stays in mode 10 -- the correct minimal behaviour for a level whose
    Stage loader has not run (R14). */
+DSSTATE_BEGIN
 static char hal_area_table[64 * 12];
 static char hal_viewobj_table[64 * 0xe];
 void *data_0209f314 = hal_area_table;
@@ -267,6 +269,7 @@ int data_0209ee90[0x348 / 4];
    whenever the test fails, which on the castle grounds is the AUTHENTIC
    dormancy of the ambient set (bird/butterfly/fish), not a port gap. */
 int data_0209f43c[0x5c / 4];
+DSSTATE_END
 
 /* Camera::SaveCameraStateBeforeTalk is called ARGLESS by both its callers
    (func_02005324 and func_02009a8c, which the community names func_0200cc5c):

--- a/port/hal/camera_states.cpp
+++ b/port/hal/camera_states.cpp
@@ -21,6 +21,7 @@
 // addresses, so ordinary separate definitions would do -- but every state
 // past 0 is reached by an explicit &data_0209bXXX, so each one is named.
 #include <cstdio>
+#include "dsstate_seg.h"
 
 extern "C" {
 
@@ -69,7 +70,14 @@ int hal_call_camera_state_fn(void *self, unsigned ds_addr)
 }
 
 /* The 19 State objects. Layout: {onEnter fn, onEnter delta, main fn, main
-   delta}. The deltas are all zero in the ROM's pairs. */
+   delta}. The deltas are all zero in the ROM's pairs.
+
+   These are routed into the save state's captured section even though nothing
+   writes them after boot (the ROM's __sinit_02073a24 fills them once; the port
+   bakes the same values in). Capturing 304 bytes that never change is free;
+   exempting them would put back the hand-asserted "this one cannot diverge"
+   list that the 0.2.0 restore crash came out of. See hal/dsstate_seg.h. */
+DSSTATE_BEGIN
 #define CAMSTATE(name, enter, main) \
     unsigned name[4] = {enter, 0, main, 0}
 
@@ -94,5 +102,6 @@ CAMSTATE(data_0209b118, 0x020094e4, 0x020094c0);
 CAMSTATE(data_0209b128, 0x02005060, 0x02005000);
 
 #undef CAMSTATE
+DSSTATE_END
 
 }  /* extern "C" */

--- a/port/hal/cannon_probe.cpp
+++ b/port/hal/cannon_probe.cpp
@@ -16,7 +16,7 @@
 // dialogue lands. It calls nothing the game does not: OpenCannonInCurLevel ->
 // OpenCannonInLevel(data_0209f2f8) -> SublevelToLevel -> OpenCannon(course),
 // which is data_0209caa0[4] |= 1<<course -- the staged save block
-// (.savblk$0000, hal/level_boot.cpp). It is idempotent (OR of a bit already
+// (.dsstate$savblk0000, hal/level_boot.cpp). It is idempotent (OR of a bit already
 // set) and reads the current level from data_0209f2f8, so it must run AFTER
 // level_boot sets data_0209f2f8 = port_level_id() and on the spawn boot path
 // only. Its one call site is described in the wiring report; delete this file

--- a/port/hal/clsn_vtable.cpp
+++ b/port/hal/clsn_vtable.cpp
@@ -270,9 +270,9 @@ void hal_fill_mmc_vtable(void)
     extern "C" __declspec(allocate(sec)) __declspec(align(4))    \
     unsigned char name[size] = {0}
 
-CLSNSCRATCH(".mmcray$0000", data_020a0d0c, 0x10);
-CLSNSCRATCH(".mmcray$0001", data_020a0d1c, 0x44);
-CLSNSCRATCH(".mmcray$0002", data_020a0d60, 0x24);
+CLSNSCRATCH(".dsstate$mmcray0000", data_020a0d0c, 0x10);
+CLSNSCRATCH(".dsstate$mmcray0001", data_020a0d1c, 0x44);
+CLSNSCRATCH(".dsstate$mmcray0002", data_020a0d60, 0x24);
 
 #undef CLSNSCRATCH
 

--- a/port/hal/cxx_aliases.cpp
+++ b/port/hal/cxx_aliases.cpp
@@ -6,6 +6,8 @@
 // lifted verbatim from the link log; each maps to its cdecl C name.
 #include <string.h>
 
+#include "dsstate_seg.h"
+
 #pragma comment(linker, "/alternatename:?FUN_02029a68@@YAXXZ=_FUN_02029a68")
 #pragma comment(linker, "/alternatename:?_ZN6Player11ChangeStateERNS_5StateE@@YAXPAUPlayer@@PAUState@@@Z=__ZN6Player11ChangeStateERNS_5StateE")
 #pragma comment(linker, "/alternatename:?_ZN6Player11ChangeStateERNS_5StateE@@YAXPAXPAUState@@@Z=__ZN6Player11ChangeStateERNS_5StateE")
@@ -61,8 +63,10 @@
 
 extern "C" {
 /* BSS the aliased data references land on (non-ov002 ring) */
+DSSTATE_BEGIN
 int data_0208e6ec[4]; short data_02092144[4];
 void *data_020992a4[4], *data_020992b4[4];
+DSSTATE_END
 /* data_0209b0c8 moved to hal/camera_states.cpp (camera State object 12) */
 
 }
@@ -216,7 +220,9 @@ int func_02017e34(int x) { return x; }   /* fileptr dtor body: host no-op */
 void SharedFilePtr_Destruct_TexSeq(void) {}
 /* PORT_HOST_ABI: fileptr dtor veneer; host card seam does not refcount. */
 void SharedFilePtr_Destruct_Anim(void) {}
+DSSTATE_BEGIN
 void *data_020aa3f0;                     /* MSL global-dtor chain head */
+DSSTATE_END
 
 /* PORT_HOST_ABI: the OBJECT-message box-open ride-through.
  *
@@ -256,6 +262,7 @@ extern "C" void func_0205a588(void *p, int v, int n) { memset(p, v, n); }
    crash-screen-only ITCM entry; trap keeps it honest if ever reached */
 void func_01ffdd98(int a) { (void)a; __debugbreak(); }
 
+DSSTATE_BEGIN
 int data_0209cdcc, data_0209cde4[4], data_0209cde8[4];
 int data_020a4b4c, data_020a4b50;
 int data_020a7fc0[8];
@@ -333,6 +340,7 @@ int data_0209f274[8];
 int data_0209a5ec, data_0209a5f4[2], data_0209a5fc, data_0209a600;
 int data_0209a604, data_0209a60c[2], data_0209a614, data_0209a618;
 int data_0209a61c[4], data_020a6128, data_020a6134[4];
+DSSTATE_END
 }
 
 #pragma comment(linker, "/alternatename:__ZN2GX12SetBankForBGEt=?SetBankForBG@GX@@YAXG@Z")

--- a/port/hal/cxxname_bridge.cpp
+++ b/port/hal/cxxname_bridge.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cstring>
 #include "MeshColliderBase.h"
+#include "dsstate_seg.h"
 
 extern "C" {
 void hal_fileptr_release(void *self);
@@ -86,8 +87,10 @@ void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp)
 }
 
 // BSS the shadow/collider systems use
+DSSTATE_BEGIN
 char data_020ad524[0x40];       /* ShadowModel's template BMD stub */
 void *data_020a0c80[24];        /* the collision actor registry (gate 8) */
+DSSTATE_END
 }
 
 #include "MeshCollider.h"
@@ -122,6 +125,18 @@ extern "C" void _ZN12MeshCollider7SetFileEP8KCL_FileR10CLPS_Block(
 // operator new support: the game heap pointer for actors (the smoke seeds
 // it with the root heap), and the zero-fill veneer -- its DS chain rides
 // arguments through registers, so the host supplies the semantics direct.
+//
+// DELIBERATELY OUTSIDE .dsstate: this is the real storage behind the game
+// heap word data_020a0eac (the two /alternatename lines below), so it IS a
+// hosted DS global -- but a BOOT-CONSTANT one. The ROM writes it exactly once,
+// in Heap::InitializeGameHeap off the main.c boot spine (func_0201a054), and
+// the port seeds it once before the frame loop (walk_window.cpp / the smoke
+// preambles). Nothing writes it during play, so it cannot diverge between a
+// save and a load, and a snapshot of it would restore the value it already
+// holds. Excluded so the capture stays exactly "state that can change";
+// tools/dsstate_guard.py records the same exclusion by name. If a future level
+// path ever re-initializes the game heap mid-session, move this inside a
+// DSSTATE_BEGIN/END bracket and drop the guard exemption.
 extern "C" {
 void *data_020a0eac_c;
 }
@@ -147,6 +162,7 @@ extern "C" int _ZN16MeshColliderBase6EnableEP5Actor(void *self, void *actor)
     return ((MeshColliderBase *)self)->MeshColliderBase::Enable((Actor *)actor);
 }
 extern "C" {
+DSSTATE_BEGIN
 /* player-list globals ClosestPlayer scans: empty world -> null result */
 int data_0208e37c[2];
 int data_0208e380[2];
@@ -154,6 +170,7 @@ int data_0209b450[2];
 int data_0209b458[2];
 int data_0209f21c[8];
 int data_0209f394[8];
+DSSTATE_END
 }
 
 extern "C" void _ZN6Memory10DeallocateEPv(void *p);

--- a/port/hal/dsstate_seg.cpp
+++ b/port/hal/dsstate_seg.cpp
@@ -1,0 +1,23 @@
+/* The two sentinels that bracket the hosted-DS-state section family. See
+ * hal/dsstate_seg.h for the scheme. lk6_savestate.cpp captures the bytes
+ * between them.
+ *
+ * dsstate_lo sits in .dsstate$aaa and dsstate_hi in .dsstate$zzz; every hosted
+ * global a DSSTATE_BEGIN/END block emits lands in .dsstate$mmm, which the
+ * linker orders after aaa and before zzz. The two sentinels are one byte each
+ * and their addresses are the capture bounds: &dsstate_hi - &dsstate_lo is the
+ * whole hosted-DS extent, allocator-independent and recomputed by the linker
+ * every build, so a newly hosted global is captured the moment it is placed in
+ * the section -- no list to grow.
+ *
+ * These live in their own translation unit so nothing accidentally emits a
+ * global between the two markers here. */
+#include "dsstate_seg.h"
+
+#pragma section(".dsstate$aaa", read, write)
+#pragma section(".dsstate$zzz", read, write)
+
+extern "C" {
+__declspec(allocate(".dsstate$aaa")) char dsstate_lo = 0;
+__declspec(allocate(".dsstate$zzz")) char dsstate_hi = 0;
+}

--- a/port/hal/dsstate_seg.h
+++ b/port/hal/dsstate_seg.h
@@ -1,0 +1,73 @@
+/* One linker section family that gathers every hosted DS global the save state
+ * has to roll back, so the snapshot captures them WHOLESALE by section bounds
+ * instead of a hand-maintained symbol list. The 0.2.0 crash was a symbol the
+ * hand list (23 entries) never named: the ANIM_PTRS SharedFilePtr table in
+ * ov002, a hosted overlay global that survived a restore and handed
+ * Player::SetAnim a null BCA_File*. A list that has to be grown by hand for
+ * every hosted symbol is the shape of that bug, so this replaces it.
+ *
+ * HOW IT WORKS
+ * ------------
+ * MSVC merges same-named grouped sections in order of the text after the `$`,
+ * exactly like the CRT's .CRT$XCA..XCZ initializer table. So one base section
+ * .dsstate with a low sentinel in .dsstate$aaa and a high sentinel in
+ * .dsstate$zzz brackets everything a translation unit routes into .dsstate$mmm
+ * (or any suffix that sorts between aaa and zzz). hal/dsstate_seg.cpp defines
+ * the two sentinels and lk6_savestate.cpp memcpy's [dsstate_lo, dsstate_hi).
+ *
+ * A file that hosts DS globals puts DSSTATE_BEGIN before its definitions and
+ * DSSTATE_END after them; every plain global (bss or data) in between lands in
+ * the captured span with no per-symbol annotation. The overlay data generators
+ * (tools/ovdata.py) emit these two markers around their arrays and a per-slot
+ * $mmmNNNN suffix for the packed mounts so a mount's ROM-spaced run stays
+ * contiguous inside the bracket.
+ *
+ * WHAT MUST NOT GO IN HERE
+ * ------------------------
+ * Host-only bookkeeping that must NOT roll back on a restore: the playlog path,
+ * the frame counter, telemetry, the window and frame pacing in ntr_2x, out_win,
+ * the launcher glue and the CRT. Those files simply do not use these markers, so
+ * their globals stay in the ordinary .bss/.data the snapshot never touches. The
+ * line is drawn per symbol, not per file: ntr/runtime.cpp is a host library that
+ * happens to own two genuine DS globals (the DMA state and callback table), and
+ * those two ARE bracketed while the rest of that file is not. The audio path is
+ * captured like everything else but the live sequencer/mixer are additionally
+ * reset on load (see lk6_savestate.cpp); that reset is the one deliberate
+ * exception and it runs after the section copy.
+ */
+#ifndef PORT_HAL_DSSTATE_SEG_H
+#define PORT_HAL_DSSTATE_SEG_H
+
+/* Declare the attributes of the shared slot BEFORE anything routes into it.
+ *
+ * This line is load-bearing and its absence is silent. A bare bss_seg gives its
+ * contribution CNT_UNINITIALIZED_DATA while the sentinels' explicitly-declared
+ * section carries CNT_INITIALIZED_DATA, and the linker does NOT merge two
+ * same-named sections whose characteristics differ -- it emits a SECOND output
+ * section also called .dsstate, placed nowhere near the fence, and says so only
+ * as `LNK4078: multiple '.dsstate' sections found with different attributes`.
+ * Every hosted global in that second section is outside [dsstate_lo, dsstate_hi)
+ * and is silently not captured, which is the exact bug this scheme exists to
+ * kill. Declaring the section here pins one attribute set for the whole family,
+ * so bss- and data-flavoured contributions land in the same output section.
+ *
+ * The cost is that formerly-uninitialized hosted globals are now zero-filled in
+ * the image rather than demand-zeroed (~35 KB of exe). They stay writable: the
+ * `write` attribute is part of what is being pinned. */
+#pragma section(".dsstate$mmm", read, write)
+
+/* Route every plain global between these two markers into the captured span.
+ * $mmm sorts between the $aaa low sentinel and the $zzz high sentinel. Both
+ * bss and data defaults are set so uninitialized and initialized hosted globals
+ * both land inside the bracket. */
+#define DSSTATE_BEGIN                                                          \
+    __pragma(bss_seg(".dsstate$mmm"))                                          \
+    __pragma(data_seg(".dsstate$mmm"))
+
+/* Restore the default (unnamed) segments so anything after the hosted block --
+ * a host-only helper's static, a string literal pool -- is not swept in. */
+#define DSSTATE_END                                                            \
+    __pragma(bss_seg())                                                        \
+    __pragma(data_seg())
+
+#endif /* PORT_HAL_DSSTATE_SEG_H */

--- a/port/hal/fader_wipes.cpp
+++ b/port/hal/fader_wipes.cpp
@@ -68,6 +68,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <new>
+#include "dsstate_seg.h"
 
 typedef int Fix12i;
 
@@ -223,8 +224,10 @@ int hal_wipe_index(const void *self)
    colour into +0xc, which is where HalFaderWipe's `color` sits. Placement-new
    rather than a plain C++ definition because the storage has to keep its C
    name and its address. */
+DSSTATE_BEGIN
 extern "C" __declspec(align(8)) unsigned char
     data_0209f5e8[sizeof(HalFaderWipe)] = {0};
+DSSTATE_END
 
 namespace {
 struct HalColorFaderInit {
@@ -234,6 +237,7 @@ HalColorFaderInit hal_color_fader_init;
 }  /* anonymous namespace */
 
 extern "C" {
+DSSTATE_BEGIN
 /* 0x0209f324: the pointer Stage::InitResources fills and every wipe caller
    derefs. WIPES is what the two fader-wipe entry points call the same
    word. */
@@ -246,6 +250,7 @@ void *data_0209f324 = &hal_wipes[0];
    starts. Wipe 0 is an arbitrary but valid choice: it sits at currInterp
    = 0, which is what "no fade in progress" looks like. */
 void *data_0209f5bc = &hal_wipes[0];
+DSSTATE_END
 }
 #pragma comment(linker, "/alternatename:_WIPES=_data_0209f324")
 

--- a/port/hal/fs.cpp
+++ b/port/hal/fs.cpp
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "dsstate_seg.h"
 
 typedef unsigned int u32;
 typedef unsigned short u16;
@@ -102,7 +103,9 @@ void Deallocate(void *p);
 extern "C" void _ZN6Memory10DeallocateEPv(void *p) { Memory::Deallocate(p); }
 
 extern "C" {
+DSSTATE_BEGIN
 u32 data_0209d3bc; /* last fileID touched; the game's FS breadcrumb */
+DSSTATE_END
 
 /* ov0 handle -> FAT file id (data_ov000_020bd4b8 on the DS)
    PORT_HOST_ABI: src reads the ROM's ov0 handle table (data_0209d3b8), not hosted;

--- a/port/hal/heap_globals.cpp
+++ b/port/hal/heap_globals.cpp
@@ -13,12 +13,19 @@
 // TUs are C (plain-name definitions). Each alias below names the x86-32
 // decorated forms.
 
+#include "dsstate_seg.h"
+
 extern "C" {
 // The single real storage. Memory::rootHeapIterator is a NestedHeapIterator
 // (a list head); the decomp TUs address it as a blob. 0x20 covers the
-// evidenced fields with room; the ctor initializes it.
+// evidenced fields with room; the ctor initializes it. Both are hosted DS
+// globals the save state must roll back (the list head threads INTO the
+// arena), so they live in the .dsstate capture section -- they were in the
+// old hand-picked list and stay captured under the section scheme.
+DSSTATE_BEGIN
 char _ZN6Memory16rootHeapIteratorE[0x20];
 int _ZN6Memory25isRootHeapIterInitializedE;
+DSSTATE_END
 
 // SDK asm primitive (stmia burst fill) -> plain word fill on host. The
 // frontier classifies its TU as HAL-owned; this is the HAL half.

--- a/port/hal/heap_vtable.cpp
+++ b/port/hal/heap_vtable.cpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include "dsstate_seg.h"
 
 typedef unsigned int u32;
 
@@ -50,11 +51,13 @@ struct ExpandingHeapAllocator {
 };
 
 // ---- globals the root-heap chain stores through --------------------------
+DSSTATE_BEGIN
 extern "C" {
 void *data_020a0e9c;   /* Heap::rootHeap */
 void *data_020a0ea0;   /* Memory::defaultHeapPtr */
 int data_02099d90;     /* heap bring-up state flag */
 }
+DSSTATE_END
 
 // ---- allocator methods -> the C-linkage definitions from gate 2 ----------
 extern "C" {

--- a/port/hal/level_boot.cpp
+++ b/port/hal/level_boot.cpp
@@ -73,6 +73,7 @@
 #include <cstring>
 
 #include "MeshCollider.h"
+#include "dsstate_seg.h"
 
 extern "C" {
 void port_ov009_patch(void);
@@ -917,6 +918,7 @@ static void port_load14(void *t, int a, unsigned b)
 
 extern "C" {
 typedef void (*PortObjLoader)(void *, int, unsigned);
+DSSTATE_BEGIN
 PortObjLoader data_ov002_0210cbb8[32] = {
     port_load0,        /*  0 */
     port_load1,        /*  1 */
@@ -935,6 +937,7 @@ PortObjLoader data_ov002_0210cbb8[32] = {
     port_load14,      /* 14 */
     /* 15..31: the ROM's overrun, made explicit */
 };
+DSSTATE_END
 }  /* extern "C" */
 
 /* Two loaders define plain C++ names (their TUs never wrapped the definition
@@ -1036,6 +1039,7 @@ int _ZNK12MeshCollider13GetUnkOctreeYEv(const void *self)
 // Every "Load<Kind>Objects" that is not a spawner is a two-word veneer:
 // store the table pointer in one global, the count in another. Storage only;
 // the consumers (minimap, fog, teleport) are Stage B and C.
+DSSTATE_BEGIN
 short data_ov002_0211118c;   /* the per-level spawn counter, ov002 bss */
 int data_02092138;           /* world Y min (func_0202a850) */
 int data_020a0d8c[4];        /* path count */
@@ -1049,6 +1053,7 @@ unsigned char data_0209f2d0[4];                                /* teleport dest
                                                                   data_0209f330
                                                                   is auto_bss */
 int data_0209f338[4];        /* the unused type-13 word */
+DSSTATE_END
 /* the CURRENT LVL_Overlay: storage is hal/actor_vtables.cpp, parked on a
    zeroed block for the no-level case; the boot points it at the real one */
 extern unsigned char *data_0209f340;
@@ -1071,10 +1076,10 @@ extern unsigned char *data_0209f340;
     extern "C" __declspec(allocate(sec)) __declspec(align(2))    \
     unsigned char name[size] = {0}
 
-SAVEBLK(".savblk$0000", data_0209caa0, 0x14);
-SAVEBLK(".savblk$0001", data_0209cab4, 0x1e);
-SAVEBLK(".savblk$0002", data_0209cad2, 0x12);
-SAVEBLK(".savblk$0003", data_0209cae4, 0x10);
+SAVEBLK(".dsstate$savblk0000", data_0209caa0, 0x14);
+SAVEBLK(".dsstate$savblk0001", data_0209cab4, 0x1e);
+SAVEBLK(".dsstate$savblk0002", data_0209cad2, 0x12);
+SAVEBLK(".dsstate$savblk0003", data_0209cae4, 0x10);
 
 #undef SAVEBLK
 

--- a/port/hal/lk4_solidheap_seat.cpp
+++ b/port/hal/lk4_solidheap_seat.cpp
@@ -36,6 +36,7 @@
 // verbatim from the link errors (the heap_globals law).
 
 #include "types.h"
+#include "dsstate_seg.h"
 
 // Flat C references -> the MSVC-method definitions the matched TUs emit
 // (decorated names read from the compiled objs with dumpbin /SYMBOLS):
@@ -93,7 +94,9 @@ extern "C" {
 extern void *data_0208e3a4[31];       /* _ZTV5Actor, hal/actor_vtables.cpp */
 
 void *_ZTV9SolidHeap[16];             /* installed by SolidHeap C1 */
+DSSTATE_BEGIN
 void *data_020a0ea8;                  /* Memory::tmpHeapPtr */
+DSSTATE_END
 
 /* the flat .c bodies */
 void *_ZN9SolidHeapD1Ev(void *self);              /* slot 0 */

--- a/port/hal/lk6_savestate.cpp
+++ b/port/hal/lk6_savestate.cpp
@@ -3,11 +3,36 @@
 // WHAT A SAVE STATE IS HERE
 // -------------------------
 // One in-memory slot. Snapshot (F8 / the debug menu) copies the whole hosted
-// DS main-RAM arena plus a short list of game-mutable host globals that live
-// OUTSIDE the arena into a heap buffer. Restore (F9 / the debug menu) copies
-// those bytes straight back and silences the audio mixer so nothing keeps
-// playing off the pre-restore sequencer state. The slot survives for the
-// process lifetime; it is not written to disk.
+// DS main-RAM arena plus every game-mutable hosted DS global that lives OUTSIDE
+// the arena into a heap buffer. Restore (F9 / the debug menu) copies those
+// bytes straight back and silences the audio mixer so nothing keeps playing off
+// the pre-restore sequencer state. The slot survives for the process lifetime;
+// it is not written to disk.
+//
+// WHY THE OUT-OF-ARENA SET IS A LINKER SECTION, NOT A LIST
+// -------------------------------------------------------
+// The 0.2.0 slot captured the arena plus a hand-picked list of 23 out-of-arena
+// globals. Real players crashed after a restore: Player::SetAnim read a null
+// BCA_File* out of the ANIM_PTRS SharedFilePtr table (ov002's
+// data_ov002_020ff480), a hosted overlay global the list never named. The arena
+// rolled back to the saved animation while that table -- Released and reloaded
+// as the player animated between save and load -- did not, so the file pointer
+// came back null. A dialogue or cutscene left the same way: the message-active
+// lock (data_0209d660) is a hosted global outside the list, so a restore rolled
+// the world back but left the game wedged in the message.
+//
+// A hand list that has to be grown for every hosted symbol IS that bug. So the
+// out-of-arena set is now defined by a linker section, not a list. Every file
+// that hosts DS globals brackets them with DSSTATE_BEGIN/END (hal/dsstate_seg.h)
+// and the overlay-data generators emit the same markers, which routes all of
+// them -- auto_bss, model_host, the overlay data/pack/whole mounts, the sound
+// bss, every bridge -- into one .dsstate section. hal/dsstate_seg.cpp brackets
+// that section with two sentinels, and the snapshot copies the bytes between
+// them. A newly hosted global is captured the moment it is placed in the
+// section; there is nothing to keep in sync by hand. The dsstate_guard build
+// step (tools/dsstate_guard.py) fails the build if a hosted DS symbol landed
+// OUTSIDE the section, so a file that forgets the markers is caught at build
+// time rather than by a player.
 //
 // WHY THE ARENA IS THE BULK OF IT
 // -------------------------------
@@ -28,30 +53,40 @@
 // freshly restored data. So the cursor is captured and restored like any other
 // value.
 //
-// WHAT LIVES OUTSIDE THE ARENA (and so is listed explicitly below)
-// ----------------------------------------------------------------
-// A number of DS BSS symbols are hosted as ordinary C globals in hal/*.cpp
-// rather than inside the arena. The correctness-critical ones for a same-level
-// restore are the actor processing-list heads (list heads that thread INTO the
-// arena), the particle-engine RNG and its arena cursors, the common-model-data
-// registry, the render camera matrix, the texture-VRAM bump cursors, and the
-// current-model-matrix pointer. Each is named by its real symbol below with its
-// exact declared size and snapshotted byte-for-byte. See the coverage note at
-// the bottom of this file for what is deliberately NOT in the set and why that
-// is safe for a within-session restore.
+// WHAT LIVES OUTSIDE THE ARENA (and so is captured as the .dsstate section)
+// ------------------------------------------------------------------------
+// A large set of DS BSS/data symbols are hosted as ordinary C globals in
+// hal/*.cpp and in the generated overlay-data files rather than inside the
+// arena: the actor processing-list heads, the particle-engine RNG and its arena
+// cursors, the common-model-data registry, the render camera matrix, the
+// texture-VRAM cursors, the message and cutscene mode/lock flags, the ANIM_PTRS
+// SharedFilePtr table every overlay actor animates through, and much more. All
+// of them are routed into one linker section, .dsstate, by the DSSTATE_BEGIN/END
+// markers in each hosting file (see hal/dsstate_seg.h). The snapshot copies the
+// whole section in one shot, so any hosted global is captured by virtue of
+// being in the section -- there is no per-symbol list to keep current.
 //
 // WHAT IS DELIBERATELY NOT CAPTURED (reset instead)
 // -------------------------------------------------
 // The SDAT host audio path keeps live sequencer players and mixer channels
 // (hal/sdat/sseq.cpp g_pl/g_note, hal/sdat/mixer.cpp g_ch) plus a phase
-// accumulator. Their pointers address the arena, so restoring the arena keeps
-// them valid, but the mixer phase and note envelopes would be a few frames
-// ahead of the restored world. Rather than reason about that drift we silence
-// the sequencer and mixer on restore (sd_seq_reset + sd_mix_reset); the game
-// re-triggers sounds from the restored state on the next tick. The wave decode
-// cache (hal/sdat/sdat.cpp g_waves) is keyed by SWAV record addresses in the
-// arena; for a same-level restore those addresses hold identical sample data,
-// so the cache stays correct and needs no flush.
+// accumulator. Their storage IS in .dsstate and so is copied back like anything
+// else, but the mixer phase and note envelopes would be a few frames ahead of
+// the restored world if merely restored, so after the section copy the load
+// path additionally silences the sequencer and mixer (sd_seq_reset +
+// sd_mix_reset); the game re-triggers sounds from the restored state on the next
+// tick. The wave decode cache (hal/sdat/sdat.cpp g_waves) is keyed by SWAV
+// record addresses in the arena; for a same-level restore those addresses hold
+// identical sample data, so the restored cache stays correct.
+//
+// WHAT IS NOT IN .dsstate ON PURPOSE (host-only, must not roll back)
+// -----------------------------------------------------------------
+// Host bookkeeping that describes the SESSION, not the game: the playlog path
+// and frame counter (walk_window.cpp), telemetry, the launcher glue, ntr_2x's
+// host framebuffer/window state, and the C runtime's own globals (locale, FILE
+// tables). None of those files use the DSSTATE markers, so their globals stay in
+// the ordinary .bss/.data the snapshot never touches. Rolling the frame counter
+// or a FILE* back would be wrong.
 
 #include <stdlib.h>
 #include <string.h>
@@ -64,6 +99,7 @@ typedef unsigned int u32;
 // block below or the linker looks for a C-mangled symbol that does not exist.
 void sd_seq_reset(void);
 void sd_mix_reset(void);
+void sd_consumer_reset(void);
 
 extern "C" {
 // hal/os_arena.cpp
@@ -72,109 +108,36 @@ void *port_arena_end(void);
 void *port_arena_cursor(void);
 void  port_arena_set_cursor(void *p);
 
-// ---- game-mutable host globals that live OUTSIDE the arena ----------------
-// Referenced by their real DS symbol names; taking their address to snapshot
-// them is a read, it does not redefine or move any storage. Sizes are the
-// exact declared extents from hal/model_host.cpp and hal/auto_bss.cpp.
-
-// the heap registry root iterator (hal/heap_globals.cpp): the list head/tail/
-// count for every heap that hangs directly off the root. It threads INTO the
-// arena (the HeapAllocator objects it links live in arena-carved storage), so
-// if the game creates or destroys a root-level heap between save and load, this
-// head describes the post-save topology while the restored arena describes the
-// saved one. Capturing it keeps the two in step. isRootHeapIterInitialized is
-// invariant after the first heap comes up but is captured too so the snapshot
-// is internally consistent.
-extern char _ZN6Memory16rootHeapIteratorE[0x20];
-extern int  _ZN6Memory25isRootHeapIterInitializedE;
-
-// actor processing-list heads (hal/model_host.cpp): list heads that thread into
-// arena-resident actor records.
-extern int data_020a4b78[4];
-extern int data_020a4b88[4];
-extern int data_020a4b98[4];
-extern int data_02099f24[4];
-// the Process cleanup list head/tail/callback and the teardown id hook
-// (hal/auto_bss.cpp).
-extern int data_020a4ba8[8];
-extern int data_020a4b5c[4];
-// common-model-data registry: 100 records of 0xc, plus the live count
-// (hal/model_host.cpp).
-extern int data_0209cefc[3 * 100];
-extern int data_0209cef8[1];
-// the render camera matrix and the bound model-matrix pointer
-// (hal/model_host.cpp).
-extern int data_0209b3ec[12];
-extern void *data_020a4bd0;
-// texture-VRAM bump cursors (hal/model_host.cpp): where uploads have reached.
-extern u32 data_020a4bc8;
-extern u32 data_020a4be8;
-extern u32 data_020a4be0;
-extern u32 data_020a4bdc;
-extern u32 data_020a4be4;
-extern u32 data_020a4bcc;
-extern u32 data_020a4bd8;
-// particle-engine RNG state and its arena bump cursors (hal/auto_bss.cpp).
-extern int LCG_STATE_0204da4c;
-extern int data_0209ee78[8];
-extern int data_0209ee7c[8];
-extern int data_0209ee80[8];
+// The two sentinels hal/dsstate_seg.cpp places at the low and high ends of the
+// .dsstate section family. The captured out-of-arena region is the bytes
+// between them: &dsstate_hi - &dsstate_lo, recomputed by the linker every build.
+extern char dsstate_lo;
+extern char dsstate_hi;
 }
 
 namespace {
 
-struct Block { void *addr; size_t size; const char *name; };
-
-// The explicit out-of-arena set. sizeof is taken on the real definitions above
-// so the snapshot tracks whatever those declarations say; a size mismatch would
-// be a compile error, not a silent short copy.
-const Block g_blocks[] = {
-    { _ZN6Memory16rootHeapIteratorE, sizeof _ZN6Memory16rootHeapIteratorE,
-      "heap_root_iterator" },
-    { &_ZN6Memory25isRootHeapIterInitializedE,
-      sizeof _ZN6Memory25isRootHeapIterInitializedE, "heap_root_iter_init" },
-    { data_020a4b78, sizeof data_020a4b78, "actor_list_head_0" },
-    { data_020a4b88, sizeof data_020a4b88, "actor_list_head_1" },
-    { data_020a4b98, sizeof data_020a4b98, "actor_list_head_2" },
-    { data_02099f24, sizeof data_02099f24, "actor_list_head_3" },
-    { data_020a4ba8, sizeof data_020a4ba8, "process_cleanup_list" },
-    { data_020a4b5c, sizeof data_020a4b5c, "process_teardown_hook" },
-    { data_0209cefc, sizeof data_0209cefc, "common_model_records" },
-    { data_0209cef8, sizeof data_0209cef8, "common_model_count" },
-    { data_0209b3ec, sizeof data_0209b3ec, "render_camera_matrix" },
-    { &data_020a4bd0, sizeof data_020a4bd0, "bound_model_matrix_ptr" },
-    { &data_020a4bc8, sizeof data_020a4bc8, "vram_tex_cursor_lo0" },
-    { &data_020a4be8, sizeof data_020a4be8, "vram_tex_ceil0" },
-    { &data_020a4be0, sizeof data_020a4be0, "vram_tex_cursor_lo1" },
-    { &data_020a4bdc, sizeof data_020a4bdc, "vram_tex_ceil1" },
-    { &data_020a4be4, sizeof data_020a4be4, "vram_tex_uploaded_bytes" },
-    { &data_020a4bcc, sizeof data_020a4bcc, "vram_pal_cursor_lo" },
-    { &data_020a4bd8, sizeof data_020a4bd8, "vram_pal_ceil" },
-    { &LCG_STATE_0204da4c, sizeof LCG_STATE_0204da4c, "particle_rng" },
-    { data_0209ee78, sizeof data_0209ee78, "particle_arena_base" },
-    { data_0209ee7c, sizeof data_0209ee7c, "particle_arena_end" },
-    { data_0209ee80, sizeof data_0209ee80, "particle_arena_cursor" },
-};
-const int g_block_count = (int)(sizeof g_blocks / sizeof g_blocks[0]);
+char  *dsstate_base() { return &dsstate_lo; }
+size_t dsstate_size()
+{
+    // The linker orders .dsstate$aaa (dsstate_lo) before every $mmm/$pk... run
+    // and .dsstate$zzz (dsstate_hi) after them, so hi is always >= lo. Guard
+    // anyway: a zero or inverted span means the section collapsed (a build
+    // without the sentinels) and the caller must not copy a bogus length.
+    char *lo = &dsstate_lo, *hi = &dsstate_hi;
+    return hi > lo ? (size_t)(hi - lo) : 0;
+}
 
 struct Slot {
     int    valid;
     char  *arena;        // captured [base, end) bytes
     size_t arena_size;   // end - base
     void  *arena_cursor; // captured low-water carve pointer
-    char  *globals;      // captured out-of-arena blocks, concatenated
+    char  *globals;      // captured [dsstate_lo, dsstate_hi) bytes
     size_t globals_size;
 };
 
 Slot g_slot;
-
-size_t globals_total()
-{
-    size_t t = 0;
-    for (int i = 0; i < g_block_count; ++i)
-        t += g_blocks[i].size;
-    return t;
-}
 
 } // namespace
 
@@ -192,7 +155,17 @@ int lk6_savestate_save(void)
         return 0;
     }
     size_t asz = (size_t)(end - base);
-    size_t gsz = globals_total();
+    size_t gsz = dsstate_size();
+    if (gsz == 0) {
+        // The sentinels collapsed: the .dsstate section is empty, which only
+        // happens in a build where hal/dsstate_seg.cpp did not link or no file
+        // routed a global into the section. Capturing the arena alone would be
+        // the old partial snapshot that crashed on restore, so refuse rather
+        // than ship a state that cannot restore correctly.
+        fprintf(stderr, "[savestate] .dsstate section is empty; save ignored "
+                        "(build is missing the hosted-DS-state section)\n");
+        return 0;
+    }
 
     // Allocate first, commit second: if either malloc fails, keep the prior
     // slot untouched.
@@ -206,11 +179,7 @@ int lk6_savestate_save(void)
     }
 
     memcpy(na, base, asz);
-    size_t off = 0;
-    for (int i = 0; i < g_block_count; ++i) {
-        memcpy(ng + off, g_blocks[i].addr, g_blocks[i].size);
-        off += g_blocks[i].size;
-    }
+    memcpy(ng, dsstate_base(), gsz);
 
     free(g_slot.arena);
     free(g_slot.globals);
@@ -221,8 +190,8 @@ int lk6_savestate_save(void)
     g_slot.globals_size = gsz;
     g_slot.valid        = 1;
 
-    fprintf(stderr, "[savestate] saved: arena %zu bytes, %d globals %zu bytes\n",
-            asz, g_block_count, gsz);
+    fprintf(stderr, "[savestate] saved: arena %zu bytes, dsstate %zu bytes\n",
+            asz, gsz);
     return 1;
 }
 
@@ -245,22 +214,35 @@ int lk6_savestate_load(void)
                 base ? (size_t)(end - base) : 0, g_slot.arena_size);
         return 0;
     }
+    if (dsstate_size() != g_slot.globals_size) {
+        // The section is fixed at link time, so a mismatch means the running
+        // binary is not the one that saved (a disk state from another build,
+        // once lk7's persistence lands). Refuse rather than copy a wrong length.
+        fprintf(stderr, "[savestate] dsstate section changed (%zu vs saved "
+                        "%zu); load refused\n",
+                dsstate_size(), g_slot.globals_size);
+        return 0;
+    }
 
     memcpy(base, g_slot.arena, g_slot.arena_size);
-    size_t off = 0;
-    for (int i = 0; i < g_block_count; ++i) {
-        memcpy(g_blocks[i].addr, g_slot.globals + off, g_blocks[i].size);
-        off += g_blocks[i].size;
-    }
+    memcpy(dsstate_base(), g_slot.globals, g_slot.globals_size);
     port_arena_set_cursor(g_slot.arena_cursor);
 
     // The audio path is the one thing that cannot be memcpy'd back cleanly:
-    // silence it and let the restored game re-trigger sound on the next tick.
+    // even though its storage rode back in with the section above, the live
+    // sequencer phase and mixer envelopes would be a few frames ahead of the
+    // restored world. Silence them and let the restored game re-trigger sound.
     sd_seq_reset();
     sd_mix_reset();
+    // Same reasoning one layer down, and this one FAULTS rather than just
+    // sounding wrong. The ARM7 command queue is described by DS-named globals
+    // (captured) and by host cursors sitting beside them (not captured), so a
+    // restore leaves the two halves disagreeing and func_0205b274 walks the
+    // free list into a null. Re-seed both halves together.
+    sd_consumer_reset();
 
-    fprintf(stderr, "[savestate] restored: arena %zu bytes, %d globals, "
-                    "audio reset\n", g_slot.arena_size, g_block_count);
+    fprintf(stderr, "[savestate] restored: arena %zu bytes, dsstate %zu bytes, "
+                    "audio reset\n", g_slot.arena_size, g_slot.globals_size);
     return 1;
 }
 
@@ -271,39 +253,28 @@ int lk6_savestate_has(void) { return g_slot.valid; }
 
 // ---- COVERAGE NOTE ---------------------------------------------------------
 // COVERED: the whole hosted DS main-RAM arena (the entire heap object graph:
-// Player, actors, camera, collision, model records, allocations), the arena
-// carve cursor, the heap registry root iterator and its init flag, the actor
-// processing-list heads, the Process cleanup list and teardown hook, the
-// common-model-data registry and count, the render camera matrix, the bound
-// model-matrix pointer, the texture-VRAM bump cursors, the particle RNG and its
-// arena cursors.
+// Player, actors, camera, collision, model records, allocations) plus the arena
+// carve cursor, and EVERY hosted DS global routed into the .dsstate section by
+// the DSSTATE_BEGIN/END markers -- the actor processing-list heads, the heap
+// registry root iterator, the Process cleanup list, the common-model-data
+// registry, the render camera matrix, the texture-VRAM cursors, the particle
+// RNG, the message/cutscene mode and lock flags, the ANIM_PTRS SharedFilePtr
+// table and every other overlay-data global, the sound bss, and the bridge
+// state. The set is defined by section membership, not by a list here, so a
+// newly hosted global is captured the moment its file uses the markers. The
+// dsstate_guard build step fails the build if a hosted DS symbol landed outside
+// the section.
 //
-// NOT CAPTURED, RESET ON LOAD: the SDAT sequencer players, mixer channels and
-// phase accumulator (silenced via sd_seq_reset / sd_mix_reset). The game
-// re-triggers sound from the restored world.
+// RESET ON LOAD (captured, then re-silenced): the SDAT sequencer players, mixer
+// channels and phase accumulator ride back in with the section, but the live
+// mixer phase would be a few frames ahead of the restored world, so the load
+// path calls sd_seq_reset / sd_mix_reset after the copy and the game re-triggers
+// sound from the restored state on the next tick. This is the one deliberate
+// departure from a byte-exact restore.
 //
-// KNOWN PARTIAL (host audio bookkeeping): the sound subsystem keeps its own
-// voice and sound-heap iterators (hal/sdat and hal/player_bridges.cpp, e.g.
-// data_020a5bc8 / data_020a4d54 / data_020a4d60) that are neither captured nor
-// rebuilt by the two resets above. Silencing the mixer stops anything reading a
-// stale voice, but a sound object created or destroyed between save and load
-// leaves those voice-list heads describing the post-save topology. In practice
-// the reset plus the game re-triggering sound covers the audible cases; a
-// sound-heap walk immediately after a restore that straddled a voice
-// alloc/free is the residual risk. Left out deliberately: capturing them is the
-// same mechanism as the heap root iterator above and can be added to g_blocks
-// if it ever surfaces as an audible fault.
-//
-// NOT CAPTURED, LEFT ALONE (safe because the next tick overwrites them from
-// arena-resident state, or they are pure host bookkeeping): the per-frame pad
-// shadows (data_0209f49x), the HUD star/red-coin/results caches
-// (data_0209f2d4/30c/fc9c), the 2D scroll offsets and camera-button latches
-// (data_0209d46x/47x/49x), and host-only counters (frame index, telemetry).
-// These are cosmetic for at most one frame after a restore. If a future need
-// arises to make the restore bit-exact on those too, add each symbol to
-// g_blocks above with its declared size; the design does not otherwise change.
-//
-// The OAM shadow buffers (hal/model_host.cpp data_0209e674 / data_0209ea74) are
-// rebuilt from scratch every frame by hal_sub_screen_frame_begin before any
-// sprite is drawn, so they carry nothing across a frame boundary and need no
-// snapshot.
+// DELIBERATELY OUTSIDE .dsstate (host-only, must NOT roll back): the playlog
+// path and frame counter, telemetry, the launcher glue, ntr_2x's host window
+// and framebuffer state, and the C runtime's own globals (locale, FILE tables).
+// Those files do not use the DSSTATE markers, so their storage stays in the
+// ordinary .bss/.data the snapshot never touches. Rolling the frame counter or a
+// FILE* back would corrupt the session, not the game.

--- a/port/hal/message_boot.cpp
+++ b/port/hal/message_boot.cpp
@@ -45,6 +45,7 @@
 #include <cctype>
 
 #include "MessageBank.h"
+#include "dsstate_seg.h"
 
 extern "C" {
 
@@ -65,8 +66,10 @@ extern int data_0209d70c[];   /* gMessageInfoSection (the header func_0201f32c r
 
 /* Written by the real parser, read by nothing matched. Defined below so the
    host copy stores everything the ROM parser does. */
+DSSTATE_BEGIN
 int data_0209d6e8;            /* gMessageBankHeader */
 int data_0209d6ec;            /* gMessageDataSection */
+DSSTATE_END
 
 void port_message_dump(int id); /* defined below */
 

--- a/port/hal/model_host.cpp
+++ b/port/hal/model_host.cpp
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "dsstate_seg.h"
+
 typedef unsigned int u32;
 
 extern "C" {
@@ -85,12 +87,13 @@ void MultiCopy32Bytes(int *src, int *dst, int len)
     __declspec(allocate(sec)) __declspec(align(4))               \
     type name[count]
 
+DSSTATE_BEGIN
 unsigned char data_0209e660 = 1;
 int data_0209e664, data_0209e668, data_0209e66c, data_0209e670;
 /* main OAM shadow, 0x400 bytes, spelled as the ROM's three symbols */
-OAMSHADOW(".oamsh$0000", data_0209e674, unsigned int, 2);      /* +0x000 */
-OAMSHADOW(".oamsh$0001", data_0209e67c, int, 6);               /* +0x008 */
-OAMSHADOW(".oamsh$0002", data_0209e694, int, 0xf8);            /* +0x020 */
+OAMSHADOW(".dsstate$oamsh0000", data_0209e674, unsigned int, 2);      /* +0x000 */
+OAMSHADOW(".dsstate$oamsh0001", data_0209e67c, int, 6);               /* +0x008 */
+OAMSHADOW(".dsstate$oamsh0002", data_0209e694, int, 0xf8);            /* +0x020 */
 unsigned int data_0209ea74[0x100];   /* sub OAM shadow, its own 0x400 */
 
 #undef OAMSHADOW
@@ -258,6 +261,7 @@ void *VTable_Animation_ModelAnimThunk[8];
 void *_ZTV16MeshColliderBase[13];
 unsigned char data_020a0c78[8]; /* the default CLPS ENTRY (8-byte storage,
                                    func_02037e9c fills it on first lookup) */
+DSSTATE_END
 
 // 0x02099f80..0x02099f94 USED TO LIVE HERE, on the reading that 0x02099xxx
 // was past bss_start and so runtime-initialized. It is not: the arm9's real

--- a/port/hal/os_arena.cpp
+++ b/port/hal/os_arena.cpp
@@ -5,6 +5,7 @@
 // set-low). On host the arena is one big malloc'd block, initialized on
 // first use so the smoke needs no setup call.
 #include <stdlib.h>
+#include "dsstate_seg.h"
 
 typedef unsigned int u32;
 
@@ -64,7 +65,9 @@ void  port_arena_set_cursor(void *p) { g_lo = (char *)p; }
 
 extern "C" {
 // the OS globals object; the accessors ignore it, but the address must exist
+DSSTATE_BEGIN
 char data_020a0ea4[4];
+DSSTATE_END
 
 /* PORT_HOST_ABI: DS OS-arena globals live at unmapped 0x27ffda0; host substitutes
    a deterministic calloc'd arena. */

--- a/port/hal/particle_vtable.cpp
+++ b/port/hal/particle_vtable.cpp
@@ -45,6 +45,7 @@
 // sharing is the ROM's, not a simplification -- see the to: addresses.
 #include <cstdio>
 #include <cstdlib>
+#include "dsstate_seg.h"
 
 extern "C" {
 
@@ -73,6 +74,7 @@ void _ZN8Particle21CleanParticleCallback8OnUpdateERNS_6SystemEb(void *, void *, 
 #define SPAWN(f) ((void *)&f)
 #define UPDATE(f) ((void *)&f)
 
+DSSTATE_BEGIN
 /* BubbleCallback.  from:0x0208f3a4 to:0x02022640 | 0x0208f3a8 to:0x02022464 */
 void *data_0208f3a4[2] = {
     SPAWN(_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE),
@@ -184,6 +186,7 @@ void (*data_02099fb4[2])(unsigned char, unsigned char) = {
     (void (*)(unsigned char, unsigned char))func_0204c24c,
     (void (*)(unsigned char, unsigned char))func_0204c194,
 };
+DSSTATE_END
 
 /* Called once before the first frame. Cheap, and it catches the two ways
    this file can rot: a slot left null (the symbol got zeroed storage from

--- a/port/hal/player_bridges.cpp
+++ b/port/hal/player_bridges.cpp
@@ -16,6 +16,8 @@
 #include "Heap.h"
 #include "ModelAnim.h"
 
+#include "dsstate_seg.h"
+
 /* the geometry-engine polygon buffer, for the tongue render self-check
    (SM64DS_WINGS_PROBE); same forward decl cxxname_bridge.cpp uses so the
    header's wider surface does not have to come in here */
@@ -791,6 +793,7 @@ int _ZN4Heap6IntactEv(void *self)
 /* data_0209b44c is NOT here: it is the one-byte area id, hosted in
    hal/actor_vtables.cpp so the smoke targets that link no player bridge
    still get it, and so writer and reader share one object. */
+DSSTATE_BEGIN
 int data_0208e428[8], data_0209b480[4];
 int data_020a4d60[8], data_020a6438[8], data_020a6488[4], data_020a648c[4];
 int data_020a6490[4], data_020a649c[4], data_020a64a0[4], data_020a64a4[4];
@@ -812,6 +815,7 @@ int data_020a4b58[4], data_020a4b68[4], data_020a60f4[4];
 __declspec(align(8)) unsigned char data_023c0000[64];
 int data_02099e94[4], data_02099ebc[4], data_02099ec4[4], data_02099fcc[4];
 int data_020a6084[4], data_020a6088[2], data_020a8114[4];
+DSSTATE_END
 
 }  /* extern "C" */
 

--- a/port/hal/ptr_tables.cpp
+++ b/port/hal/ptr_tables.cpp
@@ -75,6 +75,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "dsstate_seg.h"
+
 extern "C" {
 
 /* THE ONE PRIMITIVE THE CALLEES REACH THAT HAS NO C BODY. src/CpuCopy8.c is
@@ -116,6 +118,7 @@ unsigned int func_0205c448(char *);
    from:0x02086768 to:0x0205c048 | 0x0208676c to:0x0205bc88
    from:0x02086770 to:0x0205bc0c | 0x02086774 to:0x0205bbe4
    from:0x02086778 to:0x0205bbdc */
+DSSTATE_BEGIN
 unsigned int (*data_02086758[9])(char *) = {
     func_0205c448,
     func_0205c410,
@@ -337,6 +340,7 @@ void *data_020876e4[6] = {
     kuppa_blob_0208776c,
     kuppa_blob_02088b14,
 };
+DSSTATE_END
 
 static const unsigned g_kuppa_script_addr[6] = {
     0x02088388, 0x020888f0, 0x0208776c, 0x020889b0, 0x0208776c, 0x02088b14,

--- a/port/hal/sdat/consumer.cpp
+++ b/port/hal/sdat/consumer.cpp
@@ -491,24 +491,22 @@ extern "C" void sd_sound_level_reap(void)
     func_02011974(data_0209b53c);
 }
 
-void sd_consumer_init(void)
+/* Put the command queue back in its just-booted shape: free list relinked, ring
+   empty, every cursor at zero.
+ *
+ * Called from sd_consumer_init at boot and from lk6_savestate_load on a restore.
+ * The restore needs it because this queue is described TWICE -- by the DS-named
+ * globals (data_020a6484 head, data_020a6494 tail, data_020a6498 read index,
+ * data_020a64a0 in flight, ...) and by the host statics beside them (g_readIdx,
+ * g_consumed) -- and the save state captures the first set but not the second.
+ * Rolling back half of a cursor pair leaves the two disagreeing: the restored
+ * read index walks a ring slot the host side has already reclaimed, and
+ * func_0205b274's `while (*node)` chases a stale link into a null. Resetting
+ * both sides together is the same treatment the sequencer and mixer already get
+ * (sd_seq_reset / sd_mix_reset) and for the same reason: this is live plumbing,
+ * not game state, and the game re-fills it on the next tick. */
+void sd_consumer_reset(void)
 {
-    if (g_seeded) return;
-    g_seeded = 1;
-
-    g_trace = getenv("SM64DS_SND_TRACE") != 0;
-    /* the same switch arms Sound::Play's two cull reports (sound_abi.cpp) */
-    g_snd_trace_play = g_trace;
-
-    // Seed the free list. This is func_0205b358's data effect, written out
-    // by hand on purpose: that function is unusable on the host because it
-    // depends on three symbols being ADJACENT in DS memory --
-    //   data_020a6760 (pool) + 0x1800 == data_020a7f60 (callback table),
-    //   data_020a7760 + 0x7e8      == the pool's LAST node, and
-    //   data_020a7f48              == that same last node,
-    // which it uses to zero pool[255].next and to seat the tail pointer.
-    // Host symbols are separate objects, so running it would write past two
-    // of them. The three lines below are what it means, not where it wrote.
     Node *pool = (Node *)data_020a6760;
     for (int i = 0; i < NODES - 1; i++) pool[i].next = &pool[i + 1];
     pool[NODES - 1].next = 0;
@@ -527,6 +525,27 @@ void sd_consumer_init(void)
     data_020a7fc0 = g_status;
     g_consumed = 0;
     g_readIdx = 0;
+}
+
+void sd_consumer_init(void)
+{
+    if (g_seeded) return;
+    g_seeded = 1;
+
+    g_trace = getenv("SM64DS_SND_TRACE") != 0;
+    /* the same switch arms Sound::Play's two cull reports (sound_abi.cpp) */
+    g_snd_trace_play = g_trace;
+
+    // Seed the free list. This is func_0205b358's data effect, written out
+    // by hand on purpose: that function is unusable on the host because it
+    // depends on three symbols being ADJACENT in DS memory --
+    //   data_020a6760 (pool) + 0x1800 == data_020a7f60 (callback table),
+    //   data_020a7760 + 0x7e8      == the pool's LAST node, and
+    //   data_020a7f48              == that same last node,
+    // which it uses to zero pool[255].next and to seat the tail pointer.
+    // Host symbols are separate objects, so running it would write past two
+    // of them. The three lines below are what it means, not where it wrote.
+    sd_consumer_reset();
 
     // func_0205b358 would now send command 0x19 to tell the ARM7 where the
     // status block is. There is no message to send: this consumer owns the

--- a/port/hal/sdat/sdat.h
+++ b/port/hal/sdat/sdat.h
@@ -132,6 +132,12 @@ void sd_mix_frame(void);              // advance every envelope one 192Hz frame
 void sd_mix_render(sd_s16 *dst, int frames);   // stereo interleaved
 void sd_mix_reset(void);
 
+// Re-seed the command queue (free list, ring, cursors) to its booted shape.
+// Boot calls it through sd_consumer_init; a save-state restore calls it beside
+// sd_seq_reset/sd_mix_reset, because the queue's DS-named globals are captured
+// while the host cursors next to them are not. See the note on the definition.
+void sd_consumer_reset(void);
+
 // dB conversion shared by the sequencer and the mixer: 0..127 -> tenths of
 // a dB in -723..0, the DS's own volume range.
 int sd_cnv_vol(int v);

--- a/port/hal/sdat/sound_bss.cpp
+++ b/port/hal/sdat/sound_bss.cpp
@@ -6,7 +6,10 @@
 // that walks it -- a too-small array here is silent corruption of whatever
 // the linker happens to place next, not a crash, so the arithmetic is spelled
 // out rather than rounded up.
+#include "../dsstate_seg.h"
+
 extern "C" {
+DSSTATE_BEGIN
 
 // The 16 voice records. func_0204fc40 runs i = 0..15 writing +0x2c and +0x3c
 // and adding each to the free list, so the stride is 0x40 and 16 * 0x40 =
@@ -36,4 +39,5 @@ int data_020a4d48, data_020a4d4c, data_020a4d50;
 int data_020a55fc;
 unsigned char data_020a5634[0x50];
 
+DSSTATE_END
 }

--- a/port/hal/sub_actors.cpp
+++ b/port/hal/sub_actors.cpp
@@ -64,6 +64,7 @@
 #include "Actor.h"
 #include "ActorBase.h"
 #include "ActorDerived.h"
+#include "dsstate_seg.h"
 
 extern "C" {
 /* HUD's own C-named halves: the two destructors */
@@ -162,10 +163,10 @@ extern "C" void _ZN7Minimap19UpdateLevelSpecificEv(void)
     extern "C" __declspec(allocate(sec)) __declspec(align(4))     \
     unsigned char name[size] = {0}
 
-MMBLK(".mmblk$0000", data_0209f3a4, 0x20);   /* 8 Obj* -- the red-coin markers */
-MMBLK(".mmblk$0001", data_0209f3c4, 0x04);
-MMBLK(".mmblk$0002", data_0209f3c8, 0x20);
-MMBLK(".mmblk$0003", data_0209f3e8, 0x24);   /* 9 Obj* -- the star markers */
+MMBLK(".dsstate$mmblk0000", data_0209f3a4, 0x20);   /* 8 Obj* -- the red-coin markers */
+MMBLK(".dsstate$mmblk0001", data_0209f3c4, 0x04);
+MMBLK(".dsstate$mmblk0002", data_0209f3c8, 0x20);
+MMBLK(".dsstate$mmblk0003", data_0209f3e8, 0x24);   /* 9 Obj* -- the star markers */
 
 #undef MMBLK
 
@@ -251,6 +252,7 @@ extern "C" void port_minimap_affine_update(void)
 }
 
 extern "C" {
+DSSTATE_BEGIN
 /* Standalone, and zero on this boot -- nothing on the castle grounds writes
    them, so the branches they gate stay off and say nothing. */
 unsigned char data_0209f288;          /* "draw the second marker set" flag */
@@ -267,6 +269,7 @@ unsigned data_020a60a4;               /* GXS ext-palette: the saved VRAM bank */
    never read for a value that matters. */
 unsigned char data_0209f4a8[0x60];
 unsigned char data_0209f4a9[0x60];
+DSSTATE_END
 }
 
 // ---- the faces --------------------------------------------------------------

--- a/port/ntr/runtime.cpp
+++ b/port/ntr/runtime.cpp
@@ -17,6 +17,7 @@
 #include "ntr/gx.h"
 
 #include <cstring>
+#include "hal/dsstate_seg.h"
 
 // ---------------------------------------------------------------------------
 // Interrupt control. The ARM originals set/clear the CPSR I bit and return the
@@ -135,9 +136,16 @@ extern "C" void func_020553c0(unsigned addr) {
 // ---------------------------------------------------------------------------
 
 extern "C" {
-// storage for the game's DMA bookkeeping (BSS on the DS)
+// storage for the game's DMA bookkeeping (BSS on the DS). These two are the
+// only DS globals this host library owns, and they are real save state rather
+// than host bookkeeping: the callback table holds the handlers the game itself
+// registered through func_02056e98. Everything else in this file (the window,
+// frame pacing, the IE stand-in below) deliberately stays out of the capture.
+// See hal/dsstate_seg.h.
+DSSTATE_BEGIN
 int data_020a6460[8];                                   /* GX-DMA state */
 struct { unsigned handler, active, arg; } data_020a60c4[8]; /* per-channel cbs */
+DSSTATE_END
 }
 
 namespace {

--- a/port/tests/smoke_savestate.cpp
+++ b/port/tests/smoke_savestate.cpp
@@ -64,21 +64,33 @@ void *port_arena_base(void);
 void *port_arena_end(void);
 void *port_arena_cursor(void);
 extern int LCG_STATE_0204da4c;
-// out-of-arena globals the snapshot must restore through g_blocks, NOT through
-// the arena copy. The test fingerprints these directly (data_0209b3ec, the
-// render camera matrix, is already declared above) so that dropping any of them
-// from g_blocks would fail this test rather than pass silently.
+// out-of-arena globals the snapshot must restore through the .dsstate section,
+// NOT through the arena copy. The test fingerprints these directly (data_0209b3ec,
+// the render camera matrix, is already declared above) so that dropping any of
+// them from the captured section would fail this test rather than pass silently.
 extern char _ZN6Memory16rootHeapIteratorE[0x20];   /* heap registry head */
 extern u32  data_020a4bc8;                          /* a VRAM bump cursor */
+// A hosted global that was NEVER in the old hand-picked list: the message-active
+// mode/lock flag (auto_bss.cpp). It is the kind of symbol the 0.2.0 snapshot
+// dropped -- set it after save, and only a whole-.dsstate capture rolls it back.
+// Fingerprinting it here is acceptance test 2 (a mode/lock global rolls back)
+// run on the underlying global, alongside the arena/actor checks.
+extern unsigned char data_0209d660;                 /* message-active lock */
 }
 
-// lk6_savestate_load() calls the sdat audio reset on restore. The full sdat
+// lk6_savestate_load() calls the sdat audio resets on restore. The full sdat
 // host stack is far more than this actor smoke needs to link, and the audio
 // reset is a no-op for a headless run with no device open, so this test
-// provides the two symbols directly. In the shipped walk_window build these
-// resolve to the real hal/sdat/sseq.cpp and hal/sdat/mixer.cpp.
+// provides the symbols directly. In the shipped walk_window build these
+// resolve to the real hal/sdat/sseq.cpp, mixer.cpp and consumer.cpp.
+//
+// Note what this means for coverage: the command-queue reset that keeps a
+// restore from faulting in func_0205b274 is stubbed out HERE, so this test
+// cannot see that bug. It is the walk_window reproducer
+// (SM64DS_SS_SAVE/SM64DS_SS_LOAD) that covers it, against the real queue.
 void sd_seq_reset(void) {}
 void sd_mix_reset(void) {}
+void sd_consumer_reset(void) {}
 
 typedef int (__thiscall *Fn0)(void *);
 static int vcall0(void *actor, int slot)
@@ -130,6 +142,7 @@ struct Fingerprint {
     char     heaphead[0x20]; // heap registry root iterator (out-of-arena)
     int      cammat[12];     // render camera matrix (out-of-arena)
     u32      vramcur;        // a VRAM bump cursor (out-of-arena)
+    unsigned char msglock;   // message-active lock (never in the old list)
 };
 
 static Fingerprint fingerprint(int *actor)
@@ -145,6 +158,7 @@ static Fingerprint fingerprint(int *actor)
     memcpy(f.heaphead, _ZN6Memory16rootHeapIteratorE, sizeof f.heaphead);
     memcpy(f.cammat, data_0209b3ec, sizeof f.cammat);
     f.vramcur = data_020a4bc8;
+    f.msglock = data_0209d660;
     return f;
 }
 
@@ -155,7 +169,7 @@ static int fp_equal(const Fingerprint &a, const Fingerprint &b)
            a.pos[2] == b.pos[2] && a.timer == b.timer &&
            memcmp(a.heaphead, b.heaphead, sizeof a.heaphead) == 0 &&
            memcmp(a.cammat, b.cammat, sizeof a.cammat) == 0 &&
-           a.vramcur == b.vramcur;
+           a.vramcur == b.vramcur && a.msglock == b.msglock;
 }
 
 int main(void)
@@ -232,12 +246,16 @@ int main(void)
     *(int *)((char *)actor + 0x64) = 0x00000000;
     *(int *)((char *)actor + 0x70) = 0x00000000;
     LCG_STATE_0204da4c = 0x0badc0de;
-    // stomp the out-of-arena globals too: these restore through g_blocks, not
-    // through the arena copy, so mangling them here proves the block path works
-    // (and would catch a block dropped from g_blocks).
+    // stomp the out-of-arena globals too: these restore through the .dsstate
+    // section, not through the arena copy, so mangling them here proves the
+    // section path works (and would catch one dropped from the capture).
     memset(_ZN6Memory16rootHeapIteratorE, 0x5a, sizeof(_ZN6Memory16rootHeapIteratorE));
     for (int k = 0; k < 12; ++k) data_0209b3ec[k] = 0x0badf00d;
     data_020a4bc8 = 0xdeadbeefu;
+    // the message-active lock: set it the way opening a dialogue would. It was
+    // never in the old hand-picked list, so only a whole-.dsstate capture rolls
+    // it back. Saved value was 0 (boot), so this is a real divergence.
+    data_0209d660 = 1;
     Fingerprint diverged = fingerprint(actor);
     printf("  diverged fingerprint: hash=%016llx rng=%08x pos0=%08x\n",
            (unsigned long long)diverged.hash, (unsigned)diverged.rng,
@@ -264,10 +282,14 @@ int main(void)
     CHECK(after.pos[2] == saved.pos[2]);
     CHECK(after.timer == saved.timer);
     // the out-of-arena block path specifically: heap head, camera matrix, VRAM
-    // cursor all came back through g_blocks.
+    // cursor all came back through the .dsstate section.
     CHECK(memcmp(after.heaphead, saved.heaphead, sizeof after.heaphead) == 0);
     CHECK(memcmp(after.cammat, saved.cammat, sizeof after.cammat) == 0);
     CHECK(after.vramcur == saved.vramcur);
+    // the widened capture, specifically: a hosted global outside the old list
+    // (the message-active lock) rolled back too. This is the assertion that
+    // would have caught the 0.2.0 crash class.
+    CHECK(after.msglock == saved.msglock);
     CHECK(fp_equal(saved, after));
 
     // ---- (7) keep running after the load -----------------------------------

--- a/port/tests/walk_window.cpp
+++ b/port/tests/walk_window.cpp
@@ -2396,6 +2396,78 @@ int main(void)
             save_edge = save_now;
             load_edge = load_now;
         }
+        /* SCRIPTED SAVE-STATE REPRODUCER (headless, selftest only).
+           This is the regression rig for the 0.2.0 restore crash: real players
+           save, then a message/cutscene changes hosted mode-lock state that
+           lives OUTSIDE the arena, then they restore, and the game either
+           faults in Player::SetAnim on a null BCA_File* (the ANIM_PTRS
+           SharedFilePtr table, data_ov002_020ff480, is a hosted overlay global
+           the pre-fix snapshot never captured) or stays wedged in a message the
+           arena has already rolled away from.
+
+               SM64DS_SS_SAVE=<frame>   fire lk6_savestate_save() at this frame
+               SM64DS_SS_LOAD=<frame>   fire lk6_savestate_load() at this frame
+               SM64DS_SS_LOCK=1         between save and load, force the hosted
+                                        message-active lock (data_0209d660) set,
+                                        the way opening a dialogue would, so the
+                                        restore has a specific out-of-arena bit
+                                        to prove it rolls back
+               SM64DS_SS_ASSERT=1       capture data_0209d660 at save and assert
+                                        it equals that value after load; a
+                                        non-zero exit if the lock survived the
+                                        restore. This is acceptance test 2 (the
+                                        mode/lock global rolls back) run
+                                        directly on the underlying global, since
+                                        a full castle-grounds cutscene is not
+                                        reachable in a plain headless walk. */
+        if (selftest) {
+            static int ss_env, ss_save_fr = -1, ss_load_fr = -1,
+                       ss_lock = 0, ss_assert = 0;
+            static unsigned char ss_lock_at_save;
+            static int ss_saw_save = 0;
+            if (!ss_env) {
+                ss_env = 1;
+                const char *s = getenv("SM64DS_SS_SAVE");
+                const char *l = getenv("SM64DS_SS_LOAD");
+                if (s) ss_save_fr = atoi(s);
+                if (l) ss_load_fr = atoi(l);
+                ss_lock = getenv("SM64DS_SS_LOCK") != 0;
+                ss_assert = getenv("SM64DS_SS_ASSERT") != 0;
+            }
+            if (ss_save_fr >= 0 && frame == ss_save_fr) {
+                lk6_savestate_save();
+                ss_lock_at_save = data_0209d660;
+                ss_saw_save = 1;
+                fprintf(stderr, "[ss-repro] f%d save: msglock(d660)=%u\n",
+                        frame, (unsigned)data_0209d660);
+            }
+            /* perturb the out-of-arena lock strictly between save and load, so
+               the world provably diverges on a hosted global the arena copy
+               does not own */
+            if (ss_lock && ss_saw_save && ss_load_fr >= 0 &&
+                frame > ss_save_fr && frame < ss_load_fr)
+                data_0209d660 = 1;
+            if (ss_load_fr >= 0 && frame == ss_load_fr) {
+                fprintf(stderr, "[ss-repro] f%d pre-load: msglock(d660)=%u\n",
+                        frame, (unsigned)data_0209d660);
+                if (lk6_savestate_load()) an_pivot_live = 0;
+                fprintf(stderr, "[ss-repro] f%d post-load: msglock(d660)=%u "
+                        "(saved %u)\n", frame, (unsigned)data_0209d660,
+                        (unsigned)ss_lock_at_save);
+                if (ss_assert && data_0209d660 != ss_lock_at_save) {
+                    fprintf(stderr, "[ss-repro] FAIL: message-lock global "
+                            "data_0209d660 did NOT roll back on restore "
+                            "(post-load %u, saved %u) -- a hosted DS global "
+                            "outside the capture set survived the load\n",
+                            (unsigned)data_0209d660, (unsigned)ss_lock_at_save);
+                    ntr::ppu_write_bmp("walk_window_selftest.bmp", fb);
+                    return 3;
+                }
+                if (ss_assert)
+                    fprintf(stderr, "[ss-repro] PASS: message-lock global "
+                            "rolled back on restore\n");
+            }
+        }
         /* drain what the window procedure collected. Unconditionally, so a
            drag taken in DS-exact mode does not pile up and dump into the rig
            the moment F1 hands it the view. MOUSE_YAW is 48 binangs a pixel --

--- a/port/tools/dsstate_guard.py
+++ b/port/tools/dsstate_guard.py
@@ -1,0 +1,210 @@
+"""Build-time guard: every hosted DS global must live in the .dsstate section.
+
+The save state (hal/lk6_savestate.cpp) captures the hosted DS main-RAM arena
+plus the whole .dsstate section, where every file that hosts DS globals routes
+them with the DSSTATE_BEGIN/END markers (hal/dsstate_seg.h). The 0.2.0 restore
+crash was a hosted global that was NOT captured -- the ANIM_PTRS SharedFilePtr
+table in ov002. This guard is the ratchet that keeps that from recurring: it
+reads the linked map and fails the build if a hosted DS symbol landed OUTSIDE
+the bracket the snapshot copies.
+
+WHAT COUNTS AS A HOSTED DS SYMBOL
+--------------------------------
+A public symbol in the read/write data segment whose name is a DS symbol the
+port hosts:
+
+    data_0XXXXXXX            a DS main-RAM BSS/data symbol (0x02......)
+    data_ovNNN_0XXXXXXX      an overlay data symbol
+    LCG_STATE_0XXXXXXX       the particle RNG
+    port_ovNNN_image         a whole-overlay host image
+    _ZNK...E / _ZN...E       a C++-mangled DS data symbol (rare; the heap
+                             registry root iterator is one)
+
+Host-only symbols (walk_window's playlog path, ntr_2x window state, the CRT)
+never match these patterns, so they are correctly ignored: they must NOT be in
+.dsstate and the guard does not ask them to be.
+
+HOW THE BOUND IS READ
+---------------------
+hal/dsstate_seg.cpp puts dsstate_lo in .dsstate$aaa and dsstate_hi in
+.dsstate$zzz, so [addr(dsstate_lo), addr(dsstate_hi)) is the captured span. A
+hosted symbol passes iff its address is inside that half-open range. The two
+sentinels themselves are excluded (they are the fence, not payload).
+
+USAGE
+    python tools/dsstate_guard.py <path-to-walk_window.map>
+
+Exit 0 if every hosted DS symbol is inside .dsstate; non-zero (with the offending
+symbols listed) otherwise.
+"""
+
+import re
+import sys
+
+
+# Publics-by-value rows look like:
+#   0003:000002e8       _data_ov002_020ff480       005852e8     ov002_data.c.obj
+# and, for a symbol the linker flagged as code, with an extra one-letter column:
+#   0001:000936f0       _data_ov000_020ab3c4       004946f0 f   func_ov001_020ab3c4.c.obj
+# groups: seg:off, name, rva+base, flag ('f' = function, 'i' = import, or none),
+# object. The flag matters: dsd names some FUNCTIONS `data_*` (a symbol it saw
+# referenced as data that turned out to be code), and those live in .text. They
+# are not save state and must not be asked to move into .dsstate.
+ROW = re.compile(
+    r"^\s*([0-9a-fA-F]{4}):([0-9a-fA-F]{8})\s+(\S+)\s+([0-9a-fA-F]{8})\s+"
+    r"(?:([fi])\s+)?(\S+)")
+
+# The map's leading section table. Rows look like:
+#   0005:00000008 0002b8c8H .dsstate$mmm            DATA
+# groups: seg, offset, length, name, class
+SECTION_ROW = re.compile(
+    r"^\s*([0-9a-fA-F]{4}):([0-9a-fA-F]{8})\s+([0-9a-fA-F]+)H\s+(\.\S+)\s+(\S+)\s*$")
+
+# A hosted DS symbol by name. Leading underscore is MSVC's cdecl decoration on
+# C symbols; C++-mangled names (_ZN..) keep their own leading underscore-Z.
+HOSTED = re.compile(
+    r"^_?("
+    r"data_0[0-9a-fA-F]{7}"          # DS main-RAM data/bss
+    r"|data_ov\d+_0[0-9a-fA-F]{7}"   # overlay data
+    r"|LCG_STATE_0[0-9a-fA-F]{7}"    # particle RNG
+    r"|port_ov\d+_image"             # whole-overlay host image
+    r")$"
+    # plus the handful of C++-mangled DS data symbols the port hosts; matched
+    # loosely by the trailing E on a data name we know lands in rw data.
+    r"|^_ZN6Memory16rootHeapIteratorE$"
+    r"|^_ZN6Memory25isRootHeapIterInitializedE$")
+
+SENTINELS = {"_dsstate_lo", "dsstate_lo", "_dsstate_hi", "dsstate_hi"}
+
+# Named boot-constant exclusions. These ARE hosted DS globals but are written
+# exactly once at boot and never during play, so they cannot diverge between a
+# save and a load and are deliberately outside .dsstate. Each entry names every
+# map spelling of the symbol (the real storage AND its /alternatename aliases:
+# an alias appears in the map as its own public at the same address, so the
+# guard must know both or it flags the alias). Keep the rationale next to the
+# definition too -- data_020a0eac's is in hal/cxxname_bridge.cpp.
+BOOT_CONSTANT = {
+    # the game heap pointer: Heap::InitializeGameHeap writes it once off the
+    # main.c boot spine; the port seeds it once before the frame loop.
+    "_data_020a0eac", "data_020a0eac", "_data_020a0eac_c", "data_020a0eac_c",
+    "?data_020a0eac@@3PAUHeap@@A",
+}
+
+# Object files whose data_* symbols are READ-ONLY ROM constants, not mutable
+# game state: the game never writes them, so they never diverge between a save
+# and a load and do not need to roll back. romdata.py emits only such constants
+# (its own header says so, and it explicitly excludes the symbols that ARE
+# written at runtime, which live in model_host.cpp / auto_bss.cpp and so are in
+# .dsstate). Capturing them would just bloat the snapshot by the ROM's constant
+# tables. They are allowed to sit outside .dsstate.
+CONST_OBJS = ("romdata.c.obj",)
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: dsstate_guard.py <walk_window.map>")
+    try:
+        text = open(sys.argv[1], encoding="ascii", errors="replace").read()
+    except OSError as e:
+        sys.exit(f"dsstate_guard: cannot read map: {e}")
+
+    lo = hi = None
+    rows = []
+    dsstate_segs = {}
+    for line in text.splitlines():
+        s = SECTION_ROW.match(line)
+        if s:
+            sseg, soff, slen, sname, sclass = s.groups()
+            if sname.startswith(".dsstate"):
+                dsstate_segs.setdefault(sseg, []).append(sname)
+            continue
+        m = ROW.match(line)
+        if not m:
+            continue
+        seg, off, name, rva, flag, obj = m.groups()
+        if flag == "f":       # code, not data -- see the ROW comment
+            continue
+        rva = int(rva, 16)
+        if name in ("_dsstate_lo", "dsstate_lo"):
+            lo = rva
+        elif name in ("_dsstate_hi", "dsstate_hi"):
+            hi = rva
+        rows.append((name, rva, obj))
+
+    # The split-section trap. MSVC will not merge two same-named sections whose
+    # characteristics differ, so a contribution routed in with a bare bss_seg
+    # (CNT_UNINITIALIZED_DATA) forms a SECOND output section also called
+    # .dsstate, placed outside the sentinels, and every hosted global in it is
+    # silently uncaptured. The compiler says only `LNK4078` about it, which is a
+    # warning nobody reads in a 2000-line build log. Catch it here, by name,
+    # because the symptom otherwise reads as "hundreds of files forgot their
+    # markers" and sends the reader off fixing files that are already correct.
+    if len(dsstate_segs) > 1:
+        print(f"dsstate_guard: .dsstate was SPLIT across {len(dsstate_segs)} "
+              f"segments -- the linker refused to merge them because their "
+              f"section attributes differ (this is what LNK4078 means). Only "
+              f"the segment holding the sentinels is captured; the rest is "
+              f"silently lost on a restore.", file=sys.stderr)
+        for sseg, names in sorted(dsstate_segs.items()):
+            shown = ", ".join(sorted(set(names))[:4])
+            more = "" if len(set(names)) <= 4 else f" (+{len(set(names)) - 4} more)"
+            print(f"  segment {sseg}: {shown}{more}", file=sys.stderr)
+        print("Fix: every file routing into .dsstate must declare the section's "
+              "attributes BEFORE routing, so both bss- and data-flavoured "
+              "contributions agree: `#pragma section(\".dsstate$mmm\", read, "
+              "write)`. hal/dsstate_seg.h does this for anything that includes "
+              "it; a generator emitting raw pragmas must emit it too.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if lo is None or hi is None:
+        sys.exit("dsstate_guard: .dsstate sentinels (dsstate_lo/dsstate_hi) not "
+                 "found in the map -- hal/dsstate_seg.cpp is not linked into this "
+                 "target, or the section collapsed. The save state cannot "
+                 "capture the hosted DS globals without it.")
+    if hi <= lo:
+        sys.exit(f"dsstate_guard: .dsstate span is empty or inverted "
+                 f"(lo={lo:#x} hi={hi:#x}); the section did not gather anything.")
+
+    outside = []
+    seen = set()
+    for name, rva, obj in rows:
+        if name in SENTINELS or name in BOOT_CONSTANT:
+            continue
+        if not HOSTED.match(name):
+            continue
+        if name in seen:      # a symbol can appear under several C++ aliases
+            continue
+        seen.add(name)
+        if obj.endswith(CONST_OBJS):   # read-only ROM constants, never diverge
+            continue
+        if not (lo <= rva < hi):
+            outside.append((name, rva, obj))
+
+    if outside:
+        print(f"dsstate_guard: {len(outside)} hosted DS symbol(s) are OUTSIDE "
+              f".dsstate [{lo:#x}, {hi:#x}) and would NOT be captured by a save "
+              f"state:", file=sys.stderr)
+        for name, rva, obj in sorted(outside, key=lambda r: r[0])[:60]:
+            print(f"  {name}  @ {rva:#010x}  ({obj})", file=sys.stderr)
+        if len(outside) > 60:
+            print(f"  ... and {len(outside) - 60} more", file=sys.stderr)
+        print("Fix, in the file that DEFINES each symbol above:\n"
+              "  - a plain global: put DSSTATE_BEGIN before and DSSTATE_END "
+              "after it (hal/dsstate_seg.h).\n"
+              "  - a global placed by hand into its own grouped section to keep "
+              "ROM spacing (the COMM/MMBLK/SAVEBLK-style macros): the segment "
+              "default does NOT reach it, because __declspec(allocate) wins. "
+              "Rename its section into the captured family instead, "
+              "`.dsstate$<family><NNNN>`, the way tools/ovdata.py names packed "
+              "overlay mounts `.dsstate$pkNNN_SSSS`.\n"
+              "  - a generated overlay file: have tools/ovdata.py emit the "
+              "markers.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"dsstate_guard: OK -- {len(seen)} hosted DS symbols all inside "
+          f".dsstate [{lo:#x}, {hi:#x}), {(hi - lo)} bytes captured.")
+
+
+if __name__ == "__main__":
+    main()

--- a/port/tools/ovdata.py
+++ b/port/tools/ovdata.py
@@ -234,11 +234,23 @@ def whole_mode(root, ov, ovid, base, data, out_path):
     lines += [
         "typedef unsigned char u8;",
         "",
+        # The whole-overlay image is mutable game state (SharedFilePtr caches,
+        # actor tables) that a save state has to roll back, so route it into the
+        # .dsstate section the snapshot captures. The section declaration must
+        # come first: without it a bss-flavoured contribution gets different
+        # characteristics from the sentinels' section and the linker silently
+        # splits .dsstate in two, leaving these bytes outside the captured span
+        # (LNK4078). See hal/dsstate_seg.h.
+        '#pragma section(".dsstate$mmm", read, write)',
+        '#pragma data_seg(".dsstate$mmm")',
+        '#pragma bss_seg(".dsstate$mmm")',
         f"/* {len(data):#x} bytes of image + {bss:#x} of bss, one object so the"
         " game's",
         " * table walks stay inside it however far past a symbol they step. */",
         f"__declspec(align(8)) u8 {tag}_image[{total}] = "
         f"{{ {romblob_common.init_body(data)} }};",
+        "#pragma data_seg()",
+        "#pragma bss_seg()",
         f"const unsigned {tag}_ds_base = {base:#010x}u;",
         f"const unsigned {tag}_ds_end = {base + total:#010x}u;",
         "",
@@ -505,6 +517,19 @@ def main():
     if romblob_common.ROM_CLEAN:
         lines.append("#include <string.h>")
     lines += ["typedef unsigned char u8;", ""]
+    # Overlay data is mutable game state (SharedFilePtr caches, actor and anim
+    # tables) a save state must roll back. The plain per-symbol arrays below
+    # come out in the default rw data unless routed, so set the .dsstate default
+    # segment before them and clear it after. Packed mounts (--pack) place each
+    # symbol in its own .dsstate$pkNNN slot explicitly, so they do not lean on
+    # this default. The section declaration comes first so a bss-flavoured array
+    # here carries the same characteristics as the sentinels' section; without it
+    # the linker splits .dsstate in two and these bytes fall outside the captured
+    # span (LNK4078). See hal/dsstate_seg.h.
+    if not pack:
+        lines.append('#pragma section(".dsstate$mmm", read, write)')
+        lines.append('#pragma data_seg(".dsstate$mmm")')
+        lines.append('#pragma bss_seg(".dsstate$mmm")')
     # --pack: THE SYMBOLS KEEP THEIR ROM SPACING.
     #
     # dsd names a symbol wherever code happened to reference one, so a single
@@ -548,6 +573,15 @@ def main():
 
     if pack:
         tag = f"pk{ovid:03d}"
+        # A packed mount keeps each symbol in its own section slot so the run
+        # reproduces the ROM's spacing. Route those slots INTO the .dsstate
+        # section the save state captures: one base section .dsstate, grouped
+        # (and ordered) by a per-mount, per-slot suffix after the single `$`.
+        # MSVC merges grouped sections by the text after the first `$`, so
+        # pkNNN_SSSS sorts this mount's slots in order and drops the whole run
+        # between the .dsstate$aaa/$zzz sentinels. See hal/dsstate_seg.h.
+        def pksect(s):
+            return f".dsstate$pk{ovid:03d}_{s:04d}"
         pack_rows.sort()
         slot = 0
         prev_end = None
@@ -576,15 +610,15 @@ def main():
                 # only to pad the run so the named symbols keep their ROM
                 # spacing, and its bytes are never read directly.
                 lines.append(
-                    f'__pragma(section(".{tag}${slot:04d}", read, write))'
-                    f' __declspec(allocate(".{tag}${slot:04d}"))'
+                    f'__pragma(section("{pksect(slot)}", read, write))'
+                    f' __declspec(allocate("{pksect(slot)}"))'
                     f' __declspec(align({rom_align(prev_end)}))'
                     f' static u8 {tag}_gap_{prev_end:08x}'
                     f'[{gap}] = {{ 0 }};')
                 slot += 1
             lines.append(
-                f'__pragma(section(".{tag}${slot:04d}", read, write))'
-                f' __declspec(allocate(".{tag}${slot:04d}"))'
+                f'__pragma(section("{pksect(slot)}", read, write))'
+                f' __declspec(allocate("{pksect(slot)}"))'
                 f' __declspec(align({rom_align(a)}))'
                 f' u8 {name}[{size}] = '
                 f'{{ {romblob_common.init_body(blob_of[name])} }};')
@@ -692,6 +726,14 @@ def main():
                 patches.append("    *(unsigned int *)(%s + %d) = "
                                "(unsigned int)(%s + %d);"
                                % (name, off, hit[2], v - hit[0]))
+    # Close the .dsstate default segment opened for the plain mount so the
+    # apply/patch code and anything after it stays in the ordinary segments.
+    # (data_seg does not affect functions, but the synthetic gap arrays above
+    # are data and had to land in .dsstate too, which they did while it was
+    # open.) Packed mounts never opened it.
+    if not pack:
+        lines.append('#pragma data_seg()')
+        lines.append('#pragma bss_seg()')
     lines.append("")
     lines.append("void port_%s_%spatch(void)\n{"
                  % (ov, "syms_" if pack else ""))

--- a/port/unmatched/MeshCollider_DetectClsn_Sphere.cpp
+++ b/port/unmatched/MeshCollider_DetectClsn_Sphere.cpp
@@ -67,6 +67,7 @@
 
 #include "MeshCollider.h"
 #include "ntr/mmio.h"
+#include "hal/dsstate_seg.h"
 
 /* Completed here the way the line walk next door completes it: the 8-byte CLPS
    entry then the face normal, pinned by SurfaceInfo::CopyNormalTo (0x02037dcc).
@@ -147,7 +148,9 @@ s32  _ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b(void *self, const void *info
    seed: c[0] = 0xfc0, c[1] = 0xff, c[2..4] = 0. GetSurfaceInfo rewrites all
    five before every read, so the seed only ever describes the state before the
    first prism of the first frame. */
+DSSTATE_BEGIN
 u32 data_020a0cec[5] = { 0xfc0u, 0xffu, 0u, 0u, 0u };
+DSSTATE_END
 
 /* Stage telemetry, read by the probes -- the g_walk_dbg convention from the
    line walk next door, cheap enough to keep permanently.

--- a/port/unmatched/Player_InitResources.cpp
+++ b/port/unmatched/Player_InitResources.cpp
@@ -10,6 +10,7 @@
 // -O4,p (only stack u8[N]={0} does); small asm block reproduces it.
 // Also: pin data_0209f2d8 in local `d` so ==2 keeps r1 bool (preserves r0);
 // decl order td,tx,tz + load order for RaycastGround pos regs.
+#include "hal/dsstate_seg.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -44,6 +45,11 @@ extern "C" {
     void func_020072c0(void);
     void func_0203d384(void);
 
+/* The definitions below are hosted DS globals (the player's resource and
+   spawn latches), so they go in the section the save state captures. A
+   restore that left these behind would keep the pre-save player-init state
+   alive underneath a restored world. See hal/dsstate_seg.h. */
+DSSTATE_BEGIN
     u8 data_0209f2d8;
     s8 data_0209f2f8;
     u8 data_0209f254;
@@ -66,6 +72,7 @@ extern "C" {
        recorded return point" value. This TU only ever writes 2. */
     extern s8 data_0209211c;
     u8 data_0209f200;
+DSSTATE_END
 }
 
 struct V3 { int x, y, z; };


### PR DESCRIPTION
Finishes the `.dsstate` capture scheme and fixes the two bugs standing between it and a working restore.

## What was wrong

The scheme replaces the snapshot's hand-written 23-entry symbol list with a linker section every hosted DS global is routed into, plus a build guard that fails the build if one lands outside. The list is what shipped the 0.2.0 restore crash: it never named ov002's ANIM_PTRS SharedFilePtr table, which survived a restore and handed `Player::SetAnim` a null `BCA_File*`.

The markers were all in place, but MSVC will not merge two same-named sections whose characteristics differ. A global routed in with a bare `bss_seg` carries `CNT_UNINITIALIZED_DATA`, the sentinels' explicitly-declared section carries `CNT_INITIALIZED_DATA`, and the linker emits a **second** output section also called `.dsstate`, placed nowhere near the fence. 553 hosted globals sat in it, uncaptured, announced only as `LNK4078` in the build log.

Declaring the section's attributes before anything routes into it pins one attribute set for the whole family.

The remainder were globals the segment default cannot reach because `__declspec(allocate)` wins: six families placed by hand into their own grouped sections to hold ROM spacing (`.camcomm`, `.camrec`, `.savblk`, `.mmblk`, `.hvsstar`, `.oamsh`, `.mmcray`). They are renamed into `.dsstate$<family><NNNN>`, the way packed overlay mounts already name their slots, so they keep their spacing inside the captured span.

## The bug capturing more state exposed

The ARM7 sound command queue is described twice, by DS-named globals (now captured) and by host cursors beside them (not captured). A restore rolled back half of a cursor pair, and `func_0205b274` walked the free list into a null. `sd_consumer_reset` re-seeds both halves together, the same treatment the sequencer and mixer already get on load.

## Guard

`tools/dsstate_guard.py` now names the split-section failure directly instead of listing hundreds of symbols under a "add your markers" hint, which reads as "these files forgot something" when the files are already correct. It also stops flagging linker-flagged code symbols: dsd names some functions `data_*`, they live in `.text`, and they are not save state.

## Verification

- guard: 4818 hosted DS symbols inside `.dsstate`, 0 outside, 323780 bytes captured
- `smoke_savestate`: world evolved, saved, diverged, restored byte-exact, kept running
- `walk_window` reproducer (`SM64DS_SS_SAVE`/`SM64DS_SS_LOAD`): message-lock global rolls back, clean at 200 and 400 frames, against a control run that was already clean

Note the byte gate says nothing about this change: `git diff -- src/` is empty, and nothing in CI builds `port/`. The evidence above is a local build.