### PR TITLE
The save state carries the hardware stores, so it survives crossing areas

### DIFF
--- a/port/hal/lk6_savestate.cpp
+++ b/port/hal/lk6_savestate.cpp
@@ -76,8 +76,20 @@
 // path additionally silences the sequencer and mixer (sd_seq_reset +
 // sd_mix_reset); the game re-triggers sounds from the restored state on the next
 // tick. The wave decode cache (hal/sdat/sdat.cpp g_waves) is keyed by SWAV
-// record addresses in the arena; for a same-level restore those addresses hold
-// identical sample data, so the restored cache stays correct.
+// record addresses in the arena; those keys only mean the same thing when the
+// restore does not cross an area, so the load path drops it (sd_waves_reset)
+// and it refills on demand.
+//
+// THE HARDWARE CONTENT STORES (captured since 0.2.2)
+// --------------------------------------------------
+// Palette, video and sprite memory are reserved host memory at the DS addresses
+// (ntr/io.cpp), written at area-mount time, and belong to neither the arena nor
+// .dsstate. Not capturing them was the 0.2.1 cross-area bug: save, walk into a
+// door or painting (the new area's textures upload over the same VRAM offsets),
+// load -- the world rolls back, the pixels do not, and every texture reference
+// resolves into the wrong area's bytes. The slot now carries the three regions
+// via the port_hw_regions_* hooks, and restoring them drops the ntr texture
+// decode cache so the next bind re-decodes from the restored VRAM.
 //
 // WHAT IS NOT IN .dsstate ON PURPOSE (host-only, must not roll back)
 // -----------------------------------------------------------------
@@ -100,6 +112,7 @@ typedef unsigned int u32;
 void sd_seq_reset(void);
 void sd_mix_reset(void);
 void sd_consumer_reset(void);
+void sd_waves_reset(void);
 
 extern "C" {
 // hal/os_arena.cpp
@@ -107,6 +120,18 @@ void *port_arena_base(void);
 void *port_arena_end(void);
 void *port_arena_cursor(void);
 void  port_arena_set_cursor(void *p);
+
+// ntr/io.cpp: the game-mutable hardware content stores (palette, video and
+// sprite memory). Their allocator cursors are hosted globals in .dsstate and
+// always rolled back; the BYTES at the reserved DS addresses were not, which
+// is the 0.2.1 cross-area bug: save, mount another area (its textures upload
+// over the same VRAM offsets), load -- the world rolls back, the pixels do
+// not. size is 0 when the regions are not reserved (the savestate smoke links
+// no ntr and stubs all three); copy_in also drops the ntr texture decode
+// cache, since the bytes under its keys just changed.
+unsigned port_hw_regions_size(void);
+void port_hw_regions_copy_out(void *dst);
+void port_hw_regions_copy_in(const void *src);
 
 // The two sentinels hal/dsstate_seg.cpp places at the low and high ends of the
 // .dsstate section family. The captured out-of-arena region is the bytes
@@ -135,6 +160,8 @@ struct Slot {
     void  *arena_cursor; // captured low-water carve pointer
     char  *globals;      // captured [dsstate_lo, dsstate_hi) bytes
     size_t globals_size;
+    char  *hw;           // captured palette + video + sprite memory bytes
+    size_t hw_size;      // port_hw_regions_size() at save; 0 = not captured
 };
 
 Slot g_slot;
@@ -167,31 +194,43 @@ int lk6_savestate_save(void)
         return 0;
     }
 
-    // Allocate first, commit second: if either malloc fails, keep the prior
+    // The hardware content stores (palette, video, sprite memory). 0 in a
+    // build that reserves none of them (the headless smokes); when present,
+    // they are captured with everything else, because a save that skipped them
+    // is exactly the 0.2.1 cross-area texture bug.
+    size_t hsz = port_hw_regions_size();
+
+    // Allocate first, commit second: if any malloc fails, keep the prior
     // slot untouched.
     char *na = (char *)malloc(asz);
     char *ng = (char *)malloc(gsz);
-    if (!na || !ng) {
-        free(na); free(ng);
-        fprintf(stderr, "[savestate] out of memory (%zu + %zu bytes); "
-                        "save ignored\n", asz, gsz);
+    char *nh = hsz ? (char *)malloc(hsz) : 0;
+    if (!na || !ng || (hsz && !nh)) {
+        free(na); free(ng); free(nh);
+        fprintf(stderr, "[savestate] out of memory (%zu + %zu + %zu bytes); "
+                        "save ignored\n", asz, gsz, hsz);
         return 0;
     }
 
     memcpy(na, base, asz);
     memcpy(ng, dsstate_base(), gsz);
+    if (hsz)
+        port_hw_regions_copy_out(nh);
 
     free(g_slot.arena);
     free(g_slot.globals);
+    free(g_slot.hw);
     g_slot.arena        = na;
     g_slot.arena_size   = asz;
     g_slot.arena_cursor = port_arena_cursor();
     g_slot.globals      = ng;
     g_slot.globals_size = gsz;
+    g_slot.hw           = nh;
+    g_slot.hw_size      = hsz;
     g_slot.valid        = 1;
 
-    fprintf(stderr, "[savestate] saved: arena %zu bytes, dsstate %zu bytes\n",
-            asz, gsz);
+    fprintf(stderr, "[savestate] saved: arena %zu bytes, dsstate %zu bytes, "
+                    "hw %zu bytes\n", asz, gsz, hsz);
     return 1;
 }
 
@@ -223,9 +262,21 @@ int lk6_savestate_load(void)
                 dsstate_size(), g_slot.globals_size);
         return 0;
     }
+    if (port_hw_regions_size() != g_slot.hw_size) {
+        // Same discipline for the hardware stores: the region set is fixed for
+        // the process lifetime, so a mismatch means the slot came from a build
+        // with a different capture shape. Refuse rather than restore a world
+        // whose textures cannot be put back with it.
+        fprintf(stderr, "[savestate] hw regions changed (%u vs saved %zu); "
+                        "load refused\n",
+                port_hw_regions_size(), g_slot.hw_size);
+        return 0;
+    }
 
     memcpy(base, g_slot.arena, g_slot.arena_size);
     memcpy(dsstate_base(), g_slot.globals, g_slot.globals_size);
+    if (g_slot.hw_size)
+        port_hw_regions_copy_in(g_slot.hw);   /* also drops the decode cache */
     port_arena_set_cursor(g_slot.arena_cursor);
 
     // The audio path is the one thing that cannot be memcpy'd back cleanly:
@@ -240,9 +291,16 @@ int lk6_savestate_load(void)
     // restore leaves the two halves disagreeing and func_0205b274 walks the
     // free list into a null. Re-seed both halves together.
     sd_consumer_reset();
+    // The wave decode cache is keyed by SWAV record ADDRESSES in the arena.
+    // Its own comment scoped that keying to a same-level restore; a cross-area
+    // restore rolls the arena back to different sample data at the same
+    // addresses, so the keys would serve the other area's decoded audio. Drop
+    // it; it refills on demand.
+    sd_waves_reset();
 
     fprintf(stderr, "[savestate] restored: arena %zu bytes, dsstate %zu bytes, "
-                    "audio reset\n", g_slot.arena_size, g_slot.globals_size);
+                    "hw %zu bytes, audio reset\n", g_slot.arena_size,
+            g_slot.globals_size, g_slot.hw_size);
     return 1;
 }
 

--- a/port/hal/sdat/sdat.cpp
+++ b/port/hal/sdat/sdat.cpp
@@ -123,6 +123,17 @@ struct WaveCache {
 };
 static std::unordered_map<const void *, WaveCache> g_waves;
 
+/* Drop every decoded wave. The cache is keyed by SWAV record ADDRESSES in the
+   game arena, and an address only names the same sample while the arena around
+   it stands still. A save-state restore that crossed an area rolls the arena
+   back to different sample data at the same addresses, so the keys would hand
+   out the other area's audio. lk6_savestate_load calls this beside the other
+   sd_*_reset calls; the cache refills on demand at the next note-on. */
+void sd_waves_reset(void)
+{
+    g_waves.clear();
+}
+
 // Decode one SWAV record (12-byte header + payload) into mono s16.
 static const WaveCache *decode_swav(const sd_u8 *rec)
 {

--- a/port/hal/sdat/sdat.h
+++ b/port/hal/sdat/sdat.h
@@ -166,6 +166,12 @@ void sd_seq_frame(void);                          // one 192Hz sequencer frame
 void sd_seq_reset(void);
 int  sd_seq_active(int player);
 
+// Drop the decoded-wave cache. It keys on SWAV record addresses in the game
+// arena, so it is only valid while the arena stands still; a save-state
+// restore that crossed an area invalidates every key. Called by
+// lk6_savestate_load beside the other resets; refills on demand.
+void sd_waves_reset(void);
+
 // The bit per player the hardware publishes in SNDSharedWork.playerStatus.
 // Bit p is set while player p still owns the sequence it was started with.
 sd_u32 sd_seq_player_mask(void);

--- a/port/ntr/io.cpp
+++ b/port/ntr/io.cpp
@@ -584,6 +584,81 @@ int io_reserve_stage_won() { return g_stage_won; }
 
 }  // namespace ntr
 
+/* ---- save-state capture of the game-mutable hardware regions ---------------
+   The save state (hal/lk6_savestate.cpp) captures the arena and the .dsstate
+   section, and for one area that is the whole game. What it did NOT capture
+   until 0.2.2 is the hardware content stores this file reserves: palette
+   memory, video memory and sprite memory. Their allocator CURSORS are hosted
+   globals in .dsstate and rolled back fine; the BYTES at these addresses did
+   not, so a save in one area restored after mounting another came back with
+   the new area's textures under the old area's world -- the cross-area
+   texture-destruction bug (the same visual damage as the stale-VRAM minimap
+   bug, reached through the save state instead of a warp).
+
+   These three hooks are the fix's transport. They live here because this file
+   owns the region table and knows what is actually held; hal/lk6_savestate.cpp
+   calls them through plain C declarations so it stays free of ntr headers, and
+   smoke_savestate (which links no ntr) stubs them to size 0, keeping its
+   capture exactly what it always was.
+
+   The order of regions inside the blob is the kRegions order, fixed by
+   construction. IO register shadows and the shared block are deliberately NOT
+   captured: the game rewrites the per-frame registers on the next tick, and
+   restoring shadows the host GX layer has already consumed would desynchronize
+   host state rather than roll it back. Palette, video and sprite memory are
+   the stores written at MOUNT time, which is exactly what a cross-area restore
+   has to put back. */
+namespace {
+// The three content-store regions, by base address, in blob order.
+const uintptr_t kHwCaptureBases[] = { ntr::PLTT_BASE, ntr::VRAM_BASE,
+                                      ntr::OAM_BASE };
+
+int hw_region_index(uintptr_t base)
+{
+    for (unsigned i = 0; i < ntr::kRegionCount; ++i)
+        if (ntr::kRegions[i].base == base)
+            return (int)i;
+    return -1;
+}
+}  // namespace
+
+extern "C" unsigned port_hw_regions_size(void)
+{
+    unsigned total = 0;
+    for (uintptr_t base : kHwCaptureBases) {
+        const int i = hw_region_index(base);
+        if (i < 0 || !ntr::g_held[i])
+            return 0;   /* any store missing: no hw capture (headless smokes) */
+        total += (unsigned)ntr::kRegions[i].size;
+    }
+    return total;
+}
+
+extern "C" void port_hw_regions_copy_out(void *dst)
+{
+    char *p = (char *)dst;
+    for (uintptr_t base : kHwCaptureBases) {
+        const int i = hw_region_index(base);
+        std::memcpy(p, (const void *)base, ntr::kRegions[i].size);
+        p += ntr::kRegions[i].size;
+    }
+}
+
+extern "C" void port_hw_regions_copy_in(const void *src)
+{
+    const char *p = (const char *)src;
+    for (uintptr_t base : kHwCaptureBases) {
+        const int i = hw_region_index(base);
+        std::memcpy((void *)base, p, ntr::kRegions[i].size);
+        p += ntr::kRegions[i].size;
+    }
+    /* The 3D texture decode cache keys on VRAM words plus a cheap content
+       probe; a probe is not a proof, and the bytes under every key just
+       changed. Drop it and let the next bind re-decode from the restored
+       VRAM. The 2D side re-reads VRAM every frame and keeps no cache. */
+    ntr::gx_invalidate_textures();
+}
+
 #if defined(_WIN32)
 // ---------------------------------------------------------------------------
 // THE EARLY CLAIM.

--- a/port/tests/smoke_savestate.cpp
+++ b/port/tests/smoke_savestate.cpp
@@ -82,7 +82,7 @@ extern unsigned char data_0209d660;                 /* message-active lock */
 // host stack is far more than this actor smoke needs to link, and the audio
 // reset is a no-op for a headless run with no device open, so this test
 // provides the symbols directly. In the shipped walk_window build these
-// resolve to the real hal/sdat/sseq.cpp, mixer.cpp and consumer.cpp.
+// resolve to the real hal/sdat/sseq.cpp, mixer.cpp, consumer.cpp and sdat.cpp.
 //
 // Note what this means for coverage: the command-queue reset that keeps a
 // restore from faulting in func_0205b274 is stubbed out HERE, so this test
@@ -91,6 +91,16 @@ extern unsigned char data_0209d660;                 /* message-active lock */
 void sd_seq_reset(void) {}
 void sd_mix_reset(void) {}
 void sd_consumer_reset(void) {}
+void sd_waves_reset(void) {}
+
+// The hardware content stores (palette/video/sprite memory) need NO stub: this
+// smoke links the ntr library, so lk6_savestate reaches the real
+// port_hw_regions_* hooks in ntr/io.cpp, and the slot simply carries whatever
+// the reservation pass actually held (all three regions normally, size 0 if a
+// range was lost to another module). Either way the arena and .dsstate halves
+// of this test are unchanged. The cross-area texture roll-back those regions
+// exist for is walk_window reproducer territory (SM64DS_SS_* +
+// SM64DS_EXIT_ENTER), where another area actually mounts.
 
 typedef int (__thiscall *Fn0)(void *);
 static int vcall0(void *actor, int slot)

--- a/port/tests/walk_window.cpp
+++ b/port/tests/walk_window.cpp
@@ -459,6 +459,47 @@ void port_stage_a2_seat(void);
 int lk6_savestate_save(void);
 int lk6_savestate_load(void);
 int lk6_savestate_has(void);
+
+/* Two seconds of on-screen text for the save-state actions. Every earlier
+   report of "F8 did nothing" was undiagnosable because the only evidence was a
+   line on stderr, which a player never sees: a press eaten by the focus gate,
+   a menu row left unconfirmed and a save that genuinely happened all looked
+   identical. The toast is drawn every frame after the menu (so neither the
+   menu nor the overlay hides it) and says which of the three it was. */
+static char ss_toast[64];
+static int  ss_toast_left;
+static void ss_note(const char *msg)
+{
+    snprintf(ss_toast, sizeof ss_toast, "%s", msg);
+    ss_toast_left = 120;
+}
+
+/* ntr/io.cpp: the hardware content stores the save state captures. The
+   reproducer below hashes them to PROVE a restore put the bytes back, because
+   "the run kept stepping" is satisfiable with the wrong textures on screen --
+   that is precisely how the 0.2.1 cross-area bug shipped. */
+extern "C" unsigned port_hw_regions_size(void);
+extern "C" void port_hw_regions_copy_out(void *dst);
+
+/* FNV-1a over the hardware stores, through the same copy-out the save uses.
+   One lazily allocated buffer; ~9.5MB, three hashes an assert run. */
+static unsigned long long ss_hw_hash(void)
+{
+    static char *buf;
+    const unsigned n = port_hw_regions_size();
+    if (!n) return 0;
+    if (!buf) {
+        buf = (char *)malloc(n);
+        if (!buf) return 0;
+    }
+    port_hw_regions_copy_out(buf);
+    unsigned long long h = 1469598103934665603ull;
+    for (unsigned i = 0; i < n; ++i) {
+        h ^= (unsigned char)buf[i];
+        h *= 1099511628211ull;
+    }
+    return h;
+}
 /* the actor registry and the ROM's own processing lists (hal/actor_registry) */
 void port_actor_tick(void);          /* phases 4/2/3: cleanup, init, behaviour */
 /* gate 31: the level handoff (hal/level_change.cpp). port_level_change_poll
@@ -2389,9 +2430,17 @@ int main(void)
             static int save_edge, load_edge;
             const int save_now = key_live(VK_F8);
             const int load_now = key_live(VK_F9);
-            if (save_now && !save_edge) lk6_savestate_save();
+            if (save_now && !save_edge)
+                ss_note(lk6_savestate_save() ? "state saved (F9 loads it)"
+                                             : "state NOT saved (see log)");
             if (load_now && !load_edge) {
-                if (lk6_savestate_load()) an_pivot_live = 0;  /* no ease across */
+                if (lk6_savestate_load()) {
+                    an_pivot_live = 0;   /* no ease across */
+                    ss_note("state loaded");
+                } else {
+                    ss_note(lk6_savestate_has() ? "state NOT loaded (see log)"
+                                                : "no state saved yet (F8 saves)");
+                }
             }
             save_edge = save_now;
             load_edge = load_now;
@@ -2422,9 +2471,10 @@ int main(void)
                                         reachable in a plain headless walk. */
         if (selftest) {
             static int ss_env, ss_save_fr = -1, ss_load_fr = -1,
-                       ss_lock = 0, ss_assert = 0;
+                       ss_lock = 0, ss_assert = 0, ss_expect_mount = 0;
             static unsigned char ss_lock_at_save;
             static int ss_saw_save = 0;
+            static unsigned long long ss_hash_at_save;
             if (!ss_env) {
                 ss_env = 1;
                 const char *s = getenv("SM64DS_SS_SAVE");
@@ -2433,13 +2483,21 @@ int main(void)
                 if (l) ss_load_fr = atoi(l);
                 ss_lock = getenv("SM64DS_SS_LOCK") != 0;
                 ss_assert = getenv("SM64DS_SS_ASSERT") != 0;
+                /* the cross-area variant: something between save and load is
+                   expected to MOUNT another area (SM64DS_EXIT_ENTER drives the
+                   real door path). Requiring the hardware stores to have
+                   actually CHANGED before the load makes a mistimed run fail
+                   loudly instead of passing without testing anything. */
+                ss_expect_mount = getenv("SM64DS_SS_EXPECT_MOUNT") != 0;
             }
             if (ss_save_fr >= 0 && frame == ss_save_fr) {
                 lk6_savestate_save();
                 ss_lock_at_save = data_0209d660;
+                ss_hash_at_save = ss_hw_hash();
                 ss_saw_save = 1;
-                fprintf(stderr, "[ss-repro] f%d save: msglock(d660)=%u\n",
-                        frame, (unsigned)data_0209d660);
+                fprintf(stderr, "[ss-repro] f%d save: msglock(d660)=%u "
+                        "hw=%016llx\n", frame, (unsigned)data_0209d660,
+                        ss_hash_at_save);
             }
             /* perturb the out-of-arena lock strictly between save and load, so
                the world provably diverges on a hosted global the arena copy
@@ -2448,12 +2506,26 @@ int main(void)
                 frame > ss_save_fr && frame < ss_load_fr)
                 data_0209d660 = 1;
             if (ss_load_fr >= 0 && frame == ss_load_fr) {
-                fprintf(stderr, "[ss-repro] f%d pre-load: msglock(d660)=%u\n",
-                        frame, (unsigned)data_0209d660);
+                const unsigned long long pre = ss_hw_hash();
+                fprintf(stderr, "[ss-repro] f%d pre-load: msglock(d660)=%u "
+                        "hw=%016llx (%s the saved hash)\n", frame,
+                        (unsigned)data_0209d660, pre,
+                        pre == ss_hash_at_save ? "STILL" : "differs from");
+                if (ss_expect_mount && pre == ss_hash_at_save) {
+                    fprintf(stderr, "[ss-repro] FAIL(vacuous): the hardware "
+                            "stores never changed between save and load, so "
+                            "no area mounted and a cross-area restore was not "
+                            "tested. Check SM64DS_EXIT_ENTER's index/frame "
+                            "and give the mount more frames.\n");
+                    ntr::ppu_write_bmp("walk_window_selftest.bmp", fb);
+                    return 5;
+                }
                 if (lk6_savestate_load()) an_pivot_live = 0;
+                const unsigned long long post = ss_hw_hash();
                 fprintf(stderr, "[ss-repro] f%d post-load: msglock(d660)=%u "
-                        "(saved %u)\n", frame, (unsigned)data_0209d660,
-                        (unsigned)ss_lock_at_save);
+                        "(saved %u) hw=%016llx\n", frame,
+                        (unsigned)data_0209d660, (unsigned)ss_lock_at_save,
+                        post);
                 if (ss_assert && data_0209d660 != ss_lock_at_save) {
                     fprintf(stderr, "[ss-repro] FAIL: message-lock global "
                             "data_0209d660 did NOT roll back on restore "
@@ -2463,9 +2535,18 @@ int main(void)
                     ntr::ppu_write_bmp("walk_window_selftest.bmp", fb);
                     return 3;
                 }
+                if (ss_assert && post != ss_hash_at_save) {
+                    fprintf(stderr, "[ss-repro] FAIL: the hardware stores did "
+                            "NOT roll back on restore (post-load %016llx, "
+                            "saved %016llx) -- the world came back under "
+                            "another area's textures, the 0.2.1 cross-area "
+                            "bug\n", post, ss_hash_at_save);
+                    ntr::ppu_write_bmp("walk_window_selftest.bmp", fb);
+                    return 4;
+                }
                 if (ss_assert)
-                    fprintf(stderr, "[ss-repro] PASS: message-lock global "
-                            "rolled back on restore\n");
+                    fprintf(stderr, "[ss-repro] PASS: message-lock global and "
+                            "the hardware stores rolled back on restore\n");
             }
         }
         /* drain what the window procedure collected. Unconditionally, so a
@@ -2704,14 +2785,27 @@ int main(void)
                     case MENU_SAVESTATE:
                         /* enter/right only: snapshot into the slot. Same call
                            F8 makes; the menu pauses the tick, which is as safe
-                           a between-frames point as the top-of-loop latch. */
-                        if (edge & (1u << 5)) lk6_savestate_save();
+                           a between-frames point as the top-of-loop latch.
+                           The toast fires here too: highlighting the row and
+                           closing the menu does NOT save, and the only way a
+                           player can learn that is being shown the difference. */
+                        if (edge & (1u << 5))
+                            ss_note(lk6_savestate_save()
+                                        ? "state saved (F9 loads it)"
+                                        : "state NOT saved (see log)");
                         break;
                     case MENU_LOADSTATE:
                         /* enter/right only: restore the slot. A no-op with no
                            saved state. */
                         if (edge & (1u << 5)) {
-                            if (lk6_savestate_load()) an_pivot_live = 0;
+                            if (lk6_savestate_load()) {
+                                an_pivot_live = 0;
+                                ss_note("state loaded");
+                            } else {
+                                ss_note(lk6_savestate_has()
+                                            ? "state NOT loaded (see log)"
+                                            : "no state saved yet (F8 saves)");
+                            }
                         }
                         break;
                     default:
@@ -4952,6 +5046,16 @@ int main(void)
             ovl_draw(fb, os);
         }
         if (menu_on) menu_draw(fb);
+        /* the save-state toast, over everything, bottom-left. Decremented here
+           rather than in the tick so the menu's pause does not freeze it. */
+        if (ss_toast_left > 0) {
+            --ss_toast_left;
+            const int tw = (int)strlen(ss_toast) * OVL_ADVANCE * OVL_SCALE;
+            const int ty = ntr::SCREEN_H - OVL_LINE - 4;
+            ovl_shade(fb, 2, ty - 2, tw + 8 * OVL_SCALE,
+                      OVL_LINE + 4 * OVL_SCALE);
+            ovl_text(fb, 4 + OVL_SCALE, ty, ss_toast, 0xFFFFFFFFu);
+        }
 
         ph_begin(&t_phase);
         W.StretchDIBits_(hdc, 0, 0, ntr::SCREEN_W * ZOOM, ntr::SCREEN_H * ZOOM,


### PR DESCRIPTION
Fixes the 0.2.1 cross-area save-state bug: save, walk through a door or painting, load, and the world came back under the other area's textures (the same damage as the stale-VRAM minimap bug, reached through the save state).

Root cause: palette, video and sprite memory are reserved host memory at the DS addresses (`ntr/io.cpp`), written at area-mount time, in neither the arena nor `.dsstate`. Cursors rolled back, bytes did not. Same disease as the sound-queue fix, one layer out.

- Slot carries the three regions via `port_hw_regions_*` hooks in `ntr/io.cpp`; restore drops the 3D texture decode cache and the SWAV wave cache (address-keyed, same-level assumption in its own comment). IO shadows and the shared block stay out deliberately (rewritten per frame / already consumed by the host GX layer).
- Reproducer proves bytes, not survival: hashes the hw stores at save, requires a change by load when `SM64DS_SS_EXPECT_MOUNT=1` (mount driven by `SM64DS_EXIT_ENTER`, the real door path), requires byte-identical after. Negative control with the restore disabled exits 4 naming the bug.
- F8/F9 and the menu rows now show an on-screen toast (saved / loaded / nothing saved / not saved, see log), because every "F8 did nothing" report was stderr-only and undiagnosable.

Verified: smoke byte-exact (hw 9,441,280 bytes in the slot), same-area PASS, cross-area PASS (pre-load hash differs, post-load identical, 200 more frames clean), control 300 frames clean, negative control exit 4.

`git diff -- src/` is empty; nothing in CI builds `port/`, so the evidence above is the local matrix.