### PR TITLE
Save states survive closing and reopening the game

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -595,6 +595,37 @@ if(MSVC)
     target_compile_options(smoke_savestate PRIVATE /wd4311 /wd4312 /wd4068)
 endif()
 
+# Disk-persistence verification (lane lk7): the same actor world, plus
+# hal/lk7_persist.cpp. The parent saves and mirrors to savestate.bin, then
+# spawns a SECOND PROCESS of itself which loads the disk state and must land on
+# the identical arena hash -- the save surviving the process ending is the
+# whole point, so the test crosses a real process boundary. Two header-refusal
+# cases (corrupted magic, stale gittip) run in the parent afterwards.
+add_executable(smoke_persist tests/smoke_persist.cpp
+    hal/lk6_savestate.cpp hal/lk7_persist.cpp hal/dsstate_seg.cpp
+    hal/auto_bss.cpp
+    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
+    hal/model_host.cpp hal/gx_upload_bridge.cpp hal/cstd_div.c
+    hal/clsn_vtable.cpp hal/actor_vtables.cpp hal/anim_bridge.cpp
+    hal/cxxname_bridge.cpp hal/megachar_stub.cpp
+    "${PORT_GITTIP_C}"
+    ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES} ${SLICE4B_SOURCES}
+    ${SLICE7_SOURCES} ${SLICE8_SOURCES} ${SLICE9_SOURCES} ${GATE8_EXTRA_SOURCES}
+    ${GATE4A_GEN} ${GATE4B_GEN} ${GATE8_GEN} ${GATE9_GEN} "${ROMDATA_C}")
+target_include_directories(smoke_persist PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+target_link_libraries(smoke_persist PRIVATE ntr)
+target_compile_definitions(smoke_persist PRIVATE SM64DS_PLATFORM_PC
+    PORT_REPO_ROOT="${PORT_REPO_ROOT_ABS}")
+if(MSVC)
+    target_compile_options(smoke_persist PRIVATE /wd4311 /wd4312 /wd4068)
+    # A disk state stores absolute pointers into the exe image (every actor's
+    # vtable), so the image must load at the same base every run. See the
+    # matching flag on walk_window, which is the base the shipped states use.
+    target_link_options(smoke_persist PRIVATE /DYNAMICBASE:NO)
+endif()
+
 # Gate 10: Player spawns and stands (the walking campaign).
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate10.txt" SLICE10_LINES)
 set(SLICE10_SOURCES "")
@@ -2577,7 +2608,7 @@ add_executable(walk_window tests/walk_window.cpp tests/io_pressure.cpp "${OV002D
     hal/host_settings.cpp
     # in-memory save state (lane lk6): F8/F9 snapshot and restore of the hosted
     # DS arena plus the out-of-arena game globals.
-    hal/lk6_savestate.cpp hal/dsstate_seg.cpp
+    hal/lk6_savestate.cpp hal/lk7_persist.cpp hal/dsstate_seg.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
     hal/model_host.cpp hal/meshcolliderbase_vtable.cpp hal/meshcollider_dtor_seat.cpp hal/lk1_eh_vmax_seat.cpp hal/lk2_platform_dtor_seat.cpp hal/model_dtor_seat.cpp hal/lk4_eh_dtor_seat.cpp hal/lk4_solidheap_seat.cpp hal/gx_upload_bridge.cpp hal/cstd_div.c
     hal/clsn_vtable.cpp hal/actor_vtables.cpp hal/anim_bridge.cpp
@@ -2647,6 +2678,14 @@ if(PORT_ROM_CLEAN)
 endif()
 if(MSVC)
     target_compile_options(walk_window PRIVATE /wd4311 /wd4312 /wd4068 /wd4576)
+    # No ASLR for the shipped window: a disk save state (hal/lk7_persist
+    # .cpp) stores absolute pointers into the exe image -- every actor's
+    # vtable pointer -- and they only relocate if the image loads at the
+    # SAME base on the next launch. ASLR rebases once per boot, which
+    # would refuse every state written before a reboot. The header still
+    # checks the base, so if anything rebases the exe anyway the state is
+    # refused with a message rather than loaded onto dangling pointers.
+    target_link_options(walk_window PRIVATE /DYNAMICBASE:NO)
 endif()
 
 # The save state captures the whole .dsstate section (hal/dsstate_seg.h). Fail
@@ -2668,7 +2707,7 @@ add_executable(walk_window_hires tests/walk_window.cpp "${OV002DATA_C}" ${LEVEL_
     hal/host_settings.cpp
     # in-memory save state (lane lk6): F8/F9 snapshot and restore of the hosted
     # DS arena plus the out-of-arena game globals.
-    hal/lk6_savestate.cpp hal/dsstate_seg.cpp
+    hal/lk6_savestate.cpp hal/lk7_persist.cpp hal/dsstate_seg.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
     hal/model_host.cpp hal/meshcolliderbase_vtable.cpp hal/meshcollider_dtor_seat.cpp hal/lk1_eh_vmax_seat.cpp hal/lk2_platform_dtor_seat.cpp hal/model_dtor_seat.cpp hal/lk4_eh_dtor_seat.cpp hal/lk4_solidheap_seat.cpp hal/gx_upload_bridge.cpp hal/cstd_div.c
     hal/clsn_vtable.cpp hal/actor_vtables.cpp hal/anim_bridge.cpp
@@ -2728,6 +2767,14 @@ if(PORT_ROM_CLEAN)
 endif()
 if(MSVC)
     target_compile_options(walk_window_hires PRIVATE /wd4311 /wd4312 /wd4068 /wd4576)
+    # No ASLR for the shipped window: a disk save state (hal/lk7_persist
+    # .cpp) stores absolute pointers into the exe image -- every actor's
+    # vtable pointer -- and they only relocate if the image loads at the
+    # SAME base on the next launch. ASLR rebases once per boot, which
+    # would refuse every state written before a reboot. The header still
+    # checks the base, so if anything rebases the exe anyway the state is
+    # refused with a message rather than loaded onto dangling pointers.
+    target_link_options(walk_window_hires PRIVATE /DYNAMICBASE:NO)
 endif()
 
 

--- a/port/hal/lk6_savestate.cpp
+++ b/port/hal/lk6_savestate.cpp
@@ -113,6 +113,7 @@ void sd_seq_reset(void);
 void sd_mix_reset(void);
 void sd_consumer_reset(void);
 void sd_waves_reset(void);
+void sd_sdat_reseat(void);
 
 extern "C" {
 // hal/os_arena.cpp
@@ -297,6 +298,13 @@ int lk6_savestate_load(void)
     // addresses, so the keys would serve the other area's decoded audio. Drop
     // it; it refills on demand.
     sd_waves_reset();
+    // One captured global is a HOST BOOT POINTER, not game state: data_020a5bb8
+    // holds sdat_init's heap-allocated root. An in-process restore rewrites it
+    // with the same value; a DISK state from an earlier run (lk7) rewrites it
+    // with a heap address that no longer exists, and the first sound lookup
+    // walks it into a fault. Re-seat the live process's own root, which is
+    // correct in both cases.
+    sd_sdat_reseat();
 
     fprintf(stderr, "[savestate] restored: arena %zu bytes, dsstate %zu bytes, "
                     "hw %zu bytes, audio reset\n", g_slot.arena_size,

--- a/port/hal/lk7_persist.cpp
+++ b/port/hal/lk7_persist.cpp
@@ -1,0 +1,385 @@
+// Disk-backed save state for the PC port (lane lk7). Makes the single lk6 slot
+// survive the game closing and reopening.
+//
+// WHAT THIS ADDS ON TOP OF lk6
+// ----------------------------
+// hal/lk6_savestate.cpp keeps one IN-MEMORY slot: the hosted DS arena, the
+// .dsstate section, and the hardware content stores, valid for the life of the
+// process. lk7 writes that same content to a file next to the exe on every
+// successful save, and reads it back at startup so the slot is populated from
+// disk. Everything about WHAT is captured stays in lk6; lk7 only moves those
+// bytes to and from disk and guards the move with a header.
+//
+// THE HARD PART: ABSOLUTE POINTERS ACROSS A RESTART
+// -------------------------------------------------
+// The snapshot is full of raw absolute pointers, and they come in TWO kinds.
+// Pointers INTO THE ARENA (actor-list heads, model records, intrusive links)
+// relocate only if the arena comes up at the same base, which is why
+// hal/os_arena.cpp pins it at a fixed address (0x30000000) with VirtualAlloc,
+// the same technique ntr/io.cpp uses for the DS ranges. Pointers INTO THE EXE
+// IMAGE (every vtable pointer in every actor, every code pointer in a hosted
+// table) relocate only if the IMAGE comes up at the same base -- and ASLR
+// rebases a Windows exe once per boot, so a state written before a reboot
+// would come back with every vtable pointing into the void. The original lane
+// draft never checked that; the header now carries the image base and refuses
+// a mismatch, and the build links the window targets with /DYNAMICBASE:NO so
+// the base is the same every boot and the refusal never fires in practice.
+//
+// THE HEADER, AND WHAT EACH FIELD REFUSES
+// ---------------------------------------
+// A disk state is only loaded if every header field matches this process:
+//   magic         wrong bytes           -> not our file, refuse
+//   format        version bump          -> old on-disk layout, refuse
+//   gittip        different build       -> another version's world, refuse
+//   image_base    exe rebased           -> code pointers would dangle, refuse
+//   arena_base    arena at a diff base  -> arena pointers would dangle, refuse
+//   arena_size    arena a diff size     -> lengths would not line up, refuse
+//   dsstate_base  section moved         -> hosted globals moved, refuse
+//   dsstate_size  section grew/shrank   -> another layout's blob, refuse
+//   hw_size       regions differ        -> textures would not line up, refuse
+// A refusal names the field on stderr and leaves the file untouched. A gittip
+// mismatch is the common one: it is how a state written by an older build of
+// the game is turned away instead of loaded into a world it no longer
+// describes. (gittip, image_base and dsstate_base overlap in what they catch;
+// they are all kept because each refusal message tells the reader something
+// different about WHY the file cannot load.)
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+typedef unsigned int u32;
+
+extern "C" {
+// os_arena window + whether it is at the fixed base.
+void *port_arena_base(void);
+void *port_arena_end(void);
+void *port_arena_cursor(void);
+void  port_arena_set_cursor(void *p);
+int   port_arena_is_fixed(void);
+
+// the .dsstate section bounds (hal/dsstate_seg.cpp sentinels).
+extern char dsstate_lo;
+extern char dsstate_hi;
+
+// the hardware content stores (ntr/io.cpp).
+unsigned port_hw_regions_size(void);
+void port_hw_regions_copy_out(void *dst);
+void port_hw_regions_copy_in(const void *src);
+
+// lk6: the in-memory slot this layer mirrors to and from disk.
+int lk6_savestate_save(void);
+int lk6_savestate_load(void);
+int lk6_savestate_has(void);
+
+// the build's git tip, embedded by CMake (host-src/port_gittip.c). Weakly
+// aliased in fault_probe.h for builds without it; here we only read it.
+extern const char port_build_gittip[];
+}
+
+namespace {
+
+// Bumping any field layout below is a FORMAT_VERSION bump; an older file is
+// then refused on the format field rather than misread. Format 2 is the
+// .dsstate-section world (format 1 was the never-shipped hand-list draft).
+const char   MAGIC[8]        = { 'S','M','6','4','D','S','S','T' };
+const u32    FORMAT_VERSION  = 2;
+const u32    GITTIP_FIELD    = 64;   // fixed-width, NUL-padded, always NUL-terminated
+
+#pragma pack(push, 1)
+struct Header {
+    char     magic[8];
+    u32      format;
+    char     gittip[GITTIP_FIELD];   // stays at offset 12: smoke_persist pokes it there
+    uint64_t image_base;             // exe base: vtable/code pointers relocate iff equal
+    uint64_t arena_base;
+    uint64_t arena_size;
+    uint64_t arena_cursor;   // low-water carve pointer at save time (host state)
+    uint64_t dsstate_base;   // &dsstate_lo: where the hosted globals sit this build
+    uint64_t dsstate_size;   // &dsstate_hi - &dsstate_lo
+    uint64_t hw_size;        // palette + video + sprite memory, 0 if not reserved
+};
+#pragma pack(pop)
+
+size_t dsstate_size_live()
+{
+    char *lo = &dsstate_lo, *hi = &dsstate_hi;
+    return hi > lo ? (size_t)(hi - lo) : 0;
+}
+
+// Fill hdr for THIS process. Returns 0 (and leaves hdr zeroed) if there is no
+// usable arena window, which is the same guard lk6_savestate_save uses.
+int fill_header(Header *hdr)
+{
+    memset(hdr, 0, sizeof *hdr);
+    char *base = (char *)port_arena_base();
+    char *end  = (char *)port_arena_end();
+    if (!base || end <= base) return 0;
+    memcpy(hdr->magic, MAGIC, sizeof hdr->magic);
+    hdr->format = FORMAT_VERSION;
+    snprintf(hdr->gittip, sizeof hdr->gittip, "%s", port_build_gittip);
+#if defined(_WIN32)
+    hdr->image_base = (uint64_t)(uintptr_t)GetModuleHandleA(NULL);
+#endif
+    hdr->arena_base   = (uint64_t)(uintptr_t)base;
+    hdr->arena_size   = (uint64_t)(size_t)(end - base);
+    hdr->arena_cursor = (uint64_t)(uintptr_t)port_arena_cursor();
+    hdr->dsstate_base = (uint64_t)(uintptr_t)&dsstate_lo;
+    hdr->dsstate_size = (uint64_t)dsstate_size_live();
+    hdr->hw_size      = (uint64_t)port_hw_regions_size();
+    return 1;
+}
+
+// The state file path: next to the exe, the folder the launcher puts the bundle
+// in (same idea as host_settings.cpp find_settings). Returns 0 if it cannot be
+// determined. Non-Windows never gets here because port_arena_is_fixed is 0
+// there, so this is Windows-only.
+int state_path(char *out, size_t cap)
+{
+#if defined(_WIN32)
+    char exe[MAX_PATH];
+    DWORD n = GetModuleFileNameA(NULL, exe, MAX_PATH);
+    if (n > 0 && n < MAX_PATH) {
+        char *slash = strrchr(exe, '\\');
+        char *fwd   = strrchr(exe, '/');
+        if (fwd && (!slash || fwd > slash)) slash = fwd;
+        if (slash) {
+            *slash = '\0';
+            if (strlen(exe) + 16 < cap) {
+                snprintf(out, cap, "%s\\savestate.bin", exe);
+                return 1;
+            }
+        }
+    }
+#endif
+    (void)out; (void)cap;
+    return 0;
+}
+
+// Compare the on-disk header field by field against this process. On the first
+// mismatch, name the field on stderr and return 0. Returns 1 only if every
+// field matches.
+int header_matches(const Header *disk, const Header *self)
+{
+    if (memcmp(disk->magic, self->magic, sizeof disk->magic) != 0) {
+        fprintf(stderr, "[savestate] disk state refused: magic mismatch (not a save file)\n");
+        return 0;
+    }
+    if (disk->format != self->format) {
+        fprintf(stderr, "[savestate] disk state refused: format mismatch (file %u, build %u)\n",
+                disk->format, self->format);
+        return 0;
+    }
+    if (strncmp(disk->gittip, self->gittip, GITTIP_FIELD) != 0) {
+        fprintf(stderr, "[savestate] disk state refused: gittip mismatch (file %.*s, build %.*s)\n",
+                (int)GITTIP_FIELD, disk->gittip, (int)GITTIP_FIELD, self->gittip);
+        return 0;
+    }
+    if (disk->image_base != self->image_base) {
+        fprintf(stderr, "[savestate] disk state refused: exe image base mismatch "
+                        "(file 0x%llx, this run 0x%llx) -- code pointers would "
+                        "not relocate\n",
+                (unsigned long long)disk->image_base,
+                (unsigned long long)self->image_base);
+        return 0;
+    }
+    if (disk->arena_base != self->arena_base) {
+        fprintf(stderr, "[savestate] disk state refused: arena base mismatch "
+                        "(file 0x%llx, this run 0x%llx)\n",
+                (unsigned long long)disk->arena_base,
+                (unsigned long long)self->arena_base);
+        return 0;
+    }
+    if (disk->arena_size != self->arena_size) {
+        fprintf(stderr, "[savestate] disk state refused: arena size mismatch "
+                        "(file %llu, this run %llu)\n",
+                (unsigned long long)disk->arena_size,
+                (unsigned long long)self->arena_size);
+        return 0;
+    }
+    if (disk->dsstate_base != self->dsstate_base) {
+        fprintf(stderr, "[savestate] disk state refused: dsstate base mismatch "
+                        "(file 0x%llx, this run 0x%llx)\n",
+                (unsigned long long)disk->dsstate_base,
+                (unsigned long long)self->dsstate_base);
+        return 0;
+    }
+    if (disk->dsstate_size != self->dsstate_size) {
+        fprintf(stderr, "[savestate] disk state refused: dsstate size mismatch "
+                        "(file %llu, this run %llu)\n",
+                (unsigned long long)disk->dsstate_size,
+                (unsigned long long)self->dsstate_size);
+        return 0;
+    }
+    if (disk->hw_size != self->hw_size) {
+        fprintf(stderr, "[savestate] disk state refused: hardware-store size mismatch "
+                        "(file %llu, this run %llu)\n",
+                (unsigned long long)disk->hw_size,
+                (unsigned long long)self->hw_size);
+        return 0;
+    }
+    return 1;
+}
+
+} // namespace
+
+extern "C" {
+
+// 1 if disk states are usable this run: Windows and the arena is at its fixed
+// base. When 0, save and load are memory-only (the caller stays on lk6).
+int lk7_persist_available(void)
+{
+    return port_arena_is_fixed();
+}
+
+// Write the current live world to <exedir>\savestate.bin. The caller invokes
+// this right after a successful lk6_savestate_save, so live memory IS the slot
+// content. Returns 1 if the file was written, 0 otherwise (disk states off, no
+// arena, path or IO failure). A failure to write the disk copy never fails the
+// in-memory save.
+int lk7_persist_write(void)
+{
+    if (!lk7_persist_available()) return 0;
+
+    Header hdr;
+    if (!fill_header(&hdr)) return 0;
+
+    char path[512];
+    if (!state_path(path, sizeof path)) {
+        fprintf(stderr, "[savestate] could not resolve disk state path; disk save skipped\n");
+        return 0;
+    }
+
+    char  *base = (char *)port_arena_base();
+    size_t asz  = (size_t)hdr.arena_size;
+    size_t dsz  = (size_t)hdr.dsstate_size;
+    size_t hsz  = (size_t)hdr.hw_size;
+
+    // The hardware stores go through the same copy-out the slot uses, into one
+    // temporary blob, so the file's byte order is the hook's fixed region order.
+    char *hbuf = 0;
+    if (hsz) {
+        hbuf = (char *)malloc(hsz);
+        if (!hbuf) { fprintf(stderr, "[savestate] out of memory for disk save; skipped\n"); return 0; }
+        port_hw_regions_copy_out(hbuf);
+    }
+
+    // Write to a temp file then rename, so a crash mid-write cannot leave a
+    // truncated savestate.bin that the next launch would try to load.
+    char tmp[540];
+    snprintf(tmp, sizeof tmp, "%s.tmp", path);
+    FILE *f = fopen(tmp, "wb");
+    if (!f) {
+        fprintf(stderr, "[savestate] cannot open %s for write; disk save skipped\n", tmp);
+        free(hbuf);
+        return 0;
+    }
+    int ok = 1;
+    ok &= (fwrite(&hdr, sizeof hdr, 1, f) == 1);
+    ok &= (asz == 0 || fwrite(base, 1, asz, f) == asz);
+    ok &= (dsz == 0 || fwrite(&dsstate_lo, 1, dsz, f) == dsz);
+    ok &= (hsz == 0 || fwrite(hbuf, 1, hsz, f) == hsz);
+    fclose(f);
+    free(hbuf);
+    if (!ok) {
+        fprintf(stderr, "[savestate] write to %s failed; disk save skipped\n", tmp);
+        remove(tmp);
+        return 0;
+    }
+
+    remove(path);          // MoveFile/rename won't overwrite on Windows
+    if (rename(tmp, path) != 0) {
+        fprintf(stderr, "[savestate] rename %s -> %s failed; disk save skipped\n", tmp, path);
+        remove(tmp);
+        return 0;
+    }
+    fprintf(stderr, "[savestate] wrote disk state: %zu arena + %zu dsstate + "
+                    "%zu hw bytes -> %s\n", asz, dsz, hsz, path);
+    return 1;
+}
+
+// Read <exedir>\savestate.bin and, if its header matches this process in every
+// field, copy the arena, the .dsstate section and the hardware stores straight
+// into place and hand the world to lk6 (cursor, cache drops, audio reset, all
+// of it) via lk6_savestate_save + lk6_savestate_load. Returns 1 if a disk state
+// was loaded, 0 if there was no file, disk states are off, or the header was
+// refused (a refusal names the field and leaves the file alone).
+int lk7_persist_read(void)
+{
+    if (!lk7_persist_available()) return 0;
+
+    char path[512];
+    if (!state_path(path, sizeof path)) return 0;
+
+    FILE *f = fopen(path, "rb");
+    if (!f) return 0;   // no saved disk state; silent, this is the normal case
+
+    Header disk;
+    if (fread(&disk, sizeof disk, 1, f) != 1) {
+        fprintf(stderr, "[savestate] disk state refused: file too short for a header\n");
+        fclose(f);
+        return 0;
+    }
+
+    Header self;
+    if (!fill_header(&self)) { fclose(f); return 0; }
+    if (!header_matches(&disk, &self)) { fclose(f); return 0; }
+
+    size_t asz = (size_t)disk.arena_size;
+    size_t dsz = (size_t)disk.dsstate_size;
+    size_t hsz = (size_t)disk.hw_size;
+    char  *base = (char *)port_arena_base();
+
+    // Copy the arena and the section straight in. The bases matched the header,
+    // so every absolute pointer in these bytes addresses what it did at save.
+    if (asz && fread(base, 1, asz, f) != asz) {
+        fprintf(stderr, "[savestate] disk state refused: arena body truncated\n");
+        fclose(f);
+        return 0;
+    }
+    if (dsz && fread(&dsstate_lo, 1, dsz, f) != dsz) {
+        fprintf(stderr, "[savestate] disk state refused: dsstate body truncated\n");
+        fclose(f);
+        return 0;
+    }
+    if (hsz) {
+        char *hbuf = (char *)malloc(hsz);
+        if (!hbuf) { fprintf(stderr, "[savestate] out of memory reading disk state\n"); fclose(f); return 0; }
+        if (fread(hbuf, 1, hsz, f) != hsz) {
+            fprintf(stderr, "[savestate] disk state refused: hardware-store body truncated\n");
+            free(hbuf);
+            fclose(f);
+            return 0;
+        }
+        port_hw_regions_copy_in(hbuf);   /* also drops the texture decode cache */
+        free(hbuf);
+    }
+    fclose(f);
+
+    // Put the arena carve cursor back where it stood at save. It is host state
+    // in os_arena.cpp, NOT part of the arena bytes, so a fresh boot left it
+    // wherever this session's own allocations reached; without this the lk6
+    // snapshot below would capture the wrong high-water mark and the next
+    // allocation would stomp restored data.
+    port_arena_set_cursor((void *)(uintptr_t)disk.arena_cursor);
+
+    // The bytes and the cursor are in place. Snapshot them into the lk6 slot so
+    // lk6 owns the world exactly as if F8 had run this session, then load it:
+    // that path re-asserts the cursor, drops the wave cache and resets audio,
+    // and it leaves the slot valid so the menu shows a state is present and F9
+    // works without touching the disk again.
+    lk6_savestate_save();
+    lk6_savestate_load();
+
+    fprintf(stderr, "[savestate] loaded disk state: %zu arena + %zu dsstate + "
+                    "%zu hw bytes from %s\n", asz, dsz, hsz, path);
+    return 1;
+}
+
+}

--- a/port/hal/os_arena.cpp
+++ b/port/hal/os_arena.cpp
@@ -6,12 +6,43 @@
 // first use so the smoke needs no setup call.
 #include <stdlib.h>
 #include "dsstate_seg.h"
+#include <stdio.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 typedef unsigned int u32;
 
 enum { HOST_ARENA = 8 << 20 };   /* 8 MB: larger than the DS main-RAM arena */
 
 static char *g_lo, *g_hi;
+
+/* WHY THE ARENA WANTS A FIXED BASE (lane lk7, save states that outlive the run)
+   ---------------------------------------------------------------------------
+   The in-memory save state (hal/lk6_savestate.cpp) memcpy's the whole arena and
+   restores it verbatim, which works because the block never moves for the life
+   of the process: a pointer captured at save still addresses the same arena
+   offset after restore. A save state written to DISK has to survive the process
+   ENDING. On the next launch the arena is a fresh allocation, and a plain calloc
+   lands wherever the host allocator puts it, which is a different absolute
+   address every run. The disk state is full of raw absolute pointers into the
+   arena (actor-list heads, model-matrix pointers, intrusive next-links), so it
+   only loads correctly if the arena comes up at the SAME base it had when the
+   state was written.
+
+   So the arena is reserved at a fixed host address with VirtualAlloc, the same
+   technique ntr/io.cpp uses to pin the DS ranges. The base sits above every DS
+   range (main RAM 0x02000000..0x02400000, the shared block at 0x027ff000, and
+   the MMIO/VRAM ranges up to 0x07000800) and well below 2GB so the truncating
+   32-bit round-trips the loaders do stay exact. If the reservation fails at
+   boot (something else holds the range), the arena falls back to calloc and the
+   persist layer refuses disk load/save for the run; the in-memory slot still
+   works exactly as before. port_arena_is_fixed() reports which path we took. */
+#if defined(_WIN32)
+enum : size_t { ARENA_FIXED_BASE = 0x30000000u };  /* 768 MB, above the DS ranges */
+static int g_fixed_base;                            /* 1 = VirtualAlloc'd at ARENA_FIXED_BASE */
+#endif
 
 /* THE ARENA HAS TO BE DETERMINISTIC. It was a plain malloc, which left two
    things different on every run: the contents (whatever the host allocator
@@ -42,6 +73,27 @@ static void arena_init(void)
         const char *env = getenv("SM64DS_HOST_ARENA_MB");
         size_t mb = env ? (size_t)atoi(env) : 0;
         size_t size = mb ? mb << 20 : (size_t)HOST_ARENA;
+
+#if defined(_WIN32)
+        /* Try the fixed base first. ARENA_FIXED_BASE is 64K-aligned, so the
+           reservation starts exactly there and no post-alignment is needed --
+           the base is deterministic across runs, which is what the disk save
+           state leans on. VirtualAlloc zeroes committed pages, matching the
+           calloc'd DS arena. */
+        void *fixed = VirtualAlloc((void *)ARENA_FIXED_BASE, size,
+                                   MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        if (fixed) {
+            g_lo = (char *)fixed;
+            g_hi = g_lo + size;
+            g_base = g_lo;
+            g_fixed_base = 1;
+            return;
+        }
+        /* Fell through: something holds 0x30000000. Say so once and keep the
+           game running on a calloc'd arena; the persist layer reads
+           port_arena_is_fixed() and turns disk states off for the run. */
+        fprintf(stderr, "[savestate] arena not at fixed base; disk states off this run\n");
+#endif
         char *base = (char *)calloc(size + ARENA_ALIGN, 1);
         if (!base) return;
         g_lo = (char *)(((size_t)base + (ARENA_ALIGN - 1))
@@ -61,6 +113,22 @@ void *port_arena_base(void)   { arena_init(); return g_base; }
 void *port_arena_end(void)    { arena_init(); return g_hi; }
 void *port_arena_cursor(void) { arena_init(); return g_lo; }
 void  port_arena_set_cursor(void *p) { g_lo = (char *)p; }
+
+/* 1 if the arena came up at its fixed host base (VirtualAlloc succeeded), 0 if
+   it fell back to calloc. The disk save state (hal/lk7_persist.cpp) is only
+   loadable and savable when this is 1, because a disk state carries absolute
+   pointers into the arena and only a fixed base makes them valid across a
+   restart. On non-Windows the arena is always calloc'd, so this is 0 and disk
+   states are off (the shipped port is Windows-only). */
+int port_arena_is_fixed(void)
+{
+    arena_init();
+#if defined(_WIN32)
+    return g_fixed_base;
+#else
+    return 0;
+#endif
+}
 }
 
 extern "C" {

--- a/port/hal/sdat/sdat.cpp
+++ b/port/hal/sdat/sdat.cpp
@@ -134,6 +134,21 @@ void sd_waves_reset(void)
     g_waves.clear();
 }
 
+/* Put THIS process's SDAT root back into data_020a5bb8. The global is a hosted
+   DS symbol, so a save state captures and restores it like any other -- but
+   what it holds is a HOST BOOT POINTER (sdat_init's calloc'd root object), not
+   game state: it is written once at boot and never changes during play. An
+   in-process restore rewrites it with the same value, harmless. A DISK state
+   from an earlier run rewrites it with the OTHER process's heap address, and
+   the first sound lookup (func_02050c14 walking root+0x84) dereferences a
+   pointer into a heap that no longer exists. lk6_savestate_load calls this
+   after the section copy so the live root always wins. */
+void sd_sdat_reseat(void)
+{
+    if (g_sdat.root)
+        data_020a5bb8 = g_sdat.root;   /* the extern "C" decl at the top */
+}
+
 // Decode one SWAV record (12-byte header + payload) into mono s16.
 static const WaveCache *decode_swav(const sd_u8 *rec)
 {

--- a/port/hal/sdat/sdat.h
+++ b/port/hal/sdat/sdat.h
@@ -172,6 +172,12 @@ int  sd_seq_active(int player);
 // lk6_savestate_load beside the other resets; refills on demand.
 void sd_waves_reset(void);
 
+// Re-seat data_020a5bb8 with THIS process's SDAT root. The global is captured
+// like any hosted DS symbol, but it holds a host boot pointer, so a disk state
+// from an earlier run would restore a heap address that no longer exists.
+// Called by lk6_savestate_load after the section copy; idempotent.
+void sd_sdat_reseat(void);
+
 // The bit per player the hardware publishes in SNDSharedWork.playerStatus.
 // Bit p is set while player p still owns the sequence it was started with.
 sd_u32 sd_seq_player_mask(void);

--- a/port/tests/smoke_persist.cpp
+++ b/port/tests/smoke_persist.cpp
@@ -1,0 +1,340 @@
+// Disk save-state verification (lane lk7).
+//
+// This proves the save state survives the process ending. It reuses the actor
+// world smoke_savestate builds (SetupRootHeap, spawn one real actor, tick it),
+// then drives the DISK path in hal/lk7_persist.cpp across a real process
+// boundary:
+//
+//   PHASE "save" (the parent):
+//     1. boots the actor world and ticks it so real state lives in the arena;
+//     2. saves the in-memory slot (lk6) and mirrors it to savestate.bin
+//        (lk7_persist_write);
+//     3. records the arena hash and prints it;
+//     4. re-execs ITSELF with SM64DS_PERSIST_PHASE=load and the expected hash in
+//        SM64DS_PERSIST_HASH, then returns the child's exit code.
+//
+//   PHASE "load" (the child, a genuinely separate process):
+//     1. boots the SAME way but does NOT rebuild the evolved actor state;
+//     2. calls lk7_persist_read, which validates the header, copies the arena
+//        and globals into place and hands the world to lk6;
+//     3. asserts the restored arena hash equals the parent's saved hash. A
+//        second process loading the first one's disk state and landing on the
+//        identical arena hash is the core proof.
+//
+// Two refusal cases run in-process in the parent after the child returns, so
+// they need no second boot:
+//   - a corrupted header (magic byte flipped) is refused cleanly, file left;
+//   - a gittip mismatch (the build-tip field overwritten) is refused cleanly.
+//
+// The arena is pinned at a fixed host base (hal/os_arena.cpp), so both the
+// parent and the child bring the arena up at the SAME base and the saved
+// pointers relocate. If that pin ever fails, lk7_persist_available returns 0 and
+// this test reports the run as skipped rather than failing, because a disk state
+// is legitimately off when the arena is not fixed.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include "ntr/gx.h"
+#include "ntr/mmio.h"
+#include "ntr/ppu.h"
+
+#include "fault_probe.h"
+
+typedef unsigned int u32;
+
+extern "C" {
+int *ArrowSignRight_Spawn(void);
+void *_ZN4Heap13SetupRootHeapEv(void);
+extern int data_0209b3ec[12];       /* camera matrix */
+struct SharedFilePtrC { unsigned short fileID; unsigned char numRefs;
+                        unsigned char pad; void *filePtr; };
+SharedFilePtrC *_ZN13SharedFilePtr9ConstructEj(SharedFilePtrC *s, u32 id);
+extern unsigned short data_020a4b54;    /* pending actor ID */
+extern void **data_020a4bb8;            /* actorID -> SpawnInfo* */
+void *data_ov098_0213c380[6];
+char data_ov098_0213c384[0x18];
+extern void *data_020a0eac_c;           /* actor heap = root heap */
+extern void *data_020a0ea0;             /* defaultHeapPtr */
+extern void *data_0209f394[];           /* the player array */
+extern unsigned char data_0209f21c;     /* player count */
+void hal_fill_model_vtable(void);
+void hal_fill_shadow_vtable(void);
+void hal_fill_mmc_vtable(void);
+
+// the in-memory + disk save-state layers under test
+int lk6_savestate_save(void);
+int lk6_savestate_load(void);
+int lk6_savestate_has(void);
+int lk7_persist_write(void);
+int lk7_persist_read(void);
+int lk7_persist_available(void);
+
+// arena window
+void *port_arena_base(void);
+void *port_arena_end(void);
+void *port_arena_cursor(void);
+int   port_arena_is_fixed(void);
+extern int LCG_STATE_0204da4c;
+}
+
+// lk7_persist_read hands off to lk6_savestate_load, which calls the sdat
+// resets. A headless smoke opens no device, so they are no-ops here, the same
+// four smoke_savestate stubs. The hardware-store hooks need no stubs: this
+// smoke links ntr, so the real port_hw_regions_* in ntr/io.cpp serve both lk6
+// and lk7 against the real reservations.
+void sd_seq_reset(void) {}
+void sd_mix_reset(void) {}
+void sd_consumer_reset(void) {}
+void sd_waves_reset(void) {}
+void sd_sdat_reseat(void) {}
+
+typedef int (__thiscall *Fn0)(void *);
+static int vcall0(void *actor, int slot)
+{
+    void **vt = *(void ***)actor;
+    return ((Fn0)vt[slot])(actor);
+}
+
+static int g_failures;
+#define CHECK(cond) \
+    do { if (!(cond)) { ++g_failures; \
+        fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); } } while (0)
+
+static void ident_fx(void *m)
+{
+    memset(m, 0, 48);
+    ((int *)m)[0] = ((int *)m)[4] = ((int *)m)[8] = 0x1000;
+}
+
+static void reset_scene()
+{
+    ntr::gx_reset();
+    NTR_MMIO(uint32_t, 0x04000440) = 0;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000440) = 1;
+    NTR_MMIO(uint32_t, 0x04000454) = 0;
+    NTR_MMIO(uint32_t, 0x04000580) = 0u | (0u << 8) | (255u << 16) | (191u << 24);
+    ntr::gx_set_light(0, -0.4f, -0.6f, -0.7f, 0x7FFF);
+    ntr::gx_enable_lights(0x1);
+}
+
+static uint64_t arena_hash()
+{
+    const unsigned char *b = (const unsigned char *)port_arena_base();
+    const unsigned char *e = (const unsigned char *)port_arena_end();
+    uint64_t h = 1469598103934665603ULL;
+    for (; b < e; ++b) { h ^= *b; h *= 1099511628211ULL; }
+    return h;
+}
+
+// Boot the shared actor world both phases stand on. Returns the spawned actor.
+static int *boot_actor_world()
+{
+    CHECK(_ZN4Heap13SetupRootHeapEv() != NULL);
+    ident_fx(data_0209b3ec);
+
+    hal_fill_model_vtable();
+    hal_fill_shadow_vtable();
+    hal_fill_mmc_vtable();
+    data_020a4b54 = 0x12b;
+    static unsigned short spawn_info[4] = { 0, 0, 100, 100 };
+    data_020a4bb8[0x12b] = spawn_info;
+    data_020a0eac_c = data_020a0ea0;
+    static SharedFilePtrC sign_model, sign_kcl;
+    _ZN13SharedFilePtr9ConstructEj(&sign_model, 1177);
+    _ZN13SharedFilePtr9ConstructEj(&sign_kcl, 1178);
+    data_ov098_0213c380[0] = &sign_model;
+    data_ov098_0213c380[1] = &sign_kcl;
+    *(void **)(data_ov098_0213c384 + 0) = &sign_kcl;
+
+    static char fake_player[0x800];
+    data_0209f394[0] = fake_player;
+    *(unsigned char *)&data_0209f21c = 1;
+
+    int *actor = ArrowSignRight_Spawn();
+    CHECK(actor != NULL);
+    if (!actor) return NULL;
+    CHECK(vcall0(actor, 0) == 1);           // InitResources
+    reset_scene();
+    return actor;
+}
+
+static const char *state_file_path(char *buf, size_t cap)
+{
+    char exe[MAX_PATH];
+    DWORD n = GetModuleFileNameA(NULL, exe, MAX_PATH);
+    if (n == 0 || n >= MAX_PATH) return NULL;
+    char *slash = strrchr(exe, '\\');
+    char *fwd = strrchr(exe, '/');
+    if (fwd && (!slash || fwd > slash)) slash = fwd;
+    if (!slash) return NULL;
+    *slash = '\0';
+    snprintf(buf, cap, "%s\\savestate.bin", exe);
+    return buf;
+}
+
+// ---- PHASE "load": the spawned child --------------------------------------
+static int phase_load()
+{
+    setvbuf(stdout, NULL, _IONBF, 0);
+    if (!ntr::io_init()) { fprintf(stderr, "io_init failed\n"); return 2; }
+    if (!port_arena_is_fixed()) {
+        fprintf(stderr, "  [child] arena not at fixed base; disk load cannot run\n");
+        return 3;   // signalled to the parent as a skip
+    }
+
+    const char *hs = getenv("SM64DS_PERSIST_HASH");
+    if (!hs) { fprintf(stderr, "  [child] no expected hash passed\n"); return 4; }
+    uint64_t expect = strtoull(hs, NULL, 16);
+
+    int *actor = boot_actor_world();
+    if (!actor) { fprintf(stderr, "  [child] actor world did not boot\n"); return 1; }
+
+    // Load the disk state the parent wrote. This is the cross-process load: a
+    // separate process picking up the first one's savestate.bin.
+    int loaded = lk7_persist_read();
+    CHECK(loaded == 1);
+    CHECK(lk6_savestate_has() == 1);
+
+    uint64_t got = arena_hash();
+    printf("  [child] loaded disk state, arena hash=%016llx expected=%016llx\n",
+           (unsigned long long)got, (unsigned long long)expect);
+    CHECK(got == expect);
+
+    // keep running after the load: the actor still dispatches
+    for (int f = 0; f < 8; ++f) vcall0(actor, 6);
+    (void)vcall0(actor, 9);
+    printf("  [child] ran 8 frames after the cross-process load: no crash\n");
+
+    if (g_failures) { fprintf(stderr, "  [child] %d FAILURE(S)\n", g_failures); return 1; }
+    printf("  [child] cross-process load byte-exact: ok\n");
+    return 0;
+}
+
+// ---- PHASE "save": the parent ---------------------------------------------
+static int phase_save()
+{
+    PORT_INSTALL_FAULT_PROBE();
+    setvbuf(stdout, NULL, _IONBF, 0);
+    if (!ntr::io_init()) { fprintf(stderr, "io_init failed\n"); return 2; }
+
+    if (!port_arena_is_fixed()) {
+        // Legitimately off: the fixed base was taken. A disk state cannot
+        // relocate, so report a skip rather than a failure.
+        printf("smoke_persist: SKIPPED (arena not at fixed base; disk states off)\n");
+        return 0;
+    }
+    CHECK(lk7_persist_available() == 1);
+
+    char path[512];
+    if (!state_file_path(path, sizeof path)) { fprintf(stderr, "no state path\n"); return 2; }
+    remove(path);   // start from no file so the write is provably ours
+
+    int *actor = boot_actor_world();
+    if (!actor) { fprintf(stderr, "smoke_persist: no actor, abort\n"); return 1; }
+
+    // evolve real state, then move a few words so there is unmistakable live
+    // state to carry across the restart
+    for (int f = 0; f < 8; ++f) vcall0(actor, 6);
+    *(int *)((char *)actor + 0x5c) = 0x11110000;
+    *(int *)((char *)actor + 0x60) = 0x22220000;
+    *(int *)((char *)actor + 0x64) = 0x33330000;
+    *(int *)((char *)actor + 0x70) = 0x0000abcd;
+    LCG_STATE_0204da4c = 0x5eedf715;
+
+    // save to the in-memory slot, then mirror to disk
+    CHECK(lk6_savestate_save() == 1);
+    CHECK(lk7_persist_write() == 1);
+
+    // the file must now exist and be non-trivial
+    FILE *chk = fopen(path, "rb");
+    CHECK(chk != NULL);
+    long fsz = 0;
+    if (chk) { fseek(chk, 0, SEEK_END); fsz = ftell(chk); fclose(chk); }
+    CHECK(fsz > (long)(8 << 20));   // header + 8MB arena + globals
+    printf("  [parent] wrote savestate.bin (%ld bytes) at %s\n", fsz, path);
+
+    uint64_t saved = arena_hash();
+    printf("  [parent] saved arena hash=%016llx\n", (unsigned long long)saved);
+
+    // ---- spawn a genuinely separate process to load it --------------------
+    char exe[MAX_PATH];
+    GetModuleFileNameA(NULL, exe, MAX_PATH);
+    char hashenv[64];
+    snprintf(hashenv, sizeof hashenv, "%016llx", (unsigned long long)saved);
+    SetEnvironmentVariableA("SM64DS_PERSIST_PHASE", "load");
+    SetEnvironmentVariableA("SM64DS_PERSIST_HASH", hashenv);
+
+    STARTUPINFOA si; memset(&si, 0, sizeof si); si.cb = sizeof si;
+    PROCESS_INFORMATION pi; memset(&pi, 0, sizeof pi);
+    printf("  [parent] spawning a second process to load the disk state...\n");
+    BOOL ok = CreateProcessA(exe, NULL, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi);
+    CHECK(ok);
+    int child_rc = -1;
+    if (ok) {
+        WaitForSingleObject(pi.hProcess, INFINITE);
+        DWORD rc = 0; GetExitCodeProcess(pi.hProcess, &rc); child_rc = (int)rc;
+        CloseHandle(pi.hProcess); CloseHandle(pi.hThread);
+    }
+    SetEnvironmentVariableA("SM64DS_PERSIST_PHASE", NULL);
+    printf("  [parent] child exited %d\n", child_rc);
+    if (child_rc == 3) {
+        printf("smoke_persist: SKIPPED (child could not pin the fixed base)\n");
+        return 0;
+    }
+    CHECK(child_rc == 0);
+
+    // ---- refusal case A: a corrupted header is refused cleanly ------------
+    // Flip the first magic byte, then try to read: the read must refuse and
+    // return 0, and it must NOT touch the (already valid) in-memory slot.
+    {
+        FILE *f = fopen(path, "r+b");
+        CHECK(f != NULL);
+        if (f) { unsigned char bad = 'X'; fseek(f, 0, SEEK_SET); fwrite(&bad, 1, 1, f); fclose(f); }
+        int r = lk7_persist_read();
+        CHECK(r == 0);
+        printf("  [parent] corrupted-magic header refused: r=%d\n", r);
+    }
+
+    // ---- refusal case B: a gittip mismatch is refused cleanly -------------
+    // Rewrite a valid file (write() again), then overwrite the gittip field with
+    // a different build string. Header magic/format/base/size still match, so
+    // the ONLY thing that can turn it away is the gittip field.
+    {
+        CHECK(lk7_persist_write() == 1);
+        // header layout: magic[8], format(u32), gittip[64] at offset 12
+        FILE *f = fopen(path, "r+b");
+        CHECK(f != NULL);
+        if (f) {
+            const char fake[] = "deadbeef-not-this-build";
+            fseek(f, 12, SEEK_SET);
+            fwrite(fake, 1, sizeof fake, f);   // includes the terminating NUL
+            fclose(f);
+        }
+        int r = lk7_persist_read();
+        CHECK(r == 0);
+        printf("  [parent] gittip-mismatch header refused: r=%d\n", r);
+    }
+
+    // leave a clean valid file behind (tidy, and matches shipped behaviour)
+    CHECK(lk7_persist_write() == 1);
+    remove(path);   // do not leave a savestate.bin in the build tree
+
+    if (g_failures) { fprintf(stderr, "smoke_persist: %d FAILURE(S)\n", g_failures); return 1; }
+    printf("smoke_persist: all checks passed (wrote disk state, a second process "
+           "loaded it byte-exact, corrupted and stale-build headers both refused)\n");
+    return 0;
+}
+
+int main(void)
+{
+    const char *phase = getenv("SM64DS_PERSIST_PHASE");
+    if (phase && strcmp(phase, "load") == 0) return phase_load();
+    return phase_save();
+}

--- a/port/tests/smoke_savestate.cpp
+++ b/port/tests/smoke_savestate.cpp
@@ -92,6 +92,7 @@ void sd_seq_reset(void) {}
 void sd_mix_reset(void) {}
 void sd_consumer_reset(void) {}
 void sd_waves_reset(void) {}
+void sd_sdat_reseat(void) {}
 
 // The hardware content stores (palette/video/sprite memory) need NO stub: this
 // smoke links the ntr library, so lk6_savestate reaches the real

--- a/port/tests/walk_window.cpp
+++ b/port/tests/walk_window.cpp
@@ -459,6 +459,13 @@ void port_stage_a2_seat(void);
 int lk6_savestate_save(void);
 int lk6_savestate_load(void);
 int lk6_savestate_has(void);
+/* disk-backed save state (hal/lk7_persist.cpp): makes the slot survive a
+   restart. write() mirrors a successful save to <exedir>\savestate.bin,
+   read() loads it at startup; available() is 1 only when the arena is at its
+   fixed base so disk states can relocate. */
+int lk7_persist_write(void);
+int lk7_persist_read(void);
+int lk7_persist_available(void);
 
 /* Two seconds of on-screen text for the save-state actions. Every earlier
    report of "F8 did nothing" was undiagnosable because the only evidence was a
@@ -1324,8 +1331,12 @@ static void menu_draw(ntr::Framebuffer &fb)
     snprintf(ln[MENU_CAMERA], sizeof ln[0], "camera            %s",
              cam_mode_name(cam_mode));
     snprintf(ln[MENU_RECORDER], sizeof ln[0], "recorder          %s", g_playlog);
-    snprintf(ln[MENU_SAVESTATE], sizeof ln[0], "save state        F8   %s",
-             lk6_savestate_has() ? "(slot in use, overwrite)" : "(slot empty)");
+    /* the disk suffix tells the player whether a save will outlive the run: it
+       does only when the arena is at its fixed base, which is what lets a disk
+       state's pointers relocate on the next launch (hal/lk7_persist.cpp). */
+    snprintf(ln[MENU_SAVESTATE], sizeof ln[0], "save state        F8   %s%s",
+             lk6_savestate_has() ? "(slot in use, overwrite)" : "(slot empty)",
+             lk7_persist_available() ? " to disk" : " this run only");
     snprintf(ln[MENU_LOADSTATE], sizeof ln[0], "load state        F9   %s",
              lk6_savestate_has() ? "(restore slot)" : "(no state saved)");
 
@@ -2376,6 +2387,24 @@ int main(void)
        the sink here, in one write (see the setvbuf note above) */
     fflush(stdout);
 
+    /* Disk save state, read exactly once, here: the world is fully booted (the
+       disk state describes a booted world, so restoring earlier would be
+       stomped by the rest of boot) and the frame loop has not started. Never in
+       a selftest: the comparator runs must stay deterministic, and a stray
+       savestate.bin beside the exe would silently swap the world out from
+       under them. */
+    /* SM64DS_SS_DISKLOAD=1 opts a selftest INTO the disk read, for the
+       cross-restart reproducer: run one saves to disk (SM64DS_SS_DISK=1), run
+       two boots with this set and must land on the first run's hardware hash.
+       Without the env, selftests never touch savestate.bin, so the comparator
+       runs stay deterministic. */
+    if ((!selftest || getenv("SM64DS_SS_DISKLOAD")) && lk7_persist_available()) {
+        if (lk7_persist_read()) {
+            an_pivot_live = 0;   /* no ease across the load */
+            ss_note("state loaded from disk (F9 reloads it)");
+        }
+    }
+
     static ntr::Framebuffer fb;
     MSG msg;
     for (;;) {
@@ -2430,9 +2459,18 @@ int main(void)
             static int save_edge, load_edge;
             const int save_now = key_live(VK_F8);
             const int load_now = key_live(VK_F9);
-            if (save_now && !save_edge)
-                ss_note(lk6_savestate_save() ? "state saved (F9 loads it)"
-                                             : "state NOT saved (see log)");
+            if (save_now && !save_edge) {
+                if (lk6_savestate_save()) {
+                    /* mirror to disk; the toast tells the player whether this
+                       save will outlive the run, which is the difference every
+                       "it did not save" report was actually about */
+                    ss_note(lk7_persist_write()
+                                ? "state saved to disk (F9 loads it)"
+                                : "state saved for THIS RUN (F9 loads it)");
+                } else {
+                    ss_note("state NOT saved (see log)");
+                }
+            }
             if (load_now && !load_edge) {
                 if (lk6_savestate_load()) {
                     an_pivot_live = 0;   /* no ease across */
@@ -2471,7 +2509,9 @@ int main(void)
                                         reachable in a plain headless walk. */
         if (selftest) {
             static int ss_env, ss_save_fr = -1, ss_load_fr = -1,
-                       ss_lock = 0, ss_assert = 0, ss_expect_mount = 0;
+                       ss_lock = 0, ss_assert = 0, ss_expect_mount = 0,
+                       ss_disk = 0;
+            static unsigned long long ss_expect_hw;
             static unsigned char ss_lock_at_save;
             static int ss_saw_save = 0;
             static unsigned long long ss_hash_at_save;
@@ -2483,6 +2523,13 @@ int main(void)
                 if (l) ss_load_fr = atoi(l);
                 ss_lock = getenv("SM64DS_SS_LOCK") != 0;
                 ss_assert = getenv("SM64DS_SS_ASSERT") != 0;
+                ss_disk = getenv("SM64DS_SS_DISK") != 0;
+                /* the cross-restart reproducer's second half: this run did not
+                   save, it BOOTED from run one's savestate.bin, so the hash to
+                   hold the restore to arrives from outside (run one's printed
+                   save hash) instead of from a save frame in this process */
+                if (const char *xh = getenv("SM64DS_SS_EXPECT_HW"))
+                    ss_expect_hw = strtoull(xh, 0, 16);
                 /* the cross-area variant: something between save and load is
                    expected to MOUNT another area (SM64DS_EXIT_ENTER drives the
                    real door path). Requiring the hardware stores to have
@@ -2492,6 +2539,12 @@ int main(void)
             }
             if (ss_save_fr >= 0 && frame == ss_save_fr) {
                 lk6_savestate_save();
+                /* the cross-restart reproducer's first half: mirror this save
+                   to savestate.bin so a SECOND run (SM64DS_SS_DISKLOAD=1) can
+                   boot from it and compare hashes across the restart */
+                if (ss_disk)
+                    fprintf(stderr, "[ss-repro] f%d disk write: %s\n", frame,
+                            lk7_persist_write() ? "ok" : "SKIPPED/FAILED");
                 ss_lock_at_save = data_0209d660;
                 ss_hash_at_save = ss_hw_hash();
                 ss_saw_save = 1;
@@ -2511,7 +2564,7 @@ int main(void)
                         "hw=%016llx (%s the saved hash)\n", frame,
                         (unsigned)data_0209d660, pre,
                         pre == ss_hash_at_save ? "STILL" : "differs from");
-                if (ss_expect_mount && pre == ss_hash_at_save) {
+                if (ss_expect_mount && ss_saw_save && pre == ss_hash_at_save) {
                     fprintf(stderr, "[ss-repro] FAIL(vacuous): the hardware "
                             "stores never changed between save and load, so "
                             "no area mounted and a cross-area restore was not "
@@ -2535,12 +2588,16 @@ int main(void)
                     ntr::ppu_write_bmp("walk_window_selftest.bmp", fb);
                     return 3;
                 }
-                if (ss_assert && post != ss_hash_at_save) {
+                /* the reference hash: this run's own save when there was one,
+                   else the one passed in for a cross-restart run. Neither set
+                   means there is nothing sound to hold the restore to. */
+                const unsigned long long want =
+                    ss_saw_save ? ss_hash_at_save : ss_expect_hw;
+                if (ss_assert && want && post != want) {
                     fprintf(stderr, "[ss-repro] FAIL: the hardware stores did "
                             "NOT roll back on restore (post-load %016llx, "
-                            "saved %016llx) -- the world came back under "
-                            "another area's textures, the 0.2.1 cross-area "
-                            "bug\n", post, ss_hash_at_save);
+                            "expected %016llx) -- the world came back under "
+                            "another area's textures\n", post, want);
                     ntr::ppu_write_bmp("walk_window_selftest.bmp", fb);
                     return 4;
                 }
@@ -2789,10 +2846,14 @@ int main(void)
                            The toast fires here too: highlighting the row and
                            closing the menu does NOT save, and the only way a
                            player can learn that is being shown the difference. */
-                        if (edge & (1u << 5))
-                            ss_note(lk6_savestate_save()
-                                        ? "state saved (F9 loads it)"
-                                        : "state NOT saved (see log)");
+                        if (edge & (1u << 5)) {
+                            if (lk6_savestate_save())
+                                ss_note(lk7_persist_write()
+                                            ? "state saved to disk (F9 loads it)"
+                                            : "state saved for THIS RUN (F9 loads it)");
+                            else
+                                ss_note("state NOT saved (see log)");
+                        }
                         break;
                     case MENU_LOADSTATE:
                         /* enter/right only: restore the slot. A no-op with no


### PR DESCRIPTION
Lands lane lk7 (cut off mid-session), carried forward onto the `.dsstate`-section and hardware-store world it predated. Driven by the direct report: saving, closing the game, reopening, and F9 saying there is nothing to load.

Kept from the lane: fixed arena base (`0x30000000`, the ntr reservation technique) so arena pointers relocate across launches; atomic write of the slot to `savestate.bin` beside the exe on every F8; startup read; field-by-field header refusals (magic, format, gittip, bases, sizes) that name what mismatched and leave the file alone.

Added over the lane draft:
- **Image-base guard + `/DYNAMICBASE:NO`** on the window targets. States hold absolute pointers into the exe image (every vtable); ASLR rebases per boot, which the lane never checked. Belt and suspenders: the pinned base makes it moot, the header check catches it anyway.
- **`sd_sdat_reseat`**: `data_020a5bb8` is a captured DS global holding a host boot pointer (sdat's calloc'd root). A disk state restored another process's heap address and the first sound lookup faulted. Found crash-driven by the new cross-restart reproducer; the live root is re-seated after every load.
- Payload is the full current slot (arena + dsstate + hw, format 2).
- The toast and menu row say whether a save went **to disk** or is **this run only**, and a startup load announces itself.

Verified: `smoke_persist` (a second process loads the file byte-exact; corrupted and stale-build headers refused), walk_window cross-restart (run 2 boots from run 1's file, hardware hash matches via `SM64DS_SS_EXPECT_HW`, 200 frames clean), and the full prior matrix stays green (smoke_savestate, control, same-area, cross-area).

`git diff -- src/` is empty. Nothing in CI builds `port/`; the evidence is the local matrix.