### PR TITLE
Seven size asserts claimed a field span; the ROM's operator new disagreed

### DIFF
--- a/include/BobOmb.h
+++ b/include/BobOmb.h
@@ -23,8 +23,10 @@
  * Member NAMES are the ones this header already used -- a rebase should not
  * also rename things its callers spell.
  *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
+ * SIZE IS THE ROM'S OWN, not a rounded-up field span: `BobOmb_Spawn` calls
+ * `ActorBase::operator new(1024)` -- 0x400 -- and stores `_ZTV6BobOmb`,
+ * so that literal IS this class's sizeof. The observed fields only span to
+ * 0x3f8; the difference is trailing space no source reads.
  */
 
 #include "Enemy.h"
@@ -64,7 +66,7 @@ struct BobOmb : Enemy {
     u8                           unk_3f4;               /* 0x3f4 */
     u8                           unk_3f5;               /* 0x3f5 */
     u8                           unk_3f6;               /* 0x3f6 */
-    u8  pad_3f7[0x1];
+    u8  pad_3f7[0x9];
 
     /* --- vtable --- */
     virtual ~BobOmb();
@@ -78,6 +80,6 @@ struct BobOmb : Enemy {
     int Render();
 };
 
-typedef char BobOmb_size_must_be_0x3f8[sizeof(BobOmb) == 0x3f8 ? 1 : -1];
+typedef char BobOmb_size_must_be_0x400[sizeof(BobOmb) == 0x400 ? 1 : -1];
 
 #endif /* BOBOMB_H */

--- a/include/FlyGuy.h
+++ b/include/FlyGuy.h
@@ -18,8 +18,10 @@
  * Member NAMES are the ones this header already used -- a rebase should not
  * also rename things its callers spell.
  *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
+ * SIZE IS THE ROM'S OWN, not a rounded-up field span: `FlyGuy_Spawn` calls
+ * `ActorBase::operator new(1000)` -- 0x3e8 -- and stores `_ZTV6FlyGuy`,
+ * so that literal IS this class's sizeof. The observed fields only span to
+ * 0x3e4; the difference is trailing space no source reads.
  */
 
 #include "Enemy.h"
@@ -53,6 +55,7 @@ struct FlyGuy : Enemy {
     u16                          unk_3cc;               /* 0x3cc */
     u8  pad_3ce[0x12];
     s32                          unk_3e0;               /* 0x3e0 */
+    u8  pad_3e4[0x4];
 
     /* --- vtable --- */
     virtual ~FlyGuy();
@@ -67,6 +70,6 @@ struct FlyGuy : Enemy {
     int Render();
 };
 
-typedef char FlyGuy_size_must_be_0x3e4[sizeof(FlyGuy) == 0x3e4 ? 1 : -1];
+typedef char FlyGuy_size_must_be_0x3e8[sizeof(FlyGuy) == 0x3e8 ? 1 : -1];
 
 #endif /* FLYGUY_H */

--- a/include/HeaveHo.h
+++ b/include/HeaveHo.h
@@ -23,8 +23,10 @@
  * Member NAMES are the ones this header already used -- a rebase should not
  * also rename things its callers spell.
  *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
+ * SIZE IS THE ROM'S OWN, not a rounded-up field span: `HeaveHo_Spawn` calls
+ * `ActorBase::operator new(1068)` -- 0x42c -- and stores `_ZTV7HeaveHo`,
+ * so that literal IS this class's sizeof. The observed fields only span to
+ * 0x428; the difference is trailing space no source reads.
  */
 
 #include "Enemy.h"
@@ -53,7 +55,7 @@ struct HeaveHo : Enemy {
     s32                          unk_418;               /* 0x418 */
     u8  pad_41c[0xa];
     u8                           unk_426;               /* 0x426 */
-    u8  pad_427[0x1];
+    u8  pad_427[0x5];
 
     /* --- vtable --- */
     virtual ~HeaveHo();
@@ -65,6 +67,6 @@ struct HeaveHo : Enemy {
     void OnPendingDestroy();
 };
 
-typedef char HeaveHo_size_must_be_0x428[sizeof(HeaveHo) == 0x428 ? 1 : -1];
+typedef char HeaveHo_size_must_be_0x42c[sizeof(HeaveHo) == 0x42c ? 1 : -1];
 
 #endif /* HEAVEHO_H */

--- a/include/HootTheOwl.h
+++ b/include/HootTheOwl.h
@@ -29,8 +29,10 @@
  *   - unk_368 = that Animation's speed (+0x0c); Behavior copies mAnimSpeed
  *     into it, and InitResources sets mAnimSpeed to 0x1000, which is 1.0
  *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
+ * SIZE IS THE ROM'S OWN, not a rounded-up field span: `HootTheOwl_Spawn` calls
+ * `ActorBase::operator new(1016)` -- 0x3f8 -- and stores `_ZTV10HootTheOwl`,
+ * so that literal IS this class's sizeof. The observed fields only span to
+ * 0x3f4; the difference is trailing space no source reads.
  */
 
 #include "Enemy.h"
@@ -63,6 +65,7 @@ struct HootTheOwl : Enemy {
     u8  unk_3e4;                      /* 0x3e4 */
     u8  pad_3e5[0xb];
     Fix12i mAnimSpeed;                /* 0x3f0 -- copied into mModelAnim.speed */
+    u8  pad_3f4[0x4];
 
     /* --- vtable --- */
     virtual ~HootTheOwl();
@@ -74,6 +77,6 @@ struct HootTheOwl : Enemy {
     int Render();
 };
 
-typedef char HootTheOwl_size_must_be_0x3f4[sizeof(HootTheOwl) == 0x3f4 ? 1 : -1];
+typedef char HootTheOwl_size_must_be_0x3f8[sizeof(HootTheOwl) == 0x3f8 ? 1 : -1];
 
 #endif /* HOOTTHEOWL_H */

--- a/include/RollingRock.h
+++ b/include/RollingRock.h
@@ -18,8 +18,10 @@
  * Member NAMES are the ones this header already used -- a rebase should not
  * also rename things its callers spell.
  *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
+ * SIZE IS THE ROM'S OWN, not a rounded-up field span: `RollingRock_Spawn` calls
+ * `ActorBase::operator new(968)` -- 0x3c8 -- and stores `_ZTV11RollingRock`,
+ * so that literal IS this class's sizeof. The observed fields only span to
+ * 0x3c4; the difference is trailing space no source reads.
  */
 
 #include "Enemy.h"
@@ -44,7 +46,7 @@ struct RollingRock : Enemy {
     u8                           unk_3c0;               /* 0x3c0 */
     u8                           unk_3c1;               /* 0x3c1 */
     u8                           unk_3c2;               /* 0x3c2 */
-    u8  pad_3c3[0x1];
+    u8  pad_3c3[0x5];
 
     /* --- vtable --- */
     virtual ~RollingRock();
@@ -57,6 +59,6 @@ struct RollingRock : Enemy {
     int CleanupResources();
 };
 
-typedef char RollingRock_size_must_be_0x3c4[sizeof(RollingRock) == 0x3c4 ? 1 : -1];
+typedef char RollingRock_size_must_be_0x3c8[sizeof(RollingRock) == 0x3c8 ? 1 : -1];
 
 #endif /* ROLLINGROCK_H */

--- a/include/Snowball.h
+++ b/include/Snowball.h
@@ -18,8 +18,10 @@
  * Member NAMES are the ones this header already used -- a rebase should not
  * also rename things its callers spell.
  *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
+ * SIZE IS THE ROM'S OWN, not a rounded-up field span: `Snowball_Spawn` calls
+ * `ActorBase::operator new(908)` -- 0x38c -- and stores `_ZTV8Snowball`,
+ * so that literal IS this class's sizeof. The observed fields only span to
+ * 0x388; the difference is trailing space no source reads.
  */
 
 #include "Enemy.h"
@@ -40,6 +42,7 @@ struct Snowball : Enemy {
     s32                          unk_37c;               /* 0x37c */
     s32                          unk_380;               /* 0x380 */
     s32                          unk_384;               /* 0x384 */
+    u8  pad_388[0x4];
 
     /* --- vtable --- */
     virtual ~Snowball();
@@ -51,6 +54,6 @@ struct Snowball : Enemy {
     void OnPendingDestroy();
 };
 
-typedef char Snowball_size_must_be_0x388[sizeof(Snowball) == 0x388 ? 1 : -1];
+typedef char Snowball_size_must_be_0x38c[sizeof(Snowball) == 0x38c ? 1 : -1];
 
 #endif /* SNOWBALL_H */

--- a/include/Snufit.h
+++ b/include/Snufit.h
@@ -25,8 +25,10 @@
  * `speed` of its Animation base (base at +0x50, speed at +0x0c). Same shape as
  * HootTheOwl's.
  *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
+ * SIZE IS THE ROM'S OWN, not a rounded-up field span: `Snufit_Spawn` calls
+ * `ActorBase::operator new(996)` -- 0x3e4 -- and stores `_ZTV6Snufit`,
+ * so that literal IS this class's sizeof. The observed fields only span to
+ * 0x3dc; the difference is trailing space no source reads.
  */
 
 #include "Enemy.h"
@@ -58,6 +60,7 @@ struct Snufit : Enemy {
     s32 mHomePosY;                    /* 0x3d0 */
     s32 mHomePosZ;                    /* 0x3d4 */
     s32 unk_3d8;                      /* 0x3d8 -- advanced by 0x200 a frame */
+    u8  pad_3dc[0x8];
 
     /* --- vtable --- */
     virtual ~Snufit();
@@ -72,6 +75,6 @@ struct Snufit : Enemy {
     int Render();
 };
 
-typedef char Snufit_size_must_be_0x3dc[sizeof(Snufit) == 0x3dc ? 1 : -1];
+typedef char Snufit_size_must_be_0x3e4[sizeof(Snufit) == 0x3e4 ? 1 : -1];
 
 #endif /* SNUFIT_H */


### PR DESCRIPTION
Seven headers carried this disclaimer:

> SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it is not independent evidence about the ROM.

That is honest, and in all seven cases the ROM *does* have independent evidence one file away. Each class's own `<Class>_Spawn` calls `ActorBase::operator new(N)` and stores that class's `_ZTV`, so `N` **is** its `sizeof`.

| class | assert | ROM literal | vtable stored |
|---|---|---|---|
| `BobOmb` | 0x3f8 → **0x400** | `operator new(1024)` | `_ZTV6BobOmb` |
| `FlyGuy` | 0x3e4 → **0x3e8** | `operator new(1000)` | `_ZTV6FlyGuy` |
| `HeaveHo` | 0x428 → **0x42c** | `operator new(1068)` | `_ZTV7HeaveHo` |
| `HootTheOwl` | 0x3f4 → **0x3f8** | `operator new(1016)` | `_ZTV10HootTheOwl` |
| `RollingRock` | 0x3c4 → **0x3c8** | `operator new(968)` | `_ZTV11RollingRock` |
| `Snowball` | 0x388 → **0x38c** | `operator new(908)` | `_ZTV8Snowball` |
| `Snufit` | 0x3dc → **0x3e4** | `operator new(996)` | `_ZTV6Snufit` |

Every factory stores its **own** vtable, so the class↔factory pairing here is by vtable address, not by name — the direction that matters, given 41 classes in this tree carry the name of the class at the *next* vtable.

The difference is trailing space no source reads, so each correction is a pad at the end of the data members. **No existing field offset moves.**

## Verification

- **Byte-neutral, measured not asserted.** All **53** `src/` consumers of these seven headers compile to identical bytes at `2004/b56` before and after: **53 byte-identical, 0 changed, 0 compile-fail.**
- **The asserts actually hold** — each consumer compiles at the pin, which is what makes `sizeof(Class) == <new>` a real check rather than a claim.
- `check_header_offsets` on all seven: **0 mismatched**, struct spans land exactly on the new sizes. (An intermediate version of this change extended the last `pad_` *declaration* rather than the trailing one, which shoved later fields forward — that gate caught it. Worth knowing it earns its keep.)
- `prepush_attribution`: `11292 tracked, 0 changed, 0 lost`.
- `port_refcheck`: 393 references, 0 stale.

## Provenance

Recovered from the stranded tip of `cpp/enemy-subclasses-2` (#1387), which the merge-stranding gate has been flagging since 2026-08-11.

**Re-derived onto current main rather than cherry-picked**, deliberately: that branch predates main adding `OnYoshiTryEat` / `OnAimedAtWithEgg` to four of these classes, so replaying it verbatim would have silently deleted two virtuals from `BobOmb`, `FlyGuy`, `RollingRock` and `Snufit`. Virtual counts are unchanged here (verified per class against main).

Every literal above was re-read from the factory in this tree rather than taken from the stranded branch's own comments.

## Not included

`#1387`'s other half — the `CapEnemy` intermediate — is **not** here. Main's `CapEnemy.h` has evolved independently since that branch and already describes the class as deriving from `Enemy` at 0x180, so it needs reconciling rather than replaying. That leaves #1387 still flagged; it should stay flagged until someone settles the CapEnemy half.

**64 headers on main still carry the "observed field span" wording**, so this is a slice of that worklist, not the end of it.