### PR TITLE
Enroll 4 already-eligible functions missing their `complete` marker (+4 source-built)

### DIFF
--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -306,6 +306,7 @@ src/_ZN11dScMgBase_c8BehaviorEv.cpp:
     .text start:0x020b0618 end:0x020b0620
 
 src/_ZN11dScMgBase_c14BeforeBehaviorEv.cpp:
+    complete
     .text start:0x020b0620 end:0x020b0840
 
 src/_ZN11dScMgBase_c21AfterCleanupResourcesEj.cpp:
@@ -317,6 +318,7 @@ src/_ZN11dScMgBase_c18AfterInitResourcesEj.cpp:
     .text start:0x020b08f0 end:0x020b0930
 
 src/_ZN11dScMgBase_c19BeforeInitResourcesEv.cpp:
+    complete
     .text start:0x020b0930 end:0x020b0a38
 
 src/func_ov004_020b0a38.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -4121,6 +4121,7 @@ src/func_ov006_020f8ed8.c:
     .text start:0x020f8ed8 end:0x020f8ef4
 
 src/_ZN14dScMgMCarlo2_cD1Ev.cpp:
+    complete
     .text start:0x020f8ef4 end:0x020f8f68
 
 src/_ZN14dScMgMCarlo2_cD0Ev.cpp:
@@ -5914,6 +5915,7 @@ src/func_ov006_02119900.c:
     .text start:0x02119900 end:0x02119904
 
 src/_ZN12dScMgSound_cD1Ev.cpp:
+    complete
     .text start:0x02119904 end:0x02119958
 
 src/_ZN12dScMgSound_cD0Ev.cpp:


### PR DESCRIPTION
## What this is

Four `src/` files that byte-match their ROM function, pass every rule in `tools/eligible.py`, and are **not enrolled** — their `config/**/delinks.txt` entry has no `complete` marker. dsd therefore never asks for the compiled object and serves the ROM's own bytes for those four address ranges. The match exists in the tree and reaches nothing.

This PR adds the four missing markers. **No source file is touched.** The diff is 4 added lines across 2 ledger files.

| symbol | module | range |
|---|---|---|
| `_ZN11dScMgBase_c14BeforeBehaviorEv` | ov004 | `0x020b0620..0x020b0840` |
| `_ZN11dScMgBase_c19BeforeInitResourcesEv` | ov004 | `0x020b0930..0x020b0a38` |
| `_ZN14dScMgMCarlo2_cD1Ev` | ov006 | `0x020f8ef4..0x020f8f68` |
| `_ZN12dScMgSound_cD1Ev` | ov006 | `0x02119904..0x02119958` |

## ROM evidence that they were already eligible

On **pristine `origin/main`** (commit `094678737`), in a clean worktree:

```
python tools/eligible.py -j 16   ->  eligible: 10821 / 11162
python tools/rombuild.py  -j 16  ->  source-built functions: 10,817  (88.00%)
```

All four names are present in `build/eligible-names.txt` on that pristine tree:

```
$ grep -E 'dScMgBase_c14BeforeBehavior|dScMgBase_c19BeforeInitResources|dScMgSound_cD1Ev|dScMgMCarlo2_cD1Ev' build/eligible-names.txt
_ZN11dScMgBase_c14BeforeBehaviorEv
_ZN11dScMgBase_c19BeforeInitResourcesEv
_ZN12dScMgSound_cD1Ev
_ZN14dScMgMCarlo2_cD1Ev
```

The gap between 10821 eligible and 10,817 source-built is exactly these four. This PR closes it.

## Gates (run on this branch, clean tree, own `build/`)

| gate | result |
|---|---|
| `rombuild.py -j16` **before** | `10,817` source-built, `88.00%`, **106/106 exact**, mismatching **0** |
| `rombuild.py -j16` **after** | `10,821` source-built, `88.04%`, **106/106 exact**, mismatching **0** |
| `eligible.py` before → after | `10821 / 11162` → `10821 / 11162`; **name-list diff is empty** |
| `check_references.py` | unresolved 234 (baseline 234), eligible 10821 (baseline 10821) — `OK: no new unresolvable references` |
| `check_data_definitions.py` | 10974 objects, none define a ROM data symbol |
| `port_refcheck.py` | 393 references checked, 0 stale |
| `check_duplicate_sources.py` | 11282 stems, none doubled |
| `langmode_audit.py --check` (baseline from `origin/chaos-data`) | `langmode ratchet PASS` |
| `prepush_attribution.py --base origin/main --head HEAD` | `11292 tracked, 0 moved, 0 renamed, 0 changed, 0 lost` |

The empty eligible name-list diff is the point, not an omission: this PR changes **enrollment**, not eligibility. A count-only check would have shown "no change" and looked like a no-op; the ROM number is where the change lands.

## What this does NOT claim

- It does not claim any new byte match. All four functions already reproduced; they were simply never linked in.
- It does not touch any `src/` file, header, or symbol name.
- It makes no statement about *why* the markers were missing. This is recovery, not diagnosis.
- The `+0.04%` is real but small; the value here is that it is free and was already paid for.

## Sequencing

Part of a three-PR phantom-reference sweep. Intended landing order:

1. **#1475** (`cpp/mg-single3d-rest`) — it also edits `config/arm9/overlays/ov006/delinks.txt`; land it first.
2. **this PR (A)** — stale enrollment only, no source change.
3. **#1481** (PR B) — `resolve_placeholders.py --apply`, 14 files.
4. **#1482** (PR C) — 3 hand-resolved phantom references.

All three merged together give **10,838 source-built, 88.33%, 106/106 exact, 0 mismatching** — verified locally by merging all three branches and running `rombuild.py -j16` on the result. `10,817 + 4 + 14 + 3 = 10,838`; the three PRs' contributions are disjoint.

`merge=union` on `delinks.txt` runs locally but **not** on github.com, so these must be merged one at a time with a re-check between each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT

