### PR TITLE
resolve_placeholders.py --apply: 14 files stop referencing invented symbols (+14 source-built)

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -3780,6 +3780,7 @@ src/_ZN5Stage7VE_InitEv.cpp:
     .text start:0x02023a80 end:0x02023be0
 
 src/_ZN5Stage20RenderBouncingArrowsEv.cpp:
+    complete
     .text start:0x02023be0 end:0x02023db8
 
 src/_ZN5Stage9LC_RenderEv.cpp:
@@ -3795,6 +3796,7 @@ src/_ZN5Stage16CheckCameraInputEv.cpp:
     .text start:0x02024c70 end:0x020250d0
 
 src/_ZN5Stage12RenderNumberEhiibi.cpp:
+    complete
     .text start:0x020250d0 end:0x020251d0
 
 src/_ZN5Stage9PS_RenderEv.cpp:
@@ -4179,6 +4181,7 @@ src/_ZN5Stage16OnPendingDestroyEv.cpp:
     .text start:0x0202b8a0 end:0x0202b8a4
 
 src/_ZN5Stage6RenderEv.cpp:
+    complete
     .text start:0x0202b8a4 end:0x0202bbbc
 
 src/_ZN5Stage8BehaviorEv.cpp:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -5784,6 +5784,7 @@ src/_ZN3HUD15CalculateDigitsEt.cpp:
     .text start:0x020fbdac end:0x020fbe38
 
 src/_ZN3HUD15RenderLifeCountEv.cpp:
+    complete
     .text start:0x020fbe38 end:0x020fc04c
 
 src/_ZN3HUD19RenderCameraButtonsEv.cpp:
@@ -5795,6 +5796,7 @@ src/_ZN3HUD17RenderSilverStarsEv.cpp:
     .text start:0x020fc3c4 end:0x020fc458
 
 src/_ZN3HUD15RenderStarCountEv.cpp:
+    complete
     .text start:0x020fc458 end:0x020fc77c
 
 src/_ZN3HUD14RenderRedCoinsEv.cpp:
@@ -5802,6 +5804,7 @@ src/_ZN3HUD14RenderRedCoinsEv.cpp:
     .text start:0x020fc77c end:0x020fc81c
 
 src/_ZN3HUD15RenderCoinCountEv.cpp:
+    complete
     .text start:0x020fc81c end:0x020fca18
 
 src/_ZN3HUD13RenderVsTimerEv.cpp:

--- a/config/arm9/overlays/ov003/delinks.txt
+++ b/config/arm9/overlays/ov003/delinks.txt
@@ -64,9 +64,11 @@ src/func_ov003_020adf50.c:
     .text start:0x020adf50 end:0x020adfc8
 
 src/func_ov003_020adfc8.cpp:
+    complete
     .text start:0x020adfc8 end:0x020ae0b0
 
 src/func_ov003_020ae0b0.c:
+    complete
     .text start:0x020ae0b0 end:0x020ae1a4
 
 src/func_ov003_020ae1a4.c:
@@ -74,6 +76,7 @@ src/func_ov003_020ae1a4.c:
     .text start:0x020ae1a4 end:0x020ae238
 
 src/func_ov003_020ae238.c:
+    complete
     .text start:0x020ae238 end:0x020ae358
 
 src/func_ov003_020ae6f0.c:

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -140,6 +140,7 @@ src/_ZN10ChainChomp13InitResourcesEv.cpp:
     .text start:0x02112b14 end:0x02112d1c
 
 src/ChainChomp_Spawn.cpp:
+    complete
     .text start:0x02112d1c end:0x02112e0c
 
 src/_ZN15ChainChompFenceD1Ev.cpp:

--- a/config/arm9/overlays/ov034/delinks.txt
+++ b/config/arm9/overlays/ov034/delinks.txt
@@ -136,6 +136,7 @@ src/_ZN7Wiggler13InitResourcesEv.cpp:
     .text start:0x0211323c end:0x021136a4
 
 src/Wiggler_Spawn.c:
+    complete
     .text start:0x021136a4 end:0x02113820
 
 src/__sinit_ov034_021138ec.c:

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -188,6 +188,7 @@ src/_ZN11ChiefChilly16OnAimedAtWithEggEv.cpp:
     .text start:0x02121ec0 end:0x02121ec8
 
 src/ChiefChilly_Spawn.cpp:
+    complete
     .text start:0x02121ec8 end:0x02121f90
 
 src/_ZN8CccArenaD1Ev.c:

--- a/config/arm9/overlays/ov074/delinks.txt
+++ b/config/arm9/overlays/ov074/delinks.txt
@@ -204,9 +204,11 @@ src/func_ov074_02122634.cpp:
     .text start:0x02122634 end:0x02122764
 
 src/ExplosionGoomba_Spawn.cpp:
+    complete
     .text start:0x02122764 end:0x02122838
 
 src/Goomboss_Spawn.cpp:
+    complete
     .text start:0x02122838 end:0x0212290c
 
 src/__sinit_ov074_02122978.c:

--- a/src/ChainChomp_Spawn.cpp
+++ b/src/ChainChomp_Spawn.cpp
@@ -1,7 +1,7 @@
 //cpp
 extern "C" {
 void* _ZN9ActorBasenwEj(unsigned int);
-void func_020aed98(void);
+void _ZN5EnemyC2Ev(void);
 int _ZN25MovingCylinderClsnWithPosC1Ev(void*);
 int _ZN9ModelAnimC1Ev(void*);
 int _ZN11ShadowModelC1Ev(void*);
@@ -15,7 +15,7 @@ extern void func_0203d384();
 void* ChainChomp_Spawn(void){
   char* c = (char*)_ZN9ActorBasenwEj(0x620);
   if(c){
-    func_020aed98();
+    _ZN5EnemyC2Ev();
     *(int**)c = _ZTV10ChainChomp;
     _ZN25MovingCylinderClsnWithPosC1Ev(c+0x110);
     _ZN9ModelAnimC1Ev(c+0x150);

--- a/src/ChiefChilly_Spawn.cpp
+++ b/src/ChiefChilly_Spawn.cpp
@@ -1,6 +1,6 @@
 //cpp
 extern "C" void* _ZN9ActorBasenwEj(unsigned int sz);
-extern "C" void func_020aed98(void);
+extern "C" void _ZN5EnemyC2Ev(void);
 extern "C" void _ZN25MovingCylinderClsnWithPosC1Ev(void*);
 extern "C" void _ZN12WithMeshClsnC1Ev(void*);
 extern "C" void _ZN14BlendModelAnimC1Ev(void*);
@@ -15,7 +15,7 @@ extern "C" void* ChiefChilly_Spawn(void)
 {
     char* p = (char*)_ZN9ActorBasenwEj(0x504);
     if (p) {
-        func_020aed98();
+        _ZN5EnemyC2Ev();
         *(void**)p = &_ZTV11ChiefChilly;
         _ZN25MovingCylinderClsnWithPosC1Ev(p + 0x110);
         _ZN12WithMeshClsnC1Ev(p + 0x150);

--- a/src/ExplosionGoomba_Spawn.cpp
+++ b/src/ExplosionGoomba_Spawn.cpp
@@ -1,7 +1,7 @@
 //cpp
 extern "C" {
 extern void* _ZN9ActorBasenwEj(unsigned int);
-extern void func_020aed98(void*);
+extern void _ZN5EnemyC2Ev(void*);
 extern void func_020733a8(void* arr, int count, int size, void(*ctor)(void*), void(*dtor)(void*));
 extern void _ZN9ModelAnimC1Ev(void*);
 extern void _ZN15MaterialChangerC1Ev(void*);
@@ -18,7 +18,7 @@ extern void* _ZTV8Goomboss[];
 void* ExplosionGoomba_Spawn(void){
   char* p=(char*)_ZN9ActorBasenwEj(0x610);
   if(p){
-    func_020aed98(p);
+    _ZN5EnemyC2Ev(p);
     *(void***)p=(void**)_ZTV8Goomboss;
     func_020733a8(p+0x110, 4, 0x40, _ZN25MovingCylinderClsnWithPosC1Ev, _ZN25MovingCylinderClsnWithPosD1Ev);
     _ZN9ModelAnimC1Ev(p+0x210);

--- a/src/Goomboss_Spawn.cpp
+++ b/src/Goomboss_Spawn.cpp
@@ -1,7 +1,7 @@
 //cpp
 extern "C" {
 extern void* _ZN9ActorBasenwEj(unsigned int);
-extern void func_020aed98(void*);
+extern void _ZN5EnemyC2Ev(void*);
 extern void func_020733a8(void* arr, int count, int size, void(*ctor)(void*), void(*dtor)(void*));
 extern void _ZN9ModelAnimC1Ev(void*);
 extern void _ZN15MaterialChangerC1Ev(void*);
@@ -18,7 +18,7 @@ extern void* _ZTV8Goomboss[];
 void* Goomboss_Spawn(void){
   char* p=(char*)_ZN9ActorBasenwEj(0x610);
   if(p){
-    func_020aed98(p);
+    _ZN5EnemyC2Ev(p);
     *(void***)p=(void**)_ZTV8Goomboss;
     func_020733a8(p+0x110, 4, 0x40, _ZN25MovingCylinderClsnWithPosC1Ev, _ZN25MovingCylinderClsnWithPosD1Ev);
     _ZN9ModelAnimC1Ev(p+0x210);

--- a/src/Wiggler_Spawn.c
+++ b/src/Wiggler_Spawn.c
@@ -1,5 +1,5 @@
 extern void* _ZN9ActorBasenwEj(unsigned int sz);
-extern void func_020aed98(void);
+extern void _ZN5EnemyC2Ev(void);
 extern int func_020733a8(void *p, int a, int b, void *ctor, void *dtor);
 extern int _ZN12WithMeshClsnC1Ev(void *p);
 extern int _ZN25MovingCylinderClsnWithPosC1Ev(void *p);
@@ -19,7 +19,7 @@ extern int _ZTV7Wiggler[];
 void *Wiggler_Spawn(void){
   char *c = (char *)_ZN9ActorBasenwEj(0x8e8);
   if(c){
-    func_020aed98();
+    _ZN5EnemyC2Ev();
     *(int**)(c) = _ZTV7Wiggler;
     func_020733a8(c+0x110, 5, 0x64, _ZN9ModelAnimC1Ev, _ZN9ModelAnimD1Ev);
     func_020733a8(c+0x304, 5, 0x14, _ZN15MaterialChangerC1Ev, _ZN15MaterialChangerD1Ev);

--- a/src/_ZN3HUD15RenderCoinCountEv.cpp
+++ b/src/_ZN3HUD15RenderCoinCountEv.cpp
@@ -11,9 +11,9 @@ extern unsigned char data_0209f2d8;
 extern unsigned char data_0209f250;
 extern unsigned short data_0209f358[];
 extern signed char data_0209f2f8;
-extern OamAttr* func_020aba70[];
-extern OamAttr func_020ab9c8;
-extern OamAttr func_020abad8;
+extern OamAttr* _ZN3OAM7NUMBERSE[];
+extern OamAttr _ZN3OAM5TIMESE;
+extern OamAttr _ZN3OAM4COINE;
 extern int SublevelToLevel(int i);
 }
 
@@ -37,12 +37,12 @@ void HUD::RenderCoinCount()
         for (int i = 2; i >= 0; i--) {
             signed char d = digits[i];
             if (d >= 0) {
-                OAM::Render(true, func_020aba70[d], sb, 2, -1, 1, 0);
+                OAM::Render(true, _ZN3OAM7NUMBERSE[d], sb, 2, -1, 1, 0);
                 sb -= 9;
             }
         }
-        OAM::Render(true, &func_020ab9c8, sb, 0xa, -1, 1, 0);
-        OAM::Render(true, &func_020abad8, sb - 0x10, 2, -1, 1, 0);
+        OAM::Render(true, &_ZN3OAM5TIMESE, sb, 0xa, -1, 1, 0);
+        OAM::Render(true, &_ZN3OAM4COINE, sb - 0x10, 2, -1, 1, 0);
     } else {
         if (SublevelToLevel(data_0209f2f8) == 0x1d)
             return;
@@ -52,11 +52,11 @@ void HUD::RenderCoinCount()
         for (i = 2; i >= 0; i--) {
             signed char d = digits[i];
             if (d >= 0) {
-                OAM::Render(false, func_020aba70[d], sb, 2, -1, 1, 0);
+                OAM::Render(false, _ZN3OAM7NUMBERSE[d], sb, 2, -1, 1, 0);
                 sb -= 9;
             }
         }
-        OAM::Render(false, &func_020ab9c8, sb, 0xa, -1, 1, 0);
-        OAM::Render(false, &func_020abad8, sb - 0x10, 2, -1, 1, 0);
+        OAM::Render(false, &_ZN3OAM5TIMESE, sb, 0xa, -1, 1, 0);
+        OAM::Render(false, &_ZN3OAM4COINE, sb - 0x10, 2, -1, 1, 0);
     }
 }

--- a/src/_ZN3HUD15RenderLifeCountEv.cpp
+++ b/src/_ZN3HUD15RenderLifeCountEv.cpp
@@ -7,9 +7,9 @@ extern signed char data_0209f2f4;
 
 struct OamAttr;
 
-extern OamAttr* func_020ab948[];
-extern OamAttr func_020ab9c8;
-extern OamAttr* func_020aba70[];
+extern OamAttr* _ZN3OAM10LIFE_ICONSE[];
+extern OamAttr _ZN3OAM5TIMESE;
+extern OamAttr* _ZN3OAM7NUMBERSE[];
 
 struct HUDInfo {
     char pad[0x6d9];
@@ -39,27 +39,27 @@ void HUD::RenderLifeCount()
     unsigned char state = data_ov002_02111178;
 
     if (state >= 3 && state < 6) {
-        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, func_020ab948[info->field_6d9], xBase, 0xa, -1, 1, 0x1000, 0x1000, 0, -1);
-        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, xBase + 0x10, 0xa, -1, 1, 0);
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, _ZN3OAM10LIFE_ICONSE[info->field_6d9], xBase, 0xa, -1, 1, 0x1000, 0x1000, 0, -1);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM5TIMESE, xBase + 0x10, 0xa, -1, 1, 0);
         CalculateDigits((unsigned short)data_0209f2f4);
         int x = xBase + 0x18;
         for (int i = 0; i < 3; i++) {
             signed char d = digits[i];
             if (d >= 0) {
-                _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[d], x, 2, -1, 1, 0);
+                _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[d], x, 2, -1, 1, 0);
                 x += 9;
             }
         }
     } else {
-        _ZN3OAM9RenderSubEP7OamAttriiii(func_020ab948[info->field_6d9], xBase, 0xa, -1, 1);
-        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &func_020ab9c8, xBase + 0x10, 0xa, -1, 1, 0);
+        _ZN3OAM9RenderSubEP7OamAttriiii(_ZN3OAM10LIFE_ICONSE[info->field_6d9], xBase, 0xa, -1, 1);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &_ZN3OAM5TIMESE, xBase + 0x10, 0xa, -1, 1, 0);
         CalculateDigits((unsigned short)data_0209f2f4);
         int i;
         int x = xBase + 0x18;
         for (i = 0; i < 3; i++) {
             signed char d = digits[i];
             if (d >= 0) {
-                _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, func_020aba70[d], x, 2, -1, 1, 0);
+                _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, _ZN3OAM7NUMBERSE[d], x, 2, -1, 1, 0);
                 x += 9;
             }
         }

--- a/src/_ZN3HUD15RenderStarCountEv.cpp
+++ b/src/_ZN3HUD15RenderStarCountEv.cpp
@@ -39,9 +39,9 @@ extern unsigned char data_0209f2ac;
 extern unsigned char data_0209f2d4;
 extern int data_020a0db0;
 
-extern struct OamAttr* func_020aba70[];
-extern struct OamAttr func_020ab9c8;
-extern struct OamAttr func_020abad0;
+extern struct OamAttr* _ZN3OAM7NUMBERSE[];
+extern struct OamAttr _ZN3OAM5TIMESE;
+extern struct OamAttr _ZN3OAM10POWER_STARE;
 
 extern unsigned char NumStars(void);
 extern void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int b, struct OamAttr* attr, int x, int y, int a, int c, struct Matrix2x2* m);
@@ -57,12 +57,12 @@ void HUD::RenderStarCount()
         CalculateDigits((unsigned short)data_0209f310[data_0209f250]);
         for (i = 2; i >= 0; i--) {
             if (mDigits[i] >= 0) {
-                _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[mDigits[i]], x, 2, -1, 1, 0);
+                _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[mDigits[i]], x, 2, -1, 1, 0);
                 x -= 9;
             }
         }
-        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, x, 10, -1, 1, 0);
-        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020abad0, x - 16, 10, -1, 1, 0);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM5TIMESE, x, 10, -1, 1, 0);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM10POWER_STARE, x - 16, 10, -1, 1, 0);
         return;
     }
 
@@ -87,22 +87,22 @@ void HUD::RenderStarCount()
             }
             for (i = 2; i >= 0; i--) {
                 if (mDigits[i] >= 0) {
-                    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[mDigits[i]], x, 2, -1, 1, 0);
+                    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[mDigits[i]], x, 2, -1, 1, 0);
                     x -= 9;
                 }
             }
-            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, x, 10, -1, 1, 0);
-            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020abad0, x - 16, 10, -1, 1, 0);
+            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM5TIMESE, x, 10, -1, 1, 0);
+            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM10POWER_STARE, x - 16, 10, -1, 1, 0);
             return;
         }
     }
 
     for (i = 2; i >= 0; i--) {
         if (mDigits[i] >= 0) {
-            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, func_020aba70[mDigits[i]], x, 2, -1, 1, 0);
+            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, _ZN3OAM7NUMBERSE[mDigits[i]], x, 2, -1, 1, 0);
             x -= 9;
         }
     }
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &func_020ab9c8, x, 10, -1, 1, 0);
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &func_020abad0, x - 16, 10, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &_ZN3OAM5TIMESE, x, 10, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &_ZN3OAM10POWER_STARE, x - 16, 10, -1, 1, 0);
 }

--- a/src/_ZN5Stage12RenderNumberEhiibi.cpp
+++ b/src/_ZN5Stage12RenderNumberEhiibi.cpp
@@ -16,7 +16,7 @@ public:
 
 extern "C" int __aeabi_idiv(int, int);
 extern unsigned char data_020755b8[];
-extern OamAttr *func_020aba70[];
+extern OamAttr *_ZN3OAM7NUMBERSE[];
 
 void Stage::RenderNumber(unsigned char num, int x, int y, bool b, int p5)
 {
@@ -31,11 +31,11 @@ void Stage::RenderNumber(unsigned char num, int x, int y, bool b, int p5)
         {
             if (b == 0)
             {
-                OAM::Render(true, func_020aba70[digit], x, y, p5, -1, mtx);
+                OAM::Render(true, _ZN3OAM7NUMBERSE[digit], x, y, p5, -1, mtx);
             }
             else
             {
-                OAM::Render(false, func_020aba70[digit], x, y, p5, -1, 0);
+                OAM::Render(false, _ZN3OAM7NUMBERSE[digit], x, y, p5, -1, 0);
             }
             leading = 1;
             x += 9;

--- a/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
+++ b/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
@@ -9,7 +9,7 @@ extern unsigned char data_0209f2c4;
 extern unsigned char data_0209f284;
 extern unsigned char data_0209f2d8;
 extern unsigned char data_0209f248;
-extern void func_020abd88(void);
+extern void _ZN3OAM14BOUNCING_ARROWE(void);
 int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, void*, int, int, int, int, int, int, int, int);
 
 void Stage::RenderBouncingArrows() {
@@ -31,13 +31,13 @@ void Stage::RenderBouncingArrows() {
         if ((unsigned char)(d + 0xf7) > 2u) goto draw2;
     }
 draw1:
-    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0x40, r4, -1, -1, 0x1000, 0x1000, 0, -1);
-    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0x80, r4, -1, -1, 0x1000, 0x1000, 0, -1);
-    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xc0, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)_ZN3OAM14BOUNCING_ARROWE, 0x40, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)_ZN3OAM14BOUNCING_ARROWE, 0x80, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)_ZN3OAM14BOUNCING_ARROWE, 0xc0, r4, -1, -1, 0x1000, 0x1000, 0, -1);
     return;
 draw2:
-    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xc, r4, -1, -1, 0x1000, 0x1000, 0, -1);
-    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xf4, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)_ZN3OAM14BOUNCING_ARROWE, 0xc, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)_ZN3OAM14BOUNCING_ARROWE, 0xf4, r4, -1, -1, 0x1000, 0x1000, 0, -1);
     return;
 }
 }

--- a/src/_ZN5Stage6RenderEv.cpp
+++ b/src/_ZN5Stage6RenderEv.cpp
@@ -66,8 +66,8 @@ extern "C" {
     extern AnimMgr* data_0209f340;
     extern char* data_0209f318;
     extern char* data_0209f394[];
-    extern OamAttr func_020abad8;
-    extern OamAttr func_020ab9c8;
+    extern OamAttr _ZN3OAM4COINE;
+    extern OamAttr _ZN3OAM5TIMESE;
 }
 
 struct Stage {
@@ -146,8 +146,8 @@ int Stage::Render() {
         int v = (SublevelToLevel(data_02092124) < 0xf) ? 0x80 : 0x70;
         if (data_0209f2b0 != 0)
             v += 0x10;
-        OAM::Render(0, &func_020abad8, 0x68, v, -1, -1, 0);
-        OAM::Render(0, &func_020ab9c8, 0x78, v + 8, -1, -1, 0);
+        OAM::Render(0, &_ZN3OAM4COINE, 0x68, v, -1, -1, 0);
+        OAM::Render(0, &_ZN3OAM5TIMESE, 0x78, v + 8, -1, -1, 0);
         RenderNumber(data_0209f260, 0x80, v, 1, 8);
     }
     LC_Render();

--- a/src/func_ov003_020adfc8.cpp
+++ b/src/func_ov003_020adfc8.cpp
@@ -5,9 +5,9 @@ extern int _ZN8SaveData13GetCoinRecordEj(unsigned int);
 extern void func_ov003_020ae1a4(void* sl, int r);
 extern void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int b, void* attr, int x, int y, int a, int c, void* m);
 extern signed char data_02092110[];
-extern void* func_020aba70[];
-extern void* func_020ab9c8[];
-extern void* func_020abad8[];
+extern void* _ZN3OAM7NUMBERSE[];
+extern void* _ZN3OAM5TIMESE[];
+extern void* _ZN3OAM4COINE[];
 void func_ov003_020adfc8(char* sl) {
     int sb = 0xb8;
     int lvl = SublevelToLevel(data_02092110[0]);
@@ -17,11 +17,11 @@ void func_ov003_020adfc8(char* sl) {
     for (i = 2; i >= 0; i--) {
         signed char d = *(signed char*)(sl + i + 0x121);
         if (d >= 0) {
-            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[d], sb, 0x4c, 8, -1, 0);
+            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[d], sb, 0x4c, 8, -1, 0);
             sb -= 9;
         }
     }
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020ab9c8, sb, 0x54, -1, -1, 0);
-    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020abad8, sb - 0x10, 0x4c, -1, -1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM5TIMESE, sb, 0x54, -1, -1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM4COINE, sb - 0x10, 0x4c, -1, -1, 0);
 }
 }

--- a/src/func_ov003_020ae0b0.c
+++ b/src/func_ov003_020ae0b0.c
@@ -3,9 +3,9 @@ unsigned char NumStars(void);
 void func_ov003_020ae1a4(void *sl, int r);
 void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int b, void *attr, int x, int y, int a, int cc, void *m);
 extern signed char data_02092110[];
-extern void *func_020aba70[];
-extern void *func_020ab9c8;
-extern void *func_020abad0;
+extern void *_ZN3OAM7NUMBERSE[];
+extern void *_ZN3OAM5TIMESE;
+extern void *_ZN3OAM10POWER_STARE;
 void func_ov003_020ae0b0(char *sl)
 {
   int sb;
@@ -28,13 +28,13 @@ void func_ov003_020ae0b0(char *sl)
       signed char d = *((signed char *) ((sl + i) + 0x121));
       if (d >= 0)
       {
-        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[d], sb, r8, 8, -1, 0);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[d], sb, r8, 8, -1, 0);
         sb -= 9;
       }
       i--;
     }
     while (i >= 0);
   }
-  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, sb, r8 + 8, -1, -1, 0);
-  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020abad0, sb - 0x10, r8 + 8, -1, -1, 0);
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM5TIMESE, sb, r8 + 8, -1, -1, 0);
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM10POWER_STARE, sb - 0x10, r8 + 8, -1, -1, 0);
 }

--- a/src/func_ov003_020ae238.c
+++ b/src/func_ov003_020ae238.c
@@ -5,9 +5,9 @@ void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int b, void *attr, int x, int y, i
 void func_ov003_020ae1a4(void *sl, int r);
 extern signed char data_02092110[];
 extern signed char data_0209f2f4[];
-extern void *func_020ab948[];
-extern void *func_020ab9c8;
-extern void *func_020aba70[];
+extern void *_ZN3OAM10LIFE_ICONSE[];
+extern void *_ZN3OAM5TIMESE;
+extern void *_ZN3OAM7NUMBERSE[];
 void func_ov003_020ae238(char *sl)
 {
   int sb;
@@ -22,8 +22,8 @@ void func_ov003_020ae238(char *sl)
     sb = 0x10;
     r8 = 0xac;
   }
-  _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, func_020ab948[*((unsigned char *) (sl + 0x116))], sb, r8 + 8, -1, -1, 0x1000, 0x1000, 0, -1);
-  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, sb + 0x10, r8 + 8, -1, -1, 0);
+  _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, _ZN3OAM10LIFE_ICONSE[*((unsigned char *) (sl + 0x116))], sb, r8 + 8, -1, -1, 0x1000, 0x1000, 0, -1);
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &_ZN3OAM5TIMESE, sb + 0x10, r8 + 8, -1, -1, 0);
   func_ov003_020ae1a4(sl, (unsigned short) data_0209f2f4[0]);
   {
     int i = 0;
@@ -33,7 +33,7 @@ void func_ov003_020ae238(char *sl)
       signed char d = *((signed char *) ((sl + i) + 0x121));
       if (d >= 0)
       {
-        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[d], sb, r8, 8, -1, 0);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[d], sb, r8, 8, -1, 0);
         sb += 9;
       }
       i++;


### PR DESCRIPTION
## What this is

`tools/resolve_placeholders.py` has been sitting in the tree and **nobody re-ran it after the last batch of recovered sources landed**. Running it now rewrites 14 files with no hand editing at all. This PR is that tool's output, plus the `complete` markers for the same 14 files.

## The defect

An earlier automated decompilation pass emitted placeholder names for symbols it could not identify — `func_020abad8`, `func_020aed98` — and those names are defined in no module. The byte gate cannot see this: `match.py` compares a relocated word as a **wildcard**, so any name at all passes. `eligible.py` rule 5 does see it and refuses to enroll the file. Result: 14 files that byte-match perfectly, and the ROM serves its own bytes for all 14 because dsd was never asked for the object.

## Where the answers come from (not guesswork)

`config/**/relocs.txt` already records, per relocation, both the target address and the owning module:

```
from:0x021111e8 kind:load to:0x021099e4 module:overlay(2)
```

Compiling gives the patch offset; offset + function address gives the `from:`; dsd gives `to:` and `module:`; that module's `symbols.txt` gives the name. The module cannot be skipped — overlays are overlaid, so one address names a different symbol in each overlay covering it. Where dsd could not decide, it says so (`module:overlays(2,9,14)`) and the tool **reports rather than guesses**. Each rewrite is then re-verified against the file's own build pin and reverted if it no longer byte-matches.

## What the 14 files turn out to reference

```
func_020ab948 -> _ZN3OAM10LIFE_ICONSE      func_020abad0 -> _ZN3OAM10POWER_STARE
func_020ab9c8 -> _ZN3OAM5TIMESE            func_020abad8 -> _ZN3OAM4COINE
func_020aba70 -> _ZN3OAM7NUMBERSE          func_020abd88 -> _ZN3OAM14BOUNCING_ARROWE
func_020aed98 -> _ZN5EnemyC2Ev
```

Every one is an OAM sprite-attribute table or the `Enemy` base constructor, landing in files that draw HUD counters (`HUD::RenderCoinCount`, `Stage::RenderBouncingArrows`) and spawn enemies (`ChainChomp_Spawn`, `Wiggler_Spawn`). The resolved names are **semantically right**, not merely link-satisfying — that is the check that a wildcard-blind byte gate cannot make for you.

Sample:

```diff
-    extern OamAttr func_020abad8;
-    extern OamAttr func_020ab9c8;
+    extern OamAttr _ZN3OAM4COINE;
+    extern OamAttr _ZN3OAM5TIMESE;
...
-        OAM::Render(0, &func_020abad8, 0x68, v, -1, -1, 0);
+        OAM::Render(0, &_ZN3OAM4COINE, 0x68, v, -1, -1, 0);
```

## The tool's full accounting, so you can see what is left alone

Over the 234 files that carry placeholder references:

| verdict | count |
|---|---|
| target unnamed in config | 134 |
| unresolved (ambiguous module, or no reloc recorded) | 45 |
| not textual (needs a source transform, not a rename) | 26 |
| **rewritten — this PR** | **14** |
| reverted (rewrite did not byte-match; tool restored the original) | 9 |
| partial (some names textual, some not; tool restored the original) | 6 |

Only the 14 are touched. The other 220 are byte-for-byte as they were.

## Why the `complete` markers are in the same PR

Resolving the reference is what makes the file *eligible*; the `complete` marker is what makes dsd actually link it. A PR that does the first without the second ships a win that never reaches the ROM. They are one change.

## Gates (run on this branch, clean tree, own `build/`)

| gate | result |
|---|---|
| `rombuild.py -j16` **before** (pristine `origin/main`) | `10,817` source-built, `88.00%`, **106/106 exact**, mismatching **0** |
| `rombuild.py -j16` **after** | `10,831` source-built, `88.24%`, **106/106 exact**, mismatching **0** |
| `eligible.py` before → after | `10821 / 11162` → `10835 / 11162` |
| eligible **name-list diff** | **+14, −0** — see below |
| `check_references.py` | unresolved 220 (baseline 234), eligible 10835 (baseline 10821) — `OK: no new unresolvable references` |
| `check_data_definitions.py` | 10974 objects, none define a ROM data symbol |
| `port_refcheck.py` | 393 references checked, 0 stale |
| `check_duplicate_sources.py` | 11282 stems, none doubled |
| `langmode_audit.py --check` (baseline from `origin/chaos-data`) | `langmode ratchet PASS` |
| `prepush_attribution.py --base origin/main --head HEAD` | `11292 tracked, 0 moved, 0 renamed, 0 changed, 0 lost` |

The name-list diff, not just the count — every line is an addition, nothing was lost:

```
+ ChainChomp_Spawn                   + _ZN5Stage12RenderNumberEhiibi
+ ChiefChilly_Spawn                  + _ZN5Stage20RenderBouncingArrowsEv
+ ExplosionGoomba_Spawn              + _ZN5Stage6RenderEv
+ Goomboss_Spawn                     + func_ov003_020adfc8
+ Wiggler_Spawn                      + func_ov003_020ae0b0
+ _ZN3HUD15RenderCoinCountEv         + func_ov003_020ae238
+ _ZN3HUD15RenderLifeCountEv
+ _ZN3HUD15RenderStarCountEv
```

## What this does NOT claim

- **No new byte match.** All 14 already reproduced; a relocated word is a wildcard, so renaming the target cannot change the compared bytes. What changes is that the object now links, and therefore ships.
- It does not resolve the remaining 220 placeholder files, and makes no claim about them.
- It does not touch `tools/resolve_placeholders.py` itself. The tool is unmodified; this is only its output.
- **`config/unresolved-baseline.json` is deliberately NOT banked here.** `check_references.py` reports "14 fixed since the baseline — run `--update` to bank it", and the gate passes without it. That file is not union-merged, so banking it in each of the three sequenced PRs would make them conflict with each other on GitHub. One `--update` after all three land is the clean way.

## Sequencing

Part of a three-PR phantom-reference sweep. Intended landing order:

1. **#1475** (`cpp/mg-single3d-rest`) — also edits `config/arm9/overlays/ov006/delinks.txt`; land it first.
2. **#1480** (PR A) — stale enrollment only, no source change.
3. **this PR (B)**.
4. **PR C** — 3 hand-resolved phantom references.

All three merged together give **10,838 source-built, 88.33%, 106/106 exact, 0 mismatching** — verified locally by merging all three branches and running `rombuild.py -j16` on the result. `10,817 + 4 + 14 + 3 = 10,838`; the three PRs' contributions are disjoint.

`merge=union` on the ledgers runs locally but **not** on github.com, so `git merge-tree` reporting clean is not proof GitHub will agree. Merge one at a time and re-check the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT

