### PR TITLE
Resolve 3 phantom references the placeholder tool cannot reach (+3 source-built)

### DIFF
--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -2411,6 +2411,7 @@ src/func_ov002_020c897c.c:
     .text start:0x020c897c end:0x020c8a4c
 
 src/func_ov002_020c8a4c.cpp:
+    complete
     .text start:0x020c8a4c end:0x020c8b54
 
 src/func_ov002_020c8b54.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -342,6 +342,7 @@ src/func_ov006_020c3b80.c:
     .text start:0x020c3b80 end:0x020c3bc8
 
 src/func_ov006_020c3bc8.c:
+    complete
     .text start:0x020c3bc8 end:0x020c3bf4
 
 src/func_ov006_020c3bf4.cpp:

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -189,6 +189,7 @@ src/_ZN13SnowmanBreath6RenderEv.cpp:
     .text start:0x02112740 end:0x021127a4
 
 src/_ZN13SnowmanBreath8BehaviorEv.cpp:
+    complete
     .text start:0x021127a4 end:0x021129dc
 
 src/_ZN13SnowmanBreath13InitResourcesEv.cpp:

--- a/src/_ZN13SnowmanBreath8BehaviorEv.cpp
+++ b/src/_ZN13SnowmanBreath8BehaviorEv.cpp
@@ -14,8 +14,7 @@ extern int _ZN6Player9StartTalkER9ActorBaseb(void *self, void *actor, int b);
    //cpp file mangles it a second time -- this one was reaching the linker as
    _Z48_ZN6Player11ShowMessage... and sat in the unresolved baseline. Byte
    gates cannot see it, because relocations compare as wildcards; only
-   check_references does. (_ZN5Sound8PlayLongEjjjRK7Vector3s below has the
-   same defect and is left for whoever owns that symbol.) */
+   check_references does. */
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3hh(void *self, void *actor,
                                                             unsigned int msg,
                                                             const Vector3 *pos,
@@ -24,10 +23,12 @@ extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3hh(void *self, void *ac
 }
 extern "C" {
 extern int _ZN6Player12GetTalkStateEv(void *self);
-}
+/* Same double-mangle defect as ShowMessage above: outside this block the
+   bare `extern` reached the linker as _Z33_ZN5Sound8PlayLongEjjjRK7Vector3sijjPvj. */
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3s(int handle, unsigned int a,
                                              unsigned int b, void *pos,
                                              unsigned int c);
+}
 
 int SnowmanBreath::Behavior()
 {

--- a/src/func_ov002_020c8a4c.cpp
+++ b/src/func_ov002_020c8a4c.cpp
@@ -5,7 +5,16 @@
 /* recovered: shared common types */
 #include "common.h"
 
-struct Player { unsigned int SetAnim(unsigned int, int, int, unsigned int); };
+/* The ROM's Player::SetAnim takes Fix12<int> third, so its symbol is
+   _ZN6Player7SetAnimEji5Fix12IiEj. A local `struct Player` declaring
+   `SetAnim(unsigned, int, int, unsigned)` mangles to _ZN6Player7SetAnimEjiij,
+   which exists in no module -- invisible to the byte gate, because relocated
+   words compare as wildcards. Same extern "C" idiom the rest of the tree uses
+   for this symbol (src/_ZN6Player12St_Hurt_InitEv.cpp). */
+extern "C" {
+extern unsigned int _ZN6Player7SetAnimEji5Fix12IiEj(char* thiz, unsigned int anim,
+                                                    int a, int fix, unsigned int b);
+}
 extern "C" short Vec3_HorzAngle(const Vector3*, const Vector3*);
 extern "C" void func_020731dc(void*, void*, void*);
 extern "C" void Vec3_RotateYAndTranslate(Vector3*, const Vector3*, int, const Vector3*);
@@ -19,7 +28,7 @@ extern "C" int func_ov002_020c8a4c(char* self);
 int func_ov002_020c8a4c(char* self) {
     int spd = *(int*)(self + 0x98) >> 3;
     if (spd < 0x400) spd = 0x400;
-    ((Player*)self)->SetAnim(0x48, 0, spd, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x48, 0, spd, 0);
     *(short*)(self + 0x94) = Vec3_HorzAngle((Vector3*)(self + 0x5c), (Vector3*)(self + 0x744));
     *(short*)(self + 0x8e) = *(short*)(self + 0x94);
     if (func_02053274((Vector3*)(self + 0x5c), (Vector3*)(self + 0x744)) < 0xa000) {

--- a/src/func_ov006_020c3bc8.c
+++ b/src/func_ov006_020c3bc8.c
@@ -1,4 +1,4 @@
-extern void func_020c3adc(void *);
+extern void func_ov006_020c3adc(void *);
 void func_ov006_020c3bc8(void *a)
 {
   int i = 0;
@@ -8,5 +8,5 @@ void func_ov006_020c3bc8(void *a)
     *((int *) (p + 0x48)) = 0;
     p += 0x98;
   }
-  func_020c3adc(a);
+  func_ov006_020c3adc(a);
 }


### PR DESCRIPTION
## What this is

Three files that **byte-match their ROM function perfectly** and call a symbol that exists in no module. `match.py` compares a relocated word as a **wildcard**, so the byte gate is blind to it. `eligible.py` rule 5 is not, and refuses to enroll the file — so dsd keeps serving the ROM's own bytes and the match reaches nothing.

All three are already recorded in `config/unresolved-baseline.json`, under **exactly the phantom name each fix removes**:

```
ov002:0x020c8a4c  func_ov002_020c8a4c            missing=['_ZN6Player7SetAnimEjiij']
ov006:0x020c3bc8  func_ov006_020c3bc8            missing=['func_020c3adc']
ov027:0x021127a4  _ZN13SnowmanBreath8BehaviorEv  missing=['_Z33_ZN5Sound8PlayLongEjjjRK7Vector3sijjPvj']
```

`tools/resolve_placeholders.py` (see PR B) classifies all three as **"not textual — needs a source transform, not a rename"**, which is correct: none is a token it could substitute. Each needs a different, small hand edit. That is why they are here and not in PR B.

## The three fixes, and the ROM evidence for each

### 1. `func_ov006_020c3bc8.c` — wrong module prefix

```diff
-extern void func_020c3adc(void *);
+extern void func_ov006_020c3adc(void *);
```

`config/arm9/overlays/ov006/symbols.txt:83`:
```
func_ov006_020c3adc kind:function(arm,size=0x50) addr:0x020c3adc
```
The bare form `func_020c3adc` appears in **no** config file anywhere in the tree.

### 2. `func_ov002_020c8a4c.cpp` — a shadow struct whose method mangles to nothing

The file declared a local `struct Player` purely to spell one call:

```cpp
struct Player { unsigned int SetAnim(unsigned int, int, int, unsigned int); };
```

That mangles to `_ZN6Player7SetAnimEjiij`. The ROM's function takes `Fix12<int>` third, so its real symbol is `_ZN6Player7SetAnimEji5Fix12IiEj` — `config/arm9/overlays/ov002/symbols.txt:470`, `addr:0x020bef2c`, `size=0x210`. Two independent derivations agree: reading `symbols.txt`, and `resolve_placeholders.py`'s own relocation-table walk, which reports

```
src/func_ov002_020c8a4c.cpp
    _ZN6Player7SetAnimEjiij -> _ZN6Player7SetAnimEji5Fix12IiEj
```

Replaced with the `extern "C"` idiom the rest of the tree already uses for this symbol (`src/_ZN6Player12St_Hurt_InitEv.cpp`). The shadow struct was read before deletion: the call site is a direct `bl`, not a vtable dispatch, so removing the struct cannot change dispatch — and the byte match confirms it.

### 3. `_ZN13SnowmanBreath8BehaviorEv.cpp` — the double-mangling defect, second instance in the same file

`_ZN5Sound8PlayLongEjjjRK7Vector3s` was declared with a bare `extern` **outside** the file's `extern "C"` block, so C++ mangled the already-mangled name a second time and it reached the linker as `_Z33_ZN5Sound8PlayLongEjjjRK7Vector3sijjPvj`. Real symbol: `config/arm9/symbols.txt:369`, `addr:0x02012328`. The fix is to move the declaration inside the block that already holds its sibling.

A comment in this same file had already identified this defect and explicitly deferred it — *"has the same defect and is left for whoever owns that symbol"*. This PR fixes it, so that deferral is removed.

## What actually proves these are right

A relocated word compares as a wildcard, so all three matched at 100% while calling into nothing. A byte gate cannot settle this. What settles it is **the link**: `rombuild.py` now compiles and links all three objects into the ROM and still reports **106/106 exact, 0 mismatching**. That is the evidence here — not the byte count, which was already green and already wrong about what it was proving.

## Why the `complete` markers are in the same PR

Resolving the reference is what makes the file *eligible*; the `complete` marker is what makes dsd link it. Without the marker, the fix never reaches the ROM. They ship together.

## Scope carve-out

The phantom-reference sweep that produced this found **five** hand-resolvable cases. Two of them — `src/_ZN13MgMemoryMatchD1Ev.cpp` and `src/_ZN14MgMemoryMasterD1Ev.cpp` — are **deliberately excluded** from this PR. Those two files are being rewritten and renamed wholesale by **#1479** (`cpp/mg-memory-pair`), which migrates `MgMemoryMatch` → `dScMgMemory_c` and `MgMemoryMaster` → `dScMgMemory2_c` into real C++ classes — it touches `src/_ZN13MgMemoryMatchD1Ev.cpp` and `src/_ZN14MgMemoryMasterD1Ev.cpp` directly. Their phantom-reference fix travels with that migration instead, so this PR does not collide with it.

So this PR is **3 files, not 5**, and the remaining `+2` from the sweep is accounted for elsewhere.

## Gates (run on this branch, clean tree, own `build/`)

| gate | result |
|---|---|
| `rombuild.py -j16` **before** (pristine `origin/main`) | `10,817` source-built, `88.00%`, **106/106 exact**, mismatching **0** |
| `rombuild.py -j16` **after** | `10,820` source-built, `88.04%`, **106/106 exact**, mismatching **0** |
| `eligible.py` before → after | `10821 / 11162` → `10824 / 11162` |
| eligible **name-list diff** | `+ _ZN13SnowmanBreath8BehaviorEv`, `+ func_ov002_020c8a4c`, `+ func_ov006_020c3bc8` — **+3, −0** |
| `check_references.py` | unresolved 231 (baseline 234), eligible 10824 (baseline 10821) — `OK: no new unresolvable references` |
| `check_data_definitions.py` | 10974 objects, none define a ROM data symbol |
| `port_refcheck.py` | 393 references checked, 0 stale |
| `check_duplicate_sources.py` | 11282 stems, none doubled |
| `langmode_audit.py --check` (baseline from `origin/chaos-data`) | `langmode ratchet PASS` |
| `prepush_attribution.py --base origin/main --head HEAD` | `11292 tracked, 0 moved, 0 renamed, 0 changed, 0 lost` |

## What this does NOT claim

- **No new byte match.** All three already reproduced. Renaming a relocation target cannot change the compared bytes. What changes is that these objects now link, and therefore ship.
- It does not name or type `Player::SetAnim`'s parameters beyond what the mangled symbol already states; the `extern "C"` declaration is a spelling of the existing symbol, not a recovered signature.
- It does not sweep the rest of `config/unresolved-baseline.json`. 231 entries remain and are untouched.
- It makes no claim about the two carved-out `MgMemory*` destructors.
- **`config/unresolved-baseline.json` is deliberately NOT banked here.** `check_references.py` reports "3 fixed since the baseline — run `--update` to bank it", and the gate passes without it. That file is not union-merged, so banking it in each of the three sequenced PRs would make them conflict with each other on GitHub. One `--update` after all three land is the clean way.

## Sequencing

Part of a three-PR phantom-reference sweep. Intended landing order:

1. **#1475** (`cpp/mg-single3d-rest`) — also edits `config/arm9/overlays/ov006/delinks.txt`; land it first.
2. **#1480** (PR A) — stale enrollment only, no source change.
3. **#1481** (PR B) — `resolve_placeholders.py --apply`, 14 files.
4. **this PR (C)** — last, because it touches `ov002` and `ov006` `delinks.txt` alongside all three of the above.

All three merged together give **10,838 source-built, 88.33%, 106/106 exact, 0 mismatching** — verified locally by merging all three branches and running `rombuild.py -j16` on the result. `10,817 + 4 + 14 + 3 = 10,838`; the three PRs' contributions are disjoint.

`merge=union` on the ledgers runs locally but **not** on github.com, so `git merge-tree` reporting clean is not proof GitHub will agree. Merge one at a time and re-check this branch after each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT


