### PR TITLE
attribution.json: restore tangosdev credit lost in PR #1485

### DIFF
--- a/attribution.json
+++ b/attribution.json
@@ -61,6 +61,14 @@
     "src/_ZN15dScMgRoulette_cD1Ev.cpp": "tangosdev",
     "src/_ZN12MetalNetLift16CleanupResourcesEv.cpp": "tangosdev",
     "src/_ZN12MetalNetLift13InitResourcesEv.cpp": "tangosdev",
-    "src/_ZN12SwitchPillar8BehaviorEv.cpp": "tangosdev"
+    "src/_ZN12SwitchPillar8BehaviorEv.cpp": "tangosdev",
+    "src/_ZN11dScMgJump_cD1Ev.cpp": "tangosdev",
+    "src/_ZN11dScMgJump_cD0Ev.cpp": "tangosdev",
+    "src/_ZN12dScMgJump2_cD1Ev.cpp": "tangosdev",
+    "src/_ZN12dScMgJump2_cD0Ev.cpp": "tangosdev",
+    "src/_ZN17dScMgTrampoline_cD1Ev.cpp": "tangosdev",
+    "src/_ZN17dScMgTrampoline_cD0Ev.cpp": "tangosdev",
+    "src/_ZN18dScMgTrampoline2_cD1Ev.cpp": "tangosdev",
+    "src/_ZN18dScMgTrampoline2_cD0Ev.cpp": "tangosdev"
   }
 }


### PR DESCRIPTION
## Summary
- PR #1485 promoted 8 tangosdev-matched raw-asm files into `dScMgJump_c`/`dScMgJump2_c`/`dScMgTrampoline_c`/`dScMgTrampoline2_c`'s D0/D1 destructors, moving and rewriting each file's content in the same commit
- Same address, same size, pure symbol rename — but git recorded it as delete+add rather than a rename (no R100), so the attribution gate re-pointed credit to the pusher instead of following the file
- Same defect shape as `dScMgSingle3DBase_c`'s pair in #1421 and the sixteen other minigame destructors already pinned in `attribution.json` — this follows that exact precedent for the 8 files PR #1485 missed

## Test plan
- [x] `python tools/prepush_attribution.py --base main --head fix-attribution-1485` reports `8 changed, 0 lost` (credit moves from `andrewboudreau` back to `tangosdev` for all 8 files, no credit lost)
- [x] `attribution.json` is data-only; no build/gate impact beyond the contributor chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)