### PR TITLE
Match func_ov006_0210f564 -- cMgSmartball_board_c's SaveSnapshot

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -5497,6 +5497,10 @@ src/func_ov006_0210ef48.c:
     complete
     .text start:0x0210ef48 end:0x0210f564
 
+src/func_ov006_0210f564.c:
+    complete
+    .text start:0x0210f564 end:0x0210f914
+
 src/func_ov006_0210f914.c:
     complete
     .text start:0x0210f914 end:0x0210f998

--- a/src/func_ov006_0210f564.c
+++ b/src/func_ov006_0210f564.c
@@ -1,0 +1,136 @@
+#include "types.h"
+
+/* cMgSmartball_board_c's slot 0 (SaveSnapshot). The class is not migrated yet,
+ * so this is written against raw offsets. Like every sibling's slot 0 it opens
+ * with the base's own SaveSnapshot body written out inline rather than called.
+ *
+ * Then: spend the countdown at +0x94 and, once a second, replay the jingle for
+ * the line count at +0x98; age the eight per-line timers at +0x6c; scan the
+ * shared manager's up-to-13 tracked balls for one sitting in the board's strip,
+ * map it to one of the nine cells and claim the cell; finally spin every
+ * claimed cell's angle at +0x3c up to its 0x8000 stop. */
+
+typedef struct { int x; int y; } V2;
+
+typedef struct {
+    int f0;          /* 0x00 */
+    char *f4;        /* 0x04 manager */
+    int f8;          /* 0x08 x */
+    int fc;          /* 0x0c y */
+    int f10;         /* 0x10 snapshot x */
+    int f14;         /* 0x14 snapshot y */
+    u8 pad18[0x19];  /* 0x18 */
+    u8 cells[9];     /* 0x31 */
+    u8 pad3a[2];     /* 0x3a */
+    int angles[9];   /* 0x3c */
+    u8 f60[12];      /* 0x60 */
+    int lines[8];    /* 0x6c */
+    u8 marks[8];     /* 0x8c */
+    int f94;         /* 0x94 */
+    int f98;         /* 0x98 */
+} S;
+
+extern int data_ov006_02142c1c[];
+
+extern void func_ov006_0211470c(int *a, int *b);
+extern int func_ov006_02111dcc(char *p, int val);
+extern void func_ov006_02114800(void *c, int *p, int f);
+extern void func_ov006_0210ef48(void *c, int i);
+extern void func_02012718(void *a, int b);
+extern void _ZN5Sound12PlayBank2_2DEj(u32 id);
+
+static inline u8 *GetObj(char *g, int i)
+{
+    return i >= 13 ? 0 : ((u8 **)(g + 0x4688))[i];
+}
+
+static inline void SetV2(V2 *p, int x, int y)
+{
+    p->x = x;
+    p->y = y;
+}
+
+#pragma opt_strength_reduction off
+void func_ov006_0210f564(S *c)
+{
+    int i;
+    int n;
+    int j;
+    int lo;
+    int hi;
+    V2 v;
+    V2 t;
+    V2 a;
+    V2 b;
+    V2 d;
+
+    c->f10 = c->f8;
+    c->f14 = c->fc;
+    if (c->f94 > 0) {
+        (*(int *)((int)c + 0x94))--;
+        if (c->f94 > 0 && c->f94 % 60 == 0) {
+            switch (c->f98) {
+            case 0:
+            case 1:
+                _ZN5Sound12PlayBank2_2DEj(0x176);
+                break;
+            case 2:
+                _ZN5Sound12PlayBank2_2DEj(0x177);
+                break;
+            case 3:
+                _ZN5Sound12PlayBank2_2DEj(0x178);
+                break;
+            case 4:
+            default:
+                _ZN5Sound12PlayBank2_2DEj(0x179);
+                break;
+            }
+        }
+    }
+    for (i = 0; i < 8; i++) {
+        if (c->lines[i] > 0)
+            (*(int *)((int)c + i * 4 + 0x6c))--;
+    }
+    for (n = 0; n < *(int *)(c->f4 + 0x4668); n++) {
+        if (*(u8 *)(c->f4 + 0x595c) != 0)
+            break;
+        if (GetObj(c->f4, n)[0x30] == 0)
+            continue;
+        func_ov006_0211470c((int *)&t, (int *)GetObj(c->f4, n));
+        v = t;
+        if (v.y < 0x74000)
+            continue;
+        if (v.y >= 0x7c000)
+            continue;
+        for (j = 0, lo = 0xc000, hi = 0x14000; j < 9; j++) {
+            int slot = data_ov006_02142c1c[j];
+            if (v.x >= lo && v.x < hi) {
+                if (func_ov006_02111dcc((char *)GetObj(c->f4, n), 0x14)) {
+                    if (c->cells[slot] == 0) {
+                        SetV2(&a, c->f8 + ((data_ov006_02142c1c[j] % 3 - 1) * 0x18 << 12),
+                              c->fc + ((data_ov006_02142c1c[j] / 3 - 1) * 0x18 << 12));
+                        func_ov006_02114800(c->f4, (int *)&a, 0);
+                        SetV2(&b, (j * 0x18 + 0x10) << 12, 0x78000);
+                        func_ov006_02114800(c->f4, (int *)&b, 0);
+                        func_02012718((void *)0x1be, j * 0x18000 + 0x10000);
+                    } else {
+                        SetV2(&d, (j * 0x18 + 0x10) << 12, 0x78000);
+                        func_ov006_02114800(c->f4, (int *)&d, 1);
+                        func_02012718((void *)0x17a, j * 0x18000 + 0x10000);
+                    }
+                    func_ov006_0210ef48(c, j);
+                    break;
+                }
+            }
+            lo += 0x18000;
+            hi += 0x18000;
+        }
+    }
+    for (i = 0; i < 9; i++) {
+        if (c->cells[i] == 1) {
+            (*(int *)((int)c + i * 4 + 0x3c)) += 0x400;
+            if (c->angles[i] >= 0x8000)
+                c->angles[i] = 0x8000;
+        }
+    }
+}

--- a/src/func_ov006_0210f564.c
+++ b/src/func_ov006_0210f564.c
@@ -50,6 +50,9 @@ static inline void SetV2(V2 *p, int x, int y)
     p->y = y;
 }
 
+/* Load-bearing for this spelling: without it the function is 5 words too long.
+ * Not a property of the function itself -- match/board-slot0-a reproduces the
+ * same bytes with different statement order and no pragma at all. */
 #pragma opt_strength_reduction off
 void func_ov006_0210f564(S *c)
 {


### PR DESCRIPTION
The last unmatched function in the Smartball object family, and the only thing
keeping `cMgSmartball_board_c` from being migrated alongside its ten siblings
in #1489.

`func_ov006_0210f564`, ov006, `0x0210f564`, size `0x3b0` — 236 instructions.
Pin `2004/b56`, derived from board's own two already-matching slots.

**source-built +1 function**, module fidelity 106/106 exact. (The absolute count/percentage moves fast on this tree -- check current `eligible.py` output rather than a number pinned here.)

The function had **no `delinks.txt` entry at all** — it was absent from the build
entirely, not merely unmatched. The entry added here carries the `complete` marker;
without it dsd serves the ROM's own bytes and every gate still reports green, so the
rise in source-built is the real signal, not the byte match.

## Derived twice, independently

Two agents matched this from the same disassembly without seeing each other's work.
Their sources differ in 87 lines: **one uses `#pragma opt_strength_reduction off`,
the other reproduces the same bytes with no pragma at all.** So the pragma is not a
property of this function — it is a property of how the surrounding statements are
spelled, and it is not diagnostic. The alternative derivation is preserved on
`match/board-slot0-a` if anyone wants to compare.

What both converged on independently is the strongest evidence in this PR:

- **`GetObj` is a real `static inline` accessor, not a macro.** The ROM loads the
  manager pointer *unconditionally* and only then tests the index. That is argument
  evaluation; a macro cannot reproduce it, because a macro makes the load predicated.
- **Its array access must be a subscript** — `((u8 **)(g + 0x4688))[i]`, not
  `*(u8 **)(g + 0x4688 + i * 4)`. The second spelling makes mwcc build a
  strength-reduced induction variable the ROM does not have.
- **The three effect vectors go through an inlined `SetXY(V2 *, int, int)`**, not two
  stores each. Argument evaluation order is what defers the first vector's stores past
  the second component's arithmetic.
- **The main scan loop needs its own index variable.** Sharing one index with the
  housekeeping loops rotates four callee-saved registers — mwcc scores allocation
  priority per *variable*, not per live range.

The `% 60 == 0` tick is written as a plain modulo; mwcc regenerates the magic
multiply by `0x88888889` and the multiply-back by `0x3c` on its own.

## Verification

`build_pin.verify` → `(True, '2004/b56')`, but plain `verify` is **not** the proof by
itself: it wildcards every relocated word, so a `bl` to the wrong helper would still
pass. Also ran the **strict** variant (`reloc_audit`, `name_index`, `config_relocs`,
`sym_index`) — reloc *destinations* checked directly, 13/13 OK, closing that hole
without needing a full rombuild. The independent proof either way is `rombuild`'s
post-link comparison reporting ov006 **106/106 exact** with this function source-built
and reproducing — a wrong call target changes the linked bytes.

- `rombuild` 106/106 exact, source-built +1 (net-zero baseline bracket)
- `eligible.py` brackets identical before/after except this one function
- `check_references` unresolved count unchanged vs baseline
- `check_data_definitions`, `check_duplicate_sources` clean · langmode ratchet PASS

## Follow-up

With this landed, `cMgSmartball_board_c` is unblocked and can be migrated like its ten
siblings (size `0x9c`, already known). One detail found while reading the
disassembly: board's tail loop indexes a 9-byte array starting at **`0x31`**, which is
below its own `0x34` region — it reads what the base declares as `unk_031`/`unk_032`
as the first elements of its own array. That is a real modelling question for the
migration, and further evidence the `0x31`/`0x32`-are-not-padding correction in #1489
was right.
