### PR TITLE
Smartball: retire the stale 0x31-0x33 comments, and one stale cast

### DIFF
--- a/include/cMgSmartball_ana_c.h
+++ b/include/cMgSmartball_ana_c.h
@@ -15,15 +15,16 @@
  *
  * OFFSETS 0x31 AND 0x32 ARE NOT DECLARED HERE even though this class's own
  * functions touch them -- they belong to cMgSmartball_object_c (unk_031,
- * unk_032), not to this class's 0x34+ region. The two are reached
- * DIFFERENTLY, and the difference is deliberate. 0x31 goes through the
- * base's member name: the base declares it u8 and every access here is a
- * byte, so the name states exactly the right thing. 0x32 keeps a raw
- * `(char*)this + 0x32` cast, because the base declares it 16 bits wide --
- * the more common reading among its 43 touching files -- while this class
- * only ever writes a u8 0/1 into its low byte. The name would misstate the
- * instruction there; the cast says what the ROM does. See
- * cMgSmartball_object_c.h on that field's contested width.
+ * unk_032), not to this class's 0x34+ region. Both are reached through the
+ * base's member names, and every access here is a byte.
+ *
+ * That is a change from how this class first landed. The base then declared
+ * 0x32 as a 16-bit field, so this class's byte-wide 0/1 write had to go
+ * through a raw `(char*)this + 0x32` cast to avoid misstating the emitted
+ * instruction. Migrating cMgSmartball_board_c showed the region is three
+ * independent bytes read three incompatible ways, the base was corrected to
+ * three u8s, and this class's view now agrees with the declaration. Siblings
+ * that read a 16-bit angle across 0x32-0x33 still need their casts.
  *
  * CONSTRUCTED BY func_ov006_02111774, left a free function per the recipe
  * (this tree has migrated zero constructors), with only its vtable-symbol

--- a/include/cMgSmartball_ball_c.h
+++ b/include/cMgSmartball_ball_c.h
@@ -10,7 +10,7 @@
  * FIELD EVIDENCE. All fields below 0x34 belong to the base and are reached
  * through inherited members (unk_004, mCurrent0/1, unk_020/024/028/02c,
  * unk_030); this class's own four functions never touch the base's
- * contested 0x31/0x32 span, so no raw cast is needed anywhere here.
+ * 0x31-0x33 region, so no raw cast is needed anywhere here.
  *
  * Most of the 0x34+ fields are both declared AND zeroed by this class's own
  * RestoreInitial, which is exhaustive -- it is the strongest single source

--- a/include/cMgSmartball_propeller_c.h
+++ b/include/cMgSmartball_propeller_c.h
@@ -11,8 +11,8 @@
  * (the constructor, SaveSnapshot, Update, RestoreInitial): an s16 "ease
  * toward target" pair at 0x34/0x36. SaveSnapshot steps 0x36 by +-8 toward
  * the target at 0x34 (clamping once it crosses), then adds the stepped
- * value onto the BASE's own contested-width field at 0x32 -- so 0x36 is a
- * rotation speed and 0x32 accumulates it into a rotation angle.
+ * value onto the BASE's field at 0x32 -- so 0x36 is a rotation speed and
+ * 0x32 accumulates it into a rotation angle.
  * RestoreInitial zeroes 0x36, sets 0x34 to 0x40 (the default target speed),
  * and (through the base call) zeroes mCurrent. Update never touches 0x34+
  * at all -- it only reads the base's angle (0x32) and position
@@ -20,9 +20,9 @@
  *
  * 0x32 IS NOT DECLARED HERE, same as every sibling that reaches it: it
  * belongs to cMgSmartball_object_c (unk_032), reached with the base's own
- * raw `(char*)this + 0x32` idiom because the base's declared width for that
- * field is contested (see cMgSmartball_object_c.h). This class's own
- * Update is in fact one of the files that resolved the base header's note --
+ * raw `(char*)this + 0x32` idiom because 0x31-0x33 is a three-byte region
+ * with no single type, read three incompatible ways (see
+ * cMgSmartball_object_c.h). This class's own Update is one of the three --
  * it indexes a sine table with `>> 4` (lsr, not asr) on that field, i.e. an
  * UNSIGNED reading, one of the several conflicting accesses the base header
  * already records.

--- a/include/cMgSmartball_slot_c.h
+++ b/include/cMgSmartball_slot_c.h
@@ -6,8 +6,8 @@
  *
  * SIZE 0x88, from _Znwj(0x88) in func_ov006_02115b0c. Base ends at 0x34, so
  * this class adds 0x54 bytes. This class's own four functions never touch
- * the base's contested 0x31/0x32 span, so no raw cast is needed anywhere
- * here (unlike wing_c/ana_c).
+ * the base's 0x31-0x33 region, so no raw cast is needed anywhere here
+ * (unlike wing_c/ana_c/board_c).
  *
  * FIELD EVIDENCE. The constructor (func_ov006_021101bc) placement-constructs
  * two 3-element, 8-byte-stride arrays via func_020733a8(this+0x34,3,8,...)

--- a/include/cMgSmartball_wing_c.h
+++ b/include/cMgSmartball_wing_c.h
@@ -15,11 +15,13 @@
  * 0x3000 by SaveSnapshot and zeroed by RestoreInitial and the constructor,
  * belongs to the BASE -- it sits below 0x34. Migrating this class is what
  * turned it up: the base header used to call bytes 0x31-0x33 padding, and
- * they are not padding (11 files touch 0x31, 43 touch 0x32). That is fixed
- * in cMgSmartball_object_c.h now, where the contested signedness is
- * recorded. This class still reaches the byte with an explicit
- * `(char*)this + 0x32` cast rather than the base's name, because the name's
- * type is not yet settled and the cast states exactly what the ROM does.
+ * they are not padding (11 files touch 0x31, 43 touch 0x32). The base header
+ * now declares all three as u8, because migrating cMgSmartball_board_c
+ * showed the region has no single type -- three children read the same three
+ * bytes three incompatible ways, and this class's signed 16-bit angle at
+ * 0x32-0x33 is one of them. The explicit `(char*)this + 0x32` cast stays for
+ * exactly that reason: it states this reader's view without asserting it is
+ * the region's type.
  *
  * THE TAIL FROM 0x45 TO 0x87 IS AN EXPLICIT PAD, and it is UNMODELLED, NOT
  * UNREAD. func_ov006_0210d93c -- a free helper called from both

--- a/src/_ZN18cMgSmartball_ana_c12SaveSnapshotEv.cpp
+++ b/src/_ZN18cMgSmartball_ana_c12SaveSnapshotEv.cpp
@@ -3,9 +3,10 @@
  * rather than called -- same pattern as every sibling in this family (the
  * base's copy is out-of-line and there is no bl here). Then decrements this
  * class's own countdown (unk_034); when it reaches zero it calls the shared
- * helper func_ov006_02114ec0 and sets the BASE's unk_032 byte -- low byte
- * only, see cMgSmartball_ana_c.h and cMgSmartball_object_c.h for why that
- * field's width is contested -- to 1. */
+ * helper func_ov006_02114ec0 and sets the BASE's unk_032 byte to 1 -- the
+ * low byte only. 0x031-0x033 is a three-byte region that three children read
+ * three incompatible ways; this class's byte-wide view is one of them. See
+ * cMgSmartball_object_c.h. */
 #include "cMgSmartball_ana_c.h"
 
 extern "C" void func_ov006_02114ec0(void *self);
@@ -20,5 +21,5 @@ void cMgSmartball_ana_c::SaveSnapshot()
     if (unk_034 > 0)
         return;
     func_ov006_02114ec0((void *)unk_004);
-    *(u8 *)((char *)this + 0x32) = 1;
+    unk_032 = 1;
 }

--- a/src/_ZN18cMgSmartball_ana_c14RestoreInitialEv.cpp
+++ b/src/_ZN18cMgSmartball_ana_c14RestoreInitialEv.cpp
@@ -3,16 +3,16 @@
  * the base's unk_031 flag, the low byte of the base's unk_032, and this
  * class's own countdown.
  *
- * unk_031 goes through the base's member name -- same width, no ambiguity.
- * 0x32 stays a raw cast: the ROM stores ONE byte into a field the base
- * declares 16 bits wide, so the name would misstate the access. See
- * cMgSmartball_object_c.h on that field's contested width. */
+ * Both go through the base's member names. That became possible when
+ * cMgSmartball_board_c showed 0x031-0x033 to be three independent bytes
+ * rather than a byte plus a halfword -- this class's byte-wide view now
+ * agrees with the base's declaration, so no cast is needed. */
 #include "cMgSmartball_ana_c.h"
 
 void cMgSmartball_ana_c::RestoreInitial()
 {
     cMgSmartball_object_c::RestoreInitial();
     unk_031 = 0;
-    *(u8 *)((char *)this + 0x32) = 0;
+    unk_032 = 0;
     unk_034 = 0;
 }

--- a/src/_ZN19cMgSmartball_wing_c12SaveSnapshotEv.cpp
+++ b/src/_ZN19cMgSmartball_wing_c12SaveSnapshotEv.cpp
@@ -3,7 +3,7 @@
  * rather than called -- same pattern as every sibling in this family (the
  * base's copy is out-of-line and there is no bl here). Then, unless unk_044
  * is 1 or unk_040 is not positive, eases the angle at offset 0x32 (see the
- * header -- it lives in the BASE's tail padding, not this class) toward
+ * header -- it belongs to the BASE, not this class) toward
  * 0x3000 by steps of 0x200, clamping on overshoot in either direction.
  * Always tail-calls the shared helper func_ov006_0210d93c, which touches
  * the unmodelled 0x48..0x87 tail (see the header). */

--- a/src/_ZN19cMgSmartball_wing_c6UpdateEv.cpp
+++ b/src/_ZN19cMgSmartball_wing_c6UpdateEv.cpp
@@ -1,7 +1,7 @@
 //cpp
 /* Slot 1. While unk_040 is 0 or 1, draws two extra base sprites under the
  * main pair; then four OAM::Render calls draw a mirrored quad using the
- * eased angle at offset 0x32 (base tail padding -- see the header) to
+ * eased angle at offset 0x32 (a BASE field -- see the header) to
  * spread each half away from vertical. */
 #include "cMgSmartball_wing_c.h"
 #include "OamAttr.h"

--- a/src/_ZN24cMgSmartball_propeller_c6UpdateEv.cpp
+++ b/src/_ZN24cMgSmartball_propeller_c6UpdateEv.cpp
@@ -1,9 +1,9 @@
 //cpp
 /* Slot 1. Looks up a rotation matrix from the base's angle field at 0x32,
  * reading it UNSIGNED (>> 4, lsr not asr) to index the sine table -- one of
- * the conflicting readings cMgSmartball_object_c.h records for that field's
- * contested width, so it stays a raw cast rather than the base's member
- * name. Draws two OAM sprites (front and back cap) at the base's position
+ * the three incompatible readings cMgSmartball_object_c.h records for that
+ * three-byte region, so it stays a raw cast rather than the base's member
+ * name: no single member type is right for all three readers. Draws two OAM sprites (front and back cap) at the base's position
  * (mCurrent0/mCurrent1) using that matrix; touches nothing in this class's
  * own 0x34+ region at all. */
 #include "cMgSmartball_propeller_c.h"

--- a/src/_ZN24cMgSmartball_propeller_c6UpdateEv.cpp
+++ b/src/_ZN24cMgSmartball_propeller_c6UpdateEv.cpp
@@ -3,9 +3,10 @@
  * reading it UNSIGNED (>> 4, lsr not asr) to index the sine table -- one of
  * the three incompatible readings cMgSmartball_object_c.h records for that
  * three-byte region, so it stays a raw cast rather than the base's member
- * name: no single member type is right for all three readers. Draws two OAM sprites (front and back cap) at the base's position
- * (mCurrent0/mCurrent1) using that matrix; touches nothing in this class's
- * own 0x34+ region at all. */
+ * name: no single member type is right for all three readers. Draws two
+ * OAM sprites (front and back cap) at the base's position (mCurrent0/
+ * mCurrent1) using that matrix; touches nothing in this class's own 0x34+
+ * region at all. */
 #include "cMgSmartball_propeller_c.h"
 
 extern "C" short data_02082214[];


### PR DESCRIPTION
Stacked on #1492. The follow-up flagged there. **Byte-free** — 106/106 exact, 10,855
source-built, unchanged.

Two generations of wrong description had accumulated on the same three bytes:

- **`wing`'s two files still called `0x32` "base tail padding".** That became wrong the
  moment #1489 landed — that PR is what established the bytes are fields, not padding.
- **Five more files called the field's width "contested".** Accurate for exactly as
  long as it took to migrate `cMgSmartball_board_c` in #1492. The region isn't
  contested, it's *per-reader*: three children read the same three bytes three
  incompatible ways and all of them byte-match.

## The stale comment was hiding a stale cast

`cMgSmartball_ana_c` wrote its 0/1 flag at `0x32` through a raw `(char*)this + 0x32`
cast, and the comment gave the reason: the base declared a **16-bit** field there, so
the member name would have misstated a byte-wide store. That reasoning was right when
written.

Once board forced the base to three `u8`s, the reason evaporated — ana's byte-wide
view now agrees with the declaration. So both `0x31` and `0x32` go through the base's
member names and the casts are gone:

```c
-    *(u8 *)((char *)this + 0x32) = 1;
+    unk_032 = 1;
```

Verified byte-identical rather than assumed.

Siblings that genuinely read a **16-bit** angle spanning `0x32`–`0x33` (`wing`,
`propeller`) keep their casts, and their comments now say why: no single member type is
right for all three readers, so each states its own view without asserting it is the
region's type.

## Files

`ana` (header + 2 sources — comments and casts), `wing` (header + 2 sources),
`propeller` (header ×2 + 1 source), `ball` (header), `slot` (header).

Every comment that survived now describes the region the same way. The only remaining
use of the word "contested" is the base header's own line saying it is not.