### PR TITLE
port w7d: touch input correctness -- one 16-byte stylus block, four names aliased +0..+3

### DIFF
--- a/port/hal/auto_bss.cpp
+++ b/port/hal/auto_bss.cpp
@@ -117,9 +117,60 @@ int data_0209fc68[8];
 int data_020a0d84[8];
 int data_020a0d88[8];
 int data_020a0db0[8];
-int data_020a0de8[8];
-int data_020a0de9[8];
-int data_020a0deb[8];
+/* ---- THE STYLUS RECORD, 0x020a0de8 .. 0x020a0df7 -------------------------
+   ONE 16-byte block, not three independent arrays.
+
+   On hardware this is TouchInfo[4] -- one 4-byte record per controller,
+   {u8 touched, u8 held, u8 x, u8 y} -- and dsd named a symbol at each of the
+   FIRST record's four bytes, because code reached the fields through separate
+   addresses. config/arm9/symbols.txt has the four one byte apart
+
+       data_020a0de8 0x020a0de8   (+0 touched)
+       data_020a0de9 0x020a0de9   (+1 held)
+       data_020a0dea 0x020a0dea   (+2 x)
+       data_020a0deb 0x020a0deb   (+3 y)
+
+   the next named symbol is data_020a0df8, and delinks.txt puts all of it in
+   .bss (0x0209b000..0x020aa420), so the block is exactly 16 bytes = 4
+   records and there are no image bytes to read: the LAYOUT evidence is the
+   readers. Every one of them indexes ITS OWN name by slot*4 --
+   Message::Update's data_020a0de9[idx * 4], Stage::CheckCameraInput's
+   data_020a0de8[i].held, TouchArea_Update's data_020a0dea[i4] -- so the four
+   names have to BE the same storage, one byte apart.
+
+   WHAT WAS HERE BEFORE. The link sweep grew three separate `int [8]` arrays
+   (de8, de9, deb) and nothing at all for dea. hal/sub_screen.cpp writes the
+   packed record through data_020a0de8, so Message::Update's
+   data_020a0de9[idx*4] and data_020a0deb[idx*4] read two other arrays that
+   nothing ever writes: measured with SM64DS_TOUCH_PROBE before this change,
+   the block held 01 01 78 96 while de9 and deb read 0, and the two names sat
+   +32 and +64 bytes from de8 instead of +1 and +3. `held` and `y` were zero
+   on every frame of every run. Same class as the pad pair data_020a0e58 /
+   data_020a0e5a that hal/input_probe.cpp works around by writing both; this
+   fixes the storage instead.
+
+   HOW THE LAYOUT IS RESTORED. The mechanism tools/ovdata.py uses to
+   reproduce ROM spacing and dsstate_guard names in its own fix-it text: one
+   ordered .dsstate$<family><NNNN> slot per symbol, each with its ROM
+   alignment, so the linker concatenates the four into one contiguous run.
+   $touch0000..0003 sorts after the $aaa sentinel and before $zzz, so the run
+   stays inside the captured span -- the stylus record is DS state a save
+   state has to roll back. Sizes are the DS symbol spacing (next symbol minus
+   this one) and the LAST name owns the rest of the block, which is ovdata's
+   rule too.
+
+   DO NOT give these "sizes that look right" (de8[16], de9[16], ...). They
+   OVERLAP by construction, and MSVC treats two named globals as disjoint
+   objects: a TU that stores through one and loads through another IN THE
+   SAME FUNCTION can have the load folded away. Nothing in the game path can
+   hit it -- the one writer only stores, every reader only loads -- and
+   sub_screen's probe reads volatile for exactly this reason. */
+__pragma(section(".dsstate$touch0000", read, write)) __declspec(allocate(".dsstate$touch0000")) __declspec(align(1)) unsigned char data_020a0de8[1] = { 0 };
+__pragma(section(".dsstate$touch0001", read, write)) __declspec(allocate(".dsstate$touch0001")) __declspec(align(1)) unsigned char data_020a0de9[1] = { 0 };
+__pragma(section(".dsstate$touch0002", read, write)) __declspec(allocate(".dsstate$touch0002")) __declspec(align(1)) unsigned char data_020a0dea[1] = { 0 };
+/* the last name carries the tail of the block: 0x020a0deb..0x020a0df7, which
+   is slot 0's y plus records 1..3 */
+__pragma(section(".dsstate$touch0003", read, write)) __declspec(allocate(".dsstate$touch0003")) __declspec(align(1)) unsigned char data_020a0deb[13] = { 0 };
 int data_020a0e5a[8];
 /* data_020a1052 moved to hal/camera_bridges.cpp: it is a field INSIDE the
    local comms record at data_020a1040, not storage of its own */

--- a/port/hal/cxx_aliases.cpp
+++ b/port/hal/cxx_aliases.cpp
@@ -488,6 +488,11 @@ extern "C" int _ZN13RaycastGround10DetectClsnEv(void *self)
 #pragma comment(linker, "/alternatename:?data_020a0db0@@3HA=_data_020a0db0")
 #pragma comment(linker, "/alternatename:?data_020a0de8@@3PAEA=_data_020a0de8")
 #pragma comment(linker, "/alternatename:?data_020a0de9@@3PAEA=_data_020a0de9")
+/* the third byte of the stylus record (x). It had no host storage at all until
+   hal/auto_bss.cpp hosted the block properly, so no .cpp reader of it could
+   ever have linked; the route is here so the next slice of a TouchArea TU that
+   declares it outside extern "C" resolves like its three siblings. */
+#pragma comment(linker, "/alternatename:?data_020a0dea@@3PAEA=_data_020a0dea")
 #pragma comment(linker, "/alternatename:?data_020a0deb@@3PAEA=_data_020a0deb")
 #pragma comment(linker, "/alternatename:?data_020a0e5a@@3EA=_data_020a0e5a")
 #pragma comment(linker, "/alternatename:?data_ov002_020ff128@@3PAGA=_data_ov002_020ff128")

--- a/port/hal/sub_screen.cpp
+++ b/port/hal/sub_screen.cpp
@@ -72,8 +72,17 @@ extern signed char data_0209f2f8;       /* current level */
 extern unsigned char data_0209d454;
 /* TouchInfo data_020a0de8[4]: {u8 touched, u8 held, u8 x, u8 y} per slot, in
    DS bottom-screen pixels. Stage::CheckCameraInput and every TouchArea read
-   it; nothing on the host was writing it. */
-extern unsigned char data_020a0de8[];
+   it; nothing on the host was writing it.
+
+   THE FOUR NAMES ARE ONE BLOCK. dsd named a symbol at each of slot 0's four
+   bytes, and readers reach the fields through whichever name they were
+   decompiled with -- Message::Update reads `held` as data_020a0de9[idx*4] and
+   `y` as data_020a0deb[idx*4]. hal/auto_bss.cpp hosts all four over the one
+   16-byte run so a write here reaches every one of them; the touch probe
+   below is what proves it. */
+extern unsigned char data_020a0de8[];   /* +0 touched */
+extern unsigned char data_020a0de9[];   /* +1 held    */
+extern unsigned char data_020a0deb[];   /* +3 y       */
 /* Stage::CheckCameraInput's own inputs and outputs */
 void _ZN5Stage16CheckCameraInputEv(void);
 extern int data_0209f498[];      /* the Ctrl[4] block, stride 0x18 */
@@ -117,6 +126,102 @@ int env_flag(const char *name, int dflt)
     return v ? std::atoi(v) : dflt;
 }
 
+/* ---- SM64DS_TOUCH_PROBE: a scripted stylus, and what the four names read ---
+ *
+ * The stylus record is FOUR DS symbols over ONE 16-byte block -- data_020a0de8
+ * .. data_020a0deb at +0/+1/+2/+3 of TouchInfo[4] (hal/auto_bss.cpp carries the
+ * layout and its evidence). poll_touch writes the record through the FIRST
+ * name; Message::Update reads `held` and `y` through the SECOND and FOURTH.
+ * Whether those are the same bytes is a LINK-TIME property no compiler
+ * diagnostic covers, and a headless run has no mouse, so without this hook the
+ * question cannot be asked of a running binary at all.
+ *
+ *   SM64DS_TOUCH_PROBE="58-59:120:150,60,100-101:33:44,199-201"
+ *
+ * Comma-separated entries, the same grammar as SM64DS_PROBE_INPUT:
+ *
+ *   <frame>[-<frame>]:<x>:<y>   force a press at those DS pixels on those
+ *                               frames, and log
+ *   <frame>[-<frame>]           log only, no press
+ *
+ * One stderr line per listed frame:
+ *
+ *   [touch] f59 poke=(1,120,150) pre={de8=1 de9=0 dea=.. deb=150}
+ *           post={de8=1 de9=1 dea=.. deb=150} d=(1,3) block=01 01 78 96 ...
+ *
+ * `pre` is what the names read on ENTRY to the poll -- which is what a
+ * save-state restore left behind when the load frame is a logged frame --
+ * and `post` is after the write. `d` is (&de9-&de8, &deb-&de8) and MUST read
+ * (1,3): those numbers ARE the bug. Hosted as separate arrays they are two
+ * unrelated addresses and de9/deb read zero on every frame forever.
+ *
+ * THE READS ARE VOLATILE ON PURPOSE. MSVC treats two named globals as
+ * disjoint objects, so a load through data_020a0de9 in the same function as a
+ * store through data_020a0de8 folds to the old value even across translation
+ * units (measured: the plain read prints 0 where the volatile read prints 2).
+ * The game path cannot hit that -- the one writer only stores and every
+ * reader only loads -- but a probe that writes and reads in one function can,
+ * and a probe that lies about the fix is worse than no probe. src/ already
+ * carries the same shape: Stage::LC_Update declares data_020a0dea/deb
+ * volatile.
+ *
+ * The probe's own state is host bookkeeping and deliberately NOT in .dsstate:
+ * a save-state load must not rewind the script that is testing it. */
+struct TouchProbeEnt {
+    int f0, f1, x, y, poke;
+};
+TouchProbeEnt g_tp[32];
+int g_tp_n = -1;            /* -1 = env not read yet, 0 = probe off */
+int g_tp_frame;             /* polls since the first one */
+int g_tp_cur = -1;          /* the frame being polled, for the camera log */
+
+void touch_probe_parse(void)
+{
+    g_tp_n = 0;
+    const char *s = std::getenv("SM64DS_TOUCH_PROBE");
+    if (!s) return;
+    while (*s && g_tp_n < (int)(sizeof g_tp / sizeof *g_tp)) {
+        TouchProbeEnt e = {0, 0, 0, 0, 0};
+        e.f0 = std::atoi(s);
+        while (*s && *s != '-' && *s != ':' && *s != ',') ++s;
+        if (*s == '-') {
+            ++s;
+            e.f1 = std::atoi(s);
+            while (*s && *s != ':' && *s != ',') ++s;
+        } else {
+            e.f1 = e.f0;
+        }
+        if (*s == ':') {
+            ++s;
+            e.x = std::atoi(s);
+            while (*s && *s != ':' && *s != ',') ++s;
+            if (*s == ':') {
+                ++s;
+                e.y = std::atoi(s);
+                while (*s && *s != ',') ++s;
+            }
+            e.poke = 1;
+        }
+        g_tp[g_tp_n++] = e;
+        while (*s && *s != ',') ++s;
+        if (*s == ',') ++s;
+    }
+}
+
+const TouchProbeEnt *touch_probe_at(int f)
+{
+    for (int i = 0; i < g_tp_n; ++i)
+        if (f >= g_tp[i].f0 && f <= g_tp[i].f1) return &g_tp[i];
+    return 0;
+}
+
+/* one byte, read the way a reader in another TU reads it -- see the note on
+   volatile above */
+unsigned char tp_rd(const unsigned char *p, int i)
+{
+    return *(const volatile unsigned char *)(p + i);
+}
+
 // The stylus, from the mouse. `touched` is "down now", `held` adds "and it was
 // down last frame too" -- the pair Stage::CheckCameraInput tests together to
 // tell a press from a hold.
@@ -137,12 +242,48 @@ void poll_touch(void)
             }
         }
     }
+    if (g_tp_n < 0) touch_probe_parse();
+    const int f = g_tp_frame++;
+    g_tp_cur = f;
+    const TouchProbeEnt *tp = g_tp_n > 0 ? touch_probe_at(f) : 0;
+    unsigned char pre8 = 0, pre9 = 0, preb = 0;
+    if (tp) {
+        /* what the three names read BEFORE this poll writes anything: slot 0,
+           in Message::Update's own shape (data_020a0deX[idx * 4], idx = 0) */
+        pre8 = tp_rd(data_020a0de8, 0);
+        pre9 = tp_rd(data_020a0de9, 0);
+        preb = tp_rd(data_020a0deb, 0);
+        if (tp->poke) {
+            down = 1;
+            sx = (unsigned char)tp->x;
+            sy = (unsigned char)tp->y;
+        }
+    }
+
     const unsigned char was = data_020a0de8[0];
     data_020a0de8[0] = down;
     data_020a0de8[1] = (unsigned char)(down && was);
     if (down) {
         data_020a0de8[2] = sx;
         data_020a0de8[3] = sy;
+    }
+
+    if (tp) {
+        const unsigned char *b = data_020a0de8;
+        std::fprintf(stderr,
+            "[touch] f%d poke=%s(%u,%u,%u) pre={de8=%u de9=%u deb=%u} "
+            "post={de8=%u de9=%u deb=%u} d=(%d,%d) block=%02x%02x%02x%02x "
+            "%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x\n",
+            f, tp->poke ? "yes" : "no", down, sx, sy,
+            pre8, pre9, preb,
+            tp_rd(data_020a0de8, 0), tp_rd(data_020a0de9, 0),
+            tp_rd(data_020a0deb, 0),
+            (int)(data_020a0de9 - data_020a0de8),
+            (int)(data_020a0deb - data_020a0de8),
+            tp_rd(b, 0), tp_rd(b, 1), tp_rd(b, 2), tp_rd(b, 3),
+            tp_rd(b, 4), tp_rd(b, 5), tp_rd(b, 6), tp_rd(b, 7),
+            tp_rd(b, 8), tp_rd(b, 9), tp_rd(b, 10), tp_rd(b, 11),
+            tp_rd(b, 12), tp_rd(b, 13), tp_rd(b, 14), tp_rd(b, 15));
     }
 }
 
@@ -442,6 +583,24 @@ void hal_sub_camera_input(void)
     _ZN5Stage16CheckCameraInputEv();
     *(unsigned short *)data_0209f49c |= *(const unsigned short *)(ctrl + 4);
     *(unsigned short *)data_0209f49e |= *(const unsigned short *)(ctrl + 6);
+
+    /* SM64DS_TOUCH_PROBE: what a REAL reader made of the record this frame.
+       Stage::CheckCameraInput is matched ROM code from src/, it reads the
+       stylus through data_020a0de8[i].{touched,held,x,y}, and these two
+       halfwords are its entire output -- so a rotate bit here is the whole
+       write-to-read path proven end to end, not a probe reading its own
+       write back. It runs after poll_touch in the same frame. */
+    if (g_tp_n > 0 && touch_probe_at(g_tp_cur))
+        std::fprintf(stderr, "[touch] f%d cam: Ctrl+4 held=%04x Ctrl+6 "
+                     "pressed=%04x  f49c=%04x f49e=%04x  gate(+0x154)=%08x\n",
+                     g_tp_cur, *(const unsigned short *)(ctrl + 4),
+                     *(const unsigned short *)(ctrl + 6),
+                     *(const unsigned short *)data_0209f49c,
+                     *(const unsigned short *)data_0209f49e,
+                     data_0209f318
+                         ? *(const unsigned *)((const char *)data_0209f318 +
+                                               0x154)
+                         : 0u);
 
     static int said;
     if (!said++) {

--- a/port/hal/sub_screen.cpp
+++ b/port/hal/sub_screen.cpp
@@ -82,6 +82,7 @@ extern unsigned char data_0209d454;
    below is what proves it. */
 extern unsigned char data_020a0de8[];   /* +0 touched */
 extern unsigned char data_020a0de9[];   /* +1 held    */
+extern unsigned char data_020a0dea[];   /* +2 x       */
 extern unsigned char data_020a0deb[];   /* +3 y       */
 /* Stage::CheckCameraInput's own inputs and outputs */
 void _ZN5Stage16CheckCameraInputEv(void);
@@ -146,14 +147,15 @@ int env_flag(const char *name, int dflt)
  *
  * One stderr line per listed frame:
  *
- *   [touch] f59 poke=(1,120,150) pre={de8=1 de9=0 dea=.. deb=150}
- *           post={de8=1 de9=1 dea=.. deb=150} d=(1,3) block=01 01 78 96 ...
+ *   [touch] f59 poke=yes(1,120,150) pre={de8=1 de9=0 dea=120 deb=150}
+ *           post={de8=1 de9=1 dea=120 deb=150} d=(1,2,3) block=01017896 ...
  *
  * `pre` is what the names read on ENTRY to the poll -- which is what a
  * save-state restore left behind when the load frame is a logged frame --
- * and `post` is after the write. `d` is (&de9-&de8, &deb-&de8) and MUST read
- * (1,3): those numbers ARE the bug. Hosted as separate arrays they are two
- * unrelated addresses and de9/deb read zero on every frame forever.
+ * and `post` is after the write. `d` is (&de9-&de8, &dea-&de8, &deb-&de8)
+ * and MUST read (1,2,3): those three numbers ARE the bug. Hosted as separate
+ * arrays they read (32,-,64) -- unrelated addresses, dea not hosted at all --
+ * and de9/deb read zero on every frame forever.
  *
  * THE READS ARE VOLATILE ON PURPOSE. MSVC treats two named globals as
  * disjoint objects, so a load through data_020a0de9 in the same function as a
@@ -246,12 +248,13 @@ void poll_touch(void)
     const int f = g_tp_frame++;
     g_tp_cur = f;
     const TouchProbeEnt *tp = g_tp_n > 0 ? touch_probe_at(f) : 0;
-    unsigned char pre8 = 0, pre9 = 0, preb = 0;
+    unsigned char pre8 = 0, pre9 = 0, prea = 0, preb = 0;
     if (tp) {
-        /* what the three names read BEFORE this poll writes anything: slot 0,
+        /* what the four names read BEFORE this poll writes anything: slot 0,
            in Message::Update's own shape (data_020a0deX[idx * 4], idx = 0) */
         pre8 = tp_rd(data_020a0de8, 0);
         pre9 = tp_rd(data_020a0de9, 0);
+        prea = tp_rd(data_020a0dea, 0);
         preb = tp_rd(data_020a0deb, 0);
         if (tp->poke) {
             down = 1;
@@ -271,14 +274,16 @@ void poll_touch(void)
     if (tp) {
         const unsigned char *b = data_020a0de8;
         std::fprintf(stderr,
-            "[touch] f%d poke=%s(%u,%u,%u) pre={de8=%u de9=%u deb=%u} "
-            "post={de8=%u de9=%u deb=%u} d=(%d,%d) block=%02x%02x%02x%02x "
+            "[touch] f%d poke=%s(%u,%u,%u) pre={de8=%u de9=%u dea=%u deb=%u} "
+            "post={de8=%u de9=%u dea=%u deb=%u} d=(%d,%d,%d) "
+            "block=%02x%02x%02x%02x "
             "%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x\n",
             f, tp->poke ? "yes" : "no", down, sx, sy,
-            pre8, pre9, preb,
+            pre8, pre9, prea, preb,
             tp_rd(data_020a0de8, 0), tp_rd(data_020a0de9, 0),
-            tp_rd(data_020a0deb, 0),
+            tp_rd(data_020a0dea, 0), tp_rd(data_020a0deb, 0),
             (int)(data_020a0de9 - data_020a0de8),
+            (int)(data_020a0dea - data_020a0de8),
             (int)(data_020a0deb - data_020a0de8),
             tp_rd(b, 0), tp_rd(b, 1), tp_rd(b, 2), tp_rd(b, 3),
             tp_rd(b, 4), tp_rd(b, 5), tp_rd(b, 6), tp_rd(b, 7),


### PR DESCRIPTION
External-contributor lane from the second coordination site (operation per the campaign handoff; primary site's reservations respected — `port/tests/walk_window.cpp` and `port/ntr/` untouched).

## What this is

TOUCH INPUT CORRECTNESS (target-menu item 4). The four stylus bytes `data_020a0de8/9/a/b` are DS-adjacent bytes of one TouchInfo record, but the host tree hosted `de8/de9/deb` as three disjoint `int[8]` arrays and `dea` nowhere — so the packed record `sub_screen.cpp` writes was invisible through the sibling symbols (`Message::Update`'s `held`/`y` read constant zero). This lane hosts the record as ONE 16-byte block with the four names aliased at +0/+1/+2/+3, inside the save-state section, and adds an env-gated `SM64DS_TOUCH_PROBE` diagnostic that makes the aliasing measurable end to end.

Two commits: `91f74ee7` (probe), `79281aed` (hosting fix). Three files: `port/hal/auto_bss.cpp`, `port/hal/cxx_aliases.cpp`, `port/hal/sub_screen.cpp`. No CMake change; `src/`, `include/`, `config/`, root `tools/` untouched (diff = 0 bytes).

## Headline numbers (worker's own maps; independently rebuilt by the reviewer)

| | linkage | map |
|---|---|---|
| base `daeeb9b2` | 4623 (41.1%) | 2,523,451 B |
| tip `79281aed` | 4623 (41.1%) — floor held, no TU change intended | 2,524,825 B |

Map evidence at tip: `_data_020a0de8/9/a/b` at `00a48f30/31/32/33` — consecutive, inside `[dsstate_lo, dsstate_hi)`, section rows `.dsstate$touch0000..0003` sized 1,1,1,13 (the tail size is load-bearing: 16 B = the 4 records the readers' controller loop can touch). `dea` newly hosted (dsstate 5585→5586 symbols; 372624→372544 B, the −80 = 96 bytes of dead arrays replaced by the 16-byte block).

## Gates (all green; full tables in the two reports below)

control 300 `pos=(-4915200, 2805556, 9342995)` exit 0 (stdout differs from base only in two host-pointer address lines); soak 1000 `pos=(-4900460, 2736154, 8004169)`; all seven pinned censuses byte-identical (L2 64/10, L12 136/4, L13 187/1, L14 180/29, L15 55/1, L37 109/6, L38 17/0); full sweep 1-15/37/38 exit 0 under FAULTS_FATAL; battery ALL GREEN at `--linked-floor 4623`; 18/18 smokes; guards: alternatename 0 new defeats (the new `dea` alias has no defined LHS — the guard-clean case), closestplayer OK, inferred_stub 2=baseline, ptr_audit 0, dsstate OK; both save-state reproducers PASS, including a new demonstration that a synthetic touch value poked before the save survives restore in all four names.

Defect demonstrated live (probe-only build at `91f74ee7`, old hosting): probe deltas `(32,64)`, `de9`/`deb` read 0 every frame while the block plainly holds `01 01 78 96`. At tip: deltas `(1,2,3)`, all four names track the poked values.

## Setup facts for reproduction on the primary site

- `extracted/dsd/files/files.txt` must exist (`python port/tools/ntr_manifest.py`) or `smoke_gx` exits 2 with "no assets" — this bit multiple lanes on the second site before the coordinator traced it to a missing setup step. Not a lane effect.
- This site builds with VS2022 Preview via a local mirror of `port/build-port.cmd` (same guards/flags, only the toolchain path differs); `battery.py` was run with `--skip-build` after building.

## Carried items for the primary site

1. `port/tests/walk_window.cpp:314` declares `extern int data_020a0de8[];` — wrong element type against the new 1-byte-object definition. Measured inert (declared, never referenced, C linkage, no relocation emitted). File is reserved; recommend fixing the shape or deleting the line on the primary side.
2. `Message::Update`'s state-6 touch-drag branch (the exact reader the bug killed) is not executable headlessly without a scrollable-message driver, which would need the reserved harness file. Fix proven at link level (its two mangled refs resolve to block+1/block+3 in the tip map) and storage level (probe reads in that reader's exact expression shapes).
3. Reviewer finding worth a follow-up lane: `port/hal/sub_actors.cpp:270-271` hosts `data_0209f4a8/0209f4a9` as disjoint arrays — same sibling-symbol class (bytes 0x10/0x11 of the DS 0x18-stride Ctrl record, read by linked `Minimap::Behavior`). Inert today (no host writer); will bite whenever a slice starts writing the Ctrl block's stylus bytes.
4. Reviewer note: the aliasing's strict-aliasing safety rests on LTCG staying off for the port link (verified off today). Recorded as an invariant.

---

# Worker evidence report (lane w7d, verbatim)

[The complete worker report follows.]

Worktree `C:\tmp\w7d-touch`, branch `port-w7d-touch`, base `daeeb9b2`. Two commits, three files, no pushes until review passed.

## 1. Linkage, from my own maps

| | map size | `linked into walk_window` |
|---|---|---|
| base `daeeb9b2` | 2,523,451 B | **4623** (41.1%) |
| tip `79281aed` | 2,524,825 B | **4623** (41.1%) |

Floor 4623 held. Both maps non-truncated and content-verified. Base map captured by rebuilding the three owned files at `daeeb9b2`, then restoring and relinking the tip.

## 2. Complete reader/writer inventory of the four names

**81 files** name `data_020a0de8/9/a/b` — 76 under `src/`, 5 under `port/`. **9 are in the walk_window link.**

Ground truth: `config/arm9/symbols.txt:4932-4936` — the four names at `0x020a0de8/9/a/b`, next symbol `data_020a0df8` → 16-byte block, TouchInfo[4], stride 4, fields +0 touched / +1 held / +2 x / +3 y; `config/arm9/delinks.txt:8` `.bss 0x0209b000..0x020aa420` (BSS — layout evidence is reader code, not image bytes); every reader indexes its name by `slot*4`.

Linked readers, byte reached before → after:
- `port/hal/auto_bss.cpp:120-122`: was three disjoint 32-byte `int[8]` arrays, `dea` nowhere → one 16-byte run, names at +0/+1/+2/+3.
- `port/hal/sub_screen.cpp:76,140-145`: packed TouchInfo writes through `de8` — correct before and after.
- `port/hal/cxx_aliases.cpp:489-491,1257`: 3 `/alternatename` directives routed onto the disjoint arrays → 4 onto the block (+ new `dea` alias, LHS absent → unused, guard-clean).
- `port/tests/walk_window.cpp:314`: `extern int data_020a0de8[]` — declared, never referenced; untouched (reserved).
- `src/ProcessKuppaScript.cpp:18,97`: `de8[off]`, `*(de8+off+1)` — correct before and after.
- `src/_ZN5Stage10CheckInputEv.cpp:37,91-155`: `struct TouchData de8[]`, stride 4 — correct.
- `src/_ZN5Stage16CheckCameraInputEv.cpp:28,49-93`: `TouchInfo de8[]` outside `extern "C"` → mangled alias → correct.
- `src/_ZN7Message6UpdateEv.cpp:33-35,171-181`: `de8[idx*4]` correct; **`de9[idx*4]` read the disjoint array at de8+0x20 (always 0) → now block+1; `((u8(*)[4])deb)[idx][0]` read de8+0x40 (always 0) → now block+3.** This was the whole defect.

72 unlinked src/ files catalogued by declaration shape (31 `extern u8 N[]`, 23 `extern unsigned char N[]`, 5 `N[][4]`, plus mixed/exotic single cases). All resolve to `slot*4 + field` under the new hosting; exotic manglings not yet aliased will surface as clean unresolved externals when sliced, never silent misbinds.

## 3. Map evidence

BEFORE: `_data_020a0de8` @ `00a22138`, `_data_020a0de9` @ `00a22158` (+0x20), `_data_020a0deb` @ `00a22178` (+0x40), `_data_020a0dea` ABSENT.
AFTER: `00a48f30 / 31 / 32 / 33` consecutive; `.dsstate$touch0000..0003` sections sized 1,1,1,13; whole run inside `[_dsstate_lo 009ee000, _dsstate_hi 00a48f40)`.
Mechanism: `__pragma(section(".dsstate$touchNNNN", read, write)) __declspec(allocate) __declspec(align(1))` per slot — ovdata.py's own spacing idiom and dsstate_guard's prescribed fix-it. Verified standalone that `/OPT:REF /OPT:ICF` neither pads nor folds the four.

## 4. Touch-probe transcript

`SM64DS_TOUCH_PROBE="<frame>[-<frame>][:x:y],..."` pokes a synthetic stylus in `poll_touch`, logs each name's volatile read-back, the address deltas, all 16 block bytes.

BEFORE (probe-only commit, old hosting): block holds `01 01 78 96` while `de9`/`deb` read 0, deltas `(32,64)`.
AFTER (tip): deltas `(1,2,3)`; `de8/de9/dea/deb` = touched/held/x/y track every poke; frame-60 release drops touched/held while x/y persist (DS semantics).
End-to-end reader: poking the left camera-arrow hotspot (32,144) makes matched `Stage::CheckCameraInput` produce camera bit `0x200` from a synthetic stylus.
Save/load survival: value A poked before save at f60, value B after, restore at f200 → all four names return to A. `[ss-repro] PASS`, exit 0.

## 5. Censuses and gates

All seven pins byte-identical base→tip; control 300 / soak 1000 exact; full sweep 17/17 exit 0; battery ALL GREEN `--linked-floor 4623`; 18/18 smokes (after `ntr_manifest.py`); dsstate 5586/372544 B (base 5585/372624); alternatename 1367 scanned, 0 new defeats; closestplayer OK; inferred_stub 2=baseline; ptr_audit 0; heap 241592.

## 6-7. Hygiene and carried items

`git diff daeeb9b2..HEAD` for `src/ include/ config/ tools/` all empty; no notes/ files; tree clean; no non-owned file touched. Carried: the reserved-file declaration shape at `walk_window.cpp:314`; `Message::Update` state-6 branch driven at link+storage level only (driver needs the reserved harness); first-build flaky empty-output `cl.exe` failures under machine load (re-run converges — environment, not lane).

---

# Independent review verdict (verbatim)

## VERDICT: **MERGE**

Built base (`daeeb9b2`), tip (`79281aed`), and probe-only (`91f74ee7`) from scratch in own worktrees; every number re-derived.

Per-claim: defect CONFIRMED (base map +0x20/+0x40 separations, `dea` absent; only `Message::Update` names the siblings among linked readers); fix CONFIRMED exact (consecutive `00a48f30..33`, sections 1,1,1,13, block abuts `dsstate_hi` exactly, `dea` alias guard-clean); layout ground truth CONFIRMED (symbols.txt spacing 1,1,1,13; the ROM readers' expression shapes are correct only under de9=de8+1, deb=de8+3 — independently judged); inventory CONFIRMED (81 files; the linked set re-derived from build.ninja's 4975-object link line = exactly 9); linkage CONFIRMED 4623/4623 (map sizes 4 B under claim — timestamp-bearing, environment-dependent; delta +1374 B reproduces exactly; immaterial); probe CONFIRMED both directions (`d=(32,64)` + dead siblings at probe-only commit; `d=(1,2,3)` + live tracking at tip); save-state CONFIRMED (all four names return to pre-save values; dsstate deltas verified by fence arithmetic); gates CONFIRMED (full table: control/soak exact, 7 censuses match, 17/17 sweep, battery ALL GREEN, 18/18 smokes, all guards green, heap 241592); hygiene CONFIRMED (3 files, clean tree, nothing on remote).

Findings beyond the worker's report:
1. `port/hal/sub_actors.cpp:270-271` hosts `data_0209f4a8/9` as disjoint arrays — the same defect class (bytes 0x10/0x11 of the 0x18-stride Ctrl record; linked reader `Minimap::Behavior`). Inert until something writes them. Follow-up lane, not a blocker.
2. The camera `0x200` sub-test does not discriminate base from tip (`CheckCameraInput` is de8-relative and was always correct) — probe-validity evidence, not fix evidence. The fix evidence is the delta pair.
3. "Byte-identical" census stdout carries the same two host-pointer lines as the control — wording, not substance.
4. Strict-aliasing safety rests on LTCG staying off (verified: no `/GL` in the port build; definition TU never reads the names; the probe uses volatile). Record as invariant.
5. The 13-byte tail is load-bearing (16 B = the 4 records the controller loop can touch; a 1-byte tail would run a 4-controller read off the end).
6. The bare-`bss_seg` section trap (unmerged second `.dsstate` with only LNK4078 as symptom) was actively avoided via explicit `section(read,write)` + `= { 0 }`; zero LNK4078 in both builds, verified.
7. Probe parser bounded and terminating; unset cost ≈ one getenv + ~3 instructions/frame.
8. Methodology caution: one search tool undercounted the inventory (67 vs 76 src files); cross-check greps when re-deriving.

Integrity: lane branch untouched, nothing pushed by the reviewer; reviewer worktrees left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
