### PR TITLE
port w7c: mount levels 36 and 40 (koopa1/koopa3 boss arenas) + the ov044 cast

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -1029,6 +1029,42 @@ list(APPEND PORT_LEVEL_OVERLAYS ov045)
 # prior level mounts, so this mount cannot flip a resolved target raw; the
 # cross-pass counts are re-measured in this lane's report.
 list(APPEND PORT_LEVEL_OVERLAYS ov046)
+# run linkw wave 7 (lane w7-c): the other two koopaN_boss arenas, so all three
+# boss arenas are mounted. Every number below was re-derived on this lane from
+# extracted/arm9_dec.bin (base 0x02004000) and the raw overlay images, and the
+# whole pipeline was re-validated first: all 52 words of data_02092208 dumped
+# and checked against the seventeen already-mounted rows, 17/17 exact.
+#
+# ov044 = LEVEL 36, Bowser in the Dark World arena (data/stage/koopa1_boss),
+# course 15. data_020758c8[36] (word at 0x02075958) = 0x2c = 44 -- level+8, and
+# the +8 is a READ: all 52 words are contiguous 8..59. LVL_Overlay
+# data_02092208[36] (word at 0x02092298) = 0x021113b0. OV0 handles at +8 read
+# out of extracted/overlays/overlay_0044.bin (offset 0x210; ov044 is
+# compressed:true, so the dsd export is the compressed image and its halfwords
+# are noise): bmd 0x076b / kcl 0x0769 / icg 0x076c / icl 0x076d, resolved
+# DIRECTLY through build/assets/handles.tsv (delta 0) to koopa1_boss_all.bmd
+# (1899, 4411 bytes) / koopa1_boss.kcl (1897, 1624) / koopa1_boss_icg.bin
+# (1900, 13728) / koopa1_boss_icl.bin (1901, 512). SUBLEVEL_LEVEL_TABLE[36]
+# (byte at 0x020752bc) = 0x0f = course 15; subCount 1, flags 0.
+list(APPEND PORT_LEVEL_OVERLAYS ov044)
+# ov048 = LEVEL 40, Bowser in the Sky arena (data/stage/koopa3_boss), course 17.
+# data_020758c8[40] (word at 0x02075968) = 0x30 = 48. LVL_Overlay
+# data_02092208[40] (word at 0x020922a8) = 0x02111624. OV0 handles at +8 out of
+# extracted/overlays/overlay_0048.bin (offset 0x484; compressed:true as well):
+# bmd 0x0787 / kcl 0x0785 / icg 0x0788 / icl 0x0789 -> koopa3_boss_all.bmd
+# (1927, 7228) / koopa3_boss.kcl (1925, 1889) / koopa3_boss_icg.bin (1928,
+# 15028) / koopa3_boss_icl.bin (1929, 512). SUBLEVEL_LEVEL_TABLE[40] (byte at
+# 0x020752c0) = 0x11 = course 17; subCount 1, flags 0.
+#
+# Shared-window note (the ov045 calibration two blocks up, asked before the
+# mount rather than after): ov044 is 0x021111a0..0x021116a0 (code 1248 + bss 32)
+# and ov048 is 0x021111a0..0x02111900 (code 1888, bss 0). Both are strictly
+# inside windows the seventeen prior level mounts already contest -- ov009 runs
+# to 0x02113ee0 and ov016 to 0x02114ea0 -- so neither mount can flip a target
+# from resolved to raw. The cross-pass counts are re-measured in this lane's
+# report; the raw total grows because two more images add addresses, which is
+# not a regression.
+list(APPEND PORT_LEVEL_OVERLAYS ov048)
 set(LEVEL_OV_DATA "")
 foreach(ovn IN LISTS PORT_LEVEL_OVERLAYS)
     set(ovn_out "${CMAKE_BINARY_DIR}/host-src/${ovn}_data.c")
@@ -1250,6 +1286,19 @@ list(APPEND PORT_ACTOR_OVERLAYS ov060)
 # block, which BowserFireSeaArena::InitResources reaches by name under a
 # shared-window spelling. See port/ov046_syms.txt's header.
 list(APPEND PORT_ACTOR_OVERLAYS ov046)
+# run linkw wave 7 (lane w7-c): ov044 (level 36's own overlay, whole-mounted
+# this same lane) joins the per-symbol mounts too, because the arena's ONE
+# non-ov060 class -- ORANGE_BALL_BILLBOARD / daObjKb1Billboard_c (301), the
+# sixteen orange balls ringing the arena -- lives in the LEVEL overlay and
+# reaches its SpawnInfo and its two bss cells by name. Same dual-mount shape as
+# ov012/ov013/ov021/ov045/ov046. Its one vtable (0x02111604, 31 slots, pinned by
+# both the reloc run and the .data/.bss boundary) is a host array
+# hal/actor_classes_ov044.cpp fills; the mount bring-up and the single sinit run
+# from the registry fill (the ov045/ov060 lane-ownership pattern -- no lane owns
+# hal/actor_overlays.cpp this wave). See port/ov044_syms.txt and
+# port/slice_w7c.txt. ov048 (level 40) gets NO per-symbol half: its whole cast
+# is ov060's and nothing in ov048 is reached by name.
+list(APPEND PORT_ACTOR_OVERLAYS ov044)
 # run linkw wave 5 (lane w5-c): ov070, the Amp/FlameChomp/FlameChompFire pack
 # (level 37's roaming enemies; FlyGuy rides the mount unregistered). Fresh
 # per-symbol mount, ids re-read from the raw overlay image; the four vtables
@@ -1613,6 +1662,22 @@ foreach(line IN LISTS SLICE_W6F_LINES)
         continue()
     endif()
     list(APPEND SLICE_W6F_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
+endforeach()
+
+# run linkw wave 7, lane w7-c: ORANGE_BALL_BILLBOARD (301, ov044) -- level 36's
+# only cast item that was not already registered, plus the fill/registry host
+# file. Level 40 needs no slice: its three ids are all ov060, all landed in
+# wave 6. One TU is held out (the shadow-class MSVC destructor); the header of
+# port/slice_w7c.txt carries the reason and the closure walk. Same one-owner
+# contract as the lane slices above.
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_w7c.txt" SLICE_W7C_LINES)
+set(SLICE_W7C_SOURCES "")
+foreach(line IN LISTS SLICE_W7C_LINES)
+    string(STRIP "${line}" line)
+    if(line MATCHES "^#" OR line STREQUAL "")
+        continue()
+    endif()
+    list(APPEND SLICE_W7C_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
 
 # run linkw wave 6, lane w6-D: PATH_LIFT (31) and the PathLift base branch --
@@ -3028,6 +3093,7 @@ add_executable(smoke_player tests/smoke_player.cpp "${OV002DATA_C}" ${LEVEL_OV_D
     ${SLICE_W6A_SOURCES}
     ${SLICE_W5C_SOURCES} ${SQRTUNIT_GEN} ${OV70GEN}
     ${SLICE_W5B_SOURCES} ${SLICE_W5A_SOURCES} ${SLICE_W6D_SOURCES}
+    ${SLICE_W7C_SOURCES}
     ${SLICE21_SOURCES} ${SLICE22_SOURCES} ${SLICE23_SOURCES} ${SLICE25_SOURCES} ${SLICE26_SOURCES}
     ${SLICE27_SOURCES} ${SLICE28_SOURCES} ${SLICE33_SOURCES} ${GATE6_GEN} ${SLICE31_SOURCES} ${SLICE35_SOURCES}
     ${SLICE27_SOURCES} ${SLICE28_SOURCES} ${SLICE32_SOURCES}
@@ -3103,6 +3169,7 @@ add_executable(walk_window tests/walk_window.cpp tests/io_pressure.cpp "${OV002D
     ${SLICE_W6A_SOURCES}
     ${SLICE_W5C_SOURCES} ${SQRTUNIT_GEN} ${OV70GEN}
     ${SLICE_W5B_SOURCES} ${SLICE_W5A_SOURCES} ${SLICE_W6D_SOURCES}
+    ${SLICE_W7C_SOURCES}
     ${SLICE21_SOURCES} ${SLICE22_SOURCES} ${SLICE23_SOURCES}
     ${SLICE25_SOURCES} ${SLICE27_SOURCES} ${SLICE28_SOURCES} ${SLICE26_SOURCES}
     ${SLICE33_SOURCES} ${GATE6_GEN}
@@ -3209,6 +3276,7 @@ add_executable(walk_window_hires tests/walk_window.cpp "${OV002DATA_C}" ${LEVEL_
     ${SLICE_W6A_SOURCES}
     ${SLICE_W5C_SOURCES} ${SQRTUNIT_GEN} ${OV70GEN}
     ${SLICE_W5B_SOURCES} ${SLICE_W5A_SOURCES} ${SLICE_W6D_SOURCES}
+    ${SLICE_W7C_SOURCES}
     ${SLICE21_SOURCES} ${SLICE22_SOURCES} ${SLICE23_SOURCES}
     ${SLICE25_SOURCES} ${SLICE27_SOURCES} ${SLICE28_SOURCES} ${SLICE26_SOURCES}
     ${SLICE33_SOURCES} ${GATE6_GEN}

--- a/port/hal/actor_classes.inc
+++ b/port/hal/actor_classes.inc
@@ -933,6 +933,20 @@ void hal_fill_flamethrower_vtable(void);         /* fills _ZTV12Flamethrower, 31
 extern unsigned char PathLift_SpawnInfo[];       /* ov100 0x02148558, +4 reads 31 */
 void *PathLift_Spawn(void);                      /* ov100 0x02147328 */
 void hal_fill_path_lift_vtable(void);            /* fills data_ov100_0214857c, 33 */
+/* ---- run linkw wave 7 (lane w7-c): ORANGE_BALL_BILLBOARD (301), the ONE
+   class either new boss arena needed. Its overlay is the LEVEL overlay, not an
+   actor overlay: arm9 spawn table 0x02090864 + 301*4 = 0x02090d18 holds
+   0x021115e0, and that record read RAW out of extracted/overlays/
+   overlay_0044.bin (ov044 is compressed:true, so the dsd export is the wrong
+   image) is {0x021112dc, 0x00be012d, ...} -- word[0] is
+   OrangeBallBillboard_Spawn inside ov044's own load window and word[1]'s low
+   half is 301. RTTI at vtable[-1] names the class daObjKb1Billboard_c (kb1 =
+   koopa boss 1); the width pin, the held-out D1 and the cross-overlay
+   SharedFilePtr spelling are in hal/actor_classes_ov044.cpp. x16 on level 36,
+   placed on no other level. ---- */
+extern unsigned char OrangeBallBillboard_SpawnInfo[]; /* ov044 0x021115e0, +4 reads 301 */
+void *OrangeBallBillboard_Spawn(void);                /* ov044 0x021112dc */
+void hal_fill_orange_ball_billboard_vtable(void);     /* _ZTV19OrangeBallBillboard, 31 */
 }
 
 #define PORT_ACTOR_CLASS_ROWS                                                 \
@@ -1382,4 +1396,8 @@ void hal_fill_path_lift_vtable(void);            /* fills data_ov100_0214857c, 3
        its own table by a real name, so no factory wrapper. Placed on
        levels 13 (x1) and 15 (x2). ---- */ \
     {31, "PATH_LIFT", PathLift_SpawnInfo, PathLift_Spawn, \
-     hal_fill_path_lift_vtable},
+     hal_fill_path_lift_vtable}, \
+    /* ---- run linkw wave 7 (lane w7-c): the Dark World arena's own class.
+       Spawn stores its table by a real name, so no factory wrapper. ---- */ \
+    {301, "ORANGE_BALL_BILLBOARD", OrangeBallBillboard_SpawnInfo, \
+     OrangeBallBillboard_Spawn, hal_fill_orange_ball_billboard_vtable},

--- a/port/hal/actor_classes_ov044.cpp
+++ b/port/hal/actor_classes_ov044.cpp
@@ -1,0 +1,320 @@
+// RUN LINKW WAVE 7, LANE w7-c: THE DARK WORLD ARENA'S OWN CLASS (ov044, level 36).
+//
+// ONE class, and it is the only cast either new arena needs. Level 40's three
+// ids (167 BOWSER_SKY_PLATFORM x10, 279 BOWSER x1, 284 SPIKE_BOMB x5) are all
+// ov060 and all registered since wave 6, so that arena is a pure mount. Level
+// 36 places 279 x1 and 284 x8 from the same ov060 pack -- and 301 x16, which is
+// not an ov060 class at all.
+//
+// ---- WHY 301 IS ov044's, MEASURED BOTH WAYS -------------------------------
+//
+// The level's object table (LVL_Overlay 0x021113b0 -> objTable 0x02111374, one
+// Standard sub-table of 25 entries at area 0, ids through
+// data_ov002_0210cbf4[raw]) yields 279 x1, 284 x8, 301 x16. For 301:
+//
+//   arm9 ACTOR_SPAWN_TABLE 0x02090864 + 301*4 = 0x02090d18  ->  0x021115e0
+//   overlay_0044.bin @0x021115e0 word[0] = 0x021112dc  (OrangeBallBillboard_Spawn)
+//   overlay_0044.bin @0x021115e0 word[1] & 0xffff = 0x012d = 301
+//
+// BOTH tests, because sibling overlays share the load window: the spawnFunc
+// 0x021112dc is inside ov044's own 0x021111a0..0x02111680 (overlays.yaml
+// ram_size 1248), AND the id halfword matches the slot it was reached from.
+// Bytes come from extracted/overlays/overlay_0044.bin -- ov044 is
+// compressed:true, so the dsd export is the compressed image and its halfwords
+// are noise.
+//
+// ---- CLASS IDENTITY: RTTI, NOT THE LABEL ----------------------------------
+//
+// _ZTV19OrangeBallBillboard is at 0x02111604; its vtable[-1] (0x02111600)
+// points at 0x021115bc, and that typeinfo's name string (0x021115c8) reads
+// "19daObjKb1Billboard_c". kb1 = koopa boss 1 -- this arena. The asset agrees
+// independently: __sinit_ov044_02111314 constructs the class's SharedFilePtr on
+// handle 1570, which build/assets/handles.tsv resolves to
+// data/special_obj/kb1_ball/kb1_ball.bmd. So "OrangeBallBillboard" is the
+// config's chosen spelling of daObjKb1Billboard_c, NOT a shifted label -- ov044
+// contains exactly one class, so there is no neighbour for a shift to land on.
+// No RTTI alias is needed here: the only two TUs that restore the table by name
+// (D0 and Spawn) both spell it _ZTV19OrangeBallBillboard.
+//
+// ---- THE WIDTH: THIRTY-ONE, PINNED TWICE ----------------------------------
+//
+// config/arm9/overlays/ov044/relocs.txt carries an unbroken run of `load`
+// relocs at 0x02111604, 0x02111608, ... 0x0211167c -- thirty-one consecutive
+// words -- and NOTHING at 0x02111680. delinks.txt ends .data at 0x02111680 and
+// starts .bss there. Reloc run and next-symbol landing agree: 31 slots, the
+// plain Actor shape, no Platform::Kill tail. (A slot-31 undersize has taken a
+// level before; a slot-31 OVERSIZE here would put a host pointer into bss.)
+//
+// The shared half is byte-identical to the arena class the port already hosts:
+// slots 1,2,4,5,7,8,10..15 and 18..30 of this table hold exactly the same arm9
+// addresses as _ZTV18BowserFireSeaArena's (0x0211a8b0, ov060) -- compared word
+// for word on this lane. Two slots differ from that class's shape and both are
+// INHERITED here rather than own:
+//   slot  6  0x02043b24  _ZN9ActorBase8BehaviorEv        (no Behavior of its own)
+//   slot 12  0x02043ac0  _ZN9ActorBase16OnPendingDestroyEv
+// Own slots are 0 / 3 / 9 / 16 / 17 only. Sixteen static billboards that turn
+// to face the camera do not need a per-frame Behavior, and the ROM agrees.
+//
+// ---- D1/D0 NUMBERING ------------------------------------------------------
+//
+// This seat uses dsd's Itanium numbering, and the ROM settles which is which
+// rather than the names doing it: 0x021111d0 (dsd: D0) ends in
+// Memory::Deallocate (src/_ZN19OrangeBallBillboardD0Ev.c, and reloc 0x021111fc
+// -> 0x0203c1e8), 0x021111a0 (dsd: D1) does not (its only calls are
+// 0x02016d20 Model::~Model and 0x020112c8 Actor::D2). So D1 = complete-object,
+// slot 16; D0 = deleting, slot 17. That is the arena/spikebomb seating.
+//
+// ---- THE ONE TU HELD OUT OF THE SLICE -------------------------------------
+//
+// src/_ZN19OrangeBallBillboardD1Ev.cpp is a real MSVC destructor over a SHADOW
+// class (`struct OrangeBallBillboard : Actor { Model m0; }` declared inside its
+// own .cpp), so MSVC emits ??1OrangeBallBillboard@@UAE@XZ and auto-generates
+// calls to ??1Model@@QAE@XZ and ??1Actor@@UAE@XZ, neither of which exists
+// anywhere in this build -- the BigBooIcon / HauntedChair / SPIKE_BOMB case.
+// obb_d1 below is the chain its matched sibling D0 spells minus the
+// Deallocate, which relocs.txt confirms instruction for instruction.
+//
+// ---- THE ONE CROSS-OVERLAY SPELLING ---------------------------------------
+//
+// src/_ZN19OrangeBallBillboard13InitResourcesEv.c reaches the class's
+// SharedFilePtr as `data_ov059_02111680` while its sibling
+// CleanupResources and the sinit both spell the SAME cell `data_ov044_02111680`
+// -- dsd's shared-window naming race (0x02111680 is inside twenty overlays'
+// windows; ov059 is not mounted anywhere in this build). One storage, sibling
+// name aliased onto it, the ov060 data_ov066_* recipe. Getting this wrong is
+// not a link error but a silent one: the sinit would construct one
+// SharedFilePtr and InitResources would load a model through a different,
+// zeroed one.
+//
+// ---- LANE OWNERSHIP -------------------------------------------------------
+//
+// No lane owns hal/actor_overlays.cpp this wave, so the ov044 mount bring-up
+// and its single sinit ride the registry fill (port_ov44_bringup, the
+// ov045/ov060 shape). Whoever next owns actor_overlays.cpp should move the body
+// beside the ov013/ov045/ov060 blocks and cut the guard here to a call.
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "dsstate_seg.h"
+#include "Actor.h"
+#include "ActorBase.h"
+#include "OrangeBallBillboard.h"
+
+extern "C" {
+
+/* ---- the shared arm9 half, slots 1..30 (see the width block above) ---- */
+int  _ZN5Actor19BeforeInitResourcesEv(void *self);              /* slot 1  */
+void _ZN5Actor18AfterInitResourcesEj(void *self, unsigned a);   /* slot 2  */
+int  _ZN5Actor14BeforeBehaviorEv(void *self);                   /* slot 7  */
+int  _ZN5Actor12BeforeRenderEv(void *self);                     /* slot 10 */
+int  _ZN5Actor13OnYoshiTryEatEv(void *self);                    /* slot 18 */
+void _ZN5Actor13OnTurnIntoEggER6Player(void *self, void *p);    /* slot 19 */
+int  _ZN5Actor9Virtual50Ev(void *self);                         /* slot 20 */
+void _ZN5Actor15OnGroundPoundedERS_(void *self, void *o);       /* slot 21 */
+void _ZN5Actor11OnAttacked1ERS_(void *self, void *o);           /* slot 22 */
+void _ZN5Actor11OnAttacked2ERS_(void *self, void *o);           /* slot 23 */
+void _ZN5Actor8OnKickedERS_(void *self, void *o);               /* slot 24 */
+void _ZN5Actor8OnPushedERS_(void *self, void *o);               /* slot 25 */
+void _ZN5Actor24OnHitByCannonBlastedCharERS_(void *self, void *o);  /* slot 26 */
+void _ZN5Actor15OnHitByMegaCharER6Player(void *self, void *p);      /* slot 27 */
+void _ZN5Actor19OnHitFromUnderneathERS_(void *self, void *o);       /* slot 28 */
+int  _ZN5Actor16OnAimedAtWithEggEv(void *self);                     /* slot 29 */
+
+/* ---- the class's own matched bodies ---- */
+int  _ZN19OrangeBallBillboard13InitResourcesEv(void *self);     /* slot 0  */
+int  _ZN19OrangeBallBillboard16CleanupResourcesEv(void);        /* slot 3  */
+int *_ZN19OrangeBallBillboardD0Ev(int *self);                   /* slot 17 */
+void *OrangeBallBillboard_Spawn(void);
+void __sinit_ov044_02111314(void);
+
+/* ---- the destructor chain obb_d1 spells (relocs 0x021111b4 / 0x021111bc) ---- */
+void  _ZN5ModelD1Ev(void *m);
+void *_ZN5ActorD2Ev(void *self);
+
+/* ---- the ov044 per-symbol mount (port/ov044_syms.txt) ---- */
+void port_ov044_pack_check(void);
+void port_ov044_syms_patch(void);
+
+void port_actor_render_probe(const char *cls, void *model);
+void port_actor_slot_decline(const char *what);
+const char *port_actor_class_name(unsigned id);
+
+/* HOST STORAGE for the one vtable, 31 slots (the width block above). Excluded
+   from port/ov044_syms.txt: a mounted vtable hands a factory DS code
+   addresses. */
+DSSTATE_BEGIN
+void *_ZTV19OrangeBallBillboard[31];   /* ROM 0x02111604..0x02111680 */
+DSSTATE_END
+
+}  /* extern "C" */
+
+/* The InitResources spelling of the class's own SharedFilePtr, onto the one
+   storage the sinit and CleanupResources use (the cross-overlay block above).
+   Data aliases are exact -- there is no `this` to lose. */
+#pragma comment(linker, "/alternatename:_data_ov059_02111680=_data_ov044_02111680")
+
+// ---- the trap --------------------------------------------------------------
+static void obb_trap_report(void *self, int slot)
+{
+    unsigned id = self ? *(unsigned short *)((char *)self + 0xc) : 0u;
+    std::fprintf(stderr,
+                 "UNHOSTED: ov044 vtable slot %d is not hosted (actor id %u "
+                 "%s)\n", slot, id, port_actor_class_name(id));
+    { static char _m[128];
+      std::snprintf(_m, sizeof _m, "unhosted ov044 vtable slot %d on id %u %s",
+                    slot, id, port_actor_class_name(id));
+      port_actor_slot_decline(_m); }
+}
+#define OBB_TRAP(n) \
+    static int __fastcall obb_trap##n(void *s, void *) \
+    { obb_trap_report(s, n); return 0; }
+OBB_TRAP(13) OBB_TRAP(14) OBB_TRAP(30)
+#undef OBB_TRAP
+
+// ---- the shared half -------------------------------------------------------
+static int __fastcall obb_binit(void *s, void *)
+{ return _ZN5Actor19BeforeInitResourcesEv(s); }
+static void __fastcall obb_ainit(void *s, void *, unsigned a)
+{ _ZN5Actor18AfterInitResourcesEj(s, a); }
+static int __fastcall obb_bclean(void *s, void *)
+{ return ((Actor *)s)->Actor::BeforeCleanupResources(); }
+static void __fastcall obb_aclean(void *s, void *, unsigned a)
+{ ((ActorBase *)s)->ActorBase::AfterCleanupResources(a); }
+static int __fastcall obb_bbeh(void *s, void *)
+{ return _ZN5Actor14BeforeBehaviorEv(s); }
+static void __fastcall obb_abeh(void *s, void *, unsigned a)
+{ ((ActorBase *)s)->ActorBase::AfterBehavior(a); }
+static int __fastcall obb_bren(void *s, void *)
+{ return _ZN5Actor12BeforeRenderEv(s); }
+static void __fastcall obb_aren(void *s, void *, unsigned a)
+{ ((ActorBase *)s)->ActorBase::AfterRender(a); }
+static int __fastcall obb_pdes(void *s, void *)
+{ ((ActorBase *)s)->ActorBase::OnPendingDestroy(); return 0; }
+static int __fastcall obb_heap(void *s, void *)
+{ return ((ActorBase *)s)->ActorBase::OnHeapCreated(); }
+static int __fastcall obb_yoshi(void *s, void *)
+{ return _ZN5Actor13OnYoshiTryEatEv(s); }
+/* slot 19 takes the three-parameter shape so it emits `ret 4`: the dispatch
+   site pushes the Player the callee pops -- the wf_turn_egg contract. */
+static int __fastcall obb_turn_egg(void *s, void *, void *p)
+{ _ZN5Actor13OnTurnIntoEggER6Player(s, p); return 0; }
+static int __fastcall obb_v50(void *s, void *)
+{ return _ZN5Actor9Virtual50Ev(s); }
+static int __fastcall obb_pounded(void *s, void *, void *o)
+{ _ZN5Actor15OnGroundPoundedERS_(s, o); return 0; }
+static int __fastcall obb_atk1(void *s, void *, void *o)
+{ _ZN5Actor11OnAttacked1ERS_(s, o); return 0; }
+static int __fastcall obb_atk2(void *s, void *, void *o)
+{ _ZN5Actor11OnAttacked2ERS_(s, o); return 0; }
+static int __fastcall obb_kicked(void *s, void *, void *o)
+{ _ZN5Actor8OnKickedERS_(s, o); return 0; }
+static int __fastcall obb_pushed(void *s, void *, void *o)
+{ _ZN5Actor8OnPushedERS_(s, o); return 0; }
+static int __fastcall obb_cannon(void *s, void *, void *o)
+{ _ZN5Actor24OnHitByCannonBlastedCharERS_(s, o); return 0; }
+static int __fastcall obb_mega(void *s, void *, void *p)
+{ _ZN5Actor15OnHitByMegaCharER6Player(s, p); return 0; }
+static int __fastcall obb_under(void *s, void *, void *o)
+{ _ZN5Actor19OnHitFromUnderneathERS_(s, o); return 0; }
+static int __fastcall obb_egg(void *s, void *)
+{ return _ZN5Actor16OnAimedAtWithEggEv(s); }
+/* slot 6, INHERITED: the ROM's word is 0x02043b24 = ActorBase::Behavior, the
+   base no-op. This class has no Behavior of its own. */
+static int __fastcall obb_behavior(void *s, void *)
+{ return ((ActorBase *)s)->ActorBase::Behavior(); }
+
+// ---- the class's own slots -------------------------------------------------
+static int __fastcall obb_init(void *s, void *)
+{ return _ZN19OrangeBallBillboard13InitResourcesEv(s); }
+/* slot 3 takes NO receiver: the matched body is a free function over the
+   overlay's one SharedFilePtr (the SPIKE_BOMB / arena shape). */
+static int __fastcall obb_clean(void *s, void *)
+{ (void)s; return _ZN19OrangeBallBillboard16CleanupResourcesEv(); }
+/* slot 9 is a REAL MSVC METHOD (src/..Render..cpp defines
+   OrangeBallBillboard::Render over include/OrangeBallBillboard.h), so it is
+   called through the class rather than by a C name that is never emitted.
+   Its body is `((Sub *)&mModel)->m(0)` -- a six-virtual local shadow landing on
+   _ZTV5Model slot 5, which hal/cxxname_bridge.cpp DUAL-FILLS (slots 4 and 5
+   both Render) precisely for shadow-TU dispatch. Same reading as SPIKE_BOMB's,
+   and this class has no ModelAnim, so the dual-fill collision does not apply. */
+static int __fastcall obb_render(void *s, void *)
+{
+    port_actor_render_probe("ORANGE_BALL_BILLBOARD", (char *)s + 0xd4);
+    return ((OrangeBallBillboard *)s)->Render();
+}
+/* slot 16, HOST THUNK, not the matched TU -- the shadow-class MSVC destructor
+   (file header). The chain is what the matched D0 spells minus the Deallocate,
+   and relocs.txt pins it: 0x021111cc loads 0x02111604 (the table), 0x021111b4
+   calls 0x02016d20 (Model::~Model, member at +0xd4), 0x021111bc calls
+   0x020112c8 (Actor::D2). Nothing else. */
+static int __fastcall obb_d1(void *s, void *)
+{
+    *(void **)s = (void *)_ZTV19OrangeBallBillboard;
+    _ZN5ModelD1Ev((char *)s + 0xd4);
+    _ZN5ActorD2Ev(s);
+    return (int)(size_t)s;
+}
+static int __fastcall obb_d0(void *s, void *)
+{ return (int)(size_t)_ZN19OrangeBallBillboardD0Ev((int *)s); }
+
+// ---- the mount bring-up ----------------------------------------------------
+extern "C" void port_ov44_bringup(void)
+{
+    static int done;
+    if (done)
+        return;
+    done = 1;
+    port_ov044_pack_check();
+    port_ov044_syms_patch();
+    __sinit_ov044_02111314();
+}
+
+// ============================================================================
+// ORANGE_BALL_BILLBOARD / daObjKb1Billboard_c (id 301) -- table 0x02111604,
+// 31 slots, x16 on level 36
+// ============================================================================
+//
+// Actor build: operator new(292 = 0x124) in OrangeBallBillboard_Spawn, Model at
+// +0xd4, no collider. Spawn stores the table BY A REAL NAME
+// (`p[0] = (int)_ZTV19OrangeBallBillboard`, not a VT placeholder), so the row
+// registers the matched Spawn directly with no factory wrapper.
+//
+// THE POINTER IS VOLATILE ON PURPOSE -- the gate-200 elided-stores bug
+// (hal/actor_classes_ov002g200.cpp).
+extern "C" void hal_fill_orange_ball_billboard_vtable(void)
+{
+    port_ov44_bringup();
+    void *volatile *vt = (void *volatile *)_ZTV19OrangeBallBillboard;
+    vt[0]  = (void *)obb_init;
+    vt[1]  = (void *)obb_binit;
+    vt[2]  = (void *)obb_ainit;
+    vt[3]  = (void *)obb_clean;
+    vt[4]  = (void *)obb_bclean;
+    vt[5]  = (void *)obb_aclean;
+    vt[6]  = (void *)obb_behavior;   /* ActorBase::Behavior, inherited */
+    vt[7]  = (void *)obb_bbeh;
+    vt[8]  = (void *)obb_abeh;
+    vt[9]  = (void *)obb_render;
+    vt[10] = (void *)obb_bren;
+    vt[11] = (void *)obb_aren;
+    vt[12] = (void *)obb_pdes;       /* ActorBase::OnPendingDestroy, inherited */
+    vt[13] = (void *)obb_trap13;     /* ActorBase::Virtual34, the wf/ov45 trap */
+    vt[14] = (void *)obb_trap14;     /* ActorBase::Virtual38, likewise */
+    vt[15] = (void *)obb_heap;
+    vt[16] = (void *)obb_d1;
+    vt[17] = (void *)obb_d0;
+    vt[18] = (void *)obb_yoshi;
+    vt[19] = (void *)obb_turn_egg;
+    vt[20] = (void *)obb_v50;
+    vt[21] = (void *)obb_pounded;
+    vt[22] = (void *)obb_atk1;
+    vt[23] = (void *)obb_atk2;
+    vt[24] = (void *)obb_kicked;
+    vt[25] = (void *)obb_pushed;
+    vt[26] = (void *)obb_cannon;
+    vt[27] = (void *)obb_mega;
+    vt[28] = (void *)obb_under;
+    vt[29] = (void *)obb_egg;
+    vt[30] = (void *)obb_trap30;     /* declines, the wf/ov45 reading */
+}

--- a/port/hal/actor_classes_ov044.cpp
+++ b/port/hal/actor_classes_ov044.cpp
@@ -48,10 +48,12 @@
 // The shared half is byte-identical to the arena class the port already hosts:
 // slots 1,2,4,5,7,8,10..15 and 18..30 of this table hold exactly the same arm9
 // addresses as _ZTV18BowserFireSeaArena's (0x0211a8b0, ov060) -- compared word
-// for word on this lane. Two slots differ from that class's shape and both are
+// for word on this lane. One slot differs from that class's shape and is
 // INHERITED here rather than own:
 //   slot  6  0x02043b24  _ZN9ActorBase8BehaviorEv        (no Behavior of its own)
-//   slot 12  0x02043ac0  _ZN9ActorBase16OnPendingDestroyEv
+// (slot 12, 0x02043ac0 _ZN9ActorBase16OnPendingDestroyEv, is the SAME word in
+// both tables -- inherited in each; the review's word-for-word recomparison
+// puts the full differing set at {0, 3, 6, 9, 16, 17}.)
 // Own slots are 0 / 3 / 9 / 16 / 17 only. Sixteen static billboards that turn
 // to face the camera do not need a per-frame Behavior, and the ROM agrees.
 //

--- a/port/hal/actor_registry.cpp
+++ b/port/hal/actor_registry.cpp
@@ -184,9 +184,64 @@ static int port_host_abi_blocked(unsigned id)
     /* The PAINTING's levels-4/5/13 skip came off 2026-08-08: the mis-strided
        PMF dispatch behind those faults is hosted in
        port/unmatched/Painting_Dispatch.cpp now (see the long note above),
-       and all three levels boot their paintings through it. Nothing is
-       host-ABI-blocked at the moment; the hook stays for the next case. */
-    (void)id;
+       and all three levels boot their paintings through it. */
+
+    /* run linkw wave 7 (lane w7-c): BOWSER_SKY_PLATFORM (167) on LEVEL 40, the
+       Bowser in the Sky arena -- the second case this hook exists for, and it
+       is a HOST BOOT-ORDER limit rather than a class defect. Level 40 is the
+       only level in all fifty-two that places id 167, so the class had never
+       actually spawned until this lane mounted the arena; it is fault-free
+       everywhere it is reachable, which is nowhere else.
+
+       MEASURED, not reasoned. Its InitResources (src/func_ov060_021182b0.cpp,
+       daKpa3Bg_c::InitResources) calls CopyTexPalFromLevelModel(this + 0xdc),
+       and src/CopyTexPalFromLevelModel.c opens on
+
+           struct Entry* sbase = data_0209f320->entries;
+
+       -- a load through data_0209f320 + 4. data_0209f320 is the Stage's
+       ModelComponents pointer, and its ONLY writer is Stage::LoadModel
+       (src/_ZN5Stage9LoadModelEv.cpp, last line). The fault caught under
+       SM64DS_FAULTS_FATAL is exactly that load:
+
+           FAULT code c0000005 at +0x0008e07f accessing 00000004, eax=00000000
+           _CopyTexPalFromLevelModel+0xf
+             <- _func_ov060_021182b0+0x44  <- ?skyplat_init  <- Actor::Spawn
+             <- LoadStandardObjects <- LoadObjects <- Stage::LoadClsnAndObjects
+             <- _port_stage_a_boot+0x211  <- _main+0x797
+
+       THE ROM RUNS THE TWO THE OTHER WAY ROUND. Stage::InitResources
+       (src/_ZN5Stage13InitResourcesEv.cpp) is
+           :361  Stage::LoadModel(thiz);
+           :363  Stage::LoadClsnAndObjects(...);
+       so on the DS data_0209f320 is seated before any actor initialises. The
+       host harness inverts them: port/tests/walk_window.cpp calls
+       port_stage_a_boot (which runs LoadClsnAndObjects) at :2099 and
+       Stage::LoadModel only at :2265 -- confirmed on this tree by print order,
+       not by reading (level 36's log has [census] on line 31 and "level model
+       loaded by Stage::LoadModel ... components 3003AF24" on line 59). The
+       level-change path has the same inversion (:4362 boot, :4382 LoadModel).
+
+       AND IT CANNOT BE FIXED FROM port_stage_a_boot. Calling Stage::LoadModel
+       early there would leave the harness's own call as a SECOND one, and a
+       second Stage::LoadModel is not idempotent: LoadAndSetFile -> the port's
+       cached LoadFile(handle) -> func_02016ff4, which calls
+       Model::UpdateFileOffsets UNCONDITIONALLY, and that function rebases the
+       BMD's file-relative offsets IN PLACE (`file.bones = REBASE(file.bones)`,
+       src/_ZN5Model17UpdateFileOffsetsER8BMD_File.cpp). A duplicate pass adds
+       the base a second time and sends every pointer in the level model out of
+       the file -- on EVERY level, not just this one. So the fix is one line in
+       port/tests/walk_window.cpp (hoist the LoadModel call above the boot, the
+       ROM's own order), and that file is reserved to another owner.
+
+       Until then id 167 is declined ON LEVEL 40 ONLY. The arena boots, exits 0
+       under FAULTS_FATAL, and the census names the ten skipped platforms rather
+       than the port faking them. Nothing else changes: no other level places
+       167, and the class's registry row, vtable fill and ov060 mount are
+       untouched. */
+    if (id == 167 && port_level_id() == 40)
+        return 1;
+
     return 0;
 }
 

--- a/port/hal/level_boot.cpp
+++ b/port/hal/level_boot.cpp
@@ -564,6 +564,126 @@ void port_ov046_patch(void);
 void *port_ov046_at(unsigned ds);
 extern unsigned char port_ov046_image[];
 extern const unsigned port_ov046_ds_base, port_ov046_ds_end;
+
+/* ov044 = LEVEL 36, the Bowser in the Dark World BATTLE ARENA
+   (data/stage/koopa1_boss), course 15 -- the SECOND of the three koopaN_boss
+   arenas the port mounts, and ov048 below is the third. Everything re-derived
+   from extracted/arm9_dec.bin (base 0x02004000) and
+   extracted/overlays/overlay_0044.bin on this lane; the level-38 row above is
+   the model and it reproduces byte for byte from the same reads:
+
+     1. data_020758c8[36] -- the arm9 level->overlay map, a WORD table (stride
+        4, the ov045 correction; byte stride gets every level wrong). The read
+        is 0x020758c8 + 36*4 = 0x02075958, raw word 0x0000002c = overlay 44.
+        IT IS level+8, AND THAT IS A READ, NOT AN ASSUMPTION: all 52 words were
+        dumped on this lane and the table is contiguous 8..59 with no
+        exceptions, so the +8 is a property the table HAS, not a rule applied
+        to it. (Same read gives [38] = 0x2e = 46 and [40] = 0x30 = 48, which
+        reproduces the landed level-38 row.)
+
+     2. LVL_Overlay = data_02092208[36], also a word table: 0x02092208 + 36*4 =
+        0x02092298, raw word 0x021113b0. Re-derived for all 52 levels on this
+        lane and checked against every one of the seventeen rows already in the
+        table below -- 17/17 reproduce exactly, which is what makes the two new
+        reads trustworthy.
+
+     3. The four OV0 asset handles at LVL_Overlay+8, read out of
+        extracted/overlays/overlay_0044.bin (image offset 0x210; ov044 is
+        compressed:true in overlays.yaml, so the dsd export is the COMPRESSED
+        image and its halfwords are noise). Raw record bytes at 0x021113b0:
+          cc 13 11 02 | 74 13 11 02 | 6b 07 | 69 07 | 6c 07 | 6d 07 | ...
+        clps 0x021113cc, objTable 0x02111374, bmd 0x076b / kcl 0x0769 /
+        icg 0x076c / icl 0x076d. RESOLVED THROUGH build/assets/handles.tsv,
+        not arithmetic -- delta 0, the mapping levels 8..15 / 37 / 38 use:
+          1899 -> data/stage/koopa1_boss/koopa1_boss_all.bmd  (4411 bytes)
+          1897 -> data/stage/koopa1_boss/koopa1_boss.kcl      (1624)
+          1900 -> data/stage/koopa1_boss/koopa1_boss_icg.bin  (13728)
+          1901 -> data/stage/koopa1_boss/koopa1_boss_icl.bin  (512)
+        subTables 0x0211137c, subCount 1, flags 0 -- one area, no sublevel
+        tricks, the smallest KCL of any mounted level.
+
+     4. SUBLEVEL_LEVEL_TABLE (arm9 0x02075298, a BYTE table): 0x02075298 + 36 =
+        0x020752bc, raw 0x0f = course 15. koopa1 is the ROM's own name for the
+        first Bowser stage, and [35] is 0x0f too -- level 35 is the approach,
+        36 the arena, exactly the 37/38 pairing one course up.
+
+   ITS CAST is ov060 + ov089, by the same arm9 special case the level-38 row
+   documents (LoadOrUnloadObjectOverlays short-circuits idx 0x24/0x26/0x28 --
+   levels 36/38/40 -- to ov060 with an early return, after the selector loop has
+   already pulled ov089 in). Read off the level's own object table on this lane,
+   the arena places THREE ids: 279 BOWSER x1 and 284 SPIKE_BOMB x8 (both landed
+   in wave 6, lane w6-A) and 301 x16 -- which is NOT an ov060 class at all. The
+   arm9 spawn table 0x02090864 + 301*4 = 0x02090d18 holds 0x021115e0, a
+   LEVEL-OVERLAY address, and at that address in overlay_0044.bin the record's
+   +0 word is 0x021112dc (inside ov044's own 0x021111a0..0x02111680 window) and
+   its +4 halfword is 0x012d = 301. Both attribution tests pass on ov044, so
+   the sixteen orange balls ringing the arena are ov044's own class -- hosted
+   this lane in hal/actor_classes_ov044.cpp. Mounted --whole like the rest, and
+   ALSO per symbol (port/ov044_syms.txt) because that class reaches its
+   SpawnInfo and its two bss cells by name; own_sinits stays 0 (the ov044 sinit
+   runs from the registry fill, the ov045/ov060 lane-ownership shape). */
+void port_ov044_patch(void);
+void *port_ov044_at(unsigned ds);
+extern unsigned char port_ov044_image[];
+extern const unsigned port_ov044_ds_base, port_ov044_ds_end;
+
+/* ov048 = LEVEL 40, the Bowser in the Sky BATTLE ARENA
+   (data/stage/koopa3_boss), course 17 -- the LAST of the three koopaN_boss
+   arenas, and with it every boss arena in the game is mounted. Same four reads,
+   same discipline:
+
+     1. data_020758c8[40] = word at 0x020758c8 + 40*4 = 0x02075968, raw
+        0x00000030 = overlay 48. level+8 again, from the same 52-word dump.
+
+     2. data_02092208[40] = word at 0x02092208 + 40*4 = 0x020922a8, raw
+        0x02111624. (0x02111624 is ALSO the address of a dsd data label inside
+        ov044 -- every level overlay is linked at 0x021111a0, so the windows
+        collide by construction. The word is ov048's LVL_Overlay because it is
+        what ov048's row of the table says; port_level_mounts_install asserts
+        each row against port_level_ds_overlay and would say so loudly if not.)
+
+     3. LVL_Overlay+8 out of extracted/overlays/overlay_0048.bin (image offset
+        0x484; compressed:true, so again NOT the dsd export). Raw at 0x02111624:
+          80 17 11 02 | ac 15 11 02 | 87 07 | 85 07 | 88 07 | 89 07 | ...
+        clps 0x02111780, objTable 0x021115ac, bmd 0x0787 / kcl 0x0785 /
+        icg 0x0788 / icl 0x0789 -> through build/assets/handles.tsv (delta 0):
+          1927 -> data/stage/koopa3_boss/koopa3_boss_all.bmd  (7228 bytes)
+          1925 -> data/stage/koopa3_boss/koopa3_boss.kcl      (1889)
+          1928 -> data/stage/koopa3_boss/koopa3_boss_icg.bin  (15028)
+          1929 -> data/stage/koopa3_boss/koopa3_boss_icl.bin  (512)
+        subTables 0x021115c8, subCount 1, flags 0.
+
+     4. SUBLEVEL_LEVEL_TABLE[40] = byte at 0x020752c0 = 0x11 = course 17.
+        [39] is 0x11 as well -- the approach/arena pair, koopa3.
+
+   ITS CAST NEEDS NO NEW CLASS. The level's object table places exactly three
+   ids: 167 BOWSER_SKY_PLATFORM x10, 279 BOWSER x1, 284 SPIKE_BOMB x5 -- all
+   three ov060, all three registered by wave 6 lane w6-A, and 167's registry
+   comment already says in as many words that it is "level 40's floor (not
+   placed in 38)". So level 40 is a pure mount, and no slice.
+
+   ONE OF THE THREE IS DECLINED HERE, and the reason is a HOST BOOT-ORDER limit
+   in a file this lane may not touch. Level 40 is the only level of the
+   fifty-two that places id 167, so wave 6 registered a class that had never
+   actually spawned; mounting the arena ran it for the first time and it faulted
+   under FAULTS_FATAL. daKpa3Bg_c::InitResources (src/func_ov060_021182b0.cpp)
+   calls CopyTexPalFromLevelModel, whose first line loads through
+   data_0209f320 -- the Stage's ModelComponents pointer, written ONLY by
+   Stage::LoadModel. The ROM seats it first (Stage::InitResources :361 LoadModel,
+   :363 LoadClsnAndObjects); port/tests/walk_window.cpp does the two the other
+   way round (:2099 the boot, :2265 LoadModel), so the pointer is still null when
+   the object pass runs. port_stage_a_boot cannot compensate: a second
+   Stage::LoadModel is not idempotent (Model::UpdateFileOffsets rebases the BMD's
+   offsets in place and the harness's own call would run it twice, corrupting the
+   level model on every level). The whole derivation, with the fault dump, is in
+   port_host_abi_blocked (hal/actor_registry.cpp). Level 40 therefore boots and
+   exits 0 with the ten platforms named in the census as skipped rather than
+   faked. Mounted --whole; own_sinits 0, and no per-symbol half (nothing in ov048
+   is reached by name). */
+void port_ov048_patch(void);
+void *port_ov048_at(unsigned ds);
+extern unsigned char port_ov048_image[];
+extern const unsigned port_ov048_ds_base, port_ov048_ds_end;
 }
 
 /* LVL_Overlay, the fields the boot uses. */
@@ -679,6 +799,12 @@ static const PortLevelDesc port_level_table[] = {
     {38, "Bowser fight arena (koopa2_boss, course 16)", "ov046", 0x02111560,
      port_ov046_patch, port_ov046_at,
      &port_ov046_ds_base, &port_ov046_ds_end, 0},
+    {36, "Bowser in the Dark World arena (koopa1_boss, course 15)", "ov044",
+     0x021113b0, port_ov044_patch, port_ov044_at,
+     &port_ov044_ds_base, &port_ov044_ds_end, 0},
+    {40, "Bowser in the Sky arena (koopa3_boss, course 17)", "ov048",
+     0x02111624, port_ov048_patch, port_ov048_at,
+     &port_ov048_ds_base, &port_ov048_ds_end, 0},
 };
 
 enum { PORT_LEVEL_COUNT = sizeof port_level_table / sizeof port_level_table[0] };
@@ -877,6 +1003,11 @@ static void *port_mount_row_14(void) { return port_level_mount_at(14); }
 static void *port_mount_row_lvl37(void) { return port_level_mount_at(15); }
 /* Level 38's row is table index 16, the same append-only convention. */
 static void *port_mount_row_lvl38(void) { return port_level_mount_at(16); }
+/* Levels 36 and 40 are table indices 17 and 18 -- the other two koopaN_boss
+   arenas. Named by level, the same append-only convention, so a sibling stream
+   appending its own level against this base does not collide. */
+static void *port_mount_row_lvl36(void) { return port_level_mount_at(17); }
+static void *port_mount_row_lvl40(void) { return port_level_mount_at(18); }
 static void *(*const port_level_mount_fns[PORT_LEVEL_COUNT])(void) = {
     port_mount_row_0, port_mount_row_1, port_mount_row_2, port_mount_row_3,
     port_mount_row_4,
@@ -892,6 +1023,8 @@ static void *(*const port_level_mount_fns[PORT_LEVEL_COUNT])(void) = {
     port_mount_row_14,
     port_mount_row_lvl37,
     port_mount_row_lvl38,
+    port_mount_row_lvl36,
+    port_mount_row_lvl40,
 };
 
 // ---- the loader dispatch table ---------------------------------------------

--- a/port/ov044_syms.txt
+++ b/port/ov044_syms.txt
@@ -1,0 +1,88 @@
+# run linkw wave 7 (lane w7-c): ov044's ONE class, per symbol.
+#
+# ov044 (level 36, Bowser in the Dark World's battle arena,
+# data/stage/koopa1_boss) is mounted WHOLE in PORT_LEVEL_OVERLAYS by this same
+# lane -- the loaders walk the LVL_Overlay's object tables across whatever
+# symbol boundaries dsd named, which is why a level overlay needs the whole
+# image. This file is the SECOND mount of the same overlay, per symbol, and the
+# two do not conflict: tools/ovdata.py --whole emits port_ov044_image/_patch/_at
+# and NOTHING by name, while --from-list --pack emits the named arrays plus
+# port_ov044_syms_patch. ov012/ov013/ov014/ov021/ov045/ov046 are all
+# dual-mounted the same way; this is the seventh.
+#
+# ==== WHY THE NAMED HALF EXISTS ============================================
+# The registry rewrites OrangeBallBillboard_SpawnInfo's +0 word to the host
+# factory and ActorBase's constructor reads the two list priorities back out of
+# the SAME record, so it has to be storage the actor code and the registry
+# agree on -- which the whole image is not (it emits no names). The class's
+# InitResources / CleanupResources / sinit reach the overlay's two bss cells by
+# name for the same reason.
+#
+# ==== MANDATORY WINDOW-ALIAS CHECK (the gate-199/202 rule) =================
+# OrangeBallBillboard_SpawnInfo is flagged `ambiguous` in
+# config/arm9/overlays/ov044/symbols.txt -- 0x021115e0 sits in the level-overlay
+# window every one of the fifty-two level overlays is linked into (base
+# 0x021111a0), so the label alone proves nothing. RESOLVED by reading the raw
+# bytes out of extracted/overlays/overlay_0044.bin (ov044 is compressed:true in
+# overlays.yaml, so extracted/dsd/arm9_overlays/ov044.bin is the COMPRESSED
+# image and reading halfwords out of it is reading noise -- the ov045 trap):
+#
+#   arm9 ACTOR_SPAWN_TABLE 0x02090864 + 301*4 = 0x02090d18 -> 0x021115e0
+#   0x021115e0 word[0] = 0x021112dc  OrangeBallBillboard_Spawn
+#   0x021115e0 word[1] & 0xffff = 0x012d = 301
+#
+# BOTH attribution tests pass and both are needed: the spawn word lands inside
+# ov044's OWN load window (0x021111a0..0x02111680 code, ..0x021116a0 with bss,
+# from overlays.yaml ram_size 1248 / bss_size 32), and the id halfword matches
+# the spawn-table slot it was reached from. Sibling overlays share the window;
+# they do not share both of those.
+#
+# ==== CLASS IDENTITY COMES FROM RTTI, NOT THE LABEL ========================
+# _ZTV19OrangeBallBillboard sits at 0x02111604 and its vtable[-1] word
+# (0x02111600) points at 0x021115bc, a typeinfo record whose name string at
+# 0x021115c8 reads "19daObjKb1Billboard_c" -- kb1 = koopa boss 1, the ROM's own
+# name for this arena. The asset agrees: the sinit constructs its SharedFilePtr
+# on handle 1570, which resolves through build/assets/handles.tsv to
+# data/special_obj/kb1_ball/kb1_ball.bmd. "OrangeBallBillboard" is the config's
+# chosen spelling of daObjKb1Billboard_c, not a shifted label: ov044 holds
+# exactly ONE class, so there is no neighbour for a shift to land on.
+#
+# ==== ONE SYMBOL LEFT OUT ==================================================
+# _ZTV19OrangeBallBillboard (0x02111604..0x02111680, 31 slots) is a HOST ARRAY
+# hal/actor_classes_ov044.cpp fills -- the ov015/ov016/ov045/ov060 rule: a
+# mounted vtable hands a factory DS code addresses. Its width is pinned TWICE:
+# by the reloc run (config/arm9/overlays/ov044/relocs.txt carries an unbroken
+# 31-word run of `load` relocs from 0x02111604 to 0x0211167c inclusive, and
+# nothing at 0x02111680), and by the next symbol landing -- delinks.txt ends
+# .data at 0x02111680 and starts .bss there, so the table cannot be 32 and
+# cannot be 30. Thirty-one, the plain Actor shape, no Platform::Kill tail.
+#
+# dsd's ".p__sinit_ov044_02111314" .ctor entry is left out as well (not a C
+# identifier), and so is the .init body: __sinit_ov044_02111314 is a FUNCTION
+# and mounting it would emit its code bytes under its own name. It is matched
+# src (slice_w7c.txt) and runs from the registry fill.
+#
+# ==== THE SPAWNINFO PACK ===================================================
+# dsd split the 0x021115e0 record into three data symbols; --pack puts the ROM
+# spacing back (the ov060 SpawnInfo shape). Sizes are next-symbol deltas:
+# 0x021115e0 +4, 0x021115e4 +0x10, 0x021115f4 +0x10 -> one contiguous
+# 0x021115e0..0x02111604 run. The last word of it (0x02111600) is the excluded
+# vtable's typeinfo-pointer header; it is carried for spacing and nothing reads
+# it by name.
+OrangeBallBillboard_SpawnInfo data_ov044_021115e4 data_ov044_021115f4
+
+# ==== THE TWO BSS CELLS ====================================================
+# .bss is 0x02111680..0x021116a0 (delinks.txt), two symbols, both zero in the
+# ROM and both written at runtime:
+#   0x02111680  the class's SharedFilePtr (8 bytes, next-symbol delta) --
+#               __sinit_ov044_02111314 constructs it on handle 1570,
+#               InitResources loads the model through it, CleanupResources
+#               releases it. The host PortSharedFilePtr (hal/fs.cpp) is 8 bytes
+#               too, so the delta is exact.
+#   0x02111688  the static-destructor chain node func_020731dc links (0x18 by
+#               section end -- the LAST symbol of the section, so the size is
+#               the section end and not a 4-byte fallback: the ov018
+#               ICE_SLIDE_MANAGER trample is what that rule exists for). The
+#               node is three host pointers = 12 bytes, comfortably inside 0x18.
+data_ov044_02111680
+data_ov044_02111688:0x18

--- a/port/slice_w7c.txt
+++ b/port/slice_w7c.txt
@@ -1,0 +1,47 @@
+# slice_w7c.txt -- lane-owned slice for the linkage campaign (run linkw,
+# wave 7, lane w7-c: the other two boss arenas). One matched src TU per line,
+# path relative to the repo root, comments with #. ONE OWNER (lane w7-c).
+#
+# What this slice wires: ov044's single class, daObjKb1Billboard_c /
+# OrangeBallBillboard (id 301), the sixteen orange balls that ring Bowser in
+# the Dark World's arena -- level 36's only cast item that was not already
+# registered. Level 40's three ids (167 / 279 / 284) are all ov060 and all
+# landed in wave 6, so that arena needs no slice at all.
+#
+# ONE TU HELD OUT, for a measured reason:
+#   src/_ZN19OrangeBallBillboardD1Ev.cpp -- a real MSVC destructor over a
+#     SHADOW class declared inside its own .cpp, so MSVC emits
+#     ??1OrangeBallBillboard@@UAE@XZ and auto-generates calls to
+#     ??1Model@@QAE@XZ and ??1Actor@@UAE@XZ, which exist nowhere in this build.
+#     The BigBooIcon / HauntedChair / SPIKE_BOMB case. Slot 16 is the host
+#     thunk obb_d1 in hal/actor_classes_ov044.cpp, which is exactly what the
+#     matched sibling D0 spells minus Memory::Deallocate; relocs.txt pins the
+#     chain (0x021111cc load 0x02111604, 0x021111b4 call 0x02016d20
+#     Model::~Model, 0x021111bc call 0x020112c8 Actor::D2, nothing else).
+#
+# CLOSURE, walked from relocs.txt rather than assumed. Every arm9 callee the
+# seven wired TUs reach is ALREADY in the link, so this slice drags nothing in:
+#   Model::~Model 0x02016d20 / Actor::D2 0x020112c8 / Memory::Deallocate
+#   0x0203c1e8 / Matrix4x3_FromRotationY 0x0203bd6c / SharedFilePtr::Release
+#   0x02017b64 / Model::LoadFile 0x02017a3c / ModelBase::SetFile 0x02016fd4 /
+#   ActorBase::operator new 0x02043444 / Actor::C2 0x0201150c / Model::C1
+#   0x02016d58 (slice_gate4b, slice_gate9) and the two sinit veneers
+#   func_02017acc / func_02017ab4, which are HOST bodies in hal/cxx_aliases.cpp
+#   -- the ARM-r1 fileID ride-through the one-arg matched veneers cannot
+#   express. func_020731dc (the static-dtor chain link) is matched src and
+#   already in slice_gate10.txt.
+#
+# THE SINIT: __sinit_ov044_02111314 is a FUNCTION, so it is linked here and
+# CALLED from the registry fill (port_ov44_bringup) -- the ov045/ov060
+# lane-ownership shape, because no lane owns hal/actor_overlays.cpp this wave.
+
+src/OrangeBallBillboard_Spawn.c
+src/_ZN19OrangeBallBillboard13InitResourcesEv.c
+src/_ZN19OrangeBallBillboard16CleanupResourcesEv.c
+src/_ZN19OrangeBallBillboard6RenderEv.cpp
+src/_ZN19OrangeBallBillboardD0Ev.c
+src/func_ov044_02111214.c
+src/__sinit_ov044_02111314.c
+
+# the registry row / vtable fill / host D1 / cross-overlay alias host file
+port/hal/actor_classes_ov044.cpp

--- a/port/tools/battery.py
+++ b/port/tools/battery.py
@@ -26,7 +26,7 @@ import sys
 
 # Every mounted level, port_level_table[] in hal/level_boot.cpp -- a new
 # level mount adds its id here or the battery silently under-tests.
-LEVELS = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 37, 38)
+LEVELS = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 36, 37, 38, 40)
 SELFTEST_FRAMES = "300"
 STEP_TIMEOUT = 600
 


### PR DESCRIPTION
External-contributor lane from the second coordination site (campaign handoff operation; the primary site's reservations respected — `port/tests/walk_window.cpp` and `port/ntr/` untouched, which is load-bearing for the one declined id below).

## What this is

LEVELS 36 AND 40 (target-menu item 3): the two remaining koopaN_boss arenas mounted in `port/hal/level_boot.cpp` by the landed level-38 recipe, plus level 36's cast (one new class, id 301 ORANGE_BALL_BILLBOARD, ov044). Level 40 needed no new class — its 167/279/284 are ov060 classes landed in wave 6 — but running its table for the first time exposed a real pre-existing harness-order fault (below).

Five commits from `daeeb9b2`: mounts (`dbfdc079`), the ov044 cast (`d0a50905`), the level-40 id-167 decline (`5d6e92ad`), the dedicated CMake wiring commit (`15be33e7`, the reviewed tip), and one review-ordered comment-only fixup (`3e89d876`, banner correction; rebuilt and re-gated — control 300 exact, linkage 4630, guards green).

## Headline numbers

| | linkage | map |
|---|---|---|
| base `daeeb9b2` | 4623 (41.1%) | 2,523,451 B |
| tip | **4630 (41.2%)**, +7 = exactly the `slice_w7c.txt` TUs, reach verified in-map | 2,530,820 B |

Censuses: all seven pins byte-identical (L2 64/10, L12 136/4, L13 187/1, L14 180/29, L15 55/1, L37 109/6, L38 17/0). NEW: **L36 = 31/0** (ids 191, 278, 279, 280, 284 x8, 301 x16, 332, 334, 335 — matching the ROM object-table prediction exactly), **L40 = 12/10** (10 skips all id 167, deliberate). 19-level sweep exit 0 under FAULTS_FATAL; heap 241592 everywhere; battery ALL GREEN; both save-state reproducers PASS; all guards green; ptr_audit 0. Full gate tables in both reports below.

## The two mount rows (evidence chains re-derived twice)

Both derived from the ROM's own tables and re-derived by the independent reviewer from fresh dumps, every value agreeing: `data_020758c8[36]`=44 / `[40]`=48 (the level+8 layout confirmed by dumping all 52 words — contiguous 8..59, zero exceptions; the 17 landed rows reproduce 17/17), LVL_Overlay `0x021113b0` (koopa1_boss, handles 0x076b/0x0769/0x076c/0x076d, course 15) and `0x02111624` (koopa3_boss, 0x0787/0x0785/0x0788/0x0789, course 17), all eight handles resolving through `build/assets/handles.tsv` with sizes verified, runtime corroborating (`Stage::LoadModel, handle 1899` / `1927`).

## The one new class (id 301, ov044)

Both attribution tests (spawnFunc `0x021112dc` inside ov044's window AND id halfword 301); the reviewer additionally swept every overlay whose window contains the SpawnInfo — only ov044 passes both (ov057 passes the window test but reads id 270: the exact trap the two-test law exists for). Identity from RTTI (`19daObjKb1Billboard_c`), corroborated by the sinit's asset handle (kb1_ball.bmd). Vtable width 31 pinned four ways. D1/D0 stated in ROM/Itanium numbering, settled by the Deallocate-bearing body; slot 16 is a host thunk because the matched D1 TU is a shadow-class MSVC destructor that cannot link on host (documented in the file). All 31 seats verified word-for-word against the ROM by the reviewer.

## The level-40 id-167 decline (the real find)

BOWSER_SKY_PLATFORM (167) is placed ONLY on level 40 in the entire ROM (all 52 object tables swept — twice, worker and reviewer). Wave 6 registered its class; this lane ran it for the first time and it faults: `CopyTexPalFromLevelModel` reads `data_0209f320->entries` (+0x04) with a null base. `data_0209f320`'s only writer is `Stage::LoadModel`'s last line; the ROM's `Stage::InitResources` calls LoadModel (:361) BEFORE LoadClsnAndObjects (:363), while the `walk_window` harness inverts the order (boot :2099, LoadModel :2265; change path :4382) — confirmed by print order on two independently built trees, and the fault reproduced end-to-end by the reviewer with an identical resolved stack.

A compensating early LoadModel in lane-owned code is impossible: `func_02016ff4` → `Model::UpdateFileOffsets` rebases BMD offsets IN PLACE unconditionally, so a second LoadModel pass corrupts the level model on every level (verified in code by both worker and reviewer).

**The fix is one line in `port/tests/walk_window.cpp`** — hoist the LoadModel call above the boot, the ROM's own order — **which is reserved by the primary site** (an active window/present lane is mid-flight there). Until then 167 is declined via the registry's existing `port_host_abi_blocked` hook, scoped `id == 167 && port_level_id() == 40`, with the census naming the ten skipped platforms rather than faking them. Nothing else moves.

## Independent review verdict: MERGE-WITH-NOTES

All claims CONFIRMED after from-scratch rebuilds of base and head; the reviewer strengthened several (fourth width pin; adversarial attribution sweep; the fault reproduction; independent object-table walks reproducing both censuses exactly). Notes, all addressed or carried:

1. The vtable-comparison banner's slot-12 sentence was factually wrong (slot 12 is the SAME word in both tables; the differing set is {0,3,6,9,16,17}) — **fixed in `3e89d876`**, comment-only, re-gated.
2. "Byte-identical" census/control stdout more precisely = identical apart from host-static address lines (the `.dsstate` span moves when TUs land) — restated here.
3. The canonical cross-area save-state spelling should include `SM64DS_SS_ASSERT=1` (without it the reproducer passes silently instead of printing PASS) — recommendation for the primary site's gate notes.
4. Trial-merge with lane w7-b (`git merge-tree`): **0 conflicts** on the shared `CMakeLists.txt` / `actor_classes.inc` — land in either order.
5. Repo-wide, per-class trap reporters use `port_actor_slot_decline(msg)` rather than the `_for(self, …)` variant that `actor_classes.cpp` itself documents as better for slots 20..31; this lane followed house style — flagged as a separate ticket for the primary site.

Setup facts for reproduction: `extracted/dsd/files/files.txt` must exist (`python port/tools/ntr_manifest.py`) or `smoke_gx` exits 2 — a second-site setup gap traced this session, not a lane effect. This site builds via a local mirror of `build-port.cmd` (VS2022 Preview paths, same guards/flags); `battery.py` run with `--skip-build`. `port/tools/battery.py` here gains levels 36/40 in `LEVELS` so the sweep exercises the new mounts.

Coordinator's cross-checks: the mount-table words and SUBLEVEL bytes re-derived from a third independent dump before review; tip linkage re-measured on the lane's own map (4630, 2,530,820 B).

---

# Worker evidence report (lane w7c, verbatim)

Both arenas are mounted, level 36's cast is landed, and level 40 boots with one measured blocker.

## 1. Linkage, from my own maps

| | map size | linked into walk_window |
|---|---|---|
| base (daeeb9b2, clean rebuild) | 2,523,451 B | **4623** (41.1%) |
| tip (15be33e7) | 2,530,820 B | **4630** (41.2%) |

+7 = exactly the seven matched src TUs in `slice_w7c.txt`. Both maps non-truncated. /OPT:REF reach verified by content in my map: `actor_classes_ov044` (37 hits), `OrangeBallBillboard_Spawn`, `..13InitResourcesEv`, `..16CleanupResourcesEv`, `..D0Ev`, `func_ov044_02111214`, `__sinit_ov044_02111314`, `ov044_syms`, `ov044_data`, `ov048_data`.

## 2. The two mount rows — full ROM chains

Pipeline re-validated first: all 52 words of `data_02092208` dumped, checked against the 17 landed rows — 17/17 exact.

Level 36 → ov044, LVL_Overlay 0x021113b0, koopa1_boss, course 15: `data_020758c8[36]` @0x02075958 = 0x2c (overlay 44); `data_02092208[36]` @0x02092298 = 0x021113b0; LVL_Overlay+0/+4 (overlay_0044.bin off 0x210) = clps 0x021113cc, objTable 0x02111374; handles +8/+a/+c/+e = 0x076b/0x0769/0x076c/0x076d → handles.tsv delta 0 → koopa1_boss_all.bmd (1899, 4411 B) / koopa1_boss.kcl (1897, 1624) / _icg (1900, 13728) / _icl (1901, 512); +0x10/+0x14/+0x15 = subTables 0x0211137c, subCount 1, flags 0; `SUBLEVEL_LEVEL_TABLE[36]` @0x020752bc = 0x0f = course 15.

Level 40 → ov048, LVL_Overlay 0x02111624, koopa3_boss, course 17: `data_020758c8[40]` @0x02075968 = 0x30 (overlay 48); `data_02092208[40]` @0x020922a8 = 0x02111624; LVL_Overlay (overlay_0048.bin off 0x484) = clps 0x02111780, objTable 0x021115ac; handles 0x0787/0x0785/0x0788/0x0789 → koopa3_boss assets (7228/1889/15028/512 B); subCount 1, flags 0; `SUBLEVEL_LEVEL_TABLE[40]` @0x020752c0 = 0x11 = course 17.

The level+8 is a READ, not an assumption: all 52 words dumped, contiguous 8..59, no exceptions. Both overlays are compressed:true, so handles came from `extracted/overlays/overlay_00NN.bin`, never the dsd export. Controls: the same reads reproduce ov046/0x02111560/koopa2_boss and ov045/0x021124d4/koopa2_map byte for byte.

## 3. Census table (all under FAULTS_FATAL=1, 300 frames, rc=0, heap 241592 everywhere)

L1 82/0, L2 64/10 (pin), L3 53/0, L4 47/3, L5 64/4, L6 200/0, L7 190/0, L8 194/21, L9 14/2, L10 122/4, L11 84/0, L12 136/4 (pin), L13 187/1 (pin), L14 180/29 (pin), L15 55/1 (pin), L37 109/6 (pin), L38 17/0 (pin) — all identical base→tip. NEW: L36 not-mounted → **31 spawned / 0 skipped**; L40 not-mounted → **12 spawned / 10 skipped**.

Per-id arithmetic, derived from the ROM before the run (objTable walk: count@+0, entries@+4, stride 8; Standard entries stride 16; ids through `data_ov002_0210cbf4`; model calibrated on level 38's pin = 11 table objects + PLAYER/CAMERA/HUD/MINIMAP + Bowser's two unchecked init children (278, 280) = 17 ✓):
- L36 table = 279 x1, 284 x8, 301 x16 = 25; +4 harness +2 Bowser children = 31. Measured 31, ids exactly: 191 x1, 278 x1, 279 x1, 280 x1, 284 x8, 301 x16, 332 x1, 334 x1, 335 x1.
- L40 table = 167 x10, 279 x1, 284 x5 = 16; +4 +2 = 22 predicted, −10 declined 167 = 12/10. Measured exactly that. (Cross-checks: the ov060 comment's "exactly EIGHT id-284" on level 38 and the registry's "167 is level 40's floor (not placed in 38)" both reproduce.)

## 4. Gate table

baseline reproduces before any edit (4623; control pos exact) PASS; control 300 at tip exact rc 0 PASS; ctrl300 stdout vs base: 1 line differs, `[reg] 174 → 175 actor classes registered` (intended) PASS; soak 1000 exact PASS; 7 pinned censuses identical PASS; levels 36/40 boot rc 0 under FAULTS_FATAL PASS; full 19-level sweep all rc 0 PASS; heap 241592 on all 19 PASS; linked floor 4630 ≥ 4623 PASS; ptr_audit 0 PASS; closestplayer OK 4747 TUs PASS; inferred_stub 2 live = baseline PASS; dsstate OK 5592 symbols 376112 B PASS; alternatename OK 1367 directives 0 new defeats PASS; save-state same-area PASS; save-state cross-area (EXIT_ENTER=0,58, SS_EXPECT_MOUNT=1) PASS; smokes 17/18 at first — `smoke_gx` rc=2 pre-existing (missing extracted/dsd/files/files.txt manifest; binary dated to the baseline build; not a lane effect), 18/18 after the manifest was generated; battery run by hand past its first-red stop, all remaining steps green.

## 5. Commits (branch port-w7c-arena, base daeeb9b2, no pushes at report time)

```
dbfdc079  w7-c: mount levels 36 and 40, the other two koopaN_boss arenas
d0a50905  w7-c: ORANGE_BALL_BILLBOARD (301, ov044) -- level 36's arena cast
5d6e92ad  w7-c: decline id 167 on level 40 (host boot-order limit), sweep 36/40
15be33e7  w7-c: CMake wiring for the two arena mounts and the ov044 cast   <- reviewed tip
```
`git diff daeeb9b2..HEAD -- src/` → 0 bytes at every commit. 8 files, +734/−5.

The cast (level 36): level 40 needed no new class (167/279/284 all ov060, landed wave 6). Level 36 needed exactly one: id 301 — spawn table 0x02090864 + 301*4 = 0x02090d18 → 0x021115e0, word[0] 0x021112dc inside ov044's window (0x021111a0..0x02111680, ram_size 1248) AND word[1]&0xffff = 0x012d = 301: both attribution tests. Identity from RTTI, not the label: vtable[−1] (0x02111600) → typeinfo 0x021115bc → name `19daObjKb1Billboard_c`; the asset agrees independently (sinit handle 1570 = kb1_ball.bmd). Width 31, pinned twice (31-word reloc run 0x02111604..0x0211167c with nothing at 0x02111680; .data ends at 0x02111680 where .bss starts). Slots 1,2,4,5,7,8,10–15,18–30 are word-for-word `_ZTV18BowserFireSeaArena`'s; own slots 0/3/9/16/17; slot 6 inherited `ActorBase::Behavior`, slot 12 `ActorBase::OnPendingDestroy`. D1/D0: dsd's Itanium numbering, settled by the ROM (0x021111d0 ends in Memory::Deallocate, 0x021111a0 does not) → D1 at 16, D0 at 17. One TU held out — `_ZN19OrangeBallBillboardD1Ev.cpp` is a real MSVC destructor over a shadow class (would auto-call absent `??1Model@@` / `??1Actor@@`); slot 16 is host thunk `obb_d1`, the matched D0's chain minus the Deallocate, pinned by relocs. One cross-overlay spelling aliased: InitResources reaches the SharedFilePtr as `data_ov059_02111680` while its sibling and the sinit spell it `data_ov044_02111680` — silent corruption if missed, not a link error.

## 6. Blocked

1. BOWSER_SKY_PLATFORM (167) on level 40 — blocked on `port/tests/walk_window.cpp` (reserved). Fault chain, order inversion, non-idempotence of a compensating LoadModel, and the level-40-only decline as detailed in the PR summary above.
2. `smoke_gx` — blocked on the extraction tree, not code (files.txt manifest; resolved by the coordinator as a setup step).

Two files edited that were neither owned nor forbidden, flagged for the merge: `port/hal/actor_classes.inc` (the registry row — the only seam; tail append, collision-free) and `port/tools/battery.py` (LEVELS gains 36 and 40, which the full-sweep requirement demands). `port/hal/actor_registry.cpp` carries the level-40 decline in the hook that exists for exactly this.

---

# Independent review verdict (verbatim)

## Verdict: **MERGE-WITH-NOTES**

Per-claim findings:

**Claim 1 — L36/L40 mounts — CONFIRMED (every byte re-dumped from my own extracted/).** `data_020758c8[36]` @0x02075958 = 0x2c = ov44; `[40]` @0x02075968 = 0x30 = ov48; all 52 words contiguous 8..59, zero exceptions to level+8; 17 landed rows vs my dump 17/17 exact; `data_02092208[36]` = 0x021113b0, `[40]` = 0x02111624; SUBLEVEL[36] = 0x0f course 15, [40] = 0x11 course 17; ov44/ov48 bases both 34673056 = 0x021111a0 (ram 1248/1888, bss 32/0). LVL_Overlay+8 raw from the compressed-source images at offsets 0x210/0x484 exactly as claimed; all eight handles resolve in handles.tsv to koopa1_boss / koopa3_boss bmd·kcl·icg·icl with the exact claimed byte sizes. Runtime corroborates: L36 logs `Stage::LoadModel, handle 1899`, L40 `handle 1927`.

**Claim 2 — ORANGE_BALL_BILLBOARD — CONFIRMED, attribution strengthened.** Spawn-table chain reproduced; RTTI chain reproduced (wording note: vtable[-1] holds the typeinfo record pointer, the name is one hop further; the file body describes the chain correctly). Independent corroboration: `__sinit_ov044_02111314` constructs on handle 1570 = kb1_ball.bmd. Width 31 pinned FOUR ways (reloc run; `data_ov044_02111680 kind:bss`; last word = `Actor::OnAimedAtWithEggReturnVec`, vtspan's documented 31-slot signature; generated `pk044_gap_02111604[124]` = 31×4); `vtspan --sweep`: 0 tables short, ov044 31/31. D1/D0 confirmed and settled by dsd names too (slot 16 → `_ZN19OrangeBallBillboardD1Ev` @0x021111a0, slot 17 → D0 @0x021111d0; the Deallocate reloc is inside D0 only). All 31 seats verified against the ROM words. The held-out D1 TU is indeed a shadow-class MSVC destructor that cannot link on host; it is absent from the head map; `obb_d1` reproduces the ROM chain exactly. My own adversarial attribution test: of every overlay whose window contains 0x021115e0, only ov044 passes both tests — ov057 passes the window test but its id halfword reads 270, not 301.

**Claim 3 — linkage — CONFIRMED.** My base 4623 (map 2,523,447 B), head 4630 (2,530,816 B), Δ +7,369 B identical to claim; the 4-byte absolute difference is the build-tree path embedded as a mangled string literal from fs.cpp.obj — environment, not substance. I enumerated the added objects by diffing the maps: 11 added, 0 removed — the 7 slice TUs, actor_classes_ov044.cpp, and the three generated data/syms TUs; D1Ev.cpp correctly absent. Closure re-walked from relocs.txt: all 14 arm9 targets the eight ov044 functions reach are already in the base map — the slice drags nothing in.

**Claim 4 — censuses — CONFIRMED, one precision correction.** All seven pins match and are identical base↔head; precisely, one line differs in each — the camera host-static address line (`.dsstate` grew when the TUs landed; hosted-static addresses necessarily shift). With that line excluded, full stdout is 0 diff lines on all seven. L36 = 31/0 with the exact claimed id set; L40 = 12/10, all skips 167. I re-derived both object tables from the ROM myself: L36 25 entries (279/284×8/301×16), L40 16 entries (167×10/279/284×5); the census arithmetic checks out exactly.

**Claim 5 — the 167 decline — CONFIRMED, reproduced end to end.** Re-enabled 167 in a throwaway edit on my own build: `FAULT c0000005 at +0x0008e07f accessing 00000004, eax=00000000`, stack resolved against MY map with identical offsets (`_CopyTexPalFromLevelModel+0xf <- _func_ov060_021182b0+0x44 <- skyplat_init+0x6 <- Actor::Spawn+0x27 <- LoadStandardObjects+0x73 <- LoadObjects+0x43 <- Stage::LoadClsnAndObjects+0x97 <- port_stage_a_boot+0x211 <- main+0x797`). Supporting reads verbatim: `CopyTexPalFromLevelModel`'s first line loads `data_0209f320->entries` (+0x04, matching the fault address with a null base); `data_0209f320`'s only src/ setter is `Stage::LoadModel`'s last line; ROM `Stage::InitResources` :361 LoadModel before :363 LoadClsnAndObjects; harness :2099 boot before :2265 LoadModel (change path :4382); print-order witness reproduces at the same line numbers (census line 31, LoadModel line 59). Non-idempotence confirmed: `func_02016ff4` calls `Model::UpdateFileOffsets` unconditionally and it rebases `file.bones` in place. Scoping verified independently: across all 52 levels' object tables, 167 appears ONLY on level 40, exactly ×10; the guard is exactly `id == 167 && port_level_id() == 40`. Throwaway edit reverted, tree rebuilt clean at 15be33e7, L40 back to 12/10, linkage 4630.

**Claim 6 — gates — CONFIRMED, all re-measured on my builds.** Control 300 exact at base and head; soak 1000 exact; 19/19 sweep exit 0; heap 241592 on all 19; smokes 18/18 at base AND head (after ntr_manifest.py); battery ALL GREEN --linked-floor 4623 (linkage 4630, ptr_audit 0); closestplayer OK 4747; inferred_stub 2=baseline; dsstate OK 5592; alternatename 911 fired, 0 new defeats; vtspan --sweep 0 short; ovsweep 0 raw cross-mount words; save-state same-area and cross-area PASS (cross-area non-vacuous: pre-load hash differed, post-load restored). Corrections: the control stdout diff is TWO lines (the [reg] line plus the host-static camera line); the brief's cross-area spelling omits SM64DS_SS_ASSERT=1 and then passes silently — with the assert added it prints PASS explicitly; recommend adding it to the canonical spelling.

**Claim 7 — ownership — CONFIRMED.** src/, include/, config/, root tools/ diffs empty; every changed path under port/ (8 files); CMake wiring one dedicated tip commit; nothing pushed at review time; reflog clean, no amends. The two flagged extras are sound: the .inc edit is a pure tail append at the only registration seam; battery.py's LEVELS addition is required or the sweep silently under-tests (confirmed the battery exercises both new levels).

**Findings the worker missed:**
1. The actor_classes_ov044.cpp vtable-comparison banner's slot-12 sentence is wrong — slot 12 is 0x02043ac0 in BOTH tables; differing slots are {0,3,6,9,16,17}; the comment also self-contradicts (lists 10..15 as same-range AND 12 as differing). The seats themselves are correct; documentation-only. [Coordinator: fixed in 3e89d876, comment-only, re-gated.]
2. Contention with lane w7-b is benign: `git merge-tree` on the two lane tips → 0 conflict markers on the shared CMakeLists.txt / actor_classes.inc (w7-b inserts mid-file, w7-c appends at tail). Land in either order.
3. Pre-existing repo-wide gap, not this lane's: per-class trap reporters use `port_actor_slot_decline(msg)` rather than the `_for(self, …)` variant `actor_classes.cpp` documents as better for slots 20..31 (this lane traps slot 30). Every per-class file shares the pattern; separate ticket.
4. The `Actor::After*` → `ActorBase::After*` seats (slots 5/8/11) are equivalent, not mis-seats: the src TU is a tail-call veneer; 141 uses repo-wide.

**Housekeeping:** nothing modified on port-w7c-arena, nothing pushed by the review; throwaway edit reverted; both review worktrees left in place with built artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
