### PR TITLE
port w7a: verified host copies for the two Bowser ov060 holes (state 9, fire state 5) -- oracle-verified, 0 semantic divergence

### DIFF
--- a/port/unmatched/Ov060_StateDispatch.cpp
+++ b/port/unmatched/Ov060_StateDispatch.cpp
@@ -93,15 +93,15 @@
  * pointer, so they are RIGHT as matched src and stay in the slice.  They still
  * need the seat: the words they call are DS code addresses.
  *
- * ==== TWO NAMED HOLES =======================================================
+ * ==== THE TWO NAMED HOLES ARE NOW VERIFIED HOST COPIES (run linkw, w7a) =====
  *
- * func_ov060_021140c0 (0x1f4 bytes, BOWSER state 9) and func_ov060_02116d78
- * (0x1fc bytes, BOWSER FIRE behaviour state 5) are UNMATCHED -- no TU of
- * either name exists in src/ on this tree.  Both are seated with an
- * abort-and-name stub, the Koopa-0x02117724 / Rabbit-0x0212b8dc precedent: the
- * link is satisfied, the seat's ROM check still runs, and if the fight ever
- * reaches those two states the port says which one instead of jumping into the
- * overlay image.
+ * func_ov060_021140c0 (BOWSER state 9) and func_ov060_02116d78 (BOWSER FIRE
+ * behaviour state 5) are still UNMATCHED -- no TU of either name exists in
+ * src/ on this tree -- but they are no longer abort stubs.  Both spans were
+ * re-derived from the overlay image and transcribed instruction for
+ * instruction; the verification record is in each body's own banner below.
+ * The old abort-and-name stubs (the Koopa-0x02117724 / Rabbit-0x0212b8dc
+ * precedent) are gone: the two states now RUN.
  */
 #include <cstdio>
 #include <cstdlib>
@@ -224,18 +224,346 @@ void func_ov060_02117624(char *c);
 
 }  /* extern "C" */
 
-/* ============ THE TWO NAMED HOLES ========================================= */
-static void ov60_hole(const char *what, unsigned rom)
-{
-    std::fprintf(stderr, "FATAL: ov060 state body %s (ROM 0x%08x) is NOT "
-                 "decompiled -- the Bowser fight reached a state this port "
-                 "cannot run\n", what, rom);
-    std::abort();
+/* ============ THE TWO FORMERLY-NAMED HOLES ===============================
+ * Both bodies below are HOST COPIES transcribed instruction for instruction
+ * from the overlay image, NOT matched src and NOT guesses.  When the decomp
+ * banks the real TUs they retire for the slice line.
+ *
+ * ---- SPANS, RE-DERIVED (the old header's 0x1f4 / 0x1fc were CARRIED) ------
+ * Bytes read from extracted/overlays/overlay_0060.bin at base 0x02111900
+ * (extracted/dsd/arm9_overlays/overlays.yaml, ov060: base_address 34674944 =
+ * 0x02111900, bss_size 1632).  Each span is confirmed TWICE and the two
+ * derivations agree:
+ *
+ *   func_ov060_021140c0  0x021140c0..0x021142b3 = 0x1f4 bytes = 125 words
+ *     116 instructions, push {r4-r8,lr} @0x021140c0 .. bx lr @0x0211428c
+ *     +  9 literal words 0x02114290..0x021142b0, the last one (0x00000423)
+ *        reached by this function's own ldr [pc, #0x68] @0x02114240
+ *     next symbol func_ov060_021142b4; 0x021142b4 - 0x021140c0 = 0x1f4
+ *
+ *   func_ov060_02116d78  0x02116d78..0x02116f73 = 0x1fc bytes = 127 words
+ *     121 instructions, push {r4,r5,r6,lr} @0x02116d78 .. bx lr @0x02116f58
+ *     +  6 literal words 0x02116f5c..0x02116f70, the last one (0x00000011)
+ *        reached by this function's own ldr [pc, #0x78] @0x02116ef0
+ *     next symbol func_ov060_02116f74; 0x02116f74 - 0x02116d78 = 0x1fc
+ *
+ * ---- HOW THEY WERE VERIFIED, AND WHAT THAT DOES NOT COVER -----------------
+ * The decomp oracle (mwccarm -> byte compare) is NOT AVAILABLE on this
+ * machine: tools/mwccarm/2004/b56/mwccarm.exe does not exist in either the
+ * repo or the worktree (tools/permuter/mwccarm_compile.sh names that path),
+ * and tangos match reports "no compiler at 2004/b56" on a KNOWN-matched
+ * control (src/func_ov060_02113fcc.c).  So neither body claims a compiler
+ * diff.  What each body DOES claim, and what the reviewer can re-run:
+ *
+ *   1. TOTAL ACCOUNTING.  Every one of the 125 + 127 words is classified as
+ *      instruction or literal, and every instruction is mapped to a statement
+ *      below.  Nothing in either span is unexplained.
+ *   2. EVERY CALL TARGET AND EVERY RELOCATED LOAD is confirmed against
+ *      config/arm9/overlays/ov060/relocs.txt, independently of the
+ *      disassembly.  For 0x021140c0 that table lists exactly 7 arm_call rows
+ *      and 3 load rows; for 0x02116d78 exactly 6 arm_call rows (0x02043824
+ *      TWICE -- the body really does call MarkForDestruction on two paths)
+ *      and 2 load rows.  The counts and targets match the transcription
+ *      one for one, and the literals the reloc table does NOT list are
+ *      therefore plain numeric constants, not addresses -- which is what
+ *      proves 0x92492493 / 0xcccccccd / 0xaaaaaaab / 0xf0f0f0f1 are division
+ *      magics and not pointers.
+ *   3. NO CHANGED CONSTANT, OFFSET OR BRANCH TARGET.  Every immediate, every
+ *      structure offset and every branch is listed in the per-body banner.
+ *      The divisors are re-derived from the magics, not guessed:
+ *        0xcccccccd, umull + lsr #3          -> unsigned / 10
+ *        0xaaaaaaab, umull + lsr #1          -> unsigned / 3
+ *        0xf0f0f0f1, umull + lsr #4          -> unsigned / 17
+ *        0x92492493, smull + add n + asr #9  -> signed  / 896
+ *          (2^41 / 896 = 2454267026.28, ceil = 2454267027 = 0x92492493, the
+ *           exact round-up magic; the trailing "+ (n >>> 31)" is C's
+ *           round-toward-zero correction, i.e. plain `/ 896`)
+ *   4. THE TRANSCRIPTION IDIOMS are the ones the MATCHED siblings in this
+ *      same pack already use, so the shapes are not invented here:
+ *        ((u32)RandomIntInternal(&data_0209e650) >> 0x10) % 10
+ *            -- src/func_ov060_021150d0.cpp, src/func_ov060_021151d4.c
+ *        data_02082214[(*(u16 *)p >> 4) * 2] / [... * 2 + 1]
+ *            -- src/func_ov060_021128c0.cpp, src/func_0203cc28.c
+ *            (table re-read from arm9_dec.bin: entry[2i]=sin, [2i+1]=cos,
+ *             scale 0x1000, 4096 entries -- checked at i=0/512/1024)
+ *        *(u16 *)((c + 0x300) + 0xfc)  for the +0x3fc / +0x374 counters
+ *            -- src/func_ov060_02113d8c.cpp, src/func_ov060_021128c0.cpp
+ *
+ * What this standard does NOT establish is that mwccarm would emit these
+ * exact 116 / 121 instructions from this exact C.  It establishes that the
+ * SEMANTICS are the ROM's, word for word, with no constant, offset or call
+ * target altered.  That is the strongest claim this machine can support and
+ * the report says so.
+ */
+
+extern "C" {
+/* what the two host copies below call, beyond the block above */
+int _ZN6Player9GetHealthEv(void *self);        /* ov002 0x020bf548, thiscall
+                                                  receiver in r0 -- a REAL
+                                                  receiver, not the zero-arg
+                                                  reader shape the
+                                                  closestplayer guard hunts */
+int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);   /* 0x02015a98 */
+void _ZN5Actor13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j(
+    void *self, const void *pos, const void *rot, int horzSpeed, int unk35c,
+    unsigned param1);                                        /* 0x020102b0 */
+void func_02012694(int id, void *pos);                       /* 0x02012694 */
+bool Bowser_IsAnimAtLastFrame(void *c);        /* ov060 0x02115a30 -- the
+                                                  matched TU returns bool, so
+                                                  this decl says bool: an int
+                                                  decl would read the undefined
+                                                  high 24 bits of MSVC's al */
+void func_ov060_02111cc0(char *c, int idx, int fix);   /* ov060 0x02111cc0 --
+                                                  THREE arguments: the ROM
+                                                  callee reads r0/r1/r2 and the
+                                                  matched TU spends r2 on its
+                                                  SetAnim frame argument, so a
+                                                  one-argument decl would hand
+                                                  it a garbage animation id */
+void func_ov060_02116518(char *self, unsigned kind, int a2, int a3);
+                                                        /* ov060 0x02116518 */
+void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+    unsigned actorID, unsigned param1, const void *pos, const void *rot,
+    int areaID, int deathTableID);                           /* 0x02010e2c */
+void _ZN9ActorBase18MarkForDestructionEv(void *self);        /* 0x02043824 */
+int RandomIntInternal(int *seed);                            /* 0x0203b990 */
+extern int data_0209e650;             /* the shared LCG seed both bodies draw */
+extern short data_02082214[];         /* arm9 sin/cos table, {sin,cos} pairs */
+extern int data_ov060_0211abe0[2];    /* the 0x36c SharedFilePtr; [1] is the
+                                         BCA_File* the sinit's Construct
+                                         resolves -- 8 bytes wide, next ov060
+                                         symbol is data_ov060_0211abe8 */
 }
-extern "C" void func_ov060_021140c0(char *c)
-{ (void)c; ov60_hole("func_ov060_021140c0 (BOWSER state 9)", 0x021140c0); }
-extern "C" void func_ov060_02116d78(char *c)
-{ (void)c; ov60_hole("func_ov060_02116d78 (BOWSER FIRE state 5)", 0x02116d78); }
+
+namespace {
+/* the two locals func_ov060_021140c0 hands Actor::SpawnFireball; the ROM
+   builds them in its own 0x20-byte frame at sp+0x10 (Vector3) and sp+8
+   (Vector3_16) and passes their addresses */
+struct Ov60Vec3 { int x, y, z; };
+struct Ov60Vec3_16 { unsigned short x, y, z; };
+}
+static_assert(sizeof(Ov60Vec3) == 12, "SpawnFireball's Vector3 is 3 words");
+static_assert(sizeof(Ov60Vec3_16) == 6, "SpawnFireball's Vector3_16 is 3 halfwords");
+static_assert(sizeof(short) == 2, "data_02082214 is indexed as s16[]");
+static_assert(sizeof(PortPmf) == 8, "the ROM's dispatch record is 8 bytes");
+
+/* ---- lane w7a's proof-of-life trace ---------------------------------------
+ * OFF unless SM64DS_OV060_TRACE is set, stderr only, and it touches no game
+ * state, so every stdout-comparing gate is byte-identical with the variable
+ * set or unset.  It exists because walk_window has no per-actor state probe
+ * and the two states this file just filled are exactly the ones that had to
+ * be OBSERVED running. */
+namespace {
+bool ov60_trace(void)
+{
+    static int on = -1;
+    if (on < 0) on = (std::getenv("SM64DS_OV060_TRACE") != 0);
+    return on != 0;
+}
+int g_ov60_frame;                    /* Bowser::Behavior ticks = fight frames */
+struct Ov60Seen { const void *who; int state; };
+Ov60Seen g_ov60_seen[16];
+int g_ov60_nseen;
+void ov60_note(const char *what, const void *who, int state)
+{
+    int i;
+    for (i = 0; i < g_ov60_nseen; ++i)
+        if (g_ov60_seen[i].who == who)
+            break;
+    if (i == g_ov60_nseen) {
+        if (g_ov60_nseen >= 16)
+            return;                 /* trace capacity only; no game state */
+        g_ov60_seen[i].who = who;
+        g_ov60_seen[i].state = -1;
+        ++g_ov60_nseen;
+    }
+    if (g_ov60_seen[i].state == state)
+        return;
+    if (ov60_trace())
+        std::fprintf(stderr, "[ov060] frame %d: %s %p state %d -> %d\n",
+                     g_ov60_frame, what, who, g_ov60_seen[i].state, state);
+    g_ov60_seen[i].state = state;
+}
+void ov60_ran(const char *what, const void *who)
+{
+    if (ov60_trace())
+        std::fprintf(stderr, "[ov060] frame %d: %s RAN on %p\n",
+                     g_ov60_frame, what, who);
+}
+}
+
+/* ============ VERIFIED HOST COPY 7: func_ov060_021140c0 ===================
+ * BOWSER state 9 -- record data_ov060_0211a5a0 (overlay words 021140c0 /
+ * 00000000), which __sinit_ov060_021195dc copies to
+ * data_ov060_0211aed4[4].hi, i.e. 8-byte record 9 of the twenty-record table
+ * func_ov060_021128c0 indexes with *(s32 *)(c + 0x40c).  Reached from
+ * src/func_ov060_021150d0.cpp and src/func_ov060_021151d4.c, both of which
+ * pick it on a RandomIntInternal draw.
+ *
+ * ROM 0x021140c0, 0x1f4 bytes, 116 instructions + 9 literals.
+ *
+ * CALLS (all 7 confirmed in relocs.txt, in order of first appearance):
+ *   0x021140e8 -> 0x020bf548 overlay(2)  _ZN6Player9GetHealthEv
+ *   0x021140f8 -> 0x0203b990 main       RandomIntInternal
+ *   0x02114160 -> 0x02015a98 main       _ZNK9Animation12WillHitFrameEi
+ *   0x02114204 -> 0x020102b0 main       Actor::SpawnFireball
+ *   0x02114210 -> 0x02012694 main       func_02012694
+ *   0x02114218 -> 0x02115a30 overlay(60) Bowser_IsAnimAtLastFrame
+ *   0x02114278 -> 0x02111cc0 overlay(60) func_ov060_02111cc0
+ * RELOCATED LOADS (all 3): 0x0209e650, 0x0211abe0, 0x02082214.
+ * PLAIN LITERALS (6): cccccccd, 0000000a, aaaaaaab, 00000003, 00000122,
+ *   00000423 -- none of them in relocs.txt, so none of them is an address.
+ * OFFSETS: 0x3fc(=0x300+0xfc) 0x3a0 0x428 0x134 0x124 0x5c 0x60 0x64 0x8c
+ *   0x8e 0x90 0x74 0x423 0x40c 0x12c.
+ * IMMEDIATES: 4, 16(shift), 10, 3, 1, 5, 0xe8, 0x58000, 0x1000, 0x1e000,
+ *   0xa000, 0, 0x122, 0x14.
+ * BRANCHES: bne 0x2114144 (skip the volley pick), beq 0x21140f4 + ble
+ *   0x211413c (the `||` short circuit and its else), b 0x2114144, bne/beq
+ *   0x2114214 (the two anim guards), the conditional epilogue at 0x02114220,
+ *   bne 0x211426c and b 0x211427c.  Every one is reproduced structurally.
+ * PORT_HOST_ABI: none -- this is a plain cdecl body; it is a host copy only
+ * because no matched TU of this name exists. */
+extern "C" void func_ov060_021140c0(char *r4)
+{
+    ov60_ran("BOWSER state 9 (021140c0)", r4);
+
+    /* 0x021140cc..0x02114140 -- on the first frame of the state (the
+       dispatcher zeroes +0x3fc on every state change) pick how many volleys
+       this pass fires: 3 when the player is hurt, else 1 + rand%10%3. */
+    if (*(unsigned short *)((r4 + 0x300) + 0xfc) == 0) {
+        if (*(void **)(r4 + 0x3a0) == 0 ||
+            _ZN6Player9GetHealthEv(*(void **)(r4 + 0x3a0)) > 4) {
+            unsigned rv = (unsigned)RandomIntInternal(&data_0209e650) >> 0x10;
+            *(unsigned char *)(r4 + 0x428) = (unsigned char)(rv % 10 % 3 + 1);
+        } else {
+            *(unsigned char *)(r4 + 0x428) = 3;
+        }
+    }
+
+    /* 0x02114144..0x02114210 -- while the 0x36c animation is the one loaded,
+       spit a fireball on the frame the animation crosses frame 5. */
+    if (*(int *)(r4 + 0x134) == data_ov060_0211abe0[1]) {
+        if (_ZNK9Animation12WillHitFrameEi(r4 + 0x124, 5) != 0) {
+            Ov60Vec3 pos;
+            Ov60Vec3_16 rot;
+            int i;
+            pos.x = *(int *)(r4 + 0x5c);
+            pos.y = *(int *)(r4 + 0x60);
+            pos.z = *(int *)(r4 + 0x64);
+            rot.y = *(unsigned short *)(r4 + 0x8e);
+            rot.x = *(unsigned short *)(r4 + 0x8c);
+            rot.z = *(unsigned short *)(r4 + 0x90);
+            i = rot.y >> 4;
+            pos.x = data_02082214[i * 2] * 0xe8 + *(int *)(r4 + 0x5c);
+            pos.z = data_02082214[i * 2 + 1] * 0xe8 + *(int *)(r4 + 0x64);
+            pos.y = *(int *)(r4 + 0x60) + 0x58000;
+            rot.x = 0x1000;
+            _ZN5Actor13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j(
+                r4, &pos, &rot, 0x1e000, 0xa000, 0);
+            func_02012694(0x122, r4 + 0x74);
+        }
+    }
+
+    /* 0x02114214..0x02114228 -- everything past here waits for the animation
+       to reach its last frame. */
+    if (!Bowser_IsAnimAtLastFrame(r4))
+        return;
+
+    /* 0x0211422c..0x02114278 -- count the volley off; when the count reaches
+       the number picked above, drop back to state 0.  If the spit animation
+       is NOT the one loaded, load it (index 0x14) instead. */
+    if (*(int *)(r4 + 0x134) == data_ov060_0211abe0[1]) {
+        *(unsigned char *)(r4 + 0x423) =
+            (unsigned char)(*(unsigned char *)(r4 + 0x423) + 1);
+        if (*(unsigned char *)(r4 + 0x423) >= *(unsigned char *)(r4 + 0x428))
+            *(int *)(r4 + 0x40c) = 0;
+    } else {
+        func_ov060_02111cc0(r4, 0x14, 0);
+    }
+
+    /* 0x0211427c..0x0211428c */
+    *(int *)(r4 + 0x12c) = 0;
+}
+
+/* ============ VERIFIED HOST COPY 8: func_ov060_02116d78 ===================
+ * BOWSER FIRE behaviour state 5 -- record data_ov060_0211a774 (overlay words
+ * 02116d78 / 00000000), which __sinit_ov060_02119df0 copies to
+ * data_ov060_0211afb4.p5, i.e. record 5 of the eight-record behaviour table
+ * _ZN10BowserFire8BehaviorEv indexes with *(int *)(c + 0x35c).
+ *
+ * ROM 0x02116d78, 0x1fc bytes, 121 instructions + 6 literals.
+ *
+ * CALLS (all 6 confirmed in relocs.txt, in order):
+ *   0x02116ec8 -> 0x02116518 overlay(60) func_ov060_02116518
+ *   0x02116ed0 -> 0x020356e8 main       _ZNK12WithMeshClsn10IsOnGroundEv
+ *   0x02116ee0 -> 0x0203b990 main       RandomIntInternal
+ *   0x02116f24 -> 0x02010e2c main       Actor::Spawn
+ *   0x02116f2c -> 0x02043824 main       ActorBase::MarkForDestruction
+ *   0x02116f4c -> 0x02043824 main       ActorBase::MarkForDestruction
+ *     -- TWO rows for 0x02043824 in the reloc table, so the double call on the
+ *        ground path (destroy, then fall through to the age check and destroy
+ *        again) is the ROM's own behaviour, not a transcription slip.
+ * RELOCATED LOADS (both): 0x02082214, 0x0209e650.
+ * PLAIN LITERALS (4): 00000255, 92492493, f0f0f0f1, 00000011.
+ * OFFSETS: 0x360 0x92 0x94 0x98 0xa4 0xa8 0xac 0x5c 0x60 0x64 0x110 0xcc
+ *   0x374(=0x300+0x74).
+ * IMMEDIATES: 0x5000, 0x255, 0x800, 0x200, 4(shift), 896, 0x9a, 1, 12,
+ *   0x118, 6, -1, 0x3c, 16(shift), 17.
+ * BRANCHES: the four conditional-execution blocks (addlt/strlt at
+ *   0x02116d90, addgt/strhgt at 0x02116db0, the lo-conditional epilogue at
+ *   0x02116f3c), beq 0x2116f30, beq 0x2116f28.  All reproduced structurally.
+ * PORT_HOST_ABI: none -- plain cdecl; host copy only because no matched TU of
+ * this name exists. */
+extern "C" void func_ov060_02116d78(char *r4)
+{
+    int a, b;
+
+    ov60_ran("BOWSERFIRE state 5 (02116d78)", r4);
+
+    /* 0x02116d84..0x02116da4 -- grow the flame up to its cap */
+    if (*(int *)(r4 + 0x360) < 0x5000)
+        *(int *)(r4 + 0x360) += 0x255;
+
+    /* 0x02116da8..0x02116dbc -- pitch back toward level */
+    if (*(short *)(r4 + 0x92) > 0x800)
+        *(short *)(r4 + 0x92) = (short)(*(short *)(r4 + 0x92) - 0x200);
+
+    /* 0x02116dc0..0x02116e7c -- speed from (pitch 0x92, yaw 0x94, speed 0x98)
+       through the arm9 sin/cos table.  The three components are computed with
+       exactly the table entries and the exactly one divisor the ROM uses:
+       x and z divide by 896, y does not divide at all. */
+    a = *(unsigned short *)(r4 + 0x92) >> 4;
+    b = *(unsigned short *)(r4 + 0x94) >> 4;
+    *(int *)(r4 + 0xa4) = *(int *)(r4 + 0x98) * data_02082214[a * 2]
+                          * data_02082214[b * 2 + 1] / 896;
+    a = *(unsigned short *)(r4 + 0x92) >> 4;
+    *(int *)(r4 + 0xa8) = -*(int *)(r4 + 0x98) * data_02082214[a * 2];
+    a = *(unsigned short *)(r4 + 0x92) >> 4;
+    b = *(unsigned short *)(r4 + 0x94) >> 4;
+    *(int *)(r4 + 0xac) = -*(int *)(r4 + 0x98) * data_02082214[a * 2]
+                          * data_02082214[b * 2] / 896;
+
+    /* 0x02116e80..0x02116ec8 -- integrate, then drive the flame particle at
+       twelve times the current size */
+    *(int *)(r4 + 0x5c) += *(int *)(r4 + 0xa4);
+    *(int *)(r4 + 0x60) += *(int *)(r4 + 0xa8);
+    *(int *)(r4 + 0x64) += *(int *)(r4 + 0xac);
+    func_ov060_02116518(r4, 0x9a, 1, *(int *)(r4 + 0x360) * 12);
+
+    /* 0x02116ecc..0x02116f2c -- on touching the floor, sixteen times out of
+       seventeen leave a 0x118 behind, then die */
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(r4 + 0x110) != 0) {
+        if (((unsigned)RandomIntInternal(&data_0209e650) >> 0x10) % 17 != 0)
+            _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0x118, 6, r4 + 0x5c, 0, *(signed char *)(r4 + 0xcc), -1);
+        _ZN9ActorBase18MarkForDestructionEv(r4);
+    }
+
+    /* 0x02116f30..0x02116f58 -- and die of old age at 60 frames */
+    if (*(unsigned short *)((r4 + 0x300) + 0x74) < 0x3c)
+        return;
+    _ZN9ActorBase18MarkForDestructionEv(r4);
+}
 
 /* ============ HOST COPY 1: func_ov060_02112434 ============================
  * BOWSER's per-frame target/flag pass, called from Bowser::Behavior.  Line for
@@ -389,6 +717,7 @@ extern "C" int _ZN10BowserFire13InitResourcesEv(char *c)
  * PORT_HOST_ABI: mwcc pointer-to-member stride/receiver, the Crate case. */
 extern "C" int _ZN10BowserFire8BehaviorEv(char *c)
 {
+    ov60_note("BOWSERFIRE", c, *(int *)(c + 0x35c));   /* w7a trace, stderr */
     *(int *)(c + 0x370) += 1;
     {
         PortPmf *e = &data_ov060_0211afb4[*(int *)(c + 0x35c)];
@@ -447,6 +776,8 @@ extern char *data_0209f318;
 extern "C" int _ZN6Bowser8BehaviorEv(void *selfv)
 {
     char *c = (char *)selfv;
+    ++g_ov60_frame;                                   /* w7a trace, stderr */
+    ov60_note("BOWSER", c, *(int *)(c + 0x40c));
     RandomIntInternal(&data_0209e650);
     *(int *)(c + 0x3a0) = (int)(size_t)_ZN5Actor13ClosestPlayerEv(c);
     if (*(char **)(c + 0x3a0) != 0) {

--- a/port/unmatched/Ov060_StateDispatch.cpp
+++ b/port/unmatched/Ov060_StateDispatch.cpp
@@ -461,6 +461,7 @@ extern "C" void func_ov060_021140c0(char *r4)
             _ZN5Actor13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j(
                 r4, &pos, &rot, 0x1e000, 0xa000, 0);
             func_02012694(0x122, r4 + 0x74);
+            ov60_ran("BOWSER state 9 SPIT (SpawnFireball branch)", r4);
         }
     }
 
@@ -553,6 +554,7 @@ extern "C" void func_ov060_02116d78(char *r4)
     /* 0x02116ecc..0x02116f2c -- on touching the floor, sixteen times out of
        seventeen leave a 0x118 behind, then die */
     if (_ZNK12WithMeshClsn10IsOnGroundEv(r4 + 0x110) != 0) {
+        ov60_ran("BOWSERFIRE state 5 GROUND (Spawn+destroy branch)", r4);
         if (((unsigned)RandomIntInternal(&data_0209e650) >> 0x10) % 17 != 0)
             _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
                 0x118, 6, r4 + 0x5c, 0, *(signed char *)(r4 + 0xcc), -1);

--- a/port/unmatched/Ov060_StateDispatch.cpp
+++ b/port/unmatched/Ov060_StateDispatch.cpp
@@ -395,7 +395,7 @@ void ov60_ran(const char *what, const void *who)
 /* ============ VERIFIED HOST COPY 7: func_ov060_021140c0 ===================
  * BOWSER state 9 -- record data_ov060_0211a5a0 (overlay words 021140c0 /
  * 00000000), which __sinit_ov060_021195dc copies to
- * data_ov060_0211aed4[4].hi, i.e. 8-byte record 9 of the twenty-record table
+ * data_ov060_0211aed4 + 0x48, i.e. 8-byte record 9 of the twenty-record table
  * func_ov060_021128c0 indexes with *(s32 *)(c + 0x40c).  Reached from
  * src/func_ov060_021150d0.cpp and src/func_ov060_021151d4.c, both of which
  * pick it on a RandomIntInternal draw.


### PR DESCRIPTION
External-contributor lane from the second coordination site (campaign handoff operation; `port/tests/walk_window.cpp` and `port/ntr/` untouched).

## What this is

BOWSER STATE BODIES (target-menu item 1): verified host copies of the two undecompiled ov060 holes, seated in place of their loud abort stubs in `port/unmatched/Ov060_StateDispatch.cpp`:

- `func_ov060_021140c0` — BOWSER state 9 (0x1f4 bytes: 116 instructions + 9 pool words)
- `func_ov060_02116d78` — BOWSER FIRE behaviour state 5 (0x1fc bytes: 121 instructions + 6 pool words)

Whole diff is ONE file (+351/−18 worker, +1/−1 review fixup). No CMake change (the file was already in `slice_w6a.txt`; every callee already linked). Linkage intentionally unchanged: **4623 before and after**. Three commits: `f80ae8c6` (bodies), `64f27478` (two env-gated trace points), `3e…` fixup (comment-only, review-ordered; rebuilt and re-gated: control 300 exact, linkage 4623, guards green).

## Verification — the full host-copy standard, including the mwcc oracle

The worker verified by total word accounting (every one of the 125 + 127 words classified; every instruction mapped), reloc-table corroboration (exactly 7 arm_call + 3 load rows for body 1, 6 + 2 for body 2 — including `MarkForDestruction` TWICE in body 2, proving the ground path's double destroy is ROM behaviour), magic-constant proofs (`0xcccccccd`→/10, `0xaaaaaaab`→/3, `0x92492493`+asr#9 = ⌈2⁴¹/896⌉ → signed /896, `0xf0f0f0f1`→/17), and arity re-derivation from ROM register use (notably `func_ov060_02111cc0` takes THREE args; `Bowser_IsAnimAtLastFrame` returns bool — an int decl would read MSVC's undefined high bits of al).

The independent reviewer then ran what the worker could not (the compiler was absent at the time): **the mwccarm 1.2/sp2p3 byte oracle**, on minimal standalone renditions of both bodies against the ROM spans:

| | body 1 | body 2 |
|---|---|---|
| size | 0x1f4 exact | 0x1fc exact |
| byte-identical words | 67/125 | 39/127 |
| register-rename only | 10 | 4 |
| scheduling only | 32 | 72 |
| frame/push-mask | 6 | 3 |
| reloc wildcard slots | 10 | 9 |
| **changed constants / offsets / branch-or-call targets** | **0** | **0** |
| literal-pool multiset | identical | identical |
| reloc symbol names | identical | identical |

**Zero semantic divergence on either body — the law's standard met in full**, and the oracle covers the sub-branches runtime didn't reach.

## Proof of life (level 38, FAULTS_FATAL=1, A/B on both builds)

Stub build: rc 127 with the loud FATAL naming each state. Tip build: rc 0. Bowser state 9 entered and ran (85 executions in the reviewer's drive; the fight loops on past it); BowserFire state 5 ran via direct spawn (`SM64DS_SPAWN_ACTOR=280:5`). Reproduction requires `SM64DS_SELFTEST_IDLE=1` plus scheduled A presses (the talk gate must be cleared; with the default W-hold Mario walks out of range and the fight never starts).

Runtime coverage, with the review's corrections folded in: the flame's 61-tick lifetime is a property of the spawn site, not the body (61 ticks on levels 6/12/38; on levels 1/5 it grounds on the first tick — which means the `IsOnGround` branch, listed by the worker as unexercised, WAS exercised at review time: the encoded `Actor::Spawn(0x118, 6, …)` + double-destroy sequence was observed directly). Still runtime-unexercised: body 1's SpawnFireball window and `GetHealth()<=4` arm — both inside the oracle's zero-divergence span.

## Findings for the primary site

1. **The handoff's framing of these holes needs updating.** Measured twice (worker, then reviewer with stronger evidence): (a) the "state 5→6 at ~frame 38" transition is BOWSER's own (both matched src), not BowserFire's; (b) **BowserFire state 5 is unreachable on any currently mounted level** — the ROM's only `Actor::Spawn(0x118, 5, …)` site (0x02117608, confirmed by a 104-module scan) is gated on the owner Bowser reaching state 0xf, which only variants 0 and 2 (koopa1/koopa3) produce; level 38's variant-1 Bowser cannot. The states were reachable-but-unreached headlessly — a plain 5000-frame level-38 selftest at base exits 0; (c) with the arena PR (#1504) mounting levels 36/40 — the koopa1/koopa3 fights — state 5 becomes naturally reachable; a combined-integration drive there is the natural follow-up test.
2. Pre-existing, not this lane's: `src/func_ov060_02111cc0.cpp` **defines two parameters** while the ROM callee consumes three registers (the third reaches `ModelAnim::SetAnim`'s frame argument from an uninitialised local on host). The 3-arg declaration here is ROM-faithful and matches six other matched TUs; the src-side definition deserves its own look.
3. For whoever banks the matched TU later: the ROM's own C used the pointer-local RMW idiom in four places body 2 spells as `+=` (the `+=` spelling is 7 instructions short under mwcc). Harmless for the host copy; load-bearing for a future `src/` match.
4. Smoke-count trivia settled: 17 `add_executable(smoke_*` + 1 bare `add_executable(smoke` = 18 smoke executables.

Setup facts for reproduction: `extracted/dsd/files/files.txt` must exist (`python port/tools/ntr_manifest.py`); this site builds via a local mirror of `build-port.cmd` (VS2022 Preview paths, same guards/flags), `battery.py` with `--skip-build`.

---

# Worker evidence report (lane w7a, verbatim)

Linkage: base 4623 (map 2,523,452 B), tip 4623 (2,524,555 B) — no TU added by design; freshness by content (3 trace-symbol hits in tip map, 0 in base). Censuses: all 17 levels byte-identical base→tip, class-count halves included (pins: L2 64/10, L12 136/4, L13 187/1, L14 180/29, L15 55/1, L37 109/6, L38 17/0). Gates: control 300 exact with stdout byte-identical UNMASKED; soak 1000 exact; full sweep exit 0; battery ALL GREEN `--linked-floor 4623`; 18/18 smokes (after the files.txt setup step — measured pre-existing, binary dated to baseline, not a lane effect); guards all green (closestplayer 4739 TUs, inferred_stub 2=baseline, dsstate 5585/372624, alternatename 0 new defeats, ptr_audit 0); both save-state reproducers PASS with `[ss-repro]` lines identical to base; heap 241592.

Verification record: spans re-derived two ways each (next-symbol landing AND prologue-to-`bx lr` + pool accounting, closing exactly); record identities traced through the sinit copies (`data_ov060_0211a5a0` → aed4 record 9, indexed by `*(s32*)(c+0x40c)`; `data_ov060_0211a774` → afb4 record 5, indexed by `*(int*)(c+0x35c)`); every reloc row one-for-one with the transcription; unlisted literals therefore constants (the magic divisions above); runtime corroboration of a transcribed constant (the 0x3c age check). Body banners document the method and the honest scope: the mwcc byte-compare was NOT run by the worker — the compiler was absent (proven on a known-matched control) — and neither banner claims a compiler diff. Traps checked: the C-linkage arity class (the three-arg callee), bool-vs-int return width, transcription idioms lifted from matched siblings in the same pack.

Proof of life: A/B against the stub build (rc 127 FATAL on each state → rc 0 through both); Bowser state stream driven with `SM64DS_PROBE_INPUT` A presses; state 9 sub-branches exercised: the volley pick with the `rand%10%3+1` draw, both arms of the anim-identity test, the `IsAnimAtLastFrame` early return, the `+0x423 >= +0x428` counter reset, the `+0x12c = 0` tail. Refutations of the campaign brief, measured: the frame-39 transition is BOWSER aed4 5→6; BowserFire state 5 unreachable on mounted levels (spawner gated on owner state 0xf, produced only by variants 0/2; level 38 is variant 1); baseline level-38 selftest exits 0 (the talk gate idles headlessly).

Hygiene: `git diff daeeb9b2..HEAD -- src/` = 0 bytes; one-file diff; the base file's only two `ov60_hole` sites are the two replaced (none silently guessed — all 50 seat rows still verify `fn == rom && adj == 0` and abort on mismatch); no pushes at report time.

---

# Independent review verdict (verbatim)

**Verdict: MERGE.** Every load-bearing claim reproduces; the refutations found are peripheral and two are in the lane's favour.

Oracle: proven green on the control first; `2004/b56` is not installed here — of 24 builds swept, only the 1.2 trio is codegen-viable for these spans. Minimal standalone mwcc-dialect renditions of both shipped bodies, against the ROM spans: body 1 near-miss, 0 semantic divergence (125 words: 67 IDENT, 10 RELOC-wildcard, 10 REGALLOC, 32 SCHEDULE, 6 FRAME; pool multiset identical; branch-target multiset identical; 10/10 reloc names at same offsets; byte-identical result under 1.2/base, sp2, sp2p3); body 2 near-miss, 0 semantic divergence (127 words: 39/9/4/72/3; pool identical; 7/8 reloc names at same offset, 8th = pool reorder). Residual register-abstracted difference on both = exactly {frame words} ∪ {unlinked bl placeholders}. **Meets the law's standard as stated, covering the runtime-unreached sub-branches.** Rendition deltas from the shipped bodies, all semantics-preserving, enumerated (removed trace calls; bool→int; RMW respellings — with the finding that the ROM's own C used the pointer-local idiom in four places, relevant to a future src/ match).

Per-claim: spans CONFIRMED with a third pin (symbols.txt sizes); reloc row counts and addresses exact; magic constants re-proven; record chains re-derived by simulating both sinits; the three-arg arity CONFIRMED from the callee's register flow into `ModelAnim::SetAnim`; A/B CONFIRMED with own numbers (rc 127 FATAL at base on both drives; rc 0 at head; state 9 ran 85×; trace-on stdout byte-identical to trace-off); brief refutations CONFIRMED and (a) upgraded to runtime proof, (b) strengthened by a 104-module scan for the spawner and a whole-image scan for stores of 0xf to `+0x40c` (exactly two sites, both outside variant 1's dispatcher; caveat: a pooled `ldr r0,=0x118` would evade the scan — mwcc uses the encodable `mov`); (c) CONFIRMED rc 0 at 5000 frames.

Findings beyond the worker: the 61-tick figure is level-dependent (61 on L6/12/38; 2 on L1/5 where the flame grounds immediately); the IsOnGround branch IS exercisable and was exercised (second BOWSERFIRE spawned state 6 + destruction observed on L1/5); the claimed level-38 state set was wrong as written ({0,1,5,6,9,0xd,0xe,0x10,0x13} measured — includes 0x10, no 7 — the load-bearing "never 0xf" holds); reproduction needs `SM64DS_SELFTEST_IDLE=1` (default W-hold walks out of range); the +5 publics are string-literal COMDATs, not trace symbols (which are statics in the map's Static section); the absolute map-size offsets between measurements are a build-path COMDAT literal (deltas match exactly); `src/func_ov060_02111cc0.cpp` defines two parameters against the ROM's three-register consumption (pre-existing src condition, banner rationale overstated for host); banner record-spelling `[4].hi` should read +0x48/record 9 [fixed in the fixup commit]; smoke count settled at 18 (17 `smoke_*` + 1 bare).

Gate table: all measured on from-scratch builds of base and head — linkage 4623/4623 (maps 2,523,447 / 2,524,550, Δ +1,103 matching the worker's Δ); all guards green both builds; control/soak exact, 17/17 sweep stdouts byte-identical; battery ALL GREEN; 18/18 smokes; heap 241,592; both save-state reproducers PASS with identical `[ss-repro]` lines; the A/B pair rc 127 → rc 0 on both drives; all 17 censuses exact and identical at base and head.

Attestation: nothing modified on the lane branch, nothing committed, nothing pushed by the review; scratch renditions deleted; worktrees left in place with builds intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
