### PR TITLE
port w7b: the MR. I family (262/263/264) -- level 12 census to 140/0, +32 linkage, oracle-verified cores

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -716,6 +716,11 @@ set_source_files_properties(
     # gate 194: a //cpp-marked .c (a top-level `extern "C" {` block, invalid C),
     # HootTheOwl's own state-transition helper.
     "${CMAKE_CURRENT_SOURCE_DIR}/../src/func_ov094_02136024.c"
+    # run linkw wave 7, lane w7b: MrI's InitResources, the one body of the Mr. I
+    # closure that is NONMATCHING-but-decompiled. //cpp-marked .c with extern "C"
+    # blocks and SharedFilePtr& reference params -- invalid C, same treatment as
+    # the gate-176 entry above.
+    "${CMAKE_CURRENT_SOURCE_DIR}/../src/_ZN3MrI13InitResourcesEv.c"
     PROPERTIES LANGUAGE CXX)
 
 # Wave-5 close surgery (w5b_review.md R1/R2): two /alternatename routes died
@@ -2630,6 +2635,23 @@ foreach(line IN LISTS SLICE176_LINES)
     list(APPEND SLICE176_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
 
+# run linkw wave 7, lane w7b: THE MR. I FAMILY -- MR_I (262) and BIG_MR_I (263),
+# which share one class and one vtable, plus MR_I_PROJECTILE (264), the shot
+# MrI's state 1 fires through Actor::Spawn(0x108). ov071 was already mounted
+# per-symbol by gate 176, so this lane adds no overlay: rows, two fills, the
+# state seat, and four host copies (the two unmatched per-frame state MAINs,
+# the two PMF dispatchers, plus the slot-5 Render and two D1 thunks).
+# See slice_w7b.txt.
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_w7b.txt" SLICE_W7B_LINES)
+set(SLICE_W7B_SOURCES "")
+foreach(line IN LISTS SLICE_W7B_LINES)
+    string(STRIP "${line}" line)
+    if(line MATCHES "^#" OR line STREQUAL "")
+        continue()
+    endif()
+    list(APPEND SLICE_W7B_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
+endforeach()
+
 # Gate 177: BULLY (215) + BIG_BULLY (216) + ROTATING_FIREBAR (81), ov064's
 # first mount. No PMF tables; the bullies' D1/D0 and all three Renders are
 # host thunks/copies (the fill and unmatched/ModelAnim_Renders.cpp); the
@@ -3046,6 +3068,7 @@ add_executable(smoke_player tests/smoke_player.cpp "${OV002DATA_C}" ${LEVEL_OV_D
     hal/actor_classes_flame.cpp ${SLICE175_SOURCES}
     hal/actor_classes_flamethrower.cpp ${SLICE_W6F_SOURCES} unmatched/Flamethrower_Behavior.c
     hal/actor_classes_scuttlebug.cpp ${SLICE176_SOURCES} unmatched/Scuttlebug_StateDispatch.cpp
+    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
     hal/actor_classes_ov064.cpp ${SLICE177_SOURCES} unmatched/Bully_AfterClsn.cpp
     hal/actor_classes_ov064_gate178.cpp ${SLICE178_SOURCES} unmatched/Ov064Gate178_States.cpp
     hal/actor_classes_jrb.cpp ${SLICE188_SOURCES} unmatched/Jrb_Renders.cpp
@@ -3123,6 +3146,7 @@ add_executable(walk_window tests/walk_window.cpp tests/io_pressure.cpp "${OV002D
     hal/actor_classes_flame.cpp ${SLICE175_SOURCES}
     hal/actor_classes_flamethrower.cpp ${SLICE_W6F_SOURCES} unmatched/Flamethrower_Behavior.c
     hal/actor_classes_scuttlebug.cpp ${SLICE176_SOURCES} unmatched/Scuttlebug_StateDispatch.cpp
+    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
     hal/actor_classes_ov064.cpp ${SLICE177_SOURCES} unmatched/Bully_AfterClsn.cpp
     hal/actor_classes_ov064_gate178.cpp ${SLICE178_SOURCES} unmatched/Ov064Gate178_States.cpp
     hal/actor_classes_jrb.cpp ${SLICE188_SOURCES} unmatched/Jrb_Renders.cpp
@@ -3229,6 +3253,7 @@ add_executable(walk_window_hires tests/walk_window.cpp "${OV002DATA_C}" ${LEVEL_
     hal/actor_classes_flame.cpp ${SLICE175_SOURCES}
     hal/actor_classes_flamethrower.cpp ${SLICE_W6F_SOURCES} unmatched/Flamethrower_Behavior.c
     hal/actor_classes_scuttlebug.cpp ${SLICE176_SOURCES} unmatched/Scuttlebug_StateDispatch.cpp
+    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
     hal/actor_classes_ov064.cpp ${SLICE177_SOURCES} unmatched/Bully_AfterClsn.cpp
     hal/actor_classes_ov064_gate178.cpp ${SLICE178_SOURCES} unmatched/Ov064Gate178_States.cpp
     hal/actor_classes_jrb.cpp ${SLICE188_SOURCES} unmatched/Jrb_Renders.cpp

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -2652,6 +2652,32 @@ foreach(line IN LISTS SLICE_W7B_LINES)
     list(APPEND SLICE_W7B_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
 
+# Two MR_I_PROJECTILE TUs need hostgen, both mwcc-vs-MSVC syntax quirks the
+# byte-verified tree must not be edited for (the gate-32 / gate-64 treatment).
+# func_ov071_02121b08 is C++ inside a .c -- `struct Callback {}`, an empty
+# struct, which MSVC will not compile as C (C2016); hostgen emits it as .cpp
+# with the symbols wrapped back to C linkage.
+# func_ov071_02121ba4 is the decl_common.h HEADER_SHADOW case: that header
+# declares it `(void*)` inside its extern "C" block while the TU defines it
+# `(char*)` -- one register on the ROM, C2733 to MSVC. This lane adds the
+# HEADER_SHADOW table entry in tools/hostgen.py.
+set(GATE_W7B_SYMS func_ov071_02121b08 func_ov071_02121ba4)
+set(GATE_W7B_GEN "")
+foreach(sym IN LISTS GATE_W7B_SYMS)
+    if(EXISTS "${PORT_REPO_ROOT_ABS}/src/${sym}.c")
+        set(sym_src "${PORT_REPO_ROOT_ABS}/src/${sym}.c")
+    else()
+        set(sym_src "${PORT_REPO_ROOT_ABS}/src/${sym}.cpp")
+    endif()
+    set(sym_out "${CMAKE_BINARY_DIR}/host-src/src/${sym}.cpp")
+    add_custom_command(OUTPUT "${sym_out}"
+        COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/tools/hostgen.py"
+                --out "${CMAKE_BINARY_DIR}/host-src" ${sym}
+        DEPENDS "${sym_src}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/hostgen.py"
+        COMMENT "hostgen ${sym}")
+    list(APPEND GATE_W7B_GEN "${sym_out}")
+endforeach()
+
 # Gate 177: BULLY (215) + BIG_BULLY (216) + ROTATING_FIREBAR (81), ov064's
 # first mount. No PMF tables; the bullies' D1/D0 and all three Renders are
 # host thunks/copies (the fill and unmatched/ModelAnim_Renders.cpp); the
@@ -3068,7 +3094,7 @@ add_executable(smoke_player tests/smoke_player.cpp "${OV002DATA_C}" ${LEVEL_OV_D
     hal/actor_classes_flame.cpp ${SLICE175_SOURCES}
     hal/actor_classes_flamethrower.cpp ${SLICE_W6F_SOURCES} unmatched/Flamethrower_Behavior.c
     hal/actor_classes_scuttlebug.cpp ${SLICE176_SOURCES} unmatched/Scuttlebug_StateDispatch.cpp
-    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
+    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} ${GATE_W7B_GEN} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
     hal/actor_classes_ov064.cpp ${SLICE177_SOURCES} unmatched/Bully_AfterClsn.cpp
     hal/actor_classes_ov064_gate178.cpp ${SLICE178_SOURCES} unmatched/Ov064Gate178_States.cpp
     hal/actor_classes_jrb.cpp ${SLICE188_SOURCES} unmatched/Jrb_Renders.cpp
@@ -3146,7 +3172,7 @@ add_executable(walk_window tests/walk_window.cpp tests/io_pressure.cpp "${OV002D
     hal/actor_classes_flame.cpp ${SLICE175_SOURCES}
     hal/actor_classes_flamethrower.cpp ${SLICE_W6F_SOURCES} unmatched/Flamethrower_Behavior.c
     hal/actor_classes_scuttlebug.cpp ${SLICE176_SOURCES} unmatched/Scuttlebug_StateDispatch.cpp
-    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
+    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} ${GATE_W7B_GEN} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
     hal/actor_classes_ov064.cpp ${SLICE177_SOURCES} unmatched/Bully_AfterClsn.cpp
     hal/actor_classes_ov064_gate178.cpp ${SLICE178_SOURCES} unmatched/Ov064Gate178_States.cpp
     hal/actor_classes_jrb.cpp ${SLICE188_SOURCES} unmatched/Jrb_Renders.cpp
@@ -3253,7 +3279,7 @@ add_executable(walk_window_hires tests/walk_window.cpp "${OV002DATA_C}" ${LEVEL_
     hal/actor_classes_flame.cpp ${SLICE175_SOURCES}
     hal/actor_classes_flamethrower.cpp ${SLICE_W6F_SOURCES} unmatched/Flamethrower_Behavior.c
     hal/actor_classes_scuttlebug.cpp ${SLICE176_SOURCES} unmatched/Scuttlebug_StateDispatch.cpp
-    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
+    hal/actor_classes_ov071.cpp ${SLICE_W7B_SOURCES} ${GATE_W7B_GEN} unmatched/MrI_StateDispatch.cpp unmatched/MrI_StateMains.cpp unmatched/MrI_Render.cpp
     hal/actor_classes_ov064.cpp ${SLICE177_SOURCES} unmatched/Bully_AfterClsn.cpp
     hal/actor_classes_ov064_gate178.cpp ${SLICE178_SOURCES} unmatched/Ov064Gate178_States.cpp
     hal/actor_classes_jrb.cpp ${SLICE188_SOURCES} unmatched/Jrb_Renders.cpp

--- a/port/hal/actor_classes.inc
+++ b/port/hal/actor_classes.inc
@@ -637,6 +637,28 @@ void *RedFlame_Spawn(void);                         /* ov002 0x020b59e0 (matched
 extern unsigned char Scuttlebug_SpawnInfo[];        /* ov071 0x02122c08, +4 reads 255 */
 void *Scuttlebug_Spawn(void);                       /* ov071 0x02120618 (matched src) */
 void hal_fill_scuttlebug_vtable(void);
+/* ---- run linkw wave 7, lane w7b: THE MR. I FAMILY, ov071's second cast ----
+   MR_I (262) and BIG_MR_I (263) are ONE class behind ONE vtable -- MrI_Spawn
+   and BigMrI_Spawn are the same 0x50-byte function twice, both `new(0x218)`
+   storing _ZTV3MrI, and MrI::InitResources tells the two apart by the actor's
+   own id (0x106 -> scale 0x1000, 0x107 -> 0x2000). So 263 is a FREE SHARE of
+   262's fill and carries a null filler in its row, the RED_FLAME shape.
+   MR_I_PROJECTILE (264) is the shot MrI's state 1 fires through
+   Actor::Spawn(0x108); it needs its own vtable and row or every shot would
+   meet the pre-spawn gate as an unregistered id.
+   ov071 was already mounted (gate 176); the fill is hal/actor_classes_ov071.cpp,
+   the closure slice_w7b.txt, the two per-frame state MAINs + the two PMF
+   dispatchers + the record seat + the slot-5 Render in port/unmatched/MrI_*.cpp.
+   Ids re-derived from ACTOR_SPAWN_TABLE + each record's +4 halfword, NOT from
+   port/ov071_syms.txt's header comment, which mis-attributes them to 198/199. */
+extern unsigned char MrI_SpawnInfo[];               /* ov071 0x02122cf0, +4 reads 262 */
+extern unsigned char BigMrI_SpawnInfo[];            /* ov071 0x02122d0c, +4 reads 263 */
+extern unsigned char MrI_Projectile_SpawnInfo[];    /* ov071 0x02122dc4, +4 reads 264 */
+void *MrI_Spawn(void);                              /* ov071 0x02121a1c (matched src) */
+void *BigMrI_Spawn(void);                           /* ov071 0x021219cc (matched src) */
+void *MrI_Projectile_Spawn(void);                   /* ov071 0x02121f9c (matched src) */
+void hal_fill_mri_vtable(void);
+void hal_fill_mri_projectile_vtable(void);
 /* ---- gate 177: ov064's first mount -- BULLY (215), BIG_BULLY (216),
    ROTATING_FIREBAR (81), Lethal Lava Land's no-PMF trio. The bullies'
    factories leave the vptr on the BASE table (VT1), so the registry rows
@@ -1256,6 +1278,13 @@ void hal_fill_path_lift_vtable(void);            /* fills data_ov100_0214857c, 3
     /* ---- gate 176: SCUTTLEBUG (255), ov071's first mount ---- */ \
     {255, "SCUTTLEBUG", Scuttlebug_SpawnInfo, Scuttlebug_Spawn, \
      hal_fill_scuttlebug_vtable}, \
+    /* ---- run linkw wave 7, lane w7b: the MR. I family (ov071) -- MR_I \
+       carries the fill, BIG_MR_I reuses it (one class, one vtable, the \
+       RED_FLAME shape), MR_I_PROJECTILE has its own ---- */ \
+    {262, "MR_I", MrI_SpawnInfo, MrI_Spawn, hal_fill_mri_vtable}, \
+    {263, "BIG_MR_I", BigMrI_SpawnInfo, BigMrI_Spawn, 0}, \
+    {264, "MR_I_PROJECTILE", MrI_Projectile_SpawnInfo, MrI_Projectile_Spawn, \
+     hal_fill_mri_projectile_vtable}, \
     /* ---- gate 177: ov064's Bully family + firebar (Lethal Lava Land) ---- */ \
     {215, "BULLY", Bully_SpawnInfo, port_factory_bully, hal_fill_bully_vtable}, \
     {216, "BIG_BULLY", BigBully_SpawnInfo, port_factory_big_bully, \

--- a/port/hal/actor_classes_ov071.cpp
+++ b/port/hal/actor_classes_ov071.cpp
@@ -1,0 +1,382 @@
+// RUN LINKW WAVE 7 (lane w7b): THE MR. I FAMILY -- MR_I (262) and BIG_MR_I
+// (263), the floating eyeball daEykn_c, plus MR_I_PROJECTILE (264), the shot it
+// fires. Second, third and fourth classes hosted out of ov071; the overlay was
+// already mounted per-symbol by gate 176 (SCUTTLEBUG 255) and by wave 5 lane
+// w5-A (COFFIN 64), so this lane adds NO new overlay -- only rows, fills, a
+// state seat and two host-copied cores.
+//
+// Same law as hal/actor_classes_scuttlebug.cpp (the sibling in this very
+// overlay, and the Enemy-31-slot exemplar this file is built on) and
+// hal/actor_classes_ov065.cpp: ROM slot order, __fastcall thunks that call
+// QUALIFIED or by C name, unhosted slots trap by name.
+//
+// ---- THE CAST MAP WAS RE-DERIVED, NOT CARRIED ------------------------------
+// The brief named 262/263 as "the MR. I family"; port/ov071_syms.txt's own
+// header comment says something DIFFERENT -- "MrI/BigMrI (198/199, the
+// eyeball), MrI_Projectile (262?)". That comment is WRONG and the ids below are
+// re-derived from the ROM, by the double test the shared ov070/071/073/074
+// address window makes mandatory (spawnFunc must land inside ov071 AND the
+// record's +4 id halfword must match):
+//
+//   id  ACTOR_SPAWN_TABLE slot   SpawnInfo   word[0] spawnFunc      +4 halfword
+//   255 0x02090c60 -> 0x02122c08 Scuttlebug  0x02120618 Scuttlebug_Spawn   255
+//   262 0x02090c7c -> 0x02122cf0 MrI         0x02121a1c MrI_Spawn          262
+//   263 0x02090c80 -> 0x02122d0c BigMrI      0x021219cc BigMrI_Spawn       263
+//   264 0x02090c84 -> 0x02122dc4 MrI_Proj    0x02121f9c MrI_Projectile_S.  264
+//
+// read from extracted/arm9_dec.bin (base 0x02004000) for the table and from
+// extracted/overlays/overlay_0071.bin for the records. Ids 198 and 199 DO
+// resolve to records inside ov071's address window but their word[0] spawnFuncs
+// land OUTSIDE it -- they belong to another module sharing the window, which is
+// exactly the trap the double test exists for. So the syms header's "198/199"
+// is a mis-attribution and "262?" was one class short.
+//
+// THE OVERLAY BASE the byte reads use is 0x0211f000, NOT the 0x0211f600 that
+// extracted/dsd/arm9_overlays/overlays.yaml records as base_address 34729984.
+// The yaml is stale by 0x600. Pinned three ways that agree, all in
+// config/arm9/overlays/ov071/delinks.txt and the yaml's own size fields:
+// .text start:0x0211f000, .bss end:0x02123100; image 0x02122f80-0x0211f000 =
+// 0x3f80 = 16256 = ram_size = the byte length of overlay_0071.bin; bss
+// 0x02123100-0x02122f80 = 0x180 = 384 = bss_size. At 0x0211f600 the symbol
+// func_ov071_0211f0a4 would sit below the overlay.
+//
+// ---- 263 IS A FREE SHARE OF 262'S FILL -------------------------------------
+// MrI_Spawn (0x02121a1c) and BigMrI_Spawn (0x021219cc) are the SAME function
+// twice: both `new(0x218)`, both store _ZTV3MrI (0x02122d30) as the vptr, both
+// construct ModelAnim +0xd4, TextureSequence +0x138, ShadowModel +0x14c,
+// MovingCylinderClsnWithPos +0x174. One class, one vtable, two ids. The class
+// separates the two at runtime by its own actor id: MrI::InitResources gives
+// 0x106 (262) scale 0x1000 with a 0x55000/0x96000 collider and 0x107 (263)
+// scale 0x2000 with 0xaa000/0x12c000, and func_ov071_02120d30's step 3 pays out
+// a plain drop for 262 but the tracked star for 263. So BIG_MR_I costs one
+// registry row and no second fill.
+//
+// ---- WIDTHS, each pinned by the reloc run AND the next dsd symbol ----------
+//   _ZTV3MrI            0x02122d30  31 slots (Enemy shape). Declared span to
+//                       the next symbol (data_ov071_02122dac) is 0x7c = 31
+//                       words, and config/arm9/overlays/ov071/relocs.txt has
+//                       exactly 31 relocations in [+0x00, +0x78] and NONE at or
+//                       after 0x02122dac. Both tests agree.
+//   _ZTV14MrI_Projectile 0x02122de8 31 slots, the identical double check
+//                       (31 relocs +0x00..+0x78, next symbol 0x02122e64).
+// Cross-checked against _ZTV10Scuttlebug in the same overlay: the shared
+// Actor/ActorBase halves (1/2/4/5/7/8/10/11/13/14/15/20..28/30) hold the
+// identical arm9 addresses in all three tables.
+//
+// IDENTITY BY CODE LANDING, not by label: this overlay's dsd data labels are
+// the `ambiguous` kind the brief warns can shift one class over, and mwcc emits
+// no Itanium RTTI here, so there is no typeinfo string at vtable[-1] to read.
+// The test that does apply is the ov065 header's "each table's slot 0 landing
+// in that class's own code", and it is decisive -- slot 0 of _ZTV3MrI is
+// 0x02121734 = _ZN3MrI13InitResourcesEv, slot 0 of _ZTV14MrI_Projectile is
+// 0x02121eb4 = _ZN14MrI_Projectile13InitResourcesEv, and (the control) slot 0
+// of _ZTV10Scuttlebug is 0x021203f8 = Scuttlebug's own. No label is shifted.
+//
+// ---- SLOTS EACH CLASS OWNS -------------------------------------------------
+// MrI owns 0 (Init), 3 (Cleanup), 6 (Behavior), 9 (Render), 12
+// (OnPendingDestroy), 16 (D1), 17 (D0). UNLIKE Scuttlebug it has NO 18/19/29
+// overrides -- those bind Actor's own defaults. MrI_Projectile owns the same
+// seven plus 18 (OnYoshiTryEat func_ov071_02121b00, returns 4).
+// Slots 13/14 (ActorBase::Virtual34/38) trap by name the way every sibling fill
+// traps that pair, and slot 30 (OnAimedAtWithEggReturnVec) traps because its
+// matched body is SRET -- a hidden return-slot pointer before self -- which no
+// fill's thunk shape models. The Scuttlebug binding set exactly.
+//
+// ---- WHAT IS A HOST COPY AND WHY -------------------------------------------
+//   the two per-frame state MAINs -- func_ov071_021211e0 (0x314) and
+//     func_ov071_02120d30 (0x3dc) -- are the ONLY two ov071 names with no src/
+//     TU at all. port/unmatched/MrI_StateMains.cpp, with the derivation.
+//   the two state dispatchers -- func_ov071_021215c0 (MAIN, record+8) and
+//     func_ov071_021215fc (ENTER, record+0) -- are the Scuttlebug PMF-stride
+//     case: the matched TUs form `c->pp + 1` over an mwcc 8-byte PMF that MSVC
+//     makes 4, so the host `+1` lands on the delta word and dispatches a zero.
+//     port/unmatched/MrI_StateDispatch.cpp, with the source-side seat.
+//   MrI::Render -- the ModelAnim slot-5 collision (the Whomp/Fish/Scuttlebug
+//     case): the matched TU dispatches slot 5 of a local six-virtual shadow,
+//     which is ModelAnim::Render in ROM order but Virtual18 in the host's
+//     MSVC-ordered _ZTV9ModelAnim. port/unmatched/MrI_Render.cpp.
+//   both D1s (slot 16) are HOST THUNKS, the flame/HauntedChair/Scuttlebug
+//     treatment: the matched D1s are the auto-emitted-member-dtor form whose
+//     compiler-emitted member and base dtor calls resolve to MSVC-mangled names
+//     that do not exist in this build, so they are NOT compiled. Each thunk
+//     runs its own D0 chain minus the final Memory::Deallocate, because the
+//     slot-16 caller (ActorBase::AfterCleanupResources) deallocates itself.
+//     Member sub-objects are destroyed high address first, the D0 order:
+//       MrI            +0x174 MovingCylinderClsnWithPos, +0x14c ShadowModel,
+//                      +0x138 TextureSequence, +0xd4 ModelAnim, ~Actor
+//       MrI_Projectile +0x13c WithMeshClsn, +0xfc MovingCylinderClsnWithPos,
+//                      +0xd4 ShadowModel, ~Actor
+//     Both orders are read from the matched D0 TUs, which ARE compiled.
+//   D1/D0 NUMBERING: the seats above are ROM vtable slots 16 and 17 -- the
+//     Itanium pair. MSVC folds its own complete/deleting destructors into one
+//     slot, which is why slot 16 cannot be an MSVC `~MrI()` and is a thunk.
+//
+// MrI::InitResources is NONMATCHING-but-decompiled src
+// (src/_ZN3MrI13InitResourcesEv.c, "constant / value (div=6)", logic verified
+// correct vs ROM by whoever banked it). It is real behaviour, not a stub, so it
+// rides the slice; it is the one body in the closure that is not byte-matched.
+#include <cstdio>
+#include <cstdlib>
+
+#include "Actor.h"
+#include "ActorBase.h"
+
+extern "C" {
+/* the shared lifecycle halves, the same functions every fill writes */
+int _ZN5Actor19BeforeInitResourcesEv(void *self);             /* slot 1  */
+void _ZN5Actor18AfterInitResourcesEj(void *self, unsigned a); /* slot 2  */
+int _ZN5Actor14BeforeBehaviorEv(void *self);                  /* slot 7  */
+int _ZN5Actor12BeforeRenderEv(void *self);                    /* slot 10 */
+int _ZN5Actor13OnYoshiTryEatEv(void *self);                   /* slot 18 */
+void _ZN5Actor13OnTurnIntoEggER6Player(void *self, void *p);  /* slot 19 */
+int _ZN5Actor9Virtual50Ev(void *self);                        /* slot 20 */
+void _ZN5Actor15OnGroundPoundedERS_(void *self, void *o);     /* slot 21 */
+void _ZN5Actor11OnAttacked1ERS_(void *self, void *o);         /* slot 22 */
+void _ZN5Actor11OnAttacked2ERS_(void *self, void *o);         /* slot 23 */
+void _ZN5Actor8OnKickedERS_(void *self, void *o);             /* slot 24 */
+void _ZN5Actor8OnPushedERS_(void *self, void *o);             /* slot 25 */
+void _ZN5Actor24OnHitByCannonBlastedCharERS_(void *self, void *o); /* slot 26 */
+void _ZN5Actor15OnHitByMegaCharER6Player(void *self, void *p);     /* slot 27 */
+void _ZN5Actor19OnHitFromUnderneathERS_(void *self, void *o);      /* slot 28 */
+int _ZN5Actor16OnAimedAtWithEggEv(void *self);                     /* slot 29 */
+
+extern int data_02099f24[];          /* the frame phase the lists are in */
+extern unsigned char data_020a4b4c;  /* the spawn spine's own step */
+const char *port_actor_class_name(unsigned id);            /* hal/actor_registry */
+void port_actor_slot_decline(const char *what);            /* func_02043fdc.cpp */
+void port_actor_render_probe(const char *cls, void *model); /* actor_classes */
+
+/* ---- MR. I's own bodies --------------------------------------------------- */
+int _ZN3MrI13InitResourcesEv(char *self);      /* slot 0,  nonmatching src */
+int _ZN3MrI16CleanupResourcesEv(void);         /* slot 3,  C linkage, no self */
+int _ZN3MrI8BehaviorEv(void *self);            /* slot 6,  real C++ member */
+int _ZN3MrI6RenderEv(void *self);              /* slot 9,  HOST COPY */
+void _ZN3MrI16OnPendingDestroyEv(void);        /* slot 12, empty, no self */
+int *_ZN3MrID0Ev(int *self);                   /* slot 17, C linkage */
+void *MrI_Spawn(void);
+void *BigMrI_Spawn(void);
+
+/* ---- MR_I_PROJECTILE's own bodies ----------------------------------------- */
+int _ZN14MrI_Projectile13InitResourcesEv(void *self);   /* slot 0  */
+int _ZN14MrI_Projectile16CleanupResourcesEv(void);      /* slot 3  */
+int _ZN14MrI_Projectile8BehaviorEv(void *self);         /* slot 6  */
+int _ZN14MrI_Projectile6RenderEv(void *self);           /* slot 9  */
+void _ZN14MrI_Projectile16OnPendingDestroyEv(void);     /* slot 12 */
+int *_ZN14MrI_ProjectileD0Ev(int *self);                /* slot 17 */
+int func_ov071_02121b00(void);                          /* slot 18, returns 4 */
+void *MrI_Projectile_Spawn(void);
+
+/* the D1 chains' sub-object destructors, all C-linkage in the build (the same
+   node dtors the two D0 TUs call) */
+void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
+void _ZN11ShadowModelD1Ev(void *);
+void _ZN15TextureSequenceD1Ev(void *);
+void _ZN9ModelAnimD1Ev(void *);
+void _ZN12WithMeshClsnD1Ev(void *);
+void *_ZN5ActorD2Ev(void *);
+
+/* The arrays the ROM factories install (MrI_Spawn and BigMrI_Spawn both do
+   `p[0] = (int)_ZTV3MrI`; MrI_Projectile_Spawn stores its own); thirty-one
+   slots each. Defined here, not just declared: the `int` type and C linkage
+   match the `extern int _ZTV3MrI[]` in include/decl_common.h that the .c
+   factories and D0s read. */
+int _ZTV3MrI[31];
+int _ZTV14MrI_Projectile[31];
+}
+
+/* The two D0 TUs store the RTTI base spellings (the dsd names at the same
+   addresses) into slot 0; both references are C linkage, so point the
+   underscore spellings at the one host array each -- the daSpd_c / daChoropu_c
+   precedent in the sibling fill. */
+#pragma comment(linker, "/alternatename:__ZTV8daEykn_c=__ZTV3MrI")
+#pragma comment(linker, "/alternatename:__ZTV8daEyBm_c=__ZTV14MrI_Projectile")
+
+/* NAME RACE RESOLVED BY ADDRESS (the shared-window rule, and the same disease
+   the sibling fill records for data_ov073_02122f88). src/func_ov071_021209c8.cpp
+   spells its texture-sequence SharedFilePtr `data_ov074_02123038`, but the load
+   site's own relocation settles it: config/arm9/overlays/ov071/relocs.txt has
+       from:0x02120a1c kind:load to:0x02123038 module:overlay(71)
+   -- ov071's OWN bss pointer, mounted in port/ov071_syms.txt. The ov074
+   spelling is another module's dsd export winning the race at a shared-window
+   address. Alias by address; the config rename goes upstream as its own PR. */
+#pragma comment(linker, "/alternatename:_data_ov074_02123038=_data_ov071_02123038")
+
+// ---- the trap --------------------------------------------------------------
+static void mri_trap_report(void *self, int slot)
+{
+    unsigned id = self ? *(unsigned short *)((char *)self + 0xc) : 0u;
+    std::fprintf(stderr,
+                 "UNHOSTED: vtable slot %d is not hosted (actor id %u %s, "
+                 "phase %d, spawn step %d)\n",
+                 slot, id, port_actor_class_name(id), data_02099f24[0],
+                 (int)data_020a4b4c);
+    { static char _m[128];
+      std::snprintf(_m, sizeof _m, "unhosted vtable slot %d on id %u %s",
+                    slot, id, port_actor_class_name(id));
+      port_actor_slot_decline(_m); }
+}
+#define MRI_TRAP(n) \
+    static int __fastcall mri_trap##n(void *s, void *) \
+    { mri_trap_report(s, n); return 0; }
+/* 13/14 are ActorBase::Virtual34/38 (not linked, the sibling trap); 30 is the
+   SRET OnAimedAtWithEggReturnVec no thunk shape models. */
+MRI_TRAP(13) MRI_TRAP(14) MRI_TRAP(30)
+#undef MRI_TRAP
+
+// ---- the shared half -------------------------------------------------------
+static int __fastcall mri_binit(void *s, void *)
+{ return _ZN5Actor19BeforeInitResourcesEv(s); }
+static void __fastcall mri_ainit(void *s, void *, unsigned a)
+{ _ZN5Actor18AfterInitResourcesEj(s, a); }
+static int __fastcall mri_bclean(void *s, void *)
+{ return ((Actor *)s)->Actor::BeforeCleanupResources(); }
+static void __fastcall mri_aclean(void *s, void *, unsigned a)
+{ ((ActorBase *)s)->ActorBase::AfterCleanupResources(a); }
+static int __fastcall mri_bbeh(void *s, void *)
+{ return _ZN5Actor14BeforeBehaviorEv(s); }
+static void __fastcall mri_abeh(void *s, void *, unsigned a)
+{ ((ActorBase *)s)->ActorBase::AfterBehavior(a); }
+static int __fastcall mri_bren(void *s, void *)
+{ return _ZN5Actor12BeforeRenderEv(s); }
+static void __fastcall mri_aren(void *s, void *, unsigned a)
+{ ((ActorBase *)s)->ActorBase::AfterRender(a); }
+static int __fastcall mri_heap(void *s, void *)
+{ return ((ActorBase *)s)->ActorBase::OnHeapCreated(); }
+static int __fastcall mri_yoshi(void *s, void *)
+{ return _ZN5Actor13OnYoshiTryEatEv(s); }
+static int __fastcall mri_egg(void *s, void *, void *p)
+{ _ZN5Actor13OnTurnIntoEggER6Player(s, p); return 0; }
+static int __fastcall mri_v50(void *s, void *)
+{ return _ZN5Actor9Virtual50Ev(s); }
+static int __fastcall mri_pounded(void *s, void *, void *o)
+{ _ZN5Actor15OnGroundPoundedERS_(s, o); return 0; }
+static int __fastcall mri_atk1(void *s, void *, void *o)
+{ _ZN5Actor11OnAttacked1ERS_(s, o); return 0; }
+static int __fastcall mri_atk2(void *s, void *, void *o)
+{ _ZN5Actor11OnAttacked2ERS_(s, o); return 0; }
+static int __fastcall mri_kicked(void *s, void *, void *o)
+{ _ZN5Actor8OnKickedERS_(s, o); return 0; }
+static int __fastcall mri_pushed(void *s, void *, void *o)
+{ _ZN5Actor8OnPushedERS_(s, o); return 0; }
+static int __fastcall mri_cannon(void *s, void *, void *o)
+{ _ZN5Actor24OnHitByCannonBlastedCharERS_(s, o); return 0; }
+static int __fastcall mri_mega(void *s, void *, void *p)
+{ _ZN5Actor15OnHitByMegaCharER6Player(s, p); return 0; }
+static int __fastcall mri_under(void *s, void *, void *o)
+{ _ZN5Actor19OnHitFromUnderneathERS_(s, o); return 0; }
+static int __fastcall mri_aimed(void *s, void *)
+{ return _ZN5Actor16OnAimedAtWithEggEv(s); }
+
+// ---- MR. I's own slots ------------------------------------------------------
+static int __fastcall mri_init(void *s, void *)
+{ return _ZN3MrI13InitResourcesEv((char *)s); }
+static int __fastcall mri_clean(void *s, void *)
+{ (void)s; return _ZN3MrI16CleanupResourcesEv(); }
+static int __fastcall mri_behavior(void *s, void *)
+{ return _ZN3MrI8BehaviorEv(s); }
+/* Render is the MrI_Render host copy (ROM-order ModelAnim slot-5 dispatch, the
+   Whomp/Fish case), not the matched TU. */
+static int __fastcall mri_render(void *s, void *)
+{ port_actor_render_probe("MR_I", (char *)s + 0xd4);
+  return _ZN3MrI6RenderEv(s); }
+static int __fastcall mri_pdes(void *s, void *)
+{ (void)s; _ZN3MrI16OnPendingDestroyEv(); return 0; }
+static int __fastcall mri_d0(void *s, void *)
+{ return (int)(size_t)_ZN3MrID0Ev((int *)s); }
+/* D1, the complete-object destructor ROM slot 16 holds: the D0 chain without
+   the Memory::Deallocate at its tail. */
+static int __fastcall mri_d1(void *s, void *)
+{
+    char *t = (char *)s;
+    *(void **)t = (void *)_ZTV3MrI;
+    _ZN25MovingCylinderClsnWithPosD1Ev(t + 0x174);
+    _ZN11ShadowModelD1Ev(t + 0x14c);
+    _ZN15TextureSequenceD1Ev(t + 0x138);
+    _ZN9ModelAnimD1Ev(t + 0xd4);
+    _ZN5ActorD2Ev(t);
+    return (int)(size_t)s;
+}
+
+// ---- MR_I_PROJECTILE's own slots -------------------------------------------
+static int __fastcall mrp_init(void *s, void *)
+{ return _ZN14MrI_Projectile13InitResourcesEv(s); }
+static int __fastcall mrp_clean(void *s, void *)
+{ (void)s; return _ZN14MrI_Projectile16CleanupResourcesEv(); }
+static int __fastcall mrp_behavior(void *s, void *)
+{ return _ZN14MrI_Projectile8BehaviorEv(s); }
+/* The projectile's Render is a real method with NO vtable dispatch in it (two
+   Particle::System::NewUnkCallback818 calls), so the matched TU is used. */
+static int __fastcall mrp_render(void *s, void *)
+{ return _ZN14MrI_Projectile6RenderEv(s); }
+static int __fastcall mrp_pdes(void *s, void *)
+{ (void)s; _ZN14MrI_Projectile16OnPendingDestroyEv(); return 0; }
+static int __fastcall mrp_d0(void *s, void *)
+{ return (int)(size_t)_ZN14MrI_ProjectileD0Ev((int *)s); }
+static int __fastcall mrp_yoshi(void *s, void *)
+{ (void)s; return func_ov071_02121b00(); }
+static int __fastcall mrp_d1(void *s, void *)
+{
+    char *t = (char *)s;
+    *(void **)t = (void *)_ZTV14MrI_Projectile;
+    _ZN12WithMeshClsnD1Ev(t + 0x13c);
+    _ZN25MovingCylinderClsnWithPosD1Ev(t + 0xfc);
+    _ZN11ShadowModelD1Ev(t + 0xd4);
+    _ZN5ActorD2Ev(t);
+    return (int)(size_t)s;
+}
+
+/* the eighteen shared-half seats both tables get, written once */
+#define MRI_SHARED_TAIL(vt)                       \
+    vt[1]  = (void *)mri_binit;                   \
+    vt[2]  = (void *)mri_ainit;                   \
+    vt[4]  = (void *)mri_bclean;                  \
+    vt[5]  = (void *)mri_aclean;                  \
+    vt[7]  = (void *)mri_bbeh;                    \
+    vt[8]  = (void *)mri_abeh;                    \
+    vt[10] = (void *)mri_bren;                    \
+    vt[11] = (void *)mri_aren;                    \
+    vt[13] = (void *)mri_trap13;                  \
+    vt[14] = (void *)mri_trap14;                  \
+    vt[15] = (void *)mri_heap;                    \
+    vt[19] = (void *)mri_egg;                     \
+    vt[20] = (void *)mri_v50;                     \
+    vt[21] = (void *)mri_pounded;                 \
+    vt[22] = (void *)mri_atk1;                    \
+    vt[23] = (void *)mri_atk2;                    \
+    vt[24] = (void *)mri_kicked;                  \
+    vt[25] = (void *)mri_pushed;                  \
+    vt[26] = (void *)mri_cannon;                  \
+    vt[27] = (void *)mri_mega;                    \
+    vt[28] = (void *)mri_under;                   \
+    vt[29] = (void *)mri_aimed;                   \
+    vt[30] = (void *)mri_trap30;
+
+/* MR_I (262) and BIG_MR_I (263) share this one table -- both factories store
+   _ZTV3MrI, and the class tells the two apart by its own actor id. */
+extern "C" void hal_fill_mri_vtable(void)
+{
+    void **vt = (void **)_ZTV3MrI;
+    vt[0]  = (void *)mri_init;
+    vt[3]  = (void *)mri_clean;
+    vt[6]  = (void *)mri_behavior;
+    vt[9]  = (void *)mri_render;
+    vt[12] = (void *)mri_pdes;
+    vt[16] = (void *)mri_d1;
+    vt[17] = (void *)mri_d0;
+    vt[18] = (void *)mri_yoshi;   /* Actor's default; MrI has no override */
+    MRI_SHARED_TAIL(vt)
+}
+
+extern "C" void hal_fill_mri_projectile_vtable(void)
+{
+    void **vt = (void **)_ZTV14MrI_Projectile;
+    vt[0]  = (void *)mrp_init;
+    vt[3]  = (void *)mrp_clean;
+    vt[6]  = (void *)mrp_behavior;
+    vt[9]  = (void *)mrp_render;
+    vt[12] = (void *)mrp_pdes;
+    vt[16] = (void *)mrp_d1;
+    vt[17] = (void *)mrp_d0;
+    vt[18] = (void *)mrp_yoshi;   /* its OWN, func_ov071_02121b00, returns 4 */
+    MRI_SHARED_TAIL(vt)
+}

--- a/port/hal/actor_classes_ov071.cpp
+++ b/port/hal/actor_classes_ov071.cpp
@@ -120,6 +120,8 @@
 
 #include "Actor.h"
 #include "ActorBase.h"
+#include "MrI.h"
+#include "MrI_Projectile.h"
 
 extern "C" {
 /* the shared lifecycle halves, the same functions every fill writes */
@@ -146,21 +148,24 @@ const char *port_actor_class_name(unsigned id);            /* hal/actor_registry
 void port_actor_slot_decline(const char *what);            /* func_02043fdc.cpp */
 void port_actor_render_probe(const char *cls, void *model); /* actor_classes */
 
-/* ---- MR. I's own bodies --------------------------------------------------- */
-int _ZN3MrI13InitResourcesEv(char *self);      /* slot 0,  nonmatching src */
+/* ---- MR. I's own bodies ----------------------------------------------------
+   Behavior is a REAL C++ METHOD (src/_ZN3MrI8BehaviorEv.cpp defines
+   `int MrI::Behavior()` against include/MrI.h), so it is reached qualified
+   below, not by the _ZN name -- the Scuttlebug Init/Behavior/Render treatment.
+   InitResources IS spelled extern "C" inside its own TU, so it keeps the
+   _ZN name; Render is this lane's host copy. */
+int _ZN3MrI13InitResourcesEv(char *self);      /* slot 0,  nonmatching src, extern "C" */
 int _ZN3MrI16CleanupResourcesEv(void);         /* slot 3,  C linkage, no self */
-int _ZN3MrI8BehaviorEv(void *self);            /* slot 6,  real C++ member */
 int _ZN3MrI6RenderEv(void *self);              /* slot 9,  HOST COPY */
 void _ZN3MrI16OnPendingDestroyEv(void);        /* slot 12, empty, no self */
 int *_ZN3MrID0Ev(int *self);                   /* slot 17, C linkage */
 void *MrI_Spawn(void);
 void *BigMrI_Spawn(void);
 
-/* ---- MR_I_PROJECTILE's own bodies ----------------------------------------- */
-int _ZN14MrI_Projectile13InitResourcesEv(void *self);   /* slot 0  */
+/* ---- MR_I_PROJECTILE's own bodies -----------------------------------------
+   Init/Behavior/Render are all real C++ methods against
+   include/MrI_Projectile.h -- reached qualified below. */
 int _ZN14MrI_Projectile16CleanupResourcesEv(void);      /* slot 3  */
-int _ZN14MrI_Projectile8BehaviorEv(void *self);         /* slot 6  */
-int _ZN14MrI_Projectile6RenderEv(void *self);           /* slot 9  */
 void _ZN14MrI_Projectile16OnPendingDestroyEv(void);     /* slot 12 */
 int *_ZN14MrI_ProjectileD0Ev(int *self);                /* slot 17 */
 int func_ov071_02121b00(void);                          /* slot 18, returns 4 */
@@ -200,6 +205,25 @@ int _ZTV14MrI_Projectile[31];
    spelling is another module's dsd export winning the race at a shared-window
    address. Alias by address; the config rename goes upstream as its own PR. */
 #pragma comment(linker, "/alternatename:_data_ov074_02123038=_data_ov071_02123038")
+
+/* C++-MANGLED DATA SPELLINGS, the data_02082128 / data_020a0e68 precedent.
+   src/_ZN3MrI13InitResourcesEv.c and the two MrI_Projectile method TUs declare
+   their mount data OUTSIDE any extern "C" block, so MSVC mangles the
+   references while the mount defines the plain C names. Point each mangled
+   spelling at the one host object. Every LHS below is the exact decorated name
+   the linker asked for, and each is undefined everywhere else, so no alias can
+   be defeated by a real definition (the wave-5 R1/R2 lesson). */
+#pragma comment(linker, "/alternatename:?data_ov071_02123038@@3USharedFilePtr@@A=_data_ov071_02123038")
+#pragma comment(linker, "/alternatename:?data_ov071_02123048@@3USharedFilePtr@@A=_data_ov071_02123048")
+#pragma comment(linker, "/alternatename:?data_ov071_02123050@@3USharedFilePtr@@A=_data_ov071_02123050")
+#pragma comment(linker, "/alternatename:?data_ov071_021226a0@@3USharedFilePtr@@A=_data_ov071_021226a0")
+#pragma comment(linker, "/alternatename:?data_ov071_021226a4@@3PAPAUSharedFilePtr@@A=_data_ov071_021226a4")
+/* data_ov071_021230b8 is the gravity Vector3 __sinit_ov071_02122a1c seats
+   {0, -0x19000, 0}. MrI_Projectile::Behavior spells it `Vector3` and
+   MrI_Projectile::InitResources spells the SAME address `void *` -- one
+   storage, two spellings, the data_ov071_02122ecc_d case in the sibling fill. */
+#pragma comment(linker, "/alternatename:?data_ov071_021230b8@@3UVector3@@A=_data_ov071_021230b8")
+#pragma comment(linker, "/alternatename:?data_ov071_021230b8@@3PAXA=_data_ov071_021230b8")
 
 // ---- the trap --------------------------------------------------------------
 static void mri_trap_report(void *self, int slot)
@@ -273,7 +297,7 @@ static int __fastcall mri_init(void *s, void *)
 static int __fastcall mri_clean(void *s, void *)
 { (void)s; return _ZN3MrI16CleanupResourcesEv(); }
 static int __fastcall mri_behavior(void *s, void *)
-{ return _ZN3MrI8BehaviorEv(s); }
+{ return ((MrI *)s)->MrI::Behavior(); }
 /* Render is the MrI_Render host copy (ROM-order ModelAnim slot-5 dispatch, the
    Whomp/Fish case), not the matched TU. */
 static int __fastcall mri_render(void *s, void *)
@@ -299,15 +323,16 @@ static int __fastcall mri_d1(void *s, void *)
 
 // ---- MR_I_PROJECTILE's own slots -------------------------------------------
 static int __fastcall mrp_init(void *s, void *)
-{ return _ZN14MrI_Projectile13InitResourcesEv(s); }
+{ return ((MrI_Projectile *)s)->MrI_Projectile::InitResources(); }
 static int __fastcall mrp_clean(void *s, void *)
 { (void)s; return _ZN14MrI_Projectile16CleanupResourcesEv(); }
 static int __fastcall mrp_behavior(void *s, void *)
-{ return _ZN14MrI_Projectile8BehaviorEv(s); }
+{ return ((MrI_Projectile *)s)->MrI_Projectile::Behavior(); }
 /* The projectile's Render is a real method with NO vtable dispatch in it (two
-   Particle::System::NewUnkCallback818 calls), so the matched TU is used. */
+   Particle::System::NewUnkCallback818 calls), so the matched TU is used --
+   unlike MrI::Render, which is this lane's ModelAnim slot-5 host copy. */
 static int __fastcall mrp_render(void *s, void *)
-{ return _ZN14MrI_Projectile6RenderEv(s); }
+{ return ((MrI_Projectile *)s)->MrI_Projectile::Render(); }
 static int __fastcall mrp_pdes(void *s, void *)
 { (void)s; _ZN14MrI_Projectile16OnPendingDestroyEv(); return 0; }
 static int __fastcall mrp_d0(void *s, void *)

--- a/port/hal/actor_classes_ov071.cpp
+++ b/port/hal/actor_classes_ov071.cpp
@@ -31,14 +31,15 @@
 // exactly the trap the double test exists for. So the syms header's "198/199"
 // is a mis-attribution and "262?" was one class short.
 //
-// THE OVERLAY BASE the byte reads use is 0x0211f000, NOT the 0x0211f600 that
-// extracted/dsd/arm9_overlays/overlays.yaml records as base_address 34729984.
-// The yaml is stale by 0x600. Pinned three ways that agree, all in
+// THE OVERLAY BASE the byte reads use is 0x0211f000 -- which IS the yaml's
+// base_address 34729984 (34729984 == 0x0211f000; the yaml is correct, a
+// wrong hex gloss in the lane brief said 0x0211f600).
+// Pinned three ways that agree, all in
 // config/arm9/overlays/ov071/delinks.txt and the yaml's own size fields:
 // .text start:0x0211f000, .bss end:0x02123100; image 0x02122f80-0x0211f000 =
 // 0x3f80 = 16256 = ram_size = the byte length of overlay_0071.bin; bss
-// 0x02123100-0x02122f80 = 0x180 = 384 = bss_size. At 0x0211f600 the symbol
-// func_ov071_0211f0a4 would sit below the overlay.
+// 0x02123100-0x02122f80 = 0x180 = 384 = bss_size. At the glossed 0x0211f600
+// the symbol func_ov071_0211f0a4 would sit below the overlay.
 //
 // ---- 263 IS A FREE SHARE OF 262'S FILL -------------------------------------
 // MrI_Spawn (0x02121a1c) and BigMrI_Spawn (0x021219cc) are the SAME function

--- a/port/hal/actor_overlays.cpp
+++ b/port/hal/actor_overlays.cpp
@@ -1122,7 +1122,8 @@ extern "C" void port_actor_overlays_sinits(void)
     /* run linkw wave 7, lane w7b: the same order one class over. MrI's SIX
        state SOURCE PMFs (data_ov071_02122ca8/cb0/cb8/cc0/cc8/cd0) must be
        seated over their host bodies BEFORE __sinit_ov071_021228c8 copies them
-       into data_ov071_02123088 -- that sinit is the very next call below. */
+       into data_ov071_02123088 -- that sinit runs below (after
+       __sinit_ov071_021226ac, which is the next call; ordering holds). */
     port_mri_states_seat();
     __sinit_ov071_021226ac();
     __sinit_ov071_021228c8();

--- a/port/hal/actor_overlays.cpp
+++ b/port/hal/actor_overlays.cpp
@@ -837,6 +837,7 @@ void __sinit_ov071_021228c8(void);
 void __sinit_ov071_02122a1c(void);
 void __sinit_ov071_02122a64(void);
 void port_scuttlebug_states_seat(void);
+void port_mri_states_seat(void);   /* wave 7 lane w7b, unmatched/MrI_StateDispatch.cpp */
 }
 
 /* ---- gate 177: ov064, Lethal Lava Land's actor overlay, first mount ----
@@ -1118,6 +1119,11 @@ extern "C" void port_actor_overlays_sinits(void)
     port_ov071_pack_check();
     port_ov071_syms_patch();
     port_scuttlebug_states_seat();
+    /* run linkw wave 7, lane w7b: the same order one class over. MrI's SIX
+       state SOURCE PMFs (data_ov071_02122ca8/cb0/cb8/cc0/cc8/cd0) must be
+       seated over their host bodies BEFORE __sinit_ov071_021228c8 copies them
+       into data_ov071_02123088 -- that sinit is the very next call below. */
+    port_mri_states_seat();
     __sinit_ov071_021226ac();
     __sinit_ov071_021228c8();
     __sinit_ov071_02122a1c();

--- a/port/ov071_syms.txt
+++ b/port/ov071_syms.txt
@@ -76,3 +76,44 @@ data_ov071_021230e0 data_ov071_021230ec:0x14
 # readback in overlay_0071.bin: w0 = 0x02122670 = Coffin_Spawn, +4 reads 64.
 # Span 0x1c by the next symbol (data_ov071_02122ecc, the state table).
 Coffin_SpawnInfo
+
+# ---------------------------------------------------------------------------
+# run linkw wave 7 (lane w7b): THE MR. I FAMILY joins -- MR_I (262), BIG_MR_I
+# (263) and MR_I_PROJECTILE (264).
+#
+# THE HEADER COMMENT AT THE TOP OF THIS FILE IS WRONG about the ids and is left
+# in place only so this correction has something to point at. It says ov071
+# carries "MrI/BigMrI (198/199, the eyeball), MrI_Projectile (262?)". Re-derived
+# from the ROM by the double test the shared ov070/071/073/074 window makes
+# mandatory -- the spawnFunc must land INSIDE ov071 AND the record's +4 id
+# halfword must match -- the real map is:
+#
+#   id  spawn-table slot        SpawnInfo   word[0]                  +4 reads
+#   262 0x02090c7c -> 0x02122cf0 MrI        0x02121a1c MrI_Spawn          262
+#   263 0x02090c80 -> 0x02122d0c BigMrI     0x021219cc BigMrI_Spawn       263
+#   264 0x02090c84 -> 0x02122dc4 MrI_Proj   0x02121f9c MrI_Projectile_S.  264
+#
+# Ids 198 and 199 DO point at records inside this overlay's window, but their
+# word[0] spawnFuncs land OUTSIDE ov071 -- another module sharing the window,
+# which is precisely the trap the double test exists for.
+#
+# Each record is pinned to its real 0x1c. MrI_SpawnInfo would take 0x1c from the
+# next symbol anyway; the other two would take 0x24 (the next symbol is the
+# class's VTABLE, which is a HOST array deliberately left out of this mount) and
+# would over-size into a host/ROM gap -- the Scuttlebug_SpawnInfo lesson.
+MrI_SpawnInfo:0x1c
+BigMrI_SpawnInfo:0x1c
+MrI_Projectile_SpawnInfo:0x1c
+
+# The .rodata pointer table MrI's InitResources and CleanupResources index, the
+# only data this lane adds. .rodata is 0x021226a0..0x021226ac (3 words) and the
+# config names only the first two of them:
+#   021226a0 -> 0x02123048  the anim SharedFilePtr   (Animation::LoadFile)
+#   021226a4 -> 0x02123038  the texseq SharedFilePtr }  CleanupResources walks
+#   021226a8 -> 0x02123040  the texseq SharedFilePtr }  (&data..21226a4)[i], i<2
+# so data_ov071_021226a4 must carry BOTH words as one object -- it is indexed as
+# a two-element array by both methods. Its next-symbol delta would run to
+# 0x02122b30 (the .ctor section, past all four sinit bodies), so it is pinned to
+# its real 0x8. All three pointees (02123038/40/48) were already mounted above.
+data_ov071_021226a0
+data_ov071_021226a4:0x8

--- a/port/slice_w7b.txt
+++ b/port/slice_w7b.txt
@@ -75,6 +75,12 @@ src/func_ov071_0212110c.c
 src/func_ov071_021214f4.c
 src/func_ov071_0212152c.c
 src/func_ov071_02121570.c
+# The one arm9 body the closure reaches that no earlier gate had linked:
+# func_ov071_02120b14's call at 0x02120b50 relocates to 0x02010374 =
+# Actor::FindExplosionActor(CylinderClsn&) (arm9 symbols.txt, size 0x40), and
+# nothing else in the binary named it before this lane -- /OPT:REF had always
+# stripped it. Measured as a link error, not guessed.
+src/_ZN5Actor18FindExplosionActorER12CylinderClsn.c
 
 # ---- MR_I_PROJECTILE (264) --------------------------------------------------
 src/MrI_Projectile_Spawn.c
@@ -85,7 +91,18 @@ src/_ZN14MrI_Projectile16OnPendingDestroyEv.c
 src/_ZN14MrI_Projectile6RenderEv.cpp
 src/_ZN14MrI_Projectile8BehaviorEv.cpp
 src/func_ov071_02121b00.c
-src/func_ov071_02121b08.c
 src/func_ov071_02121b50.c
-src/func_ov071_02121ba4.cpp
 src/func_ov071_02121c6c.cpp
+# NOT listed here -- routed through hostgen instead (${GATE_W7B_GEN} in
+# port/CMakeLists.txt), two mwcc-vs-MSVC syntax quirks the byte-verified tree
+# must not be edited for. Both are still the decomp's own bodies; hostgen only
+# rewrites the wrapper:
+#   func_ov071_02121b08 -- C++ inside a .c (`struct Callback {}`, an empty
+#       struct, which C rejects: MSVC error C2016). hostgen emits it as .cpp
+#       with the symbols wrapped back to C linkage -- the gate-9 /
+#       func_ov084_021298d0 case.
+#   func_ov071_02121ba4 -- decl_common.h:2793 declares it `(void*)` inside that
+#       header's extern "C" block while the TU defines it `(char*)`. One
+#       register on the ROM, C2733 to MSVC. hostgen's HEADER_SHADOW hides the
+#       header's declaration across the include -- the func_ov102_0214b248
+#       case; the table entry is this lane's addition to port/tools/hostgen.py.

--- a/port/slice_w7b.txt
+++ b/port/slice_w7b.txt
@@ -1,0 +1,91 @@
+# RUN LINKW WAVE 7, lane w7b: THE MR. I FAMILY out of ov071 -- MR_I (262) and
+# BIG_MR_I (263), which share ONE class and ONE vtable (_ZTV3MrI), plus
+# MR_I_PROJECTILE (264), the shot MrI state 1 fires.
+#
+# ov071 needs NO new mount: gate 176 (SCUTTLEBUG 255) stood the overlay up
+# per-symbol and wave 5 lane w5-A added COFFIN. This lane appends only two
+# .rodata pointer words to port/ov071_syms.txt (data_ov071_021226a0 and
+# data_ov071_021226a4:0x8, the SharedFilePtr pointer table MrI's InitResources
+# and CleanupResources index) -- every other datum the closure touches was
+# already mounted.
+#
+# WHY 264 IS IN THIS SLICE AND NOT A SEPARATE GATE: MrI's state 1 MAIN
+# (func_ov071_021211e0, 0x021213cc..0x021213d4) calls
+# Actor::Spawn(0x108, ...) -- 0x108 is 264. Registering 262/263 without 264
+# would hand the pre-spawn gate an unregistered id every time a Mr. I fires,
+# so the projectile is part of the family's closure, not an extra.
+#
+# EXCLUDED from the slice, host-copied in port/unmatched/:
+#   func_ov071_02120d30 -- MrI state 2 MAIN; NO src/ TU exists at all.
+#                          MrI_StateMains.cpp (0x3dc, verified copy)
+#   func_ov071_021211e0 -- MrI state 1 MAIN; NO src/ TU exists at all.
+#                          MrI_StateMains.cpp (0x314, verified copy)
+#   func_ov071_021215c0 -- the MAIN dispatcher; `c->pp + 1` is an mwcc 8-byte
+#                          PMF stride MSVC makes 4, so the host `+1` lands on
+#                          the delta word. MrI_StateDispatch.cpp
+#   func_ov071_021215fc -- the ENTER dispatcher, same wrong stride modelled.
+#                          MrI_StateDispatch.cpp
+#   _ZN3MrI6RenderEv    -- ModelAnim slot-5 collision (the Whomp/Fish/
+#                          Scuttlebug case): the matched TU dispatches slot 5
+#                          of a local six-virtual shadow, which is
+#                          ModelAnim::Render in ROM order but Virtual18 in the
+#                          host's MSVC-ordered _ZTV9ModelAnim. MrI_Render.cpp
+# EXCLUDED, host thunks in the fill (hal/actor_classes_ov071.cpp):
+#   _ZN3MrID1Ev            -- auto-emitted-member-dtor form, the flame/
+#                             Scuttlebug D1 treatment; the thunk runs the D0
+#                             chain minus the final Memory::Deallocate.
+#   _ZN14MrI_ProjectileD1Ev -- same form, same treatment.
+#
+# The two vtables _ZTV3MrI and _ZTV14MrI_Projectile stay OUT (host arrays the
+# registry fills, the ov095/ov080 rule). The state records __sinit_ov071_021228c8
+# builds carry DS code addresses; the seat over the SIX source PMFs
+# (data_ov071_02122ca8/cb0/cb8/cc0/cc8/cd0, all already mounted) rewrites them
+# to host bodies before that sinit copies them into data_ov071_02123088.
+#
+# ONE BODY IS NONMATCHING-BUT-DECOMPILED: src/_ZN3MrI13InitResourcesEv.c is
+# banked "NONMATCHING: constant / value (div=6). Logic verified correct vs ROM".
+# It is real behaviour rather than a stub, so it rides the slice; it also needs
+# LANGUAGE CXX (a //cpp marker over extern "C" blocks and reference params),
+# wired in port/CMakeLists.txt beside the gate-176 func_ov071_0211f7d4.c entry.
+#
+# Cross-overlay reach: ov002 only (the engine overlay, always mounted) --
+# data_ov002_0210da38, the blue-coin model SharedFilePtr MrI loads and releases.
+# Everything else the closure names is ov071's own or arm9, and every ov071
+# callee is in this file (checked by scanning the closure for func_ov071_*
+# references: the only two that resolve outside it are the two dispatchers
+# above, by design).
+
+# ---- MR_I / BIG_MR_I (262 / 263), one class ---------------------------------
+src/MrI_Spawn.c
+src/BigMrI_Spawn.c
+src/_ZN3MrID0Ev.c
+src/_ZN3MrI13InitResourcesEv.c
+src/_ZN3MrI16CleanupResourcesEv.cpp
+src/_ZN3MrI16OnPendingDestroyEv.c
+src/_ZN3MrI8BehaviorEv.cpp
+src/func_ov071_02121634.c
+src/func_ov071_0212070c.c
+src/func_ov071_02120860.cpp
+src/func_ov071_021209c8.cpp
+src/func_ov071_02120a20.c
+src/func_ov071_02120a48.cpp
+src/func_ov071_02120b14.cpp
+src/func_ov071_02120c90.cpp
+src/func_ov071_0212110c.c
+src/func_ov071_021214f4.c
+src/func_ov071_0212152c.c
+src/func_ov071_02121570.c
+
+# ---- MR_I_PROJECTILE (264) --------------------------------------------------
+src/MrI_Projectile_Spawn.c
+src/_ZN14MrI_ProjectileD0Ev.c
+src/_ZN14MrI_Projectile13InitResourcesEv.cpp
+src/_ZN14MrI_Projectile16CleanupResourcesEv.c
+src/_ZN14MrI_Projectile16OnPendingDestroyEv.c
+src/_ZN14MrI_Projectile6RenderEv.cpp
+src/_ZN14MrI_Projectile8BehaviorEv.cpp
+src/func_ov071_02121b00.c
+src/func_ov071_02121b08.c
+src/func_ov071_02121b50.c
+src/func_ov071_02121ba4.cpp
+src/func_ov071_02121c6c.cpp

--- a/port/tools/hostgen.py
+++ b/port/tools/hostgen.py
@@ -388,6 +388,11 @@ HEADER_SHADOW = {
     # (void*,int) -- one register on the ROM, two C2733s to MSVC.
     "_ZN5Whomp13InitResourcesEv": ("decl_common.h",
                                    ("func_01ffb07c", "func_020396d0")),
+    # run linkw wave 7, lane w7b, MR_I_PROJECTILE (264): decl_common.h:2793
+    # declares func_ov071_02121ba4 `(void*)` inside its extern "C" block while
+    # src/func_ov071_02121ba4.cpp defines it `(char*)`. One register on the
+    # ROM, C2733 to MSVC -- the func_ov102_0214b248 case exactly.
+    "func_ov071_02121ba4": "decl_common.h",
 }
 
 # ---- REDUNDANT OUT-OF-LINE MEMBER REDECLARATIONS ---------------------------

--- a/port/unmatched/MrI_Render.cpp
+++ b/port/unmatched/MrI_Render.cpp
@@ -1,0 +1,55 @@
+/* HOST COPY of _ZN3MrI6RenderEv (ov071 0x021216b8, 0x34 bytes) -- the
+ * ModelAnim slot-5 collision, one more class into the same wall the
+ * Butterfly/Fish/QuestionBlock/Whomp/Scuttlebug copies in
+ * port/unmatched/ModelAnim_Renders.cpp already document.
+ *
+ * WHY: src/_ZN3MrI6RenderEv.cpp dispatches through a LOCAL six-virtual shadow
+ *
+ *     struct Sub { virtual int g0(); ... virtual int g5(void*); };
+ *     ((Sub*)((char*)&mModelAnim))->g5((char*)&mScaleX);
+ *
+ * so its "slot 5" is the ROM's ModelAnim::Render. hal/cxxname_bridge.cpp fills
+ * _ZTV9ModelAnim in MSVC order, where slot 5 is Virtual18 -- a two-argument
+ * method the shadow calls with one. That is the c0000005 the Butterfly gate
+ * measured, and _ZTV9ModelAnim cannot be dual-filled because Virtual18 really
+ * occupies the slot.
+ *
+ * The ROM body, read from extracted/overlays/overlay_0071.bin at base
+ * 0x0211f000 (the base derivation is in unmatched/MrI_StateMains.cpp), is
+ * thirteen instructions and does exactly two things:
+ *
+ *     021216c0  add r0, r4, #0x138      TextureSequence at +0x138
+ *     021216c4  add r1, r4, #0xdc       ModelComponents  at +0xdc
+ *     021216c8  bl  0x02015988          TextureSequence::Update(ModelComponents&)
+ *     021216cc  add r0, r4, #0xd4       &mModelAnim
+ *     021216d0  ldr r2, [r0]            its vptr
+ *     021216d4  add r1, r4, #0x80       &mScaleX
+ *     021216d8  ldr r2, [r2, #0x14]     vtable[5]  (0x14/4 = 5)
+ *     021216dc  blx r2                  ROM slot 5 = ModelAnim::Render
+ *     021216e0  mov r0, #1              returns 1
+ *
+ * The +0xdc argument is mModelAnim.data (mModelAnim sits at 0xd4, its
+ * ModelComponents at +0x8), the same relationship the Whomp copy spells.
+ * Only the dispatch is respelled as the qualified method the ROM means; the
+ * control flow is the matched source's, line for line.
+ *
+ * HOST COPY, not matched src: src/_ZN3MrI6RenderEv.cpp is EXCLUDED from this
+ * lane's slice. If _ZTV9ModelAnim ever gains a ROM-order view, this retires.
+ */
+#include "Model.h"
+#include "ModelAnim.h"
+
+extern "C" {
+int _ZN15TextureSequence6UpdateER15ModelComponents(void *seq, void *comp);
+int _ZN3MrI6RenderEv(void *selfv);
+}
+
+/* PORT_HOST_ABI: ROM-order ModelAnim slot-5 dispatch, the Whomp/Fish case. */
+extern "C" int _ZN3MrI6RenderEv(void *selfv)
+{
+    char *c = (char *)selfv;
+    _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x138, c + 0xdc);
+    /* ((Sub *)&mModelAnim)->g5(&mScaleX) -- the ROM slot-5 Render */
+    ((ModelAnim *)(c + 0xd4))->ModelAnim::Render((const Vector3 *)(c + 0x80));
+    return 1;
+}

--- a/port/unmatched/MrI_StateDispatch.cpp
+++ b/port/unmatched/MrI_StateDispatch.cpp
@@ -1,0 +1,146 @@
+/* HOST COPIES of MR. I's (MrI / daEykn_c, actors 262 and 263, ov071) two state
+ * dispatchers, and the seat of the table they read.
+ *
+ * This is the Scuttlebug treatment applied to the second class in the same
+ * overlay -- see port/unmatched/Scuttlebug_StateDispatch.cpp, which this file
+ * is built on. The shapes are identical; the addresses, the record count and
+ * the source list are MrI's own and were re-derived from the ROM.
+ *
+ * ---- THE MACHINE, READ OUT OF THE ROM --------------------------------------
+ * MrI drives a THREE-state machine through data_ov071_02123088 (bss), three
+ * 16-byte records each holding an {ENTER, MAIN} pair of mwcc {fn, delta} PMFs.
+ *
+ *   func_ov071_02121634(c, idx)  -- MrI_SetState. `add r1, r2, r1, lsl #4`:
+ *       stores &data_ov071_02123088[idx] at 16-byte stride into c+0x1e4, then
+ *       tail-calls the ENTER dispatcher. MATCHED SRC and correct as it stands
+ *       (src/func_ov071_02121634.c strides a 16-byte `Item16`), so it rides
+ *       the slice rather than being copied here.
+ *   func_ov071_021215fc(c)  -- ENTER: reads record+0, called on SetState
+ *   func_ov071_021215c0(c)  -- MAIN:  reads record+8, called by MrI::Behavior
+ *                              every frame
+ *
+ * The record array is filled by __sinit_ov071_021228c8, which copies SIX
+ * 8-byte SOURCE PMFs into it. The mapping below is the sinit's OWN store
+ * offsets (0x02122940..0x021229b8), not a guess:
+ *
+ *   record 0 (+0x00) <- data_ov071_02122cb8 (enter) , data_ov071_02122cc0 (main)
+ *   record 1 (+0x10) <- data_ov071_02122ca8 (enter) , data_ov071_02122cd0 (main)
+ *   record 2 (+0x20) <- data_ov071_02122cb0 (enter) , data_ov071_02122cc8 (main)
+ *
+ * and the six source words, read raw out of extracted/overlays/overlay_0071.bin
+ * at base 0x0211f000 (NOT the stale 0x0211f600 in overlays.yaml -- see the
+ * base derivation in unmatched/MrI_StateMains.cpp), are:
+ *
+ *   02122ca8 -> 021214f4 / 0    state 1 enter   matched src
+ *   02122cb0 -> 0212110c / 0    state 2 enter   matched src
+ *   02122cb8 -> 02121570 / 0    state 0 enter   matched src
+ *   02122cc0 -> 0212152c / 0    state 0 main    matched src
+ *   02122cc8 -> 02120d30 / 0    state 2 main    HOST COPY (MrI_StateMains.cpp)
+ *   02122cd0 -> 021211e0 / 0    state 1 main    HOST COPY (MrI_StateMains.cpp)
+ *
+ * All six .delta halves are 0 (non-virtual complete-class form, per the bytes).
+ * data_ov071_02123088's mounted span is 0x30 -- three records exactly, closed
+ * by the next symbol data_ov071_021230b8 -- so the array cannot silently
+ * over-run. All six sources were ALREADY in port/ov071_syms.txt from the
+ * gate-176 mount; this lane adds no new source symbols, only the seat.
+ *
+ * ---- WHY BOTH DISPATCHERS MUST BE HOST COPIES ------------------------------
+ * The same two reasons as Scuttlebug's pair, verified against the matched TUs:
+ *
+ *   1. src/func_ov071_021215c0.cpp is
+ *          struct C; typedef void (C::*PMF)();
+ *          struct C { char pad[0x1e4]; PMF *pp; };
+ *          void func_ov071_021215c0(C *c) { PMF *p = c->pp + 1; (c->**p)(); }
+ *      `c->pp + 1` is an mwcc 8-byte PMF stride. MSVC forms a 4-byte PMF over
+ *      the complete single-inheritance C, so the host `+ 1` lands on the
+ *      record's +4 -- the delta=0 word -- instead of the MAIN PMF at +8, and
+ *      dispatches a zero. That is a null call on the FIRST frame MrI ticks.
+ *   2. src/func_ov071_021215fc.cpp reads `*c->pp`, which happens to work
+ *      because delta is 0, but models the same wrong stride. Both are read
+ *      here as plain { fn, 0 } halves and the fn is called with `this`.
+ *
+ * ---- WHY THE SEAT ----------------------------------------------------------
+ * The words the sinit copies are the overlay image's own -- DS CODE ADDRESSES.
+ * The seat rewrites each SOURCE PMF's fn word with its host body BEFORE
+ * __sinit_ov071_021228c8 copies it into the runtime array (the MontyMole /
+ * Crate / Scuttlebug order: seat the source, before the copy). Each rewrite is
+ * gated on the mount holding the ROM's own word, so a mount pointing at the
+ * wrong bytes aborts loudly instead of copying a DS address into a live table.
+ * Invocation order is in hal/actor_overlays.cpp: this seat runs after
+ * port_scuttlebug_states_seat() and before the four ov071 sinits.
+ */
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+
+/* the six state halves. Four are matched src (this lane's slice); the two
+   MAIN halves of states 1 and 2 are the host copies in MrI_StateMains.cpp. */
+int func_ov071_02121570(void *c);   /* state 0 enter, matched src */
+int func_ov071_0212152c(void *c);   /* state 0 main , matched src */
+int func_ov071_021214f4(void *c);   /* state 1 enter, matched src */
+int func_ov071_021211e0(char *c);   /* state 1 main , HOST COPY */
+int func_ov071_0212110c(char *c);   /* state 2 enter, matched src */
+int func_ov071_02120d30(char *c);   /* state 2 main , HOST COPY */
+
+struct PortPmf { unsigned fn; int delta; };
+
+/* the six SOURCE PMFs __sinit_ov071_021228c8 copies from, address order */
+extern PortPmf data_ov071_02122ca8[], data_ov071_02122cb0[],
+    data_ov071_02122cb8[], data_ov071_02122cc0[], data_ov071_02122cc8[],
+    data_ov071_02122cd0[];
+
+void func_ov071_021215c0(void *c);
+void func_ov071_021215fc(void *c);
+void port_mri_states_seat(void);
+
+}  /* extern "C" */
+
+/* PORT_HOST_ABI: the matched TU forms `c->pp + 1` -- an mwcc 8-byte PMF stride
+   MSVC makes 4. Read the MAIN PMF at the record's +8 half directly.
+   ROM 0x021215c0, 0x3c bytes. */
+extern "C" void func_ov071_021215c0(void *c)
+{
+    PortPmf *rec = *(PortPmf **)((char *)c + 0x1e4);
+    ((void (*)(void *))(size_t)rec[1].fn)(c);
+}
+
+/* PORT_HOST_ABI: the matched TU forms `(c->**c->pp)()` over the ENTER PMF at
+   the record's +0; here the record is read as a plain { fn, 0 } and the fn
+   called with `this`. ROM 0x021215fc, 0x38 bytes. */
+extern "C" void func_ov071_021215fc(void *c)
+{
+    PortPmf *rec = *(PortPmf **)((char *)c + 0x1e4);
+    ((void (*)(void *))(size_t)rec[0].fn)(c);
+}
+
+/* Each SOURCE PMF, in the mount's address order, with the ROM fn it holds and
+   the host body that replaces it. */
+static const struct { PortPmf *slot; unsigned rom; int (*host)(void *); }
+g_mri_sources[] = {
+    {data_ov071_02122ca8, 0x021214f4, (int (*)(void *))func_ov071_021214f4}, /* s1 enter */
+    {data_ov071_02122cb0, 0x0212110c, (int (*)(void *))func_ov071_0212110c}, /* s2 enter */
+    {data_ov071_02122cb8, 0x02121570, (int (*)(void *))func_ov071_02121570}, /* s0 enter */
+    {data_ov071_02122cc0, 0x0212152c, (int (*)(void *))func_ov071_0212152c}, /* s0 main  */
+    {data_ov071_02122cc8, 0x02120d30, (int (*)(void *))func_ov071_02120d30}, /* s2 main  */
+    {data_ov071_02122cd0, 0x021211e0, (int (*)(void *))func_ov071_021211e0}, /* s1 main  */
+};
+
+extern "C" void port_mri_states_seat(void)
+{
+    static int done;
+    if (done)
+        return;
+    done = 1;
+    for (unsigned i = 0; i < sizeof g_mri_sources / sizeof g_mri_sources[0];
+         ++i) {
+        PortPmf *p = g_mri_sources[i].slot;
+        if (p->fn != g_mri_sources[i].rom || p->delta != 0) {
+            std::fprintf(stderr, "FATAL: MrI source %u: the mount holds "
+                         "%08x/%d, the ROM's own table says %08x/0 -- WRONG "
+                         "BYTES\n", i, p->fn, p->delta, g_mri_sources[i].rom);
+            std::abort();
+        }
+        p->fn = (unsigned)(size_t)g_mri_sources[i].host;
+    }
+}

--- a/port/unmatched/MrI_StateDispatch.cpp
+++ b/port/unmatched/MrI_StateDispatch.cpp
@@ -28,7 +28,7 @@
  *   record 2 (+0x20) <- data_ov071_02122cb0 (enter) , data_ov071_02122cc8 (main)
  *
  * and the six source words, read raw out of extracted/overlays/overlay_0071.bin
- * at base 0x0211f000 (NOT the stale 0x0211f600 in overlays.yaml -- see the
+ * at base 0x0211f000 (= overlays.yaml's base_address 34729984 -- see the
  * base derivation in unmatched/MrI_StateMains.cpp), are:
  *
  *   02122ca8 -> 021214f4 / 0    state 1 enter   matched src

--- a/port/unmatched/MrI_StateMains.cpp
+++ b/port/unmatched/MrI_StateMains.cpp
@@ -1,0 +1,445 @@
+/* HOST COPIES of the two MR. I bodies src/ has NO TU for: the per-frame MAIN
+ * halves of MrI's states 1 and 2.
+ *
+ *   func_ov071_021211e0  ov071 0x021211e0, 0x314 bytes  -- state 1 MAIN, the
+ *                        chase/aim/fire core
+ *   func_ov071_02120d30  ov071 0x02120d30, 0x3dc bytes  -- state 2 MAIN, the
+ *                        spin-down / pop / reward core
+ *
+ * WHY HOST COPIES AND NOT SLICE LINES: there is nothing to slice. Every other
+ * body in MrI's block (ROM 0x02120668..0x02121a6c) has a src/ TU; these two
+ * alone do not. Measured, not carried: config/arm9/overlays/ov071/delinks.txt
+ * has no entry whose `.text start:` is either address, and the set difference
+ * between the func_ov071_* names in config/arm9/overlays/ov071/symbols.txt and
+ * the func_ov071_* files in src/ is exactly {func_ov071_02120d30,
+ * func_ov071_021211e0} -- two names, no others.
+ *
+ * ---- HOW THE SPANS WERE RE-DERIVED ----------------------------------------
+ * NOT carried from the brief. config/arm9/overlays/ov071/symbols.txt:
+ *     func_ov071_02120d30 kind:function(arm,size=0x3dc) addr:0x02120d30
+ *     func_ov071_021211e0 kind:function(arm,size=0x314) addr:0x021211e0
+ * and each size closes exactly on the next symbol (0x0212110c and 0x021214f4).
+ *
+ * THE OVERLAY BASE IS 0x0211f000, NOT the 0x0211f600 that
+ * extracted/dsd/arm9_overlays/overlays.yaml's `base_address: 34729984` says.
+ * The yaml entry is stale by 0x600 and reading the bytes at that base would
+ * have produced garbage for every listing below. The base is pinned three
+ * ways, all agreeing: config/arm9/overlays/ov071/delinks.txt opens
+ * `.text start:0x0211f000` and closes `.bss end:0x02123100`; the image span
+ * 0x02122f80 - 0x0211f000 = 0x3f80 = 16256 is exactly the yaml's own
+ * `ram_size` AND the byte length of extracted/overlays/overlay_0071.bin; and
+ * the bss span 0x02123100 - 0x02122f80 = 0x180 = 384 is exactly the yaml's
+ * `bss_size`. At base 0x0211f600 the symbol func_ov071_0211f0a4 would sit
+ * BELOW the overlay. File offset used throughout: addr - 0x0211f000.
+ *
+ * ---- VERIFICATION RECORD ---------------------------------------------------
+ * Method: disassemble the ROM span out of extracted/overlays/overlay_0071.bin
+ * (capstone, ARM) with config/arm9/overlays/ov071/relocs.txt and both symbol
+ * tables applied, then transcribe per instruction. Every constant, member
+ * offset, branch target and call target below is read from that listing; none
+ * is inferred. Size accounting closes on both:
+ *
+ *   func_ov071_02120d30: 0x3dc = 0x3a0 code (232 ARM instructions,
+ *       0x02120d30..0x021210d0) + 0x3c literal pool (15 words at 0x021210d0)
+ *   func_ov071_021211e0: 0x314 = 0x2fc code (191 ARM instructions,
+ *       0x021211e0..0x021214dc) + 0x18 literal pool (6 words at 0x021214dc)
+ *
+ * LITERAL POOL of func_ov071_02120d30 @0x021210d0 -- every word is used below:
+ *     021210d0  80008001   the signed magic for the /0x1fffe pair
+ *     021210d4  00000119   func_0201267c sound id (the spin loop)
+ *     021210d8  0001fffe   the divisor itself
+ *     021210dc  0000013a   Particle::System::New effect id
+ *     021210e0  0000013b   Particle::System::NewUnkCallback818 effect id
+ *     021210e4  00007fff   the +0x50 lifetime both systems get
+ *     021210e8  02082214   data_02082214, arm9 s16 [sin, cos] pairs
+ *     021210ec  00000215   the +0x215 member offset (DecIfAbove0_Byte)
+ *     021210f0  00000106   actor id 262 = MR_I
+ *     021210f4  00000107   actor id 263 = BIG_MR_I
+ *     021210f8  00000122   actor id 290, the thing MR_I leaves behind
+ *     021210fc  00000217   the +0x217 member offset (the star ref)
+ *     02121100  00000125   Particle::System::NewSimple effect id
+ *     02121104  00000126   Particle::System::NewSimple effect id
+ *     02121108  0209f2f8   data_0209f2f8, arm9 bss, the current level
+ *   (0x124, the third NewSimple id, is a `mov r0,#0x124` immediate, not pooled.)
+ *
+ * LITERAL POOL of func_ov071_021211e0 @0x021214dc -- likewise all used:
+ *     021214dc  000008fc   the UpdateAngle delta for the Y turn
+ *     021214e0  00000213   the +0x213 member offset (DecIfAbove0_Byte)
+ *     021214e4  02082214   data_02082214
+ *     021214e8  00000107   actor id 263 = BIG_MR_I (selects the big shot)
+ *     021214ec  00000165   func_0201267c sound id (the shot)
+ *     021214f0  005dc000   the leash distance, Fix12i
+ *
+ * THE ONE DIVISION. func_ov071_02120d30 spells `x / 0x1fffe` and `x % 0x1fffe`
+ * over *(int *)(self+0x1f8) with mwcc's magic-multiply sequence (smull by
+ * 0x80008001, add x, asr #16, add the sign bit; the remainder is then
+ * x - q*0x1fffe). That sequence was CHECKED to equal C truncating division by
+ * 0x1fffe, not assumed: evaluated against the C result over the edge cases
+ * (0, +-1, +-131069..131071, +-262139, +-(1<<20), +-0x7fffffff) and 20000
+ * random values in +-(1<<28) -- 0 mismatches. So `/` and `%` are the exact
+ * transcription and the magic does not need to be reproduced.
+ *
+ * CALL TARGETS: eighteen distinct, every one resolved BY ADDRESS from the
+ * listing, and every arity taken from the ROM's own register/stack use rather
+ * than from a C prototype (C linkage would hide an arity mismatch silently):
+ *
+ *   0203ae58  _Z14ApproachLinearRiii      (int*, int, int) -> int, r0..r2
+ *   0203af90  _Z11UpdateAngleRssis        (short*, short, int, short), r0..r3
+ *   0203add4  DecIfAbove0_Byte            (u8*) -> int, r0
+ *   0203b7ac  Vec3_HorzAngle              (Vector3*, Vector3*) -> s16
+ *   0203b770  Vec3_VertAngle              (Vector3*, Vector3*) -> s16
+ *   0203cfdc  Vec3_Dist                   (Vector3*, Vector3*) -> int
+ *   0201267c  func_0201267c               (int, void*), r0/r1
+ *   02022d80  Particle::System::New              7 args: r0..r3 + sp[0,4,8]
+ *   02022bb4  Particle::System::NewUnkCallback818 6 args: r0..r3 + sp[0,4]
+ *   02022e68  Particle::System::FromUniqueID     (u32) -> void*, r0
+ *   02022e98  Particle::System::NewSimple        (u32, int, int, int), r0..r3
+ *   02010e2c  Actor::Spawn                6 args: r0..r3 + sp[0,4]
+ *   0200fe3c  Actor::PoofDust             (this), r0
+ *   0200ff14  Actor::UntrackAndSpawnStar  5 args: r0..r3 + sp[0]
+ *   0200f9b8  Actor::KillAndTrackInDeathTable (this), r0
+ *   02043824  ActorBase::MarkForDestruction   (this), r0
+ *   02015c3c  Animation::Advance          (this), r0
+ *   02015bcc  Animation::Finished         (this) -> int, r0
+ *   0200f658  Actor::DetectRaycastClsn    (this, Vector3*, Vector3*, bool)
+ *   plus four ov071 siblings, all matched src and all in this lane's slice:
+ *   02120a20, 021209c8, 02120860, 0212070c, 02120b14, 02121634.
+ *
+ * The two arm9 data symbols were already mounted before this lane: the trig
+ * table as `short data_02082214[]` and the level byte as
+ * `signed char data_0209f2f8` (the spellings unmatched/Flamethrower_Behavior.c
+ * and unmatched/Actor_ClosestPlayer_OverlayReaders.cpp already use).
+ *
+ * HOST COPY, not matched src: when the decomp banks either real TU, that body
+ * retires for a slice line.
+ */
+#include <cstdio>
+
+extern "C" {
+
+/* ---- arm9 helpers, signatures pinned by the ROM's register use ------------ */
+int  _Z14ApproachLinearRiii(int *cur, int target, int step);
+void _Z11UpdateAngleRssis(short *cur, short target, int rate, short delta);
+int  DecIfAbove0_Byte(unsigned char *p);
+short Vec3_HorzAngle(const void *a, const void *b);
+short Vec3_VertAngle(const void *a, const void *b);
+int  Vec3_Dist(const void *a, const void *b);
+void func_0201267c(int id, void *p);
+
+unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned uniqueID, unsigned effectID, int x, int y, int z,
+    const void *dir, void *callback);
+void *_ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+    unsigned uniqueID, unsigned effectID, int x, int y, int z, const void *dir);
+void *_ZN8Particle6System12FromUniqueIDEj(unsigned uniqueID);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned id, int x, int y,
+                                                    int z);
+
+void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned actorID,
+                                                   unsigned param1,
+                                                   const void *pos,
+                                                   const void *rot,
+                                                   int areaID, int deathTableID);
+void _ZN5Actor8PoofDustEv(void *self);
+void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void *self, signed char *ref,
+                                                   unsigned b, const void *pos,
+                                                   unsigned j);
+void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
+void _ZN9ActorBase18MarkForDestructionEv(void *self);
+void _ZN9Animation7AdvanceEv(void *anim);
+int  _ZN9Animation8FinishedEv(void *anim);
+int  _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, void *from,
+                                                void *to, bool flag);
+
+extern short data_02082214[];     /* arm9: s16 [sin, cos] pairs, 4096 = 1.0 */
+extern signed char data_0209f2f8; /* arm9 bss: the current level */
+
+/* ---- MrI's own siblings, all matched src (this lane's slice) -------------- */
+int  func_ov071_02120a20(void *self);
+void func_ov071_021209c8(void *self);
+void func_ov071_02120860(void *self);
+int  func_ov071_0212070c(void *self);
+void func_ov071_02120b14(void *self);
+void func_ov071_02121634(void *self, int state);   /* MrI_SetState */
+
+int func_ov071_021211e0(char *self);
+int func_ov071_02120d30(char *self);
+
+}  /* extern "C" */
+
+namespace {
+struct V3  { int x, y, z; };
+struct V16 { short x, y, z; };
+
+/* The ROM's Fix12 multiply-accumulate: a 32x32 -> 64 signed product, rounded
+   with +0x800 and taken >> 12 (the `umull/mla/mla/adds/adc/lsr/orr` run). */
+inline int fx12(long long a, long long b)
+{
+    return (int)((a * b + 0x800) >> 12);
+}
+}  /* namespace */
+
+/* =========================================================================
+ * func_ov071_021211e0 -- ov071 0x021211e0, 0x314 bytes, MrI state 1 MAIN.
+ *
+ * Reached every frame while MrI is awake and hunting: it turns the eye toward
+ * the tracked actor at +0x1ec, and when the wind-up counter at +0x214 hits 7
+ * it fires actor 0x108 (264, MR_I_PROJECTILE) out of a muzzle point pushed
+ * 0x50000 forward along the Y angle. Then it runs the shared movement helper
+ * and drops back to state 0 on any of three leash conditions, or to state 2
+ * when func_ov071_0212070c reports the hit.
+ *
+ * Stack frame in the ROM is 0x44: sp+0x08 V16 shot angles, sp+0x10 V3 target,
+ * sp+0x1c V3 aim, sp+0x28 V3 muzzle, sp+0x34 V3 ray end; sp+0x00/0x04 are the
+ * outgoing stack halves of Actor::Spawn. The five locals below are those.
+ * ========================================================================= */
+int func_ov071_021211e0(char *self)
+{
+    V3  target;   /* sp+0x10 */
+    V16 shotAng;  /* sp+0x08 */
+    V3  aim;      /* sp+0x1c */
+    V3  muzzle;   /* sp+0x28 */
+    V3  rayEnd;   /* sp+0x34 */
+    char *t;
+
+    /* 021211ec..02121210: target = tracked->pos, lifted 0x78000 in Y */
+    t = *(char **)(self + 0x1ec);
+    target.x = *(int *)(t + 0x5c);
+    target.y = *(int *)(t + 0x60) + 0x78000;
+    target.z = *(int *)(t + 0x64);
+
+    /* 02121214: the ROM calls Vec3_HorzAngle here and DISCARDS r0 -- r0 is
+       overwritten at 0212121c before any use. Kept so the call sequence is the
+       ROM's; the function is pure, so keeping it is behaviourally free. */
+    (void)Vec3_HorzAngle(self + 0x5c, &target);
+
+    /* 02121220..02121234: pitch toward the target, rate 2, delta 0x320 */
+    _Z11UpdateAngleRssis((short *)(self + 0x8c),
+                         Vec3_VertAngle(self + 0x5c, &target), 2, 0x320);
+    /* 02121240..02121254: yaw toward the target, rate 2, delta 0x8fc */
+    _Z11UpdateAngleRssis((short *)(self + 0x8e),
+                         Vec3_HorzAngle(self + 0x5c, &target), 2, 0x8fc);
+
+    /* 02121258..021212a0: once the yaw has settled onto the stored facing,
+       tick the +0x213 timer down and re-arm from func_ov071_02120a20 */
+    if ((short)(*(short *)(self + 0x8e) - *(short *)(self + 0x20c)) == 0) {
+        if (DecIfAbove0_Byte((unsigned char *)(self + 0x213)) == 0) {
+            if (func_ov071_02120a20(self))
+                *(unsigned char *)(self + 0x213) = 0x53;
+        }
+        *(unsigned char *)(self + 0x212) = 0xf0;
+    }
+
+    /* 021212a4..02121408: the shot, only on wind-up step 7 */
+    if (*(unsigned char *)(self + 0x214) == 7) {
+        int ay, sinv, cosv;
+
+        /* 021212b0..021212d0: aim point = tracked->pos lifted 0x4b000 */
+        t = *(char **)(self + 0x1ec);
+        aim.x = *(int *)(t + 0x5c);
+        aim.y = *(int *)(t + 0x60) + 0x4b000;
+        aim.z = *(int *)(t + 0x64);
+
+        /* 021212d4..021212f4: muzzle starts at MrI's own position */
+        muzzle.x = *(int *)(self + 0x5c);
+        muzzle.y = *(int *)(self + 0x60);
+        muzzle.z = *(int *)(self + 0x64);
+
+        /* 021212f8..02121314: the shot inherits MrI's three angles */
+        shotAng.x = *(short *)(self + 0x8c);
+        shotAng.y = *(short *)(self + 0x8e);
+        shotAng.z = *(short *)(self + 0x90);
+
+        /* 02121318..0212138c: push the muzzle 0x50000 along the Y angle.
+           The ROM indexes data_02082214 as [sin, cos] pairs: sin at
+           (angY >> 4) * 2, cos at (angY >> 4) * 2 + 1, angY read UNSIGNED. */
+        ay = *(unsigned short *)(self + 0x8e);
+        sinv = data_02082214[(ay >> 4) * 2];
+        cosv = data_02082214[((ay >> 4) * 2) + 1];
+        muzzle.x = *(int *)(self + 0x5c) + fx12(sinv, 0x50000);
+        muzzle.z = *(int *)(self + 0x64) + fx12(cosv, 0x50000);
+
+        /* 02121390..02121394: the shot's pitch is muzzle -> aim */
+        shotAng.x = Vec3_VertAngle(&muzzle, &aim);
+
+        /* 02121398..021213d4: BIG_MR_I (263) fires param 1, MR_I (262) param 0 */
+        _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+            0x108,
+            (*(unsigned short *)(self + 0xc) == 0x107) ? 1u : 0u,
+            &muzzle, &shotAng,
+            *(signed char *)(self + 0xcc), -1);
+
+        /* 021213d8..02121408 */
+        func_0201267c(0x165, self + 0x74);
+        *(unsigned char *)(self + 0x216) = 0x2e;
+        *(unsigned char *)(self + 0x212) = 0xf0;
+        *(unsigned char *)(self + 0x213) = 0x53;
+        *(int *)(self + 0x1f4) = 0;
+        func_ov071_021209c8(self);
+    }
+
+    /* 0212140c..02121410 */
+    func_ov071_02120860(self);
+
+    /* 02121414..02121434: the ray end is the tracked actor lifted 0x8c000 */
+    t = *(char **)(self + 0x1ec);
+    rayEnd.x = *(int *)(t + 0x5c);
+    rayEnd.y = *(int *)(t + 0x60) + 0x8c000;
+    rayEnd.z = *(int *)(t + 0x64);
+
+    /* 02121438..021214c0: one of four exits, first match wins */
+    if (func_ov071_0212070c(self)) {
+        func_ov071_02121634(self, 2);
+    } else if (Vec3_Dist(self + 0x5c, &target) > 0x5dc000) {
+        func_ov071_02121634(self, 0);
+    } else if (*(unsigned char *)(*(char **)(self + 0x1ec) + 0x6fb) != 0) {
+        func_ov071_02121634(self, 0);
+    } else if (_ZN5Actor17DetectRaycastClsnER7Vector3S1_b(self, &rayEnd,
+                                                          self + 0x5c, false)) {
+        func_ov071_02121634(self, 0);
+    }
+
+    /* 021214c4..021214cc */
+    func_ov071_02120b14(self);
+    return 1;
+}
+
+/* =========================================================================
+ * func_ov071_02120d30 -- ov071 0x02120d30, 0x3dc bytes, MrI state 2 MAIN.
+ *
+ * The defeat sequence, run every frame once state 2 is entered: the eye spins
+ * up (the yaw integrator at +0x1f8 with its /0x1fffe sound tick), two particle
+ * systems are kept alive on the body, and a four-step machine on +0x214 winds
+ * the spin down, plays out the animation, shrinks the actor, and finally pops
+ * it -- MR_I (262) leaving actor 0x122 behind, BIG_MR_I (263) paying out the
+ * tracked star and three burst effects. Both ends run the same tail.
+ *
+ * Stack frame is 0x1c: sp+0x0c is the V3 handed to Actor::Spawn in the 262
+ * branch; sp+0x00..0x08 are outgoing stack args.
+ * ========================================================================= */
+int func_ov071_02120d30(char *self)
+{
+    V3 spawnPos;   /* sp+0x0c */
+
+    /* 02120d3c..02120d4c: ease the spin rate toward the stored target */
+    _Z14ApproachLinearRiii((int *)(self + 0x98), *(short *)(self + 0x20e),
+                           0x12c);
+
+    /* 02120d50..02120d74: advance the yaw and the accumulator by that rate */
+    *(short *)(self + 0x8e) =
+        (short)(*(short *)(self + 0x8e) + *(int *)(self + 0x98));
+    *(int *)(self + 0x1f8) += *(int *)(self + 0x98);
+
+    /* 02120d78..02120d9c: one spin sound per whole turn.
+       02120da0..02120dcc: keep the accumulator inside one turn. */
+    if (*(int *)(self + 0x1f8) / 0x1fffe != 0)
+        func_0201267c(0x119, self + 0x74);
+    *(int *)(self + 0x1f8) %= 0x1fffe;
+
+    /* 02120dd0..02120e60: while both handles are live, refresh both systems
+       on the body and stamp each with the 0x7fff lifetime */
+    if (*(unsigned *)(self + 0x204) != 0 && *(unsigned *)(self + 0x208) != 0) {
+        void *a, *b;
+
+        *(unsigned *)(self + 0x204) =
+            _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                *(unsigned *)(self + 0x204), 0x13a, *(int *)(self + 0x5c),
+                *(int *)(self + 0x60), *(int *)(self + 0x64), 0, 0);
+        *(unsigned *)(self + 0x208) = (unsigned)(size_t)
+            _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+                *(unsigned *)(self + 0x208), 0x13b, *(int *)(self + 0x5c),
+                *(int *)(self + 0x60), *(int *)(self + 0x64), 0);
+
+        a = _ZN8Particle6System12FromUniqueIDEj(*(unsigned *)(self + 0x204));
+        b = _ZN8Particle6System12FromUniqueIDEj(*(unsigned *)(self + 0x208));
+        if (a)
+            *(int *)((char *)a + 0x50) = 0x7fff;
+        if (b)
+            *(int *)((char *)b + 0x50) = 0x7fff;
+    }
+
+    /* 02120e64..02120e80: the ROM's `cmp #3 / addls pc, pc, r0, lsl #2` table.
+       Anything above 3 falls straight through to the common return. */
+    switch (*(unsigned char *)(self + 0x214)) {
+
+    /* ---- 02120e84..02120ef8: step 0, wobble the pitch and bleed the spin -- */
+    case 0: {
+        int phase = *(unsigned short *)(self + 0x210);
+        *(short *)(self + 0x8c) =
+            (short)fx12(*(int *)(self + 0x1fc),
+                        data_02082214[(phase >> 4) * 2]);
+        *(short *)(self + 0x210) =
+            (short)(*(short *)(self + 0x210) + 0xe000);
+        _Z14ApproachLinearRiii((int *)(self + 0x1fc), 0, 0x1b);
+        if (DecIfAbove0_Byte((unsigned char *)(self + 0x215)) == 0)
+            ++*(unsigned char *)(self + 0x214);
+        break;
+    }
+
+    /* ---- 02120efc..02120f20: step 1, let the animation play out ----------- */
+    case 1:
+        _ZN9Animation7AdvanceEv(self + 0x124);
+        if (_ZN9Animation8FinishedEv(self + 0x124))
+            ++*(unsigned char *)(self + 0x214);
+        break;
+
+    /* ---- 02120f24..02120fa8: step 2, shrink to nothing -------------------- */
+    case 2: {
+        int s;
+        if (_Z14ApproachLinearRiii((int *)(self + 0x1f0), 0xa4, 0xa4))
+            ++*(unsigned char *)(self + 0x214);
+        s = *(int *)(self + 0x1f0);
+        *(int *)(self + 0x80) = s;
+        *(int *)(self + 0x84) = s;
+        *(int *)(self + 0x88) = s;
+        /* Both id arms store the same product in the ROM (0x55 either way);
+           transcribed as the two arms the listing actually spells. */
+        if (*(unsigned short *)(self + 0xc) == 0x106)
+            *(int *)(self + 0x178) = *(int *)(self + 0x1f0) * 0x55;
+        else if (*(unsigned short *)(self + 0xc) == 0x107)
+            *(int *)(self + 0x178) = *(int *)(self + 0x1f0) * 0x55;
+        break;
+    }
+
+    /* ---- 02120fac..021210bc: step 3, pay out and die ---------------------- */
+    case 3:
+        if (*(unsigned short *)(self + 0xc) == 0x106) {
+            /* 02120fc8..0212100c: MR_I drops actor 0x122 and a dust puff */
+            spawnPos.x = *(int *)(self + 0x5c);
+            spawnPos.y = *(int *)(self + 0x60) + 0x78000;
+            spawnPos.z = *(int *)(self + 0x64);
+            _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0x122, 2, &spawnPos, 0,
+                *(signed char *)(self + 0xcc), -1);
+            _ZN5Actor8PoofDustEv(self);
+        } else if (*(unsigned short *)(self + 0xc) == 0x107) {
+            /* 0212102c..0212108c: BIG_MR_I pays the star and three bursts */
+            _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(
+                self, (signed char *)(self + 0x217),
+                (unsigned)((*(int *)(self + 8) & 0xf) & 0xff),
+                self + 0x5c, 4);
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(
+                0x124, *(int *)(self + 0x5c), *(int *)(self + 0x60),
+                *(int *)(self + 0x64));
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(
+                0x125, *(int *)(self + 0x5c), *(int *)(self + 0x60),
+                *(int *)(self + 0x64));
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(
+                0x126, *(int *)(self + 0x5c), *(int *)(self + 0x60),
+                *(int *)(self + 0x64));
+        }
+        /* 02121090..021210bc: the tail runs for every id, including neither */
+        func_0201267c(0xc4, self + 0x74);
+        if (data_0209f2f8 == 0x2e)
+            _ZN5Actor24KillAndTrackInDeathTableEv(self);
+        else
+            _ZN9ActorBase18MarkForDestructionEv(self);
+        break;
+
+    default:
+        break;
+    }
+
+    /* 021210c0..021210cc */
+    return 1;
+}

--- a/port/unmatched/MrI_StateMains.cpp
+++ b/port/unmatched/MrI_StateMains.cpp
@@ -20,17 +20,18 @@
  *     func_ov071_021211e0 kind:function(arm,size=0x314) addr:0x021211e0
  * and each size closes exactly on the next symbol (0x0212110c and 0x021214f4).
  *
- * THE OVERLAY BASE IS 0x0211f000, NOT the 0x0211f600 that
- * extracted/dsd/arm9_overlays/overlays.yaml's `base_address: 34729984` says.
- * The yaml entry is stale by 0x600 and reading the bytes at that base would
- * have produced garbage for every listing below. The base is pinned three
+ * THE OVERLAY BASE IS 0x0211f000 -- which IS overlays.yaml's
+ * `base_address: 34729984` (34729984 == 0x0211f000; the yaml is correct).
+ * A wrong hand-converted hex gloss (0x0211f600) circulated in this lane's
+ * brief; reading bytes at THAT base would have produced garbage for every
+ * listing below. The base is pinned three
  * ways, all agreeing: config/arm9/overlays/ov071/delinks.txt opens
  * `.text start:0x0211f000` and closes `.bss end:0x02123100`; the image span
  * 0x02122f80 - 0x0211f000 = 0x3f80 = 16256 is exactly the yaml's own
  * `ram_size` AND the byte length of extracted/overlays/overlay_0071.bin; and
  * the bss span 0x02123100 - 0x02122f80 = 0x180 = 384 is exactly the yaml's
- * `bss_size`. At base 0x0211f600 the symbol func_ov071_0211f0a4 would sit
- * BELOW the overlay. File offset used throughout: addr - 0x0211f000.
+ * `bss_size`. At the glossed 0x0211f600 the symbol func_ov071_0211f0a4 would
+ * sit BELOW the overlay. File offset used throughout: addr - 0x0211f000.
  *
  * ---- VERIFICATION RECORD ---------------------------------------------------
  * Method: disassemble the ROM span out of extracted/overlays/overlay_0071.bin
@@ -79,7 +80,7 @@
  * random values in +-(1<<28) -- 0 mismatches. So `/` and `%` are the exact
  * transcription and the magic does not need to be reproduced.
  *
- * CALL TARGETS: eighteen distinct, every one resolved BY ADDRESS from the
+ * CALL TARGETS: nineteen distinct, every one resolved BY ADDRESS from the
  * listing, and every arity taken from the ROM's own register/stack use rather
  * than from a C prototype (C linkage would hide an arity mismatch silently):
  *
@@ -102,7 +103,7 @@
  *   02015c3c  Animation::Advance          (this), r0
  *   02015bcc  Animation::Finished         (this) -> int, r0
  *   0200f658  Actor::DetectRaycastClsn    (this, Vector3*, Vector3*, bool)
- *   plus four ov071 siblings, all matched src and all in this lane's slice:
+ *   plus six ov071 siblings, all matched src and all in this lane's slice:
  *   02120a20, 021209c8, 02120860, 0212070c, 02120b14, 02121634.
  *
  * The two arm9 data symbols were already mounted before this lane: the trig


### PR DESCRIPTION
External-contributor lane from the second coordination site (campaign handoff operation; `port/tests/walk_window.cpp` and `port/ntr/` untouched).

## What this is

THE MR. I FAMILY (target-menu item 2): actor ids **262 = MrI, 263 = BigMrI, 264 = MrI_Projectile** registered, running, and finishing **level 12's census at 140/0** (was 136/4 — the four skips were 262 x3 + 263 x1, i.e. 100% Mr. I). Level 13 finishes at 188/0 (its one skip was 262); level 14 clears its two 262 skips (180/29 → 182/27; the remaining 27 are the untouched lava cast). The two unmatched per-frame cores are VERIFIED HOST COPIES — now **oracle-verified** (below):

- `func_ov071_021211e0` (0x314: 191 instructions + 6 pool words) — MrI state 1 MAIN
- `func_ov071_02120d30` (0x3dc: 232 instructions + 15 pool words) — MrI state 2 MAIN

Linkage **4623 → 4655 (+32 = 30 slice TUs + 2 hostgen'd, 0 lost, 0 unattributed)**.

Four commits: `e7e2de7a` (host copies + dispatchers + Render + seat), `3775a723` (fills, rows, slice, syms, state seat), `90796af4` (link closure — the reviewed tip), plus one review-ordered comment-only fixup (rebuilt and re-gated: control 300 exact, L12 140/0, linkage 4655, guards green).

## The cast map, corrected from the ROM

The pre-existing `ov071_syms.txt` header claimed MrI/BigMrI were ids 198/199. By the mandatory double test (spawnFunc inside ov071's window AND record id halfword), 198/199 fail BOTH tests in ov071 — the reviewer additionally attributed them positively to **ov074**, where both pass both. The real family: 262 (SpawnInfo 0x02122cf0 → 0x02121a1c, id 0x0106), 263 (0x02122d0c → 0x021219cc, 0x0107), 264 (0x02122dc4 → 0x02121f9c, 0x0108). 263 is a free share (the two 0x50-byte spawn functions are identical but for pc-relative encodings, both `new(0x218)` storing `_ZTV3MrI`; the class separates by actor id at 0x0212139c). **264 is closure, not scope creep**: state-1 MAIN calls `Actor::Spawn(0x108)` at 0x021213d4 — inside its own span — so registering 262/263 without it hands the pre-spawn gate an unregistered id on every shot.

## Verification — the full standard, oracle included

Worker: capstone disassembly with relocs + both symbol tables applied, per-instruction transcription, sizes closing exactly on next symbols, 19 distinct external call targets resolved BY ADDRESS with arity from ROM register/stack use, all pool words used and documented. Three vtables (MrI, MrI_Projectile, + the Scuttlebug control) at width 31 by both tests; identity by slot-0-landing-in-own-InitResources (mwcc emitted no RTTI typeinfo here — confirmed); D1/D0 in ROM/Itanium numbering with the collision handled: ROM `_ZTV9ModelAnim` slot 5 is `ModelAnim::Render` while the host's MSVC-order fill puts Virtual18 there (MSVC folds D1+D0) — hence the third small host copy `_ZN3MrI6RenderEv`. Both ov071 state dispatchers had the 4-byte-MSVC-PMF-vs-8-byte-ROM-record bug (`c->pp + 1` lands on the delta word — a null call on the first tick); they are host copies with a loud abort seat verifying source bytes.

Reviewer, independently, with the mwccarm 1.2/sp2p3 oracle (proven on a control first):

| | body 1 | body 2 |
|---|---|---|
| pool constants | 6/6 match | 15/15 match (incl. `0x80008001`, `0x1fffe`) |
| changed constants / member offsets / call targets | **0** | **0** |
| all deltas classify as | register allocation / scheduling | same |

**Standard met for both.** The two renderings the worker had flagged as divergences are in fact **byte-identical** under mwcc: the `/0x1fffe` + `%0x1fffe` pair compiles to the ROM's exact magic-multiply words (same registers), and the C `switch` reproduces the `addls pc` jump table byte-for-byte including the 5-entry table. The reviewer also ran its own equivalence sweep on the division pair: 1,084,760 values (exhaustive near-zero band, boundary multiples ±1, random full-range) — 0 mismatches. Remaining real divergences: the `(void)`-cast discarded-result `Vec3_HorzAngle` call and the two literally-transcribed identical id arms — both correctly documented.

## Gates (all green, both worker and reviewer from-scratch builds)

control 300 `pos=(-4915200, 2805556, 9342995)` exit 0; soak 1000 `pos=(-4900460, 2736154, 8004169)` exit 0; heap 241592; censuses — L12 136/4→**140/0**, L13 187/1→**188/0**, L14 180/29→**182/27** with full per-id arithmetic (base skip ids re-derived at base by both parties), all 14 other mounted levels byte-identical apart from `[reg] 174 → 177 actor classes registered`; 1200-frame L12 soak exit 0 at 140/0 with the behaviour list 135→139 (the four actors tick); full sweep exit 0; battery ALL GREEN `--linked-floor 4623`; smokes all green (count settled: 17 `smoke_*` targets + 1 bare `smoke` = 18 executables); guards: alternatename 1376 scanned/920 fired/**0 new defeats**, closestplayer OK, inferred_stub 2=baseline, dsstate OK, ptr_audit 0; both save-state reproducers PASS (cross-area hash restored exactly).

Note for the canonical gate spellings: the save-state reproducers need `SM64DS_WINDOW_SELFTEST` set (the logic is inside the selftest path; without it the run never terminates — both worker and reviewer confirmed).

## Files beyond the owned list, all flagged and reviewed

`port/CMakeLists.txt` (slice + hostgen + 3 targets + one LANGUAGE CXX); `port/hal/actor_classes.inc` (declarations + 3 rows, tail-append — trial-merged against the w7c PR with zero conflicts); `port/hal/actor_overlays.cpp` (+6: the seat call); `port/tools/hostgen.py` (+5: one HEADER_SHADOW entry — reviewer-proven from code to be scoped to exactly one TU's include of `decl_common.h`, resolving a real declaration conflict `extern void func_ov071_02121ba4(void*)` vs the TU's `(char*)`; corroborated by 14 byte-identical censuses).

## Review verdict: MERGE-WITH-NOTES — all notes documentation-only, all applied

The fixup commit corrects: three comment blocks that had turned a settled coordination error into a false statement about a correct primary source (the yaml's `base_address: 34729984` IS 0x0211f000; a wrong hex gloss in the lane brief said 0x0211f600 — the yaml was never stale); "eighteen distinct" over a 19-entry call-target list; "four ov071 siblings" over a 6-entry list; and a sinit-ordering note naming the wrong next call. Reviewer findings carried without change: the reloc-run width test alone is unsound in general (on `_ZTV10Scuttlebug` it over-runs one word into a state-source PMF; only the next-symbol test pins width — both agree at 31 for the MrI tables), and map-file byte sizes are not portable invariants (the map embeds the build path; quote linked-TU counts, not map bytes).

Setup facts for reproduction: `extracted/dsd/files/files.txt` (`python port/tools/ntr_manifest.py`); local `build-port.cmd` mirror for VS2022 Preview; `battery.py --skip-build`.

---

# Worker evidence report (lane w7b, verbatim)

Deliverable met: level 12's census finished at 140/0. Linkage: base 4623 (map 2,523,448 B) / tip 4655 (+32) (2,534,280 B), both maps content-verified (tip names `port_mri_states_seat`, `hal_fill_mri_vtable`, `hal_fill_mri_projectile_vtable`; base none). Census table with per-id arithmetic: L12 skips were 262 x3 + 263 x1 = 4 (136+4=140, 0 left); L13 262 x1 (187+1=188); L14 262 x2 cleared (29−2=27; remaining 11 classes are the lava cast, untouched); all other levels identical with full stdout byte-identical after masking host pointers except `[reg] 174 → 177`. Gate table: control/soak exact; heap 241592; sweep exit 0; battery ALL GREEN (linkage 4655); 17 `add_executable(smoke_*)` targets all exit 0; closestplayer OK 4769 TUs; inferred_stub 2=baseline; dsstate OK 5588; alternatename 1376/920/0 new defeats; ptr_audit 0; save-state same-area and cross-area PASS (with the WINDOW_SELFTEST requirement noted). Verification record: base re-pinned three ways (delinks.txt, image length = ram_size, bss arithmetic); sizes 0x314/0x3dc closing exactly on next symbols; 191+6 and 232+15 word accounting; 19 call targets by address with ROM-derived arity; documented divergences incl. the /0x1FFFE pair proven over 20,000 random values + edges (0 mismatches), the jump-table-as-switch, the (void) discarded pure call, the two literal id arms. Third host copy `_ZN3MrI6RenderEv` for the ModelAnim slot-5 collision; two D1 thunks with chains read from the compiled D0 TUs; seat numbering stated (ROM/Itanium 16/17; MSVC folds — why slot 16 cannot be an MSVC `~MrI()`). Cast map corrected from ROM by the double test; 263 free share; 264 closure (spawn call inside the state-1 span). Vtables 31 by both tests; identity by slot-0 landing (no RTTI emitted here); stride evidence `ADD r1,r2,r1,LSL#4` (16-byte records); both dispatchers host copies with loud-abort source seats (the 4-byte PMF bug); `func_ov071_02121634` rides the slice (already correct 16-byte stride). Running, not just spawning: L12 behaviour list 135 → 139; 1200-frame L12 soak exit 0 at 140/0. Hygiene: src/, include/, config/, root tools/ diffs empty; no forbidden file touched; flagged extras as listed; no pushes at report time. Environment findings: the machine-overload silent cl.exe failure trap measured in detail (14 concurrent cl.exe from sibling lanes; exit-0 no-op runs detected by the alternatename guard reporting no link); the "18 smokes" count is 17 under the `smoke_*` pattern.

---

# Independent review verdict (verbatim)

## VERDICT: MERGE-WITH-NOTES

Every load-bearing claim reproduced from primary sources on from-scratch builds (base GREEN on 2nd run — first run hit the documented empty-diagnostic cl.exe trap, 5 deaths; head GREEN 1st run). Maps: base 2,523,447 B / head 2,534,279 B (Δ 10,832 matching), linkage 4623 → 4655 (+32: 30 slice + 2 hostgen, 0 lost, 0 unattributed).

Cast map CONFIRMED and strengthened: the double test passes for 262/263/264 with the exact SpawnInfo/spawnFunc/id values; 198/199 fail BOTH tests in ov071 and pass both in ov074 (positive attribution the worker didn't make). Free share and 264-closure CONFIRMED from the image (identical 0x50-byte spawn functions; `mov r0,#0x108` + `bl Actor::Spawn` at 0x021213d4 inside the state-1 span). Host copies CONFIRMED: my own disassembly matches 191+6 / 232+15; instruction-by-instruction transcription check — zero discrepancies in any constant, member offset, branch or call target. Vtables CONFIRMED 31 by both tests with slot-0 landings; all 21 shared slots identical across the three tables; slot-5 collision confirmed exactly (ROM slot 5 = Render; host `_ZTV9ModelAnim` [5] = Virtual18, MSVC order). Dispatcher bug CONFIRMED (8-byte mwcc PMF vs MSVC 4; the +1 lands on delta words that are 0 in all six source PMFs → null call on first tick; 16-byte Item16 stride verified from `add r1,r2,r1,lsl #4`).

Oracle: both bodies rendered standalone and compiled with 1.2/sp2p3 — pool constants 6/6 and 15/15 matching, ZERO changed constants/offsets/call targets, every delta register-allocation/scheduling (frame 0x44→0x40, pc-relative pool shifts, dead ldrh↔ldrsh before truncating stores, predication-vs-boolean materialisation, a folded redundant mask, base-vs-offset addressing). STANDARD MET for both. The two contested renderings are byte-identical, not divergent: the /0x1fffe-%0x1fffe pair emits the ROM's exact words in the same registers, and the switch emits the identical `908ff100` dispatch plus the same 5-entry table. My own equivalence check: 1,084,760 values (32 edges; exhaustive [-3·0x1fffe, 3·0x1fffe]; 200,000 random; 98,307 boundary multiples ±1) — 0 mismatches.

Censuses CONFIRMED including the per-id merge gate (base skip compositions re-derived at base: L12 262 x3+263 x1; L13 262 x1; L14 262 x2; L14's remaining 27 enumerated across the 11 lava classes); all other levels 0-line sorted-multiset diff with `[reg]` masked; 1200-frame L12 soak exit 0 at 140/0, behaviour 135→139. Gates all reproduced (control/soak exact; heap 241592; sweep; battery ALL GREEN; 18 smoke executables — count settled: 17 `smoke_*` + 1 bare `smoke`, both parties right under their own pattern; guards incl. alternatename 0 new defeats; save-state both PASS with the hw hash restored exactly; the WINDOW_SELFTEST requirement confirmed — without it the run never terminates). Diff hygiene CONFIRMED (src/include/config/root-tools all empty; ov071_syms.txt is under port/; zero config/ changes). hostgen.py scrutinized from code: the HEADER_SHADOW entry is double-gated (stem match + literal include) and scoped to one TU's view of one header — cannot perturb any other TU; corroborated by 14 byte-identical censuses; the declaration conflict it resolves is real.

Findings (all documentation-only): F1 three shipped comment blocks assert the yaml base is stale/0x0211F600 — 34729984 IS 0x0211F000, the yaml is correct, the false statement about a correct primary source should not ship [coordinator: fixed in the fixup commit, re-gated]. F2 "eighteen distinct" over a 19-entry list; "four siblings" over six [fixed]. F3 the worker's report over-declares its divergence count (four; two are byte-identical under the oracle) — report-only. F4 the sinit-ordering note names the wrong next call; required ordering holds [fixed]. F5 the reloc-run width test is unsound in general (Scuttlebug's table over-runs one word into a state-source PMF; only next-symbol pins width; MrI tables agree at 31 under both). F6 map byte-sizes are not portable (build-path literal; quote counts, not bytes).

Integrity: lane branch untouched (reflog = the three lane commits only); nothing committed or pushed by the review; oracle scratch renditions deleted; review worktrees left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
