### PR TITLE
The vtable-slot marker described the name, not the body

### DIFF
--- a/notes/dscene-c-siblings-census.md
+++ b/notes/dscene-c-siblings-census.md
@@ -255,5 +255,51 @@ reason; it doesn't yet report on the comment layer's own accuracy -- extending
 it to do so would settle the "how far does this spread" question in one run
 instead of by hand.
 
+**Update (2026-08-15): measured, and the answer is that it was systematic and is
+now spent.** Two questions were open above: how the mislabel was minted, and how
+far it spread. Both are answered.
+
+Minting: there is no generator. No script in this tree, in any branch, writes
+either the `// recovered name:` slot names or the `recovered from vtable slot
+identity` tag; `tools/reconcile_names.py` only copies a pre-existing `@emits`
+line into a comment, and derives nothing. The shift came from reading a slot
+table that numbers `virtual` DECLARATIONS instead of vtable WORDS. A class
+declares its destructor once and mwcc emits two words for it (D1 at 16, D0 at
+17), so declaration index equals slot index up to the destructor and is one
+short of it from the destructor onward. That is why a slot-17 D0 collected slot
+18's name, `OnYoshiTryEat`, and it is a uniform +1 from that word on rather than
+a general off-by-one. The tables that carry the shift are gitignored working
+material, not repo content; every table tracked here is correct, including the
+only executable one, `tools/actor_names.py`'s `SLOT_SIGS` (16 = D1, 17 = D0),
+which has been right since PR #211. `notes/actor-vtables.md` states the trap
+directly: D1/D0 land at slots 16 and 17.
+
+Spread, counted against `src/` on this commit and classified by body structure
+rather than by comment (a body is a deleting destructor when it stores a vtable
+into the object and calls `Memory::Deallocate`):
+
+| measure | count |
+|---|---:|
+| `src/` files scanned | 11287 |
+| bodies that are deleting destructors | 208 |
+| of those, carrying a D0/D1/D2 name | 170 |
+| of those, carrying an ordinary method name instead | **0** |
+| files still claiming an `OnYoshiTryEat` name | 31 |
+| of those 31, bodies that are deleting destructors | **0** |
+
+So the D0-labelled-as-OnYoshiTryEat defect no longer has a single instance in
+`src/`. The seven survivors §3 counted were fixed as their classes were named,
+each one settled by reading the body; `src/_ZN10ChillBullyD0Ev.c` and
+`src/_ZN10LavaSeesawD0Ev.c` carry the reasoning in their headers. All 31
+remaining `OnYoshiTryEat` claims sit on genuine slot-18 bodies. The standing
+advice is still right and still cheap: don't trust a slot-17 "recovered name"
+without checking the body.
+
+What is NOT spent is the separate overloaded-marker problem. 531 files carried
+`recovered from vtable slot identity`, a tag that reads as "this body was
+guessed" while in practice it usually records where the NAME came from. 30 of
+them were adjudicated against the ROM and reworded (run linkw w13); 501 still
+carry the bare tag and none of those has been ruled on.
+
 Related: `notes/plan-cpp-language-mode.md`, `notes/dtor-variant-audit.md`,
 `notes/runbook-type-reconstruction.md` section 2.

--- a/src/_ZN11ChiefChilly16OnAimedAtWithEggEv.cpp
+++ b/src/_ZN11ChiefChilly16OnAimedAtWithEggEv.cpp
@@ -3,7 +3,9 @@
 #include "ChiefChilly.h"
 // recovered name: ChiefChilly_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
-/* daKing_Donketu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+/* daKing_Donketu_c::OnAimedAtWithEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 s32 ChiefChilly::OnAimedAtWithEgg() {
     return 409600;
 }

--- a/src/_ZN11RollingRock16OnAimedAtWithEggEv.cpp
+++ b/src/_ZN11RollingRock16OnAimedAtWithEggEv.cpp
@@ -3,7 +3,9 @@
 #include "RollingRock.h"
 // recovered name: RollingRock_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
-/* daGrock_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+/* daGrock_c::OnAimedAtWithEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 s32 RollingRock::OnAimedAtWithEgg() {
     return 0;
 }

--- a/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
@@ -7,7 +7,9 @@
 #include "daObjKm2_Agaru_c.h"
 // recovered name: daObjKm2_Agaru_c_InitResources
 /* recovered: renamed to Class_Method */
-/* daObjKm2_Agaru_c::InitResources - recovered from vtable slot identity */
+/* daObjKm2_Agaru_c::InitResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *p, int file, int a, int b);

--- a/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp
@@ -5,7 +5,9 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
-/* daObjKm2_Agaru_c::CleanupResources - recovered from vtable slot identity */
+/* daObjKm2_Agaru_c::CleanupResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int data_ov045_02113188[];

--- a/src/_ZN15FireSeaElevator6RenderEv.cpp
+++ b/src/_ZN15FireSeaElevator6RenderEv.cpp
@@ -3,7 +3,9 @@
 #include "FireSeaElevator.h"
 // recovered name: daObjKm2_Agaru_c_Render
 /* recovered: renamed to Class_Method */
-/* daObjKm2_Agaru_c::Render - recovered from vtable slot identity */
+/* daObjKm2_Agaru_c::Render - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
 s32 FireSeaElevator::Render() {

--- a/src/_ZN15FireSeaElevator8BehaviorEv.cpp
+++ b/src/_ZN15FireSeaElevator8BehaviorEv.cpp
@@ -5,7 +5,9 @@
 #include "daObjKm2_Agaru_c.h"
 // recovered name: daObjKm2_Agaru_c_Behavior
 /* recovered: renamed to Class_Method */
-/* daObjKm2_Agaru_c::Behavior - recovered from vtable slot identity */
+/* daObjKm2_Agaru_c::Behavior - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);

--- a/src/_ZN17BowserSkyPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN17BowserSkyPlatform16CleanupResourcesEv.cpp
@@ -7,7 +7,9 @@
 #include "daKpa3Bg_c.h"
 // recovered name: daKpa3Bg_c_CleanupResources
 /* recovered: renamed to Class_Method */
-/* daKpa3Bg_c::CleanupResources - recovered from vtable slot identity */
+/* daKpa3Bg_c::CleanupResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern void *data_ov060_02119514[];

--- a/src/_ZN17BowserSkyPlatform6RenderEv.cpp
+++ b/src/_ZN17BowserSkyPlatform6RenderEv.cpp
@@ -3,7 +3,9 @@
 #include "BowserSkyPlatform.h"
 // recovered name: daKpa3Bg_c_Render
 /* recovered: renamed to Class_Method */
-/* daKpa3Bg_c::Render - recovered from vtable slot identity */
+/* daKpa3Bg_c::Render - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
 s32 BowserSkyPlatform::Render() {

--- a/src/_ZN5Swoop16OnAimedAtWithEggEv.cpp
+++ b/src/_ZN5Swoop16OnAimedAtWithEggEv.cpp
@@ -3,7 +3,9 @@
 #include "Swoop.h"
 // recovered name: Swoop_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
-/* daBasabasa_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+/* daBasabasa_c::OnAimedAtWithEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 s32 Swoop::OnAimedAtWithEgg() {
     return 0;
 }

--- a/src/_ZN6Snufit16OnAimedAtWithEggEv.cpp
+++ b/src/_ZN6Snufit16OnAimedAtWithEggEv.cpp
@@ -3,7 +3,9 @@
 #include "Snufit.h"
 // recovered name: Snufit_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
-/* daYurei_Mucho_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+/* daYurei_Mucho_c::OnAimedAtWithEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 s32 Snufit::OnAimedAtWithEgg() {
     return 0;
 }

--- a/src/_ZN8BookShot16OnAimedAtWithEggEv.cpp
+++ b/src/_ZN8BookShot16OnAimedAtWithEggEv.cpp
@@ -3,7 +3,9 @@
 #include "BookShot.h"
 // recovered name: BookShot_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
-/* daBook_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+/* daBook_c::OnAimedAtWithEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 s32 BookShot::OnAimedAtWithEgg() {
     char* c = (char*)this;

--- a/src/func_ov045_02111bc8.c
+++ b/src/func_ov045_02111bc8.c
@@ -3,7 +3,9 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
-/* daObjKm2_Ukishima_c::CleanupResources - recovered from vtable slot identity */
+/* daObjKm2_Ukishima_c::CleanupResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 int func_ov045_02111bc8(void *self)
 {
     return func_020b6424(self, data_ov045_02112f08);

--- a/src/func_ov045_02111bdc.c
+++ b/src/func_ov045_02111bdc.c
@@ -3,7 +3,9 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
-/* daObjKm2_Ukishima_c::InitResources - recovered from vtable slot identity */
+/* daObjKm2_Ukishima_c::InitResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 int func_ov045_02111bdc(void *self)
 {
     return func_020b6584(self, data_ov045_02112f08, 0xf50);

--- a/src/func_ov052_0211123c.c
+++ b/src/func_ov052_0211123c.c
@@ -1,7 +1,9 @@
 // @symbol func_ov052_0211123c
 // recovered name: daObjEmmLog_c_CleanupResources
 /* recovered: renamed to Class_Method */
-/* daObjEmmLog_c::CleanupResources - recovered from vtable slot identity */
+/* daObjEmmLog_c::CleanupResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern int _ZN16MeshColliderBase9IsEnabledEv();
 extern int _ZN16MeshColliderBase7DisableEv();
 extern int _ZN13SharedFilePtr7ReleaseEv();

--- a/src/func_ov052_02111284.cpp
+++ b/src/func_ov052_02111284.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov052_02111284
 // recovered name: daObjEmmLog_c_Render
 /* recovered: renamed to Class_Method */
-/* daObjEmmLog_c::Render - recovered from vtable slot identity */
+/* daObjEmmLog_c::Render - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
 extern "C" int func_ov052_02111284(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov052_021112ac.c
+++ b/src/func_ov052_021112ac.c
@@ -3,7 +3,9 @@
 #include "daObjEmmLog_c.h"
 // recovered name: daObjEmmLog_c_Behavior
 /* recovered: renamed to Class_Method */
-/* daObjEmmLog_c::Behavior - recovered from vtable slot identity */
+/* daObjEmmLog_c::Behavior - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 typedef int Fix12;
 extern void func_020393a4(int *p, int v);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);

--- a/src/func_ov052_02111348.cpp
+++ b/src/func_ov052_02111348.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov052_02111348
 // recovered name: daObjEmmLog_c_InitResources
 /* recovered: renamed to Class_Method */
-/* daObjEmmLog_c::InitResources - recovered from vtable slot identity */
+/* daObjEmmLog_c::InitResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 struct Model { int d; };

--- a/src/func_ov060_021182b0.cpp
+++ b/src/func_ov060_021182b0.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov060_021182b0
 // recovered name: daKpa3Bg_c_InitResources
 /* recovered: renamed to Class_Method */
-/* daKpa3Bg_c::InitResources - recovered from vtable slot identity */
+/* daKpa3Bg_c::InitResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 struct BMD_File; struct KCL_File; struct Actor; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr;
 struct Vector3;

--- a/src/func_ov065_02116f14.cpp
+++ b/src/func_ov065_02116f14.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov065_02116f14
 // recovered name: Snufit_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
-/* daYurei_Mucho_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* daYurei_Mucho_c::OnTurnIntoEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);

--- a/src/func_ov065_02117eb4.cpp
+++ b/src/func_ov065_02117eb4.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov065_02117eb4
 // recovered name: Swoop_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
-/* daBasabasa_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* daBasabasa_c::OnTurnIntoEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);

--- a/src/func_ov073_021223f4.cpp
+++ b/src/func_ov073_021223f4.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov073_021223f4
 // recovered name: CccArena_Kill
 /* recovered: shared common types, renamed to Class_Method */
-/* daObjEwbIce_c::Kill - recovered from vtable slot identity */
+/* daObjEwbIce_c::Kill - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 // func_ov073_021223f4 at 0x021223f4
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov073).
 struct Vector3 { int x, y, z; };

--- a/src/func_ov080_02124eb0.c
+++ b/src/func_ov080_02124eb0.c
@@ -1,7 +1,9 @@
 // @symbol func_ov080_02124eb0
 // recovered name: MontyMole_Kill
 /* recovered: renamed to Class_Method */
-/* daChoropu_c::Kill - recovered from vtable slot identity */
+/* daChoropu_c::Kill - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern void _ZN12CylinderClsn5ClearEv(void *);
 int func_ov080_02124eb0(char *c)
 {

--- a/src/func_ov080_02125318.cpp
+++ b/src/func_ov080_02125318.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov080_02125318
 // recovered name: CrazedCrate_OnTurnIntoEgg
 /* recovered: shared common types, renamed to Class_Method */
-/* daBttBk_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* daBttBk_c::OnTurnIntoEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 // func_ov080_02125318 at 0x02125318
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov080).
 struct Vector3 { int x, y, z; };

--- a/src/func_ov089_02131f04.cpp
+++ b/src/func_ov089_02131f04.cpp
@@ -2,7 +2,9 @@
 // @symbol func_ov089_02131f04
 // recovered name: Key_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
-/* daObjKey_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* daObjKey_c::OnTurnIntoEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern "C" {
 extern int func_ov089_02131df4(void *c, int a);
 extern int func_ov089_02131dcc(void *c, int a);

--- a/src/func_ov100_02147054.c
+++ b/src/func_ov100_02147054.c
@@ -3,7 +3,9 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
-/* daObjPathLift_c::CleanupResources - recovered from vtable slot identity */
+/* daObjPathLift_c::CleanupResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
 int func_ov100_02147054(void *t)

--- a/src/func_ov100_021470a4.cpp
+++ b/src/func_ov100_021470a4.cpp
@@ -6,7 +6,9 @@
 #include "daObjPathLift_c.h"
 // recovered name: daObjPathLift_c_Render
 /* recovered: renamed to Class_Method */
-/* daObjPathLift_c::Render - recovered from vtable slot identity */
+/* daObjPathLift_c::Render - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 extern "C" {
 int func_ov100_021470a4(char* c){

--- a/src/func_ov100_021470f4.cpp
+++ b/src/func_ov100_021470f4.cpp
@@ -6,7 +6,9 @@
 #include "daObjPathLift_c.h"
 // recovered name: daObjPathLift_c_Behavior
 /* recovered: shared common types, renamed to Class_Method */
-/* daObjPathLift_c::Behavior - recovered from vtable slot identity */
+/* daObjPathLift_c::Behavior - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 typedef int Fix12i;
 
 struct PathLift { void BaseBehavior(); };

--- a/src/func_ov100_021471e0.cpp
+++ b/src/func_ov100_021471e0.cpp
@@ -6,7 +6,9 @@
 #include "daObjPathLift_c.h"
 // recovered name: daObjPathLift_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
-/* daObjPathLift_c::InitResources - recovered from vtable slot identity */
+/* daObjPathLift_c::InitResources - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 struct Actor;
 struct RaycastGround {
   char pad[0x44];

--- a/src/unnamed/ov063/func_ov063_021160c4.c
+++ b/src/unnamed/ov063/func_ov063_021160c4.c
@@ -1,7 +1,9 @@
 // @symbol func_ov063_021160c4
 // recovered name: Boo_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
-/* daTrs_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+/* daTrs_c::OnAimedAtWithEgg - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 int func_ov063_021160c4(void* c) {
     return *(int *)((char *)c + 0x18c) / 2;
 }

--- a/src/unnamed/ov063/func_ov063_0211c7b0.c
+++ b/src/unnamed/ov063/func_ov063_0211c7b0.c
@@ -3,7 +3,9 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
-/* daTBasket_c::Kill - recovered from vtable slot identity */
+/* daTBasket_c::Kill - name recovered from the vtable slot it fills.
+   The body is a decompilation verified against the ROM, not an
+   inferred stub. */
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3s(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int e);
 void func_ov063_0211c7b0(char *c) {
     short *t;


### PR DESCRIPTION
43 `src/` bodies carried

```
/* <Class>::<Method> - recovered from vtable slot identity */
```

The port reads that exact string as "this body was guessed from a vtable slot and was never decompiled" (`port/tools/inferred_stub_guard.py`), so all 43 sat in a debt queue the guard would not let shrink. A guessed body that is seated in a live vtable runs every frame as unverified behaviour, which is the risk that queue existed to track.

The claim is false on all 43. Each was disassembled out of the shipped overlay image and compared instruction for instruction with its source. Every one is a faithful decompilation. What was recovered from the slot was the **name**.

Two files have been asserting both things at once: `src/func_ov073_021223f4.cpp` and `src/func_ov080_02125318.cpp` each carry "Matched byte-for-byte with mwccarm 1.2/sp2p3" in the same header that calls the body a slot guess.

## What changed

30 of the 43 still carried the tag on `main`; the other 13 lost it when their classes were named. Those 30 lines now read:

```
/* <Class>::<Method> - name recovered from the vtable slot it fills.
   The body is a decompilation verified against the ROM, not an
   inferred stub. */
```

Comment text only. No code line is touched anywhere in the diff.

## Verification

`tools/linkcheck.py` per function, which is strict about relocation destinations rather than wildcarding them the way the byte gate does. Run on all 43 before the edit and again after, resolving each function at its current name and its `config/arm9/overlays/ovNNN/symbols.txt` address and size:

| verdict | before | after |
|---|---:|---:|
| VERIFIED | 39 | 39 |
| BLIND-n | 4 | 4 |
| WRONG | 0 | 0 |
| NO-REPRO | 0 | 0 |

Zero verdict changes across all 43. The four BLIND-n (`func_ov060_021182b0`, `func_ov100_02147054`, `func_ov100_021470f4`, `func_ov100_021471e0`) are unresolved reloc target symbols, identical before and after, and are a symbol-coverage limit rather than a mismatch.

`tools/port_refcheck.py`: 393 references checked, all resolve.

`tools/rombuild.py` does not complete on this box, before or after the change: `dsd` aborts with `function Div could not be analyzed: IllegalIns` at `0x0200407e` on a pristine `origin/main` checkout with the edit stashed. Pre-existing and unrelated, but flagging it rather than quietly skipping a gate. CI `validate` is the authority.

## Scope note

531 files in `src/` carried this tag. Only these 30 have been ruled on against the ROM, so only these 30 are reworded. 501 still carry the bare tag and none of them has been adjudicated.

## Second-order finding

`notes/dscene-c-siblings-census.md` section 3 flagged a related defect, slot-17 deleting destructors labelled `OnYoshiTryEat`, and left two questions open: whether it was systematic, and what produced it. Both are answered in the note now.

There is no generator. Nothing in this tree, in any branch, writes these comments; `tools/reconcile_names.py` only copies a pre-existing `@emits` line and derives nothing. The shift comes from numbering virtual **declarations** instead of vtable **words**. A class declares its destructor once and mwcc emits two words for it (D1 at 16, D0 at 17), so declaration index tracks slot index up to the destructor and runs one short from there on. A slot-17 D0 therefore collects slot 18's name. Every slot table tracked in this repo is correct, including the only executable one, `tools/actor_names.py`'s `SLOT_SIGS`.

Measured against `src/` on this commit, classifying bodies by structure rather than by comment:

| measure | count |
|---|---:|
| `src/` files scanned | 11287 |
| bodies that are deleting destructors | 208 |
| carrying a D0/D1/D2 name | 170 |
| carrying an ordinary method name instead | **0** |
| files still claiming an `OnYoshiTryEat` name | 31 |
| of those, bodies that are deleting destructors | **0** |

The defect has no surviving instance in `src/`. The seven survivors section 3 counted were fixed as their classes were named; `src/_ZN10ChillBullyD0Ev.c` and `src/_ZN10LavaSeesawD0Ev.c` carry the reasoning in their headers.
