### PR TITLE
Stamp the LINKED floor at 4888 of 11243 (43.5%)

### DIFF
--- a/config/port_linkage.json
+++ b/config/port_linkage.json
@@ -28,11 +28,11 @@
     "Enrolling free TUs does nothing, because the release build dead-strips whatever the",
     "linked closure never references."
   ],
-  "linkedTus": 3881,
-  "matchedTus": 11240,
-  "measuredAt": "2026-08-12",
+  "linkedTus": 4888,
+  "matchedTus": 11243,
+  "measuredAt": "2026-08-15",
   "branch": "port-mount-noseat-cluster",
-  "commit": "4b323dc1c",
+  "commit": "8cd187fe0",
   "stale": false,
-  "basis": "best of seven live port lanes; branches unmerged, combined figure is higher"
+  "basis": "single lane cons at its pushed tip, measured against its own walk_window.map; three parked lanes (w19/w20/w21) unmerged, so the figure stays a floor"
 }


### PR DESCRIPTION
Refreshes config/port_linkage.json from 3881 (34.5%, stamped 2026-08-12 at 4b323dc1c) to 4888 (43.5%), measured with port/tools/linkage.py against the cons lane's own walk_window.map at the pushed tip 8cd187fe0. The reading reproduces the figure the w19 and w20 lane reports recorded against the same baseline. Parked lanes w19/w20/w21 are unmerged, so the published number stays a floor. Provenance fields moved together with the count, as the stamp contract requires.