### PR TITLE
Re-stamp the LINKED floor at 4871 of 11243 (43.3%), a definition correction

### DIFF
--- a/config/port_linkage.json
+++ b/config/port_linkage.json
@@ -28,11 +28,11 @@
     "Enrolling free TUs does nothing, because the release build dead-strips whatever the",
     "linked closure never references."
   ],
-  "linkedTus": 4888,
+  "linkedTus": 4871,
   "matchedTus": 11243,
   "measuredAt": "2026-08-15",
   "branch": "port-mount-noseat-cluster",
-  "commit": "8cd187fe0",
+  "commit": "4bba244fd",
   "stale": false,
-  "basis": "single lane cons at its pushed tip, measured against its own walk_window.map; three parked lanes (w19/w20/w21) unmerged, so the figure stays a floor"
+  "basis": "single lane cons at its pushed tip, measured against its own walk_window.map. The drop from the prior 4888 stamp is a correction, not a regression: nothing was unlinked. Eighteen matched TUs were credited as linked while a host stand-in of the same basename was what reached the binary; the stand-ins are renamed _hostcopy so the map can tell them apart, and the count now measures what it always claimed to. The wave itself added five verified seats and traded four Render TUs for crash fixes."
 }


### PR DESCRIPTION
Refreshes config/port_linkage.json from 4888 (stamped this morning at 8cd187fe0) to 4871, measured at the wave-C-integrated tip 4bba244fd. The drop is a correction, not a backslide: the wave's audit proved 18 matched TUs were being credited while same-basename host stand-ins were what linked, the stand-ins are renamed so the map distinguishes them, and objsrc_check.py now guards the class of error. Independently reviewed on a from-scratch build before stamping. Provenance fields move with the count per the stamp contract; the basis field records the definition change so the series reads correctly.