### PR TITLE
Make the validator report what it actually proves

### DIFF
--- a/.github/workflows/header-offsets.yml
+++ b/.github/workflows/header-offsets.yml
@@ -1,0 +1,65 @@
+# Do a header's field offsets agree with the offsets its own comments claim?
+#
+# The generated headers encode layout twice -- as a sequence of declarations and pads,
+# and as a `/* 0x0a4 */` comment per field. Retyping a field breaks the agreement unless
+# the following pad shrinks to match, and NOTHING ELSE IN THE BUILD WOULD NOTICE: a
+# header is not compiled on its own, and the byte gate cannot see a field no source file
+# happens to read. `objisolate` then drops every `.data` section a C++ TU emits, so even
+# a wrong vtable links clean against the ROM's own gap object.
+#
+# This is the only gate that touches the project's FIRST goal -- accurate C++ -- rather
+# than byte equality. It existed for months and gated nothing: no workflow and no hook
+# invoked `tools/check_header_offsets.py`, and run with no arguments it checked zero
+# files, printed nothing, and exited 0. Its first whole-tree run found four problems.
+#
+# SCOPED TO CHANGED HEADERS on purpose. 441 of 445 headers pass; the four that do not
+# are written down in config/header-offset-known-issues.txt rather than silently
+# allowed, so this job is a ratchet on NEW breakage and cannot go red on debt a pull
+# request did not create. A gate that lands red gets switched off.
+#
+# Costs nothing: a textual walk over git-tracked headers, stdlib only, no compiler and
+# no ROM. That is why it lives here rather than on the private build box that
+# pr-validate.yml relays to.
+name: header offsets
+
+on:
+  pull_request:
+    paths:
+      - "include/**"
+      - "config/header-offset-known-issues.txt"
+      - "tools/check_header_offsets.py"
+      - ".github/workflows/header-offsets.yml"
+  workflow_dispatch:
+    inputs:
+      all:
+        description: "Check every header, not just the changed ones"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: header-offsets-${{ github.event.pull_request.head.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  offsets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # --changed diffs `<base>...HEAD`, so the merge-base has to be present.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Offsets agree with their comments
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "${{ inputs.all }}" = "true" ] || [ -z "$BASE" ]; then
+            python tools/check_header_offsets.py $(git ls-files 'include/**/*.h' 'include/*.h')
+          else
+            python tools/check_header_offsets.py --changed "$BASE"
+          fi

--- a/config/header-offset-known-issues.txt
+++ b/config/header-offset-known-issues.txt
@@ -1,0 +1,35 @@
+# Headers tools/check_header_offsets.py tolerates today, by path.
+#
+# Modelled on config/layout-known-issues.txt and config/rombuild-exclude.txt: the gate
+# is real for anything NEW, and the debt already in the tree is written down instead of
+# silently allowed. This list should only ever shrink.
+#
+# All four were found the moment the tool was first run over the whole tree. It had
+# never gated anything -- no workflow and no hook invoked it, and run with no arguments
+# it checked nothing and exited 0 -- so none of these had ever been reported.
+#
+# Format: one repo-relative header path per line. '#' starts a comment.
+
+# --- tool cannot parse the declaration (NOT a layout defect) ----------------------
+# A two-word scalar type. DECL reads `unsigned` as the type and `short` as the field
+# name, so all four members come back UNPARSED. The offsets in the file are right;
+# the parser is what is short. Teaching DECL about `unsigned short`/`unsigned long`
+# and friends retires this entry.
+include/OamAttr.h
+
+# An anonymous inline aggregate as a member type -- `struct { s32 a; s32 b; } unk_034[3];`.
+# AGG matches a struct body with no nested braces, so a member whose type IS a brace
+# body cannot be walked. Two members affected.
+include/cMgSmartball_slot_c.h
+
+# `T val;` inside a template. There is no width for T until it is instantiated, so
+# this is not answerable by textual walk at all and probably never leaves this list.
+include/math/Fix12.h
+
+# --- a real disagreement, unresolved ----------------------------------------------
+# Four fields sit exactly 3 bytes later than the tool computes (0x4660 vs 0x465d, and
+# three pads after it). A constant 3-byte shortfall means one earlier member is modelled
+# 3 bytes too small, so either the header's comments or an earlier field's type is wrong.
+# Whichever it is, it is a pre-existing question about this header and not something the
+# validator work that wired this gate up should have been deciding.
+include/dScMgSlot1_c.h

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -34,7 +34,31 @@ sys.path.insert(0, str(REPO / "tools"))
 import asm_policy  # noqa: E402
 import srcpath as SP  # noqa: E402
 import relocs as RL  # noqa: E402
+import rombuild_check as RBC  # noqa: E402
 import tiers as TIERS  # noqa: E402
+
+
+def enrolled_addresses():
+    """{(module, addr)} for every range a delinks.txt marks ``complete``.
+
+    This is the set the ROM build actually compiles and byte-compares against the
+    cartridge.  ``matched`` below is a different and much weaker test -- a ``src/``
+    file named after the symbol, with no ``NONMATCHING`` banner and no ``dcd`` blob --
+    and the two differ by several hundred functions, because a file can sit in the
+    tree, be counted, and be compiled by nothing.  The published percentage was the
+    weaker number alone, so both now ride along and the site can say which is which.
+
+    Reads only committed config, so it stays CI-safe: no ROM, no compiler.
+    """
+    out = set()
+    for sym, label in RL.module_universe():
+        delinks = sym.parent / "delinks.txt"
+        if not delinks.is_file():
+            continue
+        for rel, addr, _end in RBC.complete_entries(delinks):
+            if not rel.startswith("mods/"):
+                out.add((label, addr))
+    return out
 
 
 def tier_stats():
@@ -412,6 +436,8 @@ def main():
 
     functions = []
     total_b = matched_b = matched_n = 0
+    verified_b = verified_n = 0
+    enrolled = enrolled_addresses()
     transcribed_files, unbannered_files = set(), set()
     # Every module, itcm included. relocs.module_universe is the one definition of
     # what "every module" means, and it fails loudly rather than skipping a new one.
@@ -451,6 +477,14 @@ def main():
             if matched:
                 matched_b += size
                 matched_n += 1
+                # Byte-verified is the subset the ROM build proves: enrolled, compiled,
+                # linked into its module and compared to the cartridge. The rest are
+                # matched on the strength of a filename and are filled at link time by
+                # a gap object holding the ROM's own bytes.
+                if (label, addr) in enrolled:
+                    rec["verified"] = True
+                    verified_b += size
+                    verified_n += 1
             else:
                 r = nm.get((label, addr))
                 if r and r.get("divergences") is not None:
@@ -482,6 +516,12 @@ def main():
             "matchedFunctions": matched_n,
             "totalBytes": total_b,
             "matchedBytes": matched_b,
+            # The subset of `matched` the cartridge actually settles. `matched` is kept
+            # unchanged -- it is what contributor credit is computed from, and every
+            # existing consumer reads it -- but shipping it alone overstated coverage,
+            # so the measured figure travels beside it. See enrolled_addresses.
+            "verifiedFunctions": verified_n,
+            "verifiedBytes": verified_b,
             "moduleCount": len({f["module"] for f in functions}),
             # The other two tiers ride along here so every consumer reads ONE file.
             # romstats-sync.sh on the VPS fetches this db and nothing else, and the
@@ -499,6 +539,14 @@ def main():
           f"{matched_n}/{len(functions)} funcs, {matched_b}/{total_b} bytes, "
           f"{db['stats']['moduleCount']} modules, "
           f"{sum(1 for f in functions if 'author' in f)} authored")
+    # Both numbers in the log, always. The gap between them is the number of functions
+    # counted on the strength of a filename that no build compiles, and it is only
+    # visible if the smaller figure is printed next to the larger one.
+    print(f"  byte-verified: {verified_n}/{len(functions)} funcs, "
+          f"{verified_b}/{total_b} bytes "
+          f"({100.0 * verified_b / total_b:.2f}% vs {100.0 * matched_b / total_b:.2f}% "
+          f"matched); {matched_n - verified_n} matched function(s) are compiled by "
+          f"nothing")
     # Per-module counts in the log, so a module that stops being emitted shows up in
     # the CI diff as a line that vanished. The silent version of this cost itcm its
     # entire visibility; a number that goes to zero is at least readable.

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -10,9 +10,12 @@ This walks the declarations, applies natural alignment, and compares. Used as th
 first gate on any header edit; see notes/plan-scalar-markers.md 4.
 
     python tools/check_header_offsets.py include/Enemy.h include/Camera.h
-    python tools/check_header_offsets.py $(git diff --name-only include/)
+    python tools/check_header_offsets.py --changed              # vs origin/main
+    python tools/check_header_offsets.py --changed main
+
+Running it with no arguments is an error, not a pass -- see _resolve_paths.
 """
-import re, sys, pathlib
+import re, subprocess, sys, pathlib
 SZ = {"u8":1,"s8":1,"char":1,"u16":2,"s16":2,"short":2,"u32":4,"s32":4,"int":4,
       "unsigned":4,"long":4,"Fix12i":4,"float":4,"u64":8,"s64":8,"double":8}
 # Alignment is NOT the same as width once aggregates are in play: a Vector3 is 12
@@ -158,8 +161,62 @@ for _h in pathlib.Path(__file__).resolve().parents[1].joinpath("include").rglob(
         if _last is not None and _cls not in DATA_SIZE:
             DATA_SIZE[_cls] = _last
 
+KNOWN = REPO / "config" / "header-offset-known-issues.txt"
+
+
+def _known_issues():
+    """Header paths this gate already tolerates. See the file's own header comment.
+
+    Waived rather than skipped silently: each one still prints, so the debt stays
+    visible in the log and the list can only shrink.
+    """
+    if not KNOWN.is_file():
+        return set()
+    return {line.split("#", 1)[0].strip().replace("\\", "/")
+            for line in KNOWN.read_text(encoding="utf-8").splitlines()
+            if line.split("#", 1)[0].strip()}
+
+
+def _resolve_paths(argv):
+    """The headers to check, or exit non-zero having said why.
+
+    This tool fed ``sys.argv[1:]`` straight into the loop below, so running it bare
+    checked nothing, printed nothing, and exited 0 -- a clean pass over zero files.
+    Nothing in `.github/workflows/` or `tools/hooks/` invoked it, so that silent
+    vacuous pass was, in practice, its only behaviour. Refusing an empty list is what
+    makes wiring it into CI mean anything.
+
+    ``--changed [base]`` is the CI form: the added and modified headers of this branch.
+    Renames arrive as an add because ``-M`` is deliberately not passed -- a header that
+    moved still has to have its offsets agree.
+    """
+    if argv and argv[0] == "--changed":
+        base = argv[1] if len(argv) > 1 else "origin/main"
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
+             "--", "include/"],
+            cwd=REPO, capture_output=True, text=True)
+        if proc.returncode != 0:
+            sys.exit(f"check_header_offsets: git diff against {base} failed: "
+                     f"{proc.stderr.strip()}")
+        argv = [p for p in proc.stdout.split() if p.endswith((".h", ".hpp"))]
+        if not argv:
+            print(f"check_header_offsets: no include/ header added or modified "
+                  f"against {base}")
+            sys.exit(0)
+        print(f"check_header_offsets: {len(argv)} changed header(s) vs {base}")
+    if not argv:
+        sys.exit("usage: check_header_offsets.py <header>... | --changed [base]\n"
+                 "refusing to run with no headers: an empty check is not a pass")
+    return argv
+
+
 rc = 0
-for path in sys.argv[1:]:
+WAIVED = _known_issues()
+for path in _resolve_paths(sys.argv[1:]):
+    if pathlib.PurePath(path).as_posix() in WAIVED:
+        print(f"{path}: WAIVED -- config/header-offset-known-issues.txt")
+        continue
     txt = pathlib.Path(path).read_text(errors="replace")
     off, bad, n, skipped, pending = 0, 0, 0, [], []
     trusted = True

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -52,6 +52,7 @@ sys.path.insert(0, str(REPO / "tools"))
 import objisolate as OI  # noqa: E402
 import rombuild_cache as RBK  # noqa: E402
 import rombuild_check as RBC  # noqa: E402
+import romdata_check as RDC  # noqa: E402
 import layout_check as LAY  # noqa: E402
 import rombuild_profile as RP  # noqa: E402
 
@@ -231,7 +232,7 @@ def init_section_sources():
     return {rel for (_d, _name, rel, _addr, _size, sec) in cands if sec == ".init"}
 
 
-def _isolate(obj, rel, syms):
+def _isolate(obj, rel, syms, data_sink=None):
     """Reduce a compiled `src/` object to its declared function. Returns an error or None.
 
     `mods/` is deliberately exempt. A mod is not a recovered ROM function: it may
@@ -242,6 +243,16 @@ def _isolate(obj, rel, syms):
     """
     if not rel.replace("\\", "/").startswith("src/"):
         return None
+    if data_sink is not None:
+        # THE ONLY MOMENT THIS IS POSSIBLE. The object still carries every `.data`
+        # section mwcc emitted -- the vtable, the typeinfo record, the typeinfo name --
+        # and `OI.isolate` on the next line zeroes all of them and rebinds their symbols
+        # to the ROM's carved-out addresses. After that the bytes are gone from the
+        # pipeline and the link compares the cartridge's own data against itself.
+        #
+        # Measurement only: check_object swallows its own exceptions, and nothing here
+        # can fail the build. See tools/romdata_check.py for why it is not a gate.
+        data_sink.extend(RDC.check_object(obj, rel))
     plan = OI.isolate(obj, (syms or {}).get(rel, pathlib.Path(rel).stem))
     if plan.get("kind") == OI.NOT_A_FUNCTION:
         return None          # nothing to reduce; other gates judge this file
@@ -326,7 +337,8 @@ def retarget_text_section(obj, section=".init"):
     return False
 
 
-def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_root=None):
+def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_root=None,
+                data_sink=None):
     """Compile one enrolled source file to the object path dsd's objects.txt names.
 
     Returns (rel, error-or-None, outcome), where outcome is how the object was
@@ -359,7 +371,7 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_roo
             err = _retarget(obj, rel, init_srcs)
             if err:
                 return rel, f"retarget: {err}", "error"
-            err = _isolate(obj, rel, syms)
+            err = _isolate(obj, rel, syms, data_sink)
             if err:
                 return rel, f"isolate: {err}", "error"
             return rel, None, "hit"
@@ -393,18 +405,18 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_roo
         if err:
             return rel, f"retarget: {err}", "error"
         if key is None:
-            err = _isolate(obj, rel, syms)
+            err = _isolate(obj, rel, syms, data_sink)
             return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
         deps = cache.deps_from(scratch)
         if deps is None:
-            err = _isolate(obj, rel, syms)
+            err = _isolate(obj, rel, syms, data_sink)
             return (rel, f"isolate: {err}", "error") if err else (rel, None, "uncacheable")
         # Cache the RAW object, then isolate the working copy. Storing the reduced
         # form instead would bake this transformation into every entry, so any later
         # fix to it would be masked by isolate()'s own idempotence -- which is exactly
         # how the STB_LOPROC bug survived a rebuild and forced SCHEMA 2.
         cache.put(key, deps, obj)
-        err = _isolate(obj, rel, syms)
+        err = _isolate(obj, rel, syms, data_sink)
         return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
     finally:
         if scratch:
@@ -426,6 +438,9 @@ def main():
                     help="skip the src/ layout invariant gate (see tools/layout_check.py)")
     ap.add_argument("--no-check", action="store_true",
                     help="skip module/source fidelity analysis; report status is unchecked")
+    ap.add_argument("--no-data-check", action="store_true",
+                    help="skip comparing emitted vtable/RTTI data against the ROM "
+                         "(see tools/romdata_check.py); never affects the link")
     ap.add_argument("--arm7-bios", help="passed to dsd rom build if your dump needs it")
     ap.add_argument("--no-cache", action="store_true",
                     help="compile every enrolled file, ignoring the object cache")
@@ -502,6 +517,10 @@ def main():
                                 enabled=not args.no_cache)
         init_srcs = init_section_sources()
         syms = enrolled_symbols()
+        # Collected during the compile because that is the only point at which the
+        # objects still carry the data mwcc emitted -- see _isolate. None switches the
+        # measurement off entirely; it never affects what gets linked either way.
+        data_sink = None if args.no_data_check else []
         print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
               + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
         failures = []
@@ -509,7 +528,8 @@ def main():
         if srcs:
             with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
                 for rel, err, outcome in ex.map(
-                        lambda s: compile_one(s, vers, cache, init_srcs, syms), srcs):
+                        lambda s: compile_one(s, vers, cache, init_srcs, syms,
+                                              data_sink=data_sink), srcs):
                     outcomes[outcome] = outcomes.get(outcome, 0) + 1
                     if err:
                         failures.append((rel, err))
@@ -560,7 +580,20 @@ def main():
             return 0
         print("[6/6] analyze module and source fidelity")
         analysis = RBC.analyze(config_root, args.profile)
+        if data_sink is not None:
+            # Folded in before printing, so the composition line can say how much of the
+            # data it just called unreachable is nonetheless proven. Reported, never
+            # gated: most of the tree fails this today for known modelling reasons, and
+            # validate_merge ratchets the verified count instead.
+            romdata = RDC.summarize(data_sink)
+            report["romData"] = romdata
+            analysis["moduleComposition"]["dataBytesVerified"] = romdata["verifiedBytes"]
         RBC.print_report(analysis)
+        if data_sink is not None:
+            rd = report["romData"]
+            print(f"ROM data from source: {rd['verified']:,} symbol(s) verified, "
+                  f"{rd['partial']:,} partial, {rd['differs']:,} differ, "
+                  f"{rd['unnamed']:,} unnamed by config")
         report["analysis"] = analysis
         report["status"] = "passed" if analysis["passed"] else "failed"
         save_report()

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -116,6 +116,29 @@ def _code_totals(config_root):
     return funcs, size
 
 
+def _module_code_bytes(sym_path):
+    """Bytes this module's symbols.txt accounts for as functions.
+
+    Everything else in the module image -- vtables, RTTI records, jump tables, string
+    and data tables -- is DATA, and no part of this pipeline reconstructs it. Delink
+    entries carve out functions; `objisolate` then reduces each compiled object to the
+    single `.text` its entry names and zeroes every other content section, so even the
+    `.data` a C++ TU does emit is dropped and re-imported from the ROM's gap object.
+
+    Subtracting this from the module image size is what makes that boundary a number
+    instead of an unstated assumption. Computed per module rather than from
+    `_code_totals`, which excludes itcm/dtcm from the published denominator while
+    `moduleFidelity` still compares them -- mixing the two would misattribute their
+    whole size to data.
+    """
+    total = 0
+    for line in sym_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        m = FUNC_RE.match(line)
+        if m:
+            total += int(m.group(2), 16)
+    return total
+
+
 def _diff_counts(built, retail, allowed=()):
     common = min(len(built), len(retail))
     differing = unexpected = 0
@@ -161,6 +184,7 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
         module_results.append({
             "module": label,
             "comparedBytes": max(len(built), len(retail)),
+            "codeBytes": _module_code_bytes(sym),
             "differingBytes": module_diff,
             "unexpectedDifferingBytes": unexpected_diff,
             "exact": module_diff == 0,
@@ -203,6 +227,7 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
 
     total_functions, total_code_bytes = _code_totals(config_root)
     compared_module_bytes = sum(m["comparedBytes"] for m in module_results)
+    module_code_bytes = sum(m["codeBytes"] for m in module_results)
     differing_module_bytes = sum(m["differingBytes"] for m in module_results)
     unexpected_module_bytes = sum(m["unexpectedDifferingBytes"] for m in module_results)
     compiled_functions = source_functions + mod_functions
@@ -225,6 +250,23 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             "percent": (100.0 * (compared_module_bytes - differing_module_bytes)
                         / compared_module_bytes) if compared_module_bytes else 0.0,
             "results": module_results,
+        },
+        # What the 106 module images are MADE OF, so the headline percentages cannot be
+        # read as coverage of the cartridge. `moduleFidelity.percent` is 100% whenever
+        # the build is green, but only `sourceBytes` of these bytes came from source --
+        # every other byte is one dsd handed back from the ROM, compared against itself.
+        # `dataBytes` is the part no delink entry can reach at all today.
+        "moduleComposition": {
+            "moduleBytes": compared_module_bytes,
+            "codeBytes": module_code_bytes,
+            "dataBytes": compared_module_bytes - module_code_bytes,
+            "sourceBytes": source_bytes,
+            "sourceBytesOfModulePercent": (100.0 * source_bytes / compared_module_bytes
+                                           if compared_module_bytes else 0.0),
+            "dataBytesVerified": 0,
+            "dataBytesOfModulePercent": (100.0 * (compared_module_bytes - module_code_bytes)
+                                         / compared_module_bytes
+                                         if compared_module_bytes else 0.0),
         },
         "sourceBuild": {
             "totalCodeFunctions": total_functions,
@@ -266,6 +308,15 @@ def print_report(report, show=12):
     print(f"  mismatching: {sf['mismatchingFunctions']:,}")
     print(f"module fidelity: {mf['modulesExact']}/{mf['modulesChecked']} exact, "
           f"{mf['percent']:.6f}% of compared bytes")
+    mc = report.get("moduleComposition")
+    if mc:
+        # Printed right under the 100.000000%, because that figure is exact by
+        # construction for every byte dsd supplies from the ROM and says nothing at all
+        # about them. This line is what it is a percentage OF.
+        print(f"  of {mc['moduleBytes']:,} module bytes: {mc['sourceBytes']:,} "
+              f"({mc['sourceBytesOfModulePercent']:.1f}%) built from source, "
+              f"{mc['dataBytes']:,} ({mc['dataBytesOfModulePercent']:.1f}%) are data "
+              f"no delink entry reaches ({mc['dataBytesVerified']:,} verified)")
     if report["missingModuleBinaries"]:
         print(f"missing module binaries: {report['missingModuleBinaries'][:8]}")
     for f in report["failures"][:show]:

--- a/tools/romdata_check.py
+++ b/tools/romdata_check.py
@@ -1,0 +1,320 @@
+"""Compare the DATA a compiled src/ object emits against the cartridge.
+
+WHY NOTHING CHECKED THIS
+------------------------
+Delink entries carve out functions. `tools/objisolate.py` then reduces each compiled
+object to the single `.text` its entry names and zeroes every other content section,
+rebinding the dropped symbols to the ROM's own carved-out addresses. That is correct
+and load-bearing -- an object that kept defining `_ZTV4Coin` in a now-empty `.data`
+would have every user of Coin's vtable bind to address 0 -- but it means the vtable,
+typeinfo record and typeinfo-name string that mwcc emitted are thrown away unexamined.
+
+So the ROM build's `106/106 exact` says nothing whatever about them. It cannot: those
+bytes come from a gap object holding the cartridge's own data, compared against itself.
+Roughly 26.7% of every module image is data in that position, and the fraction of it
+this project has ever verified was, before this tool, exactly zero.
+
+WHAT IT ANSWERS
+---------------
+For every data symbol a compiled source emits AND the ROM names in a `symbols.txt`:
+does the emitted object, once its relocations are resolved the way the linker would,
+equal the bytes at that address in the retail module?
+
+A hit is a real verification the build was already computing and discarding. A miss is
+a defect no existing gate can see -- a class whose vtable disagrees with the ROM's is a
+wrong class model even when its destructor byte-matches perfectly, and `include/` is
+full of generated flat headers that declare no virtuals at all.
+
+WHY IT IS A MEASUREMENT AND NOT A PASS/FAIL GATE
+------------------------------------------------
+Because most of the tree fails it, for a reason that is understood. `BrickBlock`'s
+generated header declares zero virtuals, so mwcc emits a 2-slot vtable stub where the
+ROM has 31 slots; the emitted prefix is not even the same slots. Failing a merge on
+that would fail nearly every C++ file in the tree for pre-existing modelling debt.
+
+So the verdicts are counted, the count is reported, and `validate_merge` ratchets it:
+the number of verified data symbols may rise freely and may not fall. That is the same
+shape as langmode-ratchet and converted-ratchet, and it is the only shape that can
+land green.
+
+THE VTABLE PREAMBLE, AND WHY THE COMPARE IS OFFSET
+--------------------------------------------------
+mwcc's `_ZTV<C>` addresses the START of the vtable object -- offset-to-top, then
+typeinfo, then the slots. This tree's `symbols.txt` uses the other convention: `_ZTV<C>`
+IS the slot array, already past those two words. `objisolate.VTABLE_PREAMBLE` exists for
+exactly this reason and is reused here rather than respelled, so the two cannot drift.
+
+Usage:
+    python tools/romdata_check.py                       # every enrolled source
+    python tools/romdata_check.py --files src/a.cpp
+    python tools/romdata_check.py --json build/romdata.json
+"""
+import argparse
+import collections
+import concurrent.futures
+import io
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+from elftools.elf.elffile import ELFFile  # noqa: E402
+import linkcheck as LC  # noqa: E402
+import objisolate as OI  # noqa: E402
+import relocs as RL  # noqa: E402
+import reloc_audit as RA  # noqa: E402
+import reverify_corpus as RV  # noqa: E402
+# `rombuild` is imported lazily inside _compile/main, never at module scope: rombuild
+# imports THIS module so it can measure each object while it is still raw, and a
+# top-level import here would close that cycle. Nothing above _compile needs it.
+
+_SYM_RE = re.compile(r"^(\S+)\s+kind:(\S+?)[\s(].*?addr:0x([0-9a-fA-F]+)")
+
+# VERIFIED  every byte of the ROM's extent for this symbol was compared and equal
+# PARTIAL   everything compared was equal, but the coverage is short -- the object
+#           emitted fewer bytes than the ROM's extent, or some words were blind
+# DIFFERS   at least one compared byte disagreed
+# UNNAMED   no symbols.txt entry gives this symbol an address; nothing to compare to
+VERIFIED, PARTIAL, DIFFERS, UNNAMED = "VERIFIED", "PARTIAL", "DIFFERS", "UNNAMED"
+
+_index_lock = threading.Lock()
+_index = None
+_names_lock = threading.Lock()
+_names = None
+
+
+def name_index():
+    """`reloc_audit`'s symbol->address index, built once for the whole process.
+
+    Cached because `check_object` runs once per compiled file inside the ROM build's
+    thread pool, and rebuilding this per object would walk every symbols.txt eleven
+    thousand times.
+    """
+    global _names
+    with _names_lock:
+        if _names is None:
+            _names = RA.build_name_index()
+        return _names
+
+
+def rom_data_index():
+    """{(module, name): (addr, extent)} for every symbol the ROM config names.
+
+    `extent` is the distance to the next symbol in the same module, which is the only
+    size information available: `symbols.txt` writes data as `kind:data(any)` with no
+    size, while functions carry one. It is an upper bound on the object -- a trailing
+    alignment gap belongs to nobody -- so a short compare is reported PARTIAL rather
+    than being silently rounded up into a pass.
+    """
+    global _index
+    with _index_lock:
+        if _index is not None:
+            return _index
+        per_module = collections.defaultdict(list)
+        for sym_path, label in RL.module_universe():
+            for line in sym_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+                m = _SYM_RE.match(line.strip())
+                if m:
+                    per_module[label].append((int(m.group(3), 16), m.group(1)))
+        index = {}
+        for label, entries in per_module.items():
+            entries.sort()
+            for i, (addr, name) in enumerate(entries):
+                nxt = next((entries[j][0] for j in range(i + 1, len(entries))
+                            if entries[j][0] > addr), None)
+                if nxt is not None:
+                    index[(label, name)] = (addr, nxt - addr)
+        _index = index
+        return _index
+
+
+def emitted_data_symbols(raw):
+    """[(name, shndx, value, size)] for defined data objects in this object file.
+
+    Every one of these is a section `objisolate` drops, because it keeps exactly one
+    `.text` and zeroes the rest. Locals are skipped: a static table has no ROM symbol
+    to be compared against and never collides with one.
+    """
+    elf = ELFFile(io.BytesIO(raw))
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return []
+    out = []
+    for s in symtab.iter_symbols():
+        if not s.name or s["st_shndx"] in ("SHN_UNDEF", "SHN_ABS"):
+            continue
+        if s["st_info"]["type"] != "STT_OBJECT" or not s["st_size"]:
+            continue
+        if s["st_info"]["bind"] == "STB_LOCAL":
+            continue
+        out.append((s.name, s["st_shndx"], s["st_value"], s["st_size"]))
+    return out
+
+
+def verify_data_symbol(raw, name, shndx, value, size, names=None):
+    """One verdict dict for one emitted data symbol.
+
+    The relocations are applied exactly as `linkcheck.link_function` applies them to a
+    function body -- same helper, so a vtable slot and a `bl` target are resolved by one
+    piece of code. Words it could not resolve come back as `blind` and are excluded from
+    the comparison rather than counted as differences: an unresolvable slot is a word we
+    have no opinion about, and calling it a mismatch would manufacture defects.
+    """
+    names = names if names is not None else name_index()
+    resolved = RA.resolve_candidate(name, names)
+    if not resolved or resolved[0] is None:
+        return {"symbol": name, "verdict": UNNAMED, "bytes": 0}
+    module, addr = resolved
+    extent = rom_data_index().get((module, name), (addr, None))[1]
+
+    elf = ELFFile(io.BytesIO(raw))
+    body = elf.get_section(shndx).data()[value:value + size]
+    # mwcc's _ZTV symbol starts at the vtable OBJECT; the ROM's starts at the slots.
+    preamble = OI.VTABLE_PREAMBLE if name.startswith("_ZTV") else 0
+    if len(body) <= preamble:
+        return {"symbol": name, "verdict": PARTIAL, "bytes": 0, "module": module,
+                "addr": addr, "note": "nothing past the vtable preamble"}
+    linked, blind = LC.link_function(body, addr - preamble,
+                                     LC.func_relocs_typed(raw, name, names) or [])
+    linked = linked[preamble:]
+    blind = {o - preamble for o in blind if o >= preamble}
+
+    retail = RV.rom_bytes(module, addr, len(linked))
+    if retail is None or len(retail) < len(linked):
+        return {"symbol": name, "verdict": PARTIAL, "bytes": 0, "module": module,
+                "addr": addr, "note": "module image shorter than the emitted symbol"}
+    compared = differing = 0
+    for off in range(0, len(linked) & ~3, 4):
+        if off in blind:
+            continue
+        compared += 4
+        if linked[off:off + 4] != retail[off:off + 4]:
+            differing += 4
+    rec = {"symbol": name, "module": module, "addr": addr, "bytes": compared,
+           "emitted": len(linked), "romExtent": extent, "blindWords": len(blind)}
+    if differing:
+        rec["verdict"] = DIFFERS
+        rec["differingBytes"] = differing
+    elif compared and not blind and extent is not None and len(linked) >= extent:
+        rec["verdict"] = VERIFIED
+    else:
+        rec["verdict"] = PARTIAL
+    return rec
+
+
+def check_object(obj_path, rel, names=None):
+    """Verdicts for every data symbol in one compiled object.
+
+    Called from `rombuild.compile_one` while the object is still RAW -- `objisolate`
+    zeroes these sections moments later, which is the whole reason this has to happen
+    inside the build rather than over the artifacts it leaves behind.
+    """
+    try:
+        raw = pathlib.Path(obj_path).read_bytes()
+        out = []
+        for name, shndx, value, size in emitted_data_symbols(raw):
+            rec = verify_data_symbol(raw, name, shndx, value, size, names)
+            rec["src"] = rel
+            out.append(rec)
+        return out
+    except Exception as exc:  # noqa: BLE001 - a measurement must never fail a build
+        # This runs inside the ROM build. A malformed object, a module image this tool
+        # cannot map, or any other surprise must cost its own measurement and nothing
+        # else -- failing the link over a statistic would be strictly worse than not
+        # having the statistic.
+        return [{"src": rel, "symbol": "?", "verdict": UNNAMED, "bytes": 0,
+                 "note": f"{type(exc).__name__}: {exc}"}]
+
+
+def summarize(records):
+    counts = collections.Counter(r["verdict"] for r in records)
+    verified_bytes = sum(r.get("bytes", 0) for r in records if r["verdict"] == VERIFIED)
+    partial_bytes = sum(r.get("bytes", 0) for r in records if r["verdict"] == PARTIAL)
+    return {
+        "symbols": len(records),
+        "verified": counts[VERIFIED],
+        "partial": counts[PARTIAL],
+        "differs": counts[DIFFERS],
+        "unnamed": counts[UNNAMED],
+        "verifiedBytes": verified_bytes,
+        "partialBytes": partial_bytes,
+        # The actionable list: a class model whose vtable disagrees with the cartridge.
+        "differing": sorted(
+            ({"src": r["src"], "symbol": r["symbol"], "module": r.get("module"),
+              "addr": r.get("addr"), "differingBytes": r.get("differingBytes")}
+             for r in records if r["verdict"] == DIFFERS),
+            key=lambda r: (r["src"], r["symbol"])),
+    }
+
+
+def _compile(rel, tmpdir):
+    """Compile one source the way the ROM build does, WITHOUT isolating it."""
+    import rombuild as RB
+    src = REPO / rel
+    flags = RB.CFLAGS
+    try:
+        if src.read_text(encoding="utf-8").startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+    except OSError:
+        return None
+    version = RB.versions().get(pathlib.Path(rel).stem, RB.VERSION)
+    obj = pathlib.Path(tmpdir) / (pathlib.Path(rel).stem + ".o")
+    proc = subprocess.run(
+        [*RB.launcher(), str(RB.MW / version / "mwccarm.exe"), *flags.split(),
+         "-i", str(RB.INCLUDE), "-c", str(src), "-o", str(obj)],
+        capture_output=True, text=True,
+        env=dict(os.environ, LM_LICENSE_FILE=str(RB.LICENSE)), cwd=REPO)
+    return obj if proc.returncode == 0 and obj.is_file() else None
+
+
+def main():
+    import rombuild as RB
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--files", nargs="*", help="sources to check (default: all enrolled)")
+    ap.add_argument("-j", "--jobs", type=int, default=RB.default_jobs())
+    ap.add_argument("--json", help="write the structured report here")
+    ap.add_argument("--show", type=int, default=15, help="differing symbols to print")
+    args = ap.parse_args()
+
+    sources = args.files or [s for s in RB.enrolled() if s.startswith("src/")]
+    names = name_index()
+    rom_data_index()
+    records = []
+    with tempfile.TemporaryDirectory() as tmp:
+        def one(rel):
+            obj = _compile(rel, tmp)
+            return check_object(obj, rel, names) if obj else []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+            for got in ex.map(one, sources):
+                records.extend(got)
+
+    report = summarize(records)
+    report["sourcesChecked"] = len(sources)
+    print(f"data symbols emitted by {len(sources):,} enrolled source(s): "
+          f"{report['symbols']:,}")
+    print(f"  VERIFIED {report['verified']:,}  ({report['verifiedBytes']:,} bytes "
+          f"equal to the cartridge)")
+    print(f"  PARTIAL  {report['partial']:,}  ({report['partialBytes']:,} bytes equal, "
+          f"coverage short of the ROM's extent)")
+    print(f"  DIFFERS  {report['differs']:,}")
+    print(f"  UNNAMED  {report['unnamed']:,}  (no symbols.txt address to compare against)")
+    for r in report["differing"][:args.show]:
+        print(f"    {r['symbol']:44s} {r['module'] or '?':6s} "
+              f"0x{(r['addr'] or 0):08x}  {r['differingBytes']} byte(s)  {r['src']}")
+    if len(report["differing"]) > args.show:
+        print(f"    +{len(report['differing']) - args.show} more")
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(report, indent=2) + "\n",
+                                           encoding="utf-8", newline="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -160,6 +160,40 @@ def enrollment_snapshot(rev):
                       "modBytes": sum(e["size"] for e in mods.values())}}
 
 
+def verification_split(functions, enrollment):
+    """Divide ``matched`` into what the ROM build PROVES and what only asserts itself.
+
+    ``function_snapshot`` calls a function matched when a file named after its symbol
+    exists in ``src/``, carries no ``NONMATCHING`` banner, and is not a ``dcd``
+    transcription.  That is a filename test.  Nothing in it compiles the file, links
+    it, or compares a byte -- and it cannot, because the real per-function ledger
+    (``progress/matched.jsonl``) is gitignored and never reaches a validator.
+
+    What the cartridge actually settles is the OTHER set: a range carrying ``complete``
+    in a ``delinks.txt`` is compiled, linked into its module, and byte-compared against
+    retail.  Everything else is filled by a gap object holding the ROM's own bytes, so
+    it is exact by construction and proves nothing about the source beside it.
+
+    The two are not close.  Reporting only the larger one puts a 10-point overstatement
+    in front of every reader, so both travel, separately labelled, and the measured one
+    leads.  ``matched`` itself is deliberately left alone: ``attribution_snapshot`` keys
+    contributor credit off it, so redefining it here would move credit for everyone.
+    """
+    enrolled = {key.split("-", 1)[0] for key in enrollment["source"]}
+    verified = {k: r for k, r in functions["matched"].items() if k in enrolled}
+    claimed = {k: r for k, r in functions["matched"].items() if k not in enrolled}
+    return {
+        "verified": verified,
+        "claimed": claimed,
+        "stats": {
+            "verifiedFunctions": len(verified),
+            "verifiedBytes": sum(r["size"] for r in verified.values()),
+            "claimedFunctions": len(claimed),
+            "claimedBytes": sum(r["size"] for r in claimed.values()),
+        },
+    }
+
+
 def _json_at(rev, path):
     try:
         return json.loads(git_text(rev, path))
@@ -370,6 +404,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
 
     bf, hf = function_snapshot(base_sha), function_snapshot(head_sha)
     be, he = enrollment_snapshot(base_sha), enrollment_snapshot(head_sha)
+    bv, hv = verification_split(bf, be), verification_split(hf, he)
     ba, ha = attribution_snapshot(base_sha, bf), attribution_snapshot(head_sha, hf)
     diff = diff_snapshot(base_sha, head_sha, set(tree_paths(head_sha, "src/")))
 
@@ -414,6 +449,16 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append("function/byte coverage denominator changed")
     if he["stats"]["sourceBytes"] < be["stats"]["sourceBytes"]:
         reasons.append("source-built byte coverage decreased")
+    # Bytes alone cannot see a SWAP. Dropping `complete` from one delinks entry and
+    # adding it to another of equal or greater size holds sourceBytes flat while the
+    # first range quietly leaves the set the ROM build actually byte-compares -- and
+    # its src/ file still exists, so `matched` does not move either and nothing in the
+    # report changes. Two more checks, because the pair is what closes it: the count
+    # catches a same-size swap, and the range diff below names anything that left even
+    # when both totals hold.
+    if he["stats"]["sourceFunctions"] < be["stats"]["sourceFunctions"]:
+        reasons.append("source-built function coverage decreased")
+    dropped_enrollment = sorted(set(be["source"]) - set(he["source"]))
     # The attribution-override label (carried on the job by tangos-backend) makes every
     # attribution finding advisory for this one pull request.  The finding is still
     # computed and still named -- an override says "I know, and I meant it", not "do not
@@ -454,6 +499,16 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                         "the pull request")
     if same_baseline_failure:
         warnings.append("base and merge share the same pre-existing ROM-build failure")
+    if (dropped_enrollment
+            and he["stats"]["sourceBytes"] >= be["stats"]["sourceBytes"]
+            and he["stats"]["sourceFunctions"] >= be["stats"]["sourceFunctions"]):
+        # Both totals held, so neither reason above fired -- but these ranges are no
+        # longer byte-compared against the cartridge. Re-splitting an entry (its `end`
+        # moving) lands here too, which is why it warns rather than failing.
+        warnings.append(
+            f"{len(dropped_enrollment)} address range(s) left the byte-verified set "
+            f"while enrolled totals held steady: " + ", ".join(dropped_enrollment[:5])
+            + (f", +{len(dropped_enrollment) - 5} more" if len(dropped_enrollment) > 5 else ""))
     if new_unbannered:
         warnings.append(f"{len(new_unbannered)} new/changed file(s) carry an asm body "
                         f"with no HAND-ASM PRIMITIVE or NONMATCHING banner: "
@@ -465,10 +520,25 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         warnings.append(f"{unresolved} affected source file(s) could not be fully link-checked")
     if not head_rom_state.get("available"):
         warnings.append("no head full-ROM report was supplied")
+    new_claimed = hv["stats"]["claimedFunctions"] - bv["stats"]["claimedFunctions"]
+    if new_claimed > 0:
+        # Landing a match before enrolling it is ordinary, so this is not a failure --
+        # but the count only ever grew silently before, and it is the number that makes
+        # the headline percentage bigger than the evidence.
+        warnings.append(
+            f"{new_claimed} more function(s) now claim a match "
+            f"that nothing compiles; enroll them in a delinks.txt to have the ROM "
+            f"build check them")
 
     coverage_delta = {
         "matchedFunctions": hf["stats"]["matchedFunctions"] - bf["stats"]["matchedFunctions"],
         "matchedBytes": hf["stats"]["matchedBytes"] - bf["stats"]["matchedBytes"],
+        "verifiedFunctions": (hv["stats"]["verifiedFunctions"]
+                              - bv["stats"]["verifiedFunctions"]),
+        "verifiedBytes": hv["stats"]["verifiedBytes"] - bv["stats"]["verifiedBytes"],
+        "claimedFunctions": (hv["stats"]["claimedFunctions"]
+                             - bv["stats"]["claimedFunctions"]),
+        "claimedBytes": hv["stats"]["claimedBytes"] - bv["stats"]["claimedBytes"],
         "sourceBuiltFunctions": he["stats"]["sourceFunctions"] - be["stats"]["sourceFunctions"],
         "sourceBuiltBytes": he["stats"]["sourceBytes"] - be["stats"]["sourceBytes"],
         "newMatchedFunctions": len(head_keys - base_keys),
@@ -506,7 +576,9 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         "summary": summary,
         "reasons": reasons,
         "warnings": warnings,
-        "coverage": {"base": bf["stats"], "head": hf["stats"], "delta": coverage_delta},
+        "coverage": {"base": {**bf["stats"], **bv["stats"]},
+                     "head": {**hf["stats"], **hv["stats"]},
+                     "delta": coverage_delta},
         "sourceBuild": {"base": base_source_stats, "head": head_source_stats},
         "attribution": {"base": ba["contributors"], "head": ha["contributors"],
                         "baseStats": ba["stats"], "headStats": ha["stats"],
@@ -527,6 +599,10 @@ def _signed(n):
     return f"{n:+,}"
 
 
+def _pct(n, d):
+    return f"{100.0 * n / d:.2f}%" if d else "n/a"
+
+
 def render_markdown(r):
     c, s, l = r["coverage"], r["sourceBuild"], r["linkcheck"]
     h, d = c["head"], c["delta"]
@@ -535,14 +611,31 @@ def render_markdown(r):
     lines = ["### Full merge validation", "",
              "| Check | Result |", "|---|---|",
              f"| Committed test merge | {'yes' if r['committedMerge'] else 'no'} |",
-             f"| Matched functions | {h['matchedFunctions']:,} / {h['totalFunctions']:,} "
-             f"({h['matchedFunctionPercent']:.1f}%, {_signed(d['matchedFunctions'])}) |",
-             f"| Matched code bytes | {h['matchedBytes']:,} / {h['totalBytes']:,} "
-             f"({h['matchedBytePercent']:.1f}%, {_signed(d['matchedBytes'])}) |",
-             f"| Tracked source enrollment | {s['head']['sourceFunctions']:,} functions, "
-             f"{s['head']['sourceBytes']:,} bytes "
-             f"({s['head']['sourceBytesPercent']:.2f}%, {_signed(d['sourceBuiltBytes'])}) |",
-             f"| Perfect source moves | {len(r['diff']['perfectRenames'])} R100 |",
+             # The measured number leads and the asserted one is named as an assertion.
+             # Printing only `matchedFunctions` overstated coverage by ten points,
+             # because a filename with no `complete` delinks entry counts there and is
+             # compiled by nothing -- see verification_split.
+             f"| Byte-verified functions | {h['verifiedFunctions']:,} / "
+             f"{h['totalFunctions']:,} ({_pct(h['verifiedFunctions'], h['totalFunctions'])}, "
+             f"{_signed(d['verifiedFunctions'])}) |",
+             f"| Byte-verified code bytes | {h['verifiedBytes']:,} / {h['totalBytes']:,} "
+             f"({_pct(h['verifiedBytes'], h['totalBytes'])}, {_signed(d['verifiedBytes'])}) |",
+             f"| Claimed, not byte-verified | {h['claimedFunctions']:,} functions, "
+             f"{h['claimedBytes']:,} bytes ({_signed(d['claimedFunctions'])}) |",
+             f"| Perfect source moves | {len(r['diff']['perfectRenames'])} R100 |"]
+    # The delinks view of the same quantity. Identical to byte-verified above whenever
+    # every enrolled range is a matched symbols.txt function, which is the healthy
+    # state -- so it earns a row only when the two disagree, where the disagreement is
+    # the news: an enrolled range with no matched function behind it, or a matched
+    # function whose enrolled entry the symbol table does not know about.
+    if s["head"]["sourceFunctions"] != h["verifiedFunctions"]:
+        lines.append(
+            f"| Enrolled ranges (delinks `complete`) | {s['head']['sourceFunctions']:,} "
+            f"functions, {s['head']['sourceBytes']:,} bytes "
+            f"({s['head']['sourceBytesPercent']:.2f}%, {_signed(d['sourceBuiltBytes'])}) "
+            f"-- differs from byte-verified by "
+            f"{s['head']['sourceFunctions'] - h['verifiedFunctions']:+,} |")
+    lines += [
              f"| Contributor credit | {len(r['attribution']['added'])} added, "
              f"{len(r['attribution']['changed'])} changed, "
              f"{len(r['attribution']['lost'])} lost"
@@ -567,6 +660,14 @@ def render_markdown(r):
     else:
         lines.append("| Full ROM build | not supplied |")
     lines += _credit_table(r["attribution"])
+    if h.get("claimedFunctions"):
+        lines += ["", f"*Byte-verified* means the range carries `complete` in a "
+                      f"`delinks.txt`, so the ROM build compiled it and compared it to "
+                      f"the cartridge. The {h['claimedFunctions']:,} *claimed* functions "
+                      f"have a `src/` file named after the symbol with no `NONMATCHING` "
+                      f"banner, and nothing compiles them -- dsd fills their addresses "
+                      f"with the ROM's own bytes. Both together are the "
+                      f"{h['matchedFunctions']:,} this project calls matched."]
     if r["warnings"]:
         lines += ["", "Warnings: " + "; ".join(r["warnings"]) + "."]
     return "\n".join(lines)

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -284,6 +284,11 @@ def _rom_state(report):
             json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
     return {"available": True, "passed": passed, "signature": signature,
             "analysis": analysis if "moduleFidelity" in analysis else None,
+            # tools/romdata_check.py's counts, present only from a rombuild that ran the
+            # measurement. A base report cached before it existed simply has none, and
+            # the ratchet below then does not run -- which is the right degradation:
+            # nothing to compare against is not a regression.
+            "romData": report.get("romData"),
             "failure": failure}
 
 
@@ -482,6 +487,20 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append(f"{len(link['blocking'])} blocking relocation verdict(s)")
     if port.get("available") and not port["passed"]:
         reasons.append(_port_reason(port))
+    # A RATCHET, not a gate. The emitted vtable and RTTI that `objisolate` discards are
+    # compared against the cartridge, and most of the tree fails that today for a
+    # understood reason -- a generated flat header declares no virtuals, so mwcc emits a
+    # two-slot stub where the ROM has thirty-one. Failing a merge on it would fail nearly
+    # every C++ file for pre-existing modelling debt. So the count may rise freely and
+    # may not fall: this is the only check in the report that watches ROM DATA at all.
+    base_data = base_rom_state.get("romData") or {}
+    head_data = head_rom_state.get("romData") or {}
+    data_ratchet = (base_data.get("verified") is not None
+                    and head_data.get("verified") is not None)
+    if data_ratchet and head_data["verified"] < base_data["verified"]:
+        reasons.append(
+            f"ROM data verified from source fell from {base_data['verified']} to "
+            f"{head_data['verified']} symbol(s)")
     if rom_regression:
         reasons.append("full-ROM result regressed from the base commit")
     if head_rom_state.get("available") and not head_rom_state.get("passed") \
@@ -655,6 +674,20 @@ def render_markdown(r):
                      f"{mf['percent']:.6f}% compared bytes |")
         lines.append(f"| Code linked from verified source | {sf['sourceFunctions']:,} functions, "
                      f"{sf['sourceBytes']:,} bytes ({sf['sourceBytesPercent']:.2f}%) |")
+        # What the 100.000000% above is a percentage OF. Every byte not built from
+        # source is one dsd handed back from the cartridge and compared against itself.
+        mc = head_rom["analysis"].get("moduleComposition")
+        if mc:
+            lines.append(
+                f"| Module bytes from source | {mc['sourceBytes']:,} / "
+                f"{mc['moduleBytes']:,} ({mc['sourceBytesOfModulePercent']:.1f}%); "
+                f"{mc['dataBytes']:,} ({mc['dataBytesOfModulePercent']:.1f}%) are data "
+                f"no delink entry reaches |")
+    rom_data = head_rom.get("romData")
+    if rom_data:
+        lines.append(f"| ROM data reproduced from source | {rom_data['verified']:,} "
+                     f"symbol(s) exact, {rom_data['partial']:,} partial, "
+                     f"{rom_data['differs']:,} differ |")
     elif head_rom.get("failure"):
         lines.append(f"| Full ROM build | {head_rom['failure'].get('phase')} failed |")
     else:


### PR DESCRIPTION

Branch: `validator/honest-metrics` (3 commits, tools + CI only — no `src/`, no `include/`, no config that affects a link)

This started as an audit of what our gates really answer. Three of the four changes
here fix places where a check said more than it knew; the fourth adds a check where
there was none.

---

## 1. Two coverage numbers existed and we published the weaker one

`validate_merge.function_snapshot` calls a function **matched** when a file named
after its symbol exists under `src/`, has no `NONMATCHING` banner, and is not a `dcd`
blob. That is a filename test. Nothing in it compiles the file, links it, or compares
a byte — and it *cannot*, because the real per-function ledger
(`progress/matched.jsonl`) is gitignored and never reaches a validator. The code says
so outright: `cluster_targets.py:52` and `coddog.py:82` both note that a committed
`src/` file is the only portable is-it-matched signal we have.

What the ROM build actually settles is a different set: a range carrying `complete` in
a `delinks.txt` gets compiled, linked into its module, and byte-compared against
retail. Everything else is filled by a gap object holding the cartridge's own bytes.

Measured on `main` @ `54748873a`:

| | functions | code bytes |
|---|---|---|
| symbols.txt denominator | 11,347 | 2,211,124 |
| counted `matched` | 11,190 (98.62%) | 94.36% |
| enrolled + relinked | 10,826 | 1,954,024 (88.37%) |
| **claimed, never built** | **364** | **132,292** |

Both numbers now travel, separately labelled, and the measured one leads — in the PR
check, in `chaos-db.json` (so the site and badge stop quoting the filename count
alone), and in the CI log.

**`matched` itself is deliberately unchanged.** `attribution_snapshot` keys contributor
credit off it; redefining it would move credit for everyone.

## 2. `106/106 exact, 100.000000%` needed a denominator

That figure is exact **by construction** for every byte dsd supplies from a gap
object — the cartridge compared against itself. Of 3,049,600 module bytes:

- **1,960,912 (64.3%) built from source**
- **814,132 (26.7%) is data no delink entry can reach**

That line now prints directly under the 100.000000% it is a percentage of.

## 3. Nothing had ever verified a byte of ROM data — now something does

`objisolate` reduces each compiled object to the single `.text` its delink entry names
and zeroes every other section. That is correct and load-bearing (an object still
defining `_ZTV4Coin` in an empty `.data` would have every user of Coin's vtable bind to
address 0), but it means the vtable, typeinfo record and typeinfo name mwcc emitted are
discarded unexamined.

New `tools/romdata_check.py` compares each of them against retail, resolving
relocations through `linkcheck.link_function` — the same helper that links a function
body, so a vtable slot and a `bl` target can't drift apart. It runs **inside**
`rombuild.compile_one`, because that is the only moment the objects still carry the
data; a pass over build artifacts would find it already zeroed.

Tree-wide: **121 VERIFIED** (11,128 bytes exactly equal to the cartridge), **523
PARTIAL**, **217 DIFFERS**, 3,036 UNNAMED by any `symbols.txt`.

The 217 are class models whose vtable disagrees with the ROM, which no gate could
previously see: a generated flat header declares no virtuals, so mwcc emits a two-slot
stub where the ROM has thirty-one, and the link stays green because the stub is
dropped. **Reported, not gated** — hard-failing would fail nearly every C++ file for
pre-existing debt. `validate_merge` ratchets the verified count instead: may rise
freely, may not fall.

Cost: none measurable. Warm-cache full build 91–95s without, 90–100s with.

## 4. `check_header_offsets` gated nothing, and a swap could hide

- The tool fed `sys.argv[1:]` straight into its loop, so **run bare it checked zero
  files, printed nothing, and exited 0** — and nothing invoked it. An empty run is now
  an error, `--changed [base]` was added, and `.github/workflows/header-offsets.yml`
  runs it on changed headers. First whole-tree run: 441/445 clean; the 4 are written
  into `config/header-offset-known-issues.txt` (3 parser limits, 1 real off-by-3 in
  `include/dScMgSlot1_c.h`). Verified by planting the exact defect it exists for.
- Dropping `complete` from one delinks entry and adding it to another of **equal or
  greater size** held `sourceBytes` flat while the first range left the byte-compared
  set — and its `src/` file still existed, so `matched` didn't move either. The
  function count now catches a same-size swap, and a range diff names anything that
  left even when both totals hold.

---

## Not fixed here — the finding this turned up

Of the 364 counted matched but never built, 21 are HAND-ASM primitives. I compiled the
other **343** under the pin against the cartridge:

- **236 reproduce exactly** — real matches, just unenrolled. Enrollment candidates.
- **80** compile to a **different length** (`999` is `match.py:174`'s size-mismatch sentinel)
- **22 do not compile at all** — 17 `.cpp`, 5 `.c`; four of the `.c` files contain
  `virtual` and other C++ syntax in a file compiled as C99
- **5** compile but the object lacks the symbol they claim

So roughly a third of the unbuilt portion is not a match, and 22 functions carry a
match claim from files nothing can compile. Caveat: `build_pin` compiles in isolation
and we have a recorded case of an isolated mismatch the real link reproduces, so some
of the 80 may be artifacts — the 22 are not.

Suggested follow-up as two separate commits: harvest the 236 into enrollment (adds
byte-verified coverage), and banner the 107 `NONMATCHING` (removes a false claim).
None of this is new breakage — `eligible.py` would have reported all of it, and
`eligible.py` runs in no workflow.

Also unmeasured: **357 files** (338 enrolled, 157 distinct classes) use the
`extern int _ZTV6ToxBox[]; *(int**)p = _ZTV6ToxBox;` idiom. No class exists, mwcc emits
no vtable, so `romdata_check` finds *zero* symbols in them — invisible by construction.
`_ZTV8Platform` alone is faked 161 times. A textual ratchet on that count is the
obvious next gate.

---

## Deployment

There is no deploy step. `restore_trusted_controls` checks `tools/` out from the PR's
**base commit** on every job, so this goes live for every PR whose base includes it —
i.e. when it lands on main. The worker harness (`sm64ds-validator`) is untouched and
needs no restart.

Consequence: **this branch is validated by the code it replaces.** Its own check will
show the old table. The first PR to display the new rows is the one after this lands.

Base ROM reports cached before this lands carry no `romData`, so the data ratchet
simply won't run against them; that degradation is deliberate and heals as bases move
forward.

## Verification

```
rombuild.py -j16 --no-rom   106/106 exact, 100.000000%, 10,854 reproducing, 0 mismatching, PASS
pytest tools/               295 passed, 3 skipped
check_python_names          0 unresolvable, 0 unparseable, PASS
port_refcheck               393 checked, all resolve
check_duplicate_sources     11,287 stems, none doubled
tiers_ratchet --check       PASS (baseline 426, current 426)
check_header_offsets        445 headers, 441 clean, 4 waived
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT
