### PR TITLE
notes: resolve two committed stash-conflict regions in mwccarm-codegen.md

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -2888,17 +2888,11 @@ commutative op, try the sub-identity before calling it a floor.
 
 Landing note (split-symbol carriers, extends 9a(3)): func_02072168 is banked and
 re-verified at the COMBINED 0x88c extent (0x02072168..0x020729f4) because its compiled
-<<<<<<< Updated upstream
 object also emits func_020729e8, the severed 12-byte epilogue. RESOLVED 2026-08-01: the
 symbol map now merges the pair (config/arm9/symbols.txt lists func_02072168 at size
 0x88c, the func_020729e8 row and its stub src file are gone) -- the first symbol-map
 merge of a severed fragment into its parent. Precedent for the func_02071644/
 func_02071694 pair (9a(3)'s other proven case) when someone lands that one.
-=======
-object also emits func_020729e8, the severed 12-byte epilogue. matched.jsonl carries size
-2188; the symbol map still lists both symbols. src/func_020729e8.c stays as a documented
-stub.
->>>>>>> Stashed changes
 
 ## 6ax. Inverse RMW-launder: demote the PLAIN read to let the RMW chain lead an interleave (2026-08-01, CapEnemy::GetCapState MATCHED)
 
@@ -2919,7 +2913,6 @@ Rule amendment: "launder ONLY the RMW sites" holds for the ADDRESS-MATERIALIZATI
 (that is what the ROM's RMW/single-use anatomy dictates). But for ORDERING residue between
 two chains, the launder is a scheduling-class demotion you can apply to EITHER side: launder
 the chain that must YIELD, not the one that must lead.
-<<<<<<< Updated upstream
 
 ## 6ay. Four new axes tested on the arm9 floors, all closed (2026-08-01, post-#960 theory sweep)
 


### PR DESCRIPTION
`notes/mwccarm-codegen.md` on main carries four live conflict-marker lines in two regions. Commit 87a55cfa ("config: 0x02092680 is Scene's vtable...") applied a stash, hit conflicts in this file, and committed with the markers in place. This is the shared 6xx codegen-notes file that every crack lane reads, so the mangled regions are live misinformation. Docs-only change, one file, seven lines deleted, no prose rewritten.

## Region 1: the 6aw landing note, main lines 2891-2901

Closed conflict, both sides continuing the same sentence. This is one paragraph in two versions, not two distinct notes, so the usual "keep both in note-number order" resolution does not apply.

**`Updated upstream` side (5 lines, KEPT).** Says the split-symbol pair was resolved: the symbol map now merges func_020729e8 into func_02072168, the stub src file is gone, and it is precedent for the func_02071644/func_02071694 pair.

**`Stashed changes` side (3 lines, DROPPED).** An older snapshot of the same paragraph: `matched.jsonl carries size 2188; the symbol map still lists both symbols. src/func_020729e8.c stays as a documented stub.`

**How it was reconstructed.** Two independent checks agree on keeping upstream:

1. **History.** `git show de4b5576:notes/mwccarm-codegen.md` (87a55cfa's parent, the pre-stash committed state) contains the upstream text verbatim. The repaired passage is byte-identical to it. The stashed side is the older text the stash was carrying, which had already been superseded on main before the stash was applied.
2. **Ground truth on main today.** The stashed side's two distinguishing claims are both false now:
   - `config/arm9/symbols.txt:3036` is a single merged row, `func_02072168 kind:function(arm,size=0x88c) addr:0x02072168`, with no `func_020729e8` row.
   - `src/func_020729e8.c` does not exist.

**Deliberate drop, with reason.** The 3 stashed lines are dropped as superseded and factually wrong. The only fact they carried on their own is `size 2188`, which is 0x88c in decimal and is already stated in hex on the kept side (`config/arm9/symbols.txt lists func_02072168 at size 0x88c`). The lead-in clause (`object also emits func_020729e8, the severed 12-byte epilogue.`) is word-for-word identical on both sides. Nothing unique is lost.

## Region 2: between 6ax and 6ay, main line 2922

An **orphan** `<<<<<<< Updated upstream` with no `=======` and no `>>>>>>>`. Not a second two-sided conflict, despite appearances.

**How it was reconstructed.** `git show 87a55cfa -- notes/mwccarm-codegen.md` shows the original region: the `Updated upstream` side was everything from the end of 6ax to EOF (notes 6ay and 6ba), and the `Stashed changes` side was **empty**, with the closing pair sitting alone at EOF. The stash predated 6ay/6ba, so it simply had no content there. PR #1111 (`98e3e6cf8`) later replaced the trailing `=======` / `>>>>>>> Stashed changes` at EOF when it appended note 6bb, which is what orphaned the opener.

**Resolution.** Delete the stray line. Upstream content (6ay, 6ba) is retained in full and untouched; the empty stashed side contributes nothing. Zero prose changes in this region.

## Verification

- **Zero markers.** `^(<{4,}|>{4,}|={4,}|\|{4,})` matches nothing in the repaired file. Repo-wide rescan (tracked files, ripgrep and `git grep`) finds no `<<<<<<< `, `>>>>>>> `, `||||||| `, or bare equals-run line anywhere in the tree.
- **No content lost.** Scripted diff of the repaired file against both sides of both regions: region 1 upstream 5/5 lines present, region 2 upstream 338/338 lines present, 0 upstream lines lost. The only dropped lines are the 3 region-1 stashed lines listed above.
- **Numbering intact.** Heading-order scan finds the same 5 pre-existing out-of-order 6xx headings before and after the repair, so this introduced no drift. In the touched window the sequence is monotonic: 6aw, 6ax, 6ay, 6ba, 6bb, 6bc.
- **Byte-for-byte to ground truth.** Repaired region 1 diffs clean against `de4b5576`'s copy of the same passage.

## Scope

Docs-only. Nothing outside `notes/` is touched, and no other mangled file was found anywhere in the repo, so there is nothing in `config/`, `src/` or `tools/` to report.
