### PR TITLE
Emit an enrollment tier, and audit the 251 matched functions the cartridge does not settle

### DIFF
--- a/audit/enrollment_report.md
+++ b/audit/enrollment_report.md
@@ -1,0 +1,348 @@
+# Enrollment audit: what the matched count contains that the cartridge does not settle
+
+Measured at **code ref `7bbfa1ef3edf231df3d40cfb16e59884e82e9420`** (origin/main,
+"notes: resolve two committed stash-conflict regions in mwccarm-codegen.md (#1531)").
+Every number below was re-derived at that ref by this audit. Nothing is quoted forward
+from an earlier measurement, because the counts move by tens of functions per day.
+
+This is a **report, not a policy change**. `matched` is untouched, no flag is flipped,
+and contributions.json is byte-identical before and after the code in this PR. What the
+published count should be is Tango's call, made on this.
+
+## 1. The shape of the gap
+
+| | functions | bytes | share of code bytes |
+| --- | --- | --- | --- |
+| universe (config/**/symbols.txt) | 11,396 | 2,235,468 | |
+| `matched` (a src/ file exists, unbannered, not a dcd transcription) | 11,221 | 2,093,152 | 93.63% |
+| `verified` (a delinks range carries `complete`) | 10,970 | 2,017,640 | 90.26% |
+| **gap** | **251** | **75,512** | 3.38pp |
+
+The 251 split cleanly in two, and the halves are different problems:
+
+| class | rows | bytes | meaning |
+| --- | --- | --- | --- |
+| `unenrolled` | 203 | 71,620 | a delinks entry names the source, with no `complete` |
+| `no_block` | 48 | 3,892 | no delinks entry names the range at all |
+| stale paths | **0** | 0 | every unenrolled block's src path exists on disk |
+
+Zero stale paths is worth stating plainly: `layout_check` L1 is clean, so none of this
+gap is a file that moved and left its delinks entry pointing at nothing.
+
+## 2. The 47-vs-48 boundary, settled
+
+Two independent derivations of the no-block set produced 47 and 48. The one record
+between them is:
+
+**`src/Player_ScaleByCharFactor.c`, ov002, 0x020bf30c.**
+
+Both derivations are right about different questions. The address range 0x020bf30c to
+0x020bf340 IS marked `complete` in `config/arm9/overlays/ov002/delinks.txt`, so a test
+that asks "is this address covered by a complete range" answers yes and returns **47**.
+But the entry that owns it is `mods/Player_ScaleByCharFactor.c`, the single intentional
+ROM divergence in the tree (a 4.12 shift changed from 12 to 11, doubling the character
+scale factor, documented in notes/rom-build.md as M3). `enrolled_addresses()` drops
+`rel.startswith("mods/")` on purpose, and a test keyed on the src path answers no and
+returns **48**.
+
+For the question this audit is about, 48 is the right answer:
+`src/Player_ScaleByCharFactor.c` is the faithful decomp, it is counted `matched`, and
+it is compiled by nothing. The mod is built in its place. This is the only `mods/` entry
+in all 106 delinks files, so the discrepancy cannot recur elsewhere without someone
+adding a second mod.
+
+## 3. The 48 no-block rows: policy, not error
+
+Every one of the 48 was re-run through `enroll.candidates()`'s own gates, in order.
+**Zero are unexplained.**
+
+| enroll.py's own reason | rows |
+| --- | --- |
+| on the exclude list (`config/rombuild-exclude.txt`) | 22 |
+| not 4-byte aligned (thumb stub) | 12 |
+| thumb function | 9 |
+| zero size | 4 |
+| intentional mod, enrolled under the `mods/` path | 1 |
+
+The 21 thumb rows are the SDK SWI stubs at the bottom of arm9 (`Div`, `IntrWait`,
+`CpuSet`, `Sqrt`, `BitUnPack`, `VBlankIntrWait` and friends, 4 or 6 bytes each) plus
+three thumb helpers at 0x0205xxxx. `enroll.py` documents why: dsd gives carved code
+sections 4-byte alignment, so a 2-aligned thumb stub gets padded up by the linker and
+shifts the whole module. These are `HAND-ASM PRIMITIVE` files (`asm void Div(void) { swi
+0x09; bx lr }`), which the project's asm policy already accepts as matched.
+
+The 22 exclude-list rows are two documented sub-blocks: 12 in the 0x0206d9dc secondary
+entry point cluster, which cannot be carved because a local dsd label cannot be
+referenced across objects, and 10 that dsd rejected on relink.
+
+**Verdict: policy-done, count them.** With one flagged sub-case and one defect, below.
+
+### 3a. Flagged: the 8 "produced the wrong bytes" exclusions
+
+`config/rombuild-exclude.txt` puts 8 symbols under "linked cleanly but produced the
+wrong bytes": `_ZN11MirrorLuigiD1Ev`, `_ZN15RecRoomCupboardD1Ev`,
+`_ZN15RecRoomCupboardD0Ev`, `_ZN14BlendModelAnimD1Ev`, `_ZN5ModelD2Ev`,
+`_ZN5ModelD1Ev`, `CleanCommonModelDataArr`, `func_020313d8`.
+
+`tools/linkcheck.py` returns **BENIGN** for all 8: the only word that differs resolves
+to a sibling destructor variant, which linkcheck classifies as a benign reloc
+resolution. That agrees exactly with the exclude file's own note ("a deleting/complete
+variant resolves differently in a real relink than it does when linkcheck verifies the
+match in isolation"). The C is right; which of D0/D1/D2 the linker picks is the
+disagreement. This is the same failure surface as the known Actor/ActorBase D1/D2
+address swap. Counting them is defensible, but they are the weakest 8 rows in the
+no-block set and a reader should know they exist.
+
+### 3b. Defect: 4 zero-size itcm aliases double-count in one direction and undercount in the other
+
+| alias (counted matched) | size | primary at the same address | size | primary counted |
+| --- | --- | --- | --- | --- |
+| `_dmul` | 0 | `func_01ff8708` | 1,776 | **not matched** |
+| `_ll_sdiv` | 0 | `func_01ffaa34` | 432 | **not matched** |
+| `_s32_div_f` | 0 | `__aeabi_idiv` | 524 | **not matched** |
+| `_u32_div_f` | 0 | `__aeabi_uidiv` | 484 | **not matched** |
+
+`config/arm9/itcm/symbols.txt` declares each of these twice, once as a sized function
+and once as a zero-size alias at the identical address. `srcpath` resolves
+`src/_dmul.c`, which carries a `HAND-ASM PRIMITIVE` banner and is a real accepted
+match, onto the **zero-size** record. So the same body is simultaneously counted as
+matched (as the alias, worth 0 bytes) and unmatched (as the primary, worth its real
+size).
+
+Net effect at this ref: the function count is 4 too high, the byte count is 3,216 too
+low, and because itcm carries a 10x coin weight these four zero-byte records are worth
+40 MC. Four more zero-size aliases exist in the same file (`__cxa_vec_cleanup`, `_dadd`,
+`_ll_udiv`, `_ull_mod`) and are currently unmatched, so the same trap is waiting.
+
+The fix is a naming fix, not a policy fix: point the alias records at the sized primary
+symbol, or teach the universe reader to drop zero-size symbols that duplicate an
+address. It is out of scope for this PR because it moves `matched`.
+
+## 4. The 203 unenrolled rows: byte-gated, not eyeballed
+
+The brief asked for drafts, complete-but-unenrolled, and stale paths. Comment scanning
+answers this badly (only 1 of the 203 carries any draft language at all), so each row
+was put through the repository's own byte gate instead: `tools/linkcheck.py` recompiles
+the committed source, writes the resolved target into every relocation slot with the
+real ARM encoding, and compares the linked function to the cartridge.
+
+| linkcheck verdict | rows | reading |
+| --- | --- | --- |
+| VERIFIED | 103 | every reloc resolved, linked bytes identical to the ROM |
+| BLIND-n | 82 | identical except for n reloc slots that cannot be resolved to an address |
+| NO-SYM | 18 | does not compile, or compiles to the wrong length |
+| **WRONG** | **0** | no false match anywhere in the set |
+
+**185 of 203 reproduce the cartridge.** Zero are proven wrong.
+
+So "unenrolled" is overwhelmingly **not** "unmatched". Cross-tabulating against
+`tools/eligible.py`, which answers the different question of whether the compiled object
+is a drop-in replacement for the ROM's bytes, shows why they are still unenrolled:
+
+| eligible.py reason | rows | VERIFIED | BLIND | NO-SYM |
+| --- | --- | --- | --- | --- |
+| unresolvable reference (rule 5) | 96 | 28 | 68 | 0 |
+| .text section larger than the declared range | 80 | 74 | 6 | 0 |
+| compile failed under the pinned version | 22 | 0 | 4 | 18 |
+| extra sections: .data | 4 | 0 | 4 | 0 |
+| defines a differently named symbol | 1 | 1 | 0 | 0 |
+
+The two large classes are placement problems, not matching problems:
+
+* **80 rows overshoot their declared range** by 4 to 32 bytes (a trailing literal pool
+  or alignment pad the ROM's own layout absorbs elsewhere). 74 of them byte-match
+  perfectly. Dropping the object in would shift every later address in the module, so
+  the build correctly refuses, and the source is correct anyway.
+* **96 rows name a symbol `config/**/symbols.txt` does not define**: invented
+  placeholders like `G`, `@30`, `base_dtor_Clipper`, `overlay_64`, `Actor_TrackStar`.
+  Rule 5 rejects those because a gap object imports carved symbols weakly and the
+  reference would silently link to 0. This is symbol-coverage debt. It is also what
+  makes 82 rows BLIND: 305 reloc slots across those 82 rows cannot be resolved, so those
+  words are not compared.
+
+### 4a. The 18 that do not compile
+
+These are the real overstatements in the unenrolled half. All 18 were compiled by hand
+at this ref with the ROM build's own flags and every version in the sweep. All 18 fail.
+
+| root cause | rows |
+| --- | --- |
+| `illegal function overloading`: the file's `extern "C"` declaration of a symbol clashes with a C++-linkage declaration of the same symbol in `include/decl_common.h` | 16 |
+| `template argument list expected`: `Fix12` used bare where the real type is `Fix12<int>` | 1 |
+| broken draft: three struct members the file's own structs do not declare | 1 |
+
+The overloading class is a single mechanical defect. Example:
+`src/func_ov002_020cfbdc.cpp:24` defines `extern "C" int func_ov002_020cfbdc(char *self)`
+while `include/decl_common.h:1414` declares `extern int func_ov002_020cfbdc(void*);`
+with C++ linkage and a different parameter type. 12 of the 16 clash on their own symbol,
+4 on a callee they redeclare (for instance `func_ov064_02119ecc`, declared `(void*, void*)`
+in the source and `(char*, void*)` at `decl_common.h:2744`). These files are plausibly
+correct decompilations that stopped compiling when `decl_common.h` grew; the byte gate
+cannot say, because nothing gets as far as codegen.
+
+The one broken draft is `src/func_ov007_020ba05c.c`, which is the file lane PC1 named.
+Independently confirmed here: it fails with `'array28' is not a member of class 'struct
+StructObj20'`, plus `array24` and `f2C`, and it carries the comment
+`bHolder->b->f2C = 0; // or bHolder->f2C? wait`. It has never been compiled by any gate
+and it is counted `matched: true` today.
+
+## 5. Sample verification
+
+At least 10 rows per class were opened and read, beyond the byte gate.
+
+* **unenrolled VERIFIED** (10 of 103 sampled, seed 60): `func_02029408.c`,
+  `func_02070c68.c`, `func_ov004_020adbc0.c`, `func_ov004_020b0b1c.c`,
+  `func_ov006_020d5fd8.c`, `func_ov006_020d672c.c`, `func_ov006_020dbaf0.cpp`,
+  `func_ov006_02103cbc.c`, `_ZN12dScMgSlot1_cD0Ev.cpp`, `func_ov007_020c5dec.cpp`.
+  All ordinary decompiled C with no draft language. Confirmed by reading:
+  `func_02029408.c` is a two-line indexed dispatch, `func_ov004_020adbc0.c` a null-checked
+  field load.
+* **unenrolled BLIND** (10 of 82 sampled): `_ZN7ClipperD0Ev.c`, `func_0201a694.c`,
+  `func_02034fbc.c`, `func_02037d84.cpp`, `func_02037db4.c`, `func_02044b30.c`,
+  `func_02055454.c`, `func_0205f650.c`, `func_ov007_020cc2cc.c`,
+  `_ZN13RacingPenguin13InitResourcesEv.cpp`. Every blind slot traced to an invented
+  extern name, never to a suspicious body. `func_02055454.c` is
+  `extern int G[]; void func_02055454(int v) { G[0] = v; }`: correct code, placeholder
+  global. `func_02037db4.c` is a documented this-adjusting virtual-destructor thunk that
+  needs C++ flags its `.c` extension does not request.
+* **unenrolled NO-SYM**: all 18 opened and compiled, listed in the appendix.
+* **no_block**: all 48 attributed to a gate; `Div.c` (thumb `swi 0x09` primitive),
+  `_ZN5ModelD1Ev.c` (documented D1 with the D2 codegen note), `func_0206d9cc.c`
+  (FIQ-disable primitive with a shared body label), the four itcm aliases and
+  `mods/Player_ScaleByCharFactor.c` versus `src/Player_ScaleByCharFactor.c` read in full.
+
+## 6. What the count becomes under each candidate policy
+
+Baseline is 11,221 matched / 2,093,152 bytes / 93.63% of code bytes.
+
+| policy | matched | delta | bytes | share | coins lost, by contributor |
+| --- | --- | --- | --- | --- | --- |
+| **A** status quo (a src/ file exists) | 11,221 | 0 | 2,093,152 | 93.63% | none |
+| **B** enrolled only (`complete` in delinks) | 10,970 | -251 | 2,017,640 | 90.26% | tangosdev -146, ruspecial -79, andrewboudreau -36, lunavyqo -19, lplaat -4, aitddlabs -2 |
+| **C** drop the 203 unenrolled, keep the policy set | 11,018 | -203 | 2,021,532 | 90.43% | tangosdev -127, andrewboudreau -32, lunavyqo -19, ruspecial -18, lplaat -4, aitddlabs -2 |
+| **D** byte-gated (drop what linkcheck cannot reproduce) | 11,199 | -22 | 2,085,244 | 93.28% | ruspecial -43, tangosdev -8, lunavyqo -4, andrewboudreau -2, mitch030504 -1 |
+| **E** narrow fix (drop only what will not compile) | 11,203 | -18 | 2,085,244 | 93.28% | tangosdev -8, lunavyqo -4, ruspecial -3, andrewboudreau -2, mitch030504 -1 |
+
+Coin figures assume `COIN_WEIGHTS` unchanged (itcm at 10x, which is why ruspecial's
+D-column loss of 43 is dominated by the four zero-byte itcm aliases at 10 MC each).
+Any of B through E requires bumping `COIN_FORMULA` so the backend rebases instead of
+paying or clawing back a delta.
+
+### Recommendation
+
+**Adopt D, the byte gate, and keep `verified` published beside it.**
+
+Reasoning:
+
+1. **B is wrong on the evidence.** It would delete 251 matches of which 229 provably
+   reproduce the cartridge. Enrollment is a *placement* test: 80 of the 203 are excluded
+   purely because the compiled section runs a few bytes past its declared range, and
+   96 because a global has a placeholder name. Neither says anything about whether the
+   decompilation is right. Publishing 90.26% as the matched figure would understate the
+   project by more than three points and take 146 coins off Tango for work that is
+   correct.
+2. **C is B's mistake, smaller.** It still deletes 185 reproducing matches.
+3. **D removes exactly what cannot be defended**: 18 files that no compiler in the sweep
+   will build, and 4 zero-size alias records that are double-counting a body their sized
+   twin already reports as unmatched. Nothing that reproduces the ROM is lost. The
+   headline moves 93.63% to 93.28%, which is a rounding-level correction, and the largest
+   individual coin change is a 43 MC reduction that is mostly the alias defect rather
+   than anyone's real work being revoked.
+4. **E is D without the alias fix.** It is the smaller edit, but it leaves a record that
+   is matched at 0 bytes sitting on top of a record that is unmatched at 1,776 bytes,
+   which is the harder thing to explain to anybody reading the site.
+5. **Keep `verified` published either way.** #1530 already ships it. The honest sentence
+   for the site is that the cartridge settles 90.26% of code bytes today and 93.28% have
+   a source that reproduces them, and both numbers should be visible with their
+   definitions attached. Collapsing to one number is what created this gap in the first
+   place.
+
+Whichever is chosen, two follow-ups are independent of the policy and should land
+regardless:
+
+* Fix the 16 `decl_common.h` signature clashes. They are mechanical, and they would
+  move 16 files from "counted but never compiled" to "counted and byte-checked".
+* Fix the 4 (soon 8) zero-size itcm alias records in `config/arm9/itcm/symbols.txt`.
+
+## 7. Unproven
+
+Stated so nobody reads more into this than it carries.
+
+* **BLIND is not VERIFIED.** 85 rows across both classes have 311 relocation slots that
+  cannot be resolved to an address, so those words were not compared. A wrong callee
+  hiding in a blind slot would pass. 12 rows have more than 5 blind slots;
+  `_ZN13RacingPenguin13InitResourcesEv.cpp` has 13 and two rows have 33 and 35. These
+  should be treated as "reproducing, modulo symbol coverage", not proven.
+* **The 8 BENIGN rows are contested.** linkcheck (in isolation) says benign;
+  `config/rombuild-exclude.txt` says a real relink produced the wrong bytes. The relink
+  is the stronger evidence and this audit did not reproduce it.
+* **linkcheck sweeps 12 compiler versions; the ROM build pins one per file.** A row that
+  reproduces only under 1.2/base is a match by the project's own definition and still
+  not buildable at the pinned version. This audit did not record which version won per
+  row, so the D column may include rows that would need a
+  `config/rombuild-versions.txt` entry before they could ever be enrolled.
+* **The 10,970 enrolled rows were not re-verified here.** They are taken as reproducing
+  because the ROM build compiles and byte-compares them. No full `rombuild.py` was run
+  for this audit.
+* **Whether the 16 clashing files are correct decompilations is unknown.** They do not
+  compile, so no byte evidence exists in either direction. They are classified as
+  "counted without evidence", not as "wrong".
+* **Coin deltas are computed from the current attribution** (overrides, aliases and
+  finisher credit as of this ref) and will drift as attribution.json changes.
+* **The 48 no-block rows were attributed by replaying `enroll.candidates()`'s gates in
+  source order**, not by instrumenting the tool. The reasons agree with
+  `config/rombuild-exclude.txt` and with `enroll.py`'s own skip counter, but a gate
+  reordering would change which reason a row is credited to (never whether it is
+  skipped).
+
+## 8. How to reproduce
+
+```
+python tools/chaos_db_ci.py --out chaos-db.json      # emits the enrollment field
+python tools/linkcheck.py --module ov006 -j 10       # the byte gate, per module
+python tools/eligible.py -j 16                       # drop-in eligibility, per file
+python tools/layout_check.py --json                  # L1 stale paths, L5 unenrolled
+```
+
+The `enrollment` field added in this PR is what makes the 203 / 48 split queryable
+without re-deriving it. It is purely additive: generating chaos-db.json before and after
+at this ref differs by exactly one inserted key per record, with every existing field
+holding both its value and its position, an identical `stats` block, and a byte-identical
+contributions.json.
+
+## Appendix: the 22 rows that do not reproduce
+
+Every one compiled by hand at this ref with `tools/mwccarm/2004/b56` and the ROM build's
+own flags, then swept across all 12 versions by linkcheck. Line numbers are from the
+file at this ref.
+
+| module | addr | size | file | credited to | first error |
+| --- | --- | --- | --- | --- | --- |
+| arm9 | 0x02022f40 | 428 | `src/_ZN8Particle10SysTracker10InitialiseEv.cpp` | tangosdev | line 20: illegal function overloading |
+| itcm | 0x01ff8708 | 0 | `src/_dmul.c` | ruspecial | zero-size alias of `func_01ff8708` (1,776 bytes, unmatched) |
+| itcm | 0x01ffaa34 | 0 | `src/_ll_sdiv.c` | ruspecial | zero-size alias of `func_01ffaa34` (432 bytes, unmatched) |
+| itcm | 0x01ffabe4 | 0 | `src/_s32_div_f.c` | ruspecial | zero-size alias of `__aeabi_idiv` (524 bytes, unmatched) |
+| itcm | 0x01ffadf0 | 0 | `src/_u32_div_f.c` | ruspecial | zero-size alias of `__aeabi_uidiv` (484 bytes, unmatched) |
+| ov002 | 0x020cfbdc | 424 | `src/func_ov002_020cfbdc.cpp` | ruspecial | line 24: illegal function overloading |
+| ov002 | 0x020e3e00 | 400 | `src/func_ov002_020e3e00.cpp` | ruspecial | line 14: illegal function overloading |
+| ov004 | 0x020aeed8 | 372 | `src/func_ov004_020aeed8.cpp` | tangosdev | line 50: illegal function overloading |
+| ov004 | 0x020af094 | 488 | `src/func_ov004_020af094.cpp` | andrewboudreau | line 56: illegal function overloading |
+| ov006 | 0x020e6e78 | 232 | `src/func_ov006_020e6e78.cpp` | tangosdev | line 14: illegal function overloading |
+| ov007 | 0x020ba05c | 644 | `src/func_ov007_020ba05c.c` | mitch030504 | line 114: `'array28' is not a member of class 'struct StructObj20'` |
+| ov064 | 0x02119afc | 356 | `src/func_ov064_02119afc.cpp` | tangosdev | line 15: illegal function overloading |
+| ov065 | 0x02119c38 | 644 | `src/_ZN15TtcRotatingCube13InitResourcesEv.cpp` | tangosdev | line 20: illegal function overloading |
+| ov071 | 0x02121ba4 | 200 | `src/func_ov071_02121ba4.cpp` | tangosdev | line 12: illegal function overloading |
+| ov078 | 0x02124cf4 | 424 | `src/func_ov078_02124cf4.cpp` | lunavyqo | line 14: illegal function overloading |
+| ov080 | 0x02124088 | 384 | `src/func_ov080_02124088.cpp` | andrewboudreau | line 20: illegal function overloading |
+| ov081 | 0x02123910 | 528 | `src/func_ov081_02123910.cpp` | lunavyqo | line 31: illegal function overloading |
+| ov084 | 0x0212bc30 | 912 | `src/_ZN6Goomba13InitResourcesEv.cpp` | tangosdev | line 17: template argument list expected |
+| ov085 | 0x02129dbc | 256 | `src/func_ov085_02129dbc.cpp` | ruspecial | line 17: illegal function overloading |
+| ov096 | 0x02137088 | 568 | `src/func_ov096_02137088.cpp` | lunavyqo | line 22: illegal function overloading |
+| ov098 | 0x0213a794 | 332 | `src/func_ov098_0213a794.cpp` | tangosdev | line 22: illegal function overloading |
+| ov102 | 0x0214b248 | 316 | `src/func_ov102_0214b248.cpp` | lunavyqo | line 18: illegal function overloading |
+
+`src/_ZN6Goomba13InitResourcesEv.cpp` carries its `//cpp` sentinel on line 2, behind an
+`#include`. `eligible.classify` and `reloc_audit.winning_object` both test
+`text.startswith("//cpp")`, so the file is offered to the compiler as C99 first. Moving
+the sentinel to line 1 does not fix it (the bare `Fix12` on line 17 is a genuine error),
+but the sentinel placement is worth knowing about as a trap for other files.

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -35,6 +35,7 @@ import asm_policy  # noqa: E402
 import srcpath as SP  # noqa: E402
 import relocs as RL  # noqa: E402
 import rombuild_check as RBC  # noqa: E402
+import layout_check as LYC  # noqa: E402
 import tiers as TIERS  # noqa: E402
 
 
@@ -59,6 +60,43 @@ def enrolled_addresses():
             if not rel.startswith("mods/"):
                 out.add((label, addr))
     return out
+
+
+def enrollment_of(label, addr, src_path, enrolled, blocks):
+    """``enrolled`` / ``unenrolled`` / ``no_block`` for one function.
+
+    ``verified`` above is a boolean, and a boolean cannot tell the two halves of its
+    false case apart. They are different facts with different remedies:
+
+      enrolled    a delinks range carries ``complete``: mwccarm compiles this source
+                  and the link byte-compares it against the cartridge. Identical to
+                  ``verified`` for a matched function, by construction: both read the
+                  same enrolled_addresses() set, so the two fields cannot drift.
+      unenrolled  a delinks entry names a source for this range but has no ``complete``.
+                  The source is in the tree and the build reads ROM bytes instead. This
+                  is where a real match that nobody promoted looks exactly like a file
+                  that was never going to build.
+      no_block    no delinks entry names this range at all. Overwhelmingly deliberate:
+                  enroll.py skips thumb functions, addresses that are not 4-aligned,
+                  zero-size alias symbols and everything in config/rombuild-exclude.txt,
+                  and it writes an intentional divergence under mods/ rather than src/.
+
+    Two existing readers, no third delinks parser: enrolled_addresses() for ``complete``
+    (address-keyed, the same set ``verified`` uses) and layout_check.delinks_paths() for
+    "is there an entry at all" (path-keyed, the L1/L5 reader).
+
+    The two keyings disagree for exactly one entry in the tree, and it is worth naming
+    because it is the whole 47-vs-48 discrepancy two independent derivations of this gap
+    produced: mods/Player_ScaleByCharFactor.c (ov002 0x020bf30c) IS marked ``complete``,
+    so an address-coverage test calls it enrolled, but the path it names is not the
+    src/ path, and enrolled_addresses() drops mods/ on purpose, because a deliberate
+    divergence must never be counted as a reproduction of the cartridge. It is reported
+    no_block here, which is the honest answer for src/Player_ScaleByCharFactor.c: that
+    file is compiled by nothing.
+    """
+    if (label, addr) in enrolled:
+        return "enrolled"
+    return "unenrolled" if src_path and src_path in blocks else "no_block"
 
 
 def tier_stats():
@@ -438,6 +476,11 @@ def main():
     total_b = matched_b = matched_n = 0
     verified_b = verified_n = 0
     enrolled = enrolled_addresses()
+    # Every src path any delinks.txt names, promoted or not. Read once: delinks_paths
+    # walks all 106 delinks files, and calling it per function would walk them 11,396
+    # times.
+    blocks = set(LYC.delinks_paths())
+    enrollment_n = collections.Counter()
     transcribed_files, unbannered_files = set(), set()
     # Every module, itcm included. relocs.module_universe is the one definition of
     # what "every module" means, and it fails loudly rather than skipping a new one.
@@ -489,6 +532,13 @@ def main():
                 r = nm.get((label, addr))
                 if r and r.get("divergences") is not None:
                     rec["div"] = r["divergences"]
+            # Appended last, deliberately. Every field above keeps the position it had
+            # before this existed, so the whole diff against a previous chaos-db is one
+            # inserted key per record and a reviewer can see at a glance that nothing
+            # else moved. Nothing here reads it back, and `matched` is untouched: this
+            # annotation reports the tree, it does not redefine the count.
+            rec["enrollment"] = enrollment_of(label, addr, src_path, enrolled, blocks)
+            enrollment_n[(rec["enrollment"], matched)] += 1
             functions.append(rec)
 
     if transcribed_files:
@@ -547,6 +597,14 @@ def main():
           f"({100.0 * verified_b / total_b:.2f}% vs {100.0 * matched_b / total_b:.2f}% "
           f"matched); {matched_n - verified_n} matched function(s) are compiled by "
           f"nothing")
+    # ...and WHICH KIND of nothing, because the two halves have different remedies. A
+    # matched/unenrolled function has a delinks entry waiting for a `complete`; a
+    # matched/no_block one is almost always deliberate (thumb, alias, exclude list) and
+    # promoting it is not on the table. Printed so the split lands in the CI log next to
+    # the number it explains. See audit/enrollment_report.md.
+    print("  enrollment: " + ", ".join(
+        f"{k[0]}{'/matched' if k[1] else ''}={n}"
+        for k, n in sorted(enrollment_n.items(), key=lambda kv: (kv[0][0], not kv[0][1]))))
     # Per-module counts in the log, so a module that stops being emitted shows up in
     # the CI diff as a line that vanished. The silent version of this cost itcm its
     # entire visibility; a number that goes to zero is at least readable.


### PR DESCRIPTION
Stage 1 of two. This PR adds a **distinct tier and a report**. It does not change the
`matched` definition, does not flip any flag, and does not touch contributions or coins.
The counting policy is a decision for @tangosdev to make on the report, and section 6 of
the report lays out the options with the numbers attached.

## What the code does

`tools/chaos_db_ci.py` emits one new field per function record:

    "enrollment": "enrolled" | "unenrolled" | "no_block"

`verified` (landed in #1530) is a boolean, and its false case holds two facts with two
different remedies. 203 matched functions have a delinks entry sitting there without
`complete`. 48 have no entry at all. Those are not the same problem and nothing in the
data could tell them apart.

Two readers, no third delinks parser: `enrolled_addresses()` for `complete`, which is the
same set `verified` already reads so the two fields cannot drift, and
`layout_check.delinks_paths()` for "is there an entry at all".

**Additive, proven.** Generating chaos-db.json before and after at this ref:

* keys added: `['enrollment']`, nothing else
* records whose other fields changed in value **or position**: 0
* `stats` block: identical
* `contributions.json`: byte identical

The field is appended after every conditional key so no existing field moves. 66 unit
tests across test_layout, test_rombuild_check, test_srcpath and test_attribution pass.

## What the audit found

Measured at `7bbfa1ef3edf231df3d40cfb16e59884e82e9420`, re-derived here rather than
carried forward from any earlier count.

11,396 functions / 2,235,468 bytes. `matched` 11,221 (93.63% of code bytes). `verified`
10,970 (90.26%). **Gap 251** = 203 unenrolled + 48 no_block + **0 stale paths**.

Every one of the 251 went through `tools/linkcheck.py`, which recompiles the committed
source, writes the resolved target into every relocation slot and byte-compares the
linked function to the cartridge:

| verdict | rows |
| --- | --- |
| VERIFIED | 136 |
| BENIGN | 8 |
| BLIND-n | 85 |
| NO-SYM | 22 |
| **WRONG** | **0** |

**229 of 251 reproduce the cartridge.** So "unenrolled" overwhelmingly does not mean
"unmatched". Cross-tabbed against `tools/eligible.py`, 80 of the 203 are rejected only
because the compiled `.text` runs 4 to 32 bytes past its declared range (a literal pool),
and 96 because a global carries a placeholder name like `G` or `overlay_64` that no
symbols.txt defines. Both are placement and symbol-coverage debt, not wrong C.

All 48 no_block rows are explained by `enroll.py`'s own documented gates, zero
unexplained: 22 on `config/rombuild-exclude.txt`, 21 thumb, 4 zero-size, 1 `mods/`.

### The 22 that do not reproduce

* **18 files that no compiler in the sweep will build.** 16 are one mechanical defect:
  the file's `extern "C"` declaration of a symbol clashes with a C++-linkage declaration
  of the same symbol in `include/decl_common.h`, so mwcc reports `illegal function
  overloading` and never reaches codegen. 1 uses a bare `Fix12` where the type is
  `Fix12<int>`. 1 is a genuinely broken draft, `src/func_ov007_020ba05c.c`, which
  references three struct members its own structs do not declare and carries the comment
  `// or bHolder->f2C? wait`. That last one confirms the overstatement lane PC1 named, by
  an independent route.
* **4 zero-size itcm alias records.** `config/arm9/itcm/symbols.txt` declares `_dmul`,
  `_ll_sdiv`, `_s32_div_f` and `_u32_div_f` at size 0 at the same addresses as
  `func_01ff8708` (1,776 bytes), `func_01ffaa34` (432), `__aeabi_idiv` (524) and
  `__aeabi_uidiv` (484). `srcpath` resolves the real `HAND-ASM PRIMITIVE` source onto the
  zero-size record, so the same body is counted matched at 0 bytes and unmatched at its
  real size. The count is 4 too high, the byte total 3,216 too low, and at itcm's 10x
  weight those four zero-byte records are worth 40 MC.

### The 47-vs-48 disagreement, settled

`src/Player_ScaleByCharFactor.c` (ov002 0x020bf30c). The range IS `complete`, but the
entry that owns it is `mods/Player_ScaleByCharFactor.c`, the single intentional ROM
divergence in the tree, and `enrolled_addresses()` drops `mods/` on purpose. An
address-coverage derivation therefore answers 47 and a src-path derivation answers 48.
48 is right for this question: the faithful src/ file is counted matched and is compiled
by nothing. It is the only `mods/` entry in all 106 delinks files.

## The policy question, for @tangosdev

Baseline 11,221 matched / 93.63% of code bytes.

| policy | matched | delta | share | coins lost |
| --- | --- | --- | --- | --- |
| **A** status quo | 11,221 | 0 | 93.63% | none |
| **B** enrolled only | 10,970 | -251 | 90.26% | tangosdev -146, ruspecial -79, andrewboudreau -36, lunavyqo -19, lplaat -4, aitddlabs -2 |
| **C** drop the 203 unenrolled | 11,018 | -203 | 90.43% | tangosdev -127, andrewboudreau -32, lunavyqo -19, ruspecial -18, lplaat -4, aitddlabs -2 |
| **D** byte-gated | 11,199 | -22 | 93.28% | ruspecial -43, tangosdev -8, lunavyqo -4, andrewboudreau -2, mitch030504 -1 |
| **E** narrow fix (will not compile only) | 11,203 | -18 | 93.28% | tangosdev -8, lunavyqo -4, ruspecial -3, andrewboudreau -2, mitch030504 -1 |

**Recommendation: D, and keep `verified` published beside it.** B would delete 251
matches of which 229 provably reproduce the cartridge, understating the project by more
than three points and taking 146 coins off work that is correct. D removes exactly what
cannot be defended: 18 files nothing will compile and 4 alias records that double-count.
The headline moves 93.63% to 93.28%, and the largest coin change is mostly the alias
defect rather than anyone's real work being revoked. Any of B through E needs
`COIN_FORMULA` bumped so the backend rebases instead of clawing back a delta.

Two follow-ups are worth doing regardless of the policy chosen, and are deliberately not
in this PR because both move `matched`: fix the 16 `decl_common.h` signature clashes, and
fix the zero-size itcm alias records.

Section 7 of the report is an explicit unproven-items list. The short version: BLIND is
not VERIFIED (311 reloc slots across 85 rows were not compared), the 8 BENIGN rows are
contested by `rombuild-exclude.txt`'s own note about a real relink, linkcheck accepts any
of 12 compiler versions where the build pins one per file, and the 10,970 enrolled rows
were taken as reproducing rather than re-verified.

**Do not merge on my account.** Coordinator holds the merge gate.
