### PR TITLE
Make the stamp_provenance verify gate actually verify

### DIFF
--- a/tools/stamp_provenance.py
+++ b/tools/stamp_provenance.py
@@ -3,14 +3,14 @@
 
 A successful match must permanently record how it was matched:
 
-  AI:    --kind ai --model … --reasoning … --harness …
-  Human: --kind human [--by …] [--note …]
+  AI:    --kind ai --model ... --reasoning ... --harness ...
+  Human: --kind human [--by ...] [--note ...]
 
 Missing/incomplete AI provenance aborts (exit 2). This is the only supported
 banking path for provenance; do not hand-edit src/ alone without a ledger row.
 
 Repo root is discovered via --repo, DECOMP_ROOT / MATCH_REPO, cwd walk, then
-__file__ walk — so copies of this script under /tmp still work if you pass
+__file__ walk -- so copies of this script under /tmp still work if you pass
 --repo or run from the decomp tree.
 
 Examples:
@@ -28,7 +28,7 @@ Examples:
       --src src/arm9/func_0200abcd.c --kind ai --author lunavyqo \\
       --model grok-4.5 --reasoning high --harness grok-build --no-verify
 
-  # Verify + promote scratch → src + ledger
+  # Verify + promote scratch -> src + ledger
   python tools/bank.py --c scratch/foo.c --func func_0200abcd \\
       --kind ai --author lunavyqo --model claude-opus-4 --reasoning high \\
       --harness cursor-agent --promote
@@ -121,6 +121,52 @@ def resolve_from_src(src: pathlib.Path) -> tuple[str, str, int, int]:
     return name, module, addr, 0
 
 
+VERDICT_RE = re.compile(r"^MATCHING VERSIONS:\s*(.*)$")
+
+
+def matching_versions(out: str) -> list[str] | None:
+    """The versions match.py's verdict line reports. None if it never printed one.
+
+    match.py exits 0 whether or not anything reproduced, and its last line is always
+    "MATCHING VERSIONS: <comma list, or none>". So the string "MATCH" is present in
+    every run's output, failures included -- it is a substring of "MATCHING". Anything
+    gating on that substring cannot fail. Read the verdict line and its payload.
+
+    None (no verdict line at all) is not a pass either: it means match.py died before
+    it could grade anything, and a gate that waves through what it could not check is
+    not a gate.
+    """
+    found = None
+    for line in out.splitlines():
+        m = VERDICT_RE.match(line.strip())
+        if not m:
+            continue
+        payload = m.group(1).strip()
+        if payload in ("", "none"):
+            found = []
+        else:
+            found = [v.strip() for v in payload.split(",") if v.strip()]
+    return found
+
+
+def module_target(module: str) -> tuple[pathlib.Path, int] | None:
+    """(binary, load address) for a module, from the registry match.py itself reads.
+
+    tools/modules.py is the single source of truth for this: main ARM9 is
+    extracted/arm9_dec.bin at 0x02004000, and every overlay and autoload takes its
+    base from the LOWEST symbol address in the module's config symbols.txt -- dsd's
+    delinked space, not the ROM overlay table's ramAddress. Deriving it any other way
+    makes addr - base land outside the image.
+    """
+    import modules as MOD
+
+    for mod in MOD.modules():
+        label = "arm9" if mod["name"] == "main" else mod["name"]
+        if label == module:
+            return pathlib.Path(mod["bin"]), int(mod["base"])
+    return None
+
+
 def run_match(
     c_path: pathlib.Path,
     func: str,
@@ -131,6 +177,23 @@ def run_match(
 ) -> None:
     if size <= 0:
         raise SystemExit("--size required for verify (symbol not found or size 0)")
+    # The target image has to be the symbol's OWN module. This used to pass
+    # `module if module in ("arm9", "arm7") else "arm9"`, so every overlay function was
+    # compared against extracted/arm9_dec.bin. That file is 0x9cfb8 bytes, an overlay
+    # address is far past its end, target_bytes() sliced an empty string, and match.py
+    # reported "size differs: target 0x0 vs candidate 0x...". Guaranteed non-match, on
+    # every overlay, forever. --module also selects config/<module>/relocs.txt for the
+    # reloc-destination check, so the coercion pointed that at the wrong config too.
+    target = module_target(module)
+    if target is None:
+        raise SystemExit(
+            f"cannot verify {func}: no target binary for module {module!r} in "
+            "tools/modules.py (needs extracted/; arm7 has no config module here). "
+            "Fix the module or pass --no-verify and say so."
+        )
+    bin_path, base = target
+    if not bin_path.is_file():
+        raise SystemExit(f"cannot verify {func}: module {module} binary missing: {bin_path}")
     match_py = get_repo() / "tools" / "match.py"
     cmd = [
         sys.executable,
@@ -144,16 +207,31 @@ def run_match(
         "--size",
         hex(size),
         "--module",
-        module if module in ("arm9", "arm7") else "arm9",
+        module,
+        "--bin",
+        str(bin_path),
+        "--base",
+        hex(base),
         "--version",
         version,
         "--brief",
     ]
     r = subprocess.run(cmd, cwd=get_repo(), capture_output=True, text=True, timeout=180)
     out = (r.stdout or "") + (r.stderr or "")
-    if r.returncode != 0 or "MATCH" not in out:
+    versions = matching_versions(out)
+    if r.returncode != 0:
+        reason = f"match.py exited {r.returncode}"
+    elif versions is None:
+        reason = "match.py printed no MATCHING VERSIONS verdict"
+    elif not versions:
+        reason = f"no version reproduced the target ({module}:{addr:#x})"
+    elif version not in versions:
+        reason = f"reproduced under {', '.join(versions)} but not the requested {version}"
+    else:
+        reason = None
+    if reason:
         print(out, file=sys.stderr)
-        raise SystemExit("match verification failed — not banking")
+        raise SystemExit(f"match verification failed ({reason}) -- not banking")
     print("\n".join(out.strip().splitlines()[-5:]))
 
 
@@ -190,12 +268,12 @@ def main() -> None:
     ap.add_argument("--kind", required=True, choices=("human", "ai"))
     ap.add_argument(
         "--model",
-        help="AI model id (required for --kind ai). Spaces ok; slugified (Grok 4.5 → grok-4.5)",
+        help="AI model id (required for --kind ai). Spaces ok; slugified (Grok 4.5 -> grok-4.5)",
     )
     ap.add_argument("--reasoning", help="AI reasoning/effort level (required for ai)")
     ap.add_argument(
         "--harness",
-        help="AI harness/pipeline id (required for ai). Spaces ok; slugified (Grok Build → grok-build)",
+        help="AI harness/pipeline id (required for ai). Spaces ok; slugified (Grok Build -> grok-build)",
     )
     ap.add_argument(
         "--author",
@@ -238,7 +316,7 @@ def main() -> None:
         type=int,
         default=None,
         dest="batch_size",
-        help="Functions in the session (1 if focused; required ≥2 if batch)",
+        help="Functions in the session (1 if focused; required >=2 if batch)",
     )
     args = ap.parse_args()
 
@@ -260,7 +338,7 @@ def main() -> None:
     except ProvenanceError as e:
         print(f"ERROR: provenance invalid: {e}", file=sys.stderr)
         print(
-            "AI matches require: --kind ai --model … --reasoning … --harness …",
+            "AI matches require: --kind ai --model ... --reasoning ... --harness ...",
             file=sys.stderr,
         )
         print(f"Hint: {TOKEN_HELP}", file=sys.stderr)
@@ -350,7 +428,7 @@ def main() -> None:
         if size is None or size <= 0:
             print("ERROR: --size required for verify", file=sys.stderr)
             sys.exit(2)
-        print(f"Verifying {name} @ {module}:0x{addr:08x} size 0x{size:x} …")
+        print(f"Verifying {name} @ {module}:0x{addr:08x} size 0x{size:x} ...")
         run_match(verify_c, name, addr, size, module, args.version)
     else:
         print("Skipping verify (--no-verify)")
@@ -363,7 +441,7 @@ def main() -> None:
         dest = default_src_path(module, name, ext)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(c_path, dest)
-        print(f"Promoted → {dest.relative_to(get_repo())}")
+        print(f"Promoted -> {dest.relative_to(get_repo())}")
         src_rel = dest.relative_to(get_repo()).as_posix()
     elif src_path:
         try:
@@ -383,7 +461,7 @@ def main() -> None:
 
     if src_rel and not src_rel.startswith("src/"):
         print(
-            f"WARNING: path {src_rel!r} is not under src/ — "
+            f"WARNING: path {src_rel!r} is not under src/ -- "
             "atlas only counts files under src/ as matched.",
             file=sys.stderr,
         )
@@ -435,7 +513,7 @@ def main() -> None:
                 batch_size=args.batch_size,
             )
             print(
-                "Logged attempt status=matched → config/match_attempts.jsonl "
+                "Logged attempt status=matched -> config/match_attempts.jsonl "
                 "(no prior matched try; bank-only path)"
             )
         except ProvenanceError as e:
@@ -457,7 +535,7 @@ def main() -> None:
                     db.pop(k, None)
             save_db(db)
             print(f"Pruned near-miss tip for {module}:{addr:#x} from nearmiss/db.jsonl")
-    print("OK — regenerate atlas with: python tools/chaos_db_ci.py")
+    print("OK -- regenerate atlas with: python tools/chaos_db_ci.py")
 
 
 def json_dumps(obj: dict) -> str:

--- a/tools/test_stamp_provenance_verify.py
+++ b/tools/test_stamp_provenance_verify.py
@@ -1,0 +1,218 @@
+"""The verify gate in tools/stamp_provenance.py: what it compares, and when it refuses.
+
+Regression test for a gate that never fired. Until this landed, `run_match` had two
+independent defects and either one alone was enough to bank a non-reproducing file:
+
+  1. It sent every non-arm9/arm7 symbol to match.py as `--module arm9` with no
+     --bin/--base, so an overlay function was compared against extracted/arm9_dec.bin.
+     That image is 0x9cfb8 bytes; an overlay address sits past its end, the target
+     slice came back empty, and match.py printed
+     "size differs: target 0x0 vs candidate 0x104" for a file that reproduces the ROM
+     byte for byte.
+
+  2. It gated on `if "MATCH" not in out`. match.py's last line is always
+     "MATCHING VERSIONS: <list or none>", so "MATCH" is a substring of the output on
+     every run, failures included, and it also exits 0 either way. The guard could not
+     fire, so 1. was invisible and so was a genuinely wrong candidate.
+
+Net effect: a file that did not reproduce could be stamped into
+config/match_provenance.jsonl, logged as a matched attempt, and have its near-miss tip
+pruned. Only CI validate would catch it, days later.
+
+These cases drive the failure branch directly, which is the branch a green run never
+exercises. FAIL_OV and PASS_OV are real captured match.py output.
+
+    python -m unittest tools.test_stamp_provenance_verify -v
+"""
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import stamp_provenance as SP  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# Captured from tools/match.py --brief on the pre-fix coercion: an overlay candidate
+# that reproduces the ROM, compared against arm9_dec.bin at an out-of-range offset.
+FAIL_OV = """TARGET func_ov006_020cb030 @ 0x020cb030 size 0x104  bytes:
+  2004/b56: 999 word(s) differ
+
+--- closest: 2004/b56 (999 differ) ---
+  size differs: target 0x0 vs candidate 0x104
+
+========================================
+MATCHING VERSIONS: none
+"""
+
+PASS_OV = """TARGET func_ov006_020cb030 @ 0x020cb030 size 0x104  bytes: 10402de9...
+  2004/b56: MATCH
+
+========================================
+MATCHING VERSIONS: 2004/b56
+"""
+
+CANONICAL = "2004/b56"
+
+
+class FakeRun:
+    """Stand-in for subprocess.run that records the argv it was handed."""
+
+    def __init__(self, out, returncode=0):
+        self.out, self.returncode, self.cmd = out, returncode, None
+
+    def __call__(self, cmd, **kw):
+        self.cmd = cmd
+        return subprocess.CompletedProcess(cmd, self.returncode, self.out, "")
+
+    def flag(self, name):
+        """The value following `name` in the recorded argv."""
+        return self.cmd[self.cmd.index(name) + 1]
+
+
+class Verdict(unittest.TestCase):
+    """Reading match.py's verdict line instead of a substring of it."""
+
+    def test_failure_output_contains_the_substring_the_old_guard_used(self):
+        """The defect verbatim: 'MATCH' is present in output that matched nothing."""
+        self.assertIn("MATCH", FAIL_OV)
+        self.assertEqual(SP.matching_versions(FAIL_OV), [])
+
+    def test_none_is_no_versions(self):
+        self.assertEqual(SP.matching_versions("MATCHING VERSIONS: none"), [])
+
+    def test_one_version(self):
+        self.assertEqual(SP.matching_versions(PASS_OV), [CANONICAL])
+
+    def test_several_versions(self):
+        self.assertEqual(
+            SP.matching_versions("MATCHING VERSIONS: 1.2/base, 1.2/sp2, 2004/b56"),
+            ["1.2/base", "1.2/sp2", CANONICAL],
+        )
+
+    def test_no_verdict_line_is_not_an_empty_list(self):
+        """A crashed match.py must be distinguishable from a clean non-match."""
+        self.assertIsNone(SP.matching_versions("Traceback (most recent call last):\n"))
+
+    def test_last_verdict_wins(self):
+        """Only the final line grades the run."""
+        two = "MATCHING VERSIONS: 2004/b56\nsecond pass\nMATCHING VERSIONS: none\n"
+        self.assertEqual(SP.matching_versions(two), [])
+
+
+class RunMatch(unittest.TestCase):
+    """What run_match sends to match.py, and what it does with the answer."""
+
+    def setUp(self):
+        # run_match checks the module binary exists before it spends a compile, so the
+        # stand-in registry points at real (empty) files rather than patching pathlib.
+        self._tmp = tempfile.TemporaryDirectory()
+        d = pathlib.Path(self._tmp.name)
+        images = {"ov006": (d / "overlay_0006.bin", 0x020C7000),
+                  "arm9": (d / "arm9_dec.bin", 0x02004000)}
+        for p, _ in images.values():
+            p.write_bytes(b"")
+        self._run = subprocess.run
+        self._target = SP.module_target
+        SP.module_target = images.get
+
+    def tearDown(self):
+        subprocess.run = self._run
+        SP.module_target = self._target
+        self._tmp.cleanup()
+
+    def _call(self, fake, module="ov006", version=CANONICAL):
+        subprocess.run = fake
+        SP.run_match(pathlib.Path("scratch/f.cpp"), "func_ov006_020cb030",
+                     0x020CB030, 0x104, module, version)
+
+    def test_overlay_failure_refuses_to_bank(self):
+        with self.assertRaises(SystemExit) as e:
+            self._call(FakeRun(FAIL_OV))
+        self.assertIn("not banking", str(e.exception))
+
+    def test_overlay_pass_banks(self):
+        self._call(FakeRun(PASS_OV))  # no SystemExit
+
+    def test_nonzero_exit_refuses_even_with_a_passing_verdict(self):
+        with self.assertRaises(SystemExit) as e:
+            self._call(FakeRun(PASS_OV, returncode=1))
+        self.assertIn("exited 1", str(e.exception))
+
+    def test_no_verdict_refuses(self):
+        with self.assertRaises(SystemExit) as e:
+            self._call(FakeRun("Traceback: match.py died\n"))
+        self.assertIn("no MATCHING VERSIONS verdict", str(e.exception))
+
+    def test_a_match_under_another_version_is_not_the_requested_one(self):
+        with self.assertRaises(SystemExit) as e:
+            self._call(FakeRun("MATCHING VERSIONS: 1.2/base\n"))
+        self.assertIn("not the requested", str(e.exception))
+
+    def test_overlay_is_compared_against_its_own_image(self):
+        """The coercion: --module arm9 for an overlay symbol, and no --bin/--base."""
+        fake = FakeRun(PASS_OV)
+        self._call(fake)
+        self.assertEqual(fake.flag("--module"), "ov006")
+        self.assertTrue(fake.flag("--bin").endswith("overlay_0006.bin"))
+        self.assertEqual(fake.flag("--base"), "0x20c7000")
+
+    def test_arm9_still_uses_arm9_dec_at_0x02004000(self):
+        fake = FakeRun(PASS_OV)
+        self._call(fake, module="arm9")
+        self.assertEqual(fake.flag("--module"), "arm9")
+        self.assertTrue(fake.flag("--bin").endswith("arm9_dec.bin"))
+        self.assertEqual(fake.flag("--base"), "0x2004000")
+
+    def test_unresolvable_module_refuses_instead_of_falling_back_to_arm9(self):
+        """arm7 has no module in the registry. Silence here is how 1. survived."""
+        subprocess.run = FakeRun(PASS_OV)
+        with self.assertRaises(SystemExit) as e:
+            SP.run_match(pathlib.Path("scratch/f.c"), "f", 0x037F8000, 0x10,
+                         "arm7", CANONICAL)
+        self.assertIn("no target binary for module", str(e.exception))
+
+    def test_zero_size_refuses(self):
+        with self.assertRaises(SystemExit):
+            SP.run_match(pathlib.Path("scratch/f.c"), "f", 0x02004000, 0, "arm9",
+                         CANONICAL)
+
+
+@unittest.skipUnless((REPO / "extracted" / "arm9_dec.bin").is_file(),
+                     "needs extracted/ (ROM dump)")
+class RegistryTargets(unittest.TestCase):
+    """module_target against the real registry, when a checkout has the ROM.
+
+    Guarded rather than mocked because the point is the values tools/modules.py
+    actually produces. A checkout without extracted/ skips; it also cannot verify.
+    """
+
+    def test_arm9(self):
+        binp, base = SP.module_target("arm9")
+        self.assertEqual(binp, REPO / "extracted" / "arm9_dec.bin")
+        self.assertEqual(base, 0x02004000)
+
+    def test_overlay_base_is_its_lowest_config_symbol(self):
+        """The delinked base, not the ROM overlay table's ramAddress."""
+        import modules as MOD
+
+        ov = next((m for m in MOD.modules() if m["name"].startswith("ov")), None)
+        if ov is None:
+            self.skipTest("no overlay modules in this checkout")
+        binp, base = SP.module_target(ov["name"])
+        self.assertEqual(binp, pathlib.Path(ov["bin"]))
+        self.assertEqual(base, MOD._overlay_base(ov["syms"]))
+
+    def test_an_overlay_address_is_outside_arm9(self):
+        """Why the coercion could never work, measured rather than asserted."""
+        arm9 = (REPO / "extracted" / "arm9_dec.bin").stat().st_size
+        self.assertGreater(0x020CB030 - 0x02004000, arm9)
+
+    def test_arm7_has_no_module(self):
+        self.assertIsNone(SP.module_target("arm7"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`tools/stamp_provenance.py` is the only supported path for stamping a match into
`config/match_provenance.jsonl`, and it runs `tools/match.py` first unless you pass
`--no-verify`. That verify has never been able to fail. Found by lane CK1 during a
verified match; both defects reproduce on a pristine `origin/main` checkout.

## Defect 1: every overlay symbol was compared against arm9

`run_match` sent `--module (module if module in ("arm9", "arm7") else "arm9")` and no
`--bin`/`--base`, so any overlay function was compared against `extracted/arm9_dec.bin`.
That image is `0x9cfb8` bytes; an overlay address sits far past its end, so
`target_bytes()` sliced an empty string.

`src/func_ov006_020cb030.cpp` is the repo's own canary, the function used to prove a
fresh worktree's toolchain works. On main:

```
$ python tools/stamp_provenance.py --src src/func_ov006_020cb030.cpp \
      --kind human --by tangosdev --session-scope focused --force
Verifying func_ov006_020cb030 @ ov006:0x020cb030 size 0x104 ...
--- closest: 2004/b56 (999 differ) ---
  size differs: target 0x0 vs candidate 0x104
MATCHING VERSIONS: none
Banked ov006:0x020cb030: author=tangosdev how={"kind": "human"}
```

`build_pin.verify(...)` returns `(True, '2004/b56')` for that same file in that same
tree. `--module` also selects `config/<module>/relocs.txt` for the reloc-destination
check, so that ran against arm9's config for every overlay as well.

## Defect 2: the guard could not fire

The gate was `if r.returncode != 0 or "MATCH" not in out`. `match.py` exits 0 whether or
not anything reproduced, and its last line is always
`MATCHING VERSIONS: <comma list, or none>`, so `"MATCH"` is present in every run's
output because it is a substring of `MATCHING`. Both halves of the guard are dead.

Defect 1 alone would have been caught by a working gate, so here it is on its own, on
the arm9 path, with a candidate that genuinely differs (operands swapped in
`src/AngleDiff.c`, 1 word out of 5):

```
$ python tools/stamp_provenance.py --c scratch/AngleDiff.c --func AngleDiff \
      --kind human --by tangosdev --session-scope focused --force
Verifying AngleDiff @ arm9:0x0203b0e8 size 0x14 ...
MATCHING VERSIONS: none
Banked arm9:0x0203b0e8: author=tangosdev how={"kind": "human"}
Logged attempt status=matched
```

A ledger row, a matched attempt row, and the near-miss tip pruned, for a file that does
not reproduce. Only CI validate would have caught it, days later, on someone else's PR.

## Defect 3, found while reproducing: the tool dies on a Windows console

`--help`, `--promote`, and the first bank of any function print U+2192, which has no
cp1252 encoding:

```
$ python tools/stamp_provenance.py --help
UnicodeEncodeError: 'charmap' codec can't encode character '→'
```

On a bank it lands after `append_ledger_row` and `append_attempt`, and before the
near-miss prune, so on Windows the row is written, the tool exits 1, and the tip is
never dropped from `nearmiss/db.jsonl`.

## The fix

`module_target()` resolves a module's image through `tools/modules.py`, the registry
`match.py` itself reads for `--module ovNNN`: main ARM9 is `extracted/arm9_dec.bin` at
`0x02004000`, and an overlay or autoload takes its base from the lowest symbol address
in its config `symbols.txt` (dsd's delinked space, not the overlay table's ramAddress).
`run_match` passes `--module` with that `--bin` and `--base`, the same shape
`tools/verify_mangled.py` already uses. An unresolvable module now refuses to verify
instead of silently falling back to arm9.

The gate reads `matching_versions(out)`: the parsed payload of the final
`MATCHING VERSIONS:` line. The requested version has to be in it. No verdict line at
all is a failure, not a pass, since that means match.py died before it graded anything.
A non-zero exit still fails. The failure message says which of the four it was.

Runtime strings are ASCII now.

I checked both derivations of an overlay base against each other across all 90
overlays: `modules.py`'s lowest-symbol base and `delinks.txt`'s first section start
agree on all 81 overlays that contain functions. The 9 that differ (by `0x20`, e.g.
ov008 `0x21111c0` vs `0x21111a0`) are data-only overlays with zero `kind:function`
symbols, so nothing this gate can be asked to verify lives in them.

## Caller survey

| caller | uses | affected |
|---|---|---|
| `tools/prepush_linkcheck.py:49` | `load_symbol` only, via `exec_module` | no |
| `tools/pgate.py:37` | `load_symbol` only, via `exec_module` | no |
| `tangos.json` `stamp_provenance` | CLI, `--no-verify` is an opt-in boolean | yes: the Console default verifies, so every Console-driven overlay bank has been running the broken gate |
| `AGENTS.md`, `CONTRIBUTING.md`, `notes/match-*.md` | prose | no |

Nothing else imports `run_match`, and nothing reads its return value: it either returns
or raises `SystemExit`. The near-miss prune CK1 saw is inside `main()`, after banking,
so it now runs only for candidates that actually reproduced. That is a real semantic
change and it is the intended one. A non-reproducing candidate must not drop the
near-miss tip it failed to beat.

Does anything today depend on the always-pass behaviour? I ran 26 already-banked
functions back through the fixed gate, 18 random overlay functions across 13 overlays
and 8 arm9 functions, and all 26 pass. No collision found: the fix stops false banks
without blocking work that reproduces.

Two adjacent findings, not touched here:

- `tools/cpp_rename.py:152` has a function literally named `verify_match` with the
  inverse defect. It omits the `--size` argparse requires, so `match.py` exits 2 with
  empty stdout and the check returns `False` on every rename. It reports
  `VERIFICATION FAILED!` after the `git mv` has already happened, and never rolls back.
- `load_symbol` still cannot see `config/arm9/itcm` or `dtcm` (the regex takes `arm9`,
  `arm7` and `arm9/overlays/ovNNN` only), so the 31 itcm functions that have a src file
  resolve to `None` and cannot be banked with verify unless the caller passes `--addr`
  and `--module` by hand. `module_target("itcm")` now answers correctly, so fixing the
  resolver is all that is left, but it is a different change.

## Tests

`tools/test_stamp_provenance_verify.py`, stdlib unittest like its siblings, 19 cases
driving the failure branch directly:

- the failing output verbatim, asserting `"MATCH" in FAIL_OV` while
  `matching_versions(FAIL_OV) == []`, so the substring trap cannot come back
- verdict parsing: `none`, one version, several, no line at all, last line wins
- `run_match` refuses on a failing verdict, on a non-zero exit with a passing verdict,
  on a missing verdict line, and on a match under a version other than the requested one
- the argv it builds carries `ov006` with `overlay_0006.bin` and its base, and arm9
  still gets `arm9_dec.bin` at `0x02004000`
- an unresolvable module (arm7) refuses instead of falling back to arm9
- against the real registry, guarded on `extracted/` being present: arm9's target, an
  overlay's base equal to `modules._overlay_base`, and the measurement that an overlay
  address is past the end of arm9_dec.bin

```
$ python -m unittest tools.test_stamp_provenance_verify -v
Ran 19 tests in 0.227s
OK

$ python -m unittest tools.test_stamp_provenance_verify tools.test_match_provenance \
    tools.test_match_attempts tools.test_srcpath tools.test_check_python_names
Ran 90 tests in 5.421s
OK (skipped=2)

$ python tools/check_python_names.py
python-names: 196 tracked file(s) checked
  0 unresolvable names, 0 unparseable files, 32 advisory finding(s)
python-names: PASS
```

End to end in a worktree with the ROM and the compiler, after the fix:

| case | before | after |
|---|---|---|
| ov006 canary, correct source | banked on "size differs: target 0x0" | `2004/b56: MATCH`, banked, rc 0 |
| ov006, one field offset changed | banked | `2 word(s) differ` against the real ov006 image, refused, rc 1 |
| arm9 AngleDiff, operands swapped | banked | refused, rc 1 |
| arm9 AngleDiff, committed source | banked | `MATCHING VERSIONS: 2004/b56`, banked, rc 0 |

## Unproven

- No existing ledger row is re-checked by this PR. Rows banked through the broken gate
  before today are unaudited; the 26-function sample above is evidence about the flow,
  not a clean bill for the ledger. Auditing `config/match_provenance.jsonl` against
  `linkcheck` is a separate job.
- `arm7` now refuses to verify rather than comparing against arm9. There is no
  `config/arm7/` in this repo, so `load_symbol` can never return it and I could not
  exercise the path with a real symbol, only with a synthetic one in the tests.
- The 9 data-only overlays where the two base derivations differ have no functions
  today. If a function is ever delinked into one of them, which derivation is correct
  becomes a live question, and this gate would follow `modules.py`.
- Only `python-names` runs in CI, so `tools/test_stamp_provenance_verify.py` is not
  wired to a workflow. It runs under plain `python -m unittest` like the other 29
  `tools/test_*.py` files.
