### PR TITLE
Name the receiver FaderColor::AdvanceFade was already being handed

### DIFF
--- a/include/decl_FaderColor.h
+++ b/include/decl_FaderColor.h
@@ -20,7 +20,13 @@
 extern "C" {
 #endif
 
-extern void _ZN10FaderColor11AdvanceFadeEv(void);
+/* AdvanceFade is a non-static member of FaderColor, so its receiver rides r0
+   like any other first argument. Declared `(void)` it still byte-matches, because
+   every caller happens to already hold the object in r0 and the compiler emits no
+   argument setup either way. It is still a dropped argument, and any host whose
+   calling convention makes the receiver explicit loses it. Named, per the
+   Heap::_Destroy precedent. */
+extern void _ZN10FaderColor11AdvanceFadeEv(void*);
 extern void _ZN10FaderColorD1Ev(void*);
 
 

--- a/src/func_0202f428.c
+++ b/src/func_0202f428.c
@@ -13,7 +13,7 @@ void func_0202f428(char *obj)
 {
     struct dWipe_c *self = (struct dWipe_c *)(void *)obj;
     if (self->unk_014 == 1) {
-        _ZN10FaderColor11AdvanceFadeEv();
+        _ZN10FaderColor11AdvanceFadeEv(obj);
         return;
     }
     switch (self->unk_010) {


### PR DESCRIPTION
## The defect

`src/func_0202f428.c` is `dWipe_c::AdvanceFade`, arm9 `0x0202f428`, size `0x164`, `complete` in
`config/arm9/delinks.txt`. Inside its `type == 1` branch it calls

```c
_ZN10FaderColor11AdvanceFadeEv();
```

with no argument, against a declaration in `include/decl_FaderColor.h` that reads
`extern void _ZN10FaderColor11AdvanceFadeEv(void);`.

`AdvanceFade` is a non-static member of `FaderColor`. `src/engine/fader/_ZN10FaderColor11AdvanceFadeEv.cpp`
defines it as `void FaderColor::AdvanceFade()` and dereferences `this` on its first
statement. On ARM its receiver rides r0 like any other first argument, and the ROM call
site supplies one. From the function's own bytes:

```
+0x08  0040a0e1  mov r4, r0
+0x0c  141094e5  ldr r1, [r4, #0x14]
+0x10  010051e3  cmp r1, #1
+0x14  0300001a  bne  +0x28
+0x18  26a0ffeb  bl   0x020174e0        <- _ZN10FaderColor11AdvanceFadeEv
```

There is no argument setup anywhere between the entry and that `bl`, because r0 still holds
the incoming object. Compare the two calls in the same function that do spell their
argument, `+0x128` and `+0x148`, each one preceded by `mov r0, r4`.

`config/arm9/relocs.txt:5492` confirms the destination:
`from:0x0202f440 kind:arm_call to:0x020174e0 module:main`, and
`config/arm9/symbols.txt:639` puts `_ZN10FaderColor11AdvanceFadeEv` at `0x020174e0`.

So the C source drops an argument the hardware passes anyway. mwccarm reproduces the bytes
either way, which is why the byte gate has never had anything to say about it. Any host
whose calling convention makes the receiver explicit loses the object.

`func_0202f428` is the only writer of the `dWipe_c` interp value outside arm time and the
only caller of the table rebuild outside arm time, so the port's slot-0x08 fader seat is
downstream of this.

## The precedent

Same class of defect, same fix, as `Heap::_Destroy`. `src/_ZN9ActorBase9Virtual34Ejj.cpp`
declares the mangled ROM symbol with the receiver written out,

```c
void _ZN4Heap8_DestroyEv(Heap* h);
```

inside its `extern "C"` block, and passes it at each of its five call sites. Here the header
already spells `FaderColor`'s other receiver-taking symbol that way,
`_ZN10FaderColorD1Ev(void*)`, so `AdvanceFade` now matches its own neighbour rather than
contradicting it.

## The change

Two lines.

- `include/decl_FaderColor.h`: `_ZN10FaderColor11AdvanceFadeEv(void)` becomes
  `_ZN10FaderColor11AdvanceFadeEv(void*)`, with a comment recording why the `(void)` form
  byte-matched anyway.
- `src/func_0202f428.c`: the call becomes `_ZN10FaderColor11AdvanceFadeEv(obj);`.

`include/decl_FaderColor.h` has exactly one includer, `src/func_0202f428.c`. Its
AUTO-GENERATED banner is a fossil: `tools/decl_headers.py` does not exist in this repo and
never has in its history, so nothing regenerates the file over the edit.

`void*` rather than a `FaderColor*`: `obj` is a `char*` in a C translation unit that does not
have `FaderColor`'s definition in scope, and `char* -> void*` is an implicit conversion with
no codegen. Giving the receiver a real type belongs with whatever commit works out how
`dWipe_c` and `FaderColor` are related, which this one does not touch.

## Proof the bytes did not move

Both legs at the pinned compiler `2004/b56` with `--strict-relocs --module arm9` against
`extracted/arm9_dec.bin` at base `0x02004000`.

```
BEFORE  tools/match.py ... --version 2004/b56 --strict-relocs   MATCHING VERSIONS: 2004/b56
AFTER   tools/match.py ... --version 2004/b56 --strict-relocs   MATCHING VERSIONS: 2004/b56
```

Not read off the summary line. The complete `match.py` output, which prints the target word
and the produced word side by side for all 89 words of the function, is byte for byte
identical between the two runs -- `diff` of the two captures is empty. Zero cost, as
expected: r0 already holds `obj` at the call, so the compiler emits no argument setup for the
explicit argument either, and in particular does not insert a `mov r0, r4`.

Three further gates, all on this branch:

```
build_pin.verify('src/func_0202f428.c', 'func_0202f428', 0x0202f428, 0x164, 'arm9')
  -> (True, '2004/b56')

tools/linkcheck.py --module arm9 --c src/func_0202f428.c --name func_0202f428
                   --addr 0x0202f428 --size 0x164
  -> {"verdict": "VERIFIED", "diffs": [], "blind": 0}      (and the same on the BEFORE tree)

tools/check_references.py
  -> unresolved symbols: 96 (baseline 96)
     OK: no new unresolvable references
```

`build_pin` matters here because it compiles with `rombuild`'s own single pinned version and
`rombuild`'s own flags rather than the 25-version sweep, and `linkcheck` matters because it
writes the resolved destination into the reloc slot and byte-compares the linked function to
the ROM, so the `bl` at `+0x18` is verified to land on `0x020174e0` and not merely wildcarded.

## Siblings

Nothing else in `src/func_0202f428.c`. Its only other calls are `func_0202fb30(obj)` and
`func_0202f290(obj)`, both of which pass their argument, and three calls to
`_ZN3G2x18SetBlendBrightnessEPVtts`, which is a namespace-scoped free function with no
receiver and is handed all three of its arguments.

Found while sweeping, not fixed here, no proof run on any of them:

Same shape exactly, a real body whose r0 already holds the object and a member symbol
called with empty parentheses:

- `src/_ZN13MotherPenguin8BehaviorEv.cpp:17` -- `_ZN13RacingPenguin16OnPendingDestroyEv();`
  as the first statement of a method, where every other call in the same function does spell
  its receiver.
- `src/Wiggler_Spawn.c:22`, `src/ChainChomp_Spawn.cpp:18`, `src/ChiefChilly_Spawn.cpp:18` --
  `_ZN5EnemyC2Ev();`. A C2 base-object constructor cannot not take a receiver.

Seventeen call sites sit inside documented tail-call veneers, which is the family
`Heap::_Destroy` already came from and which `src/_ZN4Heap8_DestroyEv.cpp` has already been
migrated out of once:

```
src/_ZN13HeapAllocator7DestroyEv.cpp:8      _ZN13HeapAllocator6RemoveEv
src/func_02011cfc.c:7                       _ZN5Sound13Func_02048eb4Ev
src/func_02011d08.c:7                       _ZN5Sound13Func_02048ec4Ev
src/func_02011d20.c:7                       _ZN5Sound13Func_02048ee4Ev
src/func_02014a20.c:12                      _ZN18MovingCylinderClsn10GetOwnerIDEv
src/func_0201721c.c:12                      _ZN5Fader13AdvanceInterpEv
src/func_0202ed08.c:12                      _ZN15FaderBrightness8SetToEndEv
src/func_020383e4.c:7                       _ZN12WithMeshClsn20UpdateExtraContinousEv
src/func_020383f0.c:7                       _ZN12WithMeshClsn22UpdateContinuousNoLavaEv
src/func_02038414.c:7                       _ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev
src/func_0204ebb8.c:7                       _ZN13HeapAllocator6RemoveEv
src/func_ov030_021145d4.c:11                _ZN9ActorBase18MarkForDestructionEv
src/func_ov072_02121fa0.c:11                _ZN9ActorBase18MarkForDestructionEv
src/func_ov075_0211a734.c:11                _ZN5Scene19ResetFadersAndSoundEv
src/func_ov091_0213448c.c:11                _ZN9ActorBase18MarkForDestructionEv
src/WithMeshClsn_UpdateContinuous_Veneer.c:7        _ZN12WithMeshClsn16UpdateContinuousEv
src/WithMeshClsn_UpdateDiscreteNoLava_veneer.c:7    _ZN12WithMeshClsn20UpdateDiscreteNoLavaEv
```

Two of those, `src/func_0201721c.c` and `src/func_0202ed08.c`, are the same fader chain as
this file: `dFdDummy_c::AdvanceFade` and `dWipe_c::SetToEnd`.

## Unproven

- I did not classify the rest of the tree. A grep finds 94 distinct mangled symbols called
  with empty parentheses across 476 sites, but most of those are namespace-scoped functions
  (`GX`, `G2`, `G2S`, `GXS`, `IRQ`, `OAM`, `CP15`, `cstd`) where there is no receiver to
  drop and the empty parentheses are correct. I have no honest count of how many of the
  remainder are real defects, and this PR should not be read as claiming one. The five body
  sites and seventeen veneer sites listed above are the ones I read individually.
- The relationship between `dWipe_c` and `FaderColor` is not established here. `FaderColor`
  is 0x10 bytes and `dWipe_c`'s own named fields all start at 0x010, which is consistent with
  `FaderColor` being a base sub-object at offset 0, but `src/func_0202f428.c` also writes a
  byte at 0x0f, which sits in `FaderColor`'s tail padding. Nothing here depends on resolving
  that, and the receiver is `void*` precisely so that it does not.
- `src/func_0202f428.c:10` declares `_ZN3G2x18SetBlendBrightnessEPVtts` as
  `(unsigned short*, unsigned short, int)`, where the mangled suffix `PVtts` says
  `(volatile unsigned short*, unsigned short, short)`. Not a receiver defect, both spellings
  pass in r0/r1/r2, and out of scope for this branch. Noted so it is on the record.
- No ROM link was run on this branch. The evidence above is the pinned-compiler byte gate,
  the link reconstruction for this one function, and the reference check.
