### PR TITLE
Repair 15 byte-gate failures into matches, banner 6 that cannot be, retire 17 manifest rows

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -3701,6 +3701,7 @@ src/_ZN8Particle10SysTracker6UpdateEv.c:
     .text start:0x02022f20 end:0x02022f40
 
 src/_ZN8Particle10SysTracker10InitialiseEv.cpp:
+    complete
     .text start:0x02022f40 end:0x020230ec
 
 src/_ZN8Particle7Texture12AllocPalVramEjb.c:
@@ -5074,9 +5075,6 @@ src/_ZN13RaycastGroundC1Ev.c:
 src/func_020375b0.cpp:
     .text start:0x020375b0 end:0x020375c0
 
-src/func_020375c0.c:
-    .text start:0x020375c0 end:0x020375d0
-
 src/_ZN11RaycastLine10GetClsnPosEv.c:
     complete
     .text start:0x020375d0 end:0x020375ec
@@ -5107,9 +5105,6 @@ src/_ZN11RaycastLineC1Ev.cpp:
 
 src/func_0203780c.cpp:
     .text start:0x0203780c end:0x0203781c
-
-src/func_0203781c.c:
-    .text start:0x0203781c end:0x0203782c
 
 src/func_0203782c.c:
     complete
@@ -5206,14 +5201,8 @@ src/_ZN10SphereClsnC1Ev.c:
 src/func_02037d84.cpp:
     .text start:0x02037d84 end:0x02037d94
 
-src/func_02037d94.c:
-    .text start:0x02037d94 end:0x02037da4
-
 src/func_02037da4.cpp:
     .text start:0x02037da4 end:0x02037db4
-
-src/func_02037db4.c:
-    .text start:0x02037db4 end:0x02037dc4
 
 src/func_02037dc4.c:
     complete

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -2921,6 +2921,7 @@ src/func_ov002_020cfaf0.cpp:
     .text start:0x020cfaf0 end:0x020cfbdc
 
 src/func_ov002_020cfbdc.cpp:
+    complete
     .text start:0x020cfbdc end:0x020cfd84
 
 src/func_ov002_020cfd84.cpp:

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -204,6 +204,7 @@ src/func_ov004_020aeb24.cpp:
     .text start:0x020aeb24 end:0x020aeed8
 
 src/func_ov004_020aeed8.cpp:
+    complete
     .text start:0x020aeed8 end:0x020af04c
 
 src/func_ov004_020af04c.cpp:
@@ -211,6 +212,7 @@ src/func_ov004_020af04c.cpp:
     .text start:0x020af04c end:0x020af094
 
 src/func_ov004_020af094.cpp:
+    complete
     .text start:0x020af094 end:0x020af27c
 
 src/func_ov004_020af27c.cpp:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -2691,6 +2691,7 @@ src/func_ov006_020e6e54.c:
     .text start:0x020e6e54 end:0x020e6e78
 
 src/func_ov006_020e6e78.cpp:
+    complete
     .text start:0x020e6e78 end:0x020e6f60
 
 src/_ZN14dScMgD3DBase_c21AfterCleanupResourcesEj.cpp:

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -745,9 +745,6 @@ src/func_ov007_020b9fc0.c:
     complete
     .text start:0x020b9fc0 end:0x020ba05c
 
-src/func_ov007_020ba05c.c:
-    .text start:0x020ba05c end:0x020ba2e0
-
 src/func_ov007_020ba2e0.c:
     complete
     .text start:0x020ba2e0 end:0x020ba368

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -493,6 +493,7 @@ src/_ZN9WaterRingD0Ev.cpp:
     .text start:0x02119aa0 end:0x02119afc
 
 src/func_ov064_02119afc.cpp:
+    complete
     .text start:0x02119afc end:0x02119c60
 
 src/func_ov064_02119c60.c:

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -329,6 +329,7 @@ src/_ZN15TtcRotatingCube8BehaviorEv.cpp:
     .text start:0x02119a50 end:0x02119c38
 
 src/_ZN15TtcRotatingCube13InitResourcesEv.cpp:
+    complete
     .text start:0x02119c38 end:0x02119ebc
 
 src/TtcRotatingPrism_Spawn.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -263,6 +263,7 @@ src/func_ov071_02121b50.c:
     .text start:0x02121b50 end:0x02121ba4
 
 src/func_ov071_02121ba4.cpp:
+    complete
     .text start:0x02121ba4 end:0x02121c6c
 
 src/func_ov071_02121c6c.cpp:

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -107,6 +107,7 @@ src/func_ov078_02124c94.c:
     .text start:0x02124c94 end:0x02124cf4
 
 src/func_ov078_02124cf4.cpp:
+    complete
     .text start:0x02124cf4 end:0x02124e9c
 
 src/func_ov078_02124e9c.c:

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -49,6 +49,7 @@ src/func_ov080_02123fcc.cpp:
     .text start:0x02123fcc end:0x02124088
 
 src/func_ov080_02124088.cpp:
+    complete
     .text start:0x02124088 end:0x02124208
 
 src/func_ov080_02124208.c:

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -21,6 +21,7 @@ src/func_ov081_021237ec.cpp:
     .text start:0x021237ec end:0x02123910
 
 src/func_ov081_02123910.cpp:
+    complete
     .text start:0x02123910 end:0x02123b20
 
 src/func_ov081_02123b20.cpp:

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -122,9 +122,6 @@ src/_ZN6Goomba8BehaviorEv.cpp:
     complete
     .text start:0x0212b6ec end:0x0212bc30
 
-src/_ZN6Goomba13InitResourcesEv.cpp:
-    .text start:0x0212bc30 end:0x0212bfc0
-
 src/func_ov084_0212bfc0.cpp:
     complete
     .text start:0x0212bfc0 end:0x0212bff8

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -73,6 +73,7 @@ src/_ZN13PrincessPeachD0Ev.c:
     .text start:0x02129d60 end:0x02129dbc
 
 src/func_ov085_02129dbc.cpp:
+    complete
     .text start:0x02129dbc end:0x02129ebc
 
 src/func_ov085_02129ebc.cpp:

--- a/config/arm9/overlays/ov096/delinks.txt
+++ b/config/arm9/overlays/ov096/delinks.txt
@@ -164,6 +164,7 @@ src/func_ov096_02136fd4.c:
     .text start:0x02136fd4 end:0x02137088
 
 src/func_ov096_02137088.cpp:
+    complete
     .text start:0x02137088 end:0x021372c0
 
 src/func_ov096_021372c0.cpp:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -248,6 +248,7 @@ src/func_ov098_0213a36c.cpp:
     .text start:0x0213a36c end:0x0213a794
 
 src/func_ov098_0213a794.cpp:
+    complete
     .text start:0x0213a794 end:0x0213a8e0
 
 src/func_ov098_0213a8e0.c:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -260,6 +260,7 @@ src/func_ov102_0214b128.cpp:
     .text start:0x0214b128 end:0x0214b248
 
 src/func_ov102_0214b248.cpp:
+    complete
     .text start:0x0214b248 end:0x0214b384
 
 src/func_ov102_0214b384.c:

--- a/config/bytegate-known-failures.txt
+++ b/config/bytegate-known-failures.txt
@@ -27,7 +27,7 @@
 #
 # The hash is taken over the file with CRLF folded to LF. There is no `text=auto` rule in
 # .gitattributes, so a Windows clone materialises these files CRLF and the ubuntu runner
-# that publishes the count materialises them LF. A raw-byte pin would miss on all 18 rows
+# that publishes the count materialises them LF. A raw-byte pin would miss on every row
 # in CI, lapse every exclusion at once, and quietly restore the pre-policy number while
 # every local check still passed. Do not re-pin these by hand; use --recheck.
 #
@@ -37,45 +37,37 @@
 # TO ADD OR RETIRE A ROW
 #   python tools/bytegate.py --recheck        # needs tools/mwccarm; prints the true set
 #
-# Re-derived at a6dd3d3ec: 18 rows, every one of them failing under all 12 versions.
-# linkcheck reports all 18 as NO-SYM, and reports WRONG for none of them -- these are
-# "counted without evidence", NOT "proven wrong". See audit/enrollment_report.md 4a.
+# HISTORY
+# --------
+# Recorded at a6dd3d3ec with 18 rows. `--recheck` now confirms 1 and retires 17: the
+# self-healing property did exactly what its docstring promised -- the 17 fixes were
+# made without reference to this file, and the rows lapsed on their own. They are
+# deleted here rather than left to lapse because a lapsed row is indistinguishable
+# from an un-re-checked one, which is what test_bytegate.test_no_row_is_stale exists
+# to refuse.
+#
+#   15 now build AND reproduce the cartridge -- the signature clash was repaired and
+#      the functions are enrolled, so they are counted matched and verified both.
+#    2 now build but do NOT reproduce it (Goomba::InitResources, 916 against 912;
+#      func_ov007_020ba05c, 0x22c against 0x284). Fixing the compile is what revealed
+#      each gap -- it had been hidden behind the compile error. Both now carry a
+#      NONMATCHING banner, so `matched` excludes them by the ordinary route and this
+#      list has nothing left to say about them.
+#
+# linkcheck reported all 18 as NO-SYM and WRONG for none -- "counted without evidence",
+# NOT "proven wrong", and repairing 15 of them into byte matches is what that predicted.
+# See audit/enrollment_report.md 4a.
 
-# --- extern "C" signature clash with include/decl_common.h (16) -------------------
+# --- extern "C" signature clash with include/decl_common.h (1) --------------------
 # The file declares a symbol `extern "C"` with one signature and decl_common.h declares
 # the same symbol with C++ linkage and a different parameter type, so mwccarm rejects the
-# pair as an illegal overload and never reaches codegen. 12 clash on their own symbol,
-# 4 on a callee they redeclare. Mechanical, and plausibly correct decompilations that
-# stopped compiling when decl_common.h grew -- fixing the 16 signatures retires all of
-# these rows at once and returns the functions to the count.
-a6ea3b1a74b57099 src/_ZN8Particle10SysTracker10InitialiseEv.cpp extern-c-clash
-58afde3c2716d8b2 src/func_ov002_020cfbdc.cpp extern-c-clash
+# pair as an illegal overload and never reaches codegen.
+#
+# This is the one row of the original 16 that survives, and it is not a harder signature
+# problem -- the same repair compiles it. It stays because compiling it exposes calls to
+# func_02111b64/func_02111b6c, an address that resolves in four overlays (ov008, ov012,
+# ov013, ov017), so resolve_placeholders cannot settle the destination and
+# check_references reports a NEW unresolvable reference. It also fails eligibility rule 2
+# (.text section size against declared size), so repairing it would not enrol it either.
+# Retire this row only together with the co-residency work that settles the callee.
 2371acc5ad305f55 src/func_ov002_020e3e00.cpp extern-c-clash
-b4ec67022e088af8 src/func_ov004_020aeed8.cpp extern-c-clash
-cf7d83579757ff4c src/func_ov004_020af094.cpp extern-c-clash
-01cadd806d718eb1 src/func_ov006_020e6e78.cpp extern-c-clash
-fb8c9547cf4b4a3a src/func_ov064_02119afc.cpp extern-c-clash
-3f2675885e87d552 src/_ZN15TtcRotatingCube13InitResourcesEv.cpp extern-c-clash
-7a37d816f5e354a9 src/func_ov071_02121ba4.cpp extern-c-clash
-a058233791d59bb6 src/func_ov078_02124cf4.cpp extern-c-clash
-58d9bf39038be0ed src/func_ov080_02124088.cpp extern-c-clash
-e2ff5d9f25ff7b90 src/func_ov081_02123910.cpp extern-c-clash
-3282c177d8044544 src/func_ov085_02129dbc.cpp extern-c-clash
-83976ff4cb5e9444 src/func_ov096_02137088.cpp extern-c-clash
-7fb411355a511de8 src/func_ov098_0213a794.cpp extern-c-clash
-219e3a71c05fb4b8 src/func_ov102_0214b248.cpp extern-c-clash
-
-# --- bare Fix12 where the real type is Fix12<int> (1) ------------------------------
-# line 17: template argument list expected. A genuine error, not a sentinel problem --
-# but the file also carries its //cpp sentinel on line 2, behind an #include, and both
-# eligible.classify and reloc_audit.winning_object test text.startswith("//cpp"), so it
-# is offered to the compiler as C99 first. Moving the sentinel to line 1 does not fix
-# this file, and is worth knowing about as a trap for others.
-818732269ec59bd1 src/_ZN6Goomba13InitResourcesEv.cpp bare-template-arg
-
-# --- broken draft (1) ---------------------------------------------------------------
-# line 114: 'array28' is not a member of class 'struct StructObj20', plus array24 and
-# f2C. The file carries the comment `bHolder->b->f2C = 0; // or bHolder->f2C? wait`.
-# It has never been compiled by any gate. This is the one row of the 18 that is a
-# genuinely unfinished draft rather than a mechanical signature defect.
-08e164c9fb1168c6 src/func_ov007_020ba05c.c broken-draft

--- a/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
@@ -2,7 +2,6 @@
 #include "types.h"
 // @symbol _ZN15TtcRotatingCube13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
 struct SharedFilePtr;
@@ -14,6 +13,10 @@ struct Vector3;
 struct Actor;
 
 extern "C" {
+    extern void*data_ov065_0211c0a8[];
+    extern s16 data_ov065_0211cfa8[];
+    extern void*data_ov065_0211cfd8[];
+    extern u8 data_ov065_0211cfa4[];
     void *_ZN5Model8LoadFileER13SharedFilePtr(void *shared);
     void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *mb, void *bmd, int a, int b);
     void _ZN11ShadowModel10InitCuboidEv(void *self);
@@ -34,7 +37,7 @@ extern "C" {
 
 extern void *data_ov065_0211cfd0[];
 extern void *data_ov065_0211cfd4[];
-extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
+extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern u8 data_0209f2c0;
 extern s32 data_020a0e68[];
 

--- a/src/_ZN6Goomba13InitResourcesEv.cpp
+++ b/src/_ZN6Goomba13InitResourcesEv.cpp
@@ -1,3 +1,18 @@
+// NONMATCHING -- compiles, but the result is 916 bytes against the ROM's 912.
+// Four bytes, so this is a near-miss and not a wrong reconstruction; it is one
+// instruction over. The `Fix12` -> `Fix12i` retype below was needed just to make the
+// file compile at all (Fix12 became a template, and the declarations still used the
+// bare name), and it is correct: include/math/Fix12.h records that a Fix12 passes in a
+// single register bit-identical to an int, and these are extern declarations whose
+// symbol names are spelled literally, so the parameter type only decides the call ABI.
+// Fixing the compile is what revealed the size gap -- it was hidden behind the error.
+//
+// NOTE, pre-existing and left alone: this file's `//cpp` marker is on line 2, behind an
+// #include, so `text.startswith("//cpp")` -- the whole test, in rombuild.compile_one and
+// build_pin.flags_for alike -- is FALSE for it. Every tool in the tree therefore selects
+// -lang c99 for a file whose body is C++. It is left as-is because moving it changes
+// nothing measurable: 916 bytes comes out identical under -lang c99 and -lang c++, so
+// the marker's position is not what stands between this file and a match.
 #include "MaterialChanger.h"
 //cpp
 
@@ -14,13 +29,13 @@ void _ZN8CapEnemy6AddCapEj(void* self, unsigned int x);
 int _ZN8CapEnemy21DestroyIfCapNotNeededEv(void* self);
 int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 int _ZN11ShadowModel12InitCylinderEv(void* self);
-void _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(void* self, void* bma, int a, Fix12 b, unsigned int cc);
+void _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(void* self, void* bma, int a, Fix12i b, unsigned int cc);
 void LoadBlueCoinModel(void* c);
-void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
-void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* a, Fix12 b, Fix12 cc, void* d, Fix12 e);
+void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
+void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* a, Fix12i b, Fix12i cc, void* d, Fix12i e);
 void _ZN12WithMeshClsn19StartDetectingWaterEv(void* self);
 void func_ov084_021290d4(void* c);
-void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* f, int a, Fix12 b, unsigned int cc);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* f, int a, Fix12i b, unsigned int cc);
 
 extern SharedFilePtr data_ov084_02130cf8;
 extern SharedFilePtr data_ov084_02130ce8;

--- a/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
+++ b/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
@@ -3,10 +3,11 @@
 // @symbol _ZN8Particle10SysTracker10InitialiseEv
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_Heap.h"
-#include "decl_Particle.h"
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle__SysTracker.h"
+extern "C" extern u32 _ZN8Particle7Texture12AllocTexVramEjb(const void*, u32);
+extern "C" extern unsigned int _ZN8Particle7Texture12AllocPalVramEjb(unsigned int, unsigned int);
 extern "C" void DecompressLZ16(const void* src, void* dst);
 
 

--- a/src/func_020375c0.c
+++ b/src/func_020375c0.c
@@ -1,3 +1,20 @@
+/* NONMATCHING -- this file does not compile, and cannot become a match as written.
+ *
+ * It reconstructs the thunk's BYTES from a synthetic hierarchy: the classes below
+ * are placeholders (`Base2`, `Derived`) chosen to make mwcc emit a this-adjusting
+ * thunk of the right shape, not the ROM's real types. The object therefore defines
+ * _ZThn16_N7DerivedD0Ev / D1Ev and _ZN7DerivedD0Ev / D1Ev / D2Ev -- five functions,
+ * none of which any any symbols.txt under config/ names -- rather than the single symbol
+ * `func_020375c0` this file claims.
+ *
+ * So it fails eligibility three ways at once: five .text sections where one is
+ * allowed, a symbol name the delink entry does not declare, and undefined
+ * references nothing defines. It can never be enrolled, and until it is bannered
+ * it counts toward the project's matched total on the strength of its filename.
+ *
+ * Recovering it for real needs the ROM's actual derived class, which is the
+ * vtable-naming workstream, not a byte experiment.
+ */
 /* func_020375c0 is a compiler-generated this-adjusting virtual-destructor
  * thunk (CodeWarrior _ZThn16_N...D1Ev form): ldr ip,[pc,#4]; add r0,r0,ip; b D1
  * Adjusts this by -16 and tail-branches to RaycastGround::~RaycastGround.

--- a/src/func_0203781c.c
+++ b/src/func_0203781c.c
@@ -1,3 +1,20 @@
+/* NONMATCHING -- this file does not compile, and cannot become a match as written.
+ *
+ * It reconstructs the thunk's BYTES from a synthetic hierarchy: the classes below
+ * are placeholders (`Base2`, `Derived`) chosen to make mwcc emit a this-adjusting
+ * thunk of the right shape, not the ROM's real types. The object therefore defines
+ * _ZThn16_N7DerivedD0Ev / D1Ev and _ZN7DerivedD0Ev / D1Ev / D2Ev -- five functions,
+ * none of which any any symbols.txt under config/ names -- rather than the single symbol
+ * `func_0203781c` this file claims.
+ *
+ * So it fails eligibility three ways at once: five .text sections where one is
+ * allowed, a symbol name the delink entry does not declare, and undefined
+ * references nothing defines. It can never be enrolled, and until it is bannered
+ * it counts toward the project's matched total on the strength of its filename.
+ *
+ * Recovering it for real needs the ROM's actual derived class, which is the
+ * vtable-naming workstream, not a byte experiment.
+ */
 /* func_0203781c is a compiler-generated this-adjusting virtual-destructor
  * thunk (CodeWarrior _ZThn16_...D1Ev form): ldr ip,[pc,#4]; add r0,r0,ip; b D1
  * The thunk adjusts `this` by -16 (the size of the primary base subobject) then

--- a/src/func_02037d94.c
+++ b/src/func_02037d94.c
@@ -1,3 +1,20 @@
+/* NONMATCHING -- this file does not compile, and cannot become a match as written.
+ *
+ * It reconstructs the thunk's BYTES from a synthetic hierarchy: the classes below
+ * are placeholders (`Base2`, `Derived`) chosen to make mwcc emit a this-adjusting
+ * thunk of the right shape, not the ROM's real types. The object therefore defines
+ * _ZThn16_N7DerivedD0Ev / D1Ev and _ZN7DerivedD0Ev / D1Ev / D2Ev -- five functions,
+ * none of which any any symbols.txt under config/ names -- rather than the single symbol
+ * `func_02037d94` this file claims.
+ *
+ * So it fails eligibility three ways at once: five .text sections where one is
+ * allowed, a symbol name the delink entry does not declare, and undefined
+ * references nothing defines. It can never be enrolled, and until it is bannered
+ * it counts toward the project's matched total on the strength of its filename.
+ *
+ * Recovering it for real needs the ROM's actual derived class, which is the
+ * vtable-naming workstream, not a byte experiment.
+ */
 /* func_02037d94 is a compiler-generated this-adjusting virtual-destructor
  * thunk (CodeWarrior _ZThn16_...D1Ev form): ldr ip,[pc,#4]; add r0,r0,ip; b D1
  * The thunk adjusts `this` by -16 (the size of the primary base subobject) then

--- a/src/func_02037db4.c
+++ b/src/func_02037db4.c
@@ -1,3 +1,20 @@
+/* NONMATCHING -- this file does not compile, and cannot become a match as written.
+ *
+ * It reconstructs the thunk's BYTES from a synthetic hierarchy: the classes below
+ * are placeholders (`Base2`, `Derived`) chosen to make mwcc emit a this-adjusting
+ * thunk of the right shape, not the ROM's real types. The object therefore defines
+ * _ZThn56_N7DerivedD0Ev / D1Ev and _ZN7DerivedD0Ev / D1Ev / D2Ev -- five functions,
+ * none of which any any symbols.txt under config/ names -- rather than the single symbol
+ * `func_02037db4` this file claims.
+ *
+ * So it fails eligibility three ways at once: five .text sections where one is
+ * allowed, a symbol name the delink entry does not declare, and undefined
+ * references nothing defines. It can never be enrolled, and until it is bannered
+ * it counts toward the project's matched total on the strength of its filename.
+ *
+ * Recovering it for real needs the ROM's actual derived class, which is the
+ * vtable-naming workstream, not a byte experiment.
+ */
 /* func_02037db4 is a compiler-generated this-adjusting virtual-destructor
  * thunk (CodeWarrior _ZThn56_...D1Ev form): ldr ip,[pc,#4]; add r0,r0,ip; b D1
  * It adjusts `this` by -56 (size of the primary base subobject) then tail-branches

--- a/src/func_ov002_020cfbdc.cpp
+++ b/src/func_ov002_020cfbdc.cpp
@@ -2,12 +2,12 @@
 // @symbol func_ov002_020cfbdc
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_ClsnResult.h"
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 
 
 extern "C" {
+    extern void func_ov002_020d0948(void*);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
 extern void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);

--- a/src/func_ov004_020aeed8.cpp
+++ b/src/func_ov004_020aeed8.cpp
@@ -2,9 +2,11 @@
 #include "types.h"
 // @symbol func_ov004_020aeed8
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBase_c.h"
+extern "C" {
+    extern void MultiCopy_Int(int*, int*, int);
+}
 // recovered name: dScMgBase_c_OnAimedAtWithEggReturnVec
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */

--- a/src/func_ov004_020af094.cpp
+++ b/src/func_ov004_020af094.cpp
@@ -1,9 +1,15 @@
 //cpp
 #include "types.h"
+extern "C" {
+    extern void func_02019028(void);
+    extern void MultiCopy_Int(int*, int*, int);
+    extern char data_ov004_020bea28[];
+    extern char data_ov004_020beac8[];
+    extern void*data_ov004_020bbf94[];
+}
 // @symbol func_ov004_020af094
 // recovered name: dScMgBase_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 extern "C" void _ZN4CP1527FlushAndInvalidateDataCacheEjj(void *addr, unsigned int size);

--- a/src/func_ov006_020e6e78.cpp
+++ b/src/func_ov006_020e6e78.cpp
@@ -1,8 +1,13 @@
+extern "C" {
+    extern unsigned char data_0209d464;
+    extern int data_ov006_02141a44;
+    extern void func_ov006_020e7508(void);
+    extern void func_ov006_020e759c(void);
+}
 //cpp
 // @symbol func_ov006_020e6e78
 // recovered name: dScMgJump2_c_OnKicked
 /* recovered: renamed to Class_Method, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::OnKicked - recovered from vtable slot identity */
 extern "C" int func_ov004_020ae140(void* self);

--- a/src/func_ov007_020ba05c.c
+++ b/src/func_ov007_020ba05c.c
@@ -1,3 +1,15 @@
+/* NONMATCHING -- compiles, but the result is 0x22c bytes against the ROM's 0x284:
+ * 88 bytes SHORT, so this is an incomplete reconstruction rather than a near-miss.
+ *
+ * Three defects had to be fixed before it would compile at all, and each was a shadow
+ * struct disagreeing with itself: `array24` and `array28` are members of StructObj0 but
+ * were being read off StructObj20, and `f2C` was used on StructAInner without being
+ * declared. The pad split below keeps every later offset where it was (pad1 spanned
+ * 0x0c..0x30, so 0x20 of pad puts f2C at 0x2c and leaves f30 at 0x30).
+ *
+ * Those fixes are right, and they are what exposed the 88-byte gap the compile error
+ * had been hiding.
+ */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -69,7 +81,8 @@ typedef struct StructAInner {
     StructObj0* obj0;
     u8 pad0[4];
     s16* p8;
-    u8 pad1[0x24];
+    u8 pad1[0x20];
+    u32 f2C;
     u32 f30;
     u32 f34;
 } StructAInner;
@@ -111,10 +124,10 @@ int func_ov007_020ba05c(void) {
         s32 check = 0;
         if (obj20->f8 >= 2) {
             s32 sb = b->f3E;
-            u32 sl1 = obj20->array28[obj20->f8 - 2];
+            u32 sl1 = obj0->array28[obj20->f8 - 2];
             u32 lr = (u32)(sb * sb);
             s32 sb_val = (s32)(sl1 >> 12) - (s32)b->fA;
-            u32 sl2 = obj20->array24[obj20->f8 - 2];
+            u32 sl2 = obj0->array24[obj20->f8 - 2];
             s32 r7 = b->f3C;
             s32 sb_sq = sb_val * sb_val;
             s32 sb_acc = r7 * r7 + lr;

--- a/src/func_ov064_02119afc.cpp
+++ b/src/func_ov064_02119afc.cpp
@@ -2,10 +2,10 @@
 #include "types.h"
 // @symbol func_ov064_02119afc
 /* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 extern "C" {
+    extern int data_ov064_0211c944;
 void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* t, const Vector3& v);
 void* _ZN5Actor10FindWithIDEj(unsigned int id);
 s16 Vec3_VertAngle(const Vector3* v1, const Vector3* v0);

--- a/src/func_ov071_02121ba4.cpp
+++ b/src/func_ov071_02121ba4.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov071_02121ba4
 /* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 
 extern "C" {
+    extern void func_ov071_02121b08(void*);
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, const struct Vector3 *v, unsigned int a, int fix, unsigned int b, unsigned int d, unsigned int e);
 

--- a/src/func_ov078_02124cf4.cpp
+++ b/src/func_ov078_02124cf4.cpp
@@ -1,14 +1,15 @@
 //cpp
 // @symbol func_ov078_02124cf4
 /* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 
 struct ActorBase;
 
 extern "C" {
-int WithMeshClsn_IsOnGround(void* self);
+    extern int data_ov078_021270ac;
+    extern int data_ov078_021270ec;
+int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
 void KingBobOmb_SetState(void* c, void* p);
 void func_02012694(int a, int* t);
 void func_ov078_02125c24(void* c, int a);
@@ -23,7 +24,7 @@ extern unsigned char data_0209f220;
 
 extern "C" int func_ov078_02124cf4(unsigned char* thiz)
 {
-    if (WithMeshClsn_IsOnGround(thiz + 0x110) == 0) goto done;
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(thiz + 0x110) == 0) goto done;
     *(int*)(thiz + 0x98) = 0;
     if ((int)(*(int*)(thiz + 0x4d8) - 0x28000) > *(int*)(thiz + 0x60)) {
         func_02012694(0x128, (int*)(thiz + 0x74));

--- a/src/func_ov080_02124088.cpp
+++ b/src/func_ov080_02124088.cpp
@@ -2,12 +2,13 @@
 #include "types.h"
 // @symbol func_ov080_02124088
 /* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 #define LAUND(p) ((void*)((((long long)(int)(p)))))
 
 extern "C" {
+    extern int data_ov080_021283d8[];
+    extern void func_ov080_02124360(void*);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* file, int a, int b, unsigned int e);
 extern void func_0201267c(unsigned int id, const Vector3* v);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& v);

--- a/src/func_ov081_02123910.cpp
+++ b/src/func_ov081_02123910.cpp
@@ -3,7 +3,6 @@
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Enemy.h"
 #include "decl_Player.h"
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 
@@ -21,6 +20,8 @@ struct VObj {
 };
 
 extern "C" {
+    extern void func_ov081_021237ec(void*);
+    extern int func_ov002_020e10a8(void*);
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(void* self, void* cyl, void* player);
 extern short Vec3_HorzAngle(void* a, void* b);

--- a/src/func_ov085_02129dbc.cpp
+++ b/src/func_ov085_02129dbc.cpp
@@ -1,9 +1,11 @@
 //cpp
 // @symbol func_ov085_02129dbc
 /* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+extern "C" {
+    extern int AngleDiff(int, int);
+}
 struct Actor { Actor *ClosestPlayer(); };
 
 extern "C" int Vec3_HorzDist(const void *a, const void *b);

--- a/src/func_ov096_02137088.cpp
+++ b/src/func_ov096_02137088.cpp
@@ -2,11 +2,12 @@
 // @symbol func_ov096_02137088
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_WithMeshClsn.h"
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 extern "C" {
 
+    extern int func_ov002_020de328(void*);
+    extern void func_ov096_02136e54(void*, int);
 extern short Vec3_HorzAngle(const void *a, const void *b);
 extern int Vec3_HorzDist(const void *a, const void *b);
 extern int Vec3_Dist(const void *a, const void *b);

--- a/src/func_ov098_0213a794.cpp
+++ b/src/func_ov098_0213a794.cpp
@@ -1,9 +1,11 @@
 //cpp
 // @symbol func_ov098_0213a794
 /* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+extern "C" {
+    extern void func_ov098_0213a8ec();
+}
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);

--- a/src/func_ov102_0214b248.cpp
+++ b/src/func_ov102_0214b248.cpp
@@ -1,10 +1,10 @@
 //cpp
 // @symbol func_ov102_0214b248
 /* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 extern "C" {
+    extern void func_ov102_0214ae1c(void*);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern void func_0203568c(int *p, int v);
 extern void func_02035684(int *p, int v);
@@ -12,7 +12,7 @@ extern void func_ov002_020ef228(void *c, int arg);
 extern int func_ov102_0214b128(void *c);
 }
 
-namespace Sound { unsigned int PlayLong(unsigned int, unsigned int, unsigned int, Vector3 const &, unsigned int); }
+namespace Sound { unsigned int PlayLong(unsigned int, unsigned int, unsigned int, Vector3 const &, short); }
 
 extern "C" int func_ov102_0214b248(char *c)
 {

--- a/tools/bytegate.py
+++ b/tools/bytegate.py
@@ -14,7 +14,7 @@ that test which cannot be computed from committed data alone.
 The class splits by what it takes to decide it, and the two halves are implemented
 differently on purpose:
 
-  zero-size alias   DERIVED, live, in chaos_db_ci.zero_size_alias_records(). It reads
+  zero-size alias   DERIVED, live, in chaos_db_ci.alias_collision_addresses(). It reads
                     config/**/symbols.txt and nothing else, so it costs nothing in CI
                     and it self-heals in both directions: fix the config and the record
                     returns to the count, match one of the four aliases that are
@@ -28,7 +28,7 @@ differently on purpose:
                     fetches them. There is no compiler in the process that computes the
                     number, so the number has to read a recorded verdict.
 
-A bare name list would not self-heal -- someone fixes one of the 18 and the function
+A bare name list would not self-heal -- someone fixes one of the rows and the function
 stays uncounted until a human remembers this file exists. So each row pins the sha256 of
 the source it was recorded against, and the exclusion lapses the moment the file changes.
 A fix therefore restores the count with no list edit and no compiler. The cost is that a
@@ -36,6 +36,9 @@ cosmetic edit lapses it too, which would re-count a file that still does not bui
 is what tools/test_bytegate.py's staleness check is for, and it fails loudly rather than
 letting the count go quietly wrong. Both failure directions land on the old status quo
 plus a red test, never on a silently smaller-or-larger number.
+
+That property has now been exercised: 17 of the original 18 rows were repaired without
+anyone consulting this file, and every one lapsed on its own. The manifest is down to 1.
 
 What this does NOT do: notice a NEW file that will not build. Nothing in CI can, for the
 same no-compiler reason. `--scan` below is the discovery pass, run with a compiler.


### PR DESCRIPTION
Rebased over the eight PRs that landed while this was open, including **#1534**, which
collides with it directly — see the last commit.

`audit/enrollment_report.md` found 22 functions counted `matched` that the byte gate
reports NO-SYM, and #1534 subtracted them from the published count. 18 of the 22 were
files no compiler in the sweep will build. This branch repairs 15 of those 18 into byte
matches, shows 2 more to be genuine near-misses with measured deltas, and leaves 1 with
a recorded reason.

## What was actually wrong

`include/decl_common.h` declares functions with generic `void*` parameters. A file that
types its arguments properly becomes an illegal `extern "C"` overload of that
declaration, so mwccarm rejects the pair and never reaches codegen. For 12 files the
clash is on the symbol the file itself defines; for 3 it is on a helper they redeclare.
None of them is a bad decompilation — they are correct reconstructions that stopped
compiling when `decl_common.h` grew.

The repair is per-file and minimal: drop the `#include`, restore only the declarations
the body genuinely uses, verbatim from `decl_common.h`, driven by what the compiler says
is missing. Largest restoration in the branch is 5 declarations; most are 1.

Three needed a symbol respelled rather than a declaration restored:

| file | was | is |
|---|---|---|
| `_ZN15TtcRotatingCube13InitResourcesEv.cpp` | bare `extern` in a `//cpp` file, double-mangled to `_Z94_ZN16...` | `extern "C"` |
| `func_ov102_0214b248.cpp` | `Sound::PlayLong(..., unsigned int)` | `..., short)` → `_ZN5Sound8PlayLongEjjjRK7Vector3s` |
| `func_ov078_02124cf4.cpp` | `WithMeshClsn_IsOnGround` | `_ZNK12WithMeshClsn10IsOnGroundEv` |

The **link** is what proves those three, not the byte compare — `match.py` treats
relocated words as wildcards, so a call to the wrong function still byte-matches. All 15
are enrolled here, so the linker checks them from now on.

## The 6 that cannot be matches

Four `src/func_0203*.c` files are synthetic: `struct Derived : RaycastGround, Base2` with
placeholder names, reproducing thunk bytes with fake classes. They can never link. Two
are real near-misses that had been hidden behind their compile errors — fixing the
compile is what revealed each gap:

- `_ZN6Goomba13InitResourcesEv.cpp` — 916 bytes against 912, one instruction over.
  Identical under `-lang c99` and `-lang c++`, so the misplaced `//cpp` marker on line 2
  is a real trap but not this file's problem.
- `func_ov007_020ba05c.c` — 0x22c against 0x284, 88 short.

All six get a `NONMATCHING` banner with the measured delta.

## The #1534 collision

This branch edits 17 of #1534's 18 sha-pinned rows, so on merge every pin lapses:
`tools/bytegate.py` exits 1 and `test_bytegate.py::test_no_row_is_stale` fails. The lapse
is the manifest working as designed, but a lapsed row is indistinguishable from one
nobody re-checked. `--recheck` across all 12 versions says **1 confirmed, 17 to retire**,
so the rows are deleted rather than left to lapse. The manifest goes 18 → 1.

The survivor, `src/func_ov002_020e3e00.cpp`, is not a harder signature problem — the same
repair compiles it. It stays because compiling it exposes calls to
`func_02111b64`/`func_02111b6c`, an address live in four overlays, so
`resolve_placeholders` cannot settle the destination and `check_references` reports a new
unresolvable. That reason is now written into the row.

## Verification

```
rombuild.py -j16 --no-rom   106/106 exact, 100.000000%
                            source-built 10,989   reproducing 10,989   mismatching 0
                            2,024,772 / 2,211,124 = 91.57%
eligible.py                 10,989 / 11,169
bytegate.py                 1 row, 1 live, 0 stale
test_bytegate.py            18 passed
check_references            unresolved 95 (baseline 95)
port_refcheck               393 checked, all resolve
duplicate-sources           11,288 stems, none doubled
attribution                 11,333 tracked, 0 changed, 0 lost
langmode ratchet            PASS
```

Starting figure **91.30%**, measured from `origin/main`'s own delinks rather than quoted
from a PR title. The 15 functions are 5,952 bytes, so the delta is **+0.27pp**.

The sixteenth repair — `func_ov002_020e3e00.cpp` — byte-matched too, but that is not
demonstrable from this branch, since the fix was reverted for the reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT
