### PR TITLE
Name the receiver three Enemy base-ctor spawn sites already pass

### DIFF
--- a/src/ChainChomp_Spawn.cpp
+++ b/src/ChainChomp_Spawn.cpp
@@ -1,7 +1,7 @@
 //cpp
 extern "C" {
 void* _ZN9ActorBasenwEj(unsigned int);
-void _ZN5EnemyC2Ev(void);
+void _ZN5EnemyC2Ev(void*);
 int _ZN25MovingCylinderClsnWithPosC1Ev(void*);
 int _ZN9ModelAnimC1Ev(void*);
 int _ZN11ShadowModelC1Ev(void*);
@@ -15,7 +15,7 @@ extern void func_0203d384();
 void* ChainChomp_Spawn(void){
   char* c = (char*)_ZN9ActorBasenwEj(0x620);
   if(c){
-    _ZN5EnemyC2Ev();
+    _ZN5EnemyC2Ev(c);
     *(int**)c = _ZTV10ChainChomp;
     _ZN25MovingCylinderClsnWithPosC1Ev(c+0x110);
     _ZN9ModelAnimC1Ev(c+0x150);

--- a/src/ChiefChilly_Spawn.cpp
+++ b/src/ChiefChilly_Spawn.cpp
@@ -1,6 +1,6 @@
 //cpp
 extern "C" void* _ZN9ActorBasenwEj(unsigned int sz);
-extern "C" void _ZN5EnemyC2Ev(void);
+extern "C" void _ZN5EnemyC2Ev(void*);
 extern "C" void _ZN25MovingCylinderClsnWithPosC1Ev(void*);
 extern "C" void _ZN12WithMeshClsnC1Ev(void*);
 extern "C" void _ZN14BlendModelAnimC1Ev(void*);
@@ -15,7 +15,7 @@ extern "C" void* ChiefChilly_Spawn(void)
 {
     char* p = (char*)_ZN9ActorBasenwEj(0x504);
     if (p) {
-        _ZN5EnemyC2Ev();
+        _ZN5EnemyC2Ev(p);
         *(void**)p = &_ZTV11ChiefChilly;
         _ZN25MovingCylinderClsnWithPosC1Ev(p + 0x110);
         _ZN12WithMeshClsnC1Ev(p + 0x150);

--- a/src/Wiggler_Spawn.c
+++ b/src/Wiggler_Spawn.c
@@ -1,5 +1,5 @@
 extern void* _ZN9ActorBasenwEj(unsigned int sz);
-extern void _ZN5EnemyC2Ev(void);
+extern void _ZN5EnemyC2Ev(void *p);
 extern int func_020733a8(void *p, int a, int b, void *ctor, void *dtor);
 extern int _ZN12WithMeshClsnC1Ev(void *p);
 extern int _ZN25MovingCylinderClsnWithPosC1Ev(void *p);
@@ -19,7 +19,7 @@ extern int _ZTV7Wiggler[];
 void *Wiggler_Spawn(void){
   char *c = (char *)_ZN9ActorBasenwEj(0x8e8);
   if(c){
-    _ZN5EnemyC2Ev();
+    _ZN5EnemyC2Ev(c);
     *(int**)(c) = _ZTV7Wiggler;
     func_020733a8(c+0x110, 5, 0x64, _ZN9ModelAnimC1Ev, _ZN9ModelAnimD1Ev);
     func_020733a8(c+0x304, 5, 0x14, _ZN15MaterialChangerC1Ev, _ZN15MaterialChangerD1Ev);


### PR DESCRIPTION
Follow-up to #1539, which named the receiver `FaderColor::AdvanceFade` was already
being handed, and to the `Heap::_Destroy` fix before it. #1539's body listed four more
call sites with the same proven shape. Three of them are that shape and are fixed here.
The fourth is not, and the reason it is not is the more interesting result.

## Fixed: three Enemy base-object constructor call sites

`src/Wiggler_Spawn.c`, `src/ChainChomp_Spawn.cpp` and `src/ChiefChilly_Spawn.cpp` each
declared `_ZN5EnemyC2Ev(void)` and called it bare. A C2 base-object constructor cannot
take no receiver, and the ROM call sites supply one. All three open the same way, with
the `bl` preceded only by the `movs` on the `operator new` result and the `beq` that
skips the body:

```
ChiefChilly_Spawn, ov073 0x02121ec8
  +0x008 ldr  r0, [pc, #0xa0]
  +0x00c bl   0x02043444       (_ZN9ActorBasenwEj)
  +0x010 movs r4, r0
  +0x014 beq  0x02121f68
  +0x018 bl   0x020aed98       (_ZN5EnemyC2Ev)
  +0x01c ldr  r1, [pc, #0x90]
  +0x020 add  r0, r4, #0x110
```

`Wiggler_Spawn` (ov034 0x021136a4) is `+0x010 movs r4, r0 / +0x014 beq / +0x018 bl`,
and `ChainChomp_Spawn` (ov014 0x02112d1c) is the same three words at the same offsets.
No argument setup anywhere between the allocation and the branch, because r0 still
holds the object.

The callee is a real base constructor, not a veneer that drops the receiver on the way
through. ov002 0x020aed98 is:

```
  push {r4, lr}
  mov  r4, r0
  bl   0x0201150c        (_ZN5ActorC2Ev)
  ldr  r1, [pc, #0xc]
  mov  r0, r4
  str  r1, [r4]          (vptr store)
  pop  {r4, lr}
  bx   lr
```

The three relocations record `to:0x020aed98 module:overlays(2,7)`, which is ambiguous on
its face, but only ov002's body at that address is a constructor. ov007's is a
five-register loop over a table. ov002 is also where #1044 placed `_ZN5EnemyC2Ev`, and
where `config/arm9/overlays/ov002/delinks.txt` enrolls `src/_ZN5EnemyC2Ev.cpp`.

### Header blast radius: none

`src/_ZN5EnemyC2Ev.cpp` already defines the symbol as `int _ZN5EnemyC2Ev(void* c)`, and
`include/decl_Enemy.h:26` already declares it `extern void _ZN5EnemyC2Ev(void*)`. Nine
sibling `*_Spawn` files already declare it locally with a receiver and pass their
pointer; 67 files reference it in total. These three were the only ones left declaring
it `(void)`.

None of the three includes `decl_Enemy.h`, so each keeps its own file-local declaration
in its own spelling convention (`void *p` in the C file, `void*` in the two C++ files)
and the shared header is not touched. No other translation unit is reached by this
change, so there is nothing here of the `decl_common` redeclaration shape.

### Proof

At the pinned compiler with the build's own flags, the object each file compiles to is
identical before and after the edit: same sha256 over the function's code bytes, same
set of relocation offsets, and MATCH against the ROM both times.

| file | module | addr | size | sha256 of code bytes, before and after |
|---|---|---|---|---|
| `src/Wiggler_Spawn.c` | ov034 | 0x021136a4 | 0x17c | `591fa00c1a35514d5ea930963f8a387c28b8a941fde75ad5f3cfe7c9adc979e6` |
| `src/ChainChomp_Spawn.cpp` | ov014 | 0x02112d1c | 0xf0 | `48851b86981268c036cfba60220b833720a9eab7e5387a9d78106a2cda823a57` |
| `src/ChiefChilly_Spawn.cpp` | ov073 | 0x02121ec8 | 0xc8 | `2dd577516b7ebddbb800d507dca87b5f76ceed6d29cccc43d268bd4fa76c782d` |

All three are pinned to 2004/b56 and are `complete` in their delinks entries.
`tools/build_pin.py` verify with strict relocations reports MATCH before and after, and
`tools/linkcheck.py` reports VERIFIED for all three. Because the emitted object bytes
are literally unchanged, the ROM link cannot be affected by this commit.

## Stopped: MotherPenguin::Behavior, and why

`src/_ZN13MotherPenguin8BehaviorEv.cpp:17` calls `_ZN13RacingPenguin16OnPendingDestroyEv()`
bare, and the shape looks right at first glance:

```
_ZN13MotherPenguin8BehaviorEv, ov018 0x02112480
  +0x000 push {r4, lr}
  +0x004 mov  r4, r0
  +0x008 bl   0x0211235c
```

r0 does hold `this` at the branch. But the named callee is the wrong function.

`MotherPenguin::Behavior` is in ov018. ov014, ov018, ov019 and ov034 all load at base
0x021111a0, so they are mutually exclusive, and a call from ov018 code resolves inside
ov018. `config/arm9/overlays/ov018/relocs.txt:168` agrees:
`from:0x02112488 kind:arm_call to:0x0211235c module:overlay(18)`.

What is at 0x0211235c depends entirely on which overlay is resident:

```
ov018 (the one this file links into), func_ov018_0211235c, 0x3c bytes
  stmdb sp!, {lr}
  sub   sp, sp, #4
  ldr   r1, [r0, #0x370]
  add   r3, r1, #8
  ldr   r1, [r3, #4]
  add   r0, r0, r1, asr #1
  ands  r1, r1, #1
  ldrne r2, [r0]
  ...
  blx   r1

ov019, _ZN13RacingPenguin16OnPendingDestroyEv, 0x4 bytes
  bx lr
```

Different code, different length, different overlay. The repo already has the right
one: `src/func_ov018_0211235c.cpp` is enrolled and complete at
`.text start:0x0211235c end:0x02112398`, and it already spells its receiver,
`extern "C" void func_ov018_0211235c(C *c)`. RacingPenguin's symbols are confined to
ov019, where `RacingPenguin::OnPendingDestroy` is the usual four-byte `bx lr` stub.

So the receiver-naming fix the sweep proposed would have been applied to a callee this
file never calls. Naming the receiver would have made a wrong cross-overlay reference
look deliberate.

No gate can currently see this. All three spellings compile to the same bytes:

| variant | sha256 of code bytes | vs ROM | linkcheck |
|---|---|---|---|
| on main, bare `_ZN13RacingPenguin16OnPendingDestroyEv()` | `aec0c684c764cbea9b786800b35f80a41a84087ec601b7001cb001271939201c` | MATCH | VERIFIED |
| the proposed receiver fix on that same name | `aec0c684...` identical | MATCH | VERIFIED |
| `func_ov018_0211235c((char*)this)`, the correct callee | `aec0c684...` identical | MATCH | VERIFIED |

The byte gate wildcards the relocated word. `tools/reloc_audit.py` compares the resolved
destination *address*, and both symbols sit at 0x0211235c, so the address is right under
either name. `tools/linkcheck.py` writes the resolved address into the slot and compares
the linked bytes, and again the address is right. The only thing wrong is which module
owns that address, and nothing in the chain reads the module.

This is left for a separate change rather than folded in here. It is a name correction
rather than a receiver correction, it deletes the sole use of
`include/decl_RacingPenguin.h` (that header has exactly one includer and one
declaration, both for this call), and it deserves its own review. The variant above is
already proven byte-clean, so the follow-up has a verified recipe.

## Unproven

- Whether other files carry the same wrong-module reference. The check that would find
  them is "does the named symbol exist in the module this file links into", which no
  tool in the tree runs today. Only the four call sites #1539 listed were examined here.
- No full `tools/rombuild.py` was run. It is not load-bearing for this commit: the
  compiled object bytes are byte-identical before and after, so the link has the same
  input it had on main.
- The port side was not touched. `_ZN5EnemyC2Ev` and the three spawn functions do not
  appear in `port/` on main, so there is no host veneer to note in the port ledger for
  these; the ROM callee is a real constructor either way.
