### PR TITLE
class-hierarchy: refuse stale inputs, and give the CONTRADICTED tier a zero case

### DIFF
--- a/docs/class-hierarchy.html
+++ b/docs/class-hierarchy.html
@@ -126,7 +126,7 @@ footer{margin-top:72px; padding-top:18px; border-top:1.5px solid var(--ink);
 <dl class="fields">
 <div class="f"><dt>Source</dt><dd>retail ROM, ARM9 + 103 overlays</dd></div>
 <div class="f"><dt>Classes</dt><dd>429 named by the ROM</dd></div>
-<div class="f"><dt>Edges</dt><dd>413 proven · 54 inferred</dd></div>
+<div class="f"><dt>Edges</dt><dd>413 proven · 56 inferred</dd></div>
 <div class="f"><dt>Deepest chain</dt><dd>5 levels</dd></div>
 <div class="f"><dt>Generated</dt><dd>tools/rtti_hierarchy_page.py</dd></div>
 </dl></div>
@@ -140,11 +140,11 @@ footer{margin-top:72px; padding-top:18px; border-top:1.5px solid var(--ink);
 <div class="scroll"><table><thead><tr><th>Tier</th><th>Count</th><th>What makes it true</th><th>Can it be wrong?</th></tr></thead><tbody>
 <tr><td><strong>Proven</strong></td><td class="m">413 edges</td><td>The class's <code>type_info</code> record holds a pointer to its base's record. The compiler wrote it; this is read, not inferred.</td><td>Only if the pointer was misread. 0 of 413 are unresolved.</td></tr>
 <tr><td><strong>Proven root</strong></td><td class="m">24 classes</td><td>A <code>__class_type_info</code> record — the ABI's own encoding for “no base”.</td><td>No. The record kind is the statement.</td></tr>
-<tr><td><strong>Inferred</strong></td><td class="m">54 classes</td><td>No <code>type_info</code> exists, so the base comes from vptr stores in the constructor/destructor chain.</td><td>Yes. A shim or an inlined base constructor can mislead it.</td></tr>
-<tr><td><strong>Contradicted</strong></td><td class="m">24 classes</td><td>The repo's header names a real ancestor, but not the immediate base. The ROM names the immediate one.</td><td>The ROM is right by construction; the header is the error.</td></tr>
+<tr><td><strong>Inferred</strong></td><td class="m">56 classes</td><td>No <code>type_info</code> exists, so the base comes from vptr stores in the constructor/destructor chain.</td><td>Yes. A shim or an inlined base constructor can mislead it.</td></tr>
+<tr><td><strong>Contradicted</strong></td><td class="m">0 classes</td><td>The repo's header names a real ancestor, but not the immediate base. The ROM names the immediate one.</td><td>The ROM is right by construction; the header is the error.</td></tr>
 <tr><td><strong>Unplaced</strong></td><td class="m">4 classes</td><td>Known to the repo, no <code>type_info</code>, and no vptr chain placed it.</td><td>Nothing is claimed, so nothing can be wrong.</td></tr>
 </tbody></table></div>
-<div class="note">The ROM stores 429 type_info records and 413 base pointers, and <strong>every one of those pointers resolves</strong> — 183 of them across an overlay boundary. Where this page is silent it is because the ROM is silent, not because the reading was hard.</div>
+<div class="note">The ROM stores 429 type_info records and 413 base pointers, and <strong>every one of those pointers resolves</strong> — 293 of them across an overlay boundary. Where this page is silent it is because the ROM is silent, not because the reading was hard.</div>
 </section><section><div class="sec-h"><span class="sec-n">§2</span><h2>The spine</h2></div>
 <p>Of the 429 classes, 338 hang off a single root. Strip out everything with fewer than two children and the framework EAD actually built is four levels deep and fits on a screen.</p>
 <div class="tree"><span class="dim"></span><span class="cls pv">fBase_c</span><span class="cnt">  337 below</span>
@@ -177,48 +177,48 @@ footer{margin-top:72px; padding-top:18px; border-top:1.5px solid var(--ink);
 </tbody></table></div>
 <details><summary>dBgActor_c — 101 direct children, 132 in the subtree</summary><div class="tree"><span class="dim"></span><span class="cls pv">dBgActor_c</span><span class="cnt">  132 below</span>
 <span class="dim">├─ </span><span class="cls pv">daObjKaitendai_c</span><span class="cnt">  5 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjBk_Ukisima_c</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjFl_Koma_D_c</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjKm3_Kaitendai_c</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjRc_Kaitendai_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daObjWc_Obj07_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjBk_Ukisima_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjFl_Koma_D_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjKm3_Kaitendai_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjRc_Kaitendai_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daObjWc_Obj07_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjFallBlock_c</span><span class="cnt">  4 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjBk_Fall_Block_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjBk_Fall_Block_c</span>
 │  <span class="dim">├─ </span><span class="cls pv">daObjFl_Fall_Block_c</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjKm2_Fall_Block_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjKm2_Fall_Block_c</span>
 │  <span class="dim">└─ </span><span class="cls pv">daObjTh_Fall_Block_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjDorifu_c</span><span class="cnt">  3 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjKm1_Dorifu_c</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjKm3_Dorifu_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daObjRc_Dorifu_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjKm1_Dorifu_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjKm3_Dorifu_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daObjRc_Dorifu_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjFloatBoard_c</span><span class="cnt">  3 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjKi_Ita_c</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjWcObj01_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daObjWcObj06_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjKi_Ita_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjWcObj01_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daObjWcObj06_c</span>
 <span class="dim">├─ </span><span class="cls pv">dPathLiftActor_c</span><span class="cnt">  2 below</span>
 │  <span class="dim">├─ </span><span class="cls pv">daObjPathLift_c</span>
 │  <span class="dim">└─ </span><span class="cls pv">daObjRcCarpet_c</span>
 <span class="dim">├─ </span><span class="cls pv">daDsnBase_c</span><span class="cnt">  2 below</span>
 │  <span class="dim">├─ </span><span class="cls pv">daDkk_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daDsn_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daDsn_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjGuragura_c</span><span class="cnt">  2 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjFl_Gura_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daObjKm2_Gura_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjFl_Gura_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daObjKm2_Gura_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjKuruma_c</span><span class="cnt">  2 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjKm1_Kuruma_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjKm1_Kuruma_c</span>
 │  <span class="dim">└─ </span><span class="cls pv">daObjKm3_Kuruma_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjKurumajiku_c</span><span class="cnt">  2 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjKm1_Kurumajiku_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjKm1_Kurumajiku_c</span>
 │  <span class="dim">└─ </span><span class="cls pv">daObjKm3_Kurumajiku_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjMaruta_c</span><span class="cnt">  2 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjFlMaruta_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daObjHmMaruta_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjFlMaruta_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daObjHmMaruta_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjSwdoor_c</span><span class="cnt">  2 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjBSwdoor_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daObjCvShutter_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjBSwdoor_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daObjCvShutter_c</span>
 <span class="dim">├─ </span><span class="cls pv">daObjUkiyuka_c</span><span class="cnt">  2 below</span>
-│  <span class="dim">├─ </span><span class="cls ct">daObjFl_Ukiyuka_c</span>
-│  <span class="dim">└─ </span><span class="cls ct">daObjKm2_Ukishima_c</span>
+│  <span class="dim">├─ </span><span class="cls pv">daObjFl_Ukiyuka_c</span>
+│  <span class="dim">└─ </span><span class="cls pv">daObjKm2_Ukishima_c</span>
 <span class="dim">├─ </span><span class="cls pv">daDgr_c</span>
 <span class="dim">├─ </span><span class="cls pv">daDpLift_c</span>
 <span class="dim">├─ </span><span class="cls pv">daIwante_c</span>
@@ -322,7 +322,9 @@ footer{margin-top:72px; padding-top:18px; border-top:1.5px solid var(--ink);
 <span class="inf">├┈ TtcConveyorBeltLarge</span><span class="cnt">  inferred · high</span>
 <span class="inf">├┈ WDW_Water</span><span class="cnt">  inferred · high</span>
 <span class="inf">├┈ WallSign</span><span class="cnt">  inferred · high</span>
-<span class="inf">└┈ dBgActor_c</span><span class="cnt">  inferred · medium</span></div></details>
+<span class="inf">├┈ daDsnBase_c</span><span class="cnt">  inferred · high</span>
+<span class="inf">├┈ daObjFallBlock_c</span><span class="cnt">  inferred · high</span>
+<span class="inf">└┈ daObjMaruta_c</span><span class="cnt">  inferred · high</span></div></details>
 <details><summary>dEnemyBase_c — 55 direct children, 60 in the subtree</summary><div class="tree"><span class="dim"></span><span class="cls pv">dEnemyBase_c</span><span class="cnt">  60 below</span>
 <span class="dim">├─ </span><span class="cls pv">daOts_c</span><span class="cnt">  3 below</span>
 │  <span class="dim">├─ </span><span class="cls pv">daBDonketu_c</span>
@@ -440,41 +442,16 @@ footer{margin-top:72px; padding-top:18px; border-top:1.5px solid var(--ink);
 <p>Exactly 6 classes use multiple inheritance, and the ROM records the byte offset of each base subobject. The base at <code>+0x0</code> is the primary — and it is <em>not</em> always the first one listed, which is a trap that has already cost this project one wrong reading.</p>
 <figure><svg viewBox="0 0 900 448" role="img" aria-label="Base subobject offsets for the six classes with multiple inheritance"><text x="0" y="16" font-size="11" font-weight="700" letter-spacing="1.3" fill="var(--mute)">DERIVED CLASS</text><text x="210" y="16" font-size="11" font-weight="700" letter-spacing="1.3" fill="var(--mute)">BASE SUBOBJECTS, PLACED AT THEIR RECORDED OFFSET</text><line x1="0" y1="26" x2="900" y2="26" stroke="var(--rule)"/><text x="0" y="50" font-size="13" font-family="var(--mono)" font-weight="600" fill="var(--ink)">dBgCh_Lin</text><rect x="210.0" y="32" width="64.0" height="24" rx="2" fill="var(--proven-bg)" stroke="var(--proven)" stroke-width="1.6"/><text x="218.0" y="48" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dBgCh</text><text x="210.0" y="27" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x0</text><rect x="243.6" y="32" width="64.0" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="251.6" y="48" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dBgPi</text><text x="243.6" y="27" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x10</text><rect x="327.6" y="32" width="75.2" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="335.6" y="48" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dM3dGLin</text><text x="327.6" y="27" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x38</text><line x1="0" y1="68" x2="900" y2="68" stroke="var(--rule-soft)"/><text x="0" y="114" font-size="13" font-family="var(--mono)" font-weight="600" fill="var(--ink)">dBgCh_SphCrr</text><rect x="210.0" y="96" width="64.0" height="24" rx="2" fill="var(--proven-bg)" stroke="var(--proven)" stroke-width="1.6"/><text x="218.0" y="112" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dBgCh</text><text x="210.0" y="91" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x0</text><rect x="243.6" y="96" width="64.0" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="251.6" y="112" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dBgPi</text><text x="243.6" y="91" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x10</text><rect x="327.6" y="96" width="75.2" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="335.6" y="112" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dM3dGSph</text><text x="327.6" y="91" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x38</text><line x1="0" y1="132" x2="900" y2="132" stroke="var(--rule-soft)"/><text x="0" y="178" font-size="13" font-family="var(--mono)" font-weight="600" fill="var(--ink)">dBgCh_Gnd</text><rect x="210.0" y="160" width="64.0" height="24" rx="2" fill="var(--proven-bg)" stroke="var(--proven)" stroke-width="1.6"/><text x="218.0" y="176" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dBgCh</text><text x="210.0" y="155" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x0</text><rect x="243.6" y="160" width="64.0" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="251.6" y="176" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dBgPi</text><text x="243.6" y="155" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x10</text><line x1="0" y1="196" x2="900" y2="196" stroke="var(--rule-soft)"/><text x="0" y="242" font-size="13" font-family="var(--mono)" font-weight="600" fill="var(--ink)">dExtAnmModel_c</text><rect x="210.0" y="224" width="141.8" height="24" rx="2" fill="var(--proven-bg)" stroke="var(--proven)" stroke-width="1.6"/><text x="218.0" y="240" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dExtSimpleModel_c</text><text x="210.0" y="219" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x0</text><rect x="378.0" y="224" width="127.0" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="386.0" y="240" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dExtFrameCtrl_c</text><text x="378.0" y="219" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x50</text><line x1="0" y1="260" x2="900" y2="260" stroke="var(--rule-soft)"/><text x="0" y="306" font-size="13" font-family="var(--mono)" font-weight="600" fill="var(--ink)">daDemo_c::anmModel_c</text><rect x="210.0" y="288" width="119.6" height="24" rx="2" fill="var(--proven-bg)" stroke="var(--proven)" stroke-width="1.6"/><text x="218.0" y="304" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dExtAnmModel_c</text><text x="210.0" y="283" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x0</text><rect x="420.0" y="288" width="141.8" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="428.0" y="304" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">daDemo_c::param_c</text><text x="420.0" y="283" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x64</text><line x1="0" y1="324" x2="900" y2="324" stroke="var(--rule-soft)"/><text x="0" y="370" font-size="13" font-family="var(--mono)" font-weight="600" fill="var(--ink)">daDemo_c::simpleModel_c</text><rect x="210.0" y="352" width="141.8" height="24" rx="2" fill="var(--proven-bg)" stroke="var(--proven)" stroke-width="1.6"/><text x="218.0" y="368" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">dExtSimpleModel_c</text><text x="210.0" y="347" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x0</text><rect x="378.0" y="352" width="141.8" height="24" rx="2" fill="none" stroke="var(--proven)" stroke-width="1"/><text x="386.0" y="368" font-size="11.5" font-family="var(--mono)" fill="var(--proven)">daDemo_c::param_c</text><text x="378.0" y="347" font-size="10" font-family="var(--mono)" fill="var(--mute)">+0x50</text><line x1="0" y1="388" x2="900" y2="388" stroke="var(--rule-soft)"/></svg><figcaption>Base subobjects drawn at their recorded offsets. The filled box is the primary base at offset 0. <code>dExtAnmModel_c</code> lists <code>dExtFrameCtrl_c</code> (+0x50) before <code>dExtSimpleModel_c</code> (+0x0): list order is not offset order.</figcaption></figure>
 </section><section><div class="sec-h"><span class="sec-n">§5</span><h2>Where the repo's headers are wrong</h2></div>
-<p>24 classes have a header naming a base that is a genuine ancestor but not the immediate one — the chain was flattened. Every one is in the Platform family, and each names an intermediate class the repo has never modelled. There are no outright contradictions: not one header names a class that is absent from the ROM's ancestor chain.</p>
-<div class="scroll"><table><thead><tr><th>Class (ROM)</th><th>Repo calls it</th><th>Repo's base</th><th>Actual base</th></tr></thead><tbody>
-<tr><td class="m">daDsn_c</td><td class="m">Thwomp</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daDsnBase_c</td></tr>
-<tr><td class="m">daObjRc_Dorifu_c</td><td class="m">daObjRc_Dorifu_c</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjDorifu_c</td></tr>
-<tr><td class="m">daObjKm1_Dorifu_c</td><td class="m">daObjKm1_Dorifu_c</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjDorifu_c</td></tr>
-<tr><td class="m">daObjKm3_Dorifu_c</td><td class="m">RickshawPlatformBs</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjDorifu_c</td></tr>
-<tr><td class="m">daObjBk_Fall_Block_c</td><td class="m">FallBlockWf</td><td class="m" style="color:var(--contra)">dBgActor_c</td><td class="m" style="color:var(--proven)">daObjFallBlock_c</td></tr>
-<tr><td class="m">daObjKm2_Fall_Block_c</td><td class="m">FallBlockBfs</td><td class="m" style="color:var(--contra)">dBgActor_c</td><td class="m" style="color:var(--proven)">daObjFallBlock_c</td></tr>
-<tr><td class="m">daObjKi_Ita_c</td><td class="m">FloatOnWaterPlatformJrb</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjFloatBoard_c</td></tr>
-<tr><td class="m">daObjWcObj01_c</td><td class="m">FloatOnWaterPlatformWdwSquare</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjFloatBoard_c</td></tr>
-<tr><td class="m">daObjWcObj06_c</td><td class="m">FloatOnWaterPlatformWdwRectangle</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjFloatBoard_c</td></tr>
-<tr><td class="m">daObjKm2_Gura_c</td><td class="m">TiltingPlatformBfs</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjGuragura_c</td></tr>
-<tr><td class="m">daObjFl_Gura_c</td><td class="m">TiltingPlatformLll</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjGuragura_c</td></tr>
-<tr><td class="m">daObjBk_Ukisima_c</td><td class="m">RotatingPlatformWf</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjKaitendai_c</td></tr>
-<tr><td class="m">daObjFl_Koma_D_c</td><td class="m">RotatingPlatformLll</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjKaitendai_c</td></tr>
-<tr><td class="m">daObjWc_Obj07_c</td><td class="m">RotatingPlatformWdw</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjKaitendai_c</td></tr>
-<tr><td class="m">daObjRc_Kaitendai_c</td><td class="m">RotatingPlatformRr</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjKaitendai_c</td></tr>
-<tr><td class="m">daObjKm3_Kaitendai_c</td><td class="m">RickshawBs</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjKaitendai_c</td></tr>
-<tr><td class="m">daObjKm1_Kuruma_c</td><td class="m">RickshawPlatformBdw</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjKuruma_c</td></tr>
-<tr><td class="m">daObjKm1_Kurumajiku_c</td><td class="m">RickshawBdw</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjKurumajiku_c</td></tr>
-<tr><td class="m">daObjFlMaruta_c</td><td class="m">RollingLogLll</td><td class="m" style="color:var(--contra)">dBgActor_c</td><td class="m" style="color:var(--proven)">daObjMaruta_c</td></tr>
-<tr><td class="m">daObjHmMaruta_c</td><td class="m">RollingLogTtm</td><td class="m" style="color:var(--contra)">dBgActor_c</td><td class="m" style="color:var(--proven)">daObjMaruta_c</td></tr>
-<tr><td class="m">daObjBSwdoor_c</td><td class="m">ShutterBob</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjSwdoor_c</td></tr>
-<tr><td class="m">daObjCvShutter_c</td><td class="m">ShutterHmc</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjSwdoor_c</td></tr>
-<tr><td class="m">daObjFl_Ukiyuka_c</td><td class="m">FloatingFloorLllSmall</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjUkiyuka_c</td></tr>
-<tr><td class="m">daObjKm2_Ukishima_c</td><td class="m">FloatingFloorBfs</td><td class="m" style="color:var(--contra)">Platform</td><td class="m" style="color:var(--proven)">daObjUkiyuka_c</td></tr>
-</tbody></table></div>
-<div class="note">Those 24 rows collapse to <strong>11 missing intermediate classes</strong>, not 24 separate mistakes: <code>daObjKaitendai_c</code> (5), <code>daObjFloatBoard_c</code> (3), <code>daObjDorifu_c</code> (3), <code>daObjSwdoor_c</code> (2), <code>daObjFallBlock_c</code> (2), <code>daObjUkiyuka_c</code> (2), <code>daObjMaruta_c</code> (2), <code>daObjGuragura_c</code> (2), <code>daObjKurumajiku_c</code> (1), <code>daObjKuruma_c</code> (1), <code>daDsnBase_c</code> (1). Modelling those 11 is the single highest-yield correction available to the hierarchy.</div>
+<p><strong>Nowhere.</strong> Every class the repo both names and holds a belief about names the <em>immediate</em> base the ROM records. Not one header names a class absent from the ROM's ancestor chain, and — the weaker failure this section was built to catch — not one names a genuine ancestor further up the chain than the real parent.</p>
+<p>The chain-flattening this section reports comes from modelling a class's grandparent as its parent, which happens when the intermediate has no header and the evidence for the edge is a destructor vptr store that skips it. It is therefore retired by writing the intermediate down, not by correcting the children.</p>
+<div class="note">Empty because the finding was acted on, not because the test was relaxed: the same comparison still runs against all 429 records. 201 of them are parented by a hand-written <code>struct D : B</code> in a de-bannered header rather than by a base pointer the ROM supplied, and those are the only rows that <em>can</em> disagree with the ROM. None does.</div>
 </section><section><div class="sec-h"><span class="sec-n">§6</span><h2>What is still guessed</h2></div>
-<p>58 classes the repo knows have no <code>type_info</code> record at all. They are not polymorphic, or their vtable was never emitted, so RTTI cannot speak to them and their placement rests entirely on constructor evidence. 54 of them have an inferred base; 4 have none.</p>
+<p>60 classes the repo knows have no <code>type_info</code> record at all. They are not polymorphic, or their vtable was never emitted, so RTTI cannot speak to them and their placement rests entirely on constructor evidence. 56 of them have an inferred base; 4 have none.</p>
 <div class="scroll"><table><thead><tr><th>Status</th><th>Count</th><th>Classes</th></tr></thead><tbody>
-<tr><td style="color:var(--inferred)"><strong>Inferred base</strong></td><td class="n">54</td><td class="m">BlueFlame, BooCage, BowserFireSeaArena, Bullet, Chuckya, Clam, ClockPaintingHandShort, Cloud, DorrieCap, EnemySwitchTag, Fireball, Flag, FlyGuy, Fwoosh, HugeWater, IceBlock, JetStream, Key, LakituBro, LightBeam, MansionSteps, MegaMushroomCreateTag, MetalNet, MontyMole, MotherPenguin, Number, OneUpLogo, PoleLift, PowerStar, RabbitKey, RacingPenguin, RotatingUpDownPlatform, RotatingUpDownPlatformUtm, ShipWater, ShipWing, SignPost, SlideDecorationSilverStar, Snowball, Snufit, Spindrift, StarDoor, SwitchActivatedPlank, Swoop, Toad, TowerStep, TreasureChest, TtcConveyorBeltLarge, WDW_Water, WallSign, WaterBomb, WaterRing, Whirlpool, dBgActor_c, daOts_c</td></tr>
+<tr><td style="color:var(--inferred)"><strong>Inferred base</strong></td><td class="n">56</td><td class="m">BlueFlame, BooCage, BowserFireSeaArena, Bullet, Chuckya, Clam, ClockPaintingHandShort, Cloud, DorrieCap, EnemySwitchTag, Fireball, Flag, FlyGuy, Fwoosh, HugeWater, IceBlock, JetStream, Key, LakituBro, LightBeam, MansionSteps, MegaMushroomCreateTag, MetalNet, MontyMole, MotherPenguin, Number, OneUpLogo, PoleLift, PowerStar, RabbitKey, RacingPenguin, RotatingUpDownPlatform, RotatingUpDownPlatformUtm, ShipWater, ShipWing, SignPost, SlideDecorationSilverStar, Snowball, Snufit, Spindrift, StarDoor, SwitchActivatedPlank, Swoop, Toad, TowerStep, TreasureChest, TtcConveyorBeltLarge, WDW_Water, WallSign, WaterBomb, WaterRing, Whirlpool, daDsnBase_c, daObjFallBlock_c, daObjMaruta_c, daOts_c</td></tr>
 <tr><td><strong>No placement</strong></td><td class="n">4</td><td class="m">FaderBrightness, FaderColor, RaycastGround, WithMeshClsn</td></tr>
 </tbody></table></div>
-<p>Separately, 84 ROM classes have no name in the repo at all — the ROM knows them, the project has never given them a header. They are proven within this graph and invisible outside it.</p>
+<p>Separately, 76 ROM classes have no name in the repo at all — the ROM knows them, the project has never given them a header. They are proven within this graph and invisible outside it.</p>
 </section><section><div class="sec-h"><span class="sec-n">§7</span><h2>What this document cannot tell you</h2></div>
 <p>The ROM's RTTI carries class <em>names</em> and base <em>pointers</em>. That is all it carries. Specifically:</p>
 <div class="scroll"><table><thead><tr><th>Not available</th><th>Why</th></tr></thead><tbody>
@@ -482,7 +459,7 @@ footer{margin-top:72px; padding-top:18px; border-top:1.5px solid var(--ink);
 <tr><td><strong>Parameter types</strong></td><td>The <code>type_info</code> kinds that encode a signature (<code>__function_type_info</code>, <code>__pointer_type_info</code>) were never linked in — this program never does <code>typeid</code> on a function type.</td></tr>
 <tr><td><strong>Field names or layouts</strong></td><td>RTTI records a base's <em>offset</em>, never its members. Sizes come from the <code>operator new</code> literal at each call site instead.</td></tr>
 <tr><td><strong>Original filenames</strong></td><td>Exactly one <code>__FILE__</code> string survives ROM-wide — <code>isdoverlay.c</code>, Nintendo's debugger SDK. Game code was built with asserts stripped.</td></tr>
-<tr><td><strong>Non-polymorphic classes</strong></td><td>A class with no virtual function gets no vtable and no record. The 58 inferred classes in §6 are exactly this population.</td></tr>
+<tr><td><strong>Non-polymorphic classes</strong></td><td>A class with no virtual function gets no vtable and no record. The 60 inferred classes in §6 are exactly this population.</td></tr>
 </tbody></table></div></section>
 <footer>Generated by <code>tools/rtti_hierarchy_page.py</code> from <code>build/rtti.json</code>, <code>build/rtti_reconcile.json</code> and <code>build/evidence_hierarchy.json</code>. Every count, edge and offset on this page is joined at generation time; nothing is typed by hand. Re-run <code>tools/rtti_extract.py --check</code> to re-prove the census before trusting a number here.</footer>
 </div>

--- a/tools/rtti_hierarchy_page.py
+++ b/tools/rtti_hierarchy_page.py
@@ -8,21 +8,27 @@ each edge, what makes it true.
 Three evidence tiers, and the distinction is the whole point:
 
     PROVEN       the ROM's type_info record holds a pointer to the base's record.
-                 Read, not inferred.  405 edges + 24 records the ROM calls roots.
+                 Read, not inferred.
     INFERRED     no type_info record exists (the class is not polymorphic, or its
                  vtable was never emitted), and the base comes from
-                 evidence_hierarchy.py reading ctor/dtor vptr chains.  58 classes.
+                 evidence_hierarchy.py reading ctor/dtor vptr chains.
     CONTRADICTED the repo's own header names a class that IS on the ROM's ancestor
-                 chain but is not the immediate base.  24 classes, all in the
-                 Platform family, and rtti_reconcile.py calls this `flattened`.
+                 chain but is not the immediate base -- rtti_reconcile.py calls this
+                 `flattened`.  Currently EMPTY, and §5 has a zero case that says so
+                 in words; do not assume a count here is non-zero.
+
+No tier count is written down in this file on purpose.  They move every time headers
+land, and a stale number in a docstring is how a reader ends up trusting a page that
+disagrees with it.  Run `--check` to print the live ones.
 
 Nothing on the page is typed by hand except the glosses, which come from
 config/rom-name-glossary.json and carry their own confidence.  Every count, edge and
-offset is joined at generation time from:
+offset is joined at generation time.  The inputs MUST be regenerated in this order,
+because each reads the ones above it and load() now refuses a build that was not:
 
     build/rtti.json                  tools/rtti_extract.py  (gated with --check)
-    build/rtti_reconcile.json        tools/rtti_reconcile.py
     build/evidence_hierarchy.json    tools/evidence_hierarchy.py
+    build/rtti_reconcile.json        tools/rtti_reconcile.py
     build/tu_names.json              tools/tu_names.py       (optional)
 
 Usage:
@@ -53,12 +59,51 @@ E = html.escape
 # data
 # --------------------------------------------------------------------------
 
+# build/ dependency order.  Each generator READS the ones above it, so a file older
+# than an input was produced from a state that no longer exists.
+#
+#   rtti.json                rtti_extract.py        <- the ROM
+#   evidence_hierarchy.json  evidence_hierarchy.py  <- include/, src/, rtti.json
+#   rtti_reconcile.json      rtti_reconcile.py      <- rtti.json, evidence_hierarchy.json
+#
+# This is checked because getting it wrong is silent and convincing.  Running
+# rtti_reconcile BEFORE evidence_hierarchy joins fresh ROM records against a stale
+# hierarchy and produces a §5 full of CONTRADICTED rows -- rows that accuse headers
+# which, read on disk, name exactly the base the ROM names.  The page renders it as
+# "where the repo's headers are wrong" and every count on it is internally consistent.
+# The old --check passed on that state, because it only asked whether the files parse.
+STAGES = [("rtti.json", RTTI, "rtti_extract.py"),
+          ("evidence_hierarchy.json", EVIDENCE, "evidence_hierarchy.py"),
+          ("rtti_reconcile.json", RECONCILE, "rtti_reconcile.py")]
+
+
+def check_order():
+    """Names of the stages that are older than something they were built from."""
+    stale = []
+    for i, (name, path, gen) in enumerate(STAGES):
+        newer = [STAGES[j][0] for j in range(i)
+                 if STAGES[j][1].stat().st_mtime > path.stat().st_mtime]
+        if newer:
+            stale.append((name, gen, newer))
+    return stale
+
+
 def load():
     missing = [p for p in (RTTI, RECONCILE, EVIDENCE) if not p.is_file()]
     if missing:
-        sys.exit("missing: %s\nrun rtti_extract.py, rtti_reconcile.py, "
-                 "evidence_hierarchy.py first"
+        sys.exit("missing: %s\nrun rtti_extract.py, evidence_hierarchy.py, "
+                 "rtti_reconcile.py first (in that order)"
                  % ", ".join(str(p.relative_to(REPO)) for p in missing))
+    stale = check_order()
+    if stale:
+        sys.exit("\n".join(
+            ["stale inputs -- these were built before something they read:"]
+            + ["  %s is older than %s; re-run tools/%s"
+               % (name, ", ".join(newer), gen) for name, gen, newer in stale]
+            + ["", "The generators must run in dependency order:",
+               "  python tools/rtti_extract.py --check",
+               "  python tools/evidence_hierarchy.py",
+               "  python tools/rtti_reconcile.py"]))
     d = {
         "rtti": json.loads(RTTI.read_text(encoding="utf-8")),
         "rec": json.loads(RECONCILE.read_text(encoding="utf-8")),
@@ -350,6 +395,11 @@ def build(d):
     st = rec["stats"]
     n_edges = len(d["rtti"]["edges"])
     n_rec = len(g.name)
+    n_unresolved = len(d["rtti"]["unresolved"])
+    # Joined, not typed.  This was hardcoded as 183 and the true figure had reached 293
+    # -- on a page whose footer says nothing on it is typed by hand.
+    n_cross = sum(1 for e in d["rtti"]["edges"]
+                  if g.module[e["derived_key"]] != g.module[e["base_key"]])
 
     H = []
     A = H.append
@@ -393,7 +443,8 @@ def build(d):
         ("Proven", "%d edges" % n_edges,
          "The class's <code>type_info</code> record holds a pointer to its base's "
          "record. The compiler wrote it; this is read, not inferred.",
-         "Only if the pointer was misread. 0 of %d are unresolved." % n_edges),
+         "Only if the pointer was misread. %d of %d are unresolved."
+         % (n_unresolved, n_edges)),
         ("Proven root", "%d classes" % len(g.roots),
          "A <code>__class_type_info</code> record — the ABI's own encoding for "
          "“no base”.",
@@ -414,9 +465,12 @@ def build(d):
           "<td>%s</td></tr>" % (E(tier), E(cnt), how, wrong))
     A("</tbody></table></div>")
     A('<div class="note">The ROM stores %d type_info records and %d base pointers, '
-      "and <strong>every one of those pointers resolves</strong> — 183 of them across "
-      "an overlay boundary. Where this page is silent it is because the ROM is "
-      "silent, not because the reading was hard.</div>" % (n_rec, n_edges))
+      "and <strong>%s</strong> — %d of them across an overlay boundary. Where this "
+      "page is silent it is because the ROM is silent, not because the reading was "
+      "hard.</div>"
+      % (n_rec, n_edges,
+         "every one of those pointers resolves" if not n_unresolved
+         else "%d of those pointers do not resolve" % n_unresolved, n_cross))
 
     # ---- §2 spine
     A('</section><section><div class="sec-h"><span class="sec-n">§2</span>'
@@ -491,30 +545,61 @@ def build(d):
       % mi_diagram(g))
 
     # ---- §5 contradicted
+    #
+    # This section has a zero case and it is not cosmetic.  The prose used to assume a
+    # non-zero count unconditionally and degenerated into "Those 0 rows collapse to 0
+    # missing intermediate classes, not 0 separate mistakes: . Modelling those 0 is the
+    # single highest-yield correction available to the hierarchy" -- a dangling list and
+    # a recommendation to do nothing, rendered with total confidence.  An empty finding
+    # is a result, so it gets written as one.
     A('</section><section><div class="sec-h"><span class="sec-n">§5</span>'
       "<h2>Where the repo's headers are wrong</h2></div>")
-    A("<p>%d classes have a header naming a base that is a genuine ancestor but not "
-      "the immediate one — the chain was flattened. Every one is in the Platform "
-      "family, and each names an intermediate class the repo has never modelled. "
-      "There are no outright contradictions: not one header names a class that is "
-      "absent from the ROM's ancestor chain.</p>" % len(contra))
-    A('<div class="scroll"><table><thead><tr><th>Class (ROM)</th>'
-      "<th>Repo calls it</th><th>Repo's base</th><th>Actual base</th>"
-      "</tr></thead><tbody>")
-    for r in sorted(by_verdict["flattened"], key=lambda x: x["rom_bases"][0]):
-        A('<tr><td class="m">%s</td><td class="m">%s</td>'
-          '<td class="m" style="color:var(--contra)">%s</td>'
-          '<td class="m" style="color:var(--proven)">%s</td></tr>'
-          % (E(r["rom_name"]), E(r["tree_name"] or "—"), E(r["tree_base"] or "—"),
-             E(", ".join(r["rom_bases"]))))
-    A("</tbody></table></div>")
-    inter = collections.Counter(r["rom_bases"][0] for r in by_verdict["flattened"])
-    A('<div class="note">Those %d rows collapse to <strong>%d missing intermediate '
-      "classes</strong>, not %d separate mistakes: %s. Modelling those %d is the "
-      "single highest-yield correction available to the hierarchy.</div>"
-      % (len(contra), len(inter), len(contra),
-         ", ".join("<code>%s</code> (%d)" % (E(k), v) for k, v in inter.most_common()),
-         len(inter)))
+    if not contra:
+        # Joined, like everything else: how many agreements rest on a hand-written base
+        # clause rather than on a belief the ROM itself supplied.
+        by_hand = sum(1 for r in rows
+                      if r["verdict"].startswith("agree")
+                      and "reference_header" in (r["tree_sources"] or []))
+        A("<p><strong>Nowhere.</strong> Every class the repo both names and holds a "
+          "belief about names the <em>immediate</em> base the ROM records. Not one "
+          "header names a class absent from the ROM's ancestor chain, and — the "
+          "weaker failure this section was built to catch — not one names a genuine "
+          "ancestor further up the chain than the real parent.</p>")
+        A("<p>The chain-flattening this section reports comes from modelling a class's "
+          "grandparent as its parent, which happens when the intermediate has no "
+          "header and the evidence for the edge is a destructor vptr store that skips "
+          "it. It is therefore retired by writing the intermediate down, not by "
+          "correcting the children.</p>")
+        A('<div class="note">Empty because the finding was acted on, not because the '
+          "test was relaxed: the same comparison still runs against all %d records. "
+          "%d of them are parented by a hand-written <code>struct D : B</code> in a "
+          "de-bannered header rather than by a base pointer the ROM supplied, and "
+          "those are the only rows that <em>can</em> disagree with the ROM. None "
+          "does.</div>" % (n_rec, by_hand))
+    else:
+        A("<p>%d classes have a header naming a base that is a genuine ancestor but "
+          "not the immediate one — the chain was flattened. Each names an "
+          "intermediate class the repo has never modelled. There are no outright "
+          "contradictions: not one header names a class that is absent from the ROM's "
+          "ancestor chain.</p>" % len(contra))
+        A('<div class="scroll"><table><thead><tr><th>Class (ROM)</th>'
+          "<th>Repo calls it</th><th>Repo's base</th><th>Actual base</th>"
+          "</tr></thead><tbody>")
+        for r in sorted(by_verdict["flattened"], key=lambda x: x["rom_bases"][0]):
+            A('<tr><td class="m">%s</td><td class="m">%s</td>'
+              '<td class="m" style="color:var(--contra)">%s</td>'
+              '<td class="m" style="color:var(--proven)">%s</td></tr>'
+              % (E(r["rom_name"]), E(r["tree_name"] or "—"), E(r["tree_base"] or "—"),
+                 E(", ".join(r["rom_bases"]))))
+        A("</tbody></table></div>")
+        inter = collections.Counter(r["rom_bases"][0] for r in by_verdict["flattened"])
+        A('<div class="note">Those %d rows collapse to <strong>%d missing intermediate '
+          "class%s</strong>, not %d separate mistakes: %s. Modelling %s is the single "
+          "highest-yield correction available to the hierarchy.</div>"
+          % (len(contra), len(inter), "" if len(inter) == 1 else "es", len(contra),
+             ", ".join("<code>%s</code> (%d)" % (E(k), v)
+                       for k, v in inter.most_common()),
+             "it" if len(inter) == 1 else "those %d" % len(inter)))
 
     # ---- §6 unproven
     A('</section><section><div class="sec-h"><span class="sec-n">§6</span>'
@@ -590,6 +675,8 @@ def main():
     print("tree-only classes %d, flattened %d"
           % (len(d["rec"]["tree_only_classes"]),
              sum(1 for r in d["rec"]["rows"] if r["verdict"] == "flattened")))
+    print("inputs in dependency order: %s"
+          % " -> ".join(n for n, _p, _g in STAGES))
     if a.check:
         print("CHECK OK")
         return 0


### PR DESCRIPTION
Regenerating `docs/class-hierarchy.html` turned up three ways the page can be
confidently wrong. Two of them bit me while doing it.

## `--check` passed on mutually inconsistent inputs

The three `build/*.json` inputs form a chain — `rtti.json` feeds
`evidence_hierarchy.json`, and both feed `rtti_reconcile.json` — but `load()` only
checked that the files exist and parse.

I ran `rtti_reconcile` **before** `evidence_hierarchy`. That joins fresh ROM records
against a stale hierarchy, and the page it produces is fully populated, internally
consistent, and wrong: §5 listed **26 CONTRADICTED classes**, 8 of them accusing headers
that name exactly the base the ROM names.

| class | header on disk | page claimed the repo believed | ROM says |
|---|---|---|---|
| `Thwomp` | `struct Thwomp : daDsnBase_c` | `Platform` | `daDsnBase_c` |
| `Bully` | `struct Bully : daOts_c` | `Enemy` | `daOts_c` |
| `RollingLogLll` | `struct RollingLogLll : daObjMaruta_c` | `Actor` | `daObjMaruta_c` |
| `FallBlockWf` | `struct FallBlockWf : daObjFallBlock_c` | `dBgActor_c` | `daObjFallBlock_c` |

`--check` printed `CHECK OK` for that state. `load()` now compares mtimes along the
dependency chain and refuses to build, naming which input to regenerate and in what
order.

## §5 had no zero case

With correctly-ordered inputs the CONTRADICTED tier is **empty**. All 24 formerly
flattened rows now read `agree`, each on the strength of a hand-written `struct D : B`
in a de-bannered header — the 11 unmodelled intermediate classes the page called *"the
single highest-yield correction available to the hierarchy"* have been written down.

The prose assumed a non-zero count unconditionally and rendered:

> Those 0 rows collapse to **0 missing intermediate classes**, not 0 separate mistakes: .
> Modelling those 0 is the single highest-yield correction available to the hierarchy.

A dangling list and a recommendation to do nothing, stated with total confidence. §5 now
branches. The empty case says *nowhere*, says what the check still covers, and says which
rows are even capable of disagreeing (the 201 parented by hand rather than by a ROM base
pointer). The non-zero branch keeps its table, loses the hardcoded "every one is in the
Platform family" — which the mis-ordered run had already falsified with two Enemy-family
rows — and gets singular/plural agreement.

## Numbers typed by hand, on a page whose footer promises otherwise

| was | true value |
|---|---|
| `"183 of them across an overlay boundary"` | **293** |
| `"0 of %d are unresolved"` | now `len(rtti["unresolved"])` |

The module docstring carried a third set — 405 edges, 58 inferred, 24 contradicted,
against a live 413 / 56 / 0. Its tier counts are **deleted** rather than corrected: a
count in a docstring is a number nothing re-derives.

## Also in the regenerated page

Ordinary drift since the inputs were last built: unnamed ROM classes 84 → 76, inferred
classes 54 → 56.

Verified: `--check` OK in order, exits 1 with the right message out of order; `pyflakes`
clean; page tags balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT
