### PR TITLE
Tell a withdrawn claim apart from a lost match

### DIFF
--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -317,6 +317,89 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(report["status"], "Passed")
         self.assertEqual(report["asmPolicy"], {"transcribed": [], "unbanneredAsm": []})
 
+    def _claim_without_enrolling(self, name):
+        """A symbol with a src/ file and NO `complete` delinks entry: matched by the
+        filename test, byte-verified by nothing. The population policy D subtracts."""
+        self._declare_symbol(name)
+        (self.repo / "src" / f"{name}.c").write_text(
+            f"int {name}(void) {{ return 0; }}\n", encoding="utf-8")
+        return commit(self.repo, f"claim {name}", "bob")
+
+    def test_withdrawing_an_unverified_claim_warns_instead_of_blocking(self):
+        # Bannering a file that compiles to the wrong length is how this repo says
+        # "not a match". When every exit from `matched` counted as loss, that edit
+        # was the one thing a PR could not do -- so the gate rewarded leaving the
+        # false claim in the tree. The file is still there under the same name and
+        # was never byte-verified, so nothing was lost; a claim was retracted.
+        base = self._claim_without_enrolling("Claimed")
+        self.assertTrue(
+            VM.function_snapshot(base)["functions"]["arm9:0x02000004"]["matched"])
+        (self.repo / "src" / "Claimed.c").write_text(
+            "// NONMATCHING -- compiles to 0x14 against the ROM's 0x10.\n"
+            "int Claimed(void) { return 0; }\n", encoding="utf-8")
+        head = commit(self.repo, "banner Claimed", "bob")
+
+        # Withdrawing also hands the claim's contributor credit back to nobody, which
+        # is its own reason and keeps its own label. That is the real shape of such a
+        # PR: attribution-override for the credit, and this rule for the count. Assert
+        # the two separately so neither can be mistaken for the other.
+        unlabelled = VM.build_report(base, head)
+        self.assertEqual(unlabelled["status"], "Failed")
+        self.assertEqual([r.split(" (")[0] for r in unlabelled["reasons"]],
+                         ["contributor attribution changed or was lost"])
+
+        report = VM.build_report(base, head, allow_attribution_change=True)
+        self.assertEqual(report["status"], "Passed")
+        self.assertEqual(report["coverage"]["delta"]["withdrawnMatchedFunctions"], 1)
+        self.assertEqual(report["coverage"]["delta"]["lostMatchedFunctions"], 0)
+        # The total is deliberately unchanged, so an existing reader of this field
+        # still sees everything that left the set.
+        self.assertEqual(report["coverage"]["delta"]["removedMatchedFunctions"], 1)
+        self.assertEqual([w["path"] for w in report["matchedWithdrawn"]],
+                         ["src/Claimed.c"])
+        self.assertTrue(any("withdrawn" in w for w in report["warnings"]))
+        self.assertFalse(any("lost" in x and "matched" in x
+                             for x in report["reasons"]))
+        self.assertIn("Claims withdrawn", VM.render_markdown(report))
+
+    def test_withdrawing_a_byte_verified_match_still_blocks(self):
+        # The restriction that makes the rule safe. Example.c carries `complete`, so
+        # the ROM build compiles it and compares it to the cartridge -- retracting
+        # that claim is a real coverage loss, not a correction.
+        (self.repo / "src" / "Example.c").write_text(
+            "// NONMATCHING\nint Example(void) { return 0; }\n", encoding="utf-8")
+        head = commit(self.repo, "banner a verified match", "bob")
+        report = VM.build_report(self.base, head)
+        self.assertEqual(report["status"], "Failed")
+        self.assertEqual(report["coverage"]["delta"]["withdrawnMatchedFunctions"], 0)
+        self.assertEqual(report["coverage"]["delta"]["lostMatchedFunctions"], 1)
+        self.assertTrue(any("lost 1 matched function" in x for x in report["reasons"]))
+
+    def test_deleting_a_claimed_source_is_loss_not_withdrawal(self):
+        # No banner, no file: the tree really did shed something. `matched` falls the
+        # same way it does for a withdrawal, and only the surviving-file test tells
+        # the two apart.
+        base = self._claim_without_enrolling("Claimed")
+        (self.repo / "src" / "Claimed.c").unlink()
+        head = commit(self.repo, "delete Claimed", "bob")
+        report = VM.build_report(base, head)
+        self.assertEqual(report["status"], "Failed")
+        self.assertEqual(report["coverage"]["delta"]["withdrawnMatchedFunctions"], 0)
+        self.assertTrue(any("lost 1 matched function" in x for x in report["reasons"]))
+
+    def test_replacing_a_claim_with_a_transcription_is_not_a_withdrawal(self):
+        # A dcd dump is not a retraction, it is a vacuous match wearing a banner's
+        # clothes: the file survives under the same name, so only the transcription
+        # test keeps it out of the withdrawn set.
+        base = self._claim_without_enrolling("Claimed")
+        (self.repo / "src" / "Claimed.c").write_text(
+            "asm void Claimed(void) {\n    dcd 0xe12fff1e\n}\n", encoding="utf-8")
+        head = commit(self.repo, "transcribe Claimed", "bob")
+        report = VM.build_report(base, head)
+        self.assertEqual(report["status"], "Failed")
+        self.assertEqual(report["coverage"]["delta"]["withdrawnMatchedFunctions"], 0)
+        self.assertTrue(any("lost 1 matched function" in x for x in report["reasons"]))
+
     def test_raw_asm_group_verdict_blocks_and_overrides_vacuous_slots(self):
         # pr_linkcheck stamps RAW-ASM on the group row while the transcription's
         # per-slot results read VERIFIED (vacuously -- the dcd words ARE the ROM

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -447,8 +447,40 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     link = _link_state(link_rows)
     port = _port_state(port_report)
     reasons = []
-    if base_keys - head_keys:
-        reasons.append(f"lost {len(base_keys - head_keys)} matched function(s)")
+    # A function can leave `matched` two ways, and they are opposite acts.
+    #
+    #   REMOVED    the file was deleted, renamed out from under its symbol, or turned
+    #              into a dcd transcription. Something the tree had is gone. Blocks.
+    #   WITHDRAWN  the same file is still there, still named after the same symbol, and
+    #              now carries a NONMATCHING banner. Nothing was lost -- a claim was
+    #              retracted, which is the sanctioned way to tell the truth here.
+    #
+    # Treating both as loss made the gate reward the lie: a file that compiles to 916
+    # bytes where the ROM has 912 was never a match, and bannering it -- the only
+    # mechanism this repo HAS for saying so -- was the one edit that could not land.
+    # Same shape as the CONVERTED defect, where un-converting a class was the only way
+    # to score. See tools/bytegate.py: policy D already stopped counting the
+    # unevidenced half of `matched`; this is the same judgement at the PR gate.
+    #
+    # WITHDRAWN is restricted to functions that were NOT byte-verified in the base.
+    # That restriction is the whole safety argument, and it is explicit rather than
+    # emergent: a byte-verified function is one the ROM build compiles and compares, so
+    # retracting its claim is a real coverage loss and stays a hard reason (it would
+    # also trip `source-built function coverage decreased`, but relying on that
+    # interaction would leave the rule true only by accident).
+    base_enrolled = {key.split("-", 1)[0] for key in be["source"]}
+    transcribed_now = set(new_transcribed)
+    withdrawn, removed = [], []
+    for k in sorted(base_keys - head_keys):
+        hr, br = hf["functions"].get(k) or {}, bf["functions"].get(k) or {}
+        if (k not in base_enrolled and hr.get("srcPath")
+                and hr["srcPath"] == br.get("srcPath")
+                and hr["srcPath"] not in transcribed_now):
+            withdrawn.append({"id": k, "path": hr["srcPath"], "name": hr.get("name")})
+        else:
+            removed.append(k)
+    if removed:
+        reasons.append(f"lost {len(removed)} matched function(s)")
     if (hf["stats"]["totalFunctions"] != bf["stats"]["totalFunctions"]
             or hf["stats"]["totalBytes"] != bf["stats"]["totalBytes"]):
         reasons.append("function/byte coverage denominator changed")
@@ -508,6 +540,13 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append("full-ROM validation failed")
 
     warnings = []
+    if withdrawn:
+        warnings.append(
+            f"{len(withdrawn)} claimed match(es) withdrawn by a NONMATCHING banner "
+            "rather than lost: each file is still present under the same name, and "
+            "none was byte-verified -- "
+            + ", ".join(w["path"] for w in withdrawn[:3])
+            + (f", +{len(withdrawn) - 3} more" if len(withdrawn) > 3 else ""))
     if allow_attribution_change and credit_moved:
         warnings.append("attribution-override label: contributor attribution changed or "
                         f"was lost ({_credit_detail(credit_changes, lost_credit)}), "
@@ -561,7 +600,11 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         "sourceBuiltFunctions": he["stats"]["sourceFunctions"] - be["stats"]["sourceFunctions"],
         "sourceBuiltBytes": he["stats"]["sourceBytes"] - be["stats"]["sourceBytes"],
         "newMatchedFunctions": len(head_keys - base_keys),
+        # Kept as the total, so an existing reader of this field does not silently see
+        # a smaller number than the tree actually shed. The split is beside it.
         "removedMatchedFunctions": len(base_keys - head_keys),
+        "withdrawnMatchedFunctions": len(withdrawn),
+        "lostMatchedFunctions": len(removed),
     }
     base_source_stats = dict(be["stats"])
     head_source_stats = dict(he["stats"])
@@ -605,6 +648,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                         "lost": lost_credit, "overridden": allow_attribution_change},
         "diff": diff,
         "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered},
+        "matchedWithdrawn": withdrawn,
         "linkcheck": link,
         "portRefcheck": port,
         "rom": {"base": base_rom_state, "head": head_rom_state,
@@ -642,6 +686,12 @@ def render_markdown(r):
              f"| Claimed, not byte-verified | {h['claimedFunctions']:,} functions, "
              f"{h['claimedBytes']:,} bytes ({_signed(d['claimedFunctions'])}) |",
              f"| Perfect source moves | {len(r['diff']['perfectRenames'])} R100 |"]
+    # Only when it happened. A retracted claim is news; a zero here would be noise on
+    # every other pull request.
+    if r.get("matchedWithdrawn"):
+        lines.append(
+            f"| Claims withdrawn (banner added) | {len(r['matchedWithdrawn'])} "
+            f"function(s), none byte-verified |")
     # The delinks view of the same quantity. Identical to byte-verified above whenever
     # every enrolled range is a matched symbols.txt function, which is the healthy
     # state -- so it earns a row only when the two disagree, where the disagreement is


### PR DESCRIPTION
`validate_merge` failed any PR where a function left `matched`:

```python
if base_keys - head_keys:
    reasons.append(f"lost {len(base_keys - head_keys)} matched function(s)")
```

No override, no exceptions. But a function leaves that set two ways, and they are
opposite acts:

| | what happened | should |
|---|---|---|
| **REMOVED** | the file was deleted, renamed out from under its symbol, or turned into a `dcd` transcription | block |
| **WITHDRAWN** | the same file is still there under the same name and now carries a `NONMATCHING` banner | warn |

## Why this matters

`matched` is a filename test — a file named after the symbol, no banner, not a
transcription. **Nothing compiles it.** So a file that compiles to 916 bytes where the
ROM has 912 counts as a match until somebody says otherwise, and the only mechanism this
repo *has* for saying otherwise is the banner — which was the one edit that could not
land.

The gate rewarded leaving the false claim in the tree. Same shape as the CONVERTED
defect, where un-converting a class was the only way to score. #1541 measured six such
files and is blocked on precisely this reason, with every other check green.

#1534 already ruled on the principle at the published-count end: policy D stopped
counting the unevidenced half of `matched`. This is that same judgement at the PR gate.

## What makes it safe

WITHDRAWN requires all three, and the first is the whole argument:

1. **The function was NOT byte-verified in the base.** A byte-verified function is one
   the ROM build compiles and compares against the cartridge — retracting *that* claim is
   real coverage loss and stays a hard reason. Stated explicitly rather than left to the
   `source-built function coverage decreased` reason it would also trip: a rule that
   holds only through another rule's side effect is a rule that holds by accident.
2. The head still has a source file for that symbol, **at the same path**.
3. That file is not a new `dcd` transcription — a vacuous match wearing a banner's
   clothes, which blocks on its own reason already.

## Never silent

A warning naming the files, a `Claims withdrawn` row that appears only when it happened,
and `matchedWithdrawn` in the JSON. `removedMatchedFunctions` keeps meaning the **total**,
so no existing reader of that field starts seeing a smaller number than the tree shed;
the split sits beside it as `withdrawnMatchedFunctions` / `lostMatchedFunctions`.

Withdrawing also hands the claim's credit back to nobody — a separate reason with its own
`attribution-override` label. Both halves are asserted separately in the tests so neither
can be mistaken for the other.

## Tests

| case | expected |
|---|---|
| withdraw an unverified claim | passes (with the label), warns, `Claims withdrawn` row |
| withdraw a **byte-verified** match | still blocks |
| delete a claimed source | still blocks |
| replace a claim with a `dcd` transcription | still blocks |

23 passed in `test_validate_merge.py`; `pyflakes` clean.

**Sequencing:** this cannot help #1541 until it lands. `restore_trusted_controls` puts
`tools/` back to the PR's *base* commit, so a gate change takes effect only from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT
