### PR TITLE
Make two shared-header declarations agree with the tree's own definitions

### DIFF
--- a/include/dScMgBase_c.h
+++ b/include/dScMgBase_c.h
@@ -60,7 +60,12 @@
 #define DSCMGBASE_C_H
 #include "Scene.h"
 
-extern "C" void func_ov004_020b929c(void *);
+/* Returns its argument. The ROM parks the pointer in r4 across the
+   __destroy_arr call and hands it straight back -- 0x020b92ac `mov r4, r0`,
+   0x020b92b4 `mov r0, r4`, 0x020b92b8 `pop {r4, lr}` -- and the tree's own
+   definition (src/func_ov004_020b929c.c) already says `void *`. All three
+   call sites discard the result, so this only makes the two agree. */
+extern "C" void *func_ov004_020b929c(void *);
 extern "C" void *data_ov004_020beb68;
 
 struct dScMgBase_c : Scene {

--- a/include/decl_common.h
+++ b/include/decl_common.h
@@ -2924,7 +2924,9 @@ extern void func_ov100_021437d4(void*);
 extern void func_ov100_02143b68(char*);
 extern void func_ov100_02145070(int);
 extern void func_ov100_02145170(char*, char*, struct Vector3*, struct Vector3*);
-extern void func_ov100_021453d8(char*, void*, int);
+/* Returns int -- the tree's own definition (src/func_ov100_021453d8.cpp)
+   defines it `extern "C" int`, and its early-out is `return 1`. */
+extern int func_ov100_021453d8(char*, void*, int);
 extern void func_ov100_02145e10(char*, char*);
 extern void func_ov100_02146280(void);
 extern void func_ov100_0214629c(void*, int);

--- a/src/_ZN11dScMgBase_cD2Ev.cpp
+++ b/src/_ZN11dScMgBase_cD2Ev.cpp
@@ -4,7 +4,7 @@ extern int data_ov004_020beb68[];
 extern int _ZTV5Scene[];
 extern int data_0208e4b8[];
 extern "C" {
-extern void func_ov004_020b929c(void *);
+extern void *func_ov004_020b929c(void *);
 /* The ROM calls the base-object destructor D2. The explicit destructor call
    this replaces compiled to the complete-object destructor D1 instead --
    0x02043dbc where the ROM branches to 0x02043d48. Same shape as the sibling


### PR DESCRIPTION
Two shared headers declare a symbol with a return type that the tree's **own definition already contradicts**. No ROM archaeology is needed to see either one — two files in the repo disagree, and the byte gates cannot notice, because no TU enrolls both.

### `include/dScMgBase_c.h:63` — `func_ov004_020b929c`

| | says |
|---|---|
| the header | `extern "C" void func_ov004_020b929c(void *);` |
| `src/func_ov004_020b929c.c:4` | `void *func_ov004_020b929c(void *self)` |

The ROM sides with the definition — it parks the argument in `r4` across the `__destroy_arr` call and hands it straight back:

```
0x020b92ac  mov r4, r0
0x020b92b4  mov r0, r4
0x020b92b8  pop {r4, lr}
```

All three call sites (`D0`, `D1`, `D2`) discard the result, so the change is codegen-free; it only stops the header from lying. `src/_ZN11dScMgBase_cD2Ev.cpp:7` carries its own duplicate declaration of the same symbol — corrected here too, so the two spellings cannot drift apart again.

### `include/decl_common.h:2927` — `func_ov100_021453d8`

| | says |
|---|---|
| the header | `extern void func_ov100_021453d8(char*, void*, int);` |
| `src/func_ov100_021453d8.cpp` | `extern "C" int func_ov100_021453d8(C*, PMF*, int)`, early-out `return 1` |

None of the nine files referencing that symbol include `decl_common.h`, so today the declaration is reachable only by *future* callers — which is precisely when a wrong return type starts costing bytes silently. The parameter list is left as the generic `char*, void*, int`; only the return type was wrong.

## Verification — both halves of the shared-header bracket

**Byte gate.** 50 files: the 39 direct includers of `dScMgBase_c.h`, the 4 referencing `func_ov004_020b929c`, and the 9 referencing `func_ov100_021453d8`.

```
before  46/50 reproduce the ROM
after   46/50 reproduce the ROM
        LOST 0   GAINED 0
```

**Eligibility.** `python tools/eligible.py` before and after: **10974 / 11175** both times, and the eligible **name list is byte-identical**. A bare count would have hidden one file trading its eligibility for another's; the name list cannot.

The 4 non-matching files are pre-existing failures on a clean `origin/main` checkout and are untouched: `_ZN12dScMgSlot1_cD1Ev.cpp`, `func_ov004_020aeed8.cpp`, `func_ov006_020dbaf0.cpp`, `func_ov100_021455a0.c`.

Note `func_ov004_020aeed8.cpp` fails with `illegal function overloading` — the same header-collision defect #1541 repairs, and that file is already on its list. This PR touches neither the file nor the declaration involved, so the two should not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01537rCges61uTkNNen7F6vJ