### PR TITLE
Respell 10 phantom references the symbol table can settle (91.57% -> 91.72%)

### DIFF
--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -116,6 +116,7 @@ src/_ZN13RacingPenguin8BehaviorEv.cpp:
     .text start:0x02112394 end:0x021123d4
 
 src/_ZN13RacingPenguin13InitResourcesEv.cpp:
+    complete
     .text start:0x021123d4 end:0x021125bc
 
 src/RacingPenguin_Spawn.c:

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -21,6 +21,7 @@ src/_ZN15BookShotSpawnerD0Ev.c:
     .text start:0x02111278 end:0x021112b0
 
 src/func_ov020_021112b0.c:
+    complete
     .text start:0x021112b0 end:0x02111340
 
 src/func_ov020_02111340.c:

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -77,6 +77,7 @@ src/_ZN19FloatOnLavaPlatform6RenderEv.cpp:
     .text start:0x021117a4 end:0x021117cc
 
 src/_ZN19FloatOnLavaPlatform8BehaviorEv.cpp:
+    complete
     .text start:0x021117cc end:0x02111870
 
 src/_ZN19FloatOnLavaPlatform13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov055/delinks.txt
+++ b/config/arm9/overlays/ov055/delinks.txt
@@ -40,6 +40,7 @@ src/_ZN11MirrorLuigi8BehaviorEv.cpp:
     .text start:0x02111508 end:0x02111674
 
 src/_ZN11MirrorLuigi13InitResourcesEv.cpp:
+    complete
     .text start:0x02111674 end:0x02111860
 
 src/MirrorLuigi_Spawn.cpp:

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -504,6 +504,7 @@ src/_ZN17BowserSkyPlatform8BehaviorEv.cpp:
     .text start:0x02118254 end:0x021182b0
 
 src/func_ov060_021182b0.cpp:
+    complete
     .text start:0x021182b0 end:0x021183cc
 
 src/func_ov060_021183cc.c:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -363,4 +363,5 @@ src/__sinit_ov071_02122a1c.c:
     .init start:0x02122a1c end:0x02122a64
 
 src/__sinit_ov071_02122a64.c:
+    complete
     .init start:0x02122a64 end:0x02122b30

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -89,6 +89,7 @@ src/_ZN9MontyMole8BehaviorEv.cpp:
     .text start:0x02124530 end:0x0212459c
 
 src/_ZN13MontyMoleRock8BehaviorEv.cpp:
+    complete
     .text start:0x0212459c end:0x0212478c
 
 src/_ZN9MontyMole13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -149,6 +149,7 @@ src/func_ov098_02139070.c:
     .text start:0x02139070 end:0x021390ec
 
 src/func_ov098_021390ec.cpp:
+    complete
     .text start:0x021390ec end:0x02139228
 
 src/func_ov098_02139228.cpp:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -17,6 +17,7 @@ src/func_ov100_02140e44.cpp:
     .text start:0x02140e44 end:0x0214109c
 
 src/func_ov100_0214109c.cpp:
+    complete
     .text start:0x0214109c end:0x0214117c
 
 src/func_ov100_0214117c.cpp:

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -25,6 +25,7 @@ src/_ZN13FortressTower8BehaviorEv.cpp:
     .text start:0x02148ba8 end:0x02148c94
 
 src/_ZN13FortressTower13InitResourcesEv.cpp:
+    complete
     .text start:0x02148c94 end:0x02148e9c
 
 src/RopeBarrier_Spawn.c:

--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,5 +1,5 @@
 {
- "eligible": 10973,
+ "eligible": 10999,
  "unresolved": {
   "arm9:0x02009374": {
    "name": "func_02009374",
@@ -357,42 +357,10 @@
     "p__sinit_ov031_02111434"
    ]
   },
-  "ov019:0x021123d4": {
-   "name": "_ZN13RacingPenguin13InitResourcesEv",
-   "missing": [
-    "Actor_TrackStar",
-    "Animation_LoadFile",
-    "ModelBase_SetFile",
-    "Model_LoadFile",
-    "MovingCylinderClsn_Init",
-    "PathPtr_FromID",
-    "PathPtr_GetNode",
-    "ShadowModel_InitCylinder",
-    "TextureSequence_LoadFile",
-    "TextureSequence_Prepare",
-    "WithMeshClsn_Init"
-   ]
-  },
-  "ov020:0x021112b0": {
-   "name": "func_ov020_021112b0",
-   "missing": [
-    "Actor_ClosestPlayer",
-    "cstd_atan2"
-   ]
-  },
   "ov021:0x02111434": {
    "name": "func_ov021_02111434",
    "missing": [
     "conv_ov021"
-   ]
-  },
-  "ov022:0x021117cc": {
-   "name": "_ZN19FloatOnLavaPlatform8BehaviorEv",
-   "missing": [
-    "Platform_IsClsnInRange",
-    "Platform_UpdateClsnPosAndRot",
-    "Platform_UpdateModelPosAndRotY",
-    "_Z13func_020393a4Pii"
    ]
   },
   "ov022:0x02112434": {
@@ -435,18 +403,6 @@
     "func_0213a794"
    ]
   },
-  "ov055:0x02111674": {
-   "name": "_ZN11MirrorLuigi13InitResourcesEv",
-   "missing": [
-    "Animation_LoadFile",
-    "ModelAnim_SetAnim",
-    "ModelBase_SetFile",
-    "Model_LoadFile",
-    "ShadowModel_InitCylinder",
-    "TextureSequence_Prepare",
-    "TextureSequence_SetFile"
-   ]
-  },
   "ov060:0x02117c30": {
    "name": "_ZN18BowserFireSeaArena13InitResourcesEv",
    "missing": [
@@ -457,13 +413,6 @@
     "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
     "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
     "func_021115bc"
-   ]
-  },
-  "ov060:0x021182b0": {
-   "name": "func_ov060_021182b0",
-   "missing": [
-    "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_v",
-    "_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x3isR10CLPS_Block"
    ]
   },
   "ov060:0x02119004": {
@@ -579,12 +528,6 @@
     "_ZN18MovingCylinderClsn4InitEP5Actoriijj"
    ]
   },
-  "ov071:0x02122a64": {
-   "name": "__sinit_ov071_02122a64",
-   "missing": [
-    "data_ov071_02122ecc_d"
-   ]
-  },
   "ov074:0x02121e98": {
    "name": "_ZN8Goomboss13InitResourcesEv",
    "missing": [
@@ -609,20 +552,6 @@
    "name": "_ZN5Whomp13InitResourcesEv",
    "missing": [
     "func_021135d4"
-   ]
-  },
-  "ov080:0x0212459c": {
-   "name": "_ZN13MontyMoleRock8BehaviorEv",
-   "missing": [
-    "ActorBase_MarkForDestruction",
-    "Actor_FindWithID",
-    "Actor_MakeVanishLuigiWork",
-    "Actor_UpdatePos",
-    "CylinderClsn_Clear",
-    "CylinderClsn_Update",
-    "Enemy_UpdateWMClsn",
-    "Player_Hurt",
-    "WithMeshClsn_IsOnGround"
    ]
   },
   "ov085:0x02129f8c": {
@@ -675,19 +604,6 @@
     "func_02112968"
    ]
   },
-  "ov098:0x021390ec": {
-   "name": "func_ov098_021390ec",
-   "missing": [
-    "_Z19func_ov002_020ef228Pvi",
-    "_ZN5Actor12ReflectAngleEiis"
-   ]
-  },
-  "ov100:0x0214109c": {
-   "name": "func_ov100_0214109c",
-   "missing": [
-    "ActorBase_MarkForDestruction"
-   ]
-  },
   "ov100:0x02147054": {
    "name": "func_ov100_02147054",
    "missing": [
@@ -704,17 +620,6 @@
     "_ZN16MeshColliderBase6EnableEPv",
     "_ZN9Platform219UpdateClsnPosAndRotEv",
     "_ZN9Platform313IsClsnInRangeEii"
-   ]
-  },
-  "ov102:0x02148c94": {
-   "name": "_ZN13FortressTower13InitResourcesEv",
-   "missing": [
-    "MeshCollider_LoadFile",
-    "ModelBase_SetFile",
-    "Model_LoadFile",
-    "MovingMeshCollider_SetFile",
-    "Platform_UpdateClsnPosAndRot",
-    "Platform_UpdateModelPosAndRotY"
    ]
   }
  }

--- a/src/_ZN11MirrorLuigi13InitResourcesEv.cpp
+++ b/src/_ZN11MirrorLuigi13InitResourcesEv.cpp
@@ -4,6 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MirrorLuigi.h"
+extern "C" void* _ZN9Animation8LoadFileER13SharedFilePtr(void*);
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
+extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
+extern "C" int _ZN11ShadowModel12InitCylinderEv(void*);
+extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void*, void*);
+extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
 struct M48 { int w[12]; };
 
 extern "C" void func_02016b24(void *self, int v);
@@ -24,22 +31,22 @@ int MirrorLuigi::InitResources()
     unsigned char *c = (unsigned char *)((void *)this);
     int t[3];
 
-    ModelBase_SetFile(c + 0xd4, Model_LoadFile(&data_ov002_0210ebb8), 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210ebb8), 1, -1);
     func_02016acc(c + 0xd4, 0x80);
     func_02016b24(c + 0xd4, 0x40);
 
-    ModelBase_SetFile(c + 0x138, Model_LoadFile(&data_ov002_0210eb20), 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x138, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210eb20), 1, -1);
     func_02016acc(c + 0x138, 0x80);
     func_02016b24(c + 0x138, 0x40);
 
-    TextureSequence_Prepare((&data_ov002_0210ebb8)[1], (&data_ov002_0210e8d0)[1]);
-    TextureSequence_SetFile(c + 0x1b0, (&data_ov002_0210e8d0)[1], 0, 0x1000, 0);
-    TextureSequence_Prepare((&data_ov002_0210eb20)[1], (&data_ov002_0210ebd8)[1]);
-    TextureSequence_SetFile(c + 0x1c4, (&data_ov002_0210ebd8)[1], 0, 0x1000, 0);
+    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((&data_ov002_0210ebb8)[1], (&data_ov002_0210e8d0)[1]);
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x1b0, (&data_ov002_0210e8d0)[1], 0, 0x1000, 0);
+    _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((&data_ov002_0210eb20)[1], (&data_ov002_0210ebd8)[1]);
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x1c4, (&data_ov002_0210ebd8)[1], 0, 0x1000, 0);
 
-    ShadowModel_InitCylinder(c + 0x188);
+    _ZN11ShadowModel12InitCylinderEv(c + 0x188);
 
-    ModelAnim_SetAnim(c + 0xd4, Animation_LoadFile(&data_ov002_0210eaa0), 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210eaa0), 0, 0x1000, 0);
 
     Vec3_Asr(t, c + 0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, t[0], t[1], t[2]);

--- a/src/_ZN13FortressTower13InitResourcesEv.cpp
+++ b/src/_ZN13FortressTower13InitResourcesEv.cpp
@@ -4,6 +4,12 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FortressTower.h"
+extern "C" void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
+extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
+extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
+extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
+extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
+extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -34,21 +40,21 @@ int FortressTower::InitResources()
 
     idx = *(unsigned char *)(c + 0x31e);
     {
-        void *f = Model_LoadFile(*(void **)((char *)data_ov102_0214e188 + idx * 0xc));
-        ModelBase_SetFile(c + 0xd4, f, 1, -1);
+        void *f = _ZN5Model8LoadFileER13SharedFilePtr(*(void **)((char *)data_ov102_0214e188 + idx * 0xc));
+        _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, f, 1, -1);
     }
-    Platform_UpdateModelPosAndRotY(c);
-    Platform_UpdateClsnPosAndRot(c);
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    _ZN8Platform19UpdateClsnPosAndRotEv(c);
 
     idx = *(unsigned char *)(c + 0x31e);
     if (idx == 0 || idx == 2) {
-        void *f = MeshCollider_LoadFile(*(void **)((char *)data_ov102_0214e18c + idx * 0xc));
-        MovingMeshCollider_SetFile(c + 0x124, f, c + 0x2ec, 0x1000,
+        void *f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(*(void **)((char *)data_ov102_0214e18c + idx * 0xc));
+        _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x124, f, c + 0x2ec, 0x1000,
                                    *(short *)(c + 0x8e),
                                    *(void **)((char *)data_ov102_0214e190 + idx * 0xc));
     } else {
-        void *f = MeshCollider_LoadFile(*(void **)((char *)data_ov102_0214e18c + idx * 0xc));
-        MovingMeshCollider_SetFile(c + 0x124, f, c + 0x2ec, 0x199,
+        void *f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(*(void **)((char *)data_ov102_0214e18c + idx * 0xc));
+        _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x124, f, c + 0x2ec, 0x199,
                                    *(short *)(c + 0x8e),
                                    *(void **)((char *)data_ov102_0214e190 + idx * 0xc));
     }

--- a/src/_ZN13MontyMoleRock8BehaviorEv.cpp
+++ b/src/_ZN13MontyMoleRock8BehaviorEv.cpp
@@ -4,6 +4,15 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MontyMoleRock.h"
+extern "C" void _ZN9ActorBase18MarkForDestructionEv(void*);
+extern "C" void* _ZN5Actor10FindWithIDEj(unsigned int);
+extern "C" void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void*, void*);
+extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void*, void*);
+extern "C" void _ZN12CylinderClsn5ClearEv(void*);
+extern "C" void _ZN12CylinderClsn6UpdateEv(void*);
+extern "C" void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void*, void*, unsigned int);
+extern "C" void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void*, void*, unsigned int, int, unsigned int, unsigned int, unsigned int);
+extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
 extern "C" void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16as(unsigned int a, unsigned int b, void *pos, void *v16, int e, int f);
 extern "C" int RandomIntInternal(int *seed);
 
@@ -14,31 +23,31 @@ s32 MontyMoleRock::Behavior()
     unsigned char *c = (unsigned char *)((void *)this);
     unsigned char *o;
 
-    Actor_MakeVanishLuigiWork(c, c + 0x160);
+    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x160);
 
     {
         unsigned int id = *(unsigned int *)(c + 0x184);
         if (id != 0) {
-            o = (unsigned char *)Actor_FindWithID(id);
+            o = (unsigned char *)_ZN5Actor10FindWithIDEj(id);
             if (o != 0 && (*(int *)(c + 0x180) & 0x400000)) {
                 if (*(unsigned char *)(o + 0x6f9) != 0) {
                     int v1[3];
                     v1[0] = *(int *)(c + 0x5c);
                     v1[1] = *(int *)(c + 0x60);
                     v1[2] = *(int *)(c + 0x64);
-                    Player_Hurt(o, v1, 1, 0xc000, 1, 0, 1);
+                    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(o, v1, 1, 0xc000, 1, 0, 1);
                 } else if (*(unsigned char *)(o + 0x6fb) == 0) {
                     int v2[3];
                     v2[0] = *(int *)(c + 0x5c);
                     v2[1] = *(int *)(c + 0x60);
                     v2[2] = *(int *)(c + 0x64);
-                    Player_Hurt(o, v2, 1, 0xc000, 1, 0, 1);
+                    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(o, v2, 1, 0xc000, 1, 0, 1);
                 }
             }
         }
     }
 
-    if (WithMeshClsn_IsOnGround(c + 0x194) != 0) {
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x194) != 0) {
         if (*(unsigned char *)(c + 0x350) == 0) {
             unsigned char *s;
             int r;
@@ -63,13 +72,13 @@ s32 MontyMoleRock::Behavior()
             *(int *)(s + 0xa8) = 0x5000;
             *(int *)(s + 0xac) = 0;
         }
-        ActorBase_MarkForDestruction(c);
+        _ZN9ActorBase18MarkForDestructionEv(c);
     }
 
-    Actor_UpdatePos(c, 0);
-    Enemy_UpdateWMClsn(c, c + 0x194, 0);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x194, 0);
     func_ov080_02124418(c);
-    CylinderClsn_Clear(c + 0x160);
-    CylinderClsn_Update(c + 0x160);
+    _ZN12CylinderClsn5ClearEv(c + 0x160);
+    _ZN12CylinderClsn6UpdateEv(c + 0x160);
     return 1;
 }

--- a/src/_ZN13RacingPenguin13InitResourcesEv.cpp
+++ b/src/_ZN13RacingPenguin13InitResourcesEv.cpp
@@ -4,6 +4,17 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RacingPenguin.h"
+extern "C" unsigned char _ZN5Actor9TrackStarEjj(void*, unsigned int, unsigned int);
+extern "C" void* _ZN9Animation8LoadFileER13SharedFilePtr(void*);
+extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
+extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
+extern "C" void _ZN7PathPtr6FromIDEj(void*, unsigned int);
+extern "C" void _ZNK7PathPtr7GetNodeER7Vector3j(void*, void*, unsigned int);
+extern "C" int _ZN11ShadowModel12InitCylinderEv(void*);
+extern "C" void* _ZN15TextureSequence8LoadFileER13SharedFilePtr(void*);
+extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void*, void*);
+extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void*, void*, int, int, void*, int);
 extern "C" unsigned char NumStars(void);
 extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, int a, int b, int cc, int d);
 
@@ -13,41 +24,41 @@ int RacingPenguin::InitResources()
     unsigned char *c = (unsigned char *)((void *)this);
     int i;
 
-    ModelBase_SetFile(c + 0xd4, Model_LoadFile(&data_ov019_02113498), 1, 1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov019_02113498), 1, 1);
 
     for (i = 0; i < 7; i++)
-        Animation_LoadFile(data_ov019_02112788[i]);
+        _ZN9Animation8LoadFileER13SharedFilePtr(data_ov019_02112788[i]);
 
     for (int j = 0; j < 3; j++) {
         void *t = data_ov019_0211277c[j];
-        TextureSequence_LoadFile(t);
-        TextureSequence_Prepare((&data_ov019_02113498)[1], *(void **)((char *)t + 4));
+        _ZN15TextureSequence8LoadFileER13SharedFilePtr(t);
+        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((&data_ov019_02113498)[1], *(void **)((char *)t + 4));
     }
 
-    if (ShadowModel_InitCylinder(c + 0x14c) == 0)
+    if (_ZN11ShadowModel12InitCylinderEv(c + 0x14c) == 0)
         return 0;
 
     if (NumStars() == 0x96) {
-        MovingCylinderClsn_Init(c + 0x174, c, 0xd0000, 0x12c000, 0x800004, 0);
+        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x174, c, 0xd0000, 0x12c000, 0x800004, 0);
         *(int *)(c + 0x80) = 0x1999;
         *(int *)(c + 0x84) = 0x1000;
         *(int *)(c + 0x88) = 0x1999;
-        WithMeshClsn_Init(c + 0x1a8, c, 0xd0000, 0xd0000, 0, 0);
+        _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x1a8, c, 0xd0000, 0xd0000, 0, 0);
         _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, 0xf0000, 0xf0000, 0x1c20000, 0x1c20000);
     } else {
-        MovingCylinderClsn_Init(c + 0x174, c, 0x82000, 0x12c000, 0x800004, 0);
+        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x174, c, 0x82000, 0x12c000, 0x800004, 0);
         *(int *)(c + 0x80) = 0x1000;
         *(int *)(c + 0x84) = 0x1000;
         *(int *)(c + 0x88) = 0x1000;
-        WithMeshClsn_Init(c + 0x1a8, c, 0x82000, 0x82000, 0, 0);
+        _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x1a8, c, 0x82000, 0x82000, 0, 0);
     }
 
     *(unsigned char *)(c + 0x396) =
-        Actor_TrackStar(c, (unsigned char)((*(unsigned int *)(c + 8) >> 8) & 0xf), 2);
+        _ZN5Actor9TrackStarEjj(c, (unsigned char)((*(unsigned int *)(c + 8) >> 8) & 0xf), 2);
     func_ov019_021122dc(c, 0);
-    PathPtr_FromID(c + 0x364, *(unsigned int *)(c + 8) & 0xff);
+    _ZN7PathPtr6FromIDEj(c + 0x364, *(unsigned int *)(c + 8) & 0xff);
     *(int *)(c + 0x36c) = 0;
-    PathPtr_GetNode(c + 0x364, c + 0x5c, *(unsigned int *)(c + 0x36c));
+    _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x364, c + 0x5c, *(unsigned int *)(c + 0x36c));
     func_ov019_021113b0(c);
     func_ov019_021114ec(c);
     return 1;

--- a/src/_ZN19FloatOnLavaPlatform8BehaviorEv.cpp
+++ b/src/_ZN19FloatOnLavaPlatform8BehaviorEv.cpp
@@ -4,7 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnLavaPlatform.h"
-extern void func_020393a4(int* p, int v);
+extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
+extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
+extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
+extern "C" void func_020393a4(int* p, int v);
 
 int FloatOnLavaPlatform::Behavior()
 {
@@ -21,9 +24,9 @@ int FloatOnLavaPlatform::Behavior()
         int lim = unk_320;
         if (mPosY > lim) mPosY = lim;
     }
-    Platform_UpdateModelPosAndRotY(((char*)this));
-    if (Platform_IsClsnInRange(((char*)this), 0, 0)) {
-        Platform_UpdateClsnPosAndRot(((char*)this));
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0)) {
+        _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
     }
     return 1;
 }

--- a/src/__sinit_ov071_02122a64.c
+++ b/src/__sinit_ov071_02122a64.c
@@ -13,7 +13,6 @@ extern struct Pair data_ov071_02122e74;
 extern struct Pair data_ov071_02122e8c;
 extern struct Pair data_ov071_02122e84;
 extern struct Pair data_ov071_02122e7c;
-extern struct Pair data_ov071_02122ecc;
 
 struct Dst {
     struct Pair p0;   /* 0x0, 0x4 */
@@ -22,7 +21,7 @@ struct Dst {
     struct Pair p5;   /* 0x14, 0x18 */
     struct Pair p7;   /* 0x1c, 0x20 */
 };
-extern struct Dst data_ov071_02122ecc_d;
+extern struct Dst data_ov071_02122ecc;
 
 void __sinit_ov071_02122a64(void)
 {
@@ -30,8 +29,8 @@ void __sinit_ov071_02122a64(void)
     func_020731dc(data_ov071_021230d0, &func_02017ab4, data_ov071_021230e0);
     func_02017b4c(data_ov071_021230d8, 0x5b5);
     func_020731dc(data_ov071_021230d8, &SharedFilePtr_Destruct_Clsn, data_ov071_021230ec);
-    data_ov071_02122ecc_d.p0 = data_ov071_02122e74;
-    data_ov071_02122ecc_d.p2 = data_ov071_02122e8c;
-    data_ov071_02122ecc_d.p5 = data_ov071_02122e84;
-    data_ov071_02122ecc_d.p7 = data_ov071_02122e7c;
+    data_ov071_02122ecc.p0 = data_ov071_02122e74;
+    data_ov071_02122ecc.p2 = data_ov071_02122e8c;
+    data_ov071_02122ecc.p5 = data_ov071_02122e84;
+    data_ov071_02122ecc.p7 = data_ov071_02122e7c;
 }

--- a/src/func_ov020_021112b0.c
+++ b/src/func_ov020_021112b0.c
@@ -3,6 +3,8 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+extern char* _ZN5Actor13ClosestPlayerEv(void*);
+extern short _ZN4cstd5atan2E5Fix12IiES1_(int, int);
 /* func_ov020_021112b0 at 0x021112b0 (ov020), size 0x90
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
@@ -14,7 +16,7 @@ extern int Vec3_HorzLen(struct Vector3 *);
 
 void func_ov020_021112b0(char *c)
 {
-  char *p = Actor_ClosestPlayer(c);
+  char *p = _ZN5Actor13ClosestPlayerEv(c);
   if (!p)
     return;
   struct Vector3 *ps = (struct Vector3 *)(((long long)(int)(p + 0x5c)));
@@ -24,7 +26,7 @@ void func_ov020_021112b0(char *c)
   tmp.z = ps->z;
   struct Vector3 d;
   Vec3_Sub(&d, &tmp, (struct Vector3 *)(c + 0x5c));
-  *((short *)(c + 0x446)) = cstd_atan2(d.x, d.z);
-  *((short *)(c + 0x444)) = cstd_atan2(d.y, Vec3_HorzLen(&d));
+  *((short *)(c + 0x446)) = _ZN4cstd5atan2E5Fix12IiES1_(d.x, d.z);
+  *((short *)(c + 0x444)) = _ZN4cstd5atan2E5Fix12IiES1_(d.y, Vec3_HorzLen(&d));
   *((short *)(c + 0x448)) = 0x4000;
 }

--- a/src/func_ov060_021182b0.cpp
+++ b/src/func_ov060_021182b0.cpp
@@ -13,9 +13,15 @@ struct Model { static BMD_File* LoadFile(SharedFilePtr& f); };
 struct ModelBase { void SetFile(BMD_File* f, int b, int c); };
 struct Platform { void UpdateClsnPosAndRot(); };
 struct MeshCollider { static KCL_File* LoadFile(SharedFilePtr& f); };
-struct MovingMeshCollider {
-    void SetFile(KCL_File* f, const Matrix4x3& m, int fix, short sh, CLPS_Block& b);
-};
+struct MovingMeshCollider { };
+/* Declared by its final name rather than as a shadow method: the ROM's symbol takes
+   Fix12<int> where the call site has an int, and Fix12<int> is an aggregate with no
+   converting constructor, so a shadow declaration cannot be both callable and mangle
+   correctly. Spelling the symbol literally sidesteps the mangling entirely -- the
+   parameter types then only decide the call ABI, and a Fix12 passes in one register
+   bit-identical to an int. */
+extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+    void* self, KCL_File* f, const Matrix4x3& m, int fix, short sh, CLPS_Block& b);
 struct MeshColliderBase { void Enable(Actor* a); };
 
 extern "C" void CopyTexPalFromLevelModel(void* p);
@@ -26,7 +32,7 @@ extern "C" int data_0208e738;
 extern "C" SharedFilePtr* data_ov060_02119514[];
 extern "C" SharedFilePtr* data_ov060_0211953c[];
 extern "C" CLPS_Block* data_ov060_0211a980[];
-extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
+extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern "C" void func_ov060_021183f4();
 
 extern "C" int func_ov060_021182b0(char* self);
@@ -42,8 +48,8 @@ int func_ov060_021182b0(char* self)
     ((Platform*)self)->UpdateClsnPosAndRot();
     {
         int i = *(unsigned char*)(self + 0x329);
-        ((MovingMeshCollider*)(self + 0x124))->SetFile(
-            MeshCollider::LoadFile(*data_ov060_0211953c[i]),
+        _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+            self + 0x124, MeshCollider::LoadFile(*data_ov060_0211953c[i]),
             *(Matrix4x3*)(self + 0x2ec), 0x1000, *(short*)(self + 0x8e),
             *data_ov060_0211a980[i]);
     }

--- a/src/func_ov098_021390ec.cpp
+++ b/src/func_ov098_021390ec.cpp
@@ -3,6 +3,10 @@
 // @symbol func_ov098_021390ec
 /* recovered: shared common types */
 #include "common.h"
+/* Final name, not a shadow method: the ROM symbol takes Fix12<int> and the call
+   site has an int. See func_ov060_021182b0.cpp for the same case. */
+extern "C" short _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void* self, int a, int b,
+                                                       short c);
 struct ClsnResult { int GetClsnID() const; };
 struct SurfaceInfo { void CopyNormalTo(Vector3 &) const; };
 struct WithMeshClsn {
@@ -43,11 +47,10 @@ struct Actor {
     virtual void v30();
     virtual void vcall();
     static Actor *FindWithID(u32 id);
-    s16 ReflectAngle(int a, int b, s16 c);
 };
 
 extern "C" u8 DecIfAbove0_Byte(u8 *p);
-extern int func_ov002_020ef228(void *c, int arg);
+extern "C" int func_ov002_020ef228(void *c, int arg);
 
 extern "C" void func_ov098_021390ec(char *cc)
 {
@@ -79,5 +82,6 @@ extern "C" void func_ov098_021390ec(char *cc)
     }
     Vector3 v;
     ((SurfaceInfo *)((char *)((WithMeshClsn *)((char *)c + 0x320))->GetWallResult() + 4))->CopyNormalTo(v);
-    *(s16 *)((char *)c + 0x94) = c->ReflectAngle(v.x, v.z, *(s16 *)((char *)c + 0x94));
+    *(s16 *)((char *)c + 0x94) =
+        _ZN5Actor12ReflectAngleE5Fix12IiES1_s(c, v.x, v.z, *(s16 *)((char *)c + 0x94));
 }

--- a/src/func_ov100_0214109c.cpp
+++ b/src/func_ov100_0214109c.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+extern "C" void _ZN9ActorBase18MarkForDestructionEv(void*);
 typedef int Fix12;
 
 
@@ -22,7 +23,7 @@ void func_ov100_0214109c(void *t) {
         }
         int sub = *(signed char*)(c+0xcc);
         _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16as(0x114, 0, (struct Vector3*)(c+0x5c), 0, sub, -1);
-        ActorBase_MarkForDestruction(c);
+        _ZN9ActorBase18MarkForDestructionEv(c);
         return;
     }
     if (st <= 0x14) return;


### PR DESCRIPTION
A file can reproduce every byte of the cartridge and still be absent from the ROM build.
If it names a symbol nothing defines, `eligible.py` refuses it (rule 5), it never gets
`complete` in delinks, and dsd serves the ROM's own bytes instead. Nothing turns red —
`match.py` wildcards every relocated word, so a byte compare cannot see it either. Only
`check_references` can.

`config/unresolved-baseline.json` held **95** such functions. This lands the **10** whose
every blocker is decidable from the symbol table alone.

## The rule: a candidate, or nothing

Each proposal had to come from one of four evidence classes, and anything with zero or
more than one candidate was reported unresolved rather than guessed:

| class | evidence | n |
|---|---|---|
| `DEMANGLE` | the phantom is `_Z<len><realname><params>` and `<realname>` is defined — the real name is a **literal substring** | 53 |
| `METHOD` | `Class_Method` where **exactly one** defined symbol mangles that class + method | 40 |
| `ARITY` | a mangled name that is not defined, where exactly one defined symbol has the same class + method with other parameters | 13 |
| `ADDRESS` | `func_`/`data_<addr>` where **exactly one** symbol sits at that address | 1 |

`DEMANGLE` is the double-mangling defect: a bare `extern T Name(...)` in a `//cpp` file
mangles `Name` a second time, so the emitted reference names nothing. The declaration was
already right — only its linkage was wrong.

`METHOD` is `include/decl_common.h` declaring invented names — `WithMeshClsn_IsOnGround`,
`Model_LoadFile`, `Platform_UpdateClsnPosAndRot` — that no symbol table defines.

`ADDRESS` was `data_ov071_02122ecc_d`: a `_d` suffix invented because one address needed
two types in one file. The real-named declaration sat directly above it, unused.

All 10 **byte-match under `build_pin` (2004/b56)** after the change. Nothing here is a new
decompilation — only names the linker can now resolve.

## Two wrong approaches, both measured, both reverted

**Renaming inside `decl_common.h` → 210 compile failures.** The 210 files that already
declare the real symbol locally get a second, `void*`-typed declaration from the shared
header, which mwccarm rejects as an illegal overload. #1541's defect from the other
direction. Every edit here is in-file; `decl_common.h` is untouched.

**Adding `extern "C"` tree-wide → 266 compile failures.** The `//cpp` marker, not the
extension, selects C++, and `extern "C"` is a syntax error in the c99 files it reached.

The two `ARITY` sites could not become shadow methods either: `Fix12<int>` is an aggregate
with no converting constructor, so a shadow declaration cannot be both callable from an
`int` call site and mangle to the ROM's name — and adding a constructor risks how the type
is passed. Both are declared by final name in an `extern "C"` block, which sidesteps
mangling entirely.

## Verification

```
rombuild.py -j16 --no-rom   106/106 exact, 100.000000%
                            source-built 10,999  reproducing 10,999  mismatching 0
                            2,028,104 / 2,211,124 = 91.72%   (+10 fn, +3,332 bytes)
eligible.py                 10,999 / 11,169      (10,989 -> 10,999)
build_pin                   10 / 10 byte-match
check_references            85 unresolved (was 95); "10 fixed", no new unresolvable
port_refcheck               393 checked, all resolve
bytegate                    1 row, 1 live, 0 stale
langmode ratchet            PASS
attribution                 11,333 tracked, 0 changed, 0 lost
```

Every one of the 10 left the unresolved set **by becoming eligible**, not by failing for a
different reason — which is the distinction `check_references` exists to draw.

## What is left

**85 blocked functions**, needing evidence a symbol table cannot give: the `_ZTV*`
per-family intermediates (a known trap — one invented name standing for several distinct
symbols), `decl_common`'s `G`/`G0`/`table$6` inventions, and per-actor-overlay data slots
with 9–21 candidates where co-residency is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT
