### PR TITLE
Repair func_ov002_020e3e00: a header collision hid it, a phantom blocked it

### DIFF
--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -4026,6 +4026,7 @@ src/_ZN6Player6RenderEv.cpp:
     .text start:0x020e3a08 end:0x020e3e00
 
 src/func_ov002_020e3e00.cpp:
+    complete
     .text start:0x020e3e00 end:0x020e3f90
 
 src/func_ov002_020e3f90.c:

--- a/src/func_ov002_020e3e00.cpp
+++ b/src/func_ov002_020e3e00.cpp
@@ -1,15 +1,34 @@
 //cpp
 // @symbol func_ov002_020e3e00
-/* recovered: shared common types, declarations from a shared header */
-#include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 //
+
+/* decl_common.h is deliberately NOT included. This file declares its callees
+   concretely -- `const int *`, `unsigned int`, `Model *` -- while the header
+   declares the same symbols with generic `void*`/`int`. Under `extern "C"`
+   those are not compatible redeclarations but illegal overloads, so the file
+   did not compile AT ALL (errors on the MulMat3x3Mat3x3, func_02016acc and
+   func_ov002_020e3e00 lines) for as long as the include was here -- which is
+   why no gate ever noticed: an uncompilable file is dropped by all of them.
+   Only two declarations were ever needed from the header; they are restated
+   below under their real names. */
 
 extern "C" {
     extern signed char data_0209f2f8;
     extern signed char data_02092120;
     extern int data_020a0e68[12];
+
+    /* Were spelled `func_02111b64` / `func_02111b6c` -- invented names that
+       exist in no symbols.txt anywhere in config/. ov002's own relocs record
+       both sites as `kind:load` to an address claimed by 17 and 13 modules
+       respectively (config/arm9/overlays/ov002/relocs.txt:6676-6677). A `load`
+       cannot answer a function, which rules out ov012/ov025/ov045/ov052; of
+       the data claimants that remain, ov055 alone declares BOTH addresses
+       unambiguous `kind:bss`. ov017 and ov033 are clean at 0x02111b6c but
+       ambiguous at 0x02111b64; every other candidate is ambiguous at both. */
+    extern int data_ov055_02111b64;
+    extern int data_ov055_02111b6c;
 
     void func_0203c178(int *dst, int a, int b, int c);
     void MulMat3x3Mat3x3(int *dst, const int *a, const int *b);
@@ -35,7 +54,7 @@ extern "C" void func_ov002_020e3e00(Model *obj, Vector3 *vec, unsigned int opaci
 
     if (ip) {
         int ok;
-        if (func_02111b6c == 0 || (func_02111b64 & 0x20000) != 0)
+        if (data_ov055_02111b6c == 0 || (data_ov055_02111b64 & 0x20000) != 0)
             ok = 1;
         else
             ok = 0;


### PR DESCRIPTION
This function is byte-perfect, and has been all along. Two defects kept anyone from finding out, and **each one hid the other**.

## 1. It did not compile

The file includes `decl_common.h` and then declares its callees concretely:

| | file says | header says |
|---|---|---|
| `MulMat3x3Mat3x3` | `(int *dst, const int *a, const int *b)` | `(void*, void*, void*)` |
| `func_02016acc` | `(void *obj, unsigned int mask)` | `(void*, int)` |
| `func_ov002_020e3e00` | `(Model*, Vector3*, unsigned int)` | `(void*, void*, u32)` |

Under `extern "C"` those are not compatible redeclarations — they are **illegal overloads**, and mwccarm rejected the file outright.

That is precisely why nothing ever complained. **An uncompilable file is dropped by every gate in this tree, and `106/106` stays green.** Same defect class as #1541, which repaired 15 files this way; the fix is the same recipe — drop the include, restate only what the body actually needs.

## 2. The two declarations it actually needed were phantoms

Restating "only what the body needs" left exactly two symbols: `func_02111b64` and `func_02111b6c`. Neither exists in **any** `symbols.txt` in `config/`.

ov002's own relocations record both sites as `kind:load` to an address claimed by 17 and 13 modules respectively (`config/arm9/overlays/ov002/relocs.txt:6676-6677`). Resolving it:

- a `load` cannot answer a **function**, which rules out ov012, ov025, ov045 (`_ZN16FloatingFloorBfsD0Ev`) and ov052;
- of the data claimants that remain, **ov055 alone declares BOTH addresses unambiguous `kind:bss`**;
- ov017 and ov033 are clean at `0x02111b6c` but `ambiguous` at `0x02111b64`; every other candidate is `ambiguous` at both.

Renamed to `data_ov055_02111b64` / `data_ov055_02111b6c`, which `decl_common.h` already declares at lines 1170 and 1172.

**This is the reference that made #1541 revert its own repair of this function** — it byte-matched, but `resolve_placeholders` could not resolve the ambiguous address, so it could not be enrolled. Resolving it is what unblocks enrollment.

## Verification

```
byte        build_pin.verify(func_ov002_020e3e00, 0x020e3e00, 0x190, ov002)
            -> (True, '2004/b56')

eligible    11000 / 11170 before,  11001 / 11170 after
            name list gains exactly one entry, func_ov002_020e3e00, loses none

references  unresolved symbols: 85 (baseline 85)
            OK: no new unresolvable references

rombuild    source-built functions: 11,001 — reproducing 11,001, mismatching 0
            module fidelity: 106/106 exact, 100.000000% of compared bytes
            ROM-build analysis: PASS
```

`rombuild` is the one that matters here. This change does not merely make a file match — the `complete` marker in `ov002/delinks.txt` **enrolls** it, so it is genuinely linked into the ROM for the first time. A wrong callee behind a relocated word is invisible to the byte gate, which wildcards it; the link is the only thing that could have refuted the ov055 attribution, and it did not.

Independent of #1547 and #1548 (different files; this one does not touch `include/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01537rCges61uTkNNen7F6vJ