### PR TITLE
Give Platform its 32nd vtable slot: Platform::Kill (ov002 0x020ee55c)

### DIFF
--- a/include/Platform.h
+++ b/include/Platform.h
@@ -93,6 +93,28 @@ struct Platform : Actor {
        translation unit that merely includes this header emits _ZTV8Platform. */
     virtual ~Platform() {}
 
+    /* SLOT 31, AND THE ONLY NEW VIRTUAL THIS CLASS ADDS. Actor ends at slot 30,
+       so this one word is the whole difference between the vtable this header
+       emitted and the one in the cartridge.
+
+       _ZTV8Platform is 0x84 at ov002:0x0210ae38 -- 33 words, one more than the
+       32 an Actor-shaped table needs -- and _ZTV8PoleLift, one of the 70
+       subclasses, is 0x84 as well. rtti_vtables agrees from the other side:
+       dBgActor_c's parent dActor_c has 31 slots and dBgActor_c's own overrides
+       are 16 (D1), 17 (D0) and 31, and 97 of its 101 RTTI children have exactly
+       32 slots. Without this line every one of those tables came out a word
+       short, which is why daObjFallBlock_c::Kill and its siblings had to reach
+       slot 31 through a hand-declared 32-slot shadow struct.
+
+       Kill is not an override: no ancestor declares it, so `virtual` here
+       CREATES the slot. It also makes Kill this class's key function -- the
+       destructor above is inline on purpose -- so the TU defining it emits
+       _ZTV8Platform, _ZTI8Platform and the destructor variants alongside. That
+       is expected and handled: objisolate.py reduces the object to the one
+       function its delink entry declares before eligible.py and rombuild.py
+       judge it. */
+    virtual void Kill();
+
     /* --- non-virtual --- */
     void KillByMegaChar(Player &player_);
     void UpdateClsnPosAndRot();

--- a/include/Sound.h
+++ b/include/Sound.h
@@ -19,7 +19,16 @@
 
 #ifdef __cplusplus
 
+#include "types.h"
+
 namespace Sound {
+
+/* A bank-bound wrapper over Sound::Play, defined in
+   src/_ZN5Sound9PlayBank3EjRK7Vector3.cpp. The position is a REFERENCE -- the
+   mangled name says RK7Vector3 -- and a caller spelling it as a pointer is
+   byte-identical, which is why the wrong spelling survived so long in the
+   sources that call it. Declared here so callers stop hand-mangling the name. */
+void PlayBank3(u32 id, const Vector3 &pos);
 
 struct Player {
     /* STATIC, and the bytes are what say so. A non-static member would take

--- a/notes/actor-vtables.md
+++ b/notes/actor-vtables.md
@@ -163,3 +163,72 @@ listed in the commit that detached them from `Player.h`. Measured against `sizeo
 = 0x768, they read offsets like 0x4eb0 and 0x62ad, thousands of bytes past the end of the
 object. Do not treat a `_ZN6Player*` name as proof of module membership; check which
 `symbols.txt` owns the address.
+
+## Platform — 0x0210ae30 (ov002), 32 slots
+
+`Platform` (RTTI name `dBgActor_c`) derives **directly from Actor** and is the base of the
+largest family in the tree: **101 direct RTTI children, 132 classes in the whole subtree.**
+
+It is the first class in this document that **adds** a virtual rather than only overriding
+one. Its table is Actor's 31 slots with three differences:
+
+| # | override |
+|---:|---|
+| 16 | `~Platform` (D1) — ov002 `0x020ee42c` |
+| 17 | `~Platform` (D0) — ov002 `0x020ee464` |
+| **31** | **`Platform::Kill()` — ov002 `0x020ee55c`, NEW** |
+
+### The 32nd slot, and how long it was missing
+
+`include/Platform.h` declared nothing but `virtual ~Platform() {}` until 2026-08-16, so
+every translation unit that included it emitted a **31-slot** table against the cartridge's
+32. Nothing caught it: no source file delivers `_ZTV8Platform` — the ROM's gap object does
+— and `objisolate.py` drops the vtable a key-function TU emits before any byte gate sees
+it. The table was wrong in the only place it could be wrong silently.
+
+Four independent measurements agree it is 32:
+
+- **`_ZTV8Platform` spans `0x0210ae30`..`0x0210aeb8` = 0x88 bytes.** Two header words plus
+  32 slots. `_ZTV8PoleLift`, one of the subclasses, is 0x88 as well.
+- `rtti_vtables.py` reads `dActor_c` at 31 slots and `dBgActor_c`'s own overrides as
+  16, 17 and **31**.
+- **97 of `dBgActor_c`'s 101 direct RTTI children have exactly 32 slots** (three add one or
+  two more of their own; `daObjBlockS_c` adds 31).
+- With `virtual void Kill();` declared, mwcc emits a `_ZTV8Platform` of **exactly 0x88**.
+
+What the gap cost is visible in the sources: fourteen subclasses override slot 31, and
+their bodies reach it through a hand-declared 32-slot shadow struct because no real class
+spelled that slot.
+
+### There IS an RTTI header here, and `_ZTV8Platform` is not where it starts
+
+The note at the top of this file — "CodeWarrior 1.2 emits no RTTI header, so the address
+stored into `[this+0x0]` *is* slot 0" — holds for the four arm9 tables and **not** for this
+one:
+
+    0x0210ae30  0x00000000    offset-to-top
+    0x0210ae34  0x021089ec    _ZTI8Platform
+    0x0210ae38  0x02043c80    slot 0            <- config's _ZTV8Platform is HERE
+
+`config/arm9/overlays/ov002/symbols.txt` puts `_ZTV8Platform` at the **address point**,
+`0x0210ae38`, which is the vptr value; mwcc emits its `_ZTV8Platform` at the **object
+start**, eight bytes earlier. Nothing depends on this today because the compiled vtable is
+always dropped, but a future change that tries to make a source file *deliver* a Platform
+vtable has to reconcile the eight bytes first.
+
+### Key function, and what it did to the D0 file
+
+`~Platform()` is inline on purpose — the seventy-odd subclasses inline its vptr store
+rather than calling it — so `Kill` is the **first out-of-line virtual and therefore the key
+function**. Its TU emits `_ZTV8Platform`, `_ZTI8Platform` and the destructor variants;
+`objisolate.py` reduces the object back to Kill's one `0x74` `.text` before the gates see
+it.
+
+The second-order effect is the one worth remembering. While Platform had **no** key
+function, any TU touching the destructor group emitted all of it, and
+`src/_ZN8PlatformD0Ev.cpp` got D0 from a plain `p->~Platform()` call. Once Kill exists, D0
+is emitted *only* where the vtable is — so that file compiled to D1 plus its own forcing
+function, two `.text` sections, and **dropped out of the build with every byte gate still
+green**. `delete p` asks for the deleting half by name and brings it back. The same
+sentence is in `src/_ZN19dScMgSingle3DBase_cD0Ev.cpp`, which has had a key function since
+\#1544.

--- a/src/_ZN8Platform4KillEv.cpp
+++ b/src/_ZN8Platform4KillEv.cpp
@@ -1,30 +1,51 @@
 //cpp
-// _ZN8Platform4KillEv at 0x020ee55c
-// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
-struct Vector3 { int x, y, z; };
+// @symbol _ZN8Platform4KillEv
+/* Platform::Kill() at ov002 0x020ee55c, 0x74 bytes -- vtable slot 31.
+ *
+ * THE SLOT THIS CLASS ADDS. Actor's table ends at slot 30; Kill is the one new
+ * virtual Platform declares, and 97 of the 101 classes deriving from it have
+ * exactly 32 slots because of this function. See include/Platform.h.
+ *
+ * Kill is also, necessarily, Platform's key function: the destructor is inline
+ * on purpose (every subclass inlines its body rather than calling
+ * _ZN8PlatformD1Ev), so this is the first out-of-line virtual and this TU emits
+ * _ZTV8Platform, _ZTI8Platform and the destructor variants. objisolate.py
+ * reduces the object back to this one function before the byte gates see it.
+ *
+ * The particle spawns 0x64000 -- one 20.12 unit is 0x1000, so 100 units --
+ * above the platform, and the poof and the sound both take the position by
+ * reference. mCamSpacePos is read as a Vector3 through its first member, which
+ * is how the rest of the tree spells that triple (see BulletBill::Behavior).
+ *
+ * Particle::System::NewSimple stays spelled as its mangled name: its parameters
+ * are Fix12<int> BY VALUE, and declaring the true types changes how the caller
+ * passes them and breaks the bytes. Same reason, same note, as
+ * src/_ZN5Actor10PoofDustAtERK7Vector3.cpp -- notes/mwccarm-codegen.md 6az. */
+#include "Platform.h"
+#include "Sound.h"
 
-extern "C" {
-void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
-void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
-void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
-void _ZN9ActorBase18MarkForDestructionEv(void* self);
-}
+extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(
+    u32 id, Fix12i x, Fix12i y, Fix12i z);
 
-extern "C" void _ZN8Platform4KillEv(char* self);
-void _ZN8Platform4KillEv(char* self) {
-    Vector3 vec;
-    Vector3 vec2;
-    int x = *(int*)(self + 0x5c);
-    int y = *(int*)(self + 0x60) + 0x64000;
-    int z = *(int*)(self + 0x64);
-    vec.x = x;
-    vec.y = y;
-    vec.z = z;
-    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xa, vec.x, vec.y, vec.z);
-    ((int*)&vec2)[0] = ((int*)&vec)[0];
-    ((int*)&vec2)[1] = ((int*)&vec)[1];
-    ((int*)&vec2)[2] = ((int*)&vec)[2];
-    _ZN5Actor10PoofDustAtERK7Vector3(self, vec2);
-    _ZN5Sound9PlayBank3EjRK7Vector3(0x41, *(Vector3*)(self + 0x74));
-    _ZN9ActorBase18MarkForDestructionEv(self);
+void Platform::Kill()
+{
+    Vector3 pos;
+    Vector3 dustPos;
+    Fix12i x = mPosX;
+    Fix12i y = mPosY + 0x64000;
+    Fix12i z = mPosZ;
+    pos.x = x;
+    pos.y = y;
+    pos.z = z;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xa, pos.x, pos.y, pos.z);
+    /* MEMBERWISE, NOT `dustPos = pos`. Vector3 declares a destructor (see
+       types.h), so it is non-POD, and a whole-object assignment compiles to an
+       ldm/stm pair -- four instructions where the ROM has six. Three field
+       stores are what the cartridge does. */
+    dustPos.x = pos.x;
+    dustPos.y = pos.y;
+    dustPos.z = pos.z;
+    PoofDustAt(dustPos);
+    Sound::PlayBank3(0x41, *(Vector3 *)&mCamSpacePosX);
+    MarkForDestruction();
 }

--- a/src/_ZN8PlatformD0Ev.cpp
+++ b/src/_ZN8PlatformD0Ev.cpp
@@ -5,9 +5,21 @@
  * ~Platform is defined in the class body -- the seventy-odd classes derived
  * from it inline its vptr store rather than calling it, which the compiler can
  * only do from a visible body. So this file cannot define it, and a TU that
- * merely includes the header emits nothing. The explicit destructor call below
- * forces the whole group into existence; objisolate keeps the one this file is
- * bound to and drops the rest.
+ * merely includes the header emits nothing. The delete-expression below forces
+ * the deleting destructor's own out-of-line copy into existence; objisolate
+ * keeps the one this file is bound to and drops the rest.
+ *
+ * A DELETE-EXPRESSION, NOT `p->~Platform()`, AND THE DIFFERENCE IS NEW. While
+ * Platform declared no virtual but its inline destructor it had no key
+ * function, so any TU that touched the destructor group emitted all of it and
+ * a plain destructor call was enough. Platform now declares Kill (slot 31, see
+ * the header), which IS a key function -- so D0 is emitted only where the
+ * vtable is, and the destructor call here stopped producing it: this file
+ * compiled to D1 plus the forcing function, two .text sections, and dropped
+ * out of the build with every byte gate still green. `delete p` asks for the
+ * deleting half by name and brings it back. Same shape, same fix, same
+ * sentence in src/_ZN19dScMgSingle3DBase_cD0Ev.cpp, which has had a key
+ * function since #1544.
  *
  * D0 is the deleting half: destroy through Platform and Actor, then hand the
  * object back through Actor's inline operator delete, which is why nothing
@@ -15,8 +27,8 @@
  */
 #include "Platform.h"
 
-/* Not called. Forces the out-of-line copy of the inline destructor group. */
+/* Not called. Forces the out-of-line copy of the deleting destructor. */
 void Platform_EmitDeletingDestructor(Platform *p)
 {
-    p->~Platform();
+    delete p;
 }


### PR DESCRIPTION
`include/Platform.h` declared nothing but `virtual ~Platform() {}`, so every translation
unit that included it emitted a **31-slot vtable against the cartridge's 32**. Nothing
caught it: no source file delivers `_ZTV8Platform` — the ROM's gap object does — and
`objisolate.py` drops the vtable a key-function TU emits before any byte gate sees it. The
table was wrong in the one place it could be wrong silently.

`Platform` is `dBgActor_c`, the base of the largest family in the tree: **101 direct RTTI
children, 132 classes in the subtree.**

## Four independent measurements say 32

```
_ZTV8Platform spans 0x0210ae30..0x0210aeb8 = 0x88   two header words + 32 slots
_ZTV8PoleLift, one of the subclasses                also 0x88
rtti_vtables: dActor_c 31 slots, dBgActor_c own 16 (D1), 17 (D0), 31
97 of dBgActor_c's 101 direct children              exactly 32 slots
with `virtual void Kill();` declared, mwcc emits    exactly 0x88
```

The cost of the gap is visible in the sources: fourteen subclasses override slot 31, and
their bodies reach it through a hand-declared 32-slot shadow struct, because until now no
real class spelled that slot.

## `Platform::Kill` becomes a real method

116 bytes, byte-identical under the pin. Two details the ROM insisted on:

- **The `Vector3` copies are memberwise.** `Vector3` declares a destructor (see `types.h`),
  so it is non-POD and `a = b` compiles to an ldm/stm pair — four instructions where the ROM
  has six. Three field stores are what the cartridge does.
- **`Particle::System::NewSimple` stays spelled as its mangled name.** Its parameters are
  `Fix12<int>` by value; declaring the true types changes how the caller passes them and
  breaks the bytes. Same note, same reason, as `src/_ZN5Actor10PoofDustAtERK7Vector3.cpp`.

## The second-order effect, which is the part worth remembering

While Platform had **no** key function, any TU touching the destructor group emitted all of
it, and `src/_ZN8PlatformD0Ev.cpp` got D0 from a plain `p->~Platform()` call.

`Kill` is the first out-of-line virtual and therefore **is** a key function — its destructor
stays inline on purpose, because seventy-odd subclasses inline its vptr store. So D0 is now
emitted only where the vtable is, and that file compiled to D1 plus its own forcing
function: **two `.text` sections, dropped out of the build, with every byte gate still
green.** `delete p` asks for the deleting half by name and brings it back. The same sentence
is already in `src/_ZN19dScMgSingle3DBase_cD0Ev.cpp`, which has had a key function since
\#1544.

That is the `key-function-emits-vtable` failure one level deeper than it has been seen
before: not the file you edited dropping out, but a *sibling* file that you did not touch.
The eligible-name diff is what caught it, and it is why this change is on its own.

## `_ZTV8Platform` is not where mwcc puts it

Recorded in `notes/actor-vtables.md` because it will bite eventually:

```
0x0210ae30  0x00000000    offset-to-top
0x0210ae34  0x021089ec    _ZTI8Platform
0x0210ae38  0x02043c80    slot 0        <- config's _ZTV8Platform is HERE
```

The config symbol is the **address point**; mwcc emits its `_ZTV8Platform` at the **object
start**, eight bytes earlier. Nothing depends on it today because the compiled vtable is
always dropped, but a change that tries to make a source file *deliver* a Platform vtable
has to reconcile those eight bytes first. The note at the top of `actor-vtables.md` —
"CodeWarrior 1.2 emits no RTTI header" — holds for the four arm9 tables and not for this one.

## Verification, whole tree

```
build_pin.verify   Kill / D0 / D1 all True, 2004/b56
objisolate         error None, single .text 0x74
eligible           11,000 / 11,170   name list IDENTICAL to the baseline
source-built       11,000 functions, 2,029,048 / 2,211,124 code bytes (91.77%)
  reproducing      11,000      mismatching 0
module fidelity    106/106 exact, 100.000000% of compared bytes
check_references   85 unresolved (baseline 85) -- no new unresolvable references
port_refcheck      393 checked, 0 stale
check_header_offsets  Platform.h 5 commented fields, 0 mismatched
langmode ratchet   PASS
CONVERTED ratchet  PASS   1,576 == 1,576
attribution        11,334 tracked, 0 changed, 0 lost
```

**CONVERTED moves by zero, on purpose.** `Kill` scores 4 of 5 both before and after, held
back by `no_mangled_refs` on `NewSimple`. 123 files carry that declaration and 8 of them are
otherwise complete — a real, bounded hole, not a surprise.

## What it unblocks, measured

The Platform subtree is 132 classes, **116 of which already have a real C++ header**. 149 of
their vtable slots carry placeholder names that an ancestor's slot resolves, spread over 63
classes (49 with headers):

```
InitResources 30   Render 21   CleanupResources 19   Behavior 19
OnHitByMegaChar 17   Kill 14   OnGroundPounded 11   ...
```

The fourteen `Kill`s are the ones this change makes possible at all. Thirteen of them are on
a class that already has a header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdiRuUyAwsG1Xqb1yeof3g
