### PR TITLE
Give 18 size asserts the name of the struct they actually guard (and retract 2 bogus size errors)

### DIFF
--- a/include/ArmedRotatingPlatform.h
+++ b/include/ArmedRotatingPlatform.h
@@ -33,7 +33,7 @@ struct ArmedRotatingPlatform : Platform {
     int Render();
 };
 
-typedef char DonutBlock_size_must_be_0x320[sizeof(ArmedRotatingPlatform) == 0x320 ? 1 : -1];
+typedef char ArmedRotatingPlatform_size_must_be_0x320[sizeof(ArmedRotatingPlatform) == 0x320 ? 1 : -1];
 
 #endif /* __cplusplus */
 

--- a/include/BasementWater.h
+++ b/include/BasementWater.h
@@ -36,7 +36,7 @@ struct BasementWater : Platform {
     int Render();
 };
 
-typedef char SwitchPillar_size_must_be_0x340[sizeof(BasementWater) == 0x340 ? 1 : -1];
+typedef char BasementWater_size_must_be_0x340[sizeof(BasementWater) == 0x340 ? 1 : -1];
 
 #else
 

--- a/include/DonutBlock.h
+++ b/include/DonutBlock.h
@@ -37,7 +37,7 @@ struct DonutBlock : Platform {
     int Render();
 };
 
-typedef char ShipWing_size_must_be_0x4ec[sizeof(DonutBlock) == 0x4ec ? 1 : -1];
+typedef char DonutBlock_size_must_be_0x4ec[sizeof(DonutBlock) == 0x4ec ? 1 : -1];
 
 #else
 

--- a/include/FloatOnLavaPlatform.h
+++ b/include/FloatOnLavaPlatform.h
@@ -31,7 +31,7 @@ struct FloatOnLavaPlatform : Platform {
     int Render();
 };
 
-typedef char RotatingPlatformLll_size_must_be_0x328[sizeof(FloatOnLavaPlatform) == 0x328 ? 1 : -1];
+typedef char FloatOnLavaPlatform_size_must_be_0x328[sizeof(FloatOnLavaPlatform) == 0x328 ? 1 : -1];
 
 #else
 

--- a/include/Fwoosh.h
+++ b/include/Fwoosh.h
@@ -38,7 +38,7 @@ struct Fwoosh : Enemy {
     int Render();
 };
 
-typedef char Stump_size_must_be_0x378[sizeof(Fwoosh) == 0x378 ? 1 : -1];
+typedef char Fwoosh_size_must_be_0x378[sizeof(Fwoosh) == 0x378 ? 1 : -1];
 
 #else
 

--- a/include/HugeWater.h
+++ b/include/HugeWater.h
@@ -31,7 +31,7 @@ struct HugeWater : Platform {
     int Render();
 };
 
-typedef char HugeCover_size_must_be_0x334[sizeof(HugeWater) == 0x334 ? 1 : -1];
+typedef char HugeWater_size_must_be_0x334[sizeof(HugeWater) == 0x334 ? 1 : -1];
 
 #else
 

--- a/include/JetStream.h
+++ b/include/JetStream.h
@@ -35,7 +35,7 @@ struct JetStream : Enemy {
     virtual s32 Render();
 };
 
-typedef char BowserPuzzlePiece_size_must_be_0x31c[sizeof(JetStream) == 0x31c ? 1 : -1];
+typedef char JetStream_size_must_be_0x31c[sizeof(JetStream) == 0x31c ? 1 : -1];
 
 #else
 

--- a/include/KnockDownPlank.h
+++ b/include/KnockDownPlank.h
@@ -42,7 +42,7 @@ struct KnockDownPlank : Platform {
     int Render();
 };
 
-typedef char PoleBillboard_size_must_be_0x398[sizeof(KnockDownPlank) == 0x398 ? 1 : -1];
+typedef char KnockDownPlank_size_must_be_0x398[sizeof(KnockDownPlank) == 0x398 ? 1 : -1];
 
 #else
 

--- a/include/LavaPlank.h
+++ b/include/LavaPlank.h
@@ -30,7 +30,7 @@ struct LavaPlank : Platform {
     int Render();
 };
 
-typedef char FloatingFloorLllBig_size_must_be_0x328[sizeof(LavaPlank) == 0x328 ? 1 : -1];
+typedef char LavaPlank_size_must_be_0x328[sizeof(LavaPlank) == 0x328 ? 1 : -1];
 
 #else
 

--- a/include/MovingBar.h
+++ b/include/MovingBar.h
@@ -33,7 +33,7 @@ struct MovingBar : Platform {
     int Render();
 };
 
-typedef char KnockDownPlank_size_must_be_0x330[sizeof(MovingBar) == 0x330 ? 1 : -1];
+typedef char MovingBar_size_must_be_0x330[sizeof(MovingBar) == 0x330 ? 1 : -1];
 
 #else
 

--- a/include/PoleLift.h
+++ b/include/PoleLift.h
@@ -32,7 +32,7 @@ struct PoleLift : Platform {
     int Render();
 };
 
-typedef char FireSeaElevator_size_must_be_0x358[sizeof(PoleLift) == 0x358 ? 1 : -1];
+typedef char PoleLift_size_must_be_0x358[sizeof(PoleLift) == 0x358 ? 1 : -1];
 
 #else
 

--- a/include/RotatingBridge.h
+++ b/include/RotatingBridge.h
@@ -31,7 +31,7 @@ struct RotatingBridge : Platform {
     int Render();
 };
 
-typedef char TowerStep_size_must_be_0x324[sizeof(RotatingBridge) == 0x324 ? 1 : -1];
+typedef char RotatingBridge_size_must_be_0x324[sizeof(RotatingBridge) == 0x324 ? 1 : -1];
 
 #else
 

--- a/include/SpikeBomb.h
+++ b/include/SpikeBomb.h
@@ -58,7 +58,7 @@ struct SpikeBomb : Actor {
     int Render();
 };
 
-typedef char BowserSkyPlatform_size_must_be_0x32c[
+typedef char SpikeBomb_size_must_be_0x32c[
     sizeof(SpikeBomb) == 0x32c ? 1 : -1];
 
 #else

--- a/include/TTC_MovingBeam.h
+++ b/include/TTC_MovingBeam.h
@@ -35,7 +35,7 @@ struct TTC_MovingBeam : Platform {
     int Render();
 };
 
-typedef char TtcMovingCubeA_size_must_be_0x35c[sizeof(TTC_MovingBeam) == 0x35c ? 1 : -1];
+typedef char TTC_MovingBeam_size_must_be_0x35c[sizeof(TTC_MovingBeam) == 0x35c ? 1 : -1];
 
 #else
 

--- a/include/TinyWater.h
+++ b/include/TinyWater.h
@@ -34,7 +34,7 @@ struct TinyWater : Platform {
     int Render();
 };
 
-typedef char TinyCover_size_must_be_0x340[sizeof(TinyWater) == 0x340 ? 1 : -1];
+typedef char TinyWater_size_must_be_0x340[sizeof(TinyWater) == 0x340 ? 1 : -1];
 
 #else
 

--- a/include/TowerStep.h
+++ b/include/TowerStep.h
@@ -40,7 +40,7 @@ struct TowerStep : Platform {
     int Render();
 };
 
-typedef char MovingBarSmall_size_must_be_0x394[sizeof(TowerStep) == 0x394 ? 1 : -1];
+typedef char TowerStep_size_must_be_0x394[sizeof(TowerStep) == 0x394 ? 1 : -1];
 
 #else
 

--- a/include/WDW_Water.h
+++ b/include/WDW_Water.h
@@ -38,7 +38,7 @@ struct WDW_Water : Platform {
     int Render();
 };
 
-typedef char RotatingPlatformWdw_size_must_be_0x348[sizeof(WDW_Water) == 0x348 ? 1 : -1];
+typedef char WDW_Water_size_must_be_0x348[sizeof(WDW_Water) == 0x348 ? 1 : -1];
 
 #else
 

--- a/include/Whirlpool.h
+++ b/include/Whirlpool.h
@@ -54,6 +54,6 @@ struct Whirlpool : Enemy {
     void OnPendingDestroy();
 };
 
-typedef char Submarine_size_must_be_0x1bc[sizeof(Whirlpool) == 0x1bc ? 1 : -1];
+typedef char Whirlpool_size_must_be_0x1bc[sizeof(Whirlpool) == 0x1bc ? 1 : -1];
 
 #endif /* WHIRLPOOL_H */


### PR DESCRIPTION
Each of these labels a size assert with a **neighbouring class's** name, while the guard expression itself is correct:

```c
typedef char DonutBlock_size_must_be_0x320[sizeof(ArmedRotatingPlatform) == 0x320 ? 1 : -1];
typedef char KnockDownPlank_size_must_be_0x330[sizeof(MovingBar) == 0x330 ? 1 : -1];
```

Same shifted-name family as the 41 actor classes carrying the next vtable's name. All 18 are in `include/`; the guard size agrees with the label size in **every** one (0 mismatches across all 234 asserts in the tree); and a typedef name is never referenced, so this is a pure record-correctness fix.

| header | was labelled | actually guards |
|---|---|---|
| `ArmedRotatingPlatform.h` | DonutBlock | ArmedRotatingPlatform |
| `BasementWater.h` | SwitchPillar | BasementWater |
| `DonutBlock.h` | ShipWing | DonutBlock |
| `FloatOnLavaPlatform.h` | RotatingPlatformLll | FloatOnLavaPlatform |
| `Fwoosh.h` | Stump | Fwoosh |
| `HugeWater.h` | HugeCover | HugeWater |
| `JetStream.h` | BowserPuzzlePiece | JetStream |
| `KnockDownPlank.h` | PoleBillboard | KnockDownPlank |
| `LavaPlank.h` | FloatingFloorLllBig | LavaPlank |
| `MovingBar.h` | KnockDownPlank | MovingBar |
| `PoleLift.h` | FireSeaElevator | PoleLift |
| `RotatingBridge.h` | TowerStep | RotatingBridge |
| `SpikeBomb.h` | BowserSkyPlatform | SpikeBomb |
| `TinyWater.h` | TinyCover | TinyWater |
| `TowerStep.h` | MovingBarSmall | TowerStep |
| `TTC_MovingBeam.h` | TtcMovingCubeA | TTC_MovingBeam |
| `WDW_Water.h` | RotatingPlatformWdw | WDW_Water |
| `Whirlpool.h` | Submarine | Whirlpool |

## This also retracts two entries from the wrong-size worklist

The earlier size survey recorded `BowserPuzzlePiece 0x31c -> 0x378` and `TtcMovingCubeA 0x35c -> 0x38c` as confirmed size errors.

**Neither class has a size assert at all.** Those numbers came off the mislabelled asserts in `JetStream.h` and `TTC_MovingBeam.h` — 0x31c is JetStream's size and 0x35c is TTC_MovingBeam's, and both are correct. The survey was comparing one class's assert against a different class's ROM literal.

`BowserSkyPlatform` had already been flagged "recheck by hand" for exactly this smell, and this explains it: `SpikeBomb.h` was labelled BowserSkyPlatform, so two separate asserts read 0x32c. BowserSkyPlatform's own assert is the one to judge; it stays open.

Two more now need the same recheck rather than being taken at face value: `PoleBillboard`'s own assert says **0x124** while the assert *labelled* PoleBillboard (in `KnockDownPlank.h`) says **0x398**.

## Byte-neutrality

Verified with the strong test, not the count: `eligible.py` name lists before and after are **identical** — 11,001 entries, nothing entered or left the set. `check_header_offsets` on all 18 reports 0 mismatched, 0 unparsed, with non-zero field counts so the check actually ran rather than passing vacuously.

One gate note worth carrying: `check_header_offsets.py --changed origin/main` reads **committed** diffs, so against a dirty tree it prints *"no include/ header added or modified"* and exits 0. That is a pass that is not a pass — name the headers explicitly when checking uncommitted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT