### PR TITLE
Replace two fabricated lookup tables with the ROM's own (and close out the local-static phantom class)

### DIFF
--- a/src/func_02044b30.c
+++ b/src/func_02044b30.c
@@ -72,7 +72,12 @@ void func_02044b30(char *obj, int idx)
 
     case 2:
     {
-      s16 buf[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+      /* The ROM's template for this array is data_02099f94 = {4,8,16,32,64,128,256,512},
+         i.e. 4 << i, a texture-size table. What stood here was {1,2,...,8}, invented and
+         never compared to anything: mwccarm puts a local initializer in an anonymous
+         .rodata object (`@30`) that objisolate drops, and match.py wildcards the
+         relocation to it, so the file byte-matched with the wrong data in it. */
+      s16 buf[8] = {4, 8, 16, 32, 64, 128, 256, 512};
       int idx1;
       int idx2;
       s16 sa;

--- a/src/func_ov004_020b2cb8.c
+++ b/src/func_ov004_020b2cb8.c
@@ -6,6 +6,7 @@ typedef struct Entry {
 extern int GetGameLanguage(void);
 extern int LoadFile(int handle);
 
+extern int data_ov004_020b9f54;
 extern int data_ov004_020bc42c[];
 extern int data_ov004_020bc65c[];
 extern int data_ov004_020bc418[];
@@ -70,36 +71,18 @@ extern int data_ov004_020bf5d4[];
 void func_ov004_020b2cb8(void)
 {
     int i;
+    /* The ROM's template for this array is at 0x020bc6e8 and is all zero except
+       entry 1. What stood here was 29 invented pairs {1,100}, {2,101} ... {29,128};
+       none of them were ever compared to anything, because mwccarm puts a local
+       initializer in an anonymous .rodata object (`@7`) that objisolate drops and
+       match.py wildcards the relocation to.
+
+       It matters for exactly one entry. Every index except 1 is overwritten below
+       before the loop reads it -- entry 1 is not, so its initial value is live, and
+       it was wrong. */
     Entry entries[29] = {
-        { 1, 100 },
-        { 2, 101 },
-        { 3, 102 },
-        { 4, 103 },
-        { 5, 104 },
-        { 6, 105 },
-        { 7, 106 },
-        { 8, 107 },
-        { 9, 108 },
-        { 10, 109 },
-        { 11, 110 },
-        { 12, 111 },
-        { 13, 112 },
-        { 14, 113 },
-        { 15, 114 },
-        { 16, 115 },
-        { 17, 116 },
-        { 18, 117 },
-        { 19, 118 },
-        { 20, 119 },
-        { 21, 120 },
-        { 22, 121 },
-        { 23, 122 },
-        { 24, 123 },
-        { 25, 124 },
-        { 26, 125 },
-        { 27, 126 },
-        { 28, 127 },
-        { 29, 128 },
+        { 0, 0 },
+        { 0x140, (int)&data_ov004_020b9f54 },
     };
 
     entries[0].id = data_ov004_020bc42c[GetGameLanguage()];


### PR DESCRIPTION
Both files **byte-match before and after**. That is the problem, not the reassurance.

mwccarm puts a local array initializer in an anonymous `.rodata` object (`@30`, `@7`); `objisolate` drops that section, and `match.py` wildcards the relocation to it. So the initializer *contents* were never compared to anything and could hold whatever anyone typed. They did.

### `func_02044b30`

```c
s16 buf[8] = {1, 2, 3, 4, 5, 6, 7, 8};
```

The ROM's template is `data_02099f94` = `{4, 8, 16, 32, 64, 128, 256, 512}` — i.e. `4 << i`, a texture-size table. The file already declared `data_02099f94` and never used it.

### `func_ov004_020b2cb8`

```c
Entry entries[29] = { {1,100}, {2,101}, ... {29,128} };
```

The ROM's template at `0x020bc6e8` is **all zero except entry 1**, which is `{0x140, &data_ov004_020b9f54}`. Twenty-eight of twenty-nine pairs were invented.

It matters for exactly one of them, and it happens to be the one that was wrong: every index *except* 1 is overwritten from `data_ov004_020bcXXX[GetGameLanguage()]` before the loop reads it. Entry 1 is not, so its initial value is live.

## These five files cannot be enrolled, and that is now settled

I went in expecting to restructure the anonymous objects into file-scope externs at the ROM's addresses. **That does not work, and the ROM says why.**

Retail `func_02044b30` loads `data_02099f94` and runs mwcc's standard initializer **copy loop** into a stack buffer, then indexes the stack copy:

```
ldr  r4,[pc,#0xb4]   ; the template
add  r3, sp, #0x30   ; buf
mov  r2, #4
ldrh r1,[r4],#2 / ldrh r0,[r4],#2 / strh r1,[r3],#2 / strh r0,[r3],#2 / bne
add  r1, sp, #0x30   ; index the STACK copy
```

(The `add sp, sp, #0x40` at the epilogue corroborates it: 0x30 for `mtx[12]` plus 0x10 for `buf`.)

Reproducing that needs a local array with an initializer — and *that construct is exactly what emits the anonymous object*. Measured, all three fail on length: indexing the extern directly, a hand-written `do/while` copy, and a hand-written `for` loop. Only the initializer reproduces.

So `@N` / `table$N` are **inherent to one-function-per-file isolation**, not naming defects to repair. `unresolved` stays 60; this PR buys correctness, not coverage.

## The other three were checked the same way and are correct

`func_ov002_020bd664`, `func_ov002_020f7d74` and `func_ov004_020b87e0` hold pointer-to-member tables whose entries are relocations — also wildcarded, also unverified until now. All **58** table addresses were read per-site out of the cartridge and every one agrees with the source. No change needed.

## Gates

`eligible` 11,026, `check_references` OK — unresolved unchanged at 60, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT