### PR TITLE
Correct three class sizes from the ROM's operator new, and clear PoleBillboard

### DIFF
--- a/include/Goomboss.h
+++ b/include/Goomboss.h
@@ -65,6 +65,11 @@ struct Goomboss : Enemy {
     u8  mSizeIndex;            /* 0x604 */
     u8  pad_605[0x5];
     u8  unk_60a;            /* 0x60a */
+    /* The field span ends at 0x60b, but a span is only a LOWER BOUND. Both factories
+       that store _ZTV8Goomboss (ov074:0x02122eb8) -- Goomboss_Spawn and
+       ExplosionGoomba_Spawn -- call ActorBase::operator new(0x610). Two factories
+       building one actor is a spawn-info variant, not a second class. */
+    u8  pad_60b[0x5];       /* 0x60b, to the ROM's 0x610 */
 
     virtual ~Goomboss();
 
@@ -73,7 +78,7 @@ struct Goomboss : Enemy {
     virtual s32 Render();
 };
 
-typedef char Goomboss_size_must_be_0x60c[sizeof(Goomboss) == 0x60c ? 1 : -1];
+typedef char Goomboss_size_must_be_0x610[sizeof(Goomboss) == 0x610 ? 1 : -1];
 
 #else
 

--- a/include/KnockDownPlank.h
+++ b/include/KnockDownPlank.h
@@ -33,6 +33,10 @@ struct KnockDownPlank : Platform {
     s16 unk_394;                      /* 0x394 */
     s8 unk_396;                       /* 0x396 */
     u8 unk_397;                       /* 0x397 */
+    /* KnockDownPlank_Spawn, the one factory storing _ZTV14KnockDownPlank
+       (ov015:0x02114420), calls ActorBase::operator new(0x39c). The field span
+       stopping at 0x398 is a lower bound, not the size. */
+    u8 pad_398[0x4];                  /* 0x398, to the ROM's 0x39c */
 
     /* --- vtable --- */
     virtual ~KnockDownPlank();
@@ -42,7 +46,7 @@ struct KnockDownPlank : Platform {
     int Render();
 };
 
-typedef char KnockDownPlank_size_must_be_0x398[sizeof(KnockDownPlank) == 0x398 ? 1 : -1];
+typedef char KnockDownPlank_size_must_be_0x39c[sizeof(KnockDownPlank) == 0x39c ? 1 : -1];
 
 #else
 

--- a/include/MovingBar.h
+++ b/include/MovingBar.h
@@ -23,6 +23,11 @@ struct MovingBar : Platform {
     s32 unk_324;                      /* 0x324 */
     s32 unk_328;                      /* 0x328 */
     s32 mVariant;                     /* 0x32c */
+    /* Both factories storing _ZTV9MovingBar (ov015:0x0211458c) -- MovingBarBig_Spawn
+       and MovingBarSmall_Spawn -- call ActorBase::operator new(0x338). They agree, so
+       they are two spawn-info variants of one actor, and 0x330 was the field span
+       rather than the size. */
+    u8 pad_330[0x8];                  /* 0x330, to the ROM's 0x338 */
 
     /* --- vtable --- */
     virtual ~MovingBar();
@@ -33,7 +38,7 @@ struct MovingBar : Platform {
     int Render();
 };
 
-typedef char MovingBar_size_must_be_0x330[sizeof(MovingBar) == 0x330 ? 1 : -1];
+typedef char MovingBar_size_must_be_0x338[sizeof(MovingBar) == 0x338 ? 1 : -1];
 
 #else
 


### PR DESCRIPTION
Rechecks the four sizes that the assert-relabelling (#1556) left suspect.

Each class was paired to its factory **by vtable address** — never by name, since 41 actor classes carry the name of the class one vtable along — and the size read off the retail instruction that sets up `ActorBase::operator new`, straight from the cartridge.

| class | header said | ROM | factory (stores the class's own `_ZTV`) | |
|---|---|---|---|---|
| **PoleBillboard** | 0x124 | **0x124** | `PoleBillboard_Spawn` | ✅ correct |
| **KnockDownPlank** | 0x398 | **0x39c** | `KnockDownPlank_Spawn` | +4 |
| **MovingBar** | 0x330 | **0x338** | `MovingBarBig_Spawn`, `MovingBarSmall_Spawn` | +8 |
| **Goomboss** | 0x60c | **0x610** | `Goomboss_Spawn`, `ExplosionGoomba_Spawn` | +4 |

## PoleBillboard was never wrong

It was listed as a size error because the assert in `KnockDownPlank.h` was **labelled** `PoleBillboard` and reads 0x398 — the survey read that number against PoleBillboard's ROM literal. Its own assert says 0x124 and always did.

That's the third entry retracted from the wrong-size list on the same grounds as `BowserPuzzlePiece` and `TtcMovingCubeA`, and it's the same lesson: **when a name defect and a value defect share a table, every value read before the names were fixed is suspect.**

## MovingBar wasn't even on the list

It came along only because it was in the relabelled set — and it turns out to be the largest error of the three, at 8 bytes.

## Corroboration

Both multi-factory classes have their factories **agree** (0x338 twice, 0x610 twice). That's the check this pairing method asks for: two factories building one actor are two spawn-info variants, not two classes.

## Verification

Each gap is tail padding, so the fix is a named pad field carrying its own evidence.

- `check_header_offsets`: 0 mismatched, 0 unparsed, spans now exactly 0x610 / 0x39c / 0x338.
- A size change is **not** automatically byte-neutral, so it was bracketed with `eligible.py` **name-list** diffs rather than counts — identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT