### PR TITLE
Correct 13 class sizes from the ROM's own operator new (full 236-assert sweep)

### DIFF
--- a/include/CheepCheep.h
+++ b/include/CheepCheep.h
@@ -34,9 +34,14 @@ struct CheepCheep : Enemy {
     int Behavior();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: CheepCheep_Spawn
+       calls ActorBase::operator new(0x388), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_380[0x8];      /* 0x380, to the ROM's 0x388 */
 };
 
-typedef char CheepCheep_size_must_be_0x380[sizeof(CheepCheep) == 0x380 ? 1 : -1];
+typedef char CheepCheep_size_must_be_0x388[sizeof(CheepCheep) == 0x388 ? 1 : -1];
 
 #else
 

--- a/include/HUD.h
+++ b/include/HUD.h
@@ -43,9 +43,14 @@ struct HUD : ActorDerived {
     void RenderTimeTimer();
     void RenderVsTimer();
     void UpdateHealthMeter();
+
+    /* Tail padding. The field span stops short of the real size: _ZN3HUDC1Ev
+       calls ActorBase::operator new(0x7c), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_078[0x4];      /* 0x078, to the ROM's 0x7c */
 };
 
-typedef char HUD_size_must_be_0x78[sizeof(HUD) == 0x78 ? 1 : -1];
+typedef char HUD_size_must_be_0x7c[sizeof(HUD) == 0x7c ? 1 : -1];
 
 #else
 

--- a/include/JetStream.h
+++ b/include/JetStream.h
@@ -33,9 +33,14 @@ struct JetStream : Enemy {
     virtual s32 InitResources();
     virtual void OnPendingDestroy();
     virtual s32 Render();
+
+    /* Tail padding. The field span stops short of the real size: JetStream_Spawn
+       calls ActorBase::operator new(0x378), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_31c[0x5c];      /* 0x31c, to the ROM's 0x378 */
 };
 
-typedef char JetStream_size_must_be_0x31c[sizeof(JetStream) == 0x31c ? 1 : -1];
+typedef char JetStream_size_must_be_0x378[sizeof(JetStream) == 0x378 ? 1 : -1];
 
 #else
 

--- a/include/MrBlizzard.h
+++ b/include/MrBlizzard.h
@@ -48,9 +48,14 @@ struct MrBlizzard : Enemy {
     int Behavior();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: MrBlizzard_Spawn
+       calls ActorBase::operator new(0x46c), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_458[0x14];      /* 0x458, to the ROM's 0x46c */
 };
 
-typedef char MrBlizzard_size_must_be_0x458[sizeof(MrBlizzard) == 0x458 ? 1 : -1];
+typedef char MrBlizzard_size_must_be_0x46c[sizeof(MrBlizzard) == 0x46c ? 1 : -1];
 
 #else
 

--- a/include/PyramidStep.h
+++ b/include/PyramidStep.h
@@ -33,9 +33,14 @@ struct PyramidStep : Platform {
     int CleanupResources();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: PyramidStep_Spawn
+       calls ActorBase::operator new(0x3a4), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_378[0x2c];      /* 0x378, to the ROM's 0x3a4 */
 };
 
-typedef char PyramidStep_size_must_be_0x378[sizeof(PyramidStep) == 0x378 ? 1 : -1];
+typedef char PyramidStep_size_must_be_0x3a4[sizeof(PyramidStep) == 0x3a4 ? 1 : -1];
 
 #else
 

--- a/include/QuestionBlock.h
+++ b/include/QuestionBlock.h
@@ -40,9 +40,14 @@ struct QuestionBlock : Platform {
     int Behavior();
     int CleanupResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: CapBlockLuigi_Spawn and CapBlockMario_Spawn
+       call ActorBase::operator new(0x3f8), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_3f4[0x4];      /* 0x3f4, to the ROM's 0x3f8 */
 };
 
-typedef char QuestionBlock_size_must_be_0x3f4[sizeof(QuestionBlock) == 0x3f4 ? 1 : -1];
+typedef char QuestionBlock_size_must_be_0x3f8[sizeof(QuestionBlock) == 0x3f8 ? 1 : -1];
 
 #else
 

--- a/include/Shark.h
+++ b/include/Shark.h
@@ -38,9 +38,14 @@ struct Shark : Enemy {
     int Behavior();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: Shark_Spawn
+       calls ActorBase::operator new(0x3a0), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_394[0xc];      /* 0x394, to the ROM's 0x3a0 */
 };
 
-typedef char Shark_size_must_be_0x394[sizeof(Shark) == 0x394 ? 1 : -1];
+typedef char Shark_size_must_be_0x3a0[sizeof(Shark) == 0x3a0 ? 1 : -1];
 
 #else
 

--- a/include/SlidingPlatformWf.h
+++ b/include/SlidingPlatformWf.h
@@ -30,9 +30,14 @@ struct SlidingPlatformWf : Platform {
     int CleanupResources();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: SlidingPlatformBdw_Spawn and SlidingPlatformBfsRectangle_Spawn
+       call ActorBase::operator new(0x330), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_324[0xc];      /* 0x324, to the ROM's 0x330 */
 };
 
-typedef char SlidingPlatformWf_size_must_be_0x324[sizeof(SlidingPlatformWf) == 0x324 ? 1 : -1];
+typedef char SlidingPlatformWf_size_must_be_0x330[sizeof(SlidingPlatformWf) == 0x330 ? 1 : -1];
 
 #else
 

--- a/include/SpikeBomb.h
+++ b/include/SpikeBomb.h
@@ -15,8 +15,14 @@
  * MovingCylinderClsnWithPos's D1 at +0x124, and 0x40 lands exactly where the next
  * declared field starts.
  *
- * sizeof is 0x32c, which is not inferred from the fields: BowserSkyPlatform_Spawn
- * asks ActorBase::operator new for 812 bytes.
+ * sizeof is 0x1b0, and it IS the field span: the last field unk_1ae ends at 0x1af.
+ *
+ * It used to say 0x32c, "not inferred from the fields", on the authority of
+ * BowserSkyPlatform_Spawn -- a DIFFERENT CLASS's factory. That is the pair-by-name
+ * error: SpikeBomb_Spawn is the factory that stores _ZTV9SpikeBomb, and it asks
+ * ActorBase::operator new for 0x1b0. BowserSkyPlatform's own assert is 0x32c and is
+ * correct; this class simply inherited its number, and 0x17d bytes of tail padding
+ * were invented to reach it.
  *
  * Field NAMES for the unk_ entries are placeholders. */
 #ifndef SPIKEBOMB_H
@@ -46,7 +52,7 @@ struct SpikeBomb : Actor {
     s32 unk_1a8;            /* 0x1a8 */
     u8  pad_1ac[0x2];
     u8  unk_1ae;            /* 0x1ae */
-    u8  pad_1af[0x17d];
+    u8  pad_1af[0x1];       /* 0x1af, closing on the ROM's 0x1b0 */
 
     /* --- vtable, in ROM order. Do not reorder. --- */
     virtual ~SpikeBomb();       /* slots 16 (D1), 17 (D0) */
@@ -58,8 +64,7 @@ struct SpikeBomb : Actor {
     int Render();
 };
 
-typedef char SpikeBomb_size_must_be_0x32c[
-    sizeof(SpikeBomb) == 0x32c ? 1 : -1];
+typedef char SpikeBomb_size_must_be_0x1b0[sizeof(SpikeBomb) == 0x1b0 ? 1 : -1];
 
 #else
 
@@ -89,7 +94,7 @@ struct SpikeBomb {
     s32 unk_1a8;            /* 0x1a8 */
     u8  pad_1ac[0x2];
     u8  unk_1ae;            /* 0x1ae */
-    u8  pad_1af[0x17d];
+    u8  pad_1af[0x1];       /* 0x1af, closing on the ROM's 0x1b0 */
 };
 
 #endif /* __cplusplus */

--- a/include/Squasher.h
+++ b/include/Squasher.h
@@ -31,9 +31,14 @@ struct Squasher : Platform {
     int CleanupResources();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: Squasher_Spawn
+       calls ActorBase::operator new(0x37c), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_34c[0x30];      /* 0x34c, to the ROM's 0x37c */
 };
 
-typedef char Squasher_size_must_be_0x34c[sizeof(Squasher) == 0x34c ? 1 : -1];
+typedef char Squasher_size_must_be_0x37c[sizeof(Squasher) == 0x37c ? 1 : -1];
 
 #else
 

--- a/include/TTC_MovingBar.h
+++ b/include/TTC_MovingBar.h
@@ -30,9 +30,14 @@ struct TTC_MovingBar : Platform {
     int CleanupResources();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: TtcRotatingGear_Spawn and TtcRotatingTriangle_Spawn
+       call ActorBase::operator new(0x37c), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_34c[0x30];      /* 0x34c, to the ROM's 0x37c */
 };
 
-typedef char TTC_MovingBar_size_must_be_0x34c[sizeof(TTC_MovingBar) == 0x34c ? 1 : -1];
+typedef char TTC_MovingBar_size_must_be_0x37c[sizeof(TTC_MovingBar) == 0x37c ? 1 : -1];
 
 #else
 

--- a/include/TTC_MovingBeam.h
+++ b/include/TTC_MovingBeam.h
@@ -33,9 +33,14 @@ struct TTC_MovingBeam : Platform {
     int CleanupResources();
     int InitResources();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: TTC_MovingBeam_Spawn
+       calls ActorBase::operator new(0x38c), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_35c[0x30];      /* 0x35c, to the ROM's 0x38c */
 };
 
-typedef char TTC_MovingBeam_size_must_be_0x35c[sizeof(TTC_MovingBeam) == 0x35c ? 1 : -1];
+typedef char TTC_MovingBeam_size_must_be_0x38c[sizeof(TTC_MovingBeam) == 0x38c ? 1 : -1];
 
 #else
 

--- a/include/WallSign.h
+++ b/include/WallSign.h
@@ -29,9 +29,14 @@ struct WallSign : Platform {
     int InitResources();
     int Behavior();
     int Render();
+
+    /* Tail padding. The field span stops short of the real size: WallSign_Spawn
+       calls ActorBase::operator new(0x368), read off the retail
+       instruction. A span is only a LOWER BOUND. */
+    u8 pad_360[0x8];      /* 0x360, to the ROM's 0x368 */
 };
 
-typedef char WallSign_size_must_be_0x360[sizeof(WallSign) == 0x360 ? 1 : -1];
+typedef char WallSign_size_must_be_0x368[sizeof(WallSign) == 0x368 ? 1 : -1];
 
 #else
 


### PR DESCRIPTION
## In plain English

Every actor class in the tree has a line asserting how big it is. Those numbers were often guessed from "the highest field offset anyone has identified so far", which is a **lower bound**, not the size — the real answer is the number the game's own allocator asks for.

I checked all 236 of them against the cartridge. 15 were wrong. This fixes 13 of them; the other 2 turned out to be a mistake in my checking method, described at the bottom.

---

## The sweep

Rather than recheck the handful the previous survey listed, I swept **all 236** `X_size_must_be_0xN` asserts. Each class is paired to its factory **by vtable address** — never by name, since 41 actor classes carry the name of the class one vtable along — and the size read off the retail instruction that sets up `ActorBase::operator new`.

```
before   160 agree   15 disagree
after    175 agree    0 disagree
```

**The 15 are not the 15 the old survey named.** That list was written while 18 asserts still carried a *neighbouring* class's label (fixed in #1556), so several rows had the right number attached to the wrong class. Two I had previously struck as "artifacts" turned out to be real errors under a different name — `JetStream` and `TTC_MovingBeam`.

| | | | |
|---|---|---|---|
| JetStream | 0x31c → **0x378** | MrBlizzard | 0x458 → **0x46c** |
| Squasher | 0x34c → **0x37c** | Shark | 0x394 → **0x3a0** |
| TTC_MovingBar | 0x34c → **0x37c** | SlidingPlatformWf | 0x324 → **0x330** |
| TTC_MovingBeam | 0x35c → **0x38c** | CheepCheep | 0x380 → **0x388** |
| PyramidStep | 0x378 → **0x3a4** | WallSign | 0x360 → **0x368** |
| QuestionBlock | 0x3f4 → **0x3f8** | HUD | 0x78 → **0x7c** |
| SpikeBomb | 0x32c → **0x1b0** | | |

## SpikeBomb is a shrink, and its header already confessed why

Its own comment read:

> *sizeof is 0x32c, which is not inferred from the fields: **BowserSkyPlatform_Spawn** asks ActorBase::operator new for 812 bytes.*

That's a **different class's factory**. `SpikeBomb_Spawn` — the one that stores `_ZTV9SpikeBomb` — asks for **0x1b0**, and the field span agrees exactly: the last field `unk_1ae` ends at 0x1af. 0x17d bytes of tail padding had been invented to reach the borrowed number. BowserSkyPlatform's own assert is 0x32c and is correct.

## Two were in the sweep and are deliberately NOT here

`daObjMaruta_c` (0x320→0x344) and `daObjSwdoor_c` (0x320→0x324) are **base classes**, and my method was wrong for them.

When a base's constructor is inlined into a derived class's factory, that factory carries a relocation to the **base's** vtable while allocating the **derived** size. So the sweep read `RollingLogLll`'s and `ShutterBob`'s sizes and grew the base into its own children.

The `eligible.py` **name-list** diff caught it — `ShutterBob`, `ShutterHmc`, `RollingLogLll` and `RollingLogTtm` each lost `InitResources`/`CleanupResources`/`Behavior`/`D1`. **A count would not have shown it**; the totals moved by an amount easily mistaken for noise. Both reverted. A base class needs its size from its own allocation, not from a subclass factory that inlined its constructor.

## Verification

- 236 asserts **re-swept after** the change: 0 disagree.
- `check_header_offsets` on all 13: 0 mismatched, 0 unparsed, non-zero field counts (so the check really ran).
- `eligible.py` **name-list** diff against clean main: **identical**.
- `rombuild` full link: **11,001 source-built, 0 mismatching, 106/106 modules exact, PASS.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT