### PR TITLE
Enemy (dEnemyBase_c): 30/31 verified, and merging exposed a load-bearing argument

### DIFF
--- a/config/tu_manifest.json
+++ b/config/tu_manifest.json
@@ -2778,6 +2778,318 @@
         "romIdenticalToBaseline": "The 16,777,216-byte ROM this run built has sha256 d1506e90efae5e2d2cf119926a4ac2a291bd5ca78349d09d5024e1a918c478e8, which is BIT-IDENTICAL to the one `linkcheck --baseline --module arm9` builds with no TU substitution at all. Substituting all 21 derived objects changes nothing in the cartridge.",
         "checkSymbolsIsPreExisting": "phases.checkSymbols is false, and it is NOT this TU's. `dsd check symbols --fail` emits exactly two errors -- data_020ad524 and data_020ad560 'not found in linked binary', both ~0x7f000 bytes outside this TU's span -- and the BASELINE CONTROL run, which substitutes nothing, emits the same two. Recorded by the tool itself as symbolCheckNewVsBaseline: [] (0 NEW, 0 resolved). The first partial run reported NOT partial-link-verified only because no baseline artefact existed yet to attribute it against; with the control in hand the same run passes."
       }
+    },
+    {
+      "id": "ov002/Enemy",
+      "module": "ov002",
+      "source": "src_tu/actors/Enemy.cpp",
+      "promoted_source": "src/actors/Enemy.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "medium",
+      "boundary_evidence": [
+        "contiguous linker run: 0x020ad838..0x020aedbc, 31 functions in build/tu_map.json (tools/tu_map.py, run after rtti_extract.py + rtti_vtables.py). THIRTY are declared here; ordinal 4, _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn at 0x020ade78 size 0x3cc, has no source anywhere under src/ and is a hole in the middle of the run.",
+        "class label(s): Enemy -- the tree's name for Nintendo's dEnemyBase_c",
+        "neighbours: the function immediately below the span is func_ov002_020ad660 and the one immediately above is func_ov002_020aedbc, which is followed at 0x020aedf4 by the CapEnemy/OneUpMushroom destructor family -- a different class. Every function symbol strictly inside 0x020ad838..0x020aedbc is one of the 31.",
+        "module sinit corroboration: 26 sinit(s) / 26 .ctor entries, sinit_vs_tu=ok, corroborated=False (module-wide, NOT narrowed to this one TU).",
+        "VTABLE EXTENT, measured: config/arm9/overlays/ov002/symbols.txt puts _ZTS12dEnemyBase_c at 0x021081cc and _ZTI11dCapEnemy_c at 0x02108260, so the vtable OBJECT occupies 0x021081dc..0x02108260 = 0x84 bytes exactly, which is the size this TU's compiled _ZTV5Enemy comes out. Its 33 words are offset-to-top 0, typeinfo -> 0x021081c0 (_ZTI12dEnemyBase_c), then 31 slots -- slot 16 = 0x020aed74 (_ZN5EnemyD1Ev) and slot 17 = 0x020aed3c (_ZN5EnemyD0Ev), both inside this span; the other 29 point into arm9. That independently confirms include/Enemy.h's virtual set: Enemy declares exactly one virtual of its own, the destructor, and adds no new slot to Actor's 31."
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x020ad838",
+          "end": "0x020aedbc"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj",
+          "address": "0x020ad838",
+          "size": "0x00000208",
+          "legacy_source": "src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "func_ov002_020ada40",
+          "address": "0x020ada40",
+          "size": "0x00000100",
+          "legacy_source": "src/func_ov002_020ada40.cpp",
+          "ordinal": 1
+        },
+        {
+          "symbol": "_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc",
+          "address": "0x020adb40",
+          "size": "0x00000280",
+          "legacy_source": "src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp",
+          "ordinal": 2
+        },
+        {
+          "symbol": "_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn",
+          "address": "0x020addc0",
+          "size": "0x000000b8",
+          "legacy_source": "src/_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn.cpp",
+          "ordinal": 3
+        },
+        {
+          "symbol": "_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs",
+          "address": "0x020ae244",
+          "size": "0x00000074",
+          "legacy_source": "src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp",
+          "ordinal": 5
+        },
+        {
+          "symbol": "_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_",
+          "address": "0x020ae2b8",
+          "size": "0x0000019c",
+          "legacy_source": "src/_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_.cpp",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov002_020ae454",
+          "address": "0x020ae454",
+          "size": "0x00000078",
+          "legacy_source": "src/func_ov002_020ae454.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov002_020ae4cc",
+          "address": "0x020ae4cc",
+          "size": "0x000000fc",
+          "legacy_source": "src/func_ov002_020ae4cc.cpp",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov002_020ae5c8",
+          "address": "0x020ae5c8",
+          "size": "0x00000040",
+          "legacy_source": "src/func_ov002_020ae5c8.c",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov002_020ae608",
+          "address": "0x020ae608",
+          "size": "0x00000044",
+          "legacy_source": "src/func_ov002_020ae608.c",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov002_020ae64c",
+          "address": "0x020ae64c",
+          "size": "0x0000005c",
+          "legacy_source": "src/func_ov002_020ae64c.c",
+          "ordinal": 11
+        },
+        {
+          "symbol": "_ZN5Enemy11UpdateDeathER12WithMeshClsn",
+          "address": "0x020ae6a8",
+          "size": "0x00000094",
+          "legacy_source": "src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp",
+          "ordinal": 12
+        },
+        {
+          "symbol": "func_ov002_020ae73c",
+          "address": "0x020ae73c",
+          "size": "0x000000d0",
+          "legacy_source": "src/func_ov002_020ae73c.c",
+          "ordinal": 13
+        },
+        {
+          "symbol": "func_ov002_020ae80c",
+          "address": "0x020ae80c",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov002_020ae80c.c",
+          "ordinal": 14
+        },
+        {
+          "symbol": "func_ov002_020ae844",
+          "address": "0x020ae844",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov002_020ae844.c",
+          "ordinal": 15
+        },
+        {
+          "symbol": "func_ov002_020ae87c",
+          "address": "0x020ae87c",
+          "size": "0x00000014",
+          "legacy_source": "src/func_ov002_020ae87c.c",
+          "ordinal": 16
+        },
+        {
+          "symbol": "func_ov002_020ae890",
+          "address": "0x020ae890",
+          "size": "0x00000028",
+          "legacy_source": "src/func_ov002_020ae890.c",
+          "ordinal": 17
+        },
+        {
+          "symbol": "func_ov002_020ae8b8",
+          "address": "0x020ae8b8",
+          "size": "0x0000009c",
+          "legacy_source": "src/func_ov002_020ae8b8.c",
+          "ordinal": 18
+        },
+        {
+          "symbol": "func_ov002_020ae954",
+          "address": "0x020ae954",
+          "size": "0x00000014",
+          "legacy_source": "src/func_ov002_020ae954.c",
+          "ordinal": 19
+        },
+        {
+          "symbol": "func_ov002_020ae968",
+          "address": "0x020ae968",
+          "size": "0x00000090",
+          "legacy_source": "src/func_ov002_020ae968.c",
+          "ordinal": 20
+        },
+        {
+          "symbol": "func_ov002_020ae9f8",
+          "address": "0x020ae9f8",
+          "size": "0x0000002c",
+          "legacy_source": "src/func_ov002_020ae9f8.c",
+          "ordinal": 21
+        },
+        {
+          "symbol": "func_ov002_020aea24",
+          "address": "0x020aea24",
+          "size": "0x00000008",
+          "legacy_source": "src/func_ov002_020aea24.c",
+          "ordinal": 22
+        },
+        {
+          "symbol": "func_ov002_020aea2c",
+          "address": "0x020aea2c",
+          "size": "0x00000004",
+          "legacy_source": "src/func_ov002_020aea2c.c",
+          "ordinal": 23
+        },
+        {
+          "symbol": "func_ov002_020aea30",
+          "address": "0x020aea30",
+          "size": "0x0000008c",
+          "legacy_source": "src/func_ov002_020aea30.cpp",
+          "ordinal": 24
+        },
+        {
+          "symbol": "_ZN5Enemy9SpawnCoinEv",
+          "address": "0x020aeabc",
+          "size": "0x0000013c",
+          "legacy_source": "src/_ZN5Enemy9SpawnCoinEv.cpp",
+          "ordinal": 25
+        },
+        {
+          "symbol": "_ZN5Enemy12UpdateWMClsnER12WithMeshClsnj",
+          "address": "0x020aebf8",
+          "size": "0x00000120",
+          "legacy_source": "src/_ZN5Enemy12UpdateWMClsnER12WithMeshClsnj.cpp",
+          "ordinal": 26
+        },
+        {
+          "symbol": "_ZN5EnemyD2Ev",
+          "address": "0x020aed18",
+          "size": "0x00000024",
+          "legacy_source": "src/_ZN5EnemyD2Ev.c",
+          "ordinal": 27
+        },
+        {
+          "symbol": "_ZN5EnemyD0Ev",
+          "address": "0x020aed3c",
+          "size": "0x00000038",
+          "legacy_source": "src/_ZN5EnemyD0Ev.cpp",
+          "ordinal": 28
+        },
+        {
+          "symbol": "_ZN5EnemyD1Ev",
+          "address": "0x020aed74",
+          "size": "0x00000024",
+          "legacy_source": "src/_ZN5EnemyD1Ev.cpp",
+          "ordinal": 29
+        },
+        {
+          "symbol": "_ZN5EnemyC2Ev",
+          "address": "0x020aed98",
+          "size": "0x00000024",
+          "legacy_source": "src/_ZN5EnemyC2Ev.cpp",
+          "ordinal": 30
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "HAND-ASSEMBLED, not `tubuild.py create`. That generator refuses this candidate twice over: one member has no legacy source at all, and three of the thirty legacy files (func_ov002_020ada40.cpp, func_ov002_020ae454.cpp, _ZN5EnemyC2Ev.cpp) wrap their whole body in `extern \"C\" { ... }`, which its splitter cannot parse. The manifest entry is still tubuild's own, built through tubuild.build_manifest_entry.",
+        "ONE MEMBER IS NOT ADMITTED: _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn, 0x020ade78, size 0x3cc, ordinal 4. It is ov002's one unmatched function inside this span and no file for it exists under src/. That hole is why the TU can never be link-verified as it stands: `linkcheck --partial` refuses the whole span with 'range gap/overlap at 0x020ade78'.",
+        "THE SECOND ARGUMENT TO func_ov002_020ae5c8 IS REAL. Its own file defines it `(void *c)` and never reads a second argument; func_ov002_020ae64c's file declared it `(char *, int)` and passed one. Merged the one-argument way, func_ov002_020ae64c compiles to 0x50 against the ROM's 0x5c -- three instructions short, because `x` no longer has to survive the body in a callee-saved register. Both observations are true at once and the definition here carries the parameter unused. This is a declaration conflict that per-function compilation could not have exposed.",
+        "KEY-FUNCTION SIDE EFFECT, expected and inventoried rather than verified: Enemy's first non-inline virtual is ~Enemy and this TU defines it, so the object also emits _ZTV5Enemy (0x84, STB_GLOBAL), _ZTI5Enemy/_ZTS5Enemy and the inherited Actor/ActorDerived/ActorBase RTTI records, plus a vague-linkage _ZN7Vector3D1Ev from types.h's Vector3 destructor. Ten unlicensed symbols; none is claimed correct here.",
+        "THE VTABLE DATA CANNOT DATA-VERIFY UNTIL THE CLASS IS RENAMED, and that is a measurement, not a guess: the ROM's typeinfo record at 0x021081c0 is _ZTI12dEnemyBase_c with the name string _ZTS12dEnemyBase_c, while this tree calls the class `Enemy`, so the compiler emits _ZTI5Enemy / _ZTS5Enemy (a 7-byte string where the ROM holds sixteen). The vtable's 33 slot words are structurally right; only the RTTI names are not. Renaming Enemy -> dEnemyBase_c is a tree-wide change and is out of scope here.",
+        "_ZN5EnemyD2Ev is the one member whose derived object is not byte-identical in linker contribution to the production one, and the difference is a symbol ALIAS, not a byte: the legacy src/_ZN5EnemyD2Ev.c stores the vptr through `data_ov002_021081e4` while a real `Enemy::~Enemy()` makes the compiler name its own _ZTV5Enemy. ov002/symbols.txt gives both names the same address, 0x021081e4, objisolate's addend correction lands the derived reloc on addend 0 there, and the scratch link reproduced the range byte-for-byte -- so the destination is proven identical and only the name differs.",
+        "NAMING WAS DELIBERATELY LEFT ALONE. Eighteen members still carry func_ov002_* placeholder names, including 0x020ada40, which include/Enemy.h identifies as Enemy::KillByInvincibleChar. Renaming a linker symbol strands references this tree's gates cannot see, so it is a separate change."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov002-Enemy/Enemy.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 30,
+        "functions_declared": 30,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 10 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PASS",
+          "relocation_destinations_verified": "PASS"
+        }
+      },
+      "partial_isolation": {
+        "round": "tools/tubuild.py partial -- one compile of the consolidated source, objisolate.derive per licensed function, compared against rombuild.compile_one + objisolate.isolate of each legacy source",
+        "derivedObjects": 30,
+        "contributionEquivalent": "29/30",
+        "comparedFields": [
+          "keptSection",
+          "keptBytes",
+          "relocs",
+          "defined",
+          "mapping",
+          "live",
+          "undefReferenced"
+        ],
+        "legacyEntriesComplete": "30/30",
+        "extraInertImports": 125,
+        "extraImportsWithNoHome": [],
+        "artefacts": "build/tu/ov002-Enemy/partial/partial.json (gitignored)",
+        "state": "derived",
+        "stateMeaning": "N per-function objects were extracted from one compiled TU object; their equivalence to the production objects was not established",
+        "axisNote": "Orthogonal to `status` (plan sec 6). This entry's `status` describes whole-range linking; this block describes a source consolidation whose linker contribution stays per-function."
+      },
+      "sub_span_link": {
+        "round": "tools/tubuild.py linkcheck --partial, run TWICE against the two contiguous sub-spans the hole at ordinal 4 leaves behind. The whole span cannot be run: `linkcheck --partial` refuses it with 'range gap/overlap at 0x020ade78: next entry src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp starts at 0x020ae244'. config/**/delinks.txt was NOT changed in either run: the same entries, the same object paths, only the source that produced those objects.",
+        "lower": {
+          "span": "0x020ad838..0x020ade78",
+          "functions": "ordinals 0..3",
+          "contributionEquivalent": "4/4",
+          "linkedRange": "1600 bytes IDENTICAL",
+          "moduleFidelity": "106/106 exact, 100.000000% of compared bytes; dsd check modules --fail PASS",
+          "symbolCheck": "2 pre-existing error line(s), 0 NEW, 0 resolved",
+          "rom": "built, sha256 d1506e90efae5e2d2cf119926a4ac2a291bd5ca78349d09d5024e1a918c478e8",
+          "verdict": "PARTIAL-LINK-VERIFIED"
+        },
+        "upper": {
+          "span": "0x020ae244..0x020aedbc",
+          "functions": "ordinals 5..30",
+          "contributionEquivalent": "25/26 -- the one exception is _ZN5EnemyD2Ev's data_ov002_021081e4 / _ZTV5Enemy alias, same address",
+          "linkedRange": "2936 bytes IDENTICAL",
+          "moduleFidelity": "106/106 exact, 100.000000% of compared bytes; dsd check modules --fail PASS",
+          "symbolCheck": "2 pre-existing error line(s), 0 NEW, 0 resolved",
+          "rom": "built, sha256 d1506e90efae5e2d2cf119926a4ac2a291bd5ca78349d09d5024e1a918c478e8",
+          "verdict": "NOT partial-link-verified, on the alias above alone; every byte measurement in the run is green"
+        },
+        "baselineControl": {
+          "round": "tools/tubuild.py linkcheck --baseline -- same scratch pipeline, NO TU substitution",
+          "moduleFidelity": "106/106 exact; dsd check modules --fail PASS",
+          "symbolCheck": "FAIL with exactly the same two lines -- data_020ad524 and data_020ad560 in ARM9 main not found in the linked binary. PRE-EXISTING, belongs to the tree, not to this TU.",
+          "rom": "built, sha256 d1506e90efae5e2d2cf119926a4ac2a291bd5ca78349d09d5024e1a918c478e8 -- bit-identical to both substituted runs."
+        },
+        "axisNote": "This does NOT make the TU link-verified (plan sec 6): the range is still linked from N per-function contributions, and the vtable/RTTI ownership question is untouched. It is stronger than `partial` alone, because a real mwldarm link resolved every reference and the ROM came out bit-identical to the control."
+      }
     }
   ]
 }

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -94,6 +94,14 @@ struct Enemy : Actor {
        spell the mangled name. */
     void SpawnCoin();
     int SpawnParticlesIfHitOtherObj(CylinderClsn & clsn_);
+    /* Its own file still builds this from a local `struct Enemy { char pad[0x100]; }`
+       shadow, but SpawnParticlesIfHitOtherObj -- which shares its translation unit,
+       ov002 0x020ad838..0x020aedbc -- calls it, so the merged TU needs the real
+       declaration. Non-virtual, so it cannot move a vtable slot or change which TU
+       is Enemy's key function; ~Enemy is still the first virtual declared. The
+       second parameter is the CylinderClsn the caller was handed, passed as raw
+       bytes because that class has no header here. */
+    void SpawnMegaCharParticles(Actor & a, char * p);
     int UpdateKillByInvincibleChar(WithMeshClsn & ww_, ModelAnim & mm_, unsigned int flags);
     /* PROVISIONAL SIGNATURE -- do not migrate a caller against it yet. Two
        separate problems, both caller-side:

--- a/src_tu/actors/Enemy.cpp
+++ b/src_tu/actors/Enemy.cpp
@@ -1,0 +1,927 @@
+//cpp
+/* Recovered translation unit -- ov002/Enemy  (Nintendo's dEnemyBase_c)
+ *
+ * .text span 0x020ad838..0x020aedbc, 31 functions in build/tu_map.json.
+ * THIRTY of them are assembled here; ordinal 4,
+ * _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn (0x020ade78, 0x3cc), has no source
+ * anywhere under src/ and is the module's one unmatched member, so it is a hole
+ * in the middle of this run. That is why the manifest declares 30 functions and
+ * why this TU can never be link-verified as it stands.
+ *
+ * NOT ENROLLED. config/**\/delinks.txt still names the thirty one-function
+ * files under src/ as the sole owners of these bytes.
+ *
+ * FUNCTION ORDER IS THE REVERSE OF THE ROM'S. mwccarm 2004/b56 emits one .text
+ * section per function in the reverse of source order, so the HIGHEST-address
+ * ROM function (_ZN5EnemyC2Ev, 0x020aed98) is written FIRST and the lowest
+ * (Enemy::UpdateKillByInvincibleChar, 0x020ad838) LAST. Do not reorder. The one
+ * exception is the destructor: a single `Enemy::~Enemy()` emits D2, D0 and D1 as
+ * three sections in a compiler-chosen order, which here happens to be exactly
+ * the ROM's (0x020aed18 D2, 0x020aed3c D0, 0x020aed74 D1).
+ *
+ * Assembled by hand rather than by `tubuild.py create`: three of the legacy
+ * files wrap their whole body in `extern "C" { ... }`, which that generator's
+ * splitter refuses, and one member has no legacy file at all. The manifest entry
+ * is still tubuild's own (tubuild.build_manifest_entry).
+ *
+ * WHAT THE MERGE FORCED, and nothing else was changed:
+ *   1. Local shadow `struct Enemy` / `struct Actor` (SpawnMegaCharParticles,
+ *      SpawnCoin) replaced by include/Enemy.h's real classes -- two globally
+ *      visible types named `Enemy` and `Actor` cannot survive in one TU.
+ *   2. Duplicate local helper types renamed apart per block (UnkA/UnkB appeared
+ *      twice with identical bodies; two files declared their own POD `Vector3`
+ *      that collides with types.h's non-POD one). Renaming a file-local type
+ *      cannot change codegen; keeping the POD spelling deliberately does not.
+ *   3. `enum { false, true };` deleted -- both are keywords in C++.
+ *   4. Three members are real Enemy methods here, so the four call sites that
+ *      used to reach them through `extern "C"` mangled-name declarations call
+ *      them as methods instead. Non-virtual, so still a direct `bl`.
+ *   5. Same extern declared with different signatures in different files ->
+ *      one canonical spelling, keeping the most complete observation.
+ *   6. include/decl_common.h dropped: it declares this TU's OWN
+ *      func_ov002_020ae968 as `int (void*, void*)` while the definition below
+ *      is `void (char*, char*)`.
+ *
+ * KEY-FUNCTION SIDE EFFECT: Enemy's first non-inline virtual is ~Enemy, and this
+ * TU defines it, so the object also carries _ZTV5Enemy/_ZTI5Enemy/_ZTS5Enemy and
+ * the inherited RTTI records. Expected, unlicensed, and inventoried by
+ * `tubuild.py verify` -- their correctness is NOT claimed here.
+ */
+#include "Enemy.h"
+#include "decl_ClsnResult.h"
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 30 -- _ZN5EnemyC2Ev, 0x020aed98, size 0x24                      */
+/* -------------------------------------------------------------------------- */
+/* Left as an extern "C" free function under its mangled name, NOT written as
+   `Enemy::Enemy() {}`. Enemy.h declares `Enemy();` precisely so the compiler
+   never synthesises and inlines one into the 51 subclasses; defining it as a
+   real method here would undo that. The vptr is stored through
+   data_ov002_021081e4 -- the alias ov002/symbols.txt gives _ZTV5Enemy's ROM
+   address -- rather than through the locally emitted _ZTV5Enemy, so the addend
+   stays 0 and the pilot report's sec 5.1 vtable-preamble trap does not apply. */
+extern "C" {
+extern int _ZN5ActorC2Ev(void *);
+extern int data_ov002_021081e4[];
+int _ZN5EnemyC2Ev(void *c)
+{
+    _ZN5ActorC2Ev(c);
+    *(int *)c = (int)data_ov002_021081e4;
+    return (int)c;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinals 27/28/29 -- _ZN5EnemyD2Ev 0x020aed18, _ZN5EnemyD0Ev 0x020aed3c, */
+/* _ZN5EnemyD1Ev 0x020aed74.  ONE definition, three emitted sections.          */
+/* -------------------------------------------------------------------------- */
+/* Store this class's vtable over the one Actor's constructor left, then run the
+   Actor subobject destructor. D0 additionally returns the object to the actor
+   heap through Enemy's own inline operator delete (see include/Enemy.h). The
+   three legacy files each spelled one variant; the compiler emits all three from
+   this. */
+Enemy::~Enemy()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 26 -- _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj, 0x020aebf8, 0x120 */
+/* -------------------------------------------------------------------------- */
+/* Runs the mesh collision (sel picks which of four update flavours), then caches
+   whichever surface normals came back: the floor result's into mFloorNormal*,
+   the wall result's into mWallNormal*. Those two CopyNormalTo calls are what
+   evidence both triples as Vector3s.
+
+   On a floor that does not limit movement, the vertical velocity is re-derived
+   so the motion stays in the floor plane. */
+struct SurfaceInfo { s32 pad; };
+
+extern "C" {
+extern void func_020383f0(WithMeshClsn *);
+extern void WithMeshClsn_UpdateDiscreteNoLava_veneer(WithMeshClsn *);
+extern void func_02038414(WithMeshClsn *);
+extern void WithMeshClsn_UpdateContinuous_Veneer(WithMeshClsn *);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *);
+extern struct SurfaceInfo *_ZNK12WithMeshClsn14GetFloorResultEv(WithMeshClsn *);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *, Vector3 *);
+extern int _ZNK12WithMeshClsn13GetLimMovFlagEv(WithMeshClsn *);
+extern int _ZN4cstd4fdivEii(int, int);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void *);
+extern struct SurfaceInfo *_ZNK12WithMeshClsn13GetWallResultEv(WithMeshClsn *);
+}
+
+void Enemy::UpdateWMClsn(WithMeshClsn & clsn_, unsigned int sel)
+{
+    WithMeshClsn *clsn = &clsn_;
+
+    switch (sel) {
+    case 1: func_020383f0(clsn); break;
+    case 2: WithMeshClsn_UpdateDiscreteNoLava_veneer(clsn); break;
+    case 3: func_02038414(clsn); break;
+    default: WithMeshClsn_UpdateContinuous_Veneer(clsn); break;
+    }
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(clsn)) {
+
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)_ZNK12WithMeshClsn14GetFloorResultEv(clsn)+4, (Vector3*)&mFloorNormalX);
+        if (_ZNK12WithMeshClsn13GetLimMovFlagEv(clsn) == 0) {
+            int dz = mFloorNormalY;
+            if (dz != 0) {
+                int nx = mFloorNormalX;
+                int vx = unk_0a4;
+                int nz = mFloorNormalZ;
+                int vz = unk_0ac;
+                long long a = (long long)nx * vx + 0x800;
+                long long b = (long long)nz * vz + 0x800;
+                int num = (int)(a >> 12) + (int)(b >> 12);
+                int q = _ZN4cstd4fdivEii(num, dz);
+                mVertSpeed = -(q + 0x8000);
+            }
+        }
+    }
+    if (_ZNK12WithMeshClsn8IsOnWallEv(clsn)) {
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)_ZNK12WithMeshClsn13GetWallResultEv(clsn)+4, (Vector3*)&mWallNormalX);
+    }
+
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 25 -- _ZN5Enemy9SpawnCoinEv, 0x020aeabc, size 0x13c             */
+/* -------------------------------------------------------------------------- */
+/* Its legacy file built this from a local `struct Enemy : Actor` shadow with a
+   local POD `struct Vector3`; both are the real ones now. Measured: using
+   types.h's Vector3 -- which declares ~Vector3(){} and is therefore NOT a POD --
+   for the local `v` costs nothing here, all 0x13c bytes reproduce, which is what
+   lets Actor::Spawn take it by const reference as its real signature says. */
+extern "C" int RandomIntInternal(int *seed);
+extern u16 data_ov002_020ff014;
+extern int data_0209e650;
+
+void Enemy::SpawnCoin()
+{
+    char *t = (char *)this;
+    int i;
+    Vector3 v;
+    if (*(u8 *)(t + 0x108) != 0) {
+        int tz = *(int *)(t + 0x64);
+        int ty = *(int *)(t + 0x60) + 0x78000;
+        int tx = *(int *)(t + 0x5c);
+        v.x = tx;
+        v.y = ty;
+        v.z = tz;
+        if (*(u8 *)(t + 0x108) >= 4)
+            *(u8 *)(t + 0x108) = 1;
+        for (i = 0; i < *(u8 *)(t + 0x10a) + 1; i++) {
+            Actor *coin = Actor::Spawn(
+                (&data_ov002_020ff014)[*(u8 *)(t + 0x108) - 1],
+                0xf2, v, 0, *(s8 *)(t + 0xcc), -1);
+            if (coin != 0) {
+                int rnd1 = RandomIntInternal(&data_0209e650);
+                int rnd2 = RandomIntInternal(&data_0209e650);
+                int a = (int)((u32)rnd1 >> 16 << 27) >> 16;
+                u32 b = (u32)rnd2 >> 16;
+                *(s16 *)((char *)coin + 0x92) = 0;
+                *(s16 *)((char *)coin + 0x94) = (s16)(a * i);
+                *(s16 *)((char *)coin + 0x96) = 0;
+                *(int *)((char *)coin + 0x98) = (((b % 50) + 100) << 15) / 100;
+            }
+        }
+    }
+    this->PoofDust();
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 24 -- func_ov002_020aea30, 0x020aea30, size 0x8c               */
+/* -------------------------------------------------------------------------- */
+/* If the state index at +0x10c is set: clears bit 0x10000000 at +0xb0, zeroes
+   the halfword at +0x102, invokes the pointer-to-member-function from
+   data_ov002_0210db80[index-1] (forwarding both int args), then writes -0x2000
+   to +0x9c and clears the +0xb0 bit again.
+
+   The receiver stays a file-local shadow (`Aea30C`) rather than Enemy: the
+   pointer-to-member type is what selects the call sequence, and Enemy has a
+   polymorphic base, so retyping it is a codegen change, not a rename. */
+struct Aea30C;
+typedef void (Aea30C::*Aea30PMF)(int, int);
+extern Aea30PMF data_ov002_0210db80[];
+struct Aea30C {
+  char pad0[0x9c];
+  int f9c;
+  char pad1[0x10];
+  int fb0;
+  char pad2[0x4e];
+  short f102;
+  char pad3[8];
+  int f10c;
+};
+extern "C" void func_ov002_020aea30(Aea30C* c, int a, int b) {
+  if (c->f10c == 0) return;
+  (*(unsigned int*)((char*)c + 0xb0)) &= ~0x10000000;
+  c->f102 = 0;
+  (c->*data_ov002_0210db80[c->f10c - 1])(a, b);
+  c->f9c = -0x2000;
+  (*(unsigned int*)((char*)c + 0xb0)) &= ~0x10000000;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 23 -- func_ov002_020aea2c, 0x020aea2c, size 0x4                */
+/* -------------------------------------------------------------------------- */
+extern "C" void func_ov002_020aea2c(void)
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 22 -- func_ov002_020aea24, 0x020aea24, size 0x8                */
+/* -------------------------------------------------------------------------- */
+extern "C" int func_ov002_020aea24(void)
+{
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 21 -- func_ov002_020ae9f8, 0x020ae9f8, size 0x2c               */
+/* -------------------------------------------------------------------------- */
+/* Zero two u32 fields, set a u16 field to 0xf, then clear bit 0x1 in the u32 at
+   self+0xb0. */
+extern "C" void func_ov002_020ae9f8(char *self)
+{
+    *(unsigned int *)(self + 0x98) = 0;
+    *(unsigned int *)(self + 0xa8) = 0;
+    *(unsigned short *)(self + 0x102) = 0xf;
+    *(unsigned int *)(self + 0xb0) &= ~0x1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 20 -- func_ov002_020ae968, 0x020ae968, size 0x90               */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, void *v);
+extern u16 data_ov002_020ff01c[];
+}
+
+extern "C" void func_ov002_020ae968(char* c, char* arg)
+{
+    int b;
+    *(int*)(c + 0xa8) = 0x14000;
+    b = *(u16*)(arg + 0xc);
+    b = b == 0xbf;
+    if (b != 0) {
+        u16 t = data_ov002_020ff01c[(u16)*(int*)(arg + 8)];
+        *(int*)(c + 0x98) = ((int)t << 0xf) / 50;
+    } else {
+        *(int*)(c + 0x98) = 0x14000;
+    }
+    *(int *)(((int)c + 0xb0)) &= ~1;
+    _ZN5Sound9PlayBank0EjRK7Vector3(9, (void*)(c + 0x74));
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 19 -- func_ov002_020ae954, 0x020ae954, size 0x14               */
+/* -------------------------------------------------------------------------- */
+struct Unk954A
+{
+    char pad[0x94];
+    short unk94;
+};
+
+struct Unk954B
+{
+    char pad[0x8e];
+    short unk8e;
+};
+
+extern "C" void func_ov002_020ae954(Unk954A *a, Unk954B *b)
+{
+    a->unk94 = b->unk8e;
+    func_ov002_020ae968((char *)a, (char *)b);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- func_ov002_020ae8b8, 0x020ae8b8, size 0x9c               */
+/* -------------------------------------------------------------------------- */
+extern "C" void func_ov002_020ae8b8(char* c, char* arg)
+{
+    int b;
+    b = *(u16*)(arg + 0xc);
+    b = b == 0xbf;
+    if (b != 0) {
+        u16 t = data_ov002_020ff01c[(u16)*(int*)(arg + 8)];
+        int r4 = (int)t << 3;
+        int ip = r4 << 12;
+        int d1 = ip / 100;
+        int d2 = r4 / 100;
+        *(int*)(c + 0x98) = d1;
+        *(int*)(c + 0xa8) = (d2 + 0x20) << 12;
+    } else {
+        *(int*)(c + 0x98) = 0xa000;
+        *(int*)(c + 0xa8) = 0x28000;
+    }
+    *(int *)(((int)c + 0xb0)) &= ~1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- func_ov002_020ae890, 0x020ae890, size 0x28               */
+/* -------------------------------------------------------------------------- */
+extern "C" int func_ov002_020ae890(void* c, void* a)
+{
+    *(short*)((char*)c+0x94) = *(short*)((char*)a+0x8e);
+    func_ov002_020ae8b8((char*)c, (char*)a);
+    return _ZN5Sound9PlayBank0EjRK7Vector3(0xa, (char*)c+0x74);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- func_ov002_020ae87c, 0x020ae87c, size 0x14               */
+/* -------------------------------------------------------------------------- */
+struct Unk87cA
+{
+    char pad[0x94];
+    short unk94;
+};
+
+struct Unk87cB
+{
+    char pad[0x8e];
+    short unk8e;
+};
+
+extern "C" void func_ov002_020ae87c(Unk87cA *a, Unk87cB *b)
+{
+    a->unk94 = b->unk8e;
+    func_ov002_020ae8b8((char *)a, (char *)b);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- func_ov002_020ae844, 0x020ae844, size 0x38               */
+/* -------------------------------------------------------------------------- */
+extern "C" s16 Vec3_HorzAngle(const void *v0, const void *v1);
+
+extern "C" void func_ov002_020ae844(void *c, void *a)
+{
+    s16 angle = Vec3_HorzAngle((char *)a + 0x5c, (char *)c + 0x5c);
+    *(short *)((char *)c + 0x94) = angle;
+    func_ov002_020ae968((char *)c, (char *)a);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- func_ov002_020ae80c, 0x020ae80c, size 0x38               */
+/* -------------------------------------------------------------------------- */
+extern "C" void func_ov002_020ae80c(void* c, void* a)
+{
+    *(short*)((char*)c+0x94) = Vec3_HorzAngle((char*)a+0x5c, (char*)c+0x5c);
+    func_ov002_020ae8b8((char*)c, (char*)a);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- func_ov002_020ae73c, 0x020ae73c, size 0xd0               */
+/* -------------------------------------------------------------------------- */
+extern "C" void func_ov002_020ae73c(char* c, char* arg)
+{
+    *(s16*)(c + 0x94) = Vec3_HorzAngle(arg + 0x5c, c + 0x5c);
+    *(int*)(c + 0xa8) = 0xa000;
+
+    if ((int)(*(unsigned short*)(arg + 0xc) == 0xbf) != 0)
+        *(int*)(c + 0x98) = (data_ov002_020ff01c[(unsigned short)*(u32*)(arg + 8)] << 15) / 50;
+    else
+        *(int*)(c + 0x98) = 0x14000;
+
+    {
+        int *p = (int *)(((int)(c) + 0x98));
+        *p = *p / 6;
+    }
+    *(s16*)(c + 0x102) = 8;
+    *(int *)(((int)(c) + 0xb0)) &= ~1;
+    _ZN5Sound9PlayBank0EjRK7Vector3(0xa, c + 0x74);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- _ZN5Enemy11UpdateDeathER12WithMeshClsn, 0x020ae6a8, 0x94  */
+/* -------------------------------------------------------------------------- */
+/* unk_10c selects which death handler from a table of POINTERS TO MEMBER
+   FUNCTION, then the position and mesh collision are updated regardless. */
+extern int (Enemy::*data_ov002_0210dbc0[])(WithMeshClsn &);
+
+extern "C" {
+extern void DecIfAbove0_Short(unsigned short *p);
+extern int _ZN5Actor9UpdatePosEP12CylinderClsn(void *thiz, void *clsn);
+}
+
+int Enemy::UpdateDeath(WithMeshClsn & clsn_)
+{
+    WithMeshClsn *clsn = &clsn_;
+    int ret;
+    if (mDeathState == 0)
+        return 0;
+    DecIfAbove0_Short(&mDeathTimer);
+    ret = (this->*data_ov002_0210dbc0[mDeathState - 1])(*clsn);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(this, 0);
+    UpdateWMClsn(*clsn, 0);
+    return ret;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov002_020ae64c, 0x020ae64c, size 0x5c               */
+/* -------------------------------------------------------------------------- */
+/* Forward declaration, because ordinal 9 is written LOWER in this file (the whole
+   TU runs highest ROM address first).
+
+   THE SECOND PARAMETER IS REAL AND IS LOAD-BEARING, and merging is what proved
+   it. func_ov002_020ae5c8's own file defines it as `(void *c)` and never reads a
+   second argument; this file's declared it `(char *, int)` and passed one. Built
+   the one-argument way, this function comes out 0x50 against the ROM's 0x5c --
+   twelve bytes and three instructions short, because `x` no longer has to
+   survive the body in a callee-saved register. So both observations are true at
+   once: the caller passes it, the callee ignores it, and the definition below
+   carries the parameter unused. */
+extern "C" int func_ov002_020ae5c8(void *c, int x);
+
+extern "C" int func_ov002_020ae64c(char* c, int x){
+  if(*(unsigned short*)(c+0x102) >= 5){
+    int v=*(int*)(c+0x84) - 0x23d;
+    if(v < 0x4cc) v=0x4cc;
+    *(int*)(c+0x84)=v;
+    *(int*)(c+0x88)=0x2000 - *(int*)(c+0x84);
+    *(int*)(c+0x80)=*(int*)(c+0x88);
+  }
+  return func_ov002_020ae5c8(c, x);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov002_020ae608, 0x020ae608, size 0x44               */
+/* -------------------------------------------------------------------------- */
+extern "C" int func_ov002_020ae608(void* c, void* a){
+  if(_ZNK12WithMeshClsn10IsOnGroundEv(a)==0) return 0;
+  ((Enemy *)c)->SpawnCoin();
+  ((Enemy *)c)->KillAndTrackInDeathTable();
+  *(int*)((char*)c+0x10c)=0;
+  return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov002_020ae5c8, 0x020ae5c8, size 0x40                */
+/* -------------------------------------------------------------------------- */
+/* `x` is unused on purpose -- see the note on ordinal 11, which passes it. */
+extern "C" int func_ov002_020ae5c8(void* c, int x){
+  unsigned short* p=(unsigned short*)((char*)c+0x100);
+  if(p[1]!=0) return 0;
+  ((Enemy *)c)->SpawnCoin();
+  ((Enemy *)c)->KillAndTrackInDeathTable();
+  *(int*)((char*)c+0x10c)=0;
+  return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov002_020ae4cc, 0x020ae4cc, size 0xfc               */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+  unsigned int a, unsigned int b, int c, int d, int e, const void* f, void* g);
+extern void* _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+  unsigned int a, unsigned int b, int c, int d, int e, const void* f);
+}
+
+extern "C" int func_ov002_020ae4cc(char* self, char* clsn){
+  int v[3];
+  int n = *(int*)(self+0x84);
+  if (n == 0) {
+    int z = *(int*)(self+0x64);
+    int y = *(int*)(self+0x60) + 0x50000;
+    int x = *(int*)(self+0x5c);
+    v[0] = x;
+    v[1] = y;
+    v[2] = z;
+  } else {
+    int z = *(int*)(self+0x64);
+    int y = *(int*)(self+0x60) + n * 0x50;
+    int x = *(int*)(self+0x5c);
+    v[0] = x;
+    v[1] = y;
+    v[2] = z;
+  }
+  if (_ZNK12WithMeshClsn10IsOnGroundEv(clsn)) {
+    ((Enemy *)self)->SpawnCoin();
+    ((Enemy *)self)->KillAndTrackInDeathTable();
+    *(int*)(self+0x10c) = 0;
+    return 1;
+  }
+  *(void**)(self+0xf8) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    *(unsigned int*)(self+0xf8), 0x13a, *(int*)((char*)v + 0), *(int*)((char*)v + 4), *(int*)((char*)v + 8), 0, 0);
+  *(void**)(self+0xfc) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+    *(unsigned int*)(self+0xfc), 0x13b, *(int*)((char*)v + 0), *(int*)((char*)v + 4), *(int*)((char*)v + 8), 0);
+  return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov002_020ae454, 0x020ae454, size 0x78               */
+/* -------------------------------------------------------------------------- */
+extern "C" int func_ov002_020ae454(char* c, void* a){
+  if(*(unsigned short*)(c+0x102)==0 || _ZNK12WithMeshClsn10IsOnGroundEv(a)!=0 || _ZNK12WithMeshClsn8IsOnWallEv(a)!=0){
+    ((Enemy *)c)->SpawnCoin();
+    ((Enemy *)c)->KillAndTrackInDeathTable();
+    *(int*)(c+0x10c)=0;
+    return 1;
+  }
+  return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_ */
+/* 0x020ae2b8, size 0x19c                                                     */
+/* -------------------------------------------------------------------------- */
+/* Stays an extern "C" free function under its mangled name: the symbol claims
+   two by-value Fix12<int> parameters, which is the mwccarm 6az wall. */
+extern "C" {
+extern void _ZN11RaycastLineC1Ev(void* self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
+extern void _ZN4BgCh19StartDetectingWaterEv(void* self);
+extern int _ZN11RaycastLine10DetectClsnEv(void* self);
+extern void _ZN10ClsnResultC1Ev(void* self);
+extern void _ZNK10ClsnResult6CopyToERS_(void* self, void* other);
+extern void _ZN10ClsnResultD1Ev(void* self);
+extern void _ZN11RaycastLineD1Ev(void* self);
+extern short data_02082214[];
+}
+
+extern "C" int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(struct Enemy *self, void* clsn, int fix2, short a3, unsigned char a4, unsigned char a5, int fix6) {
+  Vector3 v1;
+  Vector3 v2;
+  char cr[0x28];
+  Vector3 normal;
+  char rl[0x7c];
+  ((char*)self)[0x106] = 0;
+  if (_ZNK12WithMeshClsn10IsOnGroundEv(clsn) != 0) {
+    _ZN11RaycastLineC1Ev(rl);
+    v1.x = self->mPosX;
+    v1.y = self->mPosY;
+    v1.z = self->mPosZ;
+    v1.y += fix6;
+    v2.x = self->mPosX;
+    v2.y = self->mPosY;
+    v2.z = self->mPosZ;
+    v2.y -= fix2;
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &v1, &v2, ((char*)self));
+    if (a4 != 0)
+      _ZN4BgCh19StartDetectingWaterEv(rl);
+    if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
+      if (*(int*)(rl + 0x60) - fix6 >= fix2)
+        ((char*)self)[0x106] = 1;
+      if (a5 == 0) {
+        _ZN10ClsnResultC1Ev(cr);
+        _ZNK10ClsnResult6CopyToERS_(rl + 0x10, cr);
+        if (_ZNK10ClsnResult9GetClsnIDEv(cr) != -1) {
+          ((char*)self)[0x106] = 1;
+          _ZN10ClsnResultD1Ev(cr);
+          _ZN11RaycastLineD1Ev(rl);
+          return 1;
+        }
+        _ZN10ClsnResultD1Ev(cr);
+      }
+      _ZNK11SurfaceInfo12CopyNormalToER7Vector3(rl + 0x14, &normal);
+      int idx = ((unsigned short)a3 >> 4) * 2;
+      short s = data_02082214[idx + 1];
+      if (normal.y < s)
+        ((char*)self)[0x106] = 2;
+    } else {
+      ((char*)self)[0x106] = 1;
+    }
+    _ZN11RaycastLineD1Ev(rl);
+  }
+  return self->unk_106 != 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- _ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs      */
+/* 0x020ae244, size 0x74                                                      */
+/* -------------------------------------------------------------------------- */
+/* On a wall, reflect the heading off it; on a cliff edge (unk_106), turn
+   around; otherwise report that nothing was done. */
+extern "C" {
+/* ReflectAngle takes Fix12<int> by value -- the mwccarm 6az wall, runbook
+   section 7 -- so it stays extern "C" with scalars in those slots. */
+extern short _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *actor, int a, int b, short c);
+}
+
+int Enemy::AngleAwayFromWallOrCliff(WithMeshClsn & clsn_, short & outAngle_)
+{
+    void *clsn = &clsn_;
+    short *outAngle = &outAngle_;
+    if (_ZNK12WithMeshClsn8IsOnWallEv(clsn)) {
+        *outAngle = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(this,
+            mWallNormalX, mWallNormalZ, *outAngle);
+    } else if (unk_106) {
+        *outAngle = (short)(mPrevAngleY + 0x8000);
+    } else {
+        return 0;
+    }
+    return 1;
+}
+
+/* ========================================================================== */
+/* HOLE: ROM ordinal 4 -- _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn,          */
+/* 0x020ade78, size 0x3cc. No source exists anywhere under src/; this is      */
+/* ov002's one unmatched member inside the span. Nothing is written for it,    */
+/* which is why this TU cannot be link-verified.                              */
+/* ========================================================================== */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn     */
+/* 0x020addc0, size 0xb8                                                      */
+/* -------------------------------------------------------------------------- */
+/* While unk_107 is set, a cylinder collision against anything other than actor
+   IDs 0x120/0x121 spawns the mega-character particles; otherwise bit 0x20000 on
+   the collision is raised. Clearing unk_107 clears that bit instead. */
+extern "C" {
+extern void* _ZN5Actor10FindWithIDEj(unsigned int);
+}
+
+int Enemy::SpawnParticlesIfHitOtherObj(CylinderClsn & clsn_)
+{
+    char* clsn = (char*)&clsn_;
+    int* f;
+    if (unk_107 != 0) {
+        unsigned int id = *(unsigned int*)(clsn+0x24);
+        if (id != 0) {
+            void* a = _ZN5Actor10FindWithIDEj(id);
+            if (a != 0) {
+                unsigned short t = *(unsigned short*)((char*)a+0xc);
+                int e1 = (t == 0x120);
+                if (e1 == 0) {
+                    int e2 = (t == 0x121);
+                    if (e2 == 0) {
+                        SpawnMegaCharParticles(*(Actor *)a, clsn);
+                        return 1;
+                    }
+                }
+            }
+        }
+        f = (int*)(((int)clsn + 0x18));
+        *f = *f | 0x20000;
+        goto done;
+    }
+    f = (int*)(((int)clsn + 0x18));
+    *f = *f & ~0x20000;
+done:
+    return 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- _ZN5Enemy22SpawnMegaCharParticlesER5ActorPc               */
+/* 0x020adb40, size 0x280                                                     */
+/* -------------------------------------------------------------------------- */
+/* MegaV3 is deliberately a POD copy of Vector3: types.h's Vector3 declares
+   ~Vector3(){} and is therefore non-POD, and every use here is a local
+   scratch triple never handed to a Vector3-typed callee. */
+struct MegaV3 { s32 x, y, z; };
+
+extern "C" {
+extern void Vec3_Sub(MegaV3 *out, const MegaV3 *a, const MegaV3 *b);
+extern s32 Vec3_HorzLen(const MegaV3 *v);
+extern s16 _ZN4cstd5atan2E5Fix12IiES1_(s32 y, s32 x);
+extern s32 *Vec3_AsrInPlace(s32 *v, s32 sh);
+}
+
+void Enemy::SpawnMegaCharParticles(Actor &a, char *p)
+{
+    char *self = (char *)this;
+    char *ap = (char *)&a;
+    s16 dirvec[3];
+    MegaV3 v;
+    MegaV3 dst, src;
+
+    dst.x = *(s32 *)(self + 0x5c);
+    dst.y = *(s32 *)(self + 0x60);
+    {
+        MegaV3 *pv = (MegaV3 *)(((long long)(int)(ap + 0x5c)));
+        dst.z = *(s32 *)(self + 0x64);
+        src.x = pv->x;
+        src.y = pv->y;
+        src.z = pv->z;
+    }
+
+    {
+        int t = ((int) * (u16 *)(self + 0x8e)) >> 4;
+        dirvec[0] = data_02082214[t * 2];
+        dirvec[1] = 0;
+        t = ((int) * (u16 *)(self + 0x8e)) >> 4;
+        dirvec[2] = data_02082214[t * 2 + 1];
+    }
+
+    if (p != 0) {
+        MegaV3 delta;
+        s32 w = *(s32 *)(p + 4);
+        s32 aX, aY;
+        s32 iX, iY;
+        s32 s;
+
+        Vec3_Sub(&delta, &src, &dst);
+
+        v.x = delta.x;
+        v.y = delta.y;
+        v.z = delta.z;
+
+        aX = _ZN4cstd5atan2E5Fix12IiES1_(v.x, v.z);
+        aY = _ZN4cstd5atan2E5Fix12IiES1_(v.y, Vec3_HorzLen(&v));
+
+        iX = (u16)aX >> 4;
+        iY = (u16)aY >> 4;
+
+        s = (s32)(((long long)w * data_02082214[iY * 2 + 1] + 0x800) >> 12);
+        dst.x += (s32)(((long long)s * data_02082214[iX * 2] + 0x800) >> 12);
+        dst.y += (s32)(((long long)w * data_02082214[iY * 2] + 0x800) >> 12);
+        dst.z += (s32)(((long long)s * data_02082214[iX * 2 + 1] + 0x800) >> 12);
+
+        dst.y += (*(s32 *)(p + 8)) >> 1;
+    } else {
+        MegaV3 delta;
+        Vec3_Sub(&delta, &src, &dst);
+        dst.x = delta.x;
+        dst.y = delta.y;
+        dst.z = delta.z;
+        Vec3_AsrInPlace(&dst.x, 1);
+        dst.y += 0x46000;
+    }
+
+    _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        0, 0x43, dst.x, dst.y, dst.z, 0, 0);
+    _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        0, 0x44, dst.x, dst.y, dst.z, 0, 0);
+    _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        0, 0xbf, dst.x, dst.y, dst.z, dirvec, 0);
+    _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        0, 0xc0, dst.x, dst.y, dst.z, 0, 0);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- func_ov002_020ada40, 0x020ada40, size 0x100               */
+/* -------------------------------------------------------------------------- */
+/* include/Enemy.h identifies this address as Enemy::KillByInvincibleChar, but
+   naming is out of scope for this TU, so the placeholder symbol stands and the
+   receiver stays a file-local shadow. */
+struct A40Obj {
+    virtual int m00(); virtual int m01(); virtual int m02(); virtual int m03();
+    virtual int m04(); virtual int m05(); virtual int m06(); virtual int m07();
+    virtual int m08(); virtual int m09(); virtual int m0a(); virtual int m0b();
+    virtual int m0c(); virtual int m0d(); virtual int m0e(); virtual int m0f();
+    virtual int m10(); virtual int m11(); virtual int m12(); virtual int m13();
+    virtual int m14(); virtual int m15(); virtual int m16(); virtual int m17();
+    virtual int m18(); virtual int m19(); virtual int m1a(); virtual int m1b();
+    virtual int m1c(); virtual int hit();
+};
+
+struct A40V3 { int x, y, z; };
+
+struct A40Player {
+    char pad5c[0x5c];
+    A40V3 pos;
+    char pad68[0x94-0x68];
+    short ang;
+    char pad96[0x98-0x96];
+    int f98, f9c, fa0;
+    char pada4[0xa8-0xa4];
+    int fa8;
+    char padac[0xb0-0xac];
+    int fb0;
+    char padb4[0xec-0xb4];
+    short fec, fee, ff0;
+    char padf2[0x102-0xf2];
+    short f102;
+    char pad104[0x10c-0x104];
+    int f10c;
+};
+
+extern "C" {
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int a, int x, int y, int z);
+extern void _ZN6Player16IncMegaKillCountEv(void* p);
+}
+
+extern "C" void func_ov002_020ada40(A40Player* r0, short* r1, void* r2) {
+    *(int *)(((int)r0 + 0xb0)) &= ~0x10000001;
+    r0->ang = Vec3_HorzAngle((char*)r2+0x5c, &r0->pos);
+    r0->f98 = 0xa000;
+    r0->fa8 = 0x28000;
+    r0->f102 = 0x1e;
+    r0->fec = r1[0];
+    r0->fee = r1[1];
+    r0->ff0 = r1[2];
+    r0->f10c = 8;
+    r0->f9c = -0x2000;
+    r0->fa0 = -0x32000;
+    _ZN5Sound9PlayBank0EjRK7Vector3(9, (char*)r0+0x74);
+    volatile int v[3];
+    v[0] = r0->pos.x;
+    v[1] = r0->pos.y;
+    v[2] = r0->pos.z;
+    int ret = ((A40Obj*)r0)->hit();
+    int vy = v[1];
+    int vx = v[0];
+    vy = vy + ret;
+    v[1] = vy;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x43, vx, vy, v[2]);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x44, v[0], v[1], v[2]);
+    _ZN6Player16IncMegaKillCountEv(r2);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsn      */
+/*                  R9ModelAnimj, 0x020ad838, size 0x208                      */
+/* -------------------------------------------------------------------------- */
+/* One frame of the death an invincible (mega) character inflicts. `flags` is a
+   two-bit selector, not a boolean: bit 0 drops a coin, bit 1 books the kill in
+   the death table. Both reference parameters are null-checked -- the compiler
+   emits the test rather than folding it away, so `&ref == 0` is how the ROM's
+   check is spelled. */
+extern "C" {
+extern void Vec3_Asr(void *dst, const void *src, int sh);
+extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
+extern void Matrix4x3_ApplyInPlaceToTranslation(void *m, int x, int y, int z);
+extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(void *m, int x, int y, int z);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *actor);
+extern char data_020a0e68;
+}
+
+/* Reaches Actor vtable slot 29 -- vtable+0x74 -- whose return value, arithmetic
+   shifted right by 3, is the height of the point the model spins about. Kept as
+   a stand-in rather than Actor::OnAimedAtWithEgg() because that slot's NAME is
+   imported from a different hierarchy (dScMgBase_c) and does not fit this use;
+   flagged, not resolved. */
+struct KbicVB {
+    virtual void d00();
+    virtual void d01();
+    virtual void d02();
+    virtual void d03();
+    virtual void d04();
+    virtual void d05();
+    virtual void d06();
+    virtual void d07();
+    virtual void d08();
+    virtual void d09();
+    virtual void d10();
+    virtual void d11();
+    virtual void d12();
+    virtual void d13();
+    virtual void d14();
+    virtual void d15();
+    virtual void d16();
+    virtual void d17();
+    virtual void d18();
+    virtual void d19();
+    virtual void d20();
+    virtual void d21();
+    virtual void d22();
+    virtual void d23();
+    virtual void d24();
+    virtual void d25();
+    virtual void d26();
+    virtual void d27();
+    virtual void d28();
+    virtual int m29();
+};
+
+struct KbicM48 { int w[12]; };
+
+#define LAUNDER(p) ((int)(p))
+
+int Enemy::UpdateKillByInvincibleChar(WithMeshClsn & ww_, ModelAnim & mm_, unsigned int flags)
+{
+    WithMeshClsn *clsn = &ww_;
+    ModelAnim *anim = &mm_;
+    int v[3];
+
+    if (mDeathState != 8)
+        return 0;
+
+    if (mDeathTimer != 0)
+        *(unsigned short *)LAUNDER(&mDeathTimer) -= 1;
+
+    if (mDeathTimer == 0 ||
+        (clsn != 0 && _ZNK12WithMeshClsn10IsOnGroundEv(clsn) != 0 && mVertSpeed < 0)) {
+        if (flags & 1)
+            SpawnCoin();
+        if (flags & 2)
+            _ZN5Actor24KillAndTrackInDeathTableEv(this);
+        mDeathState = 0;
+        return 2;
+    }
+
+    _ZN5Actor9UpdatePosEP12CylinderClsn(this, 0);
+    if (clsn != 0) {
+        UpdateWMClsn(*clsn, 0);
+        if (_ZNK12WithMeshClsn8IsOnWallEv(clsn) != 0)
+            mPrevAngleY = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(
+                this, mWallNormalX, mWallNormalZ, mPrevAngleY);
+    }
+
+    if (anim != 0) {
+        *(short *)LAUNDER(&mAngleX) += mSpinRateX;
+        *(short *)LAUNDER(&mAngleY) += mSpinRateY;
+        *(short *)LAUNDER(&mAngleZ) += mSpinRateZ;
+        Vec3_Asr(v, &mPosX, 3);
+        Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
+        Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0,
+            ((KbicVB *)(void *)this)->m29() >> 3, 0);
+        Matrix4x3_ApplyInPlaceToRotationZXYExt(&data_020a0e68,
+            mAngleX, mAngleY, mAngleZ);
+        Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0,
+            (-((KbicVB *)(void *)this)->m29()) >> 3, 0);
+        *(KbicM48 *)((char *)anim + 0x1c) = *(KbicM48 *)&data_020a0e68;
+    }
+    return 1;
+}


### PR DESCRIPTION
## TL;DR for a reader who knows C++ but not decomp

`src/` stores this game as ~11,000 files holding **one function each**. This PR takes back
`Enemy` — Nintendo's `dEnemyBase_c` — as the single `.cpp` it originally was: 30 of its 31
functions, each reproducing the cartridge byte-for-byte.

The 31st is not a tooling failure. `_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn` (972 bytes)
**has no source file anywhere in the repo and no delinks entry** — it is simply
undecompiled, sitting in the middle of the class. Someone has to write it.

The find worth reading is what merging *exposed*. Two neighbouring functions had quietly
disagreed for as long as they were separate files: one passes a second argument the other
declares away. Merged into one file they finally had to agree, and getting it wrong made a
*different* function compile three instructions short. Per-function files could never have
made those two contradict each other out loud.

---

## What this is

| manifest id | source | range | members | ladder |
|---|---|---|---|---|
| `ov002/Enemy` | `src_tu/actors/Enemy.cpp` | 0x020ad838..0x020aedbc | **30/31** | text-verified |

Hand-assembled: `tubuild.py create` refuses this candidate twice over — three legacy files
wrap their whole body in `extern "C" { … }` (its splitter cannot parse that), and one member
has no legacy source at all. Manifest entry still built by `tubuild.build_manifest_entry`.

Written highest-ROM-address first, because mwccarm 2004/b56 emits one `.text` section per
function in the REVERSE of source order.

## Verification

```
byte comparison   : 30/30 MATCH  (relocation-aware)
objisolate check  : clean
reloc-destinations: clean
emission order    : all 30 in expected ROM-ascending section order
                                                -> TEXT-VERIFIED
```

`linkcheck --partial` **refuses the whole span** — `range gap/overlap at 0x020ade78` —
because the missing member leaves a hole. Run instead on the two contiguous sub-spans that
hole leaves, `delinks.txt` untouched in both:

| span | ordinals | equivalence | linked range |
|---|---|---|---|
| 0x020ad838..0x020ade78 | 0–3 | **4/4** | `1600 bytes IDENTICAL` |
| 0x020ae244..0x020aedbc | 5–30 | 25/26 | `2936 bytes IDENTICAL` |

Both: `module fidelity: 106/106 exact, 100.000000%`, `dsd check modules --fail: PASS`, full
ROM built to `sha256 d1506e90…` — **bit-identical to the `--baseline` control**.

The upper span's 25/26 is a **symbol alias, not a byte**: the legacy `_ZN5EnemyD2Ev.c` names
`data_ov002_021081e4` where a real `Enemy::~Enemy()` names `_ZTV5Enemy`. Same address in
`ov002/symbols.txt`, objisolate lands the addend on 0, and the linked range came out
identical.

**`dsd check symbols --fail` is RED and is not being reported green** —
`data_020ad524` / `data_020ad560`. The baseline, which substitutes nothing, fails with
*exactly those two*: **0 NEW, 0 resolved.**

## Not admitted — one member

| symbol | address | size | why |
|---|---|---|---|
| `_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn` | 0x020ade78 | 0x3cc | ov002's one unmatched function inside the span. **No file anywhere under `src/`**; `build_pin.verify` reports `NO LEGACY SOURCE`. This hole is the sole blocker to link-verifying the TU. |

## What the merge exposed, and could not have been found otherwise

`func_ov002_020ae5c8`'s **second parameter is real and load-bearing** — even though the
callee genuinely ignores it. Merged the one-argument way, the neighbouring
`func_ov002_020ae64c` compiles to **0x50 against the ROM's 0x5c**: three instructions short,
because the argument no longer has to survive the body in a callee-saved register.

Two separate one-function files can hold contradictory views of the same signature forever
and both still "match". One file cannot.

## `include/Enemy.h` — one added declaration

`void SpawnMegaCharParticles(Actor &a, char *p);`. `SpawnParticlesIfHitOtherObj` shares this
TU and calls it, and is written earlier in source order, so the class needs it. Non-virtual,
so it cannot move a slot or change the key function — `~Enemy` is still the first virtual
declared.

Cost **measured, not assumed**: all three linkcheck runs compiled the tree's 11,001 enrolled
sources with the edited header and reported `reproducing: 11,001 / mismatching: 0`,
`106/106 exact`.

## Enemy's vtable, independently confirmed

`_ZTS12dEnemyBase_c` at 0x021081cc and `_ZTI11dCapEnemy_c` at 0x02108260 put the vtable
object at 0x021081dc..0x02108260 = **0x84 — exactly the size this TU's `_ZTV5Enemy` comes
out**. Its 33 words are offset-to-top 0, typeinfo → 0x021081c0, then 31 slots; slot 16 =
0x020aed74 (`D1`) and slot 17 = 0x020aed3c (`D0`), both inside this span. **`Enemy` adds no
slot to `Actor`'s 31.**

## Signatures: what the bytes settled, what they did not

RTTI carries **class names only**, never parameter types.

**Confirmed:** the second parameter of `func_ov002_020ae5c8` (above); the arity of every
admitted member; `Actor::Spawn(…, s8, s16)` — SpawnCoin's 0x13c reproduces through it.

**Taken on faith:** every `R5Actor` / `R12WithMeshClsn` / `5Fix12IiE` parameter *type* — all
pointer-passed and unobservable. `IsGoingOffCliff` keeps scalar `extern "C"` parameters
against a name claiming two by-value `Fix12<int>`.

**Unobservable, so changed freely:** `func_ov002_020ae80c` and `func_ov002_020ae844` were
declared `int` and ended `return f(…)`; as `void` with a tail call both still MATCH at 0x38.
Nothing in the ROM settles their return type.

**No symbol was renamed.** Eighteen members keep `func_ov002_*` names, including 0x020ada40,
which `include/Enemy.h` itself identifies as `Enemy::KillByInvincibleChar`.

## Also found, not fixed

* **`include/decl_common.h:1370`** declares `extern int func_ov002_020ae968(void*, void*);`
  — wrong on return type *and* pointer types against the definition `void (char*, char*)`.
  This TU drops the header and restates rather than fix it tree-wide.
* **`_ZTV5Enemy` can never data-verify while the class is called `Enemy`.** The ROM's
  typeinfo is `_ZTI12dEnemyBase_c` / `_ZTS12dEnemyBase_c`, and an `_ZTS` record's *bytes are
  the mangled class name* — so the compiler emits a 7-byte `_ZTS5Enemy` where the ROM holds
  sixteen. The slot words are structurally right; only the names are not. Renaming `Enemy`
  → `dEnemyBase_c` is tree-wide and out of scope here.
* **`include/Enemy.h` carries seven junk forward declarations** harvested from *parameter
  names* by `gen_header.py`: `struct a1_; struct a2_; struct clsn_; struct flags; struct
  mm_; struct outAngle_; struct ww_;`. `flags` in particular is a plausible real type name
  now permanently forward-declared as an empty struct in every includer.
* **`tools/test_tubuild.py` has 2 pre-existing failures** on `origin/main`, confirmed by
  reverting this PR's header edit and re-running: they assert stale pilot-report numbers
  (15 unlicensed symbols where PoleLift now emits 12; `sections (43):` where it has 42).
* **`tubuild.py create` is more brittle than it needs to be** — it hard-refuses on a member
  lacking a legacy source and on an `extern "C" {`-wrapped body, even when the other N−1
  members would assemble cleanly. An `--exclude`/`--skip-missing` flag would have made this
  candidate generatable rather than hand-written.
* **`linkcheck --partial` demands 100% contribution-equivalence for its verdict**, so a pure
  symbol-*alias* difference at an identical address downgrades an otherwise green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fEVixn2pwuKzDABa2okcp
