### PR TITLE
Fix claims table `.md` syntax

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -38,6 +38,7 @@ take over, ping the claimant first.
 ## Claims
 
 | Range | Who | Claimed | Status |
+|---|---|---|---|
 | ov005 func_ov005_020c16e4 (0x020c16e4, size 0x33c) | lunavyqo | 2026-08-13 | **done** — verified byte-identical + linkcheck VERIFIED (mwccarm 2004/b56); levers: ++row MultiCopy tail, dest pin `idx?dstp:dstp` / `destOff?dstp:dstp` (equal-arm) for rem-before-quot + increment order; from near-miss 136→18→16→3→0; API clm_84a56ab710d3 kept |
 | ov005 func_ov005_020c0378 (0x020c0378, size 0x354) | lunavyqo | 2026-08-13 | **active** — near-miss improved **77→44** size-exact. 0250-style S.a/S.b has + loop_invariants off + S[idx].d y. Residual pure regperm (idx r1 vs r5, has r3 vs r2) + path-B y early. API clm_3c2c2b05061d |
 | ov015 _ZN14KnockDownPlank13InitResourcesEv (0x02111960, size 0x208) | lunavyqo | 2026-08-13 | **done** — verified byte-identical + linkcheck VERIFIED (mwccarm 2004/b56); levers: `#pragma opt_propagation off` + u64-mask angle increment + named `zero` for vec stores; API clm_645f51ab54fa kept |


### PR DESCRIPTION
<!--
Matched functions? Add a Provenance line to the PR description or to any commit
message, and CI records HOW the match was made alongside WHO made it.

  Provenance: ai model=grok-4.5 reasoning=high harness=grok-build
  Provenance: human
  Provenance: human hand-traced the regalloc by eye

Without it the function still merges and you still get the credit -- it just lands
with no method recorded, which is the gap that left the provenance ledger empty for
weeks. Agent batches that already name their model in the commit subject are picked
up automatically and need nothing here.
-->

## What this changes

Only fixes the `.md` table syntax of ***Claims*** header so it renders properly.
