### PR TITLE
pr-validate: tell the relay when a PR cannot affect what validation measures

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -25,9 +25,12 @@ on:
     # once, when it claims the build.
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
-# No permissions needed. This workflow no longer comments — the app does, under its
-# own identity — so the default read-only token is enough to submit and exit.
-permissions: {}
+# `pull-requests: read` is here to LIST THE CHANGED FILE PATHS, and nothing else. That is
+# PR metadata, not PR code: the files endpoint returns paths, and this job still never
+# checks out or executes anything from the head branch, so the pull_request_target safety
+# argument above is unchanged.
+permissions:
+  pull-requests: read
 
 concurrency:
   # Key on the head SHA, not the PR number. Grouping by PR number meant every new event for
@@ -53,6 +56,57 @@ jobs:
       (github.event.action != 'labeled' && github.event.action != 'unlabeled')
       || github.event.label.name == 'attribution-override'
     steps:
+      # Decide whether this PR can possibly change what validation measures, and tell the
+      # relay. A full validation is a stock ROM build plus a whole-module compare against
+      # retail, and the worker runs ONE AT A TIME -- so a pull request that only edits
+      # prose costs every other pull request its place in the queue for nothing.
+      #
+      # THE DEFAULT IS TO VALIDATE. This computes an INERT set and skips only when every
+      # changed path is in it; anything unrecognised is treated as relevant. That
+      # direction is deliberate: a filter that is too narrow silently skips validation on
+      # a pull request that needed it, which is the failure nobody would notice.
+      #
+      # What is NOT inert, and why -- the verdict covers reconstruction AND attribution:
+      #   src/ include/ src_tu/   compiled, or change codegen
+      #   config/                 delinks.txt and symbols.txt decide what is compiled and
+      #                           where; relocs.txt decides what it points at
+      #   tools/                  the ROM build itself
+      #   *.jsonl, attribution.json
+      #                           match_provenance.jsonl and match_attempts.jsonl feed the
+      #                           attribution half of the verdict, and attribution.json
+      #                           pins credit by source path. A stale row there is a real
+      #                           finding, so these must still be validated.
+      #   .gitattributes          decides how those ledgers merge
+      # Everything above is simply "not inert", so it needs no listing.
+      - name: Classify changed paths
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
+          if [ -z "$files" ]; then
+            # No file list is not evidence of an inert pull request. Fail safe.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "no files returned -- treating as validation-relevant"
+            exit 0
+          fi
+          # Inert: prose, generated progress pages, and the licence. Note docs/index.html
+          # and docs/progress-treemap.svg are bot-written progress artefacts, not sources.
+          inert='^(docs/|notes/|\.github/ISSUE_TEMPLATE/)|(^|/)[^/]+\.(md|png|jpg|jpeg|gif|svg)$|^LICENSE$'
+          relevant=false
+          while IFS= read -r f; do
+            if ! printf '%s\n' "$f" | grep -Eq "$inert"; then
+              relevant=true
+              echo "validation-relevant: $f"
+            fi
+          done <<< "$files"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          total=$(printf '%s\n' "$files" | wc -l)
+          echo "$total changed file(s); validation-relevant=$relevant"
+
       - name: Submit validation job
         env:
           RELAY: ${{ secrets.PR_VALIDATE_RELAY }}
@@ -62,12 +116,26 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           ALLOW_ATTRIBUTION_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'attribution-override') }}
+          VALIDATION_RELEVANT: ${{ steps.classify.outputs.relevant }}
         run: |
           set -euo pipefail
+          # `validationRelevant` is ADVISORY and the relay decides what to do with it.
+          #
+          # THE SUBMISSION STILL HAPPENS EITHER WAY, and that is the point: `PR validation`
+          # is a required check pinned to the tangos-validator app (integration_id
+          # 4461188), so only the relay can post a verdict that satisfies the ruleset. If
+          # this workflow skipped submitting, no check would ever arrive and the pull
+          # request would sit unmergeable forever waiting for one. Equally, a relay that
+          # does not know this field yet simply ignores it and validates as before, so
+          # landing this change on its own is a no-op rather than a regression.
+          #
+          # Relay side, to actually claim the saving: when validationRelevant is false,
+          # post a passing `PR validation` check immediately and do not queue a build.
           payload=$(jq -n --arg repo "$REPO" --argjson pr "$PR" \
             --arg sha "$SHA" --arg baseSha "$BASE_SHA" \
             --argjson allowAttributionChange "$ALLOW_ATTRIBUTION_CHANGE" \
-            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha,allowAttributionChange:$allowAttributionChange}')
+            --argjson validationRelevant "$VALIDATION_RELEVANT" \
+            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha,allowAttributionChange:$allowAttributionChange,validationRelevant:$validationRelevant}')
           resp=$(curl -sS -X POST "$RELAY/api/pr-validate" \
             -H "X-Api-Key: $TOKEN" -H "Content-Type: application/json" \
             --data "$payload")


### PR DESCRIPTION
## TL;DR

A full validation is a stock ROM build plus a whole-module compare against retail, and the worker runs **one job at a time**. A PR that only edits prose currently pays for that build *and* costs every other PR its place in the queue — #1562 and #1564 were both documentation-only and both consumed one.

This adds a step that lists the changed paths and sends `validationRelevant` with the submission.

## Why it still submits, always

This is the part worth reviewing, because the two obvious implementations are both wrong.

`PR validation` is a **required status check pinned to an app**. The ruleset `main: validation gate` requires context `PR validation` with `integration_id: 4461188`, which is `tangos-validator`. Only the relay can post a verdict that satisfies it. So:

- **`paths-ignore` on the trigger** — the workflow never runs, the relay never posts, and the PR waits forever for a check that cannot arrive. It would look *stuck*, not skipped. Worse than the problem.
- **this workflow posting the check itself** — it would come from `github-actions` (id 15368), not `tangos-validator`, so the ruleset would reject it.

Hence the flag is **advisory** and the relay decides. On a relay that doesn't know the field, it's ignored and behaviour is exactly as today — so **this commit is a no-op on its own, not a regression**. The saving is claimed by the matching relay change:

> when `validationRelevant` is false, post a passing `PR validation` check immediately and do not queue a build.

## The default is to validate

The step computes an **inert** set and skips only when *every* changed path is in it. Anything unrecognised counts as relevant, and an empty file list counts as relevant too.

That direction is the entire safety argument. A filter that is too narrow silently skips validation on a PR that needed it — the failure nobody notices. A filter that is too wide merely wastes a build, which is the failure we already have.

**Inert:** `docs/`, `notes/`, `.github/ISSUE_TEMPLATE/`, any `*.md`, images, `LICENSE`. (`docs/index.html` and `docs/progress-treemap.svg` are bot-written progress artefacts, not sources.)

**Everything else is relevant by construction**, which matters most for the non-obvious ones:

| path | why it must still validate |
|---|---|
| `config/` | `delinks.txt` and `symbols.txt` decide what is compiled and where; `relocs.txt` decides what it points at |
| `tools/` | the ROM build itself |
| `*.jsonl` | `match_provenance.jsonl` / `match_attempts.jsonl` feed the **attribution** half of the verdict — it is not only about bytes |
| `attribution.json` | pins credit by source path, so a stale row is a real finding |
| `.gitattributes` | decides how those ledgers merge |

## Permissions

`{}` → `pull-requests: read`, for the files endpoint. That returns **paths, not code**: the job still never checks out or executes anything from the head branch, so the `pull_request_target` safety argument in the file's header comment is unchanged.

## Verified, not just reasoned about

Against real PRs:

```
PR 1562  files=5     relevant=0     SKIP       (agent skills, docs only)
PR 1564  files=2     relevant=0     SKIP
PR 1573  files=143   relevant=143   VALIDATE
PR 1577  files=2112  relevant=2111  VALIDATE
PR 1571  files=2980  relevant=2979  VALIDATE
```

And unit-tested on 24 paths, including the ones easiest to get wrong — every `*.jsonl`, `attribution.json`, `.gitattributes`, `Makefile`, `tools/*.py` and `port/` validate; `README.md`, `notes/*.md`, `CLAIMS.md`, `docs/index.html`, `docs/progress-treemap.svg` and `LICENSE` skip.

## Note on this PR itself

It changes `.github/workflows/pr-validate.yml`, which the classifier treats as **relevant** — deliberately conservative, since a workflow file can't affect the ROM but I'd rather the filter err toward validating. So this PR validates itself normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fEVixn2pwuKzDABa2okcp
