### PR TITLE
check_references: correct nine mangled-name lengths the class renames left stale

### DIFF
--- a/config/unresolved-baseline.json
+++ b/config/unresolved-baseline.json
@@ -1,5 +1,5 @@
 {
- "eligible": 11025,
+ "eligible": 11026,
  "unresolved": {
   "arm9:0x02017848": {
    "name": "_ZN5FaderD0Ev",
@@ -178,8 +178,8 @@
    "missing": [
     "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPcP8BMD_Fileii",
     "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-    "_Z50_ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jjPcP8dActor_ciijj",
-    "_Z58_ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_PcP8dActor_ciiP10Vector3_16i",
+    "_Z53_ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jjPcP8dActor_ciijj",
+    "_Z61_ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_PcP8dActor_ciiP10Vector3_16i",
     "func_0211d610"
    ]
   },
@@ -287,7 +287,7 @@
     "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
     "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
     "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
-    "_Z88_ZN16MeshColliderBase16UpdatePosAndAngsERS_P8dActor_cR10ClsnResultR7Vector3P10Vector3_16S8_v",
+    "_Z91_ZN16MeshColliderBase16UpdatePosAndAngsERS_P8dActor_cR10ClsnResultR7Vector3P10Vector3_16S8_v",
     "func_021115bc"
    ]
   },
@@ -304,10 +304,10 @@
     "_Z30_ZN11ShadowModel10InitCuboidEvPv",
     "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvP8BMD_Fileii",
     "_Z35_ZN5Model8LoadFileER13SharedFilePtrR13SharedFilePtr",
-    "_Z35_ZN10dBgActor_c19UpdateClsnPosAndRotEvPv",
+    "_Z38_ZN10dBgActor_c19UpdateClsnPosAndRotEvPv",
     "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrR13SharedFilePtr",
     "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvP8KCL_FileRK9Matrix4x3isR10CLPS_Block",
-    "_Z94_ZN16MeshColliderBase22UpdatePosWithTransformERS_P8dActor_cR10ClsnResultR7Vector3P10Vector3_16S8_v",
+    "_Z97_ZN16MeshColliderBase22UpdatePosWithTransformERS_P8dActor_cR10ClsnResultR7Vector3P10Vector3_16S8_v",
     "func_02112198"
    ]
   },
@@ -326,8 +326,8 @@
    "missing": [
     "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
     "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
-    "_Z35_ZN10dBgActor_c19UpdateClsnPosAndRotEvPv",
-    "_Z37_ZN10dBgActor_c21UpdateModelPosAndRotYEvPv",
+    "_Z38_ZN10dBgActor_c19UpdateClsnPosAndRotEvPv",
+    "_Z40_ZN10dBgActor_c21UpdateModelPosAndRotYEvPv",
     "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
     "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPvS_S_isS_",
     "func_021121b8"
@@ -381,14 +381,14 @@
    "missing": [
     "_Z13func_020393c4PvS_",
     "_Z13func_020393d4PvS_",
-    "_Z22_ZN8dActor_c9TrackStarEjjPvjj",
+    "_Z25_ZN8dActor_c9TrackStarEjjPvjj",
     "_Z32_ZN11ShadowModel12InitCylinderEvPv",
     "_Z34_ZN9ModelBase7SetFileEP8BMD_FileiiPvS_ii",
     "_Z35_ZN5Model8LoadFileER13SharedFilePtrPv",
     "_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv",
     "_Z43_ZN12MeshCollider8LoadFileER13SharedFilePtrPv",
     "_Z46_ZN15TextureSequence8LoadFileER13SharedFilePtrPv",
-    "_Z67_ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
+    "_Z70_ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jjPvS_P7Vector3iijj",
     "_Z77_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_BlockPviS_isS_",
     "func_02112c08",
     "func_02112ca8",


### PR DESCRIPTION
`python tools/check_references.py` FAILS on main today, reporting five files as having
"new unresolvable references". Nothing is newly unresolvable. The same five addresses were
already in the baseline, the unresolved total is 60 against a baseline of 60, and no
reference changed what it points at. Only the SPELLING of eight recorded names changed, and
the baseline was not updated to match.

WHY THE RENAMES DID THIS. These are double-mangled names: a file hand-declares a callee by
its mangled name, and in a //cpp translation unit mwcc mangles that identifier a second
time, giving `_Z<len><identifier><params>`. #1572-#1577 renamed six classes to the
cartridge's own RTTI names, and the substitution correctly rewrote the class token INSIDE
each recorded name -- `5Actor` -> `8dActor_c`, `8Platform` -> `10dBgActor_c`. It could not
rewrite the enclosing `_Z<len>`, because that length counts the identifier and no
token-level rule knows it is there. So every affected entry ended up internally
inconsistent: a body naming the new class, behind a length measured for the old one.

The correction is +3 on all nine, exactly `8dActor_c` (9) minus `5Actor` (6):

    _Z50 -> _Z53   _ZN18MovingCylinderClsn4InitEP8dActor_c...
    _Z58 -> _Z61   _ZN12WithMeshClsn4InitEP8dActor_c...
    _Z88 -> _Z91   _ZN16MeshColliderBase16UpdatePosAndAngs...
    _Z94 -> _Z97   _ZN16MeshColliderBase22UpdatePosWithTransform...
    _Z35 -> _Z38   _ZN10dBgActor_c19UpdateClsnPosAndRot...   (twice, two callers)
    _Z37 -> _Z40   _ZN10dBgActor_c21UpdateModelPosAndRotY...
    _Z22 -> _Z25   _ZN8dActor_c9TrackStar...
    _Z67 -> _Z70   _ZN25MovingCylinderClsnWithPos4Init...

THIS IS NOT A RATCHET RAISE, WHICH IS WHY `--update` COULD NOT DO IT. `--update` only ever
lowers, and `worse()` compares per address with `added = set(current) - set(baseline)`, so a
RENAMED missing symbol reads as an addition while its old spelling sits unremoved in the
baseline -- five "new" references and not one of them new. The tool was right to refuse; the
edit it refused is not the edit this needs. Each of the nine was verified to be a pure
re-spelling before being touched: strip the `_Z<len>` prefix from the added and the removed
name and the remainders are byte-identical, one-to-one, no leftovers on either side.

`eligible` moves 11025 -> 11026, which is a gain, not a loss.

Net: 60 unresolved identities before and after, same addresses, same referents.

HOW SIX PULL REQUESTS MISSED IT. `check_references` runs in no workflow -- there are eight
and none invokes it -- and the pre-push hook skips it unless a current eligibility report
exists, printing

    pre-push: (skipping reference check -- no current eligibility report;
              run 'python tools/eligible.py' to include it)

on every push in the rename series. The gate opted out and said so in one line, every time.

Verified on a clean checkout of main plus this commit:

    unresolved symbols: 60  (baseline 60)
    eligible:           11026  (baseline 11026)
    OK: no new unresolvable references

Not fixed here, both worth their own change: the same substitution also rewrote HISTORICAL
evidence prose in config/tu_manifest.json, so two entries now contradict themselves
(arm9/Scene argues "the ROM holds b'8dScene_c\x00' where this TU emits b'8dScene_c\x00'",
which was the contrast between the ROM's name and our coinage before the rename made both
sides the same string). And `check_references` exits 0 after refusing to run on a dirty
tree -- a gate that declines to check should not report success.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016fEVixn2pwuKzDABa2okcp
