### PR TITLE
Three more: the credit a squash merge destroys that a commit split saved

### DIFF
--- a/attribution.json
+++ b/attribution.json
@@ -405,6 +405,12 @@
     "src/_ZN9PowerStar13OnTurnIntoEggER6Player.c": "ruspecial",
     "src/_ZN9PowerStar13OnTurnIntoEggER6Player.cpp": "ruspecial",
     "src/_ZN9Spindrift13OnTurnIntoEggER6Player.c": "tangosdev",
-    "src/_ZN9Spindrift13OnTurnIntoEggER6Player.cpp": "tangosdev"
+    "src/_ZN9Spindrift13OnTurnIntoEggER6Player.cpp": "tangosdev",
+    "src/_ZN13PoleBillboard13InitResourcesEv.c": "tangosdev",
+    "src/_ZN13PoleBillboard13InitResourcesEv.cpp": "tangosdev",
+    "src/_ZN5Whomp25OnAimedAtWithEggReturnVecEv.c": "ruspecial",
+    "src/_ZN5Whomp25OnAimedAtWithEggReturnVecEv.cpp": "ruspecial",
+    "src/_ZN5Whomp15OnHitByMegaCharER6Player.c": "tangosdev",
+    "src/_ZN5Whomp15OnHitByMegaCharER6Player.cpp": "tangosdev"
   }
 }


### PR DESCRIPTION
## TL;DR

#1598 fixed the 126 functions whose credit moved onto me because a file rename and a rewrite shared one commit. These three are different: they were done **correctly** on the branch, and the credit dies when the PR is squash-merged.

This repo squash-merges — `a64045669` is a single commit tagged `(#1583)`. Squashing collapses a PR's commits into one, so a branch that deliberately split `git mv` from the rewrite arrives as one commit doing both. That is exactly the shape git refuses to call a rename.

#1597 split Whomp properly: `6134a7dd2` pure `git mv` (`R100`), then `48e01231f` content-only (`M`). It survives on the branch and dies on the squash.

| address | symbol | credit |
|---|---|---|
| ov015:0x021112a0 | `PoleBillboard::InitResources` | tangosdev |
| ov079:0x02123b54 | `Whomp::OnAimedAtWithEggReturnVec` | **ruspecial** |
| ov079:0x02123e60 | `Whomp::OnHitByMegaChar` | tangosdev |

**The point worth keeping:** in a squash-merge repo the commit-split remedy is cosmetic. It protects credit right up to the merge button. The override table is the only thing that holds.

## Verification

- Simulated the real merge shape — chained *single-parent* commits (what a squash produces) for #1585–#1597 onto current main — then ran `validate_merge`'s own `function_snapshot`/`attribution_snapshot`: **3 TO_ME, 0 lost**. With these six entries: **0 TO_ME, 0 lost**, `off_me` still 0.
- JSON parses, `aliases` untouched, 398 → 404 entries, zero collisions.
- Both `.c` and `.cpp` spellings per stem, matching #1598 and the file's existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5wXLsUQ2epxBcmNPSV9vz