### PR TITLE
linkcheck: a Thumb function pointer in a data word is not a wrong destination

### DIFF
--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -133,6 +133,31 @@ def is_interwork(rom_word, rom_t, cand_t):
     return (rom_word >> 24) in (0xfa, 0xfb) and cand_t is not None and rom_t == cand_t
 
 
+def is_thumb_pointer(rtype, rom_t, cand_t):
+    """True if the ROM slot is a DATA word holding a Thumb function pointer.
+
+    Taking the address of a Thumb function yields ``addr | 1``. Bit 0 is the state
+    bit ``bx``/``blx`` reads, not part of the address, and ``symbols.txt`` names the
+    function at its even address -- so a correct source naming that symbol produces a
+    slot the linker fills with ``addr | 1``, and the raw comparison is off by one.
+
+    ``is_interwork`` above covers the CALL form, a BL the linker rewrote to BLX. This
+    is the literal-pool form -- ``ldr ip, [pc]; bx ip; .word addr|1`` -- which is
+    R_ARM_ABS32 and so never reaches that check.
+
+    Safe because ARM instructions are 4-byte aligned and Thumb 2-byte aligned, so no
+    genuine function address ever carries bit 0. ``rom_t == cand_t | 1`` with an even
+    candidate identifies this case uniquely; every other divergence still reports
+    WRONG.
+
+    Proven on func_0203c178 (arm9 0x0203c178), a veneer whose literal is 0x020527e9
+    for the Thumb symbol func_020527e8: enrolling that range and building the ROM
+    reproduces the cartridge byte for byte while this check called it WRONG.
+    """
+    return (rtype == R_ARM_ABS32 and cand_t is not None
+            and cand_t % 2 == 0 and rom_t == (cand_t | 1))
+
+
 def is_benign(rom_t, cand_t, prefer):
     """True if the ROM target is a veneer to cand_t, or a byte-identical twin of it."""
     if cand_t is None:
@@ -256,7 +281,8 @@ def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=()
             if rl is not None:
                 rt = rom_target(target, i, rl["type"], addr)
                 rw = int.from_bytes(target[i:i + 4], "little")
-                if is_benign(rt, rl["addr"], prefer) or is_interwork(rw, rt, rl["addr"]):
+                if (is_benign(rt, rl["addr"], prefer) or is_interwork(rw, rt, rl["addr"])
+                        or is_thumb_pointer(rl["type"], rt, rl["addr"])):
                     benign += 1
                     continue
             tgt = (rl["addr"] + rl.get("add", 0)) & 0xFFFFFFFF if rl and rl["addr"] is not None else None


### PR DESCRIPTION
## TL;DR

`linkcheck.py` calls a source WRONG when it correctly names a **Thumb** function. Taking the address of a Thumb function yields `addr | 1` — bit 0 is the state bit `bx` reads, not part of the address — while `symbols.txt` names the function at its even address. So a correct source is off by exactly one and reads as a wrong callee.

## Why the existing allowances miss it

- `is_interwork` covers the **call** form: a `BL` the linker rewrote to `BLX` (opcode `0xfa/0xfb`). This is the **literal-pool** form — `ldr ip, [pc]; bx ip; .word addr|1` — which is `R_ARM_ABS32`, where `rom_target` returns the raw word and the BLX branch is never taken.
- `is_benign` misses it too: it reads 12 bytes at the **odd** address looking for a veneer, and finds nothing at that misalignment.

## Evidence, not inference

`arm9:0x0203c178` is a 12-byte veneer whose literal is `0x020527e9`, and the only declared symbol is the even one:

```
config/arm9/relocs.txt   from:0x0203c180 kind:load to:0x020527e9
config/arm9/symbols.txt  func_020527e8 kind:function(thumb,size=0x16) addr:0x020527e8
```

Its delink entry carried no `complete`, so dsd was supplying the cartridge's own bytes and **nothing ever compiled it** — the question had never actually been put to the ROM. Enrolling the range and building settles it:

```
source-built functions: 11,010 -> 11,011   (+12 bytes, exactly 0x0203c178..0x0203c184)
module fidelity: 106/106 exact, 0 mismatching, 100.000000% of compared bytes
```

The source is right; the linker sets bit 0 itself, as ARM interworking requires. The check was wrong.

## Why the predicate is safe

ARM instructions are 4-byte aligned and Thumb 2-byte aligned, so **no genuine function address ever carries bit 0**. `rom_t == cand_t | 1` with an even candidate identifies this case uniquely, and any other divergence still reports WRONG. It additionally requires `R_ARM_ABS32`, so no branch encoding can reach it.

## Verification

- `pr_linkcheck --files src/func_0203c178.c` against a tree carrying the rename: **WRONG → ok(ben)**.
- `pr_linkcheck --base origin/main --fail -j8` over the same **1,449-file** header fan-out the merge gate runs: previously ended `validation FAILED: src/func_0203c178.c [WRONG]`, now ends clean with no FAILED line. No other verdict moved.
- pyflakes clean.

Found while unblocking #1596, whose Thumb-bit rename this was failing. The enrolment that proves it lives in that PR; this is the tool half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5wXLsUQ2epxBcmNPSV9vz