### PR TITLE
Make a 105/106 diagnosable: guard the version pins, name the failing module

### DIFF
--- a/notes/rom-build.md
+++ b/notes/rom-build.md
@@ -433,7 +433,27 @@ so `LD_VERSION` keeps the link on 1.2/sp2p3's `mwldarm` regardless.
 
 **3. Per-file version overrides.** `config/rombuild-versions.txt` names the exceptions;
 `tools/rombuild_versions.py` finds them by sweeping `match.py`'s version list over
-whatever `rombuild_check.py` reported. Seven functions match only under `1.2/base`.
+whatever `rombuild_check.py` reported. Eight enrolled functions match only under
+`1.2/base` (a ninth is pinned but not yet enrolled, so its pin is inert).
+
+The table is keyed by **file stem** -- `compile_one` does
+`vers.get(pathlib.Path(rel).stem, VERSION)` -- so **renaming a pinned function's file
+detaches its pin unless the same commit re-keys it.** That failure is uniquely
+expensive: the build falls back to `2004/b56` and emits wrong bytes for a function
+whose source is perfectly correct, while every per-file gate keeps calling it exact,
+because `build_pin.verify`, `pr_linkcheck` and `eligible.py` all read this same table
+and compile *with* the pin. Only the whole-module compare disagrees, by a handful of
+bytes, in one module. #1607 spent a day on that shape before
+`_ZN21ClockPaintingPendulum8BehaviorEv` -- the first mangled pin key a ROM build had
+ever exercised -- was identified as the cause.
+
+`rombuild.audit_version_pins` now checks the table against the tree before the first
+compile: a pin naming no `src/` or `mods/` file at all is a hard preflight error, a
+pin naming an uninstalled service pack is too, and every applied pin is printed by
+name in phase [3/6] and recorded in the report as `alternateToolchain.applied`.
+`tools/validate_merge.py` renders that alongside the failing module, so a `105/106`
+in a PR comment now names the module, the function, the address and the byte count
+instead of only counting modules.
 
 **4. Per-function diffing beats bisection.** Because eligibility requires the object's
 `.text` to equal the declared size exactly, no function can shift its neighbours, so

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -97,6 +97,59 @@ def versions():
     return out
 
 
+def audit_version_pins(vers, srcs):
+    """Check every `config/rombuild-versions.txt` pin still names a real source file.
+
+    The pin is keyed by FILE STEM -- `compile_one` does
+    `vers.get(pathlib.Path(rel).stem, VERSION)` -- so renaming a pinned function's
+    file silently DETACHES its pin. The build then falls back to the default
+    compiler and emits wrong bytes for a function whose source is perfectly
+    correct.
+
+    Nothing else in the tree can see that. `build_pin.verify`, `pr_linkcheck` and
+    `eligible.py` all compile with the pin (build_pin.version_for reads this same
+    table), so they keep reporting the function exact; only the full-module compare
+    disagrees, by a handful of bytes, in one module, outside every per-file check.
+    That is the most expensive shape of failure this pipeline can produce, and it
+    cost a day on #1607. A stale pin is therefore a hard error, checked before the
+    first compile.
+
+    A pin whose file EXISTS but carries no `complete` is inert, not broken: the
+    function is configured and waiting to be enrolled. That is reported, not failed.
+
+    Returns (applied, inert) as sorted stem lists.
+    """
+    stems = {p.stem for root in ("src", "mods")
+             for p in (REPO / root).rglob("*")
+             if p.suffix in (".c", ".cpp") and p.is_file()}
+    enrolled_stems = {pathlib.Path(s).stem for s in srcs}
+
+    stale = sorted(k for k in vers if k not in stems)
+    if stale:
+        raise BuildError("preflight", 1,
+                         "stale entry in config/rombuild-versions.txt -- no src/ or "
+                         "mods/ file has this stem, so the pin no longer applies and "
+                         "the build would silently use " + VERSION + " instead:\n  "
+                         + "\n  ".join(stale)
+                         + "\nIf the function was renamed, re-key its pin to "
+                           "the new file stem in the same commit.")
+
+    # The preflight only proves the DEFAULT compiler is installed. A pin naming a
+    # service pack that is not present would otherwise fail deep in the compile with
+    # a path error, or -- worse, on a tree where the pin had already detached -- not
+    # at all.
+    for version in sorted(set(vers.values())):
+        exe = MW / version / "mwccarm.exe"
+        if not exe.is_file():
+            raise BuildError("preflight", 1,
+                             f"config/rombuild-versions.txt pins {version}, but "
+                             f"{exe} is missing - see notes/setup-mwccarm.md")
+
+    applied = sorted(k for k in vers if k in enrolled_stems)
+    inert = sorted(k for k in vers if k in stems and k not in enrolled_stems)
+    return applied, inert
+
+
 def launcher():
     """Wine prefix on the Linux build box; empty on native Windows (see match.py)."""
     return os.environ.get("MWCCARM_LAUNCHER", "").split()
@@ -510,9 +563,19 @@ def main():
 
         srcs = enrolled(config_root)
         vers = versions()
-        n_alt = sum(1 for s in srcs if pathlib.Path(s).stem in vers)
+        # Before the first compile: a pin that no longer names a real file has quietly
+        # stopped applying, and the only symptom downstream is a few wrong bytes in one
+        # module that no per-file check can see.
+        pins_applied, pins_inert = audit_version_pins(vers, srcs)
+        n_alt = len(pins_applied)
         report["enrolledFiles"] = len(srcs)
         report["alternateToolchainFiles"] = n_alt
+        # Named, not just counted. When a module compare disagrees with a per-file
+        # check, the first question is which pins actually ran, and a count cannot
+        # answer it -- see tools/validate_merge.py:_module_fidelity_detail.
+        report["alternateToolchain"] = {
+            "applied": {k: vers[k] for k in pins_applied},
+            "inertNotEnrolled": {k: vers[k] for k in pins_inert}}
         cache = RBK.ObjectCache(args.cache_dir or (BUILD / "objcache"), REPO,
                                 enabled=not args.no_cache)
         init_srcs = init_section_sources()
@@ -523,6 +586,10 @@ def main():
         data_sink = None if args.no_data_check else []
         print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
               + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
+        for stem in pins_applied:
+            print(f"      pinned {vers[stem]:<12} {stem}")
+        for stem in pins_inert:
+            print(f"      pinned {vers[stem]:<12} {stem}  (not enrolled - pin inert)")
         failures = []
         outcomes = {}
         if srcs:

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -107,5 +107,63 @@ class Retarget(unittest.TestCase):
         self.assertEqual(self.obj.read_bytes(), before)
 
 
+class VersionPinAudit(unittest.TestCase):
+    """A pin that stops applying is the most expensive failure this build can emit.
+
+    It produces wrong bytes for a function whose source is correct, and every
+    per-file gate keeps calling that function exact, because they all compile it
+    WITH the pin (build_pin reads the same table). Only the whole-module compare
+    disagrees. So the pin table is checked against the tree before the first
+    compile rather than discovered afterwards.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name)
+        (self.repo / "src").mkdir()
+        (self.repo / "mods").mkdir()
+        for stem in ("Pinned", "Waiting"):
+            (self.repo / "src" / f"{stem}.c").write_text("int x;\n", encoding="utf-8")
+        self.mw = self.repo / "tools" / "mwccarm"
+        (self.mw / "1.2" / "base").mkdir(parents=True)
+        (self.mw / "1.2" / "base" / "mwccarm.exe").write_bytes(b"stub")
+        self.old_repo, self.old_mw = RB.REPO, RB.MW
+        RB.REPO, RB.MW = self.repo, self.mw
+
+    def tearDown(self):
+        RB.REPO, RB.MW = self.old_repo, self.old_mw
+        self.tmp.cleanup()
+
+    def test_enrolled_pin_is_reported_as_applied(self):
+        applied, inert = RB.audit_version_pins({"Pinned": "1.2/base"}, ["src/Pinned.c"])
+        self.assertEqual(applied, ["Pinned"])
+        self.assertEqual(inert, [])
+
+    def test_pin_on_a_file_that_exists_but_is_not_enrolled_is_inert_not_fatal(self):
+        # Configured and waiting for a `complete` marker. Not a defect.
+        applied, inert = RB.audit_version_pins({"Waiting": "1.2/base"}, ["src/Pinned.c"])
+        self.assertEqual(applied, [])
+        self.assertEqual(inert, ["Waiting"])
+
+    def test_pin_naming_no_file_at_all_is_fatal(self):
+        # The shape of a rename whose pin was not re-keyed in the same commit.
+        with self.assertRaises(RB.BuildError) as caught:
+            RB.audit_version_pins({"func_ov013_021112a8": "1.2/base"}, ["src/Pinned.c"])
+        self.assertIn("func_ov013_021112a8", caught.exception.output)
+        self.assertIn("re-key", caught.exception.output)
+
+    def test_pin_naming_an_uninstalled_compiler_is_fatal(self):
+        # The default-only preflight cannot catch this: it never looks at the pins.
+        with self.assertRaises(RB.BuildError) as caught:
+            RB.audit_version_pins({"Pinned": "1.2/sp4"}, ["src/Pinned.c"])
+        self.assertIn("1.2/sp4", caught.exception.output)
+
+    def test_a_mods_file_satisfies_a_pin(self):
+        (self.repo / "mods" / "Replaced.cpp").write_text("int y;\n", encoding="utf-8")
+        applied, inert = RB.audit_version_pins({"Replaced": "1.2/base"},
+                                               ["mods/Replaced.cpp"])
+        self.assertEqual(applied, ["Replaced"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -413,5 +413,67 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(len(state["blocking"]), 1)
 
 
+class ModuleFidelityDetail(unittest.TestCase):
+    """`105/106` on its own is unactionable -- name the module and the function.
+
+    The worker already ships both (`moduleFidelity.results` and `failures`); the
+    summary table used to drop them, so a few wrong bytes in three million came
+    with no way to find them while every per-file check on the PR stayed green.
+    """
+
+    def detail(self, **analysis):
+        analysis.setdefault("moduleFidelity", {"results": []})
+        analysis.setdefault("failures", [])
+        return "\n".join(VM._module_fidelity_detail({"analysis": analysis}))
+
+    def test_exact_build_renders_nothing(self):
+        self.assertEqual(self.detail(
+            moduleFidelity={"results": [{"module": "ov013", "exact": True}]}), "")
+
+    def test_missing_analysis_renders_nothing(self):
+        self.assertEqual(VM._module_fidelity_detail({"available": False}), [])
+        self.assertEqual(VM._module_fidelity_detail(None), [])
+
+    def test_names_the_module_and_the_function(self):
+        out = self.detail(
+            moduleFidelity={"results": [
+                {"module": "ov013", "exact": False,
+                 "differingBytes": 8, "comparedBytes": 4320},
+                {"module": "arm9", "exact": True, "differingBytes": 0},
+            ]},
+            failures=[{"module": "ov013", "name": "_ZN21ClockPaintingPendulum8BehaviorEv",
+                       "addr": 0x021112a8, "size": 0x94, "differingBytes": 8}])
+        self.assertIn("`ov013`", out)
+        self.assertIn("_ZN21ClockPaintingPendulum8BehaviorEv", out)
+        self.assertIn("0x021112a8", out)
+        self.assertNotIn("`arm9`", out)          # exact modules stay out of the way
+
+    def test_module_differing_with_no_failing_function_says_so(self):
+        # Bytes outside every delink range -- padding, alignment, unreached data.
+        # Nothing per-function can ever surface these, so the absence is the news.
+        out = self.detail(moduleFidelity={"results": [
+            {"module": "arm9", "exact": False,
+             "differingBytes": 8, "comparedBytes": 382212}]})
+        self.assertIn("No enrolled function range accounts", out)
+
+    def test_a_mismatching_pinned_function_is_flagged_as_a_pin_failure(self):
+        out = self.detail(
+            moduleFidelity={"results": [{"module": "ov013", "exact": False,
+                                         "differingBytes": 8, "comparedBytes": 4320}]},
+            failures=[{"module": "ov013", "name": "Behavior",
+                       "addr": 0x021112a8, "size": 0x94, "differingBytes": 8}],
+            alternateToolchain={"applied": {"Behavior": "1.2/base"}})
+        self.assertIn("did not apply its pin", out)
+        self.assertIn("1.2/base", out)
+
+    def test_a_failure_with_a_reason_instead_of_a_count_still_renders(self):
+        out = self.detail(
+            moduleFidelity={"results": [{"module": "ov013", "exact": False,
+                                         "differingBytes": 4, "comparedBytes": 4320}]},
+            failures=[{"module": "ov013", "name": "Odd", "addr": 0x1, "size": 0x4,
+                       "reason": "range outside built or retail module"}])
+        self.assertIn("range outside built or retail module", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -839,9 +839,83 @@ def render_markdown(r):
                       f"banner, and nothing compiles them -- dsd fills their addresses "
                       f"with the ROM's own bytes. Both together are the "
                       f"{h['matchedFunctions']:,} this project calls matched."]
+    lines += _module_fidelity_detail(head_rom)
     if r["warnings"]:
         lines += ["", "Warnings: " + "; ".join(r["warnings"]) + "."]
     return "\n".join(lines)
+
+
+SHOWN = 12
+
+
+def _module_fidelity_detail(head_rom):
+    """Name the modules and functions behind a `105/106`, instead of only counting them.
+
+    The worker already ships all of this -- `moduleFidelity.results` carries a row per
+    module and `failures` a row per function range -- and the summary table used to
+    drop both. A bare "105/106 exact; 99.999738% compared bytes" says a few bytes are
+    wrong somewhere in three million and gives no way to find them, while every
+    per-file check on the PR stays green, because a per-file check compiles with the
+    right pin and the module compare is the only thing that does not. That combination
+    cost a full day on #1607. rombuild_check.py has printed this to the worker's
+    console all along; this puts it in the comment.
+
+    Returns markdown lines, or [] when the build is exact or said nothing.
+    """
+    analysis = (head_rom or {}).get("analysis")
+    if not analysis:
+        return []
+    mf = analysis.get("moduleFidelity") or {}
+    bad_modules = [m for m in (mf.get("results") or []) if not m.get("exact")]
+    failures = analysis.get("failures") or []
+    if not bad_modules and not failures:
+        return []
+
+    out = ["", f"**Module fidelity detail --- {len(bad_modules)} module(s) differ "
+               f"from the cartridge.**", ""]
+    if bad_modules:
+        out += ["| Module | Bytes differing | Module bytes |", "|---|---:|---:|"]
+        for m in sorted(bad_modules, key=lambda m: -m.get("differingBytes", 0))[:SHOWN]:
+            out.append(f"| `{m.get('module')}` | {m.get('differingBytes', 0):,} "
+                       f"| {m.get('comparedBytes', 0):,} |")
+        out.append("")
+
+    if failures:
+        out += ["Function ranges that account for it:", "",
+                "| Module | Function | Address | Size | Bytes differing |",
+                "|---|---|---|---:|---:|"]
+        for f in sorted(failures,
+                        key=lambda f: -(f.get("differingBytes") or 0))[:SHOWN]:
+            detail = (f"{f['differingBytes']:,}" if f.get("differingBytes") is not None
+                      else f.get("reason", "?"))
+            out.append(f"| `{f.get('module')}` | `{f.get('name')}` "
+                       f"| 0x{f.get('addr', 0):08x} | 0x{f.get('size', 0):x} "
+                       f"| {detail} |")
+        if len(failures) > SHOWN:
+            out.append(f"| ... | {len(failures) - SHOWN} more | | | |")
+        out.append("")
+    else:
+        # The distinction worth calling out: a module can differ with every enrolled
+        # function exact, when the differing bytes fall outside every delink range
+        # (padding, alignment, or data no entry reaches). Nothing per-function can
+        # ever surface those, so say so rather than leave an empty section.
+        out += ["No enrolled function range accounts for these bytes --- they fall "
+                "outside every `delinks.txt` range, so no per-function or per-file "
+                "check can see them.", ""]
+
+    # A function that is pinned to a non-default mwccarm and is ALSO mismatching is
+    # the signature of a pin that did not apply: the source is fine, the compiler was
+    # wrong. Worth naming, because the fix is a config re-key, not a decomp change.
+    pinned = ((analysis.get("alternateToolchain") or {}).get("applied")
+              or (head_rom or {}).get("alternateToolchain", {}).get("applied") or {})
+    hits = [f for f in failures if f.get("name") in pinned]
+    if hits:
+        out += ["Pinned to a non-default mwccarm in `config/rombuild-versions.txt`: "
+                + ", ".join(f"`{f['name']}` ({pinned[f['name']]})" for f in hits)
+                + ". A pinned function that mismatches usually means the ROM build "
+                  "did not apply its pin --- check `alternateToolchainFiles` in the "
+                  "build report before treating this as a source defect.", ""]
+    return out
 
 
 def _credit_table(a):


### PR DESCRIPTION
## What this does

Two gaps that combined to cost a day on #1607, where a `105/106 exact; 99.999738%
compared bytes` verdict had to be reverse-engineered from a percentage.

### 1. The version-pin table is checked before the first compile

`config/rombuild-versions.txt` is keyed by **file stem** — `compile_one` does
`vers.get(pathlib.Path(rel).stem, VERSION)` — so renaming a pinned function's file
detaches its pin unless the same commit re-keys it.

That failure is uniquely expensive. The build falls back to `2004/b56` and emits wrong
bytes for a function whose **source is perfectly correct**, while every per-file gate
keeps calling it exact — `build_pin.verify`, `pr_linkcheck` and `eligible.py` all read
this same table and compile *with* the pin. Only the whole-module compare disagrees, by
a handful of bytes, in one module, outside every per-file check.

`audit_version_pins`:

- a pin naming **no `src/` or `mods/` file at all** is a hard preflight error, with the
  stem named and "re-key its pin" in the message;
- a pin naming an **uninstalled service pack** is too — the existing preflight could not
  catch this, since it only proves the *default* compiler is installed;
- a pin whose file **exists but carries no `complete`** is inert, not broken (configured
  and waiting to be enrolled), so it is reported, never failed;
- every applied pin is printed **by name** in phase [3/6] and recorded as
  `alternateToolchain.applied` in the report.

```
[3/6] mwccarm: 11028 enrolled source file(s), -j16 (8 on an alternate toolchain version)
      pinned 1.2/base     func_02062428
      ...
      pinned 1.2/base     _ZN11dScMgCard_c13InitResourcesEv  (not enrolled - pin inert)
```

### 2. The PR comment now names the module

The worker has always shipped `moduleFidelity.results` and `failures`;
`render_markdown` dropped both. `_module_fidelity_detail` renders them:

> **Module fidelity detail --- 1 module(s) differ from the cartridge.**
>
> | Module | Bytes differing | Module bytes |
> |---|---:|---:|
> | `ov013` | 8 | 4,320 |
>
> Function ranges that account for it:
>
> | Module | Function | Address | Size | Bytes differing |
> |---|---|---|---:|---:|
> | `ov013` | `_ZN21ClockPaintingPendulum8BehaviorEv` | 0x021112a8 | 0x94 | 8 |

Plus two cases worth distinguishing explicitly:

- a **mismatching function that carries a version pin** is flagged as a likely detached
  pin rather than a source defect — the fix is a config re-key, not decomp work;
- a module that differs with **no failing function range** says so, because those bytes
  fall outside every `delinks.txt` range and nothing per-function can ever surface them.

## Verification

- Full `tools/rombuild.py -j16`: **106/106 exact, 100.000000%, PASS** with the guard
  active and all 8 pins named in the log
- `alternateToolchain.applied` verified in the emitted report JSON
- **46 tests pass (11 new)** across `test_rombuild.py`, `test_validate_merge.py`,
  `test_rombuild_check.py`; pyflakes clean on both changed tools
- The rendering was exercised against the real failing report captured from #1607's
  reproduction, and against all four branches (exact, module-only, pinned, reason-only)

No change to what gets built, linked or compared — this is preflight and reporting only.

## Plain-English TL;DR

When the ROM build says "105 of 106 modules match", it used to stop there: somewhere in
three million bytes about eight were wrong, with no hint where. Now it names the module
and the function. It also catches the specific mistake that caused the last one —
renaming a file whose function needs an older compiler, without updating the list that
says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5wXLsUQ2epxBcmNPSV9vz
