### PR TITLE
Goomba OnTurnIntoEgg: defeat the field-address CSE, byte-matched at 0x1cc

### DIFF
--- a/src/func_ov084_0212b344.cpp
+++ b/src/func_ov084_0212b344.cpp
@@ -65,7 +65,10 @@ extern "C" void func_ov084_0212b344(char *self, char *player)
                 _ZN8dActor_c11UntrackStarERa(self, (signed char *)(self + 0x465));
                 b4 = 1;
                 _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(0xb4, 0x50, self + 0x41c, 0, *(signed char *)(self + 0xcc), -1);
-                *(int *)(self + 8) = *(int *)(self + 8) & 0xff0f;
+                /* unsigned on the load side only: spelling both sides identically
+                   lets mwccarm CSE the field address (add r2,r7,#8 + [r2]),
+                   one instruction the ROM does not have -- it wants [r7,#8] direct */
+                *(int *)(self + 8) = *(unsigned int *)(self + 8) & 0xff0f;
             } else if (*(unsigned char *)(self + 0x464) == 2) {
                 if (*(unsigned char *)(self + 0x466) == data_0209f344[data_0209f208]) {
                     _ZN8dActor_c11UntrackStarERa(self, (signed char *)(self + 0x465));


### PR DESCRIPTION
## What

Rescues one commit that fell through the crack: it was pushed to `cpp/goomba-family` after the combined-validation PR #1614 was cut, so when #1610 was closed in favor of #1614 the fix never reached main. Cherry-picked clean onto current main.

The function (daKrb_c's OnTurnIntoEgg, `func_ov084_0212b344`) compiled 4 bytes long: mwccarm 2004/b56 CSEs a field address in a read-modify-write whenever the load and store spell the *same* lvalue (`add r2,r7,#8` + `[r2]` twice, where the ROM has `[r7,#8]` direct). Twenty controlled probes established the rule — every same-spelling form CSEs (plain, compound, typed member, reference, temp), every differing-spelling form doesn't (volatile, unsigned-vs-int, index-vs-offset). The fix loads through `unsigned int *` while storing through `int *` — the least invasive of the CSE-defeating spellings.

## Verification

`build_pin.verify(src/func_ov084_0212b344.cpp, func_ov084_0212b344, 0x0212b344, 0x1cc, 'ov084')` → `(True, '2004/b56')` on this branch, i.e. byte-identical to the cartridge under the pinned compiler. One source file, no header or config changes.

## Plain-English TL;DR

One Goomba function was compiling to four bytes more than the original game because the compiler saved an address in a spare register before using it twice. Writing the read and the write with slightly different types makes the compiler use the address directly both times — exactly what the 2004 developers' code did. The function now matches the cartridge byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT