### PR TITLE
TU seed 3: reassemble ov070's four translation units at 2.5x scale, 92/92 byte-verified, with the struct-copy scalarization fix

### DIFF
--- a/config/tu_manifest.json
+++ b/config/tu_manifest.json
@@ -4016,6 +4016,830 @@
           "relocation_destinations_verified": "PASS"
         }
       }
+    },
+    {
+      "id": "ov070/Amp",
+      "module": "ov070",
+      "source": "src_tu/actors/Amp.cpp",
+      "promoted_source": "src/actors/Amp.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "high",
+      "boundary_evidence": [
+        "contiguous linker run: 0x2120570..0x2121118, 19 function(s), from build/tu_map.json (tools/tu_map.py)",
+        "class label(s): Amp",
+        "module sinit corroboration: 4 sinit(s) / 4 .ctor entries, sinit_vs_tu=ok, corroborated=True (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x02120570",
+          "end": "0x02121118"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN3AmpD1Ev",
+          "address": "0x02120570",
+          "size": "0x00000060",
+          "legacy_source": "src/_ZN3AmpD1Ev.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "_ZN3AmpD0Ev",
+          "address": "0x021205d0",
+          "size": "0x00000074",
+          "legacy_source": "src/_ZN3AmpD0Ev.cpp",
+          "ordinal": 1
+        },
+        {
+          "symbol": "func_ov070_02120644",
+          "address": "0x02120644",
+          "size": "0x000000e0",
+          "legacy_source": "src/func_ov070_02120644.cpp",
+          "ordinal": 2
+        },
+        {
+          "symbol": "func_ov070_02120724",
+          "address": "0x02120724",
+          "size": "0x00000180",
+          "legacy_source": "src/func_ov070_02120724.c",
+          "ordinal": 3
+        },
+        {
+          "symbol": "func_ov070_021208a4",
+          "address": "0x021208a4",
+          "size": "0x0000006c",
+          "legacy_source": "src/func_ov070_021208a4.c",
+          "ordinal": 4
+        },
+        {
+          "symbol": "func_ov070_02120910",
+          "address": "0x02120910",
+          "size": "0x000000d4",
+          "legacy_source": "src/func_ov070_02120910.cpp",
+          "ordinal": 5
+        },
+        {
+          "symbol": "func_ov070_021209e4",
+          "address": "0x021209e4",
+          "size": "0x00000214",
+          "legacy_source": "src/func_ov070_021209e4.cpp",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov070_02120bf8",
+          "address": "0x02120bf8",
+          "size": "0x000000b4",
+          "legacy_source": "src/func_ov070_02120bf8.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov070_02120cac",
+          "address": "0x02120cac",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov070_02120cac.cpp",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov070_02120ce4",
+          "address": "0x02120ce4",
+          "size": "0x00000050",
+          "legacy_source": "src/func_ov070_02120ce4.c",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov070_02120d34",
+          "address": "0x02120d34",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov070_02120d34.cpp",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov070_02120d70",
+          "address": "0x02120d70",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov070_02120d70.cpp",
+          "ordinal": 11
+        },
+        {
+          "symbol": "func_ov070_02120da8",
+          "address": "0x02120da8",
+          "size": "0x0000001c",
+          "legacy_source": "src/func_ov070_02120da8.c",
+          "ordinal": 12
+        },
+        {
+          "symbol": "_ZN3Amp16CleanupResourcesEv",
+          "address": "0x02120dc4",
+          "size": "0x0000005c",
+          "legacy_source": "src/_ZN3Amp16CleanupResourcesEv.cpp",
+          "ordinal": 13
+        },
+        {
+          "symbol": "_ZN3Amp16OnPendingDestroyEv",
+          "address": "0x02120e20",
+          "size": "0x00000004",
+          "legacy_source": "src/_ZN3Amp16OnPendingDestroyEv.cpp",
+          "ordinal": 14
+        },
+        {
+          "symbol": "_ZN3Amp6RenderEv",
+          "address": "0x02120e24",
+          "size": "0x00000068",
+          "legacy_source": "src/_ZN3Amp6RenderEv.cpp",
+          "ordinal": 15
+        },
+        {
+          "symbol": "_ZN3Amp8BehaviorEv",
+          "address": "0x02120e8c",
+          "size": "0x00000060",
+          "legacy_source": "src/_ZN3Amp8BehaviorEv.cpp",
+          "ordinal": 16
+        },
+        {
+          "symbol": "_ZN3Amp13InitResourcesEv",
+          "address": "0x02120eec",
+          "size": "0x000001c0",
+          "legacy_source": "src/_ZN3Amp13InitResourcesEv.cpp",
+          "ordinal": 17
+        },
+        {
+          "symbol": "Amp_Spawn",
+          "address": "0x021210ac",
+          "size": "0x0000006c",
+          "legacy_source": "src/Amp_Spawn.c",
+          "ordinal": 18
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically.",
+        "tubuild create warning: hand-assembled: raw concatenation in reverse ROM order; tubuild create refused this TU (extern \"C\"-wrapped legacy bodies)",
+        "19/19 MATCH, objisolate clean, reloc-destinations clean. Hand-assembled. Internal state-machine helpers unified on (void*)+cast definitions so every block's declaration agrees under C linkage; one destructor emits D0+D1; Amp_Spawn stores &_ZTV3Amp[2]."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov070-Amp/Amp.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 19,
+        "functions_declared": 19,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 11 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
+          "relocation_destinations_verified": "PASS"
+        }
+      }
+    },
+    {
+      "id": "ov070/FlameChompFire",
+      "module": "ov070",
+      "source": "src_tu/actors/FlameChompFire.cpp",
+      "promoted_source": "src/actors/FlameChompFire.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "high",
+      "boundary_evidence": [
+        "contiguous linker run: 0x2121b48..0x2122244, 21 function(s), from build/tu_map.json (tools/tu_map.py)",
+        "class label(s): FlameChompFire",
+        "module sinit corroboration: 4 sinit(s) / 4 .ctor entries, sinit_vs_tu=ok, corroborated=True (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x02121b48",
+          "end": "0x02122244"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN14FlameChompFireD1Ev",
+          "address": "0x02121b48",
+          "size": "0x00000040",
+          "legacy_source": "src/_ZN14FlameChompFireD1Ev.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "_ZN14FlameChompFireD0Ev",
+          "address": "0x02121b88",
+          "size": "0x00000054",
+          "legacy_source": "src/_ZN14FlameChompFireD0Ev.cpp",
+          "ordinal": 1
+        },
+        {
+          "symbol": "_ZN14FlameChompFire13OnYoshiTryEatEv",
+          "address": "0x02121bdc",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN14FlameChompFire13OnYoshiTryEatEv.cpp",
+          "ordinal": 2
+        },
+        {
+          "symbol": "func_ov070_02121be4",
+          "address": "0x02121be4",
+          "size": "0x000000a8",
+          "legacy_source": "src/func_ov070_02121be4.cpp",
+          "ordinal": 3
+        },
+        {
+          "symbol": "func_ov070_02121c8c",
+          "address": "0x02121c8c",
+          "size": "0x00000030",
+          "legacy_source": "src/func_ov070_02121c8c.c",
+          "ordinal": 4
+        },
+        {
+          "symbol": "func_ov070_02121cbc",
+          "address": "0x02121cbc",
+          "size": "0x00000094",
+          "legacy_source": "src/func_ov070_02121cbc.c",
+          "ordinal": 5
+        },
+        {
+          "symbol": "func_ov070_02121d50",
+          "address": "0x02121d50",
+          "size": "0x000000c4",
+          "legacy_source": "src/func_ov070_02121d50.cpp",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov070_02121e14",
+          "address": "0x02121e14",
+          "size": "0x0000009c",
+          "legacy_source": "src/func_ov070_02121e14.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov070_02121eb0",
+          "address": "0x02121eb0",
+          "size": "0x00000048",
+          "legacy_source": "src/func_ov070_02121eb0.c",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov070_02121ef8",
+          "address": "0x02121ef8",
+          "size": "0x00000020",
+          "legacy_source": "src/func_ov070_02121ef8.c",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov070_02121f18",
+          "address": "0x02121f18",
+          "size": "0x00000098",
+          "legacy_source": "src/func_ov070_02121f18.cpp",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov070_02121fb0",
+          "address": "0x02121fb0",
+          "size": "0x00000020",
+          "legacy_source": "src/func_ov070_02121fb0.c",
+          "ordinal": 11
+        },
+        {
+          "symbol": "func_ov070_02121fd0",
+          "address": "0x02121fd0",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov070_02121fd0.cpp",
+          "ordinal": 12
+        },
+        {
+          "symbol": "func_ov070_0212200c",
+          "address": "0x0212200c",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov070_0212200c.cpp",
+          "ordinal": 13
+        },
+        {
+          "symbol": "func_ov070_02122044",
+          "address": "0x02122044",
+          "size": "0x0000001c",
+          "legacy_source": "src/func_ov070_02122044.c",
+          "ordinal": 14
+        },
+        {
+          "symbol": "_ZN14FlameChompFire16CleanupResourcesEv",
+          "address": "0x02122060",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN14FlameChompFire16CleanupResourcesEv.cpp",
+          "ordinal": 15
+        },
+        {
+          "symbol": "_ZN14FlameChompFire16OnPendingDestroyEv",
+          "address": "0x02122068",
+          "size": "0x00000004",
+          "legacy_source": "src/_ZN14FlameChompFire16OnPendingDestroyEv.cpp",
+          "ordinal": 16
+        },
+        {
+          "symbol": "_ZN14FlameChompFire6RenderEv",
+          "address": "0x0212206c",
+          "size": "0x00000098",
+          "legacy_source": "src/_ZN14FlameChompFire6RenderEv.cpp",
+          "ordinal": 17
+        },
+        {
+          "symbol": "_ZN14FlameChompFire8BehaviorEv",
+          "address": "0x02122104",
+          "size": "0x00000020",
+          "legacy_source": "src/_ZN14FlameChompFire8BehaviorEv.cpp",
+          "ordinal": 18
+        },
+        {
+          "symbol": "_ZN14FlameChompFire13InitResourcesEv",
+          "address": "0x02122124",
+          "size": "0x000000d8",
+          "legacy_source": "src/_ZN14FlameChompFire13InitResourcesEv.cpp",
+          "ordinal": 19
+        },
+        {
+          "symbol": "FlameChompFire_Spawn",
+          "address": "0x021221fc",
+          "size": "0x00000048",
+          "legacy_source": "src/FlameChompFire_Spawn.c",
+          "ordinal": 20
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically.",
+        "tubuild create warning: hand-assembled: raw concatenation in reverse ROM order; tubuild create refused this TU (extern \"C\"-wrapped legacy bodies)",
+        "21/21 MATCH, objisolate clean, reloc-destinations clean. Hand-assembled. The legacy WithMeshClsn shadow's extra methods (GetFloorResult, SurfaceInfo::CopyNormalTo) are spelled by their mangled names against the real header type; RaycastGround kept one definition with one extern-C signature set; one destructor emits D0+D1; Spawn stores &_ZTV14FlameChompFire[2]."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov070-FlameChompFire/FlameChompFire.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 21,
+        "functions_declared": 21,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 11 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
+          "relocation_destinations_verified": "PASS"
+        }
+      }
+    },
+    {
+      "id": "ov070/FlameChomp",
+      "module": "ov070",
+      "source": "src_tu/actors/FlameChomp.cpp",
+      "promoted_source": "src/actors/FlameChomp.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "high",
+      "boundary_evidence": [
+        "contiguous linker run: 0x2121118..0x2121b48, 25 function(s), from build/tu_map.json (tools/tu_map.py)",
+        "class label(s): FlameChomp",
+        "module sinit corroboration: 4 sinit(s) / 4 .ctor entries, sinit_vs_tu=ok, corroborated=True (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x02121118",
+          "end": "0x02121b48"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN10FlameChompD1Ev",
+          "address": "0x02121118",
+          "size": "0x00000048",
+          "legacy_source": "src/_ZN10FlameChompD1Ev.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "_ZN10FlameChompD0Ev",
+          "address": "0x02121160",
+          "size": "0x0000005c",
+          "legacy_source": "src/_ZN10FlameChompD0Ev.cpp",
+          "ordinal": 1
+        },
+        {
+          "symbol": "_ZN10FlameChomp13OnYoshiTryEatEv",
+          "address": "0x021211bc",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN10FlameChomp13OnYoshiTryEatEv.cpp",
+          "ordinal": 2
+        },
+        {
+          "symbol": "func_ov070_021211c4",
+          "address": "0x021211c4",
+          "size": "0x000000d4",
+          "legacy_source": "src/func_ov070_021211c4.cpp",
+          "ordinal": 3
+        },
+        {
+          "symbol": "func_ov070_02121298",
+          "address": "0x02121298",
+          "size": "0x00000078",
+          "legacy_source": "src/func_ov070_02121298.cpp",
+          "ordinal": 4
+        },
+        {
+          "symbol": "func_ov070_02121310",
+          "address": "0x02121310",
+          "size": "0x000000bc",
+          "legacy_source": "src/func_ov070_02121310.cpp",
+          "ordinal": 5
+        },
+        {
+          "symbol": "func_ov070_021213cc",
+          "address": "0x021213cc",
+          "size": "0x0000006c",
+          "legacy_source": "src/func_ov070_021213cc.c",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov070_02121438",
+          "address": "0x02121438",
+          "size": "0x000000c0",
+          "legacy_source": "src/func_ov070_02121438.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov070_021214f8",
+          "address": "0x021214f8",
+          "size": "0x00000050",
+          "legacy_source": "src/func_ov070_021214f8.cpp",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov070_02121548",
+          "address": "0x02121548",
+          "size": "0x00000024",
+          "legacy_source": "src/func_ov070_02121548.c",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov070_0212156c",
+          "address": "0x0212156c",
+          "size": "0x0000014c",
+          "legacy_source": "src/func_ov070_0212156c.c",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov070_021216b8",
+          "address": "0x021216b8",
+          "size": "0x00000058",
+          "legacy_source": "src/func_ov070_021216b8.c",
+          "ordinal": 11
+        },
+        {
+          "symbol": "func_ov070_02121710",
+          "address": "0x02121710",
+          "size": "0x0000009c",
+          "legacy_source": "src/func_ov070_02121710.cpp",
+          "ordinal": 12
+        },
+        {
+          "symbol": "func_ov070_021217ac",
+          "address": "0x021217ac",
+          "size": "0x00000060",
+          "legacy_source": "src/func_ov070_021217ac.c",
+          "ordinal": 13
+        },
+        {
+          "symbol": "func_ov070_0212180c",
+          "address": "0x0212180c",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov070_0212180c.cpp",
+          "ordinal": 14
+        },
+        {
+          "symbol": "func_ov070_02121848",
+          "address": "0x02121848",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov070_02121848.cpp",
+          "ordinal": 15
+        },
+        {
+          "symbol": "func_ov070_02121880",
+          "address": "0x02121880",
+          "size": "0x0000001c",
+          "legacy_source": "src/func_ov070_02121880.c",
+          "ordinal": 16
+        },
+        {
+          "symbol": "_ZN10FlameChomp16CleanupResourcesEv",
+          "address": "0x0212189c",
+          "size": "0x00000024",
+          "legacy_source": "src/_ZN10FlameChomp16CleanupResourcesEv.cpp",
+          "ordinal": 17
+        },
+        {
+          "symbol": "_ZN10FlameChomp16OnPendingDestroyEv",
+          "address": "0x021218c0",
+          "size": "0x00000004",
+          "legacy_source": "src/_ZN10FlameChomp16OnPendingDestroyEv.cpp",
+          "ordinal": 18
+        },
+        {
+          "symbol": "_ZN10FlameChomp6RenderEv",
+          "address": "0x021218c4",
+          "size": "0x00000030",
+          "legacy_source": "src/_ZN10FlameChomp6RenderEv.cpp",
+          "ordinal": 19
+        },
+        {
+          "symbol": "_ZN10FlameChomp8BehaviorEv",
+          "address": "0x021218f4",
+          "size": "0x00000020",
+          "legacy_source": "src/_ZN10FlameChomp8BehaviorEv.cpp",
+          "ordinal": 20
+        },
+        {
+          "symbol": "_ZN10FlameChomp13InitResourcesEv",
+          "address": "0x02121914",
+          "size": "0x00000150",
+          "legacy_source": "src/_ZN10FlameChomp13InitResourcesEv.cpp",
+          "ordinal": 21
+        },
+        {
+          "symbol": "func_ov070_02121a64",
+          "address": "0x02121a64",
+          "size": "0x0000007c",
+          "legacy_source": "src/func_ov070_02121a64.c",
+          "ordinal": 22
+        },
+        {
+          "symbol": "func_ov070_02121ae0",
+          "address": "0x02121ae0",
+          "size": "0x00000018",
+          "legacy_source": "src/func_ov070_02121ae0.c",
+          "ordinal": 23
+        },
+        {
+          "symbol": "FlameChomp_Spawn",
+          "address": "0x02121af8",
+          "size": "0x00000050",
+          "legacy_source": "src/FlameChomp_Spawn.c",
+          "ordinal": 24
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically.",
+        "tubuild create warning: hand-assembled: raw concatenation in reverse ROM order; tubuild create refused this TU (extern \"C\"-wrapped legacy bodies)",
+        "25/25 MATCH, objisolate clean, reloc-destinations clean. Hand-assembled. Two different legacy shadow structs both named C (a PMF dispatch view and a Render vtable view) -- the Render one renamed TU-locally; decl_common.h's declarations win where they exist (0212180c char*, 02121880 void*); one destructor emits D0+D1; Spawn stores &_ZTV10FlameChomp[2]."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov070-FlameChomp/FlameChomp.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 25,
+        "functions_declared": 25,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 11 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
+          "relocation_destinations_verified": "PASS"
+        }
+      }
+    },
+    {
+      "id": "ov070/FlyGuy",
+      "module": "ov070",
+      "source": "src_tu/actors/FlyGuy.cpp",
+      "promoted_source": "src/actors/FlyGuy.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "high",
+      "boundary_evidence": [
+        "contiguous linker run: 0x211f000..0x2120570, 27 function(s), from build/tu_map.json (tools/tu_map.py)",
+        "class label(s): FlyGuy",
+        "module sinit corroboration: 4 sinit(s) / 4 .ctor entries, sinit_vs_tu=ok, corroborated=True (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x0211f000",
+          "end": "0x02120570"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN6FlyGuyD1Ev",
+          "address": "0x0211f000",
+          "size": "0x00000048",
+          "legacy_source": "src/_ZN6FlyGuyD1Ev.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "_ZN6FlyGuyD0Ev",
+          "address": "0x0211f048",
+          "size": "0x0000005c",
+          "legacy_source": "src/_ZN6FlyGuyD0Ev.cpp",
+          "ordinal": 1
+        },
+        {
+          "symbol": "func_ov070_0211f0a4",
+          "address": "0x0211f0a4",
+          "size": "0x0000005c",
+          "legacy_source": "src/func_ov070_0211f0a4.cpp",
+          "ordinal": 2
+        },
+        {
+          "symbol": "func_ov070_0211f100",
+          "address": "0x0211f100",
+          "size": "0x00000268",
+          "legacy_source": "src/func_ov070_0211f100.cpp",
+          "ordinal": 3
+        },
+        {
+          "symbol": "func_ov070_0211f368",
+          "address": "0x0211f368",
+          "size": "0x000000e8",
+          "legacy_source": "src/func_ov070_0211f368.cpp",
+          "ordinal": 4
+        },
+        {
+          "symbol": "func_ov070_0211f450",
+          "address": "0x0211f450",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov070_0211f450.c",
+          "ordinal": 5
+        },
+        {
+          "symbol": "func_ov070_0211f48c",
+          "address": "0x0211f48c",
+          "size": "0x00000164",
+          "legacy_source": "src/func_ov070_0211f48c.c",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov070_0211f5f0",
+          "address": "0x0211f5f0",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov070_0211f5f0.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov070_0211f62c",
+          "address": "0x0211f62c",
+          "size": "0x00000068",
+          "legacy_source": "src/func_ov070_0211f62c.c",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov070_0211f694",
+          "address": "0x0211f694",
+          "size": "0x0000004c",
+          "legacy_source": "src/func_ov070_0211f694.cpp",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov070_0211f6e0",
+          "address": "0x0211f6e0",
+          "size": "0x000003a0",
+          "legacy_source": "src/func_ov070_0211f6e0.c",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov070_0211fa80",
+          "address": "0x0211fa80",
+          "size": "0x00000064",
+          "legacy_source": "src/func_ov070_0211fa80.c",
+          "ordinal": 11
+        },
+        {
+          "symbol": "func_ov070_0211fae4",
+          "address": "0x0211fae4",
+          "size": "0x0000027c",
+          "legacy_source": "src/func_ov070_0211fae4.c",
+          "ordinal": 12
+        },
+        {
+          "symbol": "func_ov070_0211fd60",
+          "address": "0x0211fd60",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov070_0211fd60.c",
+          "ordinal": 13
+        },
+        {
+          "symbol": "func_ov070_0211fd98",
+          "address": "0x0211fd98",
+          "size": "0x00000210",
+          "legacy_source": "src/func_ov070_0211fd98.c",
+          "ordinal": 14
+        },
+        {
+          "symbol": "func_ov070_0211ffa8",
+          "address": "0x0211ffa8",
+          "size": "0x00000078",
+          "legacy_source": "src/func_ov070_0211ffa8.cpp",
+          "ordinal": 15
+        },
+        {
+          "symbol": "FlyGuy_ChangeState",
+          "address": "0x02120020",
+          "size": "0x00000050",
+          "legacy_source": "src/FlyGuy_ChangeState.cpp",
+          "ordinal": 16
+        },
+        {
+          "symbol": "func_ov070_02120070",
+          "address": "0x02120070",
+          "size": "0x000000e0",
+          "legacy_source": "src/func_ov070_02120070.cpp",
+          "ordinal": 17
+        },
+        {
+          "symbol": "_ZN6FlyGuy16CleanupResourcesEv",
+          "address": "0x02120150",
+          "size": "0x0000006c",
+          "legacy_source": "src/_ZN6FlyGuy16CleanupResourcesEv.cpp",
+          "ordinal": 18
+        },
+        {
+          "symbol": "_ZN6FlyGuy16OnPendingDestroyEv",
+          "address": "0x021201bc",
+          "size": "0x00000004",
+          "legacy_source": "src/_ZN6FlyGuy16OnPendingDestroyEv.cpp",
+          "ordinal": 19
+        },
+        {
+          "symbol": "_ZN6FlyGuy6RenderEv",
+          "address": "0x021201c0",
+          "size": "0x00000050",
+          "legacy_source": "src/_ZN6FlyGuy6RenderEv.cpp",
+          "ordinal": 20
+        },
+        {
+          "symbol": "_ZN6FlyGuy8BehaviorEv",
+          "address": "0x02120210",
+          "size": "0x000001a4",
+          "legacy_source": "src/_ZN6FlyGuy8BehaviorEv.cpp",
+          "ordinal": 21
+        },
+        {
+          "symbol": "_ZN6FlyGuy13InitResourcesEv",
+          "address": "0x021203b4",
+          "size": "0x00000130",
+          "legacy_source": "src/_ZN6FlyGuy13InitResourcesEv.cpp",
+          "ordinal": 22
+        },
+        {
+          "symbol": "_ZN6FlyGuy16OnAimedAtWithEggEv",
+          "address": "0x021204e4",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN6FlyGuy16OnAimedAtWithEggEv.cpp",
+          "ordinal": 23
+        },
+        {
+          "symbol": "_ZN6FlyGuy13OnTurnIntoEggER6Player",
+          "address": "0x021204ec",
+          "size": "0x0000002c",
+          "legacy_source": "src/_ZN6FlyGuy13OnTurnIntoEggER6Player.cpp",
+          "ordinal": 24
+        },
+        {
+          "symbol": "_ZN6FlyGuy13OnYoshiTryEatEv",
+          "address": "0x02120518",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN6FlyGuy13OnYoshiTryEatEv.cpp",
+          "ordinal": 25
+        },
+        {
+          "symbol": "FlyGuy_Spawn",
+          "address": "0x02120520",
+          "size": "0x00000050",
+          "legacy_source": "src/FlyGuy_Spawn.c",
+          "ordinal": 26
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically.",
+        "tubuild create warning: hand-assembled: raw concatenation in reverse ROM order; tubuild create refused this TU (extern \"C\"-wrapped legacy bodies)",
+        "27/27 MATCH, objisolate clean, reloc-destinations clean. Hand-assembled (create refuses extern-C-wrapped bodies). Carries the NEW struct-copy lever: mwccarm's C++ front end scalarizes a plain struct assignment where the C front end emits an ldm/stm block copy; an array-wrapper view (struct V3w { int w[3]; }) restores the block copy -- fixed func_ov070_0211f48c (-4B) and func_ov070_0211f6e0 (+8B) after fdiff proved the idiom byte-exact. Also: two members keep their own int-target ApproachAngle view via BLOCK-SCOPE extern declarations (C++ name hiding), because the TU-wide extern-C declaration cannot serve both signatures and the parameter width is byte-load-bearing. FlyGuy_Spawn stores &_ZTV6FlyGuy[2] (+8 rule)."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov070-FlyGuy/FlyGuy.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 27,
+        "functions_declared": 27,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 13 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
+          "relocation_destinations_verified": "PASS"
+        }
+      }
     }
   ]
 }

--- a/config_tu/arm9/config.yaml
+++ b/config_tu/arm9/config.yaml
@@ -518,7 +518,7 @@ overlays:
     name: ov070
     object: ../../build/build/arm9_ov070.bin
     hash: faaf020ce867bfbb
-    delinks: ../../config/arm9/overlays/ov070/delinks.txt
+    delinks: overlays/ov070/delinks.txt
     symbols: ../../config/arm9/overlays/ov070/symbols.txt
     relocations: ../../config/arm9/overlays/ov070/relocs.txt
   - id: 71

--- a/config_tu/arm9/overlays/ov070/delinks.txt
+++ b/config_tu/arm9/overlays/ov070/delinks.txt
@@ -1,0 +1,33 @@
+    .text       start:0x0211f000 end:0x02122244 kind:code align:32
+    .rodata     start:0x02122244 end:0x02122afc kind:rodata align:4
+    .init       start:0x02122afc end:0x021230a4 kind:code align:4
+    .ctor       start:0x021230a4 end:0x021230b4 kind:rodata align:4
+    .data       start:0x021230c0 end:0x02123500 kind:data align:32
+    .bss        start:0x02123500 end:0x02123720 kind:bss align:32
+src_tu/actors/FlyGuy.cpp:
+    .text start:0x0211f000 end:0x02120570
+    .init start:0x02122afc end:0x02122d80
+    .ctor start:0x021230a4 end:0x021230a8
+    .data start:0x021230c0 end:0x021231e4
+    .bss start:0x02123500 end:0x021235ec
+
+src_tu/actors/Amp.cpp:
+    .text start:0x02120570 end:0x02121118
+    .init start:0x02122d80 end:0x02122f30
+    .ctor start:0x021230a8 end:0x021230ac
+    .data start:0x0212320c end:0x021232f4
+    .bss start:0x021235ec end:0x02123698
+
+src_tu/actors/FlameChomp.cpp:
+    .text start:0x02121118 end:0x02121b48
+    .init start:0x02122f30 end:0x02123030
+    .ctor start:0x021230ac end:0x021230b0
+    .data start:0x021232f4 end:0x021233ec
+    .bss start:0x02123698 end:0x021236ec
+
+src_tu/actors/FlameChompFire.cpp:
+    .text start:0x02121b48 end:0x02122244
+    .init start:0x02123030 end:0x021230a4
+    .ctor start:0x021230b0 end:0x021230b4
+    .data start:0x021233ec end:0x021234c4
+    .bss start:0x021236ec end:0x02123720

--- a/config_tu/tu_modules.json
+++ b/config_tu/tu_modules.json
@@ -60,6 +60,54 @@
      "detail": "4/4 TUs, 704 of 704 bytes; 59/69 symbol runs whose every self-module referrer is already attributed to one and the same TU"
     }
    ]
+  },
+  "ov070": {
+   "entriesBefore": 96,
+   "entriesAfter": 4,
+   "tuEntries": 4,
+   "carriedEntries": 0,
+   "functions": 92,
+   "textBytes": 12868,
+   "textGrewBy": 0,
+   "sections": {
+    ".text": 12868,
+    ".init": 1448,
+    ".ctor": 16,
+    ".data": 988,
+    ".bss": 544
+   },
+   "attribution": [
+    {
+     "section": ".text",
+     "verdict": "claimed",
+     "detail": "4 contiguous runs from build/tu_map.json, tiling 0x0211f000-0x02122244"
+    },
+    {
+     "section": ".init",
+     "verdict": "claimed",
+     "detail": "4 sinit blocks tiling 0x02122afc-0x021230a4; ordinal k -> TU k (counts agree: sinits == .ctor words == TUs)"
+    },
+    {
+     "section": ".ctor",
+     "verdict": "claimed",
+     "detail": "4 words tiling 0x021230a4-0x021230b4, one per TU, each resolved through its own relocation"
+    },
+    {
+     "section": ".rodata",
+     "verdict": "unattributed",
+     "detail": "0 seed run(s) whose own code pointers land in one TU, 0 more by closure over their referrers, of 19 symbol runs -- no run could be attributed"
+    },
+    {
+     "section": ".data",
+     "verdict": "claimed",
+     "detail": "4/4 TUs, 988 of 1088 bytes; 40 seed run(s) whose own code pointers land in one TU, 8 more by closure over their referrers, of 52 symbol runs"
+    },
+    {
+     "section": ".bss",
+     "verdict": "claimed",
+     "detail": "4/4 TUs, 544 of 544 bytes; 35/37 symbol runs whose every self-module referrer is already attributed to one and the same TU"
+    }
+   ]
   }
  }
 }

--- a/src_tu/actors/Amp.cpp
+++ b/src_tu/actors/Amp.cpp
@@ -1,0 +1,585 @@
+//cpp
+/* HAND-ASSEMBLED translation unit -- ov070/Amp (19 function(s)).
+ * tubuild create refused this TU (legacy bodies wrapped in extern "C" { }),
+ * so this is a raw concatenation of the complete legacy files in REVERSE
+ * ROM order (mwccarm emits one .text section per function in the reverse
+ * of source order). Conflicting declarations were reconciled by hand; see
+ * the manifest notes.
+ *
+ * Assembled from these legacy one-function sources (ROM address order):
+ *   [0] 0x02120570  src/_ZN3AmpD1Ev.cpp
+ *   [1] 0x021205d0  src/_ZN3AmpD0Ev.cpp
+ *   [2] 0x02120644  src/func_ov070_02120644.cpp
+ *   [3] 0x02120724  src/func_ov070_02120724.c
+ *   [4] 0x021208a4  src/func_ov070_021208a4.c
+ *   [5] 0x02120910  src/func_ov070_02120910.cpp
+ *   [6] 0x021209e4  src/func_ov070_021209e4.cpp
+ *   [7] 0x02120bf8  src/func_ov070_02120bf8.cpp
+ *   [8] 0x02120cac  src/func_ov070_02120cac.cpp
+ *   [9] 0x02120ce4  src/func_ov070_02120ce4.c
+ *   [10] 0x02120d34  src/func_ov070_02120d34.cpp
+ *   [11] 0x02120d70  src/func_ov070_02120d70.cpp
+ *   [12] 0x02120da8  src/func_ov070_02120da8.c
+ *   [13] 0x02120dc4  src/_ZN3Amp16CleanupResourcesEv.cpp
+ *   [14] 0x02120e20  src/_ZN3Amp16OnPendingDestroyEv.cpp
+ *   [15] 0x02120e24  src/_ZN3Amp6RenderEv.cpp
+ *   [16] 0x02120e8c  src/_ZN3Amp8BehaviorEv.cpp
+ *   [17] 0x02120eec  src/_ZN3Amp13InitResourcesEv.cpp
+ *   [18] 0x021210ac  src/Amp_Spawn.c
+ */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- Amp_Spawn, 0x021210ac, size 0x6c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol Amp_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV3Amp */
+int *Amp_Spawn(void)
+{
+    int *p = (int *)_ZN7fBase_cnwEj(1076);
+    if (p) {
+        _ZN8dActor_cC2Ev(p);
+        p[0] = (int)&_ZTV3Amp[2]; /* +8: this TU defines the vtable */
+        _ZN9ModelAnimC1Ev((char *)p + 0xd4);
+        _ZN5ModelC1Ev((char *)p + 0x138);
+        _ZN15TextureSequenceC1Ev((char *)p + 0x188);
+        _ZN18TextureTransformerC1Ev((char *)p + 0x19c);
+        _ZN11ShadowModelC1Ev((char *)p + 0x1b0);
+        _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x1d8);
+        _ZN12WithMeshClsnC1Ev((char *)p + 0x218);
+    }
+    return p;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- _ZN3Amp13InitResourcesEv, 0x02120eec, size 0x1c0 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN3Amp13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Amp.h"
+#include "TextureSequence.h"
+struct SharedFilePtr;
+struct BMD_File;
+struct BTA_File;
+struct dActor_c;
+struct Vector3;
+struct Vector3_16;
+
+extern "C" void _ZN8dActor_c9SetRangesE5Fix12IiES1_S1_S1_(dActor_c *self, int a, int b, int c, int d);
+extern "C" void _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(void *self, dActor_c *a, Vector3 const &b, int c, int d, unsigned int e, unsigned int f);
+extern "C" void _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *self, dActor_c *a, int b, int c, Vector3_16 *d, Vector3_16 *e);
+extern "C" void func_ov070_02120da8(char *c, int a);
+extern "C" void func_ov070_02120724(char *c);
+
+extern SharedFilePtr data_ov070_021235fc;
+extern SharedFilePtr data_ov070_02123604;
+extern SharedFilePtr *data_ov070_021222e0[];
+extern SharedFilePtr data_ov070_021235ec;
+extern BTA_File data_ov070_021231f4;
+extern Vector3 data_ov070_0212365c;
+extern char data_02082128;
+
+struct M48 { int w[12]; };
+
+int Amp::InitResources()
+{
+    BMD_File *bmd;
+    bmd = (BMD_File *)Model::LoadFile(data_ov070_021235fc);
+    mModelAnim.SetFile(bmd, 1, 1);
+    bmd = (BMD_File *)Model::LoadFile(data_ov070_02123604);
+    mModel.SetFile(bmd, 1, 1);
+
+    int i;
+    for (i = 0; i < 2; i++) {
+        Animation::LoadFile(*data_ov070_021222e0[i]);
+    }
+
+    BMD_File *bmd2 = *(BMD_File **)((char *)&data_ov070_02123604 + 4);
+    BTP_File *btp = (BTP_File *)TextureSequence::LoadFile(data_ov070_021235ec);
+    TextureSequence::Prepare(*bmd2, *btp);
+
+    bmd2 = *(BMD_File **)((char *)&data_ov070_02123604 + 4);
+    TextureTransformer::Prepare(*bmd2, data_ov070_021231f4);
+
+    if (!mShadowModel.InitCylinder())
+        return 0;
+
+    if ((unsigned char)((param1 >> 1) & 1)) {
+        _ZN8dActor_c9SetRangesE5Fix12IiES1_S1_S1_(this, 0, 0x20d000, 0x1000000, 0xa28000);
+    } else {
+        _ZN8dActor_c9SetRangesE5Fix12IiES1_S1_S1_(this, 0, 0x2c1000, 0x1000000, 0xa28000);
+    }
+
+    _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(&mMovingCylinderClsnWithPos, this, data_ov070_0212365c, 0x2d000, 0x50000, 0x200002, 0x8000);
+    _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(&mWithMeshClsn, this, 0x2d000, 0x2d000, 0, 0);
+
+    mVertAccel = 0;
+    mTerminalVelocity = 0;
+    func_ov070_02120da8((char *)this, 1);
+
+    *(M48 *)unk_3d4 = *(M48 *)&data_02082128;
+
+    func_ov070_02120724((char *)this);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- _ZN3Amp8BehaviorEv, 0x02120e8c, size 0x60 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN3Amp8BehaviorEv
+#include "Amp.h"
+
+extern "C" {
+extern void func_ov070_02120d34(void *c);
+extern void func_ov070_02120724(char *c);
+}
+
+int Amp::Behavior()
+{
+    func_ov070_02120d34(this);
+    mCylinderOffset.y += data_ov070_0212365c.y;  /* was int[] view's [1]; same word */
+    mMovingCylinderClsnWithPos.SetPosRelativeToActor(mCylinderOffset);
+    mMovingCylinderClsnWithPos.Clear();
+    mMovingCylinderClsnWithPos.Update();
+    func_ov070_02120724((char *)this);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- _ZN3Amp6RenderEv, 0x02120e24, size 0x68 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN3Amp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Amp.h"
+
+int Amp::Render()
+{
+    mModelAnim.Render(0);
+
+    if (mState != 0 && mState != 2) {
+        mTextureSequence.Update(mModel.data);
+        mTextureTransformer.Update(mModel.data);
+        mModel.Render((Vector3 *)&mScaleX);
+    }
+
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- _ZN3Amp16OnPendingDestroyEv, 0x02120e20, size 0x4 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN3Amp16OnPendingDestroyEv
+
+#include "Amp.h"
+
+void Amp::OnPendingDestroy()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- _ZN3Amp16CleanupResourcesEv, 0x02120dc4, size 0x5c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN3Amp16CleanupResourcesEv
+
+#include "Amp.h"
+#include "SharedFilePtr.h"
+
+extern SharedFilePtr data_ov070_021235fc;
+extern SharedFilePtr data_ov070_02123604;
+extern SharedFilePtr *data_ov070_021222e0[2];
+extern SharedFilePtr data_ov070_021235ec;
+
+int Amp::CleanupResources()
+{
+    data_ov070_021235fc.Release();
+    data_ov070_02123604.Release();
+
+    int i = 0;
+    do {
+        data_ov070_021222e0[i]->Release();
+        i++;
+    } while (i < 2);
+
+    data_ov070_021235ec.Release();
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- func_ov070_02120da8, 0x02120da8, size 0x1c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern char data_ov070_02123668;
+extern void func_ov070_02120d70(void *c);
+void func_ov070_02120da8(char *c, int a) {
+    *(int *)(c + 0x41c) = (int)&data_ov070_02123668 + (a << 4);
+    func_ov070_02120d70(c);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov070_02120d70, 0x02120d70, size 0x38 */
+/* -------------------------------------------------------------------------- */
+struct C; typedef void (C::*PMF)();
+struct C { char pad[0x41c]; PMF *pp; };
+extern "C" void func_ov070_02120d70(void *vc) { C *c = (C *)vc; PMF *p = c->pp; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov070_02120d34, 0x02120d34, size 0x3c */
+/* -------------------------------------------------------------------------- */
+/* (struct C / PMF: defined once at ordinal 11 above) */
+extern "C" void func_ov070_02120d34(void *vc) { C *c = (C *)vc; PMF *p = c->pp + 1; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov070_02120ce4, 0x02120ce4, size 0x50 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern int data_ov070_0212360c[];
+int func_ov070_02120ce4(char *c) {
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov070_0212360c[1], 0x40000000, 0x1000, 0);
+    *(unsigned char*)(c+0x430) = 0x3c;
+    *(int*)(c+0x420) = 0;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov070_02120cac, 0x02120cac, size 0x38 */
+/* -------------------------------------------------------------------------- */
+/* (Animation: real header type in scope) */
+
+extern "C" unsigned char DecIfAbove0_Byte(unsigned char *p);
+extern "C" void func_ov070_02120da8(char *c, int a);
+
+extern "C" int func_ov070_02120cac(char *c) {
+    ((Animation *)(c + 0x124))->Advance();
+    unsigned char r = DecIfAbove0_Byte((unsigned char *)(c + 0x430));
+    if (r == 0) {
+        func_ov070_02120da8(c, 1);
+    }
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov070_02120bf8, 0x02120bf8, size 0xb4 */
+/* -------------------------------------------------------------------------- */
+typedef int Fix12i;
+struct BCA_File; struct BTP_File; struct BTA_File;
+/* (ModelAnim/TextureSequence/TextureTransformer: real header types in scope) */
+
+extern "C" unsigned int _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
+    TextureSequence*, BTP_File&, int, Fix12i, unsigned int);
+extern "C" unsigned int _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(
+    TextureTransformer*, BTA_File&, int, Fix12i, unsigned int);
+
+struct D1 { int a; BCA_File* f; };
+struct D2 { int a; BTP_File* f; };
+extern D1 data_ov070_021235f4;
+extern BTA_File data_ov070_021231f4;
+
+extern "C" void func_ov070_02120bf8(char* thiz)
+{
+    char* c = thiz;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
+        (ModelAnim*)(c + 0xd4), data_ov070_021235f4.f, 0, 0x1000, 0);
+    *(int*)(c + 0x130) = 0x1000;
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
+        (TextureSequence*)(c + 0x188), *((D2 *)&data_ov070_021235ec)->f, 0, 0x1000, 0);
+    *(int*)(c + 0x194) = 0x1000;
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(
+        (TextureTransformer*)(c + 0x19c), data_ov070_021231f4, 0, 0x1000, 0);
+    *(int*)(c + 0x1a8) = 0x2000;
+    *(unsigned char*)(c + 0x430) = 0xf;
+    *(int*)(c + 0x424) = 0;
+    *(short*)(c + 0x42e) = 0;
+    *(int*)(c + 0x80) = 0x1000;
+    *(int*)(c + 0x84) = 0x1000;
+    *(int*)(c + 0x88) = 0x1000;
+    *(int*)(c + 0x420) = 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- func_ov070_021209e4, 0x021209e4, size 0x214 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_021209e4
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+typedef long long s64;
+
+
+/* (Animation: real header type in scope) */
+
+void _Z14ApproachLinearRiii(int *val, int target, int step);
+void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3s(unsigned int a, unsigned int b, unsigned int c, Vector3 *v, unsigned int d);
+unsigned char DecIfAbove0_Byte(unsigned char *p);
+int func_ov070_02120644(char *c);
+extern short data_02082214[];
+
+int func_ov070_021209e4(char *c) {
+    _Z14ApproachLinearRiii((int*)(c + 0x424), 1000, 20);
+
+    unsigned char bit0 = (unsigned char)(*(int*)(c + 8) & 1);
+    if (bit0) {
+        *(short*)(c + 0x94) = (short)(*(short*)(c + 0x94) + *(int*)(c + 0x424));
+    } else {
+        *(short*)(c + 0x94) = (short)(*(short*)(c + 0x94) - *(int*)(c + 0x424));
+    }
+
+    *(short*)(c + 0x42c) = (short)(*(short*)(c + 0x42c) + 0xa00);
+
+    unsigned char bit1 = (unsigned char)(((unsigned int)*(int*)(c + 8) >> 1) & 1);
+    int ip = bit1 ? 0xb4000 : 0x168000;
+
+    *(int*)(c + 0x404) = *(int*)(c + 0x5c);
+    *(int*)(c + 0x408) = *(int*)(c + 0x60);
+    *(int*)(c + 0x40c) = *(int*)(c + 0x64);
+
+    {
+        int idx = (*(unsigned short*)(c + 0x94)) >> 4;
+        int cosv = data_02082214[idx * 2];
+        *(int*)(c + 0x410) = (int)(((s64)ip * cosv + 0x800) >> 0xc);
+    }
+    {
+        int idx = (*(unsigned short*)(c + 0x42c)) >> 4;
+        int sinv = data_02082214[idx * 2];
+        *(int*)(c + 0x414) = (int)(((s64)0x14000 * sinv + 0x800) >> 0xc);
+    }
+    {
+        int idx = (*(unsigned short*)(c + 0x94)) >> 4;
+        int sinv = data_02082214[idx * 2 + 1];
+        *(int*)(c + 0x418) = (int)(((s64)ip * sinv + 0x800) >> 0xc);
+    }
+
+    AddVec3((Vector3*)(c + 0x404), (Vector3*)(c + 0x410), (Vector3*)(c + 0x404));
+
+    *(short*)(c + 0x42e) = (short)(*(short*)(c + 0x42e) + 0x4000);
+
+    {
+        int idx = (*(unsigned short*)(c + 0x42e)) >> 4;
+        int cosv = data_02082214[idx * 2];
+        int scale = (int)(((s64)0x555 * cosv + 0x800) >> 0xc) + 0x800;
+        *(int*)(c + 0x80) = scale;
+        *(int*)(c + 0x84) = scale;
+        *(int*)(c + 0x88) = scale;
+    }
+
+    ((Animation*)(c + 0x124))->Advance();
+    ((Animation*)(c + 0x188))->Advance();
+    ((Animation*)(c + 0x19c))->Advance();
+
+    *(unsigned int*)(c + 0x428) = _ZN5Sound8PlayLongEjjjRK7Vector3s(*(unsigned int*)(c + 0x428), 3, 0x183, (Vector3*)(c + 0x74), 0);
+
+    if (DecIfAbove0_Byte((unsigned char*)(c + 0x430)) == 0) {
+        func_ov070_02120644(c);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- func_ov070_02120910, 0x02120910, size 0xd4 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_02120910
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
+
+int func_ov070_02120910(char* c)
+{
+    _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
+    *(int*)(((int)c + 0xb0)) &= ~1;
+    *(int*)(c + 0x9c) = -0x2000;
+    *(int*)(c + 0xa0) = -0x3c000;
+    *(int*)(c + 0x5c) = *(int*)(c + 0x404);
+    *(int*)(c + 0x60) = *(int*)(c + 0x408);
+    *(int*)(c + 0x64) = *(int*)(c + 0x40c);
+    *(int*)(c + 0x98) = 0xa000;
+    *(int*)(c + 0xa8) = 0x28000;
+    *(unsigned char*)(c + 0x430) = 0x2d;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, *(void**)((char*)data_ov070_0212360c + 4), 0x40000000, 0x1000, 0);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x43, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x44, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    *(int*)(c + 0x420) = 2;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 4 -- func_ov070_021208a4, 0x021208a4, size 0x6c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern int _ZN9Animation7AdvanceEv(void *);
+extern int _ZN8dActor_c9UpdatePosEP12CylinderClsn(void *, void *);
+extern int WithMeshClsn_UpdateDiscreteNoLava_veneer(void *);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *);
+extern unsigned char DecIfAbove0_Byte(unsigned char *);
+extern int _ZN8dActor_c8PoofDustEv(void *);
+extern int _ZN7fBase_c18MarkForDestructionEv(void *);
+int func_ov070_021208a4(char *c){
+ *(short*)(c+0x8c)=*(short*)(c+0x8c)-0x1000;
+ _ZN9Animation7AdvanceEv((char*)c+0x124);
+ _ZN8dActor_c9UpdatePosEP12CylinderClsn(c,(char*)c+0x1d8);
+ WithMeshClsn_UpdateDiscreteNoLava_veneer((char*)c+0x218);
+ if(_ZNK12WithMeshClsn13JustHitGroundEv((char*)c+0x218)==0){
+   if(DecIfAbove0_Byte((unsigned char*)c+0x430)!=0) goto end;
+ }
+ _ZN8dActor_c8PoofDustEv(c);
+ _ZN7fBase_c18MarkForDestructionEv(c);
+end:
+ return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- func_ov070_02120724, 0x02120724, size 0x180 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov070_02120724
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+typedef short s16;
+
+
+
+
+extern void _ZN13RaycastGroundC1Ev(void *rg);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(void *rg, struct Vector3 *pos, void *actor);
+extern int _ZN13RaycastGround10DetectClsnEv(void *rg);
+extern void _ZN13RaycastGroundD1Ev(void *rg);
+extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+    void *c, void *sm, void *mtx, int h, int g, unsigned int u);
+extern signed char data_0209f2f8[];
+
+struct RG { char pad[0x44]; int ground; char pad2[8]; };
+
+void func_ov070_02120724(char *c)
+{
+    int g;
+
+    if (*(int*)(c + 0x420) == 2) {
+        Matrix4x3_FromRotationXYZExt(c + 0xf0,
+            *(s16*)(c + 0x8c), *(s16*)(c + 0x8e), *(s16*)(c + 0x90));
+        *(int*)(c + 0x114) = *(int*)(c + 0x5c) >> 3;
+        *(int*)(c + 0x118) = *(int*)(c + 0x60) >> 3;
+        *(int*)(c + 0x11c) = *(int*)(c + 0x64) >> 3;
+        *(int*)(c + 0x3f8) = *(int*)(c + 0x5c) >> 3;
+        *(int*)(c + 0x3fc) = *(int*)(c + 0x60) >> 3;
+        *(int*)(c + 0x400) = *(int*)(c + 0x64) >> 3;
+    } else {
+        *(int*)(c + 0x114) = *(int*)(c + 0x404) >> 3;
+        *(int*)(c + 0x118) = *(int*)(c + 0x408) >> 3;
+        *(int*)(c + 0x11c) = *(int*)(c + 0x40c) >> 3;
+        *(struct Matrix4x3*)(c + 0x154) = *(struct Matrix4x3*)(c + 0xf0);
+        *(int*)(c + 0x3f8) = *(int*)(c + 0x404) >> 3;
+        *(int*)(c + 0x3fc) = *(int*)(c + 0x408) >> 3;
+        *(int*)(c + 0x400) = *(int*)(c + 0x40c) >> 3;
+    }
+
+    g = 0x1f4000;
+    if (data_0209f2f8[0] == 0x11) {
+        struct RG rg;
+        struct Vector3 pos;
+        int y;
+        pos.x = *(int*)(c + 0x5c);
+        y = *(int*)(c + 0x60);
+        pos.y = y;
+        pos.z = *(int*)(c + 0x64);
+        pos.y = y - 0xa000;
+        _ZN13RaycastGroundC1Ev(&rg);
+        _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(&rg, &pos, 0);
+        if (_ZN13RaycastGround10DetectClsnEv(&rg) != 0) {
+            g = (*(int*)(c + 0x60) - rg.ground) + 0x28000;
+        }
+        _ZN13RaycastGroundD1Ev(&rg);
+    }
+
+    _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+        c, c + 0x1b0, c + 0x3d4, 0x5a000, g, 0xf);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- func_ov070_02120644, 0x02120644, size 0xe0 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_02120644
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+
+extern void* _ZN8dActor_c10FindWithIDEj(unsigned int id);
+extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
+extern void _ZN6Player16IncMegaKillCountEv(void* thiz);
+extern void func_ov070_02120da8(char* c, int n);
+extern int _ZN6Player5ShockEj(void* thiz, unsigned int n);
+
+int func_ov070_02120644(char* c)
+{
+    unsigned int id = *(unsigned int*)(c + 0x1fc);
+    if (id == 0) return 0;
+    char* o = (char*)_ZN8dActor_c10FindWithIDEj(id);
+    if (o == 0) goto ret0;
+    {
+        int b = (*(unsigned short*)(o + 0xc) == 0xbf);
+        if (b != 0) goto cont;
+    }
+ret0:
+    return 0;
+cont:
+    if (*(unsigned char*)(o + 0x6fb) != 0) return 0;
+    if (*(int*)(c + 0x1f8) & 0x10) {
+        *(short*)(c + 0x94) = Vec3_HorzAngle((Vector3*)(o + 0x5c), (Vector3*)(c + 0x5c));
+        *(short*)(c + 0x8e) = (short)(*(short*)(c + 0x94) + 0x8000);
+        _ZN6Player16IncMegaKillCountEv(o);
+        func_ov070_02120da8(c, 2);
+    } else {
+        if (_ZN6Player5ShockEj(o, 1) != 0)
+            func_ov070_02120da8(c, 0);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- _ZN3AmpD0Ev, 0x021205d0, size 0x74 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN3AmpD0Ev
+
+#include "Amp.h"
+
+/* (no separate definition: the single ~Amp() below emits the D0 and D1
+ * variants together; mwccarm orders the variant group itself.) */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN3AmpD1Ev, 0x02120570, size 0x60 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN3AmpD1Ev
+
+#include "Amp.h"
+
+Amp::~Amp()
+{
+}
+

--- a/src_tu/actors/FlameChomp.cpp
+++ b/src_tu/actors/FlameChomp.cpp
@@ -1,0 +1,609 @@
+//cpp
+/* HAND-ASSEMBLED translation unit -- ov070/FlameChomp (25 function(s)).
+ * tubuild create refused this TU (legacy bodies wrapped in extern "C" { }),
+ * so this is a raw concatenation of the complete legacy files in REVERSE
+ * ROM order (mwccarm emits one .text section per function in the reverse
+ * of source order). Conflicting declarations were reconciled by hand; see
+ * the manifest notes.
+ *
+ * Assembled from these legacy one-function sources (ROM address order):
+ *   [0] 0x02121118  src/_ZN10FlameChompD1Ev.cpp
+ *   [1] 0x02121160  src/_ZN10FlameChompD0Ev.cpp
+ *   [2] 0x021211bc  src/_ZN10FlameChomp13OnYoshiTryEatEv.cpp
+ *   [3] 0x021211c4  src/func_ov070_021211c4.cpp
+ *   [4] 0x02121298  src/func_ov070_02121298.cpp
+ *   [5] 0x02121310  src/func_ov070_02121310.cpp
+ *   [6] 0x021213cc  src/func_ov070_021213cc.c
+ *   [7] 0x02121438  src/func_ov070_02121438.cpp
+ *   [8] 0x021214f8  src/func_ov070_021214f8.cpp
+ *   [9] 0x02121548  src/func_ov070_02121548.c
+ *   [10] 0x0212156c  src/func_ov070_0212156c.c
+ *   [11] 0x021216b8  src/func_ov070_021216b8.c
+ *   [12] 0x02121710  src/func_ov070_02121710.cpp
+ *   [13] 0x021217ac  src/func_ov070_021217ac.c
+ *   [14] 0x0212180c  src/func_ov070_0212180c.cpp
+ *   [15] 0x02121848  src/func_ov070_02121848.cpp
+ *   [16] 0x02121880  src/func_ov070_02121880.c
+ *   [17] 0x0212189c  src/_ZN10FlameChomp16CleanupResourcesEv.cpp
+ *   [18] 0x021218c0  src/_ZN10FlameChomp16OnPendingDestroyEv.cpp
+ *   [19] 0x021218c4  src/_ZN10FlameChomp6RenderEv.cpp
+ *   [20] 0x021218f4  src/_ZN10FlameChomp8BehaviorEv.cpp
+ *   [21] 0x02121914  src/_ZN10FlameChomp13InitResourcesEv.cpp
+ *   [22] 0x02121a64  src/func_ov070_02121a64.c
+ *   [23] 0x02121ae0  src/func_ov070_02121ae0.c
+ *   [24] 0x02121af8  src/FlameChomp_Spawn.c
+ */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 24 -- FlameChomp_Spawn, 0x02121af8, size 0x50 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol FlameChomp_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10FlameChomp */
+int *FlameChomp_Spawn(void)
+{
+    int *p = (int *)_ZN7fBase_cnwEj(944);
+    if (p) {
+        _ZN8dActor_cC2Ev(p);
+        p[0] = (int)&_ZTV10FlameChomp[2]; /* +8: this TU defines the vtable */
+        _ZN9ModelAnimC1Ev((char *)p + 0xd4);
+        _ZN11ShadowModelC1Ev((char *)p + 0x138);
+        _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x160);
+        _ZN12WithMeshClsnC1Ev((char *)p + 0x1a0);
+    }
+    return p;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 23 -- func_ov070_02121ae0, 0x02121ae0, size 0x18 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+void func_ov070_02121ae0(void *c, int a, int b, int d)
+{
+    *(int *)((char *)c + 4) = a;
+    *(int *)((char *)c + 8) = b;
+    *(int *)c = d;
+    *(int *)((char *)c + 0xc) = 0;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 22 -- func_ov070_02121a64, 0x02121a64, size 0x7c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern unsigned int __aeabi_uidiv(unsigned int a, unsigned int b);
+
+int func_ov070_02121a64(void* vc)
+{
+    char* c = (char*)vc;
+    switch (*(int*)c) {
+    case 0:
+        if (*(unsigned int*)(c + 0xc) < *(unsigned int*)(c + 8)) {
+            unsigned int* p = (unsigned int*)(((int)c + 0xc));
+            *p = *p + 1;
+        }
+        break;
+    case 1:
+        {
+            unsigned int* p = (unsigned int*)(((int)c + 0xc));
+            *p = *p + 1;
+            *p = *p % *(unsigned int*)(c + 8);
+        }
+        break;
+    }
+    return (*(unsigned int**)(c + 4))[*(unsigned int*)(c + 0xc)];
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 21 -- _ZN10FlameChomp13InitResourcesEv, 0x02121914, size 0x150 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChomp13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChomp.h"
+/* was `typedef int Fix12;` -- collides with the real Fix12<> template, which
+   FlameChomp.h now reaches via Model.h. The typedef WAS int, so spelling it
+   int below is byte-neutral. */
+struct RG { char pad[0x44]; int f44; char pad2[8]; };
+struct Blk { int w[12]; };
+
+extern "C" {
+extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
+extern int _ZN11ShadowModel12InitCylinderEv(void* self);
+}
+extern "C" {
+extern void _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(
+    void* self, void* actor, const struct Vector3* v, int a, int b, unsigned int c, unsigned int d);
+}
+extern "C" {
+extern void _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
+    void* self, void* actor, int a, int b, void* v, int c);
+}
+extern "C" {
+extern void _ZN13RaycastGroundC1Ev(struct RG* rg);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(struct RG* rg, const struct Vector3* v, void* a);
+extern int _ZN13RaycastGround10DetectClsnEv(struct RG* rg);
+extern void func_ov070_02121310(char* c);
+extern void _ZN13RaycastGroundD1Ev(struct RG* rg);
+}
+
+extern struct Blk data_02082128;
+
+int FlameChomp::InitResources()
+{
+    struct RG rg;
+    struct Vector3 v;
+    void* bmd;
+    int t;
+
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov070_02123698);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, bmd, 1, 1);
+    if (!_ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel))
+        return 0;
+
+    v.x = 0;
+    v.y = -0x32000;
+    v.z = 0;
+    _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(
+        ((char*)this) + 0x160, ((char*)this), &v, 0x32000, 0x64000, 0x200002, 0x8000);
+    _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
+        ((char*)this) + 0x1a0, ((char*)this), 0x32000, 0x32000, 0, 0);
+
+    mVertAccel = 0;
+    mTerminalVelocity = 0;
+    func_ov070_02121880(((char*)this), 0);
+
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    *(struct Blk*)((char*)&unk_35c) = data_02082128;
+
+    _ZN13RaycastGroundC1Ev(&rg);
+    _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(&rg, (struct Vector3*)((char*)&mPosX), ((char*)this));
+    if (_ZN13RaycastGround10DetectClsnEv(&rg))
+        t = (mPosY - rg.f44) + 0x1e000;
+    else
+        t = 0x1f4000;
+    unk_3a8 = t;
+    func_ov070_02121310(((char*)this));
+    _ZN13RaycastGroundD1Ev(&rg);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 20 -- _ZN10FlameChomp8BehaviorEv, 0x021218f4, size 0x20 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChomp8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChomp.h"
+extern "C" {
+extern void func_ov070_02121310(char* c);
+}
+
+int FlameChomp::Behavior()
+{
+    func_ov070_0212180c(((char*)this));
+    func_ov070_02121310(((char*)this));
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 19 -- _ZN10FlameChomp6RenderEv, 0x021218c4, size 0x30 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChomp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChomp.h"
+struct RenderBase { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void M(void*); };
+struct RenderSub : RenderBase { };
+struct RenderView { char p1[0xd4]; RenderSub sub; };  /* was C/Sub/Base; renamed: another member's shadow C has a different layout */
+
+int FlameChomp::Render()
+{
+  ((RenderView*)this)->sub.M((char*)&mScaleX);
+  return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- _ZN10FlameChomp16OnPendingDestroyEv, 0x021218c0, size 0x4 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChomp16OnPendingDestroyEv
+
+#include "FlameChomp.h"
+
+void FlameChomp::OnPendingDestroy()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- _ZN10FlameChomp16CleanupResourcesEv, 0x0212189c, size 0x24 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChomp16CleanupResourcesEv
+
+#include "FlameChomp.h"
+#include "SharedFilePtr.h"
+
+int FlameChomp::CleanupResources()
+{
+    ((SharedFilePtr *)&data_ov070_02123698)->Release();  /* declared void* earlier in this TU; same object */
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- func_ov070_02121880, 0x02121880, size 0x1c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern char data_ov070_021236ac;
+extern void func_ov070_02121848(char *c);
+void func_ov070_02121880(void *vc, int a) {
+    char *c = (char *)vc;
+    *(int *)(c + 0x39c) = (int)&data_ov070_021236ac + (a << 4);
+    func_ov070_02121848(c);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- func_ov070_02121848, 0x02121848, size 0x38 */
+/* -------------------------------------------------------------------------- */
+struct C; typedef void (C::*PMF)();
+struct C { char pad[0x39c]; PMF *pp; };
+extern "C" void func_ov070_02121848(char *vc) { C *c = (C *)vc; PMF *p = c->pp; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- func_ov070_0212180c, 0x0212180c, size 0x3c */
+/* -------------------------------------------------------------------------- */
+/* (struct C / PMF: defined once at ordinal 15 above) */
+extern "C" void func_ov070_0212180c(char *vc) { C *c = (C *)vc; PMF *p = c->pp + 1; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- func_ov070_021217ac, 0x021217ac, size 0x60 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern void func_ov070_02121ae0(void*, int, int, int);
+extern void* data_ov070_02122404;
+int func_ov070_021217ac(char* c){
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, &data_ov070_021234c4, 0, 0x1000, 0);
+    func_ov070_02121ae0(c + 0x38c, (int)&data_ov070_02122404, 0x64, 1);
+    *(unsigned char*)(c + 0x3ac) = 0x73;
+    *(int*)(c + 0x3a0) = 0;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- func_ov070_02121710, 0x02121710, size 0x9c */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern unsigned char DecIfAbove0_Byte(unsigned char* p);
+extern void func_ov070_02121880(void* c, int a);
+extern void _ZN9Animation7AdvanceEv(void* a);
+extern int func_ov070_02121a64(void* p);
+extern void func_ov070_02121298(char* c);
+extern void func_ov070_021211c4(char* c);
+extern void _ZN12CylinderClsn5ClearEv(void* cc);
+extern void _ZN12CylinderClsn6UpdateEv(void* cc);
+extern int data_0209f32c;
+int func_ov070_02121710(char* c) {
+  int r;
+  if (*(int*)(c + 0x3a4) != 0) {
+    if (*(int*)(c + 0x60) > data_0209f32c) {
+      if (DecIfAbove0_Byte((unsigned char*)(c + 0x3ac)) == 0)
+        func_ov070_02121880(c, 1);
+    }
+  } else {
+    *(unsigned char*)(c + 0x3ac) = 0x73;
+  }
+  _ZN9Animation7AdvanceEv(c + 0x124);
+  r = func_ov070_02121a64(c + 0x38c);
+  *(int*)(c + 0x80) = r;
+  *(int*)(c + 0x84) = r;
+  *(int*)(c + 0x88) = r;
+  func_ov070_02121298(c);
+  func_ov070_021211c4(c);
+  _ZN12CylinderClsn5ClearEv(c + 0x160);
+  _ZN12CylinderClsn6UpdateEv(c + 0x160);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov070_021216b8, 0x021216b8, size 0x58 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern void func_ov070_02121ae0(void*, int, int, int);
+extern void* data_ov070_021234dc;
+extern void* data_ov070_021222e8;
+int func_ov070_021216b8(void* c) {
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((char*)c + 0xd4, &data_ov070_021234dc, 0x40000000, 0x1000, 0);
+    func_ov070_02121ae0((char*)c + 0x38c, (int)&data_ov070_021222e8, 0x47, 0);
+    *(int*)((char*)c + 0x3a0) = 1;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov070_0212156c, 0x0212156c, size 0x14c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov070_0212156c
+/* recovered: shared common types */
+#include "common.h"
+extern short data_02082214[];
+void _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(unsigned int a, unsigned int b, struct Vector3 *pos, void *v16, int d, int e);
+void func_0201267c(int a, void *p);
+void func_ov070_02121880(void *c, int i);
+void _ZN9Animation7AdvanceEv(void *thiz);
+int func_ov070_02121a64(void *p);
+void func_ov070_02121298(char *c);
+void func_ov070_021211c4(char *c);
+void _ZN12CylinderClsn5ClearEv(void *thiz);
+void _ZN12CylinderClsn6UpdateEv(void *thiz);
+
+int func_ov070_0212156c(char *c){
+  if(*(int*)(c+0x398) == 0x1e){
+    struct Vector3 pos;
+    int idx = (int)*(unsigned short*)(c+0x8e) >> 4;
+    int s = data_02082214[idx*2+1];
+    int cn = data_02082214[idx*2];
+    int offZ = (int)(((long long)s * 0x50000 + 0x800) >> 12);
+    int offX = (int)(((long long)cn * 0x50000 + 0x800) >> 12);
+    int x = *(int*)(c+0x5c) + offX;
+    int z = *(int*)(c+0x64) + offZ;
+    int y = *(int*)(c+0x60) - 0x29000;
+    ((int*)&pos)[0] = x;
+    ((int*)&pos)[2] = z;
+    ((int*)&pos)[1] = y;
+    _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(0x10f, 0, &pos, c+0x8c, *(signed char*)(c+0xcc), -1);
+    func_0201267c(0x105, c+0x74);
+  }
+  if(*(int*)(c+0x398) == *(int*)(c+0x394)){
+    func_ov070_02121880(c, 0);
+  }
+  _ZN9Animation7AdvanceEv(c+0x124);
+  {
+    int r = func_ov070_02121a64(c+0x38c);
+    *(int*)(c+0x80) = r;
+    *(int*)(c+0x84) = r;
+    *(int*)(c+0x88) = r;
+  }
+  func_ov070_02121298(c);
+  func_ov070_021211c4(c);
+  _ZN12CylinderClsn5ClearEv(c+0x160);
+  _ZN12CylinderClsn6UpdateEv(c+0x160);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov070_02121548, 0x02121548, size 0x24 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN12CylinderClsn5ClearEv(void *);
+int func_ov070_02121548(char *c)
+{
+    _ZN12CylinderClsn5ClearEv((char *)c + 0x160);
+    *(int *)(c + 0x3a0) = 2;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov070_021214f8, 0x021214f8, size 0x50 */
+/* -------------------------------------------------------------------------- */
+extern "C" void _ZN8dActor_c8PoofDustEv(void *c);
+extern "C" void _ZN7fBase_c18MarkForDestructionEv(void *c);
+extern "C" int func_ov070_021214f8(char *c)
+{
+    int flags;
+    int b;
+    flags = *(int*)(c + 0xb0);
+    b = (flags & 0x20000) != 0;
+    if (!b) {
+        b = (flags & 0x40000) != 0;
+        if (!b) {
+            _ZN8dActor_c8PoofDustEv(c);
+            _ZN7fBase_c18MarkForDestructionEv(c);
+        }
+    }
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov070_02121438, 0x02121438, size 0xc0 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_02121438
+// recovered name: Amp_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daBrq_c::Kill - recovered from vtable slot identity */
+extern "C" {
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
+}
+
+extern "C" int func_ov070_02121438(char* c)
+{
+    _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
+    int* p_b0 = (int*)(((int)c + 0xb0));
+    *p_b0 = *p_b0 & ~1;
+    *(int*)(c + 0x9c) = -0x2000;
+    *(int*)(c + 0xa0) = -0x3c000;
+    *(int*)(c + 0x98) = 0xa000;
+    *(int*)(c + 0xa8) = 0x28000;
+    *(int*)(c + 0x80) = 0x1000;
+    *(int*)(c + 0x84) = 0x1000;
+    *(int*)(c + 0x88) = 0x1000;
+    *(unsigned char*)(c + 0x3ac) = 0x2d;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, &data_ov070_021234c4, 0, 0x1000, 0);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x43, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x44, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    *(int*)(c + 0x3a0) = 3;
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- func_ov070_021213cc, 0x021213cc, size 0x6c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9Animation7AdvanceEv(void *);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void *, void *);
+extern int WithMeshClsn_UpdateDiscreteNoLava_veneer(void *);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *);
+extern unsigned char DecIfAbove0_Byte(unsigned char *);
+extern void _ZN8dActor_c8PoofDustEv(void *);
+extern void _ZN7fBase_c18MarkForDestructionEv(void *);
+int func_ov070_021213cc(char *c){
+ *(short*)(c+0x8c)=*(short*)(c+0x8c)-0x1000;
+ _ZN9Animation7AdvanceEv((char*)c+0x124);
+ _ZN8dActor_c9UpdatePosEP12CylinderClsn(c,(char*)c+0x160);
+ WithMeshClsn_UpdateDiscreteNoLava_veneer((char*)c+0x1a0);
+ if(_ZNK12WithMeshClsn13JustHitGroundEv((char*)c+0x1a0)==0){
+   if(DecIfAbove0_Byte((unsigned char*)c+0x3ac)!=0) goto end;
+ }
+ _ZN8dActor_c8PoofDustEv(c);
+ _ZN7fBase_c18MarkForDestructionEv(c);
+end:
+ return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- func_ov070_02121310, 0x02121310, size 0xbc */
+/* -------------------------------------------------------------------------- */
+extern "C" void Matrix4x3_FromRotationXYZExt(void *m, int x, int y, int z);
+extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
+extern "C" void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+    void *thiz, void *sm, void *mtx, int f, int t, unsigned int u);
+
+extern "C" void func_ov070_02121310(char *thiz)
+{
+    if (*(int*)(thiz + 0x3a0) == 3) {
+        Matrix4x3_FromRotationXYZExt(thiz + 0xf0,
+            *(short*)(thiz + 0x8c),
+            *(short*)(thiz + 0x8e),
+            *(short*)(thiz + 0x90));
+    } else {
+        Matrix4x3_FromRotationY(thiz + 0xf0, *(short*)(thiz + 0x8e));
+    }
+    *(int*)(thiz + 0x114) = *(int*)(thiz + 0x5c) >> 3;
+    *(int*)(thiz + 0x118) = *(int*)(thiz + 0x60) >> 3;
+    *(int*)(thiz + 0x11c) = *(int*)(thiz + 0x64) >> 3;
+    *(int*)(thiz + 0x380) = *(int*)(thiz + 0x5c) >> 3;
+    *(int*)(thiz + 0x384) = *(int*)(thiz + 0x60) >> 3;
+    *(int*)(thiz + 0x388) = *(int*)(thiz + 0x64) >> 3;
+    _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+        thiz, thiz + 0x138, thiz + 0x35c,
+        *(int*)(thiz + 0x80) * 0x46,
+        *(int*)(thiz + 0x3a8), 0xf);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 4 -- func_ov070_02121298, 0x02121298, size 0x78 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern char* _ZN8dActor_c22ClosestNonVanishPlayerEv();
+extern int Vec3_Dist(void* a, void* b);
+extern short Vec3_HorzAngle(void* a, void* b);
+extern void _Z14ApproachLinearRsss(short* p, short target, short step);
+}
+
+extern "C" void func_ov070_02121298(char* c){
+    char* p = _ZN8dActor_c22ClosestNonVanishPlayerEv();
+    if (p == 0) {
+        *(int*)(c + 0x3a4) = 0;
+        return;
+    }
+    if (Vec3_Dist(c + 0x5c, p + 0x5c) >= 0x2bc000) {
+        *(int*)(c + 0x3a4) = 0;
+        return;
+    }
+    *(char**)(c + 0x3a4) = p;
+    _Z14ApproachLinearRsss((short*)(c + 0x8e), Vec3_HorzAngle(c + 0x5c, p + 0x5c), 0x800);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- func_ov070_021211c4, 0x021211c4, size 0xd4 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_021211c4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+
+extern void* _ZN8dActor_c10FindWithIDEj(unsigned int id);
+extern short Vec3_HorzAngle(void* a, void* b);
+extern void _ZN6Player16IncMegaKillCountEv(void* thiz);
+
+void func_ov070_021211c4(char* c)
+{
+    unsigned int id = *(unsigned int*)(c + 0x184);
+    if (id == 0) return;
+    char* o = (char*)_ZN8dActor_c10FindWithIDEj(id);
+    if (o == 0) return;
+    int b = (*(unsigned short*)(o + 0xc) == 0xbf);
+    if (b == 0) return;
+    int b2 = ((*(int*)(c + 0xb0) & 0x20000) != 0);
+    if (b2 != 0) {
+        func_ov070_02121880(c, 2);
+        return;
+    }
+    if ((*(int*)(c + 0x180) & 0x10) == 0) return;
+    *(short*)(c + 0x94) = Vec3_HorzAngle((void*)(o + 0x5c), (void*)(c + 0x5c));
+    *(short*)(c + 0x8e) = (short)(*(short*)(c + 0x94) + 0x8000);
+    _ZN6Player16IncMegaKillCountEv(o);
+    func_ov070_02121880(c, 3);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- _ZN10FlameChomp13OnYoshiTryEatEv, 0x021211bc, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChomp13OnYoshiTryEatEv
+
+#include "FlameChomp.h"
+
+int FlameChomp::OnYoshiTryEat()
+{
+    return 5;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- _ZN10FlameChompD0Ev, 0x02121160, size 0x5c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChompD0Ev
+
+#include "FlameChomp.h"
+
+/* (no separate definition: the single ~FlameChomp() below emits the D0 and
+ * D1 variants together; mwccarm orders the variant group itself.) */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN10FlameChompD1Ev, 0x02121118, size 0x48 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN10FlameChompD1Ev
+
+#include "FlameChomp.h"
+
+FlameChomp::~FlameChomp()
+{
+}
+

--- a/src_tu/actors/FlameChompFire.cpp
+++ b/src_tu/actors/FlameChompFire.cpp
@@ -1,0 +1,441 @@
+//cpp
+/* HAND-ASSEMBLED translation unit -- ov070/FlameChompFire (21 function(s)).
+ * tubuild create refused this TU (legacy bodies wrapped in extern "C" { }),
+ * so this is a raw concatenation of the complete legacy files in REVERSE
+ * ROM order (mwccarm emits one .text section per function in the reverse
+ * of source order). Conflicting declarations were reconciled by hand; see
+ * the manifest notes.
+ *
+ * Assembled from these legacy one-function sources (ROM address order):
+ *   [0] 0x02121b48  src/_ZN14FlameChompFireD1Ev.cpp
+ *   [1] 0x02121b88  src/_ZN14FlameChompFireD0Ev.cpp
+ *   [2] 0x02121bdc  src/_ZN14FlameChompFire13OnYoshiTryEatEv.cpp
+ *   [3] 0x02121be4  src/func_ov070_02121be4.cpp
+ *   [4] 0x02121c8c  src/func_ov070_02121c8c.c
+ *   [5] 0x02121cbc  src/func_ov070_02121cbc.c
+ *   [6] 0x02121d50  src/func_ov070_02121d50.cpp
+ *   [7] 0x02121e14  src/func_ov070_02121e14.cpp
+ *   [8] 0x02121eb0  src/func_ov070_02121eb0.c
+ *   [9] 0x02121ef8  src/func_ov070_02121ef8.c
+ *   [10] 0x02121f18  src/func_ov070_02121f18.cpp
+ *   [11] 0x02121fb0  src/func_ov070_02121fb0.c
+ *   [12] 0x02121fd0  src/func_ov070_02121fd0.cpp
+ *   [13] 0x0212200c  src/func_ov070_0212200c.cpp
+ *   [14] 0x02122044  src/func_ov070_02122044.c
+ *   [15] 0x02122060  src/_ZN14FlameChompFire16CleanupResourcesEv.cpp
+ *   [16] 0x02122068  src/_ZN14FlameChompFire16OnPendingDestroyEv.cpp
+ *   [17] 0x0212206c  src/_ZN14FlameChompFire6RenderEv.cpp
+ *   [18] 0x02122104  src/_ZN14FlameChompFire8BehaviorEv.cpp
+ *   [19] 0x02122124  src/_ZN14FlameChompFire13InitResourcesEv.cpp
+ *   [20] 0x021221fc  src/FlameChompFire_Spawn.c
+ */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 20 -- FlameChompFire_Spawn, 0x021221fc, size 0x48 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol FlameChompFire_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14FlameChompFire */
+int *FlameChompFire_Spawn(void)
+{
+    int *p = (int *)_ZN7fBase_cnwEj(816);
+    if (p) {
+        _ZN8dActor_cC2Ev(p);
+        p[0] = (int)&_ZTV14FlameChompFire[2]; /* +8: this TU defines the vtable */
+        _ZN11ShadowModelC1Ev((char *)p + 0xd4);
+        _ZN18MovingCylinderClsnC1Ev((char *)p + 0xfc);
+        _ZN12WithMeshClsnC1Ev((char *)p + 0x130);
+    }
+    return p;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 19 -- _ZN14FlameChompFire13InitResourcesEv, 0x02122124, size 0xd8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFire13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChompFire.h"
+struct M48 { int w[12]; };
+extern "C" {
+extern int _ZN11ShadowModel12InitCylinderEv(void* thiz);
+extern void _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(void* thiz, void* actor, int fix12, int t, unsigned int a, unsigned int b);
+extern void _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void* thiz, void* actor, int fix12, int t, void* vec, int last);
+extern int data_02082128[];
+}
+
+int FlameChompFire::InitResources()
+{
+    if (_ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel) == 0)
+        return 0;
+    _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(((char*)this) + 0xfc, ((char*)this), 0x37000, 0x78000, 0x200002, 0x8000);
+    _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x130, ((char*)this), 0x32000, 0x32000, 0, 0);
+    mVertAccel = -0x400;
+    mTerminalVelocity = -0x5000;
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    func_ov070_02122044(((char*)this), 0);
+    *(struct M48*)((char*)&unk_2ec) = *(struct M48*)data_02082128;
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- _ZN14FlameChompFire8BehaviorEv, 0x02122104, size 0x20 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFire8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChompFire.h"
+
+int FlameChompFire::Behavior()
+{
+    func_ov070_02121fd0(((char*)this));
+    func_ov070_02121e14(((char*)this));
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- _ZN14FlameChompFire6RenderEv, 0x0212206c, size 0x98 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFire6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChompFire.h"
+extern "C" {
+extern int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned int a, unsigned int b, int c, int d, int e, void* f);
+}
+
+int FlameChompFire::Render()
+{
+  int b = (mFlags & 0x40000) != 0;
+  if (b) return 1;
+  unk_324 = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+      unk_324, 0x7f, mPosX, mPosY + 0x4b000, mPosZ, 0);
+  unk_328 = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+      unk_328, 0x80, mPosX, mPosY + 0x4b000, mPosZ, 0);
+  return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- _ZN14FlameChompFire16OnPendingDestroyEv, 0x02122068, size 0x4 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFire16OnPendingDestroyEv
+
+#include "FlameChompFire.h"
+
+void FlameChompFire::OnPendingDestroy()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- _ZN14FlameChompFire16CleanupResourcesEv, 0x02122060, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFire16CleanupResourcesEv
+
+#include "FlameChompFire.h"
+
+int FlameChompFire::CleanupResources()
+{
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- func_ov070_02122044, 0x02122044, size 0x1c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+typedef struct { int a, b, c, d; } Item16;
+
+extern Item16 data_ov070_021236ec[];
+extern void func_ov070_0212200c(void *self);
+
+void func_ov070_02122044(void *vself, int idx)
+{
+    char *self = (char *)vself;
+    *(Item16 **)(self + 0x31c) = &data_ov070_021236ec[idx];
+    func_ov070_0212200c(self);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- func_ov070_0212200c, 0x0212200c, size 0x38 */
+/* -------------------------------------------------------------------------- */
+struct C; typedef void (C::*PMF)();
+struct C { char pad[0x31c]; PMF *pp; };
+extern "C" void func_ov070_0212200c(void *vc) { C *c = (C *)vc; PMF *p = c->pp; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- func_ov070_02121fd0, 0x02121fd0, size 0x3c */
+/* -------------------------------------------------------------------------- */
+/* (struct C / PMF: defined once at ordinal 13 above) */
+extern "C" void func_ov070_02121fd0(char *vc) { C *c = (C *)vc; PMF *p = c->pp + 1; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov070_02121fb0, 0x02121fb0, size 0x20 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov070_02121fb0
+// recovered name: FlameChomp_Kill
+/* recovered: renamed to Class_Method */
+/* daKrpa_c::Kill - recovered from vtable slot identity */
+int func_ov070_02121fb0(char *p)
+{
+    *(int *)(p + 0x98) = 40960;
+    *(char *)(p + 0x32c) = 105;
+    *(int *)(p + 0x320) = 0;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov070_02121f18, 0x02121f18, size 0x98 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern unsigned char DecIfAbove0_Byte(unsigned char* p);
+extern void func_ov070_02121c8c(void* c);
+extern void* _ZN8dActor_c22ClosestNonVanishPlayerEv(void* c);
+extern short Vec3_HorzAngle(void* v0, void* v1);
+extern void _Z14ApproachLinearRsss(short* p, short t, short step);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void* c, void* cc);
+extern void func_ov070_02121be4(void* c);
+extern void func_ov070_02121d50(void* c, void* p);
+extern void func_ov070_02121cbc(char* c);
+extern void _ZN12CylinderClsn5ClearEv(void* cc);
+extern void _ZN12CylinderClsn6UpdateEv(void* cc);
+int func_ov070_02121f18(char* c) {
+  char* p;
+  if (DecIfAbove0_Byte((unsigned char*)(c + 0x32c)) == 0)
+    func_ov070_02121c8c(c);
+  p = (char*)_ZN8dActor_c22ClosestNonVanishPlayerEv(c);
+  if (p) {
+    short ang = Vec3_HorzAngle(c + 0x5c, p + 0x5c);
+    _Z14ApproachLinearRsss((short*)(c + 0x8e), ang, 0x180);
+    *(short*)(c + 0x94) = *(short*)(c + 0x8e);
+  }
+  _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, c + 0xfc);
+  func_ov070_02121be4(c);
+  func_ov070_02121d50(c, c + 0x130);
+  func_ov070_02121cbc(c);
+  _ZN12CylinderClsn5ClearEv(c + 0xfc);
+  _ZN12CylinderClsn6UpdateEv(c + 0xfc);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov070_02121ef8, 0x02121ef8, size 0x20 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN12CylinderClsn5ClearEv(void *);
+int func_ov070_02121ef8(char *c)
+{
+    _ZN12CylinderClsn5ClearEv((char *)c + 0xfc);
+    *(int *)(c + 0x320) = 1;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov070_02121eb0, 0x02121eb0, size 0x48 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void func_ov070_02121c8c(void *t);
+int func_ov070_02121eb0(void *c) {
+    int r2 = *(int *)((char *)c + 0xb0);
+    int r1 = (r2 & 0x20000) ? 1 : 0;
+    if (r1 == 0) {
+        r1 = (r2 & 0x40000) ? 1 : 0;
+        if (r1 == 0)
+            func_ov070_02121c8c(c);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov070_02121e14, 0x02121e14, size 0x9c */
+/* -------------------------------------------------------------------------- */
+struct RaycastGround { char pad[0x44]; int hit; char pad2[0x8]; };
+extern "C" {
+extern void _ZN13RaycastGroundC1Ev(RaycastGround* r);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(RaycastGround* r, void* v, void* a);
+extern int _ZN13RaycastGround10DetectClsnEv(RaycastGround* r);
+extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* a, void* sm, void* m, int f1, int f2, unsigned int j);
+extern void _ZN13RaycastGroundD1Ev(RaycastGround* r);
+void func_ov070_02121e14(char* c) {
+  RaycastGround rg;
+  int f;
+  *(int*)(c + 0x310) = *(int*)(c + 0x5c) >> 3;
+  *(int*)(c + 0x314) = *(int*)(c + 0x60) >> 3;
+  *(int*)(c + 0x318) = *(int*)(c + 0x64) >> 3;
+  _ZN13RaycastGroundC1Ev(&rg);
+  _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(&rg, c + 0x5c, c);
+  if (_ZN13RaycastGround10DetectClsnEv(&rg) != 0)
+    f = (*(int*)(c + 0x60) - rg.hit) + 0x1e000;
+  else
+    f = 0x12c000;
+  _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0xd4, c + 0x2ec, 0x64000, f, 0xf);
+  _ZN13RaycastGroundD1Ev(&rg);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- func_ov070_02121d50, 0x02121d50, size 0xc4 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_02121d50
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
+/* (WithMeshClsn: real header type in scope; the legacy shadow's extra methods
+ * are spelled by their mangled names below, same symbols, same calls) */
+struct SurfaceInfo;
+namespace cstd { int fdiv(int a, int b); }
+
+extern "C" void WithMeshClsn_UpdateContinuous_Veneer(void* c);
+extern "C" SurfaceInfo* _ZNK12WithMeshClsn14GetFloorResultEv(const void*);
+extern "C" void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(const SurfaceInfo*, Vector3&);
+
+extern "C" void func_ov070_02121d50(void* vself, void* vclsn) {
+    int* self = (int*)vself;
+    WithMeshClsn* clsn = (WithMeshClsn*)vclsn;
+    Vector3 n;
+    WithMeshClsn_UpdateContinuous_Veneer(clsn);
+    if (clsn->IsOnGround()) {
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((SurfaceInfo*)((char*)_ZNK12WithMeshClsn14GetFloorResultEv(clsn) + 4), n);
+        if (n.y != 0) {
+            int a = (int)(((long long)n.x * self[0x29] + 0x800) >> 12);
+            int b = (int)(((long long)n.z * self[0x2b] + 0x800) >> 12);
+            self[0x2a] = -(cstd::fdiv(a + b, n.y) + 0x8000);
+        }
+    }
+    if (clsn->IsOnWall())
+        func_ov070_02121c8c(self);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- func_ov070_02121cbc, 0x02121cbc, size 0x94 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern char* _ZN8dActor_c10FindWithIDEj(unsigned int id);
+extern void func_ov070_02122044(void* c, int a);
+extern void _ZN6Player4BurnEv(char* p);
+extern void func_ov070_02121c8c(void* c);
+
+void func_ov070_02121cbc(char* r4){
+  char* found;
+  int b;
+  unsigned int id = *(unsigned int*)(r4 + 0x120);
+  if (id == 0) return;
+  found = _ZN8dActor_c10FindWithIDEj(id);
+  if (found == 0) return;
+  b = (int)(*(unsigned short*)(found + 0xc) == 0xbf);
+  if (b == 0) return;
+  b = (int)((*(int*)(r4 + 0xb0) & 0x20000) != 0);
+  if (b != 0) {
+    func_ov070_02122044(r4, 1);
+    return;
+  }
+  if (*(unsigned char*)(found + 0x6fb) != 0) return;
+  _ZN6Player4BurnEv(found);
+  func_ov070_02121c8c(r4);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 4 -- func_ov070_02121c8c, 0x02121c8c, size 0x30 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void func_02012694(int id, void *pos);
+extern void _ZN8dActor_c13SmallPoofDustEv(void *c);
+extern void _ZN7fBase_c18MarkForDestructionEv(void *c);
+void func_ov070_02121c8c(void *c)
+{
+    func_02012694(0x166, (char*)c + 0x74);
+    _ZN8dActor_c13SmallPoofDustEv(c);
+    _ZN7fBase_c18MarkForDestructionEv(c);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- func_ov070_02121be4, 0x02121be4, size 0xa8 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_02121be4
+/* recovered: shared common types */
+#include "common.h"
+
+/* (RaycastGround: defined once at ordinal 7 above; declarations below match
+ * that block's extern "C" signatures exactly -- C linkage cannot overload) */
+extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void *thiz);
+
+extern "C" void func_ov070_02121be4(void *thiz)
+{
+    unsigned char *c = (unsigned char *)thiz;
+    struct RaycastGround rg;
+    struct Vector3 v;
+
+    if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x130)) return;
+
+    _ZN13RaycastGroundC1Ev(&rg);
+    {
+        int z = *(int *)(c + 0x64);
+        int y = *(int *)(c + 0x60) + 0x1e000;
+        int x = *(int *)(c + 0x5c);
+        v.x = x;
+        v.y = y;
+        v.z = z;
+    }
+    _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, (void *)c);
+    if (_ZN13RaycastGround10DetectClsnEv(&rg) == 0 ||
+        *(int *)((char *)&rg + 0x44) < *(int *)(c + 0x60) - 0x32000) {
+        *(int *)(c + 0x5c) = *(int *)(c + 0x68);
+        *(int *)(c + 0x60) = *(int *)(c + 0x6c);
+        *(int *)(c + 0x64) = *(int *)(c + 0x70);
+    }
+    _ZN13RaycastGroundD1Ev(&rg);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- _ZN14FlameChompFire13OnYoshiTryEatEv, 0x02121bdc, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFire13OnYoshiTryEatEv
+
+#include "FlameChompFire.h"
+
+int FlameChompFire::OnYoshiTryEat()
+{
+    return 5;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- _ZN14FlameChompFireD0Ev, 0x02121b88, size 0x54 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFireD0Ev
+
+#include "FlameChompFire.h"
+
+/* (no separate definition: the single ~FlameChompFire() below emits the D0 and
+ * D1 variants together; mwccarm orders the variant group itself.) */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN14FlameChompFireD1Ev, 0x02121b48, size 0x40 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN14FlameChompFireD1Ev
+
+#include "FlameChompFire.h"
+
+FlameChompFire::~FlameChompFire()
+{
+}
+

--- a/src_tu/actors/FlyGuy.cpp
+++ b/src_tu/actors/FlyGuy.cpp
@@ -1,0 +1,1072 @@
+//cpp
+/* HAND-ASSEMBLED translation unit -- ov070/FlyGuy (27 function(s)).
+ * tubuild create refused this TU (legacy bodies wrapped in extern "C" { }),
+ * so this is a raw concatenation of the complete legacy files in REVERSE
+ * ROM order (mwccarm emits one .text section per function in the reverse
+ * of source order). Conflicting declarations were reconciled by hand; see
+ * the manifest notes.
+ *
+ * Assembled from these legacy one-function sources (ROM address order):
+ *   [0] 0x0211f000  src/_ZN6FlyGuyD1Ev.cpp
+ *   [1] 0x0211f048  src/_ZN6FlyGuyD0Ev.cpp
+ *   [2] 0x0211f0a4  src/func_ov070_0211f0a4.cpp
+ *   [3] 0x0211f100  src/func_ov070_0211f100.cpp
+ *   [4] 0x0211f368  src/func_ov070_0211f368.cpp
+ *   [5] 0x0211f450  src/func_ov070_0211f450.c
+ *   [6] 0x0211f48c  src/func_ov070_0211f48c.c
+ *   [7] 0x0211f5f0  src/func_ov070_0211f5f0.cpp
+ *   [8] 0x0211f62c  src/func_ov070_0211f62c.c
+ *   [9] 0x0211f694  src/func_ov070_0211f694.cpp
+ *   [10] 0x0211f6e0  src/func_ov070_0211f6e0.c
+ *   [11] 0x0211fa80  src/func_ov070_0211fa80.c
+ *   [12] 0x0211fae4  src/func_ov070_0211fae4.c
+ *   [13] 0x0211fd60  src/func_ov070_0211fd60.c
+ *   [14] 0x0211fd98  src/func_ov070_0211fd98.c
+ *   [15] 0x0211ffa8  src/func_ov070_0211ffa8.cpp
+ *   [16] 0x02120020  src/FlyGuy_ChangeState.cpp
+ *   [17] 0x02120070  src/func_ov070_02120070.cpp
+ *   [18] 0x02120150  src/_ZN6FlyGuy16CleanupResourcesEv.cpp
+ *   [19] 0x021201bc  src/_ZN6FlyGuy16OnPendingDestroyEv.cpp
+ *   [20] 0x021201c0  src/_ZN6FlyGuy6RenderEv.cpp
+ *   [21] 0x02120210  src/_ZN6FlyGuy8BehaviorEv.cpp
+ *   [22] 0x021203b4  src/_ZN6FlyGuy13InitResourcesEv.cpp
+ *   [23] 0x021204e4  src/_ZN6FlyGuy16OnAimedAtWithEggEv.cpp
+ *   [24] 0x021204ec  src/_ZN6FlyGuy13OnTurnIntoEggER6Player.cpp
+ *   [25] 0x02120518  src/_ZN6FlyGuy13OnYoshiTryEatEv.cpp
+ *   [26] 0x02120520  src/FlyGuy_Spawn.c
+ */
+
+struct V3w { int w[3]; };  /* array-wrapper: C++ scalarizes a plain struct copy; this form keeps the C front end's ldm/stm block copy */
+struct V3h { short h[3]; };
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 26 -- FlyGuy_Spawn, 0x02120520, size 0x50 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol FlyGuy_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6FlyGuy */
+int *FlyGuy_Spawn(void)
+{
+    int *p = (int *)_ZN7fBase_cnwEj(1000);
+    if (p) {
+        _ZN12dEnemyBase_cC2Ev(p);
+        p[0] = (int)&_ZTV6FlyGuy[2]; /* +8: this TU defines the vtable */
+        _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
+        _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
+        _ZN9ModelAnimC1Ev((char *)p + 0x300);
+        _ZN11ShadowModelC1Ev((char *)p + 0x364);
+    }
+    return p;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 25 -- _ZN6FlyGuy13OnYoshiTryEatEv, 0x02120518, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy13OnYoshiTryEatEv
+#include "FlyGuy.h"
+/* recovered: renamed to Class_Method */
+s32 FlyGuy::OnYoshiTryEat() {
+    return 5;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 24 -- _ZN6FlyGuy13OnTurnIntoEggER6Player, 0x021204ec, size 0x2c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy13OnTurnIntoEggER6Player
+// recovered name: FlyGuy_OnTurnIntoEgg
+/* daPropeller_Heyho_c::OnTurnIntoEgg -- vtable slot 19, verified against ov070
+ * relocs.txt: _ZTV6FlyGuy (0x02123168) + 0x4c -> 0x021204ec, exactly this
+ * placeholder's former address (former name func_ov070_021204ec).
+ * Matched byte-for-byte with mwccarm 2004/b56 (ov070).
+ */
+#include "FlyGuy.h"
+#include "Player.h"
+
+int FlyGuy::OnTurnIntoEgg(Player &player)
+{
+    GivePlayerCoins(player, (unsigned char)(unk_10a + 1), 0);
+    KillAndTrackInDeathTable();
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 23 -- _ZN6FlyGuy16OnAimedAtWithEggEv, 0x021204e4, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy16OnAimedAtWithEggEv
+#include "FlyGuy.h"
+// recovered name: FlyGuy_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daPropeller_Heyho_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+s32 FlyGuy::OnAimedAtWithEgg() {
+    return 176128;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 22 -- _ZN6FlyGuy13InitResourcesEv, 0x021203b4, size 0x130 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "FlyGuy.h"
+#include "SharedFilePtr.h"
+extern SharedFilePtr data_ov070_02123530;
+extern SharedFilePtr data_ov070_02123520;
+extern SharedFilePtr data_ov070_02123518;
+extern SharedFilePtr data_ov070_02123510;
+extern SharedFilePtr data_ov070_02123528;
+extern SharedFilePtr data_ov070_02123508;
+extern SharedFilePtr data_ov070_02123500;
+extern char data_ov070_0212359c[];
+extern "C" {
+extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
+extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
+extern void _ZN11ShadowModel12InitCylinderEv(void* self);
+extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
+extern void _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(void* self, dActor_c* a, int r, int h, unsigned int e, unsigned int g);
+extern void _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void* self, dActor_c* a, int r, int h, Vector3_16* p, Vector3_16* q);
+extern int FlyGuy_ChangeState(void* c, void* p);
+}
+
+int FlyGuy::InitResources()
+{
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0x300, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov070_02123530), 1, -1);
+    _ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov070_02123520);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov070_02123518);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov070_02123510);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov070_02123528);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov070_02123508);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov070_02123500);
+    unk_3e0 = param1 & 0xff;
+    if (unk_3e0 == 0xff) unk_3e0 = 0;
+    mTerminalVelocity = -0x1e000;
+    _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(((char*)this)+0x110, (dActor_c*)((char*)this), 0x3c000, 0x32000, 0x200000, 0x7eff0);
+    _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char*)this)+0x144, (dActor_c*)((char*)this), 0x50000, 0x3c000, 0, 0);
+    unk_108 = 1;
+    unk_10a = 1;
+    unk_3c0 = mPosX;
+    unk_3c4 = mPosY;
+    unk_3c8 = mPosZ;
+    FlyGuy_ChangeState(((char*)this), &data_ov070_0212359c);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 21 -- _ZN6FlyGuy8BehaviorEv, 0x02120210, size 0x1a4 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FlyGuy.h"
+
+/* This file used to open with `struct dEnemyBase_c { char pad[0x800]; };` and work a
+ * `char *c` through raw offsets. FlyGuy.h now supplies the real chain, so the
+ * stand-in is gone and every offset is a named field.
+ *
+ * dEnemyBase_c::UpdateYoshiEat is still reached by its mangled name -- unlike
+ * UpdateDeath and UpdateWMClsn, it is not declared in dEnemyBase_c.h yet.
+ */
+extern "C" {
+extern int _ZN12dEnemyBase_c14UpdateYoshiEatER12WithMeshClsn(dEnemyBase_c *thiz, WithMeshClsn *c);
+extern unsigned short DecIfAbove0_Short(unsigned short *p);
+}
+
+int FlyGuy::Behavior()
+{
+    if (_ZN12dEnemyBase_c14UpdateYoshiEatER12WithMeshClsn(this, &mWithMeshClsn) != 0) {
+        mMovingCylinderClsn.Clear();
+        if (unk_107 != 0) {
+            if (unk_104 == 0) {
+                mMovingCylinderClsn.Update();
+            }
+        }
+        func_ov070_02120070((char *)this);
+        return 1;
+    }
+
+    if (mDeathState != 0) {
+        UpdateDeath(mWithMeshClsn);
+        func_ov070_02120070((char *)this);
+        return 1;
+    }
+
+    if (mCurrentState != (State *)data_ov070_021235cc) {
+        DecIfAbove0_Short((unsigned short *)&unk_100);
+    }
+    DecIfAbove0_Short(&unk_3cc);
+
+    {
+        State *q = mCurrentState;
+        /* Reads the handler's pointer word directly rather than as `&q->mMain`:
+           taking the ADDRESS of a pointer-to-member makes mwcc materialise the
+           whole 8-byte pmf. Reading one to CALL it is free. */
+        if (*(int *)((char *)q + 8) != 0) {
+            (this->*(q->mMain))();
+        }
+    }
+
+    {
+        /* Gravity, clamped at terminal velocity. unk_0ac is read and written
+           back unchanged -- the ROM really does reload and restore it here. */
+        int v = mVertSpeed + mVertAccel;
+        int hi = mTerminalVelocity;
+        if (v >= hi) {
+            hi = v;
+        }
+        int tmp = unk_0ac;
+        mVertSpeed = hi;
+        unk_0ac = tmp;
+    }
+
+    UpdatePosWithOnlySpeed(&mMovingCylinderClsn);
+    UpdateWMClsn(mWithMeshClsn, 0);
+
+    if (mCurrentState != (State *)data_ov070_021235bc) {
+        mAngleY = mPrevAngleY;
+        mAngleZ = mPrevAngleZ;
+    }
+
+    func_ov070_02120070((char *)this);
+
+    if (mCurrentState != (State *)data_ov070_021235bc) {
+        func_ov070_0211f100((char *)this);
+    }
+
+    mMovingCylinderClsn.Clear();
+    {
+        char *p = (char *)ClosestPlayer();
+        if (p != 0 && *(unsigned char *)(p + 0x6fb) == 0) {
+            mMovingCylinderClsn.Update();
+        }
+    }
+
+    mModelAnim.speed = 0x1000;
+    mModelAnim.Advance();
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 20 -- _ZN6FlyGuy6RenderEv, 0x021201c0, size 0x50 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FlyGuy.h"
+struct Obj {
+    virtual void m0();
+    virtual void m1();
+    virtual void m2();
+    virtual void m3();
+    virtual void m4();
+    virtual void Target(int);
+};
+
+int FlyGuy::Render()
+{
+    int b = ((mFlags & 0x40000) != 0);
+    if (b) return 1;
+    Obj *o = (Obj*)((char *)&mModelAnim);
+    o->Target(0);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 19 -- _ZN6FlyGuy16OnPendingDestroyEv, 0x021201bc, size 0x4 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy16OnPendingDestroyEv
+/* recovered: shared header, real C++ method
+ *
+ * fBase_c slot 12. Empty in the ROM: four bytes, `bx lr`.
+ */
+#include "FlyGuy.h"
+
+void FlyGuy::OnPendingDestroy()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- _ZN6FlyGuy16CleanupResourcesEv, 0x02120150, size 0x6c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuy16CleanupResourcesEv
+/* recovered: shared header, real C++ method
+ *
+ * Releases the 7 shared file(s) InitResources claimed.
+ *
+ * TOUCHES NO FIELD. The ROM body takes no `this`; as a method it now receives
+ * one and ignores it, which measured byte-free.
+ */
+#include "FlyGuy.h"
+#include "SharedFilePtr.h"
+
+extern "C" {
+}
+
+int FlyGuy::CleanupResources()
+{
+    ((SharedFilePtr *)&data_ov070_02123530)->Release();
+    ((SharedFilePtr *)&data_ov070_02123520)->Release();
+    ((SharedFilePtr *)&data_ov070_02123518)->Release();
+    ((SharedFilePtr *)&data_ov070_02123510)->Release();
+    ((SharedFilePtr *)&data_ov070_02123528)->Release();
+    ((SharedFilePtr *)&data_ov070_02123508)->Release();
+    ((SharedFilePtr *)&data_ov070_02123500)->Release();
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- func_ov070_02120070, 0x02120070, size 0xe0 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_02120070
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+
+extern void Vec3_Asr(void* d, void* s, int sh);
+extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
+extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
+extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* thiz, void* sm, void* mtx, int f, int g, unsigned int h);
+extern int data_020a0e68[];
+
+typedef struct { int w[12]; } M48;
+
+void func_ov070_02120070(char* c)
+{
+    Vector3 v;
+    Vec3_Asr(&v, c + 0x5c, 3);
+    Matrix4x3_FromTranslation(data_020a0e68, v.x, v.y, v.z);
+    Matrix4x3_ApplyInPlaceToRotationXYZExt(data_020a0e68, *(short*)(c + 0x8c), *(short*)(c + 0x8e), *(short*)(c + 0x90));
+    *(M48*)(c + 0x31c) = *(M48*)data_020a0e68;
+    Matrix4x3_FromTranslation(data_020a0e68, *(int*)(c + 0x5c) >> 3, (*(int*)(c + 0x60) - 0xa000) >> 3, *(int*)(c + 0x64) >> 3);
+    *(M48*)(c + 0x38c) = *(M48*)data_020a0e68;
+    _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+        c, c + 0x364, c + 0x38c, 0x76000, 0x320000, 0xf);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- FlyGuy_ChangeState, 0x02120020, size 0x50 */
+/* -------------------------------------------------------------------------- */
+struct C; typedef int (C::*PMF)();
+struct C { char pad[0x3bc]; PMF *pp; };
+extern "C" int FlyGuy_ChangeState(void *vc, void *vp) { C *c = (C *)vc; PMF *p = (PMF *)vp; c->pp = p; PMF *q = c->pp; if (*q == 0) return 1; return (c->**q)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- func_ov070_0211ffa8, 0x0211ffa8, size 0x78 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+extern unsigned int RandomIntInternal(void* s);
+extern int data_0209e650[];
+int func_ov070_0211ffa8(char* c){
+  *(short*)(c+0x300+0xe6) = (short)(((RandomIntInternal(data_0209e650) >> 8) & 0xf) << 0xc);
+  *(short*)(c+0x100) = (short)(((RandomIntInternal(data_0209e650) >> 8) & 0x1f) + 0x32);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x300, (void*)((int *)&data_ov070_02123520)[1], 0, 0x1000, 0);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- func_ov070_0211fd98, 0x0211fd98, size 0x210 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+typedef short s16;
+
+extern int Vec3_Dist(void *a, void *b);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void *p);
+extern short Vec3_HorzAngle(void *a, void *b);
+extern void ApproachAngle(s16 *dst, s16 target, int a, int b, int c);
+extern short Vec3_VertAngle(void *a, void *b);
+extern void _Z14ApproachLinearRsss(void *dst, short a, short b);
+extern void Matrix4x3_FromRotationY(void *m, int angle);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, short ang);
+extern void MulVec3Mat4x3(void *in, void *m, void *out);
+extern void _Z14ApproachLinearRiii(void *dst, int a, int b);
+extern int FlyGuy_ChangeState(void *c, void *p);
+extern void *_ZN8dActor_c22ClosestNonVanishPlayerEv(void *c);
+
+extern int data_020a0e68[];
+extern char data_ov070_0212359c[];
+extern char data_ov070_021235ac[];
+
+int func_ov070_0211fd98(char *c)
+{
+    int in[3];
+    int out[3];
+    Vector3 t;
+    void *p;
+
+    in[0] = 0; in[1] = 0; in[2] = 0;
+    out[0] = 0; out[1] = 0; out[2] = 0;
+
+    if (Vec3_Dist(c + 0x5c, c + 0x3c0) > 0x1f4000 ||
+        _ZNK12WithMeshClsn8IsOnWallEv(c + 0x144)) {
+        *(s16 *)(c + 0x300 + 0xe6) = Vec3_HorzAngle(c + 0x5c, c + 0x3c0);
+        if (*(unsigned short *)(c + 0x100) < 0x14)
+            *(unsigned short *)(c + 0x100) = 0x14;
+    }
+    ApproachAngle((s16 *)(c + 0x94), *(s16 *)(c + 0x300 + 0xe6), 0xa, 0x200, 0x100);
+
+    _Z14ApproachLinearRsss(c + 0x92, Vec3_VertAngle(c + 0x5c, c + 0x3c0), 0x100);
+
+    ApproachAngle((s16 *)(c + 0x96),
+                  (*(s16 *)(c + 0x94) - *(s16 *)(c + 0x300 + 0xe6)) / 2,
+                  0xa, 0x100, 0x50);
+
+    in[2] = 0xa000;
+    Matrix4x3_FromRotationY(data_020a0e68, *(s16 *)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(s16 *)(c + 0x92));
+    MulVec3Mat4x3(in, data_020a0e68, out);
+
+    _Z14ApproachLinearRiii(c + 0xa4, out[0], 0x1000);
+    _Z14ApproachLinearRiii(c + 0xa8, out[1], 0x800);
+    _Z14ApproachLinearRiii(c + 0xac, out[2], 0x1000);
+
+    if (*(unsigned short *)(c + 0x100) == 0) {
+        FlyGuy_ChangeState(c, data_ov070_0212359c);
+        return 1;
+    }
+    if (*(unsigned short *)(c + 0x300 + 0xcc) != 0)
+        return 1;
+    if (Vec3_Dist(c + 0x5c, c + 0x3c0) < 0x5dc000) {
+        p = _ZN8dActor_c22ClosestNonVanishPlayerEv(c);
+        if (p) {
+            int *pos = (int *)(((int)p + 0x5c));
+            t.x = pos[0];
+            t.y = pos[1];
+            t.z = pos[2];
+            if (Vec3_Dist(c + 0x5c, &t) < 0x3e8000)
+                FlyGuy_ChangeState(c, data_ov070_021235ac);
+        }
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- func_ov070_0211fd60, 0x0211fd60, size 0x38 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+/* (data_ov070_02123520: SharedFilePtr view declared earlier in this TU) */
+int func_ov070_0211fd60(char *p) {
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(p+0x300, ((void**)&data_ov070_02123520)[1], 0, 0x1000, 0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- func_ov070_0211fae4, 0x0211fae4, size 0x27c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+
+extern void *_ZN8dActor_c22ClosestNonVanishPlayerEv(void *self);
+extern short Vec3_HorzAngle(void *v0, void *v1);
+extern short Vec3_VertAngle(void *v1, void *v0);
+extern void ApproachAngle(s16 *cur, s16 target, int a, int b, int c);
+extern void Matrix4x3_FromRotationY(void *m, int ang);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, short ang);
+extern void MulVec3Mat4x3(void *a, void *m, void *out);
+extern int Vec3_Dist(void *a, void *b);
+extern unsigned int RandomIntInternal(void *seed);
+extern int FlyGuy_ChangeState(void *c, void *p);
+
+extern signed char data_0209f2f8;
+extern char data_ov070_021235dc[];
+extern int data_020a0e68[];
+extern char data_ov070_0212359c[];
+extern int data_0209e650[];
+extern char data_ov070_021235cc[];
+extern char data_ov070_0212358c[];
+
+int func_ov070_0211fae4(void *arg)
+{
+    char *c = (char *)arg;
+    char *player;
+    Vector3 vin;
+    Vector3 vb;
+    Vector3 vc;
+    Vector3 vd;
+
+    player = (char *)_ZN8dActor_c22ClosestNonVanishPlayerEv(c);
+    if (player == 0) {
+        if (data_0209f2f8 != 0x16) {
+            *(int *)(c + 0x3c0) = *(int *)(c + 0x5c);
+            *(int *)(c + 0x3c4) = *(int *)(c + 0x60);
+            *(int *)(c + 0x3c8) = *(int *)(c + 0x64);
+            *(int *)(((int)c + 0x3c4)) += 0xc8000;
+        }
+        *(int *)(c + 0x5c) = *(int *)(c + 0x68);
+        *(int *)(c + 0x60) = *(int *)(c + 0x6c);
+        *(int *)(c + 0x64) = *(int *)(c + 0x70);
+        *(short *)(c + 0x92) = 0;
+        *(short *)(c + 0x100) = 0;
+        *(int *)(c + 0xa8) = 0;
+        FlyGuy_ChangeState(c, data_ov070_021235dc);
+        return 1;
+    }
+
+    vin.x = 0;
+    vin.y = 0;
+    vin.z = 0;
+
+    {
+    int *q = (int *)(((int)player + 0x5c));
+    vb.x = q[0];
+    vb.y = q[1];
+    vb.z = q[2];
+    }
+    vb.y += 0xc8000;
+    vc.x = vb.x;
+    vc.y = vb.y;
+    vc.z = vb.z;
+
+    *(short *)(c + 0x3e6) = Vec3_HorzAngle((Vector3 *)(c + 0x5c), &vc);
+    ApproachAngle((short *)(c + 0x94), *(short *)(c + 0x3e6), 1, 0x500, 0x500);
+
+    vd.x = vb.x;
+    vd.y = vb.y;
+    vd.z = vb.z;
+    ApproachAngle((short *)(c + 0x92), Vec3_VertAngle((Vector3 *)(c + 0x5c), &vd), 1, 0x500, 0x500);
+
+    ApproachAngle((short *)(c + 0x96),
+                  (*(short *)(c + 0x94) - *(short *)(c + 0x3e6)) / 2,
+                  0xa, 0x100, 0x50);
+
+    vin.z = 0xf000;
+    Matrix4x3_FromRotationY(data_020a0e68, *(short *)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(short *)(c + 0x92));
+    MulVec3Mat4x3(&vin, data_020a0e68, c + 0xa4);
+
+    if (Vec3_Dist((Vector3 *)(c + 0x5c), (Vector3 *)(c + 0x3c0)) > 0x5dc000) {
+        FlyGuy_ChangeState(c, data_ov070_0212359c);
+        return 1;
+    }
+
+    {
+    int dist = Vec3_Dist((Vector3 *)(c + 0x5c), &vb);
+    int thresh = 0x258000;
+    if (data_0209f2f8 == 0x16) thresh = 0x384000;
+    if (dist < thresh) {
+        *(int *)(c + 0xa4) = 0;
+        *(int *)(c + 0xa8) = 0;
+        *(int *)(c + 0xac) = 0;
+        if (*(int *)(c + 0x3e0) == 0 ||
+            (((unsigned int)RandomIntInternal(&data_0209e650) >> 8) & 1) == 0) {
+            FlyGuy_ChangeState(c, data_ov070_021235cc);
+        } else {
+            FlyGuy_ChangeState(c, data_ov070_0212358c);
+        }
+    }
+    }
+
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov070_0211fa80, 0x0211fa80, size 0x64 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern int _ZN8dActor_c23HorzAngleToCPlayerOrAngEv(void *);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+int func_ov070_0211fa80(char *c) {
+    *(int *)(c + 0x3dc) = 0;
+    *(short *)(c + 0x100) = 0x3f;
+    *(int *)(c + 0x3d8) = 0;
+    *(short *)(c + 0x3e6) = _ZN8dActor_c23HorzAngleToCPlayerOrAngEv(c);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x300, (void*)((int *)&data_ov070_02123518)[1], 0x40000000, 0x1000, 0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov070_0211f6e0, 0x0211f6e0, size 0x3a0 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+typedef int s32;
+typedef short s16;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef signed char s8;
+
+
+/* (data_ov070_02123510: SharedFilePtr view declared earlier in this TU) */
+extern s8 data_0209f2f8;
+extern char data_ov070_0212359c[];
+extern char data_ov070_021235dc[];
+extern s32 data_0209f32c;
+extern int data_020a0e68[];
+
+/* (ApproachAngle: this file's own int-target view, declared inside the function body) */
+extern int _ZN9Animation8FinishedEv(void* thiz);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+extern int FlyGuy_ChangeState(void* c, void* p);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void* thiz);
+extern void* _ZN8dActor_c22ClosestNonVanishPlayerEv(void* thiz);
+extern short Vec3_VertAngle(void* v1, void* v0);
+extern int Vec3_Dist(void* a, void* b);
+extern u16 DecIfAbove0_Short(u16* p);
+extern void Matrix4x3_FromRotationY(void* m, int angle);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void* mF, s16 angX);
+extern void MulVec3Mat4x3(void* v, void* m, void* res);
+
+int func_ov070_0211f6e0(char* c)
+{
+    extern int ApproachAngle(s16* angle, int target, int step, int maxDelta, int minDelta); /* byte-load-bearing: int target */
+    char* player;
+    Vector3 tmp;
+    Vector3 v;
+    Vector3 aim;
+    s16 vAngle;
+    s16 half;
+    s32 z;
+
+    ApproachAngle((s16*)(c + 0x94), *(s16*)(c + 0x3e6), 0x100, 0x1000, 0x1000);
+    ApproachAngle((s16*)(c + 0x96), 0, 0x100, 0x1000, 0x1000);
+
+    if (_ZN9Animation8FinishedEv(c + 0x350)) {
+        if (*(s32*)(c + 0x3d8) == 0) {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x300, (void*)((int *)&data_ov070_02123510)[1], 0, 0x1000, 0);
+            *(s32*)(c + 0x3d8) = 1;
+        }
+        if (*(s32*)(c + 0x3dc) == 1) {
+            if (data_0209f2f8 != 0x16)
+                *(s32 *)(c + 0x3c4) += 0x12c000;
+            *(s32*)(c + 0x3d8) = 0;
+            *(u16*)(c + 0x3cc) = 0x5a;
+            FlyGuy_ChangeState(c, &data_ov070_0212359c);
+            return 1;
+        }
+    }
+
+    if (*(u16*)(c + 0x100) == 0 || _ZNK12WithMeshClsn8IsOnWallEv(c + 0x144)) {
+        if (data_0209f2f8 != 0x16) {
+            *(s32*)(c + 0x3c0) = *(s32*)(c + 0x5c);
+            *(s32*)(c + 0x3c4) = *(s32*)(c + 0x60);
+            *(s32*)(c + 0x3c8) = *(s32*)(c + 0x64);
+        }
+        *(u16*)(c + 0x92) = 0;
+        FlyGuy_ChangeState(c, &data_ov070_021235dc);
+        return 1;
+    }
+
+    player = (char*)_ZN8dActor_c22ClosestNonVanishPlayerEv(c);
+    if (player == 0) {
+        if (data_0209f2f8 != 0x16) {
+            *(s32*)(c + 0x3c0) = *(s32*)(c + 0x5c);
+            *(s32*)(c + 0x3c4) = *(s32*)(c + 0x60);
+            *(s32*)(c + 0x3c8) = *(s32*)(c + 0x64);
+        }
+        *(u16*)(c + 0x92) = 0;
+        FlyGuy_ChangeState(c, &data_ov070_021235dc);
+        return 1;
+    }
+
+    if (*(u8*)(player + 0x706) != 0 && data_0209f32c > *(s32*)(c + 0x60)) {
+        if (data_0209f2f8 != 0x16) {
+            *(s32*)(c + 0x3c0) = *(s32*)(c + 0x5c);
+            *(s32*)(c + 0x3c4) = *(s32*)(c + 0x60);
+            *(s32*)(c + 0x3c8) = *(s32*)(c + 0x64);
+            *(s32 *)(c + 0x3c4) += 0xc8000;
+        }
+        *(s32*)(c + 0x5c) = *(s32*)(c + 0x68);
+        *(s32*)(c + 0x60) = *(s32*)(c + 0x6c);
+        *(s32*)(c + 0x64) = *(s32*)(c + 0x70);
+        *(u16*)(c + 0x92) = 0;
+        *(u16*)(c + 0x100) = 0;
+        *(u32*)(c + 0xa8) = 0;
+        FlyGuy_ChangeState(c, &data_ov070_021235dc);
+        return 1;
+    }
+
+    *(V3w*)&tmp = *(V3w*)(player + 0x5c);  /* array-wrapper keeps the ldm/stm block copy under -lang c++ */
+    z = 0;
+    v.x = z;
+    v.y = z;
+    v.z = z;
+    tmp.y = *(int *)(player + 0x644);
+    if (data_0209f2f8 == 0x16)
+        tmp.y += 0x32000;
+    else
+        tmp.y += 0x47000;
+    {
+        int tx = tmp.x;
+        int ty = tmp.y;
+        int tz = tmp.z;
+        aim.x = tx;
+        aim.y = ty;
+        aim.z = tz;
+    }
+    vAngle = Vec3_VertAngle((Vector3*)(c + 0x5c), &aim);
+    ApproachAngle((s16*)(c + 0x92), vAngle, 0xa, 0x200, 0x100);
+
+    v.z = 0x11000;
+    if (*(s32*)(c + 0x60) <= *(s32*)((char*)&tmp + 4) + 0x5000 ||
+        *(s32*)(c + 0x60) <= *(s32*)(player + 0x60) + 0x5000 ||
+        Vec3_Dist((Vector3*)(c + 0x5c), (Vector3*)(c + 0x3c0)) > 0x5dc000) {
+        DecIfAbove0_Short((u16*)(c + 0x100));
+        v.z = 0x9000;
+    }
+
+    half = (*(s16*)(c + 0x94) - *(s16*)(c + 0x3e6)) / 2;
+    ApproachAngle((s16*)(c + 0x96), half, 0xa, 0x100, 0x50);
+
+    Matrix4x3_FromRotationY(data_020a0e68, *(s16*)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(s16*)(c + 0x92));
+    MulVec3Mat4x3(&v, data_020a0e68, (Vector3*)(c + 0xa4));
+
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov070_0211f694, 0x0211f694, size 0x4c */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+int func_ov070_0211f694(char *c) {
+    *(int*)(c+0x3d8) = 0;
+    if (*(int*)(c+0x3dc) == 0) {
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x300, (void*)((int *)&data_ov070_02123508)[1], 0x40000000, 0x1000, 0);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov070_0211f62c, 0x0211f62c, size 0x68 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern int _ZN9Animation8FinishedEv(void *p);
+extern signed char data_0209f2f8;
+extern int FlyGuy_ChangeState(void *c, void *p);
+extern char data_ov070_0212359c[];
+
+int func_ov070_0211f62c(char *c)
+{
+    if (_ZN9Animation8FinishedEv(c + 0x350) != 0) {
+        if (data_0209f2f8 != 0x16)
+            *(int *)(c + 0x3c4) += 0x12c000;
+        *(int *)(c + 0x3d8) = 0;
+        *(short *)(c + 0x3cc) = 0x5a;
+        FlyGuy_ChangeState(c, &data_ov070_0212359c);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov070_0211f5f0, 0x0211f5f0, size 0x3c */
+/* -------------------------------------------------------------------------- */
+struct BCA_File;
+/* (ModelAnim: real header type in scope) */
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+
+
+/* (data_ov070_02123500: SharedFilePtr view declared earlier in this TU) */
+
+extern "C" int func_ov070_0211f5f0(char *c) {
+    unsigned int flags = 0;
+    BCA_File *file = (BCA_File *)(((int *)&data_ov070_02123500)[1]);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0x300), file, 0x40000000, 0x1000, flags);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- func_ov070_0211f48c, 0x0211f48c, size 0x164 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov070_0211f48c
+/* recovered: shared common types */
+#include "common.h"
+char* _ZN8dActor_c13ClosestPlayerEv(void* self);
+short Vec3_HorzAngle(void* a, void* b);
+/* (ApproachAngle: this file's own int-target view, declared inside the function body) */
+int _ZNK9Animation12WillHitFrameEi(void* a, int f);
+short Vec3_VertAngle(void* a, void* b);
+void* _ZN8dActor_c13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j(void* self, void* pos, void* vel, int a, int b, unsigned int d);
+void func_02012694(int a, void* p);
+int _ZN9Animation8FinishedEv(void* a);
+int FlyGuy_ChangeState(void* c, void* p);
+extern char data_ov070_0212359c[];
+
+#define M(p) (p)
+
+int func_ov070_0211f48c(char* c) {
+    extern void ApproachAngle(short* p, int target, int a, int b, int limit); /* byte-load-bearing: int target */
+    char* pl;
+    struct Vector3_16 vel;
+    struct Vector3 posbuf;
+    struct Vector3 fp;
+    struct Vector3 tmp;
+
+    pl = _ZN8dActor_c13ClosestPlayerEv(c);
+    if ((unsigned)(*(int*)(c+0x358) << 4) >> 0x10 >= 0xd)
+        goto hitframe;
+
+    if (pl != 0) {
+        *(V3w*)&posbuf = *(V3w*)(pl+0x5c);
+        tmp.x = posbuf.x;
+        tmp.y = posbuf.y;
+        tmp.z = posbuf.z;
+        *(short*)(c + 0x3e6) = Vec3_HorzAngle(c+0x5c, &tmp);
+    }
+    ApproachAngle((short*)(c+0x94), *(short*)(c + 0x3e6), 0xa, 0x400, 0x200);
+
+hitframe:
+    if (_ZNK9Animation12WillHitFrameEi(c+0x350, 0xd) != 0) {
+        *(V3h*)&vel = *(V3h*)(c+0x8c);
+        if (pl != 0) {
+            int *base = (int *)(int)M(pl + 0x5c);
+            fp.x = base[0];
+            fp.y = base[1];
+            fp.z = base[2];
+            vel.x = Vec3_VertAngle(c+0x5c, &fp);
+        }
+        _ZN8dActor_c13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j(c, c+0x5c, &vel, 0x1e000, 0xa000, 1);
+        func_02012694(0x105, c+0x74);
+    }
+    if (_ZN9Animation8FinishedEv(c+0x350) != 0) {
+        *(int*)(c+0x358) = 0;
+        *(short*)(c + 0x3cc) = 0x5a;
+        FlyGuy_ChangeState(c, data_ov070_0212359c);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- func_ov070_0211f450, 0x0211f450, size 0x3c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+short func_ov070_0211f450(char *c) {
+    *(int *)(c + 0xa4) = 0;
+    *(int *)(c + 0xa8) = 0;
+    *(int *)(c + 0xac) = 0;
+    *(int *)(c + 0xa8) = 0x32000;
+    *(int *)(c + 0x9c) = -0x5000;
+    *(short *)(c + 0x100) = 3;
+    *(int *)(c + 0xb0) = 0;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 4 -- func_ov070_0211f368, 0x0211f368, size 0xe8 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_0211f368
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+typedef int Fix12i;
+
+extern "C" unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, Fix12i c, Fix12i d, Fix12i e, void* f, void* g);
+extern "C" unsigned _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned a, unsigned b, Fix12i c, Fix12i d, Fix12i e, void* f);
+extern "C" void ApproachAngle(short* v, short a, int b, int c, int d);
+extern "C" void _Z14ApproachLinearRsss(void* v, short a, short b);
+
+extern "C" int func_ov070_0211f368(char* c)
+{
+    if (*(int*)(c + 0x3d8) != 0) {
+        Vector3 v;
+        int x, y, z;
+        x = *(int*)(c + 0x5c);
+        z = *(int*)(c + 0x64);
+        y = *(int*)(c + 0x60) + 0x50000;
+        ((int*)&v)[0] = x;
+        ((int*)&v)[1] = y;
+        ((int*)&v)[2] = z;
+        *(unsigned*)(c + 0x3d0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned*)(c + 0x3d0), 0x13a, v.x, v.y, v.z, 0, 0);
+        *(unsigned*)(c + 0x3d4) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+            *(unsigned*)(c + 0x3d4), 0x13b, v.x, v.y, v.z, 0);
+    }
+    ApproachAngle((short*)(c + 0x8c), -0x4000, 0xa, 0x200, 0x100);
+    _Z14ApproachLinearRsss((short*)(c + 0x8c), -0x4000, 0x200);
+    if (*(unsigned short*)(c + 0x100) == 0)
+        func_ov070_0211f0a4(c);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- func_ov070_0211f100, 0x0211f100, size 0x268 */
+/* -------------------------------------------------------------------------- */
+typedef int s32;
+typedef short s16;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+struct BCA_File;
+
+extern char data_ov070_021235bc[];
+extern char data_ov070_021235cc[];
+/* (data_ov070_02123528: SharedFilePtr view declared earlier in this TU) */
+
+extern "C" {
+extern void* _ZN8dActor_c10FindWithIDEj(u32 id);
+extern int FlyGuy_ChangeState(void* c, void* p);
+extern int func_ov002_020aea30(void* c, void* p, int a, int b);
+extern int _ZN8dActor_c16JumpedOnByPlayerER12CylinderClsnR6Player(void* c, void* clsn, void* player);
+extern void _ZN6Player10SpinBounceE5Fix12IiE(void* p, s32 f);
+extern void _ZN12dEnemyBase_c22SpawnMegaCharParticlesER8dActor_cPc(void* enemy, void* actor, char* s);
+extern void _ZN6Player16IncMegaKillCountEv(void* p);
+extern void func_02012694(int a, void* b);
+extern int _ZN6Player9IsOnShellEv(void* p);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* p, const Vector3* v, u32 a, s32 f, u32 b, u32 c, u32 d);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+}
+
+extern "C" void func_ov070_0211f100(char* c)
+{
+    void* r5;
+    s32 r4;
+
+    if (*(s32*)(c + 0x134) == 0)
+        return;
+    r5 = _ZN8dActor_c10FindWithIDEj(*(s32*)(c + 0x134));
+    if (!r5)
+        return;
+
+    r4 = *(s32*)(c + 0x130);
+    if (r4 & 0x40000) {
+        *(s32*)(c + 0x3d8) = 1;
+        FlyGuy_ChangeState(c, &data_ov070_021235bc);
+        return;
+    }
+    if (r4 & 0x20) {
+        *(s32*)(c + 0x10c) = 1;
+        func_ov002_020aea30(c, r5, 0, 1);
+        return;
+    }
+    if (r4 & 0x67c0) {
+        *(s32*)(c + 0x3d8) = 0;
+        FlyGuy_ChangeState(c, &data_ov070_021235bc);
+        return;
+    }
+
+    {
+        int isBf = (int)(*(u16*)((char*)r5 + 0xc) == 0xbf);
+        if (!isBf)
+            return;
+    }
+    if (*(u8*)((char*)r5 + 0x6fb) != 0)
+        return;
+
+    if (_ZN8dActor_c16JumpedOnByPlayerER12CylinderClsnR6Player(c, c + 0x110, r5)) {
+        _ZN6Player10SpinBounceE5Fix12IiE(r5, 0x28000);
+        *(s32*)(c + 0x10c) = 1;
+        func_ov002_020aea30(c, r5, 0, 1);
+        return;
+    }
+
+    if (r4 & 0x10) {
+        _ZN12dEnemyBase_c22SpawnMegaCharParticlesER8dActor_cPc(c, r5, (char*)0);
+        _ZN6Player16IncMegaKillCountEv(r5);
+        func_02012694(0x1d, c + 0x74);
+        FlyGuy_ChangeState(c, &data_ov070_021235bc);
+        return;
+    }
+
+    if (*(u8*)((char*)r5 + 0x6f9) == 1 || _ZN6Player9IsOnShellEv(r5) == 1) {
+        *(s32*)(c + 0x3d8) = 0;
+        FlyGuy_ChangeState(c, &data_ov070_021235bc);
+        return;
+    }
+
+    {
+        Vector3 v;
+        v.x = *(s32*)(c + 0x5c);
+        v.y = *(s32*)(c + 0x60);
+        v.z = *(s32*)(c + 0x64);
+        _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(r5, &v, 2, 0xc000, 1, 0, 1);
+    }
+    if (*(s32*)(c + 0x3dc) != 0)
+        return;
+    if (*(s32*)(c + 0x3bc) != (s32)&data_ov070_021235cc)
+        return;
+
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x300, (void*)((int *)&data_ov070_02123528)[1], 0x40000000, 0x1000, 0);
+    *(s32*)(c + 0x3d8) = 1;
+    *(s32*)(c + 0x3dc) = 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- func_ov070_0211f0a4, 0x0211f0a4, size 0x5c */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov070_0211f0a4
+/* recovered: shared common types */
+#include "common.h"
+
+
+/* (dActor_c: real header type in scope; SpawnCoins goes through the mangled extern below) */
+/* Signature deliberately copied from the local declaration above: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which
+   mwccarm passes differently at the call site, so declaring the true
+   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+extern "C" void _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(void *, Vector3 const &, unsigned int, int, short);
+
+
+extern "C" int func_ov070_0211f0a4(void *c) {
+    dActor_c *a = (dActor_c *)c;
+    a->SmallPoofDust();
+    Vector3 pos;
+    pos.x = *(int *)((char *)c + 0x5c);
+    pos.y = *(int *)((char *)c + 0x60);
+    pos.z = *(int *)((char *)c + 0x64);
+    unsigned int coins = *(unsigned char *)((char *)c + 0x10a) + 1;
+    _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(a, pos, coins, 0xa000, 0);
+    a->KillAndTrackInDeathTable();
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- _ZN6FlyGuyD0Ev, 0x0211f048, size 0x5c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuyD0Ev
+/* recovered: real C++ deleting destructor -- the compiler emits the whole body
+ *
+ * D0 is the DELETING destructor: destroy through this class and its bases, then
+ * return the object to its heap. Declaring `~FlyGuy()` is enough -- mwcc emits
+ * D2, D0 and D1 together and objisolate keeps the one this file is bound to.
+ *
+ * The deallocation is an inline operator delete -- dEnemyBase_c's, reachable because
+ * dEnemyBase_c is this class's IMMEDIATE base.
+ */
+#include "FlyGuy.h"
+
+/* (no separate definition: the single ~FlyGuy() below emits the D0 and
+ * D1 variants together; mwccarm orders the variant group itself.) */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN6FlyGuyD1Ev, 0x0211f000, size 0x48 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6FlyGuyD1Ev
+/* recovered: real C++ destructor -- the compiler emits the whole body
+ *
+ * One vtable store and a destructor call per member, every one a consequence of
+ * `struct FlyGuy : dEnemyBase_c` and the members that declaration types, destroyed in
+ * reverse declaration order, then dEnemyBase_c::~dEnemyBase_c.
+ *
+ * This body is the evidence for the header: each member's size closes exactly
+ * on the next one's offset.
+ */
+#include "FlyGuy.h"
+
+FlyGuy::~FlyGuy()
+{
+}
+


### PR DESCRIPTION
Third TU seed, and the scale test: ov070 is 2.5x ov009 (92 functions vs 36), its TUs are 19-27 members each (the size class where all-or-nothing merging historically compiled 0 of 159), and every one of its four TUs had to be hand-assembled because `tubuild create` refuses the module's dominant legacy shape (function definitions inside `extern "C" { }` blocks). The recipe held.

**Why ov070**: 92 functions, 100% source-built (96/96 `complete`, zero NONMATCHING hatches), all `tu_map` boundaries `high`, module sinit-corroborated (4 sinits = 4 `.ctor` words = 4 TUs), no scene classes, and Amp freshly enriched by the overlay-leaf queue (#1626).

**Source side — 92/92 byte-verified in 4 merged TUs, 0 excluded:**

| TU | fn | verdict |
|---|---|---|
| src_tu/actors/FlyGuy.cpp | 27 | 27/27 MATCH, objisolate clean, reloc-destinations clean |
| src_tu/actors/Amp.cpp | 19 | 19/19, all three checks clean |
| src_tu/actors/FlameChomp.cpp | 25 | 25/25, all three checks clean |
| src_tu/actors/FlameChompFire.cpp | 21 | 21/21, all three checks clean |

All four manifest entries `text-verified`, re-verified after rebasing onto current main.

**Two new codegen levers, both proven byte-exact by `fdiff` before adoption** (full detail in the manifest notes):

1. **The struct-copy scalarization wall has a source-level fix.** mwccarm's C++ front end scalarizes a plain struct assignment (`v = *(Vector3*)(p+0x5c)`) where the C front end emits an `ldmia/stmia` block copy — the known wall that made two FlyGuy members 4 bytes short / 8 bytes long. An array-wrapper view restores the block copy under `-lang c++`: `struct V3w { int w[3]; }; *(V3w*)&v = *(V3w*)(p+0x5c);` — byte-exact on both members. (`memcpy` was probed too: it emits a different, shorter shape; the array wrapper is the fix.)
2. **Per-member declaration views via block scope.** Two members byte-require `int`-width parameters on `ApproachAngle` while the rest of the TU requires `s16` — and `extern "C"` forbids two signatures. A block-scope `extern` declaration inside the divergent member hides the file-scope one (C++ name hiding), giving each call site its byte-load-bearing view. This generalizes ov009's "declaration merges are not byte-neutral" lesson into a repair tool.

Also reproduced at scale: the +8 vtable-slot addend at all four Spawn sites (these TUs define their `_ZTV`s), the one-destructor-emits-D0+D1 collapse in all four classes, and the hand-mangled-D0-plus-real-destructor ICE avoided by construction.

**Config side — `config_tu/` now holds ov009 AND ov070 in one root:** ov070's 96 delink entries become 4, five sections each, and it **passes `--strict-text`: `.text` grows 0** — 12,868 bytes tiled exactly. Partition ascending and disjoint; `.init` tiles the 4 sinit blocks; `.ctor`'s 4 words resolve one-per-TU through their own relocations; `.data` 988/1088 B and `.bss` 544/544 B by contains-then-closure; `.rodata` honestly 0/19. Regenerating with `--module ov009,ov070` reproduces ov009's committed delinks byte-identically. `dsd delink` and `dsd objdiff` both exit 0; ov070's objdiff units become 7 (4 TUs + 3 gap objects).

**Verification, at exactly this tip (c14d86a0c):**

```
module fidelity: 106/106 exact, 100.000000% of compared bytes
  mismatching: 0                               [src/ and config/**/delinks.txt untouched]
ROM-build analysis: PASS
unresolved symbols: 45  (baseline 45)          [check_references: OK]
eligible name list: byte-identical to origin/main's own run (11,063 = 11,063, diff exit 0)
langmode ratchet PASS                          [fresh chaos-data bank; a mid-run FAIL was the
                                                #1634 re-bank cascade -- reproduced as PASS on
                                                main, vanished on rebase, exactly per the
                                                stale-baseline-gates protocol]
port-refcheck: 393 checked - all references resolve
tubuild re-verified all four TUs at this tip: 92/92 MATCH
```

If the validator reports attribution `CREDIT CHANGED`, that is expected and per standing policy not a blocker.

## Plain-English TL;DR

Same operation as the last overlay, on one 2.5x bigger: the Fly Guy, the electric Amp, and the two halves of the fire-breathing Flame Chomp had their 92 recovered functions spread across 92 tiny files. This PR reassembles them into the four real C++ source files the original 2004 build used, and proves every byte still matches the cartridge. Two compiler quirks had to be solved along the way — the modern file layout was hiding the fact that the old compiler copies small structures with one block instruction, and two functions needed a slightly different view of a shared function's signature — and both solutions are now written down for the next overlay. The build-description tool now describes both converted overlays together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WasbE1QEmFdSreEKNKbVSP
