### PR TITLE
Sweep delinks drift: 27 already-eligible functions promoted to complete

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -361,6 +361,7 @@ src/func_020092c4.c:
     .text start:0x020092c4 end:0x02009374
 
 src/func_02009374.c:
+    complete
     .text start:0x02009374 end:0x020093d4
 
 src/func_020093d4.c:
@@ -1956,6 +1957,7 @@ src/_ZN7Clipper13Func_020156DCEv.cpp:
     .text start:0x020156dc end:0x020156fc
 
 src/_ZN7ClipperD0Ev.c:
+    complete
     .text start:0x020156fc end:0x02015720
 
 src/_ZN7ClipperD1Ev.c:
@@ -3848,6 +3850,7 @@ src/IsButtonInputValid.c:
     .text start:0x02029654 end:0x020297f4
 
 src/_ZN5Stage14GraphCallback2Ev.cpp:
+    complete
     .text start:0x020297f4 end:0x02029838
 
 src/_ZN5Stage14GraphCallback1Ev.cpp:
@@ -6068,8 +6071,8 @@ src/Matrix4x3_ApplyInPlaceToScale.c:
     .text start:0x0203c148 end:0x0203c178
 
 src/func_0203c178.c:
-    .text start:0x0203c178 end:0x0203c184
     complete
+    .text start:0x0203c178 end:0x0203c184
 
 src/Matrix4x3_ApplyInPlaceToTranslation.c:
     complete
@@ -8604,6 +8607,7 @@ src/_ZN4cstd11ldiv_resultEv.cpp:
     .text start:0x02053108 end:0x02053130
 
 src/func_02053130.c:
+    complete
     .text start:0x02053130 end:0x020531a4
 
 src/func_020531a4.c:
@@ -8967,6 +8971,7 @@ src/func_020553a4.c:
     .text start:0x020553a4 end:0x020553c0
 
 src/func_02055454.c:
+    complete
     .text start:0x02055454 end:0x02055464
 
 src/func_02055464.c:
@@ -9262,9 +9267,11 @@ src/func_020570b8.c:
     .text start:0x020570b8 end:0x020570c0
 
 src/func_020570c0.c:
+    complete
     .text start:0x020570c0 end:0x020570d8
 
 src/func_020570d8.c:
+    complete
     .text start:0x020570d8 end:0x020570f0
 
 src/func_020570f0.c:
@@ -9276,9 +9283,11 @@ src/func_0205710c.c:
     .text start:0x0205710c end:0x02057128
 
 src/func_02057128.c:
+    complete
     .text start:0x02057128 end:0x02057140
 
 src/func_02057140.c:
+    complete
     .text start:0x02057140 end:0x02057158
 
 src/func_02057158.c:
@@ -9615,6 +9624,7 @@ src/func_02059624.c:
     .text start:0x02059624 end:0x02059640
 
 src/func_02059640.c:
+    complete
     .text start:0x02059640 end:0x02059650
 
 src/func_02059650.c:
@@ -9714,6 +9724,7 @@ src/func_02059f2c.c:
     .text start:0x02059f2c end:0x02059f48
 
 src/func_02059f48.c:
+    complete
     .text start:0x02059f48 end:0x02059f58
 
 src/func_02059f58.c:
@@ -10409,6 +10420,7 @@ src/func_0205f5fc.c:
     .text start:0x0205f5fc end:0x0205f650
 
 src/func_0205f650.c:
+    complete
     .text start:0x0205f650 end:0x0205f66c
 
 src/func_0205f66c.c:

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -1560,6 +1560,7 @@ src/_ZN8SignPost8BehaviorEv.cpp:
     .text start:0x020bbea4 end:0x020bc240
 
 src/_ZN8SignPost13InitResourcesEv.cpp:
+    complete
     .text start:0x020bc240 end:0x020bc3c8
 
 src/SignPost_Spawn.c:
@@ -5046,6 +5047,7 @@ src/_ZN19AmbientSoundEffects8BehaviorEv.cpp:
     .text start:0x020f19fc end:0x020f1ac4
 
 src/_ZN19AmbientSoundEffects13InitResourcesEv.cpp:
+    complete
     .text start:0x020f1ac4 end:0x020f1b94
 
 src/AmbientSoundEffects_Spawn.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -1891,6 +1891,7 @@ src/func_ov006_020db9dc.cpp:
     .text start:0x020db9dc end:0x020dbaf0
 
 src/_ZN11dScMgCard_c13InitResourcesEv.cpp:
+    complete
     .text start:0x020dbaf0 end:0x020dbd54
 
 src/MgPicturePoker_Spawn.cpp:
@@ -3482,6 +3483,7 @@ src/_ZN12dScMgLuigi_c21AfterCleanupResourcesEj.cpp:
     .text start:0x020efc68 end:0x020efcf8
 
 src/func_ov006_020efcf8.c:
+    complete
     .text start:0x020efcf8 end:0x020efdac
 
 src/func_ov006_020efdac.c:

--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -113,6 +113,7 @@ src/_ZN13RacingPenguin6RenderEv.cpp:
     .text start:0x02112360 end:0x02112394
 
 src/_ZN13RacingPenguin8BehaviorEv.cpp:
+    complete
     .text start:0x02112394 end:0x021123d4
 
 src/_ZN13RacingPenguin13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -69,6 +69,7 @@ src/_ZN16SpinningPlatform8BehaviorEv.cpp:
     .text start:0x0211195c end:0x02111a98
 
 src/_ZN16SpinningPlatform13InitResourcesEv.cpp:
+    complete
     .text start:0x02111a98 end:0x02111b98
 
 src/SpinningPlatform_Spawn.c:

--- a/config/arm9/overlays/ov039/delinks.txt
+++ b/config/arm9/overlays/ov039/delinks.txt
@@ -24,6 +24,7 @@ src/_ZN5Cloud6RenderEv.cpp:
     .text start:0x02111278 end:0x021112a0
 
 src/_ZN5Cloud8BehaviorEv.cpp:
+    complete
     .text start:0x021112a0 end:0x0211132c
 
 src/_ZN5Cloud13InitResourcesEv.cpp:

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -141,6 +141,7 @@ src/_ZN10Scuttlebug8BehaviorEv.cpp:
     .text start:0x02120398 end:0x021203f8
 
 src/_ZN10Scuttlebug13InitResourcesEv.cpp:
+    complete
     .text start:0x021203f8 end:0x02120580
 
 src/_ZN10Scuttlebug13OnTurnIntoEggER6Player.cpp:

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -273,6 +273,7 @@ src/func_ov075_02116ebc.c:
     .text start:0x02116ebc end:0x02116f40
 
 src/func_ov075_02116f40.cpp:
+    complete
     .text start:0x02116f40 end:0x0211705c
 
 src/func_ov075_0211705c.c:

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -104,6 +104,7 @@ src/_ZN6Goomba16OnAimedAtWithEggEv.cpp:
     .text start:0x0212b30c end:0x0212b344
 
 src/func_ov084_0212b344.cpp:
+    complete
     .text start:0x0212b344 end:0x0212b510
 
 src/_ZN6Goomba16CleanupResourcesEv.cpp:

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -156,6 +156,7 @@ src/_ZN13PrincessPeach8BehaviorEv.cpp:
     .text start:0x0212a52c end:0x0212a588
 
 src/_ZN13PrincessPeach13InitResourcesEv.cpp:
+    complete
     .text start:0x0212a588 end:0x0212a684
 
 src/PrincessPeach_Spawn.c:

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -93,9 +93,11 @@ src/_ZN22RotatingUpDownPlatform6RenderEv.cpp:
     .text start:0x021320e0 end:0x02132108
 
 src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp:
+    complete
     .text start:0x02132108 end:0x0213220c
 
 src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp:
+    complete
     .text start:0x0213220c end:0x02132360
 
 src/func_ov091_02132360.cpp:

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -495,6 +495,7 @@ src/func_ov100_0214700c.c:
     .text start:0x0214700c end:0x02147054
 
 src/_ZN15daObjPathLift_c16CleanupResourcesEv.c:
+    complete
     .text start:0x02147054 end:0x021470a4
 
 src/_ZN15daObjPathLift_c6RenderEv.cpp:
@@ -502,6 +503,7 @@ src/_ZN15daObjPathLift_c6RenderEv.cpp:
     .text start:0x021470a4 end:0x021470f4
 
 src/_ZN15daObjPathLift_c8BehaviorEv.cpp:
+    complete
     .text start:0x021470f4 end:0x021471e0
 
 src/_ZN15daObjPathLift_c13InitResourcesEv.cpp:


### PR DESCRIPTION
## TL;DR (plain English)

Our build config keeps a per-file checklist of which recovered source files are fully verified ("complete"). 27 functions had already passed byte-verification but their checklist entries were never updated — pure bookkeeping lag. This PR updates those 27 entries across 12 config files. No source or symbol changes; the ROM build is untouched at 106/106.

## What drifted and why

`enroll.py --complete-list` (dry-run) against current main reports 13 files of drift:

- **12 files fixed here** (`config/arm9/delinks.txt` + 11 overlay delinks): 27 functions promoted `rombytes` → `complete`, plus one cosmetic line-order normalization (`func_0203c178`). All had already passed `eligible.py`.
- **1 file deliberately left** (`config/arm9/itcm/delinks.txt`): NOT lag — a real `enroll.py`/`srcpath.py` defect. Four symbols (`func_01ff98f4`, `func_01ff99a4`, `func_01ff9d40`, `func_01ff9e2c`/`_deq`) are entry points *inside* the single-entry asm blob `src/func_01ff97d8.c` (0x01ff97d8–0x01ffa344, the soft-float runtime block). Enrolling them writes overlapping sub-ranges: `dsd delink` fails with an overlap error, and promoting the 6 functions that call them by name fails the link with `Undefined: "_deq"` etc. The root fix is splitting that blob into its real multiple entry points — a source-recovery task, out of scope here. The 4 itcm entries and the 6 dependent functions (`_ZN4cstd5atan2E5Fix12IiES1_`, `func_0206ece0`, `func_0206f46c`, `func_020708b4`, `func_02070c68`, `func_ov002_020dc560`) are withheld. 33 candidates = 27 applied + 6 withheld.

## Verification

- `rombuild.py -j16 --no-rom`: 106/106 exact, 100.000000%, before and after.
- `eligible.py`: 11063/11189 before and after; the only name-list delta across runs was the known one-name `func_01ff97d8` flake, reproduced on identical committed state.
- `check_references.py`: 45 unresolved (= baseline). `port_refcheck.py`: 393/393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiaNrthjeXwrnx1tB3oBTT