### PR TITLE
Overlay-leaf crumbs: Amp's matrix typed on three witnesses, Cloud's Vec3_Dist const-correct, WaterfallMist's handle documented as deliberately opaque

### DIFF
--- a/include/Amp.h
+++ b/include/Amp.h
@@ -24,7 +24,12 @@ struct Amp : dActor_c {
     ShadowModel               mShadowModel;                  /* 0x1b0 */
     MovingCylinderClsnWithPos mMovingCylinderClsnWithPos;    /* 0x1d8 */
     WithMeshClsn              mWithMeshClsn;                 /* 0x218 */
-    u8                        unk_3d4[0x30];                  /* 0x3d4 */
+    /* Matrix4x3, on three witnesses: InitResources block-copies the identity
+       matrix data_02082128 (0x30 bytes) into it; the state handlers write the
+       position (>>3) at +0x24/+0x28/+0x2c -- exactly the translation row; and
+       func_ov070_021206b0-family passes &this->0x3d4 as the matrix argument of
+       the shadow call. Same role as Lakitu's 0x3f8 translation words. */
+    Matrix4x3                 mMat4x3;                       /* 0x3d4 */
     u8                        pad_404[0xc];
     Vector3                   mCylinderOffset;               /* 0x410 */
     u8                        pad_41c[0x4];

--- a/include/WaterfallMist.h
+++ b/include/WaterfallMist.h
@@ -12,6 +12,10 @@ struct WaterfallMist : dActor_c {
     u8    pad_0d0[0x4];
     u16   mParticleID;       /* 0x0d4 */
     u8    pad_0d6[0x2];
+    /* Stays void*: the only use (Behavior) stores Particle::System::New's
+       result and passes it straight back as a u32 handle on the next call.
+       Nothing ever dereferences it, so no pointee type is evidenced -- naming
+       one would be invention, not recovery. */
     void *mParticle;         /* 0x0d8 */
 
     virtual ~WaterfallMist();

--- a/src/_ZN3Amp13InitResourcesEv.cpp
+++ b/src/_ZN3Amp13InitResourcesEv.cpp
@@ -62,7 +62,7 @@ int Amp::InitResources()
     mTerminalVelocity = 0;
     func_ov070_02120da8(this, 1);
 
-    *(M48 *)unk_3d4 = *(M48 *)&data_02082128;
+    *(M48 *)&mMat4x3 = *(M48 *)&data_02082128;
 
     func_ov070_02120724(this);
     return 1;

--- a/src/_ZN5Cloud8BehaviorEv.cpp
+++ b/src/_ZN5Cloud8BehaviorEv.cpp
@@ -4,19 +4,19 @@
 #include "Cloud.h"
 
 extern "C" {
-extern int Vec3_Dist(void* a, void* b);
+extern int Vec3_Dist(const Vector3* a, const Vector3* b);
 }
 
 #pragma opt_propagation off
 int Cloud::Behavior()
 {
-    int d = Vec3_Dist(&mCamSpacePosX, &mPosX);
+    int d = Vec3_Dist((const Vector3*)&mCamSpacePosX, (const Vector3*)&mPosX);
     int rank = 1;
     int base = 2;
     dActor_c *actor = FindWithActorID(0x13a, 0);
     while (actor) {
         if (actor != this) {
-            int d2 = Vec3_Dist(&mCamSpacePosX, &actor->mPosX);
+            int d2 = Vec3_Dist((const Vector3*)&mCamSpacePosX, (const Vector3*)&actor->mPosX);
             if (d > d2)
                 rank++;
         }

--- a/src_tu/actors/Amp.cpp
+++ b/src_tu/actors/Amp.cpp
@@ -130,7 +130,7 @@ int Amp::InitResources()
     mTerminalVelocity = 0;
     func_ov070_02120da8((char *)this, 1);
 
-    *(M48 *)unk_3d4 = *(M48 *)&data_02082128;
+    *(M48 *)&mMat4x3 = *(M48 *)&data_02082128;
 
     func_ov070_02120724((char *)this);
     return 1;


### PR DESCRIPTION
The three crumbs left open by the overlay-leaf queue, each byte-gated individually. Two are fixes, one is a documented refusal.

**1. Amp's `u8 unk_3d4[0x30]` is a `Matrix4x3` — typed (include/Amp.h).** Three witnesses, not a hunch: `InitResources` block-copies the 0x30-byte identity matrix `data_02082128` into it; the state handlers write `position >> 3` at `+0x24/+0x28/+0x2c` — exactly the translation row `t.x/t.y/t.z`; and the shadow call takes `&this->0x3d4` as its matrix argument. Same role as Lakitu's documented translation words (Lakitu's header keeps scalars only because its marker never spanned the full object; Amp's did). Byte-verified twice: `build_pin.verify` on `_ZN3Amp13InitResourcesEv` -> `(True, '2004/b56')`, and `tubuild verify ov070/Amp` -> `19/19 MATCH, objisolate clean, reloc-destinations clean` (the merged TU carries the same member spelling).

**2. Cloud::Behavior's `Vec3_Dist(void*, void*)` — const-correct declaration (src/_ZN5Cloud8BehaviorEv.cpp).** Now `(const Vector3*, const Vector3*)` with explicit casts at the `&mCamSpacePosX` / `&mPosX` call sites; `build_pin.verify` -> `(True, '2004/b56')`. Scope note: `Vec3_Dist` is a C-named symbol, so no signature is encoded in the ROM and none is being claimed — this is declaration hygiene inside one file. (Tree-wide, the function is declared 10+ different ways; unifying that is a separate, larger cleanup.)

**3. WaterfallMist's `void *mParticle` — deliberately NOT typed; reasoning now lives in the header.** Its only use stores `Particle::System::New`'s result and passes it straight back as a `(u32)` handle on the next call. Nothing anywhere dereferences it, so no pointee type is evidenced — the return type is not even encoded in the mangled name. Typing it would be invention, not recovery, so the header now says exactly that where the next reader will look.

**Verification, at exactly this tip (3badce658):**

```
module fidelity: 106/106 exact, 100.000000% of compared bytes
  mismatching: 0
ROM-build analysis: PASS
unresolved symbols: 45  (baseline 45)   [check_references: OK]
eligible: 11,063 -- unchanged (single-name deltas are signal again post-#1638; there were none)
langmode ratchet PASS                   [fresh chaos-data bank]
port-refcheck: 393 checked - all references resolve
build_pin per touched function: Amp InitResources True, Cloud Behavior True
tubuild verify ov070/Amp: 19/19 MATCH
```

If the validator reports attribution `CREDIT CHANGED`, that is expected and per standing policy not a blocker.

## Plain-English TL;DR

Three small leftovers from the recent enemy-code cleanup. The electric Amp had a 48-byte blob of "unknown data" that turns out to be its 3D transformation matrix — the code fills it with the identity matrix and writes the enemy's position into the exact slots a matrix keeps its position in, so it's now declared as one. A distance-check declaration in the Cloud code got proper types. And a mystery field in the waterfall mist was investigated and deliberately left alone: the game only ever passes it back to the particle engine as an opaque ticket, so giving it a specific type would be guessing — the file now explains that, so nobody re-investigates. The rebuilt game still matches the cartridge byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WasbE1QEmFdSreEKNKbVSP
