### PR TITLE
TU seed 4: reassemble ov077's three translation units (34-member Spiny, largest yet), 88/88 byte-verified, with the namespace repair for divergent extern-C views

### DIFF
--- a/config/tu_manifest.json
+++ b/config/tu_manifest.json
@@ -4840,6 +4840,757 @@
           "relocation_destinations_verified": "PASS"
         }
       }
+    },
+    {
+      "id": "ov077/HeaveHo",
+      "module": "ov077",
+      "source": "src_tu/actors/HeaveHo.cpp",
+      "promoted_source": "src/actors/HeaveHo.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "high",
+      "boundary_evidence": [
+        "contiguous linker run: 0x212624c..0x2127230, 22 function(s), from build/tu_map.json (tools/tu_map.py)",
+        "class label(s): HeaveHo",
+        "module sinit corroboration: 3 sinit(s) / 3 .ctor entries, sinit_vs_tu=ok, corroborated=True (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x0212624c",
+          "end": "0x02127230"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN7HeaveHoD1Ev",
+          "address": "0x0212624c",
+          "size": "0x00000050",
+          "legacy_source": "src/_ZN7HeaveHoD1Ev.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "_ZN7HeaveHoD0Ev",
+          "address": "0x0212629c",
+          "size": "0x00000064",
+          "legacy_source": "src/_ZN7HeaveHoD0Ev.cpp",
+          "ordinal": 1
+        },
+        {
+          "symbol": "func_ov077_02126300",
+          "address": "0x02126300",
+          "size": "0x00000228",
+          "legacy_source": "src/func_ov077_02126300.c",
+          "ordinal": 2
+        },
+        {
+          "symbol": "func_ov077_02126528",
+          "address": "0x02126528",
+          "size": "0x00000118",
+          "legacy_source": "src/func_ov077_02126528.cpp",
+          "ordinal": 3
+        },
+        {
+          "symbol": "func_ov077_02126640",
+          "address": "0x02126640",
+          "size": "0x00000118",
+          "legacy_source": "src/func_ov077_02126640.cpp",
+          "ordinal": 4
+        },
+        {
+          "symbol": "func_ov077_02126758",
+          "address": "0x02126758",
+          "size": "0x00000044",
+          "legacy_source": "src/func_ov077_02126758.cpp",
+          "ordinal": 5
+        },
+        {
+          "symbol": "func_ov077_0212679c",
+          "address": "0x0212679c",
+          "size": "0x00000194",
+          "legacy_source": "src/func_ov077_0212679c.c",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov077_02126930",
+          "address": "0x02126930",
+          "size": "0x00000078",
+          "legacy_source": "src/func_ov077_02126930.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov077_021269a8",
+          "address": "0x021269a8",
+          "size": "0x0000005c",
+          "legacy_source": "src/func_ov077_021269a8.cpp",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov077_02126a04",
+          "address": "0x02126a04",
+          "size": "0x0000004c",
+          "legacy_source": "src/func_ov077_02126a04.c",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov077_02126a50",
+          "address": "0x02126a50",
+          "size": "0x00000034",
+          "legacy_source": "src/func_ov077_02126a50.c",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov077_02126a84",
+          "address": "0x02126a84",
+          "size": "0x0000004c",
+          "legacy_source": "src/func_ov077_02126a84.c",
+          "ordinal": 11
+        },
+        {
+          "symbol": "func_ov077_02126ad0",
+          "address": "0x02126ad0",
+          "size": "0x00000204",
+          "legacy_source": "src/func_ov077_02126ad0.c",
+          "ordinal": 12
+        },
+        {
+          "symbol": "func_ov077_02126cd4",
+          "address": "0x02126cd4",
+          "size": "0x00000088",
+          "legacy_source": "src/func_ov077_02126cd4.cpp",
+          "ordinal": 13
+        },
+        {
+          "symbol": "func_ov077_02126d5c",
+          "address": "0x02126d5c",
+          "size": "0x00000050",
+          "legacy_source": "src/func_ov077_02126d5c.cpp",
+          "ordinal": 14
+        },
+        {
+          "symbol": "func_ov077_02126dac",
+          "address": "0x02126dac",
+          "size": "0x00000040",
+          "legacy_source": "src/func_ov077_02126dac.c",
+          "ordinal": 15
+        },
+        {
+          "symbol": "_ZN7HeaveHo16CleanupResourcesEv",
+          "address": "0x02126dec",
+          "size": "0x00000048",
+          "legacy_source": "src/_ZN7HeaveHo16CleanupResourcesEv.cpp",
+          "ordinal": 16
+        },
+        {
+          "symbol": "_ZN7HeaveHo16OnPendingDestroyEv",
+          "address": "0x02126e34",
+          "size": "0x00000004",
+          "legacy_source": "src/_ZN7HeaveHo16OnPendingDestroyEv.cpp",
+          "ordinal": 17
+        },
+        {
+          "symbol": "_ZN7HeaveHo6RenderEv",
+          "address": "0x02126e38",
+          "size": "0x00000050",
+          "legacy_source": "src/_ZN7HeaveHo6RenderEv.cpp",
+          "ordinal": 18
+        },
+        {
+          "symbol": "_ZN7HeaveHo8BehaviorEv",
+          "address": "0x02126e88",
+          "size": "0x000001e4",
+          "legacy_source": "src/_ZN7HeaveHo8BehaviorEv.cpp",
+          "ordinal": 19
+        },
+        {
+          "symbol": "_ZN7HeaveHo13InitResourcesEv",
+          "address": "0x0212706c",
+          "size": "0x00000168",
+          "legacy_source": "src/_ZN7HeaveHo13InitResourcesEv.cpp",
+          "ordinal": 20
+        },
+        {
+          "symbol": "HeaveHo_Spawn",
+          "address": "0x021271d4",
+          "size": "0x0000005c",
+          "legacy_source": "src/HeaveHo_Spawn.c",
+          "ordinal": 21
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically.",
+        "tubuild create warning: hand-assembled: raw concatenation in reverse ROM order; tubuild create refused this TU (extern \"C\"-wrapped legacy bodies)",
+        "22/22 MATCH, objisolate clean, reloc-destinations clean. Hand-assembled. Two different pointer-to-member shadows both named PMF (a Klass-dispatch view and the state-machine view) -- the state one renamed TU-locally; AngleDiff keeps its byte-load-bearing (short, short) view via a block-scope extern declaration against decl_common's (int, int); one ~HeaveHo() emits D0+D1; Spawn stores &_ZTV7HeaveHo[2]."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov077-HeaveHo/HeaveHo.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 22,
+        "functions_declared": 22,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 13 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
+          "relocation_destinations_verified": "PASS"
+        }
+      }
+    },
+    {
+      "id": "ov077/Lakitu",
+      "module": "ov077",
+      "source": "src_tu/actors/Lakitu.cpp",
+      "promoted_source": "src/actors/Lakitu.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "high",
+      "boundary_evidence": [
+        "contiguous linker run: 0x2123740..0x2124b64, 32 function(s), from build/tu_map.json (tools/tu_map.py)",
+        "class label(s): Lakitu",
+        "module sinit corroboration: 3 sinit(s) / 3 .ctor entries, sinit_vs_tu=ok, corroborated=True (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x02123740",
+          "end": "0x02124b64"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN6LakituD1Ev",
+          "address": "0x02123740",
+          "size": "0x00000058",
+          "legacy_source": "src/_ZN6LakituD1Ev.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "_ZN6LakituD0Ev",
+          "address": "0x02123798",
+          "size": "0x0000006c",
+          "legacy_source": "src/_ZN6LakituD0Ev.cpp",
+          "ordinal": 1
+        },
+        {
+          "symbol": "_ZN6Lakitu13OnYoshiTryEatEv",
+          "address": "0x02123804",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN6Lakitu13OnYoshiTryEatEv.cpp",
+          "ordinal": 2
+        },
+        {
+          "symbol": "_ZN6Lakitu16OnAimedAtWithEggEv",
+          "address": "0x0212380c",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN6Lakitu16OnAimedAtWithEggEv.cpp",
+          "ordinal": 3
+        },
+        {
+          "symbol": "func_ov077_02123814",
+          "address": "0x02123814",
+          "size": "0x0000006c",
+          "legacy_source": "src/func_ov077_02123814.c",
+          "ordinal": 4
+        },
+        {
+          "symbol": "func_ov077_02123880",
+          "address": "0x02123880",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov077_02123880.c",
+          "ordinal": 5
+        },
+        {
+          "symbol": "func_ov077_021238bc",
+          "address": "0x021238bc",
+          "size": "0x00000050",
+          "legacy_source": "src/func_ov077_021238bc.cpp",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov077_0212390c",
+          "address": "0x0212390c",
+          "size": "0x00000110",
+          "legacy_source": "src/func_ov077_0212390c.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov077_02123a1c",
+          "address": "0x02123a1c",
+          "size": "0x00000058",
+          "legacy_source": "src/func_ov077_02123a1c.cpp",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov077_02123a74",
+          "address": "0x02123a74",
+          "size": "0x000001f8",
+          "legacy_source": "src/func_ov077_02123a74.cpp",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov077_02123c6c",
+          "address": "0x02123c6c",
+          "size": "0x000000d4",
+          "legacy_source": "src/func_ov077_02123c6c.cpp",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov077_02123d40",
+          "address": "0x02123d40",
+          "size": "0x0000028c",
+          "legacy_source": "src/func_ov077_02123d40.cpp",
+          "ordinal": 11
+        },
+        {
+          "symbol": "func_ov077_02123fcc",
+          "address": "0x02123fcc",
+          "size": "0x0000006c",
+          "legacy_source": "src/func_ov077_02123fcc.c",
+          "ordinal": 12
+        },
+        {
+          "symbol": "func_ov077_02124038",
+          "address": "0x02124038",
+          "size": "0x000000e0",
+          "legacy_source": "src/func_ov077_02124038.cpp",
+          "ordinal": 13
+        },
+        {
+          "symbol": "func_ov077_02124118",
+          "address": "0x02124118",
+          "size": "0x00000094",
+          "legacy_source": "src/func_ov077_02124118.cpp",
+          "ordinal": 14
+        },
+        {
+          "symbol": "func_ov077_021241ac",
+          "address": "0x021241ac",
+          "size": "0x00000144",
+          "legacy_source": "src/func_ov077_021241ac.c",
+          "ordinal": 15
+        },
+        {
+          "symbol": "func_ov077_021242f0",
+          "address": "0x021242f0",
+          "size": "0x000000a4",
+          "legacy_source": "src/func_ov077_021242f0.c",
+          "ordinal": 16
+        },
+        {
+          "symbol": "func_ov077_02124394",
+          "address": "0x02124394",
+          "size": "0x0000002c",
+          "legacy_source": "src/func_ov077_02124394.c",
+          "ordinal": 17
+        },
+        {
+          "symbol": "func_ov077_021243c0",
+          "address": "0x021243c0",
+          "size": "0x00000114",
+          "legacy_source": "src/func_ov077_021243c0.cpp",
+          "ordinal": 18
+        },
+        {
+          "symbol": "func_ov077_021244d4",
+          "address": "0x021244d4",
+          "size": "0x00000090",
+          "legacy_source": "src/func_ov077_021244d4.cpp",
+          "ordinal": 19
+        },
+        {
+          "symbol": "func_ov077_02124564",
+          "address": "0x02124564",
+          "size": "0x00000134",
+          "legacy_source": "src/func_ov077_02124564.c",
+          "ordinal": 20
+        },
+        {
+          "symbol": "func_ov077_02124698",
+          "address": "0x02124698",
+          "size": "0x00000080",
+          "legacy_source": "src/func_ov077_02124698.c",
+          "ordinal": 21
+        },
+        {
+          "symbol": "func_ov077_02124718",
+          "address": "0x02124718",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov077_02124718.cpp",
+          "ordinal": 22
+        },
+        {
+          "symbol": "func_ov077_02124754",
+          "address": "0x02124754",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov077_02124754.cpp",
+          "ordinal": 23
+        },
+        {
+          "symbol": "func_ov077_0212478c",
+          "address": "0x0212478c",
+          "size": "0x0000001c",
+          "legacy_source": "src/func_ov077_0212478c.c",
+          "ordinal": 24
+        },
+        {
+          "symbol": "_ZN6Lakitu16CleanupResourcesEv",
+          "address": "0x021247a8",
+          "size": "0x0000007c",
+          "legacy_source": "src/_ZN6Lakitu16CleanupResourcesEv.cpp",
+          "ordinal": 25
+        },
+        {
+          "symbol": "_ZN6Lakitu16OnPendingDestroyEv",
+          "address": "0x02124824",
+          "size": "0x00000004",
+          "legacy_source": "src/_ZN6Lakitu16OnPendingDestroyEv.cpp",
+          "ordinal": 26
+        },
+        {
+          "symbol": "_ZN6Lakitu6RenderEv",
+          "address": "0x02124828",
+          "size": "0x00000090",
+          "legacy_source": "src/_ZN6Lakitu6RenderEv.cpp",
+          "ordinal": 27
+        },
+        {
+          "symbol": "_ZN6Lakitu8BehaviorEv",
+          "address": "0x021248b8",
+          "size": "0x00000050",
+          "legacy_source": "src/_ZN6Lakitu8BehaviorEv.cpp",
+          "ordinal": 28
+        },
+        {
+          "symbol": "_ZN6Lakitu13InitResourcesEv",
+          "address": "0x02124908",
+          "size": "0x0000019c",
+          "legacy_source": "src/_ZN6Lakitu13InitResourcesEv.cpp",
+          "ordinal": 29
+        },
+        {
+          "symbol": "_ZN6Lakitu13OnTurnIntoEggER6Player",
+          "address": "0x02124aa4",
+          "size": "0x00000060",
+          "legacy_source": "src/_ZN6Lakitu13OnTurnIntoEggER6Player.cpp",
+          "ordinal": 30
+        },
+        {
+          "symbol": "Lakitu_Spawn",
+          "address": "0x02124b04",
+          "size": "0x00000060",
+          "legacy_source": "src/Lakitu_Spawn.c",
+          "ordinal": 31
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically.",
+        "tubuild create warning: hand-assembled: raw concatenation in reverse ROM order; tubuild create refused this TU (extern \"C\"-wrapped legacy bodies)",
+        "32/32 MATCH, objisolate clean, reloc-destinations clean. Hand-assembled. Carries the NEW namespace repair for divergent extern-C declaration views: decl_common.h declares func_ov077_0212478c with ONE parameter and Lakitu::InitResources's call byte-requires that shape (no r1 setup), while the definition and every other caller need (void*, int) -- a namespace-wrapped extern \"C\" declaration/definition binds the same C symbol under a distinct C++ name, so both views coexist (probed on 2004/b56 before use; block-scope extern cannot serve here because the divergent caller is a C++ member). Same repair for the zero-arg views of _ZN8dActor_c22ClosestNonVanishPlayerEv and func_ov077_02123880. One ~Lakitu() emits D0+D1; Spawn stores &_ZTV6Lakitu[2]."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov077-Lakitu/Lakitu.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 32,
+        "functions_declared": 32,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 11 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
+          "relocation_destinations_verified": "PASS"
+        }
+      }
+    },
+    {
+      "id": "ov077/Spiny",
+      "module": "ov077",
+      "source": "src_tu/actors/Spiny.cpp",
+      "promoted_source": "src/actors/Spiny.cpp",
+      "status": "text-verified",
+      "boundary_confidence": "high",
+      "boundary_evidence": [
+        "contiguous linker run: 0x2124b64..0x212624c, 34 function(s), from build/tu_map.json (tools/tu_map.py)",
+        "class label(s): Spiny",
+        "module sinit corroboration: 3 sinit(s) / 3 .ctor entries, sinit_vs_tu=ok, corroborated=True (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+      ],
+      "sections": [
+        {
+          "name": ".text",
+          "start": "0x02124b64",
+          "end": "0x0212624c"
+        }
+      ],
+      "functions": [
+        {
+          "symbol": "_ZN5SpinyD1Ev",
+          "address": "0x02124b64",
+          "size": "0x00000050",
+          "legacy_source": "src/_ZN5SpinyD1Ev.cpp",
+          "ordinal": 0
+        },
+        {
+          "symbol": "_ZN5SpinyD0Ev",
+          "address": "0x02124bb4",
+          "size": "0x00000064",
+          "legacy_source": "src/_ZN5SpinyD0Ev.c",
+          "ordinal": 1
+        },
+        {
+          "symbol": "_ZN5Spiny13OnYoshiTryEatEv",
+          "address": "0x02124c18",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN5Spiny13OnYoshiTryEatEv.cpp",
+          "ordinal": 2
+        },
+        {
+          "symbol": "_ZN5Spiny16OnAimedAtWithEggEv",
+          "address": "0x02124c20",
+          "size": "0x00000008",
+          "legacy_source": "src/_ZN5Spiny16OnAimedAtWithEggEv.cpp",
+          "ordinal": 3
+        },
+        {
+          "symbol": "func_ov077_02124c28",
+          "address": "0x02124c28",
+          "size": "0x000000bc",
+          "legacy_source": "src/func_ov077_02124c28.cpp",
+          "ordinal": 4
+        },
+        {
+          "symbol": "func_ov077_02124ce4",
+          "address": "0x02124ce4",
+          "size": "0x00000024",
+          "legacy_source": "src/func_ov077_02124ce4.c",
+          "ordinal": 5
+        },
+        {
+          "symbol": "func_ov077_02124d08",
+          "address": "0x02124d08",
+          "size": "0x000001a8",
+          "legacy_source": "src/func_ov077_02124d08.cpp",
+          "ordinal": 6
+        },
+        {
+          "symbol": "func_ov077_02124eb0",
+          "address": "0x02124eb0",
+          "size": "0x000001f8",
+          "legacy_source": "src/func_ov077_02124eb0.cpp",
+          "ordinal": 7
+        },
+        {
+          "symbol": "func_ov077_021250a8",
+          "address": "0x021250a8",
+          "size": "0x00000128",
+          "legacy_source": "src/func_ov077_021250a8.cpp",
+          "ordinal": 8
+        },
+        {
+          "symbol": "func_ov077_021251d0",
+          "address": "0x021251d0",
+          "size": "0x000000c0",
+          "legacy_source": "src/func_ov077_021251d0.cpp",
+          "ordinal": 9
+        },
+        {
+          "symbol": "func_ov077_02125290",
+          "address": "0x02125290",
+          "size": "0x00000074",
+          "legacy_source": "src/func_ov077_02125290.c",
+          "ordinal": 10
+        },
+        {
+          "symbol": "func_ov077_02125304",
+          "address": "0x02125304",
+          "size": "0x000000a0",
+          "legacy_source": "src/func_ov077_02125304.cpp",
+          "ordinal": 11
+        },
+        {
+          "symbol": "func_ov077_021253a4",
+          "address": "0x021253a4",
+          "size": "0x000000dc",
+          "legacy_source": "src/func_ov077_021253a4.cpp",
+          "ordinal": 12
+        },
+        {
+          "symbol": "func_ov077_02125480",
+          "address": "0x02125480",
+          "size": "0x000000d0",
+          "legacy_source": "src/func_ov077_02125480.cpp",
+          "ordinal": 13
+        },
+        {
+          "symbol": "func_ov077_02125550",
+          "address": "0x02125550",
+          "size": "0x00000164",
+          "legacy_source": "src/func_ov077_02125550.cpp",
+          "ordinal": 14
+        },
+        {
+          "symbol": "func_ov077_021256b4",
+          "address": "0x021256b4",
+          "size": "0x0000017c",
+          "legacy_source": "src/func_ov077_021256b4.c",
+          "ordinal": 15
+        },
+        {
+          "symbol": "func_ov077_02125830",
+          "address": "0x02125830",
+          "size": "0x000000ac",
+          "legacy_source": "src/func_ov077_02125830.c",
+          "ordinal": 16
+        },
+        {
+          "symbol": "func_ov077_021258dc",
+          "address": "0x021258dc",
+          "size": "0x0000002c",
+          "legacy_source": "src/func_ov077_021258dc.c",
+          "ordinal": 17
+        },
+        {
+          "symbol": "func_ov077_02125908",
+          "address": "0x02125908",
+          "size": "0x00000104",
+          "legacy_source": "src/func_ov077_02125908.c",
+          "ordinal": 18
+        },
+        {
+          "symbol": "func_ov077_02125a0c",
+          "address": "0x02125a0c",
+          "size": "0x00000048",
+          "legacy_source": "src/func_ov077_02125a0c.c",
+          "ordinal": 19
+        },
+        {
+          "symbol": "func_ov077_02125a54",
+          "address": "0x02125a54",
+          "size": "0x000000c8",
+          "legacy_source": "src/func_ov077_02125a54.c",
+          "ordinal": 20
+        },
+        {
+          "symbol": "func_ov077_02125b1c",
+          "address": "0x02125b1c",
+          "size": "0x00000098",
+          "legacy_source": "src/func_ov077_02125b1c.cpp",
+          "ordinal": 21
+        },
+        {
+          "symbol": "func_ov077_02125bb4",
+          "address": "0x02125bb4",
+          "size": "0x00000220",
+          "legacy_source": "src/func_ov077_02125bb4.c",
+          "ordinal": 22
+        },
+        {
+          "symbol": "func_ov077_02125dd4",
+          "address": "0x02125dd4",
+          "size": "0x0000004c",
+          "legacy_source": "src/func_ov077_02125dd4.c",
+          "ordinal": 23
+        },
+        {
+          "symbol": "func_ov077_02125e20",
+          "address": "0x02125e20",
+          "size": "0x0000003c",
+          "legacy_source": "src/func_ov077_02125e20.cpp",
+          "ordinal": 24
+        },
+        {
+          "symbol": "func_ov077_02125e5c",
+          "address": "0x02125e5c",
+          "size": "0x00000038",
+          "legacy_source": "src/func_ov077_02125e5c.cpp",
+          "ordinal": 25
+        },
+        {
+          "symbol": "func_ov077_02125e94",
+          "address": "0x02125e94",
+          "size": "0x0000001c",
+          "legacy_source": "src/func_ov077_02125e94.c",
+          "ordinal": 26
+        },
+        {
+          "symbol": "_ZN5Spiny16CleanupResourcesEv",
+          "address": "0x02125eb0",
+          "size": "0x0000003c",
+          "legacy_source": "src/_ZN5Spiny16CleanupResourcesEv.c",
+          "ordinal": 27
+        },
+        {
+          "symbol": "_ZN5Spiny16OnPendingDestroyEv",
+          "address": "0x02125eec",
+          "size": "0x00000004",
+          "legacy_source": "src/_ZN5Spiny16OnPendingDestroyEv.c",
+          "ordinal": 28
+        },
+        {
+          "symbol": "_ZN5Spiny6RenderEv",
+          "address": "0x02125ef0",
+          "size": "0x00000078",
+          "legacy_source": "src/_ZN5Spiny6RenderEv.cpp",
+          "ordinal": 29
+        },
+        {
+          "symbol": "_ZN5Spiny8BehaviorEv",
+          "address": "0x02125f68",
+          "size": "0x000000f0",
+          "legacy_source": "src/_ZN5Spiny8BehaviorEv.cpp",
+          "ordinal": 30
+        },
+        {
+          "symbol": "_ZN5Spiny13InitResourcesEv",
+          "address": "0x02126058",
+          "size": "0x0000013c",
+          "legacy_source": "src/_ZN5Spiny13InitResourcesEv.cpp",
+          "ordinal": 31
+        },
+        {
+          "symbol": "_ZN5Spiny13OnTurnIntoEggER6Player",
+          "address": "0x02126194",
+          "size": "0x00000060",
+          "legacy_source": "src/_ZN5Spiny13OnTurnIntoEggER6Player.cpp",
+          "ordinal": 32
+        },
+        {
+          "symbol": "Spiny_Spawn",
+          "address": "0x021261f4",
+          "size": "0x00000058",
+          "legacy_source": "src/Spiny_Spawn.c",
+          "ordinal": 33
+        }
+      ],
+      "data": [],
+      "bss": [],
+      "notes": [
+        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically.",
+        "tubuild create warning: hand-assembled: raw concatenation in reverse ROM order; tubuild create refused this TU (extern \"C\"-wrapped legacy bodies)",
+        "34/34 MATCH, objisolate clean, reloc-destinations clean -- the largest TU reconstructed so far. Hand-assembled. Two RaycastGround shadow views of DIFFERENT sizes (0x50 and 0x54) are both stack-frame-load-bearing; the 0x54 view lives in namespace rg54, binding the same C symbols. InitResources byte-requires a THREE-argument call to func_ov077_02125e94 (r2 = 0x2c) against the TU's (void*, int) definition -- namespaced three-arg view. The hand-mangled D0 body is dropped (mwccarm ICE ELFgen.c:483 with a real destructor in the same TU); one ~Spiny() emits both variants. Spawn stores &_ZTV5Spiny[2]."
+      ],
+      "verification": {
+        "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
+        "toolchain": "tools/mwccarm/2004/b56/mwccarm.exe",
+        "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+        "object": "build/tu/ov077-Spiny/Spiny.o (gitignored)",
+        "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
+        "functions_matched": 34,
+        "functions_declared": 34,
+        "criteria": {
+          "every_declared_function_defined": "PASS",
+          "every_declared_function_bytes_match": "PASS",
+          "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 11 unlicensed section/symbol(s); see unlicensed_output_observed",
+          "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
+          "relocation_destinations_verified": "PASS"
+        }
+      }
     }
   ]
 }

--- a/config_tu/arm9/config.yaml
+++ b/config_tu/arm9/config.yaml
@@ -567,7 +567,7 @@ overlays:
     name: ov077
     object: ../../build/build/arm9_ov077.bin
     hash: acc34cc03f3743fe
-    delinks: ../../config/arm9/overlays/ov077/delinks.txt
+    delinks: overlays/ov077/delinks.txt
     symbols: ../../config/arm9/overlays/ov077/symbols.txt
     relocations: ../../config/arm9/overlays/ov077/relocs.txt
   - id: 78

--- a/config_tu/arm9/overlays/ov077/delinks.txt
+++ b/config_tu/arm9/overlays/ov077/delinks.txt
@@ -1,0 +1,26 @@
+    .text       start:0x02123740 end:0x02127230 kind:code align:32
+    .rodata     start:0x02127230 end:0x02127240 kind:rodata align:4
+    .init       start:0x02127240 end:0x021277cc kind:code align:4
+    .ctor       start:0x021277cc end:0x021277d8 kind:rodata align:4
+    .data       start:0x021277e0 end:0x02127b20 kind:data align:32
+    .bss        start:0x02127b20 end:0x02127d40 kind:bss align:32
+src_tu/actors/Lakitu.cpp:
+    .text start:0x02123740 end:0x02124b64
+    .init start:0x02127240 end:0x0212749c
+    .ctor start:0x021277cc end:0x021277d0
+    .data start:0x021277e0 end:0x021278e8
+    .bss start:0x02127b50 end:0x02127c14
+
+src_tu/actors/Spiny.cpp:
+    .text start:0x02124b64 end:0x0212624c
+    .init start:0x0212749c end:0x021275fc
+    .ctor start:0x021277d0 end:0x021277d4
+    .data start:0x021278e8 end:0x02127a00
+    .bss start:0x02127c14 end:0x02127c40
+
+src_tu/actors/HeaveHo.cpp:
+    .text start:0x0212624c end:0x02127230
+    .init start:0x021275fc end:0x021277cc
+    .ctor start:0x021277d4 end:0x021277d8
+    .data start:0x02127a00 end:0x02127b20
+    .bss start:0x02127c88 end:0x02127d40

--- a/config_tu/tu_modules.json
+++ b/config_tu/tu_modules.json
@@ -108,6 +108,54 @@
      "detail": "4/4 TUs, 544 of 544 bytes; 35/37 symbol runs whose every self-module referrer is already attributed to one and the same TU"
     }
    ]
+  },
+  "ov077": {
+   "entriesBefore": 91,
+   "entriesAfter": 3,
+   "tuEntries": 3,
+   "carriedEntries": 0,
+   "functions": 88,
+   "textBytes": 15088,
+   "textGrewBy": 0,
+   "sections": {
+    ".text": 15088,
+    ".init": 1420,
+    ".ctor": 12,
+    ".data": 832,
+    ".bss": 424
+   },
+   "attribution": [
+    {
+     "section": ".text",
+     "verdict": "claimed",
+     "detail": "3 contiguous runs from build/tu_map.json, tiling 0x02123740-0x02127230"
+    },
+    {
+     "section": ".init",
+     "verdict": "claimed",
+     "detail": "3 sinit blocks tiling 0x02127240-0x021277cc; ordinal k -> TU k (counts agree: sinits == .ctor words == TUs)"
+    },
+    {
+     "section": ".ctor",
+     "verdict": "claimed",
+     "detail": "3 words tiling 0x021277cc-0x021277d8, one per TU, each resolved through its own relocation"
+    },
+    {
+     "section": ".rodata",
+     "verdict": "unattributed",
+     "detail": "0 seed run(s) whose own code pointers land in one TU, 0 more by closure over their referrers, of 2 symbol runs -- no run could be attributed"
+    },
+    {
+     "section": ".data",
+     "verdict": "claimed",
+     "detail": "3/3 TUs, 832 of 832 bytes; 38 seed run(s) whose own code pointers land in one TU, 6 more by closure over their referrers, of 45 symbol runs"
+    },
+    {
+     "section": ".bss",
+     "verdict": "claimed",
+     "detail": "3/3 TUs, 424 of 544 bytes; 27/35 symbol runs whose every self-module referrer is already attributed to one and the same TU"
+    }
+   ]
   }
  }
 }

--- a/src_tu/actors/HeaveHo.cpp
+++ b/src_tu/actors/HeaveHo.cpp
@@ -1,0 +1,802 @@
+//cpp
+/* HAND-ASSEMBLED translation unit -- ov077/HeaveHo (22 function(s)).
+ * tubuild create refused this TU (legacy bodies wrapped in extern "C" { }),
+ * so this is a raw concatenation of the complete legacy files in REVERSE
+ * ROM order (mwccarm emits one .text section per function in the reverse
+ * of source order). Conflicting declarations were reconciled by hand; see
+ * the manifest notes.
+ *
+ * Assembled from these legacy one-function sources (ROM address order):
+ *   [0] 0x0212624c  src/_ZN7HeaveHoD1Ev.cpp
+ *   [1] 0x0212629c  src/_ZN7HeaveHoD0Ev.cpp
+ *   [2] 0x02126300  src/func_ov077_02126300.c
+ *   [3] 0x02126528  src/func_ov077_02126528.cpp
+ *   [4] 0x02126640  src/func_ov077_02126640.cpp
+ *   [5] 0x02126758  src/func_ov077_02126758.cpp
+ *   [6] 0x0212679c  src/func_ov077_0212679c.c
+ *   [7] 0x02126930  src/func_ov077_02126930.cpp
+ *   [8] 0x021269a8  src/func_ov077_021269a8.cpp
+ *   [9] 0x02126a04  src/func_ov077_02126a04.c
+ *   [10] 0x02126a50  src/func_ov077_02126a50.c
+ *   [11] 0x02126a84  src/func_ov077_02126a84.c
+ *   [12] 0x02126ad0  src/func_ov077_02126ad0.c
+ *   [13] 0x02126cd4  src/func_ov077_02126cd4.cpp
+ *   [14] 0x02126d5c  src/func_ov077_02126d5c.cpp
+ *   [15] 0x02126dac  src/func_ov077_02126dac.c
+ *   [16] 0x02126dec  src/_ZN7HeaveHo16CleanupResourcesEv.cpp
+ *   [17] 0x02126e34  src/_ZN7HeaveHo16OnPendingDestroyEv.cpp
+ *   [18] 0x02126e38  src/_ZN7HeaveHo6RenderEv.cpp
+ *   [19] 0x02126e88  src/_ZN7HeaveHo8BehaviorEv.cpp
+ *   [20] 0x0212706c  src/_ZN7HeaveHo13InitResourcesEv.cpp
+ *   [21] 0x021271d4  src/HeaveHo_Spawn.c
+ */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 21 -- HeaveHo_Spawn, 0x021271d4, size 0x5c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol HeaveHo_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7HeaveHo */
+int *HeaveHo_Spawn(void)
+{
+    int *p = (int *)_ZN7fBase_cnwEj(1068);
+    if (p) {
+        _ZN12dEnemyBase_cC2Ev(p);
+        p[0] = (int)&_ZTV7HeaveHo[2]; /* +8: this TU defines the vtable */
+        _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
+        _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x144);
+        _ZN12WithMeshClsnC1Ev((char *)p + 0x184);
+        _ZN9ModelAnimC1Ev((char *)p + 0x340);
+        _ZN11ShadowModelC1Ev((char *)p + 0x3a4);
+    }
+    return p;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 20 -- _ZN7HeaveHo13InitResourcesEv, 0x0212706c, size 0x168 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN7HeaveHo13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HeaveHo.h"
+extern "C" {
+extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
+extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
+extern void _ZN9Animation8LoadFileER13SharedFilePtr(void*);
+extern void _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
+extern void _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(void*, void*, void*, int, int, unsigned int, unsigned int);
+extern void _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void*, void*, int, int, void*, int);
+extern int func_ov077_02126d5c(void*, void*);
+struct V3 { int x, y, z; };
+extern struct V3 data_ov077_02127a5c;
+}
+
+int HeaveHo::InitResources()
+{
+  struct V3 v;
+  void* f;
+  f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov077_02127c88);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x340, f, 1, -1);
+  _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov077_02127ca0);
+  _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov077_02127c90);
+  _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov077_02127c98);
+  mVertAccel = -0x1000;
+  mTerminalVelocity = -0x1e000;
+  _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(((char*)this) + 0x110, ((char*)this), 0x52000, 0x52000, 0x800004, 0);
+  v.x = data_ov077_02127a5c.x;
+  v.y = data_ov077_02127a5c.y;
+  v.z = data_ov077_02127a5c.z;
+  _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(((char*)this) + 0x144, ((char*)this), &v, 0x54000, 0x32000, 0x200004, 0);
+  mAngleY = mPrevAngleY;
+  _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x184, ((char*)this), 0x64000, 0x64000, 0, 0);
+  unk_400 = 0;
+  unk_404 = mPosX;
+  unk_408 = mPosY;
+  unk_40c = mPosZ;
+  mModelAnim.speed = 0x1000;
+  unk_410 = mPosX;
+  unk_414 = mPosY;
+  unk_418 = mPosZ;
+  func_ov077_02126d5c(((char*)this), &data_ov077_02127ce8);
+  return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 19 -- _ZN7HeaveHo8BehaviorEv, 0x02126e88, size 0x1e4 */
+/* -------------------------------------------------------------------------- */
+#include "types.h"
+// @symbol _ZN7HeaveHo8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HeaveHo.h"
+struct Klass; typedef void (Klass::*PMF)();
+struct M { char pad[8]; PMF pmf; };
+struct CylinderClsn;
+struct WithMeshClsn;
+extern "C" {
+unsigned short DecIfAbove0_Short(unsigned short *p);
+void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void *self, CylinderClsn *cc);
+int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
+void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
+void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *self, Vector3 *v);
+int func_02010844(void *unused, Vector3 *v, s16 angle);
+int _ZN12dEnemyBase_c15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *self, WithMeshClsn *wm, Fix12i a, s16 b, int c, int d, void *e);
+void _ZN12dEnemyBase_c12UpdateWMClsnER12WithMeshClsnj(void *self, WithMeshClsn *wm, unsigned int j);
+void func_ov077_02126dac(char *t);
+void func_ov077_02126528(char *c);
+void _ZN12CylinderClsn5ClearEv(CylinderClsn *self);
+void _ZN12CylinderClsn6UpdateEv(CylinderClsn *self);
+void _ZN9Animation7AdvanceEv(void *self);
+extern int data_0209f32c;
+}
+
+int HeaveHo::Behavior()
+{
+    int b;
+    Vector3 v;
+    int r5;
+    M *m;
+
+    if (mPosY < data_0209f32c) {
+        mPosX = unk_404;
+        mPosY = unk_408;
+        mPosZ = unk_40c;
+        return 1;
+    }
+
+    DecIfAbove0_Short((unsigned short *)((char *)&unk_100));
+    DecIfAbove0_Short((unsigned short *)((char *)&unk_426));
+
+    m = *(M **)((char *)&unk_3fc);
+    if (m->pmf != 0)
+        (((Klass *)((char *)this))->*(m->pmf))();
+
+    _ZN8dActor_c9UpdatePosEP12CylinderClsn(((char *)this), (CylinderClsn *)((char *)&mMovingCylinderClsnWithPos));
+
+    r5 = 0;
+    if (_ZNK12WithMeshClsn10IsOnGroundEv((char *)&mWithMeshClsn)) {
+        void *fr = _ZNK12WithMeshClsn14GetFloorResultEv((char *)&mWithMeshClsn);
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char *)fr + 4, &v);
+        r5 = func_02010844(((char *)this), &v, mAngleY);
+    }
+
+    b = _ZN12dEnemyBase_c15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(((char *)this), (WithMeshClsn *)((char *)&mWithMeshClsn), 0x3c000, (s16)0x2888, 0, 1, (void *)0x32000);
+    if (b == 0) {
+        if (r5 < 0)
+            r5 = (s16)-r5;
+        if (r5 <= 0x100)
+            goto writeback;
+    }
+    mPosX = unk_410;
+    mPosY = unk_414;
+    mPosZ = unk_418;
+writeback:
+    unk_410 = mPosX;
+    unk_414 = mPosY;
+    unk_418 = mPosZ;
+    _ZN12dEnemyBase_c12UpdateWMClsnER12WithMeshClsnj(((char *)this), (WithMeshClsn *)((char *)&mWithMeshClsn), 2);
+
+    mAngleY = mPrevAngleY;
+    func_ov077_02126dac(((char *)this));
+
+    if (_ZNK12WithMeshClsn10IsOnGroundEv((char *)&mWithMeshClsn) && *(void **)((char *)&unk_3fc) != (void *)data_ov077_02127cd8) {
+        func_ov077_02126528(((char *)this));
+    }
+    _ZN12CylinderClsn5ClearEv((CylinderClsn *)((char *)&mMovingCylinderClsn));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)((char *)&mMovingCylinderClsn));
+    _ZN12CylinderClsn5ClearEv((CylinderClsn *)((char *)&mMovingCylinderClsnWithPos));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)((char *)&mMovingCylinderClsnWithPos));
+
+    mModelAnim.Advance();
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- _ZN7HeaveHo6RenderEv, 0x02126e38, size 0x50 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN7HeaveHo6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "HeaveHo.h"
+extern int data_0209f32c;
+
+struct Cls {
+    virtual void method0();
+    virtual void method1();
+    virtual void method2();
+    virtual void method3();
+    virtual void method4();
+    virtual void method5(int);  /* at vtable offset 0x14 */
+};
+
+int HeaveHo::Render()
+{
+    if (mPosY < data_0209f32c) return 1;
+    Cls *obj = (Cls*)((char*)&mModelAnim);
+    obj->method5(0);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- _ZN7HeaveHo16OnPendingDestroyEv, 0x02126e34, size 0x4 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN7HeaveHo16OnPendingDestroyEv
+/* recovered: shared header, real C++ method
+ *
+ * fBase_c slot 12. Empty in the ROM: four bytes, `bx lr`.
+ */
+#include "HeaveHo.h"
+
+void HeaveHo::OnPendingDestroy()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- _ZN7HeaveHo16CleanupResourcesEv, 0x02126dec, size 0x48 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN7HeaveHo16CleanupResourcesEv
+/* recovered: shared header, real C++ method
+ *
+ * Releases the 4 shared file(s) InitResources claimed.
+ *
+ * TOUCHES NO FIELD. The ROM body takes no `this`; as a method it now receives
+ * one and ignores it, which measured byte-free.
+ */
+#include "HeaveHo.h"
+#include "SharedFilePtr.h"
+
+extern "C" {
+}
+
+int HeaveHo::CleanupResources()
+{
+    ((SharedFilePtr *)&data_ov077_02127c88)->Release();
+    ((SharedFilePtr *)&data_ov077_02127ca0)->Release();
+    ((SharedFilePtr *)&data_ov077_02127c90)->Release();
+    ((SharedFilePtr *)&data_ov077_02127c98)->Release();
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- func_ov077_02126dac, 0x02126dac, size 0x40 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void Matrix4x3_FromRotationY(void *, int);
+void func_ov077_02126dac(char *t)
+{
+    Matrix4x3_FromRotationY(t + 0x35c, *(short *)(t + 0x8e));
+    *(int *)(t + 0x380) = *(int *)(t + 0x5c) >> 3;
+    *(int *)(t + 0x384) = *(int *)(t + 0x60) >> 3;
+    *(int *)(t + 0x388) = *(int *)(t + 0x64) >> 3;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- func_ov077_02126d5c, 0x02126d5c, size 0x50 */
+/* -------------------------------------------------------------------------- */
+struct Cst; typedef int (Cst::*PMFst)();  /* renamed: another member's shadow PMF has a different signature */
+struct Cst { char pad[0x3fc]; PMFst *pp; };
+extern "C" int func_ov077_02126d5c(void *vc, void *vp) { Cst *c = (Cst *)vc; PMFst *p = (PMFst *)vp; c->pp = p; PMFst *q = c->pp; if (*q == 0) return 1; return (c->**q)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- func_ov077_02126cd4, 0x02126cd4, size 0x88 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern unsigned int RandomIntInternal(void* s);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+extern int data_0209e650[];
+int func_ov077_02126cd4(char* c){
+  *(short*)(c+0x400+0x20) = (short)(((RandomIntInternal(data_0209e650) >> 8) & 0xf) << 0xc);
+  *(short*)(c+0x100) = (short)(((RandomIntInternal(data_0209e650) >> 8) & 0x3f) + 0xaa);
+  *(int*)(c+0x39c) = 0x1000;
+  *(int*)(c+0x98) = 0x8000;
+  *(int*)(c+0x41c) = 0;
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x340, (void*)((int*)&data_ov077_02127c90)[1], 0, 0x1000, 0);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- func_ov077_02126ad0, 0x02126ad0, size 0x204 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov077_02126ad0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern int Vec3_Dist(void* a, void* b);
+extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3s(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int d);
+extern int func_ov077_02126300(void* c);
+extern int func_ov077_02126d5c(void* c, void* p);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void* p);
+extern short Vec3_HorzAngle(void* a, void* b);
+extern void _Z14ApproachLinearRsss(short* a, short b, short cc);
+extern void* _ZN8dActor_c13ClosestPlayerEv(void* c);
+
+extern char data_ov077_02127cf8[];
+
+int func_ov077_02126ad0(char* c)
+{
+    int dist;
+    char* player;
+    struct Vector3 pp;
+
+    dist = Vec3_Dist(c + 0x5c, c + 0x404);
+    *(unsigned int*)(c + 0x428) = _ZN5Sound8PlayLongEjjjRK7Vector3s(*(unsigned int*)(c + 0x428), 3, 0x186, c + 0x74, 0);
+
+    if (func_ov077_02126300(c) != 0) {
+        func_ov077_02126d5c(c, data_ov077_02127d18);
+        return 1;
+    }
+
+    if (_ZNK12WithMeshClsn8IsOnWallEv(c + 0x184) != 0) {
+        *(int*)(c + 0x5c) = *(int*)(c + 0x410);
+        *(int*)(c + 0x60) = *(int*)(c + 0x414);
+        *(int*)(c + 0x64) = *(int*)(c + 0x418);
+    }
+
+    if (dist > 0x1f4000) {
+        *(short*)(c + 0x420) = Vec3_HorzAngle(c + 0x5c, c + 0x404);
+        if (*(unsigned short*)(c + 0x100) < 0x14)
+            *(unsigned short*)(c + 0x100) = 0x14;
+        _Z14ApproachLinearRsss((short*)(c + 0x94), *(short*)(c + 0x420), 0x400);
+    }
+    _Z14ApproachLinearRsss((short*)(c + 0x94), *(short*)(c + 0x420), 0x100);
+
+    if (*(unsigned short*)(c + 0x100) < 0x64)
+        *(int*)(c + 0x39c) = 0x1000 / (0x64 - *(unsigned short*)(c + 0x100));
+
+    if (*(unsigned short*)(c + 0x100) == 0) {
+        func_ov077_02126d5c(c, data_ov077_02127cf8);
+        return 1;
+    }
+
+    if (*(unsigned short*)(c + 0x426) != 0)
+        return 1;
+
+    player = (char*)_ZN8dActor_c13ClosestPlayerEv(c);
+    if (player != 0) {
+        struct Vector3* src = (struct Vector3*)(((long)(player + 0x5c)));
+        pp.x = src->x;
+        pp.y = src->y;
+        pp.z = src->z;
+        if (Vec3_Dist(c + 0x404, &pp) < 0x3e8000
+            && *(unsigned char*)(player + 0x6f9) == 0
+            && *(unsigned char*)(player + 0x703) == 0
+            && _ZN6Player12GetHurtStateEv(player) < 0) {
+            func_ov077_02126d5c(c, data_ov077_02127d08);
+            return 1;
+        }
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov077_02126a84, 0x02126a84, size 0x4c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int frame, int speed, unsigned int flags);
+int func_ov077_02126a84(char *c) {
+    *(int*)(c + 0x98) = 0;
+    *(short*)(c + 0x100) = 0x46;
+    *(int*)(c + 0x39c) = 0x1000;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x340, (void*)((void**)&data_ov077_02127c98)[1], 0, 0x1000, 0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov077_02126a50, 0x02126a50, size 0x34 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern int func_ov077_02126d5c(void*, void*);
+
+int func_ov077_02126a50(char *c) {
+    unsigned short h = *(unsigned short*)(c + 0x100);
+    if (h == 0) {
+        func_ov077_02126d5c(c, &data_ov077_02127ce8);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov077_02126a04, 0x02126a04, size 0x4c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+
+int func_ov077_02126a04(char *c) {
+    *(short*)(c + 0x420) = *(short*)(c + 0x8e) + 0x4000;
+    *(int*)(c + 0x39c) = 0x1000;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x340, ((void**)&data_ov077_02127c90)[1], 0, 0x1000, 0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov077_021269a8, 0x021269a8, size 0x5c */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern void _Z14ApproachLinearRsss(short*, short, short);
+extern int func_ov077_02126d5c(void*, void*);
+int func_ov077_021269a8(char* c) {
+    extern int AngleDiff(short, short); /* this file's own view (decl_common says int,int); short is byte-load-bearing here */
+    short tgt = *(short*)(c + 0x420);
+    _Z14ApproachLinearRsss((short*)(c + 0x94), tgt, 0x500);
+    int diff = AngleDiff(*(short*)(c + 0x94), *(short*)(c + 0x420));
+    if (diff < 0x100) {
+        *(short*)(c + 0x426) = 0x1e;
+        func_ov077_02126d5c(c, &data_ov077_02127ce8);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov077_02126930, 0x02126930, size 0x78 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int a, int fix, unsigned int j);
+extern unsigned int RandomIntInternal(void* s);
+extern int data_0209e650[];
+int func_ov077_02126930(char* c){
+  *(short*)(c+0x100) = (short)(((RandomIntInternal(data_0209e650) >> 8) & 0x3f) + 0xaa);
+  *(int*)(c+0x98) = 0x6000;
+  *(short*)(c+0x400+0x22) = 0;
+  *(int*)(c+0x41c) = 0;
+  *(int*)(c+0x39c) = 0x2000;
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x340, (void*)((int*)&data_ov077_02127c90)[1], 0, 0x1000, 0);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- func_ov077_0212679c, 0x0212679c, size 0x194 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov077_0212679c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern int Vec3_Dist(void *a, void *b);
+extern int func_ov077_02126300(void *c);
+extern int func_ov077_02126d5c(void *c, void *p);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void *thiz);
+extern void* _ZN8dActor_c13ClosestPlayerEv(void* thiz);
+extern short Vec3_HorzAngle(void *a, void *b);
+extern void _Z14ApproachLinearRsss(short *r, short a, short b);
+extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3s(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int d);
+extern char data_ov077_02127cf8[];
+
+int func_ov077_0212679c(char *c)
+{
+    struct Vector3 pv;
+    struct Vector3 *pp;
+    int dist;
+    char *p;
+    unsigned short spd;
+
+    dist = Vec3_Dist((void *)(c + 0x5c), (void *)(c + 0x404));
+
+    if (func_ov077_02126300(c) != 0) {
+        func_ov077_02126d5c(c, data_ov077_02127d18);
+        return 1;
+    }
+
+    if (_ZNK12WithMeshClsn8IsOnWallEv(c + 0x184) != 0) {
+        *(int *)(c + 0x5c) = *(int *)(c + 0x410);
+        *(int *)(c + 0x60) = *(int *)(c + 0x414);
+        *(int *)(c + 0x64) = *(int *)(c + 0x418);
+    }
+
+    p = (char *)_ZN8dActor_c13ClosestPlayerEv(c);
+    if (p != 0) {
+        /* u64 launder forces base materialization after the null cmp */
+        pp = (struct Vector3 *)(void *)(unsigned long long)(unsigned long)(p + 0x5c);
+        pv.x = pp->x;
+        pv.y = pp->y;
+        pv.z = pp->z;
+        *(short *)(c + 0x420) = Vec3_HorzAngle((void *)(c + 0x5c), &pv);
+    }
+
+    _Z14ApproachLinearRsss((short *)(c + 0x94), *(short *)(c + 0x420), *(short *)(c + 0x422));
+    _Z14ApproachLinearRsss((short *)(c + 0x422), 0x600, 0x100);
+
+    *(unsigned int *)(c + 0x428) = _ZN5Sound8PlayLongEjjjRK7Vector3s(
+        *(unsigned int *)(c + 0x428), 3, 0x186, c + 0x74, 0);
+
+    spd = *(unsigned short *)(c + 0x100);
+    if (spd < 0x64) {
+        *(int *)(c + 0x39c) = __aeabi_idiv(0x1000, 5 - spd / 20);
+    }
+
+    if (dist > 0x5dc000 || *(unsigned short *)(c + 0x100) == 0 || func_ov077_02126300(c) != 0)
+        func_ov077_02126d5c(c, data_ov077_02127cf8);
+
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- func_ov077_02126758, 0x02126758, size 0x44 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* c, void* f, int a, int b, unsigned int u);
+int func_ov077_02126758(char* c){
+  *(int*)(c+0x98)=0;
+  *(int*)(c+0x39c)=0x1000;
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x340, ((void**)&data_ov077_02127ca0)[1], 0x40000000, 0x1000, 0);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 4 -- func_ov077_02126640, 0x02126640, size 0x118 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02126640
+// recovered name: Spiny_Kill
+/* recovered: renamed to Class_Method */
+/* daTgz_c::Kill - recovered from vtable slot identity */
+/* (Vector3: real header type in scope) */
+extern "C" {
+void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void *thiz, const Vector3 &v);
+void *_ZN8dActor_c10FindWithIDEj(unsigned int id);
+int _ZN6Player12GetHurtStateEv(void *p);
+int func_ov002_020db674(void *c, int a1, int a2, int a3);
+void func_02012694(int a, void *b, int c);
+int _ZN9Animation8FinishedEv(void *p);
+int func_ov077_02126d5c(void *c, void *p);
+extern char data_ov077_02127cf8[];
+}
+
+extern "C" int func_ov077_02126640(char *c)
+{
+    Vector3 v;
+    char *a;
+    int t;
+    if (*(int *)(c + 0x400) != 0) {
+        v.x = data_ov077_02127a5c.x;
+        v.y = data_ov077_02127a5c.y;
+        v.z = data_ov077_02127a5c.z;
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x144, v);
+        if (*(int *)(c + 0x168) != 0) {
+            a = (char *)_ZN8dActor_c10FindWithIDEj(*(int *)(c + 0x168));
+            if (a != 0) {
+                if (a == *(char **)(c + 0x400)) {
+                    if (*(unsigned char *)(a + 0x6f9) == 0) {
+                        if (*(unsigned char *)(a + 0x703) == 0) {
+                            t = (*(unsigned char *)(a + 0x709) != 0);
+                            if (t == 0) {
+                                if (_ZN6Player12GetHurtStateEv(a) < 0) {
+                                    if (func_ov002_020db674(a, 0x28000, 0x70000,
+                                            (int)(short)(*(short *)(c + 0x8e) + 0x8000)) != 0) {
+                                        *(int *)(c + 0x400) = 0;
+                                        func_02012694(0x10b, c + 0x74, 0);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (_ZN9Animation8FinishedEv(c + 0x390) != 0) {
+        func_ov077_02126d5c(c, &data_ov077_02127cf8);
+    }
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- func_ov077_02126528, 0x02126528, size 0x118 */
+/* -------------------------------------------------------------------------- */
+/* (Vector3: real header type in scope) */
+extern "C" {
+void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void *thiz, const Vector3 &v);
+void *_ZN8dActor_c10FindWithIDEj(unsigned int id);
+int _ZN6Player12GetHurtStateEv(void *p);
+int _ZN6Player15IsCollectingCapEv(void *p);
+int func_ov077_02126d5c(void *c, void *p);
+extern char data_ov077_02127cd8[]; /* decl_common's view; only its address is taken here */
+}
+
+extern "C" void func_ov077_02126528(char *c)
+{
+    Vector3 v;
+    char *a;
+    int t;
+    v.x = data_ov077_02127a5c.x;
+    v.y = data_ov077_02127a5c.y;
+    v.z = data_ov077_02127a5c.z;
+    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x144, v);
+    if (*(int *)(c + 0x168) == 0) return;
+    a = (char *)_ZN8dActor_c10FindWithIDEj(*(int *)(c + 0x168));
+    if (a == 0) return;
+    t = (*(unsigned short *)(a + 0xc) == 0xbf);
+    if (t == 0) return;
+    if (*(unsigned char *)(a + 0x6f9) == 1) return;
+    if (*(unsigned char *)(a + 0x703) == 1) return;
+    t = (*(unsigned char *)(a + 0x709) != 0);
+    if (t == 1) return;
+    if (_ZN6Player12GetHurtStateEv(a) >= 0) return;
+    if (_ZN6Player15IsCollectingCapEv(a) != 0) return;
+    *(int *)(c + 0x400) = (int)a;
+    func_ov077_02126d5c(c, &data_ov077_02127cd8);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- func_ov077_02126300, 0x02126300, size 0x228 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+/* (Vector3: real header type in scope) */
+
+typedef struct RaycastLine {
+    char pad[0x78];
+} RaycastLine;
+
+extern signed char data_0209f2f8;
+extern char data_020a0e68[];
+
+extern void _ZN11RaycastLineC1Ev(void *self);
+extern void _ZN11RaycastLineD1Ev(void *self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P8dActor_c(
+    void *self, Vector3 *a, Vector3 *b, void *actor);
+extern int _ZN11RaycastLine10DetectClsnEv(void *self);
+extern void Matrix4x3_FromRotationY(void *m, int angle);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, int angle);
+extern void MulVec3Mat4x3(void *in, void *m, void *out);
+
+int func_ov077_02126300(void *vc)
+{
+    char *c = (char *)vc;
+    RaycastLine ray1;
+    RaycastLine ray2;
+    Vector3 start;
+    Vector3 end;
+    Vector3 dir;
+    Vector3 out;
+    int y;
+
+    if (data_0209f2f8 == 0x2a) {
+        _ZN11RaycastLineC1Ev(&ray1);
+        _ZN11RaycastLineC1Ev(&ray2);
+
+        start.x = 0;
+        start.y = 0;
+        start.z = 0;
+        end.x = 0;
+        end.y = 0;
+        end.z = 0;
+        dir.x = 0;
+        dir.y = 0;
+        dir.z = 0;
+        out.x = 0;
+        out.y = 0;
+        out.z = 0;
+
+        start.x = *(int *)(c + 0x5c);
+        y = *(int *)(c + 0x60);
+        start.y = y;
+        start.z = *(int *)(c + 0x64);
+        start.y = y + 0x28000;
+        dir.z = 0xc8000;
+        Matrix4x3_FromRotationY(data_020a0e68, *(short *)(c + 0x8e));
+        MulVec3Mat4x3(&dir, data_020a0e68, &out);
+        {
+            int sx = start.x;
+            int ox = out.x;
+            int sy = start.y;
+            int sz = start.z;
+            int oy;
+            int oz;
+            end.x = sx;
+            end.x = sx + ox;
+            oy = out.y;
+            oz = out.z;
+            end.y = sy;
+            end.y = sy + oy;
+            end.z = sz;
+            end.z = sz + oz;
+        }
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P8dActor_c(&ray1, &start, &end, c);
+
+        start.x = *(int *)(c + 0x5c);
+        y = *(int *)(c + 0x60);
+        start.y = y;
+        start.z = *(int *)(c + 0x64);
+        start.y = y + 0x28000;
+        dir.x = 0;
+        dir.y = 0;
+        dir.z = 0x2c000;
+        Matrix4x3_FromRotationY(data_020a0e68, *(short *)(c + 0x8e));
+        Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, 0x3000);
+        MulVec3Mat4x3(&dir, data_020a0e68, &out);
+        {
+            int sx = start.x;
+            int ox = out.x;
+            int sy = start.y;
+            int sz = start.z;
+            int oy;
+            int oz;
+            end.x = sx;
+            end.x = sx + ox;
+            oy = out.y;
+            oz = out.z;
+            end.y = sy;
+            end.y = sy + oy;
+            end.z = sz;
+            end.z = sz + oz;
+        }
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P8dActor_c(&ray2, &start, &end, c);
+
+        if (_ZN11RaycastLine10DetectClsnEv(&ray1) != 0 ||
+            _ZN11RaycastLine10DetectClsnEv(&ray2) == 0) {
+            *(int *)(c + 0x5c) = *(int *)(c + 0x410);
+            *(int *)(c + 0x60) = *(int *)(c + 0x414);
+            *(int *)(c + 0x64) = *(int *)(c + 0x418);
+            *(int *)(c + 0x98) = 0;
+            _ZN11RaycastLineD1Ev(&ray2);
+            _ZN11RaycastLineD1Ev(&ray1);
+            return 1;
+        }
+        _ZN11RaycastLineD1Ev(&ray2);
+        _ZN11RaycastLineD1Ev(&ray1);
+    }
+    return 0;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- _ZN7HeaveHoD0Ev, 0x0212629c, size 0x64 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN7HeaveHoD0Ev
+/* recovered: real C++ deleting destructor -- the compiler emits the whole body
+ *
+ * D0 is the DELETING destructor: destroy through this class and its bases, then
+ * return the object to its heap. Declaring `~HeaveHo()` is enough -- mwcc emits
+ * D2, D0 and D1 together and objisolate keeps the one this file is bound to.
+ *
+ * The deallocation is an inline operator delete -- dEnemyBase_c's, reachable because
+ * dEnemyBase_c is this class's IMMEDIATE base.
+ */
+#include "HeaveHo.h"
+
+/* (no separate definition: the single ~HeaveHo() below emits the D0 and
+ * D1 variants together; mwccarm orders the variant group itself.) */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN7HeaveHoD1Ev, 0x0212624c, size 0x50 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN7HeaveHoD1Ev
+/* recovered: real C++ destructor -- the compiler emits the whole body
+ *
+ * One vtable store and a destructor call per member, every one a consequence of
+ * `struct HeaveHo : dEnemyBase_c` and the members that declaration types, destroyed in
+ * reverse declaration order, then dEnemyBase_c::~dEnemyBase_c.
+ *
+ * This body is the evidence for the header: each member's size closes exactly
+ * on the next one's offset.
+ */
+#include "HeaveHo.h"
+
+HeaveHo::~HeaveHo()
+{
+}
+

--- a/src_tu/actors/Lakitu.cpp
+++ b/src_tu/actors/Lakitu.cpp
@@ -1,0 +1,1012 @@
+//cpp
+/* HAND-ASSEMBLED translation unit -- ov077/Lakitu (32 function(s)).
+ * tubuild create refused this TU (legacy bodies wrapped in extern "C" { }),
+ * so this is a raw concatenation of the complete legacy files in REVERSE
+ * ROM order (mwccarm emits one .text section per function in the reverse
+ * of source order). Conflicting declarations were reconciled by hand; see
+ * the manifest notes.
+ *
+ * Assembled from these legacy one-function sources (ROM address order):
+ *   [0] 0x02123740  src/_ZN6LakituD1Ev.cpp
+ *   [1] 0x02123798  src/_ZN6LakituD0Ev.cpp
+ *   [2] 0x02123804  src/_ZN6Lakitu13OnYoshiTryEatEv.cpp
+ *   [3] 0x0212380c  src/_ZN6Lakitu16OnAimedAtWithEggEv.cpp
+ *   [4] 0x02123814  src/func_ov077_02123814.c
+ *   [5] 0x02123880  src/func_ov077_02123880.c
+ *   [6] 0x021238bc  src/func_ov077_021238bc.cpp
+ *   [7] 0x0212390c  src/func_ov077_0212390c.cpp
+ *   [8] 0x02123a1c  src/func_ov077_02123a1c.cpp
+ *   [9] 0x02123a74  src/func_ov077_02123a74.cpp
+ *   [10] 0x02123c6c  src/func_ov077_02123c6c.cpp
+ *   [11] 0x02123d40  src/func_ov077_02123d40.cpp
+ *   [12] 0x02123fcc  src/func_ov077_02123fcc.c
+ *   [13] 0x02124038  src/func_ov077_02124038.cpp
+ *   [14] 0x02124118  src/func_ov077_02124118.cpp
+ *   [15] 0x021241ac  src/func_ov077_021241ac.c
+ *   [16] 0x021242f0  src/func_ov077_021242f0.c
+ *   [17] 0x02124394  src/func_ov077_02124394.c
+ *   [18] 0x021243c0  src/func_ov077_021243c0.cpp
+ *   [19] 0x021244d4  src/func_ov077_021244d4.cpp
+ *   [20] 0x02124564  src/func_ov077_02124564.c
+ *   [21] 0x02124698  src/func_ov077_02124698.c
+ *   [22] 0x02124718  src/func_ov077_02124718.cpp
+ *   [23] 0x02124754  src/func_ov077_02124754.cpp
+ *   [24] 0x0212478c  src/func_ov077_0212478c.c
+ *   [25] 0x021247a8  src/_ZN6Lakitu16CleanupResourcesEv.cpp
+ *   [26] 0x02124824  src/_ZN6Lakitu16OnPendingDestroyEv.cpp
+ *   [27] 0x02124828  src/_ZN6Lakitu6RenderEv.cpp
+ *   [28] 0x021248b8  src/_ZN6Lakitu8BehaviorEv.cpp
+ *   [29] 0x02124908  src/_ZN6Lakitu13InitResourcesEv.cpp
+ *   [30] 0x02124aa4  src/_ZN6Lakitu13OnTurnIntoEggER6Player.cpp
+ *   [31] 0x02124b04  src/Lakitu_Spawn.c
+ */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 31 -- Lakitu_Spawn, 0x02124b04, size 0x60 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol Lakitu_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Lakitu */
+int *Lakitu_Spawn(void)
+{
+    int *p = (int *)_ZN7fBase_cnwEj(1056);
+    if (p) {
+        _ZN8dActor_cC2Ev(p);
+        p[0] = (int)&_ZTV6Lakitu[2]; /* +8: this TU defines the vtable */
+        _ZN9ModelAnimC1Ev((char *)p + 0xd4);
+        _ZN5ModelC1Ev((char *)p + 0x138);
+        _ZN11ShadowModelC1Ev((char *)p + 0x188);
+        _ZN15TextureSequenceC1Ev((char *)p + 0x1b0);
+        _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x1c4);
+        _ZN12WithMeshClsnC1Ev((char *)p + 0x204);
+    }
+    return p;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 30 -- _ZN6Lakitu13OnTurnIntoEggER6Player, 0x02124aa4, size 0x60 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu13OnTurnIntoEggER6Player
+/* daJgm_c::OnTurnIntoEgg -- vtable slot 19, recovered from vtable slot identity.
+ * Gives the player 5 coins (as cap-collection coins if Yoshi is wearing the cap,
+ * otherwise as egg coins), then kills this actor and tracks it in the death table. */
+#include "Lakitu.h"
+#include "Player.h"
+
+int Lakitu::OnTurnIntoEgg(Player &player)
+{
+    if (player.IsCollectingCap())
+        GivePlayerCoins(player, 5, 0);
+    else
+        player.RegisterEggCoinCount(5, 0, 0);
+    KillAndTrackInDeathTable();
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 29 -- _ZN6Lakitu13InitResourcesEv, 0x02124908, size 0x19c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Lakitu.h"
+#include "TextureSequence.h"
+extern "C" {
+extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
+extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
+extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *f);
+extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *f);
+extern int _ZN11ShadowModel12InitCylinderEv(void *self);
+extern void _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(void *self, void *a, void *v, int b, int c, unsigned int d, unsigned int e);
+extern void _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *self, void *a, int b, int c, void *d, void *e);
+extern void func_ov077_02123d40(void *c);
+extern int data_ov077_02127b38[];
+extern int data_ov077_02127b48[];
+extern int data_ov077_02127b88[];
+struct M48 { int w[12]; };
+extern M48 data_02082128;
+}
+
+int Lakitu::InitResources()
+{
+    _ZN5Model8LoadFileER13SharedFilePtr(data_ov077_02127b38);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov077_02127b50), 1, 1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x138, _ZN5Model8LoadFileER13SharedFilePtr(data_ov077_02127b48), 1, 1);
+    for (int i = 0; i < 2; i++)
+        _ZN9Animation8LoadFileER13SharedFilePtr((void *)data_ov077_02127238[i]);
+    for (int i = 0; i < 2; i++) {
+        void *t = (void *)data_ov077_02127230[i];
+        _ZN15TextureSequence8LoadFileER13SharedFilePtr(t);
+        TextureSequence::Prepare(*(BMD_File *)data_ov077_02127b50[1], *(BTP_File *)((int *)t)[1]);
+    }
+    if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0)
+        return 0;
+    _ZN25MovingCylinderClsnWithPos4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(((char *)this) + 0x1c4, ((char *)this), data_ov077_02127b88, 0x41000, 0x78000, 0x200002, 0x6eff0);
+    _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x204, ((char *)this), 0x2d000, 0x2d000, 0, 0);
+
+    *(int *)(((int)((char *)this + 0x9c)) & 0xFFFFFFFFFFFFFFFFLL) = 0;
+    *(int *)(((int)((char *)this + 0xa0)) & 0xFFFFFFFFFFFFFFFFLL) = 0;
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    *(int *)(((int)((char *)this + 0x3f8)) & 0xFFFFFFFFFFFFFFFFLL) = *(int *)(((int)((char *)this + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    *(int *)(((int)((char *)this + 0x3fc)) & 0xFFFFFFFFFFFFFFFFLL) = *(int *)(((int)((char *)this + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+    unk_400 = *(int *)(((int)((char *)this + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    unk_410 = 0;
+
+    func_ov077_0212478c(((char *)this));
+    *(M48 *)((char *)&unk_3c0) = data_02082128;
+    func_ov077_02123d40(((char *)this));
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 28 -- _ZN6Lakitu8BehaviorEv, 0x021248b8, size 0x50 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Lakitu.h"
+extern "C" {
+extern int _ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(void*, int);
+extern void func_ov077_02123d40(void*);
+}
+
+int Lakitu::Behavior()
+{
+  int v = param1;
+  if(_ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(((char *)this), v ? 0x1068000 : 0x7d0000)) return 1;
+  func_ov077_02124718(((char *)this));
+  func_ov077_02123d40(((char *)this));
+  return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 27 -- _ZN6Lakitu6RenderEv, 0x02124828, size 0x90 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Lakitu.h"
+struct ModelComponents;
+
+int Lakitu::Render()
+{
+    int b = (int)((mFlags & 0x40000) != 0);
+    if (b != 0)
+        return 1;
+    mTextureSequence.Update(*(ModelComponents *)((char *)this + 0xdc));
+    mModelAnim.Render(0);
+    if (unk_3f4 == 1) {
+        unsigned int v = ((unsigned int)(*(s32 *)((char *)this + 0x12c) << 4)) >> 0x10;
+        if (v >= 0x19 && v <= 0x3a)
+            mModel.Render(0);
+    }
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 26 -- _ZN6Lakitu16OnPendingDestroyEv, 0x02124824, size 0x4 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu16OnPendingDestroyEv
+
+#include "Lakitu.h"
+
+void Lakitu::OnPendingDestroy()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 25 -- _ZN6Lakitu16CleanupResourcesEv, 0x021247a8, size 0x7c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu16CleanupResourcesEv
+
+#include "Lakitu.h"
+#include "SharedFilePtr.h"
+
+int Lakitu::CleanupResources()
+{
+    ((SharedFilePtr *)data_ov077_02127b50)->Release();
+    ((SharedFilePtr *)data_ov077_02127b48)->Release();
+    ((SharedFilePtr *)data_ov077_02127b38)->Release();
+
+    for (int i = 0; i < 2; i++)
+        ((SharedFilePtr *)data_ov077_02127238[i])->Release();
+
+    for (int i = 0; i < 2; i++)
+        ((SharedFilePtr *)data_ov077_02127230[i])->Release();
+
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 24 -- func_ov077_0212478c, 0x0212478c, size 0x1c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern char data_ov077_02127bc4[];
+extern void func_ov077_02124754(void* c);
+
+namespace two_arg_478c { extern "C" void func_ov077_0212478c(void* vc, int i) {
+    char* c = (char*)vc;
+    *(char**)(c + 0x3f0) = data_ov077_02127bc4 + (i << 4);
+    func_ov077_02124754(c);
+} }
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 23 -- func_ov077_02124754, 0x02124754, size 0x38 */
+/* -------------------------------------------------------------------------- */
+struct C; typedef void (C::*PMF)();
+struct C { char pad[0x3f0]; PMF *pp; };
+extern "C" void func_ov077_02124754(void *vc) { C *c = (C *)vc; PMF *p = c->pp; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 22 -- func_ov077_02124718, 0x02124718, size 0x3c */
+/* -------------------------------------------------------------------------- */
+/* (struct C / PMF: defined once at ordinal 23 above) */
+extern "C" int func_ov077_02124718(void *vc) { C *c = (C *)vc; PMF *p = c->pp + 1; (c->**p)(); } /* int per decl_common; no value returned, matching the ROM */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 21 -- func_ov077_02124698, 0x02124698, size 0x80 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern int data_ov077_02127b28[];
+extern int data_ov077_02127b20[];
+int func_ov077_02124698(char* c){
+  *(int*)(c+0x98)=0xc000;
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((char*)c+0xd4, (void*)data_ov077_02127b28[1], 0, 0x1000, 0);
+  *(int*)(c+0x130)=0x1000;
+  _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj((char*)c+0x1b0, (void*)data_ov077_02127b20[1], 0, 0x1000, 0);
+  *(int*)(c+0x1bc)=0x1000;
+  *(unsigned char*)(c+0x41c)=0x96;
+  *(int*)(c+0x3f4)=0;
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 20 -- func_ov077_02124564, 0x02124564, size 0x134 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov077_02124564
+/* recovered: shared common types */
+#include "common.h"
+extern unsigned char DecIfAbove0_Byte(unsigned char* p);
+void* _ZN8dActor_c22ClosestNonVanishPlayerEv(void* p);
+int Vec3_HorzDist(void* a, void* b);
+int func_ov077_02123880(void* c);
+namespace two_arg_478c { extern "C" void func_ov077_0212478c(void* c, int i); } /* decl_common carries a 1-arg view of this name that Lakitu::InitResources's call byte-requires; the namespace keeps this block's true 2-arg view out of its way (both bind the same C symbol) */
+void func_ov077_0212390c(char* c);
+void func_ov077_02123814(char* c);
+void _ZN9Animation7AdvanceEv(void* p);
+void func_ov077_02123a74(void* thiz);
+void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* thiz, const struct Vector3* v);
+void _ZN12CylinderClsn5ClearEv(void* p);
+void _ZN12CylinderClsn6UpdateEv(void* p);
+unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3s(unsigned int a, unsigned int b, unsigned int c, const struct Vector3* pos, unsigned int e);
+
+extern int data_ov077_02127b88[3];
+
+int func_ov077_02124564(char* c) {
+    *(int*)(c + 0x98) = 0xc000;
+    if (DecIfAbove0_Byte((unsigned char*)(c + 0x41c)) == 0) {
+        char* p = (char*)_ZN8dActor_c22ClosestNonVanishPlayerEv(c);
+        if (p == 0) goto store2;
+        if (*(int*)(p + 0x60) >= *(int*)(c + 0x60)) goto store1;
+        if (Vec3_HorzDist((struct Vector3*)(c + 0x5c), (struct Vector3*)(p + 0x5c)) >= 0x190000) goto store1;
+        if (func_ov077_02123880(c) >= 4) goto store1;
+        two_arg_478c::func_ov077_0212478c(c, 1);
+        goto tail;
+    store1:
+        *(unsigned char*)(c + 0x41c) = 0x96;
+        goto tail;
+    store2:
+        *(unsigned char*)(c + 0x41c) = 0x96;
+    }
+tail:
+    func_ov077_0212390c(c);
+    func_ov077_02123814(c);
+    _ZN9Animation7AdvanceEv(c + 0x124);
+    _ZN9Animation7AdvanceEv(c + 0x1b0);
+    func_ov077_02123a74(c);
+    {
+        struct Vector3 pos;
+        pos.y = data_ov077_02127b88[1] + *(int*)(c + 0x414);
+        pos.x = data_ov077_02127b88[0];
+        pos.z = data_ov077_02127b88[2];
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x1c4, &pos);
+    }
+    _ZN12CylinderClsn5ClearEv(c + 0x1c4);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1c4);
+    *(int*)(c + 0x410) = _ZN5Sound8PlayLongEjjjRK7Vector3s(*(int*)(c + 0x410), 3, 0x182, (struct Vector3*)(c + 0x74), 0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 19 -- func_ov077_021244d4, 0x021244d4, size 0x90 */
+/* -------------------------------------------------------------------------- */
+struct BCA_File;
+struct BTP_File;
+/* (ModelAnim/Animation/TextureSequence: real header types in scope. The calls
+   below stay on the hand-mangled spellings with int in place of the by-value
+   Fix12<int>, which mwccarm passes differently -- see notes/mwccarm-codegen.md
+   6az; the real member declarations would break the byte match.) */
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+
+
+extern void *data_ov077_02127b40[];
+extern void *data_ov077_02127b30[];
+
+extern "C" void func_ov077_021244d4(char *c)
+{
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim *)(c + 0xd4), (BCA_File *)data_ov077_02127b40[1], 0, 0x1000, 0);
+    ((Animation *)(c + 0x124))->SetFlags(0x40000000);
+    *(int *)(c + 0x130) = 0x1000;
+    *(int *)(c + 0x12c) = 0;
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj((TextureSequence *)(c + 0x1b0), (void*)data_ov077_02127b30[1], 0, 0x1000, 0);
+    ((Animation *)(c + 0x1b0))->SetFlags(0x40000000);
+    *(int *)(c + 0x1bc) = 0x1000;
+    *(int *)(c + 0x1b8) = 0;
+    *(int *)(c + 0x3f4) = 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- func_ov077_021243c0, 0x021243c0, size 0x114 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_021243c0
+/* recovered: shared common types */
+#include "common.h"
+typedef int Fix12i;
+
+extern "C" {
+int _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(unsigned int, unsigned int, struct Vector3*, void*, int, int);
+void func_0201267c(int a, void* p);
+int _ZN9Animation8FinishedEv(void* self);
+namespace two_arg_478c { extern "C" void func_ov077_0212478c(void* c, int i); }
+void func_ov077_0212390c(char* c);
+void func_ov077_02123814(char* c);
+void _ZN9Animation7AdvanceEv(void* self);
+void func_ov077_02123a74(void* c);
+void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* self, const struct Vector3* v);
+void _ZN12CylinderClsn5ClearEv(void* self);
+void _ZN12CylinderClsn6UpdateEv(void* self);
+unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3s(unsigned int a, unsigned int b, unsigned int c, const struct Vector3* v, unsigned int d);
+extern int data_ov077_02127b88[];
+
+int func_ov077_021243c0(char* c){
+    if ((((unsigned int)*(int*)(c + 0x12c) << 4) >> 16) == 0x3a) {
+        _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(
+            0x104, 0, (struct Vector3*)(c + 0x404), (void*)(c + 0x8c),
+            *(signed char*)(c + 0xcc), -1);
+        func_0201267c(0xd2, c + 0x74);
+    }
+    if (_ZN9Animation8FinishedEv(c + 0x124)) {
+        two_arg_478c::func_ov077_0212478c(c, 0);
+    }
+    func_ov077_0212390c(c);
+    func_ov077_02123814(c);
+    _ZN9Animation7AdvanceEv(c + 0x124);
+    _ZN9Animation7AdvanceEv(c + 0x1b0);
+    func_ov077_02123a74(c);
+    {
+        int* d = data_ov077_02127b88;
+        int off = *(int*)(c + 0x414);
+        int z = d[2];
+        int y = d[1] + off;
+        int x = d[0];
+        struct Vector3 v;
+        v.x = x; v.y = y; v.z = z;
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x1c4, &v);
+    }
+    _ZN12CylinderClsn5ClearEv(c + 0x1c4);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1c4);
+    *(int*)(c + 0x410) = _ZN5Sound8PlayLongEjjjRK7Vector3s(
+        *(unsigned int*)(c + 0x410), 3, 0x182, (const struct Vector3*)(c + 0x74), 0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- func_ov077_02124394, 0x02124394, size 0x2c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN12CylinderClsn5ClearEv(void *);
+int func_ov077_02124394(char *c)
+{
+    *(int *)(c + 0x98) = 0;
+    _ZN12CylinderClsn5ClearEv((char *)c + 0x1c4);
+    *(int *)(c + 0x3f4) = 2;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- func_ov077_021242f0, 0x021242f0, size 0xa4 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+namespace two_arg_478c { extern "C" void func_ov077_0212478c(void* c, int i); } /* decl_common carries a 1-arg view of this name that Lakitu::InitResources's call byte-requires; the namespace keeps this block's true 2-arg view out of its way (both bind the same C symbol) */
+
+int func_ov077_021242f0(char *c)
+{
+    if (((*(int *)(c + 0xb0) & 0x40000) ? 1 : 0) != 0)
+    {
+        char *p = *(char **)(c + 0xd0);
+        int *src = (int *)(p + 0x5c);
+        *(int *)(c + 0x5c) = src[0];
+        *(int *)(c + 0x60) = src[1];
+        *(int *)(c + 0x64) = src[2];
+    }
+    {
+        int flags = *(int *)(c + 0xb0);
+        if (((flags & 0x80000) ? 1 : 0) != 0)
+        {
+            two_arg_478c::func_ov077_0212478c(c, 3);
+        }
+        else if (((flags & 0x20000) ? 1 : 0) == 0 && ((flags & 0x40000) ? 1 : 0) == 0)
+        {
+            two_arg_478c::func_ov077_0212478c(c, 0);
+        }
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- func_ov077_021241ac, 0x021241ac, size 0x144 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+#include "types.h"
+extern s16 data_02082214[];
+#define LA(p) ((int)(p))
+
+int func_ov077_021241ac(char *o)
+{
+
+    char *d0; int *a5c; int *a60; int *a64; int *src;
+    char *p400; int three; int k; s16 s; s16 cval; int v7000; int v1e;
+
+    *(int *)LA(o + 0xb0) &= ~0x80000;
+
+    d0 = *(char **)(o + 0xd0);
+    a5c = (int *)LA(o + 0x5c);
+    *(int *)(o + 0x98) = *(int *)(d0 + 0x98) + 0xa000;
+
+    d0 = *(char **)(o + 0xd0);
+    a60 = (int *)LA(o + 0x60);
+    a64 = (int *)LA(o + 0x64);
+    *(s16 *)(o + 0x94) = *(s16 *)(d0 + 0x8e);
+
+    d0 = *(char **)(o + 0xd0);
+
+    v7000 = 0x7000;
+    src = (int *)LA(d0 + 0x5c);
+    *(int *)(o + 0x5c) = src[0];
+    p400 = o + 0x400;
+    v1e = 0x1e;
+    *(int *)(o + 0x60) = src[1];
+    *(int *)(o + 0x64) = src[2];
+    three = 3;
+
+
+    k = ((int)*(u16 *)(o + 0x94)) >> 4;
+    s = data_02082214[k * 2];
+    *a5c = *a5c + (int)(((s64)s * 0x50000 + 0x800) >> 12);
+    *a60 = *a60 + 0x50000;
+    k = ((int)*(u16 *)(o + 0x94)) >> 4;
+    cval = data_02082214[k * 2 + 1];
+    *a64 = *a64 + (int)(((s64)cval * 0x50000 + 0x800) >> 12);
+
+    *(s16 *)(p400 + 0x1a) = (s16)v7000;
+    *(u8 *)(o + 0x41c) = (u8)v1e;
+    *(int *)(o + 0xd0) = 0;
+    *(int *)(o + 0x3f4) = three;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- func_ov077_02124118, 0x02124118, size 0x94 */
+/* -------------------------------------------------------------------------- */
+/* (CylinderClsn/dActor_c: real header types in scope) */
+
+void ApproachLinear2(short &v, short t, short step);
+extern "C" unsigned char DecIfAbove0_Byte(unsigned char *p);
+extern "C" void func_ov077_02123c6c(char *c, void *p);
+extern "C" void func_ov077_02123a74(void *c);
+namespace two_arg_478c { extern "C" void func_ov077_0212478c(void* c, int i); } /* decl_common carries a 1-arg view of this name that Lakitu::InitResources's call byte-requires; the namespace keeps this block's true 2-arg view out of its way (both bind the same C symbol) */
+
+extern "C" int func_ov077_02124118(char *c)
+{
+    *(short *)(c + 0x8e) = (short)(*(short *)(c + 0x8e) + *(short *)(c + 0x41a));
+    ApproachLinear2(*(short *)(c + 0x41a), 0, 0x300);
+    ((dActor_c *)c)->UpdatePos((CylinderClsn *)(c + 0x1c4));
+    func_ov077_02123c6c(c, (void *)(c + 0x204));
+    func_ov077_02123a74(c);
+    ((CylinderClsn *)(c + 0x1c4))->Clear();
+    ((CylinderClsn *)(c + 0x1c4))->Update();
+    if (!DecIfAbove0_Byte((unsigned char *)(c + 0x41c)))
+        two_arg_478c::func_ov077_0212478c(c, 0);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- func_ov077_02124038, 0x02124038, size 0xe0 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02124038
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
+}
+
+struct Base {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void v5();
+    virtual void v6();
+    virtual void v7();
+    virtual void v8();
+    virtual void v9();
+    virtual void v10();
+    virtual void v11();
+    virtual void v12();
+    virtual void v13();
+    virtual void v14();
+    virtual void v15();
+    virtual void v16();
+    virtual void v17();
+    virtual void v18();
+    virtual void v19();
+    virtual void v20();
+    virtual void v21();
+    virtual void v22();
+    virtual void v23();
+    virtual void v24();
+    virtual void v25();
+    virtual void v26();
+    virtual void v27();
+    virtual void v28();
+    virtual int m();   // slot 0x74/4 = 29
+};
+
+extern "C" int func_ov077_02124038(char* c)
+{
+    _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
+    *(int*)(c + 0x9c) = -0x2000;
+    *(int*)(c + 0xa0) = -0x3c000;
+    *(int*)(c + 0x98) = 0xa000;
+    *(int*)(c + 0xa8) = 0x28000;
+    *(unsigned char*)(c + 0x41c) = 0x2d;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, *(void**)((char*)data_ov077_02127b28 + 4), 0, 0x1000, 0);
+    *(int*)(c + 0x130) = 0x4000;
+    Base* b = (Base*)c;
+    int r1 = b->m();
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x43, *(int*)(c + 0x5c), *(int*)(c + 0x60) + r1, *(int*)(c + 0x64));
+    int r2 = b->m();
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x44, *(int*)(c + 0x5c), *(int*)(c + 0x60) + r2, *(int*)(c + 0x64));
+    *(int*)(c + 0x3f4) = 4;
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- func_ov077_02123fcc, 0x02123fcc, size 0x6c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN9Animation7AdvanceEv(void *);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void *, void *);
+extern int WithMeshClsn_UpdateDiscreteNoLava_veneer(void *);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *);
+extern unsigned char DecIfAbove0_Byte(unsigned char *);
+extern void func_ov077_02123a1c(char* c);
+int func_ov077_02123fcc(char* c){
+    *(short*)((char*)c+0x8c)=*(short*)((char*)c+0x8c)-0x1000;
+    _ZN9Animation7AdvanceEv((char*)c+0x124);
+    _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, (char*)c+0x1c4);
+    WithMeshClsn_UpdateDiscreteNoLava_veneer((char*)c+0x204);
+    if(!_ZNK12WithMeshClsn13JustHitGroundEv((char*)c+0x204)){
+        if(DecIfAbove0_Byte((unsigned char*)c+0x41c)) goto end;
+    }
+    func_ov077_02123a1c(c);
+end:
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov077_02123d40, 0x02123d40, size 0x28c */
+/* -------------------------------------------------------------------------- */
+#include "types.h"
+typedef struct Mtx43 { int w[12]; } Mtx43;
+
+extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
+extern "C" void Matrix4x3_ApplyInPlaceToTranslation(void* m, int x, int y, int z);
+extern "C" void Matrix4x3_ApplyInPlaceToRotationX(void* m, s16 angX);
+extern "C" void Matrix4x3_ApplyInPlaceToRotationY(void* m, s16 angY);
+extern "C" void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+    void* c, void* shadow, void* mtx, int rad, int height, u32 flags);
+extern "C" void MulMat4x3Mat4x3(void* a, void* b, void* out);
+extern "C" void Vec3_LslInPlace(void* v, int sh);
+extern "C" void Vec3_Asr(void* d, void* s, int sh);
+extern "C" void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
+
+extern Mtx43 data_020a0e68;
+
+struct VObj {
+    virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
+    virtual void v04(); virtual void v05(); virtual void v06(); virtual void v07();
+    virtual void v08(); virtual void v09(); virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(); virtual int  m29();  // slot 0x74 = index 29
+};
+
+extern "C" void func_ov077_02123d40(void* vc)
+{
+    char* c = (char*)vc;
+    int b = (int)((*(u32*)(c + 0xb0) & 0x40000) != 0);
+    if (b)
+        return;
+
+    Matrix4x3_FromRotationY(c + 0xf0, *(s16*)(c + 0x8e));
+    *(int*)(c + 0x114) = *(int*)(c + 0x5c) >> 3;
+    *(int*)(c + 0x118) = (*(int*)(c + 0x60) + *(int*)(c + 0x414)) >> 3;
+    *(int*)(c + 0x11c) = *(int*)(c + 0x64) >> 3;
+
+    if (*(int*)(c + 0x3f4) == 4) {
+        data_020a0e68 = *(Mtx43*)(c + 0xf0);
+        int y1 = ((VObj*)c)->m29() >> 3;
+        Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, y1, 0);
+        Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(s16*)(c + 0x8c));
+        int y2 = (-((VObj*)c)->m29()) >> 3;
+        Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, y2, 0);
+        *(Mtx43*)(c + 0xf0) = data_020a0e68;
+    }
+
+    *(int*)(c + 0x3e4) = *(int*)(c + 0x5c) >> 3;
+    *(int*)(c + 0x3e8) = *(int*)(c + 0x60) >> 3;
+    *(int*)(c + 0x3ec) = *(int*)(c + 0x64) >> 3;
+
+    _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+        c, c + 0x188, c + 0x3c0, 0x5a000, 0x320000, 0xf);
+
+    if (*(int*)(c + 0x3f4) != 1)
+        return;
+
+    u32 t = (u32)(*(int*)(c + 0x12c) << 4) >> 0x10;
+    if (t < 0x19)
+        return;
+    if (t > 0x3a)
+        return;
+
+    struct { int t[3]; int v[3]; } lv;
+    lv.t[0] = -0x2000;
+    lv.t[1] = 0x1800;
+    lv.t[2] = 0x1000;
+
+    data_020a0e68 = *(Mtx43*)(c + 0xf0);
+    MulMat4x3Mat4x3(*(char**)(c + 0xe8) + 0x90, &data_020a0e68, &data_020a0e68);
+
+    *(int*)(c + 0x404) = data_020a0e68.w[9];
+    *(int*)(c + 0x408) = data_020a0e68.w[10];
+    *(int*)(c + 0x40c) = data_020a0e68.w[11];
+
+    Vec3_LslInPlace(c + 0x404, 3);
+
+    Vec3_Asr(lv.v, c + 0x404, 3);
+
+    Matrix4x3_FromTranslation(&data_020a0e68, lv.v[0], lv.v[1], lv.v[2]);
+    Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(s16*)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, lv.t[0], lv.t[1], lv.t[2]);
+
+    *(Mtx43*)(c + 0x154) = data_020a0e68;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov077_02123c6c, 0x02123c6c, size 0xd4 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02123c6c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+
+struct RG { char buf[0x54]; };
+extern int WithMeshClsn_UpdateDiscreteNoLava_veneer(void* w);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void* w);
+extern int _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* s, struct Vector3* v);
+extern int _ZN13RaycastGroundC1Ev(struct RG* r);
+extern int _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(struct RG* r, struct Vector3* v, void* a);
+extern int _ZN4BgCh19StartDetectingWaterEv(struct RG* r);
+extern int _ZN13RaycastGround10DetectClsnEv(struct RG* r);
+extern int _ZN4BgCh18StopDetectingWaterEv(struct RG* r);
+extern int _ZN13RaycastGroundD1Ev(struct RG* r);
+void func_ov077_02123c6c(char* c, void* w){
+  struct Vector3 nrm;
+  struct Vector3 pos;
+  struct RG rg;
+  WithMeshClsn_UpdateDiscreteNoLava_veneer(w);
+  if (_ZNK12WithMeshClsn8IsOnWallEv(w) != 0) {
+    _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)_ZNK12WithMeshClsn13GetWallResultEv(w) + 4, &nrm);
+    *(unsigned char*)(((int)c + 0x41d)) ^= 1;
+  }
+  pos.x = *(int*)(c+0x5c);
+  pos.y = *(int*)(c+0x60);
+  pos.z = *(int*)(c+0x64);
+  pos.y += 0x64000;
+  _ZN13RaycastGroundC1Ev(&rg);
+  _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(&rg, &pos, 0);
+  _ZN4BgCh19StartDetectingWaterEv(&rg);
+  if (_ZN13RaycastGround10DetectClsnEv(&rg) != 0) {
+    int yy = *(int*)((char*)&rg + 0x44) + 0x3c000;
+    if (*(int*)(c+0x60) < yy) *(int*)(c+0x60) = yy;
+  }
+  _ZN4BgCh18StopDetectingWaterEv(&rg);
+  _ZN13RaycastGroundD1Ev(&rg);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov077_02123a74, 0x02123a74, size 0x1f8 */
+/* -------------------------------------------------------------------------- */
+extern "C" int _ZN8dActor_c7FindEggER12CylinderClsn(void *self, void *clsn); /* decl_Actor.h view */
+extern "C" void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, const Vector3& pos);
+extern "C" void func_ov077_02123a1c(char *c); /* aligned to the TU decl */
+extern "C" void *_ZN8dActor_c10FindWithIDEj(unsigned int id);
+extern "C" int _ZN8dActor_c24BumpedUnderneathByPlayerER6Player(void *self, void *player);
+extern "C" int _ZN6Player9IsOnShellEv(void *p);
+extern "C" short Vec3_HorzAngle(void *a, void *b);
+extern "C" void _ZN6Player16IncMegaKillCountEv(void *p);
+extern "C" int _ZN8dActor_c16JumpedOnByPlayerER12CylinderClsnR6Player(void *self, void *clsn, void *player);
+extern "C" void _ZN6Player6BounceE5Fix12IiE(void *p, int fix);
+extern "C" void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *self, void *pos, unsigned int a, int fix, unsigned int b, unsigned int cc, unsigned int d);
+namespace two_arg_478c { extern "C" void func_ov077_0212478c(void* c, int i); } /* decl_common carries a 1-arg view of this name that Lakitu::InitResources's call byte-requires; the namespace keeps this block's true 2-arg view out of its way (both bind the same C symbol) */
+
+extern "C" void func_ov077_02123a74(void *thiz)
+{
+    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *r4;
+    int b;
+
+    if (_ZN8dActor_c7FindEggER12CylinderClsn(c, c + 0x1c4) != 0) {
+        _ZN5Sound9PlayBank0EjRK7Vector3(9, *(const Vector3*)(c + 0x74));
+        func_ov077_02123a1c((char *)c);
+        return;
+    }
+
+    {
+        unsigned int id = *(unsigned int *)(c + 0x1e8);
+        if (id == 0)
+            return;
+        r4 = (unsigned char *)_ZN8dActor_c10FindWithIDEj(id);
+    }
+    if (r4 == 0)
+        return;
+
+    b = (int)(*(unsigned short *)(r4 + 0xc) == 0xbf);
+    if (b == 0)
+        return;
+
+    b = (int)((*(int *)(c + 0xb0) & 0x20000) != 0);
+    if (b != 0) {
+        two_arg_478c::func_ov077_0212478c(c, 2);
+        return;
+    }
+
+    if ((*(int *)(c + 0x1e4) & 0x66fe0)
+        || _ZN8dActor_c24BumpedUnderneathByPlayerER6Player(c, r4) != 0
+        || _ZN6Player9IsOnShellEv(r4) != 0
+        || *(unsigned char *)(r4 + 0x6f9) != 0) {
+        _ZN5Sound9PlayBank0EjRK7Vector3(9, *(const Vector3*)(c + 0x74));
+        func_ov077_02123a1c((char *)c);
+        return;
+    }
+
+    if (*(int *)(c + 0x1e4) & 0x10) {
+        *(short *)(c + 0x94) = Vec3_HorzAngle(r4 + 0x5c, c + 0x5c);
+        *(short *)(c + 0x8e) = (short)(*(short *)(c + 0x94) + 0x8000);
+        _ZN6Player16IncMegaKillCountEv(r4);
+        two_arg_478c::func_ov077_0212478c(c, 4);
+        return;
+    }
+
+    if (_ZN8dActor_c16JumpedOnByPlayerER12CylinderClsnR6Player(c, c + 0x1c4, r4) != 0) {
+        _ZN6Player6BounceE5Fix12IiE(r4, 0x28000);
+        func_ov077_02123a1c((char *)c);
+        return;
+    }
+
+    if (*(int *)(c + 0x3f4) == 3)
+        return;
+
+    {
+        int v[3];
+        v[0] = *(int *)(c + 0x5c);
+        v[1] = *(int *)(c + 0x60);
+        v[2] = *(int *)(c + 0x64);
+        _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(r4, v, 2, 0xc000, 1, 0, 1);
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov077_02123a1c, 0x02123a1c, size 0x58 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02123a1c
+/* recovered: shared common types */
+#include "common.h"
+
+extern "C"{
+void _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(void*,Vector3 const&,unsigned int,int,short);
+void _ZN8dActor_c8PoofDustEv(void*);
+void _ZN8dActor_c24KillAndTrackInDeathTableEv(void*);
+void func_ov077_02123a1c(char* c){
+  Vector3 t; t.x=*(int*)(c+0x5c); t.y=*(int*)(c+0x60); t.z=*(int*)(c+0x64);
+  _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(c,t,5,0x3000,0);
+  _ZN8dActor_c8PoofDustEv(c);
+  _ZN8dActor_c24KillAndTrackInDeathTableEv(c);
+}}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov077_0212390c, 0x0212390c, size 0x110 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+namespace no_arg_cnvp { extern "C" char* _ZN8dActor_c22ClosestNonVanishPlayerEv(); } /* this block byte-requires the zero-arg call (no r0 setup); the TU's file-scope view takes (void*) */
+extern int Vec3_HorzDist(void* a, void* b);
+extern short Vec3_HorzAngle(void* a, void* b);
+extern void _Z14ApproachLinearRsss(void* a, short b, short c);
+extern int func_ov077_021238bc(int unused, int x);
+extern void _Z14ApproachLinearRiii(void* a, int b, int c);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void* a, void* b);
+extern int _ZN9Spindrift8BehaviorEv(void* a, void* b);
+void func_ov077_0212390c(char* c){
+  char* p = no_arg_cnvp::_ZN8dActor_c22ClosestNonVanishPlayerEv();
+  char* tgt;
+  int r6;
+  if(p != 0){
+    r6 = (*(int*)(c+8) != 0) ? 0x1068000 : 0x7d0000;
+    if(Vec3_HorzDist(c+0x3f8, p+0x5c) < r6){
+      int d = *(int*)(c+0x3fc) - *(int*)(p+0x60);
+      if(d < 0) d = -d;
+      if(d < 0x5dc000){ tgt = p+0x5c; goto L64; }
+    }
+    tgt = c+0x3f8;
+  } else {
+    tgt = c+0x3f8;
+  }
+L64:
+  {
+    int hd = Vec3_HorzDist(c+0x5c, tgt);
+    short ha = Vec3_HorzAngle(c+0x5c, tgt);
+    _Z14ApproachLinearRsss(c+0x8e, ha, 0x5e8);
+    if(*(unsigned char*)(c+0x41d) != 0){
+      *(short*)(c+0x94) = *(short*)(c+0x8e) - func_ov077_021238bc((int)c, hd);
+    } else {
+      *(short*)(c+0x94) = *(short*)(c+0x8e) + func_ov077_021238bc((int)c, hd);
+    }
+    _Z14ApproachLinearRiii(c+0x60, *(int*)(tgt+4) + 0x12c000, 0x2000);
+    _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, c+0x1c4);
+    _ZN9Spindrift8BehaviorEv(c, c+0x204);
+  }
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- func_ov077_021238bc, 0x021238bc, size 0x50 */
+/* -------------------------------------------------------------------------- */
+namespace cstd { int fdiv(int,int); }
+extern "C" int func_ov077_021238bc(int unused, int x){
+  if(x>0x190000) return 0;
+  int q=cstd::fdiv(0x4000,0xc8000);
+  long long m=(long long)q*x;
+  m+=0x800;
+  int r=(int)(m>>12);
+  r=0x8000-r;
+  return (short)r;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- func_ov077_02123880, 0x02123880, size 0x3c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern int _ZN8dActor_c15FindWithActorIDEjPS_(unsigned int, void*);
+namespace no_arg_3880 {  /* this definition byte-requires zero parameters; the TU's file-scope view is (void*) -- both bind the same C symbol */
+extern "C" int func_ov077_02123880(void) {
+  int r5 = 0;
+  void* r1 = 0;
+  do {
+    r1 = (void*)_ZN8dActor_c15FindWithActorIDEjPS_(0x104, r1);
+    if (r1) r5++;
+  } while (r1);
+  return r5;
+}
+}  /* namespace no_arg_3880 */
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 4 -- func_ov077_02123814, 0x02123814, size 0x6c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern short data_02082214[];
+void func_ov077_02123814(char* c){
+  unsigned short v = *(unsigned short*)(c+0x418);
+  short s = *(short*)((char*)data_02082214 + ((v>>4)<<2));
+  long long prod = (long long)s * 0x27000;
+  *(int*)(c+0x414) = (int)((prod + 0x800) >> 12);
+  *(short*)(c+0x418) = (short)(*(short*)(c+0x418) + 0x700);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- _ZN6Lakitu16OnAimedAtWithEggEv, 0x0212380c, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu16OnAimedAtWithEggEv
+/* daJgm_c::OnAimedAtWithEgg -- vtable slot 29, recovered from vtable slot identity.
+ * The ROM body ignores `this` and returns a constant. */
+#include "Lakitu.h"
+
+int Lakitu::OnAimedAtWithEgg()
+{
+    return 245760;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- _ZN6Lakitu13OnYoshiTryEatEv, 0x02123804, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6Lakitu13OnYoshiTryEatEv
+/* daJgm_c::OnYoshiTryEat -- vtable slot 18, recovered from vtable slot identity.
+ * The ROM body ignores `this` and returns a constant. */
+#include "Lakitu.h"
+
+int Lakitu::OnYoshiTryEat()
+{
+    return 6;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- _ZN6LakituD0Ev, 0x02123798, size 0x6c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6LakituD0Ev
+
+#include "Lakitu.h"
+
+/* (no separate definition: the single ~Lakitu() below emits the D0 and
+ * D1 variants together; mwccarm orders the variant group itself.) */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN6LakituD1Ev, 0x02123740, size 0x58 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN6LakituD1Ev
+/* recovered: real C++ destructor -- the compiler emits the whole body.
+ * Vtable slot 16: one vtable store, the members in reverse, then ~dActor_c. */
+#include "Lakitu.h"
+
+Lakitu::~Lakitu()
+{
+}
+

--- a/src_tu/actors/Spiny.cpp
+++ b/src_tu/actors/Spiny.cpp
@@ -1,0 +1,1243 @@
+//cpp
+/* HAND-ASSEMBLED translation unit -- ov077/Spiny (34 function(s)).
+ * tubuild create refused this TU (legacy bodies wrapped in extern "C" { }),
+ * so this is a raw concatenation of the complete legacy files in REVERSE
+ * ROM order (mwccarm emits one .text section per function in the reverse
+ * of source order). Conflicting declarations were reconciled by hand; see
+ * the manifest notes.
+ *
+ * Assembled from these legacy one-function sources (ROM address order):
+ *   [0] 0x02124b64  src/_ZN5SpinyD1Ev.cpp
+ *   [1] 0x02124bb4  src/_ZN5SpinyD0Ev.c
+ *   [2] 0x02124c18  src/_ZN5Spiny13OnYoshiTryEatEv.cpp
+ *   [3] 0x02124c20  src/_ZN5Spiny16OnAimedAtWithEggEv.cpp
+ *   [4] 0x02124c28  src/func_ov077_02124c28.cpp
+ *   [5] 0x02124ce4  src/func_ov077_02124ce4.c
+ *   [6] 0x02124d08  src/func_ov077_02124d08.cpp
+ *   [7] 0x02124eb0  src/func_ov077_02124eb0.cpp
+ *   [8] 0x021250a8  src/func_ov077_021250a8.cpp
+ *   [9] 0x021251d0  src/func_ov077_021251d0.cpp
+ *   [10] 0x02125290  src/func_ov077_02125290.c
+ *   [11] 0x02125304  src/func_ov077_02125304.cpp
+ *   [12] 0x021253a4  src/func_ov077_021253a4.cpp
+ *   [13] 0x02125480  src/func_ov077_02125480.cpp
+ *   [14] 0x02125550  src/func_ov077_02125550.cpp
+ *   [15] 0x021256b4  src/func_ov077_021256b4.c
+ *   [16] 0x02125830  src/func_ov077_02125830.c
+ *   [17] 0x021258dc  src/func_ov077_021258dc.c
+ *   [18] 0x02125908  src/func_ov077_02125908.c
+ *   [19] 0x02125a0c  src/func_ov077_02125a0c.c
+ *   [20] 0x02125a54  src/func_ov077_02125a54.c
+ *   [21] 0x02125b1c  src/func_ov077_02125b1c.cpp
+ *   [22] 0x02125bb4  src/func_ov077_02125bb4.c
+ *   [23] 0x02125dd4  src/func_ov077_02125dd4.c
+ *   [24] 0x02125e20  src/func_ov077_02125e20.cpp
+ *   [25] 0x02125e5c  src/func_ov077_02125e5c.cpp
+ *   [26] 0x02125e94  src/func_ov077_02125e94.c
+ *   [27] 0x02125eb0  src/_ZN5Spiny16CleanupResourcesEv.c
+ *   [28] 0x02125eec  src/_ZN5Spiny16OnPendingDestroyEv.c
+ *   [29] 0x02125ef0  src/_ZN5Spiny6RenderEv.cpp
+ *   [30] 0x02125f68  src/_ZN5Spiny8BehaviorEv.cpp
+ *   [31] 0x02126058  src/_ZN5Spiny13InitResourcesEv.cpp
+ *   [32] 0x02126194  src/_ZN5Spiny13OnTurnIntoEggER6Player.cpp
+ *   [33] 0x021261f4  src/Spiny_Spawn.c
+ */
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 33 -- Spiny_Spawn, 0x021261f4, size 0x58 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol Spiny_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Spiny */
+int *Spiny_Spawn(void)
+{
+    int *p = (int *)_ZN7fBase_cnwEj(1004);
+    if (p) {
+        _ZN8dActor_cC2Ev(p);
+        p[0] = (int)&_ZTV5Spiny[2]; /* +8: this TU defines the vtable */
+        _ZN5ModelC1Ev((char *)p + 0xd4);
+        _ZN9ModelAnimC1Ev((char *)p + 0x124);
+        _ZN11ShadowModelC1Ev((char *)p + 0x188);
+        _ZN18MovingCylinderClsnC1Ev((char *)p + 0x1b0);
+        _ZN12WithMeshClsnC1Ev((char *)p + 0x1e4);
+    }
+    return p;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 32 -- _ZN5Spiny13OnTurnIntoEggER6Player, 0x02126194, size 0x60 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN5Spiny13OnTurnIntoEggER6Player
+/* daTgz_c::OnTurnIntoEgg -- vtable slot 19, recovered from vtable slot identity.
+ * Gives the player 1 coin (as a cap-collection coin if Yoshi is wearing the cap,
+ * otherwise as an egg coin), then marks this actor for destruction. */
+#include "Spiny.h"
+#include "Player.h"
+
+int Spiny::OnTurnIntoEgg(Player &player)
+{
+    if (player.IsCollectingCap())
+        GivePlayerCoins(player, 1, 0);
+    else
+        player.RegisterEggCoinCount(1, 0, 0);
+    MarkForDestruction();
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 31 -- _ZN5Spiny13InitResourcesEv, 0x02126058, size 0x13c */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN5Spiny13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Spiny.h"
+struct SharedFilePtr;
+struct BMD_File;
+struct BCA_File;
+struct dActor_c;
+struct Vector3_16;
+
+extern "C" BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr &f);
+extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, BMD_File *f, int a, int b);
+extern "C" BCA_File *_ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr &f);
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *f, int a, int b, unsigned int c);
+extern "C" int _ZN11ShadowModel12InitCylinderEv(void *self);
+extern "C" void _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(void *self, dActor_c *a, int b, int c, unsigned int d, unsigned int e);
+extern "C" void _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *self, dActor_c *a, int b, int c, Vector3_16 *d, Vector3_16 *e);
+namespace three_arg_e94 { extern "C" int func_ov077_02125e94(void *c, int a, int b); } /* InitResources's call byte-requires the third argument; the TU's file-scope view is (void*, int) */
+
+extern SharedFilePtr data_ov077_02127b48;
+extern SharedFilePtr data_ov077_02127b38;
+extern SharedFilePtr data_ov077_02127c14;
+extern char data_02082128;
+
+struct M48 { int w[12]; };
+
+int Spiny::InitResources()
+{
+    BMD_File *bmd;
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov077_02127b48);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, bmd, 1, -1);
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov077_02127b38);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x124, bmd, 1, -1);
+    _ZN9Animation8LoadFileER13SharedFilePtr(data_ov077_02127c14);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *)this) + 0x124, *(BCA_File **)((char *)&data_ov077_02127c14 + 4), 0, 0x1000, 0);
+    if (!_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel))
+        return 0;
+    _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(((char *)this) + 0x1b0, (dActor_c *)((char *)this), 0x2d000, 0x3c000, 0x200000, 0x4a3d0);
+    _ZN12WithMeshClsn4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x1e4, (dActor_c *)((char *)this), 0x2d000, 0, (Vector3_16 *)((char *)&mPrevAngleX), (Vector3_16 *)((char *)&mAngleX));
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    unk_3e9 = 0x2c;
+    three_arg_e94::func_ov077_02125e94(((char *)this), 0, 0x2c);
+    *(M48 *)((char *)&unk_3a0) = *(M48 *)&data_02082128;
+    func_ov077_02125304(((char *)this));
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 30 -- _ZN5Spiny8BehaviorEv, 0x02125f68, size 0xf0 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN5Spiny8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Spiny.h"
+extern "C" {
+int _ZNK12WithMeshClsn10IsOnGroundEv(void* c);
+int _ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(void* c, int d);
+unsigned char DecIfAbove0_Byte(unsigned char* p);
+void _ZN7fBase_c18MarkForDestructionEv(void* c);
+int func_ov077_02124c28(void* c);
+void func_ov077_02125e20(void* c);
+void _ZN8dActor_c19MakeVanishLuigiWorkER12CylinderClsn(void* c, void* cyl);
+void func_ov077_02125304(char* c);
+void _ZN8dActor_c8PoofDustEv(void* c);
+void func_02012694(int a, void* p);
+
+extern signed char data_0209f2f8;
+}
+
+int Spiny::Behavior()
+{
+    int s = unk_3d8;
+    if (s != 1 || _ZNK12WithMeshClsn10IsOnGroundEv((char*)&mWithMeshClsn)) {
+        s = unk_3d8;
+        if (s != 4 && s != 5 && _ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(((char*)this), 0x5dc000)) {
+            if (DecIfAbove0_Byte((unsigned char*)((char*)&unk_3e9)) == 0) {
+                _ZN7fBase_c18MarkForDestructionEv(((char*)this));
+                return 1;
+            }
+            goto done;
+        }
+    }
+    func_ov077_02124c28(((char*)this));
+    func_ov077_02125e20(((char*)this));
+    _ZN8dActor_c19MakeVanishLuigiWorkER12CylinderClsn(((char*)this), ((char*)this) + 0x1b0);
+    func_ov077_02125304(((char*)this));
+    if (data_0209f2f8 == 0x1c && mPosY <= -0x1600000) {
+        _ZN8dActor_c8PoofDustEv(((char*)this));
+        func_02012694(0xc4, ((char*)this) + 0x74);
+        _ZN7fBase_c18MarkForDestructionEv(((char*)this));
+    }
+done:
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 29 -- _ZN5Spiny6RenderEv, 0x02125ef0, size 0x78 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN5Spiny6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Spiny.h"
+struct Obj {
+  virtual void m0(); virtual void m1(); virtual void m2();
+  virtual void m3(); virtual void m4(); virtual void doit(int);
+};
+
+int Spiny::Render()
+{
+  if((mFlags & 0x40000) ? 1 : 0) return 1;
+  int s=unk_3d8;
+  if(s==0 || s==4) ((Obj*)((char *)&mModel))->doit(0);
+  else ((Obj*)((char *)&mModelAnim))->doit(0);
+  return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 28 -- _ZN5Spiny16OnPendingDestroyEv, 0x02125eec, size 0x4 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+void _ZN5Spiny16OnPendingDestroyEv(void)
+{
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 27 -- _ZN5Spiny16CleanupResourcesEv, 0x02125eb0, size 0x3c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+int _ZN5Spiny16CleanupResourcesEv(void)
+{
+    _ZN13SharedFilePtr7ReleaseEv(&data_ov077_02127b48);
+    _ZN13SharedFilePtr7ReleaseEv(&data_ov077_02127b38);
+    _ZN13SharedFilePtr7ReleaseEv(&data_ov077_02127c14);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 26 -- func_ov077_02125e94, 0x02125e94, size 0x1c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern char data_ov077_02127c28[];
+extern void func_ov077_02125e5c(void* c);
+
+void func_ov077_02125e94(void* vc, int i) {
+    char* c = (char*)vc;
+    *(char**)(c + 0x3d0) = data_ov077_02127c28 + (i << 4);
+    func_ov077_02125e5c(c);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 25 -- func_ov077_02125e5c, 0x02125e5c, size 0x38 */
+/* -------------------------------------------------------------------------- */
+struct C; typedef void (C::*PMF)();
+struct C { char pad[0x3d0]; PMF *pp; };
+extern "C" void func_ov077_02125e5c(void *vc) { C *c = (C *)vc; PMF *p = c->pp; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 24 -- func_ov077_02125e20, 0x02125e20, size 0x3c */
+/* -------------------------------------------------------------------------- */
+/* (struct C / PMF: defined once at ordinal 25 above) */
+extern "C" void func_ov077_02125e20(void *vc) { C *c = (C *)vc; PMF *p = c->pp + 1; (c->**p)(); }
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 23 -- func_ov077_02125dd4, 0x02125dd4, size 0x4c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void *);
+int func_ov077_02125dd4(char *c)
+{
+    *(int *)(c + 0x9c) = -0x2000;
+    *(int *)(c + 0xa0) = -0x3c000;
+    *(int *)(c + 0x98) = 0x4000;
+    *(int *)(c + 0xa8) = 0x19000;
+    _ZN12WithMeshClsn13SetLimMovFlagEv((char *)c + 0x1e4);
+    *(int *)(c + 0x3d8) = 0;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 22 -- func_ov077_02125bb4, 0x02125bb4, size 0x220 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov077_02125bb4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Particle.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+typedef int Fix12i;
+
+
+
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void *c, void *p);
+extern void WithMeshClsn_UpdateContinuous_Veneer(void *p);
+extern void func_02012694(int id, void *pos);
+extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned int uniqueID, unsigned int effectID,
+    Fix12i x, Fix12i y, Fix12i z,
+    const void *dir, void *callback);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *p);
+extern void _ZN8dActor_c8PoofDustEv(void *c);
+extern void _ZN7fBase_c18MarkForDestructionEv(void *c);
+extern void func_ov077_02125e94(void *c, int a);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12i x, Fix12i y, Fix12i z);
+extern void func_0201267c(int id, void *pos);
+extern void _ZN12CylinderClsn5ClearEv(void *p);
+extern void _ZN12CylinderClsn6UpdateEv(void *p);
+
+extern int data_0209f32c;
+
+int func_ov077_02125bb4(char *c)
+{
+    int r4;
+    int d;
+    int x, y, z;
+    struct Vector3 vec;
+
+    *(short *)(c + 0x8c) = *(short *)(c + 0x8c) + 0x4e20;
+    _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, c + 0x1b0);
+    func_ov077_021250a8(c);
+    _ZN12WithMeshClsn13SetLimMovFlagEv(c + 0x1e4);
+    WithMeshClsn_UpdateContinuous_Veneer(c + 0x1e4);
+
+    r4 = func_ov077_02124ce4(c);
+    if (r4) {
+        if (*(unsigned char *)(c + 0x3e4) == 0) {
+            func_02012694(0xe2, c + 0x74);
+            _ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_(
+                *(int *)(c + 0x5c), data_0209f32c, *(int *)(c + 0x64));
+            *(unsigned int *)(c + 0x3e0) =
+                _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                    *(unsigned int *)(c + 0x3e0), 0x109,
+                    *(int *)(c + 0x5c), data_0209f32c, *(int *)(c + 0x64),
+                    0, 0);
+        }
+        *(int *)(c + 0x9c) = -0x400;
+        *(int *)(c + 0xa0) = -0x5000;
+        *(int *)(c + 0x98) = 0x2000;
+    } else {
+        *(int *)(c + 0x9c) = -0x2000;
+        *(int *)(c + 0xa0) = -0x3c000;
+        *(int *)(c + 0x98) = 0x4000;
+    }
+    *(unsigned char *)(c + 0x3e4) = (unsigned char)r4;
+
+    if (_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x1e4)) {
+        *(int *)(c + 0xa8) = (*(int *)(c + 0xa8) * -0x3c) / 100;
+        d = *(int *)(c + 0x3dc) ? *(int *)(c + 0x60) - *(int *)(c + 0x3dc) : 0;
+        if (d < -0xc8000) {
+            _ZN8dActor_c8PoofDustEv(c);
+            func_02012694(0x166, c + 0x74);
+            _ZN7fBase_c18MarkForDestructionEv(c);
+        } else if (*(int *)(c + 0xa8) < 0xa000) {
+            *(int *)(c + 0xa8) = 0;
+            *(short *)(c + 0x8c) = *(short *)(c + 0x92);
+            *(short *)(c + 0x8e) = *(short *)(c + 0x94);
+            *(short *)(c + 0x90) = *(short *)(c + 0x96);
+            _ZN12WithMeshClsn15ClearLimMovFlagEv(c + 0x1e4);
+            *(unsigned int *)(c + 0xb0) |= 0x10000000u;
+            func_ov077_02125e94(c, 1);
+        } else {
+            x = *(int *)(c + 0x5c);
+            y = *(int *)(c + 0x60) + 0x28000;
+            z = *(int *)(c + 0x64);
+            ((int *)&vec)[0] = x;
+            ((int *)&vec)[1] = y;
+            ((int *)&vec)[2] = z;
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb2, vec.x, vec.y, vec.z);
+            func_0201267c(0x109, c + 0x74);
+        }
+    }
+
+    _ZN12CylinderClsn5ClearEv(c + 0x1b0);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 21 -- func_ov077_02125b1c, 0x02125b1c, size 0x98 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* ma, void* bca, int a, int f, unsigned int j);
+extern void func_02035684(int* p, int v);
+extern int RandomIntInternal(int* seed);
+extern int data_0209e650;
+void func_ov077_02125b1c(char* c) {
+  *(int*)(c + 0x9c) = -0x2000;
+  *(int*)(c + 0xa0) = -0x3c000;
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x124, ((void**)&data_ov077_02127c14)[1], 0, 0x1000, 0);
+  *(int*)(c + 0x180) = 0x1000;
+  func_02035684((int*)(c + 0x1e4), 0x28000);
+  *(int*)(c + 0x98) = 0x1b33;
+  *(short*)(c + 0x3e6) = RandomIntInternal(&data_0209e650);
+  *(unsigned char*)(c + 0x3e8) = RandomIntInternal(&data_0209e650);
+  *(int*)(c + 0x3d8) = 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 20 -- func_ov077_02125a54, 0x02125a54, size 0xc8 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void _Z14ApproachLinearRsss(short *a, short b, short c);
+extern void _ZN9Animation7AdvanceEv(void *);
+extern void func_ov077_02124eb0(void *c);
+extern void _ZN8dActor_c8PoofDustEv(void *);
+extern void func_02012694(int a, void *b);
+extern void _ZN7fBase_c18MarkForDestructionEv(void *);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void *c, void *clsn);
+extern void func_ov077_02124d08(void *c, void *p);
+extern void _ZN12CylinderClsn5ClearEv(void *c);
+extern void _ZN12CylinderClsn6UpdateEv(void *c);
+extern unsigned char DecIfAbove0_Byte(unsigned char* p);
+extern void func_ov077_02125e94(void *c, int a);
+
+int func_ov077_02125a54(char *c){
+  int d;
+  _Z14ApproachLinearRsss((short*)(c + 0x8e), *(short*)(c + 0x3e6), 0x64);
+  *(short*)(c + 0x94) = *(short*)(c + 0x8e);
+  _ZN9Animation7AdvanceEv(c + 0x174);
+  func_ov077_02124eb0(c);
+  if(*(int*)(c + 0x3dc))
+    d = *(int*)(c + 0x60) - *(int*)(c + 0x3dc);
+  else
+    d = 0;
+  if(d < -0xc8000){
+    _ZN8dActor_c8PoofDustEv(c);
+    func_02012694(0x166, c + 0x74);
+    _ZN7fBase_c18MarkForDestructionEv(c);
+  }
+  _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, c + 0x1b0);
+  func_ov077_02124d08(c, c + 0x1e4);
+  _ZN12CylinderClsn5ClearEv(c + 0x1b0);
+  _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
+  if(DecIfAbove0_Byte((unsigned char*)(c + 0x3e8)) == 0)
+    func_ov077_02125e94(c, 1);
+  return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 19 -- func_ov077_02125a0c, 0x02125a0c, size 0x48 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern short Vec3_HorzAngle(void*, void*);
+extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void *);
+int func_ov077_02125a0c(char *c) {
+    *(int*)(c+0x98) = 0x5000;
+    *(int*)(c+0xa8) = 0xd000;
+    short ang = (short)Vec3_HorzAngle((char*)*(int*)(c+0x3d4)+0x5c, c+0x5c);
+    *(short*)(c+0x94) = ang;
+    _ZN12WithMeshClsn13SetLimMovFlagEv(c+0x1e4);
+    *(int*)(c+0x3d8) = 2;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 18 -- func_ov077_02125908, 0x02125908, size 0x104 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void WithMeshClsn_UpdateDiscreteNoLava_veneer(void *p);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *p);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *p);
+extern void _ZN12WithMeshClsn15ClearLimMovFlagEv(void *p);
+extern void _ZN8dActor_c8PoofDustEv(void *p);
+extern void _ZN7fBase_c18MarkForDestructionEv(void *p);
+extern void _ZN9Animation7AdvanceEv(void *p);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void *p, void *cc);
+extern void _ZN12CylinderClsn5ClearEv(void *p);
+extern void _ZN12CylinderClsn6UpdateEv(void *p);
+extern void func_02012694(int a, void *b);
+extern void func_ov077_02125e94(void *p, int v);
+extern void func_ov077_02124eb0(void *p);
+
+int func_ov077_02125908(char *c)
+{
+    int v;
+
+    WithMeshClsn_UpdateDiscreteNoLava_veneer(c + 0x1e4);
+    if (_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x1e4) != 0)
+    {
+        *(int *)(c + 0xa8) = *(int *)(c + 0xa8) * -50 / 100;
+    }
+    else if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x1e4) != 0)
+    {
+        *(int *)(c + 0xa8) = 0;
+        _ZN12WithMeshClsn15ClearLimMovFlagEv(c + 0x1e4);
+        *(int *)(c + 0x3d4) = 0;
+        *(short *)(c + 0x94) = *(short *)(c + 0x8e);
+        func_ov077_02125e94(c, 1);
+    }
+
+    if (*(int *)(c + 0x3dc) != 0)
+        v = *(int *)(c + 0x60) - *(int *)(c + 0x3dc);
+    else
+        v = 0;
+
+    if (v < -0xc8000)
+    {
+        _ZN8dActor_c8PoofDustEv(c);
+        func_02012694(0x166, c + 0x74);
+        _ZN7fBase_c18MarkForDestructionEv(c);
+    }
+
+    _ZN9Animation7AdvanceEv(c + 0x174);
+    _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, c + 0x1b0);
+    func_ov077_02124eb0(c);
+    _ZN12CylinderClsn5ClearEv(c + 0x1b0);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 17 -- func_ov077_021258dc, 0x021258dc, size 0x2c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol func_ov077_021258dc
+// recovered name: Lakitu_Kill
+/* recovered: renamed to Class_Method */
+/* daJgm_c::Kill - recovered from vtable slot identity */
+extern void _ZN12CylinderClsn5ClearEv(void *);
+int func_ov077_021258dc(char *c)
+{
+    *(int *)(c + 0x98) = 0;
+    _ZN12CylinderClsn5ClearEv((char *)c + 0x1b0);
+    *(int *)(c + 0x3d8) = 3;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 16 -- func_ov077_02125830, 0x02125830, size 0xac */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void func_ov077_02125e94(void *c, int v);
+
+int func_ov077_02125830(char *c)
+{
+    if (((*(int *)(c + 0xb0) & 0x40000) ? 1 : 0) != 0)
+    {
+        char *p = *(char **)(c + 0xd0);
+        int *src = (int *)(p + 0x5c);
+        *(int *)(c + 0x5c) = src[0];
+        *(int *)(c + 0x60) = src[1];
+        *(int *)(c + 0x64) = src[2];
+    }
+    {
+        int flags = *(int *)(c + 0xb0);
+        if (((flags & 0x80000) ? 1 : 0) != 0)
+        {
+            func_ov077_02125e94(c, 4);
+        }
+        else if (((flags & 0x20000) ? 1 : 0) == 0 && ((flags & 0x40000) ? 1 : 0) == 0)
+        {
+            *(int *)(c + 0xd0) = 0;
+            func_ov077_02125e94(c, 1);
+        }
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 15 -- func_ov077_021256b4, 0x021256b4, size 0x17c */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+#include "types.h"
+// @symbol func_ov077_021256b4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types */
+#include "common.h"
+extern s16 data_02082214[];
+extern int _ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b(void *self, struct Vector3 *a, struct Vector3 *out, int doStore);
+#define LA(p) ((int)(p))
+int func_ov077_021256b4(char *o)
+{
+    char *d0;
+    int *a5c;
+    int *a60;
+    int *a64;
+    int *src;
+    int k;
+    s16 s;
+    s16 cval;
+    s16 ang;
+    struct Vector3 v;
+    int one;
+    int y;
+    int z;
+    int x;
+
+    *(int *)LA(o + 0xb0) &= ~0x80000;
+    *(int *)(o + 0x98) = 0xa000;
+    *(int *)(o + 0xa8) = 0;
+
+    d0 = *(char **)(o + 0xd0);
+    a5c = (int *)LA(o + 0x5c);
+    ang = *(s16 *)(d0 + 0x8e);
+    *(s16 *)(o + 0x8c) = 0;
+    *(s16 *)(o + 0x8e) = ang;
+    *(s16 *)(o + 0x90) = 0;
+
+    *(s16 *)(o + 0x94) = *(s16 *)(o + 0x8e);
+    a60 = (int *)LA(o + 0x60);
+    a64 = (int *)LA(o + 0x64);
+
+    d0 = *(char **)(o + 0xd0);
+    src = (int *)LA(d0 + 0x5c);
+    one = 1;
+    *(int *)(o + 0x5c) = src[0];
+    *(int *)(o + 0x60) = src[1];
+    *(int *)(o + 0x64) = src[2];
+
+    k = ((int)*(u16 *)(o + 0x8e)) >> 4;
+    s = data_02082214[k * 2];
+    *a5c = *a5c + (int)(((s64)s * 0x3c000 + 0x800) >> 12);
+    *a60 = *a60 + 0x85000;
+    k = ((int)*(u16 *)(o + 0x8e)) >> 4;
+    cval = data_02082214[k * 2 + 1];
+    *a64 = *a64 + (int)(((s64)cval * 0x3c000 + 0x800) >> 12);
+
+    d0 = *(char **)(o + 0xd0);
+
+    {
+        int ty = *(int *)(d0 + 0x60);
+        int tz = *(int *)(d0 + 0x64);
+        int ty2 = ty + 0x50000;
+        int tx = *(int *)(d0 + 0x5c);
+        v.x = tx; v.y = ty2; v.z = tz;
+    }
+
+    _ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b(o, &v, (struct Vector3 *)(o + 0x5c), one);
+
+    *(int *)(o + 0xd0) = 0;
+    _ZN12WithMeshClsn13SetLimMovFlagEv(o + 0x1e4);
+
+    *(int *)(o + 0x3d8) = 4;
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 14 -- func_ov077_02125550, 0x02125550, size 0x164 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02125550
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
+
+extern "C" {
+extern void WithMeshClsn_UpdateContinuous_Veneer(void* p);
+extern void WithMeshClsn_UpdateDiscreteNoLava_veneer(void* p);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void* p);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
+extern void func_0201267c(int a, void* p);
+extern void func_ov077_02125e94(void* c, int a);
+extern void _ZN8dActor_c8PoofDustEv(void* c);
+extern void func_02012694(int a, void* p);
+extern void _ZN7fBase_c18MarkForDestructionEv(void* c);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void* c, void* p);
+extern void _ZN12CylinderClsn5ClearEv(void* p);
+extern void _ZN12CylinderClsn6UpdateEv(void* p);
+}
+
+extern "C" int func_ov077_02125550(char* c)
+{
+    Vector3 vec;
+    int x, y, z;
+    int d;
+
+    *(short*)(c + 0x8c) = *(short*)(c + 0x8c) + 0x4e20;
+
+    if (*(int*)(c + 0x98) >= *(int*)(c + 0x1fc) || *(int*)(c + 0xa8) >= *(int*)(c + 0x1fc)) {
+        WithMeshClsn_UpdateContinuous_Veneer(c + 0x1e4);
+    } else {
+        WithMeshClsn_UpdateDiscreteNoLava_veneer(c + 0x1e4);
+    }
+
+    if (_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x1e4)) {
+        *(int*)(c + 0xa8) = *(int*)(c + 0xa8) * -0x3c / 100;
+        if (*(int*)(c + 0xa8) > 0x8000) {
+            x = *(int*)(c + 0x5c);
+            y = *(int*)(c + 0x60) + 0x28000;
+            z = *(int*)(c + 0x64);
+            ((int*)&vec)[0] = x;
+            ((int*)&vec)[1] = y;
+            ((int*)&vec)[2] = z;
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb2, vec.x, vec.y, vec.z);
+            func_0201267c(0x109, c + 0x74);
+        } else {
+            *(int*)(c + 0xa8) = 0;
+            *(short*)(c + 0x8c) = 0;
+            _ZN12WithMeshClsn15ClearLimMovFlagEv(c + 0x1e4);
+            func_ov077_02125e94(c, 1);
+        }
+    }
+
+    d = *(int*)(c + 0x3dc) ? *(int*)(c + 0x60) - *(int*)(c + 0x3dc) : 0;
+    if (d < -0xc8000) {
+        _ZN8dActor_c8PoofDustEv(c);
+        func_02012694(0x166, c + 0x74);
+        _ZN7fBase_c18MarkForDestructionEv(c);
+    }
+
+    _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, c + 0x1b0);
+    func_ov077_02124eb0(c);
+    _ZN12CylinderClsn5ClearEv(c + 0x1b0);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 13 -- func_ov077_02125480, 0x02125480, size 0xd0 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02125480
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
+}
+
+struct Base {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void v5();
+    virtual void v6();
+    virtual void v7();
+    virtual void v8();
+    virtual void v9();
+    virtual void v10();
+    virtual void v11();
+    virtual void v12();
+    virtual void v13();
+    virtual void v14();
+    virtual void v15();
+    virtual void v16();
+    virtual void v17();
+    virtual void v18();
+    virtual void v19();
+    virtual void v20();
+    virtual void v21();
+    virtual void v22();
+    virtual void v23();
+    virtual void v24();
+    virtual void v25();
+    virtual void v26();
+    virtual void v27();
+    virtual void v28();
+    virtual int m();   // slot 0x74/4 = 29
+};
+
+extern "C" int func_ov077_02125480(char* c)
+{
+    _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
+    *(int*)(c + 0x98) = 0xa000;
+    *(int*)(c + 0xa8) = 0x28000;
+    *(short*)(c + 0x8c) = 0;
+    *(short*)(c + 0x90) = 0;
+    *(unsigned char*)(c + 0x3e8) = 0x2d;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x124, *(void**)((char*)&data_ov077_02127c14 + 4), 0, 0x1000, 0);
+    *(int*)(c + 0x180) = 0x4000;
+    Base* b = (Base*)c;
+    int r1 = b->m();
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x43, *(int*)(c + 0x5c), *(int*)(c + 0x60) + r1, *(int*)(c + 0x64));
+    int r2 = b->m();
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x44, *(int*)(c + 0x5c), *(int*)(c + 0x60) + r2, *(int*)(c + 0x64));
+    *(int*)(c + 0x3d8) = 5;
+    return 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 12 -- func_ov077_021253a4, 0x021253a4, size 0xdc */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_021253a4
+/* recovered: shared common types */
+#include "common.h"
+
+extern "C" {
+extern void _ZN9Animation7AdvanceEv(void*);
+extern void _ZN8dActor_c9UpdatePosEP12CylinderClsn(void*, void*);
+extern void WithMeshClsn_UpdateContinuous_Veneer(void*);
+extern void WithMeshClsn_UpdateDiscreteNoLava_veneer(void*);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void*);
+extern unsigned char DecIfAbove0_Byte(unsigned char* p);
+extern void _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(void*, const Vector3*, unsigned int, int, short);
+extern void _ZN8dActor_c8PoofDustEv(void*);
+extern void func_02012694(int a, void* b);
+extern void _ZN7fBase_c18MarkForDestructionEv(void*);
+
+int func_ov077_021253a4(char* c)
+{
+    *(short*)(c + 0x8c) = *(short*)(c + 0x8c) - 0x1000;
+    _ZN9Animation7AdvanceEv(c + 0x174);
+    _ZN8dActor_c9UpdatePosEP12CylinderClsn(c, c + 0x1b0);
+
+    if (*(int*)(c + 0x98) >= *(int*)(c + 0x1fc) || *(int*)(c + 0xa8) >= *(int*)(c + 0x1fc)) {
+        WithMeshClsn_UpdateContinuous_Veneer(c + 0x1e4);
+    } else {
+        WithMeshClsn_UpdateDiscreteNoLava_veneer(c + 0x1e4);
+    }
+
+    if (_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x1e4) || DecIfAbove0_Byte((unsigned char*)(c + 0x3e8)) == 0) {
+        Vector3 v;
+        v.x = *(int*)(c + 0x5c);
+        v.y = *(int*)(c + 0x60);
+        v.z = *(int*)(c + 0x64);
+        _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(c, &v, 1, 0x2000, 0);
+        _ZN8dActor_c8PoofDustEv(c);
+        func_02012694(0xc4, c + 0x74);
+        _ZN7fBase_c18MarkForDestructionEv(c);
+    }
+    return 1;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 11 -- func_ov077_02125304, 0x02125304, size 0xa0 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+void func_ov077_021251d0(void *t);
+void func_ov077_02125290(char *t);
+void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *thisp, void *sm, void *mtx, int rad, int t, unsigned int j);
+void func_ov077_02125304(char *c) {
+    int b = (int)((*(int*)(c+0xb0) & 0x40000) != 0);
+    if (b != 0) return;
+    if (*(int*)(c+0x3d8) == 5) func_ov077_021251d0(c);
+    else func_ov077_02125290(c);
+    *(int*)(c+0x3c4) = *(int*)(c+0x5c) >> 3;
+    *(int*)(c+0x3c8) = *(int*)(c+0x60) >> 3;
+    *(int*)(c+0x3cc) = *(int*)(c+0x64) >> 3;
+    _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c+0x188, c+0x3a0, 0x50000, 0x320000, 0xf);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 10 -- func_ov077_02125290, 0x02125290, size 0x74 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+extern void Matrix4x3_FromRotationZXYExt(void *, int, int, int);
+void func_ov077_02125290(char *t)
+{
+    int v = *(int *)(t + 0x3d8);
+    int b = 1;
+    char *m;
+    if (v != 0) b = (v == 4);
+    if (b) m = t + 0xf0;
+    else m = t + 0x140;
+    Matrix4x3_FromRotationZXYExt(m, *(short *)(t + 0x8c), *(short *)(t + 0x8e), *(short *)(t + 0x90));
+    *(int *)(m + 0x24) = *(int *)(t + 0x5c) >> 3;
+    *(int *)(m + 0x28) = *(int *)(t + 0x60) >> 3;
+    *(int *)(m + 0x2c) = *(int *)(t + 0x64) >> 3;
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 9 -- func_ov077_021251d0, 0x021251d0, size 0xc0 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_021251d0
+/* recovered: shared common types */
+#include "common.h"
+extern "C" {
+void Vec3_Asr(void* d, void* s, int sh);
+void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
+void Matrix4x3_ApplyInPlaceToTranslation(void* m, int x, int y, int z);
+void Matrix4x3_ApplyInPlaceToRotationZXYExt(void* m, int x, int y, int z);
+
+extern Matrix4x3 data_020a0e68;
+}
+/* (Base: the identical 30-slot shadow defined once above, at ordinal 12's block) */
+extern "C" void func_ov077_021251d0(void* c)
+{
+  char* r4 = (char*)c;
+  int v[3];
+  Vec3_Asr(v, r4+0x5c, 3);
+  Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
+  Base* b = (Base*)c;
+  int r = b->m();
+  Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, r >> 3, 0);
+  Matrix4x3_ApplyInPlaceToRotationZXYExt(&data_020a0e68,
+      *(short*)(r4+0x8c), *(short*)(r4+0x8e), *(short*)(r4+0x90));
+  int r2 = b->m();
+  Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, (-r2) >> 3, 0);
+  *(Matrix4x3*)(r4+0x140) = data_020a0e68;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 8 -- func_ov077_021250a8, 0x021250a8, size 0x128 */
+/* -------------------------------------------------------------------------- */
+extern "C" {
+typedef struct dActor_c dActor_c;
+typedef struct Player Player;
+void* _ZN8dActor_c10FindWithIDEj(unsigned int id);
+void func_ov077_02125e94(void* c, int a);
+short Vec3_HorzAngle(void* a, void* b);
+void _ZN6Player16IncMegaKillCountEv(void* p);
+void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* p, const Vector3* v, unsigned int a, int b, unsigned int d, unsigned int e, unsigned int f);
+
+void func_ov077_021250a8(void* vc){
+  char* c = (char*)vc;
+  unsigned int id = *(unsigned int*)(c+0x1d4);
+  if (id == 0) return;
+  char* r4 = (char*)_ZN8dActor_c10FindWithIDEj(id);
+  if (r4 == 0) return;
+  int b1 = (int)(*(unsigned short*)(r4+0xc) == 0xbf);
+  if (b1 == 0) return;
+  int b2 = (int)((*(int*)(c+0xb0) & 0x20000) != 0);
+  if (b2 != 0) {
+    func_ov077_02125e94(c, 3);
+    return;
+  }
+  int flags = *(int*)(c+0x1d0);
+  if ((flags & 0x10) != 0) {
+    *(short*)(c+0x94) = Vec3_HorzAngle((Vector3*)(r4+0x5c), (Vector3*)(c+0x5c));
+    *(short*)(c+0x8e) = *(short*)(c+0x94) + 0x8000;
+    _ZN6Player16IncMegaKillCountEv((Player*)r4);
+    func_ov077_02125e94(c, 5);
+    return;
+  }
+  if ((flags & 0x40000) != 0) return;
+  Vector3 v;
+  v.x = *(int*)(c+0x5c);
+  v.y = *(int*)(c+0x60);
+  v.z = *(int*)(c+0x64);
+  _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj((Player*)r4, &v, 2, 0xc000, 1, 0, 1);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 7 -- func_ov077_02124eb0, 0x02124eb0, size 0x1f8 */
+/* -------------------------------------------------------------------------- */
+extern "C" int _ZN8dActor_c7FindEggER12CylinderClsn(void *self, void *clsn); /* decl_Actor.h view */
+extern "C" void _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(void *self, const Vector3 *pos, unsigned int a, int fix, short b);
+extern "C" void _ZN8dActor_c8PoofDustEv(void *self);
+extern "C" void func_02012694(int a, void *pos);
+extern "C" void _ZN7fBase_c18MarkForDestructionEv(void *self);
+extern "C" void *_ZN8dActor_c10FindWithIDEj(unsigned int id);
+extern "C" void func_ov077_02125e94(void *c, int i);
+extern "C" int _ZN6Player9IsOnShellEv(void *p);
+extern "C" void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, const Vector3 &pos);
+extern "C" short Vec3_HorzAngle(void *a, void *b);
+extern "C" void _ZN6Player16IncMegaKillCountEv(void *p);
+extern "C" void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *self, const Vector3 *pos, unsigned int a, int fix, unsigned int b, unsigned int cc, unsigned int d);
+
+extern "C" void func_ov077_02124eb0(void *thiz)
+{
+    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *r4;
+    int b;
+
+    if (_ZN8dActor_c7FindEggER12CylinderClsn(c, c + 0x1b0) != 0) {
+        int v[3];
+        v[0] = *(int *)(c + 0x5c);
+        v[1] = *(int *)(c + 0x60);
+        v[2] = *(int *)(c + 0x64);
+        _ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs(c, (const Vector3 *)v, 1, 0x2000, 0);
+        _ZN8dActor_c8PoofDustEv(c);
+        func_02012694(0xc4, c + 0x74);
+        _ZN7fBase_c18MarkForDestructionEv(c);
+        return;
+    }
+
+    {
+        unsigned int id = *(unsigned int *)(c + 0x1d4);
+        if (id == 0)
+            return;
+        r4 = (unsigned char *)_ZN8dActor_c10FindWithIDEj(id);
+    }
+    if (r4 == 0)
+        return;
+
+    b = (int)(*(unsigned short *)(r4 + 0xc) == 0xbf);
+    if (b == 0)
+        return;
+
+    b = (int)((*(int *)(c + 0xb0) & 0x20000) != 0);
+    if (b != 0) {
+        func_ov077_02125e94(c, 3);
+        return;
+    }
+
+    if ((*(int *)(c + 0x1d0) & 0x403c0)
+        || _ZN6Player9IsOnShellEv(r4) != 0
+        || *(unsigned char *)(r4 + 0x6f9) != 0) {
+        if (*(int *)(c + 0x3d8) != 1)
+            return;
+        _ZN5Sound9PlayBank0EjRK7Vector3(0xb5, *(const Vector3 *)(c + 0x74));
+        *(unsigned char **)(c + 0x3d4) = r4;
+        func_ov077_02125e94(c, 2);
+        return;
+    }
+
+    if (*(int *)(c + 0x1d0) & 0x10) {
+        *(short *)(c + 0x94) = Vec3_HorzAngle(r4 + 0x5c, c + 0x5c);
+        _ZN6Player16IncMegaKillCountEv(r4);
+        func_ov077_02125e94(c, 5);
+        return;
+    }
+
+    if (*(int *)(c + 0x3d8) == 4)
+        return;
+
+    {
+        int v[3];
+        v[0] = *(int *)(c + 0x5c);
+        v[1] = *(int *)(c + 0x60);
+        v[2] = *(int *)(c + 0x64);
+        _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(r4, (const Vector3 *)v, 2, 0xc000, 1, 0, 1);
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 6 -- func_ov077_02124d08, 0x02124d08, size 0x1a8 */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02124d08
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+typedef short s16;
+
+struct WithMeshClsn;
+struct dActor_c;
+struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
+struct ClsnResult;
+struct SurfaceInfo;
+
+extern "C" void WithMeshClsn_UpdateDiscreteNoLava_veneer(void* p);
+extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
+extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround* self);
+extern "C" void _ZN4BgCh19StartDetectingToxicEv(void* self);
+extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(RaycastGround* self, const Vector3& v, void* actor);
+extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround* self);
+extern "C" void _ZN8dActor_c8PoofDustEv(void* self);
+extern "C" void func_02012694(int a, void* b);
+extern "C" void _ZN7fBase_c18MarkForDestructionEv(void* self);
+extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround* self);
+extern "C" void* _ZNK12WithMeshClsn14GetFloorResultEv(void* self);
+extern "C" void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vector3* out);
+extern "C" int _ZN4cstd4fdivEii(int a, int b);
+extern "C" s16 func_02010844(void* unused, Vector3* v, s16 angle);
+extern "C" int _ZNK12WithMeshClsn8IsOnWallEv(void* self);
+
+extern "C" void func_ov077_02124d08(void* va, void* vw) {
+    char* a = (char*)va; char* w = (char*)vw;
+    RaycastGround rc;
+    Vector3 pos;
+    Vector3 normal;
+    Vector3 wallnormal;
+
+    WithMeshClsn_UpdateDiscreteNoLava_veneer(w);
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(w)) {
+        _ZN13RaycastGroundC1Ev(&rc);
+        {
+            int p60 = *(int*)(a+0x60);
+            int pz = *(int*)(a+0x64);
+            int py = p60 + 0xc8000;
+            pos.x = *(int*)(a+0x5c);
+            pos.y = py;
+            pos.z = pz;
+        }
+        _ZN4BgCh19StartDetectingToxicEv(&rc);
+        _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, a);
+        if (_ZN13RaycastGround10DetectClsnEv(&rc)) {
+            if (func_02037e20(rc.floor) != 0 && *(int*)(a+0x60) < rc.floor[(0x44-0x14)/4]) {
+                _ZN8dActor_c8PoofDustEv(a);
+                func_02012694(0xc4, a+0x74);
+                _ZN7fBase_c18MarkForDestructionEv(a);
+                _ZN13RaycastGroundD1Ev(&rc);
+                return;
+            }
+            {
+                void* fr = _ZNK12WithMeshClsn14GetFloorResultEv(w);
+                _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)fr + 4, &normal);
+            }
+            if (normal.y != 0) {
+                *(int*)(a+0xa8) = -(_ZN4cstd4fdivEii(
+                    (int)(((long long)normal.x * *(int*)(a+0xa4) + 0x800) >> 12)
+                  + (int)(((long long)normal.z * *(int*)(a+0xac) + 0x800) >> 12),
+                    normal.y) + 0x8000);
+            }
+            *(s16*)(a+0x8c) = func_02010844(a, &normal, *(s16*)(a+0x8e));
+            *(s16*)(a+0x90) = func_02010844(a, &normal, (s16)(*(s16*)(a+0x8e) - 0x4000));
+        }
+        _ZN13RaycastGroundD1Ev(&rc);
+    }
+    if (_ZNK12WithMeshClsn8IsOnWallEv(w)) {
+        void* wr = _ZNK12WithMeshClsn13GetWallResultEv(w);
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)wr + 4, &wallnormal);
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 5 -- func_ov077_02124ce4, 0x02124ce4, size 0x24 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+int func_ov077_02124ce4(void* vc){
+  char* c = (char*)vc;
+  int r1=*(int*)(c+0x3dc);
+  if(r1==0) return 0;
+  return r1 > *(int*)(c+0x60);
+}
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 4 -- func_ov077_02124c28, 0x02124c28, size 0xbc */
+/* -------------------------------------------------------------------------- */
+// @symbol func_ov077_02124c28
+/* recovered: shared common types */
+#include "common.h"
+
+struct dActor_c;
+
+namespace rg54 {  /* this member's 0x54-byte RaycastGround view is stack-frame-load-bearing;
+                     ordinal 6's block uses a 0x50-byte view of the same name -- the namespace
+                     keeps both, binding the same C symbols */
+struct RaycastGround {
+    char pad0[0x14];
+    int m14[12];
+    int m44;
+    char pad48[0xc];
+};
+extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround*);
+extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(RaycastGround*, const Vector3&, dActor_c*);
+extern "C" void _ZN4BgCh19StartDetectingWaterEv(void*);
+extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround*);
+extern "C" int SurfaceInfo_TestFlag0x20(int* p);
+extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround*);
+extern "C" void _ZN4BgCh18StopDetectingWaterEv(void*);
+}
+
+extern "C" int func_ov077_02124c28(void* vc)
+{
+    char* c = (char*)vc;
+    if (*(int*)(c + 0x3dc) == 0) {
+        rg54::RaycastGround rg;
+        Vector3 pos;
+        int r;
+        rg54::_ZN13RaycastGroundC1Ev(&rg);
+        {
+            int y = *(int*)(c + 0x60);
+            int z = *(int*)(c + 0x64);
+            int y2 = y + 0xc8000;
+            int x = *(int*)(c + 0x5c);
+            pos.x = x;
+            pos.y = y2;
+            pos.z = z;
+        }
+        rg54::_ZN13RaycastGround12SetObjAndPosERK7Vector3P8dActor_c(&rg, pos, (dActor_c*)c);
+        rg54::_ZN4BgCh19StartDetectingWaterEv(&rg);
+        if (rg54::_ZN13RaycastGround10DetectClsnEv(&rg) == 0) goto fail;
+        r = rg54::SurfaceInfo_TestFlag0x20(rg.m14);
+        if (r != 0) {
+            *(int*)(c + 0x3dc) = rg.m44;
+        } else {
+        fail:
+            rg54::_ZN13RaycastGroundD1Ev(&rg);
+            return 0;
+        }
+        rg54::_ZN4BgCh18StopDetectingWaterEv(&rg);
+        rg54::_ZN13RaycastGroundD1Ev(&rg);
+    }
+    return *(int*)(c + 0x60) - *(int*)(c + 0x3dc);
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 3 -- _ZN5Spiny16OnAimedAtWithEggEv, 0x02124c20, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN5Spiny16OnAimedAtWithEggEv
+/* daTgz_c::OnAimedAtWithEgg -- vtable slot 29, recovered from vtable slot identity.
+ * The ROM body ignores `this` and returns a constant. */
+#include "Spiny.h"
+
+int Spiny::OnAimedAtWithEgg()
+{
+    return 122880;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 2 -- _ZN5Spiny13OnYoshiTryEatEv, 0x02124c18, size 0x8 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN5Spiny13OnYoshiTryEatEv
+/* daTgz_c::OnYoshiTryEat -- vtable slot 18, recovered from vtable slot identity.
+ * The ROM body ignores `this` and returns a constant. */
+#include "Spiny.h"
+
+int Spiny::OnYoshiTryEat()
+{
+    return 6;
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 1 -- _ZN5SpinyD0Ev, 0x02124bb4, size 0x64 */
+/* -------------------------------------------------------------------------- */
+extern "C" {  /* .c-derived member: C linkage for the whole block */
+// @symbol _ZN5SpinyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daTgz_c */
+/* (no separate definition: the single ~Spiny() below emits the D0 and D1
+ * variants together -- keeping this hand-mangled body alongside the real
+ * destructor is the known mwccarm ICE (ELFgen.c:483). The legacy file
+ * stored _ZTV7daTgz_c, the RTTI spelling of the address _ZTV5Spiny names.) */
+}
+
+/* -------------------------------------------------------------------------- */
+/* ROM ordinal 0 -- _ZN5SpinyD1Ev, 0x02124b64, size 0x50 */
+/* -------------------------------------------------------------------------- */
+// @symbol _ZN5SpinyD1Ev
+/* recovered: real C++ destructor -- the compiler emits the whole body.
+ * Vtable slot 16: one vtable store, the members in reverse, then ~dActor_c. */
+#include "Spiny.h"
+
+Spiny::~Spiny()
+{
+}
+


### PR DESCRIPTION
Fourth TU seed. ov077 pushes the recipe to its largest translation units yet — Spiny is a 34-member TU (ov070's biggest was 27) — and surfaced a declaration-conflict class the earlier repairs could not handle, which now has a proven fix.

**Why ov077**: 88 functions in 3 TUs (Lakitu 32, Spiny 34, HeaveHo 22), all `tu_map` boundaries `high`, **module sinit-corroborated** (3 = 3 = 3), 100% source-built with zero unmatched/pragma flags. The alternative at scale (ov100, 128 fn) has 2 unmatched functions, 2 pragma flags, and no sinit corroboration; ov077 also avoids every class the concurrent enemy-rename session owns.

**Source side — 88/88 byte-verified in 3 merged TUs, 0 excluded:**

| TU | fn | verdict |
|---|---|---|
| src_tu/actors/Lakitu.cpp | 32 | 32/32 MATCH, objisolate clean, reloc-destinations clean |
| src_tu/actors/Spiny.cpp | 34 | 34/34, all three checks clean — largest TU reconstructed so far |
| src_tu/actors/HeaveHo.cpp | 22 | 22/22, all three checks clean |

All three manifest entries `text-verified`, re-verified after rebasing onto current main.

**New repair, probed on 2004/b56 before adoption — namespace-wrapped `extern "C"`:** when one C symbol needs two byte-load-bearing declaration views at file scope, a declaration (or definition) inside a namespace binds the same plain C symbol under a distinct C++ name, so both views coexist. Verified by probe: the namespaced declaration emits a call to the plain symbol, and a namespaced definition emits the plain `STT_FUNC`. Used four times, each with the byte evidence in the manifest notes:
- `decl_common.h` declares `func_ov077_0212478c` with ONE parameter and `Lakitu::InitResources`'s call byte-requires that shape (no `r1` setup) — while the definition and six other callers need `(void*, int)`. The divergent caller is a C++ member, so ov070's block-scope trick would mangle the name; the namespace subsumes it.
- zero-arg vs `(void*)` views of `_ZN8dActor_c22ClosestNonVanishPlayerEv` and `func_ov077_02123880` (r0 setup is the byte difference).
- `Spiny::InitResources` byte-requires a THREE-argument call (`r2 = 0x2c`) to a two-argument function.
- two `RaycastGround` stack shadows of different SIZES (0x50 and 0x54), both frame-layout-load-bearing, in one TU.

Also reproduced at scale: the hand-mangled-D0 + real-destructor mwccarm ICE (ELFgen.c:483) avoided by deletion in Spiny; one destructor emitting D0+D1 in all three classes; the +8 vtable-slot addend at all three Spawns; block-scope declaration views (HeaveHo's `AngleDiff(short, short)` against decl_common's `(int, int)`).

**Config side:** `config_tu/` gains ov077: 91 delink entries → 3, five sections, `.text` grows 0 (15,088 B tiled exactly), `.init` tiles the 3 sinit blocks, `.ctor` one word per TU, `.data` 832 B / `.bss` 424 B by contains-then-closure. `dsd delink` and `objdiff` exit 0 against the three-module root; ov077's objdiff units become 5 (3 TUs + 2 gaps). ov009's regenerated delinks are byte-identical to the committed ones.

**Cross-PR drift found and contained (follow-up work, deliberately not forced here):** #1640 renamed FlameChomp → `daKrpa_c` and FlameChompFire → `daKpFr_c` *after* #1637 landed ov070's TU config. Regenerating ov070 today redraws its `tu_map` clusters (4 TUs → 6, and the `.init`/`.ctor` ordinal gate fails at 4 sinits vs 6 TUs) and would reference TU sources that do not exist. ov070's committed delinks are kept as-is — they still describe the byte-verified sources at unchanged addresses — and the realignment of ov070's TU sources to the RTTI names is flagged as follow-up.

**Verification, at exactly this tip (c182b370e):**

```
module fidelity: 106/106 exact, 100.000000% of compared bytes
  mismatching: 0                               [src/ and config/**/delinks.txt untouched]
ROM-build analysis: PASS
unresolved symbols: 45  (baseline 45)          [check_references: OK]
eligible name list: byte-identical to origin/main's own run (11,064 = 11,064, diff exit 0)
langmode ratchet PASS                          [fresh chaos-data bank]
port-refcheck: 393 checked - all references resolve
tubuild re-verified all three TUs at this tip: 88/88 MATCH
```

If the validator reports attribution `CREDIT CHANGED`, that is expected and per standing policy not a blocker.

## Plain-English TL;DR

Fourth overlay reassembled into its original source files: Lakitu the cloud rider, the Spiny he throws, and the Heave-Ho robot — 88 functions from 88 scattered files back into the three real C++ files of the 2004 build, every byte matching the cartridge. The interesting obstacle this time: in several places, two parts of the original code disagreed about a function's exact shape (one caller passes an argument another doesn't), and the old compiler was fine with that in C — but a merged C++ file refuses to hold both views. The fix, tested against the compiler before use, is a C++ namespace trick that lets both views of the same function coexist while still calling the same machine code. One overlay converted earlier needs a small follow-up because a parallel renaming effort changed two of its class names after the fact; that's documented rather than patched over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WasbE1QEmFdSreEKNKbVSP
