### PR TITLE
tubuild: create learns the hand-assembly repairs (linkage blocks, positional long_calls, raw fallback), and verify stops eating curated prose

### DIFF
--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -314,3 +314,62 @@ if __name__ == "__main__":
              "themselves rather than failing)")
     print(f"\n{ran} test(s) run, {fails} failure(s)")
     sys.exit(1 if fails else 0)
+
+
+import tubuild
+
+# ---------------------------------------------------------------- create repairs
+# The three assemble_shadow_source behaviors proven by six modules of
+# hand-assembly (222 byte-verified functions) before being folded into the
+# generator: extern "C" BLOCKS around .c-derived members (defect 2), #pragma
+# long_calls carried in position and bracketed (positional on 2004/b56 -- the
+# ov014 seed), and raw-concatenation fallback instead of refusing a candidate
+# (defect 4). Synthetic: no compiler, no ROM -- these test the emitted TEXT.
+
+def _member(cpp, text, pragmas=(), **over):
+    d = {"error": None, "cpp": cpp, "includes": [], "pragmas": list(pragmas),
+         "macros": [], "externs": [], "shadow_decls": [], "notes": [],
+         "function_text": text, "legacy_path": "src/synthetic.c"}
+    d.update(over)
+    return d
+
+
+def test_c_member_gets_a_linkage_block_not_a_prefix():
+    ord_rows = [(0, "f_lo", 0x1000, 8), (1, "f_hi", 0x1008, 8)]
+    parsed = {"f_lo": _member(False, "int f_lo(void) { return 0; }\n"),
+              "f_hi": _member(True, "int f_hi() { return 1; }\n")}
+    body, _w = tubuild.assemble_shadow_source("t/T", ord_rows, parsed)
+    assert 'extern "C" {' in body, "the .c member must be wrapped in a block"
+    assert 'extern "C" int f_lo' not in body, \
+        "prefixing the first line is defect 2: the linkage lands on a preamble decl"
+    assert body.index("f_hi") < body.index("int f_lo"), "source order must be reverse ROM"
+
+
+def test_long_calls_is_carried_in_position_and_bracketed():
+    ord_rows = [(0, "veneer", 0x1000, 8)]
+    parsed = {"veneer": _member(False, "int veneer(void) { return g(); }\n",
+                                pragmas=["#pragma long_calls on"])}
+    body, _w = tubuild.assemble_shadow_source("t/T", ord_rows, parsed)
+    on = body.index("#pragma long_calls on")
+    off = body.index("#pragma long_calls off")
+    assert on < body.index("int veneer") < off, \
+        "long_calls must open before its own member and close after it"
+
+
+def test_file_global_pragmas_are_still_left_out():
+    ord_rows = [(0, "f", 0x1000, 8)]
+    parsed = {"f": _member(False, "int f(void) { return 0; }\n",
+                           pragmas=["#pragma optimize_for_size on"])}
+    body, _w = tubuild.assemble_shadow_source("t/T", ord_rows, parsed)
+    assert body.count("#pragma optimize_for_size") == 0 or \
+        "NOT carried" in body.split("optimize_for_size", 1)[1][:200], \
+        "file-global pragmas poison a merged TU and stay advisory-only"
+
+
+def test_sourceless_member_becomes_a_banner_not_a_refusal():
+    ord_rows = [(0, "ghost", 0x1000, 8), (1, "real", 0x1008, 8)]
+    parsed = {"ghost": _member(False, "", missing=True),
+              "real": _member(True, "int real() { return 1; }\n")}
+    body, _w = tubuild.assemble_shadow_source("t/T", ord_rows, parsed)
+    assert "SOURCELESS member ghost" in body
+    assert "int real()" in body

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1281,7 +1281,21 @@ def cmd_verify(args):
     # only the fields this run has an opinion on; leave later-phase fields (symbol
     # addresses, module/ROM build) alone since verify never touches those.
     criteria = entry["verification"].setdefault("criteria", {})
-    criteria.update({
+
+    def _keep_richer(key, verdict):
+        """A curated criteria value often carries evidence prose ('PASS --
+        reloc_audit.check_destinations(): 57 relocations, 57 OK, 0 WRONG-DEST').
+        Overwriting it with a bare verdict destroys strictly more informative
+        text every run (notes/tubuild-defects, defect 1). Keep the existing
+        text whenever it already states the SAME verdict and says more; replace
+        it only when this run's verdict differs."""
+        old = criteria.get(key)
+        if isinstance(old, str) and old.split()[0].rstrip(":,") == verdict.split()[0] \
+                and len(old) > len(verdict):
+            return old
+        return verdict
+
+    for key, verdict in {
         "every_declared_function_defined": "PASS" if not any(v == "MISSING" for _o, _s, v in rows) else "FAIL",
         "every_declared_function_bytes_match": "PASS" if all_bytes_ok else "FAIL",
         "declared_function_set_equals_defined_function_set":
@@ -1290,7 +1304,8 @@ def cmd_verify(args):
         "functions_occur_in_expected_order":
             "PASS" if not bad_pairs else f"PARTIAL -- ordinal pair(s) not in ROM order: {bad_pairs}",
         "relocation_destinations_verified": "PASS" if all_reloc_ok else "FAIL -- see DIFF/objisolate lines above",
-    })
+    }.items():
+        criteria[key] = _keep_richer(key, verdict)
     if text_verified and entry.get("status") == "shadow":
         entry["status"] = "text-verified"
     elif not text_verified and entry.get("status") == "text-verified":

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -535,6 +535,7 @@ def cmd_inspect(args):
 
 _CPP_MARKER = "//cpp"
 _PRAGMA_LINE_RE = re.compile(r'^\s*#\s*pragma\b.*$')
+_LONG_CALLS_ON_RE = re.compile(r'^\s*#\s*pragma\s+long_calls\s+on\b')
 _INCLUDE_RE = re.compile(r'^\s*#\s*include\s*.+$')
 _DEFINE_RE = re.compile(r'^\s*#\s*define\b.*$')
 _DECL_KEYWORDS = ("struct", "class", "enum", "typedef", "namespace")
@@ -723,14 +724,17 @@ def assemble_shadow_source(tu_id, ord_rows, parsed):
     out.append("")
 
     if pragma_hits:
-        out.append("/* TUBUILD WARNING -- #pragma directive(s) were present in the legacy")
-        out.append(" * sources of this TU and were NOT carried into this file automatically.")
-        out.append(" * Per notes/translation-unit-reconstruction-plan.md section 10, a pragma")
-        out.append(" * that was FUNCTION-scoped in its own one-function file can become")
-        out.append(" * TU-scoped once merged and silently change codegen for the OTHER")
-        out.append(" * functions here. Decide by hand whether/where each one still applies:")
+        out.append("/* TUBUILD NOTE -- #pragma directive(s) were present in the legacy sources")
+        out.append(" * of this TU. `#pragma long_calls` is POSITIONAL in mwccarm 2004/b56 and is")
+        out.append(" * carried verbatim before its own member below, bracketed with `off` so it")
+        out.append(" * cannot leak into later members (dropping it silently costs the pooled")
+        out.append(" * cross-overlay tail-call -- a byte diff; see ShutterBob in ov014).")
+        out.append(" * Any OTHER pragma is FILE-GLOBAL last-wins (opt_propagation,")
+        out.append(" * optimize_for_size) and is still left out: carried into a merged TU it")
+        out.append(" * would silently recompile every other member. Decide those by hand:")
         for name, p in pragma_hits:
-            out.append(f" *   {name}: {p}")
+            carried = "carried below" if _LONG_CALLS_ON_RE.match(p) else "NOT carried -- review"
+            out.append(f" *   {name}: {p}   [{carried}]")
         out.append(" */")
         out.append("")
 
@@ -783,15 +787,40 @@ def assemble_shadow_source(tu_id, ord_rows, parsed):
         out.append("/* " + "-" * 74 + " */")
         out.append(f"/* ROM ordinal {o} -- {name}, 0x{addr:08x}, size 0x{size:x} */")
         out.append("/* " + "-" * 74 + " */")
+        if p.get("missing"):
+            # No legacy source under src/. The candidate is still worth assembling
+            # for its other members; this range stays the ROM's own bytes and
+            # `verify` will honestly report the member as MISSING.
+            out.append(f"/* SOURCELESS member {name}: no file under src/ supplies it; the")
+            out.append(" * ROM's own bytes cover this range. Recover it before promotion. */")
+            out.append("")
+            continue
         for note in p["notes"]:
             out.append(note)
+        # `#pragma long_calls` is POSITIONAL (measured on 2004/b56, notes in the
+        # ov014 seed): carried verbatim before its own member and closed after it,
+        # so the pooled cross-overlay tail-call it forces cannot leak into later
+        # members. Other pragmas are file-global last-wins and are never carried.
+        long_calls_here = [pr for pr in p["pragmas"] if _LONG_CALLS_ON_RE.match(pr)]
+        for pr in long_calls_here:
+            out.append(pr + "  /* carried verbatim from the legacy file (positional) */")
         func_text = p["function_text"]
         if cpp_needed and not p["cpp"]:
             # A legacy .c file's identifier is unmangled by construction; giving the
             # merged C++ TU the same text without linkage protection would let the
             # compiler mangle it a second time (notes/double-mangling-defect.md).
-            func_text = 'extern "C" ' + func_text
-        out.append(func_text.rstrip("\n"))
+            # The linkage goes on a BLOCK around the member's whole text: prefixing
+            # the first line lands it on a preamble declaration and the definition
+            # is emitted mangled -- the TU then silently fails to define its own
+            # ROM symbol (notes/tubuild-defects, defect 2).
+            out.append('extern "C" {  /* .c-derived member: C linkage for the whole block */')
+            out.append(func_text.rstrip("\n"))
+            out.append("}")
+        else:
+            out.append(func_text.rstrip("\n"))
+        for pr in long_calls_here:
+            out.append("#pragma long_calls off  "
+                       "/* close the bracket: positional, must not leak downward */")
         out.append("")
 
     return "\n".join(out).rstrip("\n") + "\n", warnings
@@ -851,26 +880,41 @@ def cmd_create(args):
     if not ord_rows:
         raise SystemExit(f"{args.id}: tu_map lists no symbols.txt-resolvable functions")
 
-    missing = [name for _o, name, _a, _s in ord_rows if SP.path_for(name) is None]
-    if missing:
-        raise SystemExit(f"{args.id}: {len(missing)} function(s) have no legacy source under "
-                         f"src/, cannot assemble a starting point: {missing}")
-
+    # Neither a sourceless member nor an unsplittable file refuses the whole
+    # candidate any more (notes/tubuild-defects, defect 4): the largest TUs were
+    # only reachable by hand-assembly because one member's shape aborted create.
+    # A sourceless member becomes a banner (verify reports it MISSING, honestly);
+    # an unsplittable file is carried VERBATIM -- raw concatenation is exactly
+    # what six modules' hand-assembly did, byte-verified 222 functions.
+    pre_warnings = []
     parsed = {}
     for _o, name, _a, _s in ord_rows:
         legacy = SP.path_for(name)
+        if legacy is None:
+            pre_warnings.append(f"SOURCELESS: {name} has no legacy file under src/; a banner "
+                                f"marks its slot and verify will report the member MISSING")
+            parsed[name] = {"error": None, "cpp": False, "missing": True,
+                            "includes": [], "pragmas": [], "macros": [], "externs": [],
+                            "shadow_decls": [], "notes": [], "function_text": "",
+                            "legacy_path": f"<none for {name}>"}
+            continue
         text = legacy.read_text(encoding="utf-8", errors="ignore")
         p = split_legacy_source(text)
         p["legacy_path"] = legacy.relative_to(REPO).as_posix()
         if p["error"]:
-            raise SystemExit(
-                f"{args.id}: could not parse {p['legacy_path']} ({name}): {p['error']}\n"
-                f"This file's shape does not match tubuild's one-function-per-file "
-                f"assumption; assemble this TU by hand instead, the way pilot #1 did "
-                f"(see notes/tu-reconstruction-pilot-report.md).")
+            is_cpp = text.startswith("//cpp")
+            raw = text.split("\n", 1)[1] if is_cpp and "\n" in text else text
+            pre_warnings.append(f"RAW: {p['legacy_path']} ({name}) did not split "
+                                f"({p['error']}); carried verbatim -- its own includes/"
+                                f"declarations stay inside its member block")
+            p = {"error": None, "cpp": is_cpp, "raw": True,
+                 "includes": [], "pragmas": [], "macros": [], "externs": [],
+                 "shadow_decls": [], "notes": [], "function_text": raw,
+                 "legacy_path": p["legacy_path"]}
         parsed[name] = p
 
     body, warnings = assemble_shadow_source(args.id, ord_rows, parsed)
+    warnings = pre_warnings + warnings
 
     # mwccarm selects its C vs C++ FRONT END from the file's EXTENSION, not just
     # from -lang: the same source text compiled as .c under "-lang c99" emits the


### PR DESCRIPTION
The tooling PR promised in #1647: `tubuild create` learns the three behaviors that six modules of hand-assembly (ov009/ov014/ov029/ov045/ov070/ov077, 222 byte-verified functions) proved out — plus, as a separable second commit, the `verify` prose-destruction fix (defect 1).

**Commit 1 — the create repairs:**

1. **Linkage blocks, not prefixes (defect 2).** A `.c`-derived member's whole text is now wrapped in `extern "C" { }`. The old `extern "C" `-prefix landed the linkage on the member's first *declaration*, so the *definition* was emitted mangled and the TU silently failed to define its own ROM symbols (hit 36 of 41 members in one ov004 TU).
2. **`#pragma long_calls` carried in position, bracketed (the #1646 finding).** It is positional in mwccarm 2004/b56; create used to drop it, which silently costs the pooled cross-overlay tail-call — a byte diff. It is now emitted verbatim before its own member and closed with `off` after. File-global pragmas (`opt_propagation`, `optimize_for_size`) deliberately stay advisory-only: carried into a merged TU they'd recompile every other member (the ov062/001 lesson). The banner now says per-pragma which treatment applied.
3. **No more whole-candidate refusals (defect 4).** An unsplittable legacy file (the `extern "C" { }`-wrapped-body shape that forced hand-assembly on four of six modules) is carried **verbatim** — raw concatenation, exactly what the hand assembler did. A sourceless member becomes a banner comment and `verify` reports it MISSING, honestly.

**A/B proof against reality:**

| case | before | after |
|---|---|---|
| `create ov070/Amp` | hard refusal: "could not parse … assemble by hand" | generates; all five `.c` members block-wrapped; conflicts flagged not resolved |
| `create ov029/ArrowLift` → verify | pragma silently dropped → 999-word DIFF on the veneer until hand-restored | **pragma carried automatically**; after re-applying only the same declaration reconciliations as the landed version: **9/9 MATCH, objisolate clean, reloc-destinations clean** |
| `create ov029/FloatOnWaterPlatformWdwSquare` → verify | (old create generated it, minus safety) | **4/4 MATCH, all three checks clean** after the same two known reconciliations |

The regenerated text differs from the committed hand-assembled sources but byte-verifies identically — the bytes are the standard, so the committed sources stay canonical and this PR ships **zero** src_tu/manifest churn (working tree restored and re-verified clean).

Four new unit tests pin the emitted-text contract (block-not-prefix, positional bracket, file-global pragmas advisory, sourceless banner). The suite's 4 pre-existing failures are unchanged — same set re-measured on origin/main before and after.

**Commit 2 — verify stops destroying curated prose (defect 1, trivially separable so included).** `criteria.update()` replaced values like `"PASS -- reloc_audit.check_destinations(): 57 relocations, 57 OK, 0 WRONG-DEST"` with a bare `"PASS"` on every run — the reason the standing protocol was "git checkout the manifest after any verify". A curated value now survives when it states the same verdict this run measured and says more; it is replaced only when the verdict changes. Functionally proven: curated prose planted in ov029/ArrowLift's criteria survived a full re-verify unchanged.

**Verification, at exactly this tip (bf2d172af):**

```
pyflakes tools/tubuild.py tools/test_tubuild.py: clean
pytest tools/test_tubuild.py: 11 passed, 4 failed -- the identical pre-existing set as origin/main
module fidelity: 106/106 exact, 100.000000%, mismatching: 0, ROM-build analysis: PASS
unresolved symbols: 45 (baseline 45)   [check_references: OK]
eligible name list: byte-identical to origin/main's own run (11,064 = 11,064, diff exit 0)
langmode ratchet PASS [fresh chaos-data bank]; port-refcheck: 393/393
git status: clean -- no manifest or config churn
```

If the validator reports attribution `CREDIT CHANGED`, that is expected and per standing policy not a blocker.

## Plain-English TL;DR

Our tool that merges single-function files back into real source files had three long-standing bugs that forced most of that work to be done by hand: it put a language-linkage marker on the wrong line (so the compiler quietly renamed functions), it deleted a compiler directive that changes how function calls are encoded (a silent byte difference), and it refused entire jobs when a single file confused its parser. All three fixes are transplants of the hand process that has already produced 222 byte-verified functions, proven by regenerating two previously-hand-built files and matching the cartridge again. A fourth bug — the verifier overwriting carefully written audit notes with a bare "PASS" — is fixed in a second commit, so the notes survive re-verification now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WasbE1QEmFdSreEKNKbVSP
