### PR TITLE
Fix code block syntax highlighting in all .md files, pass 1: BOILERPLATE

### DIFF
--- a/.claude/skills/decomp-cpp-class-form/SKILL.md
+++ b/.claude/skills/decomp-cpp-class-form/SKILL.md
@@ -10,7 +10,7 @@ Byte-matching a real C++ class is a question about **source form**, not about be
 
 ## Ask the compiler, don't hand-mangle
 
-```
+```sh
 python tools/mangle.py candidate.cpp
 python tools/mangle.py candidate.cpp --expect _ZN5Actor8BehaviorEv
 python tools/mangle.py candidate.cpp --mangled-only --json

--- a/.claude/skills/decomp-match-review/SKILL.md
+++ b/.claude/skills/decomp-match-review/SKILL.md
@@ -152,7 +152,7 @@ Report each hit; do not editorialize.
    `clang-format --dry-run -Werror <changed files>`. Where none exists, do not propose one.
 
 2. **Magic addresses.** Grep changed files for hardware-map literals used inline:
-   ```
+   ```sh
    grep -nE '\b0x0?[4-7][0-9a-fA-F]{6}\b' <changed files>
    grep -n 'reinterpret_cast<volatile' <changed files>
    ```
@@ -206,7 +206,7 @@ Report each hit; do not editorialize.
 
 9. **Signature changes in shared headers.** Diff headers *alone* first — this is where scope
    creep hides and where tree-wide regressions originate:
-   ```
+   ```sh
    gh api repos/<r>/pulls/<n>/files --paginate \
      --jq '.[] | select(.filename|test("\\.hp?p?$")) | .filename, .patch'
    ```
@@ -228,7 +228,7 @@ Report each hit; do not editorialize.
 12. **Port reference integrity — blocking, and the maintainer's own written rule.** If the diff
     contains *any* rename, file move, or `.c`→`.cpp` migration
     (`git diff --name-status origin/main | grep -E '^[RD]'`), run:
-    ```
+    ```sh
     python tools/port_refcheck.py
     ```
     sm64ds's in-tree `port/` references `src/` by literal path and symbol name — the
@@ -401,7 +401,7 @@ The one greppable hazard hostgen cannot absorb, because it transforms text and l
 addresses alone — a **write** through a computed `0x04…` address. Reads still work through the
 mapped latch window; write-triggered side effects silently do not fire:
 
-```
+```sh
 grep -nE '\*\s*\(\s*(volatile\s+)?(u8|u16|u32|unsigned)[a-z ]*\*\s*\)\s*\(\s*0x0?4' <changed files>
 ```
 
@@ -478,7 +478,7 @@ Genuinely unbuilt, and still worth proposing:
 
 Order by what blocks the merge, not by file. Suggested shape:
 
-```
+```markdown
 ## Verification        (what you rebuilt, with which compiler, and what you could not check)
 ## Blocking
 ## Should fix

--- a/.claude/skills/decomp-tu-build/SKILL.md
+++ b/.claude/skills/decomp-tu-build/SKILL.md
@@ -12,7 +12,7 @@ the merge and proving it**. For deciding *which* functions belong together, read
 
 ## 0. Prerequisites, in this exact order
 
-```
+```sh
 python tools/rtti_extract.py     # -> build/rtti.json
 python tools/rtti_vtables.py     # -> build/rtti_vtables.json
 python tools/tu_map.py           # -> build/tu_map.json
@@ -41,7 +41,7 @@ Measured on `main` at `343eab070` with the full chain: **74 modules, 11,091 func
 
 ## 1. The loop
 
-```
+```sh
 python tools/tubuild.py list                      # candidate worklist
 python tools/tubuild.py inspect ov045/PoleLift    # one candidate, full detail
 python tools/tubuild.py create  ov062/Chuckya     # generate a shadow .cpp
@@ -119,7 +119,7 @@ reported MATCH.
 
 **Always confirm the run reported all three.** `verify` prints the first two as labelled
 lines and folds the third into its verdict line:
-```
+```sh
 byte comparison   : 7/7 MATCH  (tools/match.py extract_func + compare, relocation-aware)
 objisolate check  : clean  (tools/objisolate.py plan() -- relocation type/addend ...)
 ...
@@ -158,7 +158,7 @@ produced.
 Once a root exists, one ordering constraint on it is absolute: **`dsd delink` must run
 before `dsd objdiff`**, because objdiff consumes what delink wrote.
 
-```
+```sh
 tools/bin/dsd.exe delink  -c config_tu/arm9/config.yaml
 tools/bin/dsd.exe objdiff -c config_tu/arm9/config.yaml -o build/tu/objdiff
 ```

--- a/.claude/skills/decomp-tu-slicing/SKILL.md
+++ b/.claude/skills/decomp-tu-slicing/SKILL.md
@@ -12,7 +12,7 @@ on it.
 
 ## 0. Regenerate the map, in this order
 
-```
+```sh
 python tools/rtti_extract.py     # -> build/rtti.json
 python tools/rtti_vtables.py     # -> build/rtti_vtables.json
 python tools/tu_map.py           # -> build/tu_map.json
@@ -56,7 +56,7 @@ boundaries `{low: 68, medium: 110, high: 280}`, 400/532 carrying a class.
 methods interleaved in source order, so they look like many alternating blocks and are
 in fact one TU. Never slice on "the class name changed."
 
-```
+```sh
 python tools/tu_map.py --module ov080
 ov080: 86 functions -> 5 TUs (4 with a class), 3 sinits / 3 ctor entries [ok]
   0x2123740-0x2124a20    26 fn  MontyMole, MontyMoleRock, daChoropu_c   <- ONE TU

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ the ROM. Green = byte-verified = mergeable. Red means at least one file either:
 
 Do not open a PR expecting a maintainer to "fix it up." Verify locally first:
 
-```
+```sh
 python tools/match.py --c yourfile.c --func <name> --addr 0x<addr> --size 0x<size> --version 2004/b56
 ```
 
@@ -58,7 +58,7 @@ Most files are in `src/` itself, but that is a fact about the tree, not a rule. 
 it are grouped (`src/engine/fader/`, `src/actors/daTrs_c/`, `src/unnamed/ov063/`), and more
 will be. **Do not compose the path yourself** — ask:
 
-```
+```sh
 python tools/srcpath.py <symbol>              # where it lives now, if it exists
 ```
 
@@ -78,7 +78,7 @@ deliberate, separate, **rename-only** PR (see #970 and #975).
 **Banking a near-miss** (do this instead of committing it to `src/`): write your draft
 to a one-line-per-entry seeds file `{"name": "<symbol>", "c_source": "<the C>"}` and run
 
-```
+```sh
 python tools/nearmiss_db.py ingest --seeds my_seeds.jsonl --label <your-handle>
 ```
 
@@ -97,7 +97,7 @@ moves the codegen of every file that includes it, including files your diff neve
 So:
 
 - Before pushing a header edit, list what it touches and verify all of it:
-  ```
+  ```sh
   python tools/affected_src.py include/types.h        # who consumes it
   python tools/prepush_linkcheck.py --range origin/main..HEAD   # verifies consumers too
   ```
@@ -119,7 +119,7 @@ and `extern "C"`. None of that is compiled by the normal decomp toolchain or `to
 so a rename, a `.c`-to-`.cpp` migration, or a file move can silently strand a `port/`
 reference. Before pushing anything that renames or moves a `src/`/`include/` file, run:
 
-```
+```sh
 python tools/port_refcheck.py
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,14 +48,14 @@ You bring your own copy of the game. Nothing copyrighted lives in this repo.
    binary for your platform from the releases page and put it at `tools/bin/dsd.exe`
    (`tools/bin/` is git-ignored).
 4. **Python 3** plus a few packages:
-   ```
+   ```sh
    pip install ndspy capstone pyelftools    # core
    pip install py7zr pefile                # only for tools/recover_cw2004.py
    ```
 
 ## First-time setup
 
-```
+```sh
 git clone https://github.com/tangosdev/sm64ds-decomp
 cd sm64ds-decomp
 pip install ndspy capstone pyelftools py7zr pefile
@@ -76,7 +76,7 @@ accept `2004/b56`, so a sweep hit under another version is iteration, never a ve
 The pinned matching compiler is **mwccarm `2004/b56`** (reproduces more of this
 corpus than the 1.2 service packs; see `notes/rom-build.md`). Flags:
 
-```
+```sh
 -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
 ```
 
@@ -85,12 +85,12 @@ sweeps. The ROM **linker** is still 1.2/sp2p3 `mwldarm` (b56 ships no linker).
 
 1. **Pick an unmatched function.** Ask in Discord or claim it on an issue.
 2. **Disassemble it** to see what you're matching:
-   ```
+   ```sh
    python tools/disasm.py extracted/arm9.bin --offset 0x... --length 0x...
    ```
 3. **Write C** for it (scratch first is fine).
 4. **Compile + byte-diff**, relocation-aware:
-   ```
+   ```sh
    python tools/match.py --c yourfile.c --func name --addr 0x020xxxxx --size 0x.. \
        --version 2004/b56
    ```
@@ -118,14 +118,14 @@ to matching but not exact - many are only 1-4 instructions off. Each record carr
 function name, address, the candidate C, and how many instructions diverge. These are the
 best-value functions to finish by hand:
 
-```
+```sh
 python tools/nearmiss_db.py list --max-div 4
 ```
 
 then take the stored `c_source` as your starting point and iterate with
 `tools/fdiff.py` (prints exactly which instructions differ, relocation-aware):
 
-```
+```sh
 python tools/fdiff.py --c yourfile.c --name FUNC --module ov0xx --addr 0x... --size 0x...
 ```
 
@@ -193,7 +193,7 @@ push to main and records both stores for whatever landed, so the only thing it n
 from you is a statement of method it can trust. Put one line in a commit message or the
 PR description:
 
-```
+```sh
 Provenance: ai model=grok-4.5 reasoning=high harness=grok-build
 Provenance: human
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The matching compiler is pinned to **mwccarm 2004/b56** with these flags (the 1.
 `base`/`sp2`/`sp2p3` trio remains available for version sweeps; the linker is still
 1.2/sp2p3 `mwldarm`, because b56 ships no linker):
 
-```
+```sh
 -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
 ```
 
@@ -168,7 +168,7 @@ is in [CONTRIBUTING.md](CONTRIBUTING.md) and
 
 Short version:
 
-```
+```sh
 pip install ndspy capstone pyelftools
 # get mwccarm per notes/setup-mwccarm.md, then:
 python tools/unpack.py "path/to/your-own-sm64ds.nds"

--- a/audit/enrollment_report.md
+++ b/audit/enrollment_report.md
@@ -297,7 +297,7 @@ Stated so nobody reads more into this than it carries.
 
 ## 8. How to reproduce
 
-```
+```sh
 python tools/chaos_db_ci.py --out chaos-db.json      # emits the enrollment field
 python tools/linkcheck.py --module ov006 -j 10       # the byte gate, per module
 python tools/eligible.py -j 16                       # drop-in eligibility, per file

--- a/notes/collision-query-classes.md
+++ b/notes/collision-query-classes.md
@@ -118,7 +118,7 @@ hit path, i.e. a `hasClsn` byte, the same role `RaycastGround.h` already names a
 `include/SphereClsn.h` does not have — both fall inside its `pad_039[0x3b]`, and both land
 inside the polymorphic sub-object at 0x38 identified above. Straight off the entry code:
 
-```
+```arm
 add r0, fp, #0x3c     then [r0], [r0,#4], [r0,#8]   -> a Vector3 CENTRE at 0x3c
 ldr r0, [fp, #0x48]                                 -> the RADIUS at 0x48
 ```
@@ -215,7 +215,7 @@ loop supplies, not a source defect -- do not chase it before the body exists.
 
 **Where the sphere diverges, and it is the thing to design around.** After the descent:
 
-```
+```arm
 ldr r2,[sp,#0x88]                     the leaf just found
 cmp r2,[sp,#0x48] -> beq skip         THREE previously-visited leaves
 cmp r2,[sp,#0x4c] -> beq skip
@@ -241,7 +241,7 @@ novel part.
 The score is `cy`, the cell's remaining Y extent — the same key the Line overload uses for
 its single `rowStep`/`rowLeaf`, kept three deep and sorted descending:
 
-```
+```arm
 cmp cy,[0x7c]  ble skip     s3 -- below all three, no insert
 cmp cy,[0x78]  ble ins3
 cmp cy,[0x74]  ble ins2
@@ -286,7 +286,7 @@ All fourteen now have meanings, which fixes declaration order for the whole func
 
 **The first six are three running min/max pairs.** Every write site is the same shape:
 
-```
+```arm
 cmp v,[sp,#0x2c] ; strgt v,[sp,#0x2c] ; bgt skip      if (v > hi) hi = v
 cmp v,[sp,#0x28] ; strlt v,[sp,#0x28]                 else if (v < lo) lo = v
 ```
@@ -423,13 +423,13 @@ The claim above that our target "never writes through `fp` -- there is not one
 Grepping for the `[fp, #imm]` addressing form cannot see a write that goes through a register
 derived from `fp`, and that is exactly what this function does:
 
-```
-01FFCFFC  add  r0, fp, #0x10      &sphere->result
+```arm
+01FFCFFC  add  r0, fp, #0x10     ; &sphere->result
 01FFD000  bl   0x2037fd4          func_02037fd4(&sphere->result, triID, info)
-01FFD008  add  r4, fp, #0x70      r4 = &sphere->flags
+01FFD008  add  r4, fp, #0x70      ; r4 = &sphere->flags
 01FFD010  ldrb r0, [r4]
-01FFD014  orr  r0, r0, #1         flags |= 1   (general hit)
-01FFD018  strb r0, [r4]           <-- a write to the object
+01FFD014  orr  r0, r0, #1         ; flags |= 1   (general hit)
+01FFD018  strb r0, [r4]          ; <-- a write to the object
 ```
 
 Counted properly — every `str`/`strb` whose base is not `sp` — there are **eight**: four
@@ -465,7 +465,7 @@ The per-prism opening is the matched `DetectClsn(RaycastGround&)` twin's, with o
 substitution — where the twin uses a fixed `0x20000` tolerance the sphere uses **its own
 radius**:
 
-```
+```arm
 ldrh r2,[r0,#2]!         *++leaf, the writeback walker
 add  r0, r1, r2, lsl #4  tri = &file->tris[lv]
 mul  r1, tri->posIdx, #0xc
@@ -487,7 +487,7 @@ The units work out: `d` is raw, normals are `1.0 == 0x400`, and `rsc = radius <<
 
 Straight after the face test:
 
-```
+```arm
 ldrb r0,[sl,#0x34]        this->unk_34
   set   -> reject unless faceDot >= -0x50000
 ldrb r0,[sl,#0x35]        this->unk_35
@@ -541,7 +541,7 @@ classification**, and it lines up one-for-one with what the wrappers told us:
 
 The accept path, in order:
 
-```
+```arm
 sub  r0, rsc, faceDot ; str [sp,#0x9c]     penetration depth along the face normal
 bl   func_020396dc    ; str [sp,#0xa0]     triID
 ldr  r3,[r3,#0xc] ; blx r3                 GetSurfaceInfo -- REAL virtual call, slot 3
@@ -579,7 +579,7 @@ return 0/1/2), and these three one-line recorders (which offset each writes). Cl
 
 Per hit, in ROM order:
 
-```
+```c
 func_02037fd4(&sphere->result /*0x10*/, triID, info)    always, the shared result
 sphere->flags |= 1
   cls 0 floor: if !(flags & 4) { func_020379f4(...); ret |= 1 }
@@ -614,7 +614,7 @@ address.
 The unexamined 0x1ffbe80..0x1ffcff0 -- about 1100 of the function's 1778 words -- has a
 simple shape once you see the dispatch:
 
-```
+```arm
 bl 0x2039488 ; cmp r0,#0 ; bne reject     ShouldPassThroughImpl(this, info, sphere, flag)
 cmp r8,r7 / cmp r8,r6 / cmp r7,r6         which of the three EDGE dots is largest
 cmp r8,#0  ; ble 0x1ffcaa4                largest <= 0 -> centre is INSIDE -> face case
@@ -644,7 +644,7 @@ allowed to pass through never reaches the accumulators.
 
 **Order of the per-prism body, settled:**
 
-```
+```text
 1  three edge-normal rejects, then the face-normal reject
 2  depth = rsc - faceDot
 3  triID, GetSurfaceInfo (real virtual call), CopyNormalTo, classify on normal.Y
@@ -664,7 +664,7 @@ Inside each of the three symmetric branches, before any distance is computed, th
 test that decides **edge contact vs vertex contact**. For the branch where edge 1's dot is
 largest:
 
-```
+```arm
 smull en1.z, en2.z ; >>10        three component products of the two EDGE NORMALS,
 smull en1.x, en2.x ; >>10        summed:
 smull en1.y, en2.y ; >>10          nn = dot(en1, en2) >> 10
@@ -706,7 +706,7 @@ reproduce the ROM's control flow.
 
 What is actually there:
 
-```
+```arm
 0x1ffbea8   dispatch: which of dot1/dot2/dot3 is largest      -> 3 blocks
 0x1ffc1ec   E1   closest point is on edge 1                   \
 0x1ffc35c   E2   closest point is on edge 2                    > 3 EDGE blocks
@@ -742,7 +742,7 @@ Confirmed exhaustively -- every dispatch target, both arms:
 case's answer**. Every edge and vertex region overwrites it in the shared tail at
 `0x1ffca80`:
 
-```
+```c
 depth = SqrtRaw(rsq - d*d) - faceDot;      /* d = the winning edge dot */
 if (depth < 0) continue;                    /* `bmi 0x1ffd314` */
 ```
@@ -826,7 +826,7 @@ until the candidate is the target's size. Score the intermediate drafts with the
 ratio instead, and note that `--align-shape` is a *modifier*: without `--align` it prints
 nothing at all and you get a silent no-op.
 
-```
+```python
 python tools/fdiff.py --c <draft> --name _ZN12MeshCollider10DetectClsnER10SphereClsn \
   --module itcm --addr 0x01ffb830 --size 0x1bc8 --version 2004/b56 \
   --align --align-shape --align-changes 0 --quiet
@@ -847,7 +847,7 @@ them.
 
 It is gated four ways, all of which must pass:
 
-```
+```c
 sphere.unk_108 >= surfaceNormal.y      0x1ffcaa4   (already in the draft)
 sphere.unk_ec  >  0                    0x1ffcab4
 cls == 1                               0x1ffcac0   walls only
@@ -918,7 +918,7 @@ and the edge normals are not.
 > **The slab is ASYMMETRIC.** The original quoted four instructions and stopped one short.
 > `r1` is redefined:
 >
-> ```
+> ```arm
 > 01ffcf9c  ldr r6,[fp,#0xec]      wallHeight
 > 01ffcfa0  ldr r3,[fp,#0x48]      radius
 > 01ffcfa8  add r1, r6, r3         HI  =  ec + rad
@@ -1021,7 +1021,7 @@ into codegen. Section 1 of the handoff has been corrected.
 
 ### What the frame comparison actually shows (2026-08-06)
 
-```
+```c
 ROM        sub sp, sp, #0x1b4     f -> sp+0x0c      &centre -> sp+0xc4
 candidate  sub sp, sp, #0x1dc     f -> sp+0x0c      &centre -> sp+0x10
 ```
@@ -1095,7 +1095,7 @@ The ROM's aggregate block, read straight off the frame and now mirrored in the d
 declaration order (byte-neutral, but it is the known-correct answer so there is no reason to
 hold a different one):
 
-```
+```arm
 0x16c  cr[3]   s16, 2 words   the cross scratch, reused by both KCL_VERTEX rounds
 0x174  nrm[3]                 the DotVec3 argument in the unk_35 branch
 0x180  sn                     the surface normal
@@ -1137,7 +1137,7 @@ Re-scoping does not free one either, so C scope is not driving slot reuse.
 
 And the decisive measurement:
 
-```
+```arm
 below 0x180 : ROM 87   cand 87
 below 0x1a0 : ROM 95   cand 95
 below 0x1b0 : ROM 99   cand 99      <- ROM's highest slot is 0x1ac
@@ -1211,7 +1211,7 @@ are live at once across the prism body — not anything in the declaration block
 The theory was that the draft holds loop state in registers where the ROM spills it, starving
 the prism body. **It does not.** The ROM's loop tails are pure memory traffic:
 
-```
+```arm
 0x1ffd314  ldr r0,[sp,#0x88] ; ldrh r2,[r0,#2]! ; str r0,[sp,#0x88] ; cmp r2,#0 -> body
 0x1ffd328  x += [sp+0x68] ; cmp against [sp+0x14]      (x at 0x84, stepX 0x68, hiX 0x14)
 0x1ffd344  y += [sp+0x6c] ; cmp against [sp+0x1c]      (y at 0x80, stepY 0x6c, hiY 0x1c)

--- a/port/docs/opie-assessment.md
+++ b/port/docs/opie-assessment.md
@@ -230,7 +230,7 @@ mirrored 1:1. And use `-fno-strict-aliasing` regardless.)
 
 **All five `cybervisi0n` repos are GitHub forks of `ntrtwl/*`**, verified via the API:
 
-```
+```sh
 libntr        fork=true  parent=ntrtwl/NitroSDK     license=none
 libntrsystem  fork=true  parent=ntrtwl/NitroSystem  license=none
 libntrwifi    fork=true  parent=ntrtwl/NitroWiFi    license=none

--- a/tools/trace/README.md
+++ b/tools/trace/README.md
@@ -17,7 +17,7 @@ Status: **Phase 0 spike** (attach + breakpoint + canary + register/mem dump).
 
 1. Install melonDS (Qt frontend — the GDB stub lives there).
 2. Emu settings → enable the GDB stub. In `melonDS.ini` the keys are roughly:
-   ```
+   ```ini
    GdbEnabled=1
    GdbPortARM9=3333
    GdbPortARM7=3334
@@ -34,7 +34,7 @@ DeSmuME fallback: launch with `--arm9gdb=3333`; everything below is identical.
 
 ## Run the spike
 
-```
+```sh
 # default: 6 small always-resident arm9 funcs, 20s window
 python tools/trace/gdb_harness.py --duration 20
 
@@ -118,7 +118,7 @@ Port=3333 BreakOnStartup=true`, `[JIT] Enable=false`; clone
 `reference/DynamicAllocationDecomp` for actor-ID names.
 
 Use:
-```
+```sh
 1. start melonDS with sm64.nds        (game waits, halted, for the client)
 2. python tools/trace/actors.py       (attaches, releases the boot, prompts)
 3. play; press Enter to snapshot, or type "star exploded" + Enter to tag one


### PR DESCRIPTION
## What this changes
Here begins the revamp and cleanup of fenced `.md` code blocks in the entire documentation, until currently. 

This is phase 1, focusing on ***boilerplate***, before the big `notes` folder with sub `archive`.

Folders:

- `.claude\skills`
- `audit`
- `port\docs`
- `tools`
- `notes` - one file only as a test

Root repo folder files:

- `AGENTS.MD`
- `CONTRIBUTING.MD`
- `README.MD`
