### PR TITLE
Type 43 header placeholders from reference field offsets (36 markers + 7 widths)

### DIFF
--- a/include/BasementWater.h
+++ b/include/BasementWater.h
@@ -23,8 +23,7 @@ struct BasementWater : dBgActor_c {
     TextureTransformer mTextureTransformer;/* 0x320 */
     s32 mLoweredY;                    /* 0x334 */
     u32 unk_338;                      /* 0x338 */
-    u8 unk_33c;                       /* 0x33c */
-    u8  pad_33d[0x1];
+    u16 unk_33c;              /* 0x33c */
     u8 unk_33e;                       /* 0x33e */
 
     /* --- vtable --- */
@@ -65,14 +64,10 @@ struct BasementWater {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mTextureTransformer;            /* 0x320 */
-    u8  pad_321[0xb];
-    s32 unk_32c;            /* 0x32c */
-    u8  pad_330[0x4];
+    TextureTransformer mTextureTransformer; /* 0x320 */
     s32 mLoweredY;            /* 0x334 */
     u32 unk_338;            /* 0x338 */
-    u8  unk_33c;            /* 0x33c */
-    u8  pad_33d[0x1];
+    u16 unk_33c;              /* 0x33c */
     u8  unk_33e;            /* 0x33e */
 };
 

--- a/include/BigMovingIceBlock.h
+++ b/include/BigMovingIceBlock.h
@@ -6,6 +6,7 @@
 #define BIGMOVINGICEBLOCK_H
 #include "types.h"
 #include "Model.h"
+#include "PathPtr.h"
 
 struct BigMovingIceBlock {
     u8  pad_000[0x8];
@@ -24,8 +25,7 @@ struct BigMovingIceBlock {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mPath;            /* 0x320 */
-    u8  pad_321[0x7];
+    PathPtr mPath;            /* 0x320 */
     s32 mPathNodeIdx;            /* 0x328 */
     s32 mPathDir;            /* 0x32c */
 #ifdef __cplusplus

--- a/include/CastleWater.h
+++ b/include/CastleWater.h
@@ -20,6 +20,7 @@
 #define CASTLEWATER_H
 #include "types.h"
 #include "math/Matrix.h"
+#include "TextureTransformer.h"
 
 struct CastleWater {
     u8  pad_000[0x5c];
@@ -45,12 +46,7 @@ struct CastleWater {
        dBgW_KcMbg::SetFile through an explicit `Matrix4x3&` cast. */
     Matrix4x3 mMatrix;            /* 0x2ec */
     u8  pad_31c[0x4];
-    u8  mTexTransformer;            /* 0x320 */
-    u8  pad_321[0xb];
-    /* Inside the TextureTransformer at its +0xc. Behavior rewrites it to
-       0x1000 EVERY frame before advancing the animation, so the scroll runs at
-       a fixed rate no matter what else touched it. */
-    s32 unk_32c;            /* 0x32c */
+    TextureTransformer mTexTransformer; /* 0x320 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/Clam.h
+++ b/include/Clam.h
@@ -6,6 +6,7 @@
 #define CLAM_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "dCcAc_c.h"
 
 struct Clam {
     u8  pad_000[0x5c];
@@ -22,12 +23,7 @@ struct Clam {
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the
        Animation base), which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mdCcAc_c;            /* 0x138 */
-    u8  pad_139[0x17];
-    u8  unk_150;            /* 0x150 */
-    u8  pad_151[0xb];
-    s32 unk_15c;            /* 0x15c */
-    u8  pad_160[0xc];
+    dCcAc_c mdCcAc_c;         /* 0x138 */
     /* 0 shut, 1 lunging -- the only two values Behavior's switch has arms
        for, and InitResources sets it to 0. */
     u8  mState;            /* 0x16c */

--- a/include/Coin.h
+++ b/include/Coin.h
@@ -6,6 +6,7 @@
 #include "ShadowModel.h"
 #include "dCcAc_c.h"
 #include "dBgCh_Actr.h"
+#include "math/Matrix.h"
 
 /* THREE WITNESSES:
  *
@@ -60,8 +61,7 @@ struct Coin : dActor_c {
        dBgCh_Actr's D1 at +0x1ac -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
     dBgCh_Actr mWithMeshClsn;            /* 0x1ac */
-    u8  unk_368;            /* 0x368 */
-    u8  pad_369[0x2f];
+    Matrix4x3 unk_368;        /* 0x368 */
     s32 unk_398;            /* 0x398 */
     u8  pad_39c[0x4];
     s32 mCoinType;            /* 0x3a0 */

--- a/include/ExtendingPlatform.h
+++ b/include/ExtendingPlatform.h
@@ -6,6 +6,7 @@
 #define EXTENDINGPLATFORM_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbgSclY.h"
 
 struct ExtendingPlatform {
     u8  pad_000[0x8e];
@@ -19,9 +20,7 @@ struct ExtendingPlatform {
        padding rather than being folded into the member. */
     Model mModel;            /* 0x0d8 */
     u8  pad_128[0x30];
-    u8  mCollider;            /* 0x158 */
-    u8  pad_159[0x4c];
-    u8  unk_1a5;            /* 0x1a5 */
+    dBgW_KcMbgSclY mCollider; /* 0x158 */
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();

--- a/include/FaderWipe.h
+++ b/include/FaderWipe.h
@@ -49,7 +49,7 @@ struct FaderWipe {
     Fix12i speed;       /* 0x08 (from Fader) */
     u16    unk_00c;     /* 0x0c (from FaderColor) */
     u8     pad_00e[0x2];
-    u8     model[0x50]; /* 0x10 */
+    Model model;              /* 0x010 */
 };
 #endif
 

--- a/include/Fog.h
+++ b/include/Fog.h
@@ -14,6 +14,12 @@ struct Fog {
     u16 unk_024;            /* 0x024 */
 };
 
+/* Over-determined, not assumed: Fog's own fields end at 0x026 and its widest
+   member is u16, so sizeof rounds to 0x26; independently, Stage.h places Fog at
+   0x96c with its next real field at 0x994 behind pad_992[0x2], i.e. a 0x26 span.
+   check_header_offsets.py sizes a member type from this typedef -- without it,
+   `Fog unk_96c;` is UNPARSED and blinds the checker to the rest of Stage.h. */
+typedef char Fog_size_must_be_0x26[sizeof(struct Fog) == 0x26 ? 1 : -1];
 typedef struct Fog Fog;
 
 #endif

--- a/include/Fog.h
+++ b/include/Fog.h
@@ -14,4 +14,6 @@ struct Fog {
     u16 unk_024;            /* 0x024 */
 };
 
+typedef struct Fog Fog;
+
 #endif

--- a/include/Goomboss.h
+++ b/include/Goomboss.h
@@ -2,6 +2,8 @@
 #define GOOMBOSS_H
 
 #include "types.h"
+#include "ModelAnim.h"
+#include "dBgCh_Actr.h"
 
 /* The Goomboss. Its destructor is the layout, and eight boundaries close on
  * sizes other headers assert:
@@ -106,8 +108,8 @@ struct Goomboss {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x16c];
-    u8  mModelAnim;            /* 0x210 */
-    u8  pad_211[0x1a7];
+    ModelAnim mModelAnim;     /* 0x210 */
+    u8  pad_274[0x144];
     s32 unk_3b8;            /* 0x3b8 */
     s32 unk_3bc;            /* 0x3bc */
     s32 unk_3c0;            /* 0x3c0 */
@@ -124,8 +126,8 @@ struct Goomboss {
     u8  pad_3f4[0x4];
     u8  mTextureTransformer;            /* 0x3f8 */
     u8  pad_3f9[0x13];
-    u8  mWithMeshClsn;            /* 0x40c */
-    u8  pad_40d[0x1bf];
+    struct dBgCh_Actr mWithMeshClsn; /* 0x40c */
+    u8  pad_5c8[0x4];
     s32 unk_5cc;            /* 0x5cc */
     s32 unk_5d0;            /* 0x5d0 */
     s32 unk_5d4;            /* 0x5d4 */

--- a/include/HugeWater.h
+++ b/include/HugeWater.h
@@ -47,9 +47,7 @@ struct HugeWater {
     Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mTextureTransformer;            /* 0x320 */
-    u8  pad_321[0xb];
-    s32 unk_32c;            /* 0x32c */
+    TextureTransformer mTextureTransformer; /* 0x320 */
 };
 
 #endif /* __cplusplus */

--- a/include/KnockDownPlank.h
+++ b/include/KnockDownPlank.h
@@ -71,8 +71,8 @@ struct KnockDownPlank {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mShadowModel;            /* 0x320 */
-    u8  pad_321[0x57];
+    ShadowModel mShadowModel; /* 0x320 */
+    u8  pad_348[0x30];
     s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */
     s32 unk_380;            /* 0x380 */

--- a/include/KoopaFlag.h
+++ b/include/KoopaFlag.h
@@ -6,13 +6,11 @@
 #define KOOPAFLAG_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "dCcAc_c.h"
 
 struct KoopaFlag {
     u8  pad_000[0xd4];
-    u8  mdCcAc_c;            /* 0x0d4 */
-    u8  pad_0d5[0x23];
-    u32 unk_0f8;            /* 0x0f8 */
-    u8  pad_0fc[0xc];
+    dCcAc_c mdCcAc_c;         /* 0x0d4 */
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x108 -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the

--- a/include/LightBeam.h
+++ b/include/LightBeam.h
@@ -6,15 +6,16 @@
 #define LIGHTBEAM_H
 #include "types.h"
 #include "Model.h"
+#include "dCcAcPos_c.h"
 
 struct LightBeam {
     u8  pad_000[0xd4];
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mdCcAcPos_c;            /* 0x124 */
-    u8  pad_125[0x43];
-    u8  unk_168;            /* 0x168 */
+    dCcAcPos_c mdCcAcPos_c;   /* 0x124 */
+    u8  pad_164[0x4];
+    u16 unk_168;              /* 0x168 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/MovingBar.h
+++ b/include/MovingBar.h
@@ -27,7 +27,8 @@ struct MovingBar : dBgActor_c {
        and MovingBarSmall_Spawn -- call fBase_c::operator new(0x338). They agree, so
        they are two spawn-info variants of one actor, and 0x330 was the field span
        rather than the size. */
-    u8 pad_330[0x8];                  /* 0x330, to the ROM's 0x338 */
+    u32 unk_330;              /* 0x330 */
+    u8  pad_334[0x4];
 
     /* --- vtable --- */
     virtual ~MovingBar();

--- a/include/PowerStar.h
+++ b/include/PowerStar.h
@@ -47,8 +47,8 @@ struct PowerStar : dEnemyBase_c {
     u8  pad_49e[0x1];
     u8                           unk_49f;               /* 0x49f */
     u8  pad_4a0[0x2];
-    u8                           unk_4a2;               /* 0x4a2 */
-    u8  pad_4a3[0x5];
+    u16 unk_4a2;              /* 0x4a2 */
+    u8  pad_4a4[0x4];
     s32                          unk_4a8;               /* 0x4a8 */
     s32                          unk_4ac;               /* 0x4ac */
     s32                          unk_4b0;               /* 0x4b0 */

--- a/include/PyramidTag.h
+++ b/include/PyramidTag.h
@@ -5,13 +5,11 @@
 #ifndef PYRAMIDTAG_H
 #define PYRAMIDTAG_H
 #include "types.h"
+#include "dCcAc_c.h"
 
 struct PyramidTag {
     u8  pad_000[0xd4];
-    u8  mdCcAc_c;            /* 0x0d4 */
-    u8  pad_0d5[0x23];
-    s32 unk_0f8;            /* 0x0f8 */
-    u8  pad_0fc[0xc];
+    dCcAc_c mdCcAc_c;         /* 0x0d4 */
     s32 unk_108;            /* 0x108 */
 #ifdef __cplusplus
     /* methods */

--- a/include/ShipWater.h
+++ b/include/ShipWater.h
@@ -77,10 +77,7 @@ struct ShipWater {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mTextureTransformer;            /* 0x320 */
-    u8  pad_321[0xb];
-    s32 unk_32c;            /* 0x32c */
-    u8  pad_330[0x4];
+    TextureTransformer mTextureTransformer; /* 0x320 */
     s32 unk_334;            /* 0x334 */
     u8  unk_338;            /* 0x338 */
     u8  pad_339[0x3];

--- a/include/SpinningPlatform.h
+++ b/include/SpinningPlatform.h
@@ -6,6 +6,7 @@
 #define SPINNINGPLATFORM_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
 
 struct SpinningPlatform {
     u8  pad_000[0x5c];
@@ -29,7 +30,7 @@ struct SpinningPlatform {
     u16 unk_320;            /* 0x320 */
     u16 unk_322;            /* 0x322 */
     s32 unk_324;            /* 0x324 */
-    u8  mShadowModel;            /* 0x328 */
+    ShadowModel mShadowModel; /* 0x328 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/SquarePathLift.h
+++ b/include/SquarePathLift.h
@@ -2,6 +2,7 @@
 #define SQUAREPATHLIFT_H
 
 #include "types.h"
+#include "PathPtr.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -19,8 +20,7 @@
 
 struct SquarePathLift : dBgActor_c {
     u8  pad_31e[0x2];
-    u8 mPath;                         /* 0x320 */
-    u8  pad_321[0x7];
+    PathPtr mPath;            /* 0x320 */
     s32 mNodeIndex;                   /* 0x328 */
     s32 mPathDir;                     /* 0x32c */
 
@@ -57,8 +57,7 @@ struct SquarePathLift {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mPath;            /* 0x320 */
-    u8  pad_321[0x7];
+    PathPtr mPath;            /* 0x320 */
     s32 mNodeIndex;            /* 0x328 */
     s32 mPathDir;            /* 0x32c */
 };

--- a/include/Squasher.h
+++ b/include/Squasher.h
@@ -2,6 +2,7 @@
 #define SQUASHER_H
 
 #include "types.h"
+#include "math/Matrix.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -35,7 +36,7 @@ struct Squasher : dBgActor_c {
     /* Tail padding. The field span stops short of the real size: Squasher_Spawn
        calls fBase_c::operator new(0x37c), read off the retail
        instruction. A span is only a LOWER BOUND. */
-    u8 pad_34c[0x30];      /* 0x34c, to the ROM's 0x37c */
+    Matrix4x3 pad_34c;        /* 0x34c */
 };
 
 typedef char Squasher_size_must_be_0x37c[sizeof(Squasher) == 0x37c ? 1 : -1];
@@ -75,7 +76,7 @@ struct Squasher {
     s16 unk_320;            /* 0x320 */
     u8  unk_322;            /* 0x322 */
     u8  pad_323[0x1];
-    u8  mShadowModel;            /* 0x324 */
+    ShadowModel mShadowModel; /* 0x324 */
 };
 
 #endif /* __cplusplus */

--- a/include/Stage.h
+++ b/include/Stage.h
@@ -4,6 +4,7 @@
 #include "dScene_c.h"
 #include "Model.h"
 #include "dBgW_Kc.h"
+#include "Fog.h"
 
 struct SceneRelated;
 struct LVL_Overlay;
@@ -152,10 +153,8 @@ struct Stage : dScene_c {
     Model mModel;             /* 0x86c */
     u8  pad_8bc[0x60];       /* Model ends 0x8bc; dBgW_Kc does not start until 0x91c */
     dBgW_Kc mMeshCollider; /* 0x91c */
-    u8  unk_96c;            /* 0x96c */
-    u8  pad_96d[0x1f];
-    u8  unk_98c;            /* 0x98c */
-    u8  pad_98d[0x7];
+    Fog unk_96c;       /* 0x96c */
+    u8  pad_992[0x2];
     u8  unk_994;            /* 0x994 */
     u8  pad_995[0x1f];
     u8  unk_9b4;            /* 0x9b4 */

--- a/include/TTC_MovingBeam.h
+++ b/include/TTC_MovingBeam.h
@@ -2,6 +2,7 @@
 #define TTC_MOVINGBEAM_H
 
 #include "types.h"
+#include "math/Matrix.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -37,7 +38,7 @@ struct TTC_MovingBeam : dBgActor_c {
     /* Tail padding. The field span stops short of the real size: TTC_MovingBeam_Spawn
        calls fBase_c::operator new(0x38c), read off the retail
        instruction. A span is only a LOWER BOUND. */
-    u8 pad_35c[0x30];      /* 0x35c, to the ROM's 0x38c */
+    Matrix4x3 pad_35c;        /* 0x35c */
 };
 
 typedef char TTC_MovingBeam_size_must_be_0x38c[sizeof(TTC_MovingBeam) == 0x38c ? 1 : -1];
@@ -75,7 +76,7 @@ struct TTC_MovingBeam {
     u8  unk_328;            /* 0x328 */
     u8  pad_329[0x7];
     s32 unk_330;            /* 0x330 */
-    u8  mShadowModel;            /* 0x334 */
+    ShadowModel mShadowModel; /* 0x334 */
 };
 
 #endif /* __cplusplus */

--- a/include/TinyWater.h
+++ b/include/TinyWater.h
@@ -23,7 +23,7 @@ struct TinyWater : dBgActor_c {
     TextureTransformer mTextureTransformer;/* 0x320 */
     s32 unk_334;                      /* 0x334 */
     u8  pad_338[0x4];
-    u8 unk_33c;                       /* 0x33c */
+    u16 unk_33c;              /* 0x33c */
 
     /* --- vtable --- */
     virtual ~TinyWater();
@@ -60,7 +60,7 @@ struct TinyWater {
     TextureTransformer mTextureTransformer;            /* 0x320 */
     s32 unk_334;            /* 0x334 */
     u8  pad_338[0x4];
-    u8  unk_33c;            /* 0x33c */
+    u16 unk_33c;              /* 0x33c */
 };
 
 #endif /* __cplusplus */

--- a/include/TowerStep.h
+++ b/include/TowerStep.h
@@ -75,8 +75,8 @@ struct TowerStep {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mShadowModel;            /* 0x320 */
-    u8  pad_321[0x57];
+    ShadowModel mShadowModel; /* 0x320 */
+    u8  pad_348[0x30];
     s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */
     s32 unk_380;            /* 0x380 */

--- a/include/TreasureChest.h
+++ b/include/TreasureChest.h
@@ -6,6 +6,7 @@
 #define TREASURECHEST_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "dCcAc_c.h"
 
 struct TreasureChest {
     u8  pad_000[0x8];
@@ -14,8 +15,8 @@ struct TreasureChest {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mdCcAc_c;            /* 0x138 */
-    u8  pad_139[0x39];
+    dCcAc_c mdCcAc_c;         /* 0x138 */
+    u8  pad_16c[0x6];
     u8  unk_172;            /* 0x172 */
     u8  pad_173[0x1];
     u8  unk_174;            /* 0x174 */

--- a/include/VolcanoFire.h
+++ b/include/VolcanoFire.h
@@ -5,10 +5,11 @@
 #ifndef VOLCANOFIRE_H
 #define VOLCANOFIRE_H
 #include "types.h"
+#include "dCcAc_c.h"
 
 struct VolcanoFire {
     u8  pad_000[0xd4];
-    u8  mdCcAc_c;            /* 0x0d4 */
+    dCcAc_c mdCcAc_c;         /* 0x0d4 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/WDW_Water.h
+++ b/include/WDW_Water.h
@@ -64,10 +64,7 @@ struct WDW_Water {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    u8  mTextureTransformer;            /* 0x320 */
-    u8  pad_321[0xb];
-    s32 unk_32c;            /* 0x32c */
-    u8  pad_330[0x4];
+    TextureTransformer mTextureTransformer; /* 0x320 */
     s32 mTargetPosY;            /* 0x334 */
     u8  unk_338;            /* 0x338 */
     u8  pad_339[0x3];

--- a/include/dBgCh_Actr.h
+++ b/include/dBgCh_Actr.h
@@ -4,6 +4,10 @@
 #include "types.h"
 #include "dBgCh.h"
 
+/* Only a pointer to it is stored, so a forward declaration is enough -- and
+   this header reaches 826 translation units. */
+struct dActor_c;
+
 /* An dActor_c's mesh-collision query, vtable at 0x02099204 (still unnamed in
  * symbols.txt).
  *
@@ -155,10 +159,8 @@ typedef char dBgCh_Actr_size_must_be_0x1bc[
    converted, not before. */
 struct dBgCh_Actr {
     u8  pad_000[0x10];      /* dBgCh base */
-    u8  mFlags;             /* 0x010 - u32 on the C++ side; see above */
-    u8  pad_011[0x3];
-    u8  mActor;             /* 0x014 */
-    u8  pad_015[0x3];
+    u32 mFlags;               /* 0x010 */
+    struct dActor_c * mActor; /* 0x014 */
     s32 unk_018;            /* 0x018 */
     s32 unk_01c;            /* 0x01c */
     u8  mSphereClsn;        /* 0x020 */

--- a/include/dBgCh_SphCrr.h
+++ b/include/dBgCh_SphCrr.h
@@ -5,6 +5,7 @@
 #ifndef DBGCH_SPHCRR_H
 #define DBGCH_SPHCRR_H
 #include "types.h"
+#include "dBgPi.h"
 
 /* fwd */
 struct dBgPi;
@@ -28,21 +29,9 @@ struct dBgCh_SphCrr {
        copying the matching dBgPi below it. */
     u8  flags;              /* 0x070 */
     u8  pad_071[0x3];
-    u8  mClsnResult1;            /* 0x074 */
-    u8  pad_075[0x3];
-    s64 unk_078;            /* 0x078 */
-    s32 unk_080;            /* 0x080 */
-    s32 unk_084;            /* 0x084 */
-    s32 unk_088;            /* 0x088 */
-    u16 unk_08c;            /* 0x08c */
-    u16 unk_08e;            /* 0x08e */
-    s32 unk_090;            /* 0x090 */
-    s32 unk_094;            /* 0x094 */
-    s32 unk_098;            /* 0x098 */
-    u8  mClsnResult2;            /* 0x09c */
-    u8  pad_09d[0x27];
-    u8  mClsnResult3;            /* 0x0c4 */
-    u8  pad_0c5[0x27];
+    dBgPi mClsnResult1; /* 0x074 */
+    dBgPi mClsnResult2; /* 0x09c */
+    dBgPi mClsnResult3; /* 0x0c4 */
     s32 unk_0ec;            /* 0x0ec */
     u8  pad_0f0[0xc];
     /* An adjacent pair, kept unnamed. All that is evidenced is the shape of

--- a/include/dBgPi.h
+++ b/include/dBgPi.h
@@ -23,4 +23,9 @@ struct dBgPi {
 #endif
 };
 
+/* Size is the dBgPi's own span AND the stride of the three consecutive results
+   dBgCh_SphCrr holds at 0x74/0x9c/0xc4 -- notes/collision-system.md 3.2. */
+typedef char dBgPi_size_must_be_0x28[sizeof(struct dBgPi) == 0x28 ? 1 : -1];
+typedef struct dBgPi dBgPi;
+
 #endif

--- a/include/dBgW_KcMbg.h
+++ b/include/dBgW_KcMbg.h
@@ -39,8 +39,7 @@ struct dBgW_KcMbg : dBgW_Kc {
     s16 angVelY;               /* 0x116 */
     Vector3 pos;               /* 0x118 */
     Vector3 velocity;          /* 0x124 */
-    u8 unk_130;                /* 0x130 */
-    u8 pad_131[3];
+    u32 unk_130;              /* 0x130 */
     Matrix4x3 newScaledMat;    /* 0x134 */
     s32 unk_164;               /* 0x164 - func_02053200(scale) */
     Matrix4x3 invScaledMat;    /* 0x168 */

--- a/include/daEyBm_c.h
+++ b/include/daEyBm_c.h
@@ -5,6 +5,7 @@
 #include "ShadowModel.h"
 #include "dBgCh_Actr.h"
 #include "dActor_c.h"
+#include "math/Matrix.h"
 
 /* daEyBm_c is the ROM's own RTTI name for this class (this tree once coined it
  * MrI_Projectile): the typeinfo at ov071
@@ -34,8 +35,7 @@ struct daEyBm_c : dActor_c {
     ShadowModel               mShadowModel;                  /* 0x0d4 */
     dCcAcPos_c mdCcAcPos_c;    /* 0x0fc */
     dBgCh_Actr              mWithMeshClsn;                 /* 0x13c */
-    u8                        unk_2f8;                       /* 0x2f8 */
-    u8                        pad_2f9[0x2f];
+    Matrix4x3 unk_2f8;        /* 0x2f8 */
     s32                       unk_328;                       /* 0x328 */
     s32                       unk_32c;                       /* 0x32c */
     s16                       unk_330;                       /* 0x330 */

--- a/include/daKrb_c.h
+++ b/include/daKrb_c.h
@@ -2,6 +2,11 @@
 #define DAKRB_C_H
 #include "types.h"
 #include "dCapEnemy_c.h"
+#include "dCcAc_c.h"
+#include "dBgCh_Actr.h"
+#include "ModelAnim.h"
+#include "ShadowModel.h"
+#include "MaterialChanger.h"
 
 /* The ROM's RTTI names this class daKrb_c and derives it from dCapEnemy_c, not from
  * dEnemyBase_c directly -- the tree used to believe `Goomba : Enemy`, which skipped the
@@ -64,20 +69,11 @@
  * All other slots hold dCapEnemy_c's (or an ancestor's) word and are inherited.
  */
 struct daKrb_c : dCapEnemy_c {
-    u8  mdCcAc_c;            /* 0x180 -- dCcAc_c, 0x34 bytes */
-    u8  pad_181[0x33];
-    u8  mWithMeshClsn;            /* 0x1b4 -- dBgCh_Actr, 0x1bc bytes */
-    u8  pad_1b5[0x1bb];
-    u8  mModelAnim;            /* 0x370 -- ModelAnim, 0x64 bytes */
-    u8  pad_371[0x4f];
-    u8  mAnimation;            /* 0x3c0 -- ModelAnim's Animation base, +0x50 */
-    u8  pad_3c1[0xb];
-    s32 unk_3cc;            /* 0x3cc -- ModelAnim's own field, +0x5c */
-    s32 unk_3d0;            /* 0x3d0 -- ModelAnim's own field, +0x60 */
-    u8  mShadowModel;            /* 0x3d4 -- ShadowModel, 0x28 bytes */
-    u8  pad_3d5[0x27];
-    u8  mMaterialChanger;            /* 0x3fc -- MaterialChanger, 0x14 bytes */
-    u8  pad_3fd[0x13];
+    dCcAc_c mdCcAc_c;         /* 0x180 */
+    dBgCh_Actr mWithMeshClsn; /* 0x1b4 */
+    ModelAnim mModelAnim;     /* 0x370 */
+    ShadowModel mShadowModel; /* 0x3d4 */
+    MaterialChanger mMaterialChanger; /* 0x3fc */
     s32 unk_410;            /* 0x410 */
     s32 unk_414;            /* 0x414 */
     s32 unk_418;            /* 0x418 */

--- a/src/_ZN10PyramidTag8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTag8BehaviorEv.cpp
@@ -11,7 +11,7 @@ extern void _ZN5dCc_c6UpdateEv(void* a);
 
 int PyramidTag::Behavior()
 {
-  if(unk_0f8 != 0){
+  if(mdCcAc_c.otherOwner != 0){
     unsigned int id = unk_108;
     if(id == 0){
       _ZN7fBase_c18MarkForDestructionEv(((char*)this));

--- a/src/_ZN11CastleWater8BehaviorEv.cpp
+++ b/src/_ZN11CastleWater8BehaviorEv.cpp
@@ -4,19 +4,15 @@
  *
  * The whole frame: force the scroll rate, advance the texture animation.
  *
- * unk_32c is rewritten to 0x1000 EVERY frame rather than once at init, so the
+ * mTexTransformer.speed is rewritten to 0x1000 EVERY frame rather than once at init, so the
  * scroll runs at a fixed rate regardless of what else touched it.
  */
 #include "CastleWater.h"
 
-class Animation {
-public:
-    void Advance();
-};
 
 int CastleWater::Behavior()
 {
-    unk_32c = 0x1000;
+    mTexTransformer.speed = 0x1000;
     ((Animation *)&mTexTransformer)->Advance();
     return 1;
 }

--- a/src/_ZN11VolcanoFire13InitResourcesEv.cpp
+++ b/src/_ZN11VolcanoFire13InitResourcesEv.cpp
@@ -5,9 +5,6 @@
 /* recovered: named members + shared header, real C++ method */
 #include "VolcanoFire.h"
 struct dActor_c;
-struct dCcAc_c {
-    void Init(dActor_c *a, int b, int c, unsigned int d, unsigned int e);
-};
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true

--- a/src/_ZN13TreasureChest8BehaviorEv.cpp
+++ b/src/_ZN13TreasureChest8BehaviorEv.cpp
@@ -4,7 +4,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TreasureChest.h"
-struct dCc_c { int dummy; };
 extern "C" {
 extern void _ZN5dCc_c5ClearEv(struct dCc_c *t);
 extern void _ZN5dCc_c6UpdateEv(struct dCc_c *t);

--- a/src/_ZN16SpinningPlatform13InitResourcesEv.cpp
+++ b/src/_ZN16SpinningPlatform13InitResourcesEv.cpp
@@ -10,7 +10,6 @@ extern "C" void _ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P1
 struct BMD_File; struct KCL_File; struct dActor_c; struct Vector3; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr;
 /* ModelBase is the real class now, through this actor's header. */
-struct ShadowModel { void InitCuboid(); };
 struct dBgActor_c { void UpdateClsnPosAndRot(); };
 /* Declared by final name, not as a member: the ROM's SetFile takes Fix12<int> where
    this call passes 0x1000, and Fix12<int> is an aggregate with no converting

--- a/src/_ZN17ExtendingPlatform13InitResourcesEv.cpp
+++ b/src/_ZN17ExtendingPlatform13InitResourcesEv.cpp
@@ -5,12 +5,11 @@
 /* recovered: named members + shared header, real C++ method */
 #include "ExtendingPlatform.h"
 #include "dBgW.h"
-typedef int Fix12;
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void* _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void*);
-extern int _ZN14dBgW_KcMbgSclY7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
+extern int _ZN14dBgW_KcMbgSclY7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 }
 
 int ExtendingPlatform::InitResources()
@@ -24,7 +23,7 @@ int ExtendingPlatform::InitResources()
   kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov045_021131d0);
   _ZN14dBgW_KcMbgSclY7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x158, kcl, ((char*)this)+0x128, 0x1000, unk_08e, data_ov045_021125b0);
   func_020396c0(((char*)this)+0x158, 4);
-  unk_1a5 = 1;
+  mCollider.unk_4d = 1;
   ((dBgW *)(((char*)this)+0x158))->Enable((dActor_c *)(((char*)this)));
   unk_0d4 = 1;
   return 1;

--- a/src/_ZN4Clam8BehaviorEv.cpp
+++ b/src/_ZN4Clam8BehaviorEv.cpp
@@ -66,7 +66,7 @@ int Clam::Behavior()
                 u.shutPuff[0], u.shutPuff[1], u.shutPuff[2]);
             unk_170 = 0xa;
             mStateTimer = 0;
-            *(int *)&unk_150 &= ~1;
+            *(int *)&mdCcAc_c.flags &= ~1;
         } else {
             if (mStateTimer > 0x96 &&
                 _ZN8dActor_c13DistToCPlayerEv((char *)this) < 0x1f4000) {
@@ -96,7 +96,7 @@ int Clam::Behavior()
         } else {
             if (!mModelAnim.WillHitFrame(8)) {
                 if (mModelAnim.WillHitFrame(0xf))
-                    *(int *)&unk_150 |= 1;
+                    *(int *)&mdCcAc_c.flags |= 1;
             }
         }
         break;
@@ -104,8 +104,8 @@ int Clam::Behavior()
 
     mStateTimer++;
 
-    if (unk_15c != 0) {
-        char *touched = _ZN8dActor_c10FindWithIDEj(unk_15c);
+    if (mdCcAc_c.otherOwner != 0) {
+        char *touched = _ZN8dActor_c10FindWithIDEj(mdCcAc_c.otherOwner);
         if (touched != 0) {
             int isPlayer = (int)(*(u16 *)(touched + 0xc) == 0xbf);
             if (isPlayer != 0) {

--- a/src/_ZN5Stage7LoadFogEv.cpp
+++ b/src/_ZN5Stage7LoadFogEv.cpp
@@ -20,7 +20,7 @@ void Stage::LoadFog()
     a += 4;
     b += 2;
   }
-  *((unsigned char *) ((char *)&unk_98c)) = 0;
+  *((unsigned char *) ((char *)&unk_96c.unk_020)) = 0;
   *((unsigned char *) ((char *)&unk_9b4)) = 1;
   *((unsigned char *) ((char *)&unk_9b5)) = 6;
   *((unsigned short *) ((char *)&unk_9b6)) = 0;

--- a/src/_ZN7daKrb_c8BehaviorEv.cpp
+++ b/src/_ZN7daKrb_c8BehaviorEv.cpp
@@ -10,13 +10,12 @@ typedef unsigned int u32;
 typedef unsigned short u16;
 typedef signed char s8;
 
-typedef s32 Fix12;
 
 extern s8 data_0209f2f8;
 
 extern "C" {
 extern void _ZN8dActor_c8PoofDustEv(char* c);
-extern int _ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(char* c, Fix12 f);
+extern int _ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(char* c, int f);
 extern int _ZN12dEnemyBase_c26UpdateKillByInvincibleCharER10dBgCh_ActrR9ModelAnimj(char* c, void* w, void* m, u32 j);
 extern void func_ov084_02129498(char* c);
 extern void _ZN11dCapEnemy_c10ReleaseCapERK7Vector3(char* c, Vector3* v);
@@ -26,7 +25,7 @@ extern int _ZN4cstd4fdivEii(int a, int b);
 extern void _ZN8dActor_c19MakeVanishLuigiWorkER5dCc_c(char* c, void* cyl);
 extern void _ZN9Animation7AdvanceEv(void* c);
 extern void _ZN8dActor_c9UpdatePosEP5dCc_c(char* c, void* cyl);
-extern int _ZN12dEnemyBase_c15IsGoingOffCliffER10dBgCh_Actr5Fix12IiEsbbS3_(char* c, void* w, Fix12 f, int s, int b1, int b2, Fix12 g);
+extern int _ZN12dEnemyBase_c15IsGoingOffCliffER10dBgCh_Actr5Fix12IiEsbbS3_(char* c, void* w, int f, int s, int b1, int b2, int g);
 extern void _ZN12dEnemyBase_c12UpdateWMClsnER10dBgCh_Actrj(char* c, void* w, u32 j);
 extern void _ZN5dCc_c5ClearEv(void* c);
 extern void _ZN5dCc_c6UpdateEv(void* c);
@@ -87,21 +86,21 @@ int daKrb_c::Behavior()
         return 1;
 
     if (mState >= 3 ||
-        (mGoombaType == 3 && unk_3d0 == data_ov084_02130cc8[1]))
+        (mGoombaType == 3 && (int)mModelAnim.file == data_ov084_02130cc8[1]))
     {
-        unk_3cc = 0x1000;
+        mModelAnim.speed = 0x1000;
     } else {
         int v = _ZN4cstd4fdivEii(mHorzSpeed, mScaleX * 2);
         if (v > 0x3000)
             v = 0x3000;
-        unk_3cc = v;
+        mModelAnim.speed = v;
     }
 
     _ZN8dActor_c19MakeVanishLuigiWorkER5dCc_c(((char*)this), ((char*)this) + 0x180);
 
     if (mState != 2) {
         func_ov084_0212934c(((char*)this));
-        _ZN9Animation7AdvanceEv((char*)&mAnimation);
+        _ZN9Animation7AdvanceEv((char*)(Animation*)&mModelAnim);
     }
 
     st = mState;

--- a/src/_ZN9KoopaFlag13InitResourcesEv.cpp
+++ b/src/_ZN9KoopaFlag13InitResourcesEv.cpp
@@ -15,9 +15,6 @@ struct dActor_c;
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
 extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File* f, int a, Fix12i b, unsigned int c);
 
-struct dCcAc_c {
-    void Init(dActor_c* a, Fix12i b, Fix12i c, unsigned int d, unsigned int e);
-};
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true

--- a/src/_ZN9KoopaFlag8BehaviorEv.cpp
+++ b/src/_ZN9KoopaFlag8BehaviorEv.cpp
@@ -21,7 +21,7 @@ int KoopaFlag::Behavior()
     int b;
 
     if (unk_16e == 0) {
-        id = unk_0f8;
+        id = mdCcAc_c.otherOwner;
         if (id != 0) {
             a = _ZN8dActor_c10FindWithIDEj(id);
             if (a != 0) {


### PR DESCRIPTION
Our headers carried bare `u8` markers where a member of a real class type lives, plus a handful of members declared one width too narrow. 

| | Count |
|---|---:|
| `u8` markers → real class types | 36 |
| members → corrected width | 7 |
| **applied, all byte-neutral under 2004/b56** | **43** |

## Evidence split

Of the 45 marker candidates: **35 double-evidenced** (our own ROM marker census and the reference agree), **10 decided only by the reference**, **0 conflicting on type**. 4 further candidates were already correct in our headers; 5 remain blocked.

Classification needed a name bridge, since the reference still uses names this project retracted in #1572–#1577 — `MovingCylinderClsn`→`dCcAc_c`, `WithMeshClsn`→`dBgCh_Actr`, `SphereClsn`→`dBgCh_SphCrr`, `ClsnResult`→`dBgPi`, `MovingMeshCollider`→`dBgW_KcMbg`, plus `Goomba`→`daKrb_c`, `MrI_Projectile`→`daEyBm_c`, `DorrieCap`→`daDossyCap_c`, each resolved through its `*_Spawn` `_ZTV` store. **No base clause was taken from the reference** — only field offsets, types and names.

## Two candidates the cartridge REFUTED (not included)

- **`dBgCh_SphCrr+0x70` `u8 flags`** — reference says `u32 resultFlags`. `dBgW_KcMbg::DetectClsn(dBgCh_SphCrr&)` goes from exact to **2 words differing**. The ROM does byte accesses; our source already spells `*(u8*)(&sphere->flags) |= 1`.
- **`PeachPainting+0x124` `u8 mOpacity`** — reference says `u32 opacity`. `PeachPainting::Behavior()` changes frame size (999 words): `(unsigned char)(o>>3)` into a `u32` costs a masking instruction.

The reference agrees with our ROM evidence on **47 of 54** candidates. Where the two disagree the bytes decide — and both times the reference was wrong.

## Consumer respellings

Sites carrying ad-hoc shadow declarations that collided with the real types now read through the new members (`unk_0f8`→`mdCcAc_c.otherOwner`, `unk_3cc`→`mModelAnim.speed`, `unk_98c`→`unk_96c.unk_020`), and the local `typedef s32 Fix12;` / `struct dCcAc_c {...}` / `struct ShadowModel {...}` shadows are deleted.

This retires **9 of the ~29 classes** `notes/handoff-marker-typing.md` §5 lists as blocked, each with a one- or two-line edit. Stage and `daKrb_c` are on that list — §5's cost estimate for this wall was too high.

`dBgPi.h` and `Fog.h` gain `typedef struct X X;` (Model.h's existing convention) so the flat C structs can spell them; `dBgPi.h` also gains a `_size_must_be_0x28` assert, proven in `notes/collision-system.md` §3.2 and by the `0x28` stride of the three results `dBgCh_SphCrr` holds at `0x74`/`0x9c`/`0xc4`. `dBgCh_Actr.h` takes a forward declaration rather than an include to keep its 826-TU fan-out light.

## Verification

| Gate | Result |
|---|---|
| `build_pin.verify` | 1,468 affected enrolled functions under 2004/b56; 2 failures, **both pre-existing on the untouched baseline** (`RollingIronBall::InitResources`, `daObjMarioCap_c::InitResources`) |
| `rombuild.py -j16` | **106/106 exact**, 100.000000% of compared bytes, 11,058 reproducing / **0 mismatching** |
| `eligible.py` bracket | 11064 / 11186 before and after, **byte-identical name lists** |
| `check_header_offsets.py` | 0 mismatched over 33 changed headers |
| `check_references.py` | OK, unresolved 45 = baseline 45 |
| `port_refcheck.py` | 393 references checked, all resolve |

Two headers have wide fan-out and are byte-neutral across all of it: `dBgCh_Actr.h` (826 functions) and `dBgW_KcMbg.h` (572).

Local `rombuild` 106/106 is local evidence only and does not overrule the validator's per-PR verdict.
