### PR TITLE
Name 176 header field placeholders from the reference's own names

### DIFF
--- a/include/ArmedRotatingPlatform.h
+++ b/include/ArmedRotatingPlatform.h
@@ -11,7 +11,7 @@
  * then destroys the dBgW_KcMbg at 0x124 and the Model at 0xd4 and
  * chains to dActor_c. Those three are dBgActor_c's own.
  *
- * unk_31e sits at 0x31e, in dBgActor_c's TAIL PADDING: dBgActor_c's last field
+ * mAngVelY sits at 0x31e, in dBgActor_c's TAIL PADDING: dBgActor_c's last field
  * ends at 0x31e and its size rounds to 0x320, and the Itanium ABI lets a
  * derived class place members in a non-POD base's tail padding. Behavior reads
  * this+0x31e and reproduces the ROM, which is what confirms the placement.
@@ -22,7 +22,7 @@
 #include "dBgActor_c.h"
 
 struct ArmedRotatingPlatform : dBgActor_c {
-    s16 unk_31e;            /* 0x31e - per-frame yaw step; see InitResources */
+    s16 mAngVelY;            /* 0x31e - per-frame yaw step; see InitResources */
 
     /* --- vtable --- */
     virtual ~ArmedRotatingPlatform();

--- a/include/BasementWater.h
+++ b/include/BasementWater.h
@@ -22,9 +22,9 @@ struct BasementWater : dBgActor_c {
     u8  pad_31e[0x2];
     TextureTransformer mTextureTransformer;/* 0x320 */
     s32 mLoweredY;                    /* 0x334 */
-    u32 unk_338;                      /* 0x338 */
-    u16 unk_33c;              /* 0x33c */
-    u8 unk_33e;                       /* 0x33e */
+    u32 mSoundID;                      /* 0x338 */
+    u16 mSoundTimer;              /* 0x33c */
+    u8 mWasJustDrained;                       /* 0x33e */
 
     /* --- vtable --- */
     virtual ~BasementWater();
@@ -66,9 +66,9 @@ struct BasementWater {
     u8  pad_125[0x1fb];
     TextureTransformer mTextureTransformer; /* 0x320 */
     s32 mLoweredY;            /* 0x334 */
-    u32 unk_338;            /* 0x338 */
-    u16 unk_33c;              /* 0x33c */
-    u8  unk_33e;            /* 0x33e */
+    u32 mSoundID;            /* 0x338 */
+    u16 mSoundTimer;              /* 0x33c */
+    u8  mWasJustDrained;            /* 0x33e */
 };
 
 #endif /* __cplusplus */

--- a/include/BigBully.h
+++ b/include/BigBully.h
@@ -15,9 +15,9 @@
 struct BigBully : daOts_c {
     u8  pad_398[0x62];
     u16 mSecretSoundCounter;        /* 0x3fa */
-    u8  unk_3fc;                    /* 0x3fc */
+    u8  mStarID;                    /* 0x3fc */
     u8  unk_3fd;                    /* 0x3fd */
-    u8  unk_3fe;                    /* 0x3fe */
+    u8  mNumBulliesKilled;                    /* 0x3fe */
     u8  pad_3ff[0x1];
 
     virtual ~BigBully();

--- a/include/Bird.h
+++ b/include/Bird.h
@@ -19,7 +19,7 @@ struct Bird : dActor_c {
     u8          pad_16c[0xc];
     u32         mOwnerID;        /* 0x178 */
     s32         mState;          /* 0x17c */
-    u8          unk_180;         /* 0x180 */
+    u8          mIsLeader;         /* 0x180 */
     u8          pad_181[0x3];
 
     virtual ~Bird();

--- a/include/BooCage.h
+++ b/include/BooCage.h
@@ -40,8 +40,8 @@ struct BooCage : dEnemyBase_c {
     dBgCh_Actr                 mWithMeshClsn;         /* 0x144 */
     Model                        mModel;                /* 0x300 */
     ShadowModel                  mShadowModel;          /* 0x350 */
-    s32                          unk_378;               /* 0x378 */
-    s16                          unk_37c;               /* 0x37c */
+    s32                          mParticleID;               /* 0x378 */
+    s16                          mSoundTimer;               /* 0x37c */
     u8                           unk_37e;               /* 0x37e */
     u8  pad_37f[0x1];
 

--- a/include/BowserPuzzlePiece.h
+++ b/include/BowserPuzzlePiece.h
@@ -23,17 +23,17 @@ struct BowserPuzzlePiece {
     dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x37];
-    s32 unk_324;            /* 0x324 */
-    u8  unk_328;            /* 0x328 */
+    s32 mStateInfo;            /* 0x324 */
+    u8  mStateIndex;            /* 0x328 */
     u8  pad_329[0x3];
     s32 unk_32c;            /* 0x32c */
     u8  pad_330[0x4];
-    s16 unk_334;            /* 0x334 */
-    u8  unk_336;            /* 0x336 */
-    u8  unk_337;            /* 0x337 */
-    u8  unk_338;            /* 0x338 */
-    u8  unk_339;            /* 0x339 */
-    u8  unk_33a;            /* 0x33a */
+    s16 mMoveTimer;            /* 0x334 */
+    u8  mState;            /* 0x336 */
+    u8  mType;            /* 0x337 */
+    u8  mHadClsn;            /* 0x338 */
+    u8  mFreezeState;            /* 0x339 */
+    u8  mCanSpawnCoin;            /* 0x33a */
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();

--- a/include/Bully.h
+++ b/include/Bully.h
@@ -19,7 +19,7 @@ struct Bully : daOts_c {
        Left unnamed because that is as far as the bytes go -- BigBully's u8 at the
        same offset is a different field with a different use, so the offset is no
        guide. */
-    s32 unk_3fc;                    /* 0x3fc */
+    s32 mBigBullyID;                    /* 0x3fc */
 
     virtual ~Bully();
 

--- a/include/ClockPaintingPendulum.h
+++ b/include/ClockPaintingPendulum.h
@@ -80,7 +80,7 @@ struct ClockPaintingPendulum : dActor_c {
        +0xd4 -- a relocation the ROM build checks. */
     Model mModel;             /* 0x0d4 */
 
-    s16 unk_124;               /* 0x124 -- swing angle/phase, see SIZE above */
+    s16 mAngSpeed;               /* 0x124 -- swing angle/phase, see SIZE above */
     u8  pad_126[0x2];
 
     /* --- vtable. Declared first, deliberately -- it is already the key

--- a/include/Coin.h
+++ b/include/Coin.h
@@ -18,7 +18,7 @@
  * All three Spawn entry points build the SAME class (same vtable, same
  * size) -- Coin is the coin actor shared by yellow/blue/red spawn paths.
  *
- * SIZE 0x3b4 is the factory's own literal; the last member (unk_3b0, 1 byte)
+ * SIZE 0x3b4 is the factory's own literal; the last member (mInBrickBlock, 1 byte)
  * closes at 0x3b1 and rounds up to 0x3b4 under 4-byte alignment.
  *
  * Everything below 0x0d0 duplicated dActor_c's own fields under placeholder
@@ -40,7 +40,7 @@
  */
 struct Coin : dActor_c {
     s32 mEatingPlayer;            /* 0x0d0 */
-    s32 unk_0d4;            /* 0x0d4 */
+    s32 mPuzzleManagerID;            /* 0x0d4 */
     /* CommonModel member, named by the class's own destructor calling
        CommonModel's D1 at +0x0d8 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
@@ -61,19 +61,19 @@ struct Coin : dActor_c {
        dBgCh_Actr's D1 at +0x1ac -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN4CoinD0Ev.c] */
     dBgCh_Actr mWithMeshClsn;            /* 0x1ac */
-    Matrix4x3 unk_368;        /* 0x368 */
-    s32 unk_398;            /* 0x398 */
+    Matrix4x3 mShadowMat;        /* 0x368 */
+    s32 mFloorPosY;            /* 0x398 */
     u8  pad_39c[0x4];
     s32 mCoinType;            /* 0x3a0 */
     s32 mBehaviorType;            /* 0x3a4 */
-    s16 unk_3a8;            /* 0x3a8 */
-    u8  unk_3aa;            /* 0x3aa */
+    s16 mDisappearTimer;            /* 0x3a8 */
+    u8  mNoClsnTimer;            /* 0x3aa */
     u8  unk_3ab;            /* 0x3ab */
-    s8  unk_3ac;            /* 0x3ac */
+    s8  mTrackStarID;            /* 0x3ac */
     u8  pad_3ad[0x1];
     u8  unk_3ae;            /* 0x3ae */
     u8  pad_3af[0x1];
-    u8  unk_3b0;            /* 0x3b0 */
+    u8  mInBrickBlock;            /* 0x3b0 */
 
     virtual ~Coin();            /* slots 16 (D1), 17 (D0) */
 

--- a/include/DonutBlock.h
+++ b/include/DonutBlock.h
@@ -24,8 +24,8 @@ struct DonutBlock : dBgActor_c {
     s32 unk_4dc;                      /* 0x4dc */
     s32 unk_4e0;                      /* 0x4e0 */
     s32 unk_4e4;                      /* 0x4e4 */
-    u8 unk_4e8;                       /* 0x4e8 */
-    u8 unk_4e9;                       /* 0x4e9 */
+    u8 mHadClsn;                       /* 0x4e8 */
+    u8 mClsnTimer;                       /* 0x4e9 */
     u8 mState;                        /* 0x4ea */
 
     /* --- vtable --- */
@@ -69,8 +69,8 @@ struct DonutBlock {
     s32 unk_4dc;            /* 0x4dc */
     s32 unk_4e0;            /* 0x4e0 */
     s32 unk_4e4;            /* 0x4e4 */
-    u8  unk_4e8;            /* 0x4e8 */
-    u8  unk_4e9;            /* 0x4e9 */
+    u8  mHadClsn;            /* 0x4e8 */
+    u8  mClsnTimer;            /* 0x4e9 */
     u8  mState;            /* 0x4ea */
 };
 

--- a/include/Dorrie.h
+++ b/include/Dorrie.h
@@ -22,12 +22,12 @@ struct Dorrie {
     u8  pad_090[0x3c];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    s32 unk_0d4;            /* 0x0d4 */
+    s32 mCap;            /* 0x0d4 */
     s32 unk_0d8;            /* 0x0d8 */
     s32 unk_0dc;            /* 0x0dc */
     s32 unk_0e0;            /* 0x0e0 */
     u8  pad_0e4[0x4];
-    u8  unk_0e8;            /* 0x0e8 */
+    u8  mHasCap;            /* 0x0e8 */
     u8  pad_0e9[0x3];
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xec -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
@@ -45,26 +45,26 @@ struct Dorrie {
     /* dCcAc_c member, named by the class's own destructor calling
        dCcAc_c's D1 at +0x110c -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN6DorrieD1Ev.cpp] */
-    dCcAc_c unk_110c;           /* 0x110c */
+    dCcAc_c mCylClsn1;           /* 0x110c */
     /* dCcAcPos_c member, named by the class's own destructor calling
        dCcAcPos_c's D1 at +0x1140 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN6DorrieD1Ev.cpp] */
-    dCcAcPos_c unk_1140;           /* 0x1140 */
+    dCcAcPos_c mCylClsn2;           /* 0x1140 */
     s32 unk_1180;           /* 0x1180 */
     s32 unk_1184;           /* 0x1184 */
     s32 unk_1188;           /* 0x1188 */
-    s32 unk_118c;           /* 0x118c */
-    s32 unk_1190;           /* 0x1190 */
+    s32 mClsnPlayer;           /* 0x118c */
+    s32 mRider;           /* 0x1190 */
     s32 unk_1194;           /* 0x1194 */
     s32 unk_1198;           /* 0x1198 */
     s32 unk_119c;           /* 0x119c */
     u8  pad_11a0[0x8];
-    s32 unk_11a8;           /* 0x11a8 */
-    s32 unk_11ac;           /* 0x11ac */
+    s32 mPushDownHeight;           /* 0x11a8 */
+    s32 mSinkHeight;           /* 0x11ac */
     u8  pad_11b0[0x2];
-    s16 unk_11b2;           /* 0x11b2 */
+    s16 mStateTimer;           /* 0x11b2 */
     u8  pad_11b4[0x1];
-    u8  unk_11b5;           /* 0x11b5 */
+    u8  mClsnState;           /* 0x11b5 */
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();

--- a/include/ExtendingPlatform.h
+++ b/include/ExtendingPlatform.h
@@ -12,7 +12,7 @@ struct ExtendingPlatform {
     u8  pad_000[0x8e];
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x44];
-    s8  unk_0d4;            /* 0x0d4 */
+    s8  mGrowing;            /* 0x0d4 */
     u8  pad_0d5[0x3];
     /* Model member, named by _ZN5ModelD1Ev at +0xd8 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. The marker's pad ran 0x30

--- a/include/FaderColor.h
+++ b/include/FaderColor.h
@@ -29,11 +29,12 @@
  */
 #ifdef __cplusplus
 struct FaderColor : FaderBrightness {
-    /* 0x0c. Only its zero/non-zero-ness is observed: AdvanceFade picks a blend
-       step of +0x10 when it is set and -0x10 when it is clear. Kept as unk_00c
-       rather than renamed, because a rename cannot change codegen and belongs in
-       its own commit -- and src/_ZN8dScene_c14StartSceneFadeEjjt.* names it. */
-    u16 unk_00c;
+    /* 0x0c. Only its zero/non-zero-ness is observed here: AdvanceFade picks a
+       blend step of +0x10 when it is set and -0x10 when it is clear. What
+       writes it is src/_ZN8dScene_c14StartSceneFadeEjjt.*, whose parameter is
+       the fade colour -- which is also the name the upstream reference header
+       gives this field, so it is named for that now. */
+    u16 color;
 
     virtual ~FaderColor();          /* key function; see above */
     virtual void AdvanceFade();     /* slot 2 -- the only override */
@@ -47,7 +48,7 @@ struct FaderColor {
     void*  vtable;      /* 0x00 */
     Fix12i currInterp;  /* 0x04 (from Fader) */
     Fix12i speed;       /* 0x08 (from Fader) */
-    u16    unk_00c;     /* 0x0c */
+    u16    color;     /* 0x0c */
 };
 #endif
 

--- a/include/FaderWipe.h
+++ b/include/FaderWipe.h
@@ -47,7 +47,7 @@ struct FaderWipe {
     void*  vtable;      /* 0x00 */
     Fix12i currInterp;  /* 0x04 (from Fader) */
     Fix12i speed;       /* 0x08 (from Fader) */
-    u16    unk_00c;     /* 0x0c (from FaderColor) */
+    u16    color;       /* 0x0c (from FaderColor) */
     u8     pad_00e[0x2];
     Model model;              /* 0x010 */
 };

--- a/include/FloatOnLavaPlatform.h
+++ b/include/FloatOnLavaPlatform.h
@@ -19,8 +19,8 @@
 
 struct FloatOnLavaPlatform : dBgActor_c {
     u8  pad_31e[0x2];
-    s32 unk_320;                      /* 0x320 */
-    u8 unk_324;                       /* 0x324 */
+    s32 mMaxPosY;                      /* 0x320 */
+    u8 mHadClsn;                       /* 0x324 */
 
     /* --- vtable --- */
     virtual ~FloatOnLavaPlatform();
@@ -49,8 +49,8 @@ struct FloatOnLavaPlatform {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    s32 unk_320;            /* 0x320 */
-    u8  unk_324;            /* 0x324 */
+    s32 mMaxPosY;            /* 0x320 */
+    u8  mHadClsn;            /* 0x324 */
 };
 
 #endif /* __cplusplus */

--- a/include/Goomboss.h
+++ b/include/Goomboss.h
@@ -41,32 +41,32 @@ struct Goomboss : dEnemyBase_c {
     ModelAnim mModelAnim;                         /* 0x210 */
     ShadowModel mShadowModels[3];                 /* 0x274 */
     u8  pad_2ec[0xc0];
-    Vector3 unk_3ac[3];                           /* 0x3ac */
+    Vector3 mCylClsnPos[3];                           /* 0x3ac */
     MaterialChanger mMaterialChanger;             /* 0x3d0 */
     TextureSequence mTextureSequence;             /* 0x3e4 */
     TextureTransformer mTextureTransformer;       /* 0x3f8 */
     dBgCh_Actr mWithMeshClsn;                   /* 0x40c */
     u8  pad_5c8[0x4];
-    s32 unk_5cc;            /* 0x5cc */
+    s32 mState;            /* 0x5cc */
     s32 unk_5d0;            /* 0x5d0 */
     s32 unk_5d4;            /* 0x5d4 */
     s32 unk_5d8;            /* 0x5d8 */
-    s32 unk_5dc;            /* 0x5dc */
+    s32 mMegaMushroomID;            /* 0x5dc */
     u8  pad_5e0[0x4];
-    s32 unk_5e4;            /* 0x5e4 */
-    s32 unk_5e8;            /* 0x5e8 */
+    s32 mCurrentScale;            /* 0x5e4 */
+    s32 mGoombaTargetSpeed;            /* 0x5e8 */
     u8  pad_5ec[0x4];
-    s32 unk_5f0;            /* 0x5f0 */
-    u16 unk_5f4;            /* 0x5f4 */
-    s16 unk_5f6;            /* 0x5f6 */
-    s16 unk_5f8;            /* 0x5f8 */
+    s32 mDirection;            /* 0x5f0 */
+    u16 mWalkAngle;            /* 0x5f4 */
+    s16 mWalkSpeed;            /* 0x5f6 */
+    s16 mMaxWalkSpeed;            /* 0x5f8 */
     u8  pad_5fa[0x4];
-    u8  unk_5fe;            /* 0x5fe */
-    u8  unk_5ff;            /* 0x5ff */
+    u8  mLeftFootSteppedOnGround;            /* 0x5fe */
+    u8  mRightFootSteppedOnGround;            /* 0x5ff */
     u8  pad_600[0x4];
     u8  mSizeIndex;            /* 0x604 */
     u8  pad_605[0x5];
-    u8  unk_60a;            /* 0x60a */
+    u8  mShouldRender;            /* 0x60a */
     /* The field span ends at 0x60b, but a span is only a LOWER BOUND. Both factories
        that store _ZTV8Goomboss (ov074:0x02122eb8) -- Goomboss_Spawn and
        ExplosionGoomba_Spawn -- call fBase_c::operator new(0x610). Two factories
@@ -128,26 +128,26 @@ struct Goomboss {
     u8  pad_3f9[0x13];
     struct dBgCh_Actr mWithMeshClsn; /* 0x40c */
     u8  pad_5c8[0x4];
-    s32 unk_5cc;            /* 0x5cc */
+    s32 mState;            /* 0x5cc */
     s32 unk_5d0;            /* 0x5d0 */
     s32 unk_5d4;            /* 0x5d4 */
     s32 unk_5d8;            /* 0x5d8 */
-    s32 unk_5dc;            /* 0x5dc */
+    s32 mMegaMushroomID;            /* 0x5dc */
     u8  pad_5e0[0x4];
-    s32 unk_5e4;            /* 0x5e4 */
-    s32 unk_5e8;            /* 0x5e8 */
+    s32 mCurrentScale;            /* 0x5e4 */
+    s32 mGoombaTargetSpeed;            /* 0x5e8 */
     u8  pad_5ec[0x4];
-    s32 unk_5f0;            /* 0x5f0 */
-    u16 unk_5f4;            /* 0x5f4 */
-    s16 unk_5f6;            /* 0x5f6 */
-    s16 unk_5f8;            /* 0x5f8 */
+    s32 mDirection;            /* 0x5f0 */
+    u16 mWalkAngle;            /* 0x5f4 */
+    s16 mWalkSpeed;            /* 0x5f6 */
+    s16 mMaxWalkSpeed;            /* 0x5f8 */
     u8  pad_5fa[0x4];
-    u8  unk_5fe;            /* 0x5fe */
-    u8  unk_5ff;            /* 0x5ff */
+    u8  mLeftFootSteppedOnGround;            /* 0x5fe */
+    u8  mRightFootSteppedOnGround;            /* 0x5ff */
     u8  pad_600[0x4];
     u8  mSizeIndex;            /* 0x604 */
     u8  pad_605[0x5];
-    u8  unk_60a;            /* 0x60a */
+    u8  mShouldRender;            /* 0x60a */
 };
 
 #endif /* __cplusplus */

--- a/include/KnockDownPlank.h
+++ b/include/KnockDownPlank.h
@@ -25,14 +25,14 @@ struct KnockDownPlank : dBgActor_c {
     s32 unk_378;                      /* 0x378 */
     s32 unk_37c;                      /* 0x37c */
     s32 unk_380;                      /* 0x380 */
-    s32 unk_384;                      /* 0x384 */
-    s32 unk_388;                      /* 0x388 */
-    s32 unk_38c;                      /* 0x38c */
-    u16 unk_390;                      /* 0x390 */
-    s16 unk_392;                      /* 0x392 */
-    s16 unk_394;                      /* 0x394 */
-    s8 unk_396;                       /* 0x396 */
-    u8 unk_397;                       /* 0x397 */
+    s32 mFrontFloorY;                      /* 0x384 */
+    s32 mOriginalPosY;                      /* 0x388 */
+    s32 mJumpSpeed;                      /* 0x38c */
+    u16 mWobbleAng;                      /* 0x390 */
+    s16 mFallAngVel;                      /* 0x392 */
+    s16 mWobbleTimer;                      /* 0x394 */
+    s8 mKnockDir;                       /* 0x396 */
+    u8 mState;                       /* 0x397 */
     /* KnockDownPlank_Spawn, the one factory storing _ZTV14KnockDownPlank
        (ov015:0x02114420), calls fBase_c::operator new(0x39c). The field span
        stopping at 0x398 is a lower bound, not the size. */
@@ -76,14 +76,14 @@ struct KnockDownPlank {
     s32 unk_378;            /* 0x378 */
     s32 unk_37c;            /* 0x37c */
     s32 unk_380;            /* 0x380 */
-    s32 unk_384;            /* 0x384 */
-    s32 unk_388;            /* 0x388 */
-    s32 unk_38c;            /* 0x38c */
-    u16 unk_390;            /* 0x390 */
-    s16 unk_392;            /* 0x392 */
-    s16 unk_394;            /* 0x394 */
-    s8  unk_396;            /* 0x396 */
-    u8  unk_397;            /* 0x397 */
+    s32 mFrontFloorY;            /* 0x384 */
+    s32 mOriginalPosY;            /* 0x388 */
+    s32 mJumpSpeed;            /* 0x38c */
+    u16 mWobbleAng;            /* 0x390 */
+    s16 mFallAngVel;            /* 0x392 */
+    s16 mWobbleTimer;            /* 0x394 */
+    s8  mKnockDir;            /* 0x396 */
+    u8  mState;            /* 0x397 */
 };
 
 #endif /* __cplusplus */

--- a/include/Koopa.h
+++ b/include/Koopa.h
@@ -45,13 +45,13 @@ struct Koopa : dEnemyBase_c {
     s32                          unk_3ac;               /* 0x3ac */
     s32                          unk_3b0;               /* 0x3b0 */
     u8  pad_3b4[0x8];
-    s32                          unk_3bc;               /* 0x3bc */
+    s32                          mAnimSpeed;               /* 0x3bc */
     u8  pad_3c0[0x4];
-    u16                          unk_3c4;               /* 0x3c4 */
+    u16                          mWalkState;               /* 0x3c4 */
     u8  pad_3c6[0x4];
-    u16                          unk_3ca;               /* 0x3ca */
+    u16                          mInvincibleTimer;               /* 0x3ca */
     u8  pad_3cc[0x2];
-    u8                           unk_3ce;               /* 0x3ce */
+    u8                           mLandingDustTimer;               /* 0x3ce */
     u8  pad_3cf[0x1];
 
     /* --- vtable --- */

--- a/include/KoopaFlag.h
+++ b/include/KoopaFlag.h
@@ -17,7 +17,7 @@ struct KoopaFlag {
        Animation base), which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x108 */
     u16 mVictoryTimer;            /* 0x16c */
-    u8  unk_16e;            /* 0x16e */
+    u8  mHasTouchedFlag;            /* 0x16e */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/KoopaTheQuick.h
+++ b/include/KoopaTheQuick.h
@@ -36,28 +36,28 @@ struct KoopaTheQuick : dEnemyBase_c {
     dBgCh_Actr                 mWithMeshClsn;         /* 0x144 */
     ModelAnim                    mModelAnim;            /* 0x300 */
     ShadowModel                  mShadowModel;          /* 0x364 */
-    s32                          unk_38c;               /* 0x38c */
+    s32                          mState;               /* 0x38c */
     u8  pad_390[0x4];
-    s32                          unk_394;               /* 0x394 */
-    s32                          unk_398;               /* 0x398 */
+    s32                          mFlagID;               /* 0x394 */
+    s32                          mPlayer;               /* 0x398 */
     s32                          unk_39c;               /* 0x39c */
     s32                          unk_3a0;               /* 0x3a0 */
     u8                           unk_3a4;               /* 0x3a4 */
     u8  pad_3a5[0x5];
     s16                          unk_3aa;               /* 0x3aa */
-    u8                           unk_3ac;               /* 0x3ac */
-    u8                           unk_3ad;               /* 0x3ad */
-    u8                           unk_3ae;               /* 0x3ae */
+    u8                           mHasPlayerUsedCannon;               /* 0x3ac */
+    u8                           mPathPtToJumpAt1;               /* 0x3ad */
+    u8                           mPathPtToJumpAt2;               /* 0x3ae */
     u8  pad_3af[0x1];
-    u8                           unk_3b0;               /* 0x3b0 */
-    u8                           unk_3b1;               /* 0x3b1 */
+    u8                           mTrackedStar;               /* 0x3b0 */
+    u8                           mStarID;               /* 0x3b1 */
     u8  pad_3b2[0x2];
-    u8                           unk_3b4;               /* 0x3b4 */
-    u8                           unk_3b5;               /* 0x3b5 */
-    u8                           unk_3b6;               /* 0x3b6 */
+    u8                           mHasFinished;               /* 0x3b4 */
+    u8                           mIsRacing;               /* 0x3b5 */
+    u8                           mIsTalkingToMario;               /* 0x3b6 */
     u8  pad_3b7[0x1];
-    s32                          unk_3b8;               /* 0x3b8 */
-    s32                          unk_3bc;               /* 0x3bc */
+    s32                          mNumPathPts;               /* 0x3b8 */
+    s32                          mCurPathPt;               /* 0x3bc */
     s32                          unk_3c0;               /* 0x3c0 */
     s32                          unk_3c4;               /* 0x3c4 */
     u8                           unk_3c8;               /* 0x3c8 */

--- a/include/LavaBridge.h
+++ b/include/LavaBridge.h
@@ -17,7 +17,7 @@
  * is deliberately not redeclared here.
  *
  * mCooldown/mFlag sit at 0x31e/0x31f, in dBgActor_c's TAIL PADDING (same placement
- * rationale as ArmedRotatingPlatform's unk_31e). InitResources is this task's only
+ * rationale as ArmedRotatingPlatform's mAngVelY). InitResources is this task's only
  * evidence for them (seeds mCooldown to 0xf, mFlag to 0); Behavior (out of this
  * task's scope) is presumably where they are read.
  */

--- a/include/LavaPlank.h
+++ b/include/LavaPlank.h
@@ -19,7 +19,7 @@
 
 struct LavaPlank : dBgActor_c {
     u8  pad_31e[0x2];
-    s32 unk_320;                      /* 0x320 */
+    s32 mOriginalPosY;                      /* 0x320 */
     s16 unk_324;                      /* 0x324 */
 
     /* --- vtable --- */
@@ -49,7 +49,7 @@ struct LavaPlank {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    s32 unk_320;            /* 0x320 */
+    s32 mOriginalPosY;            /* 0x320 */
     s16 unk_324;            /* 0x324 */
 };
 

--- a/include/LavaSeesaw.h
+++ b/include/LavaSeesaw.h
@@ -17,7 +17,7 @@
  * is deliberately not redeclared here.
  *
  * mSwingStep sits at 0x31e, in dBgActor_c's TAIL PADDING (same placement rationale
- * as ArmedRotatingPlatform's unk_31e): Behavior adds it to mAngleX every frame while
+ * as ArmedRotatingPlatform's mAngVelY): Behavior adds it to mAngleX every frame while
  * mSwingCooldown is zero, and flips its sign (a see-saw tilt reversal) once mAngleX
  * passes +-0x400, also reloading mSwingCooldown to 0x1e. InitResources seeds
  * mSwingStep to -0x10.

--- a/include/LightBeam.h
+++ b/include/LightBeam.h
@@ -15,7 +15,7 @@ struct LightBeam {
     Model mModel;            /* 0x0d4 */
     dCcAcPos_c mdCcAcPos_c;   /* 0x124 */
     u8  pad_164[0x4];
-    u16 unk_168;              /* 0x168 */
+    u16 mSoundTimer;              /* 0x168 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/Minimap.h
+++ b/include/Minimap.h
@@ -20,33 +20,33 @@ struct Minimap : dBase_c {
     s32 unk_054;                      /* 0x054 */
     s32 unk_058;                      /* 0x058 */
     s32 mPosX;                        /* 0x05c */
-    s32 unk_060;                      /* 0x060 */
-    s32 unk_064;                      /* 0x064 */
+    s32 mMapCenterX;                      /* 0x060 */
+    s32 mMapCenterY;                      /* 0x064 */
     u8  pad_068[0x8];
-    s32 unk_070[4];                   /* 0x070 */
-    s32 unk_080[4];                   /* 0x080 */
+    s32 mPlayerIconX[4];                   /* 0x070 */
+    s32 mPlayerIconY[4];                   /* 0x080 */
     s32 unk_090;                      /* 0x090 */
     s32 unk_094;                      /* 0x094 */
     s32 unk_098;                      /* 0x098 */
     s32 unk_09c;                      /* 0x09c */
-    s32 unk_0a0[12];                  /* 0x0a0 */
-    s32 unk_0d0[12];                  /* 0x0d0 */
-    s32 unk_100[9];                   /* 0x100 */
-    s32 unk_124[9];                   /* 0x124 */
+    s32 mStarIconX[12];                  /* 0x0a0 */
+    s32 mStarIconY[12];                  /* 0x0d0 */
+    s32 mCapIconX[9];                   /* 0x100 */
+    s32 mCapIconY[9];                   /* 0x124 */
     u8  pad_148[0x30];
-    s32 unk_178;                      /* 0x178 */
-    s32 unk_17c;                      /* 0x17c */
-    s32 unk_180[8];                   /* 0x180 */
-    s32 unk_1a0[8];                   /* 0x1a0 */
+    s32 mStarKeyIconX;                      /* 0x178 */
+    s32 mStarKeyIconY;                      /* 0x17c */
+    s32 mSpikeBombIconX[8];                   /* 0x180 */
+    s32 mSpikeBombIconY[8];                   /* 0x1a0 */
     u8  pad_1c0[0x14];
-    s32 unk_1d4;                      /* 0x1d4 */
-    s32 unk_1d8;                      /* 0x1d8 */
-    s32 unk_1dc;                      /* 0x1dc */
+    s32 mScale;                      /* 0x1d4 */
+    s32 mMapWidth;                      /* 0x1d8 */
+    s32 mMapCenterOffset;                      /* 0x1dc */
     s32 unk_1e0;                      /* 0x1e0 */
     s32 unk_1e4;                      /* 0x1e4 */
     s32 unk_1e8;                      /* 0x1e8 */
     s32 unk_1ec;                      /* 0x1ec */
-    s32 unk_1f0;                      /* 0x1f0 */
+    s32 mCurrentScale;                      /* 0x1f0 */
     s32 unk_1f4;                      /* 0x1f4 */
     s32 unk_1f8;                      /* 0x1f8 */
     s32 unk_1fc;                      /* 0x1fc */
@@ -54,21 +54,21 @@ struct Minimap : dBase_c {
     s32 unk_204;                      /* 0x204 */
     s32 unk_208;                      /* 0x208 */
     s32 unk_20c;                      /* 0x20c */
-    s32 unk_210;                      /* 0x210 */
-    s32 unk_214;                      /* 0x214 */
-    s32 unk_218;                      /* 0x218 */
-    u16 unk_21c;                      /* 0x21c */
-    s8 unk_21e[4];                    /* 0x21e */
-    s8 unk_222[12];                   /* 0x222 */
+    s32 mArrowScale;                      /* 0x210 */
+    s32 mTargetInvScale;                      /* 0x214 */
+    s32 mInvScale;                      /* 0x218 */
+    u16 mAngle;                      /* 0x21c */
+    s8 mPlayerMapIDs[4];                    /* 0x21e */
+    s8 mStarMapIDs[12];                   /* 0x222 */
     u8  pad_22e[0xc];
-    s8 unk_23a[9];                    /* 0x23a */
+    s8 mCapMapIDs[9];                    /* 0x23a */
     u8  pad_243[0x5];
-    s8 unk_248;                       /* 0x248 */
-    s8 unk_249[8];                    /* 0x249 */
-    u8 unk_251;                       /* 0x251 */
+    s8 mStarKeyMapID;                       /* 0x248 */
+    s8 mSpikeBombMapIDs[8];                    /* 0x249 */
+    u8 mArrowType;                       /* 0x251 */
     u8  pad_252[0x2];
-    u8 unk_254;                       /* 0x254 */
-    u8 unk_255;                       /* 0x255 */
+    u8 mTouchCircleTimer;                       /* 0x254 */
+    u8 mInIntroCutscene;                       /* 0x255 */
 
     /* --- vtable --- */
     virtual ~Minimap();
@@ -93,32 +93,32 @@ struct Minimap {
     s32 unk_054;            /* 0x054 */
     s32 unk_058;            /* 0x058 */
     s32 mPosX;            /* 0x05c */
-    s32 unk_060;            /* 0x060 */
-    s32 unk_064;            /* 0x064 */
+    s32 mMapCenterX;            /* 0x060 */
+    s32 mMapCenterY;            /* 0x064 */
     u8  pad_068[0x8];
     /* Minimap::Behavior carries a shadow struct that declares these ranges as
        ARRAYS and indexes them; the header had them as flat padding, which is
        why the shadow existed at all. Sizes are the shadow's own, and the
        reconstruction is offset-neutral -- the struct still spans 0x256. */
-    s32 unk_070[4];            /* 0x070 */
-    s32 unk_080[4];            /* 0x080 */
+    s32 mPlayerIconX[4];            /* 0x070 */
+    s32 mPlayerIconY[4];            /* 0x080 */
     s32 unk_090;            /* 0x090 */
     s32 unk_094;            /* 0x094 */
     s32 unk_098;            /* 0x098 */
     s32 unk_09c;            /* 0x09c */
-    s32 unk_0a0[12];            /* 0x0a0 */
-    s32 unk_0d0[12];            /* 0x0d0 */
-    s32 unk_100[9];            /* 0x100 */
-    s32 unk_124[9];            /* 0x124 */
+    s32 mStarIconX[12];            /* 0x0a0 */
+    s32 mStarIconY[12];            /* 0x0d0 */
+    s32 mCapIconX[9];            /* 0x100 */
+    s32 mCapIconY[9];            /* 0x124 */
     u8  pad_148[0x30];
-    s32 unk_178;            /* 0x178 */
-    s32 unk_17c;            /* 0x17c */
-    s32 unk_180[8];            /* 0x180 */
-    s32 unk_1a0[8];            /* 0x1a0 */
+    s32 mStarKeyIconX;            /* 0x178 */
+    s32 mStarKeyIconY;            /* 0x17c */
+    s32 mSpikeBombIconX[8];            /* 0x180 */
+    s32 mSpikeBombIconY[8];            /* 0x1a0 */
     u8  pad_1c0[0x14];
-    s32 unk_1d4;            /* 0x1d4 */
-    s32 unk_1d8;            /* 0x1d8 */
-    s32 unk_1dc;            /* 0x1dc */
+    s32 mScale;            /* 0x1d4 */
+    s32 mMapWidth;            /* 0x1d8 */
+    s32 mMapCenterOffset;            /* 0x1dc */
     /* 0x1e0 and 0x1f4 are each a Vector3 in the shadow -- three consecutive
        words handed to Vec3 helpers as one object. Kept as scalars here so the
        header does not assert a type the other eight matched functions never
@@ -127,7 +127,7 @@ struct Minimap {
     s32 unk_1e4;            /* 0x1e4 */
     s32 unk_1e8;            /* 0x1e8 */
     s32 unk_1ec;            /* 0x1ec */
-    s32 unk_1f0;            /* 0x1f0 */
+    s32 mCurrentScale;            /* 0x1f0 */
     s32 unk_1f4;            /* 0x1f4 */
     s32 unk_1f8;            /* 0x1f8 */
     s32 unk_1fc;            /* 0x1fc */
@@ -135,24 +135,24 @@ struct Minimap {
     s32 unk_204;            /* 0x204 */
     s32 unk_208;            /* 0x208 */
     s32 unk_20c;            /* 0x20c */
-    s32 unk_210;            /* 0x210 */
-    s32 unk_214;            /* 0x214 */
-    s32 unk_218;            /* 0x218 */
+    s32 mArrowScale;            /* 0x210 */
+    s32 mTargetInvScale;            /* 0x214 */
+    s32 mInvScale;            /* 0x218 */
     /* Stays u16. Behavior's shadow spelled it s16 and then cast EVERY read to
        (u16) -- `(u16)ang >= 0x8000` and `(s32)(u16)ang >> 4` -- so the reads
        want unsigned and the two spellings mean the same thing. */
-    u16 unk_21c;            /* 0x21c */
-    s8  unk_21e[4];            /* 0x21e */
-    s8  unk_222[12];            /* 0x222 */
+    u16 mAngle;            /* 0x21c */
+    s8  mPlayerMapIDs[4];            /* 0x21e */
+    s8  mStarMapIDs[12];            /* 0x222 */
     u8  pad_22e[0xc];
-    s8  unk_23a[9];            /* 0x23a */
+    s8  mCapMapIDs[9];            /* 0x23a */
     u8  pad_243[0x5];
-    s8  unk_248;            /* 0x248 */
-    s8  unk_249[8];            /* 0x249 */
-    u8  unk_251;            /* 0x251 */
+    s8  mStarKeyMapID;            /* 0x248 */
+    s8  mSpikeBombMapIDs[8];            /* 0x249 */
+    u8  mArrowType;            /* 0x251 */
     u8  pad_252[0x2];
-    u8  unk_254;            /* 0x254 */
-    u8  unk_255;            /* 0x255 */
+    u8  mTouchCircleTimer;            /* 0x254 */
+    u8  mInIntroCutscene;            /* 0x255 */
 };
 
 #endif /* __cplusplus */

--- a/include/MovingBar.h
+++ b/include/MovingBar.h
@@ -27,7 +27,7 @@ struct MovingBar : dBgActor_c {
        and MovingBarSmall_Spawn -- call fBase_c::operator new(0x338). They agree, so
        they are two spawn-info variants of one actor, and 0x330 was the field span
        rather than the size. */
-    u32 unk_330;              /* 0x330 */
+    u32 mState;              /* 0x330 */
     u8  pad_334[0x4];
 
     /* --- vtable --- */

--- a/include/PathLift.h
+++ b/include/PathLift.h
@@ -25,7 +25,7 @@ struct PathLift : dBgActor_c {
     u8  unk_42a;                          /* 0x42a */
     u8  unk_42b;                          /* 0x42b */
     u8  pad_42c[0x20];
-    s32 unk_44c;                          /* 0x44c */
+    s32 mState;                          /* 0x44c */
 
     virtual ~PathLift();
 
@@ -51,7 +51,7 @@ struct PathLift {
     u8  unk_42a;            /* 0x42a */
     u8  unk_42b;            /* 0x42b */
     u8  pad_42c[0x20];
-    s32 unk_44c;            /* 0x44c */
+    s32 mState;            /* 0x44c */
 };
 
 #endif /* __cplusplus */

--- a/include/PoleLift.h
+++ b/include/PoleLift.h
@@ -21,7 +21,7 @@
 struct PoleLift : dBgActor_c {
     u8  pad_31e[0x2];
     dCcAc_c mdCcAc_c;/* 0x320 */
-    u16 unk_354;                      /* 0x354 */
+    u16 mHeightAng;                      /* 0x354 */
 
     /* --- vtable --- */
     virtual ~PoleLift();
@@ -54,7 +54,7 @@ struct PoleLift {
        dCcAc_c's D1 at +0x320 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN8PoleLiftD1Ev.c] */
     dCcAc_c mdCcAc_c;            /* 0x320 */
-    u16 unk_354;            /* 0x354 */
+    u16 mHeightAng;            /* 0x354 */
 };
 
 #endif /* __cplusplus */

--- a/include/PyramidLift.h
+++ b/include/PyramidLift.h
@@ -35,8 +35,8 @@ struct PyramidLift {
     u8  pad_37c[0x78];
     u16 mShakeTimer;            /* 0x3f4 */
     u8  mState;            /* 0x3f6 */
-    u8  unk_3f7;            /* 0x3f7 */
-    u8  unk_3f8;            /* 0x3f8 */
+    u8  mHadClsn;            /* 0x3f7 */
+    u8  mNextBullet;            /* 0x3f8 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/PyramidStep.h
+++ b/include/PyramidStep.h
@@ -21,8 +21,8 @@
 struct PyramidStep : dBgActor_c {
     u8  pad_31e[0x2];
     Model mModel;                     /* 0x320 */
-    s16 unk_370;                      /* 0x370 */
-    u8 unk_372;                       /* 0x372 */
+    s16 mStateTimer;                      /* 0x370 */
+    u8 mState;                       /* 0x372 */
     u8  pad_373[0x1];
     u8 unk_374;                       /* 0x374 */
 
@@ -64,8 +64,8 @@ struct PyramidStep {
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel2;            /* 0x320 */
-    s16 unk_370;            /* 0x370 */
-    u8  unk_372;            /* 0x372 */
+    s16 mStateTimer;            /* 0x370 */
+    u8  mState;            /* 0x372 */
     u8  pad_373[0x1];
     u8  unk_374;            /* 0x374 */
 };

--- a/include/PyramidTag.h
+++ b/include/PyramidTag.h
@@ -10,7 +10,7 @@
 struct PyramidTag {
     u8  pad_000[0xd4];
     dCcAc_c mdCcAc_c;         /* 0x0d4 */
-    s32 unk_108;            /* 0x108 */
+    s32 mPyramidTopID;            /* 0x108 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/PyramidTop.h
+++ b/include/PyramidTop.h
@@ -25,12 +25,12 @@ struct PyramidTop : dBgActor_c {
     s32 unk_3a0;                      /* 0x3a0 */
     s32 unk_3a4;                      /* 0x3a4 */
     s32 unk_3a8;                      /* 0x3a8 */
-    s32 unk_3ac;                      /* 0x3ac */
-    s16 unk_3b0;                      /* 0x3b0 */
-    u16 unk_3b2;                      /* 0x3b2 */
-    s16 unk_3b4;                      /* 0x3b4 */
-    u8 unk_3b6;                       /* 0x3b6 */
-    u8 unk_3b7;                       /* 0x3b7 */
+    s32 mSpinParticleID;                      /* 0x3ac */
+    s16 mAngVelY;                      /* 0x3b0 */
+    u16 mStateTimer;                      /* 0x3b2 */
+    s16 mSoundTimer;                      /* 0x3b4 */
+    u8 mNumTagsTriggered;                       /* 0x3b6 */
+    u8 mState;                       /* 0x3b7 */
 
     /* --- vtable --- */
     virtual ~PyramidTop();
@@ -80,12 +80,12 @@ struct PyramidTop {
     s32 unk_3a0;            /* 0x3a0 */
     s32 unk_3a4;            /* 0x3a4 */
     s32 unk_3a8;            /* 0x3a8 */
-    s32 unk_3ac;            /* 0x3ac */
-    s16 unk_3b0;            /* 0x3b0 */
-    u16 unk_3b2;            /* 0x3b2 */
-    s16 unk_3b4;            /* 0x3b4 */
-    u8  unk_3b6;            /* 0x3b6 */
-    u8  unk_3b7;            /* 0x3b7 */
+    s32 mSpinParticleID;            /* 0x3ac */
+    s16 mAngVelY;            /* 0x3b0 */
+    u16 mStateTimer;            /* 0x3b2 */
+    s16 mSoundTimer;            /* 0x3b4 */
+    u8  mNumTagsTriggered;            /* 0x3b6 */
+    u8  mState;            /* 0x3b7 */
 };
 
 #endif /* __cplusplus */

--- a/include/ShipWater.h
+++ b/include/ShipWater.h
@@ -21,10 +21,10 @@
 struct ShipWater : dBgActor_c {
     u8  pad_31e[0x2];
     TextureTransformer mTextureTransformer;/* 0x320 */
-    s32 unk_334;                      /* 0x334 */
-    u8 unk_338;                       /* 0x338 */
+    s32 mOriginalPosY;                      /* 0x334 */
+    u8 mChestsOpen;                       /* 0x338 */
     u8  pad_339[0x3];
-    s32 unk_33c;                      /* 0x33c */
+    s32 mSoundID;                      /* 0x33c */
 
     /* --- vtable --- */
     virtual ~ShipWater();
@@ -78,10 +78,10 @@ struct ShipWater {
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     TextureTransformer mTextureTransformer; /* 0x320 */
-    s32 unk_334;            /* 0x334 */
-    u8  unk_338;            /* 0x338 */
+    s32 mOriginalPosY;            /* 0x334 */
+    u8  mChestsOpen;            /* 0x338 */
     u8  pad_339[0x3];
-    s32 unk_33c;            /* 0x33c */
+    s32 mSoundID;            /* 0x33c */
 };
 
 #endif /* __cplusplus */

--- a/include/SlidingBox.h
+++ b/include/SlidingBox.h
@@ -32,7 +32,7 @@ struct SlidingBox {
     Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
-    s32 unk_320;            /* 0x320 */
+    s32 mShip;            /* 0x320 */
     /* dBgCh_Actr member, named by the class's own destructor calling
        dBgCh_Actr's D1 at +0x324 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN10SlidingBoxD1Ev.c] */
@@ -40,9 +40,9 @@ struct SlidingBox {
     s32 unk_4e0;            /* 0x4e0 */
     s32 unk_4e4;            /* 0x4e4 */
     s32 unk_4e8;            /* 0x4e8 */
-    s32 unk_4ec;            /* 0x4ec */
-    s32 unk_4f0;            /* 0x4f0 */
-    u8  unk_4f4;            /* 0x4f4 */
+    s32 mHorzPos;            /* 0x4ec */
+    s32 mSoundID;            /* 0x4f0 */
+    u8  mState;            /* 0x4f4 */
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();

--- a/include/SlidingIce.h
+++ b/include/SlidingIce.h
@@ -19,10 +19,10 @@
 
 struct SlidingIce : dBgActor_c {
     s16 unk_31e;                      /* 0x31e */
-    s8 unk_320;                       /* 0x320 */
+    s8 mNumToBigIce;                       /* 0x320 */
     u8  pad_321[0x3];
-    s32 unk_324;                      /* 0x324 */
-    s32 unk_328;                      /* 0x328 */
+    s32 mMinPosY;                      /* 0x324 */
+    s32 mSoundID;                      /* 0x328 */
 
     /* --- vtable --- */
     virtual ~SlidingIce();
@@ -65,10 +65,10 @@ struct SlidingIce {
     s8  unk_170;            /* 0x170 */
     u8  pad_171[0x1ad];
     s16 unk_31e;            /* 0x31e */
-    s8  unk_320;            /* 0x320 */
+    s8  mNumToBigIce;            /* 0x320 */
     u8  pad_321[0x3];
-    s32 unk_324;            /* 0x324 */
-    s32 unk_328;            /* 0x328 */
+    s32 mMinPosY;            /* 0x324 */
+    s32 mSoundID;            /* 0x328 */
 };
 
 #endif /* __cplusplus */

--- a/include/SpinningPlatform.h
+++ b/include/SpinningPlatform.h
@@ -25,11 +25,11 @@ struct SpinningPlatform {
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x31];
-    s8  unk_31e;            /* 0x31e */
+    s8  mRandDirection;            /* 0x31e */
     u8  pad_31f[0x1];
-    u16 unk_320;            /* 0x320 */
-    u16 unk_322;            /* 0x322 */
-    s32 unk_324;            /* 0x324 */
+    u16 mRandTimer;            /* 0x320 */
+    u16 mRandFrames;            /* 0x322 */
+    s32 mFloorPosY;            /* 0x324 */
     ShadowModel mShadowModel; /* 0x328 */
 #ifdef __cplusplus
     /* methods */

--- a/include/Squasher.h
+++ b/include/Squasher.h
@@ -20,9 +20,9 @@
 #include "ShadowModel.h"
 
 struct Squasher : dBgActor_c {
-    s16 unk_31e;                      /* 0x31e */
-    s16 unk_320;                      /* 0x320 */
-    u8 unk_322;                       /* 0x322 */
+    s16 mAngVelX;                      /* 0x31e */
+    s16 mStateTimer;                      /* 0x320 */
+    u8 mState;                       /* 0x322 */
     u8  pad_323[0x1];
     ShadowModel mShadowModel;         /* 0x324 */
 
@@ -36,7 +36,7 @@ struct Squasher : dBgActor_c {
     /* Tail padding. The field span stops short of the real size: Squasher_Spawn
        calls fBase_c::operator new(0x37c), read off the retail
        instruction. A span is only a LOWER BOUND. */
-    Matrix4x3 pad_34c;        /* 0x34c */
+    Matrix4x3 mShadowMat;        /* 0x34c */
 };
 
 typedef char Squasher_size_must_be_0x37c[sizeof(Squasher) == 0x37c ? 1 : -1];
@@ -72,9 +72,9 @@ struct Squasher {
     dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x31];
-    s16 unk_31e;            /* 0x31e */
-    s16 unk_320;            /* 0x320 */
-    u8  unk_322;            /* 0x322 */
+    s16 mAngVelX;            /* 0x31e */
+    s16 mStateTimer;            /* 0x320 */
+    u8  mState;            /* 0x322 */
     u8  pad_323[0x1];
     ShadowModel mShadowModel; /* 0x324 */
 };

--- a/include/SwitchActivatedPlank.h
+++ b/include/SwitchActivatedPlank.h
@@ -23,10 +23,10 @@ struct SwitchActivatedPlank {
        padding rather than being folded into the member. */
     Model mModel2;            /* 0x320 */
     u8  pad_370[0x30];
-    s16 unk_3a0;            /* 0x3a0 */
-    u8  unk_3a2;            /* 0x3a2 */
-    u8  unk_3a3;            /* 0x3a3 */
-    u8  unk_3a4;            /* 0x3a4 */
+    s16 mStateTimer;            /* 0x3a0 */
+    u8  mState;            /* 0x3a2 */
+    u8  mVisible;            /* 0x3a3 */
+    u8  mEventID;            /* 0x3a4 */
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();

--- a/include/SwitchPillar.h
+++ b/include/SwitchPillar.h
@@ -17,7 +17,7 @@
  * is deliberately not redeclared here.
  *
  * mPressed sits at 0x31e, in dBgActor_c's TAIL PADDING (same placement rationale as
- * ArmedRotatingPlatform's unk_31e): InitResources and OnGroundPounded both guard on
+ * ArmedRotatingPlatform's mAngVelY): InitResources and OnGroundPounded both guard on
  * and set this byte -- OnGroundPounded no-ops if already set, then walks every other
  * actorID-0x22 instance and, on finding one already pressed, sets a shared flag in
  * data_0209caa0[2]. It is this switch pillar's own "pressed" state.

--- a/include/TTC_MovingBeam.h
+++ b/include/TTC_MovingBeam.h
@@ -21,9 +21,9 @@
 
 struct TTC_MovingBeam : dBgActor_c {
     u8  pad_31e[0x2];
-    s32 unk_320;                      /* 0x320 */
-    s32 unk_324;                      /* 0x324 */
-    u8 unk_328;                       /* 0x328 */
+    s32 mStartPosY;                      /* 0x320 */
+    s32 mEndPosY;                      /* 0x324 */
+    u8 mDirection;                       /* 0x328 */
     u8  pad_329[0x7];
     s32 unk_330;                      /* 0x330 */
     ShadowModel mShadowModel;         /* 0x334 */
@@ -38,7 +38,7 @@ struct TTC_MovingBeam : dBgActor_c {
     /* Tail padding. The field span stops short of the real size: TTC_MovingBeam_Spawn
        calls fBase_c::operator new(0x38c), read off the retail
        instruction. A span is only a LOWER BOUND. */
-    Matrix4x3 pad_35c;        /* 0x35c */
+    Matrix4x3 mShadowMat;        /* 0x35c */
 };
 
 typedef char TTC_MovingBeam_size_must_be_0x38c[sizeof(TTC_MovingBeam) == 0x38c ? 1 : -1];
@@ -71,9 +71,9 @@ struct TTC_MovingBeam {
     dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
-    s32 unk_320;            /* 0x320 */
-    s32 unk_324;            /* 0x324 */
-    u8  unk_328;            /* 0x328 */
+    s32 mStartPosY;            /* 0x320 */
+    s32 mEndPosY;            /* 0x324 */
+    u8  mDirection;            /* 0x328 */
     u8  pad_329[0x7];
     s32 unk_330;            /* 0x330 */
     ShadowModel mShadowModel; /* 0x334 */

--- a/include/TinyWater.h
+++ b/include/TinyWater.h
@@ -21,9 +21,9 @@
 struct TinyWater : dBgActor_c {
     u8  pad_31e[0x2];
     TextureTransformer mTextureTransformer;/* 0x320 */
-    s32 unk_334;                      /* 0x334 */
+    s32 mMinPosY;                      /* 0x334 */
     u8  pad_338[0x4];
-    u16 unk_33c;              /* 0x33c */
+    u16 mSoundTimer;              /* 0x33c */
 
     /* --- vtable --- */
     virtual ~TinyWater();
@@ -58,9 +58,9 @@ struct TinyWater {
        TextureTransformer's D1 at +0x320 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN9TinyWaterD1Ev.c] */
     TextureTransformer mTextureTransformer;            /* 0x320 */
-    s32 unk_334;            /* 0x334 */
+    s32 mMinPosY;            /* 0x334 */
     u8  pad_338[0x4];
-    u16 unk_33c;              /* 0x33c */
+    u16 mSoundTimer;              /* 0x33c */
 };
 
 #endif /* __cplusplus */

--- a/include/TowerStep.h
+++ b/include/TowerStep.h
@@ -22,15 +22,15 @@ struct TowerStep : dBgActor_c {
     u8  pad_31e[0x2];
     ShadowModel mShadowModel;         /* 0x320 */
     u8  pad_348[0x30];
-    s32 unk_378;                      /* 0x378 */
-    s32 unk_37c;                      /* 0x37c */
-    s32 unk_380;                      /* 0x380 */
-    s32 unk_384;                      /* 0x384 */
-    s32 unk_388;                      /* 0x388 */
-    s32 unk_38c;                      /* 0x38c */
-    u8 unk_390;                       /* 0x390 */
-    u8 unk_391;                       /* 0x391 */
-    u8 unk_392;                       /* 0x392 */
+    s32 mFloorPosY;                      /* 0x378 */
+    s32 mMinPosY;                      /* 0x37c */
+    s32 mMaxPosY;                      /* 0x380 */
+    s32 mShadowOffsetX;                      /* 0x384 */
+    s32 mShadowOffsetY;                      /* 0x388 */
+    s32 mSoundID;                      /* 0x38c */
+    u8 mMoveTimer;                       /* 0x390 */
+    u8 mJustSteppedOn;                       /* 0x391 */
+    u8 mMove;                       /* 0x392 */
 
     /* --- vtable --- */
     virtual ~TowerStep();
@@ -77,15 +77,15 @@ struct TowerStep {
     u8  pad_125[0x1fb];
     ShadowModel mShadowModel; /* 0x320 */
     u8  pad_348[0x30];
-    s32 unk_378;            /* 0x378 */
-    s32 unk_37c;            /* 0x37c */
-    s32 unk_380;            /* 0x380 */
-    s32 unk_384;            /* 0x384 */
-    s32 unk_388;            /* 0x388 */
-    s32 unk_38c;            /* 0x38c */
-    u8  unk_390;            /* 0x390 */
-    u8  unk_391;            /* 0x391 */
-    u8  unk_392;            /* 0x392 */
+    s32 mFloorPosY;            /* 0x378 */
+    s32 mMinPosY;            /* 0x37c */
+    s32 mMaxPosY;            /* 0x380 */
+    s32 mShadowOffsetX;            /* 0x384 */
+    s32 mShadowOffsetY;            /* 0x388 */
+    s32 mSoundID;            /* 0x38c */
+    u8  mMoveTimer;            /* 0x390 */
+    u8  mJustSteppedOn;            /* 0x391 */
+    u8  mMove;            /* 0x392 */
 };
 
 #endif /* __cplusplus */

--- a/include/Trap.h
+++ b/include/Trap.h
@@ -48,12 +48,12 @@ struct Trap : dBgActor_c {
        numbered pair is a flat-struct-only convention). */
     Model mModel;                     /* 0x320 */
     u8  pad_370[0x30];
-    s32 unk_3a0;                      /* 0x3a0 */
-    s32 unk_3a4;                      /* 0x3a4 */
-    u16 unk_3a8;                      /* 0x3a8 */
-    u8  unk_3aa;                      /* 0x3aa */
-    u8  unk_3ab;                      /* 0x3ab */
-    s32 unk_3ac;                      /* 0x3ac */
+    s32 mState;                      /* 0x3a0 */
+    s32 mPlayerDist;                      /* 0x3a4 */
+    u16 mOpenSpeed;                      /* 0x3a8 */
+    u8  mTrapActive;                      /* 0x3aa */
+    u8  mIsSpawner;                      /* 0x3ab */
+    s32 mSpawnerID;                      /* 0x3ac */
 
     /* --- vtable --- */
     virtual ~Trap();
@@ -82,12 +82,12 @@ struct Trap {
     u8  pad_090[0x3c];
     s8  unk_0cc;            /* 0x0cc */
     u8  pad_0cd[0x2d3];
-    s32 unk_3a0;            /* 0x3a0 */
-    s32 unk_3a4;            /* 0x3a4 */
-    u16 unk_3a8;            /* 0x3a8 */
-    u8  unk_3aa;            /* 0x3aa */
-    u8  unk_3ab;            /* 0x3ab */
-    s32 unk_3ac;            /* 0x3ac */
+    s32 mState;            /* 0x3a0 */
+    s32 mPlayerDist;            /* 0x3a4 */
+    u16 mOpenSpeed;            /* 0x3a8 */
+    u8  mTrapActive;            /* 0x3aa */
+    u8  mIsSpawner;            /* 0x3ab */
+    s32 mSpawnerID;            /* 0x3ac */
 };
 
 #endif /* __cplusplus */

--- a/include/TreasureChest.h
+++ b/include/TreasureChest.h
@@ -17,10 +17,10 @@ struct TreasureChest {
     ModelAnim mModelAnim;            /* 0x0d4 */
     dCcAc_c mdCcAc_c;         /* 0x138 */
     u8  pad_16c[0x6];
-    u8  unk_172;            /* 0x172 */
+    u8  mOrder;            /* 0x172 */
     u8  pad_173[0x1];
-    u8  unk_174;            /* 0x174 */
-    u8  unk_175;            /* 0x175 */
+    u8  mStarID;            /* 0x174 */
+    u8  mTrackedStarID;            /* 0x175 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/WDW_Water.h
+++ b/include/WDW_Water.h
@@ -24,10 +24,10 @@ struct WDW_Water : dBgActor_c {
     s32 mTargetPosY;                  /* 0x334 */
     u8 unk_338;                       /* 0x338 */
     u8  pad_339[0x3];
-    s32 unk_33c;                      /* 0x33c */
-    u8 unk_340;                       /* 0x340 */
+    s32 mSoundID;                      /* 0x33c */
+    u8 mTrueAreaID;                       /* 0x340 */
     u8  pad_341[0x3];
-    s32 unk_344;                      /* 0x344 */
+    s32 mWaterHeight;                      /* 0x344 */
 
     /* --- vtable --- */
     virtual ~WDW_Water();
@@ -68,10 +68,10 @@ struct WDW_Water {
     s32 mTargetPosY;            /* 0x334 */
     u8  unk_338;            /* 0x338 */
     u8  pad_339[0x3];
-    s32 unk_33c;            /* 0x33c */
-    u8  unk_340;            /* 0x340 */
+    s32 mSoundID;            /* 0x33c */
+    u8  mTrueAreaID;            /* 0x340 */
     u8  pad_341[0x3];
-    s32 unk_344;            /* 0x344 */
+    s32 mWaterHeight;            /* 0x344 */
 };
 
 #endif /* __cplusplus */

--- a/include/WaterDiamond.h
+++ b/include/WaterDiamond.h
@@ -23,9 +23,9 @@ struct WaterDiamond {
        dCcAc_c's D1 at +0x124 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN12WaterDiamondD0Ev.c] */
     dCcAc_c mdCcAc_c;            /* 0x124 */
-    s32 unk_158;            /* 0x158 */
-    s8  unk_15c;            /* 0x15c */
-    u8  unk_15d;            /* 0x15d */
+    s32 mWaterID;            /* 0x158 */
+    s8  mWaterParam;            /* 0x15c */
+    u8  mActive;            /* 0x15d */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/dFdDummy_c.h
+++ b/include/dFdDummy_c.h
@@ -62,7 +62,7 @@ struct dFdDummy_c {
     void*  vtable;      /* 0x00 */
     Fix12i currInterp;  /* 0x04 (from Fader) */
     Fix12i speed;       /* 0x08 (from Fader) */
-    u16    unk_00c;     /* 0x0c (from FaderColor) */
+    u16    color;       /* 0x0c (from FaderColor) */
 };
 #endif
 

--- a/include/dWipe_c.h
+++ b/include/dWipe_c.h
@@ -25,7 +25,7 @@
  *     (func_0202ed14, dWipe_c's own field-init helper called from the
  *     constructor), and 0x29 rounds up to the 4-byte-aligned 0x2c.
  *
- * MEMBERS. FaderColor's own dsize (vptr+currInterp+speed+unk_00c) is 0xe;
+ * MEMBERS. FaderColor's own dsize (vptr+currInterp+speed+color) is 0xe;
  * its sizeof of 0x10 leaves a 2-byte tail-padding gap at 0xe..0xf that the
  * Itanium ABI lets a derived class reuse, and dWipe_c's constructor helper
  * (func_0202ed14) does: it writes single bytes at both 0xe and 0xf before
@@ -94,7 +94,7 @@ struct dWipe_c {
     void*  vtable;      /* 0x00 */
     Fix12i currInterp;  /* 0x04 (from Fader) */
     Fix12i speed;       /* 0x08 (from Fader) */
-    u16    unk_00c;     /* 0x0c (from FaderColor) */
+    u16    color;       /* 0x0c (from FaderColor) */
     u8     unk_00e;     /* 0x0e */
     s8     unk_00f;     /* 0x0f */
     s32    unk_010;     /* 0x10 */

--- a/src/_ZN10DonutBlock8BehaviorEv.cpp
+++ b/src/_ZN10DonutBlock8BehaviorEv.cpp
@@ -18,14 +18,14 @@ int DonutBlock::Behavior()
 {
     switch (mState) {
     case 0:
-        if (unk_4e8 == 0) {
-            unk_4e9 = 0;
+        if (mHadClsn == 0) {
+            mClsnTimer = 0;
         } else {
             unsigned char* pc9 = (unsigned char*)(((int)((char*)this) + 0x4e9));
             *pc9 = *pc9 + 1;
-            unk_4e8 = 0;
+            mHadClsn = 0;
         }
-        if (unk_4e9 >= 0xf) mState = 1;
+        if (mClsnTimer >= 0xf) mState = 1;
         break;
     case 1:
         _ZN8dActor_c9UpdatePosEP5dCc_c(((char*)this), 0);
@@ -45,8 +45,8 @@ int DonutBlock::Behavior()
         if (d <= 0x3e8000) break;
         if (d < 0x7d0000) {
             mVertSpeed = 0;
-            unk_4e9 = 0;
-            unk_4e8 = 0;
+            mClsnTimer = 0;
+            mHadClsn = 0;
             mState = 0;
         }
         break;

--- a/src/_ZN10PyramidTag13InitResourcesEv.cpp
+++ b/src/_ZN10PyramidTag13InitResourcesEv.cpp
@@ -12,7 +12,7 @@ int PyramidTag::InitResources()
 {
     int a = _ZN8dActor_c15FindWithActorIDEjPS_(0x55, 0);
     if(a == 0){ _ZN7fBase_c18MarkForDestructionEv(((char*)this)); return 1; }
-    unk_108 = *(int*)(a+4);
+    mPyramidTopID = *(int*)(a+4);
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(((char*)this)+0xd4, ((char*)this), 0x7d000, 0x28000, 2, 0x400000);
     return 1;
 }

--- a/src/_ZN10PyramidTag8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTag8BehaviorEv.cpp
@@ -12,7 +12,7 @@ extern void _ZN5dCc_c6UpdateEv(void* a);
 int PyramidTag::Behavior()
 {
   if(mdCcAc_c.otherOwner != 0){
-    unsigned int id = unk_108;
+    unsigned int id = mPyramidTopID;
     if(id == 0){
       _ZN7fBase_c18MarkForDestructionEv(((char*)this));
       return 1;

--- a/src/_ZN10PyramidTop13InitResourcesEv.cpp
+++ b/src/_ZN10PyramidTop13InitResourcesEv.cpp
@@ -29,11 +29,11 @@ int PyramidTop::InitResources()
     unk_3a0 = mPosX;
     unk_3a4 = mPosY;
     unk_3a8 = mPosZ;
-    unk_3b0 = 0;
-    unk_3b6 = 0;
-    unk_3b7 = 0;
-    unk_3ac = 0;
-    unk_3b4 = 0;
+    mAngVelY = 0;
+    mNumTagsTriggered = 0;
+    mState = 0;
+    mSpinParticleID = 0;
+    mSoundTimer = 0;
     _ZN5Event8ClearBitEj(0xe);
     return 1;
 }

--- a/src/_ZN10PyramidTop8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTop8BehaviorEv.cpp
@@ -12,22 +12,22 @@ extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int bank, void* pos);
 
 int PyramidTop::Behavior()
 {
-    u8 state = unk_3b7;
+    u8 state = mState;
     switch (state) {
     case 0:
-        if (unk_3b6 == 4) {
-            (*(u8*)((char*)&unk_3b7))++;
+        if (mNumTagsTriggered == 4) {
+            (*(u8*)((char*)&mState))++;
         }
         break;
     case 1:
-        _ZN5Sound15PlaySecretSoundEP8dActor_cPt(((char*)this), (void*)((char*)&unk_3b4));
-        if (unk_3b2 == 0) {
+        _ZN5Sound15PlaySecretSoundEP8dActor_cPt(((char*)this), (void*)((char*)&mSoundTimer));
+        if (mStateTimer == 0) {
             _ZN5Sound9PlayBank3EjRK7Vector3(0x4b, (void*)((char*)&mCamSpacePosX));
         }
         func_ov024_02111350(((char*)this));
         break;
     case 2:
-        if (_ZN5Sound15PlaySecretSoundEP8dActor_cPt(((char*)this), (void*)((char*)&unk_3b4))) {
+        if (_ZN5Sound15PlaySecretSoundEP8dActor_cPt(((char*)this), (void*)((char*)&mSoundTimer))) {
             _ZN5Sound9PlayBank3EjRK7Vector3(0x4c, (void*)((char*)&mCamSpacePosX));
             func_ov024_021112c0(((char*)this));
         } else {
@@ -35,9 +35,9 @@ int PyramidTop::Behavior()
         }
         break;
     }
-    (*(u16*)((char*)&unk_3b2))++;
-    if (state != unk_3b7) {
-        unk_3b2 = 0;
+    (*(u16*)((char*)&mStateTimer))++;
+    if (state != mState) {
+        mStateTimer = 0;
     }
     func_ov024_021114c4(((char*)this));
     func_ov024_02111480(((char*)this));

--- a/src/_ZN10SlidingBox13InitResourcesEv.cpp
+++ b/src/_ZN10SlidingBox13InitResourcesEv.cpp
@@ -28,8 +28,8 @@ int SlidingBox::InitResources()
     _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x324, ((char*)this), 0x14000, 0x14000, 0, 0);
     unk_09c = -0x2000;
     unk_0a0 = -0x14000;
-    unk_320 = 0;
-    unk_4f4 = 0;
-    unk_4f0 = 0;
+    mShip = 0;
+    mState = 0;
+    mSoundID = 0;
     return 1;
 }

--- a/src/_ZN10SlidingIce8BehaviorEv.cpp
+++ b/src/_ZN10SlidingIce8BehaviorEv.cpp
@@ -20,12 +20,12 @@ int SlidingIce::Behavior()
   if(isType){
     if(DecIfAbove0_Short((char *)&unk_31e) == 0){
       _Z14ApproachLinearRiii((int*)((char *)&mHorzSpeed), 0, 0x3000);
-      if(_Z14ApproachLinearRiii((int*)((char *)&mPosY), unk_324, 0xa000) != 0){
+      if(_Z14ApproachLinearRiii((int*)((char *)&mPosY), mMinPosY, 0xa000) != 0){
         _ZN7fBase_c18MarkForDestructionEv(((char *)this));
       }
     }
     _ZN8dActor_c9UpdatePosEP5dCc_c(((char *)this), 0);
-    unk_328 = _ZN5Sound8PlayLongEjjjRK7Vector3s(unk_328, 3, 0x98, ((char *)this)+0x74, 0);
+    mSoundID = _ZN5Sound8PlayLongEjjjRK7Vector3s(mSoundID, 3, 0x98, ((char *)this)+0x74, 0);
   } else {
     if(DecIfAbove0_Short((char *)&unk_31e) == 0){
       V3 pos;
@@ -33,13 +33,13 @@ int SlidingIce::Behavior()
       pos.y = mPosY;
       pos.z = mPosZ;
       int spawnType = 1;
-      if(DecIfAbove0_Byte((char *)&unk_320) == 0){
-        unk_320 = 5;
+      if(DecIfAbove0_Byte((char *)&mNumToBigIce) == 0){
+        mNumToBigIce = 5;
         spawnType = 2;
       } else {
         pos.y -= 0x50000;
       }
-      unsigned char cnt = unk_320;
+      unsigned char cnt = mNumToBigIce;
       unk_31e = (cnt + 1) * 0x14;
       _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(0x5d, spawnType, &pos, ((char *)this)+0x8c, mAreaId, -1);
     }

--- a/src/_ZN11PyramidLift13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidLift13InitResourcesEv.cpp
@@ -51,7 +51,7 @@ int PyramidLift::InitResources()
         ip = ((char*)this);
         unk_378 = mPosZ;
         mState = (unsigned char)n;
-        unk_3f7 = (unsigned char)n;
+        mHadClsn = (unsigned char)n;
         k = 0x1cc000;
         do {
             int *py;

--- a/src/_ZN11PyramidLift6RenderEv.cpp
+++ b/src/_ZN11PyramidLift6RenderEv.cpp
@@ -24,7 +24,7 @@ int PyramidLift::Render()
         Sub* s = (Sub*)((char*)&mModel1);
         s->m(0);
     }
-    int i = unk_3f8;
+    int i = mNextBullet;
     if (i < 0xa) {
         Elem* e = (Elem*)(((char*)this) + i * 0xc);
         do {

--- a/src/_ZN11PyramidLift8BehaviorEv.cpp
+++ b/src/_ZN11PyramidLift8BehaviorEv.cpp
@@ -13,7 +13,7 @@ int PyramidLift::Behavior()
 {
     switch (mState) {
     case 0:
-        if (unk_3f7 != 0) {
+        if (mHadClsn != 0) {
             mState = 1;
             mShakeTimer = 0;
         }
@@ -37,7 +37,7 @@ int PyramidLift::Behavior()
     }
     case 2: {
         int v = mPosY;
-        int idx = unk_3f8;
+        int idx = mNextBullet;
         int* p = (int*)(((char*)this) + idx * 0xc + 0x380);
         int lim = *p + 0x14000;
         if (v <= lim) {
@@ -77,6 +77,6 @@ int PyramidLift::Behavior()
     _ZN10dBgActor_c21UpdateModelPosAndRotYEv(((char*)this));
     if (_ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0))
         _ZN10dBgActor_c19UpdateClsnPosAndRotEv(((char*)this));
-    unk_3f7 = 0;
+    mHadClsn = 0;
     return 1;
 }

--- a/src/_ZN11PyramidStep13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidStep13InitResourcesEv.cpp
@@ -36,8 +36,8 @@ int PyramidStep::InitResources()
         int v = 0x5000;
         int k = (*(s32 *)&param1) & 3;
         mVertSpeed = -v;
-        unk_372 = 0;
-        unk_370 = 0;
+        mState = 0;
+        mStateTimer = 0;
         switch (k) {
         case 0:
             break;
@@ -47,7 +47,7 @@ int PyramidStep::InitResources()
             break;
         case 2:
             *(int*)(((int)((char *)this) + 0x60)) -= 0x1f4000;
-            unk_372 = 1;
+            mState = 1;
             mVertSpeed = v;
             break;
         }

--- a/src/_ZN12WaterDiamond13InitResourcesEv.cpp
+++ b/src/_ZN12WaterDiamond13InitResourcesEv.cpp
@@ -15,9 +15,9 @@ int WaterDiamond::InitResources()
   void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_02114270);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, m, 1, -1);
   _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(((char*)this)+0x124, ((char*)this), 0x32000, 0x64000, 0x800002, 0);
-  unk_158 = 0;
-  unk_15c = mParam & 1;
-  unk_15d = 0;
+  mWaterID = 0;
+  mWaterParam = mParam & 1;
+  mActive = 0;
   mAngleY = 0;
   return 1;
 }

--- a/src/_ZN12WaterDiamond8BehaviorEv.cpp
+++ b/src/_ZN12WaterDiamond8BehaviorEv.cpp
@@ -14,19 +14,19 @@ extern void _ZN5dCc_c6UpdateEv(void* self);
 int WaterDiamond::Behavior()
 {
     func_ov029_02111850(((char*)this));
-    if (unk_158 == 0) return 1;
+    if (mWaterID == 0) return 1;
     func_ov029_021117ac(((char*)this));
-    if (unk_15d != 0) {
+    if (mActive != 0) {
         char* p;
         s16* a = (s16*)(((int)((char*)this) + 0x8e));
         *a = *a + 0x400;
-        p = _ZN8dActor_c10FindWithIDEj(unk_158);
+        p = _ZN8dActor_c10FindWithIDEj(mWaterID);
         if (p != 0) {
             if (mPosY == *(int*)(p+0x60)) {
-                if (mAngleY == 0) unk_15d = 0;
+                if (mAngleY == 0) mActive = 0;
             }
             if (mPosY != *(int*)(p+0x334)) {
-                unk_15d = 0;
+                mActive = 0;
                 mAngleY = 0;
             }
         }

--- a/src/_ZN13BasementWater8BehaviorEv.cpp
+++ b/src/_ZN13BasementWater8BehaviorEv.cpp
@@ -15,15 +15,15 @@ extern int data_0209f32c;
 
 int BasementWater::Behavior()
 {
-    if (unk_33e != 0)
-        _ZN5Sound15PlaySecretSoundEP8dActor_cPt(((char*)this), (unsigned short*)((char*)&unk_33c));
+    if (mWasJustDrained != 0)
+        _ZN5Sound15PlaySecretSoundEP8dActor_cPt(((char*)this), (unsigned short*)((char*)&mSoundTimer));
     if (mPosY <= mLoweredY) {
         mPosY = mLoweredY;
     } else if (*(int*)((char*)data_0209caa0 + 8) & 0x80000) {
-        unk_338 = _ZN5Sound8PlayLongEjjjRK7Vector3s(
-            unk_338, 3, 0x96, (void*)((char*)&mCamSpacePosX), 0);
+        mSoundID = _ZN5Sound8PlayLongEjjjRK7Vector3s(
+            mSoundID, 3, 0x96, (void*)((char*)&mCamSpacePosX), 0);
         *(int*)((char*)&mPosY) -= 0x5000;
-        unk_33e = 1;
+        mWasJustDrained = 1;
         if (mPosY <= mLoweredY) {
             mPosY = mLoweredY;
             _ZN7Minimap19UpdateLevelSpecificEv();

--- a/src/_ZN13KoopaTheQuick13InitResourcesEv.cpp
+++ b/src/_ZN13KoopaTheQuick13InitResourcesEv.cpp
@@ -51,9 +51,9 @@ int KoopaTheQuick::InitResources()
     *(int *)((char *)&mScaleZ) = 0x14cc;
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj((char *)((void *)this) + 0x110, ((void *)this), 0x78000, 0x12c000, 0x800004, 0);
     zero = 0;
-    *(int *)((char *)&unk_38c) = zero;
+    *(int *)((char *)&mState) = zero;
     *(s16 *)((char *)&unk_3aa) = (s16)zero;
-    *(unsigned char *)((char *)&unk_3b4) = (unsigned char)zero;
+    *(unsigned char *)((char *)&mHasFinished) = (unsigned char)zero;
     *(int *)((char *)&unk_39c) = *(int *)((char *)&mPosX);
     *(int *)((char *)&unk_3a0) = *(int *)((char *)&mPosY);
     *(int *)((char *)&unk_3a4) = *(int *)((char *)&mPosZ);
@@ -61,27 +61,27 @@ int KoopaTheQuick::InitResources()
     *(int *)((char *)&mTerminalVelocity) = -0x3c000;
     _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_((char *)((void *)this) + 0x144, ((void *)this), 0x78000, 0x78000, 0, 0);
     _ZN7PathPtr6FromIDEj((char *)((void *)this) + 0x3d8, *(unsigned int *)((char *)&param1) & 0xf);
-    *(int *)((char *)&unk_3b8) = _ZNK7PathPtr8NumNodesEv((char *)&mPathPtr);
-    *(int *)((char *)&unk_3bc) = zero;
+    *(int *)((char *)&mNumPathPts) = _ZNK7PathPtr8NumNodesEv((char *)&mPathPtr);
+    *(int *)((char *)&mCurPathPt) = zero;
     *(int *)((char *)&unk_3c0) = *(int *)((char *)&mPosX);
     *(int *)((char *)&unk_3c4) = *(int *)((char *)&mPosY);
     *(int *)((char *)&unk_3c8) = *(int *)((char *)&mPosZ);
-    _ZNK7PathPtr7GetNodeER7Vector3j((char *)((void *)this) + 0x3d8, (char *)((void *)this) + 0x3cc, *(unsigned int *)((char *)&unk_3bc));
-    *(unsigned char *)((char *)&unk_3ac) = (unsigned char)zero;
+    _ZNK7PathPtr7GetNodeER7Vector3j((char *)((void *)this) + 0x3d8, (char *)((void *)this) + 0x3cc, *(unsigned int *)((char *)&mCurPathPt));
+    *(unsigned char *)((char *)&mHasPlayerUsedCannon) = (unsigned char)zero;
     b = (unsigned char)((((unsigned int)*(int *)((char *)&param1) >> 4) + 1) & 0x3f);
-    *(unsigned char *)((char *)&unk_3ad) = b;
+    *(unsigned char *)((char *)&mPathPtToJumpAt1) = b;
     b = (unsigned char)((((unsigned int)*(int *)((char *)&param1) >> 10) + 1) & 0x3f);
-    *(unsigned char *)((char *)&unk_3ae) = b;
-    if (*(unsigned char *)((char *)&unk_3ad) <= 1)
-        *(unsigned char *)((char *)&unk_3ad) = 0xff;
-    if (*(unsigned char *)((char *)&unk_3ae) <= 1)
-        *(unsigned char *)((char *)&unk_3ae) = 0xff;
-    *(unsigned char *)((char *)&unk_3b1) = (unsigned char)(*(s16 *)((char *)&mAngleX) & 0xf);
-    b = *(unsigned char *)((char *)&unk_3b1);
-    *(unsigned char *)((char *)&unk_3b0) = _ZN8dActor_c9TrackStarEjj(((void *)this), b, 2);
-    *(int *)((char *)&unk_394) = zero;
-    *(int *)((char *)&unk_398) = zero;
-    *(unsigned char *)((char *)&unk_3b5) = (unsigned char)zero;
-    *(unsigned char *)((char *)&unk_3b6) = (unsigned char)zero;
+    *(unsigned char *)((char *)&mPathPtToJumpAt2) = b;
+    if (*(unsigned char *)((char *)&mPathPtToJumpAt1) <= 1)
+        *(unsigned char *)((char *)&mPathPtToJumpAt1) = 0xff;
+    if (*(unsigned char *)((char *)&mPathPtToJumpAt2) <= 1)
+        *(unsigned char *)((char *)&mPathPtToJumpAt2) = 0xff;
+    *(unsigned char *)((char *)&mStarID) = (unsigned char)(*(s16 *)((char *)&mAngleX) & 0xf);
+    b = *(unsigned char *)((char *)&mStarID);
+    *(unsigned char *)((char *)&mTrackedStar) = _ZN8dActor_c9TrackStarEjj(((void *)this), b, 2);
+    *(int *)((char *)&mFlagID) = zero;
+    *(int *)((char *)&mPlayer) = zero;
+    *(unsigned char *)((char *)&mIsRacing) = (unsigned char)zero;
+    *(unsigned char *)((char *)&mIsTalkingToMario) = (unsigned char)zero;
     return 1;
 }

--- a/src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp
+++ b/src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp
@@ -27,6 +27,6 @@ int KoopaTheQuick::CleanupResources()
     _ZN13SharedFilePtr7ReleaseEv(&data_ov062_0211e03c);
     _ZN13SharedFilePtr7ReleaseEv(&data_ov062_0211e02c);
     _ZN13SharedFilePtr7ReleaseEv(&data_ov062_0211e004);
-    if (unk_3b5) _ZN5Sound22StopLoadedMusic_Layer2Ev();
+    if (mIsRacing) _ZN5Sound22StopLoadedMusic_Layer2Ev();
     return 1;
 }

--- a/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
+++ b/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
@@ -14,7 +14,7 @@ extern void _ZN5dCc_c6UpdateEv(void* p);
 
 int KoopaTheQuick::Behavior()
 {
-  int idx = unk_38c;
+  int idx = mState;
   char* ent = (char*)&data_ov062_0211e0a4[idx*2];
   int adj = *(int*)(ent+4);
   char* self = ((char*)this) + (adj>>1);

--- a/src/_ZN13TreasureChest13InitResourcesEv.cpp
+++ b/src/_ZN13TreasureChest13InitResourcesEv.cpp
@@ -30,10 +30,10 @@ int TreasureChest::InitResources()
         _ZN9Animation8LoadFileER13SharedFilePtr(data_ov064_0211c964), 0x40000000, 0x1000, 0);
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(((char*)this) + 0x138, (dActor_c*)((char*)this), 0x96000, 0x96000, 0x200004, 0);
     func_ov064_0211a284(((char*)this));
-    unk_172 = unk_008;
-    unk_174 = (unsigned int)unk_008 >> 8;
-    if (unk_174 != 0xff) {
-        unk_175 = _ZN8dActor_c9TrackStarEjj(((char*)this), unk_174, 2);
+    mOrder = unk_008;
+    mStarID = (unsigned int)unk_008 >> 8;
+    if (mStarID != 0xff) {
+        mTrackedStarID = _ZN8dActor_c9TrackStarEjj(((char*)this), mStarID, 2);
     }
     return 1;
 }

--- a/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
+++ b/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
@@ -61,9 +61,9 @@ int KnockDownPlank::InitResources()
     c.y += 0x14000;
     _ZN9dBgCh_GndC1Ev(&rg);
     _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &c, 0);
-    unk_384 = c.y;
+    mFrontFloorY = c.y;
     if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0)
-        unk_384 = rg.clsnY;
+        mFrontFloorY = rg.clsnY;
 
     zero = 0;
     a.z = 0x32000; a.x = zero; a.y = zero; b.x = zero; b.y = zero; b.z = zero;
@@ -76,8 +76,8 @@ int KnockDownPlank::InitResources()
     unk_378 = d.x;
     unk_37c = d.y;
     unk_380 = d.z;
-    unk_388 = mPosY;
-    unk_396 = (s8)one;
+    mOriginalPosY = mPosY;
+    mKnockDir = (s8)one;
 
     if (data_0209f2f8 == 7 && (data_0209f220 == 1 || IsStarCollectedInCurLevel(one) == 0)
         && mPosY >= 0xdac000)

--- a/src/_ZN14KnockDownPlank15OnHitByMegaCharER6Player.cpp
+++ b/src/_ZN14KnockDownPlank15OnHitByMegaCharER6Player.cpp
@@ -5,15 +5,15 @@
 
 /* KnockDownPlank::OnHitByMegaChar -- vtable slot 27, ov015 0x021113c0.
  *
- * Real member function on this class's own named fields (unk_397, unk_394 --
+ * Real member function on this class's own named fields (mState, mWobbleTimer --
  * include/KnockDownPlank.h) and Player::IncMegaKillCount, a real method
- * (include/Player.h). unk_397 is the same hit-stage counter OnAttacked2/
- * OnKicked's shared helper advances; unk_394 is the same cooldown timer that
+ * (include/Player.h). mState is the same hit-stage counter OnAttacked2/
+ * OnKicked's shared helper advances; mWobbleTimer is the same cooldown timer that
  * helper sets to 0x640 after a hit registers. */
 void KnockDownPlank::OnHitByMegaChar(Player &player)
 {
-    if (unk_397 >= 2) return;
+    if (mState >= 2) return;
     player.IncMegaKillCount();
-    unk_397 = 2;
-    unk_394 = 0x640;
+    mState = 2;
+    mWobbleTimer = 0x640;
 }

--- a/src/_ZN16SpinningPlatform13InitResourcesEv.cpp
+++ b/src/_ZN16SpinningPlatform13InitResourcesEv.cpp
@@ -51,8 +51,8 @@ int SpinningPlatform::InitResources()
     v.y = v.y - 0xa000;
     dBgCh_Gnd rg;
     rg.SetObjAndPos(*(Vector3*)&v, (dActor_c*)0);
-    unk_324 = v.y;
+    mFloorPosY = v.y;
     if (rg.DetectClsn() != 0)
-        unk_324 = rg.result;
+        mFloorPosY = rg.result;
     return 1;
 }

--- a/src/_ZN16SpinningPlatform8BehaviorEv.cpp
+++ b/src/_ZN16SpinningPlatform8BehaviorEv.cpp
@@ -20,16 +20,16 @@ int SpinningPlatform::Behavior()
     unsigned char idx = data_0209f2c0[0];
     mPrevAngleX = data_ov035_02112b80[idx];
     if (idx == 2) {
-        if (DecIfAbove0_Short((char *)&unk_320) == 0) {
+        if (DecIfAbove0_Short((char *)&mRandTimer) == 0) {
             int r = (unsigned short)((unsigned)RandomIntInternal((char*)data_0209e650) >> 16);
-            if ((unsigned)r >= 0x7fff) unk_31e = 1;
-            else unk_31e = -1;
-            unk_320 = (short)((r % 4 + 1) * 0x1e);
-            unk_322 = unk_320;
+            if ((unsigned)r >= 0x7fff) mRandDirection = 1;
+            else mRandDirection = -1;
+            mRandTimer = (short)((r % 4 + 1) * 0x1e);
+            mRandFrames = mRandTimer;
         } else {
-            if ((int)unk_320 < (int)unk_322 - 5) {
+            if ((int)mRandTimer < (int)mRandFrames - 5) {
                 short *q = (short*)(((int)((char *)this) + 0x92));
-                *q = (short)(*q * unk_31e);
+                *q = (short)(*q * mRandDirection);
             } else {
                 mPrevAngleX = 0;
             }

--- a/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
+++ b/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
@@ -23,9 +23,9 @@ extern CLPS_Block data_ov064_0211baac;
 
 void BowserPuzzlePiece::InitResources()
 {
-    unk_337 = unk_008 & 0xf;
+    mType = unk_008 & 0xf;
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4,
-        _ZN5Model8LoadFileER13SharedFilePtr(*data_ov064_0211adc8[unk_337]), 1, -1);
+        _ZN5Model8LoadFileER13SharedFilePtr(*data_ov064_0211adc8[mType]), 1, -1);
     func_ov064_02119010(((char*)this));
     func_ov064_02118fa4(((char*)this));
     _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
@@ -33,12 +33,12 @@ void BowserPuzzlePiece::InitResources()
         _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov064_0211c800),
         *(const Matrix4x3*)((char*)&unk_2ec), 0x1000, unk_08e, data_ov064_0211baac);
     func_020393c4((int*)((char*)&mMovingMeshCollider), (int)&func_ov064_021192bc);
-    unk_324 = data_ov064_0211c198[unk_337];
-    unk_328 = 0;
+    mStateInfo = data_ov064_0211c198[mType];
+    mStateIndex = 0;
     unk_32c = 0;
-    unk_334 = 0;
-    unk_338 = 0;
-    unk_339 = 1;
-    unk_336 = 0;
-    unk_33a = 1;
+    mMoveTimer = 0;
+    mHadClsn = 0;
+    mFreezeState = 1;
+    mState = 0;
+    mCanSpawnCoin = 1;
 }

--- a/src/_ZN17BowserPuzzlePiece16CleanupResourcesEv.cpp
+++ b/src/_ZN17BowserPuzzlePiece16CleanupResourcesEv.cpp
@@ -13,7 +13,7 @@ int BowserPuzzlePiece::CleanupResources()
 {
     unsigned char idx;
     ((dBgW *)((char *)&mMovingMeshCollider))->Disable();
-    idx = *(unsigned char *)((char *)&unk_337);
+    idx = *(unsigned char *)((char *)&mType);
     ((SharedFilePtr *)(data_ov064_0211adc8[idx]))->Release();
     ((SharedFilePtr *)(&data_ov064_0211c800))->Release();
     return 1;

--- a/src/_ZN17ExtendingPlatform13InitResourcesEv.cpp
+++ b/src/_ZN17ExtendingPlatform13InitResourcesEv.cpp
@@ -25,6 +25,6 @@ int ExtendingPlatform::InitResources()
   func_020396c0(((char*)this)+0x158, 4);
   mCollider.unk_4d = 1;
   ((dBgW *)(((char*)this)+0x158))->Enable((dActor_c *)(((char*)this)));
-  unk_0d4 = 1;
+  mGrowing = 1;
   return 1;
 }

--- a/src/_ZN19FloatOnLavaPlatform13InitResourcesEv.cpp
+++ b/src/_ZN19FloatOnLavaPlatform13InitResourcesEv.cpp
@@ -31,6 +31,6 @@ int FloatOnLavaPlatform::InitResources()
   _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(&mMeshCollider, kcl, &mClsnMat, 0x199, mAngleY, data_ov064_0211bb0c);
   func_020393d4(&mMeshCollider, &_ZN4dBgW21UpdatePosWithVelocityERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
   func_020393c4(&mMeshCollider, &func_ov022_0211193c);
-  unk_320 = mPosY;
+  mMaxPosY = mPosY;
   return 1;
 }

--- a/src/_ZN19FloatOnLavaPlatform8BehaviorEv.cpp
+++ b/src/_ZN19FloatOnLavaPlatform8BehaviorEv.cpp
@@ -12,16 +12,16 @@ extern "C" void func_020393a4(int* p, int v);
 int FloatOnLavaPlatform::Behavior()
 {
     func_020393a4((int*)((char*)&(*(u8 *)&mMeshCollider)), 0x150000);
-    if (unk_324) {
+    if (mHadClsn) {
         int* py = (int*)(((int)((char*)this) + 0x60));
         *py = *py - 0x2000;
-        int lim = unk_320 - 0xc8000;
+        int lim = mMaxPosY - 0xc8000;
         if (mPosY < lim) mPosY = lim;
-        unk_324 = 0;
+        mHadClsn = 0;
     } else {
         int* py = (int*)(((int)((char*)this) + 0x60));
         *py = *py + 0x2000;
-        int lim = unk_320;
+        int lim = mMaxPosY;
         if (mPosY > lim) mPosY = lim;
     }
     _ZN10dBgActor_c21UpdateModelPosAndRotYEv(((char*)this));

--- a/src/_ZN20SwitchActivatedPlank6RenderEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank6RenderEv.cpp
@@ -6,7 +6,7 @@ struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual vo
 
 int SwitchActivatedPlank::Render()
 {
-  if (unk_3a3 != 0) {
+  if (mVisible != 0) {
     Sub *s = (Sub*)((char *)&mModel2);
     s->v5(0);
   }

--- a/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
@@ -14,9 +14,9 @@ int _ZN10dBgW_KcMbg9TransformERK9Matrix4x3s(void*, void*, int);
 int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
     func_020393a4(((char*)self)+0x124, 0x100000);
 
-    switch(self->unk_3a2){
+    switch(self->mState){
     case 0:
-        if(_ZN5Event6GetBitEj(self->unk_3a4) == 0) break;
+        if(_ZN5Event6GetBitEj(self->mEventID) == 0) break;
 
         {
             unsigned char* st_ptr = (unsigned char*)(((int)((char*)self) + 0x3a2));
@@ -24,7 +24,7 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         }
 
         *(short*)(((char*)self) + 0x300 + 0xa0) = 0;
-        self->unk_3a3 = 1;
+        self->mVisible = 1;
 
         ((dBgW *)(((char*)self)+0x124))->Enable((dActor_c *)(((char*)self)));
         func_ov029_021126dc(((char*)self));
@@ -32,15 +32,15 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         break;
 
     case 1: {
-        unsigned short* p = (unsigned short*)((char*)&self->unk_3a0);
+        unsigned short* p = (unsigned short*)((char*)&self->mStateTimer);
         if (*(unsigned short*)(((char*)self) + 0x300 + 0xa0) > 0x168) {
-            self->unk_3a3 = *(unsigned short*)(((char*)self) + 0x300 + 0xa0) & 1;
+            self->mVisible = *(unsigned short*)(((char*)self) + 0x300 + 0xa0) & 1;
         }
         *p = *p + 1;
-        if (_ZN5Event6GetBitEj(self->unk_3a4) != 0) break;
+        if (_ZN5Event6GetBitEj(self->mEventID) != 0) break;
         ((dBgW *)((char*)&self->mMovingMeshCollider))->Disable();
-        self->unk_3a2 = 0;
-        self->unk_3a3 = 0;
+        self->mState = 0;
+        self->mVisible = 0;
         break;
     }
     }

--- a/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
@@ -27,7 +27,7 @@ int ArmedRotatingPlatform::InitResources()
   kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov036_02113d78[1]);
   _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(&mMeshCollider, kcl, &mClsnMat, 0x1000, mAngleY, data_ov036_02113d78[2]);
   func_020393d4(&mMeshCollider, &_ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
-  unk_31e = -0x80;
-  if (mAngleZ != 0) unk_31e = mAngleZ;
+  mAngVelY = -0x80;
+  if (mAngleZ != 0) mAngVelY = mAngleZ;
   return 1;
 }

--- a/src/_ZN21ArmedRotatingPlatform8BehaviorEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform8BehaviorEv.cpp
@@ -2,14 +2,14 @@
 // @symbol _ZN21ArmedRotatingPlatform8BehaviorEv
 /* recovered: named members + shared header, real C++ method
  *
- * Spin by unk_31e a frame; stop and switch the collider off once the actor is
+ * Spin by mAngVelY a frame; stop and switch the collider off once the actor is
  * flagged; otherwise follow the model and, when the player is close enough to
  * matter, the collision mesh too.
  *
  * Three shadow declarations are gone -- a `typedef int Fix12` and stand-in
  * `dBgW` and `dBgActor_c` structs -- along with the raw offsets they
  * served. `this + 0x8e` is dActor_c::mAngleY, and the `t[0x1e/2]` read off
- * `this + 0x300` was this class's own unk_31e reached the long way round.
+ * `this + 0x300` was this class's own mAngVelY reached the long way round.
  *
  * IsClsnInRange keeps its mangled spelling: the name carries Fix12<int> by
  * value, wall 6az, so a real call would not reproduce the call site.
@@ -24,7 +24,7 @@ int ArmedRotatingPlatform::Behavior()
        address into a register and reuses it for the load and the store, which
        is what the ROM does here. That is a per-SITE fact -- the expanded
        spelling is the matching one in Player::St_WallJump_Init. */
-    mAngleY += unk_31e;
+    mAngleY += mAngVelY;
 
     /* The temporary is load-bearing: the ROM materialises the predicate with
        movne/moveq and then tests it, where a direct `if` folds the two. */

--- a/src/_ZN4Bird13InitResourcesEv.cpp
+++ b/src/_ZN4Bird13InitResourcesEv.cpp
@@ -24,7 +24,7 @@ int Bird::InitResources()
         *p60 = y + 0xa000;
         mVertAccel = zero;
         mTerminalVelocity = -0x32000;
-        unk_180 = 1;
+        mIsLeader = 1;
         mOwnerID = uniqueID;
         mHomePos.x = mPosX;
         mHomePos.y = mPosY;

--- a/src/_ZN4Coin6RenderEv.cpp
+++ b/src/_ZN4Coin6RenderEv.cpp
@@ -14,7 +14,7 @@ int Coin::Render()
   b = (f & 0x40000) != 0;
   if (b) return 1;
   {
-    unsigned short x = unk_3a8;
+    unsigned short x = mDisappearTimer;
     if (x < 0x2d && (x & 1)) return 1;
   }
   if (!(f & 0x10))

--- a/src/_ZN4Coin8BehaviorEv.cpp
+++ b/src/_ZN4Coin8BehaviorEv.cpp
@@ -44,15 +44,15 @@ int Coin::Behavior()
     (((C *)((char *)this))->*data_ov002_0210dc70[mBehaviorType])();
     if ((int)(data_0209f2d8 == 1) == 0 && (int)((mFlags & 8) != 0) != 0) {
         _ZN5dCc_c5ClearEv((char *)&mdCc_c);
-        if (unk_3aa == 0 && LenVec3((char *)&mCamSpacePosX) < 0x64000) {
-            if (mCoinType != 1 || unk_3b0 == 0)
+        if (mNoClsnTimer == 0 && LenVec3((char *)&mCamSpacePosX) < 0x64000) {
+            if (mCoinType != 1 || mInBrickBlock == 0)
                 _ZN5dCc_c6UpdateEv((char *)&mdCc_c);
         }
     } else {
         func_ov002_020b14d8(((char *)this));
         _ZN5dCc_c5ClearEv((char *)&mdCc_c);
-        if (unk_3aa == 0) {
-            if (mCoinType != 1 || unk_3b0 == 0)
+        if (mNoClsnTimer == 0) {
+            if (mCoinType != 1 || mInBrickBlock == 0)
                 _ZN5dCc_c6UpdateEv((char *)&mdCc_c);
         }
     }

--- a/src/_ZN4Trap13InitResourcesEv.c
+++ b/src/_ZN4Trap13InitResourcesEv.c
@@ -29,8 +29,8 @@ extern short data_02082214[];
 int _ZN4Trap13InitResourcesEv(char* c)
 {
     struct Trap *self = (struct Trap *)(void *)c;
-    self->unk_3aa = 0;
-    self->unk_3ac = 0;
+    self->mTrapActive = 0;
+    self->mSpawnerID = 0;
 
     if ((*(int*)(c + 8) & 0xff) == 0xff) {
         struct Vector3 v;
@@ -39,8 +39,8 @@ int _ZN4Trap13InitResourcesEv(char* c)
         int x, y, z;
         void* sp;
 
-        self->unk_3ab = 1;
-        self->unk_3a4 = 0;
+        self->mIsSpawner = 1;
+        self->mPlayerDist = 0;
 
         idx = ((int)(self->unk_08e) >> 4) * 2;
         sx = data_02082214[idx + 1];
@@ -69,7 +69,7 @@ int _ZN4Trap13InitResourcesEv(char* c)
         return 1;
     }
 
-    self->unk_3ab = 0;
+    self->mIsSpawner = 0;
     {
         void* f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov010_02112d08);
         _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x320, f, 1, -1);
@@ -82,8 +82,8 @@ int _ZN4Trap13InitResourcesEv(char* c)
     }
     func_020393c4((int*)(c + 0x124), (int)func_ov010_02111984);
     _ZN4dBgW6EnableEP8dActor_c(c + 0x124, c);
-    self->unk_3a8 = 0;
-    self->unk_3a0 = 0;
+    self->mOpenSpeed = 0;
+    self->mState = 0;
 
     if ((*(int*)(c + 8) & 0xff) == 1) {
         short* pa = (short*)(((int)c + 0x8e));

--- a/src/_ZN4Trap6RenderEv.cpp
+++ b/src/_ZN4Trap6RenderEv.cpp
@@ -10,14 +10,14 @@
  * body is the same virtual-dispatch-through-a-shadow-vtable trick the file
  * used before the rename (Model's own Render, called through the Model
  * sub-object at +0x320), unconverted. include/Trap.h is included for the
- * `struct Trap` cast that reads unk_3ab by hand offset. */
+ * `struct Trap` cast that reads mIsSpawner by hand offset. */
 #include "Trap.h"
 extern "C" {
 struct A { char pad[0x320]; };
 struct B { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual void m5(bool); };
 int _ZN4Trap6RenderEv(char* c){
     struct Trap *self = (struct Trap *)(void *)c;
-  if(self->unk_3ab == 0){
+  if(self->mIsSpawner == 0){
     ((B*)(c+0x320))->m5(false);
   }
   return 1;

--- a/src/_ZN5Bully13InitResourcesEv.cpp
+++ b/src/_ZN5Bully13InitResourcesEv.cpp
@@ -10,7 +10,7 @@ extern void func_ov064_02116ec0(char* c);
 
 int Bully::InitResources()
 {
-    unk_3fc = 0;
+    mBigBullyID = 0;
     mFileTable = (int)&data_ov064_0211b834;
     func_ov064_02116ec0(((char*)this));
 }

--- a/src/_ZN5Bully8BehaviorEv.cpp
+++ b/src/_ZN5Bully8BehaviorEv.cpp
@@ -11,7 +11,7 @@
  * itself, facing its own heading turned 0x8000 (180 degrees) plus a random
  * 10-bit spread, then gives the coin an upward launch: 0xa000 of vertical
  * speed and 0x50000 of terminal velocity, with the two acceleration slots
- * zeroed. Finally it looks up the actor whose unique ID sits in unk_3fc and
+ * zeroed. Finally it looks up the actor whose unique ID sits in mBigBullyID and
  * bumps the byte at +0x3fe of it. The field is left unnamed on purpose: what
  * the bytes establish is that it holds an actor ID, not what that actor is.
  *
@@ -69,7 +69,7 @@ int Bully::Behavior()
                 *(int *)(coin + 0xa8) = 0x50000;
                 *(int *)(coin + 0xac) = 0;
             }
-            char *spawner = _ZN8dActor_c10FindWithIDEj(unk_3fc);
+            char *spawner = _ZN8dActor_c10FindWithIDEj(mBigBullyID);
             if (spawner) {
                 (*(u8 *)(spawner + 0x3fe))++;
             }

--- a/src/_ZN5Koopa13InitResourcesEv.cpp
+++ b/src/_ZN5Koopa13InitResourcesEv.cpp
@@ -46,7 +46,7 @@ int Koopa::InitResources()
     if (isSpecial)
     {
         mKoopaVariant = 2;
-        unk_3bc = 0x2000;
+        mAnimSpeed = 0x2000;
         mScaleX = 0x599;
         mScaleY = 0x599;
         mScaleZ = 0x599;
@@ -56,7 +56,7 @@ int Koopa::InitResources()
     else
     {
         mKoopaVariant = 0;
-        unk_3bc = 0x1000;
+        mAnimSpeed = 0x1000;
         mScaleX = 0xa66;
         mScaleY = 0xa66;
         mScaleZ = 0xa66;

--- a/src/_ZN5Koopa8BehaviorEv.cpp
+++ b/src/_ZN5Koopa8BehaviorEv.cpp
@@ -65,8 +65,8 @@ int Koopa::Behavior()
 
         {
             int *pb0 = (int *)((char *)&mFlags);
-            if (unk_3ce != 0)
-                *(u8 *)((char *)&unk_3ce) -= 1;
+            if (mLandingDustTimer != 0)
+                *(u8 *)((char *)&mLandingDustTimer) -= 1;
             *pb0 = *pb0 | 0x10000000;
         }
         func_ov062_02118258(((char *)this), 0x3e8000);
@@ -96,7 +96,7 @@ int Koopa::Behavior()
         }
         if (state != mState || kind != mKoopaVariant) {
             unk_100 = 0;
-            unk_3c4 = 0;
+            mWalkState = 0;
         }
         func_ov062_02117c98(((char *)this));
         _ZN8dActor_c9UpdatePosEP5dCc_c(((char *)this), ((char *)this) + 0x110);
@@ -118,10 +118,10 @@ int Koopa::Behavior()
         func_ov062_02117570(((char *)this));
         _ZN5dCc_c5ClearEv((char *)&mdCc_c);
         if (mDeathState == 0) {
-            if (unk_3ca == 0) {
+            if (mInvincibleTimer == 0) {
                 _ZN5dCc_c6UpdateEv((char *)&mdCc_c);
             } else {
-                *(u16 *)((char *)&unk_3ca) -= 1;
+                *(u16 *)((char *)&mInvincibleTimer) -= 1;
             }
         }
     } else {

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -86,19 +86,19 @@ int Dorrie::InitResources()
         unk_1180 = mPosX;
         unk_1184 = mPosY;
         unk_1188 = mPosZ;
-        unk_11b2 = 0;
-        unk_11b5 = 0;
-        unk_118c = 0;
-        unk_1190 = 0;
-        unk_11ac = 0;
-        unk_11a8 = unk_11ac;
+        mStateTimer = 0;
+        mClsnState = 0;
+        mClsnPlayer = 0;
+        mRider = 0;
+        mSinkHeight = 0;
+        mPushDownHeight = mSinkHeight;
     }
     if ((mParam & 0xff) == 1)
-        unk_0e8 = 1;
+        mHasCap = 1;
     else
-        unk_0e8 = 0;
-    unk_0d4 = 0;
-    if (unk_0e8 != 0) {
+        mHasCap = 0;
+    mCap = 0;
+    if (mHasCap != 0) {
         unk_0d8 = 0;
         unk_0dc = 0;
         unk_0e0 = 0;
@@ -107,10 +107,10 @@ int Dorrie::InitResources()
             void* a = _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(
                 0xa9, 0, ((char*)this) + 0x5c, ((char*)this) + 0x8c, mAreaId, -1);
             if (a != 0) {
-                unk_0d4 = (int)a;
+                mCap = (int)a;
                 *(int*)((char*)a + 0x174) = (int)((char*)this);
             } else {
-                unk_0e8 = 0;
+                mHasCap = 0;
             }
         }
     }

--- a/src/_ZN6DorrieD0Ev.cpp
+++ b/src/_ZN6DorrieD0Ev.cpp
@@ -16,8 +16,8 @@ extern void *_ZTV6Dorrie[];
 extern void *data_020a0eac;
 void *_ZN6DorrieD0Ev(struct Dorrie *self) {
     *(void ***)((char *)self) = _ZTV6Dorrie;
-    _ZN10dCcAcPos_cD1Ev((char *)&self->unk_1140);
-    _ZN7dCcAc_cD1Ev((char *)&self->unk_110c);
+    _ZN10dCcAcPos_cD1Ev((char *)&self->mCylClsn2);
+    _ZN7dCcAc_cD1Ev((char *)&self->mCylClsn1);
     _ZN10dBgCh_ActrD1Ev((char *)&self->mWithMeshClsn);
     __destroy_arr(((char *)self) + 0x150, 7, 0x200, (void*)&func_ov065_021180b8);
     _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);

--- a/src/_ZN7Minimap13InitResourcesEv.cpp
+++ b/src/_ZN7Minimap13InitResourcesEv.cpp
@@ -91,8 +91,8 @@ int Minimap::InitResources()
             || SublevelToLevel(data_0209f2f8) == -1)
         {
             *(volatile u16*)0x400100e = (u16)(((0x1f - data_ov002_02111148) << 8) | ((*(volatile u16*)0x400100e & 0x43) | 0x4010));
-            unk_1d8 = 0x100;
-            unk_1dc = 0x80;
+            mMapWidth = 0x100;
+            mMapCenterOffset = 0x80;
 
             if (SublevelToLevel(data_0209f2f8) == 4) {
                 unk_1e0 = 0x258000;
@@ -108,22 +108,22 @@ int Minimap::InitResources()
                 unk_1e4 = 0;
                 unk_1e8 = 0;
             }
-            unk_251 = 1;
+            mArrowType = 1;
         } else {
             *(volatile u16*)0x400100e = (u16)(((0x1f - data_ov002_02111148) << 8) | ((*(volatile u16*)0x400100e & 0x43) | 0x10));
-            unk_1d8 = 0x80;
-            unk_1dc = 0x40;
+            mMapWidth = 0x80;
+            mMapCenterOffset = 0x40;
             unk_1e0 = 0;
             unk_1e4 = 0;
             unk_1e8 = 0;
-            unk_251 = 2;
+            mArrowType = 2;
         }
         data_0209d454 |= 8;
     } else {
         data_0209d454 &= ~8;
     }
 
-    unk_214 = GetMinimapScale(data_ov002_02111148);
+    mTargetInvScale = GetMinimapScale(data_ov002_02111148);
 
     {
         int b1 = (data_0209f2d8 == 0);
@@ -131,15 +131,15 @@ int Minimap::InitResources()
             if (!(data_0209caa0[2] & 0x80)) {
                 int b3 = (data_0209fc48 != 0);
                 if (!b3) {
-                    unk_218 = (unk_214) << 1;
-                    unk_21c = 0;
-                    unk_255 = 1;
+                    mInvScale = (mTargetInvScale) << 1;
+                    mAngle = 0;
+                    mInIntroCutscene = 1;
                     goto unk218_done;
                 }
             }
         }
-        unk_218 = unk_214;
-        unk_255 = 0;
+        mInvScale = mTargetInvScale;
+        mInIntroCutscene = 0;
     unk218_done:;
     }
 
@@ -153,14 +153,14 @@ int Minimap::InitResources()
     unk_208 = 0;
     unk_20c = 0x1000;
     unk_1ec = 0;
-    unk_210 = 0x1000;
+    mArrowScale = 0x1000;
     unk_090 = 0;
     unk_094 = 0;
     unk_098 = 0;
     unk_09c = 0;
 
-    unk_1d4 = func_0202a958();
-    unk_1d4 = ((unk_1d8) << 12) / (unk_1d4) / 10;
+    mScale = func_0202a958();
+    mScale = ((mMapWidth) << 12) / (mScale) / 10;
 
     return 1;
 }

--- a/src/_ZN7Minimap8BehaviorEv.cpp
+++ b/src/_ZN7Minimap8BehaviorEv.cpp
@@ -119,7 +119,7 @@ s32 Minimap::Behavior()
     if (data_0209f350[data_0209f250] != 0) goto L274;
     if (_ZN6Player12Unk_020ca8f8Ev(player) == 1) goto L274;
 
-    if (self->unk_254 != 0) {
+    if (self->mTouchCircleTimer != 0) {
         F254 -= data_0208ee44;
     }
 
@@ -131,10 +131,10 @@ s32 Minimap::Behavior()
     if (data_0209d660 != 0) goto L200;
     {
         u8 v = data_0209f4ac[data_020a0e40 * 0x18];
-        if (v == 0 && self->unk_254 == 0) goto L200;
+        if (v == 0 && self->mTouchCircleTimer == 0) goto L200;
         data_0209d454 |= 4;
         if (v != 0) {
-            self->unk_254 = 0x1e;
+            self->mTouchCircleTimer = 0x1e;
             SetSubBg2Offset(0x100 - data_0209f4a8[data_020a0e40 * 0x18],
                             0x80 - data_0209f4a9[data_020a0e40 * 0x18]);
         }
@@ -157,7 +157,7 @@ L200:
             *(volatile s32 *)0x4001000 = (*(volatile s32 *)0x4001000 & ~0x1f00) | (data_0209d454 << 8);
             *(volatile u16 *)0x4001050 = 0;
         }
-        self->unk_254 = 0;
+        self->mTouchCircleTimer = 0;
         goto L2a4;
     }
 
@@ -182,17 +182,17 @@ L318:
         s32 b = (data_0209f2d8 == 0);
         if (b == 0) goto L360;
         if (data_0209caa0[2] & 0x80) goto L360;
-        if (self->unk_255 != 0) goto L360;
+        if (self->mInIntroCutscene != 0) goto L360;
     }
 L350:
-    self->unk_21c = 0;
+    self->mAngle = 0;
     goto L3e0;
 
 L360:
-    if (self->unk_255 == 0) goto L3a4;
+    if (self->mInIntroCutscene == 0) goto L3a4;
     if (data_ov002_0211114c == 0) goto L3e0;
     FANG += 0x40;
-    if ((u16)self->unk_21c >= 0x8000)
+    if ((u16)self->mAngle >= 0x8000)
         data_ov002_0211114c = 0;
     goto L3e0;
 
@@ -203,7 +203,7 @@ L3a4:
         if (f & 0xc000) goto L3e0;
         if (f & 8) goto L3e0;
     }
-    self->unk_21c = (s16)(cam->f17c & 0xffe0);
+    self->mAngle = (s16)(cam->f17c & 0xffe0);
 
 L3e0:
     obj = (Obj *)cam->f110;
@@ -211,56 +211,56 @@ L3e0:
 L3e8:
     if (obj == 0) goto Lae4;
 
-    if (self->unk_255 == 0) goto L44c;
+    if (self->mInIntroCutscene == 0) goto L44c;
     if (data_ov002_02111144 == 0) goto L4d8;
     F218 -= 9;
-    if (self->unk_214 <= self->unk_218) goto L4d8;
-    self->unk_218 = self->unk_214;
+    if (self->mTargetInvScale <= self->mInvScale) goto L4d8;
+    self->mInvScale = self->mTargetInvScale;
     data_ov002_02111144 = 0;
     data_ov002_0211114c = 1;
     goto L4d8;
 
 L44c:
     if (data_0209d660 == 0) goto L47c;
-    if (self->unk_218 < 0xbb8)
+    if (self->mInvScale < 0xbb8)
         F218 += 0x1c;
     goto L4d8;
 
 L47c:
-    if (self->unk_214 <= self->unk_218) goto L4b0;
+    if (self->mTargetInvScale <= self->mInvScale) goto L4b0;
     F218 += 0x1c;
-    if (self->unk_214 < self->unk_218)
-        self->unk_218 = self->unk_214;
+    if (self->mTargetInvScale < self->mInvScale)
+        self->mInvScale = self->mTargetInvScale;
     goto L4d8;
 
 L4b0:
-    if (self->unk_214 >= self->unk_218) goto L4d8;
+    if (self->mTargetInvScale >= self->mInvScale) goto L4d8;
     F218 -= 0x1c;
-    if (self->unk_214 > self->unk_218)
-        self->unk_218 = self->unk_214;
+    if (self->mTargetInvScale > self->mInvScale)
+        self->mInvScale = self->mTargetInvScale;
 
 L4d8:
-    self->unk_1f0 = _ZN4cstd4fdivEii(self->unk_1d4, self->unk_218);
-    { s32 s1 = data_02082214[(((s32)(u16)self->unk_21c >> 4) * 2) + 1];
-      self->unk_050 = FMUL(s1, self->unk_218); }
-    { s32 s2 = data_02082214[((s32)(u16)self->unk_21c >> 4) * 2];
-      self->unk_054 = FMUL(s2, self->unk_218); }
+    self->mCurrentScale = _ZN4cstd4fdivEii(self->mScale, self->mInvScale);
+    { s32 s1 = data_02082214[(((s32)(u16)self->mAngle >> 4) * 2) + 1];
+      self->unk_050 = FMUL(s1, self->mInvScale); }
+    { s32 s2 = data_02082214[((s32)(u16)self->mAngle >> 4) * 2];
+      self->unk_054 = FMUL(s2, self->mInvScale); }
     self->unk_058 = -self->unk_054;
     self->mPosX = self->unk_050;
     ((Vector3*)&self->unk_1f4)->x = ((Vector3*)&self->unk_1e0)->x;
     ((Vector3*)&self->unk_1f4)->y = ((Vector3*)&self->unk_1e0)->y;
     ((Vector3*)&self->unk_1f4)->z = ((Vector3*)&self->unk_1e0)->z;
-    self->unk_060 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->x, self->unk_1d4) + 0x800) >> 12);
-    self->unk_064 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->z, self->unk_1d4) + 0x800) >> 12);
+    self->mMapCenterX = self->mMapCenterOffset + ((FMUL(((Vector3*)&self->unk_1f4)->x, self->mScale) + 0x800) >> 12);
+    self->mMapCenterY = self->mMapCenterOffset + ((FMUL(((Vector3*)&self->unk_1f4)->z, self->mScale) + 0x800) >> 12);
 
     op = (Vector3 *)(((int)obj + 0x5c));
     v14 = *op;
     _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(&v14);
-    _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v14, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
+    _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v14, (Vector3*)&self->unk_1f4, self->mCurrentScale, self->mAngle, &v8);
     {
         s32 p = data_0209f250;
-        self->unk_070[p] = (v8.x + 0x800) >> 12;
-        self->unk_080[p] = (v8.z + 0x800) >> 12;
+        self->mPlayerIconX[p] = (v8.x + 0x800) >> 12;
+        self->mPlayerIconY[p] = (v8.z + 0x800) >> 12;
 
         if (SublevelToLevel(data_0209f2f8) != 0x1d) goto B1;
         if (data_0209f2f8 != 1) goto L6a4;
@@ -270,86 +270,86 @@ B1:
         if (SublevelToLevel(data_0209f2f8) != 0x13) goto L6f0;
         if (data_0209f2f8 != 0x2e) goto L6f0;
 L6a4:
-        if (self->unk_070[p] < 0x60) { v8.x = 0x60000; }
-        else if (self->unk_070[p] > 0xa0) { v8.x = 0xa0000; }
-        if (self->unk_080[p] < 0x40) { v8.z = 0x40000; }
-        else if (self->unk_080[p] > 0x80) { v8.z = 0x80000; }
+        if (self->mPlayerIconX[p] < 0x60) { v8.x = 0x60000; }
+        else if (self->mPlayerIconX[p] > 0xa0) { v8.x = 0xa0000; }
+        if (self->mPlayerIconY[p] < 0x40) { v8.z = 0x40000; }
+        else if (self->mPlayerIconY[p] > 0x80) { v8.z = 0x80000; }
         goto L738;
 L6f0:
-        if (self->unk_070[p] < 0x24) { v8.x = 0x24000; }
-        else if (self->unk_070[p] > 0xdc) { v8.x = 0xdc000; }
-        if (self->unk_080[p] < 0x24) { v8.z = 0x24000; }
-        else if (self->unk_080[p] > 0x9c) { v8.z = 0x9c000; }
+        if (self->mPlayerIconX[p] < 0x24) { v8.x = 0x24000; }
+        else if (self->mPlayerIconX[p] > 0xdc) { v8.x = 0xdc000; }
+        if (self->mPlayerIconY[p] < 0x24) { v8.z = 0x24000; }
+        else if (self->mPlayerIconY[p] > 0x9c) { v8.z = 0x9c000; }
     }
 L738:
-    _ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_(&v8, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v20);
+    _ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_(&v8, (Vector3*)&self->unk_1f4, self->mCurrentScale, self->mAngle, &v20);
     Vec3_Sub(&v38, &v14, &v20);
     AddVec3((Vector3*)&self->unk_1f4, &v38, (Vector3*)&self->unk_1f4);
-    self->unk_060 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->x, self->unk_1d4) + 0x800) >> 12);
-    self->unk_064 = self->unk_1dc + ((FMUL(((Vector3*)&self->unk_1f4)->z, self->unk_1d4) + 0x800) >> 12);
+    self->mMapCenterX = self->mMapCenterOffset + ((FMUL(((Vector3*)&self->unk_1f4)->x, self->mScale) + 0x800) >> 12);
+    self->mMapCenterY = self->mMapCenterOffset + ((FMUL(((Vector3*)&self->unk_1f4)->z, self->mScale) + 0x800) >> 12);
 
     for (i = 0; i < 4; i++) {
         Obj *o = data_0209f394[i];
         if (o != 0) {
         v2c = *(Vector3 *)(((int)o + 0x5c));
         _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(&v2c);
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v2c, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
-        self->unk_070[i] = (v8.x + 0x800) >> 12;
-        self->unk_080[i] = (v8.z + 0x800) >> 12;
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v2c, (Vector3*)&self->unk_1f4, self->mCurrentScale, self->mAngle, &v8);
+        self->mPlayerIconX[i] = (v8.x + 0x800) >> 12;
+        self->mPlayerIconY[i] = (v8.z + 0x800) >> 12;
         if (i != data_0209f250)
-            self->unk_21e[i] = (s8)GetMinimapID(o, -1);
+            self->mPlayerMapIDs[i] = (s8)GetMinimapID(o, -1);
         else
-            self->unk_21e[i] = (s8)GetMinimapID(o, data_ov002_02111148);
+            self->mPlayerMapIDs[i] = (s8)GetMinimapID(o, data_ov002_02111148);
         } else {
-            self->unk_21e[i] = -1;
+            self->mPlayerMapIDs[i] = -1;
         }
     }
 
     for (i = 0; i < 0xc; i++) {
         Obj *o = data_0209f40c[i];
         if (o != 0) {
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
-        self->unk_0a0[i] = (v8.x + 0x800) >> 12;
-        self->unk_0d0[i] = (v8.z + 0x800) >> 12;
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->mCurrentScale, self->mAngle, &v8);
+        self->mStarIconX[i] = (v8.x + 0x800) >> 12;
+        self->mStarIconY[i] = (v8.z + 0x800) >> 12;
         if (data_0209f37c[i] != 4)
-            self->unk_222[i] = (s8)GetMinimapID(o, -1);
+            self->mStarMapIDs[i] = (s8)GetMinimapID(o, -1);
         else
-            self->unk_222[i] = 1;
+            self->mStarMapIDs[i] = 1;
         } else {
-            self->unk_222[i] = -1;
+            self->mStarMapIDs[i] = -1;
         }
     }
 
     for (i = 0; i < 9; i++) {
         Obj *o = data_0209f3e8[i];
         if (o != 0) {
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
-        self->unk_100[i] = (v8.x + 0x800) >> 12;
-        self->unk_124[i] = (v8.z + 0x800) >> 12;
-        self->unk_23a[i] = (s8)GetMinimapID(o, -1);
-        } else { self->unk_23a[i] = -1; }
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->mCurrentScale, self->mAngle, &v8);
+        self->mCapIconX[i] = (v8.x + 0x800) >> 12;
+        self->mCapIconY[i] = (v8.z + 0x800) >> 12;
+        self->mCapMapIDs[i] = (s8)GetMinimapID(o, -1);
+        } else { self->mCapMapIDs[i] = -1; }
     }
 
     if (data_0209caa0[1] & 0x40) goto La64;
     if ((data_0209caa0[2] & 0x20000) == 0) goto La64;
     {
         Obj *o = data_0209f33c;
-        if (o == 0) { self->unk_248 = -1; goto La64; }
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
-        self->unk_178 = (v8.x + 0x800) >> 12;
-        self->unk_17c = (v8.z + 0x800) >> 12;
-        self->unk_248 = 1;
+        if (o == 0) { self->mStarKeyMapID = -1; goto La64; }
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->mCurrentScale, self->mAngle, &v8);
+        self->mStarKeyIconX = (v8.x + 0x800) >> 12;
+        self->mStarKeyIconY = (v8.z + 0x800) >> 12;
+        self->mStarKeyMapID = 1;
     }
 
 La64:
     for (i = 0; i < 8; i++) {
         Obj *o = data_0209f3a4[i];
         if (o != 0) {
-        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->unk_1f0, self->unk_21c, &v8);
-        self->unk_180[i] = (v8.x + 0x800) >> 12;
-        self->unk_1a0[i] = (v8.z + 0x800) >> 12;
-        self->unk_249[i] = o->f0cc;
-        } else { self->unk_249[i] = -1; }
+        _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&o->pos, (Vector3*)&self->unk_1f4, self->mCurrentScale, self->mAngle, &v8);
+        self->mSpikeBombIconX[i] = (v8.x + 0x800) >> 12;
+        self->mSpikeBombIconY[i] = (v8.z + 0x800) >> 12;
+        self->mSpikeBombMapIDs[i] = o->f0cc;
+        } else { self->mSpikeBombMapIDs[i] = -1; }
     }
 
 Lae4:
@@ -382,9 +382,9 @@ Lbf0:
 Lc00:
         *(volatile s32 *)0x4001000 = (*(volatile s32 *)0x4001000 & ~0x1f00) | (data_0209d454 << 8);
         data_ov002_02111148 = (s8)id;
-        self->unk_214 = GetMinimapScale(id);
+        self->mTargetInvScale = GetMinimapScale(id);
     }
 Lc30:
-    UpdateMinimap(&self->unk_050, self->unk_060, self->unk_064, self->unk_060 - 0x80, self->unk_064 - 0x60);
+    UpdateMinimap(&self->unk_050, self->mMapCenterX, self->mMapCenterY, self->mMapCenterX - 0x80, self->mMapCenterY - 0x60);
     return 1;
 }

--- a/src/_ZN8BigBully13InitResourcesEv.cpp
+++ b/src/_ZN8BigBully13InitResourcesEv.cpp
@@ -25,8 +25,8 @@ int BigBully::InitResources()
 
     *(void**)((char*)&mFileTable) = &data_ov064_0211b93c;
     saved = func_ov064_02116ec0(((char*)this));
-    unk_3fc = param1 & 0xf;
-    unk_3fd = (u8)_ZN8dActor_c9TrackStarEjj((dActor_c*)((char*)this), unk_3fc, 2);
+    mStarID = param1 & 0xf;
+    unk_3fd = (u8)_ZN8dActor_c9TrackStarEjj((dActor_c*)((char*)this), mStarID, 2);
     mSecretSoundCounter = 0;
 
     if ((param1 & 0xff00) == 0x100) {
@@ -36,7 +36,7 @@ int BigBully::InitResources()
         int i;
         int ang;
 
-        unk_3fe = 0;
+        mNumBulliesKilled = 0;
         _ZN9dBgCh_GndC1Ev(&rg);
 
         {
@@ -78,7 +78,7 @@ int BigBully::InitResources()
         goto done;
     }
 
-    unk_3fe = 0xff;
+    mNumBulliesKilled = 0xff;
 done:
     return saved;
 }

--- a/src/_ZN8BigBully6RenderEv.cpp
+++ b/src/_ZN8BigBully6RenderEv.cpp
@@ -6,7 +6,7 @@ struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g
 
 int BigBully::Render()
 {
-  if(unk_3fe >= 3)
+  if(mNumBulliesKilled >= 3)
     ((Sub*)((char*)&mModelAnim))->g5(0);
   return 1;
 }

--- a/src/_ZN8BigBully8BehaviorEv.cpp
+++ b/src/_ZN8BigBully8BehaviorEv.cpp
@@ -14,7 +14,7 @@ extern int _ZNK10dBgCh_Actr10IsOnGroundEv(void* c);
 
 int BigBully::Behavior()
 {
-    u8 s = unk_3fe;
+    u8 s = mNumBulliesKilled;
     if (s >= 4) {
         if (mSecretSoundCounter != 0) {
             if (_ZN5Sound15PlaySecretSoundEP8dActor_cPt(((char*)this), (u16*)((char*)&mSecretSoundCounter)) != 0)

--- a/src/_ZN8Goomboss6RenderEv.cpp
+++ b/src/_ZN8Goomboss6RenderEv.cpp
@@ -17,7 +17,7 @@ struct Sub {
 int Goomboss::Render()
 {
   if(param1==0x1111) return func_ov074_021222e0(((char*)this));
-  if(unk_60a==0) return 1;
+  if(mShouldRender==0) return 1;
   Sub* s = (Sub*)((char*)&mModelAnim);
   s->m((char*)&mScaleX);
   _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x3e4, ((char*)this)+0x218);

--- a/src/_ZN8Goomboss8BehaviorEv.cpp
+++ b/src/_ZN8Goomboss8BehaviorEv.cpp
@@ -29,11 +29,11 @@ int Goomboss::Behavior()
         return func_ov074_021223bc(((char *)this));
     }
 
-    t = ((s64)unk_5f6 * 0x646 + 0x800) >> 12;
+    t = ((s64)mWalkSpeed * 0x646 + 0x800) >> 12;
     u = ((s64)t * 0x546000 + 0x800) >> 12;
-    unk_5e8 = u < 0 ? -u : u;
+    mGoombaTargetSpeed = u < 0 ? -u : u;
 
-    if (unk_5cc != 7) {
+    if (mState != 7) {
         *(void **)(data_0209f318 + 0x114) = ((char *)this);
     }
 
@@ -54,53 +54,53 @@ int Goomboss::Behavior()
         }
     }
 
-    if (unk_5cc != 1 && unk_5cc != 0) {
+    if (mState != 1 && mState != 0) {
         quake = data_ov074_0212290c[mSizeIndex];
 
-        if (unk_5fe != 0) {
+        if (mLeftFootSteppedOnGround != 0) {
             if (mSizeIndex >= 2) {
                 Vector3 v;
-                v.x = unk_3ac[2].x;
-                v.y = unk_3ac[2].y;
-                v.z = unk_3ac[2].z;
+                v.x = mCylClsnPos[2].x;
+                v.y = mCylClsnPos[2].y;
+                v.z = mCylClsnPos[2].z;
                 _ZN8dActor_c17HugeLandingDustAtER7Vector3b(((char *)this), &v, 1);
             } else {
                 Vector3 v;
-                v.x = unk_3ac[2].x;
-                v.y = unk_3ac[2].y;
-                v.z = unk_3ac[2].z;
+                v.x = mCylClsnPos[2].x;
+                v.y = mCylClsnPos[2].y;
+                v.z = mCylClsnPos[2].z;
                 _ZN8dActor_c13LandingDustAtER7Vector3b(((char *)this), &v, 1);
             }
             func_02012694(0x15e, ((char *)this) + 0x74);
             {
                 Vector3 v;
-                v.x = unk_3ac[2].x;
-                v.y = unk_3ac[2].y;
-                v.z = unk_3ac[2].z;
+                v.x = mCylClsnPos[2].x;
+                v.y = mCylClsnPos[2].y;
+                v.z = mCylClsnPos[2].z;
                 _ZN8dActor_c10EarthquakeERK7Vector35Fix12IiE(((char *)this), &v, quake);
             }
         }
 
-        if (unk_5ff != 0) {
+        if (mRightFootSteppedOnGround != 0) {
             if (mSizeIndex >= 2) {
                 Vector3 v;
-                v.x = unk_3ac[1].x;
-                v.y = unk_3ac[1].y;
-                v.z = unk_3ac[1].z;
+                v.x = mCylClsnPos[1].x;
+                v.y = mCylClsnPos[1].y;
+                v.z = mCylClsnPos[1].z;
                 _ZN8dActor_c17HugeLandingDustAtER7Vector3b(((char *)this), &v, 1);
             } else {
                 Vector3 v;
-                v.x = unk_3ac[1].x;
-                v.y = unk_3ac[1].y;
-                v.z = unk_3ac[1].z;
+                v.x = mCylClsnPos[1].x;
+                v.y = mCylClsnPos[1].y;
+                v.z = mCylClsnPos[1].z;
                 _ZN8dActor_c13LandingDustAtER7Vector3b(((char *)this), &v, 1);
             }
             func_02012694(0x15e, ((char *)this) + 0x74);
             {
                 Vector3 v;
-                v.x = unk_3ac[1].x;
-                v.y = unk_3ac[1].y;
-                v.z = unk_3ac[1].z;
+                v.x = mCylClsnPos[1].x;
+                v.y = mCylClsnPos[1].y;
+                v.z = mCylClsnPos[1].z;
                 _ZN8dActor_c10EarthquakeERK7Vector35Fix12IiE(((char *)this), &v, quake);
             }
         }

--- a/src/_ZN8PathLift9AfterClsnEv.cpp
+++ b/src/_ZN8PathLift9AfterClsnEv.cpp
@@ -12,7 +12,7 @@ void func_ov002_020efa54(void *c, int a);
 void PathLift::AfterClsn()
 {
     if (func_ov002_020efedc(((char *)this)) != 0 &&
-        unk_44c == 0 &&
+        mState == 0 &&
         DecIfAbove0_Byte((char *)&unk_42b) == 0) {
         int b = actorID == 0x1f;
         if (b) {

--- a/src/_ZN8PoleLift8BehaviorEv.cpp
+++ b/src/_ZN8PoleLift8BehaviorEv.cpp
@@ -16,12 +16,12 @@ int PoleLift::Behavior()
     _ZN5dCc_c5ClearEv((char *)&mdCcAc_c);
     _ZN5dCc_c6UpdateEv((char *)&mdCcAc_c);
     if ((*(s32 *)&param1) != 0xffff) {
-        int idx = unk_354 >> 4;
+        int idx = mHeightAng >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
         *(int*)(((int)((char *)this) + 0x60)) =
             *(int*)(((int)((char *)this) + 0x60)) + (int)(((long long)s * 0x7000 + 0x800) >> 12);
     } else {
-        int idx = unk_354 >> 4;
+        int idx = mHeightAng >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
         *(int*)(((int)((char *)this) + 0x60)) =
             *(int*)(((int)((char *)this) + 0x60)) - (int)(((long long)s * 0x3000 + 0x800) >> 12);

--- a/src/_ZN8Squasher13InitResourcesEv.cpp
+++ b/src/_ZN8Squasher13InitResourcesEv.cpp
@@ -28,8 +28,8 @@ int Squasher::InitResources()
   _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(&mMeshCollider, kcl, (struct Matrix4x3*)((char*)&(*(u8 *)&mClsnMat)), 0x1000, (*(u16 *)&mAngleY), &data_ov064_0211ba4c);
   func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
   ((dBgW *)(&mMeshCollider))->Enable((dActor_c *)(((char*)this)));
-  unk_31e = 0;
-  unk_320 = 0;
-  unk_322 = 0;
+  mAngVelX = 0;
+  mStateTimer = 0;
+  mState = 0;
   return 1;
 }

--- a/src/_ZN8dScene_c14StartSceneFadeEjjt.cpp
+++ b/src/_ZN8dScene_c14StartSceneFadeEjjt.cpp
@@ -16,5 +16,5 @@ extern FaderColor data_0209f5e8;
 void dScene_c::StartSceneFade(u32 sceneID, u32 param, u16 fadeColor)
 {
     if (SetSceneToSpawn(sceneID, param))
-        data_0209f5e8.unk_00c = fadeColor;
+        data_0209f5e8.color = fadeColor;
 }

--- a/src/_ZN9KoopaFlag13InitResourcesEv.cpp
+++ b/src/_ZN9KoopaFlag13InitResourcesEv.cpp
@@ -31,7 +31,7 @@ int KoopaFlag::InitResources()
         (BMD_File*)Model::LoadFile(data_ov062_0211e0d4), 1, -1);
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((ModelAnim*)((char*)&mModelAnim), (BCA_File*)Animation::LoadFile(data_ov062_0211e0dc), 0, 0x1000, 0);
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj((dCcAc_c*)((char*)&mdCcAc_c), (dActor_c*)((char*)this), 0x35555, 0x294000, 0x280000c, 0);
-    unk_16e = 0xff;
+    mHasTouchedFlag = 0xff;
     mVictoryTimer = 0;
     return 1;
 }

--- a/src/_ZN9KoopaFlag8BehaviorEv.cpp
+++ b/src/_ZN9KoopaFlag8BehaviorEv.cpp
@@ -20,7 +20,7 @@ int KoopaFlag::Behavior()
     char *a;
     int b;
 
-    if (unk_16e == 0) {
+    if (mHasTouchedFlag == 0) {
         id = mdCcAc_c.otherOwner;
         if (id != 0) {
             a = _ZN8dActor_c10FindWithIDEj(id);
@@ -28,7 +28,7 @@ int KoopaFlag::Behavior()
                 b = *(unsigned short *)(a + 0xC);
                 b = b == 0xBF;
                 if (b) {
-                    unk_16e = 1;
+                    mHasTouchedFlag = 1;
                     _ZN5Timer9StopTimerEv(data_0209d4c8);
                     mVictoryTimer = 1;
                     _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x1F, 0x14, 0x7F, 0x6B000, 0);

--- a/src/_ZN9LavaPlank13InitResourcesEv.cpp
+++ b/src/_ZN9LavaPlank13InitResourcesEv.cpp
@@ -27,7 +27,7 @@ int LavaPlank::InitResources()
   kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov022_02114618);
   _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(&mMeshCollider, kcl, &mClsnMat, 0x1000, mAngleY, data_ov064_0211ba6c);
   func_020393d4(&mMeshCollider, &_ZN4dBgW21UpdatePosWithVelocityERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
-  unk_320 = mPosY;
+  mOriginalPosY = mPosY;
   unk_324 = mAngleX;
   return 1;
 }

--- a/src/_ZN9LightBeam8BehaviorEv.cpp
+++ b/src/_ZN9LightBeam8BehaviorEv.cpp
@@ -88,7 +88,7 @@ int LightBeam::Behavior()
                         if (*(s32*)((char*)o + 0x664) == 0xd) {
                             if (_ZN6Player9StartTalkER7fBase_cb(o, ((Obj*)this), 0)) {
                                 ((Obj*)this)->f164 = (s32)o;
-                                *(s16*)((char*)&unk_168) = 0;
+                                *(s16*)((char*)&mSoundTimer) = 0;
                             }
                         }
                     }

--- a/src/_ZN9ShipWater8BehaviorEv.cpp
+++ b/src/_ZN9ShipWater8BehaviorEv.cpp
@@ -12,7 +12,7 @@ extern int _ZN10dBgActor_c19UpdateClsnPosAndRotEv(char* t);
 
 int ShipWater::Behavior()
 {
-    if (unk_338 == 0) {
+    if (mChestsOpen == 0) {
         int ok = 1;
         char* p = _ZN8dActor_c15FindWithActorIDEjPS_(0xd, 0);
         while (p != 0) {
@@ -24,13 +24,13 @@ int ShipWater::Behavior()
             if (cond == 0) ok = 0;
             p = _ZN8dActor_c15FindWithActorIDEjPS_(0xd, p);
         }
-        if (ok != 0) unk_338 = 1;
+        if (ok != 0) mChestsOpen = 1;
     } else {
-        int d = unk_334 - mPosY;
+        int d = mOriginalPosY - mPosY;
         if (d < 0) d = -d;
         if (d < 0x92e000) {
             int* q;
-            unk_33c = _ZN5Sound8PlayLongEjjjRK7Vector3s(unk_33c, 3, 0x96, ((char*)this)+0x74, 0);
+            mSoundID = _ZN5Sound8PlayLongEjjjRK7Vector3s(mSoundID, 3, 0x96, ((char*)this)+0x74, 0);
             q = (int*)((char*)&mPosY);
             *q -= 0x5000;
         }

--- a/src/_ZN9TinyWater13InitResourcesEv.cpp
+++ b/src/_ZN9TinyWater13InitResourcesEv.cpp
@@ -29,6 +29,6 @@ int TinyWater::InitResources()
     _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
         ((char*)this) + 0x124, mc, ((char*)this) + 0x2ec, 0x1000, mAngleY, data_ov033_02111c1c);
     ((dBgW *)(((char*)this) + 0x124))->Enable((dActor_c *)(((char*)this)));
-    unk_334 = mPosY - 0x3c000;
+    mMinPosY = mPosY - 0x3c000;
     return _ZN5Event6GetBitEj(0xe) == 0;
 }

--- a/src/_ZN9TowerStep8BehaviorEv.cpp
+++ b/src/_ZN9TowerStep8BehaviorEv.cpp
@@ -20,46 +20,46 @@ int TowerStep::Behavior()
     int kind = param1 & 0xff;
 
     if (kind == 1) {
-        if (DecIfAbove0_Byte(&unk_390) == 0) {
+        if (DecIfAbove0_Byte(&mMoveTimer) == 0) {
             s16 *p = &mPrevAngleY;
             s16 v = *p;
             u8 b = 0x87;
             v = (s16)(v + 0x8000);
             *p = v;
-            unk_390 = b;
+            mMoveTimer = b;
         }
         _ZN8dActor_c9UpdatePosEP5dCc_c(self, 0);
         UpdateModelPosAndRotY();
         if (_ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(self, 0x150000, 0x1000) != 0)
             UpdateClsnPosAndRot();
     } else if (kind == 2) {
-        if (DecIfAbove0_Byte(&unk_390) == 0) {
-            if (unk_392 != 0) {
+        if (DecIfAbove0_Byte(&mMoveTimer) == 0) {
+            if (mMove != 0) {
                 int flag;
                 int bound;
                 int y;
 
                 _ZN8dActor_c9UpdatePosEP5dCc_c(self, 0);
-                bound = unk_37c;
+                bound = mMinPosY;
                 y = mPosY;
                 flag = (y >= bound);
                 if (flag != 0)
                     goto c2_hi;
                 mPosY = (y < bound) ? bound : y;
                 mVertSpeed = 0xa000;
-                if (unk_391 == 0) {
+                if (mJustSteppedOn == 0) {
                     flag = 0;
-                    unk_392 = (u8)flag;
+                    mMove = (u8)flag;
                 }
                 goto c2_after;
             c2_hi:
-                bound = unk_380;
+                bound = mMaxPosY;
                 flag = (y <= bound);
                 if (flag != 0)
                     goto c2_after;
                 mPosY = (y > bound) ? bound : y;
                 mVertSpeed = -0xa000;
-                unk_390 = 0x5a;
+                mMoveTimer = 0x5a;
             }
         }
     c2_after:
@@ -69,10 +69,10 @@ int TowerStep::Behavior()
         if (Vec3_Dist(&mPosX, &unk_068) != 0) {
             unsigned z = 0;
             unsigned r = _ZN5Sound8PlayLongEjjjRK7Vector3s(
-                (unsigned)unk_38c, 3, 0x82, &mCamSpacePosX, (s16)z);
-            unk_38c = (s32)r;
+                (unsigned)mSoundID, 3, 0x82, &mCamSpacePosX, (s16)z);
+            mSoundID = (s32)r;
         }
-        unk_391 = 0;
+        mJustSteppedOn = 0;
     } else {
         _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(self, 0x150000, 0x1000);
     }

--- a/src/_ZN9WDW_Water13InitResourcesEv.cpp
+++ b/src/_ZN9WDW_Water13InitResourcesEv.cpp
@@ -50,7 +50,7 @@ int WDW_Water::InitResources()
         &mMeshCollider, k, &mClsnMat, 0x1000, mAngleY, &data_ov029_02112fec);
     ((dBgW *)(&mMeshCollider))->Enable((dActor_c *)(((char *)this)));
 
-    unk_340 = (u8)mAreaId;
+    mTrueAreaID = (u8)mAreaId;
     mAreaId = -1;
     *(s16*)(((char *)this) + 0x300 + 0x42) = 0;
 

--- a/src/_ZN9WDW_Water8BehaviorEv.cpp
+++ b/src/_ZN9WDW_Water8BehaviorEv.cpp
@@ -50,8 +50,8 @@ int WDW_Water::Behavior()
     }
 
     if (mPosY != unk_06c) {
-        unk_33c = _ZN5Sound8PlayLongEjjjRK7Vector3s(
-            *(unsigned *)((u8 *)&unk_33c), 3, 0x96, ((u8 *)this) + 0x74, 0);
+        mSoundID = _ZN5Sound8PlayLongEjjjRK7Vector3s(
+            *(unsigned *)((u8 *)&mSoundID), 3, 0x96, ((u8 *)this) + 0x74, 0);
     }
 
     {
@@ -60,9 +60,9 @@ int WDW_Water::Behavior()
         *q = (s16)(*q + 0x200);
         /* index from (u16)angle at 0x342 via 0x300+0x42 */
         i = *(u16 *)((u8 *)(((unsigned)((u8 *)this) + 0x300)) + 0x42) >> 4;
-        unk_344 = (int)data_02082214[i * 2] * 0xf + mPosY;
+        mWaterHeight = (int)data_02082214[i * 2] * 0xf + mPosY;
     }
-    data_0209f32c = unk_344;
+    data_0209f32c = mWaterHeight;
     func_ov029_021122b4(((u8 *)this));
     func_ov029_02112250(((u8 *)this));
     (*(s32 *)((char *)&mTextureTransformer + 0xc)) = 0x1000;

--- a/src/actors/BooCage/_ZN7BooCage13InitResourcesEv.cpp
+++ b/src/actors/BooCage/_ZN7BooCage13InitResourcesEv.cpp
@@ -23,8 +23,8 @@ int BooCage::InitResources()
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(((char *)this) + 0x110, ((char *)this), 0x64000, 0x64000, 0x200004, 0);
     _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x144, ((char *)this), 0x64000, 0x64000, 0, 0);
     _ZN10dBgCh_Actr13SetLimMovFlagEv((char *)&mWithMeshClsn);
-    unk_378 = 0;
-    unk_37c = 0;
+    mParticleID = 0;
+    mSoundTimer = 0;
     unk_37e = 0;
     return 1;
 }

--- a/src/engine/fader/_ZN10FaderColor11AdvanceFadeEv.cpp
+++ b/src/engine/fader/_ZN10FaderColor11AdvanceFadeEv.cpp
@@ -14,7 +14,7 @@ void FaderColor::AdvanceFade()
     _ZN5Fader13AdvanceInterpEv(((char*)this));
     if (currInterp == old) return;
     {
-        unsigned short color = unk_00c;
+        unsigned short color = this->color;
         int m = color ? 0x10 : -0x10;
         int r = (currInterp * m) >> 12;
         if (r != 0) {

--- a/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
+++ b/src/engine/fader/_ZN9FaderWipe11AdvanceFadeEv.cpp
@@ -36,7 +36,7 @@ void FaderWipe::AdvanceFade()
     }
     if (*(Fix12i*)((char*)&currInterp) == old) return;
     {
-        u16 color = unk_00c;
+        u16 color = this->color;
         int m = color ? 0x10 : -0x10;
         int prod = *(Fix12i*)((char*)&currInterp) * m;
         int r = prod >> 12;

--- a/src_tu/actors/Bird.cpp
+++ b/src_tu/actors/Bird.cpp
@@ -125,7 +125,7 @@ int Bird::InitResources()
         *p60 = y + 0xa000;
         mVertAccel = zero;
         mTerminalVelocity = -0x32000;
-        unk_180 = 1;
+        mIsLeader = 1;
         mOwnerID = uniqueID;
         mHomePos.x = mPosX;
         mHomePos.y = mPosY;

--- a/src_tu/actors/LightBeam.cpp
+++ b/src_tu/actors/LightBeam.cpp
@@ -59,7 +59,7 @@ struct LightBeam : dActor_c {   /* real member types at the evidenced offsets */
     Model mModel;            /* 0x0d4 */
     dCcAcPos_c mdCcAcPos_c;  /* 0x124 */
     u8  pad_125[0x43];
-    u8  unk_168;             /* 0x168 */
+    u8  mSoundTimer;             /* 0x168 */
     virtual ~LightBeam();
     int Behavior();
     int InitResources();
@@ -209,7 +209,7 @@ int LightBeam::Behavior()
                         if (*(s32*)((char*)o + 0x664) == 0xd) {
                             if (_ZN6Player9StartTalkER7fBase_cb(o, ((Obj*)this), 0)) {
                                 ((Obj*)this)->f164 = (s32)o;
-                                *(s16*)((char*)&unk_168) = 0;
+                                *(s16*)((char*)&mSoundTimer) = 0;
                             }
                         }
                     }

--- a/src_tu/actors/PoleLift.cpp
+++ b/src_tu/actors/PoleLift.cpp
@@ -128,12 +128,12 @@ int PoleLift::Behavior()
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
     _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
     if ((*(s32 *)&param1) != 0xffff) {
-        int idx = unk_354 >> 4;
+        int idx = mHeightAng >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
         *(int*)(((int)((char *)this) + 0x60)) =
             *(int*)(((int)((char *)this) + 0x60)) + (int)(((long long)s * 0x7000 + 0x800) >> 12);
     } else {
-        int idx = unk_354 >> 4;
+        int idx = mHeightAng >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
         *(int*)(((int)((char *)this) + 0x60)) =
             *(int*)(((int)((char *)this) + 0x60)) - (int)(((long long)s * 0x3000 + 0x800) >> 12);

--- a/src_tu/actors/SwitchActivatedPlank.cpp
+++ b/src_tu/actors/SwitchActivatedPlank.cpp
@@ -107,9 +107,9 @@ int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void*, void*, int);
 int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
     func_020393a4(((char*)self)+0x124, 0x100000);
 
-    switch(self->unk_3a2){
+    switch(self->mState){
     case 0:
-        if(_ZN5Event6GetBitEj(self->unk_3a4) == 0) break;
+        if(_ZN5Event6GetBitEj(self->mEventID) == 0) break;
 
         {
             unsigned char* st_ptr = (unsigned char*)(((int)((char*)self) + 0x3a2));
@@ -117,7 +117,7 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         }
 
         *(short*)(((char*)self) + 0x300 + 0xa0) = 0;
-        self->unk_3a3 = 1;
+        self->mVisible = 1;
 
         ((MeshColliderBase *)(((char*)self)+0x124))->Enable((dActor_c *)(((char*)self)));
         func_ov029_021126dc(((char*)self));
@@ -125,15 +125,15 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         break;
 
     case 1: {
-        unsigned short* p = (unsigned short*)((char*)&self->unk_3a0);
+        unsigned short* p = (unsigned short*)((char*)&self->mStateTimer);
         if (*(unsigned short*)(((char*)self) + 0x300 + 0xa0) > 0x168) {
-            self->unk_3a3 = *(unsigned short*)(((char*)self) + 0x300 + 0xa0) & 1;
+            self->mVisible = *(unsigned short*)(((char*)self) + 0x300 + 0xa0) & 1;
         }
         *p = *p + 1;
-        if (_ZN5Event6GetBitEj(self->unk_3a4) != 0) break;
+        if (_ZN5Event6GetBitEj(self->mEventID) != 0) break;
         ((MeshColliderBase *)((char*)&self->mMovingMeshCollider))->Disable();
-        self->unk_3a2 = 0;
-        self->unk_3a3 = 0;
+        self->mState = 0;
+        self->mVisible = 0;
         break;
     }
     }
@@ -152,7 +152,7 @@ struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual vo
 
 int SwitchActivatedPlank::Render()
 {
-  if (unk_3a3 != 0) {
+  if (mVisible != 0) {
     Sub *s = (Sub*)((char *)&mModel2);
     s->v5(0);
   }

--- a/src_tu/actors/Trap.cpp
+++ b/src_tu/actors/Trap.cpp
@@ -192,17 +192,17 @@ struct TrapFlat {
     u8  pad_090[0x3c];
     s8  unk_0cc;
     u8  pad_0cd[0x2d3];
-    s32 unk_3a0, unk_3a4;
-    u16 unk_3a8;
-    u8  unk_3aa, unk_3ab;
-    s32 unk_3ac;
+    s32 mState, mPlayerDist;
+    u16 mOpenSpeed;
+    u8  mTrapActive, mIsSpawner;
+    s32 mSpawnerID;
 };
 extern "C" {  /* .c-derived member: C linkage for the whole block */
 int _ZN4Trap13InitResourcesEv(char* c)
 {
     struct TrapFlat *self = (struct TrapFlat *)(void *)c;
-    self->unk_3aa = 0;
-    self->unk_3ac = 0;
+    self->mTrapActive = 0;
+    self->mSpawnerID = 0;
 
     if ((*(int*)(c + 8) & 0xff) == 0xff) {
         struct Vector3 v;
@@ -211,8 +211,8 @@ int _ZN4Trap13InitResourcesEv(char* c)
         int x, y, z;
         void* sp;
 
-        self->unk_3ab = 1;
-        self->unk_3a4 = 0;
+        self->mIsSpawner = 1;
+        self->mPlayerDist = 0;
 
         idx = ((int)(self->unk_08e) >> 4) * 2;
         sx = data_02082214[idx + 1];
@@ -241,7 +241,7 @@ int _ZN4Trap13InitResourcesEv(char* c)
         return 1;
     }
 
-    self->unk_3ab = 0;
+    self->mIsSpawner = 0;
     {
         void* f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov010_02112d08);
         _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x320, f, 1, -1);
@@ -254,8 +254,8 @@ int _ZN4Trap13InitResourcesEv(char* c)
     }
     func_020393c4((int*)(c + 0x124), (int)func_ov010_02111984);
     _ZN4dBgW6EnableEP8dActor_c(c + 0x124, c);
-    self->unk_3a8 = 0;
-    self->unk_3a0 = 0;
+    self->mOpenSpeed = 0;
+    self->mState = 0;
 
     if ((*(int*)(c + 8) & 0xff) == 1) {
         short* pa = (short*)(((int)c + 0x8e));
@@ -304,14 +304,14 @@ extern "C" int _ZN4Trap8BehaviorEv(C* c)
  * body is the same virtual-dispatch-through-a-shadow-vtable trick the file
  * used before the rename (Model's own Render, called through the Model
  * sub-object at +0x320), unconverted. include/Trap.h is included for the
- * `struct Trap` cast that reads unk_3ab by hand offset. */
+ * `struct Trap` cast that reads mIsSpawner by hand offset. */
 #include "Trap.h"
 extern "C" {
 struct A { char pad[0x320]; };
 struct B { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual void m5(bool); };
 int _ZN4Trap6RenderEv(char* c){
     struct Trap *self = (struct Trap *)(void *)c;
-  if(self->unk_3ab == 0){
+  if(self->mIsSpawner == 0){
     ((B*)(c+0x320))->m5(false);
   }
   return 1;

--- a/src_tu/actors/WDW_Water.cpp
+++ b/src_tu/actors/WDW_Water.cpp
@@ -96,7 +96,7 @@ int WDW_Water::InitResources()
         &mMeshCollider, k, &mClsnMat, 0x1000, mAngleY, &data_ov029_02112fec);
     ((MeshColliderBase *)(&mMeshCollider))->Enable((dActor_c *)(((char *)this)));
 
-    unk_340 = (u8)mAreaId;
+    mTrueAreaID = (u8)mAreaId;
     mAreaId = -1;
     *(s16*)(((char *)this) + 0x300 + 0x42) = 0;
 
@@ -157,8 +157,8 @@ int WDW_Water::Behavior()
     }
 
     if (mPosY != unk_06c) {
-        unk_33c = _ZN5Sound8PlayLongEjjjRK7Vector3s(
-            *(unsigned *)((u8 *)&unk_33c), 3, 0x96, ((u8 *)this) + 0x74, 0);
+        mSoundID = _ZN5Sound8PlayLongEjjjRK7Vector3s(
+            *(unsigned *)((u8 *)&mSoundID), 3, 0x96, ((u8 *)this) + 0x74, 0);
     }
 
     {
@@ -167,9 +167,9 @@ int WDW_Water::Behavior()
         *q = (s16)(*q + 0x200);
         /* index from (u16)angle at 0x342 via 0x300+0x42 */
         i = *(u16 *)((u8 *)(((unsigned)((u8 *)this) + 0x300)) + 0x42) >> 4;
-        unk_344 = (int)data_02082214[i * 2] * 0xf + mPosY;
+        mWaterHeight = (int)data_02082214[i * 2] * 0xf + mPosY;
     }
-    data_0209f32c = unk_344;
+    data_0209f32c = mWaterHeight;
     func_ov029_021122b4(((u8 *)this));
     func_ov029_02112250(((u8 *)this));
     (*(s32 *)((char *)&mTextureTransformer + 0xc)) = 0x1000;

--- a/src_tu/actors/WaterDiamond.cpp
+++ b/src_tu/actors/WaterDiamond.cpp
@@ -49,9 +49,9 @@ struct dActor_c {   /* shadow base: vptr at 0, evidenced dActor_c fields, size 0
 struct WaterDiamond : dActor_c {
     Model mModel;                            /* 0x0d4 */
     MovingCylinderClsn mMovingCylinderClsn;  /* 0x124 */
-    s32 unk_158;                             /* 0x158 */
-    s8  unk_15c;
-    u8  unk_15d;
+    s32 mWaterID;                             /* 0x158 */
+    s8  mWaterParam;
+    u8  mActive;
     virtual ~WaterDiamond();
     int Behavior();
     int InitResources();
@@ -96,9 +96,9 @@ int WaterDiamond::InitResources()
   void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_02114270);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, m, 1, -1);
   _ZN18MovingCylinderClsn4InitEP8dActor_c5Fix12IiES3_jj(((char*)this)+0x124, ((char*)this), 0x32000, 0x64000, 0x800002, 0);
-  unk_158 = 0;
-  unk_15c = mParam & 1;
-  unk_15d = 0;
+  mWaterID = 0;
+  mWaterParam = mParam & 1;
+  mActive = 0;
   mAngleY = 0;
   return 1;
 }
@@ -121,19 +121,19 @@ extern void _ZN12CylinderClsn6UpdateEv(void* self);
 int WaterDiamond::Behavior()
 {
     func_ov029_02111850(((char*)this));
-    if (unk_158 == 0) return 1;
+    if (mWaterID == 0) return 1;
     func_ov029_021117ac(((char*)this));
-    if (unk_15d != 0) {
+    if (mActive != 0) {
         char* p;
         s16* a = (s16*)(((int)((char*)this) + 0x8e));
         *a = *a + 0x400;
-        p = _ZN8dActor_c10FindWithIDEj(unk_158);
+        p = _ZN8dActor_c10FindWithIDEj(mWaterID);
         if (p != 0) {
             if (mPosY == *(int*)(p+0x60)) {
-                if (mAngleY == 0) unk_15d = 0;
+                if (mAngleY == 0) mActive = 0;
             }
             if (mPosY != *(int*)(p+0x334)) {
-                unk_15d = 0;
+                mActive = 0;
                 mAngleY = 0;
             }
         }

--- a/src_tu/scene/Scene.cpp
+++ b/src_tu/scene/Scene.cpp
@@ -408,7 +408,7 @@ extern fBase_c *data_0209f5c0;
 /* RECONCILED. Three of this TU's legacy files declared 0x0209f5e8 three
    different ways -- `FaderBrightness` (SetAndStopColorFader, which uses
    ::speed, and ResetFadersAndSound, which takes its address), `FaderColor`
-   (StartSceneFade, which uses ::unk_00c) and a local one-field shadow
+   (StartSceneFade, which uses ::color) and a local one-field shadow
    (BeforeBehavior, which dispatches through its vptr with the wrong arity;
    see there). FaderColor is the most complete of the three and is what the
    object really is -- __sinit_02074edc constructs it up the chain and leaves
@@ -722,7 +722,7 @@ int dScene_c::SetSceneToSpawn(u32 sceneID, u32 param)
 void dScene_c::StartSceneFade(u32 sceneID, u32 param, u16 fadeColor)
 {
     if (SetSceneToSpawn(sceneID, param))
-        data_0209f5e8.unk_00c = fadeColor;
+        data_0209f5e8.color = fadeColor;
 }
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
**Stacked on #1659 (`types/marker-import`) — land it after that one.** It edits the same 42 headers, so basing on `main` would have conflicted with every one of them. The 43 fields #1659 typed are excluded here by construction: the join was re-derived against the post-#1659 headers, not against the stale table.

## What this is

The vendored upstream reference headers (DynamicAllocationDecomp) name fields at offsets this tree still models as `unk_NNN` / `pad_NNN`. Joining the two on `(class, offset)` and keeping only pairs whose **declared field size agrees on both sides** gives **176 renames across 42 classes**.

Renames only. No type, no width, no extent changes — so this cannot move a byte. Every gate ran anyway.

## What was dropped, out of the 209 candidates the join offered

| n | reason |
|---|---|
| 11 | the reference's name is a placeholder too (`unk320`, `unk090`, `unk42a`, `unk4a2`, …) — nothing to import |
| 21 | **extent mismatch.** 19 are the reference declaring one aggregate where this tree models several scalars (a `Vector3` or `Matrix2x2` against our single `s32` — e.g. `Koopa+0x39c`, `Minimap+0x50`); 2 are a `bool` against a multi-byte pad array (`Goomboss pad_60b[5]`, `HUD pad_078[4]`). Naming the first word of a vector after the whole vector asserts an extent the declaration does not have — that is a retype, not a rename |
| 1 | `Stage Fog unk_96c` against the reference's `Fog fog[2]` |

The 223 fields under `findings.json` key `new` — offsets we model as padding — are untouched; that is a separate PR.

## Types are ours, names are theirs

**102 of the 176** disagree with the reference about *type* while agreeing about the field. Our declared type is kept untouched in every one — a signedness change is a codegen change:

`s32` vs `Fix12i` ×30 · `u8` vs `bool` ×25 · `s32` vs `u32` ×20 · `s16` vs `u16` ×8 · `u16` vs `s16` ×4 · `u8` vs `s8` ×4 · `s32` vs a pointer type ×6 · plus `dCcAc_c`/`dCcAcPos_c` vs their `MovingCylinderClsn*` spellings.

No case where our *name* disagreed with theirs in meaning: everything renamed here was a bare `unk_`/`pad_` placeholder, so there was nothing of ours to defend.

## Spelling follows the file, not the reference

This tree's headers name fields `mFoo`, so `soundTimer` lands as `mSoundTimer`. The Fader family is the one exception — `Fader.h`/`FaderBrightness.h` name their own fields bare (`currInterp`, `speed`) — so `FaderColor`'s 0x0c is `color`, matching its neighbours. No header was reformatted; only identifiers moved, so the offset comments the gate reads are untouched.

## Scoping — the part that had to be got right

Placeholder names are **not unique**. `unk_320` names a field in seven of these classes alone, and dozens more tree-wide; a tree-wide substitution would have silently renamed unrelated classes' fields to names that mean nothing there.

- Every substitution was scoped to the owning class: its header's own struct blocks (both the C++ and the flat C half, where a file has both) plus the files that reach the field *through that class*.
- Every rule is word-bounded and idempotent.
- Every consumer site had its receiver checked first — all 370 are `this`-implicit or `self->` with `self` declared as the class. Zero sites reached the field through anything else.
- The three ad-hoc shadow structs that restate one of these classes by hand — `TrapFlat` in `src_tu/actors/Trap.cpp`, and the local `LightBeam` / `WaterDiamond` declarations in their TU files — were respelled in full rather than half-renamed.

**One real collision, caught before it landed.** `FaderColor::AdvanceFade` and `FaderWipe::AdvanceFade` each already declare a local `u16 color` initialised from this very field, so the naive rename produced `unsigned short color = color;` — a self-initialisation that compiles silently and would have been a live bug. Both sites now read `this->color`.

Also moved, so nothing is left half-renamed: the C-half restatements of `FaderColor`'s 0x0c in `dFdDummy_c.h` / `dWipe_c.h` / `FaderWipe.h`, and the prose in `LavaBridge.h` / `LavaSeesaw.h` / `SwitchPillar.h` that named `ArmedRotatingPlatform`'s 0x31e by its old placeholder.

## Gates — all run in the worktree, all still

- **`eligible.py` bracketed before and after: 11064 / 11186 both times, and the two `eligible-names.txt` are byte-identical.** No neighbour was un-built by a header edit.
- **`rombuild.py -j 16`: 106/106 exact, 100.000000% of compared bytes, 11,058 reproducing, 0 mismatching.**
- `check_header_offsets.py --changed`: 48 changed headers, 0 mismatched, 0 unparsed.
- `port_refcheck.py`: 393 references checked, 0 stale.
- `langmode_audit.py --check` against the pre-change baseline: **PASS**, and every numeric key in the audit JSON is identical before and after — the textual metric did not move.

A tree-wide grep of the 134 new names finds 37 that now appear in more than one class (`mState` in 30+, `mSoundID` in 6, …). All are unrelated classes with no shared scope, which is already this tree's norm — `mState` lived in 30 classes before this PR. Base chains were walked separately: **no new name shadows a base-class field**, which is the case that could have silently repointed an existing access.
