### PR TITLE
Read every class size out of the ROM's own `operator new`, and hold 19 headers to it

### DIFF
--- a/include/ArrowLift.h
+++ b/include/ArrowLift.h
@@ -17,6 +17,8 @@ struct ArrowLift {
     u8  mMovingMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     s32 unk_320;            /* 0x320 */
+    /* trailing extent the ROM's `new ArrowLift` literal proves; see tools/opnew_sizes.py */
+    u8 pad_324[0x4];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -25,5 +27,7 @@ struct ArrowLift {
     int Render();
 #endif
 };
+
+typedef char ArrowLift_size_must_be_0x328[sizeof(struct ArrowLift) == 0x328 ? 1 : -1];
 
 #endif

--- a/include/CameraTag.h
+++ b/include/CameraTag.h
@@ -4,21 +4,28 @@
  *
  * ALL FIVE of its virtual overrides are STUBS -- InitResources, Behavior,
  * Render and CleanupResources are `return 1`, OnPendingDestroy is empty, and
- * not one of them reads `this`. The class exists to BE somewhere: it is an
- * dActor_c carrying a dCcAc_c and nothing else, so what it does is
- * occupy a collision volume that other code queries. Overriding every hook to
- * do nothing is how it stays inert while still being a full actor.
+ * not one of them reads `this`. The class exists to BE somewhere: it is a
+ * dActor_c and nothing more, marking a position other code queries.
+ * Overriding every hook to do nothing is how it stays inert while still being
+ * a full actor.
  *
- * The layout therefore comes from the spawner and the constructor, not from
- * the methods -- none of them touches a field:
+ * SIZE 0xd4, which is sizeof(dActor_c) exactly: CameraTag adds no members at
+ * all. It comes from the class's OWN factory, and CameraTag_Spawn spells it
+ * `sizeof(struct CameraTag)` so the byte gate holds this header to it:
  *
- *   InvisiblePole_Spawn allocates 264 == 0x108 bytes, so that is sizeof.
- *   It then runs dCcAc_c's constructor at +0xd4, and dActor_c is
- *   0xd0, so the sub-object begins on the first 4-aligned offset past the
- *   base and runs to the end: 0x108 - 0xd4 == 0x34.
+ *   CameraTag_Spawn  0x020b07c8  new(212 == 0xd4), dActor_c::dActor_c(),
+ *                                stores _ZTV9CameraTag. No member ctor runs,
+ *                                which is what "no members" looks like.
  *
- * That 0x34 is corroborated independently -- KoopaShell puts a
- * dCcAc_c at 0x110 and its next member at 0x144, the same span.
+ * THIS HEADER USED TO SAY 0x108, with a dCcAc_c at 0xd4. That was
+ * InvisiblePole's layout, read off InvisiblePole_Spawn (0x020b0710) -- the
+ * function immediately BEFORE this class's own factory, whose story the old
+ * comment reproduced verbatim, down to naming it. InvisiblePole is a different
+ * class with a different vtable (0x02108480, RTTI daBar_c), and it is already
+ * correctly declared at 0x108 in include/InvisiblePole.h, dCcAc_c and all.
+ * Pairing a class to a factory by NAME is what produced that, and it is the
+ * same defect PR #1556 had to retract two findings for. tools/opnew_sizes.py
+ * pairs by vtable address instead, and that is what caught this one.
  *
  * Field NAMES are placeholders - renaming cannot change codegen.
  */
@@ -28,10 +35,6 @@
 
 struct CameraTag {
     u8  pad_000[0xd4];
-    /* dCcAc_c, 0x34 bytes, running to the end of the object. Kept
-       as a byte marker: nothing in this class ever looks inside it. */
-    u8  mdCc_c;            /* 0x0d4 */
-    u8  pad_0d5[0x33];
 #ifdef __cplusplus
     /* methods -- every one a stub; see the note above */
     int Behavior();
@@ -41,5 +44,7 @@ struct CameraTag {
     int Render();
 #endif
 };
+
+typedef char CameraTag_size_must_be_0xd4[sizeof(struct CameraTag) == 0xd4 ? 1 : -1];
 
 #endif

--- a/include/ChiefChilly.h
+++ b/include/ChiefChilly.h
@@ -60,6 +60,8 @@ struct ChiefChilly : dEnemyBase_c {
     s32 unk_4ec;                                           /* 0x4ec */
     s32 unk_4f0;                                           /* 0x4f0 */
     s32 unk_4f4;                                           /* 0x4f4 */
+    /* trailing extent the ROM's `new ChiefChilly` literal proves; see tools/opnew_sizes.py */
+    u8 pad_4f8[0xc];
 
     virtual ~ChiefChilly();
 
@@ -71,6 +73,8 @@ struct ChiefChilly : dEnemyBase_c {
     virtual s32 Render();
     virtual void OnPendingDestroy();
 };
+
+typedef char ChiefChilly_size_must_be_0x504[sizeof(struct ChiefChilly) == 0x504 ? 1 : -1];
 
 #endif /* __cplusplus */
 

--- a/include/Coffin.h
+++ b/include/Coffin.h
@@ -24,6 +24,8 @@ struct Coffin {
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */
+    /* trailing extent the ROM's `new Coffin` literal proves; see tools/opnew_sizes.py */
+    u8 pad_2f0[0x3c];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -32,5 +34,7 @@ struct Coffin {
     int Render();
 #endif
 };
+
+typedef char Coffin_size_must_be_0x32c[sizeof(struct Coffin) == 0x32c ? 1 : -1];
 
 #endif

--- a/include/Flamethrower.h
+++ b/include/Flamethrower.h
@@ -30,11 +30,15 @@ struct Flamethrower {
        Vector3 mPartPos[12] at 0x3a4 (stride 0xc),
        Matrix4x3 at 0x434, then u8 state 0x464 / u8 active 0x465 /
        u16 timer 0x466 / u32 sound handle 0x468. */
+    /* trailing extent the ROM's `new Flamethrower` literal proves; see tools/opnew_sizes.py */
+    u8 pad_094[0x3d8];
 #ifdef __cplusplus
     /* methods */
     int InitResources();
     int Behavior();
 #endif
 };
+
+typedef char Flamethrower_size_must_be_0x46c[sizeof(struct Flamethrower) == 0x46c ? 1 : -1];
 
 #endif

--- a/include/MadPiano.h
+++ b/include/MadPiano.h
@@ -41,6 +41,8 @@ struct MadPiano {
     s32 unk_6d4;            /* 0x6d4 */
     s32 unk_6d8;            /* 0x6d8 */
     s32 unk_6dc;            /* 0x6dc */
+    /* trailing extent the ROM's `new MadPiano` literal proves; see tools/opnew_sizes.py */
+    u8 pad_6e0[0x4];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -49,5 +51,7 @@ struct MadPiano {
     int Render();
 #endif
 };
+
+typedef char MadPiano_size_must_be_0x6e4[sizeof(struct MadPiano) == 0x6e4 ? 1 : -1];
 
 #endif

--- a/include/MirrorLuigi.h
+++ b/include/MirrorLuigi.h
@@ -37,6 +37,8 @@ struct MirrorLuigi {
     s32 unk_1cc;            /* 0x1cc */
     u8  pad_1d0[0x8];
     u8  unk_1d8;            /* 0x1d8 */
+    /* trailing extent the ROM's `new MirrorLuigi` literal proves; see tools/opnew_sizes.py */
+    u8 pad_1dc[0x30];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -44,5 +46,7 @@ struct MirrorLuigi {
     int Render();
 #endif
 };
+
+typedef char MirrorLuigi_size_must_be_0x20c[sizeof(struct MirrorLuigi) == 0x20c ? 1 : -1];
 
 #endif

--- a/include/Stage.h
+++ b/include/Stage.h
@@ -235,8 +235,12 @@ struct Stage : dScene_c {
        of Stage only as the family's legacy scope for dScStage_c; non-static
        because slot 2 needs `this`, non-virtual to keep their TUs from
        emitting a vtable the delink ranges do not own. */
+    /* trailing extent the ROM's `new Stage` literal proves; see tools/opnew_sizes.py */
+    u8 pad_9c0[0x8];
     int  GraphCallback1();
     int  GraphCallback2();
 };
+
+typedef char Stage_size_must_be_0x9c8[sizeof(struct Stage) == 0x9c8 ? 1 : -1];
 
 #endif

--- a/include/ToxBox.h
+++ b/include/ToxBox.h
@@ -47,11 +47,15 @@ struct ToxBox {
     s32 unk_57c;            /* 0x57c */
     u8  pad_580[0xc];
     u8  mPathPtr;            /* 0x58c */
+    /* trailing extent the ROM's `new ToxBox` literal proves; see tools/opnew_sizes.py */
+    u8 pad_590[0x4];
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();
     int Render();
 #endif
 };
+
+typedef char ToxBox_size_must_be_0x594[sizeof(struct ToxBox) == 0x594 ? 1 : -1];
 
 #endif

--- a/include/Tree.h
+++ b/include/Tree.h
@@ -13,11 +13,15 @@ struct Tree {
     s32 mPosX;            /* 0x05c */
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
+    /* trailing extent the ROM's `new Tree` literal proves; see tools/opnew_sizes.py */
+    u8 pad_068[0x1fc];
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();
     int Render();
 #endif
 };
+
+typedef char Tree_size_must_be_0x264[sizeof(struct Tree) == 0x264 ? 1 : -1];
 
 #endif

--- a/include/Unagi.h
+++ b/include/Unagi.h
@@ -60,6 +60,8 @@ struct Unagi : dEnemyBase_c {
     s32 unk_444;                                            /* 0x444 */
     Vector3 unk_448[7];                                     /* 0x448 */
     s32 mStarUniqueID;                                      /* 0x49c */
+    /* trailing extent the ROM's `new Unagi` literal proves; see tools/opnew_sizes.py */
+    u8 pad_4a0[0x10];
 
     virtual ~Unagi();
 
@@ -69,6 +71,8 @@ struct Unagi : dEnemyBase_c {
     virtual s32 Render();
     void OnPendingDestroy();
 };
+
+typedef char Unagi_size_must_be_0x4b0[sizeof(struct Unagi) == 0x4b0 ? 1 : -1];
 
 #else
 
@@ -134,6 +138,8 @@ struct Unagi {
     s32 unk_444;            /* 0x444 */
     u8  pad_448[0x54];
     s32 mStarUniqueID;            /* 0x49c */
+    /* trailing extent the ROM's `new Unagi` literal proves; see tools/opnew_sizes.py */
+    u8 pad_4a0[0x10];
 };
 
 #endif /* __cplusplus */

--- a/include/Wiggler.h
+++ b/include/Wiggler.h
@@ -41,6 +41,8 @@ struct Wiggler : dEnemyBase_c {
     dCcAcPos_c mdCc_cs2[5];    /* 0x5b8 */
     u8  pad_6f8[0x10];
     dBgCh_Actr mWithMeshClsn;                      /* 0x708 */
+    /* trailing extent the ROM's `new Wiggler` literal proves; see tools/opnew_sizes.py */
+    u8 pad_8c4[0x24];
 
     virtual ~Wiggler();
 
@@ -49,12 +51,16 @@ struct Wiggler : dEnemyBase_c {
     int Render();
 };
 
+typedef char Wiggler_size_must_be_0x8e8[sizeof(struct Wiggler) == 0x8e8 ? 1 : -1];
+
 #else
 
 /* The same object for a C translation unit, flat. */
 struct Wiggler {
     u8  pad_000[0x708];
     u8  mWithMeshClsn[0x1bc];      /* 0x708 */
+    /* trailing extent the ROM's `new Wiggler` literal proves; see tools/opnew_sizes.py */
+    u8 pad_8c4[0x24];
 };
 
 #endif /* __cplusplus */

--- a/include/WorkElevator.h
+++ b/include/WorkElevator.h
@@ -35,11 +35,15 @@ struct WorkElevator {
     s32 unk_c6c;            /* 0xc6c */
     u8  pad_c70[0xa];
     s8  unk_c7a;            /* 0xc7a */
+    /* trailing extent the ROM's `new WorkElevator` literal proves; see tools/opnew_sizes.py */
+    u8 pad_c7c[0x4];
 #ifdef __cplusplus
     /* methods */
     int CleanupResources();
     int Render();
 #endif
 };
+
+typedef char WorkElevator_size_must_be_0xc80[sizeof(struct WorkElevator) == 0xc80 ? 1 : -1];
 
 #endif

--- a/include/dScMgBomroom_c.h
+++ b/include/dScMgBomroom_c.h
@@ -24,6 +24,10 @@ struct dScMgBomroom_c : dScMgBase_c {
     u8  pad_62d4[0x1a];
     u16 unk_62ee;            /* 0x62ee */
     u16 unk_62f0;            /* 0x62f0 */
+    /* trailing extent the ROM's `new dScMgBomroom_c` literal proves; see tools/opnew_sizes.py */
+    u8 pad_62f4[0xc];
 };
+
+typedef char dScMgBomroom_c_size_must_be_0x6300[sizeof(struct dScMgBomroom_c) == 0x6300 ? 1 : -1];
 
 #endif

--- a/include/dScMgCurling_c.h
+++ b/include/dScMgCurling_c.h
@@ -38,6 +38,10 @@ struct dScMgCurling_c : dScMgBase_c {
     u16 unk_4ee2;            /* 0x4ee2 */
     u8  pad_4ee4[0x3];
     u8  unk_4ee7;            /* 0x4ee7 */
+    /* trailing extent the ROM's `new dScMgCurling_c` literal proves; see tools/opnew_sizes.py */
+    u8 pad_4ee8[0x4];
 };
+
+typedef char dScMgCurling_c_size_must_be_0x4eec[sizeof(struct dScMgCurling_c) == 0x4eec ? 1 : -1];
 
 #endif

--- a/include/dScMgPachinko2_c.h
+++ b/include/dScMgPachinko2_c.h
@@ -24,6 +24,10 @@ struct dScMgPachinko2_c : dScMgBase_c {
     u8  pad_5664[0x8];
     u16 unk_566c;            /* 0x566c */
     u16 unk_566e;            /* 0x566e */
+    /* trailing extent the ROM's `new dScMgPachinko2_c` literal proves; see tools/opnew_sizes.py */
+    u8 pad_5670[0xc];
 };
+
+typedef char dScMgPachinko2_c_size_must_be_0x567c[sizeof(struct dScMgPachinko2_c) == 0x567c ? 1 : -1];
 
 #endif

--- a/include/dScMgPachinko_c.h
+++ b/include/dScMgPachinko_c.h
@@ -31,6 +31,10 @@ struct dScMgPachinko_c : dScMgBase_c {
     u16 unk_5c24;            /* 0x5c24 */
     u8  pad_5c26[0x4];
     u16 unk_5c2a;            /* 0x5c2a */
+    /* trailing extent the ROM's `new dScMgPachinko_c` literal proves; see tools/opnew_sizes.py */
+    u8 pad_5c2c[0xc];
 };
+
+typedef char dScMgPachinko_c_size_must_be_0x5c38[sizeof(struct dScMgPachinko_c) == 0x5c38 ? 1 : -1];
 
 #endif

--- a/include/dScMgTeresa_c.h
+++ b/include/dScMgTeresa_c.h
@@ -26,6 +26,10 @@ struct dScMgTeresa_c : dScMgBase_c {
     s16 unk_4c16;            /* 0x4c16 */
     u8  pad_4c18[0xb];
     u8  unk_4c23;            /* 0x4c23 */
+    /* trailing extent the ROM's `new dScMgTeresa_c` literal proves; see tools/opnew_sizes.py */
+    u8 pad_4c24[0x4];
 };
+
+typedef char dScMgTeresa_c_size_must_be_0x4c28[sizeof(struct dScMgTeresa_c) == 0x4c28 ? 1 : -1];
 
 #endif

--- a/include/daObjMcWater_c.h
+++ b/include/daObjMcWater_c.h
@@ -12,6 +12,10 @@ struct daObjMcWater_c {
     s16 unk_08e;            /* 0x08e */
     u8  pad_090[0x29c];
     s32 unk_32c;            /* 0x32c */
+    /* trailing extent the ROM's `new daObjMcWater_c` literal proves; see tools/opnew_sizes.py */
+    u8 pad_330[0x8];
 };
+
+typedef char daObjMcWater_c_size_must_be_0x338[sizeof(struct daObjMcWater_c) == 0x338 ? 1 : -1];
 
 #endif

--- a/src/ArrowLift_Spawn.c
+++ b/src/ArrowLift_Spawn.c
@@ -1,3 +1,4 @@
+#include "ArrowLift.h"
 // @symbol ArrowLift_Spawn
 /* recovered: globals resolved, declarations from a shared header */
 #include "decl_ActorBase.h"
@@ -7,7 +8,7 @@
 /* resolved: VT = _ZTV9ArrowLift */
 int *ArrowLift_Spawn(void)
 {
-    int *p = (int *)_ZN7fBase_cnwEj(808);
+    int *p = (int *)_ZN7fBase_cnwEj(sizeof(struct ArrowLift));
     if (p) { _ZN10dBgActor_cC2Ev(p); p[0] = (int)_ZTV9ArrowLift; }
     return p;
 }

--- a/src/CameraTag_Spawn.c
+++ b/src/CameraTag_Spawn.c
@@ -1,4 +1,5 @@
 // @symbol CameraTag_Spawn
+#include "CameraTag.h"
 /* recovered: globals resolved, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_ActorBase.h"
@@ -7,7 +8,7 @@
 /* resolved: VT = _ZTV9CameraTag */
 int *CameraTag_Spawn(void)
 {
-    int *p = (int *)_ZN7fBase_cnwEj(212);
+    int *p = (int *)_ZN7fBase_cnwEj(sizeof(struct CameraTag));
     if (p) { _ZN8dActor_cC2Ev(p); p[0] = (int)_ZTV9CameraTag; }
     return p;
 }

--- a/src/CastleWater_Spawn.c
+++ b/src/CastleWater_Spawn.c
@@ -1,3 +1,4 @@
+#include "daObjMcWater_c.h"
 // @symbol CastleWater_Spawn
 /* recovered: vtable identified, declarations from a shared header */
 #include "decl_ActorBase.h"
@@ -8,7 +9,7 @@
 /* vtable identified: VT0 = _ZTV14daObjMcWater_c */
 int *CastleWater_Spawn(void)
 {
-    int *p = (int *)_ZN7fBase_cnwEj(824);
+    int *p = (int *)_ZN7fBase_cnwEj(sizeof(struct daObjMcWater_c));
     if (p) {
         _ZN10dBgActor_cC2Ev(p);
         p[0] = (int)_ZTV14daObjMcWater_c;

--- a/src/ChiefChilly_Spawn.cpp
+++ b/src/ChiefChilly_Spawn.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "ChiefChilly.h"
 extern "C" void* _ZN7fBase_cnwEj(unsigned int sz);
 extern "C" void _ZN12dEnemyBase_cC2Ev(void*);
 extern "C" void _ZN10dCcAcPos_cC1Ev(void*);
@@ -13,7 +14,7 @@ extern "C" void func_0203d384(void);
 
 extern "C" void* ChiefChilly_Spawn(void)
 {
-    char* p = (char*)_ZN7fBase_cnwEj(0x504);
+    char* p = (char*)_ZN7fBase_cnwEj(sizeof(struct ChiefChilly));
     if (p) {
         _ZN12dEnemyBase_cC2Ev(p);
         *(void**)p = &_ZTV11ChiefChilly;

--- a/src/Coffin_Spawn.c
+++ b/src/Coffin_Spawn.c
@@ -1,3 +1,4 @@
+#include "Coffin.h"
 // @symbol Coffin_Spawn
 /* recovered: globals resolved, declarations from a shared header */
 #include "decl_ActorBase.h"
@@ -7,7 +8,7 @@
 /* resolved: VT = _ZTV6Coffin */
 int *Coffin_Spawn(void)
 {
-    int *p = (int *)_ZN7fBase_cnwEj(812);
+    int *p = (int *)_ZN7fBase_cnwEj(sizeof(struct Coffin));
     if (p) { _ZN10dBgActor_cC2Ev(p); p[0] = (int)_ZTV6Coffin; }
     return p;
 }

--- a/src/Flamethrower_Spawn.cpp
+++ b/src/Flamethrower_Spawn.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Flamethrower.h"
 extern "C" {
 extern void* _ZN7fBase_cnwEj(unsigned int);
 extern void _ZN8dActor_cC2Ev(void*);
@@ -10,7 +11,7 @@ extern void func_020733a8(void* arr, int count, int size, void(*ctor)(void*), vo
 extern void* _ZTV12Flamethrower[];
 
 int* Flamethrower_Spawn(void){
-  int* p = (int*)_ZN7fBase_cnwEj(0x46c);
+  int* p = (int*)_ZN7fBase_cnwEj(sizeof(struct Flamethrower));
   if(p){
     _ZN8dActor_cC2Ev(p);
     *(void***)p = (void**)_ZTV12Flamethrower;

--- a/src/MirrorLuigi_Spawn.cpp
+++ b/src/MirrorLuigi_Spawn.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MirrorLuigi.h"
 extern "C" {
 extern void* _ZN7fBase_cnwEj(unsigned int sz);
 extern void _ZN8dActor_cC2Ev(void* c);
@@ -10,7 +11,7 @@ extern int _ZTV11MirrorLuigi[];
 extern void _ZN15TextureSequenceD1Ev(void*);
 extern void _ZN15TextureSequenceC1Ev(void*);
 void* MirrorLuigi_Spawn(void){
-  char* c = (char*)_ZN7fBase_cnwEj(0x20c);
+  char* c = (char*)_ZN7fBase_cnwEj(sizeof(struct MirrorLuigi));
   if (c) {
     _ZN8dActor_cC2Ev(c);
     *(int**)c = _ZTV11MirrorLuigi;

--- a/src/ToxBox_Spawn.c
+++ b/src/ToxBox_Spawn.c
@@ -1,3 +1,4 @@
+#include "ToxBox.h"
 extern void* _ZN7fBase_cnwEj(unsigned int size);
 extern void _ZN10dBgActor_cC2Ev(void *p);
 extern void _ZN10dBgCh_ActrC1Ev(void *p);
@@ -6,7 +7,7 @@ extern void _ZN7PathPtrC1Ev(void *p);
 extern int _ZTV6ToxBox[];
 
 int* ToxBox_Spawn(void) {
-    int *p = (int*)_ZN7fBase_cnwEj(0x594);
+    int *p = (int*)_ZN7fBase_cnwEj(sizeof(struct ToxBox));
     if (p) {
         _ZN10dBgActor_cC2Ev(p);
         *(int**)p = _ZTV6ToxBox;

--- a/src/Tree_Spawn.cpp
+++ b/src/Tree_Spawn.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "Tree.h"
 extern "C" {
 extern void* _ZN7fBase_cnwEj(unsigned int);
 extern void _ZN8dActor_cC2Ev(void*);
@@ -7,7 +8,7 @@ extern void _ZN5ModelC1Ev(void*);
 extern void func_020733a8(void* arr, int count, int size, void(*ctor)(void*), void(*dtor)(void*));
 extern void* _ZTV4Tree[];
 int* Tree_Spawn(void){
-  int* p = (int*)_ZN7fBase_cnwEj(0x264);
+  int* p = (int*)_ZN7fBase_cnwEj(sizeof(struct Tree));
   if(p){
     _ZN8dActor_cC2Ev(p);
     *(void***)p = (void**)_ZTV4Tree;

--- a/src/Unagi_Spawn.c
+++ b/src/Unagi_Spawn.c
@@ -1,3 +1,4 @@
+#include "Unagi.h"
 extern void *_ZN7fBase_cnwEj(unsigned);
 extern void _ZN12dEnemyBase_cC2Ev(void *);
 extern void _ZN10dCcAcPos_cC1Ev(void *);
@@ -9,7 +10,7 @@ extern int _ZN7Vector3D1Ev[];
 extern int func_0203d384[];
 int *Unagi_Spawn(void)
 {
-    int *p = (int *)_ZN7fBase_cnwEj(0x4b0);
+    int *p = (int *)_ZN7fBase_cnwEj(sizeof(struct Unagi));
     if (p) {
         _ZN12dEnemyBase_cC2Ev(p);
         p[0] = (int)_ZTV5Unagi;

--- a/src/Wiggler_Spawn.c
+++ b/src/Wiggler_Spawn.c
@@ -1,3 +1,4 @@
+#include "Wiggler.h"
 extern void* _ZN7fBase_cnwEj(unsigned int sz);
 extern void _ZN12dEnemyBase_cC2Ev(void *p);
 extern int func_020733a8(void *p, int a, int b, void *ctor, void *dtor);
@@ -17,7 +18,7 @@ extern int _ZN9ModelAnimD1Ev(void *p);
 extern int _ZTV7Wiggler[];
 
 void *Wiggler_Spawn(void){
-  char *c = (char *)_ZN7fBase_cnwEj(0x8e8);
+  char *c = (char *)_ZN7fBase_cnwEj(sizeof(struct Wiggler));
   if(c){
     _ZN12dEnemyBase_cC2Ev(c);
     *(int**)(c) = _ZTV7Wiggler;

--- a/src/WorkElevator_Spawn.cpp
+++ b/src/WorkElevator_Spawn.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "WorkElevator.h"
 extern "C" {
 extern void* _ZN7fBase_cnwEj(unsigned);
 extern void _ZN10dBgActor_cC2Ev(void*);
@@ -9,7 +10,7 @@ extern void _ZN5ModelC1Ev(void*);
 extern void _ZN10dBgW_KcMbgD1Ev(void*);
 extern void _ZN10dBgW_KcMbgC1Ev(void*);
 void* WorkElevator_Spawn(void){
-  char* c = (char*)_ZN7fBase_cnwEj(0xc80);
+  char* c = (char*)_ZN7fBase_cnwEj(sizeof(struct WorkElevator));
   if(c){
     _ZN10dBgActor_cC2Ev(c);
     *(int*)c = (int)_ZTV12WorkElevator;

--- a/src/actors/MadPiano/MadPiano_Spawn.cpp
+++ b/src/actors/MadPiano/MadPiano_Spawn.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "MadPiano.h"
 extern "C" {
 void* _ZN7fBase_cnwEj(unsigned int);
 void _ZN10dBgActor_cC2Ev(void*);
@@ -10,7 +11,7 @@ void _ZN10dCcAcPos_cD1Ev(void*);
 void _ZN10dBgCh_ActrC1Ev(void*);
 extern int _ZTV8MadPiano[];
 void* MadPiano_Spawn(void) {
-  char* r4 = (char*)_ZN7fBase_cnwEj(0x6e4);
+  char* r4 = (char*)_ZN7fBase_cnwEj(sizeof(struct MadPiano));
   if (r4) {
     _ZN10dBgActor_cC2Ev(r4);
     *(int*)r4 = (int)_ZTV8MadPiano;

--- a/tools/opnew_sizes.py
+++ b/tools/opnew_sizes.py
@@ -1,0 +1,1049 @@
+#!/usr/bin/env python3
+"""Class sizes read out of the ROM: the literal the cartridge hands its own `operator new`.
+
+`fBase_c::operator new(unsigned int)` -- `_ZN7fBase_cnwEj`, arm9 0x02043444 -- is this
+game's allocator, and every `new Class` in the original source compiled to a `mov r0,
+#sizeof(Class)` immediately before a `bl` to it.  That immediate is not inference: it is
+`sizeof` as the original compiler computed it, frozen in the instruction stream.  There
+are 391 such call sites in `config/**/relocs.txt`.
+
+`evidence_rom.py` (pass 3 of gen_header) recovers FIELDS from loads and stores, and is
+blind by construction to any field a class never touches -- including all the trailing
+padding a class inherits or simply never reads.  It therefore cannot see a struct's
+extent, only its occupied prefix.  This pass can see nothing but the extent.  The two
+are complements: one says where the fields are, this one says where the object ends.
+
+    python tools/opnew_sizes.py --report          # populations, then findings
+    python tools/opnew_sizes.py --gap             # ROM size vs each header's declaration
+    python tools/opnew_sizes.py --check           # fail unless the frozen census reproduces
+
+Output: build/opnew_sizes.json -- per class, its ROM size, the factories that prove it,
+the vtable it was attributed through, and whether any two sites disagree.
+
+How a site is read
+------------------
+    bl _ZN7fBase_cnwEj      r0 on entry is the size.  Constant-propagate backwards
+                            through the enclosing function to recover it.
+    ...                     r0 on return is the object.  Follow it.
+    str rV, [rObj]          rV a pool literal -> that is a vptr store.
+
+The class is then whichever RTTI record in `build/rtti.json` owns that vtable.
+
+Four traps, three of which have already cost this project landed work
+---------------------------------------------------------------------
+pair by vtable    Never by name.  PR #1556 had to retract 2 of 21 "wrong sizes" that
+                  were artifacts of pairing a class to a factory by name; if a name
+                  defect and a value defect share a table, the names are wrong first.
+                  Nothing here ever reads a symbol's spelling to decide whose size it is.
+
+take the LAST     #1559/#1560 landed 13 size corrections and then reverted 2 because the
+vptr store        pairing walked to a base.  A factory inlines its base constructors and
+                  each one stores ITS OWN vtable to [this] before the derived store; the
+                  Itanium order guarantees the derived vptr is written last.  Reading the
+                  first store makes every derived class report as its base.  Confirmed
+                  live here: `_ZN6CameraC1Ev` stores three different vtables to [r4] and
+                  only the third is Camera's.
+
+bound the scan    Commit 3f760a354 is the post-mortem.  `actor_names.parse_spawnfunc`
+                  scanned a fixed 0x50 bytes; most factories are 0x30-0x40, and the next
+                  function is almost always the FOLLOWING class's D1, which stores its
+                  own vtable in its first few instructions.  "Last store" then named the
+                  next class -- the mechanism behind the 41 misnamed classes fixed in
+                  #1418-#1423.  Every scan here is bounded by the function's own
+                  `size=` from config/**/symbols.txt and stops there.
+
+a vtable is not   The literal is `sizeof` of the class actually being newed; the vptr names
+the class        the most-derived class that HAS a vtable.  Those are the same class unless
+                  a subclass adds no virtual of its own and overrides none, in which case
+                  mwccarm gives it no vtable and its constructor leaves the base's vptr in
+                  place -- so its size is filed against the base.  Exactly one site in this
+                  ROM does it: `StarCamera_Spawn` (ov002 0x020ebe68) allocates 0xd4, calls
+                  `dActor_c::dActor_c` and stores nothing further, so `dActor_c` reads as
+                  0xd4.  It is 0xd0: 120 classes in this tree inherit dActor_c and every one
+                  of them agrees with its own ROM size at 0xd0, which they could not do if
+                  the base were four bytes longer.  `gap` therefore refuses to call a class
+                  with agreeing descendants SHORT -- it buckets it BASE, NOT SHORT.  Treat
+                  the ROM size as an upper bound for any class that is somebody's base, and
+                  as exact for a leaf.
+
+raw images, not   `extracted/dsd/arm9_overlays/*.bin` are dsd's DELINKED images: every
+delinked ones     relocated word is a placeholder, and a vtable pool literal is nothing
+                  but a relocation.  Read through those and every overlay factory reports
+                  NOVTABLE.  The ROM's linked bytes are `extracted/overlays/*.bin`; only
+                  the base addresses come from the dsd yaml.  Same rule as
+                  `rtti_extract.py` and `actor_names.py`.
+
+Requires capstone and pyyaml, like `evidence_rom.py`.  Deterministic: every collection is
+sorted before it is emitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import collections
+import json
+import os
+import pathlib
+import re
+import struct
+import sys
+
+try:
+    from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM
+    from capstone.arm import (
+        ARM_CC_AL, ARM_CC_INVALID, ARM_GRP_JUMP,
+        ARM_INS_ADD, ARM_INS_AND, ARM_INS_BIC, ARM_INS_BL, ARM_INS_BLX, ARM_INS_CMN,
+        ARM_INS_CMP, ARM_INS_EOR, ARM_INS_LDM, ARM_INS_LDR, ARM_INS_MOV, ARM_INS_MVN,
+        ARM_INS_ORR, ARM_INS_POP, ARM_INS_RSB, ARM_INS_STM, ARM_INS_STR, ARM_INS_STRB,
+        ARM_INS_STRD, ARM_INS_STRH, ARM_INS_SUB, ARM_INS_TEQ, ARM_INS_TST,
+        ARM_OP_IMM, ARM_OP_MEM, ARM_OP_REG, ARM_SFT_INVALID,
+    )
+except ImportError:                                                    # pragma: no cover
+    sys.exit("capstone not installed. Run: pip install capstone")
+try:
+    import yaml
+except ImportError:                                                    # pragma: no cover
+    sys.exit("pyyaml not installed. Run: pip install pyyaml")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+ARM9_BASE = 0x02004000
+OPERATOR_NEW = 0x02043444          # _ZN7fBase_cnwEj
+OPERATOR_NEW_SYM = "_ZN7fBase_cnwEj"
+
+# How deep to follow `bl <ctor>` looking for the vptr store the factory did not inline.
+# Two levels covers factory -> ctor -> base ctor; deeper has never added a class and a
+# cycle would otherwise not terminate.
+MAX_CTOR_DEPTH = 3
+
+SYM_FN = re.compile(
+    r"^(\S+)\s+kind:function\(arm,size=(0x[0-9a-fA-F]+)\)\s+addr:(0x[0-9a-fA-F]+)")
+SYM_ANY = re.compile(r"^(\S+)\s+kind:\S+\s+addr:(0x[0-9a-fA-F]+)")
+RELOC = re.compile(r"^from:0x([0-9a-fA-F]+)\s+kind:(\S+)\s+to:0x([0-9a-fA-F]+)")
+LEN_PREFIX = re.compile(r"(\d+)")
+
+# `typedef char Foo_size_must_be_0x330[sizeof(Foo) == 0x330 ? 1 : -1];` -- the tree's
+# convention, 307 headers carry one and nothing here uses static_assert.
+SIZE_ASSERT = re.compile(
+    r"^[ \t]*typedef[ \t]+char[ \t]+(\w+)_size_must_be_0x([0-9a-fA-F]+)\s*\[",
+    re.M)
+
+NAMED_REG = {"sb": 9, "sl": 10, "fp": 11, "ip": 12, "sp": 13, "lr": 14, "pc": 15}
+
+# Instructions whose first operand is a source, not a destination.
+NO_DEST = {ARM_INS_STR, ARM_INS_STRB, ARM_INS_STRH, ARM_INS_STRD, ARM_INS_STM,
+           ARM_INS_CMP, ARM_INS_CMN, ARM_INS_TST, ARM_INS_TEQ}
+
+
+# --------------------------------------------------------------------------
+# modules
+# --------------------------------------------------------------------------
+
+def find_extracted(root):
+    """Locate extracted/, which is gitignored and so absent from a fresh worktree.
+
+    Same search order as evidence_rom.find_extracted: the worktree, this file's own
+    repo, $SM64DS_EXTRACTED, then the shared .git parent a linked worktree points at.
+    Never a hardcoded developer path.
+    """
+    import subprocess
+    cands = [root / "extracted", REPO / "extracted"]
+    env = os.environ.get("SM64DS_EXTRACTED")
+    if env:
+        cands.append(pathlib.Path(env))
+    try:
+        r = subprocess.run(["git", "rev-parse", "--path-format=absolute",
+                            "--git-common-dir"], cwd=str(root), capture_output=True,
+                           text=True, timeout=10)
+        if r.returncode == 0 and r.stdout.strip():
+            cands.append(pathlib.Path(r.stdout.strip()).parent / "extracted")
+    except (OSError, subprocess.SubprocessError):                      # pragma: no cover
+        pass
+    for c in cands:
+        if (c / "dsd/arm9_overlays/overlays.yaml").exists():
+            return c
+    sys.exit("could not locate extracted/ -- set SM64DS_EXTRACTED or pass --extracted")
+
+
+def coerce_addr(v):
+    """overlays.yaml gives hex strings for some overlays and ints for others."""
+    return v if isinstance(v, int) else int(str(v), 16)
+
+
+def load_modules(ext, stats):
+    """name -> (base, bytes).  Raw linked images; see the module docstring."""
+    arm9 = (ext / "arm9_dec.bin").read_bytes()
+    # arm9_dec.bin is the DECOMPRESSED arm9 at 0x02004000. extracted/dsd/arm9/arm9.bin
+    # is the compressed payload and is garbage past its uncompressed prefix; the anchor
+    # below is the same one actor_names.py asserts (Copy36Bytes).
+    if arm9[0x0205A548 - ARM9_BASE:0x0205A54C - ARM9_BASE] == b"\0\0\0\0":
+        sys.exit("arm9_dec.bin failed the known-code anchor (Copy36Bytes)")
+    mods = {"arm9": (ARM9_BASE, arm9)}
+    cfg = yaml.safe_load((ext / "dsd/arm9_overlays/overlays.yaml").read_text())
+    for o in cfg["overlays"]:
+        p = ext / "overlays" / ("overlay_%04d.bin" % o["id"])
+        if p.is_file():
+            mods["ov%03d" % o["id"]] = (coerce_addr(o["base_address"]), p.read_bytes())
+        else:
+            stats["overlay_images_missing"] += 1
+    stats["modules_loaded"] = len(mods)
+    return mods
+
+
+def load_symbols(root, mods, stats):
+    """module -> sorted [(addr, size, name)] of every function symbol."""
+    out = {}
+    paths = [("arm9", root / "config" / "arm9" / "symbols.txt")]
+    for d in sorted((root / "config" / "arm9" / "overlays").glob("ov*")):
+        paths.append((d.name, d / "symbols.txt"))
+    for mod, p in paths:
+        if mod not in mods or not p.is_file():
+            continue
+        fns = []
+        for line in p.read_text(errors="replace").splitlines():
+            m = SYM_FN.match(line)
+            if m:
+                fns.append((int(m.group(3), 16), int(m.group(2), 16), m.group(1)))
+        fns.sort()
+        out[mod] = fns
+        stats["function_symbols"] += len(fns)
+    stats["modules_with_symbols"] = len(out)
+    return out
+
+
+def load_vtable_symbols(root, mods, stats):
+    """(module, addr) -> the tree's own name for the class whose vtable sits there.
+
+    The cartridge's RTTI name and this tree's name for the same class are often
+    different -- `_ZTV6Camera` and `dCamera_c` are one class -- because most of the
+    English names predate the RTTI pass and have not been renamed yet.  A header can
+    only be found under the name the tree uses, so both are carried.
+
+    This is still a VTABLE-ADDRESS join, not a name join: the address decides which
+    symbol is read, and the symbol only supplies the spelling.  Pairing a class to a
+    factory by name is what PR #1556 had to retract 2 of 21 findings for.
+    """
+    out = {}
+    paths = [("arm9", root / "config" / "arm9" / "symbols.txt")]
+    for d in sorted((root / "config" / "arm9" / "overlays").glob("ov*")):
+        paths.append((d.name, d / "symbols.txt"))
+    for mod, p in paths:
+        if mod not in mods or not p.is_file():
+            continue
+        for line in p.read_text(errors="replace").splitlines():
+            if not line.startswith("_ZTV"):
+                continue
+            m = SYM_ANY.match(line)
+            if m:
+                out[(mod, int(m.group(2), 16))] = m.group(1)
+    stats["vtable_symbols_named_in_config"] = len(out)
+    return out
+
+
+def demangle_ztv(sym):
+    """`_ZTV6Camera` -> Camera;  `_ZTVN8dGraph_c10callback_cE` -> dGraph_c__callback_c.
+
+    Nested names are joined with `__`, matching how this tree names their headers
+    (`include/ActorBase__SceneNode.h`) -- the same convention evidence_rom.class_of uses.
+    """
+    if not sym.startswith("_ZTV"):
+        return None
+    body = sym[4:]
+    if body.startswith("N") and body.endswith("E"):
+        body = body[1:-1]
+    parts, i = [], 0
+    while i < len(body):
+        m = LEN_PREFIX.match(body, i)
+        if not m:
+            return None
+        n = int(m.group(1))
+        i = m.end()
+        if n == 0 or i + n > len(body):
+            return None
+        parts.append(body[i:i + n])
+        i += n
+    return "__".join(parts) if parts else None
+
+
+def load_call_sites(root, mods, stats):
+    """Every `bl` to operator new, as sorted (module, from_addr).
+
+    The reloc's module is the one whose relocs.txt records it -- `from:` addresses are
+    that module's own.  `to:` is a bare address, which is only unambiguous here because
+    the callee is in arm9, always resident.
+    """
+    sites = []
+    paths = [("arm9", root / "config" / "arm9" / "relocs.txt")]
+    for d in sorted((root / "config" / "arm9" / "overlays").glob("ov*")):
+        paths.append((d.name, d / "relocs.txt"))
+    for mod, p in paths:
+        if not p.is_file():
+            continue
+        if mod not in mods:
+            stats["sites_in_a_module_with_no_image"] += 1
+            continue
+        for line in p.read_text(errors="replace").splitlines():
+            m = RELOC.match(line)
+            if not m or int(m.group(3), 16) != OPERATOR_NEW:
+                continue
+            if m.group(2) != "arm_call":
+                stats["sites_not_arm_call"] += 1
+                continue
+            sites.append((mod, int(m.group(1), 16)))
+    sites.sort()
+    stats["call_sites"] = len(sites)
+    return sites
+
+
+# --------------------------------------------------------------------------
+# a very small ARM abstract interpreter
+# --------------------------------------------------------------------------
+
+def reg_num(name):
+    if not name:
+        return -1
+    if re.fullmatch(r"r\d+", name):
+        return int(name[1:])
+    return NAMED_REG.get(name, -1)
+
+
+class Image:
+    """The bytes of every module, and a cached disassembly per function."""
+
+    def __init__(self, mods, syms):
+        self.mods = mods
+        self.syms = syms
+        self.md = Cs(CS_ARCH_ARM, CS_MODE_ARM)
+        self.md.detail = True
+        self._dis = {}
+
+    def word(self, mod, va):
+        """A word at a virtual address: the module's own image, else always-resident arm9."""
+        for m in (mod, "arm9"):
+            ent = self.mods.get(m)
+            if not ent:
+                continue
+            base, blob = ent
+            o = va - base
+            if 0 <= o <= len(blob) - 4:
+                return struct.unpack_from("<I", blob, o)[0]
+        return None
+
+    def enclosing(self, mod, addr):
+        """(start, size, name) of the function containing addr, or None.
+
+        This is the ONLY thing that bounds a scan.  See trap 3 in the module docstring:
+        a window that is not the function's own runs into the next class's destructor.
+        """
+        lst = self.syms.get(mod, ())
+        i = bisect.bisect_right(lst, (addr, 1 << 62, "￿")) - 1
+        if i < 0:
+            return None
+        a, s, n = lst[i]
+        return (a, s, n) if a <= addr < a + s else None
+
+    def disasm(self, mod, start, size):
+        key = (mod, start)
+        if key not in self._dis:
+            base, blob = self.mods[mod]
+            o = start - base
+            if o < 0 or o + size > len(blob):
+                self._dis[key] = []
+            else:
+                self._dis[key] = list(self.md.disasm(blob[o:o + size], start))
+        return self._dis[key]
+
+
+class State:
+    """Registers that provably hold a known constant, and those that hold the object."""
+
+    __slots__ = ("const", "obj")
+
+    def __init__(self, obj=()):
+        self.const = {}
+        self.obj = set(obj)
+
+    def kill(self, r):
+        self.const.pop(r, None)
+        self.obj.discard(r)
+
+    def clobber_call(self):
+        """AAPCS: r0-r3 and r12 are call-clobbered; r4-r11 survive."""
+        for r in (0, 1, 2, 3, 12, 14):
+            self.kill(r)
+        self.const = {k: v for k, v in self.const.items() if 4 <= k <= 11}
+
+
+def _dest_regs(ins):
+    if ins.id in NO_DEST or not ins.operands:
+        return []
+    if ins.id in (ARM_INS_POP, ARM_INS_LDM):
+        return [reg_num(ins.reg_name(o.reg)) for o in ins.operands
+                if o.type == ARM_OP_REG]
+    o = ins.operands[0]
+    return [reg_num(ins.reg_name(o.reg))] if o.type == ARM_OP_REG else []
+
+
+def _evaluate(img, mod, ins, st):
+    """(new_const|None, propagates_object) for this instruction's destination."""
+    ops = ins.operands
+    if ins.id == ARM_INS_MOV and len(ops) == 2:
+        if ops[1].type == ARM_OP_IMM:
+            return ops[1].imm & 0xFFFFFFFF, False
+        if ops[1].type == ARM_OP_REG and ops[1].shift.type == ARM_SFT_INVALID:
+            s = reg_num(ins.reg_name(ops[1].reg))
+            return st.const.get(s), s in st.obj
+    if ins.id == ARM_INS_MVN and len(ops) == 2 and ops[1].type == ARM_OP_IMM:
+        return (~ops[1].imm) & 0xFFFFFFFF, False
+    if ins.id == ARM_INS_LDR and len(ops) == 2 and ops[1].type == ARM_OP_MEM:
+        m = ops[1].mem
+        # A pc-relative load is a literal-pool read: the value is in the image.
+        if ins.reg_name(m.base) == "pc" and m.index == 0:
+            return img.word(mod, ins.address + 8 + m.disp), False
+        return None, False
+    if ins.id in (ARM_INS_ADD, ARM_INS_SUB) and len(ops) == 3 and \
+            ops[1].type == ARM_OP_REG and ops[2].type == ARM_OP_IMM:
+        s = reg_num(ins.reg_name(ops[1].reg))
+        v = st.const.get(s)
+        if v is not None:
+            v = (v + ops[2].imm if ins.id == ARM_INS_ADD else v - ops[2].imm) & 0xFFFFFFFF
+        # `subs rD, rObj, #0` is mwcc's copy-and-null-test; the pointer survives it.
+        # `add rD, rObj, #n` is a SUBOBJECT and must not: a member's constructor stores
+        # its own vtable to [this+n], and treating that as the object's vptr is how a
+        # class ends up wearing a member's identity.
+        return v, (ins.id == ARM_INS_SUB and ops[2].imm == 0 and s in st.obj)
+    if ins.id in (ARM_INS_ORR, ARM_INS_AND, ARM_INS_EOR, ARM_INS_BIC, ARM_INS_RSB) and \
+            len(ops) == 3 and ops[1].type == ARM_OP_REG and ops[2].type == ARM_OP_IMM:
+        s = st.const.get(reg_num(ins.reg_name(ops[1].reg)))
+        if s is None:
+            return None, False
+        i = ops[2].imm
+        v = {ARM_INS_ORR: s | i, ARM_INS_AND: s & i, ARM_INS_EOR: s ^ i,
+             ARM_INS_BIC: s & ~i, ARM_INS_RSB: i - s}[ins.id]
+        return v & 0xFFFFFFFF, False
+    return None, False
+
+
+def _step(img, mod, ins, st):
+    """Apply one instruction to the state.  Unmodelled writes invalidate."""
+    conditional = ins.cc not in (ARM_CC_AL, ARM_CC_INVALID)
+    val, is_obj = _evaluate(img, mod, ins, st)
+    for d in _dest_regs(ins):
+        if d < 0:
+            continue
+        if conditional:
+            # The write may not have happened; neither the old nor the new value is known.
+            st.kill(d)
+            continue
+        st.kill(d)
+        if val is not None:
+            st.const[d] = val
+        if is_obj:
+            st.obj.add(d)
+    # writeback forms (`ldr rD, [rB, #n]!`, `stm rB!, {...}`) also change the base
+    if ins.writeback:
+        for o in ins.operands:
+            if o.type == ARM_OP_MEM and o.mem.base:
+                st.kill(reg_num(ins.reg_name(o.mem.base)))
+
+
+def _vptr_store(ins, st):
+    """The literal a `str rV, [rObj]` writes to offset 0, or None.
+
+    Offset 0 only.  A store to [rObj, #n] is a member subobject's vptr, not this
+    object's, and admitting one would attribute the class to whatever it contains.
+    """
+    ops = ins.operands
+    if ins.id != ARM_INS_STR or len(ops) != 2 or ops[1].type != ARM_OP_MEM:
+        return None
+    m = ops[1].mem
+    if m.index != 0 or m.disp != 0 or ins.writeback:
+        return None
+    if reg_num(ins.reg_name(m.base)) not in st.obj:
+        return None
+    if ops[0].type != ARM_OP_REG:
+        return None
+    return st.const.get(reg_num(ins.reg_name(ops[0].reg)))
+
+
+def _branch_targets(inss):
+    t = set()
+    for ins in inss:
+        if ins.group(ARM_GRP_JUMP) and ins.operands and \
+                ins.operands[-1].type == ARM_OP_IMM:
+            t.add(ins.operands[-1].imm)
+    return t
+
+
+def _walk(img, mod, start, size, st, callsite, stats, depth, seen):
+    """Linear sweep of one function; returns the ordered vptr evidence it produced.
+
+    Each element is ('store', addr, vtable) or ('call', addr, callee) -- a call made
+    with the object in r0, i.e. a constructor that may install the vptr itself.  The
+    caller takes the LAST, which is the derived-most: see trap 2.
+    """
+    inss = img.disasm(mod, start, size)
+    if not inss:
+        stats["functions_that_would_not_disassemble"] += 1
+        return []
+    targets = _branch_targets(inss)
+    events = []
+    armed = callsite is None            # None => r0 is `this` on entry (a ctor)
+    for ins in inss:
+        if ins.address in targets:
+            # A join: another path reaches here, so no constant is provable any more.
+            # The object pointer itself is kept -- it lives in a callee-saved register
+            # across the null test every one of these factories performs, and dropping
+            # it here loses the vptr store on the taken path.
+            st.const.clear()
+        if callsite is not None and ins.address == callsite:
+            # r0 in  = the size; r0 out = the object.
+            st.const.clear()
+            st.obj = {0}
+            armed = True
+            continue
+        if ins.id in (ARM_INS_BL, ARM_INS_BLX):
+            if armed and 0 in st.obj and ins.operands and \
+                    ins.operands[0].type == ARM_OP_IMM:
+                events.append(("call", ins.address, ins.operands[0].imm))
+            st.clobber_call()
+            continue
+        if armed:
+            v = _vptr_store(ins, st)
+            if v:
+                events.append(("store", ins.address, v))
+                continue
+        _step(img, mod, ins, st)
+    return events
+
+
+def resolve_vptr(img, mod, events, stats, depth=0, seen=None):
+    """The class's own vtable: the LAST piece of evidence, followed into a ctor if need be.
+
+    Returns (vtable, how, via) or (None, reason, None).
+    """
+    seen = seen if seen is not None else set()
+    for kind, _addr, val in reversed(events):
+        if kind == "store":
+            return val, "inline_store", None
+        if depth >= MAX_CTOR_DEPTH:
+            stats["ctor_chains_deeper_than_the_limit"] += 1
+            continue
+        # A call made with the object in r0: a constructor. Read its own last store.
+        for m in (mod, "arm9"):
+            e = img.enclosing(m, val)
+            if e is None or e[0] != val:
+                continue
+            if (m, val) in seen:
+                break
+            seen.add((m, val))
+            sub = _walk(img, m, e[0], e[1], State(obj={0}), None, stats, depth + 1, seen)
+            vt, how, via = resolve_vptr(img, m, sub, stats, depth + 1, seen)
+            if vt:
+                return vt, "ctor_" + how, "%s:%s" % (m, e[2])
+            break
+    return None, "no_vptr_store_found", None
+
+
+# --------------------------------------------------------------------------
+# joining to RTTI
+# --------------------------------------------------------------------------
+
+def load_rtti(root, stats):
+    """(vtable address -> [(module, class name)], class -> set of ancestor classes).
+
+    An address alone is not an identity in this ROM -- overlays share address space and
+    two addresses host two different classes each.  Resolution keeps (module, addr).
+    The ancestor closure exists only to audit this file's central assumption; see
+    `audit_derived_most`.
+    """
+    p = root / "build" / "rtti.json"
+    if not p.is_file():
+        sys.exit("build/rtti.json absent -- run tools/rtti_extract.py first")
+    doc = json.loads(p.read_text(encoding="utf-8"))
+    by_addr = collections.defaultdict(list)
+    for rec in doc["records"].values():
+        if rec.get("vtable"):
+            by_addr[int(rec["vtable"], 16)].append((rec["vtable_module"], rec["name"]))
+    direct = collections.defaultdict(set)
+    for e in doc["edges"]:
+        direct[e["derived"]].add(e["base"])
+    anc = {}
+
+    def ancestors(n, seen=None):
+        if n in anc:
+            return anc[n]
+        seen = seen or set()
+        if n in seen:
+            return set()
+        seen = seen | {n}
+        out = set()
+        for b in direct.get(n, ()):
+            out.add(b)
+            out |= ancestors(b, seen)
+        anc[n] = out
+        return out
+
+    for n in list(direct):
+        ancestors(n)
+    stats["rtti_records"] = len(doc["records"])
+    stats["rtti_vtable_addresses"] = len(by_addr)
+    return by_addr, anc
+
+
+def class_for_vtable(by_addr, mod, vt, stats):
+    """(name, how) or (None, why).  Own module, then arm9, then residency, then give up."""
+    cands = sorted(set(by_addr.get(vt, ())))
+    if not cands:
+        stats["vtables_with_no_rtti_record"] += 1
+        return None, "no_rtti_record_at_vtable"
+    own = [c for c in cands if c[0] == mod]
+    if len(own) == 1:
+        return own[0][1], "own_module"
+    a9 = [c for c in cands if c[0] == "arm9"]
+    if len(a9) == 1:
+        return a9[0][1], "arm9"
+    if len(cands) == 1:
+        return cands[0][1], "unique"
+    try:
+        sys.path.insert(0, str(REPO / "tools"))
+        import overlay_residency as RES
+        left = [c for c in cands if RES.possible(c[0], mod)]
+    except Exception:                                                  # noqa: BLE001
+        left = cands
+    if len(left) == 1:
+        return left[0][1], "residency"
+    stats["vtables_ambiguous_across_modules"] += 1
+    return None, "ambiguous:" + ",".join("%s/%s" % c for c in cands)
+
+
+# --------------------------------------------------------------------------
+# build
+# --------------------------------------------------------------------------
+
+def audit_derived_most(by_addr, anc, mod, chosen, events, stats, warnings):
+    """Prove, per site, that the LAST vptr store really was the derived-most one.
+
+    This file's whole attribution rests on the Itanium ordering: base constructors run
+    first and each writes its own vtable, so the derived class's vptr is written last.
+    #1559/#1560 landed 13 size corrections on that rule and had to revert 2, so it is
+    asserted rather than assumed.  Every OTHER vtable the factory stored to [this] must
+    name a class that `chosen` derives from.  If `chosen` turns out to be an ANCESTOR of
+    something else stored, the rule read the wrong store and the site is a finding.
+    """
+    others = set()
+    for kind, _a, val in events:
+        if kind != "store":
+            continue
+        name, _ = class_for_vtable(by_addr, mod, val, collections.Counter())
+        if name:
+            others.add(name)
+    others.discard(chosen)
+    if not others:
+        return
+    for o in sorted(others):
+        if o in anc.get(chosen, ()):
+            stats["cross_check_other_store_is_a_base_as_expected"] += 1
+        elif chosen in anc.get(o, ()):
+            stats["CROSS_CHECK_FAIL_chose_a_base_over_a_derived"] += 1
+            warnings.append("%s: chose %s but %s (a derived class) was also stored"
+                            % (mod, chosen, o))
+        else:
+            stats["cross_check_other_store_unrelated"] += 1
+            warnings.append("%s: chose %s; also stored unrelated %s" % (mod, chosen, o))
+
+
+def build(root, ext):
+    stats = collections.Counter()
+    mods = load_modules(ext, stats)
+    syms = load_symbols(root, mods, stats)
+    sites = load_call_sites(root, mods, stats)
+    by_addr, anc = load_rtti(root, stats)
+    vtsyms = load_vtable_symbols(root, mods, stats)
+    img = Image(mods, syms)
+
+    def tree_class(mod, vt):
+        for m in (mod, "arm9"):
+            s = vtsyms.get((m, vt))
+            if s:
+                return demangle_ztv(s)
+        return None
+
+    records, warnings = [], []
+    for mod, site in sites:
+        enc = img.enclosing(mod, site)
+        if enc is None:
+            stats["sites_with_no_enclosing_function"] += 1
+            records.append({"module": mod, "site": "0x%08x" % site, "factory": None,
+                            "factory_addr": None, "size": None,
+                            "size_confidence": "no_enclosing_function",
+                            "vtable": None, "attribution": "no_enclosing_function",
+                            "via": None, "class": None})
+            continue
+        fa, fs, fn = enc
+        events = _walk(img, mod, fa, fs, State(), site, stats, 0, set())
+        size, size_conf = read_size(img, mod, fa, fs, site, stats)
+        vt, how, via = resolve_vptr(img, mod, events, stats)
+        cls, cls_how = None, how
+        if vt:
+            cls, cls_how = class_for_vtable(by_addr, mod, vt, stats)
+        if cls:
+            audit_derived_most(by_addr, anc, mod, cls, events, stats, warnings)
+        tcls = tree_class(mod, vt) if vt else None
+        if vt:
+            stats["vtables_the_tree_has_not_named" if not tcls
+                  else "vtables_named_by_the_tree"] += 1
+            if tcls and cls and tcls != cls:
+                stats["classes_the_tree_spells_differently_from_the_rtti"] += 1
+        records.append({
+            "module": mod, "site": "0x%08x" % site, "factory": fn,
+            "factory_addr": "0x%08x" % fa, "factory_size": "0x%x" % fs,
+            "size": size, "size_confidence": size_conf,
+            "vtable": ("0x%08x" % vt) if vt else None,
+            "attribution": how, "resolved_by": cls_how if vt else None,
+            "via": via, "class": cls, "tree_class": tcls,
+        })
+        stats["size_" + size_conf] += 1
+        stats["attribution_" + (cls_how if vt else how)] += 1
+
+    # ---- fold to classes, keyed on the name the TREE uses (the one a header carries),
+    # falling back to the RTTI name where the tree has not named the vtable yet.
+    per = collections.defaultdict(list)
+    for r in records:
+        key = r["tree_class"] or r["class"]
+        if key and r["size"] is not None:
+            per[key].append(r)
+    classes = {}
+    for name, rs in sorted(per.items()):
+        sizes = sorted({r["size"] for r in rs})
+        classes[name] = {
+            "size": sizes[0] if len(sizes) == 1 else None,
+            "size_hex": ("0x%x" % sizes[0]) if len(sizes) == 1 else None,
+            "ambiguous": len(sizes) > 1,
+            "sizes_seen": ["0x%x" % s for s in sizes],
+            "rtti_name": sorted({r["class"] for r in rs if r["class"]}),
+            "named_by_the_tree": bool(rs[0]["tree_class"]),
+            "sites": len(rs),
+            "confidence": ("inline_store" if any(r["attribution"] == "inline_store"
+                                                 for r in rs) else "via_constructor"),
+            "factories": sorted({"%s:%s" % (r["module"], r["factory"]) for r in rs}),
+            "vtables": sorted({r["vtable"] for r in rs if r["vtable"]}),
+        }
+        stats["classes_ambiguous" if len(sizes) > 1 else "classes_unambiguous"] += 1
+    stats["classes_total"] = len(classes)
+    stats["sites_attributed"] = sum(1 for r in records if r["class"])
+    stats["sites_unattributed"] = len(records) - stats["sites_attributed"]
+
+    return {
+        "meta": {
+            "operator_new": {"symbol": OPERATOR_NEW_SYM,
+                             "addr": "0x%08x" % OPERATOR_NEW},
+            "source": "config/**/relocs.txt + extracted/arm9_dec.bin + "
+                      "extracted/overlays/*.bin + build/rtti.json",
+            "stats": dict(sorted(stats.items())),
+        },
+        "classes": classes,
+        "sites": records,
+        "cross_check_warnings": sorted(set(warnings)),
+    }
+
+
+def read_size(img, mod, fa, fs, site, stats):
+    """r0 at the `bl`, constant-propagated from the top of the enclosing function."""
+    inss = img.disasm(mod, fa, fs)
+    targets = _branch_targets(inss)
+    st = State()
+    for ins in inss:
+        if ins.address in targets:
+            st.const.clear()
+        if ins.address == site:
+            v = st.const.get(0)
+            return (v, "exact") if v is not None else (None, "not_a_constant")
+        if ins.id in (ARM_INS_BL, ARM_INS_BLX):
+            st.clobber_call()
+            continue
+        _step(img, mod, ins, st)
+    return None, "call_site_not_in_function"
+
+
+# --------------------------------------------------------------------------
+# gap report: ROM size vs the headers
+# --------------------------------------------------------------------------
+
+DEFINITION = re.compile(r"^[ \t]*(?:class|struct)[ \t]+(\w+)[ \t]*(?::[^;{]*)?\{", re.M)
+
+
+def header_sizes(root):
+    """class -> {"assert": size|None, "header": path|None}, over every include/**/*.h.
+
+    Only the size assert is read for the declared extent.  A header's real extent is
+    whatever the compiler makes of it and cannot be recovered by regex -- but the assert
+    IS the tree's statement of that extent, and it is compiler-checked on every build,
+    so where one exists it is exactly as authoritative and is the thing an edit changes.
+    A class with a definition but no assert is reported as its own bucket rather than
+    guessed at.
+    """
+    out = {}
+    for h in sorted((root / "include").rglob("*.h")):
+        txt = h.read_text(errors="replace")
+        for m in DEFINITION.finditer(txt):
+            out.setdefault(m.group(1), {"assert": None, "header": h})
+        for m in SIZE_ASSERT.finditer(txt):
+            e = out.setdefault(m.group(1), {"assert": None, "header": h})
+            if e["assert"] is None:
+                e["assert"] = int(m.group(2), 16)
+                e["header"] = h
+    return out
+
+
+BUCKETS = ("AGREES", "HEADER SHORT", "HEADER LONG", "BASE, NOT SHORT", "NO SIZE",
+           "NO HEADER", "AMBIGUOUS")
+
+INHERITS = re.compile(r"^[ \t]*(?:class|struct)[ \t]+(\w+)[ \t]*:([^{;]+)\{", re.M)
+ACCESS = {"public", "protected", "private", "virtual"}
+
+
+def subclass_index(root):
+    """class -> every class in include/ that transitively derives from it."""
+    bases = collections.defaultdict(set)
+    for h in sorted((root / "include").rglob("*.h")):
+        for m in INHERITS.finditer(h.read_text(errors="replace")):
+            for b in re.findall(r"[A-Za-z_]\w*", m.group(2)):
+                if b not in ACCESS:
+                    bases[m.group(1)].add(b)
+    kids = collections.defaultdict(set)
+    for d, bs in bases.items():
+        for b in bs:
+            kids[b].add(d)
+    out = {}
+    for b in list(kids):
+        seen, stack = set(), list(kids[b])
+        while stack:
+            n = stack.pop()
+            if n in seen:
+                continue
+            seen.add(n)
+            stack.extend(kids.get(n, ()))
+        out[b] = seen
+    return out
+
+PROBE_SRC = '#include "%s"\nchar opnew_probe[sizeof(%s)];\n'
+
+
+def probe_one(exe, flags, include, tmp, cls, header):
+    """`sizeof(cls)` as the build's own compiler computes it, or (None, why).
+
+    A regex cannot measure a header.  Half of these classes are flat shadow structs
+    with no size assert at all, and the ones that do carry an assert only restate a
+    number a human typed.  This asks mwccarm: declare `char opnew_probe[sizeof(X)]`
+    and read the symbol's st_size back out of the object.  One compile, exact answer,
+    and it accounts for base classes, alignment and the vptr the same way the ROM build
+    does because it IS the ROM build's compiler and flags.
+    """
+    import subprocess
+    from elftools.elf.elffile import ELFFile
+    src = tmp / ("probe_%s.cpp" % re.sub(r"\W", "_", cls))
+    obj = src.with_suffix(".o")
+    for spelling in (cls, "struct " + cls):
+        src.write_text(PROBE_SRC % (header, spelling), encoding="utf-8")
+        r = subprocess.run([str(exe), *flags.split(), "-i", str(include),
+                            "-c", str(src), "-o", str(obj)],
+                           capture_output=True, text=True, timeout=180)
+        if r.returncode == 0 and obj.is_file():
+            with open(obj, "rb") as fh:
+                st = ELFFile(fh).get_section_by_name(".symtab")
+                for s in st.iter_symbols():
+                    if s.name == "opnew_probe":
+                        return s["st_size"], None
+            return None, "probe symbol absent"
+    msg = (r.stderr or r.stdout or "").strip().splitlines()
+    return None, (msg[0][:120] if msg else "compile failed")
+
+
+def probe_sizes(root, wanted, stats):
+    """{class: (size|None, why)} measured by the compiler, over `wanted` (cls -> header)."""
+    import concurrent.futures
+    import tempfile
+    sys.path.insert(0, str(root / "tools"))
+    try:
+        from rombuild import CFLAGS, MW, VERSION
+    except Exception as exc:                                           # noqa: BLE001
+        stats["probe_unavailable"] = 1
+        return {}, "rombuild unimportable: %s" % exc
+    import importlib.util
+    if importlib.util.find_spec("elftools") is None:
+        stats["probe_unavailable"] = 1
+        return {}, "pyelftools not installed"
+    exe = MW / VERSION / "mwccarm.exe"
+    if not exe.is_file():
+        stats["probe_unavailable"] = 1
+        return {}, "mwccarm %s not installed" % VERSION
+    # The build's own flags, in C++ mode: a class with a base or a vtable has no size
+    # in C, and `-lang c99` would silently measure the shadow struct instead.
+    flags = CFLAGS.replace("-lang c99", "-lang c++")
+    out = {}
+    with tempfile.TemporaryDirectory(prefix="opnew-probe-") as td:
+        tmp = pathlib.Path(td)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            futs = {pool.submit(probe_one, exe, flags, root / "include", tmp,
+                                cls, hdr): cls for cls, hdr in sorted(wanted.items())}
+            for f in concurrent.futures.as_completed(futs):
+                cls = futs[f]
+                try:
+                    out[cls] = f.result()
+                except Exception as exc:                               # noqa: BLE001
+                    out[cls] = (None, "probe raised: %s" % exc)
+    stats["probe_measured"] = sum(1 for v in out.values() if v[0] is not None)
+    stats["probe_would_not_compile"] = sum(1 for v in out.values() if v[0] is None)
+    return out, None
+
+
+def gap(root, doc, probe=True):
+    """Bucket every unambiguously-sized class against the tree's own declaration.
+
+    The declared size is the compiler's answer where the probe can build, and the size
+    assert only where it cannot -- the assert is a human's claim, `sizeof` is the fact.
+    A header with neither is NO SIZE: unmeasured, never guessed at.
+    """
+    hdr = header_sizes(root)
+    stats = collections.Counter()
+    measured, why = ({}, "probe disabled")
+    if probe:
+        wanted = {n: hdr[n]["header"].name for n in doc["classes"] if n in hdr}
+        measured, why = probe_sizes(root, wanted, stats)
+    kids = subclass_index(root)
+
+    def agreeing_descendants(name):
+        """Descendants whose own declared size already matches their own ROM size.
+
+        One of those is proof the base is NOT short: growing it moves every one of them.
+        See the fifth trap in the module docstring -- this is what dActor_c is."""
+        out = []
+        for k in sorted(kids.get(name, ())):
+            c = doc["classes"].get(k)
+            if not c or c["ambiguous"]:
+                continue
+            d = measured.get(k, (None, None))[0]
+            if d is None and k in hdr:
+                d = hdr[k]["assert"]
+            if d is not None and d == c["size"]:
+                out.append(k)
+        return out
+
+    buckets = collections.defaultdict(list)
+    for name, c in sorted(doc["classes"].items()):
+        if c["ambiguous"]:
+            buckets["AMBIGUOUS"].append((name, None, c["sizes_seen"], None, "-"))
+            continue
+        rom = c["size"]
+        e = hdr.get(name)
+        if e is None:
+            buckets["NO HEADER"].append((name, None, rom, None, "-"))
+            continue
+        path = str(e["header"].relative_to(root)).replace("\\", "/")
+        dec, how = measured.get(name, (None, None))
+        how = "sizeof"
+        if dec is None:
+            dec, how = e["assert"], "assert"
+        if dec is None:
+            buckets["NO SIZE"].append((name, None, rom, path,
+                                       measured.get(name, (None, why))[1] or "-"))
+        elif dec == rom:
+            buckets["AGREES"].append((name, dec, rom, path, how))
+        elif dec < rom:
+            agree = agreeing_descendants(name)
+            if agree:
+                buckets["BASE, NOT SHORT"].append(
+                    (name, dec, rom, path,
+                     "%d agreeing subclasses, e.g. %s" % (len(agree), agree[0])))
+            else:
+                buckets["HEADER SHORT"].append((name, dec, rom, path, how))
+        else:
+            buckets["HEADER LONG"].append((name, dec, rom, path, how))
+    return buckets, hdr, stats
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+# The frozen census.  A pass that silently matches nothing reports a clean, confident,
+# wrong answer -- notes/plan-gen-header.md 2.  These are the numbers this file produced
+# when it landed; a change to any of them is a finding, not a detail.
+GATE = {
+    "call_sites": 391,
+    "size_exact": 391,
+}
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", default=".", help="repo/worktree root")
+    ap.add_argument("--extracted", default=None)
+    ap.add_argument("-o", "--out", default=None,
+                    help="default build/opnew_sizes.json under --root")
+    ap.add_argument("--report", action="store_true", help="print populations first")
+    ap.add_argument("--gap", action="store_true",
+                    help="bucket every ROM size against the headers")
+    ap.add_argument("--no-probe", action="store_true",
+                    help="--gap: read size asserts instead of asking the compiler")
+    ap.add_argument("--check", action="store_true",
+                    help="fail unless the frozen census reproduces")
+    a = ap.parse_args(argv)
+
+    root = pathlib.Path(a.root).resolve()
+    ext = pathlib.Path(a.extracted) if a.extracted else find_extracted(root)
+    out = a.out or str(root / "build" / "opnew_sizes.json")
+
+    doc = build(root, ext)
+    st = doc["meta"]["stats"]
+
+    if a.report:
+        print("== populations ==")
+        for k in sorted(st):
+            print("  %-48s %s" % (k, st[k]))
+        bad = [r for r in doc["sites"] if not r["class"]]
+        print("\n== unattributed sites (%d) ==" % len(bad))
+        for r in bad[:40]:
+            print("  %-6s %s  %-40s %s" % (r["module"], r["site"],
+                                           (r["factory"] or "-")[:40], r["attribution"]))
+        if len(bad) > 40:
+            print("  ... %d more" % (len(bad) - 40))
+        print("\n== cross-check warnings (%d) ==" % len(doc["cross_check_warnings"]))
+        for w in doc["cross_check_warnings"][:40]:
+            print("  " + w)
+
+    if a.gap:
+        buckets, _hdr, gstats = gap(root, doc, probe=not a.no_probe)
+        print("\n== gap vs headers ==")
+        for k in sorted(gstats):
+            print("  (%s %s)" % (k, gstats[k]))
+        for b in BUCKETS:
+            print("  %-13s %d" % (b, len(buckets[b])))
+        for b in ("HEADER LONG", "HEADER SHORT", "BASE, NOT SHORT", "NO SIZE"):
+            print("\n-- %s (%d) --" % (b, len(buckets[b])))
+            for name, dec, rom, path, how in buckets[b]:
+                d = ("0x%x" % dec) if dec is not None else how
+                print("  %-34s header %-9s rom 0x%-6x %s" % (name, d, rom, path))
+
+    os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+    with open(out, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump(doc, fh, indent=1, sort_keys=False)
+        fh.write("\n")
+    print("wrote %s: %d sites, %d classes (%d unambiguous), %d sites unattributed"
+          % (out, st.get("call_sites", 0), st.get("classes_total", 0),
+             st.get("classes_unambiguous", 0), st.get("sites_unattributed", 0)))
+
+    if a.check:
+        bad = [(k, v, st.get(k, 0)) for k, v in GATE.items() if st.get(k, 0) != v]
+        for k, want, got in bad:
+            print("GATE FAIL %s: want %d got %s" % (k, want, got))
+        if bad:
+            return 1
+        print("GATE OK")
+    return 0
+
+
+if __name__ == "__main__":                                             # pragma: no cover
+    sys.exit(main())

--- a/tools/test_opnew_sizes.py
+++ b/tools/test_opnew_sizes.py
@@ -1,0 +1,227 @@
+"""The three traps that have already cost this project landed work, as tests.
+
+`opnew_sizes.py` recovers a class's size from the literal the ROM hands
+`fBase_c::operator new`, and attributes it by the vtable the factory installs. Each of
+the three ways that attribution has been got wrong before -- taking the first vptr store
+instead of the last (#1559/#1560 reverted 2 of 13), reading past the factory's own extent
+(commit 3f760a354, the mechanism behind the 41 misnamed classes of #1418-#1423), and
+crediting a member subobject's vptr to its owner -- is a case below, driven through
+synthetic ARM rather than the ROM so it runs in a checkout with no `extracted/`.
+
+The two end-to-end cases skip themselves when the ROM dump is not installed, the same
+way tools/test_build_pin.py does.
+"""
+import collections
+import pathlib
+import sys
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+REPO = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import opnew_sizes as O     # noqa: E402
+
+BASE = 0x02000000
+NEW = 0x02043444
+
+
+# --------------------------------------------------------------- ARM encoders
+
+def mov_imm(rd, imm8, rot=0):
+    """`mov rD, #imm8 ror 2*rot`."""
+    return 0xE3A00000 | (rd << 12) | (rot << 8) | (imm8 & 0xFF)
+
+
+def mov_reg(rd, rs):
+    return 0xE1A00000 | (rd << 12) | rs
+
+
+def ldr_pc(rd, disp):
+    return 0xE59F0000 | (rd << 12) | (disp & 0xFFF)
+
+
+def str_off(rv, rb, off=0):
+    return 0xE5800000 | (rb << 16) | (rv << 12) | (off & 0xFFF)
+
+
+def bl(at, target):
+    return 0xEB000000 | (((target - (at + 8)) >> 2) & 0xFFFFFF)
+
+
+def image(words, at=BASE, syms=None, extra=b""):
+    """An Image over one synthetic module named `m`."""
+    import struct
+    blob = b"".join(struct.pack("<I", w) for w in words) + extra
+    return O.Image({"m": (at, blob)}, {"m": sorted(syms or [])})
+
+
+def run(img, start, size, callsite):
+    stats = collections.Counter()
+    events = O._walk(img, "m", start, size, O.State(), callsite, stats, 0, set())
+    sz, conf = O.read_size(img, "m", start, size, callsite, stats)
+    return sz, conf, events
+
+
+# --------------------------------------------------------------- the size read
+
+def test_the_size_is_the_r0_literal_at_the_call():
+    site = BASE + 4
+    img = image([mov_imm(0, 0xCB, 15),          # mov r0, #0x32c
+                 bl(site, NEW), 0xE12FFF1E])
+    size, conf, _ = run(img, BASE, 12, site)
+    assert (size, conf) == (0x32C, "exact")
+
+
+def test_a_size_that_is_not_a_constant_is_reported_not_guessed():
+    site = BASE + 4
+    img = image([0xE0800001,                    # add r0, r0, r1 -- unmodelled
+                 bl(site, NEW), 0xE12FFF1E])
+    size, conf, _ = run(img, BASE, 12, site)
+    assert size is None and conf == "not_a_constant"
+
+
+# ------------------------------------------------- trap 2: take the LAST store
+
+def test_the_last_vptr_store_wins_not_the_first():
+    """A factory inlines its base constructors and each stores ITS OWN vtable first.
+
+    Reading the first store makes every derived class report as its base. This is the
+    shape `_ZN6CameraC1Ev` has in the live ROM: three stores to [r4], only the third
+    is Camera's."""
+    site = BASE + 4
+    words = [mov_imm(0, 0x1A, 12),              # mov r0, #0x1a000... (any size)
+             bl(site, NEW),
+             mov_reg(4, 0),                     # r4 = the object
+             ldr_pc(0, 0x10), str_off(0, 4),    # base vptr
+             ldr_pc(1, 0x0C), str_off(1, 4),    # derived vptr
+             0xE12FFF1E, 0x00000000]
+    # literals: read at pc+8+disp -> words[3] is at BASE+0xc, +8+0x10 = BASE+0x24
+    img = image(words + [0x0BADBA5E, 0x0DE21AED])
+    _sz, _c, events = run(img, BASE, len(words) * 4, site)
+    stores = [e for e in events if e[0] == "store"]
+    assert len(stores) == 2, stores
+    vt, how, _ = O.resolve_vptr(img, "m", events, collections.Counter())
+    assert (vt, how) == (stores[-1][2], "inline_store")
+    assert vt != stores[0][2], "took the base's vtable, the #1559/#1560 defect"
+
+
+# ------------------------------ trap 3: the scan stops at the function's extent
+
+def test_the_scan_stops_at_the_functions_own_size():
+    """The next function is almost always the NEXT class's D1, storing its own vtable.
+
+    An unbounded window attributes that table here -- the shifted-name mechanism of
+    commit 3f760a354. The window is the config `size=`, and nothing past it is read."""
+    site = BASE + 4
+    ours = [mov_imm(0, 0x40), bl(site, NEW), mov_reg(4, 0),
+            ldr_pc(0, 0x14), str_off(0, 4), 0xE12FFF1E]
+    # the neighbour: same shape, a different literal, immediately after
+    nxt = [ldr_pc(0, 0x00), str_off(0, 4), 0xE12FFF1E, 0xDEADBEEF]
+    img = image(ours + nxt + [0x0AAAAAAA])
+    _sz, _c, events = run(img, BASE, len(ours) * 4, site)
+    stores = [e for e in events if e[0] == "store"]
+    assert len(stores) == 1, "read past the factory into the next function"
+    assert all(a < BASE + len(ours) * 4 for _k, a, _v in events)
+
+
+# -------------------------------- a member subobject's vptr is not the object's
+
+def test_a_store_to_a_nonzero_offset_is_not_this_objects_vptr():
+    """`add rD, this, #n` then a ctor there is a MEMBER. Its vtable is the member's."""
+    site = BASE + 4
+    words = [mov_imm(0, 0x40), bl(site, NEW), mov_reg(4, 0),
+             ldr_pc(0, 0x04), str_off(0, 4, 0x50), 0xE12FFF1E]
+    img = image(words + [0x0BADBA5E])
+    _sz, _c, events = run(img, BASE, len(words) * 4, site)
+    assert not [e for e in events if e[0] == "store"]
+
+
+def test_an_add_does_not_carry_the_object_but_a_subs_zero_does():
+    """`subs rD, rObj, #0` is mwcc's copy-and-null-test; `add rD, rObj, #n` is a member."""
+    site = BASE + 4
+    sub0 = 0xE2504000                                   # subs r4, r0, #0
+    add50 = 0xE2805050                                  # add r5, r0, #0x50
+    words = [mov_imm(0, 0x40), bl(site, NEW), sub0, add50,
+             ldr_pc(1, 0x08), str_off(1, 4), str_off(1, 5), 0xE12FFF1E]
+    img = image(words + [0x0BADBA5E])
+    _sz, _c, events = run(img, BASE, len(words) * 4, site)
+    stores = [e for e in events if e[0] == "store"]
+    assert len(stores) == 1 and stores[0][2] == 0x0BADBA5E
+
+
+# ----------------------------------- trap 1: identity comes from the vtable ADDRESS
+
+def test_class_for_vtable_never_reads_a_name_to_choose():
+    """Two overlays host a record at the same address; the module decides, not the name."""
+    by_addr = {0x1000: [("ov014", "daObjWanwanShutter_c"), ("ov015", "daObjBk_Fall_Block_c")]}
+    st = collections.Counter()
+    assert O.class_for_vtable(by_addr, "ov015", 0x1000, st)[0] == "daObjBk_Fall_Block_c"
+    assert O.class_for_vtable(by_addr, "ov014", 0x1000, st)[0] == "daObjWanwanShutter_c"
+
+
+def test_an_unknown_vtable_is_a_refusal_not_a_guess():
+    st = collections.Counter()
+    name, why = O.class_for_vtable({}, "m", 0x1000, st)
+    assert name is None and why == "no_rtti_record_at_vtable"
+
+
+# ------------------------------------------------------------------- demangling
+
+def test_demangle_ztv():
+    assert O.demangle_ztv("_ZTV6Camera") == "Camera"
+    assert O.demangle_ztv("_ZTV7da1up_c") == "da1up_c"
+    assert O.demangle_ztv("_ZTVN8dGraph_c10callback_cE") == "dGraph_c__callback_c"
+    assert O.demangle_ztv("data_0208e3a4") is None
+    assert O.demangle_ztv("_ZTV99Truncated") is None
+
+
+# ---------------------------------------------------------- the header readers
+
+def test_header_sizes_reads_the_assert_and_notices_one_that_is_missing(tmp_path):
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "A.h").write_text(
+        "struct A {\n  int x;\n};\n"
+        "typedef char A_size_must_be_0x330[sizeof(struct A) == 0x330 ? 1 : -1];\n")
+    (inc / "B.h").write_text("struct B : A {\n  int y;\n};\n")
+    got = O.header_sizes(tmp_path)
+    assert got["A"]["assert"] == 0x330
+    assert got["B"]["assert"] is None and got["B"]["header"].name == "B.h"
+
+
+def test_subclass_index_is_transitive(tmp_path):
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "H.h").write_text(
+        "struct A {\n int x;\n};\n"
+        "struct B : public A {\n int y;\n};\n"
+        "struct C : B {\n int z;\n};\n")
+    kids = O.subclass_index(tmp_path)
+    assert kids["A"] == {"B", "C"}
+    assert kids["B"] == {"C"}
+
+
+# ------------------------------------------------------------------- end to end
+
+def _rom():
+    return (REPO / "extracted" / "arm9_dec.bin").is_file() and \
+           (REPO / "build" / "rtti.json").is_file()
+
+
+def test_the_live_census_reproduces():
+    if not _rom():
+        return
+    doc = O.build(REPO, REPO / "extracted")
+    st = doc["meta"]["stats"]
+    for k, want in O.GATE.items():
+        assert st.get(k) == want, (k, want, st.get(k))
+    assert not doc["cross_check_warnings"], doc["cross_check_warnings"][:5]
+
+
+def test_every_site_the_ROM_has_is_attributed_to_a_class():
+    """A pass that silently matches nothing reports a clean, confident, wrong answer."""
+    if not _rom():
+        return
+    doc = O.build(REPO, REPO / "extracted")
+    assert doc["meta"]["stats"]["sites_unattributed"] == 0
+    assert all(s["size"] is not None for s in doc["sites"])


### PR DESCRIPTION
`fBase_c::operator new(unsigned int)` — `_ZN7fBase_cnwEj`, arm9 `0x02043444` — is this game's allocator, and every `new Class` in the original source compiled to `mov r0, #sizeof(Class)` immediately before the `bl`. That immediate is not inference: it is `sizeof` as the original compiler computed it, frozen in the instruction stream. `config/**/relocs.txt` records **391** such call sites and nothing in the tree had ever read them.

`evidence_rom.py` recovers *fields* from loads and stores and is blind by construction to any field a class never touches, so it can see a struct's occupied prefix but never its extent. This pass sees nothing but the extent. They are complements.

## The tool — `tools/opnew_sizes.py`

Harvests all 391 sites, recovers the literal by constant-propagating r0 through the enclosing function, follows the returned pointer, and attributes the size to a class by the vtable the factory installs, joined against `build/rtti.json`.

| | |
|---|---|
| call sites | 391 |
| size recovered exactly | **391 / 391** |
| attributed to a class | **391 / 391** |
| distinct classes | 315 |
| ambiguous (two sites disagreeing) | **0** |

`--report` prints every population including rejects, `--gap` buckets against the headers, `--check` holds the frozen census. `tools/test_opnew_sizes.py` drives the three traps below through synthetic ARM, so it runs in a checkout with no `extracted/`; the two end-to-end cases skip themselves without the ROM dump, as `test_build_pin.py` does.

### The three traps, and how each is answered

**Pair by vtable address, never by name.** PR #1556 had to retract 2 of 21 "wrong sizes" that were name-pairing artifacts. Nothing here reads a symbol's spelling to decide whose size it is; the address decides, and the symbol only supplies a spelling for the header lookup.

**Take the LAST vptr store.** #1559/#1560 landed 13 size corrections and reverted 2 for walking to a base. A factory inlines its base constructors and each writes its own vtable before the derived one — `_ZN6CameraC1Ev` stores three different vtables to `[r4]` and only the third is Camera's. The rule is asserted rather than assumed: **76 factories store more than one vtable, and in all 76 every table not chosen is a proper ancestor of the one that was.** Zero cases of choosing a base over a derived, zero unrelated.

**Bound the scan by the function's own extent.** Commit `3f760a354` is the post-mortem: a fixed `0x50` window ran past factories that are `0x30–0x40` into the next class's D1, which is the mechanism behind the 41 misnamed classes of #1418–#1423. Every scan here stops at the `size=` in `config/**/symbols.txt`.

## The gap

`--gap` measures each header by asking mwccarm for `sizeof` — a regex cannot measure a header, and half of these carry no size assert at all. **188 of 188 headers probe cleanly.**

| bucket | before | after |
|---|---|---|
| AGREES | 168 | **187** |
| HEADER SHORT | 19 | **0** |
| HEADER LONG | 1 | **0** |
| BASE, NOT SHORT | — | 1 |
| NO SIZE | 0 | 0 |
| NO HEADER | 127 | 127 |
| AMBIGUOUS | 0 | 0 |

## Applied

* **18 headers** extended with explicit trailing padding to the ROM's extent.
* **1 header shrunk** — `CameraTag.h`, `0x108 → 0xd4`. It had been describing **InvisiblePole**, the factory immediately *before* CameraTag's own, down to naming `InvisiblePole_Spawn` in its comment. InvisiblePole is a different class with a different vtable (`0x02108480`, RTTI `daBar_c`) and is already correct at `0x108`. This is trap 1 exactly, and pairing by vtable address is what caught it.
* **19 size asserts** added, spelled `sizeof(struct X)` so C sources check them too.
* **13 factories** now pass `sizeof(struct X)` to `operator new` instead of a hand-spelled literal. That is the part that matters: it puts each header's extent on the byte gate instead of on an assert restating a number a human typed.

### Byte verification

**165 / 165** enrolled functions across the full include closure of the 19 changed headers reproduce under `2004/b56` (`build_pin.verify`). That is every function the edits can reach, not a sample.

Local evidence only, not a substitute for the validator: `eligible.py` 11065/11187 with the only name-list delta being `_ZN7dBgW_Kc10DetectClsnER12dBgCh_SphCrr`, which #1655 landed on main — nothing lost, nothing gained from this change. `rombuild.py -j 16` 106/106 exact, 11,059 source-built, 0 mismatching. `check_header_offsets.py` 0 mismatched on all 19. `port_refcheck.py` 393 references, all resolve. `pytest` 13/13 new, 57/57 with the neighbouring suites. `pyflakes` clean.

## Reverted

**6 factories** kept their hand-spelled literal: `_ZN5StageC3Ev.c`, `MgSortOrSplode_Spawn.c`, `MgShuffleShell_Spawn.c`, `MgLakituLaunch_Spawn.c`, `MgBobOmbSquad_Spawn.c`, `MgHideAndBooSeek_Spawn.c`. All six are `.c` files and their classes (`Stage`, the five `dScMg*_c`) are C++-only — they derive from `dScene_c`/`dScMgBase_c` and have virtuals, so including the header in a C TU does not compile. Their **header** changes are applied and byte-verified; only the `sizeof` wiring was backed out. Making those TUs `//cpp` is a language-mode change and belongs in its own PR.

## Not applied — and the interesting one

**`dActor_c`: the ROM says `0xd4`, the header says `0xd0`, and both apparently pass. The header is right.**

`StarCamera_Spawn` (ov002 `0x020ebe68`) allocates `0xd4`, calls `dActor_c::dActor_c` and stores nothing further, so the object's final vptr is `dActor_c`'s. But that is a subclass which adds no virtual of its own and overrides none, gets no vtable from mwccarm, and therefore files its size against its base. The counter-evidence is decisive: **120 classes in this tree inherit `dActor_c` and every one agrees with its own ROM size at `0xd0`** — they could not, if the base were four bytes longer.

So the general rule, now documented as the tool's fifth trap: **the ROM size is exact for a leaf and an upper bound for a class that is somebody's base.** `--gap` no longer calls such a class SHORT; it buckets it `BASE, NOT SHORT` and names an agreeing subclass, so the next reader is not invited to grow it. This is the only such class in the ROM.

## Still tool-only

**127 classes have a ROM size and no header at all** — a standing worklist this PR does not touch. `build/opnew_sizes.json` carries every one with its factory, vtable and confidence.
