### PR TITLE
Join `--gap` to headers by vtable address too, and bank the 43 sizes it was hiding

### DIFF
--- a/include/BigMovingIceBlock.h
+++ b/include/BigMovingIceBlock.h
@@ -37,4 +37,7 @@ struct BigMovingIceBlock {
 #endif
 };
 
+typedef char BigMovingIceBlock_size_must_be_0x330[
+    sizeof(struct BigMovingIceBlock) == 0x330 ? 1 : -1];
+
 #endif

--- a/include/BowserPuzzlePiece.h
+++ b/include/BowserPuzzlePiece.h
@@ -42,4 +42,7 @@ struct BowserPuzzlePiece {
 #endif
 };
 
+typedef char BowserPuzzlePiece_size_must_be_0x33c[
+    sizeof(struct BowserPuzzlePiece) == 0x33c ? 1 : -1];
+
 #endif

--- a/include/BrickBlock.h
+++ b/include/BrickBlock.h
@@ -23,4 +23,6 @@ struct BrickBlock {
 #endif
 };
 
+typedef char BrickBlock_size_must_be_0xdc[sizeof(struct BrickBlock) == 0xdc ? 1 : -1];
+
 #endif

--- a/include/Butterfly.h
+++ b/include/Butterfly.h
@@ -64,4 +64,6 @@ struct Butterfly {
 #endif
 };
 
+typedef char Butterfly_size_must_be_0x3f4[sizeof(struct Butterfly) == 0x3f4 ? 1 : -1];
+
 #endif

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -75,4 +75,6 @@ struct Camera {
 #endif
 };
 
+typedef char Camera_size_must_be_0x1a8[sizeof(struct Camera) == 0x1a8 ? 1 : -1];
+
 #endif

--- a/include/ChainChomp.h
+++ b/include/ChainChomp.h
@@ -54,6 +54,8 @@ struct ChainChomp : dEnemyBase_c {
     int Render();
 };
 
+typedef char ChainChomp_size_must_be_0x620[sizeof(ChainChomp) == 0x620 ? 1 : -1];
+
 #else
 
 /* The same object for a C translation unit, flat. */

--- a/include/Clam.h
+++ b/include/Clam.h
@@ -39,4 +39,6 @@ struct Clam {
 #endif
 };
 
+typedef char Clam_size_must_be_0x174[sizeof(struct Clam) == 0x174 ? 1 : -1];
+
 #endif

--- a/include/ClockPaintingHandShort.h
+++ b/include/ClockPaintingHandShort.h
@@ -39,4 +39,7 @@ struct ClockPaintingHandShort {
 #endif
 };
 
+typedef char ClockPaintingHandShort_size_must_be_0x128[
+    sizeof(struct ClockPaintingHandShort) == 0x128 ? 1 : -1];
+
 #endif

--- a/include/CutsceneObject.h
+++ b/include/CutsceneObject.h
@@ -51,4 +51,6 @@ struct CutsceneObject {
 #endif
 };
 
+typedef char CutsceneObject_size_must_be_0x104[sizeof(struct CutsceneObject) == 0x104 ? 1 : -1];
+
 #endif

--- a/include/Dorrie.h
+++ b/include/Dorrie.h
@@ -73,4 +73,6 @@ struct Dorrie {
 #endif
 };
 
+typedef char Dorrie_size_must_be_0x11b8[sizeof(struct Dorrie) == 0x11b8 ? 1 : -1];
+
 #endif

--- a/include/EnemySwitchTag.h
+++ b/include/EnemySwitchTag.h
@@ -26,4 +26,6 @@ struct EnemySwitchTag {
 #endif
 };
 
+typedef char EnemySwitchTag_size_must_be_0x110[sizeof(struct EnemySwitchTag) == 0x110 ? 1 : -1];
+
 #endif

--- a/include/Exit.h
+++ b/include/Exit.h
@@ -71,4 +71,6 @@ struct Exit {
 #endif
 };
 
+typedef char Exit_size_must_be_0x104[sizeof(struct Exit) == 0x104 ? 1 : -1];
+
 #endif

--- a/include/ExtendingPlatform.h
+++ b/include/ExtendingPlatform.h
@@ -29,4 +29,7 @@ struct ExtendingPlatform {
 #endif
 };
 
+typedef char ExtendingPlatform_size_must_be_0x328[
+    sizeof(struct ExtendingPlatform) == 0x328 ? 1 : -1];
+
 #endif

--- a/include/Fish.h
+++ b/include/Fish.h
@@ -34,4 +34,6 @@ struct Fish {
 #endif
 };
 
+typedef char Fish_size_must_be_0x160[sizeof(struct Fish) == 0x160 ? 1 : -1];
+
 #endif

--- a/include/Flag.h
+++ b/include/Flag.h
@@ -29,4 +29,6 @@ struct Flag {
 #endif
 };
 
+typedef char Flag_size_must_be_0x138[sizeof(struct Flag) == 0x138 ? 1 : -1];
+
 #endif

--- a/include/HealingHeart.h
+++ b/include/HealingHeart.h
@@ -61,4 +61,6 @@ struct HealingHeart {
 #endif
 };
 
+typedef char HealingHeart_size_must_be_0x174[sizeof(struct HealingHeart) == 0x174 ? 1 : -1];
+
 #endif

--- a/include/IceSlideManager.h
+++ b/include/IceSlideManager.h
@@ -56,4 +56,6 @@ struct IceSlideManager {
 #endif
 };
 
+typedef char IceSlideManager_size_must_be_0xd8[sizeof(struct IceSlideManager) == 0xd8 ? 1 : -1];
+
 #endif

--- a/include/LightBeam.h
+++ b/include/LightBeam.h
@@ -24,4 +24,6 @@ struct LightBeam {
 #endif
 };
 
+typedef char LightBeam_size_must_be_0x16c[sizeof(struct LightBeam) == 0x16c ? 1 : -1];
+
 #endif

--- a/include/MrI.h
+++ b/include/MrI.h
@@ -56,4 +56,6 @@ struct MrI {
 #endif
 };
 
+typedef char MrI_size_must_be_0x218[sizeof(struct MrI) == 0x218 ? 1 : -1];
+
 #endif

--- a/include/Number.h
+++ b/include/Number.h
@@ -43,4 +43,6 @@ struct Number {
 #endif
 };
 
+typedef char Number_size_must_be_0x150[sizeof(struct Number) == 0x150 ? 1 : -1];
+
 #endif

--- a/include/PeachPainting.h
+++ b/include/PeachPainting.h
@@ -21,4 +21,6 @@ struct PeachPainting {
 #endif
 };
 
+typedef char PeachPainting_size_must_be_0x128[sizeof(struct PeachPainting) == 0x128 ? 1 : -1];
+
 #endif

--- a/include/PyramidLift.h
+++ b/include/PyramidLift.h
@@ -45,4 +45,6 @@ struct PyramidLift {
 #endif
 };
 
+typedef char PyramidLift_size_must_be_0x3fc[sizeof(struct PyramidLift) == 0x3fc ? 1 : -1];
+
 #endif

--- a/include/PyramidTag.h
+++ b/include/PyramidTag.h
@@ -18,4 +18,6 @@ struct PyramidTag {
 #endif
 };
 
+typedef char PyramidTag_size_must_be_0x10c[sizeof(struct PyramidTag) == 0x10c ? 1 : -1];
+
 #endif

--- a/include/RotatingUpDownPlatform.h
+++ b/include/RotatingUpDownPlatform.h
@@ -56,4 +56,7 @@ struct RotatingUpDownPlatform {
 #endif
 };
 
+typedef char RotatingUpDownPlatform_size_must_be_0x358[
+    sizeof(struct RotatingUpDownPlatform) == 0x358 ? 1 : -1];
+
 #endif

--- a/include/ShipUp.h
+++ b/include/ShipUp.h
@@ -34,4 +34,6 @@ struct ShipUp {
 #endif
 };
 
+typedef char ShipUp_size_must_be_0x32c[sizeof(struct ShipUp) == 0x32c ? 1 : -1];
+
 #endif

--- a/include/SlideDecorationSilverStar.h
+++ b/include/SlideDecorationSilverStar.h
@@ -23,4 +23,7 @@ struct SlideDecorationSilverStar {
 #endif
 };
 
+typedef char SlideDecorationSilverStar_size_must_be_0x128[
+    sizeof(struct SlideDecorationSilverStar) == 0x128 ? 1 : -1];
+
 #endif

--- a/include/SlidingBox.h
+++ b/include/SlidingBox.h
@@ -51,4 +51,6 @@ struct SlidingBox {
 #endif
 };
 
+typedef char SlidingBox_size_must_be_0x4f8[sizeof(struct SlidingBox) == 0x4f8 ? 1 : -1];
+
 #endif

--- a/include/SnowmanBody.h
+++ b/include/SnowmanBody.h
@@ -53,4 +53,6 @@ struct SnowmanBody {
 #endif
 };
 
+typedef char SnowmanBody_size_must_be_0x3a8[sizeof(struct SnowmanBody) == 0x3a8 ? 1 : -1];
+
 #endif

--- a/include/SnowmanBreath.h
+++ b/include/SnowmanBreath.h
@@ -44,4 +44,6 @@ struct SnowmanBreath {
 #endif
 };
 
+typedef char SnowmanBreath_size_must_be_0x13d4[sizeof(struct SnowmanBreath) == 0x13d4 ? 1 : -1];
+
 #endif

--- a/include/StarMarker.h
+++ b/include/StarMarker.h
@@ -64,4 +64,6 @@ struct StarMarker {
 #endif
 };
 
+typedef char StarMarker_size_must_be_0x1dc[sizeof(struct StarMarker) == 0x1dc ? 1 : -1];
+
 #endif

--- a/include/SwitchActivatedPlank.h
+++ b/include/SwitchActivatedPlank.h
@@ -35,4 +35,7 @@ struct SwitchActivatedPlank {
 #endif
 };
 
+typedef char SwitchActivatedPlank_size_must_be_0x3a8[
+    sizeof(struct SwitchActivatedPlank) == 0x3a8 ? 1 : -1];
+
 #endif

--- a/include/Toad.h
+++ b/include/Toad.h
@@ -58,4 +58,6 @@ struct Toad {
 #endif
 };
 
+typedef char Toad_size_must_be_0x210[sizeof(struct Toad) == 0x210 ? 1 : -1];
+
 #endif

--- a/include/TreasureChest.h
+++ b/include/TreasureChest.h
@@ -30,4 +30,6 @@ struct TreasureChest {
 #endif
 };
 
+typedef char TreasureChest_size_must_be_0x178[sizeof(struct TreasureChest) == 0x178 ? 1 : -1];
+
 #endif

--- a/include/TtcConveyorBeltLarge.h
+++ b/include/TtcConveyorBeltLarge.h
@@ -49,4 +49,7 @@ struct TtcConveyorBeltLarge {
 #endif
 };
 
+typedef char TtcConveyorBeltLarge_size_must_be_0x3a0[
+    sizeof(struct TtcConveyorBeltLarge) == 0x3a0 ? 1 : -1];
+
 #endif

--- a/include/UnknownVsEntry.h
+++ b/include/UnknownVsEntry.h
@@ -42,4 +42,6 @@ struct UnknownVsEntry {
 #endif
 };
 
+typedef char UnknownVsEntry_size_must_be_0xf48[sizeof(struct UnknownVsEntry) == 0xf48 ? 1 : -1];
+
 #endif

--- a/include/UpDownLiftBbh.h
+++ b/include/UpDownLiftBbh.h
@@ -97,4 +97,6 @@ struct UpDownLiftBbh {
 #endif
 };
 
+typedef char UpDownLiftBbh_size_must_be_0x34c[sizeof(struct UpDownLiftBbh) == 0x34c ? 1 : -1];
+
 #endif

--- a/include/WaterDiamond.h
+++ b/include/WaterDiamond.h
@@ -34,4 +34,6 @@ struct WaterDiamond {
 #endif
 };
 
+typedef char WaterDiamond_size_must_be_0x160[sizeof(struct WaterDiamond) == 0x160 ? 1 : -1];
+
 #endif

--- a/include/WingFeather.h
+++ b/include/WingFeather.h
@@ -50,4 +50,6 @@ struct WingFeather {
 #endif
 };
 
+typedef char WingFeather_size_must_be_0x388[sizeof(struct WingFeather) == 0x388 ? 1 : -1];
+
 #endif

--- a/include/dScMgCoin_c.h
+++ b/include/dScMgCoin_c.h
@@ -28,4 +28,6 @@ struct dScMgCoin_c : dScMgBase_c {
     u8  unk_51dc;            /* 0x51dc */
 };
 
+typedef char dScMgCoin_c_size_must_be_0x51e0[sizeof(dScMgCoin_c) == 0x51e0 ? 1 : -1];
+
 #endif

--- a/include/dScMgCurling2_c.h
+++ b/include/dScMgCurling2_c.h
@@ -28,4 +28,6 @@ struct dScMgCurling2_c : dScMgBase_c {
     u8  unk_55c3;            /* 0x55c3 */
 };
 
+typedef char dScMgCurling2_c_size_must_be_0x55c4[sizeof(dScMgCurling2_c) == 0x55c4 ? 1 : -1];
+
 #endif

--- a/include/dScMgHanachan_c.h
+++ b/include/dScMgHanachan_c.h
@@ -60,4 +60,6 @@ struct dScMgHanachan_c : dScMgBase_c {
     u8  unk_4f64;            /* 0x4f64 */
 };
 
+typedef char dScMgHanachan_c_size_must_be_0x4f68[sizeof(dScMgHanachan_c) == 0x4f68 ? 1 : -1];
+
 #endif

--- a/include/dScMgLuigi_c.h
+++ b/include/dScMgLuigi_c.h
@@ -29,4 +29,6 @@ struct dScMgLuigi_c : dScMgBase_c {
     u8  unk_5459;            /* 0x5459 */
 };
 
+typedef char dScMgLuigi_c_size_must_be_0x545c[sizeof(dScMgLuigi_c) == 0x545c ? 1 : -1];
+
 #endif

--- a/include/dScMgPanel_c.h
+++ b/include/dScMgPanel_c.h
@@ -28,4 +28,6 @@ struct dScMgPanel_c : dScMgBase_c {
     u8  unk_4fea;            /* 0x4fea */
 };
 
+typedef char dScMgPanel_c_size_must_be_0x4fec[sizeof(dScMgPanel_c) == 0x4fec ? 1 : -1];
+
 #endif

--- a/tools/opnew_sizes.py
+++ b/tools/opnew_sizes.py
@@ -17,6 +17,12 @@ are complements: one says where the fields are, this one says where the object e
     python tools/opnew_sizes.py --gap             # ROM size vs each header's declaration
     python tools/opnew_sizes.py --check           # fail unless the frozen census reproduces
 
+`--gap` buckets AGREES separately from NO ASSERT because only the first is CHECKED.  An
+`X_size_must_be_0xN` typedef is how `check_header_offsets.py` sizes X when X appears as a
+MEMBER of another struct; without one, every header that types a member as X reports
+UNPARSED, and that gate exits 1 on unparsed, not merely on mismatched (PR #1659, where
+`Stage.h`'s `Fog unk_96c` failed CI for exactly this).  NO ASSERT is the actionable list.
+
 Output: build/opnew_sizes.json -- per class, its ROM size, the factories that prove it,
 the vtable it was attributed through, and whether any two sites disagree.
 
@@ -29,8 +35,20 @@ How a site is read
 
 The class is then whichever RTTI record in `build/rtti.json` owns that vtable.
 
-Four traps, three of which have already cost this project landed work
+Five traps, four of which have already cost this project landed work
 ---------------------------------------------------------------------
+join the HEADER   The one this file got wrong itself.  Attribution is by address, but the
+by address too    class then has to be found in `include/`, and a file can only be found
+                  under a SPELLING.  Joining on the single spelling the attribution
+                  happened to carry made `--gap` report NO HEADER for 125 classes the
+                  tree describes perfectly well: the cartridge's RTTI calls a class
+                  `daStar_c` and this tree calls the same object `PowerStar`, both
+                  `_ZTV` symbols sit at one address, and only the second has a file.
+                  So the candidate set is every `_ZTV` spelling at the vtable's address
+                  plus the RTTI name, and the first with a header wins -- see
+                  `resolve_header_name`.  Those 125 were never compared to the header
+                  that describes them; 16 of them turned out to be SHORT.
+
 pair by vtable    Never by name.  PR #1556 had to retract 2 of 21 "wrong sizes" that
                   were artifacts of pairing a class to a factory by name; if a name
                   defect and a value defect share a table, the names are wrong first.
@@ -213,18 +231,25 @@ def load_symbols(root, mods, stats):
 
 
 def load_vtable_symbols(root, mods, stats):
-    """(module, addr) -> the tree's own name for the class whose vtable sits there.
+    """(module, addr) -> EVERY name the tree gives the class whose vtable sits there.
 
     The cartridge's RTTI name and this tree's name for the same class are often
     different -- `_ZTV6Camera` and `dCamera_c` are one class -- because most of the
     English names predate the RTTI pass and have not been renamed yet.  A header can
     only be found under the name the tree uses, so both are carried.
 
+    One address routinely carries SEVERAL `_ZTV` symbols, because a class being renamed
+    keeps its old spelling as an alias until every consumer moves: 0x021280b0 is
+    `_ZTV12FortressWall`, `_ZTV9MontyMole` and `_ZTV11daChoropu_c` at once, and only
+    `MontyMole` has a header.  Collapsing that to one name -- whichever happened to come
+    last in the file -- is what made `--gap` report NO HEADER for 125 classes the tree
+    describes perfectly well.  All of them are kept, sorted, and the header join picks.
+
     This is still a VTABLE-ADDRESS join, not a name join: the address decides which
-    symbol is read, and the symbol only supplies the spelling.  Pairing a class to a
+    symbols are read, and the symbols only supply the spellings.  Pairing a class to a
     factory by name is what PR #1556 had to retract 2 of 21 findings for.
     """
-    out = {}
+    out = collections.defaultdict(list)
     paths = [("arm9", root / "config" / "arm9" / "symbols.txt")]
     for d in sorted((root / "config" / "arm9" / "overlays").glob("ov*")):
         paths.append((d.name, d / "symbols.txt"))
@@ -236,9 +261,11 @@ def load_vtable_symbols(root, mods, stats):
                 continue
             m = SYM_ANY.match(line)
             if m:
-                out[(mod, int(m.group(2), 16))] = m.group(1)
-    stats["vtable_symbols_named_in_config"] = len(out)
-    return out
+                out[(mod, int(m.group(2), 16))].append(m.group(1))
+    stats["vtable_symbols_named_in_config"] = sum(len(v) for v in out.values())
+    stats["vtable_addresses_with_more_than_one_name"] = sum(
+        1 for v in out.values() if len(v) > 1)
+    return dict(out)
 
 
 def demangle_ztv(sym):
@@ -663,12 +690,20 @@ def build(root, ext):
     vtsyms = load_vtable_symbols(root, mods, stats)
     img = Image(mods, syms)
 
-    def tree_class(mod, vt):
+    def tree_names(mod, vt):
+        """(primary, every alias) the tree spells for the vtable at (mod, vt).
+
+        The primary keeps the historical pick -- the last symbol the config file lists
+        -- so the per-class keys of build/opnew_sizes.json do not move under anyone.
+        The aliases are what the header join actually consults.
+        """
         for m in (mod, "arm9"):
-            s = vtsyms.get((m, vt))
-            if s:
-                return demangle_ztv(s)
-        return None
+            syms = vtsyms.get((m, vt))
+            if syms:
+                names = [n for n in (demangle_ztv(s) for s in syms) if n]
+                if names:
+                    return names[-1], sorted(set(names))
+        return None, []
 
     records, warnings = [], []
     for mod, site in sites:
@@ -690,7 +725,7 @@ def build(root, ext):
             cls, cls_how = class_for_vtable(by_addr, mod, vt, stats)
         if cls:
             audit_derived_most(by_addr, anc, mod, cls, events, stats, warnings)
-        tcls = tree_class(mod, vt) if vt else None
+        tcls, taliases = tree_names(mod, vt) if vt else (None, [])
         if vt:
             stats["vtables_the_tree_has_not_named" if not tcls
                   else "vtables_named_by_the_tree"] += 1
@@ -703,6 +738,7 @@ def build(root, ext):
             "vtable": ("0x%08x" % vt) if vt else None,
             "attribution": how, "resolved_by": cls_how if vt else None,
             "via": via, "class": cls, "tree_class": tcls,
+            "tree_class_aliases": taliases,
         })
         stats["size_" + size_conf] += 1
         stats["attribution_" + (cls_how if vt else how)] += 1
@@ -717,7 +753,17 @@ def build(root, ext):
     classes = {}
     for name, rs in sorted(per.items()):
         sizes = sorted({r["size"] for r in rs})
+        # Every spelling this class's VTABLE ADDRESS is known by -- the tree's `_ZTV`
+        # aliases and the cartridge's own RTTI name.  Still an address join; the names
+        # are only what the address resolves to.  `gap` looks for a header under each.
+        aliases = set()
+        for r in rs:
+            aliases.update(r.get("tree_class_aliases") or ())
+            if r["class"]:
+                aliases.add(r["class"])
+        aliases.discard(name)
         classes[name] = {
+            "aliases": sorted(aliases),
             "size": sizes[0] if len(sizes) == 1 else None,
             "size_hex": ("0x%x" % sizes[0]) if len(sizes) == 1 else None,
             "ambiguous": len(sizes) > 1,
@@ -797,8 +843,8 @@ def header_sizes(root):
     return out
 
 
-BUCKETS = ("AGREES", "HEADER SHORT", "HEADER LONG", "BASE, NOT SHORT", "NO SIZE",
-           "NO HEADER", "AMBIGUOUS")
+BUCKETS = ("AGREES", "NO ASSERT", "HEADER SHORT", "HEADER LONG", "BASE, NOT SHORT",
+           "NO SIZE", "NO HEADER", "AMBIGUOUS")
 
 INHERITS = re.compile(r"^[ \t]*(?:class|struct)[ \t]+(\w+)[ \t]*:([^{;]+)\{", re.M)
 ACCESS = {"public", "protected", "private", "virtual"}
@@ -827,6 +873,30 @@ def subclass_index(root):
             stack.extend(kids.get(n, ()))
         out[b] = seen
     return out
+
+
+def resolve_header_name(name, aliases, hdr):
+    """(the name this class's header is written under, how) or (None, None).
+
+    THE defect this function exists to close.  Sizes are attributed by vtable address
+    -- trap 1, never by name -- but the class then has to be looked up in `include/`,
+    and a header can only be found under a spelling.  Joining on the ONE spelling the
+    attribution happened to carry reported NO HEADER for 125 classes: the cartridge's
+    RTTI calls a class `daStar_c` and this tree calls it `PowerStar`, both `_ZTV`
+    symbols sit at the same address, and only the second has a file.
+
+    So the candidate set is every spelling that address resolves to, and the first one
+    with a header wins.  The class's own key is tried first so a class that has its own
+    header is never redirected to an alias's.  The plain name join survives only as the
+    zero-alias case.
+    """
+    if name in hdr:
+        return name, "name"
+    for a in aliases:                                  # sorted upstream, so this is stable
+        if a in hdr:
+            return a, "vtable alias"
+    return None, None
+
 
 PROBE_SRC = '#include "%s"\nchar opnew_probe[sizeof(%s)];\n'
 
@@ -905,29 +975,55 @@ def gap(root, doc, probe=True):
     The declared size is the compiler's answer where the probe can build, and the size
     assert only where it cannot -- the assert is a human's claim, `sizeof` is the fact.
     A header with neither is NO SIZE: unmeasured, never guessed at.
+
+    AGREES and NO ASSERT are both "the header is right".  They are separated because
+    only the first is CHECKED: an `X_size_must_be_` typedef is how check_header_offsets
+    sizes X when X appears as a MEMBER of another struct, and a header with no assert
+    makes every struct that types a member as X report UNPARSED -- which fails that gate
+    outright.  NO ASSERT is therefore the actionable list, not a footnote.
     """
     hdr = header_sizes(root)
     stats = collections.Counter()
+
+    # class key -> the name its header is written under.  See resolve_header_name.
+    hname, hhow = {}, {}
+    for name, c in sorted(doc["classes"].items()):
+        if c["ambiguous"]:
+            continue
+        n, how = resolve_header_name(name, c.get("aliases") or (), hdr)
+        if n is not None:
+            hname[name], hhow[name] = n, how
+            stats["header_found_by_" + how.replace(" ", "_")] += 1
+        else:
+            stats["header_not_found"] += 1
+    # the ROM size of whatever class each header describes, keyed by the header's name
+    rom_by_header = {}
+    for name, n in sorted(hname.items()):
+        rom_by_header.setdefault(n, doc["classes"][name]["size"])
+
     measured, why = ({}, "probe disabled")
     if probe:
-        wanted = {n: hdr[n]["header"].name for n in doc["classes"] if n in hdr}
+        wanted = {n: str(hdr[n]["header"].relative_to(root / "include")).replace("\\", "/")
+                  for n in set(hname.values())}
         measured, why = probe_sizes(root, wanted, stats)
     kids = subclass_index(root)
 
-    def agreeing_descendants(name):
+    def agreeing_descendants(hn):
         """Descendants whose own declared size already matches their own ROM size.
 
         One of those is proof the base is NOT short: growing it moves every one of them.
-        See the fifth trap in the module docstring -- this is what dActor_c is."""
+        See the fifth trap in the module docstring -- this is what dActor_c is.
+        Keyed by HEADER name throughout: `subclass_index` reads `include/`, so a ROM
+        size filed under an RTTI spelling has to come back through rom_by_header."""
         out = []
-        for k in sorted(kids.get(name, ())):
-            c = doc["classes"].get(k)
-            if not c or c["ambiguous"]:
+        for k in sorted(kids.get(hn, ())):
+            rom = rom_by_header.get(k)
+            if rom is None:
                 continue
             d = measured.get(k, (None, None))[0]
             if d is None and k in hdr:
                 d = hdr[k]["assert"]
-            if d is not None and d == c["size"]:
+            if d is not None and d == rom:
                 out.append(k)
         return out
 
@@ -937,30 +1033,34 @@ def gap(root, doc, probe=True):
             buckets["AMBIGUOUS"].append((name, None, c["sizes_seen"], None, "-"))
             continue
         rom = c["size"]
-        e = hdr.get(name)
-        if e is None:
+        hn = hname.get(name)
+        if hn is None:
             buckets["NO HEADER"].append((name, None, rom, None, "-"))
             continue
+        e = hdr[hn]
+        label = name if hn == name else "%s (%s)" % (hn, name)
         path = str(e["header"].relative_to(root)).replace("\\", "/")
-        dec, how = measured.get(name, (None, None))
+        dec, how = measured.get(hn, (None, None))
         how = "sizeof"
         if dec is None:
             dec, how = e["assert"], "assert"
         if dec is None:
-            buckets["NO SIZE"].append((name, None, rom, path,
-                                       measured.get(name, (None, why))[1] or "-"))
+            buckets["NO SIZE"].append((label, None, rom, path,
+                                       measured.get(hn, (None, why))[1] or "-"))
         elif dec == rom:
-            buckets["AGREES"].append((name, dec, rom, path, how))
+            buckets["AGREES" if e["assert"] is not None else "NO ASSERT"].append(
+                (label, dec, rom, path, how if e["assert"] is not None
+                 else "sizeof agrees, no typedef"))
         elif dec < rom:
-            agree = agreeing_descendants(name)
+            agree = agreeing_descendants(hn)
             if agree:
                 buckets["BASE, NOT SHORT"].append(
-                    (name, dec, rom, path,
+                    (label, dec, rom, path,
                      "%d agreeing subclasses, e.g. %s" % (len(agree), agree[0])))
             else:
-                buckets["HEADER SHORT"].append((name, dec, rom, path, how))
+                buckets["HEADER SHORT"].append((label, dec, rom, path, how))
         else:
-            buckets["HEADER LONG"].append((name, dec, rom, path, how))
+            buckets["HEADER LONG"].append((label, dec, rom, path, how))
     return buckets, hdr, stats
 
 
@@ -1021,11 +1121,13 @@ def main(argv=None):
             print("  (%s %s)" % (k, gstats[k]))
         for b in BUCKETS:
             print("  %-13s %d" % (b, len(buckets[b])))
-        for b in ("HEADER LONG", "HEADER SHORT", "BASE, NOT SHORT", "NO SIZE"):
+        for b in ("HEADER LONG", "HEADER SHORT", "BASE, NOT SHORT", "NO SIZE",
+                  "NO ASSERT", "NO HEADER"):
             print("\n-- %s (%d) --" % (b, len(buckets[b])))
             for name, dec, rom, path, how in buckets[b]:
                 d = ("0x%x" % dec) if dec is not None else how
-                print("  %-34s header %-9s rom 0x%-6x %s" % (name, d, rom, path))
+                print("  %-42s header %-9s rom 0x%-6x %s"
+                      % (name, d, rom, path or "-"))
 
     os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
     with open(out, "w", encoding="utf-8", newline="\n") as fh:

--- a/tools/test_opnew_sizes.py
+++ b/tools/test_opnew_sizes.py
@@ -1,4 +1,4 @@
-"""The three traps that have already cost this project landed work, as tests.
+"""The four traps that have already cost this project landed work, as tests.
 
 `opnew_sizes.py` recovers a class's size from the literal the ROM hands
 `fBase_c::operator new`, and attributes it by the vtable the factory installs. Each of
@@ -7,6 +7,12 @@ instead of the last (#1559/#1560 reverted 2 of 13), reading past the factory's o
 (commit 3f760a354, the mechanism behind the 41 misnamed classes of #1418-#1423), and
 crediting a member subobject's vptr to its owner -- is a case below, driven through
 synthetic ARM rather than the ROM so it runs in a checkout with no `extracted/`.
+
+The fourth is this file's own: attribution by address is worth nothing if the HEADER is
+then looked up by name. One vtable address carries several `_ZTV` spellings and only one
+of them has a file, so the single-spelling join reported NO HEADER for 125 classes the
+tree describes -- and their sizes went uncompared. Four cases cover it, and a live
+ratchet holds the residue at the two classes that really have no header.
 
 The two end-to-end cases skip themselves when the ROM dump is not installed, the same
 way tools/test_build_pin.py does.
@@ -189,6 +195,47 @@ def test_header_sizes_reads_the_assert_and_notices_one_that_is_missing(tmp_path)
     assert got["B"]["assert"] is None and got["B"]["header"].name == "B.h"
 
 
+def test_a_class_is_found_under_the_name_its_vtable_alias_carries():
+    """THE `--gap` defect.  Attribution is by address; the header lookup was by name.
+
+    One vtable address routinely carries several `_ZTV` symbols -- 0x021280b0 is
+    `_ZTV12FortressWall`, `_ZTV9MontyMole` and `_ZTV11daChoropu_c` at once -- and only
+    one of those spellings has a file.  Keying the header lookup on whichever spelling
+    the attribution happened to carry reported NO HEADER for 125 classes `include/`
+    describes, so their sizes were never compared to the header that describes them.
+    """
+    hdr = {"MontyMole": {"assert": 0x18C, "header": pathlib.Path("MontyMole.h")}}
+    assert O.resolve_header_name("daChoropu_c", ["FortressWall", "MontyMole"], hdr) \
+        == ("MontyMole", "vtable alias")
+
+
+def test_a_class_that_has_its_own_header_is_never_redirected_to_an_alias():
+    """The class's own key wins, so a real header is never shadowed by a sibling's."""
+    hdr = {"A": {"assert": 1, "header": None}, "B": {"assert": 2, "header": None}}
+    assert O.resolve_header_name("A", ["B"], hdr) == ("A", "name")
+
+
+def test_no_header_survives_only_when_no_spelling_has_one():
+    hdr = {"Other": {"assert": 1, "header": None}}
+    assert O.resolve_header_name("BigBooIcon", ["BigBooIcon"], hdr) == (None, None)
+    assert O.resolve_header_name("BigBooIcon", [], hdr) == (None, None)
+
+
+def test_every_ZTV_name_at_an_address_is_kept_not_just_the_last(tmp_path):
+    """The collapse that caused it: a dict keyed on (module, addr) keeps one name."""
+    cfg = tmp_path / "config" / "arm9"
+    (cfg / "overlays").mkdir(parents=True)
+    (cfg / "symbols.txt").write_text(
+        "_ZTV12FortressWall kind:data(any) addr:0x021280b0\n"
+        "_ZTV9MontyMole kind:data(any) addr:0x021280b0\n"
+        "_ZTV11daChoropu_c kind:data(any) addr:0x021280b0\n"
+        "_ZTV6Camera kind:data(any) addr:0x02100000\n")
+    st = collections.Counter()
+    got = O.load_vtable_symbols(tmp_path, {"arm9": (0, b"")}, st)
+    assert len(got[("arm9", 0x021280B0)]) == 3
+    assert st["vtable_addresses_with_more_than_one_name"] == 1
+
+
 def test_subclass_index_is_transitive(tmp_path):
     inc = tmp_path / "include"
     inc.mkdir()
@@ -225,3 +272,17 @@ def test_every_site_the_ROM_has_is_attributed_to_a_class():
     doc = O.build(REPO, REPO / "extracted")
     assert doc["meta"]["stats"]["sites_unattributed"] == 0
     assert all(s["size"] is not None for s in doc["sites"])
+
+
+def test_only_two_live_classes_are_genuinely_headerless():
+    """The ratchet on the alias join: it silently reverts to 127 if the join regresses.
+
+    `BigBooIcon` (0xd8) and `RecRoomCupboard` (0x21c) are the only two sized classes in
+    this ROM that no header in `include/` describes under any spelling their vtable
+    carries.  The probe is off: the header LOOKUP is what is under test, not sizeof."""
+    if not _rom():
+        return
+    doc = O.build(REPO, REPO / "extracted")
+    buckets, _hdr, _st = O.gap(REPO, doc, probe=False)
+    assert sorted(n for n, *_ in buckets["NO HEADER"]) == \
+        ["BigBooIcon", "RecRoomCupboard"], buckets["NO HEADER"]


### PR DESCRIPTION
Stacked behind #1661 (`types/opnew-sizes`) — review that first; this PR's own diff is its single commit. Restacked onto #1661's rebased tip `a8d886381`, so it sits on top of #1659 as well.

## The defect

`opnew_sizes.py` attributes a class size by **vtable address** — its own trap 1, never by name, because PR #1556 had to retract 2 of 21 findings that were name-pairing artifacts. But `--gap` then has to find the class in `include/`, and a file can only be found under a **spelling**. So the header lookup was a name join after all.

One vtable address routinely carries several `_ZTV` symbols, because a class being renamed keeps its old spelling until every consumer moves:

```
_ZTV12FortressWall kind:data(any) addr:0x021280b0
_ZTV9MontyMole     kind:data(any) addr:0x021280b0
_ZTV11daChoropu_c  kind:data(any) addr:0x021280b0
```

`load_vtable_symbols` collapsed each address to one name — whichever came last in the config file — and `--gap` looked for a header under that one. It reported **NO HEADER 127**. The truth is **2**.

Those 125 classes were bucketed unmeasurable, so their ROM sizes were **never compared to the header that actually describes them**.

## The fix

`resolve_header_name` tries the class's own key first (so a class with its own header is never redirected), then every other spelling the vtable address resolves to — the `_ZTV` aliases and the cartridge's RTTI name. The plain name join survives only as the zero-alias case. Still an address join throughout: the address decides which symbols are read, the symbols only supply spellings.

| bucket | before | after the join fix | after the asserts |
|---|---|---|---|
| AGREES | 187 | 254 | **297** |
| NO ASSERT | – | 43 | **0** |
| HEADER SHORT | 0 | 15 | **15** |
| HEADER LONG | 0 | 0 | 0 |
| BASE, NOT SHORT | 1 | 1 | 1 |
| NO SIZE | 0 | 0 | 0 |
| NO HEADER | **127** | **2** | **2** |
| AMBIGUOUS | 0 | 0 | 0 |

`AGREES` changed meaning: it now also requires the assert to exist, which is why 18 previously-`AGREES` classes moved into `NO ASSERT`. The 125 aliases split **85 / 25 / 15** — 85 already asserted correctly, 25 agreed with the ROM but asserted nothing, 15 are short.

## The 43 asserts

Every one was probed with the build's own mwccarm at the build's own flags: `sizeof` as the compiler computes it already equals the literal the ROM hands `fBase_c::operator new`. The typedef only freezes what both already say. None of the 43 is a base of another class in `include/`, so trap 5 does not apply — the ROM size is exact for a leaf.

**Why this is worth doing beyond the census.** An `X_size_must_be_0xN` typedef is how `check_header_offsets.py` sizes `X` when `X` appears as a **member** of another struct. Without one, any header that types a member as `X` reports UNPARSED — and that gate **exits 1 on unparsed**, not merely on mismatched. That is a real CI failure this tree has already taken, on #1659 (`Stage.h`'s `Fog unk_96c`). These 43 pre-emptively unblock typing a member as any of those 43 types, which is directly what the marker-typing campaign needs.

## The 15 refusals — reported, not forced

Each of these had its assert written, refused to compile under mwccarm, and was reverted. The header's extent disagrees with the ROM; none of the 15 is anybody's base, so the ROM size is exact for a leaf and it is the header that is short. Left exactly as #1661 left `dActor_c`.

| class | header `sizeof` | ROM | class | header `sizeof` | ROM |
|---|---|---|---|---|---|
| SnowmanHead | 0x170 | 0x338 | VolcanoFire | 0x108 | 0x11c |
| HauntedChair | 0x398 | 0x3a8 | PrincessPeach | 0x358 | 0x36c |
| Cannon | 0x188 | 0x198 | MotherPenguin | 0x378 | 0x38c |
| BulletBill | 0x3dc | 0x3e0 | RacingPenguin | 0x1ac | 0x398 |
| SpinningPlatform | 0x350 | 0x380 | KoopaFlag | 0x170 | 0x174 |
| TtcRotatingCube | 0x384 | 0x3d8 | KoopaShell | 0x3d8 | 0x3e0 |
| MegaMushroomCreateTag | 0x10c | 0x110 | Tornado | 0x36c | 0x370 |
| MansionSteps | 0x160 | 0x354 | | | |

`ExtendingPlatform` was the sixteenth on the pre-restack base; #1659 retyped it from 0x1a8 to 0x328, it now agrees with the ROM, and it takes its assert here. That is the shape the other 15 are expected to follow.

## The two genuinely headerless classes

`BigBooIcon` (0xd8) and `RecRoomCupboard` (0x21c) — no `include/` file describes either under any spelling their vtable carries. Recommendation: leave them to the header-generation pass rather than hand-writing a shell here. 0xd8 is `dActor_c`'s own 0xd0 plus 8, so `BigBooIcon` is very likely a near-empty `dActor_c` subclass, and both headers should come out of `gen_header` with real recovered fields rather than a size assert standing alone.

## Regression tests

Four new cases in `tools/test_opnew_sizes.py` cover the alias join — the bug that would silently come back — including a **live ratchet** that holds the `NO HEADER` residue at exactly those two classes. 18 pass.

## Gates (all run in the worktree; exit codes checked, not just counts)

| gate | result | exit |
|---|---|---|
| `tools/eligible.py -j 16`, bracketed | 11065 / 11187 both sides, **name lists byte-identical** | 0 / 0 |
| `tools/rombuild.py -j 16` | **106/106 exact**, 11,059 reproducing, 0 mismatching | 0 |
| `tools/check_header_offsets.py --changed origin/main` | 62 headers, 0 mismatched, **0 unparsed** (all 62 lines) | **0** |
| `tools/port_refcheck.py` | 393 references checked, all resolve | 0 |
| `tools/langmode_audit.py --check <freshly fetched chaos-data>` | **ratchet PASS**; full JSON diff vs #1661's tip shows **zero** metric deltas | 0 |
| `tools/opnew_sizes.py --check` | GATE OK — 391 call sites, 391 exact sizes | 0 |
| `tools/test_opnew_sizes.py` | 18 passed | 0 |
| `pyflakes tools/opnew_sizes.py tools/test_opnew_sizes.py` | clean | 0 |
