### PR TITLE
Type the 15 short headers up to the size the ROM's `operator new` proves

### DIFF
--- a/include/BulletBill.h
+++ b/include/BulletBill.h
@@ -35,6 +35,10 @@ struct BulletBill : dEnemyBase_c {
     ShadowModel mShadowModel;                              /* 0x3ac */
     s32 mState;            /* 0x3d4 */
     s32 unk_3d8;            /* 0x3d8 */
+    /* Trailing remainder, 4 bytes. Every sub-object is typed and every field
+       the seven recovered functions touch ends at 0x3dc; BulletBill_Spawn
+       allocates 0x3e0. */
+    u8  pad_3dc[0x4];
 
     virtual ~BulletBill();
 
@@ -97,8 +101,14 @@ struct BulletBill {
     u8  mShadowModel[0x28];            /* 0x3ac */
     s32 mState;            /* 0x3d4 */
     s32 unk_3d8;            /* 0x3d8 */
+    /* Trailing remainder, 4 bytes. Every sub-object is typed and every field
+       the seven recovered functions touch ends at 0x3dc; BulletBill_Spawn
+       allocates 0x3e0. */
+    u8  pad_3dc[0x4];
 };
 
 #endif /* __cplusplus */
+
+typedef char BulletBill_size_must_be_0x3e0[sizeof(struct BulletBill) == 0x3e0 ? 1 : -1];
 
 #endif /* BULLETBILL_H */

--- a/include/Cannon.h
+++ b/include/Cannon.h
@@ -6,6 +6,7 @@
 #define CANNON_H
 #include "types.h"
 #include "Model.h"
+#include "dCcAc_c.h"
 
 struct Cannon {
     u8  pad_000[0xd4];
@@ -13,11 +14,32 @@ struct Cannon {
        Model's D1 at +0x0d4 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN6CannonD0Ev.c] */
     Model mModel;            /* 0x0d4 */
-    u8  mdCcAc_c;            /* 0x124 */
-    u8  pad_125[0x5b];
+    /* dCcAc_c member, named by the class's own destructor calling
+       dCcAc_c's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN6CannonD0Ev.c] */
+    dCcAc_c mdCcAc_c;            /* 0x124 */
+    u8  pad_158[0x4];
+    /* Where the cannon was placed: InitResources copies mPos here verbatim
+       after lowering mPosY by 0x50000. */
+    s32 mSpawnPosX;            /* 0x15c */
+    s32 mSpawnPosY;            /* 0x160 */
+    s32 mSpawnPosZ;            /* 0x164 */
+    u8  pad_168[0xc];
+    s32 unk_174;            /* 0x174 */
+    s16 unk_178;            /* 0x178 */
+    s16 unk_17a;            /* 0x17a */
+    s16 unk_17c;            /* 0x17c */
+    u8  pad_17e[0x2];
+    /* State index. Behavior calls data_ov098_0213c8fc[unk_180] as a
+       pointer-to-member on `this`. */
     s32 unk_180;            /* 0x180 */
-    u8  pad_184[0x1];
+    /* Cannon variant, the low two bits of the spawn word. */
+    u8  unk_184;            /* 0x184 */
     u8  unk_185;            /* 0x185 */
+    u8  pad_186[0xe];
+    /* Read out of *(*(this + 0xe4) + 0x58) by InitResources -- the last field
+       of the object, and what closes the 0x198 Cannon_Spawn allocates. */
+    s32 unk_194;            /* 0x194 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -25,5 +47,7 @@ struct Cannon {
     int Render();
 #endif
 };
+
+typedef char Cannon_size_must_be_0x198[sizeof(struct Cannon) == 0x198 ? 1 : -1];
 
 #endif

--- a/include/HauntedChair.h
+++ b/include/HauntedChair.h
@@ -23,8 +23,11 @@ struct HauntedChair {
        ShadowModel's D1 at +0x124 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN12HauntedChairD0Ev.c] */
     ShadowModel mShadowModel;            /* 0x124 */
-    u8  unk_14c;            /* 0x14c */
-    u8  pad_14d[0x2f];
+    /* Matrix4x3: InitResources block-copies the 48-byte identity at
+       data_02082128 over this range in one go, and 0x14c + 0x30 lands exactly
+       on the dCcAcPos_c below -- the ShadowModel + shadow matrix pair this
+       family uses everywhere. Was a u8 marker plus its pad. */
+    Matrix4x3 mShadowMat;            /* 0x14c */
     /* dCcAcPos_c member, named by the class's own destructor calling
        dCcAcPos_c's D1 at +0x17c -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN12HauntedChairD0Ev.c] */
@@ -41,6 +44,10 @@ struct HauntedChair {
     s32 unk_38c;            /* 0x38c */
     s32 unk_390;            /* 0x390 */
     s32 unk_394;            /* 0x394 */
+    /* Trailing remainder, 0x10 bytes. Every marker is typed and the last field
+       the five recovered functions touch ends at 0x398; HauntedChair_Spawn
+       allocates 0x3a8. The reference does not document this class's members. */
+    u8  pad_398[0x10];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -48,5 +55,7 @@ struct HauntedChair {
     int Render();
 #endif
 };
+
+typedef char HauntedChair_size_must_be_0x3a8[sizeof(struct HauntedChair) == 0x3a8 ? 1 : -1];
 
 #endif

--- a/include/KoopaFlag.h
+++ b/include/KoopaFlag.h
@@ -18,6 +18,12 @@ struct KoopaFlag {
     ModelAnim mModelAnim;            /* 0x108 */
     u16 mVictoryTimer;            /* 0x16c */
     u8  mHasTouchedFlag;            /* 0x16e */
+    /* Trailing remainder, 5 bytes. Both markers were already typed and every
+       field the three recovered functions touch ends at 0x16f, but
+       KoopaFlag_Spawn allocates 0x174. The reference proposes an unused u8 at
+       0x16f and an unused u32 at 0x170; nothing in this tree reads either, so
+       they stay padding. */
+    u8  pad_16f[0x5];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -25,5 +31,7 @@ struct KoopaFlag {
     int Render();
 #endif
 };
+
+typedef char KoopaFlag_size_must_be_0x174[sizeof(struct KoopaFlag) == 0x174 ? 1 : -1];
 
 #endif

--- a/include/KoopaShell.h
+++ b/include/KoopaShell.h
@@ -52,6 +52,10 @@ struct KoopaShell : dEnemyBase_c {
     s32 unk_3cc;            /* 0x3cc */
     s32 unk_3d0;            /* 0x3d0 */
     s32 unk_3d4;            /* 0x3d4 */
+    /* Trailing remainder, 8 bytes. Every sub-object is typed and every field
+       the eight recovered functions touch ends at 0x3d8; KoopaShell_Spawn
+       allocates 0x3e0. */
+    u8  pad_3d8[0x8];
 
     virtual ~KoopaShell();
 
@@ -130,8 +134,14 @@ struct KoopaShell {
     s32 unk_3cc;            /* 0x3cc */
     s32 unk_3d0;            /* 0x3d0 */
     s32 unk_3d4;            /* 0x3d4 */
+    /* Trailing remainder, 8 bytes. Every sub-object is typed and every field
+       the eight recovered functions touch ends at 0x3d8; KoopaShell_Spawn
+       allocates 0x3e0. */
+    u8  pad_3d8[0x8];
 };
 
 #endif /* __cplusplus */
+
+typedef char KoopaShell_size_must_be_0x3e0[sizeof(struct KoopaShell) == 0x3e0 ? 1 : -1];
 
 #endif /* KOOPASHELL_H */

--- a/include/MansionSteps.h
+++ b/include/MansionSteps.h
@@ -6,6 +6,7 @@
 #define MANSIONSTEPS_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct MansionSteps {
     u8  pad_000[0xd4];
@@ -20,7 +21,18 @@ struct MansionSteps {
     u8  pad_151[0x5];
     u8  unk_156;            /* 0x156 */
     u8  pad_157[0x5];
-    u8  mMovingMeshCollider;            /* 0x15c */
+    /* dBgW_KcMbg member, named by the class's own destructor calling
+       dBgW_KcMbg's D1 at +0x15c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN12MansionStepsD0Ev.c] */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x15c */
+    /* The collider's transform, the second half of the dBgW_KcMbg + Matrix4x3
+       pair this tree carries everywhere a moving mesh collider appears
+       (dBgActor_c 0x124/0x2ec, SpinningPlatform and TtcRotatingCube the same,
+       both of which hand `this + 0x2ec` to dBgW_KcMbg::SetFile as a
+       `const Matrix4x3 &`). 0x15c + 0x1c8 = 0x324, and 0x324 + 0x30 closes on
+       the 0x354 MansionSteps_Spawn allocates. InitResources, which is where
+       the SetFile call would be, is still a near miss and not in the tree. */
+    Matrix4x3 mClsnMat;            /* 0x324 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -28,5 +40,7 @@ struct MansionSteps {
     int Render();
 #endif
 };
+
+typedef char MansionSteps_size_must_be_0x354[sizeof(struct MansionSteps) == 0x354 ? 1 : -1];
 
 #endif

--- a/include/MegaMushroomCreateTag.h
+++ b/include/MegaMushroomCreateTag.h
@@ -5,19 +5,32 @@
 #ifndef MEGAMUSHROOMCREATETAG_H
 #define MEGAMUSHROOMCREATETAG_H
 #include "types.h"
+#include "dCcAc_c.h"
 
 struct MegaMushroomCreateTag {
     u8  pad_000[0x8];
     s32 unk_008;            /* 0x008 */
     u8  pad_00c[0xc8];
-    u8  mdCcAc_c;            /* 0x0d4 */
-    u8  pad_0d5[0x34];
+    /* dCcAc_c member, named by the class's own destructor calling
+       dCcAc_c's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN21MegaMushroomCreateTagD0Ev.c] */
+    dCcAc_c mdCcAc_c;            /* 0x0d4 */
+    /* Five bytes past the cylinder, and Behavior reads or writes every one of
+       them through its own flat view of the object -- which is what closes the
+       0x110 MegaMushroomCreateTag_Spawn allocates. */
+    u8  unk_108;            /* 0x108 */
     s8  unk_109;            /* 0x109 */
+    u8  unk_10a;            /* 0x10a */
+    u8  unk_10b;            /* 0x10b */
+    u8  unk_10c;            /* 0x10c */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
     int InitResources();
 #endif
 };
+
+typedef char MegaMushroomCreateTag_size_must_be_0x110[
+    sizeof(struct MegaMushroomCreateTag) == 0x110 ? 1 : -1];
 
 #endif

--- a/include/MotherPenguin.h
+++ b/include/MotherPenguin.h
@@ -51,6 +51,11 @@ struct MotherPenguin {
     s32 unk_36c;            /* 0x36c */
     u8  pad_370[0x4];
     s32 unk_374;            /* 0x374 */
+    /* Trailing remainder, 0x14 bytes. Every marker is already typed and the
+       last field the five recovered functions touch ends at 0x378;
+       MotherPenguin_Spawn allocates 0x38c. The reference does not document
+       this class's members. */
+    u8  pad_378[0x14];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -58,5 +63,7 @@ struct MotherPenguin {
     int Render();
 #endif
 };
+
+typedef char MotherPenguin_size_must_be_0x38c[sizeof(struct MotherPenguin) == 0x38c ? 1 : -1];
 
 #endif

--- a/include/PrincessPeach.h
+++ b/include/PrincessPeach.h
@@ -6,6 +6,9 @@
 #define PRINCESSPEACH_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "ShadowModel.h"
+#include "dCcAc_c.h"
+#include "dBgCh_Actr.h"
 
 struct PrincessPeach {
     u8  pad_000[0xd4];
@@ -14,13 +17,25 @@ struct PrincessPeach {
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the
        Animation base), which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x138 */
-    u8  pad_139[0x27];
-    u8  mdCcAc_c;            /* 0x160 */
-    u8  pad_161[0x33];
-    u8  mWithMeshClsn;            /* 0x194 */
-    u8  pad_195[0x1bf];
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13PrincessPeachD0Ev.c] */
+    ShadowModel mShadowModel;            /* 0x138 */
+    /* dCcAc_c member, named by the class's own destructor calling
+       dCcAc_c's D1 at +0x160 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13PrincessPeachD0Ev.c] */
+    dCcAc_c mdCcAc_c;            /* 0x160 */
+    /* dBgCh_Actr member, named by the class's own destructor calling
+       dBgCh_Actr's D1 at +0x194 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13PrincessPeachD0Ev.c] */
+    dBgCh_Actr mWithMeshClsn;            /* 0x194 */
+    u8  pad_350[0x4];
     s32 unk_354;            /* 0x354 */
+    /* Trailing remainder, 0x14 bytes. All three markers are typed and the last
+       field the five recovered functions touch ends at 0x358;
+       PrincessPeach_Spawn allocates 0x36c. The reference does not document
+       this class's members. */
+    u8  pad_358[0x14];
 #ifdef __cplusplus
     /* methods */
     int Render();
@@ -30,5 +45,7 @@ struct PrincessPeach {
     int InitResources();
 #endif
 };
+
+typedef char PrincessPeach_size_must_be_0x36c[sizeof(struct PrincessPeach) == 0x36c ? 1 : -1];
 
 #endif

--- a/include/RacingPenguin.h
+++ b/include/RacingPenguin.h
@@ -9,6 +9,8 @@
 #include "TextureSequence.h"
 #include "ShadowModel.h"
 #include "dCcAc_c.h"
+#include "dBgCh_Actr.h"
+#include "PathPtr.h"
 
 struct RacingPenguin {
     u8  pad_000[0x80];
@@ -57,7 +59,22 @@ struct RacingPenguin {
        dCcAc_c's D1 at +0x174 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN13RacingPenguinD0Ev.c] */
     dCcAc_c mdCcAc_c;            /* 0x174 */
-    u8  mWithMeshClsn;            /* 0x1a8 */
+    /* dBgCh_Actr member, named by the class's own destructor calling
+       dBgCh_Actr's D1 at +0x1a8 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN13RacingPenguinD0Ev.c] */
+    dBgCh_Actr mWithMeshClsn;            /* 0x1a8 */
+    /* PathPtr: InitResources calls PathPtr::FromID on +0x364 and then
+       PathPtr::GetNode on it -- both take the address, so this is the object
+       and not a word inside one. */
+    PathPtr mPath;            /* 0x364 */
+    /* The node index GetNode is handed, by value, from +0x36c -- so it is a
+       field of the penguin and not part of the two-word PathPtr above. */
+    s32 mPathNodeIndex;            /* 0x36c */
+    u8  pad_370[0x26];
+    /* InitResources stores dActor_c::TrackStar's result here. It is the last
+       byte of the object: 0x397 rounds to the 0x398 RacingPenguin_Spawn
+       allocates. */
+    u8  unk_396;            /* 0x396 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -65,5 +82,7 @@ struct RacingPenguin {
     int Render();
 #endif
 };
+
+typedef char RacingPenguin_size_must_be_0x398[sizeof(struct RacingPenguin) == 0x398 ? 1 : -1];
 
 #endif

--- a/include/SnowmanHead.h
+++ b/include/SnowmanHead.h
@@ -6,6 +6,9 @@
 #define SNOWMANHEAD_H
 #include "types.h"
 #include "Model.h"
+#include "TextureSequence.h"
+#include "dCcAc_c.h"
+#include "dBgCh_Actr.h"
 
 struct SnowmanHead {
     u8  pad_000[0x5c];
@@ -20,11 +23,24 @@ struct SnowmanHead {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mTextureSequence;            /* 0x124 */
-    u8  pad_125[0x13];
-    u8  mdCcAc_c;            /* 0x138 */
-    u8  pad_139[0x33];
-    u8  mWithMeshClsn;            /* 0x16c */
+    /* TextureSequence member, named by the class's own destructor calling
+       TextureSequence's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11SnowmanHeadD0Ev.c] */
+    TextureSequence mTextureSequence;            /* 0x124 */
+    /* dCcAc_c member, named by the class's own destructor calling
+       dCcAc_c's D1 at +0x138 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11SnowmanHeadD0Ev.c] */
+    dCcAc_c mdCcAc_c;            /* 0x138 */
+    /* dBgCh_Actr member, named by the class's own destructor calling
+       dBgCh_Actr's D1 at +0x16c -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN11SnowmanHeadD0Ev.c] */
+    dBgCh_Actr mWithMeshClsn;            /* 0x16c */
+    /* Trailing remainder, 0x10 bytes. All three markers are typed and the
+       last one ends at 0x328; SnowmanHead_Spawn allocates 0x338. Nothing in
+       the five recovered functions reads this range -- the state machine that
+       does lives in func_ov072_02120560 / func_ov072_021205d4, which are not
+       decompiled -- so it stays explicit padding rather than invented fields. */
+    u8  pad_328[0x10];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -32,5 +48,7 @@ struct SnowmanHead {
     int Render();
 #endif
 };
+
+typedef char SnowmanHead_size_must_be_0x338[sizeof(struct SnowmanHead) == 0x338 ? 1 : -1];
 
 #endif

--- a/include/SpinningPlatform.h
+++ b/include/SpinningPlatform.h
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "Model.h"
 #include "ShadowModel.h"
+#include "dBgW_KcMbg.h"
 
 struct SpinningPlatform {
     u8  pad_000[0x5c];
@@ -21,16 +22,26 @@ struct SpinningPlatform {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
-    u8  unk_2ec;            /* 0x2ec */
-    u8  pad_2ed[0x31];
+    /* dBgW_KcMbg member, named by the class's own destructor calling
+       dBgW_KcMbg's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN16SpinningPlatformD1Ev.c] */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    /* The collider's transform: InitResources hands +0x2ec to
+       dBgW_KcMbg::SetFile as its `const Matrix4x3 &`. Was a u8 marker
+       plus its pad. */
+    Matrix4x3 mClsnMat;            /* 0x2ec */
+    u8  pad_31c[0x2];
     s8  mRandDirection;            /* 0x31e */
     u8  pad_31f[0x1];
     u16 mRandTimer;            /* 0x320 */
     u16 mRandFrames;            /* 0x322 */
     s32 mFloorPosY;            /* 0x324 */
     ShadowModel mShadowModel; /* 0x328 */
+    /* The shadow's transform. ShadowModel + Matrix4x3 is the same pair
+       HauntedChair evidences by byte (a 48-byte identity block-copied over
+       +0x14c, which lands exactly on the next member), and 0x350 + 0x30 closes
+       on the 0x380 SpinningPlatform_Spawn allocates. */
+    Matrix4x3 mShadowMat;            /* 0x350 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -39,5 +50,8 @@ struct SpinningPlatform {
     int Render();
 #endif
 };
+
+typedef char SpinningPlatform_size_must_be_0x380[
+    sizeof(struct SpinningPlatform) == 0x380 ? 1 : -1];
 
 #endif

--- a/include/Tornado.h
+++ b/include/Tornado.h
@@ -6,6 +6,7 @@
 #define TORNADO_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "dCcAc_c.h"
 #include "dBgCh_Actr.h"
 #include "TextureTransformer.h"
 
@@ -32,11 +33,12 @@ struct Tornado {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mdCcAc_c;            /* 0x0d4 */
-    u8  pad_0d5[0x1f];
-    s32 unk_0f4;            /* 0x0f4 */
-    u32 unk_0f8;            /* 0x0f8 */
-    u8  pad_0fc[0xc];
+    /* dCcAc_c member, named by the class's own destructor calling
+       dCcAc_c's D1 at +0x0d4 -- a relocation the ROM build
+       checks. Was a u8 marker whose pad stopped short of the object, so the
+       member also takes over unk_0f4 (+0x20 = dCc_c::hitFlags) and unk_0f8
+       (+0x24 = dCc_c::otherOwner), which Behavior reads as exactly those two. */
+    dCcAc_c mdCcAc_c;            /* 0x0d4 */
     /* dBgCh_Actr member, named by the class's own destructor calling
        dBgCh_Actr's D1 at +0x108 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN7TornadoD0Ev.c] */
@@ -63,11 +65,17 @@ struct Tornado {
     u8  pad_361[0x3];
     s32 unk_364;            /* 0x364 */
     s32 unk_368;            /* 0x368 */
+    /* Trailing remainder, 4 bytes. The one marker is typed and the last field
+       the five recovered functions touch ends at 0x36c; Tornado_Spawn
+       allocates 0x370. */
+    u8  pad_36c[0x4];
 #ifdef __cplusplus
     /* methods */
     int Behavior();
     int InitResources();
 #endif
 };
+
+typedef char Tornado_size_must_be_0x370[sizeof(struct Tornado) == 0x370 ? 1 : -1];
 
 #endif

--- a/include/TtcRotatingCube.h
+++ b/include/TtcRotatingCube.h
@@ -6,6 +6,8 @@
 #define TTCROTATINGCUBE_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
+#include "dBgW_KcMbg.h"
 
 struct TtcRotatingCube {
     u8  pad_000[0x90];
@@ -26,8 +28,14 @@ struct TtcRotatingCube {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel1;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member, named by the class's own destructor calling
+       dBgW_KcMbg's D1 at +0x124 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN15TtcRotatingCubeD1Ev.c] */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    /* The collider's transform: InitResources hands +0x2ec to
+       dBgW_KcMbg::SetFile as its `const Matrix4x3 &`. */
+    Matrix4x3 mClsnMat;            /* 0x2ec */
+    u8  pad_31c[0x4];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel2;            /* 0x320 */
@@ -36,8 +44,19 @@ struct TtcRotatingCube {
     u8  unk_376;            /* 0x376 */
     u8  unk_377;            /* 0x377 */
     s16 unk_378;            /* 0x378 */
-    u8  pad_37a[0x6];
-    u8  mShadowModel;            /* 0x380 */
+    /* Set to 1 by InitResources when the two ground probes disagree. */
+    u8  unk_37a;            /* 0x37a */
+    u8  pad_37b[0x1];
+    /* The floor height under the cube, from a dBgCh_Gnd probe. */
+    s32 unk_37c;            /* 0x37c */
+    /* ShadowModel member, named by the class's own destructor calling
+       ShadowModel's D1 at +0x380 -- a relocation the ROM build
+       checks. Was a u8 marker. [_ZN15TtcRotatingCubeD1Ev.c] */
+    ShadowModel mShadowModel;            /* 0x380 */
+    /* The shadow's transform, the same ShadowModel + Matrix4x3 pair
+       HauntedChair evidences by byte. 0x3a8 + 0x30 closes on the 0x3d8
+       TtcRotatingCube_Spawn allocates. */
+    Matrix4x3 mShadowMat;            /* 0x3a8 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
@@ -46,5 +65,8 @@ struct TtcRotatingCube {
     int Render();
 #endif
 };
+
+typedef char TtcRotatingCube_size_must_be_0x3d8[
+    sizeof(struct TtcRotatingCube) == 0x3d8 ? 1 : -1];
 
 #endif

--- a/include/VolcanoFire.h
+++ b/include/VolcanoFire.h
@@ -10,11 +10,29 @@
 struct VolcanoFire {
     u8  pad_000[0xd4];
     dCcAc_c mdCcAc_c;         /* 0x0d4 */
+    /* The four fields below are read by Behavior and CleanupResources and were
+       simply off the end of the generated header. VolcanoFire_Spawn allocates
+       0x11c, and 0x118 is the only word neither function touches. */
+    /* State record. Behavior loads it, reads a pointer-to-member at +0x8 and
+       calls it on `this` -- so it points at a state table entry, not a scalar. */
+    void *mState;             /* 0x108 */
+    /* The VolcanoRing that spawned this fire: CleanupResources decrements the
+       u16 at +0x324 of whatever this points at. */
+    void *mSpawner;           /* 0x10c */
+    /* Counted down every frame by DecIfAbove0_Short. */
+    u16 mKillTimer;           /* 0x110 */
+    u8  pad_112[0x2];
+    /* Particle handle, passed back into Particle::System::NewUnkCallback818. */
+    u32 mParticleID;          /* 0x114 */
+    /* Unread by the five recovered functions; the reference calls it killPosY. */
+    s32 unk_118;              /* 0x118 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();
     int InitResources();
 #endif
 };
+
+typedef char VolcanoFire_size_must_be_0x11c[sizeof(struct VolcanoFire) == 0x11c ? 1 : -1];
 
 #endif

--- a/src/_ZN11SnowmanHead8BehaviorEv.cpp
+++ b/src/_ZN11SnowmanHead8BehaviorEv.cpp
@@ -4,14 +4,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SnowmanHead.h"
-struct dCc_c { void Clear(); void Update(); };
 extern "C" void func_ov072_0211ffd8(void *c);
 
 int SnowmanHead::Behavior()
 {
     func_ov072_02120560(((char *)this));
-    ((dCc_c*)((char *)&mdCcAc_c))->Clear();
-    ((dCc_c*)((char *)&mdCcAc_c))->Update();
+    mdCcAc_c.Clear();
+    mdCcAc_c.Update();
     func_ov072_0211ffd8(((char *)this));
     return 1;
 }

--- a/src/_ZN12HauntedChair13InitResourcesEv.cpp
+++ b/src/_ZN12HauntedChair13InitResourcesEv.cpp
@@ -30,6 +30,6 @@ int HauntedChair::InitResources()
     unk_380 = mPosX;
     unk_384 = mPosY;
     unk_388 = mPosZ;
-    *(struct M48*)((char*)&unk_14c) = data_02082128;
+    *(struct M48*)((char*)&mShadowMat) = data_02082128;
     return 1;
 }

--- a/src/_ZN13PrincessPeach13InitResourcesEv.cpp
+++ b/src/_ZN13PrincessPeach13InitResourcesEv.cpp
@@ -7,8 +7,7 @@
 extern "C" void _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 struct BMD_File; struct dActor_c; struct Vector3_16;
-/* ModelBase is the real class now, through PrincessPeach.h. */
-struct ShadowModel { int InitCylinder(); };
+/* ModelBase and ShadowModel are the real classes now, through PrincessPeach.h. */
 /* Declared by final name, not as members: both take Fix12<int> where these calls pass
    int literals, and Fix12<int> is an aggregate with no converting constructor from int.
    dBgCh_Actr::Init's last parameter is a Vector3_16* as well -- the S5_ in
@@ -26,7 +25,7 @@ int PrincessPeach::InitResources()
     ((ModelBase*)(s + 0xd4))->SetFile((BMD_File*)f, 1, -1);
     for (int i = 0; i < 7; i++)
         _ZN9Animation8LoadFileER13SharedFilePtr((void*)data_ov085_0212f280[i]);
-    if (((ShadowModel*)(s + 0x138))->InitCylinder() == 0)
+    if (mShadowModel.InitCylinder() == 0)
         return 0;
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(
         s + 0x160, ((dActor_c *)this), 0x90000, 0xc0000, 0x4800004, 0);

--- a/src/_ZN16SpinningPlatform13InitResourcesEv.cpp
+++ b/src/_ZN16SpinningPlatform13InitResourcesEv.cpp
@@ -41,7 +41,7 @@ int SpinningPlatform::InitResources()
     void *kf = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(&data_ov035_02112cb8);
     _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
         (char *)&mMeshCollider, (KCL_File*)kf,
-        *(Matrix4x3*)((char *)&unk_2ec), 0x1000, mAngleY, data_ov035_02112238);
+        mClsnMat, 0x1000, mAngleY, data_ov035_02112238);
     func_020393d4(((char *)this) + 0x124, (void*)&_ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
     func_020396c0(((char *)this) + 0x124, 0);
     V3 v;

--- a/src/_ZN21MegaMushroomCreateTag8BehaviorEv.cpp
+++ b/src/_ZN21MegaMushroomCreateTag8BehaviorEv.cpp
@@ -8,11 +8,6 @@ typedef int Fix12i;
 
 extern "C" Fix12i Vec3_Dist(const Vector3 *a, const Vector3 *b);
 
-struct dCc_c {
-    void Clear();
-    void Update();
-};
-
 struct fBase_c {
     void MarkForDestruction();
 };
@@ -22,9 +17,7 @@ struct dActor_c : fBase_c {
     unsigned short actorID;   /* 0xc */
     char pad1[0x5c - 0xe];
     Vector3 pos;              /* 0x5c */
-    char pad2[0xd4 - 0x68];
-    dCc_c clsn;        /* 0xd4 */
-    char pad2b[0x108 - 0xd5];
+    char pad2[0x108 - 0x68];
     unsigned char b108;       /* 0x108 */
     unsigned char b109;       /* 0x109 */
     unsigned char b10a;       /* 0x10a */
@@ -71,7 +64,7 @@ int MegaMushroomCreateTag::Behavior()
             func_ov002_020b47ec(((dActor_c *)this));
         }
     }
-    ((dActor_c *)this)->clsn.Clear();
-    ((dActor_c *)this)->clsn.Update();
+    mdCcAc_c.Clear();
+    mdCcAc_c.Update();
     return 1;
 }

--- a/src/_ZN7Tornado8BehaviorEv.cpp
+++ b/src/_ZN7Tornado8BehaviorEv.cpp
@@ -28,8 +28,8 @@ int Tornado::Behavior()
         unk_350 = 0;
         unk_360 = 0;
     }
-    unsigned int id = unk_0f8;
-    if (id != 0 && (unk_0f4 & 0x400000) != 0) {
+    unsigned int id = mdCcAc_c.otherOwner;
+    if (id != 0 && (mdCcAc_c.hitFlags & 0x400000) != 0) {
         void *o = _ZN8dActor_c10FindWithIDEj(id);
         if (o != 0) {
             void *closest = _ZN8dActor_c18ClosestWithActorIDEj(((char *)this), 0x135);


### PR DESCRIPTION
Stacked on #1661 -> #1663. Base branch `types/opnew-gap-join`.

#1663 reported `HEADER SHORT 15`: fifteen leaf classes whose header models fewer
bytes than their own `X_Spawn` hands `operator new`. All fifteen are leaves, so the
allocation size is exact and it is the header that is short. This closes all fifteen.

**Padding was the last resort, not the first.** 14 markers were typed from the
ROM-decided evidence `marker_census.py --list` reports (the class's own D0/D1 calling
a sized type's destructor at that exact offset -- a relocation the byte gate checks),
2 more scalar markers were retyped from what the code does with them, and 26 further
fields were recovered from what the enrolled functions actually read and write past
the end of the generated header.

| class | header sizeof | ROM | markers typed / fields recovered | trailing pad | |
|---|---|---|---|---|---|
| SnowmanHead | 0x170 -> 0x338 | 0x338 | `TextureSequence`@0x124, `dCcAc_c`@0x138, `dBgCh_Actr`@0x16c | 0x10 | RESOLVED |
| MansionSteps | 0x160 -> 0x354 | 0x354 | `dBgW_KcMbg`@0x15c, `Matrix4x3`@0x324 | - | RESOLVED |
| RacingPenguin | 0x1ac -> 0x398 | 0x398 | `dBgCh_Actr`@0x1a8; `PathPtr`@0x364, `s32`@0x36c, `u8`@0x396 | - | RESOLVED |
| SpinningPlatform | 0x350 -> 0x380 | 0x380 | `dBgW_KcMbg`@0x124, `Matrix4x3`@0x2ec, `Matrix4x3`@0x350 | - | RESOLVED |
| TtcRotatingCube | 0x384 -> 0x3d8 | 0x3d8 | `dBgW_KcMbg`@0x124, `Matrix4x3`@0x2ec, `ShadowModel`@0x380, `Matrix4x3`@0x3a8; `u8`@0x37a, `s32`@0x37c | - | RESOLVED |
| VolcanoFire | 0x108 -> 0x11c | 0x11c | state ptr@0x108, spawner ptr@0x10c, `u16`@0x110, `u32`@0x114, `s32`@0x118 | - | RESOLVED |
| Cannon | 0x188 -> 0x198 | 0x198 | `dCcAc_c`@0x124; spawn `Vector3`@0x15c, `s32`@0x174, three `s16`@0x178/17a/17c, `u8`@0x184, `s32`@0x194 | - | RESOLVED |
| HauntedChair | 0x398 -> 0x3a8 | 0x3a8 | `Matrix4x3`@0x14c | 0x10 | RESOLVED |
| PrincessPeach | 0x358 -> 0x36c | 0x36c | `ShadowModel`@0x138, `dCcAc_c`@0x160, `dBgCh_Actr`@0x194 | 0x14 | RESOLVED |
| MotherPenguin | 0x378 -> 0x38c | 0x38c | (all markers already typed) | 0x14 | RESOLVED |
| BulletBill | 0x3dc -> 0x3e0 | 0x3e0 | (all sub-objects already typed) | 4 | RESOLVED |
| KoopaShell | 0x3d8 -> 0x3e0 | 0x3e0 | (all sub-objects already typed) | 8 | RESOLVED |
| Tornado | 0x36c -> 0x370 | 0x370 | `dCcAc_c`@0x0d4, absorbing `unk_0f4`/`unk_0f8` | 4 | RESOLVED |
| KoopaFlag | 0x170 -> 0x174 | 0x174 | (none left) | 5 | RESOLVED |
| MegaMushroomCreateTag | 0x10c -> 0x110 | 0x110 | `dCcAc_c`@0x0d4; five `u8`@0x108..0x10c | - | RESOLVED |

15 RESOLVED, 0 STILL SHORT. `opnew_sizes.py --gap`: `HEADER SHORT 15 -> 0`, `AGREES 297 -> 312`.

### Two structural pairs did most of the work, and both are byte-evidenced

* **`dBgW_KcMbg` is always followed by its own `Matrix4x3`.** SpinningPlatform and
  TtcRotatingCube both hand `this + 0x2ec` to `dBgW_KcMbg::SetFile` as its
  `const Matrix4x3 &`, and `0x124 + 0x1c8 = 0x2ec`. MansionSteps' collider sits at
  0x15c instead, and `0x15c + 0x1c8 + 0x30 = 0x354` exactly. (`dBgActor_c` carries the
  same pair at 0x124/0x2ec.)
* **`ShadowModel` is always followed by its own `Matrix4x3`.** HauntedChair proves it by
  byte: `InitResources` block-copies the 48-byte identity at `data_02082128` over
  `+0x14c`, which lands exactly on the next member. That is what licenses the shadow
  matrices at SpinningPlatform 0x350 and TtcRotatingCube 0x3a8.

### Consumers respelt (rule 6)

Six ad-hoc shadow declarations collided once the member was typed and were respelt
through the real member: two `struct dCc_c { Clear(); Update(); }` shadows
(SnowmanHead, MegaMushroomCreateTag -- the latter's shadow also carried a
`dCc_c clsn` whose 1-byte assumption fixed the following pads),
`struct ShadowModel { int InitCylinder(); }` (PrincessPeach),
`*(Matrix4x3 *)&unk_2ec` (SpinningPlatform), `*(M48 *)&unk_14c` (HauntedChair), and
Tornado's `unk_0f4`/`unk_0f8`, which are `dCc_c::hitFlags` and `dCc_c::otherOwner`
inside the cylinder the header had left untyped -- the `mdCcAc_c.otherOwner` pattern
KoopaFlag already carries.

### Trailing remainders, reported per rule 1

Where the ROM has bytes no function in this tree reads, the remainder is explicit
padding with the amount stated in the header, not invented fields:
SnowmanHead 0x10, HauntedChair 0x10, PrincessPeach 0x14, MotherPenguin 0x14,
KoopaShell 8, KoopaFlag 5, BulletBill 4, Tornado 4. Total 0x5d bytes across 8 classes.

### Where the reference contradicted the bytes

The reference types VolcanoFire `+0x108` as a plain `u32 unk108`. `Behavior` loads it,
reads a pointer-to-member at `+0x8` out of what it points at and calls that on `this`,
so it is a state-record pointer. Typed from the bytes, not from the reference.
The reference does not document HauntedChair, MotherPenguin or RacingPenguin members
at all, and its `Trap` (0x3b0, a `Platform`) is not `daTrsTrap_c`/MansionSteps (0x354,
collider at 0x15c) -- so MansionSteps' matrix comes from the in-tree pair above, not
from it. Where the reference does document a class (SnowmanHead, VolcanoFire,
KoopaFlag, SpinningPlatform, TTC_RotatingBlock) its field list lands on exactly the ROM
size this PR asserts, which is a useful independent corroboration.

### Byte verification

53 enrolled functions include one of these 15 headers. Every one was run through
`build_pin.verify` **before** any edit (53/53 OK, 2004/b56) and **again after** the
final tree (53/53 OK) -- 106 verifications, plus a per-class run as each header
landed. **Zero regressions, nothing reverted.** One compile failure was caught
mid-flight and fixed rather than worked around: SnowmanHead's `Behavior` carried a
`struct dCc_c` shadow that ICEs mwccarm once the real `dCc_c` is visible.

The two shadow TUs that include these headers (`src_tu/actors/HauntedChair.cpp`,
`src_tu/actors/RacingPenguin.cpp`) `#define` the include guard before including, so
they are unaffected; re-verified anyway at 14/14 and 30/30 MATCH.

### Gates -- all run, exit code reported

| gate | result | exit |
|---|---|---|
| `eligible.py -j 16` (bracketed) | 11065 / 11187 both sides, name lists byte-identical | 0 |
| `rombuild.py -j 16` | 106/106 exact, 11,059 reproducing, **0 mismatching** | 0 |
| `check_header_offsets.py --changed origin/main` | 77 headers; all 15 report 0 mismatched, 0 unparsed | 0 |
| `port_refcheck.py` | 393 checked, all resolve | 0 |
| `langmode_audit.py --check` (fresh `origin/chaos-data`) | `langmode ratchet PASS` | 0 |
| `opnew_sizes.py --check` | `GATE OK` | 0 |
| `opnew_sizes.py --gap` | HEADER SHORT 0, HEADER LONG 0, NO ASSERT 0 | 0 |
| `pytest tools/test_opnew_sizes.py` | 18 passed | 0 |

`marker_census.py`: bare markers 213 -> 203, decidable-now 48 -> 34; none of the
remaining 34 belongs to any of these 15 classes.
