### PR TITLE
Read member types out of the cartridge's destructor relocations

### DIFF
--- a/include/ArrowSignRight.h
+++ b/include/ArrowSignRight.h
@@ -2,6 +2,7 @@
 #define ARROWSIGNRIGHT_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -59,8 +60,11 @@ struct ArrowSignRight {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~ArrowSignRight calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* ShadowModel member, named by the class's own destructor calling
        ShadowModel's D1 at +0x320 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN14ArrowSignRightD1Ev.c] */

--- a/include/BasementWater.h
+++ b/include/BasementWater.h
@@ -2,6 +2,7 @@
 #define BASEMENTWATER_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -62,8 +63,11 @@ struct BasementWater {
        short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
        header declared separately inside it. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~BasementWater calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     TextureTransformer mTextureTransformer; /* 0x320 */
     s32 mLoweredY;            /* 0x334 */
     u32 mSoundID;            /* 0x338 */

--- a/include/BigBrickBlock.h
+++ b/include/BigBrickBlock.h
@@ -2,6 +2,7 @@
 #define BIGBRICKBLOCK_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -119,8 +120,11 @@ struct BigBrickBlock {
        Model's D1 at +0x0d4 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN13BigBrickBlockD1Ev.c] */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~BigBrickBlock calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     u8  unk_31e;            /* 0x31e */
     u8  unk_31f;            /* 0x31f */
     u8  mEventID;            /* 0x320 */

--- a/include/BigMovingIceBlock.h
+++ b/include/BigMovingIceBlock.h
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "Model.h"
 #include "PathPtr.h"
+#include "dBgW_KcMbg.h"
 
 struct BigMovingIceBlock {
     u8  pad_000[0x8];
@@ -23,8 +24,12 @@ struct BigMovingIceBlock {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~BigMovingIceBlock calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     PathPtr mPath;            /* 0x320 */
     s32 mPathNodeIdx;            /* 0x328 */
     s32 mPathDir;            /* 0x32c */

--- a/include/BlueCoinSwitch.h
+++ b/include/BlueCoinSwitch.h
@@ -2,6 +2,8 @@
 #define BLUECOINSWITCH_H
 
 #include "types.h"
+#include "Model.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -64,10 +66,14 @@ struct BlueCoinSwitch {
        after the switch stops claiming membership. */
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* Model member. The cartridge's own ~BlueCoinSwitch calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
+    /* dBgW_KcMbg member. The cartridge's own ~BlueCoinSwitch calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     /* Real type, not a marker: InitResources hands it to
        dBgW_KcMbg::SetFile as the collider's transform. */
     Matrix4x3 mMatrix;            /* 0x2ec */

--- a/include/Butterfly.h
+++ b/include/Butterfly.h
@@ -9,6 +9,7 @@
 #include "Model.h"
 #include "ShadowModel.h"
 #include "dBgCh_Actr.h"
+#include "dCcAcPos_c.h"
 
 struct Butterfly {
     u8  pad_000[0x80];
@@ -50,8 +51,11 @@ struct Butterfly {
        dBgCh_Actr's D1 at +0x1d8 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN9ButterflyD0Ev.c] */
     dBgCh_Actr mWithMeshClsn;            /* 0x1d8 */
-    u8  mdCcAcPos_c;            /* 0x394 */
-    u8  pad_395[0x4b];
+    /* dCcAcPos_c member. The cartridge's own ~Butterfly calls _ZN10dCcAcPos_cD1Ev at
+       +0x394 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dCcAcPos_c mdCcAcPos_c;            /* 0x394 */
+    u8  pad_3d4[0xc];
     s32 unk_3e0;            /* 0x3e0 */
     s32 unk_3e4;            /* 0x3e4 */
     u8  pad_3e8[0x8];

--- a/include/CastleWater.h
+++ b/include/CastleWater.h
@@ -21,6 +21,7 @@
 #include "types.h"
 #include "math/Matrix.h"
 #include "TextureTransformer.h"
+#include "dBgW_KcMbg.h"
 
 struct CastleWater {
     u8  pad_000[0x5c];
@@ -40,8 +41,10 @@ struct CastleWater {
     u8  pad_0d5[0x7];
     u8  mModelComponents;            /* 0x0dc */
     u8  pad_0dd[0x47];
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* dBgW_KcMbg member. The cartridge's own ~CastleWater calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     /* Real type, not a marker: InitResources hands it to
        dBgW_KcMbg::SetFile through an explicit `Matrix4x3&` cast. */
     Matrix4x3 mMatrix;            /* 0x2ec */

--- a/include/CccArena.h
+++ b/include/CccArena.h
@@ -14,6 +14,7 @@
 #ifndef CCCARENA_H
 #define CCCARENA_H
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 #ifdef __cplusplus
 
@@ -74,8 +75,11 @@ struct CccArena {
     s16 mAngleZ;            /* 0x090 */
     u8  pad_092[0x42];
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~CccArena calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     u8  unk_320;            /* 0x320 */
     u8  pad_321[0xf];
     u16 unk_330;            /* 0x330 */

--- a/include/ChainChompFence.h
+++ b/include/ChainChompFence.h
@@ -2,6 +2,7 @@
 #define CHAINCHOMPFENCE_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -43,8 +44,11 @@ struct ChainChompFence {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~ChainChompFence calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     u8  unk_31e;            /* 0x31e */
 };
 

--- a/include/Crate.h
+++ b/include/Crate.h
@@ -23,6 +23,8 @@
 #ifndef CRATE_H
 #define CRATE_H
 #include "types.h"
+#include "Model.h"
+#include "dBgW_KcMbg.h"
 
 /* Player is only ever pointed at from here, so a declaration is enough --
  * no definition is pulled in. The typedef keeps the member spelled the
@@ -109,10 +111,15 @@ struct Crate {
     u32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x1c];
     s32 mEatingPlayer;            /* 0x0d0 */
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* Model member. The cartridge's own ~Crate calls _ZN5ModelD1Ev at +0x0d4 (D0/D1), a
+       relocation the ROM build checks; recovered by tools/dtor_members.py. D1 and not
+       D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
+    /* dBgW_KcMbg member. The cartridge's own ~Crate calls _ZN10dBgW_KcMbgD1Ev at +0x124
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     u8  mWithMeshClsn;            /* 0x320 */
     u8  pad_321[0x1c7];
     s32 unk_4e8;            /* 0x4e8 */

--- a/include/DonutBlock.h
+++ b/include/DonutBlock.h
@@ -2,6 +2,7 @@
 #define DONUTBLOCK_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -60,8 +61,11 @@ struct DonutBlock {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~DonutBlock calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* dBgCh_Actr member, named by the class's own destructor calling
        dBgCh_Actr's D1 at +0x320 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN10DonutBlockD1Ev.c] */

--- a/include/Eyerok.h
+++ b/include/Eyerok.h
@@ -34,6 +34,8 @@
 #ifndef EYEROK_H
 #define EYEROK_H
 #include "types.h"
+#include "Model.h"
+#include "dBgW_KcMbg.h"
 
 #ifdef __cplusplus
 
@@ -107,10 +109,15 @@ struct Eyerok {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel1;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  unk_124;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* Model member. The cartridge's own ~Eyerok calls _ZN5ModelD1Ev at +0x0d4 (D0/D1),
+       a relocation the ROM build checks; recovered by tools/dtor_members.py. D1 and not
+       D2, so it is this type and not an inlined base. */
+    Model mModel1;            /* 0x0d4 */
+    /* dBgW_KcMbg member. The cartridge's own ~Eyerok calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg unk_124;            /* 0x124 */
+    u8  pad_2ec[0x34];
     u8  mdCcAcPos_c;            /* 0x320 */
     u8  pad_321[0x33];
     s32 unk_354;            /* 0x354 */

--- a/include/Fish.h
+++ b/include/Fish.h
@@ -5,6 +5,7 @@
 #ifndef FISH_H
 #define FISH_H
 #include "types.h"
+#include "ModelAnim.h"
 
 struct Fish {
     u8  pad_000[0x4];
@@ -13,8 +14,11 @@ struct Fish {
     u8  pad_00c[0x54];
     s32 mPosY;            /* 0x060 */
     u8  pad_064[0x70];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x67];
+    /* ModelAnim member. The cartridge's own ~Fish calls _ZN9ModelAnimD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
+    u8  pad_138[0x4];
     s32 unk_13c;            /* 0x13c */
     s32 unk_140;            /* 0x140 */
     u8  pad_144[0x8];

--- a/include/FloatOnLavaPlatform.h
+++ b/include/FloatOnLavaPlatform.h
@@ -2,6 +2,7 @@
 #define FLOATONLAVAPLATFORM_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -47,8 +48,12 @@ struct FloatOnLavaPlatform {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~FloatOnLavaPlatform calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 mMaxPosY;            /* 0x320 */
     u8  mHadClsn;            /* 0x324 */
 };

--- a/include/FortressWall.h
+++ b/include/FortressWall.h
@@ -2,6 +2,7 @@
 #define FORTRESSWALL_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -74,8 +75,11 @@ struct FortressWall {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~FortressWall calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     u8  unk_31e;            /* 0x31e */
     u8  unk_31f;            /* 0x31f */
     u8  pad_320[0x1];

--- a/include/HugeWater.h
+++ b/include/HugeWater.h
@@ -2,6 +2,7 @@
 #define HUGEWATER_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -45,8 +46,11 @@ struct HugeWater {
        short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
        header declared separately inside it. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~HugeWater calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     TextureTransformer mTextureTransformer; /* 0x320 */
 };
 

--- a/include/IceBlock.h
+++ b/include/IceBlock.h
@@ -2,6 +2,7 @@
 #define ICEBLOCK_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -67,8 +68,11 @@ struct IceBlock {
        Model's D1 at +0x0d4 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN8IceBlockD1Ev.c] */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~IceBlock calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     u8  mdCcAc_c;            /* 0x320 */
     u8  pad_321[0x1f];
     s32 unk_340;            /* 0x340 */

--- a/include/KnockDownPlank.h
+++ b/include/KnockDownPlank.h
@@ -2,6 +2,7 @@
 #define KNOCKDOWNPLANK_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -69,8 +70,11 @@ struct KnockDownPlank {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~KnockDownPlank calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     ShadowModel mShadowModel; /* 0x320 */
     u8  pad_348[0x30];
     s32 unk_378;            /* 0x378 */

--- a/include/LavaPlank.h
+++ b/include/LavaPlank.h
@@ -2,6 +2,7 @@
 #define LAVAPLANK_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -47,8 +48,11 @@ struct LavaPlank {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~LavaPlank calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 mOriginalPosY;            /* 0x320 */
     s16 unk_324;            /* 0x324 */
 };

--- a/include/MadPiano.h
+++ b/include/MadPiano.h
@@ -6,6 +6,7 @@
 #define MADPIANO_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "Model.h"
 
 struct MadPiano {
     u8  pad_000[0x5c];
@@ -21,8 +22,10 @@ struct MadPiano {
     s32 unk_09c;            /* 0x09c */
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member. The cartridge's own ~MadPiano calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1fb];
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x320 -- a relocation the ROM build checks.

--- a/include/MovingBar.h
+++ b/include/MovingBar.h
@@ -2,6 +2,7 @@
 #define MOVINGBAR_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -88,8 +89,11 @@ struct MovingBar {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~MovingBar calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 unk_320;            /* 0x320 */
     s32 unk_324;            /* 0x324 */
     s32 unk_328;            /* 0x328 */

--- a/include/MrI.h
+++ b/include/MrI.h
@@ -6,6 +6,8 @@
 #define MRI_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "ShadowModel.h"
+#include "dCcAcPos_c.h"
 
 struct MrI {
     u8  pad_000[0x8];
@@ -34,10 +36,14 @@ struct MrI {
     u8  pad_139[0xb];
     s32 unk_144;            /* 0x144 */
     u8  pad_148[0x4];
-    u8  mShadowModel;            /* 0x14c */
-    u8  pad_14d[0x27];
-    u8  mdCcAcPos_c;            /* 0x174 */
-    u8  pad_175[0x3f];
+    /* ShadowModel member. The cartridge's own ~MrI calls _ZN11ShadowModelD1Ev at +0x14c
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel;            /* 0x14c */
+    /* dCcAcPos_c member. The cartridge's own ~MrI calls _ZN10dCcAcPos_cD1Ev at +0x174
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    dCcAcPos_c mdCcAcPos_c;            /* 0x174 */
     u8  unk_1b4;            /* 0x1b4 */
     u8  pad_1b5[0x37];
     s32 unk_1ec;            /* 0x1ec */

--- a/include/PathLift.h
+++ b/include/PathLift.h
@@ -2,6 +2,8 @@
 #define PATHLIFT_H
 
 #include "types.h"
+#include "Model.h"
+#include "dBgW_KcMbg.h"
 
 /* A lift that runs along a path. Derives from dBgActor_c, and its own data starts
  * in the base's tail padding at 0x31e (dBgActor_c's last field ends there and its
@@ -44,10 +46,15 @@ struct PathLift {
     u8  pad_000[0xc];
     u16 unk_00c;            /* 0x00c */
     u8  pad_00e[0xc6];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x305];
+    /* Model member. The cartridge's own ~PathLift calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
+    /* dBgW_KcMbg member. The cartridge's own ~PathLift calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x13e];
     u8  unk_42a;            /* 0x42a */
     u8  unk_42b;            /* 0x42b */
     u8  pad_42c[0x20];

--- a/include/PoleLift.h
+++ b/include/PoleLift.h
@@ -2,6 +2,7 @@
 #define POLELIFT_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -48,8 +49,11 @@ struct PoleLift {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~PoleLift calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* dCcAc_c member, named by the class's own destructor calling
        dCcAc_c's D1 at +0x320 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN8PoleLiftD1Ev.c] */

--- a/include/PyramidStep.h
+++ b/include/PyramidStep.h
@@ -2,6 +2,7 @@
 #define PYRAMIDSTEP_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -59,8 +60,11 @@ struct PyramidStep {
        Model's D1 at +0x0d4 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN11PyramidStepD1Ev.c] */
     Model mModel1;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~PyramidStep calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel2;            /* 0x320 */

--- a/include/PyramidTop.h
+++ b/include/PyramidTop.h
@@ -2,6 +2,7 @@
 #define PYRAMIDTOP_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -69,8 +70,11 @@ struct PyramidTop {
        Model's D1 at +0x0d4 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN10PyramidTopD1Ev.c] */
     Model mModel1;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~PyramidTop calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. The marker's pad ran 0x30
        bytes PAST the end of the object; that space is not evidenced and stays explicit

--- a/include/QuestionBlock.h
+++ b/include/QuestionBlock.h
@@ -2,6 +2,7 @@
 #define QUESTIONBLOCK_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -99,8 +100,11 @@ struct QuestionBlock {
     u8  pad_0d5[0x1b];
     u8  unk_0f0;            /* 0x0f0 */
     u8  pad_0f1[0x33];
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~QuestionBlock calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x320 -- a relocation the ROM build
        checks. D1 and not D2, so it is this type and not an inlined base. The marker's pad
        stopped short of the object, so the member also takes over mAnimation (+0x50 = the

--- a/include/QuestionSwitch.h
+++ b/include/QuestionSwitch.h
@@ -15,6 +15,8 @@
 #ifndef QUESTIONSWITCH_H
 #define QUESTIONSWITCH_H
 #include "types.h"
+#include "Model.h"
+#include "dBgW_KcMbg.h"
 
 #ifdef __cplusplus
 
@@ -69,10 +71,15 @@ struct QuestionSwitch {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  unk_124;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* Model member. The cartridge's own ~QuestionSwitch calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
+    /* dBgW_KcMbg member. The cartridge's own ~QuestionSwitch calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg unk_124;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 mActiveMeshCollider;            /* 0x320 */
     u8  unk_324;            /* 0x324 */
     u8  pad_325[0x1c7];

--- a/include/RickshawPlatformBs.h
+++ b/include/RickshawPlatformBs.h
@@ -2,6 +2,7 @@
 #define RICKSHAWPLATFORMBS_H
 
 #include "types.h"
+#include "Model.h"
 
 /* The Bowser-in-the-Sky drifting platform. ROM name daObjKm3_Dorifu_c.
  *
@@ -49,8 +50,10 @@ typedef char RickshawPlatformBs_size_must_be_0xdcc[sizeof(RickshawPlatformBs) ==
    can never be migrated. Same arrangement as include/dBgActor_c.h. */
 struct RickshawPlatformBs {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member. The cartridge's own ~RickshawPlatformBs calls _ZN5ModelD1Ev at
+       +0x0d4 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 };
 

--- a/include/RotatingBridge.h
+++ b/include/RotatingBridge.h
@@ -2,6 +2,7 @@
 #define ROTATINGBRIDGE_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -56,8 +57,11 @@ struct RotatingBridge {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~RotatingBridge calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     s8  unk_31e;            /* 0x31e */
     u8  pad_31f[0x1];
     s32 unk_320;            /* 0x320 */

--- a/include/RotatingCogSmall.h
+++ b/include/RotatingCogSmall.h
@@ -2,6 +2,7 @@
 #define ROTATINGCOGSMALL_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -50,8 +51,12 @@ struct RotatingCogSmall {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~RotatingCogSmall calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     s16 unk_31e;            /* 0x31e */
     s16 unk_320;            /* 0x320 */
     s16 unk_322;            /* 0x322 */

--- a/include/RotatingUpDownPlatform.h
+++ b/include/RotatingUpDownPlatform.h
@@ -6,6 +6,7 @@
 #define ROTATINGUPDOWNPLATFORM_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct RotatingUpDownPlatform {
     u8  pad_000[0x8];
@@ -32,8 +33,12 @@ struct RotatingUpDownPlatform {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1ff];
+    /* dBgW_KcMbg member. The cartridge's own ~RotatingUpDownPlatform calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x38];
     s32 unk_324;            /* 0x324 */
     s32 unk_328;            /* 0x328 */
     s32 unk_32c;            /* 0x32c */

--- a/include/RotatingUpDownPlatformUtm.h
+++ b/include/RotatingUpDownPlatformUtm.h
@@ -15,6 +15,7 @@
 #ifndef ROTATINGUPDOWNPLATFORMUTM_H
 #define ROTATINGUPDOWNPLATFORMUTM_H
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 #ifdef __cplusplus
 
@@ -103,8 +104,12 @@ struct RotatingUpDownPlatformUtm {
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1db];
+    /* dBgW_KcMbg member. The cartridge's own ~RotatingUpDownPlatformUtm calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x14];
     u8  unk_300;            /* 0x300 */
     u8  pad_301[0x1f];
     u8  mShadowModel;            /* 0x320 */

--- a/include/SeesawBob.h
+++ b/include/SeesawBob.h
@@ -2,6 +2,7 @@
 #define SEESAWBOB_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -52,8 +53,11 @@ struct SeesawBob {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~SeesawBob calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 unk_320;            /* 0x320 */
     s16 unk_324;            /* 0x324 */
     u8  unk_326;            /* 0x326 */

--- a/include/ShipUp.h
+++ b/include/ShipUp.h
@@ -6,6 +6,7 @@
 #define SHIPUP_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct ShipUp {
     u8  pad_000[0xc];
@@ -17,8 +18,11 @@ struct ShipUp {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~ShipUp calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     u8  mModelIndex;            /* 0x31e */
     u8  pad_31f[0x1];
     u16 unk_320;            /* 0x320 */

--- a/include/ShipWater.h
+++ b/include/ShipWater.h
@@ -2,6 +2,7 @@
 #define SHIPWATER_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -75,8 +76,11 @@ struct ShipWater {
        short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
        header declared separately inside it. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~ShipWater calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     TextureTransformer mTextureTransformer; /* 0x320 */
     s32 mOriginalPosY;            /* 0x334 */
     u8  mChestsOpen;            /* 0x338 */

--- a/include/SignPost.h
+++ b/include/SignPost.h
@@ -38,6 +38,9 @@
 #ifndef SIGNPOST_H
 #define SIGNPOST_H
 #include "types.h"
+#include "Model.h"
+#include "dBgW_KcMbg.h"
+#include "dBgCh_Actr.h"
 
 /* Player is only ever pointed at from here, so a declaration is enough --
  * no definition is pulled in. The typedef keeps the member spelled the
@@ -66,8 +69,11 @@ struct SignPost : dBgActor_c {
     s16 unk_3be;                /* 0x3be */
     s16 unk_3c0;                /* 0x3c0 */
     u8  pad_3c2[0x6];
-    u8  mWithMeshClsn;          /* 0x3c8 */
-    u8  pad_3c9[0x1c5];
+    /* dBgCh_Actr member. The cartridge's own ~SignPost calls _ZN10dBgCh_ActrD1Ev at
+       +0x3c8 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgCh_Actr mWithMeshClsn;            /* 0x3c8 */
+    u8  pad_584[0xa];
     u8  unk_58e;                /* 0x58e */
     u8  unk_58f;                /* 0x58f */
     u8  unk_590;                /* 0x590 */
@@ -136,10 +142,14 @@ struct SignPost {
     u8  pad_0a4[0xc];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* Model member. The cartridge's own ~SignPost calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
+    /* dBgW_KcMbg member. The cartridge's own ~SignPost calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
     u8  mdCcAc_c;            /* 0x320 */
@@ -153,8 +163,11 @@ struct SignPost {
     s16 unk_3be;            /* 0x3be */
     s16 unk_3c0;            /* 0x3c0 */
     u8  pad_3c2[0x6];
-    u8  mWithMeshClsn;            /* 0x3c8 */
-    u8  pad_3c9[0x1c5];
+    /* dBgCh_Actr member. The cartridge's own ~SignPost calls _ZN10dBgCh_ActrD1Ev at
+       +0x3c8 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgCh_Actr mWithMeshClsn;            /* 0x3c8 */
+    u8  pad_584[0xa];
     u8  unk_58e;            /* 0x58e */
     u8  unk_58f;            /* 0x58f */
     u8  unk_590;            /* 0x590 */

--- a/include/SlidingBox.h
+++ b/include/SlidingBox.h
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "Model.h"
 #include "dBgCh_Actr.h"
+#include "dBgW_KcMbg.h"
 
 struct SlidingBox {
     u8  pad_000[0x5c];
@@ -30,8 +31,11 @@ struct SlidingBox {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~SlidingBox calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 mShip;            /* 0x320 */
     /* dBgCh_Actr member, named by the class's own destructor calling
        dBgCh_Actr's D1 at +0x324 -- a relocation the ROM build

--- a/include/SlidingPlatformWf.h
+++ b/include/SlidingPlatformWf.h
@@ -2,6 +2,7 @@
 #define SLIDINGPLATFORMWF_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -49,8 +50,12 @@ struct SlidingPlatformWf {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~SlidingPlatformWf calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     u8  unk_31e;            /* 0x31e */
     u8  pad_31f[0x1];
     s16 unk_320;            /* 0x320 */

--- a/include/SnowmanBody.h
+++ b/include/SnowmanBody.h
@@ -6,6 +6,9 @@
 #define SNOWMANBODY_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
+#include "dCcAc_c.h"
+#include "dBgCh_Actr.h"
 
 struct SnowmanBody {
     u8  pad_000[0x8];
@@ -27,12 +30,18 @@ struct SnowmanBody {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mShadowModel;            /* 0x124 */
-    u8  pad_125[0x27];
-    u8  mdCcAc_c;            /* 0x14c */
-    u8  pad_14d[0x33];
-    u8  mWithMeshClsn;            /* 0x180 */
-    u8  pad_181[0x1bb];
+    /* ShadowModel member. The cartridge's own ~SnowmanBody calls _ZN11ShadowModelD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel;            /* 0x124 */
+    /* dCcAc_c member. The cartridge's own ~SnowmanBody calls _ZN7dCcAc_cD1Ev at +0x14c
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    dCcAc_c mdCcAc_c;            /* 0x14c */
+    /* dBgCh_Actr member. The cartridge's own ~SnowmanBody calls _ZN10dBgCh_ActrD1Ev at
+       +0x180 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgCh_Actr mWithMeshClsn;            /* 0x180 */
     s32 unk_33c;            /* 0x33c */
     s32 unk_340;            /* 0x340 */
     s32 unk_344;            /* 0x344 */

--- a/include/SquarePathLift.h
+++ b/include/SquarePathLift.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "PathPtr.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -55,8 +56,11 @@ struct SquarePathLift {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~SquarePathLift calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     PathPtr mPath;            /* 0x320 */
     s32 mNodeIndex;            /* 0x328 */
     s32 mPathDir;            /* 0x32c */

--- a/include/StarSwitch.h
+++ b/include/StarSwitch.h
@@ -2,6 +2,7 @@
 #define STARSWITCH_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -90,8 +91,11 @@ struct StarSwitch {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~StarSwitch calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 unk_320;            /* 0x320 */
     s32 unk_324;            /* 0x324 */
     s32 unk_328;            /* 0x328 */

--- a/include/SwitchActivatedPlank.h
+++ b/include/SwitchActivatedPlank.h
@@ -6,6 +6,7 @@
 #define SWITCHACTIVATEDPLANK_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct SwitchActivatedPlank {
     u8  pad_000[0x8e];
@@ -15,8 +16,12 @@ struct SwitchActivatedPlank {
        Model's D1 at +0x0d4 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN20SwitchActivatedPlankD1Ev.c] */
     Model mModel1;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~SwitchActivatedPlank calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. The marker's pad ran 0x30
        bytes PAST the end of the object; that space is not evidenced and stays explicit

--- a/include/TTC_MovingBar.h
+++ b/include/TTC_MovingBar.h
@@ -2,6 +2,7 @@
 #define TTC_MOVINGBAR_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -57,8 +58,11 @@ struct TTC_MovingBar {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1f9];
+    /* dBgW_KcMbg member. The cartridge's own ~TTC_MovingBar calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     u8  unk_31e;            /* 0x31e */
     u8  pad_31f[0x1];
     s32 unk_320;            /* 0x320 */

--- a/include/TinyWater.h
+++ b/include/TinyWater.h
@@ -2,6 +2,7 @@
 #define TINYWATER_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -52,8 +53,11 @@ struct TinyWater {
        short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
        header declared separately inside it. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~TinyWater calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* TextureTransformer member, named by the class's own destructor calling
        TextureTransformer's D1 at +0x320 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN9TinyWaterD1Ev.c] */

--- a/include/Toad.h
+++ b/include/Toad.h
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "ModelAnim.h"
 #include "dCcAc_c.h"
+#include "ShadowModel.h"
 
 struct Toad {
     u8  pad_000[0x8];
@@ -30,8 +31,11 @@ struct Toad {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x108 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x108 */
-    u8  mShadowModel;            /* 0x16c */
-    u8  pad_16d[0x87];
+    /* ShadowModel member. The cartridge's own ~Toad calls _ZN11ShadowModelD1Ev at
+       +0x16c (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel;            /* 0x16c */
+    u8  pad_194[0x60];
     s32 unk_1f4;            /* 0x1f4 */
     u8  pad_1f8[0x8];
     /* Two ApproachLinear pairs: 0x200 chases 0x202 and 0x204 chases 0x206,

--- a/include/TowerStep.h
+++ b/include/TowerStep.h
@@ -2,6 +2,7 @@
 #define TOWERSTEP_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -73,8 +74,11 @@ struct TowerStep {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~TowerStep calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     ShadowModel mShadowModel; /* 0x320 */
     u8  pad_348[0x30];
     s32 mFloorPosY;            /* 0x378 */

--- a/include/TtcConveyorBeltLarge.h
+++ b/include/TtcConveyorBeltLarge.h
@@ -6,6 +6,8 @@
 #define TTCCONVEYORBELTLARGE_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
+#include "ShadowModel.h"
 
 struct TtcConveyorBeltLarge {
     u8  pad_000[0xc];
@@ -24,16 +26,23 @@ struct TtcConveyorBeltLarge {
        short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
        header declared separately inside it. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* dBgW_KcMbg member. The cartridge's own ~TtcConveyorBeltLarge calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
     u8  mTextureTransformer;            /* 0x320 */
     u8  pad_321[0xb];
     s32 unk_32c;            /* 0x32c */
     u8  pad_330[0x4];
-    u8  mShadowModel;            /* 0x334 */
-    u8  pad_335[0x57];
+    /* ShadowModel member. The cartridge's own ~TtcConveyorBeltLarge calls
+       _ZN11ShadowModelD1Ev at +0x334 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    ShadowModel mShadowModel;            /* 0x334 */
+    u8  pad_35c[0x30];
     s32 mBeltSpeed;            /* 0x38c */
     s32 mTargetBeltSpeed;            /* 0x390 */
     s32 unk_394;            /* 0x394 */

--- a/include/TtcRotatingGear.h
+++ b/include/TtcRotatingGear.h
@@ -2,6 +2,7 @@
 #define TTCROTATINGGEAR_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -56,8 +57,11 @@ struct TtcRotatingGear {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~TtcRotatingGear calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 unk_320;            /* 0x320 */
     s32 unk_324;            /* 0x324 */
     s32 unk_328;            /* 0x328 */

--- a/include/UpDownLiftBbh.h
+++ b/include/UpDownLiftBbh.h
@@ -6,6 +6,7 @@
 #define UPDOWNLIFTBBH_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct UpDownLiftBbh {
     u8  pad_000[0xc];
@@ -67,8 +68,11 @@ struct UpDownLiftBbh {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1db];
+    /* dBgW_KcMbg member. The cartridge's own ~UpDownLiftBbh calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x14];
     u16 unk_300;            /* 0x300 */
     u8  pad_302[0x1e];
     s32 unk_320;            /* 0x320 */

--- a/include/WDW_Water.h
+++ b/include/WDW_Water.h
@@ -2,6 +2,7 @@
 #define WDW_WATER_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -62,8 +63,11 @@ struct WDW_Water {
        short of the object, so the member also takes over unk_0dc (+0x8 = data), which the
        header declared separately inside it. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~WDW_Water calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     TextureTransformer mTextureTransformer; /* 0x320 */
     s32 mTargetPosY;            /* 0x334 */
     u8  unk_338;            /* 0x338 */

--- a/include/WallSign.h
+++ b/include/WallSign.h
@@ -2,6 +2,7 @@
 #define WALLSIGN_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -48,8 +49,11 @@ struct WallSign {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~WallSign calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     u8  mdCcAcPos_c;            /* 0x320 */
 };
 

--- a/include/WingFeather.h
+++ b/include/WingFeather.h
@@ -6,6 +6,7 @@
 #define WINGFEATHER_H
 #include "types.h"
 #include "Model.h"
+#include "ShadowModel.h"
 
 struct WingFeather {
     u8  pad_000[0x5c];
@@ -35,8 +36,11 @@ struct WingFeather {
     u8  pad_159[0x1a7];
     u8  unk_300;            /* 0x300 */
     u8  pad_301[0x13];
-    u8  mShadowModel;            /* 0x314 */
-    u8  pad_315[0x63];
+    /* ShadowModel member. The cartridge's own ~WingFeather calls _ZN11ShadowModelD1Ev
+       at +0x314 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel;            /* 0x314 */
+    u8  pad_33c[0x3c];
     s32 unk_378;            /* 0x378 */
     u16 unk_37c;            /* 0x37c */
     u8  pad_37e[0x2];

--- a/include/WorkElevator.h
+++ b/include/WorkElevator.h
@@ -5,6 +5,7 @@
 #ifndef WORKELEVATOR_H
 #define WORKELEVATOR_H
 #include "types.h"
+#include "Model.h"
 
 struct WorkElevator {
     u8  pad_000[0x5c];
@@ -14,8 +15,10 @@ struct WorkElevator {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member. The cartridge's own ~WorkElevator calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
     u8  mMeshCollider;            /* 0x124 */
     u8  pad_125[0x1c7];
     u8  unk_2ec;            /* 0x2ec */

--- a/include/daDgr_c.h
+++ b/include/daDgr_c.h
@@ -2,6 +2,7 @@
 #define DADGR_C_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 #ifdef __cplusplus
 
@@ -126,8 +127,10 @@ struct daDgr_c {
     s32 unk_118;                 /* 0x118 */
     s32 unk_11c;                 /* 0x11c */
     u8  pad_120[0x4];
-    u8  mMeshCollider;           /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* dBgW_KcMbg member. The cartridge's own ~daDgr_c calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     struct Matrix4x3 mClsnMat;   /* 0x2ec */
     u8  unk_31c;                 /* 0x31c */
     u8  unk_31d;                 /* 0x31d */

--- a/include/daObjKm1_Dorifu_c.h
+++ b/include/daObjKm1_Dorifu_c.h
@@ -2,6 +2,7 @@
 #define DAOBJKM1_DORIFU_C_H
 
 #include "types.h"
+#include "Model.h"
 
 /* The Bob-omb Battlefield drifting stairs. The tree's factory for it is
  * StairsBdw_Spawn; the class itself is only ever named by its ROM name.
@@ -45,8 +46,10 @@ typedef char daObjKm1_Dorifu_c_size_must_be_0xdcc[sizeof(daObjKm1_Dorifu_c) == 0
    can never be migrated. Same arrangement as include/dBgActor_c.h. */
 struct daObjKm1_Dorifu_c {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member. The cartridge's own ~daObjKm1_Dorifu_c calls _ZN5ModelD1Ev at
+       +0x0d4 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 };
 

--- a/include/daObjRc_Dorifu_c.h
+++ b/include/daObjRc_Dorifu_c.h
@@ -2,6 +2,7 @@
 #define DAOBJRC_DORIFU_C_H
 
 #include "types.h"
+#include "Model.h"
 
 /* The Rainbow Ride drifting platform. Only ever named by its ROM name.
  *
@@ -46,8 +47,10 @@ typedef char daObjRc_Dorifu_c_size_must_be_0xdcc[sizeof(daObjRc_Dorifu_c) == 0xd
    can never be migrated. Same arrangement as include/dBgActor_c.h. */
 struct daObjRc_Dorifu_c {
     u8  pad_000[0xd4];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x4f];
+    /* Model member. The cartridge's own ~daObjRc_Dorifu_c calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
     u8  mMovingMeshCollider;            /* 0x124 */
 };
 

--- a/include/daPgDfdr_c.h
+++ b/include/daPgDfdr_c.h
@@ -2,6 +2,7 @@
 #define DAPGDFDR_C_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 #ifdef __cplusplus
 
@@ -137,8 +138,10 @@ struct daPgDfdr_c {
     s32 unk_118;                 /* 0x118 */
     s32 unk_11c;                 /* 0x11c */
     u8  pad_120[0x4];
-    u8  mMeshCollider;           /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* dBgW_KcMbg member. The cartridge's own ~daPgDfdr_c calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     struct Matrix4x3 mClsnMat;   /* 0x2ec */
     u8  unk_31c;                 /* 0x31c */
     u8  unk_31d;                 /* 0x31d */

--- a/src/_ZN11SnowmanBody8BehaviorEv.cpp
+++ b/src/_ZN11SnowmanBody8BehaviorEv.cpp
@@ -4,7 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SnowmanBody.h"
-struct dCc_c { void Clear(); void Update(); };
+/* dCc_c comes from the real dCcAc_c chain now that SnowmanBody.h types
+   mdCcAc_c; the ad-hoc redeclaration that used to stand in for it ICEd
+   mwccarm (CClass.c:3328) once the real class was visible. Clear and Update
+   are non-virtual there, so the direct bl is unchanged. */
 extern "C" void func_ov072_0211f3e4(void *c);
 
 int SnowmanBody::Behavior()

--- a/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
+++ b/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_PathPtr.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigMovingIceBlock.h"
-typedef int Fix12;
+/* Not `Fix12`: this actor's header now reaches math/Fix12.h, where Fix12 is a
+   class template. Only the raw word matters at this call. */
+typedef int Fix12Raw;
 extern "C" {
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, void *out, unsigned idx);
 extern void Vec3_Sub(void *out, void *a, void *b);
@@ -14,7 +16,7 @@ extern void Vec3_MulScalar(void *out, void *v, int s);
 extern void SubVec3(void *a, void *b, void *c);
 extern void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *p);
 extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *p);
-extern int _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void *p, Fix12 a, int b);
+extern int _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void *p, Fix12Raw a, int b);
 }
 
 struct V3 { int x, y, z; };

--- a/src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp
@@ -6,9 +6,10 @@
 #include "SwitchActivatedPlank.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
-/* Model and ModelBase are the real classes now, through this actor's header. */
-struct dBgW_Kc { int d; };
-struct dBgW_KcMbg { int d; };
+/* Model, ModelBase and dBgW_KcMbg are the real classes now, through this
+   actor's header. The placeholder `struct dBgW_KcMbg { int d; };` was only
+   ever a cast target and redefining the real one ICEd mwccarm; dBgW_Kc was
+   never used as a type at all. */
 
 extern "C" BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(ModelBase*, BMD_File*, int, int);

--- a/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
@@ -16,9 +16,8 @@ extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 
 /* ModelBase is the real class now, through TtcConveyorBeltLarge.h. */
 
-struct ShadowModel {
-    void InitCuboid();
-};
+/* ShadowModel is the real class now, through this actor's header, and it
+   declares InitCuboid itself. */
 
 extern "C" void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(
     BMD_File &f, BTA_File &b);
@@ -40,10 +39,9 @@ struct dBgActor_c {
 
 extern "C" void *_ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void *fp);
 
-struct dBgW_KcMbg {
-    void SetFile(KCL_File *f, const Matrix4x3 &m, int fix, short sh,
-                 CLPS_Block &b);
-};
+/* dBgW_KcMbg is the real class now, through this actor's header. Only the
+   cast below needs the name; SetFile is already reached by its mangled
+   symbol because the real one takes Fix12<int> by value. */
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true

--- a/src/_ZN3MrI8BehaviorEv.cpp
+++ b/src/_ZN3MrI8BehaviorEv.cpp
@@ -8,10 +8,10 @@ extern "C" {
     void func_ov071_02120c90(void *c);
 }
 
-struct dCc_c {
-    void Clear();
-    void Update();
-};
+/* dCc_c comes from the real dCcAc_c chain now that MrI.h types mdCcAcPos_c;
+   the ad-hoc redeclaration that used to stand in for it ICEd mwccarm
+   (CClass.c:3328) once the real class was visible. Clear and Update are
+   non-virtual there, so the direct bl is unchanged. */
 
 int MrI::Behavior()
 {

--- a/src/_ZN8SignPost13InitResourcesEv.cpp
+++ b/src/_ZN8SignPost13InitResourcesEv.cpp
@@ -42,9 +42,8 @@ extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(
     void *self, dActor_c *a, s32 radius, s32 height, u32 u0, u32 u1);
 extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
     void *self, dActor_c *a, s32 radius, s32 height, Vector3_16 *v, Vector3_16 *v2);
-struct dBgCh_Actr {
-    void StartDetectingWater();
-};
+/* dBgCh_Actr is the real class now, through this actor's header, and it
+   declares StartDetectingWater itself. */
 struct dBgCh_Gnd {
     int pad[0x11];
     int result;       // offset 0x44

--- a/tools/dtor_members.py
+++ b/tools/dtor_members.py
@@ -1029,8 +1029,11 @@ def main(argv=None):
         only = set(a.only.split(",")) if a.only else None
         picked, held = plan(root, buckets, hdr, sizes, only)
         done, refused = apply(root, picked, sizes, write=a.apply)
-        print("\n%s: %d members in %d headers"
-              % ("applied" if a.apply else "would apply", len(done),
+        # `done` is one entry per DECLARATION written, and a class defined twice in one
+        # header takes two.  Report both, so neither number can be read as the other.
+        wrote = {(r["owner"], r["offset"]) for r in done}
+        print("\n%s: %d declaration(s), %d pair(s), %d header(s)"
+              % ("applied" if a.apply else "would apply", len(done), len(wrote),
                  len({r["header_path"] for r in done})))
         for k, v in held.most_common():
             print("  held  %3d  %s" % (v, k))

--- a/tools/dtor_members.py
+++ b/tools/dtor_members.py
@@ -793,8 +793,8 @@ def adjacency(doc, hdr, sizes, aliases):
                 decl = hdr[hn]["fields"].get(off + sz) if hn else None
                 later = sorted(o for o in fields if o > off)
                 room = (later[0] - off) if later else None
-                if decl and decl[0] == want:
-                    v, note = "CONFIRMED", "header declares %s %s" % decl
+                if decl and any(t == want for t, _ in decl):
+                    v, note = "CONFIRMED", "the header declares a %s there" % want
                 elif room is None:
                     v, note = "TAIL", "no later proven member"
                 elif room < sz + wsz:

--- a/tools/dtor_members.py
+++ b/tools/dtor_members.py
@@ -1,0 +1,1060 @@
+#!/usr/bin/env python3
+"""Member TYPES read out of the ROM: the destructor a destructor calls.
+
+A class with an aggregate member of type `T` destroys it: the original source's
+`~Owner()` ends with an implicit `mMember.~T()`, and mwccarm compiled that to
+
+    add r0, r4, #0x124          ; r4 is `this`, 0x124 is the member's offset
+    bl  _ZN10dBgW_KcMbgD1Ev     ; a RELOCATION, recorded in config/**/relocs.txt
+
+The triple (owner, offset, member type) is therefore not inference.  The call target
+is a relocation the ROM build already checks, the offset is an immediate frozen in the
+instruction stream, and the owner is whichever function the call site sits inside.
+This file harvests every such triple in the cartridge.
+
+    python tools/dtor_members.py --report      # populations, then the true gap
+    python tools/dtor_members.py --gap         # per-pair, against what headers declare
+    python tools/dtor_members.py --adjacency   # test the two proposed adjacency rules
+    python tools/dtor_members.py --apply       # type the decidable markers
+    python tools/dtor_members.py --check       # fail unless the frozen census reproduces
+
+Output: build/dtor_members.json.
+
+Relation to what already existed
+--------------------------------
+`marker_census.py` asks the same question of `src/`: it greps decompiled destructor
+BODIES for `_ZN9ModelAnimD1Ev(t + 0xd4)`.  That is the same evidence, but it can only
+see the destructors this tree has already recovered as C.  This pass reads the
+cartridge, so it also sees every destructor that is still `func_ov084_0212b344` or has
+no source file at all.  `marker_census` reports 34 decidable; the cartridge proves 814
+member pairs, of which 91 were decidable and untyped when this landed.
+
+`opnew_sizes.py` recovers a class's EXTENT from the `operator new` literal and is blind
+to what is inside it.  This recovers the INTERIOR and is blind to the extent.  Neither
+sees the other's evidence; together they bracket a class.
+
+How a site is read
+------------------
+For every `arm_call` relocation whose target address carries a `_ZN...D[012]Ev` symbol,
+the enclosing function of the `from:` address is found from that module's own
+`symbols.txt` (never a fixed window -- see opnew_sizes trap 3).  If the enclosing
+function is itself a named destructor, a small `this`-relative abstract interpreter is
+run over it to a fixed point and r0 at the call site is read out.  `this` is r0 on
+entry; the lattice is (this + k), (sp + k), (imm k) or unknown, with stack slots tracked
+so a spilled `this` survives and the literal pool read so an offset with no ARM
+immediate encoding is still recovered.  Every one of the 2,358 sites yields an offset.
+
+Five things this file refuses to do
+-----------------------------------
+join on names     An earlier survey in this tree reported "127 classes with no header";
+                  125 of them were RTTI ALIASES sharing one vtable address with a name
+                  the tree does have a file for.  Attribution here is by ADDRESS -- the
+                  reloc's `to:` address picks the member type, the `from:` address picks
+                  the owner through the symbol table's own address ranges.  A name is
+                  only ever used afterwards, to find a header, and then every spelling
+                  at the class's vtable address is a candidate (`resolve_header_name`).
+                  `test_dtor_members.py::test_alias_join_regression` pins this.
+
+trust offset 0    `~Derived()` chains to its base at +0, which is an inheritance edge and
+                  not a member.  Offset 0 is bucketed BASE-AT-0 and never applied.
+
+trust D2 at +k    A D2 (base-object destructor) at a nonzero offset is a secondary base
+                  under multiple inheritance, not an aggregate member.  Bucketed
+                  SECONDARY-BASE.  `notes/collision-system.md` documents the family that
+                  does this.  Only D1 at a nonzero offset is a member.
+
+type without a    `check_header_offsets.py` sizes a member type from its
+size assert       `T_size_must_be_0xN` typedef, and reports UNPARSED -- exit 1, not a
+                  warning -- when there is none.  That is how PR #1659 failed CI.  A
+                  proposal whose type carries no assert is bucketed NO ASSERT and held.
+
+overrun the span  A member of size `sizeof(T)` may only be written where at least that
+                  many bytes of marker + padding follow it.  Where the span is longer the
+                  remainder stays as an explicit pad; where it is SHORTER `--apply`
+                  refuses the finding rather than truncating it, because an evidenced
+                  field is already declared inside the member and re-spelling it through
+                  the member is a separate, per-consumer job.
+
+Requires capstone and pyyaml, like `opnew_sizes.py` and `evidence_rom.py`.
+Deterministic: every collection is sorted before it is emitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import collections
+import json
+import os
+import pathlib
+import re
+import sys
+import textwrap
+
+try:
+    from capstone.arm import (
+        ARM_CC_AL, ARM_CC_INVALID,
+        ARM_INS_ADD, ARM_INS_B, ARM_INS_BL, ARM_INS_BLX, ARM_INS_BX,
+        ARM_INS_LDM, ARM_INS_LDR, ARM_INS_MOV, ARM_INS_POP, ARM_INS_PUSH,
+        ARM_INS_STM, ARM_INS_STR, ARM_INS_SUB,
+        ARM_OP_IMM, ARM_OP_MEM, ARM_OP_REG, ARM_SFT_INVALID,
+    )
+except ImportError:                                                    # pragma: no cover
+    sys.exit("capstone not installed. Run: pip install capstone")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import opnew_sizes as O                                                # noqa: E402
+
+SYM_FN = re.compile(
+    r"^(\S+)\s+kind:function\((arm|thumb),size=(0x[0-9a-fA-F]+)\)\s+addr:(0x[0-9a-fA-F]+)")
+SYM_ANY = re.compile(r"^(\S+)\s+kind:\S+\s+addr:(0x[0-9a-fA-F]+)")
+RELOC = re.compile(
+    r"^from:(0x[0-9a-fA-F]+)\s+kind:(\S+)\s+to:(0x[0-9a-fA-F]+)\s+module:(\S+)")
+DTOR_SYM = re.compile(r"^_ZN([0-9N].*?)D([012])Ev$")
+LEN_PREFIX = re.compile(r"(\d+)")
+SIZE_ASSERT = re.compile(r"(\w+)_size_must_be_(0x[0-9a-fA-F]+)")
+
+# `u8 mFoo;   /* 0x124 */`  -- the original generator's "an object starts here" marker.
+MARKER = re.compile(r"^(\s*)u8(\s+)(\w+)\s*;\s*/\*\s*(0x[0-9a-fA-F]+)\s*\*/\s*$")
+PAD = re.compile(r"^(\s*)u8\s+(pad_[0-9a-fA-F]+)\s*\[\s*(0x[0-9a-fA-F]+|\d+)\s*\]\s*;\s*$")
+ANY_FIELD = re.compile(r"^\s*([A-Za-z_]\w*)\s+(\w+)\s*(\[[^\]]*\])?\s*;\s*/\*\s*"
+                       r"(0x[0-9a-fA-F]+)\s*\*/")
+OPEN_DEF = re.compile(r"^[ \t]*(?:class|struct)[ \t]+(\w+)\b")
+SKIPPABLE = re.compile(r"^\s*($|/\*|\*|//)")
+
+# An offset above this is a literal-pool word that is really an ADDRESS folded into
+# `this`, not a member.  `Stage` (0xa2b8) is the largest class in the cartridge.
+MAX_OFFSET = 0x10000
+
+# Frozen census.  Raise these deliberately; a fall means evidence was lost.
+GATE = {
+    "dtor_symbols": 765,
+    "arm_call_relocs_to_a_destructor": 2666,
+    "sites_inside_a_named_destructor": 2358,
+    "sites_inside_an_unnamed_function": 308,
+    "sites_cross_class": 2358,
+    "sites_offset_recovered": 2358,
+    "pairs_distinct": 1178,
+    "pairs_member_evidence": 814,
+    "pairs_base_at_0": 359,
+    "pairs_secondary_base": 5,
+    "owners_distinct": 365,
+}
+
+
+# --------------------------------------------------------------------------
+# symbols and relocations
+# --------------------------------------------------------------------------
+
+def module_dirs(root):
+    """(name, dir) for every module that has its own symbols.txt / relocs.txt."""
+    out = [("arm9", root / "config" / "arm9")]
+    for extra in ("itcm", "dtcm"):
+        p = root / "config" / "arm9" / extra
+        if p.is_dir():
+            out.append((extra, p))
+    for d in sorted((root / "config" / "arm9" / "overlays").glob("ov*")):
+        out.append((d.name, d))
+    return out
+
+
+def load_functions(root, stats):
+    """module -> sorted [(addr, size, name, mode)] over every function symbol."""
+    out = {}
+    for mod, d in module_dirs(root):
+        p = d / "symbols.txt"
+        if not p.is_file():
+            continue
+        fns = []
+        for line in p.read_text(errors="replace").splitlines():
+            m = SYM_FN.match(line)
+            if m:
+                fns.append((int(m.group(4), 16), int(m.group(3), 16),
+                            m.group(1), m.group(2)))
+        fns.sort()
+        out[mod] = fns
+        stats["function_symbols"] += len(fns)
+    return out
+
+
+def load_destructors(root, stats):
+    """(module, addr) -> sorted [destructor symbol names at that address]."""
+    out = collections.defaultdict(list)
+    for mod, d in module_dirs(root):
+        p = d / "symbols.txt"
+        if not p.is_file():
+            continue
+        for line in p.read_text(errors="replace").splitlines():
+            m = SYM_ANY.match(line)
+            if m and DTOR_SYM.match(m.group(1)):
+                out[(mod, int(m.group(2), 16))].append(m.group(1))
+    for v in out.values():
+        v.sort()
+    stats["dtor_symbols"] = sum(len(v) for v in out.values())
+    stats["dtor_addresses"] = len(out)
+    stats["dtor_addresses_with_more_than_one_name"] = sum(
+        1 for v in out.values() if len(v) > 1)
+    return dict(out)
+
+
+def target_modules(field):
+    """`module:` names the module the target lives in, not the one recording it.
+
+    Three spellings: `main`, `overlay(23)`, and `overlays(0,4)` for an address that
+    two mutually exclusive overlays both cover.  The last is genuinely ambiguous and
+    is counted, not silently collapsed.
+    """
+    if field == "main":
+        return ["arm9"]
+    m = re.fullmatch(r"overlays?\(([\d,]+)\)", field)
+    if m:
+        return ["ov%03d" % int(x) for x in m.group(1).split(",")]
+    return [field]
+
+
+def load_dtor_calls(root, dtors, stats):
+    """Every `arm_call` relocation whose target address carries a destructor symbol."""
+    sites = []
+    for mod, d in module_dirs(root):
+        p = d / "relocs.txt"
+        if not p.is_file():
+            continue
+        for line in p.read_text(errors="replace").splitlines():
+            m = RELOC.match(line)
+            if not m:
+                continue
+            ta = int(m.group(3), 16)
+            cands = [t for t in target_modules(m.group(4)) if (t, ta) in dtors]
+            if not cands:
+                continue
+            if m.group(2) != "arm_call":
+                stats["non_call_relocs_to_a_destructor"] += 1
+                continue
+            if len(cands) > 1:
+                stats["target_module_ambiguous"] += 1
+            sites.append((mod, int(m.group(1), 16), cands[0], ta))
+    sites.sort()
+    stats["arm_call_relocs_to_a_destructor"] = len(sites)
+    return sites
+
+
+# --------------------------------------------------------------------------
+# names
+# --------------------------------------------------------------------------
+
+def demangle_dtor(sym):
+    """`_ZN7daKrb_cD1Ev` -> ("daKrb_c", 1);  nested names join with `__`.
+
+    Same convention as `evidence_rom.class_of` and `opnew_sizes.demangle_ztv`, which is
+    how this tree names the headers for nested classes (`ActorBase__SceneNode.h`).
+    """
+    m = DTOR_SYM.match(sym or "")
+    if not m:
+        return None, None
+    body, variant = m.group(1), int(m.group(2))
+    if body.startswith("N"):
+        body = body[1:]
+    parts, i = [], 0
+    while i < len(body):
+        lm = LEN_PREFIX.match(body, i)
+        if not lm:
+            return None, None
+        n = int(lm.group(1))
+        i = lm.end()
+        if n == 0 or i + n > len(body):
+            return None, None
+        parts.append(body[i:i + n])
+        i += n
+    return ("__".join(parts), variant) if parts else (None, None)
+
+
+# --------------------------------------------------------------------------
+# a `this`-relative abstract interpreter
+# --------------------------------------------------------------------------
+#
+# Values are ("this", k), ("sp", k), ("imm", k) or absent (unknown).  Entry state is
+# r0 = this+0, sp = sp+0.  Everything is a fixed point over the function's own
+# instructions, so a loop or a forward branch cannot make a stale value survive into a
+# join.
+#
+# ("imm", k) is not decoration.  An offset above 0xfff has no ARM rotated-8-bit
+# encoding, so mwccarm spills it to the function's own literal pool and emits
+# `ldr r1, [pc, #0x48]; add r0, r4, r1`.  `Stage::~Stage` does that for both its
+# members.  Without pool reads, every member past the immediate range is invisible --
+# which is the opposite of the bias you want, since those are the big classes.
+
+def _merge(a, b):
+    if a is None:
+        return dict(b)
+    return {k: v for k, v in a.items() if b.get(k) == v}
+
+
+def _regs_written(ins):
+    out = []
+    if ins.id in (ARM_INS_POP, ARM_INS_LDM):
+        return [o.reg for o in ins.operands if o.type == ARM_OP_REG]
+    if ins.id in (ARM_INS_PUSH, ARM_INS_STM, ARM_INS_STR, ARM_INS_B,
+                  ARM_INS_BX, ARM_INS_BL, ARM_INS_BLX):
+        return []
+    if ins.operands and ins.operands[0].type == ARM_OP_REG:
+        out.append(ins.operands[0].reg)
+    return out
+
+
+def _rn(ins, reg):
+    return ins.reg_name(reg)
+
+
+class ThisFlow:
+    """Reads r0 at every call site of `fn`, as an offset from `this`."""
+
+    def __init__(self, img, mod, start, size):
+        self.img, self.mod = img, mod
+        self.ins = img.disasm(mod, start, size)
+        self.start, self.size = start, size
+        self.index = {i.address: n for n, i in enumerate(self.ins)}
+
+    def _succ(self, n):
+        ins = self.ins[n]
+        nxt = [n + 1] if n + 1 < len(self.ins) else []
+        if ins.id == ARM_INS_B:
+            tgt = ins.operands[0].imm if ins.operands and \
+                ins.operands[0].type == ARM_OP_IMM else None
+            j = self.index.get(tgt)
+            uncond = ins.cc in (ARM_CC_AL, ARM_CC_INVALID)
+            out = ([j] if j is not None else [])
+            return out if uncond else out + nxt
+        if ins.id == ARM_INS_BX and ins.cc in (ARM_CC_AL, ARM_CC_INVALID):
+            return []
+        if ins.id in (ARM_INS_POP, ARM_INS_LDM) and "pc" in ins.op_str \
+                and ins.cc in (ARM_CC_AL, ARM_CC_INVALID):
+            return []
+        return nxt
+
+    def _transfer(self, st, ins):
+        """Registers and stack after `ins`, given `st` before it."""
+        regs, stk = dict(st.get("r", {})), dict(st.get("s", {}))
+        cond = ins.cc not in (ARM_CC_AL, ARM_CC_INVALID)
+        ops = ins.operands
+
+        def rv(reg):
+            return regs.get(_rn(ins, reg))
+
+        new = dict(regs)
+        if ins.id in (ARM_INS_PUSH, ARM_INS_STM) and ins.id == ARM_INS_PUSH:
+            sp = regs.get("sp")
+            if sp and sp[0] == "sp":
+                new["sp"] = ("sp", sp[1] - 4 * len(ops))
+        elif ins.id in (ARM_INS_POP, ARM_INS_LDM) and ins.id == ARM_INS_POP:
+            for o in ops:
+                if o.type == ARM_OP_REG:
+                    new.pop(_rn(ins, o.reg), None)
+            sp = regs.get("sp")
+            if sp and sp[0] == "sp":
+                new["sp"] = ("sp", sp[1] + 4 * len(ops))
+        elif ins.id == ARM_INS_MOV and len(ops) == 2 and \
+                ops[0].type == ARM_OP_REG and ops[1].shift.type == ARM_SFT_INVALID:
+            d = _rn(ins, ops[0].reg)
+            if ops[1].type == ARM_OP_REG:
+                new[d] = rv(ops[1].reg) or None
+            elif ops[1].type == ARM_OP_IMM:
+                new[d] = ("imm", ops[1].imm)
+            else:
+                new[d] = None
+        elif ins.id in (ARM_INS_ADD, ARM_INS_SUB) and len(ops) == 3 and \
+                ops[0].type == ARM_OP_REG and ops[1].type == ARM_OP_REG and \
+                ops[2].shift.type == ARM_SFT_INVALID:
+            a = rv(ops[1].reg)
+            b = (("imm", ops[2].imm) if ops[2].type == ARM_OP_IMM
+                 else rv(ops[2].reg) if ops[2].type == ARM_OP_REG else None)
+            d = _rn(ins, ops[0].reg)
+            sign = 1 if ins.id == ARM_INS_ADD else -1
+            if a and b and b[0] == "imm":
+                new[d] = (a[0], a[1] + sign * b[1])
+            elif a and a[0] == "imm" and b and sign > 0:
+                new[d] = (b[0], b[1] + a[1])
+            else:
+                new[d] = None
+        elif ins.id == ARM_INS_LDR and len(ops) == 2 and \
+                ops[1].type == ARM_OP_MEM and ops[1].mem.base and \
+                _rn(ins, ops[1].mem.base) == "pc" and ops[1].mem.index == 0:
+            # the function's own literal pool: an offset with no ARM immediate encoding
+            w = self.img.word(self.mod, ins.address + 8 + ops[1].mem.disp)
+            new[_rn(ins, ops[0].reg)] = None if w is None else ("imm", w)
+        elif ins.id == ARM_INS_STR and len(ops) == 2 and \
+                ops[0].type == ARM_OP_REG and ops[1].type == ARM_OP_MEM:
+            base = regs.get(_rn(ins, ops[1].mem.base)) if ops[1].mem.base else None
+            if base and base[0] == "sp" and ops[1].mem.index == 0:
+                slot = base[1] + ops[1].mem.disp
+                if cond:
+                    stk.pop(slot, None)
+                else:
+                    v = rv(ops[0].reg)
+                    stk[slot] = v if v else None
+        elif ins.id == ARM_INS_LDR and len(ops) == 2 and \
+                ops[0].type == ARM_OP_REG and ops[1].type == ARM_OP_MEM:
+            base = regs.get(_rn(ins, ops[1].mem.base)) if ops[1].mem.base else None
+            d = _rn(ins, ops[0].reg)
+            new[d] = (stk.get(base[1] + ops[1].mem.disp)
+                      if base and base[0] == "sp" and ops[1].mem.index == 0 else None)
+        else:
+            for r in _regs_written(ins):
+                new[_rn(ins, r)] = None
+
+        if ins.id in (ARM_INS_BL, ARM_INS_BLX):
+            for r in ("r0", "r1", "r2", "r3", "r12", "ip", "lr"):
+                new[r] = None
+
+        if cond and ins.id not in (ARM_INS_B, ARM_INS_BL, ARM_INS_BLX):
+            # predicated: the write may not have happened.  Keep only agreement.
+            new = {k: v for k, v in new.items() if regs.get(k) == v}
+
+        return {"r": {k: v for k, v in new.items() if v is not None},
+                "s": {k: v for k, v in stk.items() if v is not None}}
+
+    def run(self):
+        """address -> ("this", k) | ("sp", k) | None, for r0 at each instruction."""
+        if not self.ins:
+            return {}
+        entry = {"r": {"r0": ("this", 0), "sp": ("sp", 0)}, "s": {}}
+        state = [None] * len(self.ins)
+        state[0] = entry
+        work, guard = [0], 0
+        while work and guard < 40000:
+            guard += 1
+            n = work.pop()
+            st = state[n]
+            if st is None:
+                continue
+            out = self._transfer(st, self.ins[n])
+            for s in self._succ(n):
+                merged = {"r": _merge(None if state[s] is None else state[s]["r"],
+                                      out["r"]),
+                          "s": _merge(None if state[s] is None else state[s]["s"],
+                                      out["s"])}
+                if state[s] is None or merged != state[s]:
+                    state[s] = merged
+                    work.append(s)
+        return {i.address: (state[n]["r"].get("r0") if state[n] else None)
+                for n, i in enumerate(self.ins)}
+
+
+# --------------------------------------------------------------------------
+# harvest
+# --------------------------------------------------------------------------
+
+def enclosing(fns, mod, addr):
+    lst = fns.get(mod, ())
+    i = bisect.bisect_right(lst, (addr, 1 << 62, "ï¿¿", "ï¿¿")) - 1
+    if i < 0:
+        return None
+    a, s, n, m = lst[i]
+    return (a, s, n, m) if a <= addr < a + s else None
+
+
+def harvest(root, ext):
+    stats = collections.Counter()
+    mods = O.load_modules(ext, stats)
+    fns = load_functions(root, stats)
+    dtors = load_destructors(root, stats)
+    sites = load_dtor_calls(root, dtors, stats)
+    img = O.Image(mods, {m: [(a, s, n) for a, s, n, _ in v] for m, v in fns.items()})
+
+    flows, rows = {}, []
+    for mod, fa, tmod, ta in sites:
+        e = enclosing(fns, mod, fa)
+        if e is None:
+            stats["sites_with_no_enclosing_function"] += 1
+            continue
+        owner_sym = e[2]
+        owner, ovar = demangle_dtor(owner_sym)
+        if owner is None:
+            stats["sites_inside_an_unnamed_function"] += 1
+            stats["unnamed_callers"] += 0
+            rows.append({"module": mod, "site": "0x%08x" % fa, "owner": None,
+                         "owner_symbol": owner_sym, "owner_variant": None,
+                         "member": demangle_dtor(dtors[(tmod, ta)][0])[0],
+                         "member_symbol": dtors[(tmod, ta)][0],
+                         "member_variant": demangle_dtor(dtors[(tmod, ta)][0])[1],
+                         "offset": None, "verdict": "OWNER NOT A NAMED DESTRUCTOR"})
+            continue
+        stats["sites_inside_a_named_destructor"] += 1
+        if mod not in mods:
+            stats["sites_in_a_module_with_no_image"] += 1
+            continue
+        key = (mod, e[0])
+        if key not in flows:
+            flows[key] = ThisFlow(img, mod, e[0], e[1]).run()
+        v = flows[key].get(fa)
+        off = v[1] if v and v[0] == "this" else None
+        if off is not None and not 0 <= off < MAX_OFFSET:
+            # a pool word that is really an address, folded into `this` by an `add`.
+            # The largest class the cartridge news is under 0x4000 bytes.
+            stats["sites_offset_implausible"] += 1
+            off = None
+        if off is None:
+            stats["sites_offset_not_recovered"] += 1
+        else:
+            stats["sites_offset_recovered"] += 1
+
+        member_sym = dtors[(tmod, ta)][0]
+        member, mvar = demangle_dtor(member_sym)
+        if member == owner:
+            stats["sites_same_class_chain"] += 1
+            verdict = "SAME CLASS"
+        else:
+            stats["sites_cross_class"] += 1
+            if off is None:
+                verdict = "OFFSET NOT RECOVERED"
+            elif off == 0:
+                verdict = "BASE-AT-0"
+            elif mvar == 2:
+                verdict = "SECONDARY-BASE"
+            else:
+                verdict = "MEMBER"
+        rows.append({
+            "module": mod, "site": "0x%08x" % fa, "owner": owner,
+            "owner_symbol": owner_sym, "owner_variant": ovar,
+            "member": member, "member_symbol": member_sym, "member_variant": mvar,
+            "member_module": tmod, "member_addr": "0x%08x" % ta,
+            "offset": None if off is None else "0x%03x" % off, "verdict": verdict,
+        })
+
+    # (owner, offset, member) -- the pair the ROM proves.  Sites agreeing is the norm:
+    # D0 and D1 of one class both destroy the same members.
+    pairs = collections.defaultdict(list)
+    for r in rows:
+        if r["owner"] and r["offset"] is not None and r["verdict"] in (
+                "MEMBER", "BASE-AT-0", "SECONDARY-BASE"):
+            pairs[(r["owner"], r["offset"], r["member"])].append(r)
+    conflicts = collections.defaultdict(set)
+    for (own, off, mem) in pairs:
+        conflicts[(own, off)].add(mem)
+
+    out = []
+    for (own, off, mem), rs in sorted(pairs.items()):
+        vs = sorted({r["verdict"] for r in rs})
+        out.append({
+            "owner": own, "offset": off, "member": mem,
+            "member_symbol": rs[0]["member_symbol"],
+            "verdict": vs[0] if len(vs) == 1 else "AMBIGUOUS VARIANT",
+            "evidence": sorted({"D%d" % r["owner_variant"] for r in rs}),
+            "member_variants": sorted({"D%d" % r["member_variant"] for r in rs}),
+            "sites": [r["site"] for r in rs],
+            "modules": sorted({r["module"] for r in rs}),
+            "conflicting_types": sorted(conflicts[(own, off)] - {mem}) or None,
+        })
+    stats["pairs_distinct"] = len(out)
+    stats["pairs_member_evidence"] = sum(1 for p in out if p["verdict"] == "MEMBER")
+    stats["pairs_base_at_0"] = sum(1 for p in out if p["verdict"] == "BASE-AT-0")
+    stats["pairs_secondary_base"] = sum(1 for p in out if p["verdict"] == "SECONDARY-BASE")
+    stats["pairs_owner_offset_with_two_types"] = sum(
+        1 for k, v in conflicts.items() if len(v) > 1)
+    stats["owners_distinct"] = len({p["owner"] for p in out})
+
+    return {"meta": {"stats": dict(sorted(stats.items()))},
+            "pairs": out, "sites": rows}
+
+
+# --------------------------------------------------------------------------
+# the gap against the headers
+# --------------------------------------------------------------------------
+
+def header_index(root):
+    """class -> {"header": path, "assert": size|None, "fields": {offset: [(type, name)]}}.
+
+    A header in this tree routinely defines the SAME class twice -- a real C++ layout
+    under `#ifdef __cplusplus` and a flat `u8`-array stand-in for C translation units
+    below it.  `Wiggler` types +0x708 as `dBgCh_Actr` in the first and as
+    `u8 mWithMeshClsn[0x1bc]` in the second.  Keeping only one definition per class
+    made 15 already-typed members read as untyped work, purely on which block came
+    last in the file, so every block's declaration is kept and a member counts as
+    typed when ANY of them types it.
+    """
+    out = {}
+    for h in sorted((root / "include").rglob("*.h")):
+        txt = h.read_text(errors="replace")
+        for m in O.DEFINITION.finditer(txt):
+            out.setdefault(m.group(1), {"header": h, "assert": None, "fields": {}})
+        for m in SIZE_ASSERT.finditer(txt):
+            e = out.setdefault(m.group(1), {"header": h, "assert": None, "fields": {}})
+            if e["assert"] is None:
+                e["assert"] = int(m.group(2), 16)
+                e["header"] = h
+    # fields, per definition block, so a header holding two structs is not merged.
+    # A definition ends at a `}` in column zero, which is how every header in this
+    # tree is written; a nested block is indented and so cannot close the outer one.
+    for h in sorted((root / "include").rglob("*.h")):
+        cur = None
+        for line in h.read_text(errors="replace").splitlines():
+            if line.startswith("}"):
+                cur = None
+                continue
+            m = OPEN_DEF.match(line)
+            if m and not line.rstrip().endswith(";"):
+                cur = m.group(1)
+                continue
+            if cur and out.get(cur, {}).get("header") == h:
+                f = ANY_FIELD.match(line)
+                if f:
+                    at = out[cur]["fields"].setdefault(int(f.group(4), 16), [])
+                    d = (f.group(1), f.group(2) + (f.group(3) or ""))
+                    if d not in at:
+                        at.append(d)
+    return out
+
+
+INCLUDE = re.compile(r'^[ \t]*#[ \t]*include[ \t]+"([^"]+)"', re.M)
+
+
+def _resolve(root, name):
+    p = root / "include" / name
+    return p if p.is_file() else None
+
+
+def c_reachable(root):
+    """Every header a `.c` translation unit can reach, transitively.
+
+    A C TU cannot use a type whose header defines it only under `__cplusplus`, and
+    `dBgW_KcMbg`, `TextureSequence`, `TextureTransformer` and `MaterialChanger` are all
+    exactly that.  Typing a member as one of them inside a header that some `.c` file
+    includes fails the build with `undefined identifier`, then `illegal constant
+    expression` from the size assert -- which is what a first run of this pass did to
+    eleven files.  Both halves of the test matter: the OWNER's reach and the MEMBER's
+    C visibility.
+    """
+    graph = {}
+    for h in sorted((root / "include").rglob("*.h")):
+        graph[h] = [x for x in
+                    (_resolve(root, n) for n in INCLUDE.findall(h.read_text(errors="replace")))
+                    if x]
+    seen, stack = set(), []
+    for c in sorted((root / "src").rglob("*.c")):
+        stack += [x for x in
+                  (_resolve(root, n) for n in INCLUDE.findall(c.read_text(errors="replace")))
+                  if x]
+    while stack:
+        n = stack.pop()
+        if n in seen:
+            continue
+        seen.add(n)
+        stack += graph.get(n, ())
+    return seen
+
+
+CPP_ONLY_OPEN = re.compile(r"^\s*#\s*if(?:def)?\s+.*__cplusplus")
+C_TYPEDEF = re.compile(r"^\s*typedef\s+(?:struct\s+)?\w+\s+(\w+)\s*;")
+
+
+def c_usable_types(root):
+    """Class names a C translation unit can spell as a BARE name.
+
+    Two separate things have to be true and only the first is obvious.  The type needs
+    a definition outside the `#ifdef __cplusplus` branch -- and it also needs
+    `typedef struct X X;`, because in C the tag alone is not a type name.  Only
+    `Model`, `ModelAnim` and `BlendModelAnim` carry that typedef today; `ShadowModel`,
+    `dBgCh_Actr`, `dCcAcPos_c` and `dCcAc_c` have flat C stand-ins and no typedef, and
+    writing `dBgCh_Actr mWithMeshClsn;` into a C-reachable header gets
+    `undefined identifier` from the tag, then `illegal constant expression` from the
+    size assert.  Adding those typedefs is the cheapest next lever this pass has.
+
+    A one-level `#ifdef __cplusplus` scan, which is the only shape this tree uses.
+    """
+    defined, typedefed = set(), set()
+    for h in sorted((root / "include").rglob("*.h")):
+        depth, skip_from = 0, None
+        for line in h.read_text(errors="replace").splitlines():
+            s = line.strip()
+            if s.startswith("#if"):
+                depth += 1
+                if skip_from is None and CPP_ONLY_OPEN.match(line):
+                    skip_from = depth
+                continue
+            if s.startswith("#else") and skip_from == depth:
+                skip_from = None
+                continue
+            if s.startswith("#endif"):
+                if skip_from == depth:
+                    skip_from = None
+                depth -= 1
+                continue
+            if skip_from is not None:
+                continue
+            m = OPEN_DEF.match(line)
+            if m and not s.endswith(";"):
+                defined.add(m.group(1))
+            t = C_TYPEDEF.match(line)
+            if t:
+                typedefed.add(t.group(1))
+    return defined & typedefed
+
+
+def vtable_aliases(root, mods, stats):
+    """class name -> every other spelling the tree gives the class at its vtable address.
+
+    THE join defect this file refuses to repeat.  An earlier survey reported "127
+    classes with no header" and 125 were aliases: `_ZTV12FortressWall`,
+    `_ZTV9MontyMole` and `_ZTV11daChoropu_c` are one address and only one has a file.
+    """
+    by_addr = O.load_vtable_symbols(root, mods, stats)
+    out = collections.defaultdict(set)
+    for (_mod, _addr), syms in by_addr.items():
+        names = sorted({n for n in (O.demangle_ztv(s) for s in syms) if n})
+        for n in names:
+            out[n].update(x for x in names if x != n)
+    return {k: sorted(v) for k, v in out.items()}
+
+
+def gap(root, doc, mods, stats):
+    hdr = header_index(root)
+    aliases = vtable_aliases(root, mods, stats)
+    sizes = {k: v["assert"] for k, v in hdr.items() if v["assert"] is not None}
+    from_c, in_c = c_reachable(root), c_usable_types(root)
+
+    buckets = collections.defaultdict(list)
+    for p in doc["pairs"]:
+        if p["verdict"] != "MEMBER":
+            buckets[p["verdict"]].append(p)
+            continue
+        own, how = O.resolve_header_name(p["owner"], aliases.get(p["owner"], ()), hdr)
+        mem, _ = O.resolve_header_name(p["member"], aliases.get(p["member"], ()), hdr)
+        rec = dict(p, owner_header=own, owner_join=how, member_header=mem)
+        off = int(p["offset"], 16)
+        if own is None:
+            buckets["NO OWNER HEADER"].append(rec)
+            continue
+        rec["header_path"] = str(hdr[own]["header"].relative_to(root)).replace("\\", "/")
+        cur = hdr[own]["fields"].get(off)
+        rec["declared"] = None if cur is None else "; ".join("%s %s" % d for d in cur)
+        if cur and any(t == mem for t, _ in cur):
+            buckets["ALREADY TYPED"].append(rec)
+        elif mem is None or mem not in sizes:
+            buckets["NO ASSERT"].append(rec)
+        elif cur and any(t != "u8" for t, _ in cur):
+            buckets["DECLARED OTHERWISE"].append(rec)
+        elif cur is None:
+            buckets["NO FIELD AT OFFSET"].append(rec)
+        elif hdr[own]["header"] in from_c and mem not in in_c:
+            buckets["MEMBER TYPE IS C++ ONLY"].append(rec)
+        else:
+            rec["member_size"] = sizes[mem]
+            buckets["DECIDABLE"].append(rec)
+    return buckets, hdr, aliases, sizes
+
+
+BUCKETS = ("DECIDABLE", "ALREADY TYPED", "NO ASSERT", "DECLARED OTHERWISE",
+           "NO FIELD AT OFFSET", "MEMBER TYPE IS C++ ONLY", "NO OWNER HEADER",
+           "BASE-AT-0", "SECONDARY-BASE", "AMBIGUOUS VARIANT")
+
+
+# --------------------------------------------------------------------------
+# adjacency rules
+# --------------------------------------------------------------------------
+
+ADJACENCY = {"dBgW_KcMbg": ("Matrix4x3", 0x30), "ShadowModel": ("Matrix4x3", 0x30)}
+
+
+def adjacency(doc, hdr, sizes, aliases):
+    """Does `T` always sit immediately before its own `Matrix4x3`?
+
+    `Matrix4x3` is `struct { s32 m[12]; }` (include/common.h) -- a POD with no
+    destructor, so no destructor relocation can ever NAME one.  The rule is therefore
+    not directly testable and only SPACE for it is: what the cartridge does prove is
+    the offset of the NEXT member, and 0x30 bytes either fit between the two or they
+    do not.  Per owner the verdict is
+
+      REFUTED     the next proven member starts before off + sizeof(T) + 0x30
+      CONFIRMED   the owner's header already declares a Matrix4x3 at off + sizeof(T)
+      CONSISTENT  exactly 0x30 of room to the next proven member
+      ROOM        more than 0x30 -- consistent, but so is anything else
+      TAIL        no later proven member; the extent is opnew_sizes' question
+
+    A single REFUTED is decisive and a thousand CONSISTENTs are not, which is why the
+    counter-examples are printed and the agreements are only counted.
+    """
+    at = collections.defaultdict(dict)
+    for p in doc["pairs"]:
+        if p["verdict"] in ("MEMBER", "SECONDARY-BASE"):
+            at[p["owner"]][int(p["offset"], 16)] = p["member"]
+    res = collections.defaultdict(collections.Counter)
+    detail = collections.defaultdict(list)
+    for typ, (want, wsz) in sorted(ADJACENCY.items()):
+        sz = sizes.get(typ)
+        for owner, fields in sorted(at.items()):
+            for off, m in sorted(fields.items()):
+                if m != typ:
+                    continue
+                if sz is None:
+                    res[typ]["NO SIZE FOR " + typ] += 1
+                    continue
+                hn, _ = O.resolve_header_name(owner, aliases.get(owner, ()), hdr)
+                decl = hdr[hn]["fields"].get(off + sz) if hn else None
+                later = sorted(o for o in fields if o > off)
+                room = (later[0] - off) if later else None
+                if decl and decl[0] == want:
+                    v, note = "CONFIRMED", "header declares %s %s" % decl
+                elif room is None:
+                    v, note = "TAIL", "no later proven member"
+                elif room < sz + wsz:
+                    v, note = "REFUTED", "next proven member %s at +0x%03x, only 0x%x of room" % (
+                        fields[later[0]], later[0], room - sz)
+                elif room == sz + wsz:
+                    v, note = "CONSISTENT", "exactly 0x%x to %s" % (wsz, fields[later[0]])
+                else:
+                    v, note = "ROOM", "0x%x to %s" % (room - sz, fields[later[0]])
+                res[typ][v] += 1
+                detail[typ].append((owner, off, v, note))
+    return res, detail
+
+
+# --------------------------------------------------------------------------
+# apply
+# --------------------------------------------------------------------------
+
+def unconditional_includes(lines, before):
+    """(includes visible on BOTH language paths above `before`, where to add another).
+
+    "The string appears earlier in the file" is not visibility.  A header's C++ branch
+    carries its own `#include "Model.h"`, textually above the flat C definition below
+    the `#else` -- and invisible to it.  Three headers were typed against an include
+    that could not be reached, and failed with `undefined identifier 'Model'`.  Only
+    an include outside every `__cplusplus` conditional counts, and a new one is
+    anchored after the last of those.
+    """
+    seen, anchor, stack = [], None, []
+    for n, line in enumerate(lines[:before]):
+        s = line.strip()
+        if s.startswith("#if"):
+            stack.append(bool(CPP_ONLY_OPEN.match(line)))
+            continue
+        if s.startswith("#endif"):
+            if stack:
+                stack.pop()
+            continue
+        if s.startswith("#else") or s.startswith("#elif"):
+            continue
+        if any(stack):
+            continue
+        m = INCLUDE.match(line)
+        if m:
+            seen.append(m.group(1))
+            anchor = n
+    return seen, anchor
+
+
+def plan(root, buckets, hdr, sizes, only=None):
+    """Per header, the edits a DECIDABLE finding implies -- or why it is held back."""
+    picked, held = [], collections.Counter()
+    for rec in buckets["DECIDABLE"]:
+        name = "%s.%s" % (rec["owner_header"], rec["offset"])
+        if only is not None and rec["owner_header"] not in only and name not in only:
+            held["not in --only"] += 1
+            continue
+        if rec["conflicting_types"]:
+            held["two types claimed at one offset"] += 1
+            continue
+        picked.append(rec)
+    return picked, held
+
+
+def apply(root, picked, sizes, write=False):
+    """Replace `u8 marker; /* 0xNN */` + its pad with the real member type.
+
+    The pad the marker stood on is the rest of the object.  Where it is longer than
+    `sizeof(T)` the remainder stays as a pad at the new offset -- nothing declared is
+    ever deleted.  Where it is shorter the finding is refused here, not silently
+    truncated, because a field is already declared inside the member.
+    """
+    by_file = collections.defaultdict(list)
+    for rec in picked:
+        by_file[rec["header_path"]].append(rec)
+
+    done, refused = [], []
+    for path, recs in sorted(by_file.items()):
+        p = root / path
+        lines = p.read_text(errors="replace").splitlines()
+        edits = []
+        for rec in recs:
+            off = int(rec["offset"], 16)
+            # EVERY block, not the first.  A header routinely defines the class twice --
+            # a C++ layout and a flat C stand-in -- and typing only one of them leaves
+            # the two disagreeing about what lives at the offset.
+            hits = [n for n, line in enumerate(lines)
+                    if MARKER.match(line) and int(MARKER.match(line).group(4), 16) == off]
+            if not hits:
+                refused.append((rec, "no bare u8 marker at that offset"))
+                continue
+            need = sizes[rec["member"]]
+            ok = []
+            for i in hits:
+                j, in_comment = i + 1, False
+                while j < len(lines):
+                    ln = lines[j]
+                    if in_comment:
+                        in_comment = "*/" not in ln
+                        j += 1
+                        continue
+                    if SKIPPABLE.match(ln):
+                        in_comment = "/*" in ln and "*/" not in ln
+                        j += 1
+                        continue
+                    break
+                pm = PAD.match(lines[j]) if j < len(lines) else None
+                span = 1 + int(pm.group(3), 0) if pm else 1
+                if span < need:
+                    refused.append((rec, "span 0x%x < sizeof(%s) 0x%x"
+                                    % (span, rec["member"], need)))
+                    ok = []
+                    break
+                ok.append((i, j, rec, span, need, pm))
+            edits.extend(ok)
+        # The include has to land ABOVE the definition it feeds, and `#include` lines
+        # also appear inside the `#ifdef __cplusplus` branch and below the struct.
+        # Anchoring on the file's LAST one put eleven of them after the use.
+        first = min((e[0] for e in edits), default=len(lines))
+        above, anchor = unconditional_includes(lines, first)
+        for i, j, rec, span, need, pm in sorted(edits, reverse=True):
+            m = MARKER.match(lines[i])
+            indent, gap, field = m.group(1), m.group(2), m.group(3)
+            typ = rec["member"]
+            gap = " " * max(1, len("u8") + len(gap) - len(typ))
+            body = ("%s member. The cartridge's own ~%s calls %s at +%s (%s), a "
+                    "relocation the ROM build checks; recovered by "
+                    "tools/dtor_members.py. D1 and not D2, so it is this type and "
+                    "not an inlined base."
+                    % (typ, rec["owner"], rec["member_symbol"], rec["offset"],
+                       "/".join(rec["evidence"])))
+            wrapped = textwrap.wrap(body, width=88 - len(indent) - 3) or [body]
+            new = ["%s/* %s" % (indent, wrapped[0])]
+            new += ["%s   %s" % (indent, w) for w in wrapped[1:-1]]
+            if len(wrapped) > 1:
+                new.append("%s   %s */" % (indent, wrapped[-1]))
+            else:
+                new[0] += " */"
+            new.append("%s%s%s%s;            /* %s */"
+                       % (indent, typ, gap, field, rec["offset"]))
+            tail = span - need
+            if pm is not None:
+                del lines[j]
+            if tail > 0:
+                new.append("%su8  pad_%03x[0x%x];"
+                           % (pm.group(1) if pm else indent, int(rec["offset"], 16) + need,
+                              tail))
+            lines[i:i + 1] = new
+            done.append(rec)
+        # Only an include ABOVE the first edit is visible to it.  A header's C++ branch
+        # carries its own `#include` list, so "the string appears somewhere in the file"
+        # said Model.h was already included when it was included 40 lines BELOW the
+        # flat C definition that now needed it -- three headers failed exactly so.
+        want = []
+        for rec in recs:
+            inc = '#include "%s.h"' % rec["member"]
+            if rec["member"] + ".h" not in above and inc not in want and rec in done:
+                want.append(inc)
+        if want:
+            if anchor is None:
+                refused.append((recs[0], "no #include above the definition to anchor %s"
+                                % want))
+            else:
+                lines[anchor + 1:anchor + 1] = want
+        if write:
+            p.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+    return done, refused
+
+
+# --------------------------------------------------------------------------
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", default=".", help="repo/worktree root")
+    ap.add_argument("--extracted", default=None)
+    ap.add_argument("-o", "--out", default=None,
+                    help="default build/dtor_members.json under --root")
+    ap.add_argument("--report", action="store_true", help="print populations first")
+    ap.add_argument("--gap", action="store_true",
+                    help="bucket every pair against what the headers declare")
+    ap.add_argument("--adjacency", action="store_true",
+                    help="test the proposed `T is always followed by its Matrix4x3` rules")
+    ap.add_argument("--apply", action="store_true", help="write the decidable members")
+    ap.add_argument("--dry-run", action="store_true", help="--apply without writing")
+    ap.add_argument("--only", default=None,
+                    help="comma-separated Class or Class.0xNNN to restrict --apply")
+    ap.add_argument("--check", action="store_true",
+                    help="fail unless the frozen census reproduces")
+    a = ap.parse_args(argv)
+
+    root = pathlib.Path(a.root).resolve()
+    ext = pathlib.Path(a.extracted) if a.extracted else O.find_extracted(root)
+    out = a.out or str(root / "build" / "dtor_members.json")
+
+    doc = harvest(root, ext)
+    st = doc["meta"]["stats"]
+
+    need_gap = a.gap or a.adjacency or a.apply or a.dry_run
+    if need_gap:
+        mods = O.load_modules(ext, collections.Counter())
+        buckets, hdr, _al, sizes = gap(root, doc, mods, collections.Counter())
+        doc["meta"]["buckets"] = {b: len(buckets[b]) for b in BUCKETS}
+
+    if a.report:
+        print("== populations ==")
+        for k in sorted(st):
+            print("  %-48s %s" % (k, st[k]))
+
+    if a.gap:
+        print("\n== pairs vs the headers ==")
+        for b in BUCKETS:
+            print("  %-20s %d" % (b, len(buckets[b])))
+        for b in ("DECIDABLE", "NO ASSERT", "DECLARED OTHERWISE", "NO FIELD AT OFFSET",
+                  "NO OWNER HEADER"):
+            print("\n-- %s (%d) --" % (b, len(buckets[b])))
+            for r in sorted(buckets[b], key=lambda r: (r["owner"], r["offset"])):
+                print("  %-34s @%s -> %-22s %s"
+                      % ((r.get("owner_header") or r["owner"]), r["offset"], r["member"],
+                         r.get("declared") or ""))
+
+    if a.adjacency:
+        res, detail = adjacency(doc, hdr, sizes, _al)
+        print("\n== adjacency rules ==")
+        for typ, (want, _wsz) in sorted(ADJACENCY.items()):
+            print("  %s always followed by its own %s?  %s"
+                  % (typ, want, dict(sorted(res[typ].items()))))
+            for owner, off, verdict, note in detail[typ]:
+                if verdict == "REFUTED":
+                    print("      COUNTER-EXAMPLE  %-30s @0x%03x  %s" % (owner, off, note))
+
+    if a.apply or a.dry_run:
+        only = set(a.only.split(",")) if a.only else None
+        picked, held = plan(root, buckets, hdr, sizes, only)
+        done, refused = apply(root, picked, sizes, write=a.apply)
+        print("\n%s: %d members in %d headers"
+              % ("applied" if a.apply else "would apply", len(done),
+                 len({r["header_path"] for r in done})))
+        for k, v in held.most_common():
+            print("  held  %3d  %s" % (v, k))
+        for rec, why in refused:
+            print("  refused  %s @%s -> %s: %s"
+                  % (rec["owner"], rec["offset"], rec["member"], why))
+
+    os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+    with open(out, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump(doc, fh, indent=1, sort_keys=False)
+        fh.write("\n")
+    print("wrote %s: %d sites, %d pairs (%d member evidence), %d owners"
+          % (out, len(doc["sites"]), st.get("pairs_distinct", 0),
+             st.get("pairs_member_evidence", 0), st.get("owners_distinct", 0)))
+
+    if a.check:
+        bad = [(k, v, st.get(k, 0)) for k, v in GATE.items() if st.get(k, 0) != v]
+        for k, want, got in bad:
+            print("GATE FAIL %s: want %d got %s" % (k, want, got))
+        if bad:
+            return 1
+        print("GATE OK")
+    return 0
+
+
+if __name__ == "__main__":                                             # pragma: no cover
+    sys.exit(main())

--- a/tools/test_dtor_members.py
+++ b/tools/test_dtor_members.py
@@ -1,0 +1,346 @@
+"""What the member-type harvester has to get right, and what already went wrong once.
+
+`dtor_members.py` reads (owner, offset, member type) out of the cartridge: a destructor
+calling a destructor, with the member's offset in r0.  The offset comes from a small
+abstract interpreter, so the interpreter's blind spots are the tool's blind spots, and
+the two that matter -- a `this` spilled to the stack, and an offset too large for an ARM
+immediate -- are cases below, driven through synthetic ARM so they run in a checkout
+with no `extracted/`.
+
+The rest are the joins.  Every one of them has cost this project work before:
+
+  * a NAME join instead of an address join.  A survey reported 127 classes with no
+    header and 125 were RTTI aliases sharing one vtable address with a spelling the
+    tree does have a file for (`opnew_sizes.resolve_header_name`, PR #1556's two
+    retractions).  `test_alias_join_regression` is the guard.
+  * one definition per class.  A header defines the same class twice, C++ and a flat
+    C stand-in, and reading only the last block reported 15 already-typed members as
+    outstanding work.
+  * "the include appears in the file" as a stand-in for "the include is visible".  A
+    header's C++ branch carries its own includes, textually above the C definition
+    below the `#else` and invisible to it; three headers failed with
+    `undefined identifier` on exactly that.
+  * a bare type name in a C-reachable header.  In C the tag is not a type name, so a
+    member needs `typedef struct X X;` as well as a C definition; without both, the
+    header fails to compile and the size assert then reports `illegal constant
+    expression` -- the shape that failed PR #1659's CI.
+"""
+import collections
+import pathlib
+import struct
+import sys
+import textwrap
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+REPO = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import dtor_members as D            # noqa: E402
+import opnew_sizes as O             # noqa: E402
+
+BASE = 0x02000000
+DTOR = 0x02100000
+
+
+# --------------------------------------------------------------- ARM encoders
+
+def push(regs):
+    return 0xE92D4000 | sum(1 << r for r in regs if r != 14)
+
+
+def mov_reg(rd, rs):
+    return 0xE1A00000 | (rd << 12) | rs
+
+
+def add_imm(rd, rn, imm8, rot=0):
+    return 0xE2800000 | (rn << 16) | (rd << 12) | (rot << 8) | (imm8 & 0xFF)
+
+
+def add_reg(rd, rn, rm):
+    return 0xE0800000 | (rn << 16) | (rd << 12) | rm
+
+
+def ldr_pc(rd, disp):
+    return 0xE59F0000 | (rd << 12) | (disp & 0xFFF)
+
+
+def str_sp(rv, off):
+    return 0xE58D0000 | (rv << 12) | (off & 0xFFF)
+
+
+def ldr_sp(rd, off):
+    return 0xE59D0000 | (rd << 12) | (off & 0xFFF)
+
+
+def bl(at, target):
+    return 0xEB000000 | (((target - (at + 8)) >> 2) & 0xFFFFFF)
+
+
+BX_LR = 0xE12FFF1E
+
+
+def offsets(words, extra=()):
+    """r0 at every instruction of a synthetic destructor, as an offset from `this`."""
+    blob = b"".join(struct.pack("<I", w) for w in list(words) + list(extra))
+    img = O.Image({"m": (BASE, blob)}, {"m": [(BASE, len(blob), "_ZN1XD1Ev")]})
+    flow = D.ThisFlow(img, "m", BASE, len(words) * 4).run()
+    return {a: (v[1] if v and v[0] == "this" else None) for a, v in flow.items()}
+
+
+# ------------------------------------------------------- the offset comes out
+
+def test_the_offset_is_the_add_immediate_before_the_call():
+    site = BASE + 8
+    got = offsets([mov_reg(4, 0), add_imm(0, 4, 0x49, 15), bl(site, DTOR), BX_LR])
+    assert got[site] == 0x124                          # #0x49 ror 30 == 0x124
+
+
+def test_a_member_at_offset_zero_is_seen_as_zero_not_as_unknown():
+    """`~Derived()` chains to its base with a bare `mov r0, r4`.  Reading that as
+    "no offset" would drop every inheritance edge instead of bucketing it BASE-AT-0."""
+    site = BASE + 8
+    got = offsets([mov_reg(4, 0), mov_reg(0, 4), bl(site, DTOR), BX_LR])
+    assert got[site] == 0
+
+
+def test_this_survives_a_spill_to_the_stack():
+    """mwccarm spills `this` in a destructor with enough live values.  Without stack
+    slots the reload is unknown and every later member of that class is lost."""
+    site = BASE + 20
+    got = offsets([push([4]), str_sp(0, 4), bl(BASE + 8, DTOR),
+                   ldr_sp(1, 4), add_imm(0, 1, 0x64), bl(site, DTOR), BX_LR])
+    assert got[site] == 0x64
+
+
+def test_an_offset_too_big_for_an_immediate_is_read_from_the_literal_pool():
+    """0x9fc4 has no rotated-8-bit encoding, so mwccarm spills it to the pool and does
+    `ldr r1, [pc, #k]; add r0, r4, r1`.  `Stage::~Stage` is the live case; 92 sites
+    reported no offset at all until the pool was read."""
+    site = BASE + 12
+    words = [mov_reg(4, 0), ldr_pc(1, 0x08), add_reg(0, 4, 1), bl(site, DTOR), BX_LR]
+    got = offsets(words, extra=[0x00009FC4])           # pc+8+8 == BASE+0x14
+    assert got[site] == 0x9FC4
+
+
+def test_a_pool_word_that_is_an_address_is_refused_not_reported():
+    """The same `ldr`/`add` shape carries real addresses too.  0x02099434 as a member
+    offset would be nonsense, and MAX_OFFSET is what stops it becoming a finding."""
+    site = BASE + 12
+    words = [mov_reg(4, 0), ldr_pc(1, 0x08), add_reg(0, 4, 1), bl(site, DTOR), BX_LR]
+    got = offsets(words, extra=[0x02099434])
+    assert got[site] is not None and not 0 <= got[site] < D.MAX_OFFSET
+
+
+def test_a_branch_join_keeps_only_what_both_paths_agree_on():
+    """`if (p) ... ;` puts a conditional branch between the add and the call.  A
+    linear walk would carry the fall-through value across the join and invent an
+    offset the cartridge does not prove."""
+    site = BASE + 16
+    words = [mov_reg(4, 0), add_imm(0, 4, 0x10),
+             0x0A000000,                               # beq -> BASE+0x10, past the add
+             add_imm(0, 4, 0x20), bl(site, DTOR), BX_LR]
+    assert offsets(words)[site] is None                # 0x10 and 0x20 disagree
+
+    # ...and the same join where both paths do agree still yields the offset
+    words[3] = add_imm(0, 4, 0x10)
+    assert offsets(words)[site] == 0x10
+
+
+# ---------------------------------------------------------------- name decode
+
+def test_a_destructor_symbol_decodes_to_its_class_and_variant():
+    assert D.demangle_dtor("_ZN7daKrb_cD1Ev") == ("daKrb_c", 1)
+    assert D.demangle_dtor("_ZN10dBgW_KcMbgD0Ev") == ("dBgW_KcMbg", 0)
+    assert D.demangle_dtor("_ZN8dGraph_c10callback_cD2Ev") == ("dGraph_c__callback_c", 2)
+    assert D.demangle_dtor("_ZN5ModelD1Ev") == ("Model", 1)
+    assert D.demangle_dtor("_ZN5Model8LoadFileEv") == (None, None)
+
+
+def test_the_target_module_field_is_parsed_in_all_three_spellings():
+    assert D.target_modules("main") == ["arm9"]
+    assert D.target_modules("overlay(2)") == ["ov002"]
+    assert D.target_modules("overlays(0,4)") == ["ov000", "ov004"]
+
+
+# ------------------------------------------------------------------- the joins
+
+def test_alias_join_regression():
+    """THE defect this file exists to keep out.
+
+    One vtable address carries several `_ZTV` spellings, because a class being renamed
+    keeps its old one as an alias, and usually only one of them has a header.  Joining
+    on the single spelling the attribution happened to carry reported NO HEADER for 125
+    classes the tree describes perfectly well.  The candidate set is every spelling at
+    the address, and the class's own key wins when it has one.
+    """
+    hdr = {"MontyMole": {"header": "x.h"}, "daStar_c": {"header": "y.h"}}
+    # the attribution carried the RTTI name; only the tree's name has a file
+    assert O.resolve_header_name("daChoropu_c", ["FortressWall", "MontyMole"], hdr) \
+        == ("MontyMole", "vtable alias")
+    # a class with its own header is never redirected to an alias's
+    assert O.resolve_header_name("daStar_c", ["PowerStar"], hdr) == ("daStar_c", "name")
+    # and no alias with a header is still an honest miss, not a silent one
+    assert O.resolve_header_name("Nowhere", ["AlsoNowhere"], hdr) == (None, None)
+
+
+def _index(tmp, name, text):
+    (tmp / "include").mkdir(parents=True, exist_ok=True)
+    (tmp / "include" / name).write_text(textwrap.dedent(text), encoding="utf-8")
+    return D.header_index(tmp)
+
+
+def test_both_definitions_of_a_dual_header_are_read(tmp_path):
+    """A header defines the class twice, C++ then a flat C stand-in.  Keeping only the
+    block that came last in the file reported 15 typed members as untyped work."""
+    idx = _index(tmp_path, "Wiggler.h", """\
+        #ifdef __cplusplus
+        struct Wiggler : dEnemyBase_c {
+            dBgCh_Actr mWithMeshClsn;                      /* 0x708 */
+        };
+        typedef char Wiggler_size_must_be_0x8e8[sizeof(struct Wiggler) == 0x8e8 ? 1 : -1];
+        #else
+        struct Wiggler {
+            u8  mWithMeshClsn[0x1bc];      /* 0x708 */
+        };
+        #endif
+        """)
+    at = idx["Wiggler"]["fields"][0x708]
+    assert ("dBgCh_Actr", "mWithMeshClsn") in at
+    assert ("u8", "mWithMeshClsn[0x1bc]") in at
+    assert idx["Wiggler"]["assert"] == 0x8E8
+
+
+def test_only_an_unconditional_include_counts_as_visible():
+    """`#include "Model.h"` inside the `#ifdef __cplusplus` branch is textually above
+    the flat C definition and invisible to it.  Three headers were typed against an
+    include that could not be reached and failed with `undefined identifier 'Model'`."""
+    lines = textwrap.dedent("""\
+        #ifndef X_H
+        #define X_H
+        #include "types.h"
+        #ifdef __cplusplus
+        #include "Model.h"
+        struct X { Model mModel; };
+        #else
+        struct X { u8 mModel; };
+        #endif
+        """).splitlines()
+    seen, anchor = D.unconditional_includes(lines, len(lines))
+    assert seen == ["types.h"]                 # NOT Model.h
+    assert lines[anchor] == '#include "types.h"'
+
+
+def test_a_c_usable_type_needs_a_typedef_as_well_as_a_definition(tmp_path):
+    """In C the tag is not a type name.  `Model` has `typedef struct Model Model;` and
+    `ShadowModel` does not, which is why one can be written into a C-reachable header
+    and the other cannot -- and why PR #1659 failed on `illegal constant expression`."""
+    inc = tmp_path / "include"
+    inc.mkdir(parents=True)
+    (inc / "Model.h").write_text(textwrap.dedent("""\
+        #ifdef __cplusplus
+        struct Model : ModelBase { };
+        #else
+        struct Model {
+            void **vtable;
+        };
+        typedef struct Model Model;
+        #endif
+        """), encoding="utf-8")
+    (inc / "ShadowModel.h").write_text(textwrap.dedent("""\
+        #ifdef __cplusplus
+        struct ShadowModel : ModelBase { };
+        #else
+        struct ShadowModel {
+            void **vtable;
+        };
+        #endif
+        """), encoding="utf-8")
+    (inc / "dBgW_KcMbg.h").write_text(textwrap.dedent("""\
+        #ifdef __cplusplus
+        struct dBgW_KcMbg : dBgW_Kc { };
+        #endif
+        """), encoding="utf-8")
+    usable = D.c_usable_types(tmp_path)
+    assert "Model" in usable
+    assert "ShadowModel" not in usable          # C definition, no typedef
+    assert "dBgW_KcMbg" not in usable           # no C definition at all
+
+
+def test_c_reachability_follows_the_include_graph(tmp_path):
+    inc, src = tmp_path / "include", tmp_path / "src"
+    inc.mkdir(parents=True)
+    src.mkdir(parents=True)
+    (inc / "A.h").write_text('#include "B.h"\n', encoding="utf-8")
+    (inc / "B.h").write_text("struct B { int x; };\n", encoding="utf-8")
+    (inc / "Lonely.h").write_text("struct Lonely { int x; };\n", encoding="utf-8")
+    (src / "t.c").write_text('#include "A.h"\nint f(void) { return 0; }\n',
+                             encoding="utf-8")
+    (src / "u.cpp").write_text('#include "Lonely.h"\n', encoding="utf-8")
+    got = D.c_reachable(tmp_path)
+    assert inc / "A.h" in got and inc / "B.h" in got     # transitively
+    assert inc / "Lonely.h" not in got                   # only a .cpp reaches it
+
+
+# ------------------------------------------------------------- the ROM itself
+
+def _rom():
+    try:
+        ext = O.find_extracted(REPO)
+    except SystemExit:
+        return None
+    return ext if (ext / "arm9_dec.bin").is_file() else None
+
+
+def test_the_frozen_census_reproduces():
+    """End-to-end, and skipped where the ROM dump is not installed -- the same way
+    tools/test_build_pin.py gates its own."""
+    ext = _rom()
+    if ext is None:
+        return
+    doc = D.harvest(REPO, ext)
+    st = doc["meta"]["stats"]
+    bad = {k: (v, st.get(k)) for k, v in D.GATE.items() if st.get(k) != v}
+    assert not bad, bad
+
+
+def test_every_call_site_the_rom_shows_yields_an_offset():
+    """The interpreter is complete over this cartridge: not one of the 2,358 dtor->dtor
+    calls inside a named destructor fails to produce an offset.  A fall here means a
+    codegen shape was introduced or the pool read was lost."""
+    ext = _rom()
+    if ext is None:
+        return
+    st = D.harvest(REPO, ext)["meta"]["stats"]
+    assert st["sites_offset_recovered"] == st["sites_inside_a_named_destructor"]
+
+
+def test_no_offset_carries_two_different_member_types():
+    """Two types at one (owner, offset) would mean the attribution is wrong somewhere,
+    the way pairing a class to a factory by name was wrong in PR #1556."""
+    ext = _rom()
+    if ext is None:
+        return
+    doc = D.harvest(REPO, ext)
+    clash = [p for p in doc["pairs"] if p["conflicting_types"]]
+    assert not clash, clash[:5]
+
+
+def test_the_applied_members_agree_with_what_the_rom_says():
+    """Every member this pass wrote is still exactly what the cartridge proves, at the
+    offset it proves, with a size assert behind it.  A header edited by hand afterwards
+    fails here rather than at the next person's `check_header_offsets` run."""
+    ext = _rom()
+    if ext is None:
+        return
+    doc = D.harvest(REPO, ext)
+    mods = O.load_modules(ext, collections.Counter())
+    buckets, hdr, _al, sizes = D.gap(REPO, doc, mods, collections.Counter())
+    for rec in buckets["ALREADY TYPED"]:
+        decl = hdr[rec["owner_header"]]["fields"][int(rec["offset"], 16)]
+        assert any(t == rec["member"] for t, _ in decl), rec
+        assert rec["member"] in sizes, rec
+
+
+if __name__ == "__main__":                                             # pragma: no cover
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
A class with an aggregate member destroys it, and mwccarm compiled that to
`add r0, r4, #off; bl _ZN<Member>D1Ev`. The call target is a relocation the ROM build
already checks and the offset is an immediate frozen in the instruction stream, so
**(owner, offset, member type) is cartridge ground truth**, not inference. `tools/dtor_members.py`
harvests all of it, and this PR applies and byte-verifies what it decides.

## The true gap, re-derived

A prior survey claimed 1,367 sites -> 734 distinct (owner, subobject) pairs, ~98 applied,
~636 remaining. Measured from `config/**/relocs.txt`:

| | survey | measured |
|---|---|---|
| `arm_call` relocations targeting a destructor symbol | 1,367 | **2,666** |
| ...inside a named destructor | - | **2,358** (308 more sit in functions this tree has not named) |
| ...with an offset recovered | - | **2,358 — every one** |
| distinct (owner, offset, member) triples | 734 | **1,178** |
| of which member evidence (nonzero offset, D1) | - | **814** |
| of which base-at-0 inheritance edges | - | **359** |
| of which secondary bases (D2 at +k, multiple inheritance) | - | **5** |
| offsets claimed by two different types | - | **0** |

Where the numbers differ, and why:

- **1,367 vs 2,666.** The survey counted about half the call sites. The likeliest cut is
  D1 only: D0 is a full copy of D1's body plus `operator delete` in this codegen, never a
  call to it, so each member is destroyed at two sites and dropping D0 halves the count.
  308 sites also sit inside destructors this tree has not yet named, which the harvester
  reports rather than silently discarding.
- **734 vs 1,178.** The survey appears to have counted only members. Splitting the triples
  by kind gives 814 members alone — still more than 734, because 92 sites carried an offset
  with no ARM immediate encoding. mwccarm spills those to the function's own literal pool
  (`ldr r1, [pc, #k]; add r0, r4, r1`), and reading the pool recovered all 92. `Stage::~Stage`
  is the live case, and the bias is exactly the wrong way round: the invisible members were
  the ones in the biggest classes.
- **~98 applied.** The tree had already typed **502**, not 98. The undercount is a parse
  defect, not a data one: a header defines the same class twice, a C++ layout and a flat C
  stand-in under `#else`, and reading one block per class hides whichever the other typed.

## What was applied

Bucketing the 814 member pairs against `include/`:

| bucket | count |
|---|---|
| ALREADY TYPED | 502 |
| DECIDABLE | 91 |
| NO FIELD AT OFFSET (offset falls inside a pad) | 181 |
| NO ASSERT (member type has no `_size_must_be_`) | 23 |
| MEMBER TYPE IS C++ ONLY | 17 |

**70 declarations written, covering 69 distinct (owner, offset) pairs across 58 headers**
(one class is defined twice in its header, so it takes two edits), byte-verified: `rombuild.py -j 16` reports
106/106 exact, 11,059 functions reproducing, **0 mismatching** — identical to the
pre-existing baseline established before any edit. The remaining 22 have an evidenced
field declared *inside* the member's span; `--apply` refuses those rather than deleting a
declaration, and re-spelling them through the member is a per-consumer job.

Six consumers carried ad-hoc shadow declarations that collide once the member is real:
`dCc_c` twice (which ICEs mwccarm at `CClass.c:3328`), `dBgW_KcMbg`, `dBgW_Kc`,
`ShadowModel`, `dBgCh_Actr`, and a `typedef int Fix12` that shadows the class template
once the header reaches `math/Fix12.h`. All deleted or renamed, none routed around.

## Both adjacency rules are refuted

`Matrix4x3` is a POD with no destructor, so no relocation can ever *name* one; what the
cartridge proves is where the next member starts, and 0x30 bytes either fit or they do not.

- **`ShadowModel` followed by its own `Matrix4x3`** — 5 confirmed by a header, 7 consistent,
  **30 counter-examples**. `MadPiano` holds three ShadowModels at 0x384, 0x3ac and 0x3d4,
  exactly `sizeof(ShadowModel)` apart with nothing between them.
- **`dBgW_KcMbg` followed by its own `Matrix4x3`** — 6 confirmed, 41 with room,
  **2 counter-examples**. `QuestionSwitch` holds three at 0x124, 0x324 and 0x4ec and a
  `ModelAnim` at 0x6b4; the last two pairs abut at exactly 0x1c8.

Both rules are properties of particular classes, not of the member type. (The dBgW_KcMbg
counter-example only became visible after the literal-pool fix — `QuestionSwitch::~QuestionSwitch`
was one of the 92 sites whose offsets could not be read.)

## The joins, each pinned by a test

Every one has cost this project work before, so `tools/test_dtor_members.py` (17 cases,
synthetic ARM where it can be, so it runs without `extracted/`) covers:

- attribution by **address**, never by name; the header is then found through every `_ZTV`
  spelling at the class's vtable address (`test_alias_join_regression` — the defect that once
  reported 127 classes with no header when 125 were RTTI aliases)
- **both** definitions of a dual C/C++ header are read
- an include counts as visible only if it is outside every `__cplusplus` conditional
- a member type needs `typedef struct X X;` **as well as** a C definition before it can go
  into a header a `.c` file reaches — without both, `undefined identifier` then
  `illegal constant expression` from the size assert, which is how PR #1659 failed CI
- `this` surviving a stack spill, the literal pool, and branch joins

## Gates

| gate | exit |
|---|---|
| `rombuild.py -j 16` — 106/106, 11,059 reproducing, 0 mismatching | 0 |
| `eligible.py` bracketed — 11065/11187 both sides, name list byte-identical | 0 |
| `check_header_offsets.py --changed origin/main` — 120 headers, 0 mismatched, 0 unparsed | 0 |
| `port_refcheck.py` — 393 references | 0 |
| `langmode_audit.py --check` vs fresh `origin/chaos-data` | 0 |
| `opnew_sizes.py --check` / `--gap` — 312 AGREES, 0 short, 0 long | 0 / 0 |
| `dtor_members.py --check` | 0 |
| `pytest tools/test_dtor_members.py` — 17 passed | 0 |
| `pyflakes tools/dtor_members.py tools/test_dtor_members.py` | 0 |

Six failures in the wider `pytest tools/` suite (`test_bytegate`, `test_srcpath`, four in
`test_tubuild`) reproduce unchanged on `origin/types/short-headers` and are not from this PR.

## Nothing contradicted the ROM

No (owner, offset) in the cartridge carries two different member types, and every member
already typed in `include/` agrees with what the destructor relocations prove.

## Named next levers

- **181 NO FIELD AT OFFSET** — the offset falls inside a pad array; splitting the pad is
  mechanical but changes more lines per header.
- **17 MEMBER TYPE IS C++ ONLY** — `dBgW_KcMbg`, `TextureSequence`, `TextureTransformer`
  and `MaterialChanger` have no flat C stand-in, and `ShadowModel`, `dBgCh_Actr`,
  `dCcAcPos_c`, `dCcAc_c` have one but no `typedef struct X X;`. Adding those unblocks
  them; deliberately out of scope here.
- **21 refused for span** — an evidenced field sits inside the member and has to be
  re-spelled through it (`unk_0f8` -> `mdCcAc_c.otherOwner` is the landed pattern).

Stacked on #1665 (`types/short-headers`).

