### PR TITLE
Two gate holes: --changed never saw the working tree, and src_tu type drift still had no compiler

### DIFF
--- a/.github/workflows/header-offsets.yml
+++ b/.github/workflows/header-offsets.yml
@@ -12,6 +12,16 @@
 # invoked `tools/check_header_offsets.py`, and run with no arguments it checked zero
 # files, printed nothing, and exited 0. Its first whole-tree run found four problems.
 #
+# AN EMPTY WORK LIST IS NOT AUTOMATICALLY A PASS. `--changed` used to exit 0 on any
+# empty diff, which collapsed "this pull request touches no header" (true of most of
+# them, and fine) together with "the base ref resolved to nothing" (a shallow clone, an
+# unfetched origin/main -- the failure that makes every other guarantee here worthless).
+# It now separates them and prints the count of files the diff DID contain as the
+# evidence, and it folds in uncommitted working-tree changes so a local pre-commit run
+# cannot report a pass over a header it never opened. `fetch-depth: 0` below is what
+# keeps the merge base reachable; without it this job now fails loudly instead of
+# passing vacuously.
+#
 # SCOPED TO CHANGED HEADERS on purpose. 441 of 445 headers pass; the four that do not
 # are written down in config/header-offset-known-issues.txt rather than silently
 # allowed, so this job is a ratchet on NEW breakage and cannot go red on debt a pull
@@ -54,6 +64,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # unittest, not pytest: pytest is not installed on this runner, and the point of
+      # this step is that the gate's own FAILURE branches still work -- so it must not
+      # be the step that needs a dependency. Same reasoning as src-tu-refs.yml.
+      #
+      # It runs BEFORE the gate, and always: the resolution tests are what say the step
+      # below looked at anything at all.
+      - name: The work-list resolution's own tests
+        run: python tools/test_check_header_offsets.py
+
       - name: Offsets agree with their comments
         env:
           BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/src-tu-refs.yml
+++ b/.github/workflows/src-tu-refs.yml
@@ -18,6 +18,12 @@
 # symbol a TU references appear in config/**/symbols.txt -- which is exactly the level
 # a rename breaks. Types and signatures are out of its reach and are not claimed.
 #
+# The compile half is tools/check_src_tu_compiles.py, which runs where the compiler is:
+# tools/hooks/pre-push and the build box. It is what catches the #1583 shape -- a header
+# retyping a virtual, with nothing renamed and every include still resolving -- and it
+# found ov029/SwitchActivatedPlank stranded by #1643 in exactly that way, after this
+# workflow had already reported the tree clean.
+#
 # AN EMPTY CHECK IS NOT A PASS. check_src_tu.py fails if it finds no translation units,
 # no includes, or no references, rather than exiting 0 the way check_references.py
 # ("skipping") and check_header_offsets.py --changed do on an empty work list.

--- a/src_tu/actors/ArrowLift.cpp
+++ b/src_tu/actors/ArrowLift.cpp
@@ -64,12 +64,17 @@ typedef int Fix12i;
 
 /* shadow struct 'SharedFilePtr' */
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
-
-/* shadow struct 'dBgW_Kc' */
-struct dBgW_Kc { int d; };
-
-/* shadow struct 'dBgW_KcMbg' */
-struct dBgW_KcMbg { int d; };
+/* Model and ModelBase are the real classes now, through this actor's header --
+ * and since #1643 so are dBgW_Kc and dBgW_KcMbg, which arrive via
+ * ArrowLift.h -> include/dBgW_Kc.h / include/dBgW_KcMbg.h. The two one-int
+ * placeholder definitions that used to stand in for them here made the whole TU
+ * fail to compile ("class 'dBgW_Kc' redefined", then an internal compiler error
+ * in the D1 body), and nothing noticed: an unbuildable source file is an ABSENT
+ * one, so every byte gate stayed green over a TU that produced no object at all.
+ * Only the references were repaired in #1667; this is the type-level half the
+ * reference gate cannot see. All functions byte-match the ROM again with the
+ * placeholders gone.
+ */
 
 extern "C" {
 extern int _ZTV9ArrowLift[];

--- a/src_tu/actors/CastleWater.cpp
+++ b/src_tu/actors/CastleWater.cpp
@@ -181,12 +181,13 @@ int CastleWater::Behavior()
 /* recovered: named members + shared header, real C++ method
  *
  * Pushes the texture transform into the model's components, then draws through
- * the model's own vtable slot 5. The transformer and the components are
- * separate sub-objects (0x320 and 0x0dc) and this is the only place they meet.
+ * the model's own vtable slot 5. The transformer and the components meet here --
+ * the components are now located at mModel.data (member of the Model aggregate
+ * at offset 0x0d4, internal offset 0x08 gives 0x0dc), not as a standalone field.
  */
 int CastleWater::Render()
 {
-    _ZN18TextureTransformer6UpdateER15ModelComponents(&mTexTransformer, &mModelComponents);
+    _ZN18TextureTransformer6UpdateER15ModelComponents(&mTexTransformer, &mModel.data);
     Sub *b = (Sub *)&mModel;
     b->m(0);
     return 1;

--- a/src_tu/actors/SwitchActivatedPlank.cpp
+++ b/src_tu/actors/SwitchActivatedPlank.cpp
@@ -52,9 +52,17 @@ int *SwitchActivatedPlank_Spawn(void)
 #include "SwitchActivatedPlank.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
-/* Model and ModelBase are the real classes now, through this actor's header. */
-struct dBgW_Kc { int d; };
-struct dBgW_KcMbg { int d; };
+/* Model and ModelBase are the real classes now, through this actor's header --
+ * and since #1643 so are dBgW_Kc and dBgW_KcMbg, which arrive via
+ * SwitchActivatedPlank.h -> include/dBgW_Kc.h / include/dBgW_KcMbg.h. The two
+ * one-int placeholder definitions that used to stand in for them here made the
+ * whole TU fail to compile ("class 'dBgW_Kc' redefined", then an internal
+ * compiler error at the D1 body), and nothing noticed: an unbuildable source
+ * file is an ABSENT one, so every byte gate stayed green over a TU that produced
+ * no object at all. Only the references were repaired in #1667; this is the
+ * type-level half the reference gate cannot see. All 9 functions byte-match the
+ * ROM again with the placeholders gone.
+ */
 
 extern "C" BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(ModelBase*, BMD_File*, int, int);

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -9,11 +9,15 @@ the byte gate cannot see a field no source file happens to read.
 This walks the declarations, applies natural alignment, and compares. Used as the
 first gate on any header edit; see notes/archive/plan-scalar-markers.md 4.
 
-    python tools/check_header_offsets.py include/Enemy.h include/Camera.h
+    python tools/check_header_offsets.py include/Amp.h include/Camera.h
     python tools/check_header_offsets.py --changed              # vs origin/main
     python tools/check_header_offsets.py --changed main
+    python tools/check_header_offsets.py --changed --committed-only   # what CI sees
 
 Running it with no arguments is an error, not a pass -- see _resolve_paths.
+An empty --changed work list is an error too, EXCEPT in the one case where it is
+honest: the diff contained files and none of them was under include/. That
+distinction is computed and printed rather than assumed -- see changed_paths.
 """
 import re, subprocess, sys, pathlib
 SZ = {"u8":1,"s8":1,"char":1,"u16":2,"s16":2,"short":2,"u32":4,"s32":4,"int":4,
@@ -27,7 +31,8 @@ SZ = {"u8":1,"s8":1,"char":1,"u16":2,"s16":2,"short":2,"u32":4,"s32":4,"int":4,
 #     struct { char c; long long v; };   /* sizeof == 12, not 16 */
 #     struct { char c; double d; };      /* sizeof == 12, not 16 */
 # (Asserting 16 instead is rejected by the compiler, so the probe discriminates.)
-# This is what lets `s64 unk_004;` sit at 0x004 in include/ClsnResult.h.
+# This is what lets `s64 unk_004;` sit at 0x004 in include/dBgPi.h (the struct
+# include/ClsnResult.h used to hold, before #1643 renamed the collision classes).
 ALIGN = {t: min(w, 4) for t, w in SZ.items()}
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -177,8 +182,173 @@ def _known_issues():
             if line.split("#", 1)[0].strip()}
 
 
-def _resolve_paths(argv):
-    """The headers to check, or exit non-zero having said why.
+HEADER_SUFFIXES = (".h", ".hpp")
+
+
+def _git_lines(args, repo=None):
+    """(lines, error). A git failure is an error string, never a traceback.
+
+    Split on newlines, not on whitespace: `git diff --name-only` quotes and escapes a
+    path containing a space, but the old `proc.stdout.split()` tore any such path into
+    two nonexistent ones, and a nonexistent path here reads as "no header changed".
+    """
+    proc = subprocess.run(["git", *args], cwd=str(repo or REPO),
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        return None, f"git {' '.join(args)} failed: {proc.stderr.strip()}"
+    return [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()], None
+
+
+def changed_paths(base, committed_only=False, repo=None, head="HEAD"):
+    """What this branch changed, in the three buckets the empty-list decision needs.
+
+    Returns ``(buckets, error)``. ``buckets`` is a dict of sorted, de-duplicated
+    repo-relative paths::
+
+        total     every added/modified file, ANY directory -- the proof the diff
+                  machinery ran at all
+        include   the subset under include/, ANY extension
+        headers   the subset of those that is a .h/.hpp -- the actual work list
+        worktree  the subset of `headers` that is NOT in the commits (see below)
+        dropped   include/ paths the extension filter discarded
+
+    THREE SOURCES, unioned:
+
+    1. ``{base}...HEAD`` -- the commits. This was the only source the tool had, and it
+       is why a local pre-commit run reported a pass on work it had never opened: a
+       header edited and not yet committed is not in this diff, so `--changed` printed
+       "no include/ header added or modified" and exited 0 over a dirty tree.
+    2. ``HEAD`` vs the working tree -- staged and unstaged edits both. Empty on a CI
+       checkout, and the entire work list when a developer runs this before committing.
+    3. untracked files -- a brand-new header that has never been `git add`ed is in
+       neither of the above, and a brand-new header is precisely the one whose offsets
+       have never been checked by anything.
+
+    ``committed_only=True`` uses source 1 alone, which is exactly what CI sees; the
+    other two are still computed so the caller can say out loud that they were ignored.
+
+    ``head`` is for pointing this at history other than the current branch -- the tests
+    aim it at real merge commits and assert the headers those pull requests edited still
+    come back. Sources 2 and 3 are relative to the working tree by definition, so they
+    are only consulted when ``head`` is the working tree's own HEAD.
+
+    Renames arrive as an add because ``-M`` is deliberately not passed -- a header that
+    moved still has to have its offsets agree.
+    """
+    commits, err = _git_lines(["diff", "--name-only", "--diff-filter=AM",
+                               f"{base}...{head}"], repo)
+    if err:
+        return None, err
+    if head == "HEAD":
+        dirty, err = _git_lines(["diff", "--name-only", "--diff-filter=AM", "HEAD"], repo)
+        if err:
+            return None, err
+        untracked, err = _git_lines(["ls-files", "--others", "--exclude-standard"], repo)
+        if err:
+            return None, err
+    else:
+        dirty = untracked = []
+
+    local = set(dirty) | set(untracked)
+    total = set(commits) if committed_only else set(commits) | local
+    inc = {p for p in total if p.startswith("include/")}
+    heads = {p for p in inc if p.endswith(HEADER_SUFFIXES)}
+    return {
+        "total": sorted(total),
+        "include": sorted(inc),
+        "headers": sorted(heads),
+        "dropped": sorted(inc - heads),
+        # Reported even under --committed-only, where it is what is being IGNORED.
+        "worktree": sorted(p for p in local
+                           if p.startswith("include/")
+                           and p.endswith(HEADER_SUFFIXES)
+                           and p not in set(commits)),
+    }, None
+
+
+def _resolve_changed(base, committed_only=False, repo=None):
+    """(paths, exit_code). ``paths`` is None when the caller should exit immediately.
+
+    AN EMPTY WORK LIST IS NOT AUTOMATICALLY A PASS, AND NOT AUTOMATICALLY A FAILURE.
+    The old code exited 0 on any empty diff, which collapsed four different situations
+    into one green line. They are not the same and this pulls them apart:
+
+    * The diff named files and none of them is under include/. This is the ONE honest
+      empty: most pull requests touch no header, the gate has genuinely nothing to do,
+      and saying so is not a hollow pass because the count of files it DID see is
+      printed as evidence the diff resolved to something.
+    * The diff named nothing at all. On a pull request that cannot happen -- a pull
+      request always changes a file -- so this is a base ref that resolved to the wrong
+      commit (an unfetched `origin/main`, a shallow clone with no merge base, HEAD equal
+      to base). The old code called it a pass. It is the failure mode that makes every
+      other guarantee in this file worthless, so it now fails.
+    * include/ changed but the .h/.hpp filter discarded every one of those paths. The
+      filter existed to skip `include/`'s non-headers; when it eats the whole work list
+      it is no longer skipping noise, it is skipping the job.
+    * The headers are only in the working tree. Included by default now; under
+      --committed-only they are reported loudly rather than silently dropped.
+    """
+    root = pathlib.Path(repo) if repo else REPO
+    buckets, err = changed_paths(base, committed_only, root)
+    if buckets is None:
+        print(f"check_header_offsets: {err}", file=sys.stderr)
+        return None, 1
+
+    if committed_only and buckets["worktree"]:
+        # Not folded in, so say so at the top of the log where it cannot be missed.
+        print(f"check_header_offsets: WARNING -- --committed-only, so "
+              f"{len(buckets['worktree'])} uncommitted header(s) are NOT being checked:")
+        for p in buckets["worktree"]:
+            print(f"    {p}")
+
+    if not buckets["total"]:
+        print(f"check_header_offsets: the diff against {base} is EMPTY -- no file added "
+              f"or modified anywhere in the tree, not merely no header.", file=sys.stderr)
+        print(f"check_header_offsets: that is not 'a change that touches no header', it "
+              f"is a base ref that resolved to nothing. Check that {base} exists and is "
+              f"fetched (a shallow clone has no merge base), or pass the header paths "
+              f"explicitly.", file=sys.stderr)
+        return None, 1
+
+    if buckets["dropped"] and not buckets["headers"]:
+        print(f"check_header_offsets: {len(buckets['dropped'])} include/ path(s) changed "
+              f"and NONE is a {'/'.join(HEADER_SUFFIXES)} -- the extension filter "
+              f"discarded this gate's entire work list:", file=sys.stderr)
+        for p in buckets["dropped"]:
+            print(f"    {p}", file=sys.stderr)
+        return None, 1
+
+    if not buckets["headers"]:
+        # The honest empty. The evidence is the count, and it is printed.
+        print(f"check_header_offsets: {len(buckets['total'])} file(s) added or modified "
+              f"vs {base}, 0 of them under include/ -- nothing for this gate to check.")
+        return None, 0
+
+    if buckets["dropped"]:
+        print(f"check_header_offsets: ignoring {len(buckets['dropped'])} non-header "
+              f"include/ path(s): {', '.join(buckets['dropped'])}")
+    if buckets["worktree"] and not committed_only:
+        print(f"check_header_offsets: {len(buckets['worktree'])} of these are "
+              f"UNCOMMITTED working-tree changes: {', '.join(buckets['worktree'])}")
+    print(f"check_header_offsets: {len(buckets['headers'])} changed header(s) vs {base}")
+
+    # A path the commit range names can have been deleted in the working tree since.
+    # Dropping it silently would shrink the work list back towards the empty pass this
+    # whole function exists to refuse, so it is named.
+    live = [p for p in buckets["headers"] if (root / p).is_file()]
+    gone = [p for p in buckets["headers"] if p not in live]
+    if gone:
+        print(f"check_header_offsets: {len(gone)} changed header(s) no longer on disk, "
+              f"skipping: {', '.join(gone)}")
+    if not live:
+        print("check_header_offsets: every changed header has since been deleted -- "
+              "nothing left to check, and that is not a pass", file=sys.stderr)
+        return None, 1
+    return live, 0
+
+
+def _resolve_paths(argv, repo=None):
+    """The headers to check, or (None, code) having said why.
 
     This tool fed ``sys.argv[1:]`` straight into the loop below, so running it bare
     checked nothing, printed nothing, and exited 0 -- a clean pass over zero files.
@@ -186,244 +356,270 @@ def _resolve_paths(argv):
     vacuous pass was, in practice, its only behaviour. Refusing an empty list is what
     makes wiring it into CI mean anything.
 
-    ``--changed [base]`` is the CI form: the added and modified headers of this branch.
-    Renames arrive as an add because ``-M`` is deliberately not passed -- a header that
-    moved still has to have its offsets agree.
+    ``--changed [base]`` is the CI form: the added and modified headers of this branch,
+    working tree included unless ``--committed-only`` is given.
     """
+    argv = list(argv)
+    committed_only = False
+    if "--committed-only" in argv:
+        argv.remove("--committed-only")
+        committed_only = True
     if argv and argv[0] == "--changed":
         base = argv[1] if len(argv) > 1 else "origin/main"
-        proc = subprocess.run(
-            ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
-             "--", "include/"],
-            cwd=REPO, capture_output=True, text=True)
-        if proc.returncode != 0:
-            sys.exit(f"check_header_offsets: git diff against {base} failed: "
-                     f"{proc.stderr.strip()}")
-        argv = [p for p in proc.stdout.split() if p.endswith((".h", ".hpp"))]
-        if not argv:
-            print(f"check_header_offsets: no include/ header added or modified "
-                  f"against {base}")
-            sys.exit(0)
-        print(f"check_header_offsets: {len(argv)} changed header(s) vs {base}")
+        return _resolve_changed(base, committed_only, repo)
+    if committed_only:
+        print("check_header_offsets: --committed-only only means anything with --changed",
+              file=sys.stderr)
+        return None, 1
     if not argv:
-        sys.exit("usage: check_header_offsets.py <header>... | --changed [base]\n"
-                 "refusing to run with no headers: an empty check is not a pass")
-    return argv
+        print("usage: check_header_offsets.py <header>... | "
+              "--changed [base] [--committed-only]\n"
+              "refusing to run with no headers: an empty check is not a pass",
+              file=sys.stderr)
+        return None, 1
+    # A named header that is not there was a bare FileNotFoundError traceback out of
+    # the walk below -- loud, but it never said WHICH argument was wrong, and this
+    # file's own usage line named two headers that renames had since deleted
+    # (include/Enemy.h in #1574, include/ClsnResult.h in #1643).
+    root = pathlib.Path(repo) if repo else REPO
+    missing = [a for a in argv
+               if not pathlib.Path(a).is_file() and not (root / a).is_file()]
+    if missing:
+        print(f"check_header_offsets: {len(missing)} named header(s) do not exist: "
+              f"{', '.join(missing)}", file=sys.stderr)
+        return None, 1
+    return argv, 0
 
 
-rc = 0
-WAIVED = _known_issues()
-for path in _resolve_paths(sys.argv[1:]):
-    if pathlib.PurePath(path).as_posix() in WAIVED:
-        print(f"{path}: WAIVED -- config/header-offset-known-issues.txt")
-        continue
-    txt = pathlib.Path(path).read_text(errors="replace")
-    off, bad, n, skipped, pending = 0, 0, 0, [], []
-    trusted = True
-    started = in_comment = unmodelled = nested = skip_other = False
-    skip_body = 0
-    unknown_base = derived_from = None
-    expected = pathlib.Path(path).stem
-    for lineno, line in enumerate(txt.splitlines(), 1):
-        if not started:
-            # A struct-with-body BEFORE the file's own class is a helper type
-            # (ActorBase_SceneNode in fBase_c.h, KCL_Tri in dBgW_Kc.h,
-            # Particle::SysTracker's namespace-nested body in Stage.h), not the
-            # struct this file is named for. Without this check the FIRST
-            # struct-with-body wins regardless of name, and the tool silently
-            # checks the helper instead of the class the header exists to
-            # verify -- confirmed tree-wide: 13 headers had this shape, most
-            # already reporting a false "0 unparsed" pass on the wrong struct.
-            if skip_other:
-                if re.match(r"^\s*\};", line):
-                    skip_other = False
-                continue
-            # `struct X {` or `struct X : Base {`. Without the second form this
-            # tool never started on a derived struct at all, and reported
-            # "0 commented fields ... struct spans 0x0" -- which reads exactly
-            # like a pass. Every class this repo reconstructs from here on is a
-            # derived struct, so that silence covered the growing majority.
-            m0 = re.match(r"^\s*struct (\w+)\s*(?::\s*(?:public\s+)?(\w+)\s*)?\{", line)
-            if m0:
-                if m0.group(1) != expected:
-                    # `struct BMA_File { u16 numFrames; };` -- opens AND closes on
-                    # the same line. Setting skip_other here and never checking
-                    # THIS line for the closing brace left it permanently stuck:
-                    # the real target struct's own opening line was then read
-                    # while still "skipping", so it was silently swallowed whole
-                    # -- MaterialChanger.h and TextureTransformer.h went from an
-                    # honest UNPARSED failure to a hollow "0 fields, 0 unparsed"
-                    # pass, checking nothing at all. Only skip forward if this
-                    # line's own body does NOT already close it.
-                    if not re.search(r"\};", line):
-                        skip_other = True
+def main(argv, repo=None):
+    """Check every header `argv` resolves to. Exit code is the gate's verdict."""
+    root = pathlib.Path(repo) if repo else REPO
+    paths, code = _resolve_paths(argv, root)
+    if paths is None:
+        return code
+    rc = 0
+    WAIVED = _known_issues()
+    for path in paths:
+        if pathlib.PurePath(path).as_posix() in WAIVED:
+            print(f"{path}: WAIVED -- config/header-offset-known-issues.txt")
+            continue
+        # Resolve against the repo root, not the process cwd: `--changed` yields
+        # repo-relative paths and the gate must not depend on where it was run
+        # from. An explicit argument that resolves from cwd still wins.
+        fp = pathlib.Path(path)
+        if not fp.is_absolute() and not fp.is_file():
+            fp = root / path
+        txt = fp.read_text(errors="replace")
+        off, bad, n, skipped, pending = 0, 0, 0, [], []
+        trusted = True
+        started = in_comment = unmodelled = nested = skip_other = False
+        skip_body = 0
+        unknown_base = derived_from = None
+        expected = fp.stem
+        for lineno, line in enumerate(txt.splitlines(), 1):
+            if not started:
+                # A struct-with-body BEFORE the file's own class is a helper type
+                # (ActorBase_SceneNode in fBase_c.h, KCL_Tri in dBgW_Kc.h,
+                # Particle::SysTracker's namespace-nested body in Stage.h), not the
+                # struct this file is named for. Without this check the FIRST
+                # struct-with-body wins regardless of name, and the tool silently
+                # checks the helper instead of the class the header exists to
+                # verify -- confirmed tree-wide: 13 headers had this shape, most
+                # already reporting a false "0 unparsed" pass on the wrong struct.
+                if skip_other:
+                    if re.match(r"^\s*\};", line):
+                        skip_other = False
                     continue
-                started = True
-                base = m0.group(2)
-                if base is not None:
-                    # A derived struct's own fields do NOT start at 0 -- the base
-                    # sub-object is there. Guessing 0 would mismatch every field,
-                    # so refuse unless the base states its own size.
-                    if base not in SZ:
-                        unknown_base = base
-                        break
-                    # Data size, not sizeof -- see DATA_SIZE above. Each field is
-                    # aligned below, so a base whose padding is unused still puts
-                    # the first own field exactly where sizeof would have.
-                    off = DATA_SIZE.get(base, SZ[base])
-                    derived_from = base
-            continue
-        if in_comment:
-            if "*/" in line:
-                in_comment = False
-            continue
-        # An inline method BODY (`virtual ~dScMgBase_c() { ...; }`), being
-        # skipped over by the methods-declared-first branch below. Track brace
-        # depth across lines the same way `nested`/`in_comment` already do,
-        # rather than assuming a method is always one line -- an unbalanced
-        # line here would otherwise fall through to DECL parsing and get
-        # reported UNPARSED against the tool's own skipped-method text.
-        if skip_body:
-            skip_body += line.count("{") - line.count("}")
-            continue
-        # A NESTED type definition -- `struct State { ... };` inside Player -- is a
-        # type, not a field: it occupies no space and advances no offset. Consume it
-        # whole, before the checks below can misread it.
-        #
-        # Two of those checks would, and both fail silently. Its closing `};` matches
-        # the outer-struct terminator on the next line, and a pointer-to-member
-        # declaration (`int (Player::*mInit)();`) matches the member-function pattern
-        # that ends the field list. Either way the walk stopped at the nested type,
-        # and for Player.h that meant "0 commented fields ... struct spans 0xd0" --
-        # the base's size, no fields checked, exit status 0. A header with 177
-        # checkable fields reported exactly like a clean pass.
-        if nested:
-            if re.match(r"^\s*\};", line):
-                nested = False
-            continue
-        # A nested FORWARD declaration -- `struct State;` inside Camera -- is a type
-        # too, and occupies no space either. It shows up when a class handles its
-        # nested type ONLY by pointer: `Camera::ChangeState` is mangled `PNS_5StateE`,
-        # which is what forces State to be nested, while nothing in the tree
-        # dereferences one, so there is no layout to write down.
-        #
-        # DECL wants two identifiers (`struct X y;`), so a bare tag matched nothing
-        # and fell through to UNPARSED -- and per the note above, ONE unparsed line
-        # suppresses the mismatch check for the whole header. That is the same
-        # silent-no-op shape this gate has already been bitten by twice, arriving a
-        # third way; here it at least exits non-zero rather than reporting a pass.
-        if re.match(r"^\s*(?:struct|union|class)\s+\w+\s*;\s*$", line):
-            continue
-        if re.match(r"^\s*struct \w+\s*(?::\s*(?:public\s+)?\w+\s*)?\{", line):
-            nested = True
-            continue
-        if re.match(r"^\s*(#|\}|/\* methods)", line):
-            break
-        if IGNORABLE.match(line):
-            if "/*" in line and "*/" not in line:
-                in_comment = True
-            continue
-        # A polymorphic C++ struct carries an implicit vptr at offset 0 that no
-        # declaration mentions, so the running offset cannot be derived from the text.
-        # Say the struct is unmodelled rather than emit a mismatch per field.
-        #
-        # `~Name(...)` (a bare, non-virtual destructor declaration -- Particle::
-        # SysTracker in include/Stage.h is the first instance) starts with `~`,
-        # which the type-name alternative below never matches (`~` is not in
-        # `[A-Za-z_]`), so without this alternative it fell through to UNPARSED.
-        if re.match(r"^\s*(virtual\b|~\w+\s*\([^;]*\)\s*;|[A-Za-z_][\w:<>, &*]*\([^;]*\)\s*(const)?\s*;)", line):
-            # ...unless we started from a base whose size is asserted. A derived
-            # class places no vptr of its own -- it inherits the base's, and the
-            # base's asserted size already counts it. The running offset is sound,
-            # so the member functions merely end the field list.
-            if derived_from is None:
-                unmodelled = True
-                break
-            # A derived class can ALSO declare its destructor/overrides FIRST
-            # (dScene_c.h's KEY FUNCTION convention -- "the destructor is declared
-            # first, which is safe for a derived class"). Before any real field
-            # has been seen, a method line doesn't end the list, it's still the
-            # header's front matter -- without this, dScMgBase_c.h (destructor +
-            # 8 overrides, THEN ~30 fields) reported "0 commented fields ...
-            # struct spans 0x50", the exact same silent-no-op shape as every
-            # other bug this file documents, just arrived at from the opposite
-            # direction. Once a field HAS been seen, a method line ends the
-            # list as before -- that's the generated-header convention
-            # (Stage.h: fields, then methods).
-            if n == 0:
-                depth = line.count("{") - line.count("}")
-                if depth > 0:
-                    skip_body = depth
+                # `struct X {` or `struct X : Base {`. Without the second form this
+                # tool never started on a derived struct at all, and reported
+                # "0 commented fields ... struct spans 0x0" -- which reads exactly
+                # like a pass. Every class this repo reconstructs from here on is a
+                # derived struct, so that silence covered the growing majority.
+                m0 = re.match(r"^\s*struct (\w+)\s*(?::\s*(?:public\s+)?(\w+)\s*)?\{", line)
+                if m0:
+                    if m0.group(1) != expected:
+                        # `struct BMA_File { u16 numFrames; };` -- opens AND closes on
+                        # the same line. Setting skip_other here and never checking
+                        # THIS line for the closing brace left it permanently stuck:
+                        # the real target struct's own opening line was then read
+                        # while still "skipping", so it was silently swallowed whole
+                        # -- MaterialChanger.h and TextureTransformer.h went from an
+                        # honest UNPARSED failure to a hollow "0 fields, 0 unparsed"
+                        # pass, checking nothing at all. Only skip forward if this
+                        # line's own body does NOT already close it.
+                        if not re.search(r"\};", line):
+                            skip_other = True
+                        continue
+                    started = True
+                    base = m0.group(2)
+                    if base is not None:
+                        # A derived struct's own fields do NOT start at 0 -- the base
+                        # sub-object is there. Guessing 0 would mismatch every field,
+                        # so refuse unless the base states its own size.
+                        if base not in SZ:
+                            unknown_base = base
+                            break
+                        # Data size, not sizeof -- see DATA_SIZE above. Each field is
+                        # aligned below, so a base whose padding is unused still puts
+                        # the first own field exactly where sizeof would have.
+                        off = DATA_SIZE.get(base, SZ[base])
+                        derived_from = base
                 continue
-            break
-        # A declaration can carry a trailing comment that runs onto later lines:
-        #     u8 unk_010;   /* 0x010 - first byte of the 0x28-byte ClsnResult
-        #                              the hit is written into ... */
-        # Those continuation lines are prose, not declarations. Without this they
-        # were reported UNPARSED and the header failed the gate on its own comments.
-        if line.count("/*") > line.count("*/"):
-            in_comment = True
-        m = DECL.match(line)
-        typ = m.group(1).rsplit("::", 1)[-1] if m else None
-        w = 4 if (m and m.group(2)) else SZ.get(typ)
-        if w is None:
-            # An unrecognised declaration is NOT harmless: skipping it leaves the
-            # running offset short, so every later field silently "matches" at the
-            # wrong place. Say so rather than quietly carrying on.
-            skipped.append(f"{lineno}: {line.strip()}")
-            # ...and stop claiming MISMATCH from here on. The running offset is now
-            # known-wrong, so every later comparison is against a meaningless number:
-            # `struct CylinderClsn base;` is unparseable, which made the very next
-            # field report "comment 0x30, computed 0x000". Those are artifacts of the
-            # skip, not defects in the header. UNPARSED already fails the gate, so
-            # nothing is being hidden -- the difference is that what it prints is true.
-            trusted = False
+            if in_comment:
+                if "*/" in line:
+                    in_comment = False
+                continue
+            # An inline method BODY (`virtual ~dScMgBase_c() { ...; }`), being
+            # skipped over by the methods-declared-first branch below. Track brace
+            # depth across lines the same way `nested`/`in_comment` already do,
+            # rather than assuming a method is always one line -- an unbalanced
+            # line here would otherwise fall through to DECL parsing and get
+            # reported UNPARSED against the tool's own skipped-method text.
+            if skip_body:
+                skip_body += line.count("{") - line.count("}")
+                continue
+            # A NESTED type definition -- `struct State { ... };` inside Player -- is a
+            # type, not a field: it occupies no space and advances no offset. Consume it
+            # whole, before the checks below can misread it.
+            #
+            # Two of those checks would, and both fail silently. Its closing `};` matches
+            # the outer-struct terminator on the next line, and a pointer-to-member
+            # declaration (`int (Player::*mInit)();`) matches the member-function pattern
+            # that ends the field list. Either way the walk stopped at the nested type,
+            # and for Player.h that meant "0 commented fields ... struct spans 0xd0" --
+            # the base's size, no fields checked, exit status 0. A header with 177
+            # checkable fields reported exactly like a clean pass.
+            if nested:
+                if re.match(r"^\s*\};", line):
+                    nested = False
+                continue
+            # A nested FORWARD declaration -- `struct State;` inside Camera -- is a type
+            # too, and occupies no space either. It shows up when a class handles its
+            # nested type ONLY by pointer: `Camera::ChangeState` is mangled `PNS_5StateE`,
+            # which is what forces State to be nested, while nothing in the tree
+            # dereferences one, so there is no layout to write down.
+            #
+            # DECL wants two identifiers (`struct X y;`), so a bare tag matched nothing
+            # and fell through to UNPARSED -- and per the note above, ONE unparsed line
+            # suppresses the mismatch check for the whole header. That is the same
+            # silent-no-op shape this gate has already been bitten by twice, arriving a
+            # third way; here it at least exits non-zero rather than reporting a pass.
+            if re.match(r"^\s*(?:struct|union|class)\s+\w+\s*;\s*$", line):
+                continue
+            if re.match(r"^\s*struct \w+\s*(?::\s*(?:public\s+)?\w+\s*)?\{", line):
+                nested = True
+                continue
+            if re.match(r"^\s*(#|\}|/\* methods)", line):
+                break
+            if IGNORABLE.match(line):
+                if "/*" in line and "*/" not in line:
+                    in_comment = True
+                continue
+            # A polymorphic C++ struct carries an implicit vptr at offset 0 that no
+            # declaration mentions, so the running offset cannot be derived from the text.
+            # Say the struct is unmodelled rather than emit a mismatch per field.
+            #
+            # `~Name(...)` (a bare, non-virtual destructor declaration -- Particle::
+            # SysTracker in include/Stage.h is the first instance) starts with `~`,
+            # which the type-name alternative below never matches (`~` is not in
+            # `[A-Za-z_]`), so without this alternative it fell through to UNPARSED.
+            if re.match(r"^\s*(virtual\b|~\w+\s*\([^;]*\)\s*;|[A-Za-z_][\w:<>, &*]*\([^;]*\)\s*(const)?\s*;)", line):
+                # ...unless we started from a base whose size is asserted. A derived
+                # class places no vptr of its own -- it inherits the base's, and the
+                # base's asserted size already counts it. The running offset is sound,
+                # so the member functions merely end the field list.
+                if derived_from is None:
+                    unmodelled = True
+                    break
+                # A derived class can ALSO declare its destructor/overrides FIRST
+                # (dScene_c.h's KEY FUNCTION convention -- "the destructor is declared
+                # first, which is safe for a derived class"). Before any real field
+                # has been seen, a method line doesn't end the list, it's still the
+                # header's front matter -- without this, dScMgBase_c.h (destructor +
+                # 8 overrides, THEN ~30 fields) reported "0 commented fields ...
+                # struct spans 0x50", the exact same silent-no-op shape as every
+                # other bug this file documents, just arrived at from the opposite
+                # direction. Once a field HAS been seen, a method line ends the
+                # list as before -- that's the generated-header convention
+                # (Stage.h: fields, then methods).
+                if n == 0:
+                    depth = line.count("{") - line.count("}")
+                    if depth > 0:
+                        skip_body = depth
+                    continue
+                break
+            # A declaration can carry a trailing comment that runs onto later lines:
+            #     u8 unk_010;   /* 0x010 - first byte of the 0x28-byte ClsnResult
+            #                              the hit is written into ... */
+            # Those continuation lines are prose, not declarations. Without this they
+            # were reported UNPARSED and the header failed the gate on its own comments.
+            if line.count("/*") > line.count("*/"):
+                in_comment = True
+            m = DECL.match(line)
+            typ = m.group(1).rsplit("::", 1)[-1] if m else None
+            w = 4 if (m and m.group(2)) else SZ.get(typ)
+            if w is None:
+                # An unrecognised declaration is NOT harmless: skipping it leaves the
+                # running offset short, so every later field silently "matches" at the
+                # wrong place. Say so rather than quietly carrying on.
+                skipped.append(f"{lineno}: {line.strip()}")
+                # ...and stop claiming MISMATCH from here on. The running offset is now
+                # known-wrong, so every later comparison is against a meaningless number:
+                # `struct CylinderClsn base;` is unparseable, which made the very next
+                # field report "comment 0x30, computed 0x000". Those are artifacts of the
+                # skip, not defects in the header. UNPARSED already fails the gate, so
+                # nothing is being hidden -- the difference is that what it prints is true.
+                trusted = False
+                continue
+            _, _, name, arr, decl = m.groups()
+            # Alignment is the strictest MEMBER alignment, never the type's size: a
+            # 100-byte ModelAnim aligns to 4, not to 100. Aligning to size padded 0xd4
+            # out to 0x12c and made every later field in the header mismatch.
+            #
+            # Prefer a computed alignment when we have one: learn_aggregates knows a
+            # Vector3 is 4-aligned because its members are. Fall back to min(w, 4) for
+            # a type known only by its `_size_must_be_` assertion -- the size alone
+            # cannot give the alignment, and no member of any struct here exceeds 4.
+            a = 4 if (m and m.group(2)) else ALIGN.get(typ, min(w, 4))
+            if off % a:                       # compiler would insert padding here
+                off += a - (off % a)
+            if decl is not None and trusted:
+                n += 1
+                if int(decl, 16) != off:
+                    # Buffered, not printed: a polymorphic struct declares its virtuals
+                    # AFTER its fields, so we only learn the layout is unmodelled once
+                    # every field has already been compared against an offset that is
+                    # short by the implicit vptr. Printing as we went emitted a screen of
+                    # MISMATCHes for a header the tool then correctly skipped.
+                    pending.append(f"  MISMATCH {path}:{lineno} {name}: comment {decl}, "
+                                   f"computed 0x{off:03x}")
+                    bad += 1
+            arr_n = 1
+            for d in ARR_DIMS.findall(arr):
+                arr_n *= int(d, 0)
+            off += w * arr_n
+        if unknown_base:
+            # Not a pass and not a failure: a statement of what is missing. Adding
+            # `typedef char X_size_must_be_0xN[sizeof(X) == 0xN ? 1 : -1];` to the
+            # base's header makes this header checkable AND makes the base's own size
+            # a claim the compiler enforces.
+            print(f"{path}: skipped -- derives from {unknown_base}, whose size is asserted "
+                  f"nowhere (add {unknown_base}_size_must_be_0x.. to its header)")
             continue
-        _, _, name, arr, decl = m.groups()
-        # Alignment is the strictest MEMBER alignment, never the type's size: a
-        # 100-byte ModelAnim aligns to 4, not to 100. Aligning to size padded 0xd4
-        # out to 0x12c and made every later field in the header mismatch.
-        #
-        # Prefer a computed alignment when we have one: learn_aggregates knows a
-        # Vector3 is 4-aligned because its members are. Fall back to min(w, 4) for
-        # a type known only by its `_size_must_be_` assertion -- the size alone
-        # cannot give the alignment, and no member of any struct here exceeds 4.
-        a = 4 if (m and m.group(2)) else ALIGN.get(typ, min(w, 4))
-        if off % a:                       # compiler would insert padding here
-            off += a - (off % a)
-        if decl is not None and trusted:
-            n += 1
-            if int(decl, 16) != off:
-                # Buffered, not printed: a polymorphic struct declares its virtuals
-                # AFTER its fields, so we only learn the layout is unmodelled once
-                # every field has already been compared against an offset that is
-                # short by the implicit vptr. Printing as we went emitted a screen of
-                # MISMATCHes for a header the tool then correctly skipped.
-                pending.append(f"  MISMATCH {path}:{lineno} {name}: comment {decl}, "
-                               f"computed 0x{off:03x}")
-                bad += 1
-        arr_n = 1
-        for d in ARR_DIMS.findall(arr):
-            arr_n *= int(d, 0)
-        off += w * arr_n
-    if unknown_base:
-        # Not a pass and not a failure: a statement of what is missing. Adding
-        # `typedef char X_size_must_be_0xN[sizeof(X) == 0xN ? 1 : -1];` to the
-        # base's header makes this header checkable AND makes the base's own size
-        # a claim the compiler enforces.
-        print(f"{path}: skipped -- derives from {unknown_base}, whose size is asserted "
-              f"nowhere (add {unknown_base}_size_must_be_0x.. to its header)")
-        continue
-    if unmodelled:
-        # not a failure: this gate is for the generated flat headers, and a
-        # hand-written polymorphic one has layout the text does not determine
-        print(f"{path}: skipped -- polymorphic C++ struct, implicit vptr not modelled")
-        continue
-    for msg in pending:
-        print(msg)
-    for s in skipped:
-        print(f"  UNPARSED {path}:{s}")
-    print(f"{path}: {n} commented fields, {bad} mismatched, "
-          f"{len(skipped)} unparsed, struct spans 0x{off:x}")
-    rc |= bool(bad or skipped)
-sys.exit(rc)
+        if unmodelled:
+            # not a failure: this gate is for the generated flat headers, and a
+            # hand-written polymorphic one has layout the text does not determine
+            print(f"{path}: skipped -- polymorphic C++ struct, implicit vptr not modelled")
+            continue
+        for msg in pending:
+            print(msg)
+        for s in skipped:
+            print(f"  UNPARSED {path}:{s}")
+        print(f"{path}: {n} commented fields, {bad} mismatched, "
+              f"{len(skipped)} unparsed, struct spans 0x{off:x}")
+        rc |= bool(bad or skipped)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/check_src_tu.py
+++ b/tools/check_src_tu.py
@@ -43,12 +43,22 @@ WHAT IT DOES NOT CHECK
 ----------------------
 Types, signatures and layout. A TU can pass this gate and still not compile, because
 a header can retype a field or change a virtual's return type without renaming
-anything -- src_tu/actors/Actor.cpp and src_tu/actors/CastleWater.cpp are in that
-state today and are NOT this gate's business. Catching those needs mwccarm, and
-mwccarm is not on the GitHub runner: it lives on the private build box that
-pr-validate.yml relays to. This check is stdlib-only over the working tree -- no
-compiler, no ROM, about a second over 41 files -- which is why it can gate every PR
-the way header-offsets.yml and python-names.yml do.
+anything. Catching those needs mwccarm, and mwccarm is not on the GitHub runner: it
+lives on the private build box that pr-validate.yml relays to. This check is
+stdlib-only over the working tree -- no compiler, no ROM, about a second over 41
+files -- which is why it can gate every PR the way header-offsets.yml and
+python-names.yml do.
+
+tools/check_src_tu_compiles.py is the other half: it runs the compiler, so it runs
+where the compiler is (tools/hooks/pre-push, the build box) and not here.
+
+This section used to name src_tu/actors/Actor.cpp and src_tu/actors/CastleWater.cpp
+as being in that state. They were not: both compile, and neither they nor any header
+has changed since this file landed, so the claim was wrong when it was written. The
+one translation unit that really did not compile -- ov029/SwitchActivatedPlank, whose
+placeholder `struct dBgW_Kc { int d; };` collided with the real class #1643 gave it --
+went unnamed, because nothing had run a compiler over src_tu to find out which was
+which. That is the whole argument for the compile gate in one sentence.
 
 AN EMPTY CHECK IS NOT A PASS
 ----------------------------

--- a/tools/check_src_tu_compiles.py
+++ b/tools/check_src_tu_compiles.py
@@ -1,0 +1,277 @@
+"""Every src_tu/ translation unit must still COMPILE under the pin the build would use.
+
+WHY THIS EXISTS
+---------------
+`tools/check_src_tu.py` (#1667) closed half a hole: it proves every `#include` resolves
+and every mangled symbol a merged TU names is a symbol the ROM configuration knows. Its
+own "WHAT IT DOES NOT CHECK" section names the other half:
+
+    Types, signatures and layout. A TU can pass this gate and still not compile,
+    because a header can retype a field or change a virtual's return type without
+    renaming anything.
+
+That is not hypothetical, it is what happened. #1583 retyped three `dActor_c` virtuals
+from `int` to `void` and swept only `src/`. `src_tu/actors/Actor.cpp` still declared them
+`int`, so it stopped compiling -- and NOTHING WENT RED, for the same reason #1643's
+rename went unnoticed: an unbuildable source file is not a failing file, it is an ABSENT
+one. It produces no object, so it produces no mismatch, and `rombuild.py` went on
+reporting 106/106 exact with the file simply gone from coverage (notes:
+unbuildable-files-invisible). A resolution check cannot see a return type. Only the
+compiler can, so this gate runs the compiler.
+
+WHERE IT RUNS
+-------------
+Not on a GitHub runner. mwccarm and its licence are not there -- `src-tu-refs.yml` says
+so in its own header, and `pr-validate.yml` exists precisely because the compiler-and-ROM
+half of validation happens on the private build box behind the relay. This gate belongs
+where `tools/hooks/pre-push` already puts the compiler-dependent checks ("this box has
+the ROM + toolchain") and where the validator worker runs. It needs the compiler and
+`config/rombuild-versions.txt`; it does NOT need the extracted ROM, because it compiles
+and never compares bytes -- which is what makes it cheap enough to run on every push
+(~0.06s per TU, about three seconds for all 41).
+
+A MISSING COMPILER IS A FAILURE, NOT A SKIP
+-------------------------------------------
+`tools/test_build_pin.py` and `tools/test_tubuild.py` both gate their end-to-end cases on
+a `_toolchain()` predicate and `return` when it is false, so an unwired worktree runs them
+and reports green having compiled nothing. That is the same false-green shape this whole
+family of gates exists to close, arrived at from inside the test suite. So there is no
+skip here and no flag that turns one on: if the pinned compiler is not installed this
+exits non-zero and says which compiler and which path. A caller that cannot provide a
+compiler must not run this gate rather than run it and read the result as a pass.
+
+WHAT IT CHECKS
+--------------
+1. toolchain - the pinned mwccarm for each TU is installed, and so is its licence file.
+2. coverage  - the manifest and the src_tu/ tree agree on the work list. A source on
+               disk with no manifest entry has no knowable pin and is not compiled by
+               anything; a manifest entry with no source on disk is a stranded record.
+               Either way the count this gate reports would otherwise be quietly wrong.
+3. compile   - the TU compiles, with the version `tubuild` would pick (derived from each
+               member function's legacy pin) and the flags `build_pin.flags_for` gives,
+               which are `rombuild.CFLAGS` -- the build's own, not `match.DEFAULT_FLAGS`.
+4. worklist  - it found translation units at all. An empty check is not a pass.
+
+Usage:
+  python tools/check_src_tu_compiles.py                 # compile every src_tu TU
+  python tools/check_src_tu_compiles.py --json          # machine-readable, to stdout
+  python tools/check_src_tu_compiles.py --json out.json
+  python tools/check_src_tu_compiles.py --id ov045/PoleLift    # one TU, repeatable
+  python tools/check_src_tu_compiles.py --quiet         # only the failures
+
+Exit code 0 when every translation unit compiles, 1 otherwise -- including a missing
+compiler, an inconsistent pin, a work list that does not match the tree, and an empty
+work list.
+"""
+import argparse
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import time
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import build_pin as BP          # noqa: E402
+import match as M               # noqa: E402
+import tubuild as TU            # noqa: E402
+
+MANIFEST = REPO / "config" / "tu_manifest.json"
+SOURCE_SUFFIXES = (".c", ".cpp")
+
+
+def _fail(check, path, message):
+    return {"check": check, "file": path, "message": message}
+
+
+def _sources_on_disk(root):
+    return sorted(p.relative_to(REPO).as_posix()
+                  for p in root.rglob("*") if p.suffix in SOURCE_SUFFIXES)
+
+
+def compile_one(entry, version_override=None, include_dirs=()):
+    """(ok, info). Never raises; every refusal is a reason.
+
+    Deliberately calls `match.compile_c` -- the same function `tubuild._compile_tu` and
+    the ROM build's own verifier reach -- rather than re-deriving an mwccarm command
+    line here. A second spelling of the compile is a second thing to drift, and drift
+    between the gate's compile and the build's compile is the defect `build_pin.py` was
+    written to stop. `compile_c` narrates failures to stdout instead of returning them,
+    so its output is captured for the report.
+
+    `include_dirs` is `match.compile_c`'s own affordance -- "candidate-specific
+    includes come first so an external workbench can be verified against its own
+    headers". THE REAL RUN PASSES NONE, because `tubuild._compile_tu` passes none, so
+    a src_tu file is searched against include/ and nothing else. It is here for
+    fixtures. Note the asymmetry it makes visible: `check_src_tu.py` also accepts an
+    include resolved against the source's OWN directory and mwccarm does not, so a
+    src_tu file that used a sibling header would pass that gate and fail this one.
+    That is this gate being right; do not "fix" it by adding the source directory.
+    """
+    src = REPO / entry["source"]
+    if not src.is_file():
+        return False, {"reason": f"source not found: {entry['source']}"}
+
+    version, note = TU.resolve_tu_version(entry, version_override)
+    if version is None:
+        # Fails closed exactly like build_pin: an unknowable pin is not a default.
+        return False, {"reason": f"no compiler version for this TU: {note}"}
+
+    exe = M.MW / version / "mwccarm.exe"
+    if not exe.is_file():
+        return False, {"version": version, "toolchain": True,
+                       "reason": f"pinned compiler {version} is not installed ({exe})"}
+
+    flags = BP.flags_for(src)
+    buf = io.StringIO()
+    t0 = time.time()
+    with contextlib.redirect_stdout(buf):
+        obj = M.compile_c(src, version, flags, include_dirs)
+    elapsed = time.time() - t0
+    diag = buf.getvalue().strip()
+
+    if obj is None:
+        return False, {"version": version, "flags": flags, "seconds": round(elapsed, 3),
+                       "reason": diag or "compile failed with no diagnostic"}
+    return True, {"version": version, "flags": flags, "seconds": round(elapsed, 3),
+                  "objectBytes": len(obj), "note": note, "diagnostic": diag or None}
+
+
+def check(manifest_path=MANIFEST, root=None, only=(), version_override=None,
+          on_result=None, include_dirs=()):
+    root = pathlib.Path(root) if root else REPO / "src_tu"
+    failures, results = [], []
+
+    if not manifest_path.is_file():
+        return {"schemaVersion": 1, "ok": False,
+                "checked": {"units": 0, "compiled": 0},
+                "failed": 1,
+                "failures": [_fail("worklist", manifest_path.as_posix(),
+                                   "the TU manifest is missing -- there is no work list "
+                                   "to check, which is not a pass")],
+                "results": []}
+
+    # The licence is as load-bearing as the executable and its absence produces a
+    # compile error per file rather than one clear line, so say it once, up front.
+    if not M.LICENSE.is_file():
+        failures.append(_fail("toolchain", M.LICENSE.as_posix(),
+                              "mwccarm licence file is missing -- every compile below "
+                              "will fail for that reason and not for a source defect"))
+
+    entries = json.loads(manifest_path.read_text(encoding="utf-8"))["entries"]
+    if only:
+        want = set(only)
+        unknown = sorted(want - {e["id"] for e in entries})
+        for u in unknown:
+            failures.append(_fail("worklist", manifest_path.as_posix(),
+                                  f"--id {u} names no manifest entry"))
+        entries = [e for e in entries if e["id"] in want]
+    else:
+        # Coverage, both directions. Only meaningful over the whole manifest.
+        on_disk = set(_sources_on_disk(root))
+        declared = {e["source"] for e in entries}
+        for orphan in sorted(on_disk - declared):
+            failures.append(_fail("coverage", orphan,
+                                  "a translation unit on disk that the manifest does not "
+                                  "declare -- nothing knows its compiler pin, so nothing "
+                                  "compiles it and this gate cannot vouch for it"))
+        for stranded in sorted(declared - on_disk):
+            failures.append(_fail("coverage", stranded,
+                                  "the manifest declares this source and it is not on "
+                                  "disk -- a stranded record, and one fewer TU checked "
+                                  "than the count would suggest"))
+
+    if not entries:
+        failures.append(_fail("worklist", root.as_posix(),
+                              "no translation units to compile -- an empty check is not "
+                              "a pass; see the module docstring"))
+
+    compiled = 0
+    for entry in sorted(entries, key=lambda e: e["id"]):
+        ok, info = compile_one(entry, version_override, include_dirs)
+        row = {"id": entry["id"], "source": entry["source"], "ok": ok, **info}
+        results.append(row)
+        if ok:
+            compiled += 1
+        else:
+            failures.append(_fail("toolchain" if info.get("toolchain") else "compile",
+                                  entry["source"],
+                                  f"{entry['id']}: {info['reason']}"))
+        if on_result:
+            on_result(row)
+
+    return {
+        "schemaVersion": 1,
+        "ok": not failures,
+        "checked": {"units": len(entries), "compiled": compiled,
+                    "manifest": manifest_path.relative_to(REPO).as_posix(),
+                    "root": root.relative_to(REPO).as_posix()},
+        "failed": len(failures),
+        "failures": failures,
+        "results": results,
+    }
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default="src_tu",
+                    help="directory of translation units (default: src_tu)")
+    ap.add_argument("--manifest", default=None,
+                    help="TU manifest (default: config/tu_manifest.json)")
+    ap.add_argument("--id", action="append", default=[], metavar="TU_ID",
+                    help="compile only this TU; repeatable")
+    ap.add_argument("--version", default=None,
+                    help="force an mwccarm version instead of the pin (for measurement "
+                         "only -- this is NOT what the build would use)")
+    ap.add_argument("--json", nargs="?", const="-", metavar="PATH",
+                    help="write the JSON report to PATH, or stdout with no PATH")
+    ap.add_argument("--quiet", action="store_true", help="print only the failures")
+    args = ap.parse_args(argv)
+
+    root = REPO / args.root
+    if not root.is_dir():
+        print(f"check_src_tu_compiles: no such directory: {args.root}", file=sys.stderr)
+        return 1
+    manifest = pathlib.Path(args.manifest) if args.manifest else MANIFEST
+
+    def narrate(row):
+        if args.quiet and row["ok"]:
+            return
+        if row["ok"]:
+            print(f"  ok    {row['id']:38} {row['version']:9} "
+                  f"{row['objectBytes']:7d} bytes  {row['seconds']:.2f}s")
+        else:
+            print(f"  FAIL  {row['id']:38} {row.get('version', '-')}")
+
+    started = time.time()
+    report = check(manifest, root, tuple(args.id), args.version,
+                   on_result=None if args.json == "-" else narrate)
+
+    if args.json:
+        text = json.dumps(report, indent=2) + "\n"
+        if args.json == "-":
+            sys.stdout.write(text)
+        else:
+            # build/ is gitignored, so a fresh checkout has no such directory --
+            # writing the report must not be what fails the gate.
+            out = pathlib.Path(args.json)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(text)
+
+    c = report["checked"]
+    print(f"check_src_tu_compiles: {c['compiled']}/{c['units']} translation unit(s) "
+          f"compiled in {time.time() - started:.1f}s")
+    if report["ok"]:
+        print("check_src_tu_compiles: every translation unit compiles.")
+        return 0
+    for f in report["failures"]:
+        print(f"  {f['check']:9} {f['file']}: {f['message']}")
+    print(f"check_src_tu_compiles: {report['failed']} failure(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -80,6 +80,33 @@ if ! python tools/check_duplicate_sources.py; then
   exit 1
 fi
 
+# Does every merged translation unit still COMPILE? tools/check_src_tu.py (run in CI)
+# proves every include and mangled symbol resolves; it cannot see a type. #1583 retyped
+# three dActor_c virtuals int -> void, swept only src/, and stranded a src_tu TU --
+# and #1643's collision rename left ov029/SwitchActivatedPlank with a placeholder
+# `struct dBgW_Kc` that the real class then collided with. Neither showed up anywhere:
+# an unbuildable source file is an ABSENT one, so rombuild kept reporting 106/106 with
+# the file simply gone from coverage.
+#
+# It needs mwccarm but NOT the ROM, and it is about three seconds for all 41 TUs, so it
+# runs on every push rather than only main-targeted ones.
+#
+# The gate itself never returns 0 without a compiler -- that is deliberate, see its
+# docstring. Deciding what an unwired worktree should do is the HOOK's call, not the
+# gate's, so the compiler is tested here and its absence is printed as NOT CHECKED
+# rather than either refusing the push or being passed over in silence.
+if [ -f tools/mwccarm/2004/b56/mwccarm.exe ]; then
+  if ! python tools/check_src_tu_compiles.py --quiet; then
+    echo "pre-push: REFUSING to push (see above). Override with --no-verify if you are certain." >&2
+    exit 1
+  fi
+else
+  echo "pre-push: src_tu COMPILE GATE NOT CHECKED -- no tools/mwccarm/2004/b56/mwccarm.exe"
+  echo "          in this worktree. This is not a pass: type drift in src_tu/ is invisible"
+  echo "          to every other gate. Wire the worktree up and re-run"
+  echo "          'python tools/check_src_tu_compiles.py' before trusting this push."
+fi
+
 # Reference resolvability needs tools/eligible.py, which compiles ~11,100 files and
 # takes minutes -- far too slow for a hook. So this checks only when a report for
 # THIS commit already exists, and otherwise says nothing was checked rather than

--- a/tools/test_check_header_offsets.py
+++ b/tools/test_check_header_offsets.py
@@ -1,0 +1,338 @@
+"""Regression tests for tools/check_header_offsets.py's WORK-LIST RESOLUTION.
+
+The parser has been debugged into shape by a long series of "this reported a pass and
+checked nothing" fixes, all written up in the module's own comments. This file covers
+the layer above it: which files the gate decides to look at in the first place. That
+layer had two holes, and a gate that looks at the wrong (empty) set of files reports a
+pass exactly as convincingly as one that looks at the right set and finds nothing wrong.
+
+Every test here is a PLANTED REGRESSION: `_resolve_the_old_way` below is the pre-fix
+resolution, verbatim, and each case asserts that it says "pass" while the current code
+says "fail". A test that only exercised the new code would not prove a hole was closed.
+"""
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+REPO = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import check_header_offsets as C  # noqa: E402
+
+# A header the tool can actually parse: struct name == file stem, one commented field
+# per declaration. `u32` is in the built-in SZ table, so this needs nothing from the
+# real include/ tree.
+GOOD = """\
+struct Widget {
+\tu32 first;   /* 0x000 */
+\tu32 second;  /* 0x004 */
+\tu16 third;   /* 0x008 */
+};
+"""
+# `second` claims 0x008; two u32s put it at 0x004. This is the #1583 shape in
+# miniature -- a field whose comment and whose computed offset have come apart.
+BROKEN = """\
+struct Widget {
+\tu32 first;   /* 0x000 */
+\tu32 second;  /* 0x008 */
+\tu16 third;   /* 0x00c */
+};
+"""
+
+# Merge commits whose pull requests edited headers, and how many .h files each touched.
+# Confirmed against `git diff --name-only --diff-filter=AM <sha>^...<sha> -- include/`.
+REAL_HISTORY = {
+    "1659": ("258fa9042903b378660000c13c31c1fc77ae717c", 33),
+    "1665": ("558a1c26b1299f6e96e1b58a4c76e1bc682cf3a2", 15),
+    "1666": ("957e60fc40ab89e6a8d240b5e97c2bfa8061d51c", 58),
+    # #1667 is the src_tu gate: 31 files, none of them a header. The honest empty.
+    "1667": ("3dc6c4df43928eb799faa4d7abe16e74198dbcd4", 0),
+}
+
+
+def _resolve_the_old_way(base, repo):
+    """The resolution as it stood before this change. Returns (headers, exit_code).
+
+    Copied from the pre-fix `_resolve_paths`, which is what makes the assertions below
+    proofs rather than assertions about the new code's opinion of itself:
+
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
+             "--", "include/"], cwd=REPO, ...)
+        argv = [p for p in proc.stdout.split() if p.endswith((".h", ".hpp"))]
+        if not argv:
+            print("no include/ header added or modified")
+            sys.exit(0)                     # <-- both defects live on this line
+    """
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
+         "--", "include/"],
+        cwd=str(repo), capture_output=True, text=True)
+    if proc.returncode != 0:
+        return [], 1
+    heads = [p for p in proc.stdout.split() if p.endswith((".h", ".hpp"))]
+    return heads, (0 if not heads else None)
+
+
+class Repo:
+    """A throwaway git repository. Real git, so the resolution is exercised for real."""
+
+    def __enter__(self):
+        self.dir = pathlib.Path(tempfile.mkdtemp(prefix="check_header_offsets_"))
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.email", "gate@example.invalid")
+        self.git("config", "user.name", "gate")
+        self.git("config", "commit.gpgsign", "false")
+        (self.dir / "include").mkdir()
+        self.write("README", "base\n")
+        self.write("include/Widget.h", GOOD)
+        self.commit("base")
+        self.base = self.rev("HEAD")
+        return self
+
+    def __exit__(self, *exc):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def git(self, *args):
+        r = subprocess.run(["git", *args], cwd=str(self.dir),
+                           capture_output=True, text=True)
+        assert r.returncode == 0, f"git {' '.join(args)}: {r.stderr}"
+        return r.stdout
+
+    def rev(self, ref):
+        return self.git("rev-parse", ref).strip()
+
+    def write(self, rel, body):
+        p = self.dir / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+        return self
+
+    def commit(self, msg):
+        self.git("add", "-A")
+        self.git("commit", "-q", "-m", msg)
+        return self
+
+    def resolve(self, *argv):
+        return C._resolve_paths(list(argv), self.dir)
+
+    def run(self, *argv):
+        return C.main(list(argv), self.dir)
+
+    def old(self, base=None):
+        return _resolve_the_old_way(base or self.base, self.dir)
+
+
+# ------------------------------------------------------- defect 1: committed-only diff
+
+class UncommittedChangesTests(unittest.TestCase):
+    """`{base}...HEAD` is the commits. A header edited and not yet committed was not in
+    it, so a local pre-commit run reported a pass over work it had never opened."""
+
+    def test_an_uncommitted_broken_header_was_invisible_and_is_now_caught(self):
+        """The header is already in the BASE, so no commit in `base...HEAD` names
+        it and the old resolution had nothing to hand the walk. That is exactly the
+        pre-commit run this gate is for, and it reported a pass over an unread file."""
+        with Repo() as r:
+            r.write("tools/x.py", "x = 1\n").commit("unrelated work")
+            r.write("include/Widget.h", BROKEN)          # edited, NOT committed
+
+            old_heads, old_code = r.old()
+            self.assertEqual(old_heads, [], "precondition: the old resolution saw nothing")
+            self.assertEqual(old_code, 0, "precondition: and called that a pass")
+
+            paths, code = r.resolve("--changed", r.base)
+            self.assertEqual(paths, ["include/Widget.h"])
+            self.assertEqual(r.run("--changed", r.base), 1)
+
+    def test_a_staged_but_uncommitted_broken_header_is_caught(self):
+        with Repo() as r:
+            r.write("tools/x.py", "x = 1\n").commit("unrelated work")
+            r.write("include/Widget.h", BROKEN)
+            r.git("add", "include/Widget.h")             # staged, still not committed
+            self.assertEqual(r.old()[1], 0)
+            self.assertEqual(r.run("--changed", r.base), 1)
+
+    def test_a_brand_new_untracked_header_is_caught(self):
+        """Neither diff sees an untracked file, and a brand-new header is the one
+        whose offsets have never been checked by anything at all."""
+        with Repo() as r:
+            r.write("include/Fresh.h", BROKEN.replace("Widget", "Fresh"))
+            self.assertEqual(r.old()[1], 0)
+            paths, _ = r.resolve("--changed", r.base)
+            self.assertEqual(paths, ["include/Fresh.h"])
+            self.assertEqual(r.run("--changed", r.base), 1)
+
+    def test_the_old_code_did_see_a_dirty_header_its_own_branch_committed(self):
+        """Bounding the claim, so nobody widens it later: `base...HEAD` names that
+        path and the walk reads the file from DISK, so the dirty bytes were checked.
+        The hole is only for headers no commit in the range names -- which is every
+        header on a branch that has not committed yet, and every untracked one."""
+        with Repo() as r:
+            r.write("include/Other.h", GOOD.replace("Widget", "Other"))
+            r.commit("add another header")
+            r.write("include/Other.h", BROKEN.replace("Widget", "Other"))
+            self.assertEqual(r.old()[0], ["include/Other.h"])
+            self.assertEqual(r.run("--changed", r.base), 1)
+
+    def test_a_good_uncommitted_header_still_passes(self):
+        """Not weakening the gate: folding the working tree in must not invent failures."""
+        with Repo() as r:
+            r.write("include/Widget.h", GOOD + "\n")   # touched, still correct
+            self.assertEqual(r.run("--changed", r.base), 0)
+
+    def test_committed_only_reproduces_ci_but_names_what_it_is_ignoring(self):
+        with Repo() as r:
+            r.write("tools/x.py", "x = 1\n").commit("a non-header commit")
+            r.write("include/Widget.h", BROKEN)          # uncommitted
+            paths, code = r.resolve("--changed", r.base, "--committed-only")
+            self.assertIsNone(paths)
+            self.assertEqual(code, 0, "the commits genuinely contain no header")
+            # ...but the uncommitted one is reported, not silently dropped.
+            buckets, err = C.changed_paths(r.base, committed_only=True, repo=r.dir)
+            self.assertIsNone(err)
+            self.assertEqual(buckets["worktree"], ["include/Widget.h"])
+
+    def test_committed_only_outside_changed_is_refused(self):
+        with Repo() as r:
+            paths, code = r.resolve("--committed-only", "include/Widget.h")
+            self.assertIsNone(paths)
+            self.assertEqual(code, 1)
+
+
+# ------------------------------------------------------- defect 2: the empty work list
+
+class EmptyWorkListTests(unittest.TestCase):
+    """The docstring already argued "an empty check is not a pass"; the guard only
+    covered the zero-argv case, not the empty-diff case."""
+
+    def test_a_diff_that_names_nothing_at_all_is_not_a_pass(self):
+        """base == HEAD with a clean tree. On a pull request this cannot happen, so it
+        is a base ref that resolved to the wrong commit -- an unfetched origin/main, a
+        shallow clone with no merge base. The old code exited 0."""
+        with Repo() as r:
+            self.assertEqual(r.old()[1], 0, "precondition: the old code passed")
+            paths, code = r.resolve("--changed", r.base)
+            self.assertIsNone(paths)
+            self.assertEqual(code, 1)
+
+    def test_include_changed_but_the_extension_filter_ate_the_work_list(self):
+        """The .h/.hpp filter exists to skip include/'s non-headers. When it discards
+        EVERY changed include/ path it is no longer skipping noise, it is skipping the
+        job -- and the old code could not tell the two apart."""
+        with Repo() as r:
+            r.write("include/Widget.inc", "u32 first;\n").commit("a non-.h header")
+            self.assertEqual(r.old()[1], 0, "precondition: the old code passed")
+            paths, code = r.resolve("--changed", r.base)
+            self.assertIsNone(paths)
+            self.assertEqual(code, 1)
+
+    def test_a_change_that_genuinely_touches_no_header_passes_with_its_evidence(self):
+        """The one honest empty, and the reason "empty always fails" would be wrong:
+        most pull requests touch no header. What makes it not a hollow pass is that the
+        count of files the diff DID contain is computed and printed."""
+        with Repo() as r:
+            r.write("tools/x.py", "x = 1\n")
+            r.write("src/y.c", "int y;\n").commit("no headers")
+            buckets, err = C.changed_paths(r.base, repo=r.dir)
+            self.assertIsNone(err)
+            self.assertEqual(len(buckets["total"]), 2)
+            self.assertEqual(buckets["include"], [])
+            paths, code = r.resolve("--changed", r.base)
+            self.assertIsNone(paths)
+            self.assertEqual(code, 0)
+
+    def test_a_non_header_include_path_alongside_a_real_one_is_only_noise(self):
+        with Repo() as r:
+            r.write("include/Other.h", GOOD.replace("Widget", "Other"))
+            r.write("include/notes.txt", "prose\n").commit("both")
+            paths, code = r.resolve("--changed", r.base)
+            self.assertEqual(paths, ["include/Other.h"])
+            self.assertEqual(code, 0)
+
+    def test_headers_deleted_since_the_commit_do_not_shrink_to_a_pass(self):
+        with Repo() as r:
+            r.write("include/Other.h", GOOD.replace("Widget", "Other")).commit("add")
+            (r.dir / "include" / "Other.h").unlink()
+            paths, code = r.resolve("--changed", r.base)
+            self.assertIsNone(paths)
+            self.assertEqual(code, 1)
+
+    def test_no_arguments_is_still_refused(self):
+        paths, code = C._resolve_paths([])
+        self.assertIsNone(paths)
+        self.assertEqual(code, 1)
+
+    def test_an_unresolvable_base_is_an_error_not_a_pass(self):
+        with Repo() as r:
+            paths, code = r.resolve("--changed", "no/such/ref")
+            self.assertIsNone(paths)
+            self.assertEqual(code, 1)
+
+
+# --------------------------------------------------------- the gate itself still works
+
+class GateStillWorksTests(unittest.TestCase):
+    def test_a_broken_header_named_explicitly_fails(self):
+        with Repo() as r:
+            r.write("include/Widget.h", BROKEN)
+            self.assertEqual(r.run("include/Widget.h"), 1)
+
+    def test_a_good_header_named_explicitly_passes(self):
+        with Repo() as r:
+            r.write("include/Widget.h", GOOD)
+            self.assertEqual(r.run("include/Widget.h"), 0)
+
+    def test_a_real_tree_header_still_parses(self):
+        """Guards the repo-root resolution added here: a relative path from --changed
+        must be read against the repository, not the process cwd."""
+        self.assertEqual(C.main(["include/Amp.h"]), 0)
+
+    def test_the_cli_entry_point_still_returns_the_gates_verdict(self):
+        r = subprocess.run([sys.executable, str(TOOLS / "check_header_offsets.py")],
+                           capture_output=True, text=True, cwd=REPO)
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("not a pass", r.stdout + r.stderr)
+
+
+# ------------------------------------------------------------------------ real history
+
+class RealHistoryTests(unittest.TestCase):
+    """The fix must not have narrowed what the gate picks up. Aimed at merge commits
+    whose pull requests really did edit headers, rather than at a fixture."""
+
+    def _require(self, sha):
+        r = subprocess.run(["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+                           cwd=str(REPO), capture_output=True, text=True)
+        # Reported, never skipped: a self-skipping history test is indistinguishable
+        # from one that passes, which is the failure mode this whole file is about.
+        self.assertEqual(r.returncode, 0,
+                         f"{sha} is not in this clone -- run `git fetch --unshallow` "
+                         f"(a shallow clone cannot verify the resolution against history)")
+
+    def test_the_headers_each_pull_request_edited_still_come_back(self):
+        for pr, (sha, want) in sorted(REAL_HISTORY.items()):
+            with self.subTest(pr=pr):
+                self._require(sha)
+                buckets, err = C.changed_paths(f"{sha}^", committed_only=True,
+                                               repo=REPO, head=sha)
+                self.assertIsNone(err)
+                self.assertEqual(len(buckets["headers"]), want)
+                self.assertEqual(buckets["dropped"], [])
+                self.assertTrue(buckets["total"], "the diff itself must not be empty")
+
+    def test_the_pull_request_that_touched_no_header_is_the_honest_empty(self):
+        sha, _ = REAL_HISTORY["1667"]
+        self._require(sha)
+        buckets, err = C.changed_paths(f"{sha}^", committed_only=True, repo=REPO, head=sha)
+        self.assertIsNone(err)
+        self.assertEqual(buckets["include"], [])
+        self.assertEqual(len(buckets["total"]), 31)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_check_src_tu_compiles.py
+++ b/tools/test_check_src_tu_compiles.py
@@ -1,0 +1,237 @@
+"""Regression tests for tools/check_src_tu_compiles.py.
+
+Every case here plants the breakage and asserts the gate goes red. Two of them are the
+shapes this gate exists for and that `check_src_tu.py` provably cannot see:
+
+  * a header retypes a method the way #1583 retyped three `dActor_c` virtuals
+    `int` -> `void`. Every `#include` still resolves and every mangled symbol still
+    exists, so the reference gate passes; the compiler does not.
+  * the pinned compiler is not installed. `tools/test_build_pin.py` and
+    `tools/test_tubuild.py` both `return` here and report green having compiled
+    nothing. This asserts the opposite.
+
+NO TEST IN THIS FILE SKIPS ITSELF. `test_the_committed_tree_compiles` needs mwccarm and
+fails, loudly, if it is missing -- because a compile gate whose test passes without a
+compiler is the exact false green the gate is for. Nothing in .github/workflows runs
+pytest, so this only ever asks a box that has the toolchain.
+"""
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+REPO = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import build_pin as BP              # noqa: E402
+import check_src_tu_compiles as CC  # noqa: E402
+import match as M                   # noqa: E402
+import rombuild as RB               # noqa: E402
+
+# A header and a TU that agree. `void` both sides.
+HEADER_OK = """\
+#ifndef PROBE_H
+#define PROBE_H
+struct Probe {
+\tvoid Behavior();
+\tint mField;
+};
+#endif
+"""
+# The #1583 shape: the header now says `void`, the translation unit still says `int`.
+# Nothing is renamed, nothing moves, no include breaks -- only the type drifts.
+HEADER_RETYPED = HEADER_OK.replace("\tvoid Behavior();", "\tint Behavior();")
+UNIT = """\
+//cpp
+#include "Probe.h"
+void Probe::Behavior() { mField = 1; }
+"""
+
+
+class Scratch:
+    """A throwaway TU plus its own manifest, inside build/ so the paths the gate reports
+    are expressible as repo-relative -- the same reason test_check_src_tu.py does it."""
+
+    def __enter__(self):
+        (REPO / "build").mkdir(exist_ok=True)
+        self.dir = pathlib.Path(tempfile.mkdtemp(prefix="src_tu_compiles_",
+                                                 dir=REPO / "build"))
+        self.rel = self.dir.relative_to(REPO).as_posix()
+        return self
+
+    def __exit__(self, *exc):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def write(self, name, body):
+        (self.dir / name).write_text(body, encoding="utf-8")
+        return self
+
+    def manifest(self, *entries):
+        p = self.dir / "manifest.json"
+        p.write_text(json.dumps({"schema_version": 1, "entries": list(entries)}),
+                     encoding="utf-8")
+        return p
+
+    def entry(self, name="Probe.cpp", tu_id="probe/Probe"):
+        # No `functions`, so resolve_tu_version takes the build default -- which is the
+        # right pin for a fixture that corresponds to no ROM address.
+        return {"id": tu_id, "source": f"{self.rel}/{name}", "functions": []}
+
+    def check(self, *entries, **kw):
+        # The scratch header sits beside the scratch source, and mwccarm does not
+        # search a source's own directory -- see compile_one's note on why the real
+        # run must not either. A fixture says so explicitly instead.
+        kw.setdefault("include_dirs", [self.dir])
+        return CC.check(self.manifest(*entries), self.dir, **kw)
+
+
+def failures_of(report, kind):
+    return [f for f in report["failures"] if f["check"] == kind]
+
+
+class TypeDriftTests(unittest.TestCase):
+    """The gap #1667 named and left open."""
+
+    def test_a_tu_whose_header_agrees_with_it_compiles(self):
+        """Positive control. Without this the test below could be passing because the
+        fixture never compiled in the first place."""
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            report = s.check(s.entry())
+            self.assertTrue(report["ok"], report["failures"])
+            self.assertEqual(report["checked"]["compiled"], 1)
+
+    def test_a_header_that_retypes_a_method_makes_the_gate_red(self):
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_RETYPED).write("Probe.cpp", UNIT)
+            report = s.check(s.entry())
+            self.assertFalse(report["ok"])
+            self.assertEqual(len(failures_of(report, "compile")), 1)
+            self.assertEqual(report["checked"]["compiled"], 0)
+
+    def test_the_retyped_header_still_passes_the_reference_gate(self):
+        """The claim that this gate is not redundant, checked rather than asserted:
+        check_src_tu.py sees a resolvable include and no mangled reference at all, so it
+        reports the same tree clean. Only the compiler disagrees."""
+        import check_src_tu as CR
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_RETYPED).write("Probe.cpp", UNIT)
+            refs = CR.check(s.dir)
+            self.assertEqual(failures_of(refs, "includes"), [])
+            self.assertEqual(failures_of(refs, "symbols"), [])
+            self.assertTrue(CC.check(s.manifest(s.entry()), s.dir,
+                                     include_dirs=[s.dir])["failed"])
+
+
+class ToolchainTests(unittest.TestCase):
+    def test_a_missing_compiler_is_a_failure_not_a_skip(self):
+        """test_build_pin.py and test_tubuild.py return green here. This must not."""
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            saved = M.MW
+            try:
+                M.MW = REPO / "build" / "no-such-compiler-root"
+                report = s.check(s.entry())
+            finally:
+                M.MW = saved
+            self.assertFalse(report["ok"])
+            self.assertEqual(len(failures_of(report, "toolchain")), 1)
+            self.assertIn("not installed", failures_of(report, "toolchain")[0]["message"])
+
+    def test_a_missing_licence_is_reported_once_and_up_front(self):
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            saved = M.LICENSE
+            try:
+                M.LICENSE = REPO / "build" / "no-such-licence.dat"
+                report = s.check(s.entry())
+            finally:
+                M.LICENSE = saved
+            self.assertFalse(report["ok"])
+            self.assertEqual(len(failures_of(report, "toolchain")), 1)
+
+    def test_the_flags_are_the_builds_flags_not_the_sweeps(self):
+        """build_pin.py exists because a check compiled with different flags than the
+        link can bless a version the build then breaks on."""
+        src = REPO / "src_tu" / "actors" / "PoleLift.cpp"
+        flags = BP.flags_for(src)
+        self.assertEqual(flags, RB.CFLAGS.replace("-lang c99", "-lang c++"))
+        self.assertNotEqual(flags, M.DEFAULT_FLAGS)
+        self.assertIn("-Cpp_exceptions off", flags)
+
+
+class WorkListTests(unittest.TestCase):
+    """An empty check is not a pass, and neither is a check over the wrong list."""
+
+    def test_no_translation_units_fails(self):
+        with Scratch() as s:
+            report = s.check()
+            self.assertFalse(report["ok"])
+            self.assertTrue(failures_of(report, "worklist"))
+
+    def test_a_source_on_disk_the_manifest_does_not_declare_fails(self):
+        """Nothing knows its pin, so nothing compiles it -- and the gate's own count
+        would say "1/1 compiled" over a directory holding two."""
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            s.write("Stray.cpp", "//cpp\nint stray() { return 0; }\n")
+            report = s.check(s.entry())
+            self.assertFalse(report["ok"])
+            self.assertEqual(len(failures_of(report, "coverage")), 1)
+            self.assertIn("Stray.cpp", failures_of(report, "coverage")[0]["file"])
+
+    def test_a_manifest_entry_with_no_source_on_disk_fails(self):
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            report = s.check(s.entry(), s.entry("Gone.cpp", "probe/Gone"))
+            self.assertFalse(report["ok"])
+            self.assertTrue(failures_of(report, "coverage"))
+
+    def test_a_missing_manifest_fails(self):
+        report = CC.check(REPO / "build" / "no-such-manifest.json", REPO / "src_tu")
+        self.assertFalse(report["ok"])
+        self.assertTrue(failures_of(report, "worklist"))
+
+    def test_an_unknown_id_fails(self):
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            report = s.check(s.entry(), only=("probe/NoSuch",))
+            self.assertFalse(report["ok"])
+            self.assertTrue(failures_of(report, "worklist"))
+
+
+class TreeTests(unittest.TestCase):
+    def test_the_committed_tree_compiles(self):
+        """The baseline. If this is red, a src_tu TU has been stranded by a type change
+        -- fix the tree, not the test. It needs mwccarm and does not skip without it:
+        see the module docstring."""
+        report = CC.check()
+        self.assertTrue(report["ok"],
+                        [f["message"] for f in report["failures"]][:5])
+        self.assertEqual(report["checked"]["units"], report["checked"]["compiled"])
+        self.assertGreaterEqual(report["checked"]["units"], 41)
+
+    def test_the_cli_exits_zero_on_the_committed_tree(self):
+        r = subprocess.run([sys.executable, str(TOOLS / "check_src_tu_compiles.py"),
+                            "--quiet"], capture_output=True, text=True, cwd=REPO)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_the_cli_writes_a_json_report(self):
+        with Scratch() as s:
+            out = s.dir / "report.json"
+            r = subprocess.run([sys.executable, str(TOOLS / "check_src_tu_compiles.py"),
+                                "--id", "ov045/PoleLift", "--json", str(out)],
+                               capture_output=True, text=True, cwd=REPO)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            report = json.loads(out.read_text())
+            self.assertTrue(report["ok"])
+            self.assertEqual(report["checked"]["units"], 1)
+            self.assertEqual(report["results"][0]["version"], BP.DEFAULT_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two gate holes of the same shape as the one #1667 closed, plus the compile gate #1667 said it could not be.

## Part 1 — `check_header_offsets.py --changed` reported a pass on work it never opened

### Defect 1: the diff was the commits only

`tools/check_header_offsets.py` line **196** (as on `main`):

```python
["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
 "--", "include/"],
```

`{base}...HEAD` is the commits. A header edited and not yet committed is in no commit in that range, so the local pre-commit run this gate exists for printed *"no include/ header added or modified"* and exited 0 over a dirty tree. An untracked new header — the one whose offsets have never been checked by anything at all — was invisible the same way.

The hole is narrower than it first looks, and the tests pin the bound: a header the branch **also committed** and has since dirtied *was* caught, because the diff names the path and the walk reads the file from disk. What was invisible is any header no commit in the range names.

### Defect 2: an empty work list exited 0

Lines **203–206**:

```python
argv = [p for p in proc.stdout.split() if p.endswith((".h", ".hpp"))]
if not argv:
    print(f"check_header_offsets: no include/ header added or modified "
          f"against {base}")
    sys.exit(0)
```

The file's own docstring says *"Running it with no arguments is an error, not a pass"*, and `check_src_tu.py` cites this exact line as a counterexample to the doctrine it was written to uphold. The guard only ever covered the zero-argv case.

### The empty-work-list design decision

"Empty always fails" is wrong: the job runs on every pull request that touches `include/`, `config/header-offset-known-issues.txt`, the tool, or the workflow — and a pull request that changes only the last three genuinely has no header to check. **This one does.** A gate that lands red gets switched off.

So the honest distinction is computed and printed rather than assumed. `changed_paths()` returns three buckets — every added/modified file anywhere, the subset under `include/`, and the subset of those that is a `.h`/`.hpp` — and the empty case resolves into four different outcomes:

| what the diff actually contained | verdict | why |
| --- | --- | --- |
| files, none under `include/` | **pass**, printing the file count | The one honest empty. The count is the evidence the diff resolved to something; the old line printed no number at all, so a working gate and a broken one looked identical. |
| nothing, anywhere | **fail** | A pull request always changes a file. Zero means the base ref resolved to nothing — an unfetched `origin/main`, a shallow clone with no merge base, `HEAD == base`. The old code called this a pass, and it is the failure that makes every other guarantee in the file worthless. |
| `include/` changed, `.h`/`.hpp` filter discarded all of it | **fail**, listing the paths | The filter exists to skip `include/`'s non-headers. When it eats the whole work list it is not skipping noise, it is skipping the job. |
| headers named, all since deleted from disk | **fail** | Otherwise the list shrinks back to the empty pass this whole function refuses. |

Working-tree and untracked changes are folded in by default and **named in the log** when they contribute. `--committed-only` reproduces exactly what CI sees and prints a `WARNING` naming every uncommitted header it is therefore ignoring, so the skip can never be read as a pass.

### Planted-regression proofs

`tools/test_check_header_offsets.py` carries `_resolve_the_old_way()` — the pre-fix resolution verbatim — and every case asserts it says *pass* while the current code says *fail*. Transcript:

```
### 1. a header edited but not yet committed (the pre-commit run)
  OLD: no include/ header added or modified  -> exit 0   (PASS)
  NEW: MISMATCH include/Widget.h:3 second: comment 0x008, computed 0x004  -> exit 1

### 2. a brand-new header that has never been `git add`ed
  OLD: no include/ header added or modified  -> exit 0   (PASS)
  NEW: MISMATCH include/Fresh.h:3 second: comment 0x008, computed 0x004   -> exit 1

### 3. the diff resolves to nothing (unfetched base / shallow clone)
  OLD: no include/ header added or modified  -> exit 0   (PASS)
  NEW: "the diff against <sha> is EMPTY ... a base ref that resolved to nothing" -> exit 1

### 4. include/ changed, the .h filter discarded the whole work list
  OLD: no include/ header added or modified  -> exit 0   (PASS)
  NEW: "1 include/ path(s) changed and NONE is a .h/.hpp"                 -> exit 1

### 5. a change that genuinely touches no header (the honest empty)
  OLD: no include/ header added or modified  -> exit 0   (PASS)
  NEW: "1 file(s) added or modified vs <sha>, 0 of them under include/"   -> exit 0
```

20 tests, all against a real throwaway git repository so the resolution is exercised for real.

### Verified against real history — the gate was not narrowed

Aimed at merge commits whose pull requests really did edit headers, and asserted in `RealHistoryTests` (not just checked once by hand):

| PR | files in the diff | headers resolved | old `git diff … -- include/` |
| --- | --- | --- | --- |
| #1659 | 44 | **33** | 33 |
| #1665 | 21 | **15** | 15 |
| #1666 | 66 | **58** | 58 |
| #1667 | 31 | **0** — the honest empty | 0 |

Nothing dropped, nothing invented.

### Also fixed while in there

* `proc.stdout.split()` split on whitespace, so a quoted path containing a space was torn into two nonexistent ones — and a nonexistent path here reads as "no header changed". Now split on newlines.
* A named header that is not on disk was a bare `FileNotFoundError` traceback that never said which argument was wrong.
* The usage line said `include/Enemy.h include/Camera.h`. `include/Enemy.h` was deleted by #1574 and `include/ClsnResult.h` (named in a code comment) by #1643, so the documented invocation could not run.
* The 213-line driver loop is now inside `main(argv, repo=None)` behind an `if __name__ == "__main__"` guard, which is what lets the tests import the module and point it at a throwaway repository instead of only shelling out. The loop body is otherwise a mechanical re-indent.

`.github/workflows/header-offsets.yml` gains a `python tools/test_check_header_offsets.py` step (unittest, not pytest — pytest is not on that runner and the point of the step is that the *failure* branches work). It runs before the gate: the resolution tests are what say the step below looked at anything.

---

## Part 2 — a `src_tu` compile gate

`tools/check_src_tu.py` wrote down its own gap:

> Types, signatures and layout. A TU can pass this gate and still not compile, because a header can retype a field or change a virtual's return type without renaming anything.

That is the #1583 shape — three `dActor_c` virtuals retyped `int` → `void` with only `src/` swept — and it is invisible to every gate in the tree, because an unbuildable source file is not a *failing* file, it is an **absent** one: no object, therefore no mismatch, and `rombuild` keeps reporting 106/106 with the file simply gone from coverage.

`tools/check_src_tu_compiles.py` compiles all 41 merged translation units.

**It follows the repo's existing pattern rather than inventing one.** The version comes from `tubuild.resolve_tu_version` (derived per-function from `config/rombuild-versions.txt`, fails closed on an unknown or conflicting pin); the flags come from `build_pin.flags_for` — `rombuild.CFLAGS`, the build's own, **not** `match.DEFAULT_FLAGS`, which is a different string; and the compile itself goes through `match.compile_c`, the same function `tubuild._compile_tu` and the ROM build's verifier reach, rather than a second hand-rolled mwccarm command line. A second spelling of the compile is a second thing to drift, and that drift is the defect `build_pin.py` was written to stop.

### Adoption path

Not a GitHub runner — mwccarm is not there, which is why `src-tu-refs.yml` says "THIS CANNOT BE A COMPILE" and why `pr-validate.yml` relays to the private build box. Adoption is **`tools/hooks/pre-push`**, the repo's existing home for compiler-dependent checks ("this box has the ROM + toolchain"), wired in this PR. It needs the compiler but **not** the extracted ROM, because it compiles and never compares bytes — so it runs on every push rather than only main-targeted ones. Cost: **2.1s for all 41**.

The same tool drops straight into the build box's validation run, and `--json` gives it a report to upload.

### A missing compiler is a failure, not a skip

`tools/test_build_pin.py` and `tools/test_tubuild.py` both gate their end-to-end cases on a `_toolchain()` predicate and `return` when it is false, so an unwired worktree runs them and reports green having compiled nothing. **There is no skip here and no flag that turns one on**: a missing compiler, a missing licence, an unknown pin and a conflicting pin are all failures with the path named.

Deciding what an unwired worktree should do is the **hook's** call, not the gate's, so `pre-push` tests for the compiler itself and prints

```
pre-push: src_tu COMPILE GATE NOT CHECKED -- no tools/mwccarm/2004/b56/mwccarm.exe
          in this worktree. This is not a pass: type drift in src_tu/ is invisible
          to every other gate. ...
```

rather than either refusing every push or passing in silence — the same shape the hook already uses for `check_references.py`. Both branches were exercised.

### It also checks the work list

* A source on disk the manifest does not declare has no knowable pin, so nothing compiles it — and the "N/N compiled" line would be quietly wrong.
* A manifest entry with no source on disk is a stranded record, same effect.
* An empty work list fails.

### Proof it catches the #1583 shape

`tools/test_check_src_tu_compiles.py` plants a header that retypes a method — nothing renamed, every `#include` still resolving — and asserts **both** that this gate goes red **and that `check_src_tu.py` reports the same tree clean**, so the two gates are demonstrably not redundant rather than assumed not to be. There is a positive control (the same fixture with the types agreeing compiles), and cases for a missing compiler, a missing licence, both coverage directions, an empty list and a missing manifest. **No test in that file skips itself.** 14 tests.

The plant is done in a scratch directory, not by editing `include/`.

### Baseline: 40/41, not 41/41

**The premise that all 41 compile was wrong.** `src_tu/actors/SwitchActivatedPlank.cpp` has not compiled since #1643:

```
src_tu\actors\SwitchActivatedPlank.cpp:56: class 'dBgW_Kc' redefined
src_tu\actors\SwitchActivatedPlank.cpp:57: class 'dBgW_KcMbg' redefined
src_tu\actors\SwitchActivatedPlank.cpp:261: internal compiler error (report to <cw_bug@metrowerks.com>)
```

It carried `struct dBgW_Kc { int d; };` / `struct dBgW_KcMbg { int d; };` as placeholders, and #1643 gave both classes real definitions that reach the TU through `SwitchActivatedPlank.h` → `include/dBgW_Kc.h` / `include/dBgW_KcMbg.h`. `check_src_tu.py` passes it — every include resolves, every mangled symbol is in `symbols.txt` — and every byte gate passes it too, because it produces no object. The manifest has claimed `text-verified`, 9/9 MATCH, throughout.

Deleting the two lines is the whole fix, and it is its own commit so it can be reverted independently. `tubuild verify ov029/SwitchActivatedPlank` is back to **9/9 MATCH, objisolate clean, reloc-destinations clean → TEXT-VERIFIED**.

**Baseline after that commit: 41/41.**

### `check_src_tu.py`'s prose was wrong and is corrected here

It named `src_tu/actors/Actor.cpp` and `src_tu/actors/CastleWater.cpp` as being in the not-compiling state "today". Both compile. `git log 3dc6c4df4..origin/main -- include/ src_tu/actors/Actor.cpp src_tu/actors/CastleWater.cpp` is **empty**, so nothing has changed since #1667 landed and the claim was wrong when it was written — while the one TU that really was broken went unnamed. Nothing had run a compiler over `src_tu` to find out which was which, which is the argument for this gate in one sentence.

---

## Gates

| command | exit | note |
| --- | --- | --- |
| `pyflakes tools/` | 1 | 28 warnings, **all pre-existing** and none in any file this PR adds or edits (the four new/edited Python files are clean, and so are their `origin/main` versions). |
| `pytest tools/ -q` | — | **2 failed, 510 passed, 3 skipped**. Same 2 failures as `origin/main` (`test_bytegate::test_no_row_is_stale`, `test_srcpath::test_enrolment_agrees_with_the_filename_convention`), where the baseline was 2 failed / 476 passed. The 34 new tests all pass. **There is no `test_linkcheck_refuses` in the tree** — `grep -rn linkcheck_refuses tools/` finds nothing, so the "three pre-existing failures" figure was two. |
| `python tools/check_src_tu.py` | 0 | 41 TUs, 468 includes, 876 mangled references, 31,782 ROM symbols |
| `python tools/check_src_tu_compiles.py` | 0 | **41/41 in 2.1s** |
| `python tools/check_header_offsets.py --changed origin/main` | 0 | `9 file(s) added or modified vs origin/main, 0 of them under include/` — this PR is itself the honest-empty case |
| `python tools/check_header_offsets.py` (bare) | 1 | refuses, as before |
| `python tools/test_check_header_offsets.py` | 0 | 20 tests |
| `python tools/test_check_src_tu_compiles.py` | 0 | 14 tests |
| `python tools/test_check_src_tu.py` | 0 | 16 tests, unchanged |

No `include/` file is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lwt9gZukUH4vb6BHwtuRRb
