### PR TITLE
The 181-site pad-split bucket was 180 header-reader defects and one pad split

### DIFF
--- a/include/dScDSMT_c.h
+++ b/include/dScDSMT_c.h
@@ -1,6 +1,7 @@
 #ifndef DSCDSMT_C_H
 #define DSCDSMT_C_H
 #include "dScene_c.h"
+#include "dFdDummy_c.h"
 
 /* One of dScene_c's ten direct children (see the census in dScene_c.h) --
  * the DS Multi-Play scene, per its own coinage (DSMT = "DS MulTi"). It had
@@ -32,18 +33,26 @@
  * with func_02017254(t + 0x54) before calling fBase_c's D2.
  *
  * That range (0x50..0x64, the entire 0x14 bytes dScDSMT_c adds over
- * dScene_c's own 0x50) lines up with the nested RTTI class the ROM's type
+ * dScene_c's own 0x50) opens with the nested RTTI class the ROM's type
  * graph records under this class, dScDSMT_c::graphCallback_c (base
  * dGraph_c::callback_c -- config/arm9/overlays/ov007/symbols.txt has
  * _ZTIN9dScDSMT_c15graphCallback_cE / _ZTSN9dScDSMT_c15graphCallback_cE
  * right next to dScDSMT_c's own RTTI). Two of its slots are independently
  * resolvable (GraphCallback0/2 at slots 0/2 of dGraph_c::callback_c's own
  * table) but recovering graphCallback_c's own internal layout is a
- * separate, later pass -- this header only needs to hold the byte range it
- * occupies, which it does as opaque storage below. (dScDSMT_c::Behavior
- * calls dScene_c::SetFaders with an argument built from this same range,
- * which is consistent with a Fader-shaped member living here without
- * pinning its exact sub-offset.)
+ * separate, later pass, so it stays opaque storage below.
+ *
+ * IT IS NOT THE WHOLE RANGE, though this header used to say it was. The
+ * constructor writes graphCallback_c's base-then-derived vptr pair at 0x50
+ * and NOTHING ELSE below 0x54, and the 0x10 bytes from 0x54 are a
+ * dFdDummy_c: `_ZN9dScDSMT_cD1Ev` calls `_ZN10dFdDummy_cD1Ev` at +0x54,
+ * an arm_call relocation the ROM build checks (arm9 0x02017254; both D1 and
+ * D0 carry the call). tools/dtor_members.py recovers it; D1 and not D2, so
+ * it is a member and not an inlined base. include/dFdDummy_c.h reached the
+ * same placement from the other side -- its own construction note already
+ * said "an embedded member of dScDSMT_c (ov007) at offset 0x54" -- and
+ * dScDSMT_c::Behavior's `SetFaders(c + 0x54)` takes its address. 0x54 +
+ * 0x10 == 0x64 closes the class exactly.
  *
  * VTABLE ORDER follows dScene_c's; dScDSMT_c adds no new virtual. The
  * destructor pair is at slots 16/17 (the fBase_c/dScene_c convention),
@@ -51,10 +60,18 @@
  * _ZN8dScene_cD1Ev / _ZN8dScene_cD0Ev.
  */
 struct dScDSMT_c : dScene_c {
-    u8  unk_050[0x14]; /* 0x050 -- opaque; holds the graphCallback_c
-                                    member constructed by func_02017278 and
-                                    torn down by func_02017254 -- see the
-                                    derivation note above */
+    u8  unk_050[0x4];  /* 0x050 -- opaque; the graphCallback_c sub-object,
+                                    whose own layout is a later pass. The
+                                    constructor writes a base-then-derived
+                                    vptr pair here and touches nothing else
+                                    below 0x54 -- see the note above */
+    dFdDummy_c fader;  /* 0x054 -- member. The cartridge's own ~dScDSMT_c
+                                    calls _ZN10dFdDummy_cD1Ev at +0x054
+                                    (D0/D1), a relocation the ROM build
+                                    checks; recovered by
+                                    tools/dtor_members.py. D1 and not D2, so
+                                    it is this type and not an inlined base.
+                                    Behavior passes &fader to SetFaders. */
 
     /* Declared first -- key function; see the family convention discussed
        in dScene_c.h. Never defined as a real method in any TU: both D1 and

--- a/tools/dtor_members.py
+++ b/tools/dtor_members.py
@@ -44,6 +44,36 @@ entry; the lattice is (this + k), (sp + k), (imm k) or unknown, with stack slots
 so a spilled `this` survives and the literal pool read so an offset with no ARM
 immediate encoding is still recovered.  Every one of the 2,358 sites yields an offset.
 
+What the header side has to get right
+-------------------------------------
+The cartridge side of this file was right from the start; the HEADER side is what
+lied.  The first census bucketed 181 pairs `NO FIELD AT OFFSET` -- read as "181 pad
+splits waiting to be written" -- and 180 of them were this reader's own defects:
+
+  144  the member is declared in a BASE.  mwccarm inlines a base destructor into the
+       derived one, so `~ArmedRotatingPlatform` destroys dBgActor_c's `Model` at +0xd4
+       itself, and reading only the derived class's own field list called that a hole.
+       `declared_at` walks the chain; those now bucket `INHERITED` and are no work.
+   26  a NAMED NESTED definition swallowed the rest of the class.  The reader closed a
+       definition on a `}` in column zero and a nested `};` is indented, so the
+       `struct State { ... };` these six open before their first real field took `cur`
+       and never gave it back: Bullet, FlyGuy, HootTheOwl, Player, Snufit and Swoop
+       each read as having ZERO declared fields.
+    6  the offset comment carried prose AND the field is a `u8` ARRAY marker.  Now
+       visible, now `DECIDABLE` -- and still held: `apply` refuses them because
+       retyping `u8 mModel1[0x50]` rewrites every consumer that spells it as an array,
+       and their owners' recovered C++ destructors call the member's D1 explicitly in
+       an order Itanium auto-destruction cannot reproduce (their headers say so).
+    4  the offset comment carried prose.  `Model mModel; /* 0x501c -- destroyed last */`
+       did not match a reader that demanded `*/` right after the number.  Now it stops
+       at the number, which is what `check_header_offsets.DECL` -- the gate this file
+       must agree with -- always did.
+    1  a real pad split: dScDSMT_c's dFdDummy_c at +0x54, inside `u8 unk_050[0x14]`.
+
+`test_dtor_members.py` pins all of them.  The lesson generalises: a bucket named for what
+the HEADERS say is only as good as the reader, and a census that is not cross-checked
+against the gate's own parser will invent work.
+
 Five things this file refuses to do
 -----------------------------------
 join on names     An earlier survey in this tree reported "127 classes with no header";
@@ -119,9 +149,17 @@ SIZE_ASSERT = re.compile(r"(\w+)_size_must_be_(0x[0-9a-fA-F]+)")
 # `u8 mFoo;   /* 0x124 */`  -- the original generator's "an object starts here" marker.
 MARKER = re.compile(r"^(\s*)u8(\s+)(\w+)\s*;\s*/\*\s*(0x[0-9a-fA-F]+)\s*\*/\s*$")
 PAD = re.compile(r"^(\s*)u8\s+(pad_[0-9a-fA-F]+)\s*\[\s*(0x[0-9a-fA-F]+|\d+)\s*\]\s*;\s*$")
+# `dCcAc_c mdCcAc_c;   /* 0x110 */`, and also
+# `Model mModel;        /* 0x501c -- 0x50, destroyed last, see banner */`.
+# The offset comment is NOT required to end right after the offset.  It used to be,
+# and every field whose comment carried a word of prose after the number was invisible
+# -- which is most of the hand-written ones.  `check_header_offsets.DECL`, the gate
+# this file has to agree with, has always stopped at the offset; now so does this.
 ANY_FIELD = re.compile(r"^\s*([A-Za-z_]\w*)\s+(\w+)\s*(\[[^\]]*\])?\s*;\s*/\*\s*"
-                       r"(0x[0-9a-fA-F]+)\s*\*/")
+                       r"(0x[0-9a-fA-F]+)")
 OPEN_DEF = re.compile(r"^[ \t]*(?:class|struct)[ \t]+(\w+)\b")
+BASE_CLAUSE = re.compile(r"^[ \t]*(?:class|struct)[ \t]+\w+[ \t]*:([^{;]+)")
+BASE_NOISE = re.compile(r"\b(?:public|protected|private|virtual)\b")
 SKIPPABLE = re.compile(r"^\s*($|/\*|\*|//)")
 
 # An offset above this is a literal-pool word that is really an ADDRESS folded into
@@ -563,7 +601,7 @@ def harvest(root, ext):
 # --------------------------------------------------------------------------
 
 def header_index(root):
-    """class -> {"header": path, "assert": size|None, "fields": {offset: [(type, name)]}}.
+    """class -> {"header", "assert", "fields": {offset: [(type, name)]}, "bases": [...]}.
 
     A header in this tree routinely defines the SAME class twice -- a real C++ layout
     under `#ifdef __cplusplus` and a flat `u8`-array stand-in for C translation units
@@ -572,38 +610,89 @@ def header_index(root):
     made 15 already-typed members read as untyped work, purely on which block came
     last in the file, so every block's declaration is kept and a member counts as
     typed when ANY of them types it.
+
+    Base classes are recorded too.  A member declared in a BASE is not missing from
+    the derived class -- mwccarm inlines the base destructor into the derived one, so
+    the cartridge shows `~Bullet` destroying dEnemyBase_c's members at their own
+    offsets, and reading only the derived class's own field list called every one of
+    them an untyped hole.  144 of the 181 findings in the first census were that.
     """
     out = {}
+
+    def entry(name, h):
+        return out.setdefault(name, {"header": h, "assert": None, "fields": {},
+                                     "bases": []})
+
     for h in sorted((root / "include").rglob("*.h")):
         txt = h.read_text(errors="replace")
         for m in O.DEFINITION.finditer(txt):
-            out.setdefault(m.group(1), {"header": h, "assert": None, "fields": {}})
+            entry(m.group(1), h)
         for m in SIZE_ASSERT.finditer(txt):
-            e = out.setdefault(m.group(1), {"header": h, "assert": None, "fields": {}})
+            e = entry(m.group(1), h)
             if e["assert"] is None:
                 e["assert"] = int(m.group(2), 16)
                 e["header"] = h
     # fields, per definition block, so a header holding two structs is not merged.
-    # A definition ends at a `}` in column zero, which is how every header in this
-    # tree is written; a nested block is indented and so cannot close the outer one.
+    #
+    # Brace depth, not "a `}` in column zero".  A NESTED definition -- the
+    # `struct State { ... };` five enemy headers open before their first real field --
+    # matched OPEN_DEF just as well as the outer one and took `cur` with it, and its
+    # own `};` is indented so nothing ever gave `cur` back.  Every field below the
+    # nested block was then dropped: Bullet, FlyGuy, HootTheOwl, Snufit and Swoop each
+    # read as having ZERO declared fields, and all 20 of their already-typed members
+    # were reported as work.  An ANONYMOUS `union {` is not a definition and its
+    # members are the enclosing class's own, so only a NAMED nested one suppresses.
     for h in sorted((root / "include").rglob("*.h")):
-        cur = None
+        cur = cur_depth = nested_from = None
+        depth = 0
         for line in h.read_text(errors="replace").splitlines():
-            if line.startswith("}"):
-                cur = None
-                continue
             m = OPEN_DEF.match(line)
-            if m and not line.rstrip().endswith(";"):
-                cur = m.group(1)
-                continue
-            if cur and out.get(cur, {}).get("header") == h:
+            is_def = bool(m) and not line.rstrip().endswith(";")
+            if cur is None:
+                if is_def:
+                    cur, cur_depth = m.group(1), depth
+                    b = BASE_CLAUSE.match(line)
+                    if b and out.get(cur, {}).get("header") == h:
+                        for x in BASE_NOISE.sub(" ", b.group(1)).split(","):
+                            x = x.strip()
+                            if re.fullmatch(r"\w+", x) and x not in out[cur]["bases"]:
+                                out[cur]["bases"].append(x)
+            elif is_def:
+                if nested_from is None:
+                    nested_from = depth
+            elif nested_from is None and out.get(cur, {}).get("header") == h:
                 f = ANY_FIELD.match(line)
                 if f:
                     at = out[cur]["fields"].setdefault(int(f.group(4), 16), [])
                     d = (f.group(1), f.group(2) + (f.group(3) or ""))
                     if d not in at:
                         at.append(d)
+            depth += line.count("{") - line.count("}")
+            if nested_from is not None and depth <= nested_from:
+                nested_from = None
+            if cur is not None and depth <= cur_depth:
+                cur = cur_depth = None
     return out
+
+
+def declared_at(hdr, cls, off):
+    """(own declarations, inherited declarations) at `off` for `cls`.
+
+    Walks the base chain header_index recorded.  Cycle-guarded: a header pair that
+    names each other as bases would otherwise recurse forever.
+    """
+    own = list(hdr.get(cls, {}).get("fields", {}).get(off, ()))
+    inh, seen, stack = [], {cls}, list(hdr.get(cls, {}).get("bases", ()))
+    while stack:
+        b = stack.pop(0)
+        if b in seen or b not in hdr:
+            continue
+        seen.add(b)
+        for d in hdr[b]["fields"].get(off, ()):
+            if d not in inh:
+                inh.append(d)
+        stack += hdr[b]["bases"]
+    return own, inh
 
 
 INCLUDE = re.compile(r'^[ \t]*#[ \t]*include[ \t]+"([^"]+)"', re.M)
@@ -726,14 +815,24 @@ def gap(root, doc, mods, stats):
             buckets["NO OWNER HEADER"].append(rec)
             continue
         rec["header_path"] = str(hdr[own]["header"].relative_to(root)).replace("\\", "/")
-        cur = hdr[own]["fields"].get(off)
+        cur, inh = declared_at(hdr, own, off)
+        cur = cur or None
         rec["declared"] = None if cur is None else "; ".join("%s %s" % d for d in cur)
+        rec["inherited"] = "; ".join("%s %s" % d for d in inh) or None
         if cur and any(t == mem for t, _ in cur):
             buckets["ALREADY TYPED"].append(rec)
+        elif not cur and inh and any(t == mem for t, _ in inh):
+            # the base owns it; the derived destructor destroys it because mwccarm
+            # inlined the base destructor, not because the class repeats the member.
+            buckets["INHERITED"].append(rec)
         elif mem is None or mem not in sizes:
             buckets["NO ASSERT"].append(rec)
         elif cur and any(t != "u8" for t, _ in cur):
             buckets["DECLARED OTHERWISE"].append(rec)
+        elif not cur and inh:
+            # a base declares SOMETHING ELSE here.  Either the base is wrong or the
+            # derived class is; the ROM says a `mem` starts at this offset.
+            buckets["INHERITED OTHERWISE"].append(rec)
         elif cur is None:
             buckets["NO FIELD AT OFFSET"].append(rec)
         elif hdr[own]["header"] in from_c and mem not in in_c:
@@ -744,8 +843,9 @@ def gap(root, doc, mods, stats):
     return buckets, hdr, aliases, sizes
 
 
-BUCKETS = ("DECIDABLE", "ALREADY TYPED", "NO ASSERT", "DECLARED OTHERWISE",
-           "NO FIELD AT OFFSET", "MEMBER TYPE IS C++ ONLY", "NO OWNER HEADER",
+BUCKETS = ("DECIDABLE", "ALREADY TYPED", "INHERITED", "NO ASSERT",
+           "DECLARED OTHERWISE", "INHERITED OTHERWISE", "NO FIELD AT OFFSET",
+           "MEMBER TYPE IS C++ ONLY", "NO OWNER HEADER",
            "BASE-AT-0", "SECONDARY-BASE", "AMBIGUOUS VARIANT")
 
 
@@ -884,7 +984,21 @@ def apply(root, picked, sizes, write=False):
             hits = [n for n, line in enumerate(lines)
                     if MARKER.match(line) and int(MARKER.match(line).group(4), 16) == off]
             if not hits:
-                refused.append((rec, "no bare u8 marker at that offset"))
+                # Diagnose, don't just decline.  Since header_index learned to read an
+                # offset comment that carries prose, six findings arrive here declared
+                # as `u8 mModel1[0x50]; /* 0x4f38 -- Model, raw bytes */`.  There IS a
+                # marker; it is an ARRAY, and "no marker" sent the last reader looking
+                # in the wrong place.
+                arr = [line.strip() for line in lines
+                       if ANY_FIELD.match(line)
+                       and int(ANY_FIELD.match(line).group(4), 16) == off
+                       and ANY_FIELD.match(line).group(1) == "u8"
+                       and ANY_FIELD.match(line).group(3)]
+                refused.append((rec, ("declared as a u8 ARRAY (%s): retyping it also "
+                                      "rewrites every consumer that spells it as an "
+                                      "array, so it is not a header-only edit"
+                                      % arr[0]) if arr else
+                                "no u8 marker at that offset"))
                 continue
             need = sizes[rec["member"]]
             ok = []
@@ -1007,13 +1121,13 @@ def main(argv=None):
         print("\n== pairs vs the headers ==")
         for b in BUCKETS:
             print("  %-20s %d" % (b, len(buckets[b])))
-        for b in ("DECIDABLE", "NO ASSERT", "DECLARED OTHERWISE", "NO FIELD AT OFFSET",
-                  "NO OWNER HEADER"):
+        for b in ("DECIDABLE", "NO ASSERT", "DECLARED OTHERWISE", "INHERITED OTHERWISE",
+                  "NO FIELD AT OFFSET", "NO OWNER HEADER"):
             print("\n-- %s (%d) --" % (b, len(buckets[b])))
             for r in sorted(buckets[b], key=lambda r: (r["owner"], r["offset"])):
                 print("  %-34s @%s -> %-22s %s"
                       % ((r.get("owner_header") or r["owner"]), r["offset"], r["member"],
-                         r.get("declared") or ""))
+                         r.get("declared") or r.get("inherited") or ""))
 
     if a.adjacency:
         res, detail = adjacency(doc, hdr, sizes, _al)

--- a/tools/test_dtor_members.py
+++ b/tools/test_dtor_members.py
@@ -210,6 +210,97 @@ def test_both_definitions_of_a_dual_header_are_read(tmp_path):
     assert idx["Wiggler"]["assert"] == 0x8E8
 
 
+def test_an_offset_comment_may_carry_prose_after_the_number(tmp_path):
+    """`/* 0x501c -- 0x50, destroyed last */` is the same evidence as `/* 0x501c */`.
+
+    The field reader demanded `*/` immediately after the offset, so every field whose
+    comment said anything at all was invisible -- which is most hand-written ones.
+    Four already-typed members read as missing on that alone (dScMgJump_c's `Model`,
+    dScMgSnowball_c's, dScMB_c's `FaderColor`, ModelAnim2's `Animation`), and six more
+    `u8` array markers were hidden with them.  `check_header_offsets.DECL`, the gate
+    this file has to agree with, has always stopped at the number; now so does this.
+    """
+    idx = _index(tmp_path, "dScMgJump_c.h", """\
+        struct dScMgJump_c : dScMgD3DBase_c {
+            s16   unk_5014;        /* 0x5014 */
+            Model mModel;          /* 0x501c -- 0x50, destroyed last, see banner */
+        };
+        typedef char dScMgJump_c_size_must_be_0x5834[sizeof(dScMgJump_c) == 0x5834 ? 1 : -1];
+        """)
+    assert idx["dScMgJump_c"]["fields"][0x5014] == [("s16", "unk_5014")]
+    assert idx["dScMgJump_c"]["fields"][0x501C] == [("Model", "mModel")]
+
+
+def test_a_nested_struct_does_not_swallow_the_fields_below_it(tmp_path):
+    """`struct State { ... };` opened before the first real field took the class with it.
+
+    The reader closed a definition on a `}` in column zero, and a nested block's `};`
+    is indented -- so it entered `State` and never came back out.  Bullet, FlyGuy,
+    HootTheOwl, Player, Snufit and Swoop each read as having ZERO declared fields, and
+    all 26 of their already-typed members were reported as outstanding work.
+    """
+    idx = _index(tmp_path, "Bullet.h", """\
+        struct Bullet : dEnemyBase_c {
+            struct State {
+                u8  pad_00[0x8];
+                void (Bullet::*mMain)();      /* 0x08 */
+            };
+
+            dCcAc_c    mdCcAc_c;        /* 0x110 */
+            dBgCh_Actr mWithMeshClsn;   /* 0x144 */
+            Model      mModel;          /* 0x300 */
+        };
+        typedef char Bullet_size_must_be_0x35c[sizeof(Bullet) == 0x35c ? 1 : -1];
+        """)
+    assert idx["Bullet"]["fields"][0x110] == [("dCcAc_c", "mdCcAc_c")]
+    assert idx["Bullet"]["fields"][0x300] == [("Model", "mModel")]
+    # the nested type's own 0x08 is not one of Bullet's offsets
+    assert 0x08 not in idx["Bullet"]["fields"]
+    assert idx["Bullet"]["bases"] == ["dEnemyBase_c"]
+
+
+def test_a_member_the_base_declares_is_inherited_not_missing(tmp_path):
+    """mwccarm INLINES a base destructor into the derived one.
+
+    So the cartridge shows `~ArmedRotatingPlatform` destroying the `Model` at +0xd4 and
+    the `dBgW_KcMbg` at +0x124 -- both of them dBgActor_c's own members, declared in
+    dBgActor_c's header.  Reading only the derived class's own field list called every
+    one of those an untyped hole; 144 of the 181 findings in the first census were
+    exactly this, across the dBgActor_c and dEnemyBase_c families.
+    """
+    idx = _index(tmp_path, "family.h", """\
+        struct dBgActor_c : dActor_c {
+            Model      mModel;          /* 0x0d4 */
+            dBgW_KcMbg mMeshCollider;   /* 0x124 */
+        };
+        typedef char dBgActor_c_size_must_be_0x320[sizeof(dBgActor_c) == 0x320 ? 1 : -1];
+        struct ArmedRotatingPlatform : dBgActor_c {
+            s16 mAngVelY;               /* 0x31e */
+        };
+        typedef char ArmedRotatingPlatform_size_must_be_0x320[1];
+        """)
+    own, inh = D.declared_at(idx, "ArmedRotatingPlatform", 0x0D4)
+    assert own == [] and inh == [("Model", "mModel")]
+    # and the class's own field is still its own, not the base's
+    own, inh = D.declared_at(idx, "ArmedRotatingPlatform", 0x31E)
+    assert own == [("s16", "mAngVelY")] and inh == []
+
+
+def test_the_base_walk_survives_a_cycle(tmp_path):
+    """Two headers naming each other as bases must not recurse forever."""
+    idx = _index(tmp_path, "cycle.h", """\
+        struct A : B {
+            s32 unk_004;   /* 0x004 */
+        };
+        typedef char A_size_must_be_0x8[1];
+        struct B : A {
+            s32 unk_000;   /* 0x000 */
+        };
+        typedef char B_size_must_be_0x8[1];
+        """)
+    assert D.declared_at(idx, "A", 0x000) == ([], [("s32", "unk_000")])
+
+
 def test_only_an_unconditional_include_counts_as_visible():
     """`#include "Model.h"` inside the `#ifdef __cplusplus` branch is textually above
     the flat C definition and invisible to it.  Three headers were typed against an


### PR DESCRIPTION
`dtor_members.py --gap` bucketed **181** ROM-proven `(owner, offset, member)` triples as
`NO FIELD AT OFFSET`, and the standing read of that bucket was "181 pads waiting to be
split". It is not. The cartridge side of that tool was right; its **header reader** was
wrong, and **180 of the 181 were its own defects**. One was a real pad split, and it is
applied here.

Every number below that came from a parse says so. The relocations themselves are ROM.

## What the 181 actually were

| n | what | disposition |
|---:|---|---|
| **144** | **no inheritance walk.** mwccarm inlines a base destructor into the derived one, so the cartridge shows `~ArmedRotatingPlatform` destroying **dBgActor_c's own** `Model` at `+0xd4`. Reading only the derived class's own field list called that an untyped hole. | new bucket `INHERITED`. No work. All 144 resolve to a base that declares the member with **exactly** the ROM's type: dBgActor_c x124 (62 classes x 2), daOts_c x12, daDsnBase_c x4, PathLift x4. |
| **26** | **a named nested definition swallowed the class.** The reader closed a definition on a `}` in column zero, and a nested `};` is indented -- so the `struct State { ... };` six headers open *before* their first real field took `cur` and never gave it back. `Bullet`, `FlyGuy`, `HootTheOwl`, `Player`, `Snufit`, `Swoop` each read as having **zero** declared fields. | already typed. Now visible. |
| **6** | **offset comment carried prose, and the field is a `u8` ARRAY marker** (`u8 mModel1[0x50]; /* 0x4f38 -- Model, raw bytes */`). | now `DECIDABLE`, **still held** -- see below. |
| **4** | **offset comment carried prose.** `Model mModel; /* 0x501c -- destroyed last */` did not match a reader that demanded `*/` right after the number, which is most hand-written fields. `check_header_offsets.DECL`, the gate this file has to agree with, has always stopped at the number. | already typed (`ModelAnim2`, `dScMB_c`, `dScMgJump_c`, `dScMgSnowball_c`). Now visible. |
| **1** | **a real pad split.** | **applied.** |

Attribution is per-site, computed by re-running the field pass against `origin/main`'s
`include/` under each combination of the two reader behaviours -- not estimated.

## Applied: 1 of 181

`include/dScDSMT_c.h` -- `u8 unk_050[0x14]` splits into the 4-byte `graphCallback_c`
sub-object and `dFdDummy_c fader; /* 0x054 */`.

- **ROM evidence:** both `_ZN9dScDSMT_cD1Ev` and `_ZN9dScDSMT_cD0Ev` call
  `_ZN10dFdDummy_cD1Ev` (arm9 `0x02017254`) at `+0x54` -- an `arm_call` relocation the
  ROM build checks. D1 and not D2, so it is a member and not an inlined base.
- **Independent agreement:** `include/dFdDummy_c.h`'s own construction note already said
  "an embedded member of `dScDSMT_c` (ov007) at offset `0x54`", and
  `dScDSMT_c::Behavior` does `SetFaders(c + 0x54)`. `0x54 + 0x10 == 0x64` closes the
  class exactly.
- **The ROM contradicted a landed header.** `dScDSMT_c.h`'s banner claimed the whole
  `0x50..0x64` range was `graphCallback_c`; on `main` it therefore disagreed with
  `dFdDummy_c.h`, which said the range from `0x54` was a `dFdDummy_c`. The relocation
  settles it in `dFdDummy_c.h`'s favour, and the banner is corrected.
- **No TU includes this header**, so *the build cannot see it*. Verified instead by
  compiling a probe under the build's own C++ flags
  (`-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -Cpp_exceptions off -i include`):
  `sizeof(dScDSMT_c) == 0x64` and `offsetof(fader) == 0x54` both hold, and a negative
  control asserting `0x50` is rejected with `illegal constant expression`. So the probe
  discriminates.

## Skipped, by bucket

- **144 `INHERITED`** -- nothing to apply; the base already declares the member.
- **30 already typed** -- the header was right the whole time; only the reader was blind.
- **6 `u8` array markers, now `DECIDABLE`, held.** `dScMg3DEsp_c` (`0x4f38`, `0x4f88`,
  `0x51f4`), `dScMgJump2_c` (`0x5a14`), `dScMgRoulette_c` (`0x531c`, `0x536c`). Two
  independent blockers, both pre-existing and both documented in those headers:
  1. their owners' **recovered C++ destructors** call the member's `D1` **explicitly**,
     in an order Itanium auto-destruction cannot reproduce (the untyped `u8` blocks
     between them must be destroyed from the user body, which runs *first*);
  2. consumers spell the field as an array (`_ZN5ModelD1Ev(mModel1)`,
     `_ZN9Animation7AdvanceEv(mTextureTransformer)`), so retyping is not a header-only
     edit.

  `apply` now refuses these with that reason instead of the old, now-wrong
  `no bare u8 marker at that offset`.
- Constraint 3 (`typedef struct X X;` + a C definition) **blocked nothing here**: the one
  applicable owner header is not reachable from any `.c`. The types that would have
  needed it (`dCcAc_c`, `dBgCh_Actr`, `ShadowModel`, `dCcAcPos_c`) were all in the
  already-typed set. The `NO ASSERT` (23) and `MEMBER TYPE IS C++ ONLY` (17) buckets are
  untouched and unchanged -- a sibling owns those.

## Census, before -> after

```
                        main   here
DECIDABLE                 22     27      +6 newly visible, -1 was already typed
ALREADY TYPED            571    603
INHERITED                  -    144      new bucket
NO ASSERT                 23     23      unchanged (sibling's)
DECLARED OTHERWISE         0      0
INHERITED OTHERWISE        -      0      new bucket, empty
NO FIELD AT OFFSET       181      0
MEMBER TYPE IS C++ ONLY   17     17      unchanged (sibling's)
NO OWNER HEADER            0      0
BASE-AT-0                359    359
SECONDARY-BASE             5      5
AMBIGUOUS VARIANT          0      0
```

The frozen `--check` census (ROM-side populations) is untouched: `GATE OK`.

`--dry-run` writes **0 declarations** -- every `DECIDABLE` entry is refused, so nothing
in this PR came from `--apply`.

## Also found: main's own DECIDABLE list carried a finished entry

`Eyerok @0x674 -> dBgW_KcMbg` was `DECIDABLE` on `main` with `declared: u8 unk_674`.
`Eyerok.h`'s C++ block has declared `dBgW_KcMbg unk_674; /* 0x674 -- this class's own,
not dBgActor_c's */` all along; only the flat C stand-in still carries the 1-byte marker.
The prose in the offset comment hid it. It buckets `ALREADY TYPED` now.

## Gates

| gate | exit | result |
|---|---:|---|
| `rombuild.py -j 16 --no-rom` | 0 | 106/106 exact, **11,059 reproducing, 0 mismatching**, 100.000000% of compared bytes |
| `eligible.py` (bracketed) | 0 | 11065 / 11187 both sides; `build/eligible-names.txt` **byte-identical** (`diff` empty) |
| `check_header_offsets.py --changed origin/main` | 0 | 1 changed header; `2 commented fields, 0 mismatched, 0 unparsed, struct spans 0x64` |
| `port_refcheck.py` | 0 | 393 checked, all resolve |
| `langmode_audit.py --check <baseline>` | 0 | `langmode ratchet PASS`. No `_chaos_data` checkout here, so the baseline was regenerated from `origin/main`'s copy of the only `include/` file this PR touches. |
| `dtor_members.py --check` | 0 | `GATE OK` |
| `opnew_sizes.py --check` | 0 | `GATE OK` |
| `pyflakes tools/dtor_members.py tools/test_dtor_members.py` | 0 | clean |
| `pytest tools/test_dtor_members.py` | 0 | 21 passed (4 new) |
| `pytest tools/` | 1 | 480 passed, 2 failed -- `test_bytegate::test_no_row_is_stale` and `test_srcpath::test_enrolment_agrees_with_the_filename_convention`, both **pre-existing on main** and unrelated (byte-gate manifest, `src/func_01ff97d8.c` enrolment) |

## Tests added

Four, one per defect: an offset comment carrying prose; a nested `struct State` not
swallowing the fields below it; a base-declared member reading as inherited rather than
missing; and the base walk surviving a cycle.
