### PR TITLE
Every member the cartridge names is now typed: the C++-only bucket and the span bucket are both empty

### DIFF
--- a/include/ArrowLift.h
+++ b/include/ArrowLift.h
@@ -6,6 +6,7 @@
 #define ARROWLIFT_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct ArrowLift {
     u8  pad_000[0x98];
@@ -14,8 +15,11 @@ struct ArrowLift {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~ArrowLift calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 unk_320;            /* 0x320 */
     /* trailing extent the ROM's `new ArrowLift` literal proves; see tools/opnew_sizes.py */
     u8 pad_324[0x4];

--- a/include/CastleWater.h
+++ b/include/CastleWater.h
@@ -22,6 +22,7 @@
 #include "math/Matrix.h"
 #include "TextureTransformer.h"
 #include "dBgW_KcMbg.h"
+#include "Model.h"
 
 struct CastleWater {
     u8  pad_000[0x5c];
@@ -35,12 +36,10 @@ struct CastleWater {
     u8  pad_068[0x26];
     s16 mAngleY;            /* 0x08e */
     u8  pad_090[0x44];
-    /* Sub-objects, kept as byte markers -- each one's extent is fixed by the
-       next member's offset, and none of the four methods looks inside one. */
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  mModelComponents;            /* 0x0dc */
-    u8  pad_0dd[0x47];
+    /* Model member. The cartridge's own ~CastleWater calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
     /* dBgW_KcMbg member. The cartridge's own ~CastleWater calls _ZN10dBgW_KcMbgD1Ev at
        +0x124 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */

--- a/include/Coffin.h
+++ b/include/Coffin.h
@@ -6,6 +6,7 @@
 #define COFFIN_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct Coffin {
     u8  pad_000[0x5c];
@@ -21,8 +22,10 @@ struct Coffin {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* dBgW_KcMbg member. The cartridge's own ~Coffin calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     /* trailing extent the ROM's `new Coffin` literal proves; see tools/opnew_sizes.py */
     u8 pad_2f0[0x3c];

--- a/include/EnemySwitchTag.h
+++ b/include/EnemySwitchTag.h
@@ -5,15 +5,14 @@
 #ifndef ENEMYSWITCHTAG_H
 #define ENEMYSWITCHTAG_H
 #include "types.h"
+#include "dCcAc_c.h"
 
 struct EnemySwitchTag {
     u8  pad_000[0xd4];
-    u8  mdCcAc_c;            /* 0x0d4 */
-    u8  pad_0d5[0x17];
-    u8  unk_0ec;            /* 0x0ec */
-    u8  pad_0ed[0xb];
-    s32 unk_0f8;            /* 0x0f8 */
-    u8  pad_0fc[0xc];
+    /* dCcAc_c member. The cartridge's own ~EnemySwitchTag calls _ZN7dCcAc_cD1Ev at
+       +0x0d4 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dCcAc_c mdCcAc_c;            /* 0x0d4 */
     u16 unk_108;            /* 0x108 */
     u16 unk_10a;            /* 0x10a */
     u8  unk_10c;            /* 0x10c */

--- a/include/Eyerok.h
+++ b/include/Eyerok.h
@@ -143,7 +143,10 @@ struct Eyerok {
     s16 unk_4d2;            /* 0x4d2 */
     u16 unk_4d4;            /* 0x4d4 */
     u8  pad_4d6[0x19e];
-    u8  unk_674;            /* 0x674 */
+    /* dBgW_KcMbg member. The cartridge's own ~Eyerok calls _ZN10dBgW_KcMbgD1Ev at
+       +0x674 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg unk_674;            /* 0x674 */
 };
 
 #endif /* __cplusplus */

--- a/include/FortressTower.h
+++ b/include/FortressTower.h
@@ -2,6 +2,7 @@
 #define FORTRESSTOWER_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -43,7 +44,10 @@ struct FortressTower {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
+    /* dBgW_KcMbg member. The cartridge's own ~FortressTower calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
 };
 
 #endif /* __cplusplus */

--- a/include/HealingHeart.h
+++ b/include/HealingHeart.h
@@ -6,6 +6,7 @@
 #define HEALINGHEART_H
 #include "types.h"
 #include "ModelAnim.h"
+#include "dCcAc_c.h"
 
 struct HealingHeart {
     u8  pad_000[0x74];
@@ -46,10 +47,12 @@ struct HealingHeart {
        Animation base), unk_130 (+0x5c = speed), which the header declared separately
        inside it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mdCcAc_c;            /* 0x138 */
-    u8  pad_139[0x23];
-    s32 unk_15c;            /* 0x15c */
-    u8  pad_160[0xc];
+    /* dCcAc_c member. The cartridge's own ~HealingHeart calls _ZN7dCcAc_cD1Ev at +0x138
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_15c
+       (+0x24 = dCc_c::otherOwner), which the header declared separately inside it. */
+    dCcAc_c mdCcAc_c;            /* 0x138 */
     s32 unk_16c;            /* 0x16c */
     u8  mHealTimer;            /* 0x170 */
     u8  unk_171;            /* 0x171 */

--- a/include/IceSheet.h
+++ b/include/IceSheet.h
@@ -2,6 +2,7 @@
 #define ICESHEET_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -56,7 +57,10 @@ struct IceSheet {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
+    /* dBgW_KcMbg member. The cartridge's own ~IceSheet calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
 };
 
 #endif /* __cplusplus */

--- a/include/MadPiano.h
+++ b/include/MadPiano.h
@@ -7,6 +7,9 @@
 #include "types.h"
 #include "ModelAnim.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
+#include "ShadowModel.h"
+#include "dBgCh_Actr.h"
 
 struct MadPiano {
     u8  pad_000[0x5c];
@@ -26,19 +29,32 @@ struct MadPiano {
        (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
        D1 and not D2, so it is this type and not an inlined base. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~MadPiano calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     ModelAnim mModelAnim;            /* 0x320 */
-    u8  mShadowModel1;            /* 0x384 */
-    u8  pad_385[0x27];
-    u8  mShadowModel2;            /* 0x3ac */
-    u8  pad_3ad[0x27];
-    u8  mShadowModel3;            /* 0x3d4 */
-    u8  pad_3d5[0x137];
-    u8  mWithMeshClsn;            /* 0x50c */
-    u8  pad_50d[0x1bf];
+    /* ShadowModel member. The cartridge's own ~MadPiano calls _ZN11ShadowModelD1Ev at
+       +0x384 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel1;            /* 0x384 */
+    /* ShadowModel member. The cartridge's own ~MadPiano calls _ZN11ShadowModelD1Ev at
+       +0x3ac (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel2;            /* 0x3ac */
+    /* ShadowModel member. The cartridge's own ~MadPiano calls _ZN11ShadowModelD1Ev at
+       +0x3d4 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel3;            /* 0x3d4 */
+    u8  pad_3fc[0x110];
+    /* dBgCh_Actr member. The cartridge's own ~MadPiano calls _ZN10dBgCh_ActrD1Ev at
+       +0x50c (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgCh_Actr mWithMeshClsn;            /* 0x50c */
+    u8  pad_6c8[0x4];
     s32 unk_6cc;            /* 0x6cc */
     u8  pad_6d0[0x4];
     s32 unk_6d4;            /* 0x6d4 */

--- a/include/MirrorLuigi.h
+++ b/include/MirrorLuigi.h
@@ -6,6 +6,8 @@
 #define MIRRORLUIGI_H
 #include "types.h"
 #include "ShadowModel.h"
+#include "ModelAnim.h"
+#include "Model.h"
 
 struct MirrorLuigi {
     u8  pad_000[0x5c];
@@ -13,20 +15,14 @@ struct MirrorLuigi {
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0x6c];
-    u8  mModelAnim;            /* 0x0d4 */
-    u8  pad_0d5[0x7];
-    u8  unk_0dc;            /* 0x0dc */
-    u8  pad_0dd[0xb];
-    u8  unk_0e8;            /* 0x0e8 */
-    u8  pad_0e9[0x4f];
-    u8  mModel;            /* 0x138 */
-    u8  pad_139[0x7];
-    u8  unk_140;            /* 0x140 */
-    u8  pad_141[0xb];
-    u8  unk_14c;            /* 0x14c */
-    u8  pad_14d[0x7];
-    u8  unk_154;            /* 0x154 */
-    u8  pad_155[0x33];
+    /* ModelAnim member. The cartridge's own ~MirrorLuigi calls _ZN9ModelAnimD1Ev at
+       +0x0d4 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ModelAnim mModelAnim;            /* 0x0d4 */
+    /* Model member. The cartridge's own ~MirrorLuigi calls _ZN5ModelD1Ev at +0x138
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x138 */
     /* ShadowModel member. The cartridge's own ~MirrorLuigi calls _ZN11ShadowModelD1Ev
        at +0x188 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */

--- a/include/MirrorLuigi.h
+++ b/include/MirrorLuigi.h
@@ -5,6 +5,7 @@
 #ifndef MIRRORLUIGI_H
 #define MIRRORLUIGI_H
 #include "types.h"
+#include "ShadowModel.h"
 
 struct MirrorLuigi {
     u8  pad_000[0x5c];
@@ -26,8 +27,10 @@ struct MirrorLuigi {
     u8  pad_14d[0x7];
     u8  unk_154;            /* 0x154 */
     u8  pad_155[0x33];
-    u8  mShadowModel;            /* 0x188 */
-    u8  pad_189[0x27];
+    /* ShadowModel member. The cartridge's own ~MirrorLuigi calls _ZN11ShadowModelD1Ev
+       at +0x188 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ShadowModel mShadowModel;            /* 0x188 */
     u8  unk_1b0;            /* 0x1b0 */
     u8  pad_1b1[0x7];
     s32 unk_1b8;            /* 0x1b8 */

--- a/include/MrI.h
+++ b/include/MrI.h
@@ -8,6 +8,7 @@
 #include "ModelAnim.h"
 #include "ShadowModel.h"
 #include "dCcAcPos_c.h"
+#include "TextureSequence.h"
 
 struct MrI {
     u8  pad_000[0x8];
@@ -32,10 +33,13 @@ struct MrI {
        stopped short of the object, so the member also takes over unk_130 (+0x5c = speed),
        which the header declared separately inside it. */
     ModelAnim mModelAnim;            /* 0x0d4 */
-    u8  mTextureSequence;            /* 0x138 */
-    u8  pad_139[0xb];
-    s32 unk_144;            /* 0x144 */
-    u8  pad_148[0x4];
+    /* TextureSequence member. The cartridge's own ~MrI calls _ZN15TextureSequenceD1Ev
+       at +0x138 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base.
+       The marker's pad stopped short of the object, so the member also takes over
+       unk_144 (+0xc = the Animation base's speed), which the header declared
+       separately inside it. */
+    TextureSequence mTextureSequence;            /* 0x138 */
     /* ShadowModel member. The cartridge's own ~MrI calls _ZN11ShadowModelD1Ev at +0x14c
        (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
        D1 and not D2, so it is this type and not an inlined base. */

--- a/include/Number.h
+++ b/include/Number.h
@@ -5,6 +5,8 @@
 #ifndef NUMBER_H
 #define NUMBER_H
 #include "types.h"
+#include "Model.h"
+#include "TextureSequence.h"
 
 struct Number {
     u8  pad_000[0x8];
@@ -19,14 +21,15 @@ struct Number {
     u8  pad_0a4[0x4];
     s32 mVertSpeed;            /* 0x0a8 */
     u8  pad_0ac[0x28];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x1b];
-    u8  unk_0f0;            /* 0x0f0 */
-    u8  pad_0f1[0x33];
-    u8  mTextureSequence;            /* 0x124 */
-    u8  pad_125[0x7];
-    s32 unk_12c;            /* 0x12c */
-    u8  pad_130[0x8];
+    /* Model member. The cartridge's own ~Number calls _ZN5ModelD1Ev at +0x0d4 (D0/D1),
+       a relocation the ROM build checks; recovered by tools/dtor_members.py. D1 and not
+       D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
+    /* TextureSequence member. The cartridge's own ~Number calls
+       _ZN15TextureSequenceD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    TextureSequence mTextureSequence;            /* 0x124 */
     s32 unk_138;            /* 0x138 */
     s32 unk_13c;            /* 0x13c */
     s32 mStartPosY;            /* 0x140 */

--- a/include/PyramidLift.h
+++ b/include/PyramidLift.h
@@ -6,6 +6,7 @@
 #define PYRAMIDLIFT_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct PyramidLift {
     u8  pad_000[0x5c];
@@ -20,8 +21,10 @@ struct PyramidLift {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel1;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* dBgW_KcMbg member. The cartridge's own ~PyramidLift calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.

--- a/include/QuestionBlock.h
+++ b/include/QuestionBlock.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "dBgW_KcMbg.h"
+#include "Model.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -96,10 +97,12 @@ struct QuestionBlock {
     u8  pad_090[0x10];
     s32 unk_0a0;            /* 0x0a0 */
     u8  pad_0a4[0x30];
-    u8  mModel;            /* 0x0d4 */
-    u8  pad_0d5[0x1b];
-    u8  unk_0f0;            /* 0x0f0 */
-    u8  pad_0f1[0x33];
+    /* Model member. The cartridge's own ~QuestionBlock calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       stopped short of the object, so the member also takes over unk_0f0
+       (+0x1c = mat4x3), which the header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     /* dBgW_KcMbg member. The cartridge's own ~QuestionBlock calls _ZN10dBgW_KcMbgD1Ev
        at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */

--- a/include/RickshawPlatformBs.h
+++ b/include/RickshawPlatformBs.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 /* The Bowser-in-the-Sky drifting platform. ROM name daObjKm3_Dorifu_c.
  *
@@ -54,7 +55,11 @@ struct RickshawPlatformBs {
        +0x0d4 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
+    /* dBgW_KcMbg member. The cartridge's own ~RickshawPlatformBs calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
 };
 
 #endif /* __cplusplus */

--- a/include/RotatingFirebar.h
+++ b/include/RotatingFirebar.h
@@ -2,6 +2,8 @@
 #define ROTATINGFIREBAR_H
 
 #include "types.h"
+#include "Model.h"
+#include "dBgW_KcMbg.h"
 
 /* The rotating bar of flames. Derives from dBgActor_c, and the ONE thing it adds
  * is the array of collision cylinders -- one per flame.
@@ -42,10 +44,14 @@ struct RotatingFirebar {
     u8  pad_090[0x20];
     s32 unk_0b0;            /* 0x0b0 */
     u8  pad_0b4[0x20];
-    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
-       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
-    u8  mModel[0x50];            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
+    /* Model member. The cartridge's own ~RotatingFirebar calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x0d4 */
+    /* dBgW_KcMbg member. The cartridge's own ~RotatingFirebar calls _ZN10dBgW_KcMbgD1Ev
+       at +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
 };
 
 #endif /* __cplusplus */

--- a/include/ShadowModel.h
+++ b/include/ShadowModel.h
@@ -91,6 +91,19 @@ struct ShadowModel {
     struct ShadowModel *next;          /* 0x24 */
 };
 
+/* In C the tag alone is not a type name, so an owner header that embeds a
+   ShadowModel BY VALUE -- which several of the cartridge's own destructors prove
+   it does, see tools/dtor_members.py -- cannot spell the member without this.
+   The definition and the typedef have to travel together: with the definition
+   and no typedef the embed gets `undefined identifier', and then the owner's
+   size assert gets `illegal constant expression' on top of it. */
+typedef struct ShadowModel ShadowModel;
+
+/* The C view substitutes for the C++ class only while it is the SAME SIZE. Once
+   an owner embeds one by value the two branches lay that owner out differently if
+   they ever disagree, and nothing else in the build compares them. */
+typedef char ShadowModel_size_must_be_0x28[sizeof(struct ShadowModel) == 0x28 ? 1 : -1];
+
 #endif /* __cplusplus */
 
 #endif /* SHADOWMODEL_H */

--- a/include/SlidingIce.h
+++ b/include/SlidingIce.h
@@ -2,6 +2,7 @@
 #define SLIDINGICE_H
 
 #include "types.h"
+#include "dBgW_KcMbg.h"
 
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
@@ -60,10 +61,14 @@ struct SlidingIce {
     /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x4b];
-    s8  unk_170;            /* 0x170 */
-    u8  pad_171[0x1ad];
+    /* dBgW_KcMbg member. The cartridge's own ~SlidingIce calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base.
+       The marker's pad stopped short of the object, so the member also takes over
+       unk_170 (+0x4c = the dBgW_Kc base's unk_4c), which the header declared
+       separately inside it. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x32];
     s16 unk_31e;            /* 0x31e */
     s8  mNumToBigIce;            /* 0x320 */
     u8  pad_321[0x3];

--- a/include/StarMarker.h
+++ b/include/StarMarker.h
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "Model.h"
 #include "ShadowModel.h"
+#include "dCcAcPos_c.h"
 
 struct StarMarker {
     u8  pad_000[0x4];
@@ -21,11 +22,10 @@ struct StarMarker {
     u8  pad_090[0x3c];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x7];
-    u8  mdCcAcPos_c;            /* 0x0d4 */
-    u8  pad_0d5[0x1f];
-    s32 unk_0f4;            /* 0x0f4 */
-    s32 unk_0f8;            /* 0x0f8 */
-    u8  pad_0fc[0x18];
+    /* dCcAcPos_c member. The cartridge's own ~StarMarker calls _ZN10dCcAcPos_cD1Ev at
+       +0x0d4 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dCcAcPos_c mdCcAcPos_c;            /* 0x0d4 */
     /* Model member, named by _ZN5ModelD1Ev at +0x114 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
        short of the object, so the member also takes over unk_154 (+0x40 = mat4x3.t.x),

--- a/include/ToxBox.h
+++ b/include/ToxBox.h
@@ -6,6 +6,9 @@
 #define TOXBOX_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
+#include "dBgCh_Actr.h"
+#include "dCcAcPos_c.h"
 
 struct ToxBox {
     u8  pad_000[0x8];
@@ -24,13 +27,21 @@ struct ToxBox {
        short of the object, so the member also takes over unk_0f0 (+0x1c = mat4x3), which
        the header declared separately inside it. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1fb];
+    /* dBgW_KcMbg member. The cartridge's own ~ToxBox calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
+    u8  pad_2ec[0x34];
     s32 unk_320;            /* 0x320 */
-    u8  mWithMeshClsn;            /* 0x324 */
-    u8  pad_325[0x1c3];
-    u8  mdCcAcPos_c;            /* 0x4e8 */
-    u8  pad_4e9[0x3f];
+    /* dBgCh_Actr member. The cartridge's own ~ToxBox calls _ZN10dBgCh_ActrD1Ev at
+       +0x324 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgCh_Actr mWithMeshClsn;            /* 0x324 */
+    u8  pad_4e0[0x8];
+    /* dCcAcPos_c member. The cartridge's own ~ToxBox calls _ZN10dCcAcPos_cD1Ev at
+       +0x4e8 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dCcAcPos_c mdCcAcPos_c;            /* 0x4e8 */
     u8  unk_528;            /* 0x528 */
     u8  pad_529[0x2f];
     s32 unk_558;            /* 0x558 */

--- a/include/TtcConveyorBeltLarge.h
+++ b/include/TtcConveyorBeltLarge.h
@@ -8,6 +8,7 @@
 #include "Model.h"
 #include "dBgW_KcMbg.h"
 #include "ShadowModel.h"
+#include "TextureTransformer.h"
 
 struct TtcConveyorBeltLarge {
     u8  pad_000[0xc];
@@ -33,10 +34,11 @@ struct TtcConveyorBeltLarge {
     dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x33];
-    u8  mTextureTransformer;            /* 0x320 */
-    u8  pad_321[0xb];
-    s32 unk_32c;            /* 0x32c */
-    u8  pad_330[0x4];
+    /* TextureTransformer member. The cartridge's own ~TtcConveyorBeltLarge calls
+       _ZN18TextureTransformerD1Ev at +0x320 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    TextureTransformer mTextureTransformer;            /* 0x320 */
     /* ShadowModel member. The cartridge's own ~TtcConveyorBeltLarge calls
        _ZN11ShadowModelD1Ev at +0x334 (D0/D1), a relocation the ROM build checks;
        recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an

--- a/include/UnknownVsEntry.h
+++ b/include/UnknownVsEntry.h
@@ -5,6 +5,8 @@
 #ifndef UNKNOWNVSENTRY_H
 #define UNKNOWNVSENTRY_H
 #include "types.h"
+#include "Model.h"
+#include "ModelAnim.h"
 
 struct UnknownVsEntry {
     u8  pad_000[0x8];
@@ -12,14 +14,15 @@ struct UnknownVsEntry {
     u8  pad_00c[0x44];
     u8  mParticle;            /* 0x050 */
     u8  pad_051[0x81b];
-    u8  mModel;            /* 0x86c */
-    u8  pad_86d[0x1b];
-    u8  unk_888;            /* 0x888 */
-    u8  pad_889[0x33];
-    u8  mModelAnim;            /* 0x8bc */
-    u8  pad_8bd[0x4f];
-    u8  mAnimation;            /* 0x90c */
-    u8  pad_90d[0x573];
+    /* Model member. The cartridge's own ~UnknownVsEntry calls _ZN5ModelD1Ev at +0x86c
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    Model mModel;            /* 0x86c */
+    /* ModelAnim member. The cartridge's own ~UnknownVsEntry calls _ZN9ModelAnimD1Ev at
+       +0x8bc (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    ModelAnim mModelAnim;            /* 0x8bc */
+    u8  pad_920[0x560];
     u8  unk_e80;            /* 0xe80 */
     u8  pad_e81[0xa7];
     s32 unk_f28;            /* 0xf28 */

--- a/include/WingFeather.h
+++ b/include/WingFeather.h
@@ -7,6 +7,8 @@
 #include "types.h"
 #include "Model.h"
 #include "ShadowModel.h"
+#include "dCcAc_c.h"
+#include "dBgCh_Actr.h"
 
 struct WingFeather {
     u8  pad_000[0x5c];
@@ -28,14 +30,14 @@ struct WingFeather {
        Model's D1 at +0x0d4 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN11WingFeatherD0Ev.c] */
     Model mModel;            /* 0x0d4 */
-    u8  mdCcAc_c;            /* 0x124 */
-    u8  pad_125[0x23];
-    u32 unk_148;            /* 0x148 */
-    u8  pad_14c[0xc];
-    u8  mWithMeshClsn;            /* 0x158 */
-    u8  pad_159[0x1a7];
-    u8  unk_300;            /* 0x300 */
-    u8  pad_301[0x13];
+    /* dCcAc_c member. The cartridge's own ~WingFeather calls _ZN7dCcAc_cD1Ev at +0x124
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. */
+    dCcAc_c mdCcAc_c;            /* 0x124 */
+    /* dBgCh_Actr member. The cartridge's own ~WingFeather calls _ZN10dBgCh_ActrD1Ev at
+       +0x158 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgCh_Actr mWithMeshClsn;            /* 0x158 */
     /* ShadowModel member. The cartridge's own ~WingFeather calls _ZN11ShadowModelD1Ev
        at +0x314 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */

--- a/include/WorkElevator.h
+++ b/include/WorkElevator.h
@@ -6,6 +6,7 @@
 #define WORKELEVATOR_H
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 struct WorkElevator {
     u8  pad_000[0x5c];
@@ -19,8 +20,10 @@ struct WorkElevator {
        (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
        D1 and not D2, so it is this type and not an inlined base. */
     Model mModel;            /* 0x0d4 */
-    u8  mMeshCollider;            /* 0x124 */
-    u8  pad_125[0x1c7];
+    /* dBgW_KcMbg member. The cartridge's own ~WorkElevator calls _ZN10dBgW_KcMbgD1Ev at
+       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
+       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
+    dBgW_KcMbg mMeshCollider;            /* 0x124 */
     u8  unk_2ec;            /* 0x2ec */
     u8  pad_2ed[0x233];
     u8  unk_520;            /* 0x520 */

--- a/include/dBgCh_Actr.h
+++ b/include/dBgCh_Actr.h
@@ -177,6 +177,22 @@ struct dBgCh_Actr {
     s32 unk_1b8;            /* 0x1b8 */
 };
 
+/* In C the tag alone is not a type name, so an owner header that embeds a
+   dBgCh_Actr BY VALUE -- which the cartridge's own destructors prove several do,
+   see tools/dtor_members.py -- cannot spell the member without this. The
+   definition and the typedef have to travel together: with the definition and no
+   typedef the embed gets `undefined identifier', and then the owner's size assert
+   gets `illegal constant expression' on top of it. */
+typedef struct dBgCh_Actr dBgCh_Actr;
+
+/* The C view substitutes for the C++ class only while it is the SAME SIZE. Once
+   an owner embeds one by value the two branches lay that owner out differently if
+   they ever disagree, and nothing else in the build compares them. Individual
+   widths differ between the two on purpose (see the note above the #else); the
+   total may not. */
+typedef char dBgCh_Actr_size_must_be_0x1bc[
+    sizeof(struct dBgCh_Actr) == 0x1bc ? 1 : -1];
+
 #endif /* __cplusplus */
 
 #endif /* DBGCH_ACTR_H */

--- a/include/dBgW_KcMbg.h
+++ b/include/dBgW_KcMbg.h
@@ -84,6 +84,49 @@ struct dBgW_KcMbg : dBgW_Kc {
 
 typedef char dBgW_KcMbg_size_must_be_0x1c8[sizeof(dBgW_KcMbg) == 0x1c8 ? 1 : -1];
 
+#else
+
+/* The C spelling of the same object, flat -- the arrangement include/ShadowModel.h
+   and include/dBgCh_Actr.h already use, and added here for the same reason they
+   have one: ten actor headers that a `.c` translation unit reaches embed a
+   dBgW_KcMbg BY VALUE, proved by their own destructors calling _ZN10dBgW_KcMbgD1Ev
+   at the offset (tools/dtor_members.py). Until this existed those ten members had
+   to stay `u8` markers, because C could not name the type at all.
+
+   The base is spelled as a pad rather than `struct dBgW_Kc base;`: dBgW_Kc.h is
+   C++-only too, and only the SIZE of the base matters to anything a C file does
+   here. Every field below is the C++ declaration above, at the same offset. */
+struct dBgW_KcMbg {
+    u8  pad_000[0x50];         /* 0x000 - dBgW_Kc base, C++-only above */
+    Fix12i scale;              /* 0x050 */
+    Matrix4x3 mat;             /* 0x054 */
+    Matrix4x3 invRotMat;       /* 0x084 */
+    Matrix4x3 scaledMat;       /* 0x0b4 */
+    Matrix4x3 invMat;          /* 0x0e4 */
+    s16 angY;                  /* 0x114 */
+    s16 angVelY;               /* 0x116 */
+    Vector3 pos;               /* 0x118 */
+    Vector3 velocity;          /* 0x124 */
+    u32 unk_130;               /* 0x130 */
+    Matrix4x3 newScaledMat;    /* 0x134 */
+    s32 unk_164;               /* 0x164 */
+    Matrix4x3 invScaledMat;    /* 0x168 */
+    Matrix4x3 prevInvScaledMat;/* 0x198 */
+};
+
+/* In C the tag alone is not a type name, so an owner header that embeds a
+   dBgW_KcMbg by value cannot spell the member without this. The definition and
+   the typedef have to travel together: with the definition and no typedef the
+   embed gets `undefined identifier', and then the owner's size assert gets
+   `illegal constant expression' on top of it. */
+typedef struct dBgW_KcMbg dBgW_KcMbg;
+
+/* The C view substitutes for the C++ class only while it is the SAME SIZE. Once
+   an owner embeds one by value the two branches lay that owner out differently if
+   they ever disagree, and nothing else in the build compares them. */
+typedef char dBgW_KcMbg_size_must_be_0x1c8[
+    sizeof(struct dBgW_KcMbg) == 0x1c8 ? 1 : -1];
+
 #endif /* __cplusplus */
 
 #endif /* DBGW_KCMBG_H */

--- a/include/dCcAcPos_c.h
+++ b/include/dCcAcPos_c.h
@@ -61,6 +61,20 @@ struct dCcAcPos_c {
     Vector3 pos;                    /* 0x34 */
 };
 
+/* In C the tag alone is not a type name, so an owner header that embeds a
+   dCcAcPos_c BY VALUE -- which the cartridge's own destructors prove several do,
+   see tools/dtor_members.py -- cannot spell the member without this. The
+   definition and the typedef have to travel together: with the definition and no
+   typedef the embed gets `undefined identifier', and then the owner's size assert
+   gets `illegal constant expression' on top of it. */
+typedef struct dCcAcPos_c dCcAcPos_c;
+
+/* The C view substitutes for the C++ class only while it is the SAME SIZE. Once
+   an owner embeds one by value the two branches lay that owner out differently if
+   they ever disagree, and nothing else in the build compares them. */
+typedef char dCcAcPos_c_size_must_be_0x40[
+    sizeof(struct dCcAcPos_c) == 0x40 ? 1 : -1];
+
 #endif /* __cplusplus */
 
 #endif /* DCCACPOS_C_H */

--- a/include/dCcAc_c.h
+++ b/include/dCcAc_c.h
@@ -74,6 +74,19 @@ struct dCcAc_c {
     struct dActor_c *owner;      /* 0x30 */
 };
 
+/* In C the tag alone is not a type name, so an owner header that embeds a
+   dCcAc_c BY VALUE -- which the cartridge's own destructors prove several do,
+   see tools/dtor_members.py -- cannot spell the member without this. The
+   definition and the typedef have to travel together: with the definition and no
+   typedef the embed gets `undefined identifier', and then the owner's size assert
+   gets `illegal constant expression' on top of it. */
+typedef struct dCcAc_c dCcAc_c;
+
+/* The C view substitutes for the C++ class only while it is the SAME SIZE. Once
+   an owner embeds one by value the two branches lay that owner out differently if
+   they ever disagree, and nothing else in the build compares them. */
+typedef char dCcAc_c_size_must_be_0x34[sizeof(struct dCcAc_c) == 0x34 ? 1 : -1];
+
 #endif /* __cplusplus */
 
 #endif /* DCCAC_C_H */

--- a/include/daDgr_c.h
+++ b/include/daDgr_c.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "dBgW_KcMbg.h"
+#include "Model.h"
 
 #ifdef __cplusplus
 
@@ -119,14 +120,13 @@ struct daDgr_c {
     s32 unk_0b4;                 /* 0x0b4 */
     s32 unk_0b8;                 /* 0x0b8 */
     u8  pad_0bc[0x18];
-    u8  mModel;                  /* 0x0d4 */
-    u8  pad_0d5[0x1b];
-    u8  unk_0f0;                 /* 0x0f0 */
-    u8  pad_0f1[0x23];
-    s32 unk_114;                 /* 0x114 */
-    s32 unk_118;                 /* 0x118 */
-    s32 unk_11c;                 /* 0x11c */
-    u8  pad_120[0x4];
+    /* Model member. The cartridge's own ~daDgr_c calls _ZN5ModelD1Ev at +0x0d4 (D0/D1),
+       a relocation the ROM build checks; recovered by tools/dtor_members.py. D1 and not
+       D2, so it is this type and not an inlined base. The marker's pad stopped short
+       of the object, so the member also takes over unk_0f0 (+0x1c = mat4x3) and
+       unk_114/unk_118/unk_11c (+0x40/+0x44/+0x48 = mat4x3.t.x/.y/.z), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     /* dBgW_KcMbg member. The cartridge's own ~daDgr_c calls _ZN10dBgW_KcMbgD1Ev at
        +0x124 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */

--- a/include/daObjKm1_Dorifu_c.h
+++ b/include/daObjKm1_Dorifu_c.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 /* The Bob-omb Battlefield drifting stairs. The tree's factory for it is
  * StairsBdw_Spawn; the class itself is only ever named by its ROM name.
@@ -50,7 +51,11 @@ struct daObjKm1_Dorifu_c {
        +0x0d4 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
+    /* dBgW_KcMbg member. The cartridge's own ~daObjKm1_Dorifu_c calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
 };
 
 #endif /* __cplusplus */

--- a/include/daObjRc_Dorifu_c.h
+++ b/include/daObjRc_Dorifu_c.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "Model.h"
+#include "dBgW_KcMbg.h"
 
 /* The Rainbow Ride drifting platform. Only ever named by its ROM name.
  *
@@ -51,7 +52,11 @@ struct daObjRc_Dorifu_c {
        (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
        D1 and not D2, so it is this type and not an inlined base. */
     Model mModel;            /* 0x0d4 */
-    u8  mMovingMeshCollider;            /* 0x124 */
+    /* dBgW_KcMbg member. The cartridge's own ~daObjRc_Dorifu_c calls
+       _ZN10dBgW_KcMbgD1Ev at +0x124 (D0/D1), a relocation the ROM build checks;
+       recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
+       inlined base. */
+    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
 };
 
 #endif /* __cplusplus */

--- a/include/daPgDfdr_c.h
+++ b/include/daPgDfdr_c.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "dBgW_KcMbg.h"
+#include "Model.h"
 
 #ifdef __cplusplus
 
@@ -130,14 +131,13 @@ struct daPgDfdr_c {
     s32 unk_0b4;                 /* 0x0b4 */
     s32 unk_0b8;                 /* 0x0b8 */
     u8  pad_0bc[0x18];
-    u8  mModel;                  /* 0x0d4 */
-    u8  pad_0d5[0x1b];
-    u8  unk_0f0;                 /* 0x0f0 */
-    u8  pad_0f1[0x23];
-    s32 unk_114;                 /* 0x114 */
-    s32 unk_118;                 /* 0x118 */
-    s32 unk_11c;                 /* 0x11c */
-    u8  pad_120[0x4];
+    /* Model member. The cartridge's own ~daPgDfdr_c calls _ZN5ModelD1Ev at +0x0d4
+       (D0/D1), a relocation the ROM build checks; recovered by tools/dtor_members.py.
+       D1 and not D2, so it is this type and not an inlined base. The marker's pad
+       of the object, so the member also takes over unk_0f0 (+0x1c = mat4x3) and
+       unk_114/unk_118/unk_11c (+0x40/+0x44/+0x48 = mat4x3.t.x/.y/.z), which the
+       header declared separately inside it. */
+    Model mModel;            /* 0x0d4 */
     /* dBgW_KcMbg member. The cartridge's own ~daPgDfdr_c calls _ZN10dBgW_KcMbgD1Ev at
        +0x124 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */

--- a/src/_ZN10StarMarker8BehaviorEv.cpp
+++ b/src/_ZN10StarMarker8BehaviorEv.cpp
@@ -76,10 +76,13 @@ int StarMarker::Behavior()
     }
     if (mState != 0) {
         if ((unsigned int)(mFlags << 0x1e) >> 0x1f) {
-            if (mState != 2 && unk_0f8 != 0) {
-                char *a = _ZN8dActor_c10FindWithIDEj(unk_0f8);
+            /* Both are fields of the dCcAcPos_c at 0x0d4, which the cartridge's own
+               ~StarMarker names (tools/dtor_members.py): 0x0f8 is +0x24,
+               dCc_c::otherOwner, and 0x0f4 is +0x20, dCc_c::hitFlags. */
+            if (mState != 2 && mdCcAcPos_c.otherOwner != 0) {
+                char *a = _ZN8dActor_c10FindWithIDEj(mdCcAcPos_c.otherOwner);
                 if (a != 0) {
-                    if ((unk_0f4 & 0x408000) != 0) {
+                    if ((mdCcAcPos_c.hitFlags & 0x408000) != 0) {
                         unk_1d0 = (int)a;
                         func_ov002_020e7d84(((char *)this));
                         return 1;

--- a/src/_ZN11CastleWater6RenderEv.cpp
+++ b/src/_ZN11CastleWater6RenderEv.cpp
@@ -3,8 +3,10 @@
 /* recovered: named members + shared header, real C++ method
  *
  * Pushes the texture transform into the model's components, then draws through
- * the model's own vtable slot 5. The transformer and the components are
- * separate sub-objects (0x320 and 0x0dc) and this is the only place they meet.
+ * the model's own vtable slot 5. The components are not a separate sub-object:
+ * 0x0dc is Model::data, +0x8 inside the Model at 0x0d4 -- the cartridge's own
+ * ~CastleWater proves the Model's extent (tools/dtor_members.py), so the header
+ * no longer declares a marker there and this is the model's own field.
  */
 #include "CastleWater.h"
 
@@ -14,7 +16,7 @@ extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *
 
 int CastleWater::Render()
 {
-    _ZN18TextureTransformer6UpdateER15ModelComponents(&mTexTransformer, &mModelComponents);
+    _ZN18TextureTransformer6UpdateER15ModelComponents(&mTexTransformer, &mModel.data);
     Sub *b = (Sub *)&mModel;
     b->m(0);
     return 1;

--- a/src/_ZN11MirrorLuigi6RenderEv.cpp
+++ b/src/_ZN11MirrorLuigi6RenderEv.cpp
@@ -44,7 +44,11 @@ int MirrorLuigi::Render()
     player = data_0209f394[data_0209f250];
     r8res = func_ov002_020e496c(player);
 
-    q = (char*)(int)((char*)&unk_0dc);
+    /* Every offset the cartridge's own ~MirrorLuigi proves is inside one of the two
+       model sub-objects (tools/dtor_members.py): 0x0dc/0x0e8 are the ModelAnim at
+       0x0d4 (+0x8 data, +0x14 data.transforms), and 0x140/0x14c/0x154 are the Model
+       at 0x138 (+0x8 data, +0x14 data.transforms, +0x1c mat4x3). */
+    q = (char*)(int)((char*)&mModelAnim.data);
     comp = *(char**)q;
     dst = *(Mtx**)(q + 0xc);
     src = *(Mtx**)(r8res + 0x14);
@@ -59,15 +63,16 @@ int MirrorLuigi::Render()
     *(int*)(p_f0 + 0x24) = -*(int*)(p_f0 + 0x24);
     func_0203c178(&data_020a0e68, -0x1000, 0x1000, 0x1000);
     MulMat3x3Mat3x3(p_f0, &data_020a0e68, p_f0);
-    *(Mtx*)((char*)&unk_154) = *(Mtx*)p_f0;
+    *(Mtx*)((char*)&mModel.mat4x3) = *(Mtx*)p_f0;
 
     if (data_ov055_02111b64 & 0x20000) return 1;
 
     _ZN5Model6RenderEPK7Vector3((void*)((char*)&mModelAnim), 0);
-    *(Mtx*)(*(char**)((char*)&unk_14c)) = *(Mtx*)(*(char**)((char*)&unk_0e8) + 0x2d0);
-    _ZN15TextureSequence6UpdateER15ModelComponents((void*)((char*)&unk_1b0), (void*)((char*)&unk_0dc));
+    *(Mtx*)(*(char**)((char*)&mModel.data.transforms)) =
+        *(Mtx*)(*(char**)((char*)&mModelAnim.data.transforms) + 0x2d0);
+    _ZN15TextureSequence6UpdateER15ModelComponents((void*)((char*)&unk_1b0), (void*)((char*)&mModelAnim.data));
     unk_1b8 = (int)(*(unsigned char*)(player + 0x6fb)) << 12;
-    _ZN15TextureSequence6UpdateER15ModelComponents((void*)((char*)&unk_1c4), (void*)((char*)&unk_140));
+    _ZN15TextureSequence6UpdateER15ModelComponents((void*)((char*)&unk_1c4), (void*)((char*)&mModel.data));
     unk_1cc = (int)(*(unsigned char*)(player + 0x6fb)) << 12;
     ((Sub*)((char*)&mModel))->m5(0);
     return 1;

--- a/src/_ZN11PyramidLift13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidLift13InitResourcesEv.cpp
@@ -5,7 +5,9 @@
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidLift.h"
 #pragma opt_strength_reduction off
-typedef int Fix12;
+/* Not `Fix12`: this actor's header now reaches math/Fix12.h, where Fix12 is a
+   class template. Only the raw word matters at this call. */
+typedef int Fix12Raw;
 /* SharedFilePtr stays incomplete: Model.h forward-declares it and its layout is
    deliberately not recovered (include/SharedFilePtr.h). Used only by address here. */
 typedef struct BMD_File BMD_File;
@@ -22,7 +24,7 @@ extern BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
 extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void* self);
 extern KCL_File* _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(SharedFilePtr* f);
-extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, KCL_File* k, Matrix4x3* m, Fix12 f, short s, CLPS_Block* b);
+extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, KCL_File* k, Matrix4x3* m, Fix12Raw f, short s, CLPS_Block* b);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
 }

--- a/src/_ZN11WingFeather8BehaviorEv.cpp
+++ b/src/_ZN11WingFeather8BehaviorEv.cpp
@@ -60,7 +60,10 @@ int WingFeather::Behavior()
         short* angp = (short*)((((s64)((char*)&unk_37c))));
         short old_ang = *angp;
         *angp = old_ang + 0x400;
-        u16 newv = *(u16*)((char*)((char*)&unk_300) + 0x7c);
+        /* 0x300 is +0x1a8 inside the dBgCh_Actr at 0x158, which the cartridge's own
+           ~WingFeather names (tools/dtor_members.py). It is unnamed there -- inside
+           dBgCh_Actr's pad_135 -- so the offset is spelled out. */
+        u16 newv = *(u16*)((char*)((char*)&mWithMeshClsn + 0x1a8) + 0x7c);
         int idx = ((newv >> 4) << 1) + 1;
         unk_098 = (int)(((s64)unk_378 * data_02082214[idx] + 0x800) >> 12);
     }
@@ -81,7 +84,8 @@ int WingFeather::Behavior()
         }
     }
 
-    u32 id = unk_148;
+    /* +0x24 inside the dCcAc_c at 0x124: dCc_c::otherOwner. */
+    u32 id = mdCcAc_c.otherOwner;
     if (id != 0) {
         void* a = _ZN8dActor_c10FindWithIDEj(id);
         if (a != 0) {

--- a/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
+++ b/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
@@ -20,8 +20,11 @@ int EnemySwitchTag::Behavior()
             _ZN5Event8ClearBitEj(mEventID);
         }
     }
-    if (unk_0f8 != 0) {
-        *(u32*)((char*)&unk_0ec) |= 1;
+    /* Both of these are fields of the dCcAc_c at 0x0d4, which the cartridge's own
+       ~EnemySwitchTag names (tools/dtor_members.py): 0x0f8 is +0x24, dCc_c::otherOwner,
+       and 0x0ec is +0x18, dCc_c::flags. */
+    if (mdCcAc_c.otherOwner != 0) {
+        *(u32*)((char*)&mdCcAc_c.flags) |= 1;
         _ZN5Event6SetBitEj(mEventID);
         if (unk_10c != 0) {
             unk_10a = unk_108;

--- a/src/_ZN14UnknownVsEntry13InitResourcesEv.cpp
+++ b/src/_ZN14UnknownVsEntry13InitResourcesEv.cpp
@@ -82,7 +82,9 @@ int UnknownVsEntry::InitResources()
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x86c, *(void**)(&data_ov075_0211d3fc + 4), 1, -1);
 
     func_0203c178(&data_020a0e68, 0x7d000, 0x7d000, 0x7d000);
-    *(struct M48*)((char*)&unk_888) = *(struct M48*)&data_020a0e68;
+    /* 0x888 is +0x1c inside the Model at 0x86c -- its mat4x3. The cartridge's own
+       ~UnknownVsEntry proves the extent; see tools/dtor_members.py. */
+    *(struct M48*)((char*)&mModel.mat4x3) = *(struct M48*)&data_020a0e68;
 
     if (mParam != 1) {
         _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x8bc, *(void**)(&data_ov075_0211d3bc + 4), 1, -1);

--- a/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
+++ b/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
@@ -59,7 +59,11 @@ int UnknownVsEntry::Behavior()
         if (unk_f40) {
             int r = func_0203da9c();
             func_ov075_021151b4(((char*)this), r);
-            _ZN9Animation7AdvanceEv((char*)&mAnimation);
+            /* 0x90c is +0x50 inside the ModelAnim at 0x8bc -- its Animation base,
+               which the cartridge's own ~UnknownVsEntry proves is there
+               (tools/dtor_members.py). Advance is non-virtual, so this is the same
+               direct bl to _ZN9Animation7AdvanceEv with this adjusted by +0x50. */
+            mModelAnim.Advance();
         }
         func_ov075_0211b418((char*)&unk_e80);
     }

--- a/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
@@ -22,9 +22,10 @@ extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern "C" void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(
     BMD_File &f, BTA_File &b);
 
-struct TextureTransformer {
-    void SetFile(BTA_File &f, int a, int fix, unsigned int u);
-};
+/* TextureTransformer is the real class now, through this actor's header, which
+   types mTextureTransformer. Redefining it ICEs mwccarm (CClass.c:3328); SetFile
+   is still reached by its mangled symbol below, because the real one takes
+   Fix12<int> BY VALUE and mwccarm passes that differently at the call site. */
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
@@ -130,7 +131,10 @@ int TtcConveyorBeltLarge::InitResources()
         data_ov065_0211c0b8[data_0209f2c0];
     *(void **)((char *)&mBeltSpeed) =
         *(void **)((char *)&mTargetBeltSpeed);
-    *(void **)((char *)&unk_32c) =
+    /* 0x32c is +0xc inside the TextureTransformer at 0x320 -- its Animation base's
+       speed. The cartridge's own ~TtcConveyorBeltLarge proves the extent; see
+       tools/dtor_members.py. */
+    *(void **)((char *)&mTextureTransformer.speed) =
         *(void **)((char *)&mBeltSpeed);
 
     v.x = mPosX;

--- a/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
@@ -50,7 +50,8 @@ int TtcConveyorBeltLarge::Behavior()
                 mBeltSpeed = data_ov065_0211c0b8[data_0209f2c0];
             }
 
-            unk_32c = mBeltSpeed;
+            /* +0xc inside the TextureTransformer at 0x320: its Animation base's speed. */
+            mTextureTransformer.speed = mBeltSpeed;
             _ZN9Animation7AdvanceEv((char*)&mTextureTransformer);
             if (mBeltSpeed != 0) {
                 unk_398 = (int)_ZN5Sound8PlayLongEjjjRK7Vector3s(unk_398, 3, 0x88, ((char*)this) + 0x74, 0);

--- a/src/_ZN6Coffin13InitResourcesEv.cpp
+++ b/src/_ZN6Coffin13InitResourcesEv.cpp
@@ -4,7 +4,9 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Coffin.h"
-typedef int Fix12;
+/* Not `Fix12`: this actor's header now reaches math/Fix12.h, where Fix12 is a
+   class template. Only the raw word matters at this call. */
+typedef int Fix12Raw;
 
 struct Matrix4x3;
 struct SharedFilePtr;
@@ -12,24 +14,21 @@ struct BMD_File;
 struct KCL_File;
 struct CLPS_Block;
 
-struct dBgW_Kc {
-    static KCL_File* LoadFile(SharedFilePtr& f);
-};
-struct dBgW_KcMbg {
-    int SetFile(KCL_File* f, const Matrix4x3& m, Fix12 s, short n, CLPS_Block& c);
-};
+/* dBgW_Kc and dBgW_KcMbg are the real classes now, through this actor's header,
+   which types mMeshCollider. Redefining them ICEs mwccarm (CClass.c:3328).
+   dBgW_Kc declares LoadFile itself; SetFile is still reached by its mangled
+   symbol below, because the real one takes Fix12<int> BY VALUE and mwccarm
+   passes that differently at the call site. */
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" int _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, KCL_File* f, const Matrix4x3& m, Fix12 s, short n, CLPS_Block& c);
+extern "C" int _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, KCL_File* f, const Matrix4x3& m, Fix12Raw s, short n, CLPS_Block& c);
 
 struct dBgActor_c {
     void UpdateClsnPosAndRot();
 };
 
-KCL_File* dBgW_Kc::LoadFile(SharedFilePtr&);
-int dBgW_KcMbg::SetFile(KCL_File*, const Matrix4x3&, Fix12, short, CLPS_Block&);
 void dBgActor_c::UpdateClsnPosAndRot();
 
 extern "C" {
@@ -68,7 +67,7 @@ int Coffin::InitResources()
     mPosZ = res.z;
     func_ov071_02122080(((char*)this));
     ((dBgActor_c*)((char*)this))->UpdateClsnPosAndRot();
-    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((dBgW_KcMbg*)((char*)&mMeshCollider), dBgW_Kc::LoadFile(data_ov071_021230d8), *(Matrix4x3*)((char*)&unk_2ec), 0x199, mAngleY, data_ov063_0211ebd8);
+    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((dBgW_KcMbg*)((char*)&mMeshCollider), (KCL_File*)dBgW_Kc::LoadFile(data_ov071_021230d8), *(Matrix4x3*)((char*)&unk_2ec), 0x199, mAngleY, data_ov063_0211ebd8);
     func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
     return 1;
 }

--- a/src/_ZN6Number13InitResourcesEv.cpp
+++ b/src/_ZN6Number13InitResourcesEv.cpp
@@ -31,7 +31,10 @@ int Number::InitResources()
                                  *(BTP_File*)data_ov002_0210da08.file);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
             ((char*)this) + 0x124, data_ov002_0210da08.file, 0x40000000, 0, 0);
-        unk_12c = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);
+        /* 0x12c is +0x8 inside the TextureSequence at 0x124 -- its Animation base's
+           currFrame. The cartridge's own ~Number proves the extent; see
+           tools/dtor_members.py. */
+        mTextureSequence.currFrame = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);
     } else {
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(data_ov002_0210d9e8);
         void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9a8);
@@ -41,7 +44,7 @@ int Number::InitResources()
                                  *(BTP_File*)data_ov002_0210d9e8.file);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
             ((char*)this) + 0x124, data_ov002_0210d9e8.file, 0x40000000, 0, 0);
-        unk_12c = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);
+        mTextureSequence.currFrame = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);
     }
 
     unk_14e = 0;

--- a/src/_ZN6Number8BehaviorEv.cpp
+++ b/src/_ZN6Number8BehaviorEv.cpp
@@ -53,6 +53,8 @@ int Number::Behavior()
             pos.y = oy + (unk_148 + (mPosY - mStartPosY));
         }
     }
-    Matrix4x3_FromTranslation((void *)((char *)&unk_0f0), pos.x >> 3, pos.y >> 3, (*(volatile int *)&pos.z) >> 3);
+    /* 0x0f0 is +0x1c inside the Model at 0x0d4 -- its mat4x3. The cartridge's own
+       ~Number proves the Model's extent; see tools/dtor_members.py. */
+    Matrix4x3_FromTranslation((void *)((char *)&mModel.mat4x3), pos.x >> 3, pos.y >> 3, (*(volatile int *)&pos.z) >> 3);
     return 1;
 }

--- a/src/_ZN9ArrowLift13InitResourcesEv.cpp
+++ b/src/_ZN9ArrowLift13InitResourcesEv.cpp
@@ -6,8 +6,9 @@
 #include "ArrowLift.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
-struct dBgW_Kc { int d; };
-struct dBgW_KcMbg { int d; };
+/* dBgW_Kc and dBgW_KcMbg are the real classes now, through this actor's header,
+   which types mMovingMeshCollider. The placeholders `{ int d; }` were only ever
+   cast targets and redefining the real ones ICEs mwccarm (CClass.c:3328). */
 
 extern "C" BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(ModelBase*, BMD_File*, int, int);

--- a/src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp
@@ -15,10 +15,10 @@ struct dActor_c {
   void UpdatePos(struct dCc_c*);
   struct dActor_c* ClosestPlayer();
 };
-struct dBgW {
-  int IsEnabled();
-  void Disable();
-};
+/* dBgW is the real class now, through this actor's header, which types
+   mMeshCollider as its dBgW_KcMbg derived class. IsEnabled and Disable are
+   non-virtual there, so the two direct `bl`s are unchanged; redefining the real
+   class ICEs mwccarm (CClass.c:3328). */
 struct dBgActor_c {
   int IsClsnInRange(int, int);
 };


### PR DESCRIPTION
`tools/dtor_members.py` (#1666) reads member types out of the cartridge: when class A's
destructor calls class B's destructor at offset 0xN, A has a B at 0xN. It left three
buckets. This PR closes two of them, and `--gap` now reports **DECIDABLE 0** and
**MEMBER TYPE IS C++ ONLY 0** (ALREADY TYPED 571 -> 610, +39 declarations).

## Bucket 1 -- 17 sites `MEMBER TYPE IS C++ ONLY`: 17/17 applied

A member type can only go into a header a `.c` file reaches if C can name it, which
takes **both** a definition outside `#ifdef __cplusplus` **and** `typedef struct X X;`
-- in C the tag alone is not a type name. Missing either gives `undefined identifier`
from the embed and then `illegal constant expression` from the owner's size assert.

Four types were actually involved (the census's live list; `dCcAc_c`,
`TextureSequence`, `TextureTransformer` and `MaterialChanger` were never in this
bucket, so nothing was needed for them here):

| type | what was missing | how it was unblocked | sites |
|---|---|---|---|
| `ShadowModel` | typedef only | `typedef struct ShadowModel ShadowModel;` | 4 |
| `dBgCh_Actr` | typedef only | `typedef struct dBgCh_Actr dBgCh_Actr;` | 2 |
| `dCcAcPos_c` | typedef only | `typedef struct dCcAcPos_c dCcAcPos_c;` | 1 |
| `dBgW_KcMbg` | **no C stand-in at all** | a flat C view of all 14 fields, base as a pad | 10 |

`dCcAc_c` gets the same typedef even though it was not blocking, because it heads the
chain `dCcAcPos_c`'s C view is built on and the two should not diverge.

`dBgW_KcMbg`'s stand-in is justified: ten C-reachable actor headers embed one BY VALUE
and the cartridge's own destructors prove it, so without a C spelling those ten members
could never stop being `u8` markers. The base is written `u8 pad_000[0x50]` rather than
`struct dBgW_Kc base` because dBgW_Kc.h is C++-only too and only the base's SIZE matters
on that path -- the same arrangement `include/dBgCh_Actr.h` already uses for `dBgCh`.

**Every C stand-in also gains its own `_size_must_be_` assert.** That is the part that
makes this safe rather than merely convenient: the C view only substitutes for the C++
class while the two are the same size, and once an owner embeds one by value a
disagreement lays that owner out differently on the two language paths. Nothing else in
the build compares them.

With the four unblocked, `--apply` typed **13 declarations across 7 headers** (ArrowLift,
Coffin, MadPiano x5, MirrorLuigi, PyramidLift, ToxBox x3, WorkElevator). The other 4 --
RickshawPlatformBs, RotatingFirebar, daObjKm1_Dorifu_c, daObjRc_Dorifu_c, all
`dBgW_KcMbg` at +0x124 -- moved from the C++ bucket into the span bucket, because their
marker has no pad behind it to spend. They are applied below. **17/17, 0 skipped.**

## Bucket 2 -- 21 sites `refused for span`: 26/26 applied

`--apply` refuses a finding when a field is already declared inside the member's span,
rather than truncating the member the cartridge proved. 21 sites after #1666, plus the 4
that arrived from bucket 1, plus RotatingFirebar +0x0d4 (refused for a different reason:
its marker was `u8 mModel[0x50]`, an array, not a bare `u8`). **26/26, 0 skipped.**

Three shapes:

**Eight had nothing inside the member at all.** The flat C view simply STOPPED at the
marker with no pad behind it, so the span read as 1 byte: Eyerok +0x674, FortressTower,
IceSheet, RickshawPlatformBs, RotatingFirebar, daObjKm1_Dorifu_c, daObjRc_Dorifu_c at
+0x124, and RotatingFirebar +0x0d4. Nothing is invented -- the flat view just reaches the
same place the C++ definition above it already does.

**Six had a declaration inside the member and no consumer anywhere:** HealingHeart, MrI,
QuestionBlock, SlidingIce, daDgr_c, daPgDfdr_c. Each absorbed declaration is named in the
member's comment (which sub-field of the member it was), so the evidence the header
carried does not vanish with the line.

**Twelve had live consumers**, respelled through the member -- sixteen call sites in
eleven files. Nothing is left reading a raw offset that the member now covers.

### Consumer-grep evidence

Done twice, by two independent methods that agree exactly on all 26 sites:

1. `grep -rlnw <field> src/`, filtered to files that name the owner class.
2. A full transitive `#include` closure per source file: resolve every `#include "..."`
   in `include/` to build the header graph, expand each of the ~11k sources to the set of
   headers it actually reaches, keep the sources that reach the owner's header, then
   word-boundary grep those.

| site | field(s) | consumers found | respelled to |
|---|---|---|---|
| CastleWater @0x0d4 Model | `mModelComponents` | `_ZN11CastleWater6RenderEv.cpp` | `mModel.data` |
| EnemySwitchTag @0x0d4 dCcAc_c | `unk_0ec`, `unk_0f8` | `_ZN14EnemySwitchTag8BehaviorEv.cpp` | `mdCcAc_c.flags`, `mdCcAc_c.otherOwner` |
| HealingHeart @0x138 dCcAc_c | `unk_15c` | **none** | absorbed (+0x24 otherOwner) |
| MirrorLuigi @0x0d4 ModelAnim | `unk_0dc`, `unk_0e8` | `_ZN11MirrorLuigi6RenderEv.cpp` | `mModelAnim.data`, `mModelAnim.data.transforms` |
| MirrorLuigi @0x138 Model | `unk_140`, `unk_14c`, `unk_154` | `_ZN11MirrorLuigi6RenderEv.cpp` | `mModel.data`, `mModel.data.transforms`, `mModel.mat4x3` |
| MrI @0x138 TextureSequence | `unk_144` | **none** | absorbed (+0xc Animation::speed) |
| Number @0x0d4 Model | `unk_0f0` | `_ZN6Number8BehaviorEv.cpp` | `mModel.mat4x3` |
| Number @0x124 TextureSequence | `unk_12c` | `_ZN6Number13InitResourcesEv.cpp` (x2) | `mTextureSequence.currFrame` |
| QuestionBlock @0x0d4 Model | `unk_0f0` | **none** | absorbed (+0x1c mat4x3) |
| SlidingIce @0x124 dBgW_KcMbg | `unk_170` | **none** | absorbed (+0x4c dBgW_Kc::unk_4c) |
| StarMarker @0x0d4 dCcAcPos_c | `unk_0f4`, `unk_0f8` | `_ZN10StarMarker8BehaviorEv.cpp` | `mdCcAcPos_c.hitFlags`, `mdCcAcPos_c.otherOwner` (x2) |
| TtcConveyorBeltLarge @0x320 TextureTransformer | `unk_32c` | `..13InitResourcesEv.cpp`, `..8BehaviorEv.cpp` | `mTextureTransformer.speed` |
| UnknownVsEntry @0x86c Model | `unk_888` | `_ZN14UnknownVsEntry13InitResourcesEv.cpp` | `mModel.mat4x3` |
| UnknownVsEntry @0x8bc ModelAnim | `mAnimation` | `_ZN14UnknownVsEntry8BehaviorEv.cpp` | `mModelAnim.Advance()` |
| WingFeather @0x124 dCcAc_c | `unk_148` | `_ZN11WingFeather8BehaviorEv.cpp` | `mdCcAc_c.otherOwner` |
| WingFeather @0x158 dBgCh_Actr | `unk_300` | `_ZN11WingFeather8BehaviorEv.cpp` | `(char*)&mWithMeshClsn + 0x1a8` |
| daDgr_c @0x0d4 Model | `unk_0f0`, `unk_114/118/11c` | **none** | absorbed (+0x1c mat4x3, +0x40/44/48 mat4x3.t) |
| daPgDfdr_c @0x0d4 Model | same | **none** | absorbed |
| the other 8 | -- | no field inside at all | -- |

Two respells deserve a note. `UnknownVsEntry`'s `mAnimation` at +0x50 inside the ModelAnim
is that class's `Animation` base; `Advance` is **non-virtual**, so `mModelAnim.Advance()`
is the same direct `bl _ZN9Animation7AdvanceEv` with `this` adjusted by +0x50, and it is
the idiom `_ZN3Key8BehaviorEv.cpp` already uses. `WingFeather`'s `unk_300` is at +0x1a8
inside the dBgCh_Actr, where dBgCh_Actr itself declares only `pad_135` -- deliberately, so
the offset is spelled out rather than a name being invented.

## Six ad-hoc shadow declarations deleted, not routed around

A consumer that carried its own stand-in for a type collides once the member is real, and
redefining one of these classes ICEs mwccarm at `CClass.c:3328`. All deleted or renamed:

| file | shadow | note |
|---|---|---|
| `ArrowLift::InitResources` | `struct dBgW_Kc/dBgW_KcMbg { int d; }` | cast targets only |
| `Coffin::InitResources` | the same pair, + `typedef int Fix12` -> `Fix12Raw` | `dBgW_Kc::LoadFile` really returns `char*`, so the call gains its cast |
| `PyramidLift::InitResources` | `typedef int Fix12` -> `Fix12Raw` | shadowed the `Fix12<>` class template |
| `MadPiano::Behavior` | `struct dBgW { IsEnabled; Disable; }` | both non-virtual in the real class, so the direct `bl` pair is unchanged |
| `TtcConveyorBeltLarge::InitResources` | `struct TextureTransformer` | `SetFile` still reached by its mangled symbol (real one takes `Fix12<int>` by value) |

## Gates

| gate | exit | result |
|---|---|---|
| `rombuild.py -j 16 --no-rom` | 0 | 106/106 exact, 11,059 reproducing, **0 mismatching** |
| `eligible.py` (bracketed vs origin/main) | 0 | 11065 / 11187; `eligible-names.txt` **byte-identical** to the origin/main baseline |
| `check_header_offsets.py --changed origin/main` | 0 | 32 headers, **0 mismatched, 0 unparsed** on every one |
| `port_refcheck.py` | 0 | 393 references, 0 stale |
| `langmode_audit.py --check` (banked chaos-data baseline) | 0 | ratchet PASS |
| `dtor_members.py --check` | 0 | GATE OK |
| `opnew_sizes.py --check` | 0 | GATE OK |
| `check_src_tu.py` | 0 | 41 TUs, 876 mangled references, all resolve |
| `pytest tools/` | 1 | 2 failed, 476 passed, 3 skipped -- **identical on origin/main** (`test_bytegate::test_no_row_is_stale`, `test_srcpath::test_enrolment_agrees_with_the_filename_convention`); pre-existing, not touched |

`test_dtor_members.py` passes in full.

## One defect found in landed work

`dtor_members.ANY_FIELD` requires the offset comment to close immediately -- `/* 0x674 */`
-- so a declaration written `/* 0x674 -- this class's own */` is **invisible to the
census**. 416 field lines across 109 headers are written that way. Ten of the 181 sites in
the `NO FIELD AT OFFSET` bucket are false because of it: the header does declare a field
there, e.g. `dScMgJump_c @0x501c` already says `Model mModel` and `ModelAnim2 @0x068`
already says `Animation otherAnim`. Nothing wrong was applied -- the effect is only
under-counting -- but `DECLARED OTHERWISE 0` cannot be trusted while this holds, since a
contradicting type written with a prose comment would not be seen either.
`tools/dtor_members.py` is not touched by this PR; filing it here so the third bucket is
re-derived against a fixed index rather than this one.
