### PR TITLE
Prove Km3 Kurumajiku text and data as one C++ TU

### DIFF
--- a/config/arm9/overlays/ov047/relocs.txt
+++ b/config/arm9/overlays/ov047/relocs.txt
@@ -207,10 +207,10 @@ from:0x021122a8 kind:load to:0x02011244 module:main
 from:0x021122ac kind:load to:0x02111254 module:overlay(47)
 from:0x021122b0 kind:load to:0x02011220 module:main
 from:0x021122b4 kind:load to:0x02011214 module:main
-from:0x021122b8 kind:load to:0x020b6b38 module:overlays(0,2)
+from:0x021122b8 kind:load to:0x020b6b38 module:overlay(2)
 from:0x021122bc kind:load to:0x02010fd4 module:main
 from:0x021122c0 kind:load to:0x02010fc8 module:main
-from:0x021122c4 kind:load to:0x020b6b10 module:overlays(0,2)
+from:0x021122c4 kind:load to:0x020b6b10 module:overlay(2)
 from:0x021122c8 kind:load to:0x02010f78 module:main
 from:0x021122cc kind:load to:0x02010f6c module:main
 from:0x021122d0 kind:load to:0x02043ac0 module:main
@@ -232,7 +232,7 @@ from:0x0211230c kind:load to:0x02010130 module:main
 from:0x02112310 kind:load to:0x0201012c module:main
 from:0x02112314 kind:load to:0x02010124 module:main
 from:0x02112318 kind:load to:0x020100dc module:main
-from:0x0211231c kind:load to:0x020ee55c module:overlays(2,7)
+from:0x0211231c kind:load to:0x020ee55c module:overlay(2)
 from:0x02112328 kind:load to:0x0209a764 module:main
 from:0x0211232c kind:load to:0x02112340 module:overlay(47)
 from:0x02112330 kind:load to:0x021091ac module:overlay(2)

--- a/config/arm9/overlays/ov047/symbols.txt
+++ b/config/arm9/overlays/ov047/symbols.txt
@@ -87,8 +87,7 @@ _ZTI21daObjKm3_Kurumajiku_c kind:data(any) addr:0x0211224c
 data_ov047_02112258 kind:data(any) addr:0x02112258
 _ZTS21daObjKm3_Kurumajiku_c kind:data(any) addr:0x02112264
 RickshawBs_SpawnInfo kind:data(any) addr:0x0211227c ambiguous
-data_ov047_02112294 kind:data(any) addr:0x02112294 ambiguous
-data_ov047_0211229c kind:data(any) addr:0x0211229c ambiguous
+data_ov047_02112298 kind:data(any) addr:0x02112298
 _ZTV21daObjKm3_Kurumajiku_c kind:data(any) addr:0x021122a0
 data_ov047_02112320 kind:data(any) addr:0x02112320
 data_ov047_02112324 kind:data(any) addr:0x02112324

--- a/config/tu_manifest.json
+++ b/config/tu_manifest.json
@@ -10476,15 +10476,20 @@
       "status": "text-verified",
       "boundary_confidence": "high",
       "boundary_evidence": [
-        "contiguous linker run: 0x21111a0..0x2111280, 4 function(s), from build/tu_map.json (tools/tu_map.py)",
-        "class label(s): daObjKm3_Kurumajiku_c",
-        "module sinit corroboration: 4 sinit(s) / 4 .ctor entries, sinit_vs_tu=ok, corroborated=False (module-wide, NOT narrowed to this one TU -- see notes/tu-reconstruction-pilot-report.md sec 2 for the by-hand narrowing step)"
+        "manually corrected contiguous linker run: 0x021111a0..0x021112bc, five functions; build/tu_map.json stopped at 0x02111280 and omitted the immediately adjacent factory RickshawBs_Spawn",
+        "RickshawBs_Spawn constructs daObjKm3_Kurumajiku_c (size 0x330, dBgActor base constructor, then daObjKurumajiku and daObjKm3_Kurumajiku vptr stores), and RickshawBs_SpawnInfo at 0x0211227c relocates directly to it inside this class's RTTI/type-name/vtable data band",
+        "one mwccarm 2004/b56 compile emits all five text contributions plus the measured class data in the retail section order; strict partitioned linkcheck proves 5/5 text contributions, the 0x02112258..0x02112320 data tail, all 106 modules, and the full stock ROM byte-identical"
       ],
       "sections": [
         {
           "name": ".text",
           "start": "0x021111a0",
-          "end": "0x02111280"
+          "end": "0x021112bc"
+        },
+        {
+          "name": ".data",
+          "start": "0x02112258",
+          "end": "0x02112320"
         }
       ],
       "functions": [
@@ -10515,12 +10520,720 @@
           "size": "0x00000018",
           "legacy_source": "src/_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv.cpp",
           "ordinal": 3
+        },
+        {
+          "symbol": "RickshawBs_Spawn",
+          "address": "0x02111280",
+          "size": "0x0000003c",
+          "legacy_source": "src/RickshawBs_Spawn.c",
+          "ordinal": 4
         }
       ],
-      "data": [],
+      "data": [
+        {
+          "symbol": "data_ov047_02112258",
+          "address": "0x02112258",
+          "size": "0xc",
+          "evidence": "three-pointer resource descriptor; all three compiler relocations match the configured ov047 destinations"
+        },
+        {
+          "symbol": "_ZTS21daObjKm3_Kurumajiku_c",
+          "address": "0x02112264",
+          "size": "0x18",
+          "evidence": "compiler-emitted type-name string matches the retail bytes"
+        },
+        {
+          "symbol": "RickshawBs_SpawnInfo",
+          "address": "0x0211227c",
+          "size": "0x1c",
+          "evidence": "typed actor descriptor; factory relocation and all priority, flag, and range words match retail"
+        },
+        {
+          "symbol": "_ZTV21daObjKm3_Kurumajiku_c",
+          "address": "0x021122a0",
+          "emitted_storage_address": "0x02112298",
+          "address_point_bias": "0x8",
+          "size": "0x88",
+          "storage_alias": {
+            "symbol": "data_ov047_02112298",
+            "address": "0x02112298",
+            "size": "0x8",
+            "binding": "STB_GLOBAL",
+            "type": "STT_OBJECT",
+            "visibility": "STV_DEFAULT",
+            "reuse_compiler_only_symbol": "_ZN21daObjKm3_Kurumajiku_cD2Ev"
+          },
+          "evidence": "compiler storage includes the two-word vtable preamble at 0x02112298; the configured public address point is eight bytes later and all 32 slot relocations match"
+        }
+      ],
+      "rodata": [],
       "bss": [],
+      "relocations": [
+        {
+          "section": ".data",
+          "source": "0x02112258",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "data_ov047_021125e8",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x021125e8"
+        },
+        {
+          "section": ".data",
+          "source": "0x0211225c",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "data_ov047_021125e0",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x021125e0"
+        },
+        {
+          "section": ".data",
+          "source": "0x02112260",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "data_ov047_02111b54",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x02111b54"
+        },
+        {
+          "section": ".data",
+          "source": "0x0211227c",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "RickshawBs_Spawn",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x02111280"
+        },
+        {
+          "section": ".data",
+          "source": "0x0211229c",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZTI21daObjKm3_Kurumajiku_c",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x0211224c"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122a0",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x02111268"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122a4",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c19BeforeInitResourcesEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02011268"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122a8",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c18AfterInitResourcesEj",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02011244"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122ac",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x02111254"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122b0",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c22BeforeCleanupResourcesEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02011220"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122b4",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c21AfterCleanupResourcesEj",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02011214"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122b8",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN17daObjKurumajiku_c8BehaviorEv",
+          "addend": 0,
+          "target_module": "ov002",
+          "target_address": "0x020b6b38"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122bc",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c14BeforeBehaviorEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010fd4"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122c0",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c13AfterBehaviorEj",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010fc8"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122c4",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN17daObjKurumajiku_c6RenderEv",
+          "addend": 0,
+          "target_module": "ov002",
+          "target_address": "0x020b6b10"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122c8",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c12BeforeRenderEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010f78"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122cc",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c11AfterRenderEj",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010f6c"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122d0",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN7fBase_c16OnPendingDestroyEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02043ac0"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122d4",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN7fBase_c9Virtual34Ejj",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x0204357c"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122d8",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN7fBase_c9Virtual38Ejj",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x0204349c"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122dc",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN7fBase_c13OnHeapCreatedEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02043494"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122e0",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN21daObjKm3_Kurumajiku_cD1Ev",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x021111a0"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122e4",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN21daObjKm3_Kurumajiku_cD0Ev",
+          "addend": 0,
+          "target_module": "ov047",
+          "target_address": "0x021111f0"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122e8",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c13OnYoshiTryEatEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010160"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122ec",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c13OnTurnIntoEggER6Player",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010154"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122f0",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c9Virtual50Ev",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x0201014c"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122f4",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c15OnGroundPoundedERS_",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010148"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122f8",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c11OnAttacked1ERS_",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010144"
+        },
+        {
+          "section": ".data",
+          "source": "0x021122fc",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c11OnAttacked2ERS_",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010140"
+        },
+        {
+          "section": ".data",
+          "source": "0x02112300",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c8OnKickedERS_",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x0201013c"
+        },
+        {
+          "section": ".data",
+          "source": "0x02112304",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c8OnPushedERS_",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010138"
+        },
+        {
+          "section": ".data",
+          "source": "0x02112308",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c24OnHitByCannonBlastedCharERS_",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010134"
+        },
+        {
+          "section": ".data",
+          "source": "0x0211230c",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c15OnHitByMegaCharER6Player",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010130"
+        },
+        {
+          "section": ".data",
+          "source": "0x02112310",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c19OnHitFromUnderneathERS_",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x0201012c"
+        },
+        {
+          "section": ".data",
+          "source": "0x02112314",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c16OnAimedAtWithEggEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x02010124"
+        },
+        {
+          "section": ".data",
+          "source": "0x02112318",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN8dActor_c25OnAimedAtWithEggReturnVecEv",
+          "addend": 0,
+          "target_module": "arm9",
+          "target_address": "0x020100dc"
+        },
+        {
+          "section": ".data",
+          "source": "0x0211231c",
+          "type": "R_ARM_ABS32",
+          "kind": "load",
+          "symbol": "_ZN10dBgActor_c4KillEv",
+          "addend": 0,
+          "target_module": "ov002",
+          "target_address": "0x020ee55c"
+        }
+      ],
+      "externalized_output": [
+        {
+          "symbol": "_ZTI7fBase_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0x8",
+          "canonical_module": "arm9",
+          "canonical_address": "0x02086d70",
+          "reason": "inherited vague RTTI copy",
+          "relocations": [
+            {
+              "offset": 0,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTVN3abi17__class_type_infoE",
+              "addend": 8,
+              "target_module": "arm9",
+              "target_address": "0x0209a774"
+            },
+            {
+              "offset": 4,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTS7fBase_c",
+              "addend": 0,
+              "target_module": "arm9",
+              "target_address": "0x02086e60"
+            }
+          ]
+        },
+        {
+          "symbol": "_ZTS7fBase_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0x9",
+          "canonical_module": "arm9",
+          "canonical_address": "0x02086e60",
+          "reason": "inherited vague RTTI copy",
+          "relocations": []
+        },
+        {
+          "symbol": "_ZTS7dBase_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0x9",
+          "canonical_module": "arm9",
+          "canonical_address": "0x02086e54",
+          "reason": "inherited vague RTTI copy",
+          "relocations": []
+        },
+        {
+          "symbol": "_ZTS8dActor_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0xa",
+          "canonical_module": "arm9",
+          "canonical_address": "0x0208e384",
+          "reason": "inherited vague RTTI copy",
+          "relocations": []
+        },
+        {
+          "symbol": "_ZTI7dBase_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0xc",
+          "canonical_module": "arm9",
+          "canonical_address": "0x02086e78",
+          "reason": "inherited vague RTTI copy",
+          "relocations": [
+            {
+              "offset": 0,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTVN3abi20__si_class_type_infoE",
+              "addend": 8,
+              "target_module": "arm9",
+              "target_address": "0x0209a764"
+            },
+            {
+              "offset": 4,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTS7dBase_c",
+              "addend": 0,
+              "target_module": "arm9",
+              "target_address": "0x02086e54"
+            },
+            {
+              "offset": 8,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTI7fBase_c",
+              "addend": 0,
+              "target_module": "arm9",
+              "target_address": "0x02086d70"
+            }
+          ]
+        },
+        {
+          "symbol": "_ZTI10dBgActor_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0xc",
+          "canonical_module": "ov002",
+          "canonical_address": "0x021089ec",
+          "reason": "inherited vague RTTI copy",
+          "relocations": [
+            {
+              "offset": 0,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTVN3abi20__si_class_type_infoE",
+              "addend": 8,
+              "target_module": "arm9",
+              "target_address": "0x0209a764"
+            },
+            {
+              "offset": 4,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTS10dBgActor_c",
+              "addend": 0,
+              "target_module": "ov002",
+              "target_address": "0x02108a04"
+            },
+            {
+              "offset": 8,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTI8dActor_c",
+              "addend": 0,
+              "target_module": "arm9",
+              "target_address": "0x0208e390"
+            }
+          ]
+        },
+        {
+          "symbol": "_ZTS10dBgActor_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0xd",
+          "canonical_module": "ov002",
+          "canonical_address": "0x02108a04",
+          "reason": "inherited vague RTTI copy",
+          "relocations": []
+        },
+        {
+          "symbol": "_ZTI8dActor_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0xc",
+          "canonical_module": "arm9",
+          "canonical_address": "0x0208e390",
+          "reason": "inherited vague RTTI copy",
+          "relocations": [
+            {
+              "offset": 0,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTVN3abi20__si_class_type_infoE",
+              "addend": 8,
+              "target_module": "arm9",
+              "target_address": "0x0209a764"
+            },
+            {
+              "offset": 4,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTS8dActor_c",
+              "addend": 0,
+              "target_module": "arm9",
+              "target_address": "0x0208e384"
+            },
+            {
+              "offset": 8,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTI7dBase_c",
+              "addend": 0,
+              "target_module": "arm9",
+              "target_address": "0x02086e78"
+            }
+          ]
+        },
+        {
+          "symbol": "_ZTI17daObjKurumajiku_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0xc",
+          "canonical_module": "ov002",
+          "canonical_address": "0x021092f8",
+          "reason": "inherited vague RTTI copy",
+          "relocations": [
+            {
+              "offset": 0,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTVN3abi20__si_class_type_infoE",
+              "addend": 8,
+              "target_module": "arm9",
+              "target_address": "0x0209a764"
+            },
+            {
+              "offset": 4,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTS17daObjKurumajiku_c",
+              "addend": 0,
+              "target_module": "ov002",
+              "target_address": "0x02109304"
+            },
+            {
+              "offset": 8,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTI10dBgActor_c",
+              "addend": 0,
+              "target_module": "ov002",
+              "target_address": "0x021089ec"
+            }
+          ]
+        },
+        {
+          "symbol": "_ZTS17daObjKurumajiku_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0x14",
+          "canonical_module": "ov002",
+          "canonical_address": "0x02109304",
+          "reason": "inherited vague RTTI copy",
+          "relocations": []
+        },
+        {
+          "symbol": "_ZTI21daObjKm3_Kurumajiku_c",
+          "disposition": "canonical-import",
+          "section": ".data",
+          "binding": "STB_LOPROC",
+          "size": "0xc",
+          "canonical_module": "ov047",
+          "canonical_address": "0x0211224c",
+          "reason": "own typeinfo remains at its exact separately gap-owned canonical home because this scratch partition claims the contiguous descriptor/type-name/SpawnInfo/vtable tail",
+          "relocations": [
+            {
+              "offset": 0,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTVN3abi20__si_class_type_infoE",
+              "addend": 8,
+              "target_module": "arm9",
+              "target_address": "0x0209a764"
+            },
+            {
+              "offset": 4,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTS21daObjKm3_Kurumajiku_c",
+              "addend": 0,
+              "target_module": "ov047",
+              "target_address": "0x02112264"
+            },
+            {
+              "offset": 8,
+              "type": "R_ARM_ABS32",
+              "kind": "load",
+              "symbol": "_ZTI17daObjKurumajiku_c",
+              "addend": 0,
+              "target_module": "ov002",
+              "target_address": "0x021092f8"
+            }
+          ]
+        }
+      ],
+      "compiler_only_output": [
+        {
+          "symbol": "_ZN21daObjKm3_Kurumajiku_cD2Ev",
+          "disposition": "deadstrip",
+          "reason": "compiler-generated base-object destructor is byte-identical to D1, has no configured ROM symbol, and has no inbound relocation"
+        }
+      ],
       "notes": [
-        "Generated by tools/tubuild.py create. See the file's own header comment for what was and was not reconciled, and notes/translation-unit-reconstruction-plan.md section 7.3 for what this generator does and does not attempt to resolve automatically."
+        "The original four-function generated candidate was incomplete. The adjacent RickshawBs_Spawn factory and its SpawnInfo data establish the corrected five-function boundary.",
+        "This scratch partition owns the contiguous data tail 0x02112258..0x02112320: resource descriptor, own type-name string, RickshawBs_SpawnInfo, and vtable storage. The own typeinfo at 0x0211224c remains at its separately gap-owned canonical home and is exact-symbol externalized, as are inherited vague RTTI copies.",
+        "The compiler-only D2 destructor is exact deadstrip evidence; the vtable is emitted at storage 0x02112298 and rebased to the repository's public address-point symbol 0x021122a0 while preserving the baseline's eight-byte storage-prefix alias.",
+        "Partitioned link verification is scratch-only: tracked src/ and config/**/delinks.txt remain authoritative and unchanged. Production promotion remains refused until the build has an equivalent supported partition/externalization/deadstrip enrollment path."
       ],
       "verification": {
         "round": "tools/tubuild.py verify -- text-only, whole shadow TU compiled once",
@@ -10528,8 +11241,8 @@
         "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
         "object": "build/tu/ov047-daObjKm3_Kurumajiku_c/daObjKm3_Kurumajiku_c.o (gitignored)",
         "comparison": "tools/match.py extract_func+compare (bytes/relocs) AND tools/objisolate.py plan() (relocation type/addend) AND tools/reloc_audit.py check_destinations() (relocation target identity)",
-        "functions_matched": 4,
-        "functions_declared": 4,
+        "functions_matched": 5,
+        "functions_declared": 5,
         "criteria": {
           "every_declared_function_defined": "PASS",
           "every_declared_function_bytes_match": "PASS",
@@ -10541,8 +11254,8 @@
       "partial_isolation": {
         "round": "tools/tubuild.py linkcheck --partial -- one compile of the consolidated source, objisolate.derive per licensed function, each derived object substituted for the production per-function object at its own existing path, then scratch dsd delink+lcf, whole-tree mwccarm, mwldarm link, linked-range and module byte comparison, dsd check symbols --fail, full ROM build",
         "delinksChanged": false,
-        "derivedObjects": 4,
-        "contributionEquivalent": "4/4",
+        "derivedObjects": 5,
+        "contributionEquivalent": "5/5",
         "comparedFields": [
           "keptSection",
           "keptBytes",
@@ -10556,9 +11269,10 @@
           "src/_ZN21daObjKm3_Kurumajiku_cD1Ev.cpp",
           "src/_ZN21daObjKm3_Kurumajiku_cD0Ev.c",
           "src/_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv.cpp",
-          "src/_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv.cpp"
+          "src/_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv.cpp",
+          "src/RickshawBs_Spawn.c"
         ],
-        "extraInertImports": 58,
+        "extraInertImports": 65,
         "extraImportsWithNoHome": [],
         "result": "partial-link-verified",
         "phases": {
@@ -10572,7 +11286,7 @@
         },
         "tuRange": {
           "start": "0x021111a0",
-          "end": "0x02111280",
+          "end": "0x021112bc",
           "differingBytes": 0,
           "firstDiff": null
         },
@@ -10586,7 +11300,733 @@
         "scratch": "build/tu/ov047-daObjKm3_Kurumajiku_c/link-partial (gitignored)",
         "state": "partial-link-verified",
         "stateMeaning": "contribution-equivalent, AND a scratch link with the N derived objects substituted at the N per-function object paths reproduces the module (and the ROM) byte-for-byte, with config/**/delinks.txt UNCHANGED",
-        "axisNote": "Orthogonal to `status` (plan sec 6). This entry's `status` describes whole-range linking; this block describes a source consolidation whose linker contribution stays per-function."
+        "axisNote": "Orthogonal to `status` (plan sec 6). This entry's `status` describes whole-range linking; this block describes a source consolidation whose linker contribution stays per-function.",
+        "legacyEntriesComplete": "5/5",
+        "artefacts": "build/tu/ov047-daObjKm3_Kurumajiku_c/partial/partial.json (gitignored)"
+      },
+      "partitioned_link": {
+        "lastAttempt": {
+          "result": "partitioned-link-verified",
+          "round": "tools/tubuild.py linkcheck --partitioned -- scratch-only additive non-text delinks entry, objisolate-derived per-function text objects, exact compiler-only/RTTI policies, exact data partition and vtable address-point rebias, whole-tree link and full-ROM comparison",
+          "trackedDelinksChanged": false,
+          "text": {
+            "toolchain": "2004/b56",
+            "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+            "mergedBytes": 7032,
+            "contributionEquivalent": "5/5",
+            "substitutedObjectPaths": [
+              "src/_ZN21daObjKm3_Kurumajiku_cD1Ev.cpp",
+              "src/_ZN21daObjKm3_Kurumajiku_cD0Ev.c",
+              "src/_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv.cpp",
+              "src/_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv.cpp",
+              "src/RickshawBs_Spawn.c"
+            ],
+            "rows": [
+              {
+                "ordinal": 0,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD1Ev",
+                "identical": true,
+                "relocCount": 6,
+                "differences": []
+              },
+              {
+                "ordinal": 1,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD0Ev",
+                "identical": true,
+                "relocCount": 8,
+                "differences": []
+              },
+              {
+                "ordinal": 2,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv",
+                "identical": true,
+                "relocCount": 2,
+                "differences": []
+              },
+              {
+                "ordinal": 3,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv",
+                "identical": true,
+                "relocCount": 2,
+                "differences": []
+              },
+              {
+                "ordinal": 4,
+                "symbol": "RickshawBs_Spawn",
+                "identical": true,
+                "relocCount": 4,
+                "differences": []
+              }
+            ]
+          },
+          "compilerOnlyPolicy": {
+            "requested": [
+              "_ZN21daObjKm3_Kurumajiku_cD2Ev"
+            ],
+            "deadstripped": [
+              "_ZN21daObjKm3_Kurumajiku_cD2Ev"
+            ],
+            "droppedSections": [
+              29,
+              30
+            ],
+            "errors": null
+          },
+          "externalizedPolicy": {
+            "requested": [
+              "_ZTI7fBase_c",
+              "_ZTS7fBase_c",
+              "_ZTS7dBase_c",
+              "_ZTS8dActor_c",
+              "_ZTI7dBase_c",
+              "_ZTI10dBgActor_c",
+              "_ZTS10dBgActor_c",
+              "_ZTI8dActor_c",
+              "_ZTI17daObjKurumajiku_c",
+              "_ZTS17daObjKurumajiku_c",
+              "_ZTI21daObjKm3_Kurumajiku_c"
+            ],
+            "externalized": [
+              "_ZTI10dBgActor_c",
+              "_ZTI17daObjKurumajiku_c",
+              "_ZTI21daObjKm3_Kurumajiku_c",
+              "_ZTI7dBase_c",
+              "_ZTI7fBase_c",
+              "_ZTI8dActor_c",
+              "_ZTS10dBgActor_c",
+              "_ZTS17daObjKurumajiku_c",
+              "_ZTS7dBase_c",
+              "_ZTS7fBase_c",
+              "_ZTS8dActor_c"
+            ],
+            "droppedSections": [
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "verificationOk": true,
+            "errors": []
+          },
+          "nontextPartition": {
+            "requestedSections": [
+              ".data"
+            ],
+            "licensedSymbols": [
+              "RickshawBs_SpawnInfo",
+              "_ZTS21daObjKm3_Kurumajiku_c",
+              "_ZTV21daObjKm3_Kurumajiku_c",
+              "data_ov047_02112258"
+            ],
+            "deferredOutputs": [
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD1Ev",
+                "section": ".text",
+                "size": "0x00000050"
+              },
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD0Ev",
+                "section": ".text",
+                "size": "0x00000064"
+              },
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv",
+                "section": ".text",
+                "size": "0x00000014"
+              },
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv",
+                "section": ".text",
+                "size": "0x00000018"
+              },
+              {
+                "symbol": "RickshawBs_Spawn",
+                "section": ".text",
+                "size": "0x0000003c"
+              }
+            ],
+            "keptSectionIndices": [
+              14,
+              24,
+              25,
+              27
+            ],
+            "droppedSectionIndices": [
+              31,
+              32,
+              33,
+              34,
+              35,
+              36,
+              37,
+              38,
+              39,
+              40
+            ],
+            "externalizedTextSymbols": [
+              "RickshawBs_Spawn",
+              "_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv",
+              "_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv",
+              "_ZN21daObjKm3_Kurumajiku_cD0Ev",
+              "_ZN21daObjKm3_Kurumajiku_cD1Ev"
+            ],
+            "deadTextSymbols": [
+              "$a",
+              "$a",
+              "$a",
+              "$a",
+              "$a",
+              "$d",
+              "$d",
+              "$d",
+              "$d",
+              "$d"
+            ],
+            "liveSections": [
+              {
+                "index": 14,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 12
+              },
+              {
+                "index": 24,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 24
+              },
+              {
+                "index": 25,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 28
+              },
+              {
+                "index": 27,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 136
+              }
+            ],
+            "error": null
+          },
+          "ownedBeforePartition": {
+            "ok": true,
+            "rows": [
+              {
+                "section": ".data",
+                "start": "0x02112258",
+                "end": "0x02112320",
+                "emittedBytes": 200,
+                "sizeOk": true,
+                "bytesOk": true,
+                "differingWords": 0,
+                "relocCount": 37
+              }
+            ],
+            "errors": []
+          },
+          "ownedAfterRebias": {
+            "ok": true,
+            "rows": [
+              {
+                "section": ".data",
+                "start": "0x02112258",
+                "end": "0x02112320",
+                "emittedBytes": 200,
+                "sizeOk": true,
+                "bytesOk": true,
+                "differingWords": 0,
+                "relocCount": 37
+              }
+            ],
+            "errors": []
+          },
+          "vtableRebias": {
+            "rebased": [
+              {
+                "symbol": "_ZTV21daObjKm3_Kurumajiku_c",
+                "bias": 8,
+                "oldValue": 0,
+                "newValue": 8,
+                "oldSize": 136,
+                "newSize": 128
+              }
+            ],
+            "aliases": [
+              {
+                "symbol": "data_ov047_02112298",
+                "donor": "_ZN21daObjKm3_Kurumajiku_cD2Ev",
+                "value": 0,
+                "size": 8,
+                "section": ".data"
+              }
+            ],
+            "error": null
+          },
+          "linkedStorageAliases": {
+            "ok": true,
+            "rows": [
+              {
+                "alias": "data_ov047_02112298",
+                "vtable": "_ZTV21daObjKm3_Kurumajiku_c",
+                "aliasMetadata": {
+                  "address": 34677400,
+                  "size": 8,
+                  "binding": "STB_GLOBAL",
+                  "type": "STT_OBJECT",
+                  "visibility": "STV_DEFAULT",
+                  "sectionIndex": 99,
+                  "section": "OV047"
+                },
+                "vtableMetadata": {
+                  "address": 34677408,
+                  "size": 128,
+                  "binding": "STB_GLOBAL",
+                  "type": "STT_OBJECT",
+                  "visibility": "STV_DEFAULT",
+                  "sectionIndex": 99,
+                  "section": "OV047"
+                },
+                "baselineElfSha256": "22619a9730d3da6814c2fdd627d440a5edc46c81c27b734c7a284ab3a8aa7392",
+                "exact": true
+              }
+            ],
+            "errors": []
+          },
+          "objectHashes": {
+            "rawTuSha256": "d495f496448f1fcc8236bd9dfc47396d838fa69358e001a93fb5a6df57b09978",
+            "rawTuBytes": 7032,
+            "tuObjectPath": "build/tu/ov047-daObjKm3_Kurumajiku_c/link-partitioned/src_tu/actors/daObjKm3_Kurumajiku_c.o",
+            "postPolicySha256": "242bff50d50bef89c552345c468fe8278fc1b0781c79b2e8ba39a4d23ddbe331",
+            "reducedStorageSha256": "fababaa11a1712005555584a64e0fcd746306ee4a18a1b20324274069c141520",
+            "linkedDataSha256": "4e9b954fc3b7dfa1cbd8a84e570006fa119db5241f28e7d49ce217cbce36de96"
+          },
+          "artifactAudit": {
+            "ok": true,
+            "errors": [],
+            "expectedTuSelectors": [
+              "daObjKm3_Kurumajiku_c.o(.data)"
+            ],
+            "observedTuSelectors": [
+              "daObjKm3_Kurumajiku_c.o(.data)"
+            ],
+            "expectedLegacyCount": 5,
+            "selectorCount": 11623,
+            "objectCount": 11416,
+            "selectorListSha256": "0624669e8b908dc2db7a12dcea73cf9a2a308c7870c6216323ac77b45c852793",
+            "objectListSha256": "56c1ba389910e4fccc23ae46c8b2f2f7014ff96a07f2a511d0afddd8c1fce096"
+          },
+          "ranges": [
+            {
+              "section": ".text",
+              "start": "0x021111a0",
+              "end": "0x021112bc",
+              "differingBytes": 0,
+              "firstDiff": null
+            },
+            {
+              "section": ".data",
+              "start": "0x02112258",
+              "end": "0x02112320",
+              "differingBytes": 0,
+              "firstDiff": null
+            }
+          ],
+          "phases": {
+            "delink": true,
+            "lcf": true,
+            "compile": true,
+            "link": true,
+            "checkModules": true,
+            "checkSymbols": false,
+            "rom": true
+          },
+          "moduleFidelityPassed": true,
+          "symbolCheckNewVsBaseline": [],
+          "rom": {
+            "bytes": 16777216,
+            "sha256": "d1506e90efae5e2d2cf119926a4ac2a291bd5ca78349d09d5024e1a918c478e8",
+            "matchesStockRom": true
+          },
+          "strayOutputs": null,
+          "scratch": "build/tu/ov047-daObjKm3_Kurumajiku_c/link-partitioned (gitignored)"
+        },
+        "state": "partitioned-link-verified",
+        "stateMeaning": "At least one scratch-only attempt compiled one shadow TU into exact ROM-ordered text partitions plus exact owned non-text data and reproduced the stock ROM. The latest attempt is recorded separately; this is never a production enrollment or promotion state.",
+        "lastVerified": {
+          "result": "partitioned-link-verified",
+          "round": "tools/tubuild.py linkcheck --partitioned -- scratch-only additive non-text delinks entry, objisolate-derived per-function text objects, exact compiler-only/RTTI policies, exact data partition and vtable address-point rebias, whole-tree link and full-ROM comparison",
+          "trackedDelinksChanged": false,
+          "text": {
+            "toolchain": "2004/b56",
+            "flags": "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off",
+            "mergedBytes": 7032,
+            "contributionEquivalent": "5/5",
+            "substitutedObjectPaths": [
+              "src/_ZN21daObjKm3_Kurumajiku_cD1Ev.cpp",
+              "src/_ZN21daObjKm3_Kurumajiku_cD0Ev.c",
+              "src/_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv.cpp",
+              "src/_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv.cpp",
+              "src/RickshawBs_Spawn.c"
+            ],
+            "rows": [
+              {
+                "ordinal": 0,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD1Ev",
+                "identical": true,
+                "relocCount": 6,
+                "differences": []
+              },
+              {
+                "ordinal": 1,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD0Ev",
+                "identical": true,
+                "relocCount": 8,
+                "differences": []
+              },
+              {
+                "ordinal": 2,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv",
+                "identical": true,
+                "relocCount": 2,
+                "differences": []
+              },
+              {
+                "ordinal": 3,
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv",
+                "identical": true,
+                "relocCount": 2,
+                "differences": []
+              },
+              {
+                "ordinal": 4,
+                "symbol": "RickshawBs_Spawn",
+                "identical": true,
+                "relocCount": 4,
+                "differences": []
+              }
+            ]
+          },
+          "compilerOnlyPolicy": {
+            "requested": [
+              "_ZN21daObjKm3_Kurumajiku_cD2Ev"
+            ],
+            "deadstripped": [
+              "_ZN21daObjKm3_Kurumajiku_cD2Ev"
+            ],
+            "droppedSections": [
+              29,
+              30
+            ],
+            "errors": null
+          },
+          "externalizedPolicy": {
+            "requested": [
+              "_ZTI7fBase_c",
+              "_ZTS7fBase_c",
+              "_ZTS7dBase_c",
+              "_ZTS8dActor_c",
+              "_ZTI7dBase_c",
+              "_ZTI10dBgActor_c",
+              "_ZTS10dBgActor_c",
+              "_ZTI8dActor_c",
+              "_ZTI17daObjKurumajiku_c",
+              "_ZTS17daObjKurumajiku_c",
+              "_ZTI21daObjKm3_Kurumajiku_c"
+            ],
+            "externalized": [
+              "_ZTI10dBgActor_c",
+              "_ZTI17daObjKurumajiku_c",
+              "_ZTI21daObjKm3_Kurumajiku_c",
+              "_ZTI7dBase_c",
+              "_ZTI7fBase_c",
+              "_ZTI8dActor_c",
+              "_ZTS10dBgActor_c",
+              "_ZTS17daObjKurumajiku_c",
+              "_ZTS7dBase_c",
+              "_ZTS7fBase_c",
+              "_ZTS8dActor_c"
+            ],
+            "droppedSections": [
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "verificationOk": true,
+            "errors": []
+          },
+          "nontextPartition": {
+            "requestedSections": [
+              ".data"
+            ],
+            "licensedSymbols": [
+              "RickshawBs_SpawnInfo",
+              "_ZTS21daObjKm3_Kurumajiku_c",
+              "_ZTV21daObjKm3_Kurumajiku_c",
+              "data_ov047_02112258"
+            ],
+            "deferredOutputs": [
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD1Ev",
+                "section": ".text",
+                "size": "0x00000050"
+              },
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_cD0Ev",
+                "section": ".text",
+                "size": "0x00000064"
+              },
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv",
+                "section": ".text",
+                "size": "0x00000014"
+              },
+              {
+                "symbol": "_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv",
+                "section": ".text",
+                "size": "0x00000018"
+              },
+              {
+                "symbol": "RickshawBs_Spawn",
+                "section": ".text",
+                "size": "0x0000003c"
+              }
+            ],
+            "keptSectionIndices": [
+              14,
+              24,
+              25,
+              27
+            ],
+            "droppedSectionIndices": [
+              31,
+              32,
+              33,
+              34,
+              35,
+              36,
+              37,
+              38,
+              39,
+              40
+            ],
+            "externalizedTextSymbols": [
+              "RickshawBs_Spawn",
+              "_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv",
+              "_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv",
+              "_ZN21daObjKm3_Kurumajiku_cD0Ev",
+              "_ZN21daObjKm3_Kurumajiku_cD1Ev"
+            ],
+            "deadTextSymbols": [
+              "$a",
+              "$a",
+              "$a",
+              "$a",
+              "$a",
+              "$d",
+              "$d",
+              "$d",
+              "$d",
+              "$d"
+            ],
+            "liveSections": [
+              {
+                "index": 14,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 12
+              },
+              {
+                "index": 24,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 24
+              },
+              {
+                "index": 25,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 28
+              },
+              {
+                "index": 27,
+                "name": ".data",
+                "type": "SHT_PROGBITS",
+                "size": 136
+              }
+            ],
+            "error": null
+          },
+          "ownedBeforePartition": {
+            "ok": true,
+            "rows": [
+              {
+                "section": ".data",
+                "start": "0x02112258",
+                "end": "0x02112320",
+                "emittedBytes": 200,
+                "sizeOk": true,
+                "bytesOk": true,
+                "differingWords": 0,
+                "relocCount": 37
+              }
+            ],
+            "errors": []
+          },
+          "ownedAfterRebias": {
+            "ok": true,
+            "rows": [
+              {
+                "section": ".data",
+                "start": "0x02112258",
+                "end": "0x02112320",
+                "emittedBytes": 200,
+                "sizeOk": true,
+                "bytesOk": true,
+                "differingWords": 0,
+                "relocCount": 37
+              }
+            ],
+            "errors": []
+          },
+          "vtableRebias": {
+            "rebased": [
+              {
+                "symbol": "_ZTV21daObjKm3_Kurumajiku_c",
+                "bias": 8,
+                "oldValue": 0,
+                "newValue": 8,
+                "oldSize": 136,
+                "newSize": 128
+              }
+            ],
+            "aliases": [
+              {
+                "symbol": "data_ov047_02112298",
+                "donor": "_ZN21daObjKm3_Kurumajiku_cD2Ev",
+                "value": 0,
+                "size": 8,
+                "section": ".data"
+              }
+            ],
+            "error": null
+          },
+          "linkedStorageAliases": {
+            "ok": true,
+            "rows": [
+              {
+                "alias": "data_ov047_02112298",
+                "vtable": "_ZTV21daObjKm3_Kurumajiku_c",
+                "aliasMetadata": {
+                  "address": 34677400,
+                  "size": 8,
+                  "binding": "STB_GLOBAL",
+                  "type": "STT_OBJECT",
+                  "visibility": "STV_DEFAULT",
+                  "sectionIndex": 99,
+                  "section": "OV047"
+                },
+                "vtableMetadata": {
+                  "address": 34677408,
+                  "size": 128,
+                  "binding": "STB_GLOBAL",
+                  "type": "STT_OBJECT",
+                  "visibility": "STV_DEFAULT",
+                  "sectionIndex": 99,
+                  "section": "OV047"
+                },
+                "baselineElfSha256": "22619a9730d3da6814c2fdd627d440a5edc46c81c27b734c7a284ab3a8aa7392",
+                "exact": true
+              }
+            ],
+            "errors": []
+          },
+          "objectHashes": {
+            "rawTuSha256": "d495f496448f1fcc8236bd9dfc47396d838fa69358e001a93fb5a6df57b09978",
+            "rawTuBytes": 7032,
+            "tuObjectPath": "build/tu/ov047-daObjKm3_Kurumajiku_c/link-partitioned/src_tu/actors/daObjKm3_Kurumajiku_c.o",
+            "postPolicySha256": "242bff50d50bef89c552345c468fe8278fc1b0781c79b2e8ba39a4d23ddbe331",
+            "reducedStorageSha256": "fababaa11a1712005555584a64e0fcd746306ee4a18a1b20324274069c141520",
+            "linkedDataSha256": "4e9b954fc3b7dfa1cbd8a84e570006fa119db5241f28e7d49ce217cbce36de96"
+          },
+          "artifactAudit": {
+            "ok": true,
+            "errors": [],
+            "expectedTuSelectors": [
+              "daObjKm3_Kurumajiku_c.o(.data)"
+            ],
+            "observedTuSelectors": [
+              "daObjKm3_Kurumajiku_c.o(.data)"
+            ],
+            "expectedLegacyCount": 5,
+            "selectorCount": 11623,
+            "objectCount": 11416,
+            "selectorListSha256": "0624669e8b908dc2db7a12dcea73cf9a2a308c7870c6216323ac77b45c852793",
+            "objectListSha256": "56c1ba389910e4fccc23ae46c8b2f2f7014ff96a07f2a511d0afddd8c1fce096"
+          },
+          "ranges": [
+            {
+              "section": ".text",
+              "start": "0x021111a0",
+              "end": "0x021112bc",
+              "differingBytes": 0,
+              "firstDiff": null
+            },
+            {
+              "section": ".data",
+              "start": "0x02112258",
+              "end": "0x02112320",
+              "differingBytes": 0,
+              "firstDiff": null
+            }
+          ],
+          "phases": {
+            "delink": true,
+            "lcf": true,
+            "compile": true,
+            "link": true,
+            "checkModules": true,
+            "checkSymbols": false,
+            "rom": true
+          },
+          "moduleFidelityPassed": true,
+          "symbolCheckNewVsBaseline": [],
+          "rom": {
+            "bytes": 16777216,
+            "sha256": "d1506e90efae5e2d2cf119926a4ac2a291bd5ca78349d09d5024e1a918c478e8",
+            "matchesStockRom": true
+          },
+          "strayOutputs": null,
+          "scratch": "build/tu/ov047-daObjKm3_Kurumajiku_c/link-partitioned (gitignored)"
+        }
       }
     },
     {

--- a/src_tu/actors/daObjKm3_Kurumajiku_c.cpp
+++ b/src_tu/actors/daObjKm3_Kurumajiku_c.cpp
@@ -1,9 +1,9 @@
 //cpp
 /* Manually curated shadow translation unit.
- * ov047/daObjKm3_Kurumajiku_c  (4 function(s))
+ * ov047/daObjKm3_Kurumajiku_c  (5 function(s))
  *
  * NOT ENROLLED and NOT CANONICAL. The readable class and member definitions
- * are compiled only by tubuild's scratch pipeline while the four legacy
+ * are compiled only by tubuild's scratch pipeline while the five legacy
  * production sources remain authoritative.
  *
  * FUNCTION ORDER IS DELIBERATELY THE REVERSE OF THE ROM'S -- mwccarm 2004/b56
@@ -17,21 +17,84 @@
  *   [1] 0x021111f0  src/_ZN21daObjKm3_Kurumajiku_cD0Ev.c
  *   [2] 0x02111254  src/_ZN21daObjKm3_Kurumajiku_c16CleanupResourcesEv.cpp
  *   [3] 0x02111268  src/_ZN21daObjKm3_Kurumajiku_c13InitResourcesEv.cpp
+ *   [4] 0x02111280  src/RickshawBs_Spawn.c
  */
-
-#include "daObjKm3_Kurumajiku_c.h"
 
 struct ResourceDescriptor {
     void *entries[3];
 };
 
 extern "C" {
+extern char data_ov047_021125e8[];
+extern char data_ov047_021125e0[];
+extern char data_ov047_02111b54[];
+}
+
+/* Keep this definition before the class header. mwcc emits these dedicated
+ * data sections in declaration order, and retail places this descriptor
+ * before the class type name, SpawnInfo, and vtable storage. */
+extern "C" ResourceDescriptor data_ov047_02112258 = {
+    data_ov047_021125e8,
+    data_ov047_021125e0,
+    data_ov047_02111b54
+};
+
+#include "daObjKm3_Kurumajiku_c.h"
+
+struct Km3SpawnInfo {
+    daObjKm3_Kurumajiku_c *(*spawn)();
+    s16 behaviorPriority;
+    s16 renderPriority;
+    u32 flags;
+    Fix12i rangeOffsetY;
+    Fix12i range;
+    Fix12i drawDistance;
+    u32 unk_18;
+};
+
+typedef char Km3SpawnInfo_size_must_be_0x1c[
+    sizeof(Km3SpawnInfo) == 0x1c ? 1 : -1];
+
+extern "C" {
+extern void *_ZN7fBase_cnwEj(unsigned size);
+extern void _ZN10dBgActor_cC2Ev(void *self);
+extern int _ZTV17daObjKurumajiku_c[];
+extern int _ZTV21daObjKm3_Kurumajiku_c[];
 int func_ov002_020b6ac8(daObjKm3_Kurumajiku_c *self,
                         ResourceDescriptor *descriptor);
 int func_ov002_020b6c54(daObjKm3_Kurumajiku_c *self,
                         ResourceDescriptor *descriptor, unsigned actorID);
-extern ResourceDescriptor data_ov047_02112258;
 }
+
+/* ROM ordinal 4 -- RickshawBs_Spawn, 0x02111280, size 0x3c */
+// @symbol RickshawBs_Spawn
+/* The object table calls this historical name, but its two vptr stores prove
+ * that it constructs daObjKm3_Kurumajiku_c. */
+extern "C" daObjKm3_Kurumajiku_c *RickshawBs_Spawn()
+{
+    daObjKm3_Kurumajiku_c *actor =
+        static_cast<daObjKm3_Kurumajiku_c *>(_ZN7fBase_cnwEj(0x330));
+
+    if (actor) {
+        _ZN10dBgActor_cC2Ev(actor);
+        *reinterpret_cast<int *>(actor) = (int)_ZTV17daObjKurumajiku_c;
+        *reinterpret_cast<int *>(actor) =
+            (int)&_ZTV21daObjKm3_Kurumajiku_c[2];
+    }
+
+    return actor;
+}
+
+extern "C" Km3SpawnInfo RickshawBs_SpawnInfo = {
+    RickshawBs_Spawn,
+    0x0098,
+    0x00df,
+    2,
+    0,
+    0x00300000,
+    0x01000000,
+    0
+};
 
 /* -------------------------------------------------------------------------- */
 /* ROM ordinal 3 -- _ZN21daObjKm3_Kurumajiku_c13InitResourcesEv, 0x02111268, size 0x18 */


### PR DESCRIPTION
## Summary

Stacked on #1694.

- correct the daObjKm3_Kurumajiku_c TU boundary to include the adjacent RickshawBs_Spawn factory
- add readable typed factory, resource descriptor, SpawnInfo, type-name, and vtable data to the shadow C++ TU
- record exact scratch-only partition evidence for five text contributions and the contiguous 0x02112258..0x02112320 data tail
- correct the vtable storage-prefix symbol boundary and narrow three relocation modules to their unique ov002 destinations

This does not enroll the TU: src/ and config/**/delinks.txt remain unchanged, and promotion is explicitly refused until production supports the same partition/externalization/deadstrip path.

## Validation

- 	ubuild linkcheck --baseline: 11,059/11,059, 106/106 modules, stock ROM hash identical; only the seven pre-existing ARM9/ITCM symbol errors
- 	ubuild linkcheck --partial: 5/5 contribution-equivalent, identical TU range and stock ROM
- 	ubuild linkcheck --partitioned: 5/5 text, 0xc8 data with 37 exact relocations, storage alias 1/1, 106/106 modules, zero new symbol errors, identical stock ROM
- 	ubuild promote --dry-run: refused as intended
- port_refcheck.py: 393 references, all resolved
- git diff --check: clean