### PR TITLE
Migrate seven remaining class methods to real C++ (batch 12)

### DIFF
--- a/include/ArrowSignRight.h
+++ b/include/ArrowSignRight.h
@@ -31,6 +31,7 @@ struct ArrowSignRight : dBgActor_c {
 
     int Behavior();
     int CleanupResources();
+    int InitResources();
     int Render();
     virtual int  OnAttacked1(dActor_c &other);      /* slot 22 */
     virtual void OnHitByMegaChar(Player &player);   /* slot 27 */

--- a/include/LavaPlank.h
+++ b/include/LavaPlank.h
@@ -26,6 +26,7 @@ struct LavaPlank : dBgActor_c {
     /* --- vtable --- */
     virtual ~LavaPlank();
 
+    int Behavior();
     int CleanupResources();
     int InitResources();
     int Render();

--- a/include/SlidingIce.h
+++ b/include/SlidingIce.h
@@ -30,6 +30,7 @@ struct SlidingIce : dBgActor_c {
 
     int Behavior();
     int CleanupResources();
+    int InitResources();
     int Render();
 
     virtual void OnHitByMegaChar(Player &player);   /* slot 27 */

--- a/include/StarSwitch.h
+++ b/include/StarSwitch.h
@@ -45,6 +45,7 @@ struct StarSwitch : dBgActor_c {
 
     int Behavior();
     int CleanupResources();
+    int InitResources();
     int Render();
     void OnGroundPounded(dActor_c &other);
 };

--- a/src/_ZN10SlidingIce13InitResourcesEv.cpp
+++ b/src/_ZN10SlidingIce13InitResourcesEv.cpp
@@ -1,39 +1,46 @@
 //cpp
-#include "dBgW.h"
+#include "SlidingIce.h"
+
 extern "C" {
-extern int _ZN5Model8LoadFileER13SharedFilePtr(void *);
-extern int _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void *);
-extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, int, int, int);
-extern void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *);
-extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *);
-extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, int, void *, int, int, void *);
-extern void func_020393d4(int *p, int v);
+int _ZN5Model8LoadFileER13SharedFilePtr(void *);
+int _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void *);
+int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, int, int, int);
+void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *);
+void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *);
+void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+    void *, int, void *, int, int, void *);
+void func_020393d4(int *p, int v);
 extern int data_ov027_02113be8[];
 extern char data_ov027_02113be0[];
 extern char data_ov027_02113108[];
 extern int _ZN4dBgW21UpdatePosWithVelocityERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_[];
-int _ZN10SlidingIce13InitResourcesEv(char *c){
-  _ZN5Model8LoadFileER13SharedFilePtr(data_ov027_02113be8);
-  _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov027_02113be0);
-  int on = (*(unsigned short*)(c+0xc)==0x5d);
-  if(on){
-    if(_ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, data_ov027_02113be8[1], 1, -1)==0)
-      return 0;
-    _ZN10dBgActor_c21UpdateModelPosAndRotYEv(c);
-    _ZN10dBgActor_c19UpdateClsnPosAndRotEv(c);
-    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c+0x124, *(int*)(data_ov027_02113be0+4), c+0x2ec, 0x1000, *(short*)(c+0x8e), data_ov027_02113108);
-    func_020393d4((int*)(c+0x124), (int)_ZN4dBgW21UpdatePosWithVelocityERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
-    *(char*)(c+0x170) = 0;
-    ((dBgW *)(c+0x124))->Enable((dActor_c *)(c));
-    *(int*)(c+0x98) = 0x2d000;
-    *(short*)(c+0x31e) = 0x64;
-    *(short*)(c+0x94) = -0x4000;
-    *(int*)(c+0x324) = *(int*)(c+0x60) - 0xc8000;
-  } else {
-    *(short*)(c+0x31e) = *(unsigned char*)(c+0x320) * 0x14;
-    *(char*)(c+0x320) = 5;
-  }
-  return 1;
 }
+
+int SlidingIce::InitResources()
+{
+    _ZN5Model8LoadFileER13SharedFilePtr(data_ov027_02113be8);
+    _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov027_02113be0);
+
+    int on = (actorID == 0x5d);
+    if (on) {
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(&mModel, data_ov027_02113be8[1], 1, -1) == 0)
+            return 0;
+        _ZN10dBgActor_c21UpdateModelPosAndRotYEv(this);
+        _ZN10dBgActor_c19UpdateClsnPosAndRotEv(this);
+        _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+            &mMeshCollider, *(int *)(data_ov027_02113be0 + 4), &mClsnMat,
+            0x1000, mAngleY, data_ov027_02113108);
+        func_020393d4((int *)&mMeshCollider,
+            (int)_ZN4dBgW21UpdatePosWithVelocityERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
+        mMeshCollider.unk_4c = 0;
+        mMeshCollider.Enable(this);
+        mHorzSpeed = 0x2d000;
+        unk_31e = 0x64;
+        mPrevAngleY = -0x4000;
+        mMinPosY = mPosY - 0xc8000;
+    } else {
+        unk_31e = (u8)mNumToBigIce * 0x14;
+        mNumToBigIce = 5;
+    }
+    return 1;
 }

--- a/src/_ZN10StarSwitch13InitResourcesEv.cpp
+++ b/src/_ZN10StarSwitch13InitResourcesEv.cpp
@@ -1,77 +1,82 @@
 //cpp
-#include "types.h"
-extern "C" void LoadSilverStarAndNumber(void);
-extern "C" int _ZN5Model8LoadFileER13SharedFilePtr(int p);
-extern "C" void _ZN5Event8ClearBitEj(unsigned int b);
-extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, int f, int a, int b);
-extern "C" void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *self);
-extern "C" void func_ov002_020b9f80(char *self);
-extern "C" int _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(int p);
-extern "C" void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+#include "StarSwitch.h"
+
+extern "C" {
+void LoadSilverStarAndNumber(void);
+int _ZN5Model8LoadFileER13SharedFilePtr(int p);
+void _ZN5Event8ClearBitEj(unsigned int b);
+void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, int f, int a, int b);
+void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *self);
+void func_ov002_020b9f80(char *self);
+int _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(int p);
+void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *self, int f, void *mtx, int fix, s16 s, int clps);
-extern "C" void func_020393c4(void *p, void *v);
+void func_020393c4(void *p, void *v);
 
-extern "C" int data_ov002_0211092c;
-extern "C" char data_ov002_021098e8[];
-extern "C" char data_ov002_021098ec[];
-extern "C" char data_ov002_021098f0[];
-extern "C" int func_ov002_020baa98;
+extern int data_ov002_0211092c;
+extern char data_ov002_021098e8[];
+extern char data_ov002_021098ec[];
+extern char data_ov002_021098f0[];
+extern int func_ov002_020baa98;
+}
 
-extern "C" int _ZN10StarSwitch13InitResourcesEv(char *c) {
+int StarSwitch::InitResources()
+{
     u8 idx;
     int f;
 
-    *(int*)(c + 0x320) = 0x1000;
-    *(int*)(c + 0x324) = 0x1000;
-    *(int*)(c + 0x328) = 0x1000;
-    *(int*)(c + 0x344) = 0;
-    *(int*)(c + 0x348) = 0;
-    *(u8*)(c + 0x353) = *(signed char*)(c + 0xcc);
+    unk_320 = 0x1000;
+    unk_324 = 0x1000;
+    unk_328 = 0x1000;
+    mTargetActorID = 0;
+    unk_348 = 0;
+    unk_353 = mAreaId;
 
     {
         int b = 0;
-        if (*(u16*)(c + 0xc) == 0xc) b = 1;
+        if (actorID == 0xc) b = 1;
         if (b) {
-            *(int*)(c + 0xb0) |= 0x4000000;
-            *(int*)(c + 0x33c) = 2;
-            *(u8*)(c + 0x351) = *(unsigned int*)(c + 8);
-            if (*(u8*)(c + 0x351) == 0xff)
-                *(u8*)(c + 0x351) = 0;
-            *(u16*)(c + 0x33a) = (*(unsigned int*)(c + 8) >> 8) & 0xff;
+            mFlags |= 0x4000000;
+            unk_33c = 2;
+            unk_351 = param1;
+            if (unk_351 == 0xff)
+                unk_351 = 0;
+            unk_33a = (param1 >> 8) & 0xff;
             LoadSilverStarAndNumber();
             _ZN5Model8LoadFileER13SharedFilePtr((int)&data_ov002_0211092c);
-            *(u8*)(c + 0x34c) = 1;
+            unk_34c = 1;
         } else {
-            *(int*)(c + 0x33c) = *(unsigned int*)(c + 8) & 3;
-            *(u8*)(c + 0x34e) = (*(unsigned int*)(c + 8) >> 3) & 0xf;
-            *(u16*)(c + 0x33a) = (*(unsigned int*)(c + 8) >> 8) & 0xff;
-            _ZN5Event8ClearBitEj(*(u8*)(c + 0x34e));
-            *(u8*)(c + 0x34c) = 0;
+            unk_33c = param1 & 3;
+            unk_34e = (param1 >> 3) & 0xf;
+            unk_33a = (param1 >> 8) & 0xff;
+            _ZN5Event8ClearBitEj(unk_34e);
+            unk_34c = 0;
         }
     }
 
-    idx = *(u8*)(c + 0x34c);
+    idx = unk_34c;
     f = _ZN5Model8LoadFileER13SharedFilePtr(*(int*)(data_ov002_021098e8 + idx * 0xc));
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, f, 1, -1);
-    _ZN10dBgActor_c21UpdateModelPosAndRotYEv(c);
-    func_ov002_020b9f80(c);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(&mModel, f, 1, -1);
+    _ZN10dBgActor_c21UpdateModelPosAndRotYEv(this);
+    func_ov002_020b9f80((char *)this);
 
-    idx = *(u8*)(c + 0x34c);
+    idx = unk_34c;
     f = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(*(int*)(data_ov002_021098ec + idx * 0xc));
     _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124, f, c + 0x2ec, 0x199, *(s16*)(c + 0x8e), *(int*)(data_ov002_021098f0 + idx * 0xc));
+        &mMeshCollider, f, &mClsnMat, 0x199, mAngleY,
+        *(int*)(data_ov002_021098f0 + idx * 0xc));
 
-    func_020393c4(c + 0x124, &func_ov002_020baa98);
+    func_020393c4(&mMeshCollider, &func_ov002_020baa98);
 
     {
-        u16 h = *(u16*)(c + 0x300 + 0x3a);
+        u16 h = unk_33a;
         if (h == 0xff || h == 0)
-            *(u16*)(c + 0x300 + 0x3a) = 0x190;
+            unk_33a = 0x190;
         else
-            *(u16*)(c + 0x33a) *= 0xa;
+            unk_33a *= 0xa;
     }
-    *(u8*)(c + 0x34f) = 5;
-    *(int*)(c + 0x60) += 0x5000;
-    *(u8*)(c + 0x34d) = 1;
+    unk_34f = 5;
+    mPosY += 0x5000;
+    unk_34d = 1;
     return 1;
 }

--- a/src/_ZN11CannonHatch8BehaviorEv.cpp
+++ b/src/_ZN11CannonHatch8BehaviorEv.cpp
@@ -1,44 +1,39 @@
 //cpp
-typedef unsigned char u8;
-typedef short s16;
-
-struct Vector3 { int x, y, z; };
+#include "CannonHatch.h"
 
 extern "C" {
 char *_ZN8dActor_c13ClosestPlayerEv(char *self);
-int _ZN10dBgActor_c21IsClsnInRangeOnScreenE5Fix12IiES1_(char *c, int a, int b);
-void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(char *c);
-void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(char *c);
-int _ZN4dBgW9IsEnabledEv(char *c);
-void _ZN4dBgW7DisableEv(char *c);
+int _ZN10dBgActor_c21IsClsnInRangeOnScreenE5Fix12IiES1_(void *self, int a, int b);
+void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *self);
+void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *self);
 void Matrix4x3_FromRotationY(void *m, int angle);
 void MulVec3Mat4x3(Vector3 *v, void *m, Vector3 *dst);
 void AddVec3(Vector3 *a, Vector3 *b, Vector3 *d);
 int Vec3_Dist(void *a, void *b);
 int Vec3_HorzDist(void *a, void *b);
-char *_ZN8dActor_c15FindWithActorIDEjPS_(unsigned int id, char *p);
-extern char data_020a0e68[];
+CannonHatch *_ZN8dActor_c15FindWithActorIDEjPS_(unsigned int id, CannonHatch *after);
+extern Matrix4x3 data_020a0e68;
 }
 
-extern "C" int _ZN11CannonHatch8BehaviorEv(char *c)
+int CannonHatch::Behavior()
 {
-    if (*(u8 *)(c + 0x32e) != 0) {
-        if (*(u8 *)(_ZN8dActor_c13ClosestPlayerEv(c) + 0x703) != 0) {
-            *(int *)(c + 0x5c) = *(int *)(c + 0x320);
-            *(int *)(c + 0x60) = *(int *)(c + 0x324);
-            *(int *)(c + 0x64) = *(int *)(c + 0x328);
-            if (_ZN10dBgActor_c21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0)) {
-                _ZN10dBgActor_c21UpdateModelPosAndRotYEv(c);
-                _ZN10dBgActor_c19UpdateClsnPosAndRotEv(c);
+    if (unk_32e != 0) {
+        if (*(u8 *)(_ZN8dActor_c13ClosestPlayerEv((char *)this) + 0x703) != 0) {
+            mPosX = unk_320;
+            mPosY = unk_324;
+            mPosZ = unk_328;
+            if (_ZN10dBgActor_c21IsClsnInRangeOnScreenE5Fix12IiES1_(this, 0, 0)) {
+                _ZN10dBgActor_c21UpdateModelPosAndRotYEv(this);
+                _ZN10dBgActor_c19UpdateClsnPosAndRotEv(this);
             }
         } else {
-            if (_ZN4dBgW9IsEnabledEv(c + 0x124)) {
-                _ZN4dBgW7DisableEv(c + 0x124);
+            if (mMeshCollider.IsEnabled()) {
+                mMeshCollider.Disable();
             }
         }
         return 1;
     }
-    if (*(u8 *)(c + 0x32c) != 0) {
+    if (unk_32c != 0) {
         Vector3 in;
         Vector3 out;
         in.x = 0;
@@ -47,28 +42,28 @@ extern "C" int _ZN11CannonHatch8BehaviorEv(char *c)
         out.x = 0;
         out.y = 0;
         out.z = 0;
-        if (*(u8 *)(c + 0x32d) != 0) {
-            if (*(u8 *)(c + 0x32d) == 1) in.z = 0x2000;
+        if (unk_32d != 0) {
+            if (unk_32d == 1) in.z = 0x2000;
         } else {
             in.y = -0x1000;
         }
-        Matrix4x3_FromRotationY(data_020a0e68, *(s16 *)(c + 0x8e));
-        MulVec3Mat4x3(&in, data_020a0e68, &out);
-        AddVec3((Vector3 *)(c + 0x5c), &out, (Vector3 *)(c + 0x5c));
-        if (Vec3_Dist((void *)(c + 0x320), (void *)(c + 0x5c)) > 0xa000) {
-            *(u8 *)(c + 0x32d) = 1;
+        Matrix4x3_FromRotationY(&data_020a0e68, mAngleY);
+        MulVec3Mat4x3(&in, &data_020a0e68, &out);
+        AddVec3((Vector3 *)&mPosX, &out, (Vector3 *)&mPosX);
+        if (Vec3_Dist(&unk_320, &mPosX) > 0xa000) {
+            unk_32d = 1;
         }
-        if (Vec3_HorzDist((void *)(c + 0x320), (void *)(c + 0x5c)) > 0xc8000) {
-            char *a = _ZN8dActor_c15FindWithActorIDEjPS_(0xe, 0);
+        if (Vec3_HorzDist(&unk_320, &mPosX) > 0xc8000) {
+            CannonHatch *a = _ZN8dActor_c15FindWithActorIDEjPS_(0xe, 0);
             while (a != 0) {
-                *(u8 *)(a + 0x32e) = 1;
+                a->unk_32e = 1;
                 a = _ZN8dActor_c15FindWithActorIDEjPS_(0xe, a);
             }
         }
-        _ZN10dBgActor_c21UpdateModelPosAndRotYEv(c);
+        _ZN10dBgActor_c21UpdateModelPosAndRotYEv(this);
     }
-    if (_ZN10dBgActor_c21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0)) {
-        _ZN10dBgActor_c19UpdateClsnPosAndRotEv(c);
+    if (_ZN10dBgActor_c21IsClsnInRangeOnScreenE5Fix12IiES1_(this, 0, 0)) {
+        _ZN10dBgActor_c19UpdateClsnPosAndRotEv(this);
     }
     return 1;
 }

--- a/src/_ZN12FortressWall8BehaviorEv.cpp
+++ b/src/_ZN12FortressWall8BehaviorEv.cpp
@@ -1,53 +1,37 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+#include "FortressWall.h"
 
-struct dBgW {
-    int IsEnabled();
-    void Disable();
-};
+namespace Sound {
+int PlaySecretSound(dActor_c *actor, u16 *state);
+}
 
-struct dActor_c;
-namespace Sound { int PlaySecretSound(dActor_c *a, unsigned short *p); }
+extern "C" void func_020393a4(int *collider, int range);
 
-struct dActor_c {
-    static dActor_c *Spawn(unsigned int id, unsigned int param, const Vector3 &pos, const Vector3_16 *rot, signed char a, short b);
-};
-struct fBase_c {
-    void MarkForDestruction();
-};
-
-extern "C" void func_020393a4(int *p, int v);
-
-struct dBgActor_c : fBase_c {
-    int IsClsnInRange(int a, int b);
-};
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
 extern "C" int _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void *, int a, int b);
 
-
-extern "C" int _ZN12FortressWall8BehaviorEv(dBgActor_c *self) {
-    int ok = (*(unsigned short *)((char *)self + 0xc) == 0x30);
-    if (ok != 0 && *(unsigned char *)((char *)self + 0x321) != 0) {
-        if (((dBgW *)((char *)self + 0x124))->IsEnabled() != 0) {
-            ((dBgW *)((char *)self + 0x124))->Disable();
+int FortressWall::Behavior()
+{
+    int ok = (actorID == 0x30);
+    if (ok != 0 && unk_321 != 0) {
+        if (mMeshCollider.IsEnabled() != 0) {
+            mMeshCollider.Disable();
         }
-        if (Sound::PlaySecretSound((dActor_c *)self, (unsigned short *)((char *)self + 0x322)) != 0) {
+        if (Sound::PlaySecretSound(this, (u16 *)&unk_322) != 0) {
             Vector3 pos;
-            pos.x = *(int *)((char *)self + 0x5c);
-            pos.y = *(int *)((char *)self + 0x60);
-            pos.z = *(int *)((char *)self + 0x64);
+            pos.x = mPosX;
+            pos.y = mPosY;
+            pos.z = mPosZ;
             pos.y += 0xc8000;
-            dActor_c::Spawn(0xb2, *(unsigned char *)((char *)self + 0x31f) | 0x40,
-                         pos, (Vector3_16 *)0, *(signed char *)((char *)self + 0xcc), -1);
-            ((fBase_c *)self)->MarkForDestruction();
+            dActor_c::Spawn(0xb2, unk_31f | 0x40, pos, (Vector3_16 *)0, mAreaId, -1);
+            MarkForDestruction();
         }
         return 1;
     }
-    func_020393a4((int *)((char *)self + 0x124), 0x240000);
-    _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(self, 0x240000, 0);
+    func_020393a4((int *)&mMeshCollider, 0x240000);
+    _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(this, 0x240000, 0);
     return 1;
 }

--- a/src/_ZN14ArrowSignRight13InitResourcesEv.cpp
+++ b/src/_ZN14ArrowSignRight13InitResourcesEv.cpp
@@ -1,36 +1,52 @@
 //cpp
+#include "ArrowSignRight.h"
+
+struct ArrowSignFileColumn {
+    void *value;
+    void *nextColumn1;
+    void *nextColumn2;
+};
+
 extern "C" {
-extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
-extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* bmd, int a, int b);
-extern void _ZN11ShadowModel10InitCuboidEv(void* self);
-extern void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void* self);
-extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void* self);
-extern void func_ov098_02137c8c(char* t);
-extern void* _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void* fp);
-extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, void* kcl, void* mtx, int fix, short s, void* clps);
+void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
+void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmd, int a, int b);
+void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *self);
+void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *self);
+void func_ov098_02137c8c(char *self);
+void *_ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void *fp);
+void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+    void *self, void *kcl, void *mtx, int scale, short angle, void *clps);
 
-struct Entry { void* a; void* b; void* c; };
-extern struct Entry data_ov098_0213c380[];
-
-int _ZN14ArrowSignRight13InitResourcesEv(char* c){
-  unsigned short field = *(unsigned short*)(c+0xc);
-  if(field != 0x12b){
-    if(field == 0x12c)
-      *(unsigned char*)(c+0x37c) = 1;
-  } else {
-    *(unsigned char*)(c+0x37c) = 0;
-  }
-  unsigned int idx = *(unsigned char*)(c+0x37c);
-  void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov098_0213c380[idx].a);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
-  _ZN11ShadowModel10InitCuboidEv(c+0x320);
-  _ZN10dBgActor_c21UpdateModelPosAndRotYEv(c);
-  _ZN10dBgActor_c19UpdateClsnPosAndRotEv(c);
-  func_ov098_02137c8c(c);
-  unsigned int idx2 = *(unsigned char*)(c+0x37c);
-  void* kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov098_0213c380[idx2].b);
-  _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-      c+0x124, kcl, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov098_0213c380[idx2].c);
-  return 1;
+/* Each row is model/KCL/CLPS, but the ROM gives each column its own symbol.
+ * These three overlapping stride-0xc views keep those relocation destinations
+ * distinct while still indexing the table as rows. */
+extern ArrowSignFileColumn data_ov098_0213c380[];
+extern ArrowSignFileColumn data_ov098_0213c384[];
+extern ArrowSignFileColumn data_ov098_0213c388[];
 }
+
+int ArrowSignRight::InitResources()
+{
+    u16 id = actorID;
+    if (id != 0x12b) {
+        if (id == 0x12c)
+            unk_37c = 1;
+    } else {
+        unk_37c = 0;
+    }
+
+    u32 modelIndex = unk_37c;
+    void *model = _ZN5Model8LoadFileER13SharedFilePtr(data_ov098_0213c380[modelIndex].value);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(&mModel, model, 1, -1);
+    mShadowModel.InitCuboid();
+    _ZN10dBgActor_c21UpdateModelPosAndRotYEv(this);
+    _ZN10dBgActor_c19UpdateClsnPosAndRotEv(this);
+    func_ov098_02137c8c((char *)this);
+
+    u32 collisionIndex = unk_37c;
+    void *kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov098_0213c384[collisionIndex].value);
+    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+        &mMeshCollider, kcl, &mClsnMat, 0x199, mAngleY,
+        data_ov098_0213c388[collisionIndex].value);
+    return 1;
 }

--- a/src/_ZN8PathLift12BaseBehaviorEv.cpp
+++ b/src/_ZN8PathLift12BaseBehaviorEv.cpp
@@ -1,12 +1,19 @@
 //cpp
-struct PathLift;
-typedef void (PathLift::*PLFn)();
-struct Entry { char pad[8]; PLFn fn; char tail[4]; };
-extern "C" Entry data_ov002_0210af2c[];
-struct PathLift { char pad[0x450]; };
-extern "C" void _ZN8PathLift12BaseBehaviorEv(PathLift *c) {
-    int i = *(int*)((char*)c + 0x44c);
-    Entry *e = &data_ov002_0210af2c[i];
-    (c->*(e->fn))();
-    *((unsigned char*)c + 0x42a) = 0;
+#include "PathLift.h"
+
+typedef void (PathLift::*PathLiftStateFn)();
+
+struct PathLiftState {
+    char pad_00[8];
+    PathLiftStateFn behavior;
+    char pad_0c[4];
+};
+
+extern "C" PathLiftState data_ov002_0210af2c[];
+
+void PathLift::BaseBehavior()
+{
+    PathLiftState &state = data_ov002_0210af2c[mState];
+    (this->*state.behavior)();
+    unk_42a = 0;
 }

--- a/src/_ZN9LavaPlank8BehaviorEv.cpp
+++ b/src/_ZN9LavaPlank8BehaviorEv.cpp
@@ -1,18 +1,21 @@
 //cpp
-struct SEnt { short a, b; };
+#include "LavaPlank.h"
+
+struct SinCosEntry { s16 sin, cos; };
 extern "C" {
 extern void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *);
 extern int _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void *, int, int);
 extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *);
 }
-extern SEnt data_02082214[];
-extern "C" int _ZN9LavaPlank8BehaviorEv(char *c)
+extern SinCosEntry data_02082214[];
+
+int LavaPlank::Behavior()
 {
-    int val = *(unsigned short *)(c + 0x324) >> 4;
-    *(int *)(c + 0x60) = data_02082214[val].a * (short)0x1e + *(int *)(c + 0x320);
-    *(short *)(((int)c + 0x324)) += 0x400;
-    _ZN10dBgActor_c21UpdateModelPosAndRotYEv(c);
-    if (_ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-        _ZN10dBgActor_c19UpdateClsnPosAndRotEv(c);
+    int val = (u16)unk_324 >> 4;
+    mPosY = data_02082214[val].sin * (s16)0x1e + mOriginalPosY;
+    unk_324 += 0x400;
+    _ZN10dBgActor_c21UpdateModelPosAndRotYEv(this);
+    if (_ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(this, 0, 0))
+        _ZN10dBgActor_c19UpdateClsnPosAndRotEv(this);
     return 1;
 }


### PR DESCRIPTION
Converts seven already-matched, hand-spelled extern-C definitions into genuine class methods over the shared layouts: PathLift::BaseBehavior, LavaPlank::Behavior, ArrowSignRight::InitResources, SlidingIce::InitResources, FortressWall::Behavior, CannonHatch::Behavior, and StarSwitch::InitResources.\n\nThe bodies now use inherited/named members instead of raw object offsets. ArrowSignRight retains three separately named stride-0xc table views so strict relocation destinations remain exact; FortressWall retains the measured raw Fix12 call signature. TTC_MovingBeam was inspected but deliberately deferred because its dBgCh_Gnd lifetime cleanup affects four existing manual-lifetime consumers and belongs in a separate slice.\n\nValidation:\n- all 7 targets MATCH under mwccarm 2004/b56 with strict relocations\n- all 7 linkcheck VERIFIED, blind: 0\n- 32/32 changed or header-affected sources VERIFIED\n- rombuild: 11,059/11,059 reproducing, 106/106 modules exact\n- port_refcheck: 393/393\n- no new dead or unresolved references\n- language-mode backlog: 583 -> 576; shadow-declaration metrics also decrease