### PR TITLE
Preserve multi-function TU enrollment and ROM builds

### DIFF
--- a/notes/cpp-tu-current-state.md
+++ b/notes/cpp-tu-current-state.md
@@ -31,13 +31,13 @@ CONVERTED is the strict five-criterion result from `tiers.converted(src)`.
 | Measure | Live value |
 | --- | ---: |
 | Tracked production source files | 11303 |
-| Tracked `.c` files | 6915 |
-| Tracked `.cpp` files | 4388 |
+| Tracked `.c` files | 6909 |
+| Tracked `.cpp` files | 4394 |
 | `.cpp` files missing first-line `//cpp` | 11 |
 | Mangled-symbol source files | 3318 |
 | Genuinely migrated C++ symbol files | 2758 |
 | Not semantically migrated | 558 |
-| `.cpp` files still hand-spelling their symbol | 189 |
+| `.cpp` files still hand-spelling their symbol | 195 |
 | Nonmatching C++-symbol drafts | 14 |
 | Delinks path-owned function-symbol records | 11191 |
 | Path-owned records still supplied from ROM bytes | 128 |
@@ -92,8 +92,8 @@ All surfaces ready: **NO**.
 This is a behavior-backed result from a disposable source containing two C++
 methods, not a checklist copied from prose. Run
 `python tools/cpp_tu_compat.py` for the per-surface
-evidence. Current ready surfaces: `srcpath`, `validate_merge`.
-Current hard production blockers: `enroll`, `rombuild`, `port_refcheck`.
+evidence. Current ready surfaces: `srcpath`, `enroll`, `rombuild`, `validate_merge`.
+Current hard production blockers: `port_refcheck`.
 Current policy/metric gaps: `eligible`, `tiers`, `langmode_audit`, `attribution`.
 
 ## Which source answers which question

--- a/tools/cpp_tu_compat.py
+++ b/tools/cpp_tu_compat.py
@@ -262,7 +262,7 @@ def _probe_rombuild(fixture):
     enrolled = RB.enrolled(fixture.repo / "config")
     mapping = RB.enrolled_symbols()
     selected = []
-    with mock.patch.object(RB.OI, "isolate",
+    with mock.patch.object(RB.OI, "isolate_many",
                            side_effect=lambda _obj, name: selected.append(name) or {}):
         RB._isolate(fixture.repo / "Pair.o", SOURCE, mapping)
     ok = (enrolled == [SOURCE] and mapping.get(SOURCE) == list(SYMBOLS)
@@ -271,9 +271,10 @@ def _probe_rombuild(fixture):
         "rombuild", "ready" if ok else "blocked",
         {"compiledSources": enrolled, "enrolledSymbolMap": mapping,
          "symbolsKeptByIsolation": selected},
-        "The source list deduplicates the TU correctly, but rel->symbol ownership keeps "
-        "only one member and isolation discards the other." if not ok else
-        "Compilation and isolation preserve every member of the shared source.")
+        "The source list or multi-symbol isolation loses at least one shared member."
+        if not ok else
+        "Compilation groups the members in ROM order and fail-closed isolation preserves "
+        "the exact text-only object.")
 
 
 @contextlib.contextmanager

--- a/tools/enroll.py
+++ b/tools/enroll.py
@@ -46,6 +46,40 @@ SYM_RE = re.compile(
     r"^(\S+)\s+kind:function\((arm|thumb),size=0x([0-9a-fA-F]+)\)\s+addr:0x([0-9a-fA-F]+)")
 SEC_RE = re.compile(
     r"^\s+(\.\S+)\s+start:0x([0-9a-fA-F]+)\s+end:0x([0-9a-fA-F]+)\s+kind:(\S+)")
+ENTRY_SEC_RE = re.compile(
+    r"^\s+(\.\S+)\s+start:0x([0-9a-fA-F]+)\s+end:0x([0-9a-fA-F]+)")
+
+
+class EnrollmentError(ValueError):
+    """A delinks rewrite would lose or ambiguously expand source ownership."""
+
+
+def read_delinks_full(path):
+    """Return ``(header, [(source_path, body_lines), ...])`` without losing bodies.
+
+    The old boolean view in :func:`read_delinks` is enough for readers that only ask
+    whether a path is complete.  A writer needs the full entry: one translation unit
+    may own several functions and several sections, none of which can be reconstructed
+    safely from a function list alone.
+    """
+    header, entries = [], []
+    cur, body = None, []
+    for raw in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if not raw.strip():
+            continue
+        line = raw.rstrip()
+        if line[0].isspace():
+            if cur is None:
+                header.append(line)
+            else:
+                body.append(line)
+            continue
+        if cur is not None:
+            entries.append((cur, body))
+        cur, body = line.strip().rstrip(":"), []
+    if cur is not None:
+        entries.append((cur, body))
+    return header, entries
 
 
 def read_delinks(path):
@@ -54,19 +88,142 @@ def read_delinks(path):
     Header = the leading indented section lines. A file entry is an unindented path
     ending in ':' followed by indented lines; we only care whether `complete` is there.
     """
-    header, entries, cur = [], {}, None
-    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
-        if not line.strip():
-            continue
-        if line[0].isspace():
-            if cur is None:
-                header.append(line.rstrip())
-            elif line.strip() == "complete":
-                entries[cur] = True
-        else:
-            cur = line.strip().rstrip(":")
-            entries.setdefault(cur, False)
+    header, full = read_delinks_full(path)
+    entries = {}
+    for rel, body in full:
+        entries[rel] = any(line.strip() == "complete" for line in body)
     return header, entries
+
+
+def _body_with_complete(body, done):
+    """Toggle only ``complete`` while preserving every other structured line."""
+    out, found = [], False
+    for line in body:
+        if line.strip() != "complete":
+            out.append(line)
+        elif done and not found:
+            out.append(line)
+            found = True
+    if done and not found:
+        out.insert(0, "    complete")
+    return out
+
+
+def _body_ranges(body):
+    """Structured ``(section, start, end)`` rows in one entry body."""
+    ranges = []
+    for line in body:
+        m = ENTRY_SEC_RE.match(line)
+        if m:
+            ranges.append((m.group(1), int(m.group(2), 16), int(m.group(3), 16)))
+    return ranges
+
+
+def _body_covers(body, rows):
+    """Whether every candidate's full range is licensed by the preserved body."""
+    ranges = _body_ranges(body)
+    return all(any(sec == row[5] and lo <= row[3] and row[3] + row[4] <= hi
+                   for sec, lo, hi in ranges)
+               for row in rows)
+
+
+def render_entries(header, existing_entries, module_candidates, promote=(),
+                   all_complete=False, demote_all=False):
+    """Render one delinks entry per source, preserving existing ownership bodies.
+
+    ``module_candidates`` remains one row per function because eligibility is still a
+    per-symbol question.  Rendering is a per-object question: several rows may point at
+    one source, including overlapping entry-point aliases inside a single asm routine.
+    Existing bodies are authoritative for their ranges and non-text sections.  A new
+    shared source without such an entry is refused because a function list cannot prove
+    the object's licensed span.
+
+    Returns ``(text, entry_count, complete_count)``.
+    """
+    promote = set(promote)
+    existing = {}
+    for rel, body in existing_entries:
+        if rel in existing:
+            raise EnrollmentError(f"duplicate existing delinks entry for {rel}")
+        existing[rel] = list(body)
+
+    grouped = collections.defaultdict(list)
+    for row in module_candidates:
+        grouped[row[2]].append(row)
+
+    ordered = sorted(grouped.items(), key=lambda item: min(row[3] for row in item[1]))
+    rendered, consumed, n_complete = [], set(), 0
+    for rel, rows in ordered:
+        rows.sort(key=lambda row: row[3])
+        names = {row[1] for row in rows}
+        requested = names & promote
+        if len(names) > 1 and requested and requested != names:
+            missing = ", ".join(sorted(names - requested))
+            raise EnrollmentError(
+                f"partial --complete-list for shared source {rel}; also require: {missing}")
+
+        body = existing.get(rel)
+        if body is not None:
+            consumed.add(rel)
+        if body is None and len(rows) == 1:
+            # Preserve the historical move contract: a same-symbol source that moved
+            # between src/ and mods/ keeps its full range/body and complete state.
+            name = rows[0][1]
+            moved = [(old_rel, old_body) for old_rel, old_body in existing.items()
+                     if pathlib.PurePosixPath(old_rel).stem == name]
+            if len(moved) > 1:
+                raise EnrollmentError(
+                    f"ambiguous prior delinks entries for moved symbol {name}: "
+                    + ", ".join(old_rel for old_rel, _body in moved))
+            if moved:
+                old_rel, body = moved[0]
+                consumed.add(old_rel)
+        if body is None:
+            if len(rows) > 1:
+                raise EnrollmentError(
+                    f"shared source {rel} has no existing delinks body; refusing to "
+                    "infer its object range from individual functions")
+            row = rows[0]
+            body = [f"    {row[5]} start:0x{row[3]:08x} "
+                    f"end:0x{row[3] + row[4]:08x}"]
+        elif not _body_covers(body, rows):
+            raise EnrollmentError(
+                f"existing delinks body for {rel} does not cover every candidate range")
+
+        was_complete = any(line.strip() == "complete" for line in body)
+        selected = all_complete or bool(names) and names <= promote
+        done = selected or (was_complete and not demote_all)
+        rendered.append((min(row[3] for row in rows), rel,
+                         _body_with_complete(body, done)))
+        n_complete += int(done)
+
+    # An incomplete entry is an intentional ROM-byte placeholder: dsd does not open
+    # its path, and dropping it is an unrelated ownership mutation. Carry it through
+    # verbatim even when candidate policy currently rejects its source (for example a
+    # NONMATCHING banner). A complete unmatched entry is different: preserving it may
+    # compile a missing/draft source while dropping it would silently fall back to ROM
+    # bytes, so neither rewrite is safe and the operator must resolve it explicitly.
+    for rel, body in existing.items():
+        if rel in consumed:
+            continue
+        if any(line.strip() == "complete" for line in body):
+            raise EnrollmentError(
+                f"complete existing source {rel} has no candidate; refusing to demote "
+                "or preserve an unverified build input implicitly")
+        ranges = _body_ranges(body)
+        if not ranges:
+            raise EnrollmentError(
+                f"existing ROM-byte entry {rel} has no section range to preserve")
+        rendered.append((min(lo for _sec, lo, _hi in ranges), rel, list(body)))
+
+    lines = list(header)
+    for _addr, rel, body in sorted(rendered, key=lambda row: (row[0], row[1])):
+        lines.append(f"{rel}:")
+        lines.extend(body)
+        lines.append("")
+
+    text = "\n".join(lines).rstrip("\n") + "\n"
+    return text, len(rendered), n_complete
 
 
 def sections(header):
@@ -180,35 +337,35 @@ def main():
         bymod[c[0]].append(c)
 
     n_entries = n_complete = 0
-    touched = []
+    touched, rewrites = [], []
     for d in sorted(CONFIG.rglob("symbols.txt")):
         path = d.parent / "delinks.txt"
         if not path.is_file():
             continue
-        header, existing = read_delinks(path)
-        # Key the carried-over `complete` marks by symbol name, not path: a function
-        # that moved between src/ and mods/ is the same function and must keep its mark.
-        existing_by_name = {pathlib.Path(p2).stem: v for p2, v in existing.items()}
-        lines = list(header)
-
-        if not args.clear:
-            # Sorted by address: delink file entries are consumed in link order.
-            for (_d, name, rel, addr, size, sec) in sorted(bymod.get(d.parent, []), key=lambda x: x[3]):
-                done = (args.all_complete or name in promote
-                        or (existing_by_name.get(name, False) and not args.demote_all))
-                lines.append(f"{rel}:")
-                if done:
-                    lines.append("    complete")
-                    n_complete += 1
-                lines.append(f"    {sec} start:0x{addr:08x} end:0x{addr + size:08x}")
-                lines.append("")
-                n_entries += 1
-
-        text = "\n".join(lines).rstrip("\n") + "\n"
+        header, existing = read_delinks_full(path)
+        if args.clear:
+            text = "\n".join(header).rstrip("\n") + "\n"
+            module_entries = module_complete = 0
+        else:
+            try:
+                text, module_entries, module_complete = render_entries(
+                    header, existing, bymod.get(d.parent, []), promote,
+                    all_complete=args.all_complete, demote_all=args.demote_all)
+            except EnrollmentError as exc:
+                print(f"enroll: {path.relative_to(REPO).as_posix()}: {exc}",
+                      file=sys.stderr)
+                return 2
+        n_entries += module_entries
+        n_complete += module_complete
         if text != path.read_text(encoding="utf-8", errors="ignore"):
             touched.append(path.relative_to(REPO).as_posix())
-            if not args.dry_run:
-                path.write_text(text, encoding="utf-8", newline="\n")
+            rewrites.append((path, text))
+
+    # Rendering every module first makes every refusal fail closed: a partial shared
+    # complete-list or malformed preserved body cannot leave earlier modules rewritten.
+    if not args.dry_run:
+        for path, text in rewrites:
+            path.write_text(text, encoding="utf-8", newline="\n")
 
     print(f"candidates: {len(cands)}")
     for k, v in skipped.most_common():
@@ -216,7 +373,8 @@ def main():
     print(f"entries written: {n_entries}  ({n_complete} complete / "
           f"{n_entries - n_complete} rom-bytes)")
     print(f"delinks.txt files {'that would change' if args.dry_run else 'changed'}: {len(touched)}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -228,6 +228,133 @@ def plan(raw, keep_symbol):
             "dead": sorted(dead), "referenced": sorted(referenced), "error": None}
 
 
+def plan_many(raw, keep_symbols):
+    """Validate an exact text-only multi-function object for production linking.
+
+    This is deliberately not ``plan`` with a wider argument.  The one-function
+    pipeline is allowed to discard compiler-emitted neighbours and data because one
+    delinks entry licenses one function.  A consolidated source has one spanning
+    delinks entry: its intact object is the linker contribution, so silently dropping
+    an unexpected helper or data section would create a hole inside a range dsd no
+    longer fills from the ROM.
+
+    The accepted shape is intentionally narrow:
+
+    * at least two distinct requested symbols, each defined exactly once as a function;
+    * one dedicated, non-empty ``.text`` section per requested symbol;
+    * those sections occur in the caller's ROM order;
+    * no other non-debug content and no unlicensed symbol in a kept section; and
+    * no undefined RTTI relocation that still needs the single-function ``-8`` rewrite.
+
+    Success therefore needs no ELF surgery: the exact input object is preserved.  The
+    returned plan uses the familiar shape so callers can report one isolation verdict
+    without weakening or changing ``plan``/``derive``/``isolate`` for singletons.
+    """
+    requested = [str(name) for name in keep_symbols if str(name)]
+    if len(requested) < 2:
+        return {"error": "multi-symbol isolation needs at least two symbols"}
+    if len(set(requested)) != len(requested):
+        return {"error": "duplicate multi-symbol isolation request"}
+
+    elf = ELFFile(io.BytesIO(bytes(raw)))
+    secs = list(elf.iter_sections())
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return {"error": "no .symtab"}
+    syms = list(symtab.iter_symbols())
+
+    by_name = {
+        name: [s for s in syms if s.name == name
+               and s["st_shndx"] not in ("SHN_UNDEF", SHN_UNDEF)]
+        for name in requested
+    }
+    for name in requested:
+        matches = by_name[name]
+        if len(matches) != 1:
+            return {"error": f"{name} has {len(matches)} defined symbols, expected one"}
+        sym = matches[0]
+        if sym["st_info"]["type"] != "STT_FUNC":
+            return {"error": f"{name} is {sym['st_info']['type']}, expected STT_FUNC"}
+        shndx = sym["st_shndx"]
+        sec = secs[shndx] if isinstance(shndx, int) else None
+        if sec is None or sec.name != ".text" \
+                or sec.header["sh_type"] != "SHT_PROGBITS" \
+                or not sec.header["sh_size"]:
+            return {"error": f"{name} is not in a non-empty .text/SHT_PROGBITS section"}
+        if sym["st_value"] != 0 or sym["st_size"] != sec.header["sh_size"]:
+            return {"error": f"{name} does not exactly cover its .text section "
+                             f"(value=0x{sym['st_value']:x}, symbol=0x{sym['st_size']:x}, "
+                             f"section=0x{sec.header['sh_size']:x})"}
+
+    keep = [by_name[name][0]["st_shndx"] for name in requested]
+    if len(set(keep)) != len(keep):
+        return {"error": "requested functions do not occupy distinct .text sections"}
+
+    occupants = sorted({
+        sym.name for sym in syms
+        if sym.name and not sym.name.startswith("$")
+        and sym["st_info"]["type"] != "STT_SECTION"
+        and sym["st_shndx"] in set(keep)
+    })
+    foreign = sorted(set(occupants) - set(requested))
+    if foreign:
+        return {"error": f"kept function section(s) also define unlicensed symbol(s): "
+                         f"{foreign}"}
+
+    live = [
+        (index, sec) for index, sec in enumerate(secs)
+        if sec.header["sh_type"] in CONTENT and sec.header["sh_size"]
+        and not any(sec.name.startswith(prefix) for prefix in IGNORE)
+    ]
+    extra = [(index, sec) for index, sec in live if index not in set(keep)]
+    if extra:
+        detail = []
+        for index, sec in extra:
+            names = sorted({
+                sym.name for sym in syms
+                if sym.name and not sym.name.startswith("$")
+                and sym["st_info"]["type"] != "STT_SECTION"
+                and sym["st_shndx"] == index
+            })
+            detail.append(f"section[{index}] {sec.name} size 0x{sec.header['sh_size']:x} "
+                          f"defines {names}")
+        return {"error": "unlicensed content in text-only multi-symbol object: "
+                         + "; ".join(detail)}
+
+    emitted = [name for _index, name in sorted(zip(keep, requested))]
+    if emitted != requested:
+        return {"error": "requested functions are not emitted in ROM order: "
+                         f"requested {requested}, emitted {emitted}"}
+
+    referenced = set()
+    for relsec in secs:
+        if not isinstance(relsec, RelocationSection) or relsec.header["sh_info"] not in keep:
+            continue
+        for reloc in relsec.iter_relocations():
+            target = symtab.get_symbol(reloc["r_info_sym"])
+            if target.name:
+                referenced.add(target.name)
+            if not target.name.startswith(("_ZTV", "_ZTI", "_ZTS")):
+                continue
+            if not relsec.is_RELA():
+                return {"error": f"{target.name}: RTTI reloc is REL, not RELA"}
+            if target["st_shndx"] in ("SHN_UNDEF", SHN_UNDEF) \
+                    and reloc["r_addend"] != 0:
+                return {"error": f"{target.name}: intact multi-symbol object has "
+                                 f"undefined RTTI addend {reloc['r_addend']}; text-only "
+                                 "production isolation cannot rewrite it"}
+
+    return {"keep": keep, "keepSymbols": requested, "drop": [],
+            "externalise": [], "dead": [], "referenced": sorted(referenced),
+            "error": None}
+
+
+def derive_many(raw, keep_symbols):
+    """Pure, fail-closed validation of one exact text-only multi-function object."""
+    p = plan_many(bytes(raw), keep_symbols)
+    return (None, p) if p.get("error") else (bytes(raw), p)
+
+
 def referenced_undefined(raw, keep_symbol):
     """Undefined symbol names the kept function actually references.
 
@@ -916,6 +1043,15 @@ def isolate(obj, keep_symbol):
     if p.get("error") or not (p["drop"] or p["externalise"]):
         return p
     obj.write_bytes(out)
+    return p
+
+
+def isolate_many(obj, keep_symbols):
+    """Validate and preserve an exact text-only multi-function object in place."""
+    raw = obj.read_bytes()
+    out, p = derive_many(raw, keep_symbols)
+    if out is not None and out != raw:
+        obj.write_bytes(out)
     return p
 
 

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -286,7 +286,11 @@ def init_section_sources():
 
 
 def _isolate(obj, rel, syms, data_sink=None):
-    """Reduce a compiled `src/` object to its declared function. Returns an error or None.
+    """Reduce a compiled `src/` object to its declared function(s).
+
+    A legacy source owns one function and takes the unchanged singular isolation path.
+    A consolidated, text-only source owns several functions in ROM order and takes
+    objisolate's separate fail-closed intact-object path. Returns an error or None.
 
     `mods/` is deliberately exempt. A mod is not a recovered ROM function: it may
     legitimately define helpers and data alongside its entry point, and isolation
@@ -306,7 +310,14 @@ def _isolate(obj, rel, syms, data_sink=None):
         # Measurement only: check_object swallows its own exceptions, and nothing here
         # can fail the build. See tools/romdata_check.py for why it is not a gate.
         data_sink.extend(RDC.check_object(obj, rel))
-    plan = OI.isolate(obj, (syms or {}).get(rel, pathlib.Path(rel).stem))
+    selected = (syms or {}).get(rel, pathlib.Path(rel).stem)
+    if isinstance(selected, (list, tuple)):
+        if not selected:
+            return "source owns no enrolled functions"
+        plan = (OI.isolate(obj, selected[0]) if len(selected) == 1
+                else OI.isolate_many(obj, selected))
+    else:
+        plan = OI.isolate(obj, selected)
     if plan.get("kind") == OI.NOT_A_FUNCTION:
         return None          # nothing to reduce; other gates judge this file
     return plan.get("error")
@@ -331,17 +342,55 @@ def _retarget(obj, rel, init_srcs):
 
 
 def enrolled_symbols():
-    """{rel: symbol} for enrolled sources.
+    """{rel: [symbols in ROM order]} for enrolled sources.
 
-    objisolate needs the symbol to keep, and the file stem is NOT it -- not as a
-    rule. The two coincide for all 11,160 candidates today, which is exactly the
-    condition under which keying on the stem goes unnoticed until it does not; the
-    same divergence build_pin's version lookup already carries. Keying on the
-    enrolled symbol costs one dict and cannot drift.
+    objisolate needs every disjoint function definition a source emits, and the file
+    stem is NOT that ownership contract. Grouping matters as soon as one consolidated
+    source replaces several legacy files; a dict comprehension silently retained only
+    the last member. Candidate ranges recognize the one exact legacy outer-owner alias
+    shape and otherwise provide the linker/ROM order required by the fail-closed intact
+    multi-function object path.
     """
     import enroll as E
     cands, _ = E.candidates()
-    return {rel: name for (_d, name, rel, _addr, _size, _sec) in cands}
+    grouped = {}
+    for _d, name, rel, addr, _size, _sec in cands:
+        grouped.setdefault(rel, []).append((addr, _size, name))
+    return {rel: _definition_symbols(rel, rows)
+            for rel, rows in grouped.items()}
+
+
+def _definition_symbols(rel, rows):
+    """Collapse owned records only for one exact legacy outer-owner alias shape.
+
+    Some ROM functions contain independently named entry points.  The concrete case
+    is ``src/func_01ff97d8.c``: one 0xb6c outer function owns the complete range while
+    four nonzero function records partition its interior.  Those records are useful
+    address/ownership aliases, but mwcc emits only the outer definition.  Treating the
+    five records as a consolidated TU would make the exact object fail with four
+    invented missing-definition errors.
+
+    There is exactly one safe exception to "every nonzero record needs a definition":
+    the legacy source's filename stem names one candidate whose interval fully contains
+    every other candidate interval.  That is direct evidence that the file's declared
+    outer function owns nested address aliases, so only the outer definition is asked
+    of the object.
+
+    No widest-range or overlap heuristic is used.  A promoted TU filename does not name
+    a function, and a stem owner beside any disjoint member is not the legacy alias-owner
+    shape; both return every ROM-ordered record so ``isolate_many`` fails closed if the
+    object does not define them.
+    """
+    stem = pathlib.PurePosixPath(rel).stem
+    ordered = sorted(rows)
+    owners = [(addr, size, name) for addr, size, name in ordered if name == stem]
+    if len(owners) == 1:
+        owner_addr, owner_size, owner_name = owners[0]
+        owner_end = owner_addr + owner_size
+        if all(owner_addr <= addr and addr + size <= owner_end
+               for addr, size, _name in ordered):
+            return [owner_name]
+    return [name for _addr, _size, name in ordered]
 
 
 def retarget_text_section(obj, section=".init"):

--- a/tools/test_cpp_tu_compat.py
+++ b/tools/test_cpp_tu_compat.py
@@ -26,9 +26,9 @@ class CppTuCompatibility(unittest.TestCase):
             {name: row["status"] for name, row in self.rows.items()},
             {
                 "srcpath": "ready",
-                "enroll": "blocked",
+                "enroll": "ready",
                 "eligible": "gap",
-                "rombuild": "blocked",
+                "rombuild": "ready",
                 "validate_merge": "ready",
                 "tiers": "gap",
                 "langmode_audit": "gap",
@@ -38,7 +38,7 @@ class CppTuCompatibility(unittest.TestCase):
         self.assertFalse(self.report["productionCompatible"])
         self.assertFalse(self.report["allSurfacesReady"])
         self.assertEqual(self.report["blockers"], [
-            "enroll", "rombuild", "port_refcheck",
+            "port_refcheck",
         ])
         self.assertEqual(self.report["policyAndMetricGaps"], [
             "eligible", "tiers", "langmode_audit", "attribution",
@@ -46,11 +46,16 @@ class CppTuCompatibility(unittest.TestCase):
 
         self.assertEqual(self.rows["srcpath"]["evidence"]["symbolsForSource"],
                          list(CTC.SYMBOLS))
-        self.assertEqual(self.rows["enroll"]["evidence"]["roundTripEntries"], 2)
-        self.assertEqual(self.rows["enroll"]["evidence"]["roundTripCompleteMarks"], 0)
+        self.assertEqual(self.rows["enroll"]["evidence"]["roundTripEntries"], 1)
+        self.assertEqual(self.rows["enroll"]["evidence"]["roundTripCompleteMarks"], 1)
         self.assertEqual(self.rows["eligible"]["evidence"]["isolatedSymbols"],
                          list(CTC.SYMBOLS))
         self.assertEqual(len(self.rows["rombuild"]["evidence"]["enrolledSymbolMap"]), 1)
+        self.assertEqual(
+            self.rows["rombuild"]["evidence"]["enrolledSymbolMap"][CTC.SOURCE],
+            list(CTC.SYMBOLS))
+        self.assertEqual(self.rows["rombuild"]["evidence"]["symbolsKeptByIsolation"],
+                         [list(CTC.SYMBOLS)])
         self.assertEqual(self.rows["validate_merge"]["evidence"]["sourceFunctions"], 2)
         self.assertEqual(self.rows["validate_merge"]["evidence"]["completeRanges"], 1)
         self.assertEqual(self.rows["tiers"]["evidence"]["legacyFiles"], 2)

--- a/tools/test_enroll.py
+++ b/tools/test_enroll.py
@@ -1,0 +1,190 @@
+"""Unit contracts for source-granular delinks regeneration."""
+import collections
+import contextlib
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import enroll as EN  # noqa: E402
+
+
+HEADER = ["    .text start:0x00001000 end:0x00002000 kind:code align:4"]
+SOURCE = "src/actors/Pair.cpp"
+
+
+def candidate(name, addr, size, rel=SOURCE, section=".text"):
+    return (pathlib.Path("config/arm9"), name, rel, addr, size, section)
+
+
+class EnrollStructuredEntries(unittest.TestCase):
+    def test_parser_keeps_complete_and_every_section_line(self):
+        text = """    .text start:0x00001000 end:0x00002000 kind:code align:4
+
+src/actors/Pair.cpp:
+    complete
+    .text start:0x00001000 end:0x00001008
+    .init start:0x00001800 end:0x00001810
+    .data start:0x00003000 end:0x00003020
+"""
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "delinks.txt"
+            path.write_text(text, encoding="utf-8")
+            header, entries = EN.read_delinks_full(path)
+            legacy_header, marks = EN.read_delinks(path)
+
+        self.assertEqual(header, HEADER)
+        self.assertEqual(legacy_header, HEADER)
+        self.assertEqual(marks, {SOURCE: True})
+        self.assertEqual(entries, [(SOURCE, [
+            "    complete",
+            "    .text start:0x00001000 end:0x00001008",
+            "    .init start:0x00001800 end:0x00001810",
+            "    .data start:0x00003000 end:0x00003020",
+        ])])
+
+    def test_nested_entry_points_round_trip_as_one_complete_source(self):
+        body = [
+            "    complete",
+            "    .text start:0x00001000 end:0x00001100",
+            "    .init start:0x00001800 end:0x00001810",
+            "    .data start:0x00003000 end:0x00003020",
+            "    .bss start:0x00004000 end:0x00004010",
+        ]
+        rows = [
+            candidate("Outer", 0x1000, 0x100),
+            candidate("InnerA", 0x1020, 0x20),
+            candidate("InnerB", 0x1040, 0x40),
+        ]
+        text, count, complete = EN.render_entries(HEADER, [(SOURCE, body)], rows)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(complete, 1)
+        self.assertEqual(text.count(f"{SOURCE}:"), 1)
+        for line in body:
+            self.assertEqual(text.count(line), 1)
+
+    def test_demote_all_removes_only_complete(self):
+        body = [
+            "    complete",
+            "    .text start:0x00001000 end:0x00001008",
+            "    .data start:0x00003000 end:0x00003020",
+        ]
+        rows = [candidate("First", 0x1000, 4), candidate("Second", 0x1004, 4)]
+        text, count, complete = EN.render_entries(
+            HEADER, [(SOURCE, body)], rows, demote_all=True)
+
+        self.assertEqual((count, complete), (1, 0))
+        self.assertNotIn("    complete", text)
+        self.assertIn(body[1], text)
+        self.assertIn(body[2], text)
+
+    def test_partial_complete_list_for_shared_source_fails_closed(self):
+        body = ["    .text start:0x00001000 end:0x00001008"]
+        rows = [candidate("First", 0x1000, 4), candidate("Second", 0x1004, 4)]
+
+        with self.assertRaisesRegex(EN.EnrollmentError, "partial --complete-list"):
+            EN.render_entries(HEADER, [(SOURCE, body)], rows, {"First"})
+
+        text, count, complete = EN.render_entries(
+            HEADER, [(SOURCE, body)], rows, {"First", "Second"})
+        self.assertEqual((count, complete), (1, 1))
+        self.assertIn("    complete", text)
+
+    def test_new_shared_source_without_authoritative_body_is_refused(self):
+        rows = [candidate("First", 0x1000, 4), candidate("Second", 0x1004, 4)]
+        with self.assertRaisesRegex(EN.EnrollmentError, "no existing delinks body"):
+            EN.render_entries(HEADER, [], rows)
+
+    def test_single_symbol_move_keeps_body_and_complete_state(self):
+        name = "_ZN4Pair5FirstEv"
+        old = f"src/{name}.cpp"
+        new = f"mods/{name}.cpp"
+        body = [
+            "    complete",
+            "    .text start:0x00001000 end:0x00001004",
+            "    .data start:0x00003000 end:0x00003010",
+        ]
+        rows = [candidate(name, 0x1000, 4, rel=new)]
+        text, count, complete = EN.render_entries(HEADER, [(old, body)], rows)
+
+        self.assertEqual((count, complete), (1, 1))
+        self.assertIn(f"{new}:", text)
+        self.assertNotIn(f"{old}:", text)
+        self.assertIn(body[1], text)
+        self.assertIn(body[2], text)
+
+    def test_new_single_symbol_keeps_legacy_generated_shape(self):
+        rows = [candidate("First", 0x1000, 4)]
+        text, count, complete = EN.render_entries(
+            HEADER, [], rows, {"First"})
+        self.assertEqual((count, complete), (1, 1))
+        self.assertIn(f"{SOURCE}:\n    complete\n", text)
+        self.assertIn("    .text start:0x00001000 end:0x00001004", text)
+
+    def test_unmatched_rom_byte_placeholder_is_preserved(self):
+        stale = "src/NonmatchingDraft.cpp"
+        body = ["    .text start:0x00001100 end:0x00001110"]
+        text, count, complete = EN.render_entries(HEADER, [(stale, body)], [])
+
+        self.assertEqual((count, complete), (1, 0))
+        self.assertIn(f"{stale}:\n{body[0]}\n", text)
+
+    def test_unmatched_complete_source_fails_instead_of_implicit_demotion(self):
+        stale = "src/MissingOrDraft.cpp"
+        body = [
+            "    complete",
+            "    .text start:0x00001100 end:0x00001110",
+        ]
+        with self.assertRaisesRegex(EN.EnrollmentError, "complete existing source"):
+            EN.render_entries(HEADER, [(stale, body)], [])
+
+    def test_preserved_body_must_cover_every_candidate(self):
+        body = ["    complete", "    .text start:0x00001000 end:0x00001004"]
+        rows = [candidate("First", 0x1000, 4), candidate("Second", 0x1004, 4)]
+        with self.assertRaisesRegex(EN.EnrollmentError, "does not cover"):
+            EN.render_entries(HEADER, [(SOURCE, body)], rows)
+
+    def test_main_refusal_writes_no_earlier_module(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = pathlib.Path(td)
+            first = repo / "config/arm9"
+            second = repo / "config/arm9/overlays/ov001"
+            first.mkdir(parents=True)
+            second.mkdir(parents=True)
+            for module in (first, second):
+                (module / "symbols.txt").write_text("", encoding="utf-8")
+            first_text = (HEADER[0] + "\n\n"
+                          "src/Stale.c:\n"
+                          "    .text start:0x00001100 end:0x00001104\n")
+            first_dl = first / "delinks.txt"
+            first_dl.write_text(first_text, encoding="utf-8")
+            (second / "delinks.txt").write_text(
+                HEADER[0] + "\n\n" + SOURCE + ":\n"
+                "    .text start:0x00001000 end:0x00001008\n", encoding="utf-8")
+            complete = repo / "complete.txt"
+            complete.write_text("First\n", encoding="utf-8")
+            shared = [
+                (first, "Solo", "src/Solo.c", 0x1000, 4, ".text"),
+                (second, "First", SOURCE, 0x1000, 4, ".text"),
+                (second, "Second", SOURCE, 0x1004, 4, ".text"),
+            ]
+
+            with mock.patch.object(EN, "REPO", repo), \
+                    mock.patch.object(EN, "CONFIG", repo / "config"), \
+                    mock.patch.object(EN, "candidates", return_value=(
+                        shared, collections.Counter())), \
+                    mock.patch.object(sys, "argv", [
+                        "enroll.py", "--complete-list", str(complete)]), \
+                    contextlib.redirect_stdout(io.StringIO()), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(EN.main(), 2)
+
+            self.assertEqual(first_dl.read_text(encoding="utf-8"), first_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -91,6 +91,97 @@ class Isolate(unittest.TestCase):
         self.assertIsNone(plan2["error"])
         self.assertNotEqual(other, out)
 
+    def _plain_two_function_tu(self, extra=""):
+        # mwcc emits function sections in reverse source order.  Defining Second
+        # first therefore makes the object order match the ROM-order license below.
+        obj = self.build(
+            "struct Pair { void First(); void Second(); };\n"
+            "void Pair::Second() {}\n"
+            "void Pair::First() {}\n" + extra)
+        return obj, ["_ZN4Pair5FirstEv", "_ZN4Pair6SecondEv"]
+
+    def test_multi_symbol_isolation_preserves_one_exact_text_only_object(self):
+        obj, names = self._plain_two_function_tu()
+        raw = obj.read_bytes()
+        out, plan = OI.derive_many(raw, names)
+        self.assertIsNone(plan["error"])
+        self.assertEqual(plan["keepSymbols"], names)
+        self.assertEqual(len(plan["keep"]), 2)
+        self.assertEqual(out, raw)
+        OI.isolate_many(obj, names)
+        self.assertEqual(obj.read_bytes(), raw)
+
+    def test_multi_symbol_isolation_refuses_a_missing_member(self):
+        obj, names = self._plain_two_function_tu()
+        out, plan = OI.derive_many(
+            obj.read_bytes(), [names[0], "_ZN4Pair7MissingEv"])
+        self.assertIsNone(out)
+        self.assertIn("0 defined symbols", plan["error"])
+
+    def test_multi_symbol_isolation_refuses_ambiguous_definitions(self):
+        import io
+        import struct
+        from elftools.elf.elffile import ELFFile
+
+        obj, names = self._plain_two_function_tu()
+        raw = bytearray(obj.read_bytes())
+        elf = ELFFile(io.BytesIO(bytes(raw)))
+        symtab = elf.get_section_by_name(".symtab")
+        symbols = list(symtab.iter_symbols())
+        first_index, first = next((i, s) for i, s in enumerate(symbols)
+                                  if s.name == names[0]
+                                  and s["st_shndx"] != "SHN_UNDEF")
+        second_index, _second = next((i, s) for i, s in enumerate(symbols)
+                                     if s.name == names[1]
+                                     and s["st_shndx"] != "SHN_UNDEF")
+        self.assertNotEqual(first_index, second_index)
+        endian = "<" if elf.little_endian else ">"
+        struct.pack_into(endian + "I", raw,
+                         symtab.header["sh_offset"] + second_index * 16,
+                         first["st_name"])
+
+        out, plan = OI.derive_many(bytes(raw), names)
+        self.assertIsNone(out)
+        self.assertIn("2 defined symbols", plan["error"])
+
+    def test_multi_symbol_isolation_refuses_unlicensed_helper_content(self):
+        obj, names = self._plain_two_function_tu(
+            'extern "C" int helper(int x) { return x + 1; }\n')
+        out, plan = OI.derive_many(obj.read_bytes(), names)
+        self.assertIsNone(out)
+        self.assertIn("unlicensed content", plan["error"])
+        self.assertIn("helper", plan["error"])
+
+    def test_multi_symbol_isolation_refuses_unlicensed_data(self):
+        obj, names = self._plain_two_function_tu(
+            'extern "C" int owned_data = 1;\n')
+        out, plan = OI.derive_many(obj.read_bytes(), names)
+        self.assertIsNone(out)
+        self.assertIn("unlicensed content", plan["error"])
+        self.assertIn("owned_data", plan["error"])
+
+    def test_multi_symbol_isolation_refuses_wrong_emission_order(self):
+        # mwcc emits these function sections in reverse source order.  This spelling
+        # therefore disagrees with the requested ROM order instead of silently
+        # accepting an object that would swap the two contributions.
+        obj = self.build(
+            "struct Pair { void First(); void Second(); };\n"
+            "void Pair::First() {}\n"
+            "void Pair::Second() {}\n")
+        names = ["_ZN4Pair5FirstEv", "_ZN4Pair6SecondEv"]
+        out, plan = OI.derive_many(obj.read_bytes(), names)
+        self.assertIsNone(out)
+        self.assertIn("not emitted in ROM order", plan["error"])
+
+    def test_multi_symbol_isolation_does_not_replace_singleton_semantics(self):
+        obj, names = self._plain_two_function_tu()
+        out, plan = OI.derive_many(obj.read_bytes(), [names[0]])
+        self.assertIsNone(out)
+        self.assertIn("at least two", plan["error"])
+        singular, singular_plan = OI.derive(obj.read_bytes(), names[0])
+        self.assertIsNone(singular_plan["error"])
+        self.assertIsNotNone(singular)
+
     def test_exact_deadstrip_removes_unreferenced_compiler_only_d2(self):
         """A whole-TU scratch link may model the retail link's discarded D2.
 

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import rombuild as RB  # noqa: E402
@@ -52,6 +53,74 @@ class RomBuildEnrollment(unittest.TestCase):
         with self.assertRaises(RB.BuildError) as raised:
             RB.enrolled(self.config)
         self.assertIn("unsafe complete", raised.exception.output)
+
+    def test_enrolled_symbols_group_one_source_in_rom_order(self):
+        candidates = [
+            (self.config, "Second", "src/Pair.cpp", 0x02000004, 4, ".text"),
+            (self.config, "Only", "src/Only.cpp", 0x02000020, 4, ".text"),
+            (self.config, "First", "src/Pair.cpp", 0x02000000, 4, ".text"),
+        ]
+        with mock.patch("enroll.candidates", return_value=(candidates, {})):
+            self.assertEqual(RB.enrolled_symbols(), {
+                "src/Pair.cpp": ["First", "Second"],
+                "src/Only.cpp": ["Only"],
+            })
+
+    def test_nested_function_records_are_aliases_not_required_definitions(self):
+        rel = "src/func_01ff97d8.c"
+        candidates = [
+            (self.config, "func_01ff98f4", rel, 0x01ff98f4, 0x0b0, ".text"),
+            (self.config, "func_01ff99a4", rel, 0x01ff99a4, 0x39c, ".text"),
+            (self.config, "func_01ff97d8", rel, 0x01ff97d8, 0xb6c, ".text"),
+            (self.config, "func_01ff9e2c", rel, 0x01ff9e2c, 0x518, ".text"),
+            (self.config, "func_01ff9d40", rel, 0x01ff9d40, 0x0ec, ".text"),
+        ]
+        with mock.patch("enroll.candidates", return_value=(candidates, {})):
+            mapping = RB.enrolled_symbols()
+        self.assertEqual(mapping, {rel: ["func_01ff97d8"]})
+
+        obj = self.repo / "Outer.o"
+        obj.write_bytes(b"object")
+        with mock.patch.object(RB.OI, "isolate", return_value={"error": None}) as one, \
+                mock.patch.object(RB.OI, "isolate_many",
+                                  return_value={"error": None}) as many:
+            self.assertIsNone(RB._isolate(obj, rel, mapping))
+        one.assert_called_once_with(obj, "func_01ff97d8")
+        many.assert_not_called()
+
+    def test_non_symbol_tu_path_never_guesses_among_overlapping_records(self):
+        rows = [
+            (0x02000000, 0x100, "Outer"),
+            (0x02000020, 0x020, "Nested"),
+        ]
+        self.assertEqual(RB._definition_symbols("src/actors/Pair.cpp", rows),
+                         ["Outer", "Nested"])
+
+    def test_stem_owner_with_a_disjoint_member_never_collapses(self):
+        rows = [
+            (0x02000000, 0x100, "Outer"),
+            (0x02000020, 0x020, "Nested"),
+            (0x02000100, 0x010, "Disjoint"),
+        ]
+        self.assertEqual(RB._definition_symbols("src/Outer.c", rows),
+                         ["Outer", "Nested", "Disjoint"])
+
+    def test_isolate_dispatches_multi_and_singleton_ownership_separately(self):
+        obj = self.repo / "Example.o"
+        obj.write_bytes(b"object")
+        with mock.patch.object(RB.OI, "isolate", return_value={"error": None}) as one, \
+                mock.patch.object(RB.OI, "isolate_many",
+                                  return_value={"error": None}) as many:
+            self.assertIsNone(RB._isolate(
+                obj, "src/Pair.cpp", {"src/Pair.cpp": ["First", "Second"]}))
+            many.assert_called_once_with(obj, ["First", "Second"])
+            one.assert_not_called()
+
+            many.reset_mock()
+            self.assertIsNone(RB._isolate(
+                obj, "src/Only.cpp", {"src/Only.cpp": ["Only"]}))
+            one.assert_called_once_with(obj, "Only")
+            many.assert_not_called()
 
 
 def _compiler():


### PR DESCRIPTION
## What

- make enrollment round-trip one source owning several function records without splitting ranges or dropping `complete`
- preserve structured multi-section delinks bodies and fail closed on partial shared-source promotion requests
- group production ownership by source and retain exact, text-only multi-function objects in ROM order
- distinguish the existing nested ITCM address aliases from real disjoint TU members without a broad overlap heuristic
- update the generated C++/TU authority report

No production source or delinks entry is promoted by this PR.

## Current compatibility

- newly ready: `enroll`, `rombuild`
- already ready: `srcpath`, `validate_merge`
- remaining hard blocker: `port_refcheck`
- remaining policy/metric gaps: `eligible`, `tiers`, `langmode_audit`, `attribution`

## Verification

- 138 focused enrollment/isolation/ROM/compatibility/state/srcpath/validation tests passed
- 2 `tubuild promote` tests and the real partial-TU comparison passed
- `python tools/enroll.py --dry-run`: 0 delinks files would change
- `python tools/cpp_tu_state.py --check-note`
- `python tools/prepush_attribution.py --base origin/main --head HEAD`: 0 changed, 0 lost
- final stock `rombuild.py -j 16 --no-rom`: 106/106 modules exact, 0 mismatches, 199 fresh compiles
- disposable two-function SceneNode pilot: cold cache-disabled build 106/106 exact; one merged object carried both symbols and replaced both legacy objects; deleting either member failed isolation instead of falling back to ROM bytes
