### PR TITLE
Migrate eleven leaf methods to real C++ (Render + CleanupResources, batch 2)

### DIFF
--- a/src/_ZN10dScEntry_c6RenderEv.cpp
+++ b/src/_ZN10dScEntry_c6RenderEv.cpp
@@ -1,21 +1,18 @@
 //cpp
 // @symbol _ZN10dScEntry_c6RenderEv
-/* recovered: renamed to Class_Method, declarations from a shared header */
+/* dScEntry_c::Render() -- vtable slot 9. Real C++ method over the shared
+ * header; local `C` models the pmf field this function touches at +0x64. */
 #include "decl_common.h"
-/* dScEntry_c::Render() -- vtable slot 9. extern "C" carries the literal
- * mangled name unmangled; local `C` models the pmf field this function
- * touches rather than including the shared header -- see
- * include/dScEntry_c.h. */
+#include "dScEntry_c.h"
 struct C;
 typedef void (C::*PMF)();
 struct C { char pad[0x64]; PMF pp[1]; };
-extern "C" {
-int _ZN10dScEntry_c6RenderEv(C *c){
+s32 dScEntry_c::Render(){
+  C *c = (C*)this;
   if(*(int*)&c->pp[0]!=0){
     PMF *p = c->pp;
     (c->**p)();
   }
   func_0203083c();
   return 1;
-}
 }

--- a/src/_ZN10dScTitle_c6RenderEv.cpp
+++ b/src/_ZN10dScTitle_c6RenderEv.cpp
@@ -1,11 +1,9 @@
 //cpp
 // @symbol _ZN10dScTitle_c6RenderEv
-/* recovered: renamed to Class_Method, declarations from a shared header */
+/* dScTitle_c::Render() -- vtable slot 9. Real C++ method over the shared
+ * header; this body never touches its own fields. */
 #include "decl_common.h"
-/* recovered: renamed to Class_Method */
-/* dScTitle_c::Render() -- vtable slot 9. extern "C" carries the literal
- * mangled name unmangled -- see include/dScTitle_c.h. This body never
- * touches its own fields, so it does not need the header. */
+#include "dScTitle_c.h"
 extern "C" {
 extern int data_0209b2f4;
 extern char data_0209e674[];
@@ -18,7 +16,7 @@ namespace OAM { void EnableSubOAM(OamTmp*);
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
 extern "C" void _ZN3OAM12EnableSubOAMEv(OamTmp*);
  }
-extern "C" int _ZN10dScTitle_c6RenderEv(void)
+s32 dScTitle_c::Render()
 {
     OamTmp tmp;
     OAM::_ZN3OAM12EnableSubOAMEv(&tmp);

--- a/src/_ZN10daPgDfdr_c6RenderEv.cpp
+++ b/src/_ZN10daPgDfdr_c6RenderEv.cpp
@@ -1,11 +1,14 @@
 //cpp
 // @symbol _ZN10daPgDfdr_c6RenderEv
-/* daPgDfdr_c::Render -- vtable slot 9. Extern "C" free function under the
-   mangled name; see src/_ZN7daDgr_c13InitResourcesEv.cpp for why it is not
-   converted to a true method body. The local shadow struct reaches
-   dBgActor_c's dBgW-style virtual the same way the pre-migration
-   file did; unrelated to daPgDfdr_c's own layout. */
+/* daPgDfdr_c::Render -- vtable slot 9. Real C++ method over the shared header.
+   The local shadow struct reaches dBgActor_c's dBgW-style virtual the same way
+   the pre-migration file did; unrelated to daPgDfdr_c's own layout. */
+#include "daPgDfdr_c.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0x320]; Sub sub; };
 extern "C" void _ZN15TextureSequence6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN10daPgDfdr_c6RenderEv(Base *c) { _ZN15TextureSequence6UpdateER15ModelComponents((char *)c + 0x384, (char *)c + 0x328); Sub *b = &c->sub; b->m(0); return 1; }
+s32 daPgDfdr_c::Render() {
+    _ZN15TextureSequence6UpdateER15ModelComponents((char *)this + 0x384, (char *)this + 0x328);
+    Sub *b = &((Base *)this)->sub; b->m(0);
+    return 1;
+}

--- a/src/_ZN11daBgSnwmn_c6RenderEv.cpp
+++ b/src/_ZN11daBgSnwmn_c6RenderEv.cpp
@@ -4,16 +4,13 @@
  * is a local stand-in for Model's own 6-slot vtable shape (mModel1/2's
  * shared g5, whichever ModelBase virtual that is) -- kept as the previous
  * recovery pass wrote it, not the typed Model member, since it calls
- * through a vtable slot rather than a named method. */
-extern "C" {
-extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
-}
+ * through a vtable slot rather than a named method. Real C++ method now. */
+#include "daBgSnwmn_c.h"
+extern "C" int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
-extern "C" {
-int _ZN11daBgSnwmn_c6RenderEv(char* c){
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x174, c+0xdc);
-  ((Sub*)(c+0xd4))->g5(c+0x80);
-  ((Sub*)(c+0x124))->g5(c+0x80);
+s32 daBgSnwmn_c::Render(){
+  _ZN15TextureSequence6UpdateER15ModelComponents((char*)this+0x174, (char*)this+0xdc);
+  ((Sub*)((char*)this+0xd4))->g5((char*)this+0x80);
+  ((Sub*)((char*)this+0x124))->g5((char*)this+0x80);
   return 1;
-}
 }

--- a/src/_ZN12dScStarSel_c16CleanupResourcesEv.cpp
+++ b/src/_ZN12dScStarSel_c16CleanupResourcesEv.cpp
@@ -1,16 +1,15 @@
 //cpp
 // @symbol _ZN12dScStarSel_c16CleanupResourcesEv
-/* recovered: renamed to Class_Method, declarations from a shared header */
+/* dScStarSel_c::CleanupResources() -- vtable slot 3. Real C++ method over the
+ * shared header. */
 #include "decl_common.h"
-/* dScStarSel_c::CleanupResources() -- vtable slot 3. extern "C" carries the
- * literal mangled name unmangled -- see include/dScStarSel_c.h. */
+#include "dScStarSel_c.h"
 class Sound {
 public:
     static void UnsetPlayerVoiceGroup();
 };
 
-
-extern "C" int _ZN12dScStarSel_c16CleanupResourcesEv(void) {
+s32 dScStarSel_c::CleanupResources() {
     CleanCommonModelDataArr();
     Sound::UnsetPlayerVoiceGroup();
     unsigned short *p = (unsigned short *)0x4000304;

--- a/src/_ZN13daObjEmmLog_c6RenderEv.cpp
+++ b/src/_ZN13daObjEmmLog_c6RenderEv.cpp
@@ -1,10 +1,10 @@
 //cpp
 // @symbol _ZN13daObjEmmLog_c6RenderEv
-// recovered name: daObjEmmLog_c_Render
-/* recovered: renamed to Class_Method */
 /* daObjEmmLog_c::Render - name recovered from the vtable slot it fills.
    The body is a decompilation verified against the ROM, not an
-   inferred stub. */
+   inferred stub. Real C++ method over the shared header; the Model
+   sub-object at +0xd4 is rendered through its own vtable. */
+#include "daObjEmmLog_c.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN13daObjEmmLog_c6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+int daObjEmmLog_c::Render() { Base *b = &((Derived *)this)->base; b->m(0); return 1; }

--- a/src/_ZN15daObjPathLift_c6RenderEv.cpp
+++ b/src/_ZN15daObjPathLift_c6RenderEv.cpp
@@ -1,24 +1,18 @@
 //cpp
 // @symbol _ZN15daObjPathLift_c6RenderEv
-/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
-#include "decl_common.h"
-/* recovered: renamed to Class_Method, RTTI class fields named */
-#include "daObjPathLift_c.h"
-// recovered name: daObjPathLift_c_Render
-/* recovered: renamed to Class_Method */
 /* daObjPathLift_c::Render - name recovered from the vtable slot it fills.
    The body is a decompilation verified against the ROM, not an
    inferred stub. unk_428 is PathLift's own tail-padding, not this class's --
-   see the header comment -- so it is read by raw offset. */
+   see the header comment -- so it is read by raw offset. Real C++ method. */
+#include "decl_common.h"
+#include "daObjPathLift_c.h"
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
-extern "C" {
-int _ZN15daObjPathLift_c6RenderEv(char* c){
-  unsigned short h = *(unsigned short*)(c + 0x428);
+int daObjPathLift_c::Render(){
+  unsigned short h = *(unsigned short*)((char*)this + 0x428);
   if(h < 0x5a){
     if(h & 1) return 1;
   }
-  func_ov002_020efc74(c);
-  ((Obj*)(c+0xd4))->m(0);
+  func_ov002_020efc74(this);
+  ((Obj*)((char*)this+0xd4))->m(0);
   return 1;
-}
 }

--- a/src/_ZN15daObjRcCarpet_c16CleanupResourcesEv.cpp
+++ b/src/_ZN15daObjRcCarpet_c16CleanupResourcesEv.cpp
@@ -1,18 +1,22 @@
 //cpp
 // @symbol _ZN15daObjRcCarpet_c16CleanupResourcesEv
+/* daObjRcCarpet_c::CleanupResources() -- vtable slot 3. Real C++ method over
+ * the shared header. The dBgW at +0x124 is PathLift's, read by raw offset (the
+ * header does not name it), and the SharedFilePtr globals are released. */
+#include "daObjRcCarpet_c.h"
 #include "SharedFilePtr.h"
 #include "dBgW.h"
 extern "C" {
 extern int data_ov002_0210d9f0[];
 extern void* data_ov036_02113f58[];
 extern int data_ov036_0211419c[];
-int _ZN15daObjRcCarpet_c16CleanupResourcesEv(char* c){
-  if (((dBgW *)(c+0x124))->IsEnabled())
-    ((dBgW *)(c+0x124))->Disable();
+}
+int daObjRcCarpet_c::CleanupResources(){
+  if (((dBgW *)((char*)this+0x124))->IsEnabled())
+    ((dBgW *)((char*)this+0x124))->Disable();
   ((SharedFilePtr *)(data_ov002_0210d9f0))->Release();
   ((SharedFilePtr *)(data_ov036_02113f58[0]))->Release();
   ((SharedFilePtr *)(data_ov036_02113f58[1]))->Release();
   ((SharedFilePtr *)(data_ov036_0211419c))->Release();
   return 1;
-}
 }

--- a/src/_ZN15daObjRcCarpet_c6RenderEv.cpp
+++ b/src/_ZN15daObjRcCarpet_c6RenderEv.cpp
@@ -1,8 +1,13 @@
 //cpp
 // @symbol _ZN15daObjRcCarpet_c6RenderEv
+/* daObjRcCarpet_c::Render -- vtable slot 9. Real C++ method over the shared
+ * header; the u16 at +0x428 (PathLift's tail-padding, read by raw offset) and
+ * the Model sub-object at +0x450 keep the recovered layout. */
+#include "daObjRcCarpet_c.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x428]; unsigned short fld; char pad2[0x450-0x42a]; Base base; };
-extern "C" int _ZN15daObjRcCarpet_c6RenderEv(Derived *d) {
+int daObjRcCarpet_c::Render() {
+    Derived *d = (Derived *)this;
     if (d->fld < 0x5a && (d->fld & 1)) return 1;
     Base *b = &d->base; b->m(0);
     return 1;

--- a/src/_ZN17daObjWlPolelift_c6RenderEv.cpp
+++ b/src/_ZN17daObjWlPolelift_c6RenderEv.cpp
@@ -1,6 +1,9 @@
 //cpp
 // @symbol _ZN17daObjWlPolelift_c6RenderEv
-/* daObjWlPolelift_c::Render -- recovered from vtable slot identity */
+/* daObjWlPolelift_c::Render -- recovered from vtable slot identity. Real C++
+ * method over the shared header; the Model sub-object at +0xd4 is rendered
+ * through its own vtable. */
+#include "daObjWlPolelift_c.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN17daObjWlPolelift_c6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+s32 daObjWlPolelift_c::Render() { Base *b = &((Derived *)this)->base; b->m(0); return 1; }

--- a/src/_ZN21ClockPaintingPendulum6RenderEv.cpp
+++ b/src/_ZN21ClockPaintingPendulum6RenderEv.cpp
@@ -1,11 +1,9 @@
 //cpp
 // @symbol _ZN21ClockPaintingPendulum6RenderEv
-// recovered name: ClockPaintingPendulum::Render
-/* recovered: renamed to Class_Method, vtable slot 9 */
-/* ClockPaintingPendulum::Render -- vtable slot 9, ov013 0x02111280. Same
- * idiom as src/_ZN4Door13InitResourcesEv.c: declared as an override in
- * include/ClockPaintingPendulum.h, defined here under the mangled symbol,
- * not as a real ClockPaintingPendulum:: method. */
+/* ClockPaintingPendulum::Render -- vtable slot 9, ov013 0x02111280. Declared
+ * as an override in include/ClockPaintingPendulum.h; real C++ method here,
+ * rendering the Model sub-object at +0xd4 through its own vtable. */
+#include "ClockPaintingPendulum.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN21ClockPaintingPendulum6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+s32 ClockPaintingPendulum::Render() { Base *b = &((Derived *)this)->base; b->m(0); return 1; }


### PR DESCRIPTION
Replaces hand-spelled `extern "C" _ZN...` free-function definitions with real
`Class::Method` bodies over each class's shared header and named members. These
functions already byte-matched; this is a readability migration and the bytes
are unchanged. Eleven leaf methods across ten classes.

| Symbol | Module |
|---|---|
| `daObjEmmLog_c::Render` | ov052 |
| `daObjWlPolelift_c::Render` | ov026 |
| `ClockPaintingPendulum::Render` | ov013 |
| `daObjPathLift_c::Render` | ov100 |
| `daObjRcCarpet_c::Render` | ov036 |
| `daBgSnwmn_c::Render` | ov072 |
| `daPgDfdr_c::Render` | ov027 |
| `dScEntry_c::Render` | ov075 |
| `dScTitle_c::Render` | ov003 |
| `dScStarSel_c::CleanupResources` | ov003 |
| `daObjRcCarpet_c::CleanupResources` | ov036 |

Each was a leaf whose body already read/wrote named members or drew a Model
sub-object; only the file's own symbol becomes a real method. Fragile callees
(by-value / `Fix12<int>`-by-value helpers — the OAM/Particle/TextureSequence
mangled entries) stay spelled as their mangled names, since converting a callee
would change how its arguments pass and break the bytes (notes/mwccarm-codegen.md
§6az). Return type is `int` or `s32` per each class's own existing header
declaration. No header edits, no layout changes, same bytes.

## Verification
- **linkcheck 11/11 VERIFIED, blind:0** (`tools/linkcheck.py`, canonical 2004/b56 pin, Europe ROM) — relocation-aware byte reproduction.
- `rombuild.py -j16 --no-rom` — all eleven functions reproduce; module fidelity unchanged from a clean `origin/main` rebuild. (The sole mismatch, `arm9 func_02071844`, is a pre-existing dsd-0.12.0 delink artifact and is not in this diff.)
- `port_refcheck.py` — 393/393 clean, zero renames/moves.
- `langmode_audit.py` ratchet — PASS.
- `git diff --check` — clean.

Reviewed with a second model (decomp-match-review lens): independently linkcheck-spot-checked 5/11, demangled all 11 against their new spellings, confirmed no header edits, no `NONMATCHING` banner, and no invented member names. Verdict: ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
