### PR TITLE
Add pull-request health monitor and repair guide

### DIFF
--- a/notes/pr-monitor.md
+++ b/notes/pr-monitor.md
@@ -1,0 +1,41 @@
+# PR monitor and repair guide
+
+Run the read-only queue monitor from a checkout with GitHub CLI authentication:
+
+```powershell
+python tools/pr_monitor.py
+```
+
+It skips #1450 by default, puts conflicts and failed checks ahead of clean work,
+and calls a PR *reviewable* only when it is not a draft, GitHub reports it clean,
+every reported check has completed successfully, and it has been open at least
+15 minutes. It never approves, rebases, pushes, or changes CI state.
+
+## Repair loop
+
+1. Work in a dedicated worktree. For decomp work, use
+   `~/.codex/skills/decomp-worktree/wt-setup.ps1`; it wires the ROM/compiler
+   inputs safely and prevents a repair from disturbing the primary checkout.
+2. Take the first `conflict` or `failed` item. Read the failed job log and compare
+   the PR diff with its merge base. Treat the check as evidence, not an obstacle.
+3. Make the smallest semantic repair that makes the check true. Resolve a conflict
+   by preserving both intended changes; fix an invalid path, broken source reference,
+   byte/relocation mismatch, header ripple, or attribution row at its source.
+4. If the failure is already fixed on current `main`, rebase the PR onto `main`
+   and rerun its relevant checks. Do not copy unrelated tooling changes into a
+   match PR. If the failure is shared but not on `main`, repair it in a separate
+   tooling PR and leave matching PRs otherwise focused.
+5. Run the same local gate named by CI, plus the relevant byte and relocation gates
+   for changed `src/` files. Never suppress a check, add a broad ignore, or bank a
+   newly broken result merely to turn CI green. If the correct repair is uncertain,
+   leave the PR untouched and record the evidence in a comment.
+6. Push only after the repair is clear. Return to the monitor and take the next
+   item; do not assume a prior check result still describes the current head.
+
+## Review and approval
+
+For a `reviewable` PR, inspect the current diff and the complete check list. Approve
+only if it remains conflict-free, all required checks are green, it has been open for
+at least 15 minutes, and the change itself has no correctness or scope issue. A green
+check is necessary evidence, not a substitute for review. Use `gh pr review <N>
+--approve` only after those conditions are independently confirmed.

--- a/tools/pr_monitor.py
+++ b/tools/pr_monitor.py
@@ -1,0 +1,113 @@
+"""Classify open GitHub pull requests without papering over their gates.
+
+Usage:
+    python tools/pr_monitor.py
+    python tools/pr_monitor.py --repo tangosdev/sm64ds-decomp --skip 1450
+
+The command is intentionally read-only.  It identifies the next repair or review
+candidate; a reviewer must inspect the diff and CI evidence before approving.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+FAILURES = {
+    "ACTION_REQUIRED", "CANCELLED", "FAILURE", "STALE", "STARTUP_FAILURE",
+    "TIMED_OUT",
+}
+
+
+def classify(pr: dict[str, Any], now: dt.datetime, minimum_age: int,
+             skipped: set[int]) -> tuple[str, str]:
+    """Return a conservative queue state and its reason for one PR payload."""
+    number = pr["number"]
+    if number in skipped:
+        return "skipped", "explicitly skipped"
+    if pr.get("isDraft"):
+        return "draft", "author still has it in draft"
+
+    checks = pr.get("statusCheckRollup") or []
+    failed = []
+    pending = []
+    for check in checks:
+        name = check.get("name", "unnamed check")
+        conclusion = (check.get("conclusion") or "").upper()
+        if check.get("status") != "COMPLETED":
+            pending.append(name)
+        elif conclusion in FAILURES:
+            failed.append(name)
+        elif conclusion not in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+            pending.append(name)
+    if pr.get("mergeStateStatus") == "DIRTY":
+        return "conflict", "GitHub reports merge conflicts"
+    if failed:
+        return "failed", "failed check: " + ", ".join(failed)
+    if pending or not checks:
+        detail = ", ".join(pending) if pending else "checks have not appeared"
+        return "waiting", detail
+
+    created = dt.datetime.fromisoformat(pr["createdAt"].replace("Z", "+00:00"))
+    age = now - created
+    if age < dt.timedelta(minutes=minimum_age):
+        return "cooldown", f"open for {int(age.total_seconds() // 60)}m"
+    if pr.get("mergeStateStatus") != "CLEAN":
+        return "merge-pending", "checks pass; GitHub mergeability is " + pr.get(
+            "mergeStateStatus", "unknown")
+    return "reviewable", "checks pass, conflict-free, and old enough"
+
+
+def _run(*args: str) -> str:
+    result = subprocess.run(args, text=True, capture_output=True)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or "command failed: " + " ".join(args))
+    return result.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", help="OWNER/REPO passed to gh; required outside a checkout")
+    ap.add_argument("--skip", type=int, action="append", default=[1450],
+                    help="PR number to omit (repeatable; default: 1450)")
+    ap.add_argument("--minimum-age", type=int, default=15,
+                    help="minutes a clean PR must be open before review (default: 15)")
+    args = ap.parse_args(argv)
+    fields = ("number,title,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,"
+              "createdAt,url")
+    command = ["gh", "pr", "list", "--state", "open", "--limit", "100",
+               "--json", fields]
+    if args.repo:
+        command.extend(["--repo", args.repo])
+    try:
+        prs = json.loads(_run(*command))
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        print(f"pr_monitor: {exc}", file=sys.stderr)
+        return 2
+
+    now = dt.datetime.now(dt.timezone.utc)
+    states: dict[str, list[tuple[dict[str, Any], str]]] = {}
+    for pr in prs:
+        state, reason = classify(pr, now, args.minimum_age, set(args.skip))
+        states.setdefault(state, []).append((pr, reason))
+
+    order = ("conflict", "failed", "waiting", "merge-pending", "reviewable",
+             "cooldown", "draft", "skipped")
+    for state in order:
+        for pr, reason in states.get(state, []):
+            print(f"{state:13} #{pr['number']:4}  {pr['title']} ({reason})")
+    for state in order:
+        if states.get(state) and state in {"conflict", "failed", "reviewable"}:
+            pr, _ = states[state][0]
+            print(f"\nnext: {state} #{pr['number']} {pr['url']}")
+            break
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pr_monitor.py
+++ b/tools/test_pr_monitor.py
@@ -1,0 +1,38 @@
+import datetime as dt
+
+from pr_monitor import classify
+
+
+NOW = dt.datetime(2026, 8, 23, 12, tzinfo=dt.timezone.utc)
+
+
+def pr(**overrides):
+    base = {
+        "number": 1, "title": "test", "isDraft": False,
+        "mergeStateStatus": "CLEAN", "createdAt": "2026-08-23T11:00:00Z",
+        "statusCheckRollup": [{"name": "validate", "status": "COMPLETED",
+                                "conclusion": "SUCCESS"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_conflict_wins_over_passing_checks():
+    assert classify(pr(mergeStateStatus="DIRTY"), NOW, 15, set())[0] == "conflict"
+
+
+def test_failed_check_needs_repair():
+    bad = [{"name": "references", "status": "COMPLETED", "conclusion": "FAILURE"}]
+    assert classify(pr(statusCheckRollup=bad), NOW, 15, set())[0] == "failed"
+
+
+def test_reviewable_requires_age_clean_merge_and_completed_checks():
+    assert classify(pr(), NOW, 15, set())[0] == "reviewable"
+    assert classify(pr(createdAt="2026-08-23T11:50:00Z"), NOW, 15, set())[0] == "cooldown"
+    waiting = [{"name": "validate", "status": "IN_PROGRESS", "conclusion": ""}]
+    assert classify(pr(statusCheckRollup=waiting), NOW, 15, set())[0] == "waiting"
+
+
+def test_skipped_and_drafts_are_never_review_candidates():
+    assert classify(pr(number=1450), NOW, 15, {1450})[0] == "skipped"
+    assert classify(pr(isDraft=True), NOW, 15, set())[0] == "draft"


### PR DESCRIPTION
Adds a read-only 	ools/pr_monitor.py queue classifier and a concise repair/review guide. It prioritizes conflicts and failed checks, skips #1450 by default, and only marks PRs reviewable after successful checks, a clean merge state, and a 15-minute cooldown.\n\nTests: python -m pytest tools/test_pr_monitor.py -q (4 passed)\n\nSeparate tooling PR; no src/ or match-batch changes.