### PR TITLE
Repair and verify the local PC port build

### DIFF
--- a/include/ArrowSignRight.h
+++ b/include/ArrowSignRight.h
@@ -4,6 +4,8 @@
 #include "types.h"
 #include "dBgW_KcMbg.h"
 
+struct Player;
+
 /* Derives from dBgActor_c: the destructor stores this class's vtable, then
  * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
  * the Model at 0xd4 before chaining to dActor_c. All three belong to dBgActor_c.
@@ -16,8 +18,58 @@
 
 #ifdef __cplusplus
 
-#include "dBgActor_c.h"
+#include "common.h"
+#include "Model.h"
 #include "ShadowModel.h"
+
+#if defined(SM64DS_PLATFORM_PC) && defined(_MSC_VER)
+#include <stddef.h>
+/* mwccarm reuses dBgActor_c's two bytes of tail padding, placing this class's
+   first derived storage at 0x31e. MSVC starts after sizeof(dBgActor_c)==0x320,
+   which shifts the derived fields and grows the object to 0x384 even though
+   ArrowSignRight_Spawn allocates exactly 0x380. The port supplies its vtable
+   manually, so use a flat host view with every exercised field pinned to the
+   ROM offset. The matching build below retains the real inheritance. */
+struct ArrowSignRight {
+    void *vtable;                      /* 0x000 */
+    u8  pad_004[0x8];
+    u16 actorID;                       /* 0x00c */
+    u8  pad_00e[0x80];
+    s16 mAngleY;                       /* 0x08e */
+    u8  pad_090[0x44];
+    Model mModel;                      /* 0x0d4 */
+    dBgW_KcMbg mMeshCollider;          /* 0x124 */
+    Matrix4x3 mClsnMat;                /* 0x2ec */
+    u8  pad_31c[0x4];
+    ShadowModel mShadowModel;          /* 0x320 */
+    u8 unk_348;                        /* 0x348 */
+    u8  pad_349[0x33];
+    u8 unk_37c;                        /* 0x37c */
+    u8  pad_37d[0x3];
+
+    ~ArrowSignRight();
+    int Behavior();
+    int CleanupResources();
+    int InitResources();
+    int Render();
+    int OnAttacked1(dActor_c &other);
+    void OnHitByMegaChar(Player &player);
+    void Kill();
+};
+
+static_assert(offsetof(ArrowSignRight, actorID) == 0x00c, "ArrowSignRight actorID");
+static_assert(offsetof(ArrowSignRight, mAngleY) == 0x08e, "ArrowSignRight mAngleY");
+static_assert(offsetof(ArrowSignRight, mModel) == 0x0d4, "ArrowSignRight mModel");
+static_assert(offsetof(ArrowSignRight, mMeshCollider) == 0x124, "ArrowSignRight collider");
+static_assert(offsetof(ArrowSignRight, mClsnMat) == 0x2ec, "ArrowSignRight matrix");
+static_assert(offsetof(ArrowSignRight, mShadowModel) == 0x320, "ArrowSignRight shadow");
+static_assert(offsetof(ArrowSignRight, unk_348) == 0x348, "ArrowSignRight +0x348");
+static_assert(offsetof(ArrowSignRight, unk_37c) == 0x37c, "ArrowSignRight +0x37c");
+static_assert(sizeof(ArrowSignRight) == 0x380, "ArrowSignRight host size");
+
+#else
+
+#include "dBgActor_c.h"
 
 struct ArrowSignRight : dBgActor_c {
     u8  pad_31e[0x2];
@@ -46,6 +98,8 @@ struct ArrowSignRight : dBgActor_c {
 };
 
 typedef char ArrowSignRight_size_must_be_0x380[sizeof(ArrowSignRight) == 0x380 ? 1 : -1];
+
+#endif /* SM64DS_PLATFORM_PC && _MSC_VER */
 
 #else
 

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(sm64ds-port C CXX)
+include(CTest)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MAP")
 add_compile_options(/Oy-)
 
@@ -8,6 +9,20 @@ add_compile_options(/Oy-)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
+
+# The matching toolchain selects C++ by an exact first-line //cpp marker even
+# when a source keeps its historical .c path. Teach the host build the same
+# rule so a verified language-mode migration cannot silently break a slice.
+function(sm64ds_honor_cpp_markers source_var)
+    foreach(source IN LISTS ${source_var})
+        if(source MATCHES "\\.c$")
+            file(STRINGS "${source}" first_line LIMIT_COUNT 1)
+            if(first_line STREQUAL "//cpp")
+                set_source_files_properties("${source}" PROPERTIES LANGUAGE CXX)
+            endif()
+        endif()
+    endforeach()
+endfunction()
 
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/slice_gate1.txt" SLICE_LINES)
 set(SLICE_SOURCES "")
@@ -18,6 +33,7 @@ foreach(line IN LISTS SLICE_LINES)
     endif()
     list(APPEND SLICE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE_SOURCES)
 
 add_executable(smoke
     tests/smoke.cpp
@@ -48,6 +64,7 @@ foreach(line IN LISTS SLICE2_LINES)
     endif()
     list(APPEND SLICE2_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE2_SOURCES)
 
 add_executable(smoke_heap tests/smoke_heap.cpp hal/heap_globals.cpp ${SLICE2_SOURCES})
 target_include_directories(smoke_heap PRIVATE
@@ -68,6 +85,7 @@ foreach(line IN LISTS SLICE3A_LINES)
     endif()
     list(APPEND SLICE3A_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE3A_SOURCES)
 
 add_executable(smoke_roots tests/smoke_roots.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp
@@ -101,6 +119,7 @@ foreach(line IN LISTS SLICE3B_LINES)
     endif()
     list(APPEND SLICE3B_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE3B_SOURCES)
 
 get_filename_component(PORT_REPO_ROOT_ABS "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
 
@@ -166,6 +185,7 @@ foreach(line IN LISTS SLICE4B_LINES)
     endif()
     list(APPEND SLICE4B_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE4B_SOURCES)
 
 # ROM constants (sine table, default matrices): generated locally from the
 # extracted arm9 image so Nintendo bytes never enter the repo.
@@ -251,6 +271,7 @@ foreach(line IN LISTS SLICE8_LINES)
     endif()
     list(APPEND SLICE8_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE8_SOURCES)
 
 add_executable(smoke_clsn tests/smoke_clsn.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
@@ -278,6 +299,7 @@ foreach(line IN LISTS SLICE7_LINES)
     endif()
     list(APPEND SLICE7_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE7_SOURCES)
 
 add_executable(smoke_modelanim tests/smoke_modelanim.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
@@ -325,10 +347,11 @@ foreach(line IN LISTS SLICE6_LINES)
     endif()
     list(APPEND SLICE6_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE6_SOURCES)
 
 add_executable(smoke_oam tests/smoke_oam.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
-    hal/model_host.cpp hal/gx_upload_bridge.cpp
+    hal/model_host.cpp hal/gx_upload_bridge.cpp hal/oam_bridge.cpp
     ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES} ${SLICE4B_SOURCES}
     ${SLICE6_SOURCES} ${GATE4A_GEN} ${GATE4B_GEN} ${GATE6_GEN} "${ROMDATA_C}")
 target_include_directories(smoke_oam PRIVATE
@@ -415,6 +438,7 @@ foreach(line IN LISTS SLICE9_LINES)
     endif()
     list(APPEND SLICE9_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${line}")
 endforeach()
+sm64ds_honor_cpp_markers(SLICE9_SOURCES)
 
 add_executable(smoke_actor tests/smoke_actor.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
@@ -432,4 +456,27 @@ target_compile_definitions(smoke_actor PRIVATE SM64DS_PLATFORM_PC
     PORT_REPO_ROOT="${PORT_REPO_ROOT_ABS}")
 if(MSVC)
     target_compile_options(smoke_actor PRIVATE /wd4311 /wd4312 /wd4068)
+endif()
+
+if(BUILD_TESTING)
+    set(PORT_SMOKE_TARGETS
+        smoke
+        smoke_heap
+        smoke_roots
+        smoke_gx
+        smoke_model
+        smoke_frames
+        smoke_soak
+        smoke_clsn
+        smoke_modelanim
+        smoke_oam
+        smoke_soak_anim
+        smoke_anim
+        smoke_fs
+        smoke_actor)
+    foreach(smoke_target IN LISTS PORT_SMOKE_TARGETS)
+        add_test(NAME ${smoke_target} COMMAND $<TARGET_FILE:${smoke_target}>)
+        set_tests_properties(${smoke_target} PROPERTIES
+            WORKING_DIRECTORY "${PORT_REPO_ROOT_ABS}")
+    endforeach()
 endif()

--- a/port/README.md
+++ b/port/README.md
@@ -16,6 +16,27 @@ build that never touches the byte-matching pipeline.
 - **32-bit host first.** The recovered ABI assumes 4-byte pointers. x64 comes
   after struct recovery makes layout host-independent.
 
+## Build locally on Windows
+
+The current port is a suite of native smoke executables, not yet a standalone
+playable game. It requires Visual Studio with the **Desktop development with
+C++** workload and its x86 tools, plus CMake, Ninja, Python, and the normal local
+ROM setup described in the repository README.
+
+Generate the gitignored asset catalog once from your own cartridge dump, then
+build and run every gate:
+
+```powershell
+python tools/asset_catalog.py generate sm64.nds
+port\build-port.cmd
+```
+
+`build-port.cmd` discovers current Community or Build Tools installations of
+Visual Studio instead of assuming a version-specific path. It configures a
+32-bit Release build under `build\port\`, builds all smoke runners, and runs all
+of them through CTest. A successful exit therefore proves both link closure and
+the runtime assertions listed below.
+
 ## Gate ledger
 
 Each gate is a slice manifest + a smoke binary that proves one seam with
@@ -30,9 +51,9 @@ game data. `build-port.cmd` builds all of them into `build\port\`.
 | 4a | `smoke_gx` | the interrupt-driven display-list pump, byte-equal vs harness |
 | 4b | `smoke_model` | the whole Model pipeline: load, rebase, VRAM upload, materials, render (Mario, textured) |
 | 4c | `smoke_anim` | Animation/UpdateBones recursion (the Mad Piano, posed) |
-| 4d | `smoke_soak` | every catalog model: 448/448 loadable render, zero faults |
+| 4d | `smoke_soak` | every compatible catalog model loads and renders with zero faults |
 | 5 | `smoke_frames` | the fiber frame loop: game-shaped frames, the piano attack in motion |
-| 5b | `smoke_soak_anim` | every compatible model+BCA pair: 472/473 animate, zero faults |
+| 5b | `smoke_soak_anim` | every compatible model+BCA pair animates and renders with zero faults |
 | 6 | `smoke_oam` | the 2D sprite engine: OAM emit, affine params, upload to mapped OAM |
 | 6b | `smoke_oam` | OBJ scan-out: the game's sprite placements become pixels |
 | 7 | `smoke_modelanim` | ModelAnim: the game owns frame progression (speed, loop wrap) |

--- a/port/build-port.cmd
+++ b/port/build-port.cmd
@@ -1,12 +1,86 @@
 @echo off
-rem Build the PC port's gate-1 smoke runner: 32-bit MSVC via VS Build Tools,
-rem same toolchain-location pattern as the recomp's build scripts.
+rem Build every PC-port smoke runner with 32-bit MSVC. Discover Visual Studio
+rem through its supported installer API so Community and Build Tools installs,
+rem including newer releases, work without editing this file.
 setlocal
-set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer;%PATH%"
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars32.bat" >nul
+
+if not exist "%~dp0..\extracted\arm9_dec.bin" (
+    echo ERROR: extracted\arm9_dec.bin is missing. Run the repository ROM setup first. 1>&2
+    exit /b 1
+)
+if not exist "%~dp0..\build\assets\files.tsv" (
+    echo ERROR: the local asset catalog is missing. 1>&2
+    echo Run: python tools\asset_catalog.py generate sm64.nds 1>&2
+    exit /b 1
+)
+if not exist "%~dp0..\build\assets\handles.tsv" (
+    echo ERROR: the local asset handle catalog is missing. 1>&2
+    echo Run: python tools\asset_catalog.py generate sm64.nds 1>&2
+    exit /b 1
+)
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+    echo ERROR: Visual Studio Installer's vswhere.exe was not found. 1>&2
+    exit /b 1
+)
+
+set "VSINSTALL="
+for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%I"
+if not defined VSINSTALL (
+    echo ERROR: no Visual Studio installation with the x86 C++ tools was found. 1>&2
+    exit /b 1
+)
+
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars32.bat" >nul
 if errorlevel 1 exit /b 1
-set "CMAKEBIN=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake"
-set "PATH=%CMAKEBIN%\CMake\bin;%CMAKEBIN%\Ninja;%PATH%"
-cmake -S "%~dp0." -B "%~dp0..\build\port" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM="%CMAKEBIN%\Ninja\ninja.exe" %*
+
+set "PYTHON_EXE="
+for /f "delims=" %%I in ('py -3 -c "import sys; print(sys.executable)" 2^>nul') do if not defined PYTHON_EXE set "PYTHON_EXE=%%I"
+if not defined PYTHON_EXE for /d %%I in ("%LocalAppData%\Programs\Python\Python*") do if exist "%%~fI\python.exe" set "PYTHON_EXE=%%~fI\python.exe"
+if not defined PYTHON_EXE for /f "delims=" %%I in ('where python.exe 2^>nul') do if not defined PYTHON_EXE set "PYTHON_EXE=%%I"
+if not defined PYTHON_EXE (
+    echo ERROR: Python 3 was not found on PATH or through py.exe. 1>&2
+    exit /b 1
+)
+"%PYTHON_EXE%" -c "import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)" >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: the discovered python.exe is not a working Python 3 installation. 1>&2
+    exit /b 1
+)
+for %%I in ("%PYTHON_EXE%") do set "PYTHON_DIR=%%~dpI"
+set "PATH=%PYTHON_DIR%;%PYTHON_DIR%Scripts;%PATH%"
+
+set "CMAKE_EXE="
+for /f "delims=" %%I in ('where cmake.exe 2^>nul') do if not defined CMAKE_EXE set "CMAKE_EXE=%%I"
+if not defined CMAKE_EXE for /d %%I in ("%LocalAppData%\Programs\Python\Python*") do if exist "%%~fI\Scripts\cmake.exe" set "CMAKE_EXE=%%~fI\Scripts\cmake.exe"
+if not defined CMAKE_EXE if exist "%VSINSTALL%\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" set "CMAKE_EXE=%VSINSTALL%\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"
+if not defined CMAKE_EXE (
+    echo ERROR: cmake.exe was not found on PATH or in Visual Studio. 1>&2
+    exit /b 1
+)
+for %%I in ("%CMAKE_EXE%") do set "CTEST_EXE=%%~dpIctest.exe"
+if not exist "%CTEST_EXE%" (
+    echo ERROR: ctest.exe was not found next to cmake.exe. 1>&2
+    exit /b 1
+)
+
+set "NINJA_EXE="
+for /f "delims=" %%I in ('where ninja.exe 2^>nul') do if not defined NINJA_EXE set "NINJA_EXE=%%I"
+if not defined NINJA_EXE for /d %%I in ("%LocalAppData%\Programs\Python\Python*") do if exist "%%~fI\Scripts\ninja.exe" set "NINJA_EXE=%%~fI\Scripts\ninja.exe"
+if not defined NINJA_EXE if exist "%VSINSTALL%\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe" set "NINJA_EXE=%VSINSTALL%\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe"
+if not defined NINJA_EXE (
+    echo ERROR: ninja.exe was not found on PATH or in Visual Studio. 1>&2
+    exit /b 1
+)
+
+"%CMAKE_EXE%" -S "%~dp0." -B "%~dp0..\build\port" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM="%NINJA_EXE%" %* -DBUILD_TESTING=ON
 if errorlevel 1 exit /b 1
-ninja -C "%~dp0..\build\port"
+"%CMAKE_EXE%" --build "%~dp0..\build\port"
+if errorlevel 1 exit /b 1
+pushd "%~dp0..\build\port"
+if errorlevel 1 exit /b 1
+"%CTEST_EXE%" --output-on-failure
+set "CTEST_RESULT=%ERRORLEVEL%"
+popd
+exit /b %CTEST_RESULT%

--- a/port/hal/actor_vtables.cpp
+++ b/port/hal/actor_vtables.cpp
@@ -14,9 +14,9 @@
 #include "ArrowSignRight.h"
 
 // The lifecycle definitions are MSVC methods (ArrowSignRight.h/fBase_c.h
-// real classes); InitResources alone is a C-named free function. Every shim
-// calls QUALIFIED -- never virtual.
-extern "C" int _ZN14ArrowSignRight13InitResourcesEv(char *self);
+// real classes). Every shim calls QUALIFIED -- never virtual.
+extern "C" int _ZN14ArrowSignRight13InitResourcesEv(char *self)
+{ return ((ArrowSignRight *)self)->ArrowSignRight::InitResources(); }
 
 static int __fastcall sl_init(void *self, void *)
 { return _ZN14ArrowSignRight13InitResourcesEv((char *)self); }
@@ -152,14 +152,6 @@ void *_ZTV11ShadowModel[8];
 void *data_ov098_0213c380[6];
 } /* extern "C" */
 
-// The extern "C" side of the cxxname bridges (see hal/cxxname_bridge.cpp).
-extern "C" {
-void _ZN13SharedFilePtr7ReleaseEv(void *self);
-void hal_fileptr_release(void *self) { _ZN13SharedFilePtr7ReleaseEv(self); }
-}
-
-
-
 extern "C" {
 /* asm primitive: plain 48-byte block copy (with writeback, unlike the
    FIFO-fixed variant) */
@@ -172,6 +164,12 @@ signed char data_0209b44c_c;
 int data_0209b468[4];      /* actor list head the ctor links into */
 }
 #pragma comment(linker, "/alternatename:?data_0209b44c@@3CA=_data_0209b44c_c")
+#pragma comment(linker, "/alternatename:_data_0209b44c=_data_0209b44c_c")
+
+// The C base constructor stores this address before the derived spawn replaces
+// it with ArrowSignRight's manual host vtable. No base virtual dispatch occurs
+// during that interval, but the storage must exist for the raw relocation.
+extern "C" void *_ZTV10dBgActor_c[32] = {};
 
 extern "C" {
 unsigned char data_0209f2d8_c;   /* mega-char state byte: none */

--- a/port/hal/clsn_vtable.cpp
+++ b/port/hal/clsn_vtable.cpp
@@ -11,6 +11,23 @@
 #include <stdlib.h>
 
 #include "dBgW_Kc.h"
+#include "dBgCh.h"
+#include "SurfaceInfo.h"
+
+namespace cstd {
+int sqrt(unsigned long long);
+int fdiv_result();
+}
+extern "C" {
+int _ZN4cstd4sqrtEy(unsigned long long value) { return cstd::sqrt(value); }
+int _ZN4cstd11fdiv_resultEv() { return cstd::fdiv_result(); }
+bool _ZN5dBgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b(
+    void *p, const CLPS &clps, const dBgCh &bg, bool flag)
+{ return dBgCh::ShouldPassThroughImpl(p, clps, bg, flag); }
+void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(
+    const SurfaceInfo *self, Vector3 *out)
+{ self->SurfaceInfo::CopyNormalTo(*out); }
+}
 
 static void __fastcall slot_v08(void *self, void *)
 { ((dBgW_Kc *)self)->dBgW_Kc::Virtual08(); }

--- a/port/hal/cxxname_bridge.cpp
+++ b/port/hal/cxxname_bridge.cpp
@@ -6,18 +6,11 @@
 // identifier.
 #include "dBgW.h"
 
-extern "C" {
-void hal_fileptr_release(void *self);
-}
-
-void _ZN13SharedFilePtr7ReleaseEv(void *self)
-{
-    hal_fileptr_release(self);
-}
 int _ZN4dBgW9IsEnabledEv(void *self)
 {
     return ((dBgW *)self)->dBgW::IsEnabled();
 }
+
 void _ZN4dBgW7DisableEv(void *self)
 {
     ((dBgW *)self)->dBgW::Disable();
@@ -29,6 +22,7 @@ void _ZN4dBgW7DisableEv(void *self)
 // SharedFilePtr pointers.
 extern "C" {
 char data_ov098_0213c384[0x18];
+char data_ov098_0213c388[0x18];
 }
 
 // ---- gate-9 method bridges (C name -> MSVC method), the gx_upload pattern -
@@ -44,7 +38,6 @@ void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void *self)
    data_020ad524 is BUILT AT RUNTIME by boot code not yet hosted (the ov000
    static image holds path strings there). InitCuboid and the per-frame
    drop-shadow install are no-ops until that boot path lands. */
-void _ZN11ShadowModel10InitCuboidEv(void *) {}
 void _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
     void *, void *, void *, int, int, int, unsigned) {}
 void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp)
@@ -81,7 +74,7 @@ void *data_020a0eac_c;
 }
 #pragma comment(linker, "/alternatename:?data_020a0eac@@3PAUHeap@@A=_data_020a0eac_c")
 #pragma comment(linker, "/alternatename:_data_020a0eac=_data_020a0eac_c")
-void func_0206e2f8(void *p, int v, unsigned n)
+extern "C" void func_0206e2f8(void *p, int v, unsigned n)
 {
     unsigned char *b = (unsigned char *)p;
     for (unsigned i = 0; i < n; ++i) b[i] = (unsigned char)v;
@@ -138,9 +131,28 @@ void hal_fill_model_vtable(void)
 }
 
 #include "ShadowModel.h"
+int ShadowModel::InitCuboid() { return 1; }
+extern "C" int _ZN11ShadowModel10InitCuboidEv(ShadowModel *self)
+{ return self->ShadowModel::InitCuboid(); }
 extern "C" {
 void hal_fill_shadow_vtable(void) {}   /* shadow system deferred */
 }
+
+// Raw Itanium spellings retained by C and local-shadow callers after the real
+// definitions migrated to C++. Each wrapper uses an explicit qualified call so
+// a synthetic host vtable cannot recurse back into the shim.
+#include "dActor_c.h"
+#include "Heap.h"
+extern "C" {
+Player *_ZN8dActor_c13ClosestPlayerEv(dActor_c *self)
+{ return self->dActor_c::ClosestPlayer(); }
+void Heap_Destroy(void *heap);
+}
+void Heap::_Destroy() { Heap_Destroy(this); }
+
+// fBase_c's local static-class shadow and the migrated namespace function are
+// both cdecl with the same two pointer arguments; only their decorations differ.
+#pragma comment(linker, "/alternatename:?Deallocate@Memory@@SAXPAXPAUHeap@@@Z=?Deallocate@Memory@@YAXPAXPAVHeap@@@Z")
 
 extern "C" {
 void *_ZN5Model23AddToCommonModelDataArrER8BMD_File(void *file)

--- a/port/hal/fs.cpp
+++ b/port/hal/fs.cpp
@@ -34,6 +34,14 @@
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
+#include "SharedFilePtr.h"
+
+extern "C" {
+void *_ZN13SharedFilePtr8LoadFileEv(SharedFilePtr *self)
+{ return self->SharedFilePtr::LoadFile(); }
+void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr *self)
+{ self->SharedFilePtr::Release(); }
+}
 
 #ifndef PORT_REPO_ROOT
 #define PORT_REPO_ROOT "."

--- a/port/hal/gx_upload_bridge.cpp
+++ b/port/hal/gx_upload_bridge.cpp
@@ -8,6 +8,18 @@
 // spellings mangle differently on MSVC; none of them add behavior.
 typedef unsigned int u32;
 typedef unsigned short u16;
+#include "SharedFilePtr.h"
+#include "ModelBase.h"
+
+// Three older callers still declare LoadFile as void. MSVC encodes return
+// types, unlike Itanium here; the call ABI is otherwise identical and all three
+// callers discard the real pointer result.
+#pragma comment(linker, "/alternatename:?LoadFile@SharedFilePtr@@QAEXXZ=?LoadFile@SharedFilePtr@@QAEPAXXZ")
+#pragma comment(linker, "/alternatename:__ZN2GX11LoadTexPlttEPKvjj=?LoadTexPltt@GX@@YAXPBXII@Z")
+#pragma comment(linker, "/alternatename:?data_020a60b0@@3IA=_data_020a60b0")
+
+namespace cstd { int abs(int); }
+extern "C" int _ZN4cstd3absEi(int value) { return cstd::abs(value); }
 
 extern "C" {
 void _ZN2GX12BeginLoadTexEv(void);
@@ -16,8 +28,6 @@ void _ZN2GX16BeginLoadTexPlttEv(void);
 void _ZN2GX14EndLoadTexPlttEv(void);
 void _ZN2GX7LoadTexEPKvjj(const void *, u32, u32);
 void _ZN2GX11LoadTexPlttEPKvjj(const void *, u32, u32);
-void _ZN13SharedFilePtr8LoadFileEv(void *);
-void _ZN15ModelComponents21UpdateVertsUsingBonesEv(void *);
 }
 
 struct GX {
@@ -35,28 +45,17 @@ void GX::EndLoadTexPltt() { _ZN2GX14EndLoadTexPlttEv(); }
 void GX::LoadTex(const void *s, u32 o, u32 z) { _ZN2GX7LoadTexEPKvjj(s, o, z); }
 void GX::LoadTexPltt(const void *s, u32 a, u32 z) { _ZN2GX11LoadTexPlttEPKvjj(s, a, z); }
 
-struct SharedFilePtr {
-    void LoadFile();
-    void ReallocateModelFile();
-};
-void SharedFilePtr::LoadFile() { _ZN13SharedFilePtr8LoadFileEv(this); }
 // Shrinks the file image to its post-parse size on the DS (a heap-space
 // optimization). Skipped on host: the image simply stays at load size.
 void SharedFilePtr::ReallocateModelFile() {}
 
-struct BCA_File;
-struct ModelComponents {
-    void UpdateVertsUsingBones();
-    void UpdateBones(BCA_File *file, int frame);
-};
-void ModelComponents::UpdateVertsUsingBones()
-{
-    _ZN15ModelComponents21UpdateVertsUsingBonesEv(this);
-}
-extern "C" void _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(void *, void *, int);
-void ModelComponents::UpdateBones(BCA_File *file, int frame)
-{
-    _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(this, file, frame);
+// Historical C-name callers -> methods that are now real C++ definitions.
+extern "C" {
+void _ZN15ModelComponents21UpdateVertsUsingBonesEv(ModelComponents *self)
+{ self->ModelComponents::UpdateVertsUsingBones(); }
+void _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(
+    ModelComponents *self, BCA_File *file, int frame)
+{ self->ModelComponents::UpdateBones(file, frame); }
 }
 
 

--- a/port/hal/heap_globals.cpp
+++ b/port/hal/heap_globals.cpp
@@ -33,8 +33,11 @@ void MultiStore_Int(int val, int *dst, int len)
 // for data (no calling convention); the decorated spellings come verbatim
 // from link errors -- the linker is the authority on decoration.
 #pragma comment(linker, "/alternatename:_data_020a4d38=__ZN6Memory16rootHeapIteratorE")
+#pragma comment(linker, "/alternatename:_data_020a4d34=__ZN6Memory25isRootHeapIterInitializedE")
 #pragma comment(linker, "/alternatename:?_ZN6Memory16rootHeapIteratorE@@3DA=__ZN6Memory16rootHeapIteratorE")
 #pragma comment(linker, "/alternatename:?_ZN6Memory25isRootHeapIterInitializedE@@3HA=__ZN6Memory25isRootHeapIterInitializedE")
+#pragma comment(linker, "/alternatename:?data_020a4d34@@3HA=__ZN6Memory25isRootHeapIterInitializedE")
+#pragma comment(linker, "/alternatename:?data_020a4d38@@3DA=__ZN6Memory16rootHeapIteratorE")
 // FUNCTION alias only where the conventions MATCH: this reference and the C
 // definition are both __cdecl free functions.
 #pragma comment(linker, "/alternatename:?_ZN18NestedHeapIteratorC1Ej@@YAXPAXI@Z=__ZN18NestedHeapIteratorC1Ej")
@@ -53,9 +56,52 @@ void _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(void *self, HeapAllocator
 int _ZN18NestedHeapIterator4NextEP13HeapAllocator(void *self, HeapAllocator *a)
 { return ((NestedHeapIterator *)self)->Next(a); }
 }
-// And the reverse direction: AddLast/AddFirst reference Init as a C++
-// __cdecl FREE function (?_ZN..4Init..@@YAXPAD0@Z, char* args) while
-// Init.cpp defines the method. C++ linkage on purpose -- extern "C" would
-// decorate this wrong.
-void _ZN18NestedHeapIterator4InitEP13HeapAllocator(char *self, char *a)
-{ ((NestedHeapIterator *)self)->Init((HeapAllocator *)a); }
+// C-name references left in the slice -> methods that have since migrated to
+// real C++. These must be forwarders, not /alternatename aliases: instance
+// methods use __thiscall on x86 MSVC while the historical C spellings are
+// __cdecl and pass `this` on the stack.
+#include "Heap.h"
+#include "ExpandingHeap.h"
+#include "ExpandingHeapAllocator.h"
+#include "MemoryNode.h"
+extern "C" {
+ExpandingHeapAllocator *_ZN4Heap28CreateExpandingHeapAllocatorEPvjj(
+    void *address, u32 size, u32 flags)
+{ return Heap::CreateExpandingHeapAllocator(address, size, flags); }
+
+void *_ZN22ExpandingHeapAllocator8AllocateEji(
+    ExpandingHeapAllocator *self, u32 size, int align)
+{ return self->Allocate(size, align); }
+
+int _ZN22ExpandingHeapAllocator10DeallocateEPv(
+    ExpandingHeapAllocator *self, void *ptr)
+{ return self->Deallocate(ptr); }
+
+void *_ZN22ExpandingHeapAllocator16AllocateForwardsEjj(
+    ExpandingHeapAllocator *self, u32 size, u32 align)
+{ return self->AllocateForwards(size, align); }
+
+void *_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj(
+    ExpandingHeapAllocator *self, u32 size, u32 align)
+{ return self->AllocateBackwards(size, align); }
+
+void *_ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(
+    MemoryNode::Target *extent, u16 tag)
+{ return ExpandingHeapAllocator::CreateNode(extent, tag); }
+
+void *_ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(
+    MemoryNode *list, MemoryNode *node, MemoryNode *prev)
+{ return ExpandingHeapAllocator::LinkNode(list, node, prev); }
+
+void *_ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(
+    MemoryNode *list, MemoryNode *node)
+{ return ExpandingHeapAllocator::UnlinkNode(list, node); }
+
+NestedHeapIterator *_ZN18NestedHeapIterator10FindNestedEPv(void *address)
+{ return NestedHeapIterator::FindNested(address); }
+
+void _ZN18NestedHeapIterator4InitEP13HeapAllocator(
+    NestedHeapIterator *self, HeapAllocator *allocator)
+{ self->Init(allocator); }
+
+}

--- a/port/hal/heap_vtable.cpp
+++ b/port/hal/heap_vtable.cpp
@@ -9,9 +9,9 @@
 // __thiscall passes it; the dummy edx parameter absorbs fastcall's second
 // register) forwarding to the real V-methods from src/.
 //
-// Slot evidence, from the shadow classes in the callers themselves:
-//   Heap::Allocate    casts to {v0,v1,v2, m(uint,int)}  -> slot 3 = VAllocate
-//   Heap::Deallocate  casts to {v0..v3,   m(void*)}     -> slot 4 = VDeallocate
+// The sources now compile against the real Heap hierarchy. On x86 MSVC one
+// deleting-destructor entry precedes the fourteen V* methods, so VAllocate and
+// VDeallocate are host slots 2 and 3 (their ROM/Itanium slots are 3 and 4).
 // Slots without caller evidence are TRAPS that abort loudly with the slot
 // number -- a silent wrong-slot dispatch is the exact class of bug the
 // hybrid's gates existed to catch, and the port has no gate to catch it.
@@ -19,19 +19,26 @@
 #include <stdlib.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include "Heap.h"
+#include "ExpandingHeap.h"
+#include "ExpandingHeapAllocator.h"
 
-typedef unsigned int u32;
+namespace Memory {
+void *Allocate(u32 size, int align, Heap *heap);
+}
+#pragma comment(linker, "/alternatename:?Allocate@Memory@@YAPAXIHPAUHeap@@@Z=?Allocate@Memory@@YAPAXIHPAVHeap@@@Z")
 
-// Shadow declarations that mangle identically to the src/ definitions.
-struct ExpandingHeap {
-    void *VAllocate(u32 size, int align);
-    int VDeallocate(void *p);
-};
-struct ExpandingHeapAllocator {
-    void *Allocate(u32 size, int align);
-    static u32 SizeofInternal(void *p);
-    u32 MemoryLeft();
-};
+extern "C" {
+u32 _ZN22ExpandingHeapAllocator14SizeofInternalEPv(void *ptr)
+{ return ExpandingHeapAllocator::SizeofInternal(ptr); }
+u32 _ZN22ExpandingHeapAllocator10MemoryLeftEv(
+    ExpandingHeapAllocator *self)
+{ return self->MemoryLeft(); }
+Heap *_ZN4Heap13SetupRootHeapEv()
+{ return Heap::SetupRootHeap(); }
+void *_ZN6Memory8AllocateEjiP4Heap(u32 size, int align, Heap *heap)
+{ return Memory::Allocate(size, align, heap); }
+}
 
 // ---- globals the root-heap chain stores through --------------------------
 extern "C" {
@@ -40,50 +47,17 @@ void *data_020a0ea0;   /* Memory::defaultHeapPtr */
 int data_02099d90;     /* heap bring-up state flag */
 }
 
-// ---- allocator methods -> the C-linkage definitions from gate 2 ----------
-extern "C" {
-void *_ZN22ExpandingHeapAllocator8AllocateEji(void *self, u32 size, int align);
-int _ZN22ExpandingHeapAllocator10DeallocateEPv(void *self, void *p);
-u32 _ZN22ExpandingHeapAllocator14SizeofInternalEPv(void *p);
-u32 _ZN22ExpandingHeapAllocator10MemoryLeftEv(void *self);
-}
-void *ExpandingHeapAllocator::Allocate(u32 size, int align)
-{ return _ZN22ExpandingHeapAllocator8AllocateEji(this, size, align); }
-u32 ExpandingHeapAllocator::SizeofInternal(void *p)
-{ return _ZN22ExpandingHeapAllocator14SizeofInternalEPv(p); }
-u32 ExpandingHeapAllocator::MemoryLeft()
-{ return _ZN22ExpandingHeapAllocator10MemoryLeftEv(this); }
-
-// ---- cross-linkage bridges surfaced by the link, both directions ---------
-// C++ method VDeallocate -> its C-linkage definition
-extern "C" int _ZN13ExpandingHeap11VDeallocateEPv(void *self, void *p);
-int ExpandingHeap::VDeallocate(void *p)
-{ return _ZN13ExpandingHeap11VDeallocateEPv(this, p); }
-
 // C references to Heap::Allocate/Deallocate -> the MSVC method definitions.
-// The src/ TUs declare `class Heap` (mangles PAV); a struct shadow here would
-// mangle PAU and miss, so the method shadow must be a class too.
-class Heap {
-public:
-    int Allocate(u32 size, int align);
-    void Deallocate(void *p);
-};
 extern "C" {
-int _ZN4Heap8AllocateEji(void *self, u32 size, int align)
+void *_ZN4Heap8AllocateEji(void *self, u32 size, int align)
 { return ((Heap *)self)->Allocate(size, align); }
 void _ZN4Heap10DeallocateEPv(void *self, void *p)
 { ((Heap *)self)->Deallocate(p); }
 }
 
-// C++ references to Memory::Allocate(u32,int,Heap*) -> the C definition
-extern "C" void *_ZN6Memory8AllocateEjiP4Heap(u32 size, int align, void *heap);
-namespace Memory {
-void *Allocate(u32 size, int align, Heap *heap)
-{ return _ZN6Memory8AllocateEjiP4Heap(size, align, heap); }
-}
-
 // Memory::defaultHeapPtr is data_020a0ea0 by its address-name (data alias).
 #pragma comment(linker, "/alternatename:?defaultHeapPtr@Memory@@3PAVHeap@@A=_data_020a0ea0")
+#pragma comment(linker, "/alternatename:?defaultHeapPtr@Memory@@3PAUHeap@@A=_data_020a0ea0")
 
 // Crash(): the game's fatal stop. Loud on host. C linkage for the .c TUs;
 // the C++-linkage references alias onto the same definition.
@@ -109,20 +83,36 @@ extern "C" void *_ZN4Heap8AllocateEj(void *self, u32 size)
 
 // ---- the synthetic vtable ------------------------------------------------
 static void *__fastcall slot_alloc(void *self, void *, u32 size, int align)
-{ return ((ExpandingHeap *)self)->VAllocate(size, align); }
-static int __fastcall slot_dealloc(void *self, void *, void *p)
-{ return ((ExpandingHeap *)self)->VDeallocate(p); }
+{ return ((ExpandingHeap *)self)->ExpandingHeap::VAllocate(size, align); }
+static void __fastcall slot_dealloc(void *self, void *, void *p)
+{ ((ExpandingHeap *)self)->ExpandingHeap::VDeallocate(p); }
+static u32 __fastcall slot_sizeof(void *self, void *, void *p)
+{ return ((ExpandingHeap *)self)->ExpandingHeap::VSizeof(p); }
+static u32 __fastcall slot_memory_left(void *self, void *)
+{ return ((ExpandingHeap *)self)->ExpandingHeap::VMemoryLeft(); }
 
 #define TRAP(n) \
     static void __fastcall slot_trap##n(void *, void *) { \
         fprintf(stderr, "FATAL: ExpandingHeap vtable slot %d dispatched " \
                         "with no caller evidence (see heap_vtable.cpp)\n", n); \
         abort(); }
-TRAP(0) TRAP(1) TRAP(2) TRAP(5) TRAP(6) TRAP(7)
+TRAP(0) TRAP(1) TRAP(4) TRAP(5) TRAP(6) TRAP(7)
+TRAP(9) TRAP(10) TRAP(12) TRAP(13) TRAP(14)
 
-extern "C" void *_ZTV13ExpandingHeap[8] = {
-    (void *)slot_trap0, (void *)slot_trap1, (void *)slot_trap2,
-    (void *)slot_alloc,        /* 3: VAllocate, pinned by Heap::Allocate */
-    (void *)slot_dealloc,      /* 4: VDeallocate, pinned by Heap::Deallocate */
-    (void *)slot_trap5, (void *)slot_trap6, (void *)slot_trap7,
+extern "C" void *_ZTV13ExpandingHeap[15] = {
+    (void *)slot_trap0,        /*  0: deleting destructor */
+    (void *)slot_trap1,        /*  1: VDestroy */
+    (void *)slot_alloc,        /*  2: VAllocate */
+    (void *)slot_dealloc,      /*  3: VDeallocate */
+    (void *)slot_trap4,        /*  4: VDeallocateAll */
+    (void *)slot_trap5,        /*  5: VIntact */
+    (void *)slot_trap6,        /*  6: VRescue */
+    (void *)slot_trap7,        /*  7: VReallocate */
+    (void *)slot_sizeof,       /*  8: VSizeof */
+    (void *)slot_trap9,        /*  9: VMaxAllocationUnitSize */
+    (void *)slot_trap10,       /* 10: VMaxAllocatableSize */
+    (void *)slot_memory_left,  /* 11: VMemoryLeft */
+    (void *)slot_trap12,       /* 12: VSetNodeID */
+    (void *)slot_trap13,       /* 13: VGetNodeID */
+    (void *)slot_trap14,       /* 14: VResizeToFit */
 };

--- a/port/hal/oam_bridge.cpp
+++ b/port/hal/oam_bridge.cpp
@@ -1,0 +1,16 @@
+// Historical raw-name calls in the OAM render TU -> real migrated static
+// methods. Static methods are cdecl, but typed wrappers keep the signatures
+// reviewable and avoid hard-coding MSVC decorations.
+#include "OAM.h"
+#include "OamAttr.h"
+
+extern "C" {
+void _ZN3OAM4LoadEv() { OAM::Load(); }
+u8 _ZN3OAM11GetObjWidthEii(int shape, int size)
+{ return OAM::GetObjWidth(shape, size); }
+u8 _ZN3OAM12GetObjHeightEii(int shape, int size)
+{ return OAM::GetObjHeight(shape, size); }
+int _ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2(
+    OamAttr *oam, int *count, Matrix2x2 *matrix)
+{ return OAM::LoadAffineParams(oam, count, matrix); }
+}

--- a/port/hal/os_time.cpp
+++ b/port/hal/os_time.cpp
@@ -14,7 +14,7 @@ typedef long long s64;
 
 static s64 g_ticks;
 
-s64 func_02059650()
+extern "C" s64 func_02059650()
 {
     return g_ticks;
 }

--- a/port/hal/shims.cpp
+++ b/port/hal/shims.cpp
@@ -29,11 +29,11 @@ int Fader::IsAtEnd() { return 0; }
 // hardware upload.
 void FaderBrightness::AdvanceFade() { AdvanceInterp(); }
 
-// The func_0203ae58 bridge that used to live here is gone, on the terms its own
-// comment set out: it existed because Fader::AdvanceInterp called the 20.12
-// approach helper by its historical address-shaped name, which the NDS build
-// resolves by address and the host cannot. That extern has now been modernised
-// to _Z14ApproachLinearRiii -- the real ROM symbol at 0x0203ae58, defined by
-// src/_Z14ApproachLinearRiii.cpp -- which is exactly what a host C++ build emits
-// for ApproachLinear(int&, int, int). The name now resolves on both sides
-// without help, so bridging it would be a duplicate definition.
+// Fader::AdvanceInterp deliberately retains the ROM's Itanium spelling as a C
+// symbol. MSVC emits its own decoration for the migrated C++ definition, so the
+// host needs a calling-convention-preserving forwarder between those spellings.
+int ApproachLinear(int &ref, int target, int step);
+extern "C" void _Z14ApproachLinearRiii(Fix12i *value, Fix12i target, Fix12i step)
+{
+    (void)ApproachLinear(*value, target, step);
+}

--- a/port/tests/smoke.cpp
+++ b/port/tests/smoke.cpp
@@ -14,7 +14,8 @@ static_assert(sizeof(u8) == 1 && sizeof(u16) == 2 && sizeof(u32) == 4, "int widt
 static_assert(sizeof(s64) == 8, "s64");
 static_assert(sizeof(void *) == 4, "32-bit host (see port/platform.h)");
 static_assert(sizeof(Fix12i) == 4, "Fix12i is a 32-bit 20.12 scalar");
-static_assert(offsetof(Timer, unk_004) == 4, "Timer +0x4");
+static_assert(offsetof(Timer, unk_000) == 0, "Timer +0x0");
+static_assert(sizeof(((Timer *)0)->unk_000) == 8, "Timer tick count is s64");
 static_assert(offsetof(Timer, mIsRunning) == 8, "Timer +0x8");
 // Fader's evidence header pins currInterp at +0x4 with the vptr at +0x0.
 // This only holds if the host vptr is exactly 4 bytes -- x86-32 MSVC -- which
@@ -62,7 +63,7 @@ static void test_timer(void)
 {
     Timer t;
     t.ResetTimer();
-    CHECK(t.mIsRunning == 0 && t.unk_000 == 0 && t.unk_004 == 0);
+    CHECK(t.mIsRunning == 0 && t.unk_000 == 0);
     CHECK(t.GetTime() == 0);
 
     t.StartTimer();

--- a/port/tests/smoke_heap.cpp
+++ b/port/tests/smoke_heap.cpp
@@ -17,6 +17,8 @@ extern "C" {
 ExpandingHeapAllocator *_ZN4Heap28CreateExpandingHeapAllocatorEPvjj(void *address, u32 size, u32 flags);
 void *_ZN22ExpandingHeapAllocator8AllocateEji(ExpandingHeapAllocator *self, u32 size, int align);
 int _ZN22ExpandingHeapAllocator10DeallocateEPv(ExpandingHeapAllocator *self, void *ptr);
+extern int _ZN6Memory25isRootHeapIterInitializedE;
+extern int data_020a4d34;
 }
 #define CreateAllocator _ZN4Heap28CreateExpandingHeapAllocatorEPvjj
 #define Alloc(a, n)     _ZN22ExpandingHeapAllocator8AllocateEji((a), (n), 4)
@@ -34,6 +36,9 @@ static u32 lcg(void) { return lcg_state = lcg_state * 1664525u + 1013904223u; }
 
 int main(void)
 {
+    /* These are two names for the same DS address, never two host globals. */
+    CHECK(&data_020a4d34 == &_ZN6Memory25isRootHeapIterInitializedE);
+
     void *arena = malloc(ARENA);
     CHECK(arena != NULL);
     ExpandingHeapAllocator *heap = CreateAllocator(arena, ARENA, 0);

--- a/src/_ZN7fBase_c21AfterCleanupResourcesEj.cpp
+++ b/src/_ZN7fBase_c21AfterCleanupResourcesEj.cpp
@@ -26,7 +26,11 @@ struct SceneNode { char b[0x14]; };
 struct PListNode { char b[0x10]; };
 
 extern "C" {
+#ifdef SM64DS_PLATFORM_PC
+  extern char data_020a4b6c;          /* host storage is supplied by actor_vtables.cpp */
+#else
   char data_020a4b6c;                 /* 0x020a4b6c */
+#endif
   char data_020a4ba8;                 /* 0x020a4ba8 */
   void func_0203b3c0(void*, void*);
   void func_0203b27c(void*, void*);


### PR DESCRIPTION
## Summary

- make the Windows launcher discover current Visual Studio, Python, CMake, and Ninja installations
- preserve the repo's first-line `//cpp` language mode across every port slice and repair migrated C++ host bridges
- register all 14 native gate executables with CTest and make the launcher run them
- document the local ROM-asset setup and clarify that the current port is a native smoke suite, not yet a standalone playable game

## Validation

- `port\build-port.cmd -DBUILD_TESTING=OFF` (forced back on by the launcher): 14/14 tests passed
- `python tools\rombuild.py -j 16 --no-rom`: 11,059/11,059 source functions reproduce; 106/106 modules exact; 0 mismatches
- `python tools\prepush_linkcheck.py --range origin/main..HEAD`: 10/10 affected sources verified
- `python tools\port_refcheck.py`: 403 references checked, 0 stale
- `python tools\check_dead_references.py`: no new dead references
