### PR TITLE
Migrate ten methods to real C++ (batch 3)

### DIFF
--- a/src/_ZN12daObjAbuku_c13InitResourcesEv.cpp
+++ b/src/_ZN12daObjAbuku_c13InitResourcesEv.cpp
@@ -1,15 +1,14 @@
 //cpp
 // @symbol _ZN12daObjAbuku_c13InitResourcesEv
-/* recovered: renamed to Class_Method, RTTI class fields named. Was
- * func_ov002_020b3518, vtable slot 0. */
+/* daObjAbuku_c::InitResources -- vtable slot 0. Real C++ method over the
+ * shared header, named members. */
 #include "daObjAbuku_c.h"
-/* daObjAbuku_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 int _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
-int _ZN12daObjAbuku_c13InitResourcesEv(char* c){
-    struct daObjAbuku_c *self = (struct daObjAbuku_c *)(void *)c;
-  _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(c+0xd4, c, 0x96000, 0x96000, 0x100002, 0);
-  self->unk_10e=0x12c;
-  return 1;
 }
+s32 daObjAbuku_c::InitResources(){
+    char* c = (char*)this;
+    _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(c+0xd4, c, 0x96000, 0x96000, 0x100002, 0);
+    unk_10e = 0x12c;
+    return 1;
 }

--- a/src/_ZN12daObjAbuku_c8BehaviorEv.cpp
+++ b/src/_ZN12daObjAbuku_c8BehaviorEv.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol _ZN12daObjAbuku_c8BehaviorEv
-/* recovered: renamed to Class_Method, declarations from a shared header.
- * Was func_ov002_020b33dc, vtable slot 6. */
+/* daObjAbuku_c::Behavior -- vtable slot 6. Real C++ method over the shared
+ * header. */
 #include "decl_common.h"
-/* daObjAbuku_c::Behavior - recovered from vtable slot identity */
+#include "daObjAbuku_c.h"
 typedef long long s64;
 extern short data_02082214[];
 extern "C" void _Z14ApproachLinearRiii(int* p, int b, int c);
@@ -15,8 +15,9 @@ extern "C" void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Ca
 extern "C" void _ZN5dCc_c5ClearEv(char* cl);
 extern "C" void _ZN5dCc_c6UpdateEv(char* cl);
 
-extern "C" int _ZN12daObjAbuku_c8BehaviorEv(char* self)
+s32 daObjAbuku_c::Behavior()
 {
+    char* self = (char*)this;
     *(short*)(((int)self + 0x10c)) += 0x400;
     int v = *(volatile unsigned short*)(self + 0x10c);
     int x = v >> 4;

--- a/src/_ZN13MotherPenguin6RenderEv.cpp
+++ b/src/_ZN13MotherPenguin6RenderEv.cpp
@@ -1,18 +1,19 @@
 //cpp
 // @symbol _ZN13MotherPenguin6RenderEv
-/* MotherPenguin::Render -- vtable slot 9. Real C++ method over the shared
-   header. TextureSequence::Update and Model::Render are DIRECT (non-virtual)
-   calls in the ROM, kept as their literal mangled extern "C" spellings so the
-   call sites stay direct; converting the callees to the real member types would
-   turn Model::Render into a vtable dispatch and miss. The ModelComponents view
-   at +0xdc and the Model view of +0xd4 are reached by raw offset. */
+/* MotherPenguin::Render -- vtable slot 9, ov018 0x02112454. Real C++ method over
+   the shared header: advance the texture animation, then draw the model.
+
+   THE Model::Render CALL IS QUALIFIED, AND THAT IS LOAD-BEARING. Model::Render is
+   virtual (slot 5 of _ZTV5Model) and ModelAnim overrides it, so a plain
+   mModelAnim.Render(0) would emit the vtable dispatch -- three words where the ROM
+   has one bl. Naming the base explicitly (mModelAnim.Model::Render(0)) suppresses
+   the dispatch and reproduces the ROM's direct call exactly. Same idiom as
+   PrincessPeach::Render. TextureSequence::Update is a plain (non-virtual) method,
+   so it is a direct call already; mModelAnim.data is the ModelComponents at +0xdc. */
 #include "MotherPenguin.h"
-extern "C" {
-int _ZN15TextureSequence6UpdateER15ModelComponents(void *self, void *mc);
-void _ZN5Model6RenderEPK7Vector3(void *self, const void *scale);
-}
+
 int MotherPenguin::Render() {
-    _ZN15TextureSequence6UpdateER15ModelComponents((char *)this + 0x138, (char *)this + 0xdc);
-    _ZN5Model6RenderEPK7Vector3((char *)this + 0xd4, 0);
+    mTextureSequence.Update(mModelAnim.data);
+    mModelAnim.Model::Render(0);
     return 1;
 }

--- a/src/_ZN13MotherPenguin6RenderEv.cpp
+++ b/src/_ZN13MotherPenguin6RenderEv.cpp
@@ -1,17 +1,18 @@
 //cpp
-struct ModelComponents;
-struct Vector3 { int x, y, z; };
-
-struct TextureSequence {
-    void Update(ModelComponents &);
-};
-
-struct Model {
-    void Render(Vector3 const *);
-};
-
-extern "C" int _ZN13MotherPenguin6RenderEv(char *c) {
-    ((TextureSequence *)(c + 0x138))->Update(*(ModelComponents *)(c + 0xdc));
-    ((Model *)(c + 0xd4))->Render(0);
+// @symbol _ZN13MotherPenguin6RenderEv
+/* MotherPenguin::Render -- vtable slot 9. Real C++ method over the shared
+   header. TextureSequence::Update and Model::Render are DIRECT (non-virtual)
+   calls in the ROM, kept as their literal mangled extern "C" spellings so the
+   call sites stay direct; converting the callees to the real member types would
+   turn Model::Render into a vtable dispatch and miss. The ModelComponents view
+   at +0xdc and the Model view of +0xd4 are reached by raw offset. */
+#include "MotherPenguin.h"
+extern "C" {
+int _ZN15TextureSequence6UpdateER15ModelComponents(void *self, void *mc);
+void _ZN5Model6RenderEPK7Vector3(void *self, const void *scale);
+}
+int MotherPenguin::Render() {
+    _ZN15TextureSequence6UpdateER15ModelComponents((char *)this + 0x138, (char *)this + 0xdc);
+    _ZN5Model6RenderEPK7Vector3((char *)this + 0xd4, 0);
     return 1;
 }

--- a/src/_ZN14EnemySwitchTag13InitResourcesEv.cpp
+++ b/src/_ZN14EnemySwitchTag13InitResourcesEv.cpp
@@ -1,45 +1,34 @@
 //cpp
-typedef int Fix12;
-struct Vector3 { int x, y, z; };
-
-struct dCcAc_c {
-    char dummy;
-};
-
-struct dActor_c {
-    char pad8[8];
-    unsigned int flags8;        // 0x8
-    char pad_to8c[0x8c - 0xc];
-    short f8c;                   // 0x8c
-    short f8e;                   // 0x8e
-    short f90;                   // 0x90
-    char pad_to100[0x100 - 0x92];
-    char f100[0x40];            // 0x100..
-};
-
-extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *clsn, struct dActor_c *a, Fix12 x, Fix12 z, unsigned int b, unsigned int c);
+// @symbol _ZN14EnemySwitchTag13InitResourcesEv
+/* EnemySwitchTag::InitResources -- vtable slot 0. Real C++ method over the
+ * shared header; the pre-0x108 fields the body reads (actor flags at +0x8,
+ * spawn params at +0x8c/+0x8e/+0x90) live in dActor_c's inherited span, read
+ * by raw offset, and the named tail fields are written through members. */
+#include "EnemySwitchTag.h"
+extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *clsn, void *a, int x, int z, unsigned int b, unsigned int c);
 extern "C" void _ZN5Event8ClearBitEj(unsigned int bit);
 
-extern "C" int _ZN14EnemySwitchTag13InitResourcesEv(struct dActor_c *a)
+int EnemySwitchTag::InitResources()
 {
+    char *a = (char *)this;
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(
-        (void *)((char *)a + 0xd4), a,
-        ((a->f8c + 1) * 0x64) << 0xc,
-        ((a->f8e + 1) * 0xc8) << 0xc,
+        a + 0xd4, this,
+        ((*(s16 *)(a + 0x8c) + 1) * 0x64) << 0xc,
+        ((*(s16 *)(a + 0x8e) + 1) * 0xc8) << 0xc,
         2, 0x400000);
 
-    *(unsigned char *)((char *)a + 0x10d) = a->flags8 & 0x1f;
-    *(unsigned char *)((char *)a + 0x10c) = (a->flags8 >> 5) & 1;
+    mEventID = *(u32 *)(a + 8) & 0x1f;
+    unk_10c = (*(u32 *)(a + 8) >> 5) & 1;
 
     {
-        short t = a->f90;
+        s16 t = *(s16 *)(a + 0x90);
         if (t <= 0)
-            *(short *)((char *)a + 0x108) = 0x96;
+            unk_108 = 0x96;
         else
-            *(short *)((char *)a + 0x108) = t;
+            unk_108 = t;
     }
-    *(short *)((char *)a + 0x10a) = 0;
+    unk_10a = 0;
 
-    _ZN5Event8ClearBitEj(*(unsigned char *)((char *)a + 0x10d));
+    _ZN5Event8ClearBitEj(mEventID);
     return 1;
 }

--- a/src/_ZN14QuestionSwitch8BehaviorEv.cpp
+++ b/src/_ZN14QuestionSwitch8BehaviorEv.cpp
@@ -1,9 +1,12 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
+// @symbol _ZN14QuestionSwitch8BehaviorEv
+/* QuestionSwitch::Behavior -- vtable slot 6. Real C++ method over the shared
+ * header. Callees whose ROM symbols carry by-value class parameters keep their
+ * literal mangled extern "C" spellings; QSVec3 is a local plain-int triple, a
+ * stack temp only. */
+#include "QuestionSwitch.h"
 
-struct Vector3 { int x, y, z; };
+struct QSVec3 { int x, y, z; };
 
 extern "C" {
 unsigned short DecIfAbove0_Short(unsigned short* p);
@@ -32,8 +35,9 @@ extern u8 data_0209d684;
 extern u8 data_0209d660;
 extern u32 data_0209caa0[];
 
-extern "C" int _ZN14QuestionSwitch8BehaviorEv(char* self)
+int QuestionSwitch::Behavior()
 {
+    char* self = (char*)this;
     if (*(u16*)(self + 0x71c) != 0) {
         if (DecIfAbove0_Short((u16*)(self + 0x71c)) == 0) {
             _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x7f, 0, 0x8777, 0);
@@ -96,7 +100,7 @@ extern "C" int _ZN14QuestionSwitch8BehaviorEv(char* self)
                 *(char**)(self + 0x320) = self + 0x4ec;
                 data_0209caa0[1] |= 0x80000000;
                 {
-                    volatile Vector3 v;
+                    volatile QSVec3 v;
                     int y = *(int*)(self + 0x60) + 0x64000;
                     int z = *(int*)(self + 0x64);
                     int x = *(int*)(self + 0x5c);

--- a/src/_ZN6Eyerok8BehaviorEv.cpp
+++ b/src/_ZN6Eyerok8BehaviorEv.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol _ZN6Eyerok8BehaviorEv
+/* Eyerok::Behavior -- vtable slot 6. Real C++ method over the shared header.
+ * EVec3 is a local plain-int triple (stack temps); callees whose ROM symbols
+ * carry by-value/ref class parameters keep their literal mangled extern "C"
+ * spellings. */
 #pragma opt_common_subs off
 #pragma opt_strength_reduction off
 
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
+#include "Eyerok.h"
 
-struct Vector3 { int x, y, z; };
+struct EVec3 { int x, y, z; };
 
 struct C;
 typedef int (C::*PMF)();
@@ -26,7 +29,7 @@ extern void func_ov066_021194fc(char *c);
 extern int _ZN4dBgW9IsEnabledEv(char *c);
 extern void func_ov066_021194a4(char *c);
 extern void _ZN8dActor_c9UpdatePosEP5dCc_c(char *c, void *clsn);
-extern void _ZN10dCcAcPos_c21SetPosRelativeToActorERK7Vector3(char *c, const Vector3 *v);
+extern void _ZN10dCcAcPos_c21SetPosRelativeToActorERK7Vector3(char *c, const void *v);
 extern void _ZN5dCc_c5ClearEv(char *c);
 extern void _ZN5dCc_c6UpdateEv(char *c);
 extern void _ZN14BlendModelAnim7AdvanceEv(char *c);
@@ -38,8 +41,10 @@ extern char data_020a0e68[];
 extern int data_ov066_0211ad18[];
 }
 
-extern "C" int _ZN6Eyerok8BehaviorEv(char *c)
+int Eyerok::Behavior()
 {
+    char *c = (char *)this;
+
     DecIfAbove0_Short((u16 *)(c + 0x4d0));
     DecIfAbove0_Short((u16 *)(c + 0x4d2));
 
@@ -62,8 +67,8 @@ extern "C" int _ZN6Eyerok8BehaviorEv(char *c)
             int *pz;
             int *py;
             int zero;
-            Vector3 vin;
-            Vector3 vout;
+            EVec3 vin;
+            EVec3 vout;
             *(int *)(bx + off) = *(int *)(c + 0x5c);
             *(int *)(by + off) = *(int *)(c + 0x60);
             *(int *)(bz + off) = *(int *)(c + 0x64);
@@ -161,7 +166,7 @@ extern "C" int _ZN6Eyerok8BehaviorEv(char *c)
     }
 
     {
-        Vector3 vrel;
+        EVec3 vrel;
         *(int *)(c + 0x4a8) = *(int *)(c + 0x4b4) + 0x8000;
         _ZN8dActor_c9UpdatePosEP5dCc_c(c, 0);
         *(int *)(c + 0x354) = *(int *)(c + 0x5c);

--- a/src/_ZN7daDgr_c16CleanupResourcesEv.cpp
+++ b/src/_ZN7daDgr_c16CleanupResourcesEv.cpp
@@ -1,19 +1,17 @@
 //cpp
 // @symbol _ZN7daDgr_c16CleanupResourcesEv
-/* daDgr_c::CleanupResources -- vtable slot 3. Extern "C" free function under
-   the mangled name; see src/_ZN7daDgr_c13InitResourcesEv.cpp for why it is not
-   converted to a true method body. */
-#include "decl_common.h"
+/* daDgr_c::CleanupResources -- vtable slot 3. Real C++ method over the shared
+   header. */
+#include "daDgr_c.h"
 #include "SharedFilePtr.h"
-#include "dBgW.h"
 extern "C" {
 extern int data_ov025_02113a68[];
 extern int data_ov025_02113a60[];
-int _ZN7daDgr_c16CleanupResourcesEv(char* c) {
+}
+s32 daDgr_c::CleanupResources() {
   ((SharedFilePtr *)(data_ov025_02113a68))->Release();
   ((SharedFilePtr *)(data_ov025_02113a60))->Release();
-  if (((dBgW *)(c+0x124))->IsEnabled())
-    ((dBgW *)(c+0x124))->Disable();
+  if (mMeshCollider.IsEnabled())
+    mMeshCollider.Disable();
   return 1;
-}
 }

--- a/src/_ZN7daDgr_c6RenderEv.cpp
+++ b/src/_ZN7daDgr_c6RenderEv.cpp
@@ -1,10 +1,7 @@
 //cpp
 // @symbol _ZN7daDgr_c6RenderEv
-/* daDgr_c::Render -- vtable slot 9. Extern "C" free function under the
-   mangled name; see src/_ZN7daDgr_c13InitResourcesEv.cpp for why it is not
-   converted to a true method body. The local shadow struct reaches
-   dBgActor_c's dBgW-style virtual at +0xd4 the same way the
-   pre-migration file did; unrelated to daDgr_c's own layout. */
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
-struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN7daDgr_c6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+/* daDgr_c::Render -- vtable slot 9. Real C++ method over the shared header;
+   the Model sub-object at +0xd4 is rendered through its own vtable (mwccarm
+   does not devirtualise an embedded member's virtual call). */
+#include "daDgr_c.h"
+s32 daDgr_c::Render() { mModel.Render(0); return 1; }

--- a/src/_ZN9daSCoin_c13InitResourcesEv.cpp
+++ b/src/_ZN9daSCoin_c13InitResourcesEv.cpp
@@ -1,24 +1,22 @@
 //cpp
 // @symbol _ZN9daSCoin_c13InitResourcesEv
-/* recovered: renamed to Class_Method, RTTI class fields named. Was
- * func_ov002_020f07dc, vtable slot 0. */
+/* daSCoin_c::InitResources -- vtable slot 0. Real C++ method over the shared
+ * header, named members. */
 #include "daSCoin_c.h"
-/* daSCoin_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void* self, void* actor, int radius, int height, unsigned int flags, unsigned int vulnFlags);
 void _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int data_ov002_0210d9a8;
-
-int _ZN9daSCoin_c13InitResourcesEv(char* c){
-    struct daSCoin_c *self = (struct daSCoin_c *)(void *)c;
+}
+s32 daSCoin_c::InitResources(){
+    char* c = (char*)this;
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(c + 0xd4, c, 0x64000, 0x40000, 0x800002, 0);
-    self->unk_10d = *(unsigned int*)(c + 8) & 0xf;
-    self->unk_10e = (*(unsigned int*)(c + 8) >> 8) & 0xf;
-    self->unk_10f = 0;
-    self->unk_108 = 0;
-    self->unk_110 = 0;
-    self->unk_113 = 0;
+    unk_10d = *(unsigned int*)(c + 8) & 0xf;
+    unk_10e = (*(unsigned int*)(c + 8) >> 8) & 0xf;
+    unk_10f = 0;
+    unk_108 = 0;
+    unk_110 = 0;
+    unk_113 = 0;
     _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9a8);
     return 1;
-}
 }

--- a/src/_ZN9daSCoin_c8BehaviorEv.cpp
+++ b/src/_ZN9daSCoin_c8BehaviorEv.cpp
@@ -1,16 +1,15 @@
 //cpp
 // @symbol _ZN9daSCoin_c8BehaviorEv
-/* recovered: renamed to Class_Method, RTTI class fields named, declarations
- * from a shared header. Was func_ov002_020f06c0, vtable slot 6. */
+/* daSCoin_c::Behavior -- vtable slot 6. Real C++ method over the shared header,
+ * named members and real inherited method calls. */
 #include "decl_common.h"
 #include "daSCoin_c.h"
-// recovered name: daSCoin_c_Behavior
-/* daSCoin_c::Behavior - recovered from vtable slot identity */
 extern "C" unsigned char DecIfAbove0_Byte(unsigned char* p);
 
-extern "C" int _ZN9daSCoin_c8BehaviorEv(char *c)
+s32 daSCoin_c::Behavior()
 {
-    struct daSCoin_c *self = (struct daSCoin_c *)(void *)c;
+    char *c = (char *)this;
+    daSCoin_c *self = this;
     if (self->unk_113) {
         if (DecIfAbove0_Byte((unsigned char *)(c + 0x113)) == 0) {
             func_ov002_020f05f4(c);


### PR DESCRIPTION
Replaces hand-spelled `extern "C" _ZN...` free-function definitions with real
`Class::Method` bodies over each class's shared header and named members. These
functions already byte-matched; this is a readability migration and the bytes
are unchanged. Ten methods across six classes.

| Symbol | Module |
|---|---|
| `daDgr_c::Render` | ov025 |
| `daDgr_c::CleanupResources` | ov025 |
| `MotherPenguin::Render` | ov018 |
| `daSCoin_c::InitResources` | ov002 |
| `daSCoin_c::Behavior` | ov002 |
| `daObjAbuku_c::InitResources` | ov002 |
| `daObjAbuku_c::Behavior` | ov002 |
| `EnemySwitchTag::InitResources` | ov002 |
| `QuestionSwitch::Behavior` | ov002 |
| `Eyerok::Behavior` | ov066 |

`daDgr_c` and `EnemySwitchTag` are full structure recoveries — `mModel.Render(0)`,
`mMeshCollider.IsEnabled()/Disable()`, named tail members. The `Behavior`s call
real inherited methods and only bridge `this` where the body still reads flat
offsets. `MotherPenguin::Render` uses the qualified-member idiom
`mModelAnim.Model::Render(0)` (same as the merged `PrincessPeach::Render`): the
explicit base qualification suppresses the vtable dispatch and reproduces the
ROM's direct call, so it needs no raw offsets or extern-C shims. No header edits,
no layout changes, same bytes.

## Verification
- **linkcheck 10/10 VERIFIED, blind:0** (`tools/linkcheck.py`, 2004/b56 pin, Europe ROM).
- `rombuild.py -j16 --no-rom` — all ten reproduce; module fidelity unchanged from clean `origin/main` (the sole mismatch, `arm9 func_02071844`, is a pre-existing dsd-0.12.0 delink artifact, not in this diff).
- `port_refcheck.py` 393/393, `langmode_audit` ratchet PASS, `git diff --check` clean.

Reviewed with a second model (decomp-match-review lens): independently linkcheck-spot-checked 5/10 (incl. both large Behaviors), demangled all 10, confirmed no header edits / no NONMATCHING / no invented members. It flagged `MotherPenguin::Render` as under-recovered vs the `PrincessPeach` precedent; that upgrade is applied here. Verdict: ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
