### PR TITLE
Migrate Door behavior and cleanup to real C++

### DIFF
--- a/include/Door.h
+++ b/include/Door.h
@@ -40,13 +40,10 @@
  * exactly the addresses above.) All five bytes still match; only the symbol
  * NAMES were placeholders (func_ov100_0214xxxx), now renamed.
  *
- * NOT CONVERTED TO REAL METHODS BY THIS PASS. Each of the five sources above
- * is still defined as a free function taking the object pointer explicitly,
- * the same idiom src/_ZN7fBase_c13InitResourcesEv.cpp uses for fBase_c's own
- * slot 0: declared here as a virtual override (so the header documents the
- * vtable completely) but never given a `Door::` definition anywhere, so
- * nothing about their bodies had to change to land the correct mangled
- * symbol.
+ * REAL METHOD STATUS. CleanupResources and Behavior are genuine `Door::`
+ * definitions. InitResources, Render and OnPendingDestroy still use the
+ * historical free-function ABI spelling; each needs its own byte-verified
+ * conversion rather than being inferred from the declaration alone.
  *
  * THEIR FIELD ACCESS, HOWEVER, IS NOW THIS HEADER'S. The naming slice left
  * Door described by two headers at once: this one, and the generated flat
@@ -122,10 +119,9 @@ struct Door : dActor_c {
 
     /* --- overrides of inherited fBase_c slots dActor_c left untouched (see
        include/dActor_c.h: "Slots 0, 3, 6, 9, 12 ... still point at the
-       fBase_c implementations"). Declared here purely so this header
-       documents the vtable completely; each is DEFINED as a free function
-       under its mangled symbol, not as a real Door:: method -- see NOT
-       CONVERTED above. --- */
+       fBase_c implementations"). CleanupResources and Behavior are real
+       Door methods; the remaining overrides retain their historical ABI
+       spellings until each can be converted without changing ROM bytes. --- */
     virtual s32 InitResources();          /* slot 0 */
     virtual s32 CleanupResources();       /* slot 3 */
     virtual s32 Behavior();               /* slot 6 */

--- a/src/_ZN4Door16CleanupResourcesEv.cpp
+++ b/src/_ZN4Door16CleanupResourcesEv.cpp
@@ -6,9 +6,9 @@
 #include "Door.h"
 #include "SharedFilePtr.h"
 /* recovered: renamed to Class_Method, vtable slot 3 */
-/* Door::CleanupResources -- vtable slot 3, ov100 0x0214542c. Declared as an
- * override in include/Door.h, defined here as an extern "C" free function
- * under the mangled symbol, the same idiom the rest of the class uses.
+/* Door::CleanupResources -- vtable slot 3, ov100 0x0214542c. This is the real
+ * virtual override declared in include/Door.h rather than a free function
+ * that only borrows the method's mangled symbol.
  *
  * FOLDED ONTO include/Door.h with the two files that used to include the
  * retired flat header. This one never included it -- it reached 0x008, 0x138
@@ -27,21 +27,21 @@ struct Elem { void* a; void* b; char pad[8]; };
 extern Elem data_ov100_02148204[];
 extern "C" {
 extern void* data_ov100_02148744;
-int _ZN4Door16CleanupResourcesEv(Door* self) {
-  Elem* e = &data_ov100_02148204[self->param1];
+}
+int Door::CleanupResources() {
+  Elem* e = &data_ov100_02148204[param1];
   Model* key;
   ((SharedFilePtr *)(e->a))->Release();
   ((SharedFilePtr *)(&data_ov100_02148744))->Release();
-  key = self->unk_138;
+  key = unk_138;
   if (key != 0) {
     delete key;
     ((SharedFilePtr *)(e->b))->Release();
   }
-  if (self->unk_13c != 0) {
-    unsigned int v = self->param1;
+  if (unk_13c != 0) {
+    unsigned int v = param1;
     if (v >= 9 && v <= 0xd) UnloadKeyModels(v - 7);
-    ((SharedFilePtr *)(self->unk_13c))->Release();
+    ((SharedFilePtr *)(unk_13c))->Release();
   }
   return 1;
-}
 }

--- a/src/_ZN4Door8BehaviorEv.cpp
+++ b/src/_ZN4Door8BehaviorEv.cpp
@@ -2,11 +2,11 @@
 // @symbol _ZN4Door8BehaviorEv
 // recovered name: Door::Behavior
 /* recovered: renamed to Class_Method, vtable slot 6 */
-/* Door::Behavior -- vtable slot 6, ov100 0x02145550. Declared as an override
- * in include/Door.h, defined here as an extern "C" free function under the
- * mangled symbol, the same idiom the rest of the class uses.
+/* Door::Behavior -- vtable slot 6, ov100 0x02145550. This is the real virtual
+ * override declared in include/Door.h rather than a free function that only
+ * borrows the method's mangled symbol.
  *
- * FOLDED ONTO include/Door.h alongside the rest of the class: `self->unk_140`
+ * FOLDED ONTO include/Door.h alongside the rest of the class: `unk_140`
  * rather than a raw `c + 0x140`. Byte-exact under the pinned 2004/b56 before
  * and after.
  *
@@ -36,11 +36,11 @@ struct CallbackNode {
 extern "C" {
 extern int func_ov100_02145370(Door *self);
 }
-extern "C" int _ZN4Door8BehaviorEv(Door *self) {
-    int res = func_ov100_02145370(self);
-    CallbackNode *node = (CallbackNode *)self->unk_140;
+int Door::Behavior() {
+    int res = func_ov100_02145370(this);
+    CallbackNode *node = (CallbackNode *)unk_140;
     if (*(int*)&node->callback != 0) {
-        (self->*(node->callback))(res);
+        (this->*(node->callback))(res);
     }
     return 1;
 }


### PR DESCRIPTION
Converts Door::CleanupResources and Door::Behavior from hand-spelled extern-C ABI functions into genuine virtual method definitions while retaining the verified class layout. Validation: strict match and relocation verification for both methods; all six Door.h consumers verified; eligibility 11065/11187 unchanged; port_refcheck clean; ROM build PASS with 106/106 modules exact.