### PR TITLE
Migrate two flying carpet methods to real C++ (batch 4)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -44,6 +44,7 @@ take over, ping the claimant first.
 | Amp, Bird | andrewboudreau | 2026-08-18 | **done** - real `dActor_c` layouts plus four cleanup hooks and two deleting destructors migrated to C++; all fourteen class consumers strict-matched and link-checked with `blind: 0`; Platform/collision work excluded |
 | AmbientSoundEffects, BobOmbBuddy | andrewboudreau | 2026-08-18 | **done** - real `dActor_c` layouts plus four cleanup/render hooks and two deleting destructors migrated to C++; all thirteen class consumers strict-matched and link-checked with `blind: 0`; Platform/collision work excluded |
 | BabyPenguin, Lakitu | andrewboudreau | 2026-08-18 | **done** - real `dActor_c` layouts plus four cleanup hooks and two deleting destructors migrated to C++; all fourteen class consumers strict-matched and link-checked with `blind: 0`; Platform/collision work excluded |
+| daObjRcCarpet_c | andrewboudreau | 2026-08-23 | **active** - converting matched InitResources and Behavior into real C++ methods; destructor variants excluded |
 
 ## Claims
 

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -44,7 +44,7 @@ take over, ping the claimant first.
 | Amp, Bird | andrewboudreau | 2026-08-18 | **done** - real `dActor_c` layouts plus four cleanup hooks and two deleting destructors migrated to C++; all fourteen class consumers strict-matched and link-checked with `blind: 0`; Platform/collision work excluded |
 | AmbientSoundEffects, BobOmbBuddy | andrewboudreau | 2026-08-18 | **done** - real `dActor_c` layouts plus four cleanup/render hooks and two deleting destructors migrated to C++; all thirteen class consumers strict-matched and link-checked with `blind: 0`; Platform/collision work excluded |
 | BabyPenguin, Lakitu | andrewboudreau | 2026-08-18 | **done** - real `dActor_c` layouts plus four cleanup hooks and two deleting destructors migrated to C++; all fourteen class consumers strict-matched and link-checked with `blind: 0`; Platform/collision work excluded |
-| daObjRcCarpet_c | andrewboudreau | 2026-08-23 | **active** - converting matched InitResources and Behavior into real C++ methods; destructor variants excluded |
+| daObjRcCarpet_c | andrewboudreau | 2026-08-23 | **done** - InitResources and Behavior migrated to real C++; strict matches and link checks verified with `blind: 0`; destructor variants excluded |
 
 ## Claims
 

--- a/src/_ZN15daObjRcCarpet_c13InitResourcesEv.cpp
+++ b/src/_ZN15daObjRcCarpet_c13InitResourcesEv.cpp
@@ -1,36 +1,40 @@
 //cpp
 // @symbol _ZN15daObjRcCarpet_c13InitResourcesEv
+#include "daObjRcCarpet_c.h"
+#include "SharedFilePtr.h"
+
 extern "C" {
-int _ZN5Model8LoadFileER13SharedFilePtr(void*);
-int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
-int _ZN9Animation8LoadFileER13SharedFilePtr(void*);
+/* SetAnim and dBgW_KcMbg::SetFile carry by-value Fix12<int> parameters.
+   Their faithful member declarations trigger mwccarm's stack-homing ABI and
+   do not reproduce these call sites, so keep the verified scalar shims. */
 int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned);
-void func_ov036_021122c0(char* c);
-int _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void*);
-int _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void*);
 int _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
 void func_020393d4(void* p, void* v);
 void func_ov002_020efaf0(void* c);
+void func_ov036_021122c0(daObjRcCarpet_c *self);
 extern int data_ov002_0210d9f0[];
-extern int data_ov036_02113f58[];
+extern void *data_ov036_02113f58[];
 extern int data_ov036_0211419c[];
 extern void _ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_();
-int _ZN15daObjRcCarpet_c13InitResourcesEv(char* c){
-  _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9f0);
-  int m = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov036_02113f58[0]);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x450, m, 1, -1);
-  _ZN9Animation8LoadFileER13SharedFilePtr(data_ov036_0211419c);
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x450, data_ov036_0211419c[1], 0, 0x1000, 0);
-  func_ov036_021122c0(c);
-  _ZN10dBgActor_c19UpdateClsnPosAndRotEv(c);
-  int k = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr((void*)data_ov036_02113f58[1]);
-  _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x199, *(short*)(c+0x8e), (void*)data_ov036_02113f58[2]);
-  func_020393d4(c+0x124, (void*)_ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
-  *(int*)(c+0x440) = 0xa000;
-  *(int*)(c+0x98) = *(int*)(c+0x440);
-  func_ov002_020efaf0(c);
-  *(int*)(c+0x43c) = 1;
-  *(unsigned char*)(c+0x42c) = 1;
-  return 1;
 }
+
+int daObjRcCarpet_c::InitResources() {
+  Model::LoadFile(*(SharedFilePtr *)data_ov002_0210d9f0);
+  void *modelFile = Model::LoadFile(*(SharedFilePtr *)data_ov036_02113f58[0]);
+  mModelAnim.SetFile((BMD_File *)modelFile, 1, -1);
+  Animation::LoadFile(*(SharedFilePtr *)data_ov036_0211419c);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(&mModelAnim, data_ov036_0211419c[1], 0, 0x1000, 0);
+  func_ov036_021122c0(this);
+  UpdateClsnPosAndRot();
+  void *clsnFile = dBgW_Kc::LoadFile(*(SharedFilePtr *)data_ov036_02113f58[1]);
+  _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+      &mMeshCollider, (int)clsnFile, &mClsnMat, 0x199, mAngleY,
+      data_ov036_02113f58[2]);
+  func_020393d4(&mMeshCollider, (void*)_ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
+  *(int*)((char*)this + 0x440) = 0xa000;
+  mHorzSpeed = *(int*)((char*)this + 0x440);
+  func_ov002_020efaf0(this);
+  *(int*)((char*)this + 0x43c) = 1;
+  *(unsigned char*)((char*)this + 0x42c) = 1;
+  return 1;
 }

--- a/src/_ZN15daObjRcCarpet_c8BehaviorEv.cpp
+++ b/src/_ZN15daObjRcCarpet_c8BehaviorEv.cpp
@@ -1,23 +1,25 @@
 //cpp
 // @symbol _ZN15daObjRcCarpet_c8BehaviorEv
+#include "daObjRcCarpet_c.h"
+
+int ApproachLinear(int &value, int target, int step);
 extern "C" {
-extern void _Z14ApproachLinearRiii(int* p, int target, int step);
-extern void _ZN8PathLift12BaseBehaviorEv(void* c);
-extern void _ZN9Animation7AdvanceEv(void* a);
-extern void func_ov036_021122c0(char* c);
-extern void func_ov036_0211224c(char* c);
+extern void func_ov036_021122c0(daObjRcCarpet_c *self);
+extern void func_ov036_0211224c(daObjRcCarpet_c *self);
+/* The true signature carries two by-value Fix12<int> parameters, which mwccarm
+   homes to the stack. Keep the verified scalar ABI spelling (runbook wall 6az). */
 extern void _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void* t, int a, int b);
 }
 
-extern "C" int _ZN15daObjRcCarpet_c8BehaviorEv(char* c){
-    if (*(unsigned char*)(c + 0x42a) != 0)
-        _Z14ApproachLinearRiii((int*)(c + 0x4bc), -0x14000, 0x5000);
+int daObjRcCarpet_c::Behavior() {
+    if (unk_42a != 0)
+        ApproachLinear(unk_4bc, -0x14000, 0x5000);
     else
-        _Z14ApproachLinearRiii((int*)(c + 0x4bc), 0, 0x5000);
-    _ZN8PathLift12BaseBehaviorEv(c);
-    _ZN9Animation7AdvanceEv(c + 0x4a0);
-    func_ov036_021122c0(c);
-    func_ov036_0211224c(c);
-    _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
+        ApproachLinear(unk_4bc, 0, 0x5000);
+    BaseBehavior();
+    mModelAnim.Advance();
+    func_ov036_021122c0(this);
+    func_ov036_0211224c(this);
+    _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(this, 0, 0);
     return 1;
 }


### PR DESCRIPTION
Converts daObjRcCarpet_c::InitResources and daObjRcCarpet_c::Behavior from hand-spelled extern-C definitions and raw object offsets into genuine class methods using the verified PathLift, ModelAnim, collision, and actor members. The only remaining mangled call shims are the documented by-value Fix12 ABI wall. Validation: both functions strict-match mwccarm 2004/b56 and linkcheck VERIFIED with blind 0; eligibility remains 11065/11187; port_refcheck is clean; full ROM build passes with 11059 reproducing, 0 mismatches, and 106/106 modules exact.