### PR TITLE
Resolve _ZTV relocations by addend, not by name alone

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -213,13 +213,19 @@ def plan(raw, keep_symbol):
                 # The predicted case above, now real: an INLINE BASE DESTRUCTOR.
                 # `Scene::~Scene()` inlines ~ActorDerived, so the object stores
                 # _ZTV12ActorDerived without ever defining it -- UNDEF from the
-                # start, addend 8, never a candidate for externalisation. The
-                # correction is the same arithmetic the externalise path uses, and
-                # it is verified the same way: rombuild byte-compares the linked
-                # module, which is the only thing that caught the original 8-high
-                # vptr bug. A different addend is still refused.
+                # start, addend 8, never a candidate for externalisation. A
+                # constructor-only TU of an MI class stores its SECONDARY vptr
+                # the same way: UNDEF _ZTV<C>, addend 24 = 8 preamble + 0x10
+                # into the secondary block, which must land on the ROM's
+                # separately named thunk table. That is exactly the
+                # externalise case's arithmetic, whose enrolled instance
+                # (ModelAnim: 44 - 8 = +0x24 = VTable_Animation_ModelAnimThunk)
+                # is the verification the original refusal asked for, and
+                # rombuild's module byte-compare still checks every landing.
+                # Non-_ZTV RTTI addends stay refused, and so does any _ZTV
+                # addend below the preamble: no surveyed shape produces one.
                 if addend and not (sym.name.startswith("_ZTV")
-                                   and addend == VTABLE_PREAMBLE):
+                                   and addend >= VTABLE_PREAMBLE):
                     return {"error": f"{sym.name}: undefined RTTI reference with "
                                      f"addend {addend}; the ROM symbol is already the "
                                      f"slot array, so this would land {addend} past it"}

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -139,10 +139,42 @@ def rel_section_for(elf, shndx):
     return None
 
 
-def object_reloc_dests(obj, func, name_index):
+# objisolate.VTABLE_PREAMBLE; kept a literal so this module stays import-light.
+# mwcc's own `_ZTV<C>` symbol addresses the vtable OBJECT -- offset-to-top,
+# typeinfo, then the slot array -- while symbols.txt's `_ZTV<C>` IS the slot
+# array. The 8-byte gap is exactly what objisolate subtracts when it rewrites a
+# vptr store's addend for the ROM link.
+_VT_PREAMBLE = 8
+
+
+def object_reloc_dests(obj, func, name_index, vt_form="raw"):
     """[(offset, symname, resolved_module, resolved_addr)] for relocs inside func.
 
-    Returns (None, reason) if the function symbol isn't in the object."""
+    Returns (None, reason) if the function symbol isn't in the object.
+
+    Everything is resolved by symbol NAME alone except `_ZTV<C>` data relocs,
+    which are ADDEND-AWARE. A synthesized vptr store names the class's one
+    `_ZTV` symbol for every block it stores -- primary AND each inherited
+    secondary -- and encodes which block in the RELA addend: 8 for the primary
+    (the preamble) plus 0x10 per secondary block past it. Resolving those by
+    name alone sends every block to the same address and reports WRONG-DEST on
+    an object whose linked form is exact (measured on _ZN9dBgCh_LinC1Ev:
+    addends 8/0x18 against _ZTV9dBgCh_Lin 0x020992a4, config destinations
+    0x020992a4/0x020992b4). The destination the build links is
+    sym + addend - _VT_PREAMBLE.
+
+    Branch relocs keep name-only resolution: their nonzero addends are PC-bias
+    encoding (-8), not addressing, and must not be added on.
+
+    vt_form says which side of objisolate's rewrite `obj` sits on, because the
+    flag cannot be inferred from the object: a raw object's secondary store
+    carries 0x18 while an isolated one carries 0x10, and both are >= the
+    preamble.
+      "raw"      straight from mwccarm (match.py, build_pin.py, bank_harvest,
+                 nearmiss_db, symscope); the preamble is still in the addend
+      "isolated" post-objisolate (reloc_audit's winning_object path);
+                 objisolate already subtracted it
+    """
     elf = ELFFile(io.BytesIO(obj))
     symtab = elf.get_section_by_name(".symtab")
     syms = list(symtab.iter_symbols())
@@ -153,6 +185,7 @@ def object_reloc_dests(obj, func, name_index):
     rel = rel_section_for(elf, sym["st_shndx"])
     dests = []
     if rel is not None:
+        is_rela = rel.header["sh_type"] == "SHT_RELA"
         for r in rel.iter_relocations():
             o = r["r_offset"] - start
             if not (0 <= o < size):
@@ -160,6 +193,12 @@ def object_reloc_dests(obj, func, name_index):
             tsym = syms[r["r_info_sym"]]
             res = resolve_candidate(tsym.name, name_index)
             mod, addr = (res if res else (None, None))
+            if is_rela and res is not None and tsym.name.startswith("_ZTV"):
+                addend = r["r_addend"]
+                if vt_form == "isolated":
+                    addr += addend
+                elif addend >= _VT_PREAMBLE:
+                    addr += addend - _VT_PREAMBLE
             dests.append((o & ~3, tsym.name, mod, addr))
     return dests, size
 
@@ -351,9 +390,14 @@ def known_modules():
     return {m for m, _path in R.iter_reloc_files(include_itcm_dtcm=True)}
 
 
-def check_destinations(obj, sym, addr, size, mod, name_index, config_relocs, sym_index):
+def check_destinations(obj, sym, addr, size, mod, name_index, config_relocs, sym_index,
+                       vt_form="raw"):
     """Per-reloc destination verdicts for an in-hand object. Shared by the audit
     and the match gate (match.py --strict-relocs).
+
+    vt_form passes through to object_reloc_dests: which side of objisolate's
+    vtable-addend rewrite `obj` sits on. The audit feeds isolated objects
+    (winning_object), every other caller compiles fresh and feeds raw.
 
     Returns (rows, missing) where rows is a list of dicts (one per object reloc in
     the function) and missing is the count of config relocs the candidate lacks.
@@ -370,7 +414,7 @@ def check_destinations(obj, sym, addr, size, mod, name_index, config_relocs, sym
     if normalized not in known_modules():
         return None, (f"unknown module {mod!r} (normalizes to {normalized!r}); "
                       f"expected one of arm9, itcm, dtcm, ovNNN")
-    dests, size_or_reason = object_reloc_dests(obj, sym, name_index)
+    dests, size_or_reason = object_reloc_dests(obj, sym, name_index, vt_form)
     if dests is None:
         return None, size_or_reason
     cfgmap = config_relocs.get(normalized, {})
@@ -407,14 +451,16 @@ def warm_gate_index():
     return _GATE_IDX
 
 
-def gate_wrong_dests(obj, sym, addr, size, mod):
+def gate_wrong_dests(obj, sym, addr, size, mod, vt_form="raw"):
     """Bank-gate wrapper around check_destinations: WRONG-DEST rows only, with the
     three config indexes built once and cached for the process. Returns [] when the
     object's reloc destinations agree with config, None when the symbol is absent
-    from the object (callers treat that as a verification failure)."""
+    from the object (callers treat that as a verification failure). vt_form passes
+    through to check_destinations/object_reloc_dests."""
     name_index, config_relocs, sym_index = warm_gate_index()
     rows, _missing = check_destinations(obj, sym, addr, size, mod,
-                                        name_index, config_relocs, sym_index)
+                                        name_index, config_relocs, sym_index,
+                                        vt_form)
     if rows is None:
         return None
     return [r for r in rows if r["verdict"] == "WRONG-DEST"]
@@ -430,7 +476,8 @@ def audit_entry(entry, name_index, config_relocs, sym_index):
         return {"name": name, "module": mod, "addr": f"0x{addr:08x}",
                 "verdict": "NO-REPRO", "reason": err, "relocs": []}
     rows, missing = check_destinations(obj, sym, addr, size, mod,
-                                       name_index, config_relocs, sym_index)
+                                       name_index, config_relocs, sym_index,
+                                       vt_form="isolated")
     if rows is None:
         return {"name": name, "module": mod, "addr": f"0x{addr:08x}",
                 "verdict": "NO-SYM", "reason": missing, "relocs": []}

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -703,6 +703,28 @@ class Isolate(unittest.TestCase):
         self.assertEqual(after, [a - 8 for a in before])
         self.assertIn(0, after)          # the primary landed on the slot array
 
+    def test_corrects_ctor_only_mi_secondary_vptr(self):
+        """A constructor-only TU of an MI class stores its secondary vptr UNDEF.
+
+        The vtable's key function is the destructor, so an MI class's
+        constructor-only TU references `_ZTV1M` without defining it -- twice:
+        addend 8 for the primary store, and 24 (8 preamble + 0x10 into the
+        secondary block) for the secondary. The secondary used to be refused
+        on the UNDEF path while no enrolled instance verified the arithmetic;
+        ModelAnim's externalised 44 - 8 = +0x24 thunk landing is that
+        verification, and dBgCh_Lin's constructor is the first enrolled
+        function to walk this exact path."""
+        obj = self.build("struct B1 { int p[4]; virtual ~B1(){} };\n"
+                         "struct B2 { int q[4]; virtual ~B2(){} };\n"
+                         "struct M : B1, B2 { M(); virtual ~M(); };\n"
+                         "M::M(){}\n")
+        self.assertIsNone(OI.plan(obj.read_bytes(), "_ZN1MC1Ev")["error"])
+        before = sorted(set(self._vtable_addends(obj, "_ZN1MC1Ev")))
+        self.assertEqual(before, [8, 24])
+        OI.isolate(obj, "_ZN1MC1Ev")
+        after = sorted(set(self._vtable_addends(obj, "_ZN1MC1Ev")))
+        self.assertEqual(after, [0, 16])
+
     def test_still_refuses_a_vtable_addend_below_the_preamble(self):
         """Correctable means "past the preamble". An addend under it is not.
 


### PR DESCRIPTION
## Summary

A synthesized vptr store names the class's **one** `_ZTV<C>` symbol for every block it stores — the primary **and** each inherited secondary — and encodes which block it means in the RELA addend. Resolving those by name alone sends every block to the same address, so a constructor over a multiply-inherited class is reported `WRONG-DEST` **on an object whose linked form is exact**.

The destination the build actually links is `sym + addend - 8`, where 8 is the vtable preamble (offset-to-top + typeinfo): mwcc's `_ZTV<C>` addresses the vtable *object*, while `symbols.txt`'s `_ZTV<C>` **is** the slot array.

Branch relocs keep name-only resolution — their nonzero addends are PC-bias encoding (`-8`), not addressing, and must not be added on. Which side of `objisolate`'s rewrite an object sits on cannot be inferred from the object (a raw secondary store carries `0x18` where an isolated one carries `0x10`, and both are `>=` the preamble), so callers pass `vt_form` (`"raw"` / `"isolated"`) to say.

## Why this is its own PR

Extracted from #1740. The validator audits a PR using the **base commit's** copy of these tools, so a PR that both fixes the resolver *and* adds code depending on the fix gets judged by the unfixed resolver. #1740 currently fails on exactly that:

| Auditor | Verdict on #1740's constructors |
|---|---|
| #1740's (fixed) | 0 WRONG |
| main's (unfixed) | 3 WRONG — `_ZN12dBgCh_SphCrrC1Ev`, `_ZN9dBgCh_GndC1Ev`, `_ZN9dBgCh_LinC1Ev`, all `_ZTV` slots |

Same shape as the compiler-pin split: land the gate fix first, then the code that needs it.

## Validation

- **Verdict-neutral on main.** All 11 real C++ constructor `.cpp` files link-check identically with and without this change — no verdict moves today.
- `pytest tools/test_objisolate.py` — **26/26 pass**, including the new addend cases.
- Measured on `_ZN9dBgCh_LinC1Ev`: addends `8`/`0x18` against `_ZTV9dBgCh_Lin` `0x020992a4`, config destinations `0x020992a4`/`0x020992b4`.
- Tools-only; no `src/`, no `config/`, no effect on the ROM build.

## After this lands

Re-run #1740 — its 3 blocking relocation verdicts should clear. Its remaining `NO-SYM` (`src/_ZN3MrI13InitResourcesEv.cpp`) is separate and **pre-existing on main**: byte-identical to main, untouched by that PR, reached only through header fan-out, and it fails on a clean `origin/main` worktree under every compiler with `class 'Vector3' redefined`. It is enrolled in no `delinks.txt`, so the ROM build never compiles it. That one wants its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01329VASaGxqnUYPcJ57sLPH