### PR TITLE
MrI::InitResources compiles again: drop the shadow Vector3, put //cpp on line 1

### DIFF
--- a/src/_ZN3MrI13InitResourcesEv.cpp
+++ b/src/_ZN3MrI13InitResourcesEv.cpp
@@ -1,5 +1,5 @@
-#include "TextureSequence.h"
 //cpp
+#include "TextureSequence.h"
 // NONMATCHING: constant / value (div=6). Logic verified correct vs ROM; not
 // byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
 // Counts as decompiled, not matched.
@@ -7,7 +7,10 @@ struct BMD_File;
 struct BTP_File;
 struct BCA_File;
 struct dActor_c;
-struct Vector3 { int x, y, z; };
+/* Vector3 comes from types.h through TextureSequence.h; the local shadow
+   `struct Vector3 { int x, y, z; }` collided with it and this file has not
+   compiled since. Fix12i is `s32`, so the header type is layout- and
+   value-identical -- the Q12 literals below are unchanged. */
 struct SharedFilePtr { void *hdr; void *ptr; };
 
 struct BMD_File;


### PR DESCRIPTION
## Summary

Two silent defects in the first ten lines of `src/_ZN3MrI13InitResourcesEv.cpp`.

**1. `Vector3` redefined.** The file declares `struct Vector3 { int x, y, z; };` locally while line 1 includes `TextureSequence.h`, which reaches types.h's real `Vector3`. The header wins and mwccarm aborts:

```
class 'Vector3' redefined — Errors caused tool to abort.
```

under **every** compiler version in the sweep. The shadow is redundant, not load-bearing: `Fix12i` is `s32`, so `struct Vector3 { Fix12i x, y, z; }` is layout- and value-identical and the Q12 literals (`-0x4b000`, `-0x96000`) keep their meaning exactly.

**2. The `//cpp` marker was inert.** It sat on line 2, behind the include. Every tool tests `text.startswith("//cpp")` (`match.py:257`, `rombuild.py:471`), so the file was handed to `-lang c99`, which cannot parse its `extern "C"` block. `match.py --cpp-check` lints for precisely this — *"is a .cpp file but lacks '//cpp' header on line 1"*.

## Why nobody noticed

The file is enrolled in **no** `delinks.txt`, so the ROM build never compiles it. It is one of the "claimed, not byte-verified" set where dsd fills the address with the cartridge's own bytes. Only `pr_linkcheck`'s isolated compile ever looks at it — and only when a PR happens to touch a header it transitively includes.

## Validation

| | before | after |
|---|---|---|
| `pr_linkcheck` | `NO-SYM` (fails) | `ok(drf)` |
| `rombuild --no-rom` | 11,059/11,059, 106/106 | **unchanged** |

It remains a NONMATCHING draft — it now *compiles* as one instead of failing to build at all. No byte-level claim is made or changed.

## Scope

Found via #1740, which reached this file through header fan-out and was credited with its breakage. The file is byte-identical to main there and untouched by that PR.

Eight other files carry an inert `//cpp` marker. **All eight are ENROLLED and byte-match today as c99**, so moving their marker would flip their language mode and put real matches at risk. Deliberately left alone — they want their own measured change:

```
ENROLLED  src/_ZN14BlueCoinSwitch13InitResourcesEv.cpp   src/func_ov006_020e7fe8.cpp
ENROLLED  src/_ZN6Number13InitResourcesEv.cpp            src/func_ov060_02111cc0.cpp
ENROLLED  src/_ZN8Goomboss13InitResourcesEv.cpp          src/func_ov075_021143e4.cpp
ENROLLED  src/func_ov002_020f6618.cpp                    src/func_ov075_02114ddc.cpp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01329VASaGxqnUYPcJ57sLPH