### PR TITLE
Print the compiler's own words when the ROM build fails

### DIFF
--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -475,5 +475,38 @@ class ModuleFidelityDetail(unittest.TestCase):
         self.assertIn("range outside built or retail module", out)
 
 
+class RomFailureDetailTest(unittest.TestCase):
+    """A failed ROM build must reach the author as the compiler said it, not as
+    the phase name alone -- "mwccarm failed" is unactionable, and when the box
+    and the author disagree it is the only evidence there is."""
+
+    def test_failure_output_is_rendered_with_phase_and_exit_code(self):
+        out = "\n".join(VM._rom_failure_detail({"failure": {
+            "phase": "mwccarm", "returncode": 1,
+            "output": "the file 'Clipper.h' cannot be opened"}}))
+        self.assertIn("the file 'Clipper.h' cannot be opened", out)
+        self.assertIn("mwccarm failed", out)
+        self.assertIn("exit 1", out)
+        self.assertIn("<details>", out)
+
+    def test_a_successful_build_renders_nothing(self):
+        self.assertEqual(VM._rom_failure_detail({"analysis": {}}), [])
+        self.assertEqual(VM._rom_failure_detail(None), [])
+
+    def test_a_failure_that_captured_no_output_renders_nothing(self):
+        # Better the bare table row than an empty code fence.
+        self.assertEqual(
+            VM._rom_failure_detail({"failure": {"phase": "mwldarm", "output": "   "}}), [])
+        self.assertEqual(
+            VM._rom_failure_detail({"failure": {"phase": "mwldarm"}}), [])
+
+    def test_long_output_keeps_the_tail_where_the_error_is(self):
+        noisy = ("compiling something" + chr(10)) * 500 + "FATAL: the real error"
+        out = "\n".join(VM._rom_failure_detail(
+            {"failure": {"phase": "mwccarm", "returncode": 1, "output": noisy}}))
+        self.assertIn("FATAL: the real error", out)
+        self.assertIn("trimmed", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -840,12 +840,42 @@ def render_markdown(r):
                       f"with the ROM's own bytes. Both together are the "
                       f"{h['matchedFunctions']:,} this project calls matched."]
     lines += _module_fidelity_detail(head_rom)
+    lines += _rom_failure_detail(head_rom)
     if r["warnings"]:
         lines += ["", "Warnings: " + "; ".join(r["warnings"]) + "."]
     return "\n".join(lines)
 
 
 SHOWN = 12
+
+
+def _rom_failure_detail(head_rom):
+    """Print the compiler's own words when the ROM build dies, not just the phase name.
+
+    rombuild.py already captures up to 4000 chars of the failing phase's output into
+    failure["output"] (rombuild.py:799), and the summary table rendered only
+    failure["phase"] -- so a build that died on one bad #include reached the author as
+    the four words "mwccarm failed" and nothing else. That is unactionable from the PR
+    page and actively misleading when the box and the author's machine disagree: the
+    author sees a clean local build and has no way to learn what the box saw. Same
+    defect and same remedy as _module_fidelity_detail above.
+
+    Returns markdown lines, or [] when the build did not fail or said nothing.
+    """
+    failure = (head_rom or {}).get("failure")
+    if not failure:
+        return []
+    out = (failure.get("output") or "").strip()
+    if not out:
+        return []
+    LIMIT = 3000
+    if len(out) > LIMIT:
+        out = "[... earlier output trimmed, showing the last " + str(LIMIT) + " chars ...]" + chr(10) + out[-LIMIT:]
+    phase = failure.get("phase")
+    code = failure.get("returncode")
+    return ["",
+            "<details><summary>Full ROM build output (%s failed, exit %s)</summary>" % (phase, code),
+            "", "```", out, "```", "", "</details>"]
 
 
 def _module_fidelity_detail(head_rom):


### PR DESCRIPTION
## Summary

`| Full ROM build | mwccarm failed |` is the entire verdict a failing build reaches the author with.

`rombuild.py` has captured up to 4000 chars of the failing phase's output into `failure["output"]` all along (`rombuild.py:799`). The summary table rendered `failure["phase"]` and dropped the rest.

## Why it matters

It is unactionable from the PR page, and it is worst exactly when it matters most: **when the box and the author's machine disagree.** The author sees a clean local build — cold, merged, full packaging — and has no way to learn what the box saw, because the one artifact that would say is discarded before it is posted.

Chasing #1740's `mwccarm failed` cost a long session and ended *without* the error text, having ruled out:

- include case and missing includes (0 problems across 11,798 files)
- case-colliding paths (0, on both the PR and main)
- the compiler pin table (byte-identical either side)
- the `mods/` source replacement (tracked, documented, same both sides)
- duplicate `.c`/`.cpp` after the rename (clean D+A)
- a stale verdict (comment `updatedAt` postdates the head commit)

Any one line of compiler output would have settled it immediately.

## Precedent

Same defect and same remedy as `_module_fidelity_detail`, added after a bare `105/106 exact` *"cost a full day on #1607"*. The worker already ships the detail — put it in the comment.

## Shape

- Collapsed `<details>` block **after** the table, so the summary stays short and the table stays valid markdown.
- Keeps the **last** 3000 chars, not the first — mwccarm prints the fatal line last, after any warnings — and says so when it trims.
- Renders **nothing** when the build passed or captured no output, so a green comment is byte-identical to today's.

## Validation

`pytest tools/test_validate_merge.py` — **33 pass** (29 existing + 4 new): output rendered with phase and exit code; success renders nothing; a failure that captured no output renders nothing rather than an empty code fence; long output keeps the tail where the error is.

Note this only takes effect once merged — `run-worker.sh` restores `tools/` from the **base** commit (`git checkout "$base" -- tools`), so a PR cannot test its own change to this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01329VASaGxqnUYPcJ57sLPH