### PR TITLE
Name 69 more standalone-struct fields, from evidence that was already in the tree

### DIFF
--- a/include/ArrowLift.h
+++ b/include/ArrowLift.h
@@ -20,7 +20,7 @@ struct ArrowLift {
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
     dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
     u8  pad_2ec[0x34];
-    s32 unk_320;            /* 0x320 */
+    s32 mTravelDist;            /* 0x320 */
     /* trailing extent the ROM's `new ArrowLift` literal proves; see tools/opnew_sizes.py */
     u8 pad_324[0x4];
 #ifdef __cplusplus

--- a/include/BowserPuzzlePiece.h
+++ b/include/BowserPuzzlePiece.h
@@ -21,7 +21,7 @@ struct BowserPuzzlePiece {
        dBgW_KcMbg's D1 at +0x124 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN17BowserPuzzlePieceD1Ev.c] */
     dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
-    u8  unk_2ec;            /* 0x2ec */
+    u8  mClsnMat;            /* 0x2ec */
     u8  pad_2ed[0x37];
     s32 mStateInfo;            /* 0x324 */
     u8  mStateIndex;            /* 0x328 */

--- a/include/BrickBlock.h
+++ b/include/BrickBlock.h
@@ -13,9 +13,9 @@ struct BrickBlock {
     u8  pad_00e[0xc6];
     s8  unk_0d4;            /* 0x0d4 */
     u8  unk_0d5;            /* 0x0d5 */
-    u8  unk_0d6;            /* 0x0d6 */
-    u8  unk_0d7;            /* 0x0d7 */
-    u8  unk_0d8;            /* 0x0d8 */
+    u8  mActionPending;            /* 0x0d6 */
+    u8  mActionIndex;            /* 0x0d7 */
+    u8  mIsAttached;            /* 0x0d8 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -45,15 +45,15 @@ struct Camera {
     Vector3 savedLookAt;            /* 0x0b0 */
     Vector3 savedPos;            /* 0x0bc */
     u8  pad_0c8[0x48];
-    s32 unk_110;            /* 0x110 */
+    s32 mTargetPlayer;            /* 0x110 */
     u8  pad_114[0x24];
     /* Current state. ChangeState compares its argument against this, and only
        swaps it -- and clears unk_1a6 -- when they differ. */
     struct State* mState;            /* 0x138 */
-    s32 unk_13c;            /* 0x13c */
+    s32 mState_13c;            /* 0x13c */
     u8  pad_140[0x8];
     /* Owned; CleanupResources deletes it. */
-    void* unk_148;            /* 0x148 */
+    void* mFixedViewPos;            /* 0x148 */
     u8  pad_14c[0x8];
     /* Flag word. Bit 0 is under-water (Camera::IsUnderwater returns it
        masked, not normalised); 0x10 vetoes a state change; 0x4000 records

--- a/include/Cannon.h
+++ b/include/Cannon.h
@@ -35,7 +35,7 @@ struct Cannon {
     s32 mState;            /* 0x180 */
     /* Cannon variant, the low two bits of the spawn word. */
     u8  unk_184;            /* 0x184 */
-    u8  unk_185;            /* 0x185 */
+    u8  mFireStep;            /* 0x185 */
     u8  pad_186[0xe];
     /* Read out of *(*(this + 0xe4) + 0x58) by InitResources -- the last field
        of the object, and what closes the 0x198 Cannon_Spawn allocates. */

--- a/include/ChainChomp.h
+++ b/include/ChainChomp.h
@@ -49,7 +49,7 @@ struct ChainChomp : dEnemyBase_c {
     s32 mSpawnPosZ;         /* 0x5f4 */
     s32 mChainExtension;    /* 0x5f8 */
     u8  pad_5fc[0x9];
-    u8  unk_605;            /* 0x605 -- gates three Behavior helpers; nothing writes it */
+    u8  mChainBroken;            /* 0x605 -- gates three Behavior helpers; nothing writes it */
     u8  pad_606[0x2];
     /* uniqueIDs (fBase_c +0x04) of two other actors. 0x1b and 0x29 are resolved
        through ACTOR_SPAWN_TABLE at 0x02090864 -- see notes/enemy-leaf-provenance.md. */
@@ -121,7 +121,7 @@ struct ChainChomp {
     s32 mSpawnPosZ;         /* 0x5f4 */
     s32 mChainExtension;    /* 0x5f8 */
     u8  pad_5fc[0x9];
-    u8  unk_605;            /* 0x605 */
+    u8  mChainBroken;            /* 0x605 */
     u8  pad_606[0x2];
     s32 mStumpUniqueID;     /* 0x608 */
     s32 mFenceUniqueID;     /* 0x60c */

--- a/include/CheepCheep.h
+++ b/include/CheepCheep.h
@@ -24,9 +24,9 @@ struct CheepCheep : dEnemyBase_c {
     dBgCh_Actr mWithMeshClsn;       /* 0x150 */
     ModelAnim mModelAnim;             /* 0x30c */
     u8  pad_370[0x4];
-    s32 unk_374;                      /* 0x374 */
-    s32 unk_378;                      /* 0x378 */
-    s32 unk_37c;                      /* 0x37c */
+    s32 mHomePosX;                      /* 0x374 */
+    s32 mHomePosY;                      /* 0x378 */
+    s32 mHomePosZ;                      /* 0x37c */
 
     /* --- vtable --- */
     virtual ~CheepCheep();
@@ -72,9 +72,9 @@ struct CheepCheep {
     dBgCh_Actr mWithMeshClsn;            /* 0x150 */
     u8  mModelAnim;            /* 0x30c */
     u8  pad_30d[0x67];
-    s32 unk_374;            /* 0x374 */
-    s32 unk_378;            /* 0x378 */
-    s32 unk_37c;            /* 0x37c */
+    s32 mHomePosX;            /* 0x374 */
+    s32 mHomePosY;            /* 0x378 */
+    s32 mHomePosZ;            /* 0x37c */
 };
 
 #endif /* __cplusplus */

--- a/include/Clam.h
+++ b/include/Clam.h
@@ -29,7 +29,7 @@ struct Clam {
     u8  mState;            /* 0x16c */
     u8  pad_16d[0x1];
     u16 mStateTimer;            /* 0x16e */
-    u16 unk_170;            /* 0x170 */
+    u16 mShutTimer;            /* 0x170 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/Clipper.h
+++ b/include/Clipper.h
@@ -30,10 +30,10 @@ struct Clipper {
     u8  pad_034[0x18];
     /* SIGNED. Func_0201559C sign-extends it into a 64-bit multiply, which a u32
        cannot do; the only other user just stores to it, so nothing disagrees. */
-    s32 unk_04c;            /* 0x04c */
-    s32 unk_050;            /* 0x050 */
-    s32 unk_054;            /* 0x054 */
-    u16 unk_058;            /* 0x058 */
+    s32 mAspectRatio;            /* 0x04c */
+    s32 mNearZ;            /* 0x050 */
+    s32 mFarZ;            /* 0x054 */
+    u16 mFovAngle;            /* 0x058 */
 #ifdef __cplusplus
     /* methods */
 

--- a/include/Coffin.h
+++ b/include/Coffin.h
@@ -26,7 +26,7 @@ struct Coffin {
        +0x124 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
     dBgW_KcMbg mMeshCollider;            /* 0x124 */
-    u8  unk_2ec;            /* 0x2ec */
+    u8  mClsnMat;            /* 0x2ec */
     /* trailing extent the ROM's `new Coffin` literal proves; see tools/opnew_sizes.py */
     u8 pad_2f0[0x3c];
 #ifdef __cplusplus

--- a/include/CutsceneObject.h
+++ b/include/CutsceneObject.h
@@ -39,9 +39,9 @@ struct CutsceneObject {
     s16 mDeathTableID;                 /* 0x0ce */
     u8  pad_0d0[0xc];
     s32 mModel;            /* 0x0dc */
-    u8  unk_0e0;            /* 0x0e0 */
+    u8  mModel2;            /* 0x0e0 */
     u8  pad_0e1[0x21];
-    u8  unk_102;            /* 0x102 */
+    u8  mOpacity;            /* 0x102 */
 #ifdef __cplusplus
     /* methods */
     int Behavior();

--- a/include/Dorrie.h
+++ b/include/Dorrie.h
@@ -55,9 +55,9 @@ struct Dorrie {
     s32 mHomePosZ;           /* 0x1188 */
     s32 mClsnPlayer;           /* 0x118c */
     s32 mRider;           /* 0x1190 */
-    s32 unk_1194;           /* 0x1194 */
-    s32 unk_1198;           /* 0x1198 */
-    s32 unk_119c;           /* 0x119c */
+    s32 mSpawnPosX;           /* 0x1194 */
+    s32 mSpawnPosY;           /* 0x1198 */
+    s32 mSpawnPosZ;           /* 0x119c */
     u8  pad_11a0[0x8];
     s32 mPushDownHeight;           /* 0x11a8 */
     s32 mSinkHeight;           /* 0x11ac */

--- a/include/ExpandingHeapAllocator.h
+++ b/include/ExpandingHeapAllocator.h
@@ -25,8 +25,8 @@ struct ExpandingHeapAllocator {
     s32 unk_00c;            /* 0x00c */
     u8  unk_010;            /* 0x010 */
     u8  pad_011[0x7];
-    s32 unk_018;            /* 0x018 */
-    s32 unk_01c;            /* 0x01c */
+    s32 mStart;            /* 0x018 */
+    s32 mEnd;            /* 0x01c */
     s32 unk_020;            /* 0x020 */
     u8  unk_024;            /* 0x024 */
     u8  pad_025[0x7];

--- a/include/HeapAllocator.h
+++ b/include/HeapAllocator.h
@@ -12,8 +12,8 @@ struct HeapAllocator {
        src/_ZN13HeapAllocatorC1EjPvPvj.cpp stores its two `void*` parameters here as
        `*(void**)((char*)&self->unk_018) = a;`. Same 4 bytes as s32, so this is
        byte-identical; it just stops the header under-claiming what the tree proves. */
-    void *unk_018;              /* 0x018 */
-    void *unk_01c;              /* 0x01c */
+    void *mStart;              /* 0x018 */
+    void *mEnd;              /* 0x01c */
     u32 unk_020;            /* 0x020 */
 #ifdef __cplusplus
     /* methods */

--- a/include/KingBobOmb.h
+++ b/include/KingBobOmb.h
@@ -34,10 +34,10 @@ struct KingBobOmb : dEnemyBase_c {
        src/KingBobOmb_SetState.cpp and src/_ZN10KingBobOmb8BehaviorEv.cpp. */
     void *mState;                     /* 0x420 */
     u8  pad_424[0x70];
-    s32 unk_494;                      /* 0x494 */
+    s32 mHeldActor;                      /* 0x494 */
     u8 unk_498;                       /* 0x498 */
     u8  pad_499[0x7];
-    s32 unk_4a0;                      /* 0x4a0 */
+    s32 mPhase;                      /* 0x4a0 */
     u8  pad_4a4[0x30];
     s32 mArenaPosX;                   /* 0x4d4 */
     s32 mArenaPosY;                   /* 0x4d8 */
@@ -125,10 +125,10 @@ struct KingBobOmb {
     u8  pad_3f9[0x27];
     void *mState;            /* 0x420 */
     u8  pad_424[0x70];
-    s32 unk_494;            /* 0x494 */
+    s32 mHeldActor;            /* 0x494 */
     u8  unk_498;            /* 0x498 */
     u8  pad_499[0x7];
-    s32 unk_4a0;            /* 0x4a0 */
+    s32 mPhase;            /* 0x4a0 */
     u8  pad_4a4[0x30];
     s32 mArenaPosX;            /* 0x4d4 */
     s32 mArenaPosY;            /* 0x4d8 */

--- a/include/MadPiano.h
+++ b/include/MadPiano.h
@@ -55,11 +55,11 @@ struct MadPiano {
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
     dBgCh_Actr mWithMeshClsn;            /* 0x50c */
     u8  pad_6c8[0x4];
-    s32 unk_6cc;            /* 0x6cc */
+    s32 mMinPosY;            /* 0x6cc */
     u8  pad_6d0[0x4];
-    s32 unk_6d4;            /* 0x6d4 */
-    s32 unk_6d8;            /* 0x6d8 */
-    s32 unk_6dc;            /* 0x6dc */
+    s32 mHomePosX;            /* 0x6d4 */
+    s32 mHomePosY;            /* 0x6d8 */
+    s32 mHomePosZ;            /* 0x6dc */
     /* trailing extent the ROM's `new MadPiano` literal proves; see tools/opnew_sizes.py */
     u8 pad_6e0[0x4];
 #ifdef __cplusplus

--- a/include/MontyMoleRock.h
+++ b/include/MontyMoleRock.h
@@ -23,7 +23,7 @@ struct MontyMoleRock : dEnemyBase_c {
     Model mModel;                     /* 0x110 */
     dCcAc_c mdCcAc_c;/* 0x160 */
     dBgCh_Actr mWithMeshClsn;       /* 0x194 */
-    u8 unk_350;                       /* 0x350 */
+    u8 mIsSmall;                       /* 0x350 */
 
     /* --- vtable --- */
     virtual ~MontyMoleRock();
@@ -63,7 +63,7 @@ struct MontyMoleRock {
        dBgCh_Actr's D1 at +0x194 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN13MontyMoleRockD1Ev.c] */
     dBgCh_Actr mWithMeshClsn;            /* 0x194 */
-    u8  unk_350;            /* 0x350 */
+    u8  mIsSmall;            /* 0x350 */
 };
 
 #endif /* __cplusplus */

--- a/include/MotherPenguin.h
+++ b/include/MotherPenguin.h
@@ -46,9 +46,9 @@ struct MotherPenguin {
        dBgCh_Actr's D1 at +0x1a8 -- a relocation the ROM build
        checks. Was a u8 marker. [_ZN13MotherPenguinD0Ev.c] */
     dBgCh_Actr mWithMeshClsn;            /* 0x1a8 */
-    s32 unk_364;            /* 0x364 */
-    s32 unk_368;            /* 0x368 */
-    s32 unk_36c;            /* 0x36c */
+    s32 mHomePosX;            /* 0x364 */
+    s32 mHomePosY;            /* 0x368 */
+    s32 mHomePosZ;            /* 0x36c */
     u8  pad_370[0x4];
     s32 unk_374;            /* 0x374 */
     /* Trailing remainder, 0x14 bytes. Every marker is already typed and the

--- a/include/NestedHeapIterator.h
+++ b/include/NestedHeapIterator.h
@@ -15,7 +15,7 @@ struct node_;
 struct NestedHeapIterator {
     u8  pad_000[0x4];
     s32 mLast;            /* 0x004 */
-    u8  unk_008;            /* 0x008 */
+    u8  mCount;            /* 0x008 */
     u8  pad_009[0x1];
     u16 mLinkOffset;            /* 0x00a */
 #ifdef __cplusplus

--- a/include/PrincessPeach.h
+++ b/include/PrincessPeach.h
@@ -30,7 +30,7 @@ struct PrincessPeach {
        checks. Was a u8 marker. [_ZN13PrincessPeachD0Ev.c] */
     dBgCh_Actr mWithMeshClsn;            /* 0x194 */
     u8  pad_350[0x4];
-    s32 unk_354;            /* 0x354 */
+    s32 mState;            /* 0x354 */
     /* Trailing remainder, 0x14 bytes. All three markers are typed and the last
        field the five recovered functions touch ends at 0x358;
        PrincessPeach_Spawn allocates 0x36c. The reference does not document

--- a/include/PyramidLift.h
+++ b/include/PyramidLift.h
@@ -25,16 +25,16 @@ struct PyramidLift {
        +0x124 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
     dBgW_KcMbg mMeshCollider;            /* 0x124 */
-    u8  unk_2ec;            /* 0x2ec */
+    u8  mClsnMat;            /* 0x2ec */
     u8  pad_2ed[0x33];
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. The marker's pad stopped
        short of the object, so the member also takes over unk_33c (+0x1c = mat4x3), which
        the header declared separately inside it. */
     Model mModel2;            /* 0x320 */
-    s32 unk_370;            /* 0x370 */
-    s32 unk_374;            /* 0x374 */
-    s32 unk_378;            /* 0x378 */
+    s32 mBasePosX;            /* 0x370 */
+    s32 mBasePosY;            /* 0x374 */
+    s32 mBasePosZ;            /* 0x378 */
     u8  pad_37c[0x78];
     u16 mShakeTimer;            /* 0x3f4 */
     u8  mState;            /* 0x3f6 */

--- a/include/SaveData.h
+++ b/include/SaveData.h
@@ -37,7 +37,7 @@ struct SaveData {
        +0x8. The u8 was the marker the generator emitted, not the width. */
     s32 flags2;
     u8  pad_00c[0x35];
-    u8  unk_041;            /* 0x041 -- current character */
+    u8  mCharacter;            /* 0x041 -- current character */
     u8  unk_042;            /* 0x042 */
 #ifdef __cplusplus
     /* methods */

--- a/include/ShipUp.h
+++ b/include/ShipUp.h
@@ -25,9 +25,9 @@ struct ShipUp {
     u8  pad_2ec[0x32];
     u8  mModelIndex;            /* 0x31e */
     u8  pad_31f[0x1];
-    u16 unk_320;            /* 0x320 */
+    u16 mBobAngle;            /* 0x320 */
     u8  pad_322[0x2];
-    s32 unk_324;            /* 0x324 */
+    s32 mSoundHandle;            /* 0x324 */
     u16 unk_328;            /* 0x328 */
 #ifdef __cplusplus
     /* methods */

--- a/include/SnowmanBreath.h
+++ b/include/SnowmanBreath.h
@@ -32,9 +32,9 @@ struct SnowmanBreath {
     Player *mTalkPlayer;           /* 0x13c4 */
     u8  pad_13c8[0x4];
     s32 mSoundHandle;           /* 0x13cc */
-    u8  unk_13d0;           /* 0x13d0 */
+    u8  mTalkDone;           /* 0x13d0 */
     u8  pad_13d1[0x1];
-    u8  unk_13d2;           /* 0x13d2 */
+    u8  mState;           /* 0x13d2 */
     u8  unk_13d3;           /* 0x13d3 */
 #ifdef __cplusplus
     /* methods */

--- a/include/SolidHeapAllocator.h
+++ b/include/SolidHeapAllocator.h
@@ -34,7 +34,7 @@
 
 struct SolidHeapAllocator {
     u8  pad_000[0x18];
-    s32 unk_018;            /* 0x018 */
+    s32 mStart;            /* 0x018 */
     s32 mEnd;               /* 0x01c */
     s32 unk_020;            /* 0x020 */
     u8  mFreeRegion;        /* 0x024 -- really a {begin, end, tail} triple; the

--- a/include/Timer.h
+++ b/include/Timer.h
@@ -14,7 +14,7 @@ struct Timer {
        value looks like on a target with no 64-bit register, so it corroborates
        rather than contradicts. Splitting it is why three of the four methods had to
        spell `*(s64*)((char*)this)`. */
-    s64 unk_000;            /* 0x000 */
+    s64 mTime;            /* 0x000 */
     u8  mIsRunning;            /* 0x008 */
 #ifdef __cplusplus
     /* methods */

--- a/include/TtcConveyorBeltLarge.h
+++ b/include/TtcConveyorBeltLarge.h
@@ -32,7 +32,7 @@ struct TtcConveyorBeltLarge {
        recovered by tools/dtor_members.py. D1 and not D2, so it is this type and not an
        inlined base. */
     dBgW_KcMbg mMeshCollider;            /* 0x124 */
-    u8  unk_2ec;            /* 0x2ec */
+    u8  mClsnMat;            /* 0x2ec */
     u8  pad_2ed[0x33];
     /* TextureTransformer member. The cartridge's own ~TtcConveyorBeltLarge calls
        _ZN18TextureTransformerD1Ev at +0x320 (D0/D1), a relocation the ROM build checks;
@@ -47,9 +47,9 @@ struct TtcConveyorBeltLarge {
     u8  pad_35c[0x30];
     s32 mBeltSpeed;            /* 0x38c */
     s32 mTargetBeltSpeed;            /* 0x390 */
-    s32 unk_394;            /* 0x394 */
-    s32 unk_398;            /* 0x398 */
-    s16 unk_39c;            /* 0x39c */
+    s32 mGroundY;            /* 0x394 */
+    s32 mSoundHandle;            /* 0x398 */
+    s16 mDirectionTimer;            /* 0x39c */
     u8  mVariant;            /* 0x39e */
 #ifdef __cplusplus
     /* methods */

--- a/include/TtcRotatingCube.h
+++ b/include/TtcRotatingCube.h
@@ -39,11 +39,11 @@ struct TtcRotatingCube {
     /* Model member, named by _ZN5ModelD1Ev at +0x320 -- a relocation the ROM build checks.
        D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
     Model mModel2;            /* 0x320 */
-    s32 unk_370;            /* 0x370 */
+    s32 mOffsetY;            /* 0x370 */
     s16 mWaitTimer;            /* 0x374 */
-    u8  unk_376;            /* 0x376 */
-    u8  unk_377;            /* 0x377 */
-    s16 unk_378;            /* 0x378 */
+    u8  mState;            /* 0x376 */
+    u8  mVariant;            /* 0x377 */
+    s16 mTargetAngleZ;            /* 0x378 */
     /* Set to 1 by InitResources when the two ground probes disagree. */
     u8  unk_37a;            /* 0x37a */
     u8  pad_37b[0x1];

--- a/include/WorkElevator.h
+++ b/include/WorkElevator.h
@@ -24,15 +24,15 @@ struct WorkElevator {
        +0x124 (D0/D1), a relocation the ROM build checks; recovered by
        tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
     dBgW_KcMbg mMeshCollider;            /* 0x124 */
-    u8  unk_2ec;            /* 0x2ec */
+    u8  mClsnMat;            /* 0x2ec */
     u8  pad_2ed[0x233];
-    u8  unk_520;            /* 0x520 */
+    u8  mPlatformClsn0;            /* 0x520 */
     u8  pad_521[0x1c7];
-    u8  unk_6e8;            /* 0x6e8 */
+    u8  mPlatformClsn1;            /* 0x6e8 */
     u8  pad_6e9[0x1c7];
-    u8  unk_8b0;            /* 0x8b0 */
+    u8  mPlatformClsn2;            /* 0x8b0 */
     u8  pad_8b1[0x1c7];
-    u8  unk_a78;            /* 0xa78 */
+    u8  mPlatformClsn3;            /* 0xa78 */
     u8  pad_a79[0x1c7];
     s32 unk_c40;            /* 0xc40 */
     s32 unk_c44;            /* 0xc44 */
@@ -40,7 +40,7 @@ struct WorkElevator {
     u8  pad_c4c[0x20];
     s32 unk_c6c;            /* 0xc6c */
     u8  pad_c70[0xa];
-    s8  unk_c7a;            /* 0xc7a */
+    s8  mLoweredPlatform;            /* 0xc7a */
     /* trailing extent the ROM's `new WorkElevator` literal proves; see tools/opnew_sizes.py */
     u8 pad_c7c[0x4];
 #ifdef __cplusplus

--- a/include/dBgCh_Gnd.h
+++ b/include/dBgCh_Gnd.h
@@ -49,7 +49,7 @@ struct dBgCh_Gnd : dBgCh, dBgPi {
     Fix12i clsnY;           /* 0x044 */
     u8  hasClsn;            /* 0x048 */
     u8  pad_049[0x3];
-    s32 unk_04c;            /* 0x04c */
+    s32 mProbeHeight;            /* 0x04c */
 
     /* --- vtable, in ROM order. Do not reorder. --- */
     /* DECLARED FIRST AND NEVER DEFINED AS A METHOD -- the key-function
@@ -78,7 +78,7 @@ typedef char dBgCh_Gnd_size_must_be_0x50[sizeof(dBgCh_Gnd) == 0x50 ? 1 : -1];
 
 struct dBgCh_Gnd {
     u8  pad_000[0x10];
-    u8  unk_010;            /* 0x010 - first byte of the 0x28-byte dBgPi
+    u8  mBgPiBase;            /* 0x010 - first byte of the 0x28-byte dBgPi
                                        the hit is written into; kept as a byte
                                        because RaycastGroundC1/D1 spell it */
     u8  pad_011[0x27];
@@ -86,7 +86,7 @@ struct dBgCh_Gnd {
     Fix12i clsnY;           /* 0x044 */
     u8  hasClsn;            /* 0x048 */
     u8  pad_049[0x3];
-    s32 unk_04c;            /* 0x04c */
+    s32 mProbeHeight;            /* 0x04c */
 
 #ifdef __cplusplus
     /* methods */

--- a/include/dBgCh_Lin.h
+++ b/include/dBgCh_Lin.h
@@ -117,7 +117,7 @@ struct dBgCh_Lin : dBgCh, dBgPi, dM3dGLin {
 
 struct dBgCh_Lin {
     u8  pad_000[0x10];
-    u8  unk_010;            /* 0x010 - the dBgPi base starts here */
+    u8  mBgPiBase;            /* 0x010 - the dBgPi base starts here */
     u8  pad_011[0x27];
     /* NOT a bare Vector3, despite DetectClsn reading three words here: the
        destructor destroys something at 0x38 via func_ov002_020feab8, so a
@@ -134,7 +134,7 @@ struct dBgCh_Lin {
        Its two accessors are named BACKWARDS in some notes. Read the bodies:
          func_ov002_020fea4c  a[0..2] = b[3..5]  -> reads 0x44  -> GetEnd
          func_ov002_020fea68  a[0..2] = b[0..2]  -> reads 0x38  -> GetStart */
-    u8  unk_038;            /* 0x038 -- dM3dGLin base: start 0x38, end 0x44 */
+    u8  mLineBase;            /* 0x038 -- dM3dGLin base: start 0x38, end 0x44 */
     u8  pad_039[0x17];
     u8  hasClsn;            /* 0x050 */
     u8  pad_051[0x3];

--- a/include/dBgCh_SphCrr.h
+++ b/include/dBgCh_SphCrr.h
@@ -61,7 +61,7 @@ struct dBgCh_SphCrr : dBgCh, dBgPi, dM3dGSph {
     s32 unk_0fc;            /* 0x0fc */
     s32 unk_100;            /* 0x100 */
     u8  pad_104[0x4];       /* through 0x10b */
-    s32 unk_108;            /* 0x108 - dBgCh_Actr's Update* copy its tail word
+    s32 mClsnScale;            /* 0x108 - dBgCh_Actr's Update* copy its tail word
                                (Actr +0x128) here each update */
     s32 unk_10c;            /* 0x10c - named 2026-08-24 when the size pin
                                landed: dBgCh_Actr::Init stores its fourth
@@ -100,9 +100,9 @@ typedef char dBgCh_SphCrr_size_must_be_0x110[
 
 struct dBgCh_SphCrr {
     u8  pad_000[0x10];
-    u8  unk_010;            /* 0x010 */
+    u8  mBgPiBase;            /* 0x010 */
     u8  pad_011[0x27];
-    u8  unk_038;            /* 0x038 */
+    u8  mSphereBase;            /* 0x038 */
     u8  pad_039[0x3];
     Vector3 pos;            /* 0x03c */
     Fix12i radius;          /* 0x048 */
@@ -118,7 +118,7 @@ struct dBgCh_SphCrr {
     s32 unk_0fc;            /* 0x0fc */
     s32 unk_100;            /* 0x100 */
     u8  pad_104[0x4];
-    s32 unk_108;            /* 0x108 */
+    s32 mClsnScale;            /* 0x108 */
     s32 unk_10c;            /* 0x10c - see the C++ branch: Init's Vector3_16 * */
 };
 

--- a/include/dBgCh_SphCrr.h
+++ b/include/dBgCh_SphCrr.h
@@ -61,7 +61,7 @@ struct dBgCh_SphCrr : dBgCh, dBgPi, dM3dGSph {
     s32 unk_0fc;            /* 0x0fc */
     s32 unk_100;            /* 0x100 */
     u8  pad_104[0x4];       /* through 0x10b */
-    s32 mClsnScale;            /* 0x108 - dBgCh_Actr's Update* copy its tail word
+    s32 mScale;            /* 0x108 - dBgCh_Actr's Update* copy its tail word
                                (Actr +0x128) here each update */
     s32 unk_10c;            /* 0x10c - named 2026-08-24 when the size pin
                                landed: dBgCh_Actr::Init stores its fourth
@@ -118,7 +118,7 @@ struct dBgCh_SphCrr {
     s32 unk_0fc;            /* 0x0fc */
     s32 unk_100;            /* 0x100 */
     u8  pad_104[0x4];
-    s32 mClsnScale;            /* 0x108 */
+    s32 mScale;            /* 0x108 */
     s32 unk_10c;            /* 0x10c - see the C++ branch: Init's Vector3_16 * */
 };
 

--- a/include/dBgW_KcMbg.h
+++ b/include/dBgW_KcMbg.h
@@ -41,7 +41,7 @@ struct dBgW_KcMbg : dBgW_Kc {
     Vector3 velocity;          /* 0x124 */
     u32 unk_130;              /* 0x130 */
     Matrix4x3 newScaledMat;    /* 0x134 */
-    s32 unk_164;               /* 0x164 - func_02053200(scale) */
+    s32 invScale;               /* 0x164 - func_02053200(scale) */
     Matrix4x3 invScaledMat;    /* 0x168 */
     Matrix4x3 prevInvScaledMat;/* 0x198 */
 
@@ -114,7 +114,7 @@ struct dBgW_KcMbg {
     Vector3 velocity;          /* 0x124 */
     u32 unk_130;               /* 0x130 */
     Matrix4x3 newScaledMat;    /* 0x134 */
-    s32 unk_164;               /* 0x164 */
+    s32 invScale;               /* 0x164 */
     Matrix4x3 invScaledMat;    /* 0x168 */
     Matrix4x3 prevInvScaledMat;/* 0x198 */
 };

--- a/include/daPgDfdr_c.h
+++ b/include/daPgDfdr_c.h
@@ -69,9 +69,9 @@ struct daPgDfdr_c : dBgActor_c {
     dCcAc_c mdCcAc_c;                      /* 0x398 */
     void *mStateTable;                     /* 0x3cc */
     s32   unk_3d0;                         /* 0x3d0 */
-    s32   unk_3d4;                         /* 0x3d4 */
+    s32   mDistanceLeft;                         /* 0x3d4 */
     u8    mTimer;                          /* 0x3d8 */
-    u8    unk_3d9;                         /* 0x3d9 */
+    u8    mStepIndex;                         /* 0x3d9 */
     u8    pad_3da[0x2];
 
     /* --- vtable, in ROM order. Do not reorder. ---
@@ -154,9 +154,9 @@ struct daPgDfdr_c {
     u8  mdCcAc_c[0x34];    /* 0x398 */
     void *mStateTable;                    /* 0x3cc */
     s32   unk_3d0;                    /* 0x3d0 */
-    s32   unk_3d4;                    /* 0x3d4 */
+    s32   mDistanceLeft;                    /* 0x3d4 */
     u8    mTimer;                    /* 0x3d8 */
-    u8    unk_3d9;                    /* 0x3d9 */
+    u8    mStepIndex;                    /* 0x3d9 */
     u8    pad_3da[0x2];
 };
 

--- a/src/_ZN10BrickBlock8BehaviorEv.cpp
+++ b/src/_ZN10BrickBlock8BehaviorEv.cpp
@@ -15,7 +15,7 @@ struct C { char pad[0x1000]; };
 int BrickBlock::Behavior()
 {
   char* o = 0;
-  if (unk_0d8 != 0) goto d6;
+  if (mIsAttached != 0) goto d6;
   o = (char*)_ZN8dActor_c4NextEPKS_(0);
   while (o){
     unsigned short t = *(unsigned short*)(o + 0xc);
@@ -30,7 +30,7 @@ int BrickBlock::Behavior()
     }
     if (Vec3_Dist(((char*)this) + 0x5c, o + 0x5c) < 0x32000){
       *(char**)(o + 0x328) = ((char*)this);
-      unk_0d8 = 1;
+      mIsAttached = 1;
       return 1;
     }
   next:
@@ -40,8 +40,8 @@ int BrickBlock::Behavior()
   _ZN7fBase_c18MarkForDestructionEv(((char*)this));
   return 1;
 d6:
-  if (unk_0d6 != 0){
-    int idx = unk_0d7;
+  if (mActionPending != 0){
+    int idx = mActionIndex;
     (((C*)((char*)this))->*data_ov002_0210dd30[idx])();
     _ZN7fBase_c18MarkForDestructionEv(((char*)this));
   }

--- a/src/_ZN10ChainChomp8BehaviorEv.cpp
+++ b/src/_ZN10ChainChomp8BehaviorEv.cpp
@@ -42,11 +42,11 @@ int ChainChomp::Behavior()
     func_ov014_02111f08(((char*)this));
     _ZN8dActor_c9UpdatePosEP5dCc_c(((char*)this), &mdCcAcPos_c);
     func_ov014_02112114(((char*)this));
-    if (unk_605 == 0) {
+    if (mChainBroken == 0) {
         func_ov014_02111fe0(((char*)this));
     }
     func_ov014_0211250c(((char*)this));
-    if (unk_605 == 0) {
+    if (mChainBroken == 0) {
         func_ov014_0211236c(((char*)this));
         func_ov014_021122dc(((char*)this));
     }

--- a/src/_ZN10CheepCheep13InitResourcesEv.cpp
+++ b/src/_ZN10CheepCheep13InitResourcesEv.cpp
@@ -48,9 +48,9 @@ int CheepCheep::InitResources()
     _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(
         (void *)((char *)&(*(dCcAcPos_c *)&mdCcAcPos_c)), (struct dActor_c *)((char *)this), v, 0x32000, 0x3c000, 0x200004, 0x8000);
 
-    unk_374 = mPosX;
-    unk_378 = mPosY;
-    unk_37c = mPosZ;
+    mHomePosX = mPosX;
+    mHomePosY = mPosY;
+    mHomePosZ = mPosZ;
     mAngleY = mPrevAngleY;
     _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
         (void *)((char *)&(*(dBgCh_Actr *)&mWithMeshClsn)), (struct dActor_c *)((char *)this), 0x1e000, 0x1e000, 0, 0);

--- a/src/_ZN10KingBobOmb13InitResourcesEv.cpp
+++ b/src/_ZN10KingBobOmb13InitResourcesEv.cpp
@@ -90,9 +90,9 @@ int KingBobOmb::InitResources()
         *(unsigned char*)(((char*)this)+0x42c+i) = (unsigned char)z;
     }
     }
-    unk_4a0 = ((unsigned int)RandomIntInternal(&data_0209e650) >> 0x1e) & 1;
+    mPhase = ((unsigned int)RandomIntInternal(&data_0209e650) >> 0x1e) & 1;
     {
-        int *p = (int*)((char*)&unk_4a0);
+        int *p = (int*)((char*)&mPhase);
         *p = *p + 1;
     }
     mInitAngleY = mAngleY;

--- a/src/_ZN10KingBobOmb6RenderEv.cpp
+++ b/src/_ZN10KingBobOmb6RenderEv.cpp
@@ -10,7 +10,7 @@ extern int _ZN5Model6RenderEPK7Vector3(void *m, void *v);
 
 int KingBobOmb::Render()
 {
-    void *r1 = (void*)*(int*)((char*)&unk_494);
+    void *r1 = (void*)*(int*)((char*)&mHeldActor);
     if (r1 != 0) {
         int r0 = *(int*)((char*)&mFlags);
         int flag = (r0 & 0x4000) ? 1 : 0;

--- a/src/_ZN10dBgCh_Actr16UpdateContinuousEv.cpp
+++ b/src/_ZN10dBgCh_Actr16UpdateContinuousEv.cpp
@@ -132,7 +132,7 @@ void dBgCh_Actr::UpdateContinuous()
     _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(((char*)this) + 0x20, &sphere, mRadius, *(void**)((char*)&mActor));
     if (func_0203553c(((char*)this)) == 0)
         *(u8*)AT(((char*)this), 0x90) |= 0x40;
-    mSphereClsn.unk_108 = mScale;
+    mSphereClsn.mScale = mScale;
     if (pos[1] - prev[1] > 0)
         *(u8*)AT(((char*)this), 0x90) |= 0x20;
     if (floorFlag != 0) {

--- a/src/_ZN10dBgCh_Actr20UpdateDiscreteNoLavaEv.cpp
+++ b/src/_ZN10dBgCh_Actr20UpdateDiscreteNoLavaEv.cpp
@@ -40,7 +40,7 @@ void dBgCh_Actr::UpdateDiscreteNoLava()
     v.y = sy + mHeight;
     _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(((char *)this) + 0x20, &v,
         mRadius, *(void **)((char *)&mActor));
-    mSphereClsn.unk_108 = mScale;
+    mSphereClsn.mScale = mScale;
     if (src->y - p68->y > 0) {
         *(unsigned char *)((char *)&mSphereClsn.flags) |= 0x20;
     }

--- a/src/_ZN10dBgCh_Actr22UpdateContinuousNoLavaEv.cpp
+++ b/src/_ZN10dBgCh_Actr22UpdateContinuousNoLavaEv.cpp
@@ -122,7 +122,7 @@ void dBgCh_Actr::UpdateContinuousNoLava()
     sphere.z = pos[2];
     sphere.y += height;
     _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(((char*)this) + 0x20, &sphere, mRadius, *(void**)((char*)&mActor));
-    mSphereClsn.unk_108 = mScale;
+    mSphereClsn.mScale = mScale;
     if (pos[1] - prev[1] > 0)
         *(u8*)AT(((char*)this), 0x90) |= 0x20;
     if (floorFlag != 0) {

--- a/src/_ZN10dBgCh_Actr22UpdateDiscreteNoLava_2Ev.cpp
+++ b/src/_ZN10dBgCh_Actr22UpdateDiscreteNoLava_2Ev.cpp
@@ -31,7 +31,7 @@ void dBgCh_Actr::UpdateDiscreteNoLava_2()
     v.y = sy + mHeight;
     _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(((char *)this) + 0x20, &v,
         mRadius, *(void **)((char *)&mActor));
-    mSphereClsn.unk_108 = mScale;
+    mSphereClsn.mScale = mScale;
     if (src->y - *(int *)(obj + 0x6c) > 0) {
         *(unsigned char *)((char *)&mSphereClsn.flags) |= 0x20;
     }

--- a/src/_ZN10dBgW_KcMbg10DetectClsnER12dBgCh_SphCrr.cpp
+++ b/src/_ZN10dBgW_KcMbg10DetectClsnER12dBgCh_SphCrr.cpp
@@ -5,11 +5,11 @@
  * Vtable slot 8, and the same trick as the other two overloads: move the query
  * into the collider's local frame rather than moving the mesh. The caller's
  * sphere centre is transformed by func_02039e48 and its radius scaled by
- * unk_164, a local dBgCh_SphCrr is aimed at the result, and the base
+ * invScale, a local dBgCh_SphCrr is aimed at the result, and the base
  * dBgW_Kc::DetectClsn does the work against the static mesh.
  *
  * Coming back out is the part that is not symmetric. The push-out vector pair
- * is scaled by `scale` -- the collider's own uniform scale, NOT unk_164 which
+ * is scaled by `scale` -- the collider's own uniform scale, NOT invScale which
  * scaled the radius on the way in -- and the three result slots are merged
  * INDEPENDENTLY, each behind its own bit of dBgCh_SphCrr::flags:
  *
@@ -81,8 +81,8 @@ int dBgW_KcMbg::DetectClsn(dBgCh_SphCrr & sphere_)
     _ZN12dBgCh_SphCrrC1Ev(&loc);
     func_02039e48(this, &sphere->centre, pos);
     _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(&loc, pos,
-        FMUL(*(int*)&sphere->radius, unk_164), 0);
-    loc.f_ec = FMUL(sphere->unk_0ec, unk_164);
+        FMUL(*(int*)&sphere->radius, invScale), 0);
+    loc.f_ec = FMUL(sphere->unk_0ec, invScale);
     func_02037940(&loc, sphere->flags);
     func_02035394(&loc, sphere);
     r = dBgW_Kc::DetectClsn(*(dBgCh_SphCrr*)&loc);

--- a/src/_ZN10dBgW_KcMbg10DetectClsnER9dBgCh_Gnd.cpp
+++ b/src/_ZN10dBgW_KcMbg10DetectClsnER9dBgCh_Gnd.cpp
@@ -7,7 +7,7 @@
  * frame, and the scratch dBgCh_Lin at 0x020a0d0c is aimed between them, so
  * the base dBgW_Kc::DetectClsn(dBgCh_Lin&) does the work.
  *
- * How far down to look is the interesting part. It starts at unk_04c, the
+ * How far down to look is the interesting part. It starts at mProbeHeight, the
  * caller's search depth; but if the caller already HAS a hit (hasClsn), the
  * drop to that existing hit bounds the search instead, whenever that is
  * shorter. So a collider can only improve on the caller's best floor, never
@@ -45,7 +45,7 @@ int dBgW_KcMbg::DetectClsn(dBgCh_Gnd & ray_)
   sp0x24[0] = sp0xc[0];
   sp0x24[1] = sp0xc[1];
   sp0x24[2] = sp0xc[2];
-  int b4c = ray->unk_04c;
+  int b4c = ray->mProbeHeight;
   if (ray->hasClsn != 0) {
     int diff = *(volatile int*)&sp0xc[1] - *(int*)&ray->clsnY;
     if (diff < b4c) b4c = diff;

--- a/src/_ZN11PyramidLift13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidLift13InitResourcesEv.cpp
@@ -40,18 +40,18 @@ int PyramidLift::InitResources()
     _ZN10dBgActor_c19UpdateClsnPosAndRotEv(((char*)this));
     kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(&data_ov025_02113ad8);
     _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        ((char*)this)+0x124, kcl, (Matrix4x3*)((char*)&unk_2ec), 0x199, mAngleY, &data_ov025_02112d08);
+        ((char*)this)+0x124, kcl, (Matrix4x3*)((char*)&mClsnMat), 0x199, mAngleY, &data_ov025_02112d08);
     func_020393d4(((char*)this)+0x124, &_ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
     func_020393c4(((char*)this)+0x124, &func_ov025_021125dc);
     {
         int n;
         char *ip;
         int k;
-        unk_370 = mPosX;
+        mBasePosX = mPosX;
         n = 0;
-        unk_374 = mPosY;
+        mBasePosY = mPosY;
         ip = ((char*)this);
-        unk_378 = mPosZ;
+        mBasePosZ = mPosZ;
         mState = (unsigned char)n;
         mHadClsn = (unsigned char)n;
         k = 0x1cc000;

--- a/src/_ZN11PyramidLift8BehaviorEv.cpp
+++ b/src/_ZN11PyramidLift8BehaviorEv.cpp
@@ -24,7 +24,7 @@ int PyramidLift::Behavior()
         int idx = t >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
-        mPosY = unk_374 + d;
+        mPosY = mBasePosY + d;
         if (mShakeTimer == 8) {
             mState = 2;
             mVertSpeed = -0xa000;

--- a/src/_ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c.cpp
+++ b/src/_ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c.cpp
@@ -16,5 +16,5 @@ extern "C" void _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c
     func_0203abd4((int *)&(dM3dGSph &)*self, (int *)pos, radius);
     func_020353b0((char *)self, actor);
     func_02037b5c((char *)self);
-    self->unk_108 = 0x1000;
+    self->mScale = 0x1000;
 }

--- a/src/_ZN12dBgCh_SphCrrD1Ev.c
+++ b/src/_ZN12dBgCh_SphCrrD1Ev.c
@@ -9,13 +9,13 @@ extern int VTable_dM3dGSph_dBgCh_SphCrrThunk[];
 extern void _ZN5dBgPiD1Ev(void *);
 int *_ZN12dBgCh_SphCrrD1Ev(struct dBgCh_SphCrr *self) {
     ((int *)self)[0] = (int)_ZTV12dBgCh_SphCrr;
-    *(int *)((char *)&self->unk_010) = (int)VTable_dBgPi_dBgCh_SphCrrThunk;
-    *(int *)((char *)&self->unk_038) = (int)VTable_dM3dGSph_dBgCh_SphCrrThunk;
+    *(int *)((char *)&self->mBgPiBase) = (int)VTable_dBgPi_dBgCh_SphCrrThunk;
+    *(int *)((char *)&self->mSphereBase) = (int)VTable_dM3dGSph_dBgCh_SphCrrThunk;
     _ZN5dBgPiD1Ev((char *)&self->mClsnResult3);
     _ZN5dBgPiD1Ev((char *)&self->mClsnResult2);
     _ZN5dBgPiD1Ev((char *)&self->mClsnResult1);
-    _ZN8dM3dGSphD2Ev((char *)&self->unk_038);
-    _ZN5dBgPiD2Ev((char *)&self->unk_010);
+    _ZN8dM3dGSphD2Ev((char *)&self->mSphereBase);
+    _ZN5dBgPiD2Ev((char *)&self->mBgPiBase);
     func_020354d0(((int *)self));
     return ((int *)self);
 }

--- a/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
+++ b/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
@@ -15,8 +15,8 @@ extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(void* iter, void* n
 
 void _ZN13HeapAllocatorC1EjPvPvj(struct HeapAllocator *self, u32 magic, void* a, void* b, unsigned short size) {
     *(u32*)((char*)self) = magic;
-    *(void**)((char*)&self->unk_018) = a;
-    *(void**)((char*)&self->unk_01c) = b;
+    *(void**)((char*)&self->mStart) = a;
+    *(void**)((char*)&self->mEnd) = b;
     self->unk_020 = 0;
     {
         u32* p = (u32*)((char*)&self->unk_020);

--- a/src/_ZN13MontyMoleRock13InitResourcesEv.cpp
+++ b/src/_ZN13MontyMoleRock13InitResourcesEv.cpp
@@ -15,11 +15,11 @@ s32 MontyMoleRock::InitResources()
   int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov080_021283c8);
   if(_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0x110, m, 1, -1) == 0) return 0;
   _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(((char*)this)+0x160, ((char*)this), 0x1e000, 0x1e000, 0x200004, 0);
-  unk_350 = (*(s32 *)&param1) & 1;
+  mIsSmall = (*(s32 *)&param1) & 1;
   _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char*)this)+0x194, ((char*)this), 0x1e000, 0x1e000, 0, 0);
   mVertAccel = -0x2000;
   mTerminalVelocity = -0x3c000;
-  if(unk_350 == 0){
+  if(mIsSmall == 0){
     mScaleX = 0x1000;
     mScaleY = 0x1000;
     mScaleZ = 0x1000;

--- a/src/_ZN13MotherPenguin13InitResourcesEv.cpp
+++ b/src/_ZN13MotherPenguin13InitResourcesEv.cpp
@@ -54,9 +54,9 @@ int MotherPenguin::InitResources()
         mPosY = *(int*)(rg+0x44);
     else
         mPosY = v[1];
-    unk_364 = mPosX;
-    unk_368 = mPosY;
-    unk_36c = mPosZ;
+    mHomePosX = mPosX;
+    mHomePosY = mPosY;
+    mHomePosZ = mPosZ;
     unk_374 = 0;
     func_ov018_02111d28(((char *)this), 0);
     _ZN9dBgCh_GndD1Ev(rg);

--- a/src/_ZN13PrincessPeach8BehaviorEv.cpp
+++ b/src/_ZN13PrincessPeach8BehaviorEv.cpp
@@ -16,7 +16,7 @@ int PrincessPeach::Behavior()
 {
     func_ov085_0212a430(((char *)this));
     func_ov085_02129dbc(((char *)this));
-    if (unk_354 != 1)
+    if (mState != 1)
         _ZN9Animation7AdvanceEv((char *)(Animation *)&mModelAnim);
     ((Sub*)((char *)&mModelAnim))->g3();
     _ZN5dCc_c5ClearEv((char *)&mdCcAc_c);

--- a/src/_ZN13SnowmanBreath8BehaviorEv.cpp
+++ b/src/_ZN13SnowmanBreath8BehaviorEv.cpp
@@ -47,8 +47,8 @@ int SnowmanBreath::Behavior()
         return 1;
     }
 
-    if (unk_13d0 == 0) {
-        switch (unk_13d2) {
+    if (mTalkDone == 0) {
+        switch (mState) {
         case 0:
             if (func_ov027_02112618(((char *)this)) == 0) {
                 break;
@@ -79,7 +79,7 @@ int SnowmanBreath::Behavior()
         case 2:
             if (_ZN6Player12GetTalkStateEv(*(void **)((char *)&mTalkPlayer)) == -1) {
                 _ZN6Player18HasFinishedTalkingEv(*(void **)((char *)&mTalkPlayer));
-                unk_13d0 = 1;
+                mTalkDone = 1;
             }
             break;
         }

--- a/src/_ZN14CutsceneObject16CleanupResourcesEv.cpp
+++ b/src/_ZN14CutsceneObject16CleanupResourcesEv.cpp
@@ -15,7 +15,7 @@ int CutsceneObject::CleanupResources()
   if (r1 == 0x2f) return func_ov002_020f23d0(((char*)this));
   Obj* a = *(Obj**)((char*)&mModel);
   if (a) if (a) a->m04();
-  Obj* b = *(Obj**)((char*)&unk_0e0);
+  Obj* b = *(Obj**)((char*)&mModel2);
   if (b) if (b) b->m04();
   return 1;
 }

--- a/src/_ZN14CutsceneObject6RenderEv.cpp
+++ b/src/_ZN14CutsceneObject6RenderEv.cpp
@@ -36,7 +36,7 @@ int CutsceneObject::Render()
     } while ((unsigned)i < 3u);
     return 1;
   }
-  unsigned char op = unk_102;
+  unsigned char op = mOpacity;
   if (op == 0) return 1;
   {
     void* a = *(void**)((char*)&mModel);
@@ -45,12 +45,12 @@ int CutsceneObject::Render()
       _ZN9ModelBase12ApplyOpacityEj(a, op, 0);
       ((ModelBase*)*(void**)((char*)&mModel))->m((int)((char*)&mScaleX));
     } else {
-      void* b = *(void**)((char*)&unk_0e0);
+      void* b = *(void**)((char*)&mModel2);
       if (b != 0){
         b = (void*)((int)b);
         func_ov002_020f65b8(b);
-        _ZN9ModelBase12ApplyOpacityEj(*(void**)((char*)&unk_0e0), unk_102, 0);
-        ((ModelBase*)*(void**)((char*)&unk_0e0))->m((int)((char*)&mScaleX));
+        _ZN9ModelBase12ApplyOpacityEj(*(void**)((char*)&mModel2), mOpacity, 0);
+        ((ModelBase*)*(void**)((char*)&mModel2))->m((int)((char*)&mScaleX));
       }
     }
   }

--- a/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp
@@ -15,8 +15,8 @@ int TtcRotatingCube::CleanupResources()
     if (((dBgW *)((char*)&mMovingMeshCollider))->IsEnabled()) {
         ((dBgW *)((char*)&mMovingMeshCollider))->Disable();
     }
-    ((SharedFilePtr *)(data_ov065_0211c0a8[unk_377]))->Release();
-    ((SharedFilePtr *)(data_ov065_0211cfd0[unk_377].p))->Release();
-    ((SharedFilePtr *)(data_ov065_0211cfd4[unk_377].p))->Release();
+    ((SharedFilePtr *)(data_ov065_0211c0a8[mVariant]))->Release();
+    ((SharedFilePtr *)(data_ov065_0211cfd0[mVariant].p))->Release();
+    ((SharedFilePtr *)(data_ov065_0211cfd4[mVariant].p))->Release();
     return 1;
 }

--- a/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
@@ -19,7 +19,7 @@ extern int data_0209e650;
 int TtcRotatingCube::Behavior()
 {
     if (data_0209f2c0 != 3) {
-        switch (unk_376) {
+        switch (mState) {
         case 0:
             if (DecIfAbove0_Short((u16 *)((char *)&mWaitTimer)) != 0)
                 break;
@@ -30,23 +30,23 @@ int TtcRotatingCube::Behavior()
         case 1:
             *(int *)(((int)((char *)this) + 0xa8)) += 0x800;
             *(int *)(((int)((char *)this) + 0x370)) += mVertSpeed;
-            if (unk_370 < 0)
+            if (mOffsetY < 0)
                 break;
-            unk_370 = 0;
+            mOffsetY = 0;
             mWaitTimer = 6;
             (*(u8 *)(((int)((char *)this) + 0x376)))++;
             break;
         case 2:
             if (DecIfAbove0_Short((u16 *)((char *)&mWaitTimer)) != 0)
                 break;
-            if (_Z14ApproachLinearRsss((s16 *)((char *)&mAngleZ), unk_378, 0x4b0) == 0)
+            if (_Z14ApproachLinearRsss((s16 *)((char *)&mAngleZ), mTargetAngleZ, 0x4b0) == 0)
                 break;
             _ZN5Sound9PlayBank3EjRK7Vector3(0x40, ((char *)this) + 0x74);
-            unk_376 = 0;
+            mState = 0;
             mWaitTimer = data_ov065_0211cfa4[data_0209f2c0];
             if (data_0209f2c0 == 2)
                 mWaitTimer = (unsigned int)RandomIntInternal(&data_0209e650) % 7 * 0x14 + 5;
-            *(s16 *)(((int)((char *)this) + 0x378)) += data_ov065_0211cfa8[unk_377];
+            *(s16 *)(((int)((char *)this) + 0x378)) += data_ov065_0211cfa8[mVariant];
             break;
         }
     }

--- a/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
+++ b/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
@@ -31,7 +31,7 @@ void BowserPuzzlePiece::InitResources()
     _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
         ((char*)this) + 0x124,
         _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov064_0211c800),
-        *(const Matrix4x3*)((char*)&unk_2ec), 0x1000, mAngleY, data_ov064_0211baac);
+        *(const Matrix4x3*)((char*)&mClsnMat), 0x1000, mAngleY, data_ov064_0211baac);
     func_020393c4((int*)((char*)&mMovingMeshCollider), (int)&func_ov064_021192bc);
     mStateInfo = data_ov064_0211c198[mType];
     mStateIndex = 0;

--- a/src/_ZN18NestedHeapIterator19RecursiveFindNestedEPv.cpp
+++ b/src/_ZN18NestedHeapIterator19RecursiveFindNestedEPv.cpp
@@ -1,7 +1,7 @@
 //cpp
 // @symbol _ZN18NestedHeapIterator19RecursiveFindNestedEPv
 /* NestedHeapIterator::RecursiveFindNested -- walk this list and, for the first
- * node whose [unk_018, unk_01c) range contains addr, recurse into that node's
+ * node whose [mStart, mEnd) range contains addr, recurse into that node's
  * own nested list before falling back to the node itself.
  *
  * The recursion target is `(char *)cur + 0xc', a NestedHeapIterator embedded in
@@ -21,7 +21,7 @@ void *NestedHeapIterator::RecursiveFindNested(void *addr)
 {
     HeapAllocator *cur = (HeapAllocator *)Next(0);
     while (cur != 0) {
-        if (cur->unk_018 <= addr && addr < cur->unk_01c) {
+        if (cur->mStart <= addr && addr < cur->mEnd) {
             void *r = ((NestedHeapIterator *)((char *)cur + 0xc))->RecursiveFindNested(addr);
             if (r == 0) r = cur;
             return r;

--- a/src/_ZN18NestedHeapIterator4InitEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator4InitEP13HeapAllocator.cpp
@@ -14,5 +14,5 @@ void NestedHeapIterator::Init(HeapAllocator * a_)
   *((int *) new_var) = 0;
   *((int *) ((char *)this)) = (int) a;
   *((int *) ((char *)&mLast)) = (int) a;
-  *(unsigned short *)((char *)&unk_008) += 1;
+  *(unsigned short *)((char *)&mCount) += 1;
 }

--- a/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.cpp
+++ b/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.cpp
@@ -9,12 +9,12 @@
  * next at +4 -- which is why this walks through char* rather than through named
  * members: the offset is a runtime value, not a layout the header can spell.
  *
- * The count at unk_008 is incremented SIXTEEN bits wide, so the cast is real
+ * The count at mCount is incremented SIXTEEN bits wide, so the cast is real
  * type information and not a codegen crutch: the header types the field u8
- * with a byte of padding after it, and a plain `unk_008 += 1' misses by two
+ * with a byte of padding after it, and a plain `mCount += 1' misses by two
  * words (measured). What this file does NOT need is the launder the sibling
- * AddLast still carries -- `*(unsigned short *)(int)((char *)&unk_008)' and
- * `*(unsigned short *)&unk_008' assemble identically here. The clean
+ * AddLast still carries -- `*(unsigned short *)(int)((char *)&mCount)' and
+ * `*(unsigned short *)&mCount' assemble identically here. The clean
  * follow-up is to retype the field u16 across the class; that touches
  * already-matched files, so it is not this change.
  */
@@ -39,6 +39,6 @@ void NestedHeapIterator::AddAt(HeapAllocator *at_, HeapAllocator *node_)
         *(char **)(nlink + 4) = (char *)at_;
         *(char **)(prev + off + 4) = (char *)node_;
         *(char **)((char *)at_ + mLinkOffset) = (char *)node_;
-        *(unsigned short *)&unk_008 += 1;
+        *(unsigned short *)&mCount += 1;
     }
 }

--- a/src/_ZN18NestedHeapIterator7AddLastEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator7AddLastEP13HeapAllocator.cpp
@@ -20,6 +20,6 @@ void NestedHeapIterator::AddLast(HeapAllocator * a_)
         last = mLast;
         *(int *)((char *)last + link_off + 4) = (int)a;
         mLast = (int)a;
-        *(unsigned short *)(int)((char *)&unk_008) += 1;
+        *(unsigned short *)(int)((char *)&mCount) += 1;
     }
 }

--- a/src/_ZN18SolidHeapAllocatorC1EPvj.c
+++ b/src/_ZN18SolidHeapAllocatorC1EPvj.c
@@ -13,7 +13,7 @@ void* _ZN18SolidHeapAllocatorC1EPvj(struct SolidHeapAllocator *self, void* ptr, 
     fl = (struct FreeList *)((char *)&self->mFreeRegion);
     _ZN13HeapAllocatorC1EjPvPvj(((void*)self), 0x46524d48, (char *)fl + 0xc, ptr, size);
     *(void **)(fl) =
-        *(void **)((char *)&self->unk_018);
+        *(void **)((char *)&self->mStart);
     fl->end = *(void **)((char *)&self->mEnd);
     fl->flags = 0;
     return ((void*)self);

--- a/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
@@ -121,7 +121,7 @@ int TtcConveyorBeltLarge::InitResources()
     e = mVariant;
     kf = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(
         data_ov065_0211d198[e].a);
-    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((dBgW_KcMbg *)((char *)&mMeshCollider), (KCL_File *)kf, *(Matrix4x3 *)((char *)&unk_2ec), 0x199, mAngleY, *(CLPS_Block *)data_ov065_0211d19c[e].a);
+    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((dBgW_KcMbg *)((char *)&mMeshCollider), (KCL_File *)kf, *(Matrix4x3 *)((char *)&mClsnMat), 0x199, mAngleY, *(CLPS_Block *)data_ov065_0211d19c[e].a);
 
     func_020393c4(
         ((char *)this) + 0x124,
@@ -146,10 +146,10 @@ int TtcConveyorBeltLarge::InitResources()
         dBgCh_Gnd rg;
 
         rg.SetObjAndPos(*(Vector3 *)&v, (dActor_c *)0);
-        unk_394 = v.y;
+        mGroundY = v.y;
 
         if (rg.DetectClsn() != 0)
-            unk_394 = rg.result;
+            mGroundY = rg.result;
     }
 
     return 1;

--- a/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
@@ -37,7 +37,7 @@ int TtcConveyorBeltLarge::Behavior()
 
             if (data_0209f2c0 == 2) {
                 if (_Z14ApproachLinearRiii((int*)((char*)&mBeltSpeed), mTargetBeltSpeed, 0xcc) != 0
-                    && DecIfAbove0_Short((u16*)((char*)&unk_39c)) == 0) {
+                    && DecIfAbove0_Short((u16*)((char*)&mDirectionTimer)) == 0) {
                     unsigned int r = (u16)((unsigned int)RandomIntInternal(&data_0209e650) >> 0x10);
                     *(s16*)(((char*)this) + 0x300 + 0x9c) = (s16)(((int)r % 7) * 0x14 + 0xa);
                     if (r >= 0x7fff) {
@@ -54,7 +54,7 @@ int TtcConveyorBeltLarge::Behavior()
             mTextureTransformer.speed = mBeltSpeed;
             _ZN9Animation7AdvanceEv((char*)&mTextureTransformer);
             if (mBeltSpeed != 0) {
-                unk_398 = (int)_ZN5Sound8PlayLongEjjjRK7Vector3s(unk_398, 3, 0x88, ((char*)this) + 0x74, 0);
+                mSoundHandle = (int)_ZN5Sound8PlayLongEjjjRK7Vector3s(mSoundHandle, 3, 0x88, ((char*)this) + 0x74, 0);
             }
         }
 

--- a/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
+++ b/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
@@ -25,8 +25,8 @@ void *_ZN22ExpandingHeapAllocatorC1EPvj(struct ExpandingHeapAllocator *self, voi
     *(u16 *)(inner + 0x10) = 0;
     *(u16 *)(inner + 0x12) = 0;
     (*(u16 *)(inner + 0x12)) &= ~1;
-    t.start = *(void **)((char *)&self->unk_018);
-    t.end = *(void **)((char *)&self->unk_01c);
+    t.start = *(void **)((char *)&self->mStart);
+    t.end = *(void **)((char *)&self->mEnd);
     node = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t, 0x4652);
     *(MemoryNode **)(inner) = node;
     *(MemoryNode **)(inner + 4) = node;

--- a/src/_ZN4Clam8BehaviorEv.cpp
+++ b/src/_ZN4Clam8BehaviorEv.cpp
@@ -64,7 +64,7 @@ int Clam::Behavior()
             u.shutPuff[1] = u.shutPuff[1] + 0x32000;
             _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x10c,
                 u.shutPuff[0], u.shutPuff[1], u.shutPuff[2]);
-            unk_170 = 0xa;
+            mShutTimer = 0xa;
             mStateTimer = 0;
             *(int *)&mdCcAc_c.flags &= ~1;
         } else {
@@ -82,8 +82,8 @@ int Clam::Behavior()
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((char *)&mModelAnim,
                     *(int *)(data_ov064_0211c9cc + 4), 0x40000000, 0x1000, 0);
             } else {
-                if (unk_170 != 0)
-                    unk_170--;
+                if (mShutTimer != 0)
+                    mShutTimer--;
             }
         }
         break;

--- a/src/_ZN5Timer10ResetTimerEv.cpp
+++ b/src/_ZN5Timer10ResetTimerEv.cpp
@@ -7,5 +7,5 @@
 void Timer::ResetTimer()
 {
     mIsRunning = 0;
-    unk_000 = 0;
+    mTime = 0;
 }

--- a/src/_ZN5Timer10StartTimerEv.cpp
+++ b/src/_ZN5Timer10StartTimerEv.cpp
@@ -7,5 +7,5 @@
 void Timer::StartTimer()
 {
   mIsRunning = 1;
-  unk_000 = func_02059650() - unk_000;
+  mTime = func_02059650() - mTime;
 }

--- a/src/_ZN5Timer7GetTimeEv.cpp
+++ b/src/_ZN5Timer7GetTimeEv.cpp
@@ -7,6 +7,6 @@
 s64 Timer::GetTime()
 {
   if (mIsRunning == 0)
-    return unk_000;
-  return func_02059650() - unk_000;
+    return mTime;
+  return func_02059650() - mTime;
 }

--- a/src/_ZN5Timer9StopTimerEv.cpp
+++ b/src/_ZN5Timer9StopTimerEv.cpp
@@ -9,5 +9,5 @@ void Timer::StopTimer()
   if (mIsRunning == 0)
     return;
   mIsRunning = 0;
-  unk_000 = func_02059650() - unk_000;
+  mTime = func_02059650() - mTime;
 }

--- a/src/_ZN6Camera14GoBehindPlayerEj.cpp
+++ b/src/_ZN6Camera14GoBehindPlayerEj.cpp
@@ -24,9 +24,9 @@ void Camera::GoBehindPlayer(unsigned int j)
     func_0200cb58((void *)((int)this), 0xa);
     *(unsigned int *)(((long long)(int)((int)&mFlags))) |= 4u;
 
-    slot4 = unk_13c;
+    slot4 = mState_13c;
     slotc = 0;
-    func_0200c66c((void *)((int)this), (void *)(unk_110 + 0x5c), &slot8, &slot4, &slotc);
+    func_0200c66c((void *)((int)this), (void *)(mTargetPlayer + 0x5c), &slot8, &slot4, &slotc);
     if (slot4 == (int)&data_020873dc)
         return;
     if (slot4 == (int)&data_0208742c)

--- a/src/_ZN6Camera16CleanupResourcesEv.cpp
+++ b/src/_ZN6Camera16CleanupResourcesEv.cpp
@@ -15,7 +15,7 @@ extern "C" void _ZN6Memory16operator_delete2EPv(void *p); /* 0x0203cbcc */
 
 int Camera::CleanupResources()
 {
-    void *p = unk_148;
+    void *p = mFixedViewPos;
     if (p) {
         if (p)
             _ZN6Memory16operator_delete2EPv(p);

--- a/src/_ZN6Cannon6RenderEv.cpp
+++ b/src/_ZN6Cannon6RenderEv.cpp
@@ -14,7 +14,7 @@ struct Sub {
 int Cannon::Render()
 {
   if(mState == 3){
-    if(unk_185 >= 3) return 1;
+    if(mFireStep >= 3) return 1;
   }
   Sub* o = (Sub*)((char*)&mModel);
   o->m3();

--- a/src/_ZN6Coffin13InitResourcesEv.cpp
+++ b/src/_ZN6Coffin13InitResourcesEv.cpp
@@ -67,7 +67,7 @@ int Coffin::InitResources()
     mPosZ = res.z;
     func_ov071_02122080(((char*)this));
     ((dBgActor_c*)((char*)this))->UpdateClsnPosAndRot();
-    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((dBgW_KcMbg*)((char*)&mMeshCollider), (KCL_File*)dBgW_Kc::LoadFile(data_ov071_021230d8), *(Matrix4x3*)((char*)&unk_2ec), 0x199, mAngleY, data_ov063_0211ebd8);
+    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((dBgW_KcMbg*)((char*)&mMeshCollider), (KCL_File*)dBgW_Kc::LoadFile(data_ov071_021230d8), *(Matrix4x3*)((char*)&mClsnMat), 0x199, mAngleY, data_ov063_0211ebd8);
     func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
     return 1;
 }

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -64,9 +64,9 @@ int Dorrie::InitResources()
     }
 
     {
-        unk_1194 = mPosX;
-        unk_1198 = mPosY;
-        unk_119c = mPosZ;
+        mSpawnPosX = mPosX;
+        mSpawnPosY = mPosY;
+        mSpawnPosZ = mPosZ;
         /* cast launder: materialize add r2,sl,#0x5c; ldr/str [r2] */
         *(int*)(((int)((char*)this) + 0x5c)) += 0x7d0000;
     }

--- a/src/_ZN6ShipUp13InitResourcesEv.cpp
+++ b/src/_ZN6ShipUp13InitResourcesEv.cpp
@@ -40,7 +40,7 @@ int ShipUp::InitResources()
         func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
     }
     ((dBgW *)(((char*)this)+0x124))->Enable((dActor_c *)(((char*)this)));
-    unk_324 = 0;
+    mSoundHandle = 0;
     unk_328 = 0;
     if (data_0209f220 > 1) {
         if (IsStarCollected(SublevelToLevel(8), 1) != 0) {

--- a/src/_ZN6ShipUp8BehaviorEv.cpp
+++ b/src/_ZN6ShipUp8BehaviorEv.cpp
@@ -21,9 +21,9 @@ int ShipUp::Behavior()
   func_020393a4((int*)((char*)&mMeshCollider), 0x2000000);
   if(mModelIndex == 0){
     *(short*)(((int)((char*)this) + 0x320)) += 0xda;
-    mAngleX = (short)((*(short*)((char*)data_02082214 + ((unk_320>>4)<<2)) << 0xa) >> 0xc);
+    mAngleX = (short)((*(short*)((char*)data_02082214 + ((mBobAngle>>4)<<2)) << 0xa) >> 0xc);
     if(_ZN8dActor_c13DistToCPlayerEv(((char*)this)) < 0xbb8000){
-      unk_324 = _ZN5Sound8PlayLongEjjjRK7Vector3s(unk_324, 3, 0x8b, ((char*)this)+0x74, 0);
+      mSoundHandle = _ZN5Sound8PlayLongEjjjRK7Vector3s(mSoundHandle, 3, 0x8b, ((char*)this)+0x74, 0);
     }
     func_ov016_021126a8(((char*)this));
     _ZN10dBgActor_c19UpdateClsnPosAndRotEv(((char*)this));

--- a/src/_ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh.cpp
+++ b/src/_ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh.cpp
@@ -27,8 +27,8 @@ extern "C" int _ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh(Clipper *thiz, Ve
         long long d;
 
         negZ = -v->z;
-        if (negZ < thiz->unk_050 - clip) goto fail1;
-        if (negZ > thiz->unk_054 + clip) goto fail1;
+        if (negZ < thiz->mNearZ - clip) goto fail1;
+        if (negZ > thiz->mFarZ + clip) goto fail1;
 
         first = *hint & 3;
         x = v->x;
@@ -61,8 +61,8 @@ extern "C" int _ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh(Clipper *thiz, Ve
         int negZ;
 
         negZ = -v->z;
-        if (negZ < thiz->unk_050 - clip) goto fail2;
-        if (negZ > thiz->unk_054 + clip) goto fail2;
+        if (negZ < thiz->mNearZ - clip) goto fail2;
+        if (negZ > thiz->mFarZ + clip) goto fail2;
 
         if ((int)(((long long)v->z * thiz->mPlaneNormals[0].z + 0x800) >> 12)
             + ((int)(((long long)v->x * thiz->mPlaneNormals[0].x + 0x800) >> 12)

--- a/src/_ZN7Clipper13Func_0201559CEv.cpp
+++ b/src/_ZN7Clipper13Func_0201559CEv.cpp
@@ -3,13 +3,13 @@
 /* Clipper::Func_0201559C -- rebuild the four view-frustum side planes from the
  * current field of view and near-plane distance.
  *
- * unk_058 is an angle; its top 12 bits index a sine/cosine pair table at
- * data_02082214, and fdiv of that pair gives the tangent. Scaling by unk_050
- * (the plane distance) gives the half-height b, and by unk_04c (the aspect
- * ratio) the half-width c. The four corner vectors at z = -unk_050 follow, and
+ * mFovAngle is an angle; its top 12 bits index a sine/cosine pair table at
+ * data_02082214, and fdiv of that pair gives the tangent. Scaling by mNearZ
+ * (the plane distance) gives the half-height b, and by mAspectRatio (the aspect
+ * ratio) the half-width c. The four corner vectors at z = -mNearZ follow, and
  * each adjacent pair crossed and normalised is one side plane's normal.
  *
- * This body is what proves unk_04c is SIGNED: it sign-extends the field into a
+ * This body is what proves mAspectRatio is SIGNED: it sign-extends the field into a
  * 64-bit multiply, which a u32 cannot do. The header used to type it u32 on the
  * weaker evidence of Func_020156DC, which only stores to it; that is now
  * corrected there rather than cast away here.
@@ -25,15 +25,15 @@ extern "C" short data_02082214[];
 
 void Clipper::Func_0201559C()
 {
-    int idx = (int)unk_058 >> 4;
+    int idx = (int)mFovAngle >> 4;
     int q = _ZN4cstd4fdivEii(data_02082214[2 * idx], data_02082214[2 * idx + 1]);
-    Fix12i b = (Fix12i)(((long long)unk_050 * q + 0x800) >> 12);
-    Fix12i c = (Fix12i)(((long long)unk_04c * b + 0x800) >> 12);
+    Fix12i b = (Fix12i)(((long long)mNearZ * q + 0x800) >> 12);
+    Fix12i c = (Fix12i)(((long long)mAspectRatio * b + 0x800) >> 12);
     Vector3 v0, v1, v2, v3;
-    v0.x = -c; v0.y = -b; v0.z = -unk_050;
-    v1.x = -c; v1.y = b;  v1.z = -unk_050;
-    v2.x = c;  v2.y = b;  v2.z = -unk_050;
-    v3.x = c;  v3.y = -b; v3.z = -unk_050;
+    v0.x = -c; v0.y = -b; v0.z = -mNearZ;
+    v1.x = -c; v1.y = b;  v1.z = -mNearZ;
+    v2.x = c;  v2.y = b;  v2.z = -mNearZ;
+    v3.x = c;  v3.y = -b; v3.z = -mNearZ;
     CrossVec3(&v1, &v0, &mPlaneNormals[0]);
     CrossVec3(&v2, &v1, &mPlaneNormals[1]);
     CrossVec3(&v3, &v2, &mPlaneNormals[2]);

--- a/src/_ZN7Clipper13Func_020156DCEv.cpp
+++ b/src/_ZN7Clipper13Func_020156DCEv.cpp
@@ -6,10 +6,10 @@
 extern "C" {
 
 void _ZN7Clipper13Func_020156DCEv(struct Clipper *self, u32 a, u16 b, Fix12i c, Fix12i d) {
-    self->unk_04c = a;
-    self->unk_058 = b;
-    *(Fix12i*)((char*)&self->unk_050) = c;
-    *(Fix12i*)((char*)&self->unk_054) = d;
+    self->mAspectRatio = a;
+    self->mFovAngle = b;
+    *(Fix12i*)((char*)&self->mNearZ) = c;
+    *(Fix12i*)((char*)&self->mFarZ) = d;
     self->Func_0201559C();
 }
 

--- a/src/_ZN7dBgW_Kc10DetectClsnER12dBgCh_SphCrr.cpp
+++ b/src/_ZN7dBgW_Kc10DetectClsnER12dBgCh_SphCrr.cpp
@@ -689,7 +689,7 @@ s32 dBgW_Kc::DetectClsn(dBgCh_SphCrr &sphere)
                         if (!contactKind) contactKind = k2;
 
                     face:
-                        if (sphere.unk_108 < sn.y) continue;
+                        if (sphere.mScale < sn.y) continue;
 
                         /* Walls only, and only once the cheap tests have accepted
                            the prism. Rebuild the triangle's three real vertices --

--- a/src/_ZN8SaveData13PlayerLoseCapEv.cpp
+++ b/src/_ZN8SaveData13PlayerLoseCapEv.cpp
@@ -10,7 +10,7 @@
  *
  * The save block still has no friendly symbol -- the reloc is a wildcard pooled
  * reference to 0x0209caa0 -- so it is reached by its placeholder name, but now
- * with its real type instead of a local shadow. `unk_041` is the current character.
+ * with its real type instead of a local shadow. `mCharacter` is the current character.
  */
 extern "C" struct SaveData data_0209caa0;
 
@@ -18,5 +18,5 @@ void SaveData::PlayerLoseCap()
 {
     if (!SaveData::CanPlayerHaveCap())
         return;
-    data_0209caa0.flags1 = data_0209caa0.flags1 | (0x1000000u << data_0209caa0.unk_041);
+    data_0209caa0.flags1 = data_0209caa0.flags1 | (0x1000000u << data_0209caa0.mCharacter);
 }

--- a/src/_ZN8SaveData16CanPlayerHaveCapEv.cpp
+++ b/src/_ZN8SaveData16CanPlayerHaveCapEv.cpp
@@ -7,7 +7,7 @@
  * True when the current character can wear a cap at all: character 3 (Wario)
  * never can, and a second global at 0x0209f2d8 gates it besides. Both are read
  * as raw globals because neither has a friendly symbol yet; the byte at +0x41
- * of the save block is the current character, which SaveData.h names unk_041.
+ * of the save block is the current character, which SaveData.h names mCharacter.
  */
 extern "C" {
 extern unsigned char data_0209caa0[];

--- a/src/_ZN8SaveData16HasPlayerLostCapEv.cpp
+++ b/src/_ZN8SaveData16HasPlayerLostCapEv.cpp
@@ -15,5 +15,5 @@ int SaveData::HasPlayerLostCap()
 {
     if (!SaveData::CanPlayerHaveCap())
         return 0;
-    return data_0209caa0.flags1 & (0x1000000u << data_0209caa0.unk_041);
+    return data_0209caa0.flags1 & (0x1000000u << data_0209caa0.mCharacter);
 }

--- a/src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp
+++ b/src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp
@@ -26,7 +26,7 @@ void SaveData::SetDefaultValues(FileSaveData* fsd_)
 {
     func_0205a588(((void*)this), 0, 0x44);
     *(int*)((void*)this) = 0x30303038;      /* magic8000, via `this` */
-    *(unsigned char*)((char*)&unk_041) = 3;
+    *(unsigned char*)((char*)&mCharacter) = 3;
     *(int*)((char*)&flags2) |= 8;
     *(unsigned char*)((char*)&unk_042) = 0;
 }

--- a/src/_ZN9ArrowLift8BehaviorEv.cpp
+++ b/src/_ZN9ArrowLift8BehaviorEv.cpp
@@ -31,8 +31,8 @@ int ArrowLift::Behavior()
             int* p = (int*)(((int)((u8*)this) + 0x320));
             *p = *p + mHorzSpeed;
         }
-        if (unk_320 >= 0x177000) {
-            unk_320 = 0;
+        if (mTravelDist >= 0x177000) {
+            mTravelDist = 0;
             {
                 u8* p = (u8*)(((int)((u8*)this) + 0x327));
                 *p = *p + 1;

--- a/src/_ZN9dBgCh_GndC1Ev.cpp
+++ b/src/_ZN9dBgCh_GndC1Ev.cpp
@@ -10,7 +10,7 @@
  *                           derived class's primary block and its one
  *                           secondary thunk block, written over whatever the
  *                           base ctors left behind
- *   unk_04c = 0x1f4000      the only state this constructor itself supplies:
+ *   mProbeHeight = 0x1f4000      the only state this constructor itself supplies:
  *                           the default probe height, a Fix12i of 496.0
  *
  * Everything except that last store is synthesized: declaring the two bases
@@ -21,4 +21,4 @@
  */
 #include "dBgCh_Gnd.h"
 
-dBgCh_Gnd::dBgCh_Gnd() : unk_04c(0x1f4000) {}
+dBgCh_Gnd::dBgCh_Gnd() : mProbeHeight(0x1f4000) {}

--- a/src/_ZN9dBgCh_GndD1Ev.c
+++ b/src/_ZN9dBgCh_GndD1Ev.c
@@ -5,8 +5,8 @@
 #include "dBgCh_Gnd.h"
 int *_ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd *self) {
     ((int *)self)[0] = (int)_ZTV9dBgCh_Gnd;
-    *(int *)((char *)&self->unk_010) = (int)VTable_dBgPi_dBgCh_GndThunk;
-    _ZN5dBgPiD2Ev((char *)&self->unk_010);
+    *(int *)((char *)&self->mBgPiBase) = (int)VTable_dBgPi_dBgCh_GndThunk;
+    _ZN5dBgPiD2Ev((char *)&self->mBgPiBase);
     func_020354d0(((int *)self));
     return ((int *)self);
 }

--- a/src/_ZN9dBgCh_LinD1Ev.c
+++ b/src/_ZN9dBgCh_LinD1Ev.c
@@ -7,10 +7,10 @@ extern int _ZTV9dBgCh_Lin[];
 extern int VTable_dBgPi_dBgCh_LinThunk[];
 int *_ZN9dBgCh_LinD1Ev(struct dBgCh_Lin *self) {
     ((int *)self)[0] = (int)_ZTV9dBgCh_Lin;
-    *(int *)((char *)&self->unk_010) = (int)VTable_dBgPi_dBgCh_LinThunk;
+    *(int *)((char *)&self->mBgPiBase) = (int)VTable_dBgPi_dBgCh_LinThunk;
     _ZN8dM3dGSphD1Ev((char *)&self->mBoundSphere);
-    func_ov002_020feab8((char *)&self->unk_038);
-    _ZN5dBgPiD2Ev((char *)&self->unk_010);
+    func_ov002_020feab8((char *)&self->mLineBase);
+    _ZN5dBgPiD2Ev((char *)&self->mBgPiBase);
     func_020354d0(((int *)self));
     return ((int *)self);
 }

--- a/src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano13InitResourcesEv.cpp
@@ -34,9 +34,9 @@ int MadPiano::InitResources()
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *)this) + 0x320, f, 0, 0x1000, 0);
     mVertAccel = -0x2000;
     mTerminalVelocity = -0x3c000;
-    unk_6d4 = mPosX;
-    unk_6d8 = mPosY;
-    unk_6dc = mPosZ;
+    mHomePosX = mPosX;
+    mHomePosY = mPosY;
+    mHomePosZ = mPosZ;
     _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x50c, ((char *)this), 0x159000, 0x159000, 0, 0);
     for (i = 0, p = ((char *)this) + 0x48c; i < 2; i++) {
         _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(

--- a/src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp
+++ b/src/actors/MadPiano/_ZN8MadPiano8BehaviorEv.cpp
@@ -33,13 +33,13 @@ int MadPiano::Behavior()
 {
   func_ov063_0211ddf4(((char*)this));
   ((struct dActor_c*)((char*)this))->UpdatePos(0);
-  if (Vec3_HorzDist((struct Vector3*)((char*)&unk_6d4), (struct Vector3*)((char*)&mPosX)) > 0x180000) {
+  if (Vec3_HorzDist((struct Vector3*)((char*)&mHomePosX), (struct Vector3*)((char*)&mPosX)) > 0x180000) {
     mPosX = mPrevPosX;
     mPosY = mPrevPosY;
     mPosZ = mPrevPosZ;
   }
   {
-    int r1 = unk_6cc;
+    int r1 = mMinPosY;
     if (mPosY <= r1) mPosY = r1;
   }
   dBgCh_Actr_UpdateContinuous_Veneer((char*)&mWithMeshClsn);

--- a/src_tu/actors/ArrowLift.cpp
+++ b/src_tu/actors/ArrowLift.cpp
@@ -204,8 +204,8 @@ int ArrowLift::Behavior()
             int* p = (int*)(((int)((u8*)this) + 0x320));
             *p = *p + mHorzSpeed;
         }
-        if (unk_320 >= 0x177000) {
-            unk_320 = 0;
+        if (mTravelDist >= 0x177000) {
+            mTravelDist = 0;
             {
                 u8* p = (u8*)(((int)((u8*)this) + 0x327));
                 *p = *p + 1;

--- a/src_tu/actors/ChainChomp.cpp
+++ b/src_tu/actors/ChainChomp.cpp
@@ -225,11 +225,11 @@ int ChainChomp::Behavior()
     func_ov014_02111f08(((char*)this));
     _ZN8dActor_c9UpdatePosEP5dCc_c(((char*)this), ((char*)this) + 0x110);
     func_ov014_02112114(((char*)this));
-    if (unk_605 == 0) {
+    if (mChainBroken == 0) {
         func_ov014_02111fe0(((char*)this));
     }
     func_ov014_0211250c(((char*)this));
-    if (unk_605 == 0) {
+    if (mChainBroken == 0) {
         func_ov014_0211236c(((char*)this));
         func_ov014_021122dc(((char*)this));
     }


### PR DESCRIPTION
Continues the standalone-struct naming pass from #1741, restacked onto main
after #1742 and #1743 landed. **69 placeholder fields named**, all byte-neutral.

## Where the names came from

**The file had already worked it out.** `Clipper`'s own body carries a
paragraph explaining that 0x058 is an angle indexing a sine/cosine table,
0x050 the plane distance, 0x04c the aspect ratio -- and then uses `unk_058`.
Same for `SaveData`'s 0x041 ("the current character", said twice, in two
files) and `NestedHeapIterator`'s 0x008 ("the count", with a whole note on
why it is incremented sixteen bits wide). Those became `mFovAngle`,
`mNearZ`, `mAspectRatio`, `mCharacter`, `mCount`.

**The body says it plainly.** Four `dBgActor_c` leaves pass the Matrix4x3 at
0x2ec to `dBgW_KcMbg::SetFile`; `dBgActor_c` has called that offset
`mClsnMat` all along. `MadPiano` and `Dorrie` snapshot `mPos` into a triple.
`TtcRotatingCube`'s 0x377 indexes three resource tables in
`CleanupResources` and an angle-step table in `Behavior`.

**The handlers say it.** `PrincessPeach`'s 0x354 is written 0,1,2,3,4 by five
separate ov085 handlers -- a state machine seen from outside the class.
`KingBobOmb`'s 0x494 is handed to a throw call, moved to 0x430, cleared.
`daPgDfdr_c`'s 0x3d9 indexes four parallel tables and wraps at 9.

**The stride says it.** `WorkElevator`'s 0x520 looked like one opaque byte.
It is the first of four `dBgW_KcMbg` exactly `sizeof(dBgW_KcMbg)` = 0x1c8
apart, and one loop walks all four -- `transform += 0x1c8` is the proof, and
it is what makes naming the other three honest rather than a guess.

## Two guards that earned their keep

`Shark` and `SlidingBox` read 0x0a4/0x0a8/0x0ac as a velocity triple around
`mVertSpeed`, so `mSpeedX`/`mSpeedZ` looked safe in a base-less struct. It is
not: `Shark`'s C++ half derives from `dEnemyBase_c` and resolves those two
through `dActor_c`, where the evidence is contradictory and the name was
already declined. The compile caught it; **reverted**.

Carrying a rename by bare word rewrote `mClsnResult1.unk_010`, which is
`dBgPi`'s field reached through a member of a class that happens to declare
its own `unk_010`. Only `this`/`self` qualification means the enclosing class.

## What is deliberately still `unk_`

`dBgPi`'s nine appear only in its own `operator=` -- a memberwise copy gives
width and no meaning. `dActor_c` 0x0a4/0x0ac stay declined for the reason
above. `MirrorLuigi`'s 0x1b8/0x1cc sit eight bytes into the `TextureSequence`
beside them, so they are interior to that object, not siblings. Roughly half
the remainder has no reader anywhere in the tree; a falsely justified `unk_`
is worse than an honest one.

## Verification

- `rombuild.py --no-rom`: **11,060 / 11,060 reproducing, 0 mismatching**,
  module fidelity **106/106 exact**, ROM-build analysis **PASS**
- `eligible.py` bracketed against `origin/main`: **byte-identical**, 11,067 names
- `twin_align --check`, `chain_align --check`: clean
- `port_refcheck`: 406/406 · `check_header_offsets --changed`: 0 unparsed
- `check_dead_references`: no new dead references
- `tiers_ratchet --check`: PASS
- `check_src_tu_compiles`: 2 failures, both **reproduced on `origin/main`**
  unchanged (`Actor.cpp` return-value warnings, a `dBgCh_Lin` redefinition
  plus an mwccarm ICE in `HeaveHo.cpp`) -- pre-existing, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmxJxTnGiPoUKRwCVkFRgQ