### PR TITLE
nearmiss: loud duplicate collapse, drops beat same-run updates, test the merge layer

### DIFF
--- a/tools/nearmiss_db.py
+++ b/tools/nearmiss_db.py
@@ -37,9 +37,10 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import asm_policy  # noqa: E402
-import match as M
-import swarm as S
 import ledger as L
+# match/swarm (the compile+disasm stack) need capstone and pyelftools; the functions
+# that evaluate candidates import them lazily so the metadata-only subcommands
+# (stats, list, dedupe) and tools/test_nearmiss_db.py run on a bare interpreter.
 
 DB = REPO / "nearmiss" / "db.jsonl"
 LOCKDIR = REPO / "nearmiss" / ".lock"
@@ -54,6 +55,7 @@ def locked():
 
 
 def _disasm(code, relocs):
+    import swarm as S
     out = []
     for ins in S.code_insns(list(S.md.disasm(code, 0))):
         if ins.address in relocs:
@@ -70,6 +72,8 @@ def evaluate(src, name, target):
     match (swarm.oracle_ok -- NOT exact byte-equality, since reloc slots are wildcarded).
     Returns (None, False) if it does not compile or the function is absent."""
     import tempfile, os, difflib
+    import match as M
+    import swarm as S
     cpp = src.startswith("//cpp")
     try:
         ok = S.oracle_ok(src, name, target)        # definitive, reloc-aware
@@ -106,7 +110,7 @@ def _rank(r):
 
 
 def load_db():
-    db = {}
+    db, dups = {}, 0
     for r in L.read_records(DB):        # corrupt lines are reported, not swallowed
         # A row that parses as JSON but lacks addr/module is unkeyable. That used to raise
         # out of key_of and take down every caller -- one bad ingest silently disabled the
@@ -118,12 +122,22 @@ def load_db():
             continue
         key = L.key_of(r)               # normalized: addr is stored as both hex str and int
         cur = db.get(key)
-        # merge=union (and a since-fixed raw-key ingest) can leave two rows for one key.
-        # Keep the BEST, never the last read: last-wins meant the next save_db() silently
-        # discarded whichever row happened to sort earlier in the file -- ov006 0x020d7c4c
-        # lost its lower-divergence attempt exactly that way.
+        # merge=union (and any pre-#1676 raw-key ingest still running in a stale lane
+        # checkout -- ov004 0x020ae858 got duplicated by one on 2026-08-25) can leave two
+        # rows for one key. Keep the BEST, never the last read: last-wins meant the next
+        # save_db() silently discarded whichever row happened to sort earlier in the file
+        # -- ov006 0x020d7c4c lost its lower-divergence attempt exactly that way. Collapse
+        # loudly: a duplicate on disk survives until someone runs dedupe, and a silent
+        # collapse reads as a healthy DB while the file carries a dead row (219 lines
+        # reporting as 218 entries in the 2026-08-25 incident).
+        if cur is not None:
+            dups += 1
         if cur is None or _rank(r) < _rank(cur):
             db[key] = r
+    if dups:
+        print(f"nearmiss_db: {dups} duplicate (module, addr) row(s) in {DB.name}; "
+              f"kept the closest per key (run `python tools/nearmiss_db.py dedupe`)",
+              file=sys.stderr)
     return db
 
 
@@ -166,6 +180,32 @@ def resolve_name(name):
                 _NAME_IDX[fn] = (f"0x{addr:08x}", size, label,
                                  data[addr - mod["base"]:addr - mod["base"] + size].hex())
     return _NAME_IDX.get(name)
+
+
+def merge_batch(db, drops, updates):
+    """Apply one ingest batch to a loaded db dict, in place. Returns (added, improved).
+
+    Drops win over updates. A dropped key means the function is matched (the ledger or
+    committed src/ says so), and one seeds file can carry two names for one (module,
+    addr) -- a stale func_ADDR placeholder next to the real symbol -- where the
+    src-file check catches one name but not the other. Popping the key and then
+    letting the update land re-created the ghost row the drop existed to remove, and
+    counted the survivor as "+1 new" because the pop had emptied the slot the update
+    compared against."""
+    dropped = set(drops)
+    for key in dropped:
+        db.pop(key, None)
+    added = improved = 0
+    for key, rec in updates.items():
+        if key in dropped:
+            continue
+        cur = db.get(key)
+        curdiv = cur.get("divergences") if cur and cur.get("divergences") is not None else 1e9
+        if cur is None or rec["divergences"] < curdiv:
+            db[key] = rec
+            added += cur is None
+            improved += cur is not None
+    return added, improved
 
 
 def ingest(args):
@@ -231,18 +271,9 @@ def ingest(args):
                             "divergences": div, "c_source": src, "source": args.label or "fanout"}
     # merge under the lock: evaluate() above is slow, so the read-modify-write
     # happens against a FRESH db snapshot to not clobber concurrent crunchers
-    added = improved = 0
     with locked():
         db = load_db()
-        for key in drops:
-            db.pop(key, None)
-        for key, rec in updates.items():
-            cur = db.get(key)
-            curdiv = cur.get("divergences") if cur and cur.get("divergences") is not None else 1e9
-            if cur is None or rec["divergences"] < curdiv:
-                db[key] = rec
-                added += cur is None
-                improved += cur is not None
+        added, improved = merge_batch(db, drops, updates)
         save_db(db)
         total = len(db)
     print(f"ingested: +{added} new, {improved} improved. DB now {total} entries.")
@@ -476,6 +507,7 @@ def resync_names(args):
 
 def bank_matches(args):
     """Re-evaluate every entry; bank any that now byte-match (score 0)."""
+    import swarm as S
     db = load_db()
     banked, banked_keys, rescored = 0, [], {}
     for key, r in list(db.items()):

--- a/tools/test_nearmiss_db.py
+++ b/tools/test_nearmiss_db.py
@@ -1,0 +1,153 @@
+"""Regression tests for the load/merge/save layer of tools/nearmiss_db.py.
+
+The shape under test is the 2026-08-25 ov004 0x020ae858 incident: a duplicated
+(module, addr) key on disk. save_db sorts ascending by divergences, so the worse
+of two duplicate rows is always the LAST one in the file -- a last-wins load_db
+made the next save silently discard the better candidate and keep the worse one.
+nearmiss/README.md promises one record per (module, addr) keeping the CLOSEST
+candidate; these tests hold load_db, merge_batch, and dedupe --check to that.
+
+Nothing here compiles or disassembles. The swarm/match stack imports lazily, so
+this suite (and the metadata-only subcommands) runs on a bare interpreter:
+
+    python -m unittest tools.test_nearmiss_db -v
+"""
+import argparse
+import contextlib
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOLS))
+import nearmiss_db as NDB  # noqa: E402
+import ledger as L  # noqa: E402
+
+KEY = L.make_key("ov004", 0x020AE858)
+
+
+def row(div, addr="0x020ae858", module="ov004", **kw):
+    r = {"module": module, "addr": addr, "name": f"func_{module}", "size": 0x164,
+         "target_hex": "00", "lang": "c", "divergences": div,
+         "c_source": "void f(void) {}", "source": "test"}
+    r.update(kw)
+    return r
+
+
+class NearMissDbTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self._saved_db = NDB.DB
+        self.addCleanup(setattr, NDB, "DB", self._saved_db)
+        NDB.DB = pathlib.Path(tmp.name) / "db.jsonl"
+
+    def write_rows(self, *rows):
+        NDB.DB.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    def load_quiet(self):
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            db = NDB.load_db()
+        return db, err.getvalue()
+
+    # ------------------------------------------------------------------ load_db
+    def test_load_db_keeps_closest_row_and_warns(self):
+        # Incident file shape: ascending save order puts the worse duplicate LAST,
+        # exactly where a last-wins reader would keep it.
+        self.write_rows(row(10), row(50))
+        db, err = self.load_quiet()
+        self.assertEqual(len(db), 1)
+        self.assertEqual(db[KEY]["divergences"], 10)
+        self.assertIn("duplicate (module, addr)", err)
+        # The other order must give the same answer.
+        self.write_rows(row(50), row(10))
+        db, _ = self.load_quiet()
+        self.assertEqual(db[KEY]["divergences"], 10)
+
+    def test_load_db_is_quiet_without_duplicates(self):
+        self.write_rows(row(10), row(42, addr="0x020ee994", module="ov006"))
+        db, err = self.load_quiet()
+        self.assertEqual(len(db), 2)
+        self.assertEqual(err, "")
+
+    def test_save_after_load_keeps_the_better_duplicate(self):
+        # The data-loss step itself: load a duplicated file, save it back, and the
+        # surviving row on disk must be the closer one (the old last-wins load wrote
+        # back div=50 and dropped div=10 here).
+        self.write_rows(row(10), row(50))
+        db, _ = self.load_quiet()
+        NDB.save_db(db)
+        lines = [json.loads(l) for l in NDB.DB.read_text().splitlines()]
+        self.assertEqual([r["divergences"] for r in lines], [10])
+
+    def test_load_db_floor_mark_breaks_a_divergence_tie(self):
+        floored = row(10, floor={"class": "ordering", "evidence": "e", "date": "2026-08-25"})
+        self.write_rows(row(10), floored)
+        db, _ = self.load_quiet()
+        self.assertTrue(db[KEY].get("floor"))
+
+    def test_load_db_collides_hex_string_and_int_addr_forms(self):
+        self.write_rows(row(50, addr="0x020ae858"), row(10, addr=0x020AE858))
+        db, _ = self.load_quiet()
+        self.assertEqual(list(db), [KEY])
+        self.assertEqual(db[KEY]["divergences"], 10)
+
+    # -------------------------------------------------------------- merge_batch
+    def test_merge_counts_a_better_candidate_as_improved_not_new(self):
+        db = {KEY: row(50)}
+        added, improved = NDB.merge_batch(db, [], {L.make_key("ov004", "0x020ae858"): row(10)})
+        self.assertEqual((added, improved), (0, 1))
+        self.assertEqual(db[KEY]["divergences"], 10)
+
+    def test_merge_ignores_a_worse_candidate(self):
+        db = {KEY: row(10)}
+        added, improved = NDB.merge_batch(db, [], {KEY: row(50)})
+        self.assertEqual((added, improved), (0, 0))
+        self.assertEqual(db[KEY]["divergences"], 10)
+
+    def test_merge_counts_a_fresh_key_as_new(self):
+        db = {}
+        added, improved = NDB.merge_batch(db, [], {KEY: row(10)})
+        self.assertEqual((added, improved), (1, 0))
+
+    def test_merge_drop_beats_a_same_run_update(self):
+        # One seeds file can carry two names for one key; if one of them proves the
+        # function matched, the update from the other must not resurrect the row.
+        db = {KEY: row(50)}
+        added, improved = NDB.merge_batch(db, [KEY], {KEY: row(10)})
+        self.assertEqual((added, improved), (0, 0))
+        self.assertNotIn(KEY, db)
+
+    # ------------------------------------------------------------ dedupe --check
+    def test_dedupe_check_fails_on_a_duplicated_key(self):
+        self.write_rows(row(10), row(50))
+        with contextlib.redirect_stdout(io.StringIO()):
+            with self.assertRaises(SystemExit) as ctx:
+                NDB.dedupe(argparse.Namespace(check=True, dry_run=False))
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_dedupe_check_passes_a_clean_db(self):
+        self.write_rows(row(10), row(42, addr="0x020ee994", module="ov006"))
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            NDB.dedupe(argparse.Namespace(check=True, dry_run=False))
+        self.assertIn("check ok", out.getvalue())
+
+    # ------------------------------------------------------------------ imports
+    def test_module_imports_without_the_compile_stack(self):
+        # stats/list/dedupe and this suite must run where capstone/pyelftools are
+        # not installed; the compile+disasm stack has to stay a lazy import.
+        code = ("import sys; sys.path.insert(0, sys.argv[1]); import nearmiss_db; "
+                "heavy = [m for m in sys.modules if m == 'capstone' or m.startswith('elftools')]; "
+                "print(','.join(heavy) or 'clean')")
+        out = subprocess.run([sys.executable, "-c", code, str(TOOLS)],
+                             capture_output=True, text=True)
+        self.assertEqual(out.returncode, 0, out.stderr)
+        self.assertEqual(out.stdout.strip(), "clean")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What happened

On 2026-08-25 an `ingest --seeds` run in the mg12 panel lane printed `+1 new, 0 improved` for ov004 0x020ae858 even though `nearmiss/db.jsonl` already held that key at div=50, and left the file with both rows (219 lines reading as 218 entries). The lane was running a pre-#1676 copy of the tool: its `updates`/`drops` were keyed by the raw `(module, "0x...")` tuple while `load_db()` keyed rows by the normalized int, so `db.get()` missed the existing row (hence "new"), `save_db()` wrote both, and every `drops` pop was a silent no-op (ov006 0x020ee994 was never actually pruned by that run; the committed lane diff still carries it). On top of that, the old last-wins `load_db()` plus ascending `save_db()` sort meant the next save would have kept the div=50 row and discarded the div=10 one.

#1676 already fixed the key normalization and made `load_db()` best-wins on main. This PR closes what the incident showed is still open here:

## Changes

- `load_db()` now collapses duplicates loudly: one stderr line with the duplicate count and a pointer at `dedupe`. A duplicated file previously looked healthy to every consumer, which is exactly how the incident state would have gone unnoticed.
- The ingest merge is extracted into `merge_batch()`, where drops win over same-run updates. The src-file drop check falls back to the seed's own name when `names.py` has no entry, so one seeds file carrying two names for one `(module, addr)` could have one item prove the function matched while the other still evaluated; the pop-then-readd resurrected the ghost row the drop existed to remove and miscounted it as `+1 new`.
- `swarm`/`match` (capstone, pyelftools) import lazily from the functions that score candidates, so `stats`/`list`/`dedupe` and the new tests run on a bare interpreter. No importer of this module touches those globals.
- `tools/test_nearmiss_db.py` (stdlib unittest, precedent `tools/test_message_bank.py`): load order both ways, the save-after-load data-loss shape, hex-string/int key collision, floor tie-break, `merge_batch` counting and drop precedence, the `dedupe --check` gate, and a subprocess check that the module imports without the compile stack. Test rows use the incident's own key.

The duplicated db.jsonl itself was already repaired by hand in the lane; this PR is the tool side only.

## Verification

- `python -m unittest tools.test_nearmiss_db -v`: 12 tests pass.
- `python tools/nearmiss_db.py stats` and `dedupe --check` clean against the live DB.
- `tools.test_check_python_names` and `tools.test_check_dead_references` still pass.