### PR TITLE
Finish the one-banner-rule migration: five leftover fixed windows, and a gate for markers no counter can see

### DIFF
--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -403,14 +403,19 @@ def match_finishers(rev="HEAD") -> dict[str, str]:
             size = int(header.rsplit(" ", 1)[1])
         except (IndexError, ValueError):
             break
-        # Clamp the banner window to THIS blob. `data` is one concatenated cat-file batch
-        # response, so a fixed 200-byte read runs past any blob shorter than that and into
-        # the next one's header and content. A clean blob followed by a drafted one was
-        # therefore misread as drafted and never recorded a finisher -- and since `want` is
-        # sorted by commit SHA, which side of that boundary a blob landed on varied between
-        # runs. Same history, different credit.
-        state[want[idx]] = ("draft" if b"// NONMATCHING" in data[pos:pos + min(200, size)]
-                            else "clean")
+        # Clamp to THIS blob. `data` is one concatenated cat-file batch response, so a
+        # fixed-width read runs past any blob shorter than that and into the next one's
+        # header and content. A clean blob followed by a drafted one was therefore
+        # misread as drafted and never recorded a finisher -- and since `want` is
+        # sorted by commit SHA, which side of that boundary a blob landed on varied
+        # between runs. Same history, different credit.
+        #
+        # The draft test is asm_policy.has_draft_banner -- the same rule the live count
+        # uses -- not a fixed head window: src/func_ov091_021339fc.c carried its marker
+        # at byte 246 for months, so a 200-byte read judged every drafted state of that
+        # file "clean" and handed the finisher's credit to the drafter.
+        blob = data[pos:pos + size].decode("utf-8", "replace")
+        state[want[idx]] = "draft" if asm_policy.has_draft_banner(blob) else "clean"
         pos += size + 1
         idx += 1
 
@@ -539,7 +544,10 @@ def main():
             f = SP.path_for(name)
             src_path = f.relative_to(REPO).as_posix() if f else None
             text = f.read_text(errors="ignore") if f else ""
-            head = text[:200]
+            # The settled tag lives in the banner, and banners drift downward as the
+            # recovery prose above them grows -- so the leading comment block, never a
+            # fixed byte window.
+            head = asm_policy.header_region(text)
             cls = asm_policy.classify(text) if src_path else None
             # Policy D (Tango's ruling on audit/enrollment_report.md section 6): a file
             # that exists is not evidence if the byte gate cannot get a verdict out of

--- a/tools/langmode_audit.py
+++ b/tools/langmode_audit.py
@@ -67,6 +67,7 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy  # noqa: E402
 import delaunder  # noqa: E402
 import demangle as D  # noqa: E402
 
@@ -118,7 +119,7 @@ def is_nonmatching(path):
         t = (REPO / path).read_text(errors="ignore")
     except OSError:
         return False
-    return "NONMATCHING" in t
+    return asm_policy.has_draft_banner(t)
 
 
 # A local struct/class body, e.g. `struct Actor { char pad[0xd0]; ... };`

--- a/tools/rebuild_ledger.py
+++ b/tools/rebuild_ledger.py
@@ -8,8 +8,8 @@ burning tokens re-deriving committed work.
 
 This reconciles the local ledger with what is actually on disk, using the exact same
 definition of "matched" as chaos_db_ci.py (the CI truth generator): a config symbol
-whose src/<name>.{c,cpp} exists and is not marked "// NONMATCHING" in its first 200
-chars. Run it once right after entering a fresh worktree, and again after any large
+whose src/<name>.{c,cpp} exists and carries no NONMATCHING marker in its leading
+comment block. Run it once right after entering a fresh worktree, and again after any large
 `git pull`/merge that brings in new src matches.
 
     python tools/rebuild_ledger.py

--- a/tools/rombuild_profile.py
+++ b/tools/rombuild_profile.py
@@ -23,6 +23,7 @@ SOURCE_CONFIG = REPO / "config" / "arm9"
 CONFIG_TU = REPO / "config_tu" / "arm9"
 BUILD = REPO / "build"
 sys.path.insert(0, str(REPO / "tools"))
+import asm_policy  # noqa: E402
 import srcpath as SP  # noqa: E402
 
 PROFILES = ("stock", "mods")
@@ -118,8 +119,8 @@ def _stock_delinks(generated_root, repo):
                     name = pathlib.PurePosixPath(mod_rel).stem
                     src = SP.path_for(name)
                     verified = (src is not None and
-                                "NONMATCHING" not in src.read_text(
-                                    encoding="utf-8", errors="ignore")[:200])
+                                not asm_policy.has_draft_banner(src.read_text(
+                                    encoding="utf-8", errors="ignore")))
                     if verified:
                         src_rel = src.relative_to(repo).as_posix()
                         line = f"{src_rel}:"

--- a/tools/sigaudit.py
+++ b/tools/sigaudit.py
@@ -98,10 +98,10 @@ def _already_matched(repo, name):
     if path is None:
         return False
     try:
-        head = path.read_text(encoding='utf-8', errors='ignore')[:400]
+        text = path.read_text(encoding='utf-8', errors='ignore')
     except OSError:
         return False
-    return 'NONMATCHING' not in head
+    return not asm_policy.has_draft_banner(text)
 
 
 def matched_sources(repo):

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -78,6 +78,33 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(VM.function_snapshot(self.base)["stats"]["matchedFunctions"], 1)
         self.assertEqual(VM.function_snapshot(head)["stats"]["matchedFunctions"], 0)
 
+    def test_marker_deep_in_the_leading_comment_block_still_counts_as_draft(self):
+        # The rule is the header REGION, not a byte window: the recovery prose above a
+        # banner grows without bound and must not push the marker out of sight.
+        prose = "".join(f"// recovery note line {i}: tried and rejected\n"
+                        for i in range(12))
+        (self.repo / "src" / "Example.c").write_text(
+            prose + "// NONMATCHING: register allocation differs\n"
+            "int Example(void) { return 0; }\n", encoding="utf-8")
+        head = commit(self.repo, "draft with a long preamble", "bob")
+        self.assertEqual(VM.function_snapshot(head)["stats"]["matchedFunctions"], 0)
+
+    def test_a_stranded_nonmatching_marker_fails_the_gate(self):
+        # A marker below the first line of code is invisible to every counter, so the
+        # file would publish as MATCHED against its author's own written claim. The
+        # gate names the file instead of letting that inversion land.
+        (self.repo / "src" / "Example.c").write_text(
+            "int Example(void) { return 0; }\n"
+            "// NONMATCHING: register allocation differs\n", encoding="utf-8")
+        head = commit(self.repo, "stranded marker", "bob")
+        # The misread the gate exists for: the counters still see a match.
+        self.assertEqual(VM.function_snapshot(head)["stats"]["matchedFunctions"], 1)
+        report = VM.build_report(self.base, head)
+        self.assertEqual(report["status"], "Failed")
+        self.assertEqual(report["asmPolicy"]["strandedMarkers"], ["src/Example.c"])
+        self.assertTrue(any("outside the leading comment block" in r
+                            for r in report["reasons"]))
+
     def test_require_merge_commit_rejects_an_uncommitted_merge_shape(self):
         with self.assertRaisesRegex(RuntimeError, "not a committed merge"):
             VM.build_report(self.base, "HEAD", require_merge_commit=True)
@@ -315,7 +342,8 @@ class ValidateMerge(unittest.TestCase):
         self.assertTrue(snap["functions"]["arm9:0x02000004"]["matched"])
         report = VM.build_report(base, head)
         self.assertEqual(report["status"], "Passed")
-        self.assertEqual(report["asmPolicy"], {"transcribed": [], "unbanneredAsm": []})
+        self.assertEqual(report["asmPolicy"], {"transcribed": [], "unbanneredAsm": [],
+                                               "strandedMarkers": []})
 
     def _claim_without_enrolling(self, name):
         """A symbol with a src/ file and NO `complete` delinks entry: matched by the

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -151,7 +151,8 @@ def function_snapshot(rev):
     candidates = {line.split(":", 1)[1] if ":" in line else line
                   for line in grep.splitlines()}
     # Match progress.py and the rest of the repo's established hatch rule: the
-    # marker is a source header and is recognized in the first 200 characters.
+    # marker is a source header, recognized anywhere in the file's leading comment
+    # block (asm_policy.has_draft_banner -- the one rule every consumer shares).
     nonmatching = {path for path in candidates
                    if AP.has_draft_banner(git_text(rev, path))}
     # An unbannered dcd transcription byte-matches vacuously (it IS the ROM words
@@ -508,9 +509,18 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     changed_src = [row["path"] for row in diff["files"]
                    if row["status"][:1] in ("A", "M") and row.get("path", "")
                    .endswith(SOURCE_SUFFIXES)]
-    changed_cls = {p: AP.classify(git_text(head_sha, p)) for p in sorted(changed_src)}
+    changed_text = {p: git_text(head_sha, p) for p in sorted(changed_src)}
+    changed_cls = {p: AP.classify(t) for p, t in changed_text.items()}
     new_transcribed = [p for p, c in changed_cls.items() if c == "transcribed"]
     new_unbannered = [p for p, c in changed_cls.items() if c == "unbannered-asm"]
+    # A marker the counters cannot see inverts the file's own claim: every consumer
+    # recognizes NONMATCHING only inside the leading comment block
+    # (asm_policy.has_draft_banner), so a marker that sits below the first line of
+    # code leaves the file counted as MATCHED while its author believes it is
+    # bannered. Scoped like the transcription gate: only sources this merge adds or
+    # modifies, so a historical stray cannot fail an unrelated PR.
+    stranded_markers = [p for p, t in changed_text.items()
+                        if AP.DRAFT_BANNER in t and not AP.has_draft_banner(t)]
 
     base_keys, head_keys = set(bf["matched"]), set(hf["matched"])
     bc, hc = ba["byFunction"], ha["byFunction"]
@@ -603,6 +613,11 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append(f"{len(new_transcribed)} asm-transcription file(s) with no "
                        f"HAND-ASM PRIMITIVE or NONMATCHING banner: "
                        + ", ".join(new_transcribed))
+    if stranded_markers:
+        reasons.append(f"{len(stranded_markers)} file(s) say NONMATCHING outside the "
+                       "leading comment block, where no counter or gate recognizes it "
+                       "-- move the marker into the file header, or reword prose that "
+                       "quotes the bare word: " + ", ".join(stranded_markers))
     if link["blocking"]:
         reasons.append(f"{len(link['blocking'])} blocking relocation verdict(s)")
     if port.get("available") and not port["passed"]:
@@ -735,7 +750,8 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                         "added": added_credit, "changed": credit_changes,
                         "lost": lost_credit, "overridden": allow_attribution_change},
         "diff": diff,
-        "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered},
+        "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered,
+                      "strandedMarkers": stranded_markers},
         "matchedWithdrawn": withdrawn,
         "linkcheck": link,
         "portRefcheck": port,

--- a/tools/worklist.py
+++ b/tools/worklist.py
@@ -100,7 +100,9 @@ def is_policy_done(src):
     sibling examples, since the body is assembly rather than recovered C."""
     if not src:
         return False
-    head = src[:600]
+    # The tags live in the banner, and banners drift downward as recovery prose grows
+    # above them -- the leading comment block, never a fixed byte window.
+    head = asm_policy.header_region(src)
     low = head.lower()
     if _OWES_C in low:                      # explicitly still owes a C decompilation
         return False


### PR DESCRIPTION
## What

#1367 made `asm_policy.has_draft_banner` (the leading comment block) the single rule for recognizing a NONMATCHING marker, but five scanners kept private fixed windows, and nothing rejected a marker placed where no scanner looks. This finishes the migration and closes the class.

### The five leftover windows

| tool | window | what it decides |
|---|---|---|
| `chaos_db_ci.py` (finisher scan) | first 200 **bytes** of every historical blob | who gets credit for finishing a draft |
| `chaos_db_ci.py` (noMatch tag) | first 200 chars | the asm-primitive / not-c-expressible viewer buckets |
| `sigaudit.py` `_already_matched` | first 400 chars | whether a signature is authoritative |
| `rombuild_profile.py` | first 200 chars | whether a src file is trusted in a stock link |
| `worklist.py` `is_policy_done` | first 600 chars | whether a SETTLED file is offered as a target |

`langmode_audit.py` had the opposite defect (whole-file scan) and now also uses the shared rule.

### The gate

`validate_merge` now fails a PR that adds or modifies a src/ file whose NONMATCHING appears only **outside** the leading comment block. That shape inverts the file's own claim: the author wrote "this is not a match" and every counter publishes MATCHED. It happened live on a port-lane branch before review caught it. Scoped to the merge's changed files, like the transcription gate, so a historical stray cannot fail an unrelated PR.

## Verification

- `chaos_db_ci.py` run before and after on this tree: **11,229 / 11,392 matched, both sides, zero per-function flips.** The public count does not move.
- All three marker predicates (anywhere / first-200 / header region) agree on every one of the 73 draft files in src/ today, so classification is identical for every correctly placed marker; the langmode ratchet population reads the same under both rules.
- **One attribution record corrects**, and it is the point of the finisher fix: `ov004:0x020b04f4` was drafted in the 925-draft batch (c31a2a63f), its marker drifted past byte 200 in the readable promotion (f2b104951) -- which the old 200-byte blob scan misread as the draft-to-clean transition, crediting the promotion -- and the banner actually left the file in #1396. Credit moves tangosdev -> andrewboudreau (one function, one coin) at the next chaos-data refresh. That is the corrected record, not a regression.
- `tools.test_validate_merge` + the six other touched tools' suites: **all green** (89 tests), including two new tests: a deep-header marker still counts as a draft, and a stranded marker fails the gate while the counters still (wrongly) see a match -- the exact misread the gate exists for.