### PR TITLE
Carry #1750's Timer rename into the port smoke test

### DIFF
--- a/port/tests/smoke.cpp
+++ b/port/tests/smoke.cpp
@@ -14,8 +14,8 @@ static_assert(sizeof(u8) == 1 && sizeof(u16) == 2 && sizeof(u32) == 4, "int widt
 static_assert(sizeof(s64) == 8, "s64");
 static_assert(sizeof(void *) == 4, "32-bit host (see port/platform.h)");
 static_assert(sizeof(Fix12i) == 4, "Fix12i is a 32-bit 20.12 scalar");
-static_assert(offsetof(Timer, unk_000) == 0, "Timer +0x0");
-static_assert(sizeof(((Timer *)0)->unk_000) == 8, "Timer tick count is s64");
+static_assert(offsetof(Timer, mTime) == 0, "Timer +0x0");
+static_assert(sizeof(((Timer *)0)->mTime) == 8, "Timer tick count is s64");
 static_assert(offsetof(Timer, mIsRunning) == 8, "Timer +0x8");
 // Fader's evidence header pins currInterp at +0x4 with the vptr at +0x0.
 // This only holds if the host vptr is exactly 4 bytes -- x86-32 MSVC -- which
@@ -63,7 +63,7 @@ static void test_timer(void)
 {
     Timer t;
     t.ResetTimer();
-    CHECK(t.mIsRunning == 0 && t.unk_000 == 0);
+    CHECK(t.mIsRunning == 0 && t.mTime == 0);
     CHECK(t.GetTime() == 0);
 
     t.StartTimer();


### PR DESCRIPTION
The local PC port build has been broken on `main` since #1750 landed yesterday.

#1750 renamed `Timer::unk_000` → `mTime` in `include/Timer.h` — correctly; the field is the s64 tick count and the evidence was already in the tree. But `port/tests/smoke.cpp` still spells the old name in three places, two of them `static_assert`s:

```
smoke.cpp(17): error C2039: 'unk_000': is not a member of 'Timer'
smoke.cpp(17): error C2618: illegal member designator in offsetof
smoke.cpp(18): error C2039: 'unk_000': is not a member of 'Timer'
smoke.cpp(66): error C2039: 'unk_000': is not a member of 'Timer'
```

Gate 1 does not compile, so ninja stops at `[16/1409]` and **none of the fourteen CTest gates run**.

### Why nothing caught it

`port_refcheck.py` checks that `port/` manifests, CMake symbol lists and hal links resolve to files and symbols that still exist. It has no view of **field names** inside `port/tests`, so it reports `408 checked - all references resolve` on a tree whose port build does not compile. The pre-push hook runs `port_refcheck` and not the port build, and the port build is not in CI. That gap is worth closing separately — this PR just unbreaks the build.

Rename only. The assertions are unchanged and still say the tick count sits at +0x0 and is 8 bytes wide.

After: `100% tests passed out of 14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01329VASaGxqnUYPcJ57sLPH