### PR TITLE
The ROM build needs no second compiler: drop the last pin

### DIFF
--- a/config/rombuild-versions.txt
+++ b/config/rombuild-versions.txt
@@ -9,4 +9,3 @@
 # Regenerate with:
 #   python tools/rombuild_check.py --out build/bad.txt
 #   python tools/rombuild_versions.py build/bad.txt --write
-_ZN11dScMgCard_c13InitResourcesEv 1.2/base

--- a/src/_ZN11dScMgCard_c13InitResourcesEv.cpp
+++ b/src/_ZN11dScMgCard_c13InitResourcesEv.cpp
@@ -15,6 +15,17 @@
  * The final `((VtObj *)c)->m18(-1)` is a self-dispatch through this class's own
  * vtable slot 18 -- left as a raw vtable-shim call, same shape the pre-migration
  * file used, just through `this` instead of a `char *c` parameter. */
+/* One OAM attribute-template entry: the list is a u32 attr word, then the two
+ * 16-bit attrs, then an 8-byte stride. Spelled as a struct rather than as casts
+ * off a u32* because the ROM addresses all three off ONE base register at
+ * displacements 0/4/6; `*((u16 *)e + 2)` makes b56 materialise a second base
+ * (`add r2, r3, #4`), and that one extra instruction moves the literal pool. */
+typedef struct OamAttrTmpl {
+    u32 attr0; /* 0x0 */
+    u16 attr2; /* 0x4 */
+    u16 attr3; /* 0x6 */
+} OamAttrTmpl;
+
 typedef struct Slot6 {
     char b[0x30];
 } Slot6;
@@ -92,13 +103,20 @@ s32 dScMgCard_c::InitResources()
     *(volatile u16 *)0x04001050 = 0;
 
     {
-        u32 *e = data_ov006_02134028;
+        OamAttrTmpl *e = (OamAttrTmpl *)data_ov006_02134028;
         u16 last;
         do {
-            e[0] = (e[0] & ~0xc00) | 0x400;
-            *((u16 *)e + 2) &= ~0xf000;
-            last = *((u16 *)e + 3);
-            e += 2;
+            e->attr0 = (e->attr0 & ~0xc00) | 0x400;
+            /* NOT `e->attr2 &= ~0xf000;`. Compound assignment makes b56 CSE the
+             * field's address and materialise it (`add r2, r3, #4`), then reach
+             * attr3 at +2 off that; the ROM keeps ONE base and uses +4 / +6.
+             * The extra instruction moves the literal pool and shifts every
+             * pc-relative load in the function -- it is the whole 4-byte size
+             * difference that kept this file pinned to 1.2/base. */
+            u16 a2 = e->attr2;
+            e->attr2 = (u16)(a2 & ~0xf000);
+            last = e->attr3;
+            e++;
         } while (last != 0xffff);
     }
 

--- a/tools/test_build_pin.py
+++ b/tools/test_build_pin.py
@@ -51,9 +51,18 @@ def test_version_for_reproduces_rombuild_lookup_for_every_enrolled_file():
 
 
 def test_the_overrides_are_actually_exercised():
-    """Guards the test above from passing because every file takes the default."""
+    """Guards the test above from passing because every file takes the default.
+
+    An EMPTY override file is the goal state, not a failure: the retail ROM was built
+    with one toolchain, so every pin is a source defect we have not found yet. What
+    must never happen is a pin that is present and does not reach the build -- so the
+    resolution check below runs on whatever is there, and only the emptiness is
+    tolerated. `pins()` still returns {} here and None for an unreadable file, which
+    test_missing_overrides_file_fails_closed pins down."""
     overrides = RB.versions()
-    assert overrides, "config/rombuild-versions.txt has no entries; nothing pins anything"
+    assert BP.pins() is not None, "the override file must be readable even when empty"
+    if not overrides:
+        return
     assert any(v != RB.VERSION for v in overrides.values())
     for stem, v in overrides.items():
         assert BP.version_for(f"src/{stem}.cpp") == v
@@ -186,7 +195,11 @@ def test_the_pinned_version_is_not_interchangeable_with_the_sweep():
         # alone -- that is the false green, restated.
         assert BP.sweep_version(src, stem, addr, size, label) is not None
         checked += 1
-    assert checked, "no override was exercisable; this test proved nothing"
+    # Not `assert checked`: with no pins left there is nothing to exercise, and that
+    # is the outcome this whole file is trying to reach. The guard against a silently
+    # vacuous pass lives in test_the_overrides_are_actually_exercised, which fails if
+    # a pin is present but unreachable.
+    assert checked or not RB.versions(),         "overrides exist but none was exercisable; this test proved nothing"
 
 
 # ------------------------------------------------------------------- keep it from coming back


### PR DESCRIPTION
`config/rombuild-versions.txt` now holds **no entries at all**. Phase `[3/6]` stops printing an alternate-toolchain line, and every one of the 11,060 enrolled files compiles with `2004/b56`.

### Why there was still a pin

#1619 cleared eight of the nine and deliberately left this one, on the grounds that `_ZN11dScMgCard_c13InitResourcesEv` was 999 words off under b56 and *was not enrolled*, so the pin was inert. **It is enrolled now** — so the pin went live and the build quietly started running two compilers again.

### What 999 actually meant

It is the sentinel `match.compare` returns when the **sizes** differ, not a word count. b56 emitted `0x268` against the ROM's `0x264`. Aligning the two disassemblies puts the one extra instruction in the OAM attribute-template loop:

```
ROM  ldr r2,[r0] / ldr r1,[r2] ...    str r1,[r2]  ldrh r1,[r2,#4]  ldrh r1,[r2,#6]
b56  ldr r3,[r0] / ldr r1,[r3] / add r2,r3,#4 ... str r1,[r3]  ldrh r1,[r2]
```

The ROM keeps **one** base register and reaches the whole 8-byte entry at displacements 0/4/6. Given `*((u16 *)e + 2) &= ~0xf000;`, b56 CSEs the field's address across the compound assignment's load and store, materialises it with `add r2, r3, #4`, and then reaches the next halfword at +2 off that. The extra instruction pushes the literal pool 4 bytes out, which shifts every pc-relative load in the function — the same shape #1619 measured on `func_0206a6d0`.

### The lever is the compound assignment, not the pointer arithmetic

Nine spellings compiled and scored under `2004/b56`:

| spelling | size | |
|---|---|---|
| struct, compound assign | `0x268` | size differs — *what was pinned* |
| **struct, expanded RMW** | `0x264` | **MATCH — taken** |
| struct, read via `char*` | `0x264` | MATCH |
| struct, store via `char*` | `0x264` | MATCH |
| `u32*`, expanded RMW | `0x264` | MATCH |
| `u32*` with `e[i]` indexing | `0x268` | size differs |
| read `attr3` first | `0x264` | 11 word(s) differ |
| mask spelled `& 0x0fff` | `0x270` | size differs |

The fifth row is the point: the **original** `u32 *e` shape reproduces with nothing changed but `&=` → an explicit read-modify-write. So this was never a compiler fact either — it is the ninth source defect in the set, and `1.2/base` was hiding it exactly as it hid the other eight.

Taken in the struct form, which reproduces *and* names the three fields of an OAM attribute entry instead of casting off a `u32*`.

### Test change

`tools/test_build_pin.py` asserted at least one pin exists — reasonable while the goal was to shrink the list, wrong now that it is empty. Both tests tolerate an empty file and stay strict about a pin that is present and does not reach the build. `pins()` still returns `{}` for an empty file and `None` for an unreadable one — which `test_missing_overrides_file_fails_closed` pins down — so an empty list does not become a silent fail-open.

### Verification

- `rombuild.py -j16 --no-rom`: **106/106 exact, 100.000000% of compared bytes, 11,060/11,060 reproducing, PASS**
- `pytest tools/test_build_pin.py`: 12 passed
- PC port: 100% tests passed out of 14

---

**Plain-English TL;DR:** the build was still running an old compiler for one file because that file only came out byte-perfect under it. That was a symptom, not a requirement — our C for it used a shorthand (`x &= mask`) that makes the newer compiler emit one extra instruction, which knocks everything after it four bytes out of place. Writing that one line the long way fixes it, and the game now builds byte-for-byte with a single compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01329VASaGxqnUYPcJ57sLPH