### PR TITLE
Apply exact compiler-only TU policy in production ROM builds

### DIFF
--- a/tools/relocs.py
+++ b/tools/relocs.py
@@ -7,6 +7,7 @@ symbol from the wrong overlay.  The public resolver therefore uses a canonical
 each relocation record.
 """
 import argparse
+import collections
 import json
 import pathlib
 import re
@@ -171,6 +172,15 @@ def load_all_syms() -> SymbolIndex:
     for module, path in iter_symbol_files(include_itcm_dtcm=True):
         d.update(load_syms_file(path, module))
     return d
+
+
+def load_symbol_homes(repo=None) -> dict[str, list[tuple[str, int]]]:
+    """Every configured home for every symbol name, preserving aliases/modules."""
+    homes = collections.defaultdict(list)
+    for module, path in iter_symbol_files(include_itcm_dtcm=True, repo=repo):
+        for name, (owner, addr) in iter_syms_pairs(path, module):
+            homes[name].append((owner, addr))
+    return dict(homes)
 
 
 def _fallback_name(addr: int) -> str:

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -58,6 +58,8 @@ import romdata_check as RDC  # noqa: E402
 import layout_check as LAY  # noqa: E402
 import rombuild_profile as RP  # noqa: E402
 import srcpath as SP  # noqa: E402
+import relocs as RL  # noqa: E402
+import tu_manifest as TUM  # noqa: E402
 
 # Default compiler for the ROM build — same as the matching pin (tools/match.py
 # CANONICAL / notes/rom-build.md). config/rombuild-versions.txt carries per-file
@@ -288,7 +290,7 @@ def init_section_sources():
     return {rel for (_d, _name, rel, _addr, _size, sec) in cands if sec == ".init"}
 
 
-def _isolate(obj, rel, syms, data_sink=None):
+def _isolate(obj, rel, syms, data_sink=None, compiler_only=None):
     """Reduce a compiled `src/` object to its declared function(s).
 
     A legacy source owns one function and takes the unchanged singular isolation path.
@@ -317,8 +319,17 @@ def _isolate(obj, rel, syms, data_sink=None):
     if isinstance(selected, (list, tuple)):
         if not selected:
             return "source owns no enrolled functions"
-        plan = (OI.isolate(obj, selected[0]) if len(selected) == 1
-                else OI.isolate_many(obj, selected))
+        if len(selected) == 1:
+            plan = OI.isolate(obj, selected[0])
+        else:
+            dead = (compiler_only or {}).get(rel.replace("\\", "/"), [])
+            if dead:
+                reduced, dead_plan = OI.derive_deadstrip(obj.read_bytes(), dead)
+                if reduced is None:
+                    return ("compiler-only deadstrip refused: "
+                            + str(dead_plan.get("error")))
+                obj.write_bytes(reduced)
+            plan = OI.isolate_many(obj, selected)
     else:
         plan = OI.isolate(obj, selected)
     if plan.get("kind") == OI.NOT_A_FUNCTION:
@@ -361,6 +372,61 @@ def enrolled_symbols():
         grouped.setdefault(rel, []).append((addr, _size, name))
     return {rel: _definition_symbols(rel, rows)
             for rel, rows in grouped.items()}
+
+
+def compiler_only_policies(enrolled=None, manifest=None, homes=None):
+    """Exact dead-strip allow-lists for promoted multi-function sources.
+
+    The manifest is evidence, not a wildcard: every row must name one homeless,
+    unlicensed function and explicitly request ``deadstrip`` with a reason.  Object
+    surgery remains objisolate's job; this preflight only proves the checked-in policy
+    cannot hide a function that has a retail address.
+    """
+    data = TUM.load() if manifest is None else manifest
+    active = None if enrolled is None else {
+        str(rel).replace("\\", "/") for rel in enrolled
+    }
+    homes = RL.load_symbol_homes() if homes is None else homes
+    out, errors = {}, []
+    for entry in data.get("entries", []):
+        rows = entry.get("compiler_only_output") or []
+        if not rows:
+            continue
+        source = str(entry.get("source", "")).replace("\\", "/")
+        if not source:
+            errors.append(f"{entry.get('id', '<unknown>')}: compiler-only policy has no source")
+            continue
+        if active is not None and source not in active:
+            continue
+        if source in out:
+            errors.append(f"{source}: compiler-only policy is declared by multiple entries")
+            continue
+        licensed = {row.get("symbol") for row in entry.get("functions", [])}
+        wanted = []
+        for i, row in enumerate(rows):
+            if not isinstance(row, dict):
+                errors.append(f"{source}: compiler_only_output[{i}] is not an object")
+                continue
+            symbol = row.get("symbol")
+            if not symbol:
+                errors.append(f"{source}: compiler_only_output[{i}] has no symbol")
+                continue
+            if row.get("disposition") != "deadstrip":
+                errors.append(f"{source}: {symbol} disposition must be deadstrip")
+            if not str(row.get("reason", "")).strip():
+                errors.append(f"{source}: {symbol} needs a non-empty reason")
+            if symbol in licensed:
+                errors.append(f"{source}: {symbol} is licensed by the manifest")
+            if homes.get(symbol):
+                errors.append(f"{source}: {symbol} has configured ROM home(s) "
+                              f"{homes[symbol]}")
+            if symbol in wanted:
+                errors.append(f"{source}: duplicate compiler-only symbol {symbol}")
+            wanted.append(symbol)
+        out[source] = wanted
+    if errors:
+        raise BuildError("compiler-only policy", 1, "\n".join(errors))
+    return out
 
 
 def _definition_symbols(rel, rows):
@@ -434,7 +500,7 @@ def retarget_text_section(obj, section=".init"):
 
 
 def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_root=None,
-                data_sink=None, prebuilt=None):
+                data_sink=None, prebuilt=None, compiler_only=None):
     """Compile one enrolled source file to the object path dsd's objects.txt names.
 
     Returns (rel, error-or-None, outcome), where outcome is how the object was
@@ -474,7 +540,7 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_roo
             err = _retarget(obj, rel, init_srcs)
             if err:
                 return rel, f"retarget: {err}", "error"
-            err = _isolate(obj, rel, syms, data_sink)
+            err = _isolate(obj, rel, syms, data_sink, compiler_only)
             if err:
                 return rel, f"isolate: {err}", "error"
             return rel, None, "hit"
@@ -508,18 +574,18 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_roo
         if err:
             return rel, f"retarget: {err}", "error"
         if key is None:
-            err = _isolate(obj, rel, syms, data_sink)
+            err = _isolate(obj, rel, syms, data_sink, compiler_only)
             return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
         deps = cache.deps_from(scratch)
         if deps is None:
-            err = _isolate(obj, rel, syms, data_sink)
+            err = _isolate(obj, rel, syms, data_sink, compiler_only)
             return (rel, f"isolate: {err}", "error") if err else (rel, None, "uncacheable")
         # Cache the RAW object, then isolate the working copy. Storing the reduced
         # form instead would bake this transformation into every entry, so any later
         # fix to it would be masked by isolate()'s own idempotence -- which is exactly
         # how the STB_LOPROC bug survived a rebuild and forced SCHEMA 2.
         cache.put(key, deps, obj)
-        err = _isolate(obj, rel, syms, data_sink)
+        err = _isolate(obj, rel, syms, data_sink, compiler_only)
         return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
     finally:
         if scratch:
@@ -663,6 +729,7 @@ def main():
                                 enabled=not args.no_cache)
         init_srcs = init_section_sources()
         syms = enrolled_symbols()
+        compiler_only = compiler_only_policies(srcs)
         # Collected during the compile because that is the only point at which the
         # objects still carry the data mwcc emitted -- see _isolate. None switches the
         # measurement off entirely; it never affects what gets linked either way.
@@ -680,6 +747,7 @@ def main():
                 for rel, err, outcome in ex.map(
                         lambda s: compile_one(s, vers, cache, init_srcs, syms,
                                               data_sink=data_sink,
+                                              compiler_only=compiler_only,
                                               prebuilt=tu_overrides.get(
                                                   s.replace("\\", "/"))), srcs):
                     outcomes[outcome] = outcomes.get(outcome, 0) + 1

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -122,6 +122,65 @@ class RomBuildEnrollment(unittest.TestCase):
             one.assert_called_once_with(obj, "Only")
             many.assert_not_called()
 
+    def test_multi_source_applies_exact_compiler_only_deadstrip_first(self):
+        obj = self.repo / "Pair.o"
+        obj.write_bytes(b"raw object")
+        policy = {"src/Pair.cpp": ["_ZN4PairC2Ev"]}
+        with mock.patch.object(
+                RB.OI, "derive_deadstrip",
+                return_value=(b"reduced object", {"error": None})) as deadstrip, \
+                mock.patch.object(RB.OI, "isolate_many",
+                                  return_value={"error": None}) as many:
+            self.assertIsNone(RB._isolate(
+                obj, "src/Pair.cpp", {"src/Pair.cpp": ["First", "Second"]},
+                compiler_only=policy))
+        deadstrip.assert_called_once_with(b"raw object", ["_ZN4PairC2Ev"])
+        many.assert_called_once_with(obj, ["First", "Second"])
+        self.assertEqual(obj.read_bytes(), b"reduced object")
+
+    def test_compiler_only_policy_refuses_a_symbol_with_a_rom_home(self):
+        manifest = {"entries": [{
+            "id": "arm9/Pair",
+            "source": "src/Pair.cpp",
+            "functions": [{"symbol": "First"}, {"symbol": "Second"}],
+            "compiler_only_output": [{
+                "symbol": "_ZN4PairC2Ev", "disposition": "deadstrip",
+                "reason": "compiler-generated constructor variant"
+            }]
+        }]}
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(
+                manifest=manifest, homes={"_ZN4PairC2Ev": [("arm9", 0x02000008)]})
+        self.assertIn("configured ROM home", raised.exception.output)
+
+    def test_compiler_only_policy_accepts_an_exact_homeless_variant(self):
+        manifest = {"entries": [{
+            "id": "arm9/Pair",
+            "source": "src/Pair.cpp",
+            "functions": [{"symbol": "First"}, {"symbol": "Second"}],
+            "compiler_only_output": [{
+                "symbol": "_ZN4PairC2Ev", "disposition": "deadstrip",
+                "reason": "compiler-generated constructor variant"
+            }]
+        }]}
+        self.assertEqual(
+            RB.compiler_only_policies(manifest=manifest, homes={}),
+            {"src/Pair.cpp": ["_ZN4PairC2Ev"]})
+
+    def test_compiler_only_policy_ignores_unenrolled_shadow_manifests(self):
+        manifest = {"entries": [{
+            "id": "arm9/Shadow",
+            "source": "src_tu/Shadow.cpp",
+            "functions": [{"symbol": "First"}],
+            "compiler_only_output": [{
+                "symbol": "ConfiguredElsewhere", "disposition": "deadstrip",
+                "reason": "research-only observation"
+            }]
+        }]}
+        self.assertEqual(RB.compiler_only_policies(
+            enrolled=["src/Pair.cpp"], manifest=manifest,
+            homes={"ConfiguredElsewhere": [("arm9", 0x02000008)]}), {})
+
 
 def _compiler():
     exe = RB.MW / RB.VERSION / "mwccarm.exe"

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -949,8 +949,9 @@ def test_scratch_and_no_rom_results_are_not_promotion_ready():
     assert tubuild.promotion_refusals(ready) == []
     assert any("non-.text" in reason for reason in tubuild.promotion_refusals(
         dict(ready, sections=[{"name": ".text"}, {"name": ".data"}])))
-    assert any("compiler_only_output" in reason for reason in tubuild.promotion_refusals(
-        dict(ready, compiler_only_output=[{"symbol": "D2"}])))
+    assert not any("compiler_only_output" in reason for reason in tubuild.promotion_refusals(
+        dict(ready, compiler_only_output=[{
+            "symbol": "D2", "disposition": "deadstrip", "reason": "unused variant"}])))
     assert any("externalized_output" in reason for reason in tubuild.promotion_refusals(
         dict(ready, externalized_output=[{"symbol": "_ZTI4Base"}])))
     no_rom = dict(ready, verification={"linkcheck": {

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1118,7 +1118,13 @@ def cmd_compile(args):
 
     obj_bytes, version, flags, build_dir, obj_path = _compile_tu(entry, args.version)
     inv = elf_inventory(obj_bytes)
-    unlicensed_funcs, unlicensed_objs, unlicensed_secs = unlicensed_inventory(entry, inv)
+    audited_bytes, compiler_only, policy_reasons = apply_compiler_only_policy(
+        obj_bytes, entry)
+    if not policy_reasons and compiler_only.get("deadstripped"):
+        print(f"compiler-only     : exact deadstrip {compiler_only['deadstripped']}")
+    audit_inv = elf_inventory(audited_bytes) if audited_bytes is not None else inv
+    unlicensed_funcs, unlicensed_objs, unlicensed_secs = unlicensed_inventory(
+        entry, audit_inv)
 
     lines = [f"TU {entry['id']}  object {obj_path.relative_to(REPO).as_posix()}",
             f"toolchain: {version}   flags: {flags}", ""]
@@ -1181,12 +1187,17 @@ def cmd_verify(args):
 
     obj_bytes, version, flags, build_dir, obj_path = _compile_tu(entry, args.version)
     inv = elf_inventory(obj_bytes)
+    audited_bytes, compiler_only, policy_reasons = apply_compiler_only_policy(
+        obj_bytes, entry)
+    audit_inv = elf_inventory(audited_bytes) if audited_bytes is not None else inv
 
     name_index = RA.build_name_index()
     config_relocs = RA.build_config_relocs()
     sym_index = RL.load_all_syms()
 
     print(f"\nTU {entry['id']}\n")
+    if not policy_reasons and compiler_only.get("deadstripped"):
+        print(f"compiler-only     : exact deadstrip {compiler_only['deadstripped']}\n")
     rows = []
     all_bytes_ok = all_reloc_ok = True
     sec_order = []
@@ -1253,7 +1264,8 @@ def cmd_verify(args):
              f"{bad_pairs}  (a destructor's D0/D1/D2 group is ordered by the compiler, not "
              f"by source text, per the pilot report sec 3 -- not necessarily a bug)")
 
-    unlicensed_funcs, unlicensed_objs, unlicensed_secs = unlicensed_inventory(entry, inv)
+    unlicensed_funcs, unlicensed_objs, unlicensed_secs = unlicensed_inventory(
+        entry, audit_inv)
     n_unlicensed = len(unlicensed_funcs) + len(unlicensed_objs) + len(unlicensed_secs)
     if n_unlicensed:
         print()
@@ -1268,6 +1280,10 @@ def cmd_verify(args):
         for s in unlicensed_secs:
             print(f"EXTRA    {s['name']:8} size=0x{s['size']:x}  not in manifest (no function/"
                  f"data claims it)")
+    if policy_reasons:
+        print()
+        for reason in policy_reasons:
+            print(f"POLICY   {reason}")
 
     secs = sorted((int(s["start"], 16), int(s["end"], 16), s["name"])
                  for s in entry.get("sections", []))
@@ -1276,7 +1292,8 @@ def cmd_verify(args):
         print(f"\nMANIFEST ERROR: overlapping section claims: {overlaps}")
 
     declared_syms = {f["symbol"] for f in entry["functions"]}
-    defined_syms = {s["name"] for s in inv["symbols"] if s["type"] == "STT_FUNC"}
+    defined_syms = {s["name"] for s in audit_inv["symbols"]
+                    if s["type"] == "STT_FUNC"}
     if declared_syms - defined_syms:
         print(f"\nMANIFEST ERROR: declared but not defined: {sorted(declared_syms - defined_syms)}")
 
@@ -1293,6 +1310,8 @@ def cmd_verify(args):
     if n_unlicensed:
         print(f"        {n_unlicensed} unlicensed section/symbol(s) present -> PROMOTION "
              f"REFUSED regardless of the above (plan sec 4.5, 8)")
+    if policy_reasons:
+        print("        compiler-only policy refused -> PROMOTION REFUSED")
 
     entry.setdefault("verification", {})
     entry["verification"].update({
@@ -1305,6 +1324,7 @@ def cmd_verify(args):
                       "tools/reloc_audit.py check_destinations() (relocation target identity)",
         "functions_matched": n_match,
         "functions_declared": len(rows),
+        "compilerOnlyOutput": compiler_only,
     })
     # Keep the nested `criteria` block honest about what THIS run actually measured --
     # `comparison` above always names reloc_audit now that verify runs it unconditionally,
@@ -1330,8 +1350,10 @@ def cmd_verify(args):
         "every_declared_function_defined": "PASS" if not any(v == "MISSING" for _o, _s, v in rows) else "FAIL",
         "every_declared_function_bytes_match": "PASS" if all_bytes_ok else "FAIL",
         "declared_function_set_equals_defined_function_set":
-            "PASS" if not (declared_syms - defined_syms) and n_unlicensed == 0
-            else f"FAIL-BY-DESIGN -- {n_unlicensed} unlicensed section/symbol(s); see unlicensed_output_observed",
+            "PASS" if (not (declared_syms - defined_syms) and n_unlicensed == 0
+                       and not policy_reasons)
+            else f"FAIL-BY-DESIGN -- {n_unlicensed} unlicensed section/symbol(s), "
+                 f"{len(policy_reasons)} compiler-only policy error(s)",
         "functions_occur_in_expected_order":
             "PASS" if not bad_pairs else f"PARTIAL -- ordinal pair(s) not in ROM order: {bad_pairs}",
         "relocation_destinations_verified": "PASS" if all_reloc_ok else "FAIL -- see DIFF/objisolate lines above",
@@ -4574,9 +4596,6 @@ def promotion_refusals(entry):
            if isinstance(s, dict)):
         reasons.append("promotion does not yet install tracked non-.text delinks claims; "
                        "rombuild --partitioned-tu supports them only in a generated profile")
-    if entry.get("compiler_only_output"):
-        reasons.append("promotion does not yet persist compiler_only_output policy; "
-                       "rombuild --partitioned-tu applies it in the opt-in production path")
     if entry.get("externalized_output"):
         reasons.append("promotion does not yet persist externalized_output policy; "
                        "rombuild --partitioned-tu applies it in the opt-in production path")


### PR DESCRIPTION
Production multi-function sources currently fail before isolation when mwccarm emits a legitimate homeless constructor/destructor variant recorded by compiler_only_output. Apply that exact-symbol policy only for enrolled sources, reject configured ROM homes and malformed policies, then run the existing fail-closed multi-symbol isolation.

Verification:
  - 53 affected rombuild/objisolate/tubuild/tu_production tests pass
  - stock rombuild: 11,060/11,060 reproducing functions, 106/106 exact modules
  - no src/include/config changes
  - 