### PR TITLE
Migrate dScStarSel_c D1 to real C++

### DIFF
--- a/include/dScStarSel_c.h
+++ b/include/dScStarSel_c.h
@@ -59,8 +59,13 @@ struct dScStarSel_c : dScene_c {
                                         character UI positions and timers */
 
     /* Declared first -- key function; see the family convention discussed in
-       dBase_c.h/dScene_c.h. Never defined as a real method in any TU: both
-       D1 and D0 are plain functions carrying their literal mangled name. */
+       dBase_c.h/dScene_c.h. The D1 source now defines this destructor as a
+       genuine compiler-spelled class method. The D0 source remains a real
+       destructor definition from which mwccarm emits the deleting variant.
+       Those one-function objects contribute only their selected text; the
+       ov003 ROM-gap data remains the production owner of this class's vtable,
+       RTTI and type-name objects. This establishes the ABI shape without
+       claiming the exact original EAD translation-unit spelling. */
     virtual ~dScStarSel_c();                             /* slots 16 (D1), 17 (D0) */
 
     /* --- overrides, in _ZTV8dScene_c/_ZTV7fBase_c order. --- */

--- a/src/_ZN12dScStarSel_cD1Ev.cpp
+++ b/src/_ZN12dScStarSel_cD1Ev.cpp
@@ -1,25 +1,8 @@
 //cpp
 // @symbol _ZN12dScStarSel_cD1Ev
-/* dScStarSel_c::~dScStarSel_c() (complete-object / D1) -- vtable slots
- * 16/17 (destructor pair, actor-family convention -- fBase_c.h). Tears
- * down the Model[2] array the constructor built at 0x064 (see
- * include/dScStarSel_c.h), then chains through dScene_c/dBase_c's own
- * vtables (inlined, per dScene_c.h) into fBase_c's D2. extern "C" carries
- * the literal mangled name unmangled -- see include/dScStarSel_c.h. */
-extern "C" {
-extern int _ZTV12dScStarSel_c[];
-extern int _ZN5ModelD1Ev[];
-extern int _ZTV8dScene_c[];
-extern int data_0208e4b8[];
-int __destroy_arr(void* a, int b, int c, void* d);
-int _ZN7fBase_cD2Ev(void* c);
-int _ZN12dScStarSel_cD1Ev(void* c){
-  char* p=(char*)c;
-  *(int*)p=(int)_ZTV12dScStarSel_c;
-  __destroy_arr(p+0x64, 2, 0x50, _ZN5ModelD1Ev);
-  *(int*)p=(int)_ZTV8dScene_c;
-  *(int*)p=(int)data_0208e4b8;
-  _ZN7fBase_cD2Ev(c);
-  return (int)c;
-}
+/* recovered: real C++ complete-object destructor */
+#include "dScStarSel_c.h"
+
+dScStarSel_c::~dScStarSel_c()
+{
 }


### PR DESCRIPTION
Migrates dScStarSel_c's complete-object destructor from a hand-spelled symbol to genuine compiler-spelled C++. Behavior, Render, and InitResources probes remain nonmatching and were restored unchanged.\n\nIndependent verification: D1 VERIFIED blind:0; raw D0/D1/D2, 0x50 18-slot vtable, and 0x0c single-inheritance RTTI agree with the ROM; all four header consumers exact; 11,060/11,060 functions and 106/106 modules exact; offsets, attribution, langmode, port and reference gates clean.