### PR TITLE
Migrate the Tree family to real C++

### DIFF
--- a/include/Tree.h
+++ b/include/Tree.h
@@ -1,5 +1,5 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class Tree: 5 matched functions, 4 evidenced fields.
+/* Reconciled from matched-function, vtable, RTTI, and constructor evidence.
+ * class Tree: 7 matched methods plus its matched spawn function.
  * Offsets/widths are observed, not guessed. Field NAMES are placeholders -
  * renaming cannot change codegen.
  *
@@ -11,24 +11,21 @@
  * (InitResources/CleanupResources/Behavior/Render/OnPendingDestroy) plus
  * the destructor pair at 16/17.
  *
- * InitResources/Behavior/D0/D1 stay hand-written extern "C" free functions
- * with the class's own mangled names (matching daObjPathLift_c/#1719's
- * precedent) -- their bodies never reference a named Tree/dActor_c member,
- * only raw self+offset arithmetic and a heap-allocated auxiliary
- * dCcPos_c-list unrelated to this class's own storage, so there is no
- * conversion benefit. The vtable slots for them are still correct: the
- * mangled symbol name is identical whether the definition is a real
- * Tree::Method() or an extern "C" free function of the same name.
+ * All seven functions are compiler-spelled Tree methods. InitResources keeps
+ * one low-level extern-C declaration for dCcPos_c::Init: its ROM name carries
+ * by-value Fix12 parameters whose honest C++ declaration changes the call ABI.
+ * That exception is about the callee signature, not Tree method ownership.
  *
- * Per the Itanium ABI the key function is the class's FIRST DECLARED
- * virtual (InitResources, slot 0), not just any virtual defined
- * out-of-line in this TU -- confirmed empirically: the compiled object has
- * zero .data sections and imports _ZTV4Tree as UNDEFINED, even though
- * CleanupResources/Render/OnPendingDestroy are real Tree:: methods here.
- * Because InitResources's real body never took class-member form, this TU
- * does NOT become the key-function TU and emits no vtable/RTTI of its own,
- * nor references any inherited base RTTI -- unlike every prior pilot in
- * this series.
+ * The destructor is declared first and is Tree's key function. A destructor
+ * source therefore emits D0/D1/D2 plus a complete 0x84-byte `_ZTV4Tree` object
+ * and RTTI. The per-function build keeps only the licensed destructor variant
+ * and rebinds its vptr store to the ROM-owned table. Raw metadata inspection is
+ * still required: the compiler calls this class `Tree` (`_ZTI4Tree`), while the
+ * cartridge RTTI string is `daTree_c` (`_ZTI8daTree_c`). The 31-slot shape and
+ * every slot destination conform, but the differently named RTTI means that
+ * compiler-emitted data must remain isolated rather than replacing the ROM
+ * bytes. This is also why the shadow TU is evidence, not a production-TU
+ * promotion candidate yet.
  */
 #ifndef TREE_H
 #define TREE_H
@@ -46,9 +43,9 @@ struct Tree : dActor_c {
     Model mModel[5];                  /* 0x0d4 */
 
     virtual ~Tree();
-    virtual s32 InitResources();       /* slot  0 -- stays extern "C", see above */
+    virtual s32 InitResources();       /* slot  0 */
     virtual s32 CleanupResources();    /* slot  3 */
-    virtual s32 Behavior();            /* slot  6 -- stays extern "C", see above */
+    virtual s32 Behavior();            /* slot  6 */
     virtual s32 Render();              /* slot  9 */
     virtual void OnPendingDestroy();   /* slot 12 -- empty body in the ROM */
 };

--- a/src/_ZN4Tree13InitResourcesEv.cpp
+++ b/src/_ZN4Tree13InitResourcesEv.cpp
@@ -1,42 +1,39 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct dCcPos_c {
-    void Init(const Vector3&, int, int, unsigned int, unsigned int);
-};
-/* Signature deliberately copied from the local declaration above: the
-   ROM name carries by-value class parameters (e.g. Fix12<int>), which
-   mwccarm passes differently at the call site, so declaring the true
-   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+#include "Tree.h"
+
+/* Keep this low-level declaration even though dCcPos_c has a class model: the
+   ROM name carries by-value class parameters (e.g. Fix12<int>), which mwccarm
+   homes differently when defined/called through the honest method signature.
+   See notes/mwccarm-codegen.md 6az. */
 extern "C" void _ZN8dCcPos_c4InitERK7Vector35Fix12IiES4_jj(void *, const Vector3&, int, int, unsigned int, unsigned int);
 
-struct Model { void LoadAndSetFile(unsigned short, int, int); };
 extern "C" void* _Znwj(unsigned int);
 extern "C" void _ZN8dCcPos_cC1Ev(void*);
 extern "C" void Vec3_AsrInPlace(void*, int);
 extern int data_ov002_02110a48[];
 extern unsigned short data_ov002_0210abb8[];
 
-extern "C" int _ZN4Tree13InitResourcesEv(char* self);
-int _ZN4Tree13InitResourcesEv(char* self) {
-    int idx = ((unsigned int)*(int*)(self + 8) >> 4) & 7;
+int Tree::InitResources()
+{
+    int idx = (param1 >> 4) & 7;
     int* slot;
     char* p;
     if (idx >= 4) idx = 4;
     slot = &data_ov002_02110a48[idx];
     if (*slot == 0) {
-        ((Model*)(self + 0xd4 + idx * 0x50))->LoadAndSetFile(data_ov002_0210abb8[idx], 1, 1);
+        mModel[idx].LoadAndSetFile(data_ov002_0210abb8[idx], 1, 1);
     }
     p = (char*)_Znwj(0x4c);
     if (p) _ZN8dCcPos_cC1Ev(p + 0xc);
-    *(int*)(p + 0) = *(int*)(self + 0x5c);
-    *(int*)(p + 4) = *(int*)(self + 0x60);
-    *(int*)(p + 8) = *(int*)(self + 0x64);
+    *(int*)(p + 0) = mPosX;
+    *(int*)(p + 4) = mPosY;
+    *(int*)(p + 8) = mPosZ;
     Vec3_AsrInPlace(p, 3);
     {
         int* q = (int*)(((int)p + 4));
         *q = *q + 0x1e000;
     }
-    _ZN8dCcPos_c4InitERK7Vector35Fix12IiES4_jj((dCcPos_c*)(p + 0xc), *(Vector3*)(self + 0x5c), 0x35555, 0x1f4000, 0x380000c, 0);
+    _ZN8dCcPos_c4InitERK7Vector35Fix12IiES4_jj(p + 0xc, *(Vector3*)&mPosX, 0x35555, 0x1f4000, 0x380000c, 0);
     *(int*)(p + 0x48) = *slot;
     *slot = (int)p;
     if (*(int*)(p + 0x48) != 0) {

--- a/src/_ZN4Tree8BehaviorEv.cpp
+++ b/src/_ZN4Tree8BehaviorEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+#include "Tree.h"
+
 extern "C" {
 extern int _ZN5dCc_c5ClearEv(void*);
 extern int _ZN5dCc_c6UpdateEv(void*);
 extern char* data_ov002_02110a48[5];
-int _ZN4Tree8BehaviorEv(void){
+}
+
+int Tree::Behavior()
+{
   char** pp = data_ov002_02110a48;
   int i;
   for(i=0;i<5;i++){
@@ -16,5 +21,4 @@ int _ZN4Tree8BehaviorEv(void){
     pp++;
   }
   return 1;
-}
 }

--- a/src/_ZN4TreeD0Ev.cpp
+++ b/src/_ZN4TreeD0Ev.cpp
@@ -1,18 +1,12 @@
 //cpp
 // @symbol _ZN4TreeD0Ev
-/* recovered: named members + shared header */
+/* recovered: real C++ deleting destructor
+ *
+ * mwccarm generates D0 from the same source destructor as D1. The inherited
+ * actor delete path resolves through dActor_c::operator delete.
+ */
 #include "Tree.h"
-extern "C" {
-extern int _ZTV4Tree[];
-extern int _ZN5ModelD1Ev[];
-void __destroy_arr(void*, int, int, void*);
-void _ZN8dActor_cD2Ev(void*);
-void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
-void* _ZN4TreeD0Ev(char* c){
-  *(int*)c = (int)_ZTV4Tree;
-  __destroy_arr(c+0xd4, 5, 0x50, (void*)_ZN5ModelD1Ev);
-  _ZN8dActor_cD2Ev(c);
-  _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-  return c;
-}
+
+Tree::~Tree()
+{
 }

--- a/src/_ZN4TreeD1Ev.cpp
+++ b/src/_ZN4TreeD1Ev.cpp
@@ -1,16 +1,12 @@
 //cpp
 // @symbol _ZN4TreeD1Ev
-/* recovered: named members + shared header */
+/* recovered: real C++ complete destructor
+ *
+ * The compiler owns Tree's vptr store, reverse destruction of mModel[5],
+ * and the inherited dActor_c destructor chain.
+ */
 #include "Tree.h"
-extern "C" {
-extern int __destroy_arr(void*, int, int, void*);
-extern void _ZN8dActor_cD2Ev(void*);
-extern void *_ZTV4Tree;
-extern int _ZN5ModelD1Ev();
-int _ZN4TreeD1Ev(char* c){
-    *(void**)c = (void*)&_ZTV4Tree;
-    __destroy_arr((char*)c+0xd4, 5, 0x50, (void*)&_ZN5ModelD1Ev);
-    _ZN8dActor_cD2Ev(c);
-    return (int)c;
-}
+
+Tree::~Tree()
+{
 }


### PR DESCRIPTION
Migrates Tree D1, D0, Behavior, and InitResources from hand-spelled symbols to genuine compiler-spelled methods. Retains the proven low-level dCcPos_c::Init declaration needed for the by-value Fix12 call ABI.\n\nIndependent verification: all 8 Tree-family sources VERIFIED blind:0; raw 0x84 vtable resolves 31/31 slots to ROM daTree_c; compiler Tree RTTI remains isolated from ROM daTree_c RTTI; 11,060/11,060 functions and 106/106 modules exact; affected-source, offsets, attribution, langmode, port and reference gates clean. The shadow TU remains unpromoted.