### PR TITLE
Use real C++ APIs in BabyPenguin initialization

### DIFF
--- a/include/BabyPenguin.h
+++ b/include/BabyPenguin.h
@@ -15,6 +15,11 @@
  *   _ZN11BabyPenguinD0Ev  the same four members destroyed in reverse,
  *       then ~dActor_c.
  *
+ * ROM RTTI names the class daPgBby_c (_ZTS9daPgBby_c); BabyPenguin is the
+ * established readable compatibility name used by the recovered method
+ * symbols. The co-addressed _ZTV11BabyPenguin/_ZTV9daPgBby_c labels pin that
+ * identity at 0x02122a90, and the RTTI record names dActor_c as its sole base.
+ *
  * SIZE 0x370 is the factory's own literal; unk_36c (2 bytes, 0x36c) closes
  * exactly on it under 4-byte alignment.
  *
@@ -38,13 +43,13 @@ struct BabyPenguin : dActor_c {
     /* ModelAnim member, named by _ZN9ModelAnimD1Ev at +0xd4 -- a relocation the ROM build checks. */
     ModelAnim mModelAnim;            /* 0x0d4 */
     /* ShadowModel member, named by the class's own destructor calling
-       ShadowModel's D1 at +0x138. [_ZN11BabyPenguinD0Ev.c] */
+       ShadowModel's D1 at +0x138. [_ZN11BabyPenguinD0Ev.cpp] */
     ShadowModel mShadowModel;            /* 0x138 */
     /* dCcAc_c member, named by the class's own destructor calling
-       dCcAc_c's D1 at +0x160. [_ZN11BabyPenguinD0Ev.c] */
+       dCcAc_c's D1 at +0x160. [_ZN11BabyPenguinD0Ev.cpp] */
     dCcAc_c mdCcAc_c;            /* 0x160 */
     /* dBgCh_Actr member, named by the class's own destructor calling
-       dBgCh_Actr's D1 at +0x194. [_ZN11BabyPenguinD0Ev.c] */
+       dBgCh_Actr's D1 at +0x194. [_ZN11BabyPenguinD0Ev.cpp] */
     dBgCh_Actr mWithMeshClsn;            /* 0x194 */
     /* Copy of mPosX/Y/Z taken once in InitResources and never written again.
        [_ZN11BabyPenguin13InitResourcesEv.cpp] */

--- a/src/_ZN11BabyPenguin13InitResourcesEv.cpp
+++ b/src/_ZN11BabyPenguin13InitResourcesEv.cpp
@@ -1,27 +1,32 @@
 //cpp
 // @symbol _ZN11BabyPenguin13InitResourcesEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
-#include "decl_common.h"
-/* recovered: named members + shared header, real C++ method */
 #include "BabyPenguin.h"
-extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
-extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *file, int a, int b);
-extern "C" void _ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
-extern "C" int _ZN11ShadowModel12InitCylinderEv(void *thiz);
+#include "SharedFilePtr.h"
+
+extern SharedFilePtr data_ov072_02122cb4;
+extern SharedFilePtr *data_ov072_02122004[];
+
+/* The collision Init symbols are measured mwccarm 6az walls. Spelling
+ * dCcAc_c::Init with its honest Fix12<int> values homes both wrappers and
+ * grows this function by 0x10. dBgCh_Actr's current scalar compatibility
+ * declaration instead mangles `ii`, while the ROM destination spells
+ * `5Fix12IiES3_`. Keep these two ABI calls until those compiler/signature
+ * levers are recovered; the remaining class APIs below are compiler-spelled. */
 extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *thiz, void *actor, int r, int h, unsigned int a, unsigned int b);
 extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *thiz, void *actor, int r, int h, void *v, int b);
+extern "C" void func_ov072_021210c4(void *c);
 extern "C" void func_ov072_02121d50(void *c);
 
 int BabyPenguin::InitResources()
 {
-    void *f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov072_02122cb4);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, f, 1, -1);
+    BMD_File *f = (BMD_File *)Model::LoadFile(data_ov072_02122cb4);
+    mModelAnim.SetFile(f, 1, -1);
     int i;
     for (i = 0; i < 5; i++) {
-        _ZN9Animation8LoadFileER13SharedFilePtr((void *)data_ov072_02122004[i]);
+        Animation::LoadFile(*data_ov072_02122004[i]);
     }
-    if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0) return 0;
-    _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(((char *)this) + 0x160, ((char *)this), 0x28000, 0x50000, 0x800004, 0x9000);
+    if (mShadowModel.InitCylinder() == 0) return 0;
+    _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(&mdCcAc_c, this, 0x28000, 0x50000, 0x800004, 0x9000);
     mVertAccel = -0x2000;
     mTerminalVelocity = -0x3c000;
     mSpawnPosX = mPosX;
@@ -30,7 +35,7 @@ int BabyPenguin::InitResources()
     mScaleX = 0x400;
     mScaleY = 0x400;
     mScaleZ = 0x400;
-    _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x194, ((char *)this), 0x32000, 0x32000, 0, 0);
+    _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(&mWithMeshClsn, this, 0x32000, 0x32000, 0, 0);
     mEatingPlayer = 0;
     unk_360 = 0;
     func_ov072_02121d50(((char *)this));


### PR DESCRIPTION
Replaces four hand-mangled ABI calls in BabyPenguin::InitResources with compiler-spelled Model, ModelAnim, Animation, and ShadowModel APIs while preserving exact code and relocations.\n\nTwo calls remain explicitly ABI-bound with measured reasons: the honest dCcAc Fix12 signature changes code size, and the current dBgCh_Actr compatibility signature links the wrong symbol. The factory likewise remains C because natural new targets global _Znwm instead of the ROM fBase allocator.\n\nVerification: all 9 affected consumers pass; InitResources VERIFIED blind: 0; all 31 vtable slots exact; full ROM build reproduces 11,060/11,060 functions and 106/106 modules.