### PR TITLE
Point the migration recipe at Heap's post-#1772 .cpp paths

### DIFF
--- a/notes/agent-cpp-class-migration.md
+++ b/notes/agent-cpp-class-migration.md
@@ -76,7 +76,7 @@ $env:AGENTLOCK_HOLDER = 'cpp-heap'
 $AgentLockCli = '<path supplied by the installed agent-lock skill>'
 python $AgentLockCli list
 python $AgentLockCli acquire `
-  --files include/Heap.h src/_ZN4HeapD0Ev.c src/_ZN4HeapD1Ev.c `
+  --files include/Heap.h src/_ZN4HeapD0Ev.cpp src/_ZN4HeapD1Ev.cpp `
           config/arm9/symbols.txt config/arm9/delinks.txt `
   --range arm9 0x0203ca10 0x0203ca54 `
   --ttl 3600 --wait 60 --note 'real C++ Heap migration'
@@ -87,12 +87,12 @@ jobs, and release only after the branch is pushed or deliberately abandoned:
 
 ```powershell
 python $AgentLockCli renew `
-  --files include/Heap.h src/_ZN4HeapD0Ev.c src/_ZN4HeapD1Ev.c `
+  --files include/Heap.h src/_ZN4HeapD0Ev.cpp src/_ZN4HeapD1Ev.cpp `
           config/arm9/symbols.txt config/arm9/delinks.txt `
   --range arm9 0x0203ca10 0x0203ca54
 
 python $AgentLockCli release `
-  --files include/Heap.h src/_ZN4HeapD0Ev.c src/_ZN4HeapD1Ev.c `
+  --files include/Heap.h src/_ZN4HeapD0Ev.cpp src/_ZN4HeapD1Ev.cpp `
           config/arm9/symbols.txt config/arm9/delinks.txt `
   --range arm9 0x0203ca10 0x0203ca54
 ```


### PR DESCRIPTION
`notes/agent-cpp-class-migration.md` (landed in #1767) spells the Heap example's file list as `src/_ZN4HeapD0Ev.c` / `src/_ZN4HeapD1Ev.c`. #1772 migrated those to real C++ and renamed both to `.cpp`, so `check_dead_references.py` fails on main:

    FAIL: 2 prose reference(s) name a path that does not exist:
      notes/agent-cpp-class-migration.md
          names `src/_ZN4HeapD0Ev.c`, which is not in the tree

This updates the three `--files` lines to the current paths. Prose only; no source, config, or tooling change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>