### PR TITLE
Rewrite IceSheet as real C++

### DIFF
--- a/include/IceSheet.h
+++ b/include/IceSheet.h
@@ -16,9 +16,11 @@
  * members before chaining to dActor_c. Those two independent observations
  * pin both the empty derived layout and the allocation size. */
 struct IceSheet : dBgActor_c {
-    /* Inline is load-bearing. Explicit use from the destructor sources makes
-     * mwccarm emit the genuine D1/D0 pair in ROM order without a homeless D2. */
-    virtual ~IceSheet() {}
+    /* Out of line is load-bearing in the repository's one-function object
+     * shape. Each enrolled destructor source must ask mwccarm for the genuine
+     * variant and retain the class's already-verified raw data contribution;
+     * objisolate keeps only that source's licensed D1 or D0 text. */
+    virtual ~IceSheet();
 
     virtual int InitResources();                  /* slot  0 */
     virtual int CleanupResources();               /* slot  3 */

--- a/include/IceSheet.h
+++ b/include/IceSheet.h
@@ -1,68 +1,34 @@
 #ifndef ICESHEET_H
 #define ICESHEET_H
 
-#include "types.h"
-#include "dBgW_KcMbg.h"
-
-/* Derives from dBgActor_c: the destructor stores this class's vtable, then
- * dBgActor_c's -- inlined -- then destroys the dBgW_KcMbg at 0x124 and
- * the Model at 0xd4 before chaining to dActor_c. All three belong to dBgActor_c.
- * Everything this header used to restate below 0x31e was dActor_c's and
- * dBgActor_c's, and is inherited now.
- *
- * SIZE IS THE OBSERVED FIELD SPAN, rounded up. It guards this declaration; it
- * is not independent evidence about the ROM.
- */
-
-#ifdef __cplusplus
-
 #include "dBgActor_c.h"
 
+/* The cartridge RTTI names this class daObjIceBoard_c. IceSheet is the
+ * readable compatibility spelling already carried by every configured
+ * method. The ROM's __si_class_type_info record gives it one direct base,
+ * dBgActor_c at offset zero, and its 32-slot vtable has the same extent as
+ * that base. A compiler object may therefore emit `_ZTI8IceSheet`; that
+ * compatibility-name metadata is a discard-only passenger of the
+ * independently isolated functions, not a claim about the cartridge RTTI.
+ *
+ * IceSheet adds no fields. The factory allocates exactly 0x320 bytes, and the
+ * destructor destroys only dBgActor_c's inherited dBgW_KcMbg and Model
+ * members before chaining to dActor_c. Those two independent observations
+ * pin both the empty derived layout and the allocation size. */
 struct IceSheet : dBgActor_c {
-    /* no fields of its own */
+    /* Inline is load-bearing. Explicit use from the destructor sources makes
+     * mwccarm emit the genuine D1/D0 pair in ROM order without a homeless D2. */
+    virtual ~IceSheet() {}
 
-    /* --- vtable --- */
-    /* DECLARED FIRST, AND IT STAYS FIRST. Out of line, so it is this class's key
-       function, and src/_ZN8IceSheetD1Ev.cpp / D0Ev.cpp define it as a real
-       method. Kill below must not displace it. */
-    virtual ~IceSheet();
-
-    int Behavior();
-    int CleanupResources();
-    int InitResources();
-    int Render();
-
-    virtual void OnGroundPounded(dActor_c &other);  /* slot 21 */
-    virtual void OnHitByMegaChar(Player &player);    /* slot 27 */
-
-    /* Slot 31, dBgActor_c's own new virtual (include/dBgActor_c.h). ATTRIBUTED BY
-       THE VTABLE: _ZTV8IceSheet (ov018 0x02113b34) carries 0x02112880 at
-       +31*4 = 0x02113bb0, and _ZTV10dBgActor_c carries _ZN10dBgActor_c4KillEv at the
-       same slot, so this is this class's own override. An override adds no slot
-       and no field; the size assert below is unaffected. */
-    virtual void Kill();                /* slot 31 */
+    virtual int InitResources();                  /* slot  0 */
+    virtual int CleanupResources();               /* slot  3 */
+    virtual int Behavior();                       /* slot  6 */
+    virtual int Render();                         /* slot  9 */
+    virtual void OnGroundPounded(dActor_c &other);/* slot 21 */
+    virtual void OnHitByMegaChar(Player &player); /* slot 27 */
+    virtual void Kill();                          /* slot 31 */
 };
 
 typedef char IceSheet_size_must_be_0x320[sizeof(IceSheet) == 0x320 ? 1 : -1];
-
-#else
-
-/* The C spelling of the same object, flat. Kept because the D0 file is a C
-   translation unit that reads these fields, and D0 is compiler-generated so it
-   can never be migrated. Same arrangement as include/ShadowModel.h. */
-struct IceSheet {
-    u8  pad_000[0x8e];
-    s16 mAngleY;            /* 0x08e */
-    u8  pad_090[0x44];
-    /* Model member, named by _ZN5ModelD1Ev at +0xd4 -- a relocation the ROM build checks.
-       D1 and not D2, so it is this type and not an inlined base. Was a u8 marker. */
-    Model mModel;            /* 0x0d4 */
-    /* dBgW_KcMbg member. The cartridge's own ~IceSheet calls _ZN10dBgW_KcMbgD1Ev at
-       +0x124 (D0/D1), a relocation the ROM build checks; recovered by
-       tools/dtor_members.py. D1 and not D2, so it is this type and not an inlined base. */
-    dBgW_KcMbg mMovingMeshCollider;            /* 0x124 */
-};
-
-#endif /* __cplusplus */
 
 #endif /* ICESHEET_H */

--- a/src/IceSheet_Spawn.c
+++ b/src/IceSheet_Spawn.c
@@ -1,13 +1,16 @@
 // @symbol IceSheet_Spawn
-/* recovered: globals resolved, declarations from a shared header */
+/* Measured C++ factory wall. `return new IceSheet` reproduces the construction
+ * shape but emits the global `_Znwm` allocator, while the cartridge calls
+ * fBase_c::operator new(unsigned int). Keep the verified C ABI construction
+ * form until that allocator relationship is representable without a wrong
+ * relocation. */
 #include "decl_ActorBase.h"
 #include "decl_Platform.h"
 #include "decl_common.h"
-/* recovered: globals resolved */
-/* resolved: VT = _ZTV8IceSheet */
+
 int *IceSheet_Spawn(void)
 {
-    int *p = (int *)_ZN7fBase_cnwEj(800);
+    int *p = (int *)_ZN7fBase_cnwEj(0x320);
     if (p) { _ZN10dBgActor_cC2Ev(p); p[0] = (int)_ZTV8IceSheet; }
     return p;
 }

--- a/src/_ZN8IceSheet13InitResourcesEv.cpp
+++ b/src/_ZN8IceSheet13InitResourcesEv.cpp
@@ -1,25 +1,30 @@
 //cpp
 // @symbol _ZN8IceSheet13InitResourcesEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
-#include "decl_common.h"
-/* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
+#include "SharedFilePtr.h"
+
 extern "C" {
-extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
-extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
-extern int _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void*);
-extern int _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void*);
-extern void* _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void*);
-extern int _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
+/* The true member signature takes Fix12<int> by value. A faithful C++ call
+ * homes that argument differently under mwccarm and does not reproduce this
+ * call site, so retain the verified scalar ABI spelling. */
+void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+    dBgW_KcMbg *self, KCL_File *file, Matrix4x3 *mat, int scale,
+    short angY, void *clps);
+extern char data_ov002_0210d754;
 }
+extern SharedFilePtr IceSheet_ClsnFile;
+extern SharedFilePtr IceSheet_ModelFile;
 
 int IceSheet::InitResources()
 {
-    void *mdl = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov018_02113c84);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(&mModel, mdl, 1, -1);
-    _ZN10dBgActor_c21UpdateModelPosAndRotYEv(((char *)this));
-    _ZN10dBgActor_c19UpdateClsnPosAndRotEv(((char *)this));
-    void *kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(&data_ov018_02113c7c);
-    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(&mMeshCollider, kcl, &mClsnMat, 0x199, mAngleY, (void *)&data_ov002_0210d754);
+    void *modelFile = Model::LoadFile(IceSheet_ModelFile);
+    mModel.SetFile((BMD_File *)modelFile, 1, -1);
+    UpdateModelPosAndRotY();
+    UpdateClsnPosAndRot();
+
+    KCL_File *clsnFile = (KCL_File *)dBgW_Kc::LoadFile(IceSheet_ClsnFile);
+    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+        &mMeshCollider, clsnFile, &mClsnMat, 0x199, mAngleY,
+        &data_ov002_0210d754);
     return 1;
 }

--- a/src/_ZN8IceSheet16CleanupResourcesEv.cpp
+++ b/src/_ZN8IceSheet16CleanupResourcesEv.cpp
@@ -1,20 +1,17 @@
 //cpp
 // @symbol _ZN8IceSheet16CleanupResourcesEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
-#include "decl_common.h"
-/* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
 #include "SharedFilePtr.h"
-#include "dBgW.h"
-extern int IceSheet_ClsnFile[];
-extern int IceSheet_ModelFile[];
+
+extern SharedFilePtr IceSheet_ClsnFile;
+extern SharedFilePtr IceSheet_ModelFile;
 
 int IceSheet::CleanupResources()
 {
-    if (((dBgW *)((char *)&(*(u8 *)&mMeshCollider)))->IsEnabled()) {
-        ((dBgW *)((char *)&(*(u8 *)&mMeshCollider)))->Disable();
-    }
-    ((SharedFilePtr *)(IceSheet_ModelFile))->Release();
-    ((SharedFilePtr *)(IceSheet_ClsnFile))->Release();
+    if (mMeshCollider.IsEnabled())
+        mMeshCollider.Disable();
+
+    IceSheet_ModelFile.Release();
+    IceSheet_ClsnFile.Release();
     return 1;
 }

--- a/src/_ZN8IceSheet6RenderEv.cpp
+++ b/src/_ZN8IceSheet6RenderEv.cpp
@@ -1,11 +1,9 @@
 //cpp
 // @symbol _ZN8IceSheet6RenderEv
-/* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
-struct Derived { char pad[0xd4]; Base base; };
 
 int IceSheet::Render()
 {
- Base *b = &((Derived *)this)->base; b->m(0); return 1;
+    mModel.Render(0);
+    return 1;
 }

--- a/src/_ZN8IceSheet8BehaviorEv.cpp
+++ b/src/_ZN8IceSheet8BehaviorEv.cpp
@@ -1,14 +1,10 @@
 //cpp
 // @symbol _ZN8IceSheet8BehaviorEv
-/* recovered: named members + shared header, real C++ method */
 #include "IceSheet.h"
-#include "dBgW.h"
-extern "C" {
-}
 
 int IceSheet::Behavior()
 {
-  if (!((dBgW *)((char*)&(*(u8 *)&mMeshCollider)))->IsEnabled())
-    ((dBgW *)(&mMeshCollider))->Enable((dActor_c *)(((char*)this)));
-  return 1;
+    if (!mMeshCollider.IsEnabled())
+        mMeshCollider.Enable(this);
+    return 1;
 }

--- a/src/_ZN8IceSheetD0Ev.cpp
+++ b/src/_ZN8IceSheetD0Ev.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol _ZN8IceSheetD0Ev
-/* A delete expression forces the genuine compiler-spelled deleting
- * destructor. dActor_c's inline operator delete supplies the actor-heap
- * deallocation used by the cartridge. */
+/* The out-of-line definition makes mwccarm materialize the genuine deleting
+ * destructor. This per-symbol source also retains the verified vtable/base
+ * RTTI contribution that the one-function build measured before migration;
+ * objisolate keeps D0 and discards the unlicensed variants and data. */
 #include "IceSheet.h"
 
-void IceSheet_EmitDeletingDestructor(IceSheet *sheet)
+IceSheet::~IceSheet()
 {
-    delete sheet;
 }

--- a/src/_ZN8IceSheetD0Ev.cpp
+++ b/src/_ZN8IceSheetD0Ev.cpp
@@ -1,18 +1,11 @@
 //cpp
 // @symbol _ZN8IceSheetD0Ev
-/* recovered: real C++ deleting destructor -- the compiler emits the whole body
- *
- * D0 is the DELETING destructor: destroy through this class and its bases --
- * which is why more than one vptr store appears -- then return the object to
- * its heap. Nobody writes that; declaring `~IceSheet()` is enough, because mwcc
- * emits D2, D0 and D1 together and objisolate keeps the one this file is bound
- * to.
- *
- * The deallocation is an inline operator delete, which is why nothing below
- * mentions a heap.
- */
+/* A delete expression forces the genuine compiler-spelled deleting
+ * destructor. dActor_c's inline operator delete supplies the actor-heap
+ * deallocation used by the cartridge. */
 #include "IceSheet.h"
 
-IceSheet::~IceSheet()
+void IceSheet_EmitDeletingDestructor(IceSheet *sheet)
 {
+    delete sheet;
 }

--- a/src/_ZN8IceSheetD1Ev.cpp
+++ b/src/_ZN8IceSheetD1Ev.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol _ZN8IceSheetD1Ev
-/* Force mwccarm to materialize the inline class-body complete destructor.
- * objisolate retains the enrolled D1 and discards this forcing helper and the
- * compatibility-name vtable/RTTI passengers. */
+/* The out-of-line definition makes mwccarm materialize the genuine complete
+ * destructor. This per-symbol source also retains the verified vtable/base
+ * RTTI contribution that the one-function build measured before migration;
+ * objisolate keeps D1 and discards the unlicensed variants and data. */
 #include "IceSheet.h"
 
-void IceSheet_EmitDestructor(IceSheet *sheet)
+IceSheet::~IceSheet()
 {
-    sheet->~IceSheet();
 }

--- a/src/_ZN8IceSheetD1Ev.cpp
+++ b/src/_ZN8IceSheetD1Ev.cpp
@@ -1,15 +1,11 @@
 //cpp
 // @symbol _ZN8IceSheetD1Ev
-/* recovered: real C++ destructor -- the compiler emits the whole body
- *
- * Two vtable stores and three destructor calls, every one a consequence of
- * `struct IceSheet : dBgActor_c`: its own vptr, then dBgActor_c's -- inlined,
- * because dBgActor_c's destructor is defined in its class body -- then
- * dBgActor_c's Model and dBgW_KcMbg, then dActor_c. This class adds no
- * member with a destructor of its own.
- */
+/* Force mwccarm to materialize the inline class-body complete destructor.
+ * objisolate retains the enrolled D1 and discards this forcing helper and the
+ * compatibility-name vtable/RTTI passengers. */
 #include "IceSheet.h"
 
-IceSheet::~IceSheet()
+void IceSheet_EmitDestructor(IceSheet *sheet)
 {
+    sheet->~IceSheet();
 }


### PR DESCRIPTION
Rewrites IceSheet around a real IceSheet : dBgActor_c declaration and compiler-spelled methods while preserving the exact ov018 object code.

The reconstructed high-confidence TU contains 10 functions at 0x021127bc-0x02112a74. All 10 independently link-check VERIFIED with blind 0, and the changed-header consumer closure is 10/10 verified.

The raw key-function object emits a 32-slot compatibility vtable whose 32 function destinations exactly match the cartridge. The cartridge RTTI uses the internal name daObjIceBoard_c; compatibility-name RTTI remains a discard-only passenger. The C factory stays in place because ordinary new emits _Znwm instead of fBase_c::operator new, and SetFile retains its verified ABI spelling because the canonical by-value Fix12 call is a measured non-match.

Full verification: 11,061/11,061 source-built functions reproduce, 106/106 modules exact, ROM-build analysis PASS. Header/layout, references, port, language-mode, dead-reference, and attribution gates also pass.
