### PR TITLE
Migrate HugeCover to real C++ class form

### DIFF
--- a/config/arm9/overlays/ov032/symbols.txt
+++ b/config/arm9/overlays/ov032/symbols.txt
@@ -136,6 +136,7 @@ HugeCover_SpawnInfo kind:data(any) addr:0x021138bc ambiguous
 data_ov032_021138c4 kind:data(any) addr:0x021138c4 ambiguous
 data_ov032_021138d8 kind:data(any) addr:0x021138d8 ambiguous
 _ZTV9HugeCover kind:data(any) addr:0x021138e0
+_ZTV13daObjTdFuta_c kind:data(any) addr:0x021138e0
 data_ov032_021138f0 kind:data(any) addr:0x021138f0 ambiguous
 data_ov032_021138fc kind:data(any) addr:0x021138fc ambiguous
 data_ov032_02113934 kind:data(any) addr:0x02113934 ambiguous

--- a/include/HugeCover.h
+++ b/include/HugeCover.h
@@ -4,26 +4,26 @@
 #include "types.h"
 #include "dBgActor_c.h"
 
-/* TWO WITNESSES, and they close on each other:
+/* The cartridge RTTI names this class daObjTdFuta_c. HugeCover is the
+ * readable compatibility spelling carried by all six named virtuals and the
+ * factory. The __si_class_type_info record points directly at dBgActor_c.
+ * Its table at 0x021138e0 has the same 32-slot extent as that base; slots 0,
+ * 3, 6, 9, 16 and 17 are the only overrides.
  *
- *   HugeCover_Spawn  fBase_c::operator new(800 = 0x320), dBgActor_c::dBgActor_c(), stores _ZTV9HugeCover,
- *                 then the members below in this order.
- *   ~HugeCover   the same members destroyed in reverse, then ~dBgActor_c.
- *
- * SIZE 0x320 is the factory's own literal, and the last member closes exactly on it.
- *
- * THE VTABLE was diffed slot by slot against _ZTV10dBgActor_c. Only the slots declared
- * below differ; every other slot holds the base's own word and is inherited, so it
- * is deliberately not redeclared here.
+ * HugeCover adds no storage. The factory allocates exactly 0x320 bytes, calls
+ * dBgActor_c's constructor, and installs this table. The empty derived
+ * destructor correspondingly lets the compiler destroy the inherited
+ * dBgActor_c object. The adjacent 0x021139a4 table is a different class:
+ * RTTI names it daObjTdWater_c and its slots point into HugeWater's TU.
  */
 struct HugeCover : dBgActor_c {
 
-    virtual ~HugeCover();            /* slots 16 (D1), 17 (D0) */
+    virtual ~HugeCover();                 /* slots 16 (D1), 17 (D0) */
 
-    virtual s32   InitResources();         /* slot  0 */
-    virtual s32   CleanupResources();      /* slot  3 */
-    virtual s32   Behavior();              /* slot  6 */
-    virtual s32   Render();                /* slot  9 */
+    virtual s32 InitResources();           /* slot  0 */
+    virtual s32 CleanupResources();        /* slot  3 */
+    virtual s32 Behavior();                /* slot  6 */
+    virtual s32 Render();                  /* slot  9 */
 };
 
 typedef char HugeCover_size_must_be_0x320[sizeof(HugeCover) == 0x320 ? 1 : -1];

--- a/src/HugeCover_Spawn.c
+++ b/src/HugeCover_Spawn.c
@@ -1,3 +1,8 @@
+// @symbol HugeCover_Spawn
+/* Factory remains in its measured C ABI form. mwccarm rejects fBase_c's actor
+ * allocator as an in-class operator new declaration (see fBase_c.h), so a
+ * source-level `new HugeCover` binds the wrong global allocator. The ROM calls
+ * the actor allocator, base constructor, and derived vptr store explicitly. */
 extern void *_ZN7fBase_cnwEj(unsigned);
 extern void _ZN10dBgActor_cC2Ev(void *);
 extern int _ZTV9HugeCover[];

--- a/src/_ZN9HugeCover13InitResourcesEv.cpp
+++ b/src/_ZN9HugeCover13InitResourcesEv.cpp
@@ -1,27 +1,31 @@
 //cpp
 // @symbol _ZN9HugeCover13InitResourcesEv
 #include "HugeCover.h"
-// recovered name: daObjTdFuta_c_InitResources
-/* recovered: renamed to Class_Method, declarations from a shared header */
-#include "decl_common.h"
-/* recovered: renamed to Class_Method */
-/* daObjTdFuta_c::InitResources - recovered from vtable slot identity */
+#include "SharedFilePtr.h"
+
+namespace Event { s32 GetBit(u32 bit); }
+
+/* dBgW_KcMbg::SetFile takes Fix12<int> by value. An ordinary member call
+ * triggers mwccarm's by-value-class parameter homing and changes the ROM ABI,
+ * so this one call deliberately retains the measured register-level view. */
 extern "C" {
-extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
-extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
-extern void _ZN10dBgActor_c21UpdateModelPosAndRotYEv(void*);
-extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void*);
-extern void* _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void*);
-extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
-extern int _ZN5Event6GetBitEj(unsigned int);
-s32 HugeCover::InitResources() {
-    char * c = (char *)this;
-  void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov032_02113ad4);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
-  _ZN10dBgActor_c21UpdateModelPosAndRotYEv(c);
-  _ZN10dBgActor_c19UpdateClsnPosAndRotEv(c);
-  void *k = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr((void*)data_ov032_02113acc);
-  _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov032_02112f98);
-  return _ZN5Event6GetBitEj(0xe) == 0;
+extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+    void *self, void *kcl, void *mtx, int scale, short angleY, void *clps);
+extern SharedFilePtr data_ov032_02113acc;
+extern SharedFilePtr data_ov032_02113ad4;
+extern char data_ov032_02112f98;
 }
+
+s32 HugeCover::InitResources()
+{
+    mModel.SetFile((BMD_File *)Model::LoadFile(data_ov032_02113ad4), 1, -1);
+    UpdateModelPosAndRotY();
+    UpdateClsnPosAndRot();
+
+    void *kcl = dBgW_Kc::LoadFile(data_ov032_02113acc);
+    _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+        &mMeshCollider, kcl, &mClsnMat, 0x199, mAngleY,
+        &data_ov032_02112f98);
+
+    return Event::GetBit(0xe) == 0;
 }

--- a/src/_ZN9HugeCover16CleanupResourcesEv.cpp
+++ b/src/_ZN9HugeCover16CleanupResourcesEv.cpp
@@ -1,22 +1,17 @@
 //cpp
 // @symbol _ZN9HugeCover16CleanupResourcesEv
 #include "HugeCover.h"
-// recovered name: daObjTdFuta_c_CleanupResources
-/* recovered: renamed to Class_Method, declarations from a shared header */
-#include "decl_common.h"
-/* recovered: renamed to Class_Method */
-/* daObjTdFuta_c::CleanupResources - recovered from vtable slot identity */
-extern "C" {
-extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int data_ov032_02113ad4[];
-}
+#include "SharedFilePtr.h"
 
-s32 HugeCover::CleanupResources() {
-    void * t = (void *)this;
-    if (_ZN4dBgW9IsEnabledEv((char *)t + 0x124)) {
-        _ZN4dBgW7DisableEv((char *)t + 0x124);
-    }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov032_02113ad4);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov032_02113acc);
+extern "C" SharedFilePtr data_ov032_02113acc;
+extern "C" SharedFilePtr data_ov032_02113ad4;
+
+s32 HugeCover::CleanupResources()
+{
+    if (mMeshCollider.IsEnabled())
+        mMeshCollider.Disable();
+
+    data_ov032_02113ad4.Release();
+    data_ov032_02113acc.Release();
     return 1;
 }

--- a/src/_ZN9HugeCover6RenderEv.cpp
+++ b/src/_ZN9HugeCover6RenderEv.cpp
@@ -1,10 +1,9 @@
 //cpp
 // @symbol _ZN9HugeCover6RenderEv
 #include "HugeCover.h"
-// recovered name: daObjTdFuta_c_Render
-/* recovered: renamed to Class_Method */
-/* daObjTdFuta_c::Render - recovered from vtable slot identity */
-struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
-struct Derived { char pad[0xd4]; Base base; };
-s32 HugeCover::Render() {
-    Derived * d = (Derived *)this; Base *b = &d->base; b->m(0); return 1; }
+
+s32 HugeCover::Render()
+{
+    mModel.Render(0);
+    return 1;
+}

--- a/src/_ZN9HugeCover8BehaviorEv.cpp
+++ b/src/_ZN9HugeCover8BehaviorEv.cpp
@@ -1,13 +1,16 @@
 //cpp
 // @symbol _ZN9HugeCover8BehaviorEv
 #include "HugeCover.h"
-// recovered name: daObjTdFuta_c_Behavior
-/* recovered: renamed to Class_Method */
-/* daObjTdFuta_c::Behavior - recovered from vtable slot identity */
-extern "C" int _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 
-s32 HugeCover::Behavior() {
-    void * c = (void *)this;
-    _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
+/* The ROM passes both Fix12<int> values directly in registers. Defining the
+ * imported function as an ordinary C++ member homes the by-value class
+ * parameters to the stack under mwccarm 2004/b56, so keep the measured ABI
+ * spelling until that shared compiler wall is solved. */
+extern "C" int _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void *self,
+                                                             int a, int b);
+
+s32 HugeCover::Behavior()
+{
+    _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(this, 0, 0);
     return 1;
 }

--- a/symbols/actor_renames.tsv
+++ b/symbols/actor_renames.tsv
@@ -913,16 +913,17 @@ ov031	0x02111944	data_ov031_02111944	SlideDecorationOrangeSmiley_SpawnInfo	spawn
 ov031	0x02111960	data_ov031_02111960	SlideDecorationBlueSmiley_SpawnInfo	spawninfo
 ov031	0x02111984	data_ov031_02111984	_ZTV25SlideDecorationSilverStar	vtable alloc=0x128
 ov032	0x02112668	func_ov032_02112668	HugeCover_Spawn	spawnfunc
-ov032	0x02112698	func_ov032_02112698	_ZN9HugeCoverD1Ev	vtable slot 16
-ov032	0x021126e4	func_ov032_021126e4	_ZN9HugeCoverD0Ev	vtable slot 17
-ov032	0x02112744	func_ov032_02112744	_ZN9HugeCover16CleanupResourcesEv	vtable slot 3
-ov032	0x02112788	func_ov032_02112788	_ZN9HugeCover6RenderEv	vtable slot 9
-ov032	0x021127bc	func_ov032_021127bc	_ZN9HugeCover8BehaviorEv	vtable slot 6
-ov032	0x021127f0	func_ov032_021127f0	_ZN9HugeCover13InitResourcesEv	vtable slot 0
+ov032	0x02112698	func_ov032_02112698	_ZN9HugeWaterD1Ev	vtable slot 16
+ov032	0x021126e4	func_ov032_021126e4	_ZN9HugeWaterD0Ev	vtable slot 17
+ov032	0x02112744	func_ov032_02112744	_ZN9HugeWater16CleanupResourcesEv	vtable slot 3
+ov032	0x02112788	func_ov032_02112788	_ZN9HugeWater6RenderEv	vtable slot 9
+ov032	0x021127bc	func_ov032_021127bc	_ZN9HugeWater8BehaviorEv	vtable slot 6
+ov032	0x021127f0	func_ov032_021127f0	_ZN9HugeWater13InitResourcesEv	vtable slot 0
 ov032	0x021128b8	func_ov032_021128b8	HugeWater_Spawn	spawnfunc
 ov032	0x021138bc	data_ov032_021138bc	HugeCover_SpawnInfo	spawninfo
+ov032	0x021138e0	data_ov032_021138e0	_ZTV9HugeCover	vtable alloc=0x320
 ov032	0x02113980	data_ov032_02113980	HugeWater_SpawnInfo	spawninfo
-ov032	0x021139a4	data_ov032_021139a4	_ZTV9HugeCover	vtable alloc=0x320
+ov032	0x021139a4	data_ov032_021139a4	_ZTV9HugeWater	vtable alloc=0x334
 ov033	0x021113a4	func_ov033_021113a4	TinyCover_Spawn	spawnfunc
 ov033	0x021113d4	func_ov033_021113d4	_ZN9TinyCoverD1Ev	vtable slot 16
 ov033	0x02111420	func_ov033_02111420	_ZN9TinyCoverD0Ev	vtable slot 17


### PR DESCRIPTION
Rewrites the seven-function HugeCover class slice to use its real inherited C++ fields and APIs while retaining the measured Fix12 and actor-factory ABI walls. Corrects stale HugeWater actor-ledger rows and adds HugeCover's ROM RTTI vtable alias. Verified 7/7 linked byte-identical with blind 0; both raw destructor objects emit the expected D2/D0/D1 group and exact 32-slot table; full ROM build is 11,061/11,061 reproducing with 106/106 modules exact.