### PR TITLE
Add agent-lock, a Redis-backed file lease for concurrent agents

### DIFF
--- a/.claude/skills/agent-lock/SKILL.md
+++ b/.claude/skills/agent-lock/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: agent-lock
+description: Take a short-lived local lock on a set of filenames and/or an address range before editing them, so parallel agents/forks in this repo don't grind the same files or ROM range at once. Use before touching shared files (headers, config/rombuild-versions.txt, build/) in any multi-agent or orchestrator workflow, before migrating a class whose address range another agent might also be working, or when a build/edit fails in a way that looks like another process touched the same files concurrently. NOT for coordinating with other human contributors over the network - that is tools/claims.py / CLAIMS.md / tangos.dev.
+---
+
+# Local agent locking (Redis, this machine only)
+
+`tools/agentlock.py` is a **local** lock, backed by a Redis container in
+`local-infra/`. It exists for the case `tools/claims.py` doesn't cover: several agents
+(forks, worktrees, a Workflow's parallel stages) running on **this machine** in **this
+session**, about to edit the same file or the same address range at the same time.
+
+It is not a substitute for `tools/claims.py` — that one coordinates with other
+contributors over the network and only understands address ranges. This one also locks
+plain filenames, has near-zero latency, and every lock expires on its own (crash-safe).
+
+## When to reach for it
+
+- An orchestrator is about to fan out several agents/forks that each edit files —
+  especially shared ones like headers, `config/rombuild-versions.txt`, `CLAIMS.md`, or
+  anything under `build/` (concurrent builds there already fake failures — see memory
+  `concurrent-builds-fake-failures`).
+- Two agents might independently pick the same class/function address range to migrate
+  or byte-match in the same run.
+- You're not sure two agents' file sets overlap — cheaper to lock and find out than to
+  debug a corrupted merge afterward.
+
+Skip it for read-only work (matching research, reading source, running `fdiff`) and for
+a single agent working alone — it's overhead with no payoff there.
+
+## Setup (once per machine, or after a restart)
+
+```
+docker compose -f local-infra/docker-compose.yml up -d
+```
+
+No persistence by design — a restart starts with an empty lock table, never resurrects
+stale locks. If `agentlock.py` can't reach Redis it says so and names this command.
+
+## Identity
+
+Locks are owned by a `holder` string: `AGENTLOCK_HOLDER` env var, else the OS username.
+**If you are one of several agents/forks running concurrently under the same OS user,
+set a distinct `AGENTLOCK_HOLDER` per agent** (its worktree name or agent name is a good
+choice) — otherwise it can renew or release a sibling agent's locks by accident, since
+holder identity is the only check (this is a local convenience lock, not an auth
+system).
+
+## Core flow
+
+Acquire is all-or-nothing across every resource in one call — if any file or the range
+is already held, nothing is locked and you get back exactly what's holding it.
+
+```
+python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp include/dActor_c.h --note "migrating Actor" --ttl 1800
+python tools/agentlock.py acquire --range ov006 0x020f0000 0x020f0100 --note "DetectClsn rewrite"
+python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp --range ov006 0x020f0000 0x020f0100
+```
+
+`--wait N` polls for up to N seconds instead of failing immediately (useful when you'd
+rather queue behind another agent than pick different work).
+
+Long edits should renew before the TTL (default 1800s) runs out — `list`/`check` show
+remaining TTL:
+
+```
+python tools/agentlock.py renew --files src_tu/actors/Actor.cpp include/dActor_c.h --ttl 1800
+```
+
+Release when done — always, even if the edit failed, so you don't sit on a lock for the
+next 30 minutes:
+
+```
+python tools/agentlock.py release --files src_tu/actors/Actor.cpp include/dActor_c.h
+python tools/agentlock.py release --range ov006 0x020f0000 0x020f0100
+```
+
+Check before planning work, or list everything currently held:
+
+```
+python tools/agentlock.py check --files src_tu/actors/Actor.cpp
+python tools/agentlock.py list --module ov006
+python tools/agentlock.py list
+```
+
+For a human watching several agents at once, `python tools/agentlock_web.py` serves a
+live plain-HTML view (two reports: all active locks, and ranges grouped by module) at
+http://127.0.0.1:8787/ — read-only, no setup.
+
+## Address ranges
+
+`--range <module> <start> <end>` takes a half-open `[start, end)` byte range, hex or
+decimal (`0x020f0000` or `34537472`). Overlap is checked precisely — two ranges that
+merely share a Redis key bucket are not treated as conflicting, and two that share even
+one byte are. Locking `ov006 0x020f0000 0x020f0100` blocks anyone requesting any range
+that intersects it; a neighboring `0x020f0100 0x020f0200` is unaffected.
+
+## Orchestrator usage (Workflow / Agent fan-out)
+
+Before dispatching a batch of agents that each own a class or file set, acquire each
+agent's resources from the orchestrator BEFORE spawning it (not inside the agent — a
+conflict should mean "give this agent different work," not "let it start and then
+fail"). Pass the resource list and a distinct `AGENTLOCK_HOLDER` into each agent's
+prompt/env, and release once that agent reports done (or on any error path — don't let
+a failed agent leave the lock TTL as the only cleanup, since 30 minutes idle blocks
+everyone else who wanted that file).
+
+## What it does NOT do
+
+- Does not coordinate across machines or with other human contributors — for that,
+  `tools/claims.py` / `CLAIMS.md` / tangos.dev remain authoritative.
+- Does not stop a human editing a file by hand outside these tools.
+- Does not persist across a Redis restart — treat locks as session-scoped, not a
+  durable record of who-did-what (that's git history / CLAIMS.md).

--- a/local-infra/GETTING_STARTED.md
+++ b/local-infra/GETTING_STARTED.md
@@ -1,0 +1,83 @@
+# Local agent lock — getting started
+
+A tiny Redis container, local to your machine, so parallel agents in this repo don't
+edit the same file or the same ROM address range at the same time. Not for coordinating
+with other contributors — that's `tools/claims.py` / tangos.dev.
+
+## 1. Start Redis
+
+```
+docker compose -f local-infra/docker-compose.yml up -d
+```
+
+That's it. No password, no persistence — it's a scratch lock table for this session.
+Bound to `127.0.0.1` only, so it's not reachable off your machine.
+
+Check it's up:
+
+```
+docker compose -f local-infra/docker-compose.yml ps
+```
+
+Stop it when you're done (locks vanish with it — that's intended):
+
+```
+docker compose -f local-infra/docker-compose.yml down
+```
+
+## 2. Take a lock
+
+```
+python tools/agentlock.py acquire --files src/Actor.cpp src/Actor.h --note "migrating Actor" --ttl 1800
+```
+
+or an address range:
+
+```
+python tools/agentlock.py acquire --range ov006 0x020f0000 0x020f0100 --note "DetectClsn rewrite"
+```
+
+If someone else already holds it, you get told who and what — nothing is locked
+half-way.
+
+## 3. Do the work, then release it
+
+```
+python tools/agentlock.py release --files src/Actor.cpp src/Actor.h
+```
+
+Locks also expire on their own after the `--ttl` (default 1800s / 30 min), so a crashed
+agent never wedges everyone else — but release explicitly when you're done, don't rely
+on the timer.
+
+## 4. See what's held
+
+```
+python tools/agentlock.py list
+```
+
+or watch it live in a browser — a plain-HTML dashboard, no JS, refreshes itself every
+3s:
+
+```
+python tools/agentlock_web.py
+```
+
+then open http://127.0.0.1:8787/. Two reports: every active lock, and address-range
+locks grouped by module (start/end sorted, so an overlap or gap is visible at a
+glance). It's read-only and just queries Redis directly per request — nothing to
+configure.
+
+## Running two agents at once? Give each one a name
+
+```
+export AGENTLOCK_HOLDER=agent-actor-migration
+```
+
+Without this, two agents running as the same OS user can renew/release *each other's*
+locks — the holder name is the only ownership check.
+
+## Full command reference
+
+See the header of `tools/agentlock.py` (`python tools/agentlock.py` with no args prints
+it), or the `agent-lock` skill for when/how agents should use this in orchestrated work.

--- a/local-infra/docker-compose.yml
+++ b/local-infra/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: sm64ds-agentlock-redis
+    # Loopback-only: this is a local coordination cache for agents on THIS machine,
+    # not a shared/network service like the tangos.dev claims board.
+    ports:
+      - "127.0.0.1:6379:6379"
+    # Locks are meaningful only while an agent session is alive; a restart should
+    # start empty, not resurrect stale locks. No AOF/RDB, no volume.
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/tools/agentlock.py
+++ b/tools/agentlock.py
@@ -1,0 +1,394 @@
+"""Local lock service (backed by Redis in local-infra/) so agents working the same
+worktree don't step on each other's files or address ranges. Sibling of tools/claims.py
+but LOCAL and SHORT-LIVED: claims.py coordinates with tangos.dev across contributors
+over the network (address ranges only); this coordinates parallel agents/forks on THIS
+machine only, and covers both address ranges and plain filenames. Start it with:
+
+    docker compose -f local-infra/docker-compose.yml up -d
+
+Lock flow: acquire a set of resources (files and/or one address range) -> renew while
+working -> release when done. All resources in one `acquire` call succeed or fail
+together. Every lock has a TTL and expires on its own if an agent dies without
+releasing, so a crash never wedges another agent forever.
+
+Identity: AGENTLOCK_HOLDER env var, else the OS username (see _default_holder below).
+Parallel agents/forks under the same OS user should each export a distinct
+AGENTLOCK_HOLDER (e.g. a worktree or agent name) -- otherwise they can renew/release
+each other's locks, since holder is the only ownership check (this is a local
+convenience lock, not an auth system).
+
+CLI:
+  python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp include/dActor_c.h --note "migrating Actor" [--ttl 1800] [--wait 60]
+  python tools/agentlock.py acquire --range ov006 0x020f0000 0x020f0100 --note "DetectClsn rewrite"
+  python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp --range ov006 0x020f0000 0x020f0100
+  python tools/agentlock.py renew   --files src_tu/actors/Actor.cpp include/dActor_c.h
+  python tools/agentlock.py renew   --range ov006 0x020f0000 0x020f0100
+  python tools/agentlock.py release --files src_tu/actors/Actor.cpp include/dActor_c.h
+  python tools/agentlock.py release --range ov006 0x020f0000 0x020f0100 [--force]
+  python tools/agentlock.py check   --files src_tu/actors/Actor.cpp
+  python tools/agentlock.py check   --range ov006 0x020f0000 0x020f0100
+  python tools/agentlock.py list    [--module ov006]
+"""
+import json
+import os
+import pathlib
+import sys
+import time
+import uuid
+
+try:
+    import redis
+except ImportError:
+    print("pip install redis  # the redis-py client, not the server", file=sys.stderr)
+    raise
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+REDIS_URL = os.environ.get("AGENTLOCK_REDIS_URL", "redis://127.0.0.1:6379/0")
+DEFAULT_TTL_S = 1800
+
+
+def _default_holder():
+    h = os.environ.get("AGENTLOCK_HOLDER")
+    if h:
+        return h.strip()
+    import getpass
+    try:
+        return getpass.getuser()
+    except Exception:
+        return "anonymous"
+
+
+HOLDER = _default_holder()
+
+# ---------------------------------------------------------------------------
+# Lua scripts. All acquire/release/renew are single EVALSHA round trips so a
+# multi-resource lock is genuinely atomic (all-or-nothing), not a client-side
+# loop that can race against another agent between checks.
+# ---------------------------------------------------------------------------
+
+# KEYS = exact "lock:file:<path>" keys. ARGV = [ttl_ms, holder, note, acquired_at]
+_ACQUIRE_EXACT = """
+local conflicts = {}
+for i, k in ipairs(KEYS) do
+  local v = redis.call('GET', k)
+  if v then table.insert(conflicts, k .. '=' .. v) end
+end
+if #conflicts > 0 then return conflicts end
+local payload = cjson.encode({holder=ARGV[2], note=ARGV[3], acquired_at=ARGV[4]})
+for i, k in ipairs(KEYS) do redis.call('SET', k, payload, 'PX', ARGV[1]) end
+return {}
+"""
+
+# KEYS = exact keys. ARGV = [holder, force]
+_RELEASE_EXACT = """
+local released, kept = {}, {}
+for i, k in ipairs(KEYS) do
+  local v = redis.call('GET', k)
+  if not v then
+    table.insert(released, k)
+  else
+    local ok, data = pcall(cjson.decode, v)
+    if ok and (data.holder == ARGV[1] or ARGV[2] == '1') then
+      redis.call('DEL', k)
+      table.insert(released, k)
+    else
+      table.insert(kept, k)
+    end
+  end
+end
+return {released, kept}
+"""
+
+# KEYS = exact keys. ARGV = [ttl_ms, holder]
+_RENEW_EXACT = """
+local renewed, missing = {}, {}
+for i, k in ipairs(KEYS) do
+  local v = redis.call('GET', k)
+  if not v then
+    table.insert(missing, k)
+  else
+    local ok, data = pcall(cjson.decode, v)
+    if ok and data.holder == ARGV[2] then
+      redis.call('PEXPIRE', k, ARGV[1])
+      table.insert(renewed, k)
+    else
+      table.insert(missing, k)
+    end
+  end
+end
+return {renewed, missing}
+"""
+
+# No KEYS (pattern scan inside the script). ARGV = [module, start, end, ttl_ms, holder, note, id, acquired_at]
+# Small local keyspace only (tens of locks) -- KEYS is fine here, avoid it at scale.
+_ACQUIRE_RANGE = """
+local pattern = 'lock:addr:' .. ARGV[1] .. ':*'
+local existing = redis.call('KEYS', pattern)
+local new_s, new_e = tonumber(ARGV[2]), tonumber(ARGV[3])
+local conflicts = {}
+for i, k in ipairs(existing) do
+  local s, e = string.match(k, ':(%d+)-(%d+):[^:]+$')
+  if s and e then
+    s, e = tonumber(s), tonumber(e)
+    if s < new_e and new_s < e then
+      local v = redis.call('GET', k)
+      table.insert(conflicts, k .. '=' .. (v or ''))
+    end
+  end
+end
+if #conflicts > 0 then return conflicts end
+local key = 'lock:addr:' .. ARGV[1] .. ':' .. ARGV[2] .. '-' .. ARGV[3] .. ':' .. ARGV[7]
+local payload = cjson.encode({module=ARGV[1], start=new_s, stop=new_e, holder=ARGV[5], note=ARGV[6], acquired_at=ARGV[8]})
+redis.call('SET', key, payload, 'PX', ARGV[4])
+return {}
+"""
+
+# ARGV = [module, start, end, holder, force]
+_RELEASE_RANGE = """
+local pattern = 'lock:addr:' .. ARGV[1] .. ':' .. ARGV[2] .. '-' .. ARGV[3] .. ':*'
+local existing = redis.call('KEYS', pattern)
+local released = {}
+for i, k in ipairs(existing) do
+  local v = redis.call('GET', k)
+  if v then
+    local ok, data = pcall(cjson.decode, v)
+    if ok and (data.holder == ARGV[4] or ARGV[5] == '1') then
+      redis.call('DEL', k)
+      table.insert(released, k)
+    end
+  end
+end
+return released
+"""
+
+# ARGV = [module, start, end, ttl_ms, holder]
+_RENEW_RANGE = """
+local pattern = 'lock:addr:' .. ARGV[1] .. ':' .. ARGV[2] .. '-' .. ARGV[3] .. ':*'
+local existing = redis.call('KEYS', pattern)
+local renewed = {}
+for i, k in ipairs(existing) do
+  local v = redis.call('GET', k)
+  if v then
+    local ok, data = pcall(cjson.decode, v)
+    if ok and data.holder == ARGV[5] then
+      redis.call('PEXPIRE', k, ARGV[4])
+      table.insert(renewed, k)
+    end
+  end
+end
+return renewed
+"""
+
+
+class LockError(RuntimeError):
+    pass
+
+
+def _client():
+    c = redis.from_url(REDIS_URL, decode_responses=True)
+    try:
+        c.ping()
+    except redis.exceptions.ConnectionError as e:
+        raise LockError(
+            f"can't reach redis at {REDIS_URL} -- start it with "
+            f"'docker compose -f local-infra/docker-compose.yml up -d' ({e})"
+        )
+    return c
+
+
+def _norm_file(p):
+    path = pathlib.Path(p)
+    try:
+        path = path.resolve().relative_to(REPO)
+    except ValueError:
+        path = pathlib.Path(p)
+    return "lock:file:" + path.as_posix()
+
+
+def _now():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def acquire(c, files=None, addr_range=None, holder=HOLDER, note="", ttl=DEFAULT_TTL_S,
+            wait=0, poll=3):
+    """addr_range = (module, start, end) ints. Returns (ok, conflicts:list[str])."""
+    file_keys = [_norm_file(f) for f in (files or [])]
+    ttl_ms = str(int(ttl * 1000))
+    deadline = time.time() + wait
+
+    while True:
+        conflicts = []
+        range_acquired = False
+
+        if addr_range:
+            module, start, end = addr_range
+            rid = uuid.uuid4().hex[:8]
+            res = c.eval(_ACQUIRE_RANGE, 0, module, start, end, ttl_ms, holder, note,
+                        rid, _now())
+            if res:
+                conflicts.extend(res)
+            else:
+                range_acquired = True
+
+        if not conflicts and file_keys:
+            res = c.eval(_ACQUIRE_EXACT, len(file_keys), *file_keys, ttl_ms, holder,
+                        note, _now())
+            if res:
+                conflicts.extend(res)
+                if range_acquired:
+                    # roll back so the whole acquire() call is all-or-nothing
+                    module, start, end = addr_range
+                    c.eval(_RELEASE_RANGE, 0, module, start, end, holder, "1")
+
+        if not conflicts:
+            return True, []
+        if time.time() >= deadline:
+            return False, conflicts
+        time.sleep(poll)
+
+
+def release(c, files=None, addr_range=None, holder=HOLDER, force=False):
+    released = []
+    if files:
+        file_keys = [_norm_file(f) for f in files]
+        rel, kept = c.eval(_RELEASE_EXACT, len(file_keys), *file_keys, holder,
+                           "1" if force else "0")
+        released.extend(rel)
+        if kept:
+            print(f"  not released (held by someone else): {kept}", file=sys.stderr)
+    if addr_range:
+        module, start, end = addr_range
+        rel = c.eval(_RELEASE_RANGE, 0, module, start, end, holder, "1" if force else "0")
+        released.extend(rel)
+    return released
+
+
+def renew(c, files=None, addr_range=None, holder=HOLDER, ttl=DEFAULT_TTL_S):
+    ttl_ms = str(int(ttl * 1000))
+    renewed = []
+    if files:
+        file_keys = [_norm_file(f) for f in files]
+        r, missing = c.eval(_RENEW_EXACT, len(file_keys), *file_keys, ttl_ms, holder)
+        renewed.extend(r)
+        if missing:
+            print(f"  not renewed (expired or not yours): {missing}", file=sys.stderr)
+    if addr_range:
+        module, start, end = addr_range
+        r = c.eval(_RENEW_RANGE, 0, module, start, end, ttl_ms, holder)
+        renewed.extend(r)
+    return renewed
+
+
+def _display_key(k):
+    """lock:addr:<module>:<start>-<end>:<id> -> same with start/end in hex, for
+    printing only; the decimal form in Redis is untouched."""
+    parts = k.split(":")
+    if len(parts) == 5 and parts[0] == "lock" and parts[1] == "addr":
+        span = parts[3]
+        if "-" in span:
+            s, e = span.split("-", 1)
+            if s.isdigit() and e.isdigit():
+                parts[3] = f"0x{int(s):08x}-0x{int(e):08x}"
+                return ":".join(parts)
+    return k
+
+
+def list_locks(c, module=None):
+    rows = []
+    for k in c.scan_iter("lock:*"):
+        v = c.get(k)
+        ttl = c.pttl(k)
+        if v is None:
+            continue
+        try:
+            data = json.loads(v)
+        except ValueError:
+            data = {}
+        if module and not (k.startswith(f"lock:addr:{module}:") or module == "*"):
+            continue
+        rows.append((_display_key(k), data.get("holder", "?"), data.get("note", ""),
+                    round(ttl / 1000, 1) if ttl and ttl > 0 else "?"))
+    return rows
+
+
+def _parse_addr(s):
+    return int(s, 0)
+
+
+def main():
+    a = sys.argv
+    if len(a) < 2:
+        print(__doc__)
+        return
+
+    def opt(name, default=None):
+        return a[a.index(name) + 1] if name in a else default
+
+    def flag(name):
+        return name in a
+
+    def multi(name):
+        if name not in a:
+            return []
+        out, i = [], a.index(name) + 1
+        while i < len(a) and not a[i].startswith("--"):
+            out.append(a[i])
+            i += 1
+        return out
+
+    cmd = a[1]
+    files = multi("--files") or None
+    range_args = multi("--range")
+    addr_range = (range_args[0], _parse_addr(range_args[1]), _parse_addr(range_args[2])) \
+        if len(range_args) == 3 else None
+    holder = opt("--holder", HOLDER)
+    note = opt("--note", "")
+    ttl = float(opt("--ttl", DEFAULT_TTL_S))
+    wait = float(opt("--wait", 0))
+    force = flag("--force")
+
+    if not files and not addr_range and cmd in ("acquire", "release", "renew", "check"):
+        print("need --files <path...> and/or --range <module> <start> <end>", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        c = _client()
+    except LockError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if cmd == "acquire":
+        ok, conflicts = acquire(c, files, addr_range, holder, note, ttl, wait)
+        if ok:
+            print(f"acquired (holder={holder}, ttl={ttl:.0f}s)")
+        else:
+            print("CONFLICT -- held by someone else:")
+            for line in conflicts:
+                key, _, rest = line.partition("=")
+                print(f"  {_display_key(key)}={rest}")
+            sys.exit(1)
+    elif cmd == "release":
+        released = [_display_key(k) for k in release(c, files, addr_range, holder, force)]
+        print(f"released: {released}" if released else "nothing released")
+    elif cmd == "renew":
+        renewed = [_display_key(k) for k in renew(c, files, addr_range, holder, ttl)]
+        print(f"renewed (ttl={ttl:.0f}s): {renewed}" if renewed else "nothing renewed")
+    elif cmd == "check":
+        rows = list_locks(c, addr_range[0] if addr_range else None)
+        keys_of_interest = set([_norm_file(f) for f in (files or [])])
+        for k, h, note_, ttl_left in rows:
+            if files and k not in keys_of_interest:
+                continue
+            print(f"  {k}  holder={h}  ttl={ttl_left}s  note={note_!r}")
+        if not rows:
+            print("  free")
+    elif cmd == "list":
+        module = opt("--module", "*")
+        for k, h, note_, ttl_left in list_locks(c, module):
+            print(f"  {k}  holder={h}  ttl={ttl_left}s  note={note_!r}")
+    else:
+        print(__doc__)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/agentlock_web.py
+++ b/tools/agentlock_web.py
@@ -1,0 +1,175 @@
+"""Tiny read-only dashboard over the local agent-lock Redis instance. Zero
+abstraction on purpose: each request queries Redis directly and renders plain HTML
+strings -- no framework, no templating engine, no JS, no build step. Auto-refreshes
+via <meta http-equiv="refresh">.
+
+Two reports:
+  1. Active locks  - every held lock (files and ranges), flat, TTL-sorted.
+  2. Ranges by module - address-range locks grouped and sorted by start address,
+     so an overlap or a gap is visible at a glance.
+
+Usage:
+    python tools/agentlock_web.py [--port 8787]
+Then open http://127.0.0.1:8787/
+"""
+import argparse
+import html
+import json
+import time
+from collections import defaultdict
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import agentlock  # sibling module: reused only for the Redis connection helper
+
+
+def _gather(c):
+    files, ranges = [], []
+    for k in c.scan_iter("lock:*"):
+        v = c.get(k)
+        if v is None:
+            continue
+        ttl_ms = c.pttl(k)
+        ttl_s = ttl_ms / 1000 if ttl_ms and ttl_ms > 0 else None
+        try:
+            data = json.loads(v)
+        except ValueError:
+            data = {}
+        parts = k.split(":", 3)
+        holder = data.get("holder", "?")
+        note = data.get("note", "")
+        acquired_at = data.get("acquired_at", "")
+        if parts[1] == "file":
+            files.append({"resource": parts[2] if len(parts) > 2 else k, "holder": holder,
+                          "note": note, "ttl": ttl_s, "acquired_at": acquired_at})
+        elif parts[1] == "addr":
+            module = parts[2]
+            span = parts[3].rsplit(":", 1)[0]  # drop the trailing random id
+            s, e = span.split("-")
+            ranges.append({"module": module, "start": int(s), "end": int(e),
+                           "holder": holder, "note": note, "ttl": ttl_s,
+                           "acquired_at": acquired_at})
+    return files, ranges
+
+
+def _esc(s):
+    return html.escape(str(s), quote=True)
+
+
+def _ttl_cell(ttl_s):
+    if ttl_s is None:
+        return "<td>?</td>"
+    css = ' class="soon"' if ttl_s < 60 else ""
+    return f"<td{css}>{ttl_s:.0f}s</td>"
+
+
+def _report_active(files, ranges):
+    rows = []
+    for f in sorted(files, key=lambda r: r["ttl"] if r["ttl"] is not None else 1e18):
+        rows.append("<tr><td>file</td><td colspan=2>{}</td><td>{}</td>{}<td>{}</td></tr>".format(
+            _esc(f["resource"]), _esc(f["holder"]), _ttl_cell(f["ttl"]), _esc(f["note"])))
+    for r in sorted(ranges, key=lambda r: r["ttl"] if r["ttl"] is not None else 1e18):
+        span = f"0x{r['start']:08x}-0x{r['end']:08x}"
+        rows.append("<tr><td>range</td><td>{}</td><td>{}</td><td>{}</td>{}<td>{}</td></tr>".format(
+            _esc(r["module"]), span, _esc(r["holder"]), _ttl_cell(r["ttl"]), _esc(r["note"])))
+    body = "\n".join(rows) or '<tr><td colspan="6"><em>nothing held</em></td></tr>'
+    return f"""
+<h2>Active locks ({len(files)} files, {len(ranges)} ranges)</h2>
+<table>
+  <tr><th>kind</th><th>module</th><th>resource</th><th>holder</th><th>ttl</th><th>note</th></tr>
+  {body}
+</table>
+"""
+
+
+def _report_by_module(ranges):
+    by_module = defaultdict(list)
+    for r in ranges:
+        by_module[r["module"]].append(r)
+    if not by_module:
+        return "<h2>Ranges by module</h2><p><em>no address-range locks held</em></p>"
+    sections = []
+    for module in sorted(by_module):
+        rows = sorted(by_module[module], key=lambda r: r["start"])
+        trs = "\n".join(
+            "<tr><td>0x{:08x}</td><td>0x{:08x}</td><td>{}</td>{}<td>{}</td></tr>".format(
+                r["start"], r["end"], _esc(r["holder"]), _ttl_cell(r["ttl"]), _esc(r["note"]))
+            for r in rows)
+        sections.append(f"""
+<h3>{_esc(module)}</h3>
+<table>
+  <tr><th>start</th><th>end</th><th>holder</th><th>ttl</th><th>note</th></tr>
+  {trs}
+</table>
+""")
+    return "<h2>Ranges by module</h2>" + "\n".join(sections)
+
+
+PAGE = """<!doctype html>
+<html><head>
+<meta http-equiv="refresh" content="3">
+<title>agent-lock</title>
+<style>
+  body {{ font-family: ui-monospace, monospace; margin: 2rem; background: #111; color: #ddd; }}
+  h1 {{ font-size: 1.1rem; color: #888; }}
+  h2 {{ margin-top: 2rem; }}
+  h3 {{ color: #9cf; margin-bottom: 0.3rem; }}
+  table {{ border-collapse: collapse; width: 100%; margin-bottom: 1rem; }}
+  th, td {{ border: 1px solid #333; padding: 0.3rem 0.6rem; text-align: left; font-size: 0.9rem; }}
+  th {{ background: #1c1c1c; }}
+  td.soon {{ color: #f66; font-weight: bold; }}
+  .meta {{ color: #666; font-size: 0.8rem; }}
+</style>
+</head><body>
+<h1>sm64ds-decomp local agent-lock -- {holder_count} holder(s) active</h1>
+<p class="meta">source: {redis_url} -- refreshes every 3s -- read-only</p>
+{report1}
+{report2}
+</body></html>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != "/":
+            self.send_response(404)
+            self.end_headers()
+            return
+        try:
+            c = agentlock._client()
+            files, ranges = _gather(c)
+            holders = {r["holder"] for r in files} | {r["holder"] for r in ranges}
+            page = PAGE.format(
+                holder_count=len(holders),
+                redis_url=_esc(agentlock.REDIS_URL),
+                report1=_report_active(files, ranges),
+                report2=_report_by_module(ranges),
+            )
+            status = 200
+        except agentlock.LockError as e:
+            page = f"<!doctype html><pre>can't reach redis: {_esc(e)}</pre>"
+            status = 503
+        body = page.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        pass  # quiet; this is a local dev dashboard, not a service to audit
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8787)
+    args = ap.parse_args()
+    srv = HTTPServer(("127.0.0.1", args.port), Handler)
+    print(f"agent-lock dashboard: http://127.0.0.1:{args.port}/  (ctrl-c to stop)")
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Several agents work this tree at once in separate worktrees, and nothing stopped two of them editing the same file. `agentlock.py` leases paths through a local Redis so a second agent asking for a held file is told who holds it and when the lease expires, instead of discovering the collision in a merge.

| file | what it is |
|---|---|
| `tools/agentlock.py` | acquire / renew / release / status, TTL leases |
| `tools/agentlock_web.py` | read-only view of what is held right now |
| `.claude/skills/agent-lock/SKILL.md` | how an agent is meant to use it |
| `local-infra/` | docker-compose for the Redis it needs, plus setup notes |

**Local developer infrastructure only.** Nothing here is imported by the ROM build, by any gate, or by any tool on the build path, so it cannot move a byte.