### PR TITLE
Re-point two stranded src_tu shadow TUs at their inherited base members

### DIFF
--- a/src_tu/actors/CastleWater.cpp
+++ b/src_tu/actors/CastleWater.cpp
@@ -122,7 +122,7 @@ extern "C" int *CastleWater_Spawn(void)
  * the water publishes a plane the rest of the level reads rather than keeping
  * its height to itself.
  *
- * The collider is given mMatrix and mAngleY directly, which is why those two
+ * The collider is given mClsnMat and mAngleY directly, which is why those two
  * are real members rather than markers.
  */
 int CastleWater::InitResources()
@@ -145,7 +145,7 @@ int CastleWater::InitResources()
     {
         struct KCL_File *kcl = _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(data_ov009_02113c70);
         _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-            &mMeshCollider, kcl, mMatrix, 0x1000, mAngleY, data_ov009_02112c38);
+            &mMeshCollider, kcl, mClsnMat, 0x1000, mAngleY, data_ov009_02112c38);
     }
     ((dBgW *)&mMeshCollider)->Enable((dActor_c *)(self));
     {

--- a/src_tu/actors/SwitchActivatedPlank.cpp
+++ b/src_tu/actors/SwitchActivatedPlank.cpp
@@ -139,7 +139,7 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         }
         *p = *p + 1;
         if (_ZN5Event6GetBitEj(self->mEventID) != 0) break;
-        ((dBgW *)((char*)&self->mMovingMeshCollider))->Disable();
+        ((dBgW *)((char*)&self->mMeshCollider))->Disable();
         self->mState = 0;
         self->mVisible = 0;
         break;
@@ -180,8 +180,8 @@ int SwitchActivatedPlank::Render()
 
 int SwitchActivatedPlank::CleanupResources()
 {
-    if (((dBgW *)((char *)&mMovingMeshCollider))->IsEnabled()) {
-        ((dBgW *)((char *)&mMovingMeshCollider))->Disable();
+    if (((dBgW *)((char *)&mMeshCollider))->IsEnabled()) {
+        ((dBgW *)((char *)&mMeshCollider))->Disable();
     }
     ((SharedFilePtr *)&data_ov029_0211432c)->Release();
     ((SharedFilePtr *)&data_ov029_02114324)->Release();


### PR DESCRIPTION
#1778 and #1792 converted `CastleWater` and `SwitchActivatedPlank` from flat structs that restated `dBgActor_c`'s fields into real subclasses of it. Both members those shadow TUs reach for now come from the base under the base's names, and neither TU was updated:

| file | was | now | offset |
|---|---|---|---|
| `src_tu/actors/CastleWater.cpp:148` | `mMatrix` | `mClsnMat` | `0x2ec` |
| `src_tu/actors/SwitchActivatedPlank.cpp:142,183,184` | `mMovingMeshCollider` | `mMeshCollider` | `0x124` |

Renames only, in files nothing links. `src_tu/` is not in the ROM build, so **no byte moves**.

### Why CI did not catch it

`src-tu-refs.yml` runs only `check_src_tu.py`, the reference half. The compile half is `check_src_tu_compiles.py`, which needs mwccarm and so runs in the pre-push hook instead — the workflow says as much in its own comment. Both PRs were correctly green.

The failure surfaces only on push, where it refuses the **whole** push and pressures the next person into `--no-verify` — which also switches off `check_references`, `eligible`, `port_refcheck`, `prepush_attribution` and `prepush_linkcheck`. That is the actual cost: not this breakage, but the next one hiding behind the same override.

### Result

`check_src_tu_compiles` goes **68/72 → 70/72**. Untouched and unrelated: `arm9/Actor` (`'dBgCh_Lin' redefined`), `ov077/HeaveHo` (internal compiler error at `CClass.c:3328`), and the stranded manifest record for `src/actors/ActorBase_SceneNode.cpp`.

Same defect as #1667 and #1669 — the gate they added is the one that caught it.