### PR TITLE
Fix two dead references that turned main's reference gate red

### DIFF
--- a/notes/plan-cpp-conversion-queue.md
+++ b/notes/plan-cpp-conversion-queue.md
@@ -14,7 +14,7 @@ Planned 2026-08-25. No builds were run during planning.
 
 | census said | tree says | impact |
 |---|---|---|
-| 19 of the 330 already compile as C++ → **311** un-migrated | **15** active, 1 inert, 314 bare → **315** un-migrated. The 15 are all `src/func_ov006_*.c`; 19 `.c` files tree-wide carry an active marker but 4 are tier P3/P4, outside the 330 | stage sizing |
+| 19 of the 330 already compile as C++ → **311** un-migrated | **15** active, 1 inert, 314 bare → **315** un-migrated. The 15 are all `func_ov006_*.c` files under `src/`; 19 `.c` files tree-wide carry an active marker but 4 are tier P3/P4, outside the 330 | stage sizing |
 | 3 inert-marker violators "in the positive pool" | only **1** (`src/_ZN7dWipe_c15SetBackwardTimeEj.c`) is in the 1,167. `src/func_0204322c.c` is WEAK-refs-only, `src/func_ov075_0211b1cc.c` is PURE-C | two are not this workstream's problem |
 | — | **262 of the 315** un-migrated direct files are in `build/eligible-names.txt`; **53 are not** | the 53 have no per-file byte gate → TU-work or nothing |
 | — | of the 55 safe-pool TUs containing a provably-C++ `.c`, **all 55 are direct-seeded. Zero purely-transitive safe TUs exist.** | the 837 transitive files split 203 (inside direct-seeded safe TUs) / 634 (blocked TUs). There is no "transitive-only merge" to schedule |
@@ -171,7 +171,11 @@ unaffected by virtualness, and not declaring them `virtual` is what keeps this f
 becoming the key-function TU and emitting `_ZTV` — the exact trap the class-form skill
 warns about. **Preserve that; do not "fix" it to `virtual`.**
 
-The exact edit (`src/_ZN12FallBlockBfs13InitResourcesEv.c`, `0x02111e10`, size `0x14`, ov045):
+**SINCE LANDED.** This pilot went in with #1684, essentially as written below; the
+file is now `src/_ZN12FallBlockBfs13InitResourcesEv.cpp`. Kept because the reasoning
+above it is what the rest of the queue rests on.
+
+The exact edit (`src/_ZN12FallBlockBfs13InitResourcesEv.cpp`, `0x02111e10`, size `0x14`, ov045):
 
 ```cpp
 //cpp
@@ -185,7 +189,7 @@ This is a **real** migration: the compiler mangles the name. Verify that claim w
 oracle **before** the byte gate — it needs no ROM and no serialization:
 
 ```
-python tools/mangle.py src/_ZN12FallBlockBfs13InitResourcesEv.c \
+python tools/mangle.py src/_ZN12FallBlockBfs13InitResourcesEv.cpp \
     --expect _ZN12FallBlockBfs13InitResourcesEv
 ```
 
@@ -341,8 +345,8 @@ python tools/match.py --c src/func_ov027_02111680.c \
 and the pilot deliberately excludes:
 
 ```
-python tools/mangle.py src/_ZN12FallBlockBfs13InitResourcesEv.c --expect _ZN12FallBlockBfs13InitResourcesEv
-python tools/match.py --c src/_ZN12FallBlockBfs13InitResourcesEv.c \
+python tools/mangle.py src/_ZN12FallBlockBfs13InitResourcesEv.cpp --expect _ZN12FallBlockBfs13InitResourcesEv
+python tools/match.py --c src/_ZN12FallBlockBfs13InitResourcesEv.cpp \
     --func _ZN12FallBlockBfs13InitResourcesEv --addr 0x02111e10 --size 0x14 --module ov045
 ```
 


### PR DESCRIPTION
**`main` is currently red.** #1821 merged while its `references` check was still running, so two stale citations in `notes/plan-cpp-conversion-queue.md` reached `main`, and `dead references` has been failing on `05463a6cf` since.

| citation | fix |
|---|---|
| `src/_ZN12FallBlockBfs13InitResourcesEv.c` | → `.cpp` |
| ```src/func_ov006_*.c``` | → ```func_ov006_*.c``` files under `src/` |

The first is real staleness with a pleasing cause: **the pilot that note proposes has since landed**, in #1684 and essentially as written, so the file is a `.cpp` now. The note was describing finished work in the future tense. It now says the pilot landed and keeps the reasoning above it, which is what the rest of the queue rests on.

The second is a glob that `check_dead_references` reads as a literal path — and it was right, `src/func_ov006_` does not exist.

Prose only. No code, no build impact.