### PR TITLE
notes: follow the Particle::SysTracker rename into the two provenance notes

### DIFF
--- a/notes/scene-provenance.md
+++ b/notes/scene-provenance.md
@@ -165,7 +165,7 @@ not the same as the last field the object has. The trailing `pad_9c0[0x8]` and t
 
 **`Particle::SysTracker`, embedded at `Stage+0x50`.** Not its own header yet:
 `include/Particle.h` and `include/Particle__SysTracker.h` are two *separate*
-`gen_header.py` shadows of this same class. `src/_ZN8Particle10SysTrackerC1Ev.c` writes
+`gen_header.py` shadows of this same class. `src/_ZN8Particle10SysTrackerC1Ev.cpp` writes
 fields through `struct Particle *self` up to `unk_818`, while
 `src/_ZN8Particle10SysTracker10InitialiseEv.cpp` and `6UpdateEv.c` read `mManager`/`mContents`
 through `struct Particle__SysTracker *self` — the same offsets `Particle.h` also

--- a/notes/system-provenance.md
+++ b/notes/system-provenance.md
@@ -103,7 +103,7 @@ because both objects start with a pointer-sized word. It now takes `char *`.
 
 `include/Particle__SysTracker.h` is a *third* declaration of this class, and it
 is what `src/_ZN8Particle10SysTracker10InitialiseEv.cpp` and
-`src/_ZN8Particle10SysTracker6UpdateEv.c` include. A later pass that owned the
+`src/_ZN8Particle10SysTracker6UpdateEv.cpp` include. A later pass that owned the
 file finished it: its three fields now read `mResourceFile` / `mManager` /
 `mContents`, with the same types `include/Particle.h` carries, so all three
 declarations of the class spell the head identically.


### PR DESCRIPTION
#1830 renamed `src/_ZN8Particle10SysTrackerC1Ev` and `..._6UpdateEv` to `.cpp` and left `notes/scene-provenance.md` and `notes/system-provenance.md` naming the `.c` paths, so `check_dead_references` on main is red.

Two lines, `.c` → `.cpp`. `check_dead_references`: 3194 repo-rooted path references, **0 that do not resolve**.

Worth noting for anyone who trusted the pre-merge run: the local check passed on #1830 because the 139-entry baseline absorbs these, and only the CI run flags them. The CI run is the one that is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TiV5Eyo3WLiA4UCNiYLX4