### PR TITLE
Three gates on main: two TUs that stopped compiling, a miscounted promoted TU, and a dead-reference gate that could not fail locally

### DIFF
--- a/notes/ctor-migration.md
+++ b/notes/ctor-migration.md
@@ -396,8 +396,11 @@ no vtable. An ABI probe settles the shape: dBgPi introduces the virtual
 destructor and derives from the non-polymorphic dBgPc. With no dynamic primary
 base, the compiler places dBgPi's own vptr at +0x00 and its dBgPc base at +0x04.
 The generated C2 sequence therefore constructs dBgPc at +0x04 before storing
-dBgPi's vptr. C1 now lives in `src/_ZN5dBgPiC1Ev.cpp` as real C++; the separately
-enrolled C2 ABI variant remains in `src/_ZN5dBgPiC2Ev.c`.
+dBgPi's vptr. C1 now lives in `src/_ZN5dBgPiC1Ev.cpp` as real C++, and since
+#1833 so does the separately enrolled C2 ABI variant, in
+`src/_ZN5dBgPiC2Ev.cpp`. The two files carry the same definition -- C1 and C2
+are two of the functions mwcc emits from one constructor, and
+`config/arm9/delinks.txt` binds each file to one of them.
 
 ## 6. The recipe, condensed
 

--- a/src_tu/actors/Actor.cpp
+++ b/src_tu/actors/Actor.cpp
@@ -1734,17 +1734,17 @@ extern "C" int _ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(dActor_c *self, in
 /* -------------------------------------------------------------------------- */
 /* ROM ordinal 0 -- _ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b
  * 0x0200f658  size 0xb4   legacy src/_ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b.cpp */
-struct dBgCh_Lin { char data[0x78]; };
+struct dBgCh_LinPad { char data[0x78]; };
 extern "C" {
-extern void _ZN9dBgCh_LinC1Ev(dBgCh_Lin*);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(dBgCh_Lin*, const Vector3*, const Vector3*, dActor_c*);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(dBgCh_Lin*);
+extern void _ZN9dBgCh_LinC1Ev(dBgCh_LinPad*);
+extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(dBgCh_LinPad*, const Vector3*, const Vector3*, dActor_c*);
+extern int _ZN9dBgCh_Lin10DetectClsnEv(dBgCh_LinPad*);
 extern Vector3* func_02037dc4(void*);
-extern void _ZN9dBgCh_LinD1Ev(dBgCh_Lin*);
+extern void _ZN9dBgCh_LinD1Ev(dBgCh_LinPad*);
 }
 extern "C" {
 int _ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b(dActor_c *self, Vector3 *a, Vector3 *out, int doStore){
-  dBgCh_Lin rl;
+  dBgCh_LinPad rl;
   _ZN9dBgCh_LinC1Ev(&rl);
   _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(&rl, a, (const Vector3*)out, 0);
   if(_ZN9dBgCh_Lin10DetectClsnEv(&rl)){

--- a/src_tu/actors/HeaveHo.cpp
+++ b/src_tu/actors/HeaveHo.cpp
@@ -647,9 +647,9 @@ extern "C" void func_ov077_02126528(char *c)
 extern "C" {  /* .c-derived member: C linkage for the whole block */
 /* (Vector3: real header type in scope) */
 
-typedef struct dBgCh_Lin {
+typedef struct dBgCh_LinPad {
     char pad[0x78];
-} dBgCh_Lin;
+} dBgCh_LinPad;
 
 extern signed char data_0209f2f8;
 extern char data_020a0e68[];
@@ -666,8 +666,8 @@ extern void MulVec3Mat4x3(void *in, void *m, void *out);
 int func_ov077_02126300(void *vc)
 {
     char *c = (char *)vc;
-    dBgCh_Lin ray1;
-    dBgCh_Lin ray2;
+    dBgCh_LinPad ray1;
+    dBgCh_LinPad ray2;
     Vector3 start;
     Vector3 end;
     Vector3 dir;

--- a/tools/check_dead_references.py
+++ b/tools/check_dead_references.py
@@ -244,6 +244,15 @@ def _git_ignored(candidates, root=REPO):
     does not, so the bare form MISSES and only `tools/mwccarm/` matches. Asking both is
     what makes the answer independent of whether the input happens to be present.
 
+    `-v`, and a hit is kept only when git names a NON-EMPTY pattern. That is not
+    decoration. On git 2.50.1.windows.1 a trailing-slash probe matches a BLANK LINE in
+    .gitignore -- asking it about ANY path with a trailing slash answers with the line
+    number of a blank line and an empty pattern -- so every probe came back ignored, `_git_ignored` returned the
+    whole candidate set, and the gate reported 0 dead references on any tree. It was
+    green locally and red in CI for months, which is how two stale paths landed. An
+    empty pattern is never a real rule, so dropping it costs nothing and restores the
+    answer git actually means.
+
     LIMIT, stated rather than papered over: `git check-ignore` answers from the ignore
     RULES, not from the filesystem, so it reports a path under `tools/mwccarm/` as
     ignored whether or not that file exists. A genuinely dead reference INSIDE an
@@ -260,16 +269,21 @@ def _git_ignored(candidates, root=REPO):
     # on Windows, git takes the CR as part of the filename, and every answer
     # comes back quoted with a stray carriage return -- so nothing matches and every
     # gitignored input looks dead again. -z sidesteps the newline question entirely.
-    out = subprocess.run(["git", "check-ignore", "-z", "--stdin"], cwd=root,
+    out = subprocess.run(["git", "check-ignore", "-v", "-z", "--stdin"], cwd=root,
                          input=NUL.join(c.encode("utf-8") for c in probes),
                          capture_output=True)
     # exit 0 = at least one ignored, 1 = none ignored; both are normal. Anything
     # else (128: not a repo) means we could not classify, so claim nothing.
     if out.returncode not in (0, 1):
         return set()
+    # -v -z emits four NUL-separated fields per hit: source, line, pattern, pathname.
+    fields = out.stdout.split(NUL)
     hits = set()
-    for raw in out.stdout.split(NUL):
-        name = raw.decode("utf-8", "replace").strip().replace("\\", "/")
+    for i in range(0, len(fields) - 3, 4):
+        pattern = fields[i + 2].decode("utf-8", "replace").strip()
+        if not pattern:
+            continue          # a blank .gitignore line matches nothing; see the docstring
+        name = fields[i + 3].decode("utf-8", "replace").strip().replace("\\", "/")
         if name:
             hits.add(name.rstrip("/"))
     return hits

--- a/tools/check_src_tu_compiles.py
+++ b/tools/check_src_tu_compiles.py
@@ -178,7 +178,13 @@ def check(manifest_path=MANIFEST, root=None, only=(), version_override=None,
                                   "a translation unit on disk that the manifest does not "
                                   "declare -- nothing knows its compiler pin, so nothing "
                                   "compiles it and this gate cannot vouch for it"))
+        # `on_disk` only walks `root`, so a TU that has been PROMOTED out of src_tu
+        # into the real build tree (status "promoted", source under src/) is absent
+        # from it while being perfectly present -- and it is still compiled below, so
+        # the "one fewer TU checked" half of the claim is false too. Ask the disk.
         for stranded in sorted(declared - on_disk):
+            if (REPO / stranded).is_file():
+                continue
             failures.append(_fail("coverage", stranded,
                                   "the manifest declares this source and it is not on "
                                   "disk -- a stranded record, and one fewer TU checked "

--- a/tools/test_check_src_tu_compiles.py
+++ b/tools/test_check_src_tu_compiles.py
@@ -191,6 +191,21 @@ class WorkListTests(unittest.TestCase):
             self.assertFalse(report["ok"])
             self.assertTrue(failures_of(report, "coverage"))
 
+    def test_a_declared_source_outside_the_scan_root_is_not_stranded(self):
+        """A TU PROMOTED out of src_tu into the real build tree (status "promoted",
+        source under src/) is absent from a walk of src_tu while being perfectly
+        present -- and the gate compiles it either way, so "one fewer TU checked"
+        was false as well. The scan root is a place to look, not the definition of
+        existence."""
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            (s.dir / "elsewhere").mkdir()
+            report = CC.check(s.manifest(s.entry()), s.dir / "elsewhere",
+                              include_dirs=[s.dir])
+            self.assertEqual(failures_of(report, "coverage"), [])
+            self.assertTrue(report["ok"])
+            self.assertEqual(report["checked"]["compiled"], 1)
+
     def test_a_missing_manifest_fails(self):
         report = CC.check(REPO / "build" / "no-such-manifest.json", REPO / "src_tu")
         self.assertFalse(report["ok"])

--- a/tools/test_dead_references.py
+++ b/tools/test_dead_references.py
@@ -2,6 +2,7 @@
 import json
 import pathlib
 import subprocess
+import sys
 import tempfile
 import pytest
 
@@ -84,6 +85,40 @@ class TestGitIgnored:
         ignored = _git_ignored(["tools/mwccarm"], REPO)
         # Should be treated as matching the directory pattern
         assert "tools/mwccarm" in ignored or len(ignored) > 0
+
+    def test_a_path_no_rule_covers_is_not_reported_ignored(self):
+        """The positive control the other tests in this class lack.
+
+        Every assertion above is `len(ignored) > 0`, which a function returning its
+        whole input satisfies -- and on git 2.50.1.windows.1 that is precisely what
+        _git_ignored did, because the trailing-slash probe matched a BLANK LINE in
+        .gitignore. The gate reported 0 dead references on every tree for months while
+        CI reported 130. Assert the other direction too.
+        """
+        ignored = _git_ignored(["src/no_rule_covers_this_zzz.c",
+                                "notes/no_rule_covers_this_zzz.md"], REPO)
+        assert ignored == set()
+
+    def test_an_empty_matching_pattern_is_not_a_hit(self):
+        """A blank .gitignore line names no pattern, so it ignores nothing."""
+        import subprocess as _sp
+
+        class _Out:
+            returncode = 0
+            # -v -z: source, line, pattern, pathname -- the middle entry has no pattern
+            stdout = NUL.join([b".gitignore", b"11", b"build/", b"build/x.o",
+                               b".gitignore", b"111", b"", b"src/dead_zzz.c/",
+                               b".gitignore", b"12", b"*.pyc", b"tools/x.pyc",
+                               b""])
+
+        real = _sp.run
+        CDR_mod = sys.modules[_git_ignored.__module__]
+        CDR_mod.subprocess.run = lambda *a, **k: _Out()
+        try:
+            hits = _git_ignored(["build/x.o", "src/dead_zzz.c", "tools/x.pyc"], REPO)
+        finally:
+            CDR_mod.subprocess.run = real
+        assert hits == {"build/x.o", "tools/x.pyc"}
 
     def test_deduplicates_candidates(self):
         """Duplicate candidates don't cause issues."""


### PR DESCRIPTION
Two gates are red on `main` today and neither is caused by a change under review. Both
refuse work that touches none of it — `check_src_tu_compiles` runs in the pre-push hook
for **every** branch, and `references` runs in CI on every PR.

## 1. A shadow struct named `dBgCh_Lin` (2 TUs)

`src_tu/actors/Actor.cpp` and `src_tu/actors/HeaveHo.cpp` each open a block with
their own placeholder for the collision-line class:

```cpp
struct dBgCh_Lin { char data[0x78]; };
```

In the `.c`-derived original that was the only `dBgCh_Lin` in scope. In a merged C++ TU
the real class arrives through a header first, so mwcc reports
`class 'dBgCh_Lin' redefined` — and then, 150 lines later, falls over:

```
src_tu/actors/HeaveHo.cpp:801: internal compiler error (report to <cw_bug@metrowerks.com>)
src_tu/actors/HeaveHo.cpp:801: while executing in file 'CClass.c' line: 3328
```

The ICE is **downstream of the redefinition**, not a second defect — renaming the
placeholder to `dBgCh_LinPad` clears both. The placeholder is still the right shape:
these bodies call `_ZN9dBgCh_LinC1Ev` / `D1Ev` explicitly and must not acquire implicit
ctor/dtor calls from the real class. Only the name changes.

`src_tu` is in no byte gate, which is why this sat unnoticed.

## 2. A promoted TU is not a stranded record

The coverage half of `check_src_tu_compiles` builds `on_disk` by walking the scan root
(`src_tu`) and calls every declared-but-unwalked source stranded, *"and one fewer TU
checked than the count would suggest"*.

Both halves are wrong for a **promoted** entry. The manifest carries one —
`arm9/ActorBase_SceneNode`, `status: "promoted"`, source
`src/actors/ActorBase_SceneNode.cpp`. The file is on disk, and the gate compiles it a
few lines further down regardless of which directory it lives in. Only the bookkeeping
complained. So ask the disk rather than the scan root.

**86/88 → 88/88**, 3 failures → 0.

## 3. The dead-reference gate could not fail on a developer machine

This one is the reason the other two were worth chasing.

`check_dead_references._git_ignored` asks `git check-ignore` about each candidate twice,
bare and with a trailing slash, because a directory-only rule like `tools/mwccarm/` only
matches the slashed form on a clean checkout. On **git 2.50.1.windows.1** the slashed
probe matches a **blank line** in `.gitignore`: git answers with that line's number and
an **empty pattern**, and reports the path as ignored.

So every probe came back ignored. `_git_ignored` returned its whole input,
`dead_references` subtracted that from the unresolved set, and the gate printed
`0 that do not resolve` on any tree. Measured before the fix — all four reported
ignored, including two fabricated paths:

```python
_git_ignored({'src/_ZN5dBgPiC2Ev.c', 'tools/claims_key.txt',
              'src/nonexistent_zzz.c', 'notes/definitely_not_here.md'})
```

Locally 0 dead references; on CI, same commit, **130**. That gap is how a stale path
reaches `main` — nobody sees the gate until it is someone else's PR.

The fix is to ask with `-v` and keep a hit only when git names a **non-empty** pattern.
An empty pattern is not a rule, so dropping it changes nothing where git behaves and
restores the answer git means where it does not. Local now reproduces CI exactly: 354
files, 3183 references, 129 unresolved, 10 baselined ones healed.

Worth noting how it survived: every test in `TestGitIgnored` asserts `len(ignored) > 0`,
which a function returning its whole input satisfies. Two that actually constrain it —
a positive control that a path no rule covers is **not** reported ignored, and a parser
test that an empty pattern is not a hit.

### And the one real dead reference it was hiding

`notes/ctor-migration.md` said the dBgPi C2 ABI variant *"remains in
`src/_ZN5dBgPiC2Ev.c`"*. Stale twice over: the file has been `.cpp` since it was
migrated, and #1833 rewrote the body as real C++ — so *"remains"* now reads as though it
were the un-migrated leftover of the pair when it is nothing of the kind.

## Verification

- `check_src_tu_compiles` **86/88 → 88/88**, 3 failures → 0
- `check_dead_references` — green, and now actually capable of being red locally
- `pytest tools/test_check_src_tu_compiles.py tools/test_tu_manifest.py tools/test_dead_references.py tools/test_check_dead_references.py` — all pass, plus the three new cases
- `port_refcheck` 407/407, `duplicate-sources` clean
- Nothing under `src/` or `config/` is touched, so the ROM build is untouched by construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VregK5ZWRa2NbUcneaprG6

