### PR TITLE
Fix promoted source coverage in src_tu compile gate

### DIFF
--- a/notes/ctor-migration.md
+++ b/notes/ctor-migration.md
@@ -397,7 +397,7 @@ destructor and derives from the non-polymorphic dBgPc. With no dynamic primary
 base, the compiler places dBgPi's own vptr at +0x00 and its dBgPc base at +0x04.
 The generated C2 sequence therefore constructs dBgPc at +0x04 before storing
 dBgPi's vptr. C1 now lives in `src/_ZN5dBgPiC1Ev.cpp` as real C++; the separately
-enrolled C2 ABI variant remains in `src/_ZN5dBgPiC2Ev.c`.
+enrolled C2 ABI variant remains in `src/_ZN5dBgPiC2Ev.cpp`.
 
 ## 6. The recipe, condensed
 

--- a/src_tu/actors/Actor.cpp
+++ b/src_tu/actors/Actor.cpp
@@ -1734,17 +1734,20 @@ extern "C" int _ZN8dActor_c22IsTooFarAwayFromPlayerE5Fix12IiE(dActor_c *self, in
 /* -------------------------------------------------------------------------- */
 /* ROM ordinal 0 -- _ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b
  * 0x0200f658  size 0xb4   legacy src/_ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b.cpp */
-struct dBgCh_Lin { char data[0x78]; };
+/* This legacy member used a 0x78-byte stack view plus explicit ABI calls.
+ * Keep that storage model distinct from the now-shared real dBgCh_Lin class,
+ * whose evidenced complete-object size is 0x84. */
+struct RaycastLineStorage { char data[0x78]; };
 extern "C" {
-extern void _ZN9dBgCh_LinC1Ev(dBgCh_Lin*);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(dBgCh_Lin*, const Vector3*, const Vector3*, dActor_c*);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(dBgCh_Lin*);
+extern void _ZN9dBgCh_LinC1Ev(RaycastLineStorage*);
+extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(RaycastLineStorage*, const Vector3*, const Vector3*, dActor_c*);
+extern int _ZN9dBgCh_Lin10DetectClsnEv(RaycastLineStorage*);
 extern Vector3* func_02037dc4(void*);
-extern void _ZN9dBgCh_LinD1Ev(dBgCh_Lin*);
+extern void _ZN9dBgCh_LinD1Ev(RaycastLineStorage*);
 }
 extern "C" {
 int _ZN8dActor_c17DetectRaycastClsnER7Vector3S1_b(dActor_c *self, Vector3 *a, Vector3 *out, int doStore){
-  dBgCh_Lin rl;
+  RaycastLineStorage rl;
   _ZN9dBgCh_LinC1Ev(&rl);
   _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(&rl, a, (const Vector3*)out, 0);
   if(_ZN9dBgCh_Lin10DetectClsnEv(&rl)){

--- a/src_tu/actors/HeaveHo.cpp
+++ b/src_tu/actors/HeaveHo.cpp
@@ -647,9 +647,12 @@ extern "C" void func_ov077_02126528(char *c)
 extern "C" {  /* .c-derived member: C linkage for the whole block */
 /* (Vector3: real header type in scope) */
 
-typedef struct dBgCh_Lin {
+/* This C-derived member owns a raw 0x78-byte stack view and drives its
+ * lifecycle through explicit ABI calls. It is not the complete 0x84-byte C++
+ * dBgCh_Lin object now exposed by the shared header. */
+typedef struct RaycastLineStorage {
     char pad[0x78];
-} dBgCh_Lin;
+} RaycastLineStorage;
 
 extern signed char data_0209f2f8;
 extern char data_020a0e68[];
@@ -666,8 +669,8 @@ extern void MulVec3Mat4x3(void *in, void *m, void *out);
 int func_ov077_02126300(void *vc)
 {
     char *c = (char *)vc;
-    dBgCh_Lin ray1;
-    dBgCh_Lin ray2;
+    RaycastLineStorage ray1;
+    RaycastLineStorage ray2;
     Vector3 start;
     Vector3 end;
     Vector3 dir;

--- a/tools/check_src_tu_compiles.py
+++ b/tools/check_src_tu_compiles.py
@@ -178,7 +178,13 @@ def check(manifest_path=MANIFEST, root=None, only=(), version_override=None,
                                   "a translation unit on disk that the manifest does not "
                                   "declare -- nothing knows its compiler pin, so nothing "
                                   "compiles it and this gate cannot vouch for it"))
-        for stranded in sorted(declared - on_disk):
+        # Promoted TUs live under src/, while shadow TUs live under src_tu/.
+        # `on_disk` intentionally scans only the shadow root so it can detect
+        # undeclared shadow files; it cannot decide whether a manifest source
+        # outside that root exists. Check every declared repo-relative path at
+        # its actual location instead.
+        for stranded in sorted(path for path in declared
+                               if not (REPO / path).is_file()):
             failures.append(_fail("coverage", stranded,
                                   "the manifest declares this source and it is not on "
                                   "disk -- a stranded record, and one fewer TU checked "

--- a/tools/test_check_src_tu_compiles.py
+++ b/tools/test_check_src_tu_compiles.py
@@ -191,6 +191,19 @@ class WorkListTests(unittest.TestCase):
             self.assertFalse(report["ok"])
             self.assertTrue(failures_of(report, "coverage"))
 
+    def test_a_promoted_source_may_live_outside_the_shadow_root(self):
+        """The manifest also describes production TUs under src/. Coverage must
+        check those at their repo-relative path, not pretend every source belongs
+        beneath the src_tu shadow root."""
+        with Scratch() as s:
+            s.write("Probe.h", HEADER_OK).write("Probe.cpp", UNIT)
+            shadow_root = s.dir / "shadow"
+            shadow_root.mkdir()
+            report = CC.check(s.manifest(s.entry()), shadow_root,
+                              include_dirs=[s.dir])
+            self.assertTrue(report["ok"], report["failures"])
+            self.assertEqual(report["checked"]["compiled"], 1)
+
     def test_a_missing_manifest_fails(self):
         report = CC.check(REPO / "build" / "no-such-manifest.json", REPO / "src_tu")
         self.assertFalse(report["ok"])


### PR DESCRIPTION
Teach the src_tu coverage pass to validate each manifest source at its repo-relative path, so promoted production TUs under src/ are not reported as missing. Also distinguish the legacy 0x78-byte raycast stack storage in Actor and HeaveHo from the real 0x84-byte dBgCh_Lin class. Verified with all 15 compile-gate regression tests, 88/88 TU compiles, 1,431 resolved TU symbol references, and 407/407 port references.