### PR TITLE
The BMP gate's precondition is base and span; the 16-byte .bss row measured nothing

### DIFF
--- a/config/dead-reference-baseline.json
+++ b/config/dead-reference-baseline.json
@@ -6,14 +6,6 @@
    "ref": "tools/CI/docs"
   },
   {
-   "file": "AGENTS.md",
-   "ref": "tools/claims_key.txt"
-  },
-  {
-   "file": "CONTRIBUTING.md",
-   "ref": "tools/claims_key.txt"
-  },
-  {
    "file": "notes/actor-leaf-provenance.md",
    "ref": "src_tu/actors/EnemySpawner"
   },
@@ -60,10 +52,6 @@
   {
    "file": "notes/archive/crack-loop-runbook.md",
    "ref": "notes/pret-idioms.md"
-  },
-  {
-   "file": "notes/archive/crack-loop-runbook.md",
-   "ref": "tools/claims_key.txt"
   },
   {
    "file": "notes/archive/func_02059d8c-asm-origin.md",
@@ -126,14 +114,6 @@
    "ref": "src/_ZN5EnemyD0Ev.c"
   },
   {
-   "file": "notes/dtor-migration.md",
-   "ref": "src/_ZN5ModelD1Ev.cpp"
-  },
-  {
-   "file": "notes/emu-trace-build.md",
-   "ref": "asm/target_hex"
-  },
-  {
    "file": "notes/emu-trace-build.md",
    "ref": "nearmiss/ledger"
   },
@@ -152,10 +132,6 @@
   {
    "file": "notes/global-data-migration.md",
    "ref": "src/testbssmid.c"
-  },
-  {
-   "file": "notes/global-data-migration.md",
-   "ref": "src/testbssmid.o"
   },
   {
    "file": "notes/global-data-migration.md",
@@ -234,6 +210,10 @@
    "ref": "port/ov009_syms.txt"
   },
   {
+   "file": "notes/port-selftest-bmp-gate.md",
+   "ref": "port/tools/battery.py"
+  },
+  {
    "file": "notes/research-matching-levers.md",
    "ref": "src/randomizer.py"
   },
@@ -264,10 +244,6 @@
   {
    "file": "notes/translation-unit-reconstruction-plan.md",
    "ref": "src/actors/Chuckya.cpp"
-  },
-  {
-   "file": "notes/translation-unit-reconstruction-plan.md",
-   "ref": "src_tu/actors/Chuckya.cpp"
   },
   {
    "file": "notes/tu-reconstruction-pilot-2-report.md",
@@ -386,14 +362,6 @@
    "ref": "include/Enemy.h"
   },
   {
-   "file": "tools/claims.py",
-   "ref": "tools/claims_handle.txt"
-  },
-  {
-   "file": "tools/claims.py",
-   "ref": "tools/claims_key.txt"
-  },
-  {
    "file": "tools/d0_migrate.py",
    "ref": "src/_ZN5EnemyD0Ev.c"
   },
@@ -508,10 +476,6 @@
   {
    "file": "tools/rtti_vtables.py",
    "ref": "src/_ZN12CylinderClsn7ProcessEv.cpp"
-  },
-  {
-   "file": "tools/srcpath.py",
-   "ref": "src/actors/ActorBase_SceneNode.cpp"
   },
   {
    "file": "tools/srcpath.py",

--- a/notes/port-selftest-bmp-gate.md
+++ b/notes/port-selftest-bmp-gate.md
@@ -12,22 +12,30 @@ defect that made the rule necessary.
 ## The rule
 
 **Compare selftest BMPs byte-exact only between builds whose `.dsstate` section
-lands at the same base address.** If the bases differ, the comparison says nothing.
+lands at the same base address with the same interior layout.** An equal base is
+necessary and not sufficient (the doctrine block in `port/tools/battery.py`,
+measured 2026-08-16): an insertion inside `.dsstate` shifts every hosted global
+past it while leaving the section base exactly where it was, and the frame follows
+the addresses. If base or span differ, the comparison says nothing.
 
 `.dsstate` is the PE section holding the hosted DS globals (`hal/dsstate_seg.cpp`
 brackets it with the `dsstate_lo` / `dsstate_hi` sentinels). Any change that grows
 port code or data past a 4 KB page boundary moves that base, and a naive byte
 compare then reports a difference with nothing wrong in the change. The difference
 looks exactly like a rendering regression: a handful of pixels, plausible colours,
-in a plausible place.
+in a plausible place. A change that adds or grows a hosted global moves the
+interior instead, to the same effect, with no base movement to flag it.
 
-To compare across a base change, pad the smaller build with an inert file-scope
-`.data` blob in 4 KB steps, outside any DSSTATE bracket, until the bases agree, then
-compare. Read the base from `dumpbin /headers`, or from the layout line the selftest
-prints beside the BMP.
+To compare across a layout change, pad the smaller build with an inert file-scope
+`.data` blob in 4 KB steps, outside any DSSTATE bracket, until base and span both
+agree, then compare. Read both from the `dsstate_guard` line the link prints, or
+from the layout line the selftest prints beside the BMP. Verify any pad is actually
+present in the .obj or the map before trusting what it measures; the retired row
+below is what happens otherwise.
 
-Do not answer a base-shift failure by adopting a pixel budget. A tolerance would hide
-the class of defect described below, which is what the gate exists to catch.
+Do not answer a base- or span-shift failure by adopting a pixel budget. A tolerance
+would hide the class of defect described below, which is what the gate exists to
+catch.
 
 ## The measurement that established it
 
@@ -37,9 +45,15 @@ all reaching an identical final player position (-4915200, 2805556, 9342995):
 | build | `.dsstate` base | BMP md5 |
 |---|---|---|
 | base as-is | 0x9ee000 | eb32dcab491562c27348aad32273cd8a |
-| base + 16B inert `.bss` | 0x9ee000 | eb32dcab491562c27348aad32273cd8a |
+| base + 16B inert `.bss` (retired) | 0x9ee000 | eb32dcab491562c27348aad32273cd8a |
 | base + 4KB inert `.data` | 0x9ef000 | 518ba22ae2604117409491e0c4f38056 |
 | base + 8KB inert `.data` | 0x9f0000 | 15fde8a893d010d8d46e3c7dc284ac47 |
+
+The `.bss` row is retired as a null result (measured 2026-08-16, recorded in
+`battery.py`): a volatile `.bss` pad is dropped by the compiler, absent from the
+recompiled .obj and not merely from the map, so that build was the base build under
+another name and its row measures nothing. Check any pad for presence in the .obj
+or the map before believing what it measures.
 
 Padding used: `extern "C" __declspec(dllexport) unsigned char rev_pad_data[4096] = {1};`
 


### PR DESCRIPTION
Doc-only. Brings notes/port-selftest-bmp-gate.md in line with the doctrine block at the top of port/tools/battery.py (updated 2026-08-16 on the port lane), which supersedes the note on two points:

- The comparison precondition was stated as base-only (equal .dsstate base). battery.py's 2026-08-16 measurement shows an equal base is necessary and not sufficient: an insertion inside .dsstate shifts every hosted global past it without moving the section base, and the frame follows the addresses. The rule now requires base and span both, read off the dsstate_guard line.
- The 2026-08-14 measurement table's 'base + 16B inert .bss' row is retired as a null result: a volatile .bss pad is dropped by the compiler (absent from the recompiled .obj), so that build was the base build under another name. The row is annotated rather than deleted, with the presence-in-the-obj check spelled out.

battery.py itself is untouched; it already points at this note as the long form.