### PR TITLE
daDemo_c's nested model classes get real destructors (a virtual base is what orders base-before-member)

### DIFF
--- a/config/arm9/overlays/ov002/symbols.txt
+++ b/config/arm9/overlays/ov002/symbols.txt
@@ -2404,6 +2404,7 @@ data_ov002_0210ba7c kind:data(any) addr:0x0210ba7c
 data_ov002_0210ba9c kind:data(any) addr:0x0210ba9c
 _ZTIN8daDemo_c10anmModel_cE kind:data(any) addr:0x0210babc
 data_ov002_0210bae4 kind:data(any) addr:0x0210bae4
+_ZTVN8daDemo_c13simpleModel_cE kind:data(any) addr:0x0210bae0
 _ZTIN8daDemo_c13simpleModel_cE kind:data(any) addr:0x0210bafc
 data_ov002_0210bb1c kind:data(any) addr:0x0210bb1c
 data_ov002_0210bb3c kind:data(any) addr:0x0210bb3c
@@ -2416,6 +2417,7 @@ data_ov002_0210bc28 kind:data(any) addr:0x0210bc28
 data_ov002_0210bc58 kind:data(any) addr:0x0210bc58
 data_ov002_0210bc88 kind:data(any) addr:0x0210bc88
 data_ov002_0210bcc4 kind:data(any) addr:0x0210bcc4
+_ZTVN8daDemo_c10anmModel_cE kind:data(any) addr:0x0210bcc0
 data_ov002_0210bce8 kind:data(any) addr:0x0210bce8
 data_ov002_0210bcf0 kind:data(any) addr:0x0210bcf0
 data_ov002_0210bd24 kind:data(any) addr:0x0210bd24

--- a/src/_ZN8daDemo_c10anmModel_cD0Ev.cpp
+++ b/src/_ZN8daDemo_c10anmModel_cD0Ev.cpp
@@ -1,37 +1,48 @@
 //cpp
+// @symbol _ZN8daDemo_c10anmModel_cD0Ev
+/* D0, the deleting destructor. Same class shape as the D1 file beside this one;
+ * one destructor definition emits D0/D1/D2 and objisolate keeps the variant this
+ * file's delinks entry names. The class operator delete is what routes the tail
+ * call to Memory::operator_delete2 (0x0203cbcc) rather than the global _ZdlPv --
+ * without it the bytes still match and only the relocation destination differs. */
+#include "ModelAnim.h"
 #include "SharedFilePtr.h"
-extern "C" {
-extern int data_ov002_0210bcc4[];
-extern int data_ov002_0210bce8[];
-extern int _ZN7Vector3D1Ev[];
-void _ZN9ModelAnimD2Ev(void*);
-void __destroy_arr(void*, int, int, void*);
-void _ZN6Memory16operator_delete2EPv(void*);
-typedef void (*VFN)(void*);
-void* _ZN8daDemo_c10anmModel_cD0Ev(char* c){
-  void* p;
-  int i;
-  *(int*)c = (int)data_ov002_0210bcc4;
-  *(int*)(c+0x50) = (int)data_ov002_0210bce8;
-  p = *(void**)(c+0x70);
-  if (p != 0) ((SharedFilePtr *)(p))->Release();
-  for (i = 0; i < *(unsigned char*)(c+0x80); i++) {
-    p = (*(void***)(c+0x74))[i];
+
+extern "C" void _ZN6Memory16operator_delete2EPv(void *);
+
+typedef void (*VFN)(void *);
+
+struct ScaleHolder {
+    Vector3 mScale[1];          /* 0x64 */
+};
+
+struct daDemo_c {
+    struct anmModel_c : ModelAnim, virtual ScaleHolder {
+        virtual ~anmModel_c();
+        void operator delete(void *ptr) { _ZN6Memory16operator_delete2EPv(ptr); }
+    };
+};
+
+daDemo_c::anmModel_c::~anmModel_c()
+{
+    char *c = (char *)this;
+    void *p;
+    int i;
+
+    p = *(void **)(c + 0x70);
     if (p != 0) ((SharedFilePtr *)(p))->Release();
-  }
-  if (*(void**)(c+0x7c) != 0) {
-    for (i = 0; i < *(unsigned char*)(c+0x81); i++) {
-      p = (*(void***)(c+0x78))[i];
-      if (p != 0) ((SharedFilePtr *)(p))->Release();
+    for (i = 0; i < *(unsigned char *)(c + 0x80); i++) {
+        p = (*(void ***)(c + 0x74))[i];
+        if (p != 0) ((SharedFilePtr *)(p))->Release();
     }
-    p = *(void**)(c+0x7c);
-    if (p != 0) {
-      (*(VFN)((*(int**)p)[1]))(p);
+    if (*(void **)(c + 0x7c) != 0) {
+        for (i = 0; i < *(unsigned char *)(c + 0x81); i++) {
+            p = (*(void ***)(c + 0x78))[i];
+            if (p != 0) ((SharedFilePtr *)(p))->Release();
+        }
+        p = *(void **)(c + 0x7c);
+        if (p != 0) {
+            (*(VFN)((*(int **)p)[1]))(p);
+        }
     }
-  }
-  _ZN9ModelAnimD2Ev(c);
-  __destroy_arr(c+0x64, 1, 0xc, (void*)_ZN7Vector3D1Ev);
-  _ZN6Memory16operator_delete2EPv(c);
-  return c;
-}
 }

--- a/src/_ZN8daDemo_c10anmModel_cD1Ev.cpp
+++ b/src/_ZN8daDemo_c10anmModel_cD1Ev.cpp
@@ -1,35 +1,55 @@
 //cpp
+// @symbol _ZN8daDemo_c10anmModel_cD1Ev
+/* D1, the complete-object destructor.
+ *
+ * The shape here is the whole finding. The cartridge destroys the ModelAnim /
+ * Model BASE before the Vector3 array at the class's own offset -- and a normal
+ * C++ destructor cannot do that: members are always destroyed before bases. A
+ * VIRTUAL base can, because D1 runs members, then non-virtual bases, then
+ * virtual bases. So the Vector3 lives in a virtual base, and that reproduces the
+ * ROM's order exactly.
+ *
+ * The base holds only the array. The remaining fields are read at raw offsets
+ * rather than declared, because a declared member would sit BEFORE the virtual
+ * base in the layout and push the array off 0x50/0x64. */
+#include "ModelAnim.h"
 #include "SharedFilePtr.h"
-extern "C" {
-extern int data_ov002_0210bcc4[];
-extern int data_ov002_0210bce8[];
-extern int _ZN7Vector3D1Ev[];
-void _ZN9ModelAnimD2Ev(void*);
-void __destroy_arr(void*, int, int, void*);
-typedef void (*VFN)(void*);
-void* _ZN8daDemo_c10anmModel_cD1Ev(char* c){
-  void* p;
-  int i;
-  *(int*)c = (int)data_ov002_0210bcc4;
-  *(int*)(c+0x50) = (int)data_ov002_0210bce8;
-  p = *(void**)(c+0x70);
-  if (p != 0) ((SharedFilePtr *)(p))->Release();
-  for (i = 0; i < *(unsigned char*)(c+0x80); i++) {
-    p = (*(void***)(c+0x74))[i];
+
+extern "C" void _ZN6Memory16operator_delete2EPv(void *);
+
+typedef void (*VFN)(void *);
+
+struct ScaleHolder {
+    Vector3 mScale[1];          /* 0x64 */
+};
+
+struct daDemo_c {
+    struct anmModel_c : ModelAnim, virtual ScaleHolder {
+        virtual ~anmModel_c();
+        void operator delete(void *ptr) { _ZN6Memory16operator_delete2EPv(ptr); }
+    };
+};
+
+daDemo_c::anmModel_c::~anmModel_c()
+{
+    char *c = (char *)this;
+    void *p;
+    int i;
+
+    p = *(void **)(c + 0x70);
     if (p != 0) ((SharedFilePtr *)(p))->Release();
-  }
-  if (*(void**)(c+0x7c) != 0) {
-    for (i = 0; i < *(unsigned char*)(c+0x81); i++) {
-      p = (*(void***)(c+0x78))[i];
-      if (p != 0) ((SharedFilePtr *)(p))->Release();
+    for (i = 0; i < *(unsigned char *)(c + 0x80); i++) {
+        p = (*(void ***)(c + 0x74))[i];
+        if (p != 0) ((SharedFilePtr *)(p))->Release();
     }
-    p = *(void**)(c+0x7c);
-    if (p != 0) {
-      (*(VFN)((*(int**)p)[1]))(p);
+    if (*(void **)(c + 0x7c) != 0) {
+        for (i = 0; i < *(unsigned char *)(c + 0x81); i++) {
+            p = (*(void ***)(c + 0x78))[i];
+            if (p != 0) ((SharedFilePtr *)(p))->Release();
+        }
+        p = *(void **)(c + 0x7c);
+        if (p != 0) {
+            (*(VFN)((*(int **)p)[1]))(p);
+        }
     }
-  }
-  _ZN9ModelAnimD2Ev(c);
-  __destroy_arr(c+0x64, 1, 0xc, (void*)_ZN7Vector3D1Ev);
-  return c;
-}
 }

--- a/src/_ZN8daDemo_c13simpleModel_cD0Ev.cpp
+++ b/src/_ZN8daDemo_c13simpleModel_cD0Ev.cpp
@@ -1,21 +1,30 @@
 //cpp
+// @symbol _ZN8daDemo_c13simpleModel_cD0Ev
+/* D0, the deleting destructor. Same class shape as the D1 file beside this one;
+ * one destructor definition emits D0/D1/D2 and objisolate keeps the variant this
+ * file's delinks entry names. The class operator delete is what routes the tail
+ * call to Memory::operator_delete2 (0x0203cbcc) rather than the global _ZdlPv --
+ * without it the bytes still match and only the relocation destination differs. */
+#include "Model.h"
 #include "SharedFilePtr.h"
-extern "C" {
-extern int data_ov002_0210bae4[];
-extern int _ZN7Vector3D1Ev[];
-void _ZN5ModelD2Ev(void*);
-void __destroy_arr(void*, int, int, void*);
-void _ZN6Memory16operator_delete2EPv(void*);
-void* _ZN8daDemo_c13simpleModel_cD0Ev(char* c){
-  void* p;
-  *(int*)c = (int)data_ov002_0210bae4;
-  p = *(void**)(c+0x5c);
-  if(p!=0){
-    ((SharedFilePtr *)(p))->Release();
-  }
-  _ZN5ModelD2Ev(c);
-  __destroy_arr(c+0x50, 1, 0xc, (void*)_ZN7Vector3D1Ev);
-  _ZN6Memory16operator_delete2EPv(c);
-  return c;
-}
+
+extern "C" void _ZN6Memory16operator_delete2EPv(void *);
+
+struct ScaleHolder {
+    Vector3 mScale[1];          /* 0x50 */
+};
+
+struct daDemo_c {
+    struct simpleModel_c : Model, virtual ScaleHolder {
+        virtual ~simpleModel_c();
+        void operator delete(void *ptr) { _ZN6Memory16operator_delete2EPv(ptr); }
+    };
+};
+
+daDemo_c::simpleModel_c::~simpleModel_c()
+{
+    SharedFilePtr *file = *(SharedFilePtr **)((char *)this + 0x5c);
+    if (file != 0) {
+        file->Release();
+    }
 }

--- a/src/_ZN8daDemo_c13simpleModel_cD1Ev.cpp
+++ b/src/_ZN8daDemo_c13simpleModel_cD1Ev.cpp
@@ -1,19 +1,37 @@
 //cpp
+// @symbol _ZN8daDemo_c13simpleModel_cD1Ev
+/* D1, the complete-object destructor.
+ *
+ * The shape here is the whole finding. The cartridge destroys the ModelAnim /
+ * Model BASE before the Vector3 array at the class's own offset -- and a normal
+ * C++ destructor cannot do that: members are always destroyed before bases. A
+ * VIRTUAL base can, because D1 runs members, then non-virtual bases, then
+ * virtual bases. So the Vector3 lives in a virtual base, and that reproduces the
+ * ROM's order exactly.
+ *
+ * The base holds only the array. The remaining fields are read at raw offsets
+ * rather than declared, because a declared member would sit BEFORE the virtual
+ * base in the layout and push the array off 0x50/0x64. */
+#include "Model.h"
 #include "SharedFilePtr.h"
-extern "C" {
-extern int data_ov002_0210bae4[];
-extern int _ZN7Vector3D1Ev[];
-void _ZN5ModelD2Ev(void*);
-void __destroy_arr(void*, int, int, void*);
-void* _ZN8daDemo_c13simpleModel_cD1Ev(char* c){
-  void* p;
-  *(int*)c = (int)data_ov002_0210bae4;
-  p = *(void**)(c+0x5c);
-  if(p!=0){
-    ((SharedFilePtr *)(p))->Release();
-  }
-  _ZN5ModelD2Ev(c);
-  __destroy_arr(c+0x50, 1, 0xc, (void*)_ZN7Vector3D1Ev);
-  return c;
-}
+
+extern "C" void _ZN6Memory16operator_delete2EPv(void *);
+
+struct ScaleHolder {
+    Vector3 mScale[1];          /* 0x50 */
+};
+
+struct daDemo_c {
+    struct simpleModel_c : Model, virtual ScaleHolder {
+        virtual ~simpleModel_c();
+        void operator delete(void *ptr) { _ZN6Memory16operator_delete2EPv(ptr); }
+    };
+};
+
+daDemo_c::simpleModel_c::~simpleModel_c()
+{
+    SharedFilePtr *file = *(SharedFilePtr **)((char *)this + 0x5c);
+    if (file != 0) {
+        file->Release();
+    }
 }


### PR DESCRIPTION
`daDemo_c::anmModel_c` and `daDemo_c::simpleModel_c` (ov002), D0 and D1
each. These were the last two classes in the mangled-name destructor
bucket blocked on **form** rather than on a missing name.

### The blocker, and the finding

The cartridge destroys the `ModelAnim` / `Model` **base** before the
`Vector3` array at the class's own offset. A normal C++ destructor cannot
emit that order -- members are always destroyed before bases. A
**virtual** base can, because D1 runs members, then non-virtual bases,
then virtual bases. Putting the array in a virtual base reproduces the
ROM's order exactly:

```cpp
struct ScaleHolder { Vector3 mScale[1]; };
struct daDemo_c {
    struct simpleModel_c : Model, virtual ScaleHolder {
        virtual ~simpleModel_c();
    };
};
```

Two details are load-bearing, both measured rather than reasoned:

- The array must be `Vector3 mScale[1]`, **not a scalar**. A scalar
  inlines the teardown and comes out six words short; the one-element
  array is what makes mwcc call `__destroy_arr`, which is what the ROM
  does.
- The remaining fields are read at **raw offsets rather than declared**.
  A declared member sits *before* the virtual base in the layout and
  pushes the array off 0x50 / 0x64 -- declaring the `SharedFilePtr *`
  moved the array to 0x54 and nothing else changed.

`anmModel_c` additionally needs its virtual base **non-polymorphic**. The
ROM stores two vptrs (+0x0 and +0x50); giving `ScaleHolder` its own
virtual destructor adds a third at +0x64.

### The vtable addend is +4 here, not +8

Both classes needed a `_ZTV` alias in ov002's `symbols.txt`. The usual
rule is that mwcc's vtable symbol sits 8 bytes below the slot array --
here it is **4**, because the virtual base adds a vbase-offset word.

```
_ZTVN8daDemo_c13simpleModel_cE  0x0210bae0
_ZTVN8daDemo_c10anmModel_cE     0x0210bcc0
```

`match.py` wildcards that word and reports `MATCH` at either address;
`linkcheck` is what says which is right. At -8 the full link built and
reported `105/106 exact` with four functions off by one or two words.

### Gates

- all four `VERIFIED` by `tools/linkcheck.py`, `blind: 0`
- full relink 106/106 exact, 100.000000% of compared bytes; 11,064
  source-built functions reproducing, 0 mismatching
- `layout-check: clean`; `port-refcheck: 407 checked, 0 stale`;
  `check_src_tu_compiles: every translation unit compiles`; no new dead
  references
- attribution `0 changed, 0 lost` (no renames -- all four files were
  already `.cpp`)
- ROM data from source: **2,631 -> 2,637 verified**, `differs` 120 -> 124.
  The four new rows are the two `_ZTV` symbols these TUs now define, one
  row per source file. Measured against a freshly built `origin/main`.
