### PR TITLE
romdata_check: count unique data symbols, not per-object records

### DIFF
--- a/tools/romdata_check.py
+++ b/tools/romdata_check.py
@@ -232,19 +232,66 @@ def check_object(obj_path, rel, names=None):
                  "note": f"{type(exc).__name__}: {exc}"}]
 
 
+def _symbol_key(r):
+    """Identity a verdict record is deduped on.
+
+    Vague linkage means the same cartridge data symbol -- a vtable, a typeinfo record --
+    is independently emitted by every object that needs it, so counting RECORDS makes the
+    headline a function of how many files the tree happens to be split into rather than
+    how much data is actually proven. `symbol == "?"` is check_object's own catch-all for
+    an object it could not even parse; it carries no real identity, so those never dedupe
+    against each other -- keying them by `src` too would be wrong the other direction.
+    """
+    if r["symbol"] == "?":
+        return (r.get("module"), r["symbol"], r["src"])
+    return (r.get("module"), r["symbol"])
+
+
+_VERDICT_RANK = {UNNAMED: 0, PARTIAL: 1, VERIFIED: 2}
+
+
 def summarize(records):
     counts = collections.Counter(r["verdict"] for r in records)
-    verified_bytes = sum(r.get("bytes", 0) for r in records if r["verdict"] == VERIFIED)
-    partial_bytes = sum(r.get("bytes", 0) for r in records if r["verdict"] == PARTIAL)
+
+    # One verdict per unique data symbol: DIFFERS wins outright over every other record
+    # for that symbol -- a class whose vtable is right in one file and wrong in another
+    # is still a wrong class model, so a correct copy must not hide a bad sibling. Absent
+    # a DIFFERS record, the best of what is left (VERIFIED over PARTIAL over UNNAMED).
+    best = {}
+    for r in records:
+        key = _symbol_key(r)
+        cur = best.get(key)
+        if cur is None:
+            best[key] = r
+        elif cur["verdict"] == DIFFERS:
+            continue
+        elif r["verdict"] == DIFFERS:
+            best[key] = r
+        elif _VERDICT_RANK[r["verdict"]] > _VERDICT_RANK[cur["verdict"]]:
+            best[key] = r
+    symbol_counts = collections.Counter(r["verdict"] for r in best.values())
+    verified_bytes = sum(r.get("bytes", 0) for r in best.values()
+                         if r["verdict"] == VERIFIED)
+    partial_bytes = sum(r.get("bytes", 0) for r in best.values()
+                        if r["verdict"] == PARTIAL)
     return {
-        "symbols": len(records),
-        "verified": counts[VERIFIED],
-        "partial": counts[PARTIAL],
-        "differs": counts[DIFFERS],
-        "unnamed": counts[UNNAMED],
+        "symbols": len(best),
+        "verified": symbol_counts[VERIFIED],
+        "partial": symbol_counts[PARTIAL],
+        "differs": symbol_counts[DIFFERS],
+        "unnamed": symbol_counts[UNNAMED],
         "verifiedBytes": verified_bytes,
         "partialBytes": partial_bytes,
+        # Per-object-record totals, kept for visibility -- these move with file topology
+        # (a TU merge or a duplicate-file cleanup changes them without a symbol's verdict
+        # changing) and are not what validate_merge ratchets.
+        "verifiedRecords": counts[VERIFIED],
+        "partialRecords": counts[PARTIAL],
+        "differsRecords": counts[DIFFERS],
+        "unnamedRecords": counts[UNNAMED],
+        "totalRecords": len(records),
         # The actionable list: a class model whose vtable disagrees with the cartridge.
+        # Left per-record (not deduped) so it still names every file carrying a bad copy.
         "differing": sorted(
             ({"src": r["src"], "symbol": r["symbol"], "module": r.get("module"),
               "addr": r.get("addr"), "differingBytes": r.get("differingBytes")}


### PR DESCRIPTION
## Summary

`romdata_check.summarize()` counted one entry per data symbol *per object*, not per unique symbol. Vague linkage means the same cartridge data symbol (a vtable, a typeinfo record) is independently emitted by every object that needs it, so the "ROM data verified from source" headline `validate_merge` ratchets was really a function of how many files the tree happens to be split into — and this migration's whole point is to reduce that number.

Concretely: merging PR #1845 consolidated several duplicate D0/D1/D2 destructor files (taking one already-landed canonical copy instead of two competing ones). That's exactly the kind of change this project wants, but it dropped the raw record count from 2656 to 2655 and tripped the ratchet, even though not one data symbol's verdict actually changed.

## What changed

`verified`/`partial`/`unnamed` now report unique `(module, symbol)` data symbols at their best verdict. `differs` is deliberately the opposite: any symbol with at least one differing record counts as differing, so a correct copy in one file can never hide a wrong copy in another. Raw per-record totals are kept under new `*Records` keys for visibility; nothing currently reads them.

## ⚠️ This PR's own validation will show a false "regression," and needs a one-time manual merge

Because each side of a PR-validation test-merge restores and runs its *own* checked-out `tools/`, base (unpatched `main`) will report the OLD per-record count (~2656) and head (this branch) will report the NEW per-unique-symbol count (~381) for the exact same underlying data. The ratchet will see a huge apparent drop and fail — this is unavoidable for this one PR, since it's the PR that changes what the number *means*. Every PR after this one lands will compare apples-to-apples again, because both sides will be running the fixed tool.

Verified there is no real loss:
- Unit-tested `summarize()` against synthetic records covering the dedup, the "differs wins" precedence, and the `symbol == "?"` catch-all case (never deduped against itself).
- Ran the fixed tool against `origin/main` directly: **1190 unique symbols, 381 verified, 215 partial, 53 differs, 541 unnamed.**
- Ran the same fixed tool against PR #1845's merged tree (which triggered this investigation): **identical numbers** — 1190/381/215/53/541. Zero regression, despite the old raw-record count reading 2656 → 2655.

## Test plan
- [x] `python tools/check_src_tu_compiles.py` — 88/88
- [x] `python tools/port_refcheck.py` — 407 checked, 0 stale
- [x] `python tools/check_dead_references.py` — no new dead references
- [x] synthetic unit check of `summarize()`
- [x] real run against `origin/main` and against a merged branch with consolidated duplicate files — identical unique-symbol counts