### PR TITLE
validate_merge: treat contributor reassignment as a warning, not a blocker

### DIFF
--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -200,22 +200,26 @@ class ValidateMerge(unittest.TestCase):
                 self.base, "HEAD", require_merge_commit=True,
                 expected_pr_head=self.base)
 
-    def test_a_credit_change_names_the_file_and_both_contributors(self):
-        # "2 changed" is unactionable: the PR author cannot see which files moved,
-        # and the worker log they would need is on the maintainer's box.
+    def test_a_credit_change_warns_without_failing(self):
+        # Reassignment alone -- both a before and an after contributor -- is never a
+        # blocker: a rebase or resolving someone else's merge conflict relabels a
+        # function's "last touched by" without losing anything, and this project spends
+        # no tokens defending credit. It is still named, in the warning and the table,
+        # so a PR author can see which files moved without that costing the merge.
         (self.repo / "attribution.json").write_text(
             '{"overrides": {"src/Example.c": "bob"}}\n', encoding="utf-8")
         commit(self.repo, "pin credit", "maintainer")
         report = VM.build_report(self.base, "HEAD")
-        self.assertEqual(report["status"], "Failed")
-        self.assertIn("src/Example.c: alice -> bob", "; ".join(report["reasons"]))
+        self.assertEqual(report["status"], "Passed")
+        self.assertEqual(report["reasons"], [])
+        self.assertIn("src/Example.c: alice -> bob", "; ".join(report["warnings"]))
         self.assertEqual(report["attribution"]["changed"][0]["path"], "src/Example.c")
         self.assertIn("| `arm9:0x02000000` | `src/Example.c` | alice | bob |",
                       report["reportMarkdown"])
 
-    def test_attribution_override_reports_the_change_without_failing(self):
-        # The label says "I know, and I meant it" -- so the finding is still computed
-        # and still named, it just stops being a reason the merge cannot land.
+    def test_attribution_override_is_not_needed_for_a_pure_change(self):
+        # The override label exists for a real LOSS. A pure reassignment already passes
+        # without it, and passing the label besides changes nothing about that.
         (self.repo / "attribution.json").write_text(
             '{"overrides": {"src/Example.c": "bob"}}\n', encoding="utf-8")
         commit(self.repo, "pin credit", "maintainer")
@@ -223,13 +227,14 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(report["status"], "Passed")
         self.assertEqual(report["reasons"], [])
         self.assertIn("src/Example.c: alice -> bob", "; ".join(report["warnings"]))
-        self.assertIn("(override label)", report["reportMarkdown"])
+        self.assertNotIn("(override label)", report["reportMarkdown"])
         self.assertEqual(len(report["attribution"]["changed"]), 1)
 
     def test_a_wholesale_credit_move_stays_within_the_relay_summary_limit(self):
         # The relay rejects a result whose summary runs past 500 characters, and a
         # rejected result is a job that never reports at all. Naming files is worth
-        # length; a repin sweep must still fit in the reply that carries the verdict.
+        # length in the warning and the check body; a repin sweep must still fit in the
+        # reply that carries the verdict.
         symbols = self.repo / "config" / "arm9" / "symbols.txt"
         text = symbols.read_text(encoding="utf-8")
         overrides = {}
@@ -246,10 +251,10 @@ class ValidateMerge(unittest.TestCase):
         commit(self.repo, "repin them all", "maintainer")
 
         report = VM.build_report(base, "HEAD")
-        self.assertEqual(report["status"], "Failed")
+        self.assertEqual(report["status"], "Passed")
         self.assertEqual(len(report["attribution"]["changed"]), 40)
         self.assertLessEqual(len(report["summary"]), VM.SUMMARY_LIMIT)
-        self.assertIn("+37 more", "; ".join(report["reasons"]))
+        self.assertIn("+37 more", "; ".join(report["warnings"]))
         self.assertIn("+15 more", report["reportMarkdown"])
 
     def test_override_does_not_excuse_a_non_attribution_failure(self):
@@ -374,7 +379,7 @@ class ValidateMerge(unittest.TestCase):
         unlabelled = VM.build_report(base, head)
         self.assertEqual(unlabelled["status"], "Failed")
         self.assertEqual([r.split(" (")[0] for r in unlabelled["reasons"]],
-                         ["contributor attribution changed or was lost"])
+                         ["contributor attribution was lost"])
 
         report = VM.build_report(base, head, allow_attribution_change=True)
         self.assertEqual(report["status"], "Passed")

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -599,15 +599,19 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     if he["stats"]["sourceFunctions"] < be["stats"]["sourceFunctions"]:
         reasons.append("source-built function coverage decreased")
     dropped_enrollment = sorted(set(be["source"]) - set(he["source"]))
-    # The attribution-override label (carried on the job by tangos-backend) makes every
-    # attribution finding advisory for this one pull request.  The finding is still
-    # computed and still named -- an override says "I know, and I meant it", not "do not
-    # look" -- it just stops being a reason the merge cannot land.
+    # Reassignment alone (a name moving from one contributor to another, credit_changes)
+    # is never a blocker: a rebase, a rename, or resolving someone else's merge conflict
+    # all relabel a function's "last touched by" without losing anything, and this project
+    # spends no tokens defending credit. Only an outright LOSS (lost_credit: a function
+    # that had a contributor and now has none) is a real regression, and the
+    # attribution-override label (carried on the job by tangos-backend) makes that one
+    # finding advisory too -- an override says "I know, and I meant it", not "do not
+    # look" -- for this one pull request.
     credit_moved = bool(credit_changes or lost_credit)
     new_unattributed = (ha["stats"]["unattributedFunctions"]
                         > ba["stats"]["unattributedFunctions"])
-    if credit_moved and not allow_attribution_change:
-        reasons.append("contributor attribution changed or was lost "
+    if lost_credit and not allow_attribution_change:
+        reasons.append("contributor attribution was lost "
                        f"({_credit_detail(credit_changes, lost_credit)}); label the pull "
                        "request attribution-override to accept it")
     if new_unattributed and not allow_attribution_change:
@@ -655,9 +659,14 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
             "none was byte-verified -- "
             + ", ".join(w["path"] for w in withdrawn[:3])
             + (f", +{len(withdrawn) - 3} more" if len(withdrawn) > 3 else ""))
-    if allow_attribution_change and credit_moved:
-        warnings.append("attribution-override label: contributor attribution changed or "
-                        f"was lost ({_credit_detail(credit_changes, lost_credit)}), "
+    if credit_changes:
+        # Never a blocker (see above) -- reported so a reader can still see whose credit
+        # moved, without needing the attribution-override label to get a passing merge.
+        warnings.append("contributor attribution changed, not a blocker "
+                        f"({_credit_detail(credit_changes, [])})")
+    if allow_attribution_change and lost_credit:
+        warnings.append("attribution-override label: contributor attribution was lost "
+                        f"({_credit_detail([], lost_credit)}), "
                         "accepted without failing the pull request")
     if allow_attribution_change and new_unattributed:
         warnings.append("attribution-override label: the merge introduced an "
@@ -724,11 +733,16 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         if hf["stats"]["totalBytes"] else 0.0)
     if reasons:
         summary = "Validation failed: " + "; ".join(reasons)
-    elif allow_attribution_change and (credit_moved or new_unattributed):
-        # Passing *because* of the label is not the same verdict as nothing having
-        # moved, and the one-liner is what most people read.
+    elif allow_attribution_change and (lost_credit or new_unattributed):
+        # Passing *because* of the label is not the same verdict as nothing having been
+        # lost, and the one-liner is what most people read.
         summary = ("Committed merge passes; the attribution-override label accepted "
-                   f"{len(credit_changes)} credit change(s), {len(lost_credit)} lost.")
+                   f"{len(lost_credit)} lost credit(s)"
+                   + (", including an unattributed match" if new_unattributed else "")
+                   + ".")
+    elif credit_changes:
+        summary = (f"Committed merge passes; {len(credit_changes)} contributor credit "
+                   "reassignment(s) noted, not a blocker.")
     else:
         summary = "Committed merge introduces no reconstruction or attribution regression."
     # tangos-backend refuses a result whose summary runs past 500 characters, and a refused
@@ -813,11 +827,16 @@ def render_markdown(r):
             f"({s['head']['sourceBytesPercent']:.2f}%, {_signed(d['sourceBuiltBytes'])}) "
             f"-- differs from byte-verified by "
             f"{s['head']['sourceFunctions'] - h['verifiedFunctions']:+,} |")
+    # "(override label)" only when the label actually waived something -- a pure
+    # reassignment (changed, no lost) already passes on its own, so tagging it here
+    # would read as "this needed permission" when it did not.
+    overrode_something = bool(r["attribution"].get("overridden")
+                              and r["attribution"]["lost"])
     lines += [
              f"| Contributor credit | {len(r['attribution']['added'])} added, "
              f"{len(r['attribution']['changed'])} changed, "
              f"{len(r['attribution']['lost'])} lost"
-             f"{' (override label)' if r['attribution'].get('overridden') else ''} |",
+             f"{' (override label)' if overrode_something else ''} |",
              f"| Relocation check | {l['checked']} checked; {relocation_summary} |"]
     # Optional phase: no row at all when it did not run, so an older worker's
     # report reads exactly as it did before.


### PR DESCRIPTION
## Summary

Three PRs in a row (#1844, #1845, #1848) needed the `attribution-override` label purely because resolving a merge conflict (taking one already-landed file over another, or a TU/destructor consolidation) relabels a function's "last touched by" contributor without losing anything — the byte match is untouched and the function still has a real owner, just a different name. This project already treats attribution as a non-goal not worth spending tokens defending; the gate hadn't caught up.

## What changed

`credit_moved` used to bundle two different things together and block on either:
- **reassignment** (`credit_changes`): before and after are both real contributors — nothing lost, just relabeled
- **loss** (`lost_credit`): a function had a contributor and now has none — a real regression

Now only `lost_credit` blocks (still requires `attribution-override` to waive). `credit_changes` is always a warning: still computed, still named per-file in the warning text and the "Contributor credit moved" table, just no longer a reason a merge can't land. The `(override label)` summary tag now only appears when the label actually waived something real (a loss), not merely when it was present on a PR that didn't need it.

`new_unattributed` (the merge introduces a byte-matched function with no contributor at all) is untouched — that's a different, more concerning gap than a reassignment and stays blocking.

## Test plan
- [x] `python -m pytest tools/test_validate_merge.py` — 35/35 passed (two tests updated to assert reassignment-alone now passes with a warning; the real-loss test is unaffected except for updated reason text)
- [x] `python tools/check_src_tu_compiles.py` — 88/88
- [x] `python tools/port_refcheck.py` — 407 checked, 0 stale
- [x] `python tools/check_dead_references.py` — no new dead references