### PR TITLE
Prefer real headers for deleting-destructor candidates

### DIFF
--- a/tools/swarm.py
+++ b/tools/swarm.py
@@ -1302,6 +1302,42 @@ def rule_frame_call_bool(name, ins, b, addr, relocs, syms):
     return (decls + f"int {name}({params}) {{ return {X}({a}) != 0; }}\n"), "frame_call_bool"
 
 
+def native_deleting_dtor(name):
+    """Use an existing class model before transcribing a D0 by hand.
+
+    A deleting destructor is source-level ``X::~X()``.  When the matching class
+    header already records the real inheritance and declares the virtual destructor,
+    emitting a second local class model is duplicate ownership of the same
+    symbol.  Return the native source in that case; the oracle remains the
+    authority on whether the header is complete enough to reproduce the ROM.
+
+    A flat/generated header is not sufficient: without a real base declaration
+    it cannot make CodeWarrior generate the base chain or inherited operator
+    delete, so the ordinary transcription rule remains available for it.
+    """
+    m = re.fullmatch(r"_ZN(\d+)([A-Za-z_]\w*)D0Ev", name)
+    if not m:
+        return None
+    n, cls = int(m.group(1)), m.group(2)
+    if len(cls) != n:
+        return None
+    header = REPO / "include" / f"{cls}.h"
+    if not header.is_file():
+        return None
+    text = header.read_text(errors="replace")
+    real_class = re.search(
+        r"^\s*(?:struct|class)\s+" + re.escape(cls)
+        + r"\s*:\s*(?:(?:public|protected|private)\s+)?[A-Za-z_]\w*",
+        text,
+        re.M,
+    )
+    virtual_dtor = re.search(r"\bvirtual\s+~" + re.escape(cls) + r"\s*\(\s*\)\s*;", text)
+    if not (real_class and virtual_dtor):
+        return None
+    return (f"//cpp\n// @symbol {name}\n#include \"{cls}.h\"\n\n"
+            f"{cls}::~{cls}()\n{{\n}}\n")
+
+
 def rule_deleting_dtor(name, ins, b, addr, relocs, syms):
     # push{r4,lr}; ldr r1,[pc]; mov r4,r0; str r1,[r4]; bl D1; ldr r1,[pc]; mov r0,r4;
     #   ldr r1,[r1]; bl D2; mov r0,r4; pop; bx; .word VT, &HEAP
@@ -1320,6 +1356,13 @@ def rule_deleting_dtor(name, ins, b, addr, relocs, syms):
     d1, d2 = R.name_for_reloc(e1, syms), R.name_for_reloc(e2, syms)
     if d1 == d2 or name in (d1, d2):
         return None
+    native = native_deleting_dtor(name)
+    if native is not None:
+        # Do not silently fall through to a competing hand-written class model
+        # when the real header is incomplete: a native miss is useful evidence,
+        # while a shadow match creates the duplicate-work conflict this guard
+        # exists to prevent.
+        return native, "deleting_dtor_native"
     decls = (f"extern int VT[];\nextern void {d1}(void *);\n"
              f"extern void {d2}(void *, void *);\nextern void *HEAP;\n")
     return (decls + f"int *{name}(int *t)\n{{\n    t[0] = (int)VT;\n    {d1}(t);\n"

--- a/tools/test_swarm.py
+++ b/tools/test_swarm.py
@@ -1,0 +1,89 @@
+"""Regression tests for swarm's native deleting-destructor preference."""
+
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOLS))
+
+import swarm as S  # noqa: E402
+
+
+class NativeDeletingDestructorTests(unittest.TestCase):
+    def setUp(self):
+        self._old_repo = S.REPO
+        self._tmp = tempfile.TemporaryDirectory()
+        S.REPO = pathlib.Path(self._tmp.name)
+        (S.REPO / "include").mkdir()
+
+    def tearDown(self):
+        S.REPO = self._old_repo
+        self._tmp.cleanup()
+
+    def write_header(self, name, text):
+        (S.REPO / "include" / f"{name}.h").write_text(text, encoding="utf-8")
+
+    @staticmethod
+    def deleting_dtor_insns():
+        mnemonics = ["push", "ldr", "mov", "str", "bl", "ldr", "mov", "ldr",
+                     "bl", "mov", "pop", "bx"]
+        operands = ["{r4,lr}", "r1,[pc,#0]", "r4,r0", "r1,[r4]", "", "r1,[pc,#0]",
+                    "r0,r4", "r1,[r1]", "", "r0,r4", "{r4,lr}", "lr"]
+        return [types.SimpleNamespace(mnemonic=mn, op_str=op, address=i * 4)
+                for i, (mn, op) in enumerate(zip(mnemonics, operands))]
+
+    def run_rule(self):
+        ins = self.deleting_dtor_insns()
+        relocs = {0x1010: "member-dtor", 0x1020: "deallocator"}
+        with mock.patch.object(S.R, "name_for_reloc", side_effect=lambda entry, _syms: entry):
+            return S.rule_deleting_dtor(
+                "_ZN4FishD0Ev", ins, b"", 0x1000, relocs, {}
+            )
+
+    def test_real_derived_header_emits_native_cpp(self):
+        self.write_header("Fish", "struct Fish : dActor_c { virtual ~Fish(); };\n")
+        source = S.native_deleting_dtor("_ZN4FishD0Ev")
+        self.assertIsNotNone(source)
+        self.assertTrue(source.startswith("//cpp\n// @symbol _ZN4FishD0Ev\n"))
+        self.assertIn('#include "Fish.h"', source)
+        self.assertIn("Fish::~Fish()", source)
+        self.assertNotIn('extern "C"', source)
+        self.assertNotIn("operator delete", source)
+
+    def test_rule_prefers_native_cpp_when_real_header_exists(self):
+        self.write_header("Fish", "struct Fish : dActor_c { virtual ~Fish(); };\n")
+        source, label = self.run_rule()
+        self.assertEqual(label, "deleting_dtor_native")
+        self.assertIn('#include "Fish.h"', source)
+        self.assertNotIn("deallocator", source)
+
+    def test_public_base_spelling_is_accepted(self):
+        self.write_header("Widget", "class Widget : public Base { virtual ~Widget(); };\n")
+        self.assertIsNotNone(S.native_deleting_dtor("_ZN6WidgetD0Ev"))
+
+    def test_flat_header_keeps_the_transcription_fallback_available(self):
+        self.write_header("Fish", "struct Fish { virtual ~Fish(); };\n")
+        self.assertIsNone(S.native_deleting_dtor("_ZN4FishD0Ev"))
+
+    def test_rule_uses_transcription_only_for_flat_header(self):
+        self.write_header("Fish", "struct Fish { virtual ~Fish(); };\n")
+        source, label = self.run_rule()
+        self.assertEqual(label, "deleting_dtor")
+        self.assertIn("deallocator", source)
+        self.assertFalse(source.startswith("//cpp"))
+
+    def test_header_without_virtual_destructor_is_not_treated_as_owner(self):
+        self.write_header("Fish", "struct Fish : dActor_c { ~Fish(); };\n")
+        self.assertIsNone(S.native_deleting_dtor("_ZN4FishD0Ev"))
+
+    def test_mangled_length_must_name_the_whole_class(self):
+        self.write_header("Fish", "struct Fish : dActor_c { virtual ~Fish(); };\n")
+        self.assertIsNone(S.native_deleting_dtor("_ZN5FishD0Ev"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Teach swarm's D0 rule to emit a native class destructor through an existing real derived header before considering the transcription fallback. Native misses are left unmatched instead of creating a competing hand-written ownership model.\n\nTests: python tools/test_swarm.py