### PR TITLE
romdata_check: correct the vtable-preamble double-count for _ZTV<C> data relocs

### DIFF
--- a/tools/romdata_check.py
+++ b/tools/romdata_check.py
@@ -180,8 +180,18 @@ def verify_data_symbol(raw, name, shndx, value, size, names=None):
     if len(body) <= preamble:
         return {"symbol": name, "verdict": PARTIAL, "bytes": 0, "module": module,
                 "addr": addr, "note": "nothing past the vtable preamble"}
-    linked, blind = LC.link_function(body, addr - preamble,
-                                     LC.func_relocs_typed(raw, name, names) or [])
+    relocs = LC.func_relocs_typed(raw, name, names) or []
+    # func_relocs_typed reads the raw ELF addend, which for a `_ZTV<C>` target still
+    # carries mwcc's own preamble skip (offset-to-top + typeinfo, OI.VTABLE_PREAMBLE
+    # bytes) on top of an address already resolved to symbols.txt's post-preamble
+    # convention -- the same double-count reloc_audit.object_reloc_dests already
+    # corrects for "raw" objects. Uncorrected here, any vptr field embedded in a DATA
+    # record (as opposed to a vptr STORE inside compiled code, which objisolate
+    # rewrites before the code ever reaches this comparison) resolves 8 bytes high.
+    for rl in relocs:
+        if rl["sym"].startswith("_ZTV") and rl["add"] >= OI.VTABLE_PREAMBLE:
+            rl["add"] -= OI.VTABLE_PREAMBLE
+    linked, blind = LC.link_function(body, addr - preamble, relocs)
     linked = linked[preamble:]
     blind = {o - preamble for o in blind if o >= preamble}
 


### PR DESCRIPTION
Tools-only change: one file, `tools/romdata_check.py`.

## The bug

`LC.func_relocs_typed()` reads the **raw ELF addend**. For a `_ZTV<C>` target that
addend still carries mwcc's own preamble skip (offset-to-top + typeinfo,
`OI.VTABLE_PREAMBLE` bytes) — but it is being applied on top of an address that has
*already* been resolved against `symbols.txt`, which uses the **post-preamble**
convention. The preamble therefore gets counted twice, and the resulting destination
lands 8 bytes past the real one.

This is the same double-count that `reloc_audit.object_reloc_dests` already corrects
for "raw" objects; `romdata_check` simply never had the matching correction.

## The fix

Subtract the preamble back out for `_ZTV` targets before handing the relocs to
`LC.link_function`:

```python
for rl in relocs:
    if rl["sym"].startswith("_ZTV") and rl["add"] >= OI.VTABLE_PREAMBLE:
        rl["add"] -= OI.VTABLE_PREAMBLE
```

## Why this PR is deliberately tools-only

The validator's `restore_trusted_controls()` runs `git checkout "$base" -- tools`
before it measures anything, so **no PR can validate its own `tools/` change** — this
one included. Expect the ROM-data count to read exactly like main's; the tool fix is
inert during validation by design.

That is the reason it goes first. The `config/arm9/symbols.txt` correction that
actually depends on this logic is a separate follow-up, and it can only be measured
honestly once this is already on main.

Precedent: #1890 was a `tools/romdata_check.py`-only PR and merged clean.

## Verification

Pushed with the pre-push hook enabled (no `--no-verify`), from a worktree at current
`origin/main`:

- port-refcheck — 405 references, 0 stale
- duplicate-sources — 11303 stems, none doubled
- check_src_tu_compiles — **88/88** translation units compile
- `build_pin.verify` canary — `(True, '2004/b56')`

No source, header, config or symbol changes. Zero effect on the build.
