### PR TITLE
Declare the ROM-null vtable slots as pure virtual in ten classes

### DIFF
--- a/include/daObjFallBlock_c.h
+++ b/include/daObjFallBlock_c.h
@@ -120,6 +120,21 @@ struct daObjFallBlock_c : dBgActor_c {
     s32 Behavior();                     /* slot  6 */
     s32 Render();                       /* slot  9 */
     virtual void OnHitByMegaChar(Player &player); /* slot 27 */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
 };
 
 typedef char daObjFallBlock_c_size_must_be_0x34c[sizeof(daObjFallBlock_c) == 0x34c ? 1 : -1];

--- a/include/daObjFloatBoard_c.h
+++ b/include/daObjFloatBoard_c.h
@@ -79,6 +79,20 @@ struct daObjFloatBoard_c : dBgActor_c {
     int CleanupResources();             /* slot 3, ov002 0x020b5be0 */
     int Behavior();                     /* slot 6, ov002 0x020b5c4c */
     s32 Render();                       /* slot 9, ov002 0x020b5c24 -- mModel.Render(0) */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual int InitResources() = 0;        /* slot  0 */
 };
 
 typedef char daObjFloatBoard_c_size_must_be_0x348[sizeof(daObjFloatBoard_c) == 0x348 ? 1 : -1];

--- a/include/daObjGuragura_c.h
+++ b/include/daObjGuragura_c.h
@@ -98,6 +98,21 @@ struct daObjGuragura_c : dBgActor_c {
        eleven .data sections; with Render first, one .text. */
     s32 Render();                      /* slot  9 -- see above; not yet migrated */
     s32 Behavior();                    /* slot  6 */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
 };
 
 typedef char daObjGuragura_c_size_must_be_0x350[sizeof(daObjGuragura_c) == 0x350 ? 1 : -1];

--- a/include/daObjKaitendai_c.h
+++ b/include/daObjKaitendai_c.h
@@ -72,6 +72,21 @@ struct daObjKaitendai_c : dBgActor_c {
        file, not assumed. */
     s32 Behavior();
     s32 Render();                      /* slot 9, ov002 0x020b66f0 -- mModel.Render(0) */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
 };
 
 typedef char daObjKaitendai_c_size_must_be_0x320[sizeof(daObjKaitendai_c) == 0x320 ? 1 : -1];

--- a/include/daObjKuruma_c.h
+++ b/include/daObjKuruma_c.h
@@ -66,6 +66,21 @@ struct daObjKuruma_c : dBgActor_c {
        Render will have to place the vtable deliberately. */
     s32 Render();                      /* slot  9 -- see above; not yet migrated */
     s32 Behavior();                    /* slot  6 */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
 };
 
 typedef char daObjKuruma_c_size_must_be_0x320[sizeof(daObjKuruma_c) == 0x320 ? 1 : -1];

--- a/include/daObjKurumajiku_c.h
+++ b/include/daObjKurumajiku_c.h
@@ -62,6 +62,21 @@ struct daObjKurumajiku_c : dBgActor_c {
        stays the first virtual DECLARED in the class. */
     s32 Behavior();
     s32 Render();                      /* slot 9, ov002 0x020b6b10 -- mModel.Render(0) */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
 };
 
 typedef char daObjKurumajiku_c_size_must_be_0x330[sizeof(daObjKurumajiku_c) == 0x330 ? 1 : -1];

--- a/include/daObjMaruta_c.h
+++ b/include/daObjMaruta_c.h
@@ -72,6 +72,22 @@ struct daObjMaruta_c : dBgActor_c {
        declares it virtual, and re-adding the keyword here is a style
        choice this header hasn't made for its own other declarations. */
     s32 Render();
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
+    virtual s32 Behavior() = 0;             /* slot  6 */
 };
 
 typedef char daObjMaruta_c_size_must_be_0x320[sizeof(daObjMaruta_c) == 0x320 ? 1 : -1];

--- a/include/daObjSwdoor_c.h
+++ b/include/daObjSwdoor_c.h
@@ -54,6 +54,22 @@ struct daObjSwdoor_c : dBgActor_c {
        tools/eligible.py's name list, same mechanism the Guragura/Kuruma
        Render comments describe. */
     s32 Render();
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
+    virtual s32 Behavior() = 0;             /* slot  6 */
 };
 
 typedef char daObjSwdoor_c_size_must_be_0x320[sizeof(daObjSwdoor_c) == 0x320 ? 1 : -1];

--- a/include/daObjUkiyuka_c.h
+++ b/include/daObjUkiyuka_c.h
@@ -80,6 +80,21 @@ struct daObjUkiyuka_c : dBgActor_c {
        file, not assumed. */
     s32 Behavior();
     s32 Render();                      /* slot 9, ov002 0x020b646c -- mModel.Render(0) */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dBgActor_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual s32 InitResources() = 0;        /* slot  0 */
+    virtual s32 CleanupResources() = 0;     /* slot  3 */
 };
 
 typedef char daObjUkiyuka_c_size_must_be_0x32c[sizeof(daObjUkiyuka_c) == 0x32c ? 1 : -1];

--- a/include/daOts_c.h
+++ b/include/daOts_c.h
@@ -66,10 +66,17 @@
  * anywhere referenced any of the five by name, which is what makes a misattributed
  * ROM symbol so easy to leave in place and so cheap to correct.
  *
- * The two pure-virtual slots are deliberately NOT declared `= 0` below. Nothing in
- * the ROM needs them to be: this class's vtable is never emitted (see the inline
- * destructor note), and declaring them would change what the children emit for no
- * gain. The zero words are the evidence; the declaration would only restate it.
+ * The two pure-virtual slots ARE declared `= 0` below, and the note that used to say
+ * they deliberately were not rested on a premise that has since stopped being true.
+ * It argued this class's vtable is never emitted, so nothing could disagree with the
+ * cartridge. That held while the inline destructor left the class without a key
+ * function -- but `virtual int CleanupResources();` is declared non-inline here and
+ * DEFINED in src/_ZN7daOts_c16CleanupResourcesEv.cpp, which makes it the key function
+ * and makes that translation unit emit _ZTV7daOts_c. Measured: the emitted table
+ * carried dEnemyBase_c's concrete InitResources and Behavior in slots 0 and 6 where
+ * the cartridge has zeros, eight bytes wrong, and no byte gate could see it -- the
+ * ROM build compares .text only. The zero words were always the evidence; the
+ * declaration is what makes the compiler act on it.
  */
 struct daOts_c : dEnemyBase_c {
     ModelAnim           mModelAnim;             /* 0x110 */
@@ -96,10 +103,25 @@ struct daOts_c : dEnemyBase_c {
 
     /* The three slots this class owns outright, each named by the diff above rather
        than by any one child's source. InitResources and Behavior are the pure-virtual
-       pair and stay undeclared, for the reason given above the struct. */
+       pair, declared at the end of the class. */
     virtual int CleanupResources();     /* slot  3 */
     virtual int Render();               /* slot  9 */
     virtual int OnAimedAtWithEgg();     /* slot 29 -- still a C file, see its source */
+    /* THE NULL SLOTS THE NOTE ABOVE ALREADY NAMES, SPELT SO THE COMPILER AGREES.
+       mwccarm lays down a bare 0x00000000 with no relocation for a pure virtual --
+       there is no __cxa_pure_virtual in this image for it to point at -- so a zero
+       word in a ROM vtable IS the `= 0`, and it is the only thing that produces one.
+       Left undeclared, this class silently inherits dEnemyBase_c's concrete bodies and
+       the vtable it emits disagrees with the cartridge at exactly these slots.
+       Measured by tools/romdata_check.py, which is the only gate that reads them:
+       the ROM build's 106/106 compares .text alone and is blind here.
+
+       DECLARED LAST, AND WITH `virtual` -- unlike the plain overrides above. The
+       pure-specifier is only valid on a declaration carrying the keyword, and a
+       pure virtual has no body to emit, so it can never become the key function:
+       whichever virtual was first and non-inline before is still first now. */
+    virtual int InitResources() = 0;        /* slot  0 */
+    virtual int Behavior() = 0;             /* slot  6 */
 };
 
 typedef char daOts_c_size_must_be_0x398[sizeof(daOts_c) == 0x398 ? 1 : -1];


### PR DESCRIPTION
## The finding

mwccarm lays down a bare `0x00000000` **with no relocation** for a pure virtual — there is no `__cxa_pure_virtual` anywhere in this image for it to point at. That was measured directly with a compiler probe, and it settles a question the tree has been guessing at: a zero word in a ROM vtable *is* the `= 0`, and it is the only thing that produces one.

Read that way, the cartridge says ten of our classes are **abstract** at slots the headers declare concrete. Left undeclared, each silently inherits its base's bodies and emits a vtable that disagrees with the ROM at exactly those slots.

| class | base | null slots in ROM |
|---|---|---|
| daObjKuruma_c, daObjUkiyuka_c, daObjGuragura_c, daObjFallBlock_c, daObjKaitendai_c, daObjKurumajiku_c | dBgActor_c | 0, 3 |
| daObjMaruta_c, daObjSwdoor_c | dBgActor_c | 0, 3, 6 |
| daObjFloatBoard_c | dBgActor_c | 0 |
| daOts_c | dEnemyBase_c | 0, 6 |

Slot 0 is `InitResources`, 3 is `CleanupResources`, 6 is `Behavior`.

## Why this was invisible

`objisolate` discards every non-`.text` section. `106/106 exact` therefore says **nothing at all** about vtables, typeinfo, or type-name strings — `tools/romdata_check.py` is the only gate in the tree that reads those bytes. All ten of these were wrong on `main` and every byte gate was green.

## The one subtlety worth reviewing

The declarations go **last** in each class and carry the `virtual` keyword, unlike the plain overrides above them. Both are load-bearing: the pure-specifier is only valid on a declaration that carries the keyword, and a pure virtual has no body to emit, so it can never become the key function. Whichever virtual was first-declared and non-inline before this change is still first after it — key-function selection, and therefore which TU owns each `_ZTV`, is unchanged.

`include/daOts_c.h` also needed prose corrected: its banner explicitly argued *against* this change, on the premise that "this class's vtable is never emitted." That premise is stale. `virtual int CleanupResources();` is declared non-inline and **defined** in `src/_ZN7daOts_c16CleanupResourcesEv.cpp`, which makes it the key function and makes that TU emit `_ZTV7daOts_c` — measured 8 bytes wrong.

## Measured, both directions, on this same base

| gate | before | after |
|---|---|---|
| `rombuild -j16 --no-rom` | 106/106 exact, 0 mismatching | 106/106 exact, 0 mismatching |
| ROM data verified | 427 | **435** |
| ROM data differ | 37 | **27** |
| ROM data partial | 237 | 239 |
| verified data bytes | 32,028 | **33,052** |
| `eligible.py` | 11089 / 11204 | 11089 / 11204, name lists byte-identical |
| `port_refcheck.py` | — | 405 references, 0 stale |
| `prepush_attribution.py` | — | 0 changed, 0 lost |
| `check_src_tu_compiles` | — | 88/88 |

Zero function bytes change — this is vtable data only.

The two classes that land on PARTIAL rather than VERIFIED are correct but short: the emitted vtable agrees everywhere it reaches, it just does not yet span the ROM's full extent.

## Deliberately not included

`daDsnBase_c` belongs to this bucket but `= 0` alone does not fix it — it also needs real overrides at slots 3 and 9. Its own change.

This is bucket 2 of a six-bucket classification of all 37 differing ROM data symbols. The rest, for context: 8 are shadow-struct artifacts that dissolve on TU promotion (not defects); 3 are a missing `virtual`; 4 are class names the cartridge proves wrong; 2 are daDemo_c's base layout; 9 need per-class work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
