### PR TITLE
Declare four vtable overrides the cartridge has and the headers did not

### DIFF
--- a/include/HUD.h
+++ b/include/HUD.h
@@ -32,6 +32,19 @@ struct HUD : dBase_c {
     /* --- vtable --- */
     virtual ~HUD();
 
+    /* Two overrides the cartridge proves and this header never declared -- and both
+       are already decompiled and byte-matching in this tree, which is what makes
+       them worth reading twice. _ZTV3HUD slot 0 pointed at fBase_c::InitResources
+       and slot 6 at fBase_c::Behavior, while the ROM has
+       ov002:_ZN3HUD13InitResourcesEv (0x020fda04) and ov002:_ZN3HUD8BehaviorEv
+       (0x020fd7a4) -- src/_ZN3HUD13InitResourcesEv.cpp and src/_ZN3HUD8BehaviorEv.cpp
+       compiled and matched all along; nothing pointed the vtable at them.
+       No `virtual` keyword, matching the overrides beside it: a derived declaration
+       of a base virtual overrides whether or not it repeats the word.
+       Measured by tools/romdata_check.py, the only gate that reads vtable bytes --
+       objisolate drops every non-.text section, so 106/106 is blind here. */
+    s32 InitResources();
+    s32 Behavior();
     int Render();
     s32 CleanupResources();
     void CalculateDigits(unsigned short value);

--- a/include/TTC_MovingBeam.h
+++ b/include/TTC_MovingBeam.h
@@ -31,6 +31,14 @@ struct TTC_MovingBeam : dBgActor_c {
     /* --- vtable --- */
     virtual ~TTC_MovingBeam();
 
+    /* An override the cartridge proves and this header never declared.
+       _ZTV14TTC_MovingBeam slot 6 pointed at fBase_c::Behavior; the ROM has
+       ov065:_ZN14TTC_MovingBeam8BehaviorEv (0x0211bd8c, 0x178 bytes), named in
+       symbols.txt but not yet decompiled -- the slot needs the symbol, not a body.
+       No `virtual` keyword, matching the overrides beside it: a derived declaration
+       of a base virtual overrides whether or not it repeats the word.
+       Measured by tools/romdata_check.py, the only gate that reads vtable bytes. */
+    int Behavior();
     int CleanupResources();
     int InitResources();
     int Render();

--- a/include/Wiggler.h
+++ b/include/Wiggler.h
@@ -46,6 +46,15 @@ struct Wiggler : dEnemyBase_c {
 
     virtual ~Wiggler();
 
+    /* An override the cartridge proves and this header never declared. _ZTV7Wiggler
+       slot 6 pointed at fBase_c::Behavior; the ROM has ov034:_ZN7Wiggler8BehaviorEv
+       (0x02112b5c, 0x6e0 bytes), named in symbols.txt but not yet decompiled -- the
+       slot needs the symbol, not a body, so declaring it is the whole fix.
+       No `virtual` keyword, matching the overrides beside it: a derived declaration
+       of a base virtual overrides whether or not it repeats the word.
+       Measured by tools/romdata_check.py, the only gate that reads vtable bytes --
+       objisolate drops every non-.text section, so 106/106 is blind here. */
+    int Behavior();
     int CleanupResources();
     int InitResources();
     int Render();


### PR DESCRIPTION
Follow-on to #1969, same measurement path, independent files.

## It was not a missing `virtual`

I went in expecting three classes that had dropped the keyword. That is not what these are. In C++ a derived declaration of a base virtual overrides whether or not it repeats the word, and `Wiggler::InitResources` proves it in this very tree — declared bare `int InitResources();`, and its vtable slot matches the cartridge fine.

The actual defect is **an override the ROM has that no header ever declared**, so the slot silently inherits `fBase_c`'s body:

| class | slot | vtable pointed at | ROM has | size |
|---|---|---|---|---|
| Wiggler | 6 | `fBase_c::Behavior` | `ov034:_ZN7Wiggler8BehaviorEv` @ 0x02112b5c | 0x6e0 |
| TTC_MovingBeam | 6 | `fBase_c::Behavior` | `ov065:_ZN14TTC_MovingBeam8BehaviorEv` @ 0x0211bd8c | 0x178 |
| HUD | 0 | `fBase_c::InitResources` | `ov002:_ZN3HUD13InitResourcesEv` @ 0x020fda04 | 0x750 |
| HUD | 6 | `fBase_c::Behavior` | `ov002:_ZN3HUD8BehaviorEv` @ 0x020fd7a4 | 0x260 |

## The HUD pair is worth reading twice

`src/_ZN3HUD13InitResourcesEv.cpp` and `src/_ZN3HUD8BehaviorEv.cpp` **already exist, compile, and byte-match** — they always did. Nothing pointed the vtable at them. Both functions were finished by every metric this project tracks, while dispatch routed around them into the base class.

That is the shape of defect worth generalising from: a green function count says a body reproduces, not that anything reaches it.

## Undecompiled bodies do not block the slot

Wiggler's and TTC_MovingBeam's `Behavior` are not decompiled — Wiggler's best near-miss in `match_attempts.jsonl` is 143 divergences. Irrelevant here: a vtable slot needs the *symbol*, and `symbols.txt` already names both addresses. Four declarations are the entire change.

## Measured, both directions, on this base

| gate | before | after |
|---|---|---|
| `rombuild -j16 --no-rom` | 106/106 exact, 0 mismatching | 106/106 exact, 0 mismatching |
| ROM data verified | 427 | **429** |
| ROM data differ | 37 | **34** |
| ROM data partial | 237 | 238 |
| `eligible.py` | 11089 / 11204 | 11089 / 11204, name lists byte-identical |
| `port_refcheck.py` | — | 405 references, 0 stale |
| `prepush_attribution.py` | — | 0 changed, 0 lost |
| `check_src_tu_compiles` | — | 88/88 |

Zero function bytes change. Found with `tools/romdata_check.py`, the only gate in the tree that reads vtable bytes at all — `objisolate` discards every non-`.text` section, so `106/106` never looked at these words.

TTC_MovingBeam lands on PARTIAL rather than VERIFIED: its emitted vtable is 128 bytes against a 152-byte ROM extent — correct everywhere it reaches, not yet spanning the whole thing.

## Bucket status

Of the 37 differing ROM data symbols originally classified: #1969 closed 10, this closes 3, leaving 24. Of those, 8 are shadow-struct artifacts that dissolve on TU promotion (not defects), leaving 16 real ones: 4 class names the cartridge proves wrong, 2 for daDemo_c's base layout, 1 daDsnBase_c, and 9 needing per-class work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
