### PR TITLE
Generate collision-query lifetimes from C++

### DIFF
--- a/include/dBgW_KcMbgSclY.h
+++ b/include/dBgW_KcMbgSclY.h
@@ -19,12 +19,10 @@
  * 6az), so those two definitions stay extern-C free functions; the declarations
  * here are the real ones.
  *
- * THE "DetectClsn triple is launder-heavy" CLAIM IS RETIRED for slot 7.
- * src/_ZN14dBgW_KcMbgSclY10DetectClsnER9dBgCh_Lin.cpp is a real method as of
- * 2026-08-22 and needs no launder at all -- every access is a named dBgCh_Lin
- * member and the base call is the ordinary qualified `dBgW_Kc::DetectClsn'.
- * Slots 6 and 8 have not been retried; the claim was never measured per slot,
- * so treat it as untested there rather than as a finding.
+ * The complete DetectClsn overload set is real C++. Slot 7 uses named line
+ * members; slots 6 and 8 also use the reconstructed query classes and their
+ * ordinary automatic C1/D1 lifetimes. All three call dBgW_Kc::DetectClsn with
+ * a qualified base call so the override cannot dispatch back into itself.
  */
 
 #ifdef __cplusplus
@@ -39,9 +37,9 @@ struct dBgW_KcMbgSclY : dBgW_KcMbg {
     virtual ~dBgW_KcMbgSclY();                     /* slots 0/1 */
     virtual void Virtual08();                             /* slot 2 */
     virtual void GetNormal(s16 triID, Vector3 &res);      /* slot 4 */
-    virtual int DetectClsn(dBgCh_Gnd &ray);           /* slot 6 - free def */
-    virtual int DetectClsn(dBgCh_Lin &ray);             /* slot 7 - free def */
-    virtual int DetectClsn(dBgCh_SphCrr &sphere);           /* slot 8 - free def */
+    virtual int DetectClsn(dBgCh_Gnd &ray);               /* slot 6 */
+    virtual int DetectClsn(dBgCh_Lin &ray);               /* slot 7 */
+    virtual int DetectClsn(dBgCh_SphCrr &sphere);         /* slot 8 */
 
     /* DECLARED, never defined as a method here -- src/_ZN14dBgW_KcMbgSclYC1Ev.cpp
        owns C1; the C2 variant has no ROM counterpart because nothing derives

--- a/src/_ZN10StarMarker13InitResourcesEv.cpp
+++ b/src/_ZN10StarMarker13InitResourcesEv.cpp
@@ -5,19 +5,13 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "StarMarker.h"
-struct Vec3 { s32 x, y, z; };
-struct dBgCh_Gnd { char pad[0x50]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" {
 extern void _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(void *self, void *actor, const void *v, int d, int e, u32 f, u32 g);
-extern void _ZN9dBgCh_GndC1Ev(void *self);
-extern void _ZN5dBgCh19StartDetectingWaterEv(void *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, const void *v, void *actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
 extern void *_ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(u32 a, u32 b, const void *v, const void *v16, int e, int f);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
-extern void _ZN9dBgCh_GndD1Ev(void *self);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern int IsStarCollectedInCurLevel(u8 x);
 extern void _ZN7fBase_c18MarkForDestructionEv(void *self);
@@ -31,11 +25,10 @@ extern s8 data_0209f2f8;
 
 int StarMarker::InitResources()
 {
-    struct Vec3 pos;
-    struct Vec3 v0;
-    struct Vec3 v4;
-    struct Vec3 v5;
-    struct dBgCh_Gnd rg;
+    Vector3 pos;
+    Vector3 v0;
+    Vector3 v4;
+    Vector3 v5;
     u32 raw;
     u8 kind;
     int r3;
@@ -47,8 +40,8 @@ int StarMarker::InitResources()
     v0.y = -0x50000;
     v0.z = 0;
     _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(((char *)this) + 0xd4, ((char *)this), &v0, 0x50000, 0xa0000, 0x100002, 0x8000);
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN5dBgCh19StartDetectingWaterEv(&rg);
+    dBgCh_Gnd ground;
+    ground.StartDetectingWater();
 
     {
         s32 pyb = mPosY;
@@ -59,9 +52,9 @@ int StarMarker::InitResources()
         pos.y = pyy;
         pos.z = pz;
     }
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &pos, ((char *)this));
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0)
-        mGroundY = *(s32 *)((char *)&rg + (0x80 - 0x3c));
+    ground.SetObjAndPos(pos, this);
+    if (ground.DetectClsn() != 0)
+        mGroundY = ground.clsnY;
 
     r3 = 0;
     mStarID = (u8)(param1 & 0xf);
@@ -75,7 +68,6 @@ int StarMarker::InitResources()
             *p = (u16)(*p | 0x80);
         }
         _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x114, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0211093c), 1, 0x18);
-        _ZN9dBgCh_GndD1Ev(&rg);
         return 0;
     }
 
@@ -114,18 +106,15 @@ int StarMarker::InitResources()
     if (mState != 0) {
         _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9a8);
         if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x114, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0211092c), 1, 0x19) == 0) {
-            _ZN9dBgCh_GndD1Ev(&rg);
             return 0;
         }
     } else {
         if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x114, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0211093c), 1, 0x18) == 0) {
-            _ZN9dBgCh_GndD1Ev(&rg);
             return 0;
         }
     }
 
     if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0) {
-        _ZN9dBgCh_GndD1Ev(&rg);
         return 0;
     }
 
@@ -145,14 +134,11 @@ int StarMarker::InitResources()
         r3 = 1;
     if (r3 == 0 && SublevelToLevel((s8)data_0209f2f8) == 0x1d && IsStarCollectedInCurLevel(mStarID) != 0) {
         _ZN7fBase_c18MarkForDestructionEv(((char *)this));
-        _ZN9dBgCh_GndD1Ev(&rg);
         return 0;
     }
     if (_ZN8dActor_c18GetBitInDeathTableEv(((char *)this)) != 0) {
         _ZN7fBase_c18MarkForDestructionEv(((char *)this));
-        _ZN9dBgCh_GndD1Ev(&rg);
         return 0;
     }
-    _ZN9dBgCh_GndD1Ev(&rg);
     return 1;
 }

--- a/src/_ZN10dBgW_KcMbg10DetectClsnER12dBgCh_SphCrr.cpp
+++ b/src/_ZN10dBgW_KcMbg10DetectClsnER12dBgCh_SphCrr.cpp
@@ -25,100 +25,77 @@
  * `#pragma opt_common_subs off` is original and load-bearing: the six FMULs
  * against `scale` are deliberately not CSE'd.
  *
- * STILL A SHADOW: the local query object. It needs an exact 0x110 footprint
- * with explicit C1/D1 calls, while dBgCh_SphCrr as declared spans 0x10c and
- * declares no structors -- giving it real ones is its own slice, since it
- * changes every by-value use of the type. Kept as a byte-exact stand-in and
- * flagged rather than half-converted.
+ * The scratch query is now the real dBgCh_SphCrr. Its 0x110-byte layout and
+ * C1/D1 lifecycle are both reconstructed, so ordinary automatic storage emits
+ * the same constructor/destructor calls without a local shadow type.
  */
 #include "types.h"
 #include "dBgW_KcMbg.h"
 #include "dBgCh_SphCrr.h"
 #include "dBgPi.h"
 
-typedef struct {
-    int head[4];        /* 0x00 */
-    char result[0x60];  /* 0x10 */
-    u8 flags;           /* 0x70 */
-    char pad71[3];
-    char floorRes[0x28];/* 0x74 */
-    char wallRes[0x28]; /* 0x9c */
-    char undRes[0x28];  /* 0xc4 */
-    int f_ec;           /* 0xec */
-    int f_f0[3];        /* 0xf0 */
-    int f_fc;           /* 0xfc */
-    int f_100;          /* 0x100 */
-    int tail[3];        /* 0x104..0x110 */
-} LocSphere;
-
 extern "C" {
-extern void _ZN12dBgCh_SphCrrC1Ev(void* o);
-extern void func_02039e48(void* m, void* v, void* c);
-extern void _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(void* o, void* v, int r, void* a);
-extern void func_02037940(void* p, int v);
-extern void func_02035394(void* o, void* r);
-extern void func_02037a04(void* o, void* d1, void* d2);
-extern void func_02037a6c(void* b, int x1, int y1, int z1, int x2, int y2, int z2);
-extern void _ZN5dBgPiaSERKS_(void* d, void* s);
-extern void func_0203794c(void* d, void* s);
-extern void func_02037888(void* d, void* s);
-extern void func_0203782c(void* d, void* s);
-extern void _ZN12dBgCh_SphCrrD1Ev(void* o);
+extern void _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(
+    dBgCh_SphCrr *sphere, const Vector3 *pos, Fix12i radius, dActor_c *actor);
+extern void func_02039e48(dBgW_KcMbg *self, const Vector3 *v, Vector3 *res);
+extern void func_02037940(dBgCh_SphCrr *sphere, u8 flags);
+extern void func_02035394(dBgCh_SphCrr *dst, dBgCh_SphCrr *src);
+extern void func_02037a04(dBgCh_SphCrr *sphere, int *first, int *second);
+extern void func_02037a6c(dBgCh_SphCrr *sphere,
+    int x1, int y1, int z1, int x2, int y2, int z2);
+extern void func_0203794c(dBgCh_SphCrr *sphere, s32 *result);
+extern void func_02037888(dBgCh_SphCrr *sphere, dBgPi *result);
+extern void func_0203782c(dBgCh_SphCrr *sphere, dBgPi *result);
 }
 
 #pragma opt_common_subs off
 
 #define FMUL(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
 
-int dBgW_KcMbg::DetectClsn(dBgCh_SphCrr & sphere_)
+int dBgW_KcMbg::DetectClsn(dBgCh_SphCrr &sphere)
 {
-    dBgCh_SphCrr* sphere = &sphere_;
-    int pos[3];
+    Vector3 pos;
     int d[12];
-    LocSphere loc;
+    dBgCh_SphCrr loc;
     int r;
 
-    _ZN12dBgCh_SphCrrC1Ev(&loc);
-    func_02039e48(this, &sphere->centre, pos);
-    _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(&loc, pos,
-        FMUL(*(int*)&sphere->radius, invScale), 0);
-    loc.f_ec = FMUL(sphere->unk_0ec, invScale);
-    func_02037940(&loc, sphere->flags);
-    func_02035394(&loc, sphere);
-    r = dBgW_Kc::DetectClsn(*(dBgCh_SphCrr*)&loc);
+    func_02039e48(this, &sphere.centre, &pos);
+    _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(&loc, &pos,
+        FMUL(sphere.radius, invScale), 0);
+    loc.unk_0ec = FMUL(sphere.unk_0ec, invScale);
+    func_02037940(&loc, sphere.flags);
+    func_02035394(&loc, &sphere);
+    r = dBgW_Kc::DetectClsn(loc);
     if (r) {
         func_02037a04(&loc, d, d + 3);
-        d[6] = FMUL(d[0], *(int*)&scale);
-        d[7] = FMUL(d[1], *(int*)&scale);
-        d[8] = FMUL(d[2], *(int*)&scale);
-        d[9] = FMUL(d[3], *(int*)&scale);
-        d[10] = FMUL(d[4], *(int*)&scale);
-        d[11] = FMUL(d[5], *(int*)&scale);
-        func_02037a6c(sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
-        /* through the REFERENCE: a pointer-level upcast makes mwcc emit the
-           null-checked MI adjustment (cmp/addne), the ROM's is unconditional */
-        _ZN5dBgPiaSERKS_(&(dBgPi &)sphere_, loc.result);
-        *(u8*)(&sphere->flags) |= 1;
+        d[6] = FMUL(d[0], scale);
+        d[7] = FMUL(d[1], scale);
+        d[8] = FMUL(d[2], scale);
+        d[9] = FMUL(d[3], scale);
+        d[10] = FMUL(d[4], scale);
+        d[11] = FMUL(d[5], scale);
+        func_02037a6c(&sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
+        (dBgPi &)sphere = (dBgPi &)loc;
+        sphere.flags |= 1;
         if (loc.flags & 4) {
-            if (sphere->flags & 4) {
+            if (sphere.flags & 4) {
                 r &= ~1;
             } else {
-                sphere->SetFloorResult(*(dBgPi*)loc.floorRes);
+                sphere.SetFloorResult(loc.mClsnResult1);
             }
-            *(u8*)(&sphere->flags) |= 4;
-            if (sphere->unk_100 < loc.f_100) {
-                func_0203794c(sphere, &loc.f_fc);
+            sphere.flags |= 4;
+            if (sphere.unk_100 < loc.unk_100) {
+                func_0203794c(&sphere, &loc.unk_0fc);
             }
         }
         if (loc.flags & 8) {
-            func_02037888(sphere, loc.wallRes);
-            *(u8*)(&sphere->flags) |= 8;
+            func_02037888(&sphere, &loc.mClsnResult2);
+            sphere.flags |= 8;
         }
         if (loc.flags & 0x10) {
-            func_0203782c(sphere, loc.undRes);
-            *(u8*)(&sphere->flags) |= 0x10;
+            func_0203782c(&sphere, &loc.mClsnResult3);
+            sphere.flags |= 0x10;
         }
     }
-    _ZN12dBgCh_SphCrrD1Ev(&loc);
     return r;
 }

--- a/src/_ZN10dBgW_KcMbg10DetectClsnER9dBgCh_Gnd.cpp
+++ b/src/_ZN10dBgW_KcMbg10DetectClsnER9dBgCh_Gnd.cpp
@@ -22,47 +22,46 @@
 #include "dBgCh_Lin.h"
 
 extern "C" {
-extern void func_020374b8(int* a, int* b);
-extern int func_02039e48(void* a, void* b, void* c);
-extern int _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* o, void* a, void* b, void* c);
-extern int func_02035394(void* o, void* r);
-extern int func_02039e30(void* o, void* a, void* b);
-extern int _ZN5dBgPiaSERKS_(void* d, void* s);
-extern char data_020a0d0c[];
-extern char data_020a0d60[];
-extern char data_020a0d1c[];
+extern void func_020374b8(int *ground, int *position);
+extern void func_02039e48(dBgW_KcMbg *self, const Vector3 *v, Vector3 *res);
+extern void func_02035394(dBgCh_Lin *dst, dBgCh_Gnd *src);
+extern void func_02039e30(dBgW_KcMbg *self, const Vector3 *v, Vector3 *res);
+
+extern dBgCh_Lin data_020a0d0c;
+extern Vector3   data_020a0d60;
+extern dBgPi     data_020a0d1c;
 }
 
-int dBgW_KcMbg::DetectClsn(dBgCh_Gnd & ray_)
+int dBgW_KcMbg::DetectClsn(dBgCh_Gnd &ray)
 {
-  dBgCh_Gnd* ray = &ray_;
-  int sp0[3];
-  int sp0xc[3];
-  int sp0x18[3];
-  int sp0x24[3];
-  int sp0x30[3];
-  func_020374b8((int*)ray, sp0xc);
-  sp0x24[0] = sp0xc[0];
-  sp0x24[1] = sp0xc[1];
-  sp0x24[2] = sp0xc[2];
-  int b4c = ray->mProbeHeight;
-  if (ray->hasClsn != 0) {
-    int diff = *(volatile int*)&sp0xc[1] - *(int*)&ray->clsnY;
-    if (diff < b4c) b4c = diff;
-  }
-  sp0x24[1] = sp0x24[1] - b4c;
-  func_02039e48(this, sp0xc, sp0);
-  func_02039e48(this, sp0x24, sp0x18);
-  _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(data_020a0d0c, sp0, sp0x18, 0);
-  func_02035394(data_020a0d0c, ray);
-  int r = dBgW_Kc::DetectClsn(*(dBgCh_Lin*)data_020a0d0c);
-  if (r) {
-    func_02039e30(this, data_020a0d60, sp0x30);
-    /* through the REFERENCE: a pointer-level upcast makes mwcc emit the
-       null-checked MI adjustment (movs/addne), the ROM's is unconditional */
-    _ZN5dBgPiaSERKS_(&(dBgPi &)*ray, data_020a0d1c);
-    ray->clsnY = sp0x30[1];
-    ray->hasClsn = 1;
-  }
-  return r;
+    Vector3 localStart;
+    Vector3 probePos;
+    Vector3 localEnd;
+    Vector3 lineEnd;
+    Vector3 worldPos;
+
+    func_020374b8((int *)&ray, (int *)&probePos);
+    lineEnd = probePos;
+
+    int probeHeight = ray.mProbeHeight;
+    if (ray.hasClsn != 0) {
+        int distanceToHit = *(volatile Fix12i *)&probePos.y - ray.clsnY;
+        if (distanceToHit < probeHeight)
+            probeHeight = distanceToHit;
+    }
+    lineEnd.y -= probeHeight;
+
+    func_02039e48(this, &probePos, &localStart);
+    func_02039e48(this, &lineEnd, &localEnd);
+    data_020a0d0c.SetObjAndLine(localStart, localEnd, 0);
+    func_02035394(&data_020a0d0c, &ray);
+
+    int hit = dBgW_Kc::DetectClsn(data_020a0d0c);
+    if (hit != 0) {
+        func_02039e30(this, &data_020a0d60, &worldPos);
+        (dBgPi &)ray = data_020a0d1c;
+        ray.clsnY = worldPos.y;
+        ray.hasClsn = 1;
+    }
+    return hit;
 }

--- a/src/_ZN10dBgW_KcMbg10DetectClsnER9dBgCh_Lin.cpp
+++ b/src/_ZN10dBgW_KcMbg10DetectClsnER9dBgCh_Lin.cpp
@@ -16,38 +16,39 @@
 #include "dBgCh_Lin.h"
 
 extern "C" {
-extern int func_02039e48(void* a, void* b, void* c);
-extern int _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* o, void* a, void* b, void* c);
-extern int func_02035394(void* o, void* r);
-extern int func_02039e30(void* o, void* a, void* b);
-extern void func_020375ec(int* d, int* s);
-extern int _ZN5dBgPiaSERKS_(void* d, void* s);
-extern char data_020a0d0c[];
-extern char data_020a0d60[];
-extern char data_020a0d1c[];
+extern void func_02039e48(dBgW_KcMbg *self, const Vector3 *v, Vector3 *res);
+extern void func_02035394(dBgCh_Lin *dst, dBgCh_Lin *src);
+extern void func_02039e30(dBgW_KcMbg *self, const Vector3 *v, Vector3 *res);
+extern void func_020375ec(int *line, const int *position);
+
+extern dBgCh_Lin data_020a0d0c;
+extern Vector3   data_020a0d60;
+extern dBgPi     data_020a0d1c;
 }
 
-int dBgW_KcMbg::DetectClsn(dBgCh_Lin & ray_)
+int dBgW_KcMbg::DetectClsn(dBgCh_Lin &ray)
 {
-  dBgCh_Lin* ray = &ray_;
-  int sp0[3];
-  int sp0xc[3];
-  int sp0x18[3];
-  func_02039e48(this, &ray->start, sp0);
-  func_02039e48(this, &ray->lineEnd, sp0xc);
-  unsigned char f50 = ray->hasClsn;
-  _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(data_020a0d0c, sp0, sp0xc, 0);
-  if (f50) *(unsigned char*)(data_020a0d0c + 0x50) = 1;
-  func_02035394(data_020a0d0c, ray);
-  int r = dBgW_Kc::DetectClsn(*(dBgCh_Lin*)data_020a0d0c);
-  if (r) {
-    int saved = *(int*)(data_020a0d0c + 0x60);
-    func_02039e30(this, data_020a0d60, sp0x18);
-    func_020375ec((int*)ray, sp0x18);
-    ray->clsnDist = saved;
-    /* the dBgPi base sub-object, at +0x10 */
-    _ZN5dBgPiaSERKS_((char *)ray + 0x10, data_020a0d1c);
-    ray->hasClsn = 1;
-  }
-  return r;
+    Vector3 start;
+    Vector3 end;
+    Vector3 worldPos;
+
+    func_02039e48(this, &ray.start, &start);
+    func_02039e48(this, &ray.lineEnd, &end);
+
+    u8 hadClsn = ray.hasClsn;
+    data_020a0d0c.SetObjAndLine(start, end, 0);
+    if (hadClsn != 0)
+        data_020a0d0c.hasClsn = 1;
+    func_02035394(&data_020a0d0c, &ray);
+
+    int hit = dBgW_Kc::DetectClsn(data_020a0d0c);
+    if (hit != 0) {
+        Fix12i distance = data_020a0d0c.clsnDist;
+        func_02039e30(this, &data_020a0d60, &worldPos);
+        func_020375ec((int *)&ray, (const int *)&worldPos);
+        ray.clsnDist = distance;
+        (dBgPi &)ray = data_020a0d1c;
+        ray.hasClsn = 1;
+    }
+    return hit;
 }

--- a/src/_ZN10daPgDfdr_c13InitResourcesEv.cpp
+++ b/src/_ZN10daPgDfdr_c13InitResourcesEv.cpp
@@ -18,6 +18,7 @@
 #include "daPgDfdr_c.h"
 #include "decl_common.h"
 #include "TextureSequence.h"
+#include "dBgCh_Gnd.h"
 
 struct BMD_File;
 struct BTP_File;
@@ -33,10 +34,6 @@ extern void *_ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *o, void *kcl, void *m, int fx, short s, void *clps);
 extern void func_020393d4(void *p, int v);
 extern void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *o, void *act, int a, int b, unsigned c, unsigned d);
-extern void _ZN9dBgCh_GndC1Ev(void *o);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *o, void *v, void *act);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *o);
-extern void _ZN9dBgCh_GndD1Ev(void *o);
 
 extern char data_ov027_02113c7c;
 extern char data_ov027_02113c94;
@@ -44,16 +41,11 @@ extern char data_ov027_02113c6c;
 extern void _ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_(void);
 }
 
-/* dBgCh_Gnd, by size only: the raycast result word this reads sits at +0x44 and
-   the object is 0x54 bytes. Its real header is not pulled in here. */
-struct RG { char pad[0x54]; };
-
 s32 daPgDfdr_c::InitResources()
 {
     int i;
     void *f;
-    RG rg;
-    int v[3];
+    Vector3 pos;
 
     f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov027_02113c7c);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(&mModelAnim, f, 1, -1);
@@ -83,19 +75,18 @@ s32 daPgDfdr_c::InitResources()
     _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(&mdCcAc_c, this, 0x82000, 0xc8000, 0x800004, 0);
     func_ov027_02111d70((char*)this, 1);
 
-    v[0] = mPosX;
-    v[1] = mPosY;
-    v[2] = mPosZ;
-    v[1] = v[1] + 0x14000;
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, v, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg))
-        mPosY = *(int*)((char*)&rg + 0x44);
+    pos.x = mPosX;
+    pos.y = mPosY;
+    pos.z = mPosZ;
+    pos.y += 0x14000;
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn())
+        mPosY = ground.clsnY;
     else
-        mPosY = v[1];
+        mPosY = pos.y;
     mScaleX = 0x1000;
     mScaleY = 0x1000;
     mScaleZ = 0x1000;
-    _ZN9dBgCh_GndD1Ev(&rg);
     return 1;
 }

--- a/src/_ZN10daPgMthr_c13InitResourcesEv.cpp
+++ b/src/_ZN10daPgMthr_c13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 /* recovered: named members + shared header, real C++ method */
 #include "daPgMthr_c.h"
 #include "TextureSequence.h"
+#include "dBgCh_Gnd.h"
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
@@ -13,11 +14,7 @@ extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *f);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *self, void *act, int a, int b, unsigned int c2, unsigned int d);
 extern void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *self, void *act, int a, int b, void *c2, void *d);
-extern void _ZN9dBgCh_GndC1Ev(void *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, void *pos, void *act);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
 extern void func_ov018_02111d28(char *c, int r1);
-extern void _ZN9dBgCh_GndD1Ev(void *self);
 extern int data_ov018_02113c00[];
 extern int data_ov018_02112c04[];
 }
@@ -42,23 +39,21 @@ int daPgMthr_c::InitResources()
     mScaleY = 0x1000;
     mScaleZ = 0x1000;
     _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(&mWithMeshClsn, this, 0x32000, 0x32000, 0, 0);
-    char rg[0x54];
-    int v[3];
-    v[0] = mPosX;
-    v[1] = mPosY;
-    v[2] = mPosZ;
-    v[1] += 0x14000;
-    _ZN9dBgCh_GndC1Ev(rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, v, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(rg))
-        mPosY = *(int*)(rg+0x44);
+    Vector3 pos;
+    pos.x = mPosX;
+    pos.y = mPosY;
+    pos.z = mPosZ;
+    pos.y += 0x14000;
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn())
+        mPosY = ground.clsnY;
     else
-        mPosY = v[1];
+        mPosY = pos.y;
     mHomePosX = mPosX;
     mHomePosY = mPosY;
     mHomePosZ = mPosZ;
     unk_374 = 0;
     func_ov018_02111d28((char *)this, 0);
-    _ZN9dBgCh_GndD1Ev(rg);
     return 1;
 }

--- a/src/_ZN11BobOmbBuddy13InitResourcesEv.cpp
+++ b/src/_ZN11BobOmbBuddy13InitResourcesEv.cpp
@@ -4,18 +4,14 @@
 #include "decl_SaveData.h"
 #include "BobOmbBuddy.h"
 #include "SharedFilePtr.h"
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" {
 extern void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void* self, void* actor, Fix12i b, Fix12i c, unsigned int d, unsigned int e);
 extern void func_ov084_0212c960(void* c, int i);
-extern void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3& v, void* actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
 extern int func_ov084_0212ca60(void* p);
 extern void* _ZN8dActor_c13ClosestPlayerEv(void* self);
 extern int IsStarCollected(int r0, int r1);
-extern void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 extern int SublevelToLevel(int sublevelID);
 extern int func_ov084_0212cac0(void *c);
 
@@ -28,7 +24,6 @@ extern SharedFilePtr data_ov084_02130d9c;
 
 int BobOmbBuddy::InitResources()
 {
-    dBgCh_Gnd rc;
     Vector3 pos;
 
     BMD_File *modelFile = (BMD_File *)Model::LoadFile(data_ov084_02130da4);
@@ -47,10 +42,10 @@ int BobOmbBuddy::InitResources()
         pos.z = z;
     }
 
-    _ZN9dBgCh_GndC1Ev(&rc);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc) != 0)
-        mPosY = rc.floor[(0x44 - 0x14) / 4];
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn() != 0)
+        mPosY = ground.clsnY;
 
     if (func_ov084_0212ca60(this) != 0) {
         void* player = _ZN8dActor_c13ClosestPlayerEv(this);
@@ -75,7 +70,6 @@ int BobOmbBuddy::InitResources()
             goto after_lostcap;
 
     state_return0:
-        _ZN9dBgCh_GndD1Ev(&rc);
         return 0;
     }
 
@@ -90,10 +84,8 @@ after_lostcap:
         goto return1;
 
 return0_2:
-    _ZN9dBgCh_GndD1Ev(&rc);
     return 0;
 
 return1:
-    _ZN9dBgCh_GndD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN11CrazedCrate13InitResourcesEv.cpp
+++ b/src/_ZN11CrazedCrate13InitResourcesEv.cpp
@@ -4,23 +4,18 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CrazedCrate.h"
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
 extern "C" void _ZN11ShadowModel10InitCuboidEv(void* self);
 extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void* self, void* actor, int a, int b, unsigned int c, unsigned int d);
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3& v, void* actor);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
 extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void* self, void* actor, int a, int b, void* v, int c);
 extern "C" void func_ov080_02124c3c(void* self);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 
 
 int CrazedCrate::InitResources()
 {
-    dBgCh_Gnd rc;
     Vector3 pos;
     void* file = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov080_02128468);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, file, 1, 1);
@@ -36,10 +31,10 @@ int CrazedCrate::InitResources()
         pos.z = mPosZ;
         pos.y = p60 + 0xc8000;
     }
-    _ZN9dBgCh_GndC1Ev(&rc);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc))
-        mPosY = rc.floor[(0x44 - 0x14) / 4];
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn())
+        mPosY = ground.clsnY;
     else
         mPosY = pos.y;
     mScaleX = 0x1000;
@@ -49,6 +44,5 @@ int CrazedCrate::InitResources()
     unk_374 = 0;
     func_ov080_0212513c(((char*)this));
     func_ov080_02124c3c(((char*)this));
-    _ZN9dBgCh_GndD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN11PowerFlower13InitResourcesEv.cpp
+++ b/src/_ZN11PowerFlower13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PowerFlower.h"
+#include "dBgCh_Gnd.h"
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
@@ -12,11 +13,7 @@ extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *self, void *act, Fix12i a, Fix12i b, unsigned int c2, unsigned int d);
 extern void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *self, void *act, Fix12i a, Fix12i b, void *d, void *e);
 extern void _ZN10dBgCh_Actr19StartDetectingWaterEv(void *self);
-extern void _ZN9dBgCh_GndC1Ev(void *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, const struct Vector3 *pos, void *act);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
 extern void *_ZN8dActor_c13ClosestPlayerEv(void *self);
-extern void _ZN9dBgCh_GndD1Ev(void *self);
 }
 
 extern void *data_ov002_0210d9d0[];
@@ -25,7 +22,6 @@ extern void *data_ov002_0210d9b0[];
 int PowerFlower::InitResources()
 {
     struct Vector3 pos;
-    char ray[0x54];
     short *angp;
 
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9d0);
@@ -53,18 +49,17 @@ int PowerFlower::InitResources()
     pos.y = mPosY;
     pos.z = mPosZ;
     pos.y += 0x14000;
-    _ZN9dBgCh_GndC1Ev(ray);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(ray, &pos, 0);
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
     mGroundY = pos.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(ray))
-        mGroundY = *(int *)(ray + 0x44);
+    if (ground.DetectClsn())
+        mGroundY = ground.clsnY;
     mLifeTimer = 0xb4;
 
     if (param1 == 0xffff) {
         if (*(int *)((char *)_ZN8dActor_c13ClosestPlayerEv(((char *)this)) + 8) == 1 && _ZN8SaveData16HasPlayerLostCapEv() == 0) {
             func_ov002_020b9704(((char *)this), 2);
         } else {
-            _ZN9dBgCh_GndD1Ev(ray);
             return 0;
         }
     } else {
@@ -72,6 +67,5 @@ int PowerFlower::InitResources()
     }
     angp = (short *)(int)((char *)&mAngleY);
     *angp = *angp - 0x4000;
-    _ZN9dBgCh_GndD1Ev(ray);
     return 1;
 }

--- a/src/_ZN11SnowmanBody13InitResourcesEv.cpp
+++ b/src/_ZN11SnowmanBody13InitResourcesEv.cpp
@@ -2,15 +2,11 @@
 // @symbol _ZN11SnowmanBody13InitResourcesEv
 #include "SnowmanBody.h"
 #include "SharedFilePtr.h"
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void* self, void* actor, int a, int b, unsigned int c, unsigned int d);
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3& v, void* actor);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
 extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void* self, void* actor, int a, int b, void* v, int c);
 extern "C" void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 
 extern "C" void *data_ov072_02122b20;
 extern Matrix4x3 IDENTITY_MATRIX4X3;
@@ -18,7 +14,6 @@ extern Matrix4x3 IDENTITY_MATRIX4X3;
 int SnowmanBody::InitResources()
 {
     struct MatrixWords { int words[12]; };
-    dBgCh_Gnd rc;
     Vector3 pos;
     void* file = Model::LoadFile(*(SharedFilePtr *)&data_ov072_02122b20);
     mModel.SetFile((BMD_File *)file, 1, 1);
@@ -34,10 +29,10 @@ int SnowmanBody::InitResources()
         pos.z = mPosZ;
         pos.y = p60 + 0x14000;
     }
-    _ZN9dBgCh_GndC1Ev(&rc);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc))
-        mPosY = rc.floor[(0x44 - 0x14) / 4];
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn())
+        mPosY = ground.clsnY;
     else
         mPosY = pos.y;
     mHomePosX = mPosX;
@@ -52,6 +47,5 @@ int SnowmanBody::InitResources()
     *(MatrixWords *)((char *)&mShadowMat) = *(MatrixWords *)&IDENTITY_MATRIX4X3;
     UpdateModel();
     _ZN7PathPtr6FromIDEj(((char*)this) + 0x380, param1 & 0xff);
-    _ZN9dBgCh_GndD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN11SnowmanHead13InitResourcesEv.cpp
+++ b/src/_ZN11SnowmanHead13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "TextureSequence.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SnowmanHead.h"
+#include "dBgCh_Gnd.h"
 
 struct BMD_File;
 struct BTP_File;
@@ -15,17 +16,12 @@ extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *base, void *file, int a, in
 extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *ref);
 extern void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *t, void *a, int b, int c, unsigned int d, unsigned int e);
 extern void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *t, void *a, int b, int c, void *d, void *e);
-extern void _ZN9dBgCh_GndC1Ev(void *t);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *t, const struct Vector3 *pos, void *actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *t);
-extern void _ZN9dBgCh_GndD1Ev(void *t);
 
 }
 
 int SnowmanHead::InitResources()
 {
     struct Vector3 pos;
-    char ray[0x54];
     int i;
 
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4,
@@ -48,15 +44,14 @@ int SnowmanHead::InitResources()
     pos.y = mPosY;
     pos.z = mPosZ;
     pos.y += 0x14000;
-    _ZN9dBgCh_GndC1Ev(ray);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(ray, &pos, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(ray) != 0)
-        mPosY = *(int *)(ray + 0x44);
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn() != 0)
+        mPosY = ground.clsnY;
     else
         mPosY = pos.y;
 
     SetState(0);
     UpdateModel();
-    _ZN9dBgCh_GndD1Ev(ray);
     return 1;
 }

--- a/src/_ZN11daBgSnwmn_c13InitResourcesEv.cpp
+++ b/src/_ZN11daBgSnwmn_c13InitResourcesEv.cpp
@@ -9,6 +9,7 @@
  * the hit (or the probe height) and raised 0xc3000. */
 #include "daBgSnwmn_c.h"
 #include "decl_common.h"
+#include "dBgCh_Gnd.h"
 
 extern "C" {
 extern int IsStarCollectedInLevel(s8 levelID, int starID);
@@ -21,17 +22,12 @@ extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *b
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, void *btp, int a, int fix, u32 u);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(void *self, void *act, void *pos, int f1, int f2, u32 u1, u32 u2);
-extern void _ZN9dBgCh_GndC1Ev(void *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, void *pos, void *act);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
-extern void _ZN9dBgCh_GndD1Ev(void *self);
 extern int data_ov072_02122c70[];
 }
 
 s32 daBgSnwmn_c::InitResources()
 {
-    char rg[0x50];
-    int v[3];
+    Vector3 pos;
     void *m;
 
     if (IsStarCollectedInLevel(0xa, 5) == 0)
@@ -54,16 +50,16 @@ s32 daBgSnwmn_c::InitResources()
 
     _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(&mCylClsn, this, data_ov072_02122c70, 0xc3000, 0x17c000, 0x800004, 0);
 
-    v[0] = mPosX;
-    v[1] = mPosY;
-    v[2] = mPosZ;
-    v[1] += 0x14000;
-    _ZN9dBgCh_GndC1Ev(rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, v, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(rg))
-        mPosY = *(int *)(rg + 0x44);
+    pos.x = mPosX;
+    pos.y = mPosY;
+    pos.z = mPosZ;
+    pos.y += 0x14000;
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn())
+        mPosY = ground.clsnY;
     else
-        mPosY = v[1];
+        mPosY = pos.y;
     mPosY += 0xc3000;
     mVertAccel = 0;
     mTerminalVelocity = 0;
@@ -71,6 +67,5 @@ s32 daBgSnwmn_c::InitResources()
     mScaleY = 0x1800;
     mScaleZ = 0x1800;
     func_ov072_021208d8(this);
-    _ZN9dBgCh_GndD1Ev(rg);
     return 1;
 }

--- a/src/_ZN13TTC_MovingBar13InitResourcesEv.cpp
+++ b/src/_ZN13TTC_MovingBar13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TTC_MovingBar.h"
+#include "dBgCh_Gnd.h"
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmd, int a, int b);
@@ -18,20 +19,13 @@ extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Bloc
 }
 extern "C" {
 extern void func_020393d4(int *p, int v);
-extern void _ZN9dBgCh_GndC1Ev(void *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, void *pos, void *actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
-extern void _ZN9dBgCh_GndD1Ev(void *self);
 }
 extern int _ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_;
 
 
-struct Vec3 { int x, y, z; };
-
 int TTC_MovingBar::InitResources()
 {
-    struct Vec3 pos;
-    char raycast[0x50];
+    Vector3 pos;
     int i;
 
     if (actorID != 0x72) {
@@ -67,12 +61,11 @@ int TTC_MovingBar::InitResources()
     pos.z = mPosZ;
     pos.y = pos.y - 0xa000;
 
-    _ZN9dBgCh_GndC1Ev(raycast);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(raycast, &pos, (void *)0);
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
     mGroundY = pos.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(raycast))
-        mGroundY = *(int *)(raycast + 0x44);
-    _ZN9dBgCh_GndD1Ev(raycast);
+    if (ground.DetectClsn())
+        mGroundY = ground.clsnY;
 
     return 1;
 }

--- a/src/_ZN14CutsceneObject8BehaviorEv.cpp
+++ b/src/_ZN14CutsceneObject8BehaviorEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CutsceneObject.h"
+#include "dBgCh_Gnd.h"
 typedef struct 
 {
   s32 x;
@@ -15,17 +16,9 @@ typedef struct
 {
   s32 w[12];
 } Mtx43;
-typedef struct 
-{
-  char pad[0x50];
-} dBgCh_Gnd;
 extern "C" {
 extern void _ZN8dActor_c22UpdatePosWithOnlySpeedEP5dCc_c(void *c, void *cyl);
 extern void _ZN8dActor_c9UpdatePosEP5dCc_c(void *c, void *cyl);
-extern void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd *rc);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd *rc, const Vec3 *v, void *actor);
-extern s32 _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd *rc);
-extern void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd *rc);
 extern void Vec3_Asr(Vec3 *d, Vec3 *s, int sh);
 extern void Matrix4x3_FromTranslation(Mtx43 *m, s32 x, s32 y, s32 z);
 extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(void *m, s32 x, s32 y, s32 z);
@@ -36,9 +29,7 @@ extern Mtx43 data_020a0e68;
 int CutsceneObject::Behavior()
 {
   char *c = (char *) ((void *)this);
-  s32 *new_var;
-  dBgCh_Gnd rc;
-  Vec3 v;
+  Vector3 v;
   Vec3 asr;
   int new_var2;
   s32 t;
@@ -72,18 +63,17 @@ int CutsceneObject::Behavior()
         v.y = new_var2;
         v.z = zz;
       }
-      _ZN9dBgCh_GndC1Ev(&rc);
-      _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, &v, 0);
-      if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc) != 0)
+      dBgCh_Gnd ground;
+      ground.SetObjAndPos(v, 0);
+      if (ground.DetectClsn() != 0)
       {
-        s32 h = *(new_var = (s32 *) (((char *) (&rc)) + 0x44));
+        s32 h = ground.clsnY;
         if ((*((s32 *) (c + 0x60))) < h)
         {
           *((s32 *) (c + 0x60)) = h;
           *((u8 *) ((((int) c) + 0x103))) |= 1;
         }
       }
-      _ZN9dBgCh_GndD1Ev(&rc);
     }
   }
   Vec3_Asr(&asr, (Vec3 *) (c + 0x5c), 3);

--- a/src/_ZN14dBgW_KcMbgSclY10DetectClsnER12dBgCh_SphCrr.cpp
+++ b/src/_ZN14dBgW_KcMbgSclY10DetectClsnER12dBgCh_SphCrr.cpp
@@ -1,100 +1,88 @@
 //cpp
-#include "types.h"
-typedef struct {
-    int head[4];         /* 0x00 */
-    char result[0x60];   /* 0x10 */
-    u8 flags;            /* 0x70 */
-    char pad71[3];
-    char floorRes[0x28]; /* 0x74 */
-    char wallRes[0x28];  /* 0x9c */
-    char undRes[0x28];   /* 0xc4 */
-    int f_ec;            /* 0xec */
-    int f_f0[3];         /* 0xf0 */
-    int f_fc;             /* 0xfc */
-    int f_100;             /* 0x100 */
-    int tail[3];           /* 0x104..0x110 */
-} LocSphere;
+/* Slot 8: test a world-space sphere against a vertically scaled collider.
+ * The local query is the real dBgCh_SphCrr, so its C1/D1 calls come from
+ * ordinary automatic storage. SetObjAndSphere retains its measured raw-Fix12
+ * call veneer: spelling that disputed parameter as Fix12<int> grows this
+ * caller by 0xc bytes under the pinned compiler. */
+#include "dBgW_KcMbgSclY.h"
+#include "dBgCh_SphCrr.h"
+#include "dBgPi.h"
 
 extern "C" {
-void func_0203abb0(int* a, int* b);
-void func_0203aa74(void* thiz, int* v, int* res);
-void _ZN12dBgCh_SphCrrC1Ev(void* o);
-void _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(void* o, void* v, int r, void* a);
-void func_02037940(void* p, int v);
-void func_02035394(void* o, void* r);
-int _ZN7dBgW_Kc10DetectClsnER12dBgCh_SphCrr(void* o, void* s);
-void func_02037a04(void* o, void* d1, void* d2);
-void func_02037a6c(void* b, int x1, int y1, int z1, int x2, int y2, int z2);
-void _ZN5dBgPiaSERKS_(void* d, void* s);
-void* func_02037938(void* p);
-void _ZN12dBgCh_SphCrr14SetFloorResultERK5dBgPi(void* o, void* r);
-void func_0203794c(void* d, void* s);
-void* func_020378dc(void* p);
-void func_02037888(void* d, void* s);
-void* func_02037880(void* p);
-void func_0203782c(void* d, void* s);
-void _ZN12dBgCh_SphCrrD1Ev(void* o);
+void func_0203abb0(dM3dGSph* sphere, Vector3* centre);
+void func_0203aa74(dBgW_KcMbgSclY* self, Vector3* v, Vector3* res);
+void _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(
+    dBgCh_SphCrr *sphere, const Vector3 *pos, Fix12i radius, dActor_c *actor);
+void func_02037940(dBgCh_SphCrr *sphere, u8 flags);
+void func_02035394(dBgCh_SphCrr *dst, dBgCh_SphCrr *src);
+void func_02037a04(dBgCh_SphCrr *sphere, int *first, int *second);
+void func_02037a6c(dBgCh_SphCrr *sphere,
+    int x1, int y1, int z1, int x2, int y2, int z2);
+dBgPi *func_02037938(dBgCh_SphCrr *sphere);
+void func_0203794c(dBgCh_SphCrr *sphere, s32 *result);
+dBgPi *func_020378dc(dBgCh_SphCrr *sphere);
+void func_02037888(dBgCh_SphCrr *sphere, dBgPi *result);
+dBgPi *func_02037880(dBgCh_SphCrr *sphere);
+void func_0203782c(dBgCh_SphCrr *sphere, dBgPi *result);
 }
 
 #pragma opt_common_subs off
 
 #define FMUL(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
 
-extern "C" int _ZN14dBgW_KcMbgSclY10DetectClsnER12dBgCh_SphCrr(char* self, char* sphere)
+int dBgW_KcMbgSclY::DetectClsn(dBgCh_SphCrr &sphere)
 {
-    int v1[3];
-    int v2[3];
+    Vector3 centre;
+    Vector3 localCentre;
     int d[12];
-    LocSphere loc;
-    int scale;
+    int inverseScale;
     int radius1;
     int radius2;
     int r;
 
-    func_0203abb0((int*)(sphere + 0x38), v1);
-    func_0203aa74(self, v1, v2);
+    func_0203abb0(&(dM3dGSph &)sphere, &centre);
+    func_0203aa74(this, &centre, &localCentre);
 
-    scale = *(int*)(self + 0x164);
-    radius1 = FMUL(*(int*)(sphere + 0x48), scale);
-    radius2 = FMUL(*(int*)(sphere + 0xec), scale);
+    inverseScale = invScale;
+    radius1 = FMUL(sphere.radius, inverseScale);
+    radius2 = FMUL(sphere.unk_0ec, inverseScale);
 
-    _ZN12dBgCh_SphCrrC1Ev(&loc);
-    _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(&loc, v2, radius1, 0);
-    loc.f_ec = radius2;
-    func_02037940(&loc, *(u8*)(sphere + 0x70));
-    func_02035394(&loc, sphere);
-    r = _ZN7dBgW_Kc10DetectClsnER12dBgCh_SphCrr(self, &loc);
+    dBgCh_SphCrr loc;
+    _ZN12dBgCh_SphCrr15SetObjAndSphereERK7Vector35Fix12IiEP8dActor_c(&loc, &localCentre, radius1, 0);
+    loc.unk_0ec = radius2;
+    func_02037940(&loc, sphere.flags);
+    func_02035394(&loc, &sphere);
+    r = dBgW_Kc::DetectClsn(loc);
     if (r) {
         func_02037a04(&loc, d, d + 3);
-        d[6] = FMUL(d[0], *(int*)(self + 0x50));
-        d[7] = FMUL(d[1], *(int*)(self + 0x50));
-        d[8] = FMUL(d[2], *(int*)(self + 0x50));
-        d[9] = FMUL(d[3], *(int*)(self + 0x50));
-        d[10] = FMUL(d[4], *(int*)(self + 0x50));
-        d[11] = FMUL(d[5], *(int*)(self + 0x50));
-        func_02037a6c(sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
-        _ZN5dBgPiaSERKS_(sphere + 0x10, loc.result);
-        *(u8*)(sphere + 0x70) |= 1;
+        d[6] = FMUL(d[0], scale);
+        d[7] = FMUL(d[1], scale);
+        d[8] = FMUL(d[2], scale);
+        d[9] = FMUL(d[3], scale);
+        d[10] = FMUL(d[4], scale);
+        d[11] = FMUL(d[5], scale);
+        func_02037a6c(&sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
+        (dBgPi &)sphere = (dBgPi &)loc;
+        sphere.flags |= 1;
         if (loc.flags & 4) {
-            if (*(u8*)(sphere + 0x70) & 4) {
+            if (sphere.flags & 4) {
                 r &= ~1;
             } else {
-                _ZN12dBgCh_SphCrr14SetFloorResultERK5dBgPi(sphere, func_02037938(&loc));
+                sphere.SetFloorResult(*(dBgPi*)func_02037938(&loc));
             }
-            *(u8*)(sphere + 0x70) |= 4;
-            if (*(int*)(sphere + 0x100) < loc.f_100) {
-                func_0203794c(sphere, &loc.f_fc);
+            sphere.flags |= 4;
+            if (sphere.unk_100 < loc.unk_100) {
+                func_0203794c(&sphere, &loc.unk_0fc);
             }
         }
         if (loc.flags & 8) {
-            func_02037888(sphere, func_020378dc(&loc));
-            *(u8*)(sphere + 0x70) |= 8;
+            func_02037888(&sphere, func_020378dc(&loc));
+            sphere.flags |= 8;
         }
         if (loc.flags & 0x10) {
-            func_0203782c(sphere, func_02037880(&loc));
-            *(u8*)(sphere + 0x70) |= 0x10;
+            func_0203782c(&sphere, func_02037880(&loc));
+            sphere.flags |= 0x10;
         }
     }
-    _ZN12dBgCh_SphCrrD1Ev(&loc);
     return r;
 }

--- a/src/_ZN14dBgW_KcMbgSclY10DetectClsnER9dBgCh_Gnd.cpp
+++ b/src/_ZN14dBgW_KcMbgSclY10DetectClsnER9dBgCh_Gnd.cpp
@@ -1,50 +1,51 @@
 //cpp
+/* Slot 6: turn a ground probe into a collider-space line query. The scratch
+ * dBgCh_Lin owns its lifetime normally; the qualified base call prevents this
+ * override from dispatching back into itself. */
+#include "dBgW_KcMbgSclY.h"
+#include "dBgCh_Gnd.h"
+#include "dBgCh_Lin.h"
+
 extern "C" {
-struct Vector3 { int x, y, z; };
-struct dActor_c;
-struct dBgCh_Lin { char data[0x78]; };
-
-extern void func_020374b8(int *a, int *b);
-extern void func_0203aa74(void *thiz, Vector3 *v, Vector3 *res);
-extern void _ZN9dBgCh_LinC1Ev(dBgCh_Lin *);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(dBgCh_Lin *, const Vector3 *, const Vector3 *, dActor_c *);
-extern void func_02035394(dBgCh_Lin *, void *);
-extern int _ZN7dBgW_Kc10DetectClsnER9dBgCh_Lin(void *, dBgCh_Lin *);
-extern Vector3 *_ZN9dBgCh_Lin10GetClsnPosEv(Vector3 *, dBgCh_Lin *);
-extern void func_0203aa10(void *thiz, const Vector3 *v, Vector3 *res);
-extern void _ZN5dBgPiaSERKS_(void *, const void *);
-extern void _ZN9dBgCh_LinD1Ev(dBgCh_Lin *);
-
-int _ZN14dBgW_KcMbgSclY10DetectClsnER9dBgCh_Gnd(void *self, char *ground)
-{
-    Vector3 v0, v0xc, v0x18, v0x24, v0x30, v0x3c;
-    dBgCh_Lin ray;
-
-    func_020374b8((int *)ground, (int *)&v0xc);
-    v0x24 = v0xc;
-
-    int b4c = *(int *)(ground + 0x4c);
-    if (*(unsigned char *)(ground + 0x48) != 0) {
-        int diff = v0xc.y - *(int *)(ground + 0x44);
-        if (diff < b4c) b4c = diff;
-    }
-    v0x24.y = v0x24.y - b4c;
-
-    func_0203aa74(self, &v0xc, &v0);
-    func_0203aa74(self, &v0x24, &v0x18);
-
-    _ZN9dBgCh_LinC1Ev(&ray);
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(&ray, &v0, &v0x18, 0);
-    func_02035394(&ray, ground);
-    int r = _ZN7dBgW_Kc10DetectClsnER9dBgCh_Lin(self, &ray);
-    if (r) {
-        _ZN9dBgCh_Lin10GetClsnPosEv(&v0x30, &ray);
-        func_0203aa10(self, &v0x30, &v0x3c);
-        _ZN5dBgPiaSERKS_(ground + 0x10, ray.data + 0x10);
-        *(int *)(ground + 0x44) = v0x3c.y;
-        *(unsigned char *)(ground + 0x48) = 1;
-    }
-    _ZN9dBgCh_LinD1Ev(&ray);
-    return r;
+void func_020374b8(int *ground, int *position);
+void func_0203aa74(dBgW_KcMbgSclY *self, Vector3 *v, Vector3 *res);
+void func_02035394(dBgCh_Lin *dst, dBgCh_Gnd *src);
+void func_0203aa10(dBgW_KcMbgSclY *self, const Vector3 *v, Vector3 *res);
 }
+
+int dBgW_KcMbgSclY::DetectClsn(dBgCh_Gnd &ground)
+{
+    Vector3 localStart;
+    Vector3 probePos;
+    Vector3 localEnd;
+    Vector3 lineEnd;
+
+    func_020374b8((int *)&ground, (int *)&probePos);
+    lineEnd = probePos;
+
+    int probeHeight = ground.mProbeHeight;
+    if (ground.hasClsn != 0) {
+        int distanceToHit = probePos.y - ground.clsnY;
+        if (distanceToHit < probeHeight)
+            probeHeight = distanceToHit;
+    }
+    lineEnd.y -= probeHeight;
+
+    func_0203aa74(this, &probePos, &localStart);
+    func_0203aa74(this, &lineEnd, &localEnd);
+
+    dBgCh_Lin ray;
+    ray.SetObjAndLine(localStart, localEnd, 0);
+    func_02035394(&ray, &ground);
+
+    int hit = dBgW_Kc::DetectClsn(ray);
+    if (hit != 0) {
+        Vector3 clsnPos = ray.GetClsnPos();
+        Vector3 worldPos;
+        func_0203aa10(this, &clsnPos, &worldPos);
+        (dBgPi &)ground = (dBgPi &)ray;
+        ground.clsnY = worldPos.y;
+        ground.hasClsn = 1;
+    }
+    return hit;
 }

--- a/src/_ZN14dBgW_KcMbgSclY10DetectClsnER9dBgCh_Lin.cpp
+++ b/src/_ZN14dBgW_KcMbgSclY10DetectClsnER9dBgCh_Lin.cpp
@@ -30,9 +30,6 @@ void func_0203aa74(dBgW_KcMbgSclY *self, const Vector3 *v, Vector3 *res);  /* wo
 void func_0203aa10(dBgW_KcMbgSclY *self, const Vector3 *v, Vector3 *res);  /* collider -> world */
 void func_02035394(dBgCh_Lin *dst, dBgCh_Lin *src);
 void func_020375ec(int *dst, const int *src);   /* dst[21..23] = src[0..2], i.e. dst->lineEnd */
-void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(
-    dBgCh_Lin *line, const Vector3 *start, const Vector3 *end, dActor_c *actor);
-void _ZN5dBgPiaSERKS_(dBgPi *dst, const dBgPi *src);
 }
 
 int dBgW_KcMbgSclY::DetectClsn(dBgCh_Lin &ray)
@@ -43,7 +40,7 @@ int dBgW_KcMbgSclY::DetectClsn(dBgCh_Lin &ray)
     func_0203aa74(this, &ray.lineEnd, &end);
 
     u8 hadClsn = ray.hasClsn;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(&data_020a0d0c, &start, &end, 0);
+    data_020a0d0c.SetObjAndLine(start, end, 0);
     if (hadClsn != 0)
         data_020a0d0c.hasClsn = 1;
     func_02035394(&data_020a0d0c, &ray);
@@ -55,7 +52,7 @@ int dBgW_KcMbgSclY::DetectClsn(dBgCh_Lin &ray)
         func_020375ec((int *)&ray, (const int *)&worldPos);
         ray.clsnDist = dist;
         /* the dBgPi base sub-object, at +0x10 */
-        _ZN5dBgPiaSERKS_((dBgPi *)((char *)&ray + 0x10), &data_020a0d1c);
+        (dBgPi &)ray = data_020a0d1c;
         ray.hasClsn = 1;
     }
     return hit;

--- a/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
+#include "dBgCh_Gnd.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -27,10 +28,6 @@ extern "C" {
     void Matrix4x3_FromRotationY(void *m, int angle);
     void MulVec3Mat4x3(void *dst, void *mtx, void *src);
     void AddVec3(void *a, void *b, void *c);
-    void _ZN9dBgCh_GndC1Ev(void *self);
-    void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, void *pos, void *actor);
-    int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
-    void _ZN9dBgCh_GndD1Ev(void *self);
 }
 
 extern void *data_ov065_0211cfd0[];
@@ -38,12 +35,6 @@ extern void *data_ov065_0211cfd4[];
 extern "C" void _ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_();
 extern u8 data_0209f2c0;
 extern s32 data_020a0e68[];
-
-struct dBgCh_Gnd {
-    char pad[0x44];
-    s32 hitY;
-    char pad2[0xc];
-};
 
 int TtcRotatingCube::InitResources()
 {
@@ -94,45 +85,43 @@ int TtcRotatingCube::InitResources()
     func_020393d4(&mMeshCollider, (void *)_ZN4dBgW22UpdatePosWithTransformERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_);
 
     {
-        s32 va[3];
-        s32 vb[3];
+        Vector3 va;
+        Vector3 vb;
         mWaitTimer = data_ov065_0211cfa4[data_0209f2c0];
-        va[0] = 0;
-        va[2] = 0;
-        vb[0] = 0;
-        vb[1] = 0;
-        vb[2] = 0;
-        va[1] = 0;
-        va[0] = 0x64000;
-        va[2] = 0x64000;
+        va.x = 0;
+        va.z = 0;
+        vb.x = 0;
+        vb.y = 0;
+        vb.z = 0;
+        va.y = 0;
+        va.x = 0x64000;
+        va.z = 0x64000;
 
         Matrix4x3_FromRotationY(data_020a0e68, mAngleY);
-        MulVec3Mat4x3(va, data_020a0e68, vb);
-        AddVec3(vb, &mPosX, vb);
-        vb[1] -= 0xd2000;
+        MulVec3Mat4x3(&va, data_020a0e68, &vb);
+        AddVec3(&vb, &mPosX, &vb);
+        vb.y -= 0xd2000;
 
-        dBgCh_Gnd rg;
-        _ZN9dBgCh_GndC1Ev(&rg);
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, vb, 0);
-        mFloorY = vb[1];
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-            mFloorY = rg.hitY;
+        dBgCh_Gnd ground;
+        ground.SetObjAndPos(vb, 0);
+        mFloorY = vb.y;
+        if (ground.DetectClsn() != 0) {
+            mFloorY = ground.clsnY;
         }
 
-        vb[0] = mPosX;
-        vb[1] = mPosY;
-        vb[2] = mPosZ;
-        vb[1] -= 0xd2000;
+        vb.x = mPosX;
+        vb.y = mPosY;
+        vb.z = mPosZ;
+        vb.y -= 0xd2000;
 
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, vb, 0);
-        s32 r5 = vb[1];
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-            r5 = rg.hitY;
+        ground.SetObjAndPos(vb, 0);
+        s32 r5 = vb.y;
+        if (ground.DetectClsn() != 0) {
+            r5 = ground.clsnY;
         }
         if (r5 != mFloorY) {
             mUnevenGround = 1;
         }
-        _ZN9dBgCh_GndD1Ev(&rg);
     }
 
     return 1;

--- a/src/_ZN16daObjPushblock_c13InitResourcesEv.cpp
+++ b/src/_ZN16daObjPushblock_c13InitResourcesEv.cpp
@@ -11,6 +11,7 @@
  * conversion is byte-exact under the pinned 2004/b56. */
 #include "daObjPushblock_c.h"
 #include "decl_common.h"
+#include "dBgCh_Gnd.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -25,20 +26,12 @@ extern "C" void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_
 extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
     void *self, void *a, int b, int c, void *d, int e);
 
-struct V3 { int x, y, z; };
-struct dBgCh_Gnd { char buf[0x44]; int f44; char rest[8]; };
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd *self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd *self, V3 *v, void *a);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd *self);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd *self);
-
 extern SharedFilePtr data_ov002_0210df9c;
 extern SharedFilePtr data_ov002_0210df94;
 
 int daObjPushblock_c::InitResources()
 {
-    dBgCh_Gnd rg;
-    V3 v;
+    Vector3 v;
     BMD_File *bmd;
     KCL_File *kcl;
 
@@ -58,14 +51,13 @@ int daObjPushblock_c::InitResources()
     v.y = mPosY;
     v.z = mPosZ;
     v.y = v.y + 0x14000;
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, 0);
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(v, 0);
     mGroundY = v.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg))
-        mGroundY = rg.f44;
+    if (ground.DetectClsn())
+        mGroundY = ground.clsnY;
     mHomePosX = mPosX;
     mHomePosY = mPosY;
     mHomePosZ = mPosZ;
-    _ZN9dBgCh_GndD1Ev(&rg);
     return 1;
 }

--- a/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
@@ -4,9 +4,8 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatformUtm.h"
+#include "dBgCh_Gnd.h"
 enum Bool { FALSE, TRUE };
-
-struct dBgCh_Gnd { char buf[0x44]; int f44; char rest[8]; };
 
 extern "C" {
 extern void _ZN8dActor_c9SetRangesE5Fix12IiES1_S1_S1_(void *self, int a, int b, int c, int d);
@@ -22,10 +21,6 @@ extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *self);
 extern void *_ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *self, void *kcl, void *mtx, int fix, short s, void *clps);
 extern void func_020393d4(void *p, void *v);
-extern void _ZN9dBgCh_GndC1Ev(struct dBgCh_Gnd *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct dBgCh_Gnd *self, const Vector3 *v, void *a);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(struct dBgCh_Gnd *self);
-extern void _ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd *self);
 }
 
 extern signed char data_0209f2f8;
@@ -40,7 +35,6 @@ int RotatingUpDownPlatformUtm::InitResources()
     Vector3 rotated;
     Vector3 posVec;
     Vector3 v2;
-    struct dBgCh_Gnd rg;
     unsigned char idx394, idx395;
     void *bmd;
     void *kcl;
@@ -116,16 +110,15 @@ int RotatingUpDownPlatformUtm::InitResources()
     posVec.z = mPosZ;
     posVec.y -= 0x14000;
 
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &posVec, 0);
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(posVec, 0);
     mGroundY = posVec.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg))
-        mGroundY = rg.f44;
+    if (ground.DetectClsn())
+        mGroundY = ground.clsnY;
 
     mSpawnAngleX = mAngleX;
     mSpawnAngleY = mAngleY;
     mSpawnAngleZ = mAngleZ;
 
-    _ZN9dBgCh_GndD1Ev(&rg);
     return 1;
 }

--- a/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
@@ -6,17 +6,14 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatformUtm.h"
-typedef struct Vec3 { int x, y, z; } Vec3;
-typedef struct dBgCh_Gnd { char pad[0x54]; } dBgCh_Gnd;
+#include "dBgCh_Gnd.h"
+typedef Vector3 Vec3;
 
 extern "C" {
 extern void *_ZN8dActor_c15FindWithActorIDEjPS_(u32 id, void *p);
 extern int Vec3_HorzDist(const Vec3 *a, const Vec3 *b);
 extern int _ZN8dActor_c13DistToCPlayerEv(void *thiz);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3s(u32 a, u32 b, u32 c, const Vec3 *pos, u32 e);
-extern void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd *rc);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd *rc, const Vec3 *pos, void *actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd *rc);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void MulVec3Mat4x3(void *src, void *m, void *dst);
 extern void Vec3_Add(Vec3 *out, Vec3 *a, Vec3 *b);
@@ -30,7 +27,6 @@ extern void func_020393a4(int *p, int v);
 extern void func_02039394(int *p, int v);
 extern int _ZN10dBgActor_c13IsClsnInRangeE5Fix12IiES1_(void *thiz, int a, int b);
 extern void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void *thiz);
-extern void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd *rc);
 }
 
 extern char data_020a0e68[];
@@ -45,7 +41,6 @@ int RotatingUpDownPlatformUtm::Behavior()
     Vec3 sp40;
     Vec3 sp4C;
     Vec3 sp58;
-    dBgCh_Gnd rc;
     int r4;
     int r6;
     int r5;
@@ -126,11 +121,11 @@ int RotatingUpDownPlatformUtm::Behavior()
         pos.z = mPosZ;
         pos.y = py - 0x14000;
     }
-    _ZN9dBgCh_GndC1Ev(&rc);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, &pos, 0);
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
     mGroundY = pos.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc) != 0) {
-        mGroundY = *(int *)((char *)&rc + 0x44);
+    if (ground.DetectClsn() != 0) {
+        mGroundY = ground.clsnY;
     }
 
     r6 = 0;
@@ -205,6 +200,5 @@ int RotatingUpDownPlatformUtm::Behavior()
     }
     }
 
-    _ZN9dBgCh_GndD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN4Toad13InitResourcesEv.cpp
+++ b/src/_ZN4Toad13InitResourcesEv.cpp
@@ -18,10 +18,8 @@
  *
  * Finally he is dropped onto the ground: a dBgCh_Gnd is aimed 0x14000
  * above his spawn point and, if it hits, mPosY is snapped to the surface. That
- * `(char *)&ray + 0x44` in the placeholder body is dBgCh_Gnd::clsnY, so it
- * is a member read now; `ray` itself stays a dumb u32 array because the ROM
- * constructs it mid-function and a typed local of the real class would
- * construct at its declaration (notes/ctor-migration.md).
+ * The local dBgCh_Gnd is declared at that exact mid-function construction
+ * point, so the compiler emits both its constructor and destructor naturally.
  *
  * `#pragma opt_propagation off` IS LOAD-BEARING and stays. Without it mwcc
  * propagates the reloaded mMessageID through the 0xffff test and the function
@@ -46,17 +44,10 @@ extern void *_ZN8dActor_c13ClosestPlayerEv(void *thiz);
 extern void *_ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(u32 a, u32 b, const Vector3 *pos, const void *rot, int e, int f);
 extern u8 NumStars(void);
 extern int IsStarCollectedInCurLevel(int s);
-extern void _ZN9dBgCh_GndC1Ev(void *thiz);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void *thiz);
-extern void _ZN9dBgCh_GndD1Ev(void *thiz);
 }
 
 int Toad::InitResources()
 {
-    /* Dumb word storage, not a typed local: a dBgCh_Gnd local now
-       synthesizes its constructor at the declaration, but the ROM constructs
-       it after the animation setup -- so keep raw words and hand-call below. */
-    u32 ray[sizeof(dBgCh_Gnd) / sizeof(u32)];
     Vector3 objPos;
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov085_02130488);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov085_02130490);
@@ -116,10 +107,11 @@ int Toad::InitResources()
     objPos.y = mPosY;
     objPos.z = mPosZ;
     objPos.y = objPos.y + 0x14000;
-    _ZN9dBgCh_GndC1Ev((dBgCh_Gnd *)ray);
-    ((dBgCh_Gnd &)ray).SetObjAndPos(objPos, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv((dBgCh_Gnd *)ray))
-        mPosY = ((dBgCh_Gnd *)ray)->clsnY;
-    _ZN9dBgCh_GndD1Ev((dBgCh_Gnd *)ray);
+    {
+        dBgCh_Gnd ground;
+        ground.SetObjAndPos(objPos, 0);
+        if (ground.DetectClsn())
+            mPosY = ground.clsnY;
+    }
     return 1;
 }

--- a/src/_ZN7Skeeter13InitResourcesEv.cpp
+++ b/src/_ZN7Skeeter13InitResourcesEv.cpp
@@ -25,6 +25,7 @@
  * wall, notes/mwccarm-codegen.md.
  */
 #include "Skeeter.h"
+#include "dBgCh_Gnd.h"
 typedef int LocFix12;
 typedef struct { int w[2]; } LocSharedFilePtr;
 typedef struct { short x,y,z; } LocVector3_16;
@@ -32,7 +33,6 @@ typedef struct { int x,y,z; } LocVec3;
 typedef struct BMD_File BMD_File;
 typedef struct dActor_c dActor_c;
 struct C; typedef int (C::*PMF)();
-struct RG { char a[0x14]; int detect[16]; };
 
 extern "C" {
 BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(LocSharedFilePtr* f);
@@ -42,12 +42,7 @@ void _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(void* self, dActor_
 void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void* self, dActor_c* a, LocFix12 r, LocFix12 h, LocVector3_16* p, LocVector3_16* q);
 void func_0203558c(void* self);
 int func_ov090_02131e00(void* c, PMF* p);
-void _ZN9dBgCh_GndC1Ev(RG* self);
-void _ZN5dBgCh19StartDetectingWaterEv(RG* self);
-void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(RG* self, const LocVec3* v, dActor_c* a);
-int _ZN9dBgCh_Gnd10DetectClsnEv(RG* self);
-int SurfaceInfo_TestFlag0x20(int* p);
-void _ZN9dBgCh_GndD1Ev(RG* self);
+int SurfaceInfo_TestFlag0x20(const SurfaceInfo* p);
 int RandomIntInternal(int* seed);
 
 extern LocSharedFilePtr data_ov090_021344a0;
@@ -68,9 +63,8 @@ int Skeeter::InitResources()
 {
     char* c = (char*)this;
     BMD_File* f;
-    RG rg;
     int r;
-    LocVec3 pos;
+    Vector3 pos;
     LocVec3 v;
 
     f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov090_021344a0);
@@ -113,9 +107,9 @@ int Skeeter::InitResources()
     }
 
     {
-        _ZN9dBgCh_GndC1Ev(&rg);
-        *(int*)((char*)&rg + 0x4c) = 0xbb8000;
-        _ZN5dBgCh19StartDetectingWaterEv(&rg);
+        dBgCh_Gnd ground;
+        ground.mProbeHeight = 0xbb8000;
+        ground.StartDetectingWater();
         {
             int py = mPosY;
             int pz = mPosZ;
@@ -125,15 +119,15 @@ int Skeeter::InitResources()
             pos.y = ip;
             pos.z = pz;
         }
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &pos, (dActor_c*)c);
+        ground.SetObjAndPos(pos, this);
         unk_3a8 = data_02092138;
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-            if (SurfaceInfo_TestFlag0x20(rg.detect) != 0) {
+        if (ground.DetectClsn() != 0) {
+            if (SurfaceInfo_TestFlag0x20(&ground.surface) != 0) {
                 unk_39c = 1;
-                unk_3ac = rg.detect[12];
+                unk_3ac = ground.clsnY;
             } else {
-                unk_3a8 = rg.detect[12];
-                unk_3ac = rg.detect[12];
+                unk_3a8 = ground.clsnY;
+                unk_3ac = ground.clsnY;
             }
         }
 
@@ -144,7 +138,6 @@ int Skeeter::InitResources()
 
         if (unk_39c != 0) {
             func_ov090_02131e00(c, &data_ov090_021344f4);
-            _ZN9dBgCh_GndD1Ev(&rg);
             return 1;
         }
 
@@ -156,7 +149,6 @@ int Skeeter::InitResources()
             mAngleY = mPrevAngleY;
         }
         func_ov090_02131e00(c, &data_ov090_021344e4);
-        _ZN9dBgCh_GndD1Ev(&rg);
     }
 
     return 1;

--- a/src/_ZN7daDkk_c13InitResourcesEv.cpp
+++ b/src/_ZN7daDkk_c13InitResourcesEv.cpp
@@ -13,15 +13,11 @@
  * class's own layout.
  */
 #include "daDkk_c.h"
+#include "dBgCh_Lin.h"
 
 extern "C" {
 extern int data_ov025_02113814[];
 extern int func_ov091_02133254(void* c);
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(void* out, void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
 }
 
 int daDkk_c::InitResources()
@@ -33,12 +29,9 @@ int daDkk_c::InitResources()
         mState = 6;
     } else {
         mState = 0;
-        char rl[0x78];
+        dBgCh_Lin ray;
         Vector3 va;
         Vector3 vb;
-        Vector3 p1;
-        Vector3 p2;
-        _ZN9dBgCh_LinC1Ev(rl);
         int x = *(int *)(c + 0x5c);
         vb.x = x;
         int y = *(int *)(c + 0x60);
@@ -49,13 +42,12 @@ int daDkk_c::InitResources()
         va.y = y;
         va.z = z;
         vb.y = y + 0x7d0000;
-        _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &va, &vb, c);
-        if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-            _ZN9dBgCh_Lin10GetClsnPosEv(&p1, rl);
-            _ZN9dBgCh_Lin10GetClsnPosEv(&p2, rl);
+        ray.SetObjAndLine(va, vb, this);
+        if (ray.DetectClsn()) {
+            Vector3 p1 = ray.GetClsnPos();
+            Vector3 p2 = ray.GetClsnPos();
             mProbeHeight = p2.y - 0x190000;
         }
-        _ZN9dBgCh_LinD1Ev(rl);
     }
     return r;
 }

--- a/src/_ZN8BigBully13InitResourcesEv.cpp
+++ b/src/_ZN8BigBully13InitResourcesEv.cpp
@@ -5,16 +5,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBully.h"
+#include "dBgCh_Gnd.h"
 extern "C" {
-typedef struct dActor_c dActor_c;
-struct dBgCh_Gnd { char buf[0x50]; };
-
 extern int func_ov064_02116ec0(void* obj);
 extern int _ZN8dActor_c9TrackStarEjj(dActor_c* self, unsigned int a, unsigned int b);
-extern void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3* p, dActor_c* a);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
-extern void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 extern dActor_c* _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(u32 actorID, u32 param1, const Vector3* pos, const Vector3_16* rot, s8 areaID, s16 deathTableID);
 extern s16 data_02082214[];
 }
@@ -30,14 +24,13 @@ int BigBully::InitResources()
     mSecretSoundCounter = 0;
 
     if ((param1 & 0xff00) == 0x100) {
-        dBgCh_Gnd rg;
+        mNumBulliesKilled = 0;
+
+        dBgCh_Gnd ground;
         Vector3 pos;
         Vector3 v;
         int i;
         int ang;
-
-        mNumBulliesKilled = 0;
-        _ZN9dBgCh_GndC1Ev(&rg);
 
         {
             int tz = mPosZ;
@@ -47,10 +40,10 @@ int BigBully::InitResources()
             v.y = ty;
             v.z = tz;
         }
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, (dActor_c*)((char*)this));
+        ground.SetObjAndPos(v, this);
 
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-            pos.y = *(int*)(rg.buf + 0x44);
+        if (ground.DetectClsn() != 0) {
+            pos.y = ground.clsnY;
         }
 
         i = 0;
@@ -66,7 +59,6 @@ int BigBully::InitResources()
             if (spawned != 0) {
                 *(int*)((char*)spawned + 0x3fc) = uniqueID;
             } else {
-                _ZN9dBgCh_GndD1Ev(&rg);
                 return 0;
             }
 
@@ -74,7 +66,6 @@ int BigBully::InitResources()
             ang += 0x5555;
         } while (i < 3);
 
-        _ZN9dBgCh_GndD1Ev(&rg);
         goto done;
     }
 

--- a/src/_ZN8Goomboss13InitResourcesEv.cpp
+++ b/src/_ZN8Goomboss13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "MaterialChanger.h"
 #include "TextureSequence.h"
 #include "types.h"
+#include "dBgCh_Gnd.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct BCA_File;
@@ -35,10 +36,6 @@ extern "C" {
     void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *self, void *f, int a, s32 fix, u32 c);
     void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
         void *self, void *actor, s32 fa, s32 fb, void *v0, void *v1);
-    void _ZN9dBgCh_GndC1Ev(void *self);
-    void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, void *pos, void *actor);
-    int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
-    void _ZN9dBgCh_GndD1Ev(void *self);
     void func_ov074_02121300(void *c);
     void func_ov074_0212195c(void *t);
 }
@@ -58,8 +55,6 @@ extern u16 data_ov074_02122e04[];
 extern u16 data_ov074_02122dfc[];
 extern s16 data_02082214[];
 
-struct RG { char pad[0x4c]; };
-
 int Goomboss::InitResources()
 {
     char *self = (char *)this;
@@ -69,8 +64,7 @@ int Goomboss::InitResources()
     char *c5;
     char *c8;
     void *p;
-    RG rg;
-    s32 v[3];
+    Vector3 pos;
 
     if (*(u32 *)(self + 8) == 0x1111) {
         return func_ov074_02122634(self);
@@ -167,15 +161,15 @@ int Goomboss::InitResources()
         a1 = *(s32 *)(self + 0x64);
         a0 = *(s32 *)(self + 0x5c);
         a3 = a2 + 0x64000;
-        v[0] = a0;
-        v[1] = a3;
-        v[2] = a1;
+        pos.x = a0;
+        pos.y = a3;
+        pos.z = a1;
     }
 
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, v, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-        *(s32 *)(self + 0x60) = *(s32 *)((char *)&rg + 0x44);
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn() != 0) {
+        *(s32 *)(self + 0x60) = ground.clsnY;
     }
 
     func_ov074_02121300(self);
@@ -184,8 +178,6 @@ int Goomboss::InitResources()
     *(s32 *)(self + 0x5dc) = 0;
     *(u8 *)(self + 0x60a) = 1;
     *(s32 *)(self + 0x5e4) = 0x1000;
-
-    _ZN9dBgCh_GndD1Ev(&rg);
 
     return 1;
 }

--- a/src/_ZN8Moneybag13InitResourcesEv.cpp
+++ b/src/_ZN8Moneybag13InitResourcesEv.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Moneybag.h"
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
@@ -13,10 +13,6 @@ extern "C" int _ZN11ShadowModel12InitCylinderEv(void* self);
 extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void* self, void* actor, int a, int b, unsigned int c, unsigned int d);
 extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void* self, void* actor, int a, int b, void* v, int c);
 extern "C" void _ZN10dBgCh_Actr19StartDetectingWaterEv(void* self);
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3& v, void* actor);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 
 
 extern int data_ov002_0210d9b8[];
@@ -24,7 +20,6 @@ extern Matrix4x3 IDENTITY_MATRIX4X3;
 
 int Moneybag::InitResources()
 {
-    dBgCh_Gnd rc;
     Vector3 pos;
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov081_02128ed4);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1);
@@ -48,10 +43,10 @@ int Moneybag::InitResources()
         pos.z = mPosZ;
         pos.y = p60 + 0x14000;
     }
-    _ZN9dBgCh_GndC1Ev(&rc);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, 0);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc))
-        mPosY = rc.floor[(0x44 - 0x14) / 4];
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(pos, 0);
+    if (ground.DetectClsn())
+        mPosY = ground.clsnY;
     else
         mPosY = pos.y;
     mScaleX = 0x1000;
@@ -63,6 +58,5 @@ int Moneybag::InitResources()
     mState = 1;
     *(Matrix4x3*)((char*)&mMatrix) = IDENTITY_MATRIX4X3;
     func_ov081_02126a20(((char*)this));
-    _ZN9dBgCh_GndD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN8daKrpa_c13InitResourcesEv.cpp
+++ b/src/_ZN8daKrpa_c13InitResourcesEv.cpp
@@ -4,11 +4,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "daKrpa_c.h"
+#include "dBgCh_Gnd.h"
 /* was `typedef int Fix12;` -- collides with the real Fix12<> template, which
    daKrpa_c.h now reaches via Model.h. The typedef WAS int, so spelling it
    int below is byte-neutral. */
-struct RG { char pad[0x44]; int f44; char pad2[8]; };
-
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
@@ -23,18 +22,13 @@ extern void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
     void* self, void* actor, int a, int b, void* v, int c);
 }
 extern "C" {
-extern void _ZN9dBgCh_GndC1Ev(struct RG* rg);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct RG* rg, const struct Vector3* v, void* a);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(struct RG* rg);
 extern void func_ov070_02121310(void* c);
-extern void _ZN9dBgCh_GndD1Ev(struct RG* rg);
 }
 
 extern struct Matrix4x3 IDENTITY_MATRIX4X3;
 
 int daKrpa_c::InitResources()
 {
-    struct RG rg;
     struct Vector3 v;
     void* bmd;
     int t;
@@ -61,14 +55,13 @@ int daKrpa_c::InitResources()
     mScaleZ = 0x1000;
     *(struct Matrix4x3*)((char*)&mMatrix) = IDENTITY_MATRIX4X3;
 
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, (struct Vector3*)((char*)&mPosX), ((char*)this));
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg))
-        t = (mPosY - rg.f44) + 0x1e000;
+    dBgCh_Gnd ground;
+    ground.SetObjAndPos(*(Vector3 *)&mPosX, this);
+    if (ground.DetectClsn())
+        t = (mPosY - ground.clsnY) + 0x1e000;
     else
         t = 0x1f4000;
     mHeightAboveGnd = t;
     func_ov070_02121310(((char*)this));
-    _ZN9dBgCh_GndD1Ev(&rg);
     return 1;
 }


### PR DESCRIPTION
## Summary

- recover the typed dBgW_KcMbgSclY interface and its real C++ methods
- make six ground, line, and sphere collision overloads use typed automatic scratch objects
- replace manual dBgCh_Gnd constructor/destructor plumbing in 22 actor methods with compiler-generated lifetimes

## Verification

- prepush_linkcheck: 42/42 VERIFIED, 0 blind or blocking
- rombuild: 11,082/11,082 reproducing; 106/106 modules exact
- check_src_tu_compiles: 88/88
- port_refcheck: 405 references clean
- duplicate-sources and layout checks clean