### PR TITLE
Generate collision-query lifetimes in readable C++

### DIFF
--- a/src/_ZN11ChiefChilly8BehaviorEv.cpp
+++ b/src/_ZN11ChiefChilly8BehaviorEv.cpp
@@ -30,6 +30,7 @@
  */
 #pragma opt_propagation off
 #include "ChiefChilly.h"
+#include "dBgCh_Lin.h"
 struct Mat4x3 { int m[12]; };
 
 struct C;
@@ -63,13 +64,9 @@ extern void MulMat4x3Mat4x3(void *d, void *a, void *b);
 extern void Vec3_Lsl(Vector3 *d, Vector3 *s, int sh);
 extern void func_02012694(int a, void *b);
 extern void _ZN8dActor_c17HugeLandingDustAtER7Vector3b(void *self, Vector3 *v, int b);
-extern void _ZN9dBgCh_LinC1Ev(void *self);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, int angX);
 extern void MulVec3Mat4x3(void *a, void *m, void *out);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void *self, const Vector3 *a, const Vector3 *b, void *actor);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void *self);
-extern void _ZN9dBgCh_LinD1Ev(void *self);
 extern void _ZN12dEnemyBase_c12UpdateWMClsnER10dBgCh_Actrj(void *self, void *wmc, unsigned int flags);
 extern void _ZN10dCcAcPos_c21SetPosRelativeToActorERK7Vector3(void *self, const Vector3 *v);
 extern void func_ov073_0211f61c(void *self);
@@ -89,7 +86,6 @@ int ChiefChilly::Behavior()
     Vector3 v3C;
     Vector3 v48;
     Vector3 v54;
-    int line[0x1f];
 
     *(C **)((char *)data_0209f318 + 0x114) = c;
     /* dEnemyBase_c declares mStateTimer as s16 -- 28 of its subclasses' generated headers
@@ -138,7 +134,7 @@ int ChiefChilly::Behavior()
         && (char *)c->pp != data_ov073_02123320
         && (char *)c->pp != data_ov073_02123340
         && (char *)c->pp != data_ov073_02123380) {
-        _ZN9dBgCh_LinC1Ev(line);
+        dBgCh_Lin line;
         rp.start.x = 0; rp.start.y = 0; rp.start.z = 0;
         rp.end.x = 0; rp.end.y = 0; rp.end.z = 0;
         rp.in.x = 0; rp.in.y = 0; rp.in.z = 0;
@@ -174,8 +170,8 @@ int ChiefChilly::Behavior()
             rp.end.z = sz;
             rp.end.z = sz + oz;
         }
-        _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(line, &rp.start, &rp.end, self);
-        if (_ZN9dBgCh_Lin10DetectClsnEv(line) == 0) {
+        line.SetObjAndLine(rp.start, rp.end, this);
+        if (!line.DetectClsn()) {
             if (mHorzSpeed > 0xa000) {
                 mNoGroundAhead = 1;
             }
@@ -191,7 +187,6 @@ int ChiefChilly::Behavior()
         } else {
             mNoGroundAhead = 0;
         }
-        _ZN9dBgCh_LinD1Ev(line);
     }
 
     _ZN12dEnemyBase_c12UpdateWMClsnER10dBgCh_Actrj(self, &mWithMeshClsn, 0);

--- a/src/_ZN12dEnemyBase_c15IsGoingOffCliffER10dBgCh_Actrisbbi.cpp
+++ b/src/_ZN12dEnemyBase_c15IsGoingOffCliffER10dBgCh_Actrisbbi.cpp
@@ -1,20 +1,10 @@
 //cpp
 // @symbol _ZN12dEnemyBase_c15IsGoingOffCliffER10dBgCh_Actrisbbi
-/* recovered: named members + shared header, declarations from a shared header */
-#include "decl_dBgPi.h"
 /* recovered: named members + shared header */
 #include "dEnemyBase_c.h"
+#include "dBgCh_Lin.h"
 extern "C" {
 extern int _ZNK10dBgCh_Actr10IsOnGroundEv(void* self);
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern void _ZN5dBgCh19StartDetectingWaterEv(void* self);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN5dBgPiC1Ev(void* self);
-extern void _ZNK5dBgPi6CopyToERS_(void* self, void* other);
-extern void _ZN5dBgPiD1Ev(void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
-extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, void* v);
 extern short data_02082214[];
 }
 
@@ -24,12 +14,9 @@ int dEnemyBase_c::IsGoingOffCliff(dBgCh_Actr &clsn_, Fix12i fix2, s16 a3,
   void *clsn = &clsn_;
   Vector3 v1;
   Vector3 v2;
-  char cr[0x28];
-  Vector3 normal;
-  char rl[0x7c];
   ((char*)this)[0x106] = 0;
   if (_ZNK10dBgCh_Actr10IsOnGroundEv(clsn) != 0) {
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
     v1.x = this->mPosX;
     v1.y = this->mPosY;
     v1.z = this->mPosZ;
@@ -38,24 +25,22 @@ int dEnemyBase_c::IsGoingOffCliff(dBgCh_Actr &clsn_, Fix12i fix2, s16 a3,
     v2.y = this->mPosY;
     v2.z = this->mPosZ;
     v2.y -= fix2;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &v1, &v2, ((char*)this));
+    line.SetObjAndLine(v1, v2, this);
     if (a4 != 0)
-      _ZN5dBgCh19StartDetectingWaterEv(rl);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-      if (*(int*)(rl + 0x60) - fix6 >= fix2)
+      line.StartDetectingWater();
+    if (line.DetectClsn()) {
+      if (line.clsnDist - fix6 >= fix2)
         ((char*)this)[0x106] = 1;
       if (a5 == 0) {
-        _ZN5dBgPiC1Ev(cr);
-        _ZNK5dBgPi6CopyToERS_(rl + 0x10, cr);
-        if (_ZNK5dBgPi9GetClsnIDEv(cr) != -1) {
+        dBgPi result;
+        line.CopyTo(result);
+        if (result.GetClsnID() != -1) {
           ((char*)this)[0x106] = 1;
-          _ZN5dBgPiD1Ev(cr);
-          _ZN9dBgCh_LinD1Ev(rl);
           return 1;
         }
-        _ZN5dBgPiD1Ev(cr);
       }
-      _ZNK11SurfaceInfo12CopyNormalToER7Vector3(rl + 0x14, &normal);
+      Vector3 normal;
+      line.surface.CopyNormalTo(normal);
       int idx = ((unsigned short)a3 >> 4) * 2;
       short s = data_02082214[idx + 1];
       if (normal.y < s)
@@ -63,7 +48,6 @@ int dEnemyBase_c::IsGoingOffCliff(dBgCh_Actr &clsn_, Fix12i fix2, s16 a3,
     } else {
       ((char*)this)[0x106] = 1;
     }
-    _ZN9dBgCh_LinD1Ev(rl);
   }
   return this->unk_106 != 0;
 }

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
@@ -1,6 +1,7 @@
 //cpp
 // @symbol _ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv
 #include "FloatOnWaterPlatformWdwSquare.h"
+#include "dBgCh_Lin.h"
 
 /* FloatOnWaterPlatformWdwSquare::InitResources -- vtable slot 0, ov029
  * 0x02111254.
@@ -10,22 +11,16 @@
  * shared file-load helper (out of this task's scope, kept under its
  * existing name -- same cross-overlay call FloatOnWaterPlatformJrb::
  * InitResources makes in ov016). dActor_c::GetWaterHeightWDW and the
- * dBgCh_Lin helpers are this class's own recovery, kept exactly as
- * found: dBgCh_Lin is a raw byte buffer (0x7c bytes matches its real
- * size but this task does not migrate it to a named type), and the
- * sppad[] staging array reproduces the ROM's own stack layout for the
- * Vector3-by-value SetObjAndLine call. mWaterY/mPosX/mPosY/mPosZ are read
+ * dBgCh_Lin now owns its scoped query lifetime directly, while the sppad[]
+ * staging array reproduces the ROM's own stack layout for the Vector3-by-value
+ * SetObjAndLine call. mWaterY/mPosX/mPosY/mPosZ are read
  * by name where the header already provides them; 0x320 stays a raw
  * offset -- daObjFloatBoard_c.h documents it as UNOBSERVED padding, not a
  * field this class's own bytes confirm the name of. */
 extern "C" {
 extern int func_ov002_020b5e58(void* c, void* d);
 extern int _ZN8dActor_c17GetWaterHeightWDWEv(void* c);
-extern void _ZN9dBgCh_LinC1Ev(void*);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void*, void*, void*, void*);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void*);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(void*, void*);
-extern void _ZN9dBgCh_LinD1Ev(void*);
+extern void _ZN9dBgCh_Lin10GetClsnPosEv(Vector3*, dBgCh_Lin*);
 extern int data_ov029_02113be8[];
 }
 
@@ -34,14 +29,13 @@ int FloatOnWaterPlatformWdwSquare::InitResources()
     char *c = (char *)this;
     int sppad[6]; /* a[3] + b[3] at low stack */
     int pos[3];
-    char rl[0x7c];
     int wh;
     int x, y, z;
 
     if (func_ov002_020b5e58(c, data_ov029_02113be8) != 0) {
         wh = _ZN8dActor_c17GetWaterHeightWDWEv(c);
         if (mPosY > wh) {
-            _ZN9dBgCh_LinC1Ev(rl);
+            dBgCh_Lin line;
             x = mPosX;
             sppad[3] = x; /* b.x */
             y = mPosY;
@@ -53,14 +47,13 @@ int FloatOnWaterPlatformWdwSquare::InitResources()
             sppad[2] = z; /* a.z */
             sppad[1] = y + 0x14000;
             sppad[4] = wh;
-            _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &sppad[0], &sppad[3], c);
-            if (_ZN9dBgCh_Lin10DetectClsnEv(rl) == 0) {
+            line.SetObjAndLine(*(Vector3*)&sppad[0], *(Vector3*)&sppad[3], this);
+            if (!line.DetectClsn()) {
                 mPosY = wh;
             } else {
-                _ZN9dBgCh_Lin10GetClsnPosEv(pos, rl);
+                _ZN9dBgCh_Lin10GetClsnPosEv((Vector3*)pos, &line);
                 mPosY = pos[1];
             }
-            _ZN9dBgCh_LinD1Ev(rl);
         }
         *(int*)(c + 0x320) = mPosX;
         mWaterY = mPosY;

--- a/src/_ZN32FloatOnWaterPlatformWdwRectangle13InitResourcesEv.cpp
+++ b/src/_ZN32FloatOnWaterPlatformWdwRectangle13InitResourcesEv.cpp
@@ -1,6 +1,7 @@
 //cpp
 // @symbol _ZN32FloatOnWaterPlatformWdwRectangle13InitResourcesEv
 #include "FloatOnWaterPlatformWdwRectangle.h"
+#include "dBgCh_Lin.h"
 
 /* FloatOnWaterPlatformWdwRectangle::InitResources -- vtable slot 0, ov029
  * 0x02111f58. Identical shape to FloatOnWaterPlatformWdwSquare::
@@ -10,11 +11,7 @@
 extern "C" {
 extern int func_ov002_020b5e58(void* c, void* d);
 extern int _ZN8dActor_c17GetWaterHeightWDWEv(void* c);
-extern void _ZN9dBgCh_LinC1Ev(void*);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void*, void*, void*, void*);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void*);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(void*, void*);
-extern void _ZN9dBgCh_LinD1Ev(void*);
+extern void _ZN9dBgCh_Lin10GetClsnPosEv(Vector3*, dBgCh_Lin*);
 extern int data_ov029_02113f00[];
 }
 
@@ -23,14 +20,13 @@ int FloatOnWaterPlatformWdwRectangle::InitResources()
     char *c = (char *)this;
     int sppad[6];
     int pos[3];
-    char rl[0x7c];
     int wh;
     int x, y, z;
 
     if (func_ov002_020b5e58(c, data_ov029_02113f00) != 0) {
         wh = _ZN8dActor_c17GetWaterHeightWDWEv(c);
         if (mPosY > wh) {
-            _ZN9dBgCh_LinC1Ev(rl);
+            dBgCh_Lin line;
             x = mPosX;
             sppad[3] = x;
             y = mPosY;
@@ -42,14 +38,13 @@ int FloatOnWaterPlatformWdwRectangle::InitResources()
             sppad[2] = z;
             sppad[1] = y + 0x14000;
             sppad[4] = wh;
-            _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &sppad[0], &sppad[3], c);
-            if (_ZN9dBgCh_Lin10DetectClsnEv(rl) == 0) {
+            line.SetObjAndLine(*(Vector3*)&sppad[0], *(Vector3*)&sppad[3], this);
+            if (!line.DetectClsn()) {
                 mPosY = wh;
             } else {
-                _ZN9dBgCh_Lin10GetClsnPosEv(pos, rl);
+                _ZN9dBgCh_Lin10GetClsnPosEv((Vector3*)pos, &line);
                 mPosY = pos[1];
             }
-            _ZN9dBgCh_LinD1Ev(rl);
         }
         *(int*)(c + 0x320) = mPosX;
         mWaterY = mPosY;

--- a/src/actors/daTrs_c/_ZN7daTrs_c8BehaviorEv.cpp
+++ b/src/actors/daTrs_c/_ZN7daTrs_c8BehaviorEv.cpp
@@ -69,11 +69,7 @@ void func_ov063_02119274(char *c);
 void func_ov063_02116fac(char *c);
 u16 DecIfAbove0_Short(void *p);
 void _ZN8dActor_c9UpdatePosEP5dCc_c(char *c, void *cyl);
-void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd *rc);
-void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd *rc, const Vector3 *v, void *actor);
-int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd *rc);
 void _ZN12dEnemyBase_c12UpdateWMClsnER10dBgCh_Actrj(char *c, void *w, u32 j);
-void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd *rc);
 void _ZN9Animation7AdvanceEv(void *anim);
 void _ZN10dCcAcPos_c21SetPosRelativeToActorERK7Vector3(void *cyl, void *v);
 void _ZN5dCc_c6UpdateEv(void *cyl);
@@ -86,14 +82,6 @@ int daTrs_c::Behavior()
     Vector3 v1;
     Vector3 v2;
     Vector3 ve;
-    /* Dumb word storage, not typed locals: rc1/rc2 are CONSTRUCTED
-       MID-FUNCTION, rc2 only on some paths (notes/ctor-migration.md item 9).
-       A typed local of a class with a declared constructor is constructed at
-       its declaration -- the ROM does not do that here. Call sites cast the
-       array's address, which costs exactly the sp-relative add the old POD
-       local spelled. */
-    u32 rc1[sizeof(dBgCh_Gnd) / sizeof(u32)];
-    u32 rc2[sizeof(dBgCh_Gnd) / sizeof(u32)];
     int t;
     void *p;
     char *q;
@@ -307,7 +295,7 @@ block_39:
         func_ov063_02119ab0(c);
         if (((((u32)((*(u16 *)(c + 0x5d4)) << 0x1f)) >> 0x1f) != 0) && ((*(s32 *)(c + 0x64)) < -0x12c000))
             *(s32 *)(c + 0x64) = -0x12c000;
-        _ZN9dBgCh_GndC1Ev((dBgCh_Gnd *)rc1);
+        dBgCh_Gnd rc1;
         y = *(s32 *)(c + 0x60);
         z = *(s32 *)(c + 0x64);
         w = y + 0x32000;
@@ -315,14 +303,14 @@ block_39:
         v1.x = x;
         v1.y = w;
         v1.z = z;
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c((dBgCh_Gnd *)rc1, &v1, c);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv((dBgCh_Gnd *)rc1) != 0) {
-            s32 ground = (*(s32 *)((char *)rc1 + 0x44)) + 0x2000;
+        rc1.SetObjAndPos(v1, (dActor_c*)this);
+        if (rc1.DetectClsn() != 0) {
+            s32 ground = rc1.clsnY + 0x2000;
             if ((*(s32 *)(c + 0x60)) < ground)
                 *(s32 *)(c + 0x60) = ground;
         }
         if (((*(u8 *)(c + 0x5cf)) != 4) && ((*(u8 *)(c + 0x5cf)) != 0xb)) {
-            _ZN9dBgCh_GndC1Ev((dBgCh_Gnd *)rc2);
+            dBgCh_Gnd rc2;
             y = *(s32 *)(c + 0x60);
             z = *(s32 *)(c + 0x64);
             w = y + 0x32000;
@@ -330,13 +318,13 @@ block_39:
             v2.x = x;
             v2.y = w;
             v2.z = z;
-            _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c((dBgCh_Gnd *)rc2, &v2, c);
+            rc2.SetObjAndPos(v2, (dActor_c*)this);
             d1 = (int)((*(u16 *)(c + 0xc)) == 0xd1);
             if (d1 != 0) {
                 if ((*(u8 *)(c + 0x5cf)) < 8) {
                     if ((((u32)((*(u16 *)(c + 0x5d4))) << 0x1a) >> 0x1f) != 0) {
-                        if ((_ZN9dBgCh_Gnd10DetectClsnEv((dBgCh_Gnd *)rc2) == 0) ||
-                            (((*(s32 *)(c + 0x60)) - (*(s32 *)((char *)rc2 + 0x44))) > 0x12c000)) {
+                        if ((rc2.DetectClsn() == 0) ||
+                            (((*(s32 *)(c + 0x60)) - rc2.clsnY) > 0x12c000)) {
                             *(s32 *)(c + 0x5c) = *(s32 *)(c + 0x528);
                             *(s32 *)(c + 0x60) = *(s32 *)(c + 0x52c);
                             *(s32 *)(c + 0x64) = *(s32 *)(c + 0x530);
@@ -353,8 +341,8 @@ block_39:
                 }
             } else {
             ray_e:
-                if ((_ZN9dBgCh_Gnd10DetectClsnEv((dBgCh_Gnd *)rc2) != 0) &&
-                    (((*(s32 *)(c + 0x60)) - (*(s32 *)((char *)rc2 + 0x44))) < 0x12c000)) {
+                if ((rc2.DetectClsn() != 0) &&
+                    (((*(s32 *)(c + 0x60)) - rc2.clsnY) < 0x12c000)) {
                     fp = (u16 *)(c + 0x5d4);
                     *fp = (*fp) | 0x20;
                     *(s32 *)(c + 0x528) = *(s32 *)(c + 0x5c);
@@ -363,9 +351,7 @@ block_39:
                 }
             }
             _ZN12dEnemyBase_c12UpdateWMClsnER10dBgCh_Actrj(c, c + 0x1c4, 0);
-            _ZN9dBgCh_GndD1Ev((dBgCh_Gnd *)rc2);
         }
-        _ZN9dBgCh_GndD1Ev((dBgCh_Gnd *)rc1);
     }
     if (((((*(u8 *)(c + 0x5cc)) != 3) && ((*(u8 *)(c + 0x5cc)) != 3)) && ((*(u8 *)(c + 0x5cc)) != 3)) && ((*(u8 *)(c + 0x5cc)) != 3))
         _ZN9Animation7AdvanceEv(c + 0x3d0);

--- a/src/func_02009e70.cpp
+++ b/src/func_02009e70.cpp
@@ -7,17 +7,10 @@
 // full closed-axis list). Not byte-matchable without the NITRO V0.5-V0.6.1 compiler.
 // For recomp/port purposes this file is complete: the compiled code is functionally
 // identical to the ROM, differing only in register names and instruction order.
+#include "dBgCh_Gnd.h"
+#include "dBgCh_Lin.h"
+
 extern "C" {
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-typedef long long s64;
-typedef unsigned long long u64;
-
-struct Vector3 { s32 x, y, z; };
-
 struct CamMode {
     s32 nearDist;   /* 0x00 */
     s32 farDist;    /* 0x04 */
@@ -64,16 +57,7 @@ extern void func_0200c9e0(void *self, s32 *a, s32 *b);
 extern u32 func_02012790(u32 a);
 extern s32 Sound_PlayIfNotActive(s32 a, s32 b, s32 c);
 
-extern void _ZN9dBgCh_LinC1Ev(void *t);
-extern void _ZN9dBgCh_LinD1Ev(void *t);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void *t, const struct Vector3 *a, const struct Vector3 *b, void *actor);
-extern s32 _ZN9dBgCh_Lin10DetectClsnEv(void *t);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(struct Vector3 *out, void *t);
-extern void _ZN9dBgCh_GndC1Ev(void *t);
-extern void _ZN9dBgCh_GndD1Ev(void *t);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *t, const struct Vector3 *p, void *actor);
-extern s32 _ZN9dBgCh_Gnd10DetectClsnEv(void *t);
-extern void _ZN5dBgCh19StartDetectingWaterEv(void *t);
+extern void _ZN9dBgCh_Lin10GetClsnPosEv(struct Vector3 *out, dBgCh_Lin *line);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *t, struct Vector3 *out);
 
 extern s16 data_02082214[];
@@ -135,8 +119,6 @@ s32 func_02009e70(char *self)
     struct Vector3 spac;
     struct Vector3 spb8;
     struct Vector3 spc4;
-    char spd0[0x78];
-    char sp148[0x54];
     s32 r7;
     s32 r6;
     s32 fl;
@@ -269,11 +251,12 @@ s32 func_02009e70(char *self)
     }
     r4 = 0x7fffffff;
     sb = *(s32 *)(self + 0x9c) + 0x82500;
-    _ZN9dBgCh_LinC1Ev(spd0);
-    func_0200897c(self, spd0);
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(spd0, (struct Vector3 *)(self + 0x98), &sp4c, 0);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(spd0) != 0) {
-        _ZN9dBgCh_Lin10GetClsnPosEv(&sp94, spd0);
+    {
+    dBgCh_Lin line;
+    func_0200897c(self, &line);
+    line.SetObjAndLine(*(struct Vector3 *)(self + 0x98), sp4c, 0);
+    if (line.DetectClsn() != 0) {
+        _ZN9dBgCh_Lin10GetClsnPosEv(&sp94, &line);
         r4 = sp94.y - 0x80000;
         if (r4 < sb) r4 = sb;
     }
@@ -287,10 +270,10 @@ s32 func_02009e70(char *self)
         sp58.z = tz;
     }
     if (sb > r4) goto L_A534;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(spd0, &sp58, (struct Vector3 *)(self + 0x8c), 0);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(spd0) == 0) goto L_A534;
-    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(spd0 + 0x14, &sp64);
-    _ZN9dBgCh_Lin10GetClsnPosEv(&spa0, spd0);
+    line.SetObjAndLine(sp58, *(struct Vector3 *)(self + 0x8c), 0);
+    if (line.DetectClsn() == 0) goto L_A534;
+    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(&line.surface, &sp64);
+    _ZN9dBgCh_Lin10GetClsnPosEv(&spa0, &line);
     *(s32 *)(self + 0xe0) = spa0.x;
     *(s32 *)(self + 0xe4) = spa0.y;
     *(s32 *)(self + 0xe8) = spa0.z;
@@ -303,7 +286,7 @@ s32 func_02009e70(char *self)
         *(u32 *)L0(self + 0x154) |= 0x80200;
         goto L_A534;
     }
-    _ZN9dBgCh_Lin10GetClsnPosEv(&sp70, spd0);
+    _ZN9dBgCh_Lin10GetClsnPosEv(&sp70, &line);
     sba = (s16)(_ZN4cstd5atan2E5Fix12IiES1_(sp64.x, sp64.z) + 0x8000);
     t1 = *(u8 *)(self + 0x1a6);
     t0 = (s16)(sba - *(s16 *)(self + 0x17c));
@@ -455,9 +438,9 @@ L_AAD0:
         sp4c.y = ty;
         sp4c.z = tz;
     }
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(spd0, (struct Vector3 *)(self + 0x8c), &sp4c, 0);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(spd0) != 0) {
-        _ZN9dBgCh_Lin10GetClsnPosEv(&spb8, spd0);
+    line.SetObjAndLine(*(struct Vector3 *)(self + 0x8c), sp4c, 0);
+    if (line.DetectClsn() != 0) {
+        _ZN9dBgCh_Lin10GetClsnPosEv(&spb8, &line);
         sp4c.y = spb8.y;
         if (r4 > spb8.y - 0x80000) r4 = spb8.y - 0x80000;
     }
@@ -466,19 +449,19 @@ L_AAD0:
     sp88.x = sp7c.x;
     sp88.y = sp7c.y + 0x100000;
     sp88.z = sp7c.z;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(spd0, &sp7c, &sp88, 0);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(spd0) != 0) {
-        _ZN9dBgCh_Lin10GetClsnPosEv(&spc4, spd0);
+    line.SetObjAndLine(sp7c, sp88, 0);
+    if (line.DetectClsn() != 0) {
+        _ZN9dBgCh_Lin10GetClsnPosEv(&spc4, &line);
         sp88.y = spc4.y - 0x80000;
         if (r4 > sp88.y) r4 = sp88.y;
     }
     sb = *(s32 *)(self + 0x9c);
-    _ZN9dBgCh_GndC1Ev(sp148);
-    *(s32 *)(sp148 + 0x4c) = 0x5dc000;
-    func_0200897c(self, sp148);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(sp148, &sp4c, 0);
-    if (sp1c > &data_02086fcc) _ZN5dBgCh19StartDetectingWaterEv(sp148);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(sp148) != 0) sb = *(s32 *)(sp148 + 0x44);
+    dBgCh_Gnd ground;
+    ground.mProbeHeight = 0x5dc000;
+    func_0200897c(self, &ground);
+    ground.SetObjAndPos(sp4c, 0);
+    if (sp1c > &data_02086fcc) ground.StartDetectingWater();
+    if (ground.DetectClsn() != 0) sb = ground.clsnY;
     if (sp1c == &data_02086ff4) {
         if (sb < data_0209f32c) sb = data_0209f32c;
         r7h = sb + 0x64000;
@@ -514,8 +497,7 @@ L_AD94:
 L_ADD4:
     Math_Function_0203b14c((s32 *)(self + 0x90), r7h, 0x300, 0x14000, 0x100);
     *(s16 *)(self + 0x17c) = Vec3_HorzAngle((struct Vector3 *)(self + 0x80), (struct Vector3 *)(self + 0x8c));
-    _ZN9dBgCh_GndD1Ev(sp148);
-    _ZN9dBgCh_LinD1Ev(spd0);
+    }
 L_AE14:
     if (r5 != 0) {
         if (data_0209b000 == 0) func_02012790(0xe);

--- a/src/func_ov002_020af4ec.cpp
+++ b/src/func_ov002_020af4ec.cpp
@@ -2,17 +2,13 @@
 // @symbol func_ov002_020af4ec
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
-struct dBgCh_Gnd { char buf[0x50]; };
 extern "C" {
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern int _ZNK10dBgCh_Actr10IsOnGroundEv(void* self);
-extern void _ZN9dBgCh_GndC1Ev(struct dBgCh_Gnd* self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct dBgCh_Gnd* self, const struct Vector3* v, void* actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(struct dBgCh_Gnd* self);
-extern void _ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd* self);
 extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* shadow, void* mtx, int height, int rad, unsigned int x);
 void func_ov002_020af4ec(void* self);
 }
@@ -22,7 +18,6 @@ void func_ov002_020af4ec(void* self)
     int rad;
     char* c = (char*)self;
     int height;
-    struct dBgCh_Gnd rg;
     struct Vector3 v2;
     struct Vector3 v1;
 
@@ -50,18 +45,17 @@ void func_ov002_020af4ec(void* self)
         v2.x = x;
         v2.y = adjustedY;
         v2.z = z;
-        _ZN9dBgCh_GndC1Ev(&rg);
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v2, 0);
+        dBgCh_Gnd rg;
+        rg.SetObjAndPos(v2, 0);
         rad = v2.y;
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg)) {
-            rad = *(int*)((char*)&rg + 0x44);
+        if (rg.DetectClsn()) {
+            rad = rg.clsnY;
         }
         rad = *(int*)(c + 0x60) - rad;
         if (rad <= 0x1000) rad = 0x1000;
         height = (*(int*)(c + 0x114) - 0xa000) * 2 - (int)(((long long)rad * 0x180 + 0x800) >> 12);
         if (height < 0xa000) height = 0xa000;
         rad += 0x3c000;
-        _ZN9dBgCh_GndD1Ev(&rg);
     } else {
         rad = 0x3c000;
         height = (*(int*)(c + 0x114) - 0xa000) * 2;

--- a/src/func_ov002_020b2c44.cpp
+++ b/src/func_ov002_020b2c44.cpp
@@ -3,8 +3,8 @@
 // @symbol func_ov002_020b2c44
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 struct Mtx43 { Fix12i a[12]; };
-struct dBgCh_Gnd { char buf[0x68 - 0x18]; };
 
 extern "C" {
 void Vec3_Asr(struct Vector3 *d, struct Vector3 *s, int sh);
@@ -15,10 +15,6 @@ void Matrix4x3_ApplyInPlaceToRotationX(void *m, s16 ang);
 void Matrix4x3_FromRotationY(void *m, int angle);
 void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void *self, void *sm, void *mtx, Fix12i a, Fix12i b, u32 u);
-void _ZN9dBgCh_GndC1Ev(struct dBgCh_Gnd *self);
-void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct dBgCh_Gnd *self, const struct Vector3 *v, void *actor);
-int _ZN9dBgCh_Gnd10DetectClsnEv(struct dBgCh_Gnd *self);
-void _ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd *self);
 }
 
 extern struct Mtx43 data_020a0e68;
@@ -26,7 +22,6 @@ extern unsigned char data_0209f2d8;
 
 extern "C" void func_ov002_020b2c44(char *c)
 {
-    struct dBgCh_Gnd rg;
     struct Vector3 pos;
     struct Vector3 v;
     int b;
@@ -53,15 +48,15 @@ extern "C" void func_ov002_020b2c44(char *c)
         int r5;
         int r4;
 
-        _ZN9dBgCh_GndC1Ev(&rg);
+        dBgCh_Gnd rg;
         pos.x = *(int *)(c + 0x5c);
         pos.y = *(int *)(c + 0x60);
         pos.z = *(int *)(c + 0x64);
         pos.y = pos.y + 0x14000;
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &pos, c);
-        _ZN9dBgCh_Gnd10DetectClsnEv(&rg);
+        rg.SetObjAndPos(pos, (dActor_c*)c);
+        rg.DetectClsn();
 
-        r5 = *(int *)(c + 0x60) - *(int *)((char *)&rg + 0x44);
+        r5 = *(int *)(c + 0x60) - rg.clsnY;
         if (r5 <= 0x1000)
             r5 = 0x1000;
         r4 = 0x96000 - (int)(((long long)r5 * 0x180 + 0x800) >> 12);
@@ -74,6 +69,5 @@ extern "C" void func_ov002_020b2c44(char *c)
         *(int *)(c + 0x368) = *(int *)(c + 0x64) >> 3;
         _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
             c, c + 0x314, c + 0x33c, r4, r5 + 0x28000, 0xf);
-        _ZN9dBgCh_GndD1Ev(&rg);
     }
 }

--- a/src/func_ov002_020b5e58.cpp
+++ b/src/func_ov002_020b5e58.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -17,19 +18,11 @@ extern "C" void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_
 extern "C" void func_020393c4(void *p, void *v);
 extern "C" void func_020393d4(void *p, void *v);
 
-
-struct dBgCh_Gnd { char buf[0x44]; int f44; char rest[8]; };
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd *self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd *self, Vector3 *v, void *a);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd *self);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd *self);
-
 extern char _ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_;
 extern "C" signed char data_0209f2f8;
 
 extern "C" int func_ov002_020b5e58(char *self, char *fp)
 {
-    dBgCh_Gnd rg;
     Vector3 v;
     BMD_File *bmd;
     KCL_File *kcl;
@@ -57,7 +50,7 @@ extern "C" int func_ov002_020b5e58(char *self, char *fp)
     *(int *)(self + 0x344) = *(int *)(self + 0x60);
 
     if (data_0209f2f8 == 0x15) {
-        _ZN9dBgCh_GndC1Ev(&rg);
+        dBgCh_Gnd rg;
         vy = *(int *)(self + 0x60);
         vz = *(int *)(self + 0x64);
         vx = *(int *)(self + 0x5c);
@@ -67,11 +60,10 @@ extern "C" int func_ov002_020b5e58(char *self, char *fp)
             v.y = t;
             v.z = vz;
         }
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, self);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg)) {
-            *(int *)(self + 0x344) = rg.f44 + 0x3e000;
+        rg.SetObjAndPos(v, (dActor_c*)self);
+        if (rg.DetectClsn()) {
+            *(int *)(self + 0x344) = rg.clsnY + 0x3e000;
         }
-        _ZN9dBgCh_GndD1Ev(&rg);
     }
     return 1;
 }

--- a/src/func_ov002_020c179c.cpp
+++ b/src/func_ov002_020c179c.cpp
@@ -2,19 +2,15 @@
 // @symbol func_ov002_020c179c
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 // func_ov002_020c179c at 0x020c179c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 
 extern "C" {
-extern void _ZN9dBgCh_GndC1Ev(void* self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void* self, void* pos, void* act);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_GndD1Ev(void* self);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern short data_02082214[];
 
 int func_ov002_020c179c(char* self, int angle) {
-    char rg[0x50];
     Vector3 v1;
     Vector3 v2;
     int idx = (unsigned short)(short)(*(short*)(self + 0x94) + angle);
@@ -25,7 +21,7 @@ int func_ov002_020c179c(char* self, int angle) {
     short dy = data_02082214[idx * 2 + 1];
     int ox = dx * 5;
     int oy = dy * 5;
-    _ZN9dBgCh_GndC1Ev(rg);
+    dBgCh_Gnd rg;
     {
         int z = *(int*)(self + 0x64) + oy;
         int y = *(int*)(self + 0x60) + 0x64000;
@@ -34,8 +30,8 @@ int func_ov002_020c179c(char* self, int angle) {
         v1.y = y;
         v1.z = z;
     }
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, &v1, self);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(rg)) y1 = *(int*)(rg + 0x44);
+    rg.SetObjAndPos(v1, (dActor_c*)self);
+    if (rg.DetectClsn()) y1 = rg.clsnY;
     {
         int z = *(int*)(self + 0x64) - oy;
         int x = *(int*)(self + 0x5c) - ox;
@@ -44,11 +40,10 @@ int func_ov002_020c179c(char* self, int angle) {
         v2.y = y;
         v2.z = z;
     }
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, &v2, self);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(rg)) y2 = *(int*)(rg + 0x44);
+    rg.SetObjAndPos(v2, (dActor_c*)self);
+    if (rg.DetectClsn()) y2 = rg.clsnY;
     {
         int r = _ZN4cstd5atan2E5Fix12IiES1_(y1 - y2, 0xa000);
-        _ZN9dBgCh_GndD1Ev(rg);
         return r;
     }
 }

--- a/src/func_ov002_020c19d0.cpp
+++ b/src/func_ov002_020c19d0.cpp
@@ -1,10 +1,6 @@
 //cpp
-#include "types.h"
+#include "dBgCh_Lin.h"
 extern "C" {
-void _ZN9dBgCh_LinC1Ev(void* self);
-void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-void _ZN9dBgCh_LinD1Ev(void* self);
 void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, void* out);
 }
 
@@ -19,24 +15,20 @@ extern "C" int func_ov002_020c19d0(char* self, int arg1, int arg2) {
     V3 v1;
     V3 v2;
     V3 nrm;
-    char rl[0x78];
     int angle = *(unsigned short*)(self + 0x8e);
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
     int k = angle >> 4;
     int cs = data_02082214[k * 2];
     int sn = data_02082214[k * 2 + 1];
     v1.set(*(int*)(self + 0x5c), *(int*)(self + 0x60) + (arg2 << 12), *(int*)(self + 0x64));
     v2.set(arg1 * cs + *(int*)(self + 0x5c), *(int*)(self + 0x60) + (arg2 << 12), arg1 * sn + *(int*)(self + 0x64));
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &v1, &v2, self);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) == 0) {
-        _ZN9dBgCh_LinD1Ev(rl);
+    line.SetObjAndLine(*(Vector3*)&v1, *(Vector3*)&v2, (dActor_c*)self);
+    if (!line.DetectClsn()) {
         return 0;
     }
-    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(rl + 0x14, &nrm);
+    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(&line.surface, &nrm);
     if (nrm.y != 0) {
-        _ZN9dBgCh_LinD1Ev(rl);
         return 0;
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return 1;
 }

--- a/src/func_ov002_020c2270.cpp
+++ b/src/func_ov002_020c2270.cpp
@@ -2,32 +2,26 @@
 // @symbol func_ov002_020c2270
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Lin.h"
 extern "C" {
 
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
 extern int func_02037e58(unsigned int* p);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(void* res, void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
+extern void _ZN9dBgCh_Lin10GetClsnPosEv(Vector3* res, dBgCh_Lin* self);
 
 int func_ov002_020c2270(void* c, void* p1, void* p2) {
-    char rl[0x78];
+    dBgCh_Lin line;
     Vector3 clsnPos;
-    _ZN9dBgCh_LinC1Ev(rl);
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, p1, p2, c);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-        if (func_02037e58((unsigned int*)(rl + 0x14)) == 1) {
-            _ZN9dBgCh_Lin10GetClsnPosEv(&clsnPos, rl);
+    line.SetObjAndLine(*(Vector3*)p1, *(Vector3*)p2, (dActor_c*)c);
+    if (line.DetectClsn()) {
+        if (func_02037e58((unsigned int*)&line.surface) == 1) {
+            _ZN9dBgCh_Lin10GetClsnPosEv(&clsnPos, &line);
             *(int*)((char*)c + 0x5c) = clsnPos.x;
             *(int*)((char*)c + 0x60) = clsnPos.y;
             *(int*)((char*)c + 0x64) = clsnPos.z;
             *((unsigned char*)c + 0x70f) = 1;
-            _ZN9dBgCh_LinD1Ev(rl);
             return 1;
         }
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }
 }

--- a/src/func_ov002_020c647c.cpp
+++ b/src/func_ov002_020c647c.cpp
@@ -2,22 +2,18 @@
 // @symbol func_ov002_020c647c
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Lin.h"
 // func_ov002_020c647c at 0x020c647c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(void* res, void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
+extern void _ZN9dBgCh_Lin10GetClsnPosEv(Vector3* res, dBgCh_Lin* self);
 
 int func_ov002_020c647c(char* c, int arg1) {
     Vector3 v1;
     Vector3 v2;
     Vector3 clsnPos;
-    char rl[0x78];
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
     int z1 = *(int*)(c + 0x64);
     int x1 = *(int*)(c + 0x5c);
     v1.x = x1;
@@ -29,15 +25,14 @@ int func_ov002_020c647c(char* c, int arg1) {
     v2.z = z2;
     v2.y = arg1 + 0xaa000;
     int r5 = -64;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &v1, &v2, c);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-        _ZN9dBgCh_Lin10GetClsnPosEv(&clsnPos, rl);
+    line.SetObjAndLine(v1, v2, (dActor_c*)c);
+    if (line.DetectClsn()) {
+        _ZN9dBgCh_Lin10GetClsnPosEv(&clsnPos, &line);
         int d = (clsnPos.y - *(int*)(c + 0x60)) / 0x1000;
         if (d > 0xa0) d = 0xa0;
         if (d < 0) d = 0;
         r5 = d;
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return r5;
 }
 }

--- a/src/func_ov002_020c6538.cpp
+++ b/src/func_ov002_020c6538.cpp
@@ -1,35 +1,29 @@
 //cpp
+#include "dBgCh_Gnd.h"
+
 extern "C" {
-extern void _ZN9dBgCh_GndC1Ev(void* self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void* self, void* pos, void* act);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_GndD1Ev(void* self);
 int func_ov002_020c6538(char* c) {
-    char rg[0x54];
-    int v[3];
+    dBgCh_Gnd rg;
+    Vector3 v;
     int y;
-    _ZN9dBgCh_GndC1Ev(rg);
-    v[0] = *(int*)(c+0x5c);
+    v.x = *(int*)(c+0x5c);
     y = *(int*)(c+0x60);
-    v[1] = y;
-    v[2] = *(int*)(c+0x64);
-    v[1] = y + 0x32000;
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, v, c);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(rg) == 0) {
-        _ZN9dBgCh_GndD1Ev(rg);
+    v.y = y;
+    v.z = *(int*)(c+0x64);
+    v.y = y + 0x32000;
+    rg.SetObjAndPos(v, (dActor_c*)c);
+    if (rg.DetectClsn() == 0) {
         return 0;
     }
     {
-        int hit = *(int*)(rg+0x44);
+        int hit = rg.clsnY;
         int d = hit - *(int*)(c+0x60);
         if (d < 0) d = -d;
         if (d >= 0x64000) {
-            _ZN9dBgCh_GndD1Ev(rg);
             return 0;
         }
         *(int*)(c+0x60) = hit;
         *(int*)(c+0x688) = *(int*)(c+0x60);
-        _ZN9dBgCh_GndD1Ev(rg);
         return 1;
     }
 }

--- a/src/func_ov002_020cede0.cpp
+++ b/src/func_ov002_020cede0.cpp
@@ -4,15 +4,10 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
 extern "C" {
-extern void _ZN9dBgCh_GndC1Ev(void* self);
-extern void _ZN5dBgCh19StartDetectingWaterEv(void* self);
-extern void _ZN5dBgCh21StopDetectingOrdinaryEv(void* self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void* self, void* v, void* act);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(void* self);
 extern int SurfaceInfo_TestFlag0x20(int* p);
-extern void _ZN9dBgCh_GndD1Ev(void* self);
 extern int data_0209f32c;
 extern signed char data_0209f2f8;
 }
@@ -20,7 +15,6 @@ extern signed char data_0209f2f8;
 extern "C" int func_ov002_020cede0(void* thiz_) {
     char* thiz = (char*)thiz_;
   Vector3 v;
-  char rg[0x54];
   int y = *(int*)(thiz + 0x60);
   int g = data_0209f32c;
   if (g < y - 0x64000)
@@ -31,7 +25,7 @@ extern "C" int func_ov002_020cede0(void* thiz_) {
     if (d >= 0xc8000)
       return 1;
   }
-  _ZN9dBgCh_GndC1Ev(rg);
+  dBgCh_Gnd rg;
   {
     int z = *(int*)(thiz + 0x64);
     int yy = data_0209f32c + 0xc8000;
@@ -40,29 +34,25 @@ extern "C" int func_ov002_020cede0(void* thiz_) {
     v.y = yy;
     v.z = z;
   }
-  _ZN5dBgCh19StartDetectingWaterEv(rg);
-  _ZN5dBgCh21StopDetectingOrdinaryEv(rg);
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, &v, thiz);
-  if (_ZN9dBgCh_Gnd10DetectClsnEv(rg) != 0 && SurfaceInfo_TestFlag0x20((int*)(rg + 0x14)) != 0) {
-    _ZN9dBgCh_GndD1Ev(rg);
+  rg.StartDetectingWater();
+  rg.StopDetectingOrdinary();
+  rg.SetObjAndPos(v, (dActor_c*)thiz);
+  if (rg.DetectClsn() != 0 && SurfaceInfo_TestFlag0x20((int*)&rg.surface) != 0) {
     return 1;
   }
   v.y = data_0209212c;
-  _ZN5dBgCh19StartDetectingWaterEv(rg);
-  _ZN5dBgCh21StopDetectingOrdinaryEv(rg);
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, &v, thiz);
-  if (_ZN9dBgCh_Gnd10DetectClsnEv(rg) != 0 && SurfaceInfo_TestFlag0x20((int*)(rg + 0x14)) != 0) {
-    *(int*)(thiz + 0x64c) = *(int*)(rg + 0x44);
+  rg.StartDetectingWater();
+  rg.StopDetectingOrdinary();
+  rg.SetObjAndPos(v, (dActor_c*)thiz);
+  if (rg.DetectClsn() != 0 && SurfaceInfo_TestFlag0x20((int*)&rg.surface) != 0) {
+    *(int*)(thiz + 0x64c) = rg.clsnY;
     data_0209f32c = *(int*)(thiz + 0x64c);
-    _ZN9dBgCh_GndD1Ev(rg);
     return 1;
   }
   if (data_0209f2f8 == 0x21) {
     *(int*)(thiz + 0x64c) = 0x80000000;
     data_0209f32c = *(int*)(thiz + 0x64c);
-    _ZN9dBgCh_GndD1Ev(rg);
     return 0;
   }
-  _ZN9dBgCh_GndD1Ev(rg);
   return 1;
 }

--- a/src/func_ov002_020cef84.cpp
+++ b/src/func_ov002_020cef84.cpp
@@ -1,6 +1,6 @@
 //cpp
-typedef struct { int a, b; } Pair2i;
-typedef struct { int x, y, z; } Vector3;
+#include "dBgCh_Lin.h"
+
 typedef struct {
     void *tag;
     int f04, f08, f0c, f10, f14;
@@ -12,11 +12,7 @@ extern "C" {
 extern int _ZN6Player7IsInAirEv(void *self);
 extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *st);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *st);
-extern void _ZN9dBgCh_LinC1Ev(void *self);
-extern void _ZN9dBgCh_LinD1Ev(void *self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void *self, void *a, void *b, void *act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void *self);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(void *ret, void *self);
+extern void _ZN9dBgCh_Lin10GetClsnPosEv(Vector3 *ret, dBgCh_Lin *self);
 extern void func_02035414(void *bgch);
 extern void func_02035428(void *bgch);
 extern int func_02037e38(unsigned int *p);
@@ -30,17 +26,15 @@ extern int data_02099368;
 
 extern "C" int func_ov002_020cef84(char *self)
 {
-    char rl[0x78];
     Vector3 v1, v2, cp;
     ClsnResultTmp tmp;
     int lim;
 
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
     if (!_ZN6Player7IsInAirEv(self) || *(unsigned char *)(self + 0x706) != 0 ||
         *(int *)(self + 0xa8) <= 0 || _ZN6Player7IsStateERNS_5StateE(self, &data_ov002_0211001c) ||
         *(unsigned char *)(self + 0x703) != 0 || *(unsigned char *)(self + 0x708) != 0 ||
         *(unsigned char *)(self + 0x709) != 0) {
-        _ZN9dBgCh_LinD1Ev(rl);
         return 0;
     }
 
@@ -64,18 +58,17 @@ extern "C" int func_ov002_020cef84(char *self)
             }
         }
     }
-    func_02035414(rl);
+    func_02035414(&line);
     if (*(unsigned char *)(self + 0x6fb) != 0)
-        func_02035428(rl);
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &v1, &v2, self);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl)) {
-        _ZN9dBgCh_Lin10GetClsnPosEv(&cp, rl);
-        if (func_02037e38((unsigned int *)(rl + 0x14)) == 3) {
+        func_02035428(&line);
+    line.SetObjAndLine(v1, v2, (dActor_c*)self);
+    if (line.DetectClsn()) {
+        _ZN9dBgCh_Lin10GetClsnPosEv(&cp, &line);
+        if (func_02037e38((unsigned int *)&line.surface) == 3) {
             int t2 = *(int *)(self + 0x358) != 0;
             if (t2 == false) {
                 _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_0211001c);
                 *(int *)(self + 0x60) = cp.y - 0x78000;
-                _ZN9dBgCh_LinD1Ev(rl);
                 return 1;
             }
         }
@@ -88,19 +81,19 @@ extern "C" int func_ov002_020cef84(char *self)
                 int w0, w1;
                 *(int *)(self + 0xa8) = -0x1000;
                 *(unsigned char *)(self + 0x6e9) |= 8;
-                w0 = *(int *)(rl + 0x14);
-                w1 = *(int *)(rl + 0x18);
+                w0 = *(int *)((char *)&line + 0x14);
+                w1 = *(int *)((char *)&line + 0x18);
                 dst[0] = w1 ? w0 : w0;
                 dst[1] = w1;
-                dst[2] = *(int *)(rl + 0x1c);
-                dst[3] = *(int *)(rl + 0x20);
-                dst[4] = *(int *)(rl + 0x24);
+                dst[2] = *(int *)((char *)&line + 0x1c);
+                dst[3] = *(int *)((char *)&line + 0x20);
+                dst[4] = *(int *)((char *)&line + 0x24);
                 tmp.tag = &data_02099368;
-                tmp.f18 = *(unsigned short *)(rl + 0x28);
-                tmp.f1a = *(unsigned short *)(rl + 0x2a);
-                tmp.f1c = *(int *)(rl + 0x2c);
-                tmp.f20 = *(int *)(rl + 0x30);
-                tmp.f24 = *(int *)(rl + 0x34);
+                tmp.f18 = *(unsigned short *)((char *)&line + 0x28);
+                tmp.f1a = *(unsigned short *)((char *)&line + 0x2a);
+                tmp.f1c = *(int *)((char *)&line + 0x2c);
+                tmp.f20 = *(int *)((char *)&line + 0x30);
+                tmp.f24 = *(int *)((char *)&line + 0x34);
                 a = _ZN8dActor_c10FindWithIDEj(_ZNK5dBgPi9GetClsnIDEv(&tmp));
                 if (a)
                     (*(void (**)(void *, char *))(*(int *)a + 0x70))(a, self);
@@ -108,6 +101,5 @@ extern "C" int func_ov002_020cef84(char *self)
             }
         }
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }

--- a/src/func_ov002_020cf20c.cpp
+++ b/src/func_ov002_020cf20c.cpp
@@ -2,26 +2,22 @@
 // @symbol func_ov002_020cf20c
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Lin.h"
 // func_ov002_020cf20c at 0x020cf20c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_Lin10GetClsnPosEv(void* res, void* self);
+extern void _ZN9dBgCh_Lin10GetClsnPosEv(Vector3* res, dBgCh_Lin* self);
 extern int func_02037e38(unsigned int* p);
 extern int func_02037e48(unsigned int* p);
 extern void func_0200ca14(void* a, unsigned char b, int c);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
 extern void* data_0209f318[];
 
 int func_ov002_020cf20c(char* c) {
     Vector3 v1;
     Vector3 v2;
     Vector3 clsnPos;
-    char rl[0x78];
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
     v1.x = *(int*)(c + 0x5c);
     int y1 = *(int*)(c + 0x60);
     v1.y = y1;
@@ -32,19 +28,17 @@ int func_ov002_020cf20c(char* c) {
     v2.z = *(int*)(c + 0x64);
     v1.y = y1 + 0x64000;
     v2.y = y2 + 0xb4000;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &v1, &v2, c);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-        if (func_02037e38((unsigned int*)(rl + 0x14)) == 3) {
-            _ZN9dBgCh_Lin10GetClsnPosEv(&clsnPos, rl);
+    line.SetObjAndLine(v1, v2, (dActor_c*)c);
+    if (line.DetectClsn()) {
+        if (func_02037e38((unsigned int*)&line.surface) == 3) {
+            _ZN9dBgCh_Lin10GetClsnPosEv(&clsnPos, &line);
             void* cam = data_0209f318[0];
-            int t = func_02037e48((unsigned int*)(rl + 0x14));
+            int t = func_02037e48((unsigned int*)&line.surface);
             func_0200ca14(cam, *(unsigned char*)(c + 0x6d8), t);
             int ret = clsnPos.y;
-            _ZN9dBgCh_LinD1Ev(rl);
             return ret;
         }
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return (int)0x80000000;
 }
 }

--- a/src/func_ov002_020cfaf0.cpp
+++ b/src/func_ov002_020cfaf0.cpp
@@ -1,16 +1,12 @@
 //cpp
+#include "dBgCh_Lin.h"
 extern short data_02082214[];
 extern "C" {
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
 
 int func_ov002_020cfaf0(char* c) {
-    char rl[0x78];
-    int v1[3];
-    int v2[3];
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
+    Vector3 v1;
+    Vector3 v2;
     {
         int ang = *(short*)(c + 0x8e);
         int j = 2 * (((unsigned short)(short)(ang + 0x8000)) >> 4);
@@ -19,22 +15,20 @@ int func_ov002_020cfaf0(char* c) {
         int ax = *(int*)(c + 0x5c) + s;
         int az = *(int*)(c + 0x64) + t;
         int ay = *(int*)(c + 0x60) - 0x20000;
-        v1[0] = ax;
-        v1[1] = ay;
-        v1[2] = az;
+        v1.x = ax;
+        v1.y = ay;
+        v1.z = az;
         int bx = *(int*)(c + 0x5c) + s;
         int bz = *(int*)(c + 0x64) + t;
         int by = *(int*)(c + 0x60) + 0x20000;
-        v2[0] = bx;
-        v2[1] = by;
-        v2[2] = bz;
+        v2.x = bx;
+        v2.y = by;
+        v2.z = bz;
     }
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, v1, v2, c);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-        _ZN9dBgCh_LinD1Ev(rl);
+    line.SetObjAndLine(v1, v2, (dActor_c*)c);
+    if (line.DetectClsn()) {
         return 1;
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }
 }

--- a/src/func_ov002_020cfbdc.cpp
+++ b/src/func_ov002_020cfbdc.cpp
@@ -4,6 +4,7 @@
 #include "decl_dBgPi.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Lin.h"
 
 
 extern "C" {
@@ -11,10 +12,6 @@ extern "C" {
 extern int _ZNK10dBgCh_Actr10IsOnGroundEv(void *self);
 extern void *_ZNK10dBgCh_Actr14GetFloorResultEv(void *self);
 extern void *_ZN8dActor_c10FindWithIDEj(unsigned int id);
-extern void _ZN9dBgCh_LinC1Ev(void *self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void *self, void *a, void *b, void *act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void *self);
-extern void _ZN9dBgCh_LinD1Ev(void *self);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *st);
 extern short data_02082214[];
 extern int data_ov002_021101b4;
@@ -23,7 +20,6 @@ extern int data_ov002_021101b4;
 extern "C" int func_ov002_020cfbdc(char *self)
 {
     Vector3 pts[3];
-    char rl[0x78];
     int idx = (unsigned short)(short)(*(short *)(self + 0x8e) + 0x8000) >> 4;
     int r6 = data_02082214[idx * 2];
     int r5 = data_02082214[idx * 2 + 1];
@@ -59,16 +55,14 @@ extern "C" int func_ov002_020cfbdc(char *self)
         pts[2].z = bz;
     }
 
-    _ZN9dBgCh_LinC1Ev(rl);
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &pts[1], &pts[2], self);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
+    dBgCh_Lin line;
+    line.SetObjAndLine(pts[1], pts[2], (dActor_c*)self);
+    if (line.DetectClsn()) {
         *(int *)((int)(self + 0x5c)) += r5 * 0x60;
         *(int *)((int)(self + 0x60)) -= 0x80000;
         *(int *)((int)(self + 0x64)) += r5 * 0x60;
         _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_021101b4);
-        _ZN9dBgCh_LinD1Ev(rl);
         return 1;
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }

--- a/src/func_ov002_020cfd84.cpp
+++ b/src/func_ov002_020cfd84.cpp
@@ -1,39 +1,32 @@
 //cpp
 // func_ov002_020cfd84 at 0x020cfd84
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+#include "dBgCh_Lin.h"
 extern "C" {
-struct CRData { int a,b,c,d,e; unsigned short f,g; int h,i,j; };
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN5dBgPiC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
 extern int _ZNK5dBgPi9GetClsnIDEv(void* self);
 extern void* _ZN8dActor_c10FindWithIDEj(unsigned int id);
-extern void _ZN5dBgPiD1Ev(void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
 
 int func_ov002_020cfd84(void* actor, void* a, void* b) {
-    char rl[0x78];
-    char res[0x28];
-    _ZN9dBgCh_LinC1Ev(rl);
-    _ZN5dBgPiC1Ev(res);
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, a, b, actor);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-        *(CRData*)(res + 4) = *(CRData*)(rl + 0x14);
-        if (_ZNK5dBgPi9GetClsnIDEv(res) != -1) {
-            void* act = _ZN8dActor_c10FindWithIDEj((unsigned int)_ZNK5dBgPi9GetClsnIDEv(res));
+    dBgCh_Lin line;
+    dBgPi result;
+    line.SetObjAndLine(*(Vector3*)a, *(Vector3*)b, (dActor_c*)actor);
+    if (line.DetectClsn()) {
+        result.surface = line.surface;
+        result.triangleID = line.triangleID;
+        result.flags = line.flags;
+        result.clsnID = line.clsnID;
+        result.unk_020 = line.unk_020;
+        result.unk_024 = line.unk_024;
+        if (_ZNK5dBgPi9GetClsnIDEv(&result) != -1) {
+            void* act = _ZN8dActor_c10FindWithIDEj((unsigned int)_ZNK5dBgPi9GetClsnIDEv(&result));
             if (act != 0) {
                 int t = (*(unsigned short*)((char*)act + 0xc) == 0x12a);
                 if (t == 0) {
-                    _ZN5dBgPiD1Ev(res);
-                    _ZN9dBgCh_LinD1Ev(rl);
                     return 1;
                 }
             }
         }
     }
-    _ZN5dBgPiD1Ev(res);
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }
 }

--- a/src/func_ov002_020d1164.cpp
+++ b/src/func_ov002_020d1164.cpp
@@ -1,31 +1,25 @@
 //cpp
 // func_ov002_020d1164 at 0x020d1164
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+#include "dBgCh_Lin.h"
 extern "C" {
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
 int func_ov002_020d1164(char* c) {
-    char rl[0x78];
-    int v1[3];
-    int v2[3];
+    dBgCh_Lin line;
+    Vector3 v1;
+    Vector3 v2;
     int y;
-    _ZN9dBgCh_LinC1Ev(rl);
-    v1[0] = *(int*)(c+0x5c);
-    v1[1] = *(int*)(c+0x60);
-    v1[2] = *(int*)(c+0x64);
-    v2[0] = *(int*)(c+0x5c);
+    v1.x = *(int*)(c+0x5c);
+    v1.y = *(int*)(c+0x60);
+    v1.z = *(int*)(c+0x64);
+    v2.x = *(int*)(c+0x5c);
     y = *(int*)(c+0x60);
-    v2[1] = y;
-    v2[2] = *(int*)(c+0x64);
-    v2[1] = y + 0x96000;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, v1, v2, c);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
-        _ZN9dBgCh_LinD1Ev(rl);
+    v2.y = y;
+    v2.z = *(int*)(c+0x64);
+    v2.y = y + 0x96000;
+    line.SetObjAndLine(v1, v2, (dActor_c*)c);
+    if (line.DetectClsn()) {
         return 1;
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }
 }

--- a/src/func_ov002_020d5cec.cpp
+++ b/src/func_ov002_020d5cec.cpp
@@ -4,14 +4,11 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Lin.h"
 
 extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int anim, int a, int b, unsigned int d);
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
 extern short data_02082214[];
 }
 
@@ -19,7 +16,6 @@ extern "C" int func_ov002_020d5cec(char* c)
 {
     Vector3 v1;
     Vector3 v2;
-    char rl[0x78];
     char* d0;
     short* m;
     char* p;
@@ -50,9 +46,9 @@ extern "C" int func_ov002_020d5cec(char* c)
     v2.y = v1.y;
     v2.z = v1.z + (int)(((long long)data_02082214[shifted * 2 + 1] * 0x50000 + 0x800) >> 12);
 
-    _ZN9dBgCh_LinC1Ev(rl);
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &v1, &v2, c);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl) != 0) {
+    dBgCh_Lin line;
+    line.SetObjAndLine(v1, v2, (dActor_c*)c);
+    if (line.DetectClsn()) {
         *(int*)(c + 0x5c) = v1.x;
         *(int*)(c + 0x60) = v1.y;
         *(int*)(c + 0x64) = v1.z;
@@ -68,6 +64,5 @@ extern "C" int func_ov002_020d5cec(char* c)
     *(unsigned short*)(c + 0x6a4) = 4;
     *(unsigned char*)(c + 0x708) = 1;
     *(int*)(c + 0xd0) = 0;
-    _ZN9dBgCh_LinD1Ev(rl);
     return 1;
 }

--- a/src/func_ov002_020eeeb8.cpp
+++ b/src/func_ov002_020eeeb8.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef struct {
-    int x, y, z;
-} Vector3;
+#include "dBgCh_Lin.h"
 
 typedef struct {
     void *tag;
@@ -11,16 +9,10 @@ typedef struct {
 } ClsnResultTmp;
 
 extern "C" {
-extern void _ZN9dBgCh_LinC1Ev(void *self);
-extern void _ZN9dBgCh_LinD1Ev(void *self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(
-    void *self, void *a, void *b, void *act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void *self);
 extern void func_ov002_020d8838(void *actor);
 extern unsigned _ZNK5dBgPi9GetClsnIDEv(void *self);
 extern void *_ZN8dActor_c10FindWithIDEj(unsigned id);
 extern void _ZN5dBgPiD1Ev(void *self);
-
 extern int data_02099368;
 extern short data_02082214[];
 }
@@ -29,9 +21,8 @@ extern "C" int func_ov002_020eeeb8(void *unused, char *actor)
 {
     Vector3 v1, v2;
     ClsnResultTmp tmp;
-    char rl[0x78];
 
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
 
     Vector3 *pos =
         (Vector3 *)(actor + 0x5c);
@@ -57,31 +48,30 @@ extern "C" int func_ov002_020eeeb8(void *unused, char *actor)
         data_02082214[((*(unsigned short *)(actor + 0x8e) >> 4) << 1) + 1] +
         v2.z;
 
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(
-        rl, &v1, &v2, actor);
+    line.SetObjAndLine(v1, v2, (dActor_c*)actor);
 
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl)) {
+    if (line.DetectClsn()) {
         int t = (*(unsigned short *)(actor + 0xc) == 0xbf);
         if (t != false)
             func_ov002_020d8838(actor);
 
         {
             int *dst = &tmp.f04;
-            int w0 = *(int *)(rl + 0x14);
-            int w1 = *(int *)(rl + 0x18);
+            int w0 = *(int *)((char *)&line + 0x14);
+            int w1 = *(int *)((char *)&line + 0x18);
 
             dst[0] = w1 ? w0 : w0;
             dst[1] = w1;
-            dst[2] = *(int *)(rl + 0x1c);
-            dst[3] = *(int *)(rl + 0x20);
-            dst[4] = *(int *)(rl + 0x24);
+            dst[2] = *(int *)((char *)&line + 0x1c);
+            dst[3] = *(int *)((char *)&line + 0x20);
+            dst[4] = *(int *)((char *)&line + 0x24);
 
             tmp.tag = &data_02099368;
-            tmp.f18 = *(unsigned short *)(rl + 0x28);
-            tmp.f1a = *(unsigned short *)(rl + 0x2a);
-            tmp.f1c = *(int *)(rl + 0x2c);
-            tmp.f20 = *(int *)(rl + 0x30);
-            tmp.f24 = *(int *)(rl + 0x34);
+            tmp.f18 = *(unsigned short *)((char *)&line + 0x28);
+            tmp.f1a = *(unsigned short *)((char *)&line + 0x2a);
+            tmp.f1c = *(int *)((char *)&line + 0x2c);
+            tmp.f20 = *(int *)((char *)&line + 0x30);
+            tmp.f24 = *(int *)((char *)&line + 0x34);
 
             if (_ZNK5dBgPi9GetClsnIDEv(&tmp) != 0xffffffff) {
                 void *a = _ZN8dActor_c10FindWithIDEj(
@@ -90,7 +80,6 @@ extern "C" int func_ov002_020eeeb8(void *unused, char *actor)
                     (*(void (**)(void *, char *))(*(int *)a + 0x60))(
                         a, actor);
                     _ZN5dBgPiD1Ev(&tmp);
-                    _ZN9dBgCh_LinD1Ev(rl);
                     return 1;
                 }
             }
@@ -98,6 +87,5 @@ extern "C" int func_ov002_020eeeb8(void *unused, char *actor)
         _ZN5dBgPiD1Ev(&tmp);
     }
 
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }

--- a/src/func_ov002_020ef070.cpp
+++ b/src/func_ov002_020ef070.cpp
@@ -1,5 +1,6 @@
 //cpp
-typedef struct { int x, y, z; } Vector3;
+#include "dBgCh_Lin.h"
+
 typedef struct {
     void *tag;
     int f04, f08, f0c, f10, f14;
@@ -8,15 +9,10 @@ typedef struct {
 } ClsnResultTmp;
 
 extern "C" {
-extern void _ZN9dBgCh_LinC1Ev(void *self);
-extern void _ZN9dBgCh_LinD1Ev(void *self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void *self, void *a, void *b, void *act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void *self);
 extern void func_ov002_020d8838(void *actor);
 extern unsigned _ZNK5dBgPi9GetClsnIDEv(void *self);
 extern void *_ZN8dActor_c10FindWithIDEj(unsigned id);
 extern void _ZN5dBgPiD1Ev(void *self);
-
 extern int data_02099368;
 extern short data_02082214[];
 }
@@ -25,9 +21,8 @@ extern "C" int func_ov002_020ef070(void *unused, char *actor)
 {
     Vector3 v1, v2;
     ClsnResultTmp tmp;
-    char rl[0x78];
 
-    _ZN9dBgCh_LinC1Ev(rl);
+    dBgCh_Lin line;
 
     Vector3 *pos = (Vector3 *)(actor + 0x5c);
     int x = pos->x;
@@ -46,39 +41,37 @@ extern "C" int func_ov002_020ef070(void *unused, char *actor)
     v2.x = scale * data_02082214[(*(unsigned short *)(actor + 0x8e) >> 4) << 1] + v2.x;
     v2.z = scale * data_02082214[((*(unsigned short *)(actor + 0x8e) >> 4) << 1) + 1] + v2.z;
 
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl, &v1, &v2, actor);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl)) {
+    line.SetObjAndLine(v1, v2, (dActor_c*)actor);
+    if (line.DetectClsn()) {
         int t = (*(unsigned short *)(actor + 0xc) == 0xbf);
         if (t != false) {
             func_ov002_020d8838(actor);
         }
         {
             int *dst = &tmp.f04;
-            int w0 = *(int *)(rl + 0x14);
-            int w1 = *(int *)(rl + 0x18);
+            int w0 = *(int *)((char *)&line + 0x14);
+            int w1 = *(int *)((char *)&line + 0x18);
             dst[0] = w1 ? w0 : w0;
             dst[1] = w1;
-            dst[2] = *(int *)(rl + 0x1c);
-            dst[3] = *(int *)(rl + 0x20);
-            dst[4] = *(int *)(rl + 0x24);
+            dst[2] = *(int *)((char *)&line + 0x1c);
+            dst[3] = *(int *)((char *)&line + 0x20);
+            dst[4] = *(int *)((char *)&line + 0x24);
             tmp.tag = &data_02099368;
-            tmp.f18 = *(unsigned short *)(rl + 0x28);
-            tmp.f1a = *(unsigned short *)(rl + 0x2a);
-            tmp.f1c = *(int *)(rl + 0x2c);
-            tmp.f20 = *(int *)(rl + 0x30);
-            tmp.f24 = *(int *)(rl + 0x34);
+            tmp.f18 = *(unsigned short *)((char *)&line + 0x28);
+            tmp.f1a = *(unsigned short *)((char *)&line + 0x2a);
+            tmp.f1c = *(int *)((char *)&line + 0x2c);
+            tmp.f20 = *(int *)((char *)&line + 0x30);
+            tmp.f24 = *(int *)((char *)&line + 0x34);
             if (_ZNK5dBgPi9GetClsnIDEv(&tmp) != 0xffffffff) {
                 void *a = _ZN8dActor_c10FindWithIDEj(_ZNK5dBgPi9GetClsnIDEv(&tmp));
                 if (a) {
                     (*(void (**)(void *, char *))(*(int *)a + 0x5c))(a, actor);
                     _ZN5dBgPiD1Ev(&tmp);
-                    _ZN9dBgCh_LinD1Ev(rl);
                     return 1;
                 }
             }
             _ZN5dBgPiD1Ev(&tmp);
         }
     }
-    _ZN9dBgCh_LinD1Ev(rl);
     return 0;
 }

--- a/src/func_ov030_02111dd0.cpp
+++ b/src/func_ov030_02111dd0.cpp
@@ -1,37 +1,33 @@
 //cpp
+#include "dBgCh_Gnd.h"
+
 extern "C" {
 extern int _ZNK10dBgCh_Actr10IsOnGroundEv(void* thiz);
-extern void _ZN9dBgCh_GndC1Ev(void* self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void* self, void* pos, void* act);
 extern int func_02038ea4(void* thiz);
-extern void _ZN9dBgCh_GndD1Ev(void* self);
 
 int func_ov030_02111dd0(char* c)
 {
     if (_ZNK10dBgCh_Actr10IsOnGroundEv(c + 0x194) != 0) {
-        char rg[0x54];
-        int v[3];
+        dBgCh_Gnd rg;
+        Vector3 v;
         int y, z, x, s;
-        _ZN9dBgCh_GndC1Ev(rg);
         y = *(int*)(c + 0x60);
         z = *(int*)(c + 0x64);
         x = *(int*)(c + 0x5c);
         s = y + 0x1e000;
-        v[0] = x;
-        v[1] = s;
-        v[2] = z;
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, v, c);
-        if (func_02038ea4(rg) == 0 || *(int*)(c + 0x60) - *(int*)(rg + 0x44) > 0x2000) {
+        v.x = x;
+        v.y = s;
+        v.z = z;
+        rg.SetObjAndPos(v, (dActor_c*)c);
+        if (func_02038ea4(&rg) == 0 || *(int*)(c + 0x60) - rg.clsnY > 0x2000) {
             *(int*)(c + 0x5c) = *(int*)(c + 0x38c);
             *(int*)(c + 0x60) = *(int*)(c + 0x390);
             *(int*)(c + 0x64) = *(int*)(c + 0x394);
-            _ZN9dBgCh_GndD1Ev(rg);
             return 1;
         }
         *(int*)(c + 0x38c) = *(int*)(c + 0x5c);
         *(int*)(c + 0x390) = *(int*)(c + 0x60);
         *(int*)(c + 0x394) = *(int*)(c + 0x64);
-        _ZN9dBgCh_GndD1Ev(rg);
     }
     return 0;
 }

--- a/src/func_ov030_02111ea4.cpp
+++ b/src/func_ov030_02111ea4.cpp
@@ -2,17 +2,9 @@
 // @symbol func_ov030_02111ea4
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
-struct dActor_c;
-
-struct dBgCh_Gnd {
-    char pad[0x54];
-};
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(void*);
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd*);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd*, const Vector3&, dActor_c*);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd*);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd*);
 
 #define ABS(x) ((x) < 0 ? -(x) : (x))
 
@@ -22,7 +14,6 @@ extern "C" int func_ov030_02111ea4(char* thiz)
     if (_ZNK10dBgCh_Actr10IsOnGroundEv(c + 0x194) != 0) {
         dBgCh_Gnd rg;
         Vector3 pos;
-        _ZN9dBgCh_GndC1Ev(&rg);
         {
             int y = *(int*)(c + 0x60);
             int z = *(int*)(c + 0x64);
@@ -32,17 +23,15 @@ extern "C" int func_ov030_02111ea4(char* thiz)
             pos.y = y2;
             pos.z = z;
         }
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, pos, (dActor_c*)c);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) == 0 ||
-            ABS(*(int*)((char*)&rg + 0x44) - *(int*)(c + 0x60)) > 0x1000) {
+        rg.SetObjAndPos(pos, (dActor_c*)c);
+        if (rg.DetectClsn() == 0 ||
+            ABS(rg.clsnY - *(int*)(c + 0x60)) > 0x1000) {
             *(int*)(c + 0x98) = 0;
             *(int*)(c + 0x5c) = *(int*)(c + 0x68);
             *(int*)(c + 0x60) = *(int*)(c + 0x6c);
             *(int*)(c + 0x64) = *(int*)(c + 0x70);
-            _ZN9dBgCh_GndD1Ev(&rg);
             return 1;
         }
-        _ZN9dBgCh_GndD1Ev(&rg);
     }
     return 0;
 }

--- a/src/func_ov060_02113b5c.cpp
+++ b/src/func_ov060_02113b5c.cpp
@@ -3,13 +3,9 @@
 // @symbol func_ov060_02113b5c
 /* recovered: shared common types */
 #include "common.h"
-struct dBgCh_Gnd { char buf[0x50]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" {
-    void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-    void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3* p, void* a);
-    int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
-    void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
     void func_ov060_02111cc0(char* c, int a, int b);
     void _Z14ApproachLinearRiii(int* v, int a, int b);
     void func_ov060_02115a84(char* c, char* arg);
@@ -27,9 +23,8 @@ extern "C" void func_ov060_02113b5c(char* c)
 
     int r4 = *(s32*)(c + 0x60);
     if (*(s32*)(c + 0x60) > *(s32*)(c + 0x3b4)) {
-        dBgCh_Gnd rg;
         Vector3 v;
-        _ZN9dBgCh_GndC1Ev(&rg);
+        dBgCh_Gnd rg;
         int base = *(s32*)(c + 0x3b4);
         int zz = *(s32*)(c + 0x64);
         int xx = *(s32*)(c + 0x5c);
@@ -37,12 +32,11 @@ extern "C" void func_ov060_02113b5c(char* c)
         v.x = xx;
         v.y = yy;
         v.z = zz;
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, c);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-            int hy = *(s32*)(rg.buf + 0x44);
+        rg.SetObjAndPos(v, (dActor_c*)c);
+        if (rg.DetectClsn() != 0) {
+            int hy = rg.clsnY;
             if (hy >= *(s32*)(c + 0x3b4) - 0x64000) r4 = hy;
         }
-        _ZN9dBgCh_GndD1Ev(&rg);
     }
 
     if (*(u8*)(c + 0x423) == 0) {

--- a/src/func_ov064_02116220.cpp
+++ b/src/func_ov064_02116220.cpp
@@ -1,20 +1,15 @@
 //cpp
 #include "daOts_c.h"
+#include "dBgCh_Gnd.h"
 
 extern "C" {
 typedef struct dActor_c dActor_c;
 typedef struct BCA_File BCA_File;
-struct dBgCh_Gnd { char buf[0x50]; };
-void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3* p, dActor_c* a);
-int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
 int func_02037e38(unsigned int* p);
 void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, BCA_File* f, int a, int b, unsigned int e);
-void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 
 void func_ov064_02116220(char* c){
   dBgCh_Gnd rg;
-  _ZN9dBgCh_GndC1Ev(&rg);
   Vector3 v;
   int y = *(int*)(c+0x60);
   int yoff = *(int*)(c+0x3ec);
@@ -26,11 +21,11 @@ void func_ov064_02116220(char* c){
   v.y = yv;
   v.z = z;
 
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, (dActor_c*)c);
-  if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-    *(int*)(c+0x3f4) = *(int*)(rg.buf + 0x44);
-    if (*(int*)(c+0x60) <= *(int*)(rg.buf + 0x44) + 0x14000) {
-      int r = func_02037e38((unsigned int*)(rg.buf + 0x14));
+  rg.SetObjAndPos(v, (dActor_c*)c);
+  if (rg.DetectClsn() != 0) {
+    *(int*)(c+0x3f4) = rg.clsnY;
+    if (*(int*)(c+0x60) <= rg.clsnY + 0x14000) {
+      int r = func_02037e38((unsigned int*)&rg.surface);
       if (r == 4 || r == 5 || r == 0x13) {
         *(int*)(c+0x398) = 5;
       } else if (r == 1) {
@@ -42,10 +37,9 @@ void func_ov064_02116220(char* c){
         *(int*)(c+0x3a8) = *(int*)(c+0x5c);
         *(int*)(c+0x3ac) = *(int*)(c+0x60);
         *(int*)(c+0x3b0) = *(int*)(c+0x64);
-        *(int*)(c+0x3ac) = *(int*)(rg.buf + 0x44) + 0x5000;
+        *(int*)(c+0x3ac) = rg.clsnY + 0x5000;
       }
     }
   }
-  _ZN9dBgCh_GndD1Ev(&rg);
 }
 }

--- a/src/func_ov065_02119fe8.cpp
+++ b/src/func_ov065_02119fe8.cpp
@@ -2,20 +2,15 @@
 // @symbol func_ov065_02119fe8
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 typedef short s16;
-
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 
 extern "C" void Matrix4x3_FromRotationZXYExt(void* m, int x, int y, int z);
 extern "C" void MulVec3Mat4x3(Vector3* in, void* m, Vector3* out);
 extern "C" void AddVec3(Vector3* a, Vector3* b, Vector3* c);
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3& v, void* actor);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
 extern "C" void _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
     void* self, void* sm, void* mtx, int f, int a, int b, unsigned int c);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 
 extern void* data_020a0e68;
 
@@ -23,7 +18,6 @@ extern "C" void func_ov065_02119fe8(char* self) {
     Vector3 v1;
     Vector3 v2;
     Vector3 pos;
-    dBgCh_Gnd rc;
     v1.y = 0;
     v1.y = -0x320000;
     v2.x = 0;
@@ -41,16 +35,15 @@ extern "C" void func_ov065_02119fe8(char* self) {
         pos.y = vy;
         pos.y = vy - 0xc8000;
     }
-    _ZN9dBgCh_GndC1Ev(&rc);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, 0);
+    dBgCh_Gnd rc;
+    rc.SetObjAndPos(pos, 0);
     *(int*)(self + 0x32c) = pos.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc))
-        *(int*)(self + 0x32c) = rc.floor[(0x44 - 0x14) / 4];
+    if (rc.DetectClsn())
+        *(int*)(self + 0x32c) = rc.clsnY;
     Matrix4x3_FromRotationY(self + 0x358, *(s16*)(self + 0x8e));
     *(int*)(self + 0x37c) = v2.x >> 3;
     *(int*)(self + 0x380) = *(int*)(self + 0x32c) >> 3;
     *(int*)(self + 0x384) = v2.z >> 3;
     _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
         self, self + 0x330, self + 0x358, 0x12c000, 0x12c000, 0x78000, 0xf);
-    _ZN9dBgCh_GndD1Ev(&rc);
 }

--- a/src/func_ov070_02121be4.cpp
+++ b/src/func_ov070_02121be4.cpp
@@ -2,25 +2,18 @@
 // @symbol func_ov070_02121be4
 /* recovered: shared common types */
 #include "common.h"
-
-struct dActor_c;
-struct dBgCh_Gnd { char buf[0x54]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(void *thiz);
-extern "C" void _ZN9dBgCh_GndC1Ev(struct dBgCh_Gnd *thiz);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct dBgCh_Gnd *thiz, const struct Vector3 *v, struct dActor_c *a);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(struct dBgCh_Gnd *thiz);
-extern "C" void _ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd *thiz);
 
 extern "C" void func_ov070_02121be4(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
-    struct dBgCh_Gnd rg;
     struct Vector3 v;
 
     if (!_ZNK10dBgCh_Actr10IsOnGroundEv(c + 0x130)) return;
 
-    _ZN9dBgCh_GndC1Ev(&rg);
+    dBgCh_Gnd rg;
     {
         int z = *(int *)(c + 0x64);
         int y = *(int *)(c + 0x60) + 0x1e000;
@@ -29,12 +22,11 @@ extern "C" void func_ov070_02121be4(void *thiz)
         v.y = y;
         v.z = z;
     }
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, (struct dActor_c *)c);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) == 0 ||
-        *(int *)((char *)&rg + 0x44) < *(int *)(c + 0x60) - 0x32000) {
+    rg.SetObjAndPos(v, (dActor_c *)c);
+    if (rg.DetectClsn() == 0 ||
+        rg.clsnY < *(int *)(c + 0x60) - 0x32000) {
         *(int *)(c + 0x5c) = *(int *)(c + 0x68);
         *(int *)(c + 0x60) = *(int *)(c + 0x6c);
         *(int *)(c + 0x64) = *(int *)(c + 0x70);
     }
-    _ZN9dBgCh_GndD1Ev(&rg);
 }

--- a/src/func_ov070_02121e14.cpp
+++ b/src/func_ov070_02121e14.cpp
@@ -1,24 +1,19 @@
 //cpp
-struct dBgCh_Gnd { char pad[0x44]; int hit; char pad2[0x8]; };
+#include "dBgCh_Gnd.h"
+
 extern "C" {
-extern void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* r);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* r, void* v, void* a);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* r);
 extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* a, void* sm, void* m, int f1, int f2, unsigned int j);
-extern void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* r);
 void func_ov070_02121e14(char* c) {
-  dBgCh_Gnd rg;
   int f;
   *(int*)(c + 0x310) = *(int*)(c + 0x5c) >> 3;
   *(int*)(c + 0x314) = *(int*)(c + 0x60) >> 3;
   *(int*)(c + 0x318) = *(int*)(c + 0x64) >> 3;
-  _ZN9dBgCh_GndC1Ev(&rg);
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, c + 0x5c, c);
-  if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0)
-    f = (*(int*)(c + 0x60) - rg.hit) + 0x1e000;
+  dBgCh_Gnd rg;
+  rg.SetObjAndPos(*(Vector3*)(c + 0x5c), (dActor_c*)c);
+  if (rg.DetectClsn() != 0)
+    f = (*(int*)(c + 0x60) - rg.clsnY) + 0x1e000;
   else
     f = 0x12c000;
   _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0xd4, c + 0x2ec, 0x64000, f, 0xf);
-  _ZN9dBgCh_GndD1Ev(&rg);
 }
 }

--- a/src/func_ov071_0211f148.cpp
+++ b/src/func_ov071_0211f148.cpp
@@ -4,35 +4,29 @@
 #include "decl_dBgCh_Actr.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 typedef int Fix12;
 typedef short s16;
 
 struct dBgCh_Actr;
-struct dActor_c;
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 struct dBgPi;
 struct SurfaceInfo;
 
 extern "C" void dBgCh_Actr_UpdateDiscreteNoLava_veneer(void* p);
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(void* self);
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3& v, void* actor);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 extern "C" void* _ZNK10dBgCh_Actr14GetFloorResultEv(void* self);
 extern "C" void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vector3* out);
 extern "C" int _ZN4cstd4fdivEii(int a, int b);
 extern "C" int _ZNK10dBgCh_Actr8IsOnWallEv(void* self);
 
 extern "C" void func_ov071_0211f148(char* a, char* w) {
-    dBgCh_Gnd rc;
     Vector3 pos;
     Vector3 normal;
     Vector3 wallnormal;
 
     dBgCh_Actr_UpdateDiscreteNoLava_veneer(w);
     if (_ZNK10dBgCh_Actr10IsOnGroundEv(w)) {
-        _ZN9dBgCh_GndC1Ev(&rc);
+        dBgCh_Gnd rc;
         {
             int p60 = *(int*)(a+0x60);
             int pz = *(int*)(a+0x64);
@@ -41,8 +35,8 @@ extern "C" void func_ov071_0211f148(char* a, char* w) {
             pos.y = py;
             pos.z = pz;
         }
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, a);
-        if (!_ZN9dBgCh_Gnd10DetectClsnEv(&rc) || rc.floor[(0x44-0x14)/4] < *(int*)(a+0x60) - 0x32000) {
+        rc.SetObjAndPos(pos, (dActor_c*)a);
+        if (!rc.DetectClsn() || rc.clsnY < *(int*)(a+0x60) - 0x32000) {
             *(int*)(a+0x98) = 0;
             *(int*)(a+0x5c) = *(int*)(a+0x68);
             *(int*)(a+0x60) = *(int*)(a+0x6c);
@@ -57,7 +51,6 @@ extern "C" void func_ov071_0211f148(char* a, char* w) {
                     normal.y) + 0x8000);
             }
         }
-        _ZN9dBgCh_GndD1Ev(&rc);
     }
     if (_ZNK10dBgCh_Actr8IsOnWallEv(w)) {
         void* wr = _ZNK10dBgCh_Actr13GetWallResultEv(w);

--- a/src/func_ov071_02121c6c.cpp
+++ b/src/func_ov071_02121c6c.cpp
@@ -1,24 +1,19 @@
 //cpp
-struct dBgCh_Gnd { char pad[0x44]; int hit; char pad2[0x8]; };
+#include "dBgCh_Gnd.h"
+
 extern "C" {
-extern void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* r);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* r, void* v, void* a);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* r);
 extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* a, void* sm, void* m, int f1, int f2, unsigned int j);
-extern void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* r);
 void func_ov071_02121c6c(char* c) {
-  dBgCh_Gnd rg;
   int f;
   *(int*)(c + 0x31c) = *(int*)(c + 0x5c) >> 3;
   *(int*)(c + 0x320) = *(int*)(c + 0x60) >> 3;
   *(int*)(c + 0x324) = *(int*)(c + 0x64) >> 3;
-  _ZN9dBgCh_GndC1Ev(&rg);
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, c + 0x5c, c);
-  if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0)
-    f = (*(int*)(c + 0x60) - rg.hit) + 0x1e000;
+  dBgCh_Gnd rg;
+  rg.SetObjAndPos(*(Vector3*)(c + 0x5c), (dActor_c*)c);
+  if (rg.DetectClsn() != 0)
+    f = (*(int*)(c + 0x60) - rg.clsnY) + 0x1e000;
   else
     f = 0x1f4000;
   _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0xd4, c + 0x2f8, 0x50000, f, 0xf);
-  _ZN9dBgCh_GndD1Ev(&rg);
 }
 }

--- a/src/func_ov072_02120f14.cpp
+++ b/src/func_ov072_02120f14.cpp
@@ -2,24 +2,17 @@
 // @symbol func_ov072_02120f14
 /* recovered: shared common types */
 #include "common.h"
-
-struct dActor_c;
-struct dBgCh_Gnd { char buf[0x54]; };
+#include "dBgCh_Gnd.h"
 
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(void *thiz);
-extern "C" void _ZN9dBgCh_GndC1Ev(struct dBgCh_Gnd *thiz);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct dBgCh_Gnd *thiz, const struct Vector3 *v, struct dActor_c *a);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(struct dBgCh_Gnd *thiz);
-extern "C" void _ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd *thiz);
 
 extern "C" int func_ov072_02120f14(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
-    struct dBgCh_Gnd rg;
     struct Vector3 v;
 
     if (_ZNK10dBgCh_Actr10IsOnGroundEv(c + 0x194)) {
-        _ZN9dBgCh_GndC1Ev(&rg);
+        dBgCh_Gnd rg;
         {
             int z = *(int *)(c + 0x64);
             int y = *(int *)(c + 0x60) + 0x1e000;
@@ -28,19 +21,18 @@ extern "C" int func_ov072_02120f14(void *thiz)
             v.y = y;
             v.z = z;
         }
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, (struct dActor_c *)c);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-            int d = *(int *)((char *)&rg + 0x44) - *(int *)(c + 0x60);
+        rg.SetObjAndPos(v, (dActor_c *)c);
+        if (rg.DetectClsn() != 0) {
+            int d = rg.clsnY - *(int *)(c + 0x60);
             if (d < 0) d = -d;
             if (d <= 0x1900) goto bail;
         }
         *(int *)(c + 0x5c) = *(int *)(c + 0x68);
         *(int *)(c + 0x60) = *(int *)(c + 0x6c);
         *(int *)(c + 0x64) = *(int *)(c + 0x70);
-        _ZN9dBgCh_GndD1Ev(&rg);
         return 1;
     bail:
-        _ZN9dBgCh_GndD1Ev(&rg);
+        ;
     }
     return 0;
 }

--- a/src/func_ov072_021210c4.cpp
+++ b/src/func_ov072_021210c4.cpp
@@ -2,19 +2,15 @@
 // @symbol func_ov072_021210c4
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
-struct dBgCh_Gnd { char buf[0x68 - 0x18]; };
 extern "C" {
 extern int _ZN6Player14IsFrontSlidingEv(void*);
 extern int _ZN6Player17LostGrabbedObjectEv(void*);
 extern void* _ZN8dActor_c11UpdateCarryER6PlayerRK7Vector3(void*, void*, void*);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
-extern void _ZN9dBgCh_GndC1Ev(struct dBgCh_Gnd *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct dBgCh_Gnd *self, const struct Vector3 *v, void *actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(struct dBgCh_Gnd *self);
 extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void *self, void *shadow, void *mtx, int fix, int t1, unsigned int t2);
-extern void _ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd *self);
 extern char data_ov072_02122d3c[];
 
 
@@ -26,7 +22,6 @@ void func_ov072_021210c4(void *self)
     char *c = (char*)self;
     int idx;
     void *res;
-    struct dBgCh_Gnd rg;
     struct Vector3 v;
     int r5;
     int r4;
@@ -60,10 +55,10 @@ void func_ov072_021210c4(void *self)
         v.y = *(int*)(c + 0x60);
         v.z = *(int*)(c + 0x64);
         v.y -= 0xa000;
-        _ZN9dBgCh_GndC1Ev(&rg);
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, 0);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg)) {
-            r5 = *(int*)(c + 0x60) - *(int*)((char*)&rg + 0x44);
+        dBgCh_Gnd rg;
+        rg.SetObjAndPos(v, 0);
+        if (rg.DetectClsn()) {
+            r5 = *(int*)(c + 0x60) - rg.clsnY;
             if (r5 < 0x1000) r5 = 0x1000;
             tmp = (long long)r5 * 0x180 + 0x800;
             r4 = r4 - (int)(tmp >> 12);
@@ -71,7 +66,6 @@ void func_ov072_021210c4(void *self)
             if (r4 > 0x5a000) r4 = 0x5a000;
             r5 = r5 + 0x28000;
         }
-        _ZN9dBgCh_GndD1Ev(&rg);
     }
 
     _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(

--- a/src/func_ov074_021223bc.cpp
+++ b/src/func_ov074_021223bc.cpp
@@ -3,7 +3,7 @@
 // @symbol func_ov074_021223bc
 /* recovered: shared common types */
 #include "common.h"
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50 - 0x14 - 0x30]; };
+#include "dBgCh_Gnd.h"
 #define AT(p,off) ((void*)(int)((char*)(p)+(off)))
 struct dBgCh_Actr;
 struct dCc_c;
@@ -16,14 +16,7 @@ extern void _ZN8dActor_c8PoofDustEv(void *self);
 extern void _ZN7fBase_c18MarkForDestructionEv(void *self);
 extern int _ZNK10dBgCh_Actr13JustHitGroundEv(void *self);
 extern void func_02012694(int a, void *b);
-extern void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd *self);
-extern void _ZN5dBgCh19StartDetectingWaterEv(dBgCh_Gnd *self);
-extern void _ZN5dBgCh19StartDetectingToxicEv(dBgCh_Gnd *self);
-extern void _ZN5dBgCh21StopDetectingOrdinaryEv(dBgCh_Gnd *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd *self, const Vector3 *v, void *actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd *self);
 extern int func_02037e20(int *p);
-extern void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd *self);
 extern void _ZN8dActor_c9UpdatePosEP5dCc_c(void *self, dCc_c *cc);
 extern void _ZN12dEnemyBase_c12UpdateWMClsnER10dBgCh_Actrj(void *self, dBgCh_Actr *wm, unsigned int j);
 extern void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
@@ -32,7 +25,6 @@ extern Matrix4x3 IDENTITY_MATRIX4X3;
 
 int func_ov074_021223bc(char *c)
 {
-    dBgCh_Gnd rg;
     Vector3 pos;
 
     if (*(u8 *)(c + 0x609) == 0) {
@@ -72,19 +64,18 @@ int func_ov074_021223bc(char *c)
         pos.z = zz;
     }
 
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN5dBgCh19StartDetectingWaterEv(&rg);
-    _ZN5dBgCh19StartDetectingToxicEv(&rg);
-    _ZN5dBgCh21StopDetectingOrdinaryEv(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &pos, c);
+    dBgCh_Gnd rg;
+    rg.StartDetectingWater();
+    rg.StartDetectingToxic();
+    rg.StopDetectingOrdinary();
+    rg.SetObjAndPos(pos, (dActor_c*)c);
 
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0
-        && func_02037e20(rg.floor) != 0
-        && rg.floor[(0x44 - 0x14) / 4] != (int)0x80000000
-        && *(int *)(c + 0x60) < rg.floor[(0x44 - 0x14) / 4]) {
+    if (rg.DetectClsn() != 0
+        && func_02037e20((int*)&rg.surface) != 0
+        && rg.clsnY != (int)0x80000000
+        && *(int *)(c + 0x60) < rg.clsnY) {
         _ZN8dActor_c8PoofDustEv(c);
         _ZN7fBase_c18MarkForDestructionEv(c);
-        _ZN9dBgCh_GndD1Ev(&rg);
         return 1;
     }
 
@@ -103,8 +94,6 @@ int func_ov074_021223bc(char *c)
 
     _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
         c, (ShadowModel *)(c + 0x274), (Matrix4x3 *)(c + 0x2ec), 0x8c000, 0x3e8000, 0xf);
-
-    _ZN9dBgCh_GndD1Ev(&rg);
 
     return 1;
 }

--- a/src/func_ov077_02123c6c.cpp
+++ b/src/func_ov077_02123c6c.cpp
@@ -4,22 +4,15 @@
 #include "decl_dBgCh_Actr.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 extern "C" {
 
-struct RG { char buf[0x54]; };
 extern int dBgCh_Actr_UpdateDiscreteNoLava_veneer(void* w);
 extern int _ZNK10dBgCh_Actr8IsOnWallEv(void* w);
 extern int _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* s, struct Vector3* v);
-extern int _ZN9dBgCh_GndC1Ev(struct RG* r);
-extern int _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct RG* r, struct Vector3* v, void* a);
-extern int _ZN5dBgCh19StartDetectingWaterEv(struct RG* r);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(struct RG* r);
-extern int _ZN5dBgCh18StopDetectingWaterEv(struct RG* r);
-extern int _ZN9dBgCh_GndD1Ev(struct RG* r);
 void func_ov077_02123c6c(char* c, void* w){
   struct Vector3 nrm;
   struct Vector3 pos;
-  struct RG rg;
   dBgCh_Actr_UpdateDiscreteNoLava_veneer(w);
   if (_ZNK10dBgCh_Actr8IsOnWallEv(w) != 0) {
     _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)_ZNK10dBgCh_Actr13GetWallResultEv(w) + 4, &nrm);
@@ -29,14 +22,13 @@ void func_ov077_02123c6c(char* c, void* w){
   pos.y = *(int*)(c+0x60);
   pos.z = *(int*)(c+0x64);
   pos.y += 0x64000;
-  _ZN9dBgCh_GndC1Ev(&rg);
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &pos, 0);
-  _ZN5dBgCh19StartDetectingWaterEv(&rg);
-  if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0) {
-    int yy = *(int*)((char*)&rg + 0x44) + 0x3c000;
+  dBgCh_Gnd rg;
+  rg.SetObjAndPos(pos, 0);
+  rg.StartDetectingWater();
+  if (rg.DetectClsn() != 0) {
+    int yy = rg.clsnY + 0x3c000;
     if (*(int*)(c+0x60) < yy) *(int*)(c+0x60) = yy;
   }
-  _ZN5dBgCh18StopDetectingWaterEv(&rg);
-  _ZN9dBgCh_GndD1Ev(&rg);
+  rg.StopDetectingWater();
 }
 }

--- a/src/func_ov077_02124c28.cpp
+++ b/src/func_ov077_02124c28.cpp
@@ -2,22 +2,9 @@
 // @symbol func_ov077_02124c28
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
-struct dActor_c;
-
-struct dBgCh_Gnd {
-    char pad0[0x14];
-    int m14[12];
-    int m44;
-    char pad48[0xc];
-};
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd*);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd*, const Vector3&, dActor_c*);
-extern "C" void _ZN5dBgCh19StartDetectingWaterEv(void*);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd*);
 extern "C" int SurfaceInfo_TestFlag0x20(int* p);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd*);
-extern "C" void _ZN5dBgCh18StopDetectingWaterEv(void*);
 
 extern "C" int func_ov077_02124c28(char* c)
 {
@@ -25,7 +12,6 @@ extern "C" int func_ov077_02124c28(char* c)
         dBgCh_Gnd rg;
         Vector3 pos;
         int r;
-        _ZN9dBgCh_GndC1Ev(&rg);
         {
             int y = *(int*)(c + 0x60);
             int z = *(int*)(c + 0x64);
@@ -35,19 +21,17 @@ extern "C" int func_ov077_02124c28(char* c)
             pos.y = y2;
             pos.z = z;
         }
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, pos, (dActor_c*)c);
-        _ZN5dBgCh19StartDetectingWaterEv(&rg);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) == 0) goto fail;
-        r = SurfaceInfo_TestFlag0x20(rg.m14);
+        rg.SetObjAndPos(pos, (dActor_c*)c);
+        rg.StartDetectingWater();
+        if (rg.DetectClsn() == 0) goto fail;
+        r = SurfaceInfo_TestFlag0x20((int*)&rg.surface);
         if (r != 0) {
-            *(int*)(c + 0x3dc) = rg.m44;
+            *(int*)(c + 0x3dc) = rg.clsnY;
         } else {
         fail:
-            _ZN9dBgCh_GndD1Ev(&rg);
             return 0;
         }
-        _ZN5dBgCh18StopDetectingWaterEv(&rg);
-        _ZN9dBgCh_GndD1Ev(&rg);
+        rg.StopDetectingWater();
     }
     return *(int*)(c + 0x60) - *(int*)(c + 0x3dc);
 }

--- a/src/func_ov077_02124d08.cpp
+++ b/src/func_ov077_02124d08.cpp
@@ -5,25 +5,19 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 typedef int Fix12;
 typedef short s16;
 
 struct dBgCh_Actr;
-struct dActor_c;
-struct dBgCh_Gnd { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 struct dBgPi;
 struct SurfaceInfo;
 
 extern "C" void dBgCh_Actr_UpdateDiscreteNoLava_veneer(void* p);
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(void* self);
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
-extern "C" void _ZN5dBgCh19StartDetectingToxicEv(void* self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3& v, void* actor);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
 extern "C" void _ZN8dActor_c8PoofDustEv(void* self);
 extern "C" void func_02012694(int a, void* b);
 extern "C" void _ZN7fBase_c18MarkForDestructionEv(void* self);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 extern "C" void* _ZNK10dBgCh_Actr14GetFloorResultEv(void* self);
 extern "C" void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vector3* out);
 extern "C" int _ZN4cstd4fdivEii(int a, int b);
@@ -31,14 +25,13 @@ extern "C" s16 func_02010844(void* unused, Vector3* v, s16 angle);
 extern "C" int _ZNK10dBgCh_Actr8IsOnWallEv(void* self);
 
 extern "C" void func_ov077_02124d08(char* a, char* w) {
-    dBgCh_Gnd rc;
     Vector3 pos;
     Vector3 normal;
     Vector3 wallnormal;
 
     dBgCh_Actr_UpdateDiscreteNoLava_veneer(w);
     if (_ZNK10dBgCh_Actr10IsOnGroundEv(w)) {
-        _ZN9dBgCh_GndC1Ev(&rc);
+        dBgCh_Gnd rc;
         {
             int p60 = *(int*)(a+0x60);
             int pz = *(int*)(a+0x64);
@@ -47,14 +40,13 @@ extern "C" void func_ov077_02124d08(char* a, char* w) {
             pos.y = py;
             pos.z = pz;
         }
-        _ZN5dBgCh19StartDetectingToxicEv(&rc);
-        _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, pos, a);
-        if (_ZN9dBgCh_Gnd10DetectClsnEv(&rc)) {
-            if (func_02037e20(rc.floor) != 0 && *(int*)(a+0x60) < rc.floor[(0x44-0x14)/4]) {
+        rc.StartDetectingToxic();
+        rc.SetObjAndPos(pos, (dActor_c*)a);
+        if (rc.DetectClsn()) {
+            if (func_02037e20((int*)&rc.surface) != 0 && *(int*)(a+0x60) < rc.clsnY) {
                 _ZN8dActor_c8PoofDustEv(a);
                 func_02012694(0xc4, a+0x74);
                 _ZN7fBase_c18MarkForDestructionEv(a);
-                _ZN9dBgCh_GndD1Ev(&rc);
                 return;
             }
             {
@@ -70,7 +62,6 @@ extern "C" void func_ov077_02124d08(char* a, char* w) {
             *(s16*)(a+0x8c) = func_02010844(a, &normal, *(s16*)(a+0x8e));
             *(s16*)(a+0x90) = func_02010844(a, &normal, (s16)(*(s16*)(a+0x8e) - 0x4000));
         }
-        _ZN9dBgCh_GndD1Ev(&rc);
     }
     if (_ZNK10dBgCh_Actr8IsOnWallEv(w)) {
         void* wr = _ZNK10dBgCh_Actr13GetWallResultEv(w);

--- a/src/func_ov080_02124c3c.cpp
+++ b/src/func_ov080_02124c3c.cpp
@@ -2,6 +2,7 @@
 // @symbol func_ov080_02124c3c
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 typedef short s16;
 typedef long long s64;
 
@@ -11,10 +12,6 @@ void Matrix4x3_ApplyInPlaceToTranslation(Mtx43* m, int x, int y, int z);
 void Vec3_LslInPlace(Vector3* v, int sh);
 void Matrix4x3_FromRotationXYZExt(void* m, int x, int y, int z);
 void Matrix4x3_FromRotationY(void* m, int angle);
-void _ZN9dBgCh_GndC1Ev(void* self);
-void _ZN9dBgCh_GndD1Ev(void* self);
-void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void* self, const Vector3* pos, void* actor);
-int _ZN9dBgCh_Gnd10DetectClsnEv(void* self);
 void _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
     void* self, void* sm, void* mtx, int r, int t5, int t6, unsigned int u);
 }
@@ -25,7 +22,6 @@ void func_ov080_02124c3c(char* c)
 {
     Vector3 t;
     Vector3 pos;
-    char rg[0x54];
     int flags = *(int*)(c + 0xb0);
     int gb = (flags & 0x40000) != 0;
     if (gb != false) return;
@@ -56,11 +52,11 @@ void func_ov080_02124c3c(char* c)
     pos.y = *(int*)(c + 0x60);
     pos.z = *(int*)(c + 0x64);
     pos.y = pos.y + 0x14000;
-    _ZN9dBgCh_GndC1Ev(rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, &pos, 0);
+    dBgCh_Gnd rg;
+    rg.SetObjAndPos(pos, 0);
     int h = pos.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(rg)) {
-        h = *(int*)(rg + 0x44);
+    if (rg.DetectClsn()) {
+        h = rg.clsnY;
     }
     Matrix4x3_FromRotationY(c + 0x33c, *(s16*)(c + 0x8e));
     *(int*)(c + 0x360) = *(int*)(c + 0x5c) >> 3;
@@ -74,5 +70,4 @@ void func_ov080_02124c3c(char* c)
         _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
             c, c + 0x124, c + 0x33c, 0x96000, 0x32000, result + 0x96000, 0xf);
     }
-    _ZN9dBgCh_GndD1Ev(rg);
 }

--- a/src/func_ov090_02131378.cpp
+++ b/src/func_ov090_02131378.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "dBgCh_Gnd.h"
+
 extern "C" {
-typedef struct { int x, y, z; } Vector3;
 typedef struct dActor_c dActor_c;
-struct dBgCh_Gnd { char buf[0x54]; };
 extern void func_ov090_02130f94(void* c);
-void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd* self);
 int Vec3_HorzDist(const Vector3* a, const Vector3* b);
-void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd* self, const Vector3* p, dActor_c* a);
-int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd* self);
-void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd* self);
 extern unsigned char data_0209f2d8;
 extern signed char data_0209f2f8;
 extern int data_0209f32c;
@@ -22,7 +18,6 @@ void func_ov090_02131378(char* c){
     }
   }
   dBgCh_Gnd rg;
-  _ZN9dBgCh_GndC1Ev(&rg);
   Vector3 v;
   int vz = *(int*)(c+0x64);
   int vy = *(int*)(c+0x60) + 0x32000;
@@ -31,9 +26,9 @@ void func_ov090_02131378(char* c){
   v.z = vz;
   *(unsigned char*)(c+0x39c) = 0;
   if (Vec3_HorzDist((Vector3*)(c+0x5c), (Vector3*)(c+0x68)) != 0) {
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, (dActor_c*)c);
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg) != 0)
-      *(int*)(c+0x3a8) = *(int*)(rg.buf + 0x44);
+    rg.SetObjAndPos(v, (dActor_c*)c);
+    if (rg.DetectClsn() != 0)
+      *(int*)(c+0x3a8) = rg.clsnY;
   }
   if (*(int*)(c+0x3a8) < data_0209f32c) {
     *(int*)(c+0x3ac) = data_0209f32c;
@@ -48,6 +43,5 @@ void func_ov090_02131378(char* c){
     *(int*)(c+0x60) = *(int*)(c+0x3ac);
     *(int*)(c+0xa8) = 0;
   }
-  _ZN9dBgCh_GndD1Ev(&rg);
 }
 }

--- a/src/func_ov090_02131648.cpp
+++ b/src/func_ov090_02131648.cpp
@@ -1,35 +1,21 @@
 //cpp
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-typedef unsigned int u32;
-
-struct Vector3 { int x, y, z; };
+#include "dBgCh_Lin.h"
 
 struct C; typedef int (C::*PMF)();
 struct C { char pad[0x420]; PMF *pp; };
-
-struct dBgCh_Lin {
-    char pad[0x78];
-};
 
 extern "C" {
 int RandomIntInternal(int *seed);
 int Vec3_Dist(const Vector3 *a, const Vector3 *b);
 void func_02012694(int a, void *p);
-void _ZN9dBgCh_LinC1Ev(dBgCh_Lin *self);
 void Matrix4x3_FromRotationY(void *m, s16 angle);
 void Matrix4x3_ApplyInPlaceToRotationX(void *m, s16 angX);
 void MulVec3Mat4x3(const Vector3 *v, const void *m, Vector3 *out);
-void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(dBgCh_Lin *self, const Vector3 *a, const Vector3 *b, void *actor);
-int _ZN9dBgCh_Lin10DetectClsnEv(dBgCh_Lin *self);
 s16 Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
 int _ZNK10dBgCh_Actr8IsOnWallEv(void *self);
 void _Z14ApproachLinearRsss(s16 *cur, s16 target, s16 step);
 int func_ov090_021314a0(void *c);
 int func_ov090_02131e00(C *c, PMF *p);
-void _ZN9dBgCh_LinD1Ev(dBgCh_Lin *self);
 }
 
 extern int data_0209e650;
@@ -44,7 +30,6 @@ extern "C" int func_ov090_02131648(C *c)
     u32 rnd;
     int selfY;
     Vector3 a, b, in, out;
-    dBgCh_Lin rc;
     int angleSet;
     s16 *p39a;
     int sh;
@@ -59,7 +44,7 @@ extern "C" int func_ov090_02131648(C *c)
     }
 
     angleSet = 0;
-    _ZN9dBgCh_LinC1Ev(&rc);
+    dBgCh_Lin line;
 
     a.x = 0; a.y = 0; a.z = 0;
     b.x = 0; b.y = 0; b.z = 0;
@@ -85,9 +70,9 @@ extern "C" int func_ov090_02131648(C *c)
     b.y = a.y + out.y;
     b.z = a.z + out.z;
 
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(&rc, &a, &b, c);
+    line.SetObjAndLine(a, b, (dActor_c*)c);
 
-    if (_ZN9dBgCh_Lin10DetectClsnEv(&rc) == 0) {
+    if (!line.DetectClsn()) {
         if (*(u8 *)(self + 0x3a0) == 0) {
             ha = Vec3_HorzAngle((Vector3 *)(self + 0x5c), (Vector3 *)(self + 0x374));
             sh = (rnd & 3) << 0xc;
@@ -175,6 +160,5 @@ extern "C" int func_ov090_02131648(C *c)
         func_ov090_02131e00(c, (PMF *)&data_ov090_02134504);
     }
 
-    _ZN9dBgCh_LinD1Ev(&rc);
     return 1;
 }

--- a/src/func_ov091_02133254.cpp
+++ b/src/func_ov091_02133254.cpp
@@ -2,6 +2,7 @@
 // @symbol func_ov091_02133254
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 #include "dBgW.h"
 #include "TextureSequence.h"
 struct SharedFilePtr;
@@ -20,18 +21,10 @@ extern "C" BTP_File *_ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePt
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, BTP_File *f, int a, int fix, unsigned int u);
 extern "C" int _ZN11ShadowModel10InitCuboidEv(void *self);
 
-
-struct dBgCh_Gnd { char buf[0x44]; int f44; char rest[8]; };
-extern "C" void _ZN9dBgCh_GndC1Ev(dBgCh_Gnd *self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(dBgCh_Gnd *self, Vector3 *v, void *a);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(dBgCh_Gnd *self);
-extern "C" void _ZN9dBgCh_GndD1Ev(dBgCh_Gnd *self);
-
 extern void *_ZN4dBgW16UpdatePosAndAngsERS_P8dActor_cR5dBgPiR7Vector3P10Vector3_16S8_;
 
 extern "C" int func_ov091_02133254(char *self)
 {
-    dBgCh_Gnd rg;
     Vector3 v;
     BMD_File *bmd;
     KCL_File *kcl;
@@ -74,19 +67,20 @@ extern "C" int func_ov091_02133254(char *self)
     v.y = *(int *)(self + 0x60);
     v.z = *(int *)(self + 0x64);
     v.y = v.y + 0x32000;
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, 0);
-    *(int *)(self + 0x394) = v.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg))
-        *(int *)(self + 0x394) = rg.f44;
+    {
+        dBgCh_Gnd rg;
+        rg.SetObjAndPos(v, 0);
+        *(int *)(self + 0x394) = v.y;
+        if (rg.DetectClsn())
+            *(int *)(self + 0x394) = rg.clsnY;
 
-    *(int *)(self + 0x390) = *(int *)(self + 0x60) + 0x190000;
-    *(int *)(self + 0x60) = *(int *)(self + 0x394);
-    *(unsigned char *)(self + 0x39e) = 0x28;
-    *(int *)(self + 0x9c) = -0x4000;
-    *(int *)(self + 0xa0) = -0x3c000;
-    *(int *)(self + 0x98) = 0xc000;
-    *(unsigned char *)(self + 0x39f) = 0;
-    _ZN9dBgCh_GndD1Ev(&rg);
+        *(int *)(self + 0x390) = *(int *)(self + 0x60) + 0x190000;
+        *(int *)(self + 0x60) = *(int *)(self + 0x394);
+        *(unsigned char *)(self + 0x39e) = 0x28;
+        *(int *)(self + 0x9c) = -0x4000;
+        *(int *)(self + 0xa0) = -0x3c000;
+        *(int *)(self + 0x98) = 0xc000;
+        *(unsigned char *)(self + 0x39f) = 0;
+    }
     return 1;
 }

--- a/src/func_ov098_021396a4.cpp
+++ b/src/func_ov098_021396a4.cpp
@@ -2,23 +2,18 @@
 // @symbol func_ov098_021396a4
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
-struct dBgCh_Gnd { char buf[0x68 - 0x18]; };
 extern "C" {
-extern void _ZN9dBgCh_GndC1Ev(struct dBgCh_Gnd *self);
-extern void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(struct dBgCh_Gnd *self, const struct Vector3 *v, void *actor);
-extern int _ZN9dBgCh_Gnd10DetectClsnEv(struct dBgCh_Gnd *self);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
     void *self, void *shadow, void *mtx, int fix, int t1, int t2, unsigned int n);
-extern void _ZN9dBgCh_GndD1Ev(struct dBgCh_Gnd *self);
 void func_ov098_021396a4(void *self);
 }
 
 void func_ov098_021396a4(void *self)
 {
     char *c = (char*)self;
-    struct dBgCh_Gnd rg;
     struct Vector3 v;
     int r5;
     int r4;
@@ -27,11 +22,11 @@ void func_ov098_021396a4(void *self)
     v.y = *(int*)(c + 0x60);
     v.z = *(int*)(c + 0x64);
     v.y -= 0xa000;
-    _ZN9dBgCh_GndC1Ev(&rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rg, &v, 0);
+    dBgCh_Gnd rg;
+    rg.SetObjAndPos(v, 0);
     *(int*)(c + 0x5ec) = v.y;
-    if (_ZN9dBgCh_Gnd10DetectClsnEv(&rg)) {
-        *(int*)(c + 0x5ec) = *(int*)((char*)&rg + 0x44);
+    if (rg.DetectClsn()) {
+        *(int*)(c + 0x5ec) = rg.clsnY;
     }
     r5 = *(int*)(c + 0x60) - *(int*)(c + 0x5ec);
     if (r5 <= 0x1000) r5 = 0x1000;
@@ -43,5 +38,4 @@ void func_ov098_021396a4(void *self)
     *(int*)(c + 0x55c) = *(int*)(c + 0x64) >> 3;
     _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
         c, c + 0x508, c + 0x530, r4, r5 + 0x28000, r4, 0xf);
-    _ZN9dBgCh_GndD1Ev(&rg);
 }

--- a/src/func_ov098_0213a794.cpp
+++ b/src/func_ov098_0213a794.cpp
@@ -3,6 +3,7 @@
 /* recovered: shared common types, declarations from a shared header */
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 extern "C" {
     extern void func_ov098_0213a8ec();
 }
@@ -13,16 +14,8 @@ extern "C" void _ZN10dBgActor_c19UpdateClsnPosAndRotEv(void* self);
 extern "C" void* _ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void* fp);
 extern "C" void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, void* f, void* m, int fx, short s, void* b);
 extern "C" void func_020393c4(int* p, int v);
-extern "C" void _ZN9dBgCh_GndC1Ev(void* self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void* self, void* pos, void* actor);
-extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(void* self);
-extern "C" void _ZN9dBgCh_GndD1Ev(void* self);
-
-
-struct RG { char b[0x4c]; };
 
 extern "C" int func_ov098_0213a794(char* self, char** fp){
-  RG rc;
   Vector3 v;
   int r2;
   int y;
@@ -36,23 +29,24 @@ extern "C" int func_ov098_0213a794(char* self, char** fp){
   v.y = y;
   v.z = *(int*)(self+0x64);
   v.y = y - 0x64000;
-  _ZN9dBgCh_GndC1Ev(&rc);
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&rc, &v, 0);
-  *(int*)(self+0x32c) = v.y;
-  if(_ZN9dBgCh_Gnd10DetectClsnEv(&rc)){
-    *(int*)(self+0x32c) = *(int*)((char*)&rc + 0x44);
+  {
+    dBgCh_Gnd rc;
+    rc.SetObjAndPos(v, 0);
+    *(int*)(self+0x32c) = v.y;
+    if(rc.DetectClsn()){
+      *(int*)(self+0x32c) = rc.clsnY;
+    }
+    *(int*)(self+0x9c) = -0x4000;
+    *(int*)(self+0xa0) = -0xc8000;
+    r2 = 1;
+    *(short*)(self+0x33a) = 4;
+    *(unsigned char*)(self+0x340) = r2;
+    *(int*)(self+0x320) = *(int*)(self+0x5c);
+    *(int*)(self+0x324) = *(int*)(self+0x60);
+    *(int*)(self+0x328) = *(int*)(self+0x64);
+    *(int*)(self+0x330) = 0;
+    if(*(unsigned short*)(self+0xc) != 0x53) r2 = 0;
+    if(r2 != 0) *(unsigned char*)(self+0x342) = 1;
   }
-  *(int*)(self+0x9c) = -0x4000;
-  *(int*)(self+0xa0) = -0xc8000;
-  r2 = 1;
-  *(short*)(self+0x33a) = 4;
-  *(unsigned char*)(self+0x340) = r2;
-  *(int*)(self+0x320) = *(int*)(self+0x5c);
-  *(int*)(self+0x324) = *(int*)(self+0x60);
-  *(int*)(self+0x328) = *(int*)(self+0x64);
-  *(int*)(self+0x330) = 0;
-  if(*(unsigned short*)(self+0xc) != 0x53) r2 = 0;
-  if(r2 != 0) *(unsigned char*)(self+0x342) = 1;
-  _ZN9dBgCh_GndD1Ev(&rc);
   return 1;
 }

--- a/src/func_ov100_02143370.cpp
+++ b/src/func_ov100_02143370.cpp
@@ -2,22 +2,16 @@
 // @symbol func_ov100_02143370
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Lin.h"
 extern "C" {
-
-extern void _ZN9dBgCh_LinC1Ev(void* self);
-extern void _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(void* self, void* a, void* b, void* act);
-extern int _ZN9dBgCh_Lin10DetectClsnEv(void* self);
-extern void _ZN9dBgCh_LinD1Ev(void* self);
 
 int func_ov100_02143370(char* c)
 {
-    char rl1[0x78];
-    char rl2[0x78];
     Vector3 va;
     Vector3 vb;
     int ya, yb;
-    _ZN9dBgCh_LinC1Ev(rl1);
-    _ZN9dBgCh_LinC1Ev(rl2);
+    dBgCh_Lin line1;
+    dBgCh_Lin line2;
     va.x = 0; va.y = 0; va.z = 0;
     vb.x = 0; vb.y = 0; vb.z = 0;
     va.x = *(int*)(c + 0x5c);
@@ -30,14 +24,10 @@ int func_ov100_02143370(char* c)
     vb.z = *(int*)(c + 0x64);
     va.y = ya + 0xa000;
     vb.y = yb - 0xb8000;
-    _ZN9dBgCh_Lin13SetObjAndLineERK7Vector3S2_P8dActor_c(rl1, &va, &vb, c);
-    if (_ZN9dBgCh_Lin10DetectClsnEv(rl1) != 0) {
-        _ZN9dBgCh_LinD1Ev(rl2);
-        _ZN9dBgCh_LinD1Ev(rl1);
+    line1.SetObjAndLine(va, vb, (dActor_c*)c);
+    if (line1.DetectClsn()) {
         return 1;
     }
-    _ZN9dBgCh_LinD1Ev(rl2);
-    _ZN9dBgCh_LinD1Ev(rl1);
     return 0;
 }
 }


### PR DESCRIPTION
## Summary

- replace raw dBgCh_Gnd and dBgCh_Lin stack buffers with real automatic C++ objects across 46 existing sources
- let mwccarm generate constructor and destructor calls on every control-flow exit
- use typed collision methods and fields while preserving the established terminal-floor candidate in func_02009e70

## Verification

- prepush_linkcheck: 45 checked, 45 VERIFIED, 0 warnings, 0 blocking; 1 documented NONMATCHING draft skipped
- full ROM: 11,082/11,082 reproducing, 106/106 modules exact
- check_src_tu_compiles: 88/88
- cpp_tu_compat: READY
- langmode ratchet: PASS
- port_refcheck: 405/405
- duplicate sources: none
- layout: clean
- attribution: 0 changed, 0 lost