### PR TITLE
tools: let a policy license a vague-linkage duplicate against the cartridge

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -421,7 +421,7 @@ def derive(raw, keep_symbol):
     return _apply(raw, p, keep_symbol), p
 
 
-def deadstrip_plan(raw, symbol_names):
+def deadstrip_plan(raw, symbol_names, expect=None):
     """Plan removal of exact, explicitly named compiler-only output sections.
 
     This is intentionally narrower than a linker dead-strip pass.  TU reconstruction
@@ -433,6 +433,16 @@ def deadstrip_plan(raw, symbol_names):
     * every named, non-mapping symbol in each removed section is requested too;
     * no relocation from a surviving content section references a requested symbol or
       an unnamed section symbol for a removed section.
+
+    ``expect`` extends this to the *duplicate* case: a vague-linkage body the compiler
+    re-emits in every TU that needs it, while the retail image keeps exactly one copy
+    at a configured address.  Such a symbol is NOT compiler-only -- it has a ROM home --
+    so discarding it is only sound when this object's copy is provably the same body.
+    ``{symbol: bytes}`` demands exactly that: ``STB_LOPROC`` binding and a section whose
+    content equals the cartridge's own bytes at the home address.  A caller that cannot
+    produce those bytes must not use this path.  If nothing else defines the symbol the
+    link fails loudly on an undefined reference, so this cannot silently drop a function
+    that has a retail address.
 
     There are no patterns and no binding-based guesses.  The caller must name every
     symbol, and any ambiguity is an error.  The returned plan has the same shape as
@@ -495,6 +505,20 @@ def deadstrip_plan(raw, symbol_names):
                                  f"{source.name} references compiler-only {label} at "
                                  f"0x{r['r_offset']:x}"}
 
+    for name, want in sorted((expect or {}).items()):
+        if name not in wanted:
+            return {"error": f"{name}: duplicate-body evidence for a symbol that was "
+                             f"not requested"}
+        sym = defined[name]
+        if sym["st_info"]["bind"] != "STB_LOPROC":
+            return {"error": f"{name}: duplicate deadstrip needs vague linkage, got "
+                             f"{sym['st_info']['bind']}"}
+        got = bytes(secs[sym["st_shndx"]].data())
+        if got != bytes(want):
+            return {"error": f"{name}: this object's body ({len(got)} bytes) is not the "
+                             f"cartridge's body at its configured home "
+                             f"({len(bytes(want))} bytes)"}
+
     drop = set(drop_content)
     drop.update(i for i, s in enumerate(secs)
                 if isinstance(s, RelocationSection) and s.header["sh_size"]
@@ -503,14 +527,14 @@ def deadstrip_plan(raw, symbol_names):
             "dead": sorted(wanted), "referenced": [], "error": None}
 
 
-def derive_deadstrip(raw, symbol_names):
+def derive_deadstrip(raw, symbol_names, expect=None):
     """Return an object with exact declared compiler-only sections discarded.
 
     ``None`` is returned instead of bytes when :func:`deadstrip_plan` refuses.  The
     input is never mutated.  This exists for scratch TU links; production one-function
     isolation continues to use :func:`derive` unchanged.
     """
-    p = deadstrip_plan(raw, symbol_names)
+    p = deadstrip_plan(raw, symbol_names, expect)
     if p.get("error"):
         return None, p
     return _apply(raw, p, None), p

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -322,9 +322,11 @@ def _isolate(obj, rel, syms, data_sink=None, compiler_only=None):
         if len(selected) == 1:
             plan = OI.isolate(obj, selected[0])
         else:
-            dead = (compiler_only or {}).get(rel.replace("\\", "/"), [])
+            pol = (compiler_only or {}).get(rel.replace("\\", "/")) or {}
+            dead = pol.get("deadstrip") or []
             if dead:
-                reduced, dead_plan = OI.derive_deadstrip(obj.read_bytes(), dead)
+                reduced, dead_plan = OI.derive_deadstrip(
+                    obj.read_bytes(), dead, pol.get("expect") or {})
                 if reduced is None:
                     return ("compiler-only deadstrip refused: "
                             + str(dead_plan.get("error")))
@@ -374,13 +376,94 @@ def enrolled_symbols():
             for rel, rows in grouped.items()}
 
 
+DISPOSITIONS = ("deadstrip", "deadstrip-duplicate")
+
+_SYM_SIZES = None
+_MOD_IMAGES = {}
+
+
+def _symbol_sizes():
+    """{(module, addr): size} for every sized function symbol in config/.
+
+    Built from the same ``symbols.txt`` files the delink reads, so the size that
+    proves a duplicate body is the size the ROM home is actually carved at.
+    """
+    global _SYM_SIZES
+    if _SYM_SIZES is None:
+        import enroll as E
+        out = {}
+        for path, module in RL.module_universe():
+            for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+                m = E.SYM_RE.match(line)
+                if m:
+                    key = (RL.normalize_module(module), int(m.group(4), 16))
+                    out[key] = int(m.group(3), 16)
+        _SYM_SIZES = out
+    return _SYM_SIZES
+
+
+def _rom_bytes(module, addr, size):
+    """The cartridge's own bytes, or None when the module image is unavailable."""
+    import modules as MOD
+    key = RL.normalize_module(module)
+    if key not in _MOD_IMAGES:
+        hit = next((m for m in MOD.modules()
+                    if RL.normalize_module(m["name"]) == key
+                    or (key == "arm9" and m["name"] == "main")), None)
+        _MOD_IMAGES[key] = (hit["bin"].read_bytes(), hit["base"]) if hit else None
+    img = _MOD_IMAGES[key]
+    if img is None:
+        return None
+    data, base = img
+    off = addr - base
+    return data[off:off + size] if 0 <= off else None
+
+
+def _duplicate_body(symbol, homes_for):
+    """The cartridge's own bytes for a vague-linkage symbol's single configured home.
+
+    Returns ``(bytes, None)`` or ``(None, reason)``.  Several homes means the name is
+    ambiguous and the evidence is refused rather than guessed at.
+    """
+    if len(homes_for) != 1:
+        return None, (f"{symbol} has {len(homes_for)} configured homes "
+                      f"{homes_for}; a duplicate body needs exactly one")
+    module, addr = homes_for[0]
+    size = _symbol_sizes().get((RL.normalize_module(module), addr))
+    if not size:
+        return None, f"{symbol}: no sized function symbol at {module}:0x{addr:08x}"
+    body = _rom_bytes(module, addr, size)
+    if body is None or len(body) != size:
+        return None, f"{symbol}: could not read {size} ROM bytes at {module}:0x{addr:08x}"
+    return body, None
+
+
 def compiler_only_policies(enrolled=None, manifest=None, homes=None):
     """Exact dead-strip allow-lists for promoted multi-function sources.
 
-    The manifest is evidence, not a wildcard: every row must name one homeless,
-    unlicensed function and explicitly request ``deadstrip`` with a reason.  Object
-    surgery remains objisolate's job; this preflight only proves the checked-in policy
-    cannot hide a function that has a retail address.
+    The manifest is evidence, not a wildcard: every row must name one unlicensed
+    function and explicitly request a disposition with a reason.  Object surgery
+    remains objisolate's job; this preflight only proves the checked-in policy cannot
+    hide a function that has a retail address.
+
+    Two dispositions, and the difference is the whole safety argument:
+
+    ``deadstrip``
+        The function is *homeless* -- mwcc emitted a body (a D2 variant, an inline
+        helper) that the retail link discarded and no configured symbol names.
+        Refused the moment it acquires a ROM home.
+
+    ``deadstrip-duplicate``
+        The function *must* have a ROM home, and the row must name it.  This is the
+        vague-linkage case: ``_ZN7Vector3D1Ev`` and friends are re-emitted by every TU
+        that destroys the type, while the cartridge keeps one copy and one enrolled
+        source owns it.  Licensing it here is sound only because the caller hands
+        objisolate the cartridge's bytes for that home and objisolate refuses unless
+        this object's copy is byte-identical vague-linkage output.  Discarding a
+        duplicate cannot lose the address: the owning source still supplies it, and if
+        it did not the link would fail on an undefined symbol rather than quietly
+        producing a hole.  This is what let a reconstructed TU be promoted at all --
+        before it, every TU holding a ``Vector3`` was stuck at text-verified.
     """
     data = TUM.load() if manifest is None else manifest
     active = None if enrolled is None else {
@@ -392,7 +475,11 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
         rows = entry.get("compiler_only_output") or []
         if not rows:
             continue
-        source = str(entry.get("source", "")).replace("\\", "/")
+        # A promoted entry is enrolled under promoted_source; keying on the
+        # src_tu path would let `active` filter the policy out and the build
+        # would then refuse the very object the policy was written for.
+        source = str(entry.get("promoted_source")
+                     or entry.get("source", "")).replace("\\", "/")
         if not source:
             errors.append(f"{entry.get('id', '<unknown>')}: compiler-only policy has no source")
             continue
@@ -402,7 +489,7 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
             errors.append(f"{source}: compiler-only policy is declared by multiple entries")
             continue
         licensed = {row.get("symbol") for row in entry.get("functions", [])}
-        wanted = []
+        wanted, expect = [], {}
         for i, row in enumerate(rows):
             if not isinstance(row, dict):
                 errors.append(f"{source}: compiler_only_output[{i}] is not an object")
@@ -411,19 +498,32 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
             if not symbol:
                 errors.append(f"{source}: compiler_only_output[{i}] has no symbol")
                 continue
-            if row.get("disposition") != "deadstrip":
-                errors.append(f"{source}: {symbol} disposition must be deadstrip")
+            disposition = row.get("disposition")
+            if disposition not in DISPOSITIONS:
+                errors.append(f"{source}: {symbol} disposition must be one of "
+                              f"{list(DISPOSITIONS)}")
             if not str(row.get("reason", "")).strip():
                 errors.append(f"{source}: {symbol} needs a non-empty reason")
             if symbol in licensed:
                 errors.append(f"{source}: {symbol} is licensed by the manifest")
-            if homes.get(symbol):
-                errors.append(f"{source}: {symbol} has configured ROM home(s) "
-                              f"{homes[symbol]}")
             if symbol in wanted:
                 errors.append(f"{source}: duplicate compiler-only symbol {symbol}")
+            if disposition == "deadstrip-duplicate":
+                if not homes.get(symbol):
+                    errors.append(f"{source}: {symbol} is declared a duplicate but has "
+                                  f"no configured ROM home")
+                else:
+                    body, why = _duplicate_body(symbol, homes[symbol])
+                    if why:
+                        errors.append(f"{source}: {why}")
+                    else:
+                        expect[symbol] = body
+            elif homes.get(symbol):
+                errors.append(f"{source}: {symbol} has configured ROM home(s) "
+                              f"{homes[symbol]}; declare it deadstrip-duplicate and "
+                              f"prove the body, or drop the policy")
             wanted.append(symbol)
-        out[source] = wanted
+        out[source] = {"deadstrip": wanted, "expect": expect}
     if errors:
         raise BuildError("compiler-only policy", 1, "\n".join(errors))
     return out

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -182,6 +182,42 @@ class Isolate(unittest.TestCase):
         self.assertIsNone(singular_plan["error"])
         self.assertIsNotNone(singular)
 
+    def test_duplicate_deadstrip_demands_the_cartridge_body(self):
+        """`expect` is what makes discarding a symbol WITH a ROM home sound.
+
+        The vague-linkage case -- types.h's empty ~Vector3, re-emitted by every TU
+        that destroys one -- is not compiler-only: the cartridge has a copy and an
+        enrolled source owns it. Licensing that here is only safe while this object's
+        copy is provably the same body, so a wrong body must refuse rather than warn.
+        """
+        # An INLINE destructor is what makes the variant vague-linkage, which is
+        # exactly the shape this path exists for: every TU that destroys the type
+        # emits its own copy.
+        obj = self.build("struct V { int v; ~V(){} };\n"
+                         "void g(){ V v; v.v = 1; }\n")
+        raw = obj.read_bytes()
+        real = self._section_bytes(raw, "_ZN1VD1Ev")
+
+        out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"], {"_ZN1VD1Ev": real})
+        self.assertIsNone(plan["error"])
+        self.assertIsNotNone(out)
+
+        _out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"],
+                                         {"_ZN1VD1Ev": bytes(len(real))})
+        self.assertIn("not the cartridge's body", plan["error"])
+
+        _out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"], {"_ZN1VD2Ev": real})
+        self.assertIn("was not requested", plan["error"])
+
+    def _section_bytes(self, raw, name):
+        import io
+        from elftools.elf.elffile import ELFFile
+        elf = ELFFile(io.BytesIO(raw))
+        secs = list(elf.iter_sections())
+        sym = next(s for s in elf.get_section_by_name(".symtab").iter_symbols()
+                   if s.name == name and isinstance(s["st_shndx"], int))
+        return bytes(secs[sym["st_shndx"]].data())
+
     def test_exact_deadstrip_removes_unreferenced_compiler_only_d2(self):
         """A whole-TU scratch link may model the retail link's discarded D2.
 

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -125,7 +125,7 @@ class RomBuildEnrollment(unittest.TestCase):
     def test_multi_source_applies_exact_compiler_only_deadstrip_first(self):
         obj = self.repo / "Pair.o"
         obj.write_bytes(b"raw object")
-        policy = {"src/Pair.cpp": ["_ZN4PairC2Ev"]}
+        policy = {"src/Pair.cpp": {"deadstrip": ["_ZN4PairC2Ev"], "expect": {}}}
         with mock.patch.object(
                 RB.OI, "derive_deadstrip",
                 return_value=(b"reduced object", {"error": None})) as deadstrip, \
@@ -134,7 +134,7 @@ class RomBuildEnrollment(unittest.TestCase):
             self.assertIsNone(RB._isolate(
                 obj, "src/Pair.cpp", {"src/Pair.cpp": ["First", "Second"]},
                 compiler_only=policy))
-        deadstrip.assert_called_once_with(b"raw object", ["_ZN4PairC2Ev"])
+        deadstrip.assert_called_once_with(b"raw object", ["_ZN4PairC2Ev"], {})
         many.assert_called_once_with(obj, ["First", "Second"])
         self.assertEqual(obj.read_bytes(), b"reduced object")
 
@@ -165,7 +165,65 @@ class RomBuildEnrollment(unittest.TestCase):
         }]}
         self.assertEqual(
             RB.compiler_only_policies(manifest=manifest, homes={}),
-            {"src/Pair.cpp": ["_ZN4PairC2Ev"]})
+            {"src/Pair.cpp": {"deadstrip": ["_ZN4PairC2Ev"], "expect": {}}})
+
+    def test_duplicate_disposition_requires_a_rom_home(self):
+        """The two dispositions have opposite preconditions, deliberately."""
+        manifest = {"entries": [{
+            "id": "arm9/Pair",
+            "source": "src/Pair.cpp",
+            "functions": [{"symbol": "First"}, {"symbol": "Second"}],
+            "compiler_only_output": [{
+                "symbol": "_ZN7Vector3D1Ev", "disposition": "deadstrip-duplicate",
+                "reason": "vague-linkage copy of types.h's empty ~Vector3"
+            }]
+        }]}
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(manifest=manifest, homes={})
+        self.assertIn("no configured ROM home", raised.exception.output)
+
+    def test_duplicate_disposition_refuses_an_ambiguous_home(self):
+        """Two homes means the name is ambiguous; the body proof would be a guess."""
+        manifest = {"entries": [{
+            "id": "arm9/Pair",
+            "source": "src/Pair.cpp",
+            "functions": [{"symbol": "First"}],
+            "compiler_only_output": [{
+                "symbol": "_ZN7Vector3D1Ev", "disposition": "deadstrip-duplicate",
+                "reason": "vague-linkage copy"
+            }]
+        }]}
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(manifest=manifest, homes={
+                "_ZN7Vector3D1Ev": [("arm9", 0x02000008), ("ov002", 0x020f0000)]})
+        self.assertIn("2 configured homes", raised.exception.output)
+
+    def test_an_unknown_disposition_is_refused(self):
+        manifest = {"entries": [{
+            "id": "arm9/Pair", "source": "src/Pair.cpp",
+            "functions": [{"symbol": "First"}],
+            "compiler_only_output": [{"symbol": "X", "disposition": "keep",
+                                      "reason": "why not"}]}]}
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(manifest=manifest, homes={})
+        self.assertIn("disposition must be one of", raised.exception.output)
+
+    def test_policy_keys_on_the_promoted_path_not_the_src_tu_path(self):
+        """A promoted entry is enrolled under promoted_source.
+
+        Keying on `source` would let the enrolled-set filter drop the policy and the
+        build would then refuse the very object it was written for.
+        """
+        manifest = {"entries": [{
+            "id": "ov100/TU",
+            "source": "src_tu/actors/TU.cpp",
+            "promoted_source": "src/actors/TU.cpp",
+            "functions": [{"symbol": "First"}],
+            "compiler_only_output": [{"symbol": "_ZN1PD2Ev", "disposition": "deadstrip",
+                                      "reason": "homeless variant"}]}]}
+        self.assertEqual(
+            RB.compiler_only_policies({"src/actors/TU.cpp"}, manifest=manifest, homes={}),
+            {"src/actors/TU.cpp": {"deadstrip": ["_ZN1PD2Ev"], "expect": {}}})
 
     def test_compiler_only_policy_ignores_unenrolled_shadow_manifests(self):
         manifest = {"entries": [{

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2005,7 +2005,7 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
               if s["type"] == "STT_FUNC" and not s["name"].startswith("$")
               and s["name"] not in licensed}
     policy = entry.get("compiler_only_output", [])
-    reasons, wanted = [], []
+    reasons, wanted, duplicates = [], [], set()
     if policy is None:
         policy = []
     if not isinstance(policy, list):
@@ -2018,10 +2018,17 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
         if not sym:
             reasons.append(f"compiler_only_output[{i}] has no symbol")
             continue
-        if row.get("disposition") != "deadstrip":
+        if row.get("disposition") not in ("deadstrip", "deadstrip-duplicate"):
             reasons.append(f"compiler_only_output {sym} has unsupported disposition "
-                           f"{row.get('disposition')!r}; only exact deadstrip is implemented")
+                           f"{row.get('disposition')!r}; expected deadstrip or "
+                           f"deadstrip-duplicate")
             continue
+        if row.get("disposition") == "deadstrip-duplicate":
+            # The vague-linkage case: the symbol MUST have a ROM home that another
+            # source owns. rombuild proves the body against the cartridge before it
+            # discards anything; this scratch path only links, so it accepts the
+            # declaration and leaves the proof to the production build.
+            duplicates.add(sym)
         if not str(row.get("reason", "")).strip():
             reasons.append(f"compiler_only_output {sym} needs a non-empty reason")
         if sym in licensed:
@@ -2037,7 +2044,11 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
         reasons.append(f"unlicensed function {sym} has no compiler_only_output policy")
     homes = all_symbol_homes() if homes is None else homes
     for sym in wanted:
-        if homes.get(sym):
+        if sym in duplicates:
+            if not homes.get(sym):
+                reasons.append(f"compiler_only_output {sym} is declared a duplicate "
+                               f"but has no configured ROM home")
+        elif homes.get(sym):
             reasons.append(f"compiler_only_output {sym} has configured ROM home(s) "
                            f"{homes[sym]}; it is not compiler-only")
     if reasons:


### PR DESCRIPTION
Splits the tool half out of #1878 so it can actually be validated. #1878 bundles this
`rombuild`/`objisolate` change with the `daObjPathLift_c` manifest rows that use it, and
the PR validator restores all of `tools/` from the base commit — so it runs *main's*
`rombuild.py`, which only knows `deadstrip`, against the new manifest and fails:

```
src/actors/daObjPathLift_c.cpp: _ZN7Vector3D1Ev disposition must be deadstrip
```

That PR can never go green on its own. This one carries no manifest change, so it can.

## The problem this unblocks

`include/types.h` declares `~Vector3() {}` inline in-class — deliberately; the ROM's
`__destroy_arr` over arrays of `Vector3` proves the element type has a destructor.
Consequence: **every TU that so much as holds a `Vector3` local emits a vague-linkage
`_ZN7Vector3D1Ev`** (4 bytes, `bx lr`, `STB_LOPROC`).

It has a real ROM home at `arm9:0x020072c0`, owned by `src/_ZN7Vector3D1Ev.cpp`. The old
policy therefore refused it — `compiler_only_output` rejects any symbol with a configured
home (correctly: it is not compiler-only), and `externalized_output` takes only
`_ZTI`/`_ZTS` data. Four reconstructed TUs stopped at TEXT-VERIFIED on those four bytes
(`ArrowSignRight`, `daObjPathLift_c`, `arm9/Actor`, `ov002/LevelObjects` all say so in
their manifest notes). In production it surfaces as:

```
isolate: unlicensed content in text-only multi-symbol object:
section[21] .text size 0x4 defines ['_ZN7Vector3D1Ev']
```

## What changes

A second disposition whose precondition is the **opposite** of `deadstrip`'s:

```json
{"symbol": "_ZN7Vector3D1Ev", "disposition": "deadstrip-duplicate",
 "reason": "vague-linkage duplicate; arm9:0x020072c0 owns the retail copy"}
```

- `deadstrip` still means **homeless-only** — refused the moment a symbol acquires a ROM
  home. Unchanged.
- `deadstrip-duplicate` **requires** a ROM home and requires it to be unambiguous (exactly
  one configured home, or the row is refused rather than guessed at). `rombuild` reads the
  module image at that address, sizes it from the same `symbols.txt` the delink reads, and
  hands the cartridge's own bytes to `objisolate`, which refuses unless this object's copy
  is `STB_LOPROC` **and** byte-identical.

Dropping a duplicate cannot lose the address: the owning source still supplies it, and if
it did not, the link fails on an undefined symbol rather than quietly leaving a hole. That
loudness is the rest of the safety argument. `deadstrip_plan` already refused when a
surviving section referenced the symbol; that check is untouched.

Also fixed here, because it is the same code path: `compiler_only_policies` keyed the
policy on `source`, but a promoted entry is enrolled under `promoted_source`. This is
forward-looking rather than a live bug -- of the 21 manifest entries carrying a
`compiler_only_output` today, exactly one (`ActorBase_SceneNode`) is enrolled, and its
`source` and `promoted_source` are the same path, so the old keying happened to work. The
other 20 are unenrolled `src_tu/` shadows that the `active` filter drops either way. The
fix matters the moment a TU is promoted while its manifest still names the `src_tu` path
-- the shape of every entry in the rest of this chain -- where the policy would otherwise
be filtered out and the build would refuse the very object it was written for.

## Test plan

- [x] `python -m pytest tools/test_rombuild.py tools/test_objisolate.py -q` → 52 passed,
      including five new cases: the cartridge-body demand, the required ROM home, the
      ambiguous-home refusal, the unknown-disposition refusal, and the promoted-path keying.
- [x] `python tools/rombuild.py -j 16` → **106/106 exact**, 100.000000% of compared bytes; 11,082 source-built functions, 11,082 reproducing, 0 mismatching -- byte-identical to main, as expected for a change that only widens what a manifest row may declare.
- [x] `python tools/port_refcheck.py` → 405 checked, all references resolve
- [x] `python tools/prepush_attribution.py --base origin/main --head HEAD` → 11,388 tracked, 0 changed, 0 lost

No `src/`, `config/` or `include/` file changes, so no byte can move: this PR only widens
what a future manifest row is allowed to declare.

Follow-up: the `daObjPathLift_c` promotion half of #1878 rebases onto this and becomes a
config+src-only PR the validator can judge on its merits. #1880 → #1882 → #1884 → #1914
then restack behind it.
