### PR TITLE
Restamp LINKED off the 0.2.15 release build: 8028 of 11312 (71.0%)

### DIFF
--- a/config/port_linkage.json
+++ b/config/port_linkage.json
@@ -28,11 +28,11 @@
     "Enrolling free TUs does nothing, because the release build dead-strips whatever the",
     "linked closure never references."
   ],
-  "linkedTus": 7718,
-  "matchedTus": 11307,
-  "measuredAt": "2026-08-27",
+  "linkedTus": 8028,
+  "matchedTus": 11312,
+  "measuredAt": "2026-08-29",
   "branch": "port-mount-noseat-cluster",
-  "commit": "b8df12b7d",
+  "commit": "f77f01169",
   "stale": false,
-  "basis": "single lane cons at its pushed tip b8df12b7d (the 0.2.14 release tip), measured against the tip's own gate build walk_window.map (tree clean, battery ALL GREEN twice on 2026-08-27, the run that shipped 0.2.14). +1887 over the 5831 stamp, from the mg11-mg15 waves landing on this lane: all 30 minigame scenes seated with the ov004/ov006 framework, the minigame menu scene, the trampoline chain, the title-screen mounts and touch feed, and the savestate guard-class closure. The replacement queue now reads 675 symbols across 243 host objects: 301 documented host-ABI exceptions, 240 faces, 134 SHADOWS; the shadows remain the replacement backlog and are not counted as linked."
+  "basis": "single lane cons at its pushed tip f77f01169 (the 0.2.15 release tip), measured against the tip's own gate build walk_window.map (tree clean, battery ALL GREEN twice on 2026-08-29, the run that shipped 0.2.15). +310 over the 7718 stamp: the title campaign (menus, file select, doodle canvas), the scene-request carrier, the opening cutscene chain with the intro dispatch, VS mode (ov075 seated as scene 6 with four arenas mounted), the MP conductor and sync batches, and the Rec Room minigame entry. The replacement queue now reads 730 rows across 257 host objects: 301 documented host-ABI exceptions, 243 faces, 170 shadows plus 15 MSVC-name shadows and 1 MSVC-name exception; the shadows remain the replacement backlog and are not counted as linked."
 }


### PR DESCRIPTION
Refreshes config/port_linkage.json off the 0.2.15 release cut (cons f77f01169, battery ALL GREEN twice, the run that shipped). linkedTus 7718 -> 8028, matchedTus 11307 -> 11312, provenance fields moved together per the file's own rule. Basis text updated for the title/cutscene/VS/MP waves and the current replacement-queue split (301 exceptions / 243 faces / 170+15 shadows).