### PR TITLE
Use canonical collision-query classes in C++ consumers

### DIFF
--- a/src/_ZN10dBgActor_c20UpdateKillByMegaCharEsss5Fix12IiE.cpp
+++ b/src/_ZN10dBgActor_c20UpdateKillByMegaCharEsss5Fix12IiE.cpp
@@ -1,6 +1,7 @@
 //cpp
+#include "dBgCh_Lin.h"
+
 template<class T> struct Fix12 { T v; };
-struct Vector3 { int x, y, z; };
 struct Matrix4x3 { int m[12]; };
 struct dCc_c;
 
@@ -15,14 +16,6 @@ extern void Vec3_Add(Vector3* out, Vector3* a, Vector3* b);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void func_ov002_020ee5d0(unsigned char* self, int arg);
 }
-
-struct dBgCh_Lin {
-    dBgCh_Lin();
-    ~dBgCh_Lin();
-    void SetObjAndLine(Vector3 const& a, Vector3 const& b, dActor_c* c);
-    int DetectClsn();
-    char buf[0x78];
-};
 
 /* Only slot 31 (vtable offset 0x7c) is used; the preceding slots are placeholders. */
 struct PlatformVT {

--- a/src/_ZN16daObjCtMecha05_c13InitResourcesEv.cpp
+++ b/src/_ZN16daObjCtMecha05_c13InitResourcesEv.cpp
@@ -5,6 +5,7 @@
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
 #include "daObjCtMecha05_c.h"
+#include "dBgCh_Gnd.h"
 
 /* daObjCtMecha05_c::InitResources - recovered from vtable slot identity.
  *
@@ -62,16 +63,6 @@ struct BMD_File; struct KCL_File; struct dActor_c; struct Vector3; struct Matrix
 struct CLPS_Block; struct SharedFilePtr;
 extern "C" unsigned char data_0209f2c0;
 extern "C" int data_ov035_02112258;
-struct dBgCh_Gnd {
-    int pad[0x11];
-    int result;       // offset 0x44
-    int pad2[3];      // pad to 0x54 total
-    dBgCh_Gnd();
-    void SetObjAndPos(const Vector3 &v, dActor_c *a);
-    int DetectClsn();
-    ~dBgCh_Gnd();
-};
-
 struct V3 { int x, y, z; };
 
 int daObjCtMecha05_c::InitResources()
@@ -105,6 +96,6 @@ int daObjCtMecha05_c::InitResources()
     rg.SetObjAndPos(*(Vector3*)&v, (dActor_c*)0);
     *(int*)(self + 0x338) = v.y;
     if (rg.DetectClsn() != 0)
-        *(int*)(self + 0x338) = rg.result;
+        *(int*)(self + 0x338) = rg.clsnY;
     return 1;
 }

--- a/src/_ZN8Particle17CheckLavaCallback14SpawnParticlesERNS_6SystemE.cpp
+++ b/src/_ZN8Particle17CheckLavaCallback14SpawnParticlesERNS_6SystemE.cpp
@@ -1,16 +1,8 @@
 //cpp
 #include "dPa_c.h"
+#include "dBgCh_Gnd.h"
 
 struct dActor_c;
-
-struct dBgCh_Gnd {
-    char pad0[0x14];
-    unsigned int sub[(0x50 - 0x14) / 4];
-    dBgCh_Gnd();
-    ~dBgCh_Gnd();
-    void SetObjAndPos(const Vector3 &pos, dActor_c *obj);
-    int DetectClsn();
-};
 
 struct Node {
     Node *next;
@@ -52,11 +44,11 @@ void CheckLavaCallback::SpawnParticles(System &sys)
         rg.SetObjAndPos(v, 0);
         if (rg.DetectClsn() == 0)
             goto Lac;
-        if (func_02037e38(rg.sub) != 1) {
+        if (func_02037e38((u32*)&rg.surface) != 1) {
         Lac:
             n->f2e = n->f2c;
         } else {
-            n->f18 = ((int)rg.sub[12] + 0x7000 >> 3) - n->fc;
+            n->f18 = (rg.clsnY + 0x7000 >> 3) - n->fc;
         }
     }
 }

--- a/src/_ZN8SignPost13InitResourcesEv.cpp
+++ b/src/_ZN8SignPost13InitResourcesEv.cpp
@@ -4,6 +4,7 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SignPost.h"
+#include "dBgCh_Gnd.h"
 /* Model::LoadFile and dBgW_Kc::LoadFile by their real ROM symbols, carried
    forward from #1554. decl_common.h's ModelLoadFile / MeshColliderLoadFile are
    phantoms -- names no module defines -- and match.py compares relocated words as
@@ -30,10 +31,8 @@ extern "C" void *_ZN7dBgW_Kc8LoadFileER13SharedFilePtr(void *);
                            match.py compares relocated words as wildcards, so
                            nothing caught it.
 
-   The remaining shadows -- ShadowModel, dCcAc_c, dBgCh_Actr,
-   dBgCh_Gnd -- are untouched: dBgActor_c.h does not pull those headers in, so
-   they still compile, and dCcAc_c::Init and dBgCh_Actr::Init have
-   the same Fix12<int> problem with no collision forcing the issue yet. */
+   The remaining ABI-only calls are dCcAc_c::Init and dBgCh_Actr::Init; they
+   have the same Fix12<int> problem with no collision forcing the issue yet. */
 struct BMD_File; struct KCL_File; struct dActor_c; struct Vector3; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr; struct Vector3_16;
 extern "C" void _ZN10dBgW_KcMbg7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
@@ -44,15 +43,6 @@ extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(
     void *self, dActor_c *a, s32 radius, s32 height, Vector3_16 *v, Vector3_16 *v2);
 /* dBgCh_Actr is the real class now, through this actor's header, and it
    declares StartDetectingWater itself. */
-struct dBgCh_Gnd {
-    int pad[0x11];
-    int result;       // offset 0x44
-    int pad2[2];      // pad to 0x50 total
-    dBgCh_Gnd();
-    void SetObjAndPos(const Vector3 &v, dActor_c *a);
-    int DetectClsn();
-    ~dBgCh_Gnd();
-};
 extern "C" CLPS_Block data_ov002_0210d714;
 
 struct V3 { int x, y, z; };
@@ -71,7 +61,7 @@ int SignPost::InitResources()
     dBgCh_Gnd rg;
     rg.SetObjAndPos(*(Vector3*)&v, (dActor_c*)0);
     if (rg.DetectClsn() != 0)
-        mPosY = rg.result;
+        mPosY = rg.clsnY;
 
     UpdateModelPosAndRotY();
     UpdateClsnPosAndRot();

--- a/src/_ZN9dBgCh_Gnd10DetectClsnEv.cpp
+++ b/src/_ZN9dBgCh_Gnd10DetectClsnEv.cpp
@@ -1,4 +1,6 @@
 //cpp
+#include "dBgCh_Gnd.h"
+
 struct Vec3 { int x, y, z; };
 struct ClsnObj { char pad[0x5c]; int vec[3]; char pad2[0x48]; int flags; int hb4; int hb8; };
 struct ClsnActor { virtual int v0(); virtual int v1(); virtual int v2(); virtual int v3(); virtual int v4(); virtual int v5(); virtual int v6(void*); };
@@ -11,7 +13,6 @@ extern "C" int func_02035354(void*, ClsnObj*);
 extern "C" void func_02037fec(char*, int, int, int, ClsnActor*);
 extern "C" int Vec3_HorzDist(Vec3*, Vec3*);
 extern "C" ClsnActor* data_020a0c80[];
-class dBgCh_Gnd { public: char pad[0x38]; Vec3 f38; int DetectClsn(); };
 
 int dBgCh_Gnd::DetectClsn()
 {
@@ -43,7 +44,7 @@ int dBgCh_Gnd::DetectClsn()
             } else {
                 pos.y = pos.y + func_0203938c(obj);
             }
-            Vec3* selfpos = (Vec3*)((long long)(int)&this->f38);
+            Vec3* selfpos = (Vec3*)((long long)(int)&this->pos);
             if (selfpos->y < pos.y - thr) continue;
             if (Vec3_HorzDist(selfpos, &pos) > thr) continue;
         }

--- a/src/_ZN9dBgCh_Lin10DetectClsnEv.cpp
+++ b/src/_ZN9dBgCh_Lin10DetectClsnEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "dBgCh_Lin.h"
 
 extern "C" {
 int func_020393b4(void *p);
@@ -35,14 +36,9 @@ struct Info {
     int pB8;
 };
 
-class dBgCh_Lin {
-public:
-    int DetectClsn();
-};
-
-int dBgCh_Lin::DetectClsn()
+bool dBgCh_Lin::DetectClsn()
 {
-    int result = 0;
+    bool result = false;
     int i;
     C *o;
     Info *info;
@@ -56,12 +52,12 @@ int dBgCh_Lin::DetectClsn()
             int mask = ((C *)e)->v7(this);
             if (mask != 0) {
                 func_02037fec((char *)this + 0x10, 0, func_020393ac(e), func_020393b4(e), e);
-                result = 1;
+                result = true;
             }
         }
     }
 
-    char *p64 = (char *)this + 0x64;
+    char *p64 = (char *)&mBoundSphere;
     base = p64 + 4;
     threshold = *(int *)(p64 + 0x10);
     for (i = 1; i < 0x18; i++) {
@@ -94,7 +90,7 @@ int dBgCh_Lin::DetectClsn()
             int mask = o->v7(this);
             if (mask != 0) {
                 func_02037fec((char *)this + 0x10, i, func_020393ac(o), func_020393b4(o), o);
-                result = 1;
+                result = true;
             }
         }
     }

--- a/src/actors/BooCage/_ZN7BooCage8BehaviorEv.cpp
+++ b/src/actors/BooCage/_ZN7BooCage8BehaviorEv.cpp
@@ -1,11 +1,6 @@
 //cpp
-struct Vector3 { int x, y, z; };
-typedef int Fix12i;
+#include "dBgCh_Actr.h"
 
-struct dBgCh_Actr {
-    bool JustHitGround() const;
-    bool IsOnGround() const;
-};
 struct dCc_c;
 struct dActor_c {
     static dActor_c* FindWithID(unsigned int id);

--- a/src/func_020371fc.cpp
+++ b/src/func_020371fc.cpp
@@ -2,20 +2,9 @@
 // @symbol func_020371fc
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
 struct dActor_c;
-struct dBgPi { char data[0x34]; };
-
-struct dBgCh_Gnd {
-    char pad0[0x10];
-    dBgPi clsn;   /* 0x10 */
-    int field44;       /* 0x44 */
-    char pad48[0x50 - 0x48];
-    dBgCh_Gnd();
-    ~dBgCh_Gnd();
-    void SetObjAndPos(const Vector3& pos, dActor_c* a);
-    int DetectClsn();
-};
 
 struct dBgCh_Actr { void SetGroundFlag(); };
 
@@ -39,12 +28,12 @@ void func_020371fc(char* self)
         pos.z = objpos->z;
         rg.SetObjAndPos(pos, *(dActor_c**)(self + 0x14));
         if (rg.DetectClsn() != 0) {
-            int cy = rg.field44;
+            int cy = rg.clsnY;
             int diff = objpos->y - cy;
             if (diff > 0 && diff < (*(int*)(self + 0x18) << 1)) {
                 objpos->y = cy;
                 *(unsigned char*)(((int)self + 0x90)) |= 4;
-                _ZN5dBgPiaSERKS_((dBgPi*)(self + 0x94), &rg.clsn);
+                _ZN5dBgPiaSERKS_((dBgPi*)(self + 0x94), &rg);
                 ((dBgCh_Actr*)self)->SetGroundFlag();
             }
         }

--- a/src/func_020371fc.cpp
+++ b/src/func_020371fc.cpp
@@ -2,11 +2,10 @@
 // @symbol func_020371fc
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Actr.h"
 #include "dBgCh_Gnd.h"
 
 struct dActor_c;
-
-struct dBgCh_Actr { void SetGroundFlag(); };
 
 extern "C" bool _ZN6Player7IsInAirEv(void* p);
 extern "C" void _ZN5dBgPiaSERKS_(dBgPi* d, const dBgPi* s);

--- a/src/func_ov002_020aefb8.cpp
+++ b/src/func_ov002_020aefb8.cpp
@@ -1,10 +1,7 @@
 //cpp
+#include "dBgCh_Actr.h"
+
 struct dCc_c;
-struct dBgCh_Actr {
-    int IsOnGround() const;
-    int JustHitGround() const;
-    int IsOnWall() const;
-};
 struct dActor_c {
     void UpdatePosWithHorzSpeedAndAng();
     void UpdatePosWithOnlySpeed(dCc_c*);

--- a/src/func_ov002_020b5ab4.cpp
+++ b/src/func_ov002_020b5ab4.cpp
@@ -2,29 +2,9 @@
 // @symbol func_ov002_020b5ab4
 /* recovered: shared common types */
 #include "common.h"
-typedef int s32;
-typedef signed char s8;
+#include "dBgCh_Gnd.h"
 
 struct dActor_c;
-
-struct dBgCh_Gnd {
-    char pad0[0x14];
-    int field14;     /* 0x14 */
-    char pad18[0x44 - 0x18];
-    int field44;     /* 0x44 */
-    char pad48[0x54 - 0x48];
-    dBgCh_Gnd();
-    ~dBgCh_Gnd();
-    void StartDetectingWater();
-    void SetObjAndPos(const Vector3& pos, dActor_c* a);
-    int DetectClsn();
-};
-/* Signature deliberately copied from the local declaration above: the
-   ROM name carries by-value class parameters (e.g. Fix12<int>), which
-   mwccarm passes differently at the call site, so declaring the true
-   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN5dBgCh19StartDetectingWaterEv(void *);
-
 
 extern "C" int SurfaceInfo_TestFlag0x20(int* p);
 extern "C" s8 data_0209f2f8;
@@ -55,11 +35,11 @@ int func_ov002_020b5ab4(char* c)
             vec.y = vy;
             vec.z = vz;
         }
-        _ZN5dBgCh19StartDetectingWaterEv(&(rg));
+        rg.StartDetectingWater();
         rg.SetObjAndPos(vec, (dActor_c*)c);
         if (rg.DetectClsn() != 0) {
-            *(int*)(c+0x324) = rg.field44;
-            if (SurfaceInfo_TestFlag0x20(&rg.field14) != 0) {
+            *(int*)(c+0x324) = rg.clsnY;
+            if (SurfaceInfo_TestFlag0x20((int*)&rg.surface) != 0) {
                 return 1;
             }
         }

--- a/src/func_ov002_020b7e1c.cpp
+++ b/src/func_ov002_020b7e1c.cpp
@@ -2,9 +2,8 @@
 // @symbol func_ov002_020b7e1c
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Actr.h"
 
-
-struct dBgCh_Actr { int IsOnGround() const; };
 struct fBase_c { void MarkForDestruction(); };
 struct dActor_c : fBase_c {
     static int Spawn(unsigned int, unsigned int, const Vector3&, const Vector3_16*, signed char, short);

--- a/src/func_ov002_020c29d4.cpp
+++ b/src/func_ov002_020c29d4.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "dBgCh_Actr.h"
+
 struct State {};
-struct dBgCh_Actr {
-    int IsOnGround() const;
-    int GetFloorResult() const;
-};
 struct Player {
     int IsState(State &s);
 };
@@ -16,6 +14,7 @@ extern "C" int _ZN6Player7IsStateERNS_5StateE(void *, State &s);
 
 extern "C" int Player_ScaleByCharFactor(void *c, int a);
 extern "C" int func_02037e38(unsigned int *p);
+extern "C" dBgPi *_ZNK10dBgCh_Actr14GetFloorResultEv(const dBgCh_Actr *self);
 extern State data_ov002_0211013c;
 extern State data_ov002_021101b4;
 
@@ -39,7 +38,7 @@ extern "C" void func_ov002_020c29d4(Player *self)
         *(unsigned char *)(base + 0x6eb) = 0x80;
     } else if (flags & 0x80) {
         if (((dBgCh_Actr *)(base + 0x380))->IsOnGround()) {
-            int r = func_02037e38((unsigned int *)((char *)((dBgCh_Actr *)(base + 0x380))->GetFloorResult() + 4));
+            int r = func_02037e38((unsigned int *)((char *)_ZNK10dBgCh_Actr14GetFloorResultEv((dBgCh_Actr *)(base + 0x380)) + 4));
             if (r >= 6 && r <= 9) return;
             *(unsigned char *)(base + 0x6eb) = 0;
             *(short *)(base + 0x6bc) = 0;

--- a/src/func_ov002_020c607c.cpp
+++ b/src/func_ov002_020c607c.cpp
@@ -1,15 +1,10 @@
 //cpp
-typedef unsigned int u32;
+#include "dBgCh_Lin.h"
 
-struct Vector3 {
+struct V3 {
     int x, y, z;
-    Vector3(int x, int y, int z) : x(x), y(y), z(z) {}
-    Vector3() {}
-};
-
-struct dBgPi {
-    char pad[0x68];
-    int GetClsnID() const;
+    V3(int x, int y, int z) : x(x), y(y), z(z) {}
+    V3() {}
 };
 
 struct dActor_c {
@@ -18,33 +13,24 @@ struct dActor_c {
     static dActor_c *FindWithID(u32 id);
 };
 
-struct dBgCh_Lin {
-    char head[0x10];
-    dBgPi mResult;
-    dBgCh_Lin();
-    ~dBgCh_Lin();
-    void SetObjAndLine(const Vector3 &a, const Vector3 &b, dActor_c *actor);
-    int DetectClsn();
-    Vector3 GetClsnPos();
-};
+extern "C" void _ZN9dBgCh_Lin10GetClsnPosEv(Vector3 *out, dBgCh_Lin *line);
 
 extern "C" int func_ov002_020c607c(char *self, int p1, int p2, int *outptr)
 {
-    Vector3 pos;
-
     *(int *)(self + 0x36c) = 0;
     *outptr = (int)0x80000000;
 
     dBgCh_Lin rc;
 
-    Vector3 a(*(int *)(self + 0x5c), p1, *(int *)(self + 0x64));
-    Vector3 b(*(int *)(self + 0x5c), p2, *(int *)(self + 0x64));
-    rc.SetObjAndLine(a, b, (dActor_c *)self);
+    V3 a(*(int *)(self + 0x5c), p1, *(int *)(self + 0x64));
+    V3 b(*(int *)(self + 0x5c), p2, *(int *)(self + 0x64));
+    V3 pos;
+    rc.SetObjAndLine(*(Vector3*)&a, *(Vector3*)&b, (dActor_c *)self);
     if (rc.DetectClsn() != 0) {
-        pos = rc.GetClsnPos();
+        _ZN9dBgCh_Lin10GetClsnPosEv((Vector3*)&pos, &rc);
         *outptr = pos.y;
-        if (rc.mResult.GetClsnID() != -1) {
-            dActor_c *found = dActor_c::FindWithID((u32)rc.mResult.GetClsnID());
+        if (rc.GetClsnID() != -1) {
+            dActor_c *found = dActor_c::FindWithID((u32)rc.GetClsnID());
             *(int *)(self + 0x36c) = (int)found;
             if (found != 0) {
                 int flag = (found->flags & 0x1000000) ? 1 : 0;

--- a/src/func_ov002_020c72a4.cpp
+++ b/src/func_ov002_020c72a4.cpp
@@ -4,18 +4,9 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 
 struct dActor_c;
-struct dBgCh_Gnd {
-    char pad0[0x14];
-    int f14;
-    char pad1[0x38];
-    dBgCh_Gnd();
-    ~dBgCh_Gnd();
-    void SetObjAndPos(const Vector3&, dActor_c*);
-    int DetectClsn();
-};
-extern "C" void _ZN5dBgCh19StartDetectingWaterEv(dBgCh_Gnd*);
 extern "C" int SurfaceInfo_TestFlag0x20(int* p);
 extern int data_0209f32c;
 
@@ -30,15 +21,15 @@ extern "C" void func_ov002_020c72a4(void* thisptr)
     v.x = x;
     v.y = d;
     v.z = z;
-    *(int*)((char*)&rg + 0x4c) = d << 1;
+    rg.mProbeHeight = d << 1;
     rg.SetObjAndPos(v, (dActor_c*)thisptr);
-    _ZN5dBgCh19StartDetectingWaterEv(&rg);
+    rg.StartDetectingWater();
     if (rg.DetectClsn()) {
-        if (SurfaceInfo_TestFlag0x20(&rg.f14) != 0) {
-            *(int*)(r4 + 0x64c) = *(int*)((char*)&rg + 0x44);
+        if (SurfaceInfo_TestFlag0x20((int*)&rg.surface) != 0) {
+            *(int*)(r4 + 0x64c) = rg.clsnY;
             data_0209f32c = *(int*)(r4 + 0x64c);
         }
     }
-    *(int*)((char*)&rg + 0x4c) = 0x1f4000;
+    rg.mProbeHeight = 0x1f4000;
     func_ov002_020c71e0(thisptr);
 }

--- a/src/func_ov002_020e2ea0.cpp
+++ b/src/func_ov002_020e2ea0.cpp
@@ -1,12 +1,7 @@
 //cpp
+#include "dBgCh_Actr.h"
+
 extern "C" {
-struct dBgCh_Actr {
-    int IsOnGround() const;
-    int GetFloorResult() const;
-};
-struct dBgPi {
-    int GetClsnID() const;
-};
 struct dActor_c {
     static dActor_c* FindWithID(unsigned int id);
 };
@@ -17,6 +12,7 @@ struct Player {
 };
 
 int func_ov002_020e3078(Player *self, Player::State *s);
+dBgPi *_ZNK10dBgCh_Actr14GetFloorResultEv(const dBgCh_Actr *self);
 }
 
 extern signed char data_0209f2f8;
@@ -44,7 +40,7 @@ extern "C" int func_ov002_020e2ea0(Player *self) {
         return 0;
     }
 
-    dBgPi *cr = (dBgPi *)((dBgCh_Actr *)(base + 0x380))->GetFloorResult();
+    dBgPi *cr = _ZNK10dBgCh_Actr14GetFloorResultEv((dBgCh_Actr *)(base + 0x380));
     if (cr->GetClsnID() != -1) {
         if (dActor_c::FindWithID((unsigned int)cr->GetClsnID()) != 0) {
             return 0;

--- a/src/func_ov002_020e7934.cpp
+++ b/src/func_ov002_020e7934.cpp
@@ -2,6 +2,7 @@
 // @symbol func_ov002_020e7934
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Lin.h"
 
 struct dActor_c;
 
@@ -13,14 +14,6 @@ extern unsigned char IsAreaShowing(int idx);
 extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern short data_02082214[];
 }
-
-struct dBgCh_Lin {
-    char pad[0x78];
-    dBgCh_Lin();
-    ~dBgCh_Lin();
-    int DetectClsn();
-    void SetObjAndLine(const Vector3& a, const Vector3& b, dActor_c* obj);
-};
 
 extern "C" void func_ov002_020e7934(char* self, void* cam)
 {

--- a/src/func_ov002_020e7d08.cpp
+++ b/src/func_ov002_020e7d08.cpp
@@ -2,17 +2,9 @@
 // @symbol func_ov002_020e7d08
 /* recovered: shared common types */
 #include "common.h"
-typedef int Fix12;
+#include "dBgCh_Gnd.h"
 
 struct dActor_c;
-
-struct dBgCh_Gnd {
-    char pad0[0x54];
-    dBgCh_Gnd();
-    ~dBgCh_Gnd();
-    void SetObjAndPos(const Vector3& pos, dActor_c* actor);
-    int DetectClsn();
-};
 
 struct Self {
     char pad[0x5c];
@@ -28,9 +20,9 @@ extern "C" void func_ov002_020e7d08(Self* self)
     v.z = self->z;
     v.y += 0x32000;
     rc.SetObjAndPos(v, 0);
-    *(int*)((char*)&rc + 0x4c) = 0x3e8000;
+    rc.mProbeHeight = 0x3e8000;
     if (rc.DetectClsn())
-        *(int*)((char*)self + 0x42c) = *(int*)((char*)&rc + 0x44);
+        *(int*)((char*)self + 0x42c) = rc.clsnY;
     else
         *(int*)((char*)self + 0x42c) = 0x7fffffff;
 }

--- a/src/func_ov030_02112400.cpp
+++ b/src/func_ov030_02112400.cpp
@@ -1,10 +1,11 @@
 //cpp
 #include "types.h"
+#include "dBgCh_Actr.h"
+
 typedef void* (*Vfn)();
 
 struct Animation { void Advance(); };
 struct dCc_c { void Clear(); void Update(); };
-struct dBgCh_Actr { int IsOnGround() const; };
 struct Vector3;
 
 extern "C" void func_ov030_02111a00(void* c);
@@ -19,17 +20,17 @@ struct dActor_c {
 };
 
 typedef struct { int a, b; } P2;
-struct dBgPi {
+struct ClsnResultTmp {
     Vfn* vtb;
     P2 v;
     int a2, a3, a4;
     u16 h0, h1;
     int t0, t1, t2;
-    int GetClsnID() const;
 };
-extern "C" dBgPi* func_0203567c(dBgCh_Actr* w);
-extern "C" int func_02037f44(dBgPi* r);
-extern "C" void _ZN5dBgPiD1Ev(dBgPi* r);
+extern "C" char* func_0203567c(dBgCh_Actr* w);
+extern "C" int func_02037f44(ClsnResultTmp* r);
+extern "C" unsigned _ZNK5dBgPi9GetClsnIDEv(const ClsnResultTmp* r);
+extern "C" void _ZN5dBgPiD1Ev(ClsnResultTmp* r);
 
 extern "C" int func_ov030_02112400(char* c)
 {
@@ -50,8 +51,8 @@ extern "C" int func_ov030_02112400(char* c)
         }
     } else {
         if (((dBgCh_Actr*)(c + 0x194))->IsOnGround()) {
-            char* r = (char*)func_0203567c((dBgCh_Actr*)(c + 0x194));
-            dBgPi res;
+            char* r = func_0203567c((dBgCh_Actr*)(c + 0x194));
+            ClsnResultTmp res;
             int* d = (int*)&res.v;
             *(double*)d = *(double*)(r + 4);
             d[2] = *(int*)(r + 0xc);
@@ -63,7 +64,7 @@ extern "C" int func_ov030_02112400(char* c)
             res.t0 = *(int*)(r + 0x1c);
             res.t1 = *(int*)(r + 0x20);
             res.t2 = *(int*)(r + 0x24);
-            if (res.GetClsnID() == -1 || func_02037f44(&res) == 0) {
+            if (_ZNK5dBgPi9GetClsnIDEv(&res) == -1 || func_02037f44(&res) == 0) {
                 func_ov030_021141a8(c, 0);
             }
             _ZN5dBgPiD1Ev(&res);

--- a/src/func_ov060_02113d8c.cpp
+++ b/src/func_ov060_02113d8c.cpp
@@ -1,11 +1,7 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
-struct Fix12 { int v; Fix12(int a) : v(a) {} };
+#include "dBgCh_Actr.h"
 
 struct dActor_c { int GetSubtraction(short a, short b); };
-struct dBgCh_Actr { int IsOnGround() const; };
 
 extern "C" {
 void func_ov060_02111cc0(char *c, int idx, int fix);

--- a/src/func_ov060_021168c4.cpp
+++ b/src/func_ov060_021168c4.cpp
@@ -4,11 +4,10 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef int Fix12i;
+#include "dBgCh_Actr.h"
 
 struct dCc_c;
 struct dActor_c;
-struct dBgCh_Actr { int JustHitGround() const; };
 struct dActor_c {
     static dActor_c* FindWithActorID(unsigned int id, dActor_c* a);
     static dActor_c* FindWithID(unsigned int id);

--- a/src/func_ov062_02116dbc.cpp
+++ b/src/func_ov062_02116dbc.cpp
@@ -8,9 +8,6 @@ struct ShadowModel;
 
 extern Matrix4x3 IDENTITY_MATRIX4X3;
 
-struct dBgCh_Actr {
-    virtual int v0();
-};
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(void* x);
 extern "C" void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void* thiz, ShadowModel& sm, Matrix4x3& mtx, Fix12i a, Fix12i b, unsigned int c);

--- a/src/func_ov062_02118004.cpp
+++ b/src/func_ov062_02118004.cpp
@@ -1,8 +1,6 @@
 //cpp
-struct dBgCh_Actr {
-    char pad[1];
-    bool IsOnGround() const;
-};
+#include "dBgCh_Actr.h"
+
 extern "C" int _Z14ApproachLinearRiii(int &r, int target, int speed);
 struct Particle {
     static void RunningSlidingDustAt(int a, int b, int c);

--- a/src/func_ov062_02118a00.cpp
+++ b/src/func_ov062_02118a00.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "dBgCh_Actr.h"
+
 extern "C" {
     extern void func_ov062_02117994(void *, int);
     extern void func_ov062_021175c0(void *);
 }
-
-struct dBgCh_Actr {
-    int IsOnGround() const;
-};
 
 extern "C" void func_ov062_02118a00(void *c) {
     int gr = ((dBgCh_Actr *)((char *)c + 0x144))->IsOnGround();

--- a/src/func_ov064_021163c0.cpp
+++ b/src/func_ov064_021163c0.cpp
@@ -1,13 +1,14 @@
 //cpp
-typedef int Fix12;
+#include "dBgCh_Actr.h"
+
+typedef int RawFix12;
 struct BCA_File;
-struct dBgCh_Actr { int IsOnGround() const; };
-struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+struct ModelAnim { void SetAnim(BCA_File *f, int a, RawFix12 b, unsigned int c); };
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which
    mwccarm passes differently at the call site, so declaring the true
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, Fix12 b, unsigned int c);
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, BCA_File *f, int a, RawFix12 b, unsigned int c);
 
 
 void ApproachLinear(short &v, short t, short step);

--- a/src/func_ov064_02116460.cpp
+++ b/src/func_ov064_02116460.cpp
@@ -1,6 +1,7 @@
 //cpp
+#include "dBgCh_Actr.h"
+
 struct BCA_File;
-struct dBgCh_Actr { int IsOnGround() const; };
 struct ModelAnim { void SetAnim(BCA_File *f, int b, int c, unsigned int d); };
 /* Signature deliberately copied from the local declaration above: the
    ROM name carries by-value class parameters (e.g. Fix12<int>), which

--- a/src/func_ov064_02116ec0.cpp
+++ b/src/func_ov064_02116ec0.cpp
@@ -25,11 +25,9 @@ struct dCcAc_c { void Init(dActor_c* a, Fix12 r, Fix12 h, unsigned int d, unsign
    types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
 extern "C" void _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *, dActor_c* a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
 
-struct dBgCh_Actr { void Init(dActor_c* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e); };
-/* Signature deliberately copied from the local declaration above: the
-   ROM name carries by-value class parameters (e.g. Fix12<int>), which
-   mwccarm passes differently at the call site, so declaring the true
-   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
+/* Keep this ABI-only call on the ROM symbol: its name carries by-value
+   Fix12<int> parameters, while the matching call site passes scalar storage.
+   See notes/mwccarm-codegen.md 6az. */
 extern "C" void _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(void *, dActor_c* a, Fix12 b, Fix12 c, Vector3_16* d, Fix12 e);
 
 
@@ -102,7 +100,7 @@ extern "C" int func_ov064_02116ec0(Obj* obj)
     obj->f3e8 = obj->f330->f1c;
     obj->f3ec = obj->f330->f20;
     obj->f100 = 0;
-    _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_((dBgCh_Actr*)&obj->f174, (dActor_c*)obj, obj->f330->f24, obj->f330->f24, 0, 0);
+    _ZN10dBgCh_Actr4InitEP8dActor_c5Fix12IiES3_P10Vector3_16S5_(&obj->f174, (dActor_c*)obj, obj->f330->f24, obj->f330->f24, 0, 0);
     obj->f3f0 = obj->f330->f28;
     obj->f338 = 0;
     obj->f334 = obj->f338;

--- a/src/func_ov070_02121d50.cpp
+++ b/src/func_ov070_02121d50.cpp
@@ -4,22 +4,18 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-
+#include "dBgCh_Actr.h"
 #include "SurfaceInfo.h"
-struct dBgCh_Actr {
-    bool IsOnGround() const;
-    SurfaceInfo* GetFloorResult() const;
-    bool IsOnWall() const;
-};
 namespace cstd { int fdiv(int a, int b); }
 
 extern "C" void dBgCh_Actr_UpdateContinuous_Veneer(void* c);
+extern "C" dBgPi *_ZNK10dBgCh_Actr14GetFloorResultEv(const dBgCh_Actr *self);
 
 extern "C" void func_ov070_02121d50(int* self, dBgCh_Actr* clsn) {
     Vector3 n;
     dBgCh_Actr_UpdateContinuous_Veneer(clsn);
     if (clsn->IsOnGround()) {
-        ((SurfaceInfo*)((char*)clsn->GetFloorResult() + 4))->CopyNormalTo(n);
+        ((SurfaceInfo*)((char*)_ZNK10dBgCh_Actr14GetFloorResultEv(clsn) + 4))->CopyNormalTo(n);
         if (n.y != 0) {
             int a = (int)(((long long)n.x * self[0x29] + 0x800) >> 12);
             int b = (int)(((long long)n.z * self[0x2b] + 0x800) >> 12);

--- a/src/func_ov071_0211f7d4.cpp
+++ b/src/func_ov071_0211f7d4.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "dBgCh_Actr.h"
+
 struct dCc_c;
 struct dActor_c { void UpdatePos(dCc_c *c); };
-struct dBgCh_Actr {
-    int JustHitGround() const;
-    void *GetFloorResult() const;
-    int IsOnGround() const;
-    void ClearLimMovFlag();
-};
 extern "C" void dBgCh_Actr_UpdateDiscreteNoLava_veneer(void *p);
+extern "C" dBgPi *_ZNK10dBgCh_Actr14GetFloorResultEv(const dBgCh_Actr *self);
 extern "C" int func_02037e38(unsigned int *p);
 extern "C" void func_ov071_0211f498(char *c);
 extern "C" void Scuttlebug_SetState(char *c, int x);
@@ -27,7 +24,7 @@ extern "C" int func_ov071_0211f7d4(dActor_c *self)
     dBgCh_Actr_UpdateDiscreteNoLava_veneer(s + 0x194);
     *(short*)(s + 0x8c) = *(short*)(s + 0x8c) + 0x1000;
     if (((dBgCh_Actr*)(s + 0x194))->JustHitGround()) {
-        if (func_02037e38((unsigned int*)((char*)((dBgCh_Actr*)(s + 0x194))->GetFloorResult() + 4)) == 4) {
+        if (func_02037e38((unsigned int*)((char*)_ZNK10dBgCh_Actr14GetFloorResultEv((dBgCh_Actr*)(s + 0x194)) + 4)) == 4) {
             func_ov071_0211f498(s);
         } else {
             *(int*)(s + 0xa8) = (*(int*)(s + 0xa8) * -0x3c) / 0x64;

--- a/src/func_ov078_02125c98.cpp
+++ b/src/func_ov078_02125c98.cpp
@@ -2,21 +2,12 @@
 // @symbol func_ov078_02125c98
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Gnd.h"
 /* func_ov078_02125c98 at 0x02125c98 (ov078), size 0x148
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-struct Vector3;
 struct dActor_c;
-struct dBgCh_Gnd {
-  char pad[0x44];
-  int result;
-  char pad2[8];
-  dBgCh_Gnd();
-  ~dBgCh_Gnd();
-  void SetObjAndPos(const Vector3& pos, dActor_c* a);
-  int DetectClsn();
-};
 
 extern "C" {
 int _ZNK10dBgCh_Actr10IsOnGroundEv(void* self);
@@ -30,7 +21,7 @@ extern "C" void func_ov078_02125c98(char* c) {
     dBgCh_Gnd rg;
     rg.SetObjAndPos(*(const Vector3*)(c+0x5c), 0);
     if (rg.DetectClsn() != 0)
-      h = rg.result;
+      h = rg.clsnY;
   }
   int b = (*(int*)(c+0xb0) & 0x4000) != 0;
   if (b) {

--- a/src/func_ov080_0212500c.cpp
+++ b/src/func_ov080_0212500c.cpp
@@ -1,6 +1,7 @@
 //cpp
+#include "dBgCh_Actr.h"
+
 struct dCc_c { void Clear(); void Update(); };
-struct dBgCh_Actr { int JustHitGround() const; int IsOnGround() const; };
 struct dActor_c { void UpdatePos(dCc_c *cc); };
 
 extern "C" void dBgCh_Actr_UpdateDiscreteNoLava_veneer(dBgCh_Actr *w);

--- a/src/func_ov081_02123b20.cpp
+++ b/src/func_ov081_02123b20.cpp
@@ -6,7 +6,6 @@ struct ShadowModel;
 
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
 
-struct dBgCh_Actr { virtual int v0(); };
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(void*);
 extern "C" void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void* thiz, ShadowModel& sm, Matrix4x3& mtx, Fix12i a, Fix12i b, unsigned int c);

--- a/src/func_ov084_02129238.cpp
+++ b/src/func_ov084_02129238.cpp
@@ -2,32 +2,9 @@
 // @symbol func_ov084_02129238
 /* recovered: shared common types */
 #include "common.h"
-typedef int s32;
+#include "dBgCh_Gnd.h"
 
 struct dActor_c;
-
-struct dBgCh_Gnd {
-    char pad0[0x14];
-    int field14;     /* 0x14 */
-    char pad18[0x44 - 0x18];
-    int field44;     /* 0x44 */
-    char pad48[0x50 - 0x48];
-    dBgCh_Gnd();
-    ~dBgCh_Gnd();
-    void StartDetectingWater();
-    void StartDetectingToxic();
-    void StopDetectingOrdinary();
-    void SetObjAndPos(const Vector3& pos, dActor_c* a);
-    int DetectClsn();
-};
-/* Signature deliberately copied from the local declaration above: the
-   ROM name carries by-value class parameters (e.g. Fix12<int>), which
-   mwccarm passes differently at the call site, so declaring the true
-   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN5dBgCh19StartDetectingWaterEv(void *);
-extern "C" void _ZN5dBgCh19StartDetectingToxicEv(void *);
-extern "C" void _ZN5dBgCh21StopDetectingOrdinaryEv(void *);
-
 
 extern "C" {
 int _ZNK10dBgCh_Actr10IsOnGroundEv(void* p);
@@ -54,14 +31,14 @@ void func_ov084_02129238(char* c)
             pos.z = vz;
         }
         dBgCh_Gnd rg;
-        _ZN5dBgCh19StartDetectingWaterEv(&(rg));
-        _ZN5dBgCh19StartDetectingToxicEv(&(rg));
-        _ZN5dBgCh21StopDetectingOrdinaryEv(&(rg));
+        rg.StartDetectingWater();
+        rg.StartDetectingToxic();
+        rg.StopDetectingOrdinary();
         rg.SetObjAndPos(pos, (dActor_c*)c);
         if (rg.DetectClsn() != 0) {
-            if (func_02037e20(&rg.field14) != 0) {
-                if (rg.field44 != (int)0x80000000) {
-                    if (*(int*)(c + 0x60) < rg.field44) {
+            if (func_02037e20((int*)&rg.surface) != 0) {
+                if (rg.clsnY != (int)0x80000000) {
+                    if (*(int*)(c + 0x60) < rg.clsnY) {
                         _ZN12dEnemyBase_c9SpawnCoinEv(c);
                         _ZN8dActor_c8PoofDustEv(c);
                         func_ov084_02129498(c);

--- a/src/func_ov084_0212aab0.cpp
+++ b/src/func_ov084_0212aab0.cpp
@@ -1,5 +1,6 @@
 //cpp
-struct dBgCh_Actr { int JustHitGround() const; int IsOnGround() const; };
+#include "dBgCh_Actr.h"
+
 struct dActor_c { void HugeLandingDust(bool b); void LandingDust(bool b); };
 void ApproachLinear(short &v, short t, short step);
 

--- a/src/func_ov098_021390ec.cpp
+++ b/src/func_ov098_021390ec.cpp
@@ -3,16 +3,12 @@
 // @symbol func_ov098_021390ec
 /* recovered: shared common types */
 #include "common.h"
+#include "dBgCh_Actr.h"
 /* Final name, not a shadow method: the ROM symbol takes Fix12<int> and the call
    site has an int. See src/_ZN17BowserSkyPlatform13InitResourcesEv.cpp for the same case. */
 extern "C" short _ZN8dActor_c12ReflectAngleE5Fix12IiES1_s(void* self, int a, int b,
                                                        short c);
-struct dBgPi { int GetClsnID() const; };
 #include "SurfaceInfo.h"
-struct dBgCh_Actr {
-    int IsOnWall() const;
-    dBgPi *GetWallResult() const;
-};
 struct dActor_c {
     virtual void v0();
     virtual void v1();
@@ -51,6 +47,7 @@ struct dActor_c {
 
 extern "C" u8 DecIfAbove0_Byte(u8 *p);
 extern "C" int func_ov002_020ef228(void *c, int arg);
+extern "C" dBgPi *_ZNK10dBgCh_Actr13GetWallResultEv(const dBgCh_Actr *self);
 
 extern "C" void func_ov098_021390ec(char *cc)
 {
@@ -58,7 +55,7 @@ extern "C" void func_ov098_021390ec(char *cc)
     if (DecIfAbove0_Byte((u8 *)((char *)c + 0x605)) != 0)
         return;
     if (((dBgCh_Actr *)((char *)c + 0x320))->IsOnWall() != 0) {
-        dBgPi *wr = ((dBgCh_Actr *)((char *)c + 0x320))->GetWallResult();
+        dBgPi *wr = _ZNK10dBgCh_Actr13GetWallResultEv((dBgCh_Actr *)((char *)c + 0x320));
         if (wr->GetClsnID() != -1) {
             dActor_c *a = dActor_c::FindWithID((u32)wr->GetClsnID());
             if (a != 0) {
@@ -81,7 +78,7 @@ extern "C" void func_ov098_021390ec(char *cc)
         return;
     }
     Vector3 v;
-    ((SurfaceInfo *)((char *)((dBgCh_Actr *)((char *)c + 0x320))->GetWallResult() + 4))->CopyNormalTo(v);
+    ((SurfaceInfo *)((char *)_ZNK10dBgCh_Actr13GetWallResultEv((dBgCh_Actr *)((char *)c + 0x320)) + 4))->CopyNormalTo(v);
     *(s16 *)((char *)c + 0x94) =
         _ZN8dActor_c12ReflectAngleE5Fix12IiES1_s(c, v.x, v.z, *(s16 *)((char *)c + 0x94));
 }

--- a/src/func_ov102_02149610.cpp
+++ b/src/func_ov102_02149610.cpp
@@ -1,24 +1,18 @@
 //cpp
-struct Vector3 { int x,y,z; Vector3(int a,int b,int d){x=a;y=b;z=d;} Vector3(){} };
-struct dBgCh_Gnd {
-  char buf[0x54];
-  dBgCh_Gnd();
-  ~dBgCh_Gnd();
-  void SetObjAndPos(const Vector3 &pos, void *actor);
-  int DetectClsn();
+#include "dBgCh_Gnd.h"
+
+struct V3 {
+  int x, y, z;
+  V3(int a, int b, int d) { x = a; y = b; z = d; }
+  V3() {}
 };
-/* Signature deliberately copied from the local declaration above: the
-   ROM name carries by-value class parameters (e.g. Fix12<int>), which
-   mwccarm passes differently at the call site, so declaring the true
-   types breaks the byte match. See notes/mwccarm-codegen.md 6az. */
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *, const Vector3 &pos, void *actor);
 
 extern "C" int func_ov102_02149610(char *c){
-  Vector3 pos(*(int*)(c+0x5c), *(int*)(c+0x60)+0x28000, *(int*)(c+0x64));
+  V3 pos(*(int*)(c+0x5c), *(int*)(c+0x60)+0x28000, *(int*)(c+0x64));
   dBgCh_Gnd rg;
-  _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(&(rg), pos, 0);
-  *(int*)((char*)&rg + 0x4c) = 0x3e8000;
+  rg.SetObjAndPos(*(Vector3*)&pos, 0);
+  rg.mProbeHeight = 0x3e8000;
   int r = *(int*)(c+0x60);
-  if (rg.DetectClsn()) r = *(int*)((char*)&rg + 0x44);
+  if (rg.DetectClsn()) r = rg.clsnY;
   return r;
 }

--- a/src/func_ov102_0214b444.cpp
+++ b/src/func_ov102_0214b444.cpp
@@ -1,16 +1,7 @@
 //cpp
-struct Vector3;
-struct dActor_c;
+#include "dBgCh_Gnd.h"
 
-struct dBgCh_Gnd {
-    char pad[0x44];
-    int result;       // offset 0x44
-    char pad2[0xc];
-    dBgCh_Gnd();
-    ~dBgCh_Gnd();
-    void SetObjAndPos(const Vector3 &pos, dActor_c *a);
-    int DetectClsn();
-};
+struct dActor_c;
 
 extern "C" int _ZNK10dBgCh_Actr10IsOnGroundEv(int self);
 extern "C" void _ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
@@ -28,7 +19,7 @@ extern "C" void func_ov102_0214b444(int c)
         dBgCh_Gnd rg;
         rg.SetObjAndPos(*(const Vector3*)(c + 0x5c), (dActor_c*)0);
         if (rg.DetectClsn() != 0)
-            v = rg.result;
+            v = rg.clsnY;
     }
 
     {


### PR DESCRIPTION
Replaces local collision-query shadow declarations across 36 existing matched C++ sources with the canonical ground, line, base-query, and actor-collision types.\n\nValidation:\n- 36/36 changed functions strict-link VERIFIED\n- 11,085/11,085 source-built functions reproduce\n- 106/106 modules exact; ROM analysis PASS\n- attribution: 0 changed, 0 lost