### PR TITLE
tools: let a policy license the class data a promoted TU emits

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -57,6 +57,7 @@ IGNORE = (".comment", ".debug", ".line", ".note")
 
 SHN_UNDEF = 0
 R_ARM_ABS32 = 2
+SHF_EXECINSTR = 0x4
 
 # "There is nothing here to reduce" -- not a failure. An object whose enrolled symbol
 # is not a defined function in it (an assembly stub, a data entry) simply has no
@@ -429,10 +430,15 @@ def deadstrip_plan(raw, symbol_names, expect=None):
     retail link discarded, while this repository links with ``-nodead``.  A caller may
     model that historical discard only when all of these facts are mechanically true:
 
-    * every requested symbol is a defined function in its own content section;
+    * every requested symbol is a defined function or data object in its own
+      content section;
     * every named, non-mapping symbol in each removed section is requested too;
-    * no relocation from a surviving content section references a requested symbol or
-      an unnamed section symbol for a removed section.
+    * no relocation from a surviving content section references a requested
+      *function* or an unnamed section symbol for a removed section.  A requested
+      *data object* may be referenced by name -- becoming an import is the point, and
+      it is the only way a destructor can go on storing the vptr of a vtable the ROM
+      owns -- but only for ``_ZTV``/``_ZTI``/``_ZTS``, whose relocation shapes are
+      surveyed, and never through an unnamed section symbol.
 
     ``expect`` extends this to the *duplicate* case: a vague-linkage body the compiler
     re-emits in every TU that needs it, while the retail image keeps exactly one copy
@@ -443,6 +449,18 @@ def deadstrip_plan(raw, symbol_names, expect=None):
     produce those bytes must not use this path.  If nothing else defines the symbol the
     link fails loudly on an undefined reference, so this cannot silently drop a function
     that has a retail address.
+
+    ``STT_OBJECT`` is accepted alongside ``STT_FUNC`` because a reconstructed TU that
+    names its key function emits the class's ``_ZTV``/``_ZTI``/``_ZTS`` as well as its
+    code, and an intact multi-symbol object refuses any surviving non-``.text`` content.
+    Without this, promoting a TU meant deleting the out-of-line destructor -- and with
+    it the only thing that makes the vtable comparable to the cartridge at all.  The
+    section-level checks above are linkage-agnostic and carry over unchanged; what does
+    NOT carry over is ``expect``.  A data object's words are relocation targets, so the
+    bytes in this object are addends, not linked addresses, and comparing them against
+    the cartridge would compare two different things.  Raw duplicate-body evidence is
+    therefore refused for data, and the caller proves those bodies the way
+    ``romdata_check`` does: by applying the relocations first.
 
     There are no patterns and no binding-based guesses.  The caller must name every
     symbol, and any ambiguity is an error.  The returned plan has the same shape as
@@ -467,10 +485,10 @@ def deadstrip_plan(raw, symbol_names, expect=None):
         return {"error": f"compiler-only symbol(s) not defined: {missing}"}
 
     bad_type = sorted(n for n in wanted
-                      if defined[n]["st_info"]["type"] != "STT_FUNC")
+                      if defined[n]["st_info"]["type"] not in ("STT_FUNC", "STT_OBJECT"))
     if bad_type:
-        return {"error": f"compiler-only deadstrip currently accepts functions only: "
-                         f"{bad_type}"}
+        return {"error": f"compiler-only deadstrip accepts functions and data objects "
+                         f"only: {bad_type}"}
 
     drop_content = {defined[n]["st_shndx"] for n in wanted}
     if not all(isinstance(i, int) and secs[i].header["sh_type"] in CONTENT
@@ -487,44 +505,121 @@ def deadstrip_plan(raw, symbol_names, expect=None):
             return {"error": f"section[{shndx}] {secs[shndx].name} also defines "
                              f"non-policy symbol(s): {foreign}"}
 
+    funcs = {n for n in wanted if defined[n]["st_info"]["type"] == "STT_FUNC"}
+    objects = wanted - funcs
+
     # A discarded section may have relocations of its own; those disappear with it.
     # Only references from SURVIVING content are load-bearing and therefore blockers.
+    #
+    # `rebase` collects the surviving CODE sections whose vtable relocations still
+    # carry mwcc's preamble skip.  mwcc's `_ZTV<C>` addresses the vtable object's
+    # start, so a vptr store against a definition in this object reads `+8`; the ROM
+    # symbol IS the slot array, so once that definition is externalised the same store
+    # must read `+0`.  `plan` performs the subtraction for the one kept function and
+    # `plan_many` refuses an object that still needs it -- this is the third producer,
+    # and it hands `_apply` a set of sections rather than a single kept index.  Data
+    # sections are deliberately excluded: a surviving `_ZTI` record's link to its ABI
+    # vtable is verified ROM data, not an address-point convention to correct.
+    rebase = set()
     for rel in secs:
         if not isinstance(rel, RelocationSection) or rel.header["sh_info"] in drop_content:
             continue
         source = secs[rel.header["sh_info"]]
         if source.header["sh_type"] not in CONTENT or not source.header["sh_size"]:
             continue
+        executable = bool(source.header["sh_flags"] & SHF_EXECINSTR)
         for r in rel.iter_relocations():
             target = symtab.get_symbol(r["r_info_sym"])
-            names_target = target.name in wanted
+            names_target = target.name in funcs
             section_target = (not target.name and target["st_shndx"] in drop_content)
             if names_target or section_target:
                 label = target.name or f"section[{target['st_shndx']}]"
                 return {"error": f"surviving section[{rel.header['sh_info']}] "
                                  f"{source.name} references compiler-only {label} at "
                                  f"0x{r['r_offset']:x}"}
+            is_rtti = target.name.startswith(("_ZTV", "_ZTI", "_ZTS"))
+            if target.name in objects and not is_rtti:
+                return {"error": f"surviving section[{rel.header['sh_info']}] "
+                                 f"{source.name} references compiler-only data "
+                                 f"{target.name} at 0x{r['r_offset']:x}; only "
+                                 f"_ZTV/_ZTI/_ZTS may be imported this way"}
+            undef = target["st_shndx"] in ("SHN_UNDEF", SHN_UNDEF)
+            if not is_rtti or not (target.name in objects or undef):
+                continue
+            if not rel.is_RELA():
+                return {"error": f"{target.name}: RTTI reloc is REL, not RELA"}
+            addend = r["r_addend"]
+            if not executable:
+                # Only a code section stores a vptr.  A surviving `_ZTI` record's own
+                # `+8` link to the ABI type_info vtable is an ordinary external
+                # reference that this plan does not disturb, so it is left alone; a
+                # data reference to a definition being externalised HERE is outside
+                # the surveyed shape and is refused rather than rewritten on a guess.
+                if addend and target.name in objects:
+                    return {"error": f"{target.name}: RTTI reference with addend "
+                                     f"{addend} from surviving data section "
+                                     f"{source.name}"}
+                continue
+            # Two spellings of a vptr store are legitimate and they differ by one
+            # preamble.  mwcc's `_ZTV<C>` addresses the vtable OBJECT, so a store
+            # against a definition in this object carries `+8` and must lose it once
+            # the definition is externalised.  A source that declares the ROM symbol
+            # itself (`extern int _ZTV10dBgActor_c[];`) is already using symbols.txt's
+            # convention, where the symbol IS the slot array: addend 0, nothing to
+            # correct, and `_apply` leaves it alone.  Anything strictly between the
+            # two is a shape this survey has not seen, and it is not guessed at.
+            shape = ((addend == 0 or addend >= VTABLE_PREAMBLE)
+                     if target.name.startswith("_ZTV") else addend == 0)
+            if r["r_info_type"] != R_ARM_ABS32 or not shape:
+                return {"error": f"{target.name}: unexpected reloc "
+                                 f"type={r['r_info_type']} addend={addend}"}
+            if addend:
+                rebase.add(rel.header["sh_info"])
 
     for name, want in sorted((expect or {}).items()):
         if name not in wanted:
             return {"error": f"{name}: duplicate-body evidence for a symbol that was "
                              f"not requested"}
         sym = defined[name]
+        if sym["st_info"]["type"] != "STT_FUNC":
+            return {"error": f"{name}: raw duplicate-body evidence is function-only; a "
+                             f"data object's words are relocation addends here and "
+                             f"linked addresses in the cartridge, so the two are not "
+                             f"comparable before the link"}
         if sym["st_info"]["bind"] != "STB_LOPROC":
             return {"error": f"{name}: duplicate deadstrip needs vague linkage, got "
                              f"{sym['st_info']['bind']}"}
-        got = bytes(secs[sym["st_shndx"]].data())
-        if got != bytes(want):
+        got, want = bytes(secs[sym["st_shndx"]].data()), bytes(want)
+        if len(got) != len(want):
             return {"error": f"{name}: this object's body ({len(got)} bytes) is not the "
                              f"cartridge's body at its configured home "
-                             f"({len(bytes(want))} bytes)"}
+                             f"({len(want)} bytes)"}
+        # A relocated word holds an addend here and a linked address in the cartridge,
+        # so comparing it raw would report every branch and every vptr store as a
+        # difference -- a 4-byte `bx lr` was the only body flat enough to survive it.
+        # What this module can prove on its own is the instruction stream around them.
+        # Resolving the relocations needs symbols.txt homes, which is a layer above:
+        # see `rombuild._duplicate_body_reasons`, which links the body and compares the
+        # words masked out here.
+        relocated = set()
+        for rel in secs:
+            if isinstance(rel, RelocationSection) and rel.header["sh_info"] == sym["st_shndx"]:
+                relocated.update(r["r_offset"] & ~3 for r in rel.iter_relocations())
+        for off in range(0, len(got) & ~3, 4):
+            if off in relocated:
+                continue
+            if got[off:off + 4] != want[off:off + 4]:
+                return {"error": f"{name}: this object's body differs from the "
+                                 f"cartridge's at its configured home, at "
+                                 f"non-relocated offset 0x{off:x}"}
 
     drop = set(drop_content)
     drop.update(i for i, s in enumerate(secs)
                 if isinstance(s, RelocationSection) and s.header["sh_size"]
                 and s.header["sh_info"] in drop_content)
-    return {"keep": None, "drop": sorted(drop), "externalise": [],
-            "dead": sorted(wanted), "referenced": [], "error": None}
+    return {"keep": None, "drop": sorted(drop), "externalise": sorted(objects),
+            "dead": sorted(funcs), "referenced": [], "rebase": sorted(rebase),
+            "error": None}
 
 
 def derive_deadstrip(raw, symbol_names, expect=None):
@@ -1166,7 +1261,13 @@ def _apply(raw, p, keep_symbol):
     # is part of the verified ROM data (for example an _ZTI record's ABI-vtable link).
     # Section partitioning therefore never opts into this rewrite: it must preserve
     # the already-verified data relocation stream byte-for-byte.
-    keeps = {p["keep"]} if isinstance(p.get("keep"), int) else set()
+    # A plan may name the sections to correct outright (deadstrip_plan does, because
+    # it keeps many and drops the definitions out from under them).  Absent that the
+    # legacy rule stands: the single kept function's section, and nothing else.
+    keeps = p.get("rebase")
+    if keeps is None:
+        keeps = {p["keep"]} if isinstance(p.get("keep"), int) else set()
+    keeps = set(keeps)
     for s in elf.iter_sections():
         if not isinstance(s, RelocationSection) or s.header["sh_info"] not in keeps:
             continue

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -35,6 +35,7 @@ See notes/rom-build.md for the milestones and the enrollment rules.
 import argparse
 import concurrent.futures
 import hashlib
+import io
 import json
 import os
 import pathlib
@@ -294,8 +295,10 @@ def _isolate(obj, rel, syms, data_sink=None, compiler_only=None):
     """Reduce a compiled `src/` object to its declared function(s).
 
     A legacy source owns one function and takes the unchanged singular isolation path.
-    A consolidated, text-only source owns several functions in ROM order and takes
-    objisolate's separate fail-closed intact-object path. Returns an error or None.
+    A consolidated source owns several functions in ROM order and takes objisolate's
+    separate fail-closed intact-object path, which admits no content the manifest has
+    not licensed -- including the vtable a key function drags in. Returns an error or
+    None.
 
     `mods/` is deliberately exempt. A mod is not a recovered ROM function: it may
     legitimately define helpers and data alongside its entry point, and isolation
@@ -325,6 +328,15 @@ def _isolate(obj, rel, syms, data_sink=None, compiler_only=None):
             pol = (compiler_only or {}).get(rel.replace("\\", "/")) or {}
             dead = pol.get("deadstrip") or []
             if dead:
+                # Before the surgery, not after: once the sections are zeroed there is
+                # nothing left to compare against the cartridge.
+                differ = _data_body_reasons(obj, rel, pol.get("data") or [])
+                if differ:
+                    return "compiler-only data policy: " + "; ".join(differ)
+                differ = _duplicate_body_reasons(
+                    obj, rel, pol.get("expect") or {}, pol.get("homes") or {})
+                if differ:
+                    return "compiler-only duplicate policy: " + "; ".join(differ)
                 reduced, dead_plan = OI.derive_deadstrip(
                     obj.read_bytes(), dead, pol.get("expect") or {})
                 if reduced is None:
@@ -376,7 +388,7 @@ def enrolled_symbols():
             for rel, rows in grouped.items()}
 
 
-DISPOSITIONS = ("deadstrip", "deadstrip-duplicate")
+DISPOSITIONS = ("deadstrip", "deadstrip-duplicate", "deadstrip-data")
 
 _SYM_SIZES = None
 _MOD_IMAGES = {}
@@ -438,6 +450,123 @@ def _duplicate_body(symbol, homes_for):
     return body, None
 
 
+def _claimed_range(entry, module, addr):
+    """The entry's own declared range containing `addr`, or None.
+
+    A promoted TU claims exact address ranges and nothing else.  Everything outside
+    them is content dsd delinks straight from the cartridge no matter what this object
+    emits, which is the whole reason a data body can be discarded at all.
+
+    The caller has already refused an entry with no module of its own: without one
+    every range comparison here would come back "not mine", which is the answer that
+    licenses the discard.
+    """
+    if RL.normalize_module(str(entry.get("module", ""))) != RL.normalize_module(module):
+        return None
+    for sec in entry.get("sections") or []:
+        try:
+            start, end = int(str(sec.get("start")), 0), int(str(sec.get("end")), 0)
+        except (TypeError, ValueError):
+            continue
+        if start <= addr < end:
+            return f"{sec.get('name') or '?'} 0x{start:08x}-0x{end:08x}"
+    return None
+
+
+def _declared_home(row):
+    """(module, addr) a policy row claims for itself, ``"bad"``, or None.
+
+    These fields are written so a human reading the manifest sees the address the row
+    leans on.  Left unvalidated they drift silently against the config that actually
+    decides, so they are checked whenever they are present.
+    """
+    module, addr = row.get("canonical_module"), row.get("canonical_address")
+    if module is None and addr is None:
+        return None
+    try:
+        return RL.normalize_module(str(module)), int(str(addr), 0)
+    except (TypeError, ValueError):
+        return "bad"
+
+
+def _duplicate_body_reasons(obj, rel, expect, homes):
+    """Reasons a ``deadstrip-duplicate`` body is not the cartridge's own.
+
+    `objisolate` compares the raw section against the cartridge, which can only speak
+    for the words no relocation covers -- an addend is not a linked address, so every
+    `bl` and every vptr store has to be masked out there.  Those are precisely the
+    words that carry the wiring, so leaving them unchecked would license discarding a
+    body whose instructions match and whose call targets do not.
+
+    `linkcheck` already links a candidate body the way the linker would, for exactly
+    this comparison; the homes come from symbols.txt, which is why this lives here and
+    not in the surgery module.  Words it cannot resolve come back blind and are
+    excluded rather than counted as differences -- the same rule
+    :func:`_data_body_reasons` inherits from romdata_check.
+    """
+    if not expect:
+        return []
+    import linkcheck as LC  # noqa: PLC0415 - heavy, and only this path needs it
+    from elftools.elf.elffile import ELFFile  # noqa: PLC0415
+    raw, names, out = obj.read_bytes(), RDC.name_index(), []
+    elf = ELFFile(io.BytesIO(raw))
+    symtab = elf.get_section_by_name(".symtab")
+    for name, want in sorted(expect.items()):
+        home = (homes or {}).get(name)
+        if home is None:
+            continue
+        module, addr = home
+        sym = next((y for y in symtab.iter_symbols() if y.name == name
+                    and y["st_shndx"] not in ("SHN_UNDEF", "SHN_ABS")), None)
+        relocs = LC.func_relocs_typed(raw, name, names)
+        if sym is None or relocs is None:
+            out.append(f"{name} is not defined in this object")
+            continue
+        body = elf.get_section(sym["st_shndx"]).data()[
+            sym["st_value"]:sym["st_value"] + len(want)]
+        for rl in relocs:
+            # mwcc's `_ZTV<C>` addresses the vtable object; symbols.txt's addresses the
+            # slots, so the raw addend double-counts the preamble. Same correction
+            # romdata_check applies to a vptr field embedded in a data record.
+            if rl["sym"].startswith("_ZTV") and rl["add"] >= OI.VTABLE_PREAMBLE:
+                rl["add"] -= OI.VTABLE_PREAMBLE
+        linked, blind = LC.link_function(body, addr, relocs)
+        differing = [off for off in range(0, len(linked) & ~3, 4)
+                     if off not in blind and linked[off:off + 4] != want[off:off + 4]]
+        if differing:
+            out.append(f"{name} linked against {module}:0x{addr:08x} differs from the "
+                       f"cartridge in {len(differing)} word(s), first at "
+                       f"0x{differing[0]:x}")
+    return sorted(out)
+
+
+def _data_body_reasons(obj, rel, symbols):
+    """Reasons a ``deadstrip-data`` symbol's body is not the cartridge's own.
+
+    The disposition is licensed on an address argument -- the home lies outside every
+    range this source claims, so discarding it cannot cost the image a byte.  That
+    makes it sound; it does not make it right.  A vtable whose slots disagree with the
+    cartridge means the class model is wrong, and quietly dropping it would bury that
+    evidence in the very file that produced it.  romdata_check already resolves the
+    relocations and compares word by word.  It is advisory everywhere else, and binding
+    here because a policy row is an explicit, checked-in claim about these symbols.
+
+    Only DIFFERS is a refusal.  PARTIAL is the normal verdict for a vtable -- the ROM
+    extent is the distance to the next symbol, so a trailing alignment gap that belongs
+    to nobody makes a fully-matching body come back short.
+    """
+    if not symbols:
+        return []
+    want, out = set(symbols), []
+    for rec in RDC.check_object(obj, rel):
+        if rec.get("symbol") in want and rec.get("verdict") == RDC.DIFFERS:
+            out.append(f"{rec['symbol']} differs from the cartridge at "
+                       f"{rec.get('module')}:0x{rec.get('addr', 0):08x} in "
+                       f"{rec.get('differingBytes')} of {rec.get('bytes')} "
+                       f"compared bytes")
+    return sorted(out)
+
+
 def compiler_only_policies(enrolled=None, manifest=None, homes=None):
     """Exact dead-strip allow-lists for promoted multi-function sources.
 
@@ -446,12 +575,13 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
     remains objisolate's job; this preflight only proves the checked-in policy cannot
     hide a function that has a retail address.
 
-    Two dispositions, and the difference is the whole safety argument:
+    Three dispositions, and the difference between them is the whole safety argument:
 
     ``deadstrip``
-        The function is *homeless* -- mwcc emitted a body (a D2 variant, an inline
-        helper) that the retail link discarded and no configured symbol names.
-        Refused the moment it acquires a ROM home.
+        The symbol is *homeless* -- mwcc emitted a body (a D2 variant, an inline
+        helper, a typeinfo record for a class the ROM never names) that the retail link
+        discarded and no configured symbol names.  Refused the moment it acquires a
+        ROM home.
 
     ``deadstrip-duplicate``
         The function *must* have a ROM home, and the row must name it.  This is the
@@ -464,6 +594,20 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
         it did not the link would fail on an undefined symbol rather than quietly
         producing a hole.  This is what let a reconstructed TU be promoted at all --
         before it, every TU holding a ``Vector3`` was stuck at text-verified.
+
+    ``deadstrip-data``
+        The same shape one level up, for ``_ZTV``/``_ZTI``/``_ZTS`` rather than code.
+        A TU that names its key function emits its class's vtable, and an intact
+        multi-symbol object refuses any surviving non-``.text`` content -- so promotion
+        used to mean deleting the out-of-line destructor and losing the vtable with it.
+        The duplicate proof cannot be reused here: a vtable's words are relocation
+        addends in this object and linked addresses in the cartridge.  The argument is
+        an address one instead.  A promoted entry claims exact ranges; a data home
+        *outside* every one of them is content dsd delinks from the cartridge whatever
+        this object does, so discarding the copy cannot cost the image a byte, and a
+        home *inside* a claimed range is refused because that is a range the source
+        undertook to build.  The bodies are then proved word-by-word at isolation time,
+        with the relocations applied -- see :func:`_data_body_reasons`.
     """
     data = TUM.load() if manifest is None else manifest
     active = None if enrolled is None else {
@@ -489,7 +633,7 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
             errors.append(f"{source}: compiler-only policy is declared by multiple entries")
             continue
         licensed = {row.get("symbol") for row in entry.get("functions", [])}
-        wanted, expect = [], {}
+        wanted, expect, data, dup_homes = [], {}, [], {}
         for i, row in enumerate(rows):
             if not isinstance(row, dict):
                 errors.append(f"{source}: compiler_only_output[{i}] is not an object")
@@ -508,6 +652,17 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
                 errors.append(f"{source}: {symbol} is licensed by the manifest")
             if symbol in wanted:
                 errors.append(f"{source}: duplicate compiler-only symbol {symbol}")
+            declared = _declared_home(row)
+            if declared == "bad":
+                errors.append(f"{source}: {symbol} canonical_module/canonical_address "
+                              f"must name a module and an integer address")
+            elif declared is not None:
+                actual = {(RL.normalize_module(m), a)
+                          for m, a in homes.get(symbol) or []}
+                if declared not in actual:
+                    errors.append(f"{source}: {symbol} names canonical home "
+                                  f"{declared[0]}:0x{declared[1]:08x}, which is not one "
+                                  f"of its configured ROM home(s) {sorted(actual)}")
             if disposition == "deadstrip-duplicate":
                 if not homes.get(symbol):
                     errors.append(f"{source}: {symbol} is declared a duplicate but has "
@@ -518,12 +673,41 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
                         errors.append(f"{source}: {why}")
                     else:
                         expect[symbol] = body
-            elif homes.get(symbol):
+                        # The link address for the resolved comparison; _duplicate_body
+                        # has already refused anything but a single unambiguous home.
+                        dup_homes[symbol] = (RL.normalize_module(homes[symbol][0][0]),
+                                             homes[symbol][0][1])
+            elif disposition == "deadstrip-data":
+                if not str(entry.get("module") or ""):
+                    # Fail closed. The licence is that the home lies outside every
+                    # range this entry claims -- an entry with no module of its own
+                    # would clear that test vacuously, for every address in the ROM.
+                    errors.append(f"{source}: {symbol} is declared compiler-only data "
+                                  f"but this entry declares no module, so its claimed "
+                                  f"ranges cannot be compared against a ROM home")
+                elif not homes.get(symbol):
+                    errors.append(f"{source}: {symbol} is declared compiler-only data "
+                                  f"but has no configured ROM home; a homeless object "
+                                  f"is a plain deadstrip")
+                else:
+                    inside = [(m, a, _claimed_range(entry, m, a))
+                              for m, a in homes[symbol]]
+                    inside = [(m, a, r) for m, a, r in inside if r]
+                    if inside:
+                        m, a, r = inside[0]
+                        errors.append(f"{source}: {symbol}'s ROM home {m}:0x{a:08x} "
+                                      f"falls inside this entry's own {r}; a range the "
+                                      f"source claims must be built, not discarded")
+                    else:
+                        data.append(symbol)
+            elif disposition == "deadstrip" and homes.get(symbol):
                 errors.append(f"{source}: {symbol} has configured ROM home(s) "
-                              f"{homes[symbol]}; declare it deadstrip-duplicate and "
-                              f"prove the body, or drop the policy")
+                              f"{homes[symbol]}; declare it deadstrip-duplicate (a "
+                              f"function) or deadstrip-data (an object) and prove the "
+                              f"body, or drop the policy")
             wanted.append(symbol)
-        out[source] = {"deadstrip": wanted, "expect": expect}
+        out[source] = {"deadstrip": wanted, "expect": expect, "data": data,
+                       "homes": dup_homes}
     if errors:
         raise BuildError("compiler-only policy", 1, "\n".join(errors))
     return out

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -204,10 +204,125 @@ class Isolate(unittest.TestCase):
 
         _out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"],
                                          {"_ZN1VD1Ev": bytes(len(real))})
+        self.assertIn("non-relocated offset", plan["error"])
+
+        # A length mismatch is a different body outright, not a masked word.
+        _out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"],
+                                         {"_ZN1VD1Ev": real + bytes(4)})
         self.assertIn("not the cartridge's body", plan["error"])
 
         _out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"], {"_ZN1VD2Ev": real})
         self.assertIn("was not requested", plan["error"])
+
+    KEY_FUNCTION_CLASS = ("struct B { virtual ~B(); virtual int f(); }; "
+                          "B::~B(){} int B::f(){ return 1; }")
+
+    def test_deadstrip_externalises_a_vtable_the_survivors_reference(self):
+        """A promoted TU keeps the vtable the ROM owns instead of losing it.
+
+        An out-of-line destructor is the key function, so mwcc emits `_ZTV` in this
+        object -- and the cartridge already has that vtable, at an address no promoted
+        source claims.  Discarding the definition while the destructor goes on storing
+        the vptr means the reference has to survive as an IMPORT, and the addend has to
+        lose mwcc's preamble skip: `_ZTV<C>` here addresses the vtable object, in
+        symbols.txt it addresses the slots.
+        """
+        raw = self.build(self.KEY_FUNCTION_CLASS).read_bytes()
+        before = self._reloc_addends(raw, "_ZTV1B")
+        self.assertTrue(any(a >= OI.VTABLE_PREAMBLE for a in before), before)
+
+        out, plan = OI.derive_deadstrip(raw, ["_ZTV1B"])
+        self.assertIsNone(plan["error"])
+        self.assertEqual(plan["externalise"], ["_ZTV1B"])
+        self.assertEqual(plan["dead"], [])
+        self.assertTrue(plan["rebase"], "the vptr store's section must be rebased")
+
+        after = self._reloc_addends(out, "_ZTV1B")
+        self.assertTrue(after, "the reference must survive as an import")
+        self.assertTrue(all(a < OI.VTABLE_PREAMBLE for a in after), after)
+        self.assertEqual(sorted(a + OI.VTABLE_PREAMBLE for a in after), sorted(before))
+
+    def test_deadstrip_accepts_a_vptr_store_already_in_rom_convention(self):
+        """A source that declares the ROM symbol itself needs no preamble correction.
+
+        `extern int _ZTV10dBgActor_c[];` names symbols.txt's slot array, so the store
+        relocates with addend 0.  There is nothing to rebase, and refusing it would
+        reject every promoted TU that inherits a base's vtable rather than owning one.
+        """
+        obj = self.build("extern int _ZTVBase[]; struct Q { virtual ~Q(); }; "
+                         "Q::~Q(){ *(int**)this = _ZTVBase; } "
+                         "int helper(){ return 7; }")
+        raw = obj.read_bytes()
+        self.assertEqual(set(self._reloc_addends(raw, "_ZTVBase")), {0})
+
+        _out, plan = OI.derive_deadstrip(raw, ["_ZTV1Q"])
+        self.assertIsNone(plan["error"])
+        self.assertEqual(plan["externalise"], ["_ZTV1Q"])
+        self.assertEqual(set(self._reloc_addends(_out, "_ZTVBase")), {0},
+                         "an addend-0 reference is left exactly as it was")
+
+    def test_deadstrip_refuses_a_vptr_store_between_the_two_conventions(self):
+        """Neither spelling, so neither answer is safe; refuse rather than guess."""
+        raw = self.build(self.KEY_FUNCTION_CLASS).read_bytes()
+        raw = self._retarget_addend(raw, "_ZTV1B", 4)
+        _out, plan = OI.derive_deadstrip(raw, ["_ZTV1B"])
+        self.assertIn("unexpected reloc", plan["error"])
+
+    def test_deadstrip_refuses_a_non_rtti_data_import(self):
+        """Only the RTTI trio may be imported; anything else is an unsurveyed shape."""
+        obj = self.build("int g_table[4] = {1,2,3,4}; int read(){ return g_table[2]; }")
+        _out, plan = OI.derive_deadstrip(obj.read_bytes(), ["g_table"])
+        self.assertIn("only _ZTV/_ZTI/_ZTS may be imported this way", plan["error"])
+
+    def test_duplicate_body_evidence_is_function_only(self):
+        """A data object's words are addends here and addresses in the cartridge."""
+        raw = self.build(self.KEY_FUNCTION_CLASS).read_bytes()
+        _out, plan = OI.derive_deadstrip(
+            raw, ["_ZTV1B"], {"_ZTV1B": self._section_bytes(raw, "_ZTV1B")})
+        self.assertIn("function-only", plan["error"])
+
+    def _retarget_addend(self, raw, target, value):
+        """A copy of `raw` with every code relocation against `target` given `value`."""
+        import io, struct
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+        out = bytearray(raw)
+        elf = ELFFile(io.BytesIO(raw))
+        secs = list(elf.iter_sections())
+        symtab = elf.get_section_by_name(".symtab")
+        endian = "<" if elf.little_endian else ">"
+        for sec in secs:
+            if not isinstance(sec, RelocationSection) or not sec.is_RELA():
+                continue
+            if not (secs[sec.header["sh_info"]].header["sh_flags"] & OI.SHF_EXECINSTR):
+                continue
+            for i, r in enumerate(sec.iter_relocations()):
+                if symtab.get_symbol(r["r_info_sym"]).name == target:
+                    struct.pack_into(endian + "i", out,
+                                     sec.header["sh_offset"] + i * 12 + 8, value)
+        return bytes(out)
+
+    def _reloc_addends(self, raw, target):
+        """Addends of every relocation against `target` from a surviving code section."""
+        import io
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+        elf = ELFFile(io.BytesIO(raw))
+        secs = list(elf.iter_sections())
+        symtab = elf.get_section_by_name(".symtab")
+        out = []
+        for sec in secs:
+            if not isinstance(sec, RelocationSection):
+                continue
+            source = secs[sec.header["sh_info"]]
+            if not (source.header["sh_flags"] & OI.SHF_EXECINSTR):
+                continue
+            if not source.header["sh_size"]:
+                continue
+            for r in sec.iter_relocations():
+                if symtab.get_symbol(r["r_info_sym"]).name == target:
+                    out.append(r["r_addend"])
+        return out
 
     def _section_bytes(self, raw, name):
         import io

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -165,7 +165,7 @@ class RomBuildEnrollment(unittest.TestCase):
         }]}
         self.assertEqual(
             RB.compiler_only_policies(manifest=manifest, homes={}),
-            {"src/Pair.cpp": {"deadstrip": ["_ZN4PairC2Ev"], "expect": {}}})
+            {"src/Pair.cpp": {"deadstrip": ["_ZN4PairC2Ev"], "expect": {}, "data": [], "homes": {}}})
 
     def test_duplicate_disposition_requires_a_rom_home(self):
         """The two dispositions have opposite preconditions, deliberately."""
@@ -208,6 +208,58 @@ class RomBuildEnrollment(unittest.TestCase):
             RB.compiler_only_policies(manifest=manifest, homes={})
         self.assertIn("disposition must be one of", raised.exception.output)
 
+    def _data_manifest(self, **row):
+        base = {"symbol": "_ZTV4Pair", "disposition": "deadstrip-data",
+                "reason": "the cartridge owns this vtable"}
+        return {"entries": [{
+            "id": "arm9/Pair",
+            "module": "arm9",
+            "source": "src/Pair.cpp",
+            "sections": [{"name": ".text", "start": "0x02000000", "end": "0x02000100"}],
+            "functions": [{"symbol": "First"}],
+            "compiler_only_output": [base | row]}]}
+
+    def test_data_disposition_requires_a_rom_home(self):
+        """A homeless data object is a plain deadstrip -- there is nothing to prove."""
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(manifest=self._data_manifest(), homes={})
+        self.assertIn("a homeless object is a plain deadstrip", raised.exception.output)
+
+    def test_data_disposition_refuses_an_entry_with_no_module(self):
+        """Without a module every claimed range reads as somebody else's, so the
+        address argument would clear itself vacuously for the whole ROM."""
+        manifest = self._data_manifest()
+        del manifest["entries"][0]["module"]
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(manifest=manifest, homes={
+                "_ZTV4Pair": [("arm9", 0x02000040)]})
+        self.assertIn("this entry declares no module", raised.exception.output)
+
+    def test_data_disposition_refuses_a_home_this_entry_claims(self):
+        """Inside a claimed range, dsd does NOT delink it: the source must build it."""
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(manifest=self._data_manifest(), homes={
+                "_ZTV4Pair": [("arm9", 0x02000040)]})
+        self.assertIn("must be built, not discarded", raised.exception.output)
+
+    def test_data_disposition_accepts_a_home_outside_every_claimed_range(self):
+        """The licence is an address argument: dsd delinks it from the cartridge
+        regardless, so discarding this object's copy cannot cost the image a byte."""
+        self.assertEqual(
+            RB.compiler_only_policies(manifest=self._data_manifest(), homes={
+                "_ZTV4Pair": [("arm9", 0x02008000)]}),
+            {"src/Pair.cpp": {"deadstrip": ["_ZTV4Pair"], "expect": {}, "homes": {},
+                              "data": ["_ZTV4Pair"]}})
+
+    def test_data_disposition_rejects_a_canonical_home_that_is_not_configured(self):
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.compiler_only_policies(
+                manifest=self._data_manifest(canonical_module="arm9",
+                                             canonical_address="0x02009999"),
+                homes={"_ZTV4Pair": [("arm9", 0x02008000)]})
+        self.assertIn("which is not one of its configured ROM home(s)",
+                      raised.exception.output)
+
     def test_policy_keys_on_the_promoted_path_not_the_src_tu_path(self):
         """A promoted entry is enrolled under promoted_source.
 
@@ -223,7 +275,7 @@ class RomBuildEnrollment(unittest.TestCase):
                                       "reason": "homeless variant"}]}]}
         self.assertEqual(
             RB.compiler_only_policies({"src/actors/TU.cpp"}, manifest=manifest, homes={}),
-            {"src/actors/TU.cpp": {"deadstrip": ["_ZN1PD2Ev"], "expect": {}}})
+            {"src/actors/TU.cpp": {"deadstrip": ["_ZN1PD2Ev"], "expect": {}, "data": [], "homes": {}}})
 
     def test_compiler_only_policy_ignores_unenrolled_shadow_manifests(self):
         manifest = {"entries": [{

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1993,10 +1993,16 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
         {"symbol": "_ZN1DD2Ev", "disposition": "deadstrip",
          "reason": "compiler-generated D2; no ROM symbol or caller"}
 
-    A policy cannot hide a configured ROM symbol, a licensed function, a non-function,
-    a shared section, or anything a surviving relocation references.  objisolate owns
-    the ELF surgery; this layer owns the manifest/config facts.  With no policy, any
-    unlicensed function is an explicit refusal rather than linker-dependent behaviour.
+    A policy cannot hide a configured ROM symbol, a licensed function, a shared
+    section, or anything a surviving relocation references.  objisolate owns the ELF
+    surgery; this layer owns the manifest/config facts.  With no policy, any unlicensed
+    function is an explicit refusal rather than linker-dependent behaviour.
+
+    Data rows -- the ``_ZTV``/``_ZTI``/``_ZTS`` a key function drags in -- are validated
+    here and stripped by nobody.  This path links ONE TU on its own, where the class's
+    own vtable is the only definition in the link; only the ROM build has a cartridge
+    copy to fall back to, and only it discards them.  That is also exactly what every
+    unpromoted TU already does with its RTTI, so the scratch object is unchanged.
     """
     inv = elf_inventory(obj_bytes)
     licensed = {f["symbol"] for f in entry.get("functions", [])}
@@ -2004,8 +2010,11 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
     extras = {s["name"]: s for s in inv["symbols"]
               if s["type"] == "STT_FUNC" and not s["name"].startswith("$")
               and s["name"] not in licensed}
+    emitted_data = {s["name"] for s in inv["symbols"]
+                    if s["type"] == "STT_OBJECT" and not s["name"].startswith("$")
+                    and s["name"] not in licensed}
     policy = entry.get("compiler_only_output", [])
-    reasons, wanted, duplicates = [], [], set()
+    reasons, wanted, duplicates, data_rows = [], [], set(), []
     if policy is None:
         policy = []
     if not isinstance(policy, list):
@@ -2018,10 +2027,29 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
         if not sym:
             reasons.append(f"compiler_only_output[{i}] has no symbol")
             continue
-        if row.get("disposition") not in ("deadstrip", "deadstrip-duplicate"):
+        if row.get("disposition") not in ("deadstrip", "deadstrip-duplicate",
+                                          "deadstrip-data"):
             reasons.append(f"compiler_only_output {sym} has unsupported disposition "
-                           f"{row.get('disposition')!r}; expected deadstrip or "
-                           f"deadstrip-duplicate")
+                           f"{row.get('disposition')!r}; expected deadstrip, "
+                           f"deadstrip-duplicate or deadstrip-data")
+            continue
+        if sym in emitted_data:
+            if row.get("disposition") == "deadstrip-duplicate":
+                reasons.append(f"compiler_only_output {sym} is a data object; raw "
+                               f"duplicate-body evidence is function-only, so it takes "
+                               f"deadstrip-data (homed) or deadstrip (homeless)")
+            if not str(row.get("reason", "")).strip():
+                reasons.append(f"compiler_only_output {sym} needs a non-empty reason")
+            if sym in licensed:
+                reasons.append(f"compiler_only_output {sym} is also licensed by the "
+                               f"manifest")
+            if sym in dict(data_rows):
+                reasons.append(f"duplicate compiler_only_output policy for {sym}")
+            data_rows.append((sym, row.get("disposition")))
+            continue
+        if row.get("disposition") == "deadstrip-data":
+            reasons.append(f"compiler_only_output {sym} is declared compiler-only data "
+                           f"but the object emits no such data object")
             continue
         if row.get("disposition") == "deadstrip-duplicate":
             # The vague-linkage case: the symbol MUST have a ROM home that another
@@ -2051,17 +2079,27 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
         elif homes.get(sym):
             reasons.append(f"compiler_only_output {sym} has configured ROM home(s) "
                            f"{homes[sym]}; it is not compiler-only")
+    for sym, disposition in data_rows:
+        if disposition == "deadstrip-data":
+            if not homes.get(sym):
+                reasons.append(f"compiler_only_output {sym} is declared compiler-only "
+                               f"data but has no configured ROM home; a homeless "
+                               f"object is a plain deadstrip")
+        elif homes.get(sym):
+            reasons.append(f"compiler_only_output {sym} has configured ROM home(s) "
+                           f"{homes[sym]}; declare it deadstrip-data")
+    data = [sym for sym, _ in data_rows]
     if reasons:
-        return None, {"requested": wanted, "unhandled": unhandled}, reasons
+        return None, {"requested": wanted, "unhandled": unhandled, "data": data}, reasons
     if not wanted:
-        return obj_bytes, {"requested": [], "deadstripped": []}, []
+        return obj_bytes, {"requested": [], "deadstripped": [], "data": data}, []
 
     out, plan = OI.derive_deadstrip(obj_bytes, wanted)
     if out is None:
         return None, {"requested": wanted, "objisolate": plan}, \
             [f"compiler-only deadstrip refused: {plan.get('error')}"]
     return out, {"requested": wanted, "deadstripped": plan.get("dead", []),
-                 "droppedSections": plan.get("drop", [])}, []
+                 "droppedSections": plan.get("drop", []), "data": data}, []
 
 
 def manifest_externalized_output(entry):


### PR DESCRIPTION
Part 3 of the #1878 split, after #1977 (the duplicate-body policy) and #1979 (the
promotion that needed it). Tools only — no manifest row uses the new disposition yet,
so this build is expected to be byte-for-byte identical to main.

## The problem

Promoting a TU consolidates N one-function objects into one, which takes objisolate's
**intact multi-symbol path**: nothing may survive that the manifest has not licensed,
and `deadstrip_plan` accepted `STT_FUNC` only. A class's `_ZTV`/`_ZTI`/`_ZTS` are
`STT_OBJECT`, so the only way to promote a TU was to strip the destructor that makes
mwcc emit them — silently trading away the one thing that makes a vtable comparable to
the cartridge at all.

Measured on `ov100/daObjPathLift_c` (the TU #1979 just promoted): **14 ROM-data records
to 0.** No gate reports this. `rombuild`'s 106/106 is blind to vtables and
`romdata_check` is advisory, so every promotion so far has traded vtable coverage for
consolidation without anyone noticing — `ActorBase_SceneNode`, the first promoted TU,
emits no ROM-data records either.

## Three pieces

**1. `deadstrip_plan` accepts `STT_OBJECT`.** Data goes to `externalise`, not `dead` —
the destructor must go on storing the vptr — so a surviving section may reference one by
name, but only for the RTTI trio whose relocation shapes are surveyed, and never through
an unnamed section symbol.

mwcc's `_ZTV<C>` addresses the vtable *object*; `symbols.txt`'s **is** the slot array.
So a vptr store carries either the 8-byte preamble skip (a definition in this object —
correct it) or nothing at all (the source declared the ROM symbol directly, as
`daObjPathLift_c.cpp` does today with `extern int _ZTV10dBgActor_c[];` — leave it).
Anything strictly between the two is refused rather than guessed at. The plan names the
sections needing the correction in a new `rebase` key; plans without one keep the old
rule exactly.

**2. A new `deadstrip-data` disposition**, licensed on an **address** argument rather
than a byte-identity one. A promoted entry claims exact ranges; a data home *outside*
every one of them is content dsd delinks from the cartridge whatever this object emits,
so discarding the copy cannot cost the image a byte. A home *inside* a claimed range is
refused — that is a range the source undertook to build — and so is an entry that
declares no module of its own, which would otherwise clear the range test vacuously for
every address in the ROM.

Sound is not the same as right: a vtable whose slots disagree with the cartridge means
the class model is wrong, and quietly dropping it would bury that evidence in the very
file that produced it. So `romdata_check`'s relocation-resolved, word-by-word comparison
is made **binding** for exactly the symbols a policy row names, and run *before* the
surgery zeroes them. It stays advisory everywhere else. `PARTIAL` is the normal verdict
for a vtable — the ROM extent is distance-to-next-symbol, so a trailing alignment gap
that belongs to nobody shortens a fully-matching body — and only `DIFFERS` refuses.

**3. `deadstrip-duplicate`'s body proof was wrong, and this fixes it.** It compared raw
section bytes against the cartridge, which can only be right for a body with no
relocations: every `bl` and every vptr store holds an *addend* in the object and a
*linked address* in the image. A 4-byte `bx lr` (`_ZN7Vector3D1Ev`) is the only body
flat enough ever to have passed it; anything real would have been rejected. objisolate
now compares the words no relocation covers, and `rombuild._duplicate_body_reasons`
links the body through `linkcheck` and compares the ones it masked. Both halves are
checked now.

## Verification

- `pytest tools/test_objisolate.py tools/test_rombuild.py tools/test_tubuild.py` —
  98 passed, +12 new cases covering both accepted vptr spellings, the shape between
  them, the non-RTTI import refusal, function-only duplicate evidence, and all four
  `deadstrip-data` licence conditions.
- `python tools/rombuild.py -j 16` — **106/106 exact, 100.000000% of compared bytes,
  PASS**; 446 verified / 239 partial / 15 differ from 7,798 object records, identical
  to main.

## What comes next

The manifest PR that uses it restores `ov100/daObjPathLift_c`'s real destructor and
takes it from 0 to 14 ROM-data records — 12 named and checked against the cartridge,
360 bytes compared, 3 VERIFIED / 9 PARTIAL / 0 DIFFERS, including this class's own
128-byte `_ZTV15daObjPathLift_c` at `ov100:0x0214857c`. It has to be a separate PR
because the validator restores all of `tools/` from base, so no PR can test its own
tool change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
