### PR TITLE
Generate PathLift lifecycle and class data from C++

### DIFF
--- a/config/tu_manifest.d/ov100/daObjPathLift_c.json
+++ b/config/tu_manifest.d/ov100/daObjPathLift_c.json
@@ -84,6 +84,114 @@
       "reason": "include/types.h gives Vector3 a deliberately empty inline destructor, so every TU that destroys a Vector3 re-emits it as vague linkage. The cartridge keeps one copy at arm9:0x020072c0 and src/_ZN7Vector3D1Ev.cpp owns it; this object's copy is the identical 4-byte `bx lr` body and no surviving section here references it.",
       "canonical_module": "arm9",
       "canonical_address": "0x020072c0"
+    },
+    {
+      "symbol": "_ZN8PathLiftD0Ev",
+      "disposition": "deadstrip-duplicate",
+      "reason": "PathLift's destructor is defined inline in its header, so every TU that destroys one re-emits this body as vague linkage. The cartridge keeps a single copy at ov002:0x020ef320; rombuild proves this object's copy is that identical body before discarding it, and no surviving section here references it.",
+      "canonical_module": "ov002",
+      "canonical_address": "0x020ef320"
+    },
+    {
+      "symbol": "_ZN8PathLiftD1Ev",
+      "disposition": "deadstrip-duplicate",
+      "reason": "PathLift's destructor is defined inline in its header, so every TU that destroys one re-emits this body as vague linkage. The cartridge keeps a single copy at ov002:0x020ef390; rombuild proves this object's copy is that identical body before discarding it, and no surviving section here references it.",
+      "canonical_module": "ov002",
+      "canonical_address": "0x020ef390"
+    },
+    {
+      "symbol": "_ZTI10dBgActor_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo record for every class in daObjPathLift_c's chain, dBgActor_c included, as vague linkage. The cartridge keeps one copy at ov002:0x021089ec, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "ov002",
+      "canonical_address": "0x021089ec"
+    },
+    {
+      "symbol": "_ZTI15daObjPathLift_c",
+      "disposition": "deadstrip-data",
+      "reason": "Defining the destructor out of line is what makes this TU emit daObjPathLift_c's own typeinfo record. Before that, nothing in the build emitted it at all and the cartridge's copy at ov100:0x02148538 had nothing to be compared against. That address is data no delink entry reaches -- this entry claims .text 0x02146d7c-0x02147328 and nothing else -- so the linked image is identical whether or not this object contributes a copy, while the bytes still reach romdata_check on the way past. Recovering that comparison is the point of the policy.",
+      "canonical_module": "ov100",
+      "canonical_address": "0x02148538"
+    },
+    {
+      "symbol": "_ZTI7dBase_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo record for every class in daObjPathLift_c's chain, dBase_c included, as vague linkage. The cartridge keeps one copy at arm9:0x02086e78, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "arm9",
+      "canonical_address": "0x02086e78"
+    },
+    {
+      "symbol": "_ZTI7fBase_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo record for every class in daObjPathLift_c's chain, fBase_c included, as vague linkage. The cartridge keeps one copy at arm9:0x02086d70, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "arm9",
+      "canonical_address": "0x02086d70"
+    },
+    {
+      "symbol": "_ZTI8PathLift",
+      "disposition": "deadstrip",
+      "reason": "PathLift's typeinfo record, emitted as vague linkage by every TU that needs the hierarchy and named by no configured symbol in any module: the retail link folded it away. The only thing that references it is _ZTI15daObjPathLift_c, which this policy drops as well, so nothing surviving in this object reaches it."
+    },
+    {
+      "symbol": "_ZTI8dActor_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo record for every class in daObjPathLift_c's chain, dActor_c included, as vague linkage. The cartridge keeps one copy at arm9:0x0208e390, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "arm9",
+      "canonical_address": "0x0208e390"
+    },
+    {
+      "symbol": "_ZTS10dBgActor_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo name for every class in daObjPathLift_c's chain, dBgActor_c included, as vague linkage. The cartridge keeps one copy at ov002:0x02108a04, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "ov002",
+      "canonical_address": "0x02108a04"
+    },
+    {
+      "symbol": "_ZTS15daObjPathLift_c",
+      "disposition": "deadstrip-data",
+      "reason": "Defining the destructor out of line is what makes this TU emit daObjPathLift_c's own typeinfo name. Before that, nothing in the build emitted it at all and the cartridge's copy at ov100:0x02148544 had nothing to be compared against. That address is data no delink entry reaches -- this entry claims .text 0x02146d7c-0x02147328 and nothing else -- so the linked image is identical whether or not this object contributes a copy, while the bytes still reach romdata_check on the way past. Recovering that comparison is the point of the policy.",
+      "canonical_module": "ov100",
+      "canonical_address": "0x02148544"
+    },
+    {
+      "symbol": "_ZTS7dBase_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo name for every class in daObjPathLift_c's chain, dBase_c included, as vague linkage. The cartridge keeps one copy at arm9:0x02086e54, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "arm9",
+      "canonical_address": "0x02086e54"
+    },
+    {
+      "symbol": "_ZTS7fBase_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo name for every class in daObjPathLift_c's chain, fBase_c included, as vague linkage. The cartridge keeps one copy at arm9:0x02086e60, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "arm9",
+      "canonical_address": "0x02086e60"
+    },
+    {
+      "symbol": "_ZTS8PathLift",
+      "disposition": "deadstrip",
+      "reason": "PathLift's typeinfo name, emitted as vague linkage by every TU that needs the hierarchy and named by no configured symbol in any module: the retail link folded it away. The only thing that references it is _ZTI15daObjPathLift_c, which this policy drops as well, so nothing surviving in this object reaches it."
+    },
+    {
+      "symbol": "_ZTS8dActor_c",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the typeinfo name for every class in daObjPathLift_c's chain, dActor_c included, as vague linkage. The cartridge keeps one copy at arm9:0x0208e384, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "arm9",
+      "canonical_address": "0x0208e384"
+    },
+    {
+      "symbol": "_ZTV15daObjPathLift_c",
+      "disposition": "deadstrip-data",
+      "reason": "Defining the destructor out of line is what makes this TU emit daObjPathLift_c's own vtable. Before that, nothing in the build emitted it at all and the cartridge's copy at ov100:0x0214857c had nothing to be compared against. That address is data no delink entry reaches -- this entry claims .text 0x02146d7c-0x02147328 and nothing else -- so the linked image is identical whether or not this object contributes a copy, while the bytes still reach romdata_check on the way past. Recovering that comparison is the point of the policy.",
+      "canonical_module": "ov100",
+      "canonical_address": "0x0214857c"
+    },
+    {
+      "symbol": "_ZTV8PathLift",
+      "disposition": "deadstrip-data",
+      "reason": "Naming a key function makes mwcc emit the vtable for every class in daObjPathLift_c's chain, PathLift included, as vague linkage. The cartridge keeps one copy at ov002:0x0210af70, outside the only range this entry claims (.text 0x02146d7c-0x02147328), so dsd delinks it from the image whether or not this object contributes one and discarding this copy cannot cost the ROM a byte. romdata_check compares it against the cartridge word for word, relocations applied, before it is dropped.",
+      "canonical_module": "ov002",
+      "canonical_address": "0x0210af70"
     }
   ],
   "notes": [
@@ -105,9 +213,82 @@
     "criteria": {
       "every_declared_function_defined": "PASS",
       "every_declared_function_bytes_match": "PASS",
-      "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 1 unlicensed section/symbol(s); see unlicensed_output_observed",
+      "declared_function_set_equals_defined_function_set": "PASS",
       "functions_occur_in_expected_order": "PASS",
       "relocation_destinations_verified": "PASS"
+    },
+    "compilerOnlyOutput": {
+      "requested": [
+        "_ZN7Vector3D1Ev",
+        "_ZN8PathLiftD0Ev",
+        "_ZN8PathLiftD1Ev"
+      ],
+      "deadstripped": [
+        "_ZN7Vector3D1Ev",
+        "_ZN8PathLiftD0Ev",
+        "_ZN8PathLiftD1Ev"
+      ],
+      "droppedSections": [
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47
+      ],
+      "data": [
+        "_ZTI10dBgActor_c",
+        "_ZTI15daObjPathLift_c",
+        "_ZTI7dBase_c",
+        "_ZTI7fBase_c",
+        "_ZTI8PathLift",
+        "_ZTI8dActor_c",
+        "_ZTS10dBgActor_c",
+        "_ZTS15daObjPathLift_c",
+        "_ZTS7dBase_c",
+        "_ZTS7fBase_c",
+        "_ZTS8PathLift",
+        "_ZTS8dActor_c",
+        "_ZTV15daObjPathLift_c",
+        "_ZTV8PathLift"
+      ],
+      "dataExternalized": [
+        "_ZTI10dBgActor_c",
+        "_ZTI15daObjPathLift_c",
+        "_ZTI7dBase_c",
+        "_ZTI7fBase_c",
+        "_ZTI8PathLift",
+        "_ZTI8dActor_c",
+        "_ZTS10dBgActor_c",
+        "_ZTS15daObjPathLift_c",
+        "_ZTS7dBase_c",
+        "_ZTS7fBase_c",
+        "_ZTS8PathLift",
+        "_ZTS8dActor_c",
+        "_ZTV15daObjPathLift_c",
+        "_ZTV8PathLift"
+      ]
     }
   },
   "partial_isolation": {

--- a/include/daObjPathLift_c.h
+++ b/include/daObjPathLift_c.h
@@ -34,7 +34,7 @@ struct daObjPathLift_c : PathLift {
     s32 mGroundY;                /* 0x4ac */
     u8  mTimer;                /* 0x4b0 */
 
-    virtual ~daObjPathLift_c();
+    virtual ~daObjPathLift_c() {}
 
     int InitResources();
     int CleanupResources();

--- a/src/actors/daObjPathLift_c.cpp
+++ b/src/actors/daObjPathLift_c.cpp
@@ -324,60 +324,19 @@ void func_ov100_02146e70(void *c_) {
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 1 -- _ZN15daObjPathLift_cD0Ev, 0x02146dec, size 0x84 */
+/* ROM ordinals 0 and 1 -- the destructor group.                              */
+/*   _ZN15daObjPathLift_cD1Ev  0x02146d7c  size 0x70                          */
+/*   _ZN15daObjPathLift_cD0Ev  0x02146dec  size 0x84                          */
+/* Both come from the `~daObjPathLift_c() {}` in the header: the compiler     */
+/* writes the group, and only the INLINE form writes it in the cartridge's    */
+/* order. An out-of-line definition here emits D2, D0, D1 instead, which is   */
+/* why this class's destructor is declared with a body and defined nowhere    */
+/* in this file. mwcc still emits _ZTV15daObjPathLift_c for it, so the        */
+/* vtable and the RTTI records stay comparable to the cartridge -- see this   */
+/* TU's compiler_only_output rows, which check every one of them and then     */
+/* discard the copy dsd already delinks.                                     */
 /* -------------------------------------------------------------------------- */
-// @symbol _ZN15daObjPathLift_cD0Ev
-/* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
 #include "decl_dBgW_KcMbg.h"
 #include "decl_ShadowModel.h"
-/* decl_common.h dropped here too -- see the note at the top of this file. */
-/* recovered: renamed to Class_Method */
-extern "C" {
-extern void* data_020a0eac;
-
-
-void* _ZN15daObjPathLift_cD0Ev(char* p){
-  *(void***)p = (void**)data_ov100_0214857c;
-  _ZN11ShadowModelD1Ev(p+0x450);
-  *(void***)p = (void**)data_ov002_0210af70;
-  __destroy_arr(p+0x320, 3, 0x50, _ZN5ModelD1Ev);
-  *(void***)p = (void**)_ZTV10dBgActor_c;
-  _ZN10dBgW_KcMbgD1Ev(p+0x124);
-  _ZN5ModelD1Ev(p+0xd4);
-  _ZN8dActor_cD2Ev(p);
-  _ZN6Memory10DeallocateEPvP4Heap(p, data_020a0eac);
-  return p;
-}
-}
-
-/* -------------------------------------------------------------------------- */
-/* ROM ordinal 0 -- _ZN15daObjPathLift_cD1Ev, 0x02146d7c, size 0x70 */
-/* -------------------------------------------------------------------------- */
-// @symbol _ZN15daObjPathLift_cD1Ev
-/* recovered: vtable identified, declarations from a shared header
- *
- * NOT a real out-of-line `daObjPathLift_c::~daObjPathLift_c()`: that form
- * measured 999 differing words under 2004/b56 (build_pin), because PathLift's
- * own destructor (include/PathLift.h) is genuinely out-of-line -- unlike
- * dBgActor_c's, which is inline on purpose precisely so every subclass
- * inlines it -- so a real derived-class destructor would call
- * `_ZN8PathLiftD2Ev`, a symbol that does not exist in the ROM. The ROM
- * instead inlines PathLift's own cleanup directly here, exactly as this free
- * function under the mangled D1 name reproduces. `virtual ~daObjPathLift_c();`
- * in the header stays a declaration only -- nothing ever calls it through a
- * real `delete`, so the linker never needs a body, matching the
- * never-define-the-key-function idiom in include/dActor_c.h.
- */
-extern "C" int _ZN15daObjPathLift_cD1Ev(char* c){
-  *(int**)c=(int*)data_ov100_0214857c;
-  _ZN11ShadowModelD1Ev(c+0x450);
-  *(int**)c=(int*)data_ov002_0210af70;
-  __destroy_arr(c+0x320,3,0x50,_ZN5ModelD1Ev);
-  *(int**)c=(int*)_ZTV10dBgActor_c;
-  _ZN10dBgW_KcMbgD1Ev(c+0x124);
-  _ZN5ModelD1Ev(c+0xd4);
-  _ZN8dActor_cD2Ev(c);
-  return (int)c;
-}


### PR DESCRIPTION
Replace ov100/daObjPathLift_c's hand-written D1/D0 bodies with one inline class destructor. mwcc now emits the destructor group in the cartridge's D1,D0 order and restores the TU's compiler-generated vtables and RTTI.\n\nValidation: tubuild verify 8/8 exact and relocation-clean; romdata_check 14 objects (3 VERIFIED, 9 PARTIAL, 2 unnamed, 0 differing); rombuild 11,085/11,085 reproducing source functions, 106/106 modules exact, zero mismatches; port and attribution checks clean.\n\nThe required fail-closed class-data policy landed separately in #1987.