### PR TITLE
Fix: main cannot build the ROM -- accept a vptr store already in the ROM's vtable convention

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -560,9 +560,17 @@ def deadstrip_plan(raw, symbol_names, expect=None):
                                      f"{addend} from surviving data section "
                                      f"{source.name}"}
                 continue
-            if r["r_info_type"] != R_ARM_ABS32 or not (
-                    addend >= VTABLE_PREAMBLE if target.name.startswith("_ZTV")
-                    else addend == 0):
+            # Two spellings of a vptr store are legitimate and they differ by one
+            # preamble.  mwcc's `_ZTV<C>` addresses the vtable OBJECT, so a store
+            # against a definition in this object carries `+8` and must lose it once
+            # the definition is externalised.  A source that declares the ROM symbol
+            # itself (`extern int _ZTV10dBgActor_c[];`) is already using symbols.txt's
+            # convention, where the symbol IS the slot array: addend 0, nothing to
+            # correct, and `_apply` leaves it alone.  Anything strictly between the
+            # two is a shape this survey has not seen, and it is not guessed at.
+            shape = ((addend == 0 or addend >= VTABLE_PREAMBLE)
+                     if target.name.startswith("_ZTV") else addend == 0)
+            if r["r_info_type"] != R_ARM_ABS32 or not shape:
                 return {"error": f"{target.name}: unexpected reloc "
                                  f"type={r['r_info_type']} addend={addend}"}
             if addend:

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -242,6 +242,32 @@ class Isolate(unittest.TestCase):
         self.assertTrue(all(a < OI.VTABLE_PREAMBLE for a in after), after)
         self.assertEqual(sorted(a + OI.VTABLE_PREAMBLE for a in after), sorted(before))
 
+    def test_deadstrip_accepts_a_vptr_store_already_in_rom_convention(self):
+        """A source that declares the ROM symbol itself needs no preamble correction.
+
+        `extern int _ZTV10dBgActor_c[];` names symbols.txt's slot array, so the store
+        relocates with addend 0.  There is nothing to rebase, and refusing it would
+        reject every promoted TU that inherits a base's vtable rather than owning one.
+        """
+        obj = self.build("extern int _ZTVBase[]; struct Q { virtual ~Q(); }; "
+                         "Q::~Q(){ *(int**)this = _ZTVBase; } "
+                         "int helper(){ return 7; }")
+        raw = obj.read_bytes()
+        self.assertEqual(set(self._reloc_addends(raw, "_ZTVBase")), {0})
+
+        _out, plan = OI.derive_deadstrip(raw, ["_ZTV1Q"])
+        self.assertIsNone(plan["error"])
+        self.assertEqual(plan["externalise"], ["_ZTV1Q"])
+        self.assertEqual(set(self._reloc_addends(_out, "_ZTVBase")), {0},
+                         "an addend-0 reference is left exactly as it was")
+
+    def test_deadstrip_refuses_a_vptr_store_between_the_two_conventions(self):
+        """Neither spelling, so neither answer is safe; refuse rather than guess."""
+        raw = self.build(self.KEY_FUNCTION_CLASS).read_bytes()
+        raw = self._retarget_addend(raw, "_ZTV1B", 4)
+        _out, plan = OI.derive_deadstrip(raw, ["_ZTV1B"])
+        self.assertIn("unexpected reloc", plan["error"])
+
     def test_deadstrip_refuses_a_non_rtti_data_import(self):
         """Only the RTTI trio may be imported; anything else is an unsurveyed shape."""
         obj = self.build("int g_table[4] = {1,2,3,4}; int read(){ return g_table[2]; }")
@@ -254,6 +280,27 @@ class Isolate(unittest.TestCase):
         _out, plan = OI.derive_deadstrip(
             raw, ["_ZTV1B"], {"_ZTV1B": self._section_bytes(raw, "_ZTV1B")})
         self.assertIn("function-only", plan["error"])
+
+    def _retarget_addend(self, raw, target, value):
+        """A copy of `raw` with every code relocation against `target` given `value`."""
+        import io, struct
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+        out = bytearray(raw)
+        elf = ELFFile(io.BytesIO(raw))
+        secs = list(elf.iter_sections())
+        symtab = elf.get_section_by_name(".symtab")
+        endian = "<" if elf.little_endian else ">"
+        for sec in secs:
+            if not isinstance(sec, RelocationSection) or not sec.is_RELA():
+                continue
+            if not (secs[sec.header["sh_info"]].header["sh_flags"] & OI.SHF_EXECINSTR):
+                continue
+            for i, r in enumerate(sec.iter_relocations()):
+                if symtab.get_symbol(r["r_info_sym"]).name == target:
+                    struct.pack_into(endian + "i", out,
+                                     sec.header["sh_offset"] + i * 12 + 8, value)
+        return bytes(out)
 
     def _reloc_addends(self, raw, target):
         """Addends of every relocation against `target` from a surviving code section."""


### PR DESCRIPTION
## main cannot build the ROM

`python tools/rombuild.py -j 16` on `baa3d97ee` stops at step 3:

```
[3/6] mwccarm: 11077 enrolled source file(s), -j16
!! mwccarm failed (exit 1)
src/actors/daObjPathLift_c.cpp: isolate: compiler-only deadstrip refused:
  _ZTV10dBgActor_c: unexpected reloc type=2 addend=0
```

Reproduced on a clean detached checkout of `origin/main`. #1987 and #1979 are each
fine on their own; the break is in the pair. #1987 added a shape survey for the RTTI
relocations a promoted TU's surviving code makes, and #1979's promoted
`ov100/daObjPathLift_c` is the first source on main to exercise it.

## The cause

There are **two** legitimate spellings of a vptr store, and they differ by exactly one
vtable preamble. The survey accepted only one of them.

mwcc's `_ZTV<C>` addresses the vtable **object**, so a store against a definition in
the same object carries the 8-byte preamble skip, and has to lose it once that
definition is externalised — that is the case #1987 was written for, and it is right.

But a source may equally declare the ROM symbol itself. `daObjPathLift_c.cpp:79`:

```c
extern int _ZTV10dBgActor_c[];
...
*(void***)p = (void**)_ZTV10dBgActor_c;
```

That is `symbols.txt`'s convention, where the symbol **is** the slot array. The store
relocates with addend 0, there is nothing to correct, and `_apply` already leaves it
alone — its rewrite is keyed on `addend >= VTABLE_PREAMBLE`. The survey refused it
anyway, so the first promoted TU to *inherit* a base's vtable rather than own one took
the whole build down.

This is not specific to `daObjPathLift_c`. Every promoted TU whose class inherits its
vptr — the common case — spells it this way.

## The fix

Accept both spellings. Anything strictly *between* them is still refused rather than
guessed at, which is the point of having a survey at all.

```python
shape = ((addend == 0 or addend >= VTABLE_PREAMBLE)
         if target.name.startswith("_ZTV") else addend == 0)
```

Two tests: one builds a class whose destructor stores an extern `_ZTVBase`, asserts the
reference relocates at 0 and comes back out untouched; the other retargets a known-good
addend to 4 and asserts the refusal still fires.

## Verification

- `python tools/rombuild.py -j 16` — **106/106 exact, 100.000000% of compared bytes,
  PASS**; 446 verified / 239 partial / 15 differ from 7,798 object records.
- `pytest tools/test_objisolate.py tools/test_rombuild.py tools/test_tubuild.py` —
  99 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
