### PR TITLE
tools: add tu_promote and tu_order_check, the TU promotion pair

### DIFF
--- a/tools/agentlock.py
+++ b/tools/agentlock.py
@@ -18,14 +18,14 @@ each other's locks, since holder is the only ownership check (this is a local
 convenience lock, not an auth system).
 
 CLI:
-  python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp include/dActor_c.h --note "migrating Actor" [--ttl 1800] [--wait 60]
+  python tools/agentlock.py acquire --files src/actors/Actor.cpp include/dActor_c.h --note "migrating Actor" [--ttl 1800] [--wait 60]
   python tools/agentlock.py acquire --range ov006 0x020f0000 0x020f0100 --note "DetectClsn rewrite"
-  python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp --range ov006 0x020f0000 0x020f0100
-  python tools/agentlock.py renew   --files src_tu/actors/Actor.cpp include/dActor_c.h
+  python tools/agentlock.py acquire --files src/actors/Actor.cpp --range ov006 0x020f0000 0x020f0100
+  python tools/agentlock.py renew   --files src/actors/Actor.cpp include/dActor_c.h
   python tools/agentlock.py renew   --range ov006 0x020f0000 0x020f0100
-  python tools/agentlock.py release --files src_tu/actors/Actor.cpp include/dActor_c.h
+  python tools/agentlock.py release --files src/actors/Actor.cpp include/dActor_c.h
   python tools/agentlock.py release --range ov006 0x020f0000 0x020f0100 [--force]
-  python tools/agentlock.py check   --files src_tu/actors/Actor.cpp
+  python tools/agentlock.py check   --files src/actors/Actor.cpp
   python tools/agentlock.py check   --range ov006 0x020f0000 0x020f0100
   python tools/agentlock.py list    [--module ov006]
 """

--- a/tools/header_cpp_sweep.py
+++ b/tools/header_cpp_sweep.py
@@ -19,7 +19,8 @@ from the header) wearing three different disguises:
 
     dScene_c.h                 Bool BeforeInitResources();
                                ^ lifted from a `typedef int Bool;` that is file-local
-                                 to src/_ZN8dScene_c19BeforeInitResourcesEv.cpp
+                                 to the BeforeInitResources body, now in
+                                 src/actors/Scene.cpp
 
 None was found by a gate. Each was found by migrating a method, which compiles the block
 for the first time -- so the cost of finding them was one slice each. This tool finds

--- a/tools/marker_evidence.py
+++ b/tools/marker_evidence.py
@@ -702,7 +702,7 @@ _SKIP_MEMBER_TY = set(EH._W1) | set(EH._W2) | set(EH._W4) | set(EH._W8) | {"void
 def scan_local_layout(code, cls, origin, path):
     """A migrated file that declares its own layout IS a member-type table.
 
-    `src/_ZN3AmpD1Ev.cpp` says `struct Amp : Actor { ModelAnim m0; /* 0xd4 */ ... }`
+    `src/actors/Amp.cpp` says `struct Amp : Actor { ModelAnim m0; /* 0xd4 */ ... }`
     and that file byte-matches, so both the offsets and the class names in it are
     pinned by the ROM's own relocations.
     """
@@ -895,7 +895,7 @@ def main():
             return sizes[cls][0], sizes[cls][1]
         if cls in layout_sizes:
             n, k = layout_sizes[cls].most_common(1)[0]
-            # UPPER BOUND ONLY.  `src/_ZN8PoleLiftD1Ev.cpp` pads Model to 0x80 so the
+            # UPPER BOUND ONLY.  `src/actors/PoleLift.cpp` pads Model to 0x80 so the
             # next member lands at 0x158; the real class is 0x50 and the 0x30 between
             # them is unknown space.  Never let this override an assertion.
             return n, "inferred (UPPER BOUND) from %d local layout(s)" % k

--- a/tools/tu_order_check.py
+++ b/tools/tu_order_check.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Compile a manifest TU once and report, per licensed function, bytes and order.
+
+The question this answers is the one blocking the promotion program: a TU that
+defines its destructor OUT OF LINE makes mwcc emit ``D2, D0, D1``, while the ROM has
+``D1`` then ``D0`` and no ``D2`` at all. Production isolation places an object's
+``.text`` sections into the spanning delink in emission order, so the order is not
+cosmetic -- it decides whether the range links correctly.
+
+Changing the source form to fix the order (an inline in-class destructor plus a real
+instantiation) also changes what else the TU emits, so the two questions have to be
+asked together: does every function still reproduce its ROM bytes, AND are they
+emitted in ROM order. Running the whole ROM build to find out costs minutes; this
+costs one compile.
+
+    python tools/tu_order_check.py ov045/PoleLift ov002/Seaweed
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+from elftools.elf.elffile import ELFFile  # noqa: E402
+from elftools.elf.relocation import RelocationSection  # noqa: E402
+
+import rombuild as RB  # noqa: E402
+import tu_manifest as TUM  # noqa: E402
+import modules as MOD  # noqa: E402
+import relocs as RL  # noqa: E402
+
+_IMAGES = {}
+
+
+def rom_bytes(module, addr, size):
+    key = RL.normalize_module(module)
+    if key not in _IMAGES:
+        hit = next((m for m in MOD.modules()
+                    if RL.normalize_module(m["name"]) == key
+                    or (key == "arm9" and m["name"] == "main")), None)
+        _IMAGES[key] = (hit["bin"].read_bytes(), hit["base"]) if hit else None
+    img = _IMAGES[key]
+    if img is None:
+        return None
+    data, base = img
+    return data[addr - base:addr - base + size]
+
+
+def compile_tu(source, out):
+    src = REPO / source
+    flags = RB.CFLAGS
+    if src.read_text(encoding="utf-8", errors="ignore").startswith("//cpp"):
+        flags = flags.replace("-lang c99", "-lang c++")
+    proc = subprocess.run(
+        [*RB.launcher(), str(RB.MW / RB.VERSION / "mwccarm.exe"), *flags.split(),
+         "-i", str(REPO / "include"), "-c", str(src), "-o", str(out)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace")
+    return proc
+
+
+def sections_of(raw):
+    """[(index, name, bytes, {relocated word offsets})] for every .text section."""
+    elf = ELFFile(io.BytesIO(raw))
+    secs = list(elf.iter_sections())
+    symtab = elf.get_section_by_name(".symtab")
+    reloc_at = {}
+    for s in secs:
+        if isinstance(s, RelocationSection) and s.header["sh_size"]:
+            reloc_at.setdefault(s.header["sh_info"], set()).update(
+                r["r_offset"] for r in s.iter_relocations())
+    out = []
+    for i, s in enumerate(secs):
+        if not s.name.startswith(".text") or not s.header["sh_size"]:
+            continue
+        names = sorted({y.name for y in symtab.iter_symbols()
+                        if y.name and not y.name.startswith("$")
+                        and y["st_info"]["type"] != "STT_SECTION"
+                        and y["st_shndx"] == i})
+        out.append((i, names, bytes(s.data()), reloc_at.get(i, set())))
+    return out
+
+
+def compare(target, cand, relocated):
+    """Words differing, ignoring relocated words -- match.compare's own rule."""
+    if len(target) != len(cand):
+        return None
+    bad = 0
+    for off in range(0, len(target), 4):
+        if off in relocated:
+            continue
+        if target[off:off + 4] != cand[off:off + 4]:
+            bad += 1
+    return bad
+
+
+def duplicate_row(symbol, homes):
+    """A `deadstrip-duplicate` policy row for a vague-linkage symbol with one home."""
+    hits = homes.get(symbol) or []
+    if len(hits) != 1:
+        return None
+    module, addr = hits[0]
+    return {
+        "symbol": symbol,
+        "disposition": "deadstrip-duplicate",
+        "canonical_module": module,
+        "canonical_address": f"0x{addr:08x}",
+        "reason": (f"vague-linkage copy of {symbol}, re-emitted by every TU that needs "
+                   f"it; the cartridge keeps one at {module}:0x{addr:08x} and another "
+                   f"enrolled source owns it. rombuild proves this object's body "
+                   f"against the cartridge before discarding it."),
+    }
+
+
+def write_policy(entry, extra, homes):
+    """Add the compiler_only_output rows this TU's unlicensed output needs.
+
+    Only the two shapes with a mechanical justification are written: a homeless
+    variant (deadstrip) and a vague-linkage duplicate with exactly one configured home
+    (deadstrip-duplicate). Anything else is reported and left for a human, because the
+    reason column is the whole point of the schema.
+    """
+    rows = list(entry.get("compiler_only_output") or [])
+    have = {r.get("symbol") for r in rows}
+    added, skipped = [], []
+    for symbol in sorted(set(extra)):
+        if symbol in have:
+            continue
+        if homes.get(symbol):
+            row = duplicate_row(symbol, homes)
+            if row is None:
+                skipped.append(f"{symbol}: {len(homes[symbol])} configured homes")
+                continue
+        elif symbol.endswith("D2Ev"):
+            row = {"symbol": symbol, "disposition": "deadstrip",
+                   "reason": "compiler-generated D2 variant; the retail link discarded "
+                             "it, no ROM symbol names it, and nothing here references it"}
+        else:
+            skipped.append(f"{symbol}: no mechanical justification, write the row by hand")
+            continue
+        rows.append(row)
+        added.append(symbol)
+    if added:
+        entry["compiler_only_output"] = rows
+        path = REPO / "config" / "tu_manifest.d" / f"{entry['id']}.json"
+        import json
+        body = json.dumps(entry, indent=2, ensure_ascii=False) + chr(10)
+        path.write_text(body, encoding="utf-8", newline="")
+    return added, skipped
+
+
+def check(entry, tmp, policy=False, homes=None):
+    ident = entry["id"]
+    source = entry.get("source")
+    obj = tmp / (pathlib.Path(source).stem + ".o")
+    proc = compile_tu(source, obj)
+    if proc.returncode != 0 or not obj.is_file():
+        print(f"{ident}: COMPILE FAILED")
+        print("   " + (proc.stderr or proc.stdout or "").strip()[:800].replace("\n", "\n   "))
+        return False
+
+    module = entry["module"]
+    licensed = [(f["symbol"], int(f["address"], 16), int(f["size"], 16))
+                for f in entry["functions"]]
+    want = [s for s, _a, _z in licensed]
+    secs = sections_of(obj.read_bytes())
+    emitted, extra = [], []
+    body = {}
+    for _i, names, data, rel in secs:
+        for n in names:
+            (emitted if n in set(want) else extra).append(n)
+            body[n] = (data, rel)
+
+    print(f"{ident}:")
+    ok = True
+    for symbol, addr, size in licensed:
+        if symbol not in body:
+            print(f"   {'MISSING':9s} {symbol}")
+            ok = False
+            continue
+        data, rel = body[symbol]
+        target = rom_bytes(module, addr, size)
+        if target is None:
+            print(f"   {'NO IMAGE':9s} {symbol}")
+            ok = False
+            continue
+        if len(data) != size:
+            print(f"   {'SIZE':9s} {symbol}  rom 0x{size:x}, emitted 0x{len(data):x}")
+            ok = False
+            continue
+        bad = compare(target, data, rel)
+        if bad:
+            print(f"   {'DIFF':9s} {symbol}  {bad} word(s)")
+            ok = False
+    if emitted != want:
+        print(f"   ORDER     emitted {emitted}")
+        print(f"             wanted  {want}")
+        ok = False
+    if extra:
+        print(f"   EXTRA     {sorted(set(extra))}")
+        if policy:
+            added, skipped = write_policy(entry, extra, homes or {})
+            for symbol in added:
+                print(f"   POLICY    wrote a row for {symbol}")
+            for why in skipped:
+                print(f"   POLICY    skipped {why}")
+            if skipped:
+                ok = False
+            extra = [x for x in extra if x not in set(added)]
+    if ok and not extra:
+        print("   ALL MATCH, ROM order, nothing unlicensed")
+    elif ok:
+        print("   all match in ROM order; the extras above need a compiler-only policy")
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("ids", nargs="+", help="manifest entry id(s)")
+    ap.add_argument("--write-policy", action="store_true",
+                    help="add the compiler_only_output rows the unlicensed output needs")
+    args = ap.parse_args()
+    homes = RL.load_symbol_homes() if args.write_policy else {}
+    by_id = {e["id"]: e for e in TUM.load()["entries"]}
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    bad = 0
+    for ident in args.ids:
+        entry = by_id.get(ident)
+        if entry is None:
+            print(f"{ident}: no such manifest entry")
+            bad += 1
+            continue
+        if not check(entry, tmp, args.write_policy, homes):
+            bad += 1
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tu_promote.py
+++ b/tools/tu_promote.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Enroll a text-verified manifest TU into the production ROM build.
+
+Promotion changes NOTHING about codegen. Text-verification already proved every
+function's bytes and relocations from a single compile of the reconstructed source;
+promotion only changes which object the linker takes them from -- one TU instead of
+N per-function objects. That is the entire point: the cartridge's own build emitted
+each class's constructors and destructors from one translation unit, and while the
+tree carries a file per mangled symbol, every structor has to be hand-placed under a
+``// @symbol`` marker. Promoting the TU hands that job back to the compiler.
+
+The mechanical steps, all of which this performs and none of which it guesses at:
+
+* replace the entry's per-function ``delinks.txt`` entries with one ``complete``
+  entry spanning the manifest's sections;
+* ``git mv`` the ``src_tu/`` source to its ``promoted_source`` path (R100, so the
+  file's own credit follows) and ``git rm`` every ``legacy_source``;
+* rewrite the manifest entry to ``status: promoted`` with ``source`` at the
+  production path, matching the entries already enrolled;
+* add one ``attribution.json`` override per absorbed symbol, so a many-to-one
+  consolidation reads as "consolidated with credit intact" instead of N lost.
+
+It deliberately does NOT compile anything. The proof that a promotion is sound is
+``rombuild.py`` reporting 106/106 with ``mismatching: 0`` afterwards, and running it
+once over a batch is far cheaper than once per entry. Refusals here are only about
+facts that can be checked without a compiler: a missing file, a delinks entry that
+does not look the way the manifest says it does, a section span that does not cover
+the functions claimed inside it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import tu_manifest as TUM  # noqa: E402
+
+CONFIG = REPO / "config"
+
+
+class PromoteError(RuntimeError):
+    """A promotion was refused on a fact that needs no compiler to check."""
+
+
+def delinks_path(module):
+    """The delinks.txt for a manifest module name ("arm9" or "ovNNN")."""
+    if module in ("arm9", "main"):
+        return CONFIG / "arm9" / "delinks.txt"
+    return CONFIG / "arm9" / "overlays" / module / "delinks.txt"
+
+
+def _entry_re(source):
+    """One whole delinks entry: the path line plus its indented body."""
+    return re.compile(re.escape(source) + r":\n(?:[ \t]+[^\n]*\n)+\n?")
+
+
+def plan(entry):
+    """Everything the promotion will touch, or a PromoteError explaining why not."""
+    ident = entry.get("id", "<unknown>")
+    if entry.get("status") == "promoted":
+        raise PromoteError(f"{ident}: already promoted")
+    src = entry.get("source", "")
+    dest = entry.get("promoted_source", "")
+    if not src.startswith("src_tu/") or not dest.startswith("src/"):
+        raise PromoteError(f"{ident}: expected src_tu/ source and src/ promoted_source, "
+                           f"got {src!r} -> {dest!r}")
+    # MEASURED, not defensive: `ChillBully+daIDonketu_c.cpp` linked fine as a src_tu
+    # compile and then broke the whole ROM at the link --
+    #   mwldarm.exe: File not found: ChillBully
+    #   mwldarm.exe: Expecting: (
+    # because dsd writes bare, unquoted object names into the LCF and mwldarm's parser
+    # treats `+` as punctuation. src_tu/ names a multi-class TU with `+` and nothing
+    # ever links those, so the convention is safe exactly until promotion. No promoted
+    # source has ever carried one; keep it that way here, where it costs a second.
+    if not re.fullmatch(r"[A-Za-z0-9_./-]+", dest):
+        raise PromoteError(f"{ident}: {dest!r} has a character the linker command file "
+                           f"cannot carry unquoted; rename the file before promoting")
+    if not (REPO / src).is_file():
+        raise PromoteError(f"{ident}: {src} is not on disk")
+    if (REPO / dest).exists():
+        raise PromoteError(f"{ident}: {dest} already exists")
+
+    sections = [s for s in entry.get("sections", []) if s.get("name") == ".text"]
+    if not sections:
+        raise PromoteError(f"{ident}: no .text section in the manifest")
+    if entry.get("data") or entry.get("bss"):
+        # Production isolation zeroes an object's data and rebinds the symbols to the
+        # cartridge's addresses; a TU that OWNS delinked data is a different problem
+        # and is not what this path models.
+        raise PromoteError(f"{ident}: entry owns data/bss; not a text-only promotion")
+
+    funcs = entry.get("functions", [])
+    if not funcs:
+        raise PromoteError(f"{ident}: entry licenses no functions")
+    spans = [(int(s["start"], 16), int(s["end"], 16)) for s in sections]
+    legacy = []
+    for f in funcs:
+        addr, size = int(f["address"], 16), int(f["size"], 16)
+        if not any(lo <= addr and addr + size <= hi for lo, hi in spans):
+            raise PromoteError(f"{ident}: {f['symbol']} at 0x{addr:08x}+0x{size:x} "
+                               f"falls outside the manifest's .text span(s)")
+        source = f.get("legacy_source")
+        if not source:
+            raise PromoteError(f"{ident}: {f['symbol']} has no legacy_source")
+        if source not in legacy:
+            legacy.append(source)
+
+    dl = delinks_path(entry["module"])
+    if not dl.is_file():
+        raise PromoteError(f"{ident}: {dl} does not exist")
+    text = dl.read_text(encoding="utf-8")
+    for source in legacy:
+        n = len(_entry_re(source).findall(text))
+        if n != 1:
+            raise PromoteError(f"{ident}: {source} has {n} entries in "
+                               f"{dl.relative_to(REPO)}, expected exactly 1")
+    return {"id": ident, "source": src, "dest": dest, "delinks": dl,
+            "legacy": legacy, "spans": spans, "functions": funcs}
+
+
+def rewrite_delinks(p):
+    """N per-function entries out, one spanning entry in, in address order."""
+    text = p["delinks"].read_text(encoding="utf-8")
+    for source in p["legacy"]:
+        text = _entry_re(source).sub("", text, count=1)
+    body = "".join(f"    .text start:0x{lo:08x} end:0x{hi:08x}\n" for lo, hi in p["spans"])
+    entry = f"{p['dest']}:\n    complete\n{body}\n"
+    # Address order is not cosmetic: it is how a reader of delinks.txt finds the entry
+    # that owns an address, and dsd emits the file sorted.
+    after = min(hi for _lo, hi in p["spans"])
+    nxt = None
+    for m in re.finditer(
+            r"^[^\s:][^\n]*:\n[ \t]+complete\n[ \t]+\.text start:0x([0-9a-fA-F]{8})",
+            text, re.M):
+        if int(m.group(1), 16) >= after:
+            nxt = m
+            break
+    text = (text[:nxt.start()] + entry + text[nxt.start():]) if nxt \
+        else text.rstrip("\n") + "\n\n" + entry
+    p["delinks"].write_text(text, encoding="utf-8", newline="")
+
+
+def rewrite_manifest(entry, p):
+    entry["source"] = p["dest"]
+    entry["status"] = "promoted"
+    path = CONFIG / "tu_manifest.d" / f"{entry['id']}.json"
+    path.write_text(json.dumps(entry, indent=2, ensure_ascii=False) + "\n",
+                    encoding="utf-8", newline="")
+
+
+def rewrite_attribution(plans, lineage):
+    """One override per absorbed symbol, so the consolidation keeps its authors.
+
+    Without these, prepush_attribution reports every legacy basename as CREDIT LOST
+    and the merge gate needs a label to pass -- for a change that took nothing away
+    from anyone.
+    """
+    path = REPO / "attribution.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    ov = data.setdefault("overrides", {})
+    added = 0
+    for p in plans:
+        for f in p["functions"]:
+            stem = pathlib.PurePosixPath(f["legacy_source"]).stem
+            who = lineage.get(f"src/{stem}")
+            if not who:
+                continue
+            key = f"{p['dest']}#{f['symbol']}"
+            if key not in ov:
+                ov[key] = who
+                added += 1
+    data["overrides"] = dict(sorted(ov.items()))
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+                    encoding="utf-8", newline="")
+    return added
+
+
+def git(*args):
+    subprocess.run(["git", *args], cwd=REPO, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("ids", nargs="+", help="manifest entry id(s), e.g. ov045/PoleLift")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what each promotion would touch and change nothing")
+    args = ap.parse_args()
+
+    data = TUM.load()
+    by_id = {e["id"]: e for e in data["entries"]}
+    plans, entries, refused = [], [], []
+    for ident in args.ids:
+        entry = by_id.get(ident)
+        if entry is None:
+            refused.append(f"{ident}: no such manifest entry")
+            continue
+        try:
+            plans.append(plan(entry))
+            entries.append(entry)
+        except PromoteError as exc:
+            refused.append(str(exc))
+
+    for why in refused:
+        print(f"  refused  {why}")
+    if not plans:
+        print("tu_promote: nothing to promote.")
+        return 1 if refused else 0
+
+    for p in plans:
+        print(f"  promote  {p['id']:38s} {len(p['functions'])} function(s), "
+              f"{len(p['legacy'])} legacy source(s) -> {p['dest']}")
+    if args.dry_run:
+        print(f"tu_promote: {len(plans)} entry(ies) would be promoted (dry run).")
+        return 0
+
+    import prepush_attribution as PA
+    lineage = PA.lineage("HEAD")
+    for p, entry in zip(plans, entries):
+        rewrite_delinks(p)
+        # `git mv` will not create the destination directory, and a promoted_source
+        # may name one src/ does not have yet (src/stage/ was the first).
+        (REPO / p["dest"]).parent.mkdir(parents=True, exist_ok=True)
+        git("mv", p["source"], p["dest"])
+        for source in p["legacy"]:
+            git("rm", "-q", source)
+        rewrite_manifest(entry, p)
+    added = rewrite_attribution(plans, lineage)
+    print(f"tu_promote: {len(plans)} entry(ies) promoted, "
+          f"{sum(len(p['functions']) for p in plans)} function(s) consolidated, "
+          f"{added} attribution override(s) added.")
+    print("tu_promote: now run `python tools/rombuild.py -j16 --no-rom` -- "
+          "106/106 with mismatching 0 is the proof.")
+    return 1 if refused else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Lifted out of the #1880 → #1882 → #1884 → #1914 promotion chain, which bundled these two tools with the manifest rows and sources they produce. **The PR validator restores all of `tools/` from base, so no PR in that chain could ever test its own tool change** — every one of them is UNSTABLE, and #1880's `PR validation` failure is exactly this. Landing the tools alone, off main, lets the content PRs that follow be judged against tools that are already there.

## What's here

**`tu_order_check.py`** compiles a manifest TU once and reports, per licensed function, bytes and emission order. Production isolation places an object's `.text` into the spanning delink in emission order, so when a TU defines its destructor out of line and mwcc emits `D2, D0, D1` against the cartridge's `D1, D0`, the range does not link. This makes that visible *before* a promotion is attempted.

**`tu_promote.py`** performs the mechanical half of a promotion and guesses at nothing: collapse the per-function `delinks.txt` entries into one `complete` entry spanning the manifest's sections; `git mv` the `src_tu/` source to its production path (R100, so credit follows); `git rm` every `legacy_source`; rewrite the entry to `status: promoted`; add one `attribution.json` override per absorbed symbol. It compiles nothing — the proof of a promotion is `rombuild.py` reporting 106/106 with `mismatching: 0` over the whole batch.

The remaining three files are **comment-only**, correcting paths that promotion moves.

## What is deliberately NOT carried

The chain's `objisolate.py` / `rombuild.py` / `romdata_check.py` deltas. They are the *predecessor* of the deadstrip-data work that has since landed as #1977, #1987 and #1989; main's versions supersede them. Carrying them would revert main.

## Verification — against main at `c05617cf2`, not the chain's 350-commit-old base

- `tu_promote --dry-run ov002/BlueCoinSwitch ov002/Exit ov045/PoleLift` → all three resolve to their production paths; `ov100/daObjPathLift_c` is correctly refused as already promoted.
- `tu_order_check ov002/BlueCoinSwitch ov045/PoleLift` → compiles both, reports emitted `D0, D1` plus an extra `D2` against the wanted `D1, D0`.
- `pytest tools/test_objisolate.py test_rombuild.py test_tubuild.py test_romdata_check.py` → **107 passed**.
- `rombuild.py -j 16 --no-rom` → **106/106 exact, 100.000000%, mismatching: 0, PASS**, 7,812 ROM-data records — identical to main, as an additive tools change should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)