### PR TITLE
Fix stale tool example paths

### DIFF
--- a/tools/agentlock.py
+++ b/tools/agentlock.py
@@ -18,14 +18,14 @@ each other's locks, since holder is the only ownership check (this is a local
 convenience lock, not an auth system).
 
 CLI:
-  python tools/agentlock.py acquire --files src/actors/Actor.cpp include/dActor_c.h --note "migrating Actor" [--ttl 1800] [--wait 60]
+  python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp include/dActor_c.h --note "migrating Actor" [--ttl 1800] [--wait 60]
   python tools/agentlock.py acquire --range ov006 0x020f0000 0x020f0100 --note "DetectClsn rewrite"
-  python tools/agentlock.py acquire --files src/actors/Actor.cpp --range ov006 0x020f0000 0x020f0100
-  python tools/agentlock.py renew   --files src/actors/Actor.cpp include/dActor_c.h
+  python tools/agentlock.py acquire --files src_tu/actors/Actor.cpp --range ov006 0x020f0000 0x020f0100
+  python tools/agentlock.py renew   --files src_tu/actors/Actor.cpp include/dActor_c.h
   python tools/agentlock.py renew   --range ov006 0x020f0000 0x020f0100
-  python tools/agentlock.py release --files src/actors/Actor.cpp include/dActor_c.h
+  python tools/agentlock.py release --files src_tu/actors/Actor.cpp include/dActor_c.h
   python tools/agentlock.py release --range ov006 0x020f0000 0x020f0100 [--force]
-  python tools/agentlock.py check   --files src/actors/Actor.cpp
+  python tools/agentlock.py check   --files src_tu/actors/Actor.cpp
   python tools/agentlock.py check   --range ov006 0x020f0000 0x020f0100
   python tools/agentlock.py list    [--module ov006]
 """

--- a/tools/header_cpp_sweep.py
+++ b/tools/header_cpp_sweep.py
@@ -19,8 +19,7 @@ from the header) wearing three different disguises:
 
     dScene_c.h                 Bool BeforeInitResources();
                                ^ lifted from a `typedef int Bool;` that is file-local
-                                 to the BeforeInitResources body, now in
-                                 src/actors/Scene.cpp
+                                 to src/_ZN8dScene_c19BeforeInitResourcesEv.cpp
 
 None was found by a gate. Each was found by migrating a method, which compiles the block
 for the first time -- so the cost of finding them was one slice each. This tool finds

--- a/tools/marker_evidence.py
+++ b/tools/marker_evidence.py
@@ -702,9 +702,9 @@ _SKIP_MEMBER_TY = set(EH._W1) | set(EH._W2) | set(EH._W4) | set(EH._W8) | {"void
 def scan_local_layout(code, cls, origin, path):
     """A migrated file that declares its own layout IS a member-type table.
 
-    `src/actors/Amp.cpp` says `struct Amp : Actor { ModelAnim m0; /* 0xd4 */ ... }`
-    and that file byte-matches, so both the offsets and the class names in it are
-    pinned by the ROM's own relocations.
+    A byte-matching revision of `src/_ZN3AmpD1Ev.cpp` declared
+    `struct Amp : Actor { ModelAnim m0; /* 0xd4 */ ... }`, so both the offsets
+    and the class names in it are pinned by the ROM's own relocations.
     """
     texts = EH.find_struct_texts(code)
     if cls not in texts:
@@ -895,9 +895,10 @@ def main():
             return sizes[cls][0], sizes[cls][1]
         if cls in layout_sizes:
             n, k = layout_sizes[cls].most_common(1)[0]
-            # UPPER BOUND ONLY.  `src/actors/PoleLift.cpp` pads Model to 0x80 so the
-            # next member lands at 0x158; the real class is 0x50 and the 0x30 between
-            # them is unknown space.  Never let this override an assertion.
+            # UPPER BOUND ONLY.  A revision of `src/_ZN8PoleLiftD1Ev.cpp` padded
+            # Model to 0x80 so the next member landed at 0x158; the real class is
+            # 0x50 and the 0x30 between them is unknown space.  Never let this
+            # override an assertion.
             return n, "inferred (UPPER BOUND) from %d local layout(s)" % k
         return None, None
 

--- a/tools/tu_promote.py
+++ b/tools/tu_promote.py
@@ -227,7 +227,7 @@ def main():
     for p, entry in zip(plans, entries):
         rewrite_delinks(p)
         # `git mv` will not create the destination directory, and a promoted_source
-        # may name one src/ does not have yet (src/stage/ was the first).
+        # may name a directory under src/ that does not exist yet (as LevelObjects does).
         (REPO / p["dest"]).parent.mkdir(parents=True, exist_ok=True)
         git("mv", p["source"], p["dest"])
         for source in p["legacy"]:


### PR DESCRIPTION
Fix the five dead references introduced by #1990 by pointing examples at paths that exist on current main. The marker-evidence examples now say explicitly that they refer to byte-matching historical revisions. This is comment-only and leaves the dead-reference baseline unchanged. Validated with check_dead_references plus both dead-reference test suites.