### PR TITLE
Validation now runs the pull request's own tools/

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -10,7 +10,13 @@ name: PR validation
 # Uses pull_request_target so repo secrets (the relay token) are available even
 # for fork PRs. SAFE because this workflow never checks out or runs PR code — it
 # only sends the PR number + immutable head/base SHAs to the relay. The actual validation
-# happens on the self-hosted worker behind the maintainer's NAT, sandboxed there.
+# happens on the self-hosted worker behind the maintainer's NAT.
+#
+# Be clear about what that second half means, though: the worker DOES run this
+# branch's own `tools/`, deliberately, so that a pull request can exercise its own
+# tool change. That code runs in the worker's container -- never on a GitHub runner,
+# never with these secrets -- but a `tools/` diff on a fork PR deserves a read before
+# it is approved.
 #
 # The attribution-override label is a maintainer's "I know, and I meant it" for a PR
 # that moves contributor credit on purpose — attribution.json pins are exactly that.

--- a/notes/plan-cpp-conversion-queue.md
+++ b/notes/plan-cpp-conversion-queue.md
@@ -462,9 +462,19 @@ contend for. Conversely the merge's largest prizes (the 73 Tier-2 TUs, 1,338 fil
 218 provably-C++ files that this plan schedules none of, because the size cliff makes that
 pool all-or-nothing merge work, not conversion work.
 
-## 7. Tooling caveat
+## 7. Tooling (resolved)
 
-Both plans want new files in `tools/` (`tu_create.py`, `tu_preflight.py`). The validator
-**restores all of `tools/` from base**, so no PR can exercise its own tool change. These
-are local dev tools rather than gates, so that is survivable — but do not let a batch's
-correctness depend on a tool the validator will delete.
+Both plans want new files in `tools/` (`tu_create.py`, `tu_preflight.py`). This used
+to be a caveat: the validator **restored all of `tools/` from base**, so no PR could
+exercise its own tool change, and a batch whose correctness depended on a new tool
+was validated with that tool deleted.
+
+That is no longer true. The validator runs the **committed test merge** whole,
+`tools/` included, so a batch ships its tools and is validated by them. A tools-only
+PR is now a full base-vs-merge ROM comparison instead of a green no-op, which is
+exactly the evidence a byte-neutral `tu_create.py` change wants.
+
+Two things a batch still may not put in `tools/`: anything under `tools/mwccarm/`
+(the compiler is the operator's, and a commit there is refused outright), and a
+`config/rombuild-versions.txt` pin naming a compiler build the validator does not
+have installed (validated, refused with a reason, never silently replaced).


### PR DESCRIPTION
The validator used to check out all of `tools/` from the base commit after making the test merge, so no pull request could exercise its own tool change. Worse, `tools/` was not in the scope that decides whether a PR changed anything, so a tools-only PR got `noverify: no source/build-data changes in this PR` and a green check that had measured nothing — #1986 is exactly that.

Both halves are fixed in `sm64ds-validator`. The committed test merge runs whole, `tools/` included, and a tools-only PR is now a full base-vs-merge ROM comparison. This PR is only the two places in *this* repo that documented the old behaviour.

**`.github/workflows/pr-validate.yml`** — the `pull_request_target` safety argument is still correct about this workflow (it never checks out or runs PR code), but "sandboxed there" undersold what the worker does. It runs the branch's `tools/` on purpose. That happens in the worker's container, never on a GitHub runner and never with these secrets — but a `tools/` diff on a fork PR is worth reading before approving.

**`notes/plan-cpp-conversion-queue.md` §7** — said not to let a batch's correctness depend on a tool the validator will delete. It no longer will: a batch ships `tu_create.py` / `tu_preflight.py` and is validated by them.

Three things a merge still may not decide, all unchanged or newly enforced:

| | |
|---|---|
| `tools/mwccarm/`, `extracted/` | refused outright — the compiler and the bytes every verdict is compared against are the operator's, gitignored here, never committed |
| `config/rombuild-versions.txt` | validated against the installed compilers, never substituted |
| `config/arm9/config.yaml`, `config/rombuild-exclude.txt` | still restored from base, so a PR cannot narrow what is built and compared |

No code changes — comments and notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zcPKb3LNpLAJq4dH8NRf