### PR TITLE
Spell the TU-promotion metavariable as <Class>, unbreaking main's references gate

### DIFF
--- a/notes/converted-tier.md
+++ b/notes/converted-tier.md
@@ -197,7 +197,7 @@ volatile int vi; vi dummy;` would carry no `volatile` at the use site at all.
 
 `tools/tiers_ratchet.py` banks the SET of CONVERTED paths and fails when one
 leaves. A TU promotion consolidates N per-symbol `src/_ZN....cpp` files into the
-one `src/actors/X.cpp` they always were, which git records as N deletions plus one
+one `src/actors/<Class>.cpp` they always were, which git records as N deletions plus one
 addition. Every one read as
 
 ```sh

--- a/tools/tiers_ratchet.py
+++ b/tools/tiers_ratchet.py
@@ -31,7 +31,7 @@ WHY BACKSLIDE-ONLY, AND NOT A COUNT. Two reasons, and the second is the importan
 
 A PATH CAN LEAVE WITHOUT ANYTHING BEING LOST. The one legitimate way is a TU
 promotion: `tubuild.py` consolidates N per-symbol `src/_ZN....cpp` files into the one
-`src/actors/X.cpp` the original translation unit was, and git records N deletions plus
+`src/actors/<Class>.cpp` the original translation unit was, and git records N deletions plus
 one addition. A set ratchet reads all N as `GONE`. Measured on PR #1882
 (`tu/inline-dtor-order`, 9c6396c5f), 90 of 90 backslid paths were exactly that and
 none was a deletion, which is a report no one can read.
@@ -47,7 +47,7 @@ as a MOVE naming the `promoted_source` that absorbed it, and:
   * if it does not, that IS a backslide and still fails. The criteria are file-wide, so
     merging a clean function into a file with one bad line genuinely costs it its
     status, and the message says which criterion, e.g. "absorbed into
-    src/actors/X.cpp by TU promotion (ov100/daObjPathLift_c), which fails: Calls
+    src/actors/<Class>.cpp by TU promotion (ov100/daObjPathLift_c), which fails: Calls
     things by real names, not mangled _Z".
 
 A promotion is therefore never silently free. In practice it lands in the second case
@@ -144,7 +144,7 @@ def promoted_moves(root=None):
 
     A TU promotion is the one way a banked path legitimately stops existing without
     anything being deleted. `tubuild.py` consolidates N per-symbol `src/_ZN....cpp`
-    files into the single `src/actors/X.cpp` the original translation unit was, and
+    files into the single `src/actors/<Class>.cpp` the original translation unit was, and
     git records that as N deletions plus one addition -- so every one of the N banked
     paths reads to a set ratchet exactly like a file someone threw away. Measured on
     PR #1882 (`tu/inline-dtor-order`, 9c6396c5f): 90 of 90 backslid paths were TU


### PR DESCRIPTION
Main is currently **red on `dead references`** at `b6da5063f`. This fixes it.

## What broke

#2007 landed prose in `tools/tiers_ratchet.py` (3 sites) and `notes/converted-tier.md` (1 site) that names `src/actors/X.cpp` as a stand-in for *"whichever file the TU promotion absorbed the symbols into"*.

`check_dead_references` reads every repo-rooted path appearing in prose as a real reference, so it read the stand-in as a rename that failed to carry into the prose:

```
FAIL: 2 prose reference(s) name a path that does not exist:
  notes/converted-tier.md
      names `src/actors/X.cpp`, which is not in the tree
  tools/tiers_ratchet.py
      names `src/actors/X.cpp`, which is not in the tree
```

Every PR cut from main after `b6da5063f` inherits this red. It is not those PRs' fault and it should not be resolved in those PRs.

## The fix, and why not the baseline

Spelled `src/actors/<Class>.cpp`. `GLOBBY` in `check_dead_references.py:93` already skips any reference containing `<>`, so the gate stops reading it as a path — and a metavariable is what the sentence meant in the first place.

This is deliberately **not** `check_dead_references.py --update`. The escape hatch is for references that are genuinely historical or belong to another repo; this one is neither. It is prose that should be clearer, so it got clearer. Suppressing it would also have left the next reader thinking `src/actors/X.cpp` was a real file.

The sibling stand-in in the same paragraphs, `src/_ZN....cpp`, has always been skipped because `GLOBBY` also matches `...`. This makes the two consistent — previously one placeholder was invisible to the gate and the other was fatal to it, for no reason a reader could see.

The `src/actors/X.cpp` literals in `tools/test_tiers.py` are **untouched**: they are fixture values in code, not prose, and the gate never read them.

## Verification

```
check_dead_references        no new dead references   (133 unresolved, was 135)
pytest tools/test_tiers.py   29 passed
tiers_ratchet --check        PASS   baseline 2567   current 2567
port_refcheck                405 checked, all resolve
check_src_tu_compiles        88/88
```

Docs/tooling-prose only. No source file, no delinks entry, no symbol, no byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ