### PR TITLE
Correct two stale claims in tiers_ratchet.py's docstring

### DIFF
--- a/tools/tiers_ratchet.py
+++ b/tools/tiers_ratchet.py
@@ -81,19 +81,41 @@ TWO FAILURE MODES OF `langmode_audit.py` THIS IS BUILT NOT TO REPEAT
      file in the tree at a fixed path, readable and writable with no git plumbing, and
      `--baseline PATH` points anywhere for a CI job or a test.
 
-     In-tree is safe here in a way a COUNTER is not, because staleness only ever runs one
+     In-tree is safe here in a way a COUNTER is not, because staleness normally runs one
      way: `--check` fails on removals alone, so a baseline that has not caught up with
      newly converted files is permissive, never falsely red. No PR needs to re-bank in
      order to pass, so the baseline is not in every PR's diff and does not conflict the
      way a counter did. Re-bank it occasionally, on its own, to bank recent gains.
 
-NOT WIRED INTO ANYTHING YET -- deliberately. Do not add it to `tools/hooks/pre-push`.
-The langmode ratchet's pre-push wiring is the one that has been observed to get stuck,
-and a local hook that a contributor cannot get past is worse than no gate. The
-recommended next step is a CI-only job mirroring `.github/workflows/langmode-ratchet.yml`
-(checkout, setup-python, run `--check`), on `pull_request` paths `src/**`,
-`tools/tiers.py`, `tools/tiers_ratchet.py`, `config/converted-baseline.json`. Prove it
-does not get stuck across a few weeks of real PRs before anyone discusses a hook.
+     STALENESS HAS ONE EXCEPTION, AND IT COST A DAY. A path that LEAVES the tree fails
+     `--check` even when nothing regressed. Two ways that happens legitimately:
+
+       - TU promotion absorbs a file. `classify_missing()` handles this: it resolves the
+         gone path through `tools/tu_manifest.py` and reports
+         `MOVED -- absorbed into <file> by TU promotion (<tu_id>)`. When the absorbing
+         file is itself CONVERTED the removal is `absorbed_clean` -- no `--reason`, no
+         exception row. The banked COUNT drops, and that is correct; a promotion batch
+         is expected to lower it. There is no floor number to defend.
+
+       - A plain file rename. `classify_missing()` has NO rename detection, so a move
+         reports `GONE -- not a tracked source file any more` and demands a `--reason`,
+         which would write a permanent fake backslide row. Until that is fixed, apply
+         the renames to the parent's banked set FIRST, then regenerate.
+
+WIRED INTO CI, NOT INTO THE HOOK. `.github/workflows/converted-ratchet.yml` runs
+`--check` on `pull_request` and on `push: main`, over `src/**`, this file, `tiers.py`,
+`delaunder.py`, the TU manifest, and the baseline itself (that workflow's `on:` block is
+the authoritative list -- do not re-enumerate it here). It reads the baseline from the
+tree under test; there is no second checkout.
+
+Do NOT add it to `tools/hooks/pre-push`. The langmode ratchet's pre-push wiring is the
+one that has been observed to get stuck, and a local hook a contributor cannot get past
+is worse than no gate. Prove the CI job does not get stuck across a few weeks of real
+PRs before anyone discusses a hook.
+
+A CI red here is usually a BASE desync, not a regression: a PR cut before a re-bank
+lands merges against a baseline that predates it and inherits the red. Fix by merging
+main into the branch, never by lowering the pin.
 
 Usage:
     python tools/tiers_ratchet.py                 # summary; no exit-code meaning


### PR DESCRIPTION
Docstring only. `--check` still `PASS 2565/2565`; no behaviour change.

Both claims were introduced by me, and both actively mislead a reader:

**1. "NOT WIRED INTO ANYTHING YET -- deliberately."**

False since #2011, which added `.github/workflows/converted-ratchet.yml` (`pull_request` + `push: main`). An agent working #1993 read this line, concluded the gate was unwired, and spent a cycle on a theory that could not be true. Replaced with what the workflow actually does — and it points at that workflow's `on:` block as the authoritative path list rather than duplicating it here, since a duplicated list is the thing that goes stale next.

**2. "staleness only ever runs one way."**

False for two shapes, both of which cost real time this week.

- **TU promotion removes banked paths.** `classify_missing()` already handles it — resolves the gone path through `tools/tu_manifest.py` and reports `MOVED`; when the absorbing file is itself CONVERTED the removal is `absorbed_clean`, needing no `--reason` and logging no exception row. **The banked COUNT drops, and that is correct.** Stated explicitly because I circulated the opposite rule — *"the floor is 2565, never go below it"* — to three agents, and two of them had to come back with the source to correct me. This is a **SET** ratchet. There is no floor number to defend, and a promotion batch is expected to lower the count.

- **A plain file rename has no detection at all.** It reports `GONE -- not a tracked source file any more` and demands a `--reason`, which would write a permanent fake backslide row into `config/converted-backslide-exceptions.jsonl`. The workaround (apply the renames to the parent's banked set first, then regenerate) is now recorded in the docstring until real rename detection lands.

Also records the failure shape from #1996: a CI red here is usually a **base desync**, not a regression — a PR cut before a re-bank merges against a baseline that predates it, inherits the red, and the *next unrelated* `src/**` PR is the one that turns red for it. Fix is to merge main in, never to lower the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
