### PR TITLE
TU: fix stale legacy_source extensions in the manifest

### DIFF
--- a/config/tu_manifest.d/arm9/Actor.json
+++ b/config/tu_manifest.d/arm9/Actor.json
@@ -362,7 +362,7 @@
       "symbol": "_ZN8dActor_c13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j",
       "address": "0x020102b0",
       "size": "0x00000054",
-      "legacy_source": "src/_ZN8dActor_c13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j.c",
+      "legacy_source": "src/_ZN8dActor_c13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j.cpp",
       "ordinal": 48
     },
     {
@@ -397,7 +397,7 @@
       "symbol": "_ZN8dActor_c12ReflectAngleE5Fix12IiES1_s",
       "address": "0x02010428",
       "size": "0x00000034",
-      "legacy_source": "src/_ZN8dActor_c12ReflectAngleE5Fix12IiES1_s.c",
+      "legacy_source": "src/_ZN8dActor_c12ReflectAngleE5Fix12IiES1_s.cpp",
       "ordinal": 53
     },
     {
@@ -411,7 +411,7 @@
       "symbol": "_ZN8dActor_c15IsPlayerInRangeE5Fix12IiES1_S1_i",
       "address": "0x02010498",
       "size": "0x00000044",
-      "legacy_source": "src/_ZN8dActor_c15IsPlayerInRangeE5Fix12IiES1_S1_i.c",
+      "legacy_source": "src/_ZN8dActor_c15IsPlayerInRangeE5Fix12IiES1_S1_i.cpp",
       "ordinal": 55
     },
     {
@@ -453,7 +453,7 @@
       "symbol": "_ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs",
       "address": "0x02010714",
       "size": "0x00000130",
-      "legacy_source": "src/_ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs.c",
+      "legacy_source": "src/_ZN8dActor_c10SpawnCoinsERK7Vector3j5Fix12IiEs.cpp",
       "ordinal": 61
     },
     {
@@ -523,14 +523,14 @@
       "symbol": "_ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j",
       "address": "0x02010b9c",
       "size": "0x0000004c",
-      "legacy_source": "src/_ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j.c",
+      "legacy_source": "src/_ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j.cpp",
       "ordinal": 71
     },
     {
       "symbol": "_ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j",
       "address": "0x02010be8",
       "size": "0x00000048",
-      "legacy_source": "src/_ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j.c",
+      "legacy_source": "src/_ZN8dActor_c19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j.cpp",
       "ordinal": 72
     },
     {
@@ -670,7 +670,7 @@
       "symbol": "_ZN8dActor_cD0Ev",
       "address": "0x02011314",
       "size": "0x00000060",
-      "legacy_source": "src/_ZN8dActor_cD0Ev.c",
+      "legacy_source": "src/_ZN8dActor_cD0Ev.cpp",
       "ordinal": 92
     },
     {

--- a/config/tu_manifest.d/arm9/ActorDerived.json
+++ b/config/tu_manifest.d/arm9/ActorDerived.json
@@ -35,7 +35,7 @@
       "symbol": "_ZN7dBase_cD0Ev",
       "address": "0x02013ea4",
       "size": "0x00000038",
-      "legacy_source": "src/_ZN7dBase_cD0Ev.c",
+      "legacy_source": "src/_ZN7dBase_cD0Ev.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov002/Platform.json
+++ b/config/tu_manifest.d/ov002/Platform.json
@@ -37,7 +37,7 @@
       "symbol": "_ZN10dBgActor_c14KillByMegaCharER6Player",
       "address": "0x020ee4b0",
       "size": "0x000000ac",
-      "legacy_source": "src/_ZN10dBgActor_c14KillByMegaCharER6Player.c",
+      "legacy_source": "src/_ZN10dBgActor_c14KillByMegaCharER6Player.cpp",
       "ordinal": 2
     },
     {
@@ -93,7 +93,7 @@
       "symbol": "_ZN10dBgActor_cC2Ev",
       "address": "0x020eea50",
       "size": "0x00000034",
-      "legacy_source": "src/_ZN10dBgActor_cC2Ev.c",
+      "legacy_source": "src/_ZN10dBgActor_cC2Ev.cpp",
       "ordinal": 10
     }
   ],

--- a/config/tu_manifest.d/ov002/Warp.json
+++ b/config/tu_manifest.d/ov002/Warp.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN4WarpD0Ev",
       "address": "0x020ec3b8",
       "size": "0x00000044",
-      "legacy_source": "src/_ZN4WarpD0Ev.c",
+      "legacy_source": "src/_ZN4WarpD0Ev.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov009/CastleWater.json
+++ b/config/tu_manifest.d/ov009/CastleWater.json
@@ -22,14 +22,14 @@
       "symbol": "_ZN11CastleWaterD1Ev",
       "address": "0x02111a70",
       "size": "0x0000004c",
-      "legacy_source": "src/_ZN11CastleWaterD1Ev.c",
+      "legacy_source": "src/_ZN11CastleWaterD1Ev.cpp",
       "ordinal": 0
     },
     {
       "symbol": "_ZN11CastleWaterD0Ev",
       "address": "0x02111abc",
       "size": "0x00000060",
-      "legacy_source": "src/_ZN11CastleWaterD0Ev.c",
+      "legacy_source": "src/_ZN11CastleWaterD0Ev.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov009/Flag.json
+++ b/config/tu_manifest.d/ov009/Flag.json
@@ -29,14 +29,14 @@
       "symbol": "_ZN4FlagD0Ev",
       "address": "0x021120a8",
       "size": "0x00000044",
-      "legacy_source": "src/_ZN4FlagD0Ev.c",
+      "legacy_source": "src/_ZN4FlagD0Ev.cpp",
       "ordinal": 1
     },
     {
       "symbol": "_ZN4Flag16CleanupResourcesEv",
       "address": "0x021120ec",
       "size": "0x00000030",
-      "legacy_source": "src/_ZN4Flag16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN4Flag16CleanupResourcesEv.cpp",
       "ordinal": 2
     },
     {

--- a/config/tu_manifest.d/ov009/MetalNet.json
+++ b/config/tu_manifest.d/ov009/MetalNet.json
@@ -43,7 +43,7 @@
       "symbol": "_ZN8MetalNet16OnPendingDestroyEv",
       "address": "0x02111ea4",
       "size": "0x00000004",
-      "legacy_source": "src/_ZN8MetalNet16OnPendingDestroyEv.c",
+      "legacy_source": "src/_ZN8MetalNet16OnPendingDestroyEv.cpp",
       "ordinal": 3
     },
     {

--- a/config/tu_manifest.d/ov010/LightBeam.json
+++ b/config/tu_manifest.d/ov010/LightBeam.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN9LightBeamD0Ev",
       "address": "0x02111a08",
       "size": "0x0000004c",
-      "legacy_source": "src/_ZN9LightBeamD0Ev.c",
+      "legacy_source": "src/_ZN9LightBeamD0Ev.cpp",
       "ordinal": 1
     },
     {
@@ -43,7 +43,7 @@
       "symbol": "_ZN9LightBeam16CleanupResourcesEv",
       "address": "0x02111a94",
       "size": "0x00000024",
-      "legacy_source": "src/_ZN9LightBeam16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN9LightBeam16CleanupResourcesEv.cpp",
       "ordinal": 3
     },
     {

--- a/config/tu_manifest.d/ov010/PeachPainting.json
+++ b/config/tu_manifest.d/ov010/PeachPainting.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN13PeachPaintingD0Ev",
       "address": "0x02111e40",
       "size": "0x00000044",
-      "legacy_source": "src/_ZN13PeachPaintingD0Ev.c",
+      "legacy_source": "src/_ZN13PeachPaintingD0Ev.cpp",
       "ordinal": 1
     },
     {
@@ -43,7 +43,7 @@
       "symbol": "_ZN13PeachPainting16CleanupResourcesEv",
       "address": "0x02111ec4",
       "size": "0x00000024",
-      "legacy_source": "src/_ZN13PeachPainting16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN13PeachPainting16CleanupResourcesEv.cpp",
       "ordinal": 3
     },
     {

--- a/config/tu_manifest.d/ov014/ShutterBob.json
+++ b/config/tu_manifest.d/ov014/ShutterBob.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN10ShutterBobD0Ev",
       "address": "0x021111f0",
       "size": "0x00000064",
-      "legacy_source": "src/_ZN10ShutterBobD0Ev.c",
+      "legacy_source": "src/_ZN10ShutterBobD0Ev.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov019/IceSlideManager.json
+++ b/config/tu_manifest.d/ov019/IceSlideManager.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN15IceSlideManagerD0Ev",
       "address": "0x02112640",
       "size": "0x00000038",
-      "legacy_source": "src/_ZN15IceSlideManagerD0Ev.c",
+      "legacy_source": "src/_ZN15IceSlideManagerD0Ev.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov019/RacingPenguin.json
+++ b/config/tu_manifest.d/ov019/RacingPenguin.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN13RacingPenguinD0Ev",
       "address": "0x021111f0",
       "size": "0x00000064",
-      "legacy_source": "src/_ZN13RacingPenguinD0Ev.c",
+      "legacy_source": "src/_ZN13RacingPenguinD0Ev.cpp",
       "ordinal": 1
     },
     {
@@ -197,7 +197,7 @@
       "symbol": "_ZN13RacingPenguin16OnPendingDestroyEv",
       "address": "0x0211235c",
       "size": "0x00000004",
-      "legacy_source": "src/_ZN13RacingPenguin16OnPendingDestroyEv.c",
+      "legacy_source": "src/_ZN13RacingPenguin16OnPendingDestroyEv.cpp",
       "ordinal": 25
     },
     {

--- a/config/tu_manifest.d/ov020/HauntedChair.json
+++ b/config/tu_manifest.d/ov020/HauntedChair.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN12HauntedChairD0Ev",
       "address": "0x02112980",
       "size": "0x0000005c",
-      "legacy_source": "src/_ZN12HauntedChairD0Ev.c",
+      "legacy_source": "src/_ZN12HauntedChairD0Ev.cpp",
       "ordinal": 1
     },
     {
@@ -85,7 +85,7 @@
       "symbol": "_ZN12HauntedChair16CleanupResourcesEv",
       "address": "0x021132d8",
       "size": "0x00000024",
-      "legacy_source": "src/_ZN12HauntedChair16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN12HauntedChair16CleanupResourcesEv.cpp",
       "ordinal": 9
     },
     {

--- a/config/tu_manifest.d/ov029/CageLift.json
+++ b/config/tu_manifest.d/ov029/CageLift.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN8CageLiftD0Ev",
       "address": "0x02111b08",
       "size": "0x00000058",
-      "legacy_source": "src/_ZN8CageLiftD0Ev.c",
+      "legacy_source": "src/_ZN8CageLiftD0Ev.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov029/RotatingPlatformWdw.json
+++ b/config/tu_manifest.d/ov029/RotatingPlatformWdw.json
@@ -36,14 +36,14 @@
       "symbol": "_ZN19RotatingPlatformWdw16CleanupResourcesEv",
       "address": "0x02112134",
       "size": "0x00000014",
-      "legacy_source": "src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp",
       "ordinal": 2
     },
     {
       "symbol": "_ZN19RotatingPlatformWdw13InitResourcesEv",
       "address": "0x02112148",
       "size": "0x00000020",
-      "legacy_source": "src/_ZN19RotatingPlatformWdw13InitResourcesEv.c",
+      "legacy_source": "src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp",
       "ordinal": 3
     },
     {

--- a/config/tu_manifest.d/ov029/SwitchActivatedPlank.json
+++ b/config/tu_manifest.d/ov029/SwitchActivatedPlank.json
@@ -22,14 +22,14 @@
       "symbol": "_ZN20SwitchActivatedPlankD1Ev",
       "address": "0x02112630",
       "size": "0x0000004c",
-      "legacy_source": "src/_ZN20SwitchActivatedPlankD1Ev.c",
+      "legacy_source": "src/_ZN20SwitchActivatedPlankD1Ev.cpp",
       "ordinal": 0
     },
     {
       "symbol": "_ZN20SwitchActivatedPlankD0Ev",
       "address": "0x0211267c",
       "size": "0x00000060",
-      "legacy_source": "src/_ZN20SwitchActivatedPlankD0Ev.c",
+      "legacy_source": "src/_ZN20SwitchActivatedPlankD0Ev.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov029/WaterDiamond.json
+++ b/config/tu_manifest.d/ov029/WaterDiamond.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN12WaterDiamondD0Ev",
       "address": "0x02111760",
       "size": "0x0000004c",
-      "legacy_source": "src/_ZN12WaterDiamondD0Ev.c",
+      "legacy_source": "src/_ZN12WaterDiamondD0Ev.cpp",
       "ordinal": 1
     },
     {
@@ -57,7 +57,7 @@
       "symbol": "_ZN12WaterDiamond16CleanupResourcesEv",
       "address": "0x02111908",
       "size": "0x00000024",
-      "legacy_source": "src/_ZN12WaterDiamond16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN12WaterDiamond16CleanupResourcesEv.cpp",
       "ordinal": 5
     },
     {

--- a/config/tu_manifest.d/ov062/KoopaFlag.json
+++ b/config/tu_manifest.d/ov062/KoopaFlag.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN9KoopaFlagD0Ev",
       "address": "0x0211af70",
       "size": "0x0000004c",
-      "legacy_source": "src/_ZN9KoopaFlagD0Ev.c",
+      "legacy_source": "src/_ZN9KoopaFlagD0Ev.cpp",
       "ordinal": 1
     },
     {
@@ -43,7 +43,7 @@
       "symbol": "_ZN9KoopaFlag16CleanupResourcesEv",
       "address": "0x0211b000",
       "size": "0x00000030",
-      "legacy_source": "src/_ZN9KoopaFlag16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN9KoopaFlag16CleanupResourcesEv.cpp",
       "ordinal": 3
     },
     {

--- a/config/tu_manifest.d/ov077/Spiny.json
+++ b/config/tu_manifest.d/ov077/Spiny.json
@@ -29,7 +29,7 @@
       "symbol": "_ZN5SpinyD0Ev",
       "address": "0x02124bb4",
       "size": "0x00000064",
-      "legacy_source": "src/_ZN5SpinyD0Ev.c",
+      "legacy_source": "src/_ZN5SpinyD0Ev.cpp",
       "ordinal": 1
     },
     {
@@ -211,14 +211,14 @@
       "symbol": "_ZN5Spiny16CleanupResourcesEv",
       "address": "0x02125eb0",
       "size": "0x0000003c",
-      "legacy_source": "src/_ZN5Spiny16CleanupResourcesEv.c",
+      "legacy_source": "src/_ZN5Spiny16CleanupResourcesEv.cpp",
       "ordinal": 27
     },
     {
       "symbol": "_ZN5Spiny16OnPendingDestroyEv",
       "address": "0x02125eec",
       "size": "0x00000004",
-      "legacy_source": "src/_ZN5Spiny16OnPendingDestroyEv.c",
+      "legacy_source": "src/_ZN5Spiny16OnPendingDestroyEv.cpp",
       "ordinal": 28
     },
     {


### PR DESCRIPTION
## What

38 `functions[].legacy_source` values across 19 TU manifest entries still point at `src/<name>.c` when the file on disk is `src/<name>.cpp` — the file was migrated C -> C++ and the manifest row was never updated.

Each stale row blocks `tu_promote` on that entry: the promote path resolves `legacy_source` to a file that no longer exists.

## Derivation

Re-derived against current `origin/main` (`25cfc136`) by script, not carried over from an older tree. For every `config/tu_manifest.d/**/*.json`, every `legacy_source` ending in `.c` was checked against `git ls-tree -r --name-only origin/main`. A row counts as stale iff the `.c` path is **absent** and the `.cpp` sibling is **present**.

- Stale rows found: **38**, across **19** files.
- Inverse case (a `.cpp` `legacy_source` whose file is actually `.c`): **0** — nothing to fix there.
- No `data[].legacy_source` rows were affected; all 38 are under `functions[]`.

Re-running the same derivation after the change reports **0** stale rows.

## Entries changed

| entry | rows |
| --- | --- |
| `arm9/Actor.json` | 7 |
| `arm9/ActorDerived.json` | 1 |
| `ov002/Platform.json` | 2 |
| `ov002/Warp.json` | 1 |
| `ov009/CastleWater.json` | 2 |
| `ov009/Flag.json` | 2 |
| `ov009/MetalNet.json` | 1 |
| `ov010/LightBeam.json` | 2 |
| `ov010/PeachPainting.json` | 2 |
| `ov014/ShutterBob.json` | 1 |
| `ov019/IceSlideManager.json` | 1 |
| `ov019/RacingPenguin.json` | 2 |
| `ov020/HauntedChair.json` | 2 |
| `ov029/CageLift.json` | 1 |
| `ov029/RotatingPlatformWdw.json` | 2 |
| `ov029/SwitchActivatedPlank.json` | 2 |
| `ov029/WaterDiamond.json` | 2 |
| `ov062/KoopaFlag.json` | 2 |
| `ov077/Spiny.json` | 3 |

## Shape

Manifest JSON only — **no tooling, no source, no config outside `config/tu_manifest.d/`**. Applied as a targeted textual substitution of the specific `"legacy_source": "src/X.c"` strings rather than a `json.load`/`json.dump` round-trip, so indentation, key order and trailing newlines are byte-identical outside the 38 changed values.

`git diff --stat` is 19 files, 38 insertions, 38 deletions; every changed line pair is verified to be an exact `.c` -> `.cpp` swap on the same base name and nothing else.

`python tools/tu_manifest.py list` still succeeds and still reports 89 TUs, unchanged from main.

## Provenance

Salvaged from the closed PR #1884 — this is the one clean, mechanical win in it. It was **re-derived from current main rather than cherry-picked**, because #1884's row set was computed against a 411-commit-old tree. This supersedes the salvageable part of #1884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
