### PR TITLE
Refuse an RTTI/vtable record banked as a plain deadstrip

### DIFF
--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -700,6 +700,30 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
                                       f"source claims must be built, not discarded")
                     else:
                         data.append(symbol)
+            elif (disposition == "deadstrip"
+                  and symbol[:4] in ("_ZTI", "_ZTS", "_ZTV")):
+                # A plain ``deadstrip`` is the ONE disposition never compared
+                # against the cartridge: ``deadstrip-data`` reaches pol["data"]
+                # and ``deadstrip-duplicate`` reaches ``expect``; this reaches
+                # neither, and OI.derive_deadstrip simply zeroes the words.
+                #
+                # The guard below only fires when a home is configured, and a
+                # COINED class name has none.  ``homes`` is keyed on the
+                # spelling in symbols.txt, while an _ZTI/_ZTS record is a
+                # LENGTH-PREFIXED mangled string, so a coined name misses on
+                # both the prefix and the body.  That miss reads as "the ROM
+                # has no such record" -- false for every coined class -- and
+                # romdata_check.verify_data_symbol then returns UNNAMED/0
+                # bytes, so the romData ratchet does not move either.  Silent
+                # coverage loss, which is why every gate stays green.
+                errors.append(f"{source}: {symbol} is an RTTI/vtable record "
+                              f"banked as a plain deadstrip, which is never "
+                              f"compared against the cartridge. If the class "
+                              f"carries a coined name, rename it to the "
+                              f"cartridge's RTTI spelling so the row resolves "
+                              f"as deadstrip-data; if the ROM genuinely has no "
+                              f"such record, drop the row. Do not reword the "
+                              f"reason -- the reason is not what is checked")
             elif disposition == "deadstrip" and homes.get(symbol):
                 errors.append(f"{source}: {symbol} has configured ROM home(s) "
                               f"{homes[symbol]}; declare it deadstrip-duplicate (a "

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -167,6 +167,41 @@ class RomBuildEnrollment(unittest.TestCase):
             RB.compiler_only_policies(manifest=manifest, homes={}),
             {"src/Pair.cpp": {"deadstrip": ["_ZN4PairC2Ev"], "expect": {}, "data": [], "homes": {}}})
 
+    def test_plain_deadstrip_is_refused_for_an_rtti_record(self):
+        """The coverage hole this guard closes.
+
+        A plain ``deadstrip`` reaches neither ``pol["data"]`` nor ``expect``, so it
+        is the one disposition never compared against the cartridge.  The
+        ``homes.get(symbol)`` guard cannot catch it for a COINED class name: an
+        _ZTI/_ZTS record is a LENGTH-PREFIXED mangled string, so a coined spelling
+        misses symbols.txt on both the prefix and the body, and the miss reads as
+        "the ROM has no such record".  romdata_check then returns UNNAMED/0 bytes,
+        so the romData ratchet does not move either and every gate stays green.
+        """
+        for symbol in ("_ZTV4Pair", "_ZTI4Pair", "_ZTS4Pair"):
+            with self.subTest(symbol=symbol):
+                manifest = self._data_manifest(symbol=symbol,
+                                               disposition="deadstrip")
+                with self.assertRaises(RB.BuildError) as raised:
+                    RB.compiler_only_policies(manifest=manifest, homes={})
+                self.assertIn("never compared against the cartridge",
+                              raised.exception.output)
+
+    def test_plain_deadstrip_still_accepted_for_a_non_rtti_symbol(self):
+        """Control: the guard is scoped to RTTI/vtable records, nothing wider."""
+        manifest = {"entries": [{
+            "id": "arm9/Pair",
+            "source": "src/Pair.cpp",
+            "functions": [{"symbol": "First"}],
+            "compiler_only_output": [{
+                "symbol": "_ZN4PairC2Ev", "disposition": "deadstrip",
+                "reason": "compiler-generated constructor variant"
+            }]
+        }]}
+        self.assertEqual(
+            RB.compiler_only_policies(manifest=manifest, homes={})
+            ["src/Pair.cpp"]["deadstrip"], ["_ZN4PairC2Ev"])
+
     def test_duplicate_disposition_requires_a_rom_home(self):
         """The two dispositions have opposite preconditions, deliberately."""
         manifest = {"entries": [{

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -709,6 +709,54 @@ def test_compiler_only_policy_reduces_data_before_its_duplicate_destructors():
     assert report["dataExternalized"] == data
 
 
+def test_plain_deadstrip_is_refused_for_an_rtti_record():
+    """The intact-object mirror of the rombuild guard.
+
+    A plain ``deadstrip`` is the one disposition never compared against the
+    cartridge, and the ``elif homes.get(sym)`` arm below cannot catch a COINED
+    class name: ``homes`` is keyed on the symbols.txt spelling while _ZTI/_ZTS
+    are LENGTH-PREFIXED mangled strings, so a coined name misses on both the
+    prefix and the body and the miss reads as "the ROM has no such record".
+    This path must refuse on its own -- ``_isolate`` returns before rombuild's
+    copy of the guard ever runs.
+    """
+    if not _toolchain():
+        return
+    obj = _compile_tu_fixture(
+        "struct B { virtual ~B() {} };\n"
+        "struct D : B { virtual ~D() {} virtual void f(); };\n"
+        "void D::f() {}\n")
+    assert obj is not None
+    symbols = {s["name"]: s for s in tubuild.elf_inventory(obj)["symbols"]
+               if s["name"] and not s["name"].startswith("$")}
+    duplicates = sorted(n for n, s in symbols.items()
+                        if s["type"] == "STT_FUNC" and n.startswith("_ZN1BD"))
+    data = sorted(n for n, s in symbols.items()
+                  if s["type"] == "STT_OBJECT"
+                  and n.startswith(("_ZTV", "_ZTI", "_ZTS")))
+    assert data, "fixture must emit RTTI records"
+    licensed = sorted(n for n, s in symbols.items()
+                      if s["type"] == "STT_FUNC" and n not in duplicates)
+    policy = [
+        {"symbol": n, "disposition": "deadstrip-duplicate",
+         "reason": "vague base destructor with a canonical cartridge copy"}
+        for n in duplicates
+    ] + [
+        {"symbol": n, "disposition": "deadstrip", "reason": "no ROM symbol"}
+        for n in data
+    ]
+    homes = {n: [("arm9", 0x02010000 + i * 0x20)]
+             for i, n in enumerate(duplicates)}
+    entry = {"functions": [{"symbol": n} for n in licensed],
+             "data": [], "bss": [], "compiler_only_output": policy}
+
+    out, _report, reasons = tubuild.apply_compiler_only_policy(
+        obj, entry, homes=homes)
+    assert out is None
+    assert all(any(n in r and "never compared against the cartridge" in r
+                   for r in reasons) for n in data), reasons
+
+
 def test_unknown_id_fails_closed_with_a_clear_reason():
     code, out = _run("inspect", "ov999/NoSuchClass")
     assert code != 0

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2005,6 +2005,17 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
     inconsistent.  Reducing the whole declared compiler-only set in one plan both
     models production and lets objisolate prove that no retained section depends on
     content the policy removes.
+
+    A data row must say WHICH kind it is, and an RTTI/vtable record may not take the
+    plain ``deadstrip``.  "A policy cannot hide a configured ROM symbol" holds only
+    for symbols whose spelling reaches ``all_symbol_homes()``; a class carrying a
+    COINED name reaches nothing, because an _ZTI/_ZTS record is a length-prefixed
+    mangled string and a coined name misses on both the prefix and the body.  The
+    miss reads as "the ROM has no such record", which is exactly backwards, and a
+    plain ``deadstrip`` then reaches neither the duplicate-body proof nor the
+    cartridge word compare -- so the record is dropped unverified while every gate
+    stays green.  Rename the class to the cartridge's RTTI spelling (the row then
+    resolves as ``deadstrip-data`` and is compared) or drop the row.
     """
     inv = elf_inventory(obj_bytes)
     licensed = {f["symbol"] for f in entry.get("functions", [])}
@@ -2082,7 +2093,22 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
             reasons.append(f"compiler_only_output {sym} has configured ROM home(s) "
                            f"{homes[sym]}; it is not compiler-only")
     for sym, disposition in data_rows:
-        if disposition == "deadstrip-data":
+        if disposition == "deadstrip" and sym[:4] in ("_ZTI", "_ZTS", "_ZTV"):
+            # Mirrors the rombuild.py guard, and must: the intact-object path
+            # returns before rombuild's copy runs, so a guard there alone leaves
+            # this route uncovered.  A plain ``deadstrip`` is the one disposition
+            # never compared against the cartridge, and the ``elif homes.get(sym)``
+            # below cannot catch a COINED class name because ``homes`` is keyed on
+            # the symbols.txt spelling while _ZTI/_ZTS are LENGTH-PREFIXED mangled
+            # strings -- a coined name misses on both the prefix and the body, and
+            # the miss reads as "the ROM has no such record".
+            reasons.append(f"compiler_only_output {sym} is an RTTI/vtable record "
+                           f"banked as a plain deadstrip, which is never compared "
+                           f"against the cartridge. If the class carries a coined "
+                           f"name, rename it to the cartridge's RTTI spelling so "
+                           f"the row resolves as deadstrip-data; if the ROM "
+                           f"genuinely has no such record, drop the row")
+        elif disposition == "deadstrip-data":
             if not homes.get(sym):
                 reasons.append(f"compiler_only_output {sym} is declared compiler-only "
                                f"data but has no configured ROM home; a homeless "


### PR DESCRIPTION
Closes the one route by which this tree can stop comparing a vtable/RTTI record against the cartridge while every gate stays green. Filed as #2015; this is the patch.

## The hole

`compiler_only_output` has three dispositions, and only two of them are ever checked:

| disposition | where it lands | verified against the ROM? |
|---|---|---|
| `deadstrip-data` | `pol["data"]` → `_data_body_reasons` | **yes** — word-for-word compare |
| `deadstrip-duplicate` | `expect[symbol] = body` | **yes** — body proved |
| `deadstrip` | *nothing* | **no** — `OI.derive_deadstrip` zeroes the words |

A plain `deadstrip` is caught only by:

```python
elif disposition == "deadstrip" and homes.get(symbol):
```

and that arm is **vacuous for exactly the rows that need it**. `homes` comes from `relocs.load_symbol_homes()` — a flat `name → [(module, addr)]` map built from the checked-in `config/**/symbols.txt`. It never opens a ROM. An `_ZTI`/`_ZTS` record is a **length-prefixed** mangled string, so a class carrying a coined name misses on both the length prefix *and* the body. The miss reads as "the ROM has no such record", which is backwards for every coined class.

`romdata_check.verify_data_symbol` misses on the same spelling and returns `UNNAMED`/0 bytes, so the `romData` ratchet does not move either. That is why this is **silent coverage loss rather than a false ratchet gain** — nothing anywhere goes red.

## Why both copies

The intact-object path is a second copy of the same shape. `rombuild._isolate` returns before the `compiler_only` block, and policy is applied instead by `tubuild.apply_compiler_only_policy`, whose `elif homes.get(sym)` arm repeats the defect verbatim. A guard in `rombuild.py` alone leaves `--no-rom` and `--profile mods` uncovered — and `tu_promote.py:240` actively prints an instruction to run `--no-rom`.

## Measured no-op on the current tree

- Census of **all 90** manifest entries (active and inactive): `deadstrip: 23, deadstrip-data: 58, deadstrip-duplicate: 2`, and **zero** `_ZTI`/`_ZTS`/`_ZTV` rows banked as a plain `deadstrip`.
- `compiler_only_policies()` over the whole manifest refuses with the **identical single pre-existing message** with and without this change:
  `src/actors/WingFeather.cpp: _ZN7Vector3D1Ev has configured ROM home(s) [('arm9', 33583808)]; …`
  That row is a real latent problem in an inactive TU, unrelated to this guard, and it is left alone.

So this defends against regression; it fixes nothing currently broken. That is deliberate — the reason to land it now is #2015's inventory of **55** manifest TUs whose class name disagrees with the cartridge's RTTI spelling. All 55 are `text-verified` (none active), and **all 55 already have the ROM-name `_ZTI` configured**, so the fix for each is a free rename that makes the row resolve as `deadstrip-data`. Without this guard, promoting any of them banks an unverified record silently.

## Residual risk, stated plainly

The guard is a hard error with no escape hatch. If a class ever genuinely has no cartridge RTTI record, the row must be dropped rather than reworded. No such case exists in the current manifest (0/90), but a future one would hit this and need a deliberate decision — which is the intent: the failure is loud instead of silent.

## Tests

- `test_plain_deadstrip_is_refused_for_an_rtti_record` (rombuild) — subtests over `_ZTV`/`_ZTI`/`_ZTS`.
- `test_plain_deadstrip_still_accepted_for_a_non_rtti_symbol` — **control**, proves the guard is scoped to RTTI records and still admits a plain-deadstrip `_ZN4PairC2Ev`.
- `test_plain_deadstrip_is_refused_for_an_rtti_record` (tubuild) — compiles a real fixture, confirms it emits `_ZTI1B/_ZTI1D/_ZTS1B/_ZTS1D/_ZTV1B/_ZTV1D`, and asserts each is refused. Verified `_toolchain()` returns `True` so this does not self-skip.

`pytest tools/test_rombuild.py tools/test_tubuild.py tools/test_objisolate.py` → **102 passed**. Pre-push hook green, `check_src_tu_compiles: 89/89`.

The `apply_compiler_only_policy` docstring claimed "a policy cannot hide a configured ROM symbol". That holds only for spellings that reach `all_symbol_homes()`, so it is corrected rather than left to mislead the next reader.

Refs #2015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
