### PR TITLE
Prove WingFeather's Vector3 destructor against the cartridge

### DIFF
--- a/config/tu_manifest.d/ov002/WingFeather.json
+++ b/config/tu_manifest.d/ov002/WingFeather.json
@@ -162,8 +162,10 @@
     },
     {
       "symbol": "_ZN7Vector3D1Ev",
-      "disposition": "deadstrip",
-      "reason": "Vector3's own compiler-emitted empty destructor, pulled in by the two local Vector3 automatics in func_ov002_020b2c44; empty body, no relocations, no inbound relocation from any licensed function -- same policy-schema gap VirtualDoor/#1725 first hit for this type"
+      "disposition": "deadstrip-duplicate",
+      "reason": "include/types.h gives Vector3 a deliberately empty inline destructor, so every TU that destroys a Vector3 re-emits it as vague linkage -- here the two local Vector3 automatics in func_ov002_020b2c44 pull it in. The cartridge keeps one copy at arm9:0x020072c0 and src/_ZN7Vector3D1Ev.cpp owns it; this object's copy is the identical 4-byte `bx lr` body and no surviving section here references it. Previously banked as a plain deadstrip, which is the one disposition never compared against the cartridge; deadstrip-duplicate makes rombuild prove this body against the ROM's own before anything is discarded. Same fix ov100/daObjPathLift_c already carries for the same symbol.",
+      "canonical_module": "arm9",
+      "canonical_address": "0x020072c0"
     }
   ],
   "externalized_output": [


### PR DESCRIPTION
## What

`config/tu_manifest.d/ov002/WingFeather.json` banked `_ZN7Vector3D1Ev` as a plain
`deadstrip`. This flips it to `deadstrip-duplicate` with the cartridge's canonical
home, `arm9:0x020072c0`.

## Why it matters

`compiler_only_output` has three dispositions and only two are ever checked against
the cartridge:

| disposition | where it lands | proved against the ROM? |
|---|---|---|
| `deadstrip-data` | `pol["data"]` -> `_data_body_reasons` | yes, word-for-word |
| `deadstrip-duplicate` | `expect[symbol] = body` | yes, body compared |
| `deadstrip` (plain) | nothing | **no** -- `OI.derive_deadstrip` zeroes the words |

So the row as written asserted "discard this without looking". That is not an
argument against the row's *reason* -- the reason is accurate -- it is that the
reason is not what gets checked.

## The symbol is verifiable

`include/types.h` gives `Vector3` a deliberately empty inline destructor, so every
TU that destroys a `Vector3` re-emits it as vague linkage; here the two local
`Vector3` automatics in `func_ov002_020b2c44` pull it in. The cartridge keeps
exactly one copy at `arm9:0x020072c0`, `src/_ZN7Vector3D1Ev.cpp` owns it, and this
object's copy is the identical 4-byte `bx lr` body.

`config/tu_manifest.d/ov100/daObjPathLift_c.json` already carries the same symbol
the right way, and its `PROMOTED` note records the identical history:

> isolation refused the object over `_ZN7Vector3D1Ev`, four bytes of vague linkage
> with a ROM home that neither policy schema could license. `compiler_only_output`
> now carries it as disposition `deadstrip-duplicate`, with the cartridge's own body
> at `arm9:0x020072c0` checked against this object's copy before anything is
> discarded. 106/106 exact.

WingFeather's row is the stale spelling of a problem already solved.

## Evidence

`compiler_only_policies()` over all 90 manifest entries, before and after:

```
before:  REFUSED  src/actors/WingFeather.cpp: _ZN7Vector3D1Ev has configured ROM home(s)
after:   ACCEPTED, 22 sources, 0 refusals
```

That refusal was the only one left in the tree.

## Scope

One config file, +4/-2. No `src/`, no `include/`, no `delinks.txt`, no `symbols.txt`,
no tooling. `check_src_tu_compiles: 88/88`, `port_refcheck: 405 checked, 0 stale` on
the push.

## Related

#2019 adds the fail-closed guard that would have refused this row's *shape* at
config time. This PR fixes the one live instance; #2019 stops the next one. They are
independent and can land in either order.
