### PR TITLE
config: repoint 12 stale legacy_source rows left behind by symbol renames

### DIFF
--- a/config/tu_manifest.d/ov002/Enemy.json
+++ b/config/tu_manifest.d/ov002/Enemy.json
@@ -31,7 +31,7 @@
       "symbol": "func_ov002_020ada40",
       "address": "0x020ada40",
       "size": "0x00000100",
-      "legacy_source": "src/func_ov002_020ada40.cpp",
+      "legacy_source": "src/_ZN12dEnemyBase_c20KillByInvincibleCharERK10Vector3_16R6Player5Fix12IiE.cpp",
       "ordinal": 1
     },
     {

--- a/config/tu_manifest.d/ov010/PeachPainting.json
+++ b/config/tu_manifest.d/ov010/PeachPainting.json
@@ -36,7 +36,7 @@
       "symbol": "func_ov010_02111e84",
       "address": "0x02111e84",
       "size": "0x00000040",
-      "legacy_source": "src/func_ov010_02111e84.c",
+      "legacy_source": "src/_ZN13PeachPainting20UpdateModelTransformEv.cpp",
       "ordinal": 2
     },
     {

--- a/config/tu_manifest.d/ov020/HauntedChair.json
+++ b/config/tu_manifest.d/ov020/HauntedChair.json
@@ -36,49 +36,49 @@
       "symbol": "func_ov020_021129dc",
       "address": "0x021129dc",
       "size": "0x00000124",
-      "legacy_source": "src/func_ov020_021129dc.c",
+      "legacy_source": "src/_ZN12HauntedChair6State3Ev.cpp",
       "ordinal": 2
     },
     {
       "symbol": "func_ov020_02112b00",
       "address": "0x02112b00",
       "size": "0x00000394",
-      "legacy_source": "src/func_ov020_02112b00.c",
+      "legacy_source": "src/_ZN12HauntedChair6State2Ev.cpp",
       "ordinal": 3
     },
     {
       "symbol": "func_ov020_02112e94",
       "address": "0x02112e94",
       "size": "0x00000234",
-      "legacy_source": "src/func_ov020_02112e94.c",
+      "legacy_source": "src/_ZN12HauntedChair6State1Ev.cpp",
       "ordinal": 4
     },
     {
       "symbol": "func_ov020_021130c8",
       "address": "0x021130c8",
       "size": "0x00000080",
-      "legacy_source": "src/func_ov020_021130c8.c",
+      "legacy_source": "src/_ZN12HauntedChair6State0Ev.cpp",
       "ordinal": 5
     },
     {
       "symbol": "func_ov020_02113148",
       "address": "0x02113148",
       "size": "0x000000b0",
-      "legacy_source": "src/func_ov020_02113148.c",
+      "legacy_source": "src/_ZN12HauntedChair18ApproachStateValueEPsS0_isis.cpp",
       "ordinal": 6
     },
     {
       "symbol": "func_ov020_021131f8",
       "address": "0x021131f8",
       "size": "0x00000048",
-      "legacy_source": "src/func_ov020_021131f8.c",
+      "legacy_source": "src/_ZN12HauntedChair5BreakEv.cpp",
       "ordinal": 7
     },
     {
       "symbol": "func_ov020_02113240",
       "address": "0x02113240",
       "size": "0x00000098",
-      "legacy_source": "src/func_ov020_02113240.cpp",
+      "legacy_source": "src/_ZN12HauntedChair11UpdateModelEv.cpp",
       "ordinal": 8
     },
     {

--- a/config/tu_manifest.d/ov029/WaterDiamond.json
+++ b/config/tu_manifest.d/ov029/WaterDiamond.json
@@ -36,21 +36,21 @@
       "symbol": "func_ov029_021117ac",
       "address": "0x021117ac",
       "size": "0x000000a4",
-      "legacy_source": "src/func_ov029_021117ac.cpp",
+      "legacy_source": "src/_ZN12WaterDiamond19CheckClsnWithPlayerEv.cpp",
       "ordinal": 2
     },
     {
       "symbol": "func_ov029_02111850",
       "address": "0x02111850",
       "size": "0x00000078",
-      "legacy_source": "src/func_ov029_02111850.cpp",
+      "legacy_source": "src/_ZN12WaterDiamond10SetWaterIDEv.cpp",
       "ordinal": 3
     },
     {
       "symbol": "func_ov029_021118c8",
       "address": "0x021118c8",
       "size": "0x00000040",
-      "legacy_source": "src/func_ov029_021118c8.c",
+      "legacy_source": "src/_ZN12WaterDiamond20UpdateModelTransformEv.cpp",
       "ordinal": 4
     },
     {


### PR DESCRIPTION
## What this is

`legacy_source` on a TU-manifest function row names the per-function `src/` file that
function is delinked from. When a `func_ovNNN_AAAAAAAA` symbol is later **named**, the
delinks entry and the file get renamed together to the mangled spelling — but the
manifest row does not, so its `legacy_source` keeps pointing at a path that no longer
exists. #2016 fixed the rows whose `.c` had become a `.cpp`. This is the residue: rows
where **neither** extension exists, because the stem itself changed.

## Derivation

Across the 89 entries in `config/tu_manifest.d/**/*.json` there are **1108**
`legacy_source` rows (only `functions` rows carry the field — `data` and `bss` never
do). Classified against `git ls-tree -r origin/main`:

| class | before | after |
|---|---|---|
| stale — `.c` row, `.cpp` on disk | 0 | 0 |
| inverse — `.cpp` row, `.c` on disk | 0 | 0 |
| **dangling — neither present** | **80** | **68** (all deliberate, see below) |

## Address-resolution rule

For each dangling row, parse the module's `config/arm9/overlays/<mod>/delinks.txt`
(`config/arm9/delinks.txt` for `arm9`) and take the entry whose section range **starts
at the row's `address`**. Never guessed from the symbol name.

All 12 rows fixed here resolved to **exactly one** entry, and every match was exact on
*both* ends — `start == address` **and** `end == address + size` — with the entry still
marked `complete`. No range moved; none was handed back to the cartridge. This is stale
bookkeeping, not lost coverage.

| entry | before | after | fixed |
|---|---|---|---|
| `ov020/HauntedChair` | 7 | 0 | 7 |
| `ov029/WaterDiamond` | 3 | 0 | 3 |
| `ov010/PeachPainting` | 1 | 0 | 1 |
| `ov002/Enemy` | 1 | 0 | 1 |
| `ov070/daKrpa_c` (promoted) | 25 | 25 | — |
| `ov070/daKpFr_c` (promoted) | 21 | 21 | — |
| `ov100/daObjPathLift_c` (promoted) | 8 | 8 | — |
| `ov002/daObjAbuku_c` (promoted) | 7 | 7 | — |
| `arm9/ActorDerived` (promoted) | 5 | 5 | — |
| `arm9/ActorBase_SceneNode` (promoted) | 2 | 2 | — |
| **total** | **80** | **68** | **12** |

Representative resolution:

```
ov020/HauntedChair  func_ov020_021129dc  0x021129dc + 0x124
  delinks ov020: src/_ZN12HauntedChair6State3Ev.cpp  complete  .text 0x021129dc-0x02112b00
  legacy_source: src/func_ov020_021129dc.c  ->  src/_ZN12HauntedChair6State3Ev.cpp
```

## The promoted entries are deliberately left alone (68 of the 80)

All six `promoted` entries in the manifest are **100% dangling** — every row, not some.
None is mixed, so leaving them untouched is fully self-consistent per entry, and there
is no other promoted entry establishing a different convention to match.

Dangling there is the **designed terminal state**, not a defect:

- `notes/translation-unit-reconstruction-plan.md` §6 lists the field as
  *"legacy source paths to remove on promotion"*.
- `tools/tu_promote.py` `git rm`s every `legacy_source` as part of promoting, and
  replaces the N per-function delinks entries with one spanning `complete` entry at
  `promoted_source`. It rewrites `status` and `source` and deliberately leaves
  `legacy_source` as the historical record.

Repointing them would also be **actively harmful**: `tu_promote.rewrite_attribution`
writes one attribution override per absorbed symbol, keyed off the legacy path's
*stem* (`lineage.get("src/" + stem)`). Collapsing 25 distinct stems onto one TU path
would destroy that 1:1 symbol→author mapping.

Resolving them by address confirms the reading: **only the first function of each
promoted TU resolves at all** — its address is the promoted span's start and it maps to
`promoted_source` (e.g. `_ZN8daKrpa_cD1Ev` @ `0x02121118` → `src/actors/daKrpa_c.cpp`
`.text 0x02121118-0x02121b48`). The other 62 interior addresses are no longer entry
starts, exactly as promotion intends.

## Post-change verification

Re-derived on the resulting tree via `python tools/tu_manifest.py export`:

- dangling **68**, all on `promoted` entries, named individually above — the set
  deliberately left;
- stale **0**, inverse **0** — unchanged;
- **every** `legacy_source` on a non-promoted entry resolves to a path that exists;
- no duplicate `legacy_source` introduced within any entry;
- each of the 12 new paths has **exactly one** entry in its `delinks.txt` — the
  precondition `tu_promote.py` checks, which a dangling row would have failed. Fixing
  these unblocks promotion for these four entries.

## No delinks / symbols / relocs / src / src_tu / include / tools changes

```
 config/tu_manifest.d/ov002/Enemy.json         |  2 +-
 config/tu_manifest.d/ov010/PeachPainting.json |  2 +-
 config/tu_manifest.d/ov020/HauntedChair.json  | 14 +++++++-------
 config/tu_manifest.d/ov029/WaterDiamond.json  |  6 +++---
 4 files changed, 12 insertions(+), 12 deletions(-)
```

12 changed lines, one per row, patched **in place** — the 2-space indent, LF endings
and trailing newline are byte-preserved and no unrelated line reflows. Nothing here is
a gate input, so no rebuild is implied. Pre-push passed unaided (`port_refcheck` 405
references, `duplicate-sources` 11250 stems, `check_src_tu_compiles` 89/89).

## Unrelated pre-existing finding (not touched here)

While asserting the `tu_promote` precondition tree-wide, one row outside the 80 fails
it: **`ov009/Bird` → `func_ov009_0211145c`**. Its `legacy_source`
`src/func_ov009_0211145c.c` *does* exist on disk, but has **zero** entries in
`config/arm9/overlays/ov009/delinks.txt` — there is a gap at `0x0211145c-0x021115d8`
(0x17c bytes, exactly the manifest's declared size) between the entries ending and
starting on either side. So the manifest licenses a range that is still handed back to
the cartridge. It predates this branch (also absent on `origin/main`) and fixing it
would mean touching `delinks.txt`, so it is out of scope here — flagging it for a
follow-up. Tree-wide, 105 `src/` files are unenrolled in any `delinks.txt`, but the
other 104 are SDK/BIOS stubs (`CpuFastSet.c`, `BitUnPack.c`, …) that no manifest row
claims; this is the only one a manifest entry points at.
