### PR TITLE
Let unittest import test_dead_references and test_pr_monitor

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -33,14 +33,19 @@
 #      it is a different change from this one, and it should come with a requirements
 #      file rather than a version invented in a `run:` line.
 #
-#   3. RED ON MAIN RIGHT NOW. `python -m unittest tools.test_dead_references` and
-#      `tools.test_pr_monitor` both fail on a clean origin/main with ImportError -- they
-#      use bare `from check_dead_references import ...` / `from pr_monitor import ...`,
-#      which only resolves with `tools/` on sys.path. Both are PYTEST modules that pass
-#      when invoked as `python tools/test_X.py` (their __main__ calls pytest.main), so
-#      this is an invocation mismatch, not a broken tool. They are named here rather
-#      than fixed: repairing them is a `tools/` change and this workflow deliberately
-#      touches nothing but itself.
+#   3. PYTEST-ONLY, SO UNITTEST CANNOT SEE THEM. test_dead_references (24 tests) and
+#      test_pr_monitor (4) used to fail on a clean origin/main with ImportError -- they
+#      used bare `from check_dead_references import ...` / `from pr_monitor import ...`,
+#      which only resolves with `tools/` on sys.path. That import is fixed now (they
+#      carry the same `sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))`
+#      bootstrap that 38 other test modules in `tools/` already spell verbatim), but
+#      fixing it does NOT make them wirable: both are pytest-style -- bare
+#      `class TestX:` and bare `def test_*()`, no unittest.TestCase anywhere -- so
+#      `python -m unittest tools.test_dead_references` now prints "Ran 0 tests ... OK"
+#      and exits 0. Adding them to the list below would buy 28 tests' worth of nothing.
+#      They are two of the eleven modules described in the next paragraph, and wiring
+#      them means converting them to TestCase classes, which is a real change to the
+#      tests rather than to how they are invoked.
 #
 # WHY THE LIST IS SPELLED OUT AND NOT A GLOB. `python -m unittest discover` would absorb
 # every future test_*.py automatically -- including one that needs mwccarm, which does

--- a/tools/test_dead_references.py
+++ b/tools/test_dead_references.py
@@ -6,7 +6,8 @@ import sys
 import tempfile
 import pytest
 
-from check_dead_references import (
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from check_dead_references import (  # noqa: E402
     collect, dead_references, _git_tracked, _git_ignored, _tree_paths,
     _normalise, REPO, NUL
 )

--- a/tools/test_pr_monitor.py
+++ b/tools/test_pr_monitor.py
@@ -1,6 +1,9 @@
 import datetime as dt
+import pathlib
+import sys
 
-from pr_monitor import classify
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from pr_monitor import classify  # noqa: E402
 
 
 NOW = dt.datetime(2026, 8, 23, 12, tzinfo=dt.timezone.utc)


### PR DESCRIPTION
## What was red

Two of `tools/`'s 57 test modules fail on a clean `origin/main` (e9de9103a) when
invoked the way `.github/workflows/tool-tests.yml` invokes everything else:

```
$ python -m unittest tools.test_dead_references
ERROR: test_dead_references (unittest.loader._FailedTest.test_dead_references)
  File "tools/test_dead_references.py", line 9, in <module>
    from check_dead_references import (
ModuleNotFoundError: No module named 'check_dead_references'
Ran 1 test in 0.000s
FAILED (errors=1)

$ python -m unittest tools.test_pr_monitor
  File "tools/test_pr_monitor.py", line 3, in <module>
    from pr_monitor import classify
ModuleNotFoundError: No module named 'pr_monitor'
FAILED (errors=1)
```

`tool-tests.yml` named them in its "RED ON MAIN RIGHT NOW" bucket and excluded
them, because that PR deliberately touched nothing but itself. This is the
`tools/` half.

## Why

Invocation mismatch, not a broken tool. Both spell a bare
`from <subject> import ...`, which only resolves when `tools/` is already on
`sys.path` — true when the file is run directly (`sys.path[0]` is the script's
directory), false under `python -m unittest tools.test_X`. Run the way their own
files expect, they are green:

```
$ python tools/test_dead_references.py   -> 24 passed
$ python -m pytest tools/test_pr_monitor.py -q -> 4 passed
```

## The fix

The house pattern, verbatim. 38 of the other 55 test modules in `tools/` already
spell this exact line (`test_check_dead_references.py`, `test_srcpath.py`,
`test_layout.py`, `test_enroll.py`, `test_affected_src.py`, …); the remaining 17
use a `TOOLS` constant form of the same thing. There is no `tools/__init__.py`,
no `conftest.py` and no `pyproject.toml`/`pytest.ini` in this repo, so the
per-module `sys.path` bootstrap *is* the convention.

```python
sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
from check_dead_references import (  # noqa: E402
```

Two lines in `test_dead_references.py` (which already imported `sys` and
`pathlib`), four in `test_pr_monitor.py` (which imported neither). Nothing else
in either file changed, and neither tool under test was touched.

## Why neither module is wired into tool-tests.yml

**Repairing the import is not enough to make them safely wirable, so they are
deliberately still absent from the workflow's enumerated list.**

Both are pytest-style: bare `class TestNormalise:` / `class TestGitTracked:` and
bare `def test_windows_bytes_handling()`, with no `unittest.TestCase` anywhere.
After this PR the import succeeds — and unittest then finds nothing to run:

```
$ python -m unittest tools.test_dead_references
Ran 0 tests in 0.000s
OK
$ python -m unittest tools.test_pr_monitor
Ran 0 tests in 0.000s
OK
```

Exit 0, green, 28 real assertions silently uncounted. That is precisely the
hollow pass `tool-tests.yml`'s own header calls out ("eleven of the 57 modules
are pytest-style bare functions with no unittest.TestCase … 158 test functions
that a glob would have silently counted as passing"). `test_dead_references` and
`test_pr_monitor` are two of those eleven. Wiring them means converting them to
`TestCase` classes — a change to the tests themselves, not to how they are
invoked — which is a bigger change than this PR should carry.

So the only workflow edit here is to bucket 3 of the header comment, which this
PR makes stale: it claimed these two fail with `ImportError` on clean main. They
no longer do. The paragraph now states the real reason they stay out — pytest-only,
`Ran 0` under unittest — and keeps the exclusion.

## Before / after

| | before (origin/main) | after |
|---|---|---|
| `python -m unittest tools.test_dead_references` | `FAILED (errors=1)` — ModuleNotFoundError | `Ran 0 tests … OK` (still not wired) |
| `python -m unittest tools.test_pr_monitor` | `FAILED (errors=1)` — ModuleNotFoundError | `Ran 0 tests … OK` (still not wired) |
| `python tools/test_dead_references.py` | 24 passed | 24 passed |
| `python -m pytest tools/test_pr_monitor.py` | 4 passed | 4 passed |
| workflow's 21-module `run:` block | `Ran 312 tests … OK` | `Ran 312 tests … OK` |

The workflow total is unchanged by design — no module was added to the list.
Verified by running the workflow's exact `run:` block from this branch:
`Ran 312 tests in 58.060s / OK (skipped=3)`. (3 skips rather than the runner's 6
because this checkout has `extracted/` present, so three of
`test_stamp_provenance_verify`'s `@skipUnless` guards are satisfied.)

Also green on this branch: `python tools/check_python_names.py` (PASS, 254 files),
`python tools/check_dead_references.py` (no new dead references), and the full
pre-push hook (port-refcheck 405/405, duplicate-sources, `check_src_tu_compiles`
89/89).

## Note for a follow-up

`tools/test_pr_monitor.py` has no `if __name__ == "__main__"` block at all, so
`python tools/test_pr_monitor.py` also runs zero tests and exits 0 — it only
defines functions. Its 4 tests are reachable solely through pytest. Adding the
`pytest.main([__file__, "-v"])` footer its siblings carry would fix that, but it
is a separate concern from the import and is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
