### PR TITLE
Fix tool-test workflow dead reference

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -37,7 +37,7 @@
 #      `tools.test_pr_monitor` both fail on a clean origin/main with ImportError -- they
 #      use bare `from check_dead_references import ...` / `from pr_monitor import ...`,
 #      which only resolves with `tools/` on sys.path. Both are PYTEST modules that pass
-#      when invoked as `python tools/test_X.py` (their __main__ calls pytest.main), so
+  #      when invoked directly by filename (their __main__ calls pytest.main), so
 #      this is an invocation mismatch, not a broken tool. They are named here rather
 #      than fixed: repairing them is a `tools/` change and this workflow deliberately
 #      touches nothing but itself.


### PR DESCRIPTION
Rewords the tool-test workflow comment so the dead-reference checker no longer interprets the illustrative test filename as a real repository path. This is the one-line follow-up needed after #2027; check_dead_references passes locally. No source or generated dashboard files are included.