### PR TITLE
Trigger the dead references gate on every workflow file, not just its own

### DIFF
--- a/.github/workflows/dead-references.yml
+++ b/.github/workflows/dead-references.yml
@@ -20,6 +20,16 @@
 # than announcing a clean tree. That guard exists because this repo has already shipped
 # a gate that reported a pass after a reformat took its match count to zero.
 #
+# THE FILTER COVERS EVERY WORKFLOW FILE, not just this one. The tool reads workflow
+# comments and `run:` lines as prose, but the trigger below used to name only
+# `dead-references.yml`, so a PR touching a SIBLING workflow never ran this gate. #2027
+# merged as `e9de9103a` naming a `test_X.py` under tools/ in a `tool-tests.yml` comment
+# -- a path that has never existed -- and the main-push run list for that commit reads
+# `src_tu references`, `tool tests`, `pages`, with no `dead references` among them. The
+# dead reference then sat on main until it turned #2030's `references` check red for a
+# defect #2030 did not introduce; `b309f5d3f` (#2031) removed the string. A gate that
+# reads a file must be triggered by that file.
+#
 # Costs nothing: static analysis over the working tree, no compiler and no ROM.
 name: dead references
 
@@ -32,7 +42,7 @@ on:
       - "src/**"
       - "src_tu/**"
       - "config/dead-reference-baseline.json"
-      - ".github/workflows/dead-references.yml"
+      - ".github/workflows/**"
   push:
     branches: [main]
     paths:
@@ -42,7 +52,7 @@ on:
       - "src/**"
       - "src_tu/**"
       - "config/dead-reference-baseline.json"
-      - ".github/workflows/dead-references.yml"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## The defect

`.github/workflows/dead-references.yml` runs `python tools/check_dead_references.py`,
which reads `.github/workflows/*.yml` as prose — comments, `name:` and `run:` lines
(see `check_dead_references.py` lines 119 and 177). But the workflow's own trigger
filter named exactly one workflow file: itself.

```yaml
      - "config/dead-reference-baseline.json"
      - ".github/workflows/dead-references.yml"
```

So the gate scans thirteen workflow files and is triggered by one of them. A PR
that edits any *sibling* workflow never runs it.

## The incident that proved it

- **#2027** merged as `e9de9103a`, adding `.github/workflows/tool-tests.yml`. Line 40
  of that file named a `test_X.py` under `tools/` — a path that has never existed.
- The main-push check run list at `e9de9103a` is `src_tu references`, `tool tests`,
  `pages`. No `dead references`. The gate did not run, because #2027 touched no path
  in the list above.
- The dead reference reached main and then turned **#2030**'s `references` check red
  for a defect #2030 did not introduce.
- **#2031** (`b309f5d3f`) removed the string. `dead references` is green on main now,
  and this branch is cut from `b309f5d3f`.

## The change

One line per block — `pull_request:` and `push:`:

```diff
-      - ".github/workflows/dead-references.yml"
+      - ".github/workflows/**"
```

Plus a paragraph in the header comment block recording why.

**Dropped rather than kept** the explicit `dead-references.yml` entry: under GitHub's
filter-pattern syntax `**` matches any character including `/`, so
`.github/workflows/**` strictly subsumes it. Keeping both would buy nothing — if the
new glob somehow failed to match a direct child of that directory, the fix would fail
for `tool-tests.yml` too, which is the same shape of path. The redundant line would
protect only the one file whose coverage was never at risk.

## Verification

**1. The gate passes.** Verbatim:

```
check_dead_references: 368 prose file(s), 3303 repo-rooted path reference(s), 132 that do not resolve
  1 baselined reference(s) now resolve -- run --update to shrink the baseline (not a failure)
  no new dead references
```

The gate's own tests: `Ran 15 tests` / `OK`.

**Worth recording:** my first draft of the header comment quoted the incident path
literally, and the gate immediately failed on it —

```
FAIL: 1 prose reference(s) name a path that does not exist:
  .github/workflows/dead-references.yml
      names `tools/test_X.py`, which is not in the tree
```

That is an unplanned live demonstration of the exact class of defect this filter
change exists to catch, on the exact file. The comment now names the file without
spelling a repo-rooted path.

**2. YAML still parses.** `yaml.safe_load` succeeds; the round-tripped `on:` block has
the seven-entry list in both `pull_request:` and `push:`, with `push.branches: [main]`
and `workflow_dispatch:` unchanged.

**3. The fix actually works.** I did not assert fnmatch equivalence. I implemented
GitHub's *documented* filter-pattern semantics — `**` matches any character including
`/`; a single `*` matches any character except `/`; `?` matches one non-`/` character;
the pattern must match the whole repo-rooted path — as an anchored regex, and ran the
old and new patterns over `git ls-files .github/workflows/`:

```
workflow file                                    OLD    NEW
------------------------------------------------------------
.github/workflows/converted-ratchet.yml        False   True
.github/workflows/dead-references.yml           True   True
.github/workflows/header-offsets.yml           False   True
.github/workflows/langmode-ratchet.yml         False   True
.github/workflows/merge-stranding.yml          False   True
.github/workflows/pr-validate-cancel.yml       False   True
.github/workflows/pr-validate.yml              False   True
.github/workflows/python-names.yml             False   True
.github/workflows/report.yml                   False   True
.github/workflows/source-coverage.yml          False   True
.github/workflows/src-tu-refs.yml              False   True
.github/workflows/tool-tests.yml               False   True
.github/workflows/update-chaos-data.yml        False   True
```

Twelve of thirteen workflow files were uncovered; all thirteen are covered now,
including this workflow itself. The incident file `tool-tests.yml` goes `False -> True`
— #2027 would have run this gate.

Python's `fnmatch` agrees, but for the wrong reason: its `*` also matches `/`, so it
cannot tell `*` from `**` and is not a valid authority here. It is noted as a
cross-check only.

I did not run the workflow.

## Blast radius

This changes a **trigger filter only**. It cannot change any gate's verdict — not the
tool, not `config/dead-reference-baseline.json`, not a job step. It changes only
*whether* the gate runs, and only ever from "did not run" to "ran". It can make CI
stricter; it cannot make it looser.

The practical consequence: PRs touching a workflow file now run one extra ~10-second
static check with no compiler and no ROM.
