### PR TITLE
ci: stop source-coverage from cancelling its own push runs

### DIFF
--- a/.github/workflows/source-coverage.yml
+++ b/.github/workflows/source-coverage.yml
@@ -59,9 +59,28 @@ on:
 permissions:
   contents: read
 
+# Cancelling is safe for a PR and DESTRUCTIVE for a push, so the two are keyed apart.
+#
+# A PR run is superseded when a newer commit arrives -- the old verdict is about code that
+# no longer exists, so cancelling it costs nothing. Grouping by PR NUMBER is what makes
+# that possible; the previous `head.sha` key was unique per commit, so every PR run sat in
+# its own group and `cancel-in-progress` could never actually fire for a pull request.
+#
+# A push run is NOT superseded by the next push. Each one checks a DIFFERENT range --
+# `--base ${{ github.event.before }}`, i.e. exactly its own before..head -- and no other
+# run ever revisits it. Cancel push run X (A..B) because push Y (B..C) arrived, and Y
+# checks B..C while A..B is never checked by anything, ever. A merge that handed bytes
+# back to the cartridge inside that window is then invisible, which is the precise failure
+# this whole workflow exists to catch. Runs take ~26s, so the window is small but wholly
+# reachable when a merge queue is drained back to back.
+#
+# Note that `cancel-in-progress: false` alone would NOT have been enough: GitHub keeps at
+# most one PENDING run per group and cancels any earlier pending one, so three rapid
+# pushes would still drop the middle range. Pushes therefore get a group key that is
+# unique per commit (`github.sha`) and can never collide in the first place.
 concurrency:
-  group: source-coverage-${{ github.event.pull_request.head.sha || github.ref }}
-  cancel-in-progress: true
+  group: source-coverage-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   coverage:


### PR DESCRIPTION
## The one check that watches merges was cancelling itself

`source-coverage.yml`'s **push** job is the only thing in this repo that asks whether a
*merge* handed source-built bytes back to the retail cartridge. Its own header says so:

> `github.event.before` is main's tip before this push -- so this asks whether the merge
> itself lost bytes, **which no PR-time check can answer**.

Each push run therefore checks a **different, non-overlapping range**, and nothing else
ever revisits it. The concurrency block was cancelling exactly those runs:

```yaml
group: source-coverage-${{ github.event.pull_request.head.sha || github.ref }}
cancel-in-progress: true
```

`head.sha` is unique per commit, so **every pull-request run already sat in its own group**
and `cancel-in-progress` could never fire for a PR. Pushes to main all shared
`refs/heads/main`. The flag's only effect in practice was to cancel main's push runs --
the single place where cancelling drops coverage instead of discarding a stale verdict.

### The failure it allows

```
push X:  before=A  head=B     <- starts, then gets cancelled
push Y:  before=B  head=C     <- runs, checks B..C

A..B is never checked by anything, ever.
```

A merge that reclaimed a range inside `A..B` leaves **no trace**: module fidelity stays
106/106, `romdata_check` stays green, the reference and relocation audits stay green,
because cartridge bytes are correct by construction. Fewer bytes came out of `src/`, and
this job is the only one that diffs that number.

### Sizing it honestly

Measured over the last five main pushes, a run takes **26 / 29 / 25 / 22 / 30 seconds**.
So the window is two merges inside ~26s. **No run has ever actually been cancelled**
(`conclusion == "cancelled"` is 0 across the last 60 runs) -- this is a latent hole, not
an incident report. It is reachable exactly when a merge queue is drained back to back,
which is the current mode of operation.

### Why `cancel-in-progress: false` alone was not the fix

GitHub keeps at most **one pending run per group** and cancels any earlier pending one.
With a shared group, three rapid pushes would still drop the middle range even with
cancellation disabled. So pushes get a group key that is unique per commit and cannot
collide in the first place:

```yaml
group: source-coverage-${{ github.event.pull_request.number || github.sha }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Switching the PR key from `head.sha` to `pull_request.number` also makes PR supersession
work **for the first time** -- pushing a new commit to a PR now cancels the stale run,
which is what the original `cancel-in-progress: true` was presumably trying to express.

### Scope

Comment and concurrency block only. Same tool, same arguments, same six steps, same tests
-- `python -m unittest tools.test_source_coverage` still runs first as the negative
control. `check_dead_references` green (`no new dead references`); the workflow YAML
parses and `jobs.coverage` still has its 6 steps.

Behaviour after this change:
- **pull_request** -- grouped per PR, newer commit cancels the older run (new, intended)
- **push to main** -- one group per commit, never cancelled, every range checked
- **workflow_dispatch** -- `pull_request.number` is null, falls through to `github.sha`

Found while auditing the merge-gating path, not by a failure.
