### PR TITLE
Strip a stray conflict marker left on main in the C/C++ classification data

### DIFF
--- a/notes/data/c-cpp-classification.tsv
+++ b/notes/data/c-cpp-classification.tsv
@@ -1411,7 +1411,6 @@ src/actors/Bookshelf/Bookshelf_Spawn.c	WEAK-refs-only	ov063				1		None		-
 src/actors/FallBlockBbh/FallBlockBbh_Spawn.c	S1-stores-rom-vptr	ov063			stores _ZTV12FallBlockBbh	1		None	_ZTV12FallBlockBbh/_ZTV16daObjFallBlock_c	-
 src/actors/FallBlockBbh/_ZN12FallBlockBbhD0Ev.cpp	DTOR-ONLY	ov063	daObjTh_Fall_Block_c	FallBlockBbh/daObjTh_Fall_Block_c	_ZN12FallBlockBbhD0Ev	1		True	_ZTV10dBgActor_c/_ZTV12FallBlockBbh/_ZTV16daObjFallBlock_c	-
 src/actors/MadPiano/_ZN8MadPianoD1Ev.cpp	DTOR-ONLY	ov063	daPiano_c	MadPiano/daPiano_c	_ZN8MadPianoD1Ev	1		True	_ZTV10dBgActor_c/_ZTV8MadPiano	-
->>>>>>> origin/main
 src/actors/MadPiano/__sinit_ov063_0211e5fc.c	WEAK-refs-only	ov063				0		None		extra-sections:init
 src/actors/MansionSteps/MansionSteps_Spawn.c	WEAK-refs-only	ov063				1		None		-
 src/actors/MansionSteps/_ZN12MansionSteps16OnPendingDestroyEv.c	P1-vtable+mangled	ov063	daTrsTrap_c	MansionSteps/daTrsTrap_c	vtable daTrsTrap_c slot 12 @0x211ce30 | _ZN12MansionSteps16OnPendingDestroyEv	1		True		-


### PR DESCRIPTION
One-line deletion: `notes/data/c-cpp-classification.tsv:1414` has been carrying a lone
`>>>>>>> origin/main` on main.

It is debris from a merge resolution that kept both sides correctly but left the trailing
marker behind. This is not a re-resolution — nothing was lost with it, and I checked that
before removing rather than after:

| check | result |
|---|---|
| conflict markers in the file | exactly one, no `<<<<<<<` and no `=======` anywhere |
| sort continuity across line 1414 | continuous — `MadPiano/_ZN8MadPianoD1Ev.cpp` → `MadPiano/__sinit_ov063_0211e5fc.c` |
| data rows after removal | 7092 |
| column count | 11 on every row, 0 malformed |
| duplicate paths | 0 |

The sort order running straight through the marker is the load-bearing observation: it
means the original resolution did not drop or duplicate a row on either side, so deleting
the marker restores the file rather than picking a side.

### Why no gate caught this

Worth recording, because it is a genuine blind spot rather than an oversight. Nothing
*parses* this file. It is consumed only by prose —
`notes/plan-cpp-conversion-queue.md`, `notes/plan-tu-merge-queue.md`,
`notes/tu-cpp-census-2026-08.md` — and `check_dead_references` extracts repo-rooted
*paths* out of prose; it does not validate TSV structure. A conflict-marker line contains
no resolvable path, so it is invisible to every check we run. Same family as #2037.

I am not proposing a new gate for it here. A cheap one would be a marker scan across
tracked text files, which would have caught this in any file, not just this one. Filing
that separately if it is wanted.

### Gates

Run on this branch:

```
check_dead_references     rc=0   372 prose files, 3351 path refs, no NEW dead references
check_python_names        PASS   258 files, 0 unresolvable
check_duplicate_sources   rc=0   11199 stems, none doubled
pre-push port_refcheck    405/405 references resolve
pre-push check_src_tu     90/90 translation units compile
```

No compiled source is touched, so there is no byte claim to make and none is made.
