### PR TITLE
docs(source_coverage): config_tu/ is out of scope on purpose, not by omission

### DIFF
--- a/tools/source_coverage.py
+++ b/tools/source_coverage.py
@@ -167,8 +167,16 @@ def module_of(delinks_path):
         return m.group(1)
     if p.endswith("config/arm9/delinks.txt"):
         return "arm9"
-    # Any other layout (config_tu/, a future module root): name it by its directory, so
+    # Any other layout under config/ (a future module root): name it by its directory, so
     # an unrecognised path is still attributed rather than silently merged with arm9.
+    #
+    # Not config_tu/, and do not "fix" the scanners to reach it. Both entries_from_tree()
+    # and entries_from_ref() are scoped to CONFIG_DIR on purpose: tu_config.py generates
+    # config_tu/ as a PARALLEL dsd root for the TU-shaped treemap experiment, and its own
+    # contract is that "config/**/delinks.txt remains the sole authority over what mwccarm
+    # compiles." Measured on main: 8 delinks files, 29 entries, ZERO marked `complete` --
+    # so widening the scan would not find a single source-built byte, it would only import
+    # 29 unenrolled entries and the false alarms that come with them.
     return pathlib.PurePosixPath(p).parent.name or p
 
 


### PR DESCRIPTION
Comment only, no behaviour change. Filed because the comment was actively
misleading in a gate, which is the failure class this tree keeps getting bitten by.

## What it said vs. what is true

`module_of()` carried:

```
# Any other layout (config_tu/, a future module root): name it by its directory, so
# an unrecognised path is still attributed rather than silently merged with arm9.
```

But `config_tu/` can never be passed to `module_of()`. Both scanners are hard-scoped to
`CONFIG_DIR = "config"`:

```
entries_from_tree()  ->  (root / CONFIG_DIR).rglob("delinks.txt")
entries_from_ref()   ->  git ls-tree -r <ref> -- CONFIG_DIR
```

So the function advertised handling for a root neither caller can reach.

## Why that is worth a commit

The obvious "fix" on reading it is to widen the scanners so the `config_tu/` branch
finally does something. That would be wrong, and `tu_config.py` says so in its own
contract:

> This generator writes a PARALLEL root (`config_tu/` by default) [...] nothing here can
> reach the ROM build: `config/**/delinks.txt` remains the sole authority over what
> mwccarm compiles

`rombuild.py` reaches that root only behind an opt-in `--module` flag, for the TU-shaped
treemap experiment.

I measured what widening would actually buy, rather than arguing it:

| `config_tu/**/delinks.txt` on main | |
|---|---|
| delinks files | 8 |
| entries | 29 |
| entries marked `complete` | **0** |

Zero. `complete` is the whole ballgame — with it mwccarm compiles the source, without it
dsd supplies the object from ROM bytes. So widening the scan finds **no source-built
byte at all**; it imports 29 unenrolled entries and the false alarms that come with them.
The new comment records that number so the next reader does not have to re-derive it.

## Why I was looking at this file

Chasing the same question that produced #2046: what actually notices when dsd stops
compiling a range from source and hands it back to the retail cartridge. `config_tu/`
came up as a candidate blind spot. It is not one — it is correctly out of scope — and
this commit is the difference between "out of scope" and "looks like an oversight."

## Verification

```
tools.test_source_coverage        Ran 25 tests   OK
python tools/source_coverage.py   2,067,148 B across 74 module(s), 10,973 range(s)
                                  .init 125,712 B   .text 1,941,436 B   exit 0
```

Byte-for-byte the figure main reports, which is the point: a comment change must move
nothing. Pre-push green: `port_refcheck` 405/405, `check_src_tu` 90/90,
duplicate-sources 11199 stems none doubled. No compiled source touched, so there is no
byte claim here and none is made.
