### PR TITLE
notes: fix the one relative link #2036 left unresolvable

### DIFF
--- a/notes/ead-debug-name-crossref.md
+++ b/notes/ead-debug-name-crossref.md
@@ -189,7 +189,7 @@ gloss exists yet.
 
 ---
 
-## Confidence-bump candidates for [config/rom-name-glossary.json](config/rom-name-glossary.json)
+## Confidence-bump candidates for [config/rom-name-glossary.json](../config/rom-name-glossary.json)
 
 - **`Kumo`: medium → high.** Index 314's debug string `OBJ_KUMO` plus the
   existing `CLOUD(314)` entry in [overlay_actors.md](../symbols/overlay_actors.md) doubly corroborate the


### PR DESCRIPTION
One-line follow-up to #2036, which merged as `e23db0c2d`.

#2036 converted 106 bare paths in `notes/ead-debug-name-crossref.md` into markdown links.
105 resolve. Line 192 points at `config/rom-name-glossary.json` without the leading `../`,
so from `notes/` it resolves to `notes/config/rom-name-glossary.json`, which does not exist.

The other **six** references to that same file in this note already use
`../config/rom-name-glossary.json` (lines 6, 27, 69, 137, 156), so this was the lone
straggler, not a systematic error.

### Measured, not eyeballed

Every relative markdown link in the file resolved against `git ls-files`, same script on
all three trees:

| tree | relative links | broken |
|---|---|---|
| before #2036 | 0 | 0 |
| after #2036 (`e23db0c2d`) | 106 | **1** |
| after this commit | 106 | **0** |

Main's version carried no markdown links at all before #2036 — the paths were bare text.
So #2036 was a real improvement that arrived with one defect, and this closes it.

### Nothing caught it, and nothing would have

`check_dead_references` extracts repo-rooted paths out of prose; it never resolves a link
**relative to the file the link lives in**. A link that names a real file by the wrong path
is therefore invisible to it, and the gate goes green either way — #2036 passed all four of
its checks with this in the diff. That blind spot is filed as #2037 and is deliberately
**not** addressed here; this PR is the content fix only, so it does not wait on a tool review.

### Why a follow-up instead of an edit to the branch

#2036 came from a fork. This repo does not push to contributors' branches, so the choice was
between blocking a strictly-improving contribution on two characters or landing it and
fixing forward. I landed it and fixed forward.

### Gates

Notes-only, no compiled source touched, so no byte claim is made and none is needed.
Pre-push hook on this branch:

```
port_refcheck            405 references checked, all resolve
check_duplicate_sources  11192 stems, none doubled
check_src_tu_compiles    90/90 translation units compiled
```
