### PR TITLE
check_dead_references: resolve markdown links relative to their own file (#2037)

### DIFF
--- a/.github/workflows/dead-references.yml
+++ b/.github/workflows/dead-references.yml
@@ -30,29 +30,26 @@
 # defect #2030 did not introduce; `b309f5d3f` (#2031) removed the string. A gate that
 # reads a file must be triggered by that file.
 #
-# Costs nothing: static analysis over the working tree, no compiler and no ROM.
+# AND A GATE THAT RESOLVES A PATH MUST BE TRIGGERED BY THAT PATH. There is no `paths:`
+# filter here any more, and that is the same lesson one step further out. The filter
+# used to list `**.py`, `**.md`, `include/**`, `src/**`, `src_tu/**`, the baseline JSON
+# and `.github/workflows/**` -- the files the tool READS. But the tool also RESOLVES
+# what that prose names, against the whole tree, so a PR that only deletes or renames a
+# resolution TARGET breaks references without touching anything in the filter. Measured
+# when #2037's relative-link check went in: 99 of the tree's 183 markdown links point
+# outside the old filter -- 89 at a per-overlay `symbols.txt`, the rest under `symbols/`
+# and `nearmiss/` or at top-level `attribution.json` and `LICENSE`. Renaming an overlay
+# symbols file is routine here and would have broken 89 links silently. Enumerating every
+# top-level directory would reproduce the whole tree in a list that goes stale on the
+# next new directory, so the filter is gone instead: this job is static analysis over
+# the working tree with no compiler and no ROM, and running it on every change costs
+# less than one missed rename.
 name: dead references
 
 on:
   pull_request:
-    paths:
-      - "**.py"
-      - "**.md"
-      - "include/**"
-      - "src/**"
-      - "src_tu/**"
-      - "config/dead-reference-baseline.json"
-      - ".github/workflows/**"
   push:
     branches: [main]
-    paths:
-      - "**.py"
-      - "**.md"
-      - "include/**"
-      - "src/**"
-      - "src_tu/**"
-      - "config/dead-reference-baseline.json"
-      - ".github/workflows/**"
   workflow_dispatch:
 
 permissions:

--- a/port/docs/opie-assessment.md
+++ b/port/docs/opie-assessment.md
@@ -1,6 +1,6 @@
 # Assessment: reusing `cybervisi0n/pokeplatinum@pc_port` + the libntr suite for an SM64DS PC port
 
-*Status: research + plan, not yet actioned. Slots into [`roadmap.md`](roadmap.md)
+*Status: research + plan, not yet actioned. Slots into [`notes/roadmap.md`](../../notes/roadmap.md)
 Phases 2–3 (LIFT / PORT). Investigated 2026-08-01; revised after adversarial review.*
 
 ---

--- a/tools/check_dead_references.py
+++ b/tools/check_dead_references.py
@@ -31,6 +31,27 @@ In those it finds repo-rooted path references -- a token whose first segment is 
 top-level directory of this repo (`tools/`, `notes/`, `include/`, `src/`, ...) -- and
 asks whether the path resolves in the working tree.
 
+AND, SEPARATELY, MARKDOWN LINKS THAT POINT AT THE WRONG PLACE
+-------------------------------------------------------------
+The scan above reads a path out of prose and resolves it FROM THE REPO ROOT. A markdown
+link does not work that way: a renderer resolves `[x](config/<name>.json)` against the
+directory of the file the link is written in. So a link inside `notes/` naming
+`config/<name>.json` points at that same path UNDER `notes/` -- a 404 -- while the
+repo-rooted scan resolves `config/<name>.json`, finds it, and reports a clean tree.
+
+Not hypothetical. #2036 turned 106 bare paths in `notes/ead-debug-name-crossref.md`
+into markdown links; 105 carried the `../` and the one at line 192 did not. All four of
+that PR's checks were green. It was found by hand and fixed forward in #2049; the blind
+spot itself is #2037, which `broken_links` below closes by resolving every markdown
+link against `os.path.dirname()` of its own file.
+
+FAIL-CLOSED, NO BASELINE. Measured over all 106 markdown prose files at `e6ede02d7`:
+183 relative links, of which exactly ONE did not resolve -- `port/docs/opie-assessment.md`
+naming `roadmap.md`, which lives at `notes/roadmap.md`. One offender is a fix, not a
+ratchet, so it was corrected in the same change and this check carries no accepted-offender
+list. The repo-rooted scan needs one because its false-positive population is large;
+this one does not, and a baseline nobody needs is a place for real breakage to hide.
+
 HOW IT AVOIDS CRYING WOLF
 -------------------------
 Two mechanisms, because a noisy gate gets switched off and then protects nothing:
@@ -53,9 +74,10 @@ FAILING LOUDLY RATHER THAN SKIPPING GREEN
 This tree has a documented history of gates that pass by doing nothing (an Allman
 reformat took `check_header_offsets` from 5 matches to 0 and printed a pass). So this
 tool refuses to report success unless the scan actually happened: if it inspects fewer
-than `MIN_FILES` prose files or extracts fewer than `MIN_REFS` candidate references, it
-exits non-zero with SCAN TOO SMALL rather than announcing a clean tree. Those floors sit
-far below today's numbers; they trip when the extractor breaks, not when prose changes.
+than `MIN_FILES` prose files, extracts fewer than `MIN_REFS` candidate references, or
+resolves fewer than `MIN_LINKS` markdown links, it exits non-zero with SCAN TOO SMALL
+rather than announcing a clean tree. Those floors sit far below today's numbers; they
+trip when the extractor breaks, not when prose changes.
 """
 import argparse
 import ast
@@ -74,6 +96,10 @@ BASELINE = REPO / "config" / "dead-reference-baseline.json"
 # The scan must be at least this big or the tool is broken, not the tree.
 MIN_FILES = 150
 MIN_REFS = 1000
+# 183 relative markdown links at e6ede02d7, 106 of them in one note. The floor sits
+# below what survives that note being deleted outright, so it trips on a broken
+# extractor and not on prose churn.
+MIN_LINKS = 50
 
 # Directories that are real parts of the repo layout. A path reference only counts
 # when its first segment is one of these -- that is what separates `tools/foo.py`
@@ -311,6 +337,138 @@ def dead_references(root=REPO):
     return files, refs, sorted(dead)
 
 
+# ------------------------------------------------------------------- relative links
+
+# `[text](target)`, and the reference-style `[label]: target` definition. The target
+# group stops at the first `)`, which is why a target containing parentheses must be
+# written in the angle-bracket form -- that is also markdown's own rule.
+LINK_RE = re.compile(r"\[[^\]\n]*\]\(([^()\n]*)\)")
+LINKDEF_RE = re.compile(r"^\s{0,3}\[[^\]\n]+\]:[ \t]*(\S+)")
+# `https:`, `mailto:`, and anything else with a URL scheme is not ours to resolve.
+SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:")
+FENCE_RE = re.compile(r"^\s{0,3}(?:```|~~~)")
+BACKTICKS_RE = re.compile(r"`+")
+# `path "title"` / `path 'title'` -- markdown's optional link title.
+TITLED_RE = re.compile(r"^(\S+)[ \t]+[\"'].*$")
+
+
+def _code_spans(line):
+    """(start, end) of every inline `code` span, so a link inside one is not a link.
+
+    Needed because this tree writes ARM and C in prose constantly, and
+    `(*(fn**)this)[N](this, ...)` in `notes/archive/pret-idioms.md` reads exactly like
+    a markdown link to `this, ...`. Four such false positives came out of the tree-wide
+    measurement; all four sit inside backticks. Runs are paired by LENGTH, as markdown
+    itself pairs them, so ``a`b`` closes on the double tick and not the single.
+    """
+    runs = [(m.start(), m.end()) for m in BACKTICKS_RE.finditer(line)]
+    spans, i = [], 0
+    while i < len(runs):
+        width = runs[i][1] - runs[i][0]
+        j = i + 1
+        while j < len(runs) and runs[j][1] - runs[j][0] != width:
+            j += 1
+        if j >= len(runs):
+            break                 # unclosed run: everything after it is ordinary text
+        spans.append((runs[i][0], runs[j][1]))
+        i = j + 1
+    return spans
+
+
+def _link_target(raw):
+    """The path part of a markdown link target: angle brackets and title stripped."""
+    target = raw.strip()
+    if target.startswith("<") and target.endswith(">"):
+        return target[1:-1].strip()
+    titled = TITLED_RE.match(target)
+    return titled.group(1) if titled else target
+
+
+def collect_links(root=REPO):
+    """[(file, line, raw_target, resolved)] for every markdown link that names a path.
+
+    MARKDOWN FILES ONLY. Link syntax means nothing in a python docstring or a workflow
+    comment, and applying it there is actively harmful: a regex character class followed
+    by a group -- `cand\\.c(?:pp)?`, `[a-z]+(...)` -- is indistinguishable from a link,
+    and seven of the twelve hits in the first tree-wide pass were exactly that.
+
+    Fenced blocks are skipped. The repo-rooted scan above does NOT skip them, and that
+    difference is deliberate: a path named in a fenced `python tools/<x>.py` example is a
+    real claim about the tree, whereas a link written inside a fence is being SHOWN, not
+    followed. It costs nothing today either way -- all 183 links at `e6ede02d7` sit
+    outside fences.
+    """
+    links = []
+    for rel in _prose_targets():
+        if not rel.endswith(".md"):
+            continue
+        text = (root / rel).read_text(encoding="utf-8", errors="replace")
+        fenced = False
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if FENCE_RE.match(line):
+                fenced = not fenced
+                continue
+            if fenced:
+                continue
+            spans = _code_spans(line)
+            found = [(m.group(1), m.start(1)) for m in LINK_RE.finditer(line)]
+            definition = LINKDEF_RE.match(line)
+            if definition:
+                found.append((definition.group(1), definition.start(1)))
+            for raw, col in found:
+                if any(a <= col < b for a, b in spans):
+                    continue
+                target = _link_target(raw)
+                # `#anchor` is same-page; a scheme is someone else's to resolve.
+                if not target or target.startswith("#") or SCHEME_RE.match(target):
+                    continue
+                # A raw space cannot appear in a bare target -- it is prose we misread.
+                if re.search(r"\s", target):
+                    continue
+                path = target.split("#", 1)[0].split("?", 1)[0].replace("\\", "/")
+                if not path:
+                    continue      # was `#frag` after all
+                if path.startswith("/"):
+                    resolved = os.path.normpath(path.lstrip("/"))
+                else:
+                    resolved = os.path.normpath(
+                        os.path.join(os.path.dirname(rel), path))
+                links.append((rel, lineno, target, resolved.replace("\\", "/")))
+    return links
+
+
+def broken_links(root=REPO, dead=()):
+    """(links_seen, sorted [(file, line, target, resolved)] that resolve to nothing).
+
+    Aliveness is judged exactly as `dead_references` judges it -- tracked by git, or on
+    disk, or gitignored -- so `[x](../build/tu_map.json)` is fine on a clean clone for
+    the same reason `build/tu_map.json` in a docstring is.
+
+    `dead` is the repo-rooted scan's own findings. A link written `[x](../include/<Gone>.h)`
+    is dead by both readings and would otherwise be printed twice, so anything the
+    repo-rooted scan already owns for that file is left to it -- including the entries
+    it has baselined. What survives is the case only this check can see: a link whose
+    target names a REAL file by a path that is wrong from where the link is written,
+    which is the #2036 shape.
+    """
+    links = collect_links(root)
+    paths = _tree_paths(root) | _git_tracked(root)
+    owned = set(dead)
+    unresolved = []
+    for rel, lineno, target, resolved in links:
+        if (rel, _normalise(target)) in owned:
+            continue
+        if resolved in paths or resolved in (".", ""):
+            continue
+        # A directory target is fine when anything tracked lives under it.
+        if not resolved.startswith("..") and any(
+                p.startswith(resolved + "/") for p in paths):
+            continue
+        unresolved.append((rel, lineno, target, resolved))
+    ignored = _git_ignored({r for _f, _l, _t, r in unresolved}, root)
+    return links, sorted(b for b in unresolved if b[3] not in ignored)
+
+
 # ------------------------------------------------------------------------ baseline
 
 def load_baseline():
@@ -342,34 +500,41 @@ def write_baseline(dead):
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--list", action="store_true",
-                    help="print every dead reference, baselined or not")
+                    help="print every dead reference and broken link, baselined or not")
     ap.add_argument("--update", action="store_true",
                     help="re-bank config/dead-reference-baseline.json")
     args = ap.parse_args(argv)
 
     files, refs, dead = dead_references()
+    links, broken = broken_links(REPO, dead)
 
     # A scan that inspected nothing must not report a clean tree.
-    if len(files) < MIN_FILES or len(refs) < MIN_REFS:
+    if len(files) < MIN_FILES or len(refs) < MIN_REFS or len(links) < MIN_LINKS:
         print(f"check_dead_references: SCAN TOO SMALL -- {len(files)} prose file(s), "
-              f"{len(refs)} path reference(s); expected at least {MIN_FILES} and "
-              f"{MIN_REFS}.")
+              f"{len(refs)} path reference(s), {len(links)} markdown link(s); expected "
+              f"at least {MIN_FILES}, {MIN_REFS} and {MIN_LINKS}.")
         print("  The extractor is broken, or the tool is being run outside the repo.")
         print("  Refusing to report a pass on a scan this size.")
         return 2
 
     print(f"check_dead_references: {len(files)} prose file(s), {len(refs)} repo-rooted "
-          f"path reference(s), {len(dead)} that do not resolve")
+          f"path reference(s), {len(dead)} that do not resolve; {len(links)} markdown "
+          f"link(s), {len(broken)} that do not resolve relative to their own file")
 
     if args.list:
         for f, r in dead:
             print(f"  {f}: {r}")
+        for f, ln, target, resolved in broken:
+            print(f"  {f}:{ln}: {target} -> {resolved}")
 
     if args.update:
         write_baseline(dead)
         print(f"  wrote {BASELINE.relative_to(REPO).as_posix()} "
               f"({len(dead)} known reference(s))")
-        return 0
+        if broken:
+            print(f"  NOTE: {len(broken)} broken markdown link(s) remain -- relative "
+                  f"links have no baseline and must be fixed, not banked")
+        return 1 if broken else 0
 
     known = load_baseline()
     new = [d for d in dead if d not in known]
@@ -381,15 +546,27 @@ def main(argv=None):
 
     if not new:
         print("  no new dead references")
-        return 0
+    else:
+        print(f"\nFAIL: {len(new)} prose reference(s) name a path that does not exist:\n")
+        for f, r in new:
+            print(f"  {f}\n      names `{r}`, which is not in the tree")
+        print("\nThis is almost always a rename that did not carry into the prose. Fix the")
+        print("sentence to name the file's current path -- or, if the reference is")
+        print("deliberately historical or belongs to another repository, add it with")
+        print("`python tools/check_dead_references.py --update`.")
 
-    print(f"\nFAIL: {len(new)} prose reference(s) name a path that does not exist:\n")
-    for f, r in new:
-        print(f"  {f}\n      names `{r}`, which is not in the tree")
-    print("\nThis is almost always a rename that did not carry into the prose. Fix the")
-    print("sentence to name the file's current path -- or, if the reference is")
-    print("deliberately historical or belongs to another repository, add it with")
-    print("`python tools/check_dead_references.py --update`.")
+    if not broken:
+        print("  no broken markdown links")
+        return 1 if new else 0
+
+    print(f"\nFAIL: {len(broken)} markdown link(s) do not resolve from the file they "
+          f"are written in:\n")
+    for f, ln, target, resolved in broken:
+        print(f"  {f}:{ln}\n      links to `{target}`, which resolves to "
+              f"`{resolved}` -- not in the tree")
+    print("\nA markdown link is resolved against the DIRECTORY OF ITS OWN FILE, not the")
+    print("repo root, so a note in `notes/` must write `../config/x.json` and not")
+    print("`config/x.json`. There is no baseline for these: fix the link.")
     return 1
 
 

--- a/tools/test_check_dead_references.py
+++ b/tools/test_check_dead_references.py
@@ -124,6 +124,137 @@ class NoiseTests(unittest.TestCase):
         self.assertEqual(self._dead("vendor/m2c/main.py"), set())
 
 
+class RelativeLinkTests(unittest.TestCase):
+    """A markdown link resolves against ITS OWN DIRECTORY, not the repo root.
+
+    The positive control here is `test_the_2036_shape_is_detected`: the exact link that
+    landed in the EAD cross-reference note with all four checks green, because the
+    repo-rooted scan resolved the target from the ROOT and found it there. If that test
+    ever starts passing vacuously, this gate is back where it was before #2037.
+    """
+
+    def _broken(self, build, dead=()):
+        with tempfile.TemporaryDirectory() as tmp:
+            t = Tree(tmp)
+            build(t)
+            old = CDR.REPO
+            CDR.REPO = t.root
+            try:
+                _links, broken = CDR.broken_links(t.root, dead)
+            finally:
+                CDR.REPO = old
+            return set(broken)
+
+    def _targets(self, build):
+        with tempfile.TemporaryDirectory() as tmp:
+            t = Tree(tmp)
+            build(t)
+            old = CDR.REPO
+            CDR.REPO = t.root
+            try:
+                links = CDR.collect_links(t.root)
+            finally:
+                CDR.REPO = old
+            return [target for _f, _l, target, _r in links]
+
+    def test_the_2036_shape_is_detected(self):
+        """A link naming `config/...` from inside `notes/` points under `notes/`."""
+        def build(t):
+            t.write("config/rom-name-glossary.json", "{}\n")
+            t.write("notes/crossref.md",
+                    "Bumped in [the glossary](config/rom-name-glossary.json).\n")
+        self.assertEqual(self._broken(build), {
+            ("notes/crossref.md", 1, "config/rom-name-glossary.json",
+             "notes/config/rom-name-glossary.json")})
+
+    def test_a_correct_dotdot_link_resolves(self):
+        def build(t):
+            t.write("config/rom-name-glossary.json", "{}\n")
+            t.write("notes/crossref.md",
+                    "Bumped in [the glossary](../config/rom-name-glossary.json).\n")
+        self.assertEqual(self._broken(build), set())
+
+    def test_a_sibling_link_resolves(self):
+        def build(t):
+            t.write("notes/other.md", "x\n")
+            t.write("notes/crossref.md", "See [the other note](other.md).\n")
+        self.assertEqual(self._broken(build), set())
+
+    def test_an_http_link_is_ignored(self):
+        self.assertEqual(self._broken(lambda t: t.write("notes/n.md", (
+            "Filed as [an issue](https://github.com/tangosdev/sm64ds-decomp/issues/2037)\n"
+            "and raised with [a human](mailto:someone@example.com).\n"))), set())
+
+    def test_an_anchor_only_link_is_ignored(self):
+        self.assertEqual(self._broken(lambda t: t.write(
+            "notes/n.md", "Jump to [the ratchet](#how-it-avoids-crying-wolf).\n")), set())
+
+    def test_a_fragment_is_stripped_before_resolving(self):
+        def build(t):
+            t.write("notes/other.md", "x\n")
+            t.write("notes/n.md", "See [the section](other.md#the-section).\n")
+        self.assertEqual(self._broken(build), set())
+
+    def test_a_link_to_a_directory_resolves(self):
+        def build(t):
+            t.write("include/dEnemyBase_c.h", "struct dEnemyBase_c {};\n")
+            t.write("notes/n.md", "The headers live in [include](../include).\n")
+        self.assertEqual(self._broken(build), set())
+
+    def test_a_link_inside_a_fence_is_not_a_link(self):
+        """Shown, not followed -- unlike a repo-rooted path in the same fence."""
+        self.assertEqual(self._broken(lambda t: t.write("notes/n.md", (
+            "Write it like this:\n\n"
+            "```markdown\n"
+            "[the glossary](config/rom-name-glossary.json)\n"
+            "```\n"))), set())
+
+    def test_a_link_inside_backticks_is_not_a_link(self):
+        """Hand-rolled dispatch reads exactly like a link and is not one."""
+        self.assertEqual(self._broken(lambda t: t.write(
+            "notes/n.md",
+            "Hand-rolling it as `(*(fn**)this)[4](this, ...)` reproduces the\n"
+            "instructions but not the register.\n")), set())
+
+    def test_angle_bracket_and_titled_targets_are_unwrapped(self):
+        def build(t):
+            t.write("notes/a b.md", "x\n")
+            t.write("notes/other.md", "x\n")
+            t.write("notes/n.md",
+                    "See [spaced](<a b.md>) and [titled](other.md \"the note\").\n")
+        self.assertEqual(self._broken(build), set())
+
+    def test_a_reference_style_definition_is_resolved(self):
+        def build(t):
+            t.write("config/rom-name-glossary.json", "{}\n")
+            t.write("notes/n.md",
+                    "Cited as [glossary].\n\n[glossary]: config/rom-name-glossary.json\n")
+        self.assertEqual(self._broken(build), {
+            ("notes/n.md", 3, "config/rom-name-glossary.json",
+             "notes/config/rom-name-glossary.json")})
+
+    def test_a_repo_rooted_dead_link_is_not_reported_twice(self):
+        """A link to a path that is dead BOTH ways belongs to the repo-rooted scan."""
+        build = lambda t: t.write(
+            "notes/n.md", "See [the header](../include/Enemy.h).\n")
+        self.assertEqual(self._broken(build), {
+            ("notes/n.md", 1, "../include/Enemy.h", "include/Enemy.h")})
+        self.assertEqual(self._broken(build, dead=[("notes/n.md", "include/Enemy.h")]),
+                         set())
+
+    def test_link_syntax_in_python_is_not_a_link(self):
+        """A regex character class followed by a group is not a markdown link."""
+        self.assertEqual(self._targets(lambda t: t.write(
+            "tools/thing.py", '"""Matches [a-z]+(?:pp)? in the name."""\n')), [])
+
+    def test_the_tree_has_no_broken_relative_links(self):
+        """Fail-closed: this check banks nothing, so the tree itself must be clean."""
+        _files, _refs, dead = CDR.dead_references()
+        links, broken = CDR.broken_links(REPO, dead)
+        self.assertGreaterEqual(len(links), CDR.MIN_LINKS)
+        self.assertEqual(broken, [], f"broken relative links: {broken}")
+
+
 class FailLoudlyTests(unittest.TestCase):
     """A scan that inspected nothing must not print a pass."""
 


### PR DESCRIPTION
Closes #2037.

`tools/check_dead_references.py` pulls repo-rooted paths out of prose and resolves them **from the repo root**. A markdown renderer does not: it resolves `[x](config/foo.json)` against the directory of the file the link is written in. So a link inside `notes/` naming `config/...` points at `notes/config/...` — a 404 — while the repo-rooted scan resolves the same string from the root, finds it, and reports a clean tree.

## The measurement that motivated it

That is #2036: it turned 106 bare paths in `notes/ead-debug-name-crossref.md` into markdown links; 105 carried the `../` and the one at line 192 did not. **All four of that PR's checks were green.** It was found by hand and fixed forward in #2049 (`745181902`), which explicitly left the blind spot to #2037. This closes it.

## Tree-wide baseline, measured before the gate was written

Implemented as a throwaway probe first and run over every markdown prose file at `e6ede02d7`:

| | |
|---|---:|
| markdown prose files | 106 |
| relative markdown links | 183 |
| that do not resolve from their own file | **1** |

The single offender: `port/docs/opie-assessment.md:3` links `roadmap.md`, which lives at `notes/roadmap.md`.

**One offender is a fix, not a ratchet.** So it is corrected in this PR and the check ships **fail-closed with no baseline** — nothing is grandfathered. The repo-rooted scan needs `config/dead-reference-baseline.json` because its false-positive population is 132 (other repos' paths, synthetic fixture paths, deliberately historical prose); this check has a population of one, and a baseline nobody needs is a place for real breakage to hide.

## What the extractor counts

**Markdown files only.** Link syntax means nothing in a python docstring, and applying it there is actively harmful — a regex character class followed by a group is indistinguishable from a link, and seven of the twelve hits in the first tree-wide pass were exactly that.

Also skipped: **inline code spans**, for the same reason — hand-rolled vtable dispatch written in backticks in `notes/archive/pret-idioms.md` reads as a markdown link and is not one (four more of those twelve). And `http:` / `mailto:` / any scheme, and bare `#anchor`.

Handled: angle-bracket targets, titles, reference definitions of the `[label]: path` form, `#fragment` stripped before resolving, and a directory target (alive when anything tracked lives under it).

**Fenced blocks are skipped, which differs from the repo-rooted scan.** Deliberate: a path in a fenced command example is a real claim about the tree, whereas a link inside a fence is being *shown*, not followed. It costs nothing either way today — all 183 links sit outside fences.

**No double-reporting.** Anything the repo-rooted scan already owns for a file is left to it, baselined entries included, so a link that is dead by both readings is reported once.

`MIN_LINKS = 50` joins the existing `SCAN TOO SMALL` floors, so this check cannot pass by extracting nothing either. 183 links today, 106 of them in one note; the floor survives that note being deleted outright.

## The failure path is exercised, not assumed

Reintroducing the exact #2036 line into the tracked note in a worktree, then running the checker:

```
check_dead_references: 372 prose file(s), 3474 repo-rooted path reference(s), 132 that do not resolve; 183 markdown link(s), 1 that do not resolve relative to their own file
  1 baselined reference(s) now resolve -- run --update to shrink the baseline (not a failure)
  no new dead references

FAIL: 1 markdown link(s) do not resolve from the file they are written in:

  notes/ead-debug-name-crossref.md:192
      links to `config/rom-name-glossary.json`, which resolves to `notes/config/rom-name-glossary.json` -- not in the tree

A markdown link is resolved against the DIRECTORY OF ITS OWN FILE, not the
repo root, so a note in `notes/` must write `../config/x.json` and not
`config/x.json`. There is no baseline for these: fix the link.

EXIT=1
```

Note the `no new dead references` line above it: the existing check is blind to the defect even while the new one fires.

On **the same injected defect**, the tool at `origin/main` in a `git archive` export:

```
check_dead_references: 372 prose file(s), 3468 repo-rooted path reference(s), 132 that do not resolve
  1 baselined reference(s) now resolve -- run --update to shrink the baseline (not a failure)
  no new dead references

EXIT=0
```

Reverted, `git diff` clean, this branch exits 0.

(The `1 baselined reference(s) now resolve` line is pre-existing on `origin/main` — it prints identically there — and the tool itself labels it *not a failure*.)

## The workflow filter was the same blind spot one step out

`dead-references.yml` filtered on the files the tool **reads** — `**.py`, `**.md`, `include/`, `src/`, `src_tu/`, the baseline JSON, `.github/workflows/`. But the tool also **resolves** what that prose names, against the whole tree, so a PR that only renames a resolution *target* broke references without touching anything in the filter.

Measured: **99 of the 183 links point outside the old filter**, 89 of them at a per-overlay symbols file, the rest under `symbols/` and `nearmiss/` or at top-level `attribution.json` and `LICENSE`. Renaming an overlay symbols file is routine here and would have broken 89 links silently — the same shape as the #2027 → #2030 → #2031 episode this workflow's own header already records.

Enumerating every top-level directory reproduces the tree in a list that goes stale on the next new directory, so the `paths:` filter is **removed** instead. The job is static analysis over the working tree with no compiler and no ROM.

The **pre-push hook does not run this gate** and this PR does not change that — `tools/hooks/pre-push` runs `prepush_linkcheck`, `prepush_attribution`, `port_refcheck`, `check_duplicate_sources`, `check_src_tu_compiles` and `check_references`, but never `check_dead_references.py`. Reported rather than fixed: adding a tree scan to every push is a policy call, not a defect fix.

## Gates, as base/branch pairs

Base is `e6ede02d7` (`origin/main`), run in a `git archive` export so the pair is like-for-like.

| gate | base `e6ede02d7` | this branch |
|---|---|---|
| `check_dead_references.py` | exit 0 | exit 0 |
| `python -m unittest tools.test_check_dead_references` | Ran 15, OK | **Ran 29, OK** (0 failures, 0 skips) |
| `pytest tools/test_dead_references.py` | 24 passed | 24 passed |
| `check_python_names.py` | PASS, 258 files, 46 advisory | PASS, 258 files, 46 advisory |
| `check_duplicate_sources.py` | 11182 stems, none doubled | 11182 stems, none doubled |
| pre-push hook | — | ran in full, clean, not bypassed |

Fourteen new tests: the exact #2036 shape (positive control), a correct `../` link, a sibling link, http and mailto, anchor-only, a fragment suffix, a directory target, a link in a fence, a link in backticks, angle-bracket and titled targets, a reference-style definition, the no-double-report case, link syntax inside python, and a fail-closed assertion that the real tree has zero broken links.

## No byte claim

This PR touches no compiled source — one workflow, one tool, its tests, and one line of a `port/docs/` note. `rombuild` was not run because there is no byte claim to make, and none is made.

---

## Post-review addendum

**A `premerge_check.py` run against the merge tree caught a regression this PR introduced — in the *pre-existing* repo-rooted scan, not the new one.** The first push's workflow comment spelled a template path with a literal `NNN` placeholder, which #2033's extension of the scan to `.github/workflows/**` reads as a real repo-rooted reference: `3473 -> 3474` references, `132 -> 133` unresolved. The new link check was clean throughout (`0 broken`).

Fixed by **rewording, not baselining** — a baseline entry for a placeholder written in the same diff would contradict this PR's own no-baseline argument on line one. The sentence now says "a per-overlay `symbols.txt`" with no slash-joined path token. Repo-rooted unresolved count is back to **132, identical to main**.

Rebased onto `e6ede02d7`. Re-measured there: still **183 relative links, 1 broken** — #2047's `src/` churn did not move them. The failure-path demo re-run on the rebased branch still exits 1 on `notes/ead-debug-name-crossref.md:192` with the same message, and `origin/main` still exits 0 on the identical injected defect.
