### PR TITLE
converted ratchet: refuse a baseline that contradicts itself

### DIFF
--- a/tools/test_tiers_ratchet.py
+++ b/tools/test_tiers_ratchet.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import sys
 import tempfile
@@ -191,6 +192,74 @@ class TranslationUnitIdentities(unittest.TestCase):
         self.assertIn(f"{dest}#Second", reason)
         self.assertIn(TR.tiers.CRITERION_LABEL["no_raw_offset"], reason)
 
+
+class BaselineIntegrity(unittest.TestCase):
+    """A baseline that contradicts itself must stop the tool, not be absorbed by it."""
+
+    def _write(self, body):
+        td = tempfile.mkdtemp()
+        path = pathlib.Path(td) / "converted-baseline.json"
+        path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+        return str(path)
+
+    def test_duplicate_identity_is_refused(self):
+        path = self._write({"count": 3, "converted": ["a.cpp", "b.cpp", "a.cpp"]})
+
+        with self.assertRaises(TR.BaselineError) as caught:
+            TR.load_baseline(path)
+
+        self.assertIn("a.cpp", str(caught.exception))
+
+    def test_count_disagreeing_with_the_array_is_refused(self):
+        path = self._write({"count": 99, "converted": ["a.cpp", "b.cpp"]})
+
+        with self.assertRaises(TR.BaselineError) as caught:
+            TR.load_baseline(path)
+
+        self.assertIn("99", str(caught.exception))
+
+    def test_a_dropped_identity_hidden_by_a_duplicate_is_caught(self):
+        """The shape this check exists for: `count` still matches, the set is smaller.
+
+        Removing one identity and duplicating another keeps len(array) == count, so the
+        count check alone would pass it. Only the distinctness check sees it.
+        """
+        path = self._write({"count": 3, "converted": ["a.cpp", "b.cpp", "b.cpp"]})
+
+        with self.assertRaises(TR.BaselineError):
+            TR.load_baseline(path)
+
+    def test_consistent_baseline_still_loads(self):
+        path = self._write({"count": 2, "converted": ["a.cpp", "b.cpp"]})
+
+        self.assertEqual(TR.load_baseline(path), {"a.cpp", "b.cpp"})
+
+    def test_absent_count_field_is_not_an_error(self):
+        """`count` is metadata; only a PRESENT and WRONG one is evidence of an edit."""
+        path = self._write({"converted": ["a.cpp", "b.cpp"]})
+
+        self.assertEqual(TR.load_baseline(path), {"a.cpp", "b.cpp"})
+
+    def test_missing_file_still_returns_None_rather_than_raising(self):
+        """The absent case keeps its old contract -- main() prints its own guidance."""
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(TR.load_baseline(str(pathlib.Path(td) / "nope.json")))
+
+    def test_unparsable_file_still_returns_None_rather_than_raising(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "bad.json"
+            path.write_text("{not json", encoding="utf-8")
+
+            self.assertIsNone(TR.load_baseline(str(path)))
+
+    def test_write_then_load_round_trips(self):
+        """--update's own output must never trip the check it now has to pass."""
+        with tempfile.TemporaryDirectory() as td:
+            path = str(pathlib.Path(td) / "baseline.json")
+            TR.write_baseline(path, {"b.cpp", "a.cpp", "a.cpp#Member"})
+
+            self.assertEqual(TR.load_baseline(path),
+                             {"a.cpp", "b.cpp", "a.cpp#Member"})
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tiers_ratchet.py
+++ b/tools/tiers_ratchet.py
@@ -241,12 +241,26 @@ def scan(paths=None, ownership=None):
     return converted, scores
 
 
+class BaselineError(Exception):
+    """The baseline file parsed, but its contents contradict themselves.
+
+    Deliberately NOT the None return below. None means "no usable baseline", and
+    --update treats that as "bake a new one", rewriting the whole file without the
+    --reason gate that removals normally require. Routing corruption through None
+    would therefore let a damaged baseline be replaced by whatever the tree happens to
+    look like -- turning the evidence of the damage into the new baseline. A
+    self-contradicting file is a fact about the file, so it stops both paths.
+    """
+
+
 def load_baseline(path):
     """The banked set, or None when there is no usable baseline file.
 
     A malformed or absent baseline is a configuration error, never an empty set: an
     empty set makes --check pass forever, so a deleted baseline would silently disable
     the gate rather than break it.
+
+    Raises BaselineError when the file parses but contradicts itself.
     """
     p = pathlib.Path(path)
     if not p.is_file():
@@ -258,6 +272,27 @@ def load_baseline(path):
     got = d.get("converted")
     if not isinstance(got, list):
         return None
+
+    # write_baseline() emits sorted(converted) from a set alongside count=len(converted),
+    # so in a file this tool wrote, these numbers agree by construction. A disagreement
+    # means something other than --update edited the file, and both shapes are silent
+    # without this check: set() below swallows duplicates, and nothing has ever read
+    # `count` back. That silence is a real weakening, not a tidiness issue -- an
+    # identity can be dropped from the array and the drop hidden by duplicating
+    # another, leaving a gate that watches less than its own count claims.
+    if len(set(got)) != len(got):
+        dupes = sorted({x for x in got if got.count(x) > 1})
+        shown = ", ".join(dupes[:5])
+        more = f", and {len(dupes) - 5} more" if len(dupes) > 5 else ""
+        raise BaselineError(
+            f"{path} lists {len(got)} identities but only {len(set(got))} are "
+            f"distinct.\nDuplicated: {shown}{more}")
+    count = d.get("count")
+    if isinstance(count, int) and count != len(got):
+        raise BaselineError(
+            f"{path} declares count={count} but its `converted` array holds "
+            f"{len(got)} identities.\nThe two are written together by --update, so "
+            "they can only disagree if the file was edited by hand.")
     return set(got)
 
 
@@ -450,7 +485,14 @@ def main():
         print("\n".join(sorted(current)))
         return 0
 
-    banked = load_baseline(args.baseline)
+    try:
+        banked = load_baseline(args.baseline)
+    except BaselineError as e:
+        print(f"baseline is internally inconsistent:\n\n{e}\n\n"
+              "Refusing to run. Fix the file in git rather than re-running --update:\n"
+              "--update would bank whatever the tree looks like now, which discards\n"
+              "the very difference this check exists to show you.")
+        return 2
 
     if args.update:
         left = sorted((banked or set()) - current)


### PR DESCRIPTION
## What is wrong today

`tiers_ratchet.load_baseline()` ends in `return set(got)`. Nothing ever reads the `count`
field back, and `set()` silently swallows duplicates. `write_baseline()` always emits
`sorted(converted)` from a set alongside `count=len(converted)`, so in any file the tool
itself wrote, those three numbers agree by construction. **A disagreement is therefore
evidence that something other than `--update` edited the file** — and both shapes of that
edit currently load without a word.

## The shape that matters

Not a stray duplicate — those are noisy but harmless. The dangerous edit **drops one
identity and hides the drop by duplicating another**. `len(converted)` stays 2571 and
`count` stays 2571, so a count-only check passes it. Only distinctness sees it.

Measured against the real `config/converted-baseline.json` at `48ae82060`, with
`src/AddSpikeBomb.c` removed and its neighbour duplicated:

| | exit | output |
|---|---|---|
| **main's tool**, `--check` | **0** | `CONVERTED ratchet PASS   baseline 2570   current 2571   (+1 gained, not yet banked)` |
| **this branch**, `--check` | **2** | `lists 2571 identities but only 2570 are distinct. Duplicated: src/AddVec3.c` |

Main does not merely pass. It reports the identity it stopped watching as a **gain in the
tree** — the one line an author would read as good news. Between that edit and the next
`--update`, the gate watches 2570 of the 2571 identities its own file claims, and says so
nowhere.

## Why this does not reuse the existing `None` return

`None` means "no usable baseline". `--update` treats that as *bake a new one* and rewrites
the whole file **without** the `--reason` gate that removals normally require. Routing
corruption through `None` would therefore make the damaged file's replacement automatic.

That is not hypothetical — main's `--update` on the same tampered file:

```
main      --update  exit 0   wrote ...: 2570 -> 2571 (+1 / -0)   AddSpikeBomb re-banked: True
hardened  --update  exit 2   refuses, points at the file
```

Main silently repairs it and records the tampering as an ordinary `+1` conversion. Nothing
is permanently lost, but the audit trail now says a file was newly converted when in fact
the baseline had been edited. A self-contradicting file is a fact about the file, so
`BaselineError` stops **both** paths at exit 2.

## Scope

- An **absent** `count` is still legal — only a present-and-wrong one is evidence of an edit.
- Absent and unparsable files keep returning `None` unchanged, so `--check`'s existing
  "no usable baseline" guidance is untouched.
- Callers are `tiers_ratchet.main()` and `test_tiers.py:195` only.
- `--update`'s own output round-trips through the new check (tested), so the tool can never
  write a file it would then refuse.

## Gates

```
tools.test_tiers_ratchet    12 -> 20 tests   OK      (8 new, incl. the hidden-drop case)
tools.test_tiers            29              OK      unchanged
live tiers_ratchet --check  PASS 2571/2571  exit 0  unchanged
pre-push hook               port-refcheck 405 refs resolve; duplicate-sources 11174 stems,
                            none doubled; check_src_tu_compiles 91/91 in 5.6s
```

`check_references.py` **skipped** (no current eligibility report) — a skip, not a pass.

**No byte claim.** This touches no compiled source: `git diff --name-only origin/main HEAD`
is two files, both under `tools/`. No `rombuild`, no `eligible`, no `romdata_check` was run,
and none is implicated.

The new tests run in CI — `converted-ratchet.yml` gained a `Ratchet unit tests` step in
\#2052, and this module is what that step executes.
