### PR TITLE
Group B of #2001, re-cut on current main: intact-TU production, with the two review regressions fixed

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -10,7 +10,7 @@
 # gate's FAILURE branch is the one path a green run never exercises: no ROM build can
 # reach it, because these tools are not compiled into the ROM. src-tu-refs.yml exists
 # because #1643 broke 26 translation units while every byte gate stayed green, and the
-# only thing that noticed was a test suite a human had to run. This job runs 432 of
+# only thing that noticed was a test suite a human had to run. This job runs 435 of
 # those assertions on every PR that touches `tools/` or `nearmiss/`, so the next one is
 # noticed by CI.
 #
@@ -29,7 +29,8 @@
 #      compiler -- is what actually stops most of `tools/` on a runner: 24 modules die
 #      on `No module named 'elftools'` alone (test_rombuild, test_romdata_check,
 #      test_check_references, test_tu_config, test_tu_production, test_reloc_audit_*,
-#      test_mangle, test_name_roundtrip, test_pr_linkcheck_*, and more), test_swarm and
+#      test_mangle, test_name_roundtrip, test_pr_linkcheck_*, test_tu_promote,
+#      test_objisolate, and more), test_swarm and
 #      test_worklist on capstone, test_bmg on ndspy. Pinning those is a fair follow-up;
 #      it is a different change from this one, and it should come with a requirements
 #      file rather than a version invented in a `run:` line.
@@ -72,7 +73,7 @@
 # test_stamp_provenance_verify ("needs extracted/ (ROM dump)", a real @skipUnless) and
 # two in test_match_provenance ("no src samples"). test_premerge_check adds none on a
 # runner with git installed, and test_symrecords and test_nearmiss_db add none anywhere.
-# 426 of the 432 assert something.
+# 429 of the 435 assert something.
 name: tool tests
 
 on:
@@ -195,8 +196,14 @@ jobs:
 #   test_rombuild_cache         (19)   rombuild_cache.py -- the content-addressed object
 #                                      cache. A stale-key bug here silently serves the
 #                                      WRONG object into a byte-gate run.
-#   test_rombuild_check          (6)   rombuild_check.py -- turns a source-built ROM into
-#                                      the fidelity metrics every gate quotes.
+#   test_rombuild_check          (9)   rombuild_check.py -- turns a source-built ROM into
+#                                      the fidelity metrics every gate quotes, including
+#                                      the diagnostic row a src/-owned NON-.text claim
+#                                      gets when it mismatches. That case is why this
+#                                      module gained 3 tests; it is also the only one of
+#                                      the intact-TU suites a bare runner can execute,
+#                                      because it imports enroll and srcpath and nothing
+#                                      that reaches elftools.
 #   test_rombuild_profile        (6)   rombuild_profile.py -- isolated stock and
 #                                      intentional-mod build configs.
 #   test_sinit_owners            (9)   sinit_owners.py -- ranks the likely original TU

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -198,7 +198,7 @@ jobs:
 #                                      WRONG object into a byte-gate run.
 #   test_rombuild_check          (9)   rombuild_check.py -- turns a source-built ROM into
 #                                      the fidelity metrics every gate quotes, including
-#                                      the diagnostic row a src/-owned NON-.text claim
+#                                      the diagnostic row a source-owned NON-.text claim
 #                                      gets when it mismatches. That case is why this
 #                                      module gained 3 tests; it is also the only one of
 #                                      the intact-TU suites a bare runner can execute,

--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -892,7 +892,7 @@ def derive_section_partition(raw, keep_section_names, licensed_symbols,
     return _apply(raw, p, None), p
 
 
-def rebias_object_symbols(raw, symbol_policies):
+def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
     """Move exact retained object symbols from storage start to public address point.
 
     C++ vtable definitions are the motivating case.  mwcc's symbol covers the full
@@ -901,11 +901,17 @@ def rebias_object_symbols(raw, symbol_policies):
     isolation already rewrites imports to that public convention; a separately linked
     data partition must therefore expose its strong definition at the same point.
 
-    Content and relocations are deliberately untouched.  A policy may additionally
-    split the preamble into an exact storage-alias symbol by reusing one explicitly
-    deadstripped compiler-only symbol-table slot.  Reusing a slot keeps every ELF
-    offset stable; it is allowed only when the old name is an unreferenced GLOBAL/FUNC
-    import with enough exclusive string-table storage for the alias.
+    Content bytes are deliberately untouched.  Surviving RELA/ABS32 references to a
+    rebased definition have their addends reduced by the same bias, preserving the
+    resolved address exactly while changing the public symbol convention.  With
+    ``normalize_undefined``, raw references to undefined ``_ZTV`` imports lose the
+    same ABI preamble from their addend; unlike a rebased local definition this fixes
+    the address the repository's already-public import would otherwise resolve to.
+    A policy may additionally split the preamble into an exact storage-alias symbol by
+    reusing one explicitly deadstripped compiler-only symbol-table slot.  Reusing a
+    slot keeps every ELF offset stable; it is allowed only when the old name is an
+    unreferenced GLOBAL/FUNC import with enough exclusive string-table storage for the
+    alias.
     """
     requested = {}
     for name, policy in dict(symbol_policies).items():
@@ -928,7 +934,7 @@ def rebias_object_symbols(raw, symbol_policies):
             return None, {"rebased": [], "aliases": [],
                           "error": f"{name} needs bias/size/section and valid optional "
                                    "storageAlias fields"}
-    if not requested:
+    if not requested and not normalize_undefined:
         return bytes(raw), {"rebased": [], "aliases": [], "error": None}
     bad_bias = sorted(name for name, policy in requested.items()
                       if policy["bias"] <= 0 or policy["bias"] >= policy["size"])
@@ -942,11 +948,6 @@ def rebias_object_symbols(raw, symbol_policies):
     if symtab is None:
         return None, {"rebased": [], "aliases": [], "error": "no .symtab"}
     syms = list(symtab.iter_symbols())
-    protected_sections = {
-        i: sec.data() for i, sec in enumerate(elf.iter_sections())
-        if ((sec.header["sh_type"] in CONTENT and sec.header["sh_size"])
-            or (isinstance(sec, RelocationSection) and sec.header["sh_size"]))
-    }
     by_name = {name: [(i, sym) for i, sym in enumerate(syms)
                       if sym.name == name and sym["st_shndx"] not in
                       ("SHN_UNDEF", "SHN_ABS")]
@@ -981,22 +982,87 @@ def rebias_object_symbols(raw, symbol_policies):
                           f"0x{sec.header['sh_size']:x}, manifest="
                           f"0x{requested[name]['size']:x})"}
 
-    # Rebiasing changes what a relocation to this definition means. No current owned
-    # data needs such a self-reference, so refuse it rather than guessing whether its
-    # addend used storage-start or public-address-point convention.
-    for relsec in elf.iter_sections():
+    import struct
+    endian = "<" if elf.little_endian else ">"
+
+    # Moving the definition from storage start to public address point must not move
+    # any resolved reference.  mwcc's live references use RELA/ABS32 with the ABI
+    # preamble bias in r_addend, so subtract exactly that bias and leave the content,
+    # relocation offset, and target symbol index untouched.
+    relocation_rewrites = []
+    mutable_relocation_sections = set()
+    for relsec_index, relsec in enumerate(elf.iter_sections()):
         if not isinstance(relsec, RelocationSection):
             continue
         source = elf.get_section(relsec.header["sh_info"])
         if source.header["sh_type"] not in CONTENT or not source.header["sh_size"]:
             continue
-        for reloc in relsec.iter_relocations():
+        for reloc_index, reloc in enumerate(relsec.iter_relocations()):
             target = symtab.get_symbol(reloc["r_info_sym"])
-            if target.name in requested:
+            target_is_rebased = target.name in requested
+            target_is_undefined = (normalize_undefined
+                                   and target.name.startswith("_ZTV")
+                                   and target["st_shndx"] in ("SHN_UNDEF", SHN_UNDEF))
+            if not target_is_rebased and not target_is_undefined:
+                continue
+            if relsec.header["sh_type"] != "SHT_RELA" or not reloc.is_RELA():
                 return None, {"rebased": [], "aliases": [],
-                              "error": f"surviving {source.name} "
-                              f"relocation at 0x{reloc['r_offset']:x} targets rebased "
-                              f"symbol {target.name}"}
+                              "relocations": [],
+                              "error": f"surviving {source.name} relocation at "
+                              f"0x{reloc['r_offset']:x} targets rebased symbol "
+                              f"{target.name} but is not SHT_RELA"}
+            if reloc["r_info_type"] != R_ARM_ABS32:
+                return None, {"rebased": [], "aliases": [],
+                              "relocations": [],
+                              "error": f"surviving {source.name} relocation at "
+                              f"0x{reloc['r_offset']:x} targets rebased symbol "
+                              f"{target.name} with unsupported type "
+                              f"{reloc['r_info_type']}"}
+            old_addend = int(reloc["r_addend"])
+            # An addend-zero undefined import was written explicitly against the
+            # repository's public address-point convention and needs no correction.
+            if target_is_undefined and old_addend == 0:
+                continue
+            bias = (requested[target.name]["bias"] if target_is_rebased
+                    else VTABLE_PREAMBLE)
+            if old_addend < bias:
+                return None, {"rebased": [], "aliases": [],
+                              "relocations": [],
+                              "error": f"surviving {source.name} relocation at "
+                              f"0x{reloc['r_offset']:x} targets rebased symbol "
+                              f"{target.name} with addend {old_addend}, smaller than "
+                              f"bias {bias}"}
+            entry_size = int(relsec.header["sh_entsize"])
+            if entry_size < 12:
+                return None, {"rebased": [], "aliases": [],
+                              "relocations": [],
+                              "error": f"{relsec.name} has invalid RELA entry size "
+                              f"{entry_size}"}
+            entry_offset = reloc_index * entry_size
+            relocation_rewrites.append({
+                "sectionIndex": relsec_index, "section": source.name,
+                "relocationSection": relsec.name, "offset": reloc["r_offset"],
+                "symbol": target.name, "type": "R_ARM_ABS32",
+                "oldAddend": old_addend, "newAddend": old_addend - bias,
+                "mode": "rebased-definition" if target_is_rebased
+                        else "undefined-public-import",
+                "entryOffset": entry_offset,
+                "fileOffset": relsec.header["sh_offset"] + entry_offset + 8,
+            })
+            mutable_relocation_sections.add(relsec_index)
+
+    protected_sections = {
+        i: sec.data() for i, sec in enumerate(elf.iter_sections())
+        if i not in mutable_relocation_sections
+        and ((sec.header["sh_type"] in CONTENT and sec.header["sh_size"])
+             or (isinstance(sec, RelocationSection) and sec.header["sh_size"]))
+    }
+    expected_relocation_sections = {
+        i: bytearray(elf.get_section(i).data()) for i in mutable_relocation_sections
+    }
+    for row in relocation_rewrites:
+        struct.pack_into(endian + "i", expected_relocation_sections[row["sectionIndex"]],
+                         row["entryOffset"] + 8, row["newAddend"])
 
     aliases = {}
     used_donors = set()
@@ -1087,8 +1153,6 @@ def rebias_object_symbols(raw, symbol_policies):
         for i, sym in enumerate(syms) if i not in mutable_symbol_indices
     }
 
-    import struct
-    endian = "<" if elf.little_endian else ">"
     base = symtab.header["sh_offset"]
     rows, alias_rows = [], []
     for name in sorted(requested):
@@ -1117,6 +1181,8 @@ def rebias_object_symbols(raw, symbol_policies):
         rows.append({"symbol": name, "bias": bias,
                      "oldValue": sym["st_value"], "newValue": new_value,
                      "oldSize": sym["st_size"], "newSize": new_size})
+    for row in relocation_rewrites:
+        struct.pack_into(endian + "i", raw_out, row["fileOffset"], row["newAddend"])
     out = bytes(raw_out)
     checked = ELFFile(io.BytesIO(out))
     checked_symtab = checked.get_section_by_name(".symtab")
@@ -1137,6 +1203,16 @@ def rebias_object_symbols(raw, symbol_policies):
     if checked_sections != protected_sections:
         return None, {"rebased": rows, "aliases": alias_rows,
                       "error": "storage rewrite changed content or relocation bytes"}
+    checked_relocation_sections = {
+        i: checked.get_section(i).data() for i in mutable_relocation_sections
+    }
+    expected_relocation_sections = {
+        i: bytes(data) for i, data in expected_relocation_sections.items()
+    }
+    if checked_relocation_sections != expected_relocation_sections:
+        return None, {"rebased": rows, "aliases": alias_rows,
+                      "relocations": relocation_rewrites,
+                      "error": "storage rewrite changed more than licensed RELA addends"}
     for name, alias in aliases.items():
         matches = [sym for sym in checked_symbols
                    if sym.name == alias["symbol"]]
@@ -1154,7 +1230,11 @@ def rebias_object_symbols(raw, symbol_policies):
             return None, {"rebased": rows, "aliases": alias_rows,
                           "error": f"post-rewrite storage split is not exact for "
                                    f"{alias['symbol']}/{name}"}
-    return out, {"rebased": rows, "aliases": alias_rows, "error": None}
+    public_relocations = [{k: v for k, v in row.items()
+                           if k not in ("sectionIndex", "entryOffset", "fileOffset")}
+                          for row in relocation_rewrites]
+    return out, {"rebased": rows, "aliases": alias_rows,
+                 "relocations": public_relocations, "error": None}
 
 
 def isolate(obj, keep_symbol):

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -33,12 +33,14 @@ tools/rombuild_cache.py for the key and why it is safe to trust.
 See notes/rom-build.md for the milestones and the enrollment rules.
 """
 import argparse
+import collections
 import concurrent.futures
 import hashlib
 import io
 import json
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -212,6 +214,19 @@ class BuildError(RuntimeError):
         self.output = output
 
 
+def intact_rom_comparison(actual_sha256, verification):
+    """Describe the final same-worker production/control ROM comparison."""
+    baseline = verification["baseline"]
+    expected = baseline["romSha256"]
+    return {
+        "expectedSha256": expected,
+        "admittedBootstrapSha256": verification["admittedRomSha256"],
+        "actualSha256": actual_sha256,
+        "moduleSetSha256": baseline["moduleSetSha256"],
+        "identical": actual_sha256 == expected,
+    }
+
+
 def run(cmd, what, quiet_patterns=()):
     r = subprocess.run(cmd, capture_output=True, text=True,
                        env=dict(os.environ, LM_LICENSE_FILE=str(LICENSE)), cwd=REPO)
@@ -253,9 +268,16 @@ def enrolled(config_root=CONFIG_ROOT, extra_roots=()):
         if path and saw_complete:
             files.append(path)
         path, saw_complete = None, False
+    normalized = [pathlib.PurePosixPath(rel.replace("\\", "/")).as_posix()
+                  for rel in files]
+    duplicates = sorted(rel for rel, count in collections.Counter(normalized).items()
+                        if count != 1)
+    if duplicates:
+        raise BuildError("profile", 1, "complete source path enrolled more than once: "
+                         + ", ".join(duplicates))
     checked = []
-    for rel in sorted(set(files)):
-        pure = pathlib.PurePosixPath(rel.replace("\\", "/"))
+    for rel in sorted(normalized):
+        pure = pathlib.PurePosixPath(rel)
         if (pure.is_absolute() or ".." in pure.parts or len(pure.parts) < 2
                 or pure.parts[0] not in ("src", "mods", *extra_roots)
                 or pure.suffix not in (".c", ".cpp")):
@@ -291,7 +313,7 @@ def init_section_sources():
     return {rel for (_d, _name, rel, _addr, _size, sec) in cands if sec == ".init"}
 
 
-def _isolate(obj, rel, syms, data_sink=None, compiler_only=None):
+def _isolate(obj, rel, syms, data_sink=None, compiler_only=None, intact_tus=None):
     """Reduce a compiled `src/` object to its declared function(s).
 
     A legacy source owns one function and takes the unchanged singular isolation path.
@@ -319,6 +341,17 @@ def _isolate(obj, rel, syms, data_sink=None, compiler_only=None):
         # can fail the build. See tools/romdata_check.py for why it is not a gate.
         data_sink.extend(RDC.check_object(obj, rel))
     selected = (syms or {}).get(rel, pathlib.Path(rel).stem)
+    intact = (intact_tus or {}).get(rel.replace("\\", "/"))
+    if intact is not None:
+        if not isinstance(selected, (list, tuple)) or not selected:
+            return "intact TU policy requires one or more enrolled function symbols"
+        try:
+            import tu_production as TP  # noqa: PLC0415 - only intact TUs need it
+            prepared, _evidence = TP.prepare_intact_object(obj.read_bytes(), intact)
+        except Exception as exc:  # noqa: BLE001 - one source gets one build verdict
+            return f"intact TU preparation refused: {exc}"
+        obj.write_bytes(prepared)
+        return None
     if isinstance(selected, (list, tuple)):
         if not selected:
             return "source owns no enrolled functions"
@@ -737,6 +770,143 @@ def compiler_only_policies(enrolled=None, manifest=None, homes=None):
     return out
 
 
+def intact_tu_policies(enrolled=None, manifest=None):
+    """Manifest entries admitted to the normal build as one intact compiler object.
+
+    This is deliberately opt-in.  A non-text manifest is not enough: the entry must
+    be promoted, request ``production_mode: intact-object``, and carry a successful
+    ordinary scratch link proving every claimed range, all modules, and the full ROM.
+    The compile path re-runs the exact object/data/relocation checks on every raw object;
+    this admission record prevents an unverified research manifest from selecting the
+    policy in the first place.
+    """
+    data = TUM.load() if manifest is None else manifest
+    active_counts = None if enrolled is None else collections.Counter(
+        str(rel).replace("\\", "/") for rel in enrolled)
+    out, errors = {}, []
+    for entry in data.get("entries", []):
+        if entry.get("production_mode") != "intact-object":
+            continue
+        source = str(entry.get("promoted_source")
+                     or entry.get("source", "")).replace("\\", "/")
+        label = entry.get("id", source or "<unknown>")
+        if active_counts is not None and active_counts[source] != 1:
+            if entry.get("status") == "promoted":
+                errors.append(f"{label}: promoted intact-object source {source!r} is "
+                              f"enrolled {active_counts[source]} time(s), expected exactly 1")
+            continue
+        if not source.startswith("src/"):
+            errors.append(f"{label}: intact-object policy has no production src/ path")
+            continue
+        if source in out:
+            errors.append(f"{source}: intact-object policy is declared by multiple entries")
+            continue
+        if entry.get("status") != "promoted":
+            errors.append(f"{label}: enrolled intact-object entry is not promoted")
+        section_names = {row.get("name") for row in entry.get("sections", [])
+                         if isinstance(row, dict)}
+        if ".text" not in section_names or not (section_names - {".text"}):
+            errors.append(f"{label}: intact-object policy needs .text and non-text claims")
+        mapped_sections = [
+            f"{row.get('name')} -> {row.get('module_section')}"
+            for row in entry.get("sections", []) if isinstance(row, dict)
+            and row.get("module_section", row.get("name")) != row.get("name")]
+        if mapped_sections:
+            errors.append(f"{label}: intact-object input-section retargeting is not "
+                          f"implemented: {', '.join(mapped_sections)}")
+        owned_fields = ("rodata", "init", "ctor", "data", "bss")
+        if any(isinstance(entry.get(field), list)
+               and any(isinstance(row, dict) and row.get("storage_alias")
+                       for row in entry[field])
+               for field in owned_fields):
+            errors.append(f"{label}: automatic intact-object storage aliases are not "
+                          "supported until baseline bootstrapping is non-circular")
+        linkcheck = (entry.get("verification") or {}).get("linkcheck") or {}
+        phases = linkcheck.get("phases") or {}
+        if linkcheck.get("result") != "scratch-data-verified":
+            errors.append(f"{label}: intact-object policy needs scratch-data-verified "
+                          "ordinary link evidence")
+        for phase in ("delink", "lcf", "compile", "link", "checkModules", "rom"):
+            if phases.get(phase) is not True:
+                errors.append(f"{label}: intact-object proof phase {phase} is not green")
+        if linkcheck.get("symbolCheckNewVsBaseline") != []:
+            errors.append(f"{label}: intact-object proof has new or unknown symbol errors")
+        recorded_errors = linkcheck.get("symbolCheckErrors")
+        baseline_errors = linkcheck.get("symbolCheckBaselineErrors")
+        if not isinstance(recorded_errors, list):
+            errors.append(f"{label}: intact-object proof has no symbol-error inventory")
+        if not isinstance(baseline_errors, list):
+            errors.append(f"{label}: intact-object proof has no baseline symbol-error "
+                          "inventory")
+        if (isinstance(recorded_errors, list) and isinstance(baseline_errors, list)
+                and sorted(set(recorded_errors)) != sorted(set(baseline_errors))):
+            errors.append(f"{label}: intact-object proof's symbol errors differ from its "
+                          "baseline inventory")
+        ranges = linkcheck.get("tuRanges") or []
+        expected_ranges = []
+        seen_sections = set()
+        for row in entry.get("sections", []):
+            try:
+                name = row["name"]
+                start, end = int(row["start"], 16), int(row["end"], 16)
+            except (KeyError, TypeError, ValueError):
+                errors.append(f"{label}: intact-object manifest has an invalid section claim")
+                continue
+            if name not in (".text", ".data", ".rodata", ".bss") or start >= end:
+                errors.append(f"{label}: intact-object manifest has unsupported/invalid "
+                              f"section claim {name!r}")
+            if name in seen_sections:
+                errors.append(f"{label}: intact-object manifest repeats section {name}")
+            seen_sections.add(name)
+            expected_ranges.append((name, start, end))
+        ordered_ranges = sorted(expected_ranges, key=lambda row: (row[1], row[2]))
+        if any(left[2] > right[1]
+               for left, right in zip(ordered_ranges, ordered_ranges[1:])):
+            errors.append(f"{label}: intact-object manifest section claims overlap")
+        proved_ranges = []
+        ranges_exact = bool(ranges)
+        for row in ranges:
+            try:
+                key = (row["section"], int(row["start"], 16), int(row["end"], 16))
+            except (KeyError, TypeError, ValueError):
+                ranges_exact = False
+                continue
+            proved_ranges.append(key)
+            if key[0] == ".bss":
+                ranges_exact = ranges_exact and row.get("comparison") == \
+                    "NOBITS -- symbol/module gates"
+            else:
+                ranges_exact = ranges_exact and row.get("differingBytes") == 0
+        if (not ranges_exact or sorted(proved_ranges) != sorted(expected_ranges)
+                or len(proved_ranges) != len(expected_ranges)):
+            errors.append(f"{label}: intact-object proof does not show every current "
+                          "manifest range exact")
+        rom = linkcheck.get("rom") or {}
+        sha = rom.get("sha256")
+        if not isinstance(sha, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", sha):
+            errors.append(f"{label}: intact-object proof has no full-ROM SHA-256")
+        if rom.get("matchesStockRom") is not True:
+            errors.append(f"{label}: intact-object proof does not show the full ROM "
+                          "identical to stock")
+        out[source] = entry
+    proof_shas = {
+        (((entry.get("verification") or {}).get("linkcheck") or {}).get("rom") or {})
+        .get("sha256") for entry in out.values()
+    }
+    if len(proof_shas) > 1:
+        errors.append("promoted intact-object entries disagree on the stock ROM SHA-256")
+    symbol_inventories = {
+        tuple(((entry.get("verification") or {}).get("linkcheck") or {})
+              .get("symbolCheckErrors") or []) for entry in out.values()
+    }
+    if len(symbol_inventories) > 1:
+        errors.append("promoted intact-object entries disagree on the allowed symbol-error "
+                      "inventory")
+    if errors:
+        raise BuildError("intact TU policy", 1, "\n".join(errors))
+    return out
+
+
 def _definition_symbols(rel, rows):
     """Collapse owned records only for one exact legacy outer-owner alias shape.
 
@@ -808,7 +978,7 @@ def retarget_text_section(obj, section=".init"):
 
 
 def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_root=None,
-                data_sink=None, prebuilt=None, compiler_only=None):
+                data_sink=None, prebuilt=None, compiler_only=None, intact_tus=None):
     """Compile one enrolled source file to the object path dsd's objects.txt names.
 
     Returns (rel, error-or-None, outcome), where outcome is how the object was
@@ -848,7 +1018,7 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_roo
             err = _retarget(obj, rel, init_srcs)
             if err:
                 return rel, f"retarget: {err}", "error"
-            err = _isolate(obj, rel, syms, data_sink, compiler_only)
+            err = _isolate(obj, rel, syms, data_sink, compiler_only, intact_tus)
             if err:
                 return rel, f"isolate: {err}", "error"
             return rel, None, "hit"
@@ -882,18 +1052,18 @@ def compile_one(rel, vers=None, cache=None, init_srcs=None, syms=None, build_roo
         if err:
             return rel, f"retarget: {err}", "error"
         if key is None:
-            err = _isolate(obj, rel, syms, data_sink, compiler_only)
+            err = _isolate(obj, rel, syms, data_sink, compiler_only, intact_tus)
             return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
         deps = cache.deps_from(scratch)
         if deps is None:
-            err = _isolate(obj, rel, syms, data_sink, compiler_only)
+            err = _isolate(obj, rel, syms, data_sink, compiler_only, intact_tus)
             return (rel, f"isolate: {err}", "error") if err else (rel, None, "uncacheable")
         # Cache the RAW object, then isolate the working copy. Storing the reduced
         # form instead would bake this transformation into every entry, so any later
         # fix to it would be masked by isolate()'s own idempotence -- which is exactly
         # how the STB_LOPROC bug survived a rebuild and forced SCHEMA 2.
         cache.put(key, deps, obj)
-        err = _isolate(obj, rel, syms, data_sink, compiler_only)
+        err = _isolate(obj, rel, syms, data_sink, compiler_only, intact_tus)
         return (rel, f"isolate: {err}", "error") if err else (rel, None, "miss")
     finally:
         if scratch:
@@ -1039,6 +1209,27 @@ def main():
         init_srcs = init_section_sources()
         syms = enrolled_symbols()
         compiler_only = compiler_only_policies(srcs)
+        intact_tus = intact_tu_policies(srcs)
+        report["intactTus"] = sorted(entry.get("id", source)
+                                     for source, entry in intact_tus.items())
+        intact_link_verification = None
+        if intact_tus and args.profile == "stock":
+            import tu_production as ITP
+            try:
+                intact_link_verification = ITP.prepare_intact_link_verification(
+                    intact_tus, jobs=args.jobs)
+            except ITP.ProductionTuError as exc:
+                raise BuildError("intact TU link control", 1, str(exc)) from exc
+        elif intact_tus:
+            # `mods` deliberately permits module/ROM differences. The stock admission
+            # proof still governs how each intact source object is prepared, while its
+            # final fidelity is judged by rombuild_check's profile-aware allowances.
+            # Running retail-exact final gates here would make the documented mods
+            # profile impossible as soon as the first intact TU is promoted.
+            report["intactTuStockVerification"] = {
+                "status": "not-applicable",
+                "reason": f"{args.profile} profile permits intentional divergences",
+            }
         # Collected during the compile because that is the only point at which the
         # objects still carry the data mwcc emitted -- see _isolate. None switches the
         # measurement off entirely; it never affects what gets linked either way.
@@ -1057,6 +1248,7 @@ def main():
                         lambda s: compile_one(s, vers, cache, init_srcs, syms,
                                               data_sink=data_sink,
                                               compiler_only=compiler_only,
+                                              intact_tus=intact_tus,
                                               prebuilt=tu_overrides.get(
                                                   s.replace("\\", "/"))), srcs):
                     outcomes[outcome] = outcomes.get(outcome, 0) + 1
@@ -1096,6 +1288,21 @@ def main():
                                  "\n".join(detail) or "unknown verification failure")
             print("      partitioned TU gates: dsd modules PASS, zero new symbol "
                   "errors, storage aliases exact")
+        if intact_link_verification:
+            verification = ITP.verify_link(
+                config_yaml, BUILD / "final_link.o", intact_link_verification)
+            report["intactTuLinkVerification"] = verification
+            if not verification["ok"]:
+                detail = []
+                if not verification["modulesOk"]:
+                    detail.append("dsd check modules --fail did not pass")
+                detail.extend(f"new symbol error: {line}"
+                              for line in verification["newSymbolErrors"])
+                detail.extend(verification["storageAliasErrors"])
+                raise BuildError("intact TU link verification", 1,
+                                 "\n".join(detail) or "unknown verification failure")
+            print("      intact TU gates: dsd modules PASS, zero new symbol errors, "
+                  "storage aliases exact")
 
         if args.no_rom:
             print("[5/6] skipped (--no-rom)")
@@ -1120,6 +1327,15 @@ def main():
                     "bytes": rom_path.stat().st_size,
                     "sha256": rom_sha256,
                 }
+                if intact_link_verification:
+                    comparison = intact_rom_comparison(
+                        rom_sha256, intact_link_verification)
+                    report["intactTuRom"] = comparison
+                    if not comparison["identical"]:
+                        raise BuildError(
+                            "intact TU ROM comparison", 1,
+                            f"built ROM sha256 {rom_sha256} differs from same-worker "
+                            f"independent control {comparison['expectedSha256']}")
                 if tu_prepared:
                     expected = tu_prepared["baseline"]["romSha256"]
                     report["partitionedTuRom"] = {

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -215,6 +215,8 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
     per_module_bad = collections.Counter()
     source_functions = source_bytes = mod_functions = mod_bytes = 0
     source_data_bytes = 0
+    source_data_claims = bad_data_claims = bad_data_bytes = 0
+    reproducing_data_claims = reproducing_data_bytes = 0
     reproducing = reproducing_bytes = bad = bad_function_bytes = differing_source_bytes = 0
     module_set_digest = hashlib.sha256()
 
@@ -296,11 +298,54 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
                 bad_function_bytes += size
                 differing_source_bytes += nd
                 failures.append({"module": label, "name": pathlib.Path(rel).stem,
-                                 "addr": addr, "size": size, "differingBytes": nd})
+                                 "addr": addr, "size": size, "kind": "code",
+                                 "section": None, "differingBytes": nd})
                 per_module_bad[label] += 1
             else:
                 reproducing += function_count
                 reproducing_bytes += size
+
+        # The loop above walks .text/.init only, because those are the entries that own
+        # FUNCTIONS and every counter in it is a function counter. A src/-owned .data,
+        # .rodata or .bss claim is a byte claim with no function in it, so it fell out
+        # of that loop entirely and produced no diagnostic row at all.
+        #
+        # The verdict was still correctly red -- _diff_counts above sees the differing
+        # byte, it is outside every mods/ range, so unexpectedDifferingBytes is non-zero
+        # and `passed` is False. But a red verdict with an empty `failures` list and
+        # mismatchingFunctions == 0 says only "something, somewhere". That is the least
+        # useful shape exactly when a data claim first goes wrong, so these claims get
+        # their own rows here.
+        #
+        # They are counted separately rather than folded into `bad`: `bad` is reported
+        # as "mismatching functions" and a data claim contributes no function to it.
+        # `passed` gains the new counter explicitly rather than leaning on the module
+        # diff to stay red on its behalf -- one fact, one gate.
+        for rel, name, addr, end in entry_sections:
+            if not rel.startswith("src/") or name in (".text", ".init"):
+                continue
+            size = end - addr
+            source_data_claims += 1
+            lo, hi = addr - base, end - base
+            row = {"module": label, "name": pathlib.Path(rel).stem, "addr": addr,
+                   "size": size, "kind": "data", "section": name}
+            if lo < 0 or hi > len(retail) or hi > len(built):
+                bad_data_claims += 1
+                bad_data_bytes += size
+                failures.append({**row,
+                                 "reason": "range outside built or retail module"})
+                per_module_bad[label] += 1
+                continue
+            nd = sum(1 for x, y in zip(built[lo:hi], retail[lo:hi]) if x != y)
+            if nd:
+                bad_data_claims += 1
+                bad_data_bytes += size
+                differing_source_bytes += nd
+                failures.append({**row, "differingBytes": nd})
+                per_module_bad[label] += 1
+            else:
+                reproducing_data_claims += 1
+                reproducing_data_bytes += size
 
     total_functions, total_code_bytes = _code_totals(config_root)
     compared_module_bytes = sum(m["comparedBytes"] for m in module_results)
@@ -310,7 +355,8 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
     compiled_functions = source_functions + mod_functions
     compiled_bytes = source_bytes + mod_bytes
     mods_applied = all(m["differingBytes"] > 0 for m in intentional) if intentional else True
-    passed = bool(module_results) and not bad and not missing_bins and not unexpected_module_bytes \
+    passed = bool(module_results) and not bad and not bad_data_claims \
+        and not missing_bins and not unexpected_module_bytes \
         and (profile != "mods" or mods_applied)
 
     return {
@@ -368,6 +414,15 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             "mismatchingFunctions": bad,
             "mismatchingFunctionBytes": bad_function_bytes,
             "differingSourceBytes": differing_source_bytes,
+            # Non-text src/-owned claims, kept as their own counters: they carry no
+            # functions, so folding them into mismatchingFunctions would report a
+            # function count that no function is behind. differingSourceBytes is
+            # shared, because a differing byte is a differing byte either way.
+            "sourceDataClaims": source_data_claims,
+            "reproducingDataClaims": reproducing_data_claims,
+            "reproducingDataClaimBytes": reproducing_data_bytes,
+            "mismatchingDataClaims": bad_data_claims,
+            "mismatchingDataClaimBytes": bad_data_bytes,
         },
         "intentionalMods": intentional,
         "modsApplied": mods_applied,
@@ -391,6 +446,13 @@ def print_report(report, show=12):
           f"{sf['sourceBytesPercent']:.2f}%)")
     print(f"  reproducing: {sf['reproducingFunctions']:,}")
     print(f"  mismatching: {sf['mismatchingFunctions']:,}")
+    if sf.get("sourceDataClaims"):
+        # Only printed when such a claim exists, so the stock line is unchanged while
+        # the count is zero -- but once one exists, a mismatch in it must be as visible
+        # as a mismatching function, not buried in the module byte delta.
+        print(f"source-owned data claims: {sf['sourceDataClaims']:,}  "
+              f"(reproducing {sf.get('reproducingDataClaims', 0):,}, "
+              f"mismatching {sf.get('mismatchingDataClaims', 0):,})")
     print(f"module fidelity: {mf['modulesExact']}/{mf['modulesChecked']} exact, "
           f"{mf['percent']:.6f}% of compared bytes")
     mc = report.get("moduleComposition")
@@ -406,7 +468,8 @@ def print_report(report, show=12):
     if report["missingModuleBinaries"]:
         print(f"missing module binaries: {report['missingModuleBinaries'][:8]}")
     for f in report["failures"][:show]:
-        print(f"  {f['module']:26s} {f['name']:44s} 0x{f['addr']:08x} "
+        tag = f" {f['section']}" if f.get("kind") == "data" and f.get("section") else ""
+        print(f"  {f['module']:26s} {f['name'] + tag:44s} 0x{f['addr']:08x} "
               f"size 0x{f['size']:<5x} {f.get('differingBytes', f.get('reason'))}")
     print(f"ROM-build analysis: {'PASS' if report['passed'] else 'FAIL'}")
 
@@ -425,8 +488,14 @@ def main():
     report = analyze(args.config_root, args.profile, args.build_root)
     print_report(report, args.show)
     if args.out:
+        # Code rows only. This file is a list of FUNCTION names -- rombuild_versions.py
+        # feeds it straight into a per-function compiler-version sweep -- and a data
+        # claim's path stem names no function, so putting one here would send the sweep
+        # after a symbol that does not exist. The data rows are not lost: they are in
+        # the printed report, in --json, and they make `passed` False on their own.
         pathlib.Path(args.out).write_text(
-            "\n".join(sorted(f["name"] for f in report["failures"])) + "\n",
+            "\n".join(sorted(f["name"] for f in report["failures"]
+                             if f.get("kind", "code") != "data")) + "\n",
             encoding="utf-8", newline="\n")
     if args.json:
         pathlib.Path(args.json).write_text(

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -14,6 +14,7 @@ Usage:
 """
 import argparse
 import collections
+import hashlib
 import json
 import pathlib
 import re
@@ -77,30 +78,69 @@ def module_binaries(d, config_root=CONFIG, build_root=None):
     return None, None
 
 
-def complete_entries_text(text):
-    """Return ``[(path, address, end)]`` for entries carrying ``complete``."""
-    out, cur, done, sec = [], None, False, None
+def complete_entry_sections_text(text):
+    """Return every ``(path, section, address, end)`` in complete entries."""
+    out, cur, done, entry_sections = [], None, False, []
+
+    def flush():
+        if cur and done:
+            out.extend((cur, name, start, end)
+                       for name, start, end in entry_sections)
+
     for line in text.splitlines():
         if not line.strip():
             continue
         if not line[0].isspace():
-            if cur and done and sec:
-                out.append((cur, *sec))
-            cur, done, sec = line.strip().rstrip(":"), False, None
+            flush()
+            cur, done, entry_sections = line.strip().rstrip(":"), False, []
         elif cur is not None:
             if line.strip() == "complete":
                 done = True
             else:
                 m = ENTRY_SEC.match(line)
                 if m:
-                    sec = (int(m.group(2), 16), int(m.group(3), 16))
-    if cur and done and sec:
-        out.append((cur, *sec))
+                    entry_sections.append((m.group(1), int(m.group(2), 16),
+                                           int(m.group(3), 16)))
+    flush()
     return out
+
+
+def complete_entries_text(text):
+    """Return complete code contributions as ``[(path, address, end)]``.
+
+    Callers of this historical API measure function/source enrollment. Intact C++
+    entries can also own data; retaining the section name prevents a trailing .data
+    claim from replacing .text and being misreported as source code.
+    """
+    return [(rel, start, end)
+            for rel, name, start, end in complete_entry_sections_text(text)
+            if name in (".text", ".init")]
 
 
 def complete_entries(path):
     return complete_entries_text(path.read_text(encoding="utf-8", errors="ignore"))
+
+
+def complete_entry_sections(path):
+    return complete_entry_sections_text(
+        path.read_text(encoding="utf-8", errors="ignore"))
+
+
+def _covered_bytes(ranges, base, size):
+    """Union length of address ranges clipped to one linked module image."""
+    clipped = sorted((max(0, lo - base), min(size, hi - base))
+                     for lo, hi in ranges if hi > base and lo < base + size)
+    total = end = 0
+    for lo, hi in clipped:
+        if hi <= lo:
+            continue
+        if lo > end:
+            total += hi - lo
+            end = hi
+        elif hi > end:
+            total += hi - end
+            end = hi
+    return total
 
 
 def _code_totals(config_root):
@@ -174,14 +214,18 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
     missing_bins = []
     per_module_bad = collections.Counter()
     source_functions = source_bytes = mod_functions = mod_bytes = 0
+    source_data_bytes = 0
     reproducing = reproducing_bytes = bad = bad_function_bytes = differing_source_bytes = 0
+    module_set_digest = hashlib.sha256()
 
     for sym in sorted(config_root.rglob("symbols.txt")):
         d = sym.parent
         dl = d / "delinks.txt"
         if not dl.is_file():
             continue
-        entries = complete_entries(dl)
+        entry_sections = complete_entry_sections(dl)
+        entries = [(rel, start, end) for rel, name, start, end in entry_sections
+                   if name in (".text", ".init")]
         built_p, retail_p = module_binaries(d, config_root, build_root)
         label = module_label(d, config_root)
         if not built_p or not built_p.is_file() or not retail_p.is_file():
@@ -193,8 +237,18 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             continue
         base = min(s[1] for s in secs)
         built, retail = built_p.read_bytes(), retail_p.read_bytes()
-        allowed_mod_ranges = [(addr - base, end - base) for rel, addr, end in entries
+        label_bytes = label.encode("utf-8")
+        module_set_digest.update(len(label_bytes).to_bytes(4, "big"))
+        module_set_digest.update(label_bytes)
+        module_set_digest.update(len(built).to_bytes(8, "big"))
+        module_set_digest.update(built)
+        allowed_mod_ranges = [(addr - base, end - base)
+                              for rel, _name, addr, end in entry_sections
                               if rel.startswith("mods/")]
+        source_data_bytes += _covered_bytes(
+            [(addr, end) for rel, name, addr, end in entry_sections
+             if rel.startswith("src/") and name not in (".text", ".init")],
+            base, max(len(built), len(retail)))
         module_diff, unexpected_diff = _diff_counts(built, retail, allowed_mod_ranges)
         module_results.append({
             "module": label,
@@ -272,6 +326,8 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             "unexpectedDifferingBytes": unexpected_module_bytes,
             "percent": (100.0 * (compared_module_bytes - differing_module_bytes)
                         / compared_module_bytes) if compared_module_bytes else 0.0,
+            "moduleSetSha256": (module_set_digest.hexdigest()
+                                if module_results else None),
             "results": module_results,
         },
         # What the 106 module images are MADE OF, so the headline percentages cannot be
@@ -283,10 +339,16 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             "moduleBytes": compared_module_bytes,
             "codeBytes": module_code_bytes,
             "dataBytes": compared_module_bytes - module_code_bytes,
+            "sourceDataBytes": source_data_bytes,
+            "unownedDataBytes": max(0, compared_module_bytes - module_code_bytes
+                                      - source_data_bytes),
             "sourceBytes": source_bytes,
             "sourceBytesOfModulePercent": (100.0 * source_bytes / compared_module_bytes
                                            if compared_module_bytes else 0.0),
             "dataBytesVerified": 0,
+            "sourceDataBytesOfModulePercent": (
+                100.0 * source_data_bytes / compared_module_bytes
+                if compared_module_bytes else 0.0),
             "dataBytesOfModulePercent": (100.0 * (compared_module_bytes - module_code_bytes)
                                          / compared_module_bytes
                                          if compared_module_bytes else 0.0),
@@ -337,9 +399,10 @@ def print_report(report, show=12):
         # construction for every byte dsd supplies from the ROM and says nothing at all
         # about them. This line is what it is a percentage OF.
         print(f"  of {mc['moduleBytes']:,} module bytes: {mc['sourceBytes']:,} "
-              f"({mc['sourceBytesOfModulePercent']:.1f}%) built from source, "
-              f"{mc['dataBytes']:,} ({mc['dataBytesOfModulePercent']:.1f}%) are data "
-              f"no delink entry reaches ({mc['dataBytesVerified']:,} verified)")
+              f"({mc['sourceBytesOfModulePercent']:.1f}%) source-built code, "
+              f"{mc.get('sourceDataBytes', 0):,} source-owned data, "
+              f"{mc.get('unownedDataBytes', mc['dataBytes']):,} data bytes no complete "
+              f"source entry reaches ({mc['dataBytesVerified']:,} verified)")
     if report["missingModuleBinaries"]:
         print(f"missing module binaries: {report['missingModuleBinaries'][:8]}")
     for f in report["failures"][:show]:

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -306,7 +306,7 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
                 reproducing_bytes += size
 
         # The loop above walks .text/.init only, because those are the entries that own
-        # FUNCTIONS and every counter in it is a function counter. A src/-owned .data,
+        # FUNCTIONS and every counter in it is a function counter. A source-owned .data,
         # .rodata or .bss claim is a byte claim with no function in it, so it fell out
         # of that loop entirely and produced no diagnostic row at all.
         #
@@ -414,7 +414,7 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             "mismatchingFunctions": bad,
             "mismatchingFunctionBytes": bad_function_bytes,
             "differingSourceBytes": differing_source_bytes,
-            # Non-text src/-owned claims, kept as their own counters: they carry no
+            # Non-text source-owned claims, kept as their own counters: they carry no
             # functions, so folding them into mismatchingFunctions would report a
             # function count that no function is behind. differingSourceBytes is
             # shared, because a differing byte is a differing byte either way.

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -741,7 +741,7 @@ class Isolate(unittest.TestCase):
         self.assertTrue(patched)
         refused, why = OI.rebias_object_symbols(bytes(bad), policy)
         self.assertIsNone(refused)
-        self.assertIn("targets rebased symbol", why["error"])
+        self.assertIn("smaller than bias", why["error"])
 
         bad = bytearray(raw)
         patched = False
@@ -760,6 +760,98 @@ class Isolate(unittest.TestCase):
         refused, why = OI.rebias_object_symbols(bytes(bad), policy)
         self.assertIsNone(refused)
         self.assertIn("still referenced", why["error"])
+
+    def test_rebias_vtable_preserves_live_reference_targets(self):
+        """Whole-object vptr stores keep their target while _ZTV moves by eight."""
+        import io
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+
+        raw = self.build("struct P { virtual ~P(); virtual int f(); }; "
+                         "P::~P(){} int P::f(){ return 1; }\n").read_bytes()
+
+        def inspect(blob):
+            parsed = ELFFile(io.BytesIO(blob))
+            table = parsed.get_section_by_name(".symtab")
+            symbols = list(table.iter_symbols())
+            vtable = next(s for s in symbols if s.name == "_ZTV1P"
+                          and s["st_shndx"] != "SHN_UNDEF")
+            content = {i: sec.data() for i, sec in enumerate(parsed.iter_sections())
+                       if sec.header["sh_type"] in OI.CONTENT and sec.header["sh_size"]}
+            references = []
+            for sec in parsed.iter_sections():
+                if not isinstance(sec, RelocationSection):
+                    continue
+                source = parsed.get_section(sec.header["sh_info"])
+                for reloc in sec.iter_relocations():
+                    if table.get_symbol(reloc["r_info_sym"]).name != "_ZTV1P":
+                        continue
+                    references.append({
+                        "section": source.name, "offset": reloc["r_offset"],
+                        "type": reloc["r_info_type"], "addend": reloc["r_addend"],
+                        "resolved": vtable["st_value"] + reloc["r_addend"],
+                    })
+            return vtable, content, references
+
+        before_vtable, before_content, before_refs = inspect(raw)
+        self.assertTrue(before_refs)
+        self.assertTrue(all(row["type"] == OI.R_ARM_ABS32 and row["addend"] >= 8
+                            for row in before_refs))
+        policy = {"_ZTV1P": {"bias": 8, "size": before_vtable["st_size"],
+                              "section": ".data"}}
+        out, report = OI.rebias_object_symbols(raw, policy)
+        self.assertIsNone(report["error"])
+        after_vtable, after_content, after_refs = inspect(out)
+        self.assertEqual(after_vtable["st_value"], before_vtable["st_value"] + 8)
+        self.assertEqual(after_vtable["st_size"], before_vtable["st_size"] - 8)
+        self.assertEqual(after_content, before_content)
+        self.assertEqual([(r["section"], r["offset"], r["type"], r["resolved"])
+                          for r in after_refs],
+                         [(r["section"], r["offset"], r["type"], r["resolved"])
+                          for r in before_refs])
+        self.assertEqual([r["addend"] for r in after_refs],
+                         [r["addend"] - 8 for r in before_refs])
+        self.assertEqual(len(report["relocations"]), len(before_refs))
+
+    def test_rebias_vtable_normalizes_undefined_base_import(self):
+        """An inlined base dtor's raw +8 import becomes the public +0 form."""
+        import io
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+
+        raw = self.build("struct B { virtual ~B(){} virtual int f(); }; "
+                         "struct D : B { virtual ~D(); }; D::~D(){}\n").read_bytes()
+
+        def addends(blob, name):
+            parsed = ELFFile(io.BytesIO(blob))
+            table = parsed.get_section_by_name(".symtab")
+            return sorted(reloc["r_addend"] for sec in parsed.iter_sections()
+                          if isinstance(sec, RelocationSection)
+                          for reloc in sec.iter_relocations()
+                          if table.get_symbol(reloc["r_info_sym"]).name == name)
+
+        parsed = ELFFile(io.BytesIO(raw))
+        table = parsed.get_section_by_name(".symtab")
+        symbols = list(table.iter_symbols())
+        own = next(s for s in symbols if s.name == "_ZTV1D"
+                   and s["st_shndx"] != "SHN_UNDEF")
+        base = next(s for s in symbols if s.name == "_ZTV1B")
+        self.assertEqual(base["st_shndx"], "SHN_UNDEF")
+        before = addends(raw, "_ZTV1B")
+        self.assertTrue(before)
+        self.assertTrue(all(value >= OI.VTABLE_PREAMBLE for value in before))
+        out, report = OI.rebias_object_symbols(
+            raw, {"_ZTV1D": {"bias": 8, "size": own["st_size"],
+                               "section": ".data"}},
+            normalize_undefined=True)
+        self.assertIsNone(report["error"])
+        self.assertEqual(addends(out, "_ZTV1B"),
+                         [value - OI.VTABLE_PREAMBLE for value in before])
+        imported = [row for row in report["relocations"]
+                    if row["symbol"] == "_ZTV1B"]
+        self.assertEqual(len(imported), len(before))
+        self.assertTrue(all(row["mode"] == "undefined-public-import"
+                            for row in imported))
 
     def test_vtable_addend_is_corrected_to_zero(self):
         """8 -> 0, because the ROM symbol is already past the preamble."""

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -54,6 +54,17 @@ class RomBuildEnrollment(unittest.TestCase):
             RB.enrolled(self.config)
         self.assertIn("unsafe complete", raised.exception.output)
 
+    def test_enrolled_rejects_duplicate_complete_source_paths(self):
+        (self.config / "delinks.txt").write_text(
+            "src/Example.c:\n    complete\n"
+            "    .text start:0x02000000 end:0x02000004\n\n"
+            "src/Example.c:\n    complete\n"
+            "    .data start:0x02001000 end:0x02001004\n",
+            encoding="utf-8")
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.enrolled(self.config)
+        self.assertIn("enrolled more than once", raised.exception.output)
+
     def test_enrolled_symbols_group_one_source_in_rom_order(self):
         candidates = [
             (self.config, "Second", "src/Pair.cpp", 0x02000004, 4, ".text"),
@@ -325,6 +336,116 @@ class RomBuildEnrollment(unittest.TestCase):
         self.assertEqual(RB.compiler_only_policies(
             enrolled=["src/Pair.cpp"], manifest=manifest,
             homes={"ConfiguredElsewhere": [("arm9", 0x02000008)]}), {})
+
+    def test_intact_policy_requires_promoted_full_ordinary_link_proof(self):
+        entry = {
+            "id": "ov047/TU", "status": "promoted",
+            "production_mode": "intact-object",
+            "source": "src/actors/TU.cpp", "promoted_source": "src/actors/TU.cpp",
+            "sections": [
+                {"name": ".text", "start": "0x1000", "end": "0x1010"},
+                {"name": ".data", "start": "0x2000", "end": "0x2010"}],
+            "verification": {"linkcheck": {
+                "result": "scratch-data-verified",
+                "phases": {name: True for name in
+                           ("delink", "lcf", "compile", "link", "checkModules", "rom")},
+                "symbolCheckNewVsBaseline": [],
+                "symbolCheckErrors": ["[ERROR] old"],
+                "symbolCheckBaselineErrors": ["[ERROR] old"],
+                "tuRanges": [
+                    {"section": ".text", "start": "0x1000", "end": "0x1010",
+                     "differingBytes": 0},
+                    {"section": ".data", "start": "0x2000", "end": "0x2010",
+                     "differingBytes": 0}],
+                "rom": {"sha256": "a" * 64, "matchesStockRom": True},
+            }},
+        }
+        manifest = {"entries": [entry]}
+        self.assertEqual(RB.intact_tu_policies(
+            {"src/actors/TU.cpp"}, manifest=manifest),
+            {"src/actors/TU.cpp": entry})
+        duplicate = dict(entry)
+        duplicate["id"] = "ov047/Duplicate"
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.intact_tu_policies({"src/actors/TU.cpp"},
+                                   manifest={"entries": [entry, duplicate]})
+        self.assertIn("declared by multiple entries", raised.exception.output)
+
+        entry["verification"]["linkcheck"]["tuRanges"][1]["differingBytes"] = 1
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.intact_tu_policies({"src/actors/TU.cpp"}, manifest=manifest)
+        self.assertIn("every current manifest range exact", raised.exception.output)
+
+        entry["verification"]["linkcheck"]["tuRanges"][1]["differingBytes"] = 0
+        entry["verification"]["linkcheck"]["tuRanges"].pop()
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.intact_tu_policies({"src/actors/TU.cpp"}, manifest=manifest)
+        self.assertIn("every current manifest range exact", raised.exception.output)
+
+        entry["verification"]["linkcheck"]["tuRanges"].append(
+            {"section": ".data", "start": "0x2000", "end": "0x2010",
+             "differingBytes": 0})
+        entry["verification"]["linkcheck"]["rom"]["matchesStockRom"] = False
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.intact_tu_policies({"src/actors/TU.cpp"}, manifest=manifest)
+        self.assertIn("identical to stock", raised.exception.output)
+
+        entry["verification"]["linkcheck"]["rom"]["matchesStockRom"] = True
+        entry["sections"][1]["name"] = ".rodata"
+        entry["sections"][1]["module_section"] = ".data"
+        entry["verification"]["linkcheck"]["tuRanges"][1]["section"] = ".rodata"
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.intact_tu_policies({"src/actors/TU.cpp"}, manifest=manifest)
+        self.assertIn("input-section retargeting", raised.exception.output)
+
+        entry["sections"][1] = {"name": ".data", "start": "0x2000", "end": "0x2010"}
+        entry["verification"]["linkcheck"]["tuRanges"][1]["section"] = ".data"
+        # Every licensed non-text field follows the same fail-closed rule, not just
+        # `.data`; vtables can be represented under `.rodata` in a manifest.
+        entry["rodata"] = [{"symbol": "_ZTV1T", "storage_alias": {
+            "symbol": "data_00002000", "address": "0x2000", "size": "0x8"}}]
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.intact_tu_policies({"src/actors/TU.cpp"}, manifest=manifest)
+        self.assertIn("baseline bootstrapping is non-circular", raised.exception.output)
+
+    def test_intact_rom_comparison_uses_current_same_worker_control(self):
+        verification = {
+            "baseline": {
+                "romSha256": "b" * 64,
+                "moduleSetSha256": "c" * 64,
+            },
+            "admittedRomSha256": ["a" * 64],
+        }
+        result = RB.intact_rom_comparison("b" * 64, verification)
+        self.assertEqual(result, {
+            "expectedSha256": "b" * 64,
+            "admittedBootstrapSha256": ["a" * 64],
+            "actualSha256": "b" * 64,
+            "moduleSetSha256": "c" * 64,
+            "identical": True,
+        })
+        self.assertFalse(
+            RB.intact_rom_comparison("d" * 64, verification)["identical"])
+
+    def test_intact_policy_ignores_unenrolled_shadow(self):
+        manifest = {"entries": [{
+            "id": "ov047/Shadow", "status": "text-verified",
+            "production_mode": "intact-object",
+            "promoted_source": "src/actors/Shadow.cpp",
+        }]}
+        self.assertEqual(RB.intact_tu_policies(
+            {"src/actors/Elsewhere.cpp"}, manifest=manifest), {})
+
+    def test_intact_policy_refuses_promoted_source_missing_from_enrollment(self):
+        manifest = {"entries": [{
+            "id": "ov047/Missing", "status": "promoted",
+            "production_mode": "intact-object",
+            "promoted_source": "src/actors/Missing.cpp",
+        }]}
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.intact_tu_policies(
+                ["src/actors/Elsewhere.cpp"], manifest=manifest)
+        self.assertIn("enrolled 0 time(s), expected exactly 1", raised.exception.output)
 
 
 def _compiler():

--- a/tools/test_rombuild_check.py
+++ b/tools/test_rombuild_check.py
@@ -90,7 +90,8 @@ class RomBuildCheck(unittest.TestCase):
         self.assertEqual(report["moduleComposition"]["unownedDataBytes"], 0)
 
     def write_intact_entry(self):
-        """One src/-owned entry that claims BOTH .text and .data, as an intact TU does."""
+        """One source-owned entry claiming BOTH .text and .data, as an intact TU
+        does."""
         (self.config / "delinks.txt").write_text(
             "    .text start:0x00001000 end:0x00001008 kind:code\n"
             "    .data start:0x00001008 end:0x0000100c kind:data\n\n"
@@ -103,10 +104,10 @@ class RomBuildCheck(unittest.TestCase):
         (self.built / "arm9.bin").write_bytes(b"ABCDEFGHIJKL")
 
     def test_nontext_source_claim_mismatch_produces_a_diagnostic_row(self):
-        """A differing byte in a src/-owned .data claim must NAME itself.
+        """A differing byte in a source-owned .data claim must NAME itself.
 
         The per-entry loop that builds `failures` walks .text/.init only, because every
-        counter in it is a function counter. A src/-owned .data claim therefore produced
+        counter in it is a function counter. A source-owned .data claim therefore produced
         no row at all: the verdict was still red (the byte is outside every mods/ range,
         so unexpectedDifferingBytes catches it), but `failures` was empty and
         mismatchingFunctions was 0 -- a red verdict that says "somewhere" and nothing
@@ -129,7 +130,7 @@ class RomBuildCheck(unittest.TestCase):
         self.assertEqual(report["sourceBuild"]["mismatchingDataClaims"], 0)
         self.assertEqual(report["failures"], [])
 
-        # B -- one differing byte inside the src/-owned .data claim (offset 0x8).
+        # B -- one differing byte inside the source-owned .data claim (offset 0x8).
         self.write_intact_entry()
         (self.built / "arm9.bin").write_bytes(b"ABCDEFGHXJKL")
         report = RBC.analyze(self.config, "stock")

--- a/tools/test_rombuild_check.py
+++ b/tools/test_rombuild_check.py
@@ -44,17 +44,50 @@ class RomBuildCheck(unittest.TestCase):
         report = RBC.analyze(self.config, "stock")
         self.assertTrue(report["passed"])
         self.assertEqual(report["moduleFidelity"]["percent"], 100.0)
+        digest = report["moduleFidelity"]["moduleSetSha256"]
+        self.assertEqual(len(digest), 64)
         self.assertEqual(report["sourceBuild"]["sourceFunctions"], 1)
         self.assertEqual(report["sourceBuild"]["sourceBytes"], 4)
         self.assertEqual(report["sourceBuild"]["sourceBytesPercent"], 50.0)
+        self.write_delinks("src/actors/Pair.cpp", end=0x00001008)
+        consolidated = RBC.analyze(self.config, "stock")
+        self.assertEqual(consolidated["moduleFidelity"]["moduleSetSha256"], digest)
 
     def test_shared_source_counts_every_owned_function(self):
         self.write_delinks("src/actors/Pair.cpp", end=0x00001008)
         report = RBC.analyze(self.config, "stock")
         self.assertTrue(report["passed"])
+        self.assertEqual(len(report["moduleFidelity"]["moduleSetSha256"]), 64)
         self.assertEqual(report["sourceBuild"]["sourceFunctions"], 2)
         self.assertEqual(report["sourceBuild"]["reproducingFunctions"], 2)
         self.assertEqual(report["sourceBuild"]["sourceBytes"], 8)
+
+    def test_intact_entry_counts_code_members_and_nontext_separately(self):
+        (self.config / "delinks.txt").write_text(
+            "    .text start:0x00001000 end:0x00001008 kind:code\n"
+            "    .data start:0x00001008 end:0x0000100c kind:data\n\n"
+            "src/actors/Pair.cpp:\n"
+            "    complete\n"
+            "    .text start:0x00001000 end:0x00001008\n"
+            "    .data start:0x00001008 end:0x0000100c\n",
+            encoding="utf-8")
+        (self.retail / "arm9" / "arm9.bin").write_bytes(b"ABCDEFGHIJKL")
+        (self.built / "arm9.bin").write_bytes(b"ABCDEFGHIJKL")
+
+        text = (self.config / "delinks.txt").read_text(encoding="utf-8")
+        self.assertEqual(RBC.complete_entries_text(text),
+                         [("src/actors/Pair.cpp", 0x1000, 0x1008)])
+        self.assertEqual(RBC.complete_entry_sections_text(text), [
+            ("src/actors/Pair.cpp", ".text", 0x1000, 0x1008),
+            ("src/actors/Pair.cpp", ".data", 0x1008, 0x100c),
+        ])
+
+        report = RBC.analyze(self.config, "stock")
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["sourceBuild"]["sourceFunctions"], 2)
+        self.assertEqual(report["sourceBuild"]["sourceBytes"], 8)
+        self.assertEqual(report["moduleComposition"]["sourceDataBytes"], 4)
+        self.assertEqual(report["moduleComposition"]["unownedDataBytes"], 0)
 
     def test_module_paths_accept_config_or_arm9_as_the_root(self):
         self.assertEqual(RBC.module_label(self.config, self.config), "arm9")

--- a/tools/test_rombuild_check.py
+++ b/tools/test_rombuild_check.py
@@ -89,6 +89,96 @@ class RomBuildCheck(unittest.TestCase):
         self.assertEqual(report["moduleComposition"]["sourceDataBytes"], 4)
         self.assertEqual(report["moduleComposition"]["unownedDataBytes"], 0)
 
+    def write_intact_entry(self):
+        """One src/-owned entry that claims BOTH .text and .data, as an intact TU does."""
+        (self.config / "delinks.txt").write_text(
+            "    .text start:0x00001000 end:0x00001008 kind:code\n"
+            "    .data start:0x00001008 end:0x0000100c kind:data\n\n"
+            "src/actors/Pair.cpp:\n"
+            "    complete\n"
+            "    .text start:0x00001000 end:0x00001008\n"
+            "    .data start:0x00001008 end:0x0000100c\n",
+            encoding="utf-8")
+        (self.retail / "arm9" / "arm9.bin").write_bytes(b"ABCDEFGHIJKL")
+        (self.built / "arm9.bin").write_bytes(b"ABCDEFGHIJKL")
+
+    def test_nontext_source_claim_mismatch_produces_a_diagnostic_row(self):
+        """A differing byte in a src/-owned .data claim must NAME itself.
+
+        The per-entry loop that builds `failures` walks .text/.init only, because every
+        counter in it is a function counter. A src/-owned .data claim therefore produced
+        no row at all: the verdict was still red (the byte is outside every mods/ range,
+        so unexpectedDifferingBytes catches it), but `failures` was empty and
+        mismatchingFunctions was 0 -- a red verdict that says "somewhere" and nothing
+        more, exactly when a data claim first goes wrong.
+
+        Three cases, kept side by side so the .text row is the control for the .data one:
+
+            A  all equal                  passed True   0 rows
+            B  .data byte differs         passed False  1 data row, differingBytes 1
+            C  .text byte differs         passed False  1 code row, differingBytes 1
+        """
+        # A -- all equal.
+        self.write_intact_entry()
+        report = RBC.analyze(self.config, "stock")
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["moduleFidelity"]["modulesExact"], 1)
+        self.assertEqual(report["sourceBuild"]["mismatchingFunctions"], 0)
+        self.assertEqual(report["sourceBuild"]["sourceDataClaims"], 1)
+        self.assertEqual(report["sourceBuild"]["reproducingDataClaims"], 1)
+        self.assertEqual(report["sourceBuild"]["mismatchingDataClaims"], 0)
+        self.assertEqual(report["failures"], [])
+
+        # B -- one differing byte inside the src/-owned .data claim (offset 0x8).
+        self.write_intact_entry()
+        (self.built / "arm9.bin").write_bytes(b"ABCDEFGHXJKL")
+        report = RBC.analyze(self.config, "stock")
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["moduleFidelity"]["modulesExact"], 0)
+        self.assertEqual(report["moduleFidelity"]["unexpectedDifferingBytes"], 1)
+        # Still zero FUNCTIONS wrong -- the claim carries none, and inventing one here
+        # would report a function count with no function behind it.
+        self.assertEqual(report["sourceBuild"]["mismatchingFunctions"], 0)
+        self.assertEqual(report["sourceBuild"]["mismatchingDataClaims"], 1)
+        self.assertEqual(report["sourceBuild"]["mismatchingDataClaimBytes"], 4)
+        self.assertEqual(report["sourceBuild"]["differingSourceBytes"], 1)
+        self.assertEqual(len(report["failures"]), 1)
+        row = report["failures"][0]
+        self.assertEqual(row["kind"], "data")
+        self.assertEqual(row["section"], ".data")
+        self.assertEqual(row["name"], "Pair")
+        self.assertEqual(row["addr"], 0x1008)
+        self.assertEqual(row["size"], 4)
+        self.assertEqual(row["differingBytes"], 1)
+        self.assertEqual(report["mismatchesByModule"], {"arm9": 1})
+
+        # C -- the control: one differing byte inside the .text claim (offset 0x0).
+        self.write_intact_entry()
+        (self.built / "arm9.bin").write_bytes(b"XBCDEFGHIJKL")
+        report = RBC.analyze(self.config, "stock")
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["moduleFidelity"]["modulesExact"], 0)
+        self.assertEqual(report["sourceBuild"]["mismatchingFunctions"], 2)
+        self.assertEqual(report["sourceBuild"]["mismatchingDataClaims"], 0)
+        self.assertEqual(len(report["failures"]), 1)
+        self.assertEqual(report["failures"][0]["kind"], "code")
+        self.assertEqual(report["failures"][0]["differingBytes"], 1)
+
+    def test_data_rows_are_kept_out_of_the_function_name_sweep_file(self):
+        """--out feeds rombuild_versions.py, which sweeps per FUNCTION name.
+
+        A data claim's path stem names no function, so it must not enter that file --
+        while remaining fully present in the report the same run prints and writes.
+        """
+        self.write_intact_entry()
+        (self.built / "arm9.bin").write_bytes(b"ABCDEFGHXJKL")
+        report = RBC.analyze(self.config, "stock")
+        names = sorted(f["name"] for f in report["failures"]
+                       if f.get("kind", "code") != "data")
+        self.assertEqual(names, [])
+        self.assertEqual(len(report["failures"]), 1)
+        RBC.print_report(report)
+
     def test_module_paths_accept_config_or_arm9_as_the_root(self):
         self.assertEqual(RBC.module_label(self.config, self.config), "arm9")
         self.assertEqual(RBC.module_label(self.config, self.config.parent), "arm9")

--- a/tools/test_tu_production.py
+++ b/tools/test_tu_production.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import sys
 import tempfile
@@ -28,8 +29,215 @@ class ProductionTuAdmission(unittest.TestCase):
                                         "missing strict stock control"):
                 TP._strict_baseline()
 
+    def test_clean_worker_bootstraps_rom_gap_control(self):
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing", "module": "ov047"}}
+        baseline = {"symbolErrors": [], "romSha256": "ab" * 32}
+        with mock.patch.object(
+                TP, "_strict_baseline",
+                side_effect=[TP.ProductionTuError("missing"), baseline]) as strict, \
+                mock.patch.object(TP.subprocess, "run",
+                                  return_value=mock.Mock(returncode=0)) as run:
+            self.assertIs(
+                TP._current_or_bootstrapped_intact_baseline(entries, 7), baseline)
+
+        self.assertEqual(strict.call_count, 2)
+        self.assertEqual(strict.call_args_list,
+                         [mock.call(entries), mock.call(entries)])
+        command = run.call_args.args[0]
+        self.assertIn("--baseline", command)
+        self.assertIn("ov047", command)
+        self.assertIn("7", command)
+        self.assertIs(run.call_args.kwargs["check"], False)
+
+    def test_clean_worker_refuses_failed_control_bootstrap(self):
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing", "module": "ov047"}}
+        with mock.patch.object(
+                TP, "_strict_baseline",
+                side_effect=TP.ProductionTuError("missing")), \
+                mock.patch.object(TP.subprocess, "run",
+                                  return_value=mock.Mock(returncode=3)):
+            with self.assertRaisesRegex(
+                    TP.ProductionTuError, "baseline command exited 3"):
+                TP._current_or_bootstrapped_intact_baseline(entries, 7)
+
+    def test_rom_gap_control_requires_exact_intact_inventory(self):
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing", "module": "ov047"}}
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "final_link.o").write_bytes(b"independent linked control")
+            report = {
+                "baseline": True,
+                "analysis": {
+                    "passed": True,
+                    "moduleFidelity": {"moduleSetSha256": "ef" * 32},
+                },
+                "phases": {
+                    "checkModules": {"ok": True},
+                    "checkSymbols": {"errors": ["[ERROR] old"]},
+                },
+                "intactTusDemoted": [{
+                    "id": "ov047/Thing", "source": "src/actors/Thing.cpp"}],
+                "rom": {"sha256": "ab" * 32},
+            }
+            (root / "linkcheck.json").write_text(
+                json.dumps(report), encoding="utf-8")
+            with mock.patch.object(TP.TB, "BASELINE_LINK", root), \
+                    mock.patch.object(
+                        TP.TB, "validate_partition_baseline_evidence",
+                        return_value=("cd" * 32, None)):
+                baseline = TP._strict_baseline(entries)
+                self.assertEqual(baseline["romSha256"], "ab" * 32)
+                self.assertEqual(baseline["moduleSetSha256"], "ef" * 32)
+                self.assertIsNone(baseline["matchesStockRom"])
+                with self.assertRaisesRegex(
+                        TP.ProductionTuError, "current intact TU inventory"):
+                    TP._strict_baseline({
+                        "src/actors/Other.cpp": {
+                            "id": "ov047/Other", "module": "ov047"}})
+
 
 class ProductionTuObjects(unittest.TestCase):
+    def test_automatic_intact_link_plan_uses_current_control_and_vtable_biases(self):
+        claims = [{"name": ".text", "start": 0x1000, "end": 0x1010},
+                  {"name": ".data", "start": 0x2000, "end": 0x2010}]
+        baseline = {
+            "symbolErrors": ["[ERROR] old"],
+            "romSha256": "ab" * 32,
+            "matchesStockRom": True,
+            "moduleSetSha256": "ef" * 32,
+        }
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing",
+            "verification": {"linkcheck": {
+                "symbolCheckErrors": ["[ERROR] old"],
+                "moduleSetSha256": "ef" * 32,
+                "rom": {"sha256": "ab" * 32}}},
+        }}
+        with mock.patch.object(TP, "_strict_baseline", return_value=baseline), \
+                mock.patch.object(TP.TB, "manifest_section_claims",
+                                  return_value=(claims, [])), \
+                mock.patch.object(TP.TB, "partition_vtable_rebiases",
+                                  return_value=({"_ZTV1T": {"bias": 8}}, [])):
+            prepared = TP.prepare_intact_link_verification(entries)
+        self.assertIs(prepared["baseline"], baseline)
+        self.assertEqual(prepared["admittedRomSha256"], ["ab" * 32])
+        self.assertEqual(prepared["admittedModuleSetSha256"], "ef" * 32)
+        self.assertEqual(prepared["entries"], [{
+            "id": "ov047/Thing", "source": "src/actors/Thing.cpp",
+            "biases": {"_ZTV1T": {"bias": 8}},
+        }])
+
+    def test_automatic_intact_link_plan_rejects_laundered_control_error(self):
+        baseline = {"symbolErrors": ["[ERROR] old", "[ERROR] new"],
+                    "romSha256": "ab" * 32, "matchesStockRom": True,
+                    "moduleSetSha256": "ef" * 32}
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing",
+            "verification": {"linkcheck": {
+                "symbolCheckErrors": ["[ERROR] old"],
+                "moduleSetSha256": "ef" * 32,
+                "rom": {"sha256": "ab" * 32}}},
+        }}
+        with mock.patch.object(TP, "_strict_baseline", return_value=baseline):
+            with self.assertRaisesRegex(TP.ProductionTuError,
+                                         "pre-promotion inventory"):
+                TP.prepare_intact_link_verification(entries)
+
+    def test_same_worker_stock_control_allows_environment_specific_outer_rom(self):
+        baseline = {
+            "symbolErrors": [], "romSha256": "cd" * 32,
+            "matchesStockRom": True, "moduleSetSha256": "ef" * 32,
+        }
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing",
+            "verification": {"linkcheck": {
+                "symbolCheckErrors": [], "moduleSetSha256": "ef" * 32,
+                "rom": {"sha256": "ab" * 32}}},
+        }}
+        with mock.patch.object(TP, "_strict_baseline", return_value=baseline), \
+                mock.patch.object(TP.TB, "manifest_section_claims",
+                                  return_value=([], [])), \
+                mock.patch.object(TP.TB, "partition_vtable_rebiases",
+                                  return_value=({}, [])):
+            prepared = TP.prepare_intact_link_verification(entries)
+        self.assertEqual(prepared["baseline"]["romSha256"], "cd" * 32)
+        self.assertEqual(prepared["admittedRomSha256"], ["ab" * 32])
+
+    def test_environment_specific_control_without_stock_comparison_refuses(self):
+        baseline = {
+            "symbolErrors": [], "romSha256": "cd" * 32,
+            "matchesStockRom": None, "moduleSetSha256": "ef" * 32,
+        }
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing",
+            "verification": {"linkcheck": {
+                "symbolCheckErrors": [], "moduleSetSha256": "ef" * 32,
+                "rom": {"sha256": "ab" * 32}}},
+        }}
+        with mock.patch.object(TP, "_strict_baseline", return_value=baseline):
+            with self.assertRaisesRegex(TP.ProductionTuError,
+                                        "no same-worker stock-ROM comparison"):
+                TP.prepare_intact_link_verification(entries)
+
+    def test_same_worker_stock_control_still_requires_admitted_module_set(self):
+        baseline = {
+            "symbolErrors": [], "romSha256": "cd" * 32,
+            "matchesStockRom": True, "moduleSetSha256": "12" * 32,
+        }
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing",
+            "verification": {"linkcheck": {
+                "symbolCheckErrors": [], "moduleSetSha256": "ef" * 32,
+                "rom": {"sha256": "ab" * 32}}},
+        }}
+        with mock.patch.object(TP, "_strict_baseline", return_value=baseline):
+            with self.assertRaisesRegex(TP.ProductionTuError,
+                                        "executable-module fingerprint"):
+                TP.prepare_intact_link_verification(entries)
+
+    def test_admitted_intact_proof_requires_module_set_fingerprint(self):
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing",
+            "verification": {"linkcheck": {
+                "symbolCheckErrors": [],
+                "rom": {"sha256": "ab" * 32}}},
+        }}
+        with self.assertRaisesRegex(TP.ProductionTuError,
+                                    "executable-module fingerprint"):
+            TP.prepare_intact_link_verification(entries)
+
+    def test_intact_object_runs_all_fail_closed_policy_gates(self):
+        entry = {"id": "ov047/Thing"}
+        claims = [{"name": ".text", "start": 0x1000, "end": 0x1010},
+                  {"name": ".data", "start": 0x2000, "end": 0x2010}]
+        owned = {"ok": True, "rows": [], "errors": []}
+        with mock.patch.object(TP.TB, "manifest_section_claims",
+                               return_value=(claims, [])), \
+                mock.patch.object(TP.TB, "apply_compiler_only_policy",
+                                  return_value=(b"compiler", {"deadstripped": []}, [])), \
+                mock.patch.object(TP.TB, "apply_externalized_output_policy",
+                                  return_value=(b"external", {"externalized": []}, [])), \
+                mock.patch.object(TP.TB, "verify_owned_sections",
+                                  side_effect=[owned, owned]) as verify, \
+                mock.patch.object(TP.TB, "partition_vtable_rebiases",
+                                  return_value=({"_ZTV1T": {"bias": 8}}, [])), \
+                mock.patch.object(TP.TB.OI, "rebias_object_symbols",
+                                  return_value=(b"linked", {"error": None})) as rebias, \
+                mock.patch.object(TP.TB, "complete_ranges", return_value={}), \
+                mock.patch.object(TP.TB, "audit_tu_object",
+                                  return_value=([], [], [], True)), \
+                mock.patch.object(TP.TB, "object_audit_refusals", return_value=[]):
+            output, evidence = TP.prepare_intact_object(b"raw", entry)
+        self.assertEqual(output, b"linked")
+        rebias.assert_called_once_with(
+            b"external", {"_ZTV1T": {"bias": 8}}, normalize_undefined=True)
+        self.assertEqual(verify.call_count, 2)
+        self.assertEqual(evidence["sha256"],
+                         __import__("hashlib").sha256(b"linked").hexdigest())
+
     def test_compile_one_installs_prepared_object_without_compiler(self):
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -49,7 +257,7 @@ class ProductionTuObjects(unittest.TestCase):
         }
         calls = [
             (True, "modules ok", 0.1),
-            (False, "[ERROR] old\nError: Some symbol(s) did not match.", 0.1),
+            (True, "[ERROR] old\nError: Some symbol(s) did not match.", 0.1),
         ]
         with mock.patch.object(TP.TB, "_run_dsd", side_effect=calls), \
                 mock.patch.object(TP.TB, "verify_linked_storage_aliases",
@@ -69,6 +277,15 @@ class ProductionTuObjects(unittest.TestCase):
             result = TP.verify_link("config.yaml", "final_link.o", prepared)
         self.assertFalse(result["ok"])
         self.assertEqual(result["newSymbolErrors"], ["[ERROR] new"])
+
+    def test_final_gate_rejects_symbol_check_operational_failure(self):
+        prepared = {"baseline": {"symbolErrors": []}, "entries": []}
+        calls = [(True, "modules ok", 0.1),
+                 (False, "tool crashed before producing an inventory", 0.1)]
+        with mock.patch.object(TP.TB, "_run_dsd", side_effect=calls):
+            result = TP.verify_link("config.yaml", "final_link.o", prepared)
+        self.assertFalse(result["ok"])
+        self.assertFalse(result["symbolsCommandOk"])
 
 
 if __name__ == "__main__":

--- a/tools/test_tu_promote.py
+++ b/tools/test_tu_promote.py
@@ -1,0 +1,267 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import tu_promote as TP  # noqa: E402
+
+
+def intact_proof(sections):
+    return {"linkcheck": {
+        "result": "scratch-data-verified",
+        "phases": {name: True for name in
+                   ("delink", "lcf", "compile", "link", "checkModules", "rom")},
+        "symbolCheckNewVsBaseline": [],
+        "symbolCheckErrors": ["[ERROR] old"],
+        "symbolCheckBaselineErrors": ["[ERROR] old"],
+        "tuRanges": [
+            {"section": row["name"], "start": row["start"], "end": row["end"],
+             "differingBytes": 0}
+            for row in sections],
+        "rom": {"sha256": "a" * 64, "matchesStockRom": True},
+    }}
+
+
+class IntactPromotion(unittest.TestCase):
+    def test_batch_preflight_refuses_shared_legacy_before_mutation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "src_tu").mkdir()
+            (root / "src").mkdir()
+            (root / "src_tu/One.cpp").write_text("//cpp\n", encoding="utf-8")
+            (root / "src_tu/Two.cpp").write_text("//cpp\n", encoding="utf-8")
+            (root / "src/Shared.cpp").write_text("//cpp\n", encoding="utf-8")
+            plans = [
+                {"id": "ov047/One", "source": "src_tu/One.cpp",
+                 "dest": "src/One.cpp", "legacy": ["src/Shared.cpp"],
+                 "delinks": root / "config/delinks.txt", "claims": []},
+                {"id": "ov047/Two", "source": "src_tu/Two.cpp",
+                 "dest": "src/Two.cpp", "legacy": ["src/Shared.cpp"],
+                 "delinks": root / "config/delinks.txt", "claims": []},
+            ]
+            with mock.patch.object(TP, "REPO", root):
+                with self.assertRaisesRegex(TP.PromoteError,
+                                             "consumed by both"):
+                    TP.batch_preflight(plans)
+
+    def test_batch_preflight_refuses_cross_plan_claim_overlap(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "src_tu").mkdir()
+            (root / "src").mkdir()
+            for rel in ("src_tu/One.cpp", "src_tu/Two.cpp",
+                        "src/First.cpp", "src/Second.cpp"):
+                (root / rel).write_text("//cpp\n", encoding="utf-8")
+            delinks = root / "config/delinks.txt"
+            plans = [
+                {"id": "ov047/One", "source": "src_tu/One.cpp",
+                 "dest": "src/One.cpp", "legacy": ["src/First.cpp"],
+                 "delinks": delinks,
+                 "claims": [(".text", 0x1000, 0x1010),
+                            (".data", 0x2000, 0x2020)]},
+                {"id": "ov047/Two", "source": "src_tu/Two.cpp",
+                 "dest": "src/Two.cpp", "legacy": ["src/Second.cpp"],
+                 "delinks": delinks,
+                 "claims": [(".text", 0x1010, 0x1020),
+                            (".data", 0x2010, 0x2030)]},
+            ]
+            with mock.patch.object(TP, "REPO", root):
+                with self.assertRaisesRegex(TP.PromoteError, "overlaps"):
+                    TP.batch_preflight(plans)
+
+    def test_converted_baseline_moves_only_banked_members_to_promoted_tu(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config = root / "config"
+            config.mkdir()
+            baseline = config / "converted-baseline.json"
+            baseline.write_text(
+                '{"_note":"old","criteria":[],"count":2,"converted":['
+                '"src/First.cpp","src/Unrelated.cpp"]}\n', encoding="utf-8")
+            original = baseline.read_text(encoding="utf-8")
+            plans = [{
+                "dest": "src/actors/TU.cpp",
+                "functions": [
+                    {"symbol": "First", "legacy_source": "src/First.cpp"},
+                    {"symbol": "Second", "legacy_source": "src/Second.cpp"},
+                ],
+            }]
+            with mock.patch.object(TP, "CONFIG", config):
+                prepared = TP.converted_baseline_update(plans)
+                self.assertEqual(baseline.read_text(encoding="utf-8"), original)
+                moved = TP.rewrite_converted_baseline(plans, prepared)
+
+            data = json.loads(baseline.read_text(encoding="utf-8"))
+            self.assertEqual(moved, 1)
+            self.assertEqual(data["count"], 2)
+            self.assertEqual(data["converted"], [
+                "src/actors/TU.cpp#First", "src/Unrelated.cpp"])
+            self.assertEqual(data["_note"], TP.TR.NOTE)
+
+    def test_attribution_update_appends_without_reordering_existing_overrides(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            path = root / "attribution.json"
+            path.write_text(
+                '{"overrides":{"src/Z.cpp":"zed","src/A.cpp":"aye"}}\n',
+                encoding="utf-8")
+            plans = [{"dest": "src/actors/TU.cpp", "functions": [{
+                "symbol": "First", "legacy_source": "src/First.cpp"}]}]
+            with mock.patch.object(TP, "REPO", root):
+                prepared = TP.attribution_update(
+                    plans, {"src/First": "author"})
+                TP.rewrite_attribution(plans, {}, prepared)
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(list(data["overrides"]), [
+                "src/Z.cpp", "src/A.cpp", "src/actors/TU.cpp#First"])
+
+    def test_single_member_converted_identity_stays_path_based(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = pathlib.Path(td) / "config"
+            config.mkdir()
+            baseline = config / "converted-baseline.json"
+            baseline.write_text(
+                '{"converted":["src/Only.cpp"],"count":1}\n', encoding="utf-8")
+            plans = [{"dest": "src/actors/Only.cpp", "functions": [
+                {"symbol": "Only", "legacy_source": "src/Only.cpp"}]}]
+            with mock.patch.object(TP, "CONFIG", config):
+                TP.rewrite_converted_baseline(plans)
+            data = json.loads(baseline.read_text(encoding="utf-8"))
+            self.assertEqual(data["converted"], ["src/actors/Only.cpp"])
+
+    def test_plan_and_rewrite_keep_nontext_claims_for_intact_object(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config = root / "config"
+            delinks = config / "arm9/overlays/ov047/delinks.txt"
+            delinks.parent.mkdir(parents=True)
+            delinks.write_text(
+                "    .text start:0x00001000 end:0x00001100 kind:code align:4\n"
+                "    .data start:0x00002000 end:0x00002100 kind:data align:4\n\n"
+                "src/First.cpp:\n    complete\n"
+                "    .text start:0x00001000 end:0x00001010\n\n"
+                "src/Second.cpp:\n    complete\n"
+                "    .text start:0x00001010 end:0x00001020\n\n",
+                encoding="utf-8")
+            (root / "src_tu").mkdir()
+            (root / "src_tu/TU.cpp").write_text("//cpp\n", encoding="utf-8")
+            (root / "src").mkdir()
+            (root / "src/First.cpp").write_text("//cpp\n", encoding="utf-8")
+            (root / "src/Second.cpp").write_text("//cpp\n", encoding="utf-8")
+            sections = [
+                {"name": ".text", "start": "0x00001000", "end": "0x00001020"},
+                {"name": ".data", "start": "0x00002040", "end": "0x00002050"},
+            ]
+            entry = {
+                "id": "ov047/TU", "module": "ov047",
+                "status": "scratch-data-verified",
+                "production_mode": "intact-object",
+                "source": "src_tu/TU.cpp", "promoted_source": "src/TU.cpp",
+                "sections": sections,
+                "data": [{"symbol": "owned", "address": "0x2040", "size": "0x10"}],
+                "verification": intact_proof(sections),
+                "functions": [
+                    {"symbol": "First", "address": "0x1000", "size": "0x10",
+                     "legacy_source": "src/First.cpp"},
+                    {"symbol": "Second", "address": "0x1010", "size": "0x10",
+                     "legacy_source": "src/Second.cpp"},
+                ],
+            }
+            with mock.patch.object(TP, "REPO", root), \
+                    mock.patch.object(TP, "CONFIG", config):
+                planned = TP.plan(entry)
+                TP.rewrite_delinks(planned)
+            written = delinks.read_text(encoding="utf-8")
+            self.assertNotIn("src/First.cpp:", written)
+            self.assertNotIn("src/Second.cpp:", written)
+            self.assertIn("src/TU.cpp:\n    complete\n"
+                          "    .text start:0x00001000 end:0x00001020\n"
+                          "    .data start:0x00002040 end:0x00002050\n", written)
+
+    def test_intact_promotion_refuses_unimplemented_section_retargeting(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config = root / "config"
+            delinks = config / "arm9/overlays/ov047/delinks.txt"
+            delinks.parent.mkdir(parents=True)
+            delinks.write_text(
+                "    .text start:0x00001000 end:0x00001100 kind:code align:4\n"
+                "    .data start:0x00002000 end:0x00002100 kind:data align:4\n\n"
+                "src/Only.cpp:\n    complete\n"
+                "    .text start:0x00001000 end:0x00001010\n\n",
+                encoding="utf-8")
+            (root / "src_tu").mkdir()
+            (root / "src_tu/TU.cpp").write_text("//cpp\n", encoding="utf-8")
+            (root / "src").mkdir()
+            (root / "src/Only.cpp").write_text("//cpp\n", encoding="utf-8")
+            entry = {
+                "id": "ov047/TU", "module": "ov047", "status": "text-verified",
+                "production_mode": "intact-object", "source": "src_tu/TU.cpp",
+                "promoted_source": "src/TU.cpp",
+                "sections": [
+                    {"name": ".text", "start": "0x1000", "end": "0x1010"},
+                    {"name": ".rodata", "module_section": ".data",
+                     "start": "0x2000", "end": "0x2010"}],
+                "functions": [{"symbol": "Only", "address": "0x1000", "size": "0x10",
+                               "legacy_source": "src/Only.cpp"}],
+            }
+            with mock.patch.object(TP, "REPO", root), \
+                    mock.patch.object(TP, "CONFIG", config):
+                with self.assertRaisesRegex(TP.PromoteError,
+                                             "input-section retargeting"):
+                    TP.plan(entry)
+
+    def test_intact_promotion_preflights_production_admission(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config = root / "config"
+            delinks = config / "arm9/overlays/ov047/delinks.txt"
+            delinks.parent.mkdir(parents=True)
+            delinks.write_text(
+                "    .text start:0x00001000 end:0x00001100 kind:code align:4\n"
+                "    .data start:0x00002000 end:0x00002100 kind:data align:4\n\n"
+                "src/Only.cpp:\n    complete\n"
+                "    .text start:0x00001000 end:0x00001010\n\n",
+                encoding="utf-8")
+            (root / "src_tu").mkdir()
+            (root / "src_tu/TU.cpp").write_text("//cpp\n", encoding="utf-8")
+            (root / "src").mkdir()
+            (root / "src/Only.cpp").write_text("//cpp\n", encoding="utf-8")
+            entry = {
+                "id": "ov047/TU", "module": "ov047", "status": "text-verified",
+                "production_mode": "intact-object", "source": "src_tu/TU.cpp",
+                "promoted_source": "src/TU.cpp",
+                "sections": [
+                    {"name": ".text", "start": "0x00001000", "end": "0x00001010"},
+                    {"name": ".data", "start": "0x00002000", "end": "0x00002010"}],
+                "functions": [{"symbol": "Only", "address": "0x1000", "size": "0x10",
+                               "legacy_source": "src/Only.cpp"}],
+                "verification": {"linkcheck": {}},
+            }
+            with mock.patch.object(TP, "REPO", root), \
+                    mock.patch.object(TP, "CONFIG", config):
+                with self.assertRaisesRegex(TP.PromoteError,
+                                             "production admission preflight failed"):
+                    TP.plan(entry)
+
+    def test_nontext_promotion_without_intact_mode_is_refused(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "src_tu").mkdir()
+            (root / "src_tu/TU.cpp").write_text("//cpp\n", encoding="utf-8")
+            entry = {"id": "ov047/TU", "source": "src_tu/TU.cpp",
+                     "promoted_source": "src/TU.cpp", "module": "ov047",
+                     "sections": [
+                         {"name": ".text", "start": "0x1000", "end": "0x1010"},
+                         {"name": ".data", "start": "0x2000", "end": "0x2010"},
+                     ]}
+            with mock.patch.object(TP, "REPO", root):
+                with self.assertRaisesRegex(TP.PromoteError, "intact-object"):
+                    TP.plan(entry)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1333,57 +1333,131 @@ def test_partition_baseline_evidence_is_content_bound_not_mtime_bound():
     with tempfile.TemporaryDirectory() as td:
         root = pathlib.Path(td)
         config = root / "config"
+        tracked = root / "tracked-config"
         rom_inputs = root / "rom-inputs"
         config.mkdir()
+        tracked.mkdir()
         rom_inputs.mkdir()
         cfg = config / "symbols.txt"
+        tracked_cfg = tracked / "symbols.txt"
         (rom_inputs / "header.yaml").write_bytes(b"ROM")
         linked, dsd, linker = root / "base.o", root / "dsd.exe", root / "mwld.exe"
         control_tool = root / "analysis.py"
         cfg.write_bytes(b"one")
+        tracked_cfg.write_bytes(b"tracked-one")
         linked.write_bytes(b"ELF")
         dsd.write_bytes(b"DSD")
         linker.write_bytes(b"MWL")
         control_tool.write_bytes(b"ANALYZE")
-        evidence = tubuild.partition_baseline_fingerprints(
-            linked, config, dsd_path=dsd, linker_path=linker,
-            rom_inputs=rom_inputs, control_tools=[control_tool])
+
+        def fingerprint():
+            return tubuild.partition_baseline_fingerprints(
+                linked, config, dsd_path=dsd, linker_path=linker,
+                rom_inputs=rom_inputs, control_tools=[control_tool],
+                tracked_config_root=tracked)
+
+        def validate(report):
+            return tubuild.validate_partition_baseline_evidence(
+                report, linked, config, dsd_path=dsd, linker_path=linker,
+                rom_inputs=rom_inputs, control_tools=[control_tool],
+                tracked_config_root=tracked)
+
+        evidence = fingerprint()
         report = {"baselineEvidence": evidence}
-        digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker,
-            rom_inputs=rom_inputs, control_tools=[control_tool])
+        digest, error = validate(report)
         assert error is None and digest == evidence["linkedElfSha256"]
 
         stamp = cfg.stat().st_mtime_ns
         cfg.write_bytes(b"two")
         os.utime(cfg, ns=(stamp, stamp))
-        _digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker,
-            rom_inputs=rom_inputs, control_tools=[control_tool])
+        _digest, error = validate(report)
         assert "configArm9Sha256" in error
 
         cfg.write_bytes(b"one")
         linked_stamp = linked.stat().st_mtime_ns
         linked.write_bytes(b"BAD")
         os.utime(linked, ns=(linked_stamp, linked_stamp))
-        _digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker,
-            rom_inputs=rom_inputs, control_tools=[control_tool])
+        _digest, error = validate(report)
         assert "linkedElfSha256" in error
 
         linked.write_bytes(b"ELF")
         (rom_inputs / "header.yaml").write_bytes(b"CHANGED")
-        _digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker,
-            rom_inputs=rom_inputs, control_tools=[control_tool])
+        _digest, error = validate(report)
         assert "romInputsSha256" in error
 
         (rom_inputs / "header.yaml").write_bytes(b"ROM")
         control_tool.write_bytes(b"CHANGED")
-        _digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker,
-            rom_inputs=rom_inputs, control_tools=[control_tool])
+        _digest, error = validate(report)
         assert "controlToolsSha256" in error
+
+        control_tool.write_bytes(b"ANALYZE")
+        _digest, error = validate(report)
+        assert error is None
+
+
+def test_partition_baseline_evidence_binds_the_tracked_config_too():
+    """The scratch copy and config/arm9 are two different facts; both are recorded.
+
+    `linkcheck --baseline` links out of a MUTATED scratch copy of config/arm9, so the
+    scratch tree is what the report has to bind to in order to describe its own inputs.
+    Binding to that alone regresses what the tracked hash used to catch: config/arm9
+    can move afterwards and the preserved scratch copy -- untouched by definition --
+    still matches, so every consumer keeps calling the baseline current. The case below
+    is exactly that: the scratch tree is left byte-identical and ONLY the tracked tree
+    changes.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        scratch, tracked, rom_inputs = (root / "scratch-config", root / "tracked-config",
+                                        root / "rom-inputs")
+        for d in (scratch, tracked, rom_inputs):
+            d.mkdir()
+        # Different bytes on purpose: demote_complete_sources rewrites the scratch copy,
+        # so in the real baseline these two trees are NOT equal and the two hashes are
+        # independent values rather than one value written twice.
+        (scratch / "symbols.txt").write_bytes(b"scratch (demoted)")
+        (tracked / "symbols.txt").write_bytes(b"tracked")
+        (rom_inputs / "header.yaml").write_bytes(b"ROM")
+        linked, dsd, linker = root / "base.o", root / "dsd.exe", root / "mwld.exe"
+        control_tool = root / "analysis.py"
+        for path, blob in ((linked, b"ELF"), (dsd, b"DSD"), (linker, b"MWL"),
+                           (control_tool, b"ANALYZE")):
+            path.write_bytes(blob)
+
+        def validate(report):
+            return tubuild.validate_partition_baseline_evidence(
+                report, linked, scratch, dsd_path=dsd, linker_path=linker,
+                rom_inputs=rom_inputs, control_tools=[control_tool],
+                tracked_config_root=tracked)
+
+        evidence = tubuild.partition_baseline_fingerprints(
+            linked, scratch, dsd_path=dsd, linker_path=linker,
+            rom_inputs=rom_inputs, control_tools=[control_tool],
+            tracked_config_root=tracked)
+        assert evidence["configArm9Sha256"] != evidence["trackedConfigArm9Sha256"]
+        report = {"baselineEvidence": evidence}
+        assert validate(report)[1] is None
+
+        scratch_before = evidence["configArm9Sha256"]
+        stamp = (tracked / "symbols.txt").stat().st_mtime_ns
+        (tracked / "symbols.txt").write_bytes(b"tracked, but edited")
+        os.utime(tracked / "symbols.txt", ns=(stamp, stamp))
+        _digest, error = validate(report)
+        assert error is not None and "trackedConfigArm9Sha256" in error
+        # The scratch binding is untouched by the drift -- which is why it cannot be the
+        # only signal, and why this is not a test of the scratch hash under another name.
+        assert tubuild.content_tree_sha256(scratch) == scratch_before
+        assert "'configArm9Sha256'" not in error
+
+        (tracked / "symbols.txt").write_bytes(b"tracked")
+        assert validate(report)[1] is None
+
+        # A report banked before this key existed cannot answer the question, so it is
+        # refused rather than given the benefit of the doubt.
+        stale = {"baselineEvidence": {k: v for k, v in evidence.items()
+                                      if k != "trackedConfigArm9Sha256"}}
+        _digest, error = validate(stale)
+        assert error is not None and "trackedConfigArm9Sha256" in error
 
 
 def test_partitioned_result_gate_requires_every_full_rom_proof():

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -509,7 +509,11 @@ def _vague_externalization_fixture():
                 })
                 config["arm9"][address + reloc["r_offset"]] = (
                     "load", next_destination, "arm9")
-                name_index[target.name] = ("arm9", next_destination - reloc["r_addend"])
+                raw_bias = (reloc["r_addend"] - tubuild.OI.VTABLE_PREAMBLE
+                            if target.name.startswith("_ZTV")
+                            and reloc["r_addend"] >= tubuild.OI.VTABLE_PREAMBLE
+                            else reloc["r_addend"])
+                name_index[target.name] = ("arm9", next_destination - raw_bias)
                 next_destination += 4
         policies.append({
             "symbol": name, "disposition": "canonical-import",
@@ -783,6 +787,116 @@ if __name__ == "__main__":
 
 
 import tubuild
+
+
+def test_linkcheck_compile_passes_all_production_object_policies():
+    original_policies = tubuild.RB.compiler_only_policies
+    original_intact = tubuild.RB.intact_tu_policies
+    original_compile = tubuild.RB.compile_one
+    policy = {"src/actors/Promoted.cpp": {"deadstrip": ["helper"]}}
+    intact = {"src/actors/Promoted.cpp": {"id": "ov047/Promoted"}}
+    seen = []
+
+    try:
+        tubuild.RB.compiler_only_policies = lambda enrolled: (
+            policy if list(enrolled) == ["src/actors/Promoted.cpp"] else None)
+        tubuild.RB.intact_tu_policies = lambda enrolled: (
+            intact if list(enrolled) == ["src/actors/Promoted.cpp"] else None)
+
+        def fake_compile(rel, vers, cache, init_srcs, syms, build_root=None,
+                         compiler_only=None, intact_tus=None):
+            seen.append((rel, build_root, compiler_only, intact_tus))
+            return rel, None, "hit"
+
+        tubuild.RB.compile_one = fake_compile
+        failures, outcomes = tubuild.compile_linkcheck_sources(
+            ["src/actors/Promoted.cpp"], {}, None, set(), {}, pathlib.Path("scratch"), 1)
+    finally:
+        tubuild.RB.compiler_only_policies = original_policies
+        tubuild.RB.intact_tu_policies = original_intact
+        tubuild.RB.compile_one = original_compile
+
+    assert failures == []
+    assert outcomes["hit"] == 1
+    assert seen == [("src/actors/Promoted.cpp", pathlib.Path("scratch"),
+                     policy, intact)]
+
+
+def test_strict_control_demotes_only_requested_complete_sources():
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        path = root / "overlays/ov047/delinks.txt"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "src/actors/Promoted.cpp:\n"
+            "    complete\n"
+            "    .text start:0x1000 end:0x1010\n"
+            "    .data start:0x2000 end:0x2010\n\n"
+            "src/Other.cpp:\n"
+            "    complete\n"
+            "    .text start:0x1010 end:0x1020\n",
+            encoding="utf-8")
+
+        demoted, errors = tubuild.demote_complete_sources(
+            root, ["src/actors/Promoted.cpp"])
+
+        assert errors == []
+        assert demoted == ["src/actors/Promoted.cpp"]
+        text = path.read_text(encoding="utf-8")
+        promoted = text.split("src/Other.cpp:", 1)[0]
+        assert "complete" not in promoted
+        assert ".text start:0x1000 end:0x1010" in promoted
+        assert ".data start:0x2000 end:0x2010" in promoted
+        assert "src/Other.cpp:\n    complete" in text
+
+
+def test_strict_control_compile_does_not_re_admit_demoted_intact_tus():
+    original_intact = tubuild.RB.intact_tu_policies
+    original_compile = tubuild.RB.compile_one
+    seen = []
+    try:
+        tubuild.RB.intact_tu_policies = lambda _enrolled: (_ for _ in ()).throw(
+            AssertionError("demoted intact policy was recomputed"))
+
+        def fake_compile(rel, vers, cache, init_srcs, syms, build_root=None,
+                         compiler_only=None, intact_tus=None):
+            seen.append(intact_tus)
+            return rel, None, "hit"
+
+        tubuild.RB.compile_one = fake_compile
+        failures, outcomes = tubuild.compile_linkcheck_sources(
+            ["src/Other.cpp"], {}, None, set(), {}, pathlib.Path("scratch"), 1,
+            intact_tus_override={})
+    finally:
+        tubuild.RB.intact_tu_policies = original_intact
+        tubuild.RB.compile_one = original_compile
+
+    assert failures == []
+    assert outcomes["hit"] == 1
+    assert seen == [{}]
+
+
+def test_strict_control_refuses_a_source_that_was_not_complete():
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        path = root / "delinks.txt"
+        path.write_text(
+            "src/actors/Promoted.cpp:\n"
+            "    .text start:0x1000 end:0x1010\n",
+            encoding="utf-8")
+        demoted, errors = tubuild.demote_complete_sources(
+            root, ["src/actors/Promoted.cpp"])
+        assert demoted == []
+        assert errors == [
+            "src/actors/Promoted.cpp: delinks entry is not complete"]
+
+
+def test_linkcheck_symbol_verdict_uses_the_stock_failure_inventory():
+    assert tubuild.linkcheck_symbol_verdict(True, False, None)
+    assert tubuild.linkcheck_symbol_verdict(False, False, [])
+    assert not tubuild.linkcheck_symbol_verdict(False, False, ["new error"])
+    assert tubuild.linkcheck_symbol_verdict(False, True, None)
+    assert not tubuild.linkcheck_symbol_verdict(False, False, None)
 
 
 def test_vtable_storage_address_requires_an_explicit_consistent_bias():
@@ -1219,25 +1333,33 @@ def test_partition_baseline_evidence_is_content_bound_not_mtime_bound():
     with tempfile.TemporaryDirectory() as td:
         root = pathlib.Path(td)
         config = root / "config"
+        rom_inputs = root / "rom-inputs"
         config.mkdir()
+        rom_inputs.mkdir()
         cfg = config / "symbols.txt"
+        (rom_inputs / "header.yaml").write_bytes(b"ROM")
         linked, dsd, linker = root / "base.o", root / "dsd.exe", root / "mwld.exe"
+        control_tool = root / "analysis.py"
         cfg.write_bytes(b"one")
         linked.write_bytes(b"ELF")
         dsd.write_bytes(b"DSD")
         linker.write_bytes(b"MWL")
+        control_tool.write_bytes(b"ANALYZE")
         evidence = tubuild.partition_baseline_fingerprints(
-            linked, config, dsd_path=dsd, linker_path=linker)
+            linked, config, dsd_path=dsd, linker_path=linker,
+            rom_inputs=rom_inputs, control_tools=[control_tool])
         report = {"baselineEvidence": evidence}
         digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker)
+            report, linked, config, dsd_path=dsd, linker_path=linker,
+            rom_inputs=rom_inputs, control_tools=[control_tool])
         assert error is None and digest == evidence["linkedElfSha256"]
 
         stamp = cfg.stat().st_mtime_ns
         cfg.write_bytes(b"two")
         os.utime(cfg, ns=(stamp, stamp))
         _digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker)
+            report, linked, config, dsd_path=dsd, linker_path=linker,
+            rom_inputs=rom_inputs, control_tools=[control_tool])
         assert "configArm9Sha256" in error
 
         cfg.write_bytes(b"one")
@@ -1245,8 +1367,23 @@ def test_partition_baseline_evidence_is_content_bound_not_mtime_bound():
         linked.write_bytes(b"BAD")
         os.utime(linked, ns=(linked_stamp, linked_stamp))
         _digest, error = tubuild.validate_partition_baseline_evidence(
-            report, linked, config, dsd_path=dsd, linker_path=linker)
+            report, linked, config, dsd_path=dsd, linker_path=linker,
+            rom_inputs=rom_inputs, control_tools=[control_tool])
         assert "linkedElfSha256" in error
+
+        linked.write_bytes(b"ELF")
+        (rom_inputs / "header.yaml").write_bytes(b"CHANGED")
+        _digest, error = tubuild.validate_partition_baseline_evidence(
+            report, linked, config, dsd_path=dsd, linker_path=linker,
+            rom_inputs=rom_inputs, control_tools=[control_tool])
+        assert "romInputsSha256" in error
+
+        (rom_inputs / "header.yaml").write_bytes(b"ROM")
+        control_tool.write_bytes(b"CHANGED")
+        _digest, error = tubuild.validate_partition_baseline_evidence(
+            report, linked, config, dsd_path=dsd, linker_path=linker,
+            rom_inputs=rom_inputs, control_tools=[control_tool])
+        assert "controlToolsSha256" in error
 
 
 def test_partitioned_result_gate_requires_every_full_rom_proof():
@@ -1326,6 +1463,35 @@ def test_partitioned_cli_modes_are_mutually_exclusive_before_any_build():
     code, out = _run("linkcheck", "ov045/PoleLift", "--partial", "--partitioned")
     assert code != 0
     assert "not allowed with argument" in out or "mutually exclusive" in out
+
+
+def test_record_linkcheck_preserves_all_owned_ranges():
+    entry = {"status": "text-verified"}
+    report = {
+        "result": "scratch-data-verified",
+        "scratch": "scratch/path",
+        "phases": {"link": {"ok": True}, "rom": {"ok": True}},
+        "tuRange": {"section": ".text", "differingBytes": 0},
+        "tuRanges": [
+            {"section": ".text", "differingBytes": 0},
+            {"section": ".data", "differingBytes": 0},
+        ],
+        "objectAudit": {},
+        "symbolsNew": [],
+        "analysis": {"moduleFidelity": {"moduleSetSha256": "b" * 64}},
+        "rom": {"matchesStockRom": True, "sha256": "a" * 64},
+    }
+    original = tubuild.save_manifest
+    try:
+        tubuild.save_manifest = lambda _data: None
+        tubuild._record_linkcheck({"entries": [entry]}, entry, report, False)
+    finally:
+        tubuild.save_manifest = original
+
+    recorded = entry["verification"]["linkcheck"]
+    assert recorded["tuRange"] == report["tuRange"]
+    assert recorded["tuRanges"] == report["tuRanges"]
+    assert recorded["moduleSetSha256"] == "b" * 64
 
 # ---------------------------------------------------------------- create repairs
 # The three assemble_shadow_source behaviors proven by six modules of

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -238,8 +238,12 @@ def _strict_baseline(expected_intact=None):
     if not expected_demoted and compared is not True:
         raise ProductionTuError(
             "stock control did not prove a ROM identical to build/sm64ds.nds")
+    # config_root is the preserved scratch copy the baseline link consumed; the tracked
+    # config is checked too (tracked_config_root defaults to TB.CFG_ARM9), because a
+    # scratch-only binding cannot see config/arm9 moving after the baseline was banked.
     _sha, error = TB.validate_partition_baseline_evidence(
-        report, linked_elf, config_root=TB.BASELINE_LINK / "config" / "arm9")
+        report, linked_elf, config_root=TB.BASELINE_LINK / "config" / "arm9",
+        tracked_config_root=TB.CFG_ARM9)
     if error:
         raise ProductionTuError(f"stock control is stale: {error}")
     base_errors = (((report.get("phases") or {}).get("checkSymbols") or {})

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import hashlib
 import json
 import pathlib
+import subprocess
+import sys
 
 import tubuild as TB
 
@@ -27,12 +29,185 @@ class ProductionTuError(RuntimeError):
     """A partitioned TU cannot safely enter the normal ROM build."""
 
 
+def prepare_intact_object(raw, entry):
+    """Apply and reverify the exact policies for one production intact TU object."""
+    claims, reasons = TB.manifest_section_claims(entry)
+    if reasons:
+        _raise(f"{entry.get('id', '<unknown>')} manifest section claims", reasons)
+    text = [claim for claim in claims if claim["name"] == ".text"]
+    nontext = [claim for claim in claims if claim["name"] != ".text"]
+    if len(text) != 1 or not nontext:
+        raise ProductionTuError(
+            f"{entry.get('id', '<unknown>')}: intact production requires one .text "
+            "claim and at least one non-text claim")
+
+    post_policy, compiler_only, reasons = TB.apply_compiler_only_policy(raw, entry)
+    if reasons:
+        _raise(f"{entry['id']} compiler-only output", reasons)
+    externalized_obj, externalized, reasons = \
+        TB.apply_externalized_output_policy(post_policy, entry)
+    if reasons:
+        _raise(f"{entry['id']} exact RTTI externalization", reasons)
+
+    owned_before = TB.verify_owned_sections(externalized_obj, entry, claims)
+    if not owned_before.get("ok"):
+        _raise(f"{entry['id']} licensed non-text contribution",
+               owned_before.get("errors", []))
+    biases, reasons = TB.partition_vtable_rebiases(entry, claims)
+    if reasons:
+        _raise(f"{entry['id']} vtable address-point policy", reasons)
+    linked_obj, rebias = TB.OI.rebias_object_symbols(
+        externalized_obj, biases, normalize_undefined=True)
+    if linked_obj is None:
+        _raise(f"{entry['id']} vtable address-point rewrite", [rebias.get("error")])
+    owned_after = TB.verify_owned_sections(
+        linked_obj, entry, claims, public_address_points=True)
+    if not owned_after.get("ok"):
+        _raise(f"{entry['id']} production non-text contribution",
+               owned_after.get("errors", []))
+
+    span_start, span_end = text[0]["start"], text[0]["end"]
+    rows, extra, emitted, order_ok = TB.audit_tu_object(
+        linked_obj, entry, span_start, span_end, TB.complete_ranges(TB.CFG_ARM9))
+    audit_errors = TB.object_audit_refusals(rows, extra, order_ok)
+    if audit_errors:
+        _raise(f"{entry['id']} production object audit", audit_errors)
+    return linked_obj, {
+        "compilerOnly": compiler_only, "externalized": externalized,
+        "ownedBefore": owned_before, "ownedAfter": owned_after,
+        "vtableRebias": rebias,
+        "objectAudit": {"rows": rows, "extraSections": extra,
+                        "emitted": emitted, "orderOk": order_ok},
+        "sha256": hashlib.sha256(linked_obj).hexdigest(),
+    }
+
+
 def _raise(label, reasons):
     detail = "; ".join(str(reason) for reason in reasons if reason)
     raise ProductionTuError(f"{label}: {detail or 'refused without a reason'}")
 
 
-def _strict_baseline():
+def _demoted_inventory(entries):
+    return sorted(({"id": entry.get("id", source), "source": source}
+                   for source, entry in entries.items()),
+                  key=lambda row: row["source"])
+
+
+def _current_or_bootstrapped_intact_baseline(entries, jobs):
+    """Return a current source-independent control, building it if necessary.
+
+    The baseline command removes every promoted intact source's ``complete`` marker
+    in its disposable config, so those ranges come directly from extracted retail
+    gap bytes. This makes the control independent of the C++ objects it will judge
+    and safe to create on a clean CI worker with no gitignored build artifacts.
+    """
+    try:
+        return _strict_baseline(entries)
+    except ProductionTuError as first_error:
+        modules = sorted({entry.get("module") for entry in entries.values()
+                          if entry.get("module")})
+        module = modules[0] if modules else "ov002"
+        print("strict stock control is missing or stale; generating a fresh "
+              f"ROM-gap control for {module}")
+        command = [
+            sys.executable, str(TB.REPO / "tools" / "tubuild.py"),
+            "linkcheck", "--baseline", "--module", module,
+            "-j", str(jobs), "--clean",
+        ]
+        result = subprocess.run(command, check=False)
+        if result.returncode:
+            raise ProductionTuError(
+                "could not bootstrap strict stock control: "
+                f"{first_error}; baseline command exited {result.returncode}")
+        try:
+            return _strict_baseline(entries)
+        except ProductionTuError as fresh_error:
+            raise ProductionTuError(
+                f"fresh strict stock control is invalid: {fresh_error}") from fresh_error
+
+
+def prepare_intact_link_verification(entries, jobs=4):
+    """Bind supported automatic intact TUs to the current strict stock control.
+
+    Object preparation proves the compiler contribution before the link. This plan
+    carries the remaining facts needed after mwldarm: the content-bound current
+    baseline's symbol-error inventory and each vtable address-point mapping. Automatic
+    intact admission refuses storage aliases until their baseline bootstrap is
+    non-circular, so refreshing this control never depends on the control being kept.
+    """
+    admitted_errors = set()
+    admitted_roms = set()
+    admitted_module_sets = set()
+    for entry in entries.values():
+        linkcheck = (entry.get("verification") or {}).get("linkcheck") or {}
+        errors = linkcheck.get("symbolCheckErrors")
+        rom_sha = (linkcheck.get("rom") or {}).get("sha256")
+        module_set_sha = linkcheck.get("moduleSetSha256")
+        if (not isinstance(errors, list) or not isinstance(rom_sha, str)
+                or not _is_sha256(module_set_sha)):
+            raise ProductionTuError(
+                f"{entry.get('id', '<unknown>')}: admitted intact proof lacks its "
+                "symbol-error inventory, stock ROM SHA-256, or complete executable-"
+                "module fingerprint")
+        admitted_errors.add(tuple(sorted(set(errors))))
+        admitted_roms.add(rom_sha)
+        admitted_module_sets.add(module_set_sha)
+    baseline = _current_or_bootstrapped_intact_baseline(entries, jobs)
+    current_errors = tuple(baseline["symbolErrors"])
+    if admitted_errors != {current_errors}:
+        raise ProductionTuError(
+            "strict post-promotion control symbol errors do not equal the admitted "
+            f"pre-promotion inventory: current={list(current_errors)!r}, "
+            f"admitted={[list(rows) for rows in sorted(admitted_errors)]!r}")
+    if admitted_module_sets != {baseline["moduleSetSha256"]}:
+        report = baseline.get("report") or {}
+        diagnostics = {
+            "rom": report.get("rom"),
+            "baselineEvidence": report.get("baselineEvidence"),
+            "moduleSetSha256": baseline["moduleSetSha256"],
+            "intactTusDemoted": report.get("intactTusDemoted"),
+            "scratch": report.get("scratch"),
+        }
+        raise ProductionTuError(
+            "strict post-promotion control executable-module fingerprint does not "
+            f"equal the admitted proof: current={baseline['moduleSetSha256']}, "
+            f"admitted={sorted(admitted_module_sets)!r}, "
+            f"control={json.dumps(diagnostics, sort_keys=True)}")
+    if baseline["matchesStockRom"] is not True \
+            and admitted_roms != {baseline["romSha256"]}:
+        raise ProductionTuError(
+            "strict post-promotion control has no same-worker stock-ROM comparison "
+            "and its ROM SHA-256 does not equal the admitted bootstrap proof: "
+            f"current={baseline['romSha256']}, admitted={sorted(admitted_roms)!r}")
+    prepared = []
+    for source, entry in sorted(entries.items()):
+        claims, reasons = TB.manifest_section_claims(entry)
+        if reasons:
+            _raise(f"{entry.get('id', source)} manifest section claims", reasons)
+        biases, reasons = TB.partition_vtable_rebiases(entry, claims)
+        if reasons:
+            _raise(f"{entry.get('id', source)} vtable address-point policy", reasons)
+        prepared.append({"id": entry.get("id", source), "source": source,
+                         "biases": biases})
+    return {
+        "baseline": baseline,
+        "entries": prepared,
+        "admittedRomSha256": sorted(admitted_roms),
+        "admittedModuleSetSha256": next(iter(admitted_module_sets)),
+    }
+
+
+def _is_sha256(value):
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _strict_baseline(expected_intact=None):
     """Return the content-bound stock baseline or refuse stale/missing evidence."""
     report_path = TB.BASELINE_LINK / "linkcheck.json"
     linked_elf = TB.BASELINE_LINK / "final_link.o"
@@ -48,16 +223,34 @@ def _strict_baseline():
             or (report.get("analysis") or {}).get("passed") is not True \
             or ((report.get("phases") or {}).get("checkModules") or {}).get("ok") is not True:
         raise ProductionTuError("stock control did not pass module fidelity")
+    expected_demoted = _demoted_inventory(expected_intact or {})
+    actual_demoted = report.get("intactTusDemoted")
+    if actual_demoted != expected_demoted:
+        raise ProductionTuError(
+            "stock control did not exclude the current intact TU inventory: "
+            f"expected={expected_demoted!r}, actual={actual_demoted!r}")
     rom = report.get("rom") or {}
-    if rom.get("matchesStockRom") is not True or not rom.get("sha256"):
-        raise ProductionTuError("stock control did not prove a ROM identical to build/sm64ds.nds")
-    _sha, error = TB.validate_partition_baseline_evidence(report, linked_elf)
+    if not rom.get("sha256"):
+        raise ProductionTuError("stock control did not produce a ROM SHA-256")
+    compared = rom.get("matchesStockRom")
+    if compared is False:
+        raise ProductionTuError("stock control ROM differs from build/sm64ds.nds")
+    if not expected_demoted and compared is not True:
+        raise ProductionTuError(
+            "stock control did not prove a ROM identical to build/sm64ds.nds")
+    _sha, error = TB.validate_partition_baseline_evidence(
+        report, linked_elf, config_root=TB.BASELINE_LINK / "config" / "arm9")
     if error:
         raise ProductionTuError(f"stock control is stale: {error}")
     base_errors = (((report.get("phases") or {}).get("checkSymbols") or {})
                    .get("errors"))
     if not isinstance(base_errors, list):
         raise ProductionTuError("stock control has no baseline symbol-error inventory")
+    module_set_sha = (((report.get("analysis") or {}).get("moduleFidelity") or {})
+                      .get("moduleSetSha256"))
+    if not _is_sha256(module_set_sha):
+        raise ProductionTuError(
+            "stock control has no complete executable-module fingerprint")
     return {
         "report": report,
         "reportPath": report_path,
@@ -65,6 +258,8 @@ def _strict_baseline():
         "linkedElfSha256": hashlib.sha256(linked_elf.read_bytes()).hexdigest(),
         "symbolErrors": sorted(set(base_errors)),
         "romSha256": rom["sha256"],
+        "matchesStockRom": compared,
+        "moduleSetSha256": module_set_sha,
     }
 
 
@@ -198,7 +393,8 @@ def prepare(tu_ids, config_root, work_root, jobs=1):
         return {"entries": [], "overrides": {}, "baseline": None}
     if len(ids) != len(set(ids)):
         raise ProductionTuError("duplicate --partitioned-tu id")
-    baseline = _strict_baseline()
+    enrolled = TB.RB.enrolled(TB.CFG_ARM9)
+    baseline = _strict_baseline(TB.RB.intact_tu_policies(enrolled))
     data = TB.load_manifest()
     config_root = pathlib.Path(config_root)
     work_root = pathlib.Path(work_root)
@@ -242,7 +438,7 @@ def verify_link(config_yaml, linked_elf, prepared):
         "dsd check modules")
     ok_symbols, symbols_out, _seconds = TB._run_dsd(
         [str(TB.RB.DSD), "check", "symbols", "-c", str(config_yaml),
-         "-e", str(linked_elf), "-f", "-m", "12"],
+         "-e", str(linked_elf), "-m", "12"],
         "dsd check symbols")
     symbol_errors = sorted({line.strip() for line in symbols_out.splitlines()
                             if "[ERROR]" in line})
@@ -254,7 +450,7 @@ def verify_link(config_yaml, linked_elf, prepared):
         alias_rows.extend(result.get("rows", []))
         alias_errors.extend(result.get("errors", []))
     return {
-        "ok": bool(ok_modules and not new_errors and not alias_errors),
+        "ok": bool(ok_modules and ok_symbols and not new_errors and not alias_errors),
         "modulesOk": bool(ok_modules),
         "modulesOutput": modules_out[-4000:],
         "symbolsCommandOk": bool(ok_symbols),

--- a/tools/tu_promote.py
+++ b/tools/tu_promote.py
@@ -12,25 +12,26 @@ tree carries a file per mangled symbol, every structor has to be hand-placed und
 The mechanical steps, all of which this performs and none of which it guesses at:
 
 * replace the entry's per-function ``delinks.txt`` entries with one ``complete``
-  entry spanning the manifest's sections;
+  entry spanning every manifest-owned section;
 * ``git mv`` the ``src_tu/`` source to its ``promoted_source`` path (R100, so the
   file's own credit follows) and ``git rm`` every ``legacy_source``;
 * rewrite the manifest entry to ``status: promoted`` with ``source`` at the
   production path, matching the entries already enrolled;
 * add one ``attribution.json`` override per absorbed symbol, so a many-to-one
   consolidation reads as "consolidated with credit intact" instead of N lost.
+* migrate banked CONVERTED legacy paths to ``promoted-path#symbol`` identities,
+  preserving the readability ratchet at function rather than physical-file granularity.
 
-It deliberately does NOT compile anything. The proof that a promotion is sound is
-``rombuild.py`` reporting 106/106 with ``mismatching: 0`` afterwards, and running it
-once over a batch is far cheaper than once per entry. Refusals here are only about
-facts that can be checked without a compiler: a missing file, a delinks entry that
-does not look the way the manifest says it does, a section span that does not cover
-the functions claimed inside it.
+It deliberately does NOT compile anything. It preflights the tracked full-ROM proof;
+after promotion, refresh the content-bound stock control, then require ``rombuild.py``
+to reproduce that stock ROM and report 106/106 with ``mismatching: 0`` plus the final
+linked-symbol/address-point gates. Refusals here need no candidate compile.
 """
 
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import pathlib
 import re
@@ -41,6 +42,9 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 
 import tu_manifest as TUM  # noqa: E402
+import tiers_ratchet as TR  # noqa: E402
+import rombuild as RB  # noqa: E402
+import tubuild as TB  # noqa: E402
 
 CONFIG = REPO / "config"
 
@@ -54,11 +58,6 @@ def delinks_path(module):
     if module in ("arm9", "main"):
         return CONFIG / "arm9" / "delinks.txt"
     return CONFIG / "arm9" / "overlays" / module / "delinks.txt"
-
-
-def _entry_re(source):
-    """One whole delinks entry: the path line plus its indented body."""
-    return re.compile(re.escape(source) + r":\n(?:[ \t]+[^\n]*\n)+\n?")
 
 
 def plan(entry):
@@ -87,19 +86,37 @@ def plan(entry):
     if (REPO / dest).exists():
         raise PromoteError(f"{ident}: {dest} already exists")
 
-    sections = [s for s in entry.get("sections", []) if s.get("name") == ".text"]
-    if not sections:
-        raise PromoteError(f"{ident}: no .text section in the manifest")
-    if entry.get("data") or entry.get("bss"):
+    normalized_claims, claim_reasons = TB.manifest_section_claims(entry)
+    if claim_reasons:
+        raise PromoteError(f"{ident}: invalid manifest section claims: "
+                           + "; ".join(claim_reasons))
+    owns_nontext = any(s["name"] != ".text" for s in normalized_claims) \
+        or bool(entry.get("data") or entry.get("rodata") or entry.get("bss"))
+    if owns_nontext and entry.get("production_mode") != "intact-object":
         # Production isolation zeroes an object's data and rebinds the symbols to the
-        # cartridge's addresses; a TU that OWNS delinked data is a different problem
-        # and is not what this path models.
-        raise PromoteError(f"{ident}: entry owns data/bss; not a text-only promotion")
+        # cartridge's addresses unless the normal build has explicitly admitted this
+        # manifest-backed intact-object policy.
+        raise PromoteError(f"{ident}: entry owns non-text data without "
+                           "production_mode: intact-object")
+
+    claims = []
+    spans = []
+    for section in normalized_claims:
+        name = section["name"]
+        module_section = section["module_section"]
+        lo, hi = section["start"], section["end"]
+        if (entry.get("production_mode") == "intact-object"
+                and module_section != name):
+            raise PromoteError(f"{ident}: intact-object claim {name} -> "
+                               f"{module_section} needs input-section retargeting, "
+                               "which is not implemented")
+        claims.append((module_section, lo, hi))
+        if name == ".text":
+            spans.append((lo, hi))
 
     funcs = entry.get("functions", [])
     if not funcs:
         raise PromoteError(f"{ident}: entry licenses no functions")
-    spans = [(int(s["start"], 16), int(s["end"], 16)) for s in sections]
     legacy = []
     for f in funcs:
         addr, size = int(f["address"], 16), int(f["size"], 16)
@@ -115,36 +132,42 @@ def plan(entry):
     dl = delinks_path(entry["module"])
     if not dl.is_file():
         raise PromoteError(f"{ident}: {dl} does not exist")
-    text = dl.read_text(encoding="utf-8")
-    for source in legacy:
-        n = len(_entry_re(source).findall(text))
-        if n != 1:
-            raise PromoteError(f"{ident}: {source} has {n} entries in "
-                               f"{dl.relative_to(REPO)}, expected exactly 1")
-    return {"id": ident, "source": src, "dest": dest, "delinks": dl,
-            "legacy": legacy, "spans": spans, "functions": funcs}
+    if len(spans) != 1:
+        raise PromoteError(f"{ident}: production promotion needs exactly one .text "
+                           f"span, got {len(spans)}")
+    _header, _entries, _inside, _validated_claims, splice_reasons = \
+        TB.validate_tu_entry_splice(dl, spans[0][0], spans[0][1], dest, legacy,
+                                    normalized_claims)
+    if splice_reasons:
+        raise PromoteError(f"{ident}: current delinks ownership is not safe to splice: "
+                           + "; ".join(splice_reasons))
+    if entry.get("production_mode") == "intact-object":
+        prospective = copy.deepcopy(entry)
+        prospective["status"] = "promoted"
+        prospective["source"] = dest
+        try:
+            RB.intact_tu_policies([dest], manifest={"entries": [prospective]})
+        except RB.BuildError as exc:
+            raise PromoteError(f"{ident}: production admission preflight failed: "
+                               f"{exc.output}") from exc
+
+    return {"id": ident, "module": entry["module"], "source": src, "dest": dest,
+            "delinks": dl,
+            "legacy": legacy, "spans": spans, "claims": claims,
+            "section_claims": normalized_claims, "functions": funcs}
 
 
 def rewrite_delinks(p):
-    """N per-function entries out, one spanning entry in, in address order."""
-    text = p["delinks"].read_text(encoding="utf-8")
-    for source in p["legacy"]:
-        text = _entry_re(source).sub("", text, count=1)
-    body = "".join(f"    .text start:0x{lo:08x} end:0x{hi:08x}\n" for lo, hi in p["spans"])
-    entry = f"{p['dest']}:\n    complete\n{body}\n"
-    # Address order is not cosmetic: it is how a reader of delinks.txt finds the entry
-    # that owns an address, and dsd emits the file sorted.
-    after = min(hi for _lo, hi in p["spans"])
-    nxt = None
-    for m in re.finditer(
-            r"^[^\s:][^\n]*:\n[ \t]+complete\n[ \t]+\.text start:0x([0-9a-fA-F]{8})",
-            text, re.M):
-        if int(m.group(1), 16) >= after:
-            nxt = m
-            break
-    text = (text[:nxt.start()] + entry + text[nxt.start():]) if nxt \
-        else text.rstrip("\n") + "\n\n" + entry
-    p["delinks"].write_text(text, encoding="utf-8", newline="")
+    """N per-function entries out, one spanning entry in, using the shared gate."""
+    replaced, reasons = TB.splice_tu_entry(
+        p["delinks"], p["spans"][0][0], p["spans"][0][1], p["dest"],
+        p["legacy"], p["section_claims"])
+    if reasons:
+        raise PromoteError(f"{p['id']}: delinks ownership changed after preflight: "
+                           + "; ".join(reasons))
+    if set(replaced) != set(p["legacy"]):
+        raise PromoteError(f"{p['id']}: shared splice replaced {replaced}, expected "
+                           f"{p['legacy']}")
 
 
 def rewrite_manifest(entry, p):
@@ -155,16 +178,21 @@ def rewrite_manifest(entry, p):
                     encoding="utf-8", newline="")
 
 
-def rewrite_attribution(plans, lineage):
-    """One override per absorbed symbol, so the consolidation keeps its authors.
+def attribution_update(plans, lineage):
+    """Prepare attribution overrides without changing the worktree.
 
     Without these, prepush_attribution reports every legacy basename as CREDIT LOST
     and the merge gate needs a label to pass -- for a change that took nothing away
     from anyone.
     """
     path = REPO / "attribution.json"
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PromoteError(f"attribution data is unreadable: {exc}") from exc
     ov = data.setdefault("overrides", {})
+    if not isinstance(ov, dict):
+        raise PromoteError("attribution overrides must be an object")
     added = 0
     for p in plans:
         for f in p["functions"]:
@@ -176,15 +204,119 @@ def rewrite_attribution(plans, lineage):
             if key not in ov:
                 ov[key] = who
                 added += 1
-    data["overrides"] = dict(sorted(ov.items()))
+    return path, data, added
+
+
+def rewrite_attribution(plans, lineage, prepared=None):
+    """Write a preflighted attribution update."""
+    path, data, added = prepared or attribution_update(plans, lineage)
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n",
                     encoding="utf-8", newline="")
     return added
 
 
+def converted_baseline_update(plans):
+    """Prepare a CONVERTED identity rewrite without changing the worktree.
+
+    The baseline historically keyed one-function intake by path. Consolidation deletes
+    those paths, while ``tiers.py`` continues counting the functions inside the promoted
+    TU. Only already-banked legacy identities move; an unbanked function does not become
+    readable merely because it now shares a file with one that was.
+    """
+    path = CONFIG / "converted-baseline.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PromoteError(f"converted baseline is unreadable: {exc}") from exc
+    rows = data.get("converted")
+    if not isinstance(rows, list) or len(rows) != len(set(rows)):
+        raise PromoteError("converted baseline must contain a unique converted list")
+
+    converted = list(rows)
+    moved = 0
+    for p in plans:
+        for f in p["functions"]:
+            legacy = f["legacy_source"]
+            symbol = f["symbol"]
+            old_keys = (legacy, f"{legacy}#{symbol}")
+            positions = [converted.index(key) for key in old_keys if key in converted]
+            if not positions:
+                continue
+            insert_at = min(positions)
+            converted = [key for key in converted if key not in old_keys]
+            target = p["dest"] if len(p["functions"]) == 1 \
+                else f"{p['dest']}#{symbol}"
+            if target not in converted:
+                converted.insert(min(insert_at, len(converted)), target)
+            moved += 1
+
+    data["_note"] = TR.NOTE
+    data["count"] = len(converted)
+    data["converted"] = converted
+    return path, data, moved
+
+
+def rewrite_converted_baseline(plans, prepared=None):
+    """Write a preflighted CONVERTED identity rewrite."""
+    path, data, moved = prepared or converted_baseline_update(plans)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+                    encoding="utf-8", newline="")
+    return moved
+
+
 def git(*args):
     subprocess.run(["git", *args], cwd=REPO, check=True,
                    stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+
+
+def batch_preflight(plans):
+    """Refuse a promotion batch before its first mutation if ownership is ambiguous."""
+    errors = []
+    destinations = {}
+    consumed = {}
+    claims_by_delinks = {}
+    required = set()
+    for p in plans:
+        dest = p["dest"]
+        if dest in destinations:
+            errors.append(f"{dest} is the destination of both {destinations[dest]} "
+                          f"and {p['id']}")
+        destinations[dest] = p["id"]
+        inputs = [("shadow source", p["source"])]
+        inputs.extend(("legacy source", rel) for rel in p["legacy"])
+        for role, rel in inputs:
+            required.add(rel)
+            owner = consumed.get(rel)
+            if owner and owner != p["id"]:
+                errors.append(f"{rel} is consumed by both {owner} and {p['id']}")
+            consumed[rel] = p["id"]
+            if not (REPO / rel).is_file():
+                errors.append(f"{p['id']}: {role} {rel} is not on disk")
+        owned = claims_by_delinks.setdefault(str(p["delinks"]), [])
+        for section, start, end in p.get("claims", []):
+            for other_start, other_end, other_id, other_section in owned:
+                if max(start, other_start) < min(end, other_end):
+                    errors.append(
+                        f"{p['id']} {section} 0x{start:08x}..0x{end:08x} overlaps "
+                        f"{other_id} {other_section} 0x{other_start:08x}.."
+                        f"0x{other_end:08x} in the same delinks file")
+            owned.append((start, end, p["id"], section))
+    for dest, owner in destinations.items():
+        if dest in consumed:
+            errors.append(f"{owner}: destination {dest} is also a source consumed "
+                          f"by {consumed[dest]}")
+
+    if errors:
+        raise PromoteError("batch preflight failed: " + "; ".join(errors))
+
+    for rel in sorted(required):
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", rel], cwd=REPO,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+        if not tracked:
+            errors.append(f"{rel} is not tracked by git")
+    if errors:
+        raise PromoteError("batch preflight failed: " + "; ".join(errors))
 
 
 def main():
@@ -211,19 +343,38 @@ def main():
 
     for why in refused:
         print(f"  refused  {why}")
-    if not plans:
+    if refused or not plans:
         print("tu_promote: nothing to promote.")
         return 1 if refused else 0
+
+    try:
+        batch_preflight(plans)
+    except PromoteError as exc:
+        print(f"  refused  {exc}")
+        print("tu_promote: nothing to promote.")
+        return 1
 
     for p in plans:
         print(f"  promote  {p['id']:38s} {len(p['functions'])} function(s), "
               f"{len(p['legacy'])} legacy source(s) -> {p['dest']}")
+    try:
+        converted_update = converted_baseline_update(plans)
+    except PromoteError as exc:
+        print(f"  refused  {exc}")
+        return 1
     if args.dry_run:
-        print(f"tu_promote: {len(plans)} entry(ies) would be promoted (dry run).")
+        print(f"tu_promote: {len(plans)} entry(ies) would be promoted and "
+              f"{converted_update[2]} CONVERTED member identity/identities retained "
+              "(dry run).")
         return 0
 
     import prepush_attribution as PA
     lineage = PA.lineage("HEAD")
+    try:
+        attribution = attribution_update(plans, lineage)
+    except PromoteError as exc:
+        print(f"  refused  {exc}")
+        return 1
     for p, entry in zip(plans, entries):
         rewrite_delinks(p)
         # `git mv` will not create the destination directory, and a promoted_source
@@ -233,12 +384,17 @@ def main():
         for source in p["legacy"]:
             git("rm", "-q", source)
         rewrite_manifest(entry, p)
-    added = rewrite_attribution(plans, lineage)
+    converted = rewrite_converted_baseline(plans, converted_update)
+    added = rewrite_attribution(plans, lineage, attribution)
     print(f"tu_promote: {len(plans)} entry(ies) promoted, "
           f"{sum(len(p['functions']) for p in plans)} function(s) consolidated, "
-          f"{added} attribution override(s) added.")
-    print("tu_promote: now run `python tools/rombuild.py -j16 --no-rom` -- "
-          "106/106 with mismatching 0 is the proof.")
+          f"{added} attribution override(s) added, "
+          f"{converted} CONVERTED member identity/identities retained.")
+    print("tu_promote: now refresh the content-bound control with "
+          f"`python tools/tubuild.py linkcheck --baseline --module "
+          f"{plans[0]['module']} -j16 --clean`, then run "
+          "`python tools/rombuild.py -j16` -- 106/106, mismatching 0, zero new "
+          "symbol errors, exact address points, and a stock-identical ROM are the proof.")
     return 1 if refused else 0
 
 

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2942,21 +2942,44 @@ def content_files_sha256(paths):
 
 def partition_baseline_fingerprints(linked_elf, config_root=CFG_ARM9,
                                     dsd_path=None, linker_path=None,
-                                    rom_inputs=None, control_tools=None):
-    """Content identities that bind a baseline report to its actual inputs/output."""
+                                    rom_inputs=None, control_tools=None,
+                                    tracked_config_root=CFG_ARM9):
+    """Content identities that bind a baseline report to its actual inputs/output.
+
+    TWO config hashes, deliberately, because the baseline link no longer reads the
+    tracked config directly.  ``linkcheck --baseline`` copies ``config/arm9`` into its
+    own scratch and then MUTATES the copy (``demote_complete_sources``), so the tree
+    that produced ``final_link.o`` is the scratch one, and only the scratch hash can
+    answer "were these the inputs to this link?".
+
+    Hashing only the scratch copy, though, silently drops the signal the tracked hash
+    used to carry.  A baseline would stay "current" while ``config/arm9`` -- symbols,
+    delinks, the whole enrollment surface -- moved underneath it, because an edit to
+    the tracked tree cannot touch a preserved scratch copy.  The scratch hash proves
+    the report was not tampered with; the tracked hash proves the world it was derived
+    from has not moved.  Neither implies the other, so both are recorded and both are
+    validated.
+
+    When ``config_root`` is the tracked root -- the default, and every caller that is
+    not the scratch baseline -- the two hashes agree by construction.
+    """
     linked_elf = pathlib.Path(linked_elf)
     dsd_path = pathlib.Path(dsd_path or RB.DSD)
     linker_path = pathlib.Path(linker_path or (RB.MW / RB.LD_VERSION / "mwldarm.exe"))
     rom_inputs = pathlib.Path(rom_inputs or (REPO / "extracted" / "dsd"))
     control_tools = tuple(control_tools or BASELINE_CONTROL_TOOLS)
+    tracked_config_root = pathlib.Path(tracked_config_root or CFG_ARM9)
     required = [linked_elf, dsd_path, linker_path, *control_tools]
     missing = [str(path) for path in required if not path.is_file()]
     if not rom_inputs.is_dir():
         missing.append(str(rom_inputs))
+    if not tracked_config_root.is_dir():
+        missing.append(str(tracked_config_root))
     if missing:
         raise FileNotFoundError(f"baseline fingerprint input(s) missing: {missing}")
     return {
         "configArm9Sha256": content_tree_sha256(config_root),
+        "trackedConfigArm9Sha256": content_tree_sha256(tracked_config_root),
         "romInputsSha256": content_tree_sha256(rom_inputs),
         "controlToolsSha256": content_files_sha256(control_tools),
         "linkedElfSha256": hashlib.sha256(linked_elf.read_bytes()).hexdigest(),
@@ -2968,15 +2991,24 @@ def partition_baseline_fingerprints(linked_elf, config_root=CFG_ARM9,
 
 def validate_partition_baseline_evidence(report, linked_elf, config_root=CFG_ARM9,
                                          dsd_path=None, linker_path=None,
-                                         rom_inputs=None, control_tools=None):
-    """Refuse a baseline whose report is detached from current bytes or tools."""
+                                         rom_inputs=None, control_tools=None,
+                                         tracked_config_root=CFG_ARM9):
+    """Refuse a baseline whose report is detached from current bytes or tools.
+
+    A report written before ``trackedConfigArm9Sha256`` existed does not carry the key,
+    so it mismatches and is refused as stale.  That is the intended direction: a report
+    that cannot answer "has the tracked config moved?" must not be trusted to say it
+    has not.  Regenerating the baseline is the fix, and it is the same fix the tracked
+    hash demanded before it was dropped.
+    """
     evidence = report.get("baselineEvidence")
     if not isinstance(evidence, dict):
         return None, "baseline report has no content-bound evidence"
     try:
         current = partition_baseline_fingerprints(
             linked_elf, config_root, dsd_path=dsd_path, linker_path=linker_path,
-            rom_inputs=rom_inputs, control_tools=control_tools)
+            rom_inputs=rom_inputs, control_tools=control_tools,
+            tracked_config_root=tracked_config_root)
     except (OSError, ValueError) as exc:
         return None, f"cannot fingerprint baseline: {exc}"
     mismatched = [key for key, value in current.items() if evidence.get(key) != value]
@@ -2999,8 +3031,13 @@ def _baseline_partition_symbols(names):
             or (report.get("phases", {}).get("link") or {}).get("ok") is not True \
             or (report.get("analysis") or {}).get("passed") is not True:
         return None, None, "baseline report does not prove a successful stock module link"
+    # Both bindings, and for different reasons: the scratch config proves the preserved
+    # baseline inputs were not edited after the link, and CFG_ARM9 proves the tracked
+    # config has not drifted since. Validating only the scratch copy would accept a
+    # baseline whose tracked inputs no longer exist in that shape.
     baseline_sha256, error = validate_partition_baseline_evidence(
-        report, elf_path, config_root=BASELINE_LINK / "config" / "arm9")
+        report, elf_path, config_root=BASELINE_LINK / "config" / "arm9",
+        tracked_config_root=CFG_ARM9)
     if error:
         return None, None, error
     rows, error = linked_symbol_rows(elf_path, names)
@@ -4365,8 +4402,14 @@ def cmd_linkcheck(args):
     print(f"      ok ({dt:.1f}s) -> {(scratch / 'final_link.o').relative_to(REPO).as_posix()}")
 
     if baseline:
+        # cfg_root is the scratch copy this link actually consumed (demote_complete_sources
+        # rewrote it), so it is what binds the report to its own inputs. tracked_config_root
+        # stays CFG_ARM9 by default so the report ALSO carries the tracked config it was
+        # derived from -- without that second hash, config/arm9 can move and every
+        # consumer still calls this baseline current.
         report["baselineEvidence"] = partition_baseline_fingerprints(
-            scratch / "final_link.o", config_root=cfg_root)
+            scratch / "final_link.o", config_root=cfg_root,
+            tracked_config_root=CFG_ARM9)
 
     if partitioned:
         linked_aliases = verify_linked_storage_aliases(

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1573,17 +1573,9 @@ def span_entries(delinks_path, span_start, span_end, expected_legacy):
     return header, entries, inside, reasons
 
 
-def splice_tu_entry(delinks_path, span_start, span_end, tu_rel, expected_legacy,
-                    section_claims=None):
-    """Replace the per-function entries tiling [span_start, span_end) with ONE TU entry.
-
-    Refuses -- returns (None, [reasons]) -- rather than producing a plausible-looking
-    scratch config, because every failure mode here is silent downstream: dsd fills any
-    range it has no object for with retail ROM bytes, so a mis-spliced delinks tree
-    links clean and compares green while contributing nothing (see
-    "unbuildable files are invisible to every gate", and layout_check's L1). `span_entries` holds
-    the checks; this adds the rewrite.
-    """
+def validate_tu_entry_splice(delinks_path, span_start, span_end, tu_rel,
+                             expected_legacy, section_claims=None):
+    """Return the fully validated inputs for one destructive TU-entry splice."""
     header, entries, inside, reasons = span_entries(delinks_path, span_start, span_end,
                                                     expected_legacy)
     claims = list(section_claims or
@@ -1598,6 +1590,9 @@ def splice_tu_entry(delinks_path, span_start, span_end, tu_rel, expected_legacy,
     # entry touches one, silently adding the TU would create two owners; deciding how
     # to retire a future data-source entry is promotion policy, not scratch plumbing.
     drop_indices = {i for i, _r, _s in inside}
+    for idx, (rel, _body) in enumerate(entries):
+        if rel == tu_rel and idx not in drop_indices:
+            reasons.append(f"TU destination {tu_rel} is already a delinks entry")
     for claim in (c for c in claims if c["name"] != ".text"):
         for idx, (rel, body) in enumerate(entries):
             for name, start, end in entry_sections(body):
@@ -1606,6 +1601,23 @@ def splice_tu_entry(delinks_path, span_start, span_end, tu_rel, expected_legacy,
                                    f"0x{claim['end']:08x} overlaps existing entry {rel}'s "
                                    f"{name} 0x{start:08x}..0x{end:08x}; it is not pure "
                                    f"gap ownership")
+    return header, entries, inside, claims, reasons
+
+
+def splice_tu_entry(delinks_path, span_start, span_end, tu_rel, expected_legacy,
+                    section_claims=None):
+    """Replace the per-function entries tiling [span_start, span_end) with ONE TU entry.
+
+    Refuses -- returns (None, [reasons]) -- rather than producing a plausible-looking
+    scratch config, because every failure mode here is silent downstream: dsd fills any
+    range it has no object for with retail ROM bytes, so a mis-spliced delinks tree
+    links clean and compares green while contributing nothing (see
+    "unbuildable files are invisible to every gate", and layout_check's L1). The
+    read-only validator above is also the production promotion preflight, so the two
+    paths cannot drift on current delinks ownership rules.
+    """
+    header, entries, inside, claims, reasons = validate_tu_entry_splice(
+        delinks_path, span_start, span_end, tu_rel, expected_legacy, section_claims)
     if reasons:
         return None, reasons
 
@@ -2374,6 +2386,16 @@ def verify_externalized_output(obj_bytes, entry, policies=None, homes=None,
                     candidate_module = (RL.normalize_module(resolved[0])
                                         if resolved[0] is not None else None)
                     candidate_address = resolved[1] + emitted["addend"]
+                    # mwcc's raw `_ZTV` relocation is relative to the storage
+                    # object, while symbols.txt names the public slot-array address
+                    # after the two-word ABI preamble.  This is the same raw-object
+                    # convention used by reloc_audit.object_reloc_dests: addend 8
+                    # resolves to the configured address point, not eight bytes past
+                    # it.  Explicit addend-zero references already use the public
+                    # convention and remain unchanged.
+                    if emitted["symbol"].startswith("_ZTV") \
+                            and emitted["addend"] >= OI.VTABLE_PREAMBLE:
+                        candidate_address -= OI.VTABLE_PREAMBLE
                     if (candidate_module, candidate_address) != \
                             (expected["target_module"], expected["target_address"]):
                         row_reasons.append(f"relocation +0x{offset:x} resolves to "
@@ -2891,18 +2913,52 @@ def content_tree_sha256(root):
     return digest.hexdigest()
 
 
+BASELINE_CONTROL_TOOLS = tuple(
+    REPO / "tools" / name for name in (
+        "objisolate.py", "reloc_audit.py", "rombuild.py", "rombuild_cache.py",
+        "rombuild_check.py", "rombuild_profile.py", "tu_manifest.py",
+        "tu_production.py", "tubuild.py"))
+
+
+def content_files_sha256(paths):
+    """Hash an ordered set of tool paths and bytes without timestamps."""
+    rows = []
+    for path in map(pathlib.Path, paths):
+        try:
+            label = path.resolve().relative_to(REPO.resolve()).as_posix()
+        except ValueError:
+            label = path.name
+        rows.append((label, path))
+    digest = hashlib.sha256()
+    for label, path in sorted(rows):
+        raw_label = label.encode("utf-8")
+        raw = path.read_bytes()
+        digest.update(len(raw_label).to_bytes(4, "big"))
+        digest.update(raw_label)
+        digest.update(len(raw).to_bytes(8, "big"))
+        digest.update(raw)
+    return digest.hexdigest()
+
+
 def partition_baseline_fingerprints(linked_elf, config_root=CFG_ARM9,
-                                    dsd_path=None, linker_path=None):
+                                    dsd_path=None, linker_path=None,
+                                    rom_inputs=None, control_tools=None):
     """Content identities that bind a baseline report to its actual inputs/output."""
     linked_elf = pathlib.Path(linked_elf)
     dsd_path = pathlib.Path(dsd_path or RB.DSD)
     linker_path = pathlib.Path(linker_path or (RB.MW / RB.LD_VERSION / "mwldarm.exe"))
-    required = [linked_elf, dsd_path, linker_path]
+    rom_inputs = pathlib.Path(rom_inputs or (REPO / "extracted" / "dsd"))
+    control_tools = tuple(control_tools or BASELINE_CONTROL_TOOLS)
+    required = [linked_elf, dsd_path, linker_path, *control_tools]
     missing = [str(path) for path in required if not path.is_file()]
+    if not rom_inputs.is_dir():
+        missing.append(str(rom_inputs))
     if missing:
         raise FileNotFoundError(f"baseline fingerprint input(s) missing: {missing}")
     return {
         "configArm9Sha256": content_tree_sha256(config_root),
+        "romInputsSha256": content_tree_sha256(rom_inputs),
+        "controlToolsSha256": content_files_sha256(control_tools),
         "linkedElfSha256": hashlib.sha256(linked_elf.read_bytes()).hexdigest(),
         "linkedElfBytes": linked_elf.stat().st_size,
         "dsdSha256": hashlib.sha256(dsd_path.read_bytes()).hexdigest(),
@@ -2911,14 +2967,16 @@ def partition_baseline_fingerprints(linked_elf, config_root=CFG_ARM9,
 
 
 def validate_partition_baseline_evidence(report, linked_elf, config_root=CFG_ARM9,
-                                         dsd_path=None, linker_path=None):
+                                         dsd_path=None, linker_path=None,
+                                         rom_inputs=None, control_tools=None):
     """Refuse a baseline whose report is detached from current bytes or tools."""
     evidence = report.get("baselineEvidence")
     if not isinstance(evidence, dict):
         return None, "baseline report has no content-bound evidence"
     try:
         current = partition_baseline_fingerprints(
-            linked_elf, config_root, dsd_path=dsd_path, linker_path=linker_path)
+            linked_elf, config_root, dsd_path=dsd_path, linker_path=linker_path,
+            rom_inputs=rom_inputs, control_tools=control_tools)
     except (OSError, ValueError) as exc:
         return None, f"cannot fingerprint baseline: {exc}"
     mismatched = [key for key, value in current.items() if evidence.get(key) != value]
@@ -2941,7 +2999,8 @@ def _baseline_partition_symbols(names):
             or (report.get("phases", {}).get("link") or {}).get("ok") is not True \
             or (report.get("analysis") or {}).get("passed") is not True:
         return None, None, "baseline report does not prove a successful stock module link"
-    baseline_sha256, error = validate_partition_baseline_evidence(report, elf_path)
+    baseline_sha256, error = validate_partition_baseline_evidence(
+        report, elf_path, config_root=BASELINE_LINK / "config" / "arm9")
     if error:
         return None, None, error
     rows, error = linked_symbol_rows(elf_path, names)
@@ -3614,6 +3673,81 @@ def shared_build_bin_snapshot():
             for path in sorted((REPO / "build").glob("*.bin")) if path.is_file()}
 
 
+def compile_linkcheck_sources(srcs, vers, cache, init_srcs, syms, build_root, jobs,
+                              intact_tus_override=None):
+    """Compile a scratch linkcheck with the normal production object policies.
+
+    A baseline substitutes no candidate TU, but it still compiles production's
+    already-promoted multi-symbol objects. Those objects rely on manifest-backed
+    compiler-only policies for exact duplicate functions and data. Omitting the
+    policies makes the control fail before it reaches the candidate, even though the
+    normal ROM build accepts and verifies the same objects.
+    """
+    compiler_only = RB.compiler_only_policies(srcs)
+    intact_tus = (RB.intact_tu_policies(srcs) if intact_tus_override is None
+                  else intact_tus_override)
+    failures, outcomes = [], collections.Counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as ex:
+        for rel, err, outcome in ex.map(
+                lambda s: RB.compile_one(
+                    s, vers, cache, init_srcs, syms, build_root=build_root,
+                    compiler_only=compiler_only, intact_tus=intact_tus), srcs):
+            outcomes[outcome] += 1
+            if err:
+                failures.append((rel, err))
+    return failures, outcomes
+
+
+def demote_complete_sources(config_root, sources):
+    """Make exact enrolled sources ROM-gap-owned in a disposable config tree.
+
+    The section claims remain unchanged; only the indented ``complete`` marker is
+    removed. dsd then supplies those ranges from the extracted retail binaries.
+    Every requested path must name exactly one complete entry or the control build
+    is refused rather than silently compiling the source it was meant to exclude.
+    """
+    wanted = {str(source).replace("\\", "/") for source in sources}
+    found, demoted = set(), set()
+    for path in sorted(pathlib.Path(config_root).rglob("delinks.txt")):
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        out, current, changed = [], None, False
+        for line in lines:
+            stripped = line.strip()
+            if line and not line[0].isspace() and stripped.endswith(":"):
+                current = stripped[:-1].replace("\\", "/")
+                if current in wanted:
+                    found.add(current)
+            elif line and not line[0].isspace():
+                current = None
+            if current in wanted and stripped == "complete":
+                if current in demoted:
+                    return [], [f"{current}: duplicate complete marker"]
+                demoted.add(current)
+                changed = True
+                continue
+            out.append(line)
+        if changed:
+            path.write_text("\n".join(out) + "\n", encoding="utf-8", newline="\n")
+    errors = [f"{source}: no delinks entry" for source in sorted(wanted - found)]
+    errors.extend(f"{source}: delinks entry is not complete"
+                  for source in sorted(found - demoted))
+    return sorted(demoted), errors
+
+
+def linkcheck_symbol_verdict(baseline, command_ok, new_errors):
+    """Whether the symbol phase is attributable-clean for this linkcheck.
+
+    The stock control's job is to inventory the tree's existing dsd errors. A
+    candidate is clean only when it adds none to that inventory; without a control it
+    must make the command itself pass.
+    """
+    if baseline:
+        return True
+    if new_errors is not None:
+        return not new_errors
+    return command_ok
+
+
 def cmd_linkcheck(args):
     data = load_manifest()
     entry = manifest_entry(data, args.id) if args.id else None
@@ -3669,6 +3803,24 @@ def cmd_linkcheck(args):
           f"({len(profile['modReplacements'])} mod entr(y/ies) redirected to src/, "
           f"{len(profile['modGapFallbacks'])} demoted to ROM gap bytes -- "
           f"rombuild_profile.prepare_profile, the same stock semantics as a real build)")
+
+    if baseline:
+        enrolled_before = RB.enrolled(cfg_root)
+        intact_before = RB.intact_tu_policies(enrolled_before)
+        demoted, reasons = demote_complete_sources(cfg_root, intact_before)
+        if reasons:
+            print("\nREFUSED -- strict control could not exclude every intact TU:")
+            for reason in reasons:
+                print(f"  {reason}")
+            return 1
+        report["intactTusDemoted"] = [
+            {"id": intact_before[source].get("id", source), "source": source}
+            for source in demoted]
+        if demoted:
+            print(f"      strict control demoted {len(demoted)} intact TU source(s) "
+                  "to independently extracted ROM gap bytes:")
+            for source in demoted:
+                print(f"        {source}")
 
     span_start = span_end = None
     claims = []
@@ -3830,14 +3982,9 @@ def cmd_linkcheck(args):
     init_srcs = RB.init_section_sources()
     syms = RB.enrolled_symbols()
     t0 = time.time()
-    failures, outcomes = [], collections.Counter()
-    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
-        for rel, err, outcome in ex.map(
-                lambda s: RB.compile_one(s, vers, cache, init_srcs, syms, build_root=scratch),
-                srcs):
-            outcomes[outcome] += 1
-            if err:
-                failures.append((rel, err))
+    failures, outcomes = compile_linkcheck_sources(
+        srcs, vers, cache, init_srcs, syms, scratch, args.jobs,
+        intact_tus_override={} if baseline else None)
     dt = time.time() - t0
     report["phases"]["compile"] = {"ok": not failures, "seconds": round(dt, 1),
                                    "outcomes": dict(outcomes)}
@@ -4103,7 +4250,49 @@ def cmd_linkcheck(args):
             print(f"      externalized {externalized['externalized']} to their exact "
                   "configured canonical homes in the SCRATCH object only")
 
-        owned = verify_owned_sections(linked_tu, entry, claims)
+        owned_before = verify_owned_sections(linked_tu, entry, claims)
+        report["ownedSectionsBeforeRebias"] = owned_before
+        if not owned_before["ok"]:
+            print("      REFUSED -- licensed non-text contribution is not exact:")
+            for reason in owned_before.get("errors", []):
+                print(f"        {reason}")
+            report["result"] = "data-refused"
+            _write_link_report(scratch, report)
+            _record_linkcheck(data, entry, report, baseline)
+            return 1
+
+        biases, bias_reasons = partition_vtable_rebiases(entry, claims)
+        vtable_policies = biases
+        if bias_reasons:
+            print("      REFUSED -- retained vtable address point is not explicit:")
+            for reason in bias_reasons:
+                print(f"        {reason}")
+            report["result"] = "vtable-rebias-refused"
+            report["vtableRebias"] = {"requested": biases,
+                                       "errors": bias_reasons}
+            _write_link_report(scratch, report)
+            _record_linkcheck(data, entry, report, baseline)
+            return 1
+        rebased_tu, bias_report = OI.rebias_object_symbols(
+            linked_tu, biases, normalize_undefined=True)
+        report["vtableRebias"] = bias_report
+        if rebased_tu is None:
+            print(f"      REFUSED -- vtable symbol rebias: {bias_report.get('error')}")
+            report["result"] = "vtable-rebias-refused"
+            _write_link_report(scratch, report)
+            _record_linkcheck(data, entry, report, baseline)
+            return 1
+        if rebased_tu != linked_tu:
+            linked_tu = rebased_tu
+            scratch_rewrite = True
+            tu_obj.write_bytes(linked_tu)
+            print(f"      rebased {len(bias_report.get('rebased', []))} retained vtable "
+                  f"symbol(s) and compensated "
+                  f"{len(bias_report.get('relocations', []))} live relocation addend(s) "
+                  "in the SCRATCH object only")
+
+        owned = verify_owned_sections(linked_tu, entry, claims,
+                                       public_address_points=True)
         report["ownedSections"] = owned
         for row in owned["rows"]:
             print(f"      {row['section']:8} {row.get('start', '-')}..{row.get('end', '-')} "
@@ -4177,7 +4366,7 @@ def cmd_linkcheck(args):
 
     if baseline:
         report["baselineEvidence"] = partition_baseline_fingerprints(
-            scratch / "final_link.o")
+            scratch / "final_link.o", config_root=cfg_root)
 
     if partitioned:
         linked_aliases = verify_linked_storage_aliases(
@@ -4293,6 +4482,7 @@ def cmd_linkcheck(args):
             for e in symbols_new[:15]:
                 print(f"      NEW | {e}")
     report["symbolsNew"] = symbols_new
+    report["symbolsBaseline"] = base_errors
 
     # ------------------------------------------------------------------- ROM build
     module_ok = bool(analysis["passed"]) and range_ok and not bad_modules
@@ -4346,12 +4536,7 @@ def cmd_linkcheck(args):
             report["strayOutputs"] = changed_shared
 
     # ------------------------------------------------------------------------ verdict
-    if baseline:
-        symbols_verdict = symbols_ok
-    elif symbols_new is not None:
-        symbols_verdict = not symbols_new
-    else:
-        symbols_verdict = symbols_ok
+    symbols_verdict = linkcheck_symbol_verdict(baseline, symbols_ok, symbols_new)
     equivalent = all(v["identical"] for _o, _s, v in partial_rows) if partial_rows else False
     verified = bool(module_ok and symbols_verdict and (rom_ok is not False))
     if partitioned:
@@ -4575,6 +4760,9 @@ def _partition_attempt_record(report):
                    for key, value in report.get("phases", {}).items()},
         "moduleFidelityPassed": bool((report.get("analysis") or {}).get("passed")),
         "symbolCheckNewVsBaseline": report.get("symbolsNew"),
+        "symbolCheckErrors": (((report.get("phases") or {}).get("checkSymbols") or {})
+                              .get("errors")),
+        "symbolCheckBaselineErrors": report.get("symbolsBaseline"),
         "rom": report.get("rom"),
         "strayOutputs": report.get("strayOutputs"),
         "scratch": report.get("scratch", "") + " (gitignored)",
@@ -4621,6 +4809,7 @@ def _record_linkcheck(data, entry, report, baseline):
         "scratch": report["scratch"] + " (gitignored)",
         "phases": {k: v.get("ok") for k, v in report["phases"].items()},
         "tuRange": report.get("tuRange"),
+        "tuRanges": report.get("tuRanges"),
         "objectAudit": {
             "counts": audit.get("counts"),
             "emittedTextOrderIsRomAscending": audit.get("orderOk"),
@@ -4631,6 +4820,12 @@ def _record_linkcheck(data, entry, report, baseline):
             "unlicensedSections": audit.get("unlicensedSections"),
         },
         "symbolCheckNewVsBaseline": report.get("symbolsNew"),
+        "symbolCheckErrors": (((report.get("phases") or {}).get("checkSymbols") or {})
+                              .get("errors")),
+        "symbolCheckBaselineErrors": report.get("symbolsBaseline"),
+        "moduleSetSha256": (((report.get("analysis") or {})
+                              .get("moduleFidelity") or {})
+                             .get("moduleSetSha256")),
         "rom": report.get("rom"),
         "linkerOutput": report["phases"].get("link", {}).get("output"),
     }


### PR DESCRIPTION
Group B of #2001, re-cut onto current `origin/main` (`2c3d31619`), with the two regressions found in review fixed and the CI gap in that PR's test coverage stated rather than papered over.

#2001's branch is 156 commits behind and its generated halves have moved on main, so this is a **fresh re-cut, not a rebase** — the repo's own lesson from #1607 and from the "regenerate, don't resolve" incidents. Group A (per-member CONVERTED scoring in `tiers_ratchet.py`) already landed as **#2052**, hardened by **#2053**; main's copies of those files are strictly newer than #2001's and are **not** touched here.

This is a **draft**. See "What was NOT verified" before treating any number below as a byte claim.

---

## What is in it

| commit | what |
|---|---|
| `d4719927b` | the re-cut itself: `tubuild.py`, `tu_production.py`, `tu_promote.py`, `objisolate.py`, `rombuild.py`, `rombuild_check.py` + their suites |
| `11e5c1e7e` | **rework 1** — baseline evidence binds the tracked config too |
| `e77fbff59` | **rework 2** — a non-`.text` source mismatch gets a diagnostic row |
| `effe47f99` | tool-tests.yml: honest counts, and what still cannot run in CI |
| `b5bdd5847` | wording fix — `src/-owned` reads to `check_dead_references` as a dead path (found by `premerge_check.py`, see below) |

The re-cut was applied with `git apply -3`, so main's independent movement on `rombuild.py`, `test_rombuild.py`, `tubuild.py` and `test_tubuild.py` (+134 lines) survived it. The result was diffed against `ef16a3073` to confirm nothing else came across.

---

## Rework 1 — baseline evidence bound only the scratch config

**The regression.** `partition_baseline_fingerprints` defaults `config_root=CFG_ARM9`, but #2001 recorded with `config_root=cfg_root` (`tubuild.py:4343`) and validated against that same scratch dir (`tu_production.py:241`). `cfg_root` is `build/tu/_baseline/link/config/arm9` — a preserved copy that `demote_complete_sources` rewrote. Main's version detected drift in the **tracked** `config/arm9`; #2001's detected only tampering with the preserved copy. None of the four new fingerprints (`romInputsSha256`, `controlToolsSha256`, `moduleSetSha256`, `intactTusDemoted`) covered it.

**The fix is not a revert.** The scratch binding is real — it is what ties the report to the bytes that link actually consumed. So the report now carries **both** hashes and validation checks **both**:

```
configArm9Sha256          the scratch copy the baseline link consumed
trackedConfigArm9Sha256   config/arm9 as tracked, which the scratch copy was derived from
```

`partition_baseline_fingerprints` and `validate_partition_baseline_evidence` gained `tracked_config_root=CFG_ARM9`; the recording site passes `config_root=cfg_root, tracked_config_root=CFG_ARM9`; `_strict_baseline` validates with both. A missing `trackedConfigArm9Sha256` key is refused, not skipped, so an old report cannot pass by omission.

**Measured, mtimes pinned so nothing turns on a timestamp.** Only the tracked tree is edited; the scratch copy is left byte-identical (asserted).

| | keys recorded | scratch unchanged | tracked config drifts |
|---|---|---|---|
| #2001 as re-cut | `configArm9Sha256`, `controlToolsSha256`, `dsdSha256`, `linkedElfBytes`, `linkedElfSha256`, `mwldarmSha256`, `romInputsSha256` | True | `error=None` — **ACCEPTED, drift invisible** |
| with rework 1 | the same **+ `trackedConfigArm9Sha256`** | True | `error="baseline content fingerprint differs for ['trackedConfigArm9Sha256']"` — **REFUSED** |

The error names only `trackedConfigArm9Sha256` (asserted: `'configArm9Sha256'` is not in the message), so the two signals stay distinguishable in a diagnosis.

**Tests.** `test_partition_baseline_evidence_is_content_bound_not_mtime_bound` was rewritten to use a separate tracked dir; `test_partition_baseline_evidence_binds_the_tracked_config_too` is new and uses deliberately different bytes in scratch vs tracked so the two hashes cannot coincide. `tools/test_tubuild.py`: 44 → 45 cases.

---

## Rework 2 — a non-`.text` source mismatch produced no diagnostic at all

**The regression.** The per-entry `failures` loop in `rombuild_check.analyze` walks `.text`/`.init` only, because every counter in it is a function counter. An intact-object TU claims `.data`/`.rodata`/`.bss` too. A differing byte inside a `src/`-owned `.data` claim therefore produced **no row and no count** — the verdict was still red (the byte is outside every `mods/` range, so `unexpectedDifferingBytes` catches it), but it said "somewhere in arm9" and nothing more, exactly at the moment the feature this PR adds first goes wrong.

**Measured — the three-case fixture, `.text` kept beside `.data` as its control:**

| case | | `passed` | `modulesExact` | `mismatchingFunctions` | `mismatchingDataClaims` | `failures` |
|---|---|---|---|---|---|---|
| A all equal | before | True | 1/1 | 0 | n/a | `[]` |
| | **after** | True | 1/1 | 0 | 0 | `[]` |
| B differing byte in `src/`-owned `.data` | before | False | 0/1 | 0 | n/a | **`[]`** |
| | **after** | False | 0/1 | 0 | **1** | **1 row** |
| C differing byte in `src/`-owned `.text` | before | False | 0/1 | 2 | n/a | 1 row, `differingBytes: 1` |
| | **after** | False | 0/1 | 2 | 0 | 1 row, `differingBytes: 1`, `kind: "code"` |

Case B's new row:

```json
{"module": "arm9", "name": "Pair", "addr": 4104, "size": 4,
 "kind": "data", "section": ".data", "differingBytes": 1}
```

Three deliberate choices:

- **Data claims are counted separately, not folded into `mismatchingFunctions`.** A `.data` claim carries no function; inventing one would report a function count with no function behind it. New `sourceBuild` keys: `sourceDataClaims`, `reproducingDataClaims`, `reproducingDataClaimBytes`, `mismatchingDataClaims`, `mismatchingDataClaimBytes`. Every existing key keeps its meaning.
- **`passed` was strengthened, not loosened**: `and not bad_data_claims` was added. A data-claim mismatch was already red via `unexpectedDifferingBytes`; it is now red on its own terms as well.
- **`--out` still contains code rows only.** That file feeds `rombuild_versions.py`, which sweeps per **function name**; a data claim's path stem names no function. Covered by its own test.

Rows now carry `kind` (`"code"`/`"data"`) and `section`; the `source-owned data claims:` line prints only when there are any, so today's output is byte-identical.

**Tests.** `test_nontext_source_claim_mismatch_produces_a_diagnostic_row` (the A/B/C table above, with the table in its docstring) and `test_data_rows_are_kept_out_of_the_function_name_sweep_file`. `tools/test_rombuild_check.py`: 7 → 9 cases.

---

## The CI item: the new tests do not run in CI, and enumerating them would go red

`.github/workflows/tool-tests.yml` runs one enumerated `unittest` invocation. It includes `tools.test_rombuild_check` but **not** `test_rombuild`, `test_tubuild`, `test_tu_promote`, `test_tu_production`, `test_objisolate` — and those five hold the strong `assertRaises` coverage this PR adds. The preference was to enumerate them. **Measured, they cannot be:** with `elftools` blocked at import (a bare runner has no pyelftools and this repo has no requirements file), each one is a load **error**, not a skip.

| module | on a bare runner |
|---|---|
| `tools.test_rombuild` | **ERROR** (`objisolate` → `rombuild` → `elftools`) |
| `tools.test_tubuild` | **ERROR** |
| `tools.test_tu_promote` | **ERROR** |
| `tools.test_tu_production` | **ERROR** |
| `tools.test_objisolate` | **ERROR** |
| `tools.test_rombuild_check` | 9 tests, 0 errors, 0 failures |

`test_tubuild` is doubly unwirable: it is pytest-style (45 bare `def test_*`, zero `TestCase`), so even with pyelftools present `python -m unittest tools.test_tubuild` prints `Ran 0 tests ... OK` and exits 0 — a hollow green on top of a red one. Enumerating these needs a requirements file, which is a different change from this one; the header already says so and now names `test_tu_promote` and `test_objisolate` in the list.

**So: state it plainly — of the ~870 lines of tests in this PR, only `test_rombuild_check`'s run in CI.** What that one module does cover is the rework-2 case-B regression itself, which is the part with a live failure mode. Its enumerated count moves 6 → 9 and the header total 432 → 435 (measured: 435 across the enumerated list with elftools blocked), so a future drop in `Ran N tests` stays visible.

---

## Verification

| check | result |
|---|---|
| `python tools/rombuild.py -j 16 --no-rom` | **`module fidelity: 106/106 exact, 100.000000%`**, `mismatching: 0`, `ROM-build analysis: PASS` (10,948 enrolled sources; 11,088 source-built functions, 0 mismatching; `0 source-owned data`) |
| `python tools/tiers_ratchet.py --check` | **`CONVERTED ratchet PASS   baseline 2571   current 2571`** |
| `tools/premerge_check.py` (extracted from `origin/main`, merge tree vs main) | **all 8 gates `pass`/`pass`** on the merge tree `1cdfe1c35dc1` vs base `2c3d31619376` — `converted-ratchet`, `dead-references`, `duplicate-sources`, `header-offsets`, `langmode-ratchet`, `layout-check`, `src-tu-refs`, `source-coverage`. `RESULT: nothing goes green -> red.` |
| unit suites | **155 tests, OK** across `test_rombuild` (37), `test_rombuild_check` (9), `test_objisolate` (34, toolchain present so none skipped), `test_tu_production` (17), `test_tu_promote` (9), `test_tiers` (29), `test_tiers_ratchet` (20) — the tiers pair holds at main's **49**. `test_tubuild` is pytest-style, run separately: **45 passed** in 13.4s. |

No gate was weakened to reach green. The one `passed` expression that changed became **stricter**.

### premerge_check earned its keep on this PR

The first run went **red on `dead-references`** — green on `origin/main`, green on this
branch's own tree, red only on the tree the merge would produce. Cause: the prose token
`src/-owned` that I wrote in the two reworks starts with `src/`, so `check_dead_references`
read it as a repo-rooted reference to a file named `src/-owned` in three files
(`.github/workflows/tool-tests.yml`, `tools/rombuild_check.py`,
`tools/test_rombuild_check.py`). Fixed in `b5bdd5847` by using **`source-owned`**, which is
the wording `rombuild_check`'s own output already uses. Comments and one docstring only; no
behaviour change, `tools.test_rombuild_check` still 9/9 and
`python tools/check_dead_references.py` reports `no new dead references`.

### Why rework 2 cannot move today's ROM numbers

Measured across all 106 `config/**/delinks.txt`: **10,948 complete entry sections, of which `src/`-owned non-`.text` = 0 (0 bytes).** The new loop has nothing to iterate over on this tree, which is why `rombuild.py` is unchanged and why the rework-2 fixture is necessarily synthetic.

### What was NOT verified

- **No byte claim for rework 2.** There is no `src/`-owned non-`.text` claim in the tree, so the new code path has never run over real ROM data. The A/B/C evidence is a synthetic fixture.
- **No byte claim for the intact-object path generally.** Every new `rombuild.py` path is gated on `production_mode == "intact-object"`, and there are **zero** `production_mode` keys in `config/tu_manifest.d/**` (`intact_tu_policies(srcs) -> {}` over 90 manifest entries). This lands dormant. That was settled in #2001's review and is not re-argued here.
- **No CI coverage for the five suites above**, as measured. `objisolate.rebias_object_symbols` — converted by this PR from *refuse* to *rewrite bytes* — has tests on its refusal branches, and none of them execute on a runner.
- The external ROM validator has not run on this branch yet; the `rombuild` figure above is a local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
