### PR TITLE
ci: run the three wirable intact-TU test suites, pin their deps

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -84,9 +84,11 @@
 # price of the three intact-TU modules. Measured at 5.3s for the 312 tests that predate
 # tools.test_premerge_check, on a runner-equivalent container (python:3.12, Linux,
 # none of the three inputs present); that module adds 87, timed at 9.7s on Windows.
-# The three modules added below cost no measurable wall time at all: 435 tests in 46.5s
-# and 498 tests in 45.7s on the same `git archive` tree, i.e. inside the noise. They are
-# mock- and tempdir-based and touch neither the network nor the tree.
+# The three modules added below cost no measurable wall time at all: on one Windows tree,
+# 435 tests in 46.5s before and 498 in 45.7s after -- inside the noise. On the runner
+# itself the whole 498 take 11.5s, plus about 1s for the two wheels (both are prebuilt;
+# nothing compiles). They are mock- and tempdir-based and touch neither the network nor
+# the tree.
 # The whole-suite timings are dominated by Windows filesystem overhead and do not
 # apply here -- test_tiers alone takes 71s on a Windows checkout and 1.3s on Linux.
 # test_symrecords needs none of the three inputs either: it reads only tracked text

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -10,30 +10,49 @@
 # gate's FAILURE branch is the one path a green run never exercises: no ROM build can
 # reach it, because these tools are not compiled into the ROM. src-tu-refs.yml exists
 # because #1643 broke 26 translation units while every byte gate stayed green, and the
-# only thing that noticed was a test suite a human had to run. This job runs 435 of
+# only thing that noticed was a test suite a human had to run. This job runs 498 of
 # those assertions on every PR that touches `tools/` or `nearmiss/`, so the next one is
 # noticed by CI.
 #
 # WHAT THIS DOES NOT COVER, and why. Three groups are deliberately absent.
 #
 #   1. NEEDS THE TOOLCHAIN. mwccarm and the extracted ROM are not on a GitHub runner;
-#      they live on the private build box pr-validate.yml relays to. Measured in a
-#      checkout with `extracted/`, `tools/mwccarm/` and `tools/bin/` absent:
-#      test_objisolate skips all 32 of its tests, test_rombuild skips 3 of 32, and
-#      test_check_src_tu_compiles FAILS 8. Wiring those here would buy a green that
+#      they live on the private build box pr-validate.yml relays to. Re-measured against
+#      8f554bce3 in a tree exported with `git archive origin/main` -- no `extracted/`, no
+#      `tools/mwccarm/`, no `tools/bin/`, which is exactly what this job's checkout is:
+#      test_objisolate skips ALL 34 of its tests (the older note here said 32; the suite
+#      grew), and test_check_src_tu_compiles FAILS 8. Wiring those would buy a green that
 #      means nothing. Also absent for the same reason: test_build_pin, test_dtor_members,
 #      test_fdiff_version, test_gen_header, test_opnew_sizes, test_tubuild.
 #
-#   2. NEEDS A PIP DEPENDENCY. A bare runner has no pyelftools, capstone or ndspy, and
-#      this repo has no requirements file to pin them from. That import wall -- not the
-#      compiler -- is what actually stops most of `tools/` on a runner: 24 modules die
-#      on `No module named 'elftools'` alone (test_rombuild, test_romdata_check,
-#      test_check_references, test_tu_config, test_tu_production, test_reloc_audit_*,
-#      test_mangle, test_name_roundtrip, test_pr_linkcheck_*, test_tu_promote,
-#      test_objisolate, and more), test_swarm and
-#      test_worklist on capstone, test_bmg on ndspy. Pinning those is a fair follow-up;
-#      it is a different change from this one, and it should come with a requirements
-#      file rather than a version invented in a `run:` line.
+#      test_tubuild deserves its own sentence, because it is the worst of the shapes and
+#      it is easy to look at its numbers and conclude the opposite. Run under pytest in
+#      that toolchain-free tree it reports "2 failed, 43 passed" -- which reads like a
+#      suite that is 95% wirable. It is not. Fifteen of its tests open with
+#      `if not _toolchain(): return`, and fourteen of those returns are bare, so those
+#      tests report PASS having asserted nothing. The honest split is 28 real passes, 15
+#      vacuous passes, 2 failures (`tubuild list` needs build/tu_map.json, which
+#      regenerates from the ROM and comes back empty without it). A bare `return` guard
+#      is strictly worse than a skip: `pytest -rs` cannot see it and neither can a
+#      reviewer reading a green log.
+#
+#   2. NEEDS A PIP DEPENDENCY -- RESOLVED for the three modules added below, and that is
+#      what tools/requirements.txt now exists for. A bare runner has no pyelftools,
+#      capstone or ndspy. That import wall -- not the compiler -- is what stops most of
+#      `tools/` on a runner: 24 modules die on `No module named 'elftools'` alone
+#      (test_romdata_check, test_check_references, test_tu_config, test_reloc_audit_*,
+#      test_mangle, test_name_roundtrip, test_pr_linkcheck_*, test_objisolate, and more),
+#      test_swarm and test_worklist on capstone, test_bmg on ndspy.
+#
+#      The wall is TWO packages deep, not one, which is the part that had been guessed
+#      rather than measured. test_rombuild, test_tu_promote and test_tu_production reach
+#      elftools through objisolate.py; satisfying that alone only moves the failure to
+#      rombuild -> romdata_check -> linkcheck -> match -> capstone, and all three still
+#      die at collection. They need both, so requirements.txt pins both.
+#
+#      This does NOT generalise. The other 21 elftools modules were not re-measured with
+#      capstone installed and are not known to be wirable; several of them are in group 1
+#      as well. Adding one is a fresh measurement, not a corollary of this one.
 #
 #   3. PYTEST-ONLY, SO UNITTEST CANNOT SEE THEM. test_dead_references (24 tests) and
 #      test_pr_monitor (4) used to fail on a clean origin/main with ImportError -- they
@@ -60,20 +79,27 @@
 # bare-`return` toolchain guard that reports PASS rather than SKIP when the compiler is
 # missing. An explicit list makes adding a module a reviewed decision.
 #
-# Costs nothing: stdlib unittest over the working tree, no compiler, no ROM, no pip step
-# and no network. Measured at 5.3s for the 312 tests that predate
+# Nearly free: unittest over the working tree, no compiler, no ROM. It now costs one pip
+# step (two wheels, no build) and the network access that implies -- that is the whole
+# price of the three intact-TU modules. Measured at 5.3s for the 312 tests that predate
 # tools.test_premerge_check, on a runner-equivalent container (python:3.12, Linux,
 # none of the three inputs present); that module adds 87, timed at 9.7s on Windows.
+# The three modules added below cost no measurable wall time at all: 435 tests in 46.5s
+# and 498 tests in 45.7s on the same `git archive` tree, i.e. inside the noise. They are
+# mock- and tempdir-based and touch neither the network nor the tree.
 # The whole-suite timings are dominated by Windows filesystem overhead and do not
 # apply here -- test_tiers alone takes 71s on a Windows checkout and 1.3s on Linux.
 # test_symrecords needs none of the three inputs either: it reads only tracked text
 # (config/**/symbols.txt, symbols/verified.tsv) and imports nothing outside the stdlib.
 #
-# SIX SKIPS ARE EXPECTED and are honest ones that name their own reason: four in
-# test_stamp_provenance_verify ("needs extracted/ (ROM dump)", a real @skipUnless) and
-# two in test_match_provenance ("no src samples"). test_premerge_check adds none on a
-# runner with git installed, and test_symrecords and test_nearmiss_db add none anywhere.
-# 429 of the 435 assert something.
+# NINE SKIPS ARE EXPECTED and are honest ones that name their own reason: four in
+# test_stamp_provenance_verify ("needs extracted/ (ROM dump)", a real @skipUnless), two
+# in test_match_provenance ("no src samples"), and three in test_rombuild ("mwccarm not
+# present" -- its Retarget class, and only that class, compiles a real object). All nine
+# are @skipUnless with a stated reason, so `-v` shows them; none is a bare `return`.
+# test_premerge_check adds none on a runner with git installed, and test_symrecords,
+# test_nearmiss_db, test_tu_promote and test_tu_production add none anywhere.
+# 489 of the 498 assert something.
 name: tool tests
 
 on:
@@ -116,11 +142,22 @@ jobs:
           # checkout makes those assert against a one-commit repository.
           fetch-depth: 0
       - uses: actions/setup-python@v5
-        # Stdlib only, no pip step. Pinned for the same reason python-names.yml pins
-        # pyflakes: a runner's default python moving under a gate that touched no Python
-        # is indistinguishable from a regression.
+        # Pinned for the same reason python-names.yml pins pyflakes: a runner's default
+        # python moving under a gate that touched no Python is indistinguishable from a
+        # regression.
         with:
           python-version: "3.12"
+
+      - name: Pinned tool dependencies
+        # Every module but the last three in the list below is stdlib-only and would run
+        # without this step. test_rombuild, test_tu_promote and test_tu_production import
+        # rombuild.py, which reaches elftools (via objisolate) and capstone (via
+        # romdata_check -> linkcheck -> match); without both they do not fail a test, they
+        # fail COLLECTION, which under `python -m unittest` is a loud error and not a
+        # silent zero. Versions live in tools/requirements.txt, not in this line, so a
+        # bump is a reviewable diff. `tools/**` already triggers this workflow, so editing
+        # that file re-runs the job that depends on it.
+        run: pip install -r tools/requirements.txt
 
       - name: The tools' own tests
         # ONE unittest invocation, so a single "Ran N tests" line in the log is the
@@ -145,6 +182,7 @@ jobs:
             tools.test_nearmiss_db \
             tools.test_premerge_check \
             tools.test_progress \
+            tools.test_rombuild \
             tools.test_rombuild_cache \
             tools.test_rombuild_check \
             tools.test_rombuild_profile \
@@ -152,6 +190,8 @@ jobs:
             tools.test_srcpath \
             tools.test_stamp_provenance_verify \
             tools.test_symrecords \
+            tools.test_tu_production \
+            tools.test_tu_promote \
             tools.test_validate_merge
 
 # What each module protects, in the order it runs above:
@@ -193,6 +233,14 @@ jobs:
 #                                      skipTests need a git binary.
 #   test_progress                (4)   progress.py -- matched functions/bytes vs the
 #                                      whole game; the number the README reports.
+#   test_rombuild               (37)   rombuild.py -- the source-to-ROM build itself:
+#                                      intact-TU policy resolution, per-file verdicts and
+#                                      the `.init` retargeting that decides which `.text`
+#                                      section dsd's `File.o(.init)` selector lands on.
+#                                      34 of the 37 are mock/tempdir tests that need no
+#                                      compiler; the other 3 are the Retarget class, which
+#                                      compiles a real object and @skipUnless-es itself
+#                                      with "mwccarm not present". CI gets 34. (3 skip)
 #   test_rombuild_cache         (19)   rombuild_cache.py -- the content-addressed object
 #                                      cache. A stale-key bug here silently serves the
 #                                      WRONG object into a byte-gate run.
@@ -200,10 +248,11 @@ jobs:
 #                                      the fidelity metrics every gate quotes, including
 #                                      the diagnostic row a source-owned NON-.text claim
 #                                      gets when it mismatches. That case is why this
-#                                      module gained 3 tests; it is also the only one of
-#                                      the intact-TU suites a bare runner can execute,
+#                                      module gained 3 tests. It used to be the only
+#                                      intact-TU suite a bare runner could execute,
 #                                      because it imports enroll and srcpath and nothing
-#                                      that reaches elftools.
+#                                      that reaches elftools; with tools/requirements.txt
+#                                      installed it is one of four.
 #   test_rombuild_profile        (6)   rombuild_profile.py -- isolated stock and
 #                                      intentional-mod build configs.
 #   test_sinit_owners            (9)   sinit_owners.py -- ranks the likely original TU
@@ -219,5 +268,22 @@ jobs:
 #                                      may be restamped. A verdict wrongly called
 #                                      mechanical would launder a wrong-identity pair
 #                                      straight into the mirror.
+#   test_tu_production          (17)   tu_production.py -- the intact-object production
+#                                      route added by #2054, and the stock/ROM-gap control
+#                                      that decides whether a produced object may stand in
+#                                      for the cartridge's. Pure mock and tempdir; needs no
+#                                      compiler, no ROM and no git. 17 of 17 run in CI.
+#   test_tu_promote              (9)   tu_promote.py -- TU promotion, including the
+#                                      per-member scoring #2052 changed and the baseline
+#                                      self-contradiction check #2053 added. Promotion
+#                                      dilutes the CONVERTED tier, so a scoring bug here
+#                                      moves a published number with nothing else
+#                                      noticing. Pure mock; 9 of 9 run in CI.
 #   test_validate_merge         (35)   validate_merge.py -- builds the machine-readable
 #                                      PR validation report the validator comment renders.
+#
+# The two suites this list still refuses, and the number that says why, measured on a
+# `git archive origin/main` tree with no toolchain: test_objisolate 0 pass / 34 skip
+# (every test in it compiles), test_tubuild 28 real pass / 15 vacuous / 2 fail. Neither
+# is a candidate until objisolate's fixtures stop needing mwcc and tubuild's bare
+# `return` guards become skips. See group 1 in the header.

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,29 @@
+# Python packages the tools/ test suites need on a bare CI runner.
+#
+# Scope: this file pins exactly what .github/workflows/tool-tests.yml installs, and
+# nothing else. It is NOT a general "everything tools/ can import" manifest -- ndspy
+# (tools/bmg.py, tools/test_bmg.py) is deliberately absent because no wired suite
+# reaches it, and adding a dependency here should mean a suite now needs it.
+#
+# WHY BOTH, when the blocker is usually described as "pyelftools". The import wall the
+# intact-TU suites hit is two packages deep, not one, and the second is easy to miss
+# because it only shows up once the first is satisfied:
+#
+#   test_rombuild      -> rombuild -> objisolate      -> elftools.elf.elffile
+#   test_tu_promote    -> tu_promote -> rombuild -> romdata_check -> linkcheck
+#                                                 -> match -> capstone
+#   test_tu_production -> rombuild (both chains above)
+#
+# Installing pyelftools alone moves the failure from objisolate.py to match.py; all
+# three modules still die at collection. Measured, not assumed.
+#
+# Versions are pinned for the reason python-names.yml pins pyflakes: a runner's
+# transitive dependency moving under a gate that touched no Python is
+# indistinguishable from a regression, and these two packages parse the ELF objects
+# and ARM encodings that every byte-fidelity claim in this repo is built on.
+#
+# .github/workflows/update-chaos-data.yml installs the same two packages UNPINNED in a
+# `run:` line. Pointing it here is a fair follow-up; it is a different change from this
+# one, and it touches a workflow that writes commits to main.
+pyelftools==0.33
+capstone==5.0.9


### PR DESCRIPTION
`tool-tests.yml`'s header lists five test suites it leaves out because a bare runner has no `pyelftools`, and calls pinning them "a fair follow-up ... it should come with a requirements file rather than a version invented in a `run:` line." This is that follow-up — but only for the three of the five that survive the measurement.

## The measurement

CI has neither the compiler nor the ROM dump, so a suite that self-skips without them reports success while asserting nothing. To find out which of the five do that, I exported a tree with `git archive origin/main` — no `extracted/`, no `tools/mwccarm/`, no `tools/bin/` — which is exactly what this job's `actions/checkout` produces, and ran each suite there and in a checkout that *does* have the toolchain.

That tree reproduces this job's documented baseline exactly (`Ran 435 tests ... OK`), so it is a faithful stand-in.

| suite | blocker | toolchain PRESENT | toolchain ABSENT (= CI) | verdict |
|---|---|---|---|---|
| `test_rombuild` | pyelftools + capstone | 37 pass | **34 pass / 3 skip** | **WIRE** |
| `test_tu_production` | pyelftools + capstone | 17 pass | **17 pass / 0 skip** | **WIRE** |
| `test_tu_promote` | pyelftools + capstone | 9 pass | **9 pass / 0 skip** | **WIRE** |
| `test_objisolate` | pyelftools + capstone | 34 pass | **0 pass / 34 skip** | DO NOT WIRE — hollow |
| `test_tubuild` | pyelftools + capstone | 45 pass | **28 real pass / 15 vacuous / 2 fail** | DO NOT WIRE — red *and* hollow |

### Two corrections to the premise

**The blocker is two packages, not one.** All five reach `elftools` through `objisolate.py`. Installing `pyelftools` alone does not unblock any of them — it moves the failure one hop, to `rombuild.py` → `romdata_check` → `linkcheck` → `match` → `capstone`, and all three wirable suites still die at *collection*. `tools/requirements.txt` pins both. `ndspy` is deliberately not in it: no wired suite reaches it.

**`test_tubuild` looks far more wirable than it is.** Under pytest on the toolchain-free tree it reports `2 failed, 43 passed`, which reads like a suite that is 95% there. It is not. Fifteen of its tests open with `if not _toolchain(): return`, and **fourteen of those returns are bare** — those tests report PASS having asserted nothing. A bare `return` guard is strictly worse than a skip, because `pytest -rs` cannot see it and neither can a reviewer reading a green log. It is also pytest-style, so `python -m unittest tools.test_tubuild` prints `Ran 0 tests ... OK` and exits 0. Its 2 real failures are `tubuild list` needing `build/tu_map.json`, which regenerates from the ROM and comes back empty without it.

`test_objisolate` is the simpler rejection: its single `TestCase` class is `@skipUnless(_compiler())`, so on a runner it is `Ran 34 tests ... OK (skipped=34)`. Wiring it would add 34 to this job's headline count and zero assertions.

## What this changes

- **`tools/requirements.txt`** (new) — pins `pyelftools==0.33`, `capstone==5.0.9`, with the import chains written down so the next person does not have to rediscover that it takes both.
- **`.github/workflows/tool-tests.yml`** — one `pip install -r tools/requirements.txt` step; three modules added to the enumerated list; header corrected.

Nothing else. No tool changes, no config, no ledger files.

**The list is still enumerated, not a glob.** That constraint is what makes this PR safe: a glob would have absorbed `test_objisolate` and scored its 34 skips as a pass.

### Numbers, stated plainly

Job total **435 → 498** tests. Expected skips **6 → 9**.

The three new skips are all in `test_rombuild`: its `Retarget` class compiles a real object and `@skipUnless`-es itself with `"mwccarm not present"`. **So of the 63 tests this PR adds, 60 assert something in CI and 3 do not.** All nine expected skips are `@skipUnless` with a stated reason and are visible under `-v`; none is a bare `return`.

Wall time is unchanged — 46.5s for 435, 45.7s for 498 on the same tree, i.e. inside the noise. The three added suites are mock- and tempdir-based and touch neither the network nor the tree (verified: the worktree was clean after running all five, and the suites create nothing outside `tempfile`).

The cost is that this job is no longer stdlib-only; it now needs one `pip` step and the network access that implies. The header says so.

### What this does *not* prove

The header notes 24 modules blocked on `elftools`. **The other 21 were not re-measured with `capstone` installed and are not known to be wirable** — several are also toolchain-bound. Adding one of them is a fresh measurement, not a corollary of this one. The header says that too.

`.github/workflows/update-chaos-data.yml` installs the same two packages **unpinned** in a `run:` line. Pointing it at this file is a fair follow-up, but it is a different change and it touches a workflow that writes commits to `main`, so it is not in here.

## Verification

- Ran the workflow's `run:` block **verbatim** against the toolchain-free tree: `Ran 498 tests ... OK`.
- Baseline on the same tree before the change: `Ran 435 tests ... OK`.
- Every skip audited by reason, not just counted.
- `pyelftools`-absent and `capstone`-absent runs done with a `sys.meta_path` blocker, so the import wall was measured rather than assumed.
- Merge-tree gates via `tools/premerge_check.py --fetch` — results in a follow-up comment.

Measured on `8f554bce3`.
