### PR TITLE
Cover tubuild's fail-closed vtable-addend arm in a place CI actually runs

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -194,6 +194,7 @@ jobs:
             tools.test_symrecords \
             tools.test_tu_production \
             tools.test_tu_promote \
+            tools.test_tubuild_owned_relocs \
             tools.test_validate_merge
 
 # What each module protects, in the order it runs above:
@@ -281,6 +282,31 @@ jobs:
 #                                      dilutes the CONVERTED tier, so a scoring bug here
 #                                      moves a published number with nothing else
 #                                      noticing. Pure mock; 9 of 9 run in CI.
+#   test_tubuild_owned_relocs    (6)   tubuild.verify_owned_sections' non-text
+#                                      relocation verdict ladder -- specifically the
+#                                      fail-closed `else None` #2059 added for a
+#                                      normalized undefined `_ZTV` import whose manifest
+#                                      addend is BELOW the two-word ABI preamble, and
+#                                      both clauses of the WRONG-DEST conjunction. It
+#                                      stubs `section_contribution` (the only part of
+#                                      that function that parses ELF) and drives the
+#                                      real verifier over a hand-written layout of the
+#                                      documented shape, so it needs no compiler, no
+#                                      ROM, no config/ and no build/. 6 of 6 run in CI,
+#                                      none skips. It exists as its own module rather
+#                                      than as more of test_tubuild.py for the reason
+#                                      spelled out in group 3 of the header: that file
+#                                      contributes zero tests to `python -m unittest`,
+#                                      and the assertions it already has for this code
+#                                      sit behind `if not _toolchain(): return`.
+#                                      Mutation-checked, all five against the whole of
+#                                      test_tubuild.py running WITH the pinned compiler
+#                                      present: `else None` -> `else 0` and
+#                                      -> `else expected_addend` and dropping
+#                                      `expected["target_address"] != cfg[1]` each leave
+#                                      46/46 of that suite green and are each caught
+#                                      here; `>=` -> `>` and disabling the normalized
+#                                      bias are caught by both.
 #   test_validate_merge         (35)   validate_merge.py -- builds the machine-readable
 #                                      PR validation report the validator comment renders.
 #
@@ -288,4 +314,6 @@ jobs:
 # `git archive origin/main` tree with no toolchain: test_objisolate 0 pass / 34 skip
 # (every test in it compiles), test_tubuild 28 real pass / 15 vacuous / 2 fail. Neither
 # is a candidate until objisolate's fixtures stop needing mwcc and tubuild's bare
-# `return` guards become skips. See group 1 in the header.
+# `return` guards become skips. See group 1 in the header. test_tubuild_owned_relocs
+# above is NOT a step toward wiring test_tubuild: it is a separate module precisely so
+# that adding it did not require relaxing that refusal.

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -10,7 +10,7 @@
 # gate's FAILURE branch is the one path a green run never exercises: no ROM build can
 # reach it, because these tools are not compiled into the ROM. src-tu-refs.yml exists
 # because #1643 broke 26 translation units while every byte gate stayed green, and the
-# only thing that noticed was a test suite a human had to run. This job runs 498 of
+# only thing that noticed was a test suite a human had to run. This job runs 504 of
 # those assertions on every PR that touches `tools/` or `nearmiss/`, so the next one is
 # noticed by CI.
 #
@@ -86,7 +86,7 @@
 # none of the three inputs present); that module adds 87, timed at 9.7s on Windows.
 # The three modules added below cost no measurable wall time at all: on one Windows tree,
 # 435 tests in 46.5s before and 498 in 45.7s after -- inside the noise. On the runner
-# itself the whole 498 take 11.5s, plus about 1s for the two wheels (both are prebuilt;
+# itself those 498 took 11.5s, plus about 1s for the two wheels (both are prebuilt;
 # nothing compiles). They are mock- and tempdir-based and touch neither the network nor
 # the tree.
 # The whole-suite timings are dominated by Windows filesystem overhead and do not
@@ -100,8 +100,9 @@
 # present" -- its Retarget class, and only that class, compiles a real object). All nine
 # are @skipUnless with a stated reason, so `-v` shows them; none is a bare `return`.
 # test_premerge_check adds none on a runner with git installed, and test_symrecords,
-# test_nearmiss_db, test_tu_promote and test_tu_production add none anywhere.
-# 489 of the 498 assert something.
+# test_nearmiss_db, test_tu_promote, test_tu_production and
+# test_tubuild_owned_relocs add none anywhere.
+# 495 of the 504 assert something.
 name: tool tests
 
 on:
@@ -151,12 +152,13 @@ jobs:
           python-version: "3.12"
 
       - name: Pinned tool dependencies
-        # Every module but the last three in the list below is stdlib-only and would run
-        # without this step. test_rombuild, test_tu_promote and test_tu_production import
+        # Every module in the list below except four is stdlib-only and would run without
+        # this step. test_rombuild, test_tu_promote and test_tu_production import
         # rombuild.py, which reaches elftools (via objisolate) and capstone (via
-        # romdata_check -> linkcheck -> match); without both they do not fail a test, they
-        # fail COLLECTION, which under `python -m unittest` is a loud error and not a
-        # silent zero. Versions live in tools/requirements.txt, not in this line, so a
+        # romdata_check -> linkcheck -> match); test_tubuild_owned_relocs imports
+        # tubuild.py, which reaches the same two by its own path. Without both wheels
+        # none of the four fails a test, they fail COLLECTION, which under
+        # `python -m unittest` is a loud error and not a silent zero. Versions live in tools/requirements.txt, not in this line, so a
         # bump is a reviewable diff. `tools/**` already triggers this workflow, so editing
         # that file re-runs the job that depends on it.
         run: pip install -r tools/requirements.txt
@@ -299,14 +301,16 @@ jobs:
 #                                      contributes zero tests to `python -m unittest`,
 #                                      and the assertions it already has for this code
 #                                      sit behind `if not _toolchain(): return`.
-#                                      Mutation-checked, all five against the whole of
+#                                      Mutation-checked, all six against the whole of
 #                                      test_tubuild.py running WITH the pinned compiler
 #                                      present: `else None` -> `else 0` and
 #                                      -> `else expected_addend` and dropping
 #                                      `expected["target_address"] != cfg[1]` each leave
 #                                      46/46 of that suite green and are each caught
-#                                      here; `>=` -> `>` and disabling the normalized
-#                                      bias are caught by both.
+#                                      here; dropping the candidate-side
+#                                      `cand_addr != expected["target_address"]` is
+#                                      likewise caught here alone; `>=` -> `>` and
+#                                      disabling the normalized bias are caught by both.
 #   test_validate_merge         (35)   validate_merge.py -- builds the machine-readable
 #                                      PR validation report the validator comment renders.
 #

--- a/tools/test_tubuild_owned_relocs.py
+++ b/tools/test_tubuild_owned_relocs.py
@@ -1,0 +1,234 @@
+"""Fail-closed coverage for ``tubuild.verify_owned_sections``' relocation verdicts.
+
+WHY THIS MODULE EXISTS AND IS NOT PART OF ``tools/test_tubuild.py``.
+
+``test_tubuild.py`` is pytest-style: 46 bare ``def test_*`` functions and zero
+``unittest.TestCase`` classes, so ``python -m unittest tools.test_tubuild`` prints
+"Ran 0 tests ... OK" and exits 0.  CI (``.github/workflows/tool-tests.yml``) runs
+``python -m unittest``, so nothing in that file has ever executed on a runner.
+Worse, fifteen of its tests open with ``if not _toolchain(): return`` -- a bare
+return, not a skip -- and every one of the existing owned-relocation assertions
+sits behind one of those guards, because its fixtures compile a real object with
+mwccarm.  Those tests are real, but they only run on a box that has the pinned
+compiler, and a reviewer reading a green log cannot tell the difference between
+"asserted" and "returned early".
+
+The one seam that needs the compiler is ``section_contribution``, which is pure
+ELF parsing: it turns an object's repeated input sections into
+``{"bytes", "relocs", "symbols", "inputSections"}``.  Everything the verdict
+ladder below decides is computed from that dict plus the manifest, the config
+relocation map and the symbol name index -- all of which the caller injects.  So
+these tests stub ``section_contribution`` with a layout of exactly the documented
+shape and drive the real ``verify_owned_sections`` over it.  No mwccarm, no
+``extracted/``, no ``config/``, no ``build/``: they assert on a bare runner.
+
+WHAT THEY PIN.  PR #2059 added the ``normalized_undefined_vtables`` arm::
+
+    bias = retained_vtable_biases.get(expected["symbol"])
+    if bias is None and normalized_undefined_vtables \\
+            and expected["symbol"].startswith("_ZTV") \\
+            and expected_addend:
+        bias = OI.VTABLE_PREAMBLE
+    if bias is not None:
+        expected_addend = (expected_addend - bias
+                           if expected_addend >= bias else None)
+
+``objisolate.rebias_object_symbols(..., normalize_undefined=True)`` rewrites an
+undefined ``_ZTV`` import's addend from ``public + N`` to ``public + N - 8``,
+because ``symbols.txt`` already names the slot array past the two-word ABI
+preamble.  This code undoes that on the manifest side so the two are comparable.
+
+The ``else None`` is the fail-closed half: a manifest addend BELOW the preamble
+cannot have come from that rewrite, so there is no honest emitted addend to
+compare against and the relocation must be rejected.  Nothing downstream re-checks
+it -- ``None`` reaches ``rel["addend"] != expected_addend`` and must land on
+``WRONG-ADDEND``.  A permissive value there (``0``, or the unbiased addend) would
+let an object whose emitted addend disagrees with the cartridge verify clean, and
+the existing suite does not notice: its wrong-addend case uses ``8 + 4 = 12``,
+which is above the preamble and takes the arithmetic arm, never the ``else``.
+
+The two ``WRONG-DEST`` clauses are pinned for the same reason: the candidate must
+agree with the manifest AND the manifest must agree with ``config/**/relocs.txt``.
+Each clause is asserted separately, because dropping either one alone still leaves
+a check that looks present.
+"""
+
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import tubuild as TB  # noqa: E402
+
+MODULE = "ov999"
+DATA_START = 0x02000000
+DATA_END = 0x02000010
+RELOC_SOURCE = DATA_START
+OWNED_SYMBOL = "_ZTI5Thing"
+IMPORTED_VTABLE = "_ZTVN10__cxxabiv117__class_type_infoE"
+IMPORT_PUBLIC = 0x00006100
+R_ARM_ABS32 = 2
+CLAIMS = [{"name": ".data", "start": DATA_START, "end": DATA_END}]
+
+
+def _layout(emitted_addend):
+    """One ``.data`` contribution in the exact shape ``section_contribution`` returns.
+
+    Sixteen bytes, one owned STT_OBJECT covering all of them, and one R_ARM_ABS32
+    relocation at offset 0 against an UNDEFINED ``_ZTV`` import -- the shape
+    ``rebias_object_symbols(normalize_undefined=True)`` produces.
+    """
+    return {
+        "bytes": bytes(range(16)),
+        "relocs": [{"offset": 0, "type": R_ARM_ABS32, "symbol": IMPORTED_VTABLE,
+                    "addend": emitted_addend, "targetSection": "SHN_UNDEF"}],
+        "symbols": {OWNED_SYMBOL: {"address": DATA_START, "size": 0x10,
+                                   "bind": "STB_GLOBAL", "type": "STT_OBJECT",
+                                   "sectionIndex": 1}},
+        "inputSections": [1],
+    }
+
+
+def _entry(manifest_addend, target_address):
+    return {
+        "module": MODULE,
+        "functions": [],
+        "data": [{"symbol": OWNED_SYMBOL, "address": f"0x{DATA_START:08x}",
+                  "size": "0x10"}],
+        "relocations": [{"section": ".data", "source": f"0x{RELOC_SOURCE:08x}",
+                         "type": "R_ARM_ABS32", "kind": "load",
+                         "symbol": IMPORTED_VTABLE, "addend": manifest_addend,
+                         "target_module": "arm9",
+                         "target_address": f"0x{target_address:08x}"}],
+    }
+
+
+class NormalizedUndefinedVtableAddend(unittest.TestCase):
+    """The ``normalized_undefined_vtables`` addend arm, both halves."""
+
+    def verify(self, emitted_addend, manifest_addend, manifest_target,
+               configured_target=None, import_address=IMPORT_PUBLIC):
+        entry = _entry(manifest_addend, manifest_target)
+        cfg = {MODULE: {RELOC_SOURCE: (
+            "load",
+            manifest_target if configured_target is None else configured_target,
+            "arm9")}}
+        layout = _layout(emitted_addend)
+        with mock.patch.object(TB, "section_contribution",
+                               lambda obj, name, start: (layout, None)):
+            return TB.verify_owned_sections(
+                b"", entry, CLAIMS,
+                name_index={IMPORTED_VTABLE: ("arm9", import_address)},
+                config_relocs=cfg, sym_index={},
+                target_reader=lambda mod, start, size: layout["bytes"][:size],
+                symbol_homes={}, bss_boundaries=set(),
+                public_address_points=True, normalized_undefined_vtables=True)
+
+    def row(self, result):
+        return next(r for r in result["relocations"]
+                    if int(r["source"], 0) == RELOC_SOURCE)
+
+    def test_normalized_import_above_the_preamble_verifies(self):
+        """Control: manifest 16 against emitted 8 is the arithmetic arm, and passes.
+
+        Without this the fail-closed tests below could be passing for any reason
+        at all -- a fixture that can never verify proves nothing about the branch.
+        """
+        result = self.verify(emitted_addend=8, manifest_addend=16,
+                             manifest_target=IMPORT_PUBLIC + 8)
+        self.assertTrue(result["ok"], result["errors"])
+        row = self.row(result)
+        self.assertEqual(row["verdict"], "OK")
+        self.assertEqual(row["expectedAddend"], 16)
+        self.assertEqual(row["expectedEmittedAddend"], 8)
+        self.assertEqual(row["candidate"], f"0x{IMPORT_PUBLIC + 8:08x}")
+
+    def test_manifest_addend_below_the_preamble_is_refused(self):
+        """A manifest addend under 8 has no honest normalized form: reject it.
+
+        The emitted addend here is 0 and every other fact -- destination, module,
+        kind, type, symbol -- agrees, so ``else 0`` in place of ``else None``
+        would call this relocation OK.  It must be WRONG-ADDEND.
+        """
+        result = self.verify(emitted_addend=0, manifest_addend=4,
+                             manifest_target=IMPORT_PUBLIC)
+        row = self.row(result)
+        self.assertEqual(row["verdict"], "WRONG-ADDEND")
+        self.assertIsNone(row["expectedEmittedAddend"])
+        self.assertEqual(row["expectedAddend"], 4)
+        self.assertFalse(result["ok"])
+        self.assertTrue(any("WRONG-ADDEND" in reason for reason in result["errors"]),
+                        result["errors"])
+
+    def test_sub_preamble_addend_is_not_silently_left_unbiased(self):
+        """The other permissive rewrite: passing the raw addend through.
+
+        Emitted addend 4 matches the manifest's 4 exactly, and the destination is
+        set so that everything downstream lines up.  ``else expected_addend``
+        would make this OK; the fail-closed arm must still refuse it.
+        """
+        result = self.verify(emitted_addend=4, manifest_addend=4,
+                             manifest_target=IMPORT_PUBLIC + 4)
+        row = self.row(result)
+        self.assertEqual(row["verdict"], "WRONG-ADDEND")
+        self.assertIsNone(row["expectedEmittedAddend"])
+        self.assertFalse(result["ok"])
+
+    def test_addend_exactly_at_the_preamble_normalizes_to_zero(self):
+        """The boundary itself takes the arithmetic arm, not the ``else``.
+
+        ``expected_addend >= bias`` is inclusive: manifest 8 is the ordinary
+        address-point reference and normalizes to 0.  A ``>`` there would push
+        the single most common case into the refusal arm.
+        """
+        result = self.verify(emitted_addend=0, manifest_addend=8,
+                             manifest_target=IMPORT_PUBLIC)
+        self.assertTrue(result["ok"], result["errors"])
+        row = self.row(result)
+        self.assertEqual(row["verdict"], "OK")
+        self.assertEqual(row["expectedEmittedAddend"], 0)
+
+
+class OwnedRelocationDestination(unittest.TestCase):
+    """Both halves of the ``WRONG-DEST`` conjunction, asserted separately."""
+
+    verify = NormalizedUndefinedVtableAddend.verify
+    row = NormalizedUndefinedVtableAddend.row
+
+    def test_candidate_destination_must_match_the_manifest(self):
+        """Clause one: where the relocation actually lands.
+
+        The import resolves four bytes off, so the candidate is public+0xc while
+        the manifest and config both say public+8.  Dropping
+        ``cand_addr != expected["target_address"]`` makes this OK.
+        """
+        result = self.verify(emitted_addend=8, manifest_addend=16,
+                             manifest_target=IMPORT_PUBLIC + 8,
+                             import_address=IMPORT_PUBLIC + 4)
+        row = self.row(result)
+        self.assertEqual(row["verdict"], "WRONG-DEST")
+        self.assertEqual(row["candidate"], f"0x{IMPORT_PUBLIC + 0xc:08x}")
+        self.assertEqual(row["configured"], f"0x{IMPORT_PUBLIC + 8:08x}")
+        self.assertFalse(result["ok"])
+
+    def test_manifest_destination_must_match_the_configured_relocation(self):
+        """Clause two: the manifest may not disagree with config/**/relocs.txt.
+
+        Candidate and manifest agree at public+8; the configured destination is
+        elsewhere.  Dropping ``expected["target_address"] != cfg[1]`` makes this
+        OK -- and a manifest that can name its own destination is not a check.
+        """
+        result = self.verify(emitted_addend=8, manifest_addend=16,
+                             manifest_target=IMPORT_PUBLIC + 8,
+                             configured_target=IMPORT_PUBLIC + 0x100)
+        row = self.row(result)
+        self.assertEqual(row["verdict"], "WRONG-DEST")
+        self.assertEqual(row["candidate"], f"0x{IMPORT_PUBLIC + 8:08x}")
+        self.assertEqual(row["configured"], f"0x{IMPORT_PUBLIC + 0x100:08x}")
+        self.assertFalse(result["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tests only. **`tools/tubuild.py` is not modified** — it is byte-identical to `origin/main` (verified after every mutation run below). The diff is one new test module and one enumeration line plus its comment block in `tool-tests.yml`. It touches only `tools/` and `.github/workflows/`, so it cannot move a ROM byte and does not interact with the TU promotion queue.

## The hole

PR #2059 added a normalized-undefined-vtable arm to `verify_owned_sections`:

```python
if public_address_points and expected is not None:
    bias = retained_vtable_biases.get(expected["symbol"])
    if bias is None and normalized_undefined_vtables \
            and expected["symbol"].startswith("_ZTV") \
            and expected_addend:
        bias = OI.VTABLE_PREAMBLE
    if bias is not None:
        expected_addend = (expected_addend - bias
                           if expected_addend >= bias else None)
```

`objisolate.rebias_object_symbols(..., normalize_undefined=True)` rewrites an undefined `_ZTV` import's addend from `public + N` to `public + N - 8`, because `symbols.txt` already names the slot array past the two-word ABI preamble. This undoes that on the manifest side so the two are comparable.

The `else None` is the **fail-closed** half. A manifest addend *below* the preamble cannot have come from that rewrite, so there is no honest emitted addend to compare against and the relocation must be rejected — `None` reaches `rel["addend"] != expected_addend` and lands on `WRONG-ADDEND`. Nothing downstream re-checks it.

**Nothing tested it.** The nearest existing assertion uses `8 + 4 = 12`, which is *above* the preamble and takes the arithmetic arm, never the `else`.

## Measured, not assumed

Mutation testing against the **whole** of `tools/test_tubuild.py` (46 tests) run **with the pinned compiler and `extracted/` present**, so every `if not _toolchain(): return` guard in that file is live — the most generous conditions the existing suite can be given:

| mutation of `tools/tubuild.py` | `test_tubuild.py` | this PR's module |
|---|---|---|
| `else None` → `else 0` | 46/46 pass — **uncaught** | 2 fail — caught |
| `else None` → `else expected_addend` | 46/46 pass — **uncaught** | 2 fail — caught |
| drop `expected["target_address"] != cfg[1]` | 46/46 pass — **uncaught** | 1 fail — caught |
| `>=` → `>` (preamble boundary) | 44/46 — caught | 1 fail — caught |
| `bias = OI.VTABLE_PREAMBLE` → `None` | 45/46 — caught | 6 fail — caught |
| drop `cand_addr != expected["target_address"]` | 45/46 — caught | 1 fail — caught |

Three mutations that make the verifier fail **open** leave the existing suite entirely green. All six are caught here.

`tools/tubuild.py` was restored from a pristine copy after each run; `git status --porcelain -- tools/tubuild.py` is empty and the file's SHA-256 matches `origin/main`.

## …and none of that ran in CI anyway

`tools/test_tubuild.py` is pytest-style: 46 bare `def test_*` functions, zero `unittest.TestCase` classes. `tool-tests.yml` runs `python -m unittest`, so:

```
$ python -m unittest tools.test_tubuild
----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
$ echo $?
0
```

A green that asserts nothing. Fifteen of its tests additionally open with `if not _toolchain(): return` — a bare return, not a skip, so on a compiler-less runner they would report PASS having asserted nothing. Every existing owned-relocation assertion sits behind one of those guards. Both facts are already documented in `tool-tests.yml`'s header; this PR does not change either, and does **not** convert `test_tubuild.py` (a much larger change — see "Not done here").

## What this adds

`tools/test_tubuild_owned_relocs.py` — `unittest.TestCase`, six tests, enumerated **explicitly** in `tool-tests.yml`. No glob: a glob would silently absorb future toolchain-dependent modules and convert self-skips into a hollow green, which is exactly what that file's header refuses.

The only part of `verify_owned_sections` that needs a compiled object is `section_contribution`, which is pure ELF parsing returning `{"bytes", "relocs", "symbols", "inputSections"}`. Everything the verdict ladder decides comes from that dict plus the manifest, the config relocation map and the symbol name index — all caller-injected. So the tests stub `section_contribution` with a layout of exactly that documented shape and drive the **real** `verify_owned_sections` over it.

Verified on a toolchain-free tree (`git archive origin/main` into a directory with no `extracted/`, no `tools/mwccarm/`, no `tools/bin/`, no `build/`): **6 run, 6 assert, 0 skip**, and the `else 0` mutation applied *in that tree* fails 2 of them. No test here self-skips; if this module ever contributes fewer than 6 tests to the job's `Ran N` line, something is wrong.

Tests:

- `test_normalized_import_above_the_preamble_verifies` — positive control (manifest 16 vs emitted 8 → OK). Without it the refusal tests could be passing for any reason at all.
- `test_manifest_addend_below_the_preamble_is_refused` — the `else None` arm. Every other fact agrees, so `else 0` would call it OK.
- `test_sub_preamble_addend_is_not_silently_left_unbiased` — the other permissive rewrite, `else expected_addend`.
- `test_addend_exactly_at_the_preamble_normalizes_to_zero` — `>=` is inclusive; a `>` would push the most common case into the refusal arm.
- `test_candidate_destination_must_match_the_manifest` — `WRONG-DEST` clause one.
- `test_manifest_destination_must_match_the_configured_relocation` — `WRONG-DEST` clause two. Asserted separately from clause one, because dropping either alone leaves a check that still *looks* present — and clause two was uncaught by the existing suite.

## Suite totals

Enumerated `tool-tests.yml` list, one `python -m unittest -v` invocation, same tree:

- before (26 modules): `Ran 498 tests ... OK (skipped=3)`
- after (27 modules): `Ran 504 tests ... OK (skipped=3)`

`+6`, `+0` skips. 498 matches the figure `tool-tests.yml` already documents.

## Not done here (findings, deliberately out of scope)

1. **The 15 vacuous `if not _toolchain(): return` guards in `test_tubuild.py`.** A bare return is not a skip: `pytest -rs` cannot see it and neither can a reviewer. Turning them into `@unittest.skipUnless` is the right fix and is a real change to those tests.
2. **Converting `test_tubuild.py` to `unittest.TestCase`** so its 46 tests become visible to CI. Twelve other `tools/` modules are in the same shape (`tool-tests.yml` header, group 3: 186 test functions a glob would silently count as passing).

Both are larger changes and neither belongs in a PR whose point is to make one specific fail-closed branch observable.

## Gates run locally

- `python -m unittest -v <the 27 enumerated modules>` → `Ran 504 tests ... OK (skipped=3)`
- `python -m pyflakes tools/test_tubuild_owned_relocs.py` → clean
- `python tools/check_python_names.py` → PASS (261 files, 0 unresolvable)
- workflow YAML parses; no `src/` or `src_tu/` token anywhere in the diff
- pre-push: `port-refcheck 405 checked - all references resolve`, `duplicate-sources: 11158 stems, none doubled`, `check_src_tu_compiles: 92/92`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
