### PR TITLE
PoleLift: define the destructor in the class body (and why promotion stops at the coined name)

### DIFF
--- a/config/tu_manifest.d/ov045/PoleLift.json
+++ b/config/tu_manifest.d/ov045/PoleLift.json
@@ -85,10 +85,10 @@
       "every_declared_function_correct_size": "PASS",
       "every_declared_function_bytes_match": "PASS",
       "no_pragma_opt_workarounds": "PASS -- no #pragma of any kind in the seven legacy sources or in the consolidated file",
-      "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 15 unlicensed section/symbol(s); see unlicensed_output_observed",
-      "functions_occur_in_expected_order": "PARTIAL -- ordinal pair(s) not in ROM order: [(0, 1)]",
-      "no_constructor_or_destructor_variants": "WAIVED -- not tested. This TU is the key-function TU of a class with a virtual destructor and does emit D0/D1/D2.",
-      "no_unexpected_vtable_rtti_or_data_emission": "WAIVED -- not tested. Vtable, RTTI and Platform's out-of-line destructors are emitted and inventoried below; their correctness is explicitly NOT verified this round.",
+      "declared_function_set_equals_defined_function_set": "FAIL-BY-DESIGN -- 11 unlicensed data section/symbol(s) and ZERO unlicensed text; see unlicensed_output_observed",
+      "functions_occur_in_expected_order": "PASS -- tools/tu_order_check.py ov045/PoleLift reports ALL MATCH, ROM order, nothing unlicensed in .text",
+      "no_constructor_or_destructor_variants": "PASS -- the destructor is defined in include/PoleLift.h's class body, so mwccarm emits D1 and D0 only. No D2 is produced, which is what the cartridge shows.",
+      "no_unexpected_vtable_rtti_or_data_emission": "WAIVED -- not tested. The vtable and RTTI chain are emitted and inventoried below; nine of the eleven resolve to a configured ROM home, two do not.",
       "all_content_sections_licensed": "WAIVED -- deferred to the data phase (plan section 11 difficulty 6 of 7)",
       "relocation_destinations_verified": "PASS",
       "symbol_addresses_match": "NOT RUN",
@@ -183,99 +183,82 @@
         ]
       },
       "symbolCheckNewVsBaseline": null,
-      "linkerOutput": "mwldarm.exe: Multiply-defined: \"virtual table for PoleLift\" in PoleLift.o\nmwldarm.exe: Previously defined in _dsd_gap@ov045_3.o\nmwldarm.exe: Multiply-defined: \"virtual table for Platform\" in PoleLift.o\nmwldarm.exe: Previously defined in _dsd_gap@ov002_13.o\n\nErrors caused tool to abort."
+      "linkerOutput": "mwldarm.exe: Multiply-defined: \"virtual table for PoleLift\" in PoleLift.o\nmwldarm.exe: Previously defined in _dsd_gap@ov045_3.o\nmwldarm.exe: Multiply-defined: \"virtual table for Platform\" in PoleLift.o\nmwldarm.exe: Previously defined in _dsd_gap@ov002_13.o\n\nErrors caused tool to abort.",
+      "supersededBy": "This round predates the in-class destructor. Its 'Multiply-defined: virtual table for Platform' half came from dBgActor_c's vague-linkage copy, which is no longer emitted. Not re-run; promotion is blocked earlier, at the isolator."
     }
   },
   "unlicensed_output_observed": {
-    "note": "Present in the compiled object as a side effect of compiling the class's key function in one TU. Inventoried, not licensed, not verified. Promotion is refused on this alone.",
-    "text": [
-      {
-        "symbol": "_ZN8PoleLiftD2Ev",
-        "size": "0x4c",
-        "binding": "STB_GLOBAL",
-        "in_rom": false,
-        "note": "byte-identical to _ZN8PoleLiftD1Ev; no ROM symbol and no caller"
-      },
-      {
-        "symbol": "_ZN10dBgActor_cD1Ev",
-        "size": "0x38",
-        "binding": "STB_LOPROC",
-        "in_rom": true,
-        "rom_address": "0x020ee42c",
-        "note": "lives in ov002, not in this range; vague-linkage copy"
-      },
-      {
-        "symbol": "_ZN10dBgActor_cD0Ev",
-        "size": "0x4c",
-        "binding": "STB_LOPROC",
-        "in_rom": true,
-        "note": "vague-linkage copy"
-      }
-    ],
+    "note": "Re-measured after the destructor was moved into the class body. One compile of src_tu/actors/PoleLift.cpp, tools/tubuild.py elf_inventory. The .text list is now EMPTY: an in-class destructor makes mwccarm emit D1 and D0 only -- the cartridge's two variants, in the cartridge's order -- and dBgActor_c's own destructor is inlined rather than emitted as a vague-linkage copy. What remains is the data the key function drags in. Inventoried, not licensed, not verified.",
+    "text": [],
     "data": [
       {
-        "symbol": "_ZTV8PoleLift",
-        "size": "0x84",
-        "binding": "STB_GLOBAL",
-        "rom_symbol_address": "0x02112dbc",
-        "note": "the ROM symbol names the slot array; the compiler's symbol names the vtable object, which starts 8 bytes earlier at 0x02112db4"
+        "symbol": "_ZTI7fBase_c",
+        "size": "0x8",
+        "binding": "STB_LOPROC",
+        "rom_home": "arm9:0x02086d70"
       },
       {
-        "symbol": "_ZTV10dBgActor_c",
-        "size": "0x84",
-        "binding": "STB_LOPROC"
+        "symbol": "_ZTS7dBase_c",
+        "size": "0x9",
+        "binding": "STB_LOPROC",
+        "rom_home": "arm9:0x02086e54"
+      },
+      {
+        "symbol": "_ZTS7fBase_c",
+        "size": "0x9",
+        "binding": "STB_LOPROC",
+        "rom_home": "arm9:0x02086e60"
+      },
+      {
+        "symbol": "_ZTS8dActor_c",
+        "size": "0xa",
+        "binding": "STB_LOPROC",
+        "rom_home": "arm9:0x0208e384"
+      },
+      {
+        "symbol": "_ZTI10dBgActor_c",
+        "size": "0xc",
+        "binding": "STB_LOPROC",
+        "rom_home": "ov002:0x021089ec"
+      },
+      {
+        "symbol": "_ZTI7dBase_c",
+        "size": "0xc",
+        "binding": "STB_LOPROC",
+        "rom_home": "arm9:0x02086e78"
+      },
+      {
+        "symbol": "_ZTI8dActor_c",
+        "size": "0xc",
+        "binding": "STB_LOPROC",
+        "rom_home": "arm9:0x0208e390"
+      },
+      {
+        "symbol": "_ZTS10dBgActor_c",
+        "size": "0xd",
+        "binding": "STB_LOPROC",
+        "rom_home": "ov002:0x02108a04"
+      },
+      {
+        "symbol": "_ZTV8PoleLift",
+        "size": "0x88",
+        "binding": "STB_GLOBAL",
+        "rom_home": "ov045:0x02112dbc",
+        "note": "the ROM symbol names the slot array; the compiler's symbol names the vtable object, which starts 8 bytes earlier at 0x02112db4"
       },
       {
         "symbol": "_ZTI8PoleLift",
         "size": "0xc",
         "binding": "STB_LOPROC",
-        "rom_symbol": "_ZTI18daObjKm2_Ami_Bou_c",
-        "rom_symbol_address": "0x02112d74"
+        "rom_home": null,
+        "note": "HOMELESS UNDER THE COINED NAME. The cartridge's record is _ZTI18daObjKm2_Ami_Bou_c at ov045:0x02112d74; the vtable's own typeinfo word at 0x02112db8 reads 0x02112d74, and that record's base pointer is 0x021089ec = _ZTI10dBgActor_c, which is the base this header already declares."
       },
       {
         "symbol": "_ZTS8PoleLift",
         "size": "0xa",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTI10dBgActor_c",
-        "size": "0xc",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTS10dBgActor_c",
-        "size": "0xa",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTI8dActor_c",
-        "size": "0xc",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTS8dActor_c",
-        "size": "0x7",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTI7dBase_c",
-        "size": "0xc",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTS7dBase_c",
-        "size": "0xf",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTI7fBase_c",
-        "size": "0x8",
-        "binding": "STB_LOPROC"
-      },
-      {
-        "symbol": "_ZTS7fBase_c",
-        "size": "0xb",
-        "binding": "STB_LOPROC"
+        "binding": "STB_LOPROC",
+        "rom_home": null,
+        "note": "HOMELESS UNDER THE COINED NAME. The cartridge holds the ASCII '18daObjKm2_Ami_Bou_c' at ov045:0x02112d80. An _ZTS record is a length-prefixed mangled string, so a coined name misses on both the prefix and the body and can never byte-match."
       }
     ],
     "bss": [],
@@ -331,7 +314,7 @@
     "All seven functions reproduce their ROM bytes when compiled together. The legacy one-function sources under src/ are untouched and remain the enrolled owners of this range.",
     "One source-level change was forced by consolidation and one relocation-convention conflict was found by it: PoleLift_Spawn's vptr store had to become (int)(_ZTV8PoleLift + 2). See the report's 'What consolidation forced' section.",
     "PoleLift_ClsnFile (0x021131d0) and PoleLift_ModelFile (0x021131d8) carry this class's name but are referenced by none of these seven functions, and __sinit_ov045_02112280 rather than this TU's initialiser touches them. Those names are probably misattributed; that is a data-phase question and nothing here depends on it.",
-    "Promotion is refused. Requires: a licensed home for _ZN8PoleLiftD2Ev, a scratch link proving the whole 0x0211150c..0x02111840 range, and the vtable/RTTI/init/bss phases."
+    "Promotion is still refused, but for a different and now-measured reason. The _ZN8PoleLiftD2Ev blocker is DISCHARGED: with the destructor in the class body the TU emits D1 and D0 only, in ROM order, and tools/tu_order_check.py returns ALL MATCH. What blocks promotion now is the class's own RTTI. A consolidated object takes objisolate's derive_deadstrip, which admits no unlicensed non-.text content; the TU emits eleven such records because it defines the key function. Nine take a compiler_only_output 'deadstrip-data' row and are accepted. _ZTI8PoleLift and _ZTS8PoleLift do not: measured against tools/tubuild.py, omitting their rows leaves objisolate refusing \"unlicensed content in text-only multi-symbol object\", 'deadstrip-data' is refused for having no configured ROM home, and plain 'deadstrip' is refused as an RTTI record that is never compared against the cartridge. production_mode 'intact-object' cannot help either: the cartridge's string is '18daObjKm2_Ami_Bou_c' (21 bytes) where the compiler emits '8PoleLift' (10 bytes), so no byte-identical emission exists under the coined name. The single remaining prerequisite is renaming this class to daObjKm2_Ami_Bou_c, which the ROM already evidences at 0x02112d74/0x02112d80 and which is deliberately NOT done here."
   ],
   "partial_isolation": {
     "round": "tools/tubuild.py linkcheck --partial -- one compile of the consolidated source, objisolate.derive per licensed function, each derived object substituted for the production per-function object at its own existing path, then scratch dsd delink+lcf, whole-tree mwccarm, mwldarm link, linked-range and module byte comparison, dsd check symbols --fail, full ROM build",

--- a/include/PoleLift.h
+++ b/include/PoleLift.h
@@ -25,7 +25,9 @@ struct PoleLift : dBgActor_c {
     u16 mHeightAng;                      /* 0x354 */
 
     /* --- vtable --- */
-    virtual ~PoleLift();
+    /* Inline is load-bearing: when forced from the two destructor source
+     * files, mwccarm emits the ROM's D1/D0 bodies without a homeless D2. */
+    virtual ~PoleLift() {}
 
     int Behavior();
     int CleanupResources();
@@ -37,9 +39,14 @@ typedef char PoleLift_size_must_be_0x358[sizeof(PoleLift) == 0x358 ? 1 : -1];
 
 #else
 
-/* The C spelling of the same object, flat. Kept because the D0 file is a C
-   translation unit that reads these fields, and D0 is compiler-generated so it
-   can never be migrated. Same arrangement as include/ShadowModel.h. */
+/* The C spelling of the same object, flat. The justification recorded here used
+   to be that the D0 file was a C translation unit reading these fields; that is
+   no longer true -- D0 is C++, and now forces the compiler-generated body from a
+   delete-expression rather than naming any field. Every file that includes this
+   header is C++ today, so this branch is currently unreached. Left in place, and
+   left aligned with the C++ branch above, because removing a flat twin is a
+   separate change with its own gate exposure. Same arrangement as
+   include/ShadowModel.h. */
 struct PoleLift {
     u8  pad_000[0x8];
     s32 param1;            /* 0x008 */

--- a/src/_ZN8PoleLiftD0Ev.cpp
+++ b/src/_ZN8PoleLiftD0Ev.cpp
@@ -1,18 +1,16 @@
 //cpp
 // @symbol _ZN8PoleLiftD0Ev
-/* recovered: real C++ deleting destructor -- the compiler emits the whole body
+/* A delete-expression forces mwccarm to emit the deleting destructor. The
+ * inherited inline dActor_c::operator delete supplies the actor-heap release
+ * used by the ROM, which is why nothing below mentions a heap.
  *
  * D0 is the DELETING destructor: destroy through this class and its bases --
  * which is why more than one vptr store appears -- then return the object to
- * its heap. Nobody writes that; declaring `~PoleLift()` is enough, because mwcc
- * emits D2, D0 and D1 together and objisolate keeps the one this file is bound
- * to.
- *
- * The deallocation is an inline operator delete, which is why nothing below
- * mentions a heap.
+ * its heap.
  */
 #include "PoleLift.h"
 
-PoleLift::~PoleLift()
+void PoleLift_EmitDeletingDestructor(PoleLift *p)
 {
+    delete p;
 }

--- a/src/_ZN8PoleLiftD1Ev.cpp
+++ b/src/_ZN8PoleLiftD1Ev.cpp
@@ -1,15 +1,18 @@
 //cpp
 // @symbol _ZN8PoleLiftD1Ev
-/* recovered: real C++ destructor -- the compiler emits the whole body
+/* The class-body destructor is real C++. This otherwise-unused explicit call
+ * forces mwccarm to emit its out-of-line D1 copy; objisolate keeps that symbol
+ * and discards the forcing wrapper.
  *
- * Two vtable stores and three destructor calls, every one a consequence of
- * `struct PoleLift : dBgActor_c`: its own vptr, then dBgActor_c's -- inlined,
- * because dBgActor_c's destructor is defined in its class body -- then
- * dBgActor_c's Model and dBgW_KcMbg, then dActor_c. This class adds no
- * member with a destructor of its own.
+ * The body is two vtable stores and three destructor calls, every one a
+ * consequence of `struct PoleLift : dBgActor_c`: its own vptr, then
+ * dBgActor_c's -- inlined, because dBgActor_c's destructor is defined in its
+ * class body -- then dBgActor_c's Model and dBgW_KcMbg, then dActor_c. This
+ * class adds no member with a destructor of its own.
  */
 #include "PoleLift.h"
 
-PoleLift::~PoleLift()
+void PoleLift_EmitDestructor(PoleLift *p)
 {
+    p->~PoleLift();
 }

--- a/src_tu/actors/PoleLift.cpp
+++ b/src_tu/actors/PoleLift.cpp
@@ -186,27 +186,21 @@ int PoleLift::CleanupResources()
 }
 
 /* ------------------------------------------------------------------------- */
-/* ROM ordinals 1 and 0 -- one definition, two ROM-visible variants:          */
+/* ROM ordinals 1 and 0 -- one inline definition, two ROM-visible variants:   */
 /*   _ZN8PoleLiftD1Ev  0x0211150c  size 0x4c   (complete-object destructor)   */
 /*   _ZN8PoleLiftD0Ev  0x02111558  size 0x60   (deleting destructor)          */
 /* ------------------------------------------------------------------------- */
-/* recovered: real C++ destructor -- the compiler emits the whole body.
+/* The destructor is defined in the class body in include/PoleLift.h, and is
+ * deliberately NOT repeated out of line here. An out-of-line definition makes
+ * mwccarm emit D2, D0, D1 -- and the cartridge holds D1, D0 with no D2 at all.
+ * Defined inline, the compiler emits exactly the ROM's two variants, in the
+ * ROM's order, from this translation unit.
  *
- * Two vtable stores and three destructor calls, every one a consequence of
- * `struct PoleLift : dBgActor_c`: its own vptr, then dBgActor_c's -- inlined,
- * because dBgActor_c's destructor is defined in its class body -- then dBgActor_c's
- * Model and dBgW_KcMbg, then dActor_c. This class adds no member with a
- * destructor of its own. D0 additionally returns the object to its heap through
- * the inline operator delete it inherits, which is why nothing here mentions a
- * heap.
- *
- * In the one-function tree these were two files, each carrying this same empty
- * body and each having objisolate keep the variant its filename named. In TU
- * context one definition produces both -- and a third, _ZN8PoleLiftD2Ev, which
- * is byte-identical to D1 and which the ROM does not contain. See the report:
- * that third section is the one thing standing between this file and a
- * whole-range link.
+ * The body itself is two vtable stores and three destructor calls, every one a
+ * consequence of `struct PoleLift : dBgActor_c`: its own vptr, then
+ * dBgActor_c's -- inlined, because dBgActor_c's destructor is defined in its
+ * class body -- then dBgActor_c's Model and dBgW_KcMbg, then dActor_c. This
+ * class adds no member with a destructor of its own. D0 additionally returns
+ * the object to its heap through the inline operator delete it inherits, which
+ * is why nothing mentions a heap.
  */
-PoleLift::~PoleLift()
-{
-}


### PR DESCRIPTION
Defines `~PoleLift()` in the class body. This is the prerequisite flip for promoting
`ov045/PoleLift` to a genuine TU. **It does not promote the TU** — I attempted the
promotion, measured a hard refusal that only a class rename can clear, and backed it
out. That measurement is the second half of this PR, recorded in the manifest.

Base: `a00c09854` (#2063). No ledger file is touched — no `config/converted-baseline.json`,
no `attribution.json`, no `delinks.txt`, no `symbols.txt` — so this PR is **not in the
ledger queue** and does not contend with a promotion PR.

## The flip

An out-of-line `~PoleLift()` makes mwccarm 2004/b56 emit **D2, D0, D1**. The cartridge
holds **D1, D0** and no D2. Defined in the class body, the compiler emits exactly the
ROM's two variants in the ROM's order:

```
before   ov045/PoleLift: D0, D1 out of order, plus a homeless _ZN8PoleLiftD2Ev
after    ov045/PoleLift: ALL MATCH, ROM order, nothing unlicensed
```

The two per-symbol sources are **rewritten as forcing helpers, not deleted**, so there
is no unbuildable intermediate state: an explicit `p->~PoleLift()` forces the
out-of-line D1 copy, a delete-expression forces D0, and `objisolate` keeps the symbol
each file is bound to. This mirrors the already-landed `ov029/ArrowLift` shape.

## Byte proof — before and after, both on this base

| | before | after |
| --- | --- | --- |
| module fidelity | 106/106 exact, 100.000000% | 106/106 exact, 100.000000% |
| source-built functions | 11,088 | 11,088 |
| reproducing / mismatching | 11,088 / **0** | 11,088 / **0** |
| source-owned data claims | 1 repro / 0 mismatch | 1 repro / 0 mismatch |
| ROM-build analysis | PASS | PASS |
| full-ROM sha256 | `d1506e90...c478e8` | `d1506e90...c478e8` (stock) |
| `eligible.py` | 11096 / 11211 | 11096 / 11211 |
| `port_refcheck.py` | 405 checked, 0 stale | 405 checked, 0 stale |
| `langmode_audit --check` | PASS | PASS |
| `tiers_ratchet` | 2568 CONVERTED, 0 backslid | 2568 CONVERTED, 0 backslid |
| ROM-data object records | 7,636 | 7,625 |

### The -11 records, per symbol

Not a coverage loss. Per-record `--data-json` diff on both trees: **1,245 distinct
symbols before and after**, and an identical verdict tally of **462 VERIFIED / 774
PARTIAL / 9 DIFFERS**. No symbol is lost and no verdict changes.

It is de-duplication. Before the flip, `~PoleLift()` was the key function and *both*
destructor files defined it, so each emitted the whole vtable/RTTI group. Inline, the
key function becomes `Behavior()` — the first declared non-inline virtual — which
exactly one file defines. `_ZTV8PoleLift` stays **VERIFIED**, re-attributed from
`src/_ZN8PoleLiftD1Ev.cpp` to `src/_ZN8PoleLift8BehaviorEv.cpp`. Every dropped record is
a second copy of one that survives.

Applying #2061's discriminator: no `data_*` entry is dropped here at all, keepable or
otherwise, so neither the gate-silencing nor the unkeepable case applies.

## Why the promotion is not in this PR

I ran `tu_promote.py ov045/PoleLift` and built it. The `D2` blocker is **discharged** —
that part of the census prediction is now compiled rather than inferred. What replaces
it is the class's own RTTI.

A consolidated object takes `objisolate.derive_deadstrip`, which admits no unlicensed
non-`.text` content. Defining the key function, the TU emits eleven such records. Nine
resolve to a configured ROM home and take a `deadstrip-data` row; those are accepted.
Two do not, and all four available routes refuse:

| route | measured verdict |
| --- | --- |
| omit the rows | `isolate: unlicensed content in text-only multi-symbol object: section[10] .data size 0xa defines ['_ZTS8PoleLift']; section[17] .data size 0xc defines ['_ZTI8PoleLift']` |
| `deadstrip-data` | `...is declared compiler-only data but has no configured ROM home; a homeless object is a plain deadstrip` |
| `deadstrip` | `...is an RTTI/vtable record banked as a plain deadstrip, which is never compared against the cartridge` |
| `production_mode: intact-object` | no byte-identical emission exists — see below |

The cause is a coined class name, and the cartridge says so directly. Read out of
`build/build/arm9_ov045.bin`:

- the vtable's typeinfo word at `0x02112db8` reads `0x02112d74`;
- `0x02112d74` is `_ZTI18daObjKm2_Ami_Bou_c`, whose name pointer is `0x02112d80` and
  whose base pointer is `0x021089ec` = `_ZTI10dBgActor_c` — the base this header already
  declares, so the hierarchy is right;
- `0x02112d80` holds the literal ASCII `18daObjKm2_Ami_Bou_c`.

An `_ZTS` record is a length-prefixed mangled string, so the compiler's `8PoleLift`
(10 bytes) can never match the cartridge's `18daObjKm2_Ami_Bou_c` (21 bytes) — under any
production mode. The gate's own remedy is the right one: **rename this class to
`daObjKm2_Ami_Bou_c`**, which the ROM evidences at `0x02112d74`/`0x02112d80`. That is a
separate PR with its own rename procedure, and deliberately not done here.

The manifest entry now records all of this: `unlicensed_output_observed` is re-measured
post-flip (`.text` list now empty; eleven data records with their homes, or their
absence, spelled out), the `verification.criteria` rows that named D2 are corrected, and
the `notes` bullet that said promotion needed "a licensed home for `_ZN8PoleLiftD2Ev`"
is replaced with the blocker that actually remains.

## Conventions checklist

Items 1-4 and 6 concern a promotion's diff. This diff promotes nothing, renames nothing,
deletes no file and touches no ledger, so they are vacuous rather than passed — with two
exceptions worth checking:

1. **Coined mangled names** — no symbol is coined or renamed here. Note for the record
   that `PoleLift` *is itself* a coined class name; this PR does not act on that, it
   documents it in the manifest with the ROM addresses that settle it.
2. **`extern int _ZTV<C>[];`** — not applicable while unpromoted, and flagged as
   outstanding work: `src_tu/actors/PoleLift.cpp` currently spells the store
   `p[0] = (int)(_ZTV8PoleLift + 2);`, where the convention asks for
   `*(int *)p = (int)&_ZTV8PoleLift[2];`. Same arithmetic, different spelling; left
   alone here to keep this diff byte-neutral and in scope.
3. **`_ZTV` address unchanged / `complete` span** — `_ZTV8PoleLift` remains
   `0x02112dbc` in `config/arm9/overlays/ov045/symbols.txt`; this PR does not touch that
   file. No `complete` span is added or widened — `delinks.txt` is untouched, so ov045
   keeps its seven per-function entries. No `data_*` or bss entry is dropped.
4. **Stale `func_<module>_<addr>` declarations** — nothing renamed, so nothing to
   remove; `include/decl_common.h` is untouched.
5. **No comment names a file the diff deletes** — the diff deletes no file. Two comments
   my change *invalidated* are corrected: `src_tu/actors/PoleLift.cpp`'s note about the
   D2 section, and `include/PoleLift.h`'s claim that the flat-C twin exists because "the
   D0 file is a C translation unit that reads these fields". Every includer of that
   header is C++ today, and D0 now names no field; the twin is left in place, only its
   justification is corrected.
6. **Ledger queue** — this PR carries no ledger file, so it neither waits on nor blocks
   the queue. #2057 merged before it was opened.

## Gates run

`rombuild -j16` (full ROM), `eligible.py`, `port_refcheck.py`, `langmode_audit --check`,
`tiers_ratchet.py`, `tu_order_check.py`, `check_src_tu.py`, `check_src_tu_compiles.py`
(92/92), `check_header_offsets.py include/PoleLift.h` (2 commented fields, 0 mismatched),
`check_dead_references.py`, `check_references.py`, `check_duplicate_sources.py`,
`check_data_definitions.py`. All pass.

`twin_align.py --check` FAILs — identically, on the same two headers, on unmodified
`origin/main`. `PoleLift.h` is not among them. Pre-existing and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
