### PR TITLE
docs: brace position on an inline structor is load-bearing for header-offsets

### DIFF
--- a/notes/tu-promotion-conventions.md
+++ b/notes/tu-promotion-conventions.md
@@ -404,6 +404,65 @@ declaration alone returns `None`, and so does a second overload. If a promotion 
 must move the destructor out of line, its two variants fall back to whole-file scoring —
 and only then can they carry markers, above their out-of-line definitions.
 
+### Put the inline structor's opening brace on the signature line
+
+Inlining the destructor to make it scoreable moves a function *body* into a struct that
+`tools/check_header_offsets.py` parses, and that gate recognises the body only when the
+signature line itself carries the `{`:
+
+    if n == 0:
+        depth = line.count("{") - line.count("}")
+        if depth > 0:
+            skip_body = depth
+        continue
+
+Written Allman the signature line has no brace, `skip_body` never arms, and the body's
+lines fall through to declaration parsing and are reported UNPARSED. Measured by
+rewriting nothing but the destructor of `include/dScMgBase_c.h` -- a derived class that
+declares its destructor first, which is the shape every inline-destructor promotion
+produces:
+
+    one line, with body    40 commented fields, 0 mismatched, 0 unparsed, spans 0x4660
+    one line, empty {}     40 commented fields, 0 mismatched, 0 unparsed, spans 0x4660
+    Allman, with body       0 commented fields, 0 mismatched, 2 unparsed, spans 0x50
+    Allman, empty           0 commented fields, 0 mismatched, 1 unparsed, spans 0x50
+
+Two things go wrong and only one of them is loud. The gate exits 1 on the UNPARSED line
+-- and it is green on `origin/main`, so this is a **merge-tree-only** red that
+`tools/premerge_check.py` will show you and your branch's own CI will not. The quiet half
+is the worse one: **one unparsed line suppresses the field walk for the whole header**,
+which is this tool's own documented silent-no-op shape. `0 commented fields` there is not
+a clean pass, it is no check at all -- forty fields stopped being checked and the reported
+span fell back to the base's `0x50`.
+
+Two conditions narrow the hazard, and both hold for precisely the promotions this document
+is about. It needs a **derived** class -- a non-derived one is declared unmodelled at its
+first method line and never reaches the brace -- whose **structor is declared before any
+field**, the key-function convention inherited from `dScene_c.h`. Where the destructor sits
+after the fields, a method line ends the field list and the stray brace is never read;
+`include/ArrowLift.h` measures identically in both styles. Note also that an **empty**
+Allman body breaks it exactly as an empty one-line body does not. It is the newline that
+costs, not the statements.
+
+So write
+
+    virtual ~PoleLift() {
+        ...
+    }
+
+and not the Allman form. Every inline destructor in `include/` today is `virtual ~X() {}`
+on a single line, so nothing has exercised this before; the inline-destructor wave will
+exercise it repeatedly. This is a defect in the gate rather than in the style, and it is
+recorded as one -- but until the gate is fixed, brace position is load-bearing.
+
+### A marker on a still-unnamed member buys nothing
+
+`score_member` recomputes `real_name` from the symbol, not from the fragment, so a member
+still called `func_ov006_0210a534` fails that criterion whichever text it is scored
+against. Marking it is still worth doing, because the boundary it creates is what protects
+its *neighbour* — that is the whole point of the rule above — but do not expect the marker
+to move that member's own score. Renaming it is the thing that does.
+
 ### Markers cannot move a ROM byte
 
 `_code_only` (line 198) blanks comments before three of the five criteria run, and the


### PR DESCRIPTION
Follow-up to #2065, same file. Two things the `@symbol` section left out, both of which the inline-destructor wave will hit immediately.

## 1. Brace position on an inline structor is load-bearing

Inlining a destructor to make it scoreable moves a function *body* into a struct that `tools/check_header_offsets.py` parses. That gate arms its body-skip only when the brace is on the signature line:

```python
if n == 0:
    depth = line.count("{") - line.count("}")
    if depth > 0:
        skip_body = depth
    continue
```

Written Allman, `skip_body` never arms and the body's lines fall through to declaration parsing.

I measured it rather than reasoning about it, rewriting **nothing but the destructor** of `include/dScMgBase_c.h` — a derived class that declares its destructor first, which is the shape every inline-destructor promotion produces:

```
one line, with body    40 commented fields, 0 mismatched, 0 unparsed, spans 0x4660
one line, empty {}     40 commented fields, 0 mismatched, 0 unparsed, spans 0x4660
Allman, with body       0 commented fields, 0 mismatched, 2 unparsed, spans 0x50
Allman, empty           0 commented fields, 0 mismatched, 1 unparsed, spans 0x50
```

The UNPARSED line exits 1, so it is loud — but green on `origin/main`, which makes it a **merge-tree-only** red: `premerge_check.py` shows it, the branch's own CI does not. The quiet half is worse. One unparsed line suppresses the field walk for the entire header, so `0 commented fields` is not a clean pass, it is no check at all: forty fields stopped being checked and the span fell back to the base's `0x50`. That is this tool's own documented silent-no-op shape, arriving a fourth way.

Two conditions narrow it, and both hold for exactly the promotions this document covers — a **derived** class (a non-derived one is called unmodelled at its first method line and never reaches the brace) whose **structor is declared before any field**, the `dScene_c.h` key-function convention. `include/ArrowLift.h`, whose destructor follows its fields, measures identically in both styles; the method line ends the field list and the stray brace is never read. And an **empty** Allman body breaks it where an empty one-line body does not — it is the newline that costs, not the statements.

## 2. A marker on a still-unnamed member buys nothing for that member

`score_member` recomputes `real_name` from the symbol rather than the fragment, so a member still called `func_ov006_0210a534` fails that criterion whichever text it is scored against. Marking it is still right, because the boundary protects its *neighbour* — but do not expect the marker to move its own score. Renaming does that.

## Scope and limits

Docs only: one file, `notes/tu-promotion-conventions.md`. No header, source or config file is touched, so no ROM byte can move.

This is a defect in the gate, not in the style, and I have filed it as one — arming `skip_body` from a following-line brace is a small change but it risks newly-reding headers and wants measurement across all 508 before it lands. Until then brace position is load-bearing and belongs in the conventions doc.

The Allman hazard was first noticed by another session on a different header; I did not take it on trust — everything above is my own reproduction, on a header that is on `main`, and it corrects the original report in two ways (the empty-body case also breaks, and the declared-before-fields precondition is required).
