### PR TITLE
tools: audit our class names against the cartridge's own RTTI (259 of 541 disagree, and that gates promotion)

### DIFF
--- a/notes/rtti-name-audit.md
+++ b/notes/rtti-name-audit.md
@@ -1,0 +1,116 @@
+# The cartridge disagrees with 259 of our class names, and that gates promotion
+
+Measured on `origin/main` `01c4d350a`, reproducible with `python tools/rtti_name_audit.py`.
+
+```
+total _ZTV symbols in config    541
+  RTTI name AGREES with ours    276
+  RTTI name DISAGREES           259
+  typeinfo word unreadable        6
+```
+
+Just under half the vtable-bearing classes in the tree carry a name the ROM contradicts.
+That has always been true; what is new is that it is now measured exhaustively, and that
+it turns out to control something other than readability.
+
+## A coined name blocks TU promotion
+
+Promoting a translation unit consolidates the class's RTTI, so the compiler emits
+`_ZTI<OurName>` and `_ZTS<OurName>`. The cartridge holds those records under the class's
+real name, at a different length, so no ROM symbol can license them. `tubuild` refuses:
+
+```
+HOMELESS     _ZTS8PoleLift  STB_LOPROC .data size=0xa
+HOMELESS     _ZTI8PoleLift  STB_LOPROC .data size=0xc
+COLLIDES-GAP _ZTV8PoleLift  STB_GLOBAL .data size=0x84 already at ov045:0x02112dbc
+```
+
+`PoleLift` is `daObjKm2_Ami_Bou_c` in the ROM. This was found the expensive way, on
+[#2066](https://github.com/tangosdev/sm64ds-decomp/pull/2066): the destructor work was
+correct and landed, and the promotion it was meant to unlock could never have succeeded.
+No amount of TU-boundary evidence would have changed that.
+
+The mechanism holds across everything that has already landed, not just the one failure.
+Of the 23 manifests on `main` with `status: promoted`:
+
+| | |
+|---|---|
+| own a vtable, name **agrees** with the ROM | **15** |
+| own a vtable, name **disagrees** | **0** |
+| own no vtable, so RTTI never arises | 8 |
+
+Nothing name-mismatched has ever promoted. Check the name before doing the work.
+
+## The evidence chain
+
+Direct, and self-checking. From a `_ZTV` address `V`, the word at `V-4` is the typeinfo
+pointer; a `__si_class_type_info` record is `[vptr][name ptr][base ptr]`, so word 1 leads
+to the `_ZTS` string. That string is length-prefixed, so a correct read verifies itself:
+
+```
+_ZTV8PoleLift @ 0x02112dbc            (ov045, base 0x021111a0)
+  [V-8] offset-to-top = 0x00000000
+  [V-4] typeinfo      = 0x02112d74
+  TI[0] vptr          = 0x0209a764
+  TI[1] name ptr      = 0x02112d80 -> '18daObjKm2_Ami_Bou_c'
+  TI[2] base's _ZTI   = 0x021089ec
+```
+
+`18` is exactly `len("daObjKm2_Ami_Bou_c")`. `TI[2]` gives the ROM-proven direct base for
+free, which is worth having when a hierarchy is in doubt.
+
+## Three ways to measure this wrong
+
+All three produced confident wrong numbers before they were caught.
+
+**Read `config/` from `origin/main`, not from a checkout.** A checkout that is behind will
+audit names that have already been renamed. Measuring the same tree from a stale working
+copy returned 265/543 instead of 259/541 -- six renames had landed and two `_ZTV` symbols
+were gone entirely.
+
+**Resolve each address in its own overlay first.** Many overlays share a base address --
+ov045, ov046 and ov047 are all at `0x021111a0` -- so a reader that picks an image by
+address, or that falls back to `arm9` first, silently reads a different overlay. The tool
+takes the overlay from the path of the `symbols.txt` the symbol came from.
+
+**Use `extracted/arm9_dec.bin`.** `extracted/dsd/arm9/arm9.bin` is compressed and its
+strings are not at their link addresses.
+
+And one reporting rule: **an unreadable typeinfo word is unmeasured, not an agreement.**
+Six are unreadable -- `daDemo_c::simpleModel_c`, `daDemo_c::anmModel_c`, `daOts_c`,
+`daObjMaruta_c`, `daDsnBase_c`, `daObjFallBlock_c` -- and folding them into the agreeing
+column would overstate what is promotable by six classes.
+
+## What this does to the inline-destructor wave
+
+The 41-TU inline-destructor census was ordered as a destructor workstream. Intersected
+against this audit, it is mostly a renaming one:
+
+| | |
+|---|---|
+| census classes whose name **agrees** | **11** -- all already have manifests on `main` |
+| census classes whose name **disagrees** | **48** |
+| census classes owning no `_ZTV` | 19 |
+
+The destructor flip itself is unaffected and still lands independently -- it changes
+`virtual ~X();` to an inline body and rewrites the two per-symbol files as forcing
+helpers, none of which touches RTTI. But the *promotion* half of that list is spent on
+the agreeing side. Work it top-to-bottom expecting 41 promotions and 48 of them will fail
+at `tubuild`, each after a full TU reconstruction.
+
+The disagreements concentrate: ov002 has 35, `arm9` 23, ov064 12, ov022 9, ov029 8. An
+ov002 rename pass would unblock more promotions than any other single piece of work.
+
+## Using it
+
+```
+python tools/rtti_name_audit.py                  # summary, first 25 disagreements
+python tools/rtti_name_audit.py --all            # every disagreement
+python tools/rtti_name_audit.py --class PoleLift # one class, with the chain
+python tools/rtti_name_audit.py --json out.json  # every row
+```
+
+`--class` is the one to run before starting a promotion. It costs a second and it is the
+difference between a promotion that can land and one that cannot.
+
+Related: [tu-promotion-conventions.md](tu-promotion-conventions.md).

--- a/tools/rtti_name_audit.py
+++ b/tools/rtti_name_audit.py
@@ -1,0 +1,223 @@
+"""Report every class whose name the cartridge's own RTTI contradicts.
+
+WHY THIS EXISTS. A coined class name is not only a readability debt -- it is a hard
+block on TU promotion, and the block does not announce itself as a naming problem.
+Promoting a translation unit consolidates the class's RTTI, so the compiler emits
+`_ZTI<OurName>` and `_ZTS<OurName>`. The cartridge holds those records under the
+*real* name, at a different length, so there is no ROM symbol to license them to and
+`tubuild` refuses:
+
+    HOMELESS     _ZTS8PoleLift  STB_LOPROC .data size=0xa
+    HOMELESS     _ZTI8PoleLift  STB_LOPROC .data size=0xc
+    COLLIDES-GAP _ZTV8PoleLift  STB_GLOBAL .data size=0x84 already at ov045:0x02112dbc
+
+`PoleLift` (#2066) is `daObjKm2_Ami_Bou_c` in the ROM. The destructor work that PR was
+about was fine; the promotion could never have landed, and no amount of TU-boundary
+evidence would have changed that. That is the whole point of running this first.
+
+The evidence is direct, not inferred. From a `_ZTV` address `V`, the word at `V-4` is
+the typeinfo pointer; a `__si_class_type_info` record is `[vptr][name ptr][base ptr]`,
+so word 1 leads to the `_ZTS` string, which is length-prefixed and therefore
+self-checking -- `18daObjKm2_Ami_Bou_c` has exactly 18 characters after the prefix.
+
+TWO WAYS TO GET THIS WRONG, both of which produced wrong numbers before they were
+caught:
+
+1. **Resolve each address in its own overlay first.** Many overlays share a base
+   address -- ov045, ov046 and ov047 are all at 0x021111a0 -- so a reader that falls
+   back to arm9, or that picks an overlay by address alone, silently reads a different
+   image and reports confident nonsense. This walks `config/arm9/**/symbols.txt` and
+   takes the overlay from the *path* of the file the symbol came from.
+
+2. **Use the decompressed arm9.** `extracted/dsd/arm9/arm9.bin` is compressed;
+   `extracted/arm9_dec.bin` is the one with readable strings at their link addresses.
+
+A class this reports as DISAGREE is not promotable until it is renamed. A class it
+reports as unreadable is *unmeasured*, not agreeing -- six of them are, and they are
+reported separately for exactly that reason.
+
+    python tools/rtti_name_audit.py                # summary + the disagreements
+    python tools/rtti_name_audit.py --json out.json
+    python tools/rtti_name_audit.py --class PoleLift    # one class, with the chain
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import struct
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+VTABLE_SYMBOL = re.compile(r"^(_ZTV\S+)\s+.*?addr:(0x[0-9a-fA-F]+)")
+OVERLAY_IN_PATH = re.compile(r"overlays/ov(\d+)/")
+LENGTH_PREFIXED = re.compile(r"^(\d+)(.*)$")
+
+
+def _load_images():
+    """Return (arm9_base, arm9_bytes, {overlay id: (base, bytes)})."""
+    arm9 = (REPO / "extracted/arm9_dec.bin").read_bytes()
+    with open(REPO / "extracted/dsd/arm9/arm9.yaml") as fh:
+        arm9_base = yaml.safe_load(fh)["base_address"]
+
+    with open(REPO / "extracted/dsd/arm9_overlays/overlays.yaml") as fh:
+        overlays = yaml.safe_load(fh)
+    if isinstance(overlays, dict):
+        overlays = overlays.get("overlays", overlays)
+
+    images = {}
+    for entry in overlays:
+        path = REPO / "extracted/dsd/arm9_overlays" / entry["file_name"]
+        if path.exists():
+            images[int(entry["id"])] = (int(entry["base_address"]), path.read_bytes())
+    return arm9_base, arm9, images
+
+
+def _reader(overlay_id, arm9_base, arm9, images):
+    """Resolve an address to bytes, preferring this overlay over arm9.
+
+    The preference is the point: overlays share base addresses, so an
+    address-only lookup is ambiguous and an arm9-first lookup is simply wrong.
+    """
+    candidates = []
+    if overlay_id is not None and overlay_id in images:
+        candidates.append(images[overlay_id])
+    candidates.append((arm9_base, arm9))
+
+    def get(addr, count):
+        for base, data in candidates:
+            offset = addr - base
+            if 0 <= offset and offset + count <= len(data):
+                return data[offset:offset + count]
+        return None
+
+    return get
+
+
+def _u32(get, addr):
+    raw = get(addr, 4)
+    return struct.unpack("<I", raw)[0] if raw else None
+
+
+def _cstr(get, addr, limit=96):
+    raw = get(addr, limit)
+    if not raw:
+        return None
+    end = raw.find(b"\0")
+    return raw[:end].decode("ascii", "replace") if end >= 0 else None
+
+
+def _demangle_length_prefixed(name):
+    """`18daObjKm2_Ami_Bou_c` -> `daObjKm2_Ami_Bou_c`, and only if the count agrees."""
+    match = LENGTH_PREFIXED.match(name or "")
+    if not match:
+        return name or ""
+    body = match.group(2)
+    return body if len(body) == int(match.group(1)) else (name or "")
+
+
+def audit():
+    """Yield one dict per `_ZTV` symbol in config, with the ROM's name beside ours."""
+    arm9_base, arm9, images = _load_images()
+    rows = []
+    for symbols in sorted(REPO.glob("config/arm9/**/symbols.txt")):
+        match = OVERLAY_IN_PATH.search(symbols.as_posix())
+        overlay_id = int(match.group(1)) if match else None
+        get = _reader(overlay_id, arm9_base, arm9, images)
+
+        for line in symbols.read_text(encoding="utf-8", errors="replace").splitlines():
+            found = VTABLE_SYMBOL.match(line.strip())
+            if not found:
+                continue
+            vtable, addr = found.group(1), int(found.group(2), 16)
+
+            typeinfo = _u32(get, addr - 4)
+            name_ptr = _u32(get, typeinfo + 4) if typeinfo else None
+            rom = _cstr(get, name_ptr) if name_ptr else None
+
+            rows.append({
+                "module": "ov%03d" % overlay_id if overlay_id is not None else "arm9",
+                "symbols": symbols.relative_to(REPO).as_posix(),
+                "vtable": vtable,
+                "addr": "0x%08x" % addr,
+                "typeinfo": "0x%08x" % typeinfo if typeinfo else None,
+                "ours": _demangle_length_prefixed(vtable[4:]),
+                "rom": _demangle_length_prefixed(rom) if rom else None,
+                "rom_raw": rom,
+            })
+    return rows
+
+
+def _classify(rows):
+    agree = [r for r in rows if r["rom"] is not None and r["rom"] == r["ours"]]
+    disagree = [r for r in rows if r["rom"] is not None and r["rom"] != r["ours"]]
+    unreadable = [r for r in rows if r["rom"] is None]
+    return agree, disagree, unreadable
+
+
+def _report_one(rows, wanted):
+    for row in rows:
+        if row["ours"] != wanted and row["vtable"] != wanted:
+            continue
+        print("%s @ %s  (%s)" % (row["vtable"], row["addr"], row["module"]))
+        print("  typeinfo   %s" % row["typeinfo"])
+        print("  ROM name   %s" % (row["rom_raw"] or "<unreadable>"))
+        print("  our name   %s" % row["ours"])
+        print("  verdict    %s" % (
+            "unreadable -- UNMEASURED, not an agreement" if row["rom"] is None
+            else "AGREES" if row["rom"] == row["ours"]
+            else "DISAGREES -- not promotable until renamed"))
+        return 0
+    print("no _ZTV symbol in config for %r" % wanted, file=sys.stderr)
+    return 1
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", metavar="PATH", help="write every row as JSON")
+    parser.add_argument("--class", dest="cls", metavar="NAME",
+                        help="report one class and its typeinfo chain")
+    parser.add_argument("--all", action="store_true",
+                        help="list every disagreement, not the first 25")
+    args = parser.parse_args(argv)
+
+    rows = audit()
+    if args.cls:
+        return _report_one(rows, args.cls)
+
+    agree, disagree, unreadable = _classify(rows)
+    print("total _ZTV symbols in config: %d" % len(rows))
+    print("  RTTI name AGREES with our class name : %d" % len(agree))
+    print("  RTTI name DISAGREES                  : %d" % len(disagree))
+    print("  typeinfo/name unreadable             : %d" % len(unreadable))
+    print()
+    print("A DISAGREE row cannot be TU-promoted until it is renamed: consolidation")
+    print("emits _ZTI/_ZTS under our name and the ROM has no home for them.")
+    print("An unreadable row is UNMEASURED. It is not an agreement.")
+    print()
+
+    shown = disagree if args.all else disagree[:25]
+    print("--- %s ---" % ("all disagreements" if args.all
+                          else "first %d of %d disagreements" % (len(shown), len(disagree))))
+    for row in sorted(shown, key=lambda r: (r["module"], r["ours"])):
+        print("  %-6s %-34s ROM: %s" % (row["module"], row["ours"], row["rom"]))
+
+    if unreadable:
+        print()
+        print("--- unreadable (%d) ---" % len(unreadable))
+        for row in unreadable:
+            print("  %-6s %s" % (row["module"], row["vtable"]))
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump(rows, fh, indent=1)
+        print()
+        print("wrote %s" % args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `tools/rtti_name_audit.py` and `notes/rtti-name-audit.md`. Tools and prose only — no source, config, manifest or gate changes.

## Why

#2066 spent a full destructor migration on `PoleLift` before discovering the promotion it was meant to unlock could never have landed:

```
HOMELESS     _ZTS8PoleLift  STB_LOPROC .data size=0xa
HOMELESS     _ZTI8PoleLift  STB_LOPROC .data size=0xc
COLLIDES-GAP _ZTV8PoleLift  STB_GLOBAL .data size=0x84 already at ov045:0x02112dbc
```

`PoleLift` is `daObjKm2_Ami_Bou_c` in the cartridge. Promoting a TU consolidates the class's RTTI, so the compiler emits `_ZTI`/`_ZTS` under **our** name; the ROM holds those records under the **real** name, at a different length, so nothing can license them. That is a naming failure wearing a TU-boundary failure's clothes, and no amount of boundary evidence fixes it.

## What it measures

Tree-wide, against `origin/main`'s `config/`:

```
total _ZTV symbols in config    541
  RTTI name AGREES with ours    276
  RTTI name DISAGREES           259
  typeinfo word unreadable        6
```

The mechanism is confirmed against everything that has already landed, not just the one failure. Of the 23 manifests on `main` with `status: promoted`:

| | |
|---|---|
| own a vtable, name **agrees** with the ROM | **15** |
| own a vtable, name **disagrees** | **0** |
| own no vtable, so RTTI never arises | 8 |

Nothing name-mismatched has ever promoted. The zero is the load-bearing number.

## What it does to the inline-destructor queue

Intersecting with the 41-TU inline-destructor census: **11 agree** (all already have manifests on `main`), **48 disagree**, **19 own no `_ZTV`**. The destructor flip is unaffected and still lands independently — it touches no RTTI. The *promotion* half of that list is spent on the agreeing side. Worked top-to-bottom expecting 41 promotions, 48 of them fail at `tubuild`, each after a full TU reconstruction.

Disagreements concentrate: ov002 has 35, `arm9` 23, ov064 12, ov022 9, ov029 8.

## The evidence chain

Direct and self-checking. From `_ZTV` address `V`, `[V-4]` is the typeinfo pointer; a `__si_class_type_info` record is `[vptr][name ptr][base ptr]`, so word 1 leads to a length-prefixed `_ZTS`:

```
_ZTV8PoleLift @ 0x02112dbc            (ov045, base 0x021111a0)
  [V-4] typeinfo      = 0x02112d74
  TI[1] name ptr      = 0x02112d80 -> '18daObjKm2_Ami_Bou_c'
  TI[2] base's _ZTI   = 0x021089ec
```

`18` is exactly `len("daObjKm2_Ami_Bou_c")`, so a correct read verifies itself. `TI[2]` also hands you the ROM-proven direct base.

## Three traps, all of which produced wrong numbers here first

Documented in the docstring and the note because each one was hit during this work:

1. **Read `config/` from `origin/main`, not a checkout.** A stale working copy returned 265/543 instead of 259/541 — six renames had landed and two `_ZTV` symbols were gone.
2. **Resolve each address in its own overlay.** ov045/ov046/ov047 all sit at `0x021111a0`; an address-only or arm9-first lookup silently reads a different image. The tool takes the overlay from the path of the `symbols.txt` the symbol came from.
3. **Use `extracted/arm9_dec.bin`.** `extracted/dsd/arm9/arm9.bin` is compressed.

And one reporting rule the tool enforces: **an unreadable typeinfo word is unmeasured, not an agreement.** Six are unreadable; folding them into the agreeing column would overstate what is promotable by six classes.

## Using it

```
python tools/rtti_name_audit.py                  # summary, first 25 disagreements
python tools/rtti_name_audit.py --all            # every disagreement
python tools/rtti_name_audit.py --class PoleLift # one class, with the chain
python tools/rtti_name_audit.py --json out.json  # every row
```

`--class` is the one to run *before* starting a promotion.

## Verification

Run from a clean worktree off `origin/main`, independently reproducing 541/276/259/6. `--class PoleLift` → DISAGREES, `--class daEyBm_c` → AGREES, `--class NoSuchClass` → exit 1.

Gates in-worktree: `check_python_names` PASS (261 files, 0 unresolvable), `check_dead_references` clean (377 prose files, 3549 references, no broken markdown links), `check_header_offsets` clean over 400 headers. Pre-push: port-refcheck 405/405, duplicate-sources 11158 stems none doubled, `check_src_tu_compiles` 92/92.

No ROM was built for this PR and none is needed — it adds no compiled source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
