### PR TITLE
Use stable examples in repository tools

### DIFF
--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -9,7 +9,7 @@ the byte gate cannot see a field no source file happens to read.
 This walks the declarations, applies natural alignment, and compares. Used as the
 first gate on any header edit; see notes/archive/plan-scalar-markers.md 4.
 
-    python tools/check_header_offsets.py include/Amp.h include/Camera.h
+    python tools/check_header_offsets.py include/Camera.h
     python tools/check_header_offsets.py --changed              # vs origin/main
     python tools/check_header_offsets.py --changed main
     python tools/check_header_offsets.py --changed --committed-only   # what CI sees

--- a/tools/marker_evidence.py
+++ b/tools/marker_evidence.py
@@ -702,9 +702,9 @@ _SKIP_MEMBER_TY = set(EH._W1) | set(EH._W2) | set(EH._W4) | set(EH._W8) | {"void
 def scan_local_layout(code, cls, origin, path):
     """A migrated file that declares its own layout IS a member-type table.
 
-    A byte-matching revision of `src/_ZN3AmpD1Ev.cpp` declared
-    `struct Amp : Actor { ModelAnim m0; /* 0xd4 */ ... }`, so both the offsets
-    and the class names in it are pinned by the ROM's own relocations.
+    A byte-matching migrated file may declare a local class layout with named
+    members at measured offsets. Both those offsets and the class names are then
+    pinned by the ROM's own relocations.
     """
     texts = EH.find_struct_texts(code)
     if cls not in texts:

--- a/tools/test_check_header_offsets.py
+++ b/tools/test_check_header_offsets.py
@@ -290,7 +290,7 @@ class GateStillWorksTests(unittest.TestCase):
     def test_a_real_tree_header_still_parses(self):
         """Guards the repo-root resolution added here: a relative path from --changed
         must be read against the repository, not the process cwd."""
-        self.assertEqual(C.main(["include/Amp.h"]), 0)
+        self.assertEqual(C.main(["include/Camera.h"]), 0)
 
     def test_the_cli_entry_point_still_returns_the_gates_verdict(self):
         r = subprocess.run([sys.executable, str(TOOLS / "check_header_offsets.py")],


### PR DESCRIPTION
Replaces volatile class-specific paths in tool documentation and the header-offset regression fixture with stable equivalents. This keeps class TU promotions from creating dead repository references without changing tool behavior.\n\nValidated locally:\n- python -m unittest -v tools.test_check_header_offsets (20/20)\n- python tools/check_header_offsets.py include/Camera.h\n- python tools/check_dead_references.py\n- pre-push port references and 92/92 src_tu compiles