### PR TITLE
tubuild: stop cutting declarations in half, and name the block when a definition is out of reach

### DIFF
--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1838,6 +1838,160 @@ def test_anonymous_typedefs_key_by_their_trailing_name():
     assert (ka, na) != (kb, nb), "distinct unnamed types must not share a merge key"
 
 
+def test_allman_braced_shadow_struct_is_captured_whole():
+    """The real input: src/func_ov006_020f8224.c (ov006/dScMgMCarlo_c), whose
+    shadow struct puts its opening brace on the next line. The first line scores
+    depth 0, so the block used to be cut to the bare words `struct Obj` -- the TU
+    got an incomplete type, the body leaked into function_text as a headless
+    `{ ... };` at file scope, and the conflict comment quoted `struct Obj` as
+    though that were the alternate body a reviewer should judge."""
+    src = ("struct Obj\n"
+           "{\n"
+           "    char pad[0x2a];\n"
+           "    short f2a;\n"
+           "    unsigned char f2c;\n"
+           "};\n"
+           "\n"
+           "int func_ov006_020f8224(struct Obj *a, struct Obj *b)\n"
+           "{\n"
+           "    return a->f2a - b->f2a;\n"
+           "}\n")
+    got = tubuild.split_legacy_source(src)
+    assert got["error"] is None, got["error"]
+    (kind, name, text), = got["shadow_decls"]
+    assert (kind, name) == ("struct", "Obj")
+    assert "char pad[0x2a];" in text and text.rstrip().endswith("};"), \
+        "the Allman body belongs to the declaration, not to the function"
+    assert "char pad[0x2a];" not in got["function_text"], \
+        "a headless struct body must never leak into the member body"
+    assert got["function_text"].startswith("int func_ov006_020f8224(")
+
+
+def test_same_name_allman_and_k_and_r_structs_conflict_with_real_bodies():
+    """Both spellings of the same name must reach _merge_field carrying their
+    OWN body, or the conflict comment asks a reviewer to compare a full struct
+    against the two words `struct Obj`."""
+    allman = tubuild.split_legacy_source(
+        "struct Obj\n{\n    char pad[0x2a];\n};\n\nint f(void)\n{\n    return 0;\n}\n")
+    kandr = tubuild.split_legacy_source(
+        "struct Obj { char pad[1]; };\n\nint g(void)\n{\n    return 0;\n}\n")
+    w = []
+    parsed = {"f": allman, "g": kandr}
+    rows = [(0, "f", 0, 4), (1, "g", 4, 4)]
+    live, dead = tubuild._merge_field(rows, parsed, lambda p: p["shadow_decls"],
+                                      lambda i: (i[0], i[1]), "local declaration", w)
+    assert len(live) == 1 and len(dead) == 1 and w
+    assert "char pad[0x2a];" in live[0][1][2]
+    assert "char pad[1];" in dead[0][1][2]
+
+
+def test_forward_declaration_still_owns_only_its_own_line():
+    """The Allman walk must stop at a `;`. `struct C;` followed by a definition
+    of something else must not swallow the next block."""
+    got = tubuild.split_legacy_source(
+        "struct C;\nstruct D { int x; };\n\nint f(void)\n{\n    return 0;\n}\n")
+    assert got["error"] is None, got["error"]
+    assert got["shadow_decls"] == [("struct", "C", "struct C;"),
+                                   ("struct", "D", "struct D { int x; };")]
+
+
+def test_declaration_wrapped_across_lines_is_kept_whole():
+    """A declaration with no brace at all that wraps to a second line used to be
+    cut after its first line, silently dropping the rest."""
+    got = tubuild.split_legacy_source(
+        "typedef void (*Fn)(int,\n                   int);\n\nint f(void)\n{\n    return 0;\n}\n")
+    assert got["error"] is None, got["error"]
+    (kind, _name, text), = got["shadow_decls"]
+    assert kind == "typedef"
+    assert text.count("int") == 2, text   # both parameter lines survived
+    assert "int);" not in got["function_text"], "the wrapped tail must not leak"
+
+
+def test_bare_brace_where_a_signature_belongs_is_refused_not_emitted():
+    """The fail-loud backstop for any residual mis-split: a function body never
+    starts on a bare `{`, so reaching one means a declaration above leaked. The
+    caller must be told to assemble by hand, not handed a TU with a headless
+    block in it."""
+    got = tubuild.split_legacy_source("#pragma once\n{\n    int x;\n};\n")
+    assert got["error"] and "bare" in got["error"], got["error"]
+    assert got["function_text"] is None
+
+
+def test_elaborated_return_type_is_not_a_shadow_declaration():
+    """Real inputs: src/_ZN11dCapEnemy_c15RespawnIfHasCapEv.cpp and
+    src/func_02041b60.c. Both open on the word `struct`, but as an elaborated
+    type specifier on the RETURN type -- the flat-C sources spell it that way
+    constantly. Filing the line as a declaration put the function's own
+    signature under `shadow struct dActor_c` and left its body headless below;
+    with the Allman walk it swallowed the whole function instead."""
+    method = tubuild.split_legacy_source(
+        "struct dActor_c;\n"
+        "\n"
+        "struct dActor_c * dCapEnemy_c::RespawnIfHasCap()\n"
+        "{\n"
+        "    return 0;\n"
+        "}\n")
+    assert method["error"] is None, method["error"]
+    assert method["shadow_decls"] == [("struct", "dActor_c", "struct dActor_c;")]
+    assert method["function_text"].startswith("struct dActor_c * dCapEnemy_c::")
+
+    freefn = tubuild.split_legacy_source(
+        "struct ListNode *func_02041b60(char *base)\n"
+        "{\n"
+        "    return 0;\n"
+        "}\n")
+    assert freefn["error"] is None, freefn["error"]
+    assert freefn["shadow_decls"] == []
+    assert freefn["function_text"].startswith("struct ListNode *func_02041b60(")
+
+
+def test_record_with_a_function_pointer_member_still_reads_as_a_record():
+    """The elaborated-return-type test is `(` before the opening brace, not `(`
+    anywhere: a one-line record whose member is a function pointer must stay a
+    record, and a function-pointer typedef must stay a typedef."""
+    got = tubuild.split_legacy_source(
+        "struct S { void (*fn)(void); int x; };\n"
+        "\n"
+        "int f(void)\n"
+        "{\n"
+        "    return 0;\n"
+        "}\n")
+    assert got["error"] is None, got["error"]
+    (kind, name, _text), = got["shadow_decls"]
+    assert (kind, name) == ("struct", "S")
+    assert got["function_text"].startswith("int f(void)")
+
+
+def test_definition_inside_a_namespace_or_extern_c_block_names_the_block():
+    """Real inputs: src/_ZN6Memory8AllocateEj.cpp (an Allman `namespace Memory`
+    whose body IS the member) and src/func_ov006_021063a0.cpp (the definition
+    inside `extern "C" {`). tubuild has nowhere to put a block-scoped member, so
+    it must refuse -- but the refusal has to name the block, or the message
+    reads as "your file has no function in it" and sends a reader hunting."""
+    ns = tubuild.split_legacy_source(
+        "namespace Memory\n"
+        "{\n"
+        "    void* Allocate(u32 size, int align, Heap* heap);\n"
+        "\n"
+        "    void* Allocate(u32 size)\n"
+        "    {\n"
+        "        return Allocate(size, 4, 0);\n"
+        "    }\n"
+        "}\n")
+    assert ns["function_text"] is None
+    assert "namespace Memory" in ns["error"] and "line 1" in ns["error"], ns["error"]
+
+    ec = tubuild.split_legacy_source(
+        'extern "C" {\n'
+        "int func_ov006_021063a0(void)\n"
+        "{\n"
+        "    return 0;\n"
+        "}\n"
+        "}\n")
+    assert ec["function_text"] is None
+    assert 'extern "C"' in ec["error"] and "line 1" in ec["error"], ec["error"]
+
+
 def test_forward_decl_folds_into_the_definition_either_order():
     """A bare `struct C;` forward declaration must never oust or conflict with a
     full `struct C { ... };` definition of the same name (RacingPenguin, ov019).

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -536,6 +536,24 @@ _LONG_CALLS_ON_RE = re.compile(r'^\s*#\s*pragma\s+long_calls\s+on\b')
 _INCLUDE_RE = re.compile(r'^\s*#\s*include\s*.+$')
 _DEFINE_RE = re.compile(r'^\s*#\s*define\b.*$')
 _DECL_KEYWORDS = ("struct", "class", "enum", "typedef", "namespace")
+
+
+def _is_elaborated_return_type(stripped, first_word):
+    """True when a line opening with a _DECL_KEYWORD is really a function."""
+    # `struct dActor_c *dCapEnemy_c::RespawnIfHasCap()` opens with `struct`, but
+    # it declares no record -- the keyword is an elaborated type specifier on the
+    # RETURN type, a spelling the flat-C sources use constantly. Treating it as a
+    # declaration filed the function's own signature under `shadow struct
+    # dActor_c` and left its body headless below.  A record head (`struct Obj`,
+    # `class A : public B`) never carries a `(`; a function's parameter list
+    # always does. Test only the text BEFORE the opening brace, so a record whose
+    # body holds a function-pointer member (`struct S { void (*fn)(void); };`)
+    # still reads as a record. typedef and namespace are exempt: a function-
+    # pointer typedef is parenthesised and a namespace never is.
+    if first_word not in ("struct", "class", "enum", "union"):
+        return False
+    return "(" in stripped.split("{", 1)[0]
+
 _EXTERN_C_BLOCK_RE = re.compile(r'^\s*extern\s+"C"\s*\{\s*$')
 
 
@@ -558,12 +576,36 @@ def split_legacy_source(text):
     includes, pragmas, macros, externs, notes = [], [], [], [], []
     shadow_decls = []          # (kind, name, text)
     body_start = None
+    wrapper = None             # a block that swallowed the definition
 
     def consume_block(start_i):
-        """From a line that opens a brace, the index of the line balancing it back
-        to depth 0 (absorbing a lone trailing ';' on the next line, if any)."""
-        depth = lines[start_i].count("{") - lines[start_i].count("}")
+        """From a declaration's first line, the index of the line that ends it
+        (absorbing a lone trailing ';' on the next line, if any).
+
+        The opening brace does NOT have to be on `start_i`. An Allman-braced
+        declaration --
+
+            struct Obj
+            {
+                char pad[0x2a];
+            };
+
+        -- used to score depth 0 on its first line, so the block was cut to the
+        bare words `struct Obj` and the body below it fell through to the
+        function split. The TU then carried an incomplete type AND a headless
+        `{ ... };` at file scope, and the conflict comment quoted `struct Obj`
+        as if that were the whole alternate body. Walk forward for the brace,
+        stopping at a `;`: `struct C;` is a forward declaration and owns
+        nothing but its own line. Stopping there also keeps a declaration that
+        merely wraps across lines (`typedef void (*Fn)(int,` / `int);`) whole,
+        which the old first-line-only cut split in half."""
         j = start_i
+        if "{" not in lines[j]:
+            while "{" not in lines[j]:
+                if ";" in lines[j] or j + 1 >= n:
+                    return j
+                j += 1
+        depth = lines[j].count("{") - lines[j].count("}")
         while depth > 0 and j + 1 < n:
             j += 1
             depth += lines[j].count("{") - lines[j].count("}")
@@ -607,6 +649,10 @@ def split_legacy_source(text):
                 s = lines[k].strip()
                 if s and s != "}":
                     externs.append(s)
+                if "{" in s:
+                    # A brace inside means this block holds a DEFINITION, and
+                    # every line of it has just been filed as a declaration.
+                    wrapper = wrapper or ('extern "C"', i)
             i = j + 1
             continue
         if stripped.startswith("extern "):
@@ -621,7 +667,7 @@ def split_legacy_source(text):
             i = j + 1
             continue
         first_word = (stripped.split()[0] if stripped.split() else "").strip("*&")
-        if first_word in _DECL_KEYWORDS:
+        if first_word in _DECL_KEYWORDS and not _is_elaborated_return_type(stripped, first_word):
             j = consume_block(i)
             block = "\n".join(lines[i:j + 1])
             nm = re.match(rf'{first_word}\s+(\w+)', stripped)
@@ -635,6 +681,8 @@ def split_legacy_source(text):
                 tail = re.search(r'(\w+)\s*;\s*$', block)
                 if tail:
                     dname = tail.group(1)
+            if first_word == "namespace" and block.count("{") > 1:
+                wrapper = wrapper or (f"namespace {dname}", i)
             shadow_decls.append((first_word, dname, block))
             i = j + 1
             continue
@@ -642,8 +690,29 @@ def split_legacy_source(text):
         body_start = i
         break
 
+    if body_start is not None and lines[body_start].strip() in ("{", "};", "}"):
+        # A function body never starts on a bare brace -- the signature is on the
+        # same line or the line above. Reaching one means a declaration above was
+        # cut short and its body leaked down here. Refuse rather than emit a TU
+        # with a headless block in it; sec 7.3 says an unfitting shape is a
+        # "assemble this one by hand", not something to guess past.
+        return {"error": (f"line {body_start + 1} is a bare {lines[body_start].strip()!r} "
+                          "where a function signature was expected -- a declaration "
+                          "above it was split mid-body"),
+                "cpp": cpp, "includes": includes, "pragmas": pragmas, "macros": macros,
+                "externs": externs, "shadow_decls": shadow_decls, "notes": notes,
+                "function_text": None}
+
     if body_start is None:
-        return {"error": "scanned to end of file without finding a function body",
+        if wrapper is not None:
+            # Naming the block is the whole value of the message: the fix is to
+            # unwrap the definition by hand, not to hunt for a missing function.
+            msg = (f"the definition is inside the {wrapper[0]} block opened on "
+                   f"line {wrapper[1] + 1}, so it was consumed as a declaration -- "
+                   "tubuild cannot place a block-scoped member in a TU")
+        else:
+            msg = "scanned to end of file without finding a function body"
+        return {"error": msg,
                 "cpp": cpp, "includes": includes, "pragmas": pragmas, "macros": macros,
                 "externs": externs, "shadow_decls": shadow_decls, "notes": notes,
                 "function_text": None}


### PR DESCRIPTION
Tools-only, off `origin/main`. No `src/`, no `config/`, no generated state — so nothing here can move a byte of the ROM. (The validator restores all of `tools/` from base, which is exactly why this cannot ride along with a promotion PR.)

## The bug

`tubuild.split_legacy_source` decided where a local declaration ended by counting braces on its **first line only**:

```python
depth = lines[start_i].count("{") - lines[start_i].count("}")
```

For an Allman-braced record that is `0`, so the loop never runs and the block is cut to the bare words `struct Obj`. Two things then go wrong at once, and #2071's MCarlo TU happened to show both:

* the body falls through to the function split and lands in `function_text` as a headless `{ ... };` at file scope — the TU carries an incomplete type *and* a stray block;
* the same truncated text is what `_merge_field` quotes, so the `TUBUILD CONFLICT` comment asks a reviewer to compare a full struct against two words.

**82 legacy sources tree-wide were handed a bare `{` as their function body** this way — 53 opened by `struct`, 31 by `typedef`, 5 by `class`.

Fixing the walk exposed two more shapes:

**2. Elaborated return types.** `struct dActor_c *dCapEnemy_c::RespawnIfHasCap()` opens on a decl keyword, but as an elaborated type specifier on the *return* type — a spelling the flat-C sources use constantly. It was being filed as a shadow declaration, taking the function's own signature with it. A record head never carries a `(` before its brace; a parameter list always does, so that is the test (applied to the text *before* the opening brace, so `struct S { void (*fn)(void); };` still reads as a record).

**3. Definitions inside a wrapper block.** When the definition sits inside `namespace X { ... }` or `extern "C" { ... }`, every line of it is consumed as a declaration and nothing is left to be the body. tubuild has nowhere to put a block-scoped member, so refusing is correct (plan sec 7.3: an unfitting shape is "assemble this one by hand"). But the old message —

```
scanned to end of file without finding a function body
```

— reads as *"your file has no function in it"* and sends a reader hunting for one. It now names the block and the line that opened it:

```
the definition is inside the namespace Memory block opened on line 5, so it was
consumed as a declaration -- tubuild cannot place a block-scoped member in a TU
```

Plus a fail-loud backstop for any residual mis-split: a function body never starts on a bare brace, so reaching one is refused rather than emitted.

## Measured, base vs this branch, over all 11150 legacy sources

| | base | this |
|---|---|---|
| headless `{` handed back as the function body | 82 | **0** |
| files that refuse | 693 | 683 |
| …of those, refusals that name the offending block | 0 | **683** |
| files that split cleanly | 10457 | **10467** |
| newly refusing | — | 7 |

The 7 newly-refusing files (`_ZN6Memory8Allocate*`, `_ZN2GX15SetBankForSubBGEt`, `func_ov006_021063a0`) are exactly the wrapper-block shape: base produced a headless body for them, which is the outcome this PR exists to stop. **None of the seven newly-refusing files is enrolled in a TU**, so no manifest entry changes shape. An earlier revision of this sentence said "none of the affected files", which overstated it: **seven of the headless-repaired files *are* enrolled**, across four TUs — `ov002/Enemy` (3), `ov062/Koopa+KoopaSmall` (2), `ov004/unit020b0a38` (1) and `ov062/KoopaTheQuick` (1). Nothing is damaged, and the correction strengthens the case rather than weakening it: all four are `text-verified`, none of their `promoted_source` destinations exists on `main`, so none of that text is in the build — and none carries a headless block today only because a human repaired them by hand, which is precisely what this change makes unnecessary. (Measured by running the pre-#2072 `split_legacy_source` over the 1246 legacy sources the manifest enrolls.)

## Tests

Five new cases, built from the **real failing inputs** rather than synthetic ones, per review feedback that `tools/` failure paths here are under-tested:

* `src/func_ov006_020f8224.c` — the MCarlo `struct Obj`, asserted at **both** ends of the bug: the declaration keeps its body, and the conflict comment carries a real alternate body instead of two words;
* `src/_ZN11dCapEnemy_c15RespawnIfHasCapEv.cpp` and `src/func_02041b60.c` — elaborated return type, method and free function;
* `src/_ZN6Memory8AllocateEj.cpp` and `src/func_ov006_021063a0.cpp` — the two wrapper-block refusals, asserting the message names the block;
* the shapes the fix must **not** disturb: a bare forward declaration, a declaration wrapped across lines, and a record whose member is a function pointer.

```
python -m pytest tools/test_tubuild.py tools/test_tubuild_owned_relocs.py \
                 tools/test_check_src_tu_compiles.py tools/test_tu_manifest.py \
                 tools/test_srcpath.py -q
145 passed, 2 deselected
```

The 2 deselected (`test_verify_reproduces_pilot_1s_7_of_7_and_clean_objisolate`, `test_compile_report_matches_the_pilots_object_inventory`) fail identically on unmodified `origin/main` — verified by stashing this diff and re-running. Pre-existing, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhhAeJwXBnfPp7B5DNjCwh

