### PR TITLE
Use prose examples the cartridge agrees with, and make the gate test prove work

### DIFF
--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -9,7 +9,7 @@ the byte gate cannot see a field no source file happens to read.
 This walks the declarations, applies natural alignment, and compares. Used as the
 first gate on any header edit; see notes/archive/plan-scalar-markers.md 4.
 
-    python tools/check_header_offsets.py include/Amp.h include/Camera.h
+    python tools/check_header_offsets.py include/dActor_c.h include/dScMgBase_c.h
     python tools/check_header_offsets.py --changed              # vs origin/main
     python tools/check_header_offsets.py --changed main
     python tools/check_header_offsets.py --changed --committed-only   # what CI sees

--- a/tools/marker_evidence.py
+++ b/tools/marker_evidence.py
@@ -702,9 +702,14 @@ _SKIP_MEMBER_TY = set(EH._W1) | set(EH._W2) | set(EH._W4) | set(EH._W8) | {"void
 def scan_local_layout(code, cls, origin, path):
     """A migrated file that declares its own layout IS a member-type table.
 
-    A byte-matching revision of `src/_ZN3AmpD1Ev.cpp` declared
+    A byte-matching migrated file declared, in effect,
     `struct Amp : Actor { ModelAnim m0; /* 0xd4 */ ... }`, so both the offsets
     and the class names in it are pinned by the ROM's own relocations.
+
+    Named by class, not by path, on purpose: check_dead_references resolves any
+    `a/b`-shaped token in prose as a live repo-rooted reference, and the file
+    this came from is a per-symbol one -- those die on rename AND on TU
+    promotion, which folds them into src/actors/<Class>.cpp.
     """
     texts = EH.find_struct_texts(code)
     if cls not in texts:

--- a/tools/marker_evidence.py
+++ b/tools/marker_evidence.py
@@ -660,8 +660,9 @@ def scan_casts(body, bases, fieldmap, env, origin, path, base_line, known_types,
                local_structs):
     """`((ModelBase *)((char *)&mModel))->SetFile(...)` -- a cast is a lower bound.
 
-    UNLESS the file declares that struct itself.  `src/_ZN5Stage11RenderModelEv.cpp`
-    writes `struct ModelComponents { void *sub; Component *components; };` -- a local
+    UNLESS the file declares that struct itself.  The migrated `Stage::RenderModel`
+    (`_ZN5Stage11RenderModelEv`) writes
+    `struct ModelComponents { void *sub; Component *components; };` -- a local
     stand-in whose NAME a human chose and whose layout does not match the real class.
     Casting through it proves nothing about the type; it is recorded as `localname`
     and never decides anything.
@@ -900,10 +901,10 @@ def main():
             return sizes[cls][0], sizes[cls][1]
         if cls in layout_sizes:
             n, k = layout_sizes[cls].most_common(1)[0]
-            # UPPER BOUND ONLY.  A revision of `src/_ZN8PoleLiftD1Ev.cpp` padded
-            # Model to 0x80 so the next member landed at 0x158; the real class is
-            # 0x50 and the 0x30 between them is unknown space.  Never let this
-            # override an assertion.
+            # UPPER BOUND ONLY.  A revision of PoleLift's D1 destructor
+            # (`_ZN8PoleLiftD1Ev`) padded Model to 0x80 so the next member landed
+            # at 0x158; the real class is 0x50 and the 0x30 between them is
+            # unknown space.  Never let this override an assertion.
             return n, "inferred (UPPER BOUND) from %d local layout(s)" % k
         return None, None
 

--- a/tools/test_check_header_offsets.py
+++ b/tools/test_check_header_offsets.py
@@ -10,7 +10,10 @@ Every test here is a PLANTED REGRESSION: `_resolve_the_old_way` below is the pre
 resolution, verbatim, and each case asserts that it says "pass" while the current code
 says "fail". A test that only exercised the new code would not prove a hole was closed.
 """
+import contextlib
+import io
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -289,8 +292,22 @@ class GateStillWorksTests(unittest.TestCase):
 
     def test_a_real_tree_header_still_parses(self):
         """Guards the repo-root resolution added here: a relative path from --changed
-        must be read against the repository, not the process cwd."""
-        self.assertEqual(C.main(["include/Amp.h"]), 0)
+        must be read against the repository, not the process cwd.
+
+        The header is `include/dActor_c.h` because the cartridge's own RTTI spells
+        that class `8dActor_c` -- it is not a coined name awaiting a rename, so the
+        path cannot go dead under check_dead_references. And rc == 0 alone would be
+        satisfied by a header the parser SKIPPED, which is the failure mode this
+        whole file exists to catch, so assert the gate did real work as well.
+        """
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = C.main(["include/dActor_c.h"])
+        out = buf.getvalue()
+        self.assertEqual(rc, 0, out)
+        self.assertRegex(out, r"(\d+) commented fields, 0 mismatched")
+        self.assertGreater(int(re.search(r"(\d+) commented fields", out).group(1)), 0,
+                           "a header the parser checked zero fields in proves nothing")
 
     def test_the_cli_entry_point_still_returns_the_gates_verdict(self):
         r = subprocess.run([sys.executable, str(TOOLS / "check_header_offsets.py")],


### PR DESCRIPTION
## Re-cut of #2070. Right diagnosis, wrong substitute — and today's red `main` proves the diagnosis.

#2070 has been sitting at the same head for nine hours with the ask unanswered, so I have re-cut it rather than let a correct idea rot. **It should be closed in favour of this.** Full credit for the finding is its; I only changed which header it points at, and added the assertion that makes the choice self-guarding.

### The premise is correct, and it went off today

`check_dead_references` resolves any `a/b`-shaped token in a comment or docstring as a live repo-rooted path. So a class-specific path hard-coded in tool prose is a **reference**, and it dies when the class is renamed. That is exactly right.

It is also not hypothetical. `main` went red on `dead references` **two hours ago** (`6d8f8e529`, fixed in #2073) because a docstring in `tools/test_tubuild.py` named `src/func_ov006_020f8224.c` and #2071 promoted that file into a TU. Same mechanism, different trigger.

### But the substitute has the same defect

#2070 replaces `include/Amp.h` with `include/Camera.h`. Both are coined names the cartridge contradicts. From `tools/rtti_name_audit.py --class`, which walks `_ZTV-4 → _ZTI → _ZTS` in the ROM images:

```
dActor_c   _ZTV8dActor_c @ 0x0208e3a4 (arm9)   ROM name 8dActor_c    AGREES
Camera     _ZTV6Camera   @ 0x02086f84 (arm9)   ROM name 9dCamera_c   DISAGREES
Amp        _ZTV3Amp      @ 0x02123278 (ov070)  ROM name 7daBrq_c     DISAGREES
```

Both sides of #2070's swap are in the 259-of-541 coined set, and both are scheduled for rename. The PR's own reason for existing applies to its own fix.

This one uses `include/dActor_c.h` and `include/dScMgBase_c.h`. Both agree with the cartridge, and `dActor_c` is `TI[2]` of most actor classes — nothing above it can re-key its name.

### The part #2070 did not ask for, which matters more

`test_a_real_tree_header_still_parses` asserted only that the gate returns 0:

```python
self.assertEqual(C.main(["include/Amp.h"]), 0)
```

A header the parser **skipped** satisfies that just as well as one it checked:

```
include/dActor_c.h  rc=0  33 commented fields, 0 mismatched, 0 unparsed, spans 0xd0
include/fBase_c.h   rc=0  skipped -- polymorphic C++ struct, implicit vptr not modelled
```

`fBase_c` also agrees with the cartridge, so it passes the naming criterion and is still useless as a test subject — an agreeing name is necessary, not sufficient. And "reported a pass and checked nothing" is the precise failure mode this test file's own module docstring says it exists to catch:

> *a gate that looks at the wrong (empty) set of files reports a pass exactly as convincingly as one that looks at the right set and finds nothing wrong.*

The test had that hole itself. It now reads the gate's stdout and requires a positive checked-field count, so a future substitution into a skipped header fails loudly. I verified both directions: `dActor_c.h` passes, `fBase_c.h` would fail.

### marker_evidence.py

#2070 rewrote the concrete struct sketch into abstract prose. Only the *path* could ever go dead, so this keeps the sketch and drops the path, plus a line saying why so it does not get restored:

```python
    A byte-matching migrated file declared, in effect,
    `struct Amp : Actor { ModelAnim m0; /* 0xd4 */ ... }`, so both the offsets
    and the class names in it are pinned by the ROM's own relocations.

    Named by class, not by path, on purpose: check_dead_references resolves any
    `a/b`-shaped token in prose as a live repo-rooted reference, and the file
    this came from is a per-symbol one -- those die on rename AND on TU
    promotion, which folds them into src/actors/<Class>.cpp.
```

`Amp` stays as the class name in the sketch because that is the file it was actually read out of and a bare class name is invisible to the gate. Only the path token was ammunition.

Per-symbol files are worth calling out separately: `src/_ZN3AmpD1Ev.cpp` dies **twice over** — on rename, and on TU promotion. Promotion deletes those by the dozen (#2071 removed 23 in one go), so it is by far the more frequent killer.

### Verified

```
check_dead_references    no new dead references / no broken markdown links
check_python_names       PASS (262 files, 0 unresolvable)
test_check_header_offsets  20 passed
marker_evidence            imports cleanly
```

Measured in a toolchain-wired worktree at `1090f44c5`. Pre-push ran port-refcheck 405/405, duplicate-sources 11110 stems, `src_tu` 95/95 compiled.
