### PR TITLE
tools: fix test_tubuild expectations that demanded #2066's defect back

### DIFF
--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -151,12 +151,29 @@ def test_verify_reproduces_pilot_1s_7_of_7_and_clean_objisolate():
     # the vtable-addend bug (PoleLift_Spawn's `+2` fix) would show here as a
     # failure even though the byte compare above is a false-green 7/7.
     assert "objisolate check  : clean" in out
-    # The one documented, non-fixable anomaly (pilot report sec 3): the compiler
-    # emits D2/D0/D1 in a fixed order that puts D0 before D1, opposite the ROM.
-    assert "1 ordinal pair(s) NOT in ROM order: [(0, 1)]" in out
+    # THIS ASSERTED THE ANOMALY ITSELF UNTIL #2066 FIXED IT, AND WENT ON ASSERTING
+    # IT AFTERWARDS -- so the test demanded the defect back. The pilot report called
+    # it non-fixable: an out-of-line ~PoleLift() makes mwccarm emit D2/D0/D1 in a
+    # fixed order that puts D0 before D1, opposite the ROM. Defining the destructor
+    # in the class body of PoleLift itself emits exactly the ROM's two variants in
+    # the ROM's order. Measured across 467bde020^ -> 467bde020 with both files
+    # swapped together: 37 sections / D2 present / "1 ordinal pair(s) NOT in ROM
+    # order: [(0, 1)]" before, 35 / no D2 / "ALL MATCH, ROM order" after.
+    #
+    # Asserted as an ABSENCE on purpose, so that reintroducing an out-of-line
+    # definition fails HERE rather than silently restoring a homeless D2 and an
+    # out-of-order pair.
+    assert "NOT in ROM order" not in out, out
+    assert "all 7 function(s) in the expected ROM-ascending section order" in out
     assert "Result: 7/7 MATCH, objisolate clean, reloc-destinations clean -> TEXT-VERIFIED" in out
-    # 1 unlicensed .text (D2) + 11 unlicensed .data (the vtable + the RTTI records)
-    # = 12 -- present and correctly refusing promotion, not silently dropped.
+    # 11 unlicensed .data (the vtable + the RTTI records) and NO unlicensed .text --
+    # present and correctly refusing promotion, not silently dropped.
+    #
+    # This read 12 until #2066, the twelfth being the unlicensed .text D2 that an
+    # out-of-line destructor emitted. Promotion is still refused, but for a narrower
+    # reason: what remains is _ZTI8PoleLift/_ZTS8PoleLift, for which no
+    # compiler_only_output disposition is admissible while PoleLift carries a coined
+    # name the cartridge contradicts.
     #
     # THE PILOT'S SEC 4 INVENTORY SAID 15, AND SO DID THIS LINE UNTIL IT WAS MEASURED.
     # The extra three were Platform's: two out-of-line vague-linkage destructors and
@@ -167,25 +184,44 @@ def test_verify_reproduces_pilot_1s_7_of_7_and_clean_objisolate():
     # and 37 / 12 at dedaa139e -- so this expectation went stale at #1555, 116 pull
     # requests before the collision rename (#1643) that later stopped the file
     # compiling at all and hid the staleness behind a compile error.
-    assert "12 unlicensed section/symbol(s) present -> PROMOTION REFUSED" in out
-    assert "_ZN8PoleLiftD2Ev" in out and "_ZTV8PoleLift" in out
+    assert "11 unlicensed section/symbol(s) present -> PROMOTION REFUSED" in out
+    assert "_ZTV8PoleLift" in out
+    assert "_ZN8PoleLiftD2Ev" not in out, "an out-of-line ~PoleLift() is back; see #2066"
 
 
 def test_compile_report_matches_the_pilots_object_inventory():
-    """37 sections, 8 .text, 11 .data, reproduced independently by tubuild.py's own
+    """35 sections, 7 .text, 11 .data, reproduced independently by tubuild.py's own
     ELF walk.
 
-    notes/tu-reconstruction-pilot-report.md sec 4 records 43/10/12, which is what this
-    file emitted until #1555 anchored Platform's vtable and its two out-of-line
-    destructors in Platform's own TU -- three fewer vague-linkage symbols here, and
-    six fewer sections because each brings its own relocation section. The measurement
-    is in test_verify_reproduces_pilot_1s_7_of_7_and_clean_objisolate above.
+    These numbers have now gone stale TWICE, both times because a vague-linkage
+    symbol stopped being emitted here, and each time the section count fell by two
+    per symbol -- the section itself plus its own relocation section.
+
+      43 / 10 / 12  notes/tu-reconstruction-pilot-report.md sec 4
+      37 /  8 / 11  #1555 anchored Platform's vtable and its two out-of-line
+                    destructors in Platform's own TU by giving Platform a key
+                    function -- three fewer vague-linkage symbols, six fewer sections
+      35 /  7 / 11  #2066 moved ~PoleLift() into the class body, so mwccarm no longer
+                    emits the D2 variant the cartridge does not contain -- one fewer
+                    .text and its .rela.text
+
+    Measured, not inferred: compiling this TU's shadow source together with PoleLift's
+    own class header at 467bde020^ -- both, because the pre-#2066 shadow source does
+    not compile against the post-#2066 header, which is why the staleness surfaced as
+    a failing assert rather than a quietly wrong number -- reads 37 sections with
+    _ZN8PoleLiftD2Ev present; at 467bde020 it reads 35 without.
+
+    Neither file is named by path here on purpose. PoleLift is a coined name the
+    cartridge contradicts (ROM RTTI: 18daObjKm2_Ami_Bou_c), the rename is a
+    prerequisite for promoting this very TU, and check_dead_references resolves any
+    a/b-shaped token in a docstring as a live repo-rooted reference -- so a path
+    naming this class is a dead reference with a scheduled fuse.
     """
     if not _toolchain():
         return
     code, out = _run("compile", "ov045/PoleLift")
     assert code == 0, out
-    assert "sections (37):" in out
+    assert "sections (35):" in out
     # Anchored to the section-LISTING line shape ("[ NN] .text  type=SHT_..."), not
     # a bare substring: "-> section[N] .text  size=..." in the function-mapping
     # block below it also contains the text "] .text ", which a plain count()
@@ -193,9 +229,12 @@ def test_compile_report_matches_the_pilots_object_inventory():
     import re
     n_text = len(re.findall(r"\[\s*\d+\] \.text\s+type=SHT_", out))
     n_data = len(re.findall(r"\[\s*\d+\] \.data\s+type=SHT_", out))
-    assert n_text == 8, f"expected 8 .text sections, counted {n_text}"
+    assert n_text == 7, f"expected 7 .text sections, counted {n_text}"
     assert n_data == 11, f"expected 11 .data sections, counted {n_data}"
-    assert "UNLICENSED function symbols (1)" in out
+    # No unlicensed .text at all since #2066, so tubuild prints no function block --
+    # asserted as an absence rather than a count of zero, because that is what the
+    # tool emits.
+    assert "UNLICENSED function symbols" not in out, out
     assert "UNLICENSED object/data symbols (11)" in out
     assert (REPO / "build" / "tu" / "ov045-PoleLift" / "inventory.txt").is_file()
     assert (REPO / "build" / "tu" / "ov045-PoleLift" / "PoleLift.o").is_file()


### PR DESCRIPTION
## One of these tests asserted the defect #2066 fixed

`tools/test_tubuild.py` has two failing assertions (`52 passed / 2 failed` on `main` at `6c7d35b0c`). Task #79 asked whether that is (a) stale expected strings or (b) a real `PoleLift` regression from the #2066 inline-destructor flip, and said to read the actual output before assuming (a).

Measured, and it is (a) — but with a sting. One of the two is not merely stale. It **asserts the anomaly #2066 removed**:

```python
# The one documented, non-fixable anomaly (pilot report sec 3): the compiler
# emits D2/D0/D1 in a fixed order that puts D0 before D1, opposite the ROM.
assert "1 ordinal pair(s) NOT in ROM order: [(0, 1)]" in out
```

An out-of-line destructor makes mwccarm emit `D2/D0/D1` with D0 ahead of D1, opposite the cartridge. #2066 (`467bde020`) moved the destructor into the class body, and the compiler then emits exactly the ROM's two variants in the ROM's order. So this test now demands the defect back: **the only way to make it pass by "fixing the code" would be to revert #2066.** That is worth more than the numbers below.

## Measured, not inferred

I reverted both #2066 files together — the shadow source alone will not compile against the post-#2066 header (`object 'PoleLift::~PoleLift()' redefined`), which is precisely why this surfaced as a failing assert rather than a quietly wrong number — and ran `tubuild.py compile` on each side:

| | sections | `.text` | unlicensed | D2 | ordinal check |
|---|---|---|---|---|---|
| `467bde020^` | 37 | 8 | 12 | `_ZN8PoleLiftD2Ev` present | `1 ordinal pair(s) NOT in ROM order: [(0, 1)]` |
| `467bde020` | 35 | 7 | 11 | absent | `ALL MATCH, ROM order` |

**Section arithmetic:** each vague-linkage symbol that stops being emitted costs *two* sections — the section itself plus its own `.rela`. That is 43 → 37 at #1555 (three symbols: Platform's vtable and its two out-of-line destructors, anchored by giving Platform a key function) and 37 → 35 here (one). The docstring now carries all three rows so the next drift is diagnosable instead of mysterious.

## Stale expectations become regression guards

Bumping `37` to `35` would fix the red and lose the information. Each stale expectation is instead restated as an **absence**, so reintroducing an out-of-line definition fails loudly right here:

```python
assert "NOT in ROM order" not in out, out
assert "all 7 function(s) in the expected ROM-ascending section order" in out
assert "_ZN8PoleLiftD2Ev" not in out, "an out-of-line ~PoleLift() is back; see #2066"
assert "UNLICENSED function symbols" not in out, out
```

The last one is an absence rather than `"(0)"` because `tubuild.py compile` prints no function block *at all* when the count is zero. Asserting a count of zero would never have matched.

Promotion is still correctly refused, but for a narrower reason than before: what remains unlicensed is `_ZTI8PoleLift`/`_ZTS8PoleLift`, for which no `compiler_only_output` disposition is admissible while the class carries a coined name the cartridge contradicts.

## Negative control

Same discipline as #2074 — a guard nobody has watched fail is a guess. Reverting both files to `467bde020^` fails the new assertion:

```
FAILED tools/test_tubuild.py:166 -- assert "NOT in ROM order" not in out
```

The guards have teeth. (A third assertion at line 112 also fails in that mixed state; that is an artifact of old source against today's manifest and I am not claiming it as evidence.)

## No path names PoleLift

The new prose names the class and the mangled symbols, never a file path. `PoleLift` is a coined name the cartridge contradicts —

```
_ZTV8PoleLift @ 0x02112dbc (ov045)   ROM name 18daObjKm2_Ami_Bou_c   DISAGREES
```

— and the rename is a *prerequisite* for promoting this very TU, so `include/PoleLift.h` and `src_tu/actors/PoleLift.cpp` are dead references with a scheduled fuse. That is the defect class #2074 landed to remove, and I caught two of them in my own first draft here. The docstring says why, so the next reader does not restore the paths as a helpful clarification.

## Gates

Base is `6c7d35b0c` = current `origin/main`, and `git merge-base --is-ancestor origin/main HEAD` succeeds, so **the merge tree is the branch tree** — these are merge-tree measurements, not proxies:

```
pytest tools/test_tubuild.py      54 passed          (was 52 passed / 2 failed)
check_dead_references             no new dead references, no broken links
check_python_names                PASS, 0 unresolvable
working tree                      only tools/test_tubuild.py; tracked config untouched
```

Single file, tools-only, no `src/`, no `config/`, no generated state. `check_dead_references` still reports `1 baselined reference(s) now resolve` — that is the pre-existing stale `src/game/actors` baseline entry, not a failure and not from this branch; it is filed separately and deliberately kept out of this PR.

## Deliberately split out

`tools/test_tubuild.py` has **10 sites** of `if not _toolchain(): return` — a silent vacuous PASS, the same false-green shape the worktree skill warns about. `.github/workflows/tool-tests.yml` already documents it (`test_tubuild 28 real pass / 15 vacuous / 2 fail`, "`return` guards become skips"). Converting them to real skips needs a decision about taking a `pytest` import dependency in this file, which is a different question from this one, so it is not bundled here.
