### PR TITLE
config: drop the stale src/game/actors dead-reference baseline entry

### DIFF
--- a/config/dead-reference-baseline.json
+++ b/config/dead-reference-baseline.json
@@ -243,10 +243,6 @@
   },
   {
    "file": "notes/src-domain-buckets.md",
-   "ref": "src/game/actors"
-  },
-  {
-   "file": "notes/src-domain-buckets.md",
    "ref": "src/runtime/graphics/fader"
   },
   {


### PR DESCRIPTION
## A baselined reference that *resolves* is a pre-armed mask

`check_dead_references` has been printing this on every run against `main`:

```
1 baselined reference(s) now resolve -- run --update to shrink the baseline (not a failure)
```

The entry is:

```json
{ "file": "notes/src-domain-buckets.md", "ref": "src/game/actors" }
```

It went stale when #1985 landed `src/game/actors/WingFeather/`, which made the path resolve. Produced by `tools/check_dead_references.py --update`, which removed **exactly this one entry and added none** — 133 → 132.

"Not a failure" is right today and wrong tomorrow. TU promotion is a mass path-deletion event — #2071 removed 23 per-symbol files in one commit — so if that directory is ever consolidated away, this entry absorbs the break *silently* instead of failing. That is the same class of hole as [`two-green-prs-can-make-a-red-main`], one step earlier in the chain.

## Negative control

Measured, not argued. Removing `WingFeather` from **both the index and disk** (my first attempt moved it only on disk and nothing changed — the checker resolves via `git ls-files`, so an on-disk move is invisible to it), then running the checker under each baseline:

| baseline | result | `notes/src-domain-buckets.md` → `src/game/actors` |
|---|---|---|
| entry present | `FAIL: 3 prose reference(s) name a path that does not exist` | **masked** |
| entry removed | `FAIL: 4 prose reference(s) name a path that does not exist` | ``names `src/game/actors`, which is not in the tree`` |

`diff` of the two runs is exactly that one row. The removal is what restores the signal, and nothing else moves.

## What I deliberately did *not* bundle

The other 3 rows in that control are pre-existing and unbaselined — they already fire. They are **per-symbol paths** in `notes/actor-leaf-provenance.md`:

```
src/game/actors/WingFeather/_ZN11WingFeather13InitResourcesEv.cpp
src/game/actors/WingFeather/_ZN11WingFeather8BehaviorEv.cpp
src/game/actors/WingFeather/_ZN11WingFeather6RenderEv.cpp
```

Doomed twice over: by promotion, and by the rename promotion requires — `WingFeather` is a coined name the cartridge contradicts.

```
_ZTV11WingFeather @ 0x021088a8 (ov002)   ROM name 11daFeather_c   DISAGREES
```

I measured the tree-wide scale before deciding whether to fix them here: **622 per-symbol path mentions across 90 prose files** (`notes/smartball-provenance.md` 67, `notes/bgobject-provenance.md` 67, `notes/actor-leaf-provenance.md` 44, …). That is a real backlog and it is not a `sed` — each mention needs the *reason* written into the prose, or the next reader restores the path as a helpful clarification. It is filed separately rather than smuggled into a single-entry config change.

## Gates

Base is `eace12bd8` = current `origin/main`, and `git merge-base --is-ancestor origin/main HEAD` succeeds, so **the merge tree is the branch tree** — these are merge-tree measurements, not proxies:

```
check_dead_references            no new dead references, no broken links, warning GONE
pytest test_check_dead_references  29 passed
check_python_names               PASS
```

Both consumers of this file — `.github/workflows/dead-references.yml` and `.github/workflows/tool-tests.yml` — are covered by those two runs.

Config only. One file, four deleted lines, no `src/`, no `tools/`, no generated state.
