### PR TITLE
check_header_offsets: model the root vptr instead of skipping the struct (18 silent skips -> 0, +52 verified offsets)

### DIFF
--- a/config/header-offset-known-issues.txt
+++ b/config/header-offset-known-issues.txt
@@ -33,3 +33,55 @@ include/math/Fix12.h
 # Whichever it is, it is a pre-existing question about this header and not something the
 # validator work that wired this gate up should have been deciding.
 include/dScMgSlot1_c.h
+
+# --- unskipped by the root-vptr change; each is a PARSER limit, not a layout defect ---
+# Until this batch landed, tools/check_header_offsets.py bailed out of any ROOT struct
+# the moment it saw a method declaration, on the grounds that a polymorphic root's
+# implicit vptr made the running offset underivable. It is derivable -- the tree writes
+# the model down by hand in Animation.h and dCc_c.h -- so the bail-out is gone and nine
+# of the eighteen headers it was hiding now check clean. These nine still do not, each
+# for a reason that is about the tool's textual walk and not about the header. Every
+# offset comment below is believed correct; none of these is a known layout question.
+
+# `Manager manager;` is fBase_c::Manager -- SceneNode(0x14) + 2 * fLiNdBaPr_c(0x10) =
+# 0x34. CLASS_SIZES is keyed by the bare tag, so it answered with
+# `Manager_size_must_be_0x3c` from include/Particle__Manager.h, an unrelated
+# Particle::Manager, and reported the two fields after it 8 bytes late -- against a
+# header whose own `fBase_c_size_must_be_0x50` proves the comments right. The gate now
+# refuses instead of guessing (see _shadowed_by_nested). Deriving a local size for a
+# nested body that carries inline method definitions retires this entry.
+include/fBase_c.h
+
+# A pointer to MEMBER function -- `typedef void (dMgState_c::*Callback)();` -- is 8
+# bytes on this ABI, not 4, and DECL has no notion of one. Three members each.
+include/dMgState_c.h
+include/dMg3DEspModel_c.h
+
+# `TouchIcon_c mIcons[8];`. The type DOES assert its size, as
+# `dMgPsOpt_TouchIcon_c_size_must_be_0x24` -- the tree already invented an
+# outer-qualified assert name to keep a nested tag from colliding with a top-level one,
+# which is the very collision fBase_c::Manager fell into. The tool only ever looks up
+# the bare tag, so it never finds it. Teaching the lookup that convention retires this.
+include/dMgPsOpt_c.h
+
+# `class X : public Y {` nested inside dPa_c. The nested-type consumer matches `struct`
+# only, so the body is not consumed and its `public:` falls through as a declaration.
+include/dPa_c.h
+
+# `struct anmModel_c : ModelAnim, virtual ScaleHolder {` nested inside daDemo_c. The
+# nested-type consumer allows exactly one base and no `virtual`, so it does not match.
+include/daDemo_c.h
+
+# `CLPS_BlockRef &operator=(CLPS_Block &block);`. The method-declaration pattern's type
+# character class has no `=` in it, so an assignment operator is not recognised as a
+# method and is read as a field.
+include/CLPS_BlockRef.h
+
+# A function-POINTER member split across three lines (`void (*beforeClsnCallback)(...)`
+# with its parameter list wrapped). DECL is line-at-a-time.
+include/dBgW.h
+
+# Inline-DEFINED structors -- `dThIcon_c() {}`. The method-declaration pattern requires
+# a trailing `;`, which a defined-in-place body does not have, so both lines fall
+# through to DECL. Note the field list here is empty, so nothing is left unchecked.
+include/dThIcon_c.h

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -119,10 +119,15 @@ IGNORABLE = re.compile(r"^\s*($|/\*|\*|//|\}|#)")
 # rglob, not glob: Matrix4x3 and Matrix3x3 assert their sizes in include/math/,
 # so a non-recursive scan missed exactly the two that Model.h and friends embed.
 CLASS_SIZES = {}
+# ...and WHERE each one came from. The table is keyed by the bare tag, so two
+# classes of the same name in different headers are one entry -- see
+# _shadowed_by_nested below, which needs the origin to tell them apart.
+CLASS_SIZE_SRC = {}
 for _h in pathlib.Path(__file__).resolve().parents[1].joinpath("include").rglob("*.h"):
     for _m in re.finditer(r"(\w+)_size_must_be_(0x[0-9a-fA-F]+)",
                           _h.read_text(errors="replace")):
         CLASS_SIZES[_m.group(1)] = int(_m.group(2), 16)
+        CLASS_SIZE_SRC[_m.group(1)] = _h
 SZ.update(CLASS_SIZES)
 
 # A derived class's own fields start at the base's DATA SIZE, not its sizeof.
@@ -391,6 +396,78 @@ def _resolve_paths(argv, repo=None):
     return argv, 0
 
 
+def _nested_names(all_lines):
+    """Tags defined as a NESTED type somewhere in this file.
+
+    Indentation is the test, which is what the field walk below already uses to
+    tell a nested definition from the outer one, so the two agree by construction.
+    """
+    out = set()
+    for line in all_lines:
+        m = re.match(r"^[ \t]+(?:struct|union|class) (\w+)\s*(?::\s*(?:public\s+)?\w+\s*)?\{", line)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def _shadowed_by_nested(typ, nested_names, fp):
+    """True when SZ[typ] is about a DIFFERENT class than the one `typ` names here.
+
+    CLASS_SIZES is keyed by the bare tag -- it has no way to record a qualified
+    name -- so a class nested inside the struct under test silently borrows the
+    size of any unrelated top-level class that happens to share its tag.
+
+    Measured, one instance in the tree and it is not a small one:
+    `fBase_c::Manager` is SceneNode(0x14) + 2 * fLiNdBaPr_c(0x10) = 0x34, but
+    `Manager_size_must_be_0x3c` in include/Particle__Manager.h describes
+    Particle::Manager. The checker took 0x3c and reported the two fields after it
+    8 bytes late -- against a header whose own `fBase_c_size_must_be_0x50`
+    assertion proves the comments right and the checker wrong. This was invisible
+    while fBase_c.h was skipped wholesale; unskipping it is what exposed it.
+
+    Refuse rather than guess. A local size is derivable in principle, but a nested
+    body carries inline method bodies that the narrow learner above will not walk,
+    and a WRONG size here is worse than an honest UNPARSED: it shifts every later
+    field and each one still "matches" if the comments were written from the same
+    wrong model.
+    """
+    if typ not in nested_names or typ not in CLASS_SIZE_SRC:
+        return False
+    # Compare RESOLVED paths. CLASS_SIZE_SRC is built by rglob from an absolute repo
+    # root while `fp` arrives from the command line, so `include/dScEntry_c.h` and
+    # `C:/...
+    # /include/dScEntry_c.h` are the same file and unequal as Path objects. Comparing
+    # them raw made a type asserted in its OWN header -- dScEntry_c::icon_c, whose
+    # `icon_c_size_must_be_0x24` sits nine lines below the struct -- look shadowed,
+    # turning a header that checked 9 fields clean into an UNPARSED failure.
+    try:
+        return CLASS_SIZE_SRC[typ].resolve() != pathlib.Path(fp).resolve()
+    except OSError:
+        return CLASS_SIZE_SRC[typ] != fp
+
+
+def _root_offset(all_lines, open_lineno):
+    """Offset of the first field of a ROOT struct whose body opens at `open_lineno`.
+
+    4 when the struct is polymorphic and leaves its vptr implicit, 0 otherwise.
+
+    Scoped to THIS struct's body on purpose. A twin header carries a flat C view of
+    the same class below an `#else`, and that half routinely spells `void *vtable;`
+    even when the C++ half above it does not -- Animation.h is exactly that shape. A
+    file-wide search for either marker reads the wrong half and silently shifts every
+    field of the right one by 4.
+    """
+    virtual = vtable_field = False
+    for line in all_lines[open_lineno:]:
+        if re.match(r"^\};", line):
+            break
+        if re.match(r"^\s*virtual\s", line):
+            virtual = True
+        elif re.match(r"^\s*[A-Za-z_][^;]*[ *]vtable\s*;", line):
+            vtable_field = True
+    return 4 if (virtual and not vtable_field) else 0
+
+
 def main(argv, repo=None):
     """Check every header `argv` resolves to. Exit code is the gate's verdict."""
     root = pathlib.Path(repo) if repo else REPO
@@ -416,7 +493,9 @@ def main(argv, repo=None):
         skip_body = 0
         unknown_base = derived_from = None
         expected = fp.stem
-        for lineno, line in enumerate(txt.splitlines(), 1):
+        all_lines = txt.splitlines()
+        nested_names = _nested_names(all_lines)
+        for lineno, line in enumerate(all_lines, 1):
             if not started:
                 # A struct-with-body BEFORE the file's own class is a helper type
                 # (ActorBase_SceneNode in fBase_c.h, KCL_Tri in dBgW_Kc.h,
@@ -452,6 +531,23 @@ def main(argv, repo=None):
                         continue
                     started = True
                     base = m0.group(2)
+                    if base is None:
+                        # A ROOT class has no base sub-object, but it is not therefore
+                        # at offset 0: a POLYMORPHIC root places one implicit 4-byte
+                        # vptr at 0x00. That is not a guess -- the tree already writes
+                        # the model down by hand, verbatim in Animation.h and dCc_c.h:
+                        #
+                        #   /* 0x00 is the vptr, placed implicitly by the first
+                        #      virtual declaration. */
+                        #
+                        # ...UNLESS the struct declares the vptr as a REAL field. The
+                        # flat port-side headers do exactly that -- ArrowSignRight.h
+                        # opens `void *vtable;  /* 0x000 */` -- and there the comments
+                        # already count it, so starting at 4 double-counts and every
+                        # field after it reads 4 bytes late. Ten-plus headers in this
+                        # tree declare a literal vtable field, so this is a real fork,
+                        # not a special case for one file.
+                        off = _root_offset(all_lines, lineno)
                     if base is not None:
                         # A derived struct's own fields do NOT start at 0 -- the base
                         # sub-object is there. Guessing 0 would mismatch every field,
@@ -528,9 +624,6 @@ def main(argv, repo=None):
                 # class places no vptr of its own -- it inherits the base's, and the
                 # base's asserted size already counts it. The running offset is sound,
                 # so the member functions merely end the field list.
-                if derived_from is None:
-                    unmodelled = True
-                    break
                 # A derived class can ALSO declare its destructor/overrides FIRST
                 # (dScene_c.h's KEY FUNCTION convention -- "the destructor is declared
                 # first, which is safe for a derived class"). Before any real field
@@ -557,7 +650,10 @@ def main(argv, repo=None):
                 in_comment = True
             m = DECL.match(line)
             typ = m.group(1).rsplit("::", 1)[-1] if m else None
-            w = 4 if (m and m.group(2)) else SZ.get(typ)
+            if m and not m.group(2) and _shadowed_by_nested(typ, nested_names, fp):
+                w = None
+            else:
+                w = 4 if (m and m.group(2)) else SZ.get(typ)
             if w is None:
                 # An unrecognised declaration is NOT harmless: skipping it leaves the
                 # running offset short, so every later field silently "matches" at the

--- a/tools/test_check_header_offsets.py
+++ b/tools/test_check_header_offsets.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 
 TOOLS = pathlib.Path(__file__).resolve().parent
 REPO = TOOLS.parent
@@ -353,3 +354,195 @@ class RealHistoryTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ------------------------------------------------- defect 3: the root-vptr bail-out
+#
+# The pre-fix code refused to model any ROOT struct the moment its body reached a
+# method declaration, on the grounds that a polymorphic root carries an implicit vptr
+# that no declaration mentions. The offset IS derivable, and the tree writes the model
+# down by hand -- verbatim, in include/Animation.h and include/dCc_c.h:
+#
+#   /* 0x00 is the vptr, placed implicitly by the first virtual declaration. */
+#
+# The bail-out also fired for structs with no `virtual` anywhere, because its third
+# alternative matches ANY member-function declaration. Eighteen headers were skipped
+# whole: no summary, no mismatch, no non-zero exit. Nine of them check clean now; the
+# other nine are enumerated in config/header-offset-known-issues.txt with the parser
+# limit that stops each one.
+
+# The predicate of the deleted arm, VERBATIM, so the cases below stay planted
+# regressions rather than tests of the new code alone.
+_OLD_BAILOUT = re.compile(
+    r"^\s*(virtual\b|~\w+\s*\([^;]*\)\s*;|[A-Za-z_][\w:<>, &*]*\([^;]*\)\s*(const)?\s*;)")
+
+
+def _skipped_the_old_way(body):
+    """True when the pre-fix code declared this ROOT struct unmodelled and skipped it."""
+    started = False
+    for line in body.splitlines():
+        if not started:
+            started = bool(re.match(r"^\s*struct \w+\s*\{", line))
+            continue
+        if _OLD_BAILOUT.match(line):
+            return True
+    return False
+
+
+# A polymorphic root. Every offset counts the implicit vptr, so the first field is
+# 0x004 -- which is what the eight headers in this shape already say.
+POLY_GOOD = """\
+struct Widget {
+\tvirtual void Update();
+\tu32 first;   /* 0x004 */
+\tu32 second;  /* 0x008 */
+};
+"""
+# The same class with its comments written as though there were no vptr.
+POLY_BROKEN = POLY_GOOD.replace("0x004", "0x000").replace("0x008", "0x004")
+
+# A flat view that declares the vptr as a REAL field; include/ArrowSignRight.h is the
+# live instance. Its comments already count that field, so the walk must start at 0 --
+# adding 4 unconditionally would report every field of every such header 4 bytes late.
+FLAT_GOOD = """\
+struct Widget {
+\tvoid *vtable;  /* 0x000 */
+\tu32 first;     /* 0x004 */
+\tu32 second;    /* 0x008 */
+\tvirtual void Update();
+};
+"""
+FLAT_BROKEN = """\
+struct Widget {
+\tvoid *vtable;  /* 0x000 */
+\tu32 first;     /* 0x008 */
+\tu32 second;    /* 0x00c */
+\tvirtual void Update();
+};
+"""
+
+# No `virtual` anywhere. The bail-out's third alternative matches any member function,
+# so a struct that merely DECLARES a method was skipped -- include/dMgState_c.h and
+# include/dMg3DEspAnimSet_c.h are that shape, and neither is polymorphic.
+NONPOLY_GOOD = """\
+struct Widget {
+\tu32 first;   /* 0x000 */
+\tu32 second;  /* 0x004 */
+\tvoid Reset();
+};
+"""
+NONPOLY_BROKEN = NONPOLY_GOOD.replace("0x004", "0x008")
+
+
+class RootVptrTests(unittest.TestCase):
+    def test_every_fixture_below_was_skipped_whole_by_the_old_code(self):
+        """The precondition for all of it. If these were not skipped there was no hole."""
+        for name, body in (("POLY_GOOD", POLY_GOOD), ("POLY_BROKEN", POLY_BROKEN),
+                           ("FLAT_GOOD", FLAT_GOOD), ("FLAT_BROKEN", FLAT_BROKEN),
+                           ("NONPOLY_GOOD", NONPOLY_GOOD),
+                           ("NONPOLY_BROKEN", NONPOLY_BROKEN)):
+            self.assertTrue(_skipped_the_old_way(body),
+                            f"{name}: precondition failed, the old code checked this")
+
+    def test_a_polymorphic_root_is_modelled_and_a_wrong_offset_is_caught(self):
+        with Repo() as r:
+            r.write("include/Widget.h", POLY_GOOD)
+            self.assertEqual(r.run("include/Widget.h"), 0)
+        with Repo() as r:
+            r.write("include/Widget.h", POLY_BROKEN)
+            self.assertEqual(r.run("include/Widget.h"), 1,
+                             "a root whose comments ignore its vptr must not pass")
+
+    def test_an_explicitly_declared_vtable_field_is_not_double_counted(self):
+        with Repo() as r:
+            r.write("include/Widget.h", FLAT_GOOD)
+            self.assertEqual(r.run("include/Widget.h"), 0,
+                             "the vptr was counted twice for a header that spells it out")
+        with Repo() as r:
+            r.write("include/Widget.h", FLAT_BROKEN)
+            self.assertEqual(r.run("include/Widget.h"), 1)
+
+    def test_a_non_polymorphic_struct_gets_no_vptr_for_declaring_a_method(self):
+        with Repo() as r:
+            r.write("include/Widget.h", NONPOLY_GOOD)
+            self.assertEqual(r.run("include/Widget.h"), 0)
+        with Repo() as r:
+            r.write("include/Widget.h", NONPOLY_BROKEN)
+            self.assertEqual(r.run("include/Widget.h"), 1)
+
+    def test_the_vptr_decision_is_scoped_to_this_struct_not_the_whole_file(self):
+        """A twin header carries a flat C view of the same class below an `#else`, and
+        that half routinely spells `void **vtable;` even where the C++ half above it
+        does not -- include/Animation.h is exactly that shape. A file-wide search for
+        either marker reads the wrong half and shifts every field of the right one.
+
+        Not a planted regression, and it cannot be one: the old code skipped this
+        header whole, so it "passed" here for the wrong reason. What this guards is the
+        obvious WRONG way to write the new code -- grep the file for `virtual` and for
+        a vtable field -- which would read 0 here and report `first` at 0x000."""
+        twin = POLY_GOOD + """
+#else
+struct Widget {
+\tvoid **vtable;  /* 0x000 */
+\tu32 first;      /* 0x004 */
+};
+#endif
+"""
+        with Repo() as r:
+            r.write("include/Widget.h", twin)
+            self.assertEqual(r.run("include/Widget.h"), 0,
+                             "the C++ half's implicit vptr was cancelled by the flat "
+                             "half's vtable field")
+
+
+class NestedTagShadowTests(unittest.TestCase):
+    """CLASS_SIZES is keyed by the bare tag, so a class NESTED in the struct under test
+    silently borrows the size of any unrelated top-level class sharing that tag.
+
+    One instance in the tree, and unskipping fBase_c.h is what exposed it:
+    `fBase_c::Manager` is SceneNode(0x14) + 2 * fLiNdBaPr_c(0x10) = 0x34, but
+    `Manager_size_must_be_0x3c` in include/Particle__Manager.h describes an unrelated
+    Particle::Manager. The checker took 0x3c and reported the two fields after it 8
+    bytes late -- against a header whose own `fBase_c_size_must_be_0x50` assertion
+    proves the comments right and the checker wrong.
+
+    Refuse rather than guess: a wrong size shifts every later field, and each one still
+    "matches" if the comments were written from the same wrong model. An honest
+    UNPARSED is recoverable; a confident wrong number is not.
+    """
+
+    SHADOWED = """\
+struct Widget {
+\tstruct Manager {
+\t\tu32 a;
+\t\tu32 b;
+\t};
+
+\tu32 first;         /* 0x000 */
+\tManager manager;   /* 0x004 */
+\tu32 last;          /* 0x00c */
+};
+"""
+
+    def test_a_nested_tag_does_not_borrow_an_unrelated_headers_size(self):
+        with Repo() as r:
+            r.write("include/Widget.h", self.SHADOWED)
+            elsewhere = pathlib.Path(REPO) / "include" / "Elsewhere.h"
+            with unittest.mock.patch.dict(C.SZ, {"Manager": 0x3c}), \
+                    unittest.mock.patch.dict(C.CLASS_SIZE_SRC, {"Manager": elsewhere}):
+                self.assertEqual(r.run("include/Widget.h"), 1,
+                                 "an unrelated class's size was used silently")
+
+    def test_a_tag_asserted_in_its_OWN_header_is_still_used(self):
+        """Bounding the refusal. include/dScEntry_c.h nests `icon_c` and asserts
+        `icon_c_size_must_be_0x24` nine lines below it; comparing the two paths
+        unresolved -- CLASS_SIZE_SRC holds absolute rglob paths, `fp` arrives from
+        argv -- made that look like a shadow and turned a header that checked nine
+        fields clean into an UNPARSED failure."""
+        with Repo() as r:
+            r.write("include/Widget.h", self.SHADOWED)
+            own = r.dir / "include" / "Widget.h"
+            with unittest.mock.patch.dict(C.SZ, {"Manager": 8}), \
+                    unittest.mock.patch.dict(C.CLASS_SIZE_SRC, {"Manager": own}):
+                self.assertEqual(r.run("include/Widget.h"), 0,
+                                 "a size asserted in this very header must still count")


### PR DESCRIPTION
`check_header_offsets` bailed out of any **root** struct the moment its body reached a method declaration, on the theory that a polymorphic root's implicit vptr makes the running offset underivable. It printed nothing for those headers — no summary, no mismatch, no non-zero exit. A silent skip reads exactly like a pass.

It is derivable, and **the tree already writes the model down by hand**. `include/Animation.h` and `include/dCc_c.h` say it verbatim:

```c
/* 0x00 is the vptr, placed implicitly by the first virtual declaration. */
```

## Measured, tree-wide over all 507 tracked headers

|  | summaries | WAIVED | silent skips | verified offset comments |
|---|---|---|---|---|
| base (`f35cf8f4d`) | 485 | 4 | **18** | 3150 |
| this PR | 494 | 13 | **0** | **3202** |

`rc=0`, **0 MISMATCH, 0 UNPARSED**. 9 headers newly summarised, **0 lost**, and **0 field-count changes** on the 485 already summarised — `Animation`, `ArrowSignRight`, `Fader`, `ModelBase`, `cMgSmartball_object_c`, `dBgCh`, `dCc_c`, `dM3dGSph`, `dMg3DEspAnimSet_c`. **+52 offset comments are now actually checked.**

One other row moves: `include/Clipper.h`'s reported span goes `0x0` → `0x4`. It has 0 commented fields before and after (its `#else` twin half stops the walk — separate issue), so nothing about its verification changes; the span is just now counting the vptr.

## The discriminator is load-bearing, not cosmetic

`_root_offset` returns 4 only when the struct is polymorphic **and** leaves its vptr implicit. Ten-plus flat headers declare `void *vtable;` as a real field and their comments already count it. Proof it matters — delete that one line from `include/ArrowSignRight.h`:

```
8 MISMATCH, every one off by exactly 4
struct spans 0x37c   (was 0x380 -- its documented allocation size)
```

The decision is scoped to **this struct's body**, not the file. A twin header's `#else` half routinely spells `void **vtable;` where the C++ half above does not (`include/Animation.h` is exactly that shape), and a file-wide search reads the wrong half and shifts every field of the right one.

The bail-out also fired for structs with **no `virtual` anywhere** — its third alternative matches any member-function declaration, so `include/dMgState_c.h`, documented in its own header as non-polymorphic, was skipped for the crime of declaring a method.

## Second defect — found *because* this change exposed it

This is the part worth reviewing hardest, because without it this PR would have turned a silent skip into a silently **wrong** offset computation, which is strictly worse than the skip.

`CLASS_SIZES` is a flat table keyed by the **bare tag**. A class nested inside the struct under test silently borrows the size of any unrelated top-level class sharing its name. One instance in the tree, and not a small one:

- `fBase_c::Manager` is `SceneNode(0x14) + 2 * fLiNdBaPr_c(0x10)` = **0x34**
- the table answered `Manager_size_must_be_0x3c` from `include/Particle__Manager.h` — an unrelated `Particle::Manager`
- the checker reported the two fields after it **8 bytes late**, against a header whose own `fBase_c_size_must_be_0x50` assertion proves the comments right and the checker wrong

Invisible while `fBase_c.h` was skipped wholesale. Unskipping it is what surfaced it.

**The gate now refuses rather than guesses.** A wrong size shifts every later field, and each one still "matches" if the comments were written from the same wrong model — an honest `UNPARSED` is recoverable, a confident wrong number is not. Deriving a local size for a nested body is worth doing and is a **separate** change: it has to walk inline method bodies the narrow learner here does not.

The refusal is **bounded to the shadowing case** — a tag asserted in its own header still counts. I got this wrong first: `CLASS_SIZE_SRC` holds absolute `rglob` paths while `fp` arrives from argv, so comparing them unresolved turned `include/dScEntry_c.h` (which nests `icon_c` and asserts `icon_c_size_must_be_0x24` nine lines below it) from 9 clean fields into an `UNPARSED` failure. Both sides are resolved now, and there is a test pinning it.

## Waivers, not skips

The other 9 headers move from a silent skip to an **enumerated** entry in `config/header-offset-known-issues.txt`, each with the parser limit that stops it written down. That file's own rule is *"this list should only ever shrink"*, and every one of the nine is a limit of the textual walk, **not** a layout question — every offset comment in them is believed correct:

| header | what stops the walk |
|---|---|
| `fBase_c.h` | the nested-tag shadow above; retired by a local nested-size learner |
| `dMgState_c.h`, `dMg3DEspModel_c.h` | pointer-to-**member**-function is 8 bytes on this ABI, and `DECL` has no notion of one |
| `dMgPsOpt_c.h` | the type *does* assert its size, as `dMgPsOpt_TouchIcon_c_size_must_be_0x24` — the tree already invented an outer-qualified assert name to dodge exactly the collision `fBase_c::Manager` fell into, and the tool only ever looks up the bare tag |
| `dPa_c.h` | the nested-type consumer matches `struct` only; this one is `class X : public Y {` |
| `daDemo_c.h` | nested-type consumer allows one base and no `virtual`; this is `: ModelAnim, virtual ScaleHolder` |
| `CLPS_BlockRef.h` | the method pattern's type character class has no `=`, so `operator=` is read as a field |
| `dBgW.h` | a function-pointer member wrapped across three lines; `DECL` is line-at-a-time |
| `dThIcon_c.h` | inline-**defined** structors — the method pattern needs a trailing `;`. Field list is empty, so nothing goes unchecked |

That `dMgPsOpt_c.h` row is the cheapest of the eight to retire and is the natural follow-up.

## Tests

7 new cases in the file's stated planted-regression style. **Verified against `origin/main`'s `tools/check_header_offsets.py` in a scratch tree: 5 fail there and pass here.** The other two cannot be planted regressions and say so in place rather than looking like they are — one *is* the precondition (that the deleted predicate, copied verbatim, matched every fixture), and the twin-scoping case guards the obvious wrong way to write the new code, which the old code never had a chance to get wrong because it skipped the header whole.

```
pytest tools/test_check_header_offsets.py -q   ->  27 passed
python tools/check_python_names.py             ->  PASS
python tools/check_dead_references.py          ->  no new dead references
```

Tools + config only. No `src/`, no `include/`, no generated state, no byte-affecting change.
