### PR TITLE
check_header_offsets: read the qualified name out of the size assertion itself

### DIFF
--- a/config/header-offset-known-issues.txt
+++ b/config/header-offset-known-issues.txt
@@ -57,12 +57,10 @@ include/fBase_c.h
 include/dMgState_c.h
 include/dMg3DEspModel_c.h
 
-# `TouchIcon_c mIcons[8];`. The type DOES assert its size, as
-# `dMgPsOpt_TouchIcon_c_size_must_be_0x24` -- the tree already invented an
-# outer-qualified assert name to keep a nested tag from colliding with a top-level one,
-# which is the very collision fBase_c::Manager fell into. The tool only ever looks up
-# the bare tag, so it never finds it. Teaching the lookup that convention retires this.
-include/dMgPsOpt_c.h
+# RETIRED from this list: include/dMgPsOpt_c.h. The lookup now reads the qualified
+# name out of the assertion's own sizeof() operand instead of trying to derive it from
+# the typedef identifier, so `dMgPsOpt_c::TouchIcon_c` resolves and the header walks to
+# `struct spans 0x128` -- exactly its own dMgPsOpt_c_size_must_be_0x128.
 
 # `class X : public Y {` nested inside dPa_c. The nested-type consumer matches `struct`
 # only, so the body is not consumed and its `public:` falls through as a declaration.

--- a/include/dMgPsOpt_c.h
+++ b/include/dMgPsOpt_c.h
@@ -13,10 +13,10 @@ struct dMgPsOpt_c {
         ~TouchIcon_c();
     };
 
-    TouchIcon_c mIcons[8];
-    s32 mSelectedIcon;
-    u8 mActive;
-    u8 pad_125[0x3];
+    TouchIcon_c mIcons[8];   /* 0x000..0x120 */
+    s32 mSelectedIcon;       /* 0x120 */
+    u8 mActive;              /* 0x124 */
+    u8 pad_125[0x3];         /* 0x125 */
 
     dMgPsOpt_c();
     ~dMgPsOpt_c();

--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -123,12 +123,72 @@ CLASS_SIZES = {}
 # classes of the same name in different headers are one entry -- see
 # _shadowed_by_nested below, which needs the origin to tell them apart.
 CLASS_SIZE_SRC = {}
+# ...and the same sizes keyed by their QUALIFIED name, read out of the assertion's
+# own `sizeof(...)` expression rather than out of its typedef identifier.
+#
+# The identifier cannot be trusted to spell the qualified name, because the tree's
+# convention for one is not mechanical. `dMgPsOpt_c::TouchIcon_c` is asserted as
+# `dMgPsOpt_TouchIcon_c_size_must_be_0x24` -- outer tag with its `_c` dropped -- and
+# `Particle::SysTracker::Contents` as `Particle_SysTracker_Contents_size_must_be_0x748`.
+# No rule derives `dMgPsOpt_TouchIcon_c` from `dMgPsOpt_c` and `TouchIcon_c` that does
+# not also have to guess. The sizeof() operand, though, is the real qualified name by
+# construction -- the compiler resolves it or the header does not build.
+#
+# Measured over all 507 headers when this was written: 486 assertions parse in full,
+# 26 of them qualified, and the typedef identifier's `_0xN` suffix agrees with the
+# expression's own constant in 486 of 486 cases. So this reads the same numbers the
+# bare-tag table already reads; it only learns a second, unambiguous key for them.
+CLASS_SIZES_QUALIFIED = {}
+# `== 6` as well as `== 0x6`: types.h asserts Vector3s in decimal, and it is the one
+# assertion in the tree that the full form would otherwise miss.
+_SIZE_ASSERT_FULL = re.compile(
+    r"typedef\s+char\s+(\w+)_size_must_be_(0x[0-9a-fA-F]+)\s*\[\s*"
+    r"sizeof\s*\(\s*(?:struct|class|union)?\s*((?:\w+\s*::\s*)*\w+)\s*\)\s*"
+    r"==\s*(0x[0-9a-fA-F]+|\d+)", re.S)
 for _h in pathlib.Path(__file__).resolve().parents[1].joinpath("include").rglob("*.h"):
-    for _m in re.finditer(r"(\w+)_size_must_be_(0x[0-9a-fA-F]+)",
-                          _h.read_text(errors="replace")):
+    _txt = _h.read_text(errors="replace")
+    for _m in re.finditer(r"(\w+)_size_must_be_(0x[0-9a-fA-F]+)", _txt):
         CLASS_SIZES[_m.group(1)] = int(_m.group(2), 16)
         CLASS_SIZE_SRC[_m.group(1)] = _h
+    for _m in _SIZE_ASSERT_FULL.finditer(_txt):
+        _expr = re.sub(r"\s+", "", _m.group(3))
+        if "::" in _expr:
+            CLASS_SIZES_QUALIFIED[_expr] = int(_m.group(2), 16)
+            # Only if nothing else claimed it: the bare-tag table above is what the
+            # shadow check reads, and a qualified entry must not overwrite the origin
+            # of a same-named top-level class.
+            CLASS_SIZE_SRC.setdefault(_expr, _h)
 SZ.update(CLASS_SIZES)
+
+
+def _qualified_size(outer, typ):
+    """Size of `typ` as written inside `outer`, from a QUALIFIED size assertion.
+
+    Returns None when no assertion names this nesting, which leaves the caller on
+    its existing bare-tag path -- this only ever adds an answer where there was
+    none, it never overrides one.
+
+    Two forms are accepted:
+
+      exact   `dMgPsOpt_c::TouchIcon_c` for `TouchIcon_c` written inside dMgPsOpt_c
+      nested  `dPa_c::level_c::callback_c` for `callback_c` written inside dPa_c,
+              where the type is declared in an intermediate scope the field walk
+              does not track
+
+    The second form must be UNIQUE to answer. Two different `Outer::*::Inner`
+    entries with the same size are still two different classes, and picking either
+    would be the exact guess this function exists to avoid -- see
+    _shadowed_by_nested, which is the same failure one level up.
+    """
+    if not outer:
+        return None
+    exact = CLASS_SIZES_QUALIFIED.get(outer + "::" + typ)
+    if exact is not None:
+        return exact
+    prefix = outer + "::"
+    hits = {v for k, v in CLASS_SIZES_QUALIFIED.items()
+            if k.startswith(prefix) and k.rsplit("::", 1)[-1] == typ}
+    return hits.pop() if len(hits) == 1 else None
 
 # A derived class's own fields start at the base's DATA SIZE, not its sizeof.
 #
@@ -650,7 +710,19 @@ def main(argv, repo=None):
                 in_comment = True
             m = DECL.match(line)
             typ = m.group(1).rsplit("::", 1)[-1] if m else None
-            if m and not m.group(2) and _shadowed_by_nested(typ, nested_names, fp):
+            # A qualified assertion is checked FIRST and settles the question. It
+            # names one class unambiguously, so neither the bare-tag lookup nor the
+            # shadow refusal below has anything left to decide. `TouchIcon_c
+            # mIcons[8];` in dMgPsOpt_c.h is the live case: the bare tag
+            # `TouchIcon_c` is asserted nowhere, so the field came back UNPARSED and
+            # the header's whole walk stopped at `struct spans 0x8`. With the
+            # qualified size it walks to 0x128, which is what the header's own
+            # `dMgPsOpt_c_size_must_be_0x128` says -- an independent check that the
+            # size read here is the right one.
+            qsize = _qualified_size(expected, typ) if (m and not m.group(2)) else None
+            if qsize is not None:
+                w = qsize
+            elif m and not m.group(2) and _shadowed_by_nested(typ, nested_names, fp):
                 w = None
             else:
                 w = 4 if (m and m.group(2)) else SZ.get(typ)

--- a/tools/test_check_header_offsets.py
+++ b/tools/test_check_header_offsets.py
@@ -546,3 +546,128 @@ struct Widget {
                     unittest.mock.patch.dict(C.CLASS_SIZE_SRC, {"Manager": own}):
                 self.assertEqual(r.run("include/Widget.h"), 0,
                                  "a size asserted in this very header must still count")
+
+
+# ------------------------------------- defect 4: nested tags that DO assert their size
+#
+# _shadowed_by_nested (above) made the gate refuse rather than guess whenever a class
+# nested in the struct under test shared its tag with an unrelated top-level one. That
+# is the right call when the size is genuinely unknown -- but for nine of the headers it
+# refused, the size is not unknown at all. The tree had already invented an
+# outer-qualified assertion name to dodge exactly this collision:
+#
+#   typedef char dMgPsOpt_TouchIcon_c_size_must_be_0x24[
+#       sizeof(dMgPsOpt_c::TouchIcon_c) == 0x24 ? 1 : -1];
+#
+# The lookup only ever read the bare tag, so it never found it, and include/dMgPsOpt_c.h
+# sat in config/header-offset-known-issues.txt reporting `struct spans 0x8`.
+#
+# The identifier is NOT a mechanical composition -- `dMgPsOpt_TouchIcon_c` drops the
+# outer's `_c` -- so nothing derives the qualified name from it without guessing. The
+# `sizeof(...)` operand IS the qualified name, by construction: the compiler resolves it
+# or the header does not build. That is what CLASS_SIZES_QUALIFIED reads.
+#
+# Every case below is planted the same way: the fixture is run with the qualified table
+# emptied, which is the pre-fix state exactly, and again with it populated.
+
+# `Manager` is nested in the struct under test and asserted ONLY under its qualified
+# name, so the bare-tag table cannot answer and the shadow check refuses. 8 bytes.
+QUALIFIED_GOOD = """\
+struct Widget {
+\tstruct Manager {
+\t\tu32 a;
+\t\tu32 b;
+\t};
+
+\tu32 first;         /* 0x000 */
+\tManager manager;   /* 0x004 */
+\tu32 last;          /* 0x00c */
+};
+"""
+# The same header with `last` written as though Manager were the 0x3c-byte top-level
+# class -- i.e. what a comment author working from the wrong model would produce.
+QUALIFIED_BROKEN = QUALIFIED_GOOD.replace("/* 0x00c */", "/* 0x040 */")
+
+
+class QualifiedSizeAssertTests(unittest.TestCase):
+    def test_a_qualified_assertion_is_read_where_the_bare_tag_cannot_answer(self):
+        with Repo() as r:
+            r.write("include/Widget.h", QUALIFIED_GOOD)
+            # Pre-fix: no qualified table. The bare tag is unknown, the nested body
+            # shadows, and the field goes UNPARSED -- which is a non-zero exit and,
+            # worse, suppresses the field walk for the whole header.
+            with unittest.mock.patch.dict(C.SZ, {}, clear=False), \
+                    unittest.mock.patch.dict(C.CLASS_SIZES_QUALIFIED, {}, clear=True):
+                self.assertEqual(r.run("include/Widget.h"), 1,
+                                 "precondition: the old lookup could not size this")
+            # With the assertion read out of its own sizeof() operand.
+            with unittest.mock.patch.dict(C.CLASS_SIZES_QUALIFIED,
+                                          {"Widget::Manager": 8}):
+                self.assertEqual(r.run("include/Widget.h"), 0)
+
+    def test_a_wrong_comment_is_still_caught_once_the_size_is_known(self):
+        """The point of retiring a waiver is to start CHECKING the header, not to
+        start passing it. A size the gate can resolve has to be able to fail."""
+        with Repo() as r:
+            r.write("include/Widget.h", QUALIFIED_BROKEN)
+            with unittest.mock.patch.dict(C.CLASS_SIZES_QUALIFIED,
+                                          {"Widget::Manager": 8}):
+                self.assertEqual(r.run("include/Widget.h"), 1)
+
+    def test_a_qualified_name_outranks_a_same_tagged_top_level_class(self):
+        """This is C++ name lookup, not a heuristic. `Manager` written inside Widget
+        names Widget::Manager whenever one exists, whatever unrelated top-level
+        Manager the tree also declares -- so the qualified answer must WIN, not merely
+        fill in where the bare table is silent. Getting this backwards reintroduces
+        the fBase_c::Manager bug the shadow check was added to stop."""
+        with Repo() as r:
+            r.write("include/Widget.h", QUALIFIED_GOOD)
+            elsewhere = pathlib.Path(REPO) / "include" / "Elsewhere.h"
+            with unittest.mock.patch.dict(C.SZ, {"Manager": 0x3c}), \
+                    unittest.mock.patch.dict(C.CLASS_SIZE_SRC, {"Manager": elsewhere}), \
+                    unittest.mock.patch.dict(C.CLASS_SIZES_QUALIFIED,
+                                             {"Widget::Manager": 8}):
+                self.assertEqual(r.run("include/Widget.h"), 0,
+                                 "the unrelated top-level size was preferred")
+
+    def test_an_ambiguous_deeper_nesting_refuses_instead_of_picking_one(self):
+        """The field walk does not track intermediate scopes, so `Outer::*::Inner` is
+        matched by suffix. Two different classes can end in the same tag -- and two
+        wrong guesses are not better than one. Refusing puts the header back on the
+        shadow path, which reports UNPARSED rather than a confident wrong number."""
+        with Repo() as r:
+            r.write("include/Widget.h", QUALIFIED_GOOD)
+            with unittest.mock.patch.dict(C.CLASS_SIZES_QUALIFIED,
+                                          {"Widget::alpha_c::Manager": 8,
+                                           "Widget::beta_c::Manager": 0x20},
+                                          clear=True):
+                self.assertEqual(r.run("include/Widget.h"), 1,
+                                 "an ambiguous suffix match was resolved by guessing")
+            # One candidate is not ambiguous, and the suffix form has to answer -- a
+            # nested type declared in an intermediate scope is the reason it exists.
+            with unittest.mock.patch.dict(C.CLASS_SIZES_QUALIFIED,
+                                          {"Widget::alpha_c::Manager": 8}, clear=True):
+                self.assertEqual(r.run("include/Widget.h"), 0)
+
+    def test_the_two_sizes_in_every_real_assertion_agree(self):
+        """The identifier carries the size as a `_0xN` suffix and the expression
+        carries it again as the compared constant. This reads the first and keys it by
+        the second's operand, which is only sound while the two never disagree. They
+        do not, in any of the tree's assertions -- and if a future header makes them
+        disagree, that header is the thing to fix, not this table."""
+        disagreements = []
+        for h in sorted((pathlib.Path(REPO) / "include").rglob("*.h")):
+            for m in C._SIZE_ASSERT_FULL.finditer(h.read_text(errors="replace")):
+                if int(m.group(2), 16) != int(m.group(4), 0):
+                    disagreements.append(f"{h.name}: {m.group(1)} vs {m.group(4)}")
+        self.assertEqual(disagreements, [])
+
+    def test_the_waiver_this_change_retires_now_checks_clean(self):
+        """include/dMgPsOpt_c.h is the live case: `TouchIcon_c mIcons[8];`, sized only
+        by `sizeof(dMgPsOpt_c::TouchIcon_c) == 0x24`. It reported `struct spans 0x8`
+        and was waived. The span it walks to now, 0x128, is independently asserted by
+        the header's own dMgPsOpt_c_size_must_be_0x128 -- so the size being read here
+        is corroborated by something other than the comments it is checking."""
+        self.assertNotIn("include/dMgPsOpt_c.h", C._known_issues(),
+                         "the waiver is back; this test guards its retirement")
+        self.assertEqual(C.main(["include/dMgPsOpt_c.h"], REPO), 0)


### PR DESCRIPTION
`check_header_offsets` sizes a member by looking its type up in `CLASS_SIZES`, a flat table keyed by the **bare tag**. #2078 made that table refuse rather than guess when a class nested inside the struct under test shared its tag with an unrelated top-level one — the `fBase_c::Manager` bug. Correct, but it also refuses for nested classes whose size the tree *does* state, just under a qualified assertion name:

```c
typedef char dMgPsOpt_TouchIcon_c_size_must_be_0x24[
    sizeof(dMgPsOpt_c::TouchIcon_c) == 0x24 ? 1 : -1];
```

That convention exists precisely to dodge the collision, and the lookup never saw it. `include/dMgPsOpt_c.h` was waived for it — #2078's own waiver note calls this "the cheapest of the nine to retire and the natural follow-up."

## Read the operand, not the identifier

The identifier is **not** a mechanical composition. `dMgPsOpt_c::TouchIcon_c` is asserted as `dMgPsOpt_TouchIcon_c_size_must_be_0x24` — the outer tag with its `_c` dropped — and `Particle::SysTracker::Contents` as `Particle_SysTracker_Contents_size_must_be_0x748`. No rule derives one from the other without guessing, and guessing a size is the exact failure #2078 closed.

The `sizeof(...)` operand *is* the qualified name, by construction: the compiler resolves it or the header does not build. So `CLASS_SIZES_QUALIFIED` keys the same sizes by that operand.

Measured over all 507 headers: **486** assertions parse in full, **26** of them qualified, and the identifier's `_0xN` suffix agrees with the expression's own constant in **486 of 486** cases. There is a test pinning that invariant, so a future header that breaks it fails loudly instead of silently keying a wrong number.

All 26 qualified asserts are keyed today under flattened identifiers (`Player_State`, `LVL_Overlay_ObjTable`) that never match the type as written (`State`, `ObjTable`) — invisible to the current lookup, every one.

## Tree-wide, exactly one row moves

`python tools/check_header_offsets.py $(git ls-files 'include/*.h' 'include/**/*.h')` — 507 headers, rc=0 both sides. Diffing the per-header rows against `origin/main` `a12691944`:

```
333c333
< include/dMgPsOpt_c.h: WAIVED -- config/header-offset-known-issues.txt
---
> include/dMgPsOpt_c.h: 4 commented fields, 0 mismatched, 0 unparsed, struct spans 0x128
```

|  | main (`a12691944`) | this PR |
|---|---|---|
| summaries | 494 | **495** |
|  of those, ≥1 field CHECKED | 363 | **364** |
| enumerated waivers | 13 | **12** |
| verified offset comments | 3203 | **3207** |
| MISMATCH / UNPARSED | 0 / 0 | 0 / 0 |

## The four new comments are real checks, not decoration

The header carried no offset comments, so unwaiving it alone would only have bought a hollow green. The four offsets are derived from the layout the header already states (`8 × 0x24 = 0x120`, then `s32`, `u8`, `u8[3]`), and the field name `pad_125` corroborates the third. Falsifying each one in turn:

```
0x000..0x120  ->  MISMATCH :16 mIcons: comment 0x004, computed 0x000
/* 0x120 */   ->  MISMATCH :17 mSelectedIcon: comment 0x124, computed 0x120
/* 0x124 */   ->  MISMATCH :18 mActive: comment 0x128, computed 0x124
/* 0x125 */   ->  MISMATCH :19 pad_125: comment 0x126, computed 0x125
```

All four are genuinely gated. And the span the walk arrives at, `0x128`, is **independently asserted by the header's own `dMgPsOpt_c_size_must_be_0x128`** — so the size being read here is corroborated by something other than the comments it is checking.

## Ambiguity still refuses

The field walk does not track intermediate scopes, so a deeper nesting (`dPa_c::level_c::callback_c` written inside `dPa_c`) is matched by suffix. Two candidates ending in the same tag are two different classes, and picking either would be the guess this change exists to avoid — so the suffix form answers **only when unique**, and otherwise falls back to #2078's shadow refusal.

A qualified answer **outranks** a same-tagged top-level class rather than merely filling in where the bare table is silent. That is C++ name lookup, not a heuristic: `Manager` written inside `Widget` names `Widget::Manager` whenever one exists. Reversing it would reintroduce `fBase_c::Manager`. There is a test.

## Tests

6 new cases, planted the same way: each fixture runs with `CLASS_SIZES_QUALIFIED` **cleared**, which is the pre-fix state exactly, and again with it populated. That the cleared state is byte-for-byte `origin/main`'s behaviour is not asserted — it is measured. Running main's checker on the `QUALIFIED_GOOD` fixture:

```
origin/main checker on QUALIFIED_GOOD -> rc=1
UNPARSED include/Widget.h:8: Manager manager;   /* 0x004 */
include/Widget.h: 1 commented fields, 0 mismatched, 1 unparsed, struct spans 0x8
```

and on the real header this PR unwaives:

```
origin/main   ->  rc=1   UNPARSED include/dMgPsOpt_c.h:16: TouchIcon_c mIcons[8];
                         0 commented fields, 1 unparsed, struct spans 0x8
this PR       ->  rc=0   4 commented fields, 0 mismatched, 0 unparsed, struct spans 0x128
```

```
pytest tools/test_check_header_offsets.py -q   ->  33 passed  (was 27)
python tools/check_python_names.py             ->  PASS
python tools/check_dead_references.py          ->  no new dead references, no broken links
```

## Byte impact: none, and verified rather than assumed

This touches a tracked header, which is the documented hazard, so it was bracketed rather than reasoned about. The change is comment-only — stripped by the preprocessor before codegen:

```
python tools/rombuild.py -j 16 --no-rom
module fidelity: 106/106 exact, 100.000000% of compared bytes
source-built functions: 11,088   reproducing: 11,088   mismatching: 0
ROM-build analysis: PASS
```

Waivers remaining: **12**. Next cheapest are `dMgState_c.h` / `dMg3DEspModel_c.h` (pointer-to-member is 8 bytes on this ABI and `DECL` has no notion of one) — a separate change.
