### PR TITLE
tu_map: a stray function must touch the TU it is absorbed into

### DIFF
--- a/tools/test_tu_map.py
+++ b/tools/test_tu_map.py
@@ -1,0 +1,134 @@
+"""A TU's .text is contiguous, so absorb_unlabelled must not reach across a gap.
+
+The call graph alone cannot tell a file-local helper from an ordinary external
+function that happens to have one caller -- both are "called from exactly one
+cluster". Absorbing on that evidence placed 128 functions into units they cannot
+be in (37 of 547 at the default settings), the worst of them a third of a
+megabyte outside the span it was filed under.
+
+Adjacency is the missing half of the argument, and it is what these pin: the
+linker lays a unit down in one contiguous run, so a stray joins a cluster only
+when it touches that cluster -- and, having joined, extends it, which is how a
+contiguous run of strays is taken in.
+
+These are pure unit tests over synthetic clusters: no ROM, no compiler, no config.
+"""
+import pathlib
+import sys
+import unittest
+
+TOOLS = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOLS))
+
+import tu_map as TM      # noqa: E402
+
+
+def cluster(start, end, classes=("C",)):
+    return {"classes": list(classes), "start": start, "end": end, "funcs": []}
+
+
+def unit_for(tus, addr):
+    """The unit holding `addr`, or None."""
+    for t in tus:
+        if any(a == addr for (a, _n, _s) in t["funcs"]):
+            return t
+    return None
+
+
+class AdjacencyTests(unittest.TestCase):
+    def test_a_stray_abutting_the_end_is_absorbed_and_extends_the_span(self):
+        c = cluster(0x1000, 0x1100)
+        tus = TM.absorb_unlabelled([c], [(0x1100, "helper", 0x40)],
+                                   {0x1100: {0x1020}})
+        self.assertEqual(len(tus), 1)
+        self.assertEqual(tus[0]["end"], 0x1140)
+        self.assertIn((0x1100, "helper", 0x40), tus[0]["funcs"])
+
+    def test_a_stray_abutting_the_start_is_absorbed(self):
+        c = cluster(0x1000, 0x1100)
+        tus = TM.absorb_unlabelled([c], [(0x0fc0, "helper", 0x40)],
+                                   {0x0fc0: {0x1020}})
+        self.assertEqual(tus[0]["start"], 0x0fc0)
+
+    def test_a_far_stray_is_not_absorbed_even_with_a_single_caller_cluster(self):
+        """The defect this file exists for: one caller cluster is not enough."""
+        c = cluster(0x21207dc, 0x212231c)
+        tus = TM.absorb_unlabelled([c], [(0x20ccd04, "far", 0x60)],
+                                   {0x20ccd04: {0x2120800}})
+        self.assertEqual(c["end"], 0x212231c, "span must not move")
+        self.assertNotIn((0x20ccd04, "far", 0x60), c["funcs"])
+        own = unit_for(tus, 0x20ccd04)
+        self.assertIsNotNone(own)
+        self.assertEqual(own["classes"], [], "a stray becomes its own unlabelled TU")
+
+    def test_a_contiguous_run_is_absorbed_whole(self):
+        """Each pass extends the span, so the next function in the run abuts it."""
+        c = cluster(0x1000, 0x1100)
+        strays = [(0x1100, "a", 0x40), (0x1140, "b", 0x40), (0x1180, "c", 0x40)]
+        calls = {0x1100: {0x1020}, 0x1140: {0x1020}, 0x1180: {0x1020}}
+        tus = TM.absorb_unlabelled([c], strays, calls)
+        self.assertEqual(len(tus), 1)
+        self.assertEqual(tus[0]["end"], 0x11c0)
+        self.assertEqual(len(tus[0]["funcs"]), 3)
+
+    def test_a_run_stops_at_the_gap(self):
+        """Contiguity is the boundary: what is past the hole stays out."""
+        c = cluster(0x1000, 0x1100)
+        strays = [(0x1100, "a", 0x40), (0x1200, "past_the_gap", 0x40)]
+        calls = {0x1100: {0x1020}, 0x1200: {0x1020}}
+        tus = TM.absorb_unlabelled([c], strays, calls)
+        self.assertEqual(tus[0]["end"], 0x1140)
+        self.assertIsNotNone(unit_for(tus, 0x1200))
+        self.assertNotEqual(unit_for(tus, 0x1200), tus[0])
+
+
+class CallerTests(unittest.TestCase):
+    def test_an_adjacent_stray_with_two_caller_clusters_is_not_absorbed(self):
+        """Adjacency is necessary, not sufficient -- the call-graph rule still runs."""
+        a, b = cluster(0x1000, 0x1100, ("A",)), cluster(0x1140, 0x1200, ("B",))
+        tus = TM.absorb_unlabelled([a, b], [(0x1100, "shared", 0x40)],
+                                   {0x1100: {0x1020, 0x1150}})
+        self.assertEqual(a["end"], 0x1100)
+        self.assertEqual(b["start"], 0x1140)
+        self.assertEqual(unit_for(tus, 0x1100)["classes"], [])
+
+    def test_a_caller_outside_every_cluster_blocks_absorption(self):
+        c = cluster(0x1000, 0x1100)
+        tus = TM.absorb_unlabelled([c], [(0x1100, "external", 0x40)],
+                                   {0x1100: {0x1020, 0x9000}})
+        self.assertEqual(c["end"], 0x1100)
+        self.assertEqual(unit_for(tus, 0x1100)["classes"], [])
+
+    def test_an_uncalled_stray_is_not_absorbed(self):
+        """No callers means no evidence, not evidence of belonging."""
+        c = cluster(0x1000, 0x1100)
+        tus = TM.absorb_unlabelled([c], [(0x1100, "orphan", 0x40)], {})
+        self.assertEqual(c["end"], 0x1100)
+        self.assertEqual(unit_for(tus, 0x1100)["classes"], [])
+
+
+class InvariantTests(unittest.TestCase):
+    def test_every_placed_function_lies_inside_its_own_units_span(self):
+        """The property the whole guard exists to hold, over a mixed input."""
+        a, b = cluster(0x1000, 0x1100, ("A",)), cluster(0x5000, 0x5100, ("B",))
+        strays = [(0x1100, "adj_a", 0x40), (0x0800, "far", 0x40),
+                  (0x5100, "adj_b", 0x40), (0x9000, "lonely", 0x40)]
+        calls = {0x1100: {0x1020}, 0x0800: {0x1020},
+                 0x5100: {0x5020}, 0x9000: {0x5020}}
+        for t in TM.absorb_unlabelled([a, b], strays, calls):
+            for (addr, name, _size) in t["funcs"]:
+                self.assertTrue(t["start"] <= addr < t["end"],
+                                "%s at %#x escapes %#x..%#x"
+                                % (name, addr, t["start"], t["end"]))
+
+    def test_no_function_is_lost_or_duplicated(self):
+        a = cluster(0x1000, 0x1100, ("A",))
+        a["funcs"].append((0x1000, "member", 0x100))
+        strays = [(0x1100, "adj", 0x40), (0x0800, "far", 0x40)]
+        tus = TM.absorb_unlabelled([a], strays, {0x1100: {0x1020}, 0x0800: {0x1020}})
+        placed = sorted(n for t in tus for (_a, n, _s) in t["funcs"])
+        self.assertEqual(placed, ["adj", "far", "member"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tu_map.py
+++ b/tools/tu_map.py
@@ -449,29 +449,55 @@ def cluster(fns, vt_for_module, factory_for_module, blind):
 def absorb_unlabelled(clusters, unlabelled, calls):
     """Attach each stray function to a neighbouring cluster when the call graph says so.
 
-    A function called ONLY from inside one cluster's span is file-local -- it has
-    internal linkage, which is why it has no mangled name to read a class from --
-    and internal linkage is a property that cannot cross a TU boundary. So its
-    callers' cluster is its cluster. That is proof, not preference.
+    A function called ONLY from inside one cluster's span is a candidate for being
+    file-local to that cluster: no mangled name to read a class from is what you
+    expect of internal linkage, and internal linkage cannot cross a TU boundary.
+
+    But a single caller-cluster is NOT proof of internal linkage. A perfectly
+    ordinary external function that happens to have exactly one caller looks
+    identical from the call graph alone. So the call graph proposes and *adjacency
+    disposes*: the linker lays a TU's .text down contiguously, so a function that
+    belongs to a TU must touch that TU's span. A stray is absorbed only when it
+    abuts the cluster -- and absorbing it extends the span, so a contiguous run of
+    strays is taken in one function at a time, which is why this iterates.
+
+    Without that guard the call-graph rule alone placed 304 functions into TUs
+    they cannot be in, across 59 of 720 units -- e.g. eight functions at
+    0x020ccd04..0x020d0bd8 absorbed into ov006's dScMgTrampoline_c
+    (0x021207dc..0x0212231c), a third of a megabyte away. A .text that jumps
+    0x54000 bytes and comes back is not a translation unit.
 
     Everything else becomes its own low-confidence TU rather than being guessed
     into a neighbour: an unattributed run between two clusters is genuinely
     ambiguous, and saying so is more useful than picking a side."""
-    leftovers = []
-    for addr, name, size in unlabelled:
-        callers = calls.get(addr, set())
+    def _owner(addr):
+        """The single cluster every caller of `addr` lies in, else None."""
         owners = set()
-        for c_addr in callers:
+        for c_addr in calls.get(addr, set()):
             for i, c in enumerate(clusters):
                 if c["start"] <= c_addr < c["end"]:
                     owners.add(i)
                     break
             else:
                 owners.add(-1)          # called from outside every cluster
-        if len(owners) == 1 and -1 not in owners:
-            clusters[owners.pop()]["funcs"].append((addr, name, size))
-        else:
-            leftovers.append((addr, name, size))
+        return owners.pop() if len(owners) == 1 and -1 not in owners else None
+
+    leftovers = list(unlabelled)
+    absorbing = True
+    while absorbing:                    # a run is absorbed one function per pass
+        absorbing = False
+        still = []
+        for addr, name, size in leftovers:
+            i = _owner(addr)
+            c = clusters[i] if i is not None else None
+            if c is not None and (addr == c["end"] or addr + size == c["start"]):
+                c["funcs"].append((addr, name, size))
+                c["start"] = min(c["start"], addr)
+                c["end"] = max(c["end"], addr + size)
+                absorbing = True
+            else:
+                still.append((addr, name, size))
+        leftovers = still
 
     # Contiguous runs of still-unattributed functions become their own TUs.
     orphan_tus = []


### PR DESCRIPTION
## The defect

`tu_map.absorb_unlabelled` attaches an unlabelled function to a cluster when every
*caller* of it lies inside that cluster's span. It never compares the absorbed
function's **own** address to the span. Its docstring called this "proof, not
preference":

> A function called ONLY from inside one cluster's span is file-local -- it has
> internal linkage, which is why it has no mangled name to read a class from --
> and internal linkage is a property that cannot cross a TU boundary. So its
> callers' cluster is its cluster.

The premise is the weak link: **one caller-cluster does not prove internal
linkage.** An ordinary external function that happens to have exactly one caller
looks identical from the call graph alone.

## What it cost, measured

| | default | `--split-swallowers` |
|---|---|---|
| units | 547 | 720 |
| units holding an out-of-span function | **37** | **59** |
| functions filed where they cannot be | **128** | **304** |

Worst case: eight functions at `0x020ccd04..0x020d0bd8` absorbed into ov006's
`dScMgTrampoline_c`, whose span is `0x021207dc..0x0212231c` — `0x54000` bytes
away. A `.text` that jumps a third of a megabyte and comes back is not a
translation unit. This is the "stale TU map overcut" hazard in a new form, and it
lands on live TU-promotion candidates: `dScMgTrampoline2_c` (16 bogus),
`dScMgFlower_c` (10), `dScMgSlot1_c`/`dScMgSlot3_c` (8), `main`'s
`Event,Fog,Message,…` unit (37).

## The fix

Adjacency is the missing half of the argument. The linker lays a unit's `.text`
down in one contiguous run, so a stray joins a cluster only when it **abuts**
the cluster — and, having joined, **extends** it, so a contiguous run of strays
is absorbed one function per pass. The call-graph rule runs first and is
unchanged: adjacency is necessary, not sufficient.

Out-of-span functions go **128 → 0** and **304 → 0**.

Unit count falls **547 → 513**. That is not the guard rejecting work: extending a
span brings callers that previously read as "outside every cluster" back inside
it, which lets adjacent strays that used to fragment into their own one-function
units join the neighbour they belong to.

## Not a regression

`tu_map.py --check`: **V1 ov063** and **V1c ov063** fail identically before and
after; every other gate passes on both. Those two were already red on `main` and
this does not claim to fix them.

`tools/test_tu_map.py` is new — 10 pure unit cases, no ROM or compiler.
**6 fail on the parent commit**; the 4 that pass are the call-graph rules this
does not touch.

## Worked example

`ov006/dScMgTrampoline_c` before: 50 functions, eight of them impossible.
After: **42 contiguous functions over `0x021207dc..0x02122490`**, starting at its
D1 destructor and ending exactly where `MgTrampolineTime_Spawn` begins — which
`tu_map` independently clusters as its own factory unit at
`0x02122490..0x021225a8`. That settled a boundary question by agreement of two
signals rather than by preference.

Tools-only, as required: the validator restores `tools/` from base, so no PR can
test its own tool change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhhAeJwXBnfPp7B5DNjCwh
