### PR TITLE
Run tools.test_tu_map in CI

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -1,6 +1,6 @@
 # Who tests the tools that nobody runs?
 #
-# `tools/` holds 59 `test_*.py` modules. Before this workflow, SIX of them ran in CI:
+# `tools/` holds 63 `test_*.py` modules. Before this workflow, SIX of them ran in CI:
 # test_tiers (converted-ratchet.yml), test_check_dead_references (dead-references.yml),
 # test_check_header_offsets (header-offsets.yml), test_check_python_names
 # (python-names.yml), test_source_coverage (source-coverage.yml) and test_check_src_tu
@@ -10,7 +10,7 @@
 # gate's FAILURE branch is the one path a green run never exercises: no ROM build can
 # reach it, because these tools are not compiled into the ROM. src-tu-refs.yml exists
 # because #1643 broke 26 translation units while every byte gate stayed green, and the
-# only thing that noticed was a test suite a human had to run. This job runs 504 of
+# only thing that noticed was a test suite a human had to run. This job runs 514 of
 # those assertions on every PR that touches `tools/` or `nearmiss/`, so the next one is
 # noticed by CI.
 #
@@ -72,7 +72,7 @@
 # every future test_*.py automatically -- including one that needs mwccarm, which does
 # not fail on a runner but SELF-SKIPS, turning this job's green hollow with no diff to
 # review. There is a sharper version of the same trap already in the tree: thirteen of the
-# 59 modules are pytest-style bare functions with no unittest.TestCase, so
+# 63 modules are pytest-style bare functions with no unittest.TestCase, so
 # `python -m unittest tools.test_tubuild` prints "Ran 0 tests ... OK" and exits 0. That
 # is 186 test functions that a glob would have silently counted as passing. Four of them
 # -- test_build_pin, test_dtor_members, test_opnew_sizes, test_tubuild -- also carry the
@@ -100,9 +100,9 @@
 # present" -- its Retarget class, and only that class, compiles a real object). All nine
 # are @skipUnless with a stated reason, so `-v` shows them; none is a bare `return`.
 # test_premerge_check adds none on a runner with git installed, and test_symrecords,
-# test_nearmiss_db, test_tu_promote, test_tu_production and
+# test_nearmiss_db, test_tu_map, test_tu_promote, test_tu_production and
 # test_tubuild_owned_relocs add none anywhere.
-# 495 of the 504 assert something.
+# 505 of the 514 assert something.
 name: tool tests
 
 on:
@@ -194,6 +194,7 @@ jobs:
             tools.test_srcpath \
             tools.test_stamp_provenance_verify \
             tools.test_symrecords \
+            tools.test_tu_map \
             tools.test_tu_production \
             tools.test_tu_promote \
             tools.test_tubuild_owned_relocs \
@@ -273,6 +274,23 @@ jobs:
 #                                      may be restamped. A verdict wrongly called
 #                                      mechanical would launder a wrong-identity pair
 #                                      straight into the mirror.
+#   test_tu_map                 (10)   tu_map.py -- the call-graph-plus-adjacency
+#                                      partition of every module into translation units.
+#                                      A single caller-cluster is NOT proof of internal
+#                                      linkage, so #2082 made a stray function have to
+#                                      ABUT the cluster that absorbs it. The reason this
+#                                      needs a gate: tu_config.attribute_text claims
+#                                      `.text` from these spans UNCONDITIONALLY -- every
+#                                      other section it attributes is fail-closed -- so a
+#                                      span inflated over a function that does not belong
+#                                      to the TU reaches a generator with nothing
+#                                      downstream able to notice. On the parent commit 6
+#                                      of these 10 fail, which is what makes them a
+#                                      bracket rather than a description. Pure stdlib: it
+#                                      imports tu_map and nothing else, builds its
+#                                      fixtures in-process, and needs no ROM, no
+#                                      compiler, no config/, no build/ and no git. 10 of
+#                                      10 run in CI, none skips, 0.000s.
 #   test_tu_production          (17)   tu_production.py -- the intact-object production
 #                                      route added by #2054, and the stock/ROM-gap control
 #                                      that decides whether a produced object may stand in


### PR DESCRIPTION
#2082 added `tools/test_tu_map.py` — 10 tests pinning the adjacency guard that stops `tu_map` absorbing a stray function into a translation unit it does not abut. It did not add the module to `.github/workflows/tool-tests.yml`, and that list is [enumerated on purpose rather than globbed](https://github.com/tangosdev/sm64ds-decomp/blob/main/.github/workflows/tool-tests.yml), so the 10 tests run nowhere.

## The tests are a bracket, not a description — so the gap is real

On #2082's parent commit, 6 of the 10 fail. Wiring them is therefore the difference between a defect that cannot come back and one that can come back silently. Proven by mutation rather than argued: with `tools/tu_map.py` reverted to `d1edc757b` and everything else on this branch, **the exact command this job runs** reports

```
Ran 514 tests    FAILED (failures=6, skipped=3)
```

and on `main` today that same revert is green. That is what this one line buys.

The command was not retyped from the YAML — it was extracted out of it and executed, so what I measured is what the runner runs:

```python
w = yaml.safe_load(open('.github/workflows/tool-tests.yml').read())
[st['run'] for st in w['jobs']['tools']['steps'] if st.get('name') == "The tools' own tests"]
```

## Why it belongs in the list rather than being an exception to the no-glob rule

The header refuses modules for three reasons — needs the toolchain, needs a pip dependency, or is pytest-style so `unittest` counts zero. `test_tu_map` is none of them. It imports `tu_map` and the stdlib, nothing else; it builds its fixtures in-process; it needs no ROM, no compiler, no `config/`, no `build/` and no git. Three `unittest.TestCase` classes, so `python -m unittest` really sees all 10. No `skip`, no `@skipUnless`, and — the shape this repo keeps getting bitten by — no bare `if not _toolchain(): return`.

```
before   Ran 504 tests in 53.990s   OK (skipped=3)
after    Ran 514 tests in 55.583s   OK (skipped=3)
```

Inside the noise, and no skip added anywhere. The two totals in the header move with it (504 → 514, and "495 of the 504 assert something" → 505 of 514), and `test_tu_map` joins the roster of modules that add no skips.

## What the inventory entry says, and why it names a consumer

The per-module comment block explains what each suite protects. For this one the reason is not in `tu_map.py` at all, it is in `tools/tu_config.py`:

```python
def attribute_text(att, tus):
    for i, (lo, hi, _c) in enumerate(tus):
        att.claim(".text", i, lo, hi)
```

Its own header says every other section is attributed "only where the ROM says so, by four rules that each fail closed" — but `.text` is claimed **unconditionally** from these spans. So a span inflated over a function that does not belong to the TU reaches a generator with nothing downstream able to notice. That is the sentence a future reader needs when deciding whether this module still earns its place.

## Two stale numbers corrected on the way past

The header says `tools/` holds 59 `test_*.py` modules; `git ls-files 'tools/test_*.py'` now reports **63**. The "thirteen ... are pytest-style bare functions with no `unittest.TestCase`" is still exactly right — re-counted, 13 of the 63 — so only the denominator moved. Both mentions updated.

## Gates

```
python tools/check_dead_references.py   ->  no new dead references, no broken markdown links
python tools/check_python_names.py      ->  PASS
python -m unittest tools.test_check_dead_references  ->  Ran 29 tests  OK
python -c "yaml.safe_load(...)"         ->  YAML OK
```

No `tools/`, `src/`, `include/` or `config/` file is touched — one workflow file, 23 insertions, 5 deletions — so there is no byte exposure to bracket.
