### PR TITLE
Drop the orphaned _ZTV3Amp declaration

### DIFF
--- a/include/decl_common.h
+++ b/include/decl_common.h
@@ -693,7 +693,6 @@ extern int _ZTV24daPropeller_Heyho_Fire_c[];
 extern int _ZTV25RotatingUpDownPlatformUtm[];
 extern int _ZTV25SlideDecorationSilverStar[];
 extern int _ZTV9ArrowLift[];
-extern int _ZTV3Amp[];
 extern int _ZTV7daTrs_c[];
 extern int _ZTV3Key[];
 extern int _ZTV3MrI[];


### PR DESCRIPTION
The follow-up I promised on #2084. One line, and the reason it is worth its own PR is that it is the residue of a real defect rather than untidiness.

## What #2084 fixed, and the one piece it left

Before #2084, `config/arm9/overlays/ov070/symbols.txt` named the same word at `0x02123278` **twice**:

```
_ZTV3Amp     kind:data(any) addr:0x02123278
_ZTV7daBrq_c kind:data(any) addr:0x02123278
```

`daBrq_c` is the ROM's own name for that class — ov070 carries the length-prefixed mwcc RTTI string `7daBrq_c` at `0x0212323c`, and `Amp` appears nowhere in the overlay — so #2084 correctly dropped the `Amp` spelling. It did not drop the declaration.

## The declaration is now an orphan, and that is measured

After #2084, `_ZTV3Amp` occurs **exactly once** in the entire tree outside `build/` and `.git/`:

```
$ grep -rn "_ZTV3Amp" . | grep -v "^./build/" | grep -v "^./.git/"
./include/decl_common.h:696:extern int _ZTV3Amp[];
```

No `symbols.txt` names it. No source references it. `decl_common.h:740` already declares the live `_ZTV7daBrq_c` seven lines below it. It is a name that resolves to nothing, in the header that **1115** source files include.

It cannot break a link — an unreferenced declaration emits nothing — which is exactly why it passed every gate on the way in and would have kept passing indefinitely. The cost is not a broken build, it is that the next person to write `_ZTV3Amp` in a `.c` file gets a declaration that compiles and a link that does not, against a symbol the project deliberately deleted.

## Byte-neutral, and proven by 1065 real recompiles rather than by argument

`decl_common.h` is a dependency of 1115 files, so editing it invalidates their content-keyed cache entries. That makes this a genuine test rather than a no-op:

```
9745 reused from cache, 1065 compiled, 0 failed  (51.4s)

source-built functions: 11,088  (2,067,148 / 2,211,124 code bytes, 93.49%)
  reproducing: 11,088
  mismatching: 0
source-owned data claims: 2  (reproducing 2, mismatching 0)
module fidelity: 106/106 exact, 100.000000% of compared bytes
ROM-build analysis: PASS
```

1065 objects were rebuilt from the changed header and every one still reproduces the cartridge, including the `.data` claim #2084 introduced — which is what actually covers `_ZTV7daBrq_c`.

## Gates

```
python tools/rombuild.py -j 16                        ->  106/106, PASS
python tools/check_dead_references.py                 ->  no new dead references, no broken links
python tools/check_header_offsets.py include/decl_common.h
                                                      ->  0 commented fields, 0 mismatched, 0 unparsed
```

No `config/`, `src/`, `src_tu/` or `tools/` file is touched — one header, one deletion.
