### PR TITLE
Normalize partitioned C++ vtable symbols

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -907,11 +907,12 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
     ``normalize_undefined``, raw references to undefined ``_ZTV`` imports lose the
     same ABI preamble from their addend; unlike a rebased local definition this fixes
     the address the repository's already-public import would otherwise resolve to.
-    A policy may additionally split the preamble into an exact storage-alias symbol by
-    reusing one explicitly deadstripped compiler-only symbol-table slot.  Reusing a
-    slot keeps every ELF offset stable; it is allowed only when the old name is an
-    unreferenced GLOBAL/FUNC import with enough exclusive string-table storage for the
-    alias.
+    A policy may additionally split the preamble and public vtable range into exact
+    symbols by reusing explicitly policy-owned symbol-table slots.  Reusing a slot
+    keeps every ELF offset stable; it is allowed only when the donor is an undefined,
+    unreferenced, non-local import with enough exclusive string-table storage.  The
+    caller is responsible for proving that every donor came from an exact deadstrip or
+    externalization policy before invoking this object-level primitive.
     """
     requested = {}
     for name, policy in dict(symbol_policies).items():
@@ -929,11 +930,18 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
                     "donor": str(alias["donor"]),
                     "size": int(alias["size"]),
                 }
+            partitions = policy.get("partitionSymbols", [])
+            if not isinstance(partitions, list):
+                raise TypeError
+            normalized["partitionSymbols"] = [{
+                "symbol": str(row["symbol"]), "donor": str(row["donor"]),
+                "value": int(row["value"]), "size": int(row["size"]),
+            } for row in partitions]
             requested[str(name)] = normalized
         except (KeyError, TypeError, ValueError):
             return None, {"rebased": [], "aliases": [],
                           "error": f"{name} needs bias/size/section and valid optional "
-                                   "storageAlias fields"}
+                                   "storageAlias/partitionSymbols fields"}
     if not requested and not normalize_undefined:
         return bytes(raw), {"rebased": [], "aliases": [], "error": None}
     bad_bias = sorted(name for name, policy in requested.items()
@@ -941,6 +949,39 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
     if bad_bias:
         return None, {"rebased": [], "aliases": [],
                       "error": f"symbol rebias must be positive: {bad_bias}"}
+    for name, policy in requested.items():
+        parts = sorted(policy["partitionSymbols"], key=lambda row: row["value"])
+        policy["partitionSymbols"] = parts
+        if not parts:
+            policy["publicSize"] = policy["size"] - policy["bias"]
+            continue
+        if parts[0]["value"] <= policy["bias"]:
+            return None, {"rebased": [], "aliases": [], "partitions": [],
+                          "error": f"{name} first partition must start after public "
+                                   "address-point bias 0x"
+                                   f"{policy['bias']:x}"}
+        cursor = parts[0]["value"]
+        for part in parts:
+            if not part["symbol"] or part["symbol"].startswith("_ZTV"):
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{name} has invalid partition symbol "
+                                       f"{part['symbol']!r}"}
+            if part["size"] <= 0:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{name} partition {part['symbol']} has "
+                                       "non-positive size"}
+            if part["value"] != cursor:
+                relation = "overlaps" if part["value"] < cursor else "leaves a gap"
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{name} partition {part['symbol']} {relation} "
+                                       f"at 0x{cursor:x}"}
+            cursor += part["size"]
+        if cursor != policy["size"]:
+            relation = "overruns" if cursor > policy["size"] else "leaves a gap before"
+            return None, {"rebased": [], "aliases": [], "partitions": [],
+                          "error": f"{name} partition coverage {relation} storage end "
+                                   f"0x{policy['size']:x} (ends 0x{cursor:x})"}
+        policy["publicSize"] = parts[0]["value"] - policy["bias"]
 
     raw_out = bytearray(raw)
     elf = ELFFile(io.BytesIO(bytes(raw_out)))
@@ -1064,88 +1105,105 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
         struct.pack_into(endian + "i", expected_relocation_sections[row["sectionIndex"]],
                          row["entryOffset"] + 8, row["newAddend"])
 
-    aliases = {}
+    synthesized = {}
     used_donors = set()
+    used_names = set()
     existing_names = {sym.name for sym in syms if sym.name}
     for vtable_name, policy in requested.items():
         alias = policy.get("storageAlias")
-        if alias is None:
-            continue
-        alias_name, donor_name = alias["symbol"], alias["donor"]
-        if not alias_name or alias_name.startswith("_ZTV"):
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"{vtable_name} storage alias has invalid name "
-                                   f"{alias_name!r}"}
-        if alias["size"] != policy["bias"]:
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"{alias_name} size 0x{alias['size']:x} does not equal "
-                                   f"{vtable_name} bias 0x{policy['bias']:x}"}
-        if alias_name in existing_names:
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias {alias_name} already exists"}
-        if donor_name in used_donors:
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias donor {donor_name} is reused"}
-        donors = [(i, sym) for i, sym in enumerate(syms) if sym.name == donor_name]
-        if len(donors) != 1:
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias donor {donor_name} has {len(donors)} "
-                                   "symbol-table slots, expected one"}
-        donor_index, donor = donors[0]
-        if donor["st_shndx"] not in ("SHN_UNDEF", SHN_UNDEF) \
-                or donor["st_value"] != 0 or donor["st_size"] != 0 \
-                or donor["st_info"]["bind"] != "STB_GLOBAL" \
-                or donor["st_info"]["type"] != "STT_FUNC" \
-                or donor["st_other"]["visibility"] != "STV_DEFAULT":
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias donor {donor_name} is not an exact "
-                                   "deadstripped GLOBAL/FUNC import"}
-        for relsec in elf.iter_sections():
-            if not isinstance(relsec, RelocationSection):
-                continue
-            source = elf.get_section(relsec.header["sh_info"])
-            if source.header["sh_type"] not in CONTENT or not source.header["sh_size"]:
-                continue
-            if any(reloc["r_info_sym"] == donor_index
-                   for reloc in relsec.iter_relocations()):
-                return None, {"rebased": [], "aliases": [],
-                              "error": f"storage alias donor {donor_name} is still "
-                                       "referenced by surviving content"}
-        donor_bytes = donor_name.encode("ascii", errors="strict")
-        alias_bytes = alias_name.encode("ascii", errors="strict")
-        if len(alias_bytes) > len(donor_bytes):
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias {alias_name} does not fit donor "
-                                   f"{donor_name}'s string-table slot"}
-        donor_name_offset = donor["st_name"]
-        overlapping = [(i, sym.name) for i, sym in enumerate(syms)
-                       if i != donor_index and isinstance(sym["st_name"], int)
-                       and donor_name_offset <= sym["st_name"] <=
-                       donor_name_offset + len(donor_bytes)]
-        if overlapping:
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias donor {donor_name} has shared or "
-                                   f"substring string-table users {overlapping}"}
-        string_table = elf.get_section(symtab.header["sh_link"])
-        string_offset = string_table.header["sh_offset"] + donor_name_offset
-        if donor_name_offset == 0 or raw_out[string_offset - 1] != 0:
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias donor {donor_name} does not start at "
-                                   "an exclusive string-table boundary"}
-        if bytes(raw_out[string_offset:string_offset + len(donor_bytes) + 1]) \
-                != donor_bytes + b"\0":
-            return None, {"rebased": [], "aliases": [],
-                          "error": f"storage alias donor {donor_name} does not occupy "
-                                   "the expected exclusive string-table bytes"}
-        aliases[vtable_name] = {**alias, "index": donor_index,
-                                "nameOffset": donor_name_offset,
-                                "stringOffset": string_offset,
-                                "donorBytes": donor_bytes, "aliasBytes": alias_bytes}
-        used_donors.add(donor_name)
+        rows = []
+        if alias is not None:
+            if not alias["symbol"] or alias["symbol"].startswith("_ZTV"):
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{vtable_name} storage alias has invalid name "
+                                       f"{alias['symbol']!r}"}
+            if alias["size"] != policy["bias"]:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{alias['symbol']} size 0x{alias['size']:x} "
+                                       f"does not equal {vtable_name} bias "
+                                       f"0x{policy['bias']:x}"}
+            rows.append({**alias, "value": 0, "kind": "storage-alias"})
+        rows.extend({**part, "kind": "partition-symbol"}
+                    for part in policy["partitionSymbols"])
+        synthesized[vtable_name] = []
+        for row in rows:
+            new_name, donor_name = row["symbol"], row["donor"]
+            label = ("storage alias" if row["kind"] == "storage-alias"
+                     else "partition symbol")
+            if new_name in existing_names or new_name in used_names:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} {new_name} already exists or is reused"}
+            if donor_name in used_donors:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} donor {donor_name} is reused"}
+            donors = [(i, sym) for i, sym in enumerate(syms) if sym.name == donor_name]
+            if len(donors) != 1:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} donor {donor_name} has {len(donors)} "
+                                       "symbol-table slots, expected one"}
+            donor_index, donor = donors[0]
+            if donor["st_shndx"] not in ("SHN_UNDEF", SHN_UNDEF) \
+                    or donor["st_value"] != 0 or donor["st_size"] != 0 \
+                    or donor["st_info"]["bind"] == "STB_LOCAL" \
+                    or donor["st_other"]["visibility"] != "STV_DEFAULT":
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} donor {donor_name} is not an exact "
+                                       "undefined, non-local, default-visible slot"}
+            for relsec in elf.iter_sections():
+                if not isinstance(relsec, RelocationSection):
+                    continue
+                source = elf.get_section(relsec.header["sh_info"])
+                if source.header["sh_type"] not in CONTENT \
+                        or not source.header["sh_size"]:
+                    continue
+                if any(reloc["r_info_sym"] == donor_index
+                       for reloc in relsec.iter_relocations()):
+                    return None, {"rebased": [], "aliases": [], "partitions": [],
+                                  "error": f"{label} donor {donor_name} is still "
+                                           "referenced by surviving content"}
+            try:
+                donor_bytes = donor_name.encode("ascii", errors="strict")
+                new_name_bytes = new_name.encode("ascii", errors="strict")
+            except UnicodeEncodeError:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} {new_name!r} or donor {donor_name!r} "
+                                       "is not ASCII"}
+            if len(new_name_bytes) > len(donor_bytes):
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} {new_name} does not fit donor "
+                                       f"{donor_name}'s string-table slot"}
+            donor_name_offset = donor["st_name"]
+            overlapping = [(i, sym.name) for i, sym in enumerate(syms)
+                           if i != donor_index and isinstance(sym["st_name"], int)
+                           and donor_name_offset <= sym["st_name"] <=
+                           donor_name_offset + len(donor_bytes)]
+            if overlapping:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} donor {donor_name} has shared or "
+                                       f"substring string-table users {overlapping}"}
+            string_table = elf.get_section(symtab.header["sh_link"])
+            string_offset = string_table.header["sh_offset"] + donor_name_offset
+            if donor_name_offset == 0 or raw_out[string_offset - 1] != 0:
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} donor {donor_name} does not start at "
+                                       "an exclusive string-table boundary"}
+            if bytes(raw_out[string_offset:string_offset + len(donor_bytes) + 1]) \
+                    != donor_bytes + b"\0":
+                return None, {"rebased": [], "aliases": [], "partitions": [],
+                              "error": f"{label} donor {donor_name} does not occupy "
+                                       "the expected exclusive string-table bytes"}
+            synthesized[vtable_name].append({
+                **row, "index": donor_index, "nameOffset": donor_name_offset,
+                "stringOffset": string_offset, "donorBytes": donor_bytes,
+                "newNameBytes": new_name_bytes,
+            })
+            used_names.add(new_name)
+            used_donors.add(donor_name)
 
     mutable_symbol_indices = {index for index, _sym in
                               (by_name[name][0] for name in requested)}
-    mutable_symbol_indices.update(alias["index"] for alias in aliases.values())
+    mutable_symbol_indices.update(row["index"] for rows in synthesized.values()
+                                  for row in rows)
     protected_symbols = {
         i: (sym.name, sym["st_name"], sym["st_value"], sym["st_size"],
             sym["st_info"]["bind"], sym["st_info"]["type"],
@@ -1154,28 +1212,35 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
     }
 
     base = symtab.header["sh_offset"]
-    rows, alias_rows = [], []
+    rows, alias_rows, partition_rows = [], [], []
     for name in sorted(requested):
         index, sym = by_name[name][0]
         bias = requested[name]["bias"]
-        alias = aliases.get(name)
-        if alias is not None:
-            string_offset = alias["stringOffset"]
-            raw_out[string_offset:string_offset + len(alias["donorBytes"])] = \
-                alias["aliasBytes"] + b"\0" * (len(alias["donorBytes"])
-                                                 - len(alias["aliasBytes"]))
-            donor_ent = base + alias["index"] * 16
-            struct.pack_into(endian + "I", raw_out, donor_ent + 4, 0)
-            struct.pack_into(endian + "I", raw_out, donor_ent + 8, alias["size"])
+        for synthetic in synthesized[name]:
+            string_offset = synthetic["stringOffset"]
+            raw_out[string_offset:string_offset + len(synthetic["donorBytes"])] = \
+                synthetic["newNameBytes"] + b"\0" * \
+                (len(synthetic["donorBytes"]) - len(synthetic["newNameBytes"]))
+            donor_ent = base + synthetic["index"] * 16
+            struct.pack_into(endian + "I", raw_out, donor_ent + 4,
+                             synthetic["value"])
+            struct.pack_into(endian + "I", raw_out, donor_ent + 8,
+                             synthetic["size"])
             raw_out[donor_ent + 12] = 0x11  # STB_GLOBAL/STT_OBJECT
             struct.pack_into(endian + "H", raw_out, donor_ent + 14,
                              sym["st_shndx"])
-            alias_rows.append({"symbol": alias["symbol"], "donor": alias["donor"],
-                               "value": 0, "size": alias["size"],
-                               "section": requested[name]["section"]})
+            report_row = {
+                "symbol": synthetic["symbol"], "donor": synthetic["donor"],
+                "value": synthetic["value"], "size": synthetic["size"],
+                "section": requested[name]["section"],
+            }
+            if synthetic["kind"] == "storage-alias":
+                alias_rows.append(report_row)
+            else:
+                partition_rows.append(report_row)
         ent = base + index * 16
         new_value = sym["st_value"] + bias
-        new_size = sym["st_size"] - bias
+        new_size = requested[name]["publicSize"]
         struct.pack_into(endian + "I", raw_out, ent + 4, new_value)
         struct.pack_into(endian + "I", raw_out, ent + 8, new_size)
         rows.append({"symbol": name, "bias": bias,
@@ -1195,6 +1260,7 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
     }
     if checked_protected != protected_symbols:
         return None, {"rebased": rows, "aliases": alias_rows,
+                      "partitions": partition_rows,
                       "error": "storage rewrite changed a non-policy symbol"}
     checked_sections = {
         i: sec.data() for i, sec in enumerate(checked.iter_sections())
@@ -1202,6 +1268,7 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
     }
     if checked_sections != protected_sections:
         return None, {"rebased": rows, "aliases": alias_rows,
+                      "partitions": partition_rows,
                       "error": "storage rewrite changed content or relocation bytes"}
     checked_relocation_sections = {
         i: checked.get_section(i).data() for i in mutable_relocation_sections
@@ -1211,29 +1278,46 @@ def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):
     }
     if checked_relocation_sections != expected_relocation_sections:
         return None, {"rebased": rows, "aliases": alias_rows,
+                      "partitions": partition_rows,
                       "relocations": relocation_rewrites,
                       "error": "storage rewrite changed more than licensed RELA addends"}
-    for name, alias in aliases.items():
-        matches = [sym for sym in checked_symbols
-                   if sym.name == alias["symbol"]]
+    for name, synthetics in synthesized.items():
         vtables = [sym for sym in checked_symbols if sym.name == name]
-        if len(matches) != 1 or len(vtables) != 1:
+        if len(vtables) != 1:
             return None, {"rebased": rows, "aliases": alias_rows,
-                          "error": f"post-rewrite alias/vtable uniqueness failed for "
-                                   f"{alias['symbol']}/{name}"}
-        got, vtable = matches[0], vtables[0]
-        if got["st_info"]["bind"] != "STB_GLOBAL" \
-                or got["st_info"]["type"] != "STT_OBJECT" \
-                or got["st_value"] != 0 or got["st_size"] != alias["size"] \
-                or got["st_shndx"] != vtable["st_shndx"] \
-                or vtable["st_value"] != alias["size"]:
+                          "partitions": partition_rows,
+                          "error": f"post-rewrite vtable uniqueness failed for {name}"}
+        vtable = vtables[0]
+        if vtable["st_value"] != requested[name]["bias"] \
+                or vtable["st_size"] != requested[name]["publicSize"]:
             return None, {"rebased": rows, "aliases": alias_rows,
-                          "error": f"post-rewrite storage split is not exact for "
-                                   f"{alias['symbol']}/{name}"}
+                          "partitions": partition_rows,
+                          "error": f"post-rewrite public vtable segment is not exact "
+                                   f"for {name}"}
+        for synthetic in synthetics:
+            matches = [sym for sym in checked_symbols
+                       if sym.name == synthetic["symbol"]]
+            if len(matches) != 1:
+                return None, {"rebased": rows, "aliases": alias_rows,
+                              "partitions": partition_rows,
+                              "error": f"post-rewrite symbol uniqueness failed for "
+                                       f"{synthetic['symbol']}/{name}"}
+            got = matches[0]
+            if got["st_info"]["bind"] != "STB_GLOBAL" \
+                    or got["st_info"]["type"] != "STT_OBJECT" \
+                    or got["st_other"]["visibility"] != "STV_DEFAULT" \
+                    or got["st_value"] != synthetic["value"] \
+                    or got["st_size"] != synthetic["size"] \
+                    or got["st_shndx"] != vtable["st_shndx"]:
+                return None, {"rebased": rows, "aliases": alias_rows,
+                              "partitions": partition_rows,
+                              "error": f"post-rewrite vtable split is not exact for "
+                                       f"{synthetic['symbol']}/{name}"}
     public_relocations = [{k: v for k, v in row.items()
                            if k not in ("sectionIndex", "entryOffset", "fileOffset")}
                           for row in relocation_rewrites]
     return out, {"rebased": rows, "aliases": alias_rows,
+                 "partitions": partition_rows,
                  "relocations": public_relocations, "error": None}
 
 

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -687,7 +687,7 @@ class Isolate(unittest.TestCase):
                                                    "donor": "_ZTI1P"}}}
         refused, why = OI.rebias_object_symbols(raw, live_donor)
         self.assertIsNone(refused)
-        self.assertIn("not an exact deadstripped", why["error"])
+        self.assertIn("not an exact undefined", why["error"])
 
         endian = "<" if elf.little_endian else ">"
         entry = symtab.header["sh_offset"] + index * 16
@@ -760,6 +760,114 @@ class Isolate(unittest.TestCase):
         refused, why = OI.rebias_object_symbols(bytes(bad), policy)
         self.assertIsNone(refused)
         self.assertIn("still referenced", why["error"])
+
+    def test_rebias_vtable_synthesizes_exact_interior_partition_symbols(self):
+        """Interior labels reuse only safe slots and never alter retained content."""
+        import io
+        import struct
+        from elftools.elf.elffile import ELFFile
+
+        whole = self.build(
+            "struct P { virtual ~P(); virtual void f(); virtual void g(); }; "
+            "P::~P(){} void P::f(){} void P::g(){} "
+            "struct Q { virtual ~Q(); }; Q::~Q(){}\n").read_bytes()
+        whole_elf = ELFFile(io.BytesIO(whole))
+        symbols = list(whole_elf.get_section_by_name(".symtab").iter_symbols())
+        licensed = [s.name for s in symbols
+                    if s.name and s["st_info"]["type"] == "STT_OBJECT"
+                    and isinstance(s["st_shndx"], int)
+                    and whole_elf.get_section(s["st_shndx"]).name == ".data"]
+        deferred = [{"symbol": s.name, "section": ".text", "size": s["st_size"]}
+                    for s in symbols if s.name and s["st_info"]["type"] == "STT_FUNC"
+                    and isinstance(s["st_shndx"], int)
+                    and whole_elf.get_section(s["st_shndx"]).name == ".text"
+                    and s["st_size"] > 0]
+        raw, partition = OI.derive_section_partition(
+            whole, [".data"], licensed, deferred)
+        self.assertIsNone(partition["error"])
+        elf = ELFFile(io.BytesIO(raw))
+        symtab = elf.get_section_by_name(".symtab")
+        symbols = list(symtab.iter_symbols())
+        vtable = next(s for s in symbols if s.name == "_ZTV1P")
+        donor1 = "_ZN1PD2Ev"
+        donor2 = "_ZN1QD2Ev"
+        donor2_index = next(i for i, s in enumerate(symbols) if s.name == donor2)
+
+        # Externalized RTTI donors are STB_LOPROC/OBJECT rather than GLOBAL/FUNC.
+        # Mutate one already-undefined, unreferenced test slot to that exact shape.
+        raw = bytearray(raw)
+        raw[symtab.header["sh_offset"] + donor2_index * 16 + 12] = 0xd1
+        raw = bytes(raw)
+        parsed = ELFFile(io.BytesIO(raw))
+        parsed_symbols = list(parsed.get_section_by_name(".symtab").iter_symbols())
+        donor2_row = next(s for s in parsed_symbols if s.name == donor2)
+        self.assertEqual((donor2_row["st_shndx"], donor2_row["st_info"]["bind"],
+                          donor2_row["st_info"]["type"]),
+                         ("SHN_UNDEF", "STB_LOPROC", "STT_OBJECT"))
+
+        total = vtable["st_size"]
+        self.assertGreater(total, 16)
+        policy = {"_ZTV1P": {
+            "bias": 8, "size": total, "section": ".data",
+            "partitionSymbols": [
+                {"symbol": "VT7", "value": 12, "size": 4, "donor": donor1},
+                {"symbol": "VT14", "value": 16, "size": total - 16,
+                 "donor": donor2},
+            ],
+        }}
+        before_content = {i: sec.data() for i, sec in enumerate(parsed.iter_sections())
+                          if sec.header["sh_type"] in OI.CONTENT
+                          and sec.header["sh_size"]}
+        out, report = OI.rebias_object_symbols(raw, policy)
+        self.assertIsNotNone(out, report)
+        self.assertIsNone(report["error"])
+        self.assertEqual([(row["symbol"], row["value"], row["size"])
+                          for row in report["partitions"]],
+                         [("VT7", 12, 4), ("VT14", 16, total - 16)])
+        result = ELFFile(io.BytesIO(out))
+        out_symbols = list(result.get_section_by_name(".symtab").iter_symbols())
+        got_vtable = next(s for s in out_symbols if s.name == "_ZTV1P")
+        self.assertEqual((got_vtable["st_value"], got_vtable["st_size"]), (8, 4))
+        for name, value, size in (("VT7", 12, 4), ("VT14", 16, total - 16)):
+            got = next(s for s in out_symbols if s.name == name)
+            self.assertEqual((got["st_value"], got["st_size"], got["st_shndx"]),
+                             (value, size, got_vtable["st_shndx"]))
+            self.assertEqual((got["st_info"]["bind"], got["st_info"]["type"]),
+                             ("STB_GLOBAL", "STT_OBJECT"))
+        self.assertFalse(any(s.name in (donor1, donor2) for s in out_symbols))
+        after_content = {i: sec.data() for i, sec in enumerate(result.iter_sections())
+                         if sec.header["sh_type"] in OI.CONTENT
+                         and sec.header["sh_size"]}
+        self.assertEqual(after_content, before_content)
+
+        def refused_with(partitions, phrase):
+            refused, why = OI.rebias_object_symbols(
+                raw, {"_ZTV1P": {**policy["_ZTV1P"],
+                                   "partitionSymbols": partitions}})
+            self.assertIsNone(refused)
+            self.assertIn(phrase, why["error"])
+
+        refused_with([
+            {"symbol": "VT7", "value": 12, "size": 4, "donor": donor1},
+            {"symbol": "VT14", "value": 15, "size": total - 15,
+             "donor": donor2}], "overlaps")
+        refused_with([
+            {"symbol": "VT7", "value": 12, "size": 4, "donor": donor1},
+            {"symbol": "VT14", "value": 20, "size": total - 20,
+             "donor": donor2}], "leaves a gap")
+        refused_with([
+            {"symbol": "VT7", "value": 12, "size": 4, "donor": "missing"},
+            {"symbol": "VT14", "value": 16, "size": total - 16,
+             "donor": donor2}], "has 0 symbol-table slots")
+        refused_with([
+            {"symbol": "VT7", "value": 12, "size": 4, "donor": donor1},
+            {"symbol": "VT14", "value": 16, "size": total - 16,
+             "donor": donor1}], "is reused")
+        refused_with([
+            {"symbol": "VT7", "value": 12, "size": 4,
+             "donor": "_ZN1PD0Ev"},
+            {"symbol": "VT14", "value": 16, "size": total - 16,
+             "donor": donor2}], "still referenced")
 
     def test_rebias_vtable_preserves_live_reference_targets(self):
         """Whole-object vptr stores keep their target while _ZTV moves by eight."""

--- a/tools/test_tu_production.py
+++ b/tools/test_tu_production.py
@@ -242,6 +242,60 @@ class ProductionTuObjects(unittest.TestCase):
         self.assertEqual(evidence["sha256"],
                          __import__("hashlib").sha256(b"linked").hexdigest())
 
+    def test_partitioned_object_normalizes_undefined_vtable_imports(self):
+        entry = {
+            "id": "ov999/Thing", "module": "ov999",
+            "source": "src/actors/Thing.cpp",
+            "functions": [{"symbol": "Thing_f", "ordinal": 0,
+                           "legacy_source": "src/Thing_f.cpp"}],
+        }
+        claims = [{"name": ".text", "start": 0x1000, "end": 0x1010},
+                  {"name": ".data", "start": 0x2000, "end": 0x2010}]
+        owned = {"ok": True, "rows": [], "errors": []}
+        biases = {"_ZTV1T": {"bias": 8}}
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config = root / "config"
+            module = config / "overlays" / "ov999"
+            module.mkdir(parents=True)
+            (module / "delinks.txt").write_text("placeholder\n", encoding="utf-8")
+            with mock.patch.object(TP.TB, "manifest_section_claims",
+                                   return_value=(claims, [])), \
+                    mock.patch.object(TP.TB, "add_partitioned_tu_entry",
+                                      return_value=(["src/Thing_f.cpp"], [])), \
+                    mock.patch.object(TP.TB, "_compile_tu",
+                                      return_value=(b"raw", "2004/b56", ["-O4"],
+                                                    root, root / "raw.o")), \
+                    mock.patch.object(TP.TB, "derive_function_objects",
+                                      return_value={"Thing_f": (b"text", {})}), \
+                    mock.patch.object(TP.TB, "production_objects",
+                                      return_value=({}, [])), \
+                    mock.patch.object(TP.TB, "partial_report", return_value=[
+                        (0, "Thing_f", {"identical": True})]), \
+                    mock.patch.object(TP.TB, "apply_compiler_only_policy",
+                                      return_value=(b"compiler", {}, [])), \
+                    mock.patch.object(TP.TB, "apply_externalized_output_policy",
+                                      return_value=(b"external", {}, [])), \
+                    mock.patch.object(TP.TB, "verify_owned_sections",
+                                      side_effect=[owned, owned]) as verify, \
+                    mock.patch.object(TP.TB, "derive_owned_nontext_object",
+                                      return_value=(b"storage", {}, [])), \
+                    mock.patch.object(TP.TB, "partition_vtable_rebiases",
+                                      return_value=(biases, [])), \
+                    mock.patch.object(TP.TB.OI, "rebias_object_symbols",
+                                      return_value=(b"linked", {"error": None})) as rebias:
+                result = TP._prepare_one(entry, config, root / "work", 1)
+
+        rebias.assert_called_once_with(
+            b"storage", biases, normalize_undefined=True)
+        self.assertEqual(verify.call_args_list, [
+            mock.call(b"external", entry, claims),
+            mock.call(b"linked", entry, claims, public_address_points=True,
+                      normalized_undefined_vtables=True),
+        ])
+        self.assertEqual(result["storageSha256"],
+                         __import__("hashlib").sha256(b"linked").hexdigest())
+
     def test_compile_one_installs_prepared_object_without_compiler(self):
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)

--- a/tools/test_tu_production.py
+++ b/tools/test_tu_production.py
@@ -228,12 +228,15 @@ class ProductionTuObjects(unittest.TestCase):
                                   return_value=(b"linked", {"error": None})) as rebias, \
                 mock.patch.object(TP.TB, "complete_ranges", return_value={}), \
                 mock.patch.object(TP.TB, "audit_tu_object",
-                                  return_value=([], [], [], True)), \
+                                  return_value=([], [], [], True)) as audit, \
                 mock.patch.object(TP.TB, "object_audit_refusals", return_value=[]):
             output, evidence = TP.prepare_intact_object(b"raw", entry)
         self.assertEqual(output, b"linked")
         rebias.assert_called_once_with(
             b"external", {"_ZTV1T": {"bias": 8}}, normalize_undefined=True)
+        audit.assert_called_once_with(
+            b"linked", entry, 0x1000, 0x1010, {},
+            validated_vtable_policies={"_ZTV1T": {"bias": 8}})
         self.assertEqual(verify.call_args_list, [
             mock.call(b"external", entry, claims),
             mock.call(b"linked", entry, claims, public_address_points=True,

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -757,6 +757,46 @@ def test_owned_rtti_raw_external_vtable_address_point_is_not_double_counted():
                 if int(row["source"], 0) == si_source)["verdict"] == "WRONG-DEST"
 
 
+def test_partitioned_nontext_normalizes_imports_and_rebiases_retained_vtables():
+    if not _toolchain():
+        return
+    from unittest import mock
+
+    obj, entry, claims, config, name_index, target_reader = \
+        _owned_rtti_external_vtable_fixture()
+    biases = {
+        row["symbol"]: {
+            "bias": 8, "size": int(row["size"], 0), "section": ".data"}
+        for row in entry["data"] if row["symbol"].startswith("_ZTV")
+    }
+    real_verify = tubuild.verify_owned_sections
+
+    def verify(candidate_obj, candidate_entry, candidate_claims, **kwargs):
+        assert kwargs == {
+            "public_address_points": True,
+            "normalized_undefined_vtables": True,
+        }
+        return real_verify(
+            candidate_obj, candidate_entry, candidate_claims,
+            name_index=name_index, config_relocs=config, sym_index={},
+            target_reader=target_reader, symbol_homes={}, bss_boundaries=set(),
+            **kwargs)
+
+    with mock.patch.object(tubuild, "verify_owned_sections", verify):
+        prepared, rebias, owned = tubuild.prepare_partitioned_nontext_vtables(
+            obj, entry, claims, biases)
+
+    assert prepared is not None, rebias
+    assert owned["ok"], owned["errors"]
+    assert rebias["rebased"]
+    assert all(row["newValue"] - row["oldValue"] == 8
+               for row in rebias["rebased"])
+    assert any(row["symbol"].startswith("_ZTVN3abi")
+               and row["oldAddend"] == 8 and row["newAddend"] == 0
+               and row["mode"] == "undefined-public-import"
+               for row in rebias["relocations"])
+
+
 def test_nontext_verifier_checks_layout_bytes_symbols_and_reloc_destinations():
     if not _toolchain():
         return

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1607,6 +1607,102 @@ def test_partitioned_vtable_rebias_needs_one_unique_configured_public_home():
         tubuild.all_symbol_homes = original
 
 
+def test_partitioned_vtable_interior_symbols_require_exact_policy_and_baseline():
+    entry = {
+        "module": "ov999", "functions": [],
+        "externalized_output": [
+            {"symbol": "_ZTS1B", "disposition": "canonical-import"},
+            {"symbol": "_ZTS1A", "disposition": "canonical-import"},
+        ],
+        "data": [{
+            "symbol": "_ZTV1P", "address": "0x2008",
+            "emitted_storage_address": "0x2000", "address_point_bias": "0x8",
+            "size": "0x30", "partition_symbols": [
+                {"symbol": "VT7", "address": "0x2010", "size": "0x8",
+                 "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                 "visibility": "STV_DEFAULT", "reuse_policy_symbol": "_ZTS1B"},
+                {"symbol": "VT14", "address": "0x2018", "size": "0x18",
+                 "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                 "visibility": "STV_DEFAULT", "reuse_policy_symbol": "_ZTS1A"},
+            ],
+        }], "bss": [],
+    }
+    claims = [{"name": ".data", "start": 0x2000, "end": 0x2030}]
+    baseline = {
+        "_ZTV1P": [{"address": 0x2008, "size": 8, "binding": "STB_GLOBAL",
+                     "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
+                     "sectionIndex": 4, "section": ".data"}],
+        "VT7": [{"address": 0x2010, "size": 8, "binding": "STB_GLOBAL",
+                 "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
+                 "sectionIndex": 4, "section": ".data"}],
+        "VT14": [{"address": 0x2018, "size": 0x18, "binding": "STB_GLOBAL",
+                  "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
+                  "sectionIndex": 4, "section": ".data"}],
+    }
+    homes = {"_ZTV1P": [("ov999", 0x2008)], "VT7": [("ov999", 0x2010)],
+             "VT14": [("ov999", 0x2018)]}
+    original_homes = tubuild.all_symbol_homes
+    original_linked = tubuild.linked_symbol_rows
+    try:
+        tubuild.all_symbol_homes = lambda: homes
+        policies, reasons = tubuild.partition_vtable_rebiases(
+            entry, claims, baseline_symbols=baseline, baseline_sha256="c" * 64)
+        assert reasons == []
+        policy = policies["_ZTV1P"]
+        assert policy["publicSize"] == 8
+        assert [(row["symbol"], row["value"], row["size"], row["donor"])
+                for row in policy["partitionSymbols"]] == [
+                    ("VT7", 0x10, 8, "_ZTS1B"),
+                    ("VT14", 0x18, 0x18, "_ZTS1A")]
+        assert policy["baseline"]["elfSha256"] == "c" * 64
+        assert [row[1]["symbol"] for row in
+                tubuild.manifest_vtable_partition_rows(entry)] == ["VT7", "VT14"]
+
+        tubuild.linked_symbol_rows = lambda _path, _names: (baseline, None)
+        proof = tubuild.verify_linked_storage_aliases("ignored.o", policies)
+        assert proof["ok"] and proof["rows"][0]["exact"]
+        wrong_baseline = {key: [dict(row) for row in value]
+                          for key, value in baseline.items()}
+        wrong_baseline["VT14"][0]["sectionIndex"] = 5
+        _policies, reasons = tubuild.partition_vtable_rebiases(
+            entry, claims, baseline_symbols=wrong_baseline,
+            baseline_sha256="d" * 64)
+        assert any("baseline metadata differs" in reason for reason in reasons)
+
+        import copy
+        overlap = copy.deepcopy(entry)
+        overlap["data"][0]["partition_symbols"][1].update(
+            {"address": "0x2014", "size": "0x1c"})
+        _policies, reasons = tubuild.partition_vtable_rebiases(
+            overlap, claims, baseline_symbols=baseline)
+        assert any("overlaps" in reason for reason in reasons)
+
+        gap = copy.deepcopy(entry)
+        gap["data"][0]["partition_symbols"][1].update(
+            {"address": "0x201c", "size": "0x14"})
+        tubuild.all_symbol_homes = lambda: {
+            **homes, "VT14": [("ov999", 0x201c)]}
+        _policies, reasons = tubuild.partition_vtable_rebiases(
+            gap, claims, baseline_symbols=baseline)
+        assert any("leaves a gap" in reason for reason in reasons)
+
+        bad_donor = copy.deepcopy(entry)
+        bad_donor["data"][0]["partition_symbols"][0]["reuse_policy_symbol"] = "missing"
+        tubuild.all_symbol_homes = lambda: homes
+        _policies, reasons = tubuild.partition_vtable_rebiases(
+            bad_donor, claims, baseline_symbols=baseline)
+        assert any("not an explicit compiler-only" in reason for reason in reasons)
+
+        reused = copy.deepcopy(entry)
+        reused["data"][0]["partition_symbols"][1]["reuse_policy_symbol"] = "_ZTS1B"
+        _policies, reasons = tubuild.partition_vtable_rebiases(
+            reused, claims, baseline_symbols=baseline)
+        assert any("donor _ZTS1B is reused" in reason for reason in reasons)
+    finally:
+        tubuild.all_symbol_homes = original_homes
+        tubuild.linked_symbol_rows = original_linked
+
+
 def test_partition_baseline_evidence_is_content_bound_not_mtime_bound():
     with tempfile.TemporaryDirectory() as td:
         root = pathlib.Path(td)

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1263,6 +1263,63 @@ def test_object_audit_makes_an_extra_unclaimed_object_and_section_fatal():
     assert any("unlicensed content section .data" in r for r in reasons)
 
 
+def test_object_audit_licenses_only_validated_manifest_vtable_partitions():
+    from unittest import mock
+
+    def partition(name, address, size):
+        return {"symbol": name, "address": hex(address), "size": hex(size),
+                "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                "visibility": "STV_DEFAULT", "reuse_policy_symbol": "donor"}
+
+    def proven(name, address, size):
+        return {"symbol": name, "address": address, "size": size,
+                "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                "visibility": "STV_DEFAULT", "baseline": {
+                    "symbol": {"address": address, "size": size,
+                               "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                               "visibility": "STV_DEFAULT", "section": ".data",
+                               "sectionIndex": 4},
+                    "vtable": {"sectionIndex": 4},
+                }}
+
+    entry = {"module": "ov999", "functions": [], "sections": [
+        {"name": ".text", "start": "0x1000", "end": "0x1004"},
+        {"name": ".data", "start": "0x2000", "end": "0x2030"}],
+        "data": [{"symbol": "_ZTV1P", "address": "0x2008", "size": "0x30",
+                  "partition_symbols": [partition("VT7", 0x2010, 8),
+                                          partition("RawOnly", 0x2018, 0x18)]}],
+        "bss": []}
+    policies = {"_ZTV1P": {"section": ".data", "partitionSymbols": [
+        proven("VT7", 0x2010, 8),
+        proven("ArbitraryCollision", 0x2040, 8),
+    ]}}
+    inventory = {
+        "sections": [{"index": 4, "name": ".data", "size": 0,
+                      "type": "SHT_PROGBITS"}],
+        "symbols": [
+            {"name": name, "bind": "STB_GLOBAL", "type": "STT_OBJECT",
+             "size": size, "shndx": 4}
+            for name, size in (("VT7", 8), ("RawOnly", 0x18),
+                               ("ArbitraryCollision", 8))],
+    }
+    homes = {"VT7": [("ov999", 0x2010)],
+             "RawOnly": [("ov999", 0x2018)],
+             "ArbitraryCollision": [("ov999", 0x2040)]}
+    with mock.patch.object(tubuild, "elf_inventory", return_value=inventory), \
+            mock.patch.object(tubuild, "all_symbol_homes", return_value=homes):
+        rows, extra, _emitted, order_ok = tubuild.audit_tu_object(
+            b"ignored", entry, 0x1000, 0x1004, ranges={"ov999": []},
+            validated_vtable_policies=policies)
+
+    verdicts = {row["name"]: row["verdict"] for row in rows}
+    assert verdicts == {"VT7": "LICENSED", "RawOnly": "COLLIDES-GAP",
+                        "ArbitraryCollision": "COLLIDES-GAP"}
+    reasons = tubuild.object_audit_refusals(rows, extra, order_ok)
+    assert not any("VT7" in reason for reason in reasons)
+    assert any("RawOnly" in reason for reason in reasons)
+    assert any("ArbitraryCollision" in reason for reason in reasons)
+
+
 def test_vague_inherited_rtti_coalescing_remains_explicitly_unsupported():
     """Two TUs emit the same STB_LOPROC base metadata; linker behavior is not a license."""
     if not _toolchain():
@@ -1846,6 +1903,14 @@ def test_partitioned_result_gate_requires_every_full_rom_proof():
         assert not tubuild.partitioned_link_ready(**bad), key
 
 
+def test_intact_link_gate_requires_final_vtable_split_symbol_fidelity():
+    good = dict(module_ok=True, symbols_ok=True, rom_ok=True,
+                split_symbols_ok=True)
+    assert tubuild.linkcheck_pipeline_ready(**good)
+    bad = dict(good, split_symbols_ok=False)
+    assert not tubuild.linkcheck_pipeline_ready(**bad)
+
+
 def test_partitioned_recorder_is_compact_orthogonal_and_preserves_verified_evidence():
     entry = {"id": "ov999/T", "status": "data-verified"}
     data = {"entries": [entry]}
@@ -1925,6 +1990,8 @@ def test_record_linkcheck_preserves_all_owned_ranges():
             {"section": ".data", "differingBytes": 0},
         ],
         "objectAudit": {},
+        "linkedStorageAliases": {"ok": True, "rows": [{"exact": True}],
+                                  "errors": []},
         "symbolsNew": [],
         "analysis": {"moduleFidelity": {"moduleSetSha256": "b" * 64}},
         "rom": {"matchesStockRom": True, "sha256": "a" * 64},
@@ -1940,6 +2007,7 @@ def test_record_linkcheck_preserves_all_owned_ranges():
     assert recorded["tuRange"] == report["tuRange"]
     assert recorded["tuRanges"] == report["tuRanges"]
     assert recorded["moduleSetSha256"] == "b" * 64
+    assert recorded["linkedStorageAliases"] == report["linkedStorageAliases"]
 
 # ---------------------------------------------------------------- create repairs
 # The three assemble_shadow_source behaviors proven by six modules of

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1277,7 +1277,7 @@ def test_object_audit_licenses_only_validated_manifest_vtable_partitions():
                 "visibility": "STV_DEFAULT", "baseline": {
                     "symbol": {"address": address, "size": size,
                                "binding": "STB_GLOBAL", "type": "STT_OBJECT",
-                               "visibility": "STV_DEFAULT", "section": ".data",
+                               "visibility": "STV_DEFAULT", "section": "OV999",
                                "sectionIndex": 4},
                     "vtable": {"sectionIndex": 4},
                 }}
@@ -1688,13 +1688,13 @@ def test_partitioned_vtable_interior_symbols_require_exact_policy_and_baseline()
     baseline = {
         "_ZTV1P": [{"address": 0x2008, "size": 8, "binding": "STB_GLOBAL",
                      "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
-                     "sectionIndex": 4, "section": ".data"}],
+                     "sectionIndex": 4, "section": "OV999"}],
         "VT7": [{"address": 0x2010, "size": 8, "binding": "STB_GLOBAL",
                  "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
-                 "sectionIndex": 4, "section": ".data"}],
+                 "sectionIndex": 4, "section": "OV999"}],
         "VT14": [{"address": 0x2018, "size": 0x18, "binding": "STB_GLOBAL",
                   "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
-                  "sectionIndex": 4, "section": ".data"}],
+                  "sectionIndex": 4, "section": "OV999"}],
     }
     homes = {"_ZTV1P": [("ov999", 0x2008)], "VT7": [("ov999", 0x2010)],
              "VT14": [("ov999", 0x2018)]}
@@ -1714,6 +1714,27 @@ def test_partitioned_vtable_interior_symbols_require_exact_policy_and_baseline()
         assert policy["baseline"]["elfSha256"] == "c" * 64
         assert [row[1]["symbol"] for row in
                 tubuild.manifest_vtable_partition_rows(entry)] == ["VT7", "VT14"]
+        assert tubuild.validated_vtable_partition_symbols(entry, policies) == {
+            "VT7", "VT14"}
+
+        # This is the ordinary intact call shape: the manifest owns input ``.data``,
+        # while the validated stock final-link metadata names its output section after
+        # the module.  Same linked section index proves the parent/part relationship.
+        inventory = {
+            "sections": [{"index": 4, "name": ".data", "size": 0,
+                          "type": "SHT_PROGBITS"}],
+            "symbols": [{"name": name, "bind": "STB_GLOBAL",
+                         "type": "STT_OBJECT", "size": size, "shndx": 4}
+                        for name, size in (("VT7", 8), ("VT14", 0x18))],
+        }
+        from unittest import mock
+        with mock.patch.object(tubuild, "elf_inventory", return_value=inventory):
+            rows, extra, _emitted, order_ok = tubuild.audit_tu_object(
+                b"ignored", entry, 0x1000, 0x1004, ranges={"ov999": []},
+                validated_vtable_policies=policies)
+        assert {row["name"]: row["verdict"] for row in rows} == {
+            "VT7": "LICENSED", "VT14": "LICENSED"}
+        assert tubuild.object_audit_refusals(rows, extra, order_ok) == []
 
         tubuild.linked_symbol_rows = lambda _path, _names: (baseline, None)
         proof = tubuild.verify_linked_storage_aliases("ignored.o", policies)

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -69,7 +69,8 @@ def prepare_intact_object(raw, entry):
 
     span_start, span_end = text[0]["start"], text[0]["end"]
     rows, extra, emitted, order_ok = TB.audit_tu_object(
-        linked_obj, entry, span_start, span_end, TB.complete_ranges(TB.CFG_ARM9))
+        linked_obj, entry, span_start, span_end, TB.complete_ranges(TB.CFG_ARM9),
+        validated_vtable_policies=biases)
     audit_errors = TB.object_audit_refusals(rows, extra, order_ok)
     if audit_errors:
         _raise(f"{entry['id']} production object audit", audit_errors)

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -342,12 +342,14 @@ def _prepare_one(entry, config_root, work_root, jobs):
     biases, reasons = TB.partition_vtable_rebiases(entry, claims)
     if reasons:
         _raise(f"{entry['id']} vtable address-point policy", reasons)
-    storage_obj, rebias = TB.OI.rebias_object_symbols(storage_obj, biases)
+    storage_obj, rebias = TB.OI.rebias_object_symbols(
+        storage_obj, biases, normalize_undefined=True)
     if storage_obj is None:
         _raise(f"{entry['id']} vtable address-point rewrite",
                [rebias.get("error")])
     owned_after = TB.verify_owned_sections(
-        storage_obj, entry, claims, public_address_points=True)
+        storage_obj, entry, claims, public_address_points=True,
+        normalized_undefined_vtables=True)
     if not owned_after.get("ok"):
         _raise(f"{entry['id']} reduced non-text contribution",
                owned_after.get("errors", []))

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -3280,6 +3280,18 @@ def partition_vtable_rebiases(entry, claims, baseline_symbols=None,
     return biases, reasons
 
 
+def prepare_partitioned_nontext_vtables(data_tu, entry, claims, biases):
+    """Normalize retained and imported vtables for the partitioned link object."""
+    data_tu, bias_report = OI.rebias_object_symbols(
+        data_tu, biases, normalize_undefined=True)
+    if data_tu is None:
+        return None, bias_report, None
+    owned = verify_owned_sections(
+        data_tu, entry, claims, public_address_points=True,
+        normalized_undefined_vtables=True)
+    return data_tu, bias_report, owned
+
+
 def verify_linked_storage_aliases(linked_elf, biases):
     """Require final-link alias/vtable metadata to reproduce the baseline pair."""
     pairs = [(name, policy["storageAlias"]) for name, policy in biases.items()
@@ -4308,7 +4320,8 @@ def cmd_linkcheck(args):
                 _write_link_report(scratch, report)
                 _record_partitioned(data, entry, report)
                 return 1
-            data_tu, bias_report = OI.rebias_object_symbols(data_tu, biases)
+            data_tu, bias_report, owned = prepare_partitioned_nontext_vtables(
+                data_tu, entry, claims, biases)
             report["vtableRebias"] = bias_report
             if data_tu is None:
                 print(f"      REFUSED -- vtable symbol rebias: {bias_report.get('error')}")
@@ -4319,8 +4332,6 @@ def cmd_linkcheck(args):
             report["partitionedObjects"]["linkedDataSha256"] = \
                 hashlib.sha256(data_tu).hexdigest()
 
-            owned = verify_owned_sections(data_tu, entry, claims,
-                                           public_address_points=True)
             report["ownedSections"] = owned
             for row in owned["rows"]:
                 print(f"      {row['section']:8} {row.get('start', '-')}.."

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -3065,9 +3065,9 @@ def validated_vtable_partition_symbols(entry, policies):
                 continue
             metadata = (baseline.get("address"), baseline.get("size"),
                         baseline.get("binding"), baseline.get("type"),
-                        baseline.get("visibility"), baseline.get("section"))
+                        baseline.get("visibility"))
             if metadata != (address, size, "STB_GLOBAL", "STT_OBJECT",
-                            "STV_DEFAULT", policy.get("section")):
+                            "STV_DEFAULT"):
                 continue
             if baseline.get("sectionIndex") != vtable.get("sectionIndex"):
                 continue

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2741,6 +2741,7 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
     expected_rows = manifest_owned_symbol_rows(entry)
     if public_address_points:
         expected_rows += manifest_storage_alias_rows(entry)
+        expected_rows += manifest_vtable_partition_rows(entry)
     expected_names = {r["symbol"] for _sec, r in expected_rows}
     emitted_names = {name for layout in layouts.values() for name, row in layout["symbols"].items()
                      if row["type"] in ("STT_FUNC", "STT_OBJECT") and not name.startswith("$")}
@@ -2790,7 +2791,19 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
                 reasons.append(f"licensed {section} symbol {name} has invalid size")
             else:
                 if public_address_points and address_bias:
-                    want_size -= address_bias
+                    partitions = expected.get("partition_symbols")
+                    if isinstance(partitions, list) and partitions:
+                        addresses = [_manifest_addr(row) for row in partitions
+                                     if isinstance(row, dict)]
+                        if len(addresses) != len(partitions) or any(
+                                address is None for address in addresses):
+                            reasons.append(f"licensed {section} symbol {name} has an "
+                                           "invalid partition_symbols address")
+                            want_size = 0
+                        else:
+                            want_size = min(addresses) - public_addr
+                    else:
+                        want_size -= address_bias
                 if want_size <= 0:
                     reasons.append(f"licensed {section} symbol {name} has no bytes after "
                                    f"address-point bias 0x{address_bias:x}")
@@ -2970,6 +2983,21 @@ def manifest_storage_alias_rows(entry):
             rows.append((section, {"symbol": alias.get("symbol"),
                                    "address": alias.get("address"),
                                    "size": alias.get("size")}))
+    return rows
+
+
+def manifest_vtable_partition_rows(entry):
+    """Nested public-range symbols licensed only after exact vtable partitioning."""
+    rows = []
+    for section, row in manifest_owned_symbol_rows(entry):
+        partitions = row.get("partition_symbols")
+        if not isinstance(partitions, list):
+            continue
+        for part in partitions:
+            if isinstance(part, dict):
+                rows.append((section, {"symbol": part.get("symbol"),
+                                       "address": part.get("address"),
+                                       "size": part.get("size")}))
     return rows
 
 
@@ -3155,6 +3183,18 @@ def partition_vtable_rebiases(entry, claims, baseline_symbols=None,
     biases, reasons = {}, []
     compiler_only = {row.get("symbol"): row for row in
                      entry.get("compiler_only_output", []) if isinstance(row, dict)}
+    externalized = {row.get("symbol"): row for row in
+                    entry.get("externalized_output", []) if isinstance(row, dict)}
+    used_donors, used_partition_names = set(), set()
+
+    def policy_donor_ok(symbol):
+        compiler = compiler_only.get(symbol)
+        external = externalized.get(symbol)
+        return ((compiler is not None and compiler.get("disposition") in
+                 ("deadstrip", "deadstrip-duplicate", "deadstrip-data"))
+                or (external is not None
+                    and external.get("disposition") == "canonical-import"))
+
     for section, row in manifest_owned_symbol_rows(entry):
         name = row["symbol"]
         if section not in claimed or not name.startswith("_ZTV"):
@@ -3193,7 +3233,8 @@ def partition_vtable_rebiases(entry, claims, baseline_symbols=None,
                            f"found {rendered or 'none'}")
             continue
         policy = {"bias": bias, "size": size, "section": section,
-                  "storageAddress": storage, "publicAddress": public}
+                  "storageAddress": storage, "publicAddress": public,
+                  "partitionSymbols": []}
         alias = row.get("storage_alias")
         if alias is not None:
             label = f"retained vtable {name} storage_alias"
@@ -3220,10 +3261,12 @@ def partition_vtable_rebiases(entry, claims, baseline_symbols=None,
             if alias.get("binding") != "STB_GLOBAL" or alias.get("type") != "STT_OBJECT" \
                     or alias.get("visibility") != "STV_DEFAULT":
                 reasons.append(f"{label} must require GLOBAL/OBJECT/DEFAULT visibility")
-            donor_row = compiler_only.get(donor)
-            if not donor_row or donor_row.get("disposition") != "deadstrip":
+            if not policy_donor_ok(donor):
                 reasons.append(f"{label} donor {donor} is not an explicit compiler-only "
-                               "deadstrip policy")
+                               "deadstrip or externalized canonical-import policy")
+            if donor in used_donors:
+                reasons.append(f"{label} donor {donor} is reused")
+            used_donors.add(donor)
             alias_homes = {(RL.normalize_module(module), address)
                            for module, address in homes.get(alias_name, [])}
             if alias_homes != {(owner_module, storage)}:
@@ -3237,46 +3280,144 @@ def partition_vtable_rebiases(entry, claims, baseline_symbols=None,
                 "binding": "STB_GLOBAL", "type": "STT_OBJECT",
                 "visibility": "STV_DEFAULT", "donor": donor,
             }
+
+        raw_partitions = row.get("partition_symbols", [])
+        if raw_partitions is None:
+            raw_partitions = []
+        if not isinstance(raw_partitions, list):
+            reasons.append(f"retained vtable {name} partition_symbols must be a list")
+            raw_partitions = []
+        partitions = []
+        for index, part in enumerate(raw_partitions):
+            label = f"retained vtable {name} partition_symbols[{index}]"
+            if not isinstance(part, dict):
+                reasons.append(f"{label} must be an object")
+                continue
+            try:
+                part_name = str(part["symbol"])
+                part_address = (int(part["address"], 0)
+                                if isinstance(part["address"], str)
+                                else int(part["address"]))
+                part_size = (int(part["size"], 0) if isinstance(part["size"], str)
+                             else int(part["size"]))
+                donor = str(part["reuse_policy_symbol"])
+            except (KeyError, TypeError, ValueError):
+                reasons.append(f"{label} needs symbol/address/size/reuse_policy_symbol")
+                continue
+            if not part_name or part_name.startswith("_ZTV"):
+                reasons.append(f"{label} has invalid symbol {part_name!r}")
+            if part_name in used_partition_names:
+                reasons.append(f"{label} reuses partition symbol {part_name}")
+            used_partition_names.add(part_name)
+            if part_size <= 0:
+                reasons.append(f"{label} has non-positive size 0x{part_size:x}")
+            if part.get("binding") != "STB_GLOBAL" \
+                    or part.get("type") != "STT_OBJECT" \
+                    or part.get("visibility") != "STV_DEFAULT":
+                reasons.append(f"{label} must require GLOBAL/OBJECT/DEFAULT visibility")
+            if not policy_donor_ok(donor):
+                reasons.append(f"{label} donor {donor} is not an explicit compiler-only "
+                               "deadstrip or externalized canonical-import policy")
+            if donor in used_donors:
+                reasons.append(f"{label} donor {donor} is reused")
+            used_donors.add(donor)
+            part_homes = {(RL.normalize_module(module), address)
+                          for module, address in homes.get(part_name, [])}
+            if part_homes != {(owner_module, part_address)}:
+                rendered = [f"{module}:0x{address:08x}"
+                            for module, address in sorted(part_homes)]
+                reasons.append(f"{label} needs one unique configured home "
+                               f"{owner_module}:0x{part_address:08x}; found "
+                               f"{rendered or 'none'}")
+            partitions.append({
+                "symbol": part_name, "address": part_address, "size": part_size,
+                "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                "visibility": "STV_DEFAULT", "donor": donor,
+                "value": part_address - storage,
+            })
+        partitions.sort(key=lambda part: part["address"])
+        storage_end = storage + size
+        if partitions:
+            if partitions[0]["address"] <= public:
+                reasons.append(f"retained vtable {name} first partition must start after "
+                               f"public address 0x{public:08x}")
+            cursor = partitions[0]["address"]
+            for part in partitions:
+                if part["address"] != cursor:
+                    relation = "overlaps" if part["address"] < cursor else "leaves a gap"
+                    reasons.append(f"retained vtable {name} partition {part['symbol']} "
+                                   f"{relation} at 0x{cursor:08x}")
+                cursor = part["address"] + part["size"]
+            if cursor != storage_end:
+                relation = "overruns" if cursor > storage_end else "leaves a gap before"
+                reasons.append(f"retained vtable {name} partition coverage {relation} "
+                               f"storage end 0x{storage_end:08x} (ends 0x{cursor:08x})")
+            policy["publicSize"] = partitions[0]["address"] - public
+        else:
+            policy["publicSize"] = size - bias
+        policy["partitionSymbols"] = partitions
         biases[name] = policy
 
-    aliases = [(name, policy["storageAlias"]) for name, policy in biases.items()
-               if policy.get("storageAlias")]
-    if aliases:
-        wanted = {name for name, _alias in aliases} | \
-                 {alias["symbol"] for _name, alias in aliases}
+    split_policies = {name: policy for name, policy in biases.items()
+                      if policy.get("storageAlias") or policy.get("partitionSymbols")}
+    if split_policies:
+        wanted = set(split_policies)
+        for policy in split_policies.values():
+            if policy.get("storageAlias"):
+                wanted.add(policy["storageAlias"]["symbol"])
+            wanted.update(part["symbol"] for part in policy["partitionSymbols"])
         if baseline_symbols is None:
             baseline_symbols, baseline_sha256, error = _baseline_partition_symbols(wanted)
             if error:
-                reasons.append(f"storage alias baseline proof unavailable: {error}")
+                reasons.append(f"vtable partition baseline proof unavailable: {error}")
                 baseline_symbols = {}
-        for name, alias in aliases:
-            base_alias = (baseline_symbols or {}).get(alias["symbol"], [])
+        for name, policy in split_policies.items():
             base_vtable = (baseline_symbols or {}).get(name, [])
-            if len(base_alias) != 1 or len(base_vtable) != 1:
-                reasons.append(f"storage alias baseline needs one {alias['symbol']} and one "
-                               f"{name}; found {len(base_alias)}/{len(base_vtable)}")
+            symbols = ([policy["storageAlias"]] if policy.get("storageAlias") else []) \
+                + policy["partitionSymbols"]
+            missing = [(part["symbol"], len((baseline_symbols or {}).get(
+                        part["symbol"], []))) for part in symbols
+                       if len((baseline_symbols or {}).get(part["symbol"], [])) != 1]
+            if len(base_vtable) != 1 or missing:
+                reasons.append(f"vtable partition baseline needs one {name} and each "
+                               f"declared split symbol; found vtable={len(base_vtable)}, "
+                               f"splits={missing}")
                 continue
-            got_alias, got_vtable = base_alias[0], base_vtable[0]
-            expected_alias = (alias["address"], alias["size"], alias["binding"],
-                              alias["type"], alias["visibility"])
-            actual_alias = (got_alias["address"], got_alias["size"],
-                            got_alias["binding"], got_alias["type"],
-                            got_alias["visibility"])
-            expected_vtable = (biases[name]["publicAddress"],
-                               biases[name]["size"] - biases[name]["bias"],
+            got_vtable = base_vtable[0]
+            expected_vtable = (policy["publicAddress"], policy["publicSize"],
                                "STB_GLOBAL", "STT_OBJECT", "STV_DEFAULT")
             actual_vtable = (got_vtable["address"], got_vtable["size"],
                              got_vtable["binding"], got_vtable["type"],
                              got_vtable["visibility"])
-            if actual_alias != expected_alias or actual_vtable != expected_vtable \
-                    or got_alias["sectionIndex"] != got_vtable["sectionIndex"]:
-                reasons.append(f"storage alias baseline metadata differs for "
-                               f"{alias['symbol']}/{name}")
+            split_rows = {part["symbol"]:
+                          (baseline_symbols or {})[part["symbol"]][0]
+                          for part in symbols}
+            split_exact = all(
+                (got["address"], got["size"], got["binding"], got["type"],
+                 got["visibility"]) ==
+                (part["address"], part["size"], part["binding"], part["type"],
+                 part["visibility"])
+                and got["sectionIndex"] == got_vtable["sectionIndex"]
+                for part in symbols for got in [split_rows[part["symbol"]]])
+            if actual_vtable != expected_vtable or not split_exact:
+                reasons.append(f"vtable partition baseline metadata differs for {name}")
                 continue
-            biases[name]["storageAlias"]["baseline"] = {
-                "elfSha256": baseline_sha256, "alias": got_alias,
-                "vtable": got_vtable,
+            policy["baseline"] = {
+                "elfSha256": baseline_sha256, "vtable": got_vtable,
+                "symbols": split_rows,
             }
+            if policy.get("storageAlias"):
+                policy["storageAlias"]["baseline"] = {
+                    "elfSha256": baseline_sha256,
+                    "alias": split_rows[policy["storageAlias"]["symbol"]],
+                    "vtable": got_vtable,
+                }
+            for part in policy["partitionSymbols"]:
+                part["baseline"] = {
+                    "elfSha256": baseline_sha256,
+                    "symbol": split_rows[part["symbol"]],
+                    "vtable": got_vtable,
+                }
     return biases, reasons
 
 
@@ -3293,33 +3434,42 @@ def prepare_partitioned_nontext_vtables(data_tu, entry, claims, biases):
 
 
 def verify_linked_storage_aliases(linked_elf, biases):
-    """Require final-link alias/vtable metadata to reproduce the baseline pair."""
-    pairs = [(name, policy["storageAlias"]) for name, policy in biases.items()
-             if policy.get("storageAlias")]
-    if not pairs:
+    """Require every synthesized vtable split symbol to reproduce the baseline."""
+    splits = {name: policy for name, policy in biases.items()
+              if policy.get("storageAlias") or policy.get("partitionSymbols")}
+    if not splits:
         return {"ok": True, "rows": [], "errors": []}
-    wanted = {name for name, _alias in pairs} | {alias["symbol"] for _name, alias in pairs}
+    wanted = set(splits)
+    for policy in splits.values():
+        if policy.get("storageAlias"):
+            wanted.add(policy["storageAlias"]["symbol"])
+        wanted.update(part["symbol"] for part in policy["partitionSymbols"])
     symbols, error = linked_symbol_rows(linked_elf, wanted)
     if error:
         return {"ok": False, "rows": [], "errors": [error]}
     rows, reasons = [], []
-    for name, alias in pairs:
-        got_alias = symbols.get(alias["symbol"], [])
+    for name, policy in splits.items():
         got_vtable = symbols.get(name, [])
-        baseline = alias.get("baseline") or {}
-        if len(got_alias) != 1 or len(got_vtable) != 1:
-            reasons.append(f"linked storage split {alias['symbol']}/{name} occurs "
-                           f"{len(got_alias)}/{len(got_vtable)} times")
+        parts = ([policy["storageAlias"]] if policy.get("storageAlias") else []) \
+            + policy["partitionSymbols"]
+        got_parts = {part["symbol"]: symbols.get(part["symbol"], []) for part in parts}
+        wrong_counts = {symbol: len(found) for symbol, found in got_parts.items()
+                        if len(found) != 1}
+        if len(got_vtable) != 1 or wrong_counts:
+            reasons.append(f"linked vtable split {name} occurs {len(got_vtable)} times; "
+                           f"split counts={wrong_counts}")
             continue
-        same = (got_alias[0] == baseline.get("alias")
-                and got_vtable[0] == baseline.get("vtable")
-                and got_alias[0]["sectionIndex"] == got_vtable[0]["sectionIndex"])
-        rows.append({"alias": alias["symbol"], "vtable": name,
-                     "aliasMetadata": got_alias[0], "vtableMetadata": got_vtable[0],
+        baseline = policy.get("baseline") or {}
+        actual_parts = {symbol: found[0] for symbol, found in got_parts.items()}
+        same = (got_vtable[0] == baseline.get("vtable")
+                and actual_parts == baseline.get("symbols")
+                and all(row["sectionIndex"] == got_vtable[0]["sectionIndex"]
+                        for row in actual_parts.values()))
+        rows.append({"vtable": name, "vtableMetadata": got_vtable[0],
+                     "splitSymbols": actual_parts,
                      "baselineElfSha256": baseline.get("elfSha256"), "exact": same})
         if not same:
-            reasons.append(f"linked storage split {alias['symbol']}/{name} does not "
-                           "match baseline metadata")
+            reasons.append(f"linked vtable split {name} does not match baseline metadata")
     return {"ok": not reasons, "rows": rows, "errors": reasons}
 
 
@@ -4530,9 +4680,9 @@ def cmd_linkcheck(args):
         storage_aliases_ok = linked_aliases["ok"]
         if linked_aliases["ok"]:
             count = len(linked_aliases["rows"])
-            print(f"      storage-prefix alias fidelity: {count}/{count} exact vs baseline")
+            print(f"      vtable split-symbol fidelity: {count}/{count} exact vs baseline")
         else:
-            print("      storage-prefix alias fidelity: FAIL")
+            print("      vtable split-symbol fidelity: FAIL")
             for reason in linked_aliases["errors"]:
                 print(f"        {reason}")
 
@@ -4728,7 +4878,7 @@ def cmd_linkcheck(args):
         else:
             print(f"Result: NOT partitioned-link-verified ({n_ok}/"
                   f"{len(partial_rows)} text contributions; data_ok="
-                  f"{partition_data_ok}; storage aliases exact={storage_aliases_ok}; "
+                  f"{partition_data_ok}; vtable splits exact={storage_aliases_ok}; "
                   "full ROM exact="
                   f"{report.get('rom', {}).get('matchesStockRom') is True}).")
     elif partial:

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1894,7 +1894,8 @@ def complete_ranges(config_root):
     return out
 
 
-def audit_tu_object(obj_bytes, entry, span_start, span_end, ranges=None):
+def audit_tu_object(obj_bytes, entry, span_start, span_end, ranges=None,
+                    validated_vtable_policies=None):
     """What the linker is about to be handed, judged against the config, BEFORE linking.
 
     plan sec 4.5 -- "a compiled object is eligible only when every defined function,
@@ -1915,6 +1916,8 @@ def audit_tu_object(obj_bytes, entry, span_start, span_end, ranges=None):
     homes = all_symbol_homes()
     licensed = {f["symbol"] for f in entry["functions"]}
     licensed |= {row["symbol"] for _sec, row in manifest_owned_symbol_rows(entry)}
+    licensed |= validated_vtable_partition_symbols(
+        entry, validated_vtable_policies)
     secname = {s["index"]: s["name"] for s in inv["sections"]}
     rows = []
     for s in inv["symbols"]:
@@ -2999,6 +3002,77 @@ def manifest_vtable_partition_rows(entry):
                                        "address": part.get("address"),
                                        "size": part.get("size")}))
     return rows
+
+
+def validated_vtable_partition_symbols(entry, policies):
+    """Names proven by successful ``partition_vtable_rebiases`` output.
+
+    Raw nested manifest rows are deliberately insufficient: a misspelled or otherwise
+    invalid partition must remain an unlicensed collision.  Callers pass policies only
+    after the validator returned no reasons, and this final boundary independently
+    cross-checks the manifest coordinates and content-bound baseline symbol metadata.
+    """
+    if not isinstance(policies, dict):
+        return set()
+    configured = {}
+    for section, owner in manifest_owned_symbol_rows(entry):
+        owner_name = owner.get("symbol")
+        partitions = owner.get("partition_symbols")
+        if not isinstance(owner_name, str) or not owner_name.startswith("_ZTV") \
+                or not isinstance(partitions, list):
+            continue
+        for part in partitions:
+            if not isinstance(part, dict):
+                continue
+            try:
+                name = str(part["symbol"])
+                address = (int(part["address"], 0) if isinstance(part["address"], str)
+                           else int(part["address"]))
+                size = int(part["size"], 0) if isinstance(part["size"], str) \
+                    else int(part["size"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            configured[(owner_name, name, address, size)] = (
+                section, part.get("binding"), part.get("type"),
+                part.get("visibility"))
+
+    licensed = set()
+    for owner_name, policy in policies.items():
+        if not isinstance(policy, dict):
+            continue
+        partitions = policy.get("partitionSymbols")
+        if not isinstance(partitions, list):
+            continue
+        for part in partitions:
+            if not isinstance(part, dict):
+                continue
+            try:
+                name = str(part["symbol"])
+                address, size = int(part["address"]), int(part["size"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            expected = configured.get((owner_name, name, address, size))
+            if expected != (policy.get("section"), "STB_GLOBAL", "STT_OBJECT",
+                             "STV_DEFAULT"):
+                continue
+            if (part.get("binding"), part.get("type"), part.get("visibility")) != \
+                    ("STB_GLOBAL", "STT_OBJECT", "STV_DEFAULT"):
+                continue
+            proof = part.get("baseline")
+            baseline = proof.get("symbol") if isinstance(proof, dict) else None
+            vtable = proof.get("vtable") if isinstance(proof, dict) else None
+            if not isinstance(baseline, dict) or not isinstance(vtable, dict):
+                continue
+            metadata = (baseline.get("address"), baseline.get("size"),
+                        baseline.get("binding"), baseline.get("type"),
+                        baseline.get("visibility"), baseline.get("section"))
+            if metadata != (address, size, "STB_GLOBAL", "STT_OBJECT",
+                            "STV_DEFAULT", policy.get("section")):
+                continue
+            if baseline.get("sectionIndex") != vtable.get("sectionIndex"):
+                continue
+            licensed.add(name)
+    return licensed
 
 
 def linked_symbol_rows(path, names):
@@ -4608,7 +4682,8 @@ def cmd_linkcheck(args):
             return 1
 
         rows, extra_secs, emitted, order_ok = audit_tu_object(
-            linked_tu, entry, span_start, span_end, complete_ranges(cfg_root))
+            linked_tu, entry, span_start, span_end, complete_ranges(cfg_root),
+            validated_vtable_policies=vtable_policies)
         buckets = print_object_audit(rows, extra_secs, emitted, order_ok, entry)
         report["objectAudit"] = {
             "counts": dict(buckets), "orderOk": order_ok,
@@ -4673,7 +4748,10 @@ def cmd_linkcheck(args):
             scratch / "final_link.o", config_root=cfg_root,
             tracked_config_root=CFG_ARM9)
 
-    if partitioned:
+    has_vtable_splits = any(
+        policy.get("storageAlias") or policy.get("partitionSymbols")
+        for policy in vtable_policies.values())
+    if has_vtable_splits:
         linked_aliases = verify_linked_storage_aliases(
             scratch / "final_link.o", vtable_policies)
         report["linkedStorageAliases"] = linked_aliases
@@ -4843,7 +4921,9 @@ def cmd_linkcheck(args):
     # ------------------------------------------------------------------------ verdict
     symbols_verdict = linkcheck_symbol_verdict(baseline, symbols_ok, symbols_new)
     equivalent = all(v["identical"] for _o, _s, v in partial_rows) if partial_rows else False
-    verified = bool(module_ok and symbols_verdict and (rom_ok is not False))
+    verified = linkcheck_pipeline_ready(
+        module_ok=module_ok, symbols_ok=symbols_verdict, rom_ok=rom_ok,
+        split_symbols_ok=storage_aliases_ok)
     if partitioned:
         verified = partitioned_link_ready(
             equivalent=bool(equivalent and partial_rows), data_ok=partition_data_ok,
@@ -4967,6 +5047,13 @@ def partitioned_link_ready(*, equivalent, data_ok, storage_aliases_ok, artifacts
     return all((equivalent, data_ok, storage_aliases_ok, artifacts_ok, module_ok,
                 modules_check_ok,
                 symbols_ok, rom_ok is True, rom_identical, no_stray_outputs))
+
+
+def linkcheck_pipeline_ready(*, module_ok, symbols_ok, rom_ok,
+                             split_symbols_ok=True):
+    """Shared link gate, including exact final-ELF vtable split metadata."""
+    return bool(module_ok and symbols_ok and (rom_ok is not False)
+                and split_symbols_ok)
 
 
 def classify_link_result(has_nontext, pipeline_ok, rom_ok, scratch_rewrite=False):
@@ -5124,6 +5211,7 @@ def _record_linkcheck(data, entry, report, baseline):
                 for r in audit.get("nonLicensed", [])],
             "unlicensedSections": audit.get("unlicensedSections"),
         },
+        "linkedStorageAliases": report.get("linkedStorageAliases"),
         "symbolCheckNewVsBaseline": report.get("symbolsNew"),
         "symbolCheckErrors": (((report.get("phases") or {}).get("checkSymbols") or {})
                               .get("errors")),


### PR DESCRIPTION
Tools-only prerequisite for compiler-owned class TUs.\n\n- normalize undefined ABI vtable imports in partitioned and production paths\n- support manifest-proven interior vtable partition symbols using policy-owned dead ELF slots\n- bind split metadata to the stock-control ELF and preserve content/relocation bytes\n\nValidation: py_compile; 35 objisolate tests; 56 tubuild tests; 18 tu_production tests; independent verifier READY. No src/, docs dashboard, claims, or attempt-ledger changes.