### PR TITLE
Wire #2091's vtable-partition licensing boundary into CI

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -27,14 +27,23 @@
 #
 #      test_tubuild deserves its own sentence, because it is the worst of the shapes and
 #      it is easy to look at its numbers and conclude the opposite. Run under pytest in
-#      that toolchain-free tree it reports "2 failed, 43 passed" -- which reads like a
-#      suite that is 95% wirable. It is not. Fifteen of its tests open with
-#      `if not _toolchain(): return`, and fourteen of those returns are bare, so those
-#      tests report PASS having asserted nothing. The honest split is 28 real passes, 15
-#      vacuous passes, 2 failures (`tubuild list` needs build/tu_map.json, which
-#      regenerates from the ROM and comes back empty without it). A bare `return` guard
-#      is strictly worse than a skip: `pytest -rs` cannot see it and neither can a
-#      reviewer reading a green log.
+#      that toolchain-free tree it used to report "2 failed, 43 passed" -- which reads
+#      like a suite that is 95% wirable. It was not: fifteen of its tests opened with
+#      `if not _toolchain(): return`, and fourteen of those returns were bare, so those
+#      tests reported PASS having asserted nothing. A bare `return` guard is strictly
+#      worse than a skip: `pytest -rs` cannot see it and neither can a reviewer reading
+#      a green log.
+#
+#      All sixteen of those guards now `raise unittest.SkipTest(...)` instead, so the
+#      pytest split is honest -- the vacuous passes became named skips and the two real
+#      failures stayed (`tubuild list` needs build/tu_map.json, which regenerates from
+#      the ROM and comes back empty without it). That does NOT make the module wirable,
+#      and the closing paragraph of this file used to imply it would. It has no
+#      `unittest.TestCase` at all, so `python -m unittest tools.test_tubuild` still finds
+#      zero tests; and a third of what it does have still compiles with mwccarm. Wiring
+#      it means converting 55 bare functions to methods, which is a change to the tests
+#      rather than to how they are invoked. Its three toolchain-free vtable-partition
+#      tests were moved out to test_tubuild_vtable_partitions instead -- see below.
 #
 #   2. NEEDS A PIP DEPENDENCY -- RESOLVED for the three modules added below, and that is
 #      what tools/requirements.txt now exists for. A bare runner has no pyelftools,
@@ -74,10 +83,11 @@
 # review. There is a sharper version of the same trap already in the tree: thirteen of the
 # 63 modules are pytest-style bare functions with no unittest.TestCase, so
 # `python -m unittest tools.test_tubuild` prints "Ran 0 tests ... OK" and exits 0. That
-# is 186 test functions that a glob would have silently counted as passing. Four of them
-# -- test_build_pin, test_dtor_members, test_opnew_sizes, test_tubuild -- also carry the
+# is 186 test functions that a glob would have silently counted as passing. Three of
+# them -- test_build_pin, test_dtor_members, test_opnew_sizes -- also carry the
 # bare-`return` toolchain guard that reports PASS rather than SKIP when the compiler is
-# missing. An explicit list makes adding a module a reviewed decision.
+# missing. (test_tubuild was the fourth; its sixteen guards are `unittest.SkipTest` now.)
+# An explicit list makes adding a module a reviewed decision.
 #
 # Nearly free: unittest over the working tree, no compiler, no ROM. It now costs one pip
 # step (two wheels, no build) and the network access that implies -- that is the whole
@@ -102,7 +112,10 @@
 # test_premerge_check adds none on a runner with git installed, and test_symrecords,
 # test_nearmiss_db, test_tu_map, test_tu_promote, test_tu_production and
 # test_tubuild_owned_relocs add none anywhere.
-# 505 of the 514 assert something.
+# 505 of the 514 assert something. test_tubuild_vtable_partitions adds four to both
+# halves of that -- all four assert and none skips -- but the 514 was measured in the
+# container and the +4 is arithmetic on it, not a re-measurement. On a Windows tree
+# WITH the toolchain the same 29 modules report 519 and three skips.
 name: tool tests
 
 on:
@@ -198,6 +211,7 @@ jobs:
             tools.test_tu_production \
             tools.test_tu_promote \
             tools.test_tubuild_owned_relocs \
+            tools.test_tubuild_vtable_partitions \
             tools.test_validate_merge
 
 # What each module protects, in the order it runs above:
@@ -329,13 +343,51 @@ jobs:
 #                                      `cand_addr != expected["target_address"]` is
 #                                      likewise caught here alone; `>=` -> `>` and
 #                                      disabling the normalized bias are caught by both.
+#   test_tubuild_vtable_partitions
+#                                (4)   tubuild's vtable-partition licensing boundary --
+#                                      the fail-closed path #2091 added, which refuses a
+#                                      manifest-declared symbol carved out of a vtable's
+#                                      public range unless `partition_vtable_rebiases`
+#                                      independently validated it against content-bound
+#                                      baseline ELF metadata. Three of the four are
+#                                      #2091's own tests, moved verbatim out of
+#                                      test_tubuild.py (bodies unchanged; `def f():` to
+#                                      `def f(self):` and one indent) because that file
+#                                      contributes zero tests to `python -m unittest`.
+#                                      Mock- and dict-driven: no compiler, no ROM, no
+#                                      config/ and no build/. 4 of 4 run in CI, none
+#                                      skips.
+#                                      WHY IT MATTERS NOW: measured on #2091's merge
+#                                      tree, that boundary licensed nothing at all -- 0
+#                                      of 97 manifest entries, 0 `partition_symbols` rows
+#                                      tree-wide -- and #2096 introduces the first two
+#                                      that have ever existed. It goes from unexercised
+#                                      to load-bearing in one PR.
+#                                      The fourth test is new and pins the invariant that
+#                                      is easiest to re-break: licensing compares
+#                                      `sectionIndex`, never section NAMES, because a
+#                                      linked ELF names a vtable's output section after
+#                                      its overlay (OV036/OV047/OV070 measured on the
+#                                      baseline link) while a manifest section is one of
+#                                      .rodata/.init/.ctor/.data/.bss. Comparing them
+#                                      refuses every real input, which is what made the
+#                                      whole path unreachable; 0b0e319 removed exactly
+#                                      that comparison. Mutation-checked both ways:
+#                                      deleting the `sectionIndex` equality is caught by
+#                                      the new test, and restoring the section-name
+#                                      comparison is caught by it and by the moved
+#                                      licensing test.
 #   test_validate_merge         (35)   validate_merge.py -- builds the machine-readable
 #                                      PR validation report the validator comment renders.
 #
-# The two suites this list still refuses, and the number that says why, measured on a
-# `git archive origin/main` tree with no toolchain: test_objisolate 0 pass / 34 skip
-# (every test in it compiles), test_tubuild 28 real pass / 15 vacuous / 2 fail. Neither
-# is a candidate until objisolate's fixtures stop needing mwcc and tubuild's bare
-# `return` guards become skips. See group 1 in the header. test_tubuild_owned_relocs
-# above is NOT a step toward wiring test_tubuild: it is a separate module precisely so
-# that adding it did not require relaxing that refusal.
+# The two suites this list still refuses, and the number that says why. test_objisolate
+# is one `@unittest.skipUnless(_compiler(), "mwccarm not present")` class and nothing
+# else, so on a runner it contributes 35 tests and 35 skips -- a green that asserts
+# nothing, which is the exact shape the header refuses a glob for. Adding it would still
+# catch a collection error in objisolate.py; that is not worth a hollow green, so it
+# stays out until its fixtures stop needing mwcc. test_tubuild has no
+# `unittest.TestCase`, so `python -m unittest` finds 0 of its 55 tests; its guards are
+# honest skips now, but that was never the binding constraint. Neither
+# test_tubuild_owned_relocs nor test_tubuild_vtable_partitions is a step toward wiring
+# test_tubuild: both are separate modules precisely so that adding them did not require
+# relaxing that refusal.

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import unittest
 
 TOOLS = pathlib.Path(__file__).resolve().parent
 REPO = TOOLS.parent
@@ -97,7 +98,8 @@ def test_inspect_polelift_reproduces_the_pilots_static_findings():
     """No compiler strictly needed for these fields, but build_pin.verify also runs
     inside `inspect`, so this is skipped without the toolchain like the rest."""
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     code, out = _run("inspect", "ov045/PoleLift")
     assert code == 0, out
     assert "classes           PoleLift" in out
@@ -124,7 +126,8 @@ def test_verify_reproduces_pilot_1s_7_of_7_and_clean_objisolate():
     involved, matching the assignment's instruction to skip it for this candidate.
     """
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     shadow = REPO / "src_tu" / "actors" / "PoleLift.cpp"
     assert shadow.is_file(), "the pilot's committed shadow TU is missing"
 
@@ -218,7 +221,8 @@ def test_compile_report_matches_the_pilots_object_inventory():
     naming this class is a dead reference with a scheduled fuse.
     """
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     code, out = _run("compile", "ov045/PoleLift")
     assert code == 0, out
     assert "sections (35):" in out
@@ -255,7 +259,8 @@ def test_partial_reproduces_the_production_per_function_objects():
     `--no-record` so the tracked manifest is not rewritten by running the suite.
     """
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     code, out = _run("partial", "ov045/PoleLift", "--no-record", timeout=600)
     assert code == 0, out
     for sym in ("_ZN8PoleLiftD1Ev", "_ZN8PoleLiftD0Ev",
@@ -638,7 +643,8 @@ def _owned_rtti_external_vtable_fixture():
 
 def test_owned_rtti_raw_external_vtable_address_point_is_not_double_counted():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     import copy
 
     obj, entry, claims, config, name_index, target_reader = \
@@ -759,7 +765,8 @@ def test_owned_rtti_raw_external_vtable_address_point_is_not_double_counted():
 
 def test_partitioned_nontext_normalizes_imports_and_rebiases_retained_vtables():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     from unittest import mock
 
     obj, entry, claims, config, name_index, target_reader = \
@@ -799,7 +806,8 @@ def test_partitioned_nontext_normalizes_imports_and_rebiases_retained_vtables():
 
 def test_nontext_verifier_checks_layout_bytes_symbols_and_reloc_destinations():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     obj = _compile_tu_fixture(
         'extern "C" int external_value;\n'
         'extern "C" int *owned_ptr = &external_value;\n'
@@ -905,7 +913,8 @@ def test_nontext_verifier_checks_layout_bytes_symbols_and_reloc_destinations():
 
 def test_compiler_only_policy_is_exact_and_refuses_a_real_rom_home():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     obj = _compile_tu_fixture(
         "struct P { int p[4]; virtual ~P(); virtual void f(); };\nP::~P(){}\n")
     assert obj is not None
@@ -933,7 +942,8 @@ def test_compiler_only_policy_is_exact_and_refuses_a_real_rom_home():
 def test_compiler_only_policy_reduces_data_before_its_duplicate_destructors():
     """A licensed vtable must not block removal of a duplicate dtor it names."""
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     obj = _compile_tu_fixture(
         "struct B { virtual ~B() {} };\n"
         "struct D : B { virtual ~D() {} virtual void f(); };\n"
@@ -988,7 +998,8 @@ def test_plain_deadstrip_is_refused_for_an_rtti_record():
     copy of the guard ever runs.
     """
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     obj = _compile_tu_fixture(
         "struct B { virtual ~B() {} };\n"
         "struct D : B { virtual ~D() {} virtual void f(); };\n"
@@ -1164,7 +1175,8 @@ def test_linkcheck_symbol_verdict_uses_the_stock_failure_inventory():
 
 def test_vtable_storage_address_requires_an_explicit_consistent_bias():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     obj = _compile_tu_fixture(
         'extern "C" int _ZTV1V[3] = {1, 2, 3};\n'
         'extern "C" int* vptr = _ZTV1V + 2;\n')
@@ -1229,7 +1241,8 @@ def test_vtable_storage_address_requires_an_explicit_consistent_bias():
 
 def test_bss_without_independent_configured_symbols_and_boundaries_is_inferred_only():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     obj = _compile_tu_fixture('extern "C" int invented_bss = 0;\n')
     start = 0x5000
     bss, error = tubuild.section_contribution(obj, ".bss", start)
@@ -1251,7 +1264,8 @@ def test_bss_without_independent_configured_symbols_and_boundaries_is_inferred_o
 
 def test_object_audit_makes_an_extra_unclaimed_object_and_section_fatal():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     obj = _compile_tu_fixture('extern "C" int unexpected_data = 7;\n')
     entry = {"module": "ov999", "functions": [], "sections": [
         {"name": ".text", "start": "0x1000", "end": "0x1004"}],
@@ -1263,67 +1277,11 @@ def test_object_audit_makes_an_extra_unclaimed_object_and_section_fatal():
     assert any("unlicensed content section .data" in r for r in reasons)
 
 
-def test_object_audit_licenses_only_validated_manifest_vtable_partitions():
-    from unittest import mock
-
-    def partition(name, address, size):
-        return {"symbol": name, "address": hex(address), "size": hex(size),
-                "binding": "STB_GLOBAL", "type": "STT_OBJECT",
-                "visibility": "STV_DEFAULT", "reuse_policy_symbol": "donor"}
-
-    def proven(name, address, size):
-        return {"symbol": name, "address": address, "size": size,
-                "binding": "STB_GLOBAL", "type": "STT_OBJECT",
-                "visibility": "STV_DEFAULT", "baseline": {
-                    "symbol": {"address": address, "size": size,
-                               "binding": "STB_GLOBAL", "type": "STT_OBJECT",
-                               "visibility": "STV_DEFAULT", "section": "OV999",
-                               "sectionIndex": 4},
-                    "vtable": {"sectionIndex": 4},
-                }}
-
-    entry = {"module": "ov999", "functions": [], "sections": [
-        {"name": ".text", "start": "0x1000", "end": "0x1004"},
-        {"name": ".data", "start": "0x2000", "end": "0x2030"}],
-        "data": [{"symbol": "_ZTV1P", "address": "0x2008", "size": "0x30",
-                  "partition_symbols": [partition("VT7", 0x2010, 8),
-                                          partition("RawOnly", 0x2018, 0x18)]}],
-        "bss": []}
-    policies = {"_ZTV1P": {"section": ".data", "partitionSymbols": [
-        proven("VT7", 0x2010, 8),
-        proven("ArbitraryCollision", 0x2040, 8),
-    ]}}
-    inventory = {
-        "sections": [{"index": 4, "name": ".data", "size": 0,
-                      "type": "SHT_PROGBITS"}],
-        "symbols": [
-            {"name": name, "bind": "STB_GLOBAL", "type": "STT_OBJECT",
-             "size": size, "shndx": 4}
-            for name, size in (("VT7", 8), ("RawOnly", 0x18),
-                               ("ArbitraryCollision", 8))],
-    }
-    homes = {"VT7": [("ov999", 0x2010)],
-             "RawOnly": [("ov999", 0x2018)],
-             "ArbitraryCollision": [("ov999", 0x2040)]}
-    with mock.patch.object(tubuild, "elf_inventory", return_value=inventory), \
-            mock.patch.object(tubuild, "all_symbol_homes", return_value=homes):
-        rows, extra, _emitted, order_ok = tubuild.audit_tu_object(
-            b"ignored", entry, 0x1000, 0x1004, ranges={"ov999": []},
-            validated_vtable_policies=policies)
-
-    verdicts = {row["name"]: row["verdict"] for row in rows}
-    assert verdicts == {"VT7": "LICENSED", "RawOnly": "COLLIDES-GAP",
-                        "ArbitraryCollision": "COLLIDES-GAP"}
-    reasons = tubuild.object_audit_refusals(rows, extra, order_ok)
-    assert not any("VT7" in reason for reason in reasons)
-    assert any("RawOnly" in reason for reason in reasons)
-    assert any("ArbitraryCollision" in reason for reason in reasons)
-
-
 def test_vague_inherited_rtti_coalescing_remains_explicitly_unsupported():
     """Two TUs emit the same STB_LOPROC base metadata; linker behavior is not a license."""
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     common = "struct Base { virtual void f() {} };\n"
     a = _compile_tu_fixture(common + "struct A : Base { virtual void a(); }; void A::a() {}\n")
     b = _compile_tu_fixture(common + "struct B : Base { virtual void b(); }; void B::b() {}\n")
@@ -1381,7 +1339,8 @@ def test_vague_inherited_rtti_coalescing_remains_explicitly_unsupported():
 
 def test_exact_vague_externalization_requires_canonical_bytes_relocs_and_home():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     import copy
 
     obj, entry, homes, cfg, targets, reader, name_index = \
@@ -1448,7 +1407,8 @@ def test_exact_vague_externalization_requires_canonical_bytes_relocs_and_home():
 
 def test_exact_vague_externalization_rejects_wrong_binding_and_vtables():
     if not _toolchain():
-        return
+        raise unittest.SkipTest(
+            "needs the pinned compiler and extracted/ ROM dump")
     import io
     import struct
     from elftools.elf.elffile import ELFFile
@@ -1664,123 +1624,6 @@ def test_partitioned_vtable_rebias_needs_one_unique_configured_public_home():
         tubuild.all_symbol_homes = original
 
 
-def test_partitioned_vtable_interior_symbols_require_exact_policy_and_baseline():
-    entry = {
-        "module": "ov999", "functions": [],
-        "externalized_output": [
-            {"symbol": "_ZTS1B", "disposition": "canonical-import"},
-            {"symbol": "_ZTS1A", "disposition": "canonical-import"},
-        ],
-        "data": [{
-            "symbol": "_ZTV1P", "address": "0x2008",
-            "emitted_storage_address": "0x2000", "address_point_bias": "0x8",
-            "size": "0x30", "partition_symbols": [
-                {"symbol": "VT7", "address": "0x2010", "size": "0x8",
-                 "binding": "STB_GLOBAL", "type": "STT_OBJECT",
-                 "visibility": "STV_DEFAULT", "reuse_policy_symbol": "_ZTS1B"},
-                {"symbol": "VT14", "address": "0x2018", "size": "0x18",
-                 "binding": "STB_GLOBAL", "type": "STT_OBJECT",
-                 "visibility": "STV_DEFAULT", "reuse_policy_symbol": "_ZTS1A"},
-            ],
-        }], "bss": [],
-    }
-    claims = [{"name": ".data", "start": 0x2000, "end": 0x2030}]
-    baseline = {
-        "_ZTV1P": [{"address": 0x2008, "size": 8, "binding": "STB_GLOBAL",
-                     "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
-                     "sectionIndex": 4, "section": "OV999"}],
-        "VT7": [{"address": 0x2010, "size": 8, "binding": "STB_GLOBAL",
-                 "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
-                 "sectionIndex": 4, "section": "OV999"}],
-        "VT14": [{"address": 0x2018, "size": 0x18, "binding": "STB_GLOBAL",
-                  "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
-                  "sectionIndex": 4, "section": "OV999"}],
-    }
-    homes = {"_ZTV1P": [("ov999", 0x2008)], "VT7": [("ov999", 0x2010)],
-             "VT14": [("ov999", 0x2018)]}
-    original_homes = tubuild.all_symbol_homes
-    original_linked = tubuild.linked_symbol_rows
-    try:
-        tubuild.all_symbol_homes = lambda: homes
-        policies, reasons = tubuild.partition_vtable_rebiases(
-            entry, claims, baseline_symbols=baseline, baseline_sha256="c" * 64)
-        assert reasons == []
-        policy = policies["_ZTV1P"]
-        assert policy["publicSize"] == 8
-        assert [(row["symbol"], row["value"], row["size"], row["donor"])
-                for row in policy["partitionSymbols"]] == [
-                    ("VT7", 0x10, 8, "_ZTS1B"),
-                    ("VT14", 0x18, 0x18, "_ZTS1A")]
-        assert policy["baseline"]["elfSha256"] == "c" * 64
-        assert [row[1]["symbol"] for row in
-                tubuild.manifest_vtable_partition_rows(entry)] == ["VT7", "VT14"]
-        assert tubuild.validated_vtable_partition_symbols(entry, policies) == {
-            "VT7", "VT14"}
-
-        # This is the ordinary intact call shape: the manifest owns input ``.data``,
-        # while the validated stock final-link metadata names its output section after
-        # the module.  Same linked section index proves the parent/part relationship.
-        inventory = {
-            "sections": [{"index": 4, "name": ".data", "size": 0,
-                          "type": "SHT_PROGBITS"}],
-            "symbols": [{"name": name, "bind": "STB_GLOBAL",
-                         "type": "STT_OBJECT", "size": size, "shndx": 4}
-                        for name, size in (("VT7", 8), ("VT14", 0x18))],
-        }
-        from unittest import mock
-        with mock.patch.object(tubuild, "elf_inventory", return_value=inventory):
-            rows, extra, _emitted, order_ok = tubuild.audit_tu_object(
-                b"ignored", entry, 0x1000, 0x1004, ranges={"ov999": []},
-                validated_vtable_policies=policies)
-        assert {row["name"]: row["verdict"] for row in rows} == {
-            "VT7": "LICENSED", "VT14": "LICENSED"}
-        assert tubuild.object_audit_refusals(rows, extra, order_ok) == []
-
-        tubuild.linked_symbol_rows = lambda _path, _names: (baseline, None)
-        proof = tubuild.verify_linked_storage_aliases("ignored.o", policies)
-        assert proof["ok"] and proof["rows"][0]["exact"]
-        wrong_baseline = {key: [dict(row) for row in value]
-                          for key, value in baseline.items()}
-        wrong_baseline["VT14"][0]["sectionIndex"] = 5
-        _policies, reasons = tubuild.partition_vtable_rebiases(
-            entry, claims, baseline_symbols=wrong_baseline,
-            baseline_sha256="d" * 64)
-        assert any("baseline metadata differs" in reason for reason in reasons)
-
-        import copy
-        overlap = copy.deepcopy(entry)
-        overlap["data"][0]["partition_symbols"][1].update(
-            {"address": "0x2014", "size": "0x1c"})
-        _policies, reasons = tubuild.partition_vtable_rebiases(
-            overlap, claims, baseline_symbols=baseline)
-        assert any("overlaps" in reason for reason in reasons)
-
-        gap = copy.deepcopy(entry)
-        gap["data"][0]["partition_symbols"][1].update(
-            {"address": "0x201c", "size": "0x14"})
-        tubuild.all_symbol_homes = lambda: {
-            **homes, "VT14": [("ov999", 0x201c)]}
-        _policies, reasons = tubuild.partition_vtable_rebiases(
-            gap, claims, baseline_symbols=baseline)
-        assert any("leaves a gap" in reason for reason in reasons)
-
-        bad_donor = copy.deepcopy(entry)
-        bad_donor["data"][0]["partition_symbols"][0]["reuse_policy_symbol"] = "missing"
-        tubuild.all_symbol_homes = lambda: homes
-        _policies, reasons = tubuild.partition_vtable_rebiases(
-            bad_donor, claims, baseline_symbols=baseline)
-        assert any("not an explicit compiler-only" in reason for reason in reasons)
-
-        reused = copy.deepcopy(entry)
-        reused["data"][0]["partition_symbols"][1]["reuse_policy_symbol"] = "_ZTS1B"
-        _policies, reasons = tubuild.partition_vtable_rebiases(
-            reused, claims, baseline_symbols=baseline)
-        assert any("donor _ZTS1B is reused" in reason for reason in reasons)
-    finally:
-        tubuild.all_symbol_homes = original_homes
-        tubuild.linked_symbol_rows = original_linked
-
-
 def test_partition_baseline_evidence_is_content_bound_not_mtime_bound():
     with tempfile.TemporaryDirectory() as td:
         root = pathlib.Path(td)
@@ -1922,14 +1765,6 @@ def test_partitioned_result_gate_requires_every_full_rom_proof():
         bad = dict(good)
         bad[key] = None if key == "rom_ok" else False
         assert not tubuild.partitioned_link_ready(**bad), key
-
-
-def test_intact_link_gate_requires_final_vtable_split_symbol_fidelity():
-    good = dict(module_ok=True, symbols_ok=True, rom_ok=True,
-                split_symbols_ok=True)
-    assert tubuild.linkcheck_pipeline_ready(**good)
-    bad = dict(good, split_symbols_ok=False)
-    assert not tubuild.linkcheck_pipeline_ready(**bad)
 
 
 def test_partitioned_recorder_is_compact_orthogonal_and_preserves_verified_evidence():

--- a/tools/test_tubuild_vtable_partitions.py
+++ b/tools/test_tubuild_vtable_partitions.py
@@ -1,0 +1,292 @@
+"""Fail-closed coverage for tubuild's vtable-partition licensing boundary.
+
+WHY THIS MODULE EXISTS AND IS NOT PART OF ``tools/test_tubuild.py``.
+
+Same reason ``tools/test_tubuild_owned_relocs.py`` exists, one boundary over.
+``test_tubuild.py`` is pytest-style -- bare ``def test_*`` functions and zero
+``unittest.TestCase`` classes -- so ``python -m unittest tools.test_tubuild``
+prints "Ran 0 tests ... OK" and exits 0.  CI (``.github/workflows/tool-tests.yml``)
+runs ``python -m unittest``, so nothing in that file has ever executed on a runner.
+The four tests PR #2091 added to describe this boundary were written there, and
+three of them need neither mwccarm nor ``extracted/``: they are mock- and
+dict-driven, and they call only ``tubuild.*``.  They are moved here verbatim --
+bodies unchanged, ``def f():`` to ``def f(self):`` and one indent level, nothing
+else -- so the move is reviewable as a move and the assertions are the ones that
+were reviewed on #2091.
+
+WHAT THEY PIN, and why it is worth wiring rather than leaving decorative.
+
+#2091 added a fail-closed licensing boundary for nested symbols carved out of a
+vtable's public range: a partition named in the manifest is a COLLIDES-GAP refusal
+unless ``partition_vtable_rebiases`` independently validated it against
+content-bound baseline ELF metadata.  Measured on #2091's merge tree, that path
+licensed nothing at all -- 0 of 97 manifest entries, 0 ``partition_symbols`` rows
+tree-wide -- because no entry had ever carried such a row.  #2096
+(``daPropeller_Heyho_c``) is what introduces the first two, ``FlyGuy_VT7`` and
+``FlyGuy_VT14``.  So the boundary goes from unexercised to load-bearing in one
+PR, and until this module it was described entirely by tests CI cannot see.
+
+THE ONE INVARIANT THAT IS EASY TO RE-BREAK is the last test here, which is new
+rather than moved.  ``validated_vtable_partition_symbols`` proves the part/parent
+relationship with ``sectionIndex`` equality and deliberately does NOT compare
+section NAMES.  It cannot: a linked ELF names a vtable's output section after its
+overlay -- ``OV036``, ``OV047``, ``OV070`` measured on the baseline link -- while
+a manifest ``section`` is one of ``.rodata .init .ctor .data .bss``.  The two
+vocabularies never intersect, so an earlier form of this check that compared them
+refused every real input, and the whole path was unreachable.  Commit 0b0e319
+removed that comparison; the #2091 thread carries the A/B.  A future reader who
+sees a "missing" section check and restores it would turn the boundary back into
+an unconditional refusal, and no byte gate would notice, because a refusal here
+is not a wrong ROM -- it is a TU that quietly stops being promotable.
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import tubuild  # noqa: E402
+
+
+class ManifestPartitionLicensing(unittest.TestCase):
+    def test_object_audit_licenses_only_validated_manifest_vtable_partitions(self):
+        from unittest import mock
+
+        def partition(name, address, size):
+            return {"symbol": name, "address": hex(address), "size": hex(size),
+                    "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                    "visibility": "STV_DEFAULT", "reuse_policy_symbol": "donor"}
+
+        def proven(name, address, size):
+            return {"symbol": name, "address": address, "size": size,
+                    "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                    "visibility": "STV_DEFAULT", "baseline": {
+                        "symbol": {"address": address, "size": size,
+                                   "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                                   "visibility": "STV_DEFAULT", "section": "OV999",
+                                   "sectionIndex": 4},
+                        "vtable": {"sectionIndex": 4},
+                    }}
+
+        entry = {"module": "ov999", "functions": [], "sections": [
+            {"name": ".text", "start": "0x1000", "end": "0x1004"},
+            {"name": ".data", "start": "0x2000", "end": "0x2030"}],
+            "data": [{"symbol": "_ZTV1P", "address": "0x2008", "size": "0x30",
+                      "partition_symbols": [partition("VT7", 0x2010, 8),
+                                              partition("RawOnly", 0x2018, 0x18)]}],
+            "bss": []}
+        policies = {"_ZTV1P": {"section": ".data", "partitionSymbols": [
+            proven("VT7", 0x2010, 8),
+            proven("ArbitraryCollision", 0x2040, 8),
+        ]}}
+        inventory = {
+            "sections": [{"index": 4, "name": ".data", "size": 0,
+                          "type": "SHT_PROGBITS"}],
+            "symbols": [
+                {"name": name, "bind": "STB_GLOBAL", "type": "STT_OBJECT",
+                 "size": size, "shndx": 4}
+                for name, size in (("VT7", 8), ("RawOnly", 0x18),
+                                   ("ArbitraryCollision", 8))],
+        }
+        homes = {"VT7": [("ov999", 0x2010)],
+                 "RawOnly": [("ov999", 0x2018)],
+                 "ArbitraryCollision": [("ov999", 0x2040)]}
+        with mock.patch.object(tubuild, "elf_inventory", return_value=inventory), \
+                mock.patch.object(tubuild, "all_symbol_homes", return_value=homes):
+            rows, extra, _emitted, order_ok = tubuild.audit_tu_object(
+                b"ignored", entry, 0x1000, 0x1004, ranges={"ov999": []},
+                validated_vtable_policies=policies)
+
+        verdicts = {row["name"]: row["verdict"] for row in rows}
+        assert verdicts == {"VT7": "LICENSED", "RawOnly": "COLLIDES-GAP",
+                            "ArbitraryCollision": "COLLIDES-GAP"}
+        reasons = tubuild.object_audit_refusals(rows, extra, order_ok)
+        assert not any("VT7" in reason for reason in reasons)
+        assert any("RawOnly" in reason for reason in reasons)
+        assert any("ArbitraryCollision" in reason for reason in reasons)
+
+    def test_partition_licensing_pins_section_index_not_section_name(self):
+        """A part is licensed by landing in the vtable's section INDEX, not its name.
+
+        This is the invariant 0b0e319 left standing after it removed a section-NAME
+        comparison that could never pass.  Both halves are asserted: the name is not
+        consulted (a real overlay name, and no name at all, both license), and the
+        index is (a part that landed elsewhere stays unlicensed).
+        """
+        import copy
+
+        entry = {
+            "module": "ov070", "functions": [],
+            "data": [{"symbol": "_ZTV1P", "address": "0x2008", "size": "0x30",
+                      "partition_symbols": [
+                          {"symbol": "VT7", "address": "0x2010", "size": "0x8",
+                           "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                           "visibility": "STV_DEFAULT",
+                           "reuse_policy_symbol": "donor"}]}],
+            "bss": [],
+        }
+
+        def policies(part_section_index, part_section_name):
+            return {"_ZTV1P": {"section": ".data", "partitionSymbols": [
+                {"symbol": "VT7", "address": 0x2010, "size": 8,
+                 "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                 "visibility": "STV_DEFAULT",
+                 "baseline": {
+                     "symbol": {"address": 0x2010, "size": 8,
+                                "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                                "visibility": "STV_DEFAULT",
+                                "section": part_section_name,
+                                "sectionIndex": part_section_index},
+                     "vtable": {"section": "OV070", "sectionIndex": 147},
+                 }}]}}
+
+        # The shape the pipeline actually produces: the linked ELF calls the output
+        # section OV070 on both the vtable and its parts, and the manifest calls the
+        # input section .data.  This licenses.
+        self.assertEqual(
+            tubuild.validated_vtable_partition_symbols(entry, policies(147, "OV070")),
+            {"VT7"})
+
+        # The section NAME is not consulted at all -- dropping it changes nothing.
+        # If this ever starts refusing, someone restored the impossible comparison.
+        nameless = copy.deepcopy(policies(147, "OV070"))
+        del nameless["_ZTV1P"]["partitionSymbols"][0]["baseline"]["symbol"]["section"]
+        self.assertEqual(
+            tubuild.validated_vtable_partition_symbols(entry, nameless), {"VT7"})
+
+        # The section INDEX is consulted.  A symbol that landed in a different output
+        # section is not a part of this vtable, whatever the manifest claims.
+        self.assertEqual(
+            tubuild.validated_vtable_partition_symbols(entry, policies(148, "OV070")),
+            set())
+
+
+class PartitionRebiasValidation(unittest.TestCase):
+    def test_partitioned_vtable_interior_symbols_require_exact_policy_and_baseline(self):
+        entry = {
+            "module": "ov999", "functions": [],
+            "externalized_output": [
+                {"symbol": "_ZTS1B", "disposition": "canonical-import"},
+                {"symbol": "_ZTS1A", "disposition": "canonical-import"},
+            ],
+            "data": [{
+                "symbol": "_ZTV1P", "address": "0x2008",
+                "emitted_storage_address": "0x2000", "address_point_bias": "0x8",
+                "size": "0x30", "partition_symbols": [
+                    {"symbol": "VT7", "address": "0x2010", "size": "0x8",
+                     "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                     "visibility": "STV_DEFAULT", "reuse_policy_symbol": "_ZTS1B"},
+                    {"symbol": "VT14", "address": "0x2018", "size": "0x18",
+                     "binding": "STB_GLOBAL", "type": "STT_OBJECT",
+                     "visibility": "STV_DEFAULT", "reuse_policy_symbol": "_ZTS1A"},
+                ],
+            }], "bss": [],
+        }
+        claims = [{"name": ".data", "start": 0x2000, "end": 0x2030}]
+        baseline = {
+            "_ZTV1P": [{"address": 0x2008, "size": 8, "binding": "STB_GLOBAL",
+                         "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
+                         "sectionIndex": 4, "section": "OV999"}],
+            "VT7": [{"address": 0x2010, "size": 8, "binding": "STB_GLOBAL",
+                     "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
+                     "sectionIndex": 4, "section": "OV999"}],
+            "VT14": [{"address": 0x2018, "size": 0x18, "binding": "STB_GLOBAL",
+                      "type": "STT_OBJECT", "visibility": "STV_DEFAULT",
+                      "sectionIndex": 4, "section": "OV999"}],
+        }
+        homes = {"_ZTV1P": [("ov999", 0x2008)], "VT7": [("ov999", 0x2010)],
+                 "VT14": [("ov999", 0x2018)]}
+        original_homes = tubuild.all_symbol_homes
+        original_linked = tubuild.linked_symbol_rows
+        try:
+            tubuild.all_symbol_homes = lambda: homes
+            policies, reasons = tubuild.partition_vtable_rebiases(
+                entry, claims, baseline_symbols=baseline, baseline_sha256="c" * 64)
+            assert reasons == []
+            policy = policies["_ZTV1P"]
+            assert policy["publicSize"] == 8
+            assert [(row["symbol"], row["value"], row["size"], row["donor"])
+                    for row in policy["partitionSymbols"]] == [
+                        ("VT7", 0x10, 8, "_ZTS1B"),
+                        ("VT14", 0x18, 0x18, "_ZTS1A")]
+            assert policy["baseline"]["elfSha256"] == "c" * 64
+            assert [row[1]["symbol"] for row in
+                    tubuild.manifest_vtable_partition_rows(entry)] == ["VT7", "VT14"]
+            assert tubuild.validated_vtable_partition_symbols(entry, policies) == {
+                "VT7", "VT14"}
+
+            # This is the ordinary intact call shape: the manifest owns input ``.data``,
+            # while the validated stock final-link metadata names its output section after
+            # the module.  Same linked section index proves the parent/part relationship.
+            inventory = {
+                "sections": [{"index": 4, "name": ".data", "size": 0,
+                              "type": "SHT_PROGBITS"}],
+                "symbols": [{"name": name, "bind": "STB_GLOBAL",
+                             "type": "STT_OBJECT", "size": size, "shndx": 4}
+                            for name, size in (("VT7", 8), ("VT14", 0x18))],
+            }
+            from unittest import mock
+            with mock.patch.object(tubuild, "elf_inventory", return_value=inventory):
+                rows, extra, _emitted, order_ok = tubuild.audit_tu_object(
+                    b"ignored", entry, 0x1000, 0x1004, ranges={"ov999": []},
+                    validated_vtable_policies=policies)
+            assert {row["name"]: row["verdict"] for row in rows} == {
+                "VT7": "LICENSED", "VT14": "LICENSED"}
+            assert tubuild.object_audit_refusals(rows, extra, order_ok) == []
+
+            tubuild.linked_symbol_rows = lambda _path, _names: (baseline, None)
+            proof = tubuild.verify_linked_storage_aliases("ignored.o", policies)
+            assert proof["ok"] and proof["rows"][0]["exact"]
+            wrong_baseline = {key: [dict(row) for row in value]
+                              for key, value in baseline.items()}
+            wrong_baseline["VT14"][0]["sectionIndex"] = 5
+            _policies, reasons = tubuild.partition_vtable_rebiases(
+                entry, claims, baseline_symbols=wrong_baseline,
+                baseline_sha256="d" * 64)
+            assert any("baseline metadata differs" in reason for reason in reasons)
+
+            import copy
+            overlap = copy.deepcopy(entry)
+            overlap["data"][0]["partition_symbols"][1].update(
+                {"address": "0x2014", "size": "0x1c"})
+            _policies, reasons = tubuild.partition_vtable_rebiases(
+                overlap, claims, baseline_symbols=baseline)
+            assert any("overlaps" in reason for reason in reasons)
+
+            gap = copy.deepcopy(entry)
+            gap["data"][0]["partition_symbols"][1].update(
+                {"address": "0x201c", "size": "0x14"})
+            tubuild.all_symbol_homes = lambda: {
+                **homes, "VT14": [("ov999", 0x201c)]}
+            _policies, reasons = tubuild.partition_vtable_rebiases(
+                gap, claims, baseline_symbols=baseline)
+            assert any("leaves a gap" in reason for reason in reasons)
+
+            bad_donor = copy.deepcopy(entry)
+            bad_donor["data"][0]["partition_symbols"][0]["reuse_policy_symbol"] = "missing"
+            tubuild.all_symbol_homes = lambda: homes
+            _policies, reasons = tubuild.partition_vtable_rebiases(
+                bad_donor, claims, baseline_symbols=baseline)
+            assert any("not an explicit compiler-only" in reason for reason in reasons)
+
+            reused = copy.deepcopy(entry)
+            reused["data"][0]["partition_symbols"][1]["reuse_policy_symbol"] = "_ZTS1B"
+            _policies, reasons = tubuild.partition_vtable_rebiases(
+                reused, claims, baseline_symbols=baseline)
+            assert any("donor _ZTS1B is reused" in reason for reason in reasons)
+        finally:
+            tubuild.all_symbol_homes = original_homes
+            tubuild.linked_symbol_rows = original_linked
+
+
+class IntactLinkGate(unittest.TestCase):
+    def test_intact_link_gate_requires_final_vtable_split_symbol_fidelity(self):
+        good = dict(module_ok=True, symbols_ok=True, rom_ok=True,
+                    split_symbols_ok=True)
+        assert tubuild.linkcheck_pipeline_ready(**good)
+        bad = dict(good, split_symbols_ok=False)
+        assert not tubuild.linkcheck_pipeline_ready(**bad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is the wiring I committed to on #2091 when I merged it. Tools-only, no source file touched, no byte claim.

## Why

#2091 added a fail-closed licensing boundary — `validated_vtable_partition_symbols`, `manifest_vtable_partition_rows`, and `audit_tu_object`'s `validated_vtable_policies` parameter, none of which exist on `main` before it. It refuses a manifest-declared symbol carved out of a vtable's public range unless `partition_vtable_rebiases` independently validated it against content-bound baseline ELF metadata.

Six tests describe that boundary. **Five of them never execute:**

```
test_tu_production.py  1 test   module IS in tool-tests.yml   -> runs
test_objisolate.py     1 test   module NOT in the list        -> never runs
test_tubuild.py        4 tests  module runs, finds 0 tests    -> never run
```

`test_tubuild.py` has bare `def test_` functions and no `unittest.TestCase`, so `python -m unittest tools.test_tubuild` prints `Ran 0 tests ... OK` and exits 0. The workflow's own comments already said as much.

That matters now rather than eventually. Measured on #2091's merge tree, the boundary licenses **nothing at all** — 0 of 97 manifest entries, 0 `partition_symbols` rows tree-wide — and **#2096 introduces the first two rows that have ever existed** (`FlyGuy_VT7`, `FlyGuy_VT14`). It goes from unexercised to load-bearing in one PR, with a decorative safety net. This closes that gap before the first entry leans on it.

## What is in the diff

**`tools/test_tubuild_vtable_partitions.py`** — new, four tests, **4 of 4 run in CI and none skips**. Mock- and dict-driven: no compiler, no ROM, no `config/`, no `build/`.

Three of the four are #2091's own toolchain-free tests, **moved verbatim** out of `test_tubuild.py`: bodies unchanged, `def f():` → `def f(self):` plus one indent level, and the plain `assert` statements deliberately kept so the move reviews as a mechanical move rather than a rewrite.

The fourth is new and pins the invariant that is easiest to re-break: **licensing compares `sectionIndex`, never section NAMES.** A linked ELF names a vtable's output section after its overlay (`OV036`/`OV047`/`OV070`, measured on the baseline link) while a manifest `section` is one of `.rodata .init .ctor .data .bss`. The two vocabularies never intersect, so comparing them refuses every real input — which is exactly what made the whole path unreachable, and exactly what `0b0e319` removed. The surviving `sectionIndex` equality is the check holding the line; this test is what keeps someone from "restoring" the tight-looking form.

**Mutation-checked in both directions**, because a test that pins an invariant is worth nothing until it has been shown to fail:

```
drop the sectionIndex invariant                  -> failures: ['test_partition_licensing_pins_section_index_not_section_name']
restore the section-NAME compare (pre-0b0e319)   -> failures: ['test_object_audit_licenses_only_validated_manifest_vtable_partitions',
                                                               'test_partition_licensing_pins_section_index_not_section_name']
```

**`tools/test_tubuild.py`** — the three moved tests removed (58 → 55 functions), and all **sixteen** `if not _toolchain(): return` guards converted to `raise unittest.SkipTest(...)`. A bare `return` reports PASS having asserted nothing; `pytest -rs` cannot see it and neither can a reviewer reading a green log. This does **not** make the module wirable — it still has no `TestCase` and a third of it still compiles with mwccarm — and the workflow comment that implied converting those returns would make it a candidate is corrected in this diff rather than left to mislead.

**`.github/workflows/tool-tests.yml`** — the new module added to the invocation list (28 → 29), an inventory entry, and every claim in the header that this change falsified.

## Two deviations from the plan I posted on #2091, both deliberate

**1. The tests went into a new module, not `test_tu_production.py`.** I said "move them into `test_tu_production.py`" when I merged #2091. On inspection that module tests `tu_production.py`, not `tubuild.py`, and `test_tubuild_owned_relocs.py` is too narrowly named to absorb them. A correctly-named new module gets the same outcome — they execute in CI — without putting `tubuild` tests behind a `tu_production` name. Flagging it because I said otherwise in public.

**2. Step 3 — "wire `tools.test_objisolate` if it is green and TestCase-shaped" — is dropped on measurement, not forgotten.** It *is* `TestCase`-shaped. It is also a single `@unittest.skipUnless(_compiler(), "mwccarm not present")` class and nothing else, so on a runner it contributes **35 tests and 35 skips** — a green that asserts nothing, which is the exact shape this workflow's header refuses a glob for. Wiring it would still catch a collection error in `objisolate.py`; that is not worth a hollow green. It stays out, and the measurement is recorded in the workflow comment so the next person does not re-litigate it.

## Verification

Full CI invocation run locally, all 29 modules, on a tree **with** the toolchain:

```
Ran 519 tests in 61.934s
OK (skipped=3)
EXIT 0
```

```
python-names: 265 tracked file(s) checked
  0 unresolvable names, 0 unparseable files, 48 advisory finding(s)
python-names: PASS

check_dead_references: 385 prose file(s), 3598 repo-rooted path reference(s), 132 that do not resolve;
185 markdown link(s), 0 that do not resolve relative to their own file
  no new dead references
  no broken markdown links
```

One provenance note on the workflow's totals comment, since I would block someone else for it: the `514` in that line was measured in the CI container and I did not re-measure it here. The `+4` is arithmetic on it, and the comment now says so instead of asserting a new absolute. The `519` above is the Windows-with-toolchain figure and is stated as such.

Line endings verified unchanged: `main` stores all three files CRLF and so does this branch, so the diff is content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
