### PR TITLE
Preserve manifest-owned section order for intact C++ TUs

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -56,8 +56,11 @@ CONTENT = ("SHT_PROGBITS", "SHT_NOBITS")
 IGNORE = (".comment", ".debug", ".line", ".note")
 
 SHN_UNDEF = 0
+SHN_XINDEX = 0xffff
 R_ARM_ABS32 = 2
 SHF_EXECINSTR = 0x4
+SHF_INFO_LINK = 0x40
+SHF_GROUP = 0x200
 
 # "There is nothing here to reduce" -- not a failure. An object whose enrolled symbol
 # is not a defined function in it (an assembly stub, a data entry) simply has no
@@ -890,6 +893,155 @@ def derive_section_partition(raw, keep_section_names, licensed_symbols,
     if p.get("error"):
         return None, p
     return _apply(raw, p, None), p
+
+
+def reorder_same_named_nontext_sections(raw, ordered_groups):
+    """Permute exact repeated non-text section headers without moving payloads.
+
+    ``ordered_groups`` is a list of ``{"section": name, "indices": [...]}``
+    rows.  Each index list must be an exact permutation of every non-empty content
+    section carrying that name; its order is the desired linker contribution order.
+    Only the section headers move.  Symbol ``st_shndx`` values and every ELF
+    section-index reference are remapped to follow their original sections, while
+    section payload bytes and relocation records remain at their original offsets.
+
+    This is intentionally not a general ELF rewriter.  Extended section indices and
+    section groups have secondary index tables/payloads, so their presence is a
+    refusal rather than an invitation to guess.  Callers own the semantic proof for
+    the requested order; this helper supplies only the fail-closed mechanical
+    permutation.
+    """
+    if not isinstance(ordered_groups, list) or not ordered_groups:
+        return None, {"reordered": [], "error":
+                      "at least one ordered non-text section group is required"}
+
+    elf = ELFFile(io.BytesIO(bytes(raw)))
+    if elf.elfclass != 32 or elf["e_type"] != "ET_REL" or elf["e_phnum"]:
+        return None, {"reordered": [], "error":
+                      "section ordering supports only 32-bit ET_REL objects "
+                      "without program headers"}
+    if not elf["e_shnum"] or elf["e_shstrndx"] in ("SHN_XINDEX", SHN_XINDEX) \
+            or elf["e_shentsize"] != 40:
+        return None, {"reordered": [], "error":
+                      "extended ELF section indices or non-standard section "
+                      "headers are unsupported"}
+
+    secs = list(elf.iter_sections())
+    if any(sec.header["sh_type"] in ("SHT_GROUP", "SHT_SYMTAB_SHNDX")
+           or sec.header["sh_flags"] & SHF_GROUP for sec in secs):
+        return None, {"reordered": [], "error":
+                      "ELF section groups and extended symbol section indices are "
+                      "unsupported"}
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return None, {"reordered": [], "error": "no .symtab"}
+    if symtab.header["sh_entsize"] != 16:
+        return None, {"reordered": [], "error":
+                      "non-standard Elf32_Sym entries are unsupported"}
+    syms = list(symtab.iter_symbols())
+    if any(sym["st_shndx"] in ("SHN_XINDEX", SHN_XINDEX) for sym in syms):
+        return None, {"reordered": [], "error":
+                      "extended symbol section indices are unsupported"}
+
+    parsed, moved, seen_names = [], {}, set()
+    for ordinal, row in enumerate(ordered_groups):
+        label = f"ordered_groups[{ordinal}]"
+        if not isinstance(row, dict) or not row.get("section") \
+                or not isinstance(row.get("indices"), list):
+            return None, {"reordered": [], "error":
+                          f"{label} needs section and indices"}
+        name = str(row["section"])
+        if name == ".text":
+            return None, {"reordered": [], "error":
+                          f"{label} may not reorder .text"}
+        if name in seen_names:
+            return None, {"reordered": [], "error":
+                          f"duplicate ordered section group {name}"}
+        seen_names.add(name)
+        try:
+            desired = [int(index) for index in row["indices"]]
+        except (TypeError, ValueError):
+            return None, {"reordered": [], "error":
+                          f"{label} indices must be integers"}
+        actual = [index for index, sec in enumerate(secs)
+                  if sec.name == name and sec.header["sh_type"] in CONTENT
+                  and sec.header["sh_size"]]
+        if not actual:
+            return None, {"reordered": [], "error":
+                          f"{label} names no non-empty content sections"}
+        if len(desired) != len(set(desired)) or set(desired) != set(actual):
+            return None, {"reordered": [], "error":
+                          f"{label} indices {desired} are not an exact permutation "
+                          f"of {actual}"}
+        types = {secs[index].header["sh_type"] for index in actual}
+        if len(types) != 1:
+            return None, {"reordered": [], "error":
+                          f"{label} mixes content section types {sorted(types)}"}
+        slots = sorted(actual)
+        for old, new in zip(desired, slots):
+            if old in moved or new in moved.values():
+                return None, {"reordered": [], "error":
+                              "ordered section groups overlap"}
+            moved[old] = new
+        parsed.append({"section": name, "original": actual,
+                       "desired": desired, "slots": slots})
+
+    # A permutation must map the selected set onto itself.  Checking both sides is
+    # useful even though every group above already checks its own exact set: it keeps
+    # this low-level rewrite honest if group construction changes later.
+    if set(moved) != set(moved.values()):
+        return None, {"reordered": [], "error":
+                      "section permutation does not preserve its exact index set"}
+    if all(old == new for old, new in moved.items()):
+        return bytes(raw), {"reordered": parsed, "symbolIndices": 0,
+                            "sectionLinks": 0, "sectionInfos": 0, "error": None}
+
+    import struct
+    endian = "<" if elf.little_endian else ">"
+    out = bytearray(raw)
+    headers = {index: bytes(raw[_shdr_offset(elf, index):
+                                     _shdr_offset(elf, index) + elf["e_shentsize"]])
+               for index in moved}
+    for old, new in moved.items():
+        offset = _shdr_offset(elf, new)
+        out[offset:offset + elf["e_shentsize"]] = headers[old]
+
+    # Symbols continue to describe the same section header/payload after that header
+    # moves to its new slot.  The symbol table itself cannot be one of the permuted
+    # content sections, so its file offset remains stable.
+    symbol_indices = 0
+    symbase = symtab.header["sh_offset"]
+    for index, sym in enumerate(syms):
+        old = sym["st_shndx"]
+        if old not in moved:
+            continue
+        struct.pack_into(endian + "H", out,
+                         symbase + index * symtab.header["sh_entsize"] + 14,
+                         moved[old])
+        symbol_indices += 1
+
+    # Parse the copied headers before fixing their own references.  sh_link is an
+    # ELF section index whenever non-zero.  sh_info is a section index for REL/RELA
+    # and for types carrying SHF_INFO_LINK; other sh_info meanings (notably the
+    # symtab local-symbol count) must not be reinterpreted.
+    copied = ELFFile(io.BytesIO(bytes(out)))
+    section_links = section_infos = 0
+    for index, sec in enumerate(copied.iter_sections()):
+        header = _shdr_offset(copied, index)
+        link = sec.header["sh_link"]
+        if link in moved:
+            struct.pack_into(endian + "I", out, header + 0x18, moved[link])
+            section_links += 1
+        info = sec.header["sh_info"]
+        info_is_section = (isinstance(sec, RelocationSection)
+                           or bool(sec.header["sh_flags"] & SHF_INFO_LINK))
+        if info_is_section and info in moved:
+            struct.pack_into(endian + "I", out, header + 0x1c, moved[info])
+            section_infos += 1
+
+    return bytes(out), {"reordered": parsed, "symbolIndices": symbol_indices,
+                        "sectionLinks": section_links,
+                        "sectionInfos": section_infos, "error": None}
 
 
 def rebias_object_symbols(raw, symbol_policies, normalize_undefined=False):

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -598,6 +598,114 @@ class Isolate(unittest.TestCase):
         self.assertIsNone(plan["error"])
         self.assertEqual(abi_addends(out), before)
 
+    def test_same_named_nontext_reorder_preserves_payloads_and_index_references(self):
+        """Only headers/section indices move; data and RELA records stay untouched."""
+        import io
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+
+        obj = self.build(
+            'extern "C" int external_first;\n'
+            'extern "C" int external_second;\n'
+            'extern "C" int *first_ptr = &external_first + 1;\n'
+            'extern "C" int *second_ptr = &external_second + 2;\n')
+        raw = obj.read_bytes()
+        elf = ELFFile(io.BytesIO(raw))
+        secs = list(elf.iter_sections())
+        symtab = elf.get_section_by_name(".symtab")
+        syms = list(symtab.iter_symbols())
+        first = next(s for s in syms if s.name == "first_ptr")
+        second = next(s for s in syms if s.name == "second_ptr")
+        self.assertNotEqual(first["st_shndx"], second["st_shndx"])
+        original = sorted((first["st_shndx"], second["st_shndx"]))
+        desired = [second["st_shndx"], first["st_shndx"]]
+        if desired == original:
+            desired.reverse()
+
+        content_regions = {(s.header["sh_offset"], s.header["sh_size"]): s.data()
+                           for s in secs if s.header["sh_type"] in OI.CONTENT
+                           and s.header["sh_size"]}
+        relocation_regions = {
+            (s.header["sh_offset"], s.header["sh_size"]): s.data()
+            for s in secs if isinstance(s, RelocationSection) and s.header["sh_size"]}
+
+        out, report = OI.reorder_same_named_nontext_sections(
+            raw, [{"section": ".data", "indices": desired}])
+        self.assertIsNotNone(out, report)
+        self.assertIsNone(report["error"])
+        self.assertEqual(obj.read_bytes(), raw, "ordering must be a pure operation")
+        self.assertEqual(len(out), len(raw))
+        self.assertGreaterEqual(report["symbolIndices"], 2)
+        self.assertEqual(report["sectionInfos"], 2)
+
+        reordered = ELFFile(io.BytesIO(out))
+        out_secs = list(reordered.iter_sections())
+        out_syms = list(reordered.get_section_by_name(".symtab").iter_symbols())
+        occupants = []
+        for shndx, sec in enumerate(out_secs):
+            if sec.name != ".data" or not sec.header["sh_size"]:
+                continue
+            names = [s.name for s in out_syms if s.name in ("first_ptr", "second_ptr")
+                     and s["st_shndx"] == shndx]
+            if names:
+                occupants.extend(names)
+        wanted_names = [next(s.name for s in syms if s["st_shndx"] == old
+                             and s.name in ("first_ptr", "second_ptr"))
+                        for old in desired]
+        self.assertEqual(occupants, wanted_names)
+
+        def relocation_for(symbol_name):
+            symbol = next(s for s in out_syms if s.name == symbol_name)
+            relsec = next(s for s in out_secs if isinstance(s, RelocationSection)
+                          and s.header["sh_info"] == symbol["st_shndx"])
+            reloc = next(relsec.iter_relocations())
+            target = reordered.get_section_by_name(".symtab").get_symbol(
+                reloc["r_info_sym"])
+            return target.name, reloc["r_addend"]
+
+        self.assertEqual(relocation_for("first_ptr"), ("external_first", 4))
+        self.assertEqual(relocation_for("second_ptr"), ("external_second", 8))
+        for (offset, size), payload in content_regions.items():
+            self.assertEqual(out[offset:offset + size], payload)
+        for (offset, size), payload in relocation_regions.items():
+            self.assertEqual(out[offset:offset + size], payload)
+
+    def test_same_named_nontext_reorder_refuses_incomplete_and_indexed_elf_shapes(self):
+        """No partial group, GROUP, or extended-index object is normalized."""
+        import io
+        import struct
+        from elftools.elf.elffile import ELFFile
+
+        raw = self.build('extern "C" int first = 1;\n'
+                         'extern "C" int second = 2;\n').read_bytes()
+        elf = ELFFile(io.BytesIO(raw))
+        indices = [i for i, sec in enumerate(elf.iter_sections())
+                   if sec.name == ".data" and sec.header["sh_size"]]
+        self.assertEqual(len(indices), 2)
+        out, report = OI.reorder_same_named_nontext_sections(
+            raw, [{"section": ".data", "indices": indices[:1]}])
+        self.assertIsNone(out)
+        self.assertIn("exact permutation", report["error"])
+
+        comment = next(i for i, sec in enumerate(elf.iter_sections())
+                       if sec.name == ".comment")
+        endian = "<" if elf.little_endian else ">"
+        grouped = bytearray(raw)
+        struct.pack_into(endian + "I", grouped, OI._shdr_offset(elf, comment) + 4,
+                         17)  # SHT_GROUP
+        out, report = OI.reorder_same_named_nontext_sections(
+            bytes(grouped), [{"section": ".data", "indices": list(reversed(indices))}])
+        self.assertIsNone(out)
+        self.assertIn("section groups", report["error"])
+
+        extended = bytearray(raw)
+        struct.pack_into(endian + "I", extended, OI._shdr_offset(elf, comment) + 4,
+                         18)  # SHT_SYMTAB_SHNDX
+        out, report = OI.reorder_same_named_nontext_sections(
+            bytes(extended), [{"section": ".data", "indices": list(reversed(indices))}])
+        self.assertIsNone(out)
+        self.assertIn("extended symbol section indices", report["error"])
+
     def test_rebias_vtable_requires_one_exact_dedicated_global_object(self):
         """Only a whole dedicated _ZTV storage object may move to its public point."""
         import io

--- a/tools/test_tu_production.py
+++ b/tools/test_tu_production.py
@@ -214,12 +214,16 @@ class ProductionTuObjects(unittest.TestCase):
         claims = [{"name": ".text", "start": 0x1000, "end": 0x1010},
                   {"name": ".data", "start": 0x2000, "end": 0x2010}]
         owned = {"ok": True, "rows": [], "errors": []}
+        section_order = {"groups": [{"section": ".data", "original": [5, 7],
+                                      "desired": [7, 5]}], "objisolate": {}}
         with mock.patch.object(TP.TB, "manifest_section_claims",
                                return_value=(claims, [])), \
                 mock.patch.object(TP.TB, "apply_compiler_only_policy",
                                   return_value=(b"compiler", {"deadstripped": []}, [])), \
                 mock.patch.object(TP.TB, "apply_externalized_output_policy",
                                   return_value=(b"external", {"externalized": []}, [])), \
+                mock.patch.object(TP.TB, "prepare_owned_nontext_section_order",
+                                  return_value=(b"ordered", section_order, [])) as order, \
                 mock.patch.object(TP.TB, "verify_owned_sections",
                                   side_effect=[owned, owned]) as verify, \
                 mock.patch.object(TP.TB, "partition_vtable_rebiases",
@@ -232,18 +236,75 @@ class ProductionTuObjects(unittest.TestCase):
                 mock.patch.object(TP.TB, "object_audit_refusals", return_value=[]):
             output, evidence = TP.prepare_intact_object(b"raw", entry)
         self.assertEqual(output, b"linked")
+        order.assert_called_once_with(b"external", entry, claims)
         rebias.assert_called_once_with(
-            b"external", {"_ZTV1T": {"bias": 8}}, normalize_undefined=True)
+            b"ordered", {"_ZTV1T": {"bias": 8}}, normalize_undefined=True)
         audit.assert_called_once_with(
             b"linked", entry, 0x1000, 0x1010, {},
             validated_vtable_policies={"_ZTV1T": {"bias": 8}})
         self.assertEqual(verify.call_args_list, [
-            mock.call(b"external", entry, claims),
+            mock.call(b"ordered", entry, claims),
             mock.call(b"linked", entry, claims, public_address_points=True,
                       normalized_undefined_vtables=True),
         ])
+        self.assertIs(evidence["sectionOrder"], section_order)
         self.assertEqual(evidence["sha256"],
                          __import__("hashlib").sha256(b"linked").hexdigest())
+
+    def test_intact_object_keeps_an_already_ordered_external_object(self):
+        """FlyGuy-shaped no-op order still flows through every production gate."""
+        entry = {"id": "ov070/FlyGuy"}
+        claims = [{"name": ".text", "start": 0x1000, "end": 0x1010},
+                  {"name": ".data", "start": 0x2000, "end": 0x2010}]
+        owned = {"ok": True, "rows": [], "errors": []}
+        section_order = {"groups": [{"section": ".data", "original": [5, 7],
+                                      "desired": [5, 7]}], "objisolate": None}
+        with mock.patch.object(TP.TB, "manifest_section_claims",
+                               return_value=(claims, [])), \
+                mock.patch.object(TP.TB, "apply_compiler_only_policy",
+                                  return_value=(b"compiler", {}, [])), \
+                mock.patch.object(TP.TB, "apply_externalized_output_policy",
+                                  return_value=(b"external", {}, [])), \
+                mock.patch.object(TP.TB, "prepare_owned_nontext_section_order",
+                                  return_value=(b"external", section_order, [])) as order, \
+                mock.patch.object(TP.TB, "verify_owned_sections",
+                                  side_effect=[owned, owned]) as verify, \
+                mock.patch.object(TP.TB, "partition_vtable_rebiases",
+                                  return_value=({}, [])), \
+                mock.patch.object(TP.TB.OI, "rebias_object_symbols",
+                                  return_value=(b"external", {"error": None})) as rebias, \
+                mock.patch.object(TP.TB, "complete_ranges", return_value={}), \
+                mock.patch.object(TP.TB, "audit_tu_object",
+                                  return_value=([], [], [], True)), \
+                mock.patch.object(TP.TB, "object_audit_refusals", return_value=[]):
+            output, evidence = TP.prepare_intact_object(b"raw", entry)
+        self.assertEqual(output, b"external")
+        order.assert_called_once_with(b"external", entry, claims)
+        rebias.assert_called_once_with(b"external", {}, normalize_undefined=True)
+        self.assertEqual(verify.call_args_list, [
+            mock.call(b"external", entry, claims),
+            mock.call(b"external", entry, claims, public_address_points=True,
+                      normalized_undefined_vtables=True),
+        ])
+        self.assertIs(evidence["sectionOrder"], section_order)
+
+    def test_intact_object_refuses_section_order_before_owned_verification(self):
+        entry = {"id": "ov047/Thing"}
+        claims = [{"name": ".text", "start": 0x1000, "end": 0x1010},
+                  {"name": ".data", "start": 0x2000, "end": 0x2010}]
+        with mock.patch.object(TP.TB, "manifest_section_claims",
+                               return_value=(claims, [])), \
+                mock.patch.object(TP.TB, "apply_compiler_only_policy",
+                                  return_value=(b"compiler", {}, [])), \
+                mock.patch.object(TP.TB, "apply_externalized_output_policy",
+                                  return_value=(b"external", {}, [])), \
+                mock.patch.object(TP.TB, "prepare_owned_nontext_section_order",
+                                  return_value=(None, {}, ["ambiguous order"])), \
+                mock.patch.object(TP.TB, "verify_owned_sections") as verify:
+            with self.assertRaisesRegex(TP.ProductionTuError,
+                                        "manifest non-text section order"):
+                TP.prepare_intact_object(b"raw", entry)
+        verify.assert_not_called()
 
     def test_partitioned_object_normalizes_undefined_vtable_imports(self):
         entry = {
@@ -256,6 +317,8 @@ class ProductionTuObjects(unittest.TestCase):
                   {"name": ".data", "start": 0x2000, "end": 0x2010}]
         owned = {"ok": True, "rows": [], "errors": []}
         biases = {"_ZTV1T": {"bias": 8}}
+        section_order = {"groups": [{"section": ".data", "original": [5, 7],
+                                      "desired": [7, 5]}], "objisolate": {}}
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
             config = root / "config"
@@ -279,10 +342,12 @@ class ProductionTuObjects(unittest.TestCase):
                                       return_value=(b"compiler", {}, [])), \
                     mock.patch.object(TP.TB, "apply_externalized_output_policy",
                                       return_value=(b"external", {}, [])), \
+                    mock.patch.object(TP.TB, "prepare_owned_nontext_section_order",
+                                      return_value=(b"ordered", section_order, [])) as order, \
                     mock.patch.object(TP.TB, "verify_owned_sections",
                                       side_effect=[owned, owned]) as verify, \
                     mock.patch.object(TP.TB, "derive_owned_nontext_object",
-                                      return_value=(b"storage", {}, [])), \
+                                      return_value=(b"storage", {}, [])) as derive, \
                     mock.patch.object(TP.TB, "partition_vtable_rebiases",
                                       return_value=(biases, [])), \
                     mock.patch.object(TP.TB.OI, "rebias_object_symbols",
@@ -291,11 +356,14 @@ class ProductionTuObjects(unittest.TestCase):
 
         rebias.assert_called_once_with(
             b"storage", biases, normalize_undefined=True)
+        order.assert_called_once_with(b"external", entry, claims)
+        derive.assert_called_once_with(b"ordered", entry, claims)
         self.assertEqual(verify.call_args_list, [
-            mock.call(b"external", entry, claims),
+            mock.call(b"ordered", entry, claims),
             mock.call(b"linked", entry, claims, public_address_points=True,
                       normalized_undefined_vtables=True),
         ])
+        self.assertIs(result["sectionOrder"], section_order)
         self.assertEqual(result["storageSha256"],
                          __import__("hashlib").sha256(b"linked").hexdigest())
 

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1110,7 +1110,11 @@ def test_manifest_order_handles_rccarpet_owned_subset_after_rtti_externalization
     import io
     from elftools.elf.elffile import ELFFile
 
-    source = REPO / "src_tu/actors/daObjRcCarpet_c.cpp"
+    manifest_entry = tubuild.manifest_entry(
+        tubuild.TUM.load(), "ov036/daObjRcCarpet_c")
+    assert manifest_entry is not None
+    source = REPO / manifest_entry["source"]
+    assert source.is_file(), source
     obj = tubuild.M.compile_c(source, tubuild.RB.VERSION,
                               tubuild.BP.flags_for(source))
     inherited = [

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -2056,6 +2056,12 @@ def test_record_linkcheck_preserves_all_owned_ranges():
             {"section": ".data", "differingBytes": 0},
         ],
         "objectAudit": {},
+        "nontextSectionOrder": {
+            "groups": [{"section": ".data", "original": [14, 20],
+                        "desired": [20, 14], "anchors": {}}],
+            "objisolate": {"reordered": [{"section": ".data"}],
+                            "error": None},
+        },
         "linkedStorageAliases": {"ok": True, "rows": [{"exact": True}],
                                   "errors": []},
         "symbolsNew": [],
@@ -2074,6 +2080,12 @@ def test_record_linkcheck_preserves_all_owned_ranges():
     assert recorded["tuRanges"] == report["tuRanges"]
     assert recorded["moduleSetSha256"] == "b" * 64
     assert recorded["linkedStorageAliases"] == report["linkedStorageAliases"]
+    assert recorded["nontextSectionOrder"] == {
+        "groups": [{"section": ".data", "original": [14, 20],
+                    "desired": [20, 14]}],
+        "objisolate": report["nontextSectionOrder"]["objisolate"],
+        "errors": None,
+    }
 
 # ---------------------------------------------------------------- create repairs
 # The three assemble_shadow_source behaviors proven by six modules of

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1203,6 +1203,76 @@ def test_manifest_order_is_a_noop_when_emitted_addresses_already_match():
     assert report["groups"][0]["desired"] == report["groups"][0]["original"]
 
 
+def _verify_grouped_owned_relocation(manifest_module, configured_module,
+                                     candidate_module):
+    """Drive the real owned-relocation verdict with one injected data layout."""
+    from unittest import mock
+
+    start, end, destination = 0x02000000, 0x02000010, 0x02120000
+    owned, imported = "owned_data", "imported_data"
+    layout = {
+        "bytes": bytes(range(end - start)),
+        "relocs": [{"offset": 0, "type": 2, "symbol": imported,
+                    "addend": 0, "targetSection": "SHN_UNDEF"}],
+        "symbols": {owned: {"address": start, "size": end - start,
+                             "bind": "STB_GLOBAL", "type": "STT_OBJECT",
+                             "sectionIndex": 1}},
+        "inputSections": [1],
+    }
+    entry = {
+        "module": "ov999", "functions": [],
+        "data": [{"symbol": owned, "address": hex(start),
+                  "size": hex(end - start)}],
+        "relocations": [{"section": ".data", "source": hex(start),
+                         "type": "R_ARM_ABS32", "kind": "load",
+                         "symbol": imported, "addend": 0,
+                         "target_module": manifest_module,
+                         "target_address": hex(destination)}],
+    }
+    claims = [{"name": ".data", "start": start, "end": end}]
+    config = {"ov999": {start: ("load", destination, configured_module)}}
+    with mock.patch.object(tubuild, "section_contribution",
+                           lambda _obj, _name, _start: (layout, None)):
+        return tubuild.verify_owned_sections(
+            b"", entry, claims,
+            name_index={imported: (candidate_module, destination)},
+            config_relocs=config, sym_index={},
+            target_reader=lambda _module, _start, size: layout["bytes"][:size],
+            symbol_homes={}, bss_boundaries=set())
+
+
+def test_owned_relocation_accepts_exact_group_and_member_candidate():
+    result = _verify_grouped_owned_relocation(
+        "overlays(2,7)", "overlays(2,7)", "ov002")
+    assert result["ok"], result["errors"]
+    row = result["relocations"][0]
+    assert row["verdict"] == "OK"
+    assert row["expectedModules"] == ["ov002", "ov007"]
+    assert row["configuredModules"] == ["ov002", "ov007"]
+    assert row["candidateModule"] == "ov002"
+
+
+def test_owned_relocation_rejects_a_different_configured_group():
+    result = _verify_grouped_owned_relocation(
+        "overlays(2,7)", "overlays(2,9)", "ov002")
+    assert not result["ok"]
+    row = result["relocations"][0]
+    assert row["verdict"] == "WRONG-MODULE"
+    assert row["expectedModules"] == ["ov002", "ov007"]
+    assert row["configuredModules"] == ["ov002", "ov009"]
+
+
+def test_owned_relocation_rejects_candidate_outside_the_exact_group():
+    result = _verify_grouped_owned_relocation(
+        "overlays(2,7)", "overlays(2,7)", "ov009")
+    assert not result["ok"]
+    row = result["relocations"][0]
+    assert row["verdict"] == "WRONG-MODULE"
+    assert row["expectedModules"] == row["configuredModules"] \
+        == ["ov002", "ov007"]
+    assert row["candidateModule"] == "ov009"
+
+
 def test_linkcheck_compile_passes_all_production_object_policies():
     original_policies = tubuild.RB.compiler_only_policies
     original_intact = tubuild.RB.intact_tu_policies

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1103,6 +1103,106 @@ if __name__ == "__main__":
 import tubuild
 
 
+def test_manifest_order_handles_rccarpet_owned_subset_after_rtti_externalization():
+    """RcCarpet's five live .data sections may reorder after inherited RTTI drops."""
+    if not _toolchain():
+        return
+    import io
+    from elftools.elf.elffile import ELFFile
+
+    source = REPO / "src_tu/actors/daObjRcCarpet_c.cpp"
+    obj = tubuild.M.compile_c(source, tubuild.RB.VERSION,
+                              tubuild.BP.flags_for(source))
+    inherited = [
+        "_ZTI7fBase_c", "_ZTS7fBase_c", "_ZTS7dBase_c", "_ZTS8dActor_c",
+        "_ZTI7dBase_c", "_ZTI10dBgActor_c", "_ZTI8dActor_c",
+        "_ZTI16dPathLiftActor_c", "_ZTS10dBgActor_c",
+        "_ZTS16dPathLiftActor_c",
+    ]
+    post_policy, externalized = tubuild.OI.derive_externalized(obj, inherited)
+    assert post_policy is not None, externalized
+    assert externalized["externalise"] == sorted(inherited)
+
+    elf = ELFFile(io.BytesIO(post_policy))
+    sections = list(elf.iter_sections())
+    retained = [i for i, sec in enumerate(sections)
+                if sec.name == ".data" and sec.header["sh_size"]]
+    assert len(retained) == 5
+    symtab = elf.get_section_by_name(".symtab")
+    symbols = {s.name: s for s in symtab.iter_symbols()}
+    owned = ["_ZTI15daObjRcCarpet_c", "data_ov036_02113f58",
+             "_ZTS15daObjRcCarpet_c", "FlyingCarpet_SpawnInfo",
+             "_ZTV15daObjRcCarpet_c"]
+    assert {symbols[name]["st_shndx"] for name in owned} == set(retained)
+    assert [symbols[name]["st_shndx"] for name in owned] != retained, (
+        "the real fixture must retain RcCarpet's measured RTTI/resource inversion")
+
+    addresses = {
+        "_ZTI15daObjRcCarpet_c": 0x02113f4c,
+        "data_ov036_02113f58": 0x02113f58,
+        "_ZTS15daObjRcCarpet_c": 0x02113f64,
+        "FlyingCarpet_SpawnInfo": 0x02113f78,
+        "_ZTV15daObjRcCarpet_c": 0x02113f9c,
+    }
+    rows = []
+    for name in owned:
+        sym = symbols[name]
+        row = {"symbol": name, "address": hex(addresses[name]),
+               "size": hex(sym["st_size"])}
+        if name.startswith("_ZTV"):
+            row.update({"emitted_storage_address": "0x02113f94",
+                        "address_point_bias": "0x8"})
+        rows.append(row)
+    entry = {"module": "ov036", "functions": [], "data": rows,
+             "rodata": [], "bss": []}
+    claims = [{"name": ".data", "start": 0x02113f4c, "end": 0x02114020}]
+
+    ordered, report, errors = tubuild.prepare_owned_nontext_section_order(
+        post_policy, entry, claims)
+    assert errors == [], errors
+    assert ordered is not None
+    assert report["groups"][0]["original"] == retained
+    assert report["groups"][0]["desired"] == [symbols[name]["st_shndx"]
+                                                for name in owned]
+    assert report["objisolate"]["error"] is None
+
+    layout, error = tubuild.section_contribution(ordered, ".data", 0x02113f4c)
+    assert error is None
+    for name in owned:
+        expected = (0x02113f94 if name == "_ZTV15daObjRcCarpet_c"
+                    else addresses[name])
+        assert layout["symbols"][name]["address"] == expected
+    assert len(layout["bytes"]) == 0xd4
+
+
+def test_manifest_order_is_a_noop_when_emitted_addresses_already_match():
+    """An already-correct TU keeps byte-identical object-file structure."""
+    if not _toolchain():
+        return
+
+    obj = _compile_tu_fixture(
+        'extern "C" int external_a;\n'
+        'extern "C" int external_b;\n'
+        'extern "C" int *first = &external_a;\n'
+        'extern "C" int *second = &external_b;\n')
+    start = 0x2000
+    layout, error = tubuild.section_contribution(obj, ".data", start)
+    assert error is None
+    entry = {"module": "ov999", "functions": [], "rodata": [], "bss": [],
+             "data": [{"symbol": name, "address": hex(row["address"]),
+                       "size": hex(row["size"])}
+                      for name, row in layout["symbols"].items()
+                      if name in ("first", "second")]}
+    claims = [{"name": ".data", "start": start,
+               "end": start + len(layout["bytes"])}]
+    ordered, report, errors = tubuild.prepare_owned_nontext_section_order(
+        obj, entry, claims)
+    assert errors == [], errors
+    assert ordered == obj
+    assert report["objisolate"] is None
+    assert report["groups"][0]["desired"] == report["groups"][0]["original"]
+
+
 def test_linkcheck_compile_passes_all_production_object_policies():
     original_policies = tubuild.RB.compiler_only_policies
     original_intact = tubuild.RB.intact_tu_policies

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -49,7 +49,12 @@ def prepare_intact_object(raw, entry):
     if reasons:
         _raise(f"{entry['id']} exact RTTI externalization", reasons)
 
-    owned_before = TB.verify_owned_sections(externalized_obj, entry, claims)
+    ordered_obj, section_order, reasons = \
+        TB.prepare_owned_nontext_section_order(externalized_obj, entry, claims)
+    if reasons:
+        _raise(f"{entry['id']} manifest non-text section order", reasons)
+
+    owned_before = TB.verify_owned_sections(ordered_obj, entry, claims)
     if not owned_before.get("ok"):
         _raise(f"{entry['id']} licensed non-text contribution",
                owned_before.get("errors", []))
@@ -57,7 +62,7 @@ def prepare_intact_object(raw, entry):
     if reasons:
         _raise(f"{entry['id']} vtable address-point policy", reasons)
     linked_obj, rebias = TB.OI.rebias_object_symbols(
-        externalized_obj, biases, normalize_undefined=True)
+        ordered_obj, biases, normalize_undefined=True)
     if linked_obj is None:
         _raise(f"{entry['id']} vtable address-point rewrite", [rebias.get("error")])
     owned_after = TB.verify_owned_sections(
@@ -76,6 +81,7 @@ def prepare_intact_object(raw, entry):
         _raise(f"{entry['id']} production object audit", audit_errors)
     return linked_obj, {
         "compilerOnly": compiler_only, "externalized": externalized,
+        "sectionOrder": section_order,
         "ownedBefore": owned_before, "ownedAfter": owned_after,
         "vtableRebias": rebias,
         "objectAudit": {"rows": rows, "extraSections": extra,
@@ -332,12 +338,17 @@ def _prepare_one(entry, config_root, work_root, jobs):
     if reasons:
         _raise(f"{entry['id']} exact RTTI externalization", reasons)
 
-    owned_before = TB.verify_owned_sections(externalized_obj, entry, claims)
+    ordered_obj, section_order, reasons = \
+        TB.prepare_owned_nontext_section_order(externalized_obj, entry, claims)
+    if reasons:
+        _raise(f"{entry['id']} manifest non-text section order", reasons)
+
+    owned_before = TB.verify_owned_sections(ordered_obj, entry, claims)
     if not owned_before.get("ok"):
         _raise(f"{entry['id']} licensed non-text contribution",
                owned_before.get("errors", []))
     storage_obj, partition, reasons = \
-        TB.derive_owned_nontext_object(externalized_obj, entry, claims)
+        TB.derive_owned_nontext_object(ordered_obj, entry, claims)
     if reasons:
         _raise(f"{entry['id']} non-text partition", reasons)
     biases, reasons = TB.partition_vtable_rebiases(entry, claims)
@@ -383,6 +394,7 @@ def _prepare_one(entry, config_root, work_root, jobs):
         "nontextClaims": [dict(claim) for claim in nontext],
         "compilerOnly": compiler_only,
         "externalized": externalized,
+        "sectionOrder": section_order,
         "partition": partition,
         "ownedBefore": owned_before,
         "ownedAfter": owned_after,

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2770,7 +2770,7 @@ _MULTI_OVERLAY_MODULE = re.compile(r"overlays\((\d+(?:,\d+)*)\)")
 
 
 def _relocation_module_set(field):
-    """Exact normalized destination-module set for one config/manifest field.
+    """Exact normalized destination-module set for one configuration or manifest field.
 
     dsd uses ``overlays(2,7)`` when the same destination address is valid in a
     known set of mutually exclusive overlays.  That is an ambiguity license, not a

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2620,6 +2620,140 @@ def section_contribution(obj_bytes, section_name, start):
             "inputSections": [i for i, _s in selected]}, None
 
 
+def prepare_owned_nontext_section_order(obj_bytes, entry, claims):
+    """Put repeated owned input sections in exact manifest-emitted address order.
+
+    mwldarm concatenates repeated ``file.o(.data)`` sections in ELF section-header
+    order.  A reconstructed source can emit independent globals in a different order
+    from retail even when every individual compiler section is exact.  The manifest's
+    emitted addresses provide a strict ordering license: every retained input section
+    must have an owned symbol anchor, every anchor in one section must imply the same
+    section base, and the resulting aligned layout must tile the claimed range.
+
+    The mechanical rewrite is delegated to objisolate and is followed by the ordinary
+    byte/symbol/relocation verifier.  This helper never guesses from symbol spelling or
+    payload bytes and never changes content or relocation records.
+    """
+    nontext = [claim for claim in claims if claim["name"] != ".text"]
+    if not nontext:
+        return obj_bytes, {"groups": [], "objisolate": None}, []
+
+    elf = ELFFile(io.BytesIO(obj_bytes))
+    secs = list(elf.iter_sections())
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return None, {"groups": [], "objisolate": None}, ["no .symtab"]
+    syms = list(symtab.iter_symbols())
+    owned_rows = manifest_owned_symbol_rows(entry)
+    owned_names = {row["symbol"] for _section, row in owned_rows}
+    reasons, groups, requested = [], [], []
+    seen_claim_names = set()
+
+    for claim in nontext:
+        name = claim["name"]
+        if name in seen_claim_names:
+            reasons.append(f"duplicate non-text claim for input section {name}")
+            continue
+        seen_claim_names.add(name)
+        selected = [index for index, sec in enumerate(secs)
+                    if sec.name == name and sec.header["sh_type"] in OI.CONTENT
+                    and sec.header["sh_size"]]
+        if not selected:
+            reasons.append(f"object emits no non-empty {name} section")
+            continue
+
+        rows = [row for section, row in owned_rows if section == name]
+        anchors = {index: [] for index in selected}
+        for row in rows:
+            symbol = row["symbol"]
+            matches = [sym for sym in syms if sym.name == symbol
+                       and sym["st_shndx"] not in ("SHN_UNDEF", "SHN_ABS")]
+            if len(matches) != 1:
+                reasons.append(f"owned {name} ordering anchor {symbol} has "
+                               f"{len(matches)} definitions, expected one")
+                continue
+            sym = matches[0]
+            shndx = sym["st_shndx"]
+            if shndx not in anchors:
+                reasons.append(f"owned {name} ordering anchor {symbol} is in "
+                               f"section[{shndx}], outside the retained group")
+                continue
+            emitted, error = _manifest_emitted_addr(row)
+            if error or emitted is None:
+                reasons.append(f"owned {name} ordering anchor {symbol}: "
+                               f"{error or 'no valid emitted address'}")
+                continue
+            anchors[shndx].append({"symbol": symbol, "address": emitted,
+                                   "sectionBase": emitted - sym["st_value"]})
+
+        occupants = {sym.name for sym in syms
+                     if sym.name and not sym.name.startswith("$")
+                     and sym["st_info"]["type"] != "STT_SECTION"
+                     and sym["st_shndx"] in set(selected)}
+        foreign = sorted(occupants - owned_names)
+        if foreign:
+            reasons.append(f"retained {name} ordering group defines unlicensed "
+                           f"symbol(s): {foreign}")
+
+        bases = {}
+        for shndx in selected:
+            rows_here = anchors[shndx]
+            if not rows_here:
+                reasons.append(f"retained {name} section[{shndx}] has no manifest "
+                               "emitted-address anchor")
+                continue
+            candidates = {row["sectionBase"] for row in rows_here}
+            if len(candidates) != 1:
+                detail = {row["symbol"]: f"0x{row['sectionBase']:08x}"
+                          for row in rows_here}
+                reasons.append(f"retained {name} section[{shndx}] anchors disagree "
+                               f"on its base: {detail}")
+                continue
+            bases[shndx] = next(iter(candidates))
+
+        if len(bases) != len(selected):
+            groups.append({"section": name, "original": selected,
+                           "desired": None, "anchors": anchors})
+            continue
+        if len(set(bases.values())) != len(bases):
+            reasons.append(f"retained {name} sections do not have unique manifest "
+                           "emitted bases")
+            groups.append({"section": name, "original": selected,
+                           "desired": None, "anchors": anchors})
+            continue
+
+        desired = sorted(selected, key=lambda index: bases[index])
+        cursor = claim["start"]
+        for shndx in desired:
+            sec = secs[shndx]
+            cursor = _align_up(cursor, sec.header["sh_addralign"])
+            if cursor != bases[shndx]:
+                reasons.append(f"retained {name} section[{shndx}] aligns at "
+                               f"0x{cursor:08x}, manifest anchors require "
+                               f"0x{bases[shndx]:08x}")
+            cursor += sec.header["sh_size"]
+        if cursor != claim["end"]:
+            reasons.append(f"manifest-ordered {name} contribution ends at "
+                           f"0x{cursor:08x}, claim ends at 0x{claim['end']:08x}")
+
+        groups.append({"section": name, "original": selected,
+                       "desired": desired, "anchors": anchors})
+        if desired != selected:
+            requested.append({"section": name, "indices": desired})
+
+    report = {"groups": groups, "objisolate": None}
+    if reasons:
+        return None, report, reasons
+    if not requested:
+        return obj_bytes, report, []
+    out, plan = OI.reorder_same_named_nontext_sections(obj_bytes, requested)
+    report["objisolate"] = plan
+    if out is None:
+        return None, report, [f"non-text section ordering refused: "
+                              f"{plan.get('error')}"]
+    return out, report, []
+
+
 _NON_TEXT_RELOC_KIND = {
     1: "arm_call",  # R_ARM_PC24
     2: "load",  # R_ARM_ABS32
@@ -4513,6 +4647,28 @@ def cmd_linkcheck(args):
                 print(f"      externalized {externalized['externalized']} to exact "
                       "configured canonical homes")
 
+            ordered_tu, section_order, order_reasons = \
+                prepare_owned_nontext_section_order(linked_tu, entry, claims)
+            report["nontextSectionOrder"] = section_order
+            if order_reasons:
+                print("      REFUSED -- manifest-licensed non-text section order:")
+                for reason in order_reasons:
+                    print(f"        {reason}")
+                report["nontextSectionOrder"]["errors"] = order_reasons
+                report["result"] = "section-order-refused"
+                _write_link_report(scratch, report)
+                _record_partitioned(data, entry, report)
+                return 1
+            linked_tu = ordered_tu
+            report["partitionedObjects"]["postOrderSha256"] = \
+                hashlib.sha256(linked_tu).hexdigest()
+            if linked_tu != externalized_tu:
+                scratch_rewrite = True
+                changed = [row["section"] for row in section_order.get("groups", [])
+                           if row.get("desired") != row.get("original")]
+                print(f"      reordered exact repeated non-text section group(s) "
+                      f"from manifest emitted addresses: {changed}")
+
             owned_before = verify_owned_sections(linked_tu, entry, claims)
             report["ownedSectionsBeforePartition"] = owned_before
             if not owned_before["ok"]:
@@ -5101,6 +5257,7 @@ def _partition_attempt_record(report):
     compiler = report.get("compilerOnlyOutput") or {}
     externalized = report.get("externalizedOutput") or {}
     external_verify = externalized.get("verification") or {}
+    section_order = report.get("nontextSectionOrder") or {}
     return {
         "result": report.get("result", "failed"),
         "round": "tools/tubuild.py linkcheck --partitioned -- scratch-only additive "
@@ -5130,6 +5287,13 @@ def _partition_attempt_record(report):
             "droppedSections": externalized.get("droppedSections"),
             "verificationOk": external_verify.get("ok"),
             "errors": externalized.get("errors") or external_verify.get("errors"),
+        },
+        "nontextSectionOrder": {
+            "groups": [{key: row.get(key) for key in
+                        ("section", "original", "desired")}
+                       for row in section_order.get("groups", [])],
+            "objisolate": section_order.get("objisolate"),
+            "errors": section_order.get("errors"),
         },
         "nontextPartition": {
             "requestedSections": partition.get("requestedSections"),

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -4810,6 +4810,27 @@ def cmd_linkcheck(args):
             print(f"      externalized {externalized['externalized']} to their exact "
                   "configured canonical homes in the SCRATCH object only")
 
+        ordered_tu, section_order, order_reasons = \
+            prepare_owned_nontext_section_order(linked_tu, entry, claims)
+        report["nontextSectionOrder"] = section_order
+        if order_reasons:
+            print("      REFUSED -- manifest-licensed non-text section order:")
+            for reason in order_reasons:
+                print(f"        {reason}")
+            report["nontextSectionOrder"]["errors"] = order_reasons
+            report["result"] = "section-order-refused"
+            _write_link_report(scratch, report)
+            _record_linkcheck(data, entry, report, baseline)
+            return 1
+        if ordered_tu != linked_tu:
+            linked_tu = ordered_tu
+            scratch_rewrite = True
+            tu_obj.write_bytes(linked_tu)
+            changed = [row["section"] for row in section_order.get("groups", [])
+                       if row.get("desired") != row.get("original")]
+            print(f"      reordered exact repeated non-text section group(s) from "
+                  f"manifest emitted addresses in the SCRATCH object only: {changed}")
+
         owned_before = verify_owned_sections(linked_tu, entry, claims)
         report["ownedSectionsBeforeRebias"] = owned_before
         if not owned_before["ok"]:
@@ -5389,6 +5410,7 @@ def _record_linkcheck(data, entry, report, baseline):
     if baseline or entry is None:
         return
     audit = report.get("objectAudit") or {}
+    section_order = report.get("nontextSectionOrder") or {}
     entry.setdefault("verification", {})["linkcheck"] = {
         "round": "tools/tubuild.py linkcheck -- scratch dsd delink+lcf, whole-tree mwccarm, "
                  "mwldarm link, linked-range and module byte comparison, dsd check symbols "
@@ -5406,6 +5428,13 @@ def _record_linkcheck(data, entry, report, baseline):
                 + (f" already at {', '.join(r['homes'])}" if r["homes"] else "")
                 for r in audit.get("nonLicensed", [])],
             "unlicensedSections": audit.get("unlicensedSections"),
+        },
+        "nontextSectionOrder": {
+            "groups": [{key: row.get(key) for key in
+                        ("section", "original", "desired")}
+                       for row in section_order.get("groups", [])],
+            "objisolate": section_order.get("objisolate"),
+            "errors": section_order.get("errors"),
         },
         "linkedStorageAliases": report.get("linkedStorageAliases"),
         "symbolCheckNewVsBaseline": report.get("symbolsNew"),

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2766,6 +2766,24 @@ _ELF_RELOC_NAME = {
     28: "R_ARM_CALL", 29: "R_ARM_JUMP24",
 }
 
+_MULTI_OVERLAY_MODULE = re.compile(r"overlays\((\d+(?:,\d+)*)\)")
+
+
+def _relocation_module_set(field):
+    """Exact normalized destination-module set for one config/manifest field.
+
+    dsd uses ``overlays(2,7)`` when the same destination address is valid in a
+    known set of mutually exclusive overlays.  That is an ambiguity license, not a
+    wildcard: manifest and config must name the same set, and a resolved candidate
+    still has to identify one member.  All ordinary spellings remain singleton sets.
+    """
+    raw = str(field).strip()
+    multi = _MULTI_OVERLAY_MODULE.fullmatch(raw)
+    if multi:
+        return {RL.normalize_module(f"overlay({number})")
+                for number in multi.group(1).split(",")}
+    return {RL.normalize_module(raw)}
+
 
 def manifest_relocation_claims(entry):
     """Exact per-word non-text relocation licenses keyed by absolute source address."""
@@ -2799,7 +2817,9 @@ def manifest_relocation_claims(entry):
         normalized = dict(row)
         normalized.update({"source": source, "addend": addend,
                            "target_address": target,
-                           "target_module": RL.normalize_module(row["target_module"])})
+                           "target_module": RL.normalize_module(row["target_module"]),
+                           "target_modules": sorted(_relocation_module_set(
+                               row["target_module"]))})
         out[source] = normalized
     return out, reasons
 
@@ -3017,6 +3037,9 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
                     expected_addend = (expected_addend - bias
                                        if expected_addend >= bias else None)
             configured_module = RL.normalize_module(cfg[2]) if cfg else None
+            configured_modules = _relocation_module_set(cfg[2]) if cfg else set()
+            expected_modules = (set(expected["target_modules"])
+                                if expected is not None else set())
             candidate_kind = _NON_TEXT_RELOC_KIND.get(rel["type"])
             if cfg is None:
                 verdict = "EXTRA"
@@ -3034,8 +3057,8 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
                 verdict = "WRONG-ADDEND"
             elif candidate_kind != expected["kind"] or expected["kind"] != cfg[0]:
                 verdict = "WRONG-KIND"
-            elif candidate_module != expected["target_module"] \
-                    or expected["target_module"] != configured_module:
+            elif expected_modules != configured_modules \
+                    or candidate_module not in expected_modules:
                 verdict = "WRONG-MODULE"
             elif cand_addr != expected["target_address"] \
                     or expected["target_address"] != cfg[1]:
@@ -3049,10 +3072,12 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
                                "expectedSymbol": expected.get("symbol") if expected else None,
                                "expectedAddend": expected.get("addend") if expected else None,
                                "expectedEmittedAddend": expected_addend,
+                               "expectedModules": sorted(expected_modules),
                                "candidateModule": candidate_module,
                                "candidate": f"0x{cand_addr:08x}" if cand_addr is not None else None,
                                "configuredKind": cfg[0] if cfg else None,
                                "configuredModule": configured_module,
+                               "configuredModules": sorted(configured_modules),
                                "configured": f"0x{cfg[1]:08x}" if cfg else None,
                                "verdict": verdict})
         for source in sorted(a for a in cfgmap


### PR DESCRIPTION
Rooted directly on current main; the previous FlyGuy stack dependency has been removed.\n\nAdds fail-closed manifest-driven ordering for repeated owned non-text input sections before intact-TU verification and production. It preserves payload and relocation bytes, remaps ELF section references, and rejects unsupported or incomplete layouts.\n\nThis PR also deliberately changes one verifier acceptance path: _relocation_module_set compares composite overlay destinations as identical bounded module sets. The old scalar comparison unconditionally rejected valid overlays(...) rows after the candidate normalized to a concrete ovNNN. The new path still requires the manifest/config sets to be identical, requires the concrete target module to be a member, and leaves target-address checking unchanged; singleton behavior is unchanged.\n\nFresh current-main validation at 6ef413aea:\n- patch-identical five-commit range-diff from the reviewed head\n- objisolate, tu_production, and tubuild suites: 118/118 passed with the wired compiler\n- full production: 11,088/11,088 functions, 2/2 source-owned data claims, 106/106 modules, zero mismatches, exact stock ROM\n- strict control: identical stock ROM and the same nine pre-existing symbol diagnostics\n- 97/97 C++ TUs compile; port references 405/405\n\nNo claims, attempt-ledger, source, or dashboard artifacts are included.