### PR TITLE
Add check_decl_return_types.py: one symbol, one declared return type (tool only, not wired into CI)

### DIFF
--- a/tools/check_decl_return_types.py
+++ b/tools/check_decl_return_types.py
@@ -1,0 +1,266 @@
+"""Confirm a mangled symbol is declared with ONE return type, not two.
+
+Every recovered C++ method is declared twice, in files that never see each other:
+
+    include/decl_common.h    extern void _ZN11dScMgBase_c16OnAimedAtWithEggEv(void*);
+    include/dScMgBase_c.h    virtual int  OnAimedAtWithEgg();          /* slot 29 */
+
+The compiler never compares them -- neither header includes the other, and a
+caller reaching the symbol through one of them compiles cleanly no matter what
+the other says. The linker binds on the mangled name alone and does not carry a
+return type, so the disagreement survives every existing gate: the byte gates
+pass because each translation unit is internally consistent, and
+check_header_offsets only looks at field layout.
+
+The failure this prevents is a caller that reads r0 from a callee which never
+wrote it (or the reverse), reached through whichever of the two declarations
+happened to be in scope. It is silent at compile time and at link time.
+
+Measured on pr/2102 by hand before this tool existed: 4 disagreements. Run over
+the same four refs, this reproduces that exactly --
+
+    origin/main                 2   (joined 7)
+    origin/cpp/minigame-slot28  2   (joined 7)
+    origin/cpp/minigame-slot29  3   (joined 8)
+    origin/cpp/minigame-slot30  4   (joined 9)
+
+-- from a wider join than the hand census managed, which missed the eight
+declarations that glue `*` or `&` to the method name.
+
+Two of the four (dScMgBase_c::BeforeInitResources, ::AfterInitResources) predate
+the slot work and are on main today, which is why this is NOT yet wired into CI
+-- see the `--summary` accounting and notes in the PR that introduced it.
+
+    python tools/check_decl_return_types.py
+    python tools/check_decl_return_types.py --summary   # show what was NOT checked
+
+There is deliberately no --changed mode. The invariant is global to one file
+plus every class header, so a whole-tree check is both cheap and the only honest
+one: editing a class header can break agreement with a decl_common.h row that
+the diff does not touch, and vice versa.
+
+Exit status is 1 if any symbol is declared with two different return types, and
+0 otherwise. A row that cannot be joined to a class virtual is reported as
+UNJOINED, never counted as agreement -- see summarize() for why most of them
+structurally cannot disagree.
+"""
+import re, sys, pathlib
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# `extern <type> _ZN...(` -- the type may end in `*` with no space before the
+# symbol, as in `extern void*_ZN2G212GetBG1ScrPtrEv(void);`, so the symbol is
+# matched first and the type is whatever precedes it.
+DECL_ROW = re.compile(r"^extern\s+(.+?)\s*(_Z\w+)\s*\(", re.M)
+# A class or struct body. Brace matching is done by hand, not by regex, because
+# these bodies nest (unions, anonymous structs) and a non-greedy `\{.*?\}` stops
+# at the first inner close.
+CLASS_OPEN = re.compile(r"^(?:struct|class)\s+(\w+)\b[^;{]*\{", re.M)
+# `virtual int  Foo();` -- return type and name. The whitespace spans newlines, so
+# a declaration split across two lines is read correctly; that is measured, not
+# assumed (test_multiline_declaration_is_parsed).
+#
+# The return type excludes `;` `(` `)` `{` `}` so a match cannot run past the end
+# of one declaration. With a permissive `.+?` there,
+#
+#     virtual ~dActor_c();
+#     ...
+#     dActor_c(s16 profile);           <- the constructor, lines later
+#
+# matched as return type `~dActor_c();` and method name `dActor_c`, borrowing its
+# `(` from the constructor. That both double-counted the destructor and injected
+# a virtual named after the class into the map.
+#
+# The separator is whitespace OR nothing at all when the type ends in `*` or `&`,
+# because this tree glues the sigil to the name:
+#
+#     virtual Vector3 &GetPos();
+#     virtual void *Unk_020c76d0() = 0;
+#
+# Eight declarations here are spelled that way. A plain `\s+` separator reads
+# none of them.
+VIRTUAL = re.compile(r"^\s*virtual\s+([^;(){}]+?)(?:\s+|(?<=[*&])\s*)(~?\w+)\s*\(",
+                     re.M)
+# `virtual ~Foo();` does NOT match VIRTUAL -- there is only one token after
+# `virtual`, and VIRTUAL needs two. Recognised separately so it is scored as
+# handled-and-dropped rather than as a blind spot.
+DESTRUCTOR = re.compile(r"^\s*virtual\s+~\w+\s*\(", re.M)
+# Any line that opens with `virtual` at all, so the tool can report how many it
+# failed to parse instead of quietly under-reaching.
+VIRTUAL_ANY = re.compile(r"^\s*virtual\b", re.M)
+COMMENT = re.compile(r"/\*.*?\*/|//[^\n]*", re.S)
+
+
+def strip_comments(text):
+    """Blank out comments, preserving newlines so line structure survives.
+
+    Not cosmetic. The headers here carry heavy prose, and VIRTUAL's `\\s+` spans
+    newlines, so a destructor followed by a comment containing a parenthesis --
+
+        virtual ~fBase_c();                    /* slots 16 (D1), 17 (D0) */
+
+    -- matches as return type `~fBase_c(); /* slots` and method name `16`,
+    taking its `(` from the comment. That invents a virtual named `16`, and on
+    this tree it did so in 116 class bodies. Comments are also the reason
+    VIRTUAL_ANY over-counted: prose lines beginning with the word `virtual` are
+    not declarations and must not be scored as blind spots either.
+    """
+    return COMMENT.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+
+
+def parse_nested(sym):
+    """Recover (class, method) from `_ZN<len>Class<len>MethodE...`.
+
+    Parsing backward out of the mangled name rather than forward from a header
+    is what makes this complete. A forward matcher -- mangle each declared
+    virtual and look it up -- has to guess parameter encodings to build the
+    string, so it silently misses every method whose arity or parameter types it
+    guesses wrong. The mangled name already carries the answer.
+
+    Returns None for anything that cannot carry a return type: vtable and
+    typeinfo data (`_ZTV`, `_ZTI`, `_ZTS`), constructors and destructors, and
+    non-nested names.
+    """
+    if not sym.startswith("_ZN"):
+        return None
+    s, parts = sym[3:], []
+    while s and s[0].isdigit():
+        n = 0
+        while s and s[0].isdigit():
+            n = n * 10 + int(s[0])
+            s = s[1:]
+        if len(s) < n:
+            return None
+        parts.append(s[:n])
+        s = s[n:]
+    # A structor has no return type to disagree about: the component encoding
+    # (C1/C2/C3, D0/D1/D2) sits where the method name would be.
+    if s[:2] in ("C1", "C2", "C3", "D0", "D1", "D2"):
+        return None
+    if not s.startswith("E") or len(parts) < 2:
+        return None
+    return parts[-2], parts[-1]
+
+
+def norm_type(t):
+    """Collapse spelling differences that are not type differences.
+
+    `void *` and `void*` are the same type; `bool` and `int` are NOT, and must
+    stay distinct -- a bool return goes through a widening cast under
+    mwccarm 2004/b56 that an int return does not, so conflating them here would
+    hide the one disagreement in this family that can cost bytes.
+    """
+    t = " ".join(t.split())
+    t = re.sub(r"\s*\*\s*", "*", t)
+    return t.replace("extern ", "").strip()
+
+
+def class_virtuals(root):
+    """Map class name -> list of (return type, method name) for every header.
+
+    Also returns the number of `virtual` lines that did not parse, so the caller
+    can report the tool's own reach rather than implying it read everything.
+    Destructors are handled, not missed: they are recognised by DESTRUCTOR and
+    deliberately dropped because they have no return type, so they must not be
+    added to the unparsed count -- doing so reported 274 phantom blind spots on
+    a tree whose real figure is zero, which would make a reader distrust a green
+    run. They need their own pattern because `virtual ~Foo();` has one token
+    after `virtual` and VIRTUAL requires two.
+    """
+    out, unparsed = {}, 0
+    for path in sorted((root / "include").rglob("*.h")):
+        text = strip_comments(path.read_text(encoding="utf-8", errors="replace"))
+        for m in CLASS_OPEN.finditer(text):
+            cls, i, depth = m.group(1), m.end(), 1
+            while i < len(text) and depth:
+                if text[i] == "{":
+                    depth += 1
+                elif text[i] == "}":
+                    depth -= 1
+                i += 1
+            body = text[m.end():i]
+            handled = len(DESTRUCTOR.findall(body))
+            for v in VIRTUAL.finditer(body):
+                handled += 1
+                if v.group(2).startswith("~"):
+                    continue                     # e.g. `virtual inline ~Foo()`
+                out.setdefault(cls, []).append((norm_type(v.group(1)), v.group(2)))
+            unparsed += len(VIRTUAL_ANY.findall(body)) - handled
+    return out, unparsed
+
+
+def check(root=REPO):
+    """Return (disagreements, accounting). Reads the tree, decides nothing."""
+    decl = strip_comments((root / "include" / "decl_common.h")
+                          .read_text(encoding="utf-8", errors="replace"))
+    virt, unparsed = class_virtuals(root)
+    known = set(virt)
+
+    bad, acct = [], {"rows": 0, "no_return_type": 0, "not_a_class": 0,
+                     "not_virtual": 0, "ambiguous": 0, "joined": 0,
+                     "unparsed_virtuals": unparsed}
+    for m in DECL_ROW.finditer(decl):
+        dtype, sym = norm_type(m.group(1)), m.group(2)
+        acct["rows"] += 1
+        pair = parse_nested(sym)
+        if pair is None:
+            acct["no_return_type"] += 1
+            continue
+        cls, meth = pair
+        if cls not in known:
+            # Almost always an SDK namespace (GX, Sound, cstd): a namespaced
+            # free function, which has no vtable slot and so cannot disagree.
+            acct["not_a_class"] += 1
+            continue
+        cand = [v for v in virt[cls] if v[1] == meth]
+        if not cand:
+            acct["not_virtual"] += 1
+            continue
+        if len(cand) > 1:
+            # Overloads share a name, so the join is not unique. Reported rather
+            # than resolved: picking one would be a guess, and a wrong guess here
+            # is a false failure on a correct tree.
+            acct["ambiguous"] += 1
+            continue
+        acct["joined"] += 1
+        if cand[0][0] != dtype:
+            bad.append((cls, meth, cand[0][0], dtype, sym))
+    return bad, acct
+
+
+def main(argv):
+    root = REPO
+    if "--root" in argv:
+        root = pathlib.Path(argv[argv.index("--root") + 1]).resolve()
+    if not (root / "include" / "decl_common.h").is_file():
+        # Reached by pointing --root at an extracted tree with a mistyped or
+        # shell-mangled path. Saying so beats a traceback: this is a gate, and a
+        # gate that crashes is indistinguishable from a gate that failed.
+        print(f"no include/decl_common.h under {root}", file=sys.stderr)
+        return 2
+    bad, acct = check(root)
+
+    for cls, meth, ctype, dtype, sym in bad:
+        print(f"DISAGREE {cls}::{meth}: class header says '{ctype}', "
+              f"decl_common.h says '{dtype}'  [{sym}]")
+
+    if "--summary" in argv or bad:
+        # Printed on failure too: the count of rows that could not be joined is
+        # the honest bound on this check, and a reader deciding whether to trust
+        # a green run needs it as much as one reading a red one.
+        print(f"\n  decl_common.h rows              {acct['rows']}")
+        print(f"    no return type (vtable/structor) {acct['no_return_type']}")
+        print(f"    not a class in include/          {acct['not_a_class']}")
+        print(f"    class method, not virtual        {acct['not_virtual']}")
+        print(f"    ambiguous (overloads)            {acct['ambiguous']}")
+        print(f"    JOINED and compared              {acct['joined']}")
+        if acct["unparsed_virtuals"]:
+            print(f"  virtual lines not parsed         {acct['unparsed_virtuals']}"
+                  "  (not checked, and NOT counted as agreement)")
+
+    print(f"{len(bad)} symbol(s) declared with two different return types")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/test_check_decl_return_types.py
+++ b/tools/test_check_decl_return_types.py
@@ -1,0 +1,344 @@
+"""Regression tests for tools/check_decl_return_types.py.
+
+Two kinds of case here, and the second kind is the one that matters:
+
+  1. It finds a real disagreement (the gate does its job).
+  2. It does NOT fire on the many shapes that merely look like one.
+
+A return-type gate that cannot tell `void *` from `void*`, or that resolves an
+overload by guessing, fails on a correct tree. That kind of red is worse than no
+gate at all: it trains everyone to route around the check. So most of what
+follows plants a shape that is CORRECT and asserts silence.
+
+The accounting is asserted too. This tool's honesty rests on reporting what it
+could not join, and an early version counted all 274 destructors in include/ as
+"virtual declarations not parsed" -- phantom blind spots on a tree whose real
+figure is zero. test_destructors_are_handled_not_missed pins that.
+"""
+import contextlib
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import check_decl_return_types as C
+
+
+class Tree:
+    """A throwaway include/ tree: `decl_common.h` plus named headers."""
+
+    def __init__(self, decl, **headers):
+        self.dir = tempfile.TemporaryDirectory()
+        root = pathlib.Path(self.dir.name)
+        (root / "include").mkdir()
+        (root / "include" / "decl_common.h").write_text(decl, encoding="utf-8")
+        for name, text in headers.items():
+            (root / "include" / (name + ".h")).write_text(text, encoding="utf-8")
+        self.root = root
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.dir.cleanup()
+
+    def check(self):
+        return C.check(self.root)
+
+
+class FindsRealDisagreements(unittest.TestCase):
+    def test_plain_disagreement_is_reported(self):
+        with Tree("extern void _ZN3Foo3BarEv(void*);\n",
+                  Foo="struct Foo {\n    virtual int Bar();\n};\n") as t:
+            bad, acct = t.check()
+            self.assertEqual(len(bad), 1)
+            cls, meth, ctype, dtype, _sym = bad[0]
+            self.assertEqual((cls, meth, ctype, dtype),
+                             ("Foo", "Bar", "int", "void"))
+            self.assertEqual(acct["joined"], 1)
+
+    def test_bool_and_int_are_not_conflated(self):
+        """The one disagreement in this family that can cost bytes.
+
+        A bool return goes through a widening cast under mwccarm 2004/b56 that
+        an int return does not, so normalising them together would hide the
+        expensive case while still catching the cheap ones.
+        """
+        with Tree("extern int _ZN3Foo3BarEv(void*);\n",
+                  Foo="struct Foo {\n    virtual bool Bar();\n};\n") as t:
+            bad, _ = t.check()
+            self.assertEqual(len(bad), 1)
+            self.assertEqual(bad[0][2:4], ("bool", "int"))
+
+    def test_disagreement_sets_exit_status(self):
+        with Tree("extern void _ZN3Foo3BarEv(void*);\n",
+                  Foo="struct Foo {\n    virtual int Bar();\n};\n") as t:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = C.main(["--root", str(t.root)])
+            self.assertEqual(rc, 1)
+            self.assertIn("DISAGREE Foo::Bar", buf.getvalue())
+            # The accounting prints on failure too, unasked: a reader deciding
+            # whether to believe a red run needs the join count as much as one
+            # reading a green run.
+            self.assertIn("JOINED and compared", buf.getvalue())
+
+    def test_clean_tree_exits_zero(self):
+        with Tree("extern int _ZN3Foo3BarEv(void*);\n",
+                  Foo="struct Foo {\n    virtual int Bar();\n};\n") as t:
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(C.main(["--root", str(t.root)]), 0)
+
+    def test_arity_mismatch_is_not_a_disagreement(self):
+        """decl_common.h spells `this` as an explicit void* first parameter.
+
+        Every row therefore has one more parameter than the class declaration.
+        Only the return type is compared; a tool that compared signatures would
+        fire on all 64 rows.
+        """
+        with Tree("extern int _ZN3Foo3BarEii(void*, int, int);\n",
+                  Foo="struct Foo {\n    virtual int Bar(int a, int b);\n};\n") as t:
+            bad, acct = t.check()
+            self.assertEqual(bad, [])
+            self.assertEqual(acct["joined"], 1)
+
+
+class DoesNotFireOnCorrectShapes(unittest.TestCase):
+    def test_pointer_spelling_is_normalised(self):
+        with Tree("extern void*_ZN3Foo3BarEv(void*);\n",
+                  Foo="struct Foo {\n    virtual void * Bar();\n};\n") as t:
+            self.assertEqual(t.check()[0], [])
+
+    def test_structors_are_skipped(self):
+        """A constructor or destructor has no return type to disagree about."""
+        decl = ("extern void _ZN3FooC1Ev(void*);\n"
+                "extern void _ZN3FooD1Ev(void*);\n"
+                "extern void _ZN3FooD2Ev(void*);\n")
+        with Tree(decl, Foo="struct Foo {\n    virtual ~Foo();\n};\n") as t:
+            bad, acct = t.check()
+            self.assertEqual(bad, [])
+            self.assertEqual(acct["joined"], 0)
+            self.assertEqual(acct["no_return_type"], 3)
+
+    def test_vtable_and_typeinfo_rows_are_skipped(self):
+        decl = ("extern void *_ZTV3Foo(void);\n"
+                "extern void *_ZTI3Foo(void);\n"
+                "extern void *_ZTS3Foo(void);\n")
+        with Tree(decl, Foo="struct Foo {\n    virtual int Bar();\n};\n") as t:
+            bad, acct = t.check()
+            self.assertEqual(bad, [])
+            self.assertEqual(acct["no_return_type"], 3)
+
+    def test_namespaced_free_function_is_not_a_class(self):
+        """`Sound::Play2D` and friends are namespaced free functions.
+
+        They have no vtable slot, so there is no second declaration site and
+        nothing to disagree with. Counting them as checked would inflate the
+        tool's apparent reach.
+        """
+        with Tree("extern int _ZN5Sound6Play2DEv(void*);\n") as t:
+            bad, acct = t.check()
+            self.assertEqual(bad, [])
+            self.assertEqual(acct["not_a_class"], 1)
+            self.assertEqual(acct["joined"], 0)
+
+    def test_overloads_are_reported_ambiguous_not_failed(self):
+        """Two virtuals share a name, so the join is not unique.
+
+        Picking one would be a guess, and a wrong guess is a false failure on a
+        correct tree. The row is counted as ambiguous and compared against
+        nothing.
+        """
+        hdr = ("struct Foo {\n"
+               "    virtual int Bar();\n"
+               "    virtual void Bar(int a);\n"
+               "};\n")
+        with Tree("extern void _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            bad, acct = t.check()
+            self.assertEqual(bad, [])
+            self.assertEqual(acct["ambiguous"], 1)
+            self.assertEqual(acct["joined"], 0)
+
+    def test_non_virtual_method_is_not_joined(self):
+        """A non-virtual method is reached by name, never through a vtable.
+
+        It is still worth counting separately rather than silently: the row
+        exists, and a reader should see that it was set aside on purpose.
+        """
+        with Tree("extern void _ZN3Foo3BarEv(void*);\n",
+                  Foo="struct Foo {\n    virtual int Other();\n    int Bar();\n};\n") as t:
+            bad, acct = t.check()
+            self.assertEqual(bad, [])
+            self.assertEqual(acct["not_virtual"], 1)
+
+    def test_nested_braces_do_not_truncate_a_class_body(self):
+        """A union or inline body inside the class must not end the scan early.
+
+        With naive `\\{.*?\\}` matching, Bar falls outside the parsed body, the
+        join fails, and the disagreement below goes unreported -- a false GREEN,
+        which is the failure mode this whole file exists to prevent.
+        """
+        hdr = ("struct Foo {\n"
+               "    union { int a; short b; } u;\n"
+               "    virtual int Bar();\n"
+               "};\n")
+        with Tree("extern void _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            bad, acct = t.check()
+            self.assertEqual(acct["joined"], 1)
+            self.assertEqual(len(bad), 1)
+
+
+class ReportsItsOwnReachHonestly(unittest.TestCase):
+    def test_destructors_are_handled_not_missed(self):
+        """Planted regression: destructors once inflated the unparsed count.
+
+        They are recognised and dropped on purpose, so they belong in neither
+        the compared set nor the blind spot count. Reporting them as unparsed
+        claimed 274 blind spots on include/ where there are none.
+        """
+        hdr = ("struct Foo {\n"
+               "    virtual ~Foo();\n"
+               "    virtual ~Foo() {}\n"
+               "    virtual int Bar();\n"
+               "};\n")
+        with Tree("extern int _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            _bad, acct = t.check()
+            self.assertEqual(acct["unparsed_virtuals"], 0)
+
+    def test_multiline_declaration_is_parsed(self):
+        """A declaration split across lines IS read, because `\\s+` spans them.
+
+        Asserted rather than assumed: I first documented the opposite, and a
+        tool that silently skipped these would under-report while looking clean.
+        """
+        hdr = ("struct Foo {\n"
+               "    virtual int\n"
+               "    Bar();\n"
+               "};\n")
+        with Tree("extern void _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            bad, acct = t.check()
+            self.assertEqual(acct["unparsed_virtuals"], 0)
+            self.assertEqual(acct["joined"], 1)
+            self.assertEqual(len(bad), 1)
+
+    def test_prose_beginning_with_virtual_is_not_a_blind_spot(self):
+        """Headers here carry heavy prose, and some lines start with `virtual`.
+
+        Comments are stripped before anything is scanned, so such a line is
+        neither read as a declaration nor scored as something the tool failed to
+        read. Counting it would inflate the blind-spot number with text that was
+        never a declaration.
+        """
+        hdr = ("struct Foo {\n"
+               "    /* comment\n"
+               "    virtual, in the sense that the slot is dispatched\n"
+               "    */\n"
+               "    virtual int Bar();\n"
+               "};\n")
+        with Tree("extern int _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            bad, acct = t.check()
+            self.assertEqual(acct["unparsed_virtuals"], 0)
+            self.assertEqual(acct["joined"], 1)
+            self.assertEqual(bad, [])
+
+    def test_comment_parenthesis_cannot_invent_a_method(self):
+        """Planted regression, and the reason strip_comments exists.
+
+        `virtual ~fBase_c();  /* slots 16 (D1), 17 (D0) */` was matched by
+        taking the `(` from the comment, yielding a virtual named `16` with
+        return type `~fBase_c(); /* slots`. It fired in 116 class bodies here and
+        drove the blind-spot counter NEGATIVE, which is how it was noticed.
+        """
+        hdr = ("struct Foo {\n"
+               "    virtual ~Foo();      /* slots 16 (D1), 17 (D0) */\n"
+               "    virtual int Bar();\n"
+               "};\n")
+        with Tree("extern int _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            bad, acct = t.check()
+            self.assertEqual(acct["unparsed_virtuals"], 0)
+            self.assertEqual(bad, [])
+            names = [n for _t, n in C.class_virtuals(t.root)[0]["Foo"]]
+            self.assertEqual(names, ["Bar"])
+
+    def test_destructor_cannot_borrow_parens_from_a_later_constructor(self):
+        """Planted regression, and the second reason the counter went negative.
+
+        `virtual ~dActor_c();` matched the virtual pattern by reading its return
+        type as `~dActor_c();` and its method name as `dActor_c` -- the
+        CONSTRUCTOR, declared lines below, whose `(` it borrowed. That both
+        double-counted the destructor and injected a virtual named after the
+        class into the map, where it could join a decl_common.h row and compare
+        a garbage return type against it.
+        """
+        hdr = ("struct Foo {\n"
+               "    virtual ~Foo();\n"
+               "\n"
+               "    Foo(int profile);\n"
+               "    virtual int Bar();\n"
+               "};\n")
+        with Tree("extern int _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            bad, acct = t.check()
+            self.assertEqual(acct["unparsed_virtuals"], 0)
+            self.assertEqual(bad, [])
+            names = [n for _t, n in C.class_virtuals(t.root)[0]["Foo"]]
+            self.assertEqual(names, ["Bar"])
+
+    def test_sigil_glued_to_the_method_name_is_still_read(self):
+        """`virtual Vector3 &GetPos();` -- no space between the type and the name.
+
+        Eight declarations in include/ are spelled this way (dCc_c and its three
+        subclasses, dMgJump3DMario_c and its adapter). A separator of `\\s+` reads
+        none of them, and they showed up as the tool's entire blind spot before
+        the lookbehind arm was added.
+        """
+        hdr = ("struct Foo {\n"
+               "    virtual Vector3 &GetPos();\n"
+               "    virtual void *Unk_020c76d0() = 0;\n"
+               "};\n")
+        decl = ("extern void* _ZN3Foo6GetPosEv(void*);\n"
+                "extern void* _ZN3Foo12Unk_020c76d0Ev(void*);\n")
+        with Tree(decl, Foo=hdr) as t:
+            bad, acct = t.check()
+            self.assertEqual(acct["unparsed_virtuals"], 0)
+            self.assertEqual(acct["joined"], 2)
+            # The pointer row agrees; the reference row does not, and saying so
+            # is the point -- `Vector3&` is not `void*`.
+            self.assertEqual([b[1] for b in bad], ["GetPos"])
+
+    def test_virtual_line_with_no_call_parens_is_counted_unparsed(self):
+        """The counter must be able to be non-zero for an honest reason."""
+        hdr = "struct Foo {\n    virtual int Bar;\n};\n"
+        with Tree("extern int _ZN3Foo3BarEv(void*);\n", Foo=hdr) as t:
+            _bad, acct = t.check()
+            self.assertEqual(acct["unparsed_virtuals"], 1)
+            self.assertEqual(acct["joined"], 0)
+
+
+class ParsesMangledNamesBackward(unittest.TestCase):
+    def test_recovers_class_and_method(self):
+        self.assertEqual(C.parse_nested("_ZN11dScMgBase_c16OnAimedAtWithEggEv"),
+                         ("dScMgBase_c", "OnAimedAtWithEgg"))
+
+    def test_length_prefix_is_respected_not_guessed(self):
+        """The prefix is a byte count, and names contain digits.
+
+        `_ZN4dBgW9IsEnabledEv` must not be read as class `dBgW9`.
+        """
+        self.assertEqual(C.parse_nested("_ZN4dBgW9IsEnabledEv"),
+                         ("dBgW", "IsEnabled"))
+
+    def test_rejects_shapes_with_no_return_type(self):
+        for sym in ("_ZTV11dScMgBase_c", "_ZN11dScMgBase_cC2Ev",
+                    "_ZN11dScMgBase_cD2Ev", "_Z9SomeThingv"):
+            self.assertIsNone(C.parse_nested(sym), sym)
+
+    def test_rejects_a_truncated_name(self):
+        """A length that runs off the end is malformed, not a class named ''."""
+        self.assertIsNone(C.parse_nested("_ZN99Foo3BarEv"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `tools/check_decl_return_types.py` and its test suite. **It is deliberately not wired into CI** — see "Why this is not a workflow yet" below.

## The gap

Every recovered C++ method is declared twice, in two files that never see each other:

```
include/decl_common.h    extern void _ZN11dScMgBase_c16OnAimedAtWithEggEv(void*);
include/dScMgBase_c.h    virtual int  OnAimedAtWithEgg();          /* slot 29 */
```

Neither header includes the other, so the compiler never compares them. A caller reaching the symbol through either one compiles cleanly regardless of what the other says. The linker binds on the mangled name and does not carry a return type.

So the disagreement survives everything we run: the byte gates pass because each translation unit is internally consistent, and `check_header_offsets` only reads field layout. The failure it allows is a caller that reads r0 from a callee which never wrote it, or the reverse — silent at compile time and at link time.

Nothing in CI catches this today. `git grep decl_common tools/` finds only `pr_linkcheck.py` and `resolve_placeholders.py`, neither of which reads return types.

## It reproduces a hand census exactly

I measured this by hand first, across the refs where it turned up. The tool run over the same four:

| ref | disagreements | joined |
|---|---|---|
| `origin/main` | 2 | 7 |
| `origin/cpp/minigame-slot28` | 2 | 7 |
| `origin/cpp/minigame-slot29` | 3 | 8 |
| `origin/cpp/minigame-slot30` | 4 | 9 |

Same numbers, same symbols. And it joins *wider* than my hand census managed — eight declarations here glue the sigil to the name (`virtual Vector3 &GetPos();`, `virtual void *Unk_020c76d0();`), which a whitespace-separated pattern reads as nothing at all. The hand census missed all eight; they agree, so the answer did not change, but the reach did.

The four rows on `slot30`:

| class::method | class header | `decl_common.h` |
|---|---|---|
| `dScMgBase_c::BeforeInitResources` | `bool` | `int` |
| `dScMgBase_c::AfterInitResources` | `void` | `int` |
| `dScMgBase_c::OnAimedAtWithEgg` | `int` | `void` |
| `dScMgBase_c::OnAimedAtWithEggReturnVec` | `int` | `void` |

Two directions, so this is not "one header is stale". `decl_common.h` is the minority witness in all four — `dScMgD3DBase_c.h`, `dScMgSlot3_c.h` and `dScMgBase_c.h` agree with each other every time.

`bool` vs `int` is not cosmetic: a `bool` return goes through a widening cast under mwccarm 2004/b56 that an `int` return does not, so `norm_type` keeps them distinct on purpose.

## Why this is not a workflow yet

Two of the four disagreements — `BeforeInitResources` and `AfterInitResources` — are on `main` right now. A workflow calling this would fail every push from the moment it landed.

The two moves available are: fix the rows, or loosen the check. **Loosening it is not on the table** — a gate written to pass is not a gate. So this lands as a tool, and wiring it is a follow-up that becomes possible once the four rows are fixed at a single site (`include/decl_common.h`; a half-flip does not compile, it is an `illegal function overloading` error, which is the one mercy here).

Same two-step as #2082 → #2083 and #2091 → #2101.

## What it reports about itself

The accounting prints on failure as well as under `--summary`, because someone reading a *green* run needs the reach as much as someone reading a red one:

```
  decl_common.h rows              64
    no return type (vtable/structor) 14
    not a class in include/          40
    class method, not virtual         3
    ambiguous (overloads)             0
    JOINED and compared               7
```

The unjoined rows are not silently counted as agreement. Most of them structurally cannot disagree: vtable and typeinfo data carry no return type, structors have none either, and the "not a class" rows are SDK namespaces (GX, Sound, cstd) whose free functions have no vtable slot. The three non-virtual rows I checked by hand — `Player::SetPlayableSeqCount`, `dBgW::Disable`, `dBgW::IsEnabled` — are genuinely non-virtual and agree anyway.

There is a blind-spot counter for `virtual` lines the matcher failed to read. **It is currently zero**, and getting it there is where the real work went — it went *negative* twice, which is how two matcher bugs surfaced that were also corrupting the map, not merely miscounting:

- a comment's parenthesis: `virtual ~fBase_c();  /* slots 16 (D1), 17 (D0) */` matched as return type `~fBase_c(); /* slots` and method name `16`, inventing a virtual named `16` in 116 class bodies;
- a destructor borrowing its `(` from the constructor declared lines below: `virtual ~dActor_c();` matched as method name `dActor_c`, injecting a virtual named after the class.

Either one could have joined a `decl_common.h` row and compared garbage. Both are pinned by tests.

## Design notes

- **Parses backward out of the mangled name**, rather than mangling each declared virtual and looking it up. A forward matcher has to guess parameter encodings to build the string and silently misses every method it guesses wrong. The mangled name already carries the answer.
- **No `--changed` mode**, on purpose. The invariant spans one file plus every class header, so editing a class header can break agreement with a `decl_common.h` row the diff never touches. A whole-tree run is cheap and is the only honest one.
- **Overloads are reported as `ambiguous`, not resolved.** Picking one would be a guess, and a wrong guess is a false failure on a correct tree. Currently zero.
- Brace matching in class bodies is done by hand — a non-greedy `{.*?}` stops at the first inner close, and these bodies nest. A test plants that as a false-green regression.

## Testing

`python -m unittest tools.test_check_decl_return_types` — 23 tests, all passing. They cover the real disagreements, the shapes that must *not* fire, the two map-pollution regressions above, and the tool's own honesty about its reach (one test asserts a multi-line declaration IS parsed — I had documented the opposite, and the test is what caught the doc being wrong).

Not added to any workflow, so no CI file changes here.
