### PR TITLE
Scope TU span checks to text sections

### DIFF
--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -390,6 +390,46 @@ def test_splice_refuses_a_span_it_cannot_tile_exactly():
         assert wrong.read_bytes() == real.read_bytes()
 
 
+def test_span_entries_ignores_nontext_owned_by_adjacent_text_entry():
+    """An intact neighbouring TU's later data is not part of this text span.
+
+    The selected legacy entries must remain text-only: the second half proves the
+    existing refusal still fires when an entry that is actually being replaced owns
+    non-text storage itself.
+    """
+    text = (
+        "    .text start:0x00000f00 end:0x00001100 kind:code align:4\n"
+        "    .data start:0x00002000 end:0x00002100 kind:data align:4\n"
+        "src/neighbor.cpp:\n"
+        "    complete\n"
+        "    .text start:0x00000f00 end:0x00001000\n"
+        "    .data start:0x00002000 end:0x00002010\n\n"
+        "src/one.c:\n"
+        "    complete\n"
+        "    .text start:0x00001000 end:0x00001010\n\n"
+        "src/two.c:\n"
+        "    complete\n"
+        "    .text start:0x00001010 end:0x00001020\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        path = pathlib.Path(td) / "delinks.txt"
+        path.write_text(text, encoding="utf-8")
+        _header, _entries, inside, reasons = tubuild.span_entries(
+            path, 0x1000, 0x1020, ["src/one.c", "src/two.c"])
+        assert reasons == [], reasons
+        assert [rel for _idx, rel, _secs in inside] == ["src/one.c", "src/two.c"]
+
+        candidate_data = text.replace(
+            "    .text start:0x00001000 end:0x00001010\n\n",
+            "    .text start:0x00001000 end:0x00001010\n"
+            "    .data start:0x00002010 end:0x00002020\n\n")
+        path.write_text(candidate_data, encoding="utf-8")
+        _header, _entries, _inside, reasons = tubuild.span_entries(
+            path, 0x1000, 0x1020, ["src/one.c", "src/two.c"])
+        assert any("declares a non-.text section .data" in reason
+                   for reason in reasons), reasons
+
+
 def test_manifest_section_claims_are_explicit_and_unambiguous():
     claims, reasons = tubuild.manifest_section_claims({"sections": [
         {"name": ".text", "start": "0x1000", "end": "0x1010"},

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1595,10 +1595,17 @@ def span_entries(delinks_path, span_start, span_end, expected_legacy):
     inside, straddling = [], []
     for idx, (rel, body) in enumerate(entries):
         secs = entry_sections(body)
-        if not secs:
+        text_secs = [section for section in secs if section[0] == ".text"]
+        if not text_secs:
             continue
-        lo = min(s[1] for s in secs)
-        hi = max(s[2] for s in secs)
+        # This helper substitutes one text contribution.  A neighbouring intact TU
+        # may own non-text storage at a numerically later address; folding that data
+        # into one min/max envelope makes an adjacent, disjoint .text range look as
+        # though it straddles this TU.  Select entries by their .text contribution,
+        # then retain all sections so the existing fail-closed check below still
+        # rejects non-text carried by an entry that is actually being replaced.
+        lo = min(s[1] for s in text_secs)
+        hi = max(s[2] for s in text_secs)
         if hi <= span_start or lo >= span_end:
             continue
         if lo < span_start or hi > span_end:


### PR DESCRIPTION
Fix intact-TU span selection so neighboring data sections cannot make an adjacent text entry appear to straddle the candidate span. Selected entries still carry all of their sections, so a candidate entry with non-text content continues to fail closed. Adds focused regressions; the full intact-TU test suite passes (121 tests).