### PR TITLE
Convert dScMgTrampoline2_c's last four bodies to real members

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -6501,7 +6501,7 @@ src/func_ov006_02122c90.c:
     complete
     .text start:0x02122c90 end:0x02122cb0
 
-src/_ZN18dScMgTrampoline2_c9Virtual88Eiiii.c:
+src/_ZN18dScMgTrampoline2_c9Virtual88Eiiii.cpp:
     complete
     .text start:0x02122cb0 end:0x02122e20
 
@@ -6513,11 +6513,11 @@ src/_ZN18dScMgTrampoline2_c11OnAttacked2Ev.cpp:
     complete
     .text start:0x02122f24 end:0x021230c4
 
-src/_ZN18dScMgTrampoline2_c8OnPushedEv.c:
+src/_ZN18dScMgTrampoline2_c8OnPushedEv.cpp:
     complete
     .text start:0x021230c4 end:0x021230e8
 
-src/_ZN18dScMgTrampoline2_c8OnKickedEv.c:
+src/_ZN18dScMgTrampoline2_c8OnKickedEv.cpp:
     complete
     .text start:0x021230e8 end:0x0212318c
 

--- a/src/_ZN18dScMgTrampoline2_c13OnYoshiTryEatEi.cpp
+++ b/src/_ZN18dScMgTrampoline2_c13OnYoshiTryEatEi.cpp
@@ -1,5 +1,6 @@
 //cpp
 #include "types.h"
+#include "dScMgTrampoline2_c.h"
 // @symbol _ZN18dScMgTrampoline2_c13OnYoshiTryEatEi
 // recovered name: dScMgTrampoline2_c_OnYoshiTryEat_021242cc
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -32,10 +33,14 @@ extern "C" s32 GetGameLanguage(void);
 extern "C" void MultiStore16(u16 val, char *dst, int nbytes);
 extern "C" void func_ov006_02124228(T *self);
 
+extern "C" {
 extern volatile s16 data_020a0dbc[];
+}
 
-extern "C" void _ZN18dScMgTrampoline2_c13OnYoshiTryEatEi(T *self)
+void dScMgTrampoline2_c::OnYoshiTryEat(int /* arg */)
 {
+    T *self = (T *)this;
+
     _ZN3G2x13SetBlendAlphaEPVttttj((volatile void *)0x4000050, 1, 0x2e, 0x10, 0x10);
 
     self->unk7BA0 = data_020a0dbc[0];

--- a/src/_ZN18dScMgTrampoline2_c8OnKickedEv.cpp
+++ b/src/_ZN18dScMgTrampoline2_c8OnKickedEv.cpp
@@ -1,13 +1,19 @@
+//cpp
 // @symbol _ZN18dScMgTrampoline2_c8OnKickedEv
 // recovered name: dScMgTrampoline2_c_OnKicked
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+#include "dScMgTrampoline2_c.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnKicked - recovered from vtable slot identity */
+extern "C" {
 extern unsigned char data_0209d45c[];
+}
 
-int _ZN18dScMgTrampoline2_c8OnKickedEv(void *thiz)
+int dScMgTrampoline2_c::OnKicked()
 {
+    void *thiz = (void *)this;
+
     unsigned char *c = (unsigned char *)thiz;
     if (!_ZN14dScMgD3DBase_c8OnKickedEv(c)) return 0;
     if (*(int *)(c + 0x4628) == 0) {

--- a/src/_ZN18dScMgTrampoline2_c8OnPushedEv.cpp
+++ b/src/_ZN18dScMgTrampoline2_c8OnPushedEv.cpp
@@ -1,7 +1,12 @@
+//cpp
 // @symbol _ZN18dScMgTrampoline2_c8OnPushedEv
 // recovered name: dScMgTrampoline2_c_OnPushed
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
+#include "dScMgTrampoline2_c.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnPushed - recovered from vtable slot identity */
-int _ZN18dScMgTrampoline2_c8OnPushedEv(void *t) { return _ZN14dScMgD3DBase_c8OnPushedEv(t) != 0; }
+int dScMgTrampoline2_c::OnPushed()
+{
+    void *t = (void *)this;
+ return _ZN14dScMgD3DBase_c8OnPushedEv(t) != 0; }

--- a/src/_ZN18dScMgTrampoline2_c9Virtual88Eiiii.cpp
+++ b/src/_ZN18dScMgTrampoline2_c9Virtual88Eiiii.cpp
@@ -1,3 +1,5 @@
+//cpp
+#include "dScMgTrampoline2_c.h"
 // @symbol _ZN18dScMgTrampoline2_c9Virtual88Eiiii
 /* dScMgTrampoline2_c::Virtual88 - slot 34.
 
@@ -7,16 +9,22 @@
    ancestor body for them to inherit. */
 #pragma opt_loop_invariants off
 
+extern "C" {
 extern int data_ov006_02142f78[];
+}
 
+extern "C" {
 extern void *func_02054efc(void);
 extern void *func_02054ea8(void);
 extern void *_ZN2G213GetBG2CharPtrEv(void);
 extern int func_02054d88(void);
 extern void MultiCopy_Int(int *dst, int *src, int len);
+}
 
-void _ZN18dScMgTrampoline2_c9Virtual88Eiiii(void *obj, int x_base, int y, int val, int n)
+void dScMgTrampoline2_c::Virtual88(int x_base, int y, int val, int n)
 {
+    void *obj = (void *)this;
+
     int half;
     int x0;
     int j;


### PR DESCRIPTION
Tail of the 79-body batch in #2114. These four were not refused by the converter — they simply were not in the applied set, which left `dScMgTrampoline2_c` split across two spellings while its sibling `dScMgTrampoline_c` was fully converted.

| body | slot | change |
|---|---|---|
| `OnYoshiTryEat(int)` | 18 | already `.cpp`; definition rewritten |
| `OnKicked()` | 24 | `.c` → `.cpp` |
| `OnPushed()` | 23 | `.c` → `.cpp` |
| `Virtual88(int,int,int,int)` | 34 | `.c` → `.cpp` |

`OnYoshiTryEat`'s body took no argument beyond `this`. The class declares `void OnYoshiTryEat(int)` — measured from the ROM's vtables during the slots-18-35 campaign — so the header wins and the unread parameter is now spelled. It costs no instruction, which is why the body could disagree indefinitely without anything noticing.

Three `delinks.txt` keys repointed. `decl_common.h` is already `#ifdef __cplusplus`-guarded, so only the file-local declarations needed `extern "C"` wrapping: `data_020a0dbc`, `data_0209d45c`, `data_ov006_02142f78`, and `Virtual88`'s five function declarations.

**Verified:** `rombuild.py -j 16 --no-rom` → 11,088/11,088 reproducing, 0 mismatching, 106/106 exact, 100.000000%. Nine static gates green. Re-run after line-ending normalization, not before.

Stacked on #2114. `attribution-override` per the standing instruction.