### PR TITLE
Convert the four intact-TU minigame classes to real members

### DIFF
--- a/src/actors/dScMgBSC_c.cpp
+++ b/src/actors/dScMgBSC_c.cpp
@@ -143,7 +143,6 @@ extern int data_ov004_020bf9ec;
 extern int RandomIntInternal(int* seed);
 extern void func_ov006_020c1604(char* c, int unused, short a2, int a3);
 extern int data_0209e650;
-extern "C" void _ZN10dScMgBSC_c15OnGroundPoundedEv(void *thisPtr);
 extern "C" void FreeGfxSlotsById(int arg);
 extern "C" void func_ov004_020b66d4(void);
 void func_ov006_020c0aa8(void *camera);
@@ -284,7 +283,10 @@ s32 dScMgBSC_c::Render()
    OnYoshiTryEat, which is slot 18 -- off by one. This body stores the class
    vtable, destroys the members and calls Memory::Deallocate; no eat handler
    does any of that. */
-extern "C" void _ZN10dScMgBSC_c13OnYoshiTryEatEi(char* c, int mode){
+void dScMgBSC_c::OnYoshiTryEat(int mode)
+{
+    char *c = (char *)this;
+
     dScMgBSC_c *self = (dScMgBSC_c *)(void *)c;
   if(mode != 4 && mode != 5 && mode == 3){
     self->mHudScore = func_ov004_020ad878();
@@ -304,8 +306,10 @@ extern "C" void _ZN10dScMgBSC_c13OnYoshiTryEatEi(char* c, int mode){
 // recovered name: dScMgBSC_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgBSC_c::OnTurnIntoEgg - recovered from vtable slot identity */
-extern "C" int _ZN10dScMgBSC_c13OnTurnIntoEggEi(char* c, int mode)
+int dScMgBSC_c::OnTurnIntoEgg(int mode)
 {
+    char *c = (char *)this;
+
     struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)c;
     int st;
     short fl;
@@ -344,7 +348,10 @@ do1:
 // recovered name: dScMgBSC_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* dScMgBSC_c::OnGroundPounded - recovered from vtable slot identity */
-void _ZN10dScMgBSC_c15OnGroundPoundedEv(void *thisPtr) {
+void dScMgBSC_c::OnGroundPounded()
+{
+    void *thisPtr = (void *)this;
+
     struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)thisPtr;
     int x = self->mHudScore;
     int v = x / 5;

--- a/src/actors/dScMgCard_c.cpp
+++ b/src/actors/dScMgCard_c.cpp
@@ -255,7 +255,6 @@ extern int data_ov004_020bf9ec;
 extern int data_ov006_0213bc44;
 extern int data_ov004_020bfa18;
 extern int data_ov006_0213bd48[];
-extern "C" void _ZN11dScMgCard_c15OnGroundPoundedEv(void *thisPtr);
 extern void FreeGfxSlotsById(int arg);
 extern void func_ov004_020b56c8(int a);
 /* already the mangled Itanium name in the ROM's own symbols.txt --
@@ -264,7 +263,6 @@ double-mangling-defect memory note: a C++ TU re-mangles a bare
 `extern` unless told not to, and this name is already the target). */
 extern s16 data_ov004_020bf9e4;
 extern void* data_ov004_020beb68;
-extern "C" int _ZN11dScMgCard_c13OnTurnIntoEggEi(char* c);
 extern "C" void func_ov006_020c1604(char *c, int unused, short a2, int a3);
 extern "C" void func_ov004_020b66d4(void);
 extern u8 data_0209d45c;
@@ -407,8 +405,10 @@ s32 dScMgCard_c::InitResources()
    OnYoshiTryEat, which is slot 18 -- off by one. This body stores the class
    vtable, destroys the members and calls Memory::Deallocate; no eat handler
    does any of that. */
-extern "C" void _ZN11dScMgCard_c13OnYoshiTryEatEi(char *c)
+void dScMgCard_c::OnYoshiTryEat(int /* arg */)
 {
+    char *c = (char *)this;
+
     dScMgCard_c *self = (dScMgCard_c *)(void *)c;
     int i;
     char *p1, *p2;
@@ -453,8 +453,10 @@ extern "C" void _ZN11dScMgCard_c13OnYoshiTryEatEi(char *c)
 // recovered name: dScMgCard_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::OnTurnIntoEgg - recovered from vtable slot identity */
-int _ZN11dScMgCard_c13OnTurnIntoEggEi(char* c)
+int dScMgCard_c::OnTurnIntoEgg(int /* mode */)
 {
+    char *c = (char *)this;
+
     struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     switch (self->mState) {
     case 0xe: {
@@ -534,7 +536,10 @@ int _ZN11dScMgCard_c13OnTurnIntoEggEi(char* c)
 // recovered name: dScMgCard_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::OnGroundPounded - recovered from vtable slot identity */
-void _ZN11dScMgCard_c15OnGroundPoundedEv(void *thisPtr) {
+void dScMgCard_c::OnGroundPounded()
+{
+    void *thisPtr = (void *)this;
+
     struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)thisPtr;
     int x = self->mHudScore;
     int v;

--- a/src/actors/dScMgMCarlo2_c.cpp
+++ b/src/actors/dScMgMCarlo2_c.cpp
@@ -250,7 +250,10 @@ s32 dScMgMCarlo2_c::InitResources()
 /* Resets the whole board: rebuild the 40 pieces, clear the match latch,
  * re-arm the shared table, then hand the score display a zero. */
 extern "C" {
-void _ZN14dScMgMCarlo2_c13OnYoshiTryEatEi(char* c) {
+void dScMgMCarlo2_c::OnYoshiTryEat(int /* arg */)
+{
+    char *c = (char *)this;
+
     struct dScMgMCarlo2_c *self = (struct dScMgMCarlo2_c *)(void *)c;
   func_ov006_020f9760((Node *)(c + 0x51a8));
   data_ov006_0213d6fc = 0;
@@ -269,8 +272,10 @@ void _ZN14dScMgMCarlo2_c13OnYoshiTryEatEi(char* c) {
 /* -------------------------------------------------------------------------- */
 // @symbol _ZN14dScMgMCarlo2_c13OnTurnIntoEggEi
 extern "C" {  /* .c-derived member: C linkage for the whole block */
-int _ZN14dScMgMCarlo2_c13OnTurnIntoEggEi(char *self)
+int dScMgMCarlo2_c::OnTurnIntoEgg(int /* mode */)
 {
+    char *self = (char *)this;
+
     short st = *(short *)(self + 0x5928);
     switch (st) {
     case 4:

--- a/src/actors/dScMgMCarlo_c.cpp
+++ b/src/actors/dScMgMCarlo_c.cpp
@@ -278,8 +278,10 @@ void func_ov006_020c1604(char* c, int unused, short a2, int a3);
 void func_ov004_020b66d4(char* p);
 
 
-void _ZN13dScMgMCarlo_c13OnYoshiTryEatEi(char* c)
+void dScMgMCarlo_c::OnYoshiTryEat(int /* arg */)
 {
+    char *c = (char *)this;
+
     struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
     func_ov006_020f7c10(c + 0x51a8);
     data_ov006_0213d564 = 0;
@@ -315,8 +317,10 @@ extern int _Z15ApproachLinear2Rsss(s16& r, s16 t, s16 s);
 extern unsigned short data_ov004_020bf9e4;
 extern void* data_ov004_020beb68;
 
-int _ZN13dScMgMCarlo_c13OnTurnIntoEggEi(char* c)
+int dScMgMCarlo_c::OnTurnIntoEgg(int /* mode */)
 {
+    char *c = (char *)this;
+
     struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
     switch (self->unk_60a8) {
     case 4:


### PR DESCRIPTION
`dScMgBSC_c`, `dScMgCard_c`, `dScMgMCarlo_c`, `dScMgMCarlo2_c` are intact-object TUs — each carries a whole class in one file and includes its own header — but their virtuals were still free functions with hand-written mangled names, sitting right next to the class they belong to.

**25 members** converted: `InitResources`, `Behavior`, `Render`, `CleanupResources`, `OnYoshiTryEat`, `OnTurnIntoEgg`, `OnGroundPounded`.

**Six bodies were missing their parameter entirely.** Card, MCarlo and MCarlo2 each declared `OnYoshiTryEat` and `OnTurnIntoEgg` taking only `this`. The class declares `(int)` — measured from the ROM's vtables during the slots-18-35 campaign — and an unread trailing argument costs no instruction, which is exactly why the disagreement was invisible. Header wins; the parameter is spelled and left unnamed.

## The risk this batch carried, and why I checked rather than assumed

A real member definition can make its TU the class's **key function**, at which point mwcc emits `_ZTV<class>` there — bytes the config does not own. `106/106` module fidelity is **blind to vtables**, so a green build would not have caught it. Checked the objects directly:

```
dScMgBSC_c       build/src/actors/dScMgBSC_c.o        no vtable/RTTI emitted
dScMgCard_c      build/src/actors/dScMgCard_c.o       no vtable/RTTI emitted
dScMgMCarlo_c    build/src/actors/dScMgMCarlo_c.o     no vtable/RTTI emitted
dScMgMCarlo2_c   build/src/actors/dScMgMCarlo2_c.o    no vtable/RTTI emitted
```

None of the four classes' key functions — the first virtual *declared* in each header — lives in these TUs, so nothing moved. `ROM data from source` is unchanged at 496 verified / 223 partial / 5 differ.

No `delinks.txt` change: these files were already `.cpp` and already enrolled.

## Flagged, not fixed

`src/actors/dScMgBSC_c.cpp` carries a comment above `OnYoshiTryEat` claiming the body is *"The DELETING DESTRUCTOR, vtable slot 17 … the old comment here called it OnYoshiTryEat, which is slot 18 — off by one"*. The body it sits above stores no vtable and calls no deallocator; it sets two flags and calls `func_ov004_020b66d4`. The ROM reproduces it at the `OnYoshiTryEat` address, so the **symbol is right and the prose is stale**. Left for a follow-up rather than silently deleted — someone measured something to write that, and I would rather it be re-measured than dropped.

## Verified

`rombuild.py -j 16 --no-rom` → 11,088/11,088 reproducing, 0 mismatching, 106/106 exact, 100.000000%. Nine static gates green, re-run **after** line-ending normalization.

With this, **every free-function body in the minigame family is now a real C++ member.** Stacked on #2115. `attribution-override`.