### PR TITLE
Accept partitioned TUs without vtable splits

### DIFF
--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -1807,6 +1807,19 @@ def test_partitioned_result_gate_requires_every_full_rom_proof():
         assert not tubuild.partitioned_link_ready(**bad), key
 
 
+def test_partitioned_storage_alias_gate_is_vacuously_exact_without_splits():
+    assert tubuild.initial_storage_alias_verdict({})
+    assert tubuild.initial_storage_alias_verdict({
+        "_ZTV1A": {"addressPointBias": 8},
+    })
+    assert not tubuild.initial_storage_alias_verdict({
+        "_ZTV1A": {"storageAlias": {"symbol": "A_VT"}},
+    })
+    assert not tubuild.initial_storage_alias_verdict({
+        "_ZTV1A": {"partitionSymbols": [{"symbol": "A_VT7"}]},
+    })
+
+
 def test_partitioned_recorder_is_compact_orthogonal_and_preserves_verified_evidence():
     entry = {"id": "ov999/T", "status": "data-verified"}
     data = {"entries": [entry]}

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -3554,6 +3554,17 @@ def verify_linked_storage_aliases(linked_elf, biases):
     return {"ok": not reasons, "rows": rows, "errors": reasons}
 
 
+def initial_storage_alias_verdict(vtable_policies):
+    """Return the pre-audit verdict for linked vtable split symbols.
+
+    A TU with no split aliases has nothing to compare and is vacuously exact.
+    A real split policy fails closed until ``verify_linked_storage_aliases``
+    replaces this default with its measured post-link verdict.
+    """
+    return not any(policy.get("storageAlias") or policy.get("partitionSymbols")
+                   for policy in vtable_policies.values())
+
+
 # ====================================== partial TU isolation (plan sec 9, phase D)
 #
 # The whole-range substitution above hands the linker ONE object for the TU's entire
@@ -4379,7 +4390,7 @@ def cmd_linkcheck(args):
     # -------------------- partial/partitioned isolation: derive, compare, substitute
     partial_rows = []
     partition_data_ok = False
-    storage_aliases_ok = not partitioned
+    storage_aliases_ok = True
     vtable_policies = {}
     if partial or partitioned:
         label = "partitioned" if partitioned else "partial"
@@ -4755,9 +4766,8 @@ def cmd_linkcheck(args):
             scratch / "final_link.o", config_root=cfg_root,
             tracked_config_root=CFG_ARM9)
 
-    has_vtable_splits = any(
-        policy.get("storageAlias") or policy.get("partitionSymbols")
-        for policy in vtable_policies.values())
+    storage_aliases_ok = initial_storage_alias_verdict(vtable_policies)
+    has_vtable_splits = not storage_aliases_ok
     if has_vtable_splits:
         linked_aliases = verify_linked_storage_aliases(
             scratch / "final_link.o", vtable_policies)


### PR DESCRIPTION
Partitioned TU linkcheck now treats the absence of a vtable split policy as vacuously satisfied. Manifests that declare storageAlias or partitionSymbols still fail closed until the post-link symbol audit verifies them. Adds focused regression coverage for ordinary address points and both split-policy forms. Verified with the canonical objisolate/tubuild suite: 102 passed.