### PR TITLE
Spell slot 28 void, so no declaration outlives what a body can honour

### DIFF
--- a/include/dScMgBase_c.h
+++ b/include/dScMgBase_c.h
@@ -363,10 +363,12 @@ struct dScMgBase_c : dScene_c {
        `recovered name: dScMgBase_c_OnHitFromUnderneath` comment, agreeing with
        include/dActor_c.h:145 on the parallel branch and with dScMgSlot1_c's
        independently recovered override.
-         return type: int, A HINT -- and slot 28 is the first in this campaign
-           whose return type NO body pins, which is why it gets no row in the
-           table above: that table is the eight slots whose own bodies DO pin
-           one.  ov004:0x020af04c leaves r0 holding whatever it last tested or
+         return type: void, and slot 28 is the first in this campaign whose
+           return type NO body pins, which is why it gets no row in the table
+           above: that table is the eight slots whose own bodies DO pin one.
+           void is chosen because nothing contradicts it and because it is the
+           only spelling both definitions can honour without inventing a result
+           neither body computes.  ov004:0x020af04c leaves r0 holding whatever it last tested or
            last called: the early exit at
            `cmp r0,#0; popeq {r4,lr}; bxeq lr` returns the zero it has just
            compared, and the fall-through returns whatever Enable3dEngines
@@ -379,9 +381,16 @@ struct dScMgBase_c : dScene_c {
            to their own caller without ever reading it, and the third branches
            to a shared epilogue that overwrites r0 with `add r0,r4,#0x4000`
            before anything can use it.  Three sites, three discarded results.
-           `int` is include/dActor_c.h's, and its RETURN types have held up
-           where its parameter lists have not; `void` compiles to the same
-           bytes.
+           include/dActor_c.h:145 spells `int`, and its RETURN types have held
+           up where its parameter lists have not -- but a hint from a parallel
+           hierarchy is not a reason to declare a type no body here produces.
+           `void` compiles to the same bytes, and unlike `int` it is a type
+           both definitions can actually satisfy: dScMgSlot1_c's override
+           computes no result and would otherwise fall off the end of a
+           non-void function, which is undefined behaviour whatever the
+           cartridge happens to leave in r0.  If a caller is ever found
+           consuming this slot, that measurement -- not dActor_c.h -- is what
+           should change it back.
          arity: no explicit parameters, MEASURED ONCE rather than twice.  The
            base body opens `mov r4, r0` and then writes r1 with
            `add r1, r4, #0x4000` before ever reading it, and reads no other
@@ -417,7 +426,7 @@ struct dScMgBase_c : dScene_c {
            compiles to from ov006; the vtable word is NOT a linker artifact,
            because the twenty-six tables that do not override this slot hold
            0x020af04c directly. */
-    virtual int  OnHitFromUnderneath();                /* slot 28 */
+    virtual void OnHitFromUnderneath();                /* slot 28 */
 
     /* Slots 29-35 are added the same way: one slot per change, together with
        every descendant override of that slot. Until then they stay undeclared

--- a/include/dScMgD3DBase_c.h
+++ b/include/dScMgD3DBase_c.h
@@ -94,7 +94,7 @@ struct dScMgD3DBase_c : dScMgBase_c {
     virtual int  OnPushed();                           /* slot 25 */
     virtual int  OnHitByCannonBlastedChar();           /* slot 26 */
     virtual void OnHitByMegaChar();                    /* slot 27 */
-    virtual int  OnHitFromUnderneath();                /* slot 28 */
+    virtual void OnHitFromUnderneath();                /* slot 28 */
 
     /* Four more of dScMgBase_c's own 18 new slots (18-35) are overridden
        here too (slots 29-31, 33 per tools/rtti_vtables.py --own

--- a/include/dScMgSlot1_c.h
+++ b/include/dScMgSlot1_c.h
@@ -155,7 +155,7 @@ struct dScMgSlot1_c : dScMgBase_c {
        for what that cost and how it was closed. */
     virtual int  OnYoshiTryEat(int arg);                 /* slot 18 */
     virtual void OnHitByMegaChar();                     /* slot 27 */
-    virtual int  OnHitFromUnderneath();                 /* slot 28 */
+    virtual void OnHitFromUnderneath();                 /* slot 28 */
 
     betIcon_c mBetIcon;      /* 0x4660 -- RTTI-proven nested touch icon */
     u8  pad_4684[0xc];      /* 0x4684 -- embedded object, own type unknown */

--- a/src/_ZN12dScMgSlot1_c19OnHitFromUnderneathEv.cpp
+++ b/src/_ZN12dScMgSlot1_c19OnHitFromUnderneathEv.cpp
@@ -21,15 +21,22 @@
    and put _ZTV12dScMgSlot1_c back into DIFFERS -- with rombuild green the
    whole time.
 
-   THE RETURN TYPE IS THE ONE THING HERE THAT IS NOT MEASURED, and slot 28 is
-   the first in this campaign where that is true.  Neither body sets r0
-   deliberately: the base falls out of a virtual call it has just compared
-   against zero, and this one returns whatever SetSubBg1Offset left behind.  No
-   caller loads vtable+0x70 anywhere in ov004 or ov006, so nothing consumes a
-   result either.  `int` is include/dActor_c.h's, kept because it is what this
-   file already carried and because dActor_c.h's RETURN types have held up
-   where its parameter lists have not -- a hint, not a measurement.  `void`
-   compiles to the same bytes.
+   THE RETURN TYPE IS NOT MEASURED, and slot 28 is the first in this campaign
+   where that is true.  Neither body sets r0 deliberately: the base falls out of
+   a virtual call it has just compared against zero, and this one falls out of
+   SetSubBg1Offset.  Nor does any caller settle it -- ov004 and ov006 hold
+   exactly three `ldr rN,[rM,#0x70]; blx rN` dispatch sites and all three
+   discard the result, written out site by site in dScMgBase_c.h.  (An earlier
+   draft of this comment said no caller loads vtable+0x70 at all.  That was
+   reasoning from an absence never scanned for, and it was wrong: a bare `ldr`
+   at +0x70 is an ordinary field read, and only the load/`blx` PAIR is a
+   dispatch.)
+     So the slot is unpinned, and it is spelled `void` -- the only type both
+   definitions can honour.  `int` is include/dActor_c.h's hint from a parallel
+   hierarchy, and declaring it would leave this body falling off the end of a
+   non-void function, which is undefined behaviour that byte-matches only by
+   accident of what SetSubBg1Offset happens to leave in r0.  `void` compiles to
+   the same bytes.
 
    The forwarding call is written qualified, dScMgBase_c::OnHitFromUnderneath(),
    which suppresses the virtual dispatch and emits the same direct `bl` the ROM
@@ -40,7 +47,7 @@
 #include "decl_common.h"
 #include "dScMgSlot1_c.h"
 
-int dScMgSlot1_c::OnHitFromUnderneath()
+void dScMgSlot1_c::OnHitFromUnderneath()
 {
     dScMgBase_c::OnHitFromUnderneath();
     SetSubBg1Offset(0x100, 0);


### PR DESCRIPTION
Opening this against `cpp/minigame-slot28` rather than pushing to it, exactly as offered on #2099 — the branch isn't mine and I'm not going to rewrite someone else's work uninvited. Merge it, cherry-pick it, or reject it and do your own; any of those clears the block.

## What it changes

`dScMgBase_c::OnHitFromUnderneath` is declared `int` and **neither definition produces one**:

- `src/_ZN12dScMgSlot1_c19OnHitFromUnderneathEv.cpp` is `int dScMgSlot1_c::OnHitFromUnderneath()` and falls off the end. Returning nothing from a non-`void` function is undefined behaviour. It byte-matches by accident of what `SetSubBg1Offset` leaves in r0.
- `src/_ZN11dScMgBase_c19OnHitFromUnderneathEv.cpp` is already `extern "C" void`.
- `src/_ZN14dScMgD3DBase_c19OnHitFromUnderneathEv.c` is already `void`.

So the declaration is the outlier, not the bodies.

## Three declarations, not one

This is the part worth checking if you'd rather write it yourself. Four headers declare the name; **three are in this hierarchy and have to move together** or the overrides stop overriding and mwcc numbers a new slot:

```
include/dScMgBase_c.h:420    int -> void
include/dScMgD3DBase_c.h:97  int -> void
include/dScMgSlot1_c.h:158   int -> void
```

`include/dActor_c.h:145` is deliberately **not** touched — it is the parallel hierarchy, it takes a `dActor_c &`, and it is a different function that merely shares an index. `include/QuestionBlock.h:75` is downstream of that one and likewise untouched.

## What this does not claim

**The ROM is neutral at slot 28 and nothing here says otherwise.** The slot stays UNPINNED. `int` and `void` compile to the same bytes — your own comment says so, and I re-measured it. `void` is chosen because it is the only spelling both definitions can honour, not because the cartridge prefers it. I've written that reasoning into the header so the next reader doesn't mistake it for a measurement, and left the note that if a caller is ever found consuming this slot, *that* is what should change it back — not `dActor_c.h`.

I'm being explicit about this because I retracted a "slot 29 is void, proven by the build" claim of my own earlier in this campaign. A green build is neutral on return type. This is an internal-consistency fix, not a discovery.

## Measured on the merge result

```
reproducing: 11,088   mismatching: 0
source-owned data claims: 2 (reproducing 2, mismatching 0)
module fidelity: 106/106 exact, 100.000000% of compared bytes
ROM-build analysis: PASS
```

Identical to the figures in your PR body. Nothing moves.

## One thing I fixed while in there

`ed243e83c` corrected the "nothing loads vtable+0x70" claim in the header's evidence block, but the **third copy** of it is still in `src/_ZN12dScMgSlot1_c19OnHitFromUnderneathEv.cpp`. It now says what was actually measured — three dispatch sites, all discarding — plus a short note on why the original was wrong, since a bare `ldr` at +0x70 is a field read and only the load/`blx` pair is a dispatch. That felt worth keeping as a record rather than silently deleting.

## Why now

#2099 is the bottom of a twelve-PR stack (#2100 → #2102 → #2106 → #2107 → #2108 → #2110 → #2112, and #2114 → #2115 → #2116 → #2118). Nothing in the 18–35 range can land until it moves, and I've been the one holding it for four rounds over two words. This is me clearing my own block rather than asking for a fifth round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdCK1xgrJdiJzPCh3bAJfQ
