### PR TITLE
Point two pilot-table intake files at where those factories live now

### DIFF
--- a/notes/tu-filename-reconstruction-pilot.md
+++ b/notes/tu-filename-reconstruction-pilot.md
@@ -93,13 +93,13 @@ claim about the whole link.
 | `C1_TRAP` | `src/actors/daObjC1_Trap_c.cpp` | ov010 `0x021111a0..0x021119d0` | `d_a_obj_c1_trap.cpp` | same | unique `d_a_obj_*` stem | B- | left edge lacks independent confidence; registry address is overlay-multiplexed |
 | `STAR_CAMERA` | `src/StarCamera_Spawn.cpp` | ov002 `0x020e6c40..0x020ebf8c` | — | — | TU contains a broader Star family | — | no most-derived RTTI class for the factory |
 | `PLAYER` | `src/Player_Spawn.cpp` | ov002 `0x020bd828..0x020e6c40` | `d_a_ply.cpp` | same | unique `d_a_*` stem | B- | left boundary is medium; very large TU |
-| `WATERFALL` | `src/WaterfallMist_Spawn.cpp` | ov002 `0x020b6e08..0x020b6f18` | `d_a_obj_waterfall.cpp` | same | unique stem and high/high boundaries | B | nearby stems are not alphabetically ordered |
+| `WATERFALL` | `src/actors/d_a_obj_waterfall.cpp` | ov002 `0x020b6e08..0x020b6f18` | `d_a_obj_waterfall.cpp` | same | unique stem and high/high boundaries | B | nearby stems are not alphabetically ordered |
 | `KURIBO` | `src/Goomba_Spawn.c` | ov084 `0x02129020..0x0212c10c` | `d_a_krb.cpp` | same | one distinct stem | B- | duplicate class entries; left edge lacks confidence |
 | `TERESA` | `src/actors/daTrs_c/Boo_Spawn.cpp` | ov063 `0x02115ee0..0x0211c600` | `d_a_trs.cpp` | — | later `d_a_*` family | — | same TU also yields `d_a_t_basket.cpp`; TU-map check has baseline failure |
 | `BOSS_TERESA` | `src/actors/BigBoo/BigBoo_Spawn.cpp` | same ov063 TU | `d_a_trs.cpp` | — | same class as `TERESA` | — | multi-stem TU and two same-class profiles |
 | `WANWAN` | `src/ChainChomp_Spawn.cpp` | ov014 `0x02111308..0x02112e0c` | `d_a_wanwan.cpp` | same | unique stem and high/high boundaries | B | nearby `d_a_obj_*` units are not globally lexical |
 | `OBJ_MIP_KEY` | `src/RabbitKey_Spawn.c` | ov085 `0x0212cc88..0x0212d528` | `d_a_obj_mip_key.cpp` | same | class family plus high/high boundaries | B | TU-name tool has no surviving stem for this interval |
-| `PROPELLER_HEYHO` | `src/FlyGuy_Spawn.c` | ov070 `0x0211f000..0x02120570` | `d_a_propeller_heyho.cpp` | same | class family only | B- | no recovered interval stem; left edge lacks confidence |
+| `PROPELLER_HEYHO` | `src/actors/daPropeller_Heyho_c.cpp` | ov070 `0x0211f000..0x02120570` | `d_a_propeller_heyho.cpp` | same | class family only | B- | no recovered interval stem; left edge lacks confidence |
 | `KINOKO_CREATE_TAG` | `src/actors/daObjKinokoTag_c.cpp` | ov002 `0x020b46a0..0x020b4a70` | `d_a_obj_kinoko_tag.cpp` | same | unique stem and high/high boundaries | B | two same-class factories weaken source organization inference |
 | `SHOOT_BOOK` | `src/BookShot_Spawn.c` | ov020 `0x021111a0..0x02112938` | `d_a_book.cpp` | — | class-family candidate | — | TU also yields `d_a_book_gen.cpp` |
 | `BOOK_GENERATOR` | `src/BookShotSpawner_Spawn.c` | same ov020 TU | `d_a_book_gen.cpp` | — | class-family candidate | — | one TU cannot have both mechanical filenames |


### PR DESCRIPTION
**`main` is red** on `tools/check_dead_references.py`, and has been since #2127 landed:

```
FAIL: 2 prose reference(s) name a path that does not exist:
  notes/tu-filename-reconstruction-pilot.md
      names `src/FlyGuy_Spawn.c`, which is not in the tree
  notes/tu-filename-reconstruction-pilot.md
      names `src/WaterfallMist_Spawn.cpp`, which is not in the tree
```

Reproduced on a clean checkout of `3d4377d61`, so this is not a branch artifact.

Neither PR was wrong on its own. #2127's pilot table was written against the tree as it
stood, and the TU promotions that deleted those two files were in flight beside it — two
green PRs, one red `main`. Every open PR now inherits the failure through its
merge-with-`main` check; it is what turned #2148 red, and #2130, #2151 and #2156 are
behind it too.

## The fix

The table's second column is headed **"Current intake file"**, so the honest fix is to
name the file each factory lives in today rather than to bank the dead paths in
`config/dead-reference-baseline.json`:

| profile | was | is now |
| --- | --- | --- |
| `WATERFALL` | `src/WaterfallMist_Spawn.cpp` | `src/actors/d_a_obj_waterfall.cpp` |
| `PROPELLER_HEYHO` | `src/FlyGuy_Spawn.c` | `src/actors/daPropeller_Heyho_c.cpp` |

Both were checked by grep, not assumed — `WaterfallMist_Spawn` is defined in the waterfall
TU, and `FlyGuy_Spawn` is ROM ordinal 26 in `daPropeller_Heyho_c.cpp`. Every other row in
the table still names a live file.

Prose only; no build input is touched. `check_dead_references` passes on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsXWgEM3Gtbqs6zEdwLMYV