### PR TITLE
Verify intact TUs with non-text sections

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -52,6 +52,122 @@ import io
 from elftools.elf.elffile import ELFFile
 from elftools.elf.relocation import RelocationSection
 
+
+def rename_undefined_symbols(raw, aliases):
+    """Rename exact undefined imports in place without touching symbol indices.
+
+    Reconstructed C++ wrapper types can make mwcc emit a source-authentic member
+    spelling for a ROM function that this project still names by an address alias.
+    The linker needs one spelling.  This operation changes only the corresponding
+    NUL-terminated string-table bytes, and only when the replacement is no longer
+    than the original and no other symbol points into that string.  Relocations,
+    section contents, symbol values/bindings/types, and table indices are unchanged.
+    """
+    requested = dict(aliases or {})
+    if not requested:
+        return bytes(raw), {"renamed": [], "error": None}
+    if any(not isinstance(old, str) or not old or not isinstance(new, str) or not new
+           for old, new in requested.items()):
+        return None, {"renamed": [], "error": "symbol aliases must be non-empty strings"}
+    if len(set(requested.values())) != len(requested):
+        return None, {"renamed": [], "error": "canonical symbol aliases must be unique"}
+
+    elf = ELFFile(io.BytesIO(bytes(raw)))
+    secs = list(elf.iter_sections())
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return None, {"renamed": [], "error": "no .symtab"}
+    strtab_index = symtab.header["sh_link"]
+    if not isinstance(strtab_index, int) or not (0 <= strtab_index < len(secs)):
+        return None, {"renamed": [], "error": "symbol table has no valid string table"}
+    strtab = secs[strtab_index]
+    syms = list(symtab.iter_symbols())
+    names = {sym.name for sym in syms if sym.name}
+    rows = []
+    out = bytearray(raw)
+    offsets = [int(sym.entry["st_name"]) for sym in syms]
+    for old, new in requested.items():
+        matches = [(index, sym) for index, sym in enumerate(syms) if sym.name == old]
+        if len(matches) != 1:
+            return None, {"renamed": rows, "error":
+                          f"undefined alias source {old} has {len(matches)} symbols"}
+        index, sym = matches[0]
+        if sym["st_shndx"] != "SHN_UNDEF":
+            return None, {"renamed": rows, "error":
+                          f"undefined alias source {old} is a definition"}
+        if new in names and new not in requested:
+            return None, {"renamed": rows, "error":
+                          f"canonical alias destination {new} already exists in object"}
+        old_bytes, new_bytes = old.encode("utf-8"), new.encode("utf-8")
+        if len(new_bytes) > len(old_bytes):
+            return None, {"renamed": rows, "error":
+                          f"canonical alias destination {new} is longer than {old}"}
+        name_offset = int(sym.entry["st_name"])
+        interior = [other for ordinal, other in enumerate(offsets)
+                    if ordinal != index and name_offset < other <= name_offset + len(old_bytes)]
+        if interior:
+            return None, {"renamed": rows, "error":
+                          f"another symbol string points inside {old}: {interior}"}
+        file_offset = strtab.header["sh_offset"] + name_offset
+        if bytes(out[file_offset:file_offset + len(old_bytes) + 1]) \
+                != old_bytes + b"\0":
+            return None, {"renamed": rows, "error":
+                          f"string-table bytes for {old} are not exact"}
+        out[file_offset:file_offset + len(old_bytes) + 1] = \
+            new_bytes + b"\0" * (len(old_bytes) + 1 - len(new_bytes))
+        rows.append({"symbolIndex": index, "from": old, "to": new})
+
+    check = ELFFile(io.BytesIO(bytes(out))).get_section_by_name(".symtab")
+    got = [sym.name for sym in check.iter_symbols()]
+    for row in rows:
+        if got[row["symbolIndex"]] != row["to"] or row["from"] in got:
+            return None, {"renamed": rows, "error":
+                          f"post-rewrite symbol verification failed for {row['from']}"}
+    return bytes(out), {"renamed": rows, "error": None}
+
+
+def rewrite_symbol_bindings(raw, policies):
+    """Rewrite exact defined-symbol bindings in place, preserving every other bit."""
+    requested = dict(policies or {})
+    if not requested:
+        return bytes(raw), {"rewritten": [], "error": None}
+    binding_values = {"STB_LOCAL": 0, "STB_GLOBAL": 1, "STB_WEAK": 2,
+                      "STB_LOPROC": 13}
+    elf = ELFFile(io.BytesIO(bytes(raw)))
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None or symtab.header["sh_entsize"] != 16:
+        return None, {"rewritten": [], "error": "no standard Elf32 symbol table"}
+    syms = list(symtab.iter_symbols())
+    out, rows = bytearray(raw), []
+    for name, policy in requested.items():
+        if not isinstance(policy, (tuple, list)) or len(policy) != 2 \
+                or policy[0] not in binding_values or policy[1] not in binding_values:
+            return None, {"rewritten": rows, "error":
+                          f"invalid binding policy for {name}: {policy!r}"}
+        matches = [(index, sym) for index, sym in enumerate(syms) if sym.name == name]
+        if len(matches) != 1:
+            return None, {"rewritten": rows, "error":
+                          f"binding rewrite symbol {name} has {len(matches)} entries"}
+        index, sym = matches[0]
+        if sym["st_shndx"] == "SHN_UNDEF" or sym["st_info"]["bind"] != policy[0]:
+            return None, {"rewritten": rows, "error":
+                          f"binding rewrite symbol {name} is {sym['st_info']['bind']}/"
+                          f"{sym['st_shndx']}, expected defined {policy[0]}"}
+        info_offset = symtab.header["sh_offset"] + index * symtab.header["sh_entsize"] + 12
+        old_info = out[info_offset]
+        if old_info >> 4 != binding_values[policy[0]]:
+            return None, {"rewritten": rows, "error":
+                          f"raw binding nibble for {name} disagrees with ELF parse"}
+        out[info_offset] = (binding_values[policy[1]] << 4) | (old_info & 0x0f)
+        rows.append({"symbolIndex": index, "symbol": name,
+                     "from": policy[0], "to": policy[1]})
+    check = list(ELFFile(io.BytesIO(bytes(out))).get_section_by_name(".symtab").iter_symbols())
+    for row in rows:
+        if check[row["symbolIndex"]]["st_info"]["bind"] != row["to"]:
+            return None, {"rewritten": rows, "error":
+                          f"post-rewrite binding verification failed for {row['symbol']}"}
+    return bytes(out), {"rewritten": rows, "error": None}
+
 CONTENT = ("SHT_PROGBITS", "SHT_NOBITS")
 IGNORE = (".comment", ".debug", ".line", ".note")
 

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -852,7 +852,8 @@ def intact_tu_policies(enrolled=None, manifest=None):
             except (KeyError, TypeError, ValueError):
                 errors.append(f"{label}: intact-object manifest has an invalid section claim")
                 continue
-            if name not in (".text", ".data", ".rodata", ".bss") or start >= end:
+            if name not in (".text", ".rodata", ".init", ".ctor", ".data", ".bss") \
+                    or start >= end:
                 errors.append(f"{label}: intact-object manifest has unsupported/invalid "
                               f"section claim {name!r}")
             if name in seen_sections:

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -215,6 +215,7 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
     per_module_bad = collections.Counter()
     source_functions = source_bytes = mod_functions = mod_bytes = 0
     source_data_bytes = 0
+    source_bss_claims = source_bss_bytes = 0
     source_data_claims = bad_data_claims = bad_data_bytes = 0
     reproducing_data_claims = reproducing_data_bytes = 0
     reproducing = reproducing_bytes = bad = bad_function_bytes = differing_source_bytes = 0
@@ -249,7 +250,7 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
                               if rel.startswith("mods/")]
         source_data_bytes += _covered_bytes(
             [(addr, end) for rel, name, addr, end in entry_sections
-             if rel.startswith("src/") and name not in (".text", ".init")],
+             if rel.startswith("src/") and name not in (".text", ".init", ".bss")],
             base, max(len(built), len(retail)))
         module_diff, unexpected_diff = _diff_counts(built, retail, allowed_mod_ranges)
         module_results.append({
@@ -325,6 +326,13 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             if not rel.startswith("src/") or name in (".text", ".init"):
                 continue
             size = end - addr
+            if name == ".bss":
+                # BSS is NOBITS and deliberately lies beyond the initialized module
+                # image. Intact-object admission separately verifies its emitted
+                # size, symbol addresses/bindings, configured boundaries, and link.
+                source_bss_claims += 1
+                source_bss_bytes += size
+                continue
             source_data_claims += 1
             lo, hi = addr - base, end - base
             row = {"module": label, "name": pathlib.Path(rel).stem, "addr": addr,
@@ -419,6 +427,8 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             # function count that no function is behind. differingSourceBytes is
             # shared, because a differing byte is a differing byte either way.
             "sourceDataClaims": source_data_claims,
+            "sourceBssClaims": source_bss_claims,
+            "sourceBssBytes": source_bss_bytes,
             "reproducingDataClaims": reproducing_data_claims,
             "reproducingDataClaimBytes": reproducing_data_bytes,
             "mismatchingDataClaims": bad_data_claims,
@@ -453,6 +463,9 @@ def print_report(report, show=12):
         print(f"source-owned data claims: {sf['sourceDataClaims']:,}  "
               f"(reproducing {sf.get('reproducingDataClaims', 0):,}, "
               f"mismatching {sf.get('mismatchingDataClaims', 0):,})")
+    if sf.get("sourceBssClaims"):
+        print(f"source-owned BSS claims: {sf['sourceBssClaims']:,}  "
+              f"({sf.get('sourceBssBytes', 0):,} NOBITS bytes; object/symbol gates)")
     print(f"module fidelity: {mf['modulesExact']}/{mf['modulesChecked']} exact, "
           f"{mf['percent']:.6f}% of compared bytes")
     mc = report.get("moduleComposition")

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -408,6 +408,40 @@ class RomBuildEnrollment(unittest.TestCase):
             RB.intact_tu_policies({"src/actors/TU.cpp"}, manifest=manifest)
         self.assertIn("baseline bootstrapping is non-circular", raised.exception.output)
 
+    def test_intact_policy_admits_exact_init_ctor_and_bss_claims(self):
+        ranges = [
+            {"section": ".text", "start": "0x1000", "end": "0x1010",
+             "differingBytes": 0},
+            {"section": ".init", "start": "0x2000", "end": "0x2010",
+             "differingBytes": 0},
+            {"section": ".ctor", "start": "0x2010", "end": "0x2014",
+             "differingBytes": 0},
+            {"section": ".bss", "start": "0x3000", "end": "0x3010",
+             "comparison": "NOBITS -- symbol/module gates"},
+        ]
+        entry = {
+            "id": "ov023/TU", "status": "promoted",
+            "production_mode": "intact-object",
+            "source": "src/actors/TU.cpp", "promoted_source": "src/actors/TU.cpp",
+            "sections": [
+                {"name": row["section"], "start": row["start"], "end": row["end"]}
+                for row in ranges
+            ],
+            "verification": {"linkcheck": {
+                "result": "scratch-data-verified",
+                "phases": {name: True for name in
+                           ("delink", "lcf", "compile", "link", "checkModules", "rom")},
+                "symbolCheckNewVsBaseline": [],
+                "symbolCheckErrors": ["[ERROR] old"],
+                "symbolCheckBaselineErrors": ["[ERROR] old"],
+                "tuRanges": ranges,
+                "rom": {"sha256": "a" * 64, "matchesStockRom": True},
+            }},
+        }
+        self.assertEqual(RB.intact_tu_policies(
+            {"src/actors/TU.cpp"}, manifest={"entries": [entry]}),
+            {"src/actors/TU.cpp": entry})
+
     def test_intact_rom_comparison_uses_current_same_worker_control(self):
         verification = {
             "baseline": {

--- a/tools/test_rombuild_check.py
+++ b/tools/test_rombuild_check.py
@@ -89,6 +89,23 @@ class RomBuildCheck(unittest.TestCase):
         self.assertEqual(report["moduleComposition"]["sourceDataBytes"], 4)
         self.assertEqual(report["moduleComposition"]["unownedDataBytes"], 0)
 
+    def test_intact_bss_is_nobits_not_an_out_of_range_data_failure(self):
+        (self.config / "delinks.txt").write_text(
+            "    .text start:0x00001000 end:0x00001008 kind:code\n"
+            "    .bss start:0x00001020 end:0x00001040 kind:bss\n\n"
+            "src/actors/Pair.cpp:\n"
+            "    complete\n"
+            "    .text start:0x00001000 end:0x00001008\n"
+            "    .bss start:0x00001020 end:0x00001030\n",
+            encoding="utf-8")
+        report = RBC.analyze(self.config, "stock")
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["sourceBuild"]["sourceDataClaims"], 0)
+        self.assertEqual(report["sourceBuild"]["sourceBssClaims"], 1)
+        self.assertEqual(report["sourceBuild"]["sourceBssBytes"], 0x10)
+        self.assertEqual(report["moduleComposition"]["sourceDataBytes"], 0)
+        self.assertEqual(report["failures"], [])
+
     def write_intact_entry(self):
         """One source-owned entry claiming BOTH .text and .data, as an intact TU
         does."""

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -319,38 +319,43 @@ def test_splice_refuses_a_span_whose_legacy_entries_are_not_complete():
     cause, clear two seams, +98 functions") marked all five, so the premise is gone: the
     command now gets past the splice and spends ninety seconds reaching a link that
     fails on the key-function wall instead. Re-pointing it at some other TU would only
-    re-arm the same trap, so the invariant is checked directly, on a scratch COPY of the
-    real file, the way its sibling test below does.
+    re-arm the same trap, so the invariant is checked directly with a synthetic delinks
+    fixture whose ownership cannot drift when another production TU is promoted.
     """
-    import json
     sys.path.insert(0, str(TOOLS))
     import tubuild as T
 
-    manifest = T.load_manifest()
-    entry = next(e for e in manifest["entries"] if e["id"] == "ov045/daObjKm2_Fall_Block_c")
-    sec = next(s for s in entry["sections"] if s["name"] == ".text")
-    start, end = int(sec["start"], 16), int(sec["end"], 16)
-    legacy = [f["legacy_source"] for f in entry["functions"]]
-    real = REPO / "config" / "arm9" / "overlays" / "ov045" / "delinks.txt"
+    start, end = 0x1000, 0x1040
+    legacy = ["src/first.cpp", "src/second.cpp"]
+    candidate = "src/actors/Combined.cpp"
+    text = (
+        "    .text start:0x00001000 end:0x00001100 kind:code align:4\n"
+        "src/first.cpp:\n"
+        "    complete\n"
+        "    .text start:0x00001000 end:0x00001020\n"
+        "\n"
+        "src/second.cpp:\n"
+        "    complete\n"
+        "    .text start:0x00001020 end:0x00001040\n"
+    )
 
     with tempfile.TemporaryDirectory() as td:
-        # As committed, every entry in the span is `complete`, so the splice is allowed.
+        # Every entry in the span is `complete`, so the splice is allowed.
         good = pathlib.Path(td) / "good.txt"
-        shutil.copyfile(real, good)
-        replaced, reasons = T.splice_tu_entry(good, start, end, entry["source"], legacy)
+        good.write_text(text, encoding="utf-8")
+        replaced, reasons = T.splice_tu_entry(good, start, end, candidate, legacy)
         assert reasons == [], reasons
         assert len(replaced) == len(legacy)
 
         # Take `complete` away from one of them and the splice must refuse, untouched.
         stripped = pathlib.Path(td) / "stripped.txt"
-        text = real.read_text(encoding="utf-8")
         victim = legacy[0]
         head, sep, tail = text.partition(f"{victim}:\n")
         assert sep, victim
         stripped.write_text(head + sep + tail.replace("    complete\n", "", 1),
                             encoding="utf-8")
         before = stripped.read_bytes()
-        replaced, reasons = T.splice_tu_entry(stripped, start, end, entry["source"], legacy)
+        replaced, reasons = T.splice_tu_entry(stripped, start, end, candidate, legacy)
         assert replaced is None
         assert any("NOT `complete` today" in r for r in reasons), reasons
         assert stripped.read_bytes() == before, "a refusal must not edit the file"
@@ -523,6 +528,94 @@ def test_splice_relinquishes_exact_manifest_data_and_bss_ranges_only():
         assert replaced is None
         assert any("not pure gap ownership" in r for r in reasons)
         assert occupied.read_bytes() == before
+
+
+def test_enrolled_intact_candidate_requires_one_complete_exact_entry():
+    text = (
+        "    .text start:0x00001000 end:0x00001100 kind:code align:4\n"
+        "    .init start:0x00002000 end:0x00002100 kind:code align:4\n"
+        "    .data start:0x00003000 end:0x00003100 kind:data align:4\n"
+        "src/actors/T.cpp:\n"
+        "    complete\n"
+        "    .text start:0x00001000 end:0x00001020\n"
+        "    .init start:0x00002040 end:0x00002050\n"
+        "    .data start:0x00003080 end:0x00003090\n"
+    )
+    claims = [
+        {"name": ".text", "start": 0x1000, "end": 0x1020},
+        {"name": ".init", "start": 0x2040, "end": 0x2050},
+        {"name": ".data", "start": 0x3080, "end": 0x3090},
+    ]
+    with tempfile.TemporaryDirectory() as td:
+        path = pathlib.Path(td) / "delinks.txt"
+        path.write_text(text, encoding="utf-8")
+        reasons = tubuild.validate_enrolled_intact_tu_entry(
+            path, "src/actors/T.cpp", claims)
+        assert reasons == [], reasons
+
+        path.write_text(text.replace(
+            "    .data start:0x00003080 end:0x00003090\n",
+            "    .data start:0x00003080 end:0x00003094\n"), encoding="utf-8")
+        reasons = tubuild.validate_enrolled_intact_tu_entry(
+            path, "src/actors/T.cpp", claims)
+        assert any("do not exactly equal" in reason for reason in reasons), reasons
+
+        path.write_text(text.replace("    complete\n", ""), encoding="utf-8")
+        reasons = tubuild.validate_enrolled_intact_tu_entry(
+            path, "src/actors/T.cpp", claims)
+        assert any("is not `complete`" in reason for reason in reasons), reasons
+
+
+def test_nontext_call_destination_ignores_encoded_pc_bias_addend():
+    assert tubuild._relocation_destination_address(
+        1, "callee", 0x02001000, -8, configured_public=True) == 0x02001000
+    assert tubuild._relocation_destination_address(
+        2, "object", 0x02002000, 4, configured_public=True) == 0x02002004
+
+
+def test_undefined_symbol_alias_policy_only_renames_exact_import():
+    if not _toolchain():
+        raise unittest.SkipTest("needs the pinned compiler")
+    obj = _compile_tu_fixture(
+        'extern "C" void generated_wrapper_symbol(void);\n'
+        'extern "C" void owner(void) { generated_wrapper_symbol(); }\n')
+    entry = {"undefined_symbol_aliases": [{
+        "symbol": "generated_wrapper_symbol",
+        "canonical_symbol": "rom_func",
+        "canonical_module": "arm9",
+        "canonical_address": "0x02001234",
+        "evidence": "fixture",
+    }]}
+    out, report, reasons = tubuild.apply_undefined_symbol_alias_policy(
+        obj, entry, name_index={"rom_func": ("arm9", 0x02001234)})
+    assert reasons == [], reasons
+    assert report["renamed"][0]["from"] == "generated_wrapper_symbol"
+    imports = set(tubuild.contribution(out, "owner")["undefReferenced"])
+    assert "generated_wrapper_symbol" not in imports
+    assert "rom_func" in imports
+
+
+def test_symbol_binding_policy_only_promotes_exact_owned_local():
+    if not _toolchain():
+        raise unittest.SkipTest("needs the pinned compiler")
+    obj = _compile_tu_fixture(
+        'static int local_word;\nextern "C" int *owner = &local_word;\n')
+    inventory = tubuild.elf_inventory(obj)
+    local = next(row for row in inventory["symbols"]
+                 if row["type"] == "STT_OBJECT" and row["bind"] == "STB_LOCAL")
+    entry = {
+        "data": [{"symbol": local["name"], "address": "0x2000", "size": "0x4"}],
+        "symbol_binding_rewrites": [{
+            "symbol": local["name"], "from": "STB_LOCAL", "to": "STB_GLOBAL",
+            "evidence": "fixture",
+        }],
+    }
+    out, report, reasons = tubuild.apply_symbol_binding_policy(obj, entry)
+    assert reasons == [], reasons
+    assert report["rewritten"][0]["symbol"] == local["name"]
+    rewritten = next(row for row in tubuild.elf_inventory(out)["symbols"]
+                     if row["name"] == local["name"])
+    assert rewritten["bind"] == "STB_GLOBAL"
 
 
 def test_splice_maps_compiler_rodata_into_module_data():

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -48,9 +48,17 @@ def prepare_intact_object(raw, entry):
         TB.apply_externalized_output_policy(post_policy, entry)
     if reasons:
         _raise(f"{entry['id']} exact RTTI externalization", reasons)
+    aliased_obj, undefined_aliases, reasons = \
+        TB.apply_undefined_symbol_alias_policy(externalized_obj, entry)
+    if reasons:
+        _raise(f"{entry['id']} undefined symbol aliases", reasons)
+    bound_obj, symbol_bindings, reasons = \
+        TB.apply_symbol_binding_policy(aliased_obj, entry)
+    if reasons:
+        _raise(f"{entry['id']} symbol binding policy", reasons)
 
     ordered_obj, section_order, reasons = \
-        TB.prepare_owned_nontext_section_order(externalized_obj, entry, claims)
+        TB.prepare_owned_nontext_section_order(bound_obj, entry, claims)
     if reasons:
         _raise(f"{entry['id']} manifest non-text section order", reasons)
 
@@ -81,6 +89,8 @@ def prepare_intact_object(raw, entry):
         _raise(f"{entry['id']} production object audit", audit_errors)
     return linked_obj, {
         "compilerOnly": compiler_only, "externalized": externalized,
+        "undefinedAliases": undefined_aliases,
+        "symbolBindings": symbol_bindings,
         "sectionOrder": section_order,
         "ownedBefore": owned_before, "ownedAfter": owned_after,
         "vtableRebias": rebias,

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1680,6 +1680,41 @@ def validate_tu_entry_splice(delinks_path, span_start, span_end, tu_rel,
     return header, entries, inside, claims, reasons
 
 
+def validate_enrolled_intact_tu_entry(delinks_path, tu_rel, section_claims):
+    """Validate an already-enrolled TU whose ownership is exactly the manifest.
+
+    Ordinary ``linkcheck`` normally replaces N legacy text entries in a disposable
+    config.  A promoted text-only TU can later grow into an intact TU, however, and
+    the tracked candidate config then already contains the final one-object entry.
+    Requiring a second destination path or pretending the historical per-function
+    files are still enrolled would make that transition impossible to prove.
+
+    This path is intentionally narrower than the splice path: exactly one entry must
+    name ``tu_rel``, it must be ``complete``, and its complete section inventory must
+    equal the manifest claims.  No subset, overlap, storage alias, or implicit gap is
+    accepted.  The caller still compiles a raw object and reruns every byte,
+    relocation, symbol, module, and full-ROM gate before recording evidence.
+    """
+    _header, entries = parse_delinks_file(delinks_path)
+    matches = [(idx, body) for idx, (rel, body) in enumerate(entries) if rel == tu_rel]
+    reasons = []
+    if len(matches) != 1:
+        reasons.append(f"enrolled intact TU {tu_rel} appears {len(matches)} time(s), "
+                       "expected exactly 1")
+        return reasons
+    _idx, body = matches[0]
+    if not entry_is_complete(body):
+        reasons.append(f"enrolled intact TU {tu_rel} is not `complete`")
+    actual = sorted(entry_sections(body))
+    expected = sorted((claim.get("module_section", claim["name"]),
+                       claim["start"], claim["end"])
+                      for claim in section_claims)
+    if actual != expected:
+        reasons.append(f"enrolled intact TU {tu_rel} sections do not exactly equal "
+                       f"the manifest claims: enrolled={actual!r}, expected={expected!r}")
+    return reasons
+
+
 def splice_tu_entry(delinks_path, span_start, span_end, tu_rel, expected_legacy,
                     section_claims=None):
     """Replace the per-function entries tiling [span_start, span_end) with ONE TU entry.
@@ -2089,6 +2124,23 @@ def _raw_configured_symbol_address(symbol, public_address, addend):
     if symbol.startswith("_ZTV") and addend >= OI.VTABLE_PREAMBLE:
         address -= OI.VTABLE_PREAMBLE
     return address
+
+
+def _relocation_destination_address(reloc_type, symbol, public_address, addend,
+                                    configured_public=False):
+    """Return the symbol destination represented by one ELF relocation.
+
+    ARM branch relocations carry the architecture's PC-bias correction in their
+    addend (mwcc emits -8 for the ordinary ARM calls in static initializers).  That
+    correction participates in encoding ``S + A - P`` but does not mean the call's
+    destination is eight bytes before ``S``.  Absolute relocations continue through
+    the existing public-vtable normalization path.
+    """
+    if reloc_type in (1, 10, 28, 29):
+        return public_address
+    if configured_public:
+        return _raw_configured_symbol_address(symbol, public_address, addend)
+    return public_address + addend
 
 
 def apply_compiler_only_policy(obj_bytes, entry, homes=None):
@@ -2557,6 +2609,96 @@ def apply_externalized_output_policy(obj_bytes, entry, homes=None,
                  "verification": verification}, []
 
 
+def apply_undefined_symbol_alias_policy(obj_bytes, entry, name_index=None):
+    """Canonicalize exact compiler imports to independently configured ROM names."""
+    raw = entry.get("undefined_symbol_aliases", [])
+    if raw is None:
+        raw = []
+    if not isinstance(raw, list):
+        return None, {"requested": [], "renamed": []}, \
+            ["undefined_symbol_aliases must be a list"]
+    index = RA.build_name_index() if name_index is None else name_index
+    mapping, requested, reasons = {}, [], []
+    for ordinal, row in enumerate(raw):
+        label = f"undefined_symbol_aliases[{ordinal}]"
+        if not isinstance(row, dict):
+            reasons.append(f"{label} is not an object")
+            continue
+        missing = [key for key in ("symbol", "canonical_symbol", "canonical_module",
+                                   "canonical_address", "evidence") if not row.get(key)]
+        if missing:
+            reasons.append(f"{label} is missing {missing}")
+            continue
+        old, new = str(row["symbol"]), str(row["canonical_symbol"])
+        try:
+            address = int(row["canonical_address"], 0)
+        except (TypeError, ValueError):
+            reasons.append(f"{label} has an invalid canonical_address")
+            continue
+        resolved = index.get(new) or RA.resolve_candidate(new, index)
+        module = RL.normalize_module(row["canonical_module"])
+        if resolved is None or RL.normalize_module(resolved[0]) != module \
+                or resolved[1] != address:
+            reasons.append(f"{label} canonical symbol {new} does not resolve exactly "
+                           f"to {module}:0x{address:08x}")
+            continue
+        if old in mapping:
+            reasons.append(f"duplicate undefined alias source {old}")
+            continue
+        mapping[old] = new
+        requested.append({"from": old, "to": new, "module": module,
+                          "address": f"0x{address:08x}", "evidence": row["evidence"]})
+    if reasons:
+        return None, {"requested": requested, "renamed": []}, reasons
+    out, plan = OI.rename_undefined_symbols(obj_bytes, mapping)
+    if out is None:
+        return None, {"requested": requested, "renamed": plan.get("renamed", []),
+                      "objisolate": plan}, [f"undefined symbol alias rewrite refused: "
+                                            f"{plan.get('error')}"]
+    return out, {"requested": requested, "renamed": plan.get("renamed", []),
+                 "objisolate": plan}, []
+
+
+def apply_symbol_binding_policy(obj_bytes, entry):
+    """Apply exact manifest-licensed binding rewrites to owned compiler locals."""
+    raw = entry.get("symbol_binding_rewrites", [])
+    if raw is None:
+        raw = []
+    if not isinstance(raw, list):
+        return None, {"requested": [], "rewritten": []}, \
+            ["symbol_binding_rewrites must be a list"]
+    owned = {row["symbol"] for _section, row in manifest_owned_symbol_rows(entry)}
+    mapping, requested, reasons = {}, [], []
+    for ordinal, row in enumerate(raw):
+        label = f"symbol_binding_rewrites[{ordinal}]"
+        if not isinstance(row, dict):
+            reasons.append(f"{label} is not an object")
+            continue
+        missing = [key for key in ("symbol", "from", "to", "evidence")
+                   if not row.get(key)]
+        if missing:
+            reasons.append(f"{label} is missing {missing}")
+            continue
+        symbol = str(row["symbol"])
+        if symbol not in owned:
+            reasons.append(f"{label} names unowned symbol {symbol}")
+            continue
+        if symbol in mapping:
+            reasons.append(f"duplicate binding rewrite for {symbol}")
+            continue
+        mapping[symbol] = (row["from"], row["to"])
+        requested.append(dict(row))
+    if reasons:
+        return None, {"requested": requested, "rewritten": []}, reasons
+    out, plan = OI.rewrite_symbol_bindings(obj_bytes, mapping)
+    if out is None:
+        return None, {"requested": requested,
+                      "rewritten": plan.get("rewritten", []), "objisolate": plan}, \
+            [f"symbol binding rewrite refused: {plan.get('error')}"]
+    return out, {"requested": requested, "rewritten": plan.get("rewritten", []),
+                 "objisolate": plan}, []
+
+
 def _align_up(value, alignment):
     alignment = max(1, int(alignment or 1))
     return (value + alignment - 1) & ~(alignment - 1)
@@ -2933,6 +3075,10 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
         if got is None:
             reasons.append(f"licensed {section} symbol {name} is not emitted there")
             continue
+        expected_binding = expected.get("binding")
+        if expected_binding is not None and got["bind"] != expected_binding:
+            reasons.append(f"licensed {section} symbol {name} binding {got['bind']}, "
+                           f"manifest says {expected_binding}")
         if address_error:
             reasons.append(f"licensed {section} symbol {name}: {address_error}")
         elif want_addr is None:
@@ -2941,7 +3087,8 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
             reasons.append(f"licensed {section} symbol {name} links at "
                            f"0x{got['address']:08x}, manifest emitted address says "
                            f"0x{want_addr:08x}")
-        if section == ".bss" and public_addr is not None:
+        if section == ".bss" and public_addr is not None \
+                and expected_binding != "STB_LOCAL":
             configured = {(RL.normalize_module(mod), addr)
                           for mod, addr in symbol_homes.get(name, [])}
             if (owner_module, public_addr) not in configured:
@@ -3011,7 +3158,8 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
                 base = manifest_addrs[rel["symbol"]]
                 candidate_module = owner_module
             else:
-                resolved = RA.resolve_candidate(rel["symbol"], name_index)
+                resolved = name_index.get(rel["symbol"]) \
+                    or RA.resolve_candidate(rel["symbol"], name_index)
                 if resolved:
                     candidate_module = (RL.normalize_module(resolved[0])
                                         if resolved[0] is not None else None)
@@ -3019,11 +3167,10 @@ def verify_owned_sections(obj_bytes, entry, claims, name_index=None,
                     configured_public_base = True
             cand_addr = None
             if base is not None:
-                if configured_public_base and not normalized_undefined_vtables:
-                    cand_addr = _raw_configured_symbol_address(
-                        rel["symbol"], base, rel["addend"])
-                else:
-                    cand_addr = base + rel["addend"]
+                cand_addr = _relocation_destination_address(
+                    rel["type"], rel["symbol"], base, rel["addend"],
+                    configured_public=(configured_public_base
+                                       and not normalized_undefined_vtables))
             cfg = cfgmap.get(source)
             expected = expected_relocs.get(source)
             expected_addend = expected.get("addend") if expected else None
@@ -4356,7 +4503,44 @@ def cmd_linkcheck(args):
 
     if baseline:
         enrolled_before = RB.enrolled(cfg_root)
-        intact_before = RB.intact_tu_policies(enrolled_before)
+        # A strict control excludes every exact enrolled intact-object candidate,
+        # including one whose admission proof is the thing this control will enable.
+        # Requiring the old proof here is circular.  Demotion is safe only after the
+        # disposable config entry is independently shown to equal every current
+        # manifest claim exactly; the control then serves those ranges from the
+        # extracted retail module rather than compiling any candidate source.
+        counts = collections.Counter(enrolled_before)
+        intact_before, control_reasons = {}, []
+        for candidate in data.get("entries", []):
+            if candidate.get("production_mode") != "intact-object" \
+                    or candidate.get("status") != "promoted":
+                continue
+            source = str(candidate.get("promoted_source")
+                         or candidate.get("source", "")).replace("\\", "/")
+            if counts[source] != 1:
+                control_reasons.append(
+                    f"{candidate.get('id', source)}: strict control candidate {source!r} "
+                    f"is enrolled {counts[source]} time(s), expected exactly 1")
+                continue
+            candidate_claims, reasons = manifest_section_claims(candidate)
+            if reasons:
+                control_reasons.extend(
+                    f"{candidate.get('id', source)}: {reason}" for reason in reasons)
+                continue
+            candidate_dl = module_dir_in(
+                cfg_root, candidate.get("module")) / "delinks.txt"
+            reasons = validate_enrolled_intact_tu_entry(
+                candidate_dl, source, candidate_claims)
+            if reasons:
+                control_reasons.extend(
+                    f"{candidate.get('id', source)}: {reason}" for reason in reasons)
+                continue
+            intact_before[source] = candidate
+        if control_reasons:
+            print("\nREFUSED -- strict control intact-TU inventory is not exact:")
+            for reason in control_reasons:
+                print(f"  {reason}")
+            return 1
         demoted, reasons = demote_complete_sources(cfg_root, intact_before)
         if reasons:
             print("\nREFUSED -- strict control could not exclude every intact TU:")
@@ -4376,6 +4560,7 @@ def cmd_linkcheck(args):
     claims = []
     replaced = []
     scratch_rewrite = False
+    enrolled_intact_candidate = False
     if not baseline:
         claims, claim_reasons = manifest_section_claims(entry)
         if claim_reasons:
@@ -4389,7 +4574,27 @@ def cmd_linkcheck(args):
         if not dl.is_file():
             raise SystemExit(f"no delinks.txt for module {module} at {dl}")
         legacy_rels = [f["legacy_source"] for f in entry["functions"]]
-        if partial:
+        enrolled_paths = [rel for rel, _body in parse_delinks_file(dl)[1]]
+        if entry["source"] in enrolled_paths and not partial and not partitioned:
+            reasons = validate_enrolled_intact_tu_entry(dl, entry["source"], claims)
+            if reasons:
+                print("\nREFUSED -- the already-enrolled intact TU candidate is not "
+                      "exactly the manifest-owned object:")
+                for r in reasons:
+                    print(f"  {r}")
+                return 1
+            enrolled_intact_candidate = True
+            replaced = [entry["source"]]
+            print("      delinks.txt already contains the exact final intact-object "
+                  "entry; no scratch splice is needed:")
+            print(f"        {entry['source']}: complete")
+            for claim in claims:
+                output_name = claim.get("module_section", claim["name"])
+                label = (claim["name"] if output_name == claim["name"] else
+                         f"{claim['name']} -> {output_name}")
+                print(f"          {label:16} 0x{claim['start']:08x}.."
+                      f"0x{claim['end']:08x}")
+        elif partial:
             # No splice. The whole point of partial isolation is that the CONFIG does
             # not move: the same N entries, the same N object paths, the same tiling of
             # the span -- only the source that produced those objects' bytes changes.
@@ -4531,10 +4736,22 @@ def cmd_linkcheck(args):
                                 enabled=not args.no_cache)
     init_srcs = RB.init_section_sources()
     syms = RB.enrolled_symbols()
+    intact_override = None
+    if enrolled_intact_candidate:
+        # Keep every previously admitted intact TU on its production preparation
+        # path, but admit this one candidate only inside the disposable proof run.
+        # Its initially prepared object is discarded below and rebuilt raw before
+        # the explicit [4b] audit, so this does not use the proof being created as
+        # evidence for itself.
+        without_candidate = dict(data)
+        without_candidate["entries"] = [
+            row for row in data.get("entries", []) if row is not entry]
+        intact_override = RB.intact_tu_policies(srcs, manifest=without_candidate)
+        intact_override[entry["source"]] = entry
     t0 = time.time()
     failures, outcomes = compile_linkcheck_sources(
         srcs, vers, cache, init_srcs, syms, scratch, args.jobs,
-        intact_tus_override={} if baseline else None)
+        intact_tus_override={} if baseline else intact_override)
     dt = time.time() - t0
     report["phases"]["compile"] = {"ok": not failures, "seconds": round(dt, 1),
                                    "outcomes": dict(outcomes)}
@@ -4784,7 +5001,18 @@ def cmd_linkcheck(args):
         if not tu_obj.is_file():
             print(f"      !! no object at {tu_obj}")
             return 1
-        raw_tu = tu_obj.read_bytes()
+        if enrolled_intact_candidate:
+            raw_tu, _version, _flags, _build_dir, _raw_path = _compile_tu(entry)
+            tu_obj.write_bytes(raw_tu)
+            report["candidateAdmission"] = {
+                "mode": "already-enrolled-exact-manifest-entry",
+                "initialPreparedObjectDiscarded": True,
+                "rawObjectRecompiledBeforeAudit": True,
+            }
+            print("      discarded the scratch-only admission copy and recompiled the "
+                  "candidate raw; every policy below is now being proved, not assumed")
+        else:
+            raw_tu = tu_obj.read_bytes()
         linked_tu, compiler_only, policy_reasons = apply_compiler_only_policy(raw_tu, entry)
         report["compilerOnlyOutput"] = compiler_only
         if policy_reasons:
@@ -4820,6 +5048,44 @@ def cmd_linkcheck(args):
             tu_obj.write_bytes(linked_tu)
             print(f"      externalized {externalized['externalized']} to their exact "
                   "configured canonical homes in the SCRATCH object only")
+
+        aliased_tu, undefined_aliases, alias_reasons = \
+            apply_undefined_symbol_alias_policy(linked_tu, entry)
+        report["undefinedSymbolAliases"] = undefined_aliases
+        if alias_reasons:
+            print("      REFUSED -- undefined symbol alias policy:")
+            for reason in alias_reasons:
+                print(f"        {reason}")
+            report["undefinedSymbolAliases"]["errors"] = alias_reasons
+            report["result"] = "undefined-alias-refused"
+            _write_link_report(scratch, report)
+            _record_linkcheck(data, entry, report, baseline)
+            return 1
+        if aliased_tu != linked_tu:
+            linked_tu = aliased_tu
+            scratch_rewrite = True
+            tu_obj.write_bytes(linked_tu)
+            print(f"      canonicalized {len(undefined_aliases['renamed'])} exact "
+                  "undefined C++ import name(s) to their configured ROM symbols")
+
+        bound_tu, symbol_bindings, binding_reasons = \
+            apply_symbol_binding_policy(linked_tu, entry)
+        report["symbolBindingRewrites"] = symbol_bindings
+        if binding_reasons:
+            print("      REFUSED -- symbol binding policy:")
+            for reason in binding_reasons:
+                print(f"        {reason}")
+            report["symbolBindingRewrites"]["errors"] = binding_reasons
+            report["result"] = "symbol-binding-refused"
+            _write_link_report(scratch, report)
+            _record_linkcheck(data, entry, report, baseline)
+            return 1
+        if bound_tu != linked_tu:
+            linked_tu = bound_tu
+            scratch_rewrite = True
+            tu_obj.write_bytes(linked_tu)
+            print(f"      promoted {len(symbol_bindings['rewritten'])} exact local "
+                  "owned symbol binding(s) for DSD's global symbol surface")
 
         ordered_tu, section_order, order_reasons = \
             prepare_owned_nontext_section_order(linked_tu, entry, claims)
@@ -5119,6 +5385,24 @@ def cmd_linkcheck(args):
                 print(f"      vs this tree's last stock build/sm64ds.nds: "
                       f"{'IDENTICAL' if same else 'DIFFERS'}")
                 report["rom"]["matchesStockRom"] = same
+            elif not baseline:
+                # A clean worktree need not have a shared build/sm64ds.nds.  The
+                # strict control is stronger for this experiment anyway: it demotes
+                # every intact TU to independently extracted retail gap bytes and
+                # runs the identical linker/ROM pipeline under the current config
+                # and tools.  Compare against its content-bound ROM digest rather
+                # than leaving a successfully reproduced clean-worker ROM ungraded.
+                control_path = BASELINE_LINK / "linkcheck.json"
+                try:
+                    control = json.loads(control_path.read_text(encoding="utf-8"))
+                    control_digest = (control.get("rom") or {}).get("sha256")
+                except (OSError, ValueError, TypeError):
+                    control_digest = None
+                if isinstance(control_digest, str):
+                    same = control_digest == digest
+                    print("      vs current source-independent strict stock control: "
+                          f"{'IDENTICAL' if same else 'DIFFERS'}")
+                    report["rom"]["matchesStockRom"] = same
         else:
             print(f"      FAILED ({dt:.1f}s)")
             print("      " + "\n      ".join(out.splitlines()[-15:]))


### PR DESCRIPTION
## Summary

- extend intact-TU verification and production admission to `.init`, `.ctor`, `.data`, and NOBITS `.bss` ownership
- add exact, fail-closed policies for undefined-symbol aliases and compiler-local symbol bindings
- compare already-enrolled intact candidates against a fresh source-independent strict control
- cover the new paths and replace one promotion-sensitive test fixture with a stable synthetic fixture

This is the tooling-only base for the stacked ov023 complete-overlay promotion.

## Validation

- `python -m pytest tools/test_tubuild.py -q` — 66 passed
- `python -m unittest tools.test_rombuild_check tools.test_rombuild tools.test_tu_production tools.test_objisolate` — 106 passed
- `python tools/rombuild.py -j 16 --no-rom` — 11,088/11,088 functions and 106/106 modules exact
- pre-push gates — 405/405 port references and 98/98 reconstructed TUs compile
