### PR TITLE
Let a licensed duplicate keep its surviving reference, on both paths

### DIFF
--- a/tools/objisolate.py
+++ b/tools/objisolate.py
@@ -686,7 +686,7 @@ def derive(raw, keep_symbol):
     return _apply(raw, p, keep_symbol), p
 
 
-def deadstrip_plan(raw, symbol_names, expect=None):
+def deadstrip_plan(raw, symbol_names, expect=None, duplicates=None):
     """Plan removal of exact, explicitly named compiler-only output sections.
 
     This is intentionally narrower than a linker dead-strip pass.  TU reconstruction
@@ -702,7 +702,15 @@ def deadstrip_plan(raw, symbol_names, expect=None):
       *data object* may be referenced by name -- becoming an import is the point, and
       it is the only way a destructor can go on storing the vptr of a vtable the ROM
       owns -- but only for ``_ZTV``/``_ZTI``/``_ZTS``, whose relocation shapes are
-      surveyed, and never through an unnamed section symbol.
+      surveyed, and never through an unnamed section symbol.  A requested *function*
+      named in ``expect`` or ``duplicates`` is the one exception, and for the same
+      reason: it HAS a configured ROM home, so a surviving reference is not evidence
+      that the body is live compiler output -- the cartridge makes that same
+      reference, to that same home.  Externalising the definition turns the reference
+      into an import the owning source resolves.  Name neither and the rule stands
+      unchanged: calling a homeless symbol is proof it is not dead compiler output.
+      An unnamed section symbol stays refused either way, because an anonymous
+      reference cannot be redirected to a home by name.
 
     ``expect`` extends this to the *duplicate* case: a vague-linkage body the compiler
     re-emits in every TU that needs it, while the retail image keeps exactly one copy
@@ -771,6 +779,25 @@ def deadstrip_plan(raw, symbol_names, expect=None):
 
     funcs = {n for n in wanted if defined[n]["st_info"]["type"] == "STT_FUNC"}
     objects = wanted - funcs
+    # Functions licensed as a DUPLICATE of a configured ROM home.  A surviving
+    # reference to one of those is expected rather than disqualifying, because the
+    # cartridge's code makes the same reference to the same home, and the reference
+    # resolves there after the link.
+    #
+    # Two callers reach this.  `expect` carries the cartridge's bytes and is checked
+    # below, so naming a symbol there both licenses the reference and demands the
+    # body match (as far as an unlinked object can: see the masking note there, and
+    # `rombuild._duplicate_body_reasons` for the linked comparison that closes it).
+    # `duplicates` licenses the reference alone, for the scratch link path in
+    # `tubuild.apply_compiler_only_policy`, which has no cartridge bytes to hand and
+    # leaves the body proof to the production build.  Neither may name anything but a
+    # requested function.
+    duplicate_names = {str(n) for n in (duplicates or ())}
+    stray = sorted(duplicate_names - funcs)
+    if stray:
+        return {"error": f"duplicate-licensed name(s) that are not requested "
+                         f"compiler-only functions: {stray}"}
+    duplicates = duplicate_names | {n for n in (expect or ()) if n in funcs}
 
     # A discarded section may have relocations of its own; those disappear with it.
     # Only references from SURVIVING content are load-bearing and therefore blockers.
@@ -794,7 +821,7 @@ def deadstrip_plan(raw, symbol_names, expect=None):
         executable = bool(source.header["sh_flags"] & SHF_EXECINSTR)
         for r in rel.iter_relocations():
             target = symtab.get_symbol(r["r_info_sym"])
-            names_target = target.name in funcs
+            names_target = target.name in funcs and target.name not in duplicates
             section_target = (not target.name and target["st_shndx"] in drop_content)
             if names_target or section_target:
                 label = target.name or f"section[{target['st_shndx']}]"
@@ -886,14 +913,14 @@ def deadstrip_plan(raw, symbol_names, expect=None):
             "error": None}
 
 
-def derive_deadstrip(raw, symbol_names, expect=None):
+def derive_deadstrip(raw, symbol_names, expect=None, duplicates=None):
     """Return an object with exact declared compiler-only sections discarded.
 
     ``None`` is returned instead of bytes when :func:`deadstrip_plan` refuses.  The
     input is never mutated.  This exists for scratch TU links; production one-function
     isolation continues to use :func:`derive` unchanged.
     """
-    p = deadstrip_plan(raw, symbol_names, expect)
+    p = deadstrip_plan(raw, symbol_names, expect, duplicates)
     if p.get("error"):
         return None, p
     return _apply(raw, p, None), p

--- a/tools/test_objisolate.py
+++ b/tools/test_objisolate.py
@@ -368,6 +368,126 @@ class Isolate(unittest.TestCase):
         self.assertIn("surviving", plan["error"])
         self.assertIn("references compiler-only helper", plan["error"])
 
+    def test_duplicate_deadstrip_allows_a_surviving_reference(self):
+        """A duplicate with a ROM home may be called by a survivor; a homeless one may not.
+
+        ov014/daWanwan_c is the case: it holds two `Vector3[7]`, so its destructor --
+        a function the ROM owns, at 0x02111308 -- hands `_ZN7Vector3D1Ev` to
+        `__destroy_arr`, and the cartridge keeps 0x020072c0 in that destructor's own
+        literal pool.  The reference is therefore ROM-real, and it is not evidence
+        that this object's vague-linkage copy is live compiler output: exactly one
+        copy has a home, an enrolled source owns it, and externalising the local
+        definition turns the reference into an import onto that home.
+
+        The exemption is opt-in and never fires on its own: a caller must name the
+        symbol in `expect` (the cartridge's bytes, compared here as far as an
+        unlinked object allows -- every relocated word is masked out, and
+        `rombuild._duplicate_body_reasons` links the body and compares those words)
+        or in `duplicates` (the reference alone, for the scratch path that has no
+        cartridge bytes).  A homeless symbol reaches neither.
+        """
+        # A member ARRAY is what forces the reference: mwcc cannot unroll the
+        # teardown, so it calls `__destroy_arr` with the element destructor's
+        # address, and that address is a relocation out of a surviving function.
+        obj = self.build("struct V { int v; ~V(){} };\n"
+                         "struct C { V a[7]; ~C(); };\n"
+                         "C::~C(){}\n")
+        raw = obj.read_bytes()
+        real = self._section_bytes(raw, "_ZN1VD1Ev")
+
+        # Without duplicate-body evidence the survivor's reference disqualifies it.
+        out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"])
+        self.assertIsNone(out)
+        self.assertIn("references compiler-only _ZN1VD1Ev", plan["error"])
+
+        # With it, the definition is externalised and the reference becomes an import.
+        import io
+        from elftools.elf.elffile import ELFFile
+
+        out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"], {"_ZN1VD1Ev": real})
+        self.assertIsNone(plan["error"])
+        self.assertIsNotNone(out)
+        elf = ELFFile(io.BytesIO(out))
+        syms = {s.name: s for s in elf.get_section_by_name(".symtab").iter_symbols()}
+        self.assertEqual(syms["_ZN1VD1Ev"]["st_shndx"], "SHN_UNDEF")
+
+        # The exemption is keyed on the evidence, not on being a function: a WRONG
+        # body is still refused even though the reference would now be allowed.
+        _out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"],
+                                         {"_ZN1VD1Ev": bytes(len(real))})
+        self.assertIn("non-relocated offset", plan["error"])
+
+        # `duplicates` licenses the reference without claiming the body: the scratch
+        # link path has no cartridge bytes and leaves that proof to rombuild.
+        out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"],
+                                        duplicates=["_ZN1VD1Ev"])
+        self.assertIsNone(plan["error"])
+        elf = ELFFile(io.BytesIO(out))
+        syms = {s.name: s for s in elf.get_section_by_name(".symtab").iter_symbols()}
+        self.assertEqual(syms["_ZN1VD1Ev"]["st_shndx"], "SHN_UNDEF")
+
+        # It cannot license anything but a requested compiler-only function.
+        _out, plan = OI.derive_deadstrip(raw, ["_ZN1VD1Ev"], duplicates=["_ZN1CD1Ev"])
+        self.assertIn("not requested compiler-only functions", plan["error"])
+
+    def test_duplicate_deadstrip_still_refuses_an_unnamed_section_reference(self):
+        """The exemption is keyed on the NAME, so an anonymous reference is untouched.
+
+        `deadstrip_plan` refuses two shapes of surviving reference: one that names a
+        requested symbol, and one that goes through the unnamed `STT_SECTION` symbol
+        of a section being removed.  Only the first consults `expect`/`duplicates`;
+        after the section is gone there is no symbol left to carry the second, so it
+        stays a refusal no matter what the caller licenses.
+        """
+        import io
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.relocation import RelocationSection
+
+        obj = self.build("struct V { int v; ~V(){} };\n"
+                         "struct C { V a[7]; ~C(); };\n"
+                         "C::~C(){}\n")
+        raw = obj.read_bytes()
+        real = self._section_bytes(raw, "_ZN1VD1Ev")
+
+        # mwcc emits no STT_SECTION entry for this section, so -- as the vague-RTTI
+        # sibling test does -- repurpose a spare symbol into the exact unnamed shape
+        # an ELF producer could legally use, then point the survivor's relocation
+        # through it instead of at `_ZN1VD1Ev`.
+        import struct
+
+        patched = bytearray(raw)
+        elf = ELFFile(io.BytesIO(raw))
+        symtab = elf.get_section_by_name(".symtab")
+        syms = list(symtab.iter_symbols())
+        victim = next(i for i, s in enumerate(syms) if s.name == "_ZN1VD1Ev")
+        shndx = syms[victim]["st_shndx"]
+        spare = next(i for i, s in enumerate(syms)
+                     if s.name.startswith("$") and s["st_shndx"] == shndx)
+        endian = "<" if elf.little_endian else ">"
+        entry = symtab.header["sh_offset"] + spare * 16
+        struct.pack_into(endian + "III", patched, entry, 0, 0, 0)
+        patched[entry + 12] = 0x03  # STB_LOCAL / STT_SECTION
+        struct.pack_into(endian + "H", patched, entry + 14, shndx)
+        found = False
+        for rel in elf.iter_sections():
+            if not isinstance(rel, RelocationSection) or rel.header["sh_info"] == shndx:
+                continue
+            for i, r in enumerate(rel.iter_relocations()):
+                if r["r_info_sym"] != victim:
+                    continue
+                struct.pack_into(endian + "I", patched,
+                                 rel.header["sh_offset"]
+                                 + i * rel.header["sh_entsize"] + 4,
+                                 (spare << 8) | r["r_info_type"])
+                found = True
+        self.assertTrue(found, "no relocation named the victim")
+
+        for kwargs in ({"expect": {"_ZN1VD1Ev": real}},
+                       {"duplicates": ["_ZN1VD1Ev"]}):
+            out, plan = OI.derive_deadstrip(bytes(patched), ["_ZN1VD1Ev"], **kwargs)
+            self.assertIsNone(out)
+            self.assertIn("references compiler-only section[", plan["error"])
+
     def test_exact_vague_rtti_externalization_keeps_named_imports(self):
         """A dedicated inherited RTTI section becomes an import, not lost bytes."""
         import io

--- a/tools/test_tu_production.py
+++ b/tools/test_tu_production.py
@@ -56,10 +56,45 @@ class ProductionTuAdmission(unittest.TestCase):
         with mock.patch.object(
                 TP, "_strict_baseline",
                 side_effect=TP.ProductionTuError("missing")), \
-                mock.patch.object(TP.subprocess, "run",
-                                  return_value=mock.Mock(returncode=3)):
+                mock.patch.object(
+                    TP.subprocess, "run",
+                    return_value=mock.Mock(
+                        returncode=3,
+                        stdout="[4/8] mwccarm\n\n      REFUSED -- pin disagreement\n")):
             with self.assertRaisesRegex(
                     TP.ProductionTuError, "baseline command exited 3"):
+                TP._current_or_bootstrapped_intact_baseline(entries, 7)
+
+    def test_failed_control_bootstrap_reports_what_the_baseline_said(self):
+        """An exit code alone cannot be acted on.
+
+        A remote gate surfaces this exception and nothing else, so the refusal has
+        to carry the baseline's own last words -- blank lines dropped, so a short
+        tail is real output rather than padding.
+        """
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing", "module": "ov047"}}
+        with mock.patch.object(
+                TP, "_strict_baseline",
+                side_effect=TP.ProductionTuError("missing")),                 mock.patch.object(
+                    TP.subprocess, "run",
+                    return_value=mock.Mock(
+                        returncode=1,
+                        stdout="[4/8] mwccarm\n\n      REFUSED -- pin disagreement\n")):
+            with self.assertRaisesRegex(
+                    TP.ProductionTuError,
+                    r"last output: .*mwccarm \| .*REFUSED -- pin disagreement"):
+                TP._current_or_bootstrapped_intact_baseline(entries, 7)
+
+    def test_failed_control_bootstrap_says_so_when_there_was_no_output(self):
+        entries = {"src/actors/Thing.cpp": {
+            "id": "ov047/Thing", "module": "ov047"}}
+        with mock.patch.object(
+                TP, "_strict_baseline",
+                side_effect=TP.ProductionTuError("missing")),                 mock.patch.object(TP.subprocess, "run",
+                                  return_value=mock.Mock(returncode=1, stdout="")):
+            with self.assertRaisesRegex(
+                    TP.ProductionTuError, "the command produced no output"):
                 TP._current_or_bootstrapped_intact_baseline(entries, 7)
 
     def test_rom_gap_control_requires_exact_intact_inventory(self):

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -132,11 +132,21 @@ def _current_or_bootstrapped_intact_baseline(entries, jobs):
             "linkcheck", "--baseline", "--module", module,
             "-j", str(jobs), "--clean",
         ]
-        result = subprocess.run(command, check=False)
+        # Capture rather than inherit.  A remote gate reports this exception and
+        # nothing else, so an exit code on its own says only that the control could
+        # not be rebuilt -- not which of the eight phases refused, which is the one
+        # fact a reader needs.  The output is echoed as it is summarised so an
+        # interactive run still sees the whole log.
+        result = subprocess.run(command, check=False, text=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        print(result.stdout, end="")
         if result.returncode:
+            tail = [line for line in (result.stdout or "").splitlines() if line.strip()]
+            detail = " | ".join(tail[-12:]) or "the command produced no output"
             raise ProductionTuError(
                 "could not bootstrap strict stock control: "
-                f"{first_error}; baseline command exited {result.returncode}")
+                f"{first_error}; baseline command exited {result.returncode}; "
+                f"last output: {detail}")
         try:
             return _strict_baseline(entries)
         except ProductionTuError as fresh_error:

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2281,7 +2281,11 @@ def apply_compiler_only_policy(obj_bytes, entry, homes=None):
         return obj_bytes, {"requested": [], "deadstripped": [], "data": [],
                            "dataExternalized": []}, []
 
-    out, plan = OI.derive_deadstrip(obj_bytes, wanted + data)
+    # `duplicates` licenses a surviving reference to a duplicate-homed function
+    # without claiming the body is the cartridge's; this path has no cartridge bytes
+    # and leaves that proof to rombuild, which passes `expect` instead.
+    out, plan = OI.derive_deadstrip(obj_bytes, wanted + data,
+                                    duplicates=sorted(duplicates))
     if out is None:
         return None, {"requested": wanted, "objisolate": plan}, \
             [f"compiler-only deadstrip refused: {plan.get('error')}"]


### PR DESCRIPTION
Splits the tool policy out of #2179 so it can land ahead of the source that needs it.

## Why it is split

The validator restores all of `tools/` from the base commit, so a PR that carries
both a tool policy and the source that policy licenses is compiled on the box with
**main's** tools. #2179 failed exactly that way: `intact TU link control failed`,
`baseline command exited 1`, while the identical command exits 0 here in every
configuration — standalone, on a fresh worktree, with a cold object cache, after
generating the base commit's control first, and from inside `rombuild.py` with
`build/tu/_baseline` deleted so the bootstrap actually fires.

Landing a *tightening* early is how main went red on 2026-08-30 (#1987 before
#1988). This is a **relaxation with no caller in the tree**, so main stays green:
name neither `expect` nor `duplicates` and the rule is unchanged.

## What it does

A promoted C++ TU that inlines a base's destructor can define a function whose
bytes duplicate a home the ROM already has. The deadstrip rule refused any
surviving reference to a compiler-only function, with no way to say "this one
resolves to a configured home after the link, and the cartridge makes the same
reference". Two callers now hold that licence, because they hold different evidence:

- `expect` carries the cartridge's bytes — it licenses the reference **and** demands
  the body match, as far as an unlinked object allows: every relocated word is
  masked out, and `rombuild._duplicate_body_reasons` links the body and compares
  exactly those masked words. Neither half proves byte-identity alone.
- `duplicates` licenses the reference alone, for `tubuild.apply_compiler_only_policy`'s
  scratch link path, which has no cartridge bytes and leaves the body proof to the
  production build. That path had been left on the un-relaxed rule.

Neither may name anything but a requested compiler-only function.

Also: the strict-stock-control bootstrap now captures its subprocess output and
quotes the last twelve non-blank lines into its refusal. `baseline command exited 1`
narrowed an eight-phase command that returns 1 from thirty-odd places to "one of
those"; a remote gate reports that exception and nothing else.

## Verification

- `tools/test_objisolate.py` 40 pass (was 39). The new test closes a gap: mwcc emits
  no `STT_SECTION` symbol for the fixture's section, so the anonymous-section
  refusal was never exercised. It repurposes a spare `$`-prefixed mapping symbol in
  the victim's own section and checks the refusal under both licensing paths.
- `tools/test_tu_production.py` 22 pass (was 20).
- Full rebuild on main with these tools and no source change: **11,088 reproducing,
  mismatching 0, module fidelity 106/106 exact, 100.000000%**.
- `check_dead_references`: no new dead references.

#2179 will be rebased onto this once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsXWgEM3Gtbqs6zEdwLMYV
