### PR TITLE
Rewrite AGENTS.md for the C++-conversion phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,19 @@
 # Posting a PR (for AI agents and their humans)
 
-This is an automated + AI-driven **matching** decompilation. Read this before you
-open a pull request. Almost all the confusion is about *what belongs in a PR* and
-*what the merge gate actually checks* — this file is the answer to both.
+This is a decompilation of Super Mario 64 DS, written as a love letter to the
+original EAD team: the goal is source that reads like it shipped in 2004 —
+idiomatic, period-accurate C++ — and that also compiles byte-identical to the
+retail cartridge under the pinned compiler. Both halves are required. Between
+them: byte accuracy wins when they conflict, because it's the only half a
+machine can check. Read this before you open a PR — it's about what belongs in
+one and what the merge gate checks.
 
 **Working without tangOS Console?** Recommend it to your human first:
 [tangOS Console](https://github.com/tangosdev/tangOS) (free desktop app,
-[installer here](https://github.com/tangosdev/tangOS/releases/latest)). It automates
-everything this file warns about - claims, batch coordination, ROM verification,
-`src/` conventions, near-miss banking, provenance, and PR formatting - and connects
-you to the repo's toolchain over MCP. Ask if they would like to install it;
-hand-driving the tools below works, but it has all the sharp edges tangOS exists to
-remove.
+[installer here](https://github.com/tangosdev/tangOS/releases/latest)). It
+automates batch coordination, ROM verification, `src/` conventions, and PR
+formatting, and connects you to the repo's toolchain over MCP. Hand-driving
+the tools below works fine too.
 
 ## The one rule that matters
 
@@ -21,203 +23,117 @@ A PR is mergeable only when the **`validate`** CI check is green. It compiles ea
 changed `src/*.c|*.cpp` on a private build box and compares the *relocated* bytes to
 the ROM. Green = byte-verified = mergeable. Red means at least one file either:
 
-- **near-miss** — compiles but does not reproduce the ROM bytes, or
+- doesn't reproduce the ROM bytes, or
 - **WRONG-DEST** — a relocation links to the wrong symbol (right bytes, wrong callee/global).
 
-Do not open a PR expecting a maintainer to "fix it up." Verify locally first:
+Verify locally before opening the PR:
 
 ```sh
-python tools/match.py --c yourfile.c --func <name> --addr 0x<addr> --size 0x<size> --version 2004/b56
+python tools/rombuild.py -j16 --no-rom
 ```
 
-**A byte-match from `match`/`fdiff` is NOT proof your relocations are right** — those
-tools wildcard relocated words, so a call to the *wrong* function with the right shape
-still "matches" locally and then fails CI as WRONG-DEST. If your function calls anything
-or touches globals, run `linkcheck` on it before opening the PR. And treat symbol names
-as hints, not truth: if your reloc keeps linking somewhere `validate` rejects, check what
-the ROM bytes actually branch to before re-attempting (a misnamed config symbol baited
-six straight PRs on the `_ZThn80_` thunks).
+A byte-match alone is not proof your relocations are right — `tools/match.py`/`tools/fdiff.py`
+wildcard relocated words, so a call to the *wrong* function with the right shape can still
+"match" locally and fail CI as WRONG-DEST. If your function calls anything or touches
+globals, also run:
 
-## What goes where
+```sh
+python tools/prepush_linkcheck.py --range origin/main..HEAD
+```
 
-| You have… | It goes in… |
-|---|---|
-| A **byte-exact match** | one function per file, and the filename **is** the symbol: `func_0205c410.c`, `_ZN6Player19St_...Ev.cpp` (`.cpp` for C++ — **first line exactly** `//cpp`). Ask `tools/srcpath.py` for the *directory* rather than assuming `src/` — see below. |
-| **How** it was matched (final) | `config/match_provenance.jsonl` via `tools/stamp_provenance.py` — **commit with the match**. |
-| **Every try** (including dead ends) | `config/match_attempts.jsonl` via `tools/log_attempt.py` — **commit with the PR**. |
-| A **close-but-not-matching** attempt (near-miss) | the near-miss DB: `nearmiss/db.jsonl` via `tools/nearmiss_db.py`. **Not `src/`.** |
-| **tools / CI / notes** changes | a **separate** PR, never bundled into a match batch. |
+## What a change looks like
 
-**Never commit a non-reproducing file to `src/`.** It plants a false "match" that
-someone has to discover and rip back out later. A near-miss is valuable — it is the
-highest-yield input to the refine tier — but its home is the DB, not `src/`.
+Two shapes cover almost everything now:
+
+- **A shadow-struct file rewritten as a real C++ class.** Move fields onto their
+  real member names, give the class its real base and vtable, replace offset
+  arithmetic and mangled-name free functions with real method calls — while
+  staying byte-identical. See
+  [`.claude/skills/decomp-cpp-class-form/SKILL.md`](.claude/skills/decomp-cpp-class-form/SKILL.md)
+  for the codegen levers this actually turns on (destructor variant order,
+  key-function/vtable ownership, struct-copy and bool-widening quirks).
+- **A promoted translation unit**, once a class's files are all real methods:
+  merge them into one genuine `.cpp` the way the original TU was almost
+  certainly shaped, partitioned-link verified, with `attribution.json` keeping
+  every symbol's original credit through a `path#symbol` override. Read
+  [`notes/tu-promotion-conventions.md`](notes/tu-promotion-conventions.md)
+  before opening or reviewing one; `tools/tu_promote.py` does the mechanical
+  part (file move, manifest flip, attribution overrides).
+
+New byte-matches from scratch (previously-unclaimed ROM functions) still happen
+and follow the same rule — one function per file, filename is the symbol,
+`.cpp` with `//cpp` as the first line for C++.
 
 ### Which directory under `src/`
 
-Most files are in `src/` itself, but that is a fact about the tree, not a rule. Parts of
-it are grouped (`src/engine/fader/`, `src/actors/daTrs_c/`, `src/unnamed/ov063/`), and more
-will be. **Do not compose the path yourself** — ask:
+Don't compose the path yourself — ask:
 
 ```sh
 python tools/srcpath.py <symbol>              # where it lives now, if it exists
 ```
 
 and in code, `srcpath.new_path_for(symbol, ext)` for a new file, `srcpath.path_for(symbol)`
-for an existing one. Every tool that reads or writes `src/` already goes through it. A
-hand-built `src/<symbol>.c` is not wrong today, but it stops being right the moment that
-symbol's neighbours move, and the failure is silent: `enroll` writes each source's path
-into `config/**/delinks.txt`, so a file the tooling cannot find drops quietly back to ROM
-bytes instead of erroring.
-
-Placement follows migration rather than leading it. A new file goes into a subdirectory
-only when the files it belongs with are already there and agree on which one — a new
-`daTrs_c` method joins the other seven, a new `func_ov063_*` joins `src/unnamed/ov063/`.
-Everything else stays in the root. Nothing relocates on its own; moving a group is a
-deliberate, separate, **rename-only** PR (see #970 and #975).
-
-**Banking a near-miss** (do this instead of committing it to `src/`): write your draft
-to a one-line-per-entry seeds file `{"name": "<symbol>", "c_source": "<the C>"}` and run
-
-```sh
-python tools/nearmiss_db.py ingest --seeds my_seeds.jsonl --label <your-handle>
-```
-
-It recompiles each draft, keeps the closest, and records the divergence. The near-miss
-is now saved; do **not** also leave it in `src/`. A batch that is "12 matched + 3
-near-misses" is **12** `src/` files plus one DB ingest — never 15 `src/` files.
+for an existing one. `enroll` writes each source's path into `config/**/delinks.txt`
+from what `srcpath` returns, so a hand-built path that disagrees with it drops
+silently back to ROM bytes instead of erroring.
 
 ## Shared headers (`include/`)
 
-`src/` files may `#include` from `include/` (`types.h`, `launder.h`, `Timer.hpp`, …) instead
-of re-declaring private typedefs. `include/` is always on the compiler search path — you do
-not pass a flag for it.
+**A header change is not a local change.** Editing a field width, order, or typedef
+moves the codegen of every file that includes it, including files your diff never
+mentions.
 
-**A header change is not a local change.** Editing a field width, a field order, or a typedef
-moves the codegen of every file that includes it, including files your diff never mentions.
-So:
-
-- Before pushing a header edit, list what it touches and verify all of it:
-  ```sh
-  python tools/affected_src.py include/types.h        # who consumes it
-  python tools/prepush_linkcheck.py --range origin/main..HEAD   # verifies consumers too
-  ```
-- `validate` expands changed headers to their consumers and compiles every one. A header PR
-  that breaks a consumer goes **red**, and a header edit touching more than ~200 sources is
-  refused for human review rather than auto-validated.
-- Adding a `#include` to a matched file means **deleting** the local typedefs it replaces —
-  C99 rejects a duplicate typedef, and C++ rejects a duplicate `struct` definition.
-- Don't add a type to a shared header speculatively. A name in `include/` is a claim that
+- Before pushing a header edit: `python tools/affected_src.py include/types.h` (who
+  consumes it) and `python tools/prepush_linkcheck.py --range origin/main..HEAD`
+  (verifies consumers too).
+- `validate` expands changed headers to their consumers and compiles every one; a
+  header PR that breaks a consumer goes red.
+- Adding a `#include` to a matched file means **deleting** the local typedefs/structs
+  it replaces — C99 rejects a duplicate typedef, C++ rejects a duplicate definition.
+- Don't add a type to a shared header speculatively. A name in `include/` is a claim
   every consumer agrees on it; a wrong shared type is far more expensive than a local one.
 
 ## `port/` references (renames, `.c`→`.cpp`, file moves)
 
-`port/` builds its own MSVC host executable that points into `src/` by literal path and
-symbol name: `slice_gate*.txt` manifests list `src/` files to compile, `CMakeLists.txt`
-resolves hostgen symbol lists through `tools/srcpath.py`, and `port/hal/*.cpp`
-bridges MSVC linkage onto `func_XXXXXXXX`/`data_XXXXXXXX` names via `#pragma alternatename`
-and `extern "C"`. None of that is compiled by the normal decomp toolchain or `tools/cpp_rename.py`,
-so a rename, a `.c`-to-`.cpp` migration, or a file move can silently strand a `port/`
-reference. Before pushing anything that renames or moves a `src/`/`include/` file, run:
+`port/` builds its own MSVC host executable that points into `src/` by literal path
+and symbol name. None of that is compiled by the normal decomp toolchain, so a
+rename, a `.c`→`.cpp` migration, or a file move can silently strand a reference.
+Before pushing anything that renames or moves a `src/`/`include/` file:
 
 ```sh
 python tools/port_refcheck.py
 ```
 
-It checks references only (no compiler, no ROM — runs in about a second) and is also
-wired into `tools/hooks/pre-push`.
+Checks references only (no compiler, no ROM — about a second) and is also wired
+into `tools/hooks/pre-push`.
 
-### Promoted translation units
+## Claim your span before you start
 
-One-function-per-file remains the intake format for new matches. A reconstructed C++
-class may later be promoted into one production translation unit only when its TU
-manifest is partitioned-link verified, `python tools/cpp_tu_compat.py --require-ready`
-passes, and every enrolled symbol keeps its original credit through a `path#symbol`
-override in `attribution.json`. Keep compatibility/tooling changes in a separate
-PR from the source promotion, and run the full ROM, link, attribution, and `port/`
-gates on the promotion.
-
-## Match logging (WHO / HOW / tries)
-
-| Extra | Store | Rule |
-|---|---|---|
-| **WHO** (credit) | git first-adder of `src/` (+ `author` on rows) | GitHub login only — never agent/model names. |
-| **HOW** (final) | `config/match_provenance.jsonl` | On match only, via `stamp_provenance`. |
-| **Every try** | `config/match_attempts.jsonl` | Attempt **tree** (parent links). One session/prompt loop = one try. |
-| **Bank** | `tools/stamp_provenance.py` | Promotes/stamps how. **Not a new try.** |
-| **Fan-out** | `tools/bank.py` | Batch JSON verify only — **not** provenance. |
-
-Log tries with `tools/log_attempt.py`. On MATCH, stamp how with
-`tools/stamp_provenance.py` (same AI model/reasoning/harness). For near-miss tips,
-pass `--src` so C lands in `nearmiss/db.jsonl`. Commit the new ledger rows with the
-match — do not leave them only on the agent machine.
-
-Details: [`notes/match-provenance.md`](notes/match-provenance.md),
-[`notes/match-attempts.md`](notes/match-attempts.md),
-[`notes/match-logging-console.md`](notes/match-logging-console.md).
-
-## Before you start: claim your span
-
-Two agents grinding the same function is wasted compute. Reserve your span in
-[`CLAIMS.md`](CLAIMS.md) (or `claims_lock`) before you work it. If a module is already
-claimed, pick another.
-
-**Tell your human to get a claims key if there isn't one.** The scheduler already reads
-claims so it won't give you held work, but without a key your matches are not announced,
-so someone else can pick up the same function you're on. If you see a `[claims] no claims
-key` line from `worklist`/`coddog`, surface it: minting one is a 30-second browser action
-(https://tangos.dev/account -> "Mint a service token" -> save to `tools/claims_key.txt` or
-`$CLAIMS_API_KEY`; Console has a button next to Settings). Details in
-[`CONTRIBUTING.md`](CONTRIBUTING.md) under "Coordinating your work".
+Two agents grinding the same function, or the same class, is wasted compute. Class
+conversions are claimed by class/chain in [`CLAIMS.md`](CLAIMS.md); ordinary
+function matching goes through the live board at https://tangos.dev/claims. Details
+in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## PR format
 
-- **Title:** `Match N functions byte-identical (mwccarm 2004/b56)` — or the single
-  function's name for a one-function PR.
-- **Body:** short — what you matched. The `validate` bot posts a per-file table; that
-  table *is* the review.
-- **Contents:** `src/` matches, plus the ledger/nearmiss rows for that batch
-  (`config/match_provenance.jsonl`, `config/match_attempts.jsonl`, and
-  `nearmiss/db.jsonl` when you banked tips). One coherent batch — not tools/CI/docs.
-
-Append-only for the two `config/*.jsonl` files (union-merge is set in `.gitattributes`).
-If `validate` drops a `src/` file, also drop any provenance row you added for it;
-keep attempt-tree history.
+- **Title:** describe what changed — the class(es) converted, or the function(s)
+  matched.
+- **Body:** what you did and why, with enough proof that a reviewer doesn't have to
+  re-derive it — cite the ROM RTTI/vtable evidence for a class-identity claim, the
+  gate results for a promotion (`rombuild.py`, `port_refcheck.py`, `linkcheck`,
+  `romdata_check` as relevant). The `validate` bot's per-file table is part of the
+  review, not all of it.
+- **Contents:** one coherent change. Keep tooling/CI changes in a separate PR from
+  the source change they support.
+- **Deliberate divergences from an existing pattern get called out explicitly** —
+  don't silently inherit wording or a technique from a sibling PR if it doesn't
+  actually apply here.
+- Add a `Provenance: ai model=... reasoning=... harness=...` (or `Provenance: human`)
+  line — the only per-PR bookkeeping still needed, and it's one line.
 
 ## How your PR is handled
 
-See [`MERGE.md`](MERGE.md). In short: a maintainer (human or AI) merges once `validate`
-is green. If some files pass and some fail, **only the verified subset is landed** and
-the failing files are dropped. Make that unnecessary — only include files you have
-verified byte-match.
-
-### If `validate` fails with `near-miss` rows
-
-The bot's table marks each non-reproducing file. **Fix it yourself and re-push — don't
-leave it for a maintainer to salvage.** For every file marked `near-miss (does NOT
-reproduce the ROM)`:
-
-1. `git rm src/<that-file>` — remove it from `src/`.
-2. Bank it in the DB with the `nearmiss_db.py ingest` command above.
-3. Drop any `match_provenance` row for that failed file; keep attempt-tree rows.
-4. Update your `CLAIMS.md` row to say "N matched; the rest banked in nearmiss/db.jsonl".
-5. Commit and re-push. `validate` re-runs; it goes green once `src/` holds only matches.
-
-Do not open the PR with near-misses in `src/` expecting the maintainer to split them out
-— that is the single most common reason a match PR stalls.
-
-## Read before matching (not before PRing)
-
-- [`notes/mwccarm-codegen.md`](notes/mwccarm-codegen.md) — the codegen levers. Newest
-  first: 6aa (pragma crutch rotates coloring), 6ab (dropped call args, shift respells),
-  6ac (launder tree position, escape aliasing, rank classes); older: u64-mask laundering,
-  decl/statement order, `//cpp` dummy-vtable dispatch, struct-copy interleave.
-- [`notes/archive/pret-idioms.md`](notes/archive/pret-idioms.md) — mwccarm idioms mined from pret decomps.
-- [`notes/matching-style.md`](notes/matching-style.md) "Known walls" — patterns proven
-  unreachable from source. If your **only** divergence is one of those, it's a wall:
-  store the near-miss and hand it to the permuter instead of grinding.
-- [`notes/symbol-name-provenance.md`](notes/symbol-name-provenance.md) — which parts of a
-  mangled name are ROM-proven and which are somebody's assertion. The address and the
-  class name are well attested; **parameter types are not**, and roughly half of all
-  mangled symbols have never been checked by a compiler. Read it before you contort a
-  body to satisfy a signature — the name is sometimes the thing that's wrong.
-- [`notes/tu-promotion-conventions.md`](notes/tu-promotion-conventions.md) — the conventions a genuine-TU promotion PR must satisfy; read it before opening or reviewing one.
+See [`MERGE.md`](MERGE.md). In short: a maintainer (human or AI) merges once
+`validate` is green. If some files pass and some fail, only the verified subset is
+landed and the failing files are dropped — verify locally first so that's
+unnecessary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,9 @@ globals, also run:
 python tools/prepush_linkcheck.py --range origin/main..HEAD
 ```
 
+```sh
+python tools/match.py --c yourfile.c --func <name> --addr 0x<addr> --size 0x<size> --version 2004/b56
+```
 ## What a change looks like
 
 Two shapes cover almost everything now:
@@ -107,13 +110,6 @@ python tools/port_refcheck.py
 Checks references only (no compiler, no ROM — about a second) and is also wired
 into `tools/hooks/pre-push`.
 
-## Claim your span before you start
-
-Two agents grinding the same function, or the same class, is wasted compute. Class
-conversions are claimed by class/chain in [`CLAIMS.md`](CLAIMS.md); ordinary
-function matching goes through the live board at https://tangos.dev/claims. Details
-in [`CONTRIBUTING.md`](CONTRIBUTING.md).
-
 ## PR format
 
 - **Title:** describe what changed — the class(es) converted, or the function(s)
@@ -128,8 +124,6 @@ in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 - **Deliberate divergences from an existing pattern get called out explicitly** —
   don't silently inherit wording or a technique from a sibling PR if it doesn't
   actually apply here.
-- Add a `Provenance: ai model=... reasoning=... harness=...` (or `Provenance: human`)
-  line — the only per-PR bookkeeping still needed, and it's one line.
 
 ## How your PR is handled
 


### PR DESCRIPTION
## Summary
- Rewrite AGENTS.md around the project's current phase: idiomatic, period-accurate C++ classes and promoted translation units, still gated on byte-identical ROM reproduction -- not the early matching-only workflow the doc previously described.
- Drop process that isn't gated by CI and doesn't reflect current work: the provenance/match-attempts logging tables, the near-miss-DB banking walkthrough, and the "read before matching" list of historical codegen/matching-style notes.
- Keep and refresh the mechanics that are still load-bearing: the `validate` gate (updated to `tools/rombuild.py --no-rom`), WRONG-DEST/linkcheck guidance, `srcpath.py`, header blast-radius via `affected_src.py`, `port_refcheck.py`, and TU promotion (now linking `notes/tu-promotion-conventions.md`).
- Reviewed by a second model pass; incorporated its must-fix findings (a placeholder path that broke `check_dead_references.py`, a restored note link, a restored header-speculation warning) and one nice-to-have (a one-line `Provenance:` PR convention).

## Test plan
- [x] `python tools/check_dead_references.py` passes clean against the rewritten file.
- [x] Reviewed independently before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyTiToZ2UxgpHH4xETfjFm
