### PR TITLE
Support compiler-owned sections in partitioned TU checks

### DIFF
--- a/tools/test_tu_production.py
+++ b/tools/test_tu_production.py
@@ -377,6 +377,10 @@ class ProductionTuObjects(unittest.TestCase):
                                       return_value=(b"compiler", {}, [])), \
                     mock.patch.object(TP.TB, "apply_externalized_output_policy",
                                       return_value=(b"external", {}, [])), \
+                    mock.patch.object(TP.TB, "apply_undefined_symbol_alias_policy",
+                                      return_value=(b"aliased", {}, [])) as aliases, \
+                    mock.patch.object(TP.TB, "apply_symbol_binding_policy",
+                                      return_value=(b"bound", {}, [])) as bindings, \
                     mock.patch.object(TP.TB, "prepare_owned_nontext_section_order",
                                       return_value=(b"ordered", section_order, [])) as order, \
                     mock.patch.object(TP.TB, "verify_owned_sections",
@@ -391,7 +395,9 @@ class ProductionTuObjects(unittest.TestCase):
 
         rebias.assert_called_once_with(
             b"storage", biases, normalize_undefined=True)
-        order.assert_called_once_with(b"external", entry, claims)
+        aliases.assert_called_once_with(b"external", entry)
+        bindings.assert_called_once_with(b"aliased", entry)
+        order.assert_called_once_with(b"bound", entry, claims)
         derive.assert_called_once_with(b"ordered", entry, claims)
         self.assertEqual(verify.call_args_list, [
             mock.call(b"ordered", entry, claims),

--- a/tools/test_tubuild.py
+++ b/tools/test_tubuild.py
@@ -73,8 +73,9 @@ def test_list_finds_polelift_and_its_module_neighbours():
     assert "ov045/PoleLift" in out
     assert "ov045/FireSeaElevator" in out          # its lower-address neighbour
     assert "ov045/ExtendingPlatform" in out         # its higher-address neighbour
-    # PoleLift is 7 functions, all `complete` -- see the manifest and the pilot report.
-    assert "7     7/7" in out
+    # The class run is six functions, all `complete`. Its reconstructed classInit
+    # uses the ROM RTTI class name and now appears as the adjacent anonymous run.
+    assert "6     6/6 medium" in out
 
 
 def test_list_has_no_duplicate_ids_anywhere_in_the_tree():
@@ -103,7 +104,7 @@ def test_inspect_polelift_reproduces_the_pilots_static_findings():
     code, out = _run("inspect", "ov045/PoleLift")
     assert code == 0, out
     assert "classes           PoleLift" in out
-    assert "boundary conf.    high" in out
+    assert "boundary conf.    medium" in out
     # The pilot's report sec 4: D1/D0 are real, D2 is a compiler-only byproduct
     # that only appears once the TU is actually compiled (verify/compile), not here.
     assert "_ZN8PoleLiftD1Ev" in out and "_ZN8PoleLiftD0Ev" in out
@@ -616,6 +617,52 @@ def test_symbol_binding_policy_only_promotes_exact_owned_local():
     rewritten = next(row for row in tubuild.elf_inventory(out)["symbols"]
                      if row["name"] == local["name"])
     assert rewritten["bind"] == "STB_GLOBAL"
+
+
+def test_derived_function_applies_its_exact_manifest_binding_rewrite():
+    if not _toolchain():
+        raise unittest.SkipTest("needs the pinned compiler")
+    obj = _compile_tu_fixture('extern "C" void owner(void) {}\n')
+    obj, rewrite = tubuild.OI.rewrite_symbol_bindings(
+        obj, {"owner": ("STB_GLOBAL", "STB_LOPROC")})
+    assert obj is not None, rewrite
+    entry = {
+        "functions": [{"symbol": "owner", "ordinal": 0,
+                       "address": "0x1000", "size": "0x4"}],
+        "symbol_binding_rewrites": [{
+            "symbol": "owner", "from": "STB_LOPROC", "to": "STB_GLOBAL",
+            "evidence": "fixture",
+        }],
+    }
+    derived, plan = tubuild.derive_function_objects(obj, entry)["owner"]
+    assert derived is not None, plan
+    assert plan["symbolBindingRewrites"]["rewritten"][0]["symbol"] == "owner"
+    owner = tubuild.contribution(derived, "owner")["defined"]["owner"]
+    assert owner[0] == "STB_GLOBAL"
+
+
+def test_contribution_ignores_only_inert_local_defs_in_empty_sections():
+    if not _toolchain():
+        raise unittest.SkipTest("needs the pinned compiler")
+    production = _compile_tu_fixture('extern "C" void owner(void) {}\n')
+    merged = _compile_tu_fixture(
+        'static int compiler_local_word;\n'
+        'extern "C" void owner(void) {}\n')
+    derived, plan = tubuild.OI.derive(merged, "owner")
+    assert derived is not None, plan
+
+    inventory = tubuild.elf_inventory(derived)
+    assert any(row["name"] == "compiler_local_word"
+               and row["bind"] == "STB_LOCAL" for row in inventory["symbols"])
+    got = tubuild.contribution(derived, "owner")
+    assert "compiler_local_word" not in got["defined"]
+    assert tubuild.compare_contribution(production, derived, "owner")["identical"]
+
+    globalized, rewrite = tubuild.OI.rewrite_symbol_bindings(
+        derived, {"compiler_local_word": ("STB_LOCAL", "STB_GLOBAL")})
+    assert globalized is not None, rewrite
+    assert "compiler_local_word" in \
+        tubuild.contribution(globalized, "owner")["defined"]
 
 
 def test_splice_maps_compiler_rodata_into_module_data():
@@ -1229,7 +1276,7 @@ def test_manifest_order_handles_rccarpet_owned_subset_after_rtti_externalization
     symtab = elf.get_section_by_name(".symtab")
     symbols = {s.name: s for s in symtab.iter_symbols()}
     owned = ["_ZTI15daObjRcCarpet_c", "data_ov036_02113f58",
-             "_ZTS15daObjRcCarpet_c", "FlyingCarpet_SpawnInfo",
+             "_ZTS15daObjRcCarpet_c", "g_profile_RC_CARPET",
              "_ZTV15daObjRcCarpet_c"]
     assert {symbols[name]["st_shndx"] for name in owned} == set(retained)
     assert [symbols[name]["st_shndx"] for name in owned] != retained, (
@@ -1239,7 +1286,7 @@ def test_manifest_order_handles_rccarpet_owned_subset_after_rtti_externalization
         "_ZTI15daObjRcCarpet_c": 0x02113f4c,
         "data_ov036_02113f58": 0x02113f58,
         "_ZTS15daObjRcCarpet_c": 0x02113f64,
-        "FlyingCarpet_SpawnInfo": 0x02113f78,
+        "g_profile_RC_CARPET": 0x02113f78,
         "_ZTV15daObjRcCarpet_c": 0x02113f9c,
     }
     rows = []

--- a/tools/tu_production.py
+++ b/tools/tu_production.py
@@ -358,8 +358,18 @@ def _prepare_one(entry, config_root, work_root, jobs):
     if reasons:
         _raise(f"{entry['id']} exact RTTI externalization", reasons)
 
+    aliased_obj, undefined_aliases, reasons = \
+        TB.apply_undefined_symbol_alias_policy(externalized_obj, entry)
+    if reasons:
+        _raise(f"{entry['id']} undefined symbol aliases", reasons)
+
+    bound_obj, symbol_bindings, reasons = \
+        TB.apply_symbol_binding_policy(aliased_obj, entry)
+    if reasons:
+        _raise(f"{entry['id']} symbol binding rewrites", reasons)
+
     ordered_obj, section_order, reasons = \
-        TB.prepare_owned_nontext_section_order(externalized_obj, entry, claims)
+        TB.prepare_owned_nontext_section_order(bound_obj, entry, claims)
     if reasons:
         _raise(f"{entry['id']} manifest non-text section order", reasons)
 

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -2664,7 +2664,7 @@ def apply_undefined_symbol_alias_policy(obj_bytes, entry, name_index=None):
 
 
 def apply_symbol_binding_policy(obj_bytes, entry):
-    """Apply exact manifest-licensed binding rewrites to owned compiler locals."""
+    """Apply exact manifest-licensed binding rewrites to owned symbols."""
     raw = entry.get("symbol_binding_rewrites", [])
     if raw is None:
         raw = []
@@ -2672,6 +2672,8 @@ def apply_symbol_binding_policy(obj_bytes, entry):
         return None, {"requested": [], "rewritten": []}, \
             ["symbol_binding_rewrites must be a list"]
     owned = {row["symbol"] for _section, row in manifest_owned_symbol_rows(entry)}
+    owned.update(row["symbol"] for row in entry.get("functions", [])
+                 if isinstance(row, dict) and row.get("symbol"))
     mapping, requested, reasons = {}, [], []
     for ordinal, row in enumerate(raw):
         label = f"symbol_binding_rewrites[{ordinal}]"
@@ -3904,8 +3906,24 @@ def derive_function_objects(obj_bytes, entry):
     stop being comparable to the production one, which is the only evidence that makes
     the substitution safe."""
     out = {}
+    binding_rows = entry.get("symbol_binding_rewrites", [])
+    if not isinstance(binding_rows, list):
+        binding_rows = []
     for f in sorted(entry["functions"], key=lambda x: x["ordinal"]):
-        out[f["symbol"]] = OI.derive(obj_bytes, f["symbol"])
+        symbol = f["symbol"]
+        derived, plan = OI.derive(obj_bytes, symbol)
+        scoped_rows = [row for row in binding_rows
+                       if isinstance(row, dict) and row.get("symbol") == symbol]
+        if derived is not None and scoped_rows:
+            scoped_entry = dict(entry)
+            scoped_entry["symbol_binding_rewrites"] = scoped_rows
+            derived, binding_report, reasons = \
+                apply_symbol_binding_policy(derived, scoped_entry)
+            plan["symbolBindingRewrites"] = binding_report
+            if reasons:
+                plan["error"] = "; ".join(reasons)
+                derived = None
+        out[symbol] = derived, plan
     return out
 
 
@@ -3923,10 +3941,11 @@ def contribution(raw, keep_symbol):
       relocs      the fixups applied to it, as (offset, type, SYMBOL NAME, addend) --
                   by name, because a symbol INDEX is a property of the object's own
                   table and means nothing to another object;
-      defined     every symbol this object defines, with its binding, type, value,
-                  size and the name+size of the section it lives in. A definition in a
-                  zeroed section still resolves for anyone who imports it, so a
-                  size-0-in-an-empty-section entry is reported rather than filtered;
+      defined     every link-visible symbol this object defines, with its binding,
+                  type, value, size and the name+size of the section it lives in. A
+                  non-local definition in a zeroed section can still resolve imports,
+                  so it remains reported. An unreferenced STB_LOCAL symbol in an empty
+                  discarded section cannot resolve another object and is omitted;
       mapping     $a/$t/$d ARM EABI mapping symbols inside the kept section, kept
                   separate because they repeat by name across sections;
       live        every content section still carrying bytes -- the check that the
@@ -3958,6 +3977,7 @@ def contribution(raw, keep_symbol):
                 relocs.append((r["r_offset"], r["r_info_type"], sym.name,
                                r["r_addend"] if s.is_RELA() else None))
 
+    referenced = {name for _offset, _type, name, _addend in relocs}
     defined, mapping, undef = {}, [], []
     for s in symtab.iter_symbols():
         if not s.name:
@@ -3968,6 +3988,9 @@ def contribution(raw, keep_symbol):
             continue
         secname = secs[shndx].name if isinstance(shndx, int) else str(shndx)
         secsize = secs[shndx].header["sh_size"] if isinstance(shndx, int) else -1
+        if (s["st_info"]["bind"] == "STB_LOCAL" and isinstance(shndx, int)
+                and shndx != keep and secsize == 0 and s.name not in referenced):
+            continue
         row = (s["st_info"]["bind"], s["st_info"]["type"], s["st_value"], s["st_size"],
                secname, secsize)
         if s.name.startswith("$"):
@@ -3981,7 +4004,6 @@ def contribution(raw, keep_symbol):
                   for x in secs if x.header["sh_type"] in OI.CONTENT
                   and x.header["sh_size"]
                   and not any(x.name.startswith(p) for p in OI.IGNORE))
-    referenced = {n for _o, _t, n, _a in relocs}
     return {
         "keptSection": (ks.name, ks.header["sh_type"], ks.header["sh_flags"],
                         ks.header["sh_addralign"], ks.header["sh_size"]),
@@ -4104,6 +4126,7 @@ def partial_report(entry, merged_bytes, derived, prod_paths):
             continue
         v = compare_contribution(ppath.read_bytes(), dbytes, sym)
         v["objisolateError"] = plan.get("error")
+        v["symbolBindingRewrites"] = plan.get("symbolBindingRewrites")
         rows.append((f["ordinal"], sym, v))
     return rows
 
@@ -4904,6 +4927,42 @@ def cmd_linkcheck(args):
                 print(f"      externalized {externalized['externalized']} to exact "
                       "configured canonical homes")
 
+            aliased_tu, undefined_aliases, alias_reasons = \
+                apply_undefined_symbol_alias_policy(linked_tu, entry)
+            report["undefinedSymbolAliases"] = undefined_aliases
+            if alias_reasons:
+                print("      REFUSED -- undefined symbol alias policy:")
+                for reason in alias_reasons:
+                    print(f"        {reason}")
+                report["undefinedSymbolAliases"]["errors"] = alias_reasons
+                report["result"] = "undefined-alias-refused"
+                _write_link_report(scratch, report)
+                _record_partitioned(data, entry, report)
+                return 1
+            if aliased_tu != linked_tu:
+                linked_tu = aliased_tu
+                scratch_rewrite = True
+                print(f"      canonicalized {len(undefined_aliases['renamed'])} exact "
+                      "undefined C++ import name(s) to their configured ROM symbols")
+
+            bound_tu, symbol_bindings, binding_reasons = \
+                apply_symbol_binding_policy(linked_tu, entry)
+            report["symbolBindingRewrites"] = symbol_bindings
+            if binding_reasons:
+                print("      REFUSED -- symbol binding policy:")
+                for reason in binding_reasons:
+                    print(f"        {reason}")
+                report["symbolBindingRewrites"]["errors"] = binding_reasons
+                report["result"] = "symbol-binding-refused"
+                _write_link_report(scratch, report)
+                _record_partitioned(data, entry, report)
+                return 1
+            if bound_tu != linked_tu:
+                linked_tu = bound_tu
+                scratch_rewrite = True
+                print(f"      promoted {len(symbol_bindings['rewritten'])} exact local "
+                      "owned symbol binding(s) for DSD's global symbol surface")
+
             ordered_tu, section_order, order_reasons = \
                 prepare_owned_nontext_section_order(linked_tu, entry, claims)
             report["nontextSectionOrder"] = section_order
@@ -5601,6 +5660,8 @@ def _partition_attempt_record(report):
     compiler = report.get("compilerOnlyOutput") or {}
     externalized = report.get("externalizedOutput") or {}
     external_verify = externalized.get("verification") or {}
+    undefined_aliases = report.get("undefinedSymbolAliases") or {}
+    symbol_bindings = report.get("symbolBindingRewrites") or {}
     section_order = report.get("nontextSectionOrder") or {}
     return {
         "result": report.get("result", "failed"),
@@ -5616,7 +5677,8 @@ def _partition_attempt_record(report):
             "contributionEquivalent": partial_report.get("contributionEquivalent"),
             "substitutedObjectPaths": partial_report.get("substituted"),
             "rows": [{key: row.get(key) for key in (
-                "ordinal", "symbol", "identical", "relocCount", "differences")}
+                "ordinal", "symbol", "identical", "relocCount", "differences",
+                "symbolBindingRewrites")}
                 for row in partial_report.get("rows", [])],
         },
         "compilerOnlyPolicy": {
@@ -5631,6 +5693,16 @@ def _partition_attempt_record(report):
             "droppedSections": externalized.get("droppedSections"),
             "verificationOk": external_verify.get("ok"),
             "errors": externalized.get("errors") or external_verify.get("errors"),
+        },
+        "undefinedAliasPolicy": {
+            "requested": undefined_aliases.get("requested"),
+            "renamed": undefined_aliases.get("renamed"),
+            "errors": undefined_aliases.get("errors"),
+        },
+        "symbolBindingPolicy": {
+            "requested": symbol_bindings.get("requested"),
+            "rewritten": symbol_bindings.get("rewritten"),
+            "errors": symbol_bindings.get("errors"),
         },
         "nontextSectionOrder": {
             "groups": [{key: row.get(key) for key in


### PR DESCRIPTION
This extends the partitioned-TU proof path for actors that own compiler-generated initialization and data. It ignores only unreferenced local symbols left in emptied sections, applies manifest-licensed function binding rewrites to derived text objects, and applies the existing alias/binding policies to the partitioned non-text object. It also updates three stale TU test expectations after the profile renames already on main.\n\nValidated locally:\n- 90 tubuild/tu_production tests\n- 147 adjacent object, ROM-build, relocation, vtable, and manifest tests (1 skipped)\n- production build: 106/106 modules exact, 0 mismatches\n- port_refcheck: 405 references resolve