### PR TITLE
Attribution findings never block a PR merge

### DIFF
--- a/.github/workflows/pr-validate-cancel.yml
+++ b/.github/workflows/pr-validate-cancel.yml
@@ -8,9 +8,8 @@ name: Cancel PR validation
 # to a job ID against the relay's own queue listing, and cancels it -- so a maintainer
 # never needs the token or a job ID directly.
 #
-# workflow_dispatch is only offered to accounts with write access to this repo, which
-# is the same population that can already label a PR attribution-override, so this
-# adds no new privilege surface.
+# workflow_dispatch is only offered to accounts with write access to this repo, so
+# this adds no new privilege surface.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -18,18 +18,9 @@ name: PR validation
 # never with these secrets -- but a `tools/` diff on a fork PR deserves a read before
 # it is approved.
 #
-# The attribution-override label is a maintainer's "I know, and I meant it" for a PR
-# that moves contributor credit on purpose — attribution.json pins are exactly that.
-# It is read here, sent with the submission, and turns every attribution finding into
-# a warning on the check instead of a reason the merge cannot land. Only somebody with
-# write access can label a pull request, which is what makes it a safe signal to trust
-# from a pull_request_target workflow.
 on:
   pull_request_target:
-    # labeled/unlabeled are here for that one label only — see the job's `if`. Adding it
-    # has to re-submit, because the override travels with the job and the worker reads it
-    # once, when it claims the build.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 # `pull-requests: read` is here to LIST THE CHANGED FILE PATHS, and nothing else. That is
 # PR metadata, not PR code: the files endpoint returns paths, and this job still never
@@ -56,11 +47,6 @@ concurrency:
 jobs:
   submit:
     runs-on: ubuntu-latest
-    # Every other label is somebody organising the queue, not asking for an hour of the
-    # worker. Only the override label re-runs validation.
-    if: >-
-      (github.event.action != 'labeled' && github.event.action != 'unlabeled')
-      || github.event.label.name == 'attribution-override'
     steps:
       # Decide whether this PR can possibly change what validation measures, and tell the
       # relay. A full validation is a stock ROM build plus a whole-module compare against
@@ -121,7 +107,6 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          ALLOW_ATTRIBUTION_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'attribution-override') }}
           VALIDATION_RELEVANT: ${{ steps.classify.outputs.relevant }}
         run: |
           set -euo pipefail
@@ -139,9 +124,8 @@ jobs:
           # post a passing `PR validation` check immediately and do not queue a build.
           payload=$(jq -n --arg repo "$REPO" --argjson pr "$PR" \
             --arg sha "$SHA" --arg baseSha "$BASE_SHA" \
-            --argjson allowAttributionChange "$ALLOW_ATTRIBUTION_CHANGE" \
             --argjson validationRelevant "$VALIDATION_RELEVANT" \
-            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha,allowAttributionChange:$allowAttributionChange,validationRelevant:$validationRelevant}')
+            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha,validationRelevant:$validationRelevant}')
           resp=$(curl -sS -X POST "$RELAY/api/pr-validate" \
             -H "X-Api-Key: $TOKEN" -H "Content-Type: application/json" \
             --data "$payload")

--- a/notes/pr-validation.md
+++ b/notes/pr-validation.md
@@ -9,7 +9,7 @@ one misleading percentage:
 | Coverage denominator | Configured function count and code-byte universe | Must not change silently |
 | Source-built functions and bytes | Code actually linked from our translation units instead of a ROM gap object | Must not regress |
 | Module fidelity | Linked executable-module bytes equal retail | Stock head must pass, unless base and head have the same recorded pre-existing build failure |
-| Contributor lineage | The first matcher still owns a surviving match after moves/renames | Must not change or disappear, unless the PR carries `attribution-override` |
+| Contributor lineage | The first matcher still owns a surviving match after moves/renames | Reported when it changes or disappears; never blocks the merge |
 | Relocations | Affected source reproduces bytes and names the correct destinations | No WRONG or NO-REPRO |
 | Port references | `port/`'s manifests and symbol bridges still name files and symbols that exist | No stale reference (optional phase) |
 
@@ -55,19 +55,14 @@ base becomes red, or the failure changes, validation fails.
 ## Moving credit on purpose
 
 Some PRs move contributor credit as their whole point — pinning a stem in
-`attribution.json` is exactly that — and the lineage gate is right to notice and wrong to
-block them. Label such a pull request **`attribution-override`**. The workflow re-submits
-on the label, the relay carries it to the worker, and the worker adds
-`--allow-attribution-change` to step 6.
+`attribution.json` is exactly that. Attribution never blocks a merge: the lineage gate
+only reports what moved, so a PR like this needs no label and no override flag. A lost
+match, a changed coverage denominator, or a failed ROM build still fails the merge on its
+own terms — attribution findings are informational either way.
 
-The finding does not go away: the check still names every file whose credit moved, with
-the contributor before and after, and says the label accepted it. Everything else is
-unaffected — a lost match, a changed coverage denominator, or a failed ROM build fails a
-labelled PR exactly as it fails an unlabelled one.
-
-Either way, the check now names the moves rather than counting them. `0 added, 2 changed,
-0 lost` was unactionable for a PR author who cannot read the worker's log: the summary
-names the first few and the check body carries a table of up to 25.
+The check names the moves rather than counting them. `0 added, 2 changed, 0 lost` was
+unactionable for a PR author who cannot read the worker's log: the summary names the
+first few and the check body carries a table of up to 25.
 
 The merge gate always uses the stock profile. `--profile mods` is a developer tool for
 building intentional experiments and is never accepted as reconstruction proof.

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -217,19 +217,6 @@ class ValidateMerge(unittest.TestCase):
         self.assertIn("| `arm9:0x02000000` | `src/Example.c` | alice | bob |",
                       report["reportMarkdown"])
 
-    def test_attribution_override_is_not_needed_for_a_pure_change(self):
-        # The override label exists for a real LOSS. A pure reassignment already passes
-        # without it, and passing the label besides changes nothing about that.
-        (self.repo / "attribution.json").write_text(
-            '{"overrides": {"src/Example.c": "bob"}}\n', encoding="utf-8")
-        commit(self.repo, "pin credit", "maintainer")
-        report = VM.build_report(self.base, "HEAD", allow_attribution_change=True)
-        self.assertEqual(report["status"], "Passed")
-        self.assertEqual(report["reasons"], [])
-        self.assertIn("src/Example.c: alice -> bob", "; ".join(report["warnings"]))
-        self.assertNotIn("(override label)", report["reportMarkdown"])
-        self.assertEqual(len(report["attribution"]["changed"]), 1)
-
     def test_a_wholesale_credit_move_stays_within_the_relay_summary_limit(self):
         # The relay rejects a result whose summary runs past 500 characters, and a
         # rejected result is a job that never reports at all. Naming files is worth
@@ -257,15 +244,15 @@ class ValidateMerge(unittest.TestCase):
         self.assertIn("+37 more", "; ".join(report["warnings"]))
         self.assertIn("+15 more", report["reportMarkdown"])
 
-    def test_override_does_not_excuse_a_non_attribution_failure(self):
-        # Scoped to attribution only: a label about credit must not wave through a
-        # PR that actually lost matched code.
+    def test_lost_credit_does_not_excuse_a_non_attribution_failure(self):
+        # Attribution never blocks a merge, but that must not mask a PR that
+        # actually lost matched code alongside its credit.
         (self.repo / "src" / "Example.c").write_text(
             "// NONMATCHING\nint Example(void) { return 0; }\n")
         (self.repo / "attribution.json").write_text(
             '{"overrides": {"src/Example.c": "bob"}}\n', encoding="utf-8")
         commit(self.repo, "unmatch and repin", "maintainer")
-        report = VM.build_report(self.base, "HEAD", allow_attribution_change=True)
+        report = VM.build_report(self.base, "HEAD")
         self.assertEqual(report["status"], "Failed")
         self.assertIn("lost 1 matched function(s)", report["reasons"])
 
@@ -373,15 +360,8 @@ class ValidateMerge(unittest.TestCase):
         head = commit(self.repo, "banner Claimed", "bob")
 
         # Withdrawing also hands the claim's contributor credit back to nobody, which
-        # is its own reason and keeps its own label. That is the real shape of such a
-        # PR: attribution-override for the credit, and this rule for the count. Assert
-        # the two separately so neither can be mistaken for the other.
-        unlabelled = VM.build_report(base, head)
-        self.assertEqual(unlabelled["status"], "Failed")
-        self.assertEqual([r.split(" (")[0] for r in unlabelled["reasons"]],
-                         ["contributor attribution was lost"])
-
-        report = VM.build_report(base, head, allow_attribution_change=True)
+        # is reported as its own warning and never blocks the merge.
+        report = VM.build_report(base, head)
         self.assertEqual(report["status"], "Passed")
         self.assertEqual(report["coverage"]["delta"]["withdrawnMatchedFunctions"], 1)
         self.assertEqual(report["coverage"]["delta"]["lostMatchedFunctions"], 0)

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -5944,9 +5944,10 @@ def cmd_promote(args):
               f"the owner of the merged file. This is NOT the rewrite-then-move hazard "
               f"prepush_attribution.py documents, which a two-commit split fixes -- a "
               f"many-to-one collapse has no commit arrangement that preserves N lineages, "
-              f"so `CREDIT LOST` is structural for this workstream and needs an explicit "
-              f"policy (an attribution.json override keyed on the surviving path, or the "
-              f"attribution-override label) BEFORE the first real promotion.")
+              f"so `CREDIT LOST` is structural for this workstream. It no longer fails "
+              f"the merge gate, but an attribution.json override keyed on the surviving "
+              f"path still keeps credit correctly recorded before the first real "
+              f"promotion.")
     # validate_merge used to infer ownership only from filename stems. It now asks the
     # revision's delinks enrollment map first, so a single path can retain matched and
     # byte-verified coverage for every licensed function range it owns. Keep the dry

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -484,7 +484,7 @@ def _credit_detail(changed, lost):
 
 def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                  require_merge_commit=False, expected_pr_head=None,
-                 port_report=None, allow_attribution_change=False):
+                 port_report=None):
     base_sha, head_sha = resolve_commit(base), resolve_commit(head)
     parents = _git("rev-list", "--parents", "-n", "1", head_sha).split()
     is_merge = len(parents) >= 3
@@ -601,21 +601,13 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     dropped_enrollment = sorted(set(be["source"]) - set(he["source"]))
     # Reassignment alone (a name moving from one contributor to another, credit_changes)
     # is never a blocker: a rebase, a rename, or resolving someone else's merge conflict
-    # all relabel a function's "last touched by" without losing anything, and this project
-    # spends no tokens defending credit. Only an outright LOSS (lost_credit: a function
-    # that had a contributor and now has none) is a real regression, and the
-    # attribution-override label (carried on the job by tangos-backend) makes that one
-    # finding advisory too -- an override says "I know, and I meant it", not "do not
-    # look" -- for this one pull request.
+    # all relabel a function's "last touched by" without losing anything, and this
+    # project spends no tokens defending credit -- not even for an outright LOSS
+    # (lost_credit: a function that had a contributor and now has none). Both are
+    # reported below so a PR author can see what moved, but neither fails the merge.
     credit_moved = bool(credit_changes or lost_credit)
     new_unattributed = (ha["stats"]["unattributedFunctions"]
                         > ba["stats"]["unattributedFunctions"])
-    if lost_credit and not allow_attribution_change:
-        reasons.append("contributor attribution was lost "
-                       f"({_credit_detail(credit_changes, lost_credit)}); label the pull "
-                       "request attribution-override to accept it")
-    if new_unattributed and not allow_attribution_change:
-        reasons.append("the merge introduced an unattributed matched function")
     if diff["leftoverOldPaths"]:
         reasons.append("old source paths remain after rename")
     if new_transcribed:
@@ -660,18 +652,16 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
             + ", ".join(w["path"] for w in withdrawn[:3])
             + (f", +{len(withdrawn) - 3} more" if len(withdrawn) > 3 else ""))
     if credit_changes:
-        # Never a blocker (see above) -- reported so a reader can still see whose credit
-        # moved, without needing the attribution-override label to get a passing merge.
+        # Never a blocker (see above) -- reported so a reader can still see whose
+        # credit moved.
         warnings.append("contributor attribution changed, not a blocker "
                         f"({_credit_detail(credit_changes, [])})")
-    if allow_attribution_change and lost_credit:
-        warnings.append("attribution-override label: contributor attribution was lost "
-                        f"({_credit_detail([], lost_credit)}), "
-                        "accepted without failing the pull request")
-    if allow_attribution_change and new_unattributed:
-        warnings.append("attribution-override label: the merge introduced an "
-                        "unattributed matched function, accepted without failing "
-                        "the pull request")
+    if lost_credit:
+        warnings.append("contributor attribution was lost, not a blocker "
+                        f"({_credit_detail([], lost_credit)})")
+    if new_unattributed:
+        warnings.append("the merge introduced an unattributed matched function, "
+                        "not a blocker")
     if same_baseline_failure:
         warnings.append("base and merge share the same pre-existing ROM-build failure")
     if (dropped_enrollment
@@ -733,13 +723,11 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         if hf["stats"]["totalBytes"] else 0.0)
     if reasons:
         summary = "Validation failed: " + "; ".join(reasons)
-    elif allow_attribution_change and (lost_credit or new_unattributed):
-        # Passing *because* of the label is not the same verdict as nothing having been
-        # lost, and the one-liner is what most people read.
-        summary = ("Committed merge passes; the attribution-override label accepted "
-                   f"{len(lost_credit)} lost credit(s)"
+    elif lost_credit or new_unattributed:
+        summary = ("Committed merge passes; "
+                   f"{len(lost_credit)} lost credit(s) noted"
                    + (", including an unattributed match" if new_unattributed else "")
-                   + ".")
+                   + ", not a blocker.")
     elif credit_changes:
         summary = (f"Committed merge passes; {len(credit_changes)} contributor credit "
                    "reassignment(s) noted, not a blocker.")
@@ -767,7 +755,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         "attribution": {"base": ba["contributors"], "head": ha["contributors"],
                         "baseStats": ba["stats"], "headStats": ha["stats"],
                         "added": added_credit, "changed": credit_changes,
-                        "lost": lost_credit, "overridden": allow_attribution_change},
+                        "lost": lost_credit},
         "diff": diff,
         "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered,
                       "strandedMarkers": stranded_markers},
@@ -827,16 +815,10 @@ def render_markdown(r):
             f"({s['head']['sourceBytesPercent']:.2f}%, {_signed(d['sourceBuiltBytes'])}) "
             f"-- differs from byte-verified by "
             f"{s['head']['sourceFunctions'] - h['verifiedFunctions']:+,} |")
-    # "(override label)" only when the label actually waived something -- a pure
-    # reassignment (changed, no lost) already passes on its own, so tagging it here
-    # would read as "this needed permission" when it did not.
-    overrode_something = bool(r["attribution"].get("overridden")
-                              and r["attribution"]["lost"])
     lines += [
              f"| Contributor credit | {len(r['attribution']['added'])} added, "
              f"{len(r['attribution']['changed'])} changed, "
-             f"{len(r['attribution']['lost'])} lost"
-             f"{' (override label)' if overrode_something else ''} |",
+             f"{len(r['attribution']['lost'])} lost |",
              f"| Relocation check | {l['checked']} checked; {relocation_summary} |"]
     # Optional phase: no row at all when it did not run, so an older worker's
     # report reads exactly as it did before.
@@ -1027,18 +1009,13 @@ def main():
     ap.add_argument("--port-refcheck-report",
                     help="tools/port_refcheck.py --json output; the check is "
                          "reported only when this is supplied and exists")
-    ap.add_argument("--allow-attribution-change", action="store_true",
-                    help="report attribution changes as warnings instead of failing "
-                         "the merge; the worker passes this for a pull request "
-                         "carrying the attribution-override label")
     ap.add_argument("--out", required=True)
     ap.add_argument("--markdown")
     args = ap.parse_args()
     report = build_report(args.base, args.head, _load_json(args.base_rom_report),
                           _load_json(args.head_rom_report), _load_json(args.link_report),
                           args.require_merge_commit, args.expected_pr_head,
-                          _load_json(args.port_refcheck_report, optional=True),
-                          args.allow_attribution_change)
+                          _load_json(args.port_refcheck_report, optional=True))
     pathlib.Path(args.out).write_text(json.dumps(report, indent=2) + "\n",
                                       encoding="utf-8", newline="\n")
     if args.markdown:


### PR DESCRIPTION
## Summary
- Reassignment or loss of contributor credit is now always reported as a non-blocking warning; it never fails a merge check
- Removes the now-dead `attribution-override` label / `--allow-attribution-change` plumbing (workflow, worker invocation, tests, docs) since nothing is left to override
- `attribution.json`, credit computation, and reporting are untouched -- only the merge-blocking behavior is removed

## Test plan
- [x] `python -m pytest tools/test_validate_merge.py -q` -- 34/34 passed
- [x] Companion changes in `sm64ds-validator` (worker no longer builds `--allow-attribution-change`) and `tangos-backend` (relay no longer accepts/stores `allowAttributionChange`) already merged to their mains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWWJPVgFeWhmaJtDkQdUxd