### PR TITLE
asset_catalog: add a resolve command for single-ID lookups

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -223,8 +223,10 @@ jobs:
 #                                      local header drags into the validation compile.
 #   test_asm_policy             (14)   asm_policy.py -- the one shared answer to "is this
 #                                      an asm transcription?". Guards the VACUOUS match.
-#   test_asset_catalog           (7)   asset_catalog.py -- NitroFS catalog build and the
-#                                      source references into it.
+#   test_asset_catalog          (10)   asset_catalog.py -- NitroFS catalog build, the
+#                                      source references into it, and `resolve`, which
+#                                      must read an integer as a runtime handle and
+#                                      never as a NitroFS file ID.
 #   test_attribution            (17)   chaos_db_ci.py -- rebuilds chaos-db.json from
 #                                      COMMITTED history; the credit data the site reads.
 #   test_bytegate               (18)   bytegate.py -- the byte-gate-failure half of the

--- a/notes/assets.md
+++ b/notes/assets.md
@@ -40,6 +40,22 @@ The second command writes three review surfaces:
 - `build/assets/layout-candidates.tsv` correlates static initializers with named
   actor directories that consume their resource globals.
 
+## Look up a single ID
+
+```powershell
+python tools/asset_catalog.py resolve 1570
+python tools/asset_catalog.py resolve kb1_ball data_ov044_02111680
+```
+
+`resolve` answers one query at a time against the generated catalogs, so reading a
+literal in matched source does not mean grepping a TSV. It accepts a handle literal
+(`1570`, `0x622`), a path fragment (`kb1_ball`), or an owner symbol
+(`data_ov044_02111680`), and prints the asset path, kind, size, the separate NitroFS
+file ID, the `ASSET_HANDLE_*` constant, and every loader call site found by the
+`references` command. An integer is always read as a runtime handle; values at or
+above `0x8000` report that they bypass the overlay 0 table rather than resolving to
+a wrong name. It exits non-zero when a query does not resolve.
+
 These are evidence for review, not automatic renames. A candidate is marked
 `high` only when one anonymous owner maps to one asset and the proposed name does
 not collide with another owner. Reused owners, duplicate names, and initializer

--- a/tools/asset_catalog.py
+++ b/tools/asset_catalog.py
@@ -641,6 +641,76 @@ def cmd_generate(args) -> None:
     print(f"  headers : {args.file_header}, {args.handle_header}")
 
 
+def resolve_queries(queries: list[str], handles: list[AssetHandle],
+                    references: list[dict[str, str]]) -> list[tuple[str, list]]:
+    """Answer handle numbers, path fragments, and owner symbols from the catalog.
+
+    An integer literal is always a runtime handle, never a NitroFS file ID; the
+    two number spaces disagree and guessing between them invents asset names.
+    """
+    by_handle = {entry.handle: entry for entry in handles}
+    results = []
+    for query in queries:
+        value = _integer_literal(query)
+        if value is not None:
+            entry = by_handle.get(value)
+            results.append((query, [entry] if entry else []))
+            continue
+        needle = query.lower()
+        matches = [entry for entry in handles if needle in entry.path.lower()]
+        if not matches:
+            owners = {row["raw_id"] for row in references
+                      if needle in row["owner"].lower() and row["owner"]}
+            matches = [by_handle[handle] for handle in
+                       sorted(_integer_literal(raw) or -1 for raw in owners)
+                       if handle in by_handle]
+        results.append((query, matches))
+    return results
+
+
+def cmd_resolve(args) -> None:
+    if not args.handles.is_file():
+        sys.exit(f"Handle catalog not found: {args.handles}\nRun the generate command first.")
+    handles = read_handles(args.handles)
+    references = []
+    if args.references.is_file():
+        with args.references.open(encoding="utf-8", newline="") as f:
+            references = list(csv.DictReader(f, delimiter="\t"))
+    names = constants_for(handles, value_attr="handle", prefix="ASSET_HANDLE")
+    by_handle_refs = collections.defaultdict(list)
+    for row in references:
+        if row["status"] == "runtime-handle":
+            by_handle_refs[_integer_literal(row["raw_id"])].append(row)
+
+    unresolved = 0
+    for query, matches in resolve_queries(args.query, handles, references):
+        if not matches:
+            value = _integer_literal(query)
+            if value is not None and value >= 0x8000:
+                print(f"{query}: not a runtime handle; values >= 0x8000 bypass the "
+                      f"overlay 0 table and stay encoded-or-unresolved")
+            else:
+                print(f"{query}: no match")
+            unresolved += 1
+            continue
+        for entry in matches[:args.limit]:
+            print(f"{entry.handle} (0x{entry.handle:04x})  {entry.path}")
+            print(f"    kind={entry.kind} size={entry.size:,} "
+                  f"nitro_file_id={entry.file_id} (0x{entry.file_id:04x})")
+            print(f"    {names[entry.handle]}")
+            for row in by_handle_refs.get(entry.handle, [])[:args.limit]:
+                owner = row["owner"] or "-"
+                suggested = row["suggested_owner"]
+                label = f"{owner} -> {suggested}" if suggested else owner
+                print(f"    used by {row['source']}:{row['line']} "
+                      f"{row['callee']}  {label}")
+        if len(matches) > args.limit:
+            print(f"    ... {len(matches) - args.limit:,} more matches "
+                  f"(raise --limit to see them)")
+    if unresolved:
+        sys.exit(1)
+
+
 def cmd_references(args) -> None:
     if not args.handles.is_file():
         sys.exit(f"Handle catalog not found: {args.handles}\nRun the generate command first.")
@@ -683,6 +753,18 @@ def main(argv=None) -> None:
     references.add_argument("--layouts", type=pathlib.Path,
                             default=DEFAULT_LAYOUT_CANDIDATES)
     references.set_defaults(func=cmd_references)
+
+    resolve = commands.add_parser(
+        "resolve",
+        help="look up runtime handles by number, path fragment, or owner symbol")
+    resolve.add_argument("query", nargs="+",
+                         help="a handle literal (1570, 0x622), a path fragment "
+                              "(kb1_ball), or an owner symbol (data_ov044_02111680)")
+    resolve.add_argument("--handles", type=pathlib.Path, default=DEFAULT_HANDLES)
+    resolve.add_argument("--references", type=pathlib.Path, default=DEFAULT_REFERENCES)
+    resolve.add_argument("--limit", type=int, default=10,
+                         help="maximum matches printed per query (default 10)")
+    resolve.set_defaults(func=cmd_resolve)
 
     args = parser.parse_args(argv)
     args.func(args)

--- a/tools/test_asset_catalog.py
+++ b/tools/test_asset_catalog.py
@@ -158,6 +158,32 @@ class AssetCatalogTests(unittest.TestCase):
             AC.resource_owner_from_source("src/_ZN7Message11DisplayTextEt.cpp")
         )
 
+    def test_resolve_reads_literals_as_handles_not_file_ids(self):
+        handles = [
+            AC.AssetHandle(1, 0x123, "data/a.bmd", 10),
+            AC.AssetHandle(2, 0x001, "data/b.kcl", 20),
+        ]
+        # 1 is a handle, so it must name a.bmd and never the file_id 1 asset.
+        self.assertEqual(
+            [h.path for _, m in AC.resolve_queries(["1", "0x2"], handles, []) for h in m],
+            ["data/a.bmd", "data/b.kcl"],
+        )
+
+    def test_resolve_matches_path_fragments_and_owner_symbols(self):
+        handles = [AC.AssetHandle(5, 0x9, "data/special_obj/kb1_ball/kb1_ball.bmd", 7)]
+        references = [{
+            "raw_id": "0x0005", "status": "runtime-handle",
+            "owner": "data_ov044_02111680",
+        }]
+        by_fragment = AC.resolve_queries(["kb1_ball"], handles, references)
+        self.assertEqual([h.handle for h in by_fragment[0][1]], [5])
+        by_owner = AC.resolve_queries(["data_ov044_02111680"], handles, references)
+        self.assertEqual([h.handle for h in by_owner[0][1]], [5])
+
+    def test_resolve_reports_no_match_for_encoded_values(self):
+        handles = [AC.AssetHandle(1, 0x123, "data/a.bmd", 10)]
+        self.assertEqual(AC.resolve_queries(["0x9807"], handles, []), [("0x9807", [])])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

`tools/asset_catalog.py` already decoded overlay 0's runtime asset-handle table, but there was no way to answer one question. Reading `Kb1BillboardModelFilePtr data_ov044_02111680(1570);` in matched source meant regenerating and grepping `build/assets/handles.tsv`.

```powershell
python tools/asset_catalog.py resolve 1570
python tools/asset_catalog.py resolve kb1_ball data_ov044_02111680
```

`resolve` takes a handle literal (`1570`, `0x622`), a path fragment, or an owner symbol, and prints the asset path, kind, size, the separate NitroFS file ID, the `ASSET_HANDLE_*` constant, and every loader call site the `references` command found. It exits non-zero when a query does not resolve.

## The rule it encodes

An integer literal is **always** a runtime handle, never a NitroFS file ID. The two number spaces disagree — handle 1570 (`0x622`) is file ID 1139 (`0x473`) — so guessing between them invents plausible, wrong asset names. Values at or above `0x8000` bypass the overlay 0 table entirely; `resolve` says so rather than resolving them to something.

## Gates

- `tools.test_asset_catalog` 7 -> 10; the new tests pin the handle-vs-file-ID reading, fragment/owner matching, and the encoded-value refusal
- full enumerated `tool-tests.yml` sweep: `Ran 541 tests ... OK`
- `check_python_names` PASS, `check_dead_references` PASS

No generated data is committed; `build/` stays gitignored. The second commit updates the module inventory comment in `tool-tests.yml`, which is what a reviewer compares against when that job's total moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyTiToZ2UxgpHH4xETfjFm