### PR TITLE
check_data_definitions: scan the objects eligible.py actually writes

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -191,6 +191,7 @@ jobs:
             tools.test_asset_catalog \
             tools.test_attribution \
             tools.test_bytegate \
+            tools.test_check_data_definitions \
             tools.test_cpp_rename_verify \
             tools.test_delaunder \
             tools.test_enroll \
@@ -229,6 +230,9 @@ jobs:
 #                                      COMMITTED history; the credit data the site reads.
 #   test_bytegate               (18)   bytegate.py -- the byte-gate-failure half of the
 #                                      matched test, over layout_check/relocs/srcpath.
+#   test_check_data_definitions  (3)   check_data_definitions.py -- WHICH objects the
+#                                      gate scans. It globbed only build/src/, which
+#                                      eligible.py never writes, so it skipped silently.
 #   test_cpp_rename_verify      (16)   cpp_rename.py -- func_ADDR -> demangled _ZN name
 #                                      renames. A wrong substitution here is silent.
 #   test_delaunder              (25)   delaunder.py -- removing launder idioms one site

--- a/tools/check_data_definitions.py
+++ b/tools/check_data_definitions.py
@@ -51,9 +51,11 @@ USAGE
     python tools/check_data_definitions.py           # gate; exit 1 on any hit
     python tools/check_data_definitions.py --list    # print every symbol found
 
-Reads the objects `tools/eligible.py` already leaves in build/src/. It compiles
-nothing, so it costs about a second -- but it is therefore only as fresh as the
-last eligible.py run, and says so when the tree is newer.
+Reads objects that are already on disk: the ones `tools/eligible.py` leaves in
+build/eligible-scratch/ and the ones `tools/rombuild.py` leaves in build/src/.
+Both roots are scanned because either tool may be the last one run. It compiles
+nothing, so it costs about a second -- but it is therefore only as fresh as that
+last run, and says so when the tree is newer.
 """
 import argparse
 import io
@@ -64,6 +66,17 @@ from elftools.elf.elffile import ELFFile
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 BUILD = REPO / "build" / "src"
+# eligible.py writes one object per (file, symbol) into a separate root, nested
+# under the source's own directory, so this one needs a recursive glob.
+SCRATCH = REPO / "build" / "eligible-scratch"
+
+
+def objects():
+    """Every already-compiled object, from whichever root produced it."""
+    found = list(BUILD.glob("*.o")) if BUILD.is_dir() else []
+    if SCRATCH.is_dir():
+        found += SCRATCH.rglob("*.o")
+    return sorted(found)
 
 # ROM address symbols. A source file may legitimately define its own named
 # globals; what it may not do is define one of the delinker's carved-out
@@ -93,9 +106,15 @@ def defined_rom_objects(obj_path):
     return sorted(found)
 
 
+def label(obj):
+    """The source this object came from, as a repo-relative path."""
+    if obj.is_relative_to(SCRATCH):
+        return obj.relative_to(SCRATCH).with_suffix("").as_posix()
+    return f"src/{obj.stem}"
+
+
 def audit():
-    return {o.stem: syms for o in sorted(BUILD.glob("*.o"))
-            if (syms := defined_rom_objects(o))}
+    return {label(o): syms for o in objects() if (syms := defined_rom_objects(o))}
 
 
 def main():
@@ -105,25 +124,26 @@ def main():
                     help="print every offending symbol, not just the file count")
     args = ap.parse_args()
 
-    if not BUILD.is_dir():
-        print("no build/src objects -- run tools/eligible.py first")
+    scanned = objects()
+    if not scanned:
+        print("no compiled objects in build/eligible-scratch/ or build/src/ -- "
+              "run tools/eligible.py first")
         print("skipping (this is NOT a pass)")
         return 0
 
-    objects = sorted(BUILD.glob("*.o"))
     hits = audit()
 
     if not hits:
-        print(f"data-definitions: {len(objects)} object(s), none define a ROM data symbol")
+        print(f"data-definitions: {len(scanned)} object(s), none define a ROM data symbol")
         return 0
 
     total = sum(len(v) for v in hits.values())
     print(f"data-definitions FAILED: {total} ROM symbol(s) defined across "
-          f"{len(hits)} object(s), of {len(objects)} scanned\n")
-    for stem in sorted(hits):
-        shown = hits[stem] if args.list else hits[stem][:4]
-        more = "" if args.list or len(hits[stem]) <= 4 else f" (+{len(hits[stem]) - 4} more)"
-        print(f"  src/{stem}")
+          f"{len(hits)} object(s), of {len(scanned)} scanned\n")
+    for source in sorted(hits):
+        shown = hits[source] if args.list else hits[source][:4]
+        more = "" if args.list or len(hits[source]) <= 4 else f" (+{len(hits[source]) - 4} more)"
+        print(f"  {source}")
         print(f"      {', '.join(shown)}{more}")
     print("\nThese are DEFINITIONS where a declaration was meant. Inside")
     print('`extern "C" { ... }` a variable needs an explicit `extern`:')

--- a/tools/premerge_check.py
+++ b/tools/premerge_check.py
@@ -158,7 +158,8 @@ and including one would buy a green that means nothing:
   check_references.py         reads build/rombuild-eligibility.json, which only
                               `eligible.py` produces, and then validates its commit
                               stamp against HEAD. An exported tree has no HEAD.
-  check_data_definitions.py   reads the objects `eligible.py` leaves in build/src/.
+  check_data_definitions.py   reads the objects `eligible.py` leaves in
+                              build/eligible-scratch/, or rombuild.py in build/src/.
   check_layout_free.py        reads `extracted/` (the ROM dump) and needs PyYAML.
   check_python_names.py       needs pyflakes, which is not stdlib.
   check_src_tu_compiles.py    needs mwccarm.

--- a/tools/test_check_data_definitions.py
+++ b/tools/test_check_data_definitions.py
@@ -1,0 +1,61 @@
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_data_definitions as CDD  # noqa: E402
+
+
+class ObjectDiscoveryTests(unittest.TestCase):
+    """The gate used to glob only build/src/*.o, which eligible.py never writes,
+    so an eligible.py run left it reporting "no objects" and skipping."""
+
+    def roots(self, tmp):
+        root = pathlib.Path(tmp)
+        old = CDD.BUILD, CDD.SCRATCH
+        CDD.BUILD = root / "build" / "src"
+        CDD.SCRATCH = root / "build" / "eligible-scratch"
+        return root, old
+
+    def test_scratch_objects_are_found_without_a_rombuild(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, old = self.roots(tmp)
+            try:
+                nested = CDD.SCRATCH / "src" / "actors"
+                nested.mkdir(parents=True)
+                (nested / "Piano.o").write_bytes(b"")
+                self.assertFalse(CDD.BUILD.exists())
+                self.assertEqual([o.name for o in CDD.objects()], ["Piano.o"])
+            finally:
+                CDD.BUILD, CDD.SCRATCH = old
+
+    def test_both_roots_are_scanned_and_labelled_by_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, old = self.roots(tmp)
+            try:
+                CDD.BUILD.mkdir(parents=True)
+                (CDD.BUILD / "Legacy.o").write_bytes(b"")
+                nested = CDD.SCRATCH / "src" / "actors"
+                nested.mkdir(parents=True)
+                (nested / "Piano.o").write_bytes(b"")
+                found = CDD.objects()
+                self.assertEqual(len(found), 2)
+                self.assertEqual(
+                    sorted(CDD.label(o) for o in found),
+                    ["src/Legacy", "src/actors/Piano"],
+                )
+            finally:
+                CDD.BUILD, CDD.SCRATCH = old
+
+    def test_missing_roots_report_nothing_rather_than_raising(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, old = self.roots(tmp)
+            try:
+                self.assertEqual(CDD.objects(), [])
+            finally:
+                CDD.BUILD, CDD.SCRATCH = old
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`check_data_definitions.py` globbed `build/src/*.o` only. `eligible.py` writes its objects to `build/eligible-scratch/<source dir>/`, so after an `eligible.py` run the gate found nothing and printed:

```
no build/src objects -- run tools/eligible.py first
skipping (this is NOT a pass)
```

and returned 0 — while telling you to run the tool that had just run. Its own docstring, and the note at `tools/premerge_check.py:161`, both claimed it reads what `eligible.py` leaves behind, so the skip read as a local configuration problem rather than a defect. Only a full `rombuild.py`, which does populate `build/src/`, ever gave it a real verdict.

That matters because this gate is the only thing that sees the silent half of its defect class: an `extern "C"` variable definition whose type is incomplete links quietly, byte-matches everywhere, and no ROM build notices.

## The fix

Scan both roots — `build/src/` non-recursively as before, and `build/eligible-scratch/` recursively, since `eligible.py` nests one object per (file, symbol) under the source's own directory. Offending objects are labelled by source path rather than a bare stem, which the scratch tree needs to stay unambiguous.

On a tree where `eligible.py` had just run, the verdict moves from `skipping` to:

```
data-definitions: 11214 object(s), none define a ROM data symbol
```

## Gates

- new `tools/test_check_data_definitions.py` (3 tests) pins the discovery rule, including the exact regression: scratch objects must be found with no `build/src/` present at all
- enrolled in `tool-tests.yml`; enumerated sweep `Ran 541 tests ... OK`
- `check_python_names` PASS, `check_dead_references` PASS

The stale claim in `premerge_check.py` is corrected in the same commit. `premerge_check` still excludes this gate — that exclusion is correct and unchanged, since an exported tree has no compiled objects under either root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyTiToZ2UxgpHH4xETfjFm