### PR TITLE
Recover the create path; partition the actor-flags word

### DIFF
--- a/include/dActor_c.h
+++ b/include/dActor_c.h
@@ -80,16 +80,28 @@ struct dActor_c : dBase_c {
     s32 unk_0a4;            /* 0x0a4 */
     s32 mVertSpeed;         /* 0x0a8 */
     s32 unk_0ac;            /* 0x0ac */
-    /* Bit meanings below are a best-effort reading, not pinned by the ROM the
-     * way the offsets are. Only 0x10000 is proven; the rest are a plausible
-     * reading from the surrounding game mechanics, not independently
-     * verified:
-     *   0x000001 skip behavior while unseen   0x000002 skip render while unseen
-     *   0x000008 unseen                       0x000010 past shadow range
-     *   0x000020 area mismatch                0x010000 suppress behavior (PROVEN)
-     *   0x020000 entering yoshi's mouth        0x040000 inside yoshi's mouth
-     *   0x2000000 squishable                   0x10000000 targetable by egg */
-    u32 mFlags;             /* 0x0b0 -- bit 0x10000 suppresses behaviour; see the bit table above */
+    /* Two populations of bits share this word. The profile descriptor's +0x08
+     * word is copied in verbatim by the constructor; the framework then sets and
+     * clears its own bits in the same storage. Across the 353 soundly-parsed
+     * actor descriptors no profile authors any runtime bit, and the runtime
+     * writes none of the authored ones -- so the split below is a measured
+     * partition, not a guess. Census and evidence:
+     * notes/profile-lifecycle-crosswalk.md.
+     *
+     * AUTHORED BY THE PROFILE, with a recovered consumer:
+     *   0x00000001 enables the clip test; with 0x08 set, skip behaviour
+     *   0x00000002 enables the clip test; with 0x08 set, skip render
+     *   0x00010000 defeat the global force-think override while invisible
+     *   0x08000000 spawn even if the death table says already killed
+     * AUTHORED BY THE PROFILE, consumer not yet recovered:
+     *   0x04  0x80  0x200  0x8000  0x800000  0x1000000  0x2000000
+     *   0x4000000  0x10000000  0x20000000  0x40000000
+     * WRITTEN BY THE FRAMEWORK, never by a profile:
+     *   0x000008 off screen        0x000010 beyond mFarDistance (also kills the
+     *   0x000020 area not showing    drop shadow)
+     *   0x020000 / 0x040000 yoshi-mouth states, written by actor code
+     * AfterInitResources seeds 0x38, so an actor starts fully invisible. */
+    u32 mFlags;             /* 0x0b0 -- see the bit table above */
     /* The clip volume, all four set together by SetRanges out of the actor's
        entry in the spawn-info table. BeforeBehavior projects
        (mPosX, mPosY + mClipOffsetY, mPosZ) into camera space and hands the

--- a/notes/profile-lifecycle-crosswalk.md
+++ b/notes/profile-lifecycle-crosswalk.md
@@ -4,6 +4,11 @@ Status: evidence crosswalk for the profile-reconstruction pilot.  It records
 Troy's NSMBW comparison as a hypothesis, then separates the portions confirmed by
 SM64DS consumers from fields and spellings that remain unresolved.
 
+Second pass adds the recovered create path -- which settles where the group-type
+byte comes from -- a measured partition of the actor-flags word into
+profile-authored and framework-written bits, and a parse defect in three registry
+rows.
+
 ## Runtime descriptor fields
 
 The recovered constructors give the following offset-level view.  The member names
@@ -15,7 +20,7 @@ SM64DS declarations.
 | `+0x00` | 4 | class-construction factory | Tier A: the registry descriptor points to an allocating wrapper |
 | `+0x04` | 2 | registry/profile index **and** behavior/execute-list order | Tier A: all 391 registry entries have a valid descriptor interpretation whose value equals the registry index; `fBase_c::fBase_c` copies the same halfword into `manager.behaviorNode` priority |
 | `+0x06` | 2 | render/draw-list order | Tier A: `fBase_c::fBase_c` copies it into `manager.renderNode` priority |
-| `+0x08` | 4 | actor flags/properties | Tier A for storage: `dActor_c::dActor_c` copies it to `dActor_c::mFlags`; individual bit meanings are only partly understood |
+| `+0x08` | 4 | actor flags/properties | Tier A for storage: `dActor_c::dActor_c` copies it to `dActor_c::mFlags`; exactly fifteen bits are ever authored and four of them have recovered consumers -- see the flags section |
 | `+0x0c` | 4 | vertical clip-volume centre offset | Tier A consumer semantics: first argument to `dActor_c::SetRanges`, stored without scaling in `mClipOffsetY` |
 | `+0x10` | 4 | clip radius | Tier A consumer semantics: second `SetRanges` argument, shifted right three and stored in `mClipRadius` |
 | `+0x14` | 4 | clip distance | Tier A consumer semantics: third `SetRanges` argument; game mode 2 adds `0x7d0000` before the call |
@@ -31,11 +36,11 @@ This sharpens Troy's initial field list in two ways:
    value as behavior/execute order.  This closely resembles NSMBW's `BASE_PROFILE`
    and `ACTOR_PROFILE` macros, which use the profile number as execute order by
    default.
-2. A distinct group-flags member has not yet been located in either runtime
-   descriptor.  `fBase_c` does carry a byte at `+0x12`, seeded from construction
-   context rather than read from the profile by the recovered constructor.  That is
-   a lead, not enough evidence to identify Troy's proposed group flags or their
-   source-declaration position.
+2. A distinct group-flags member is absent from both runtime descriptors because it
+   is not descriptor data at all.  The `fBase_c +0x12` byte is an argument of the
+   framework's create call, and the create path traced below identifies it as
+   NSMBW's group type.  Troy's group flags are a per-spawn parameter supplied by
+   whoever creates the object, not a field the profile carries.
 
 The four actor range words are not merely adjacent values inferred from magnitude.
 They flow through the matched `dActor_c` constructors and `SetRanges`, and their
@@ -43,6 +48,141 @@ later culling consumers establish offset-Y, radius, clip-distance, and far-dista
 roles.  A source-level declaration macro could still have accepted conceptually
 different or differently ordered arguments, but the emitted runtime object has the
 layout above.
+
+## The create path, and where the group-type byte comes from
+
+The registry is reached through one function, and reading it settles two of the
+questions this note previously left open.
+
+`func_02043098` is the framework's create entry point.  Its four parameters are the
+profile index, a parent scene node, a caller-supplied parameter word, and a byte:
+
+```c
+int func_02043098(int idx, SceneNode *parent, int param, u8 groupType)
+{
+    data_020a4b50 = idx;                    /* the id being constructed */
+    data_020a4b4c = 2;                      /* creation-phase state machine */
+    if (func_02043060(idx) == 3) return 0;
+    data_020a4b4c = 3;
+    func_02043180(idx, parent, param, groupType);   /* stash all four in globals */
+    data_020a4b4c = 4;
+    r5 = (*data_020a4bb8[idx])();           /* registry[idx]->factory() */
+    ...
+}
+```
+
+Two Tier-A consequences.
+
+**`data_020a4bb8` is the registry itself, and `+0x00` really is the factory.**
+`(*data_020a4bb8[idx])()` dereferences the descriptor pointer and calls the word it
+finds there.  The same `data_020a4bb8[idx]` is read by `fBase_c::fBase_c` as a
+struct to fetch the two priority halfwords.  One table, two consumers, and the
+call proves the first word's role rather than inferring it from shape.
+
+**The `+0x12` byte is a create argument, not profile data.**  It travels
+`func_02043098`'s fourth parameter -> `func_02043180` -> the global `data_020a4b48`
+-> `fBase_c::fBase_c`'s `unk_012 = data_020a4b48`.  Nothing reads it from the
+descriptor, because it never was in the descriptor.  The globals exist only to
+carry the four arguments across the factory call, which takes no arguments of its
+own.
+
+Two thin wrappers complete the shape, and both are byte-confirmed:
+
+| function | bytes at | what it does | NSMBW analogue |
+|---|---|---|---|
+| `func_02042fe4` | `0x02042fe4` | `mov r3,r2; mov r2,r1; mov r1,#0; bx` -- shifts the arguments up and passes a null parent | `createRoot(profName, param, groupType)` |
+| `func_02042ffc` | `0x02042ffc` | returns 0 on a null parent, else `add r1,r1,#0x14` and calls `func_02043098` -- converts an `fBase_c *` to `&parent->manager` | `createChild(profName, parent, param, groupType)` |
+| `func_02043098` | `0x02043098` | the core; takes the parent scene node directly | -- |
+
+The pinned NSMBW header declares
+`createChild(ProfileName profName, fBase_c *parent, unsigned long param, u8 groupType)`
+and `createRoot(ProfileName profName, unsigned long param, u8 groupType)`, with
+members `mParam` (u32), `mProfName` (`ProfileName`), and
+`mGroupType` (u8, "value is a `GROUP_TYPE_e`").  SM64DS's `fBase_c` stores the same
+three at `+0x08`, `+0x0c`, and `+0x12`, seeded in that order by the same three
+arguments.  The parameter list, its order, and the destination fields all agree.
+
+That is strong lineage evidence for the *role* of `+0x12`.  It is not proof of the
+SM64DS spelling, and this note does not rename `unk_012`: no SM64DS consumer of the
+byte has been recovered yet, so its value set is still unknown.  The one recovered
+writer is the create path; a reader would be needed to establish what the values
+mean.
+
+## Actor flags: what the profile authors and what the runtime writes
+
+The `+0x08` word is a single storage location with two populations of bits in it.
+`dActor_c::dActor_c` copies the descriptor word into `mFlags` verbatim, and the
+per-frame framework then sets and clears bits in that same word.  Separating the
+two is what makes the field readable.
+
+Across the 353 soundly-parsed actor descriptors (see the defect section below),
+exactly fifteen bits are ever authored:
+
+| bit | profiles | proven core consumer |
+|---|---:|---|
+| `0x00000001` | 54 | `BeforeBehavior`: enables the clip test (`mFlags & 0x10003`), and `(f & 9) != 9` makes off-screen skip behaviour |
+| `0x00000002` | 278 | `BeforeRender`: off screen plus this bit means do not draw; also enables the clip test |
+| `0x00000004` | 25 | none recovered |
+| `0x00000080` | 9 | none recovered |
+| `0x00000200` | 5 | none recovered |
+| `0x00008000` | 6 | none recovered |
+| `0x00010000` | 3 | `BeforeBehavior`: defeats the global force-think override while the actor is invisible |
+| `0x00800000` | 19 | none recovered in core; `Player::St_Talk_*` sets and clears it at runtime |
+| `0x01000000` | 4 | none recovered |
+| `0x02000000` | 8 | none recovered |
+| `0x04000000` | 8 | none recovered in core; read by several unrelated actor `Behavior`s |
+| `0x08000000` | 6 | `BeforeInitResources`: spawn even if the death table records this actor as already killed |
+| `0x10000000` | 38 | none recovered in core; set at runtime by enemy code |
+| `0x20000000` | 13 | none recovered |
+| `0x40000000` | 3 | none recovered |
+
+The runtime-state bits are the complement, and the population check is the point:
+**no profile authors any of them.**
+
+| bit | written by | meaning |
+|---|---|---|
+| `0x08` | `BeforeBehavior` (clipper), `AfterInitResources` | off screen |
+| `0x10` | `BeforeBehavior` when the clip distance exceeds `mFarDistance` | far away; also suppresses the drop shadow in `DropShadowRadHeight` and `DropShadowScaleXYZ` |
+| `0x20` | `BeforeBehavior` when `mAreaId` names an area that is not showing | wrong area |
+| `0x20000`, `0x40000` | actor code | Yoshi-mouth states |
+
+`AfterInitResources` seeds `0x38` -- all three at once -- so an actor starts fully
+invisible and the first `BeforeBehavior` decides otherwise.
+
+This replaces the speculative bit table in `include/dActor_c.h`, which listed
+`0x08`, `0x10`, and `0x20` as though a profile might author them and described
+`0x10` as "past shadow range".  `0x10` is the far-distance bit; shadow suppression
+is one of its consumers, not its definition.  Seventeen bit positions are never set
+by any profile and have no recovered consumer, so the word is nowhere near fully
+attributed -- but the fifteen authored bits are now a closed set rather than an
+open question, and eleven of them are still unexplained.
+
+## Three registry rows are parsed with the wrong descriptor family
+
+`CAMERA`, `MAP`, and `ENTRY_OBJECT` are recorded in
+`symbols/profile_reconstruction_registry.tsv` as `actor_profile_0x1c`, and their
+actor-only fields are visibly adjacent data rather than values:
+
+```text
+CAMERA        actor_flags 0x020084b0   clip_radius 0x020078c4   far_distance 0x02009e70
+MAP           actor_flags 0x0209a764   clip_offset_y 0x0210c158  clip_radius 0x02086e78
+ENTRY_OBJECT  actor_flags 0x0211478c   clip_radius 0x02114560   far_distance 0x02114010
+```
+
+Every one of those is a code or data pointer.  `CAMERA`'s descriptor at
+`0x02086d78` reads `{factory 0x0200e444, 0x0000014c, 0x020084b0, 0, 0x020078c4, 0,
+0x02009e70, 0}` -- an 0x08 base profile with execute order `0x14c` and draw order
+zero, followed by three more 0x08 profiles packed behind it.  This is exactly the
+failure `profile-macro-patterns.md` predicts when a short descriptor is read as a
+long one; the family choice from RTTI ancestry picked wrong for these three.
+
+The three rows are the sole source of the apparent profile-authored `0x08`, `0x10`,
+and `0x20` bits, so the flag census above is self-consistent only once they are
+removed.  That is a second, independent reason to believe they are mis-parsed.
+`KI_HASIRA`, `CASKET`, `FM_BATTAN`, `RC_TIKUWA`, and `ONIMASU` also carry
+pointer-shaped flag words (`0x02000002` and friends), but their range words are
+ordinary clip values, so those are genuine `0x02000000`-bit profiles rather than
+parse defects.
 
 ## WATERFALL with consumer-oriented labels
 
@@ -100,13 +240,27 @@ number in
 Those files are lineage evidence, not proof that SM64DS used the same source names,
 types, or macro syntax.
 
+## Answered since the first pass
+
+- **Troy's group flags.**  Not a profile field.  The `fBase_c +0x12` byte is the
+  fourth argument of the create call, matching NSMBW's `mGroupType`.  Its producer
+  is `func_02043180`, called from `func_02043098`, fed by
+  `func_02042fe4`/`func_02042ffc`.  Its *values* remain unknown: no reader has been
+  recovered.
+- **Execute and draw order as explicit arguments.**  The question is moot for
+  `+0x04`, which equals the registry index in all 391 entries.  `+0x06` is
+  independent: 347 distinct draw orders over 353 sound actor rows, spanning 0..359
+  with no relation to the index, so draw order was authored per profile.
+
 ## Open questions
 
-- What source concept and bit meanings correspond to Troy's group flags?
-- Is the `fBase_c +0x12` construction-context byte related, and where is its
-  producer?
+- What are the group-type values, and who reads `fBase_c +0x12`?  A reader would
+  turn the NSMBW `GROUP_TYPE_e` analogy into a checkable claim.
+- Eleven of the fifteen profile-authored flag bits have no recovered consumer:
+  `0x04`, `0x80`, `0x200`, `0x8000`, `0x800000`, `0x1000000`, `0x2000000`,
+  `0x4000000`, `0x10000000`, `0x20000000`, `0x40000000`.  `0x800000`, `0x4000000`,
+  and `0x10000000` have runtime writers in actor code, which is a starting thread.
 - Did SM64DS's declaration mechanism accept culling values directly, or transform a
   smaller source-level parameter set into the four runtime range words?
-- Were execute and draw order explicit arguments in exceptional profiles even though
-  `+0x04` equals the profile index throughout the registry?
-- What are the complete actor-flags/property bit definitions?
+- What is the correct descriptor family for `CAMERA`, `MAP`, and `ENTRY_OBJECT`,
+  and does fixing the extractor's family choice change any other row?


### PR DESCRIPTION
Second pass on `notes/profile-lifecycle-crosswalk.md`, closing two of its open questions from the bytes.

## The create path

`func_02043098` is the framework's create entry point: four arguments (profile index, parent scene node, caller parameter, byte), stashed in globals, then `(*data_020a4bb8[idx])()`. That call is direct proof that `data_020a4bb8` is the registry and that a descriptor's `+0x00` is the factory — `fBase_c::fBase_c` reads the same table as a struct for its priority halfwords.

The fourth argument is where `fBase_c +0x12` comes from. **Troy's proposed group flags are not a profile field**; they are a per-spawn create argument. `func_02042fe4` and `func_02042ffc` are byte-confirmed wrappers matching NSMBW's `createRoot`/`createChild`, whose pinned header declares the same four parameters in the same order landing in `mParam`, `mProfName`, `mGroupType`.

`unk_012` is deliberately **not** renamed: no SM64DS reader of the byte has been recovered, so its value set is unknown.

## The actor-flags word

Two disjoint populations share `+0x08`. Over the 353 soundly-parsed actor descriptors, exactly fifteen bits are ever authored by a profile, and the framework's own bits (`0x08` off screen, `0x10` beyond `mFarDistance`, `0x20` area not showing) are authored by **none** of them. Four authored bits have recovered consumers in `dActor_c`'s pre-hooks; eleven do not. `include/dActor_c.h`'s speculative bit table is replaced with the measured one (comment only — bytes unchanged).

## A parse defect, recorded not fixed

`CAMERA`, `MAP` and `ENTRY_OBJECT` are 0x08 base profiles recorded as 0x1c actor profiles, so their flag and range fields are adjacent pointers. CAMERA's descriptor is `{0x0200e444, exec 0x14c, draw 0}` with three more base profiles packed behind it. They are the sole source of the apparent profile-authored `0x08`/`0x10`/`0x20` bits, which is a second independent reason to believe they are mis-parsed.

## Gates

- `python tools/rombuild.py -j 16 --no-rom` — module fidelity 106/106 exact, 100.000000%, ROM-build analysis PASS
- `python tools/check_header_offsets.py include/dActor_c.h` — 33 commented fields, 0 mismatched
- `python tools/check_dead_references.py` — no new dead references, no broken markdown links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA