### PR TITLE
Reconstruct 8 promoted-TU ov002 actor profiles (wave 36)

### DIFF
--- a/config/arm9/overlays/ov002/symbols.txt
+++ b/config/arm9/overlays/ov002/symbols.txt
@@ -85,7 +85,7 @@ _ZN10daCamTag_c16OnPendingDestroyEv kind:function(arm,size=0x4) addr:0x020b07ac
 _ZN10daCamTag_c6RenderEv kind:function(arm,size=0x8) addr:0x020b07b0
 _ZN10daCamTag_c8BehaviorEv kind:function(arm,size=0x8) addr:0x020b07b8
 _ZN10daCamTag_c13InitResourcesEv kind:function(arm,size=0x8) addr:0x020b07c0
-daCamTag_c_Spawn kind:function(arm,size=0x30) addr:0x020b07c8
+daCamTag_c_classInit kind:function(arm,size=0x30) addr:0x020b07c8
 _ZN10daChRoom_cD1Ev kind:function(arm,size=0x24) addr:0x020b07f8
 _ZN10daChRoom_cD0Ev kind:function(arm,size=0x38) addr:0x020b081c
 _ZN10daChRoom_c16CleanupResourcesEv kind:function(arm,size=0x8) addr:0x020b0854
@@ -93,7 +93,7 @@ _ZN10daChRoom_c16OnPendingDestroyEv kind:function(arm,size=0x4) addr:0x020b085c
 _ZN10daChRoom_c6RenderEv kind:function(arm,size=0x8) addr:0x020b0860
 _ZN10daChRoom_c8BehaviorEv kind:function(arm,size=0xd0) addr:0x020b0868
 _ZN10daChRoom_c13InitResourcesEv kind:function(arm,size=0x48) addr:0x020b0938
-daChRoom_c_Spawn kind:function(arm,size=0x30) addr:0x020b0980
+daChRoom_c_classInit kind:function(arm,size=0x30) addr:0x020b0980
 _ZN11daChScene_cD1Ev kind:function(arm,size=0x24) addr:0x020b09b0
 _ZN11daChScene_cD0Ev kind:function(arm,size=0x38) addr:0x020b09d4
 func_ov002_020b0a0c kind:function(arm,size=0x64) addr:0x020b0a0c
@@ -102,7 +102,7 @@ _ZN11daChScene_c16OnPendingDestroyEv kind:function(arm,size=0x4) addr:0x020b0a78
 _ZN11daChScene_c6RenderEv kind:function(arm,size=0x8) addr:0x020b0a7c
 _ZN11daChScene_c8BehaviorEv kind:function(arm,size=0x304) addr:0x020b0a84
 _ZN11daChScene_c13InitResourcesEv kind:function(arm,size=0x19c) addr:0x020b0d88
-daChScene_c_Spawn kind:function(arm,size=0x30) addr:0x020b0f24
+daChScene_c_classInit kind:function(arm,size=0x30) addr:0x020b0f24
 _ZN4CoinD1Ev kind:function(arm,size=0x50) addr:0x020b0f54
 _ZN4CoinD0Ev kind:function(arm,size=0x64) addr:0x020b0fa4
 func_ov002_020b1008 kind:function(arm,size=0x98) addr:0x020b1008
@@ -398,7 +398,7 @@ _ZN13daObjWakame_c16CleanupResourcesEv kind:function(arm,size=0x30) addr:0x020bc
 _ZN13daObjWakame_c6RenderEv kind:function(arm,size=0x28) addr:0x020bc4f8
 _ZN13daObjWakame_c8BehaviorEv kind:function(arm,size=0x20) addr:0x020bc520
 _ZN13daObjWakame_c13InitResourcesEv kind:function(arm,size=0x68) addr:0x020bc540
-daObjWakame_c_Spawn kind:function(arm,size=0x38) addr:0x020bc5a8
+daObjWakame_c_classInit kind:function(arm,size=0x38) addr:0x020bc5a8
 _ZN12HealingHeartD1Ev kind:function(arm,size=0x38) addr:0x020bc5e0
 _ZN12HealingHeartD0Ev kind:function(arm,size=0x4c) addr:0x020bc618
 func_ov002_020bc664 kind:function(arm,size=0x40) addr:0x020bc664
@@ -1127,7 +1127,7 @@ _ZN8daTree_c16OnPendingDestroyEv kind:function(arm,size=0x4) addr:0x020ec0a0
 _ZN8daTree_c6RenderEv kind:function(arm,size=0x134) addr:0x020ec0a4
 _ZN8daTree_c8BehaviorEv kind:function(arm,size=0x54) addr:0x020ec1d8
 _ZN8daTree_c13InitResourcesEv kind:function(arm,size=0x100) addr:0x020ec22c
-Tree_Spawn kind:function(arm,size=0x5c) addr:0x020ec32c
+daTree_c_classInit kind:function(arm,size=0x5c) addr:0x020ec32c
 _ZN11daWarpkun_cD1Ev kind:function(arm,size=0x30) addr:0x020ec388
 _ZN11daWarpkun_cD0Ev kind:function(arm,size=0x44) addr:0x020ec3b8
 _ZN11daWarpkun_c16CleanupResourcesEv kind:function(arm,size=0x8) addr:0x020ec3fc
@@ -1135,7 +1135,7 @@ _ZN11daWarpkun_c16OnPendingDestroyEv kind:function(arm,size=0x4) addr:0x020ec404
 _ZN11daWarpkun_c6RenderEv kind:function(arm,size=0x8) addr:0x020ec408
 _ZN11daWarpkun_c8BehaviorEv kind:function(arm,size=0xb4) addr:0x020ec410
 _ZN11daWarpkun_c13InitResourcesEv kind:function(arm,size=0x70) addr:0x020ec4c4
-daWarpkun_c_Spawn kind:function(arm,size=0x38) addr:0x020ec534
+daWarpkun_c_classInit kind:function(arm,size=0x38) addr:0x020ec534
 _ZN8YoshiEggD1Ev kind:function(arm,size=0x48) addr:0x020ec56c
 _ZN8YoshiEggD0Ev kind:function(arm,size=0x5c) addr:0x020ec5b4
 func_ov002_020ec610 kind:function(arm,size=0x18) addr:0x020ec610
@@ -1268,7 +1268,7 @@ _ZN9daSetSE_c16OnPendingDestroyEv kind:function(arm,size=0x4) addr:0x020f19f0
 _ZN9daSetSE_c6RenderEv kind:function(arm,size=0x8) addr:0x020f19f4
 _ZN9daSetSE_c8BehaviorEv kind:function(arm,size=0xc8) addr:0x020f19fc
 _ZN9daSetSE_c13InitResourcesEv kind:function(arm,size=0xd0) addr:0x020f1ac4
-daSetSE_c_Spawn kind:function(arm,size=0x30) addr:0x020f1b94
+daSetSE_c_classInit kind:function(arm,size=0x30) addr:0x020f1b94
 _ZN8MugenBgmD1Ev kind:function(arm,size=0x24) addr:0x020f1bc4
 _ZN8MugenBgmD0Ev kind:function(arm,size=0x38) addr:0x020f1be8
 func_ov002_020f1c20 kind:function(arm,size=0x30) addr:0x020f1c20
@@ -1442,7 +1442,7 @@ func_ov002_020f93a8 kind:function(arm,size=0xc0) addr:0x020f93a8
 func_ov002_020f9468 kind:function(arm,size=0x94) addr:0x020f9468
 _ZN12daSoundObj_c8BehaviorEv kind:function(arm,size=0xe4) addr:0x020f94fc
 _ZN12daSoundObj_c13InitResourcesEv kind:function(arm,size=0x14c) addr:0x020f95e0
-daSoundObj_c_Spawn kind:function(arm,size=0x30) addr:0x020f972c
+daSoundObj_c_classInit kind:function(arm,size=0x30) addr:0x020f972c
 _ZN7MinimapD1Ev kind:function(arm,size=0x30) addr:0x020f975c
 _ZN7MinimapD0Ev kind:function(arm,size=0x44) addr:0x020f978c
 _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3 kind:function(arm,size=0x1d8) addr:0x020f97d0
@@ -1698,15 +1698,15 @@ g_profile_BAR kind:data(any) addr:0x0210845c
 _ZTV7daBar_c kind:data(any) addr:0x02108480
 _ZTI10daCamTag_c kind:data(any) addr:0x021084fc
 _ZTS10daCamTag_c kind:data(any) addr:0x02108508
-daCamTag_c_SpawnInfo kind:data(any) addr:0x02108518
+g_profile_CAMERA_TAG kind:data(any) addr:0x02108518
 _ZTV10daCamTag_c kind:data(any) addr:0x0210853c
 _ZTI10daChRoom_c kind:data(any) addr:0x021085b8
 _ZTS10daChRoom_c kind:data(any) addr:0x021085c4
-daChRoom_c_SpawnInfo kind:data(any) addr:0x021085d4
+g_profile_CH_ROOM kind:data(any) addr:0x021085d4
 _ZTV10daChRoom_c kind:data(any) addr:0x021085f8
 _ZTI11daChScene_c kind:data(any) addr:0x02108674
 _ZTS11daChScene_c kind:data(any) addr:0x02108680
-daChScene_c_SpawnInfo kind:data(any) addr:0x02108690
+g_profile_CH_SCENE kind:data(any) addr:0x02108690
 _ZTV11daChScene_c kind:data(any) addr:0x021086b4
 data_ov002_02108730 kind:data(any) addr:0x02108730
 data_ov002_02108738 kind:data(any) addr:0x02108738
@@ -1883,7 +1883,7 @@ _ZTV8SignPost kind:data(any) addr:0x02109af8
 _ZTV15daObjTatefuda_c kind:data(any) addr:0x02109af8
 _ZTI13daObjWakame_c kind:data(any) addr:0x02109b78
 _ZTS13daObjWakame_c kind:data(any) addr:0x02109b84
-daObjWakame_c_SpawnInfo kind:data(any) addr:0x02109b94
+g_profile_WAKAME kind:data(any) addr:0x02109b94
 _ZTV13daObjWakame_c kind:data(any) addr:0x02109bb8
 _ZTI12daObjHeart_c kind:data(any) addr:0x02109c34
 _ZTS12daObjHeart_c kind:data(any) addr:0x02109c40
@@ -2205,11 +2205,11 @@ _ZTV8daStar_c kind:data(any) addr:0x0210ab3c
 data_ov002_0210abb8 kind:data(any) addr:0x0210abb8
 _ZTS8daTree_c kind:data(any) addr:0x0210abc4
 _ZTI8daTree_c kind:data(any) addr:0x0210abd0
-Tree_SpawnInfo kind:data(any) addr:0x0210abdc
+g_profile_TREE kind:data(any) addr:0x0210abdc
 _ZTV8daTree_c kind:data(any) addr:0x0210ac00
 _ZTI11daWarpkun_c kind:data(any) addr:0x0210ac7c
 _ZTS11daWarpkun_c kind:data(any) addr:0x0210ac88
-daWarpkun_c_SpawnInfo kind:data(any) addr:0x0210ac98
+g_profile_WARPKUN kind:data(any) addr:0x0210ac98
 _ZTV11daWarpkun_c kind:data(any) addr:0x0210acbc
 data_ov002_0210ad38 kind:data(any) addr:0x0210ad38
 data_ov002_0210ad40 kind:data(any) addr:0x0210ad40
@@ -2269,7 +2269,7 @@ _ZTV14EnemySwitchTag kind:data(any) addr:0x0210b3e8
 _ZTV11daESwitch_c kind:data(any) addr:0x0210b3e8
 _ZTS9daSetSE_c kind:data(any) addr:0x0210b464
 _ZTI9daSetSE_c kind:data(any) addr:0x0210b470
-daSetSE_c_SpawnInfo kind:data(any) addr:0x0210b47c
+g_profile_SET_SE kind:data(any) addr:0x0210b47c
 data_ov002_0210b498 kind:data(any) addr:0x0210b498
 _ZTV9daSetSE_c kind:data(any) addr:0x0210b4c8
 _ZTI12daMugenBGM_c kind:data(any) addr:0x0210b544
@@ -2442,7 +2442,7 @@ data_ov002_0210c038 kind:data(any) addr:0x0210c038
 data_ov002_0210c040 kind:data(any) addr:0x0210c040
 _ZTI12daSoundObj_c kind:data(any) addr:0x0210c048
 _ZTS12daSoundObj_c kind:data(any) addr:0x0210c054
-daSoundObj_c_SpawnInfo kind:data(any) addr:0x0210c064
+g_profile_SOUND_OBJ kind:data(any) addr:0x0210c064
 data_ov002_0210c080 kind:data(any) addr:0x0210c080
 data_ov002_0210c084 kind:data(any) addr:0x0210c084
 data_ov002_0210c088 kind:data(any) addr:0x0210c088

--- a/config/tu_manifest.d/ov002/daCamTag_c.json
+++ b/config/tu_manifest.d/ov002/daCamTag_c.json
@@ -68,7 +68,7 @@
       "ordinal": 6
     },
     {
-      "symbol": "daCamTag_c_Spawn",
+      "symbol": "daCamTag_c_classInit",
       "address": "0x020b07c8",
       "size": "0x00000030",
       "legacy_source": "src/daCamTag_c_Spawn.c",

--- a/config/tu_manifest.d/ov002/daChRoom_c.json
+++ b/config/tu_manifest.d/ov002/daChRoom_c.json
@@ -68,7 +68,7 @@
       "ordinal": 6
     },
     {
-      "symbol": "daChRoom_c_Spawn",
+      "symbol": "daChRoom_c_classInit",
       "address": "0x020b0980",
       "size": "0x00000030",
       "legacy_source": "src/daChRoom_c_Spawn.c",

--- a/config/tu_manifest.d/ov002/daChScene_c.json
+++ b/config/tu_manifest.d/ov002/daChScene_c.json
@@ -75,7 +75,7 @@
       "ordinal": 7
     },
     {
-      "symbol": "daChScene_c_Spawn",
+      "symbol": "daChScene_c_classInit",
       "address": "0x020b0f24",
       "size": "0x00000030",
       "legacy_source": "src/daChScene_c_Spawn.c",

--- a/config/tu_manifest.d/ov002/daObjWakame_c.json
+++ b/config/tu_manifest.d/ov002/daObjWakame_c.json
@@ -68,7 +68,7 @@
       "ordinal": 6
     },
     {
-      "symbol": "daObjWakame_c_Spawn",
+      "symbol": "daObjWakame_c_classInit",
       "address": "0x020bc5a8",
       "size": "0x00000038",
       "legacy_source": "src/daObjWakame_c_Spawn.c",

--- a/config/tu_manifest.d/ov002/daSetSE_c.json
+++ b/config/tu_manifest.d/ov002/daSetSE_c.json
@@ -69,7 +69,7 @@
       "ordinal": 6
     },
     {
-      "symbol": "daSetSE_c_Spawn",
+      "symbol": "daSetSE_c_classInit",
       "address": "0x020f1b94",
       "size": "0x00000030",
       "legacy_source": "src/daSetSE_c_Spawn.c",

--- a/config/tu_manifest.d/ov002/daSoundObj_c.json
+++ b/config/tu_manifest.d/ov002/daSoundObj_c.json
@@ -61,7 +61,7 @@
       "ordinal": 5
     },
     {
-      "symbol": "daSoundObj_c_Spawn",
+      "symbol": "daSoundObj_c_classInit",
       "address": "0x020f972c",
       "size": "0x00000030",
       "legacy_source": "src/daSoundObj_c_Spawn.c",

--- a/config/tu_manifest.d/ov002/daTree_c.json
+++ b/config/tu_manifest.d/ov002/daTree_c.json
@@ -68,7 +68,7 @@
       "ordinal": 6
     },
     {
-      "symbol": "Tree_Spawn",
+      "symbol": "daTree_c_classInit",
       "address": "0x020ec32c",
       "size": "0x0000005c",
       "legacy_source": "src/Tree_Spawn.cpp",

--- a/config/tu_manifest.d/ov002/daWarpkun_c.json
+++ b/config/tu_manifest.d/ov002/daWarpkun_c.json
@@ -68,7 +68,7 @@
       "ordinal": 6
     },
     {
-      "symbol": "daWarpkun_c_Spawn",
+      "symbol": "daWarpkun_c_classInit",
       "address": "0x020ec534",
       "size": "0x00000038",
       "legacy_source": "src/daWarpkun_c_Spawn.c",

--- a/include/daCamTag_c.h
+++ b/include/daCamTag_c.h
@@ -2,7 +2,7 @@
  * class daCamTag_c, ov002 0x020b0748-0x020b07f8 (8 functions, no other class
  * in the TU -- tu_map.py). That range is the entry's licensed `complete`
  * delinks span and it is exact: the eight functions chain contiguously from
- * 0x020b0748 up to daCamTag_c_Spawn at 0x020b07c8 + 0x30. An earlier version
+ * 0x020b0748 up to daCamTag_c_classInit at 0x020b07c8 + 0x30. An earlier version
  * of this line said 0x020b0710-0x020b07c8, which started one function too
  * early -- 0x020b0710 is InvisiblePole_Spawn, the same off-by-one factory
  * that produced the retracted layout described below.
@@ -13,13 +13,13 @@
  * dActor_c and nothing more functionally, marking a position other code
  * queries.
  *
- * SIZE 0xd4 (212), tools/opnew_sizes.py's own literal from daCamTag_c_Spawn's
+ * SIZE 0xd4 (212), tools/opnew_sizes.py's own literal from daCamTag_c_classInit's
  * `operator new` call -- independent ROM evidence, not the header's own
  * sizeof() echoed back. dActor_c itself is 0xd0 (include/dActor_c.h), so
  * daCamTag_c adds exactly FOUR bytes on top of it: one unknown/unused field,
  * not zero as an earlier version of this header claimed.
  *
- *   daCamTag_c_Spawn  0x020b07c8  new(212 == 0xd4), dActor_c::dActor_c(),
+ *   daCamTag_c_classInit  0x020b07c8  new(212 == 0xd4), dActor_c::dActor_c(),
  *                                stores _ZTV10daCamTag_c.
  *
  * THIS HEADER USED TO SAY 0x108, with a dCcAc_c at 0xd4. That was
@@ -56,6 +56,15 @@
  */
 #ifndef DACAMTAG_C_H
 #define DACAMTAG_C_H
+
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daCamTag_c -- daCamTag_c_classInit (was daCamTag_c_Spawn),
+ *       g_profile_CAMERA_TAG (was daCamTag_c_SpawnInfo)
+ */
 #include "types.h"
 
 #ifdef __cplusplus

--- a/include/daChRoom_c.h
+++ b/include/daChRoom_c.h
@@ -1,13 +1,22 @@
 #ifndef DACHROOM_C_H
 #define DACHROOM_C_H
 
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daChRoom_c -- daChRoom_c_classInit (was daChRoom_c_Spawn),
+ *       g_profile_CH_ROOM (was daChRoom_c_SpawnInfo)
+ */
+
 #include "dActor_c.h"
 
 /* An area-transition trigger box -- ov002/daChRoom_c, and the class the ROM
  * spells daChRoom_c rather than the coined VirtualDoor it carried until this
  * commit.
  *
- * THE SIZE IS THE FACTORY'S OWN LITERAL: daChRoom_c_Spawn at 0x020b0980 is
+ * THE SIZE IS THE FACTORY'S OWN LITERAL: daChRoom_c_classInit at 0x020b0980 is
  * `mov r0, #0xd4` into fBase_c::operator new, then the dActor_c base
  * constructor, the vptr store and the return. dActor_c ends at 0xd0, so the
  * class's own storage is the final four bytes and nothing in this TU reads

--- a/include/daChScene_c.h
+++ b/include/daChScene_c.h
@@ -39,6 +39,15 @@
  */
 #ifndef DACHSCENE_C_H
 #define DACHSCENE_C_H
+
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daChScene_c -- daChScene_c_classInit (was daChScene_c_Spawn),
+ *       g_profile_CH_SCENE (was daChScene_c_SpawnInfo)
+ */
 #include "types.h"
 #include "math/Matrix.h"
 

--- a/include/daObjWakame_c.h
+++ b/include/daObjWakame_c.h
@@ -1,6 +1,15 @@
 #ifndef DAOBJWAKAME_C_H
 #define DAOBJWAKAME_C_H
 
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daObjWakame_c -- daObjWakame_c_classInit (was daObjWakame_c_Spawn),
+ *       g_profile_WAKAME (was daObjWakame_c_SpawnInfo)
+ */
+
 #include "types.h"
 #include "dActor_c.h"
 #include "ModelAnim.h"
@@ -11,7 +20,7 @@
  * THE SIZE HAS TWO WITNESSES AND THEY CLOSE ON EACH OTHER, which is the whole
  * reason this layout can be stated flatly rather than hedged.
  *
- *   SIZE 0x138 is daObjWakame_c_Spawn's own literal: `mov r0, #312` into
+ *   SIZE 0x138 is daObjWakame_c_classInit's own literal: `mov r0, #312` into
  *   fBase_c::operator new. The factory then runs dActor_c's constructor, stores
  *   the vptr, and constructs ONE member, at this+0xd4.
  *

--- a/include/daSetSE_c.h
+++ b/include/daSetSE_c.h
@@ -1,9 +1,18 @@
 #ifndef DASETSE_C_H
 #define DASETSE_C_H
 
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daSetSE_c -- daSetSE_c_classInit (was daSetSE_c_Spawn),
+ *       g_profile_SET_SE (was daSetSE_c_SpawnInfo)
+ */
+
 #include "dActor_c.h"
 
-/* SIZE 0xd8 is daSetSE_c_Spawn's own literal -- it allocates 0xd8 and
+/* SIZE 0xd8 is daSetSE_c_classInit's own literal -- it allocates 0xd8 and
  * constructs only the dActor_c base, touching no member of its own.
  *
  * THE ONE DERIVED FIELD is witnessed by Behavior, which reads 0xd4, passes it
@@ -12,7 +21,7 @@
  * inherited param1 at 0x08. Field names are a reading; the offset is pinned.
  *
  * NOTHING INITIALIZES IT, and that is the cartridge's behaviour, not an
- * omission here. daSetSE_c_Spawn allocates 0xd8 and constructs only the
+ * omission here. daSetSE_c_classInit allocates 0xd8 and constructs only the
  * dActor_c base -- it never touches 0xd4 -- so Behavior's first call reads
  * whatever fBase_c::operator new left there and hands it to PlayLong, which
  * treats a handle it does not recognise as "not playing". Do not add an

--- a/include/daSoundObj_c.h
+++ b/include/daSoundObj_c.h
@@ -1,6 +1,15 @@
 #ifndef DASOUNDOBJ_C_H
 #define DASOUNDOBJ_C_H
 
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daSoundObj_c -- daSoundObj_c_classInit (was daSoundObj_c_Spawn),
+ *       g_profile_SOUND_OBJ (was daSoundObj_c_SpawnInfo)
+ */
+
 #include "types.h"
 #include "dActor_c.h"
 
@@ -8,7 +17,7 @@
  * witnesses -- worth stating plainly, because this class initializes nothing in
  * its factory and destroys nothing in its destructor.
  *
- *   SIZE 0xe4 is daSoundObj_c_Spawn's own literal: `mov r0, #0xe4` into
+ *   SIZE 0xe4 is daSoundObj_c_classInit's own literal: `mov r0, #0xe4` into
  *   fBase_c::operator new. All twelve words of that 0x30-byte function are new,
  *   the dActor_c base constructor, the vptr store and the return -- it touches
  *   no member of its own. `~daSoundObj_c` is 0x24 bytes, one vptr store and the

--- a/include/daTree_c.h
+++ b/include/daTree_c.h
@@ -12,7 +12,7 @@
  * InitResources, CleanupResources, Render and OnPendingDestroy are real
  * compiler-spelled daTree_c methods in src/actors/d_a_tree.cpp; the destructor
  * pair is compiler-generated from the inline definition below. Behavior stays a
- * hand-written free function under its own mangled ROM name, and Tree_Spawn
+ * hand-written free function under its own mangled ROM name, and daTree_c_classInit
  * under its unmangled one, because neither body references a named daTree_c
  * member. InitResources also keeps one low-level extern-C declaration for
  * dCcPos_c::Init: its ROM name carries by-value Fix12 parameters whose honest
@@ -36,6 +36,15 @@
  */
 #ifndef DATREE_C_H
 #define DATREE_C_H
+
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daTree_c -- daTree_c_classInit (was Tree_Spawn),
+ *       g_profile_TREE (was Tree_SpawnInfo)
+ */
 #include "types.h"
 #include "dActor_c.h"
 #include "Model.h"

--- a/include/daWarpkun_c.h
+++ b/include/daWarpkun_c.h
@@ -1,13 +1,22 @@
 #ifndef DAWARPKUN_C_H
 #define DAWARPKUN_C_H
 
+/* RECONSTRUCTED NAMES USED IN THIS HEADER. SM64DS RTTI names the
+ * implementation below; the registry profile object and the factory
+ * spelling are Tier B reconstructions -- evidence-bounded proposals, not
+ * recovered SM64DS symbols. Exact original spellings are not preserved.
+ *
+ *   daWarpkun_c -- daWarpkun_c_classInit (was daWarpkun_c_Spawn),
+ *       g_profile_WARPKUN (was daWarpkun_c_SpawnInfo)
+ */
+
 #include "types.h"
 #include "dActor_c.h"
 #include "dCcAc_c.h"
 
 /* TWO WITNESSES, and they close on each other:
  *
- *   daWarpkun_c_Spawn  fBase_c::operator new(264 = 0x108), dActor_c::dActor_c(), stores _ZTV11daWarpkun_c,
+ *   daWarpkun_c_classInit  fBase_c::operator new(264 = 0x108), dActor_c::dActor_c(), stores _ZTV11daWarpkun_c,
  *                 then the member below in this order.
  *   ~daWarpkun_c   the same member destroyed in reverse, then ~dActor_c.
  *

--- a/src/actors/d_a_cam_tag.cpp
+++ b/src/actors/d_a_cam_tag.cpp
@@ -58,14 +58,18 @@ extern void *data_020a0eac;
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 7 -- daCamTag_c_Spawn, 0x020b07c8, size 0x30 */
+/* ROM ordinal 7 -- daCamTag_c_classInit, 0x020b07c8, size 0x30 */
 /* -------------------------------------------------------------------------- */
-// @symbol daCamTag_c_Spawn
+// @symbol daCamTag_c_classInit
 /* recovered: globals resolved, declarations from a shared header */
 /* recovered: globals resolved */
 /* resolved: VT = _ZTV10daCamTag_c */
 extern "C" {  /* .c-derived member: C linkage for the whole block */
-int *daCamTag_c_Spawn(void)
+/* Reconstructed source-style name: SM64DS proves daCamTag_c through RTTI,
+ * allocation size, vtable identity, and the CAMERA_TAG registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: daCamTag_c_Spawn. */
+int *daCamTag_c_classInit(void)
 {
     int *p = (int *)_ZN7fBase_cnwEj(sizeof(struct daCamTag_c));
     if (p) { _ZN8dActor_cC2Ev(p); p[0] = (int)(_ZTV10daCamTag_c + 2); }

--- a/src/actors/d_a_ch_room.cpp
+++ b/src/actors/d_a_ch_room.cpp
@@ -76,14 +76,18 @@ extern char data_020a0ebc;
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 7 -- daChRoom_c_Spawn, 0x020b0980, size 0x30 */
+/* ROM ordinal 7 -- daChRoom_c_classInit, 0x020b0980, size 0x30 */
 /* -------------------------------------------------------------------------- */
-// @symbol daChRoom_c_Spawn
+// @symbol daChRoom_c_classInit
 /* recovered: globals resolved, declarations from a shared header */
 /* recovered: globals resolved */
 /* resolved: VT = _ZTV10daChRoom_c */
 extern "C" {  /* .c-derived member: C linkage for the whole block */
-int *daChRoom_c_Spawn(void)
+/* Reconstructed source-style name: SM64DS proves daChRoom_c through RTTI,
+ * allocation size, vtable identity, and the CH_ROOM registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: daChRoom_c_Spawn. */
+int *daChRoom_c_classInit(void)
 {
     int *p = (int *)_ZN7fBase_cnwEj(sizeof(daChRoom_c));
     if (p) { _ZN8dActor_cC2Ev(p); p[0] = (int)(_ZTV10daChRoom_c + 2); }

--- a/src/actors/d_a_ch_scene.cpp
+++ b/src/actors/d_a_ch_scene.cpp
@@ -137,14 +137,18 @@ extern void Matrix4x3_ApplyInPlaceToRotationX(void* m, short angX);
  * Behavior's. */
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 8 -- daChScene_c_Spawn, 0x020b0f24, size 0x30 */
+/* ROM ordinal 8 -- daChScene_c_classInit, 0x020b0f24, size 0x30 */
 /* -------------------------------------------------------------------------- */
-// @symbol daChScene_c_Spawn
+// @symbol daChScene_c_classInit
 /* recovered: globals resolved, declarations from a shared header */
 /* recovered: globals resolved */
 /* resolved: VT = _ZTV11daChScene_c */
 extern "C" {  /* .c-derived member: C linkage for the whole block */
-int *daChScene_c_Spawn(void)
+/* Reconstructed source-style name: SM64DS proves daChScene_c through RTTI,
+ * allocation size, vtable identity, and the CH_SCENE registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: daChScene_c_Spawn. */
+int *daChScene_c_classInit(void)
 {
     int *p = (int *)_ZN7fBase_cnwEj(sizeof(daChScene_c));
     if (p) { _ZN8dActor_cC2Ev(p); p[0] = (int)(_ZTV11daChScene_c + 2); }

--- a/src/actors/d_a_obj_wakame.cpp
+++ b/src/actors/d_a_obj_wakame.cpp
@@ -58,12 +58,16 @@ extern int   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *, void *, int, in
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 7 -- daObjWakame_c_Spawn, 0x020bc5a8, size 0x38 */
+/* ROM ordinal 7 -- daObjWakame_c_classInit, 0x020bc5a8, size 0x38 */
 /* -------------------------------------------------------------------------- */
 extern "C" {  /* .c-derived member: C linkage for the whole block */
 /* The +2 addend is the vtable ADDRESS POINT: _ZTV names the record's start and
    the object stores a pointer eight bytes in, past {offset-to-top, _ZTI}. */
-int *daObjWakame_c_Spawn(void)
+/* Reconstructed source-style name: SM64DS proves daObjWakame_c through RTTI,
+ * allocation size, vtable identity, and the WAKAME registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: daObjWakame_c_Spawn. */
+int *daObjWakame_c_classInit(void)
 {
     int *p = (int *)_ZN7fBase_cnwEj(312);
     if (p) {

--- a/src/actors/d_a_set_se.cpp
+++ b/src/actors/d_a_set_se.cpp
@@ -76,10 +76,14 @@ extern int data_0209fc48;
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 7 -- daSetSE_c_Spawn, 0x020f1b94, size 0x30 */
+/* ROM ordinal 7 -- daSetSE_c_classInit, 0x020f1b94, size 0x30 */
 /* -------------------------------------------------------------------------- */
-// @symbol daSetSE_c_Spawn
-extern "C" daSetSE_c *daSetSE_c_Spawn(void)
+// @symbol daSetSE_c_classInit
+/* Reconstructed source-style name: SM64DS proves daSetSE_c through RTTI,
+ * allocation size, vtable identity, and the SET_SE registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: daSetSE_c_Spawn. */
+extern "C" daSetSE_c *daSetSE_c_classInit(void)
 {
     daSetSE_c *p =
         (daSetSE_c *)_ZN7fBase_cnwEj(sizeof(daSetSE_c));

--- a/src/actors/d_a_sound_obj.cpp
+++ b/src/actors/d_a_sound_obj.cpp
@@ -91,10 +91,14 @@ extern void _ZN8dActor_cC2Ev(void *);
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 6 -- daSoundObj_c_Spawn, 0x020f972c, size 0x30 */
+/* ROM ordinal 6 -- daSoundObj_c_classInit, 0x020f972c, size 0x30 */
 /* -------------------------------------------------------------------------- */
 extern "C" {  /* .c-derived member: C linkage for the whole block */
-int *daSoundObj_c_Spawn(void)
+/* Reconstructed source-style name: SM64DS proves daSoundObj_c through RTTI,
+ * allocation size, vtable identity, and the SOUND_OBJ registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: daSoundObj_c_Spawn. */
+int *daSoundObj_c_classInit(void)
 {
     int *p = (int *)_ZN7fBase_cnwEj(228);
     if (p) { _ZN8dActor_cC2Ev(p); p[0] = (int)(_ZTV12daSoundObj_c + 2); }

--- a/src/actors/d_a_tree.cpp
+++ b/src/actors/d_a_tree.cpp
@@ -96,7 +96,7 @@ extern unsigned short data_ov002_0210abb8[];
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 7 -- Tree_Spawn, 0x020ec32c, size 0x5c */
+/* ROM ordinal 7 -- daTree_c_classInit, 0x020ec32c, size 0x5c */
 /* -------------------------------------------------------------------------- */
 #include "daTree_c.h"
 extern "C" {
@@ -106,7 +106,11 @@ extern void _ZN5ModelD1Ev(void*);
 extern void _ZN5ModelC1Ev(void*);
 extern void func_020733a8(void* arr, int count, int size, void(*ctor)(void*), void(*dtor)(void*));
 extern void* _ZTV8daTree_c[];
-int* Tree_Spawn(void){
+/* Reconstructed source-style name: SM64DS proves daTree_c through RTTI,
+ * allocation size, vtable identity, and the TREE registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: Tree_Spawn. */
+int* daTree_c_classInit(void){
   int* p = (int*)_ZN7fBase_cnwEj(sizeof(struct daTree_c));
   if(p){
     _ZN8dActor_cC2Ev(p);

--- a/src/actors/d_a_warpkun.cpp
+++ b/src/actors/d_a_warpkun.cpp
@@ -73,14 +73,18 @@ extern int _ZN7dCcAc_c4InitEP8dActor_c5Fix12IiES3_jj(void *, void *, Fix12i, Fix
 }
 
 /* -------------------------------------------------------------------------- */
-/* ROM ordinal 7 -- daWarpkun_c_Spawn, 0x020ec534, size 0x38 */
+/* ROM ordinal 7 -- daWarpkun_c_classInit, 0x020ec534, size 0x38 */
 /* -------------------------------------------------------------------------- */
-// @symbol daWarpkun_c_Spawn
+// @symbol daWarpkun_c_classInit
 /* recovered: vtable identified, declarations from a shared header */
 /* recovered: vtable identified */
 /* vtable identified: VT0 = _ZTV11daWarpkun_c */
 extern "C" {  /* .c-derived member: C linkage for the whole block */
-int *daWarpkun_c_Spawn(void)
+/* Reconstructed source-style name: SM64DS proves daWarpkun_c through RTTI,
+ * allocation size, vtable identity, and the WARPKUN registry profile;
+ * later EAD lineage supplies classInit. Exact original spelling is not
+ * preserved. Historical alias: daWarpkun_c_Spawn. */
+int *daWarpkun_c_classInit(void)
 {
     int *p = (int *)_ZN7fBase_cnwEj(264);
     if (p) {

--- a/symbols/actor_renames.tsv
+++ b/symbols/actor_renames.tsv
@@ -24,6 +24,7 @@ ov002	0x020b067c	func_ov002_020b067c	_ZN7daBar_c13InitResourcesEv	vtable slot 0
 ov002	0x020b0710	func_ov002_020b0710	InvisiblePole_Spawn	spawnfunc
 ov002	0x020b0710	InvisiblePole_Spawn	daBar_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020b07c8	func_ov002_020b07c8	daCamTag_c_Spawn	spawnfunc
+ov002	0x020b07c8	daCamTag_c_Spawn	daCamTag_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020b07f8	func_ov002_020b07f8	_ZN10daChRoom_cD1Ev	vtable slot 16 (was _ZN10daCamTag_cD1Ev)
 ov002	0x020b081c	func_ov002_020b081c	_ZN10daChRoom_cD0Ev	vtable slot 17 (was _ZN10daCamTag_cD0Ev)
 ov002	0x020b0854	func_ov002_020b0854	_ZN10daChRoom_c16CleanupResourcesEv	vtable slot 3 (was _ZN10daCamTag_c16CleanupResourcesEv)
@@ -32,6 +33,7 @@ ov002	0x020b0860	func_ov002_020b0860	_ZN10daChRoom_c6RenderEv	vtable slot 9 (was
 ov002	0x020b0868	func_ov002_020b0868	_ZN10daChRoom_c8BehaviorEv	vtable slot 6 (was _ZN10daCamTag_c8BehaviorEv)
 ov002	0x020b0938	func_ov002_020b0938	_ZN10daChRoom_c13InitResourcesEv	vtable slot 0 (was _ZN10daCamTag_c13InitResourcesEv)
 ov002	0x020b0980	func_ov002_020b0980	daChRoom_c_Spawn	spawnfunc
+ov002	0x020b0980	daChRoom_c_Spawn	daChRoom_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020b09b0	func_ov002_020b09b0	_ZN11daChScene_cD1Ev	vtable slot 16 (was _ZN11VirtualDoorD1Ev)
 ov002	0x020b09d4	func_ov002_020b09d4	_ZN11daChScene_cD0Ev	vtable slot 17 (was _ZN11VirtualDoorD0Ev)
 ov002	0x020b0a70	func_ov002_020b0a70	_ZN11daChScene_c16CleanupResourcesEv	vtable slot 3 (was _ZN11VirtualDoor16CleanupResourcesEv)
@@ -40,6 +42,7 @@ ov002	0x020b0a7c	func_ov002_020b0a7c	_ZN11daChScene_c6RenderEv	vtable slot 9 (wa
 ov002	0x020b0a84	func_ov002_020b0a84	_ZN11daChScene_c8BehaviorEv	vtable slot 6 (was _ZN11VirtualDoor8BehaviorEv)
 ov002	0x020b0d88	func_ov002_020b0d88	_ZN11daChScene_c13InitResourcesEv	vtable slot 0 (was _ZN11VirtualDoor13InitResourcesEv)
 ov002	0x020b0f24	func_ov002_020b0f24	daChScene_c_Spawn	spawnfunc
+ov002	0x020b0f24	daChScene_c_Spawn	daChScene_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020b0f54	func_ov002_020b0f54	_ZN4CoinD1Ev	vtable slot 16
 ov002	0x020b0fa4	func_ov002_020b0fa4	_ZN4CoinD0Ev	vtable slot 17
 ov002	0x020b2198	func_ov002_020b2198	_ZN4Coin16CleanupResourcesEv	vtable slot 3
@@ -149,6 +152,7 @@ ov002	0x020bbea4	func_ov002_020bbea4	_ZN8SignPost8BehaviorEv	vtable slot 6
 ov002	0x020bc240	func_ov002_020bc240	_ZN8SignPost13InitResourcesEv	vtable slot 0
 ov002	0x020bc3c8	func_ov002_020bc3c8	SignPost_Spawn	spawnfunc
 ov002	0x020bc5a8	func_ov002_020bc5a8	daObjWakame_c_Spawn	spawnfunc
+ov002	0x020bc5a8	daObjWakame_c_Spawn	daObjWakame_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020bc5e0	func_ov002_020bc5e0	_ZN12HealingHeartD1Ev	vtable slot 16 (was _ZN7SeaweedD1Ev)
 ov002	0x020bc618	func_ov002_020bc618	_ZN12HealingHeartD0Ev	vtable slot 17 (was _ZN7SeaweedD0Ev)
 ov002	0x020bc6a4	func_ov002_020bc6a4	_ZN12HealingHeart16CleanupResourcesEv	vtable slot 3 (was _ZN7Seaweed16CleanupResourcesEv)
@@ -190,7 +194,9 @@ ov002	0x020ec0a4	func_ov002_020ec0a4	_ZN8daTree_c6RenderEv	vtable slot 9
 ov002	0x020ec1d8	func_ov002_020ec1d8	_ZN8daTree_c8BehaviorEv	vtable slot 6
 ov002	0x020ec22c	func_ov002_020ec22c	_ZN8daTree_c13InitResourcesEv	vtable slot 0
 ov002	0x020ec32c	func_ov002_020ec32c	Tree_Spawn	spawnfunc
+ov002	0x020ec32c	Tree_Spawn	daTree_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020ec534	func_ov002_020ec534	daWarpkun_c_Spawn	spawnfunc
+ov002	0x020ec534	daWarpkun_c_Spawn	daWarpkun_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020ec56c	func_ov002_020ec56c	_ZN8YoshiEggD1Ev	vtable slot 16
 ov002	0x020ec5b4	func_ov002_020ec5b4	_ZN8YoshiEggD0Ev	vtable slot 17
 ov002	0x020edf54	func_ov002_020edf54	_ZN8YoshiEgg16CleanupResourcesEv	vtable slot 3
@@ -237,6 +243,7 @@ ov002	0x020f19f4	func_ov002_020f19f4	_ZN9daSetSE_c6RenderEv	vtable slot 9 (was _
 ov002	0x020f19fc	func_ov002_020f19fc	_ZN9daSetSE_c8BehaviorEv	vtable slot 6 (was _ZN14EnemySwitchTag8BehaviorEv)
 ov002	0x020f1ac4	func_ov002_020f1ac4	_ZN9daSetSE_c13InitResourcesEv	vtable slot 0 (was _ZN14EnemySwitchTag13InitResourcesEv)
 ov002	0x020f1b94	func_ov002_020f1b94	daSetSE_c_Spawn	spawnfunc
+ov002	0x020f1b94	daSetSE_c_Spawn	daSetSE_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020f1bc4	func_ov002_020f1bc4	_ZN8MugenBgmD1Ev	vtable slot 16 (was _ZN19AmbientSoundEffectsD1Ev)
 ov002	0x020f1be8	func_ov002_020f1be8	_ZN8MugenBgmD0Ev	vtable slot 17 (was _ZN19AmbientSoundEffectsD0Ev)
 ov002	0x020f1c50	func_ov002_020f1c50	_ZN8MugenBgm16CleanupResourcesEv	vtable slot 3 (was _ZN19AmbientSoundEffects16CleanupResourcesEv)
@@ -260,6 +267,7 @@ ov002	0x020f8c94	func_ov002_020f8c94	_ZN8Fireball8BehaviorEv	vtable slot 6
 ov002	0x020f9204	func_ov002_020f9204	_ZN8Fireball13InitResourcesEv	vtable slot 0
 ov002	0x020f9304	func_ov002_020f9304	Fireball_Spawn	spawnfunc
 ov002	0x020f972c	func_ov002_020f972c	daSoundObj_c_Spawn	spawnfunc
+ov002	0x020f972c	daSoundObj_c_Spawn	daSoundObj_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x020feabc	func_ov002_020feabc	_ZN6BulletD1Ev	vtable slot 16
 ov002	0x020feafc	func_ov002_020feafc	_ZN6BulletD0Ev	vtable slot 17
 ov002	0x020fedf0	func_ov002_020fedf0	_ZN6Bullet16CleanupResourcesEv	vtable slot 3
@@ -275,9 +283,12 @@ ov002	0x0210845c	data_ov002_0210845c	InvisiblePole_SpawnInfo	spawninfo
 ov002	0x0210845c	InvisiblePole_SpawnInfo	g_profile_BAR	reconstructed profile global; literal ROM ID BAR+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x02108480	data_ov002_02108480	_ZTV7daBar_c	vtable alloc=0x108
 ov002	0x02108518	data_ov002_02108518	daCamTag_c_SpawnInfo	spawninfo
+ov002	0x02108518	daCamTag_c_SpawnInfo	g_profile_CAMERA_TAG	reconstructed profile global; literal ROM ID CAMERA_TAG+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x021085d4	data_ov002_021085d4	daChRoom_c_SpawnInfo	spawninfo
+ov002	0x021085d4	daChRoom_c_SpawnInfo	g_profile_CH_ROOM	reconstructed profile global; literal ROM ID CH_ROOM+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x021085f8	data_ov002_021085f8	_ZTV10daChRoom_c	vtable alloc=? (was _ZTV10daCamTag_c)
 ov002	0x02108690	data_ov002_02108690	daChScene_c_SpawnInfo	spawninfo
+ov002	0x02108690	daChScene_c_SpawnInfo	g_profile_CH_SCENE	reconstructed profile global; literal ROM ID CH_SCENE+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x021086b4	data_ov002_021086b4	_ZTV11daChScene_c	vtable alloc=? (was _ZTV11VirtualDoor)
 ov002	0x02108790	data_ov002_02108790	Coin_SpawnInfo	spawninfo
 ov002	0x021087ac	data_ov002_021087ac	RedCoin_SpawnInfo	spawninfo
@@ -324,6 +335,7 @@ ov002	0x02109940	data_ov002_02109940	_ZTV10StarSwitch	vtable alloc=0x354
 ov002	0x02109ad4	data_ov002_02109ad4	SignPost_SpawnInfo	spawninfo
 ov002	0x02109af8	data_ov002_02109af8	_ZTV8SignPost	vtable alloc=?
 ov002	0x02109b94	data_ov002_02109b94	daObjWakame_c_SpawnInfo	spawninfo
+ov002	0x02109b94	daObjWakame_c_SpawnInfo	g_profile_WAKAME	reconstructed profile global; literal ROM ID WAKAME+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x02109c50	data_ov002_02109c50	HealingHeart_SpawnInfo	spawninfo
 ov002	0x02109c74	data_ov002_02109c74	_ZTV12HealingHeart	vtable alloc=? (was _ZTV7Seaweed)
 ov002	0x02109d14	data_ov002_02109d14	daObjCannonShutter_c_SpawnInfo	spawninfo
@@ -337,8 +349,10 @@ ov002	0x0210aa94	data_ov002_0210aa94	StarCamera_SpawnInfo	spawninfo
 ov002	0x0210aab8	data_ov002_0210aab8	_ZTV10StarMarker	vtable alloc=0x1dc
 ov002	0x0210ab3c	data_ov002_0210ab3c	_ZTV9PowerStar	vtable alloc=?
 ov002	0x0210abdc	data_ov002_0210abdc	Tree_SpawnInfo	spawninfo
+ov002	0x0210abdc	Tree_SpawnInfo	g_profile_TREE	reconstructed profile global; literal ROM ID TREE+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x0210ac00	data_ov002_0210ac00	_ZTV8daTree_c	vtable alloc=0x264
 ov002	0x0210ac98	data_ov002_0210ac98	daWarpkun_c_SpawnInfo	spawninfo
+ov002	0x0210ac98	daWarpkun_c_SpawnInfo	g_profile_WARPKUN	reconstructed profile global; literal ROM ID WARPKUN+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x0210ad90	data_ov002_0210ad90	YoshiEgg_SpawnInfo	spawninfo
 ov002	0x0210ad90	YoshiEgg_SpawnInfo	g_profile_YOSHI_EGG	reconstructed profile global; literal ROM ID YOSHI_EGG+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x0210adb4	data_ov002_0210adb4	_ZTV8YoshiEgg	vtable alloc=?
@@ -355,6 +369,7 @@ ov002	0x0210b340	data_ov002_0210b340	EnemySpawner_SpawnInfo	spawninfo
 ov002	0x0210b364	data_ov002_0210b364	_ZTV12EnemySpawner	vtable alloc=0x110
 ov002	0x0210b3e8	data_ov002_0210b3e8	_ZTV14EnemySwitchTag	vtable alloc=? (was _ZTV14BlueCoinSwitch)
 ov002	0x0210b47c	data_ov002_0210b47c	daSetSE_c_SpawnInfo	spawninfo
+ov002	0x0210b47c	daSetSE_c_SpawnInfo	g_profile_SET_SE	reconstructed profile global; literal ROM ID SET_SE+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x0210b4c8	data_ov002_0210b4c8	_ZTV9daSetSE_c	vtable alloc=? (was _ZTV14EnemySwitchTag)
 ov002	0x0210b560	data_ov002_0210b560	MugenBgm_SpawnInfo	spawninfo
 ov002	0x0210b584	data_ov002_0210b584	_ZTV8MugenBgm	vtable alloc=? (was _ZTV19AmbientSoundEffects)
@@ -363,6 +378,7 @@ ov002	0x0210bd60	data_ov002_0210bd60	_ZTV14CutsceneObject	vtable alloc=? (was _Z
 ov002	0x0210bf70	data_ov002_0210bf70	Fireball_SpawnInfo	spawninfo
 ov002	0x0210bf94	data_ov002_0210bf94	_ZTV8Fireball	vtable alloc=0x378
 ov002	0x0210c064	data_ov002_0210c064	daSoundObj_c_SpawnInfo	spawninfo
+ov002	0x0210c064	daSoundObj_c_SpawnInfo	g_profile_SOUND_OBJ	reconstructed profile global; literal ROM ID SOUND_OBJ+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov002	0x0210d630	data_ov002_0210d630	Bullet_SpawnInfo	spawninfo
 ov002	0x0210d654	data_ov002_0210d654	_ZTV6Bullet	vtable alloc=0x35c
 ov003	0x020b04f0	func_ov003_020b04f0	StarSelect_Spawn	spawnfunc


### PR DESCRIPTION
Wave 36 of the actor/process profile reconstruction campaign. Branched fresh
off `main`, not stacked on wave 25 (#2239) or wave 26 (#2244).

**8 registry rows migrated**, module **ov002** — the rows earlier waves skipped
because their factory is folded into a promoted translation unit:

| profile | class | owning TU | descriptor | factory |
|---|---|---|---|---|
| `CAMERA_TAG` | `daCamTag_c` | `src/actors/d_a_cam_tag.cpp` | `daCamTag_c_SpawnInfo` -> `g_profile_CAMERA_TAG` | `daCamTag_c_Spawn` -> `daCamTag_c_classInit` |
| `CH_ROOM` | `daChRoom_c` | `src/actors/d_a_ch_room.cpp` | `daChRoom_c_SpawnInfo` -> `g_profile_CH_ROOM` | `daChRoom_c_Spawn` -> `daChRoom_c_classInit` |
| `CH_SCENE` | `daChScene_c` | `src/actors/d_a_ch_scene.cpp` | `daChScene_c_SpawnInfo` -> `g_profile_CH_SCENE` | `daChScene_c_Spawn` -> `daChScene_c_classInit` |
| `WAKAME` | `daObjWakame_c` | `src/actors/d_a_obj_wakame.cpp` | `daObjWakame_c_SpawnInfo` -> `g_profile_WAKAME` | `daObjWakame_c_Spawn` -> `daObjWakame_c_classInit` |
| `TREE` | `daTree_c` | `src/actors/d_a_tree.cpp` | `Tree_SpawnInfo` -> `g_profile_TREE` | `Tree_Spawn` -> `daTree_c_classInit` |
| `WARPKUN` | `daWarpkun_c` | `src/actors/d_a_warpkun.cpp` | `daWarpkun_c_SpawnInfo` -> `g_profile_WARPKUN` | `daWarpkun_c_Spawn` -> `daWarpkun_c_classInit` |
| `SET_SE` | `daSetSE_c` | `src/actors/d_a_set_se.cpp` | `daSetSE_c_SpawnInfo` -> `g_profile_SET_SE` | `daSetSE_c_Spawn` -> `daSetSE_c_classInit` |
| `SOUND_OBJ` | `daSoundObj_c` | `src/actors/d_a_sound_obj.cpp` | `daSoundObj_c_SpawnInfo` -> `g_profile_SOUND_OBJ` | `daSoundObj_c_Spawn` -> `daSoundObj_c_classInit` |

The `KINOKO_CREATE_TAG`/`KINOKO_TAG` pair in wave 26 established that a
promoted-TU row is a recipe rather than a blocked class; these eight are the
same edit applied to both halves instead of one. Per row: descriptor symbol and
factory symbol in `config/arm9/overlays/ov002/symbols.txt`; the owning TU's
`// @symbol` marker, ROM-ordinal banner and definition, with the standard
provenance comment naming the historical alias; the `"symbol"` field in
`config/tu_manifest.d/ov002/<TU>.json`; a header alias table; two ledger rows.

**No file moves.** All eight TUs already carry their NSMBW filenames, and each
is enrolled exactly once in `delinks.txt` (lines 295, 299, 303, 1303, 4140,
4144, 4614, 5271). Nothing in `delinks.txt` changes.

**Tier discipline.** The ROM ids, descriptor bytes, factory pointer, RTTI class
and vtable are ROM-proven. `g_profile_*` and `*_classInit` are evidence-bounded
reconstructions, never described as recovered SM64DS symbols.

## Three things worth a reviewer's eye

**Historical records are masked off the rename, deliberately.** The manifests'
`legacy_source` and `sources` entries, and the TUs' "assembled from these legacy
one-function sources" banners, name pre-promotion files such as
`src/Tree_Spawn.cpp` that no longer exist. They are the record of what was
merged, not live references. A whole-file substitution would have turned them
into invented paths like `src/daTree_c_classInit.cpp`, so the rename masks those
literals out and restores them. Only `"symbol"` fields moved.

**No new `@symbol` markers.** Three of the eight TUs — `d_a_obj_wakame.cpp`,
`d_a_tree.cpp`, `d_a_sound_obj.cpp` — carry markers on their other members but
not on the factory, which is introduced by a ROM-ordinal banner instead. Adding
one would change tier scoring and the `path#symbol` keys the converted-baseline
ratchet reads, which is a separate change with its own gate surface. This PR
renames the markers that exist and adds none.

**One stale prose sentence left as written.** `daWarpkun_c.json`'s pilot
narrative recounts what `symbols.txt` said at the time — "...right before
`daWarpkun_c_SpawnInfo`/`_ZTV11daWarpkun_c`". It is a dated account of a past
tree state, so it keeps the old spelling. Flagging it in case a reviewer would
rather it were restamped.

## Gates

```
python tools/rombuild.py -j 16 --no-rom
  module fidelity: 106/106 exact, 100.000000% of compared bytes
  ROM-build analysis: PASS

python tools/check_rename_ledger.py
  every mangled/vtable row agrees with its module's symbols.txt
  checked 1652 mangled/vtable row(s); 961 coined row(s) out of scope

python tools/check_dead_references.py
  no new dead references; no broken markdown links

python tools/port_refcheck.py
  405 checked - all references resolve

python tools/layout_check.py
  layout-check: clean

python -m pytest tools/test_tubuild.py -q
  68 passed

python tools/eligible.py       11085 / 11211   (run on the committed tree)
python tools/check_references.py
  unresolved symbols: 42 (baseline 45); OK: no new unresolvable references
```

The `check_references` baseline is **not** banked here — tree-wide state, not
this wave's to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA