### PR TITLE
Gate the profile campaign against the tree it claims to have renamed

### DIFF
--- a/.github/workflows/profile-campaign.yml
+++ b/.github/workflows/profile-campaign.yml
@@ -1,0 +1,106 @@
+# Does the tree carry the names the profile campaign says it does?
+#
+# `tools/check_rename_ledger.py` checks `_ZN...` and `_ZTV...` rows only, and its
+# own summary line prints how many it skipped, because a coined spelling has no
+# mangled counterpart it knows how to resolve. That is ~1,000 rows of
+# `symbols/actor_renames.tsv` -- every name the profile reconstruction campaign
+# produces -- with no gate on them at all. The row
+#
+#     ov070  0x02120520  FlyGuy_Spawn  daPropeller_Heyho_c_classInit
+#
+# sat on main asserting a symbol that ov070's symbols.txt, the function
+# definition and the manifest all still spelled `FlyGuy_Spawn`. Nothing was red.
+# A byte-perfect 106/106 build says nothing about a name the build never emitted,
+# which is the shape of gate this repo keeps adding after the fact: the failure
+# branch a green run never reaches.
+#
+# RATCHET, NOT A SWEEP. `config/profile-campaign-baseline.json` banks the
+# divergences that exist today -- seven where the ledger runs AHEAD of the tree
+# (the PROPELLER_HEYHO shape) and ten where it runs BEHIND it (a rename nobody
+# recorded). None of them is accepted; each is a defect with a note saying which
+# way it points. The job fails on a divergence that is NOT banked, which is the
+# shape a fresh drift makes, and a banked entry stops matching the moment either
+# side changes, so rebanking cannot turn the ratchet into an allowlist.
+#
+# PENDING IS NOT RED, YET. Waves of this campaign are still landing. A registry
+# row whose symbol still carries its pre-campaign spelling reports PENDING and
+# does not fail. `--strict` makes every pending row fatal; that is the one-word
+# change to make here when the campaign closes, and it is why "pending" is a
+# decision on the record rather than a silence.
+#
+# IT CANNOT PASS BY DOING NOTHING. The tool counts what it actually resolved and
+# exits non-zero with SCAN TOO SMALL below a floor rather than announcing a clean
+# tree. This repo has already shipped a gate that reported a pass after a
+# reformat took its match count to zero, and the two positive controls in the
+# test file exist for exactly that: a divergence MUST be reported, and an empty
+# scan MUST exit non-zero.
+#
+# THE DATASET IS NOT HERE YET. `symbols/profile_reconstruction_registry.tsv`
+# gains its `overlay_resolution` and `factory_filename` columns on PR #2235.
+# Until then the tool names the columns it could not read and skips the registry
+# scan; it never reports a pass on a dataset it did not read, and the ledger scan
+# -- which needs only files that are on main -- runs regardless.
+#
+# WHY THIS ONE MAY KEEP A PATHS FILTER when dead-references dropped its. That
+# job resolves prose against the WHOLE tree, so any rename anywhere can break it
+# and no filter can be complete. This one resolves against exactly two kinds of
+# file, `config/**/symbols.txt` and `config/**/delinks.txt`, and both are listed
+# below alongside the inputs. The resolution targets are enumerable here, so the
+# filter is not the same bet.
+#
+# Costs nothing: text files, no compiler and no ROM, so it runs here rather than
+# on the private build box pr-validate.yml relays to. About a second over 2,574
+# ledger rows, 401 registry rows and 70 symbols.txt files.
+name: profile campaign
+
+on:
+  pull_request:
+    paths:
+      - "symbols/actor_renames.tsv"
+      - "symbols/profile_reconstruction_registry.tsv"
+      - "config/**/symbols.txt"
+      - "config/**/delinks.txt"
+      - "config/profile-campaign-baseline.json"
+      - "tools/check_profile_campaign.py"
+      - "tools/test_check_profile_campaign.py"
+      - ".github/workflows/profile-campaign.yml"
+  push:
+    branches: [main]
+    paths:
+      - "symbols/actor_renames.tsv"
+      - "symbols/profile_reconstruction_registry.tsv"
+      - "config/**/symbols.txt"
+      - "config/**/delinks.txt"
+      - "config/profile-campaign-baseline.json"
+      - "tools/check_profile_campaign.py"
+      - "tools/test_check_profile_campaign.py"
+      - ".github/workflows/profile-campaign.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: profile-campaign-${{ github.event.pull_request.head.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  campaign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # No history needed: the tool resolves against the working tree, and a
+        # shallow checkout still contains every file.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Campaign claims the tree does not carry
+        run: python tools/check_profile_campaign.py --repo .
+      - name: The gate's own tests
+        # Positive controls first: a coined ledger row naming a symbol that is
+        # not in symbols.txt MUST be reported, and a scan that resolved almost
+        # nothing MUST exit non-zero. A campaign gate that quietly finds nothing
+        # is the defect it was written to remove. stdlib unittest -- this runner
+        # installs nothing, and these cases are unittest.TestCase so that both
+        # `python -m unittest` and pytest collect all 27 of them.
+        run: python -m unittest tools.test_check_profile_campaign -v

--- a/config/profile-campaign-baseline.json
+++ b/config/profile-campaign-baseline.json
@@ -1,0 +1,158 @@
+{
+  "_comment": "Coined actor_renames.tsv claims that config/**/symbols.txt does not carry at that address, banked so tools/check_profile_campaign.py fails only on NEW drift. An entry stops matching as soon as either side changes, so rebanking cannot silence an address permanently -- only the exact divergence someone looked at. Every entry here is a real defect awaiting an owner, not an accepted exception; the tool prints the banked count on every run so a green is not read as a clean file. Seven are the ledger running AHEAD of the tree (a name the build never emitted) and ten are it running BEHIND (a rename nobody recorded).",
+  "known": [
+    {
+      "module": "ov002",
+      "address": "0x020b56d8",
+      "claimed": "QuestionSwitch_Spawn",
+      "actual": [
+        "daObjHatenaSwitch_c_classInit"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov002",
+      "address": "0x020f085c",
+      "claimed": "InvisibleSecret_Spawn",
+      "actual": [
+        "daSCoin_c_Spawn"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov002",
+      "address": "0x02108e38",
+      "claimed": "QuestionSwitch_SpawnInfo",
+      "actual": [
+        "g_profile_HATENA_SWITCH"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov009",
+      "address": "0x02112048",
+      "claimed": "DockPole_Spawn",
+      "actual": [
+        "daObjMc_Metalnet_c_classInit"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov009",
+      "address": "0x02113abc",
+      "claimed": "DockPole_SpawnInfo",
+      "actual": [
+        "g_profile_MC_METALNET"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov029",
+      "address": "0x02111340",
+      "claimed": "daObjWcObj01_c_classInit",
+      "actual": [
+        "daObjWcObj01_c_Spawn"
+      ],
+      "note": "ledger AHEAD of the tree: the campaign name was written into this ledger row but never reached symbols.txt, so the build has never emitted it. This is the PROPELLER_HEYHO shape the gate was added for. Banked to land the gate green, NOT accepted -- the fix is to apply the rename or retract the row."
+    },
+    {
+      "module": "ov029",
+      "address": "0x02112044",
+      "claimed": "daObjWcObj06_c_classInit",
+      "actual": [
+        "daObjWcObj06_c_Spawn"
+      ],
+      "note": "ledger AHEAD of the tree: the campaign name was written into this ledger row but never reached symbols.txt, so the build has never emitted it. This is the PROPELLER_HEYHO shape the gate was added for. Banked to land the gate green, NOT accepted -- the fix is to apply the rename or retract the row."
+    },
+    {
+      "module": "ov029",
+      "address": "0x02113c08",
+      "claimed": "g_profile_WC_OBJ01",
+      "actual": [
+        "daObjWcObj01_c_SpawnInfo"
+      ],
+      "note": "ledger AHEAD of the tree: the campaign name was written into this ledger row but never reached symbols.txt, so the build has never emitted it. This is the PROPELLER_HEYHO shape the gate was added for. Banked to land the gate green, NOT accepted -- the fix is to apply the rename or retract the row."
+    },
+    {
+      "module": "ov029",
+      "address": "0x02113f20",
+      "claimed": "FloatOnWaterPlatformWdwRectangle_SpawnInfo",
+      "actual": [
+        "daObjWcObj06_c_SpawnInfo"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov043",
+      "address": "0x0211176c",
+      "claimed": "daObjKm1_Dorifu_c_classInit",
+      "actual": [
+        "StairsBdw_Spawn"
+      ],
+      "note": "ledger AHEAD of the tree: the campaign name was written into this ledger row but never reached symbols.txt, so the build has never emitted it. This is the PROPELLER_HEYHO shape the gate was added for. Banked to land the gate green, NOT accepted -- the fix is to apply the rename or retract the row."
+    },
+    {
+      "module": "ov043",
+      "address": "0x021124fc",
+      "claimed": "g_profile_KM1_DORIFU",
+      "actual": [
+        "StairsBdw_SpawnInfo"
+      ],
+      "note": "ledger AHEAD of the tree: the campaign name was written into this ledger row but never reached symbols.txt, so the build has never emitted it. This is the PROPELLER_HEYHO shape the gate was added for. Banked to land the gate green, NOT accepted -- the fix is to apply the rename or retract the row."
+    },
+    {
+      "module": "ov045",
+      "address": "0x02112cd0",
+      "claimed": "g_profile_KM2_AGARU",
+      "actual": [
+        "FireSeaElevator_SpawnInfo"
+      ],
+      "note": "ledger AHEAD of the tree: the campaign name was written into this ledger row but never reached symbols.txt, so the build has never emitted it. This is the PROPELLER_HEYHO shape the gate was added for. Banked to land the gate green, NOT accepted -- the fix is to apply the rename or retract the row."
+    },
+    {
+      "module": "ov065",
+      "address": "0x0211b328",
+      "claimed": "TTC_MovingBar_Spawn",
+      "actual": [
+        "daObjCtMecha05_c_classInit"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov065",
+      "address": "0x0211d290",
+      "claimed": "TTC_MovingBar_SpawnInfo",
+      "actual": [
+        "g_profile_CT_MECHA05"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov070",
+      "address": "0x02120520",
+      "claimed": "daPropeller_Heyho_c_classInit",
+      "actual": [
+        "FlyGuy_Spawn"
+      ],
+      "note": "ledger AHEAD of the tree: the campaign name was written into this ledger row but never reached symbols.txt, so the build has never emitted it. This is the PROPELLER_HEYHO shape the gate was added for. Banked to land the gate green, NOT accepted -- the fix is to apply the rename or retract the row."
+    },
+    {
+      "module": "ov100",
+      "address": "0x02147328",
+      "claimed": "PathLift_Spawn",
+      "actual": [
+        "daObjPathLift_c_classInit"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    },
+    {
+      "module": "ov100",
+      "address": "0x02148558",
+      "claimed": "PathLift_SpawnInfo",
+      "actual": [
+        "g_profile_PATH_LIFT"
+      ],
+      "note": "ledger BEHIND the tree: symbols.txt already carries the campaign name and no ledger row was appended to record it, so this row asserts a superseded spelling. Banked to land the gate green, NOT accepted -- the fix is one appended ledger row."
+    }
+  ]
+}

--- a/tools/check_profile_campaign.py
+++ b/tools/check_profile_campaign.py
@@ -258,9 +258,23 @@ def scan_registry(repo, sym_cache, delinks_cache):
     report['status'] is one of ok / absent / incomplete, and the caller decides
     what that means; this function never turns a dataset it could not read into
     a pass.
+
+    TWO UNITS, NEVER MIXED IN ONE SENTENCE. `complete`/`pending`/`diverged`
+    count REGISTRY ROWS and partition `scope` exactly -- a row is complete when
+    every check on it is, pending when any is outstanding and none diverged, and
+    diverged when any check disagrees with the tree. `checks` counts INDIVIDUAL
+    ASSERTIONS, of which there are up to three per row, and is reported on its
+    own line.
+
+    The first draft incremented one counter for both, so a 391-row scan printed
+    "216 complete, 889 pending" -- 1,105 things out of 391 rows. Read as rows
+    that says a fifth of the campaign is done when the true figure is near half,
+    which is the same misleading green this tool exists to remove. `exempt`
+    counts checks too, and says so where it is printed.
     """
     report = {"status": "ok", "rows": 0, "scope": 0, "superseded": 0,
-              "complete": 0, "pending": 0, "exempt": 0, "missing_columns": []}
+              "complete": 0, "pending": 0, "diverged": 0, "exempt": 0,
+              "checks": collections.Counter(), "missing_columns": []}
     failures = []
     pendings = []
 
@@ -291,6 +305,8 @@ def scan_registry(repo, sym_cache, delinks_cache):
             continue
         pid = r.get("profile_id") or r.get("actor_id") or "?"
         report["scope"] += 1
+        row_pending = False
+        row_diverged = False
 
         # 1. descriptor
         mod = r.get("overlay") or "arm9"
@@ -302,16 +318,17 @@ def scan_registry(repo, sym_cache, delinks_cache):
                 failures.append(("descriptor address unreadable", pid, mod,
                                  r["profile_address"]))
                 addr = None
+                row_diverged = True
             if addr is not None:
                 state, why = symbol_state(table, addr, r.get("current_profile_name"),
                                           r["proposed_profile_name"])
-                if state == "COMPLETE":
-                    report["complete"] += 1
-                elif state == "PENDING":
-                    report["pending"] += 1
+                report["checks"]["descriptor " + state.lower()] += 1
+                if state == "PENDING":
+                    row_pending = True
                     pendings.append(("descriptor", pid, mod, r["profile_address"],
                                      r["proposed_profile_name"]))
-                else:
+                elif state == "DIVERGED":
+                    row_diverged = True
                     failures.append(("descriptor symbol diverged", pid, mod,
                                      "%s: want %s, %s" % (r["profile_address"],
                                                           r["proposed_profile_name"], why)))
@@ -326,16 +343,17 @@ def scan_registry(repo, sym_cache, delinks_cache):
                 failures.append(("factory address unreadable", pid, fmod,
                                  r["factory_address"]))
                 faddr = None
+                row_diverged = True
             if faddr is not None:
                 state, why = symbol_state(table, faddr, r.get("current_factory_name"),
                                           r["proposed_factory_name"])
-                if state == "COMPLETE":
-                    report["complete"] += 1
-                elif state == "PENDING":
-                    report["pending"] += 1
+                report["checks"]["factory " + state.lower()] += 1
+                if state == "PENDING":
+                    row_pending = True
                     pendings.append(("factory", pid, fmod, r["factory_address"],
                                      r["proposed_factory_name"]))
-                else:
+                elif state == "DIVERGED":
+                    row_diverged = True
                     failures.append(("factory symbol diverged", pid, fmod,
                                      "%s: want %s, %s" % (r["factory_address"],
                                                           r["proposed_factory_name"], why)))
@@ -344,15 +362,30 @@ def scan_registry(repo, sym_cache, delinks_cache):
                 if want:
                     src, nfuncs = owning_source(repo, fmod, faddr, delinks_cache, table)
                     if src is None:
+                        report["checks"]["filename diverged"] += 1
+                        row_diverged = True
                         failures.append(("factory source unlocatable", pid, fmod,
                                          "%s owned by no delinks entry" % r["factory_address"]))
                     elif nfuncs > 1:
+                        # exempt: no standalone source exists to be on a filename,
+                        # so this row has no third check rather than a passing one
                         report["exempt"] += 1
                     elif os.path.basename(src) == want:
-                        report["complete"] += 1
+                        report["checks"]["filename complete"] += 1
                     else:
-                        report["pending"] += 1
+                        report["checks"]["filename pending"] += 1
+                        row_pending = True
                         pendings.append(("filename", pid, fmod, src, want))
+
+        # A row is diverged if anything on it disagrees with the tree, pending if
+        # anything is merely outstanding, complete only when nothing is either.
+        # These three partition `scope`; main() asserts that before printing.
+        if row_diverged:
+            report["diverged"] += 1
+        elif row_pending:
+            report["pending"] += 1
+        else:
+            report["complete"] += 1
 
     return report, failures, pendings
 
@@ -479,11 +512,32 @@ def main(argv=None):
         print("check_profile_campaign: registry scan SKIPPED -- %s lacks the column(s) %s."
               % (REGISTRY, ", ".join(reg["missing_columns"]) or "(file is empty)"))
     else:
-        print("check_profile_campaign: %d registry row(s), %d in scope (%d superseded); "
-              "%d assertion(s) complete, %d pending, %d factory source(s) exempt as folded "
-              "into a promoted TU"
-              % (reg["rows"], reg["scope"], reg["superseded"], reg["complete"],
-                 reg["pending"], reg["exempt"]))
+        # The two units get their own lines, each saying which it is. Printing a
+        # row count and a check count in one sentence is how "216 complete, 889
+        # pending" over 391 rows happened.
+        total = reg["complete"] + reg["pending"] + reg["diverged"]
+        if total != reg["scope"]:
+            print("check_profile_campaign: INTERNAL ERROR -- row states (%d complete + "
+                  "%d pending + %d diverged = %d) do not partition the %d row(s) in "
+                  "scope." % (reg["complete"], reg["pending"], reg["diverged"], total,
+                              reg["scope"]))
+            print("  Refusing to report a count that does not add up.")
+            return 2
+        c = reg["checks"]
+        outstanding = ", ".join(
+            "%d %s" % (c["%s pending" % k], k)
+            for k in ("descriptor", "factory", "filename") if c["%s pending" % k])
+        print("check_profile_campaign: %d registry row(s), %d in scope (%d superseded)"
+              % (reg["rows"], reg["scope"], reg["superseded"]))
+        print("  rows      : %d complete, %d pending, %d diverged"
+              % (reg["complete"], reg["pending"], reg["diverged"]))
+        print("  checks    : %d complete, %d pending, %d diverged (up to three per row%s)"
+              % (sum(c[k] for k in c if k.endswith(" complete")),
+                 sum(c[k] for k in c if k.endswith(" pending")),
+                 sum(c[k] for k in c if k.endswith(" diverged")),
+                 "; outstanding: " + outstanding if outstanding else ""))
+        print("  exempt    : %d factory source(s) folded into a promoted TU, so those "
+              "rows carry no filename check" % reg["exempt"])
 
     print("check_profile_campaign: %d live coined ledger claim(s) resolved against "
           "%d symbols.txt file(s); %d diverge, %d of them banked in %s"

--- a/tools/check_profile_campaign.py
+++ b/tools/check_profile_campaign.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Does the tree agree with what the profile reconstruction campaign claims?
+
+Two independent scans, both against `config/**/symbols.txt` -- the file the ROM
+build actually consumes -- and neither of them covered by any gate that existed
+before this one.
+
+SCAN 1, THE REGISTRY. `symbols/profile_reconstruction_registry.tsv` is the
+campaign's dataset: one row per ROM actor/process profile, naming the descriptor
+global, the construction factory, the RTTI class, and the NSMBW-convention
+filename the factory's source is meant to end up on. Per in-scope row this
+asserts three things:
+
+  1. the descriptor symbol carries its proposed `g_profile_<ID>` name
+  2. the factory symbol carries its proposed `<Class>_classInit[_<ID>]` name
+  3. the factory's standalone source sits on its `factory_filename`
+
+Rows whose `overlay_resolution` starts with `superseded_by_` are out of scope:
+the campaign resolved them to a different overlay's row and this one is a
+duplicate reading of the same profile.
+
+WHY 3 HAS AN EXEMPTION, AND WHY IT IS MEASURED. A factory that has been folded
+into a promoted translation unit has no standalone one-function source to
+rename, so there is no filename for it to be wrong about. That is not a list of
+known TUs -- lists go stale. The owning source is read out of the module's
+`delinks.txt`, and the entry is called folded when MORE THAN ONE function symbol
+falls inside the range that entry claims. One function means a standalone
+source, which must be on `factory_filename`; several means a TU, which is
+exempt. `daPropeller_Heyho_c.cpp` owns 0x0211f000..0x02120570 in ov070 and the
+factory at 0x02120520 is one of many functions inside it -- detected, not
+hardcoded.
+
+PENDING IS NOT A FAILURE, YET. Waves of this campaign are still landing, so a
+row whose symbol still carries its pre-campaign coined spelling reports PENDING
+and does not fail the build. `--strict` turns every pending row into a failure;
+that is the switch to flip when the campaign closes, and it is what makes
+"pending" a decision someone made rather than a silence.
+
+SCAN 2, THE COINED LEDGER ROWS -- and this is the blindspot the tool exists for.
+`tools/check_rename_ledger.py` checks `_ZN...` and `_ZTV...` rows only, and says
+so; the coined spellings this campaign produces (`g_profile_BAR`,
+`Foo_c_classInit`) have no counterpart it knows how to resolve, so about a
+thousand ledger rows are unchecked by it. That is not a theoretical gap. The row
+
+    ov070  0x02120520  FlyGuy_Spawn  daPropeller_Heyho_c_classInit
+
+sat on main asserting a name that `config/arm9/overlays/ov070/symbols.txt`, the
+function definition and the manifest all still spelled `FlyGuy_Spawn`. A ledger
+row claiming a symbol the build never emitted, green, with nothing watching it.
+
+The ledger is an append log, so a row is not checked in isolation: for each
+(module, address) the LAST row's fourth column is the live claim and every
+earlier row on that address is superseded history. Only the live claim is
+resolved against symbols.txt, and only when it is a coined spelling -- the
+mangled ones already belong to `check_rename_ledger.py` and are left to it.
+
+RATCHET, NOT A SWEEP. `config/profile-campaign-baseline.json` banks the
+divergences that exist today, each with the pair actually observed, so a banked
+entry stops matching the moment either side changes. The job fails on a
+divergence that is not banked, which is the shape a fresh drift makes. Banked
+entries are counted on every run so a green cannot be read as a clean tree.
+
+IT CANNOT PASS BY DOING NOTHING. The scan counts what it actually resolved and
+exits non-zero with SCAN TOO SMALL below a floor rather than announcing a pass.
+This repo has already shipped a gate that reported a pass after a reformat took
+its match count to zero; that is the failure this guard refuses to repeat.
+
+DEGRADES HONESTLY. The registry dataset is not on main yet (PR #2235). When it
+is absent, or present without the columns these checks need, scan 1 reports
+exactly what it could not read and is skipped -- it never passes vacuously --
+while scan 2, which needs only files that are on main, still runs. `--strict`
+refuses a missing dataset outright.
+"""
+import argparse
+import collections
+import io
+import json
+import os
+import re
+import sys
+
+REGISTRY = "symbols/profile_reconstruction_registry.tsv"
+LEDGER = "symbols/actor_renames.tsv"
+BASELINE = "config/profile-campaign-baseline.json"
+
+SYM_RE = re.compile(r"\s*(\S+)\s+kind:(\S+)\s+addr:(0x[0-9a-f]+)")
+RANGE_RE = re.compile(r"start:(0x[0-9a-f]+)\s+end:(0x[0-9a-f]+)")
+
+# Floors. Far below today's numbers (752 live coined ledger claims, 25 symbol
+# files, 497 registry rows); they trip when a reader breaks, not when the
+# campaign progresses.
+MIN_SYMBOL_FILES = 15
+MIN_LEDGER_CLAIMS = 300
+MIN_REGISTRY_ROWS = 150
+
+REGISTRY_COLUMNS = (
+    "overlay_resolution", "overlay", "profile_address",
+    "current_profile_name", "proposed_profile_name",
+    "factory_module", "factory_address",
+    "current_factory_name", "proposed_factory_name",
+    "factory_filename",
+)
+
+
+# --------------------------------------------------------------------------
+# readers
+
+
+def symbols_path(repo, module):
+    """Module name -> its symbols.txt, or None.
+
+    arm9's file is `config/arm9/symbols.txt`; every overlay's is
+    `config/arm9/overlays/<mod>/symbols.txt`. There is no `main/` subdirectory
+    under `config/arm9`, which is the spelling that keeps getting written down.
+    """
+    for rel in ("config/arm9/overlays/%s/symbols.txt" % module,
+                "config/%s/symbols.txt" % module):
+        p = os.path.join(repo, rel)
+        if os.path.exists(p):
+            return p
+    return None
+
+
+def read_symbols(repo, module, cache):
+    """-> {address: [names]} for one module, or None when it has no file.
+
+    Aliased addresses are real here (a descriptor can carry both a coined and a
+    cartridge spelling), so the value is a list and membership, not equality, is
+    what the checks ask.
+    """
+    if module in cache:
+        return cache[module]
+    path = symbols_path(repo, module)
+    table = None
+    if path:
+        table = collections.defaultdict(list)
+        with io.open(path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                m = SYM_RE.match(line)
+                if m:
+                    table[int(m.group(3), 16)].append(m.group(1))
+    cache[module] = table
+    return table
+
+
+def read_delinks(repo, module, cache):
+    """-> [(source_path, start, end)] over a module's .text entries.
+
+    A source path is the unindented line ending in ':'; the ranges that follow
+    are its. The bare section header (`.text start:... kind:code align:32`) is
+    unindented but carries no path, so entries before the first path line are
+    dropped rather than attributed to it.
+    """
+    if module in cache:
+        return cache[module]
+    entries = []
+    for rel in ("config/arm9/overlays/%s/delinks.txt" % module,
+                "config/%s/delinks.txt" % module):
+        p = os.path.join(repo, rel)
+        if not os.path.exists(p):
+            continue
+        current = None
+        with io.open(p, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                stripped = line.rstrip("\n").rstrip("\r")
+                if stripped and not stripped[0].isspace() and stripped.endswith(":"):
+                    current = stripped[:-1]
+                    continue
+                if current is None:
+                    continue
+                m = RANGE_RE.search(stripped)
+                if m and ".text" in stripped:
+                    entries.append((current, int(m.group(1), 16), int(m.group(2), 16)))
+        break
+    cache[module] = entries
+    return entries
+
+
+def split_ledger_lines(raw):
+    """Tolerate mixed endings: split on LF, drop a trailing CR.
+
+    Splitting on a single detected terminator merges an LF row into the previous
+    CRLF row's last column, which hides the merged row from every check below.
+    """
+    return [ln[:-1] if ln.endswith("\r") else ln for ln in raw.split("\n")]
+
+
+def is_mangled(name):
+    return name.startswith("_ZN") or name.startswith("_ZTV") or name.startswith("_ZTI") \
+        or name.startswith("_ZTS")
+
+
+def load_baseline(repo):
+    p = os.path.join(repo, BASELINE)
+    if not os.path.exists(p):
+        return {"_comment": "", "known": []}
+    with io.open(p, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def baseline_keys(data):
+    """Banked entries as a set of comparable tuples.
+
+    The observed pair is part of the key on purpose: rebanking is not a way to
+    silence an address forever, only the exact divergence someone looked at.
+    """
+    out = set()
+    for e in data.get("known", []):
+        out.add((e.get("module"), e.get("address"), e.get("claimed"),
+                 tuple(e.get("actual") or [])))
+    return out
+
+
+# --------------------------------------------------------------------------
+# scan 1: the registry
+
+
+def owning_source(repo, module, address, delinks_cache, symbol_table):
+    """-> (source_path, function_symbols_in_that_range) or (None, 0).
+
+    The count is what separates a standalone one-function source from a promoted
+    TU; see the module docstring.
+    """
+    for path, start, end in read_delinks(repo, module, delinks_cache):
+        if start <= address < end:
+            n = 0
+            if symbol_table:
+                for addr in symbol_table:
+                    if start <= addr < end:
+                        n += 1
+            return path, n
+    return None, 0
+
+
+def symbol_state(table, address, current, proposed):
+    """COMPLETE / PENDING / DIVERGED for one symbol.
+
+    DIVERGED covers both "the address is not in symbols.txt at all" and "it
+    carries something that is neither the pre-campaign name nor the proposed
+    one", because both mean the dataset and the tree disagree about a name and
+    neither is a state a wave leaves behind.
+    """
+    if table is None:
+        return "DIVERGED", "module has no symbols.txt"
+    names = table.get(address)
+    if not names:
+        return "DIVERGED", "address not in symbols.txt"
+    if proposed and proposed in names:
+        return "COMPLETE", None
+    if current and current in names:
+        return "PENDING", None
+    return "DIVERGED", "carries %s" % ", ".join(sorted(names))
+
+
+def scan_registry(repo, sym_cache, delinks_cache):
+    """-> (report dict, failures, pendings).
+
+    report['status'] is one of ok / absent / incomplete, and the caller decides
+    what that means; this function never turns a dataset it could not read into
+    a pass.
+    """
+    report = {"status": "ok", "rows": 0, "scope": 0, "superseded": 0,
+              "complete": 0, "pending": 0, "exempt": 0, "missing_columns": []}
+    failures = []
+    pendings = []
+
+    path = os.path.join(repo, REGISTRY)
+    if not os.path.exists(path):
+        report["status"] = "absent"
+        return report, failures, pendings
+
+    import csv
+    with io.open(path, encoding="utf-8", errors="replace", newline="") as fh:
+        rows = list(csv.DictReader(fh, delimiter="\t"))
+    report["rows"] = len(rows)
+    if not rows:
+        report["status"] = "incomplete"
+        report["missing_columns"] = list(REGISTRY_COLUMNS)
+        return report, failures, pendings
+
+    have = set(rows[0].keys())
+    missing = [c for c in REGISTRY_COLUMNS if c not in have]
+    if missing:
+        report["status"] = "incomplete"
+        report["missing_columns"] = missing
+        return report, failures, pendings
+
+    for r in rows:
+        if (r.get("overlay_resolution") or "").startswith("superseded_by_"):
+            report["superseded"] += 1
+            continue
+        pid = r.get("profile_id") or r.get("actor_id") or "?"
+        report["scope"] += 1
+
+        # 1. descriptor
+        mod = r.get("overlay") or "arm9"
+        if r.get("proposed_profile_name") and r.get("profile_address"):
+            table = read_symbols(repo, mod, sym_cache)
+            try:
+                addr = int(r["profile_address"], 16)
+            except ValueError:
+                failures.append(("descriptor address unreadable", pid, mod,
+                                 r["profile_address"]))
+                addr = None
+            if addr is not None:
+                state, why = symbol_state(table, addr, r.get("current_profile_name"),
+                                          r["proposed_profile_name"])
+                if state == "COMPLETE":
+                    report["complete"] += 1
+                elif state == "PENDING":
+                    report["pending"] += 1
+                    pendings.append(("descriptor", pid, mod, r["profile_address"],
+                                     r["proposed_profile_name"]))
+                else:
+                    failures.append(("descriptor symbol diverged", pid, mod,
+                                     "%s: want %s, %s" % (r["profile_address"],
+                                                          r["proposed_profile_name"], why)))
+
+        # 2. factory symbol, and 3. its filename
+        fmod = r.get("factory_module") or mod
+        if r.get("proposed_factory_name") and r.get("factory_address"):
+            table = read_symbols(repo, fmod, sym_cache)
+            try:
+                faddr = int(r["factory_address"], 16)
+            except ValueError:
+                failures.append(("factory address unreadable", pid, fmod,
+                                 r["factory_address"]))
+                faddr = None
+            if faddr is not None:
+                state, why = symbol_state(table, faddr, r.get("current_factory_name"),
+                                          r["proposed_factory_name"])
+                if state == "COMPLETE":
+                    report["complete"] += 1
+                elif state == "PENDING":
+                    report["pending"] += 1
+                    pendings.append(("factory", pid, fmod, r["factory_address"],
+                                     r["proposed_factory_name"]))
+                else:
+                    failures.append(("factory symbol diverged", pid, fmod,
+                                     "%s: want %s, %s" % (r["factory_address"],
+                                                          r["proposed_factory_name"], why)))
+
+                want = r.get("factory_filename")
+                if want:
+                    src, nfuncs = owning_source(repo, fmod, faddr, delinks_cache, table)
+                    if src is None:
+                        failures.append(("factory source unlocatable", pid, fmod,
+                                         "%s owned by no delinks entry" % r["factory_address"]))
+                    elif nfuncs > 1:
+                        report["exempt"] += 1
+                    elif os.path.basename(src) == want:
+                        report["complete"] += 1
+                    else:
+                        report["pending"] += 1
+                        pendings.append(("filename", pid, fmod, src, want))
+
+    return report, failures, pendings
+
+
+# --------------------------------------------------------------------------
+# scan 2: coined ledger rows
+
+
+def scan_ledger(repo, sym_cache):
+    """-> (claims_checked, divergences).
+
+    divergence: (module, '0x...', claimed, [actual names], ledger line number)
+    """
+    path = os.path.join(repo, LEDGER)
+    if not os.path.exists(path):
+        return 0, []
+    with io.open(path, "rb") as fh:
+        raw = fh.read().decode("utf-8", errors="replace")
+
+    live = collections.OrderedDict()
+    for i, line in enumerate(split_ledger_lines(raw), 1):
+        parts = line.split("\t")
+        if len(parts) < 4:
+            continue
+        if i == 1 and parts[0] == "module":
+            continue
+        module, addr_text, claimed = parts[0], parts[1], parts[3]
+        try:
+            addr = int(addr_text, 16)
+        except ValueError:
+            continue
+        # append log: the last row on an address is the live claim, every
+        # earlier one is superseded history
+        live[(module, addr)] = (i, addr_text, claimed)
+
+    checked = 0
+    diverged = []
+    for (module, addr), (lineno, addr_text, claimed) in live.items():
+        if is_mangled(claimed):
+            continue  # check_rename_ledger.py owns these
+        table = read_symbols(repo, module, sym_cache)
+        if table is None:
+            diverged.append((module, addr_text, claimed, [], lineno))
+            continue
+        checked += 1
+        names = table.get(addr) or []
+        if claimed not in names:
+            diverged.append((module, addr_text, claimed, sorted(names), lineno))
+    return checked, diverged
+
+
+# --------------------------------------------------------------------------
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default=".", help="repository root (default: cwd)")
+    ap.add_argument("--strict", action="store_true",
+                    help="fail on any PENDING row, and on a missing dataset -- "
+                         "the mode to flip on when the campaign closes")
+    ap.add_argument("--list", action="store_true", help="print every finding, not a sample")
+    ap.add_argument("--update", action="store_true",
+                    help="rewrite %s from what is diverged today" % BASELINE)
+    args = ap.parse_args(argv)
+    repo = args.repo
+
+    sym_cache = {}
+    delinks_cache = {}
+
+    reg, reg_failures, pendings = scan_registry(repo, sym_cache, delinks_cache)
+    claims, diverged = scan_ledger(repo, sym_cache)
+
+    # the count of files actually READ, not the count that exist -- a floor on
+    # what the scan resolved is only honest if it measures the scan
+    n_symbol_files = sum(1 for v in sym_cache.values() if v)
+
+    base = load_baseline(repo)
+    banked = baseline_keys(base)
+
+    if args.update:
+        entries = []
+        for module, addr_text, claimed, actual, lineno in diverged:
+            entries.append({"module": module, "address": addr_text, "claimed": claimed,
+                            "actual": actual, "note": ""})
+        base["known"] = entries
+        base.setdefault("_comment",
+                        "Coined actor_renames.tsv claims that config/**/symbols.txt does "
+                        "not carry at that address, banked so tools/check_profile_campaign.py "
+                        "fails only on NEW drift. An entry stops matching as soon as either "
+                        "side changes; it is not a permanent exemption for the address.")
+        with io.open(os.path.join(repo, BASELINE), "w", encoding="utf-8", newline="\n") as fh:
+            json.dump(base, fh, indent=2, sort_keys=False)
+            fh.write("\n")
+        print("check_profile_campaign: banked %d coined ledger divergence(s) in %s"
+              % (len(entries), BASELINE))
+        return 0
+
+    new_diverged = [d for d in diverged
+                    if (d[0], d[1], d[2], tuple(d[3])) not in banked]
+    n_banked_hit = len(diverged) - len(new_diverged)
+
+    # ---- the guard, before any verdict ----
+    too_small = []
+    if n_symbol_files < MIN_SYMBOL_FILES:
+        too_small.append("%d symbols.txt file(s), expected at least %d"
+                         % (n_symbol_files, MIN_SYMBOL_FILES))
+    if claims < MIN_LEDGER_CLAIMS:
+        too_small.append("%d live coined ledger claim(s), expected at least %d"
+                         % (claims, MIN_LEDGER_CLAIMS))
+    if reg["status"] == "ok" and reg["scope"] < MIN_REGISTRY_ROWS:
+        too_small.append("%d in-scope registry row(s), expected at least %d"
+                         % (reg["scope"], MIN_REGISTRY_ROWS))
+    if too_small:
+        print("check_profile_campaign: SCAN TOO SMALL -- " + "; ".join(too_small) + ".")
+        print("  A reader is broken, or the tool is being run outside the repo.")
+        print("  Refusing to report a pass on a scan this size.")
+        return 2
+
+    # ---- report ----
+    if reg["status"] == "absent":
+        print("check_profile_campaign: registry scan SKIPPED -- %s is not in the tree "
+              "(it lands with PR #2235)." % REGISTRY)
+    elif reg["status"] == "incomplete":
+        print("check_profile_campaign: registry scan SKIPPED -- %s lacks the column(s) %s."
+              % (REGISTRY, ", ".join(reg["missing_columns"]) or "(file is empty)"))
+    else:
+        print("check_profile_campaign: %d registry row(s), %d in scope (%d superseded); "
+              "%d assertion(s) complete, %d pending, %d factory source(s) exempt as folded "
+              "into a promoted TU"
+              % (reg["rows"], reg["scope"], reg["superseded"], reg["complete"],
+                 reg["pending"], reg["exempt"]))
+
+    print("check_profile_campaign: %d live coined ledger claim(s) resolved against "
+          "%d symbols.txt file(s); %d diverge, %d of them banked in %s"
+          % (claims, n_symbol_files, len(diverged), n_banked_hit, BASELINE))
+
+    rc = 0
+
+    if reg_failures:
+        rc = 1
+        print("\nFAIL: %d registry row(s) disagree with the tree:" % len(reg_failures))
+        shown = reg_failures if args.list else reg_failures[:40]
+        for kind, pid, mod, detail in shown:
+            print("  %s [%s %s]" % (kind, pid, mod))
+            print("      %s" % detail)
+        if len(shown) < len(reg_failures):
+            print("  ... and %d more (--list for all)" % (len(reg_failures) - len(shown)))
+
+    if new_diverged:
+        rc = 1
+        print("\nFAIL: %d coined ledger row(s) claim a name symbols.txt does not carry:"
+              % len(new_diverged))
+        shown = new_diverged if args.list else new_diverged[:40]
+        for module, addr_text, claimed, actual, lineno in shown:
+            print("  %s:%d  %s %s" % (LEDGER, lineno, module, addr_text))
+            print("      ledger says %s; symbols.txt carries %s"
+                  % (claimed, ", ".join(actual) if actual else "(nothing at that address)"))
+        if len(shown) < len(new_diverged):
+            print("  ... and %d more (--list for all)" % (len(new_diverged) - len(shown)))
+        print("\n  Either the rename never reached symbols.txt -- in which case the build")
+        print("  never emitted the name this row asserts -- or symbols.txt moved on and no")
+        print("  ledger row followed. Fix the side that is wrong; bank it with --update")
+        print("  only once someone has decided the divergence is correct.")
+
+    if pendings:
+        label = "FAIL" if args.strict else "PENDING"
+        if args.strict:
+            rc = 1
+        print("\n%s: %d campaign assertion(s) not yet applied:" % (label, len(pendings)))
+        shown = pendings if args.list else pendings[:40]
+        for kind, pid, mod, where, want in shown:
+            print("  %-10s %-22s %s  %s -> %s" % (kind, pid, mod, where, want))
+        if len(shown) < len(pendings):
+            print("  ... and %d more (--list for all)" % (len(pendings) - len(shown)))
+        if not args.strict:
+            print("\n  Pending rows do not fail the build while waves are still landing.")
+            print("  Run with --strict once the campaign closes.")
+
+    if args.strict and reg["status"] != "ok":
+        rc = 1
+        print("\nFAIL: --strict requires the registry dataset, and the registry scan was "
+              "skipped.")
+
+    if rc == 0:
+        print("\nOK: every campaign claim this tool can resolve is carried by the tree.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_profile_campaign.py
+++ b/tools/test_check_profile_campaign.py
@@ -296,6 +296,94 @@ class RegistryScan(Fixture):
         self.assertEqual(rc, 0)
         self.assertIn("1 in scope", out)
 
+    def test_row_states_partition_the_rows_in_scope(self):
+        """complete + pending + diverged == rows in scope, always.
+
+        THE ARITHMETIC CONTROL. The first draft incremented one counter per
+        CHECK and printed it beside a ROW count, so a 391-row scan announced
+        "216 complete, 889 pending" -- 1,105 things out of 391 rows, which reads
+        as a campaign a fifth done when it is nearer half. Two units in one
+        sentence is the same misleading green this tool exists to remove, so the
+        partition is asserted here and again at print time.
+        """
+        self._tree()  # ov002, fully migrated
+        # ov009 still on its pre-campaign names -> pending
+        self.symbols("ov009", [("DockPole_Spawn", "0x02112048", "function(arm,size=0x30)"),
+                               ("DockPole_SpawnInfo", "0x02113abc", "data(any)")])
+        self.delinks("ov009", [("src/DockPole_Spawn.c", "0x02112048", "0x02112078")])
+        # ov043 carries a third name -> diverged
+        self.symbols("ov043", [("who_is_this", "0x0211176c", "function(arm,size=0x30)"),
+                               ("g_profile_KM1_DORIFU", "0x021124fc", "data(any)")])
+        self.delinks("ov043", [("src/x.c", "0x0211176c", "0x0211179c")])
+        self.registry([
+            self._row(),
+            self._row(profile_id="MC_METALNET", overlay="ov009",
+                      profile_address="0x02113abc",
+                      current_profile_name="DockPole_SpawnInfo",
+                      proposed_profile_name="g_profile_MC_METALNET",
+                      factory_module="ov009", factory_address="0x02112048",
+                      current_factory_name="DockPole_Spawn",
+                      proposed_factory_name="daObjMc_Metalnet_c_classInit",
+                      factory_filename="d_a_obj_mc_metalnet.c"),
+            self._row(profile_id="KM1_DORIFU", overlay="ov043",
+                      profile_address="0x021124fc",
+                      current_profile_name="StairsBdw_SpawnInfo",
+                      proposed_profile_name="g_profile_KM1_DORIFU",
+                      factory_module="ov043", factory_address="0x0211176c",
+                      current_factory_name="StairsBdw_Spawn",
+                      proposed_factory_name="daObjKm1_Dorifu_c_classInit",
+                      factory_filename="d_a_obj_km1_dorifu.c"),
+        ])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 1)  # the diverged row
+        self.assertIn("3 in scope", out)
+        self.assertIn("rows      : 1 complete, 1 pending, 1 diverged", out)
+
+    def test_rows_and_checks_are_reported_as_separate_labelled_units(self):
+        """A reader must never have to guess which unit a number is in."""
+        self._tree()
+        self.registry([self._row()])
+        _rc, out = self.run_tool()
+        self.assertIn("rows      :", out)
+        self.assertIn("checks    :", out)
+        self.assertIn("up to three per row", out)
+
+    def test_a_row_is_pending_when_any_one_of_its_checks_is(self):
+        """Two checks of three applied is not a complete row."""
+        self.symbols("ov002", [
+            ("daObjSwitch_c_classInit_HANSWITCH", "0x020baadc", "function(arm,size=0x30)"),
+            ("g_profile_HANSWITCH", "0x02109900", "data(any)"),
+        ])
+        self.delinks("ov002", [("src/ExclamationSwitch_Spawn.c", "0x020baadc", "0x020bab0c")])
+        self.ledger([])
+        self.registry([self._row()])
+        _rc, out = self.run_tool()
+        self.assertIn("rows      : 0 complete, 1 pending, 0 diverged", out)
+        self.assertIn("checks    : 2 complete, 1 pending", out)
+
+    def test_an_exempt_row_is_complete_on_its_two_remaining_checks(self):
+        """A folded factory has no third check, not a failed one."""
+        self.symbols("ov070", [
+            ("daPropeller_Heyho_c_classInit", "0x02120520", "function(arm,size=0x50)"),
+            ("_ZN18daPropeller_Heyho_cD1Ev", "0x0211f100", "function(arm,size=0x40)"),
+            ("g_profile_PROPELLER_HEYHO", "0x02121000", "data(any)"),
+        ])
+        self.delinks("ov070", [("src/actors/daPropeller_Heyho_c.cpp", "0x0211f000",
+                                "0x02120570")])
+        self.ledger([])
+        self.registry([self._row(
+            profile_id="PROPELLER_HEYHO", overlay="ov070", profile_address="0x02121000",
+            proposed_profile_name="g_profile_PROPELLER_HEYHO",
+            current_profile_name="FlyGuy_SpawnInfo",
+            factory_module="ov070", factory_address="0x02120520",
+            current_factory_name="FlyGuy_Spawn",
+            proposed_factory_name="daPropeller_Heyho_c_classInit",
+            factory_filename="d_a_propeller_heyho.c")])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("rows      : 1 complete, 0 pending, 0 diverged", out)
+        self.assertIn("checks    : 2 complete", out)
+
     def test_a_row_still_on_its_pre_campaign_name_is_pending_not_a_failure(self):
         self.symbols("ov002", [
             ("ExclamationSwitch_Spawn", "0x020baadc", "function(arm,size=0x30)"),
@@ -366,7 +454,7 @@ class RegistryScan(Fixture):
             factory_filename="d_a_propeller_heyho.c")])
         rc, out = self.run_tool()
         self.assertEqual(rc, 0)
-        self.assertIn("1 factory source(s) exempt", out)
+        self.assertIn("exempt    : 1 factory source(s) folded into a promoted TU", out)
 
     def test_a_standalone_source_on_the_wrong_filename_is_pending(self):
         self.symbols("ov002", [

--- a/tools/test_check_profile_campaign.py
+++ b/tools/test_check_profile_campaign.py
@@ -1,0 +1,445 @@
+"""Tests for tools/check_profile_campaign.py.
+
+POSITIVE CONTROLS FIRST. The two failures that matter for a gate like this are
+not "it reported something wrong" but "it reported nothing at all": a coined
+ledger row asserting a name the tree does not carry MUST be reported, and a scan
+that resolved almost nothing MUST exit non-zero instead of announcing a pass.
+Those two are what the rest of this file is arranged around.
+
+Every case is a fixture tree under a temporary directory -- no repo, no config/,
+no compiler, no ROM -- so these run anywhere and cannot go quietly green because
+the real tree changed underneath them. `unittest.TestCase` on purpose: pytest
+collects these, and so does `python -m unittest`, which is how this repo's
+workflows run tool tests. A file of bare `def test_*` functions contributes zero
+tests to unittest and reports a green while asserting nothing, which is the
+exact shape tool-tests.yml already refuses for test_tubuild.py.
+"""
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import check_profile_campaign as C  # noqa: E402
+
+
+REGISTRY_HEADER = [
+    "profile_id", "overlay_resolution", "overlay", "profile_address",
+    "current_profile_name", "proposed_profile_name",
+    "factory_module", "factory_address",
+    "current_factory_name", "proposed_factory_name", "factory_filename",
+]
+
+
+def registry_row(**kw):
+    row = dict.fromkeys(REGISTRY_HEADER, "")
+    row.update(kw)
+    return row
+
+
+class Fixture(unittest.TestCase):
+    """A throwaway repo root, plus the floors lowered so fixtures can run.
+
+    The floors are the vacuous-pass guard; a fixture necessarily sits below
+    them, so they are lowered here and their real behaviour is asserted
+    separately in ScanSizeGuard rather than disabled everywhere.
+    """
+
+    def setUp(self):
+        self.repo = tempfile.mkdtemp(prefix="campaign-gate-")
+        self.addCleanup(shutil.rmtree, self.repo, ignore_errors=True)
+        self._floors = (C.MIN_SYMBOL_FILES, C.MIN_LEDGER_CLAIMS, C.MIN_REGISTRY_ROWS)
+        C.MIN_SYMBOL_FILES, C.MIN_LEDGER_CLAIMS, C.MIN_REGISTRY_ROWS = 0, 0, 0
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        C.MIN_SYMBOL_FILES, C.MIN_LEDGER_CLAIMS, C.MIN_REGISTRY_ROWS = self._floors
+
+    # ---- fixture builders ----
+
+    def write(self, rel, text, newline="\n"):
+        p = os.path.join(self.repo, rel.replace("/", os.sep))
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with io.open(p, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text.replace("\n", newline))
+        return p
+
+    def symbols(self, module, entries):
+        """entries: [(name, addr, kind)] -> that module's symbols.txt."""
+        body = "".join("%s kind:%s addr:%s\n" % (n, k, a) for n, a, k in entries)
+        rel = ("config/arm9/symbols.txt" if module == "arm9"
+               else "config/arm9/overlays/%s/symbols.txt" % module)
+        self.write(rel, body)
+
+    def delinks(self, module, entries):
+        """entries: [(path, start, end)] -> that module's delinks.txt."""
+        body = ".text       start:0x02000000 end:0x03000000 kind:code align:32\n\n"
+        for path, start, end in entries:
+            body += "%s:\n    complete\n    .text start:%s end:%s\n\n" % (path, start, end)
+        rel = ("config/arm9/delinks.txt" if module == "arm9"
+               else "config/arm9/overlays/%s/delinks.txt" % module)
+        self.write(rel, body)
+
+    def ledger(self, rows, newline="\n"):
+        body = "module\taddr\told\tnew\twhy\n"
+        for r in rows:
+            body += "\t".join(r) + "\n"
+        self.write(C.LEDGER, body, newline=newline)
+
+    def registry(self, rows):
+        body = "\t".join(REGISTRY_HEADER) + "\n"
+        for r in rows:
+            body += "\t".join(r[c] for c in REGISTRY_HEADER) + "\n"
+        self.write(C.REGISTRY, body)
+
+    def baseline(self, entries):
+        self.write(C.BASELINE, json.dumps({"_comment": "", "known": entries}, indent=2))
+
+    # ---- runner ----
+
+    def run_tool(self, *args):
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            rc = C.main(["--repo", self.repo] + list(args))
+        finally:
+            sys.stdout = old
+        return rc, buf.getvalue()
+
+
+class CoinedLedgerRows(Fixture):
+    """Scan 2 -- the blindspot this tool exists to close."""
+
+    def test_a_claim_symbols_txt_does_not_carry_is_reported(self):
+        """THE control. This is PROPELLER_HEYHO, reduced.
+
+        The ledger asserts daPropeller_Heyho_c_classInit at ov070 0x02120520
+        while symbols.txt still spells it FlyGuy_Spawn -- a name the build has
+        never emitted, sitting green because check_rename_ledger.py skips
+        coined spellings. If this test ever passes silently the gate is
+        pointless.
+        """
+        self.symbols("ov070", [("FlyGuy_Spawn", "0x02120520", "function(arm,size=0x50)")])
+        self.ledger([
+            ("ov070", "0x02120520", "func_ov070_02120520", "FlyGuy_Spawn", "spawnfunc"),
+            ("ov070", "0x02120520", "FlyGuy_Spawn", "daPropeller_Heyho_c_classInit", "x"),
+        ])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 1)
+        self.assertIn("daPropeller_Heyho_c_classInit", out)
+        self.assertIn("FlyGuy_Spawn", out)
+        self.assertIn("coined ledger row(s) claim a name symbols.txt does not carry", out)
+
+    def test_an_applied_claim_passes(self):
+        self.symbols("ov070", [("daPropeller_Heyho_c_classInit", "0x02120520",
+                                "function(arm,size=0x50)")])
+        self.ledger([
+            ("ov070", "0x02120520", "FlyGuy_Spawn", "daPropeller_Heyho_c_classInit", "x"),
+        ])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("1 live coined ledger claim(s)", out)
+
+    def test_only_the_last_row_on_an_address_is_the_live_claim(self):
+        """The ledger is an append log, not a set of independent assertions.
+
+        The first row's `FlyGuy_Spawn` is superseded history the moment a second
+        row renames it. Checking every row in isolation would report the whole
+        campaign as broken.
+        """
+        self.symbols("ov070", [("daPropeller_Heyho_c_classInit", "0x02120520",
+                                "function(arm,size=0x50)")])
+        self.ledger([
+            ("ov070", "0x02120520", "func_ov070_02120520", "FlyGuy_Spawn", "spawnfunc"),
+            ("ov070", "0x02120520", "FlyGuy_Spawn", "daPropeller_Heyho_c_classInit", "x"),
+        ])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertNotIn("FlyGuy_Spawn", out)
+
+    def test_mangled_rows_are_left_to_check_rename_ledger(self):
+        """Not this tool's job, and double-reporting them would be noise."""
+        self.symbols("ov070", [("something_else", "0x02120520", "function(arm,size=0x4)")])
+        self.ledger([
+            ("ov070", "0x02120520", "func_ov070_02120520", "_ZN7daKrb_cD1Ev", "slot 16"),
+            ("ov070", "0x02120524", "data_ov070_02120524", "_ZTV7daKrb_c", "vtable"),
+        ])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("0 live coined ledger claim(s)", out)
+
+    def test_an_aliased_address_passes_on_membership_not_equality(self):
+        """A descriptor can carry both a coined and a cartridge spelling."""
+        self.symbols("ov029", [("g_profile_WC_OBJ01", "0x02113c08", "data(any)"),
+                               ("data_ov029_02113c08", "0x02113c08", "data(any)")])
+        self.ledger([("ov029", "0x02113c08", "old", "g_profile_WC_OBJ01", "x")])
+        self.assertEqual(self.run_tool()[0], 0)
+
+    def test_a_module_with_no_symbols_txt_is_a_divergence_not_a_pass(self):
+        self.ledger([("ov999", "0x02113c08", "old", "g_profile_GONE", "x")])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 1)
+        self.assertIn("g_profile_GONE", out)
+
+    def test_crlf_ledger_is_read_without_merging_rows(self):
+        """A CR left on the last column silently changes the claim being checked."""
+        self.symbols("ov070", [("daPropeller_Heyho_c_classInit", "0x02120520",
+                                "function(arm,size=0x50)")])
+        self.ledger([("ov070", "0x02120520", "old", "daPropeller_Heyho_c_classInit", "x")],
+                    newline="\r\n")
+        self.assertEqual(self.run_tool()[0], 0)
+
+    def test_arm9_symbols_live_at_config_arm9_symbols_txt(self):
+        """Not under a `main/` subdirectory, which is the spelling people write."""
+        self.symbols("arm9", [("g_profile_BOOT", "0x020914a8", "data(any)")])
+        self.ledger([("arm9", "0x020914a8", "old", "g_profile_BOOT", "x")])
+        self.assertEqual(self.run_tool()[0], 0)
+
+
+class Ratchet(Fixture):
+    def _diverged_tree(self):
+        self.symbols("ov070", [("FlyGuy_Spawn", "0x02120520", "function(arm,size=0x50)")])
+        self.ledger([("ov070", "0x02120520", "FlyGuy_Spawn",
+                      "daPropeller_Heyho_c_classInit", "x")])
+
+    def test_a_banked_divergence_does_not_fail_the_build(self):
+        self._diverged_tree()
+        self.baseline([{"module": "ov070", "address": "0x02120520",
+                        "claimed": "daPropeller_Heyho_c_classInit",
+                        "actual": ["FlyGuy_Spawn"], "note": "known"}])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("1 diverge, 1 of them banked", out)
+
+    def test_the_banked_count_is_printed_so_green_is_not_read_as_clean(self):
+        self._diverged_tree()
+        self.baseline([{"module": "ov070", "address": "0x02120520",
+                        "claimed": "daPropeller_Heyho_c_classInit",
+                        "actual": ["FlyGuy_Spawn"], "note": "known"}])
+        self.assertIn("banked in", self.run_tool()[1])
+
+    def test_banking_is_not_a_permanent_exemption_for_the_address(self):
+        """Change either side and the entry stops matching.
+
+        Otherwise a bank would license every future drift on that address,
+        which is how a ratchet quietly becomes an allowlist.
+        """
+        self._diverged_tree()
+        self.baseline([{"module": "ov070", "address": "0x02120520",
+                        "claimed": "daPropeller_Heyho_c_classInit",
+                        "actual": ["SomethingElse_Spawn"], "note": "stale"}])
+        self.assertEqual(self.run_tool()[0], 1)
+
+    def test_update_writes_todays_divergences(self):
+        self._diverged_tree()
+        self.assertEqual(self.run_tool("--update")[0], 0)
+        with io.open(os.path.join(self.repo, C.BASELINE), encoding="utf-8") as fh:
+            data = json.load(fh)
+        self.assertEqual(len(data["known"]), 1)
+        self.assertEqual(data["known"][0]["claimed"], "daPropeller_Heyho_c_classInit")
+        self.assertEqual(self.run_tool()[0], 0)
+
+
+class ScanSizeGuard(Fixture):
+    """A gate that checks nothing must not report a pass."""
+
+    def setUp(self):
+        super().setUp()
+        C.MIN_SYMBOL_FILES, C.MIN_LEDGER_CLAIMS = 15, 300
+
+    def test_an_empty_scan_exits_non_zero(self):
+        self.symbols("ov070", [("FlyGuy_Spawn", "0x02120520", "function(arm,size=0x50)")])
+        self.ledger([("ov070", "0x02120520", "old", "FlyGuy_Spawn", "x")])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 2)
+        self.assertIn("SCAN TOO SMALL", out)
+        self.assertIn("Refusing to report a pass", out)
+
+    def test_the_guard_runs_before_any_verdict(self):
+        """A broken reader must not be able to produce OK, nor a FAIL list."""
+        self.ledger([])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 2)
+        self.assertNotIn("OK:", out)
+
+
+class RegistryScan(Fixture):
+    def _tree(self):
+        self.symbols("ov002", [
+            ("daObjSwitch_c_classInit_HANSWITCH", "0x020baadc", "function(arm,size=0x30)"),
+            ("g_profile_HANSWITCH", "0x02109900", "data(any)"),
+        ])
+        self.delinks("ov002", [("src/d_a_obj_switch_hanswitch.c", "0x020baadc", "0x020bab0c")])
+        self.ledger([])
+
+    def _row(self, **kw):
+        base = dict(profile_id="HANSWITCH", overlay_resolution="unique_registry_context",
+                    overlay="ov002", profile_address="0x02109900",
+                    current_profile_name="ExclamationSwitch_SpawnInfo",
+                    proposed_profile_name="g_profile_HANSWITCH",
+                    factory_module="ov002", factory_address="0x020baadc",
+                    current_factory_name="ExclamationSwitch_Spawn",
+                    proposed_factory_name="daObjSwitch_c_classInit_HANSWITCH",
+                    factory_filename="d_a_obj_switch_hanswitch.c")
+        base.update(kw)
+        return registry_row(**base)
+
+    def test_a_fully_migrated_row_passes(self):
+        self._tree()
+        self.registry([self._row()])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("1 in scope", out)
+
+    def test_a_row_still_on_its_pre_campaign_name_is_pending_not_a_failure(self):
+        self.symbols("ov002", [
+            ("ExclamationSwitch_Spawn", "0x020baadc", "function(arm,size=0x30)"),
+            ("ExclamationSwitch_SpawnInfo", "0x02109900", "data(any)"),
+        ])
+        self.delinks("ov002", [("src/ExclamationSwitch_Spawn.c", "0x020baadc", "0x020bab0c")])
+        self.ledger([])
+        self.registry([self._row()])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("PENDING", out)
+        self.assertIn("g_profile_HANSWITCH", out)
+
+    def test_strict_turns_pending_into_a_failure(self):
+        """The switch to flip when the campaign closes."""
+        self.symbols("ov002", [
+            ("ExclamationSwitch_Spawn", "0x020baadc", "function(arm,size=0x30)"),
+            ("ExclamationSwitch_SpawnInfo", "0x02109900", "data(any)"),
+        ])
+        self.delinks("ov002", [("src/ExclamationSwitch_Spawn.c", "0x020baadc", "0x020bab0c")])
+        self.ledger([])
+        self.registry([self._row()])
+        self.assertEqual(self.run_tool("--strict")[0], 1)
+
+    def test_a_name_that_is_neither_current_nor_proposed_is_a_failure(self):
+        """Not pending: no wave leaves a symbol in that state."""
+        self.symbols("ov002", [
+            ("who_is_this", "0x020baadc", "function(arm,size=0x30)"),
+            ("g_profile_HANSWITCH", "0x02109900", "data(any)"),
+        ])
+        self.delinks("ov002", [("src/x.c", "0x020baadc", "0x020bab0c")])
+        self.ledger([])
+        self.registry([self._row()])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 1)
+        self.assertIn("factory symbol diverged", out)
+
+    def test_superseded_rows_are_out_of_scope(self):
+        self._tree()
+        self.registry([self._row(overlay_resolution="superseded_by_ov002",
+                                 proposed_factory_name="nonsense_that_would_fail")])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("0 in scope (1 superseded)", out)
+
+    def test_a_factory_folded_into_a_promoted_tu_is_exempt_and_it_is_measured(self):
+        """Two functions inside the owning delinks range means a TU.
+
+        Detected from the tree, never a list of known TUs: the range in ov070
+        that owns daPropeller_Heyho_c's factory holds many functions, and the
+        exemption has to follow from that, not from the file's name.
+        """
+        self.symbols("ov070", [
+            ("daPropeller_Heyho_c_classInit", "0x02120520", "function(arm,size=0x50)"),
+            ("_ZN18daPropeller_Heyho_cD1Ev", "0x0211f100", "function(arm,size=0x40)"),
+            ("g_profile_PROPELLER_HEYHO", "0x02121000", "data(any)"),
+        ])
+        self.delinks("ov070", [("src/actors/daPropeller_Heyho_c.cpp", "0x0211f000",
+                                "0x02120570")])
+        self.ledger([])
+        self.registry([self._row(
+            profile_id="PROPELLER_HEYHO", overlay="ov070", profile_address="0x02121000",
+            proposed_profile_name="g_profile_PROPELLER_HEYHO",
+            current_profile_name="FlyGuy_SpawnInfo",
+            factory_module="ov070", factory_address="0x02120520",
+            current_factory_name="FlyGuy_Spawn",
+            proposed_factory_name="daPropeller_Heyho_c_classInit",
+            factory_filename="d_a_propeller_heyho.c")])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("1 factory source(s) exempt", out)
+
+    def test_a_standalone_source_on_the_wrong_filename_is_pending(self):
+        self.symbols("ov002", [
+            ("daObjSwitch_c_classInit_HANSWITCH", "0x020baadc", "function(arm,size=0x30)"),
+            ("g_profile_HANSWITCH", "0x02109900", "data(any)"),
+        ])
+        self.delinks("ov002", [("src/ExclamationSwitch_Spawn.c", "0x020baadc", "0x020bab0c")])
+        self.ledger([])
+        self.registry([self._row()])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("d_a_obj_switch_hanswitch.c", out)
+        self.assertIn("filename", out)
+
+    def test_a_factory_no_delinks_entry_owns_is_a_failure(self):
+        self.symbols("ov002", [
+            ("daObjSwitch_c_classInit_HANSWITCH", "0x020baadc", "function(arm,size=0x30)"),
+            ("g_profile_HANSWITCH", "0x02109900", "data(any)"),
+        ])
+        self.delinks("ov002", [("src/elsewhere.c", "0x02000000", "0x02000010")])
+        self.ledger([])
+        self.registry([self._row()])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 1)
+        self.assertIn("factory source unlocatable", out)
+
+
+class DegradesHonestly(Fixture):
+    """The dataset is on PR #2235, not on main. That must not crash or pass."""
+
+    def test_a_missing_registry_is_reported_and_skipped(self):
+        self.symbols("ov070", [("daPropeller_Heyho_c_classInit", "0x02120520",
+                                "function(arm,size=0x50)")])
+        self.ledger([("ov070", "0x02120520", "old", "daPropeller_Heyho_c_classInit", "x")])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("registry scan SKIPPED", out)
+        self.assertIn("PR #2235", out)
+
+    def test_the_ledger_scan_still_runs_without_the_registry(self):
+        """Skipping scan 1 must not take scan 2 down with it."""
+        self.symbols("ov070", [("FlyGuy_Spawn", "0x02120520", "function(arm,size=0x50)")])
+        self.ledger([("ov070", "0x02120520", "old", "daPropeller_Heyho_c_classInit", "x")])
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 1)
+        self.assertIn("daPropeller_Heyho_c_classInit", out)
+
+    def test_missing_columns_are_named_rather_than_guessed_at(self):
+        self.symbols("ov002", [("g_profile_HANSWITCH", "0x02109900", "data(any)")])
+        self.ledger([])
+        self.write(C.REGISTRY, "profile_id\toverlay\n" + "HANSWITCH\tov002\n")
+        rc, out = self.run_tool()
+        self.assertEqual(rc, 0)
+        self.assertIn("registry scan SKIPPED", out)
+        self.assertIn("factory_filename", out)
+        self.assertIn("overlay_resolution", out)
+
+    def test_an_empty_registry_does_not_pass_as_a_complete_campaign(self):
+        self.symbols("ov002", [("g_profile_HANSWITCH", "0x02109900", "data(any)")])
+        self.ledger([])
+        self.write(C.REGISTRY, "\t".join(REGISTRY_HEADER) + "\n")
+        rc, out = self.run_tool()
+        self.assertIn("registry scan SKIPPED", out)
+        self.assertNotIn("in scope", out)
+
+    def test_strict_refuses_a_missing_dataset(self):
+        self.symbols("ov070", [("daPropeller_Heyho_c_classInit", "0x02120520",
+                                "function(arm,size=0x50)")])
+        self.ledger([("ov070", "0x02120520", "old", "daPropeller_Heyho_c_classInit", "x")])
+        rc, out = self.run_tool("--strict")
+        self.assertEqual(rc, 1)
+        self.assertIn("--strict requires the registry dataset", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the gap `tools/check_rename_ledger.py` documents but cannot cover.

## The blindspot

`check_rename_ledger.py` resolves `_ZN…` and `_ZTV…` rows only, and prints its own
unchecked count so the green is not over-read. That count is currently **945** — every
coined spelling the profile reconstruction campaign produces (`g_profile_<ID>`,
`<Class>_classInit`), with no gate on any of them.

Not theoretical. This row has been on `main`, green:

```
ov070  0x02120520  FlyGuy_Spawn  daPropeller_Heyho_c_classInit
```

`config/arm9/overlays/ov070/symbols.txt` line 27 still reads
`FlyGuy_Spawn kind:function(arm,size=0x50) addr:0x02120520`. The ledger asserts a symbol
the build has never emitted. A byte-perfect 106/106 says nothing about it.

## What lands

`tools/check_profile_campaign.py` — two scans, both against `config/**/symbols.txt`.

**Scan 1, the registry.** Per in-scope row of
`symbols/profile_reconstruction_registry.tsv`:

1. the descriptor symbol carries its proposed `g_profile_<ID>` name
2. the factory symbol carries its proposed `<Class>_classInit[_<ID>]` name
3. the factory's standalone source sits on its `factory_filename`

Rows whose `overlay_resolution` starts with `superseded_by_` are out of scope.

Check 3's exemption is **measured, not listed**: the owning `delinks.txt` entry is read,
and the entry counts as a promoted TU when more than one function symbol falls inside the
range it claims. `src/actors/daPropeller_Heyho_c.cpp` owns `0x0211f000..0x02120570` in
ov070 and the factory at `0x02120520` is one of many functions inside it — so it is
exempt from the filename check and still bound by check 2. A hardcoded list of TUs would
go stale on the next promotion.

A row still on its pre-campaign spelling reports **PENDING** and does not fail while
waves are landing. `--strict` makes every pending row fatal — the switch to flip when the
campaign closes. A symbol that is *neither* the current nor the proposed name is a
failure, not pending: no wave leaves one in that state.

**Scan 2, the coined ledger rows.** The ledger is an append log, so for each
`(module, address)` only the last row's fourth column is the live claim; earlier rows are
superseded history, and mangled claims are left to `check_rename_ledger.py`.

## What it found on today's main

**751 live coined claims across 70 `symbols.txt` files; 17 diverge.** They split cleanly
in two, and I have not edited the ledger — every one is banked in
`config/profile-campaign-baseline.json` with a note saying which way it points, and none
is marked accepted.

**Seven where the ledger runs AHEAD of the tree** — it names a symbol the build never
emitted. This is the PROPELLER_HEYHO shape:

| module | address | ledger says | symbols.txt carries |
|---|---|---|---|
| ov029 | `0x02111340` | `daObjWcObj01_c_classInit` | `daObjWcObj01_c_Spawn` |
| ov029 | `0x02112044` | `daObjWcObj06_c_classInit` | `daObjWcObj06_c_Spawn` |
| ov029 | `0x02113c08` | `g_profile_WC_OBJ01` | `daObjWcObj01_c_SpawnInfo` |
| ov043 | `0x0211176c` | `daObjKm1_Dorifu_c_classInit` | `StairsBdw_Spawn` |
| ov043 | `0x021124fc` | `g_profile_KM1_DORIFU` | `StairsBdw_SpawnInfo` |
| ov045 | `0x02112cd0` | `g_profile_KM2_AGARU` | `FireSeaElevator_SpawnInfo` |
| ov070 | `0x02120520` | `daPropeller_Heyho_c_classInit` | `FlyGuy_Spawn` |

The ov045 row came in with wave 23 (`e5fc0aad1`): the ledger row landed, the `symbols.txt`
edit did not.

**Ten where the ledger runs BEHIND the tree** — `symbols.txt` already carries the campaign
name and no ledger row was ever appended, so the row asserts a superseded spelling:

| module | address | ledger says | symbols.txt carries |
|---|---|---|---|
| ov002 | `0x020b56d8` | `QuestionSwitch_Spawn` | `daObjHatenaSwitch_c_classInit` |
| ov002 | `0x020f085c` | `InvisibleSecret_Spawn` | `daSCoin_c_Spawn` |
| ov002 | `0x02108e38` | `QuestionSwitch_SpawnInfo` | `g_profile_HATENA_SWITCH` |
| ov009 | `0x02112048` | `DockPole_Spawn` | `daObjMc_Metalnet_c_classInit` |
| ov009 | `0x02113abc` | `DockPole_SpawnInfo` | `g_profile_MC_METALNET` |
| ov029 | `0x02113f20` | `FloatOnWaterPlatformWdwRectangle_SpawnInfo` | `daObjWcObj06_c_SpawnInfo` |
| ov065 | `0x0211b328` | `TTC_MovingBar_Spawn` | `daObjCtMecha05_c_classInit` |
| ov065 | `0x0211d290` | `TTC_MovingBar_SpawnInfo` | `g_profile_CT_MECHA05` |
| ov100 | `0x02147328` | `PathLift_Spawn` | `daObjPathLift_c_classInit` |
| ov100 | `0x02148558` | `PathLift_SpawnInfo` | `g_profile_PATH_LIFT` |

The ov009 pair is the `DockPole_*`-on-`MetalNet`'s-addresses shift that
`check_rename_ledger.py`'s docstring names as a known example it cannot see. This is the
first time a gate has been able to.

Which side is wrong is the campaign owner's call in both directions, and the shared ledger
is being edited by five concurrent waves, so I banked and reported rather than picking.
None of these fixes is unambiguous enough to make unilaterally.

## Ratchet, guard, and honest degradation

`config/profile-campaign-baseline.json` banks a divergence **with the pair actually
observed**, so an entry stops matching the moment either side changes — rebanking cannot
turn the ratchet into an allowlist. The banked count prints on every run.

The tool counts what it actually resolved and exits **SCAN TOO SMALL** below a floor
(15 symbol files, 300 live claims, 150 in-scope registry rows) rather than announcing a
clean tree, matching `check_dead_references.py`'s guard. The floors sit far below today's
numbers; they trip when a reader breaks.

The dataset gains `overlay_resolution` and `factory_filename` on **#2235**, so on `main`
today the registry scan names the columns it could not read and skips — it never reports a
pass on a dataset it did not read — while scan 2 runs on files already here. `--strict`
refuses a missing dataset outright.

Today, on `main`:

```
registry scan SKIPPED -- symbols/profile_reconstruction_registry.tsv lacks the
  column(s) overlay_resolution, factory_filename.
751 live coined ledger claim(s) resolved against 70 symbols.txt file(s);
  17 diverge, 17 of them banked in config/profile-campaign-baseline.json
OK: every campaign claim this tool can resolve is carried by the tree.
```

## Rows and checks are separate units

The first draft of the registry summary incremented one counter per **check** and printed
it beside a **row** count — `391 in scope; 216 complete, 889 pending`, which is 1,105
things out of 391 rows. Read as rows, which is how it reads, that understates the campaign
badly. Two units in one sentence is the same misleading green this tool exists to remove.

`complete`/`pending`/`diverged` now count **registry rows** and partition `scope` exactly:
a row is diverged if any check disagrees with the tree, pending if any is merely
outstanding, complete only when nothing is either. Individual assertions get their own
labelled line. A folded factory has *no* filename check rather than a passing one, so
`exempt` is reported separately and named as a check count.

`main()` asserts the partition before printing and returns 2 with `INTERNAL ERROR` if it
does not hold, so a counter that stops adding up cannot be read off a green run. Four
tests pin it, including a three-row case with one row in each state; mutation-checked by
turning the `elif` into an `if`, which turns three tests red.

## Where the campaign actually stands

Measured on a tree built from `main` + the `config/arm9` changes of **all twelve open wave
PRs** (#2238–#2245, #2247–#2250, waves 25–36) + #2235's dataset. Waves are cut on module
boundaries, so their `symbols.txt`/`delinks.txt` edits compose without conflict, and
`delinks.txt` is what check 3 reads — so `config/` plus the dataset is the whole input.

```
401 registry row(s), 391 in scope (10 superseded)
  rows      : 313 complete, 78 pending, 0 diverged
  checks    : 948 complete, 157 pending, 0 diverged
               (up to three per row; outstanding: 62 descriptor, 59 factory, 36 filename)
  exempt    : 66 factory source(s) folded into a promoted TU
```

**313 of 391 rows complete — 80%, with 78 rows left**, and **zero divergences**: every
wave's `symbols.txt` edit agrees with the dataset's proposed name. Against #2235's branch
alone the same scan reads `29 complete, 362 pending`, which is what makes the pre-merge
figure so stale — that branch carries the dataset and none of the waves.

One caveat on that measurement: I took `config/` from the waves but deliberately not
`symbols/actor_renames.tsv`, so in that synthetic tree scan 2 reports 423 ledger
divergences. That is an artifact of the ledger being `main`'s while `symbols.txt` is
post-wave — not a finding. It does incidentally show scan 2 detecting the
"ledger behind the tree" condition at scale.

## Tests

27, in `tools/test_check_profile_campaign.py`, all fixture trees — no repo, no compiler,
no ROM. Positive controls first: a divergence MUST be reported, and an empty scan MUST
exit non-zero.

Mutation-checked three ways, each turning tests red:

- disabling the coined comparison → 5 red, including the PROPELLER_HEYHO control
- removing the size guard → both `ScanSizeGuard` cases red
- dropping the append-log collapse → 16 red

Written as `unittest.TestCase` rather than bare `def test_*`. That is a deliberate
departure from `test_tubuild.py`'s shape: `tool-tests.yml`'s own header refuses that file
because `python -m unittest` finds 0 of its tests, and every workflow in this repo runs
tool tests through unittest. `TestCase` is collected by both — `pytest` 27 passed,
`python -m unittest` Ran 27 OK.

## Workflow

`.github/workflows/profile-campaign.yml`, modelled on `rename-ledger.yml`, with
`dead-references.yml`'s "refusing to report a pass on a scan this size" guard carried into
the tool. It keeps a `paths:` filter where `dead-references.yml` dropped its, and the
header says why: that job resolves prose against the whole tree so no filter can be
complete, while this one resolves against exactly `config/**/symbols.txt` and
`config/**/delinks.txt`, both listed in the filter alongside the inputs.

## Gates

```
python tools/check_profile_campaign.py     OK (the new gate, on itself)
python -m pytest  tools/test_check_profile_campaign.py -q   27 passed
python -m unittest tools.test_check_profile_campaign        Ran 27, OK
python tools/rombuild.py -j 16 --no-rom    106/106 exact, 100.000000%, PASS
python tools/check_rename_ledger.py        clean (1652 checked, 945 out of scope)
python tools/check_dead_references.py      no new dead references
python tools/check_python_names.py         PASS (271 files, 0 unresolvable)
python tools/port_refcheck.py              405 checked, all resolve
python tools/check_references.py           no new unresolvable references
```

`check_dead_references.py` earned its keep during review: it caught both of my own
docstrings naming `config/arm9/main/symbols.txt` — the non-existent path they were written
to warn about. Reworded.

This PR touches no build input; the `rombuild` run is a control, not a requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
