### PR TITLE
Reconstruct the last two profile symbols: KM3_KAITENDAI (ov047) and WC_OBJ06 (ov029)

### DIFF
--- a/config/arm9/overlays/ov029/symbols.txt
+++ b/config/arm9/overlays/ov029/symbols.txt
@@ -202,7 +202,7 @@ data_ov029_02113e88 kind:data(any) addr:0x02113e88 ambiguous
 _ZTI14daObjWcObj06_c kind:data(any) addr:0x02113ef4
 data_ov029_02113f00 kind:data(any) addr:0x02113f00
 _ZTS14daObjWcObj06_c kind:data(any) addr:0x02113f0c
-daObjWcObj06_c_SpawnInfo kind:data(any) addr:0x02113f20 ambiguous
+g_profile_WC_OBJ06 kind:data(any) addr:0x02113f20 ambiguous
 _ZTV14daObjWcObj06_c kind:data(any) addr:0x02113f44
 data_ov029_02113f4c kind:data(any) addr:0x02113f4c ambiguous
 data_ov029_02113f78 kind:data(any) addr:0x02113f78 ambiguous

--- a/config/arm9/overlays/ov047/symbols.txt
+++ b/config/arm9/overlays/ov047/symbols.txt
@@ -7,7 +7,7 @@ _ZN20daObjKm3_Kaitendai_cD1Ev kind:function(arm,size=0x50) addr:0x021112bc
 _ZN20daObjKm3_Kaitendai_cD0Ev kind:function(arm,size=0x64) addr:0x0211130c
 _ZN20daObjKm3_Kaitendai_c16CleanupResourcesEv kind:function(arm,size=0x14) addr:0x02111370
 _ZN20daObjKm3_Kaitendai_c13InitResourcesEv kind:function(arm,size=0x38) addr:0x02111384
-func_ov047_021113bc kind:function(arm,size=0x3c) addr:0x021113bc
+daObjKm3_Kaitendai_c_classInit kind:function(arm,size=0x3c) addr:0x021113bc
 _ZN17daObjKm3_Kuruma_cD1Ev kind:function(arm,size=0x50) addr:0x021113f8
 _ZN17daObjKm3_Kuruma_cD0Ev kind:function(arm,size=0x64) addr:0x02111448
 _ZN17daObjKm3_Kuruma_c16CleanupResourcesEv kind:function(arm,size=0x14) addr:0x021114ac
@@ -93,7 +93,7 @@ data_ov047_02112324 kind:data(any) addr:0x02112324
 _ZTI20daObjKm3_Kaitendai_c kind:data(any) addr:0x02112328
 data_ov047_02112334 kind:data(any) addr:0x02112334
 _ZTS20daObjKm3_Kaitendai_c kind:data(any) addr:0x02112340
-data_ov047_02112358 kind:data(any) addr:0x02112358
+g_profile_KM3_KAITENDAI kind:data(any) addr:0x02112358
 _ZTV20daObjKm3_Kaitendai_c kind:data(any) addr:0x0211237c
 _ZTI17daObjKm3_Kuruma_c kind:data(any) addr:0x021123fc
 data_ov047_02112408 kind:data(any) addr:0x02112408

--- a/config/tu_manifest.d/ov047/daObjKm3_Kaitendai_c.json
+++ b/config/tu_manifest.d/ov047/daObjKm3_Kaitendai_c.json
@@ -7,8 +7,8 @@
   "status": "promoted",
   "boundary_confidence": "high",
   "boundary_evidence": [
-    "manually corrected contiguous linker run: 0x021112bc..0x021113f8, five functions; build/tu_map.json stopped at 0x021113bc and omitted the immediately adjacent factory func_ov047_021113bc",
-    "func_ov047_021113bc constructs daObjKm3_Kaitendai_c (size 0x320, dBgActor base constructor, then daObjKaitendai and daObjKm3_Kaitendai vptr stores), and the actor descriptor at 0x02112358 relocates directly to it inside this class's RTTI/type-name/vtable data band",
+    "manually corrected contiguous linker run: 0x021112bc..0x021113f8, five functions; build/tu_map.json stopped at 0x021113bc and omitted the immediately adjacent factory daObjKm3_Kaitendai_c_classInit",
+    "daObjKm3_Kaitendai_c_classInit constructs daObjKm3_Kaitendai_c (size 0x320, dBgActor base constructor, then daObjKaitendai and daObjKm3_Kaitendai vptr stores), and the actor descriptor at 0x02112358 relocates directly to it inside this class's RTTI/type-name/vtable data band",
     "one mwccarm 2004/b56 compile emits all five text contributions plus the measured class data; strict partitioned linkcheck proved 5/5 text contributions and the 0x02112334..0x021123fc data tail, and ordinary intact-object production extends that ownership through the compiler-emitted RTTI at 0x02112328"
   ],
   "sections": [
@@ -53,7 +53,7 @@
       "ordinal": 3
     },
     {
-      "symbol": "func_ov047_021113bc",
+      "symbol": "daObjKm3_Kaitendai_c_classInit",
       "address": "0x021113bc",
       "size": "0x0000003c",
       "legacy_source": "src/func_ov047_021113bc.c",
@@ -80,7 +80,7 @@
       "evidence": "compiler-emitted type-name string matches the retail bytes; its dedicated section pads to the next four-byte boundary"
     },
     {
-      "symbol": "data_ov047_02112358",
+      "symbol": "g_profile_KM3_KAITENDAI",
       "address": "0x02112358",
       "size": "0x1c",
       "evidence": "typed actor descriptor; factory relocation and all priority, flag, and range words match retail"
@@ -162,7 +162,7 @@
       "source": "0x02112358",
       "type": "R_ARM_ABS32",
       "kind": "load",
-      "symbol": "func_ov047_021113bc",
+      "symbol": "daObjKm3_Kaitendai_c_classInit",
       "addend": 0,
       "target_module": "ov047",
       "target_address": "0x021113bc"
@@ -1001,7 +1001,7 @@
           },
           {
             "ordinal": 4,
-            "symbol": "func_ov047_021113bc",
+            "symbol": "daObjKm3_Kaitendai_c_classInit",
             "identical": true,
             "relocCount": 4,
             "differences": []
@@ -1078,7 +1078,7 @@
           "_ZTS20daObjKm3_Kaitendai_c",
           "_ZTV20daObjKm3_Kaitendai_c",
           "data_ov047_02112334",
-          "data_ov047_02112358"
+          "g_profile_KM3_KAITENDAI"
         ],
         "deferredOutputs": [
           {
@@ -1102,7 +1102,7 @@
             "size": "0x00000038"
           },
           {
-            "symbol": "func_ov047_021113bc",
+            "symbol": "daObjKm3_Kaitendai_c_classInit",
             "section": ".text",
             "size": "0x0000003c"
           }
@@ -1130,7 +1130,7 @@
           "_ZN20daObjKm3_Kaitendai_c16CleanupResourcesEv",
           "_ZN20daObjKm3_Kaitendai_cD0Ev",
           "_ZN20daObjKm3_Kaitendai_cD1Ev",
-          "func_ov047_021113bc"
+          "daObjKm3_Kaitendai_c_classInit"
         ],
         "deadTextSymbols": [
           "$a",
@@ -1363,7 +1363,7 @@
           },
           {
             "ordinal": 4,
-            "symbol": "func_ov047_021113bc",
+            "symbol": "daObjKm3_Kaitendai_c_classInit",
             "identical": true,
             "relocCount": 4,
             "differences": []
@@ -1440,7 +1440,7 @@
           "_ZTS20daObjKm3_Kaitendai_c",
           "_ZTV20daObjKm3_Kaitendai_c",
           "data_ov047_02112334",
-          "data_ov047_02112358"
+          "g_profile_KM3_KAITENDAI"
         ],
         "deferredOutputs": [
           {
@@ -1464,7 +1464,7 @@
             "size": "0x00000038"
           },
           {
-            "symbol": "func_ov047_021113bc",
+            "symbol": "daObjKm3_Kaitendai_c_classInit",
             "section": ".text",
             "size": "0x0000003c"
           }
@@ -1492,7 +1492,7 @@
           "_ZN20daObjKm3_Kaitendai_c16CleanupResourcesEv",
           "_ZN20daObjKm3_Kaitendai_cD0Ev",
           "_ZN20daObjKm3_Kaitendai_cD1Ev",
-          "func_ov047_021113bc"
+          "daObjKm3_Kaitendai_c_classInit"
         ],
         "deadTextSymbols": [
           "$a",

--- a/include/daObjKaitendai_c.h
+++ b/include/daObjKaitendai_c.h
@@ -35,7 +35,8 @@
  * UpdateClsnPosAndRot. Its own Render (`func_ov002_020b66f0`) dispatches through
  * the Model at 0xd4. Its own destructor destroys only dBgActor_c's two members. And
  * all five factories -- daObjBk_Ukisima_c_classInit, daObjFl_Koma_D_c_classInit,
- * daObjWc_Obj07_c_Spawn, RotatingPlatformRr_Spawn and `func_ov047_021113bc`,
+ * daObjWc_Obj07_c_Spawn, RotatingPlatformRr_Spawn and
+ * daObjKm3_Kaitendai_c_classInit (historical alias func_ov047_021113bc),
  * which is daObjKm3_Kaitendai_c's real factory -- pass 800 = 0x320 to
  * fBase_c::operator new, which is sizeof(dBgActor_c) exactly. There is no room for
  * a field anywhere in this class or in any of the five leaves.

--- a/include/daObjKm3_Kaitendai_c.h
+++ b/include/daObjKm3_Kaitendai_c.h
@@ -17,7 +17,8 @@
  *   base  daObjKaitendai_c, ov002 0x021091ac
  *
  * NO FIELDS OF ITS OWN, and the factory that says so is NOT the one named after this
- * class. `func_ov047_021113bc`, still unnamed, is the function that allocates 800 =
+ * class. daObjKm3_Kaitendai_c_classInit (historical alias func_ov047_021113bc)
+ * is the function that allocates 800 =
  * 0x320 and stores this class's vtable second. daObjKm3_Kurumajiku_c_classInit
  * (historical alias RickshawBs_Spawn) allocates 816 and
  * builds daObjKm3_Kurumajiku_c: the ov047 "Bs" names were crossed -- this class was

--- a/src/actors/daObjKm3_Kaitendai_c.cpp
+++ b/src/actors/daObjKm3_Kaitendai_c.cpp
@@ -66,10 +66,12 @@ extern s16 data_ov047_02112324;
 }
 
 /* ROM ordinal 4 -- func_ov047_021113bc, 0x021113bc, size 0x3c */
-// @symbol func_ov047_021113bc
-/* This function is still unnamed in the object table, but its allocation
- * size and vptr stores prove that it constructs daObjKm3_Kaitendai_c. */
-extern "C" daObjKm3_Kaitendai_c *func_ov047_021113bc()
+// @symbol daObjKm3_Kaitendai_c_classInit
+/* Reconstructed source-style name: SM64DS proves daObjKm3_Kaitendai_c through
+ * RTTI, allocation size, vtable identity, and the KM3_KAITENDAI registry
+ * profile; later EAD lineage supplies classInit. Exact original spelling is
+ * not preserved. Historical alias: func_ov047_021113bc. */
+extern "C" daObjKm3_Kaitendai_c *daObjKm3_Kaitendai_c_classInit()
 {
     daObjKm3_Kaitendai_c *actor =
         static_cast<daObjKm3_Kaitendai_c *>(_ZN7fBase_cnwEj(0x320));
@@ -84,8 +86,12 @@ extern "C" daObjKm3_Kaitendai_c *func_ov047_021113bc()
     return actor;
 }
 
-extern "C" KaitendaiSpawnInfo data_ov047_02112358 = {
-    func_ov047_021113bc,
+/* Reconstructed source-style name: SM64DS proves this descriptor through its
+ * registry role, the KM3_KAITENDAI literal ROM profile ID, and the factory
+ * relocation it carries; later EAD lineage supplies g_profile_. Exact original
+ * spelling is not preserved. Historical alias: data_ov047_02112358. */
+extern "C" KaitendaiSpawnInfo g_profile_KM3_KAITENDAI = {
+    daObjKm3_Kaitendai_c_classInit,
     0x009c,
     0x00e3,
     2,

--- a/symbols/actor_renames.tsv
+++ b/symbols/actor_renames.tsv
@@ -1280,6 +1280,7 @@ ov047	0x021112bc	func_ov047_021112bc	_ZN20daObjKm3_Kaitendai_cD1Ev	vtable slot 1
 ov047	0x0211130c	func_ov047_0211130c	_ZN20daObjKm3_Kaitendai_cD0Ev	vtable slot 17 (was _ZN10RickshawBsD0Ev)
 ov047	0x02111370	func_ov047_02111370	_ZN20daObjKm3_Kaitendai_c16CleanupResourcesEv	vtable slot 3 (was _ZN10RickshawBs16CleanupResourcesEv)
 ov047	0x02111384	func_ov047_02111384	_ZN20daObjKm3_Kaitendai_c13InitResourcesEv	vtable slot 0 (was _ZN10RickshawBs13InitResourcesEv)
+ov047	0x021113bc	func_ov047_021113bc	daObjKm3_Kaitendai_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov047	0x021114d4	func_ov047_021114d4	daObjKm3_Dorifu_c_Spawn	spawnfunc
 ov047	0x02111510	func_ov047_02111510	_ZN17daObjKm3_Dorifu_cD1Ev	vtable slot 16
 ov047	0x02111590	func_ov047_02111590	_ZN17daObjKm3_Dorifu_cD0Ev	vtable slot 17
@@ -1288,6 +1289,7 @@ ov047	0x02111638	func_ov047_02111638	_ZN17daObjKm3_Dorifu_c13InitResourcesEv	vta
 ov047	0x0211164c	func_ov047_0211164c	StairsBs_Spawn	spawnfunc
 ov047	0x0211227c	data_ov047_0211227c	RickshawBs_SpawnInfo	spawninfo
 ov047	0x0211227c	RickshawBs_SpawnInfo	g_profile_KM3_KURUMAJIKU	reconstructed profile global; literal ROM ID KM3_KURUMAJIKU+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov047	0x02112358	data_ov047_02112358	g_profile_KM3_KAITENDAI	reconstructed profile global; literal ROM ID KM3_KAITENDAI+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov047	0x0211237c	data_ov047_0211237c	_ZTV20daObjKm3_Kaitendai_c	vtable alloc=? (was _ZTV10RickshawBs)
 ov047	0x02112428	data_ov047_02112428	daObjKm3_Dorifu_c_SpawnInfo	spawninfo
 ov047	0x021124ec	data_ov047_021124ec	StairsBs_SpawnInfo	spawninfo

--- a/symbols/actor_renames.tsv
+++ b/symbols/actor_renames.tsv
@@ -1000,6 +1000,7 @@ ov029	0x02113e50	data_ov029_02113e50	daObjWc_Obj05_c_SpawnInfo	spawninfo (was Ca
 ov029	0x02113e50	daObjWc_Obj05_c_SpawnInfo	g_profile_WC_OBJ05	reconstructed profile global; literal ROM ID WC_OBJ05+registry role+later EAD lineage; exact SM64DS spelling not preserved (was CageLift_SpawnInfo)
 ov029	0x02113f20	data_ov029_02113f20	FloatOnWaterPlatformWdwRectangle_SpawnInfo	spawninfo
 ov029	0x02113f20	FloatOnWaterPlatformWdwRectangle_SpawnInfo	daObjWcObj06_c_SpawnInfo	renamed to the class's ROM RTTI identity; row recorded retroactively -- the rename reached symbols.txt without a ledger entry
+ov029	0x02113f20	daObjWcObj06_c_SpawnInfo	g_profile_WC_OBJ06	reconstructed profile global; literal ROM ID WC_OBJ06+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov029	0x02113ff4	data_ov029_02113ff4	daObjWc_Obj07_c_SpawnInfo	spawninfo
 ov029	0x02114018	data_ov029_02114018	_ZTV15daObjWc_Obj07_c	vtable alloc=? (was _ZTV32FloatOnWaterPlatformWdwRectangle)
 ov029	0x021140b8	data_ov029_021140b8	WDW_Water_SpawnInfo	spawninfo


### PR DESCRIPTION
Two rows that the wave partition missed, both following directly from the ov043 result: `production_mode: intact-object` does **not** block a profile rename. That verdict was a diagnosis misread — `owned .data ordering anchor has 0 definitions` reports an *incomplete* rename, one that reached `symbols.txt` and the manifest but not the TU source that **defines** the descriptor.

## 1. KM3_KAITENDAI (ov047) — went through

| address | old | new |
|---|---|---|
| `0x021113bc` | `func_ov047_021113bc` | `daObjKm3_Kaitendai_c_classInit` |
| `0x02112358` | `data_ov047_02112358` | `g_profile_KM3_KAITENDAI` |

This is the other row written off as blocked by `production_mode`, and it was never among the 17 banked divergences, so nobody re-examined it. Both halves live in the promoted intact-object TU `src/actors/daObjKm3_Kaitendai_c.cpp`, so the four-sided rename was applied exactly as for `KM1_DORIFU` and `PROPELLER_HEYHO`:

- `config/arm9/overlays/ov047/symbols.txt` — name token only, every other token byte-identical
- the **definitions** in the TU source (the side the earlier failed attempts missed), plus the `// @symbol` markers and the factory reference inside the descriptor initialiser
- `config/tu_manifest.d/ov047/daObjKm3_Kaitendai_c.json` — 13 live entries: function entry, the `.data` `R_ARM_ABS32` relocation symbol, the data claim at `0x02112358`, `deferredOutputs`, `externalizedTextSymbols`, `objectComparison` and both `licensedSymbols` lists
- `symbols/actor_renames.tsv`, inserted into ov047's longest contiguous block

`legacy_source` and `sources` paths (`src/func_ov047_021113bc.c` and the four mangled-name files) keep the historical spelling — records of where the bytes were assembled from, not claims about the current symbol. Header prose in `include/daObjKaitendai_c.h` and `include/daObjKm3_Kaitendai_c.h` reworded; the latter no longer says the factory is "still unnamed".

The superseded ov033 `KM3_KAITENDAI` registry row (`not_apply=overlay_multiplex_superseded_by_ov047`) is deliberately untouched.

## 2. WC_OBJ06 (ov029 `0x02113f20`)

`daObjWcObj06_c_SpawnInfo` → `g_profile_WC_OBJ06`.

Target confirmed against `symbols/profile_reconstruction_registry.tsv` **before** renaming: overlay ov029, `profile_address 0x02113f20`, `current_profile_name daObjWcObj06_c_SpawnInfo`, `proposed_profile_name g_profile_WC_OBJ06`, class `daObjWcObj06_c` from SM64DS RTTI `ov029:0x02113ef4`, `profile_rename_recommended yes`.

The address is raw overlay data — no delink entry, no TU manifest data claim, no source definition — so this is `symbols.txt` plus one ledger row. The ledger now carries the chain end to end: `data_ov029_02113f20` → `FloatOnWaterPlatformWdwRectangle_SpawnInfo` → `daObjWcObj06_c_SpawnInfo` → `g_profile_WC_OBJ06`.

## Base

Asked for `tools/profile-campaign-gate` (the #2253 base, same as #2257). I measured that base first and it does not work: #2257 already modifies `src/actors/d_a_obj_wc_obj06.cpp`, `config/tu_manifest.d/ov029/daObjWcObj06_c.json`, `include/daObjWcObj06_c.h` and `config/profile-campaign-baseline.json`, and it appends the ledger row at `0x02113f20` that this PR's row must follow. Branching off the gate branch would have produced hand-resolved conflicts in four files and a ledger chain with a missing middle.

So this is stacked on `cpp/profile-campaign-ledger-reconcile` (#2257), which is itself based on `tools/profile-campaign-gate` — the gate still runs against this work, which was the point of the requested base. **Retarget to `main` once #2253 and #2257 land.**

## Gates

```
check_profile_campaign  753 live coined ledger claims resolved against 70 symbols.txt files
                        1 diverge, 1 of them banked  (unchanged: the ov070 entry fixed in #2238)
rombuild -j 16 --no-rom module fidelity: 106/106 exact, 100.000000%
                        ROM-build analysis: PASS
                        intact TU gates: dsd modules PASS, zero new symbol errors,
                                         storage aliases exact
                        source-owned data claims: 16 (reproducing 16, mismatching 0)
romdata_check           VERIFIED 648 (43,808 bytes equal to the cartridge), DIFFERS 5  exit 0
check_rename_ledger     1652 mangled/vtable rows agree; 956 coined rows out of scope
check_dead_references   no new dead references, no broken markdown links
port_refcheck           405 references checked, all resolve
eligible                11085 / 11211
check_references        unresolved 42 (baseline 45), no new unresolvable references
pytest                  95 passed (test_tubuild + test_check_profile_campaign)
```

`check_references` reports 3 references fixed since its baseline; not banked here, to keep the baseline file out of a five-PR conflict.

All names are Tier B — evidence-bounded reconstructions, not recovered SM64DS spellings. The ROM proves the classes, sizes, vtables, factory relocations and the literal profile IDs; later EAD lineage supplies the `classInit` and `g_profile_` conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA