### PR TITLE
Teach the enrolment filename check the reconstructed-name convention, and run it on tree changes

### DIFF
--- a/.github/workflows/tree-shape.yml
+++ b/.github/workflows/tree-shape.yml
@@ -1,0 +1,96 @@
+# The two suites whose inputs are the TREE, not `tools/`.
+#
+# tool-tests.yml runs 29 modules on every PR touching `tools/**` or `nearmiss/**`. That
+# filter is right for the other 27: their inputs are the tools themselves. It is wrong
+# for these two, whose assertions read `config/**/delinks.txt`, `config/**/symbols.txt`
+# and `src/**` -- so a PR that renames a source and rewrites its enrollment changes
+# exactly what they check, matches neither path, and never runs them.
+#
+# Measured 2026-09-04, and this is not hypothetical. The actor/process profile
+# reconstruction campaign renamed 310 one-symbol sources to the NSMBW convention across
+# 21 PRs. `test_srcpath.py::EnrolmentMatchesTheTree` fails on every one of them. Two PRs
+# in that campaign touched `tools/` and so ran the job -- one of them, #2250, went red.
+# The other nineteen touched neither path, never ran it, and displayed a full green
+# check list. A missing check reads exactly like a passing one, which is the same shape
+# as dead-references.yml's own reason for existing.
+#
+# WHY A SEPARATE JOB rather than adding `src/**` to tool-tests.yml. That filter would
+# drag all 519 assertions and a `pip install -r tools/requirements.txt` onto essentially
+# every PR in the repository -- every match, every promotion, every rename. These two
+# modules are stdlib-only (srcpath -> relocs; bytegate -> chaos_db_ci, relocs; both
+# stdlib), so this job needs no wheels and no toolchain. Keeping it separate is what
+# lets the filter be wide.
+#
+# WHAT THIS DOES NOT COVER. Nothing here compiles anything or reads the ROM. These are
+# tree-shape assertions: enrollment resolves both ways, one-symbol sources sit on a
+# legal filename, nothing enrolled points outside `src/`. The byte gates stay where they
+# are -- pr-validate.yml relays those to the private build box.
+name: tree shape
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "config/**/delinks.txt"
+      - "config/**/symbols.txt"
+      # The modules under test and what they derive names with. tu_names.candidate_stem
+      # became load-bearing for test_srcpath when the reconstructed-filename rule landed:
+      # a change there reds 310 files at once, so it belongs in this filter.
+      - "tools/srcpath.py"
+      - "tools/tu_names.py"
+      - "tools/bytegate.py"
+      - "tools/relocs.py"
+      - "tools/chaos_db_ci.py"
+      - "tools/test_srcpath.py"
+      - "tools/test_bytegate.py"
+      - ".github/workflows/tree-shape.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "config/**/delinks.txt"
+      - "config/**/symbols.txt"
+      - "tools/srcpath.py"
+      - "tools/tu_names.py"
+      - "tools/bytegate.py"
+      - "tools/relocs.py"
+      - "tools/chaos_db_ci.py"
+      - "tools/test_srcpath.py"
+      - "tools/test_bytegate.py"
+      - ".github/workflows/tree-shape.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Deliberately NOT sharing a group with tool-tests.yml or the range gates: a shared
+  # group cancels the sibling rather than the stale run of the same check, which is how
+  # #2042 lost its merge check.
+  group: tree-shape-${{ github.event.pull_request.head.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tree-shape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history for the same reason tool-tests.yml takes it: test_srcpath and
+          # test_bytegate resolve tracked paths, and a shallow checkout makes them
+          # assert against a one-commit repository.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Tree-shape tests
+        # ONE invocation, so the "Ran N tests" line is the whole claim and a module that
+        # stops contributing is visible as a drop in N. No pip step on purpose: if either
+        # module ever grows a third-party import, this job fails at COLLECTION -- loudly,
+        # not silently -- and that is the signal to decide whether it still belongs here.
+        # Counts at time of writing: test_srcpath 51, test_bytegate 18, total 69.
+        run: |
+          python -m unittest -v \
+            tools.test_srcpath \
+            tools.test_bytegate

--- a/tools/test_srcpath.py
+++ b/tools/test_srcpath.py
@@ -2,12 +2,14 @@
 in the tree yet -- that is the whole point of the module, so it is the part most worth
 pinning before anything moves."""
 import pathlib
+import re
 import sys
 import tempfile
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import srcpath as SP  # noqa: E402
+import tu_names  # noqa: E402
 
 
 class SrcPath(unittest.TestCase):
@@ -349,12 +351,37 @@ class SrcPath(unittest.TestCase):
         self.assertEqual(SP.path_for("func_0203b438"), SP.SRC / "func_0203b438.c")
 
 
+def _reconstructed_stem(symbol):
+    """The NSMBW-convention stem a `<Class>_classInit[_<PROFILE_ID>]` symbol must use.
+
+    None when ``symbol`` is not a reconstructed factory, which is the signal to fall
+    back to the legacy `stem == symbol` rule."""
+    m = re.match(r"^(.*?_c)_classInit(?:_([A-Z0-9_]+))?$", symbol)
+    if not m:
+        return None
+    stem = tu_names.candidate_stem(m.group(1))
+    return "%s_%s" % (stem, m.group(2).lower()) if m.group(2) else stem
+
+
 class EnrolmentMatchesTheTree(unittest.TestCase):
     """Against the REAL repository, not a fixture.
 
-    The filename convention remains the fallback for a one-symbol source.  It cannot
-    describe a source that owns several symbols; that is exactly why the authoritative
-    enrollment table exists.  Both shapes are checked here against the live tree."""
+    A one-symbol source is named after the thing it defines, but "named after" has two
+    spellings now.  Legacy sources use the symbol itself.  The actor/process profile
+    reconstruction gave every recovered factory an NSMBW-convention filename instead --
+    `daObjKm2_Ami_Bou_c_classInit` lives in `d_a_obj_km2_ami_bou.c` -- so `symbol_for`,
+    which is `Path.stem` and nothing else, stops agreeing for those.
+
+    That is a deliberate convention change, not drift, and the check below encodes it
+    rather than being deleted for it: a reconstructed factory must sit on the stem
+    `tu_names.candidate_stem` derives for its class, which is *stricter* than the old
+    rule.  Under the old assertion these 310 sources could only be tolerated wholesale;
+    under this one a misnamed campaign file is still caught.
+
+    None of this touches resolution.  `symbol_for` has exactly one production caller --
+    the unenrolled fallback inside `symbols_for` -- so for an enrolled source the
+    filename is documentation, and `symbols_for`/`path_for` answer from the enrollment
+    table.  Both directions are asserted here for every enrolled source."""
 
     def test_enrolment_round_trips_single_and_multi_symbol_sources(self):
         idx = SP.enrolment_index()
@@ -371,9 +398,36 @@ class EnrolmentMatchesTheTree(unittest.TestCase):
                 for symbol in symbols:
                     self.assertEqual(SP.path_for(symbol).resolve(), source.resolve())
                 if len(symbols) == 1:
+                    stem = SP.symbol_for(source)
+                    if stem == symbols[0]:
+                        continue
+                    want = _reconstructed_stem(symbols[0])
+                    self.assertIsNotNone(
+                        want,
+                        "a one-symbol source no longer follows the filename fallback, "
+                        "and its symbol is not a reconstructed <Class>_classInit either")
                     self.assertEqual(
-                        SP.symbol_for(source), symbols[0],
-                        "a one-symbol source no longer follows the filename fallback")
+                        stem, want,
+                        "reconstructed factory is not on the NSMBW stem for its class")
+
+    def test_reconstructed_stem_rule_accepts_and_rejects(self):
+        """The new branch's own failure paths -- the ones a green tree never walks."""
+        self.assertEqual(_reconstructed_stem("daObjKm2_Ami_Bou_c_classInit"),
+                         "d_a_obj_km2_ami_bou")
+        self.assertEqual(_reconstructed_stem("dCamera_c_classInit"), "d_camera")
+        # a collision-suffixed factory keeps the lowercased profile id
+        self.assertEqual(_reconstructed_stem("daObjTrs_Trap_c_classInit_TERESAPIT"),
+                         "d_a_obj_trs_trap_teresapit")
+        # not a reconstructed factory -> None, so the legacy rule stays in force
+        self.assertIsNone(_reconstructed_stem("func_0203b438"))
+        self.assertIsNone(_reconstructed_stem("_ZN8dActor_cD1Ev"))
+        self.assertIsNone(_reconstructed_stem("Cloud_Spawn"))
+
+    def test_a_misnamed_reconstructed_factory_is_still_caught(self):
+        """The whole point of strengthening rather than exempting: a campaign file on
+        the wrong stem must fail, where the old assertion could only fail on all 310."""
+        self.assertNotEqual(_reconstructed_stem("daObjKumo_c_classInit"), "d_a_obj_cloud")
+        self.assertEqual(_reconstructed_stem("daObjKumo_c_classInit"), "d_a_obj_kumo")
 
     def test_no_enrolled_entry_points_outside_src(self):
         """`mods/` is the one that exists today. Any other would be just as wrong."""

--- a/tools/test_srcpath.py
+++ b/tools/test_srcpath.py
@@ -355,7 +355,15 @@ def _reconstructed_stem(symbol):
     """The NSMBW-convention stem a `<Class>_classInit[_<PROFILE_ID>]` symbol must use.
 
     None when ``symbol`` is not a reconstructed factory, which is the signal to fall
-    back to the legacy `stem == symbol` rule."""
+    back to the legacy `stem == symbol` rule.
+
+    Symbol -> stem is a function, so per-file detection is total: any single file on the
+    wrong stem fails, including a name swap between two campaign files.  It is NOT
+    injective, though -- `daObjBlockL_c_classInit_BLOCK_L` and
+    `daObjBlockLBlockL_c_classInit` both derive `d_a_obj_block_l_block_l`.  No such pair
+    exists today, and if one ever did both files would own symbols from one stem, which
+    lands in the multi-symbol branch where this check does not run.  So the rule cannot
+    detect that collision; `tools/layout_check.py` L2 is what catches it."""
     m = re.match(r"^(.*?_c)_classInit(?:_([A-Z0-9_]+))?$", symbol)
     if not m:
         return None
@@ -374,14 +382,29 @@ class EnrolmentMatchesTheTree(unittest.TestCase):
 
     That is a deliberate convention change, not drift, and the check below encodes it
     rather than being deleted for it: a reconstructed factory must sit on the stem
-    `tu_names.candidate_stem` derives for its class, which is *stricter* than the old
-    rule.  Under the old assertion these 310 sources could only be tolerated wholesale;
-    under this one a misnamed campaign file is still caught.
+    `tu_names.candidate_stem` derives for its class.  Under the old assertion these 310
+    sources could only be tolerated wholesale; under this one a misnamed campaign file
+    is still caught.
+
+    Not *strictly* stronger, and the gap is worth naming.  The `stem == symbol` escape
+    hatch is tried first, so a `classInit` symbol still sitting on its OLD spelling --
+    `src/daObjKumo_c_classInit.c` -- passes as legacy and a half-finished rename stays
+    invisible here.  Zero classInit symbols are on the legacy spelling today; this is a
+    dormant hole, not a live one.
 
     None of this touches resolution.  `symbol_for` has exactly one production caller --
-    the unenrolled fallback inside `symbols_for` -- so for an enrolled source the
+    the unenrolled fallback inside `symbols_for` -- so for an *enrolled* source the
     filename is documentation, and `symbols_for`/`path_for` answer from the enrollment
-    table.  Both directions are asserted here for every enrolled source."""
+    table.  Both directions are asserted here for every enrolled source.  An *unenrolled*
+    NSMBW-named file is a different matter: `symbol_for` would hand back
+    `d_a_obj_kumo` as though it were a symbol.  There are none today -- every convention
+    name in the tree is enrolled -- so that is an open door with nobody behind it, but it
+    is a door, and it closes the moment such a file appears.
+
+    This makes `tools/tu_names.py` load-bearing for a gate for the first time: a change
+    to `candidate_stem` now reds this test for all 310 files at once.  That is intended
+    -- it pins the convention to one derivation rather than letting each wave spell it
+    by hand -- but it is a new coupling, not a free one."""
 
     def test_enrolment_round_trips_single_and_multi_symbol_sources(self):
         idx = SP.enrolment_index()
@@ -422,6 +445,27 @@ class EnrolmentMatchesTheTree(unittest.TestCase):
         self.assertIsNone(_reconstructed_stem("func_0203b438"))
         self.assertIsNone(_reconstructed_stem("_ZN8dActor_cD1Ev"))
         self.assertIsNone(_reconstructed_stem("Cloud_Spawn"))
+
+    def test_the_derivation_is_a_function_but_not_injective(self):
+        """Pinned so the limit is a recorded fact rather than a surprise later.
+
+        Two distinct classes can derive one stem.  Detection per file is still total --
+        each symbol has exactly one legal stem -- but a genuine collision would give one
+        stem two owners, which lands in the multi-symbol branch this check skips.
+        `tools/layout_check.py` L2 is the gate for that, not this one."""
+        self.assertEqual(_reconstructed_stem("daObjBlockL_c_classInit_BLOCK_L"),
+                         _reconstructed_stem("daObjBlockLBlockL_c_classInit"))
+        self.assertEqual(_reconstructed_stem("daObjBlockLBlockL_c_classInit"),
+                         "d_a_obj_block_l_block_l")
+
+    def test_the_legacy_escape_hatch_still_accepts_an_unfinished_rename(self):
+        """The one thing this rule is NOT stricter about, pinned so it stays known.
+
+        A classInit symbol on its old `<symbol>.c` spelling passes via `stem == symbol`
+        before the convention branch is ever reached.  Zero such files exist today."""
+        stem = "daObjKumo_c_classInit"
+        self.assertNotEqual(stem, _reconstructed_stem("daObjKumo_c_classInit"))
+        self.assertEqual(_reconstructed_stem("daObjKumo_c_classInit"), "d_a_obj_kumo")
 
     def test_a_misnamed_reconstructed_factory_is_still_caught(self):
         """The whole point of strengthening rather than exempting: a campaign file on

--- a/tools/test_srcpath.py
+++ b/tools/test_srcpath.py
@@ -388,9 +388,9 @@ class EnrolmentMatchesTheTree(unittest.TestCase):
 
     Not *strictly* stronger, and the gap is worth naming.  The `stem == symbol` escape
     hatch is tried first, so a `classInit` symbol still sitting on its OLD spelling --
-    `src/daObjKumo_c_classInit.c` -- passes as legacy and a half-finished rename stays
-    invisible here.  Zero classInit symbols are on the legacy spelling today; this is a
-    dormant hole, not a live one.
+    a file named for the symbol itself, `daObjKumo_c_classInit.c` -- passes as legacy
+    and a half-finished rename stays invisible here.  Zero classInit symbols are on the
+    legacy spelling today; this is a dormant hole, not a live one.
 
     None of this touches resolution.  `symbol_for` has exactly one production caller --
     the unenrolled fallback inside `symbols_for` -- so for an *enrolled* source the


### PR DESCRIPTION
`tools/test_srcpath.py::EnrolmentMatchesTheTree::test_enrolment_round_trips_single_and_multi_symbol_sources` asserts that a one-symbol enrolled source is named after its symbol — `srcpath.symbol_for` is `Path.stem` and nothing else.

The actor/process profile reconstruction retires that spelling. `daObjKm2_Ami_Bou_c_classInit` now lives in `d_a_obj_km2_ami_bou.c`, the NSMBW convention. **On the merged campaign tree, 310 enrolled one-symbol sources violate the old assertion** — all 310 convention names, none an accidental misname.

## Read this before trusting the green check on this PR

**This branch contains no renamed files.** `ls src/ | grep -c '^d_a_'` is 0 here, so this PR's own CI exercises the new rule through two hardcoded unit tests and nothing else. The 310-file evidence comes from re-running the suite against a tree with all 21 campaign PRs merged (`tmp/profile-campaign-integration`). Do not read this PR's green as population-level proof — the population is not in this diff.

## Why the campaign's breakage was invisible

`tool-tests.yml` is path-filtered to `tools/**` and `nearmiss/**`. Nineteen of the twenty-one campaign PRs touch neither, so the job never ran, and **a missing check reads exactly like a passing one**. Only #2250 and #2253 touch `tools/` — and #2250 is genuinely red on this test right now. #2239's head fails it locally while showing all green on GitHub. `push: main` is filtered identically, so main would have gone silently red too.

The second commit fixes that root cause: a new `tree-shape.yml` runs `test_srcpath` + `test_bytegate` on `src/**`, `config/**/delinks.txt`, `config/**/symbols.txt`. Separate job rather than widening `tool-tests.yml`, which would drag 519 assertions and a pip install onto nearly every PR in the repo; both modules here are stdlib-only, and that is what lets the filter be wide.

## Strengthened, not exempted

A one-symbol source passes if `stem == symbol` (legacy), **or** its symbol parses as `<Class>_classInit[_<PROFILE_ID>]` and the stem is exactly `tu_names.candidate_stem(Class)` plus the lowercased profile id. Holds **310 of 310**. The old assertion could only have been satisfied by tolerating all 310 wholesale; this one still catches a misnamed campaign file:

```
$ mv src/d_camera.cpp src/d_kamera.cpp   # + the delinks reference, in a throwaway export
AssertionError: 'd_kamera' != 'd_camera'
 : reconstructed factory is not on the NSMBW stem for its class
```

## Three things it does NOT do, all dormant, all now pinned

Review caught these as overclaims in the first commit. Each measures **zero** on the merged tree today.

1. **Not strictly stronger.** `stem == symbol` is tried first, so a `classInit` symbol still on its old `<symbol>.c` spelling passes as legacy — a half-finished rename stays invisible here.
2. **"The filename is documentation" holds for an *enrolled* source only.** For an unenrolled NSMBW-named file, `symbol_for` would hand back `d_a_obj_kumo` as though it were a symbol.
3. **The derivation is a function, not an injection.** `daObjBlockL_c_classInit_BLOCK_L` and `daObjBlockLBlockL_c_classInit` both derive `d_a_obj_block_l_block_l`. Per-file detection is still total, since each symbol has exactly one legal stem; a real collision would give one stem two owners and land in the multi-symbol branch this check skips. `layout_check.py` L2 is that gate, not this one.

## New coupling, stated on purpose

This makes `tools/tu_names.py` load-bearing for a gate for the first time. A change to `candidate_stem` now reds `test_srcpath` for all 310 files at once. That is intended — it pins the convention to one derivation instead of letting each wave spell it by hand — but it is a new coupling, and `tu_names.py` is in `tree-shape.yml`'s filter for that reason.

## Merge order

This wants to land **before** the campaign waves. There is no red-main emergency — main is at `74859dc87` with all 21 campaign PRs still open and zero merged — but merging any wave first puts main in a state where the next `tools/`-touching PR goes red for reasons that have nothing to do with it.

## Gates

```
pytest tools/test_srcpath.py -q                          51 passed  (here, and on the merged 21-PR tree)
python -m unittest tools.test_srcpath tools.test_bytegate  Ran 69 -- OK   (what tree-shape.yml runs)
pytest tools/ -q                                         1188 passed, 1 failed, 3 skipped
```

The one failure is **not this PR's**. `test_dtor_members.py::test_the_frozen_census_reproduces` fails on `main` itself with the ROM dump present (`dtor_symbols` 765 vs 801, `owners_distinct` 365 vs 374, and two more) — a stale frozen census, pre-existing and unrelated. Note it returns early when the ROM dump is absent, so a ROM-less export reports it green; that is how I first mis-measured it. Deliberately not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA