### PR TITLE
Put twelve ov006 ledger chains back in chain order

### DIFF
--- a/symbols/actor_renames.tsv
+++ b/symbols/actor_renames.tsv
@@ -441,42 +441,42 @@ ov006	0x0213c020	data_ov006_0213c020	g_profile_MG_CUP	reconstructed profile glob
 ov006	0x0213c62c	data_ov006_0213c62c	_ZTV14dScMgD3DBase_c	vtable alloc=? (was _ZTV17MgBounceAndPounce)
 ov006	0x0213c78c	data_ov006_0213c78c	MgPsycheOut_SpawnInfo	spawninfo
 ov006	0x0213c78c	MgPsycheOut_SpawnInfo	g_profile_MG_3DESP	reconstructed profile global; literal ROM ID MG_3DESP+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213cb64	MgBounceAndPounce_SpawnInfo	g_profile_MG_JUMP	reconstructed profile global; literal ROM ID MG_JUMP+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213ce0c	MgWanted_SpawnInfo	g_profile_MG_LUIGI	reconstructed profile global; literal ROM ID MG_LUIGI+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213cfd8	MgMemoryMatch_SpawnInfo	g_profile_MG_MEMORY	reconstructed profile global; literal ROM ID MG_MEMORY+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213d288	MgMemoryMaster_SpawnInfo	g_profile_MG_MEMORY_J	reconstructed profile global; literal ROM ID MG_MEMORY_J+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213cb64	data_ov006_0213cb64	MgBounceAndPounce_SpawnInfo	spawninfo
+ov006	0x0213ce0c	data_ov006_0213ce0c	MgWanted_SpawnInfo	spawninfo
+ov006	0x0213cfd8	data_ov006_0213cfd8	MgMemoryMatch_SpawnInfo	spawninfo
+ov006	0x0213d288	data_ov006_0213d288	MgMemoryMaster_SpawnInfo	spawninfo
 ov006	0x0213d580	data_ov006_0213d580	g_profile_MG_MCARLO	reconstructed profile global; literal ROM ID MG_MCARLO+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213d910	MgBobOmbSquad_SpawnInfo	g_profile_MG_PACHINKO	reconstructed profile global; literal ROM ID MG_PACHINKO+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213da64	MgLakituLaunch_SpawnInfo	g_profile_MG_TAMAIRE	reconstructed profile global; literal ROM ID MG_TAMAIRE+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213dc64	MgPuzzlePanelPuzzlePanic_SpawnInfo	g_profile_MG_PANEL	reconstructed profile global; literal ROM ID MG_PANEL+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213d910	data_ov006_0213d910	MgBobOmbSquad_SpawnInfo	spawninfo
+ov006	0x0213da64	data_ov006_0213da64	MgLakituLaunch_SpawnInfo	spawninfo
+ov006	0x0213dc64	data_ov006_0213dc64	MgPuzzlePanelPuzzlePanic_SpawnInfo	spawninfo
 ov006	0x0213e508	data_ov006_0213e508	g_profile_MG_SLOT3	reconstructed profile global; literal ROM ID MG_SLOT3+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov006	0x0213e560	data_ov006_0213e560	g_profile_MG_SLOT1	reconstructed profile global; literal ROM ID MG_SLOT1+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213f69c	MgBoomBox_SpawnInfo	g_profile_MG_SOUND	reconstructed profile global; literal ROM ID MG_SOUND+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213f974	MgHideAndBooSeek_SpawnInfo	g_profile_MG_TERESA	reconstructed profile global; literal ROM ID MG_TERESA+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213fab8	MgTrampolineTime_SpawnInfo	g_profile_MG_TRAMPOLINE	reconstructed profile global; literal ROM ID MG_TRAMPOLINE+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213fd6c	MgLuckyStars_SpawnInfo	g_profile_MG_BS_CARD	reconstructed profile global; literal ROM ID MG_BS_CARD+registry role+later EAD lineage; exact SM64DS spelling not preserved
-ov006	0x0213ffb8	MgSnowballSlalom_SpawnInfo	g_profile_MG_SNOWBALL	reconstructed profile global; literal ROM ID MG_SNOWBALL+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213f69c	data_ov006_0213f69c	MgBoomBox_SpawnInfo	spawninfo
+ov006	0x0213f974	data_ov006_0213f974	MgHideAndBooSeek_SpawnInfo	spawninfo
+ov006	0x0213fab8	data_ov006_0213fab8	MgTrampolineTime_SpawnInfo	spawninfo
+ov006	0x0213fd6c	data_ov006_0213fd6c	MgLuckyStars_SpawnInfo	spawninfo
+ov006	0x0213ffb8	data_ov006_0213ffb8	MgSnowballSlalom_SpawnInfo	spawninfo
 ov006	0x02140114	data_ov006_02140114	g_profile_MG_FLOWER	reconstructed profile global; literal ROM ID MG_FLOWER+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov007	0x020ccad0	func_ov007_020ccad0	dScDSMT_c_classInit	reconstructed classInit; ROM RTTI+factory shape+unique class factory+later EAD lineage; exact SM64DS spelling not preserved
 ov007	0x02103264	data_ov007_02103264	g_profile_DSMT	reconstructed profile global; literal ROM ID DSMT+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov006	0x0213c98c	data_ov006_0213c98c	MgWhichWiggler_SpawnInfo	spawninfo
-ov006	0x0213cb64	data_ov006_0213cb64	MgBounceAndPounce_SpawnInfo	spawninfo
+ov006	0x0213cb64	MgBounceAndPounce_SpawnInfo	g_profile_MG_JUMP	reconstructed profile global; literal ROM ID MG_JUMP+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov006	0x0213cc7c	data_ov006_0213cc7c	MgBounceAndTrounce_SpawnInfo	spawninfo
-ov006	0x0213ce0c	data_ov006_0213ce0c	MgWanted_SpawnInfo	spawninfo
-ov006	0x0213cfd8	data_ov006_0213cfd8	MgMemoryMatch_SpawnInfo	spawninfo
-ov006	0x0213d288	data_ov006_0213d288	MgMemoryMaster_SpawnInfo	spawninfo
+ov006	0x0213ce0c	MgWanted_SpawnInfo	g_profile_MG_LUIGI	reconstructed profile global; literal ROM ID MG_LUIGI+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213cfd8	MgMemoryMatch_SpawnInfo	g_profile_MG_MEMORY	reconstructed profile global; literal ROM ID MG_MEMORY+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213d288	MgMemoryMaster_SpawnInfo	g_profile_MG_MEMORY_J	reconstructed profile global; literal ROM ID MG_MEMORY_J+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov006	0x0213d70c	data_ov006_0213d70c	MgPairAGoneAndOn_SpawnInfo	spawninfo
-ov006	0x0213d910	data_ov006_0213d910	MgBobOmbSquad_SpawnInfo	spawninfo
-ov006	0x0213da64	data_ov006_0213da64	MgLakituLaunch_SpawnInfo	spawninfo
-ov006	0x0213dc64	data_ov006_0213dc64	MgPuzzlePanelPuzzlePanic_SpawnInfo	spawninfo
+ov006	0x0213d910	MgBobOmbSquad_SpawnInfo	g_profile_MG_PACHINKO	reconstructed profile global; literal ROM ID MG_PACHINKO+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213da64	MgLakituLaunch_SpawnInfo	g_profile_MG_TAMAIRE	reconstructed profile global; literal ROM ID MG_TAMAIRE+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213dc64	MgPuzzlePanelPuzzlePanic_SpawnInfo	g_profile_MG_PANEL	reconstructed profile global; literal ROM ID MG_PANEL+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov006	0x0213e2f0	data_ov006_0213e2f0	MgMushroomRoulette_SpawnInfo	spawninfo
 ov006	0x0213ebd0	data_ov006_0213ebd0	MgBingoBallSlotsShot_SpawnInfo	spawninfo
-ov006	0x0213f69c	data_ov006_0213f69c	MgBoomBox_SpawnInfo	spawninfo
-ov006	0x0213f974	data_ov006_0213f974	MgHideAndBooSeek_SpawnInfo	spawninfo
-ov006	0x0213fab8	data_ov006_0213fab8	MgTrampolineTime_SpawnInfo	spawninfo
+ov006	0x0213f69c	MgBoomBox_SpawnInfo	g_profile_MG_SOUND	reconstructed profile global; literal ROM ID MG_SOUND+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213f974	MgHideAndBooSeek_SpawnInfo	g_profile_MG_TERESA	reconstructed profile global; literal ROM ID MG_TERESA+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213fab8	MgTrampolineTime_SpawnInfo	g_profile_MG_TRAMPOLINE	reconstructed profile global; literal ROM ID MG_TRAMPOLINE+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov006	0x0213fbc8	data_ov006_0213fbc8	MgTrampolineTerror_SpawnInfo	spawninfo
-ov006	0x0213fd6c	data_ov006_0213fd6c	MgLuckyStars_SpawnInfo	spawninfo
-ov006	0x0213ffb8	data_ov006_0213ffb8	MgSnowballSlalom_SpawnInfo	spawninfo
+ov006	0x0213fd6c	MgLuckyStars_SpawnInfo	g_profile_MG_BS_CARD	reconstructed profile global; literal ROM ID MG_BS_CARD+registry role+later EAD lineage; exact SM64DS spelling not preserved
+ov006	0x0213ffb8	MgSnowballSlalom_SpawnInfo	g_profile_MG_SNOWBALL	reconstructed profile global; literal ROM ID MG_SNOWBALL+registry role+later EAD lineage; exact SM64DS spelling not preserved
 ov009	0x021111a0	func_ov009_021111a0	_ZN4BirdD1Ev	vtable slot 16
 ov009	0x021111d8	func_ov009_021111d8	_ZN4BirdD0Ev	vtable slot 17
 ov009	0x0211183c	func_ov009_0211183c	_ZN4Bird16CleanupResourcesEv	vtable slot 3


### PR DESCRIPTION
**`main` is red on `check_profile_campaign` right now** — exit 1, twelve divergences. This fixes it.

## What is wrong

`symbols/actor_renames.tsv` is an **append log, not a set**. Several rows may share one `(module, address)` — that is a rename *chain*, one row per hop — and **file order is chain order, so the last row is the live claim**. Twelve ov006 groups are inverted: the hop that renames the coined name to `g_profile_*` sits *above* the hop that produced the coined name.

```
line 444   ov006  0x0213cb64   MgBounceAndPounce_SpawnInfo -> g_profile_MG_JUMP
line 463   ov006  0x0213cb64   data_ov006_0213cb64 -> MgBounceAndPounce_SpawnInfo
```

Read in file order the live claim is `MgBounceAndPounce_SpawnInfo`, while `symbols.txt` carries `g_profile_MG_JUMP`. Hence the divergence.

Nothing is missing. **Every rename is present and correct — only the order is wrong.** The registry rows report `0 diverged` throughout; it is the coined-ledger check that fails. Note the group two lines up, `0x0213c78c`, has the same shape and does *not* diverge, because its two hops happen to sit the right way round.

Affected: `MG_JUMP`, `MG_LUIGI`, `MG_MEMORY`, `MG_MEMORY_J`, `MG_PACHINKO`, `MG_TAMAIRE`, `MG_PANEL`, and five more at `0x0213f69c`–`0x0213ffb8`.

## A pure reorder, asserted not assumed

No row is added, deleted or edited. Line count 2708 on both sides, and the two files are **identical as multisets** — checked programmatically. 24 lines move, which is exactly the twelve pairs. A group is only touched when it forms one unambiguous chain (every row's `old_name` is another row's `new_name`, exactly one head, exactly one tail); anything else is left alone.

## The near miss, recorded because it matters for anyone doing this again

My first attempt read each row's evidence column out of the line buffer **while rewriting that buffer**, so the second row of every pair inherited the evidence of the row that had just overwritten its slot. Line count was right. `git diff --stat` said 24 insertions, 24 deletions — exactly right. `check_rename_ledger` would have passed. Only comparing the two files as **multisets** caught it.

A reorder of an append log has to be verified as a *permutation*. Counting rows proves nothing.

## Gates

```
check_profile_campaign   12 diverge -> 0 diverge, exit 0
check_rename_ledger      PASS
check_dead_references    PASS
port_refcheck            PASS
```

No source or config change, so no ROM bytes are in scope.

## Why now

Eleven campaign PRs are being rebased onto main as I write. This failure shows red on **every one of them** until main is repaired, and it looks like their fault. Landing this first stops eleven people rediscovering the same twelve rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA