### PR TITLE
Repoint the daDgr_c factory reference after wave 29 renamed it

### DIFF
--- a/notes/bgobject-provenance.md
+++ b/notes/bgobject-provenance.md
@@ -116,7 +116,7 @@ class as for the flat shadow the ROM's own code is built against.
 
 A swinging platform. Bodies read: `src/_ZN7daDgr_c13InitResourcesEv.cpp`,
 `src/_ZN7daDgr_c8BehaviorEv.cpp`, `src/_ZN7daDgr_c6RenderEv.cpp`,
-`src/_ZN7daDgr_c16CleanupResourcesEv.cpp`, [src/func_ov025_02111898.c](../src/func_ov025_02111898.c) (the factory).
+`src/_ZN7daDgr_c16CleanupResourcesEv.cpp`, [src/d_a_dgr.c](../src/d_a_dgr.c) (`daDgr_c_classInit`, the factory).
 
 | Offset | Name | Evidence |
 | --- | --- | --- |


### PR DESCRIPTION
## TL;DR

`main` is currently red on the `references` check, and it will fail that check on **every open PR** until this lands. One-line prose fix.

## What happened

#2242 (wave 29) renamed `src/func_ov025_02111898.c` → `src/d_a_dgr.c`, with the factory spelled `daDgr_c_classInit`. The rename was correct and deliberate — `d_a_dgr.c` even carries the comment `Historical alias: func_ov025_02111898`, and `config/arm9/overlays/ov025/{delinks,symbols}.txt` both agree.

Only the prose was left behind. `notes/bgobject-provenance.md:119` still links to the deleted path:

```
`src/_ZN7daDgr_c16CleanupResourcesEv.cpp`, [src/func_ov025_02111898.c](../src/func_ov025_02111898.c) (the factory).
```

That is exactly the shape `check_dead_references` exists to catch, and the relative-link half of it has **no baseline** — there is no `--update` escape, the link has to be fixed.

## Why it wasn't caught at merge

`premerge_check` gates each PR against the base it was cut from. #2242 was green when it merged; the note it stranded lives in a file #2242 never touched, so nothing in that PR's own diff pointed at it. The break only exists in the merged tree.

Verified locally against `origin/main` + this commit:

```
check_dead_references: 3944 repo-rooted path reference(s) ... 514 markdown link(s), 0 that do not resolve
  no broken markdown links
```

## Scope

One line of prose in one note. No source, config, or symbol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
