### PR TITLE
Create notes/data/class-facts so the pipeline docs stop naming a missing path

### DIFF
--- a/notes/data/class-facts/README.md
+++ b/notes/data/class-facts/README.md
@@ -1,0 +1,2 @@
+Scout-stage output lands here: one <Class>.json per class, written by
+notes/agents/roles/scout.md and consumed by the writer stage.


### PR DESCRIPTION
## TL;DR

`main` is red on `references`, and **#2268 (mine) did it.** One-line fix: create the directory the docs point at.

## What happened

`notes/agents/PIPELINE.md`, `notes/agents/roles/scout.md` and `notes/agents/roles/writer.md` all name `notes/data/class-facts` as the scout stage's output directory. That is correct — it *is* where every scout run writes. But nothing has landed in it yet; the first facts file is still unmerged on #2269. So `check_dead_references` sees three prose references to a path not in the tree and exits 1:

```
FAIL: 3 prose reference(s) name a path that does not exist:
  notes/agents/PIPELINE.md
      names `notes/data/class-facts`, which is not in the tree
  notes/agents/roles/scout.md
  notes/agents/roles/writer.md
```

Verified on a clean worktree of `origin/main` — this is not a local artifact.

## Why this fix and not a reword

The docs aren't wrong; the tree is incomplete. Rewording three files to avoid naming the directory would make the pipeline documentation vaguer to satisfy a gate, and the directory would have to be named again the moment the first scout run lands. An empty output directory is simply the honest state of a pipeline that has produced one facts file, on a branch, not yet merged.

A `README.md` rather than a `.gitkeep` because the reason the directory exists is worth one sentence to the next person who opens it.

```
check_dead_references: ... no new dead references
  no broken markdown links
rc=0
```

## Coordination

Deliberately disjoint from **#2274**, which is editing `writer.md` concurrently from another session. This touches no existing file — it only adds one — so the two cannot collide. That was the reason for fixing the path rather than the prose.

## Scope

One new file. No source, config, symbol, or manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnbWPxJY5pjvfqNg5UW743
