### PR TITLE
Recover the MSL memset (func_0206e330) as real C, replacing an assembly transcription

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -11619,6 +11619,9 @@ src/func_0206e310.c:
     complete
     .text start:0x0206e310 end:0x0206e330
 
+src/func_0206e330.c:
+    .text start:0x0206e330 end:0x0206e3dc
+
 src/func_0206e3dc.c:
     complete
     .text start:0x0206e3dc end:0x0206e450

--- a/src/func_0206e330.c
+++ b/src/func_0206e330.c
@@ -1,61 +1,60 @@
-// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
-// assembly primitive, so there is no original C to recover and no match to chase. Counts as
-// done under the asm-primitive policy - see notes/arm9-endgame.md.
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only runtime primitive).
-// SDK byte-fill (memset): replicates the fill byte across a word and runs an alignment
-// ladder (strb head to word-align, str-writeback word loop, strb tail). The hand-tuned
-// alignment ladder is not reproducible from C under our flags. Per asm policy.
-asm void func_0206e330(void *dst, unsigned int val, unsigned int n)
+// @symbol func_0206e330
+/* recovered: MSL memset/__fill_mem -- byte head, 32-byte unrolled block,
+ * word tail, byte tail. The head and block loops share one counter, which is
+ * what colours both into r3; opt_lifetimes off keeps the word counter separate. */
+#pragma opt_lifetimes off
+typedef unsigned int u32;
+typedef unsigned char u8;
+
+void func_0206e330(void *dst, int val, u32 n)
 {
-    cmp     r2, #0x20
-    and     ip, r1, #0xff
-    blo     L90
-    rsb     r1, r0, #0
-    ands    r3, r1, #3
-    beq     L2c
-    sub     r2, r2, r3
-    and     r1, ip, #0xff
-L20:
-    strb    r1, [r0], #1
-    subs    r3, r3, #1
-    bne     L20
-L2c:
-    cmp     ip, #0
-    movne   r1, ip, lsl #0x18
-    orrne   r1, r1, ip, lsl #16
-    orrne   r1, r1, ip, lsl #8
-    orrne   ip, ip, r1
-    movs    r3, r2, lsr #5
-    beq     L74
-L48:
-    str     ip, [r0]
-    str     ip, [r0, #4]
-    str     ip, [r0, #8]
-    str     ip, [r0, #0xc]
-    str     ip, [r0, #0x10]
-    str     ip, [r0, #0x14]
-    str     ip, [r0, #0x18]
-    str     ip, [r0, #0x1c]
-    add     r0, r0, #0x20
-    subs    r3, r3, #1
-    bne     L48
-L74:
-    and     r1, r2, #0x1f
-    movs    r1, r1, lsr #2
-    beq     L8c
-L80:
-    str     ip, [r0], #4
-    subs    r1, r1, #1
-    bne     L80
-L8c:
-    and     r2, r2, #3
-L90:
-    cmp     r2, #0
-    bxeq    lr
-    and     r1, ip, #0xff
-L94:
-    strb    r1, [r0], #1
-    subs    r2, r2, #1
-    bne     L94
-    bx      lr
+    u8 *p = (u8 *)dst;
+    u32 c = (u32)val & 0xff;
+
+    if (n >= 0x20) {
+        u32 k, w;
+
+        k = (u32)(-(int)p) & 3;
+        if (k != 0) {
+            n -= k;
+            do {
+                *p++ = (u8)c;
+            } while (--k);
+        }
+
+        if (c != 0) {
+            c |= (c << 24) | (c << 16) | (c << 8);
+        }
+
+        k = n >> 5;
+        if (k != 0) {
+            do {
+                ((u32 *)p)[0] = c;
+                ((u32 *)p)[1] = c;
+                ((u32 *)p)[2] = c;
+                ((u32 *)p)[3] = c;
+                ((u32 *)p)[4] = c;
+                ((u32 *)p)[5] = c;
+                ((u32 *)p)[6] = c;
+                ((u32 *)p)[7] = c;
+                p += 0x20;
+            } while (--k);
+        }
+
+        w = (n & 0x1f) >> 2;
+        if (w != 0) {
+            do {
+                *(u32 *)p = c;
+                p += 4;
+            } while (--w);
+        }
+
+        n &= 3;
+    }
+
+    if (n != 0) {
+        do {
+            *p++ = (u8)c;
+        } while (--n);
+    }
 }


### PR DESCRIPTION
From run m100, lane HANDBACK. src/func_0206e330.c was a byte-exact asm block under a NONMATCHING (ASM-PRIMITIVE) banner, which did not count and, per notes/asm-policy.md's objective test, could not: the body is ordinary ARM (no mcr/mrc/swi/msr/mrs/swp/ldm^). This replaces it with the C it was: MSL memset/__fill_mem (byte head, 32-byte unrolled block, word tail, byte tail).

The lever: the head loop and the 32-byte block loop share one counter variable, which is what colours both into r3, with #pragma opt_lifetimes off keeping the word-tail counter separate. A 720-way declaration-order sweep with distinct counters bottomed at 2 words; the shared counter closed it.

Verified: match.py MATCHING VERSIONS 2004/b56 (and every 1.2 build; 2.0 and dsi differ), strict relocations on; there are no relocation slots inside the body so every word was compared for real; prepush_linkcheck 1 checked, 1 verified, 0 blocking. Independent review re-ran the proofs, confirmed the pragma is a recognised one (notes/mwccarm-pragmas.txt #149) and load-bearing (deleting it breaks the match), and passed it. delinks.txt entry added.