### PR TITLE
Stop src_tu forcing empty validation builds; repoint 9 stale legacy_source refs

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -59,7 +59,7 @@ jobs:
       # a pull request that needed it, which is the failure nobody would notice.
       #
       # What is NOT inert, and why -- the verdict covers reconstruction AND attribution:
-      #   src/ include/ src_tu/   compiled, or change codegen
+      #   src/ include/           compiled, or change codegen
       #   config/                 delinks.txt and symbols.txt decide what is compiled and
       #                           where; relocs.txt decides what it points at
       #   tools/                  the ROM build itself
@@ -85,9 +85,26 @@ jobs:
             echo "no files returned -- treating as validation-relevant"
             exit 0
           fi
-          # Inert: prose, generated progress pages, and the licence. Note docs/index.html
-          # and docs/progress-treemap.svg are bot-written progress artefacts, not sources.
-          inert='^(docs/|notes/|\.github/ISSUE_TEMPLATE/)|(^|/)[^/]+\.(md|png|jpg|jpeg|gif|svg)$|^LICENSE$'
+          # Inert: prose, generated progress pages, the licence, and src_tu/. Note
+          # docs/index.html and docs/progress-treemap.svg are bot-written progress
+          # artefacts, not sources.
+          #
+          # src_tu/ is inert HERE because nothing relay validation runs ever reads it.
+          # The build enrolls only the files config/**/delinks.txt names, and no
+          # delinks.txt names a src_tu/ path; tools/rombuild.py:enrolled() then rejects
+          # any path whose top-level directory is not src/ or mods/ unless it is handed
+          # extra_roots, which rombuild.py:1192 populates only for --tu-module /
+          # --partitioned-tu builds. The stock profile the relay runs passes neither, so
+          # a src_tu-only pull request used to buy a full ROM build plus module compare
+          # -- one at a time, ahead of everyone else in the queue -- that compiled not
+          # one line of what it changed.
+          #
+          # src_tu/ is still gated, just not here: the COMPILE half is
+          # tools/check_src_tu_compiles.py, run from tools/hooks/pre-push and on the
+          # build box (the runner has neither mwccarm nor the ROM), and the REFERENCE
+          # half -- includes resolve, mangled symbols exist -- is
+          # .github/workflows/src-tu-refs.yml. Do not weaken either one.
+          inert='^(docs/|notes/|src_tu/|\.github/ISSUE_TEMPLATE/)|(^|/)[^/]+\.(md|png|jpg|jpeg|gif|svg)$|^LICENSE$'
           relevant=false
           while IFS= read -r f; do
             if ! printf '%s\n' "$f" | grep -Eq "$inert"; then

--- a/config/tu_manifest.d/ov004/unit020b0a38.json
+++ b/config/tu_manifest.d/ov004/unit020b0a38.json
@@ -218,21 +218,21 @@
       "symbol": "func_ov004_020b265c",
       "address": "0x020b265c",
       "size": "0x00000198",
-      "legacy_source": "src/func_ov004_020b265c.c",
+      "legacy_source": "src/_ZN11dScMgBase_c9Virtual84Ev.cpp",
       "ordinal": 45
     },
     {
       "symbol": "func_ov004_020b27f4",
       "address": "0x020b27f4",
       "size": "0x0000008c",
-      "legacy_source": "src/func_ov004_020b27f4.c",
+      "legacy_source": "src/_ZN11dScMgBase_c9Virtual80Ev.cpp",
       "ordinal": 46
     },
     {
       "symbol": "func_ov004_020b2880",
       "address": "0x020b2880",
       "size": "0x0000008c",
-      "legacy_source": "src/func_ov004_020b2880.c",
+      "legacy_source": "src/_ZN11dScMgBase_c9Virtual7CEv.cpp",
       "ordinal": 47
     },
     {
@@ -253,28 +253,28 @@
       "symbol": "func_ov004_020b298c",
       "address": "0x020b298c",
       "size": "0x00000004",
-      "legacy_source": "src/func_ov004_020b298c.c",
+      "legacy_source": "src/_ZN11dScMgBase_c15OnGroundPoundedEv.cpp",
       "ordinal": 50
     },
     {
       "symbol": "func_ov004_020b2990",
       "address": "0x020b2990",
       "size": "0x00000004",
-      "legacy_source": "src/func_ov004_020b2990.c",
+      "legacy_source": "src/_ZN11dScMgBase_c9Virtual50Ev.cpp",
       "ordinal": 51
     },
     {
       "symbol": "func_ov004_020b2994",
       "address": "0x020b2994",
       "size": "0x00000008",
-      "legacy_source": "src/func_ov004_020b2994.c",
+      "legacy_source": "src/_ZN11dScMgBase_c13OnTurnIntoEggEi.cpp",
       "ordinal": 52
     },
     {
       "symbol": "func_ov004_020b299c",
       "address": "0x020b299c",
       "size": "0x00000004",
-      "legacy_source": "src/func_ov004_020b299c.c",
+      "legacy_source": "src/_ZN11dScMgBase_c13OnYoshiTryEatEi.cpp",
       "ordinal": 53
     },
     {

--- a/config/tu_manifest.d/ov065/TTC_MovingBar.json
+++ b/config/tu_manifest.d/ov065/TTC_MovingBar.json
@@ -71,14 +71,14 @@
       "symbol": "daObjCtKaitendai_c_classInit_CT_MECHA07",
       "address": "0x0211b780",
       "size": "0x00000038",
-      "legacy_source": "src/daObjCtKaitendai_c_classInit_CT_MECHA07.c",
+      "legacy_source": "src/d_a_obj_ct_kaitendai_ct_mecha07.c",
       "ordinal": 7
     },
     {
       "symbol": "daObjCtKaitendai_c_classInit_CT_MECHA06",
       "address": "0x0211b7b8",
       "size": "0x00000038",
-      "legacy_source": "src/daObjCtKaitendai_c_classInit_CT_MECHA06.c",
+      "legacy_source": "src/d_a_obj_ct_kaitendai_ct_mecha06.c",
       "ordinal": 8
     }
   ],


### PR DESCRIPTION
Two independent housekeeping commits.

## 1. `pr-validate.yml`: `src_tu/` joins the inert set (`2e15b49e7`)

A pull request that touched nothing but a merged translation unit under `src_tu/` was classified validation-relevant and so submitted a full stock ROM build plus whole-module compare to the relay -- a worker that runs one job at a time, ahead of every other PR in the queue.

That build never compiled anything the PR changed:
- the build enrolls only what `config/**/delinks.txt` names, and **0 of 106** `delinks.txt` files name a `src_tu/` path;
- `tools/rombuild.py:enrolled()` then rejects any path whose top-level directory is not `src/` or `mods/` unless handed `extra_roots`, which `rombuild.py:1192` populates only for `--tu-module` / `--partitioned-tu` builds. The stock profile the relay runs passes neither.

So the verdict was identical to the base commit's, at the cost of the queue.

Semantics are unchanged: the job still skips only when **every** changed path is inert, and the submission to the relay still happens either way (`validationRelevant` is advisory). A PR touching `src_tu/` **and** `src/`, `include/`, `config/` or `tools/` is still relevant. The new alternation is anchored (`^(...|src_tu/|...)`): `src/**`, `port/src_tu/x`, `a/src_tu/b`, `src_tuX/y` all remain relevant; only `src_tu/**` is inert.

The two gates that DO read `src_tu/` are untouched:
- compile: `tools/check_src_tu_compiles.py` (from `tools/hooks/pre-push` and the build box);
- references: `.github/workflows/src-tu-refs.yml` (runs on every `pull_request`, no `paths:` filter).

## 2. Nine stale `legacy_source` paths repointed (`2589f875a`)

`config/tu_manifest.d/ov004/unit020b0a38.json` (7 entries) and `config/tu_manifest.d/ov065/TTC_MovingBar.json` (2 entries) named `src/` files that no longer exist. Each destination was resolved by address -- the `delinks.txt` entry whose `.text` range starts at the function's address -- and all nine exist and are tracked. Content-only: 9 lines changed, no reformatting, key order or whitespace changes; both manifests stay `text-verified`.

Both TUs re-verified after the repoint (`tools/tubuild.py verify`):
- `ov004/unit020b0a38`: 41/41 MATCH, objisolate clean, reloc-destinations clean -> TEXT-VERIFIED
- `ov065/TTC_MovingBar`: 9/9 MATCH, objisolate clean, reloc-destinations clean -> TEXT-VERIFIED

No rows were added to `config/converted-backslide-exceptions.jsonl` and `config/converted-baseline.json` is untouched by this branch.

## Gates (local)

- `check_src_tu_compiles`: 125/125 (also ran in the pre-push hook)
- `tiers_ratchet --check`: PASS (baseline 2672, current 2674)
- `rombuild --no-rom`: 106/106 exact, 0 mismatching
- `port_refcheck`: 405 references, all resolve
- `check_references`: **SKIPPED** (no eligibility report in a fresh worktree) -- not a pass

Branch base is `000c7596d`; `git merge-tree` against current `main` is conflict-free and `main` has not touched any of the three files since that base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qeuLvkrjFxZriAZ93kFnF
