### PR TITLE
Document eight mwccarm colouring levers from the ov006 third wave

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -4635,3 +4635,135 @@ needs `lr` as a scratch), this is a hand-written primitive and the existing HAND
 The transferable test: **an `ldm`/`stm` pair with different register counts, or an `stm` whose
 register list contains a value the matching `ldm` did not load, is hand-asm.** Equal widths
 with two `add`s in front of them is compiler output.
+
+## 6bu. Eight colouring levers from the ov006 third wave (four matched, run m100 lane OV62, 2026-09-05)
+
+Four ov006 functions matched in one pass -- `func_ov006_0211ba88` (0x158),
+`func_ov006_020cfc74` (0x56c), `func_ov006_02106aa8` (0x104) and `func_ov006_020d0c38`
+(0x3ac), two of them upgrades over NONMATCHING drafts. Between them they pin eight
+levers. Seven are proven on a matched body; the eighth is measured on a near-miss and is
+labelled as such below, because a lever that only ever moved a divergence count is not
+the same claim as a lever that closed a function.
+
+**1. A ternary's constants rank like named locals, not like literals.**
+`func_ov006_020cfc74` clamps two signs to +-1. Written as a macro over a ternary chain,
+
+```c
+#define CLAMP(v, lo, hi) ((v) < (lo) ? (lo) : (v) > (hi) ? (hi) : (v))
+```
+
+the `-1` and `1` enter the colouring problem with a rank ABOVE the function's own `a` and
+`i`, and take the callee-saved registers the ROM gives them. Spelling the same clamp as
+`if (s1 < -1) s1 = -1; if (s1 > 1) s1 = 1;` drops the constants out of that band. This is
+the ternary-orientation family of 6bs seen from the other side: orientation decides which
+arm is the fall-through, and the ternary's presence at all decides whether its constants
+compete for a callee-saved register.
+
+**2. Hoisted-constant emission order is a fixed per-region sequence.**
+Same function. Once mwccarm decides to hoist a set of constants for a region, the order it
+emits them in is a property of the region, not of first use in the source: moving a use
+earlier does not move its constant earlier. So there is no source edit that permutes the
+hoist block. The only lever is which region a value belongs to -- which is what levers 3
+and 7 are.
+
+**3. A named pool-array pointer assigned AFTER the guards colours in the normal band.**
+`func_ov006_020cfc74` walks `data_ov006_0214097c[i]`. The null check and the `IsActive`
+check both index the pool array directly; only after both pass does the body take a name
+for it:
+
+```c
+if (data_ov006_0214097c[i] == 0) continue;
+if (data_ov006_0214097c[i]->vt->IsActive(data_ov006_0214097c[i]) == 0) continue;
+arr = data_ov006_0214097c;          /* here, not at the top */
+```
+
+Assigned here, `arr`'s pool load lands inside the hoisted-constant sequence of lever 2 and
+`arr` colours in the normal band. Hoisting the assignment to the top of the loop, which is
+what a reader would naturally write, lifts it out of that sequence and rotates the band.
+
+**4. Read-modify-write and plain read of the same u16 element pick DIFFERENT address forms.**
+`func_ov006_02106aa8` touches the same three counter arrays both ways, and the ROM spells
+them differently at each site:
+
+```c
+u16 *q = (u16 *)(base + 0x4e78 + idx * 2);   *q = *q - 1;   /* pool constant + register offset */
+if (*(u16 *)(base + idx * 2 + 0x4e78) < lim) return;        /* split base + 0xNN00, then #off */
+```
+
+The RMW form produces the pool-constant-plus-register-offset address; the plain read
+produces the split `base + 0xNN00` / `#off` pair. Both spell the same address. Which one
+the compiler emits is decided by whether the site writes back, so a site that reads like a
+gratuitous re-computation in the ROM is often just a plain read next to an RMW. Pair this
+with `opt_common_subs off`, which is what keeps the else-branch recomputing `base + idx*2`
+in its own extended basic block.
+
+**5. A named copy of a stack word steals r4 from a umull low word.**
+`func_ov006_020d0c38` rescales a half-vector. `half[1]` is read inline twice -- once as the
+multiplicand of the Q12 multiply, once as the second word of the copy into `tmp`:
+
+```c
+m = (long long)half[1] * 0xc00 + 0x800;
+tmp[0] = half[0];
+tmp[1] = half[1];
+```
+
+Give that value a name and the name takes r4, which is where the umull's low-word
+destination has to be, and the whole block rotates. The lever is the ABSENCE of the name:
+two inline reads of the same stack word are cheaper to colour than one named copy.
+
+**6. Named `x << 12` temps keep the y shift in place.**
+Same function, the midpoint pair. The shifts have to be named:
+
+```c
+int x12 = x << 12;
+int y12 = y << 12;
+mid[0] = x12;
+mid[1] = y12;
+```
+
+Assigning `mid[0] = x << 12; mid[1] = y << 12;` directly floats the y shift away from its
+store. This is the mirror of lever 5 in the same function -- one value needs a name to hold
+its position, the other needs to stay anonymous to give up a register -- which is the
+practical reason a decl-order sweep alone does not converge on a body like this.
+
+**7. Scope depth reaches a callee-saved swap that decl order cannot. (NEAR-MISS EVIDENCE.)**
+Measured on `func_ov006_020e1854`, which is NOT matched: 16 divergences to 10. Declaring
+the pair block-scope inside the `if` that uses them, while their siblings stay at function
+scope,
+
+```c
+if (data_020a0de8[idx * 4] != 0) {
+    int dy2, dy;                    /* block scope, in this order */
+    ...                             /* dx, oldx, oldy are function scope */
+```
+
+fixes the `oldy` <-> `dy` callee-saved swap (ROM: oldy=r6, dy=r4, dy2=r5). No permutation
+of the function-scope declaration list reaches that swap; scope depth does.
+
+**Counter-check, and the limit of the lever.** Nesting is not free evidence. In the matched
+`func_ov006_020d0c38` the two inner blocks around the cross-product operands,
+
+```c
+{ s16 cx = v2[0]; cross2 = (int)ax * (int)cy - (int)ay * (int)cx; }
+```
+
+are INERT: flattening both into the enclosing block keeps every byte
+(`MATCHING VERSIONS: 2004/b56`). So scope depth is a lever only where the swap it is aimed
+at is between a block-live value and a function-live one. Deepening a scope whose
+neighbours are all block-live buys nothing, and a source that carries such a scope is
+carrying it for readability, not for codegen.
+
+**8. Plain member access at a large halfword offset gives the shared base; a named pointer folds it.**
+`func_ov006_020cfc74` reads and writes `c + 0x320`, `c + 0x324` and `c + 0x326` as
+halfwords through `c` itself. Done that way, mwccarm emits the ROM's shared `c + 0x300`
+base with the copied read on top of it. Taking a named base pointer for the region instead
+folds the copy away and the shared base with it. At small offsets the two spellings agree;
+at an offset that needs its own `add`, they do not.
+
+**Two observations, recorded as observations.** A rotation model was drafted for the
+residues these four left behind, predicting which register a displaced value lands in; it
+is not proven on any body here and is not offered as a lever. The lane also ran a long
+inert list -- decl-order permutations at function scope, named-versus-inline differences,
+u64 launder on the pool arrays (which regressed `func_ov006_020dd0e0` by nine words), tail
+source order and idx reuse -- and none of it moved a byte on the matched four; the useful
+half of that list is already the near-miss database's, not this file's.


### PR DESCRIPTION
Moves the 6bu compiler-codegen findings out of matching PR #2291 so that source matching and notes remain independently reviewable, as required by AGENTS.md. Content is unchanged from the original notes-only commit.