### PR TITLE
Settle the defer_codegen pragma lever in writer.md

### DIFF
--- a/notes/agents/roles/builder.md
+++ b/notes/agents/roles/builder.md
@@ -66,15 +66,25 @@ PASS signals:
 - `tubuild verify` → `N/N MATCH, objisolate clean, reloc-destinations clean`
 - `rombuild` → `module fidelity: 106/106 exact, 100.000000% of compared bytes`
   and `ROM-build analysis: PASS`; its stock profile must report 0 mod source
-  replacements and 0 ROM-gap fallbacks, and the built NDS must have the retail
-  SHA-256
+  replacements and 0 ROM-gap fallbacks. **There is no retail-SHA oracle — do not
+  look for one.** The built ROM differs from the repo's own `sm64.nds` in ~54 KB
+  across ~7,000 ranges, all outside the compared modules, and the manifest's
+  `matchesStockRom` means "identical to this tree's last `build/sm64ds.nds`",
+  not "identical to retail". The real checks are `module fidelity: 106/106
+  exact, 100.000000%` plus equality with the run's own source-independent stock
+  baseline control
 - `source_coverage` → `0 B` handed back to the cartridge
 - `prepush_attribution` → **no symbol *lost*.** Do **not** hold out for
   `0 changed`: a promotion folds N shards into one file, and the counter credits
   only the delinks range's *first* symbol and reclassifies the rest as
   "claimed" — see the many-to-one fold artifact below, which lists the lines
-  that are expected and are not losses. `changed` is noise on a promotion by
-  construction; `lost` is the signal. Run the check, commit what it asks for,
+  that are expected and are not losses. **But `changed` is not noise by
+  construction, and this file used to say it was.** With correct `path#symbol`
+  overrides committed, the validator reports `0 changed` and the four "expected"
+  fold lines collapse to one (`N address range(s) left the byte-verified set`).
+  Measured on `ov006/dScMgRoulette_c`: `32 consolidated with credit intact,
+  0 changed, 0 lost`. So aim for `0 changed`; if you cannot reach it, say which
+  rows resist and why, rather than writing it off as inherent. Run the check, commit what it asks for,
   report the numbers, and move on — reconciling credit beyond that is a stated
   non-goal in this repo and has consumed whole sessions before.
 - everything else → exit 0 with no backlog count increased
@@ -134,7 +144,9 @@ and addend), and `reloc_audit` (destination identity).
 **`romdata_check`'s per-symbol verdicts are not reachable from the CLI.**
 `--show` only slices `report["differing"]` and `--json` carries counts. To prove
 a specific symbol's identity — which is how the cross-module RTTI claim was
-settled — import the module and call `check_object()` directly. **Pass
+settled — import the module and call `check_object()` directly. The signature is
+`check_object(obj_path, rel, names=None)` — passing a rom index positionally
+raises `TypeError: got multiple values for argument 'names'`. **Pass
 `names=romdata_check.name_index()`**: without it `module` comes back `None`,
 which defeats the cross-module proof the call is for. The records carry `module`
 but **no address field**, so addresses still need checking against `symbols.txt`
@@ -217,6 +229,35 @@ under-reported conflicts.
 path legitimately recurs under different reasons — `main` carries 66 such rows
 from past promotions. Only byte-identical repetition is the defect. A builder
 who deduped by path would delete real history.
+
+## Check for a shallow clone before trusting ANY attribution output
+
+    git rev-parse --is-shallow-repository        # must print false
+
+**A shallow clone silently corrupts every attribution answer, and the wrong
+answer is permanent.** `first_matchers()` / `match_finishers()` replay `src/`
+history, so a truncated clone makes every lineage start at the newest commit
+that touched the file — which is usually the automated refresh, i.e.
+`github-actions[bot]`. `prepush_attribution` then reports dozens "lost", and
+banking its suggestion writes override rows that are **highest priority and
+never pruned**.
+
+Measured 2026-09-05: this repo's primary checkout was shallow at **1,325 of
+4,743 commits** for a whole session. A builder banked 40 override rows from that
+output before catching it; the merge validator's "Before" column showed it would
+have stripped functions from three named human contributors and mislabelled 24
+more. After `git fetch --unshallow`, the recomputed owner set agreed with all 25
+owners the validator printed, with **0 disagreements**.
+
+`attribution.json` currently carries **968 of 2,036 override rows crediting
+`github-actions[bot]`**, which is what this defect looks like at scale. CI is not
+the source — the workflows that read history correctly set `fetch-depth: 0`.
+Local agent runs are.
+
+**So: never bank an attribution override from a shallow clone.** If
+`--is-shallow-repository` prints true, run `git fetch --unshallow` and recompute
+before writing anything. Worktrees share the parent clone's `.git`, so one
+shallow clone makes every worktree cut from it shallow too.
 
 ## Do not use `git stash` in this repo
 
@@ -374,7 +415,10 @@ already stale. Getting this wrong costs a full validation cycle.
   decimal, i.e. the false `0x58`, on the very class where the real answer is
   `0x88`. The truthful fields are **`emitted`** and **`bytes`**, with
   `blindWords: 0`. Following the extent field confirms the trap instead of
-  catching it.
+  catching it. **This is class-specific, not universal** — on
+  `dScMgRoulette_c` the field reads `144`, which is correct and equal to
+  `emitted`/`bytes`. So it is unreliable rather than always-wrong: never take it
+  alone, and corroborate as above.
 - **Print scalar fields only from a `check_object()` record.** Its `src` key is a
   dict keyed by *tuples* covering every symbol in the module, so `json.dumps`
   raises `TypeError: keys must be str...` and printing the record raw dumps about

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -455,15 +455,36 @@ Ask the compiler rather than hand-mangling:
   `0x0211384c` reaches `0x021138d8` with **no gap anywhere** — 36 words, four
   more than the real 32 — because `_ZTI14daObjDpBrock_c` at `0x021138d0` is a
   `__si_class_type_info`, three fully-relocated words butted straight against the
-  table. Nothing in `relocs.txt` marks that boundary. **The tie-break is
-  `symbols.txt` naming a `_ZTI`/`_ZTS` inside the run**, not the run's own shape.
-  A class whose run happens to end in a real gap (`dScMgRoulette_c`: next
-  relocated word `0x0213e444`, with `0x0213e42c..0x0213e440` unrelocated) is
-  decisive by accident, not by method — do not generalise from one.
+  table. Nothing in `relocs.txt` marks that boundary.
+
+  **The `_ZTI`/`_ZTS` tie-break first proposed here does NOT generalise — a
+  later sweep refuted it.** All 51 `_ZTV` in ov006 were checked: the run-overshoot
+  is real in **15 of them**, but in every one of those the overshooting words are
+  ordinary `data_ov006_*` / `g_profile_*` objects, **never** a `_ZTI`. So "look
+  for a `_ZTI`/`_ZTS` named inside the run" would have caught **0 of 15**. And
+  the naive next-symbol read *under*-reports in the other direction
+  (`dScMgD3DBase_c`: `0x50` against a real `0x90`, because of an interior phantom
+  symbol). **Neither rule is sound alone.**
+
+  **What actually works is corroboration from three independent tools**, which is
+  what every correct extent in this campaign has rested on: the relocation gap,
+  `rtti_vtables.py --own <Class>` for the slot count, and
+  `romdata_check.check_object()` for `bytes`/`emitted` with `blindWords: 0`.
+  Worked example, `dScMgRoulette_c`: relocated run `0x0213e398..0x0213e428`, then
+  a real `0x18` gap before the next reloc at `0x0213e444`; storage
+  `0x0213e394..0x0213e42c` = `0x98`; symbol extent from the address point =
+  `0x90` = 36 slots; `rtti_vtables` says 36; `check_object` says
+  `bytes 144, emitted 144, blindWords 0, VERIFIED`. Three tools, one answer.
+  **Distinguish storage size from symbol extent** — they differ by the 8-byte
+  offset-to-top + typeinfo preamble, and quoting one where the other is meant is
+  its own source of confusion.
 - **Do NOT read the extent from `romdata_check`'s `romExtent` field.** It carries
   the *wrong short* value — `88` decimal, the false `0x58` — on the very class
   where the answer is `0x88`. Trusting it confirms the trap instead of catching
-  it. `emitted` and `bytes` are the truthful fields.
+  it. `emitted` and `bytes` are the truthful fields. **This is class-specific, not universal** — on
+  `dScMgRoulette_c` the field reads `144`, which is correct and equal to
+  `emitted`/`bytes`. So it is unreliable rather than always-wrong: never take it
+  alone, and corroborate as above.
 - **`verify` prints no `_ZTV` section size.** This file said twice to cross-check
   against one. It does not exist; `verify` prints the MATCH table, byte
   comparison, objisolate, emission order and the result.

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -612,15 +612,43 @@ measured on `ov006/dScMgHanachan_c` (22 of 61):
   that want it gave byte-identical results to omitting it entirely. (`#pragma
   push`/`O3`/`pop` *is* positional; these two are not.)
 
-  **That measurement is now suspect: try `#pragma defer_codegen off` first.**
+  **SETTLED: `#pragma defer_codegen off` makes the bracket bind, and it recovered
+  this exact class from 22 of 61 to 49 of 61.** The pragma-driven exclusions were
+  all 27 of them; the only functions still held back are the sourceless hole and
+  the 11 on its smaller side, which is a different and unfixable refusal. Measured
+  on `ov006/dScMgHanachan_c` (PR #2309): `verify` 49/49 MATCH, `linkcheck [4b/8]`
+  49 LICENSED with `emittedTextOrderIsRomAscending = true`, 106/106 modules exact,
+  ROM sha256 identical to stock. The decisive probe was adding one
+  `opt_strength_reduction off` member under a `push`/`pop` bracket: 23/23, with
+  the two `opt_strength_reduction`-**on** members still matching. Deleting that
+  one pragma line from the finished file drops it to 44/49 **and** 48 ordinal
+  pairs out of ROM order — it buys the bytes and the order together.
+
+  **So the rule above is true by default and false under `defer_codegen off`,
+  now confirmed on all three pragma families tried.** Any partial that was cut on
+  a pragma contradiction is worth re-measuring.
+
+  **The ROM-ascending rewrite is not optional when you adopt it.** Same class,
+  same bytes, three configurations:
+
+  | source order | `defer_codegen` | bytes | emission order |
+  |---|---|---|---|
+  | ROM-descending | deferred (default) | 22/22 | ROM-ascending |
+  | ROM-descending | **off** | 22/22 | **21 pairs NOT in ROM order** |
+  | ROM-ascending | **off** | 22/22 | ROM-ascending |
+
+  The rewrite is mechanical and belongs in the same edit.
+
+  **The older, superseded framing follows.**
   Bracketed pragmas do not bind while codegen is deferred, which is the default,
   and the measurement above was almost certainly taken that way. Measured on
   `ov006/dScMgMemory2_c`: with `#pragma defer_codegen off` at the top of the TU,
   **52/52 MATCH**; removing that one line dropped it to **50/52**, and the two
   DIFFs were exactly the two functions carrying bracketed pragmas —
   `opt_propagation off` (27 words) and `opt_loop_invariants off` (6 words). The
-  pair actually named above, `opt_strength_reduction` and `opt_common_subs`, has
-  **not** been re-tested under `defer_codegen off`. Do not take a pragma
+  pair actually named above, `opt_strength_reduction` and `opt_common_subs`, was
+  the last untested family; it has since been measured and behaves the same way
+  (see the settled result at the top of this bullet). Do not take a pragma
   collision as an automatic subset until you have tried it, and report what you
   measure either way.
 


### PR DESCRIPTION
`#pragma defer_codegen off` makes positional pragma brackets bind. `writer.md` told writers the opposite - that `opt_strength_reduction` and `opt_common_subs` are file-global last-wins with "no positional escape", so a pragma collision meant taking a subset.

That rule is **true by default and false under `defer_codegen off`**, now confirmed across all three pragma families tried. It recovered `ov006/dScMgHanachan_c` from **22 of 61 to 49 of 61** (PR #2309) - all 27 pragma-driven exclusions. The only functions still held back are the sourceless hole and the 11 on its smaller side, which no pragma affects.

The decisive probe: one `opt_strength_reduction off` member added under a `push`/`pop` bracket gave 23/23, with the two `opt_strength_reduction`-**on** members still matching. The control is equally clean - deleting that one pragma line from the finished file drops it to 44/49 *and* 48 ordinal pairs out of ROM order.

Also records that the ROM-ascending rewrite is **not optional** when adopting it: descending source plus `defer_codegen off` matches the same bytes but fails `linkcheck [4b/8]`, which is a hard refusal.

The superseded framing is kept below the new one rather than deleted - the default behaviour it describes is still correct and still what you get if you do nothing.

Scope, measured: of 45 manifests carrying a `partial_isolation` block, only nine record a shortfall and only one of those is pragma-related, so there is little to reclaim in landed work. The value is prospective - the queue still lists classes blocked on up to 17 pragma collisions.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA