### PR TITLE
Strike order/position from the ledger discriminator

### DIFF
--- a/notes/agents/roles/builder.md
+++ b/notes/agents/roles/builder.md
@@ -295,8 +295,14 @@ Two things follow:
 A class branch cut before `main` moved must be rebased, and **the two ratchet
 files behave differently and only one of them tells you**:
 
-- `config/converted-baseline.json` **conflicts loudly**. It is regenerated whole
-  per promotion, so any overlap collides. That is the safe one.
+- `config/converted-baseline.json` **conflicts loudly — but only when the landed
+  promotion actually changed the CONVERTED set.** It is regenerated whole per
+  promotion, so an overlapping change collides, and that is the safe one. The
+  guarantee is conditional and the condition is easy to miss: a promotion whose
+  absorbed shards were all *below* CONVERTED tier banks nothing, leaving the file
+  byte-identical and unable to collide. Measured — `dScMgRoulette_c` (#2312), a
+  40-member promotion, changed **neither** ledger file and put zero rows in the
+  exceptions file. Do not infer "no conflict, therefore no promotion landed".
 - `config/converted-backslide-exceptions.jsonl` **auto-merges silently and
   reintroduces stale rows.** Measured here: a cherry-pick re-added five
   `ShipWing` rows naming the former actor-directory location for
@@ -330,6 +336,13 @@ identical generic ones. Nothing reads those strings, so no gate goes red and no
 reviewer diff makes it obvious — it is silent data loss. This is the second half
 of the non-destructive recipe above: when the regenerated file differs from your
 copy *only in the `reason` strings*, your copy is the one to keep.
+
+**A third file conflicts on a rebase and this section used to omit it:
+`notes/cpp-tu-current-state.md`.** It is generated, every promotion rewrites it,
+and on one measured rebase it was the *only* `UU` conflict while both ledger
+files merged silently. Same rule as the ledgers — regenerate, never resolve:
+`git checkout <newbase> --` it, finish the merge, then
+`python tools/cpp_tu_state.py --write-note`.
 
 **Restore BOTH files to `main`'s version and re-run `tiers_ratchet --update`.**
 Never resolve either by hand and never let the merge resolve them for you — the

--- a/notes/agents/roles/integrator.md
+++ b/notes/agents/roles/integrator.md
@@ -70,8 +70,18 @@ Read the diff, do not just look at the exit code:
   informative reason per class; a regeneration replaces all of them with N
   copies of your single `--reason`. Nothing reads those strings, so no gate goes
   red. It is real data loss with no alarm.
-- **Differs in the path set, order, or position** — the regenerated file wins,
-  and say so in the PR body with the count.
+- **Differs in the path MULTISET** — the regenerated file wins, and say so in
+  the PR body with the count.
+
+**Order and position are NOT discriminators — strike them from that test.**
+`append_exceptions` (`tools/tiers_ratchet.py:313`) opens the file `"a"` and only
+ever appends, so a regeneration **always** relocates your row to true EOF
+whenever anything was appended after it. Measured: a writer's row went in at line
+336 of 336; an `origin/main` merge then appended seven rows behind it, and the
+regeneration moved it to 343. That is guaranteed by construction, not merge
+damage. An earlier version of this file listed position as a "regenerated wins"
+signal — following it would have committed the regenerated file and destroyed
+the writer's per-class reason every single time.
 
 Then audit what you are shipping: **count byte-identical whole records** in the
 exceptions file. Zero is the target. Dedupe by *whole record*, never by path —


### PR DESCRIPTION
Three defects in the rebase recipe, found by the #2309 rebase run. One is actively harmful.

**"Differs in the path set, order, or position -> the regenerated file wins" is wrong on two of those three terms.** `append_exceptions` (`tools/tiers_ratchet.py:313`) opens the exceptions file `"a"` and only ever appends - which the role file states itself two paragraphs earlier. A regeneration therefore **always** relocates your row to EOF whenever anything was appended behind it.

Measured: the writer''s row went in at line 336 of 336; merging `origin/main` appended seven rows after it, and the regeneration moved it to 343. Guaranteed by construction, not merge damage. Following the rule as written would have committed the regenerated file and destroyed the writer''s informative per-class reason **every single time** - the exact silent data loss the same file warns about. The discriminator is the path **multiset**, and nothing else.

**`converted-baseline.json` does not conflict loudly on every rebase.** The guarantee is conditional on the landed promotion having changed the CONVERTED set. Measured: `dScMgRoulette_c` (#2312), a 40-member promotion, changed **neither** ledger file and put zero rows in the exceptions file, because its absorbed shards were all below CONVERTED tier. So "no conflict" is not evidence that no promotion landed.

**A third file conflicts on a rebase and the section omitted it:** `notes/cpp-tu-current-state.md`. Generated, rewritten by every promotion, and on this rebase it was the **only** `UU` conflict while both ledger files merged silently. Same rule - regenerate, never resolve.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA