### PR TITLE
Let tubuild create survive a sourceless member

### DIFF
--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -927,6 +927,17 @@ def assemble_shadow_source(tu_id, ord_rows, parsed):
     return "\n".join(out).rstrip("\n") + "\n", warnings
 
 
+def _legacy_rel(name):
+    # cmd_create tolerates a SOURCELESS member (it becomes a banner and verify
+    # reports it MISSING), but this builder did not: SP.path_for returned None
+    # and the .relative_to crashed, so the one shape cmd_create was taught to
+    # survive still aborted `create` before a manifest existed. Measured on
+    # ov006/dScMgHanachan_c, whose func_ov006_020ea914 is a banked near-miss
+    # with no src/ file at all.
+    p = SP.path_for(name)
+    return p.relative_to(REPO).as_posix() if p is not None else None
+
+
 def build_manifest_entry(tu_id, module, rec, unit, ord_rows, out_path, warnings):
     start, end = int(unit["start"], 16), int(unit["end"], 16)
     classes = unit.get("classes") or []
@@ -956,7 +967,7 @@ def build_manifest_entry(tu_id, module, rec, unit, ord_rows, out_path, warnings)
         "sections": [{"name": ".text", "start": f"0x{start:08x}", "end": f"0x{end:08x}"}],
         "functions": [
             {"symbol": name, "address": f"0x{addr:08x}", "size": f"0x{size:08x}",
-             "legacy_source": SP.path_for(name).relative_to(REPO).as_posix(), "ordinal": o}
+             "legacy_source": _legacy_rel(name), "ordinal": o}
             for o, name, addr, size in ord_rows
         ],
         "data": [],


### PR DESCRIPTION
`build_manifest_entry` called `SP.path_for(name).relative_to(REPO)` for every function, so a member with no `src/` file crashed `create` with `AttributeError: ''NoneType'' object has no attribute ''relative_to''` at `tubuild.py:959`.

That directly contradicts `cmd_create`''s own comment 30 lines below, which says a sourceless member becomes a banner and `verify` reports it MISSING - the one shape `cmd_create` was explicitly taught to survive still aborted the command.

**The failure is worse than a crash:** the `.cpp` is written *before* the manifest builder runs, so the writer is left with a shadow source and no manifest, and has to hand-write the entry. Two writers hit it today on different classes - `ov006/dScMgHanachan_c` (whose `func_ov006_020ea914` is a banked near-miss with no `src/` file at all) and `ov006/dScMgBomroom_c`.

`legacy_source` becomes null for such a member, which the consumers already handle: `tu_promote.py:126-128` refuses a falsy `legacy_source`, `is_complete()` null-guards, and `BP.version_for(None)` fails closed into CONFLICT.

Measured on this tree: **0 null `legacy_source` values across 1,951 manifest function rows**, so nothing existing changes shape. **68 tubuild tests pass.**

The fix was written and reviewed earlier today on a class branch and did not survive into any PR that landed. Recovered here as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA