### PR TITLE
Make tubuild create emit an // @symbol marker for every member

### DIFF
--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -565,6 +565,15 @@ Both promoted precedents (`daDsnBase_c`, `daObjCtMecha03_c`) do. Do the same and
 align your spellings to it, rather than assuming the header will collide with
 you on its own.
 
+**But a `decl_common.h` return type can cost you the match, and then the header
+is what gives way.** Measured on ov066/`Eyerok`: `decl_common.h:2730` types
+`func_ov066_02119454` as `void(void*, void*)` and the ROM function returns a
+value — declaring it `int` MATCHes, declaring it `void` does not. That TU
+excludes the header and declares every symbol the header would have supplied.
+So: include it and align *by default*, but when a spelling it dictates breaks a
+byte match, measure both ways and say which you took and why. The bytes outrank
+the header.
+
 **Grep shadow struct *tags* too, not only declarations.** A shadow type can
 collide with a **ROM symbol**, which is a different failure and a nastier one.
 `decl_common.h` declares `extern int VT[];`, and the legacy shards carry a
@@ -638,7 +647,11 @@ Ask the compiler rather than hand-mangling:
   symbol). **Neither rule is sound alone.**
 
   **What actually works is corroboration from three independent tools**, which is
-  what every correct extent in this campaign has rested on: the relocation gap,
+  what every correct extent in this campaign has rested on — though the third is
+  **unavailable to a TU that does not own the key function**: `check_object` only
+  sees the vtable if the TU emits it, so on a partial promotion get that number
+  from whichever shard still owns the key function, or from a throwaway probe TU
+  that does. The three are the relocation gap,
   `rtti_vtables.py --own <Class>` for the slot count — **but it answers only to
   the ROM's RTTI spelling, not the tree's**. `--own Goomboss` prints
   `no vtable for Goomboss`; `--own daKuriKing_c` prints the 31 slots. For a

--- a/notes/data/tu-promotion-queue.tsv
+++ b/notes/data/tu-promotion-queue.tsv
@@ -24,6 +24,10 @@ class_name	shard_count	total_lines	overlay	has_header	already_promoted	blockers	
 # move: dScMgRoulette_c's pragmas were inert and it scored 40/40 with them deleted.
 #
 # unmatched:N        delink entries in the run with no 'complete' marker.
+#                    The NAME MISLEADS: this is a LINK condition, not a matching one.
+#                    Measured on ov066/Eyerok all six byte-MATCHed; they lack the marker
+#                    because they reference cross-overlay addresses under names no
+#                    symbols.txt gives, so dsd drops them from the link.
 # no-legacy-source:N functions with no delinks entry AND no src/<symbol>.c[pp] at all. The
 #                    cartridge's own bytes cover them, and a licensed claim cannot have a
 #                    hole, so such a run can only be taken as one of its two contiguous

--- a/tools/queue_audit.py
+++ b/tools/queue_audit.py
@@ -25,6 +25,13 @@ shard_count        distinct src/ files covering the TU's ROM run, where the run
                    abut; absorbing them adds a member to about 50 rows. It is
                    still a FLOOR -- any other unlabelled neighbour is uncounted.
 unmatched:N        delink entries in the run with no `complete` marker.
+                   The NAME MISLEADS: it is a link condition, not a matching
+                   one. Measured on ov066/Eyerok, all six `unmatched` shards
+                   byte-MATCH under `match.py --strict-relocs`; they carry no
+                   `complete` marker because they reference cross-overlay
+                   addresses under names no module's symbols.txt gives, so dsd
+                   drops them from the link. Check the bytes before assuming
+                   there is decompilation work to do.
 no-legacy-source:N functions in the run with NO delinks entry and NO
                    src/<symbol>.c[pp] -- the cartridge's own bytes cover them.
 not-in-delinks:N   functions with a src/ file but no delinks entry. A milder
@@ -352,6 +359,10 @@ NOTES = [
     "# move: dScMgRoulette_c's pragmas were inert and it scored 40/40 with them deleted.",
     "#",
     "# unmatched:N        delink entries in the run with no 'complete' marker.",
+    "#                    The NAME MISLEADS: this is a LINK condition, not a matching one.",
+    "#                    Measured on ov066/Eyerok all six byte-MATCHed; they lack the marker",
+    "#                    because they reference cross-overlay addresses under names no",
+    "#                    symbols.txt gives, so dsd drops them from the link.",
     "# no-legacy-source:N functions with no delinks entry AND no src/<symbol>.c[pp] at all. The",
     "#                    cartridge's own bytes cover them, and a licensed claim cannot have a",
     "#                    hole, so such a run can only be taken as one of its two contiguous",

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -533,6 +533,11 @@ def cmd_inspect(args):
 _CPP_MARKER = "//cpp"
 _PRAGMA_LINE_RE = re.compile(r'^\s*#\s*pragma\b.*$')
 _LONG_CALLS_ON_RE = re.compile(r'^\s*#\s*pragma\s+long_calls\s+on\b')
+_AT_SYMBOL_RE = re.compile(r'^\s*//\s*@symbol\s+(\S+)', re.M)
+# The compiler-generated destructor group is the one documented exception: it is
+# scored by tiers._lifecycle_member_fragment from the class header, not from a
+# marker, so marking it here would cut a fragment nothing reads.
+_DTOR_VARIANT_RE = re.compile(r'D[012]Ev$')
 _INCLUDE_RE = re.compile(r'^\s*#\s*include\s*.+$')
 _DEFINE_RE = re.compile(r'^\s*#\s*define\b.*$')
 _DECL_KEYWORDS = ("struct", "class", "enum", "typedef", "namespace")
@@ -896,6 +901,16 @@ def assemble_shadow_source(tu_id, ord_rows, parsed):
             out.append(" * ROM's own bytes cover this range. Recover it before promotion. */")
             out.append("")
             continue
+        # `tiers._marked_member_fragment` slices a promoted TU's member source from
+        # each `// @symbol` marker to the NEXT marker, so an unmarked body is
+        # charged to whichever member is marked above it, and the ratchet reports
+        # a BACKSLID against a member that does not contain the offending code.
+        # Emitting the marker here is byte-neutral (measured on ov066/Eyerok: 29
+        # markers added, object sha256 and its 18136 bytes unchanged) and removes
+        # a manual step every promotion previously had to remember.
+        if not _AT_SYMBOL_RE.search("\n".join(p["notes"])) \
+                and not _DTOR_VARIANT_RE.search(name):
+            out.append(f"// @symbol {name}")
         for note in p["notes"]:
             out.append(note)
         # `#pragma long_calls` is POSITIONAL (measured on 2004/b56, notes in the


### PR DESCRIPTION
`tiers._marked_member_fragment` slices a promoted TU's member source from each `// @symbol` marker to the **next** marker, so an unmarked body is charged to whichever member is marked above it — and the ratchet reports BACKSLID against a member that does not contain the offending code. Until now the markers a generated TU carried came only from whichever shards happened to have one, and every promotion has had to add the rest by hand.

Measured on `ov066/Eyerok`: 61 ordinals, **10 markers before, 61 after** — 51 functions that would have been mis-scored. The Eyerok writer added 29 of them by hand across their 34-member subset and proved the edit byte-neutral (object sha256 and its 18136 bytes unchanged), which is what makes emitting them safe.

The compiler-generated destructor group stays the documented exception: `_DTOR_VARIANT_RE` skips D0/D1/D2, which `tiers._lifecycle_member_fragment` scores from the class header instead. A marker a shard already carries is never duplicated and never stripped — verified on Eyerok, where the D0/D1 markers come from the shards and appear identically before and after.

Also from the same writer run:

- **`unmatched:N` misleads, and the queue now says so.** It is a **link** condition, not a matching one: all six of Eyerok's byte-MATCH under `match.py --strict-relocs`. They carry no `complete` marker because they reference cross-overlay addresses under names no module's `symbols.txt` gives, so dsd drops them from the link. Check the bytes before assuming there is decompilation work to do.
- **A `decl_common.h` return type can cost a byte match**, and then the header gives way: `decl_common.h:2730` types `func_ov066_02119454` as `void(void*, void*)` while the ROM function returns a value — `int` MATCHes, `void` does not.
- The third `_ZTV`-extent tool is unavailable to a TU that does not own the key function; `check_object` only sees the table if the TU emits it.

71 tubuild and classqueue tests pass; `queue_audit --check` agrees with the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA