### PR TITLE
Retract two builder.md guesses the dScMgMemory2_c run refuted

### DIFF
--- a/notes/agents/PIPELINE.md
+++ b/notes/agents/PIPELINE.md
@@ -81,6 +81,12 @@ commit push the same SHA, git answers `Everything up-to-date` and exits 0, and
 normalized to the same ref — a class lives in one overlay, so the prefix adds
 nothing. Before that normalization the two spellings built two different refs
 and two agents could hold one class simultaneously; live claims existed in both
+**Use forward slashes in `--worktree`, as the example above does — it is
+required, not cosmetic.** A backslash path passed through a shell arrives with
+its separators eaten and the claim records
+`"worktree": "C:tmpsm64ds-memory2-build"`, which points at nothing and defeats
+the whole reason the field exists.
+
 forms. Create the worktree first and claim once with `--worktree`: re-claiming
 to attach the path afterwards is denied against yourself.
     python tools/classqueue.py release dActor_c --role writer

--- a/notes/agents/roles/builder.md
+++ b/notes/agents/roles/builder.md
@@ -139,12 +139,12 @@ carrying more than one `.text` run (the 13,201 / 136 this file used to print is
 stale — promotions collapse blocks). The invariant itself holds, which is why a
 licensed claim cannot span a hole. Re-derive the counts; do not quote them.
 
-**Never read a gate's verdict through a pipe.** `python tools/X | tail -6;
+**Never read a gate's verdict through a pipe.** `python tools/source_coverage.py | tail -6;
 echo $?` reports **`tail`'s** exit status, not the tool's. Measured: a builder
 ran `source_coverage` that way, the tool printed its full failure banner into
 the truncated tail, `$?` came back 0, and they recorded it as green. Redirect to
 a file and echo `$?` *before* any pipe:
-`python tools/X > /tmp/x.log 2>&1; echo $?; tail -6 /tmp/x.log`. Two related
+`python tools/source_coverage.py > /tmp/x.log 2>&1; echo $?; tail -6 /tmp/x.log`. Two related
 parsing traps: `gh pr checks` output is **TAB**-separated, so `awk '{print $2}'`
 on `PR validation<TAB>pending` yields `validation` and a wait-loop exits
 immediately looking settled — use `awk -F'\t'`; and `classqueue.py claim

--- a/notes/agents/roles/builder.md
+++ b/notes/agents/roles/builder.md
@@ -18,10 +18,11 @@ that does not match `HEAD` — so the ratchet and its commit must come **before*
     #      that is degenerate post-promotion (contributionEquivalent "0/22",
     #      state "derived"). Revert it if it appears -- it does not always. The
     #      guess that it depends on status: promoted is refuted: daObjFallBlock_c
-    #      had that status and verify still wrote nothing. It more likely writes
-    #      only when no partial_isolation block exists yet -- a second promotion
-    #      (daDgr_c, daDkk_c: block already present, verify wrote nothing) is
-    #      consistent with that. Check, do not assume.
+    #      had that status and verify still wrote nothing. The follow-up guess --
+    #      that it writes only when no partial_isolation block exists yet -- is
+    #      ALSO refuted: dScMgMemory2_c has no such block and verify wrote
+    #      nothing across 5 runs. No correlate is known. Run `git status` after
+    #      every verify; do not predict it.
     python tools/rombuild.py -j 6
     Get-FileHash build/sm64ds.nds -Algorithm SHA256
     python tools/romdata_check.py --files src/actors/<Class>.cpp
@@ -52,7 +53,13 @@ that does not match `HEAD` — so the ratchet and its commit must come **before*
     python tools/check_duplicate_sources.py
     python tools/check_dead_references.py
     python tools/cpp_tu_state.py --check-note
-    #    ^ --write-note EXITS 2 on a dirty tree, which is exactly the state the
+    #    ^ --check-note is SAFE on a dirty tree: measured with an unrelated
+    #      unstaged change, it printed `cpp-tu state note is current`, exit 0.
+    #      It reports stale only when the note file itself differs from a
+    #      regeneration. The dirty-tree refusal below belongs to --write-note
+    #      (and the one that hard-fails on an unstaged tree is
+    #      check_references.py, a different tool).
+    #      --write-note EXITS 2 on a dirty tree, which is exactly the state the
     #      rebase recipe leaves you in, and its message tells you to STASH --
     #      which this file forbids (shared across worktrees; unstages
     #      deletions). Use `git add -A`, then re-run.
@@ -93,7 +100,18 @@ PASS signals:
   fold lines collapse to one (`N address range(s) left the byte-verified set`).
   Measured on `ov006/dScMgRoulette_c`: `32 consolidated with credit intact,
   0 changed, 0 lost`. So aim for `0 changed`; if you cannot reach it, say which
-  rows resist and why, rather than writing it off as inherent. Run the check, commit what it asks for,
+  rows resist and why, rather than writing it off as inherent. **`0 changed` is
+  a target, not a merge bar** — the landed `dScMgHanachan_c` promotion (#2309)
+  measures `43 changed, 0 lost`, exit 1, at its own commit. Judge on `lost`.
+
+  **The mechanism this file never named, which cost a builder real time:** the
+  overrides live in `attribution.json` at the repo **root**, in the `overrides`
+  dict, keyed `src/<tu>.cpp#<symbol>`. `prepush_attribution --json` prints the
+  rows verbatim, so you can lift the keys straight out of it. Two traps: an
+  override has **no effect until it is committed**, and a key must match the
+  file's real extension — `main` carries a `..._c14RoundShowCardsEv.c` key for a
+  file that is `.cpp`, and that single mis-spelled key kept one member reporting
+  CREDIT CHANGED after the fold. Add the correctly-spelled key; never prune. Run the check, commit what it asks for,
   report the numbers, and move on — reconciling credit beyond that is a stated
   non-goal in this repo and has consumed whole sessions before.
 - everything else → exit 0 with no backlog count increased
@@ -436,6 +454,27 @@ already stale. Getting this wrong costs a full validation cycle.
   fails identically for `ov002/daBar_c` on untouched `main`. **Take the writer's
   pre-promotion linkcheck as the evidence.** Do not re-run it here and do not
   report its failure as a defect in the change.
+  **But do not leave the `[4b/8]` gate unverified just because `linkcheck`
+  refuses.** The object audit behind it is reachable in about a minute without a
+  linkcheck at all: `_compile_tu(entry)` -> `apply_compiler_only_policy` ->
+  `audit_tu_object` -> `object_audit_refusals`. That gives you
+  `emittedTextOrderIsRomAscending`, the LICENSED count and the refusal list
+  directly. Run it, and run it a second time with the suspect line removed as a
+  negative control — on `dScMgMemory2_c` that turned "the pragma is
+  load-bearing" from the writer's claim into the builder's measurement
+  (`order_ok True, {'LICENSED': 52}` with `#pragma defer_codegen off`;
+  `order_ok False -> object-audit-refused` with only that line deleted).
+
+- **`source_coverage --check` and `prepush_attribution` are BASE-RELATIVE, and a
+  stale base makes both scream about other people's work.** A `main` that moved
+  mid-build produced `REGRESSION: 4,672 B stopped being built from source`
+  naming five files in ov002/ov005/ov034 with nothing to do with the class, and
+  a `CREDIT LOST` for a different class entirely. Both read exactly like real
+  regressions. Re-fetch and rebase before believing either; after the rebase
+  both were clean. The same applies to `git ls-tree origin/main` — worktrees
+  share one `.git`, so another agent's fetch moves `origin/main` under you, which
+  is enough to make an existing file look deleted.
+
 - `linkcheck --baseline` is needed **only if you actually run a `linkcheck`** —
   which this role is told not to do. Running it anyway costs a full scratch
   delink and link for nothing, and `rombuild.py` runs its own baseline control

--- a/notes/agents/roles/builder.md
+++ b/notes/agents/roles/builder.md
@@ -133,9 +133,23 @@ coverage gaps** across the whole `tu_map` run. This is the highest-value check
 available on a partial and it settles the question in one pass: on
 `dScMgHanachan_c` it produced 39 `.text` blocks with exactly one gap — the
 sourceless hole — and the exact held-out shard count as a by-product. The
-supporting invariant is worth re-deriving rather than trusting: **0 of 13,201
-delink blocks and 0 of 136 TU manifests carry more than one `.text` run**, which
-is why a licensed claim cannot span a hole.
+supporting invariant is worth re-deriving rather than trusting, and it *has*
+moved: it now measures **0 of 9,998 delink blocks and 0 of 142 TU manifests**
+carrying more than one `.text` run (the 13,201 / 136 this file used to print is
+stale — promotions collapse blocks). The invariant itself holds, which is why a
+licensed claim cannot span a hole. Re-derive the counts; do not quote them.
+
+**Never read a gate's verdict through a pipe.** `python tools/X | tail -6;
+echo $?` reports **`tail`'s** exit status, not the tool's. Measured: a builder
+ran `source_coverage` that way, the tool printed its full failure banner into
+the truncated tail, `$?` came back 0, and they recorded it as green. Redirect to
+a file and echo `$?` *before* any pipe:
+`python tools/X > /tmp/x.log 2>&1; echo $?; tail -6 /tmp/x.log`. Two related
+parsing traps: `gh pr checks` output is **TAB**-separated, so `awk '{print $2}'`
+on `PR validation<TAB>pending` yields `validation` and a wait-loop exits
+immediately looking settled — use `awk -F'\t'`; and `classqueue.py claim
+--worktree` via a shell **eats backslashes**, recording
+`C:tmpsm64ds-bomroom-build`, so pass the path with forward slashes.
 
 **Diff the declared type and `extern` set against what the shipped members
 actually reference.** A twice-narrowed TU carries preamble residue for the
@@ -427,8 +441,10 @@ reports no difference.
 
 **Re-fetch `main` and re-verify more than once.** It moved twice during a single
 `daPgDfdr_c` build, and the second move landed *that class's own direct base*
-(`dBgActor_c`, #2269). Re-fetch immediately before opening the PR, not only at
-the start.
+(`dBgActor_c`, #2269). **Twice is the old rate: a later `dScMgBomroom_c` build
+saw `main` move six times**, one of them a same-overlay promotion that conflicted
+on both `attribution.json` and `notes/cpp-tu-current-state.md`. Re-fetch
+immediately before opening the PR, not only at the start.
 
 **Re-check the base immediately before you push.** The validator test-merges
 against the *exact current base* and rejects with `test merge conflicts with

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -325,6 +325,29 @@ its oracle sits one level shallower.
     rows = 2 x (ancestors + self)  +  1 vtable  +  1 per Vector3-like
                                                      member with an inline D1
 
+**A coined class name is harmless UNLESS your TU owns the key function — and
+then it is a hard blocker.** Three runs in one day reached opposite conclusions
+about renaming, and this is the reconciliation:
+
+- **Your range does not own the key function** → the TU emits no vtable and no
+  RTTI at all, so the tree's coined spelling never reaches a manifest. Keep it.
+  Renaming is a `class_rename` campaign, not a promotion. (`Goomboss` kept
+  `Goomboss` over the cartridge's `daKuriKing_c`; `Eyerok` kept `Eyerok` over
+  `daIwante_c`.)
+- **Your range does own the key function** → the TU emits `_ZTI`/`_ZTS`/`_ZTV`
+  for its own class, and those rows **must** carry the ROM's RTTI spelling.
+  `verify` refuses a coined RTTI row — it is "banked as a plain deadstrip, never
+  compared against the cartridge" — and the precedent is unanimous: **994 RTTI
+  and vtable rows across every promoted manifest, zero of them under a coined
+  name** (measured 2026-09-05 against `build/rtti.json`). There is no such thing
+  as a promoted coined class.
+
+Look the class up in `build/rtti.json` before you decide anything else, and
+expect the alias case: `symbols.txt` can carry **both** spellings at one address
+(`_ZTV10KingBobOmb` and `_ZTV12daBombking_c` at `0x02126e4c`). If you own the key
+function and hit that, say so in your report rather than renaming silently — the
+rename touches `symbols.txt` tree-wide and is a separate, reviewable decision.
+
 **The whole formula is conditional on the licensed range owning the key
 function, and this file used to state it unconditionally.** A TU that does not
 own the key function emits **no vtable and no RTTI at all** — zero rows from

--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1351,9 +1351,12 @@ def cmd_verify(args):
     if not idxs:
         pass
     elif not bad_pairs:
+        # Do not assert HOW the source is laid out here: a TU compiled with
+        # `#pragma defer_codegen off` emits in source order, so an ascending TU
+        # is ascending in the file too. Report the finding, not a guess at the
+        # cause.
         print(f"emission order    : all {len(idxs)} function(s) in the expected ROM-ascending "
-             f"section order (mwccarm reverses source order; this TU was written in reverse "
-             f"to compensate -- see the pilot report sec 3)")
+             f"section order")
     else:
         print(f"emission order    : {len(bad_pairs)} ordinal pair(s) NOT in ROM order: "
              f"{bad_pairs}  (a destructor's D0/D1/D2 group is ordered by the compiler, not "


### PR DESCRIPTION
From the `dScMgMemory2_c` builder (52 of 52, PR #2324).

**Both of this file's guesses about when `verify` writes to the manifest are now refuted.** The `status: promoted` guess went first; the replacement — "it writes only when no `partial_isolation` block exists yet" — is wrong too: this manifest has no such block and `verify` wrote nothing across 5 runs. No correlate is known, so the instruction is now to run `git status` after every verify and predict nothing.

**`cpp_tu_state.py --check-note` does not hard-fail on a dirty tree.** Measured with an unrelated unstaged change: `cpp-tu state note is current`, exit 0. The dirty-tree refusal belongs to `--write-note`, and the tool that hard-fails on an unstaged tree is `check_references.py`. The comment sat under `--check-note` and read as if it described it.

**`0 changed` is a target, not a merge bar** — the landed `dScMgHanachan_c` promotion measures `43 changed, 0 lost`, exit 1, at its own commit. Judge on `lost`. And the file told builders to "commit every required `path#symbol` mapping" without ever naming the mechanism: `attribution.json` at the repo root, `overrides` dict, key `src/<tu>.cpp#<symbol>`, rows printed verbatim by `--json`. An override has no effect until committed, and a key must match the file's real extension — `main` carries a `.c` key for a `.cpp` file, which alone kept one member reporting CREDIT CHANGED.

**`source_coverage --check` and `prepush_attribution` are base-relative, and a stale base makes both scream about other people's work** — a moved `main` produced `REGRESSION: 4,672 B stopped being built from source` naming five files in three unrelated overlays, plus a `CREDIT LOST` for a different class. Re-fetch and rebase before believing either.

**The `[4b/8]` gate is reachable without a linkcheck**, in about a minute: `_compile_tu` → `apply_compiler_only_policy` → `audit_tu_object` → `object_audit_refusals`. That is how this builder turned "the pragma is load-bearing" from the writer''s claim into a measurement with a negative control (`order_ok True, {LICENSED: 52}` with the pragma; `order_ok False → object-audit-refused` with only that line removed). Telling builders to take the writer''s linkcheck as evidence left the one hard gate unverified by the stage that decides correctness.

Also:

- `tubuild verify`''s success line asserted "this TU was written in reverse to compensate", which is false for a `defer_codegen off` TU emitting in source order. It now reports the finding without guessing the cause.
- `claim --worktree` needs forward slashes: a backslash path arrives with its separators eaten and records `C:tmpsm64ds-memory2-build`.

68 tubuild tests pass; `check_dead_references` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA