### PR TITLE
Match three ov006 curling functions from the m100 OV66 lane: stone separation for both curling games and the stylus drag update

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -2130,6 +2130,10 @@ src/func_ov006_020e1c68.c:
     complete
     .text start:0x020e1c68 end:0x020e1dc8
 
+src/func_ov006_020e1dc8.cpp:
+    complete
+    .text start:0x020e1dc8 end:0x020e20bc
+
 src/func_ov006_020e269c.c:
     complete
     .text start:0x020e269c end:0x020e26f8
@@ -2309,6 +2313,10 @@ src/func_ov006_020e4b78.c:
     complete
     .text start:0x020e4b78 end:0x020e4bd4
 
+src/func_ov006_020e4bd4.cpp:
+    complete
+    .text start:0x020e4bd4 end:0x020e4ed4
+
 src/func_ov006_020e4ed4.c:
     complete
     .text start:0x020e4ed4 end:0x020e4fe8
@@ -2320,6 +2328,10 @@ src/func_ov006_020e4fe8.c:
 src/func_ov006_020e507c.c:
     complete
     .text start:0x020e507c end:0x020e513c
+
+src/func_ov006_020e513c.cpp:
+    complete
+    .text start:0x020e513c end:0x020e5450
 
 src/func_ov006_020e59b0.c:
     complete

--- a/include/dScMgCurling2_c.h
+++ b/include/dScMgCurling2_c.h
@@ -6,6 +6,23 @@
 #define DSCMGCURLING2_C_H
 #include "dScMgBase_c.h"
 
+/* One curling stone, 0x30 bytes, eleven of them at 0x4660 (dScMgCurling_c's
+ * stone is the same record at 0x2c; this one carries four more bytes). */
+struct dScMgCurling2_stone {
+    s32 x;              /* 0x00 */
+    s32 y;              /* 0x04 */
+    s32 speed;          /* 0x08 */
+    u8  unk0c[0x1a];    /* 0x0c */
+    u16 angle;          /* 0x26 */
+    u8  state;          /* 0x28 */
+    u8  active;         /* 0x29 */
+    u8  unk2a;          /* 0x2a */
+    u8  fast;           /* 0x2b, speed >= 0x3800 after a hit */
+    u8  unk2c[0x4];     /* 0x2c */
+};
+
+typedef char dScMgCurling2_stone_size_must_be_0x30[sizeof(struct dScMgCurling2_stone) == 0x30 ? 1 : -1];
+
 struct dScMgCurling2_c : dScMgBase_c {
     virtual ~dScMgCurling2_c();
 
@@ -16,16 +33,30 @@ struct dScMgCurling2_c : dScMgBase_c {
 
     /* Slot 18 left unnamed -- same reasoning as dScMgCurling_c.h. */
 
-    u8  pad_4660[0xf20];
+    dScMgCurling2_stone mStone[11]; /* 0x4660, stride 0x30 */
+    u8  pad_4870[0xd10];
     s32 unk_5580;            /* 0x5580 */
-    u8  pad_5584[0x28];
+    s32 unk_5584;            /* 0x5584, drag x (fx32) */
+    s32 unk_5588;            /* 0x5588, drag y */
+    u8  pad_558c[0x4];
+    s32 unk_5590;            /* 0x5590, drag y at the last direction change */
+    s32 unk_5594;            /* 0x5594, drag x offset from the stylus */
+    s32 unk_5598;            /* 0x5598, drag y offset */
+    s32 unk_559c;            /* 0x559c, throw power */
+    u8  pad_55a0[0x8];
+    s32 unk_55a8;            /* 0x55a8, last drag dy */
     s32 unk_55ac;            /* 0x55ac */
-    u8  pad_55b0[0x4];
+    u8  pad_55b0[0x2];
+    u16 unk_55b2;            /* 0x55b2, throw angle */
     u16 unk_55b4;            /* 0x55b4 */
     u16 unk_55b6;            /* 0x55b6 */
-    u8  pad_55b8[0x3];
+    u8  unk_55b8;            /* 0x55b8 */
+    u8  unk_55b9;            /* 0x55b9 */
+    u8  pad_55ba[0x1];
     u8  unk_55bb;            /* 0x55bb */
-    u8  pad_55bc[0x7];
+    u8  pad_55bc[0x2];
+    u8  unk_55be;            /* 0x55be, drag phase */
+    u8  pad_55bf[0x4];
     u8  unk_55c3;            /* 0x55c3 */
 };
 

--- a/include/dScMgCurling_c.h
+++ b/include/dScMgCurling_c.h
@@ -13,6 +13,17 @@
 #define DSCMGCURLING_C_H
 #include "dScMgBase_c.h"
 
+/* One curling stone, 0x2c bytes, five of them at 0x4660. */
+struct dScMgCurling_stone {
+    s32 x;              /* 0x00 */
+    s32 y;              /* 0x04 */
+    u8  unk08[0x21];    /* 0x08 */
+    u8  active;         /* 0x29 */
+    u8  unk2a[0x2];     /* 0x2a */
+};
+
+typedef char dScMgCurling_stone_size_must_be_0x2c[sizeof(struct dScMgCurling_stone) == 0x2c ? 1 : -1];
+
 struct dScMgCurling_c : dScMgBase_c {
     /* Declared, not defined inline -- a leaf, so nothing needs to inline
        it; real body in src/_ZN11dScMgCurling_cD1Ev.cpp / _D0Ev.cpp. */
@@ -30,7 +41,8 @@ struct dScMgCurling_c : dScMgBase_c {
        documented in notes/dscene-c-siblings-census.md section 3): its
        body sets fields and calls helpers, nothing like a destructor. */
 
-    u8  pad_4660[0x84c];
+    dScMgCurling_stone mStone[5];   /* 0x4660, stride 0x2c */
+    u8  pad_473c[0x770];
     s32 unk_4eac;            /* 0x4eac */
     u8  pad_4eb0[0x28];
     s32 unk_4ed8;            /* 0x4ed8 */

--- a/src/func_ov006_020e1dc8.cpp
+++ b/src/func_ov006_020e1dc8.cpp
@@ -1,0 +1,89 @@
+//cpp
+// @symbol func_ov006_020e1dc8
+/* recovered: dScMgCurling_c stone separation, ov006 0x020e1dc8 (756 bytes).
+ * Stone idx has just moved; any other active stone within 24 units of it is
+ * pushed to 26 units away along the line between them (FX_Mul of the angle's
+ * cos/sin by 0x1a, then back to integer units), and that pushed stone is in
+ * turn checked once against the rest: the first stone it overlaps is pushed
+ * the same way, the bump sound plays, and the routine returns. Only one push
+ * per call in each direction; the outer scan stops after its first hit.
+ *
+ * What the match hinged on: the two FX_Mul results must be named (vx, vy) --
+ * inlined into the stores they cost a reloaded 0x4660 pool constant and four
+ * bytes -- and the inner scan must have its OWN dx/dy/dist/ang, declared in
+ * the loop body. Sharing the outer loop's four variables recolours the outer
+ * head (dy/dx/i-pointer rotate through r7/r8/sb). No pragma. */
+#include "dScMgCurling_c.h"
+
+extern "C" {
+extern int _ZN4cstd4sqrtEy(u64 v);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern void func_02012718(int id, int v);
+extern s16 data_02082214[];
+}
+
+extern "C" void func_ov006_020e1dc8(dScMgCurling_c *self, int idx)
+{
+    int i;
+    int j;
+    int dx;
+    int dy;
+    int dist;
+    u16 ang;
+    int k;
+
+    for (i = 0; i < 5; i++) {
+        if (self->mStone[i].active == 0) continue;
+        if (idx == i) continue;
+        dx = (self->mStone[i].x - self->mStone[idx].x) >> 12;
+        dy = (self->mStone[i].y - self->mStone[idx].y) >> 12;
+        dist = _ZN4cstd4sqrtEy((u64)(dx * dx + dy * dy));
+        ang = _ZN4cstd5atan2E5Fix12IiES1_(dy, dx);
+        if (dist > 0x18) continue;
+        {
+            int cs;
+            int sn;
+            int vx;
+            int vy;
+
+            k = (ang >> 4) * 2;
+            cs = data_02082214[k + 1];
+            vx = (int)(((long long)cs * 0x1a + 0x800) >> 12);
+            self->mStone[i].x = self->mStone[idx].x + (vx << 12);
+            sn = data_02082214[k];
+            vy = (int)(((long long)sn * 0x1a + 0x800) >> 12);
+            self->mStone[i].y = self->mStone[idx].y + (vy << 12);
+            for (j = 0; j < 5; j++) {
+                int dx2;
+                int dy2;
+                int dist2;
+                u16 ang2;
+
+                if (self->mStone[j].active == 0) continue;
+                if (i == j) continue;
+                dx2 = (self->mStone[j].x - self->mStone[i].x) >> 12;
+                dy2 = (self->mStone[j].y - self->mStone[i].y) >> 12;
+                dist2 = _ZN4cstd4sqrtEy((u64)(dx2 * dx2 + dy2 * dy2));
+                ang2 = _ZN4cstd5atan2E5Fix12IiES1_(dy2, dx2);
+                if (dist2 > 0x18) continue;
+                {
+                    int cs2;
+                    int sn2;
+                    int vx2;
+                    int vy2;
+
+                    k = (ang2 >> 4) * 2;
+                    cs2 = data_02082214[k + 1];
+                    vx2 = (int)(((long long)cs2 * 0x1a + 0x800) >> 12);
+                    self->mStone[j].x = self->mStone[i].x + (vx2 << 12);
+                    sn2 = data_02082214[k];
+                    vy2 = (int)(((long long)sn2 * 0x1a + 0x800) >> 12);
+                    self->mStone[j].y = self->mStone[i].y + (vy2 << 12);
+                    func_02012718(0xe8, self->mStone[idx].x);
+                    return;
+                }
+            }
+            return;
+        }
+    }
+}

--- a/src/func_ov006_020e4bd4.cpp
+++ b/src/func_ov006_020e4bd4.cpp
@@ -1,0 +1,125 @@
+//cpp
+// @symbol func_ov006_020e4bd4
+/* recovered: dScMgCurling2_c stylus drag update, ov006 0x020e4bd4 (768 bytes).
+ * Runs while the player drags a stone before the throw. With no touch in
+ * the current input record it just drops the drag flags. Otherwise it moves
+ * the drag point to the stylus plus the grab offset, clamps it to the rink,
+ * and bails out (restoring the old point) when the stylus moved a unit or
+ * less. The vertical direction-change tracker (unk_55be, unk_55a8,
+ * unk_5590) plays the scrape sound on the first move and flips phases on
+ * reversals; the throw angle (unk_55b2) is atan2 of the move with the
+ * horizontal halved, snapped to straight up inside [0x4000,0x8000] and to
+ * zero below, then averaged with the previous frame; the throw power
+ * (unk_559c) follows the move length times 9 with a 0xc000 cap, rising
+ * instantly and decaying by half. Finally the grab offset is recomputed
+ * from the new point and a fresh read of the input index.
+ *
+ * Both pragmas are load-bearing. The ROM shares nothing across an extended
+ * basic block that 2004/b56 would share by default: dx >> 1 is recomputed
+ * after the atan2 call and the input index is re-read at the end, so
+ * opt_common_subs is off, and every value the ROM does share is a named
+ * local here (i4, bx/by, dy2, j-free ax/ay). opt_propagation off keeps the
+ * stylus byte loads above the first store (the ROM loads both before it)
+ * and puts i4 in r4. Loading by before bx, and ay before ax, colours the
+ * two scratch pairs the ROM's way; the twin func_ov006_020e1854 in
+ * dScMgCurling_c reads the same. */
+#include "dScMgCurling2_c.h"
+#pragma opt_common_subs off
+#pragma opt_propagation off
+
+extern "C" {
+extern int _ZN4cstd4sqrtEy(u64 v);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern void func_02012718(int id, int v);
+extern u8 data_020a0e40;
+extern u8 data_020a0de8[];
+extern u8 data_020a0dea[];
+extern u8 data_020a0deb[];
+}
+
+extern "C" void func_ov006_020e4bd4(dScMgCurling2_c *self)
+{
+    u8 idx;
+    int dx;
+    int oldx;
+    int oldy;
+    int diff;
+    u16 oldAng;
+    int mag;
+    int i4;
+
+    idx = data_020a0e40;
+    i4 = idx * 4;
+    if (data_020a0de8[idx * 4] != 0) {
+        int dy2;
+        int dy;
+        u8 bx;
+        u8 by;
+
+        by = data_020a0deb[i4];
+        bx = data_020a0dea[i4];
+        oldx = self->unk_5584;
+        oldy = self->unk_5588;
+        self->unk_5584 = self->unk_5594 + (bx << 12);
+        self->unk_5588 = self->unk_5598 + (by << 12);
+        if (self->unk_5588 <= 0x94000) self->unk_5588 = 0x94000;
+        if (self->unk_5584 <= 0x20000) self->unk_5584 = 0x20000;
+        if (self->unk_5584 >= 0xe0000) self->unk_5584 = 0xe0000;
+        if (self->unk_5588 >= 0xb8000) self->unk_5588 = 0xb8000;
+        dx = (self->unk_5584 - oldx) >> 12;
+        dy = (self->unk_5588 - oldy) >> 12;
+        dy2 = dy * dy;
+        if (_ZN4cstd4sqrtEy((u64)(dx * dx + dy2)) <= 1) {
+            self->unk_5584 = oldx;
+            self->unk_5588 = oldy;
+            return;
+        }
+        diff = (self->unk_5588 - self->unk_5590) >> 12;
+        if (self->unk_55be == 0) {
+            func_02012718(0x1d6, self->unk_5584);
+            self->unk_55be = 2;
+            self->unk_55a8 = (self->unk_5588 - self->unk_5590) >> 12;
+            self->unk_5590 = self->unk_5588;
+        } else if (self->unk_55be == 1) {
+            if (self->unk_55a8 * diff > 0) {
+                if (diff < 0) diff = -diff;
+                if (diff >= 0xa) self->unk_55be = 0;
+            } else {
+                self->unk_55a8 = diff;
+                self->unk_5590 = self->unk_5588;
+            }
+        } else {
+            if (self->unk_55a8 * diff < 0) self->unk_55be = 1;
+            self->unk_55a8 = (self->unk_5588 - self->unk_5590) >> 12;
+            self->unk_5590 = self->unk_5588;
+        }
+        oldAng = self->unk_55b2;
+        self->unk_55b2 = _ZN4cstd5atan2E5Fix12IiES1_(dy, dx >> 1);
+        {
+            u16 a = self->unk_55b2;
+
+            if (a <= 0x8000 && a >= 0x4000) {
+                self->unk_55b2 = 0x8000;
+            } else if (a <= 0x4000) {
+                self->unk_55b2 = 0;
+            }
+        }
+        self->unk_55b2 = (self->unk_55b2 + oldAng) >> 1;
+        mag = _ZN4cstd4sqrtEy((u64)((dx >> 1) * (dx >> 1) + dy2)) * 9;
+        mag = (mag << 12) >> 4;
+        if (mag >= 0xc000) mag = 0xc000;
+        if (mag > self->unk_559c) self->unk_559c = mag;
+        if (self->unk_559c > mag) self->unk_559c -= (self->unk_559c - mag) >> 1;
+        {
+            int j = data_020a0e40;
+            int ay = (self->unk_5588 >> 12) - data_020a0deb[j * 4];
+            int ax = (self->unk_5584 >> 12) - data_020a0dea[j * 4];
+
+            self->unk_5594 = ax << 12;
+            self->unk_5598 = ay << 12;
+        }
+        return;
+    }
+    self->unk_55b8 = 0;
+    self->unk_55b9 = 1;
+}

--- a/src/func_ov006_020e513c.cpp
+++ b/src/func_ov006_020e513c.cpp
@@ -1,0 +1,86 @@
+//cpp
+// @symbol func_ov006_020e513c
+/* recovered: dScMgCurling2_c stone separation, ov006 0x020e513c (788 bytes).
+ * The two-player rink's twin of func_ov006_020e1dc8: eleven stones at a
+ * 0x30 stride instead of five at 0x2c, and after the bump sound the pushed
+ * pair is handed to func_ov006_020e39e0. Everything else, including the
+ * two levers that closed the Curling version (named vx/vy, the inner scan's
+ * own dx2/dy2/dist2/ang2 declared in the loop body), carries over verbatim.
+ * The extra live idx/i for the trailing call is what moves k out of fp and
+ * spills the 0x800 constant; the compiler does that on its own. */
+#include "dScMgCurling2_c.h"
+
+extern "C" {
+extern int _ZN4cstd4sqrtEy(u64 v);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern void func_02012718(int id, int v);
+extern void func_ov006_020e39e0(dScMgCurling2_c *self, int a, int b);
+extern s16 data_02082214[];
+}
+
+extern "C" void func_ov006_020e513c(dScMgCurling2_c *self, int idx)
+{
+    int i;
+    int j;
+    int dx;
+    int dy;
+    int dist;
+    u16 ang;
+    int k;
+
+    for (i = 0; i < 11; i++) {
+        if (self->mStone[i].active == 0) continue;
+        if (idx == i) continue;
+        dx = (self->mStone[i].x - self->mStone[idx].x) >> 12;
+        dy = (self->mStone[i].y - self->mStone[idx].y) >> 12;
+        dist = _ZN4cstd4sqrtEy((u64)(dx * dx + dy * dy));
+        ang = _ZN4cstd5atan2E5Fix12IiES1_(dy, dx);
+        if (dist > 0x18) continue;
+        {
+            int cs;
+            int sn;
+            int vx;
+            int vy;
+
+            k = (ang >> 4) * 2;
+            cs = data_02082214[k + 1];
+            vx = (int)(((long long)cs * 0x1a + 0x800) >> 12);
+            self->mStone[i].x = self->mStone[idx].x + (vx << 12);
+            sn = data_02082214[k];
+            vy = (int)(((long long)sn * 0x1a + 0x800) >> 12);
+            self->mStone[i].y = self->mStone[idx].y + (vy << 12);
+            for (j = 0; j < 11; j++) {
+                int dx2;
+                int dy2;
+                int dist2;
+                u16 ang2;
+
+                if (self->mStone[j].active == 0) continue;
+                if (i == j) continue;
+                dx2 = (self->mStone[j].x - self->mStone[i].x) >> 12;
+                dy2 = (self->mStone[j].y - self->mStone[i].y) >> 12;
+                dist2 = _ZN4cstd4sqrtEy((u64)(dx2 * dx2 + dy2 * dy2));
+                ang2 = _ZN4cstd5atan2E5Fix12IiES1_(dy2, dx2);
+                if (dist2 > 0x18) continue;
+                {
+                    int cs2;
+                    int sn2;
+                    int vx2;
+                    int vy2;
+
+                    k = (ang2 >> 4) * 2;
+                    cs2 = data_02082214[k + 1];
+                    vx2 = (int)(((long long)cs2 * 0x1a + 0x800) >> 12);
+                    self->mStone[j].x = self->mStone[i].x + (vx2 << 12);
+                    sn2 = data_02082214[k];
+                    vy2 = (int)(((long long)sn2 * 0x1a + 0x800) >> 12);
+                    self->mStone[j].y = self->mStone[i].y + (vy2 << 12);
+                    func_02012718(0xe8, self->mStone[idx].x);
+                    func_ov006_020e39e0(self, idx, i);
+                    return;
+                }
+            }
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Three ov006 functions from the m100 OV66 lane, all byte-exact under the pinned mwccarm 2004/b56. Two of them are the stone separation step for the one-player and two-player curling minigames; the third is the stylus drag update that aims and powers a throw in the two-player game.

| function | address | size | provenance |
| --- | --- | --- | --- |
| `func_ov006_020e1dc8` | 0x020e1dc8 | 0x2f4 | dScMgCurling_c stone separation: the stone that just moved pushes any other active stone within 24 units out to 26, and that pushed stone is checked once against the rest. |
| `func_ov006_020e513c` | 0x020e513c | 0x314 | dScMgCurling2_c stone separation: the same routine for the eleven-stone rink at a 0x30 stride, with the bumped pair handed on to func_ov006_020e39e0. |
| `func_ov006_020e4bd4` | 0x020e4bd4 | 0x300 | dScMgCurling2_c stylus drag update: moves and clamps the drag point, tracks vertical direction changes for the scrape sound, and derives the throw angle and power. |

Byte gate, strict, one version each:

```
func_ov006_020e1dc8 0x020e1dc8 0x2f4  MATCHING VERSIONS: 2004/b56
func_ov006_020e513c 0x020e513c 0x314  MATCHING VERSIONS: 2004/b56
func_ov006_020e4bd4 0x020e4bd4 0x300  MATCHING VERSIONS: 2004/b56
```

Both headers gained fields, so every other source that includes them was re-run at its own address and size. All twelve still match:

```
_ZN14dScMgCurling_cD1Ev              0x020e0638 0x24   MATCHING VERSIONS: 2004/b56
_ZN14dScMgCurling_cD0Ev              0x020e065c 0x38   MATCHING VERSIONS: 2004/b56
_ZN14dScMgCurling_c13OnYoshiTryEatEi 0x020e3470 0x7c   MATCHING VERSIONS: 2004/b56
_ZN14dScMgCurling_c6RenderEv         0x020e34ec 0x3c   MATCHING VERSIONS: 2004/b56
_ZN14dScMgCurling_c8BehaviorEv       0x020e3528 0x50   MATCHING VERSIONS: 2004/b56
_ZN14dScMgCurling_c13InitResourcesEv 0x020e3578 0x2a8  MATCHING VERSIONS: 2004/b56
_ZN15dScMgCurling2_cD1Ev              0x020e3854 0x24  MATCHING VERSIONS: 2004/b56
_ZN15dScMgCurling2_cD0Ev              0x020e3878 0x38  MATCHING VERSIONS: 2004/b56
_ZN15dScMgCurling2_c13OnYoshiTryEatEi 0x020e6774 0x7c  MATCHING VERSIONS: 2004/b56
_ZN15dScMgCurling2_c6RenderEv         0x020e67f0 0x4c  MATCHING VERSIONS: 2004/b56
_ZN15dScMgCurling2_c8BehaviorEv       0x020e683c 0x58  MATCHING VERSIONS: 2004/b56
_ZN15dScMgCurling2_c13InitResourcesEv 0x020e6894 0x360 MATCHING VERSIONS: 2004/b56
```

Link check over the branch range:

```
prepush-linkcheck: 15 checked - 15 verified, 0 warning(s), 0 blocking
```

Ratchets and audits, no deltas to report:

```
langmode ratchet PASS
duplicate-sources: 10096 stems, none doubled
check_src_tu: 32 translation unit(s), 323 include(s), 802 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.
check_header_offsets: 2 changed header(s) vs origin/main
include/dScMgCurling2_c.h: 18 commented fields, 0 mismatched, 0 unparsed, struct spans 0x55c4
include/dScMgCurling_c.h: 6 commented fields, 0 mismatched, 0 unparsed, struct spans 0x4eec
check_references: unresolved symbols 42 (baseline 45), eligible 11122 (baseline 11044), OK: no new unresolvable references
python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll: Ran 80 tests, OK
```

Enrollment, three entries in `config/arm9/overlays/ov006/delinks.txt` so the ROM build compiles these sources instead of taking the original bytes:

```
src/func_ov006_020e1dc8.cpp:  complete  .text start:0x020e1dc8 end:0x020e20bc
src/func_ov006_020e4bd4.cpp:  complete  .text start:0x020e4bd4 end:0x020e4ed4
src/func_ov006_020e513c.cpp:  complete  .text start:0x020e513c end:0x020e5450
```

enroll.py over the full eligible list also wanted promotions in arm9, ov001, ov002, ov006, ov007 and ov063, a blank-line cleanup in ov006 and the usual ov070 reorder. That is unrelated drift and was reverted, leaving only the three hunks. No symbol sizes changed.

Header work: `dScMgCurling_c.h` gains the 0x2c-byte stone record at 0x4660 (five of them) and `dScMgCurling2_c.h` the 0x30-byte record at the same offset (eleven of them, plus the drag point, offsets, phase, angle and power fields around 0x5580). Both records replace padding inside the existing spans, so the field offsets and the struct size asserts are unchanged, and check_header_offsets confirms 0 mismatched fields in each.

Near-miss seeds from this lane, and the pruning of the three rows these matches close, follow in a separate database pull request so this one leaves `nearmiss/db.jsonl` alone.
