### PR TITLE
Inlining the destructor can create the coined-name refusal out of nothing

### DIFF
--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -266,7 +266,27 @@ long omitted:
 A cross-module home does *not* by itself send a symbol to `externalized_output`:
 what matters is whether the address has a **configured ROM home** in some
 module's `symbols.txt`. If it does — even in another overlay — it is
-`deadstrip-data` and it promotes. The promoted precedent `ov029/daObjWcObj01_c`
+`deadstrip-data` and it promotes.
+
+**But "the address has a home" is the wrong test, and this file stated it as the
+right one.** `apply_compiler_only_policy` (`tools/tubuild.py:2280`) resolves a
+row's home through `all_symbol_homes()`, which is **keyed on the `symbols.txt`
+spelling, not the address**. Measured on ov062/`Koopa`: `_ZTI5Koopa`'s record
+sits at a fully configured ov062 address — `0x0211da68` — and was refused
+anyway, because the cartridge configures it as `_ZTI8daNknk_c`. `tubuild.py`'s
+own comment at `:2264` says it outright: *"`homes` is keyed on the symbols.txt
+spelling while `_ZTI`/`_ZTS` are LENGTH-PREFIXED mangled strings — a coined name
+misses on both the prefix and the body, and the miss reads as 'the ROM has no
+such record'."*
+
+So read the rule as **spelled-the-cartridge's-way vs. not**, and expect it to
+bite exactly one class of symbol: a coined class's own `_ZTI`/`_ZTS`, in a TU
+that owns the key function. `_ZTV` frequently escapes because somebody added a
+coined alias row for it — honest for a vtable, and **not available for `_ZTS`**,
+whose *content* is the length-prefixed name (`"5Koopa"` where the cartridge
+holds `"8daNknk_c"`). Three separate classes hit this in one day (`Koopa`,
+`Scuttlebug`, `KingBobOmb`); `class_rename.py` counts **125** in this state. The
+unblock is the rename, as its own change. The promoted precedent `ov029/daObjWcObj01_c`
 carries an **empty** `externalized_output` and licenses all 13 of its RTTI
 records as `deadstrip-data`.
 

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -342,6 +342,35 @@ about renaming, and this is the reconciliation:
   name** (measured 2026-09-05 against `build/rtti.json`). There is no such thing
   as a promoted coined class.
 
+**And the inline-destructor lever can CREATE this blocker out of nothing.**
+Inlining moves the key function to the first out-of-line virtual declared. On
+ov071/`Scuttlebug` that pulled the key function *into* the claimed range — which
+is what the writer wanted for emission order, and it is also what turned a
+harmless coined name into a hard refusal. The TU then emitted
+`_ZTI10Scuttlebug` / `_ZTS10Scuttlebug`, which no `symbols.txt` anywhere names,
+and both dispositions refuse:
+
+    deadstrip-data -> "declared compiler-only data but has no configured ROM
+                       home; a homeless object is a plain deadstrip"
+    deadstrip      -> "an RTTI/vtable record banked as a plain deadstrip, which
+                       is never compared against the cartridge. If the class
+                       carries a coined name, rename it to the cartridge's RTTI
+                       spelling..."
+
+Result: `verify` 37/37 MATCH, TEXT-VERIFIED, **PROMOTION REFUSED** on two
+symbols. So before you reach for the inline destructor, check whether the class
+name is coined — the two levers interact, and `class_rename.py` reports **125
+classes** sitting in this state. Note the vtable often escapes because
+`symbols.txt` already aliases `_ZTV` under both spellings; nobody did the same
+for `_ZTI`/`_ZTS`.
+
+**Do not "fix" this by adding an alias, and understand why the temptation is
+dangerous: faking it passes every gate you can run locally.** `deadstrip-data`'s
+home check is a **name lookup**, and the byte comparison is deferred to
+`rombuild`. Giving `_ZTS10Scuttlebug` a home address would produce a green
+`verify` and a genuine 13-versus-12-byte mismatch downstream. The refusal is
+correct; the fix is the rename, as its own reviewable change.
+
 Look the class up in `build/rtti.json` before you decide anything else, and
 expect the alias case: `symbols.txt` can carry **both** spellings at one address
 (`_ZTV10KingBobOmb` and `_ZTV12daBombking_c` at `0x02126e4c`). If you own the key
@@ -452,6 +481,23 @@ mwccarm 2004/b56 behaviours, not style preferences.
   are not in ROM-ascending order: `licensed .text functions are not emitted in
   ROM address order`. Beware that `tubuild verify` reports the same condition as
   `PARTIAL ... not necessarily a bug`, which reads advisory and is not.
+
+  **And `verify`'s exit code carries no verdict about promotability.** It is
+  `return 0 if text_verified else 1` — so a run that prints `PROMOTION REFUSED`,
+  for unlicensed output or a compiler-only policy refusal, still **exits 0**.
+  Only a compile failure or a byte/reloc failure gives 1. Read the console text;
+  never gate on `$?` alone here. (Measured on ov071/`Scuttlebug`: two refused
+  runs, both exit 0.)
+
+  **Two more things that run does not say out loud.** The manifest's
+  `verification.criteria` records the **pre-policy** unlicensed count while the
+  console prints the post-policy one — `FAIL-BY-DESIGN -- 10 unlicensed
+  section/symbol(s)` in the file against `2 unlicensed section/symbol(s)` on
+  screen, after 8 were licensed. It is deterministic wording, not drift (a
+  re-run produced a byte-identical manifest), but a reader trusting the manifest
+  sees five times the real number. And it is **`linkcheck`**, not `verify`, that
+  was observed rewriting the manifest here — it adds a `verification.linkcheck`
+  block, and it can race your `git add`.
 
   The destructor pair is the usual way to hit it. Under **default** codegen the
   lever set is closed — measured, not guessed: **inline in class ⇒ D1 then D0,


### PR DESCRIPTION
From the ov071/`Scuttlebug` writer: **37/37 MATCH, TEXT-VERIFIED, PROMOTION REFUSED.**

Yesterday''s rule said a coined class name is harmless unless the TU owns the key function. This run shows the two levers interact. **Inlining the destructor moves the key function to the first out-of-line virtual declared** — which pulled it *into* the claimed range. That was the emission-order fix the writer wanted, and it is also what turned a harmless coined name into a hard refusal: the TU then emitted `_ZTI10Scuttlebug` / `_ZTS10Scuttlebug`, which no `symbols.txt` anywhere names, and both dispositions refuse.

So check whether the class name is coined **before** reaching for the inline destructor. `class_rename.py` reports **125 classes** sitting in this state. (The vtable often escapes because `symbols.txt` already aliases `_ZTV` under both spellings; nobody did the same for `_ZTI`/`_ZTS`.)

**And do not "fix" it with an alias.** `deadstrip-data`''s home check is a **name lookup**, and the byte comparison is deferred to `rombuild` — so giving `_ZTS10Scuttlebug` a home address produces a green `verify` and a genuine 13-versus-12-byte mismatch downstream. Faking it passes every gate a writer can run locally.

**`verify`''s exit code carries no verdict about promotability.** It is `return 0 if text_verified else 1`, so a run that prints `PROMOTION REFUSED` — for unlicensed output or a compiler-only policy refusal — still **exits 0**. Two refused runs measured, both exit 0. Together with the pipe trap landed earlier today, that is two independent ways to record a refusal as green.

I have **not** changed that exit code in this PR. Making `verify` exit non-zero on a refusal looks right to me, but it is a behaviour change to a shared gate with several builders mid-run, so it belongs in its own deliberate change rather than riding along with a docs fix.

Also recorded:

- The manifest''s `verification.criteria` reports the **pre-policy** unlicensed count (`FAIL-BY-DESIGN -- 10 unlicensed section/symbol(s)`) while the console reports the post-policy one (`2`), after 8 were licensed. Deterministic wording, not drift — a re-run produced a byte-identical manifest.
- It is **`linkcheck`**, not `verify`, that was observed rewriting the manifest here; it adds a `verification.linkcheck` block and can race your `git add`.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA