### PR TITLE
Match the ov006 Panel layout pass and repair two counted minigame files that had drifted from the ROM

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -3814,6 +3814,7 @@ src/func_ov006_02103bfc.c:
     .text start:0x02103bfc end:0x02103cbc
 
 src/_ZN16dScMgPachinko2_c13OnYoshiTryEatEi.cpp:
+    complete
     .text start:0x02103cbc end:0x02103d28
 
 src/_ZN16dScMgPachinko2_c6RenderEv.cpp:
@@ -4027,6 +4028,10 @@ src/func_ov006_02106048.c:
 src/func_ov006_02106080.c:
     complete
     .text start:0x02106080 end:0x02106168
+
+src/func_ov006_02106168.cpp:
+    complete
+    .text start:0x02106168 end:0x021063a0
 
 src/func_ov006_021063a0.cpp:
     complete
@@ -5118,6 +5123,7 @@ src/_ZN13dScMgTeresa_c9Virtual50Ev.cpp:
     .text start:0x02120238 end:0x02120248
 
 src/_ZN13dScMgTeresa_c13OnYoshiTryEatEi.cpp:
+    complete
     .text start:0x02120248 end:0x02120348
 
 src/_ZN13dScMgTeresa_c6RenderEv.cpp:

--- a/include/dScMgPanel_c.h
+++ b/include/dScMgPanel_c.h
@@ -30,11 +30,20 @@ struct dScMgPanel_c : dScMgBase_c {
     s32 unk_4cac;            /* 0x4cac */
     s32 unk_4cb0;            /* 0x4cb0 */
     s32 unk_4cb4;            /* 0x4cb4 */
-    s32 unk_4cb8;            /* 0x4cb8 */
-    u8  pad_4cbc[0x208];
+    s32 unk_4cb8;            /* 0x4cb8 -- panel count (<= 0x24) */
+    s32 unk_4cbc;            /* 0x4cbc -- layout index + 4 */
+    s32 unk_4cc0;            /* 0x4cc0 -- pick count (<= 0x30) */
+    s32 unk_4cc4[0x24];      /* 0x4cc4 -- panel x, Fix12, from the layout table */
+    s32 unk_4d54[0x24];      /* 0x4d54 -- panel y, Fix12, from the layout table */
+    u8  pad_4de4[0xe0];
     s16 unk_4ec4;            /* 0x4ec4 */
     u8  pad_4ec6[0x34];
-    u8  unk_4efa[0xe5];      /* 0x4efa */
+    u8  unk_4efa[0x24];      /* 0x4efa -- panel kind, indexed below unk_4cb8 */
+    u8  unk_4f1e[0x24];      /* 0x4f1e -- panel face, from the face table */
+    u8  unk_4f42[0x24];      /* 0x4f42 -- panel face copy, flipped by picks */
+    u8  pad_4f66[0x48];
+    u8  unk_4fae[0x30];      /* 0x4fae -- picked panel indices */
+    u8  unk_4fde;            /* 0x4fde -- number of picks so far */
     u8  unk_4fdf;            /* 0x4fdf */
     u8  pad_4fe0[0x2];
     u8  unk_4fe2;            /* 0x4fe2 */

--- a/src/_ZN13dScMgTeresa_c13OnYoshiTryEatEi.cpp
+++ b/src/_ZN13dScMgTeresa_c13OnYoshiTryEatEi.cpp
@@ -25,8 +25,11 @@ void dScMgTeresa_c::OnYoshiTryEat(int reset)
 
     volatile unsigned short val;
     if (reset == 0) {
-        unsigned int v = *(unsigned int*)(self + 0xbc) + 1;
-        *(unsigned int*)(self + 0xbc) = v;
+        /* `const` on the read is load-bearing: without it mwcc CSEs the +0xbc
+           field address into its own register (add r2,r4,#0xbc / ldr [r2] /
+           str [r2]) and the function grows a word; the cartridge re-issues
+           ldr r1,[r4,#0xbc]. Same lever as dScMgHanachan_c::OnYoshiTryEat. */
+        *(unsigned int*)(self + 0xbc) = *(const unsigned int*)(self + 0xbc) + 1;
         if (*(unsigned int*)(self + 0xbc) > 0x270e)
             *(unsigned int*)(self + 0xbc) = 0x270e;
     } else {

--- a/src/_ZN16dScMgPachinko2_c13OnYoshiTryEatEi.cpp
+++ b/src/_ZN16dScMgPachinko2_c13OnYoshiTryEatEi.cpp
@@ -9,19 +9,26 @@
    declaration exactly, or mwcc appends a slot instead of overriding. */
 extern "C" {
 extern void FreeGfxSlotsById(int n);
+extern void func_ov006_02103bfc(char *c);
 }
+
 void dScMgPachinko2_c::OnYoshiTryEat(int n)
 {
-    char *c = (char *)this;
+    /* The score increment reads unk_0bc through a const view of `this`.
+       Without it mwcc CSEs the +0xbc field address into its own register
+       (add r2,r4,#0xbc / ldr [r2] / str [r2]) and the function grows a
+       word; the cartridge re-issues ldr r1,[r4,#0xbc] / str r1,[r4,#0xbc].
+       Same lever as dScMgHanachan_c::OnYoshiTryEat. */
+    const dScMgPachinko2_c *ro = this;
 
-    *(int*)(c+0x5000+0x660) = 0;
-    if(n == 0x10){
-        *(int*)(c+0xbc) = *(int*)(c+0xbc) + 1;
-        if(*(unsigned int*)(c+0xbc) > 0x270e) *(int*)(c+0xbc) = 0x270e;
+    unk_5660 = 0;
+    if (n == 0x10) {
+        unk_0bc = ro->unk_0bc + 1;
+        if (unk_0bc > 0x270e) unk_0bc = 0x270e;
     } else {
-        *(int*)(c+0xbc) = 0;
-        if(*(unsigned int*)(c+0xbc) > 0x270e) *(int*)(c+0xbc) = 0x270e;
+        unk_0bc = 0;
+        if (unk_0bc > 0x270e) unk_0bc = 0x270e;
     }
     FreeGfxSlotsById(0x1d);
-    func_ov006_02103bfc(c);
+    func_ov006_02103bfc((char *)this);
 }

--- a/src/func_ov006_02106168.cpp
+++ b/src/func_ov006_02106168.cpp
@@ -1,0 +1,82 @@
+//cpp
+/* dScMgPanel_c layout pass: reads the panel layout (x/y from the layout tables,
+   face from the face table picked by Virtual8C), draws unk_4cc0 random picks
+   through func_ov006_02106080, and retries the whole thing until
+   func_ov006_02106664 accepts it, at least one panel face differs from its
+   copy, and no two picks are the same panel.
+
+   Register shape: the loop-1 counter and the loop-2 counter are DIFFERENT
+   locals (i, j); a single `i` for both loops colours out of the callee-saved
+   band (r5) no matter where it is declared. With them split, the declaration
+   order i, v, cnt2, j, cnt1, pd, pe is what puts i and j on r7, v on sb, cnt2
+   on r8, cnt1 on r6 and the ded0 table pointer on r5; every other slot for j
+   rotates loop 2 or loop 1. The pd/pe pointer locals keep the byte tables
+   hoisted above the do-loop and the [idx4] reload inside it. */
+#include "dScMgPanel_c.h"
+
+extern "C" {
+int RandomIntInternal(int *seed);
+extern int data_0209d4b8;
+void func_ov006_02106080(dScMgPanel_c *self, int x);
+int func_ov006_02106664(dScMgPanel_c *self);
+extern u16 *data_ov006_0213dd4c[];
+extern u16 *data_ov006_0213dd58[];
+extern u8 *data_ov006_0213ded0[];
+extern u8 *data_ov006_0213e070[];
+}
+
+extern "C" void func_ov006_02106168(dScMgPanel_c *self)
+{
+    int i;
+    int v;
+    int cnt2;
+    int j;
+    int cnt1;
+    u8 **pd;
+    u8 **pe;
+    int mismatch, dup, a, b, k;
+    do {
+        self->unk_4fde = 0;
+        for (i = 0; i < (cnt1 = self->unk_4cb8); i++) {
+            int m = self->unk_4cbc - 4;
+            int idx4 = self->unk_4cb4;
+            self->unk_4cc4[i] = data_ov006_0213dd4c[m][i] << 12;
+            self->unk_4d54[i] = data_ov006_0213dd58[m][i] << 12;
+            pe = data_ov006_0213e070;
+            pd = data_ov006_0213ded0;
+            if (self->Virtual8C()) {
+                self->unk_4f1e[i] = pd[idx4][i];
+                self->unk_4f42[i] = pd[idx4][i];
+            } else {
+                self->unk_4f1e[i] = pe[idx4][i];
+                self->unk_4f42[i] = pe[idx4][i];
+            }
+        }
+        cnt2 = self->unk_4cc0;
+        for (j = 0; j < cnt2; j++) {
+            u32 rnd = (u32)RandomIntInternal(&data_0209d4b8);
+            u32 s = (rnd >> 16) & 0x7fff;
+            v = (cnt1 * s) >> 15;
+            func_ov006_02106080(self, v);
+            self->unk_4fae[self->unk_4fde] = v;
+            self->unk_4fde++;
+        }
+        mismatch = 0;
+        for (k = 0; k < self->unk_4cb8; k++) {
+            if (self->unk_4f1e[k] != self->unk_4f42[k]) {
+                mismatch++;
+                break;
+            }
+        }
+        dup = 0;
+        for (a = 0; a < cnt2; a++) {
+            for (b = a + 1; b < cnt2; b++) {
+                if (self->unk_4fae[a] == self->unk_4fae[b]) {
+                    dup++;
+                    break;
+                }
+            }
+        }
+        if (dup != 0) mismatch = 0;
+    } while (func_ov006_02106664(self) == 0 || mismatch == 0);
+}

--- a/src/func_ov006_02106168.cpp
+++ b/src/func_ov006_02106168.cpp
@@ -1,4 +1,5 @@
 //cpp
+// @symbol func_ov006_02106168
 /* dScMgPanel_c layout pass: reads the panel layout (x/y from the layout tables,
    face from the face table picked by Virtual8C), draws unk_4cc0 random picks
    through func_ov006_02106080, and retries the whole thing until


### PR DESCRIPTION
Three ov006 changes. One is a new match in the panel minigame's layout code. The other two are
repairs: both files already counted on main, but neither reproduced its ROM function any more, so
the count was claiming bytes the compiler could not actually produce.

| Function | Address | Size | What changed |
| --- | --- | --- | --- |
| `dScMgPanel_c` layout pass, `func_ov006_02106168` | 0x02106168 | 0x238 | NEW MATCH |
| `dScMgPachinko2_c::OnYoshiTryEat` | 0x02103cbc | 0x6c | REPAIR: main compiled 0x70, now 0x6c |
| `dScMgTeresa_c::OnYoshiTryEat` | 0x02120248 | 0x100 | REPAIR: main compiled 0x104, now 0x100 |

Byte gate, strict, at the pinned compiler:

```
_ZN16dScMgPachinko2_c13OnYoshiTryEatEi 0x02103cbc 0x6c   MATCHING VERSIONS: 2004/b56
func_ov006_02106168                    0x02106168 0x238  MATCHING VERSIONS: 2004/b56
_ZN13dScMgTeresa_c13OnYoshiTryEatEi    0x02120248 0x100  MATCHING VERSIONS: 2004/b56
```

The lever behind both repairs: reading the score field through a const view of `this` while the same
field is being incremented stops mwcc from folding the field address into its own register, so the
function keeps the cartridge's `ldr` / `str` pair off the object pointer instead of growing a word.

`include/dScMgPanel_c.h` splits the old 0x4cbc-0x4fde padding into the fields the layout pass reads
(panel count, layout index, pick count, the two Fix12 coordinate arrays, the kind/face/face-copy byte
arrays, and the pick list). Every other source file that includes that header re-verifies at its
`symbols.txt` address and size:

```
_ZN12dScMgPanel_c13InitResourcesEv 0x021073b0 0x4a8 -> (True, '2004/b56')
_ZN12dScMgPanel_c13OnYoshiTryEatEi 0x021071fc 0x110 -> (True, '2004/b56')
_ZN12dScMgPanel_c6RenderEv         0x0210730c 0x4c  -> (True, '2004/b56')
_ZN12dScMgPanel_c8BehaviorEv       0x02107358 0x58  -> (True, '2004/b56')
_ZN12dScMgPanel_cD0Ev              0x021042b0 0x38  -> (True, '2004/b56')
_ZN12dScMgPanel_cD1Ev              0x0210428c 0x24  -> (True, '2004/b56')
func_ov006_02106fdc                0x02106fdc 0xc0  -> (True, '2004/b56')
```

`check_header_offsets.py --changed origin/main`: 19 commented fields, 0 mismatched, 0 unparsed,
struct spans 0x4feb.

Link check over the range:

```
prepush-linkcheck: 22 checked - 22 verified, 0 warning(s), 0 blocking
```

Ratchets:

```
langmode ratchet PASS                       (no deltas)
check_references: unresolved symbols 42 (baseline 45), eligible 11122 (baseline 11044)
                  OK: no new unresolvable references
duplicate-sources: 10094 stems, none doubled
check_src_tu: 32 translation units, 323 includes, 802 mangled references, every reference resolves
tools.test_srcpath + tools.test_bytegate + tools.test_enroll: Ran 80 tests, OK
```

Enrollment in `config/arm9/overlays/ov006/delinks.txt`, three entries now `complete`, so the ROM build
byte-verifies all three from here on:

```
src/_ZN16dScMgPachinko2_c13OnYoshiTryEatEi.cpp:
    complete
    .text start:0x02103cbc end:0x02103d28

src/func_ov006_02106168.cpp:
    complete
    .text start:0x02106168 end:0x021063a0

src/_ZN13dScMgTeresa_c13OnYoshiTryEatEi.cpp:
    complete
    .text start:0x02120248 end:0x02120348
```

No symbol sizes changed; `symbols.txt` already carried 0x6c and 0x100 for the two repaired functions.

A sweep turned up more counted files in the same shape, compiling to a different length than the ROM
function they claim; those repairs follow in separate pull requests.
