### PR TITLE
Repair the last six counted files that had drifted from the ROM: the Luigi board family and the multiboot parent block

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -11143,6 +11143,7 @@ src/func_02065f78.c:
     .text start:0x02065f78 end:0x0206610c
 
 src/func_0206610c.c:
+    complete
     .text start:0x0206610c end:0x020662c0
 
 src/func_020662c0.c:

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -2956,18 +2956,23 @@ src/func_ov006_020f15ac.cpp:
     .text start:0x020f15ac end:0x020f17fc
 
 src/func_ov006_020f17fc.c:
+    complete
     .text start:0x020f17fc end:0x020f192c
 
 src/func_ov006_020f192c.c:
+    complete
     .text start:0x020f192c end:0x020f1a70
 
 src/func_ov006_020f1a70.c:
+    complete
     .text start:0x020f1a70 end:0x020f1b98
 
 src/func_ov006_020f1b98.c:
+    complete
     .text start:0x020f1b98 end:0x020f1cb4
 
 src/func_ov006_020f1cb4.c:
+    complete
     .text start:0x020f1cb4 end:0x020f1dbc
 
 src/func_ov006_020f1dbc.c:

--- a/include/private/arm9_a9db8_mb_parent.h
+++ b/include/private/arm9_a9db8_mb_parent.h
@@ -1,0 +1,41 @@
+#ifndef ARM9_A9DB8_MB_PARENT_H
+#define ARM9_A9DB8_MB_PARENT_H
+#include "types.h"
+
+/* The wireless-download parent work block that data_020a9db8 points at
+ * (arm9 func_02065c2c .. func_02069994). Only the fields those functions
+ * read are placed; everything else is padding at its measured offset.
+ *
+ * Message types 3/4 sent and 7/8/9 received, fifteen per-child state words
+ * at 0x14e8 and the sixteen-entry file table below are the NitroSDK
+ * multiboot (MB) parent layout, so the names follow that role without
+ * claiming the SDK's own identifiers. */
+
+typedef struct MbParentFile {
+    u8  mHeader[0x59c];   /* 0x000 -- download info; func_020662c0 sends 0xe4 of
+                             it, func_02067530 reads three 16-byte segment rows
+                             at +0xc */
+    u8  mBlockTable[0x14];/* 0x59c -- 3 segment addresses, 3 head block numbers,
+                             block count (func_02067530) */
+    u8  pad_5b0[0x4];
+    s32 mSrcAddr;         /* 0x5b4 -- added to a block's offset before CpuCopy8 */
+    u16 mCurrentBlock;    /* 0x5b8 -- block number being sent */
+    u16 unk_5ba;          /* 0x5ba -- func_02065f08 keeps mCurrentBlock within
+                             two of it */
+    u16 mChildBitmap;     /* 0x5bc -- children waiting on this file */
+    u8  pad_5be[0x4];
+    u8  mActive;          /* 0x5c2 -- nonzero once the file is registered */
+    u8  pad_5c3[0x1];
+} MbParentFile;
+
+typedef char MbParentFile_size_must_be_0x5c4[sizeof(MbParentFile) == 0x5c4 ? 1 : -1];
+
+typedef struct MbParentWork {
+    u8  pad_0000[0x1524];
+    u8  unk_1524;         /* 0x1524 -- zero means nothing to send */
+    u8  mCurrentFile;     /* 0x1525 -- mFiles index, stepped mod 16 per send */
+    u8  pad_1526[0x1788 - 0x1526];
+    MbParentFile mFiles[16]; /* 0x1788 */
+} MbParentWork;
+
+#endif

--- a/src/func_0206610c.c
+++ b/src/func_0206610c.c
@@ -1,9 +1,22 @@
+/* Wireless-download parent send step, arm9 0x0206610c (0x1b4 bytes). Steps
+ * the current file index mod 16 up to sixteen times looking for a registered
+ * file with children waiting on it, fetches the block to send through
+ * func_02067530, writes a type-4 record header, copies the block after it,
+ * and hands the packet to func_02067f2c.
+ *
+ * Typed access through private/arm9_a9db8_mb_parent.h is the match under
+ * 2004/b56. The raw char* form this replaces pooled the whole 0x1525 address
+ * once the byte was read from more than one statement (+12 bytes), and with
+ * that fixed by hand a named `g + 0x1000` base still rotated five registers
+ * in the three reads before CpuCopy8; a struct field at 0x1525 makes that
+ * base a compiler temp and the colouring falls into place. */
 #include "types.h"
-extern char *data_020a9db8;
+#include "private/arm9_a9db8_mb_parent.h"
+extern MbParentWork *data_020a9db8;
 
 extern void func_02065f08(int idx);
 struct Out { int f0; u32 f4; int f8; u8 fc; };
-extern int func_02067530(struct Out *o, char *in, u32 val, char *tbl);
+extern int func_02067530(struct Out *o, u8 *in, u32 val, u8 *tbl);
 
 typedef struct Rec {
     u8 type;
@@ -19,22 +32,20 @@ int func_0206610c(void)
 {
     unsigned int loopCount;
     u8 idxByte;
-    char *rec;
     Rec r;
     struct Out out;
 
-    if (*(u8 *)(data_020a9db8 + 0x1000 + 0x524) == 0) return 0x15;
+    if (data_020a9db8->unk_1524 == 0) return 0x15;
 
     loopCount = 0;
     do {
         {
-            u8 *p = (u8 *)(*(char *volatile *)&data_020a9db8 + 0x1000 + 0x525);
-            *p = (*p + 1) % 16;
+            MbParentWork *g = *(MbParentWork *volatile *)&data_020a9db8;
+            g->mCurrentFile = (g->mCurrentFile + 1) % 16;
         }
-        idxByte = *(u8 *)(data_020a9db8 + 0x1000 + 0x525);
+        idxByte = data_020a9db8->mCurrentFile;
 
-        rec = data_020a9db8 + idxByte * 0x5c4;
-        if (*(u8 *)(rec + 0x1000 + 0xd4a) != 0 && *(u16 *)(rec + 0x1d00 + 0x44) != 0) break;
+        if (data_020a9db8->mFiles[idxByte].mActive != 0 && data_020a9db8->mFiles[idxByte].mChildBitmap != 0) break;
 
         loopCount = (loopCount + 1) & 0xff;
     } while (loopCount < 0x10);
@@ -42,23 +53,21 @@ int func_0206610c(void)
 
     func_02065f08(idxByte);
 
-    idxByte = *(u8 *)(data_020a9db8 + 0x1000 + 0x525);
-    rec = data_020a9db8 + idxByte * 0x5c4;
-    if (func_02067530(&out, data_020a9db8 + 0x1d24 + idxByte * 0x5c4,
-                       *(u16 *)(rec + 0x1d00 + 0x40),
-                       data_020a9db8 + 0x1788 + idxByte * 0x5c4) == 0) {
+    idxByte = data_020a9db8->mCurrentFile;
+    if (func_02067530(&out, data_020a9db8->mFiles[idxByte].mBlockTable, data_020a9db8->mFiles[idxByte].mCurrentBlock, data_020a9db8->mFiles[idxByte].mHeader) == 0) {
         return 0x15;
     }
 
-    out.f8 = out.f8 + *(int *)(data_020a9db8 + *(u8 *)(data_020a9db8 + 0x1000 + 0x525) * 0x5c4 + 0x1000 + 0xd3c);
-
-    r.type = 4;
-    r.a = *(u8 *)(data_020a9db8 + 0x1000 + 0x525);
-    r.b = *(u16 *)(data_020a9db8 + *(u8 *)(data_020a9db8 + 0x1000 + 0x525) * 0x5c4 + 0x1d00 + 0x40);
+    {
+        MbParentWork *g = data_020a9db8;
+        out.f8 = out.f8 + g->mFiles[g->mCurrentFile].mSrcAddr;
+        r.type = 4;
+        r.a = g->mCurrentFile;
+        r.b = g->mFiles[g->mCurrentFile].mCurrentBlock;
+    }
 
     CpuCopy8((void *)out.f8, func_02065d5c(&r, (u8 *)data_020a9db8), out.f4);
 
-    idxByte = *(u8 *)(data_020a9db8 + 0x1000 + 0x525);
-    rec = data_020a9db8 + idxByte * 0x5c4;
-    func_02067f2c(out.f4 + 6, *(u16 *)(rec + 0x1d00 + 0x44), (u32)data_020a9db8);
+    idxByte = data_020a9db8->mCurrentFile;
+    func_02067f2c(out.f4 + 6, data_020a9db8->mFiles[idxByte].mChildBitmap, (u32)data_020a9db8);
 }

--- a/src/func_ov006_020f17fc.c
+++ b/src/func_ov006_020f17fc.c
@@ -1,46 +1,40 @@
+//cpp
+// @symbol func_ov006_020f17fc
+/* dScMgLuigi_c per-slot mover, ov006 0x020f17fc (304 bytes). A slot that has not started draws a random phase (one of eight 0x1000 steps).
+ * A running slot adds one sine/cosine step (data_02082214, indexed by the
+ * slot's phase) scaled by its speed-level entry to mPosX/mPosY, then wraps
+ * through func_ov006_020f1dbc.
+ *
+ * Plain member access on the class header is the match under 2004/b56: the
+ * twice-read mMovePhase[idx] takes the `this + idx*2 + 0x4f00` base with a
+ * #0x7c offset as a compiler temp, and the two RMWs take the pool-loaded array
+ * base with the scaled index. The raw char* form this replaces pooled 0x4f7c
+ * whole (+8 bytes) and, once that was fixed by hand, still swapped the r4/ip
+ * pair in the second update. */
+#include "dScMgLuigi_c.h"
+
+extern "C" {
 extern int RandomIntInternal(int *seed);
 extern void func_ov006_020f1dbc(void *self, int idx);
 extern int data_0209d4b8;
 extern int data_ov006_0212e878[];
-extern short data_02082214[];
+extern s16 data_02082214[];
+}
 
-void func_ov006_020f17fc(char *c, int idx)
+extern "C" void func_ov006_020f17fc(dScMgLuigi_c *self, int idx)
 {
-    unsigned char *counterA = (unsigned char *)(c + 0x5275);
-
-    if (counterA[idx] == 0) {
+    if (self->mStarted[idx] == 0) {
         unsigned int r = ((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff;
         unsigned short val = (unsigned short)(((r << 4) >> 15) << 12);
-        *(unsigned short *)(c + idx * 2 + 0x4f7c) = val;
-        counterA[idx] += 1;
+        self->mMovePhase[idx] = val;
+        self->mStarted[idx]++;
         return;
     }
-
     {
-        unsigned char *counterC = (unsigned char *)(c + 0x5365);
-        int *accB = (int *)(c + 0x47f8);
-        int *accD = (int *)(c + 0x49d8);
-        unsigned short valB;
-        int shifted;
-        int tblOdd, tblEven;
-        int weight;
-        long long prod;
-        int add12 = 0x800;
-
-        valB = *(unsigned short *)(c + idx * 2 + 0x4f7c);
-        shifted = valB >> 4;
-        tblOdd = data_02082214[shifted * 2 + 1];
-        weight = data_ov006_0212e878[counterC[idx]];
-        prod = (long long)tblOdd * weight;
-        accB[idx] += (int)((prod + add12) >> 12);
-
-        valB = *(unsigned short *)(c + idx * 2 + 0x4f7c);
-        shifted = valB >> 4;
-        tblEven = data_02082214[shifted * 2];
-        weight = data_ov006_0212e878[counterC[idx]];
-        prod = (long long)tblEven * weight;
-        accD[idx] += (int)((prod + add12) >> 12);
+        int a = self->mMovePhase[idx] >> 4;
+        self->mPosX[idx] = self->mPosX[idx] + (s32)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e878[self->mSpeedLevel[idx]] + 0x800) >> 12);
+        a = self->mMovePhase[idx] >> 4;
+        self->mPosY[idx] = self->mPosY[idx] + (s32)(((s64)data_02082214[a * 2] * data_ov006_0212e878[self->mSpeedLevel[idx]] + 0x800) >> 12);
     }
-
-    func_ov006_020f1dbc(c, idx);
+    func_ov006_020f1dbc(self, idx);
 }

--- a/src/func_ov006_020f192c.c
+++ b/src/func_ov006_020f192c.c
@@ -1,38 +1,50 @@
-#include "types.h"
+//cpp
+// @symbol func_ov006_020f192c
+/* dScMgLuigi_c per-slot mover, ov006 0x020f192c (324 bytes). A slot that has not started is armed at phase 0x8000 or 0 from unk_51f5[idx / 8].
+ * A running slot adds one sine/cosine step (data_02082214, indexed by the
+ * slot's phase) scaled by its speed-level entry to mPosX/mPosY, then wraps
+ * through func_ov006_020f1dbc.
+ *
+ * Plain member access on the class header is the match under 2004/b56: the
+ * twice-read mMovePhase[idx] takes the `this + idx*2 + 0x4f00` base with a
+ * #0x7c offset as a compiler temp, and the two RMWs take the pool-loaded array
+ * base with the scaled index. The raw char* form this replaces pooled 0x4f7c
+ * whole (+8 bytes) and, once that was fixed by hand, still swapped the r4/ip
+ * pair in the second update. */
+#include "dScMgLuigi_c.h"
+
+extern "C" {
+extern void func_ov006_020f1dbc(void *self, int idx);
 extern int data_ov006_0212e868[];
 extern s16 data_02082214[];
+}
 
-void func_ov006_020f1dbc(char* c, int i);
-
-void func_ov006_020f192c(char* c, int i) {
-    u8* counter = (u8*)(c + 0x5275);
+extern "C" void func_ov006_020f192c(dScMgLuigi_c *self, int idx)
+{
     int cnt;
     int j;
-    if (counter[i] == 0) {
-        counter[i]++;
+    if (self->mStarted[idx] == 0) {
+        self->mStarted[idx]++;
         cnt = 0;
-        j = i;
-        if (i >= 8) {
+        j = idx;
+        if (idx >= 8) {
             do {
                 j -= 8;
                 cnt++;
             } while (j >= 8);
         }
-        if (*(u8*)(c + cnt + 0x51f5) != 0) {
-            *(u16*)(c + i * 2 + 0x4f7c) = 0x8000;
+        if (self->unk_51f5[cnt] != 0) {
+            self->mMovePhase[idx] = 0x8000;
         } else {
-            *(u16*)(c + i * 2 + 0x4f7c) = 0;
+            self->mMovePhase[idx] = 0;
         }
         return;
     }
     {
-        u8* spd = (u8*)(c + 0x5365);
-        int* xs = (int*)(c + 0x47f8);
-        int* ys = (int*)(c + 0x49d8);
-        int a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
-        xs[i] = xs[i] + (int)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e868[spd[i]] + 0x800) >> 12);
-        a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
-        ys[i] = ys[i] + (int)(((s64)data_02082214[a * 2] * data_ov006_0212e868[spd[i]] + 0x800) >> 12);
+        int a = self->mMovePhase[idx] >> 4;
+        self->mPosX[idx] = self->mPosX[idx] + (s32)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e868[self->mSpeedLevel[idx]] + 0x800) >> 12);
+        a = self->mMovePhase[idx] >> 4;
+        self->mPosY[idx] = self->mPosY[idx] + (s32)(((s64)data_02082214[a * 2] * data_ov006_0212e868[self->mSpeedLevel[idx]] + 0x800) >> 12);
     }
-    func_ov006_020f1dbc(c, i);
+    func_ov006_020f1dbc(self, idx);
 }

--- a/src/func_ov006_020f1a70.c
+++ b/src/func_ov006_020f1a70.c
@@ -1,28 +1,40 @@
-#include "types.h"
+//cpp
+// @symbol func_ov006_020f1a70
+/* dScMgLuigi_c per-slot mover, ov006 0x020f1a70 (296 bytes). A slot that has not started is armed at phase 0x4000 or 0xc000 from unk_51ed[idx & 7].
+ * A running slot adds one sine/cosine step (data_02082214, indexed by the
+ * slot's phase) scaled by its speed-level entry to mPosX/mPosY, then wraps
+ * through func_ov006_020f1dbc.
+ *
+ * Plain member access on the class header is the match under 2004/b56: the
+ * twice-read mMovePhase[idx] takes the `this + idx*2 + 0x4f00` base with a
+ * #0x7c offset as a compiler temp, and the two RMWs take the pool-loaded array
+ * base with the scaled index. The raw char* form this replaces pooled 0x4f7c
+ * whole (+8 bytes) and, once that was fixed by hand, still swapped the r4/ip
+ * pair in the second update. */
+#include "dScMgLuigi_c.h"
+
+extern "C" {
+extern void func_ov006_020f1dbc(void *self, int idx);
 extern int data_ov006_0212e858[];
 extern s16 data_02082214[];
+}
 
-void func_ov006_020f1dbc(char* c, int i);
-
-void func_ov006_020f1a70(char* c, int i) {
-    u8* counter = (u8*)(c + 0x5275);
-    if (counter[i] == 0) {
-        counter[i]++;
-        if (*(u8*)(c + (i & 7) + 0x51ed) != 0) {
-            *(u16*)(c + i * 2 + 0x4f7c) = 0x4000;
+extern "C" void func_ov006_020f1a70(dScMgLuigi_c *self, int idx)
+{
+    if (self->mStarted[idx] == 0) {
+        self->mStarted[idx]++;
+        if (self->unk_51ed[idx & 7] != 0) {
+            self->mMovePhase[idx] = 0x4000;
         } else {
-            *(u16*)(c + i * 2 + 0x4f7c) = 0xc000;
+            self->mMovePhase[idx] = 0xc000;
         }
         return;
     }
     {
-        u8* spd = (u8*)(c + 0x5365);
-        int* xs = (int*)(c + 0x47f8);
-        int* ys = (int*)(c + 0x49d8);
-        int a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
-        xs[i] = xs[i] + (int)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e858[spd[i]] + 0x800) >> 12);
-        a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
-        ys[i] = ys[i] + (int)(((s64)data_02082214[a * 2] * data_ov006_0212e858[spd[i]] + 0x800) >> 12);
+        int a = self->mMovePhase[idx] >> 4;
+        self->mPosX[idx] = self->mPosX[idx] + (s32)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e858[self->mSpeedLevel[idx]] + 0x800) >> 12);
+        a = self->mMovePhase[idx] >> 4;
+        self->mPosY[idx] = self->mPosY[idx] + (s32)(((s64)data_02082214[a * 2] * data_ov006_0212e858[self->mSpeedLevel[idx]] + 0x800) >> 12);
     }
-    func_ov006_020f1dbc(c, i);
+    func_ov006_020f1dbc(self, idx);
 }

--- a/src/func_ov006_020f1b98.c
+++ b/src/func_ov006_020f1b98.c
@@ -1,27 +1,35 @@
-#include "types.h"
-extern void func_ov006_020f1dbc(char *self, int idx);
+//cpp
+// @symbol func_ov006_020f1b98
+/* dScMgLuigi_c per-slot mover, ov006 0x020f1b98 (284 bytes). A slot that has not started takes its phase from unk_515c[speed level].
+ * A running slot adds one sine/cosine step (data_02082214, indexed by the
+ * slot's phase) scaled by its speed-level entry to mPosX/mPosY, then wraps
+ * through func_ov006_020f1dbc.
+ *
+ * Plain member access on the class header is the match under 2004/b56: the
+ * twice-read mMovePhase[idx] takes the `this + idx*2 + 0x4f00` base with a
+ * #0x7c offset as a compiler temp, and the two RMWs take the pool-loaded array
+ * base with the scaled index. The raw char* form this replaces pooled 0x4f7c
+ * whole (+8 bytes) and, once that was fixed by hand, still swapped the r4/ip
+ * pair in the second update. */
+#include "dScMgLuigi_c.h"
+
+extern "C" {
+extern void func_ov006_020f1dbc(void *self, int idx);
 extern int data_ov006_0212e8d8[];
-extern short data_02082214[];
+extern s16 data_02082214[];
+}
 
-void func_ov006_020f1b98(char *base, int idx)
+extern "C" void func_ov006_020f1b98(dScMgLuigi_c *self, int idx)
 {
-    u8 *flag = (u8 *)(base + 0x5275 + idx);
-    if (*flag == 0) {
-        u8 t = *(u8 *)(base + 0x5365 + idx);
-        *(u16 *)(base + idx * 2 + 0x4f7c) = *(u16 *)(base + t * 2 + 0x515c);
-        (*flag)++;
+    if (self->mStarted[idx] == 0) {
+        u8 t = self->mSpeedLevel[idx];
+        self->mMovePhase[idx] = self->unk_515c[t];
+        self->mStarted[idx]++;
     } else {
-        s32 a0 = ((s32)*(u16 *)(base + idx * 2 + 0x4f7c)) >> 4;
-        s32 idx0 = data_ov006_0212e8d8[*(u8 *)(base + 0x5365 + idx)];
-        s32 v0 = data_02082214[a0 * 2 + 1];
-        *(s32 *)(base + 0x47f8 + idx * 4) += (s32)(((s64)v0 * idx0 + 0x800) >> 12);
-
-        {
-            s32 a1 = ((s32)*(u16 *)(base + idx * 2 + 0x4f7c)) >> 4;
-            s32 idx1 = data_ov006_0212e8d8[*(u8 *)(base + 0x5365 + idx)];
-            s32 v1 = data_02082214[a1 * 2];
-            *(s32 *)(base + 0x49d8 + idx * 4) += (s32)(((s64)v1 * idx1 + 0x800) >> 12);
-        }
-        func_ov006_020f1dbc(base, idx);
+        int a = self->mMovePhase[idx] >> 4;
+        self->mPosX[idx] = self->mPosX[idx] + (s32)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e8d8[self->mSpeedLevel[idx]] + 0x800) >> 12);
+        a = self->mMovePhase[idx] >> 4;
+        self->mPosY[idx] = self->mPosY[idx] + (s32)(((s64)data_02082214[a * 2] * data_ov006_0212e8d8[self->mSpeedLevel[idx]] + 0x800) >> 12);
+        func_ov006_020f1dbc(self, idx);
     }
 }

--- a/src/func_ov006_020f1cb4.c
+++ b/src/func_ov006_020f1cb4.c
@@ -1,24 +1,36 @@
-#include "types.h"
+//cpp
+// @symbol func_ov006_020f1cb4
+/* dScMgLuigi_c per-slot mover, ov006 0x020f1cb4 (264 bytes). A slot that has not started is armed at phase 0x6000.
+ * A running slot adds one sine/cosine step (data_02082214, indexed by the
+ * slot's phase) scaled by its speed-level entry to mPosX/mPosY, then wraps
+ * through func_ov006_020f1dbc.
+ *
+ * Plain member access on the class header is the match under 2004/b56: the
+ * twice-read mMovePhase[idx] takes the `this + idx*2 + 0x4f00` base with a
+ * #0x7c offset as a compiler temp, and the two RMWs take the pool-loaded array
+ * base with the scaled index. The raw char* form this replaces pooled 0x4f7c
+ * whole (+8 bytes) and, once that was fixed by hand, still swapped the r4/ip
+ * pair in the second update. */
+#include "dScMgLuigi_c.h"
+
+extern "C" {
+extern void func_ov006_020f1dbc(void *self, int idx);
 extern int data_ov006_0212e8c8[];
 extern s16 data_02082214[];
+}
 
-void func_ov006_020f1dbc(char* c, int i);
-
-void func_ov006_020f1cb4(char* c, int i) {
-    u8* counter = (u8*)(c + 0x5275);
-    if (counter[i] == 0) {
-        *(u16*)(c + i * 2 + 0x4f7c) = 0x6000;
-        counter[i]++;
+extern "C" void func_ov006_020f1cb4(dScMgLuigi_c *self, int idx)
+{
+    if (self->mStarted[idx] == 0) {
+        self->mMovePhase[idx] = 0x6000;
+        self->mStarted[idx]++;
         return;
     }
     {
-        u8* spd = (u8*)(c + 0x5365);
-        int* xs = (int*)(c + 0x47f8);
-        int a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
-        xs[i] = xs[i] + (int)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e8c8[spd[i]] + 0x800) >> 12);
-        int* ys = (int*)(c + 0x49d8);
-        a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
-        ys[i] = ys[i] + (int)(((s64)data_02082214[a * 2] * data_ov006_0212e8c8[spd[i]] + 0x800) >> 12);
+        int a = self->mMovePhase[idx] >> 4;
+        self->mPosX[idx] = self->mPosX[idx] + (s32)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e8c8[self->mSpeedLevel[idx]] + 0x800) >> 12);
+        a = self->mMovePhase[idx] >> 4;
+        self->mPosY[idx] = self->mPosY[idx] + (s32)(((s64)data_02082214[a * 2] * data_ov006_0212e8c8[self->mSpeedLevel[idx]] + 0x800) >> 12);
     }
-    func_ov006_020f1dbc(c, i);
+    func_ov006_020f1dbc(self, idx);
 }


### PR DESCRIPTION
A sweep of the counted source files turned up 60 whose `delinks.txt` entry was still a plain address range, meaning the ROM build never compiled them and never byte-verified them, and which no longer reproduced the ROM bytes when compiled. All 60 are now repaired: 23 in `match/m100-repair-a-land`, 29 in `match/m100-repair-b-land`, two that landed earlier in #2334, and the last six here, each one now carrying a `complete` line so the ROM build compiles the file and checks it on every run.

## The six files

| File | Module | Address | Size | Cause of the drift |
| --- | --- | --- | --- | --- |
| `src/func_ov006_020f17fc.c` | ov006 | 0x020f17fc | 0x130 | Raw `char*` access pooled the whole 0x4f7c base (+8 bytes), and hand-fixing that still swapped the r4/ip pair in the second position update |
| `src/func_ov006_020f192c.c` | ov006 | 0x020f192c | 0x144 | Same raw `char*` base for the twice-read move phase; pooled 0x4f7c whole and then rotated the r4/ip pair |
| `src/func_ov006_020f1a70.c` | ov006 | 0x020f1a70 | 0x128 | Same raw `char*` base for the twice-read move phase; pooled 0x4f7c whole and then rotated the r4/ip pair |
| `src/func_ov006_020f1b98.c` | ov006 | 0x020f1b98 | 0x11c | Same raw `char*` base for the twice-read move phase; pooled 0x4f7c whole and then rotated the r4/ip pair |
| `src/func_ov006_020f1cb4.c` | ov006 | 0x020f1cb4 | 0x108 | Same raw `char*` base for the twice-read move phase; pooled 0x4f7c whole and then rotated the r4/ip pair |
| `src/func_0206610c.c` | arm9 | 0x0206610c | 0x1b4 | Raw `char*` access pooled the whole 0x1525 address once the byte was read from more than one statement (+12 bytes), and a named `g + 0x1000` base still rotated five registers across the three reads before `CpuCopy8` |

The five ov006 files are the `dScMgLuigi_c` per-slot movers, one per movement pattern. They share a shape: draw or arm a phase for a slot that has not started yet, then for a running slot add one sine and cosine step scaled by the slot's speed level and wrap through `func_ov006_020f1dbc`. `src/func_0206610c.c` is the wireless-download parent send step, which walks the current file index mod 16 looking for a registered file with children waiting, fetches a block, writes a type 4 record header, copies the block after it, and hands the packet off.

## The two levers

Reading a class member through the class header, instead of casting `this` to `char*` and adding a literal offset, is what makes a twice-read base a compiler temp under 2004/b56. In the five Luigi files the move phase is read twice, and with header-typed access the compiler holds `this + idx * 2 + 0x4f00` with a `#0x7c` displacement as a temporary rather than pooling the constant 0x4f7c as a whole address. That single change removes the extra pool word and, with it, the register pair swap in the second read-modify-write.

The same effect, reached through a private header rather than a class, fixes `src/func_0206610c.c`. Declaring the parent work block as a struct and going through a typed pointer makes the `g + 0x1000` base a compiler temp instead of a live named value, and the five-register rotation the hand-written form kept producing across the three reads before `CpuCopy8` resolves on its own. Both levers are the same underlying rule: give the compiler a type it can build an addressing temp from, and it will stop pooling the address.

## The new header

`include/private/arm9_a9db8_mb_parent.h` describes the block `data_020a9db8` points at, placing only the fields the arm9 range `func_02065c2c` through `func_02069994` actually reads and leaving everything else as padding at its measured offset. It carries a compile-time assert that the per-file record is 0x5c4 bytes. Provenance: the message types 3 and 4 sent and 7, 8 and 9 received, the fifteen per-child state words at 0x14e8, and the sixteen-entry file table are the NitroSDK multiboot parent work layout, identified by shape, so the names follow that role without claiming the SDK's own identifiers. This follows the repo's existing `include/private` precedent for blocks nobody owns yet.

## Gates

```
prepush_linkcheck.py --range origin/main..HEAD
1 changed header(s) fan out to 6 source file(s) to verify
  [OK  ] func_0206610c                                VERIFIED
  [OK  ] func_ov006_020f17fc                          VERIFIED
  [OK  ] func_ov006_020f192c                          VERIFIED
  [OK  ] func_ov006_020f1a70                          VERIFIED
  [OK  ] func_ov006_020f1b98                          VERIFIED
  [OK  ] func_ov006_020f1cb4                          VERIFIED
prepush-linkcheck: 6 checked - 6 verified, 0 warning(s), 0 blocking

langmode_audit.py --check langmode-baseline.json
langmode ratchet PASS

check_duplicate_sources.py
duplicate-sources: 10017 stems, none doubled

eligible.py -j 8
eligible: 11131 / 11256

check_references.py
unresolved symbols: 42  (baseline 45)
eligible:           11131  (baseline 11044)
OK: no new unresolvable references

check_src_tu.py
check_src_tu: 32 translation unit(s), 323 include(s), 802 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.

check_header_offsets.py --changed origin/main
include/private/arm9_a9db8_mb_parent.h: 0 commented fields, 0 mismatched, 0 unparsed, struct spans 0x0
(a full run over every tracked header is also clean)

python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll
Ran 80 tests in 9.889s
OK
```

Direct byte verification of the six at their `symbols.txt` address and size, all under the pinned 2004/b56:

```
src/func_ov006_020f1cb4.c func_ov006_020f1cb4 0x020f1cb4 0x108 ov006 -> (True, '2004/b56')
src/func_ov006_020f192c.c func_ov006_020f192c 0x020f192c 0x144 ov006 -> (True, '2004/b56')
src/func_ov006_020f1a70.c func_ov006_020f1a70 0x020f1a70 0x128 ov006 -> (True, '2004/b56')
src/func_ov006_020f1b98.c func_ov006_020f1b98 0x020f1b98 0x11c ov006 -> (True, '2004/b56')
src/func_ov006_020f17fc.c func_ov006_020f17fc 0x020f17fc 0x130 ov006 -> (True, '2004/b56')
src/func_0206610c.c       func_0206610c       0x0206610c 0x1b4 arm9  -> (True, '2004/b56')
```

All nine other source files that include `dScMgLuigi_c.h` were re-run under `match.py` with strict relocation checking and still match: the five `dScMgLuigi_c` methods, both destructor variants, `func_ov006_020f15ac` and `func_ov006_020f2224`. No near-miss database rows change in this PR.
