### PR TITLE
Fold the dScMgPanel_c and dScMgCoin_c runs' findings into the role files

### DIFF
--- a/notes/agents/PIPELINE.md
+++ b/notes/agents/PIPELINE.md
@@ -81,14 +81,15 @@ commit push the same SHA, git answers `Everything up-to-date` and exits 0, and
 normalized to the same ref — a class lives in one overlay, so the prefix adds
 nothing. Before that normalization the two spellings built two different refs
 and two agents could hold one class simultaneously; live claims existed in both
+forms. Create the worktree first and claim once with `--worktree`: re-claiming
+to attach the path afterwards is denied against yourself.
+
 **Use forward slashes in `--worktree`, as the example above does — it is
 required, not cosmetic.** A backslash path passed through a shell arrives with
 its separators eaten and the claim records
 `"worktree": "C:tmpsm64ds-memory2-build"`, which points at nothing and defeats
 the whole reason the field exists.
 
-forms. Create the worktree first and claim once with `--worktree`: re-claiming
-to attach the path afterwards is denied against yourself.
     python tools/classqueue.py release dActor_c --role writer
     python tools/classqueue.py list
 
@@ -97,6 +98,16 @@ lock. Do not retry it, do not force-push over it — take the next row.
 
 Release your claim when your stage's output is committed and pushed, not when
 you personally are done thinking.
+
+**A released claim does not mean nobody has done the work.** The claim ref is
+the only thing `classqueue.py` consults, so a class whose scout pushed a branch,
+opened no PR and released its claim is offered again as unclaimed — and the next
+agent rediscovers the whole thing. That happened to `dScMgCoin_c`. Before you
+start, look:
+
+    git branch -r --list 'origin/cpp/<Class>*'
+
+If one exists, read it before you cut a new one.
 
 ## Launching an agent
 
@@ -124,3 +135,7 @@ the next one rather than stopping.
 4. **A near-miss never lands in `src/`.** Bank it in `nearmiss/db.jsonl` and
    restore the matched source.
 5. **Report the outcome, not the effort.** If a gate failed, paste the failure.
+6. **Force-pushes are blocked. Merge, do not rebuild.** If you rebase and the
+   push is refused, merge `origin/main` into your branch. Rebuilding the branch
+   as a fast-forward from an older commit is how stale, tree-derived work gets
+   shipped past review — and it does not look stale, it looks confident.

--- a/notes/agents/roles/scout.md
+++ b/notes/agents/roles/scout.md
@@ -56,6 +56,39 @@ far and may be wrong; the cartridge is not.
    you could not prove as `unproven` — do not invent a name for it.
 8. **Which overlay(s)** the methods live in, and the module base address.
 
+## Stay current with `origin/main`, and know which of your facts can rot
+
+Your file mixes two kinds of claim, and only one of them is stable:
+
+- **ROM-derived** — the RTTI record, the vtable, the base class, the overrides,
+  the destructor addresses, the object size. Cut from `extracted/`. Merging
+  cannot change these.
+- **Tree-derived** — the queue row, the manifest directory, delink membership,
+  which siblings are promoted, which output convention is live. These change on
+  **every** promotion, and several land per day.
+
+Re-derive every tree-derived field against the base you actually ship, and name
+that base in the file. A scout that skipped this shipped `dScMgCoin_c.json`
+asserting two siblings were unpromoted; both had landed six promotions earlier,
+so the claim read as a confident *correction of the truth* rather than as
+obviously stale — which is the dangerous failure, not the loud one.
+
+Verify your base **after** the fact, not before: sibling worktrees share one ref
+store, so `origin/main` can advance between your fetch and your rebase. Check
+`git merge-base HEAD origin/main` == `HEAD~N` and `git log --oneline
+HEAD..origin/main` empty.
+
+**Force-pushes are blocked on this repo.** If you rebase and then cannot push,
+**merge `origin/main` into your branch.** Do not rebuild the branch as a
+fast-forward from an older commit — that is exactly how the stale derivations
+above got shipped.
+
+**Filter every relocation scan on the destination MODULE.** Overlays share
+address space, so an unfiltered scan for the callers of a run reports phantoms
+from every overlay that happens to overlap it: 115 phantom callers across nine
+overlays against 43 real ones on `dScMgCoin_c`, a 2.5x error. Accept a
+relocation only when its destination module is the overlay you are scouting.
+
 ## Output
 
 Write `notes/data/class-facts/<class>.json`:

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -52,7 +52,16 @@ uniquification stops being advice.** Measured at 41 members: duplicate
 - a naive `C` tag rename corrupts `extern "C"` into `extern "C_5fec"` —
   placeholder-protect the string first;
 - member-local `extern` declarations that mention a renamed tag must **not** be
-  hoisted into the shared block.
+  hoisted into the shared block;
+- `re.sub(r'^(\s+)extern "C" ', ..., re.M)` matches **across a preceding blank
+  line**, because `\s` includes `
+`. It rewrites file-scope `extern "C" {`
+  into `extern {` and reports `declaration syntax error` eighty lines away. Use
+  `[ 	]+`;
+- any scan for a member's definition line must **skip comments**. A doc comment
+  naming `Class::Method` is taken as the definition, which silently leaves that
+  shard's declaration block at file scope — three `illegal function
+  overloading` errors, none of them near the real cause.
 
 **And `create`'s merging of a shared `struct` is a codegen hazard, not a naming
 one.** On `dScMgSound_c`, eleven dispatch members saw `struct C` **incomplete**
@@ -513,9 +522,23 @@ both destructor variants in.
 
 mwccarm 2004/b56 behaviours, not style preferences.
 
-- **`virtual ~X() {}` inline, declared FIRST member.** Out-of-line emits
-  D2/D0/D1 in the wrong order plus a homeless D2; the ROM carries D1-then-D0
-  and no D2.
+- **The destructor form is a MEASUREMENT, not a default.** Two forms reproduce
+  the ROM's usual `D1`-then-`D0`-and-no-`D2`, and which one a TU needs is a
+  question to measure per TU:
+
+  - `virtual ~X() {}` **inline, declared FIRST member** — the variants emit in
+    reverse order of their first odr-use;
+  - the destructor **out of line** under `#pragma defer_codegen off` — emits
+    `D1, D0, D2`.
+
+  Out-of-line *without* that pragma emits `D2/D0/D1` in the wrong order plus a
+  homeless `D2`, which is where the flat "always inline it" rule this file used
+  to state came from. Landed both ways: ov006/`dScMgTeresa_c` and
+  ov006/`dScMgPanel_c` (71/71, link-verified) are both out-of-line +
+  `defer_codegen off`. **Try both before you take a partial** — and note the
+  inline form has a cost of its own, since it moves the key function to the
+  first out-of-line virtual declared, which on a coined-name class turns a
+  harmless name into a hard promotion refusal.
 - **Emission order is a hard gate, and it is the constraint most likely to stop
   you.** `linkcheck [4b/8]` fatally refuses a TU whose licensed `.text` sections
   are not in ROM-ascending order: `licensed .text functions are not emitted in
@@ -648,6 +671,17 @@ they cost minutes; discover them after and each is a cycle.
   `extern struct V dv;` in three separate function bodies compile cleanly. Only
   a **file-scope** redeclaration is rejected.
 
+  **But the licence is for FUNCTIONS with C linkage, and a project header
+  revokes it for data.** Measured on ov006/`dScMgPanel_c`:
+  `include/dScMgBase_c.h:12` already declares
+  `extern "C" void *data_ov004_020beb68;`, ordinal 60 recovered the object as
+  `char *`, and the block-scope form is rejected outright —
+  `identifier 'data_ov004_020beb68' redeclared; was declared as: 'void *'`.
+  The wording above sends you hunting for a file-scope duplicate *inside your
+  own TU* that is not there; the conflicting declaration is in a header you
+  include. The fix that kept 71/71 was a reinterpreting macro, not a
+  redeclaration.
+
 - **Canonicalising a DATA declaration is a codegen hazard, exactly like merging
   a shared `struct`.** Hoisting one canonical data declaration and casting each
   member's view back with a macro **changed the codegen of six members** on
@@ -705,6 +739,17 @@ excludes the header and declares every symbol the header would have supplied.
 So: include it and align *by default*, but when a spelling it dictates breaks a
 byte match, measure both ways and say which you took and why. The bytes outrank
 the header.
+
+**And "include it" inverts above some member count — this is a size-dependent
+rule, not a default.** `decl_common.h` declares 10 of ov006/`dScMgPanel_c`'s 71
+members and **7 of the 10 contradict the byte-matched shard**, two of them on
+the return type. Including it makes each an `illegal function overloading`
+error against code that already matches. That TU excluded the header (the ov002
+`Player` precedent) and gave the four class-method members their `decl_common`
+declarations at block scope instead. The more members a TU absorbs, the likelier
+the header contradicts one — so count the collisions before you decide. Two
+promoted TUs include it and two of the largest exclude it, and both choices are
+right for their size.
 
 **Grep shadow struct *tags* too, not only declarations.** A shadow type can
 collide with a **ROM symbol**, which is a different failure and a nastier one.

--- a/notes/data/class-facts/dScMgPanel_c.json
+++ b/notes/data/class-facts/dScMgPanel_c.json
@@ -1489,7 +1489,7 @@
       "opt_propagation off": 1
     },
     "not_a_blocker": "This is a SOLVED pattern in this overlay, with four landed precedents. Wrap each pragma-carrying function in `#pragma push` / `#pragma pop` and put `#pragma defer_codegen off` near the top of the TU. src/actors/dScMgBomroom_c.cpp does it eleven times and covers all three families including opt_propagation; src/actors/dScMgHanachan_c.cpp six times; src/actors/dScMgMemory2_c.cpp twice; src/actors/dScMgTeresa_c.cpp three times. Without `defer_codegen off` the brackets do NOT bind positionally, and opt_strength_reduction in particular behaves file-globally - which is what makes an 8-pragma TU look scary on paper.",
-    "caution": "`defer_codegen off` also fixes the emission order to ascending, so the merged source must be written in REVERSE ROM order (highest address first) exactly as src/actors/dScMgRoulette_c.cpp is. Emission order is a hard gate (linkcheck [4b/8]), not advice."
+    "caution": "CORRECTED once the promotion landed 71/71: `defer_codegen off` fixes the emission order to ascending, so the merged source must be written in ROM-ASCENDING order (LOWEST address first). This field originally said REVERSE order and cited src/actors/dScMgRoulette_c.cpp; both halves are wrong -- dScMgRoulette_c does not use `defer_codegen off` at all, it is descending source under default deferred codegen. The oracle for the ascending + `defer_codegen off` form is src/actors/dScMgTeresa_c.cpp. Measured control on the shipped TU: deleting only `defer_codegen off` costs both the bytes (71/71 -> 67/71) and the order (70 section pairs out of ROM order). Emission order is a hard gate (linkcheck [4b/8]), not advice."
   },
   "compiler_only_output_prediction": {
     "expected_rows": 12,


### PR DESCRIPTION
Documentation only — four files, no source, no gate config.

Two pipeline runs finished today and each contradicted something a role file states as a rule. Both were measured, so the corrections carry their controls.

**writer.md**, from the ov006/`dScMgPanel_c` promotion (71/71, SCRATCH-LINK-VERIFIED):

- The destructor form is a **measurement**, not a default. The file opened with `virtual ~X() {}` inline-and-first as a flat rule and stated the out-of-line + `defer_codegen off` result only much later, so a reader hits the wrong one first. Both landed forms now sit together, with the inline form's own cost — it moves the key function to the first out-of-line virtual declared, which on a coined-name class turns a harmless name into a hard promotion refusal.
- The block-scope redeclaration licence is for **functions** with C linkage. A project header revokes it for data: `include/dScMgBase_c.h:12` declares `data_ov004_020beb68` as `void *`, ordinal 60 recovered it as `char *`, and the block-scope form is rejected. The old wording sent you hunting for a file-scope duplicate inside your own TU that is not there.
- "Include `decl_common.h` and match it" **inverts above some member count**. It declares 10 of Panel's 71 members and 7 contradict the byte-matched shard, two on the return type. Now stated as size-dependent, with both precedents named.
- Two more placeholder-protection traps: `\s` in a `^(\s+)extern "C" ` regex matches across a blank line and rewrites file-scope `extern "C" {` into `extern {`, reporting a syntax error eighty lines away; and a definition-line scan that does not skip comments takes a doc comment naming `Class::Method` as the definition.

**scout.md** gains the section it was missing entirely: which facts are ROM-derived (stable) versus tree-derived (stale within a day), verify the base *after* the fact, merge rather than rebuild when a force-push is refused, and filter every relocation scan on the destination module — unfiltered gives 115 phantom callers across nine overlays against 43 real ones on `dScMgCoin_c`, a 2.5x error.

**PIPELINE.md**: repairs a paragraph an earlier edit had interleaved mid-sentence; records that a released claim with a pushed but un-PR'd branch is invisible to `classqueue.py` (which is how `dScMgCoin_c` got scouted twice); adds the force-push rule for every role.

**notes/data/class-facts/dScMgPanel_c.json** carried a `caution` that was wrong in both halves — it said `defer_codegen off` requires REVERSE source order and cited `src/actors/dScMgRoulette_c.cpp`, which does not use the pragma at all. Corrected in place with the measured control: deleting only `defer_codegen off` from the shipped TU costs both the bytes (71/71 → 67/71) and the order (70 section pairs out of ROM order).

`check_dead_references` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA