### PR TITLE
Match the ov006 Smartball ball spawn

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -4055,6 +4055,10 @@ src/func_ov006_02115150.c:
     complete
     .text start:0x02115150 end:0x02115248
 
+src/func_ov006_02115248.cpp:
+    complete
+    .text start:0x02115248 end:0x02115480
+
 src/func_ov006_02115480.c:
     complete
     .text start:0x02115480 end:0x02115598

--- a/src/func_ov006_02115248.cpp
+++ b/src/func_ov006_02115248.cpp
@@ -1,0 +1,83 @@
+//cpp
+/* func_ov006_02115248 -- dScMgSmartball_c, ov006 0x02115248, 0x238 bytes.
+ *
+ * Spawns up to four balls: for each of the four passes it takes the first free
+ * slot of sixteen, draws two angles from the shared RNG, and fills that slot's
+ * position (0x4854 + j*8) and velocity (0x48d4 + j*8) from the sine table,
+ * biased by the caller's origin, then marks the slot taken.
+ *
+ * TWO THINGS ARE LOAD BEARING AND BOTH WERE MEASURED.
+ *
+ * 1. TVec2 HAS AN EMPTY DESTRUCTOR.  `v` is never address-taken, so a plain POD
+ *    pair is scalarised into registers and the frame comes out sub sp,#0x1c; the
+ *    non-POD copy forces a stack home and the cartridge's sub sp,#0x24.  That is
+ *    the only difference between an otherwise byte-identical body and this one.
+ *
+ * 2. `sa` IS A SEPARATE s64 STATEMENT, NOT AN INITIALISER.  sinA feeds two
+ *    64-bit products, times 0x8000 here and times 0x4000 twelve lines down.
+ *    Widening it once into its own local, ASSIGNED as a statement ahead of the
+ *    first product, makes 2004/b56 compute the sign word once into a short-lived
+ *    scratch and derive both high halves from it back to back (asr ...,#0x1f then
+ *    lsl #0xf and lsl #0xe adjacent, the scratch dying immediately into the
+ *    #0x800 rounding constant).  Every other spelling defers the second shift
+ *    about twenty words into the y block and misses the whole window:
+ *    `s64 sa = sinA;` at the declaration, using sa for the 0x8000 product as
+ *    well, hoisting either product into a named int, reordering the stores, the
+ *    six FX operand and helper forms, and five optimisation pragmas were all
+ *    measured and all leave the same 27-word window.
+ *
+ * The two arrays are reached by raw offset, not through the header's mArray2 /
+ * mArray3: a struct-array view of either one changes the frame and the loop's
+ * addressing and does not reproduce.
+ */
+#include "dScMgSmartball_c.h"
+
+extern "C" {
+extern int RandomIntInternal(int *seed);
+extern int data_0209d4b8;
+extern s16 data_02082214[];
+}
+
+struct TVec2 { int x; int y; ~TVec2() {} };
+
+#define FX(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
+
+extern "C" void func_ov006_02115248(dScMgSmartball_c *self, int *origin)
+{
+    char *c = (char *)self;
+    int i;
+    int j;
+
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 0x10; j++) {
+            u8 *flag = (u8 *)(c + j + 0x4804);
+            if (*flag == 1) {
+                continue;
+            }
+            {
+                int rnd1 = RandomIntInternal(&data_0209d4b8);
+                int rnd2 = RandomIntInternal(&data_0209d4b8);
+                int angB = ((((unsigned int)rnd2 >> 16) & 0x7fff) * 0x8000) >> 16;
+                int angA = ((((unsigned int)rnd1 >> 16) & 0x7fff) * 0x20000) >> 16;
+                s16 sinB = data_02082214[(angB >> 4) * 2 + 1];
+                s16 sinA = data_02082214[(angA >> 4) * 2 + 1];
+                s16 cosA;
+                s64 sa;
+                TVec2 v;
+                sa = (s64)sinA;
+                v.x = FX(sinB, FX(sinA, 0x8000));
+                *(int *)(c + j * 8 + 0x4854) = v.x;
+                cosA = data_02082214[(angA >> 4) * 2];
+                v.y = FX(sinB, FX(cosA, 0x8000));
+                *(int *)(c + j * 8 + 0x4858) = v.y;
+                *(int *)(c + j * 8 + 0x4854) += origin[0];
+                *(int *)(c + j * 8 + 0x4858) += origin[1];
+                *(int *)(c + j * 8 + 0x48d4) = FX(sinB, FX(sa, 0x4000));
+                *(int *)(c + j * 8 + 0x48d8) = FX(sinB, FX(cosA, 0x4000));
+                *(int *)(c + j * 4 + 0x4814) = 0;
+                *flag = 1;
+            }
+            break;
+        }
+    }
+}

--- a/src/func_ov006_02115248.cpp
+++ b/src/func_ov006_02115248.cpp
@@ -1,4 +1,5 @@
 //cpp
+// @symbol func_ov006_02115248
 /* func_ov006_02115248 -- dScMgSmartball_c, ov006 0x02115248, 0x238 bytes.
  *
  * Spawns up to four balls: for each of the four passes it takes the first free


### PR DESCRIPTION
Recovers one function from overlay 6, the Smartball minigame's ball spawn. It walks four passes, takes the first free slot of sixteen each time, draws two angles from the shared RNG, and fills that slot's position and velocity from the sine table biased by the caller's origin.

| Function | Module | Address | Size |
| --- | --- | --- | --- |
| `func_ov006_02115248` | ov006 | `0x02115248` | `0x238` (568 bytes) |

## Byte gate

`python tools/match.py --c src/func_ov006_02115248.cpp --func func_ov006_02115248 --addr 0x02115248 --size 0x238 --module ov006 --all --strict-relocs`

```
========================================
MATCHING VERSIONS: 2004/b56
```

Every other candidate in the 24-version sweep produces a different size against the target's `0x238` (`0x214` and `0x210` for the 1.2 family, `0x1c0` for the 2.0 family, `0x1b8` for the dsi family), so the pin is unambiguous. `build_pin.verify` agrees:

```
(True, '2004/b56')
```

The two wildcarded words in the tail are the relocation slots for `data_0209d4b8` and `data_02082214`; everything else in the range is an exact instruction match.

## Sibling re-match

The file includes the real class header `dScMgSmartball_c.h`. Every other source file that includes that header was re-verified at its `symbols.txt` address and size, unchanged:

```
src/_ZN16dScMgSmartball_c13InitResourcesEv.cpp               0x02118b70 0x8dc   (True, '2004/b56')
src/_ZN16dScMgSmartball_c13OnYoshiTryEatEi.cpp               0x02118a8c 0x58    (True, '2004/b56')
src/_ZN16dScMgSmartball_c21AfterCleanupResourcesEj.cpp       0x0211944c 0x3d8   (True, '2004/b56')
src/_ZN16dScMgSmartball_c6RenderEv.cpp                       0x021173c8 0x10c0  (True, '2004/b56')
src/_ZN16dScMgSmartball_c8BehaviorEv.cpp                     0x02118488 0x604   (True, '2004/b56')
src/_ZN16dScMgSmartball_c8OnPushedEv.cpp                     0x021147ac 0x24    (True, '2004/b56')
src/_ZN16dScMgSmartball_c9Virtual7CEv.cpp                    0x02118ae4 0x8c    (True, '2004/b56')
src/_ZN16dScMgSmartball_cD0Ev.cpp                            0x0210d7e0 0xb4    (True, '2004/b56')
src/_ZN16dScMgSmartball_cD1Ev.cpp                            0x0210d740 0xa0    (True, '2004/b56')
src/func_ov006_02115248.cpp                                  0x02115248 0x238   (True, '2004/b56')
```

The header itself is untouched by this branch.

## Link check

`python tools/prepush_linkcheck.py --range origin/main..HEAD`

```
  [OK  ] func_ov006_02115248                          VERIFIED
prepush-linkcheck: 1 checked - 1 verified, 0 warning(s), 0 blocking
```

Every external name the file references (`RandomIntInternal`, `data_0209d4b8`, `data_02082214`) resolves in `config/**/symbols.txt`, and the relocations land where the cartridge puts them.

## Enrollment

One hunk in `config/arm9/overlays/ov006/delinks.txt`, inserted by address between the existing `0x02115150` and `0x02115480` entries:

```
src/func_ov006_02115248.cpp:
    complete
    .text start:0x02115248 end:0x02115480
```

`tools/enroll.py` proposes this same entry. It also wants to strip a run of blank lines elsewhere in ov006, reorder two ov070 entries, and rewrite the files from CRLF to LF; none of that is related to this change, so it was reverted and the entry hand-inserted with the file's existing line endings. The branch touches nothing else.

## Other gates

```
langmode ratchet PASS
duplicate-sources: 9471 stems, none doubled
eligible: 11182 / 11258         (func_ov006_02115248 is in build/eligible-names.txt)
check_references: unresolved symbols 42 (baseline 45); OK: no new unresolvable references
check_src_tu: 30 translation unit(s), 316 include(s), 783 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.
python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll  ->  Ran 80 tests, OK
```

Measured against `origin/main` rather than against the historical baseline file, the only langmode counter this branch moves is `shadow_decls.local_struct_body` 1758 to 1759 (and its `_cpp` half 933 to 934), which is the one small local type described below. Nothing else changes, and the ratchet passes.

## The lever

A two-int local value type with an empty destructor forces the ROM's stack home for the spawn pair. Written as a plain POD the pair is scalarised into registers and the frame comes out `sub sp, #0x1c`; giving the type a destructor makes it non-POD, the pair gets a stack slot, and the frame becomes the cartridge's `sub sp, #0x24`. That is the only difference between an otherwise byte-identical body and this one. The second load-bearing detail, spelling the widened sine as its own assigned statement ahead of the first 64-bit product, is documented in the file's header comment along with the twenty-odd spellings that were measured and rejected.

The two slot arrays are reached by raw offset rather than through the header's array members: a struct-array view of either one changes the frame and the loop's addressing and does not reproduce.
