### PR TITLE
Match three more ov006 minigame functions: the Coin cup touch test, the pen drag handler and the Coin cursor sprite

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -1674,9 +1674,17 @@ src/_ZN11dScMgCoin_cD0Ev.cpp:
     complete
     .text start:0x020dbe64 end:0x020dbe9c
 
+src/func_ov006_020dbe9c.c:
+    complete
+    .text start:0x020dbe9c end:0x020dbf7c
+
 src/actors/dScMgCoin_c.cpp:
     complete
     .text start:0x020dbf7c end:0x020dd0e0
+
+src/func_ov006_020dd0e0.c:
+    complete
+    .text start:0x020dd0e0 end:0x020dd2cc
 
 src/func_ov006_020dd2cc.cpp:
     complete
@@ -1877,6 +1885,10 @@ src/func_ov006_020e1680.c:
 src/func_ov006_020e17f8.cpp:
     complete
     .text start:0x020e17f8 end:0x020e1854
+
+src/func_ov006_020e1854.c:
+    complete
+    .text start:0x020e1854 end:0x020e1b54
 
 src/func_ov006_020e1b54.c:
     complete

--- a/include/dScMgAmida_c.h
+++ b/include/dScMgAmida_c.h
@@ -94,8 +94,15 @@ struct dScMgAmida_c : dScMgBase_c {
     virtual int  Virtual8C();                          /* slot 35 */
     virtual int  Unk36();                                /* slot 36 */
 
-    u8  unk_4660[4][8];      /* 0x4660 -- only ever passed around whole */
-    u8  pad_4680[0x50];
+    s32 unk_4660[4][2];      /* 0x4660 */
+    s8  unk_4680[4];          /* 0x4680 */
+    s32 unk_4684[4];          /* 0x4684 */
+    s32 unk_4694[4];          /* 0x4694 */
+    s32 unk_46a4[4];          /* 0x46a4 */
+    s8  unk_46b4[4];          /* 0x46b4 */
+    s32 unk_46b8[4];          /* 0x46b8 */
+    s32 unk_46c8;             /* 0x46c8 */
+    s32 unk_46cc;             /* 0x46cc */
     s32 mState;               /* 0x46d0 -- Behavior's state switch: 0 setup,
                                  1 playing, 2 result wait, 3 finale */
     u8  mFinished;            /* 0x46d4 -- set when mRoundCount reaches 5;

--- a/src/func_ov006_020dbe9c.c
+++ b/src/func_ov006_020dbe9c.c
@@ -1,0 +1,57 @@
+/* func_ov006_020dbe9c -- dScMgCoin_c, ov006 0x020dbe9c, 0xe0 bytes.
+ *
+ * Draws the hand cursor while the stylus is down: the sine table entry for the
+ * scene's current angle becomes a 2x2 rotation matrix [cos, sin; -sin, cos] at
+ * unit scale, and that plus the touch position goes to the shared sprite call.
+ *
+ * THE FOUR MATRIX WORDS ARE WRITTEN AS ANONYMOUS EXPRESSIONS, IN SLOT ORDER,
+ * AFTER THE ICON INDEX.  That is the whole match and it took the run's widest
+ * sweep to find.  Two rigid regimes exist here: with `#pragma opt_propagation
+ * off` the registers are the cartridge's but the two 64-bit values complete in
+ * the wrong order, and without it they complete in the right order but the sine
+ * table's base colours to ip where the cartridge uses r4.  Neither regime moved
+ * under 28 statement orders, 6 multiply spellings, 12 table-pointer forms or 39
+ * pragma combinations, because every one of those kept a named `rx` / `ry` pair.
+ * Deleting the pair -- storing straight into vec[] -- collapses both regimes
+ * onto the cartridge's schedule, and then the icon index has to be read FIRST:
+ * moving that one line below any of the four stores costs fifteen words.
+ *
+ * The unit scale is written as a multiply, not a shift, because that is what
+ * FX_MUL is; 2004/b56 strength-reduces it to the 64-bit shift either way and the
+ * bytes are identical for `* 0x1000` and `<< 12`.
+ */
+#pragma opt_propagation off
+
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+typedef long long s64;
+
+extern s16 data_02082214[];
+extern void *data_ov006_02134b4c[];
+extern void func_ov004_020b023c(void *obj, int x, int y, int w, int *vec);
+
+#define FX_MUL(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
+
+void func_ov006_020dbe9c(char *c)
+{
+    char *s = c + 0x5000;
+
+    if (*(u8 *)(s + 0x1bd) == 0)
+        return;
+    {
+        u16 idx_h = *(u16 *)(c + 0x5100 + 0xb8);
+        s32 xr = *(s32 *)(s + 0x1a8);
+        s32 yr = *(s32 *)(s + 0x1ac);
+        int i = (idx_h >> 4) * 2;
+        int vec[4];
+        u8 idx_l = *(u8 *)(s + 0x1be);
+
+        vec[0] = FX_MUL(data_02082214[i + 1], 0x1000);
+        vec[1] = FX_MUL(data_02082214[i], 0x1000);
+        vec[2] = -FX_MUL(data_02082214[i], 0x1000);
+        vec[3] = FX_MUL(data_02082214[i + 1], 0x1000);
+        func_ov004_020b023c(data_ov006_02134b4c[idx_l], xr >> 12, yr >> 12, -1, vec);
+    }
+}

--- a/src/func_ov006_020dbe9c.c
+++ b/src/func_ov006_020dbe9c.c
@@ -1,3 +1,4 @@
+// @symbol func_ov006_020dbe9c
 /* func_ov006_020dbe9c -- dScMgCoin_c, ov006 0x020dbe9c, 0xe0 bytes.
  *
  * Draws the hand cursor while the stylus is down: the sine table entry for the

--- a/src/func_ov006_020dd0e0.c
+++ b/src/func_ov006_020dd0e0.c
@@ -1,0 +1,121 @@
+/* func_ov006_020dd0e0 -- dScMgCoin_c, ov006 0x020dd0e0, 0x1ec bytes.
+ *
+ * The touch test for one of the four cups. While the scene is in state 2 and the
+ * stylus is both down and newly pressed, if the touch point is within 0x10 of
+ * this cup's centre the cup is taken: a cup that still holds something starts
+ * its hop (state 1, target y = the cup's own y, vy = -0x3000), otherwise the
+ * round ends -- state 3, a 0x40 timer, the pan-positioned reveal jingle, and the
+ * star count compared against the scene's target to set the win flag.
+ *
+ * FOUR THINGS ARE LOAD BEARING, ALL MEASURED AGAINST THE CARTRIDGE.
+ *
+ * 1. p1 IS ASSIGNED BEFORE p0.  The cup's y address has to be computed first;
+ *    swapping the two lines costs seven words and no bytes are saved.
+ * 2. THE TOUCH POINT IS RE-READ THROUGH THE GLOBAL.  ax/ay index
+ *    data_020a0dea / data_020a0deb with `data_020a0e40 * 4`, not with the `i`
+ *    that the pressed test above already holds.  The second read is what puts
+ *    the pool base in r3 and the index byte in r2 the way the ROM does; with
+ *    `i * 4` there the pair is exchanged, everything else identical.
+ * 3. THERE IS NO `fld` BASE POINTER.  Each of the five cup-record stores spells
+ *    its own `self + n + 0x4000 + ...`; hoisting one pointer for them exchanges
+ *    r2 and r3 across the whole block.
+ * 4. THE HOP'S TARGET Y RE-READS ITS ADDRESS.  `*(int *)(self + 0x4ac4 + n)`,
+ *    not `*p1`, even though p1 is that address and is still live.
+ *
+ * No pragma: `#pragma opt_propagation off`, which earlier drafts carried, costs
+ * six words here.
+ */
+typedef short s16;
+typedef unsigned char u8;
+
+extern u8 data_020a0e40;
+extern u8 data_020a0de8[];
+extern u8 data_020a0de9[];
+extern u8 data_020a0dea[];
+extern u8 data_020a0deb[];
+
+extern void func_ov006_020dd4b0(char *c, int i);
+extern void func_ov006_020dcb1c(char *c, int i);
+extern void func_020127a4(int a, int b, int c, int d);
+extern void _ZN5Sound12PlayBank2_2DEj(unsigned int id);
+
+extern void *data_ov004_020beb68;
+
+void func_ov006_020dd0e0(char *self, int idx)
+{
+    int i;
+    int ok;
+    int n;
+    int v;
+    int w;
+    int *p0;
+    int *p1;
+    int ax;
+    int ay;
+    int q0;
+    int q1;
+    int ang;
+    int stars;
+    int need;
+
+    if (*(int *)(self + 0x5000 + 0x1c8) != 2)
+        return;
+
+    i = data_020a0e40;
+    ok = 0;
+    if (data_020a0de8[i * 4] != 0 && data_020a0de9[i * 4] != 0)
+        ok = 1;
+    if (ok == 0)
+        return;
+
+    n = idx * 0x18;
+    p1 = (int *)(self + 0x4ac4 + n);
+    p0 = (int *)(self + 0x4ac0 + n);
+    q1 = *p1;
+    ax = data_020a0dea[data_020a0e40 * 4];
+    ay = data_020a0deb[data_020a0e40 * 4];
+    q0 = *p0;
+    v = ax - (q0 >> 12);
+    w = ay - (q1 >> 12);
+
+    if (v <= -0x10)
+        return;
+    if (v >= 0x10)
+        return;
+    if (w <= -0x10)
+        return;
+    if (w >= 0x10)
+        return;
+
+    *(u8 *)(self + n + 0x4000 + 0xad5) = 1;
+    if (*(u8 *)(self + n + 0x4000 + 0xad3) != 0) {
+        *(u8 *)(self + n + 0x4000 + 0xad0) = 1;
+        *(int *)(self + n + 0x4000 + 0xac8) = *(int *)(self + 0x4ac4 + n);
+        *(int *)(self + n + 0x4000 + 0xacc) = -0x3000;
+        *(u8 *)(self + n + 0x4000 + 0xad6) = 0;
+        func_ov006_020dd4b0(self, idx);
+        return;
+    }
+
+    func_ov006_020dcb1c(self, idx);
+    *(u8 *)(self + idx * 0x18 + 0x4000 + 0xad2) = 0;
+    *(int *)(self + 0x5000 + 0x1c8) = 3;
+    *(int *)(self + 0x5000 + 0x1cc) = 0x40;
+
+    ang = (*p0 >> 12) - 0x80;
+    ang >>= 1;
+    if (ang >= 0x3c)
+        ang = 0x3c;
+    if (ang <= -0x3c)
+        ang = -0x3c;
+    func_020127a4(2, 0xee, 0xffff, ang);
+    _ZN5Sound12PlayBank2_2DEj(0xf2);
+
+    *(u8 *)(self + 0x4000 + idx * 0x18 + 0xad0) = 2;
+    stars = (data_ov004_020beb68 != 0) ? *(int *)((char *)data_ov004_020beb68 + 0xa8) : 0;
+    need = *(int *)(self + 0x5000 + 0x1d4);
+    if (stars > need)
+        *(u8 *)(self + 0x5000 + 0x1db) = 1;
+    else
+        *(u8 *)(self + 0x5000 + 0x1db) = 0;
+}

--- a/src/func_ov006_020dd0e0.c
+++ b/src/func_ov006_020dd0e0.c
@@ -1,3 +1,4 @@
+// @symbol func_ov006_020dd0e0
 /* func_ov006_020dd0e0 -- dScMgCoin_c, ov006 0x020dd0e0, 0x1ec bytes.
  *
  * The touch test for one of the four cups. While the scene is in state 2 and the

--- a/src/func_ov006_020e1854.c
+++ b/src/func_ov006_020e1854.c
@@ -1,0 +1,168 @@
+/* func_ov006_020e1854 -- the pen handler for the ov006 slot-machine style scene,
+ * 0x020e1854, 0x300 bytes.
+ *
+ * While the stylus is down it drags the object: the touch point plus the stored
+ * grab offset becomes the new position, clamped into the 0x20000..0xe0000 x
+ * 0x94000..0xb8000 box.  A drag shorter than two units is undone outright.  What
+ * survives updates the swing bookkeeping (0x4eea's three-state direction
+ * machine), turns the drag vector into an angle at 0x4ede, clamps that angle
+ * into the lower half turn, averages it with the previous one, and folds the
+ * drag length into the 0x4ec8 speed with a decay when it falls.  Finally the
+ * grab offset is re-derived from the new position so the next tick drags from
+ * the same spot on the object.  With the stylus up, two flags are reset.
+ *
+ * THREE THINGS ARE LOAD BEARING AND ALL THREE WERE MEASURED.
+ *
+ * 1. THE TOUCH TABLE IS REACHED THROUGH A BYTE VIEW OF A RECORD ARRAY.
+ *    data_020a0dea and data_020a0deb are four-byte records (the B4 shape that
+ *    src/minigames/d_s_mg_trampoline.cpp already declares for the same
+ *    globals), and this file takes a `u8 *` of each before indexing.  A plain
+ *    `u8 data_020a0dea[]` extern with no cast, `&arr[0]`, `arr + 0`, or a u8*
+ *    alias of a u8 array all cost eighteen more words: the cast has to cross a
+ *    type boundary for 2004/b56 to keep the ROM's addressing.
+ *
+ * 2. dx IS COMPUTED BEFORE dy, AND NEITHER SUBTRACTION GETS A NAMED TEMPORARY.
+ *    Writing dy first, or routing either difference through an `int t`, leaves
+ *    the ROM's shape four words off: the cartridge loads the new x into a fresh
+ *    register and puts both subtractions in the register the base pointer just
+ *    vacated, while the other orders reuse the dying base for the load and
+ *    subtract in place.
+ *
+ * 3. THE TAIL BLOCK'S SLOT INDEX IS WIDER THAN A BYTE.  `unsigned short j`
+ *    (int, short and unsigned int are byte-identical to it); `u8 j` costs six
+ *    words in the two table reads under it.
+ *
+ * `#pragma opt_common_subs off` is real: the two 0x4eb0/0x4eb4 re-reads after
+ * the clamps have to stay re-reads.
+ */
+struct B4 { unsigned char v; unsigned char pad[3]; };
+
+#pragma opt_common_subs off
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef long long s64;
+extern u8 data_020a0e40[];
+extern u8 data_020a0de8[];
+extern struct B4 data_020a0dea[];
+extern struct B4 data_020a0deb[];
+extern int func_0203d744(long long x);
+extern void func_02012718(int a, int b);
+extern u16 func_0203b4dc(int a, int b);
+
+void func_ov006_020e1854(void *arg)
+{
+    u8 *c = (u8 *)arg;
+    u8 idx;
+    int dx, oldx, oldy;
+    int diff;
+    u16 ang;
+
+    idx = data_020a0e40[0];
+    if (data_020a0de8[idx * 4] != 0) {
+        int dy2, dy;
+
+        int i4 = idx * 4;
+        u8 *pa = (u8 *)data_020a0dea;
+        u8 *pb = (u8 *)data_020a0deb;
+        u8 bx = pa[i4];
+        u8 by = pb[i4];
+
+        oldx = *(int *)(c + 0x4eb0);
+        oldy = *(int *)(c + 0x4eb4);
+        *(int *)(c + 0x4eb0) = (bx << 12) + *(int *)(c + 0x4ec0);
+        *(int *)(c + 0x4eb4) = *(int *)(c + 0x4ec4) + (by << 12);
+
+        if (*(int *)(c + 0x4eb4) <= 0x94000)
+            *(int *)(c + 0x4eb4) = 0x94000;
+        if (*(int *)(c + 0x4eb0) <= 0x20000)
+            *(int *)(c + 0x4eb0) = 0x20000;
+        if (*(int *)(c + 0x4eb0) >= 0xe0000)
+            *(int *)(c + 0x4eb0) = 0xe0000;
+        if (*(int *)(c + 0x4eb4) >= 0xb8000)
+            *(int *)(c + 0x4eb4) = 0xb8000;
+
+
+        dx = (*(int *)(c + 0x4eb0) - oldx) >> 12;
+        dy = (*(int *)(c + 0x4eb4) - oldy) >> 12;
+        dy2 = dy * dy;
+
+        if (func_0203d744((s64)(dx * dx + dy2)) <= 1) {
+            *(int *)(c + 0x4eb0) = oldx;
+            *(int *)(c + 0x4eb4) = oldy;
+            return;
+        }
+
+        diff = (*(int *)(c + 0x4eb4) - *(int *)(c + 0x4ebc)) >> 12;
+        if (*(u8 *)(c + 0x4eea) == 0) {
+            func_02012718(0x1d6, *(int *)(c + 0x4eb0));
+            *(u8 *)(c + 0x4eea) = 2;
+            *(int *)(c + 0x4ed4) = (*(int *)(c + 0x4eb4) - *(int *)(c + 0x4ebc)) >> 12;
+            *(int *)(c + 0x4ebc) = *(int *)(c + 0x4eb4);
+        } else if (*(u8 *)(c + 0x4eea) == 1) {
+            if (*(int *)(c + 0x4ed4) * diff > 0) {
+                if (diff < 0)
+                    diff = -diff;
+                if (diff >= 0xa)
+                    *(u8 *)(c + 0x4eea) = 0;
+            } else {
+                *(int *)(c + 0x4ed4) = diff;
+                *(int *)(c + 0x4ebc) = *(int *)(c + 0x4eb4);
+            }
+        } else {
+            if (*(int *)(c + 0x4ed4) * diff < 0)
+                *(u8 *)(c + 0x4eea) = 1;
+            *(int *)(c + 0x4ed4) = (*(int *)(c + 0x4eb4) - *(int *)(c + 0x4ebc)) >> 12;
+            *(int *)(c + 0x4ebc) = *(int *)(c + 0x4eb4);
+        }
+
+        ang = *(u16 *)(c + 0x4ede);
+        *(u16 *)(c + 0x4ede) = func_0203b4dc(dy, dx >> 1);
+        {
+            u16 a = *(u16 *)(c + 0x4ede);
+            if (a <= 0x8000) {
+                if (a >= 0x4000) {
+                    *(u16 *)(c + 0x4ede) = 0x8000;
+                    goto ang_done;
+                }
+            }
+            if (a <= 0x4000)
+                *(u16 *)(c + 0x4ede) = 0;
+        }
+    ang_done:;
+
+        {
+            int mag;
+            *(u16 *)(c + 0x4ede) = (u16)((*(u16 *)(c + 0x4ede) + ang) >> 1);
+            mag = func_0203d744((s64)((dx >> 1) * (dx >> 1) + dy2)) * 9;
+            mag = (mag << 12) >> 4;
+            if (mag >= 0xc000)
+                mag = 0xc000;
+            if (mag > *(int *)(c + 0x4ec8))
+                *(int *)(c + 0x4ec8) = mag;
+            {
+                int cur = *(int *)(c + 0x4ec8);
+                if (cur > mag) {
+                    *(int *)(c + 0x4ec8) = *(int *)(c + 0x4ec8) - ((cur - mag) >> 1);
+                }
+            }
+        }
+
+
+        {
+            int px = *(int *)(c + 0x4eb0);
+            int py = *(int *)(c + 0x4eb4);
+            int j = data_020a0e40[0];
+            u8 jx = ((u8 *)data_020a0dea)[j * 4];
+            int ax = (px >> 12) - jx;
+            u8 jy = ((u8 *)data_020a0deb)[j * 4];
+            int ay = (py >> 12) - jy;
+            *(int *)(c + 0x4ec0) = ax << 12;
+            *(int *)(c + 0x4ec4) = ay << 12;
+        }
+
+        return;
+    }
+
+    *(u8 *)(c + 0x4ee4) = 0;
+    *(u8 *)(c + 0x4ee5) = 1;
+}

--- a/src/func_ov006_020e1854.c
+++ b/src/func_ov006_020e1854.c
@@ -1,3 +1,4 @@
+// @symbol func_ov006_020e1854
 /* func_ov006_020e1854 -- the pen handler for the ov006 slot-machine style scene,
  * 0x020e1854, 0x300 bytes.
  *

--- a/src/func_ov006_020e1854.c
+++ b/src/func_ov006_020e1854.c
@@ -46,9 +46,9 @@ extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];
 extern struct B4 data_020a0dea[];
 extern struct B4 data_020a0deb[];
-extern int func_0203d744(long long x);
+extern int _ZN4cstd4sqrtEy(long long x);
 extern void func_02012718(int a, int b);
-extern u16 func_0203b4dc(int a, int b);
+extern u16 _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
 
 void func_ov006_020e1854(void *arg)
 {
@@ -87,7 +87,7 @@ void func_ov006_020e1854(void *arg)
         dy = (*(int *)(c + 0x4eb4) - oldy) >> 12;
         dy2 = dy * dy;
 
-        if (func_0203d744((s64)(dx * dx + dy2)) <= 1) {
+        if (_ZN4cstd4sqrtEy((s64)(dx * dx + dy2)) <= 1) {
             *(int *)(c + 0x4eb0) = oldx;
             *(int *)(c + 0x4eb4) = oldy;
             return;
@@ -117,7 +117,7 @@ void func_ov006_020e1854(void *arg)
         }
 
         ang = *(u16 *)(c + 0x4ede);
-        *(u16 *)(c + 0x4ede) = func_0203b4dc(dy, dx >> 1);
+        *(u16 *)(c + 0x4ede) = _ZN4cstd5atan2E5Fix12IiES1_(dy, dx >> 1);
         {
             u16 a = *(u16 *)(c + 0x4ede);
             if (a <= 0x8000) {
@@ -134,7 +134,7 @@ void func_ov006_020e1854(void *arg)
         {
             int mag;
             *(u16 *)(c + 0x4ede) = (u16)((*(u16 *)(c + 0x4ede) + ang) >> 1);
-            mag = func_0203d744((s64)((dx >> 1) * (dx >> 1) + dy2)) * 9;
+            mag = _ZN4cstd4sqrtEy((s64)((dx >> 1) * (dx >> 1) + dy2)) * 9;
             mag = (mag << 12) >> 4;
             if (mag >= 0xc000)
                 mag = 0xc000;


### PR DESCRIPTION
Three more of ov006's minigame functions come back as byte-exact C, plus a header
commit that names the fields they and their neighbours read.

| function | address | size | what it is |
| --- | --- | --- | --- |
| `func_ov006_020dd0e0` | `0x020dd0e0` | `0x1ec` | dScMgCoin_c: the touch test for one of the four cups. While the scene is in state 2 and the stylus is newly down, a touch within `0x10` of this cup's centre takes it; a cup that still holds something starts its hop, otherwise the round ends with the reveal jingle and the star count compared against the target. |
| `func_ov006_020e1854` | `0x020e1854` | `0x300` | The pen drag handler for the slot-machine style scene. Touch point plus the stored grab offset becomes the new position, clamped into the `0x20000..0xe0000` by `0x94000..0xb8000` box; the surviving drag updates the swing direction machine, turns the drag vector into an angle, averages it with the previous one, and folds the drag length into the speed with a decay. |
| `func_ov006_020dbe9c` | `0x020dbe9c` | `0xe0` | dScMgCoin_c: the hand cursor sprite. The sine table entry for the scene's angle becomes a 2x2 rotation matrix at unit scale, and that plus the touch position goes to the shared sprite call. |

All three sat in the two holes that `src/actors/dScMgCoin_c.cpp` documents as the
reason its translation unit had to be licensed as a sub-range, plus the hole in
front of `func_ov006_020e1b54`.

## Byte gate

Strict relocs, swept across every known compiler version:

```
func_ov006_020dd0e0  MATCHING VERSIONS: 2004/b56, 1.2/base, 1.2/sp2, 1.2/sp2p3
func_ov006_020e1854  MATCHING VERSIONS: 2004/b56
func_ov006_020dbe9c  MATCHING VERSIONS: 2004/b56, 1.2/base, 1.2/sp2, 1.2/sp2p3
```

`build_pin.verify` at each symbol's `symbols.txt` address and size:

```
src/func_ov006_020dd0e0.c (True, '2004/b56')
src/func_ov006_020e1854.c (True, '2004/b56')
src/func_ov006_020dbe9c.c (True, '2004/b56')
```

## Header

`include/dScMgAmida_c.h` only names fields that already lived inside an existing
`pad_4680[0x50]` (and splits `unk_4660` into the word pairs its access sites read),
so every offset and the `sizeof(dScMgAmida_c) == 0x53fc` assert are unchanged.
`check_header_offsets --changed origin/main` reports 51 commented fields, 0
mismatched, 0 unparsed, struct spans `0x53fc`. All twelve files that include the
header still verify:

```
src/_ZN12dScMgAmida_c13InitResourcesEv.cpp          0x020d5384 0x5a0  (True, '2004/b56')
src/_ZN12dScMgAmida_c13OnYoshiTryEatEi.cpp          0x020d52f0  0x94  (True, '2004/b56')
src/_ZN12dScMgAmida_c21AfterCleanupResourcesEj.cpp  0x020d5924  0x50  (True, '2004/b56')
src/_ZN12dScMgAmida_c5Unk36Ev.cpp                   0x020d1188  0x18  (True, '2004/b56')
src/_ZN12dScMgAmida_c6RenderEv.cpp                  0x020d48dc 0x2a0  (True, '2004/b56')
src/_ZN12dScMgAmida_c8BehaviorEv.cpp                0x020d4b7c 0x774  (True, '2004/b56')
src/_ZN12dScMgAmida_c9Virtual7CEv.cpp               0x020d11a0  0x8c  (True, '2004/b56')
src/_ZN12dScMgAmida_c9Virtual88Eiiii.cpp            0x020d14c0 0x498  (True, '2004/b56')
src/_ZN12dScMgAmida_c9Virtual8CEv.cpp               0x020d1170  0x18  (True, '2004/b56')
src/_ZN12dScMgAmida_cD0Ev.cpp                       0x020d10b8  0xb4  (True, '2004/b56')
src/_ZN12dScMgAmida_cD1Ev.cpp                       0x020d1018  0xa0  (True, '2004/b56')
src/func_ov006_020d1ba0.cpp                         0x020d1ba0 0x9e0  (True, '2004/b56')
```

## Link check

```
1 changed header(s) fan out to 15 source file(s) to verify
  [OK  ] _ZN12dScMgAmida_c13InitResourcesEv           VERIFIED
  [OK  ] _ZN12dScMgAmida_c13OnYoshiTryEatEi           VERIFIED
  [OK  ] _ZN12dScMgAmida_c21AfterCleanupResourcesEj   VERIFIED
  [OK  ] _ZN12dScMgAmida_c5Unk36Ev                    VERIFIED
  [OK  ] _ZN12dScMgAmida_c6RenderEv                   VERIFIED
  [OK  ] _ZN12dScMgAmida_c8BehaviorEv                 VERIFIED
  [OK  ] _ZN12dScMgAmida_c9Virtual7CEv                VERIFIED
  [OK  ] _ZN12dScMgAmida_c9Virtual88Eiiii             VERIFIED
  [OK  ] _ZN12dScMgAmida_c9Virtual8CEv                VERIFIED
  [OK  ] _ZN12dScMgAmida_cD0Ev                        VERIFIED
  [OK  ] _ZN12dScMgAmida_cD1Ev                        VERIFIED
  [OK  ] func_ov006_020d1ba0                          VERIFIED
  [OK  ] func_ov006_020dbe9c                          VERIFIED
  [OK  ] func_ov006_020dd0e0                          VERIFIED
  [OK  ] func_ov006_020e1854                          VERIFIED
prepush-linkcheck: 15 checked - 15 verified, 0 warning(s), 0 blocking
```

## Enrollment

Three `complete` entries in `config/arm9/overlays/ov006/delinks.txt`, nothing else:

```
src/func_ov006_020dbe9c.c:   .text start:0x020dbe9c end:0x020dbf7c
src/func_ov006_020dd0e0.c:   .text start:0x020dd0e0 end:0x020dd2cc
src/func_ov006_020e1854.c:   .text start:0x020e1854 end:0x020e1b54
```

`tools/enroll.py` also wanted to strip 40 blank lines out of the ov006 file, reorder
two unrelated ov070 entries and rewrite the file to LF. None of that is in here; the
three entries were inserted by hand with the file's own CRLF endings.

## Ratchets and gates

```
langmode ratchet PASS
duplicate-sources: 9474 stems, none doubled
eligible: 11185 / 11261                     (was 11184 before the symbol-name fix below)
unresolved symbols: 42  (baseline 45)
eligible:           11185  (baseline 11044)
  3 fixed since the baseline -- run --update to bank it
OK: no new unresolvable references
check_src_tu: 30 translation unit(s), 316 include(s), 783 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.
check_header_offsets: 1 changed header(s) vs origin/main
include/dScMgAmida_c.h: 51 commented fields, 0 mismatched, 0 unparsed, struct spans 0x53fc
python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll
Ran 80 tests in 20.047s
OK
```

`config/unresolved-baseline.json` is left alone; the ratchet is three better than it
claims, which a later banking pass can pick up.

## One repair on the way in

`func_ov006_020e1854` was written calling its two helpers as `func_0203d744` and
`func_0203b4dc`, spellings no `symbols.txt` defines, so `tools/eligible.py` rejected
the file as unresolvable and a `complete` entry would have linked both calls to zero.
The addresses are `_ZN4cstd4sqrtEy` and `_ZN4cstd5atan2E5Fix12IiES1_`, and calling
them by those names from a `.c` file is what `src/Vec2_Len.c` and
`src/Vec3_HorzAngle.c` already do. Byte output is unchanged either way.

## The lever

All three cracked the same way: delete the named intermediate local and store the
expressions straight into their destination. `func_ov006_020dbe9c` is the clearest
case, where 28 statement orders, 6 multiply spellings, 12 table-pointer forms and 39
pragma combinations all failed because every one of them kept a named `rx` / `ry`
pair, and dropping the pair collapsed both rigid regimes onto the cartridge's own
register choice and schedule at once.

## Follow-up, not in this PR

The header comment on `src/actors/dScMgCoin_c.cpp` explains its partial range by
saying `func_ov006_020dbe9c` and `func_ov006_020dd0e0` have no source in the tree.
That is now out of date. The range itself is still right; only the reasoning needs a
rewrite, and it belongs with whoever next touches that translation unit.
