### PR TITLE
Repair five unmatched drafts: one that no longer compiled, three whose size was wrong, and two closer reconstructions

### DIFF
--- a/src/_ZN3MrI13InitResourcesEv.cpp
+++ b/src/_ZN3MrI13InitResourcesEv.cpp
@@ -1,54 +1,69 @@
 //cpp
-#include "TextureSequence.h"
-// NONMATCHING: constant / value (div=6). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-struct BMD_File;
-struct BTP_File;
-struct BCA_File;
-struct dActor_c;
-/* Vector3 comes from types.h through TextureSequence.h; the local shadow
-   `struct Vector3 { int x, y, z; }` collided with it and this file has not
-   compiled since. Fix12i is `s32`, so the header type is layout- and
-   value-identical -- the Q12 literals below are unchanged. */
-struct SharedFilePtr { void *hdr; void *ptr; };
+// @symbol _ZN3MrI13InitResourcesEv
+// NONMATCHING: 3/166 at exact size 0x298. The draft that stood here DID NOT COMPILE at
+// all -- `mwccarm.exe: undefined identifier 'Matrix4x3'` at its line 111 -- so it was
+// scoring nothing. This is a real C++ method on include/MrI.h with named members
+// (mModelAnim, mShadowModel, mdCcAcPos_c, mShadowRadiusScale, mShadowHeight, mTimer,
+// unk_1ec, unk_217) and no shadow structs.
+//
+// The whole residue is a three-word rotation of the ModelBase::SetFile argument setup at
+// +0x20: the ROM emits mov r2,#1 / mov r1,r0 / add r0,r4,#0xd4 / mov r3,r2, every build
+// here emits mov r1,r0 / add r0,r4,#0xd4 / mov r2,#1 / mov r3,r2. Same instruction
+// multiset, same registers -- pure emission order.
+//
+// PROBED, and this is the useful part for anyone who returns to it: mwccarm 2004/b56 DOES
+// emit the ROM's constant-first order, but only when the basic block holding the call also
+// contains a condition-code comparison. `if (!SetFile(...)) return;` and even a comparison
+// on an unrelated global (`g = (h == 3);`) both flip it; a plain call, an if with an empty
+// body, a switch, a goto label, a stored result, a trailing loop whose compare sits in the
+// loop latch, and a following call all leave it alone. This function has no comparison in
+// that block, so the order is out of reach from the source. Also inert: 14 conditional-
+// context spellings of the call, named/const/register/bool/byte/short constants, nested
+// and member-call forms of SetFile, 4 inline-helper wrappers, 7 structural variants of the
+// surrounding loop and declarations, and all 24 pragma cells.
+// @symbol _ZN3MrI13InitResourcesEv
+#include "MrI.h"
 
 struct BMD_File;
 struct BTP_File;
+struct BCA_File;
+struct SharedFilePtr { void *hdr; void *ptr; };
+
 extern "C" void LoadBlueCoinModel(void);
 extern "C" BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr &f);
-extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, BMD_File *f, int a, int b);
 extern "C" void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr &f);
+extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File &a, BTP_File &b);
 extern "C" void *_ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr &f);
-extern "C" int _ZN11ShadowModel12InitCylinderEv(void *self);
-extern "C" void _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(void *self, dActor_c *a, Vector3 const &b, int c, int d, unsigned int e, unsigned int f);
-extern "C" unsigned char _ZN8dActor_c9TrackStarEjj(dActor_c *self, unsigned int a, unsigned int b);
+extern "C" void _ZN10dCcAcPos_c4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *a, Vector3 const &b, int c, int d, unsigned int e, unsigned int f);
+extern "C" unsigned char _ZN5Actor9TrackStarEjj(void *self, unsigned int a, unsigned int b);
 extern "C" void func_ov071_02121634(void *self, int a);
 extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, BCA_File *f, int a, int b, unsigned int c);
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, BTP_File &f, int a, int b, unsigned int c);
 extern "C" void _ZN9dBgCh_GndC1Ev(void *self);
-extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(void *self, Vector3 const &pos, dActor_c *act);
+extern "C" void _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P5Actor(void *self, Vector3 const &pos, void *act);
 extern "C" int _ZN9dBgCh_Gnd10DetectClsnEv(void *self);
-extern "C" void func_ov071_02120c90(char *c);
+extern "C" void func_ov071_02120c90(void *c);
 extern "C" void _ZN9dBgCh_GndD1Ev(void *self);
 
-extern SharedFilePtr data_ov002_0210da38;
-extern SharedFilePtr data_ov071_02123050;
-extern SharedFilePtr *data_ov071_021226a4[2];
-extern SharedFilePtr data_ov071_021226a0;
-extern SharedFilePtr data_ov071_02123048;
-extern SharedFilePtr data_ov071_02123038;
-extern char IDENTITY_MATRIX4X3;
+extern "C" SharedFilePtr data_ov002_0210da38;
+extern "C" SharedFilePtr data_ov071_02123050;
+extern "C" SharedFilePtr *data_ov071_021226a4[2];
+extern "C" SharedFilePtr data_ov071_021226a0;
+extern "C" SharedFilePtr data_ov071_02123048;
+extern "C" SharedFilePtr data_ov071_02123038;
+extern "C" char data_02082128;
 
+struct M48 { int w[12]; };
 
-extern "C" int _ZN3MrI13InitResourcesEv(char *c)
+s32 MrI::InitResources()
 {
+    char *c = (char *)this;
     BMD_File *bmd;
     LoadBlueCoinModel();
 
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da38);
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov071_02123050);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, bmd, 1, 1);
+    ((ModelBase *)&mModelAnim)->SetFile(bmd, 1, 1);
 
     int i;
     for (i = 0; i < 2; i++) {
@@ -56,26 +71,26 @@ extern "C" int _ZN3MrI13InitResourcesEv(char *c)
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(*seq);
         BMD_File *bmd2 = *(BMD_File **)((char *)&data_ov071_02123050 + 4);
         BTP_File *btp = *(BTP_File **)((char *)seq + 4);
-        TextureSequence::Prepare(*bmd2, *btp);
+        _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(*bmd2, *btp);
     }
 
     _ZN9Animation8LoadFileER13SharedFilePtr(**(SharedFilePtr **)&data_ov071_021226a0);
 
-    if (!_ZN11ShadowModel12InitCylinderEv(c + 0x14c))
+    if (!mShadowModel.InitCylinder())
         return 0;
 
-    unsigned short kind = *(unsigned short *)(c + 0xc);
+    unsigned short kind = actorID;
     int isKind1 = (kind == 0x106);
     if (isKind1) {
         Vector3 v;
         v.x = 0;
         v.y = -0x4b000;
         v.z = 0;
-        _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(c + 0x174, (dActor_c *)c, v, 0x55000, 0x96000, 0x200004, 0x42000);
-        *(int *)(c + 0x80) = 0x1000;
-        *(int *)(c + 0x84) = 0x1000;
-        *(int *)(c + 0x88) = 0x1000;
-        *(int *)(c + 0x1f0) = 0x1000;
+        _ZN10dCcAcPos_c4InitEP5ActorRK7Vector35Fix12IiES6_jj(&mdCcAcPos_c, c, v, 0x55000, 0x96000, 0x200004, 0x42000);
+        mScaleX = 0x1000;
+        mScaleY = 0x1000;
+        mScaleZ = 0x1000;
+        mShadowRadiusScale = 0x1000;
     } else {
         int isKind2 = (kind == 0x107);
         if (isKind2) {
@@ -83,43 +98,44 @@ extern "C" int _ZN3MrI13InitResourcesEv(char *c)
             v.x = 0;
             v.y = -0x96000;
             v.z = 0;
-            _ZN10dCcAcPos_c4InitEP8dActor_cRK7Vector35Fix12IiES6_jj(c + 0x174, (dActor_c *)c, v, 0xaa000, 0x12c000, 0x200004, 0);
-            *(int *)(c + 0x80) = 0x2000;
-            *(int *)(c + 0x84) = 0x2000;
-            *(int *)(c + 0x88) = 0x2000;
-            *(int *)(c + 0x1f0) = 0x2000;
+            _ZN10dCcAcPos_c4InitEP5ActorRK7Vector35Fix12IiES6_jj(&mdCcAcPos_c, c, v, 0xaa000, 0x12c000, 0x200004, 0);
+            mScaleX = 0x2000;
+            mScaleY = 0x2000;
+            mScaleZ = 0x2000;
+            mShadowRadiusScale = 0x2000;
+            {
+                unsigned char mask = (unsigned char)(param1 & 0xf);
+                unsigned char star = _ZN5Actor9TrackStarEjj(c, mask, 2);
+                unk_217 = star;
+            }
         }
     }
 
-    unsigned char mask = (unsigned char)(*(unsigned int *)(c + 8) & 0xf);
-    unsigned char star = _ZN8dActor_c9TrackStarEjj((dActor_c *)c, mask, 2);
-    *(unsigned char *)(c + 0x217) = star;
-
-    *(int *)(c + 0x9c) = 0;
-    *(int *)(c + 0xa0) = 0;
+    mVertAccel = 0;
+    mTerminalVelocity = 0;
     func_ov071_02121634(c, 0);
 
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (BCA_File *)data_ov071_02123048.ptr, 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(&mModelAnim, (BCA_File *)data_ov071_02123048.ptr, 0, 0x1000, 0);
 
     *(int *)(c + 0x130) = 0x1000;
-    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, *(BTP_File *)data_ov071_02123038.ptr, 0, 0x1000, 0);
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(&mTextureSequence, *(BTP_File *)data_ov071_02123038.ptr, 0, 0x1000, 0);
 
     *(int *)(c + 0x144) = 0x1000;
-    *(int *)(c + 0x1ec) = 0;
-    *(unsigned char *)(c + 0x216) = 0x2e;
+    unk_1ec = 0;
+    mTimer = 0x2e;
 
-    *(Matrix4x3 *)(c + 0x1b4) = *(Matrix4x3 *)&IDENTITY_MATRIX4X3;
+    *(M48 *)&mShadowMat = *(M48 *)&data_02082128;
 
     char rg[0x50];
     _ZN9dBgCh_GndC1Ev(rg);
-    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P8dActor_c(rg, *(Vector3 *)(c + 0x5c), (dActor_c *)c);
+    _ZN9dBgCh_Gnd12SetObjAndPosERK7Vector3P5Actor(rg, *(Vector3 *)&mPosX, c);
     int y;
     if (_ZN9dBgCh_Gnd10DetectClsnEv(rg)) {
-        y = (*(int *)(c + 0x60) - *(int *)(rg + 0x44)) + 0x1e000;
+        y = (mPosY - *(int *)(rg + 0x44)) + 0x1e000;
     } else {
         y = 0x12c000;
     }
-    *(int *)(c + 0x200) = y;
+    mShadowHeight = y;
     func_ov071_02120c90(c);
     _ZN9dBgCh_GndD1Ev(rg);
 

--- a/src/func_ov003_020ae358.c
+++ b/src/func_ov003_020ae358.c
@@ -1,32 +1,42 @@
-// NONMATCHING: near-miss from DB (div=134)
+// NONMATCHING: 8/230 at exact size 0x398. The previous draft here was 0x394 -- four
+// bytes SHORT, so it was an incomplete reconstruction, not a near-miss; this body is
+// size-exact and every divergence is register/emission order:
+//   * +0xfc/+0x100 the two hoisted pool addresses (&data_020a0e40, &data_020a0de8) are
+//     loaded in the opposite ORDER; the registers themselves are the ROM's.
+//   * +0x11c/+0x124 the two address temps `c + i` and &data_020a0de8[data_020a0e40]
+//     swap r2 and r3, and that swap follows the load order above.
+// Naming either address (a `p = (unsigned char *)(c + i)` cursor, with or without a
+// named global index) costs 52 more words: both temps must stay anonymous. Per
+// notes/mwccarm-codegen.md 6bu lever 2 the hoisted-constant emission order is a property
+// of the region and no source edit permutes it.
 extern void func_02012790(int a);
 extern int _ZN8SaveData19IsCharacterUnlockedEj(unsigned int i);
 extern int func_ov003_020adec0(char* c, unsigned int r6);
 
-extern unsigned char data_020a0e40[];
-extern unsigned char data_020a0de8[];
-extern unsigned char data_020a0de9[];
-extern unsigned char data_020a0dea[];
-extern unsigned char data_020a0deb[];
+extern unsigned char data_020a0e40;
+extern unsigned char data_020a0de8[][4];
+extern unsigned char data_020a0de9[][4];
+extern unsigned char data_020a0dea[][4];
+extern unsigned char data_020a0deb[][4];
 extern int data_0208ee44;
 extern unsigned char data_0209caa0[];
 extern unsigned char data_02092128[];
 extern unsigned char data_02092114[];
 extern unsigned short data_020a0e58;
-extern unsigned short data_020a0e5a[];
+extern unsigned short data_020a0e5a[][2];
 
 void func_ov003_020ae358(char* c)
 {
-    unsigned char idx = data_020a0e40[0];
-    unsigned char unlocked = 0;
+    int idx = data_020a0e40;
+    int unlocked = 0;
     int i;
-    if (data_020a0de8[idx * 4] != 0) {
-        unlocked = (data_020a0de9[idx * 4] != 0);
+    if (data_020a0de8[idx][0] != 0) {
+        unlocked = (data_020a0de9[idx][0] != 0);
     }
     if (unlocked == 0) goto sect2;
-
-    if (((unsigned char)(data_020a0dea[idx * 4] - 0x58) < 0x50) &&
-        ((unsigned char)(data_020a0deb[idx * 4] - *(unsigned char*)(c + 0x12b) + 0x28) < 0x50)) {
+    
+    if (((unsigned char)(data_020a0dea[idx][0] - 0x58) < 0x50) &&
+        ((unsigned char)(data_020a0deb[idx][0] - *(unsigned char*)(c + 0x12b) + 0x28) < 0x50)) {
         *(unsigned char*)(c + 0x133) = 2;
         *(unsigned char*)(c + 0x132) = 3;
         *(unsigned char*)(c + 0x118) = (unsigned char)(data_0208ee44 * 6);
@@ -40,13 +50,9 @@ void func_ov003_020ae358(char* c)
     if (data_0209caa0[0x41] != 3) return;
     for (i = 0; i < 3; i++) {
         if (_ZN8SaveData19IsCharacterUnlockedEj(i) != 0) {
-            unsigned char id2 = data_020a0e40[0];
-            unsigned char ax = data_020a0de8[id2 * 4 + 2];
-            int dx = (unsigned short)(ax - *(unsigned char*)(c + 0x124 + i) + 0x18);
-            if (dx < 0x30) {
-                unsigned char ay = data_020a0de8[id2 * 4 + 3];
-                int dy = (unsigned short)(ay - *(unsigned char*)(c + 0x128 + i) + 0x18);
-                if (dy < 0x2b) {
+            unsigned char *rec = data_020a0de8[data_020a0e40];
+            if ((unsigned short)(rec[2] - *(unsigned char*)(c + i + 0x124) + 0x18) < 0x30) {
+                if ((unsigned short)(rec[3] - *(unsigned char*)(c + i + 0x128) + 0x18) < 0x2b) {
                     *(unsigned char*)(c + 0x133) = 1;
                     *(unsigned char*)(c + 0x134) = (unsigned char)func_ov003_020adec0(c, i);
                     data_02092128[0] = (unsigned char)i;
@@ -64,54 +70,47 @@ void func_ov003_020ae358(char* c)
     return;
 
 sect2:
-    if (data_0209caa0[0x42] != 0) return;
-    {
+    if (data_0209caa0[0x42] == 0) {
         unsigned short ctrl = data_020a0e58;
-        if ((ctrl & 0x30) == 0) return;
-        if (*(unsigned short*)(c + 0x106) != 0) {
-            *(unsigned short*)(c + 0x106) -= 1;
-            return;
-        }
-        if (*(unsigned char*)(c + 0x135) == 0) return;
-        if (*(unsigned char*)(c + 0x133) != 1) return;
-        if (*(unsigned char*)(c + 0x130) < 3) return;
-        {
-            unsigned char r3 = *(unsigned char*)(c + 0x134);
-            unsigned char cur;
+        if ((ctrl & 0x30) != 0) {
+            unsigned short timer = *(unsigned short *) (c + 0x106);
+            unsigned char nr;
+            if (timer != 0) {
+                *(unsigned short *) (c + 0x106) -= 1;
+                return;
+            }
+            if (*(unsigned char *) (c + 0x135) == 0) {
+                return;
+            }
+            if (*(unsigned char *) (c + 0x133) != 1) {
+                return;
+            }
+            if (*(unsigned char *) (c + 0x130) < 3) {
+                return;
+            }
+            nr = *(unsigned char *) (c + 0x134);
             if (ctrl & 0x20) {
-                unsigned short c2 = data_020a0e58;
-                if ((c2 & 0x20) == 0) {
-                    if (*(unsigned short*)(c + 0x106) == 0) {
-                        if ((data_020a0e5a[idx * 2] & 0x20) != 0) {
-                            *(unsigned short*)(c + 0x106) = 0x10;
-                        } else {
-                            *(unsigned short*)(c + 0x106) = 8;
-                        }
-                        if (*(unsigned char*)(c + 0x134) != 0) {
-                            r3 = (unsigned char)(r3 - 1);
-                        }
+                if (((&data_020a0e58)[1] & 0x20) != 0 || timer == 0) {
+                    *(unsigned short *) (c + 0x106) = (data_020a0e5a[idx][0] & 0x20) ? 0x10 : 8;
+                    if (*(unsigned char *) (c + 0x134) != 0) {
+                        nr = nr - 1;
                     }
                 }
             } else if (ctrl & 0x10) {
-                unsigned short c2 = data_020a0e58;
-                if ((c2 & 0x10) == 0) {
-                    if (*(unsigned short*)(c + 0x106) == 0) {
-                        if ((data_020a0e5a[idx * 2] & 0x10) != 0) {
-                            *(unsigned short*)(c + 0x106) = 0x10;
-                        } else {
-                            *(unsigned short*)(c + 0x106) = 8;
-                        }
-                        cur = *(unsigned char*)(c + 0x134);
-                        if (cur != *(unsigned char*)(c + 0x130) - 2) {
-                            r3 = (unsigned char)(r3 + 1);
-                        }
+                if (((&data_020a0e58)[1] & 0x10) != 0 || timer == 0) {
+                    *(unsigned short *) (c + 0x106) = (data_020a0e5a[idx][0] & 0x10) ? 0x10 : 8;
+                    if (*(unsigned char *) (c + 0x134) != *(unsigned char *) (c + 0x130) - 2) {
+                        nr = nr + 1;
                     }
                 }
             }
-            cur = *(unsigned char*)(c + 0x134);
-            if (r3 == cur) return;
-            *(unsigned char*)(c + 0x134) = r3;
+            if (nr == *(unsigned char *) (c + 0x134)) {
+                return;
+            }
+            *(unsigned char *) (c + 0x134) = nr;
             func_02012790(0x12e);
+            return;
         }
     }
+    *(unsigned short *) (c + 0x106) = 0;
 }

--- a/src/func_ov003_020ae358.c
+++ b/src/func_ov003_020ae358.c
@@ -1,18 +1,21 @@
-// NONMATCHING: 8/230 at exact size 0x398. The previous draft here was 0x394 -- four
-// bytes SHORT, so it was an incomplete reconstruction, not a near-miss; this body is
-// size-exact and every divergence is register/emission order:
-//   * +0xfc/+0x100 the two hoisted pool addresses (&data_020a0e40, &data_020a0de8) are
-//     loaded in the opposite ORDER; the registers themselves are the ROM's.
-//   * +0x11c/+0x124 the two address temps `c + i` and &data_020a0de8[data_020a0e40]
-//     swap r2 and r3, and that swap follows the load order above.
-// Naming either address (a `p = (unsigned char *)(c + i)` cursor, with or without a
-// named global index) costs 52 more words: both temps must stay anonymous. Per
-// notes/mwccarm-codegen.md 6bu lever 2 the hoisted-constant emission order is a property
-// of the region and no source edit permutes it.
+// NONMATCHING: 6/230 at exact size 0x398. The draft that stood here was 0x394 -- four
+// bytes SHORT, an incomplete reconstruction rather than a near-miss.
+//
+// 8 -> 6 came from the permuter and the lever is worth keeping: the FIRST of the two
+// reads through `rec` is spelled inline as data_020a0de8[data_020a0e40][2] while the
+// SECOND stays rec[3]. That one asymmetry fixes the order in which the two hoisted pool
+// addresses (&data_020a0e40, &data_020a0de8) are loaded at +0xfc/+0x100. Inlining both
+// reads, inlining only the second, or moving the `rec` declaration below the first test
+// all cost 53 more words.
+//
+// The residue is the last six words: the two address temps `c + i` and
+// &data_020a0de8[data_020a0e40] swap r2 and r3 (+0x11c..+0x148). Naming either of them
+// costs 52 words; both must stay anonymous, and no ordering of the two subtractions
+// moves the pair.
+
 extern void func_02012790(int a);
 extern int _ZN8SaveData19IsCharacterUnlockedEj(unsigned int i);
-extern int func_ov003_020adec0(char* c, unsigned int r6);
-
+extern int func_ov003_020adec0(char *c, unsigned int r6);
 extern unsigned char data_020a0e40;
 extern unsigned char data_020a0de8[][4];
 extern unsigned char data_020a0de9[][4];
@@ -24,93 +27,120 @@ extern unsigned char data_02092128[];
 extern unsigned char data_02092114[];
 extern unsigned short data_020a0e58;
 extern unsigned short data_020a0e5a[][2];
-
-void func_ov003_020ae358(char* c)
+void func_ov003_020ae358(char *c)
 {
-    int idx = data_020a0e40;
-    int unlocked = 0;
-    int i;
-    if (data_020a0de8[idx][0] != 0) {
-        unlocked = (data_020a0de9[idx][0] != 0);
-    }
-    if (unlocked == 0) goto sect2;
-    
-    if (((unsigned char)(data_020a0dea[idx][0] - 0x58) < 0x50) &&
-        ((unsigned char)(data_020a0deb[idx][0] - *(unsigned char*)(c + 0x12b) + 0x28) < 0x50)) {
-        *(unsigned char*)(c + 0x133) = 2;
-        *(unsigned char*)(c + 0x132) = 3;
-        *(unsigned char*)(c + 0x118) = (unsigned char)(data_0208ee44 * 6);
-        *(unsigned char*)(c + 0x139) = 1;
-        *(unsigned char*)(c + 0x119) = 0x10;
-        func_02012790(data_0209caa0[0x41] + 0x3c);
-        return;
-    }
-
-    if (*(unsigned char*)(c + 0x130) <= 1) return;
-    if (data_0209caa0[0x41] != 3) return;
-    for (i = 0; i < 3; i++) {
-        if (_ZN8SaveData19IsCharacterUnlockedEj(i) != 0) {
-            unsigned char *rec = data_020a0de8[data_020a0e40];
-            if ((unsigned short)(rec[2] - *(unsigned char*)(c + i + 0x124) + 0x18) < 0x30) {
-                if ((unsigned short)(rec[3] - *(unsigned char*)(c + i + 0x128) + 0x18) < 0x2b) {
-                    *(unsigned char*)(c + 0x133) = 1;
-                    *(unsigned char*)(c + 0x134) = (unsigned char)func_ov003_020adec0(c, i);
-                    data_02092128[0] = (unsigned char)i;
-                    data_02092114[0] = (unsigned char)i;
-                    *(unsigned char*)(c + 0x132) = (unsigned char)i;
-                    *(unsigned char*)(c + 0x118) = (unsigned char)(data_0208ee44 * 3);
-                    *(unsigned char*)(c + 0x139) = 2;
-                    *(unsigned char*)(c + 0x119) = 0x10;
-                    func_02012790(data_0209caa0[0x41] + 0x3c);
-                    return;
-                }
-            }
-        }
-    }
+  int idx = data_020a0e40;
+  int unlocked = 0;
+  int i;
+  if (data_020a0de8[idx][0] != 0)
+  {
+    unlocked = data_020a0de9[idx][0] != 0;
+  }
+  if (unlocked == 0)
+  {
+    goto sect2;
+  }
+  if ((((unsigned char) (data_020a0dea[idx][0] - 0x58)) < 0x50) && (((unsigned char) ((data_020a0deb[idx][0] - (*((unsigned char *) (c + 0x12b)))) + 0x28)) < 0x50))
+  {
+    *((unsigned char *) (c + 0x133)) = 2;
+    *((unsigned char *) (c + 0x132)) = 3;
+    *((unsigned char *) (c + 0x118)) = (unsigned char) (data_0208ee44 * 6);
+    *((unsigned char *) (c + 0x139)) = 1;
+    *((unsigned char *) (c + 0x119)) = 0x10;
+    func_02012790(data_0209caa0[0x41] + 0x3c);
     return;
-
-sect2:
-    if (data_0209caa0[0x42] == 0) {
-        unsigned short ctrl = data_020a0e58;
-        if ((ctrl & 0x30) != 0) {
-            unsigned short timer = *(unsigned short *) (c + 0x106);
-            unsigned char nr;
-            if (timer != 0) {
-                *(unsigned short *) (c + 0x106) -= 1;
-                return;
-            }
-            if (*(unsigned char *) (c + 0x135) == 0) {
-                return;
-            }
-            if (*(unsigned char *) (c + 0x133) != 1) {
-                return;
-            }
-            if (*(unsigned char *) (c + 0x130) < 3) {
-                return;
-            }
-            nr = *(unsigned char *) (c + 0x134);
-            if (ctrl & 0x20) {
-                if (((&data_020a0e58)[1] & 0x20) != 0 || timer == 0) {
-                    *(unsigned short *) (c + 0x106) = (data_020a0e5a[idx][0] & 0x20) ? 0x10 : 8;
-                    if (*(unsigned char *) (c + 0x134) != 0) {
-                        nr = nr - 1;
-                    }
-                }
-            } else if (ctrl & 0x10) {
-                if (((&data_020a0e58)[1] & 0x10) != 0 || timer == 0) {
-                    *(unsigned short *) (c + 0x106) = (data_020a0e5a[idx][0] & 0x10) ? 0x10 : 8;
-                    if (*(unsigned char *) (c + 0x134) != *(unsigned char *) (c + 0x130) - 2) {
-                        nr = nr + 1;
-                    }
-                }
-            }
-            if (nr == *(unsigned char *) (c + 0x134)) {
-                return;
-            }
-            *(unsigned char *) (c + 0x134) = nr;
-            func_02012790(0x12e);
-            return;
+  }
+  if ((*((unsigned char *) (c + 0x130))) <= 1)
+  {
+    return;
+  }
+  if (data_0209caa0[0x41] != 3)
+  {
+    return;
+  }
+  for (i = 0; i < 3; i++)
+  {
+    if (_ZN8SaveData19IsCharacterUnlockedEj(i) != 0)
+    {
+      unsigned char *rec = data_020a0de8[data_020a0e40];
+      if (((unsigned short) ((data_020a0de8[data_020a0e40][2] - (*((unsigned char *) ((c + i) + 0x124)))) + 0x18)) < 0x30)
+      {
+        if (((unsigned short) ((rec[3] - (*((unsigned char *) ((c + i) + 0x128)))) + 0x18)) < 0x2b)
+        {
+          *((unsigned char *) (c + 0x133)) = 1;
+          *((unsigned char *) (c + 0x134)) = (unsigned char) func_ov003_020adec0(c, i);
+          data_02092128[0] = (unsigned char) i;
+          data_02092114[0] = (unsigned char) i;
+          *((unsigned char *) (c + 0x132)) = (unsigned char) i;
+          *((unsigned char *) (c + 0x118)) = (unsigned char) (data_0208ee44 * 3);
+          *((unsigned char *) (c + 0x139)) = 2;
+          *((unsigned char *) (c + 0x119)) = 0x10;
+          func_02012790(data_0209caa0[0x41] + 0x3c);
+          return;
         }
+      }
     }
-    *(unsigned short *) (c + 0x106) = 0;
+  }
+
+  return;
+  sect2:
+  if (data_0209caa0[0x42] == 0)
+  {
+    unsigned short ctrl = data_020a0e58;
+    if ((ctrl & 0x30) != 0)
+    {
+      unsigned short timer = *((unsigned short *) (c + 0x106));
+      unsigned char nr;
+      if (timer != 0)
+      {
+        *((unsigned short *) (c + 0x106)) -= 1;
+        return;
+      }
+      if ((*((unsigned char *) (c + 0x135))) == 0)
+      {
+        return;
+      }
+      if ((*((unsigned char *) (c + 0x133))) != 1)
+      {
+        return;
+      }
+      if ((*((unsigned char *) (c + 0x130))) < 3)
+      {
+        return;
+      }
+      nr = *((unsigned char *) (c + 0x134));
+      if (ctrl & 0x20)
+      {
+        if ((((&data_020a0e58)[1] & 0x20) != 0) || (timer == 0))
+        {
+          *((unsigned short *) (c + 0x106)) = (data_020a0e5a[idx][0] & 0x20) ? (0x10) : (8);
+          if ((*((unsigned char *) (c + 0x134))) != 0)
+          {
+            nr = nr - 1;
+          }
+        }
+      }
+      else
+        if (ctrl & 0x10)
+      {
+        if ((((&data_020a0e58)[1] & 0x10) != 0) || (timer == 0))
+        {
+          *((unsigned short *) (c + 0x106)) = (data_020a0e5a[idx][0] & 0x10) ? (0x10) : (8);
+          if ((*((unsigned char *) (c + 0x134))) != ((*((unsigned char *) (c + 0x130))) - 2))
+          {
+            nr = nr + 1;
+          }
+        }
+      }
+      if (nr == (*((unsigned char *) (c + 0x134))))
+      {
+        return;
+      }
+      *((unsigned char *) (c + 0x134)) = nr;
+      func_02012790(0x12e);
+      return;
+    }
+  }
+
+  *((unsigned short *) (c + 0x106)) = 0;
 }

--- a/src/func_ov007_020ba05c.c
+++ b/src/func_ov007_020ba05c.c
@@ -1,15 +1,19 @@
-// NONMATCHING: 16/161 at exact size 0x284. The previous draft here was 0x22c -- 88 bytes
+// NONMATCHING: 9/161 at exact size 0x284. The draft that stood here was 0x22c -- 88 bytes
 // SHORT and semantically wrong (array24/array28 were read off the wrong shadow struct),
-// so it was an incomplete reconstruction rather than a near-miss. This is a fresh
-// size-exact reconstruction and the whole residue is two callee-saved pair swaps in the
-// path-node block at +0x104..+0x15c: the ROM colours the node pointer r7 and the node
-// count r8 (and the two distance accumulators sb/sl) where every build here takes the
-// mirror assignment. MEASURED INERT: all 120 declaration permutations of the block's five
-// locals with split declarations, and all 360 initialised-declaration forms (five
-// initialised declarations x the six positions of the `r5 = 0` statement) -- consistent
-// with notes 6bs, where rank stops biting once the declaration is split from the
-// assignment. Both sides take fresh registers here, so this is a colouring-priority
-// difference and not the recycle rule.
+// so it was an incomplete reconstruction rather than a near-miss.
+//
+// 16 -> 9 came from the permuter and the lever is note 6bu #5 seen from the other side:
+// the x half of the reference distance must NOT have a name. Written `int rx = *(s16 *)
+// (r4 + 0x3c); int dd = rx * rx + rz * rz;` the named copy takes r7 away from the node
+// pointer and the whole r7/r8 pair rotates; written as two inline reads of the same
+// halfword it lands on the ROM's registers. `rz` must stay named -- inlining it too costs
+// the same seven words back.
+//
+// Residue is the last nine words: the sb <-> sl pair over the two squared distances
+// (+0x138..+0x15c). MEASURED INERT: all 120 declaration permutations of the block's five
+// outer locals, all 360 initialised-declaration forms (five initialised declarations x the
+// six positions of `r5 = 0`), splitting `dz`/`dx` into a load then an in-place subtract,
+// swapping the dz/dx declaration order, and inlining rz as well.
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -67,8 +71,7 @@ int func_ov007_020ba05c(void)
                     int dz = (((int *)*(char **)(o + 0x28))[idx] >> 12) - x;
                     int rz = *(s16 *)(r4 + 0x3e);
                     int dx = (((int *)*(char **)(o + 0x24))[idx] >> 12) - y;
-                    int rx = *(s16 *)(r4 + 0x3c);
-                    int dd = rx * rx + rz * rz;
+                    int dd = *(s16 *)(r4 + 0x3c) * *(s16 *)(r4 + 0x3c) + rz * rz;
                     int dd2 = dx * dx + dz * dz;
                     if (dd >= 0x100 && dd2 <= 4)
                         flag = 1;

--- a/src/func_ov007_020ba05c.c
+++ b/src/func_ov007_020ba05c.c
@@ -1,174 +1,110 @@
-/* NONMATCHING -- compiles, but the result is 0x22c bytes against the ROM's 0x284:
- * 88 bytes SHORT, so this is an incomplete reconstruction rather than a near-miss.
- *
- * Three defects had to be fixed before it would compile at all, and each was a shadow
- * struct disagreeing with itself: `array24` and `array28` are members of StructObj0 but
- * were being read off StructObj20, and `f2C` was used on StructAInner without being
- * declared. The pad split below keeps every later offset where it was (pad1 spanned
- * 0x0c..0x30, so 0x20 of pad puts f2C at 0x2c and leaves f30 at 0x30).
- *
- * Those fixes are right, and they are what exposed the 88-byte gap the compile error
- * had been hiding.
- */
+// NONMATCHING: 16/161 at exact size 0x284. The previous draft here was 0x22c -- 88 bytes
+// SHORT and semantically wrong (array24/array28 were read off the wrong shadow struct),
+// so it was an incomplete reconstruction rather than a near-miss. This is a fresh
+// size-exact reconstruction and the whole residue is two callee-saved pair swaps in the
+// path-node block at +0x104..+0x15c: the ROM colours the node pointer r7 and the node
+// count r8 (and the two distance accumulators sb/sl) where every build here takes the
+// mirror assignment. MEASURED INERT: all 120 declaration permutations of the block's five
+// locals with split declarations, and all 360 initialised-declaration forms (five
+// initialised declarations x the six positions of the `r5 = 0` statement) -- consistent
+// with notes 6bs, where rank stops biting once the declaration is split from the
+// assignment. Both sides take fresh registers here, so this is a colouring-priority
+// difference and not the recycle rule.
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
-typedef signed char s8;
-typedef signed short s16;
-typedef signed int s32;
+typedef short s16;
 
-extern void* data_ov007_02104ba0;
-extern void* data_ov007_0210342c;
+extern char *data_ov007_02104ba0;
+extern char *data_ov007_0210342c;
 
-extern int func_ov007_020c1da0(int);
-extern void func_ov007_020c6724(void*);
-extern int func_ov007_020c65bc(int);
-extern void func_ov007_020bdbcc(s16, s16);
-extern int func_ov007_020c6550(void*);
-extern void func_ov007_020bb09c(void);
+extern int func_ov007_020c1da0(int i);
+extern void func_ov007_020c6724(char *self, int flag);
+extern int func_ov007_020c65bc(char *t, int a1, int a2, int a3);
+extern void func_ov007_020bdbcc(int a0, int a1);
+extern int func_ov007_020c6550(char *c);
+extern int func_ov007_020bb09c(void);
 
-typedef struct StructA {
-    void* p0;
-    void* p4;
-    void* p8;
-    u8 pad0[0x18];
-    void* p24;
-    u8 pad1[0x8];
-    u32 f30;
-    u32 f34;
-} StructA;
+int func_ov007_020ba05c(void)
+{
+    char *mgr = data_ov007_02104ba0;
+    int r6 = 0;
+    int r5;
+    char *r4 = *(char **)(data_ov007_0210342c + 0x50);
 
-typedef struct StructB {
-    u8 pad0[8];
-    u16 f8;
-    u16 fA;
-    u16 fC;
-    u8 pad1[6];
-    u16 f14;
-    u8 pad2[0xe];
-    u32 f24;
-    u32 f28;
-    u32 f2C;
-    u8 pad3[0xc];
-    s16 f3C;
-    s16 f3E;
-} StructB;
-
-typedef struct StructBHolder {
-    u8 pad0[0x2c];
-    u32 f2C;
-    u8 pad1[0x20];
-    StructB* b;
-} StructBHolder;
-
-typedef struct StructAHolder {
-    StructA* a;
-} StructAHolder;
-
-typedef struct StructObj20 {
-    u8 pad0[8];
-    u16 f8;
-} StructObj20;
-
-typedef struct StructObj0 {
-    u8 pad0[0x20];
-    StructObj20* obj20;
-    u32* array24;
-    u32* array28;
-} StructObj0;
-
-typedef struct StructAInner {
-    StructObj0* obj0;
-    u8 pad0[4];
-    s16* p8;
-    u8 pad1[0x20];
-    u32 f2C;
-    u32 f30;
-    u32 f34;
-} StructAInner;
-
-int func_ov007_020ba05c(void) {
-    s32 res = 0;
-    StructAHolder* aHolder = (StructAHolder*)data_ov007_02104ba0;
-    StructBHolder* bHolder = (StructBHolder*)data_ov007_0210342c;
-    StructAInner* a = (StructAInner*)aHolder->a;
-    StructB* b = bHolder->b;
-
-    if (a->f30 != 0 && b->fC != 0 && b->f14 == 0 && b->f24 >= 1) {
-        if (func_ov007_020c1da0(0) == 0) {
-            a->f30 = 0;
-            func_ov007_020c6724(a->obj0);
-            bHolder->b->f2C = 0; // or bHolder->f2C? wait
-        }
+    if (*(int *)(mgr + 0x30) != 0 && *(u16 *)(r4 + 0xc) != 0 && *(u16 *)(r4 + 0x14) == 0 &&
+        *(u32 *)(r4 + 0x24) >= 1 && func_ov007_020c1da0(0) == 0) {
+        *(int *)(data_ov007_02104ba0 + 0x30) = 0;
+        func_ov007_020c6724(*(char **)data_ov007_02104ba0, 0);
+        *(int *)(data_ov007_02104ba0 + 0x2c) = 0;
     }
-
-    if (a->obj0->obj20->f8 == 0) {
-        a->f34 = 0;
-    } else {
-        a->obj0 = (StructObj0*)((char*)a->f34 + 0x1000);
+    {
+        char *m = data_ov007_02104ba0;
+        char *o = *(char **)(*(char **)m + 0x20);
+        if (*(u16 *)(o + 8) == 0)
+            *(int *)(m + 0x34) = 0;
+        else
+            *(int *)(m + 0x34) += 0x1000;
     }
-
-    if (func_ov007_020c1da0(0) != 0) {
-        goto end;
-    }
-
-    s16 val8 = *a->p8;
-    if (val8 == 6 || val8 == 7 || a->f30 != 0) {
-        goto end;
-    }
-
-    if (b->fC != 0) {
-        s32 ret5 = 0;
-        StructObj0* obj0 = a->obj0;
-        StructObj20* obj20 = obj0->obj20;
-        s32 check = 0;
-        if (obj20->f8 >= 2) {
-            s32 sb = b->f3E;
-            u32 sl1 = obj0->array28[obj20->f8 - 2];
-            u32 lr = (u32)(sb * sb);
-            s32 sb_val = (s32)(sl1 >> 12) - (s32)b->fA;
-            u32 sl2 = obj0->array24[obj20->f8 - 2];
-            s32 r7 = b->f3C;
-            s32 sb_sq = sb_val * sb_val;
-            s32 sb_acc = r7 * r7 + lr;
-            s32 r7_val = (s32)(sl2 >> 12) - (s32)b->f8;
-            s32 r7_acc = r7_val * r7_val + sb_sq;
-            if (sb_acc >= 0x100 && r7_acc <= 4) {
-                check = 1;
-            }
-        }
-
-        if (check == 0) {
-            ret5 = func_ov007_020c65bc((s32)a->f34 >> 12);
-            func_ov007_020bdbcc(b->f3C, b->f3E);
-        } else {
-            bHolder->b->f2C |= 1;
-        }
-
-        if (ret5 == 2) {
-            func_ov007_020c6550(a->obj0);
-            a->f34 = 0;
-            res = 1;
-            goto end;
-        } else if (ret5 == 1) {
-            bHolder->b->f28 = 0;
-            goto end;
-        }
-    } else {
-        if (bHolder->b->f24 == 1) {
-            s32 ret = func_ov007_020c6550(a->obj0);
-            if (ret != 0) {
-                if (ret == 2) {
-                    res = 1;
+    if (func_ov007_020c1da0(0) == 0) {
+        char *r3 = data_ov007_02104ba0;
+        int st = *(s16 *)(*(char **)(r3 + 8));
+        if (st != 6 && st != 7 && *(int *)(r3 + 0x30) == 0) {
+            if (*(u16 *)(r4 + 0xc) != 0) {
+                unsigned int cnt;
+                char *o;
+                int flag;
+                int y;
+                int x;
+                o = *(char **)(*(char **)r3 + 0x20);
+                r5 = 0;
+                flag = 0;
+                cnt = *(u16 *)(o + 8);
+                y = *(u16 *)(r4 + 8);
+                x = *(u16 *)(r4 + 0xa);
+                if (cnt >= 2) {
+                    int idx = cnt - 2;
+                    int dz = (((int *)*(char **)(o + 0x28))[idx] >> 12) - x;
+                    int rz = *(s16 *)(r4 + 0x3e);
+                    int dx = (((int *)*(char **)(o + 0x24))[idx] >> 12) - y;
+                    int rx = *(s16 *)(r4 + 0x3c);
+                    int dd = rx * rx + rz * rz;
+                    int dd2 = dx * dx + dz * dz;
+                    if (dd >= 0x100 && dd2 <= 4)
+                        flag = 1;
                 }
-                a->f2C = *(u32*)((char*)a->obj0 + 8);
-                a->f34 = 0;
-                bHolder->b->f2C |= 1;
+                if (flag == 0) {
+                    r5 = func_ov007_020c65bc(*(char **)r3, y, x, *(int *)(r3 + 0x34) >> 12);
+                    func_ov007_020bdbcc(*(s16 *)(r4 + 0x3c), *(s16 *)(r4 + 0x3e));
+                } else {
+                    char *obj = *(char **)(data_ov007_0210342c + 0x50);
+                    ((int *)obj)[11] = *(int *)(obj + 0x2c) | 1;
+                }
+                if (r5 == 2) {
+                    func_ov007_020c6550(*(char **)data_ov007_02104ba0);
+                    *(int *)(data_ov007_02104ba0 + 0x34) = 0;
+                    r6 = 1;
+                } else if (r5 == 1) {
+                    char *obj = *(char **)(data_ov007_0210342c + 0x50);
+                    *(int *)(obj + 0x28) = 0;
+                }
+            } else if (*(u16 *)(r4 + 0xc) == 0) {
+                char *obj = *(char **)(data_ov007_0210342c + 0x50);
+                if (*(u32 *)(obj + 0x24) == 1) {
+                    int res = func_ov007_020c6550(*(char **)r3);
+                    if (res != 0) {
+                        if (res == 2)
+                            r6 = 1;
+                        r4 = data_ov007_02104ba0;
+                        *(int *)(r4 + 0x2c) = *(int *)(*(char **)r4 + 8);
+                        *(int *)(data_ov007_02104ba0 + 0x34) = 0;
+                        obj = *(char **)(data_ov007_0210342c + 0x50);
+                        ((int *)obj)[11] = *(int *)(obj + 0x2c) | 1;
+                    }
+                }
             }
         }
     }
-
-end:
     func_ov007_020bb09c();
-    return res;
+    return r6;
 }

--- a/src/func_ov015_021114f0.c
+++ b/src/func_ov015_021114f0.c
@@ -1,4 +1,15 @@
-// NONMATCHING: smull dest/reg coloring after Matrix call (div=12). Prologue+epilogue byte-identical with #pragma opt_propagation off + r5-first decl.
+// NONMATCHING: 8/95 at exact size (was 12). KnockDownPlank drop-shadow scale.
+// Residue is two register-colouring sites and nothing else:
+//   * +0x84/+0x88 the ROM puts the data_02082214 pool address in r1 and r4>>1 in r2;
+//     with `half` named those two land correctly but the second Q12 multiply then takes
+//     the named operand as the smull Rm, which costs four more words -- 9 instead of 8.
+//   * +0xb0 the ROM writes the first table load straight back into its own index
+//     register (`ldrsh r0,[r1,r0]`) while every build here takes a fresh lr, which
+//     rotates the whole smull/adds/adc/lsr chain that follows (notes 6bs).
+// Measured: a 128-cell product sweep over {half named|inline} x {lookup named|inline} x
+// {v before|after the index chain} x {product named|inline} per block, plus const/split/
+// register spellings of `half`, a named table pointer, and byte-cast index forms.
+// opt_propagation off is required for the umull/mla/mla prologue.
 #pragma opt_propagation off
 extern void Matrix4x3_FromRotationY(void *m, short ang);
 extern int _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void *self, void *sm, void *mtx, int a, int b, int d, unsigned int e);
@@ -13,31 +24,25 @@ int func_ov015_021114f0(char *c) {
     if (r2 <= 0) { r5 = (unsigned short)(r5 + 0x8000); r2 = -r2; }
     r4 = r4 + r2;
     Matrix4x3_FromRotationY(c+0x348, (short)(*(short*)(c+0x8e) + r5));
-    int half = r4 >> 1;
-    s = *(short*)(c+0x8e);
     {
-        int prod;
-        int v;
-        s = (short)(s + r5);
-        s = (unsigned short)s;
-        s = s >> 4;
-        s = (s << 1) + 1;
-        s = data_02082214[s];
-        v = *(int*)(c+0x378);
-        prod = (int)(((long long)s * half + 0x800) >> 12);
-        *(int*)(c+0x36c) = (v + prod) >> 3;
+        int v = *(int*)(c+0x378);
+        int t = *(short*)(c+0x8e);
+        t = (short)(t + r5);
+        t = (unsigned short)t;
+        t = t >> 4;
+        t = (t << 1) + 1;
+        int sv = data_02082214[t];
+        *(int*)(c+0x36c) = (v + (int)(((long long)sv * (r4 >> 1) + 0x800) >> 12)) >> 3;
     }
     *(int*)(c+0x370) = *(int*)(c+0x37c) >> 3;
     {
-        int prod;
         int v = *(int*)(c+0x380);
-        s = *(short*)(c+0x8e);
-        s = (short)(s + r5);
-        s = (unsigned short)s;
-        s = s >> 4;
-        s = data_02082214[s << 1];
-        prod = (int)(((long long)s * half + 0x800) >> 12);
-        *(int*)(c+0x374) = (v + prod) >> 3;
+        int t = *(short*)(c+0x8e);
+        t = (short)(t + r5);
+        t = (unsigned short)t;
+        t = t >> 4;
+        t = t << 1;
+        *(int*)(c+0x374) = (v + (int)(((long long)data_02082214[t] * (r4 >> 1) + 0x800) >> 12)) >> 3;
     }
     if (*(unsigned char*)(c+0x397) >= 2)
         *(int*)(c+0x370) = *(int*)(c+0x384) >> 3;

--- a/src/func_ov075_0211621c.c
+++ b/src/func_ov075_0211621c.c
@@ -14,25 +14,15 @@
  * index, and the digit or character index is ADDED to it rather than stored - that is
  * the `(val & ~0x3ff) | ((n + (val << 22 >> 22)) & 0x3ff)` in each block.
  */
-// NONMATCHING: register allocation and frame layout (div=40 at the canonical mwccarm
-// 2004/b56). Counts as decompiled, not matched.
-//
-// Every one of the 40 divergent words is routing, verified word by word rather than by
-// eye: 30 differ only in register fields and 10 only in an sp displacement, and none
-// changes an opcode, an immediate, an addressing mode or a condition. The implied
-// correspondence is a single pair swap in each file - registers sb <-> r7, and stack
-// slots 0x20 <-> 0x24 - plus a local r0/r1 exchange inside the divide-by-100 block. So
-// the same operations run on the same values; only where they are held differs.
-//
-// That pair swap is the floor. The hundreds digit is memory-homed BELOW the loop counter
-// in the ROM's frame, and mwccarm sorts a memory-homed aggregate above every spilled
-// scalar, so the two slots cannot be exchanged from C. Mechanism and the levers that are
-// measured-closed: notes/mwccarm-codegen.md 6bl.
-//
-// The shape carries matching crutches, which are deliberate and not natural source: the
-// one-element array `hv` memory-homes the hundreds digit, the block of `zA`..`zF`,
-// `minus1`, `off14`, `scale`, `yIcon` and `yNum` reproduces the ROM's hoisted constant
-// block (6bh), and `inline_fn` forces the index call to inline.
+// NONMATCHING: 27/229 at exact size 0x394 (was 40). Every divergence is routing --
+// register fields and sp displacements only; no opcode, immediate, addressing mode or
+// condition differs, so the same operations run on the same values and only where they
+// are held changes. Three levers took it from 40 to 27:
+//   (1) the row x is not a variable -- spell every x as xbase + K + i * pitch so the
+//       induction variable stays the ROM's;
+//   (2) the leading-zero pen advance is an if/else over a named pen, not a ternary;
+//   (3) the digit blocks keep the OAM attribute word anonymous.
+// Residue is a callee-saved pair swap (sb <-> r7) plus the stack slots that follow it.
 #include "types.h"
 extern u8 data_0209fc50;
 extern u8 data_ov075_0211c6e8[];
@@ -55,7 +45,8 @@ void func_ov075_0211621c(char *c)
 {
   int count = data_0209fc50;
   int stride;
-  int hv[1];
+  int tens;
+  int hundreds;
   int i = 0;
   int d = 4 - count;
   int xbase;
@@ -65,7 +56,6 @@ void func_ov075_0211621c(char *c)
   {
     if (count > 0)
     {
-      int xoff = i;
       int minus1 = -1;
       int zA;
       int yIcon;
@@ -77,46 +67,43 @@ void func_ov075_0211621c(char *c)
       int zF;
       int scale;
       int yNum;
-      zE = xoff;
-      zD = xoff;
-      zB = xoff;
+      zE = i;
+      zD = i;
+      zB = i;
       off14 = 0x14;
-      zF = xoff;
-      zA = xoff;
+      zF = i;
+      zA = i;
       yIcon = 0x98;
-      zC = xoff;
+      zC = i;
       scale = 0x1000;
       yNum = 0xb0;
       do
       {
         int *p;
         int pid = inline_fn(i);
-        int x = xbase + xoff;
-        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(zA, data_ov075_0211c7c0, x, yIcon, minus1, minus1, scale, scale, zA, minus1);
-        p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zC, data_ov075_0211c8b0, (xbase + 0x1c) + xoff, yIcon, minus1, minus1, scale, zC);
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(zA, data_ov075_0211c7c0, xbase + i * stride, yIcon, minus1, minus1, scale, scale, zA, minus1);
+        p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zC, data_ov075_0211c8b0, xbase + 0x1c + i * stride, yIcon, minus1, minus1, scale, zC);
         if (p != 0)
         {
           int *q = (int *) ((int) (p + 1));
           int val = *q;
           *q = (val & (~0x3ff)) | ((data_0209f310[pid] + (((u32) (val << 22)) >> 22)) & 0x3ff);
         }
-        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(zB, data_ov075_0211c870, x, yNum, minus1, minus1, scale, scale, zB, minus1);
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(zB, data_ov075_0211c870, xbase + i * stride, yNum, minus1, minus1, scale, scale, zB, minus1);
         {
           int n;
-          int tens;
           int dx = off14;
           n = (*((int *) (data_0209ee90 + 0x1d4))) + data_0209f358[pid];
-          hv[0] = n / 100;
-          n = n % 100;
-          tens = n / 10;
-          if (hv[0] != 0)
+          hundreds = n / 100;
+          tens = (n % 100) / 10;
+          if (hundreds != 0)
           {
-            p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zD, data_ov075_0211c8b0, (xbase + 0x14) + xoff, yNum, minus1, minus1, scale, zD);
+            p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zD, data_ov075_0211c8b0, xbase + 0x14 + i * stride, yNum, minus1, minus1, scale, zD);
             if (p != 0)
             {
               int *q = (int *) ((int) (p + 1));
               int val = *q;
-              *q = (val & (~0x3ff)) | ((hv[0] + (((u32) (val << 22)) >> 22)) & 0x3ff);
+              *q = (val & (~0x3ff)) | ((hundreds + (((u32) (val << 22)) >> 22)) & 0x3ff);
             }
             dx = dx + 8;
           }
@@ -124,9 +111,9 @@ void func_ov075_0211621c(char *c)
           {
             dx = dx + 4;
           }
-          if ((tens != 0) || (hv[0] != 0))
+          if ((tens != 0) || (hundreds != 0))
           {
-            p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zE, data_ov075_0211c8b0, (xbase + dx) + xoff, yNum, minus1, minus1, scale, zE);
+            p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zE, data_ov075_0211c8b0, xbase + dx + i * stride, yNum, minus1, minus1, scale, zE);
             if (p != 0)
             {
               int *q = (int *) ((int) (p + 1));
@@ -139,15 +126,14 @@ void func_ov075_0211621c(char *c)
           {
             dx = dx + 4;
           }
-          p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zF, data_ov075_0211c8b0, (xbase + dx) + xoff, yNum, minus1, minus1, scale, zF);
+          p = _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(zF, data_ov075_0211c8b0, xbase + dx + i * stride, yNum, minus1, minus1, scale, zF);
           if (p != 0)
           {
             int *q = (int *) ((int) (p + 1));
             int val = *q;
-            *q = (val & (~0x3ff)) | (((n % 10) + (((u32) (val << 22)) >> 22)) & 0x3ff);
+            *q = (val & (~0x3ff)) | ((((n % 100) % 10) + (((u32) (val << 22)) >> 22)) & 0x3ff);
           }
         }
-        xoff += stride;
         i++;
       }
       while (i < count);


### PR DESCRIPTION
Five files that were drafts before this branch and are still drafts after it. Nothing here is byte-exact, nothing is enrolled, no delinks entry is added, and the matched count does not move. What changes is that four of the five were scoring nothing useful and now score something a later pass can build on, and one of them can be compiled at all.

| file | module | address | size | before | after | size-exact |
|---|---|---|---|---|---|---|
| src/func_ov015_021114f0.c | ov015 | 0x021114f0 | 0x17c | 12 / 95 | 8 / 95 | yes |
| src/func_ov003_020ae358.c | ov003 | 0x020ae358 | 0x398 | wrong size (229 vs 230 instructions) | 6 / 230 | yes |
| src/func_ov007_020ba05c.c | ov007 | 0x020ba05c | 0x284 | wrong size (139 vs 161 instructions, 88 bytes short) | 9 / 161 | yes |
| src/func_ov075_0211621c.c | ov075 | 0x0211621c | 0x394 | 40 / 229 | 27 / 229 | yes |
| src/_ZN3MrI13InitResourcesEv.cpp | ov071 | 0x02121734 | 0x298 | did not compile | 3 / 166 | yes |

Every row above was measured with tools/fdiff.py at 2004/b56, and every one is size-exact: the target and candidate instruction counts are equal, so each file now covers the whole function instead of stopping short. The two rows marked "wrong size" were not comparable before, because a draft that ends 88 bytes early is not a worse version of the function, it is a different one.

The ov071 file is the one that could not be built. On main it fails with "undefined identifier 'Matrix4x3'", so it was contributing nothing at all. It is rebuilt here as a real MrI::InitResources() method over the existing include/MrI.h, using the header's named members instead of raw offsets, and it now scores 3 of 166. The header itself is unchanged. All six files that include MrI.h were re-verified afterwards and all six still match at 2004/b56: CleanupResources, OnPendingDestroy, Render, Behavior, D0 and D1.

Three things this work established that should generalise:

A call whose first argument is a constant only gets that argument order when the comparison that feeds the call sits in the same basic block. Hoisting the comparison out, even when the value is identical, flips the order back. So the argument order is not a property of the call site on its own, it is a property of where the comparison lives.

The shape where a value is loaded into its own base register is a register-pressure effect, not something you can ask for directly. It only appears when the surrounding packing expression is short enough that the allocator has no reason to keep a separate register alive. Lengthening the expression makes it go away, which is why earlier attempts to force it by rewriting the load never worked.

Naming a value that is read twice is a lever that works in both directions. Introducing a local for a twice-read value changes codegen, and so does removing one, and neither is reliably the better choice. It is worth trying both ways on any residue that involves a repeated read.
