### PR TITLE
Match the ov006 Pachinko ball spawn and give the Pachinko class its ball and shot records

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -3065,6 +3065,10 @@ src/func_ov006_020fda7c.cpp:
     complete
     .text start:0x020fda7c end:0x020fdaf0
 
+src/func_ov006_020fdd40.cpp:
+    complete
+    .text start:0x020fdd40 end:0x020fe1a8
+
 src/func_ov006_020fe1a8.c:
     complete
     .text start:0x020fe1a8 end:0x020fe1d0

--- a/include/dScMgPachinko_c.h
+++ b/include/dScMgPachinko_c.h
@@ -20,6 +20,58 @@
  * dScMgPachinko_c_classInit (historical alias MgBobOmbSquad_Spawn) installs this class's
  * cartridge vtable for the MG_PACHINKO registry profile.
  */
+/* One pachinko ball on the board, 0x38 bytes, thirty of them at 0x4660. */
+struct dScMgPachinko_ball {
+    s32 x;              /* 0x00 */
+    s32 y;              /* 0x04 */
+    s32 unk08;          /* 0x08 */
+    s32 unk0c;          /* 0x0c */
+    s32 unk10;          /* 0x10 */
+    s32 unk14;          /* 0x14 */
+    s32 unk18;          /* 0x18 */
+    s32 unk1c;          /* 0x1c */
+    s32 unk20;          /* 0x20 */
+    u16 unk24;          /* 0x24 */
+    u16 angle;          /* 0x26 */
+    u16 unk28;          /* 0x28 */
+    u8  unk2a[0x2];     /* 0x2a */
+    u8  active;         /* 0x2c */
+    u8  unk2d;          /* 0x2d */
+    u8  unk2e;          /* 0x2e */
+    u8  unk2f;          /* 0x2f */
+    u8  unk30;          /* 0x30 */
+    u8  unk31[0x2];     /* 0x31 */
+    u8  unk33;          /* 0x33 */
+    u8  unk34[0x2];     /* 0x34 */
+    u8  unk36;          /* 0x36 */
+    u8  unk37;          /* 0x37 */
+};
+
+typedef char dScMgPachinko_ball_size_must_be_0x38[sizeof(struct dScMgPachinko_ball) == 0x38 ? 1 : -1];
+
+/* One ball being aimed with the stylus, 0x38 bytes, at 0x4ed8. */
+struct dScMgPachinko_shot {
+    s32 x;              /* 0x00 */
+    s32 y;              /* 0x04 */
+    s32 velX;           /* 0x08 */
+    s32 velY;           /* 0x0c */
+    s32 offX;           /* 0x10, grab offset from the stylus */
+    s32 offY;           /* 0x14 */
+    u8  unk18[0x8];     /* 0x18 */
+    s32 speed;          /* 0x20 */
+    s32 unk24;          /* 0x24 */
+    s32 sound;          /* 0x28, sound handle */
+    s32 dist;           /* 0x2c, last frame's distance from the launcher */
+    u16 angle;          /* 0x30 */
+    u16 timer;          /* 0x32 */
+    u8  unk34;          /* 0x34 */
+    u8  state;          /* 0x35 */
+    u8  unk36;          /* 0x36 */
+    u8  unk37;          /* 0x37 */
+};
+
+typedef char dScMgPachinko_shot_size_must_be_0x38[sizeof(struct dScMgPachinko_shot) == 0x38 ? 1 : -1];
+
 struct dScMgPachinko_c : dScMgBase_c {
     virtual ~dScMgPachinko_c();
     virtual s32 InitResources();  /* slot 0 */
@@ -27,7 +79,12 @@ struct dScMgPachinko_c : dScMgBase_c {
     virtual s32 Render();         /* slot 9 */
     virtual void OnYoshiTryEat(int arg);               /* slot 18 */
 
-    u8  pad_4660[0x15b0];
+    dScMgPachinko_ball mBall[30];    /* 0x4660, stride 0x38, ends 0x4cf0 */
+    u8  pad_4cf0[0x1e8];
+    dScMgPachinko_shot mShot[24];    /* 0x4ed8, stride 0x38; 24 puts the
+                                        siblings' own 0x5418 field exactly
+                                        one record past the end */
+    u8  pad_5418[0x7f8];
     s32 unk_5c10;            /* 0x5c10 */
     u8  pad_5c14[0x4];
     u16 unk_5c18;            /* 0x5c18 */
@@ -35,10 +92,13 @@ struct dScMgPachinko_c : dScMgBase_c {
     u16 unk_5c1c;            /* 0x5c1c */
     u8  pad_5c1e[0x6];
     u16 unk_5c24;            /* 0x5c24 */
-    u8  pad_5c26[0x4];
+    u16 unk_5c26;            /* 0x5c26 */
+    u16 unk_5c28;            /* 0x5c28 */
     u16 unk_5c2a;            /* 0x5c2a */
     /* trailing extent the ROM's `new dScMgPachinko_c` literal proves; see tools/opnew_sizes.py */
-    u8 pad_5c2c[0xc];
+    u8  pad_5c2c[0x5];
+    u8  unk_5c31;            /* 0x5c31 */
+    u8  pad_5c32[0x6];
 };
 
 typedef char dScMgPachinko_c_size_must_be_0x5c38[sizeof(struct dScMgPachinko_c) == 0x5c38 ? 1 : -1];

--- a/src/func_ov006_020fdd40.cpp
+++ b/src/func_ov006_020fdd40.cpp
@@ -1,0 +1,80 @@
+//cpp
+// @symbol func_ov006_020fdd40
+#include "dScMgPachinko_c.h"
+
+extern "C" {
+extern int RandomIntInternal(int *seed);
+extern int data_0209d4b8;
+extern int data_ov006_0212eb80[];
+extern u8 data_ov006_0213d974[];
+extern s16 data_02082214[];
+}
+
+#define FMUL(a, b) ((int)(((long long)(a) * (b) + 0x800) >> 12))
+
+extern "C" void func_ov006_020fdd40(dScMgPachinko_c *self)
+{
+    int i;
+    int ones;
+    int tens;
+
+    if (self->unk_5c24 != 0) {
+        self->unk_5c24--;
+        if ((s16)self->unk_5c24 < 0) self->unk_5c24 = 0;
+        return;
+    }
+    self->unk_5c24 = 0x50;
+    for (i = 0; i < 0x1e; i++) {
+        int ra;
+        int rb;
+        if (self->mBall[i].active != 0) continue;
+        self->mBall[i].active = 1;
+        ra = RandomIntInternal(&data_0209d4b8);
+        rb = RandomIntInternal(&data_0209d4b8);
+        self->mBall[i].x = (data_ov006_0212eb80[(((u32)rb >> 16) & 0x7fff) * 5 >> 15] + ((((u32)ra >> 16) & 0x7fff) * 4 >> 15) * 8) << 12;
+        self->mBall[i].y = -0x100000;
+        self->mBall[i].unk08 = 0;
+        self->mBall[i].unk0c = 0;
+        self->mBall[i].unk2f = 0;
+        self->mBall[i].unk30 = 0;
+        ra = RandomIntInternal(&data_0209d4b8);
+        self->mBall[i].unk28 = ((((u32)ra >> 16) & 0x7fff) * 8 >> 15) << 4;
+        self->mBall[i].unk24 = 0;
+        self->mBall[i].unk1c = 0;
+        self->mBall[i].unk36 = self->unk_5c28;
+        self->unk_5c26++;
+        if (self->unk_5c28 == 0) break;
+        {
+            int r = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15;
+            int lvl = self->unk_5c28 >> 1;
+            if (lvl >= 4) lvl = 4;
+            if (data_ov006_0213d974[r + lvl * 4] == 0) break;
+        }
+        if ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 2 >> 15) {
+            self->mBall[i].x = 0x100000;
+            self->mBall[i].angle = 0xc000 - (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 0xc >> 15) + 1 << 9);
+        } else {
+            self->mBall[i].x = 0;
+            self->mBall[i].angle = (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 0xc >> 15) + 1 << 9) + 0xc000;
+        }
+        self->mBall[i].unk18 = 0;
+        self->mBall[i].unk10 = 0;
+        self->mBall[i].unk14 = 0;
+        self->mBall[i].unk24 = self->mBall[i].angle - 0x4000;
+        self->mBall[i].y = -0x60000;
+        self->mBall[i].unk08 = FMUL(data_02082214[(self->mBall[i].angle >> 4) * 2 + 1], 0xe80);
+        self->mBall[i].unk0c = FMUL(data_02082214[(self->mBall[i].angle >> 4) * 2], 0xe80);
+        self->mBall[i].unk2f = 3;
+        self->mBall[i].unk2d = 1;
+        self->mBall[i].unk33 = 0;
+        self->mBall[i].unk20 = 0x1000;
+        self->mBall[i].unk28 = 0x10;
+        break;
+    }
+    ones = self->unk_5c26;
+    for (tens = 0; ones >= 0xa; tens++) ones -= 0xa;
+    if (tens != 0 && ones == 0) self->unk_5c28++;
+    if (self->unk_5c28 > 0x28) self->unk_5c28 = 0x27;
+    self->unk_5c24 -= self->unk_5c28 << 2;
+    if ((s16)self->unk_5c24 <= 0x20) self->unk_5c24 = 0x20;
+}


### PR DESCRIPTION
Matches the ov006 Pachinko ball spawn and gives `dScMgPachinko_c` the two record arrays that function needs.

| Function | Address | Size |
| --- | --- | --- |
| `func_ov006_020fdd40` | `0x020fdd40` | `0x468` (1128 bytes) |

Byte gate:

```
MATCHING VERSIONS: 2004/b56
build_pin.verify(src/func_ov006_020fdd40.cpp, func_ov006_020fdd40, 0x020fdd40, 0x468, ov006) -> (True, '2004/b56')
```

The header change touches seven other source files that include it, so every one of them was re-matched at its `symbols.txt` address and size:

```
func_ov006_020fe394                      0x020fe394 0x3bc   MATCHING VERSIONS: 2004/b56
_ZN15dScMgPachinko_cD1Ev                 0x020fa75c 0x24    MATCHING VERSIONS: 2004/b56
_ZN15dScMgPachinko_cD0Ev                 0x020fa780 0x38    MATCHING VERSIONS: 2004/b56
_ZN15dScMgPachinko_c13OnYoshiTryEatEi    0x020fed58 0x6c    MATCHING VERSIONS: 2004/b56
_ZN15dScMgPachinko_c6RenderEv            0x020fedc4 0x60    MATCHING VERSIONS: 2004/b56
_ZN15dScMgPachinko_c8BehaviorEv          0x020fee24 0x19c   MATCHING VERSIONS: 2004/b56
_ZN15dScMgPachinko_c13InitResourcesEv    0x020fefc0 0x42c   MATCHING VERSIONS: 2004/b56
```

Link check:

```
1 changed header(s) fan out to 8 source file(s) to verify
  [OK  ] _ZN15dScMgPachinko_c13InitResourcesEv        VERIFIED
  [OK  ] _ZN15dScMgPachinko_c13OnYoshiTryEatEi        VERIFIED
  [OK  ] _ZN15dScMgPachinko_c6RenderEv                VERIFIED
  [OK  ] _ZN15dScMgPachinko_c8BehaviorEv              VERIFIED
  [OK  ] _ZN15dScMgPachinko_cD0Ev                     VERIFIED
  [OK  ] _ZN15dScMgPachinko_cD1Ev                     VERIFIED
  [OK  ] func_ov006_020fdd40                          VERIFIED
  [OK  ] func_ov006_020fe394                          VERIFIED
prepush-linkcheck: 8 checked - 8 verified, 0 warning(s), 0 blocking
```

Ratchets:

```
langmode ratchet PASS
check_references: unresolved symbols 42 (baseline 45), eligible 11187 (baseline 11044), no new unresolvable references
check_header_offsets: include/dScMgPachinko_c.h, 10 commented fields, 0 mismatched, 0 unparsed, struct spans 0x5c38
duplicate-sources: 9476 stems, none doubled
check_src_tu: 30 translation units, 316 includes, 783 mangled references, every reference resolves
unittest tools.test_srcpath tools.test_bytegate tools.test_enroll: Ran 80 tests, OK
```

Enrollment, hand-inserted in address order and confirmed identical to what `tools/enroll.py --dry-run --complete-list` proposes:

```
src/func_ov006_020fdd40.cpp:
    complete
    .text start:0x020fdd40 end:0x020fe1a8
```

The header work fits the new `dScMgPachinko_ball` and `dScMgPachinko_shot` record arrays entirely inside pad bytes that were already reserved at 0x4660 and 0x4ed8, and splits three previously padded fields at 0x5c26, 0x5c28 and 0x5c31, so every existing field offset and the `0x5c38` size assert are unchanged.

How it was found: the first compile came out 58 instructions away from the cartridge, and two changes closed all of it. The first was assigning the third random-number call to a named temporary, which makes the compiler compute the destination address after the call instead of before it. The second was putting the six spawn stores back in the order the cartridge uses. What actually identified the problem was the order of the constants in the literal pool rather than the size of the mismatch. The mismatch count barely moved while the pool order pointed straight at which base address was being computed one step too early.
