### PR TITLE
Record three pipeline rulings: method conversion, coined-name parking, verify's exit code

### DIFF
--- a/notes/agents/PIPELINE.md
+++ b/notes/agents/PIPELINE.md
@@ -18,6 +18,7 @@ conversation.
 | 1 | `scout` | the ROM | `notes/data/class-facts/<Class>.json` |
 | 2 | `writer` | the facts file | one `src/actors/<Class>.cpp`, its manifest, and the bookkeeping below |
 | 3 | `humanizer` | the written source | a revised source that reads like 2004 EAD C++ |
+| 3b | `writer` again | the humanized source | as many members as byte-match allows turned into real `<Class>::` methods |
 | 4 | `builder` | the revised source | green byte gates, then a PR |
 | 5 | `reviewer` | the PR | merge, or a rejection with a named reason |
 | - | `integrator` | several already-green PRs | one branch, one validator run |
@@ -36,6 +37,52 @@ files is typical.
 The writer is **gathering, not authoring**: 387 of 429 classes already have a
 real header, and the shards being folded together are existing matched code. Most
 promotions touch no header at all.
+
+## A promoted TU is not a reconstructed class
+
+`status: promoted` proves the shards were folded into one TU that byte-matches. It
+says **nothing** about whether the class got any methods, and until 2026-09-06 no
+role file asked for any. The result, measured on `origin/main` from each manifest's
+`functions[]` (mangled `_Z...` vs `func_*`):
+
+| class | members | real methods |
+|---|---|---|
+| `dScMgCoin_c` | 33 | 0 |
+| `dScMgTeresa_c` | 48 | 2 (D1/D0 only) |
+| `dScMgPanel_c` | 71 | 6 |
+| `dScMgCup_c` | 32 | 15 |
+| `dScMgMemory2_c` | 52 | **51** |
+
+Every one of those is `promoted`, and every queue and coverage metric counts them
+equally. A TU of thirty `extern "C" func_ovNNN_*(char *self)` free functions in
+`src/actors/<Class>.cpp` is a **merged file, not a reconstructed class** -- and the
+goal is writing the classes back.
+
+**The ruling: convert as far as byte-match allows.** `dScMgMemory2_c` is the proof
+the route works end to end. Stage 3b owns it; it is the same `writer` role file and
+may run as a separate pass on the same branch when stages 2 and 3 have already
+pushed. A member that will not convert byte-neutrally **stays a free function** --
+that is a result, not a failure. Report the count either way: "31/31 MATCH" hides
+"1 of 31 is a method".
+
+**Renaming a member is one edit, not two.** The new mangled name must reach
+`symbols.txt` in the same commit: any pointer-to-member record in unowned `.data`
+that still spells its target `func_*` links as `0x00000000`, because dsd resolves
+those records by NAME. No byte gate at stage 2 or 3 catches it. And a class member
+function **cannot sit inside an `extern "C" { }` region**, so the one file-scope
+region goes after the last surviving `func_*` member.
+
+## Coined-name classes are parked
+
+A class whose name was coined rather than read from the cartridge's RTTI **is not
+eligible for promotion**. Coined names block data verification against the ROM, and
+a promotion under one banks a claim the cartridge cannot corroborate.
+
+This parks 143 of the 201 unpromoted queue rows (2,341 shards) until the naming
+question gets its own pass. Check the class's `identity_evidence` in its facts file
+before claiming: `dScMgCurling2_c` is in scope because the ov006 bytes at
+`0x0213c4c8` are literally `15dScMgCurling2_c`. **Do not run `class_rename.py`** to
+get around this.
 
 Stage 4 is the only stage that DECIDES whether the bytes are right, and it owns
 `linkcheck` and `rombuild`. That is not the same as "stages 1-3 never run a byte

--- a/notes/agents/roles/humanizer.md
+++ b/notes/agents/roles/humanizer.md
@@ -16,6 +16,13 @@ builder's, and stage 4 remains the only stage that DECIDES.
 
 You decide whether a human being working at Nintendo EAD would have typed this.
 
+**You do not convert members into methods.** That is stage 3b, and it belongs to
+the `writer` role file -- it changes mangled names and must move `symbols.txt` in
+the same edit or unowned `.data` pointer-to-member records link as `0x00000000`.
+If you think a member should become a `<Class>::` method, say so in your report
+and leave it alone. Readability at this stage is naming, structure and comments,
+not re-signaturing.
+
 ## What you are looking for
 
 Reconstructed code has a characteristic smell. Flag it:

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -11,6 +11,42 @@ single C++ TU". Read it (`git show --stat 72c6dcfb6`) before you start.
 Do **not** use a `Reconstruct N actor profiles (wave NN)` commit as your
 template. Those rename registry rows and never touch the shard pile.
 
+## Stage 3b: gathering is only half the job
+
+Folding the shards into one byte-matching TU earns `status: promoted`. It does not
+make the class a class. Until 2026-09-06 nothing here asked for methods, and the
+landed spread runs from `dScMgCoin_c` at **0 of 33** members to `dScMgMemory2_c` at
+**51 of 52** -- all of them `promoted`, all counted the same by every metric. See
+`PIPELINE.md`, "A promoted TU is not a reconstructed class", for the full table.
+
+**Convert as far as byte-match allows.** Turn each `func_ovNNN_*(char *self, ...)`
+member into a real `<Class>::` method declared in the header; the leading `char
+*self` becomes the implicit `this` in the same register, so most conversions cost
+nothing -- but **measure, do not assume**. Work in batches, run `tubuild.py verify`
+after each, and isolate any regression to one cause before continuing. A member
+whose first parameter is not the object, or that will not convert byte-neutrally,
+**stays a free function**: that is a result, not a failure. `dScMgMemory2_c` is the
+oracle for every mechanical question -- read its source and manifest first.
+
+This may run as a separate pass on the same branch after stages 2 and 3 have
+already pushed. Whenever you report a promotion, give the method count next to the
+match count: "31/31 MATCH" hides "1 of 31 is a method".
+
+**The rename is ONE edit.** A converted member gets a new mangled name, and any
+pointer-to-member record in unowned `.data` that still spells the target `func_*`
+then links as `0x00000000` -- dsd resolves those records by NAME. `symbols.txt` and
+the manifest's `functions[]` move in the same commit. No byte gate at stage 2 or 3
+catches this; the cheap link evidence is a `.symtab` undefined-symbol scan of the
+emitted object.
+
+## Coined-name classes are parked
+
+Do not claim a class whose name was coined rather than read from the cartridge's
+RTTI -- check `identity_evidence` in its facts file first. A coined name cannot be
+corroborated against the ROM, so a promotion under one banks a claim the cartridge
+cannot support. This parks 143 of the 201 unpromoted queue rows. **Do not run
+`class_rename.py`** to get around it.
+
 ## Inputs
 
 - `notes/data/tu-promotion-queue.tsv` — your target, its `shard_count`,


### PR DESCRIPTION
Three rulings from the pipeline owner, recorded where a Codex instance and a Claude instance both read them. Docs only — no source, no config, no ledger, no tool.

## 1. A promoted TU is not a reconstructed class

`status: promoted` proves the shards were folded into one file that byte-matches. It proves nothing about whether the class got any methods — and until today no role file asked for any. Measured on `origin/main`, from each manifest's `functions[]` (mangled `_Z…` vs `func_*`):

| class | members | real methods |
|---|---|---|
| `dScMgCoin_c` | 33 | 0 |
| `dScMgTeresa_c` | 48 | 2 (D1/D0 only) |
| `dScMgPanel_c` | 71 | 6 |
| `dScMgCup_c` | 32 | 15 |
| `dScMgMemory2_c` | 52 | **51** |

All five are `promoted`, and every queue and coverage metric counts them equally. A TU of thirty `extern "C" func_ovNNN_*(char *self)` free functions in `src/actors/<Class>.cpp` is a merged file, not a reconstructed class.

**Ruling: convert as far as byte-match allows.** `dScMgMemory2_c` is the proof the route works end to end, and is named as the oracle. Recorded as **stage 3b** in `PIPELINE.md` and in `writer.md`, which owns it; `humanizer.md` now says explicitly that converting members is *not* its stage. A member that will not convert byte-neutrally stays a free function — a result, not a failure. And the method count now gets reported next to the match count, because **"31/31 MATCH" hides "1 of 31 is a method"**.

The conversion is **one edit, not two**: a converted member gets a new mangled name, and any pointer-to-member record in unowned `.data` still spelling its target `func_*` then links as `0x00000000` — dsd resolves those records by NAME. `symbols.txt` and the manifest's `functions[]` move in the same commit. No byte gate at stage 2 or 3 catches it.

## 2. Coined-name classes are parked

A name coined rather than read from the cartridge's RTTI cannot be corroborated against the ROM, so a promotion under one banks a claim the ROM cannot support. Check `identity_evidence` in the facts file before claiming. This parks **143 of the 201** unpromoted queue rows, and `class_rename.py` is not a way around it.

## 3. `verify`'s exit code

`tubuild.py verify` returns 0 even when it prints `PROMOTION REFUSED`. That is a tool change and ships in its own PR.

**Gate:** `check_dead_references` — no new dead references, no broken markdown links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
