### PR TITLE
Declare func_0205a74c extern where it is used, not static

### DIFF
--- a/src/func_02057198.c
+++ b/src/func_02057198.c
@@ -9,7 +9,7 @@ extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ10RestoreAllEj(u32 state);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 
-static u32 func_0205a74c(u32 val, LockObj *addr);
+extern u32 func_0205a74c(u32 val, LockObj *addr);
 
 u32 func_02057198(u32 val, LockObj *addr, void (*cleanupFn)(void), u32 useAll)
 {


### PR DESCRIPTION
src/func_02057198.c declared func_0205a74c static and never defined it in that file. The pinned compiler accepts that and resolves the call across translation units, so the function still reproduces the cartridge byte for byte. Stricter compilers reject it outright, which is why the PC port has been carrying a hand-written copy of the body instead of linking this one.

The change is one word, static to extern. func_0205a74c is a real symbol in config/arm9/symbols.txt.

Verification on the changed file, before and after:

    build_pin.verify before: (True, '2004/b56')
    build_pin.verify after:  (True, '2004/b56')
    match.py --module arm9 --version 2004/b56: MATCHING VERSIONS: 2004/b56

langmode ratchet PASS. No other file, header or config is touched.