### PR TITLE
Match the ov006 Luigi minigame picture placer

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -2774,6 +2774,10 @@ src/func_ov006_020f2224.cpp:
     complete
     .text start:0x020f2224 end:0x020f2790
 
+src/func_ov006_020f2790.cpp:
+    complete
+    .text start:0x020f2790 end:0x020f2cb8
+
 src/func_ov006_020f2cb8.c:
     complete
     .text start:0x020f2cb8 end:0x020f2e20

--- a/src/func_ov006_020f2790.cpp
+++ b/src/func_ov006_020f2790.cpp
@@ -1,0 +1,163 @@
+//cpp
+// @symbol func_ov006_020f2790
+/* recovered: dScMgLuigi_c picture placer, ov006 0x020f2790 (1320 bytes). Runs
+ * once per frame while the board is still filling. Boards whose
+ * data_ov006_0213ce98 entry is set are laid out in one go by
+ * func_ov006_020f2224 instead; the rest place one picture per call. The slot
+ * gets a random speed level, nudged off unk_545a when it lands on it, and the
+ * very first slot of a board is dropped at a random cell outside the middle
+ * block with a small random jitter. Every later slot retries a random cell up
+ * to 100 times, then walks the grid linearly until it finds a free one. When
+ * unk_5456 reaches the board's capacity the board is marked full (unk_5455)
+ * and four random 4-bit values go into unk_515c.
+ *
+ * Two pointer locals are load-bearing (both measured against the ROM):
+ *   - `p` in the speed-level fixup. The ROM stores and re-reads
+ *     mSpeedLevel[cur] through the scaled-index form `[r3,r0]` but keeps
+ *     `&mSpeedLevel[cur]` in a register for the three accesses inside the
+ *     fixup. Declaring p before the `if` (whose test still uses the subscript)
+ *     puts the `add` in the pre-branch block exactly where the ROM has it;
+ *     spelling the fixup with subscripts costs the address register and
+ *     re-derives the base from the literal pool.
+ *   - `f` over data_ov006_0213ce84[idx]. mwccarm shares one loaded value
+ *     across both tests when both are written as subscripts, which drops the
+ *     re-load the ROM performs after `unk_5455 = 1`. Naming a const pointer
+ *     and using it for the SECOND test only breaks that: the first test stays
+ *     folded into `[base,idx]`, the `add` survives for the pointer, and the
+ *     tail re-loads through it.
+ * `#pragma opt_propagation off` is worth 219 -> 330 aligned instructions here:
+ * without it `this` colours into r6 and the whole callee-saved file permutes. */
+#include "dScMgLuigi_c.h"
+
+extern "C" {
+int RandomIntInternal(int *seed);
+extern int data_0209d4b8;
+extern u8 data_ov006_0213ce84[];
+extern u8 data_ov006_0213ce98[];
+extern u16 data_ov006_0213cee0[];
+void func_ov006_020f2224(dScMgLuigi_c *self);
+}
+
+#pragma opt_propagation off
+extern "C" void func_ov006_020f2790(dScMgLuigi_c *self)
+{
+    int idx;
+    int cur;
+    int lim;
+    int col;
+    int row;
+    int tries;
+    int rnd;
+
+    if (self->unk_5455 != 0)
+        return;
+
+    idx = self->unk_5174;
+    if (data_ov006_0213ce98[idx] != 0) {
+        func_ov006_020f2224(self);
+        return;
+    }
+
+    lim = data_ov006_0213cee0[idx];
+    cur = self->unk_5456;
+
+    rnd = RandomIntInternal(&data_0209d4b8);
+    self->mSpeedLevel[cur] = (((u32)rnd >> 16) & 0x7fff) * 4 >> 15;
+    {
+        u8 *p = &self->mSpeedLevel[cur];
+        if (self->unk_545a == self->mSpeedLevel[cur]) {
+            rnd = RandomIntInternal(&data_0209d4b8);
+            *p += ((((u32)rnd >> 16) & 0x7fff) * 3 >> 15) + 1;
+            *p &= 3;
+        }
+    }
+
+    if (cur == 0) {
+        int jx;
+        int jy;
+        do {
+            col = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 13 >> 15;
+            row = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 9 >> 15;
+        } while (col >= 6 && col <= 10 && row >= 4 && row <= 8);
+
+        jy = -2;
+        jx = jy;
+        jx += (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 5 >> 15;
+        jy += (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 5 >> 15;
+
+        if (data_ov006_0213ce84[idx] != 0) {
+            self->mPosX[0] = (col * 20 + (jx + 8)) << 12;
+            self->mPosY[0] = (row * 20 + (jy + 16)) << 12;
+            self->unk_52ed[0] = 1;
+            self->unk_51fd[0] = 0;
+            self->mSpeedLevel[0] = self->unk_545a;
+            self->mGrid[col][row] = 1;
+            self->unk_5456++;
+            return;
+        } else {
+            int n = lim - 1;
+            self->mPosX[n] = (col * 20 + 8) << 12;
+            self->mPosY[n] = (row * 20 + 16) << 12;
+            self->unk_52ed[n] = 1;
+            self->unk_51fd[n] = 0;
+            self->mSpeedLevel[n] = self->unk_545a;
+            self->mGrid[col][row] = 1;
+        }
+    }
+
+    tries = 0;
+    while (1) {
+        u8 *cell;
+        if (tries >= 100) {
+            col++;
+            if (col >= 12) {
+                row++;
+                col = 0;
+                if (row >= 11)
+                    row = 0;
+            }
+        } else {
+            col = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 13 >> 15;
+            row = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 9 >> 15;
+        }
+        cell = (u8 *)((unsigned int)((char *)self + col * 9 + row) + 0x5178);
+        if (*cell == 0) {
+            int jx;
+            int jy;
+            jy = -2;
+            jx = jy;
+            jx += (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 5 >> 15;
+            jy += (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 5 >> 15;
+            self->mPosX[cur] = (col * 20 + (jx + 8)) << 12;
+            self->mPosY[cur] = (row * 20 + (jy + 16)) << 12;
+            *cell = 1;
+            break;
+        }
+        tries++;
+    }
+
+    self->unk_52ed[cur] = 1;
+    self->unk_51fd[cur] = 0;
+    self->unk_5456++;
+
+    const u8 *f = &data_ov006_0213ce84[idx];
+    if (self->unk_5456 >= (data_ov006_0213ce84[idx] != 0 ? lim : lim - 1)) {
+        if (idx == 0xe || idx == 0x10 || idx == 0x11 || idx == 0x13) {
+            self->mPosX[cur] = self->mPosX[lim - 1];
+            self->mPosY[cur] = self->mPosY[lim - 1] - 0x14000;
+        }
+        self->unk_5455 = 1;
+        if (*f != 0)
+            self->unk_5456 = 1;
+        else
+            self->unk_5456 = lim;
+    }
+
+    if (self->unk_5455 == 0)
+        return;
+
+    self->unk_515c[0] = ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15) << 12;
+    self->unk_515c[1] = ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15) << 12;
+    self->unk_515c[2] = ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15) << 12;
+    self->unk_515c[3] = ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15) << 12;
+}


### PR DESCRIPTION
Matches one ov006 function, the picture placer for the Luigi board minigame.

| Function | Address | Size |
| --- | --- | --- |
| `func_ov006_020f2790` | `0x020f2790` (ov006) | `0x528`, 1320 bytes |

Byte gate, strict relocs, against the pinned compiler:

```
python tools/match.py --c src/func_ov006_020f2790.cpp --func func_ov006_020f2790 \
    --addr 0x020f2790 --size 0x528 --module ov006 --strict-relocs --cpp-check
MATCHING VERSIONS: 2004/b56
```

```
build_pin.verify(src/func_ov006_020f2790.cpp, func_ov006_020f2790, 0x020f2790, 0x528, ov006)
(True, '2004/b56')
```

## The fix

The candidate sat three instructions short for weeks. The reason turned out to be
that the cartridge re-loads two values the source was caching, and two pointer
locals fix it together. Neither one works on its own.

The first is a pointer to the speed-level array element, taken before the
conditional that uses it, with the test itself still written as a subscript. That
puts the address computation in the pre-branch block, exactly where the ROM has
it, and keeps the address live in a register across the three accesses inside the
fixup instead of re-deriving the base from the literal pool.

The second is a const pointer into the frame table, used for the second test only,
with the first test left as a subscript. Written as two subscripts, the compiler
shares one loaded value across both tests and drops the re-load the cartridge
performs after the state flag is set. Naming the pointer and using it for only the
second test restores that re-load: the first test stays folded into the indexed
form, the address computation survives for the pointer, and the tail reads through
it.

## Sibling re-match

Every other source file that includes `dScMgLuigi_c.h`, re-checked at its
`symbols.txt` address and size with strict relocs. Fourteen files, all still
byte-identical:

```
PASS  src/_ZN12dScMgLuigi_c13InitResourcesEv.cpp        @ 0x020f3460 size 0x3a0  MATCHING VERSIONS: 2004/b56
PASS  src/_ZN12dScMgLuigi_c13OnYoshiTryEatEi.cpp        @ 0x020f3294 size 0x12c  MATCHING VERSIONS: 2004/b56
PASS  src/_ZN12dScMgLuigi_c21AfterCleanupResourcesEj.cpp @ 0x020efc68 size 0x90  MATCHING VERSIONS: 2004/b56
PASS  src/_ZN12dScMgLuigi_c6RenderEv.cpp                @ 0x020f33c0 size 0x54   MATCHING VERSIONS: 2004/b56
PASS  src/_ZN12dScMgLuigi_c8BehaviorEv.cpp              @ 0x020f3414 size 0x4c   MATCHING VERSIONS: 2004/b56
PASS  src/_ZN12dScMgLuigi_cD0Ev.cpp                     @ 0x020efc30 size 0x38   MATCHING VERSIONS: 2004/b56
PASS  src/_ZN12dScMgLuigi_cD1Ev.cpp                     @ 0x020efc0c size 0x24   MATCHING VERSIONS: 2004/b56
PASS  src/func_ov006_020f15ac.cpp                       @ 0x020f15ac size 0x250  MATCHING VERSIONS: 2004/b56
PASS  src/func_ov006_020f17fc.c                         @ 0x020f17fc size 0x130  MATCHING VERSIONS: 2004/b56
PASS  src/func_ov006_020f192c.c                         @ 0x020f192c size 0x144  MATCHING VERSIONS: 2004/b56
PASS  src/func_ov006_020f1a70.c                         @ 0x020f1a70 size 0x128  MATCHING VERSIONS: 2004/b56
PASS  src/func_ov006_020f1b98.c                         @ 0x020f1b98 size 0x11c  MATCHING VERSIONS: 2004/b56
PASS  src/func_ov006_020f1cb4.c                         @ 0x020f1cb4 size 0x108  MATCHING VERSIONS: 2004/b56
PASS  src/func_ov006_020f2224.cpp                       @ 0x020f2224 size 0x56c  MATCHING VERSIONS: 2004/b56
--- siblings PASS=14 FAIL=0 ---
```

No header changed, so nothing outside this list can be affected.

## Enrollment

```
src/func_ov006_020f2790.cpp:
    complete
    .text start:0x020f2790 end:0x020f2cb8
```

Hand-inserted in address order in `config/arm9/overlays/ov006/delinks.txt`, between
the `0x020f2224` and `0x020f2cb8` entries. `tools/enroll.py --complete-list` proposes
the identical entry; its other edits in that run (stripping blank lines in ov006,
reordering ov070, rewriting line endings) were reverted, so the diff is the four
lines above and nothing else.

## Gates

```
python tools/prepush_linkcheck.py --range origin/main..HEAD
  [OK  ] func_ov006_020f2790                          VERIFIED
prepush-linkcheck: 1 checked - 1 verified, 0 warning(s), 0 blocking

python tools/langmode_audit.py --check langmode-baseline.json
langmode ratchet PASS

python tools/check_duplicate_sources.py
duplicate-sources: 9476 stems, none doubled

python tools/eligible.py -j 8
eligible: 11187 / 11263        (func_ov006_020f2790 present in build/eligible-names.txt)

python tools/check_references.py
unresolved symbols: 42  (baseline 45)
eligible:           11187  (baseline 11044)
OK: no new unresolvable references

python tools/check_src_tu.py
check_src_tu: 30 translation unit(s), 316 include(s), 783 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.

python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll
Ran 80 tests in 14.623s
OK
```

Langmode ratchet, measured against `origin/main` rather than the banked baseline, so
the numbers are this branch's own contribution:

```
totals.src_files:     9475 -> 9476
totals.cpp_extension: 4048 -> 4049
```

Those two are the whole delta. No count rose in any other class, and this branch adds
no codegen hacks, no shadow declarations and no inline assembly.
