### PR TITLE
tubuild verify: a PROMOTION REFUSED is a failure, not an exit 0

### DIFF
--- a/tools/tubuild.py
+++ b/tools/tubuild.py
@@ -1405,6 +1405,7 @@ def cmd_verify(args):
     else:
         print(f"Result: {n_match}/{len(rows)} MATCH -> NOT verified (see DIFF/MISSING/ERROR "
              f"lines above)")
+    promotion_refused = bool(n_unlicensed or policy_reasons)
     if n_unlicensed:
         print(f"        {n_unlicensed} unlicensed section/symbol(s) present -> PROMOTION "
              f"REFUSED regardless of the above (plan sec 4.5, 8)")
@@ -1466,7 +1467,13 @@ def cmd_verify(args):
     upsert_manifest_entry(data, entry)
     save_manifest(data)
 
-    return 0 if text_verified else 1
+    # A PROMOTION REFUSED is a failure of this command even when the bytes
+    # reproduced. `text_verified` is deliberately NOT folded into: it drives the
+    # manifest status above, and "the bytes match but the policy refuses the
+    # promotion" is a real and distinct state that must keep saying text-verified.
+    # Before this, a refused promotion exited 0 and any caller trusting the exit
+    # code shipped it.
+    return 0 if (text_verified and not promotion_refused) else 1
 
 
 # ========================================================== `linkcheck` -- scratch delinks


### PR DESCRIPTION
`tubuild.py verify` printed

```
N unlicensed section/symbol(s) present -> PROMOTION REFUSED
compiler-only policy refused -> PROMOTION REFUSED
```

and then **returned 0** — the return was `0 if text_verified else 1`, and neither `n_unlicensed` nor `policy_reasons` feeds `text_verified`. Any caller trusting the exit code shipped a refused promotion, which is why the role files carry a standing "read the words, not the code" warning to compensate.

`text_verified` is deliberately **not** folded into. It drives the manifest status transition immediately above (`shadow` ⇄ `text-verified`), and *"the bytes reproduced but the policy refuses the promotion"* is a real and distinct state that must keep saying text-verified. The refusal gets its own `promotion_refused`; only the return value combines the two.

## Blast radius — `verify` run on all 119 `status: promoted` TUs on this base

| | |
|---:|---|
| **88** | exit 0 — unaffected |
| **14** | flip 0 → 1: byte-perfect **and** refused |
| **17** | already exited 1 before this change — untouched by it |

**The 14 that flip.** Every one is `unlicensed section/symbol(s)`; none are compiler-only policy errors:

| TU | unlicensed | TU | unlicensed |
|---|---:|---|---:|
| `ov023/daObjFm_Battan_c` | 1 | `ov036/daObjRcCarpet_c` | 10 |
| `ov044/daObjKb1Billboard_c` | 1 | `ov043/daObjKm1_Dorifu_c` | 10 |
| `ov070/daBrq_c` | 6 | `ov047/daObjKm3_Kaitendai_c` | 10 |
| `ov072/daBgSnwmn_c` | 6 | `ov047/daObjKm3_Kuruma_c` | 10 |
| `ov100/daStarGate_c` | 7 | `ov047/daObjKm3_Kurumajiku_c` | 11 |
| `ov002/daObjHatenaSwitch_c` | 8 | `ov006/dScMgTrampoline2_c` | 9 |
| `ov032/daBakubaku_c` | 8 | `ov070/daPropeller_Heyho_c` | 8 |

These are **pre-existing manifest gaps the exit code was concealing**, not regressions introduced here. Licensing them is separate work and is not attempted in this PR.

## The 17 that were already red are one unrelated cause

Recorded so nobody attributes them to this change. All **23** of their DIFF lines are the identical `objisolate: _ZTV<Class>: unexpected reloc type=2 addend=0`, and **not one is a byte mismatch**.

`objisolate.py` has two sites that judge a `_ZTV` relocation and they disagree: one accepts `addend == 0 or addend >= VTABLE_PREAMBLE`, the other accepts only `addend >= VTABLE_PREAMBLE`. The accepting site documents exactly why addend 0 is legitimate — a source that declares the ROM symbol itself uses `symbols.txt`'s convention, where the symbol *is* the slot array, so there is nothing to correct.

**Flagged, not fixed.** It is a byte-verification tool and the two vptr-store conventions are not mine to collapse on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
