### PR TITLE
Match the ov006 Snowball collision ring and the ov007 vector normalise

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -4328,6 +4328,10 @@ src/func_ov006_02125cdc.c:
     complete
     .text start:0x02125cdc end:0x02125f68
 
+src/func_ov006_02125f68.cpp:
+    complete
+    .text start:0x02125f68 end:0x02126948
+
 src/func_ov006_02126948.c:
     complete
     .text start:0x02126948 end:0x02126a98

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -1471,6 +1471,10 @@ src/func_ov007_020c3598.c:
     complete
     .text start:0x020c3598 end:0x020c368c
 
+src/func_ov007_020c368c.c:
+    complete
+    .text start:0x020c368c end:0x020c39f8
+
 src/func_ov007_020c39f8.c:
     complete
     .text start:0x020c39f8 end:0x020c3abc

--- a/include/dScMgSnowball_c.h
+++ b/include/dScMgSnowball_c.h
@@ -75,6 +75,22 @@ extern "C" void func_ov006_02125800(void);
 extern "C" void NullDestructor_0203d47c(void);
 
 struct dScMgSnowball_c : dScMgSingle3DBase_c {
+    /* The 2-vector value type the collision ring carries the last hit in
+       (Fix12 x, y -- the same pair func_0203d388 rotates in place). THE
+       EMPTY DESTRUCTOR IS LOAD-BEARING, for the reason types.h gives
+       Vector3 one and dScMgFlower_c::Vec2 repeats: a local of this type
+       keeps an 8-byte stack home in the frame's aggregate region instead
+       of being scalarised into two spill words, and func_ov006_02125f68's
+       frame only lays out as the ROM's (sample at sp+0x38, this pair at
+       sp+0x40, acc at sp+0x48) with that home -- a plain POD pair, an
+       int[2] and two scalar temps all lose it, measured on 2004/b56.
+       Nested so the coined name cannot collide with anything global. */
+    struct Vec2 {
+        Fix12i x;
+        Fix12i y;
+        ~Vec2() {}
+    };
+
     virtual ~dScMgSnowball_c();
 
     /* --- this class's own vtable slots, named from the table ---
@@ -122,7 +138,9 @@ struct dScMgSnowball_c : dScMgSingle3DBase_c {
                                 shrinks by 0x1000 a tick while melting */
     Model mModel;           /* 0xaba4 -- 0x50, see file banner */
     s32   unk_abf4;         /* 0xabf4 -- the constructor's own `= 0` write */
-    u8    pad_abf8[0x60];   /* 0xabf8 */
+    u8    mProbeHit[0x20];  /* 0xabf8 -- one flag per 32-step angle probe: set when that probe hit solid or breakable */
+    u8    mProbePush[0x20]; /* 0xac18 -- same probe hit solid; drives the push-out */
+    u8    mProbeWater[0x20];/* 0xac38 -- same probe is inside water */
     u8    mArray1Active[0x80]; /* 0xac58 -- 1 = this mArray1 slot is live */
     u8    mArray1[0x400];   /* 0xacd8 -- 0x80 * 8, elem dtor NullDestructor_0203d47c;
                                each element is a Fix12 {x,y} the ROM's own
@@ -142,7 +160,12 @@ struct dScMgSnowball_c : dScMgSingle3DBase_c {
                                 seconds.centiseconds, 0 ends the run */
     s32   mScore;           /* 0xb9e0 -- +1 a tick while rolling; handed to the
                                 HUD counter func_ov004_020adb1c on the crash */
-    u8    pad_b9e4[0x10];   /* 0xb9e4 */
+    u8    mHitBreakable;    /* 0xb9e4 -- a breakable was hit this tick */
+    u8    mAllWater;        /* 0xb9e5 -- every probe was in water */
+    u8    mSoundPending;    /* 0xb9e6 */
+    u8    pad_b9e7[0x1];    /* 0xb9e7 */
+    s32   unk_b9e8;         /* 0xb9e8 */
+    u8    pad_b9ec[0x8];    /* 0xb9ec */
     s32   mState;           /* 0xb9f4 -- 0 count-in, 1 rolling, 2/3 crash,
                                 4 melt, 5 over */
     u8    mScreensSwapped;  /* 0xb9f8 -- set once mPosY passes 0xe8000; swaps

--- a/src/func_ov006_02125f68.cpp
+++ b/src/func_ov006_02125f68.cpp
@@ -1,0 +1,278 @@
+//cpp
+// @symbol func_ov006_02125f68
+/* recovered: dScMgSnowball_c collision ring, ov006 0x02125f68 (2528 bytes).
+ * Once a tick the snowball fires 32 probes around itself, one every 0x800 of
+ * angle at the current ball radius. Each probe records three flags -- solid,
+ * push-out, in-water -- and the whole ring is re-fired (up to 0x21 times)
+ * while anything is still hit, pushing the ball out along the averaged normal
+ * each pass. If nothing is hit and the ball started inside water, the water
+ * probes instead add buoyancy to the velocity. A breakable hit shrinks the
+ * ball, spawns the two 0xf1/0xf2 particle systems scaled by the new radius,
+ * and fires the break sound; a fast non-breakable hit fires the bump sound.
+ * The tail re-walks the push flags to build the separation vector and
+ * reflects the velocity off it.
+ *
+ * Four spellings are load-bearing, all measured against the ROM on 2004/b56:
+ *   - `hit` is dScMgSnowball_c::Vec2, whose empty destructor keeps it an
+ *     8-byte aggregate in the frame (sample at sp+0x38, hit at sp+0x40, acc at
+ *     sp+0x48). As two ints or an int[2] it is scalarised into spill words at
+ *     sp+0x18/0x1c and every later slot shifts.
+ *   - `part` is Vector3 for the same reason: as three ints or an int[3] the
+ *     two Particle::System::New calls keep the scaled coordinates in
+ *     callee-saved registers instead of storing them at sp+0x90 and reloading
+ *     for the second call (-6 instructions).
+ *   - the four Particle rate fields re-read self->mBallSize instead of caching
+ *     `mBallSize - 0x4000` in a local: the ROM re-loads 0xba0 for each of the
+ *     six assignments.
+ *   - `sample[1] += self->mBallSize` (not `0 + mBallSize`): the ROM adds
+ *     through the register that just stored the zero, so the add survives.
+ * The nine zero/constant scalars before the ring are the ROM's own frame
+ * words sp+0x14..0x34 in source order; folding any pair together drops a
+ * store the cartridge makes. The push loop divides its own `k * 0x10000`
+ * rather than carrying an angle accumulator, which is what stops mwccarm
+ * strength-reducing the /32 into a second induction variable. */
+#include "dScMgSnowball_c.h"
+
+extern "C" {
+extern int func_ov006_021259d8(dScMgSnowball_c *o, int *p);
+extern int func_ov006_02125cdc(dScMgSnowball_c *o, int *p);
+extern int func_ov006_02125bbc(dScMgSnowball_c *o, int *p);
+extern void func_0203d388(int *p, int angle);
+extern int func_0203d434(int *p);
+extern int Vec2_Len(int *p);
+extern void func_0203d630(int *p, int m);
+extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    u32 uniqueID, u32 effectID, int x, int y, int z, const void *dir, void *callback);
+extern int *_ZN8Particle6System12FromUniqueIDEj(u32 uniqueID);
+extern void func_02012718(int a, int b);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern s16 data_02082214[];
+}
+
+#define MUL12(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
+
+extern "C" void func_ov006_02125f68(dScMgSnowball_c *self)
+{
+    int i;
+    int k;
+    int farHit;
+    int anyHit;
+    int initInside;
+    int iter;
+    int zNoHit;
+    int zDry;
+    int zOrigin;
+    int pushDirX;
+    int pushDirY;
+    int floatDirX;
+    int floatDirY;
+    int zNotAllWater;
+    int angle;
+    int j;
+    int sample[2];
+    dScMgSnowball_c::Vec2 hit;
+    int acc[2];
+    int rotA[2];
+    int rotB[2];
+    int push[2];
+    int rotPush[2];
+    int initPt[2];
+    int cdcCopy[2];
+    int bbcCopy[2];
+    int waterCopy[2];
+    Vector3 part;
+    int allWater;
+    int len;
+    int *sys;
+    u32 id1;
+    u32 id2;
+    int cosv;
+    int sc;
+    int vx;
+    int vy;
+
+    i = 0;
+    do {
+        self->mProbeHit[i] = 0;
+        self->mProbePush[i] = 0;
+        self->mProbeWater[i] = 0;
+        i = i + 1;
+    } while (i < 0x20);
+    farHit = 0;
+    self->mHitBreakable = 0;
+
+    initPt[0] = self->mPosX;
+    initPt[1] = self->mPosY;
+    initInside = func_ov006_021259d8(self, initPt);
+
+    iter = 0;
+    zDry = 0;
+    pushDirX = 0;
+    pushDirY = 0x800;
+    zNotAllWater = 0;
+    floatDirX = 0;
+    floatDirY = 0x1000;
+    zOrigin = 0;
+    zNoHit = 0;
+    do {
+        anyHit = zNoHit;
+        angle = zNoHit;
+        for (j = zNoHit; j < 0x20; j++) {
+            self->mProbeHit[j] = 0;
+            sample[0] = 0;
+            sample[1] = 0;
+            sample[1] += self->mBallSize;
+            func_0203d388(sample, angle);
+            sample[0] += self->mPosX;
+            sample[1] += self->mPosY;
+            cdcCopy[0] = sample[0];
+            cdcCopy[1] = sample[1];
+            if (func_ov006_02125cdc(self, cdcCopy) != 0) {
+                self->mProbeHit[j] = 1;
+                self->mProbePush[j] = 1;
+                anyHit = 1;
+                if (Vec2_Len(&self->mVelX) >= 0x800)
+                    farHit = 1;
+                hit.x = sample[0];
+                hit.y = sample[1];
+            } else {
+                bbcCopy[0] = sample[0];
+                bbcCopy[1] = sample[1];
+                if (func_ov006_02125bbc(self, bbcCopy) != 0) {
+                    self->mProbeHit[j] = 1;
+                    anyHit = 1;
+                    self->mProbePush[j] = 1;
+                    self->mHitBreakable = 1;
+                    hit.x = sample[0];
+                    hit.y = sample[1];
+                }
+            }
+            waterCopy[0] = sample[0];
+            waterCopy[1] = sample[1];
+            if (func_ov006_021259d8(self, waterCopy) != 0)
+                self->mProbeWater[j] = 1;
+            else
+                self->mProbeWater[j] = zDry;
+            angle = (s16)(angle + 0x800);
+        }
+
+        acc[0] = zOrigin;
+        acc[1] = zOrigin;
+        angle = zOrigin;
+        if (anyHit != 0) {
+            for (i = 0; i < 0x20; i++) {
+                if (self->mProbeHit[i] == 1) {
+                    rotA[0] = pushDirX;
+                    rotA[1] = pushDirY;
+                    func_0203d388(rotA, angle);
+                    acc[0] += rotA[0];
+                    acc[1] += rotA[1];
+                }
+                angle = (s16)(angle + 0x800);
+            }
+            func_0203d434(acc);
+            if (Vec2_Len(&self->mVelX) < 0x800)
+                func_0203d630(acc, Vec2_Len(&self->mVelX));
+            else
+                func_0203d630(acc, pushDirY);
+            self->mPosX -= acc[0];
+            self->mPosY -= acc[1];
+        } else if (initInside == 1) {
+            allWater = 1;
+            for (i = 0; i < 0x20; i++) {
+                if (self->mProbeWater[i] == 1) {
+                    rotB[0] = floatDirX;
+                    rotB[1] = floatDirY;
+                    func_0203d388(rotB, angle);
+                    acc[0] += rotB[0];
+                    acc[1] += rotB[1];
+                } else {
+                    allWater = zNotAllWater;
+                }
+                angle = (s16)(angle + 0x800);
+            }
+            func_0203d434(acc);
+            self->mVelX += acc[0];
+            self->mVelY += acc[1];
+            if (allWater == 1)
+                self->mAllWater = 1;
+        }
+        iter = iter + 1;
+    } while (anyHit == 1 && iter < 0x21);
+
+    if (self->mHitBreakable == 1) {
+        len = Vec2_Len(&self->mVelX);
+        self->mBallSize -= len;
+        if (self->mBallSize < 0x4000)
+            self->mBallSize = 0x4000;
+        if (len >= 0x800) {
+            int pz = self->mBallSize;
+            int py = (self->mScrollY - hit.y) + 0x110000;
+            int px = hit.x - 0x80000;
+            part.x = px;
+            part.y = py;
+            part.z = pz;
+            id1 = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                0, 0xf1, part.x * 8, part.y * 8, part.z * 8, 0, 0);
+            id2 = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                0, 0xf2, part.x * 8, part.y * 8, part.z * 8, 0, 0);
+            sys = _ZN8Particle6System12FromUniqueIDEj(id1);
+            if (sys != 0) {
+                sys[0x44 / 4] = (s16)((self->mBallSize - 0x4000) * 11 / 60 + 0x3000);
+                sys[0x48 / 4] = (s16)((self->mBallSize - 0x4000) * 36 / 10 / 60 + 0x1333);
+                sys[0x4c / 4] = (s16)((self->mBallSize - 0x4000) * 26 / 10 / 60 + 0x1666);
+                sys[0x50 / 4] = (s16)((self->mBallSize - 0x4000) * 8 / 10 / 60 + 0x666);
+            }
+            sys = _ZN8Particle6System12FromUniqueIDEj(id2);
+            if (sys != 0) {
+                sys[0x48 / 4] = (s16)((self->mBallSize - 0x4000) * 62 / 10 / 60 + 0x1ccc);
+                sys[0x50 / 4] = (s16)((self->mBallSize - 0x4000) * 45 / 10 / 60 + 0x1800);
+            }
+            if (self->mState == 1) {
+                func_02012718(0x169, hit.x);
+                if (self->mSoundPending == 1) {
+                    func_02012718(0x16a, self->unk_b9e8);
+                    self->mSoundPending = 0;
+                }
+            }
+        }
+    } else if (farHit == 1 && self->mState == 1) {
+        func_02012718(0x168, hit.x);
+    }
+
+    k = 0;
+    self->mSoundPending = 0;
+    push[0] = 0;
+    push[1] = 0;
+    do {
+        if (self->mProbePush[k] == 1) {
+            rotPush[0] = 0;
+            rotPush[1] = 0x1000;
+            func_0203d388(rotPush, (s16)(k * 0x10000 / 32));
+            push[0] -= rotPush[0];
+            push[1] -= rotPush[1];
+        }
+        k = k + 1;
+    } while (k < 0x20);
+
+    if (push[0] == 0 && push[1] == 0)
+        return;
+
+    func_0203d434(push);
+    sc = MUL12(self->mVelX, push[0]) + MUL12(self->mVelY, push[1]);
+    if (self->mHitBreakable == 1) {
+        sc = MUL12(sc, 0x1800);
+        self->mVelX -= MUL12(sc, push[0]);
+        self->mVelY -= MUL12(sc, push[1]);
+        cosv = data_02082214[((unsigned short)_ZN4cstd5atan2E5Fix12IiES1_(
+            self->mVelY, self->mVelX) >> 4) * 2];
+        vx = self->mVelX;
+        self->mVelX = vx / 8 + MUL12(vx, cosv) / 4;
+        vy = self->mVelY;
+        self->mVelY = vy / 8 + MUL12(vy, cosv) / 4;
+    } else {
+        sc = MUL12(sc, 0x1200);
+        self->mVelX -= MUL12(sc, push[0]);
+        self->mVelY -= MUL12(sc, push[1]);
+    }
+}

--- a/src/func_ov007_020c368c.c
+++ b/src/func_ov007_020c368c.c
@@ -1,0 +1,97 @@
+/* Normalises a run of Vector3_16s to unit length using the DS hardware divider
+   and square-root units, pipelined: the length of vector n+1 is queued into the
+   square-root unit while the reciprocal for vector n is still in flight, so the
+   loop body always consumes the results started on the previous pass. That is
+   why the first length is set up before the loop and the last one is consumed
+   after it.
+
+   0x04000280 DIVCNT, 0x04000290 DIV_NUMER, 0x04000298 DIV_DENOM,
+   0x040002a0 DIV_RESULT, 0x040002b0 SQRTCNT, 0x040002b4 SQRT_RESULT,
+   0x040002b8 SQRT_PARAM, 0x04000208 IME. Interrupts are masked around each
+   square-root start because an interrupt handler that used the unit mid-write
+   would corrupt the parameter. */
+// @symbol func_ov007_020c368c
+#include "common.h"
+
+#pragma opt_propagation off
+void func_ov007_020c368c(Vector3_16 *v, int count, int clamp)
+{
+    int i;
+    int len2;
+    s64 len2w;
+    u64 numer;
+    u16 ime_saved;
+    Vector3_16 *next;
+    int nextLen2;
+    s64 nextLen2w;
+    int root;
+    s64 rootw;
+    s64 recip;
+    s64 scale;
+    s64 prod;
+    volatile u16 *ime;
+
+    i = 1;
+    len2 = v->x * v->x + v->y * v->y + v->z * v->z;
+    len2w = len2;
+    *(volatile u16 *)0x4000280 = 2;
+    numer = (u64)0x1000000 << 32;
+    *(volatile u64 *)0x4000290 = numer;
+    *(volatile s64 *)0x4000298 = len2w;
+    ime = (volatile u16 *)0x4000208;
+    ime_saved = *ime;
+    *ime = 0;
+    *(volatile u16 *)0x40002b0 = (u16)i;
+    *(volatile u64 *)0x40002b8 = (u64)len2w << 2;
+    *ime;
+    *ime = ime_saved;
+
+    if (count > 1) {
+        next = v + 1;
+        do {
+            nextLen2 = next->x * next->x + next->y * next->y + next->z * next->z;
+            nextLen2w = nextLen2;
+            while (*(volatile u16 *)0x40002b0 & 0x8000) {}
+            root = *(volatile int *)0x40002b4;
+            ime_saved = *ime;
+            *ime = 0;
+            *(volatile u64 *)0x40002b8 = (u64)nextLen2w << 2;
+            *ime;
+            *ime = ime_saved;
+            while (*(volatile u16 *)0x4000280 & 0x8000) {}
+            recip = *(volatile s64 *)0x40002a0;
+            rootw = root;
+            *(volatile u64 *)0x4000290 = numer;
+            *(volatile s64 *)0x4000298 = nextLen2w;
+            scale = recip * rootw;
+            v->x = (s16)((scale * v->x + (1LL << 44)) >> 45);
+            v->y = (s16)((scale * v->y + (1LL << 44)) >> 45);
+            v->z = (s16)((scale * v->z + (1LL << 44)) >> 45);
+            if (clamp != 0) {
+                if (v->x > 0xfff) v->x = (s16)0xfff;
+                if (v->y > 0xfff) v->y = (s16)0xfff;
+                if (v->z > 0xfff) v->z = (s16)0xfff;
+            }
+            v = next;
+            next = next + 1;
+            i = i + 1;
+        } while (i < count);
+    }
+
+    while (*(volatile u16 *)0x40002b0 & 0x8000) {}
+    root = *(volatile int *)0x40002b4;
+    while (*(volatile u16 *)0x4000280 & 0x8000) {}
+    recip = *(volatile s64 *)0x40002a0;
+    scale = recip * (s64)root;
+    prod = scale * v->x;
+    v->x = (s16)((prod + (1LL << 44)) >> 45);
+    prod = scale * v->y;
+    v->y = (s16)((prod + (1LL << 44)) >> 45);
+    prod = scale * v->z;
+    v->z = (s16)((prod + (1LL << 44)) >> 45);
+    if (clamp == 0)
+        return;
+    if (v->x > 0xfff) v->x = 0xfff;
+    if (v->y > 0xfff) v->y = 0xfff;
+    if (v->z > 0xfff) v->z = 0xfff;
+}


### PR DESCRIPTION
Two matches from two lanes, plus the class-header change the first one needs.

| Function | Module | Address | Size | Provenance |
| --- | --- | --- | --- | --- |
| `func_ov006_02125f68` | ov006 | 0x02125f68 | 0x9e0 (2528 bytes) | The `dScMgSnowball_c` collision ring: 32 angle probes fired around the ball each tick, re-fired while anything is still hit, then a push-out and a velocity reflection off the averaged normal. Recovered against the cartridge, `.cpp` because it is a member-shaped body over the existing class. |
| `func_ov007_020c368c` | ov007 | 0x020c368c | 0x36c (876 bytes) | Normalises a run of `Vector3_16` to unit length on the DS hardware divider and square-root units, pipelined so vector n+1's length is queued while vector n's reciprocal is still in flight. |

## Byte gate

Both functions, strict relocations, at their `symbols.txt` address and size:

```
src/func_ov006_02125f68.cpp  func_ov006_02125f68  0x02125f68  size=0x9e0  ov006
MATCHING VERSIONS: 2004/b56

src/func_ov007_020c368c.c    func_ov007_020c368c  0x020c368c  size=0x36c  ov007
MATCHING VERSIONS: 2004/b56
```

`build_pin.verify` agrees for both:

```
ov006 0x02125f68 (True, '2004/b56')
ov007 0x020c368c (True, '2004/b56')
```

## The header change

`include/dScMgSnowball_c.h` splits two pads that were already there and adds a nested type; every field offset that was already commented is unchanged, the struct still spans 0xc59c, and the size assert is untouched. `pad_abf8[0x60]` becomes the three 0x20 probe-flag arrays the ring writes, and `pad_b9e4[0x10]` becomes three flag bytes, a word, and two smaller pads that add back to the same 0x10.

All ten other source files that include the header still match strict at their own address and size:

```
src/_ZN15dScMgSnowball_c11OnAttacked2Ev.cpp       ov006 0x021291d4 size=0x24   MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_c13InitResourcesEv.cpp     ov006 0x02129268 size=0x344  MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_c13OnYoshiTryEatEi.cpp     ov006 0x0212921c size=0x4c   MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_c16CleanupResourcesEv.cpp  ov006 0x021291f8 size=0x24   MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_c6RenderEv.cpp             ov006 0x02127d10 size=0x694  MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_c8BehaviorEv.cpp           ov006 0x021283a4 size=0xc14  MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_c8OnKickedEv.cpp           ov006 0x02128fb8 size=0x1f8  MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_c8OnPushedEv.cpp           ov006 0x021291b0 size=0x24   MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_cD0Ev.cpp                  ov006 0x0212573c size=0xc4   MATCHING VERSIONS: 2004/b56
src/_ZN15dScMgSnowball_cD1Ev.cpp                  ov006 0x0212568c size=0xb0   MATCHING VERSIONS: 2004/b56
```

## Link check

```
1 changed header(s) fan out to 12 source file(s) to verify
  [OK  ] _ZN15dScMgSnowball_c11OnAttacked2Ev          VERIFIED
  [OK  ] _ZN15dScMgSnowball_c13InitResourcesEv        VERIFIED
  [OK  ] _ZN15dScMgSnowball_c13OnYoshiTryEatEi        VERIFIED
  [OK  ] _ZN15dScMgSnowball_c16CleanupResourcesEv     VERIFIED
  [OK  ] _ZN15dScMgSnowball_c6RenderEv                VERIFIED
  [OK  ] _ZN15dScMgSnowball_c8BehaviorEv              VERIFIED
  [OK  ] _ZN15dScMgSnowball_c8OnKickedEv              VERIFIED
  [OK  ] _ZN15dScMgSnowball_c8OnPushedEv              VERIFIED
  [OK  ] _ZN15dScMgSnowball_cD0Ev                     VERIFIED
  [OK  ] _ZN15dScMgSnowball_cD1Ev                     VERIFIED
  [OK  ] func_ov006_02125f68                          VERIFIED
  [OK  ] func_ov007_020c368c                          VERIFIED
prepush-linkcheck: 12 checked - 12 verified, 0 warning(s), 0 blocking
```

## Ratchet

```
langmode ratchet PASS
```

No tracked langmode counter moves on this branch. Comparing the audit with and without the two new sources: no counter moved. Neither file carries an inline-assembly hatch, a forced-cast idiom, or a shadow struct body, so the shadow and codegen-hack columns are flat.

Other gates:

```
duplicate-sources: 9479 stems, none doubled
eligible: 11190 / 11266   (both new names present in build/eligible-names.txt)
unresolved symbols: 42  (baseline 45)
OK: no new unresolvable references
check_src_tu: 30 translation unit(s), 316 include(s), 783 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.
check_header_offsets: 1 changed header(s) vs origin/main
include/dScMgSnowball_c.h: 58 commented fields, 0 mismatched, 0 unparsed, struct spans 0xc59c
python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll
Ran 80 tests in 16.835s
OK
```

## Enrollment

Both hunks were hand-inserted in address order with the file's own CRLF endings, and `tools/enroll.py --dry-run --complete-list` proposes exactly these two entries at exactly these insertion points. Nothing else in either file moved, no arm9 delinks changed, and the near-miss database is untouched.

```
src/func_ov006_02125f68.cpp:
    complete
    .text start:0x02125f68 end:0x02126948

src/func_ov007_020c368c.c:
    complete
    .text start:0x020c368c end:0x020c39f8
```

## Notes

The header change only splits pads that already existed and adds a nested two-vector type; every commented offset, the 0xc59c span, and the size assert are unchanged.

The ov007 function was reached by reconstruction from the cartridge after two lanes had recorded conflicting divergence counts for it.
