### PR TITLE
Match the ov065 sine-table vector routine

### DIFF
--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -224,6 +224,10 @@ src/func_ov065_02118634.c:
     complete
     .text start:0x02118634 end:0x02118838
 
+src/func_ov065_02118838.cpp:
+    complete
+    .text start:0x02118838 end:0x02118c4c
+
 src/func_ov065_02118c4c.c:
     complete
     .text start:0x02118c4c end:0x02118cc4

--- a/src/func_ov065_02118838.cpp
+++ b/src/func_ov065_02118838.cpp
@@ -1,0 +1,122 @@
+//cpp
+// @symbol func_ov065_02118838
+/* Rebuilds the seven moving collision segments of the ov065 actor (Dorrie's
+   body chain) once per frame.
+
+   For each segment it takes the segment's index from the byte table at
+   data_ov065_0211c078, copies the source rotation out of the 0x34-byte entry
+   array at +0xfc, then multiplies the segment's own 0x30-byte matrix (from the
+   array at +0x100) by the actor's base matrix to get the segment's world
+   position. Segment 2 is the head: it also picks up the extra rotation stored
+   at +0x548 and drives the camera target at +0xd8 and the look-at point at
+   +0x1180 with a sine/cosine offset taken from the table at data_02082214.
+   Each finished matrix is written to the segment's slot at +0x150 (stride
+   0x200) and handed to dBgW_KcMbg::Transform along with the segment's
+   collision object at +0x180. */
+#include "common.h"
+
+extern "C" {
+void Matrix4x3_FromTranslation(Matrix4x3 *m, s32 x, s32 y, s32 z);
+void Matrix4x3_ApplyInPlaceToRotationX(Matrix4x3 *m, s16 a);
+void Matrix4x3_ApplyInPlaceToRotationY(Matrix4x3 *m, s16 a);
+void Matrix4x3_ApplyInPlaceToRotationZ(Matrix4x3 *m, s16 a);
+void MulMat4x3Mat4x3(const Matrix4x3 *a, const Matrix4x3 *b, Matrix4x3 *o);
+void SubVec3(const Vector3 *a, const Vector3 *b, Vector3 *o);
+void AddVec3(const Vector3 *a, const Vector3 *b, Vector3 *o);
+void Vec3_LslInPlace(Vector3 *v, s32 sh);
+void _ZN10dBgW_KcMbg9TransformERK9Matrix4x3s(void *self, const Matrix4x3 *m, s16 a);
+extern Matrix4x3 data_020a0e68;
+extern u8 data_ov065_0211c078[];
+extern s16 data_02082214[];
+}
+
+#pragma opt_common_subs off
+#pragma opt_strength_reduction off
+extern "C" void func_ov065_02118838(char *c)
+{
+    char *pm;
+    char *pk;
+    s32 zero;
+    s32 three;
+    Vector3s rot;
+    Vector3 v;
+    Matrix4x3 base;
+    s32 i;
+    u8 *tbl;
+
+    Matrix4x3_FromTranslation(&data_020a0e68, *(s32 *)(c + 0x5c), *(s32 *)(c + 0x60), *(s32 *)(c + 0x64));
+    Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(s16 *)(c + 0x8e));
+    base = data_020a0e68;
+    pm = c + 0x150;
+    pk = c + 0x180;
+    zero = 0;
+    three = 3;
+    tbl = data_ov065_0211c078;
+    for (i = 0; i < 7; i++) {
+        char *ent = *(char **)(c + 0xfc) + *tbl * 0x34;
+        {
+            u16 tz = *(u16 *)(ent + 0x1e);
+            u16 ty = *(u16 *)(ent + 0x1c);
+            u16 tx = *(u16 *)(ent + 0x1a);
+            rot.x = tx;
+            rot.y = ty;
+            rot.z = tz;
+        }
+        *(Vector3s *)(c + (i << 9) + 0x348) = rot;
+        if (i == 2) {
+            *(s16 *)(c + (i << 9) + 0x348) += *(s16 *)(c + 0x548);
+            *(s16 *)(c + (i << 9) + 0x34a) += *(s16 *)(c + 0x54a);
+            *(s16 *)(c + (i << 9) + 0x34c) += *(s16 *)(c + 0x54c);
+        }
+        v.x = zero;
+        v.y = zero;
+        v.z = zero;
+        {
+            Matrix4x3 *m = &data_020a0e68;
+            *m = base;
+            MulMat4x3Mat4x3((Matrix4x3 *)(*(char **)(c + 0x100) + *tbl * 0x30), m, m);
+            v.x = m->m[9];
+            v.y = m->m[10];
+            v.z = m->m[11];
+        }
+        SubVec3(&v, (Vector3 *)(c + 0x5c), &v);
+        Vec3_LslInPlace(&v, three);
+        AddVec3(&v, (Vector3 *)(c + 0x5c), &v);
+        if (i == 2) {
+            s32 *cx = (s32 *)(c + 0xd8);
+            s32 *cy = (s32 *)(c + 0xdc);
+            s32 *cz = (s32 *)(c + 0xe0);
+            s32 *hx = (s32 *)(c + 0x1180);
+            s32 *hy = (s32 *)(c + 0x1184);
+            s32 *hz = (s32 *)(c + 0x1188);
+            s32 k1e = 0x1e;
+            s32 k82 = 0x82;
+            s32 k96 = 0x96;
+            s32 rnd = 0x800;
+            s32 scaled;
+            *(s16 *)(c + 0xe4) = *(s16 *)(c + 0x748);
+            *(s32 *)(c + 0x1180) = v.x;
+            *(s32 *)(c + 0x1184) = v.y;
+            *(s32 *)(c + 0x1188) = v.z;
+            scaled = data_02082214[(*(u16 *)(c + 0xe4) >> 4) * 2] * k96;
+            *(s32 *)(c + 0xd8) = *(s32 *)(c + 0x1180);
+            *(s32 *)(c + 0xdc) = *(s32 *)(c + 0x1184);
+            *(s32 *)(c + 0xe0) = *(s32 *)(c + 0x1188);
+            *cx += (s32)(((s64)scaled * data_02082214[(*(u16 *)(c + 0x8e) >> 4) * 2] + rnd) >> 12);
+            *cy += 0x8c000 - data_02082214[(*(u16 *)(c + 0xe4) >> 4) * 2] * k1e;
+            *cz += (s32)(((s64)scaled * data_02082214[(*(u16 *)(c + 0x8e) >> 4) * 2 + 1] + rnd) >> 12);
+            *hx += data_02082214[(*(u16 *)(c + 0x8e) >> 4) * 2] * k82;
+            *hy += 0x50000;
+            *hz += data_02082214[(*(u16 *)(c + 0x8e) >> 4) * 2 + 1] * k82;
+        }
+        Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
+        Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, (s16)(*(s16 *)(c + 0x8e) + *(s16 *)(c + (i << 9) + 0x34a)));
+        Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(s16 *)(c + (i << 9) + 0x348));
+        Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(s16 *)(c + (i << 9) + 0x34c));
+        *(Matrix4x3 *)(c + (i << 9) + 0x150) = data_020a0e68;
+        _ZN10dBgW_KcMbg9TransformERK9Matrix4x3s(pk, (Matrix4x3 *)pm, *(s16 *)(c + 0x8e));
+        pm += 0x200;
+        pk += 0x200;
+        tbl++;
+    }
+}


### PR DESCRIPTION
One function, byte-identical against the cartridge under the pinned compiler.

| Function | Address | Size |
| --- | --- | --- |
| `func_ov065_02118838` | `0x02118838` (ov065) | `0x414` (1044 bytes) |

## Byte gate

`tools/match.py --strict-relocs --all --cpp-check`, every known compiler swept:

```
TARGET func_ov065_02118838 @ 0x02118838 size 0x414 (1044 bytes)
  2004/b56: MATCH
  1.2/base, 1.2/sp2, 1.2/sp2p3, 1.2/sp3, 1.2/sp4:          999 word(s) differ
  2.0/base .. 2.0/sp2p4 (15 versions):                     999 word(s) differ
  dsi/1.1 .. dsi/1.3p1:                                    999 word(s) differ
  dsi/1.6sp1, dsi/1.6sp2:                                  999 word(s) differ

========================================
MATCHING VERSIONS: 2004/b56
```

`build_pin.verify(src/func_ov065_02118838.cpp, func_ov065_02118838, 0x02118838, 0x414, ov065)` returns `(True, '2004/b56')`.

The file includes only `common.h`, so there is no shared class header to re-match alongside it. No `NONMATCHING` banner, no launder idiom, no `volatile`, no inline asm. The two pragmas it carries, `opt_common_subs` and `opt_strength_reduction`, are ordinary practice in this tree.

## Link check

```
  [OK  ] func_ov065_02118838                          VERIFIED
prepush-linkcheck: 1 checked - 1 verified, 0 warning(s), 0 blocking
```

## Ratchet and reference gates

```
langmode ratchet PASS
duplicate-sources: 9478 stems, none doubled
check_src_tu: 30 translation unit(s), 316 include(s), 783 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.
eligible: 11189 / 11265        (func_ov065_02118838 is ELIGIBLE)
check_references: unresolved symbols 42 (baseline 45), OK: no new unresolvable references
python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll
Ran 80 tests in 17.472s
OK
```

Langmode deltas attributable to this branch: `totals.src_files` 9477 to 9478, `totals.cpp_extension` 4050 to 4051. Nothing rises.

## Enrollment

One hunk added to `config/arm9/overlays/ov065/delinks.txt`, in address order, between the `0x02118634` and `0x02118c4c` entries:

```
src/func_ov065_02118838.cpp:
    complete
    .text start:0x02118838 end:0x02118c4c
```

`tools/enroll.py --complete-list` proposes a byte-identical file (same blob, `370dd456e`). Nothing else in `config/` moves: no other delinks, no `rombuild-versions.txt`, no near-miss database rows.

## What the function does

Once per frame it rebuilds the seven moving collision segments of the ov065 actor. For each segment it reads the segment index from the byte table at `data_ov065_0211c078`, pulls the source rotation out of the 0x34-byte entry array at `+0xfc`, multiplies the segment's own 0x30-byte matrix from the array at `+0x100` by the actor's base matrix, and writes the result into the segment's slot at `+0x150` before handing it to `dBgW_KcMbg::Transform` with the collision object at `+0x180`. Segment 2 is the head, so it also picks up the extra rotation at `+0x548` and drives the camera target at `+0xd8` and the look-at point at `+0x1180` from the sine table at `data_02082214`.

## Diagnosis, and a correction

This function was recorded for two days as a constant-hoisting wall. That was wrong, and the record is worth correcting because the wrong label sent several attempts after the wrong thing.

The real problem was the stack frame. Ours was eight bytes larger than the cartridge's. The compiler was parking the address of the sine table in a callee-saved register and keeping it there across the whole loop. The cartridge does not do that: it reloads the pool word six separate times. Holding the table address costs a register, and losing that register is what pushed a rounding constant and the high word of a multiply out onto the stack as two extra spill slots. Those two slots were the eight bytes, and everything downstream of them, the frame size, the stack offsets, the spill and reload traffic, was a consequence, not a separate problem.

The threshold turned out to be exact. Six references to the table is where the compiler decides the address is worth a register. Swapping a single read for a dummy dropped the reference count to five, and the frame dropped with it, which is what proved the mechanism rather than guessed at it.

The fix was moving one statement so the hoist never happens. That removed the hoist and the extra frame in the same edit and took the function from 183 divergences to 30, and then to zero.
