### PR TITLE
Stop counting zero-size aliases in the function denominator

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -230,8 +230,10 @@ jobs:
 #                                      never as a NitroFS file ID.
 #   test_attribution            (17)   chaos_db_ci.py -- rebuilds chaos-db.json from
 #                                      COMMITTED history; the credit data the site reads.
-#   test_bytegate               (18)   bytegate.py -- the byte-gate-failure half of the
-#                                      matched test, over layout_check/relocs/srcpath.
+#   test_bytegate               (23)   bytegate.py -- the byte-gate-failure half of the
+#                                      matched test, over layout_check/relocs/srcpath,
+#                                      plus is_zero_size_alias, which decides whether a
+#                                      symbol is in the published DENOMINATOR at all.
 #   test_check_data_definitions  (3)   check_data_definitions.py -- WHICH objects the
 #                                      gate scans. It globbed only build/src/, which
 #                                      eligible.py never writes, so it skipped silently.
@@ -264,8 +266,9 @@ jobs:
 #                                      profile/class namespace split, actor/base layout
 #                                      distinction, overlay-address rejection, and the
 #                                      dry-run-only policy for ambiguous factory names.
-#   test_progress                (4)   progress.py -- matched functions/bytes vs the
-#                                      whole game; the number the README reports.
+#   test_progress                (5)   progress.py -- matched functions/bytes vs the
+#                                      whole game; the number the README reports, both
+#                                      halves of the fraction.
 #   test_rombuild               (37)   rombuild.py -- the source-to-ROM build itself:
 #                                      intact-TU policy resolution, per-file verdicts and
 #                                      the `.init` retargeting that decides which `.text`

--- a/tools/bytegate.py
+++ b/tools/bytegate.py
@@ -16,9 +16,16 @@ differently on purpose:
 
   zero-size alias   DERIVED, live, by alias_collision_addresses() below. It reads
                     config/**/symbols.txt and nothing else, so the progress and Chaos
-                    generators share one definition and it self-heals in both
-                    directions: fix the config and the record returns to the count;
-                    match a previously unmatched alias and it is excluded the same day.
+                    generators share one definition, and it self-heals: fix the config
+                    so the record carries its own size and it returns to the count.
+
+                    These records leave the count ENTIRELY -- numerator and denominator
+                    both. They are not functions. Each one is a second name for a
+                    function already in the list at the same address, so counting the
+                    pair asks the project to match the same bytes twice, and the
+                    zero-size half can never be matched. Subtracting it from the
+                    numerator alone (what this did until 2026-09-06) parked ten records
+                    in the denominator that nothing could ever clear.
 
   will not build    a MANIFEST, config/bytegate-known-failures.txt, because deciding it
                     means running mwccarm. The two workflows that regenerate the
@@ -66,9 +73,9 @@ FUNC_RE = re.compile(
 def alias_collision_addresses(module_universe=None) -> set[tuple[str, int]]:
     """``{(module, addr)}`` where a zero-size function aliases a sized record.
 
-    Only the zero-size side is excluded from MATCHED. Address-keying lets callers make
-    that decision while visiting the full symbol record, and deriving it from committed
-    config keeps the progress and Chaos generators in lockstep.
+    Only the zero-size side is dropped. Address-keying lets callers make that decision
+    while visiting the full symbol record, and deriving it from committed config keeps
+    the progress and Chaos generators in lockstep.
     """
     if module_universe is None:
         sys.path.insert(0, str(REPO / "tools"))
@@ -89,6 +96,24 @@ def alias_collision_addresses(module_universe=None) -> set[tuple[str, int]]:
                 zero.append(addr)
         out.update((label, addr) for addr in zero if addr in sized)
     return out
+
+
+def is_zero_size_alias(module: str, addr: int, size: int, alias_addrs) -> bool:
+    """Is this symbol record the second-name half of an aliased address?
+
+    ONE definition, called by the numerator and by the denominator in both counting
+    tools. The set above is keyed by ADDRESS and both records sit on it, so ``size == 0``
+    is the whole of what separates the alias from the body it names; a caller that
+    forgot it would refuse to count func_01ff8708 (1,776 bytes) the day someone matches
+    it. Sharing one function is what keeps the two sides of the fraction from drifting
+    apart the way they did before -- the zero-size side was subtracted from the
+    numerator and left in the denominator, so it could never be cleared.
+
+    ``alias_addrs`` is passed in rather than derived here because the callers walk
+    thousands of symbol lines and deriving it per line would re-read every symbols.txt
+    in the repository each time.
+    """
+    return size == 0 and (module, addr) in alias_addrs
 
 
 def source_hash(path: pathlib.Path) -> str | None:

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -66,32 +66,38 @@ def enrolled_addresses():
 
 
 def alias_collision_addresses():
-    """{(module, addr)} where a size-0 function record and a SIZED one collide -- the
-    derived half of the byte-gate-failure class.
+    """{(module, addr)} where a size-0 function record and a SIZED one collide.
 
-    ADDRESSES, not records, so the caller must exclude only the `size == 0` side. Both
+    ADDRESSES, not records, so the caller must act on only the `size == 0` side. Both
     records live at the same key and dropping both would be the opposite of the fix: the
     sized primaries here are the bodies that SHOULD be counted once someone matches them,
-    and func_01ff8708 is 1,776 bytes of it.
+    and func_01ff8708 is 1,776 bytes of it. bytegate.is_zero_size_alias is the one
+    predicate that gets that right; call it rather than re-spelling the test.
 
-    config/arm9/itcm/symbols.txt declares four bodies twice, once as a sized function and
+    config/arm9/itcm/symbols.txt declares eight bodies twice, once as a sized function and
     once as a zero-size alias at the identical address (_dmul beside func_01ff8708,
     _ll_sdiv beside func_01ffaa34, _s32_div_f beside __aeabi_idiv, _u32_div_f beside
-    __aeabi_uidiv). srcpath resolves src/_dmul.c -- a real HAND-ASM PRIMITIVE match --
-    onto the ZERO-SIZE record, so the same 1,776-byte body was counted matched at 0 bytes
-    as the alias and unmatched at full size as the primary. linkcheck reports all four
+    __aeabi_uidiv, and _dadd, _deq, _ll_udiv, _ull_mod likewise); config/arm9/symbols.txt
+    declares two more (__cxa_vec_cleanup beside __destroy_arr, __cxa_vec_ctor beside
+    func_020733a8). srcpath resolves src/_dmul.c -- a real HAND-ASM PRIMITIVE match --
+    onto the ZERO-SIZE record, so the same 1,776-byte body read as matched at 0 bytes
+    under the alias and unmatched at full size under the primary. linkcheck reports those
     NO-SYM (len-mismatch), which is the byte gate declining to compare a real function
     against a zero-length range.
 
-    Deriving this rather than listing it means it self-heals both ways: repointing the
-    alias at the sized symbol in config restores the count, and the four aliases that
-    carry the same defect but are not matched today (__cxa_vec_cleanup, _dadd, _ll_udiv,
-    _ull_mod) are already covered if anyone matches them. Eight such records exist in the
-    universe and every one has a sized twin, so this cannot catch a legitimately
-    zero-size lone symbol.
+    Those ten records leave the universe here, numerator and denominator both. A second
+    name for a function already in the list is not a second function, and the zero-size
+    half can never be byte-compared, so leaving it in the denominator (which is what
+    happened until 2026-09-06) parks ten records that no amount of decompilation can
+    clear. Deriving the set rather than listing it means the drop self-heals: repoint the
+    alias at a real size in config and the record returns to the count with no edit here.
+    Every zero-size record in the universe today has a sized twin, and a zero-size symbol
+    that stands alone is NOT caught by this -- it stays counted, so a genuinely unmatched
+    stub cannot be hidden by calling it an alias.
 
     Committed config only, no ROM and no compiler, so it runs in the workflows that
-    publish the count. The other half of the class cannot be; see tools/bytegate.py.
+    publish the count. The other half of the byte-gate-failure class cannot be; see
+    tools/bytegate.py.
     """
     return BG.alias_collision_addresses(RL.module_universe)
 
@@ -532,6 +538,7 @@ def main():
     wont_build = BG.excluded_paths()
     bytegate_n = collections.Counter()
     enrollment_n = collections.Counter()
+    alias_dropped = 0
     transcribed_files, unbannered_files = set(), set()
     # Every module, itcm included. relocs.module_universe is the one definition of
     # what "every module" means, and it fails loudly rather than skipping a new one.
@@ -541,6 +548,16 @@ def main():
             if not m:
                 continue
             name, size, addr = m.group(1), int(m.group(2), 16), int(m.group(3), 16)
+            # A zero-size record sharing an address with a sized one is a second NAME
+            # for the function already on that address, not a second function, so it
+            # never becomes a record at all -- it is out of the numerator and out of
+            # the denominator alike. It used to be published as an unmatched record,
+            # which put ten rows in every total that nothing could ever clear, gave the
+            # treemap ten zero-area rectangles, and handed two records the same `id`.
+            # See alias_collision_addresses for the ten and for how the drop self-heals.
+            if BG.is_zero_size_alias(label, addr, size, alias_addrs):
+                alias_dropped += 1
+                continue
             f = SP.path_for(name)
             src_path = f.relative_to(REPO).as_posix() if f else None
             text = f.read_text(errors="ignore") if f else ""
@@ -559,23 +576,15 @@ def main():
             # not promoted, which is why the report's options B and C were rejected: they
             # would have deleted matches that are demonstrably correct. `verified` is
             # unchanged and still published beside this, and none of the 22 was verified,
-            # so that number does not move.
+            # so that number does not move. The alias half of the class is handled above,
+            # by never becoming a record; what is left here is the manifest half.
             #
-            # `size == 0` is load-bearing: alias_collision_addresses keys on the address
-            # and both records sit on it. Dropping the sized side too would refuse to
-            # count func_01ff8708 and friends the day someone matches them, which is the
-            # defect this is meant to clear, not deepen.
-            zero_alias = size == 0 and (label, addr) in alias_addrs
             # The gate is applied only to records the OLD test would have counted, so
             # that it is credited with what it actually removed rather than with every
-            # record the class happens to describe. Four of the eight zero-size aliases
-            # have no source at all and were never counted; stamping those would claim a
-            # subtraction that is not this rule's and would make the CI line disagree
-            # with the 22 this policy names.
+            # record the class happens to describe.
             countable = (bool(src_path) and not asm_policy.has_draft_banner(text)
                          and cls != "transcribed")
-            bytegate_fail = countable and (
-                zero_alias or (src_path is not None and src_path in wont_build))
+            bytegate_fail = countable and src_path is not None and src_path in wont_build
             matched = countable and not bytegate_fail
             total_b += size
             rec = {"id": f"{label}:0x{addr:08x}", "module": label, "name": name,
@@ -584,7 +593,7 @@ def main():
                 # Recorded on the record, not just subtracted from a total. A reader who
                 # wonders why a src/ file exists for an unmatched function gets the
                 # answer here instead of having to re-run the gate.
-                rec["byteGate"] = "zero-size-alias" if zero_alias else "will-not-build"
+                rec["byteGate"] = "will-not-build"
                 bytegate_n[rec["byteGate"]] += 1
             if src_path:
                 rec["srcPath"] = src_path
@@ -695,6 +704,11 @@ def main():
     # exclusion is the same mistake the enrollment split was added to fix.
     print("  byte-gate failures (NOT counted matched): " + (", ".join(
         f"{k}={n}" for k, n in sorted(bytegate_n.items())) or "none"))
+    # And the records that never became records. This one changes the DENOMINATOR, so it
+    # is the last thing that may move quietly: if this number drifts, the published rate
+    # drifted with it and the log is where anyone would look.
+    print(f"  zero-size aliases dropped from the universe: {alias_dropped} "
+          f"(second names for functions already counted at the same address)")
     # A stale manifest row means someone edited one of the will-not-build files without
     # re-running the gate, so its exclusion has lapsed and that function is being counted
     # again. Permissive by design -- the count falls back to the old behaviour rather than

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -1,6 +1,8 @@
 """Report decomp completion: matched functions / bytes vs the whole game.
 
-Totals come from the dsd config (every kind:function across all modules).
+Totals come from the dsd config (every kind:function across all modules, less
+the zero-size alias records, which are second names for functions already
+counted at the same address -- see bytegate.is_zero_size_alias).
 Matched functions are recorded in progress/matched.jsonl (one JSON object per
 line: {"addr","name","size","module","versions"}). De-duped by addr.
 
@@ -36,7 +38,6 @@ README = REPO / "README.md"
 README_START = "<!-- progress:start -->"
 README_END = "<!-- progress:end -->"
 
-FUNC_RE = re.compile(r"kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\)")
 FUNC_NAME_RE = re.compile(
     r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\)"
     r".*?addr:0x([0-9a-fA-F]+)"
@@ -49,7 +50,7 @@ def source_counts_as_matched(path, src_path, module, addr, size,
     text = path.read_text(errors="ignore")
     countable = (not asm_policy.has_draft_banner(text)
                  and asm_policy.classify(text) != "transcribed")
-    zero_alias = size == 0 and (module, addr) in alias_addrs
+    zero_alias = BG.is_zero_size_alias(module, addr, size, alias_addrs)
     return countable and not zero_alias and src_path not in excluded_paths
 
 
@@ -57,14 +58,20 @@ def totals():
     n = 0
     total_bytes = 0
     per_module = {}
-    for sym in CONFIG.rglob("symbols.txt"):
+    alias_addrs = BG.alias_collision_addresses()
+    # relocs.module_universe rather than a local rglob, so the module label this asks
+    # alias_addrs about is the same label alias_addrs was built with. The display key
+    # below stays the config-relative path it always was.
+    for sym, label in RL.module_universe():
         # module label: e.g. arm9, arm9/itcm, arm9/overlays/ov006
         mod = sym.parent.relative_to(CONFIG).as_posix()
         m_n = m_b = 0
         for line in sym.read_text(errors="ignore").splitlines():
-            mm = FUNC_RE.search(line)
+            mm = FUNC_NAME_RE.match(line)
             if mm:
-                sz = int(mm.group(1), 16)
+                sz, addr = int(mm.group(2), 16), int(mm.group(3), 16)
+                if BG.is_zero_size_alias(label, addr, sz, alias_addrs):
+                    continue  # a second name, not a second function -- see synced_from_src
                 m_n += 1
                 m_b += sz
         if m_n:
@@ -87,12 +94,28 @@ def synced_from_src():
     # too, so all the surfaces agreed on a number that left out 43 real functions
     # and 24344 bytes of real game code. They agree again, on the honest figure:
     # counting itcm moves the published rate from 92.480% to 91.580%.
+    #
+    # The denominator then had a second honesty problem, fixed the same way on
+    # 2026-09-06. Ten symbols in config are zero-size aliases: each one shares its
+    # address with a sized function that is already in this loop, so `_dmul` and
+    # func_01ff8708 are one body under two names. The numerator has always refused
+    # them (source_counts_as_matched, above) because a zero-length range cannot be
+    # byte-compared against anything -- but `n += 1` counted them anyway, so ten
+    # records sat in the denominator that no amount of decompilation could ever
+    # clear. They are dropped from both sides now, using the numerator's own
+    # predicate rather than a name list, so a config fix that gives one a real size
+    # brings it straight back. Measured at this commit's base: the count was
+    # 11,304 / 11,402 = 99.141%; it is 11,304 / 11,392 = 99.228%, and the work left
+    # is 88 functions, not 98. No function's matched status changes and no byte total
+    # moves, because all ten records are size 0.
     for sym, _label in RL.module_universe():
         for line in sym.read_text(errors="ignore").splitlines():
             m = FUNC_NAME_RE.match(line)
             if not m:
                 continue
             name, sz, addr = m.group(1), int(m.group(2), 16), int(m.group(3), 16)
+            if BG.is_zero_size_alias(_label, addr, sz, alias_addrs):
+                continue
             n += 1
             total_bytes += sz
             f = SP.path_for(name)

--- a/tools/rebuild_ledger.py
+++ b/tools/rebuild_ledger.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(REPO / "tools"))
 import srcpath as SP
 import asm_policy  # noqa: E402  # noqa: E402
 import relocs as RL  # noqa: E402
+import bytegate as BG  # noqa: E402
 MATCHED = REPO / "progress" / "matched.jsonl"
 
 FUNC_RE = re.compile(
@@ -36,6 +37,7 @@ FUNC_RE = re.compile(
 
 def main():
     recs, seen = [], set()
+    alias_addrs = BG.alias_collision_addresses()
     # Every module, itcm included. The local module_label here was the fourth copy
     # of the arm9-plus-overlays filter, and it kept itcm's matches out of the
     # ledger that the treemap and the local viewer both read.
@@ -45,6 +47,14 @@ def main():
             if not m:
                 continue
             name, size, addr = m.group(1), int(m.group(2), 16), int(m.group(3), 16)
+            # Same rule the published count uses: a zero-size record sharing its address
+            # with a sized one is a second name, not a function. src/_dmul.c is a real
+            # match, but it is a match of func_01ff8708, which sits at the same address
+            # and is the record that should carry it. Banking the alias put a row in the
+            # local ledger that the published number does not have, so the plain
+            # `python tools/progress.py` report read higher than the README.
+            if BG.is_zero_size_alias(label, addr, size, alias_addrs):
+                continue
             # A function is matched if ANY committed sibling is a real match; a stale
             # NONMATCHING draft (e.g. src/NAME.c) can shadow a landed match (NAME.cpp),
             # so never let the first extension found decide it (chaos_db_ci.py has the

--- a/tools/test_bytegate.py
+++ b/tools/test_bytegate.py
@@ -214,6 +214,39 @@ class AliasCollisions(unittest.TestCase):
         self.assertEqual(CDB.alias_collision_addresses(), set())
 
 
+class ZeroSizeAliasPredicate(unittest.TestCase):
+    """is_zero_size_alias, on its own.
+
+    It decides a DENOMINATOR now, not just a numerator, so getting it wrong in the
+    permissive direction hides real unmatched work instead of merely undercounting a
+    match. Both directions are pinned here, close to the one line that decides them."""
+
+    ALIASED = {("itcm", 0x01ff8708)}
+
+    def test_the_zero_size_side_of_a_collision_is_an_alias(self):
+        self.assertTrue(
+            BG.is_zero_size_alias("itcm", 0x01ff8708, 0, self.ALIASED))
+
+    def test_the_sized_side_of_the_same_address_is_not(self):
+        """The bug this guards: the set is keyed by address and both records sit on it,
+        so a caller that dropped the address rather than the zero-size record would
+        delete func_01ff8708's 1,776 bytes from the game."""
+        self.assertFalse(
+            BG.is_zero_size_alias("itcm", 0x01ff8708, 0x6f0, self.ALIASED))
+
+    def test_a_zero_size_symbol_at_an_uncollided_address_is_not(self):
+        """A lone zero-size symbol is real outstanding work and must stay counted.
+        Without this the predicate could quietly swallow anything sized 0."""
+        self.assertFalse(
+            BG.is_zero_size_alias("itcm", 0x01ff9000, 0, self.ALIASED))
+
+    def test_the_same_address_in_another_module_is_not(self):
+        """Overlay addresses overlap; the set is keyed by (module, addr) for that
+        reason and the predicate must respect the module half of the key."""
+        self.assertFalse(
+            BG.is_zero_size_alias("ov065", 0x01ff8708, 0, self.ALIASED))
+
+
 class MatchedConjunct(unittest.TestCase):
     """End to end through chaos_db_ci.main(): a record that fails the byte gate reads
     matched false, and reads true again once it is fixed.
@@ -229,13 +262,18 @@ class MatchedConjunct(unittest.TestCase):
         (self.root / "src").mkdir()
         (self.root / "config").mkdir()
         self.sym = self.root / "config" / "symbols.txt"
+        # `lonely` is the control: a zero-size record at an address NO sized record
+        # shares. It is not an alias, it is a real function the config happens to
+        # declare with no length, and it must survive every rule below. Without it a
+        # predicate that dropped everything sized 0 would pass this whole class.
         self.sym.write_text(
             "good kind:function(arm,size=0x10) addr:0x02000000\n"
             "broken kind:function(arm,size=0x20) addr:0x02000010\n"
             "sized kind:function(arm,size=0x100) addr:0x02000030\n"
-            "alias kind:function(arm,size=0x0) addr:0x02000030\n", encoding="utf-8")
+            "alias kind:function(arm,size=0x0) addr:0x02000030\n"
+            "lonely kind:function(arm,size=0x0) addr:0x02000200\n", encoding="utf-8")
         self.sha = {}
-        for name in ("good", "broken", "sized", "alias"):
+        for name in ("good", "broken", "sized", "alias", "lonely"):
             self.sha[name] = put(self.root / "src" / f"{name}.c", FIXED)
         self.man = self.root / "config" / "bytegate-known-failures.txt"
 
@@ -303,17 +341,38 @@ class MatchedConjunct(unittest.TestCase):
         after_coins = {c["login"]: c["coins"] for c in contrib["contributors"]}
         self.assertEqual(after_coins["matcher"], before_coins["matcher"] + 1)
 
-    def test_the_zero_size_alias_drops_and_its_sized_twin_is_untouched(self):
-        """The address-keying bug: both records sit on 0x02000030 and only the
-        zero-size one may be excluded."""
+    def test_the_zero_size_alias_leaves_the_count_entirely(self):
+        """Numerator AND denominator. The alias is a second name for `sized`, which is
+        already in the list at 0x02000030, so publishing it as an unmatched record put a
+        row in the total that nothing could ever clear -- it has no length to compare.
+
+        The address-keying half still has to hold: both records sit on 0x02000030 and
+        only the zero-size one may go."""
         self.man.write_text("", encoding="utf-8")
         recs, stats, _ = self.generate()
-        self.assertFalse(recs["alias"]["matched"])
-        self.assertEqual(recs["alias"]["byteGate"], "zero-size-alias")
+        self.assertNotIn("alias", recs, "a second name is not a second function")
         self.assertTrue(recs["sized"]["matched"],
                         "the sized primary is the body that SHOULD count")
         self.assertNotIn("byteGate", recs["sized"])
+        # good, broken, sized, lonely -- four records for five symbol lines.
+        self.assertEqual(stats["totalFunctions"], 4)
+        self.assertEqual(len(recs), 4)
         self.assertEqual(stats["matchedBytes"], 0x10 + 0x20 + 0x100)
+        # The alias carried no bytes, so removing it moves no byte total.
+        self.assertEqual(stats["totalBytes"], 0x10 + 0x20 + 0x100)
+
+    def test_a_zero_size_symbol_with_no_sized_twin_is_still_counted(self):
+        """The control. `lonely` is size 0 at an address nothing else claims, so it is
+        outstanding work, not a duplicate name, and it has to stay in both halves of the
+        fraction. A predicate that dropped every zero-size record would hide it, and the
+        published rate would rise on work nobody did."""
+        self.man.write_text("", encoding="utf-8")
+        recs, stats, _ = self.generate()
+        self.assertIn("lonely", recs)
+        self.assertEqual(recs["lonely"]["size"], 0)
+        self.assertTrue(recs["lonely"]["matched"],
+                        "src/lonely.c is a real source and nothing here may refuse it")
+        self.assertNotIn("byteGate", recs["lonely"])
 
     def test_a_lapsed_row_falls_back_to_counting_rather_than_guessing(self):
         """Permissive on staleness, by design: the count returns to the old behaviour

--- a/tools/test_progress.py
+++ b/tools/test_progress.py
@@ -7,6 +7,9 @@ from unittest import mock
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import progress as P  # noqa: E402
+import bytegate as BG  # noqa: E402
+import relocs as RL  # noqa: E402
+import srcpath as SP  # noqa: E402
 
 
 class ProgressPolicy(unittest.TestCase):
@@ -34,6 +37,44 @@ class ProgressPolicy(unittest.TestCase):
         self.assertFalse(self.counted(
             size=0, aliases=frozenset({("arm9", 0x02000000)})))
         self.assertFalse(self.counted(excluded=frozenset({"src/Example.c"})))
+
+    def test_zero_size_alias_is_not_in_the_denominator_either(self):
+        """The published fraction, both halves, over a fake config tree.
+
+        source_counts_as_matched has always refused an aliased zero-size record, but
+        synced_from_src counted it in `n` regardless, so ten symbols sat in the
+        denominator that nothing could ever move into the numerator. `alias` is a second
+        name for `sized` at the same address and must not appear on either side;
+        `lonely` is size 0 at an address nothing shares, which is real outstanding work
+        and must still be counted, or the fix would raise the rate by hiding functions
+        rather than by counting honestly."""
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        repo = pathlib.Path(temp.name)
+        (repo / "src").mkdir()
+        sym = repo / "symbols.txt"
+        sym.write_text(
+            "good kind:function(arm,size=0x10) addr:0x02000000\n"
+            "sized kind:function(arm,size=0x100) addr:0x02000030\n"
+            "alias kind:function(arm,size=0x0) addr:0x02000030\n"
+            "lonely kind:function(arm,size=0x0) addr:0x02000200\n", encoding="utf-8")
+        for name in ("good", "sized", "alias", "lonely"):
+            (repo / "src" / f"{name}.c").write_text(
+                f"int {name}(void) {{ return 0; }}\n", encoding="utf-8")
+
+        with mock.patch.object(P, "REPO", repo), \
+                mock.patch.object(RL, "module_universe", lambda: [(sym, "arm9")]), \
+                mock.patch.object(BG, "excluded_paths", lambda *a, **k: set()), \
+                mock.patch.object(
+                    SP, "path_for",
+                    lambda n: (repo / "src" / f"{n}.c"
+                               if (repo / "src" / f"{n}.c").is_file() else None)):
+            done_n, done_b, n, total_bytes = P.synced_from_src()
+
+        self.assertEqual(n, 3, "four symbol lines, three functions")
+        self.assertEqual(done_n, 3, "and every one of them has a source")
+        self.assertEqual(total_bytes, 0x10 + 0x100)
+        self.assertEqual(done_b, 0x10 + 0x100)
 
     def test_from_src_ignores_an_ambient_database(self):
         temp = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## The defect

Ten symbols in `config/**/symbols.txt` are zero-size aliases. Each one shares its
address with a sized function that is already in the count, so it is a second name for
a body the project is already asked to match, not a second body.

`progress.py` refused them in the numerator (`source_counts_as_matched` returns false
when `size == 0` and the address collides with a sized record) and counted them in the
denominator anyway (`n += 1` ran on every symbol line). `chaos_db_ci.py` did the same
thing, publishing each one as an unmatched record tagged `zero-size-alias`. A
zero-length range cannot be byte-compared against anything, so those ten could never
move into the numerator. They sat in the published total permanently, dragging the rate
down in a way no amount of decompilation could ever clear.

### The ten, and the sized symbol each one shadows

| module | address | alias (size 0) | shadows |
|---|---|---|---|
| itcm | 0x01ff8000 | `_dadd` | `func_01ff8000` (1436 B) |
| itcm | 0x01ff8708 | `_dmul` | `func_01ff8708` (1776 B) |
| itcm | 0x01ff9d40 | `_deq` | `func_01ff9d40` (236 B) |
| itcm | 0x01ffa9dc | `_ll_udiv` | `__aeabi_uldiv` (12 B) |
| itcm | 0x01ffa9e8 | `_ull_mod` | `__aeabi_ulmod` (76 B) |
| itcm | 0x01ffaa34 | `_ll_sdiv` | `func_01ffaa34` (432 B) |
| itcm | 0x01ffabe4 | `_s32_div_f` | `__aeabi_idiv` (524 B) |
| itcm | 0x01ffadf0 | `_u32_div_f` | `__aeabi_uidiv` (484 B) |
| arm9 | 0x0207328c | `__cxa_vec_cleanup` | `__destroy_arr` (92 B) |
| arm9 | 0x020733a8 | `__cxa_vec_ctor` | `func_020733a8` (200 B) |

There are exactly ten zero-size function records in the whole universe and every one of
them collides with a sized record, so nothing else is affected.

## Before and after

Measured at this branch's base (7e6d69461):

```
before   11,304 / 11,402 = 99.140502%   residual 98
after    11,304 / 11,392 = 99.227528%   residual 88
bytes    2,175,376 / 2,238,108 both ways
```

The numerator does not move. All ten records are size 0, so no byte total moves either.
The matched-function count, the byte-verified count, the contributor tally and the coin
weights are identical before and after.

## The fix

The predicate the numerator already used is factored into
`bytegate.is_zero_size_alias(module, addr, size, alias_addrs)` and both halves of the
fraction now call it. No name list and no exclusion file: the set is derived live from
committed config, so repointing an alias at a real size in `symbols.txt` brings the
record straight back into the count with no edit to any tool.

`chaos_db_ci` stops emitting the records at all rather than adjusting the stats block.
That is deliberate. The treemap computes its own header from the length of the
`functions` array, so a stats-only fix would have left it reporting 11,402 while the
README said 11,392. Emitting both records also gave two of them the same `id`
(`itcm:0x01ff8708` was both `_dmul` and `func_01ff8708`), which the drop resolves.

## Surface inventory

Everything that publishes a total, and whether it counted the ten.

| surface | counted them? | after |
|---|---|---|
| `chaos_db_ci.py` record loop, `stats.totalFunctions` | yes (11,402) | fixed at source; the records are never created |
| `progress.py` `synced_from_src()` (ROM-free scan) | yes | fixed |
| `progress.py` `totals()` (plain local report) | yes | fixed; also switched to `relocs.module_universe` so its module label matches the one the alias set is keyed by |
| `progress.py` `from_db()`, the README bar | inherits chaos-db | moves with it |
| `tiers.py` `matched()`, the README MATCHED row | inherits chaos-db | moves with it |
| `treemap.py` (`docs/index.html`, `docs/progress-treemap.svg`) | inherits the chaos-db `functions` array | moves with it |
| `decomp_report.py`, the decomp.dev `report.json` | inherits the chaos-db `functions` array | moves with it |
| `rebuild_ledger.py`, the local `progress/matched.jsonl` | yes, it banked alias rows | fixed, so the plain local report cannot read higher than the README |
| `tiers.py` `converted()` | no. Its denominator is source-owned functions, documented as deliberately different. Four of the ten (`src/_dmul.c`, `src/_ll_sdiv.c`, `src/_s32_div_f.c`, `src/_u32_div_f.c`) are real readable sources filed under the alias name and stay scored | unchanged |
| `tiers.py` `linked()` | no, reads the `config/port_linkage.json` stamp | unchanged |
| `langmode_audit.py` | no, counts mangled C++ symbols and none of the ten is mangled | unchanged |
| `source_coverage.py` | no, sums bytes inside `complete` delinks ranges; the ten are zero bytes and no delinks entry names their sources | unchanged |
| `tiers_ratchet.py`, `check_profile_campaign.py` | no, set membership and registry rows, no total | unchanged |
| workflows | none prints a rate of its own; they invoke the tools above | unchanged |

One surface was already at the new number. `validate_merge.py` `function_snapshot()`
keys its records by module and address, so the two lines at a shared address collide in
the dict and only one survives. Its `totalFunctions` has been 11,392 all along, which
means the PR gate and the README have been quoting different denominators. This change
makes them agree. The gate's "coverage denominator changed" guard cannot fire here:
both sides of that comparison are computed by one code path over committed config
blobs, and this PR touches no config.

Not addressed here, noted for the record: in all ten pairs the sized symbol is written
first and the alias second, so the record `validate_merge` keeps is the alias. That is a
pre-existing wrinkle in the gate's own snapshot rather than a published number, and
changing the merge gate does not belong in a PR that moves the published rate.

## Tests

`tools/test_bytegate.py`

* `ZeroSizeAliasPredicate`, four cases directly on `is_zero_size_alias`: the zero-size
  side of a collision is an alias; the sized side at the same address is not (the set is
  address-keyed, and getting this backwards would delete `func_01ff8708`'s 1,776 bytes
  from the game); a zero-size symbol at an address nothing else claims is not; and the
  same address in a different module is not.
* `test_the_zero_size_alias_leaves_the_count_entirely` runs the real generator over a
  fake repository and asserts the alias is absent from `functions`, that
  `stats.totalFunctions` is 4 for 5 symbol lines, and that its sized twin is untouched
  and still matched.
* `test_a_zero_size_symbol_with_no_sized_twin_is_still_counted` is the control. The
  fixture gains a `lonely` symbol, size 0 at an uncontested address, which has to stay
  in both halves of the fraction. Without it a predicate that dropped every zero-size
  record would pass the whole class while hiding real outstanding work.

`tools/test_progress.py`

* `test_zero_size_alias_is_not_in_the_denominator_either` runs `synced_from_src()` over a
  four-line fake config and pins the totals at 3 functions on each side plus both byte
  totals, so the alias is on neither side and `lonely` is on both.

Both new tests were mutation-checked: neutering `is_zero_size_alias` turns them red.

`tools/test_bytegate` goes from 18 tests to 23 and `tools/test_progress` from 4 to 5.
The count annotations in the `tool-tests.yml` header are updated to match, since that
header says those numbers are what to compare against when the job total moves.

## What this is not

This is a counting correction, not a change to what qualifies as matched. No function's
status changes, no evidence file is added, no exclusion list is introduced, and nothing
is hand-waved onto a list. The rule is derived from committed config and reverses itself
the moment the config stops declaring the same body twice.

## Generated files

`README.md`, `docs/index.html`, `docs/progress-treemap.svg` and `contributions.json` are
regenerated on main by `update-chaos-data.yml` in a `[skip ci]` commit, so they are
deliberately not hand-edited here. The published number moves on that workflow's first
run after this merges.

## Verification run locally

```
python -m unittest (the 31 modules tool-tests.yml names)   567 tests, OK (2 skipped)
python tools/progress.py --bar --from-src                  11,304 / 11,392
python tools/chaos_db_ci.py                                11304/11392 funcs, 10 aliases dropped
python tools/check_duplicate_sources.py                    9476 stems, none doubled
python tools/eligible.py -j 8                              11187 / 11263
python tools/check_references.py                           OK: no new unresolvable references
python tools/check_src_tu.py                               every reference resolves
python tools/langmode_audit.py --check                     langmode ratchet PASS
python tools/prepush_linkcheck.py --range origin/main..HEAD  no matched src/ files, nothing to verify
```
