### PR TITLE
Match the ov007 collision distance test

### DIFF
--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -767,6 +767,10 @@ src/func_ov007_020b9fc0.c:
     complete
     .text start:0x020b9fc0 end:0x020ba05c
 
+src/func_ov007_020ba05c.c:
+    complete
+    .text start:0x020ba05c end:0x020ba2e0
+
 src/func_ov007_020ba2e0.c:
     complete
     .text start:0x020ba2e0 end:0x020ba368

--- a/src/func_ov007_020ba05c.c
+++ b/src/func_ov007_020ba05c.c
@@ -1,19 +1,8 @@
-// NONMATCHING: 9/161 at exact size 0x284. The draft that stood here was 0x22c -- 88 bytes
-// SHORT and semantically wrong (array24/array28 were read off the wrong shadow struct),
-// so it was an incomplete reconstruction rather than a near-miss.
-//
-// 16 -> 9 came from the permuter and the lever is note 6bu #5 seen from the other side:
-// the x half of the reference distance must NOT have a name. Written `int rx = *(s16 *)
-// (r4 + 0x3c); int dd = rx * rx + rz * rz;` the named copy takes r7 away from the node
-// pointer and the whole r7/r8 pair rotates; written as two inline reads of the same
-// halfword it lands on the ROM's registers. `rz` must stay named -- inlining it too costs
-// the same seven words back.
-//
-// Residue is the last nine words: the sb <-> sl pair over the two squared distances
-// (+0x138..+0x15c). MEASURED INERT: all 120 declaration permutations of the block's five
-// outer locals, all 360 initialised-declaration forms (five initialised declarations x the
-// six positions of `r5 = 0`), splitting `dz`/`dx` into a load then an in-place subtract,
-// swapping the dz/dx declaration order, and inlining rz as well.
+/* ov007 manager: proximity/heading gate against the last path node. */
+// @symbol func_ov007_020ba05c
+/* `dz` is loaded and then subtracted in place; that split is what keeps the two
+ * squared distances on the cartridge's sb/sl pair (the whole 9-word residue the
+ * earlier drafts carried). */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -68,11 +57,13 @@ int func_ov007_020ba05c(void)
                 x = *(u16 *)(r4 + 0xa);
                 if (cnt >= 2) {
                     int idx = cnt - 2;
-                    int dz = (((int *)*(char **)(o + 0x28))[idx] >> 12) - x;
+                    int dz = ((int *)*(char **)(o + 0x28))[idx] >> 12;
                     int rz = *(s16 *)(r4 + 0x3e);
                     int dx = (((int *)*(char **)(o + 0x24))[idx] >> 12) - y;
                     int dd = *(s16 *)(r4 + 0x3c) * *(s16 *)(r4 + 0x3c) + rz * rz;
-                    int dd2 = dx * dx + dz * dz;
+                    int dd2;
+                    dz -= x;
+                    dd2 = dx * dx + dz * dz;
                     if (dd >= 0x100 && dd2 <= 4)
                         flag = 1;
                 }


### PR DESCRIPTION
One function, matched byte-for-byte under the pinned compiler, plus its enrollment.

| symbol | module | address | size | file |
| --- | --- | --- | --- | --- |
| `func_ov007_020ba05c` | ov007 | 0x020ba05c | 0x284 (644 bytes) | `src/func_ov007_020ba05c.c` |

The file that stood here carried a `NONMATCHING` banner at 9 divergent words out of 161.
That banner is gone: the function now reproduces exactly.

```
python tools/match.py --c src/func_ov007_020ba05c.c --func func_ov007_020ba05c \
    --addr 0x020ba05c --size 0x284 --module ov007 --strict-relocs --all

MATCHING VERSIONS: 2004/b56
```

2004/b56 is the only build in the sweep that reproduces it, and it is the build the ROM
link uses for this file, so the byte gate and the link agree.

## The lever

The residue was the last nine words, a swap of the `sb`/`sl` pair across the two squared
distances in the proximity test. The note on the old file recorded splitting `dz` into a
load and a separate in-place subtract as measured inert, and that reading was correct as
far as it went: on its own the split changes nothing. What moves the function is doing it
together with demoting the value that consumes it. `dz` is loaded from the node array and
then reduced by `x` in a second statement, and `dd2`, which reads both squared distances,
becomes an uninitialised declaration that is assigned afterwards rather than an
initialised one. Either half alone scores the same nine words. Applied together they put
both squared distances on the registers the cartridge uses, and every word falls into
place. It is worth recording because a lane that measures one half of a two-part lever
will file the half as inert and close the door on the pair.

## Gates

```
build_pin.verify(...)                                  -> (True, '2004/b56')
prepush_linkcheck.py --range origin/main..HEAD         -> 1 checked, 1 verified, 0 warning, 0 blocking
langmode_audit.py --check langmode-baseline.json       -> langmode ratchet PASS
check_duplicate_sources.py                             -> 9450 stems, none doubled
eligible.py -j 8                                       -> 11192 / 11268
check_references.py                                    -> no new unresolvable references (42 unresolved, baseline 45)
check_src_tu.py                                        -> 30 TUs, 783 mangled references, every reference resolves
python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll -> Ran 80 tests, OK
```

## Enrollment

```
src/func_ov007_020ba05c.c:
    complete
    .text start:0x020ba05c end:0x020ba2e0
```

Hand-inserted into `config/arm9/overlays/ov007/delinks.txt` in address order, between the
`0x020b9fc0` and `0x020ba2e0` entries, with the file's CRLF line endings. It is
byte-identical to what `tools/enroll.py --complete-list` writes for this symbol; that was
checked by running the tool for real and comparing, then reverting the unrelated ov006 and
ov070 edits it also makes. The symbol name at that address on `main` is unchanged.
