### PR TITLE
Strengthen ROM build coverage and data ratchets

### DIFF
--- a/config/source-coverage-exceptions.jsonl
+++ b/config/source-coverage-exceptions.jsonl
@@ -21,4 +21,4 @@
 # Waivers are consumed ONCE. After the decrease lands, main's own total is the new floor
 # and the row does nothing; stale rows are harmless and can be pruned in a later sweep.
 #
-# Empty on purpose: the tree currently hands back zero bytes.
+# Empty on purpose: no source-coverage regression has been waived.

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -1177,7 +1177,7 @@ def main():
 
         # Gap objects first: delinks.txt drives which ranges dsd carves out for us.
         print(f"profile: {args.profile} ({len(profile['modReplacements'])} mod source replacement(s), "
-              f"{len(profile['modGapFallbacks'])} ROM-gap fallback(s))")
+              f"{len(profile['modGapFallbacks'])} mod-entry gap fallback(s))")
         print("[1/6] dsd delink")
         run([str(DSD), "delink", "-c", str(config_yaml)], "dsd delink",
             quiet_patterns=("No module for relocation",))

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -144,14 +144,14 @@ def _covered_bytes(ranges, base, size):
 
 
 def _code_totals(config_root):
+    """Return the function/byte universe for every module this build analyzes.
+
+    The numerator in :func:`analyze` includes source contributions from ARM9,
+    overlays, ITCM and DTCM.  The denominator must cover that same set; excluding
+    the autoloads makes the reported percentage compare unlike universes.
+    """
     funcs = size = 0
     for sym in sorted(config_root.rglob("symbols.txt")):
-        # Match the project's progress/Chaos Viewer universe: main + overlays.
-        # itcm/dtcm are still byte-checked as modules, but are not part of the
-        # published decompilation coverage denominator.
-        rel = _arm9_relative(sym.parent, config_root)
-        if rel != "." and not re.fullmatch(r"overlays/ov\d+", rel):
-            continue
         for line in sym.read_text(encoding="utf-8", errors="ignore").splitlines():
             m = FUNC_RE.match(line)
             if m:
@@ -171,9 +171,8 @@ def _module_code_bytes(sym_path):
 
     Subtracting this from the module image size is what makes that boundary a number
     instead of an unstated assumption. Computed per module rather than from
-    `_code_totals`, which excludes itcm/dtcm from the published denominator while
-    `moduleFidelity` still compares them -- mixing the two would misattribute their
-    whole size to data.
+    `_code_totals`; this per-module calculation also keeps the composition split
+    explicit and avoids misattributing any module's non-function bytes to another.
     """
     total = 0
     for line in sym_path.read_text(encoding="utf-8", errors="ignore").splitlines():
@@ -362,6 +361,9 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
     unexpected_module_bytes = sum(m["unexpectedDifferingBytes"] for m in module_results)
     compiled_functions = source_functions + mod_functions
     compiled_bytes = source_bytes + mod_bytes
+    retail_gap_code_bytes = max(0, module_code_bytes - source_bytes - mod_bytes)
+    retail_gap_bytes = max(0, compared_module_bytes - source_bytes
+                           - source_data_bytes - mod_bytes)
     mods_applied = all(m["differingBytes"] > 0 for m in intentional) if intentional else True
     passed = bool(module_results) and not bad and not bad_data_claims \
         and not missing_bins and not unexpected_module_bytes \
@@ -396,6 +398,11 @@ def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock", build_root=None):
             "sourceDataBytes": source_data_bytes,
             "unownedDataBytes": max(0, compared_module_bytes - module_code_bytes
                                       - source_data_bytes),
+            "retailGapCodeBytes": retail_gap_code_bytes,
+            "retailGapBytes": retail_gap_bytes,
+            "retailGapBytesOfModulePercent": (
+                100.0 * retail_gap_bytes / compared_module_bytes
+                if compared_module_bytes else 0.0),
             "sourceBytes": source_bytes,
             "sourceBytesOfModulePercent": (100.0 * source_bytes / compared_module_bytes
                                            if compared_module_bytes else 0.0),
@@ -477,7 +484,11 @@ def print_report(report, show=12):
               f"({mc['sourceBytesOfModulePercent']:.1f}%) source-built code, "
               f"{mc.get('sourceDataBytes', 0):,} source-owned data, "
               f"{mc.get('unownedDataBytes', mc['dataBytes']):,} data bytes no complete "
-              f"source entry reaches ({mc['dataBytesVerified']:,} verified)")
+              f"source entry reaches; {mc['dataBytesVerified']:,} compiler-emitted "
+              "data bytes verified overall")
+        print(f"  retail-gap contribution: {mc.get('retailGapBytes', 0):,} module "
+              f"bytes ({mc.get('retailGapCodeBytes', 0):,} function-code, "
+              f"{mc.get('unownedDataBytes', mc['dataBytes']):,} data/non-function)")
     if report["missingModuleBinaries"]:
         print(f"missing module binaries: {report['missingModuleBinaries'][:8]}")
     for f in report["failures"][:show]:

--- a/tools/romdata_check.py
+++ b/tools/romdata_check.py
@@ -32,10 +32,10 @@ generated header declares zero virtuals, so mwcc emits a 2-slot vtable stub wher
 ROM has 31 slots; the emitted prefix is not even the same slots. Failing a merge on
 that would fail nearly every C++ file in the tree for pre-existing modelling debt.
 
-So the verdicts are counted, the count is reported, and `validate_merge` ratchets it:
-the number of verified data symbols may rise freely and may not fall. That is the same
-shape as langmode-ratchet and converted-ratchet, and it is the only shape that can
-land green.
+So the verdicts are reported, and `validate_merge` ratchets the exact verified-symbol
+identities and byte count while refusing newly differing symbols. Pre-existing model
+debt can remain, but an unrelated gain cannot conceal losing a known-good vtable or
+typeinfo record.
 
 THE VTABLE PREAMBLE, AND WHY THE COMPARE IS OFFSET
 --------------------------------------------------
@@ -358,6 +358,14 @@ def summarize(records):
                          if r["verdict"] == VERIFIED)
     partial_bytes = sum(r.get("bytes", 0) for r in best.values()
                         if r["verdict"] == PARTIAL)
+    verified_symbols = sorted(
+        ({"module": r.get("module"), "symbol": r["symbol"]}
+         for r in best.values() if r["verdict"] == VERIFIED),
+        key=lambda r: (r["module"] or "", r["symbol"]))
+    differing_symbols = sorted(
+        ({"module": r.get("module"), "symbol": r["symbol"]}
+         for r in best.values() if r["verdict"] == DIFFERS),
+        key=lambda r: (r["module"] or "", r["symbol"]))
     return {
         "symbols": len(best),
         "verified": symbol_counts[VERIFIED],
@@ -366,6 +374,10 @@ def summarize(records):
         "unnamed": symbol_counts[UNNAMED],
         "verifiedBytes": verified_bytes,
         "partialBytes": partial_bytes,
+        # Identities, not only a count. A count-only ratchet can lose one known-good
+        # vtable while gaining an unrelated one and report no regression at all.
+        "verifiedSymbols": verified_symbols,
+        "differingSymbols": differing_symbols,
         # Per-object-record totals, kept for visibility -- these move with file topology
         # (a TU merge or a duplicate-file cleanup changes them without a symbol's verdict
         # changing) and are not what validate_merge ratchets.

--- a/tools/source_coverage.py
+++ b/tools/source_coverage.py
@@ -74,22 +74,20 @@ main on merge; that exact failure happened to the converted ratchet on 2026-08-3
 
 SECTIONS, AND THE HONEST STORY ABOUT ROM DATA
 ----------------------------------------------
-This counts EVERY section a `complete` entry names, not just `.text`. Today that is
-`.text` (10,893 entries) and `.init` (305) -- `.init` is `kind:code`, is compiled from
-`src/` exactly like `.text`, and a `.text`-only tool would let 305 entries' worth of
-ARM9 init code be handed back in silence. Sections are counted and reported separately
-so a future data delink is picked up with no change here.
+This counts EVERY section a `complete` entry names, not just `.text`. That includes
+`.init`, and now also the `.data`, `.ctor` and `.bss` ranges owned by promoted intact
+translation units. Sections are counted and reported separately, so a non-text claim
+cannot disappear behind growth in code coverage.
 
-ROM DATA IS NOT COVERED, AND CANNOT BE COVERED HERE. As of this writing NO delinks entry
-in this tree names a `.rodata`, `.data` or `.bss` range -- the census above is the whole
-of it. Vtables, typeinfo and every other data symbol reach the ROM through `dsd`'s gap
-objects, i.e. from the cartridge, and `tools/objisolate.py` zeroes them out of the
-compiled object on purpose. So there is no "source-built data byte" for this tool to
-count, and a reader must not read a green result here as data coverage. Data
-verification is a genuinely different measurement with a genuinely different tool:
-`tools/romdata_check.py` compares emitted data symbols against the cartridge, and
-`validate_merge` ratchets its verified-symbol count. Nothing in this file substitutes
-for that, and nothing in that file substitutes for this.
+MOST ROM DATA IS STILL NOT SOURCE-BUILT. Ordinary per-function objects have their
+compiler-emitted vtables, typeinfo and other content measured and then isolated away;
+DSD gap objects supply those addresses from the cartridge. Promoted intact TUs are the
+exception: their explicitly licensed non-text ranges carry `complete` and therefore do
+count here. `tools/romdata_check.py` separately compares compiler-emitted data symbols
+even when they are not linked from source. A green result here means no previously
+source-owned range was handed back; it does not mean the build contains no retail-gap
+bytes. Nothing in this file substitutes for emitted-data verification, and nothing in
+that measurement substitutes for source ownership.
 
 HOW TO OVERRIDE WHEN A DECREASE IS LEGITIMATE
 ----------------------------------------------

--- a/tools/test_rombuild_check.py
+++ b/tools/test_rombuild_check.py
@@ -49,9 +49,35 @@ class RomBuildCheck(unittest.TestCase):
         self.assertEqual(report["sourceBuild"]["sourceFunctions"], 1)
         self.assertEqual(report["sourceBuild"]["sourceBytes"], 4)
         self.assertEqual(report["sourceBuild"]["sourceBytesPercent"], 50.0)
+        self.assertEqual(report["moduleComposition"]["retailGapCodeBytes"], 4)
+        self.assertEqual(report["moduleComposition"]["retailGapBytes"], 4)
         self.write_delinks("src/actors/Pair.cpp", end=0x00001008)
         consolidated = RBC.analyze(self.config, "stock")
         self.assertEqual(consolidated["moduleFidelity"]["moduleSetSha256"], digest)
+
+    def test_source_percentage_uses_the_same_module_universe_on_both_sides(self):
+        """ITCM/DTCM source bytes must not enter a main+overlay-only fraction."""
+        itcm = self.config / "itcm"
+        itcm.mkdir()
+        (itcm / "symbols.txt").write_text(
+            "Itcm kind:function(arm,size=0x4) addr:0x00002000\n",
+            encoding="utf-8")
+        (itcm / "delinks.txt").write_text(
+            "    .text start:0x00002000 end:0x00002004 kind:code\n\n"
+            "src/Itcm.c:\n"
+            "    complete\n"
+            "    .text start:0x00002000 end:0x00002004\n",
+            encoding="utf-8")
+        (self.retail / "arm9" / "itcm.bin").write_bytes(b"ITCM")
+        (self.built / "itcm.bin").write_bytes(b"ITCM")
+
+        report = RBC.analyze(self.config, "stock")
+        source = report["sourceBuild"]
+        self.assertEqual(source["sourceFunctions"], 2)
+        self.assertEqual(source["totalCodeFunctions"], 3)
+        self.assertEqual(source["sourceBytes"], 8)
+        self.assertEqual(source["totalCodeBytes"], 12)
+        self.assertAlmostEqual(source["sourceBytesPercent"], 100.0 * 8 / 12)
 
     def test_shared_source_counts_every_owned_function(self):
         self.write_delinks("src/actors/Pair.cpp", end=0x00001008)
@@ -88,6 +114,7 @@ class RomBuildCheck(unittest.TestCase):
         self.assertEqual(report["sourceBuild"]["sourceBytes"], 8)
         self.assertEqual(report["moduleComposition"]["sourceDataBytes"], 4)
         self.assertEqual(report["moduleComposition"]["unownedDataBytes"], 0)
+        self.assertEqual(report["moduleComposition"]["retailGapBytes"], 0)
 
     def test_intact_bss_is_nobits_not_an_out_of_range_data_failure(self):
         (self.config / "delinks.txt").write_text(

--- a/tools/test_romdata_check.py
+++ b/tools/test_romdata_check.py
@@ -27,6 +27,8 @@ class SummarizeCountsSymbols(unittest.TestCase):
         self.assertEqual(s["verifiedBytes"], 4)
         self.assertEqual(s["totalRecords"], 3)
         self.assertEqual(s["verifiedRecords"], 3)
+        self.assertEqual(s["verifiedSymbols"], [
+            {"module": None, "symbol": "_ZTI7fBase_c"}])
 
     def test_consolidating_sources_does_not_move_the_ratchet(self):
         """The measured shape of the first TU promotion, in miniature."""
@@ -46,6 +48,8 @@ class SummarizeCountsSymbols(unittest.TestCase):
         self.assertEqual(s["differs"], 1)
         self.assertEqual(s["verified"], 0)
         self.assertEqual(len(s["differing"]), 1)
+        self.assertEqual(s["differingSymbols"], [
+            {"module": None, "symbol": "_ZTV4Foo"}])
 
     def test_distinct_symbols_still_add_up(self):
         s = RDC.summarize([rec("_ZTI4Foo", RDC.VERIFIED), rec("_ZTS4Foo", RDC.PARTIAL),
@@ -58,6 +62,8 @@ class SummarizeCountsSymbols(unittest.TestCase):
         s = RDC.summarize([dict(rec("_ZTV4Foo", RDC.VERIFIED), module="ov006"),
                            dict(rec("_ZTV4Foo", RDC.DIFFERS), module="ov084")])
         self.assertEqual((s["symbols"], s["verified"], s["differs"]), (2, 1, 1))
+        self.assertEqual(s["verifiedSymbols"], [
+            {"module": "ov006", "symbol": "_ZTV4Foo"}])
 
     def test_unparsable_objects_never_dedupe_against_each_other(self):
         """check_object's `?` catch-all carries no symbol identity, only a source."""

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -71,6 +71,23 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(report["attribution"]["lost"], [])
         self.assertEqual(report["attribution"]["head"]["alice"]["functions"], 1)
 
+    def test_every_function_in_a_complete_tu_range_is_byte_verified(self):
+        functions = {"matched": {
+            "ov006:0x02000000": {
+                "module": "ov006", "addr": 0x02000000, "size": 4},
+            "ov006:0x02000004": {
+                "module": "ov006", "addr": 0x02000004, "size": 8},
+        }}
+        enrollment = {"source": {"ov006:0x02000000-0x0200000c": {
+            "module": "ov006", "addr": 0x02000000, "end": 0x0200000c,
+        }}}
+
+        split = VM.verification_split(functions, enrollment)
+        self.assertEqual(split["stats"]["verifiedFunctions"], 2)
+        self.assertEqual(split["stats"]["verifiedBytes"], 12)
+        self.assertEqual(split["stats"]["claimedFunctions"], 0)
+        self.assertEqual(split["claimed"], {})
+
     def test_nonmatching_is_read_from_requested_revision(self):
         (self.repo / "src" / "Example.c").write_text(
             "// NONMATCHING\nint Example(void) { return 0; }\n")
@@ -424,6 +441,48 @@ class ValidateMerge(unittest.TestCase):
         }])
         self.assertEqual(state["tally"], {"RAW-ASM": 1})
         self.assertEqual(len(state["blocking"]), 1)
+
+
+class RomDataRatchet(unittest.TestCase):
+    def data(self, verified=(), differing=(), verified_bytes=None):
+        body = {
+            "verified": len(verified),
+            "differs": len(differing),
+            "verifiedSymbols": [
+                {"module": module, "symbol": symbol}
+                for module, symbol in verified],
+            "differingSymbols": [
+                {"module": module, "symbol": symbol}
+                for module, symbol in differing],
+        }
+        body["verifiedBytes"] = (4 * len(verified)
+                                  if verified_bytes is None else verified_bytes)
+        return body
+
+    def test_equal_count_cannot_hide_a_lost_exact_symbol(self):
+        base = self.data(verified=(("ov006", "_ZTV3Old"),))
+        head = self.data(verified=(("ov006", "_ZTV3New"),))
+        out = VM.rom_data_regressions(base, head)
+        self.assertTrue(any("lost 1 exact symbol" in reason for reason in out))
+        self.assertIn("ov006:_ZTV3Old", "; ".join(out))
+
+    def test_equal_count_cannot_hide_a_new_differing_symbol(self):
+        base = self.data(differing=(("ov006", "_ZTV3Old"),))
+        head = self.data(differing=(("ov006", "_ZTV3New"),))
+        out = VM.rom_data_regressions(base, head)
+        self.assertTrue(any("gained 1 differing symbol" in reason for reason in out))
+        self.assertIn("ov006:_ZTV3New", "; ".join(out))
+
+    def test_verified_byte_loss_is_not_hidden(self):
+        base = self.data(verified=(("arm9", "Data"),), verified_bytes=16)
+        head = self.data(verified=(("arm9", "Data"),), verified_bytes=12)
+        self.assertTrue(any("verified bytes fell" in reason
+                            for reason in VM.rom_data_regressions(base, head)))
+
+    def test_omitting_the_head_measurement_is_a_regression(self):
+        base = self.data(verified=(("arm9", "Data"),))
+        self.assertEqual(VM.rom_data_regressions(base, {}),
+                         ["head full-ROM report omitted the ROM-data measurement"])
 
 
 class ModuleFidelityDetail(unittest.TestCase):

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -268,9 +268,23 @@ def verification_split(functions, enrollment):
     leads.  ``matched`` itself is deliberately left alone: ``attribution_snapshot`` keys
     contributor credit off it, so redefining it here would move credit for everyone.
     """
-    enrolled = {key.split("-", 1)[0] for key in enrollment["source"]}
-    verified = {k: r for k, r in functions["matched"].items() if k in enrolled}
-    claimed = {k: r for k, r in functions["matched"].items() if k not in enrolled}
+    # A complete delinks entry is an object contribution, not necessarily one
+    # function.  A promoted TU can cover dozens of consecutive function records;
+    # comparing only the entry's start address misclassifies every member after the
+    # first as "claimed, not byte-verified" even though rombuild compiles and checks
+    # the entire range.  Classify against the full enrolled interval, just as
+    # enrollment_snapshot's sourceFunctions counter does.
+    enrolled = collections.defaultdict(list)
+    for entry in enrollment["source"].values():
+        enrolled[entry["module"]].append((entry["addr"], entry["end"]))
+
+    def is_verified(record):
+        end = record["addr"] + record["size"]
+        return any(start <= record["addr"] and end <= stop
+                   for start, stop in enrolled[record["module"]])
+
+    verified = {k: r for k, r in functions["matched"].items() if is_verified(r)}
+    claimed = {k: r for k, r in functions["matched"].items() if not is_verified(r)}
     return {
         "verified": verified,
         "claimed": claimed,
@@ -384,6 +398,70 @@ def _rom_state(report):
             # nothing to compare against is not a regression.
             "romData": report.get("romData"),
             "failure": failure}
+
+
+def _data_symbol_set(data, field):
+    """Return stable ``(module, symbol)`` identities, or None for an old report."""
+    rows = data.get(field)
+    if not isinstance(rows, list):
+        return None
+    out = set()
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("symbol"), str):
+            return None
+        out.add((row.get("module"), row["symbol"]))
+    return out
+
+
+def _data_name(identity):
+    module, symbol = identity
+    return f"{module or '?'}:{symbol}"
+
+
+def rom_data_regressions(base_data, head_data):
+    """Name data-verification losses that a count-only ratchet can hide."""
+    if base_data.get("verified") is None:
+        return []
+    if head_data.get("verified") is None:
+        return ["head full-ROM report omitted the ROM-data measurement"]
+
+    out = []
+    base_verified = _data_symbol_set(base_data, "verifiedSymbols")
+    head_verified = _data_symbol_set(head_data, "verifiedSymbols")
+    if base_verified is not None and head_verified is not None:
+        lost = sorted(base_verified - head_verified, key=lambda x: (x[0] or "", x[1]))
+        if lost:
+            names = ", ".join(_data_name(x) for x in lost[:3])
+            more = f", +{len(lost) - 3} more" if len(lost) > 3 else ""
+            out.append(f"ROM data verification lost {len(lost)} exact symbol(s): "
+                       f"{names}{more}")
+    elif head_data["verified"] < base_data["verified"]:
+        out.append(
+            f"ROM data verified from source fell from {base_data['verified']} to "
+            f"{head_data['verified']} symbol(s)")
+
+    if (base_data.get("verifiedBytes") is not None
+            and head_data.get("verifiedBytes") is not None
+            and head_data["verifiedBytes"] < base_data["verifiedBytes"]):
+        out.append(
+            f"ROM data verified bytes fell from {base_data['verifiedBytes']} to "
+            f"{head_data['verifiedBytes']}")
+
+    base_differing = _data_symbol_set(base_data, "differingSymbols")
+    head_differing = _data_symbol_set(head_data, "differingSymbols")
+    if base_differing is not None and head_differing is not None:
+        new = sorted(head_differing - base_differing, key=lambda x: (x[0] or "", x[1]))
+        if new:
+            names = ", ".join(_data_name(x) for x in new[:3])
+            more = f", +{len(new) - 3} more" if len(new) > 3 else ""
+            out.append(f"ROM data gained {len(new)} differing symbol(s): {names}{more}")
+    elif (base_data.get("differs") is not None
+          and head_data.get("differs") is not None
+          and head_data["differs"] > base_data["differs"]):
+        out.append(
+            f"ROM data differing symbols rose from {base_data['differs']} to "
+            f"{head_data['differs']}")
+    return out
 
 
 def _link_state(rows):
@@ -626,17 +704,13 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     # A RATCHET, not a gate. The emitted vtable and RTTI that `objisolate` discards are
     # compared against the cartridge, and most of the tree fails that today for a
     # understood reason -- a generated flat header declares no virtuals, so mwcc emits a
-    # two-slot stub where the ROM has thirty-one. Failing a merge on it would fail nearly
-    # every C++ file for pre-existing modelling debt. So the count may rise freely and
-    # may not fall: this is the only check in the report that watches ROM DATA at all.
+    # two-slot stub where the ROM has thirty-one. Failing a merge on all existing debt
+    # would fail nearly every C++ file. Instead, known-good symbol identities and bytes
+    # may not be lost, new differing symbols are refused, and a missing head measurement
+    # is not allowed to disable the ratchet.
     base_data = base_rom_state.get("romData") or {}
     head_data = head_rom_state.get("romData") or {}
-    data_ratchet = (base_data.get("verified") is not None
-                    and head_data.get("verified") is not None)
-    if data_ratchet and head_data["verified"] < base_data["verified"]:
-        reasons.append(
-            f"ROM data verified from source fell from {base_data['verified']} to "
-            f"{head_data['verified']} symbol(s)")
+    reasons.extend(rom_data_regressions(base_data, head_data))
     if rom_regression:
         reasons.append("full-ROM result regressed from the base commit")
     if head_rom_state.get("available") and not head_rom_state.get("passed") \
@@ -838,11 +912,20 @@ def render_markdown(r):
         # source is one dsd handed back from the cartridge and compared against itself.
         mc = head_rom["analysis"].get("moduleComposition")
         if mc:
+            unowned_data = mc.get("unownedDataBytes", mc["dataBytes"])
+            unowned_percent = (100.0 * unowned_data / mc["moduleBytes"]
+                               if mc["moduleBytes"] else 0.0)
             lines.append(
                 f"| Module bytes from source | {mc['sourceBytes']:,} / "
                 f"{mc['moduleBytes']:,} ({mc['sourceBytesOfModulePercent']:.1f}%); "
-                f"{mc['dataBytes']:,} ({mc['dataBytesOfModulePercent']:.1f}%) are data "
+                f"{unowned_data:,} ({unowned_percent:.1f}%) are data "
                 f"no delink entry reaches |")
+            if mc.get("retailGapBytes") is not None:
+                lines.append(
+                    f"| Retail-gap contribution | {mc['retailGapBytes']:,} module "
+                    f"bytes ({mc.get('retailGapCodeBytes', 0):,} function-code; "
+                    f"{mc.get('unownedDataBytes', mc['dataBytes']):,} "
+                    "data/non-function) |")
     rom_data = head_rom.get("romData")
     if rom_data:
         lines.append(f"| ROM data reproduced from source | {rom_data['verified']:,} "


### PR DESCRIPTION
## Summary

- use the same ARM9, overlay, ITCM, and DTCM universe for source coverage numerator and denominator
- report the exact retail-gap contribution instead of calling zero mod demotions zero ROM fallbacks
- count every function inside a complete promoted-TU range as byte-verified
- ratchet exact compiler-emitted data symbol identities and verified bytes, reject newly differing symbols, and fail closed when the head measurement is missing
- update source-coverage documentation for source-owned data, ctor, and BSS ranges

## Current measured result

The full stock build compiles 11,186 reproducing functions and 2,132,192 of 2,238,108 code bytes from source (95.27%). All 106 executable modules are exact. Twenty initialized-data claims reproduce, three BSS claims pass their object/symbol gates, and the remaining retail-gap contribution is reported explicitly as 913,612 module bytes.

This PR deliberately does not claim that the packaged NDS is a retail-SHA oracle. Filesystem packaging validation and ordinary promoted-TU externalized-data corpus checking remain separate follow-ups.

## Verification

- python tools/rombuild.py -j 16 --report-json build/pipeline-pr-report.json --data-json build/pipeline-pr-data.json
- 106/106 modules exact; zero source-function or data-claim mismatches
- 139 focused rombuild, romdata, source-coverage, profile, and merge-validator tests
- source_coverage.py --check --base origin/main: zero bytes handed back
- tiers_ratchet.py --check: PASS
- cpp_tu_compat.py --require-ready: READY
- check_src_tu_compiles.py --quiet: 150/150
- port_refcheck.py: 402/402
- layout_check.py and check_duplicate_sources.py: clean