### PR TITLE
Match the star select render and the enemy Yoshi-eat update

### DIFF
--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -24,6 +24,10 @@ src/_ZN12dEnemyBase_c27SpawnParticlesIfHitOtherObjER5dCc_c.cpp:
     complete
     .text start:0x020addc0 end:0x020ade78
 
+src/_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr.cpp:
+    complete
+    .text start:0x020ade78 end:0x020ae244
+
 src/_ZN12dEnemyBase_c24AngleAwayFromWallOrCliffER10dBgCh_ActrRs.cpp:
     complete
     .text start:0x020ae244 end:0x020ae2b8

--- a/config/arm9/overlays/ov003/delinks.txt
+++ b/config/arm9/overlays/ov003/delinks.txt
@@ -83,6 +83,10 @@ src/_ZN12dScStarSel_c16OnPendingDestroyEv.cpp:
     complete
     .text start:0x020ae6f0 end:0x020ae6f4
 
+src/_ZN12dScStarSel_c6RenderEv.cpp:
+    complete
+    .text start:0x020ae6f4 end:0x020af038
+
 src/_ZN12dScStarSel_c16CleanupResourcesEv.cpp:
     complete
     .text start:0x020af86c end:0x020af8a0

--- a/include/dEnemyBase_c.h
+++ b/include/dEnemyBase_c.h
@@ -105,6 +105,7 @@ struct dEnemyBase_c : dActor_c {
     /* --- non-virtual --- */
     int AngleAwayFromWallOrCliff(dBgCh_Actr & clsn_, short & outAngle_);
     int UpdateDeath(dBgCh_Actr & clsn_);
+    int UpdateYoshiEat(dBgCh_Actr & clsn_);
     void UpdateWMClsn(dBgCh_Actr & clsn_, unsigned int sel);
     /* Already a real method -- its own file builds _ZN12dEnemyBase_c9SpawnCoinEv from a
        local `struct dEnemyBase_c : dActor_c` shadow. Declared here so callers need not

--- a/src/_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr.cpp
+++ b/src/_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr.cpp
@@ -26,8 +26,8 @@ extern "C" {
 extern int _ZNK10dBgCh_Actr13GetLimMovFlagEv(char *c);
 extern void _ZN10dBgCh_Actr13SetLimMovFlagEv(char *c);
 extern void _ZN10dBgCh_Actr15ClearLimMovFlagEv(char *c);
-extern void _ZN5Actor9UpdatePosEP5dCc_c(char *self, int p);
-extern void func_020383fc(char *c);
+extern void _ZN8dActor_c9UpdatePosEP5dCc_c(char *self, int p);
+extern void dBgCh_Actr_UpdateContinuous_Veneer(char *c);
 extern int _ZNK10dBgCh_Actr10IsOnGroundEv(char *c);
 extern char *_ZNK10dBgCh_Actr14GetFloorResultEv(char *c);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(char *p, char *v);
@@ -116,8 +116,8 @@ int dEnemyBase_c::UpdateYoshiEat(dBgCh_Actr & clsn_)
         }
         lim = _ZNK10dBgCh_Actr13GetLimMovFlagEv(clsn);
         _ZN10dBgCh_Actr13SetLimMovFlagEv(clsn);
-        _ZN5Actor9UpdatePosEP5dCc_c(self, 0);
-        func_020383fc(clsn);
+        _ZN8dActor_c9UpdatePosEP5dCc_c(self, 0);
+        dBgCh_Actr_UpdateContinuous_Veneer(clsn);
         if (_ZNK10dBgCh_Actr10IsOnGroundEv(clsn) != 0) {
             char *fr = _ZNK10dBgCh_Actr14GetFloorResultEv(clsn);
             _ZNK11SurfaceInfo12CopyNormalToER7Vector3(fr + 4, self + 0xd4);

--- a/src/_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr.cpp
+++ b/src/_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr.cpp
@@ -1,0 +1,148 @@
+//cpp
+// @symbol _ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr
+/* recovered: real C++ method on include/dEnemyBase_c.h.
+ *
+ * One frame of "this enemy is in Yoshi's mouth / has just been spat out". The three
+ * flag bits at 0x0b0 pick the phase: 0x40000 = held in the mouth (track the eater's
+ * position and return 2), 0x20000 = swallowed (return 1), 0x80000 = just spat out, in
+ * which case the launch velocity is built from the eater's facing angle and then the
+ * body flies under mesh collision until it lands.
+ *
+ * The launch block was the last residue: the cartridge fills the load-use slot after
+ * `ldr r0,[r6,#0xd0]` with the rounding constant (mov r3,#0x800) while every spelling
+ * tried here filled it with the position base (add r1,r6,#0x5c). Writing the eater
+ * test in its POSITIVE sense -- `if (eater != 0) { launch } else v = 0x14000;` rather
+ * than `if (eater == 0) v = 0x14000; else { launch }` -- puts the launch block first in
+ * the linearisation and the slot falls the cartridge's way. Same branch, same
+ * semantics; only the order the two arms are visited in.
+ *
+ * The raw `self + offset` spellings are kept because dEnemyBase_c's header does not
+ * name every field this function touches; `this` and the reference argument arrive in
+ * r0/r1 exactly as the free-function form did, so the body is unchanged.
+ */
+#include "dEnemyBase_c.h"
+
+extern "C" {
+extern int _ZNK10dBgCh_Actr13GetLimMovFlagEv(char *c);
+extern void _ZN10dBgCh_Actr13SetLimMovFlagEv(char *c);
+extern void _ZN10dBgCh_Actr15ClearLimMovFlagEv(char *c);
+extern void _ZN5Actor9UpdatePosEP5dCc_c(char *self, int p);
+extern void func_020383fc(char *c);
+extern int _ZNK10dBgCh_Actr10IsOnGroundEv(char *c);
+extern char *_ZNK10dBgCh_Actr14GetFloorResultEv(char *c);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(char *p, char *v);
+extern int _ZNK10dBgCh_Actr13JustHitGroundEv(char *c);
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern int Vec3_HorzLen(int *v);
+extern short data_02082214[];
+}
+
+int dEnemyBase_c::UpdateYoshiEat(dBgCh_Actr & clsn_)
+{
+    char *self = (char *)this;
+    char *clsn = (char *)&clsn_;
+    int flags;
+    int t;
+    int v;
+    int lim;
+
+    flags = *(int *)(self + 0xb0);
+    t = flags & 0x40000;
+    t = t != 0;
+    if (t != 0) {
+        if (*(char **)(self + 0xd0) == 0) {
+            *(int *)(self + 0xb0) &= ~0x40000;
+        } else {
+            char *o = *(char **)(self + 0xd0) + 0x5c;
+            *(int *)(self + 0x5c) = *(int *)o;
+            *(int *)(self + 0x60) = *(int *)(o + 4);
+            *(int *)(self + 0x64) = *(int *)(o + 8);
+            *(int *)(self + 0x60) += 0x30000;
+        }
+        *(unsigned char *)(self + 0x107) = 0;
+        return 2;
+    }
+    t = flags & 0x20000;
+    t = t != 0;
+    if (t != 0) {
+        *(unsigned char *)(self + 0x107) = 0;
+        return 1;
+    }
+    t = flags & 0x80000;
+    t = t != 0;
+    if (t != 0 || *(unsigned char *)(self + 0x107) != 0) {
+        if (*(u16 *)(self + 0x104) != 0)
+            *(u16 *)(self + 0x104) -= 1;
+        t = *(int *)(self + 0xb0) & 0x80000;
+        t = t != 0;
+        if (t != 0) {
+            *(unsigned char *)(self + 0x107) = 1;
+            *(u16 *)(self + 0x104) = 5;
+            *(int *)(self + 0xb0) &= ~0x80000;
+            if (*(char **)(self + 0xd0) != 0) {
+                char *o2 = *(char **)(self + 0xd0) + 0x5c;
+                *(int *)(self + 0x5c) = *(int *)o2;
+                *(int *)(self + 0x60) = *(int *)(o2 + 4);
+                *(int *)(self + 0x64) = *(int *)(o2 + 8);
+                *(int *)(self + 0x60) += 0x32000;
+                {
+                    long long rnd = 0x800;
+                    char *o3 = *(char **)(self + 0xd0);
+                    u16 ang = *(u16 *)(o3 + 0x8e);
+                    int idx = (ang >> 4) << 1;
+                    *(int *)(self + 0x5c) =
+                        (int)(((long long)data_02082214[idx] * 0x32000 + rnd) >> 12) +
+                        *(int *)(self + 0x5c);
+                    *(int *)(self + 0x64) +=
+                        (int)(((long long)data_02082214[idx + 1] * 0x32000 + rnd) >> 12);
+                }
+                {
+                    s16 *p = (s16 *)(*(char **)(self + 0xd0) + 0x8c);
+                    *(s16 *)(self + 0x92) = *p;
+                    *(s16 *)(self + 0x94) = p[1];
+                    *(s16 *)(self + 0x96) = p[2];
+                }
+                v = *(int *)(*(char **)(self + 0xd0) + 0x98);
+            } else {
+                v = 0x14000;
+            }
+            if (v >= 0x14000)
+                *(int *)(self + 0x98) = v + 0xa000;
+            else
+                *(int *)(self + 0x98) = (int)(((long long)v * 0x800 + 0x800) >> 12) + 0x14000;
+            *(int *)(self + 0x98) = (int)(((long long)*(int *)(self + 0x98) * 0x14cc + 0x800) >> 12);
+            *(int *)(self + 0xa8) = 0xc000;
+            *(int *)(self + 0xd0) = 0;
+        }
+        lim = _ZNK10dBgCh_Actr13GetLimMovFlagEv(clsn);
+        _ZN10dBgCh_Actr13SetLimMovFlagEv(clsn);
+        _ZN5Actor9UpdatePosEP5dCc_c(self, 0);
+        func_020383fc(clsn);
+        if (_ZNK10dBgCh_Actr10IsOnGroundEv(clsn) != 0) {
+            char *fr = _ZNK10dBgCh_Actr14GetFloorResultEv(clsn);
+            _ZNK11SurfaceInfo12CopyNormalToER7Vector3(fr + 4, self + 0xd4);
+            if (_ZNK10dBgCh_Actr13JustHitGroundEv(clsn) == 0) {
+                *(int *)(self + 0xa8) = 0;
+                *(unsigned char *)(self + 0x107) = 0;
+            } else {
+                _ZNK11SurfaceInfo12CopyNormalToER7Vector3(fr + 4, self + 0xd4);
+                *(int *)(self + 0xa8) =
+                    _ZN4cstd4fdivEii((*(int *)(self + 0xa8) * -50) / 100, *(int *)(self + 0xd8));
+            }
+            {
+                int *pa = (int *)(self + 0xa4);
+                *pa += *(int *)(self + 0xd4) << 3;
+                *(int *)(self + 0xac) += *(int *)(self + 0xdc) << 3;
+                *(int *)(self + 0x98) = Vec3_HorzLen(pa);
+            }
+        }
+        *(s16 *)(self + 0x8e) = *(s16 *)(self + 0x94);
+        if (lim == 0)
+            _ZN10dBgCh_Actr15ClearLimMovFlagEv(clsn);
+        return 3;
+    }
+    *(int *)(self + 0xd0) = 0;
+    *(int *)(self + 0xb0) &= ~0xe0000;
+    *(unsigned char *)(self + 0x107) = 0;
+    return 0;
+}

--- a/src/_ZN12dScStarSel_c6RenderEv.cpp
+++ b/src/_ZN12dScStarSel_c6RenderEv.cpp
@@ -1,10 +1,15 @@
 //cpp
 // @symbol _ZN12dScStarSel_c6RenderEv
-// NONMATCHING: 13/593 at exact size (was 58). Real dScStarSel_c method over
-// include/dScStarSel_c.h, vtable slot 9. Residue is the two-digit level number
-// block: the ROM materialises the tens-digit x (0x77) right before the OAM::Render
-// argument copy (mov r5,#0x77 / mov r2,r5 after the table load) while every
-// spelling tried here emits it at the top of the block.
+// Real dScStarSel_c method over include/dScStarSel_c.h, vtable slot 9.
+//
+// The two-digit level-number block was the last residue (13 words): the cartridge
+// materialises the tens-digit x (mov r5,#0x77) right before the OAM::Render argument
+// copy, and starts the /10 magic-multiply chain one instruction earlier. Writing the
+// test in its POSITIVE sense -- `if (v >= 10) { render tens; c += 9; } else c = 0x7c;`
+// instead of `if (v < 10) c = 0x7c; else { ... }` -- puts the tens branch first in the
+// linearisation and the whole 13-word argument-setup block falls into the cartridge's
+// order. The two branches are otherwise identical, so this is a source-shape fact and
+// not a code change.
 #pragma opt_loop_invariants off
 #pragma opt_strength_reduction off
 #include "common.h"
@@ -67,11 +72,11 @@ s32 dScStarSel_c::Render()
         func_ov003_020adfc8((char *)this);
         v = SublevelToLevel(data_02092110) + 1;
         if (v <= 0xf) {
-            if (v < 10) {
-                c = 0x7c;
-            } else {
+            if (v >= 10) {
                 _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[v / 10], c = 0x77, 0x7a, 8, -1, 0);
                 c += 9;
+            } else {
+                c = 0x7c;
             }
             _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, _ZN3OAM7NUMBERSE[v % 10], c, 0x7a, 8, -1, 0);
         }


### PR DESCRIPTION
Two functions that had been sitting as declared compiler floors now match byte for byte under the pinned compiler.

| Function | Module | Address | Size | Result |
| --- | --- | --- | --- | --- |
| `_ZN12dScStarSel_c6RenderEv` | ov003 | 0x020ae6f4 | 0x944 (2372 bytes) | matched, was NONMATCHING 13/593 |
| `_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr` | ov002 | 0x020ade78 | 0x3cc (972 bytes) | matched, new file |

Both are real C++ methods, not free functions.

## Byte gate

```
tools/match.py --c src/_ZN12dScStarSel_c6RenderEv.cpp --func _ZN12dScStarSel_c6RenderEv \
  --addr 0x020ae6f4 --size 0x944 --module ov003 --strict-relocs --all
MATCHING VERSIONS: 2004/b56

tools/match.py --c src/_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr.cpp \
  --func _ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr \
  --addr 0x020ade78 --size 0x3cc --module ov002 --strict-relocs --all
MATCHING VERSIONS: 2004/b56
```

`build_pin.verify` agrees on both:

```
dScStarSel_c::Render          ov003 0x020ae6f4 0x944 -> (True, '2004/b56')
dEnemyBase_c::UpdateYoshiEat  ov002 0x020ade78 0x3cc -> (True, '2004/b56')
```

Every other mwccarm version the harness tries comes out at the wrong size, so the pin is doing real work here rather than the match being version-agnostic.

## A correction to the second file

As first written, the Yoshi-eat file declared and called two callees whose names do not exist anywhere in `config/**/symbols.txt`: `_ZN5Actor9UpdatePosEP5dCc_c` and `func_020383fc`. The byte gate did not care, because call targets are wildcarded, so the file would have landed with its linkage unverified. The canonical names are `_ZN8dActor_c9UpdatePosEP5dCc_c` (arm9, 0x02010c30, size 0x2c; the class is `dActor_c`) and `dBgCh_Actr_UpdateContinuous_Veneer` (0x020383fc, size 0xc, which is exactly the address the wrong name had encoded). Both were renamed at their declaration and their call site, four lines in all, and both functions still match byte for byte afterwards.

The rename is not cosmetic. Against the pre-correction file the link check reports the function as `BLIND-1`, unverified; against the corrected file it reports `VERIFIED`. That is one fewer warning and one more verified file, and it closes a spot where a wrong reloc destination could have gone unnoticed. `check_references` reports the same numbers either way, so the link check was the only gate that saw it.

Every `func_*`, `data_*` and `_Z*` identifier in both files was checked against the 31763-symbol universe built from all 106 `config/**/symbols.txt` files. All 42 resolve, as does every extern declarator including `dBgCh_Actr_UpdateContinuous_Veneer` and `Vec3_HorzLen`. The only remaining unresolved tokens are C++ type names appearing in signatures.

## Link check

```
prepush_linkcheck --range origin/main..HEAD
1 changed header(s) fan out to 447 source file(s) to verify
  [OK  ] _ZN12dScStarSel_c6RenderEv                        VERIFIED
  [OK  ] _ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr   VERIFIED
  [WARN] _ZN15RollingIronBall13InitResourcesEv        BLIND-14
  [WARN] _ZN15daObjMarioCap_c13InitResourcesEv        BLIND-33
  [WARN] Goomboss / daObjMarioCap_c / daOts_c         NO-SYM
  [WARN] d_a_hanachan / d_a_king_donketu / d_a_moray  NO-SYM
  [WARN] d_a_wanwan2 / d_a_bakubaku / d_a_i_donketu   NO-SYM
  [WARN] d_a_propeller_heyho / d_a_wanwan             NO-SYM
prepush-linkcheck: 447 checked - 434 verified, 13 warning(s), 0 blocking
```

All thirteen warnings are pre-existing and none is blocking. `_ZN15RollingIronBall13InitResourcesEv` and `_ZN15daObjMarioCap_c13InitResourcesEv` were re-run against the pristine `origin/main` header and come back with exactly the same `BLIND-14` and `BLIND-33`, so they are pre-existing and not caused by the header change here. The eleven `NO-SYM` rows are likewise untouched by this branch.

## Other gates

```
langmode_audit --check langmode-baseline.json    langmode ratchet PASS
check_duplicate_sources                          9451 stems, none doubled
eligible.py -j 8                                 11194 / 11270 ELIGIBLE
check_references                                 unresolved 42 (baseline 45), eligible 11194
                                                 (baseline 11044), no new unresolvable references
check_src_tu                                     30 TUs, 316 includes, 783 mangled refs, all resolve
check_header_offsets --changed origin/main       include/dEnemyBase_c.h: 18 commented fields,
                                                 0 mismatched, 0 unparsed, struct spans 0x110
unittest test_srcpath test_bytegate test_enroll  Ran 80 tests, OK
```

## Header

`include/dEnemyBase_c.h` gains a single non-virtual declaration, `int UpdateYoshiEat(dBgCh_Actr & clsn_);`, placed in the existing non-virtual block. No data members and no virtuals change, so there is no layout change: `check_header_offsets` reports 0 mismatched fields and the struct still spans 0x110.

## Enrollment

Both hunks were hand-inserted in address order with the `complete` keyword, each in its module's existing CRLF file:

```
config/arm9/overlays/ov003/delinks.txt
src/_ZN12dScStarSel_c6RenderEv.cpp:
    complete
    .text start:0x020ae6f4 end:0x020af038

config/arm9/overlays/ov002/delinks.txt
src/_ZN12dEnemyBase_c14UpdateYoshiEatER10dBgCh_Actr.cpp:
    complete
    .text start:0x020ade78 end:0x020ae244
```

`enroll.py --dry-run --complete-list` was run only as a cross-check, and the entries it proposes for these two files are byte-identical to the hand-inserted ones. It also wanted to strip blank lines in ov006 and reorder two entries in ov070; both are unrelated pre-existing drift and were reverted. No `config/arm9/delinks.txt` change and no `nearmiss/db.jsonl` change.

## The lever

The interesting part is that both of these had been written off as compiler floors after a lot of work spent inside the residue block itself, and neither needed anything done in there. Both fell to the same move: write the branch test in its positive sense so that the heavy arm becomes the then-block rather than the else-block.

In the star select render that test is the two-digit level number check, and in the Yoshi-eat update it is the eater check. In both cases the rewritten source is semantically identical and the compiler emits the identical branch instruction, with the same condition code, because it inverts the test right back. What changes is which block it treats as the fall-through and which it treats as the branch target, and that decides the order the two blocks are laid out in. Written the original way, mwccarm placed them in the opposite order from the cartridge; written in the positive sense, it places them the way the cartridge has them, and the residue disappears.

That is worth noting because the residue in each case looked like a scheduling or materialization problem local to the block, and the fix was not in the block at all. It was in the shape of the test that decided where the block went. Anything currently parked as a floor whose diff is a displaced or reordered basic block is worth re-testing this way before more effort goes into the block's contents.
