### PR TITLE
Withdraw the coined-name parking rule; require disclosure instead

### DIFF
--- a/notes/agents/PIPELINE.md
+++ b/notes/agents/PIPELINE.md
@@ -72,17 +72,46 @@ those records by NAME. No byte gate at stage 2 or 3 catches it. And a class memb
 function **cannot sit inside an `extern "C" { }` region**, so the one file-scope
 region goes after the last surviving `func_*` member.
 
-## Coined-name classes are parked
+## Coined class names are allowed, and must be recorded as coined
 
-A class whose name was coined rather than read from the cartridge's RTTI **is not
-eligible for promotion**. Coined names block data verification against the ROM, and
-a promotion under one banks a claim the cartridge cannot corroborate.
+An earlier version of this file **parked** every class whose name was not read from
+the cartridge's RTTI. That rule is withdrawn: it was stricter than the project's own
+practice and it retroactively condemned merged work. Ten classes with coined names
+have already shipped -- `Player`, `Goomboss`, `Eyerok`, `ActorDerived`,
+`ActorBase_SceneNode`, and five `Mg*` minigame classes.
 
-This parks 143 of the 201 unpromoted queue rows (2,341 shards) until the naming
-question gets its own pass. Check the class's `identity_evidence` in its facts file
-before claiming: `dScMgCurling2_c` is in scope because the ov006 bytes at
-`0x0213c4c8` are literally `15dScMgCurling2_c`. **Do not run `class_rename.py`** to
-get around this.
+**The standard is disclosure, not abstention.** Promote the class; record the name as
+coined, with the evidence that justifies it, in the manifest and in
+`symbols/actor_renames.tsv`. That is already the discipline for coined *member*
+names -- `dScMgCurling2_c` shipped 17 of them, each with a `why` sentence separating
+what the ROM proves (member-ness, dispatch-table index) from what is invented (the
+word). Apply the same split to a class name: say what the cartridge attests and what
+you chose.
+
+State the identity either way. `dScMgCurling2_c` is ROM RTTI -- the ov006 bytes at
+`0x0213c4c8` are literally `15dScMgCurling2_c` -- and its facts file says so in
+`identity_evidence`. A coined name needs the same field, saying it is coined and on
+what basis. **Do not run `class_rename.py`** to manufacture agreement.
+
+Scale, measured 2026-09-06 against `build/rtti.json` (the parked figure quoted in the
+withdrawn rule was wrong, and wrong in a way that mattered):
+
+| | rows | shards |
+|---|---:|---:|
+| `UNATTRIBUTED` / `UNATTRIBUTED-CORE` -- **not classes**, buckets for unattributed functions | 2 | 4,560 |
+| real class rows, unpromoted | 235 | 3,708 |
+| -- name is ROM-proven | 42 | 872 |
+| -- name is coined | 193 | 2,836 |
+
+The two `UNATTRIBUTED*` rows are not promotable classes and must be excluded from any
+"how much is left" figure; counting them inflated the cost of this rule by 2.6x.
+
+The RTTI test itself is sound -- four independent searches for false negatives
+(`rtti.json` record names, raw ROM string search, the strict length-prefixed `_ZTS`
+form, and nested-scope) turned up exactly one, `dMgPsOpt_c`, attested only as the
+enclosing scope of `dMgPsOpt_c::TouchIcon_c`. **A raw substring search is not that
+test**: `Koopa`, `Door`, `Coin`, `Key` and `Fish` all "match" inside unrelated ROM
+strings.
 
 Stage 4 is the only stage that DECIDES whether the bytes are right, and it owns
 `linkcheck` and `rombuild`. That is not the same as "stages 1-3 never run a byte

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -39,13 +39,18 @@ the manifest's `functions[]` move in the same commit. No byte gate at stage 2 or
 catches this; the cheap link evidence is a `.symtab` undefined-symbol scan of the
 emitted object.
 
-## Coined-name classes are parked
+## Coined class names are allowed, and must be recorded as coined
 
-Do not claim a class whose name was coined rather than read from the cartridge's
-RTTI -- check `identity_evidence` in its facts file first. A coined name cannot be
-corroborated against the ROM, so a promotion under one banks a claim the cartridge
-cannot support. This parks 143 of the 201 unpromoted queue rows. **Do not run
-`class_rename.py`** to get around it.
+An earlier version of this file told you not to claim a class whose name was coined
+rather than read from the cartridge's RTTI. **That rule is withdrawn** -- see
+`PIPELINE.md`, "Coined class names are allowed". Ten coined-name classes have already
+shipped, so the rule condemned merged work.
+
+Claim it, and record the name as coined with its evidence in the manifest and in
+`symbols/actor_renames.tsv` -- the same discipline this file already requires for
+coined *member* names: say what the ROM proves and what you chose, separately. Check
+`identity_evidence` in the facts file and state the identity either way. **Do not run
+`class_rename.py`** to manufacture agreement.
 
 ## Inputs
 


### PR DESCRIPTION
I added the coined-name parking rule earlier today (`f70857a52`). It was wrong on two counts and is withdrawn here.

## It was stricter than the project's own practice

Ten classes with coined names have **already merged**: `Player`, `Goomboss`, `Eyerok`, `ActorDerived`, `ActorBase_SceneNode`, and five `Mg*` minigame classes. The rule retroactively condemned work already in the tree.

## The number I justified it with was inflated 2.6×

I counted `UNATTRIBUTED-CORE` (3,103 shards) and `UNATTRIBUTED` (1,457 shards) as parked classes. They are not classes — they are buckets for functions nobody has attributed to a class, and were never claimable promotions. Measured against `build/rtti.json`:

| | rows | shards |
|---|---:|---:|
| `UNATTRIBUTED*` buckets — **not classes** | 2 | 4,560 |
| real class rows, unpromoted | 235 | 3,708 |
| — name is ROM-proven | 42 | 872 |
| — name is coined | 193 | 2,836 |

So the rule held **2,836 shards**, not the 7,407 I reported.

## The replacement: disclosure, not abstention

Promote the class; record the name as coined, with its evidence, in the manifest and in `symbols/actor_renames.tsv`. That is already the discipline for coined **member** names — `dScMgCurling2_c` shipped 17 of them, each with a `why` sentence separating what the ROM proves (member-ness, dispatch-table index) from what was invented (the word). A class name gets the same split.

## What survives

The RTTI test is sound and is recorded as such. Four independent searches for false negatives — `rtti.json` record names, raw ROM string search, the strict length-prefixed `_ZTS` form, and nested-scope — turned up exactly **one**: `dMgPsOpt_c`, attested only as the enclosing scope of `dMgPsOpt_c::TouchIcon_c`.

Also recorded, because it nearly fooled me: **a raw substring search is not that test.** It appeared to rescue 20 rows until I tightened it — `Koopa`, `Door`, `Coin`, `Key` and `Fish` all "match" inside unrelated ROM strings.

`class_rename.py` stays off-limits: it manufactures agreement rather than evidence.

**Gate:** `check_dead_references` — no new dead references, no broken markdown links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
