### PR TITLE
Match the ov003 star select entry helper

### DIFF
--- a/config/arm9/overlays/ov003/delinks.txt
+++ b/config/arm9/overlays/ov003/delinks.txt
@@ -79,6 +79,10 @@ src/func_ov003_020ae238.c:
     complete
     .text start:0x020ae238 end:0x020ae358
 
+src/func_ov003_020ae358.c:
+    complete
+    .text start:0x020ae358 end:0x020ae6f0
+
 src/_ZN12dScStarSel_c16OnPendingDestroyEv.cpp:
     complete
     .text start:0x020ae6f0 end:0x020ae6f4

--- a/src/func_ov003_020ae358.c
+++ b/src/func_ov003_020ae358.c
@@ -1,18 +1,32 @@
-// NONMATCHING: 6/230 at exact size 0x398. The draft that stood here was 0x394 -- four
-// bytes SHORT, an incomplete reconstruction rather than a near-miss.
-//
-// 8 -> 6 came from the permuter and the lever is worth keeping: the FIRST of the two
-// reads through `rec` is spelled inline as data_020a0de8[data_020a0e40][2] while the
-// SECOND stays rec[3]. That one asymmetry fixes the order in which the two hoisted pool
-// addresses (&data_020a0e40, &data_020a0de8) are loaded at +0xfc/+0x100. Inlining both
-// reads, inlining only the second, or moving the `rec` declaration below the first test
-// all cost 53 more words.
-//
-// The residue is the last six words: the two address temps `c + i` and
-// &data_020a0de8[data_020a0e40] swap r2 and r3 (+0x11c..+0x148). Naming either of them
-// costs 52 words; both must stay anonymous, and no ordering of the two subtractions
-// moves the pair.
-
+// @symbol func_ov003_020ae358
+/* recovered: the per-frame update for the ov003 character-select cursor.
+ *
+ * data_020a0e40 selects the active record in the 4-byte-stride tables at
+ * data_020a0de8..deb. If byte 0 of that record is set and byte 1 (data_020a0de9)
+ * says the slot is unlocked, the cursor tests whether the touch point at c+0x12b
+ * is inside the record's box; a hit arms the "picked" state at c+0x133/0x132,
+ * seeds the timers at c+0x118/0x119 and plays sound data_0209caa0[0x41] + 0x3c.
+ *
+ * Failing that, the three unlocked characters are scanned in order: for each i,
+ * the touch point at (c+i)+0x124 / +0x128 is tested against bytes 2 and 3 of the
+ * same record, and a hit records the character index in c+0x132, data_02092128
+ * and data_02092114 before playing the same sound.
+ *
+ * With no record active (sect2) the d-pad half of the control word data_020a0e58
+ * moves the selection: the repeat timer at c+0x106 counts down, and while it is
+ * zero a held left/right steps c+0x134 within [0, c+0x130 - 2] and reloads the
+ * timer with 0x10 or 8 depending on data_020a0e5a.
+ *
+ * Codegen note: the stride belongs in the TYPE, and the INDEX is what gets named.
+ * The 4-byte records are declared `[][4]` so each read refolds its own scale
+ * (`add r2, r4, r1, lsl #2`); flattening data_020a0dea/deb to a bare `[]` with an
+ * explicit `* 4` costs 17 words, and the same is true of data_020a0e5a. The last
+ * six words were a register transposition between the `c + i` and record-row
+ * address temps, and what closed it was naming the INDEX (`int ri`) for the second
+ * record read instead of naming the row POINTER: a named row pointer welds both
+ * reads onto one address temp and inverts the r2/r3 assignment, while the named
+ * index leaves each read to fold its own scale and hands the row temp r2.
+ */
 extern void func_02012790(int a);
 extern int _ZN8SaveData19IsCharacterUnlockedEj(unsigned int i);
 extern int func_ov003_020adec0(char *c, unsigned int r6);
@@ -62,10 +76,10 @@ void func_ov003_020ae358(char *c)
   {
     if (_ZN8SaveData19IsCharacterUnlockedEj(i) != 0)
     {
-      unsigned char *rec = data_020a0de8[data_020a0e40];
+      int ri = data_020a0e40;
       if (((unsigned short) ((data_020a0de8[data_020a0e40][2] - (*((unsigned char *) ((c + i) + 0x124)))) + 0x18)) < 0x30)
       {
-        if (((unsigned short) ((rec[3] - (*((unsigned char *) ((c + i) + 0x128)))) + 0x18)) < 0x2b)
+        if (((unsigned short) ((data_020a0de8[ri][3] - (*((unsigned char *) ((c + i) + 0x128)))) + 0x18)) < 0x2b)
         {
           *((unsigned char *) (c + 0x133)) = 1;
           *((unsigned char *) (c + 0x134)) = (unsigned char) func_ov003_020adec0(c, i);


### PR DESCRIPTION
Upgrades `src/func_ov003_020ae358.c` in place. The file already existed on main under a draft banner; the banner is removed by this branch and the function now reproduces the cartridge byte for byte.

## Function

| symbol | module | address | size |
| --- | --- | --- | --- |
| `func_ov003_020ae358` | ov003 | 0x020ae358 | 0x398 (920 bytes) |

## Byte gate

`python tools/match.py --c src/func_ov003_020ae358.c --func func_ov003_020ae358 --addr 0x020ae358 --size 0x398 --bin extracted/overlays/overlay_0003.bin --base 0x020ad660 --module ov003 --strict-relocs --all`

```
TARGET func_ov003_020ae358 @ 0x020ae358 size 0x398  (920 bytes)
  2004/b56: MATCH

========================================
MATCHING VERSIONS: 2004/b56
```

Strict relocation destinations were on for that run, so every reloc slot was checked against the `config/arm9/overlays/ov003/relocs.txt` records rather than wildcarded. `build_pin.verify` agrees independently:

```
(True, '2004/b56')
```

## Symbol resolution

Every `func_*`, `data_*` and `_Z*` identifier in the file, resolved against `config/**/symbols.txt`. This check is here because the byte gate wildcards call targets, so an invented callee name passes the byte compare unnoticed.

```
identifier                           module        address
-----------------------------------------------------------------
_ZN8SaveData19IsCharacterUnlockedEj  config/arm9   0x0201392c
data_0208ee44                        config/arm9   0x0208ee44
data_02092114                        config/arm9   0x02092114
data_02092128                        config/arm9   0x02092128
data_0209caa0                        config/arm9   0x0209caa0
data_020a0de8                        config/arm9   0x020a0de8
data_020a0de9                        config/arm9   0x020a0de9
data_020a0dea                        config/arm9   0x020a0dea
data_020a0deb                        config/arm9   0x020a0deb
data_020a0e40                        config/arm9   0x020a0e40
data_020a0e58                        config/arm9   0x020a0e58
data_020a0e5a                        config/arm9   0x020a0e5a
func_02012790                        config/arm9   0x02012790
func_ov003_020adec0                  ov003         0x020adec0
func_ov003_020ae358                  ov003         0x020ae358

identifiers: 15   unresolved: 0
```

## Enrollment

One hunk added to `config/arm9/overlays/ov003/delinks.txt`, in address order, between the 0x020ae238 entry and the 0x020ae6f0 entry:

```
src/func_ov003_020ae358.c:
    complete
    .text start:0x020ae358 end:0x020ae6f0
```

The hunk was hand written and then checked against `tools/enroll.py --complete-list`, which produces a byte identical file. Everything else that run proposed was reverted, namely the pre-existing ov070 ordering drift and the ov006 blank line stripping. No arm9 delinks changes and no near miss database changes.

## Gates

```
prepush-linkcheck --range origin/main..HEAD
  [OK  ] func_ov003_020ae358                          VERIFIED
prepush-linkcheck: 1 checked - 1 verified, 0 warning(s), 0 blocking

langmode_audit --check langmode-baseline.json
langmode ratchet PASS

check_duplicate_sources
duplicate-sources: 9451 stems, none doubled

eligible.py -j 8
eligible: 11195 / 11271

check_references
unresolved symbols: 42  (baseline 45)
eligible:           11195  (baseline 11044)
OK: no new unresolvable references

check_src_tu
check_src_tu: 30 translation unit(s), 316 include(s), 783 mangled reference(s), against 31763 ROM symbols
check_src_tu: every reference resolves.

python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll
Ran 80 tests in 11.684s
OK
```

## The lever

The residue on this function had survived thirty eight source variants and roughly eleven thousand permuter iterations across two earlier attempts, and it fell to a single change in how the record table is spelled. Keep the array stride in the type and name the index, not the row pointer. The four byte records are declared `[][4]`, so each read refolds its own scale into an `add r2, r4, r1, lsl #2`; flattening `data_020a0dea` and `data_020a0deb` to a bare `[]` with an explicit `* 4` costs seventeen words, and `data_020a0e5a` behaves the same way, which confirms those existing stride carrying declarations are load bearing rather than stylistic, since flattening either of two of them takes the divergence count from six to twenty three. The last six words were a register transposition between the `c + i` address temp and the record row address temp. Naming the row pointer welds both reads onto one address temp and inverts the r2 and r3 assignment; naming the index instead, as `int ri`, leaves each read free to fold its own scale and hands the row temp r2, which is what the cartridge does. The transferable form of the rule is that a named pointer into an array is a commitment to one materialized address, while a named index is not, so when the compiler is being asked to reuse a scale it must not reuse, move the name off the pointer and onto the index.
