### PR TITLE
Define Memory::operator_delete2 for gate 1, and gate it

### DIFF
--- a/.github/workflows/port-build.yml
+++ b/.github/workflows/port-build.yml
@@ -40,10 +40,10 @@
 # smoke_heap, smoke_roots, smoke_fs. The other nine generate romdata.c from gitignored
 # extracted/arm9_dec.bin and are out of a runner's reach.
 #
-# Only smoke_gx links on main today, so only smoke_gx is blocking. Measured on 11fcd24d5,
-# 32-bit MSVC 19.51: smoke_gx clean; smoke 1 unresolved, smoke_heap 3, smoke_roots 17,
-# smoke_fs 17. The rest run in a reporting step, and each moves up
-# to the blocking step as it is fixed -- the ratchet is the target list below, in review,
+# Two of the five link, so those two are blocking. Measured on 11fcd24d5, 32-bit MSVC
+# 19.51: smoke_gx and smoke clean; smoke_heap 3 unresolved, smoke_roots 17, smoke_fs 17.
+# The rest run in a reporting step, and each moves up to the blocking step as it is
+# fixed -- the ratchet is the target list below, in review,
 # rather than a file that can drift. Configure is blocking for everything: a broken
 # CMakeLists or an unresolvable srcpath symbol is a real regression regardless.
 #
@@ -52,7 +52,9 @@
 # call it from an inline `operator delete`, so every class in those hierarchies emits a
 # reference to the Itanium spelling. That satisfies the NDS link, where the mangled string
 # IS the symbol. A host definition does exist -- port/hal/ctor_bridge.cpp:88 -- but
-# ctor_bridge.cpp is only linked into the model-family targets, so smoke never gets it.
+# ctor_bridge.cpp is only linked into the model-family targets. hal/shims.cpp now carries
+# a gate-1 definition that forwards to the host global operator delete instead, which is
+# what the ROM function does; that is what moved smoke into the blocking step.
 # port_refcheck cannot see this class at all: its hal-links check covers bare
 # func_XXXXXXXX / data_XXXXXXXX names, not _ZN... ones.
 #
@@ -144,7 +146,7 @@ jobs:
         shell: cmd
         run: |
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvars32.bat" >nul || exit /b 1
-          cmake --build build\portci --target smoke_gx
+          cmake --build build\portci --target smoke_gx smoke
 
       # Reporting only. -k 0 so ninja reports every target's link instead of stopping at
       # the first, which otherwise makes which failures you see depend on scheduling.
@@ -153,4 +155,4 @@ jobs:
         shell: cmd
         run: |
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvars32.bat" >nul || exit /b 1
-          cmake --build build\portci --target smoke smoke_heap smoke_roots smoke_fs -- -k 0
+          cmake --build build\portci --target smoke_heap smoke_roots smoke_fs -- -k 0

--- a/port/hal/shims.cpp
+++ b/port/hal/shims.cpp
@@ -1,5 +1,7 @@
 // Host-side definitions for symbols the slice references but whose NDS
 // definitions cannot serve an MSVC build.
+#include <new>
+
 #include "Fader.h"
 #include "FaderBrightness.h"
 
@@ -36,4 +38,24 @@ int ApproachLinear(int &ref, int target, int step);
 extern "C" void _Z14ApproachLinearRiii(Fix12i *value, Fix12i target, Fix12i step)
 {
     (void)ApproachLinear(*value, target, step);
+}
+
+// include/Fader.h:69 -- and sixteen other headers -- spell Memory::operator_delete2
+// as an extern "C" Itanium symbol and call it from an inline operator delete, so
+// every class in those hierarchies emits a reference to that spelling. On the NDS
+// link the mangled string IS the symbol; MSVC decorates it as a cdecl name that
+// needs a real definition.
+//
+// port/hal/ctor_bridge.cpp defines it for the model-family targets by forwarding to
+// Memory::Deallocate. Gate 1 links no Memory layer, so forwarding there would only
+// trade one unresolved symbol for another. It forwards to the host global instead,
+// which is what the ROM function does in any case: a three-word tail call to _ZdlPv,
+// the global operator delete (see src/_ZN6Memory16operator_delete2EPv.cpp, which is
+// excluded from the slice with the other *D0Ev TUs).
+//
+// No target links both this file and ctor_bridge.cpp. If one ever does, the duplicate
+// is a link error, which is loud -- not a silent divergence between the two routes.
+extern "C" void _ZN6Memory16operator_delete2EPv(void *ptr)
+{
+    ::operator delete(ptr);
 }


### PR DESCRIPTION
**Stacked on #2372** — base is `validator/port-ci-gate`, not `main`. Review that one first.

Seventeen headers — `include/Fader.h:69` is the one gate 1 reaches — spell `Memory::operator_delete2` as an `extern "C"` Itanium symbol and call it from an inline `operator delete`, so every class in those hierarchies emits a reference to that spelling. On the NDS link the mangled string *is* the symbol; MSVC decorates it as a cdecl name that needs a real definition, and gate 1 had none. `smoke.exe` failed with exactly that one unresolved external.

`port/hal/ctor_bridge.cpp:88` already defines it for the nine model-family targets, forwarding to `Memory::Deallocate`. **Gate 1 links no Memory layer**, so forwarding there would trade one unresolved symbol for another. The definition added here forwards to the host global `operator delete` instead — which is what the ROM function does in any case: `src/_ZN6Memory16operator_delete2EPv.cpp` is a three-word tail call to `_ZdlPv`, and that file is excluded from `slice_gate1.txt` with the other `*D0Ev` TUs.

No target links both `shims.cpp` and `ctor_bridge.cpp`, so the two routes cannot collide today. If one ever does, a duplicate definition is a link error — loud, rather than a silent divergence between the two. That note is in the comment.

## A pattern worth naming

This is the **second** time this symbol has had to move. `ctor_bridge.cpp`'s own comment records it arriving from `cxxname_bridge.cpp` "which only smoke_actor links; every target that builds a migrated model-family constructor needs it now." Each C++ migration that gives a class a virtual destructor widens the set of targets that need the bridge, and it gets chased one file at a time.

A shared hal bridge linked by every target would end that. This change does not attempt it, because it would touch fourteen target source lists and belongs in its own PR.

## Ratchet

With `smoke` linking, it joins `smoke_gx` in the blocking step of `port-build.yml`. Remaining in the reporting step: `smoke_heap` (3 unresolved), `smoke_roots` (17), `smoke_fs` (17) — all the same family of missing host definitions (`ExpandingHeap` virtuals and ctors, `NestedHeapIterator`, `data_020a4d38`).

Verified on a worktree with `extracted/` absent, exactly as CI sees it: `smoke.exe` links, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4FxdKHG3a6hQRYRAbx29c
