### PR TITLE
Match the snowball course generator, the last large function without a source

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -4220,6 +4220,10 @@ src/func_ov006_02126a98.c:
     complete
     .text start:0x02126a98 end:0x02126b4c
 
+src/func_ov006_02126ee4.cpp:
+    complete
+    .text start:0x02126ee4 end:0x021279b0
+
 src/func_ov006_021279b0.cpp:
     complete
     .text start:0x021279b0 end:0x02127d10

--- a/include/dScMgSnowball_c.h
+++ b/include/dScMgSnowball_c.h
@@ -106,7 +106,12 @@ struct dScMgSnowball_c : dScMgSingle3DBase_c {
     virtual int  OnKicked();                           /* slot 24 */
     virtual int  OnPushed();                           /* slot 25 */
 
-    u8    pad_4f38[0x5c00]; /* 0x4f38 -- no matched access */
+    /* 0x4f38 -- the generated course, 0x10 lanes of 0x2e0 rows. The stride
+       is the lane's: func_ov006_02126ee4 writes every tile as
+       `this + 0x4f38 + lane * 0x5c0 + row * 2`, so the lane index carries
+       0x5c0 = 0x2e0 * sizeof(u16) and the row index the halfword. 0x10 lanes
+       times 0x5c0 is 0x5c00, which closes exactly on mPosX. */
+    u16   mTileMap[0x10][0x2e0]; /* 0x4f38 */
     s32   mPosX;            /* 0xab38 -- Fix12 world position of the ball */
     s32   mPosY;            /* 0xab3c */
     s32   mPrevPosX;        /* 0xab40 -- Behavior's copy of mPos at tick start */
@@ -118,7 +123,9 @@ struct dScMgSnowball_c : dScMgSingle3DBase_c {
     s32   mSoundPosY;       /* 0xab54 */
     s32   unk_ab58;         /* 0xab58 -- downhill/uphill debt; while it is 0 the
                                 climb feeds mBallSize instead */
-    u8    pad_ab5c[0x4];    /* 0xab5c */
+    s32   unk_ab5c;         /* 0xab5c -- func_ov006_02126ee4 clears it, then
+                                writes the generated corridor's centre lane in
+                                Fix12 on the row before the goal */
     s32   mVelX;            /* 0xab60 -- Fix12, capped at 0x8000 */
     s32   mVelY;            /* 0xab64 */
     s32   mScrollX;         /* 0xab68 -- subtracted from every world X to draw */
@@ -142,7 +149,7 @@ struct dScMgSnowball_c : dScMgSingle3DBase_c {
     u8    mProbePush[0x20]; /* 0xac18 -- same probe hit solid; drives the push-out */
     u8    mProbeWater[0x20];/* 0xac38 -- same probe is inside water */
     u8    mArray1Active[0x80]; /* 0xac58 -- 1 = this mArray1 slot is live */
-    u8    mArray1[0x400];   /* 0xacd8 -- 0x80 * 8, elem dtor NullDestructor_0203d47c;
+    s32   mArray1[0x80][2]; /* 0xacd8 -- 0x80 * 8, elem dtor NullDestructor_0203d47c;
                                each element is a Fix12 {x,y} the ROM's own
                                Render indexes as i*8 + 0 / i*8 + 4 */
     s32   mArray1Kind[0x80]; /* 0xb0d8 -- 1 picks the 8-frame animated sprite
@@ -152,7 +159,7 @@ struct dScMgSnowball_c : dScMgSingle3DBase_c {
     u8    mArray2Active[0x80]; /* 0xb358 -- 1 = this mArray2 slot is live */
     s32   mArray2Kind[0x80]; /* 0xb3d8 -- Render switches 0..2 against 3 to
                                 pick the sprite */
-    u8    mArray2[0x400];   /* 0xb5d8 -- 0x80 * 8, elem dtor NullDestructor_0203d47c;
+    s32   mArray2[0x80][2]; /* 0xb5d8 -- 0x80 * 8, elem dtor NullDestructor_0203d47c;
                                same Fix12 {x,y} element shape as mArray1 */
     s32   mAnimCounter;     /* 0xb9d8 -- Render bumps it, wraps at 0x20; the
                                 obstacle sprite frame is (n / 4) & 7 */

--- a/src/func_ov006_02126ee4.cpp
+++ b/src/func_ov006_02126ee4.cpp
@@ -1,0 +1,342 @@
+//cpp
+// @symbol func_ov006_02126ee4
+/* recovered: dScMgSnowball_c course generator, ov006 0x02126ee4 (2764 bytes).
+ * Paints mTileMap row by row from the bottom of the course upwards, carving a
+ * corridor between a left and a right edge cursor that random-walk one lane at
+ * a time. Each row draws two kinds (0 hold, 1 pull in, 2 push out), clamps
+ * them against the corridor width and against the dead zones at both ends of
+ * the course, then paints solid 1 outside the corridor, a two-tile cap at each
+ * wall and 0 in between. Obstacle tile 12 drops in on a cooldown and takes an
+ * mArray1 slot with it. A second pass recolours the two goal rows, and a third
+ * walks every solid tile to seed decoration tiles 0x1d..0x20 and the mArray2
+ * props.
+ *
+ * FIVE SPELLINGS ARE LOAD-BEARING, all measured against the ROM on 2004/b56;
+ * every one of them was worth whole blocks of registers, never one or two
+ * instructions:
+ *   - mArray1 and mArray2 carry their 8-byte stride in the TYPE (the header
+ *     now spells them `s32 [0x80][2]`). Written as byte arrays with the
+ *     stride in the expression, mwccarm strength-reduces `slot * 8` into a
+ *     second induction variable, which costs the third pass the register the
+ *     ROM keeps 0x7fff in and spills the constant 1 to the frame: +9 words.
+ *   - `row` is declared AFTER rightKind. Declaration order picks the
+ *     callee-saved register here: declared earlier it takes sb and rotates
+ *     leftKind/rightKind/left/right one register each, 145 wrong words.
+ *   - the goal-row pass, the prop pass and the first `left` fill each own
+ *     their loop counter (goalRow/j, propRow/col, k). Sharing one `i` with
+ *     the rest of the function swaps the counter and the derived row pointer
+ *     between r1 and r2 in each of them.
+ *   - the wide-corridor obstacle owns `wideLane` rather than sharing `lane`
+ *     with the other two obstacle sites, which is what puts the lane in r2
+ *     and the mArray1 scan counter in r1 the way the ROM has them.
+ *   - `right - left` in the else arm stays an EXPRESSION. As a named local it
+ *     is allocated a frame slot ahead of the three induction temporaries and
+ *     every later slot shifts; the ROM spills it last, at sp+0x28.
+ * The run of literal stores at sp+0x2c..0xc4 is not a table: it is mwccarm
+ * hoisting one value per textual constant out of the row loop and spilling
+ * all of them, which falls out of writing the constants inline. */
+#include "dScMgSnowball_c.h"
+
+extern "C" {
+extern int RandomIntInternal(int *seed);
+extern int data_0209d4b8;
+}
+
+extern "C" void func_ov006_02126ee4(dScMgSnowball_c *self)
+{
+    int k;
+    int i;
+    int left;
+    int right;
+    int leftKind;
+    int rightKind;
+    int row;
+    int margin;
+    int narrow;
+    int wide;
+    int prevLeft;
+    int prevRight;
+    int cooldown;
+    int propRow;
+    int lane;
+    int slot;
+    int roll;
+    u16 tile;
+    int goalRow;
+    int col;
+    int j;
+    int wideLane;
+
+    for (i = 0; i < 0x80; i++) {
+        self->mArray1Active[i] = 0;
+        self->mArray1Kind[i] = 0;
+        self->mArray1Hit[i] = 0;
+    }
+    for (i = 0; i < 0x80; i++) {
+        self->mArray2Active[i] = 0;
+    }
+    self->unk_ab5c = 0;
+
+    if (self->Virtual8C()) {
+        narrow = 0xb;
+        wide = 0xe;
+        margin = 6;
+    } else {
+        narrow = 0xa;
+        wide = 0xd;
+        margin = 7;
+    }
+
+    rightKind = leftKind = 0;
+    left = 2;
+    right = 0xd;
+    cooldown = 0x12;
+
+    for (row = self->mScrollLimit - 1; row >= 0; row--) {
+        prevLeft = leftKind;
+        prevRight = rightKind;
+        leftKind = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 3 >> 15;
+        rightKind = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 3 >> 15;
+
+        if (row >= self->mScrollLimit - 8) {
+            rightKind = leftKind = 0;
+        } else if (row <= self->mGoalY / 16) {
+            rightKind = leftKind = 0;
+        } else if (right - left <= narrow) {
+            if (leftKind == 1) {
+                leftKind = 0;
+            }
+            if (rightKind == 1) {
+                rightKind = 0;
+            }
+        } else if (right - left == narrow + 1 && leftKind == 1 && rightKind == 1) {
+            rightKind = leftKind = 0;
+        } else if (right - left >= wide) {
+            if (leftKind == 2) {
+                leftKind = 0;
+            }
+            if (rightKind == 2) {
+                rightKind = 0;
+            }
+        } else if (right - left == wide - 1 && leftKind == 2 && rightKind == 2) {
+            rightKind = leftKind = 0;
+        }
+
+        switch (leftKind) {
+        case 0:
+            break;
+        case 1:
+            if (prevLeft == 2) {
+                leftKind = 0;
+            } else if (left >= margin) {
+                if (prevLeft == 0) {
+                    leftKind = 2;
+                    left--;
+                } else {
+                    leftKind = 0;
+                }
+            }
+            break;
+        case 2:
+            if (prevLeft == 1) {
+                leftKind = 0;
+            } else if (left < 1) {
+                if (prevLeft == 0) {
+                    leftKind = 1;
+                } else {
+                    leftKind = 0;
+                }
+            } else {
+                left--;
+            }
+            break;
+        default:
+            leftKind = 0;
+            break;
+        }
+
+        switch (rightKind) {
+        case 0:
+            break;
+        case 1:
+            if (prevRight == 2) {
+                rightKind = 0;
+            } else if (right <= 0x10 - margin) {
+                if (prevRight == 0) {
+                    rightKind = 2;
+                    right++;
+                } else {
+                    rightKind = 0;
+                }
+            }
+            break;
+        case 2:
+            if (prevRight == 1) {
+                rightKind = 0;
+            } else if (right >= 0xf) {
+                if (prevRight == 0) {
+                    rightKind = 1;
+                } else {
+                    rightKind = 0;
+                }
+            } else {
+                right++;
+            }
+            break;
+        default:
+            rightKind = 0;
+            break;
+        }
+
+        for (k = 0; k < left; k++) {
+            self->mTileMap[k][row] = 1;
+        }
+        switch (leftKind) {
+        case 0:
+            self->mTileMap[left][row] = 2;
+            self->mTileMap[left + 1][row] = 0;
+            break;
+        case 1:
+            self->mTileMap[left][row] = 3;
+            self->mTileMap[left + 1][row] = 4;
+            break;
+        case 2:
+            self->mTileMap[left][row] = 5;
+            self->mTileMap[left + 1][row] = 6;
+            break;
+        }
+        for (i = left + 2; i < right - 1; i++) {
+            self->mTileMap[i][row] = 0;
+        }
+        switch (rightKind) {
+        case 0:
+            self->mTileMap[right - 1][row] = 0;
+            self->mTileMap[right][row] = 7;
+            break;
+        case 1:
+            self->mTileMap[right - 1][row] = 8;
+            self->mTileMap[right][row] = 9;
+            break;
+        case 2:
+            self->mTileMap[right - 1][row] = 10;
+            self->mTileMap[right][row] = 11;
+            break;
+        }
+        for (i = right + 1; i < 0x10; i++) {
+            self->mTileMap[i][row] = 1;
+        }
+
+        if (leftKind == 1) {
+            left++;
+        }
+        if (rightKind == 1) {
+            right--;
+        }
+        if (row == self->mGoalY / 16 - 1) {
+            self->unk_ab5c = (right + left + 1) * 16 / 2 << 12;
+        }
+
+        if (row > self->mGoalY / 16 + 0x11) {
+            if (cooldown > 0) {
+                cooldown--;
+            } else if (self->Virtual8C() && row < self->mScrollLimit / 2) {
+                if (right - left >= 0xd) {
+                    if (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 8 >> 15) == 0) {
+                        if (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 2 >> 15) == 0) {
+                            lane = left + 2;
+                        } else {
+                            lane = right - 2;
+                        }
+                        self->mTileMap[lane][row] = 12;
+                        cooldown = 0x10;
+                        for (i = 0; i < 0x80; i++) {
+                            if (self->mArray1Active[i] == 0) {
+                                self->mArray1[i][0] = (lane * 16 + 8) << 12;
+                                self->mArray1[i][1] = (row * 16 + 8) << 12;
+                                self->mArray1Active[i] = 1;
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else {
+                if (right - left >= 0xd) {
+                    if (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15) == 0) {
+                        wideLane = left + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * (right - left - 3) >> 15) + 2;
+                        self->mTileMap[wideLane][row] = 12;
+                        cooldown = 0x10;
+                        for (i = 0; i < 0x80; i++) {
+                            if (self->mArray1Active[i] == 0) {
+                                self->mArray1[i][0] = (wideLane * 16 + 8) << 12;
+                                self->mArray1[i][1] = (row * 16 + 8) << 12;
+                                self->mArray1Active[i] = 1;
+                                break;
+                            }
+                        }
+                    }
+                } else if (right - left >= 0xa) {
+                    if (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15) == 0) {
+                        if (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 2 >> 15) == 0) {
+                            lane = left + 2;
+                        } else {
+                            lane = right - 2;
+                        }
+                        self->mTileMap[lane][row] = 12;
+                        cooldown = 0x10;
+                        for (i = 0; i < 0x80; i++) {
+                            if (self->mArray1Active[i] == 0) {
+                                self->mArray1[i][0] = (lane * 16 + 8) << 12;
+                                self->mArray1[i][1] = (row * 16 + 8) << 12;
+                                self->mArray1Active[i] = 1;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (self->Virtual8C()) {
+        for (i = 0; i < 0x80; i++) {
+            if (self->mArray1Active[i] == 1) {
+                if (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 2 >> 15) == 0) {
+                    self->mArray1Kind[i] = 1;
+                }
+            }
+        }
+    }
+
+    for (goalRow = self->mGoalY / 16 - 1; goalRow <= self->mGoalY / 16; goalRow++) {
+        for (j = 0; j < 0x10; j++) {
+            tile = self->mTileMap[j][goalRow];
+            if (tile == 0) {
+                self->mTileMap[j][goalRow] = 13;
+            } else if (tile == 2) {
+                self->mTileMap[j][goalRow] = 14;
+            } else if (tile == 7) {
+                self->mTileMap[j][goalRow] = 15;
+            }
+        }
+    }
+
+    slot = 0;
+    for (propRow = self->mScrollLimit - 1; propRow >= 0; propRow--) {
+        for (col = 0; col < 0x10; col++) {
+            if (self->mTileMap[col][propRow] == 1) {
+                roll = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 16 >> 15;
+                if (roll < 4) {
+                    self->mTileMap[col][propRow] = (u16)(roll + 0x1d);
+                } else if (roll == 4) {
+                    if (slot < 0x80) {
+                        self->mArray2[slot][0] = (col * 16 + 8) << 12;
+                        self->mArray2[slot][1] = (propRow * 16 + 8) << 12;
+                        self->mArray2Active[slot] = 1;
+                        self->mArray2Kind[slot] = (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 4 >> 15;
+                        slot++;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The snowball minigame's procedural course generator. It is the last function of this
size in the game that nobody had ever had a source for, and it now reproduces the
cartridge byte for byte.

| function | module | address | size | instructions |
| --- | --- | --- | --- | --- |
| `func_ov006_02126ee4` | ov006 | 0x02126ee4 | 0xacc (2764 bytes) | 691 |

## Byte gate

`python tools/match.py --c src/func_ov006_02126ee4.cpp --func func_ov006_02126ee4 --addr 0x02126ee4 --size 0xacc --module ov006 --all --strict-relocs`

```
MATCHING VERSIONS: 2004/b56
```

`build_pin.verify(src/func_ov006_02126ee4.cpp, func_ov006_02126ee4, 0x02126ee4, 0xacc, ov006)` returns `(True, '2004/b56')`.
Every other compiler in the sweep (dsi 1.1 through 1.6sp2) builds 0x948 and is rejected on size.

## The eleven other files that include the header still match

The header change is the reason this list exists. Each file was rebuilt at its own
address and size out of `config/arm9/overlays/ov006/symbols.txt`:

```
src/_ZN15dScMgSnowball_c11OnAttacked2Ev.cpp     ov006 0x021291d4 size 0x24  -> (True, '2004/b56')
src/_ZN15dScMgSnowball_c13InitResourcesEv.cpp   ov006 0x02129268 size 0x344 -> (True, '2004/b56')
src/_ZN15dScMgSnowball_c13OnYoshiTryEatEi.cpp   ov006 0x0212921c size 0x4c  -> (True, '2004/b56')
src/_ZN15dScMgSnowball_c16CleanupResourcesEv.cpp ov006 0x021291f8 size 0x24 -> (True, '2004/b56')
src/_ZN15dScMgSnowball_c6RenderEv.cpp           ov006 0x02127d10 size 0x694 -> (True, '2004/b56')
src/_ZN15dScMgSnowball_c8BehaviorEv.cpp         ov006 0x021283a4 size 0xc14 -> (True, '2004/b56')
src/_ZN15dScMgSnowball_c8OnKickedEv.cpp         ov006 0x02128fb8 size 0x1f8 -> (True, '2004/b56')
src/_ZN15dScMgSnowball_c8OnPushedEv.cpp         ov006 0x021291b0 size 0x24  -> (True, '2004/b56')
src/_ZN15dScMgSnowball_cD0Ev.cpp                ov006 0x0212573c size 0xc4  -> (True, '2004/b56')
src/_ZN15dScMgSnowball_cD1Ev.cpp                ov006 0x0212568c size 0xb0  -> (True, '2004/b56')
src/func_ov006_02125f68.cpp                     ov006 0x02125f68 size 0x9e0 -> (True, '2004/b56')
ALL SIBLINGS MATCH: True
```

## Header offsets

`python tools/check_header_offsets.py --changed origin/main`

```
check_header_offsets: 1 changed header(s) vs origin/main
include/dScMgSnowball_c.h: 58 commented fields, 0 mismatched, 0 unparsed, struct spans 0xc59c
```

The header change only puts names on fields that were already inside existing pads.
`pad_4f38[0x5c00]` becomes `u16 mTileMap[0x10][0x2e0]`, `pad_ab5c[4]` becomes
`s32 unk_ab5c`, and `mArray1` and `mArray2` become `s32 [0x80][2]` instead of raw byte
arrays of the same length. Every offset comment is unchanged, and the
`sizeof(dScMgSnowball_c) == 0xc59c` assert still holds.

## Symbol resolution

The byte gate wildcards call targets, so an invented callee name can pass it. Every
external identifier in the new translation unit was resolved against
`config/**/symbols.txt`:

```
RandomIntInternal      RESOLVED  arm9  0x0203b990  function(arm,size=0x24)
data_0209d4b8          RESOLVED  arm9  0x0209d4b8  bss
func_ov006_02126ee4    RESOLVED  ov006 0x02126ee4  function(arm,size=0xacc)
UNRESOLVED EXTERNS: 0
```

## Enrollment

One hunk, hand inserted in address order into `config/arm9/overlays/ov006/delinks.txt`:

```
src/func_ov006_02126ee4.cpp:
    complete
    .text start:0x02126ee4 end:0x021279b0
```

`tools/enroll.py --complete-list` proposes exactly this hunk and nothing else here.
Its other two proposals, the blank-line run in ov006 above `func_ov006_020d7c4c` and the
ov070 entry ordering, are pre-existing drift and were reverted, so the config diff is
those four lines.

## Gates

```
prepush-linkcheck --range origin/main..HEAD: 12 checked - 12 verified, 0 warning(s), 0 blocking
langmode_audit --check langmode-baseline.json: langmode ratchet PASS
check_duplicate_sources: 9452 stems, none doubled
eligible.py -j 8: eligible 11196 / 11272 (func_ov006_02126ee4 present)
check_references: unresolved symbols 42 (baseline 45); OK: no new unresolvable references
check_src_tu: 30 translation unit(s), 316 include(s), 783 mangled reference(s); every reference resolves
python -m unittest tools.test_srcpath tools.test_bytegate tools.test_enroll: Ran 85 tests, OK
```

## How it was written

This one was reconstructed straight from the cartridge disassembly against the class
header rather than tuned down from an earlier attempt, and five spellings did the work.
Each of them was worth whole blocks of registers, not one or two instructions.

The first is that `mArray1` and `mArray2` carry their eight byte stride in the type,
which is why the header now spells them `s32 [0x80][2]`. Written as byte arrays with the
stride in the expression instead, the compiler strength reduces `slot * 8` into a second
induction variable, which costs the third pass the register the ROM keeps 0x7fff in and
spills the constant 1 to the frame.

The second is that the three passes over the course each own their loop counter. The goal
row recolour, the prop walk and the first left edge fill get `goalRow`, `propRow` and `k`
of their own. Sharing one counter with the rest of the function swaps the counter and the
row pointer derived from it between r1 and r2 in every one of them.

The third is declaration order. `row` is declared after `rightKind`, and that is what
picks the callee saved register it lands in. Declared earlier it takes sb and rotates
`leftKind`, `rightKind`, `left` and `right` one register each, which is 145 wrong words.
The same rule puts `wideLane` on the wide corridor obstacle instead of sharing `lane`
with the other two obstacle sites.

The fourth is that `right - left` in the else arm stays an expression. As a named local it
takes a frame slot ahead of the three induction temporaries and every later slot shifts,
where the ROM spills it last at sp+0x28.

The fifth is that roughly forty constants are written inline. The long run of literal
stores near the end of the frame is not a table to reproduce, it is the compiler hoisting
one value per textual constant out of the row loop and spilling all of them, and it falls
out on its own once the constants are spelled in place.
