### PR TITLE
Record that the 51/52 conversion oracle was a naming pass

### DIFF
--- a/notes/agents/PIPELINE.md
+++ b/notes/agents/PIPELINE.md
@@ -59,7 +59,29 @@ equally. A TU of thirty `extern "C" func_ovNNN_*(char *self)` free functions in
 goal is writing the classes back.
 
 **The ruling: convert as far as byte-match allows.** `dScMgMemory2_c` is the proof
-the route works end to end. Stage 3b owns it; it is the same `writer` role file and
+the route works end to end -- but read what it cost before you take 51/52 as a
+target. Measured across its promotion commit `e351ffb09`, in
+`config/arm9/overlays/ov006/symbols.txt`:
+
+| | mangled `_ZN14dScMgMemory2_c*` rows |
+|---|---|
+| `e351ffb09^` | 8 |
+| `e351ffb09` | **51** |
+
+So 43 of that 51 were **renamed in the same commit**, shard and `symbols.txt` row
+together. **51/52 was a coordinated naming pass, not conversion alone.**
+
+That distinction decides what your own ceiling even means. A member already
+carrying a mangled name converts as a codegen question -- does it byte-match.
+A member carrying an auto-generated `func_ovNNN_*` name converts only by being
+**renamed**, which is a different, larger, and riskier act: the new name must
+reach `symbols.txt` in the same commit (see below), and every external caller
+must move with it. Measured on `ov071/Scuttlebug`, all 27 unconverted members
+were auto-named, so its ceiling was **name recovery, not codegen and not
+scope** -- a different wall from `dScMgCurling2_c`'s, where all 29 compiled
+byte-neutrally and 12 were refused for scope alone.
+
+State which wall you hit. "10/37" with no wall named is not a result. Stage 3b owns it; it is the same `writer` role file and
 may run as a separate pass on the same branch when stages 2 and 3 have already
 pushed. A member that will not convert byte-neutrally **stays a free function** --
 that is a result, not a failure. Report the count either way: "31/31 MATCH" hides

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -26,7 +26,24 @@ nothing -- but **measure, do not assume**. Work in batches, run `tubuild.py veri
 after each, and isolate any regression to one cause before continuing. A member
 whose first parameter is not the object, or that will not convert byte-neutrally,
 **stays a free function**: that is a result, not a failure. `dScMgMemory2_c` is the
-oracle for every mechanical question -- read its source and manifest first.
+oracle for every mechanical question -- read its source and manifest first, and
+read it knowing that **43 of its 51 methods were renamed in the promotion commit
+itself** (8 mangled rows in `ov006/symbols.txt` at `e351ffb09^`, 51 at
+`e351ffb09`). 51/52 was a coordinated naming pass, not conversion alone.
+
+**Name which wall you hit, because there are three and they need different
+answers.**
+
+| wall | what it looks like | what it costs to push |
+|---|---|---|
+| **codegen** | the member compiles as a method but the bytes move | usually unfixable here; leave it C |
+| **scope** | it byte-matches, but an unpromoted shard still calls the C name | let `mwldarm` enumerate it -- `dScMgCurling2_c`: 29/29 byte-neutral, 12 refused |
+| **naming** | the member has an auto-generated `func_ovNNN_*` name, so converting it *is* a rename | the rename must reach `symbols.txt` in the same commit, and every external namer must move with it -- `ov071/Scuttlebug`: all 27 unconverted members |
+
+Reporting "10/37" without naming the wall is not a result. The three are not
+interchangeable: a scope wall is enumerated for you by the linker, a naming wall
+is a decision about how much renaming the run is willing to carry, and only the
+codegen wall is a fact about the compiler.
 
 This may run as a separate pass on the same branch after stages 2 and 3 have
 already pushed. Whenever you report a promotion, give the method count next to the


### PR DESCRIPTION
`PIPELINE.md` cites `dScMgMemory2_c`'s **51 of 52** as proof the conversion
route works end to end. It is — but the docs never said what the number cost,
so a writer reads it as a codegen benchmark and measures itself against the
wrong thing.

## Measured

Across its promotion commit `e351ffb09`, in `config/arm9/overlays/ov006/symbols.txt`:

| ref | mangled `_ZN14dScMgMemory2_c*` rows |
|---|---:|
| `e351ffb09^` | 8 |
| `e351ffb09` | **51** |

**43 of the 51 were renamed in that same commit**, shard and `symbols.txt` row
together. 51/52 was a coordinated naming pass, not conversion alone.

Credit for spotting this goes to the `ov071/Scuttlebug` writer run, which hit a
wall that looked nothing like the oracle's and checked why.

## Why it matters

It separates three walls that until now all reported as one number:

| wall | what it looks like | what it costs to push |
|---|---|---|
| **codegen** | compiles as a method but the bytes move | usually unfixable; leave it C |
| **scope** | byte-matches, but an unpromoted shard still calls the C name | the linker enumerates it — `dScMgCurling2_c`: 29/29 byte-neutral, **12 refused** |
| **naming** | auto-generated `func_ovNNN_*` name, so converting it *is* a rename | rename must reach `symbols.txt` in the same commit and every external namer must move — `ov071/Scuttlebug`: **all 27** unconverted members |

These are not interchangeable. A scope wall is handed to you by `mwldarm`. A
naming wall is a *decision* about how much renaming a run is willing to carry.
Only the codegen wall is a fact about the compiler.

Both files now ask for the wall to be named alongside the count — "10/37" with
no wall named is not a result.

## Gates

`check_dead_references` — `no new dead references`, `no broken markdown links`,
exit 0. Docs only; no `src/`, `include/`, `config/` or tool is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
