### PR TITLE
Make the three unlinked port gates link, and gate them

### DIFF
--- a/.github/workflows/port-build.yml
+++ b/.github/workflows/port-build.yml
@@ -33,30 +33,37 @@
 #
 # `refs` is blocking and cheap. tools/port_refcheck.py already did the right check --
 # manifests, cmake symbols, hal alternatename/extern-C links -- in about a second with no
-# compiler and no ROM, and was simply never wired to anything. On 11fcd24d5 it reports
-# 402 references (229 + 21 + 152), 0 stale.
+# compiler and no ROM, and was simply never wired to anything. It reports 423 references
+# (249 + 21 + 153), 0 stale.
 #
 # `build` compiles and links the ROM-free targets. There are five: smoke, smoke_gx,
-# smoke_heap, smoke_roots, smoke_fs. The other nine generate romdata.c from gitignored
-# extracted/arm9_dec.bin and are out of a runner's reach.
+# smoke_heap, smoke_roots, smoke_fs. ALL FIVE ARE BLOCKING. The other nine generate
+# romdata.c from gitignored extracted/arm9_dec.bin and are out of a runner's reach, so
+# this file cannot gate them and does not pretend to. Configure is blocking as well: a
+# broken CMakeLists or an unresolvable srcpath symbol is a regression regardless.
 #
-# Two of the five link, so those two are blocking. Measured on 11fcd24d5, 32-bit MSVC
-# 19.51: smoke_gx and smoke clean; smoke_heap 3 unresolved, smoke_roots 17, smoke_fs 17.
-# The rest run in a reporting step, and each moves up to the blocking step as it is
-# fixed -- the ratchet is the target list below, in review,
-# rather than a file that can drift. Configure is blocking for everything: a broken
-# CMakeLists or an unresolvable srcpath symbol is a real regression regardless.
+# THREE OF THE FIVE DID NOT LINK when this workflow was first written -- smoke_heap 3
+# unresolved symbols, smoke_roots 17, smoke_fs 17 -- and ran in a reporting step instead.
+# They are fixed and that step is gone: a workflow with a permanently-red half teaches
+# people to skip the whole thing. If a target regresses, the answer is to fix it or to
+# take it off the list below, in review -- not to demote it in place.
 #
-# THE SHARED CAUSE, since it will come up on each: 17 headers (include/Fader.h:69 is the
-# one smoke reaches) declare `extern "C" void _ZN6Memory16operator_delete2EPv(void *)` and
-# call it from an inline `operator delete`, so every class in those hierarchies emits a
-# reference to the Itanium spelling. That satisfies the NDS link, where the mangled string
-# IS the symbol. A host definition does exist -- port/hal/ctor_bridge.cpp:88 -- but
-# ctor_bridge.cpp is only linked into the model-family targets. hal/shims.cpp now carries
-# a gate-1 definition that forwards to the host global operator delete instead, which is
-# what the ROM function does; that is what moved smoke into the blocking step.
-# port_refcheck cannot see this class at all: its hal-links check covers bare
-# func_XXXXXXXX / data_XXXXXXXX names, not _ZN... ones.
+# WHAT THOSE 17 WERE, because the shape recurs on every migration wave and it is most of
+# the reason a build gate is worth having. The decomp names symbols the way the NDS link
+# does, by their Itanium string, so a header line like
+#
+#     extern "C" void _ZN6Memory16operator_delete2EPv(void *);
+#
+# is a complete reference to a real function on the cartridge and nothing at all to MSVC.
+# All 17 were spelling seams of that kind, and each is answered in port/hal by a real
+# forwarder rather than an /alternatename alias, because the two spellings sit on
+# opposite sides of a calling convention -- __thiscall against cdecl -- and an alias
+# across that boundary links quietly and then reads garbage as `this`. Constructors are
+# the sharpest case: C1 is an Itanium ABI variant tag with no C++ syntax at all, so a
+# hand-written function of that name is the only thing that can ever answer one.
+#
+# port_refcheck sees none of this. Its hal-links check covers bare func_XXXXXXXX /
+# data_XXXXXXXX names, not _ZN... ones; only a link finds them.
 #
 # SCOPE. Compile and link only. BUILD_TESTING is off and no ctest runs -- the smoke
 # binaries want the asset catalog. Runtime behaviour is not claimed. "Does it still
@@ -142,17 +149,12 @@ jobs:
 
       # Each `shell: cmd` step is its own process, so vcvars32 has to be re-applied;
       # only the discovery is carried over, through GITHUB_ENV.
-      - name: Link the targets that link today
+      #
+      # -k 0 so ninja reports EVERY target's link rather than stopping at the first
+      # failure. Without it, which breakage you see depends on scheduling order, and a
+      # change that breaks three targets reads as a change that breaks one.
+      - name: Link the ROM-free targets
         shell: cmd
         run: |
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvars32.bat" >nul || exit /b 1
-          cmake --build build\portci --target smoke_gx smoke
-
-      # Reporting only. -k 0 so ninja reports every target's link instead of stopping at
-      # the first, which otherwise makes which failures you see depend on scheduling.
-      - name: The targets that do not link yet (reporting)
-        continue-on-error: true
-        shell: cmd
-        run: |
-          call "%VSINSTALL%\VC\Auxiliary\Build\vcvars32.bat" >nul || exit /b 1
-          cmake --build build\portci --target smoke_heap smoke_roots smoke_fs -- -k 0
+          cmake --build build\portci --target smoke smoke_gx smoke_heap smoke_roots smoke_fs -- -k 0

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(smoke
     hal/cstd_div.c
     hal/os_time.cpp
     hal/shims.cpp
+    hal/mem_delete2.cpp
     ${SLICE_SOURCES})
 
 target_include_directories(smoke PRIVATE
@@ -88,7 +89,7 @@ endforeach()
 sm64ds_honor_cpp_markers(SLICE3A_SOURCES)
 
 add_executable(smoke_roots tests/smoke_roots.cpp
-    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp
+    hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/mem_delete2.cpp
     ${SLICE2_SOURCES} ${SLICE3A_SOURCES})
 target_include_directories(smoke_roots PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -385,6 +386,7 @@ endif()
 
 add_executable(smoke_fs tests/smoke_fs.cpp
     hal/heap_globals.cpp hal/os_arena.cpp hal/heap_vtable.cpp hal/fs.cpp
+    hal/mem_delete2.cpp
     ${SLICE2_SOURCES} ${SLICE3A_SOURCES} ${SLICE3B_SOURCES})
 target_include_directories(smoke_fs PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/port/hal/gx_upload_bridge.cpp
+++ b/port/hal/gx_upload_bridge.cpp
@@ -18,8 +18,9 @@ typedef unsigned short u16;
 #pragma comment(linker, "/alternatename:__ZN2GX11LoadTexPlttEPKvjj=?LoadTexPltt@GX@@YAXPBXII@Z")
 #pragma comment(linker, "/alternatename:?data_020a60b0@@3IA=_data_020a60b0")
 
-namespace cstd { int abs(int); }
-extern "C" int _ZN4cstd3absEi(int value) { return cstd::abs(value); }
+// cstd::abs's C-spelling forwarder moved to hal/heap_globals.cpp, next to the
+// other Itanium-spelling bridges; every target that links this file links that
+// one, and the allocator layer needs the same symbol.
 
 extern "C" {
 void _ZN2GX12BeginLoadTexEv(void);

--- a/port/hal/heap_globals.cpp
+++ b/port/hal/heap_globals.cpp
@@ -38,9 +38,11 @@ void MultiStore_Int(int val, int *dst, int len)
 #pragma comment(linker, "/alternatename:?_ZN6Memory25isRootHeapIterInitializedE@@3HA=__ZN6Memory25isRootHeapIterInitializedE")
 #pragma comment(linker, "/alternatename:?data_020a4d34@@3HA=__ZN6Memory25isRootHeapIterInitializedE")
 #pragma comment(linker, "/alternatename:?data_020a4d38@@3DA=__ZN6Memory16rootHeapIteratorE")
-// FUNCTION alias only where the conventions MATCH: this reference and the C
-// definition are both __cdecl free functions.
-#pragma comment(linker, "/alternatename:?_ZN18NestedHeapIteratorC1Ej@@YAXPAXI@Z=__ZN18NestedHeapIteratorC1Ej")
+// ...and the same storage under the TYPED spelling. src/func_0204df54.cpp now
+// declares `extern NestedHeapIterator data_020a4d38', so MSVC decorates the
+// reference with the struct name (@@3U...@@A) rather than as the char array
+// (@@3DA) the line above covers. Both are references to one address on the NDS.
+#pragma comment(linker, "/alternatename:?data_020a4d38@@3UNestedHeapIterator@@A=__ZN6Memory16rootHeapIteratorE")
 
 // FUNCTION BRIDGES where aliasing would be a silent ABI bug: C TUs call the
 // iterator entry points as __cdecl free functions under Itanium names, but
@@ -55,6 +57,8 @@ void _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(void *self, HeapAllocator
 { ((NestedHeapIterator *)self)->AddFirst(a); }
 int _ZN18NestedHeapIterator4NextEP13HeapAllocator(void *self, HeapAllocator *a)
 { return ((NestedHeapIterator *)self)->Next(a); }
+void _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(void *self, HeapAllocator *a)
+{ ((NestedHeapIterator *)self)->Remove(a); }
 }
 // C-name references left in the slice -> methods that have since migrated to
 // real C++. These must be forwarders, not /alternatename aliases: instance
@@ -105,3 +109,60 @@ void _ZN18NestedHeapIterator4InitEP13HeapAllocator(
 { self->Init(allocator); }
 
 }
+
+// ---- CONSTRUCTOR bridges -------------------------------------------------
+//
+// Same seam as the forwarders above, on the one kind of member whose host name
+// cannot be spelled at all. A constructor has no name to declare: `C1' is an
+// Itanium ABI VARIANT tag, and MSVC has no syntax that emits or references one.
+// So a TU that says `extern "C" _ZN22ExpandingHeapAllocatorC1EPvj(...)' and calls
+// it -- which is what src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.cpp and
+// src/func_0204df54.cpp do, because on the NDS that string IS the symbol -- can
+// only be satisfied by a hand-written function of that name. Placement new is
+// the body: it runs the migrated constructor from src/ in place and, like the
+// ROM's C1, hands back the object.
+//
+// _ZN18NestedHeapIteratorC1Ej USED TO BE AN /alternatename HERE and the alias is
+// removed with this change. It pointed the MSVC-mangled reference at the C
+// spelling __ZN18NestedHeapIteratorC1Ej, which was a definition back when
+// src/_ZN18NestedHeapIteratorC1Ej.cpp was C. That file is C++ now and defines a
+// real __thiscall constructor, so the alias aimed at nothing: it named neither a
+// symbol anyone referenced nor one anything defined, and the target linked only
+// because no gate built it. This is the shape the file's own comment above warns
+// about -- an alias across a convention boundary -- landing on the migration
+// rather than on the original C.
+#include "ExpandingHeapAllocator.h"
+#include <new>
+
+// Each signature is its CALLERS' declaration, not a tidier one: the iterator is
+// declared `void' in include/decl_NestedHeapIterator.h and its result is dropped,
+// while CreateExpandingHeapAllocator returns what the C1 handed back.
+extern "C" {
+void _ZN18NestedHeapIteratorC1Ej(void *self, u32 linkOffset)
+{ ::new (self) NestedHeapIterator(linkOffset); }
+
+ExpandingHeapAllocator *_ZN22ExpandingHeapAllocatorC1EPvj(
+    ExpandingHeapAllocator *self, void *heapEnd, u32 flags)
+{ return ::new ((void *)self) ExpandingHeapAllocator(heapEnd, flags); }
+}
+
+// MemoryNode::Target's constructor, same seam again. ExpandingHeapAllocator's
+// constructor and Reallocate both build one on the stack under the C1 spelling.
+// A `MemoryNode::Target *' return matches what the ROM's C1 hands back; both
+// callers drop it.
+#include "MemoryNode.h"
+
+extern "C" MemoryNode::Target *_ZN10MemoryNode6TargetC1EPS_(
+    MemoryNode::Target *self, MemoryNode *node)
+{ return ::new ((void *)self) MemoryNode::Target(node); }
+
+// cstd::abs under its C spelling, which ExpandingHeapAllocator::MaxAllocatableSize
+// references. The forwarder was in hal/gx_upload_bridge.cpp and moved here with
+// the source file's move from slice_gate4b.txt to slice_gate2.txt, for the same
+// reason: the nine targets that link gx_upload_bridge.cpp all link this file too,
+// so the pair can have one home instead of one per layer that reaches it.
+// Declared locally: there is no cstd header in include/, and this is the
+// declaration hal/gx_upload_bridge.cpp carried for the same call.
+namespace cstd { int abs(int); }
+
+extern "C" int _ZN4cstd3absEi(int value) { return cstd::abs(value); }

--- a/port/hal/heap_vtable.cpp
+++ b/port/hal/heap_vtable.cpp
@@ -116,3 +116,29 @@ extern "C" void *_ZTV13ExpandingHeap[15] = {
     (void *)slot_trap13,       /* 13: VGetNodeID */
     (void *)slot_trap14,       /* 14: VResizeToFit */
 };
+
+// ---- ExpandingHeap's constructor, under its Itanium spelling ---------------
+//
+// src/_ZN4Heap14CreateRootHeapEPvj.cpp and src/_ZN4Heap19CreateExpandingHeapEjPS_i.cpp
+// call `_ZN13ExpandingHeapC1EPvjP4HeapP22ExpandingHeapAllocator' as an extern "C"
+// function, for the reason hal/heap_globals.cpp's constructor-bridge block gives:
+// C1 is an Itanium ABI variant tag and MSVC has no syntax that emits or references
+// one, so the only way to satisfy that string is to write a function with it.
+//
+// IT IS HERE AND NOT NEXT TO THE OTHER TWO because heap_globals.cpp is also linked
+// by smoke_heap, whose slice is the allocator layer alone. The body has to name
+// ExpandingHeap's constructor, and smoke_heap does not compile it -- putting this
+// there would trade two of smoke_heap's unresolved symbols for a new one.
+//
+// The placement new also installs the MSVC vptr, which is what
+// src/_ZN13ExpandingHeapC1EPvjP4HeapP22ExpandingHeapAllocator.cpp already does when
+// MSVC compiles it; this bridge does not change which table an object carries. The
+// synthetic _ZTV13ExpandingHeap above serves the C-spelled callers, and the note at
+// the head of this file covers the slot numbering the two orders disagree on.
+#include <new>
+
+extern "C" ExpandingHeap *_ZN13ExpandingHeapC1EPvjP4HeapP22ExpandingHeapAllocator(
+    void *self, void *start, u32 size, Heap *root, ExpandingHeapAllocator *allocator)
+{
+    return ::new (self) ExpandingHeap(start, size, root, allocator);
+}

--- a/port/hal/mem_delete2.cpp
+++ b/port/hal/mem_delete2.cpp
@@ -1,0 +1,36 @@
+// Memory::operator_delete2 under its Itanium spelling, for every target that
+// compiles a class in one of the seventeen hierarchies whose header declares it.
+//
+// THE SEAM. include/Heap.h, include/Fader.h:69 and fifteen more headers spell
+//
+//     extern "C" void _ZN6Memory16operator_delete2EPv(void *);
+//
+// and call it from an inline `operator delete', so EVERY class in those
+// hierarchies emits a reference to that exact string. On the NDS the mangled
+// string is the symbol and the ROM's own veneer at 0x0203cbcc answers it. MSVC
+// decorates it as a cdecl name that needs a real definition, and
+// src/_ZN6Memory16operator_delete2EPv.cpp cannot be it: that file is a migrated
+// C++ `namespace Memory' function, so MSVC gives it a different decoration, and
+// its body calls `extern "C" _ZdlPv', which no host runtime provides either.
+//
+// THE BODY IS WHAT THE ROM DOES. The ROM veneer is three words -- ldr ip / bx ip
+// / .word -- tail-calling _ZdlPv at 0x0203cbf0, the global operator delete. That
+// is `::operator delete' here.
+//
+// WHY ITS OWN FILE. It first appeared in hal/shims.cpp, which only `smoke' links,
+// and hal/ctor_bridge.cpp separately defines it for the nine model-family targets
+// by forwarding to Memory::Deallocate instead. Adding smoke_roots and smoke_fs
+// would have made a third copy of a definition that is not target-specific, so
+// the shims.cpp copy moved here and the two new targets link this file. The
+// ctor_bridge definition is deliberately left where it is: it is a DIFFERENT
+// route, chosen for targets that run a live Memory layer, and consolidating the
+// two is a decision with a measurement behind it rather than a file move.
+//
+// No target links both this file and ctor_bridge.cpp. If one ever does the
+// duplicate is a link error, which is loud -- not a silent divergence.
+#include <new>
+
+extern "C" void _ZN6Memory16operator_delete2EPv(void *ptr)
+{
+    ::operator delete(ptr);
+}

--- a/port/hal/shims.cpp
+++ b/port/hal/shims.cpp
@@ -1,7 +1,5 @@
 // Host-side definitions for symbols the slice references but whose NDS
 // definitions cannot serve an MSVC build.
-#include <new>
-
 #include "Fader.h"
 #include "FaderBrightness.h"
 
@@ -40,22 +38,8 @@ extern "C" void _Z14ApproachLinearRiii(Fix12i *value, Fix12i target, Fix12i step
     (void)ApproachLinear(*value, target, step);
 }
 
-// include/Fader.h:69 -- and sixteen other headers -- spell Memory::operator_delete2
-// as an extern "C" Itanium symbol and call it from an inline operator delete, so
-// every class in those hierarchies emits a reference to that spelling. On the NDS
-// link the mangled string IS the symbol; MSVC decorates it as a cdecl name that
-// needs a real definition.
-//
-// port/hal/ctor_bridge.cpp defines it for the model-family targets by forwarding to
-// Memory::Deallocate. Gate 1 links no Memory layer, so forwarding there would only
-// trade one unresolved symbol for another. It forwards to the host global instead,
-// which is what the ROM function does in any case: a three-word tail call to _ZdlPv,
-// the global operator delete (see src/_ZN6Memory16operator_delete2EPv.cpp, which is
-// excluded from the slice with the other *D0Ev TUs).
-//
-// No target links both this file and ctor_bridge.cpp. If one ever does, the duplicate
-// is a link error, which is loud -- not a silent divergence between the two routes.
-extern "C" void _ZN6Memory16operator_delete2EPv(void *ptr)
-{
-    ::operator delete(ptr);
-}
+// Memory::operator_delete2 -- referenced from include/Fader.h's inline operator
+// delete, and so from every Fader class here -- is defined in hal/mem_delete2.cpp.
+// It lived here first; smoke_roots and smoke_fs then needed the same definition,
+// and a per-target copy of a definition that is not target-specific is the thing
+// the move avoids.

--- a/port/slice_gate2.txt
+++ b/port/slice_gate2.txt
@@ -34,3 +34,24 @@ src/_ZN18NestedHeapIterator4NextEP13HeapAllocator.cpp
 src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.cpp
 src/_ZN18NestedHeapIterator8PreviousEP13HeapAllocator.cpp
 src/_ZN18NestedHeapIterator6RemoveEP13HeapAllocator.cpp
+
+# The seven allocator entry points the ExpandingHeap overrides forward to. They
+# arrive with those overrides (slice_gate3a.txt) rather than because gate 2 grew:
+# each V* method is a one-line call into this layer, so a host link that has the
+# override and not its target has half of a pair. They stay HERE because this is
+# the allocator layer's manifest and smoke_heap links it, which is the gate that
+# would catch a break in them first.
+src/_ZN13HeapAllocator7DestroyEv.cpp
+src/_ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j.cpp
+src/_ZN22ExpandingHeapAllocator13DeallocateAllEPFvPvPS_jEj.cpp
+src/_ZN22ExpandingHeapAllocator10ReallocateEPvj.cpp
+src/_ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi.cpp
+src/_ZN22ExpandingHeapAllocator9SetNodeIDEj.cpp
+src/_ZN22ExpandingHeapAllocator9GetNodeIDEv.cpp
+src/_ZN13HeapAllocator6RemoveEv.cpp
+
+# cstd::abs, which ExpandingHeapAllocator::MaxAllocatableSize calls. It was in
+# slice_gate4b.txt and moved here rather than being listed twice: the nine targets
+# that link gate 4b all link gate 2 as well, so two entries would be a duplicate
+# definition, and the layer that needs it first is this one.
+src/_ZN4cstd3absEi.cpp

--- a/port/slice_gate3a.txt
+++ b/port/slice_gate3a.txt
@@ -20,3 +20,31 @@ src/_ZN6Memory10DeallocateEPvP4Heap.cpp
 src/_ZN4Heap8AllocateEji.cpp
 src/_ZN4Heap10DeallocateEPv.cpp
 src/_ZN22ExpandingHeapAllocator10MemoryLeftEv.cpp
+
+# The ten remaining ExpandingHeap overrides, and one destructor definition per
+# class. Not new host coverage that was chosen -- MSVC EMITS THE VTABLE in the
+# translation unit that defines the constructor, and a vtable needs the ADDRESS
+# of every slot, so the four overrides above were never a linkable subset. On the
+# NDS each of these files is its own object and the ROM's table is already built,
+# so nothing forced the question there. This is the whole class: Heap declares
+# fourteen pure virtuals and ExpandingHeap overrides all fourteen.
+src/_ZN13ExpandingHeap8VDestroyEv.cpp
+src/_ZN13ExpandingHeap14VDeallocateAllEv.cpp
+src/_ZN13ExpandingHeap7VIntactEv.cpp
+src/_ZN13ExpandingHeap7VRescueEv.cpp
+src/_ZN13ExpandingHeap11VReallocateEPvj.cpp
+src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp
+src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp
+src/_ZN13ExpandingHeap10VSetNodeIDEj.cpp
+src/_ZN13ExpandingHeap10VGetNodeIDEv.cpp
+src/_ZN13ExpandingHeap12VResizeToFitEv.cpp
+
+# ONE destructor file per class, not the pair. src/_ZN4HeapD0Ev.cpp,
+# _ZN4HeapD1Ev.cpp and _ZN4HeapD2Ev.cpp each carry the SAME `Heap::~Heap() {}'
+# body -- that is the point of the D0/D1/D2 split, one definition delinked into
+# three ROM addresses -- and MSVC folds the variants into a single
+# ??1Heap@@UAE@XZ, so linking two of them is a duplicate-symbol error. D1 is
+# picked because it is the complete-object variant the host's own deleting
+# destructor calls. Same for ExpandingHeap.
+src/_ZN4HeapD1Ev.cpp
+src/_ZN13ExpandingHeapD1Ev.cpp

--- a/port/slice_gate4b.txt
+++ b/port/slice_gate4b.txt
@@ -51,7 +51,9 @@ src/func_020453c0.c
 src/func_0204547c.c
 src/func_020457f0.c
 src/func_020456a0.c
-src/_ZN4cstd3absEi.cpp
+# src/_ZN4cstd3absEi.cpp moved to slice_gate2.txt: the allocator layer needs it
+# too, and every target that links this slice links gate 2 as well, so listing it
+# in both would be a duplicate definition.
 src/_ZN9Animation8LoadFileER13SharedFilePtr.cpp
 src/_ZN9Animation17UpdateFileOffsetsER8BCA_File.cpp
 


### PR DESCRIPTION
Third and last of the port-CI stack. #2372 added the gate, #2373 made `smoke` link, and this makes the remaining three link so the workflow can gate all five ROM-free targets instead of three-fifths of them.

`smoke_heap`, `smoke_roots` and `smoke_fs` shipped in #2372 as a reporting step, with 3, 17 and 17 unresolved symbols on a 32-bit MSVC host. Tango asked for all three, gating rather than deferred. All five link now, from a clean configure, with zero warnings, and the reporting step is deleted -- a workflow with a permanently-red half teaches people to skip the whole thing.

## What the 17 actually were

Three shapes. None was a missing implementation: every file this adds already existed and already byte-matches.

**MSVC emits a vtable where mwccarm does not.** Once a constructor is a real C++ constructor, its TU becomes the vtable's key function on the host too, and a vtable needs the address of every slot. `slice_gate3a`'s four `ExpandingHeap` overrides were therefore never a linkable subset: the class overrides all fourteen of `Heap`'s pure virtuals, and MSVC needs all fourteen or none. Ten more override files join the slice, one destructor definition per class, the seven allocator entry points those overrides forward into, and transitively `HeapAllocator::Remove` and `cstd::abs`. On the cartridge each of these is its own object against a table the ROM already holds, which is why nothing forced the question there.

One destructor file per class, not the pair: `_ZN4HeapD0Ev.cpp`, `D1` and `D2` carry the same `Heap::~Heap() {}` body -- that is what the D0/D1/D2 split *is* -- and MSVC folds the variants into a single `??1Heap@@UAE@XZ`, so listing two of them is a duplicate-symbol error.

**The Itanium spelling seam**, which is the part that will recur on every migration wave. A decomp header that says

```c
extern "C" void _ZN6Memory16operator_delete2EPv(void *);
```

is a complete reference to a real cartridge function and nothing at all to MSVC. Constructors are the sharpest case: `C1` is an ABI variant tag with no C++ syntax, so a hand-written function of that name is the only thing that can ever answer one. Four such bridges here -- `NestedHeapIterator`, `ExpandingHeapAllocator` and `MemoryNode::Target` in `hal/heap_globals.cpp`; `ExpandingHeap` in `hal/heap_vtable.cpp`, because `heap_globals.cpp` is also linked by `smoke_heap`, whose slice does not compile that class. All real forwarders, never `/alternatename` aliases: the two spellings are cdecl and `__thiscall`, and an alias across that boundary links quietly and then reads garbage as `this`.

**And one alias that had already gone bad exactly that way.** `heap_globals.cpp` aliased `?_ZN18NestedHeapIteratorC1Ej@@YAXPAXI@Z` onto the C spelling, which *was* a definition back when `src/_ZN18NestedHeapIteratorC1Ej.cpp` was C. That file is C++ now, so the alias named neither a symbol anyone referenced nor one anything defined. It survived because no gate built the target. This is the concrete answer to "is the C++ migration helping or hurting the port": it is not the migration, it is the absence of a build.

**Definitions parked in a per-target file.** `Memory::operator_delete2` was in `hal/shims.cpp`, which only `smoke` links; it moves to `hal/mem_delete2.cpp` rather than growing a third copy. `cstd::abs`'s forwarder moves from `hal/gx_upload_bridge.cpp` to `hal/heap_globals.cpp` and `src/_ZN4cstd3absEi.cpp` from `slice_gate4b.txt` to `slice_gate2.txt` -- safe because every target that links gate 4b or `gx_upload_bridge` links gate 2 and `heap_globals` as well. `hal/ctor_bridge.cpp` keeps its own `operator_delete2`: it routes through `Memory::Deallocate` rather than the global operator delete, which is a different decision with its own targets, not a copy to fold in.

## What was verified

- Clean configure and build, 32-bit MSVC 19.51, Ninja: `smoke`, `smoke_gx`, `smoke_heap`, `smoke_roots`, `smoke_fs` all link. Zero warnings.
- `tools/port_refcheck.py`: 423 references (249 + 21 + 153), 0 stale.
- The nine ROM-dependent targets cannot be built here or in CI. They were checked statically for the two ways this change could reach them -- duplicate manifest entries across slices, and duplicate `hal/` definitions -- and have neither.
- `BUILD_TESTING=OFF`, no ctest. This claims compile-and-link, not behaviour.

## Deliberately not done

`hal/heap_vtable.cpp`'s synthetic `_ZTV13ExpandingHeap` still traps the ten slots whose bodies this change makes available. Seating them runs straight into the destructor-pair slot skew measured on `port/link100` (`stage_lifecycle_map.txt` sections 16-17: mwccarm gives `virtual ~X()` two vtable entries and MSVC folds them into one, so every virtual declared after it sits one slot early against a ROM-ordered table -- the live `Heap::ResizeToFit` returning a node ID is exactly this). That is a lane with a proof of its own, not a rider on a link fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4FxdKHG3a6hQRYRAbx29c
