### PR TITLE
Phase 5: Add overlay and data links in provenance documentation, biggest one yet

### DIFF
--- a/notes/ghidra-dsd-landscape.md
+++ b/notes/ghidra-dsd-landscape.md
@@ -33,7 +33,7 @@ Files\Microsoft\jdk-11.0.16.101-hotspot`); Ghidra 11.x needs JDK 21. Whatever pr
 the historical `ghidra_out` drafts ran elsewhere or has been removed.
 
 **G1.5 — The historical verdict on raw Ghidra drafts is mixed, and recorded.** [high]
-`CLAIMS.md` cites them by name both ways: a win ([ov102](../config/arm9/overlays/ov102/symbols.txt) [func_ov102_0214b53c](../src/func_ov102_0214b53c.c) — "Ghidra
+`CLAIMS.md` cites them by name both ways: a win ([ov102](../config/arm9/overlays/ov102/symbols.txt) [func_ov102_0214b53c](../src/actors/daBmb_c.cpp) — "Ghidra
 dest + ROM-order angle" → byte-identical) and repeated losses ([ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_020dbe9c](../src/func_ov006_020dbe9c.c) — "Ghidra missed s64 matrix"; [arm9](../config/arm9/symbols.txt) `OAM::Render` — "Ghidra dump div=999 (frame 0x44)";
 [ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_0211e72c](../src/actors/dScMgTeresa_c.cpp) — "Ghidra-shaped 30w attractor" that*stalls* at 26 words).
 `README.md:102` states the house position: useful for reading a function, "its output
@@ -540,7 +540,7 @@ extension links `cpp_demangle`):
 
 | function | callees in the draft |
 |---|---|
-| [func_ov102_0214b53c](../src/func_ov102_0214b53c.c) | `Matrix4x3_FromRotationY`, `MulMat4x3Mat4x3`, `Vec3_Lsl`, `Vec3_LslInPlace`, `IsFrontSliding`, `LostGrabbedObject`, `UpdateCarry`, [func_ov002_020e496c](../src/func_ov002_020e496c.c) |
+| [func_ov102_0214b53c](../src/actors/daBmb_c.cpp) | `Matrix4x3_FromRotationY`, `MulMat4x3Mat4x3`, `Vec3_Lsl`, `Vec3_LslInPlace`, `IsFrontSliding`, `LostGrabbedObject`, `UpdateCarry`, [func_ov002_020e496c](../src/func_ov002_020e496c.c) |
 | `OAM::Render` | `GetObjWidth`, `GetObjHeight`, `LoadAffineParams`, `fdiv` — and the function itself comes back as `OAM::Render(...)` with 10 parameters, not `FUN_02020994` |
 | [func_ov006_020dbe9c](../src/func_ov006_020dbe9c.c) | [func_ov004_020b023c](../src/func_ov004_020b023c.cpp) — **correctly attributed to [ov004](../config/arm9/overlays/ov004/symbols.txt)** |
 
@@ -549,7 +549,7 @@ says `MulMat4x3Mat4x3(...)` tells the LLM tier what the function *is*, where
 `FUN_020b1234(...)` tells it nothing.
 
 **G9.3 — Types: unchanged. SyncDsd carries no layout information.** [high]
-[func_ov102_0214b53c](../src/func_ov102_0214b53c.c) still decompiles to 64 `undefined*` types and 67 raw
+[func_ov102_0214b53c](../src/actors/daBmb_c.cpp) still decompiles to 64 `undefined*` types and 67 raw
 `*(int *)(param_1 + 0xNN)` field accesses, with the signature `void f(int param_1)`.
 That is expected — dsd's config has symbols and relocations, not struct definitions, so
 there is nothing for SyncDsd to import. Class layouts would have to come from our own

--- a/notes/ghidra-dsd-landscape.md
+++ b/notes/ghidra-dsd-landscape.md
@@ -35,8 +35,7 @@ the historical `ghidra_out` drafts ran elsewhere or has been removed.
 **G1.5 — The historical verdict on raw Ghidra drafts is mixed, and recorded.** [high]
 `CLAIMS.md` cites them by name both ways: a win ([ov102](../config/arm9/overlays/ov102/symbols.txt) [func_ov102_0214b53c](../src/func_ov102_0214b53c.c) — "Ghidra
 dest + ROM-order angle" → byte-identical) and repeated losses ([ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_020dbe9c](../src/func_ov006_020dbe9c.c) — "Ghidra missed s64 matrix"; [arm9](../config/arm9/symbols.txt) `OAM::Render` — "Ghidra dump div=999 (frame 0x44)";
-— "Ghidra missed s64 matrix"; [arm9](../config/arm9/symbols.txt) `OAM::Render` — "Ghidra dump div=999 (frame 0x44)";
-[ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_0211e72c](../src/actors/dScMgTeresa_c.cpp) — "Ghidra-shaped 30w attractor" that *stalls* at 26 words).
+[ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_0211e72c](../src/actors/dScMgTeresa_c.cpp) — "Ghidra-shaped 30w attractor" that*stalls* at 26 words).
 `README.md:102` states the house position: useful for reading a function, "its output
 never matches on its own."
 

--- a/notes/ghidra-dsd-landscape.md
+++ b/notes/ghidra-dsd-landscape.md
@@ -472,15 +472,15 @@ evidence is already in the tree.
 
 | target | candidates | unambiguous calls from the callers | verdict |
 |---|---|---|---|
-| `0x020aed98` | 2, 7 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **1289** / [ov007](../config/arm9/overlays/ov007/symbols.txt) 6 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
-| `0x020aea30` | 2, 4 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **387** / [ov004](../config/arm9/overlays/ov004/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
-| `0x020adc74` | 3, 4 | [ov003](../config/arm9/overlays/ov003/symbols.txt) 0 / [ov004](../config/arm9/overlays/ov004/symbols.txt) **993** | **[ov004](../config/arm9/overlays/ov004/symbols.txt)** |
-| `0x020ada40` | 2, 4 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **545** / [ov004](../config/arm9/overlays/ov004/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
-| `0x020ad660` | 2,3,4,7 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **139** / others 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
-| `0x020efaf0` | 2, 6 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **104** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
-| `0x020effb8` | 2, 6 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **148** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 5 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
-| `0x020aa420` | 0, 1 | [ov000](../config/arm9/overlays/ov000/symbols.txt) 1 / [ov001](../config/arm9/overlays/ov001/symbols.txt) **7** | **[ov001](../config/arm9/overlays/ov001/symbols.txt)** (weak) |
-| `0x020ca78c` | 2, 6 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **53** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020aed98` | 2, 7 | **[ov002](../config/arm9/overlays/ov002/symbols.txt) **1289** / [ov007](../config/arm9/overlays/ov007/symbols.txt) 6** | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020aea30` | 2, 4 | **[ov002](../config/arm9/overlays/ov002/symbols.txt) **387** / [ov004](../config/arm9/overlays/ov004/symbols.txt) 0** | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020adc74` | 3, 4 | **[ov003](../config/arm9/overlays/ov003/symbols.txt) 0** / [ov004](../config/arm9/overlays/ov004/symbols.txt) **993** | **[ov004](../config/arm9/overlays/ov004/symbols.txt)** |
+| `0x020ada40` | 2, 4 | **[ov002](../config/arm9/overlays/ov002/symbols.txt) **545** / [ov004](../config/arm9/overlays/ov004/symbols.txt) 0** | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020ad660` | 2,3,4,7 | **[ov002](../config/arm9/overlays/ov002/symbols.txt) 139 / others 0** | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020efaf0` | 2, 6 | **[ov002](../config/arm9/overlays/ov002/symbols.txt) **104** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 0** | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020effb8` | 2, 6 | **[ov002](../config/arm9/overlays/ov002/symbols.txt) **148** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 5** | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020aa420` | 0, 1 | **[ov000](../config/arm9/overlays/ov000/symbols.txt) 1** / [ov001](../config/arm9/overlays/ov001/symbols.txt) **7** | **[ov001](../config/arm9/overlays/ov001/symbols.txt) (weak)** |
+| `0x020ca78c` | 2, 6 | **[ov002](../config/arm9/overlays/ov002/symbols.txt) **53** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 0** | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
 | `0x02123804` | 77,78,79,80 | all zero | **inconclusive** |
 
 **G8.1 — `0x020aed98` is confirmed twice over.** [high] Co-residency gives [ov002](../config/arm9/overlays/ov002/symbols.txt) 1289-to-6,

--- a/notes/ghidra-dsd-landscape.md
+++ b/notes/ghidra-dsd-landscape.md
@@ -33,10 +33,10 @@ Files\Microsoft\jdk-11.0.16.101-hotspot`); Ghidra 11.x needs JDK 21. Whatever pr
 the historical `ghidra_out` drafts ran elsewhere or has been removed.
 
 **G1.5 — The historical verdict on raw Ghidra drafts is mixed, and recorded.** [high]
-`CLAIMS.md` cites them by name both ways: a win (`ov102 func_ov102_0214b53c` — "Ghidra
-dest + ROM-order angle" → byte-identical) and repeated losses (`ov006 func_ov006_020dbe9c`
-— "Ghidra missed s64 matrix"; `arm9 OAM::Render` — "Ghidra dump div=999 (frame 0x44)";
-`ov006 func_ov006_0211e72c` — "Ghidra-shaped 30w attractor" that *stalls* at 26 words).
+`CLAIMS.md` cites them by name both ways: a win ([ov102](../config/arm9/overlays/ov102/symbols.txt) [func_ov102_0214b53c](../src/func_ov102_0214b53c.c) — "Ghidra
+dest + ROM-order angle" → byte-identical) and repeated losses ([ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_020dbe9c](../src/func_ov006_020dbe9c.c) — "Ghidra missed s64 matrix"; [arm9](../config/arm9/symbols.txt) `OAM::Render` — "Ghidra dump div=999 (frame 0x44)";
+— "Ghidra missed s64 matrix"; [arm9](../config/arm9/symbols.txt) `OAM::Render` — "Ghidra dump div=999 (frame 0x44)";
+[ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_0211e72c](../src/actors/dScMgTeresa_c.cpp) — "Ghidra-shaped 30w attractor" that *stalls* at 26 words).
 `README.md:102` states the house position: useful for reading a function, "its output
 never matches on its own."
 
@@ -172,7 +172,7 @@ so these are precisely the functions we'd expect to be present.
 **G4.4 — MEASURED: 39 signatures, 4 match, 5 symbols renamed, 3 genuinely new names.**
 [high] No Rust build was needed — `sig apply -s <path>` takes a YAML path, so the PR's
 files were fetched from `Yanis002/ds-decomp@signatures` (bb810e3) and dry-run one by one
-against `config/arm9/config.yaml`. (The PR holds **39** `.yaml` files, not the 43 a
+against [config/arm9/config.yaml](../config/arm9/config.yaml). (The PR holds **39** `.yaml` files, not the 43 a
 summary suggested.) `git status config` stayed clean throughout — `--dry` writes nothing.
 
 | outcome | count |
@@ -185,11 +185,11 @@ The five renames, against what our config calls those addresses today:
 
 | addr | module | our name now | signature says | verdict |
 |---|---|---|---|---|
-| `0x020731dc` | ARM9 | `func_020731dc` | `__register_global_object` | **new name** |
-| `0x020aa3f0` | ARM9 | `data_020aa3f0` (bss) | `__global_destructor_chain` | **new name** |
-| `0x02054430` | ARM9 | `func_02054430` | `GX_SetBankForLCDC` | **new name** |
-| `0x01ffa9dc` | ITCM | `__aeabi_uldiv` | `_ll_udiv` | **conflict** |
-| `0x02053abc` | ARM9 | `_ZN3GXS15SetGraphicsModeEi` | `GXS_SetGraphicsMode` | **conflict** |
+| `0x020731dc` | [ARM9](../config/arm9/symbols.txt) | [func_020731dc](../config/arm9/symbols.txt) | `__register_global_object` | **new name** |
+| `0x020aa3f0` | [ARM9](../config/arm9/symbols.txt) | [data_020aa3f0](../config/arm9/symbols.txt) (bss) | `__global_destructor_chain` | **new name** |
+| `0x02054430` | [ARM9](../config/arm9/symbols.txt) | [func_02054430](../config/arm9/symbols.txt) | `GX_SetBankForLCDC` | **new name** |
+| `0x01ffa9dc` | [ITCM](../config/arm9/itcm/symbols.txt) | [__aeabi_uldiv](../config/arm9/itcm/symbols.txt) | `_ll_udiv` | **conflict** |
+| `0x02053abc` | [ARM9](../config/arm9/symbols.txt) | [_ZN3GXS15SetGraphicsModeEi](../config/arm9/symbols.txt) | `GXS_SetGraphicsMode` | **conflict** |
 
 **G4.5 — The transitive-rename multiplier is ~1.25x, not the hoped-for fan-out.** [high]
 Only one signature (`__register_global_object`) renamed anything beyond its own function,
@@ -226,7 +226,7 @@ and keep the two conflicts out of the same commit as the three additions.
 
 ## 5. `dsd dump ambig-relocs` — MEASURED
 
-Run against `config/arm9/config.yaml`, read-only, ~seconds. **1,560 ambiguous
+Run against [config/arm9/config.yaml](../config/arm9/config.yaml), read-only, ~seconds. **1,560 ambiguous
 relocations** across 483 distinct containing symbols.
 
 By module — this is not evenly spread:
@@ -289,38 +289,38 @@ the good news — it is not 135 problems:
 
 | target | candidates | sites | matched fns |
 |---|---|---|---|
-| `0x020aed98` | overlays(2,7) | **57** | 57 |
-| `0x020aea30` | overlays(2,4) | 32 | 10 |
-| `0x020adc74` | overlays(3,4) | 22 | 3 |
-| `0x020ada40` | overlays(2,4) | 15 | 13 |
-| `0x020ad660` | overlays(2,3,4,7) | 3 | 3 |
-| `0x020efaf0` | overlays(2,6) | 2 | 2 |
+| `0x020aed98` | overlays([2](../config/arm9/overlays/ov002/symbols.txt),[7](../config/arm9/overlays/ov007/symbols.txt)) | **57** | 57 |
+| `0x020aea30` | overlays([2](../config/arm9/overlays/ov002/symbols.txt),[4](../config/arm9/overlays/ov004/symbols.txt)) | 32 | 10 |
+| `0x020adc74` | overlays([3](../config/arm9/overlays/ov003/symbols.txt),[4](../config/arm9/overlays/ov004/symbols.txt)) | 22 | 3 |
+| `0x020ada40` | overlays([2](../config/arm9/overlays/ov002/symbols.txt),[4](../config/arm9/overlays/ov004/symbols.txt)) | 15 | 13 |
+| `0x020ad660` | overlays([2](../config/arm9/overlays/ov002/symbols.txt),[3](../config/arm9/overlays/ov003/symbols.txt),[4](../config/arm9/overlays/ov004/symbols.txt),[7](../config/arm9/overlays/ov007/symbols.txt)) | 3 | 3 |
+| `0x020efaf0` | overlays([2](../config/arm9/overlays/ov002/symbols.txt),[6](../config/arm9/overlays/ov006/symbols.txt)) | 2 | 2 |
 | `0x020effb8`, `0x020aa420`, `0x02123804`, `0x020ca78c` | various | 1 each | 1 each |
 
 **Resolving `0x020aed98` alone settles 57 of the 135.** Its callers are the enemy
 `*_Spawn` family — `Wiggler_Spawn`, `Koopa_Spawn`, `ChainChomp_Spawn`, `Whomp_Spawn`,
 `PiranhaPlant_Spawn`, … — one call each, spread over ~30 overlays, every one of them
 already matched and named. It is one shared spawn helper, called the same way everywhere,
-that dsd cannot attribute to overlay 2 or overlay 7.
+that dsd cannot attribute to [overlay 2](../config/arm9/overlays/ov002/symbols.txt) or [overlay 7](../config/arm9/overlays/ov007/symbols.txt).
 
 The next three (`0x020aea30`, `0x020adc74`, `0x020ada40`) account for another 69. Four
 addresses cover 126 of 135.
 
-**G5.4 — The data side is dominated by two tables.** [high] `data_02090864` alone
-accounts for **244** entries and `data_02092208` for 51; the rest of the top-12 are ten
+**G5.4 — The data side is dominated by two tables.** [high] [data_02090864](../config/arm9/symbols.txt) alone
+accounts for **244** entries and [data_02092208](../config/arm9/symbols.txt) for 51; the rest of the top-12 are ten
 `data_ov006_*` blocks at 21-23 each. A 244-entry ambiguous run at one address is a
 function-pointer table, not 244 independent problems.
 
-**G5.5 — Overlay 6 holds 706 of the 1,560, and `overlays(0,4)` alone is 626.** [high]
-ov006 is the minigame overlay and the most-worked module in the tree. Its share is one
+**G5.5 — [Overlay 6](../config/arm9/overlays/ov006/symbols.txt) holds 706 of the 1,560, and overlays([0](../config/arm9/overlays/ov000/symbols.txt),[4](../config/arm9/overlays/ov004/symbols.txt)) alone is 626.** [high]
+[ov006](../config/arm9/overlays/ov006/symbols.txt) is the minigame overlay and the most-worked module in the tree. Its share is one
 structural cause, not 706 scattered defects.
 
 **G5.6 — CORRECTION: these are NOT 135 latent fakematches. 60 are provably safe.**
 [high] I initially framed every ambiguous call site in a matched function as a possible
 fakematch. Checking what the callers actually reference refutes that for 60 of the 135.
 `src/Wiggler_Spawn.c` declares `extern void _ZN5EnemyC2Ev(void);` and calls it **by
-name**. Only ov002 defines that symbol, so mwldarm pins the callee at link time
-regardless of what `relocs.txt` says. The ambiguity is dsd's own bookkeeping — it
+name**. Only [ov002](../config/arm9/overlays/ov002/symbols.txt) defines that symbol, so mwldarm pins the callee at link time
+regardless of what [relocs.txt](../config/arm9/overlays/ov002/relocs.txt) says. The ambiguity is dsd's own bookkeeping — it
 governs the gap objects dsd supplies for undecompiled code, not a name-resolved call.
 
 Breaking the 135 down by how the caller pins its callee:
@@ -331,22 +331,21 @@ Breaking the 135 down by how the caller pins its callee:
 | **no candidate name appears in the source at all** | **75** |
 | raw address literal | 0 |
 
-Of the 60 safe ones, 57 are `0x020aed98 → ov002 _ZN5EnemyC2Ev` (`Enemy::Enemy()`,
-size 0x24). The rival at that address is `func_ov007_020aed98`, size 0x1e0 — a
+Of the 60 safe ones, 57 are `0x020aed98 →` [ov002](../config/arm9/overlays/ov002/symbols.txt) `_ZN5EnemyC2Ev` (`Enemy::Enemy()`,
+size 0x24). The rival at that address is [func_ov007_020aed98](../src/func_ov007_020aed98.cpp), size 0x1e0 — a
 480-byte function, obviously not a base constructor. **The top ambiguity is settled:
-overlay 2, for all 57.** That is consistent with the bounded enemy-subclass family in
+[overlay 2](../config/arm9/overlays/ov002/symbols.txt), for all 57.** That is consistent with the bounded enemy-subclass family in
 `[[enemy-subclass-census]]`.
 
 **G5.7 — The other 75 ARE the phantom-reference worklist, and this explains its cause.**
-[high] `src/func_ov006_02115b0c.c:59` declares:
+[high] [func_ov006_02115b0c](../src/func_ov006_02115b0c.c):59 declares:
 
 ```c
 extern void *func_020adc74(void *p);
 ```
 
 There is no `func_020adc74` in any `symbols.txt`. The real symbols at that address are
-`func_ov003_020adc74` and `func_ov004_020adc74`. The author could not tell which overlay
-owned the target, so they wrote a **module-less placeholder** — which resolves to
+[func_ov003_020adc74](../src/func_ov003_020adc74.cpp) and [func_ov004_020adc74](../src/func_ov004_020adc74.c). The author could not tell which overlay owned the target, so they wrote a **module-less placeholder** — which resolves to
 nothing. Checking the ten ambiguous call targets against
 `config/unresolved-baseline.json`: **nine of ten are present as module-less phantom
 names** (all but `func_020aed98`, which is the one already correctly named).
@@ -368,13 +367,13 @@ and much smaller issue than the 1,560 above — "no candidate at all" rather tha
 candidates" — but it is being hidden rather than triaged. 11 lines is cheap to just fix
 or explicitly bless.
 
-**G5.2 — The data side is dominated by two tables.** [high] `data_02090864` alone
-accounts for **244** entries and `data_02092208` for 51; the rest of the top-12 are ten
+**G5.2 — The data side is dominated by two tables.** [high] [data_02090864](../config/arm9/symbols.txt) alone
+accounts for **244** entries and [data_02092208](../config/arm9/symbols.txt) for 51; the rest of the top-12 are ten
 `data_ov006_*` blocks at 21-23 each. A 244-entry ambiguous run at one address is a
 function-pointer table (overlay dispatch, most likely), not 244 independent problems.
 Fixing the table's type would collapse a sixth of the whole list.
 
-**G5.3 — Overlay 6's 706 is a concentration, not a diffusion.** [medium] ov006 is the
+**G5.3 — [Overlay 6](../config/arm9/overlays/ov006/symbols.txt)'s 706 is a concentration, not a diffusion.** [medium] ov006 is the
 minigame overlay and is already the most-worked module in the tree. Its ambiguity share
 being 45% suggests one structural cause (the `data_ov006_*` table family above) rather
 than 706 scattered defects.
@@ -394,7 +393,7 @@ Output preserved at `scratchpad/ambig-relocs.txt` (1,560 lines,
    confirmed working, but the extension is GUI-only, so the decompiler A/B is blocked
    on a GUI session rather than on the install.
 4. **Resolve the ten ambiguous call targets** (G5.6-G5.7). Highest-value item now, and
-   it needs no Ghidra: `0x020aed98` is already settled (ov002 `Enemy::Enemy()`, 57
+   it needs no Ghidra: `0x020aed98` is already settled ([ov002](../config/arm9/overlays/ov002/symbols.txt) `Enemy::Enemy()`, 57
    sites), and the other nine are the same question. Each resolution turns a
    module-less phantom extern into a real symbol across 6-12 files at once.
 5. Only if (3) unblocks: re-point `tools/ghidra/DecompDump.java` at a SyncDsd'd project
@@ -474,49 +473,40 @@ evidence is already in the tree.
 
 | target | candidates | unambiguous calls from the callers | verdict |
 |---|---|---|---|
-| `0x020aed98` | 2, 7 | ov002 **1289** / ov007 6 | **ov002** |
-| `0x020aea30` | 2, 4 | ov002 **387** / ov004 0 | **ov002** |
-| `0x020adc74` | 3, 4 | ov003 0 / ov004 **993** | **ov004** |
-| `0x020ada40` | 2, 4 | ov002 **545** / ov004 0 | **ov002** |
-| `0x020ad660` | 2,3,4,7 | ov002 **139** / others 0 | **ov002** |
-| `0x020efaf0` | 2, 6 | ov002 **104** / ov006 0 | **ov002** |
-| `0x020effb8` | 2, 6 | ov002 **148** / ov006 5 | **ov002** |
-| `0x020aa420` | 0, 1 | ov000 1 / ov001 **7** | **ov001** (weak) |
-| `0x020ca78c` | 2, 6 | ov002 **53** / ov006 0 | **ov002** |
+| `0x020aed98` | 2, 7 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **1289** / [ov007](../config/arm9/overlays/ov007/symbols.txt) 6 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020aea30` | 2, 4 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **387** / [ov004](../config/arm9/overlays/ov004/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020adc74` | 3, 4 | [ov003](../config/arm9/overlays/ov003/symbols.txt) 0 / [ov004](../config/arm9/overlays/ov004/symbols.txt) **993** | **[ov004](../config/arm9/overlays/ov004/symbols.txt)** |
+| `0x020ada40` | 2, 4 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **545** / [ov004](../config/arm9/overlays/ov004/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020ad660` | 2,3,4,7 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **139** / others 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020efaf0` | 2, 6 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **104** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020effb8` | 2, 6 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **148** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 5 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
+| `0x020aa420` | 0, 1 | [ov000](../config/arm9/overlays/ov000/symbols.txt) 1 / [ov001](../config/arm9/overlays/ov001/symbols.txt) **7** | **[ov001](../config/arm9/overlays/ov001/symbols.txt)** (weak) |
+| `0x020ca78c` | 2, 6 | [ov002](../config/arm9/overlays/ov002/symbols.txt) **53** / [ov006](../config/arm9/overlays/ov006/symbols.txt) 0 | **[ov002](../config/arm9/overlays/ov002/symbols.txt)** |
 | `0x02123804` | 77,78,79,80 | all zero | **inconclusive** |
 
-**G8.1 — `0x020aed98` is confirmed twice over.** [high] Co-residency gives ov002 1289-to-6,
-with 30 of 31 calling modules calling ov002 and nothing else. Independently, the ov002
-symbol is `_ZN5EnemyC2Ev` (`Enemy::Enemy()`, size 0x24) and 57 `*_Spawn` callers name it
-explicitly, while the ov007 rival is a 0x1e0-byte function. Two independent lines agree.
+**G8.1 — `0x020aed98` is confirmed twice over.** [high] Co-residency gives [ov002](../config/arm9/overlays/ov002/symbols.txt) 1289-to-6,
+with 30 of 31 calling modules calling [ov002](../config/arm9/overlays/ov002/symbols.txt) and nothing else. Independently, the [ov002](../config/arm9/overlays/ov002/symbols.txt) symbol is `_ZN5EnemyC2Ev` (`Enemy::Enemy()`, size 0x24) and 57 `*_Spawn` callers name it
+explicitly, while the [ov007](../config/arm9/overlays/ov007/symbols.txt) rival is a 0x1e0-byte function. Two independent lines agree.
 
 **G8.2 — `0x020ada40` exposes one wrong reference in a byte-matching file.** [medium-high]
 All fifteen call sites live in overlays whose unambiguous calls go **exclusively** to
-ov002 — ov062 66/0, ov063 42/0, ov064 69/0, ov065 93/0, ov081 42/0, ov084 65/0, ov090
-29/0, ov100 53/0, ov102 86/0. Twelve callers write the phantom `func_020ada40`. One does
-not: **`func_ov081_02123910` names `_ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player`,
-which is the ov004 symbol** — while ov081's own evidence is 42 calls to ov002 and zero to
-ov004. The file byte-matches, because both candidates sit at the same address.
+[ov002](../config/arm9/overlays/ov002/symbols.txt) — [ov062](../config/arm9/overlays/ov062/symbols.txt) 66/0, [ov063](../config/arm9/overlays/ov063/symbols.txt) 42/0, [ov064](../config/arm9/overlays/ov064/symbols.txt) 69/0, [ov065](../config/arm9/overlays/ov065/symbols.txt) 93/0, [ov081](../config/arm9/overlays/ov081/symbols.txt) 42/0, [ov084](../config/arm9/overlays/ov084/symbols.txt) 65/0, [ov090](../config/arm9/overlays/ov090/symbols.txt) 29/0, [ov100](../config/arm9/overlays/ov100/symbols.txt) 53/0, [ov102](../config/arm9/overlays/ov102/symbols.txt) 86/0. Twelve callers write the phantom `func_020ada40`. One does not: **[func_ov081_02123910](../config/arm9/overlays/ov081/symbols.txt)** names `_ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player`, which is the **[ov004](../config/arm9/overlays/ov004/symbols.txt) symbol** — while [ov081](../config/arm9/overlays/ov081/symbols.txt)'s own evidence is 42 calls to [ov002](../config/arm9/overlays/ov002/symbols.txt) and zero to [ov004](../config/arm9/overlays/ov004/symbols.txt). The file byte-matches, because both candidates sit at the same address.
 
 Two readings, and choosing between them is a human call:
-- the *reference* is wrong and should point at ov002's `func_ov002_020ada40` (size 0x100); or
-- ov002 and ov004 are two variants of the same enemy-base code, the *name* is right but
-  attached to the ov004 copy, and ov002's copy should carry the name too.
+- the *reference* is wrong and should point at [ov002](../config/arm9/overlays/ov002/symbols.txt)'s [func_ov002_020ada40](../config/arm9/overlays/ov002/symbols.txt) (size 0x100, part of [Enemy](../src_tu/actors/Enemy.cpp)); or
+- [ov002](../config/arm9/overlays/ov002/symbols.txt) and [ov004](../config/arm9/overlays/ov004/symbols.txt) are two variants of the same enemy-base code, the *name* is right but
+  attached to the [ov004](../config/arm9/overlays/ov004/symbols.txt) copy, and [ov002](../config/arm9/overlays/ov002/symbols.txt)'s copy should carry the name too.
 
-Note the sizes differ — 0x100 (ov002) vs 0xbc (ov004) — which argues against a
-straight duplicate and so favours the first reading. Either way, a matched file currently
+Note the sizes differ — 0x100 ([ov002](../config/arm9/overlays/ov002/symbols.txt)) vs 0xbc ([ov004](../config/arm9/overlays/ov004/symbols.txt)) — which argues against a straight duplicate and so favours the first reading. Either way, a matched file currently
 references a symbol its own module never otherwise calls.
 
-**G8.3 — `0x02123804` stays open.** [high] Its single caller `func_ov002_020ec670` makes
-no unambiguous call to any of ov077/078/079/080, so co-residency says nothing. The ov080
-candidate is named (`_ZN13MontyMoleRockD0Ev`, size 0x54) and the others are placeholders
+**G8.3 — `0x02123804` stays open.** [high] Its single caller [func_ov002_020ec670](../src/func_ov002_020ec670.c) makes
+no unambiguous call to any of [ov077](../config/arm9/overlays/ov077/symbols.txt)/[ov078](../config/arm9/overlays/ov078/symbols.txt)/[ov079](../config/arm9/overlays/ov079/symbols.txt)/[ov080](../config/arm9/overlays/ov080/symbols.txt), so co-residency says nothing. The [ov080](../config/arm9/overlays/ov080/symbols.txt) candidate is named (`_ZN13MontyMoleRockD0Ev`, size 0x54) and the others are placeholders
 of size 0x8 / 0x60 / 0x288. Needs different evidence — a call-shape or runtime check.
 
-**G8.4 — Ghidra independently corroborates the ov006 → ov004 verdict.** [high] See §9:
-the SyncDsd'd decompilation of `func_ov006_020dbe9c` names its callee
-`func_ov004_020b023c`. That is a third, independent line of evidence for ov006
-co-residing with ov004 rather than ov003 — arrived at through the imported relocation
-table rather than through the `relocs.txt` histogram.
+**G8.4 — Ghidra independently corroborates the [ov006](../config/arm9/overlays/ov006/symbols.txt) → [ov004](../config/arm9/overlays/ov004/symbols.txt) verdict.** [high] See §9:
+the SyncDsd'd decompilation of [func_ov006_020dbe9c](../src/func_ov006_020dbe9c.c) names its callee
+[func_ov004_020b023c](../src/func_ov004_020b023c.cpp). That is a third, independent line of evidence for [ov006](../config/arm9/overlays/ov006/symbols.txt) co-residing with [ov004](../config/arm9/overlays/ov004/symbols.txt) rather than [ov003](../config/arm9/overlays/ov003/symbols.txt) — arrived at through the imported relocation table rather than through the `relocs.txt` histogram.
 
 **G8.5 — Applying these is a symbol-rename change, with the usual hazards.** [high]
 Nine resolutions convert module-less phantom externs into real symbols across 6-12 files
@@ -542,8 +532,8 @@ analyzeHeadless C:\tools\ghidra_proj sm64ds -process sm64.nds -noanalysis `
 **G9.1 — The sync is essentially complete.** [high] `ListBlocks` reports **486 memory
 blocks** and **11,382 functions** against the 11,394 `kind:function` symbols in the dsd
 config — a 99.9% import. Overlays land in their own address spaces, and the ambiguity of
-§5 is directly visible in the memory map: `arm9_ov002::020ad660` and
-`arm9_ov003::020ad660` both exist.
+§5 is directly visible in the memory map: `arm9_ov002::`[020ad660](../src/func_ov002_020ad660.cpp) and
+`arm9_ov003::`[020ad660](../config/arm9/overlays/ov003/symbols.txt) both exist.
 
 **G9.2 — Names: transformed. Zero `FUN_xxxxxxxx` in any of the three drafts.** [high]
 Every callee carries its real dsd name, and C++ symbols come back demangled (the
@@ -551,23 +541,23 @@ extension links `cpp_demangle`):
 
 | function | callees in the draft |
 |---|---|
-| `func_ov102_0214b53c` | `Matrix4x3_FromRotationY`, `MulMat4x3Mat4x3`, `Vec3_Lsl`, `Vec3_LslInPlace`, `IsFrontSliding`, `LostGrabbedObject`, `UpdateCarry`, `func_ov002_020e496c` |
+| [func_ov102_0214b53c](../src/func_ov102_0214b53c.c) | `Matrix4x3_FromRotationY`, `MulMat4x3Mat4x3`, `Vec3_Lsl`, `Vec3_LslInPlace`, `IsFrontSliding`, `LostGrabbedObject`, `UpdateCarry`, [func_ov002_020e496c](../src/func_ov002_020e496c.c) |
 | `OAM::Render` | `GetObjWidth`, `GetObjHeight`, `LoadAffineParams`, `fdiv` — and the function itself comes back as `OAM::Render(...)` with 10 parameters, not `FUN_02020994` |
-| `func_ov006_020dbe9c` | `func_ov004_020b023c` — **correctly attributed to ov004** |
+| [func_ov006_020dbe9c](../src/func_ov006_020dbe9c.c) | [func_ov004_020b023c](../src/func_ov004_020b023c.cpp) — **correctly attributed to [ov004](../config/arm9/overlays/ov004/symbols.txt)** |
 
 This is the whole delta over the old raw-binary path, and it is a real one: a draft that
 says `MulMat4x3Mat4x3(...)` tells the LLM tier what the function *is*, where
 `FUN_020b1234(...)` tells it nothing.
 
 **G9.3 — Types: unchanged. SyncDsd carries no layout information.** [high]
-`func_ov102_0214b53c` still decompiles to 64 `undefined*` types and 67 raw
+[func_ov102_0214b53c](../src/func_ov102_0214b53c.c) still decompiles to 64 `undefined*` types and 67 raw
 `*(int *)(param_1 + 0xNN)` field accesses, with the signature `void f(int param_1)`.
 That is expected — dsd's config has symbols and relocations, not struct definitions, so
 there is nothing for SyncDsd to import. Class layouts would have to come from our own
 headers via Ghidra's data-type manager, which nothing currently does.
 
-**G9.4 — The specific historical miss is still missed.** [high] `CLAIMS.md` records
-`ov006 func_ov006_020dbe9c` as "Ghidra missed s64 matrix". The SyncDsd'd draft is:
+**G9.4 — The specific historical miss is still missed.** [high] [CLAIMS.md](../CLAIMS.md) records
+[ov006](../config/arm9/overlays/ov006/symbols.txt) [func_ov006_020dbe9c](../src/func_ov006_020dbe9c.c) as "Ghidra missed s64 matrix". The SyncDsd'd draft is:
 
 ```c
 void func_ov006_020dbe9c(int param_1) {
@@ -612,21 +602,15 @@ against `origin/chaos-data:langmode-baseline.json` reports
 change and re-running on the clean tree gives the **identical** numbers, so the ratchet
 is stuck on main. This is the `[[stale-baseline-gates]]` case; reproduce before owning.
 
-**G10.2 — CORRECTION to G8.2: `func_ov081_02123910` is not a landed fakematch.** [high]
+**G10.2 — CORRECTION to G8.2: [func_ov081_02123910](../src/func_ov081_02123910.cpp) is not a landed fakematch.** [high]
 It is `reason: "compile failed"` in the eligibility report —
-`func_ov081_02123910.cpp:31: illegal function overloading` under 2004/b56. It is not
-eligible, not enrolled, and not in the build, so its reference to the ov004 symbol has
-never affected a byte. It is a latent problem in an unbuildable file, which is exactly
+`func_ov081_02123910.cpp:31: illegal function overloading` under 2004/b56. 
+It is not eligible, not enrolled, and not in the build, so its reference to the [ov004](../config/arm9/overlays/ov004/symbols.txt) symbol has never affected a byte. It is a latent problem in an unbuildable file, which is exactly
 the `[[unbuildable-files-invisible]]` class. The finding is still worth keeping — when
 that file is made to compile, the reference needs deciding first.
 
-**G10.3 — ov002 is itself an Enemy-base overlay, which explains the whole pattern.**
-[high] `_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj` is defined in
-**ov002** at `0x020ad838` (size 0x208). So the enemy behaviour overlays calling into
-ov002 is semantically expected, not just statistically supported — the co-residency
-verdict and the class structure agree. ov004 holds a parallel, mutually exclusive copy;
-only three ov004-resident files plus the unbuildable ov081 one name its
-`_ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player` at `0x020ada40`.
+**G10.3 — [ov002](../config/arm9/overlays/ov002/symbols.txt) is itself an Enemy-base overlay, which explains the whole pattern.**
+[high] `_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj` is defined in **[ov002](../config/arm9/overlays/ov002/symbols.txt)** at `0x020ad838` (size 0x208). So the enemy behaviour overlays calling into [ov002](../config/arm9/overlays/ov002/symbols.txt) is semantically expected, not just statistically supported — the co-residency verdict and the class structure agree. [ov004](../config/arm9/overlays/ov004/symbols.txt) holds a parallel, mutually exclusive copy; only three [ov004](../config/arm9/overlays/ov004/symbols.txt)-resident files plus the unbuildable [ov081](../config/arm9/overlays/ov081/symbols.txt) one name its `_ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player` at `0x020ada40`.
 
 **G10.4 — What is left of this worklist.** [high] Repo-wide, **213 files are rejected
 with missing symbols across 254 distinct names**. This change cleared 30 of those files.

--- a/notes/itcm.md
+++ b/notes/itcm.md
@@ -12,7 +12,7 @@ attacked and did not match; its structure is recovered and written up below.
 ## Why it was invisible
 
 **FIXED 2026-08-01.** `tools/modules.py::modules()` enumerated **`main` plus the overlays
-and nothing else.** ITCM and DTCM are autoloads in `config/arm9/config.yaml`, and they were
+and nothing else.** ITCM and DTCM are autoloads in [arm9/config.yaml](../config/arm9/config.yaml), and they were
 absent from that list. Every tool built on `modules()` inherited the blind spot:
 
 - `linkcheck.py` / `pr_linkcheck.py` — `_ranges()` never contained itcm, so a slot at
@@ -29,7 +29,7 @@ The fix was small and additive — ITCM's range `0x01ff8000..0x01ffdf3c` does no
 arm9 (`0x02004000+`) or any overlay, and DTCM's `0x023c0000..0x023c0020` overlaps nothing
 either, so `read_at`'s preference order is unaffected. The one wrinkle was provenance:
 `modules()` reads binaries out of `extracted/`, and there is no `extracted/itcm.bin`; the
-image is `build/build/itcm.bin`, named by `config/arm9/config.yaml`
+image is `build/build/itcm.bin`, named by [arm9/config.yaml](../config/arm9/config.yaml)
 (`hash: ec91a2b334e8151e`). The registry now follows config.yaml for the autoloads and
 skips them when `build/` is absent, so a checkout with no build still gets a usable
 registry.
@@ -54,7 +54,7 @@ deliberately wrong callee still reports MATCH. Verified with a negative control 
 and correctly reported no match under `itcm`. Any ITCM result recorded with the path-style
 name is unverified, not verified.
 
-`config/arm9/itcm/relocs.txt` is real and populated (152 entries), so the check works once
+[itcm/relocs.txt](../config/arm9/itcm/relocs.txt) is real and populated (152 entries), so the check works once
 the module string is right.
 
 ## What is in there
@@ -180,8 +180,7 @@ every source file that writes `/` or `%` on an `int` emits `bl _s32_div_f`. `eli
 rejects a file whose undefined references are not named in `config/**/symbols.txt`, so those
 files could byte-match forever and never enrol — the `bl` is a relocation, so the `.text`
 compares equal whether or not the target has a name. Adding the CodeWarrior spelling as a second
-symbol at the same address (the shape `_ZTV5Actor` / `data_0208e3a4` already uses) unblocked 64
-files at once. Do not *rename* `__aeabi_idiv`: `tools/reloc_audit.py` maps the two spellings onto
+symbol at the same address (the shape `_ZTV5Actor` / [data_0208e3a4](../config/arm9/symbols.txt) already uses) unblocked 64 files at once. Do not *rename* `__aeabi_idiv`: `tools/reloc_audit.py` maps the two spellings onto
 each other and wants both.
 
 **An alias must carry `size=0x0` (2026-08-04).** The aliases originally repeated the real size,
@@ -233,7 +232,7 @@ Four structural facts, each verified on the image:
 * **456 bytes are byte-identical between the two routines** (0x01ffac14..0x01ffaddc vs
   0x01ffae08..0x01ffafd0) — one macro expanded twice with different pre/postambles.
 
-And `__aeabi_uidiv` has a **second entry point**: `config/arm9/itcm/relocs.txt` records
+And `__aeabi_uidiv` has a **second entry point**: [itcm/relocs.txt](../config/arm9/itcm/relocs.txt) records
 `from:0x01ffaa0c kind:arm_call to:0x01ffadf8`, entering +8 to skip the divisor guard. The caller
 is the shared `__aeabi_uldiv`/`__aeabi_ulmod` body, *not* `func_01ffaa34` (whose only interior
 call is `bl 0x01ffabe4`). Census: 141 calls to 0x01ffabe4, 16 to 0x01ffadf0, 1 to 0x01ffadf8. A
@@ -296,13 +295,13 @@ These make their functions unmatchable *by construction*, which is why nothing h
 | `func_01ff8708` | `size=0x2dc` | 18 non-`bl` branches leave the declared body (up to +0x3ec); the 0x42c "gap" after it holds 15 `add sp,#0x10` + 16 `pop {r4-r7,lr}` -- its own teardown | ~`0x6f0` |
 | `func_01ff97d8` | `size=0x9e4` | 56 non-`bl` branches leave the declared body | extends into the 0x188 gap |
 | `func_01ffa344` + `func_01ffa3e0` | two symbols | `a3e0` has **zero** incoming branches or calls anywhere; its only entry is fallthrough from `a344` | one symbol, `size=0xfc` |
-| `func_01ffa440` | `size=0x148` | `0x01ffa4bc` has **4 external callers** (ov002 x2, ov074, arm9, all `module:none`) and no symbol | `0x78` + a new symbol at 0x01ffa4bc |
+| `func_01ffa440` | `size=0x148` | `0x01ffa4bc` has **4 external callers** ([ov002](../config/arm9/overlays/ov002/symbols.txt) x2, [ov074](../config/arm9/overlays/ov074/symbols.txt), [arm9](../config/arm9/symbols.txt), all `module:none`) and no symbol | `0x78` + a new symbol at 0x01ffa4bc |
 
 **Count, settled by coverage rather than arithmetic (2026-08-03).** I got this wrong twice --
 first "42" by summing two agents' findings without redoing the sum, then "41" by correcting the
 arithmetic while still missing entries. The answer is **43**, and the proof is not a sum: after
-the fixes below the ITCM symbol table runs 0x01ff8000..0x01ffdf3c with **zero overlaps between
-functions**, ending exactly on the `.text` end in `config/arm9/itcm/delinks.txt`. That is
+the fixes below the ITCM symbol table runs 0x01ff8000..0x01ffdf3c with **zero overlaps between**
+functions, ending exactly on the `.text` end in [itcm/delinks.txt](../config/arm9/itcm/delinks.txt). That is
 checkable in one pass and cannot be fudged.
 
 Coverage is contiguous *in bytes accounted for*, but two of the entries below are `kind:label`,
@@ -316,7 +315,7 @@ entries:
 * **0x01ff8df8** (0x18) -- xor-swaps both double argument pairs, then falls through into
   func_01ff8e10 (soft-double subtract). The library's reverse-subtract entry.
 * **0x01ffa4bc** (0xcc) -- the signed half of the int-to-float pair. It has **4 external
-  callers** (ov002 x2, ov074, arm9) all recorded `module:none`, which is the resolution
+  callers** ([ov002](../config/arm9/overlays/ov002/symbols.txt) x2, [ov074](../config/arm9/overlays/ov074/symbols.txt), [arm9](../config/arm9/symbols.txt)) all recorded `module:none`, which is the resolution
   breakage this symbol fixes.
 * **0x01ffa588** (0xc) -- xor-swaps the single-precision pair, falls through into func_01ffa594.
 
@@ -452,8 +451,7 @@ aggregates minus the 13 temp slots scalarization was using = +14 = 0x38.
 **The lever: a local vector type with a user-declared destructor** (`struct DVec { s32 x,y,z;
 ~DVec(){} };`) blocks SROA. Dead `&x` statements, references and launders do not.
 
-This is a *variant*, not a discovery: `notes/matching-style.md` (from PR #815, 2026-07-29)
-already documents the `~PVec(){}` dead-store-elimination defeat and the enclosing
+This is a *variant*, not a discovery: [notes/matching-style.md](../notes/matching-style.md) (from PR #815, 2026-07-29) already documents the `~PVec(){}` dead-store-elimination defeat and the enclosing
 address-taken struct that blocks SROA, with a ranked table of four mechanisms. Read that
 first. What is new here is only the application — putting the destructor on the vector type
 itself so that N aggregate locals stay un-SROA'd together, which is what moves a whole frame
@@ -494,7 +492,7 @@ individual divergences before the frame matches is wasted budget.
 
 Note the metrics disagree in direction: caching `this->file` in a local improves the DB
 divergence and *hurts* the size. Trust the DB metric (`nearmiss_db.evaluate`), per the same
-warning in `notes/arm9-endgame.md`.
+warning in [notes/arm9-endgame.md](../notes/arm9-endgame.md).
 
 ### The algorithm
 

--- a/notes/minigame-provenance.md
+++ b/notes/minigame-provenance.md
@@ -14,9 +14,9 @@ resolvable vtable slots were blocked on it.
 
 **Base.** dScene_c, confirmed two independent ways:
 
-* RTTI -- dScMiniGm_c's `__si_class_type_info` (ov005:0x020c2448, name
+* RTTI -- dScMiniGm_c's `__si_class_type_info` ([ov005](../config/arm9/overlays/ov005/symbols.txt):0x020c2448, name
   "dScMiniGm_c" at 0x020c2454) names its single base dScene_c (build/rtti.json).
-* Vtable -- `_ZTV11dScMiniGm_c` (ov005:0x020c2490) is 18 slots, matching
+* Vtable -- `_ZTV11dScMiniGm_c` ([ov005](../config/arm9/overlays/ov005/symbols.txt):0x020c2490) is 18 slots, matching
   dScene_c's own 18 (`tools/rtti_vtables.py --own dScMiniGm_c`). It overrides
   exactly seven: 0, 3, 6, 9, 12, 16, 17. Every other slot is still whatever
   dScene_c's table holds. dScMiniGm_c adds no new virtual, and the destructor
@@ -24,10 +24,9 @@ resolvable vtable slots were blocked on it.
   `_ZN8dScene_cD0Ev` anchors.
 
 **Size.** `dScMiniGm_c_classInit` (historical alias `func_ov005_020c21ec`) is the factory; it opens with
-`_ZN7fBase_cnwEj(0xb0)` -- fBase_c::operator new(0xb0). 0xb0 therefore comes
+`_ZN7fBase_cnwEj(0xb0)` -- `fBase_c::operator new(0xb0)`. 0xb0 therefore comes
 straight off the allocator call. The factory writes only the vtable chain
-(fBase_c -> dScene_c inlined -> data_ov005_020c2490) and two spawn-flag bits at
-fBase_c's own 0x13; it constructs no nested sub-object, matching the
+(*fBase_c -> dScene_c inlined -> [data_ov005_020c2490](../config/arm9/overlays/ov005/symbols.txt)*) and two spawn-flag bits at fBase_c's own 0x13; it constructs no nested sub-object, matching the
 plain-scalar field layout.
 
 **Members.** The old flat header put every field it found at or above 0x54,
@@ -42,7 +41,7 @@ Field names and the matched body that settles each:
 | --- | --- | --- |
 | 0x050 | `mSubBgScrollX` | InitResources sets it to 0xb0 or 0 from `data_0209b304` (the page index), then feeds it to `SetSubBg0Offset` / `SetSubBg2Offset` / `SetSubBg3Offset` and to `*(u32*)0x400101c = mSubBgScrollX & 0x1ff`. |
 | 0x054 | `mPageFlipped` | u8. Zeroed by InitResources; Behavior sets it to 1 on each of the two page-timer expiries. Render draws the left/right page arrows only while it is 0. |
-| 0x058 | `mGroupBase` | InitResources seeds it from `data_0208a170`, the base index into the minigame table `data_ov005_020c24d8[]`. func_ov005_020c0878 copies it back into `data_0208a170` once `mScrollDelay` drains, i.e. it is the *target* group base and the global is the committed one. |
+| 0x058 | `mGroupBase` | InitResources seeds it from `data_0208a170`, the base index into the minigame table [data_ov005_020c24d8](../config/arm9/overlays/ov005/symbols.txt)`[]`. [func_ov005_020c0878](../src/func_ov005_020c0878.cpp) copies it back into `data_0208a170` once `mScrollDelay` drains, i.e. it is the *target* group base and the global is the committed one. |
 | 0x05c | `unk_05c` | Zeroed by InitResources; func_ov005_020c0378 copies it into `(&data_0209b308)[0x30]`. Role not settled -- left `unk_`. |
 | 0x060 | `unk_060` | Zeroed by InitResources, no other matched access. |
 | 0x064 | `unk_064` | Zeroed by InitResources, no other matched access. |
@@ -51,10 +50,10 @@ Field names and the matched body that settles each:
 | 0x094 | `mNextPageTimer` | Same shape; expiry sets `data_0209b304 = 1`. Drives the right arrow. |
 | 0x098 | `mExitTimer` | Behavior counts it down to 1, then `dScene_c::SetAndStopColorFader()`, `ExitMinigameMenu()`, stops the music and sets `mExiting`. |
 | 0x09c | `mIconBlinkPhase` | Behavior free-runs it 0..0x3f; Render picks between two arrow frames on `>= 0x20`. |
-| 0x0a0 | `mScrollDelay` | func_ov005_020c0878 decrements it, reloads it to 0x1e after committing a group change, and gates cursor input on `<= 0`. |
+| 0x0a0 | `mScrollDelay` | [func_ov005_020c0878](../src/func_ov005_020c0878.cpp) decrements it, reloads it to 0x1e after committing a group change, and gates cursor input on `<= 0`. |
 | 0x0a4 | `unk_0a4` | Zeroed by InitResources, no other matched access. |
 | 0x0a8 | `unk_0a8` | Zeroed by InitResources, no other matched access. |
-| 0x0ac | `mExiting` | u8. Behavior sets it on the exit branch; func_ov005_020c0878 / _020c0378 / _020c06cc all early-out while it is set. |
+| 0x0ac | `mExiting` | u8. Behavior sets it on the exit branch; [func_ov005_020c0878](../src/func_ov005_020c0878.cpp) / [func_ov005_020c0378](../src/func_ov005_020c0378.cpp) / [func_ov005_020c06cc](../src/func_ov005_020c06cc.c) all early-out while it is set. |
 
 0x064..0x08c and 0x0ad..0xb0 are padding: no slot function touches them, and
 `mExiting` plus three bytes of tail padding closes exactly on the 0xb0
@@ -68,12 +67,8 @@ is empty; see notes/runbook-type-reconstruction.md section 2), so every field
 that does not carry its own evidence note is an unverified placeholder rather
 than machine-checked evidence.
 
-**Base.** dScene_c, confirmed by `tools/rtti_extract.py`: dScMgBase_c's
-`__si_class_type_info` at ov004:0x020bbf6c points at dScene_c arm9:0x020914d4,
-offset 0 -- the same edge dScene_c.h's own census documents. dScMgBase_c is also
-a second hierarchy root: 15 direct RTTI children, 32 transitive descendants (the
-minigame family -- notes/dscene-c-siblings-census.md section 2). Its own fields
-start at ROM offset 0x50 == sizeof(dScene_c), like every other dScene_c child.
+**Base.** dScene_c, confirmed by `tools/rtti_extract.py`: dScMgBase_c's `__si_class_type_info` at [ov004](../config/arm9/overlays/ov004/symbols.txt):0x020bbf6c points at dScene_c [arm9](../config/arm9/symbols.txt):0x020914d4, offset 0 -- the same edge dScene_c.h's own census documents. dScMgBase_c is also a second hierarchy root: 15 direct RTTI children, 32 transitive descendants (the
+minigame family -- [notes/dscene-c-siblings-census.md](../notes/dscene-c-siblings-census.md) section 2). Its own fields start at ROM offset 0x50 `== sizeof(dScene_c)`, like every other dScene_c child.
 
 **Destructor.** The cascade goes one more level than dScene_c's own fix.
 dScMgBase_c has 32 descendants, so its D2/D1 would have to be defined inline for
@@ -92,43 +87,34 @@ dScMgBase_c, not dScene_c.
 `func_ov004_020b929c(this + 0xf4)`, which is
 `__destroy_arr(p, count=8, elem_size=0x24, func_ov004_020b9280)`
 (0x0207328c is `__destroy_arr` / `__cxa_vec_cleanup`,
-config/arm9/symbols.txt:3050-3051). The per-element destructor writes two
+[arm9/symbols.txt](../config/arm9/symbols.txt)). The per-element destructor writes two
 vtables into `[r0+0]` back to back with no further calls -- 0x020bca7c then
 0x020ad494 -- which build/rtti.json identifies as
-`_ZTVN10dMgPsOpt_c11TouchIcon_cE` (ov004:0x020bca68, "dMgPsOpt_c::TouchIcon_c")
-and `_ZTV9dThIcon_c` (ov001:0x020ad478, "dThIcon_c", a root class). So
-TouchIcon_c : dThIcon_c, single inheritance at offset 0, both destructors
+`_ZTVN10dMgPsOpt_c11TouchIcon_cE` ([ov004](../config/arm9/overlays/ov004/symbols.txt):0x020bca68, "dMgPsOpt_c::TouchIcon_c")
+and `_ZTV9dThIcon_c` ([ov001](../config/arm9/overlays/ov001/symbols.txt):0x020ad478, "dThIcon_c", a root class). So `TouchIcon_c : dThIcon_c`, single inheritance at offset 0, both destructors
 trivial enough to fully inline into vtable writes, and 0x0f4 is 8 contiguous
 0x24-byte TouchIcon_c spanning 0x0f4..0x214. Neither class has a header yet, so
-the array stays raw bytes and the destructor calls func_ov004_020b929c on it
+the array stays raw bytes and the destructor calls `func_ov004_020b929c` on it
 explicitly, which is exactly what the ROM's D2 does. 0x214..0x21c has no matched
 access and stays padding.
 
-**data_ov004_020beb68** is a global singleton pointer to the active
-dScMgBase_c; 60+ files across ov004/ov006 read it, each having invented its own
-local type (Base*, Obj*, G*, char*, void*...). Retyping it tree-wide is its own
-slice. The D2's `*(int*)data_ov004_020beb68 = 0` writes 0 into the *global's own
-storage* -- that file declared it `extern int data_ov004_020beb68[]`, and arrays
-decay to their own address -- i.e. a plain global pointer being nulled, not a
-target zeroed through it.
+**[data_ov004_020beb68](../config/arm9/overlays/ov004/symbols.txt)** is a global singleton pointer to the active
+dScMgBase_c; 60+ files across [ov004](../config/arm9/overlays/ov004/symbols.txt)/[ov006](../config/arm9/overlays/ov006/symbols.txt) read it, each having invented its own local type (`Base*`, `Obj*`, `G*`, `char*`, `void*`...). Retyping it tree-wide is its own slice. The D2's `*(int*)data_ov004_020beb68 = 0` writes 0 into the *global's own storage* -- that file declared it `extern int data_ov004_020beb68[]`, and arrays decay to their own address -- i.e. a plain global pointer being nulled, not a target zeroed through it.
 
 **Slots 18-35** are eighteen further virtuals new at this class, the same shape
 as dActor_c's 13 new slots over fBase_c. All 18 targets are already matched
-source (func_ov004_* under arm9/ov004, notes/dscene-c-siblings-census.md
-section 2), but their signatures are not reconstructed, so they stay undeclared
-rather than guessed.
+source (`func_ov004_*` under [arm9/ov004](../config/arm9/overlays/ov004/symbols.txt), [dscene-c-siblings-census.md](../notes/dscene-c-siblings-census.md) section 2), but their signatures are not reconstructed, so they stay undeclared rather than guessed.
 
-**The blink prompt (0x0c0 / 0x0c3 / 0x0c4).** func_ov004_020b0de0, called from
+**The blink prompt (0x0c0 / 0x0c3 / 0x0c4).** [func_ov004_020b0de0](../src/func_ov004_020b0de0.c), called from
 `dScMgBase_c::BeforeRender`, is the whole story: nothing draws unless
 `mPromptEnabled` (0x0c3) is set; while `mPromptBlinkCount` (0x0c4) is below 4 the
 16-bit `mPromptBlinkTimer` (0x0c0) free-runs 0..0x2f, bumping the count each
 wrap, and the per-language prompt sprite
-(`data_ov004_020bbfa8[GetGameLanguage()] + 0x28`) is drawn at (0xc0, 0xb0) only
-during the first 0x18 frames of each cycle. Once four cycles have elapsed it is
+([data_ov004_020bbfa8](../config/arm9/overlays/ov004/symbols.txt)`[GetGameLanguage()] + 0x28`) is drawn at (0xc0, 0xb0) only during the first 0x18 frames of each cycle. Once four cycles have elapsed it is
 drawn every frame. The width and signedness of 0x0c0 come from that function's
 unsigned compares against 0x30 and 0x18; 0x0c4's from its `< 4U`.
 
-Roughly 25 pre-existing ov006 files spell these three by raw offset:
+Roughly 25 pre-existing [ov006](../config/arm9/overlays/ov006/symbols.txt) files spell these three by raw offset:
 dScMgFlower_c's, dScMgSnowball_c's and dScMgMCarlo_c's Behaviors all carry the
 identical `if (0xc4 == 0) { 0xc3 = 1; 0xc4 = 1; *(s16*)0xc0 = 0; }` idiom, i.e.
 "start the prompt blinking from the top". Naming them in the header is what lets
@@ -189,12 +175,12 @@ member -- measured on dScMgRoulette_c.h, 22/22 fields "mismatched" by exactly
 that delta. **Do not restyle those seven comments.**
 
 **The destructor must stay defined inline.** Same fix and reason as
-dScene_c.h's note: 13 direct children each inline this destructor's vptr store
+`dScene_c.h`'s note: 13 direct children each inline this destructor's vptr store
 plus mSysTracker destruction plus the chain to `~dScMgBase_c()`. Measured on
 dScMgMemory_c: a merely declared `virtual ~dScMgSingle3DBase_c();` compiles a
 derived destructor referencing `_ZN19dScMgSingle3DBase_cD2Ev` as an undefined
 external, and no such symbol exists anywhere in the ROM. The raw pre-migration
-destructors confirm it -- func_ov006_020f3834 (dScMgMemory_c's D1) destroys
+destructors confirm it -- `func_ov006_020f3834` (`dScMgMemory_c`'s *D1*) destroys
 `_ZN8Particle10SysTrackerD1Ev(c + 0x471c)` inline and then calls
 `_ZN11dScMgBase_cD2Ev(c)` directly, with no dScMgSingle3DBase_c-specific
 destructor call at all. The out-of-line definition that landed in #1421 was a
@@ -211,12 +197,11 @@ sites, which is the same call the compiler emits from the declaration.
 ## cMgSmartball_ball_c (include/cMgSmartball_ball_c.h)
 
 Real ROM name confirmed by `tools/rtti_extract.py` (build/rtti.json). Own vtable
-ov006:0x0213ec98, RTTI ov006:0x0213ebec (`_ZTI19cMgSmartball_ball_c`),
-`_ZTS19cMgSmartball_ball_c` at ov006:0x0213edc0. One of eleven direct children
-of cMgSmartball_object_c -- see that header for the family's shape (a root,
+[ov006](../config/arm9/overlays/ov006/symbols.txt):0x0213ec98, RTTI [ov006](../config/arm9/overlays/ov006/symbols.txt):0x0213ebec (`_ZTI19cMgSmartball_ball_c`),
+`_ZTS19cMgSmartball_ball_c` at [ov006](../config/arm9/overlays/ov006/symbols.txt):0x0213edc0. One of eleven direct children of `cMgSmartball_object_c` -- see that header for the family's shape (a root,
 three slots, no virtual destructor).
 
-Size 0x12c, from `_Znwj(0x12c)` in func_ov006_02115b0c. The base ends at 0x34,
+Size 0x12c, from `_Znwj(0x12c)` in [func_ov006_02115b0c](../src/func_ov006_02115b0c.c). The base ends at 0x34,
 so this class adds 0xf8 bytes -- the densest of the eleven children. Everything
 below 0x34 is reached through inherited members; this class's four functions
 never touch the base's 0x31-0x33 region, so no raw cast is needed anywhere.
@@ -226,42 +211,41 @@ RestoreInitial, which is exhaustive -- every array length and every scalar width
 below comes from that function's loop bounds and store widths. SaveSnapshot and
 Update corroborate roughly half of the same offsets.
 
-**Several names are borrowed, not invented.** func_ov006_02112ad8.c and
-func_ov006_021128fc.c -- two out-of-scope helpers SaveSnapshot calls with `this`
--- each reinterpret the pointer through their own local Obj-style struct cast
+**Several names are borrowed, not invented.** [func_ov006_02112ad8.c](../src/func_ov006_02112ad8.c) and
+[func_ov006_021128fc.c](../src/func_ov006_021128fc.c) -- two out-of-scope helpers `SaveSnapshot` calls with `this` -- each reinterpret the pointer through their own local Obj-style struct cast
 and name a number of these exact offsets (hit/hitA/hitB/hitC, anyHit,
 specialHit, nearby, targetIndex, soundTimer, soundPlayed, state3a, state3b).
 Every one of those offsets is also independently touched by RestoreInitial, so
 the width and existence of each field is evidenced in-scope; only the spelling
 is borrowed. Anything without that corroboration keeps an `unk_` name.
 
-0x44-0x4b are hitX/hitZ in func_ov006_02112ad8.c's naming, but none of this
+0x44-0x4b are hitX/hitZ in [func_ov006_02112ad8.c](../src/func_ov006_02112ad8.c)'s naming, but none of this
 class's own four functions touches them, so per the wing_c precedent they stay
 an explicit pad -- unmodelled, not unread. pad_0e7[0x11] (0xe7-0xf7) is a
 genuine gap: RestoreInitial's exhaustive zero pass skips straight over it
-(nearby[] ends at 0xe6, targetIndex starts at 0xf8) and func_ov006_02112ad8.c's
+(nearby[] ends at 0xe6, targetIndex starts at 0xf8) and [func_ov006_02112ad8.c](../src/func_ov006_02112ad8.c)'s
 Obj cast also treats it as padding. pad_101 / pad_111 / pad_122 / pad_12a are
 pure alignment gaps between adjacent int fields (house style: explicit pads over
 implicit compiler-inserted ones).
 
-Constructed by func_ov006_02114548, left a free function per the recipe. It
+Constructed by [func_ov006_02114548](../src/func_ov006_02114548.c), left a free function per the recipe. It
 calls the base constructor and writes only this vtable and the base's
 `unk_028 = 0x8000`; it touches nothing at or past 0x34, so it adds no evidence
 to the field list.
 
 ## dScMgAmida_c (include/dScMgAmida_c.h)
 
-dScMgAmida_c : dScMgBase_c, confirmed leaf via tools/rtti_extract.py (zero
+`dScMgAmida_c : dScMgBase_c`, confirmed leaf via tools/rtti_extract.py (zero
 RTTI edges name dScMgAmida_c as a base).
 
 Own vtable slots (python tools/rtti_vtables.py --own dScMgAmida_c): 0
 (InitResources), 5 (AfterCleanupResources -- the recovered source locally
 declared the base override as returning void*, which is WRONG; the real
 dScMgBase_c.h override returns void, so this now calls the base method as
-a plain statement instead of returning it, same fix dScMgLuigi_c's own
+a plain statement instead of returning it, same fix `dScMgLuigi_c`'s own
 slot 5 needed), 6 (Behavior), 9 (Render), 16 (D1), 17 (D0), 18
 (dScMgBase_c::OnYoshiTryEat, declared on the base and overridden here;
-the body is src/_ZN12dScMgAmida_c13OnYoshiTryEatEi.cpp, still a raw
+the body is `src/_ZN12dScMgAmida_c13OnYoshiTryEatEi.cpp`, still a raw
 extern "C" helper rather than a member definition, same precedent as
 every other dScMgBase_c leaf's slot 18; it no longer includes this
 header at all -- its one
@@ -274,7 +258,7 @@ was left as a raw helper by THIS migration and picked up later, when the
 slot-31 keystone commit named the base slot), 34 (now `Virtual88`,
 src/_ZN12dScMgAmida_c9Virtual88Eiiii.cpp -- the slot's signature is
 `void(int, int, int, int)`, measured from the seven call sites in
-ov004:0x020ae5c4, and this body reads only three of the four because the
+[ov004](../config/arm9/overlays/ov004/symbols.txt):0x020ae5c4, and this body reads only three of the four because the
 fourth arrives on the stack and it supplies its own size instead; it is
 the collision half of the ghost-leg rule, probing the 0x158-stride
 occupancy grid at +0x4710 and then delegating the drawing to
@@ -335,7 +319,7 @@ destroys FOUR arrays via __destroy_arr, in this exact order, in BOTH D1
 and D0 (src/_ZN12dScMgAmida_cD1Ev.cpp and .../_D0Ev.cpp carry an identical
 body, same shape dScMgHanachan_c's own D1/D0 pair uses): the 0x80x0x18
 dScMgAmida_c_Piece array at 0x4768 (own per-element dtor
-func_ov006_020d116c, a no-op -- the element type needs no real cleanup),
+[func_ov006_020d116c](../src/func_ov006_020d116c.c), a no-op -- the element type needs no real cleanup),
 then the three NullDestructor_0203d47c-based 4x8-byte arrays at 0x4744,
 0x4724, and 0x4660 in that order (their own per-element dtor is also a
 no-op). The base-D2 call and own-vtable-write are compiler generated;
@@ -407,7 +391,7 @@ ever reads or writes them, so they are not modelled as a field.
 
 ### The __destroy_arr declarations
 
-__destroy_arr / func_ov006_020d116c / NullDestructor_0203d47c: the same
+__destroy_arr / [func_ov006_020d116c](../src/func_ov006_020d116c.c) / NullDestructor_0203d47c: the same
 __destroy_arr(p, count, elemSize, dtor) idiom dScMgBase_c's own D1/D0 use
 for touchIcon_0f4 (see dScMgBase_c.h's file banner and
 src/_ZN11dScMgBase_cD1Ev.cpp) -- declared here, not per-destructor-file,
@@ -426,24 +410,24 @@ name -- a wrong name is a claim the next reader will trust.
 
 | Offset | Name | Evidence |
 | --- | --- | --- |
-| 0x46d0 | `mState` | The subject of `Behavior`'s own `switch` (src/_ZN12dScMgAmida_c8BehaviorEv.cpp): 0 sets the board up and falls into 1, 1 runs the lottery, 2 waits out the result, 3 is the finale. src/func_ov006_020d3ba0.cpp leaves it at 1. |
-| 0x46d4 | `mFinished` | u8. src/func_ov006_020d3ba0.cpp zeroes it; Behavior sets it only on the branch that fires when `mRoundCount` reaches 5, and every later read takes the celebration path (`func_ov004_020b0a54(0)` instead of `0x12`, and Render's confetti pass). |
-| 0x4700 | `mLineEndY` | InitResources stores 0x78 or 0x98 here; src/func_ov006_020d3ba0.cpp passes it as the y2 argument of four `func_ov004_020ae5c4` line draws whose other three arguments are literal screen coordinates (x = 0x20/0x60/0xa0/0xe0, y1 = -0xb4 or -0xd4). |
-| 0x4724 | `mLanePos[4][2]` | src/func_ov006_020d3ba0.cpp seeds `{ (0x20 + 0x40*i) << 12, 0xb0 << 12 }`; Behavior adds `mLaneVel` into it; Render draws the lane sprite at `>> 12`. |
+| 0x46d0 | `mState` | The subject of `Behavior`'s own `switch` (src/_ZN12dScMgAmida_c8BehaviorEv.cpp): 0 sets the board up and falls into 1, 1 runs the lottery, 2 waits out the result, 3 is the finale. [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) leaves it at 1. |
+| 0x46d4 | `mFinished` | u8. [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) zeroes it; Behavior sets it only on the branch that fires when `mRoundCount` reaches 5, and every later read takes the celebration path ([func_ov004_020b0a54](../src/func_ov004_020b0a54.cpp)`(0)` instead of `0x12`, and Render's confetti pass). |
+| 0x4700 | `mLineEndY` | InitResources stores 0x78 or 0x98 here; [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) passes it as the y2 argument of four [func_ov004_020ae5c4](../src/func_ov004_020ae5c4.cpp) line draws whose other three arguments are literal screen coordinates (x = 0x20/0x60/0xa0/0xe0, y1 = -0xb4 or -0xd4). |
+| 0x4724 | `mLanePos[4][2]` | [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) seeds `{ (0x20 + 0x40*i) << 12, 0xb0 << 12 }`; Behavior adds `mLaneVel` into it; Render draws the lane sprite at `>> 12`. |
 | 0x4744 | `mLaneVel[4][2]` | Added into `mLanePos` once a tick, and its y component loses a fixed 0x100 every tick -- a velocity under gravity. Zeroed by the same reset. |
 | 0x4768 | `mPieces[0x80]` | Renamed from `arr4768`; the element layout is unchanged (see the section above). |
-| 0x5368 | `mScrollSpeed` | src/func_ov006_020d3ba0.cpp computes it from the pattern table `data_ov006_0212e1b0 + mPatternIndex * 0x1c`, biases it by the inherited 0xbc, and clamps it to 0x64. |
-| 0x536c | `mScrollAccum` | Behavior adds `mScrollSpeed` into it, keeps the low four bits (`&= 0xf`) and runs `func_ov006_020d27dc` once per 16 accumulated -- a fixed-point step accumulator. |
+| 0x5368 | `mScrollSpeed` | [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) computes it from the pattern table [data_ov006_0212e1b0](../config/arm9/overlays/ov004/symbols.txt) `+ mPatternIndex * 0x1c`, biases it by the inherited 0xbc, and clamps it to 0x64. |
+| 0x536c | `mScrollAccum` | Behavior adds `mScrollSpeed` into it, keeps the low four bits (`&= 0xf`) and runs [func_ov006_020d27dc](../config/arm9/overlays/ov006/symbols.txt) once per 16 accumulated -- a fixed-point step accumulator. |
 | 0x5374 | `mRoundCount` | Zeroed by the reset; Behavior replays the board while it is below 5 and finishes at 5, and scales the fast-forward speed by `n * 5 + 0x20`. |
-| 0x539c | `mLaneAnimTimer[4]` | Render bumps entry `i` each frame and wraps it on the per-lane period it copies out of `data_ov006_0213b880`. |
-| 0x53ac | `mLaneAnimFrame[4]` | Bumped when the timer above wraps, cycles 0..0xd, and indexes the sprite table `data_ov006_0213a458`. |
-| 0x53bc | `mBgScrollPhase` | u16. Render adds 0xc0 a frame and feeds `>> 4` into the shared sine table `data_02082214` to get the sub-screen BG2 offset. The 16-bit width comes from the reset's own `*(s16*)` store. |
+| 0x539c | `mLaneAnimTimer[4]` | Render bumps entry `i` each frame and wraps it on the per-lane period it copies out of [data_ov006_0213b880](../config/arm9/overlays/ov006/symbols.txt). |
+| 0x53ac | `mLaneAnimFrame[4]` | Bumped when the timer above wraps, cycles 0..0xd, and indexes the sprite table [data_o006_0213a458](../config/arm9/overlays/ov006/symbols.txt). |
+| 0x53bc | `mBgScrollPhase` | u16. Render adds 0xc0 a frame and feeds `>> 4` into the shared sine table [data_02082214](../config/arm9/symbols.txt) to get the sub-screen BG2 offset. The 16-bit width comes from the reset's own `*(s16*)` store. |
 | 0x53c0 | `mResultWaitTimer` | Loaded with 0x3c on entry to state 2 and counted down there; at 0 the scene clears `mPromptEnabled` and moves to state 3. |
-| 0x53c4 | `mStartBannerTimer` | Reset to 0x3c right after `func_ov004_020b0cac(0xd, 0x80, 0x60, ...)` puts banner 0xd on screen; Behavior counts it down and calls `FreeGfxSlotsById(0xd)` on expiry. |
+| 0x53c4 | `mStartBannerTimer` | Reset to 0x3c right after [func_ov004_020b0cac](../src/func_ov004_020b0cac.c)`(0xd, 0x80, 0x60, ...)` puts banner 0xd on screen; Behavior counts it down and calls `FreeGfxSlotsById(0xd)` on expiry. |
 | 0x53d0 | `mEndDelayTimer` | Set to 0xb4 when state 3 begins; Render keeps drawing the play field until it and `mState == 3` agree, then switches to the finale. |
-| 0x53d4 | `mPatternIndex` | src/func_ov006_020d3ba0.cpp picks it (clamped, or randomised for the harder variant) and then uses it as the row index into five different 0x1c-stride tables in ov006. |
+| 0x53d4 | `mPatternIndex` | [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) picks it (clamped, or randomised for the harder variant) and then uses it as the row index into five different 0x1c-stride tables in [ov006](../config/arm9/overlays/ov006/symbols.txt). |
 | 0x53e0 | `mRoundTimer` | Behavior counts it down inside state 1; reaching 0 is what ends the round and chooses between another board and the finale. |
-| 0x53e8 | `mScore` | InitResources seeds it from the inherited 0xbc times 5; src/func_ov006_020d3ba0.cpp clamps it to 0x270f (9999); Behavior pushes it to the HUD counter `func_ov004_020adb1c` every tick. |
+| 0x53e8 | `mScore` | InitResources seeds it from the inherited 0xbc times 5; [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) clamps it to 0x270f (9999); Behavior pushes it to the HUD counter [func_ov004_020adb1c](../src/func_ov004_020adb1c.c) every tick. |
 
 Left `unk_`: 0x46d5 (a second reset flag, only ever zeroed and compared against
 1), 0x470c/0x4710 (two 0x100 x 0x158 byte buffers -- the shape is now in the

--- a/notes/minigame-provenance.md
+++ b/notes/minigame-provenance.md
@@ -39,15 +39,15 @@ Field names and the matched body that settles each:
 
 | Offset | Name | Evidence |
 | --- | --- | --- |
-| 0x050 | `mSubBgScrollX` | InitResources sets it to 0xb0 or 0 from `data_0209b304` (the page index), then feeds it to `SetSubBg0Offset` / `SetSubBg2Offset` / `SetSubBg3Offset` and to `*(u32*)0x400101c = mSubBgScrollX & 0x1ff`. |
+| 0x050 | `mSubBgScrollX` | InitResources sets it to 0xb0 or 0 from [data_0209b304](../config/arm9/symbols.txt) (the page index), then feeds it to `SetSubBg0Offset` / `SetSubBg2Offset` / `SetSubBg3Offset` and to `*(u32*)0x400101c = mSubBgScrollX & 0x1ff`. |
 | 0x054 | `mPageFlipped` | u8. Zeroed by InitResources; Behavior sets it to 1 on each of the two page-timer expiries. Render draws the left/right page arrows only while it is 0. |
-| 0x058 | `mGroupBase` | InitResources seeds it from `data_0208a170`, the base index into the minigame table [data_ov005_020c24d8](../config/arm9/overlays/ov005/symbols.txt)`[]`. [func_ov005_020c0878](../src/func_ov005_020c0878.cpp) copies it back into `data_0208a170` once `mScrollDelay` drains, i.e. it is the *target* group base and the global is the committed one. |
+| 0x058 | `mGroupBase` | InitResources seeds it from [data_0208a170](../config/arm9/symbols.txt), the base index into the minigame table [data_ov005_020c24d8](../config/arm9/overlays/ov005/symbols.txt)`[]`. [func_ov005_020c0878](../src/func_ov005_020c0878.cpp) copies it back into `data_0208a170` once `mScrollDelay` drains, i.e. it is the *target* group base and the global is the committed one. |
 | 0x05c | `unk_05c` | Zeroed by InitResources; func_ov005_020c0378 copies it into `(&data_0209b308)[0x30]`. Role not settled -- left `unk_`. |
 | 0x060 | `unk_060` | Zeroed by InitResources, no other matched access. |
 | 0x064 | `unk_064` | Zeroed by InitResources, no other matched access. |
 | 0x08c | `mArrowBobPhase` | Behavior free-runs it 0..0x3f; Render uses it as the horizontal bob of the two page arrows (`0x50 - t/2` and `t/2 + 0xE0`). |
-| 0x090 | `mPrevPageTimer` | Behavior counts it down; expiry sets `data_0209b304 = 0` (page 0) and `mPageFlipped = 1`. Render drives the left arrow's scale pop from it. |
-| 0x094 | `mNextPageTimer` | Same shape; expiry sets `data_0209b304 = 1`. Drives the right arrow. |
+| 0x090 | `mPrevPageTimer` | Behavior counts it down; expiry sets [data_0209b304](../config/arm9/symbols.txt) `= 0` (page 0) and `mPageFlipped = 1`. Render drives the left arrow's scale pop from it. |
+| 0x094 | `mNextPageTimer` | Same shape; expiry sets [data_0209b304](../config/arm9/symbols.txt) `= 1`. Drives the right arrow. |
 | 0x098 | `mExitTimer` | Behavior counts it down to 1, then `dScene_c::SetAndStopColorFader()`, `ExitMinigameMenu()`, stops the music and sets `mExiting`. |
 | 0x09c | `mIconBlinkPhase` | Behavior free-runs it 0..0x3f; Render picks between two arrow frames on `>= 0x20`. |
 | 0x0a0 | `mScrollDelay` | [func_ov005_020c0878](../src/func_ov005_020c0878.cpp) decrements it, reloads it to 0x1e after committing a group change, and gates cursor input on `<= 0`. |
@@ -125,7 +125,7 @@ dScMgD3DBase_c needs a number to start its own fields at; 0x465c is the last
 field any matched function has observed, and 0x4660 is its 4-byte-aligned round
 up. If it were short, dScMgD3DBase_c's fields would land on the wrong bytes and
 build_pin would catch it -- the safety net check_header_offsets.py's own
-DATA_SIZE comment describes. Same reasoning for every other floor assert in the
+`DATA_SIZE` comment describes. Same reasoning for every other floor assert in the
 family.
 
 ## dScMgSingle3DBase_c (include/dScMgSingle3DBase_c.h)
@@ -163,7 +163,7 @@ this class, not either leaf. 0x4718..0x471b has no matched access and stays
 padding.
 
 **Their comments deliberately avoid the usual `/* 0xNN */` style.**
-tools/check_header_offsets.py's DATA_SIZE precompute walks a struct's commented
+tools/check_header_offsets.py's `DATA_SIZE` precompute walks a struct's commented
 fields by regex to find where a derived class's fields start, and that regex
 cannot parse the namespaced `Particle::SysTracker mSysTracker` a few lines down
 -- it silently stops at the last field it CAN parse. Before these seven fields
@@ -361,7 +361,7 @@ see above) indexes through both of them as byte buffers
 through a `*(void**)` cast.
 
 Fields below dScMgBase_c's own last-observed field (mSceneKind at 0x465e,
-DATA_SIZE 0x4660 per tools/check_header_offsets.py's own convention -- see
+`DATA_SIZE` 0x4660 per tools/check_header_offsets.py's own convention -- see
 dScMgBase_c.h) are genuinely THIS class's own, drawn only from what
 InitResources/AfterCleanupResources/Behavior/Render/D1/D0 directly touch.
 Fields touched only by the raw slot 18/31/34 helpers (0x46d8..0x4700's
@@ -449,7 +449,7 @@ the previous header held as four pads, and a run/HUD block at 0xb9d8.
 | 0xab60 | `mVelX` / `mVelY` (0xab64) | `Vec2_Len` of the pair is the speed, `atan2` of it is the heading, and it is added into `mPos` each tick. Capped at 0x8000. |
 | 0xab68 | `mScrollX` | Subtracted from every world X before drawing; [func_ov006_021279b0](../src/func_ov006_021279b0.cpp) zeroes it. |
 | 0xab6c | `mScrollY` | `mPosY - 0x190000`, clamped to `[0, mScrollLimit]`; drives all four `SetBg*Offset` calls and the four hardware scroll registers in [_ZN15dScMgSnowball_c8OnKickedEv](../src/_ZN15dScMgSnowball_c8OnKickedEv.cpp). |
-| 0xab70 | `mTouchX` / `mTouchY` (0xab74) | Behavior stores the raw touch sample (`data_020a0dea` / `data_020a0deb`) here and steers off the difference from the previous one. |
+| 0xab70 | `mTouchX` / `mTouchY` (0xab74) | Behavior stores the raw touch sample ([data_020a0dea](../config/arm9/symbols.txt) / [data_020a0deb](../config/arm9/symbols.txt)) here and steers off the difference from the previous one. |
 | 0xab78 | `mRollAngle` | u16. `+= speed * 0x2710 / mBallSize` -- an angle that advances faster the smaller the ball. |
 | 0xab7c | `mHeadingAngle` | u16. `atan2(mVelX, mVelY)`, approached linearly while rolling and set outright while crashing. |
 | 0xab7e | `mPrevRollAngle` / `mPrevHeadingAngle` (0xab82) | Behavior's prologue copies 0xab78..0xab7c into 0xab7e..0xab82 verbatim. |
@@ -485,15 +485,15 @@ any matched body reads).
 | --- | --- | --- |
 | 0x4fe4 | `mReelPos[3]` | InitResources seeds each entry with `(random % mStripLength) * 0x50000`; Render divides `n >> 12` by 0x50 to get the top stop and the pixel remainder, i.e. 0x50 screen pixels per symbol. |
 | 0x4ff4 | `mReelWinPos[3]` | Read exactly the way `mReelPos` is, but only in the `mState == 6` win-line pass. Split out of the former `pad_4ff4[0xc]`, which was three words wide. |
-| 0x5000 | `mState` | Behavior's whole body is `(self->*data_ov006_02142bdc[n])()` -- it is the index into that pointer-to-member table. Render tests it against 3, 4, 6 and 7 to pick which pass to draw. |
+| 0x5000 | `mState` | Behavior's whole body is `(self->*`[data_ov006_02142bdc](../config/arm9/overlays/ov006/symbols.txt)`[n])()` -- it is the index into that pointer-to-member table. Render tests it against 3, 4, 6 and 7 to pick which pass to draw. |
 | 0x500c | `mReelDrawY` | While positive the two marker rows are drawn at `n + 0x10` and `n + 0x60`; at 0 or below a single row is drawn at 0x60. |
 | 0x5010 | `mWinColumn` | Used as `n * 0x50 + 0x20/0x30/0x40` for the payout caption's x, against the same 0x50 column pitch the reels use; a negative value selects the "no win" caption instead. |
-| 0x5018 | `mLamp1Angle` / `mLamp2Angle` (0x501a) | u16 each. Behavior subtracts 0x200 and 0x400 a tick while `mState == 1`; Render hands each to `func_ov004_020afb20` in its rotation argument. InitResources zeroes both. |
+| 0x5018 | `mLamp1Angle` / `mLamp2Angle` (0x501a) | u16 each. Behavior subtracts 0x200 and 0x400 a tick while `mState == 1`; Render hands each to `[func_ov004_020afb20](../src/func_ov004_020afb20.cpp) in its rotation argument. InitResources zeroes both. |
 | 0x501c | `mReelStrip[3][5]` | Render walks it as `*(u8*)(p + row + 0x501c)` with `p` advancing 5 a reel and `row` taken modulo `mStripLength` -- three reels of five stops. |
 | 0x502e | `mLineActive[3]` | Three bytes gating both the payout-marker pass and the win chime. |
 | 0x5031 | `mResultSymbols[3][3]` | The same walk with `p` advancing 3 a reel, indexed 0..2 -- the 3x3 window the reels stopped on, compared against `mWinSymbol`. |
 | 0x503a | `mStripLength` | The modulus of that `row` walk, i.e. the number of stops per reel. |
-| 0x503b | `mWinSymbol` | Drawn as the marker row (`data_ov006_0213e9a4[n * 3 + i]`) and compared against `mResultSymbols` to decide a win. InitResources seeds it from 0x503c. |
+| 0x503b | `mWinSymbol` | Drawn as the marker row ([data_ov006_0213e9a4](../config/arm9/overlays/ov006/symbols.txt)`[n * 3 + i]`) and compared against `mResultSymbols` to decide a win. InitResources seeds it from 0x503c. |
 | 0x503f | `mFrameCounter` | u8. Behavior increments it unconditionally; Render gates the marker pass on `n & 0x20` and fires the win chime exactly once per cycle on `(n & 0x3f) == 0x20`. |
 
 Left `unk_`: 0x4ff0, 0x5004 (copied out of dScMgBase_c's own 0xbc, but nothing
@@ -508,7 +508,7 @@ into it by raw offset).
 
 | Offset | Name | Evidence |
 | --- | --- | --- |
-| 0x5fb8 | `mCursorX` / `mCursorY` (0x5fbc) | Behavior loads the touch sample `data_020a0dea` / `data_020a0deb` and shifts it left 12; the nearest-petal test is `Vec2_Len` of the difference against this pair. |
+| 0x5fb8 | `mCursorX` / `mCursorY` (0x5fbc) | Behavior loads the touch sample [data_020a0dea](../config/arm9/symbols.txt) / [data_020a0deb](../config/arm9/symbols.txt) and shifts it left 12; the nearest-petal test is `Vec2_Len` of the difference against this pair. |
 | 0x5fc0 | `mPrevCursorX` / `mPrevCursorY` (0x5fc4) | Copied from the pair above at the top of state 0; the drag applied to the held petal is the difference between the two. |
 | 0x5fc8 | `mHeldPetal` | The `mArray` index the search loops store on a hit and read back to move that element; -1 means nothing is held, and the drop path restores it to -1. |
 | 0x5fcc | `mPetalToggle` | u8, flipped on every completed pull. One value plays sound 0x103 with banner 0x10, the other 0x104 with banner 0x13 -- the "loves me / loves me not" alternation. |
@@ -519,20 +519,20 @@ into it by raw offset).
 | 0x5fe0 | `mLoseStreak` | The mirror counter on the other outcome; at 3 it swaps in banner 0x11. It never touches the score. |
 | 0x5fe4 | `mHoldTimer` | src/_ZN13dScMgFlower_c13OnYoshiTryEatEi.cpp increments it while `<= 0x14` and otherwise resets it to 0; Behavior treats `> 0x14` as "held long enough". InitResources zeroes it. |
 | 0x5fe8 | `mState` | Behavior's `switch`: 0 plays, 1 is over (it stops the prompt and only ticks the 0x51f8 object). |
-| 0x5fec | `mFaceSprite` | Render's only use is `data_ov006_0213ab94[n]` drawn at the screen centre; Behavior sets it to 0..4 on each outcome. |
+| 0x5fec | `mFaceSprite` | Render's only use is [data_ov006_0213ab94](../config/arm9/overlays/ov006/symbols.txt)`[n]` drawn at the screen centre; Behavior sets it to 0..4 on each outcome. |
 | 0x5ff0 | `mScore` | Incremented by 1 or 3 per winning pull and clamped to 0x270f -- the same 9999 cap dScMgAmida_c and dScMgSnowball_c use. |
-| 0x5ff4 | `mBgScrollPhase` | u16. Render adds 0xc0 a frame and feeds `>> 4` into `data_02082214` for both background layers -- the same idiom as dScMgAmida_c's own. |
+| 0x5ff4 | `mBgScrollPhase` | u16. Render adds 0xc0 a frame and feeds `>> 4` into [data_02082214](../config/arm9/symbols.txt) for both background layers -- the same idiom as dScMgAmida_c's own. |
 
 Left `unk_`: 0x5fcd, a second gate on the between-rounds branch that nothing in
 scope ever writes.
 
 ## dScMgTrampoline_c field names
 
-Almost everything this class does with its own tail happens in the ov006
+Almost everything this class does with its own tail happens in the [ov006](../config/arm9/overlays/ov006/symbols.txt) trampoline minigame, so the
 helper functions its pointer-to-member state machine dispatches to, not in the
 four vtable methods; the citations below name those functions. All of them,
 helpers and vtable methods alike, now live in the class's own translation unit,
-src/minigames/d_s_mg_trampoline.cpp.
+[src/minigames/d_s_mg_trampoline.cpp](../src/minigames/d_s_mg_trampoline.cpp).
 
 The three state-entry helpers are now real `dScMgTrampoline_c` members too:
 `BeginIntro`, `BeginPlay`, and `BeginResults`. Each initializes the fields for
@@ -546,25 +546,25 @@ address-only, so the exact original source names remain unknown.
 | 0x5d98 | `mScrollTargetY` | The other argument of that `ApproachLinear`; recomputed as `(q << 3) + 0x20` once the scroll has caught up. InitResources seeds it from `mScrollY`. |
 | 0x5d9c | `mScrollHoldTimer` | Loaded with 0x78 and run down to 0 by `ApproachLinear(..., 0, 1)`; the target may not move again until it reaches 0. |
 | 0x5da0 | `mScrollOffsetY` | Added to `mScrollY` at every one of its uses, and zeroed once the scroll settles. |
-| 0x5da4 | `mArrow1X` / `mArrow2X` (0x5da8) | `dScMgTrampoline_c::StatePlay` drives the pair in opposition (`ApproachLinear` one toward 0 while the other goes toward 0x20); Render draws sprite `data_ov006_02134f08` at `n + 0xf0` for each. |
+| 0x5da4 | `mArrow1X` / `mArrow2X` (0x5da8) | `dScMgTrampoline_c::StatePlay` drives the pair in opposition (`ApproachLinear` one toward 0 while the other goes toward 0x20); Render draws sprite [data_ov006_02134f08](../config/arm9/overlays/ov006/symbols.txt) at `n + 0xf0` for each. |
 | 0x5dac | `mDragSoundHandle` | `UpdateTouchInput` passes the previous word to `func_02012468`, stores its returned handle, and zeroes it when a new drag begins; the intro interpolation uses the same positional-sound update path. |
-| 0x5db0 | `mTouchX` / `mTouchY` (0x5db2) | `dScMgTrampoline_c::UpdateTouchInput` refreshes them from the touch sample `data_020a0dea` / `data_020a0deb` every tick a drag is live, and draws the drag segment from them. |
+| 0x5db0 | `mTouchX` / `mTouchY` (0x5db2) | `dScMgTrampoline_c::UpdateTouchInput` refreshes them from the touch sample [data_020a0dea](../config/arm9/symbols.txt) / [data_020a0deb](../config/arm9/symbols.txt) every tick a drag is live, and draws the drag segment from them. |
 | 0x5db4 | `mTouchStartX` / `mTouchStartY` (0x5db6) | Copied from the pair above on the press edge and then left alone; `OnAttacked2` measures the swipe as start-to-current and only accepts it if the two ends sit on opposite sides of the screen. |
 | 0x5db8 | `mInputEnabled` | s16. `UpdateTouchInput` clears `mTouching` and returns immediately while it is 0. |
 | 0x5dc4 | `mTouching` | u8, set on the press edge and cleared when input is disabled; the drag body runs only while it is 1. |
 | 0x5dc5 | `mTouchReleased` | u8, set on the release edge by the same file; `OnAttacked2` is the only reader and clears it after scoring the swipe. |
 
 Left `unk_`: 0x5dba (an s16 with its own getter/setter pair,
-`func_ov006_02121750` and `func_ov006_02121768`, but no reader that says what it
+[func_ov006_02121750](../config/arm9/overlays/ov006/symbols.txt) and [func_ov006_02121768](../config/arm9/overlays/ov006/symbols.txt), but no reader that says what it
 means), 0x5dbc..0x5dc2 (four s16 counters inside `dScMgTrampoline_c::StatePlay`'s
 banner-blink logic).
 
 ## The minigame camera, and the base fields it explains
 
-`src/Camera_UpdateMatrices.c` is the ov006 routine every 3D minigame scene
+`src/Camera_UpdateMatrices.c` is the [ov006](../config/arm9/overlays/ov006/symbols.txt) routine every 3D minigame scene
 calls once a frame, and the local struct it already carries is the whole story:
 
-```
+```cpp
 struct Camera {           /* 0xbc */
     Matrix4x3 viewMat;    /* 0x00 */
     char      pad30[0x30];
@@ -610,13 +610,13 @@ Only the fields several descendants corroborate are named here; this class has
 
 | Offset | Name | Evidence |
 | --- | --- | --- |
-| 0x0b4 | `mHudScore` | `dScMgBase_c::BeforeInitResources` zeroes it. `func_ov004_020adb1c` -- the routine that writes the HUD counter word at scene+0x464c -- is handed it directly by `func_ov006_02125364` (src/minigames/d_s_mg_bsc.cpp) and src/func_ov006_020ea3d0.c; dScMgMemory_c and dScMgSound_c seed it in their own InitResources; dScMgCard_c::Render keeps its own high-water mark of it; dScMgAmida_c::Behavior copies its round score into it. Deliberately NOT called `mScore`: five leaves already have a field of their own by that name, and naming the base's the same would silently shadow every one of them (see the round-2 `mPrevPosX` incident). |
-| 0x21c | `mSavedMainBgBits` | src/_ZN11dScMgBase_c16OnAimedAtWithEggEv.cpp (slot 29) stores `data_0209d45c` here; src/_ZN11dScMgBase_c25OnAimedAtWithEggReturnVecEv.cpp (slot 30) restores it from here. |
-| 0x220 | `mSavedSubBgBits` | The same save/restore pair for `data_0209d454`. |
+| 0x0b4 | `mHudScore` | `dScMgBase_c::BeforeInitResources` zeroes it. [func_ov004_020adb1c](../src/func_ov004_020adb1c.c) -- the routine that writes the HUD counter word at scene+0x464c -- is handed it directly by `func_ov006_02125364` (part of:[d_s_mg_bsc.cpp](../src/minigames/d_s_mg_bsc.cpp)) and [func_ov006_020ea3d0.c](../src/func_ov006_020ea3d0.c); dScMgMemory_c and dScMgSound_c seed it in their own InitResources; dScMgCard_c::Render keeps its own high-water mark of it; dScMgAmida_c::Behavior copies its round score into it. Deliberately NOT called `mScore`: five leaves already have a field of their own by that name, and naming the base's the same would silently shadow every one of them (see the round-2 `mPrevPosX` incident). |
+| 0x21c | `mSavedMainBgBits` | src/_ZN11dScMgBase_c16OnAimedAtWithEggEv.cpp (slot 29) stores [data_0209d45c](../config/arm9/symbols.txt) here; src/_ZN11dScMgBase_c25OnAimedAtWithEggReturnVecEv.cpp (slot 30) restores it from here. |
+| 0x220 | `mSavedSubBgBits` | The same save/restore pair for [data_0209d454](../config/arm9/symbols.txt). |
 | 0x224 | `mSavedScreenSwap` | Saved as `(POWCNT1 & 0x8000) >> 15` and restored as `n << 15` by that same pair. |
 
 Deliberately left `unk_`: 0x0a8/0x0ac (a pair every leaf seeds together and
-`func_ov004_020ad79c` checks against `func_ov004_020ad8b8`, but nothing in the
+[func_ov004_020ad79c](../src/func_ov004_020ad79c.c) checks against [func_ov004_020ad8b8](../src/func_ov004_020ad8b8.c), but nothing in the
 tree says what it counts -- dScMgRoulette_c reads it through the singleton as a
 bonus added to its payout), 0x0bc (clamped to 0x270e, taken modulo 5, and used
 to scale difficulty in four different leaves -- a progression counter of some
@@ -627,8 +627,8 @@ kind, but nothing in scope increments it), 0x0b8, 0x0c8, 0x0f0, 0x05c,
 
 | Offset | Name | Evidence |
 | --- | --- | --- |
-| 0x53d6 | `mSelectedTile` | Render draws the cursor sprite at `data_ov006_02142ab4[n]` / `_02142ab8[n]` (the tile coordinate tables, stride 8); Behavior hands the same value to `func_ov006_02108b90` once per racer to score the board. |
-| 0x53e4 | `mCameraPreset` | Render copies row `n` of `data_ov006_0213e34c` and `_0213e370` (stride 0xc) into the base's `mCameraTarget` and `mCameraEye`, takes the angle from `data_ov006_0213e2e0 + n*2`, and then calls `Camera_UpdateMatrices`. 0 leaves the camera alone. Behavior sets it to 1 as the deal starts and clears it at the end. |
+| 0x53d6 | `mSelectedTile` | Render draws the cursor sprite at [data_ov006_02142ab4](../config/arm9/overlays/ov006/symbols.txt)`[n]` / [_02142ab8](../config/arm9/overlays/ov006/symbols.txt)`[n]` (the tile coordinate tables, stride 8); Behavior hands the same value to `func_ov006_02108b90` (part of:[d_s_mg_roulette.cpp](../src/minigames/d_s_mg_roulette.cpp)) once per racer to score the board. |
+| 0x53e4 | `mCameraPreset` | Render copies row `n` of [data_ov006_0213e34c](../config/arm9/overlays/ov006/symbols.txt) and [_0213e370](../config/arm9/overlays/ov006/symbols.txt) (stride 0xc) into the base's `mCameraTarget` and `mCameraEye`, takes the angle from [data_ov006_0213e2e0](../config/arm9/overlays/ov006/symbols.txt) + n*2, and then calls `Camera_UpdateMatrices`. 0 leaves the camera alone. Behavior sets it to 1 as the deal starts and clears it at the end. |
 | 0x53e6 | `mPhase` | Behavior's `switch`: 1 deals the racers out one at a time, 2 runs the countdown and reads the board, 3 pays out per landed tile, 4 announces win/lose/draw. _ZN15dScMgRoulette_c13OnYoshiTryEatEi (in src/actors/dScMgRoulette_c.cpp) starts it at 1. |
 | 0x53e8 | `mPhaseTimer` | Counted down in every phase and reloaded on each transition (8, 0x258, 1, 0x5a); Render also renders the countdown digits from it while `mPhase == 2`. |
 | 0x53f2 | `mScore` | Phase 3 sums each racer's payout into it and phase 4 compares it against `mTargetScore` to pick the win, lose or draw banner. Zeroed by the reset. |
@@ -644,10 +644,10 @@ bytes the reset zeroes and nothing reads).
 
 | Offset | Name | Evidence |
 | --- | --- | --- |
-| 0x5388 | `mState` | `func_ov006_020dac34` in src/minigames/d_s_mg_card.cpp is one long `switch` on it that mostly `++`s it; `func_ov006_020db720` in the same file switches on the same field; the reset in `func_ov006_020db9dc`, also there, starts it at 1. |
+| 0x5388 | `mState` | [func_ov006_020dac34](../src/minigames/d_s_mg_card.cpp) in [d_s_mg_card.cpp](../src/minigames/d_s_mg_card.cpp) is one long `switch` on it that mostly `++`s it; [func_ov006_020db720](../src/minigames/d_s_mg_card.cpp) in the same file switches on the same field; the reset in [func_ov006_020db9dc](../src/minigames/d_s_mg_card.cpp) also there, starts it at 1. |
 | 0x538a | `mStateTimer` | Reloaded with 0x10, 0x14, 0x1e, 0x3c or 0x5a on each step and run down to 0 (by `--` or `ApproachLinear2`) before `mState` advances. |
 | 0x5396 | `mFrameCounter` | `dScMgCard_c::Behavior`'s only own statement is `+= 1`; Render blinks the highlighted cards on bit 3. |
-| 0x5398 | `mScore` | Render keeps it as a high-water mark of the base's `mHudScore` and pushes it back out through `func_ov004_020adb1c` every frame. |
+| 0x5398 | `mScore` | Render keeps it as a high-water mark of the base's `mHudScore` and pushes it back out through [func_ov004_020adb1c](../src/func_ov004_020adb1c.c) every frame. |
 
 Left `unk_`: 0x538c, and the two highlight pairs 0x538e/0x5390 and
 0x5392/0x5394. Their mechanics are now in the header (Render blinks the card

--- a/notes/minigame-provenance.md
+++ b/notes/minigame-provenance.md
@@ -442,30 +442,30 @@ the previous header held as four pads, and a run/HUD block at 0xb9d8.
 
 | Offset | Name | Evidence |
 | --- | --- | --- |
-| 0xab38 | `mPosX` / `mPosY` (0xab3c) | src/func_ov006_021279b0.cpp seeds `mPosX = 0x80000` and `mPosY = mStartY << 12`; Behavior adds the velocity into both; Render's progress bar reads `mPosY >> 12`. |
+| 0xab38 | `mPosX` / `mPosY` (0xab3c) | [func_ov006_021279b0](../src/func_ov006_021279b0.cpp) seeds `mPosX = 0x80000` and `mPosY = mStartY << 12`; Behavior adds the velocity into both; Render's progress bar reads `mPosY >> 12`. |
 | 0xab40 | `mPrevPosX` / `mPrevPosY` (0xab44) | Behavior's first act each tick is to copy 0xab38/0xab3c here, and the climb term is `mPosY - mPrevPosY`. |
-| 0xab48 | `mDrawPosX` / `mDrawPosY` (0xab4c) | Render draws the ball sprite `data_ov006_02139c38` at `(n - mScrollX) >> 12`, the same transform every world object gets. |
+| 0xab48 | `mDrawPosX` / `mDrawPosY` (0xab4c) | Render draws the ball sprite [data_ov006_02139c38](../config/arm9/overlays/ov006/symbols.txt) at `(n - mScrollX) >> 12`, the same transform every world object gets. |
 | 0xab50 | `mSoundPosX` / `mSoundPosY` (0xab54) | Behavior fires a rolling sound whenever the position has moved 0x30000 from these two, then copies the position in. |
 | 0xab60 | `mVelX` / `mVelY` (0xab64) | `Vec2_Len` of the pair is the speed, `atan2` of it is the heading, and it is added into `mPos` each tick. Capped at 0x8000. |
-| 0xab68 | `mScrollX` | Subtracted from every world X before drawing; src/func_ov006_021279b0.cpp zeroes it. |
-| 0xab6c | `mScrollY` | `mPosY - 0x190000`, clamped to `[0, mScrollLimit]`; drives all four `SetBg*Offset` calls and the four hardware scroll registers in src/_ZN15dScMgSnowball_c8OnKickedEv.cpp. |
+| 0xab68 | `mScrollX` | Subtracted from every world X before drawing; [func_ov006_021279b0](../src/func_ov006_021279b0.cpp) zeroes it. |
+| 0xab6c | `mScrollY` | `mPosY - 0x190000`, clamped to `[0, mScrollLimit]`; drives all four `SetBg*Offset` calls and the four hardware scroll registers in [_ZN15dScMgSnowball_c8OnKickedEv](../src/_ZN15dScMgSnowball_c8OnKickedEv.cpp). |
 | 0xab70 | `mTouchX` / `mTouchY` (0xab74) | Behavior stores the raw touch sample (`data_020a0dea` / `data_020a0deb`) here and steers off the difference from the previous one. |
 | 0xab78 | `mRollAngle` | u16. `+= speed * 0x2710 / mBallSize` -- an angle that advances faster the smaller the ball. |
 | 0xab7c | `mHeadingAngle` | u16. `atan2(mVelX, mVelY)`, approached linearly while rolling and set outright while crashing. |
 | 0xab7e | `mPrevRollAngle` / `mPrevHeadingAngle` (0xab82) | Behavior's prologue copies 0xab78..0xab7c into 0xab7e..0xab82 verbatim. |
-| 0xab84 | `mSpinAxis[3]` | src/func_ov006_021279b0.cpp seeds it from a `(0, 0x1000, 0)` Vector3 and passes it to `Quaternion_FromVector3`. |
+| 0xab84 | `mSpinAxis[3]` | [func_ov006_021279b0](../src/func_ov006_021279b0.cpp) seeds it from a `(0, 0x1000, 0)` Vector3 and passes it to `Quaternion_FromVector3`. |
 | 0xab90 | `mSpinQuat[4]` | The destination of that same `Quaternion_FromVector3`, then `Quaternion_Normalize`. Four words. |
 | 0xaba0 | `mBallSize` | Seeded 0x4000; grows by the uphill distance, capped at 0x37000; Render scales mModel by `n/2 + n*4`; the melt state subtracts 0x1000 a tick until it reaches 0. |
 | 0xac58 | `mArray1Active[0x80]` | Render skips an mArray1 slot unless this byte is 1. |
 | 0xb0d8 | `mArray1Kind[0x80]` | 1 picks the eight-frame animated sprite table, anything else the single static sprite. |
-| 0xb2d8 | `mArray1Hit[0x80]` | src/func_ov006_02125bbc.c sets it to 1 on contact; Render then adds 8 to the sprite frame. |
+| 0xb2d8 | `mArray1Hit[0x80]` | [func_ov006_021279b0](../src/func_ov006_021279b0.cpp) sets it to 1 on contact; Render then adds 8 to the sprite frame. |
 | 0xb358 | `mArray2Active[0x80]` | The same gate for mArray2. |
 | 0xb3d8 | `mArray2Kind[0x80]` | Render's `switch`: 0..2 draw one sprite, 3 picks between two by X. |
 | 0xb9d8 | `mAnimCounter` | Render bumps it and wraps it at 0x20; the obstacle frame is `(n / 4) & 7`. |
 | 0xb9dc | `mTimeLeft` | Frames. Seeded 0x960 or 0x4b0 by variant; Behavior counts it down and plays a tick sound at 60/30/15-frame intervals as it shortens; Render formats it as seconds and centiseconds; 0 ends the run. |
-| 0xb9e0 | `mScore` | Zeroed by the reset, +1 a tick while rolling, handed to the HUD counter `func_ov004_020adb1c` at the crash -- the same sink dScMgAmida_c's score uses. |
+| 0xb9e0 | `mScore` | Zeroed by the reset, +1 a tick while rolling, handed to the HUD counter [func_ov004_020adb1c](../src/func_ov004_020adb1c.c) at the crash -- the same sink dScMgAmida_c's score uses. |
 | 0xb9f4 | `mState` | Behavior's `switch`: 0 count-in, 1 rolling, 2/3 crash, 4 melt, 5 over. |
-| 0xb9f8 | `mScreensSwapped` | u8. Behavior sets it from `mPosY >= 0xe8000`; src/_ZN15dScMgSnowball_c8OnKickedEv.cpp uses it to flip the POWCNT1 display-swap bit at 0x4000304 and exchange the main/sub BG offsets. |
+| 0xb9f8 | `mScreensSwapped` | u8. Behavior sets it from `mPosY >= 0xe8000`; [_ZN15dScMgSnowball_c8OnKickedEv](../src/_ZN15dScMgSnowball_c8OnKickedEv.cpp) uses it to flip the POWCNT1 display-swap bit at 0x4000304 and exchange the main/sub BG offsets. |
 | 0xb9fc | `mCountdownTimer` | Seeded 0xf1; state 0 counts it down, plays a beep at 0xf0/0xb4/0x78 and starts the run at 0x3c; Render draws the 3-2-1 banner from `n / 60`. |
 | 0xba00 | `mStartY` | 0x2dc0 or 0x1740 by variant; `mPosY` starts at `mStartY << 12` and the progress bar uses it as one end. |
 | 0xba04 | `mGoalY` | The other end of that bar, and the line `mPosY - mBallSize` must cross to end the run. |

--- a/notes/minigame-provenance.md
+++ b/notes/minigame-provenance.md
@@ -416,11 +416,11 @@ name -- a wrong name is a claim the next reader will trust.
 | 0x4724 | `mLanePos[4][2]` | [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) seeds `{ (0x20 + 0x40*i) << 12, 0xb0 << 12 }`; Behavior adds `mLaneVel` into it; Render draws the lane sprite at `>> 12`. |
 | 0x4744 | `mLaneVel[4][2]` | Added into `mLanePos` once a tick, and its y component loses a fixed 0x100 every tick -- a velocity under gravity. Zeroed by the same reset. |
 | 0x4768 | `mPieces[0x80]` | Renamed from `arr4768`; the element layout is unchanged (see the section above). |
-| 0x5368 | `mScrollSpeed` | [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) computes it from the pattern table [data_ov006_0212e1b0](../config/arm9/overlays/ov004/symbols.txt) `+ mPatternIndex * 0x1c`, biases it by the inherited 0xbc, and clamps it to 0x64. |
+| 0x5368 | `mScrollSpeed` | [src/func_ov006_020d3ba0.cpp](../src/func_ov006_020d3ba0.cpp) computes it from the pattern table [data_ov006_0212e1b0](../config/arm9/overlays/ov006/symbols.txt) `+ mPatternIndex * 0x1c`, biases it by the inherited 0xbc, and clamps it to 0x64. |
 | 0x536c | `mScrollAccum` | Behavior adds `mScrollSpeed` into it, keeps the low four bits (`&= 0xf`) and runs [func_ov006_020d27dc](../config/arm9/overlays/ov006/symbols.txt) once per 16 accumulated -- a fixed-point step accumulator. |
 | 0x5374 | `mRoundCount` | Zeroed by the reset; Behavior replays the board while it is below 5 and finishes at 5, and scales the fast-forward speed by `n * 5 + 0x20`. |
 | 0x539c | `mLaneAnimTimer[4]` | Render bumps entry `i` each frame and wraps it on the per-lane period it copies out of [data_ov006_0213b880](../config/arm9/overlays/ov006/symbols.txt). |
-| 0x53ac | `mLaneAnimFrame[4]` | Bumped when the timer above wraps, cycles 0..0xd, and indexes the sprite table [data_o006_0213a458](../config/arm9/overlays/ov006/symbols.txt). |
+| 0x53ac | `mLaneAnimFrame[4]` | Bumped when the timer above wraps, cycles 0..0xd, and indexes the sprite table [data_ov006_0213a458](../config/arm9/overlays/ov006/symbols.txt). |
 | 0x53bc | `mBgScrollPhase` | u16. Render adds 0xc0 a frame and feeds `>> 4` into the shared sine table [data_02082214](../config/arm9/symbols.txt) to get the sub-screen BG2 offset. The 16-bit width comes from the reset's own `*(s16*)` store. |
 | 0x53c0 | `mResultWaitTimer` | Loaded with 0x3c on entry to state 2 and counted down there; at 0 the scene clears `mPromptEnabled` and moves to state 3. |
 | 0x53c4 | `mStartBannerTimer` | Reset to 0x3c right after [func_ov004_020b0cac](../src/func_ov004_020b0cac.c)`(0xd, 0x80, 0x60, ...)` puts banner 0xd on screen; Behavior counts it down and calls `FreeGfxSlotsById(0xd)` on expiry. |
@@ -458,7 +458,7 @@ the previous header held as four pads, and a run/HUD block at 0xb9d8.
 | 0xaba0 | `mBallSize` | Seeded 0x4000; grows by the uphill distance, capped at 0x37000; Render scales mModel by `n/2 + n*4`; the melt state subtracts 0x1000 a tick until it reaches 0. |
 | 0xac58 | `mArray1Active[0x80]` | Render skips an mArray1 slot unless this byte is 1. |
 | 0xb0d8 | `mArray1Kind[0x80]` | 1 picks the eight-frame animated sprite table, anything else the single static sprite. |
-| 0xb2d8 | `mArray1Hit[0x80]` | [func_ov006_021279b0](../src/func_ov006_021279b0.cpp) sets it to 1 on contact; Render then adds 8 to the sprite frame. |
+| 0xb2d8 | `mArray1Hit[0x80]` | [func_ov006_02125bbc.c](../src/func_ov006_02125bbc.c) sets it to 1 on contact; Render then adds 8 to the sprite frame. |
 | 0xb358 | `mArray2Active[0x80]` | The same gate for mArray2. |
 | 0xb3d8 | `mArray2Kind[0x80]` | Render's `switch`: 0..2 draw one sprite, 3 picks between two by X. |
 | 0xb9d8 | `mAnimCounter` | Render bumps it and wraps it at 0x20; the obstacle frame is `(n / 4) & 7`. |
@@ -488,7 +488,7 @@ any matched body reads).
 | 0x5000 | `mState` | Behavior's whole body is `(self->*`[data_ov006_02142bdc](../config/arm9/overlays/ov006/symbols.txt)`[n])()` -- it is the index into that pointer-to-member table. Render tests it against 3, 4, 6 and 7 to pick which pass to draw. |
 | 0x500c | `mReelDrawY` | While positive the two marker rows are drawn at `n + 0x10` and `n + 0x60`; at 0 or below a single row is drawn at 0x60. |
 | 0x5010 | `mWinColumn` | Used as `n * 0x50 + 0x20/0x30/0x40` for the payout caption's x, against the same 0x50 column pitch the reels use; a negative value selects the "no win" caption instead. |
-| 0x5018 | `mLamp1Angle` / `mLamp2Angle` (0x501a) | u16 each. Behavior subtracts 0x200 and 0x400 a tick while `mState == 1`; Render hands each to `[func_ov004_020afb20](../src/func_ov004_020afb20.cpp) in its rotation argument. InitResources zeroes both. |
+| 0x5018 | `mLamp1Angle` / `mLamp2Angle` (0x501a) | u16 each. Behavior subtracts 0x200 and 0x400 a tick while `mState == 1`; Render hands each to [func_ov004_020afb20](../src/func_ov004_020afb20.cpp) in its rotation argument. InitResources zeroes both. |
 | 0x501c | `mReelStrip[3][5]` | Render walks it as `*(u8*)(p + row + 0x501c)` with `p` advancing 5 a reel and `row` taken modulo `mStripLength` -- three reels of five stops. |
 | 0x502e | `mLineActive[3]` | Three bytes gating both the payout-marker pass and the win chime. |
 | 0x5031 | `mResultSymbols[3][3]` | The same walk with `p` advancing 3 a reel, indexed 0..2 -- the 3x3 window the reels stopped on, compared against `mWinSymbol`. |


### PR DESCRIPTION
Enhance the documentation by adding overlay and data links in the `ITCM` section and continuing work on the two biggest docs alongside `plan-tu-merge-queue` :

`minigame-provenance`;
`ghidra-dsd-landscape`