### PR TITLE
Make stage 3b re-measure the prose its rename pass invalidates

### DIFF
--- a/notes/agents/roles/reviewer.md
+++ b/notes/agents/roles/reviewer.md
@@ -39,6 +39,15 @@ that the evidence means what it claims.
 9. **The merge tree, not the branch.** `premerge_check` gates each PR alone. Two
    individually-green PRs can produce a red main. Compose the merge yourself and
    verify before landing.
+10. **Re-measure every count a shipped artifact asserts.** This is the defect you
+    will find most often, and no gate looks for it: prose written at stage 2 is
+    invalidated by stage 3b's rename pass, and comments, manifest notes and PR
+    bodies all ship the stale figure. Count the things yourself -- symbols,
+    definitions, `extern "C"` regions, unlicensed sections, ledger rows -- and
+    compare against the file, not against the body. Treat a stated number that
+    contradicts its own artifact as a defect to name even though it is
+    byte-neutral. Check negative claims hardest: a search result is unproven until
+    its case, scope and encoding are stated.
 
 ## Merging
 

--- a/notes/agents/roles/writer.md
+++ b/notes/agents/roles/writer.md
@@ -56,6 +56,36 @@ the manifest's `functions[]` move in the same commit. No byte gate at stage 2 or
 catches this; the cheap link evidence is a `.symtab` undefined-symbol scan of the
 emitted object.
 
+**The rename also invalidates your own prose, and nothing will tell you.** Stage 2
+writes comments, manifest notes and a PR body describing the file it just folded --
+"the six C++-named members", "the two file-scope `extern "C"` regions". Stage 3b then
+renames forty or fifty members, and every one of those counts becomes wrong. No gate
+reads prose: `mwccarm` strips comments, `tiers.py` blanks them before scoring, and
+`check_dead_references.py` walks only `.md`, so a stale count inside a `.cpp` is
+completely ungated.
+
+This is the **most common defect the reviewer finds**, and it has hit both of the two
+most recent classes: five wrong counts across `ov071/Scuttlebug`'s manifest notes,
+facts file and PR body, and three in one comment block shipped inside
+`src/actors/dScMgLuigi_c.cpp`.
+
+So, before you hand off:
+
+* **Re-measure every number your prose asserts.** Count the regions, the mangled
+  symbols, the definitions -- do not carry a stage-2 figure forward on trust.
+* **State the counts you assert**, rather than describing shape vaguely. "57
+  definitions carrying 58 symbols; 55 mangled, 3 C-named; 10 file-scope regions"
+  makes the next drift visible; "the two regions below" hides it.
+* **A negative claim from a search is unproven until you state the search's case,
+  scope and encoding.** `ov071/Scuttlebug` shipped "nothing named Scuttlebug or
+  Spider exists anywhere in this cartridge" from a case-sensitive scan; lowercase
+  `spider` is in `overlay_0000.bin` as two asset paths and `SPIDER` is in
+  `arm9_dec.bin`. The class name really was coined -- the stated reason was not.
+
+A count that contradicts the file shipping around it is the same defect the builder
+keeps fixing in the banner, re-introduced one stage later. It moves no bytes and it
+misleads every agent who reads the file afterwards as fact.
+
 ## Coined class names are allowed, and must be recorded as coined
 
 An earlier version of this file told you not to claim a class whose name was coined


### PR DESCRIPTION
## What this changes

Two role files. No code, no config, no ledger.

The reviewer has now found the **same defect class on both of the last two
classes**, and it is the one no gate looks for.

| PR | class | what shipped wrong |
|---|---|---|
| #2379 | `ov071/Scuttlebug` | **5** wrong counts across the manifest notes, the scout facts file and the PR body |
| #2383 | `ov006/dScMgLuigi_c` | **3** wrong counts in one comment block shipped inside `src/actors/dScMgLuigi_c.cpp` |

Both were byte-neutral. Both were corrected before merge. Neither was caught by a
gate — a reviewer read the file and counted.

## Why it keeps happening

It is structural, not carelessness.

**Stage 2** folds the shards and writes prose describing the file it just made —
*"the six C++-named members"*, *"the two file-scope `extern "C"` regions below"*.
**Stage 3b** then renames forty or fifty members. Every one of those counts is now
wrong, and nothing re-reads them:

* `mwccarm` strips comments,
* `tiers.py` blanks them before scoring,
* `check_dead_references.py` walks only `.md`.

So a stale count inside a `.cpp` is **completely ungated**, and it ships into the
file that the next agent reads as fact.

The Scuttlebug case shows the sharper version. The facts file asserted *"nothing
named Scuttlebug or Spider exists anywhere in this cartridge."* The search behind it
was case-sensitive. Lowercase `spider` is in `overlay_0000.bin` twice, as
`data/enemy/spider/spider.bmd` and `data/enemy/spider/spider_walk.bca`, and `SPIDER`
is in `arm9_dec.bin` at `0x8b7b0` — the profile name the project already spells
`g_profile_SPIDER`. The class name genuinely is coined; the stated reason for saying
so was false.

## The change

**`writer.md`**, in Stage 3b, next to the existing "the rename is ONE edit" warning:

* Re-measure every number the prose asserts — count the regions, the mangled
  symbols, the definitions. Do not carry a stage-2 figure forward on trust.
* **State the counts you assert** rather than describing shape vaguely. "57
  definitions carrying 58 symbols; 55 mangled, 3 C-named; 10 file-scope regions"
  makes the next drift visible; "the two regions below" hides it.
* A negative claim from a search is unproven until its **case, scope and encoding**
  are stated.

**`reviewer.md`** gains it as **check 10**, named as the defect they will find most
often, with the instruction to count against the file rather than against the body.

## Gate

`check_dead_references.py` → **exit 0**: 411 prose files, 4,323 repo-rooted path
references, no new dead references, no broken markdown links. (The new prose cites
`src/actors/dScMgLuigi_c.cpp`, which resolves — #2383 landed it.)

Docs-only, so CI runs a subset. Nothing here is a build input.
