### PR TITLE
Match func_ov006_020d36a4: the Amida shuffle, 1276 bytes

### DIFF
--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -1310,6 +1310,10 @@ src/func_ov006_020d3668.cpp:
     complete
     .text start:0x020d3668 end:0x020d36a4
 
+src/func_ov006_020d36a4.cpp:
+    complete
+    .text start:0x020d36a4 end:0x020d3ba0
+
 src/func_ov006_020d3ba0.cpp:
     complete
     .text start:0x020d3ba0 end:0x020d452c

--- a/src/func_ov006_020d36a4.cpp
+++ b/src/func_ov006_020d36a4.cpp
@@ -1,0 +1,147 @@
+//cpp
+#include "dScMgAmida_c.h"
+
+extern "C" {
+int RandomIntInternal(int *seed);
+extern int data_0209d4b8;
+extern s32 data_ov006_02141640[];
+extern s32 data_ov006_02141650[];
+extern u8 data_ov006_0212e1a8[];
+}
+
+extern "C" void func_ov006_020d36a4(dScMgAmida_c *self)
+{
+    int i;
+    int j;
+    int k;
+    int r;
+    int t;
+    u32 u;
+    int again;
+    u8 mark0[4];
+    u8 mark1[4];
+
+    self->unk_53dd = 0;
+    if (self->Unk36() != 0) {
+        again = 1;
+        for (i = 0; i < 4; i++) {
+            self->unk_4694[i] = i;
+        }
+        do {
+            for (k = 0; k < 4; k++) {
+                u = (u32)RandomIntInternal(&data_0209d4b8) >> 16;
+                r = ((u & 0x7fff) * 4) >> 15;
+                t = self->unk_4694[k];
+                self->unk_4694[k] = self->unk_4694[r];
+                self->unk_4694[r] = t;
+            }
+            if (self->mRoundCount == 0) {
+                again = 0;
+                switch (self->mPatternIndex) {
+                case 0:
+                    self->unk_46a4[0] = 0;
+                    self->unk_46a4[1] = 0;
+                    self->unk_46a4[2] = 3;
+                    self->unk_46a4[3] = 3;
+                    break;
+                case 1:
+                case 3:
+                case 5:
+                    self->unk_46a4[0] = 0;
+                    self->unk_46a4[1] = 0;
+                    self->unk_46a4[2] = 1;
+                    self->unk_46a4[3] = 3;
+                    break;
+                default:
+                    for (i = 0; i < 4; i++) {
+                        self->unk_46a4[i] = i;
+                    }
+                    break;
+                }
+                for (j = 0; j < 4; j++) {
+                    data_ov006_02141640[self->unk_4694[j]] = self->unk_46a4[j];
+                }
+            } else {
+                for (i = 0; i < 4; i++) {
+                    data_ov006_02141650[i] = data_ov006_02141640[i];
+                }
+                for (j = 0; j < 4; j++) {
+                    data_ov006_02141640[self->unk_4694[j]] = self->unk_46a4[j];
+                }
+                for (j = 0; j < 4; j++) {
+                    if (data_ov006_02141650[j] != data_ov006_02141640[j]) {
+                        again = 0;
+                        break;
+                    }
+                }
+            }
+        } while (again == 1);
+    } else if (self->unk_46c8 == 1) {
+        if (self->mRoundCount == 0) {
+            r = ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 4) >> 15;
+            t = self->unk_4694[0];
+            self->unk_4694[0] = self->unk_4694[r];
+            self->unk_4694[r] = t;
+        } else {
+            r = (((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 3) >> 15) + 1;
+            t = self->unk_4694[0];
+            self->unk_4694[0] = self->unk_4694[r];
+            self->unk_4694[r] = t;
+        }
+    } else {
+        again = 1;
+        for (int n = 0; n < 4; n++) {
+            mark1[n] = 0;
+        }
+        for (j = 0; j < self->unk_46c8; j++) {
+            mark1[self->unk_4694[j]] = 1;
+        }
+        do {
+            for (int n = 0; n < 4; n++) {
+                mark0[n] = 0;
+            }
+            for (i = 0; i < 4; i++) {
+                self->unk_4694[i] = i;
+            }
+            for (k = 0; k < 4; k++) {
+                u = (u32)RandomIntInternal(&data_0209d4b8) >> 16;
+                r = ((u & 0x7fff) * 4) >> 15;
+                t = self->unk_4694[k];
+                self->unk_4694[k] = self->unk_4694[r];
+                self->unk_4694[r] = t;
+            }
+            for (j = 0; j < self->unk_46c8; j++) {
+                mark0[self->unk_4694[j]] = 1;
+            }
+            if (self->mRoundCount == 0) {
+                again = 0;
+            } else {
+                for (int n = 0; n < 4; n++) {
+                    if (mark0[n] != mark1[n]) {
+                        again = 0;
+                        break;
+                    }
+                }
+            }
+        } while (again == 1);
+    }
+
+    for (i = 0; i < 4; i++) {
+        if (self->Unk36() != 0) {
+            self->unk_46b8[i] = 0;
+        } else {
+            self->unk_46b8[i] = i * *(s32 *)(data_ov006_0212e1a8 + self->mPatternIndex * 0x1c + 0x14) * 0x3c;
+        }
+        self->unk_4660[i][0] = (self->unk_4694[i] << 6) + 0x20;
+        if (self->Unk36() != 0) {
+            self->unk_4660[i][1] = -0xcc;
+        } else {
+            self->unk_4660[i][1] = -0xd4;
+        }
+        self->unk_4684[i] = -1;
+        self->unk_4680[i] = 0;
+        self->unk_46b4[i] = 0;
+    }
+    self->unk_46cc = 0;
+    self->mRoundTimer = 0;
+}


### PR DESCRIPTION
The Amida ladder shuffle in the ov006 minigame, 1276 bytes, byte-exact. It had been sitting at 12 diverging instructions since earlier in this run, down from 68.

## The lever

A named `u32` temporary for the shifted random value, applied to **both** shuffle loops, plus a three-statement reorder. The named temporary is what fixes the literal-pool order: it makes 0x4694 emit before 0x7fff, which is the order the cartridge uses. Inlining the shift leaves the two constants the other way round and costs the twelve instructions.

This is the same family as the "delete the named intermediate" lever in notes 6bv, running in the opposite direction, and it is the second counter-example to that lever measured today. The first was on `func_ov002_020cfea4`, where removing a named shift costs 7 words. Both say the same thing: naming an intermediate is a two-outcome probe, not a simplification.

## Verification, re-run independently on a fresh worktree off main

```
banner check                 no NONMATCHING anywhere in the file
build_pin.verify             (True, '2004/b56')
prepush_linkcheck            1 checked - 1 verified, 0 warning(s), 0 blocking
check_src_tu                 every reference resolves
langmode ratchet             PASS
```

Every extern in the file resolves against the committed symbol tables, checked one at a time rather than in bulk:

| symbol | resolves in |
|---|---|
| `RandomIntInternal` | `config/arm9/symbols.txt` (0x0203b990) |
| `data_0209d4b8` | `config/arm9/symbols.txt` |
| `data_ov006_02141640` | `config/arm9/overlays/ov006/symbols.txt` |
| `data_ov006_02141650` | `config/arm9/overlays/ov006/symbols.txt` |
| `data_ov006_0212e1a8` | `config/arm9/overlays/ov006/symbols.txt` |

The delinks entry carries `complete` and spans 0x020d36a4 to 0x020d3ba0, so the ROM build compiles this function and compares it to the cartridge rather than filling the range from the cartridge itself.

No header changed, so no sibling translation unit needs re-matching.