### PR TITLE
Point the dScMgSound_c comment at Luigi's current path

### DIFF
--- a/src/actors/dScMgSound_c.cpp
+++ b/src/actors/dScMgSound_c.cpp
@@ -417,7 +417,7 @@ extern "C" void *dScMgSound_c_classInit(void)
  * pre-migration file wrote it as `*(int *)(r7 + 0xb4)`.
  *
  * The GX/G2S/GXS entry points keep their mangled spellings INSIDE extern "C",
- * which is the tree's idiom for them (src/_ZN12dScMgLuigi_c13InitResourcesEv.cpp
+ * which is the tree's idiom for them (src/actors/dScMgLuigi_c.cpp
  * does the same). Inside extern "C" the identifier is emitted verbatim; only a
  * bare namespace-scope `extern` of a mangled name would mangle a SECOND time,
  * which is the defect include/SharedFilePtr.h's banner records. */


### PR DESCRIPTION
The `references` gate is failing on main, so it reds every pull request opened against it right now, including ones that change nothing near this file.

`src/actors/dScMgSound_c.cpp` cites `src/_ZN12dScMgLuigi_c13InitResourcesEv.cpp` as the precedent for keeping mangled entry-point spellings inside `extern "C"`. #2383 folded that file into `src/actors/dScMgLuigi_c.cpp` and the surrounding prose did not follow.

The claim the comment makes is still true, so only the path needed changing. The merged translation unit carries 110 mangled `_ZN12dScMgLuigi_c` spellings inside file-scope `extern "C"` regions, which is precisely the idiom being pointed at.

```
check_dead_references: 10371 scan target(s), 9959 C/C++ file(s), 8825 repo-rooted path reference(s)
  no new dead references
  no broken markdown links
```

Comment only. No code, no config, no count movement.