### PR TITLE
Let a symbol-table SPLIT through the denominator gate

### DIFF
--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -88,6 +88,24 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(split["stats"]["claimedFunctions"], 0)
         self.assertEqual(split["claimed"], {})
 
+    def test_zero_size_alias_does_not_displace_the_function_it_aliases(self):
+        # config/arm9/symbols.txt has ten addresses carrying two function records, and
+        # in every one the LAST line is a zero-size alias over a real function. Keyed by
+        # module:addr, last-wins would hand the alias's name, size and matched flag to
+        # the address and make the function invisible.
+        config = self.repo / "config" / "arm9" / "symbols.txt"
+        config.write_text(
+            "Example kind:function(arm,size=0x4) addr:0x02000000\n"
+            "ExampleAlias kind:function(arm,size=0x0) addr:0x02000000\n",
+            encoding="utf-8")
+        head = commit(self.repo, "add alias", "bob")
+        snap = VM.function_snapshot(head)
+        record = snap["functions"]["arm9:0x02000000"]
+        self.assertEqual(record["name"], "Example")
+        self.assertEqual(record["size"], 0x4)
+        self.assertTrue(record["matched"])
+        self.assertEqual(snap["stats"]["matchedFunctions"], 1)
+
     def test_nonmatching_is_read_from_requested_revision(self):
         (self.repo / "src" / "Example.c").write_text(
             "// NONMATCHING\nint Example(void) { return 0; }\n")
@@ -483,6 +501,118 @@ class RomDataRatchet(unittest.TestCase):
         base = self.data(verified=(("arm9", "Data"),))
         self.assertEqual(VM.rom_data_regressions(base, {}),
                          ["head full-ROM report omitted the ROM-data measurement"])
+
+
+def _snap(records):
+    """A function_snapshot-shaped dict from (name, addr, size, matched) tuples."""
+    functions, spans, total, matched_bytes = {}, {}, 0, 0
+    for name, addr, size, is_matched in records:
+        key = f"arm9:0x{addr:08x}"
+        prior = functions.get(key)
+        if prior is None or size > prior["size"]:
+            functions[key] = {"id": key, "module": "arm9", "addr": addr, "name": name,
+                              "size": size, "matched": is_matched,
+                              "srcPath": f"src/{name}.c" if is_matched else None}
+        if size > 0:
+            spans.setdefault("arm9", []).append((addr, addr + size))
+        total += size
+        if is_matched:
+            matched_bytes += size
+    matched = {k: r for k, r in functions.items() if r["matched"]}
+    return {"functions": functions, "spans": spans, "matched": matched,
+            "stats": {"totalFunctions": len(functions), "totalBytes": total,
+                      "matchedFunctions": len(matched), "matchedBytes": matched_bytes}}
+
+
+class Repartition(unittest.TestCase):
+    """The denominator carve-out, and the attacks an adversarial review threw at it."""
+
+    def test_split_of_an_unmatched_symbol_is_a_repartition(self):
+        # PR #2360's shape: one 0x3c symbol is really a 0x2c routine and a 0x10 one.
+        base = _snap([("func_020610fc", 0x020610fc, 0x3c, False)])
+        head = _snap([("func_020610fc", 0x020610fc, 0x2c, False),
+                      ("func_02061128", 0x02061128, 0x10, False)])
+        got = VM.classify_repartition(base, head)
+        self.assertIsNotNone(got)
+        self.assertEqual(got["kind"], "split")
+        self.assertEqual(got["functionDelta"], 1)
+
+    def test_split_that_also_gains_a_match_is_refused(self):
+        # The free numerator: a new symbol whose name collides with an existing src
+        # stem is resolved as matched by the filename convention. Land the split first.
+        base = _snap([("func_020610fc", 0x020610fc, 0x3c, False)])
+        head = _snap([("func_020610fc", 0x020610fc, 0x2c, False),
+                      ("func_02061128", 0x02061128, 0x10, True)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_split_that_grows_a_matched_neighbour_is_refused(self):
+        # Attack S. Every count holds -- one matched function before and after, and the
+        # covered bytes are identical -- but the matched symbol grew by 4, which raises
+        # matchedBytePercent while matchedFunctionPercent falls. Counts cannot see it;
+        # pinning each matched record's SIZE can.
+        base = _snap([("hit", 0x02000000, 0x10, True), ("miss", 0x02000010, 0x20, False)])
+        head = _snap([("hit", 0x02000000, 0x14, True), ("miss", 0x02000014, 0x10, False),
+                      ("miss2", 0x02000024, 0xc, False)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_split_that_swaps_which_function_is_matched_is_refused(self):
+        # Counts again equal, one match out and one in. The matched SET is the test.
+        base = _snap([("a", 0x02000000, 0x10, True), ("b", 0x02000010, 0x10, False),
+                      ("c", 0x02000020, 0x10, False)])
+        head = _snap([("a", 0x02000000, 0x10, False), ("b", 0x02000010, 0x10, True),
+                      ("c", 0x02000020, 0x8, False), ("d", 0x02000028, 0x8, False)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_new_bytes_are_not_a_repartition(self):
+        base = _snap([("a", 0x02000000, 0x10, False)])
+        head = _snap([("a", 0x02000000, 0x10, False), ("b", 0x02000010, 0x10, False)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_merges_stay_blocked_even_when_the_absorber_is_matched(self):
+        # Attack M1, the one that killed the first draft's merge rule. A matched,
+        # TEXT-ONLY symbol grows to swallow an unmatched neighbour: matchedBytes rises
+        # by exactly the absorbed size, in a symbols.txt-only diff, with nothing
+        # compiled and nothing byte-compared. Merges get no arithmetic carve-out.
+        base = _snap([("hit", 0x02052550, 0x1c, True),
+                      ("miss", 0x0205256c, 0x1c, False)])
+        head = _snap([("hit", 0x02052550, 0x38, True)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_merging_unmatched_symbols_to_shrink_the_denominator_is_refused(self):
+        # And the crude version: a hundred unmatched symbols become one. Covered bytes
+        # identical, matched set identical -- and the headline still rises for no work,
+        # which is why "every changed range is unmatched" is not a sufficient rule.
+        base = _snap([(f"f{i}", 0x02000000 + i * 4, 4, False) for i in range(100)])
+        head = _snap([("f0", 0x02000000, 400, False)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_case_two_shaped_merge_is_refused_pending_its_own_rule(self):
+        # The __destroy_arr shape. Correct on the merits and still not this rule's to
+        # allow: it lands as a re-partition PR and then a match PR.
+        base = _snap([("__destroy_arr", 0x0207328c, 0x5c, False),
+                      ("func_020732e8", 0x020732e8, 0x18, False)])
+        head = _snap([("__destroy_arr", 0x0207328c, 0x74, True)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_a_stable_denominator_is_not_a_repartition(self):
+        base = _snap([("a", 0x02000000, 0x10, False)])
+        head = _snap([("a", 0x02000000, 0x10, True)])
+        self.assertIsNone(VM.classify_repartition(base, head))
+
+    def test_cross_module_shuffle_is_not_a_repartition(self):
+        # totalBytes alone would call this clean. The covered set is compared per
+        # module precisely because overlay addresses overlap.
+        base = {"functions": {}, "spans": {"arm9": [(0x02000000, 0x02000010)],
+                                           "ov000": [(0x02200000, 0x02200010)]},
+                "matched": {},
+                "stats": {"totalFunctions": 2, "totalBytes": 0x20,
+                          "matchedFunctions": 0, "matchedBytes": 0}}
+        head = {"functions": {}, "spans": {"arm9": [(0x02000000, 0x02000020)],
+                                           "ov000": []},
+                "matched": {},
+                "stats": {"totalFunctions": 3, "totalBytes": 0x20,
+                          "matchedFunctions": 0, "matchedBytes": 0}}
+        self.assertIsNone(VM.classify_repartition(base, head))
 
 
 class ModuleFidelityDetail(unittest.TestCase):

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -177,6 +177,7 @@ def function_snapshot(rev):
     in_tree = set(paths)
     records = {}
     total_bytes = matched_bytes = 0
+    spans = {}
     for path in paths:
         module = _module_from_symbols(path)
         if module is None:
@@ -190,14 +191,37 @@ def function_snapshot(rev):
             owner = enrolled.get((module, addr))
             src = owner if owner in in_tree else sources.get(name)
             matched = bool(src and src not in nonmatching and src not in transcribed)
-            records[key] = {"id": key, "module": module, "addr": addr, "name": name,
-                            "size": size, "matched": matched, "srcPath": src}
+            # A ZERO-SIZE ALIAS MUST NOT DISPLACE THE FUNCTION IT ALIASES. `records` is
+            # keyed by module:addr, so without this the last line at an address wins,
+            # and in every one of the ten colliding addresses in this tree the last
+            # line is the alias: `__cxa_vec_cleanup`(0x0) over `__destroy_arr`(0x5c),
+            # `_dadd`(0x0) over `func_01ff8000`(0x59c), and eight more. The surviving
+            # record then carries the alias's name, size, srcPath AND matched flag, so
+            # the real function is invisible to every check below.
+            #
+            # Latent rather than live today: none of the ten has an unbannered source,
+            # so no current count moves. It fires the moment one of them is matched --
+            # which is precisely what a pending `__destroy_arr` match does.
+            prior = records.get(key)
+            if prior is None or size > prior["size"]:
+                records[key] = {"id": key, "module": module, "addr": addr, "name": name,
+                                "size": size, "matched": matched, "srcPath": src}
+            # RAW spans, collected here rather than derived from `records` later.
+            # `records` is keyed by module:addr, so two symbols at one address collapse
+            # to whichever line comes last -- and config/arm9/symbols.txt:3052-3053 is
+            # exactly that, `__destroy_arr` (0x5c) followed by the zero-size alias
+            # `__cxa_vec_cleanup` at the SAME address. Derived from `records`, the real
+            # function's extent would simply vanish. Only classify_repartition reads
+            # this; no existing statistic changes.
+            if size > 0:
+                spans.setdefault(module, []).append((addr, addr + size))
             total_bytes += size
             if matched:
                 matched_bytes += size
     matched = {k: r for k, r in records.items() if r["matched"]}
     return {
         "functions": records,
+        "spans": spans,
         "matched": matched,
         "stats": {
             "totalFunctions": len(records),
@@ -208,6 +232,110 @@ def function_snapshot(rev):
             "matchedBytePercent": 100.0 * matched_bytes / total_bytes if total_bytes else 0.0,
         },
     }
+
+
+def _covered_spans(snapshot):
+    """Byte ranges each module's symbol table covers, merged, per module.
+
+    Reads `snapshot["spans"]`, the RAW per-line ranges, never `snapshot["functions"]`:
+    that dict is keyed by module:addr and so loses one of any two symbols sharing an
+    address. `__destroy_arr` is shadowed by the zero-size alias `__cxa_vec_cleanup` at
+    its own address (config/arm9/symbols.txt:3052-3053), and deriving the covered set
+    from `functions` would drop its 0x5c entirely -- which made the very re-partition
+    this rule exists to allow look like a change to the covered bytes.
+
+    Zero-size rows are already excluded upstream: they cover nothing, so an alias can
+    never move the covered set.
+    """
+    spans = snapshot["spans"]
+    out = {}
+    for module, raw in spans.items():
+        merged = []
+        for lo, hi in sorted(raw):
+            if merged and lo <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], hi))
+            else:
+                merged.append([lo, hi])
+        out[module] = tuple(tuple(s) for s in merged)
+    return out
+
+
+def classify_repartition(bf, hf):
+    """Is a denominator change a SPLIT of the same bytes, with the numerator frozen?
+
+    The denominator check below refuses any move in `totalFunctions` or `totalBytes`, in
+    either direction, and it is right to: the headline is a fraction, and a gate that
+    watched only the numerator would let anyone lift it by shrinking what they divide by.
+
+    But the symbol table is not ground truth. It is a HYPOTHESIS about where the
+    cartridge's functions start and end, and it is sometimes wrong -- one symbol claiming
+    a span the ROM runs as two routines. Correcting such a row moves the denominator, so
+    the gate as written makes the correction the one edit that cannot land, and holds the
+    tree in a state where its own count is a fiction. PR #2360 is the live case:
+    `func_020610fc` is declared 0x3c, the routine is 0x2c and ends in `b self`, and the
+    remaining 0x10 is a separate routine that `src/func_02019ebc.c` CALLS -- a call
+    `config/unresolved-baseline.json` records as missing because nothing defines it.
+
+    That is the trap the WITHDRAWN carve-out below was written for: "treating both as
+    loss made the gate reward the lie."
+
+    SPLITS ONLY, AND THE DIRECTION IS THE WHOLE SAFETY ARGUMENT. A split raises
+    `totalFunctions`. With the numerator frozen (below), that strictly LOWERS both
+    headline percentages, so it is not a lever anyone pulls to game a number -- the rule
+    can only ever make the tree look worse. That argument is explicit rather than
+    emergent, which is the standard the WITHDRAWN restriction sets for itself two
+    screens down.
+
+    MERGES STAY BLOCKED, AND THAT IS DELIBERATE. A merge lowers `totalFunctions` and so
+    RAISES the percentage, which makes it the direction an attack uses, and no arithmetic
+    over this snapshot can tell a true merge from a false one. In particular a rule of
+    the form "allow it when `matchedBytes` rises" does NOT work, however tightly it is
+    tied to the merged range: `matchedBytes` is `size` summed over records that merely
+    have an unbannered `src/` file (see `function_snapshot` and `verification_split`,
+    which says it outright -- "Nothing in that classification compiles the file, links
+    it, or compares a byte"). Growing an already-matched, text-only symbol to swallow an
+    unmatched neighbour raises `matchedBytes` by the absorbed size with nothing compiled
+    and nothing verified, in a symbols.txt-only diff. Nor is "every changed range is
+    unmatched" enough on its own: merging a hundred unmatched symbols into one still
+    drops the denominator by ninety-nine and lifts the headline for no work at all.
+
+    A merge carve-out therefore needs EVIDENCE rather than arithmetic -- the survivor
+    carrying a VERIFIED link row at its head size, or the merged range going `complete`
+    in `delinks.txt` with `sourceBytes` rising by exactly its size -- and that is a
+    separate change with its own proof. Until then a merge lands as two pull requests:
+    the re-partition, then the match.
+
+    THE NUMERATOR IS FROZEN BY IDENTITY, NOT BY COUNT. `matchedFunctions` staying equal
+    is not enough -- one match can leave while another arrives -- and neither is the byte
+    total, since a matched symbol may grow while another shrinks. So the matched SET must
+    be identical and every matched record must keep its size. Without the size clause a
+    split may grow a matched neighbour by a few bytes and raise `matchedBytePercent`
+    while `matchedFunctionPercent` falls, which is the leak that killed the first draft
+    of this rule. A split that genuinely produces a newly matched function lands the
+    split first and the match second.
+
+    Returns a dict describing the split, or None if the change is not one.
+    """
+    if hf["stats"]["totalFunctions"] <= bf["stats"]["totalFunctions"]:
+        return None
+    if hf["stats"]["totalBytes"] != bf["stats"]["totalBytes"]:
+        return None
+    # Per module: overlay addresses overlap, so a global address set would let a
+    # cross-module shuffle read as a clean re-partition.
+    if _covered_spans(bf) != _covered_spans(hf):
+        return None
+
+    base_matched, head_matched = bf["matched"], hf["matched"]
+    if set(base_matched) != set(head_matched):
+        return None
+    if any(base_matched[k]["size"] != head_matched[k]["size"] for k in base_matched):
+        return None
+
+    added = sorted(set(hf["functions"]) - set(bf["functions"]))
+    removed = sorted(set(bf["functions"]) - set(hf["functions"]))
+    return {"kind": "split",
+            "functionDelta": hf["stats"]["totalFunctions"] - bf["stats"]["totalFunctions"],
+            "added": added, "removed": removed}
 
 
 def enrollment_snapshot(rev):
@@ -662,9 +790,13 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
             removed.append(k)
     if removed:
         reasons.append(f"lost {len(removed)} matched function(s)")
+    # A denominator move is a blocker UNLESS it is a re-partition of the same bytes --
+    # see classify_repartition, which carries the full argument and the two tests.
+    repartition = classify_repartition(bf, hf)
     if (hf["stats"]["totalFunctions"] != bf["stats"]["totalFunctions"]
             or hf["stats"]["totalBytes"] != bf["stats"]["totalBytes"]):
-        reasons.append("function/byte coverage denominator changed")
+        if repartition is None:
+            reasons.append("function/byte coverage denominator changed")
     if he["stats"]["sourceBytes"] < be["stats"]["sourceBytes"]:
         reasons.append("source-built byte coverage decreased")
     # Bytes alone cannot see a SWAP. Dropping `complete` from one delinks entry and
@@ -718,6 +850,14 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         reasons.append("full-ROM validation failed")
 
     warnings = []
+    if repartition:
+        # A carve-out that passes quietly is a carve-out nobody audits. Say what moved.
+        warnings.append(
+            f"symbol-table split: totalFunctions {repartition['functionDelta']:+d} over "
+            "identical covered bytes, matched set and matched sizes unchanged. Allowed "
+            "as a re-partition -- see classify_repartition. Added: "
+            + ", ".join(repartition["added"][:3] or ["none"])
+            + "; removed: " + ", ".join(repartition["removed"][:3] or ["none"]))
     if withdrawn:
         warnings.append(
             f"{len(withdrawn)} claimed match(es) withdrawn by a NONMATCHING banner "
@@ -834,6 +974,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered,
                       "strandedMarkers": stranded_markers},
         "matchedWithdrawn": withdrawn,
+        "repartition": repartition,
         "linkcheck": link,
         "portRefcheck": port,
         "rom": {"base": base_rom_state, "head": head_rom_state,
@@ -877,6 +1018,11 @@ def render_markdown(r):
         lines.append(
             f"| Claims withdrawn (banner added) | {len(r['matchedWithdrawn'])} "
             f"function(s), none byte-verified |")
+    if r.get("repartition"):
+        rp = r["repartition"]
+        lines.append(
+            f"| Symbol-table {rp['kind']} | totalFunctions "
+            f"{rp['functionDelta']:+d} over identical covered bytes |")
     # The delinks view of the same quantity. Identical to byte-verified above whenever
     # every enrolled range is a matched symbols.txt function, which is the healthy
     # state -- so it earns a row only when the two disagree, where the disagreement is


### PR DESCRIPTION
`validate_merge` refuses any move in `totalFunctions` or `totalBytes`, in either direction. It is right to: the headline is a fraction, and a gate watching only the numerator would let anyone lift it by shrinking what they divide by.

But the symbol table is a hypothesis about where the cartridge's functions start and end, and it is sometimes wrong. Correcting a wrong row moves the denominator, so the gate makes the correction the one edit that cannot land.

**#2360 is the live case.** `config/arm9/symbols.txt` claims `func_020610fc` is `0x3c`. The routine is `0x2c` and ends in `b self`. The remaining `0x10` at `0x02061128` is a separate routine that `src/func_02019ebc.c:5` **calls** — a call `config/unresolved-baseline.json` records as missing because nothing defines the symbol. main ships a source file calling a symbol its own symbol table does not have.

## Splits only, and the direction is the whole safety argument

A split raises `totalFunctions`; with the numerator frozen it strictly **lowers** both headline percentages. The rule can only ever make the tree look worse.

The numerator is frozen by **identity, not count**: `matchedFunctions` staying equal is not enough (one match can leave while another arrives), so the matched **set** must be identical and every matched record must keep its **size**. Without the size clause a split can grow a matched neighbour by four bytes and raise `matchedBytePercent` while `matchedFunctionPercent` falls.

## Merges stay blocked, and the first draft was wrong to allow them

The first draft permitted a merge when `matchedBytes` rose by at least the absorbed size, reasoning that only the ROM build can raise `matchedBytes`. False — and `verification_split` says so in this very file: *"Nothing in that classification compiles the file, links it, or compares a byte."*

Growing an already-matched, **text-only** symbol to swallow an unmatched neighbour raises `matchedBytes` by exactly the absorbed size in a symbols.txt-only diff, with nothing compiled. Tying the gain to the merged range does not help; the forged gain *is* in the merged range. Nor is "every changed range is unmatched" enough: a hundred unmatched symbols merged into one drops the denominator by ninety-nine for no work at all.

A merge carve-out needs **evidence** rather than arithmetic — a VERIFIED link row at head size, or the merged range going `complete` in `delinks.txt` with `sourceBytes` rising by exactly its size. Separate change, own proof. Until then a merge lands as two PRs: the re-partition, then the match.

## One latent bug fixed en route

`function_snapshot` keyed records by `module:addr`, so two symbols at one address collapsed to whichever line came last. This tree has **ten** such addresses and in every one the last line is a zero-size alias over a real function: `__cxa_vec_cleanup`(0x0) over `__destroy_arr`(0x5c), `_dadd`(0x0) over `func_01ff8000`(0x59c), and eight more. The surviving record carried the alias's name, size, `srcPath` **and matched flag**, so the function was invisible to every check below. Bigger record now wins.

Latent rather than live: none of the ten has an unbannered source today, so no current count moves. It fires the moment one is matched.

## Measured

On #2360's head against its merge base:

| | status | reasons |
|---|---|---|
| main | Failed | `function/byte coverage denominator changed` |
| this | **Passed** | — |

The split is recorded in the report JSON, in a warning, and in the rendered table — a carve-out that passes quietly is a carve-out nobody audits.

Ten unit tests cover the shape and five attacks, including both of the reviewer's live ones. **45/45 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4FxdKHG3a6hQRYRAbx29c
