### PR TITLE
Record the stopped 2026-09-07 wave and the blocker that stops all five

### DIFF
--- a/notes/agents/IN-FLIGHT.md
+++ b/notes/agents/IN-FLIGHT.md
@@ -60,6 +60,59 @@ left where only a branch listing can find it.
 Two of the older ones carry inline-dtor flips that exist nowhere else. Audit before
 deleting anything in this set.
 
+## The 2026-09-07 wave, stopped mid-flight
+
+Five classes were promoted under the ROM-name ruling and the run was stopped
+deliberately, to upgrade the workflow. **Nothing is uncommitted and nothing is
+local-only** -- every branch below is pushed.
+
+| class | overlay | bytes | methods | where it stopped |
+|---|---|---|---|---|
+| `daGmch_c` | ov081 | 37/37 | **36/37** | PR #2395, CI green, validator red |
+| `daMky_c` | ov030 | 44/44 | 20/44 | PR #2397 |
+| `da1up_c` | ov002 | 36/36 | 9/36 | PR #2398 |
+| `daMip_c` | ov085 | 32/32 | **32/32** | gated, **no PR** -- `cpp/Rabbit-tu` |
+| `daBmb_c` | ov102 | 35/35 | 13/35 | gated, **no PR** -- `cpp/BobOmb-tu` |
+
+184 shards folded into 5 TUs; 110 members became real C++ methods. The wall on
+every unconverted member is **naming or scope, never codegen**.
+
+### The blocker that stops all five
+
+`validate_merge.rom_data_regressions` diffs raw `(module, symbol)` sets and has no
+rename awareness, so retiring a coined `_ZTV<Coined>` reads as a lost symbol:
+
+    ROM data verification lost 1 exact symbol(s): ov081:_ZTV8Moneybag
+
+Nothing was lost -- `_ZTV8daGmch_c` verifies at the same module, address
+`0x02128c04` and `0x84` bytes. **Every promotion under the ROM-name ruling trips
+this**, so it is not one PR's problem.
+
+Two workarounds are wrong and must not be taken: a `symbols.txt` alias for the
+retired name fabricates a symbol identity to silence a gate, and consulting
+`symbols/actor_renames.tsv` lets the PR under validation certify its own rename.
+**Anchor on the ROM address instead** -- a lost symbol is not a loss when head
+verifies a symbol at the same `(module, address)` with the same byte count, which
+cannot be faked because the new name must actually byte-verify there. Match
+one-to-one, and when either side's rows carry no address, report the loss exactly
+as today.
+
+`romdata_check.summarize()` currently emits `{"module", "symbol"}` only, so the
+address has to be added there first. And the validator **restores all of `tools/`
+from the base commit**, so this cannot ride along in a class PR -- it lands on
+`main` first, then the five revalidate.
+
+### One commit to revert before `cpp/BobOmb-tu` ships
+
+`93d9a31cb` ("Raise the langmode extern_vtable ratchet by one for daBmb_c") banks
+a rise that the `daGmch_c` run later proved is not byte-necessary. The `+1` is the
+promotion moving a vptr declaration from `include/decl_common.h` into the folded
+factory; putting it in the class header instead restored 165/168 with
+**byte-identical objects** (`sha256 0c6eee50…`, confirmed against the pinned
+mwccarm). `langmode_audit.py`'s own RATCHET block only permits booking a rise that
+is renames giving `func_*` functions their evidenced C++ symbols, which this is
+not. Do the same move on ov102 and drop the bank.
+
 ## What the upgrade should fix
 
 1. **A released claim erases the only record that work happened.** Release should


### PR DESCRIPTION
The class run was stopped deliberately, to upgrade the workflow. Five classes
were promoted under the ROM-name ruling and every branch is pushed -- nothing is
uncommitted and nothing is local-only. This writes down where each one stopped,
so the next session reads it from the repo rather than rediscovering it.

184 shards folded into 5 TUs; 110 members became real C++ methods. `daMip_c`
converted 32 of 32 and `daGmch_c` 36 of 37 (the 37th is the factory, free by
design). The wall on every unconverted member is naming or scope -- never codegen.

**The blocker is one line of the validator, and it stops all five.**
`validate_merge.rom_data_regressions` diffs raw `(module, symbol)` sets with no
rename awareness, so retiring a coined `_ZTV<Coined>` reads as a lost symbol.
Nothing is lost: `_ZTV8daGmch_c` verifies at the same module, address `0x02128c04`
and `0x84` bytes as the `_ZTV8Moneybag` it replaces. Every promotion under the
ROM-name ruling trips it, which makes that ruling unmergeable as things stand.

The note records the fix that does not weaken the gate -- anchor on the ROM
address, since the new name must actually byte-verify there to qualify -- and the
two workarounds that must not be taken, both of which let a PR certify its own
rename. It also records the sequencing constraint: the validator restores all of
`tools/` from the base commit, so the fix cannot ride along in a class PR.

One concrete cleanup is named too. `cpp/BobOmb-tu` carries a commit banking a
langmode `extern_vtable` rise that a later run proved is not byte-necessary --
moving the vptr declaration into the class header restored the old counts with
byte-identical objects, confirmed against the pinned mwccarm.

Notes-only; `check_dead_references` 0. No `src/`, `config/` or `include/` file is
touched, so no byte can move.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
