### PR TITLE
Attribute three near-miss residues to build deltas, and correct two banner counts

### DIFF
--- a/src/_ZN12dScStarSel_c8BehaviorEv.cpp
+++ b/src/_ZN12dScStarSel_c8BehaviorEv.cpp
@@ -1,9 +1,52 @@
 //cpp
 // @symbol _ZN12dScStarSel_c8BehaviorEv
-// NONMATCHING: 27/525 at exact size (was 100). Real dScStarSel_c method over
-// include/dScStarSel_c.h, vtable slot 6. Every remaining divergence is register
-// naming inside the touch-hit search loop (the ROM keeps found in lr, i in ip,
-// the touch record pointer in r6); declaration order moves it between 27 and 35.
+// NONMATCHING: 19/525 at exact size 0x834. Real dScStarSel_c method over
+// include/dScStarSel_c.h, vtable slot 6. Declaring the two touch-record globals with
+// their real 4-byte stride (u8 [][4]) is what took 20 to 19: with the stride in the
+// type, the index scale folds into each addressing mode instead of being CSE'd into
+// one live temp, so the second read refolds it off the surviving index exactly as the
+// ROM does (+0x28c ldrb r0,[r1,r0,lsl#2]). See notes 6bv lever 2.
+//
+// The banner that stood here claimed 27 against a source that measures 48 today; this
+// body is the near-miss DB's row (#2382), which measures 19 in the same run. Do not
+// re-derive from the 27 shape.
+//
+// ALL 19 ARE THE 6bs DEAD-REGISTER DELTA, from exactly two roots, and the rest is
+// knock-on. The ROM's compiler will not reuse a register that died on the previous
+// instruction; every build we own takes it because it is the lowest free one.
+//   root 1  +0x228  the pool address of data_020a0e40 dies at the load of `idx`.
+//           ROM: ldrb r2,[r0] (skips r0).  Here: ldrb r0,[r0].  That one choice
+//           rotates `idx` and `n` against each other -- 8 words, including the
+//           latch cmp and both data_020a0de8/9 reads.
+//   root 2  +0x264  `rec` dies at the load of `ty`.
+//           ROM: ldrb r7,[r6,#3] (skips r6, then spends r6 on the loop scratch born
+//           one instruction later).  Here: ldrb r6,[r6,#3], scratch to r7 -- 11 words.
+// Every instruction shape, every immediate and the whole frame already agree, so this
+// is the build delta of notes 6bs, not a spelling that has not been found. Per that
+// section the only construct that skips a dead register is a volatile-fed separate
+// local, which materialises a stack slot and changes the size; it is not admissible
+// and was not banked.
+//
+// MEASURED INERT at this shape (run m100 lane H1, on top of the earlier lane's decl-
+// order hill-climbs, single-type sweep, pragma table, statement shuffles and pointer
+// splits) -- 170 cells that compiled, nothing under 19:
+//   * 130 scope-depth cells moving cur/ty/idx/rec/found/i/tx/n/touched into the
+//     `if (touched)` and `if (n > 0)` blocks singly, in pairs and in triples. This is
+//     6bu lever 7 applied to exactly the swap it describes, and it does not reach it:
+//     any cell that moves `ty` costs, and the best tie is 19.
+//   * 24 cells of loop-condition shape x `ty` width. u8/u16/u32 tie at 19 and s32
+//     costs 1; a named u8 or s32 temp for the first condition ties; the
+//     `& (1 << i)` and reversed-subtract spellings of the guard tie. (The four
+//     nested-if cells in that batch did not compile and are not counted.)
+//   * 16 cells of the idx/n pair: both first-write orders, `n` hoisted above `idx`,
+//     beside it, and below `i = 0`, crossed with u8/s32 for each. This is the
+//     first-write-rank lever aimed at the rank tie it is meant for, and it is inert:
+//     the type of `idx` does not matter at all (u8 and s32 score identically), and
+//     hoisting `n`'s write above the `touched` guard costs 3. A rank tie would have
+//     moved; this does not, which is the positive evidence that root 1 is 6bs and
+//     not a naming problem.
+// Cross-build: 2004/b56 is the ONLY installed build that even reaches 0x834 here
+// (1.2 lands 2008-2012, 2.0 1952, dsi 1764-1784), so the version axis is closed too.
 #pragma opt_loop_invariants off
 #pragma opt_strength_reduction off
 #include "common.h"
@@ -32,8 +75,8 @@ extern u16 data_0209f5e8[];
 extern u8 data_02092128;
 extern u8 data_0209caa0[];
 extern u8 data_020a0e40;
-extern u8 data_020a0de8[];
-extern u8 data_020a0de9[];
+extern u8 data_020a0de8[][4];
+extern u8 data_020a0de9[][4];
 extern u16 data_020a0e58[];
 extern u16 data_020a0e5a[];
 }
@@ -45,16 +88,16 @@ extern u16 data_020a0e5a[];
 s32 dScStarSel_c::Behavior()
 {
     s32 cur;
-    u8 idx;
-    u8 touched;
     u8 ty;
+    u8 idx;
+    u8 *rec;
+    s32 found;
     s32 i;
     u8 tx;
-    s32 found;
-    u8 *rec;
     s32 n;
-    s32 hit;
     s32 pressed;
+    u8 touched;
+    s32 hit;
 
     if (data_0209f5bc->v5() != 0) {
         DecIfAbove0_Byte(&FB(this, 0x117));
@@ -98,17 +141,17 @@ s32 dScStarSel_c::Behavior()
             idx = data_020a0e40;
             cur = FB(this, 0x115);
             found = 0;
-            touched = data_020a0de8[idx * 4];
+            touched = data_020a0de8[idx][0];
             if (touched != 0) {
                 n = FB(this, 0x114);
                 i = 0;
                 if (n > 0) {
-                    rec = &data_020a0de8[idx * 4];
+                    rec = data_020a0de8[idx];
                     tx = rec[2];
                     ty = rec[3];
                     do {
                     if ((u8)(tx - FB((u8 *)this + i, 0x11a) + 8) < 0x10 && ty < 0x28 && ((FB(this, 0x131) >> i) & 1)) {
-                        hit = (touched != 0 && data_020a0de9[idx * 4] != 0);
+                        hit = (touched != 0 && data_020a0de9[idx][0] != 0);
                         if (hit != 0 || cur != i) {
                             FB(this, 0x117) = data_0208ee44 * 3;
                         }

--- a/src/_ZN3MrI13InitResourcesEv.cpp
+++ b/src/_ZN3MrI13InitResourcesEv.cpp
@@ -1,27 +1,53 @@
 //cpp
 // @symbol _ZN3MrI13InitResourcesEv
-// NONMATCHING: 3/166 at exact size 0x298. The draft that stood here DID NOT COMPILE at
-// all -- `mwccarm.exe: undefined identifier 'Matrix4x3'` at its line 111 -- so it was
-// scoring nothing. This is a real C++ method on include/MrI.h with named members
-// (mModelAnim, mShadowModel, mdCcAcPos_c, mShadowRadiusScale, mShadowHeight, mTimer,
-// unk_1ec, unk_217) and no shadow structs.
+// NONMATCHING: 3/166 at exact size 0x298. (A lane draft briefly wrote 2 here and cited
+// the near-miss DB's shadow-struct row for the same address as agreeing. Re-measured
+// against b2bd6a323, both give 3: this body 3/166, and that DB row 3/166 under its own
+// func_ov071_02121734 spelling, though the row still stores divergences: 2. The residue
+// listed just below is three slots and always was.)
 //
 // The whole residue is a three-word rotation of the ModelBase::SetFile argument setup at
-// +0x20: the ROM emits mov r2,#1 / mov r1,r0 / add r0,r4,#0xd4 / mov r3,r2, every build
-// here emits mov r1,r0 / add r0,r4,#0xd4 / mov r2,#1 / mov r3,r2. Same instruction
-// multiset, same registers -- pure emission order.
+// +0x20. The four setup instructions are the same multiset in the same registers; only
+// the slot of the independent constant differs:
+//   ROM:  mov r2,#1 / mov r1,r0 / add r0,r4,#0xd4 / mov r3,r2
+//   here: mov r1,r0 / add r0,r4,#0xd4 / mov r2,#1 / mov r3,r2
 //
 // PROBED, and this is the useful part for anyone who returns to it: mwccarm 2004/b56 DOES
 // emit the ROM's constant-first order, but only when the basic block holding the call also
 // contains a condition-code comparison. `if (!SetFile(...)) return;` and even a comparison
 // on an unrelated global (`g = (h == 3);`) both flip it; a plain call, an if with an empty
 // body, a switch, a goto label, a stored result, a trailing loop whose compare sits in the
-// loop latch, and a following call all leave it alone. This function has no comparison in
-// that block, so the order is out of reach from the source. Also inert: 14 conditional-
-// context spellings of the call, named/const/register/bool/byte/short constants, nested
-// and member-call forms of SetFile, 4 inline-helper wrappers, 7 structural variants of the
-// surrounding loop and declarations, and all 24 pragma cells.
-// @symbol _ZN3MrI13InitResourcesEv
+// loop latch, and a following call all leave it alone. The ROM's own entry block runs from
+// the prologue to the loop preheader with no cmp in it, so the trigger cannot be paid for
+// out of instructions the cartridge already spends, and the order is out of reach here.
+//
+// MEASURED INERT, first pass: 14 conditional-context spellings of the call, named/const/
+// register/bool/byte/short constants, nested and member-call forms of SetFile, 4 inline-
+// helper wrappers, 7 structural variants of the surrounding loop and declarations.
+// MEASURED INERT, run m100 lane H1 (all 3/166, size-exact): nested LoadFile inside the
+// SetFile call; a dead local for the first LoadFile result; a ModelBase& alias; a named
+// ModelBase* taken before the calls; `mModelAnim.SetFile` as a plain member call; the
+// +0xd4 this-pointer written as a char* cast; a stored return value; `bmd` as char*; an
+// initialised-at-declaration `bmd`; a comma-expression assignment inside the call; and
+// both `int one = 1` and `int a,b` forms with the constant's FIRST WRITE placed before
+// the LoadFile calls (the first-write rank lever does not reach a scheduling slot).
+// Also inert: 56 pragma cells over 28 REAL pragma names lifted out of mwccarm.exe --
+// including opt_defineargorder, opt_repositioncode, opt_prelinearize,
+// opt_serializeassignments and opt_useexpressioncostswhenlinearizingassignments, the
+// five whose names promise this exact behaviour. The sweep is not vacuous: in the same
+// batch `opt_propagation off` scores 58 at 0x2a0 and `optimize_for_size on` 42 at 0x28c,
+// so the pragmas were applied.
+// Cross-build: 1.2/base, 1.2/sp2, 1.2/sp2p3 and 2004/b56 all reach 0x298 and all four
+// give the SAME 2. Every other installed build misses the size (1.2/sp3-sp4 0x290,
+// 2.0 0x288, dsi 0x27c).
+//
+// So the verdict is a ROM-compiler build delta, in the same CLASS as notes 6bs but not
+// the same mechanism: 6bs is a register CHOICE (the ROM skips a just-dead register),
+// this is an emission SLOT for an instruction whose registers already agree. What the
+// two share is the signature -- a residue that is byte-identical across every installed
+// build able to produce the right size, and unmoved by any source spelling, belongs to
+// the compiler the cartridge was actually built with (CW NITRO V0.6.1, notes 6ah,
+// unarchived) and not to a spelling nobody has found yet.
 #include "MrI.h"
 
 struct BMD_File;

--- a/src/func_ov015_021114f0.c
+++ b/src/func_ov015_021114f0.c
@@ -1,15 +1,45 @@
-// NONMATCHING: 8/95 at exact size (was 12). KnockDownPlank drop-shadow scale.
-// Residue is two register-colouring sites and nothing else:
-//   * +0x84/+0x88 the ROM puts the data_02082214 pool address in r1 and r4>>1 in r2;
-//     with `half` named those two land correctly but the second Q12 multiply then takes
-//     the named operand as the smull Rm, which costs four more words -- 9 instead of 8.
-//   * +0xb0 the ROM writes the first table load straight back into its own index
-//     register (`ldrsh r0,[r1,r0]`) while every build here takes a fresh lr, which
-//     rotates the whole smull/adds/adc/lsr chain that follows (notes 6bs).
-// Measured: a 128-cell product sweep over {half named|inline} x {lookup named|inline} x
-// {v before|after the index chain} x {product named|inline} per block, plus const/split/
-// register spellings of `half`, a named table pointer, and byte-cast index forms.
+// NONMATCHING: 8/95 at exact size 0x17c (was 12). KnockDownPlank drop-shadow scale.
 // opt_propagation off is required for the umull/mla/mla prologue.
+//
+// ONE ROOT, and the other seven words are its knock-on. At +0xb0 the 64-bit product's
+// destination pair takes r0, the register the index chain just died in:
+//   ROM:  ldrsh r0,[r1,r0] / smull lr,r3,r0,r2   (pair = lr,r3; sv keeps the dead r0)
+//   here: ldrsh lr,[r2,r0] / smull r3,r0,lr,r1   (pair = r3,r0; sv pushed out to lr)
+// With r0 taken by RdHi, `sv` goes to lr, and the data_02082214 pool address and
+// `r4 >> 1` then rotate against each other at +0x84/+0x88 and again at the second
+// table read. That is the ROM's compiler declining to reuse a register that died on
+// the previous instruction (notes 6bs) -- the direction 6bs records as unreachable
+// from source, because the choice is made after every source-level distinction is
+// gone. The proof that r0 is the pivot: inline the block-1 table read and `sv` DOES
+// take r0, and the pool/half rotation and the ldrsh all come right at once -- but the
+// same change drops r7 out of the frame (0x10 vs 0xc, v moves to lr) for six words,
+// and both smull pairs then miss, so it scores 14.
+//
+// MEASURED INERT, first pass: a 128-cell product sweep over {half named|inline} x
+// {lookup named|inline} x {v before|after the index chain} x {product named|inline}
+// per block, plus const/split/register spellings of `half`, a named table pointer,
+// and byte-cast index forms.
+// MEASURED INERT, run m100 lane H1 -- 475 further cells, nothing under 8:
+//   * naming `half` fixes three words (pool r1, half r2, and the second table read)
+//     and costs four at the second smull, netting 9. Naming a table pointer instead is
+//     byte-identical to the baseline in both `tbl`-only and `tbl`-then-`half` order,
+//     so that name is folded away entirely; only `half` reaches the allocator.
+//   * 72 cells of {half named} x {block-1 lookup: inline | new local | written back
+//     in place into its own index} x {block-2 the same} x {product named | inline}.
+//     Writing the load back into its own index variable scores EXACTLY as a fresh
+//     named local, so the source cannot ask for the ROM's `ldrsh r0,[r1,r0]`.
+//     Naming the Q12 product is completely inert; hoisting it into an s64 costs 2.
+//   * 72 cells of smull operand order and cast placement, 50 of address form
+//     (`a[t]`, `*(a+t)`, byte-cast + `t<<1`, `t*2`, `&a[t]`), 21 of the rounding-add
+//     and store shapes, 75 of v-position x 64-bit-product form. All canonicalised.
+//   * 144 pragma cells: 36 REAL pragma names from mwccarm.exe in both directions, each
+//     run twice (baseline and half-named). None below 8; the batch's 28/29/70 outliers
+//     show the pragmas were applied.
+//   * data_02082214 stays FLAT. Retyping it s16[][2] scores 56 here, which is the
+//     fourth independent confirmation in notes 6bv lever 2.
+// Cross-build: 1.2/base, 1.2/sp2, 1.2/sp2p3 and 2004/b56 all reach 0x17c and all four
+// give the SAME 8; every other build misses the size (1.2/sp3-sp4 0x178, 2.0 0x174 or
+// 0x170, dsi 0x150).
 #pragma opt_propagation off
 extern void Matrix4x3_FromRotationY(void *m, short ang);
 extern int _ZN8dActor_c18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void *self, void *sm, void *mtx, int a, int b, int d, unsigned int e);


### PR DESCRIPTION
Three NONMATCHING drafts in ov071/ov015/ov003. None of them matches, and the count does not move: `tools/progress.py --bar --from-src` reads 11,311 / 11,392 both before and after. What changes is that each residue is attributed to a specific mechanism instead of merely described, `dScStarSel_c::Behavior` picks up the near-miss DB's better body, and two banner headlines are brought into line with what the files measure.

Every number was re-measured in a clean worktree off b2bd6a323 with `tools/fdiff.py --version 2004/b56` at the exact config size, not carried over from the lane that wrote them:

```
_ZN3MrI13InitResourcesEv       ov071 0x02121734 0x298  RESULT match=False mismatches=3/166  version=2004/b56
_ZN12dScStarSel_c8BehaviorEv   ov003 0x020af038 0x834  RESULT match=False mismatches=19/525 version=2004/b56
func_ov015_021114f0            ov015 0x021114f0 0x17c  RESULT match=False mismatches=8/95   version=2004/b56
```

`dScStarSel_c::Behavior` is the real correction: the banner claimed 27 against a body that measures 48. It now carries the DB's row for the same address, which measures 19.

`MrI::InitResources` stays at 3, which is what its banner already said. The lane commit this branch is built from had rewritten it to 2, citing the near-miss DB row for that address (which stores `divergences: 2`). Re-scored under its own `func_ov071_02121734` spelling that row gives 3/166 as well, so the stored 2 is stale and the banner's own three-slot instruction listing was right all along. That headline is restored to 3 here. The DB row itself is deliberately untouched so this does not collide with the repair in flight in #2390; its stored 2 wants fixing there or after.

Gates run in the worktree:

```
python tools/prepush_linkcheck.py --range b2bd6a323..HEAD
prepush-linkcheck: skipped 3 NONMATCHING draft(s)
prepush-linkcheck: 0 checked - 0 verified, 0 warning(s), 0 blocking

python tools/check_dead_references.py
  no new dead references
  no broken markdown links
```

Comments and one draft body only. No config change, no symbol change, no count movement.
