### PR TITLE
Make the ROM-data ratchet read a rename as a rename

### DIFF
--- a/tools/romdata_check.py
+++ b/tools/romdata_check.py
@@ -358,13 +358,24 @@ def summarize(records):
                          if r["verdict"] == VERIFIED)
     partial_bytes = sum(r.get("bytes", 0) for r in best.values()
                         if r["verdict"] == PARTIAL)
+    # `addr` and `bytes` travel with the identity because a symbol NAME is a source-side
+    # choice and the cartridge address is not. Adopting the ROM's own RTTI name for a
+    # class that carried a coined one retires `_ZTV<Coined>` and introduces
+    # `_ZTV<RomName>` proving the same bytes at the same address; without the address
+    # validate_merge's set difference could only read that as a lost symbol, and the
+    # only ways to answer it from the name alone -- an alias row in `symbols.txt`, or
+    # consulting the rename ledger the PR writes itself -- would let a PR certify its
+    # own rename. The address cannot be forged: nothing reaches this list without
+    # byte-verifying there.
+    def _identity(r):
+        return {"module": r.get("module"), "symbol": r["symbol"],
+                "addr": r.get("addr"), "bytes": r.get("bytes")}
+
     verified_symbols = sorted(
-        ({"module": r.get("module"), "symbol": r["symbol"]}
-         for r in best.values() if r["verdict"] == VERIFIED),
+        (_identity(r) for r in best.values() if r["verdict"] == VERIFIED),
         key=lambda r: (r["module"] or "", r["symbol"]))
     differing_symbols = sorted(
-        ({"module": r.get("module"), "symbol": r["symbol"]}
-         for r in best.values() if r["verdict"] == DIFFERS),
+        (_identity(r) for r in best.values() if r["verdict"] == DIFFERS),
         key=lambda r: (r["module"] or "", r["symbol"]))
     return {
         "symbols": len(best),

--- a/tools/test_romdata_check.py
+++ b/tools/test_romdata_check.py
@@ -14,8 +14,9 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import romdata_check as RDC  # noqa: E402
 
 
-def rec(symbol, verdict, src="src/a.cpp", size=4):
-    return {"symbol": symbol, "verdict": verdict, "src": src, "bytes": size}
+def rec(symbol, verdict, src="src/a.cpp", size=4, addr=None):
+    return {"symbol": symbol, "verdict": verdict, "src": src, "bytes": size,
+            "addr": addr}
 
 
 class SummarizeCountsSymbols(unittest.TestCase):
@@ -28,7 +29,7 @@ class SummarizeCountsSymbols(unittest.TestCase):
         self.assertEqual(s["totalRecords"], 3)
         self.assertEqual(s["verifiedRecords"], 3)
         self.assertEqual(s["verifiedSymbols"], [
-            {"module": None, "symbol": "_ZTI7fBase_c"}])
+            {"module": None, "symbol": "_ZTI7fBase_c", "addr": None, "bytes": 4}])
 
     def test_consolidating_sources_does_not_move_the_ratchet(self):
         """The measured shape of the first TU promotion, in miniature."""
@@ -49,7 +50,7 @@ class SummarizeCountsSymbols(unittest.TestCase):
         self.assertEqual(s["verified"], 0)
         self.assertEqual(len(s["differing"]), 1)
         self.assertEqual(s["differingSymbols"], [
-            {"module": None, "symbol": "_ZTV4Foo"}])
+            {"module": None, "symbol": "_ZTV4Foo", "addr": None, "bytes": 4}])
 
     def test_distinct_symbols_still_add_up(self):
         s = RDC.summarize([rec("_ZTI4Foo", RDC.VERIFIED), rec("_ZTS4Foo", RDC.PARTIAL),
@@ -63,7 +64,26 @@ class SummarizeCountsSymbols(unittest.TestCase):
                            dict(rec("_ZTV4Foo", RDC.DIFFERS), module="ov084")])
         self.assertEqual((s["symbols"], s["verified"], s["differs"]), (2, 1, 1))
         self.assertEqual(s["verifiedSymbols"], [
-            {"module": "ov006", "symbol": "_ZTV4Foo"}])
+            {"module": "ov006", "symbol": "_ZTV4Foo", "addr": None, "bytes": 4}])
+
+    def test_the_identity_rows_carry_the_rom_address_and_proven_bytes(self):
+        """Without the address `validate_merge` cannot tell a rename from a deletion.
+
+        `verify_data_symbol` has both on every record; dropping them here is what made
+        the ROM-data ratchet name-only, and a name is the one part of a data symbol a
+        source change is allowed to move.
+        """
+        s = RDC.summarize([
+            dict(rec("_ZTV8daGmch_c", RDC.VERIFIED, size=0x84, addr=0x02128c04),
+                 module="ov081"),
+            dict(rec("_ZTV7daMky_c", RDC.DIFFERS, size=0x84, addr=0x02115bfc),
+                 module="ov030")])
+        self.assertEqual(s["verifiedSymbols"], [
+            {"module": "ov081", "symbol": "_ZTV8daGmch_c",
+             "addr": 0x02128c04, "bytes": 0x84}])
+        self.assertEqual(s["differingSymbols"], [
+            {"module": "ov030", "symbol": "_ZTV7daMky_c",
+             "addr": 0x02115bfc, "bytes": 0x84}])
 
     def test_unparsable_objects_never_dedupe_against_each_other(self):
         """check_object's `?` catch-all carries no symbol identity, only a source."""

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -444,22 +444,37 @@ class ValidateMerge(unittest.TestCase):
 
 
 class RomDataRatchet(unittest.TestCase):
+    """Rows are `(module, symbol)` for an address-free report, `(module, symbol, addr,
+    bytes)` for one `romdata_check.summarize` produced with the cartridge anchor."""
+
+    def rows(self, entries):
+        out = []
+        for entry in entries:
+            if len(entry) == 2:
+                out.append({"module": entry[0], "symbol": entry[1]})
+            else:
+                module, symbol, addr, size = entry
+                out.append({"module": module, "symbol": symbol,
+                            "addr": addr, "bytes": size})
+        return out
+
     def data(self, verified=(), differing=(), verified_bytes=None):
+        verified_rows = self.rows(verified)
         body = {
-            "verified": len(verified),
+            "verified": len(verified_rows),
             "differs": len(differing),
-            "verifiedSymbols": [
-                {"module": module, "symbol": symbol}
-                for module, symbol in verified],
-            "differingSymbols": [
-                {"module": module, "symbol": symbol}
-                for module, symbol in differing],
+            "verifiedSymbols": verified_rows,
+            "differingSymbols": self.rows(differing),
         }
-        body["verifiedBytes"] = (4 * len(verified)
-                                  if verified_bytes is None else verified_bytes)
+        body["verifiedBytes"] = (
+            sum(row.get("bytes", 4) for row in verified_rows)
+            if verified_bytes is None else verified_bytes)
         return body
 
     def test_equal_count_cannot_hide_a_lost_exact_symbol(self):
+        """An address-free report -- a base built before `summarize` carried the
+        address -- keeps the original name-only diff, and so keeps calling this a
+        loss. The fallback is what makes the anchored path safe to add at all."""
         base = self.data(verified=(("ov006", "_ZTV3Old"),))
         head = self.data(verified=(("ov006", "_ZTV3New"),))
         out = VM.rom_data_regressions(base, head)
@@ -483,6 +498,84 @@ class RomDataRatchet(unittest.TestCase):
         base = self.data(verified=(("arm9", "Data"),))
         self.assertEqual(VM.rom_data_regressions(base, {}),
                          ["head full-ROM report omitted the ROM-data measurement"])
+
+    # -- the cartridge anchor: a rename is not a deletion ---------------------------
+    #
+    # `ov081/symbols.txt` carries `_ZTV8Moneybag` and `_ZTV8daGmch_c` at one address,
+    # 0x02128c04. Adopting the ROM's own RTTI name retires the coined row, so the head
+    # report proves 0x84 bytes at that address under the other name. Nothing was lost,
+    # and `verifiedBytes` -- unchanged across the rename -- already said so.
+
+    def test_a_rename_at_the_same_address_and_size_is_not_a_loss(self):
+        base = self.data(verified=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),))
+        head = self.data(verified=(("ov081", "_ZTV8daGmch_c", 0x02128c04, 0x84),))
+        self.assertEqual(VM.rom_data_regressions(base, head), [])
+
+    def test_a_replacement_at_another_address_is_still_a_loss(self):
+        base = self.data(verified=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),))
+        head = self.data(verified=(("ov081", "_ZTV8daGmch_c", 0x02128d00, 0x84),))
+        out = VM.rom_data_regressions(base, head)
+        self.assertTrue(any("lost 1 exact symbol" in reason for reason in out))
+        self.assertIn("ov081:_ZTV8Moneybag", "; ".join(out))
+
+    def test_two_departures_answered_by_one_arrival_still_lose_one(self):
+        """Matching is one-to-one. Two symbols proven at an address cannot both be
+        excused by a single replacement standing there."""
+        base = self.data(verified=(("ov081", "_ZTV8MoneybgA", 0x02128c04, 0x84),
+                                   ("ov081", "_ZTV8MoneybgB", 0x02128c04, 0x84)),
+                         verified_bytes=0x84)
+        head = self.data(verified=(("ov081", "_ZTV8daGmch_c", 0x02128c04, 0x84),),
+                         verified_bytes=0x84)
+        out = VM.rom_data_regressions(base, head)
+        self.assertTrue(any("lost 1 exact symbol" in reason for reason in out))
+
+    def test_a_replacement_proving_fewer_bytes_is_still_a_loss(self):
+        """Same address, less of it proven: the anchor is address AND extent, so a
+        shorter arrival cannot stand in for what the base actually verified."""
+        base = self.data(verified=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),))
+        head = self.data(verified=(("ov081", "_ZTV8daGmch_c", 0x02128c04, 0x7c),))
+        self.assertTrue(any("lost 1 exact symbol" in reason
+                            for reason in VM.rom_data_regressions(base, head)))
+
+    def test_the_same_address_in_another_module_is_still_a_loss(self):
+        """Overlays share address space; only `(module, addr)` names one datum."""
+        base = self.data(verified=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),))
+        head = self.data(verified=(("ov030", "_ZTV8daGmch_c", 0x02128c04, 0x84),))
+        self.assertTrue(any("lost 1 exact symbol" in reason
+                            for reason in VM.rom_data_regressions(base, head)))
+
+    def test_an_address_free_head_cannot_excuse_an_anchored_departure(self):
+        """A half-upgraded pair of reports falls back rather than guessing."""
+        base = self.data(verified=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),),
+                         verified_bytes=0x84)
+        head = self.data(verified=(("ov081", "_ZTV8daGmch_c"),), verified_bytes=0x84)
+        self.assertTrue(any("lost 1 exact symbol" in reason
+                            for reason in VM.rom_data_regressions(base, head)))
+
+    def test_a_renamed_differing_symbol_is_not_a_newly_differing_symbol(self):
+        """The same cartridge data still wrong at the same address under a new name is
+        not new breakage -- the gate must not go red for work that changed nothing."""
+        base = self.data(differing=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),))
+        head = self.data(differing=(("ov081", "_ZTV8daGmch_c", 0x02128c04, 0x84),))
+        self.assertEqual(VM.rom_data_regressions(base, head), [])
+
+    def test_a_genuinely_new_differing_symbol_is_still_reported(self):
+        base = self.data(differing=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),))
+        head = self.data(differing=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),
+                                    ("ov081", "_ZTV5Other", 0x02128e00, 0x40)))
+        out = VM.rom_data_regressions(base, head)
+        self.assertTrue(any("gained 1 differing symbol" in reason for reason in out))
+        self.assertIn("ov081:_ZTV5Other", "; ".join(out))
+
+    def test_a_rename_that_also_breaks_the_data_is_caught_both_ways(self):
+        """VERIFIED -> DIFFERS across a rename: the address anchor must not launder
+        it. The verified side loses the symbol; the differing side gains one."""
+        base = self.data(verified=(("ov081", "_ZTV8Moneybag", 0x02128c04, 0x84),))
+        head = self.data(differing=(("ov081", "_ZTV8daGmch_c", 0x02128c04, 0x84),),
+                         verified_bytes=0x84)
+        out = "; ".join(VM.rom_data_regressions(base, head))
+        self.assertIn("lost 1 exact symbol", out)
+        self.assertIn("gained 1 differing symbol", out)
 
 
 class ModuleFidelityDetail(unittest.TestCase):

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -400,17 +400,71 @@ def _rom_state(report):
             "failure": failure}
 
 
-def _data_symbol_set(data, field):
-    """Return stable ``(module, symbol)`` identities, or None for an old report."""
+def _data_symbol_rows(data, field):
+    """Return the report's per-symbol rows, or None for an old/unparsable report."""
     rows = data.get(field)
     if not isinstance(rows, list):
         return None
-    out = set()
+    out = []
     for row in rows:
         if not isinstance(row, dict) or not isinstance(row.get("symbol"), str):
             return None
-        out.add((row.get("module"), row["symbol"]))
+        out.append(row)
     return out
+
+
+def _data_identity(row):
+    return (row.get("module"), row["symbol"])
+
+
+def _data_anchor(row):
+    """The cartridge anchor a rename cannot move: module, ROM address, proven bytes.
+
+    A symbol NAME is a source-side choice; the address and the number of bytes that
+    byte-verified there are ROM facts. Retiring a coined ``_ZTV<Coined>`` in favour
+    of the ROM's own ``_ZTV<RomName>`` at the same address proves exactly the same
+    cartridge data, so it is a rename and not a loss. Returns None for a report that
+    predates the addresses -- `romdata_check.summarize` used to drop them -- which is
+    what puts the diff back on its old name-only footing.
+    """
+    addr, size = row.get("addr"), row.get("bytes")
+    if isinstance(addr, bool) or not isinstance(addr, int):
+        return None
+    if isinstance(size, bool) or not isinstance(size, int):
+        return None
+    return (row.get("module"), addr, size)
+
+
+def _data_departures(base_rows, head_rows):
+    """Base identities absent from head, after cancelling address-anchored renames.
+
+    Identity by ``(module, symbol)`` alone reads every symbol RENAME as a deletion,
+    which is what blocked adopting the ROM's own RTTI name over a coined one. The
+    address anchor cannot be forged from source: a head symbol has to byte-verify at
+    that address to appear in the report at all, and neither an alias row in
+    `symbols.txt` nor the PR's own rename ledger takes part in the decision.
+
+    Matching is strictly one-to-one per anchor, so two departures answered by a
+    single arrival still lose one symbol, and a departure whose only arrival sits at
+    a different address -- or proves a different number of bytes -- is still a loss.
+    A row carrying no anchor, on either side, never matches; that is exactly the
+    pre-existing name-only behaviour.
+    """
+    head_ids = {_data_identity(r) for r in head_rows}
+    base_ids = {_data_identity(r) for r in base_rows}
+    gone = [r for r in base_rows if _data_identity(r) not in head_ids]
+    arrivals = collections.Counter(
+        anchor for anchor in (_data_anchor(r) for r in head_rows
+                              if _data_identity(r) not in base_ids)
+        if anchor is not None)
+    lost = []
+    for row in sorted(gone, key=lambda r: (r.get("module") or "", r["symbol"])):
+        anchor = _data_anchor(row)
+        if anchor is not None and arrivals[anchor] > 0:
+            arrivals[anchor] -= 1
+            continue
+        lost.append(_data_identity(row))
+    return lost
 
 
 def _data_name(identity):
@@ -426,10 +480,10 @@ def rom_data_regressions(base_data, head_data):
         return ["head full-ROM report omitted the ROM-data measurement"]
 
     out = []
-    base_verified = _data_symbol_set(base_data, "verifiedSymbols")
-    head_verified = _data_symbol_set(head_data, "verifiedSymbols")
+    base_verified = _data_symbol_rows(base_data, "verifiedSymbols")
+    head_verified = _data_symbol_rows(head_data, "verifiedSymbols")
     if base_verified is not None and head_verified is not None:
-        lost = sorted(base_verified - head_verified, key=lambda x: (x[0] or "", x[1]))
+        lost = _data_departures(base_verified, head_verified)
         if lost:
             names = ", ".join(_data_name(x) for x in lost[:3])
             more = f", +{len(lost) - 3} more" if len(lost) > 3 else ""
@@ -447,10 +501,16 @@ def rom_data_regressions(base_data, head_data):
             f"ROM data verified bytes fell from {base_data['verifiedBytes']} to "
             f"{head_data['verifiedBytes']}")
 
-    base_differing = _data_symbol_set(base_data, "differingSymbols")
-    head_differing = _data_symbol_set(head_data, "differingSymbols")
+    base_differing = _data_symbol_rows(base_data, "differingSymbols")
+    head_differing = _data_symbol_rows(head_data, "differingSymbols")
     if base_differing is not None and head_differing is not None:
-        new = sorted(head_differing - base_differing, key=lambda x: (x[0] or "", x[1]))
+        # Symmetric, and for the same reason: a symbol that was already wrong on base
+        # and is still wrong at the same address under a new name is not a NEWLY wrong
+        # symbol. Reversing the arguments makes an ARRIVAL the thing to cancel. A
+        # genuinely new differing symbol has no departure to answer it, and a symbol
+        # that went VERIFIED -> DIFFERS across a rename is still caught, by the
+        # verified-loss diff above.
+        new = _data_departures(head_differing, base_differing)
         if new:
             names = ", ".join(_data_name(x) for x in new[:3])
             more = f", +{len(new) - 3} more" if len(new) > 3 else ""


### PR DESCRIPTION
Closes https://github.com/tangosdev/sm64ds-decomp/issues/2409

Tools only. No `src/`, `include/`, `config/` or ROM ranges are touched, and no byte moves.

## The defect

`rom_data_regressions` in `tools/validate_merge.py` read every symbol **rename** as a data **loss**. `_data_symbol_set` built identities as `(module, symbol)` and nothing else, and the diff was a raw set difference, so retiring a coined `_ZTV<Coined>` in favour of the ROM's own `_ZTV<RomName>` — same module, same address, same bytes — reported a lost exact symbol and turned the gate red.

The producer side made it structural: `romdata_check.summarize` emitted `verifiedSymbols` and `differingSymbols` rows as `{module, symbol}` only, **dropping the `addr` and `bytes` that every verdict record already carries**. The comparison had no address to anchor on and could not tell a deletion from a rename.

`config/arm9/overlays/ov081/symbols.txt` carries both `_ZTV8Moneybag` and `_ZTV8daGmch_c` at one address, `0x02128c04`. `ov030` (`_ZTV5Ukiki` / `_ZTV7daMky_c` @ `0x02115bfc`) and `ov002` (`_ZTV13OneUpMushroom` / `_ZTV7da1up_c` @ `0x021083c8`) have the same shape. Nothing is lost across that change, and `verifiedBytes` — unchanged — already said so.

## The fix

Carry `addr` and `bytes` through into the identity rows, then match departures to arrivals on `(module, addr, bytes)`, strictly one-to-one:

- a departure answered at the same address, proving the same bytes, is a rename and not a loss;
- a replacement at a **different address**, in a **different module**, or proving a **different number of bytes**, is still a loss;
- **two departures answered by one arrival still lose one symbol** — the match consumes the arrival;
- a row carrying **no anchor** — an old report, on either side — never matches, which is exactly the pre-existing name-only behaviour.

That last point is why this is safe to add, and why it has to land alone and first. The base half of the validator's comparison is built at `baseSha` with main's `romdata_check.py`, and may be served from a per-SHA cache, so a PR that both fixed the gate and depended on the fix would compare a new-format candidate against an address-free base. The fallback makes that case degrade to today's verdict rather than to a wrong one.

The same cancellation runs in the `differingSymbols` direction with the arguments reversed: a symbol that was already wrong at an address and is still wrong there under a new name is not *newly* wrong. A genuinely new differing symbol has no departure to answer it, and a symbol that goes VERIFIED to DIFFERS across a rename is caught twice — once as a verified loss, once as a gained differing symbol. There is a test for exactly that.

## Why the address, and not the two easier answers

Neither workaround that would also silence the gate is taken. No alias row is added to any `symbols.txt`, and `symbols/actor_renames.tsv` is never consulted — the PR under validation writes that ledger itself, so either route would let a PR certify its own rename.

The address cannot be forged from source: a head symbol has to byte-verify at that address to appear in `verifiedSymbols` at all.

## Tests

Seven new or updated assertions fail against the unfixed tools and pass with them:

- `test_a_rename_at_the_same_address_and_size_is_not_a_loss`
- `test_a_renamed_differing_symbol_is_not_a_newly_differing_symbol`
- `test_two_departures_answered_by_one_arrival_still_lose_one`
- `test_the_identity_rows_carry_the_rom_address_and_proven_bytes`, plus the three existing `summarize` assertions that now pin the wider row

Six more are guard tests that pass either way, confirming the gate was not weakened: different address, different module, fewer bytes proven, an address-free head against an anchored base, a genuinely new differing symbol, and the VERIFIED-to-DIFFERS rename.

`test_equal_count_cannot_hide_a_lost_exact_symbol` — the test that encodes the old name-only behaviour — is unchanged and still passes, now through the fallback.

| command | result |
|---|---|
| the 33 modules listed in `.github/workflows/tool-tests.yml` | `Ran 614 tests ... OK (skipped=3)`, exit 0 |
| `python -m unittest tools.test_validate_merge` | `Ran 48 tests ... OK`, exit 0 |
| `python -m unittest tools.test_romdata_check` | `Ran 21 tests ... OK`, exit 0 |
| `python tools/check_python_names.py` | PASS, exit 0 |
| `python tools/check_dead_references.py` | no new dead references, exit 0 |
| `python tools/premerge_check.py bb07478e` | 8/8 static gates unchanged, nothing green to red, exit 0 |

`tools/test_romdata_check` is **not** enrolled in `.github/workflows/tool-tests.yml` — it dies on `No module named 'elftools'` on a bare runner, as that file's own header says. Its half was run by hand on a wired worktree; the 21/21 above is that run.

## Sequencing

https://github.com/tangosdev/sm64ds-decomp/pull/2392 also holds `tools/validate_merge.py` and `tools/test_validate_merge.py`, for the unrelated denominator gate. The issue expected a textual conflict; there is none. Merging that head into this candidate auto-merges both files and the combined suite is green (`Ran 80 tests ... OK`), so the two can land in either order.

After this lands, the base ROM reports for https://github.com/tangosdev/sm64ds-decomp/pull/2398 and https://github.com/tangosdev/sm64ds-decomp/pull/2395 need regenerating, or their per-SHA cache entries superseding, before re-validation: their cached base reports still carry address-free rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
