### PR TITLE
Bank the daBrq static-initializer ownership proof note (ov070)

### DIFF
--- a/notes/handoff-issue-2422.md
+++ b/notes/handoff-issue-2422.md
@@ -1,0 +1,119 @@
+# Handoff: issue-2422
+
+This document describes this commit. The queue records its immutable output SHA.
+
+## Identity and resumption
+
+- Issue URL, task ID, stage, session and harness:
+  https://github.com/tangosdev/sm64ds-decomp/issues/2422, `issue-2422`, stage
+  `reconstruct` (producer), session `prod-2422-0907`, Claude Code.
+- Source branch and previous accepted input SHA: `cpp/daBrq_c-bank`; accepted
+  input `9fded5f5242a10f04f318da3bfd477993a192d20` (tip of the local-only
+  `cpp/dabrq-sinit-resource-tu`).
+- Original source base SHA and installed workflow/tool SHA: original base
+  `6f0a3ab9bd6d01373744d32cedb7e0f3dc6cffb8`; this commit is built on `main` at
+  `88dbe66db2cb3f0cd1dc704e9f2775eb37aea646`; workflow/tool pin
+  `f327f7b6460e157153eb7fc0749dbbe60dd854f1`.
+- Separate evidence commits and required artifacts in this commit: none
+  separate. This commit adds `notes/sinit-dabrq-ownership.md`,
+  `notes/sinit-probes/dabrq.cpp`, and this handoff. The private queue receipt
+  stays under an ignored `build/` directory and is not part of the commit.
+- Next action, responsible role and blockers: independent verification
+  (verifier) of the reproduction recorded in the note, then integration. No
+  blockers. The `rom_data_regressions` gate defect tracked at
+  https://github.com/tangosdev/sm64ds-decomp/issues/2409 is not exercised
+  here because this commit renames no symbol and touches no `symbols.txt`.
+- Status: verified candidate for the narrowed scope (a proof note whose claim
+  was re-measured under the pinned compiler on this base). Nothing is WIP.
+- Remaining uncommitted/local-only material and where it is preserved: the
+  original branch `cpp/dabrq-sinit-resource-tu` at `9fded5f52` and its
+  worktree remain in place, untouched. Its other two commits are superseded
+  (see below), not lost.
+
+## What changed and why
+
+- Class/TU/symbol and module-qualified ROM scope: `ov070/daBrq_c`; the
+  initializer `__sinit_ov070_02122d80` at `ov070:0x02122d80..0x02122f30`, its
+  `.data` PMF descriptors `ov070:0x0212320c..0x0212323c`, and its `.bss`
+  objects `ov070:0x021235ec..0x02123698`. Nothing in those ranges is
+  re-enrolled or re-owned by this commit.
+- Reserved source/header/config surfaces actually touched: none. Only
+  `notes/` changed. The reserved TU, header, manifest, `delinks.txt`,
+  `symbols.txt`, and `symbols/actor_renames.tsv` are untouched; zero rename
+  rows appended.
+- ROM observations: symbol spacing in `config/arm9/overlays/ov070/symbols.txt`
+  shows five 8-byte handles, six 12-byte registration nodes, one 12-byte
+  vector, one 48-byte state array ending exactly at the next symbol, and six
+  8-byte PMF descriptors ending exactly at `_ZTS7daBrq_c`. No absorbed array,
+  no phantom index.
+- Lineage evidence or structural inference: the original task assumed the
+  branch's promotion was unbanked. It is banked: the branch's promotion commit
+  `883c4cf4a` is the same change as `7402d8be8`, already on `main` via
+  https://github.com/tangosdev/sm64ds-decomp/pull/2084, and the later profile
+  campaign moved the TU to `src/game/actors/daBrq_c.cpp` and renamed
+  `Amp_Spawn` to `daBrq_c_classInit` (`src/d_a_brq.c`) and `Amp_SpawnInfo` to
+  `g_profile_BIRIKYU`. Every differing line between the branch TU and `main`'s
+  is that rename or comment prose. The branch's tools commit `e4650db21` was
+  superseded by https://github.com/tangosdev/sm64ds-decomp/pull/2074. The only
+  content unique to the branch was the note and probe banked here.
+- Hypothesized names/filenames, explicitly not recovered facts: the probe's
+  `Brq*Probe` class names are deliberately neutral stand-ins; the note says so
+  and forbids promoting them.
+- Compiler experiments and measured barriers: the guarded probe compiled with
+  `swarm.CPP_FLAGS` plus `-DSINIT_OWNERSHIP_PROBE` reproduces
+  `__sinit_ov070_02122d80` byte-for-byte (`0x1b0/0x1b0`) with 34/34
+  relocation offsets, types, and addends equal; only the 34 symbol spellings
+  differ. Without the define the probe emits no production sections.
+
+## Reconstruction dimensions
+
+- Exact function/byte and relocation coverage: unchanged by this commit. For
+  the record, `main`'s manifest lists 18 functions and `symbols.txt` lists 18
+  `_ZN7daBrq_c*` symbols (set difference empty both ways); the 19th class
+  symbol is the factory `daBrq_c_classInit` at `0x021210ac`, deliberately
+  enrolled outside the TU in `src/d_a_brq.c` because mwccarm cannot express
+  placement construction against the retail `fBase_c` allocator. Neither side
+  dropped a function.
+- Genuine methods; remaining free-function/ABI bridges: unchanged; the factory
+  is the one C bridge.
+- Recovered layout/fields; remaining shadow structs/raw offsets: unchanged.
+- Lifecycle, vtable/RTTI, initializer and data ownership: unchanged. The
+  destructor stays inline in `include/daBrq_c.h` with `InitResources` as the
+  key function; the manifest's `data` list still owns `_ZTS`, `_ZTI`,
+  `g_profile_BIRIKYU`, and `_ZTV`. The initializer stays separately enrolled
+  in `src/__sinit_ov070_02122d80.cpp`, identical between the branch and `main`.
+- Attribution preserved through each move/rename: no move or rename here.
+- Remaining agreed issue scope: none after this commit; the promotion is
+  already on `main`. The engine-level reconstruction of the resource wrapper
+  types at `0x020178b4..0x02017b64` that would let the initializer move into
+  the TU is a separate, unscoped follow-up named in the note.
+
+## Proof
+
+All commands were run in the worktree on this commit's tree at base
+`88dbe66db`, pinned mwccarm 2004/b56 toolchain (wired and canary-verified by
+the worktree helper).
+
+- Full-ROM build: not run; not applicable. No enrolled source, header,
+  linker configuration, manifest, or symbol changed (`git diff --name-only`
+  against `main` lists only `notes/`), so the ROM cannot differ from `main`.
+- Explicit function/consumer relocation checks: the probe reproduction above,
+  exit 0: `bytes: 0x1b0/0x1b0 equal=True`, `relocations: 34/34`, all offsets,
+  types, and addends equal, 34 name-only differences, probe without the define
+  emits no `.text`/`.init`/`.data`/`.bss`/`.ctor`/`.rodata` content. Compared
+  `__sinit_dabrq.cpp` from the probe object against `__sinit_ov070_02122d80`
+  compiled from the committed transcription with the same flags.
+- Complete emitted TU and data/metadata checks: not run; no TU changed.
+- Shared-header consumer expansion: not applicable; no header changed.
+- Port/path/reference and other applicable static gates, all exit 0:
+  `python tools/check_dead_references.py` (no new dead references, no broken
+  markdown links, nothing flagged in the two new files);
+  `python tools/layout_check.py --quiet` (clean);
+  `python tools/port_refcheck.py` (402 checked, all resolve);
+  `python tools/check_rename_ledger.py --repo .` (1923 rows agree);
+  `python tools/check_src_tu.py --json build/src_tu_refs.json` (every
+  reference resolves). No notes-directory policy file exists on `main`; the
+  tree-shape workflow runs `tools.test_srcpath` and `tools.test_bytegate`,
+  which do not read `notes/`.
+- Private validation, if run, and the exact PR head/base it tested: not run
+  locally; the PR's CI result is separately recorded evidence.

--- a/notes/sinit-dabrq-ownership.md
+++ b/notes/sinit-dabrq-ownership.md
@@ -1,0 +1,133 @@
+# daBrq static-initializer ownership and generation proof
+
+This is a production-boundary audit for `__sinit_ov070_02122d80`. It does not
+change an enrolled source, linker configuration, or symbol name. The guarded
+probe in `notes/sinit-probes/dabrq.cpp` contains ordinary global C++ objects and
+no hand-written initializer.
+
+## What this note is, and is not
+
+It is a proof note. It was first written on a branch named
+`cpp/dabrq-sinit-resource-tu`, and that name overstates the work: nothing here
+regenerates the initializer from a "resource TU", and the production enrolment
+of the initializer was never changed. On `main` today:
+
+- `src/__sinit_ov070_02122d80.cpp` is still the hand-transcribed, separately
+  enrolled initializer, byte-identical to the version this audit was measured
+  against;
+- `src/game/actors/daBrq_c.cpp`, described by
+  `config/tu_manifest.d/ov070/daBrq_c.json`, is the promoted class TU. Its
+  manifest records that the initializer, its `.ctor` word, the PMF input
+  table, the resource globals, and the state-table BSS remain separately
+  enrolled;
+- `src/d_a_brq.c` holds the factory `daBrq_c_classInit` (historical project
+  alias `Amp_Spawn`), enrolled outside the class TU because the pinned
+  compiler cannot express placement construction against the retail `fBase_c`
+  allocator. That factory is the nineteenth `daBrq_c` symbol in the overlay;
+  the manifest's eighteen functions plus this factory cover every one.
+
+The audit answers one question only: could the original `daBrq_c` source have
+produced this initializer organically? It could, as shown below.
+
+## Verdict
+
+`__sinit_ov070_02122d80`, its `.ctor` word, six PMF descriptors, and the BSS
+objects they initialize belong to the `ov070/daBrq_c` translation unit.
+CodeWarrior 2004/b56 organically reproduces the entire initializer from five
+resource objects, three state-handler pairs, and one `Vector3`-shaped object:
+
+- `.init`: `0x1b0` bytes, raw-byte identical;
+- `.rela.init`: all 34 offsets, types, and addends identical;
+- `.ctor`: one 4-byte pointer to the generated initializer;
+- `.data`: six independent 8-byte PMF descriptors (`0x30` bytes total);
+- `.bss`: five 8-byte resource handles, six 12-byte registration nodes, one
+  48-byte state-handler array, and one 12-byte vector (`0xac` bytes total);
+- no hand-written call to `__register_global_object`.
+
+The exact initializer transcription remains stronger evidence for final
+relocation destinations. The neutral probe deliberately emits neutral resource
+class names, so its constructor and destructor relocation targets differ in
+spelling while every instruction and relocation slot agrees:
+
+| Organic object | ROM constructor target | ROM destructor target |
+| --- | --- | --- |
+| model handle `0x2b1` | `func_02017acc` | `func_02017ab4` |
+| model handle `0x2b3` | `func_02017acc` | `func_02017ab4` |
+| animation handle `0x2b2` | `_ZN13SharedFilePtr9ConstructEj` | `SharedFilePtr_Destruct_Anim` |
+| animation handle `0x2b5` | `_ZN13SharedFilePtr9ConstructEj` | `SharedFilePtr_Destruct_Anim` |
+| texture-sequence handle `0x2b4` | `SharedFilePtr_Construct_TexSeq` | `SharedFilePtr_Destruct_TexSeq` |
+| cylinder offset | inline three-word construction | `_ZN7Vector3D1Ev` |
+
+The five resource globals are exactly eight bytes apart where applicable. The
+shared constructor body proves their layout as `u16 fileID`, `u8 refCount`, one
+pad byte, and a pointer at offset 4. The initializer's non-const PMF array copies
+six 8-byte descriptors in this source order:
+
+1. `daBrq_c::EnterCooldownState`, `daBrq_c::UpdateCooldownState`;
+2. `daBrq_c::EnterActiveState`, `daBrq_c::UpdateActiveState`;
+3. `daBrq_c::EnterDefeatedState`, `daBrq_c::UpdateDefeatedState`.
+
+The final object is dynamically constructed in BSS as `{0, -0x28000, 0}` and
+registered with the real `Vector3` destructor. A neutral type with the same
+three-argument inline constructor reproduces those stores exactly. The current
+shared `Vector3` declaration omits that constructor so C++ files can still use
+legacy aggregate initialization; changing that widely included header is not
+part of this audit.
+
+## Symbol spacing on `main`: no absorbed array, no phantom index
+
+An inferred initializer can silently absorb a short array into the entry below
+it and invent indices that do not exist. The ov070 symbol table rules that out
+here. In `config/arm9/overlays/ov070/symbols.txt`:
+
+- five resource handles at `0x021235ec`, `0x021235f4`, `0x021235fc`,
+  `0x02123604`, `0x0212360c`: every 8 bytes;
+- six registration nodes at `0x02123614`, `0x02123620`, `0x0212362c`,
+  `0x02123638`, `0x02123644`, `0x02123650`: every 12 bytes;
+- the `Vector3` at `0x0212365c`: 12 bytes;
+- the state-handler array at `0x02123668`, with the next symbol at
+  `0x02123698`: exactly `0x30` = three pairs of two 8-byte PMF descriptors;
+- six PMF descriptors in `.data` at `0x0212320c`, `0x02123214`, `0x0212321c`,
+  `0x02123224`, `0x0212322c`, `0x02123234`: every 8 bytes, ending at
+  `0x0212323c` where `_ZTS7daBrq_c` begins.
+
+Every object the initializer touches has its own symbol at the expected
+distance from its neighbours, so the six-entry PMF table and the three-pair
+state array are what the ROM lays out, not an artifact of the transcription.
+
+## Production boundary
+
+Do not replace the exact initializer with the neutral probe classes. The ROM
+does not preserve the original non-polymorphic resource class names, and the
+current `SharedFilePtr_Construct_*` / `SharedFilePtr_Destruct_*` labels are
+resource-family aliases rather than proof of original C++ type spellings.
+Promoting neutral names would make the bytes match only after speculative
+symbol renames.
+
+The safe next step is an engine-level reconstruction of the resource wrapper
+types at `0x020178b4..0x02017b64`. Once their genuine constructor/destructor
+identities are settled, this initializer can move into the real `daBrq_c` TU
+without a hand-written `extern "C"` initializer.
+
+## Reproduction
+
+Compile the guarded probe with the pinned production C++ flags (the
+`CPP_FLAGS` string in `tools/swarm.py`, through `compile_c` in
+`tools/match.py`) plus `-DSINIT_OWNERSHIP_PROBE`. Comparing `__sinit_dabrq.cpp`
+in that object with `__sinit_ov070_02122d80` from the committed exact
+transcription gives:
+
+```text
+bytes: 0x1b0/0x1b0 equal=True
+relocations: 34/34
+all 34 relocation offsets/types/addends: equal
+```
+
+Compiling without `SINIT_OWNERSHIP_PROBE` contributes no production sections.
+
+Re-measured on 2026-09-07 against `main` at `88dbe66db` for
+https://github.com/tangosdev/sm64ds-decomp/issues/2422, with the same result:
+34 of 34 relocation slots agree in offset, type, and addend, and the only
+differences are the 34 symbol spellings the table above maps (neutral probe
+constructors, destructors, and objects against the ROM's `func_*`,
+`SharedFilePtr_*`, `data_ov070_*`, and `__register_global_object` labels).

--- a/notes/sinit-probes/dabrq.cpp
+++ b/notes/sinit-probes/dabrq.cpp
@@ -1,0 +1,81 @@
+//cpp
+/* Notes-only organic-generation probe for __sinit_ov070_02122d80.
+ * It contributes nothing unless SINIT_OWNERSHIP_PROBE is supplied manually.
+ * There is deliberately no hand-written initializer in this file. */
+#ifdef SINIT_OWNERSHIP_PROBE
+#include "types.h"
+
+class BrqModelResourceProbe
+{
+    u32 words[2];
+
+public:
+    BrqModelResourceProbe(u32 fileID);
+    ~BrqModelResourceProbe();
+};
+
+class BrqAnimationResourceProbe
+{
+    u32 words[2];
+
+public:
+    BrqAnimationResourceProbe(u32 fileID);
+    ~BrqAnimationResourceProbe();
+};
+
+class BrqTextureResourceProbe
+{
+    u32 words[2];
+
+public:
+    BrqTextureResourceProbe(u32 fileID);
+    ~BrqTextureResourceProbe();
+};
+
+class BrqVector3Probe
+{
+    s32 x;
+    s32 y;
+    s32 z;
+
+public:
+    BrqVector3Probe(s32 x_, s32 y_, s32 z_)
+        : x(x_), y(y_), z(z_) {}
+    ~BrqVector3Probe() {}
+};
+
+struct BrqStateProbe
+{
+    s32 EnterCooldownState();
+    s32 UpdateCooldownState();
+    s32 EnterActiveState();
+    s32 UpdateActiveState();
+    s32 EnterDefeatedState();
+    s32 UpdateDefeatedState();
+};
+
+typedef s32 (BrqStateProbe::*BrqStatePMF)();
+
+struct BrqStatePairProbe
+{
+    BrqStatePMF enter;
+    BrqStatePMF update;
+};
+
+BrqModelResourceProbe brqModelResource0(0x2b1);
+BrqModelResourceProbe brqModelResource1(0x2b3);
+BrqAnimationResourceProbe brqAnimationResource0(0x2b2);
+BrqAnimationResourceProbe brqAnimationResource1(0x2b5);
+BrqTextureResourceProbe brqTextureResource(0x2b4);
+
+BrqStatePairProbe brqStateHandlers[3] = {
+    { &BrqStateProbe::EnterCooldownState,
+      &BrqStateProbe::UpdateCooldownState },
+    { &BrqStateProbe::EnterActiveState,
+      &BrqStateProbe::UpdateActiveState },
+    { &BrqStateProbe::EnterDefeatedState,
+      &BrqStateProbe::UpdateDefeatedState },
+};
+
+BrqVector3Probe brqCylinderOffset(0, -0x28000, 0);
+#endif


### PR DESCRIPTION
Banks the one piece of `cpp/dabrq-sinit-resource-tu` that never reached `main`: a notes-only proof that CodeWarrior 2004/b56 reproduces `__sinit_ov070_02122d80` organically from ordinary global objects. Task https://github.com/tangosdev/sm64ds-decomp/issues/2422. Handoff in `notes/handoff-issue-2422.md`.

## What this is

- `notes/sinit-dabrq-ownership.md` and `notes/sinit-probes/dabrq.cpp`, cherry-picked from `9fded5f52`. The note's wording now describes `main` as it is (`src/game/actors/daBrq_c.cpp`, factory `daBrq_c_classInit` in `src/d_a_brq.c`, historical alias `Amp_Spawn`), and says plainly that the source branch's "resource TU" name overstated the work: production sinit enrolment was never changed, and `src/__sinit_ov070_02122d80.cpp` stays the hand-transcribed, separately enrolled initializer.
- No enrolled source, header, manifest, `delinks.txt`, `symbols.txt`, or `symbols/actor_renames.tsv` row changes. Zero rename rows appended.

## Why the rest of that branch is not here

The promotion commit on that branch (`883c4cf4a`) is the same change as `7402d8be8`, already on `main` via https://github.com/tangosdev/sm64ds-decomp/pull/2084; the profile campaign then moved and renamed it. Every differing line between the branch TU and `main`'s is that rename or comment prose. The branch's tools commit was superseded by https://github.com/tangosdev/sm64ds-decomp/pull/2074.

## Two open questions this answers

1. **Neither side dropped a function.** `main`'s manifest lists 18 functions and `symbols.txt` lists 18 `_ZN7daBrq_c*` symbols; the set difference is empty both ways. The 19th class symbol is the `_classInit` factory `daBrq_c_classInit` at `0x021210ac`, deliberately enrolled outside the class TU in `src/d_a_brq.c` because mwccarm cannot express placement construction against the retail `fBase_c` allocator.
2. **No absorbed array, no phantom indices** in `main`'s ov070 symbol spacing: five resource handles `0x021235ec`..`0x0212360c` every 8 bytes; six registration nodes `0x02123614`..`0x02123650` every 12; the `Vector3` at `0x0212365c` (12); the state array at `0x02123668` with the next symbol at `0x02123698`, exactly `0x30` = 3 pairs x 2 x 8-byte PMF descriptors; six `.data` PMF descriptors `0x0212320c`..`0x02123234` every 8, ending at `0x0212323c` where `_ZTS7daBrq_c` begins.

## Proof

Re-measured on `main` at `88dbe66db` under the pinned compiler (`swarm.CPP_FLAGS` via `match.compile_c`, plus `-DSINIT_OWNERSHIP_PROBE`), comparing `__sinit_dabrq.cpp` from the probe object against `__sinit_ov070_02122d80` compiled from the committed transcription:

```
bytes: 0x1b0/0x1b0 equal=True
relocations: 34/34
all 34 relocation offsets/types/addends: equal
name-only differences: 34
probe without the define: no production sections
```

Static gates, all exit 0: `check_dead_references.py` (no new dead references, no broken links), `layout_check.py`, `port_refcheck.py`, `check_rename_ledger.py`, `check_src_tu.py`.

Not run, by design: full-ROM build and TU/link checks. Only `notes/` changed, so the ROM cannot differ from `main`. `rom_data_regressions` (https://github.com/tangosdev/sm64ds-decomp/issues/2409) is not exercised: no symbol is renamed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
