### PR TITLE
Restamp LINKED off port/link100: 10013 of 11328 (88.4%)

### DIFF
--- a/config/port_linkage.json
+++ b/config/port_linkage.json
@@ -28,11 +28,11 @@
     "Enrolling free TUs does nothing, because the release build dead-strips whatever the",
     "linked closure never references."
   ],
-  "linkedTus": 9121,
-  "matchedTus": 11324,
-  "measuredAt": "2026-08-30",
-  "branch": "port-mount-noseat-cluster",
-  "commit": "ce1afba51",
+  "linkedTus": 10013,
+  "matchedTus": 11328,
+  "measuredAt": "2026-09-07",
+  "branch": "port/link100",
+  "commit": "a4504f88d",
   "stale": false,
-  "basis": "single lane cons at its pushed tip ce1afba51, measured against the tip's own battery build walk_window.map (tree clean, battery ALL GREEN, the merge that closed cast-campaign wave 3). +346 over the morning's 8775 stamp: eight reviewed merges seating ov064's last three classes, Princess Peach, Snowball and Moneybag, the snowmen and the Fly Guy, three level-overlay tails (ov025 the first overlay at 100%), the ov091 lifts and Fwoosh, and the Tick Tock Clock cluster behind a per-level re-patch mechanism; plus the two Goomboss state bodies and the declared Wiggler Behavior propagated from main by address. The tree crosses 80 percent. Two disclosed holes remain and both matched on main today: func_ov074_02121380 (declared, div 11, execution-audited) and _ZN14TTC_MovingBeam8BehaviorEv (byte-matched, PR #2026) -- seating lanes for both are in flight. Remaining frontier: wave-4 partial-overlay tails, then arm9/ov002/ov006."
+  "basis": "integration branch port/link100 at its pushed tip a4504f88d, measured against that tip's own battery build walk_window.map (C:/tmp/l4pmf, tree clean, battery ALL GREEN, five proofs green including the opening-cutscene gate). +892 over the 2026-08-30 stamp of 9121 on cons ce1afba51. The branch is cons 6fa05ec03 plus run link100: the ROM's save system, thread scheduler and ARM9<->ARM7 link running as ROM code; the pre-main boot spans; Stage vtable slots 3/6/9/16/17; the boot and download-play scenes; /vmg /vmm target-wide so every pointer-to-member is the ROM's 8-byte pair, which retired 56 host copies; the Model-family virtual-destructor unfold (MSVC folds D1/D0 into one slot) which put 30 render bodies and 25 more host copies back on the ROM's own TUs; 24 ruled bodies seated by ROM address; CAGE_LIFT, RICKSHAW_BDW and PUSHABLE_BLOCK registered; TRAP moved off LIGHT_BEAM's vtable (a live wrong-alias bug). Every rung of the night was gated: 9820 -> 9843 -> 9871 -> 9895 -> 9925 -> 9945 -> 9976 -> 9988 -> 10013. The linkage number itself was proven cartridge-independent this run (an identical set of 9820 TUs links with no ROM present, locally and on a GitHub runner). Remaining: the 478-row documented host-ABI exception queue, the wireless chain behind the ARM7 model (~175), the boot chain's refused arms, and guessed vtable bodies that need real decomp."
 }


### PR DESCRIPTION
config/port_linkage.json refreshed from port/link100 at a4504f88d, measured against that tip's own battery build map (battery ALL GREEN, five proofs green including the opening-cutscene gate). Up 892 over the 2026-08-30 stamp of 9121.

The branch is cons 6fa05ec03 plus run link100, which is also being fast-forwarded onto cons. The full ladder of gated rungs and what each lane landed is in the basis field of the stamp.