### PR TITLE
Require independent source review before fleet integration

### DIFF
--- a/.github/workflows/source-review.yml
+++ b/.github/workflows/source-review.yml
@@ -1,0 +1,51 @@
+name: Source review
+
+# Use only default-branch tools and API metadata. Never execute or check out PR
+# code in this privileged workflow, including when the PR changes these tools.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number, or empty to refresh all open PRs'
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+# Serialize publication; each run reads current head/base and queue state.
+concurrency:
+  group: source-review-publication
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check review enforcement
+        run: |
+          python -m unittest discover -s tools -p 'test_*source_review.py' -v
+          python -m unittest discover -s tools -p 'test_classqueue*.py' -v
+      - name: Publish candidate source review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEW_REPO: ${{ github.repository }}
+          REVIEW_PR: ${{ github.event.pull_request.number || inputs.pr }}
+        run: |
+          args=(--repo "$REVIEW_REPO" --publish)
+          if [ -n "$REVIEW_PR" ]; then args+=(--pr "$REVIEW_PR"); fi
+          python tools/check_pr_source_review.py "${args[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,11 @@ workers; installing the files alone does not switch the live fleet.
 
 A PR is mergeable only when the **`validate`** CI check is green. It compiles each
 changed `src/*.c|*.cpp` on a private build box and compares the *relocated* bytes to
-the ROM. Green = byte-verified = mergeable. Red means at least one file either:
+the ROM. Source reconstruction also requires the independent **Source review**
+check described in [the review cutover](notes/agents/SOURCE-REVIEW-CUTOVER.md).
+A byte pass establishes byte correctness; source review establishes acceptance
+of the reconstructed C++ and its explicitly recorded remaining work.
+Red byte validation means at least one file either:
 
 - doesn't reproduce the ROM bytes, or
 - **WRONG-DEST** — a relocation links to the wrong symbol (right bytes, wrong callee/global).
@@ -135,6 +139,7 @@ into `tools/hooks/pre-push`.
 ## How your PR is handled
 
 See [`MERGE.md`](MERGE.md). In short: a maintainer (human or AI) merges once
-`validate` is green. If some files pass and some fail, only the verified subset is
+both required checks are green for the proposed candidate and base. If some files
+pass and some fail, only the verified subset is
 landed and the failing files are dropped — verify locally first so that's
 unnecessary.

--- a/MERGE.md
+++ b/MERGE.md
@@ -27,7 +27,15 @@ coordinated v2 fleet.
 
 - **Match PRs** must pass the **`validate`** CI check. It compiles every changed
   `src/*.c|*.cpp` on a private build box and compares the relocated bytes to the ROM.
-  **Green = byte-verified = merge.**
+  A passing byte check is required alongside independent source acceptance.
+- **Source reconstruction PRs** must also pass **Source review** for their exact
+  head and current base. This includes source/header changes and enrollment,
+  symbol, relocation and TU-manifest changes. Run
+  `python tools/check_pr_source_review.py --pr NUMBER` immediately before landing;
+  missing evidence, stale review, incomplete coverage and unresolved findings
+  block integration. Follow [the activation and adoption procedure](notes/agents/SOURCE-REVIEW-CUTOVER.md)
+  to install the required GitHub check. Until activation, enforce the same review
+  decision manually; do not describe a green byte check as finished humanization.
 - **WRONG / blind files.** If `validate` flags any file as `wrong-dest` (a reloc links to
   the wrong symbol) or `blind` (a reloc slot could not be resolved), **drop those files and
   land only the verified subset.** Never merge a file that does not reproduce the ROM — it

--- a/notes/agents/LAUNCH.md
+++ b/notes/agents/LAUNCH.md
@@ -83,6 +83,15 @@ in-flight source branch just to get a launcher.
 
 ## Specialists
 
+For a dedicated source reviewer, use:
+
+> Read notes/agents/PIPELINE.md, roles/humanizer.md and SOURCE-REVIEW-CUTOVER.md.
+> Review the assigned exact candidate and its inherited findings. Inspect existing
+> real interfaces before accepting shadow structs, raw fields or mangled calls.
+> Publish an independent source-review verdict with concrete dispositions. Return
+> unresolved findings through rework; do not edit the candidate you are reviewing.
+> Task: [issue URL, task ID, candidate SHA and report worktree].
+
 Scouts read [roles/scout.md](roles/scout.md); source reviewers read
 [roles/humanizer.md](roles/humanizer.md). They assist the producer or take an
 explicitly scheduled stage. They do not independently edit the producer's worktree.

--- a/notes/agents/PIPELINE.md
+++ b/notes/agents/PIPELINE.md
@@ -47,9 +47,19 @@ owns the order and composition of work landing on main.
 
 The default task sequence is `producer -> verifier -> integrator`. A scout-only
 deliverable or a focused follow-up may use fewer stages if its scope says so.
-A source reviewer normally reports to the producer before handoff; if it edits,
-make that an explicitly owned stage and verify the resulting commit afterward.
+A source reviewer reports findings before handoff. Independent source acceptance
+is required at verification and before integration; it is recorded against the
+exact candidate and tested base, not inferred from a byte pass. The verifier may
+perform this review, or a separate humanizer may own an earlier verify stage.
+If a reviewer edits, make that an explicitly owned write stage and have another
+session review and verify the resulting commit afterward.
 Role names describe responsibilities, not preferred models.
+
+The [source-review upgrade](SOURCE-REVIEW-CUTOVER.md) adds executable enforcement
+and a required GitHub check. It preserves this v2 task protocol and receipt format;
+remote state schema 3 rejects old clients after explicit coordinator activation.
+Original task workflow/source pins remain historical facts. The separately recorded
+`source_review_policy.workflow_commit` identifies the active review tools.
 
 ## Before editing
 
@@ -129,6 +139,14 @@ Each handoff records these dimensions without combining them into one score:
 complete. Keep the next concrete improvement on the class issue. Original helper
 functions need not become methods merely to increase a count.
 
+Each source finding has a stable ID, location, kind and disposition. Correctness
+and provenance findings must be fixed. A reconstruction finding may retain a
+measured compiler constraint with pinned experiment artifacts, or be accepted as
+deferred work with an issue, owner and a `partial` completion assessment. Rework
+must carry every previous finding forward; it cannot make a blocker disappear by
+renaming its kind or omitting it. Continuations name `predecessor_tasks` so the queue
+preserves findings and contributing sessions across task boundaries.
+
 Required proof is defined by AGENTS.md, the task's change scope, and current gate
 tools. Source/header edits require exact affected-consumer and full-ROM checks;
 TU/lifecycle work also requires complete emitted-object and metadata evidence.
@@ -142,6 +160,15 @@ bookkeeping, publishes the final PR, and coordinates its landing. Small coherent
 batches may be useful; compatibility follows actual shared resources and dependencies.
 Use the current private validator and relevant static gates on the proposed composition.
 A previous green head/base is not proof for a changed composition.
+
+A different composition commit needs a separately published independent review
+of that commit and base. Use a verify-only review task that reserves its own
+report path, reads the source via `requires`, names the integrator as
+`input_session`, and inherits the original task with `predecessor_tasks`.
+The source reservation stays with its existing owner. The integrator records
+`composition_review_task`; an embedded report with an invented session label is
+not an independently published review. Refresh the GitHub check after review or
+rework and recheck live review state immediately before landing.
 
 A queue's completed stages do not themselves prove a merge. The integrator records
 the PR URL, tested candidate, tested base, and resulting main commit in its evidence.

--- a/notes/agents/SOURCE-REVIEW-CUTOVER.md
+++ b/notes/agents/SOURCE-REVIEW-CUTOVER.md
@@ -1,0 +1,140 @@
+# Require source review on the existing fleet
+
+This upgrades the in-progress fleet. It does not restart classes, rebase worker
+branches, erase earlier proof or replace the designated coordinator. The tooling
+PR for [#2449](https://github.com/tangosdev/sm64ds-decomp/issues/2449) installs the
+mechanism; the steps below activate it. Do not claim it is live merely because
+the files exist on a branch or have merged.
+
+## What the gate accepts
+
+The independent verifier publishes `source_review` using
+[the evidence template](templates/verification.json). It identifies the exact
+candidate, tested base, reviewer session, inspected file paths and concrete source
+judgment. Include changed/retired source paths, shared headers, enrollment/symbol/
+relocation configuration and TU manifests. The GitHub check requires coverage of
+every such path in the actual PR, including both paths of a rename.
+
+The review examines existing real interfaces, fake virtual tables, raw field
+accesses, integer pointers, manually spelled method symbols, lifecycle machinery,
+helper ownership, naming evidence, attribution and truthful completion claims.
+It is an accountable review, not a regex score or proof of original authorship.
+Byte and relocation validation remains independently required.
+
+Each finding has `id`, `location`, `summary`, `kind`, `disposition` and `reason`:
+
+| Disposition | Acceptance requirement |
+|---|---|
+| `fixed` | The reviewer inspected the correction in this candidate; changed source receives fresh byte proof. |
+| `compiler_constraint` | Reconstruction finding only; measured cleaner alternative under `2004/b56`, with pinned experiment source and a durable committed artifact. |
+| `deferred` | Reconstruction finding only; reviewer explicitly accepts partial scope, names the issue and next owner, and sets `completion: partial`. |
+| `open` | Cannot publish pass. Return the candidate through rework. |
+
+Correctness and provenance findings cannot be relabeled as reconstruction to
+defer them. Prior finding IDs must remain in later reviews with dispositions.
+A compiler constraint's `evidence` contains `tested_commit`, `compiler`,
+`attempted_change`, `command`, `result`, `log`, `artifact_commit`, `artifact_path`.
+The queue verifies that the experiment/artifact commits and artifact file exist
+and retains them in ancestry. Inspect those commits before publishing: referenced
+history is pushed, so it must contain no ROM, compiler, receipts or credentials.
+The reviewer still judges whether the experiment actually supports the claim.
+
+## Activate deliberately
+
+1. Merge the reviewed tooling PR. Keep the existing global coordinator. In this
+   fleet that is `fleet-0907`, whose installed checkout was
+   `C:/tmp/sm64ds-attr-rescue-0907`. Give that session the PR and this file.
+2. Inventory the live queue, workers and open PRs again. Obtain checkpoint and
+   upgrade acknowledgments. Running holders preserve their work and receipts,
+   then publish or release their own leases. No age-based takeover. Only this
+   brief protocol checkpoint requires draining running leases.
+3. Every session uses a checkout containing the new tools. Keep original task
+   workflow/source SHAs unchanged. Record the full reviewed tooling SHA separately
+   as the review-policy pin; preserve a checkout at that revision.
+4. The recorded fleet coordinator runs the following from that checkout, with
+   actual immutable SHAs from its inventory:
+
+   ```powershell
+   python tools/classqueue.py v2 enable-source-review --session fleet-0907 --workflow-commit FULL_REVIEWED_TOOLING_SHA --expected-state FULL_OBSERVED_QUEUE_SHA --request-id enable-source-review-0907 --legacy-clients-stopped-and-upgraded
+   ```
+
+   The command refuses a stale inventory, another coordinator or a running lease.
+   It changes remote state schema to 3. Private receipts remain schema 2; tasks,
+   reservations, original pins, outputs, rejected attempts and history survive.
+   Old clients reject state 3 instead of publishing an unreviewed pass. `next`
+   reports both the original workflow pin and the active review-policy pin.
+5. Dispatch `source-review.yml` from main and inspect its per-PR **Source review**
+   check runs. In the repository's main ruleset, add **Source review**, pinned to
+   the GitHub Actions app that produced that check, alongside the existing
+   app-pinned **PR validation** requirement. Preserve existing protections and
+   bypass settings. Require branches to be up to date before merging, so a check
+   for an old base cannot authorize a newer composition. Do not weaken byte
+   validation or set a blanket administrative bypass.
+6. Prove the deployed boundary: an unreviewed source PR must fail Source review;
+   a populated independently published review must pass for the exact head/base;
+   a changed head/base must lose that acceptance. Record the workflow run, ruleset
+   readback, queue SHA and review-policy SHA on the cutover issue.
+
+Ruleset activation is a repository setting, not a consequence of this source PR.
+Until it is configured, the check is advisory at GitHub even though upgraded
+queue transitions enforce review. Coordinators must still honor rejected reviews.
+
+## Adopt existing PRs and changed compositions
+
+An older byte-only pass remains valid historical byte evidence. It is not a
+source-review pass. Preserve it and arrange a fresh review of the actual PR head.
+For a completed task or a composed PR, use a separate verify-only review task:
+
+- `input_commit`: actual PR/composition head; `base_commit`: its preserved source base.
+- `input_session`: the session that produced the adopted/composed head.
+- `producer_sessions`: other known source contributors from earlier work.
+- `predecessor_tasks`: original task IDs, including the previous review task when
+  revising a composition. Enqueue inherits findings and contributing sessions.
+- `resources`: the new review's own report/handoff path. This is a read-only
+  review; the source owner's existing reservations stay intact.
+- Stage: role `humanizer` or `verifier`, mode `verify`, source/header inputs in
+  `requires`, and no source output in `produces`.
+
+Publish the same input SHA with the source-review evidence. A failure remains a
+failure: preserve it on the class issue and use the existing verify-only recovery
+or an owned producer continuation. The review task never edits the candidate.
+
+For a still-running integration task, set `composition_commit`, `composition_base`
+and `composition_review_task` in its final evidence. The referenced task must
+inherit the original task and have actually published an independent verify
+output for that composition/base. A nested JSON assertion naming a reviewer is
+insufficient. The composition must retain both source and base ancestry.
+
+The first concrete adoption case is [PR #2447](https://github.com/tangosdev/sm64ds-decomp/pull/2447),
+`daSanbo_c`, task `sanbo-ov096-0907b`: accepted source
+`58a735d6ffc733823fda12aaee1d9fec724a8721`, proposed PR head at review
+`fb3babaef848aa1e4fd038fd4705d2162f4295c7`. The old task recorded the composition
+under `composed_head`. That old pass has no source review and must not be
+reinterpreted as approval of the PR. Refresh its live head before assigning work.
+
+## Keep GitHub and the coordinator current
+
+The workflow executes default-branch tools and API metadata only. It never checks
+out or executes PR code. It refreshes on PR changes, main pushes, explicit dispatch
+and a five-minute schedule. After review, rejection, rework or cancellation, run:
+
+```powershell
+gh workflow run source-review.yml --repo tangosdev/sm64ds-decomp -f pr=2447
+python tools/check_pr_source_review.py --pr 2447
+```
+
+Use the actual PR number. The Python command is read-only unless `--publish` is
+explicitly supplied. Its current queue/head/base result is required immediately
+before landing. The GitHub check is a snapshot: queue updates can precede the
+scheduled/queued refresh, so a previously green check never overrides a current
+rejection. PR and queue identities are rechecked before publishing a verdict.
+Transport failure or incomplete file coverage cannot become a pass.
+
+## Review the existing classes
+
+Inventory all promoted manifests against a pinned main SHA and reuse class
+issues, PRs, facts and handoffs. Mark missing review evidence as pending; a grep
+inventory only supplies leads. Review a whole class/TU, record the reviewed SHA
+and concrete findings on its issue, and route narrow proven fixes through PRs.
+Keep build/promotion counts in the C++ TU reports separate from source acceptance.
+An accepted partial review leaves its named follow-up work open.

--- a/notes/agents/handoffs/issue-2449-source-review-gate.md
+++ b/notes/agents/handoffs/issue-2449-source-review-gate.md
@@ -21,8 +21,12 @@ activation upgrades remote state to 3 while retaining receipt format 2 and all
 existing task history. Trusted default-branch GitHub tooling publishes Source review
 for the actual PR head/base and complete relevant changed-path set.
 
-Local validation at this checkpoint: 37 queue tests pass against disposable local
-bare remotes; 15 source-review/API fixture tests pass. These include stale and
+At `f40639d3`, independent validation passed 37 queue tests against disposable local
+bare remotes and 15 source-review/API fixture tests. The successor fixes the
+reviewer's queue-size finding by requesting raw contents at the pinned queue commit;
+16 source-review/API fixture tests pass, including a queue larger than 1 MiB.
+The queue implementation and its tests are unchanged from `f40639d3`.
+These tests include stale and
 missing review, self-review, retained findings, fake composition-review assertions,
 changed queue snapshots, read-only adoption and preserving existing receipts.
 Independent verification and publication are recorded by the queue successor.

--- a/notes/agents/handoffs/issue-2449-source-review-gate.md
+++ b/notes/agents/handoffs/issue-2449-source-review-gate.md
@@ -1,0 +1,35 @@
+# Source-review enforcement handoff
+
+Issue: [#2449](https://github.com/tangosdev/sm64ds-decomp/issues/2449).
+Producer: `codex-source-review-gate-producer-20260907`.
+Task: `issue-2449-source-review-gate`.
+Branch: `refs/heads/tools/source-review-gate-0907`.
+Worktree: `C:/tmp/sm64ds-source-review-gate-0907`.
+Source base: `788643caffdfa041eb625c868a8f200542c0bd61`.
+Task workflow pin: `f327f7b6460e157153eb7fc0749dbbe60dd854f1`.
+The queue publication supplies the immutable final candidate SHA.
+
+This continues the existing fleet, with `fleet-0907` retaining global coordination.
+The separate humanizer repair candidate `848da2bb` and its reservations are retained.
+No source/header changes, queue activation, ruleset changes or merges are part of
+this tooling publication.
+
+The queue validates source review on source-affecting verification and integration,
+preserves findings/authors through rework and explicit predecessors, and requires
+a separately published independent review of a changed composition. Explicit
+activation upgrades remote state to 3 while retaining receipt format 2 and all
+existing task history. Trusted default-branch GitHub tooling publishes Source review
+for the actual PR head/base and complete relevant changed-path set.
+
+Local validation at this checkpoint: 37 queue tests pass against disposable local
+bare remotes; 15 source-review/API fixture tests pass. These include stale and
+missing review, self-review, retained findings, fake composition-review assertions,
+changed queue snapshots, read-only adoption and preserving existing receipts.
+Independent verification and publication are recorded by the queue successor.
+
+Next action: independently inspect the frozen candidate, rerun the queue and review
+tests, inspect the trusted workflow, then publish the tooling PR. After it merges,
+the existing coordinator follows [SOURCE-REVIEW-CUTOVER.md](../SOURCE-REVIEW-CUTOVER.md).
+Only that explicit activation plus the required app-pinned GitHub check establishes
+the live merge boundary. The scheduled check can lag a queue update; integrations
+must also run the current read-only check immediately before landing.

--- a/notes/agents/queue-v2.md
+++ b/notes/agents/queue-v2.md
@@ -8,6 +8,11 @@ GitHub issues can supply the human task identity (`issue-2400`) and discussion;
 the queue records exact ownership, resources, input commits and handoffs. No
 realtime messaging service is needed: agents poll `next` and `list` between tasks.
 
+The [source-review upgrade](SOURCE-REVIEW-CUTOVER.md) adds state schema 3 while
+keeping v2 commands and receipt schema 2. It is explicitly activated by the fleet
+coordinator after checkpointing/upgrading clients. Original task workflow pins,
+leases, outputs and history are preserved; old clients reject the upgraded state.
+
 ## Cutover boundary
 
 **Do not run v1 and v2 agents concurrently.** Before initialization, stop or upgrade
@@ -204,6 +209,35 @@ That object must include `"verdict": "pass"` and `"tested_commit": "FULL_INPUT_S
 It can also hold gate commands, tested source/base SHAs and
 links to reports. Evidence is retained in state; the queue does not certify its
 truth or replace the independent private validator.
+
+After source-review activation, source-affecting verify stages additionally
+require the populated `source_review` from the verification template, an exact
+`tested_base`, `reviewer_session` equal to the lease holder, and `workflow_commit`
+equal to the active review-policy pin. Every source write must lead to independent
+verification. Integrator claims reject an older byte-only predecessor pass.
+
+For continuations, `predecessor_tasks` lists existing task IDs. Enqueue retains
+their findings and contributing sessions as immutable inherited context. Optional
+`producer_sessions` supplies additional known authors of adopted source; do not
+omit an earlier writer merely because a different session last touched the branch.
+No contributing writer may verify their own work after another writer intervenes.
+
+An integrator records `composition_commit`, `composition_base`, and
+`composition_review_task` for a changed composition. That task must inherit the
+original task and publish its own independent verify output for the composition.
+It reserves its report artifact, with source files declared as read-only
+`requires`; it does not acquire the existing source reservation. The composition
+must preserve the accepted source and declared base as ancestors.
+
+Refresh the external check after a review decision:
+
+```powershell
+gh workflow run source-review.yml --repo tangosdev/sm64ds-decomp -f pr=2447
+python tools/check_pr_source_review.py --pr 2447
+```
+
+Use the actual PR number. The second command reads current state and exits
+nonzero on missing/stale review; it does not publish or merge anything.
 
 ### Failed verification and additional dependencies
 

--- a/notes/agents/roles/coordinator.md
+++ b/notes/agents/roles/coordinator.md
@@ -31,6 +31,18 @@ the producer finishes. Source reviewers normally assist before the producer hand
 off. Additional domain coordinators help only when their ownership and escalation
 boundary are explicit.
 
+Make source review an acceptance decision before integration. Schedule an
+independent reviewer, retain its findings through rework/continuations, and check
+the recorded candidate/base against the PR that will land. Follow
+[SOURCE-REVIEW-CUTOVER.md](../SOURCE-REVIEW-CUTOVER.md) for explicit client and
+GitHub-check activation; installing the tooling alone is not activation.
+
+Inventory existing promoted classes for retrospective source review. Reuse their
+issues, PRs, facts and accepted work. Mark missing review evidence as pending;
+do not infer readability from a promoted manifest, passing byte gate or grep
+count. Record the reviewed SHA and findings on the class issue, and link repair
+PRs without closing the remaining reconstruction scope prematurely.
+
 ## At each checkpoint
 
 - Reconcile claims with actual sessions and published handoffs.

--- a/notes/agents/roles/humanizer.md
+++ b/notes/agents/roles/humanizer.md
@@ -5,6 +5,11 @@ whether the source plausibly reads like period-accurate EAD C++, while respectin
 ROM evidence and the pinned compiler. Normally report to the producer before
 independent verification; do not run a competing edit loop.
 
+Source acceptance is a required decision. Review the complete candidate, including
+inherited scaffolding that the PR retains. Existing byte matches and TU promotion
+do not exempt fake interfaces, raw fields or mangled calls from this review.
+Use the existing real declarations before proposing another view of the object.
+
 Look for meaningful methods and fields, coherent class/TU ownership, compiler-
 generated lifecycle machinery, credible helper boundaries, and clear naming
 provenance. Flag remaining shadow structs, raw offsets, invented original names,
@@ -18,6 +23,18 @@ If assigned to edit, obtain an explicit owned stage in a separate worktree.
 Hand the changed commit back for fresh proof and independent verification.
 Keep unresolved opportunities on the class issue instead of calling promotion
 the end of reconstruction.
+
+For a formal pass, own an independent verify stage and publish the structured
+`source_review` in [the evidence template](../templates/verification.json).
+Record the exact reviewed commit/base, literal files inspected, completion scope
+and every finding's disposition. A passing report is an accountable judgment,
+not a count of removed casts. Use rework for unresolved correctness/provenance
+findings and for reconstruction findings whose deferral has not been accepted.
+The reviewer must not be any contributing writer, including earlier attempts.
+
+For existing classes, track review pending until an actual review has been
+recorded. Reuse the class issue and facts; cite the reviewed SHA and related PRs.
+Build/promotion reports remain a separate dimension from source acceptance.
 
 [Historical source-review measurements](../references/humanizer-v1.md) are a
 retrieval reference, not active naming rules or permission to change shared types.

--- a/notes/agents/roles/integrator.md
+++ b/notes/agents/roles/integrator.md
@@ -8,6 +8,10 @@ Accept only an explicitly offered task with independent source verification.
 Record the candidate SHA and current main base before composing anything. Use
 your own wired integration worktree; preserve worker branches and attribution.
 
+Source acceptance is mandatory before claiming integration. Inspect the actual
+review, its remaining work and compiler experiments. A byte-only predecessor pass
+from an older task cannot satisfy this requirement.
+
 ## Compose deliberately
 
 Group only compatible, coherent changes. Shared headers, global attribution,
@@ -20,10 +24,23 @@ If composition changes source, headers, or the tested base, obtain proof of that
 new composition, including independent verification when the source changes.
 The previous candidate's green check does not transfer to a different commit.
 
+For a changed composition, arrange a separate verify-only review task with its
+own report reservation, this composition as `input_commit`, your session as
+`input_session`, and the original task in `predecessor_tasks`. Read-only source
+paths belong in `requires`; do not contend for the producer's source reservation.
+Record its task ID as `composition_review_task`. The queue checks the reviewer's
+actual published output, exact composition/base, authorship and source coverage.
+
 Run the applicable full-ROM, relocation, metadata, affected-consumer, port and
 static gates. Publish the coherent result and monitor the required private check
 to terminal success. Pending, queued, report-only and masked-byte results are not
 completion. Follow repository merge rules and the human's publication authority.
+
+After source review, rework or cancellation, dispatch `source-review.yml` for the
+affected PR. Immediately before landing, run
+`python tools/check_pr_source_review.py --pr NUMBER` from the active review tools
+and require success alongside terminal private byte validation. A failed live
+read is a blocker even if a previously posted GitHub check remains green.
 
 ## Record the outcome
 

--- a/notes/agents/roles/producer.md
+++ b/notes/agents/roles/producer.md
@@ -15,6 +15,12 @@ original filenames. Ask scouts for specific missing evidence. Ask the source
 reviewer to examine the candidate before final proof. Do not share an editing
 worktree or let a helper silently expand your reservation.
 
+Resolve source-review findings before offering a finished candidate. A retained
+bridge needs the cleaner alternative tested under the pinned compiler, with the
+result and durable experiment artifact recorded. Accepted deferred reconstruction
+belongs on the class issue with its next owner. Keep the PR's completion claims
+consistent with that remaining work.
+
 The target is plausible 2004 C++ with exact emitted bytes and destinations:
 real methods and fields where evidenced, compiler-generated lifecycle machinery
 where it matches, and narrow documented ABI bridges at measured compiler walls.

--- a/notes/agents/roles/verifier.md
+++ b/notes/agents/roles/verifier.md
@@ -13,6 +13,12 @@ unclaimed shared-header changes, raw-offset leftovers, unsupported identity/layo
 claims, ABI bridges without a measured reason, and attribution lost in renames.
 A count of promoted TUs is not a count of reconstructed classes.
 
+Publish a structured source judgment for this exact candidate and tested base.
+Carry forward prior findings and verify their dispositions; a generic pass or a
+reference to the producer's review is insufficient. The active review-policy pin
+is separate from an older task's historical workflow pin. See
+[review enforcement and adoption](../SOURCE-REVIEW-CUTOVER.md).
+
 Run the relevant checks described in repository AGENTS.md and the promotion
 conventions. Typical proof includes:
 

--- a/notes/agents/templates/verification.json
+++ b/notes/agents/templates/verification.json
@@ -15,15 +15,21 @@
     }
   ],
   "source_review": {
+    "schema": 1,
     "result": "not_run",
-    "remaining_work": [],
-    "attribution": "not_reviewed"
+    "reviewed_commit": "REPLACE_WITH_EXACT_ACCEPTED_INPUT_SHA",
+    "reviewed_base": "REPLACE_WITH_ACTUAL_TESTED_BASE_SHA",
+    "reviewer_session": "REPLACE_WITH_INDEPENDENT_SESSION",
+    "summary": "REPLACE_WITH_ACTUAL_SOURCE_JUDGMENT_INCLUDING_ATTRIBUTION",
+    "completion": "partial",
+    "files": ["REPLACE_WITH_EVERY_REVIEWED_SOURCE_HEADER_AND_CONFIG_PATH"],
+    "findings": []
   },
   "pr_url": null,
   "composition_commit": null,
   "composition_base": null,
   "composition_checks": [],
-  "composition_independent_verification": null,
+  "composition_review_task": null,
   "merged_main_sha": null,
   "next_action": "Replace placeholders and run required proof; this template is not pass evidence."
 }

--- a/tools/check_pr_source_review.py
+++ b/tools/check_pr_source_review.py
@@ -1,0 +1,132 @@
+"""Publish Source review from trusted queue data; never check out or run PR code.
+
+Read-only by default. --publish creates a GitHub Actions check when run by the
+trusted workflow. Repository rules must separately require that app-owned check.
+"""
+import argparse
+import base64
+import json
+import re
+import subprocess
+import sys
+
+import source_review as sr
+
+
+def evaluate(state, head, base, files):
+    required = {p.casefold() for p in files if sr.source_path(p)}
+    if not required:
+        return {"result": "pass", "summary": "No reconstruction source, header or TU manifest changed."}
+    if state.get("schema") != 3 or not state.get("source_review_policy"):
+        return {"result": "fail", "summary": "Source review has not been activated for the fleet."}
+    covered, accepted, errors = set(), [], []
+    policy = state["source_review_policy"]["workflow_commit"]
+    for task in state.get("tasks", {}).values():
+        if task.get("phase") == "cancelled":
+            continue
+        stages = {s["id"]: s for s in task.get("stages", [])}
+        for output in task.get("outputs", []):
+            if stages.get(output.get("stage_id"), {}).get("mode") != "verify":
+                continue
+            evidence = output.get("evidence", {})
+            reviewer = output.get("session")
+            # A composed PR needs its own independently published verify output.
+            # An integrator's nested assertion cannot impersonate that reviewer.
+            if output.get("commit") != head:
+                continue
+            try:
+                review = sr.validate_evidence(task, evidence, head, reviewer)
+                sr.require(evidence.get("tested_base") == base, "PR base changed since source review")
+                sr.require(evidence.get("workflow_commit") == policy, "review uses an older policy")
+                covered.update(p.casefold() for p in review["files"])
+                accepted.append(task["task_id"])
+            except (sr.ReviewError, KeyError, TypeError) as exc:
+                errors.append(task.get("task_id", "unknown task") + ": " + str(exc))
+    missing = sorted(required - covered)
+    if missing:
+        return {"result": "fail", "summary": "Independent source review is missing or invalid.",
+                "missing_files": missing, "errors": errors, "accepted_tasks": sorted(set(accepted))}
+    return {"result": "pass", "summary": "Independent source review covers this PR head and base.",
+            "accepted_tasks": sorted(set(accepted))}
+
+
+def api(path, payload=None, paginate=False):
+    args = ["gh", "api", path]
+    if paginate:
+        args += ["--paginate", "--slurp"]
+    if payload is not None:
+        args += ["--method", "POST", "--input", "-"]
+    result = subprocess.run(args, input=json.dumps(payload) if payload is not None else None,
+                            capture_output=True, text=True, encoding="utf-8")
+    if result.returncode:
+        raise RuntimeError("GitHub API request failed: " + result.stderr.strip())
+    return json.loads(result.stdout)
+
+
+def queue_state(repo):
+    ref = api(f"repos/{repo}/git/ref/heads/agents/coordination")
+    sha = ref["object"]["sha"]
+    contents = api(f"repos/{repo}/contents/state.json?ref={sha}")
+    if contents.get("encoding") != "base64":
+        raise RuntimeError("queue state was not returned as base64 content")
+    return sha, json.loads(base64.b64decode(contents["content"]))
+
+
+def check_pr(repo, number, publish=False):
+    pr = api(f"repos/{repo}/pulls/{number}")
+    if pr["state"] != "open":
+        return {"pr": number, "result": "closed"}
+    head, base = pr["head"]["sha"], pr["base"]["sha"]
+    state_sha = None
+    try:
+        pages = api(f"repos/{repo}/pulls/{number}/files?per_page=100", paginate=True)
+        files = [f for page in pages for f in page]
+        sr.require(len(files) == pr["changed_files"], "incomplete PR file list; review coverage unknown")
+        paths = [f["filename"] for f in files]
+        paths += [f["previous_filename"] for f in files if f.get("previous_filename")]
+        if any(sr.source_path(p) for p in paths):
+            state_sha, state = queue_state(repo)
+        else:
+            state = {}
+        report = evaluate(state, head, base, paths)
+    except (RuntimeError, sr.ReviewError, ValueError, KeyError, TypeError) as exc:
+        report = {"result": "fail", "summary": "Source review could not be established: " + str(exc)}
+    report.update(pr=number, head=head, base=base, queue_commit=state_sha)
+    if publish:
+        current = api(f"repos/{repo}/pulls/{number}")
+        if (current["head"]["sha"], current["base"]["sha"], current["state"]) != (head, base, "open"):
+            raise RuntimeError("PR changed while checking; rerun before publishing a verdict")
+        if state_sha is not None:
+            current_queue = api(f"repos/{repo}/git/ref/heads/agents/coordination")["object"]["sha"]
+            if current_queue != state_sha:
+                report.update(result="fail", summary="Queue changed during review; refresh the check.")
+        api(f"repos/{repo}/check-runs", {
+            "name": "Source review", "head_sha": head, "status": "completed",
+            "conclusion": "success" if report["result"] == "pass" else "failure",
+            "external_id": f"source-review:{number}:{head}:{base}:{state_sha}",
+            "output": {"title": report["summary"][:250],
+                       "summary": "```json\n" + json.dumps(report, indent=2)[:60000] + "\n```"}})
+    return report
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="tangosdev/sm64ds-decomp")
+    parser.add_argument("--pr", type=int)
+    parser.add_argument("--publish", action="store_true")
+    args = parser.parse_args(argv)
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", args.repo):
+        parser.error("--repo must be owner/repository")
+    try:
+        numbers = [args.pr] if args.pr else [pr["number"] for page in api(
+            f"repos/{args.repo}/pulls?state=open&per_page=100", paginate=True) for pr in page]
+        reports = [check_pr(args.repo, n, args.publish) for n in numbers]
+        print(json.dumps(reports, indent=2))
+        return int(any(r["result"] == "fail" for r in reports))
+    except (RuntimeError, ValueError, KeyError, TypeError) as exc:
+        print("Source review unavailable: " + str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_pr_source_review.py
+++ b/tools/check_pr_source_review.py
@@ -4,7 +4,6 @@ Read-only by default. --publish creates a GitHub Actions check when run by the
 trusted workflow. Repository rules must separately require that app-owned check.
 """
 import argparse
-import base64
 import json
 import re
 import subprocess
@@ -50,8 +49,10 @@ def evaluate(state, head, base, files):
             "accepted_tasks": sorted(set(accepted))}
 
 
-def api(path, payload=None, paginate=False):
+def api(path, payload=None, paginate=False, raw=False):
     args = ["gh", "api", path]
+    if raw:
+        args += ["-H", "Accept: application/vnd.github.raw+json"]
     if paginate:
         args += ["--paginate", "--slurp"]
     if payload is not None:
@@ -66,10 +67,9 @@ def api(path, payload=None, paginate=False):
 def queue_state(repo):
     ref = api(f"repos/{repo}/git/ref/heads/agents/coordination")
     sha = ref["object"]["sha"]
-    contents = api(f"repos/{repo}/contents/state.json?ref={sha}")
-    if contents.get("encoding") != "base64":
-        raise RuntimeError("queue state was not returned as base64 content")
-    return sha, json.loads(base64.b64decode(contents["content"]))
+    # The default Contents response omits inline content above 1 MiB.
+    contents = api(f"repos/{repo}/contents/state.json?ref={sha}", raw=True)
+    return sha, contents
 
 
 def check_pr(repo, number, publish=False):

--- a/tools/classqueue_v2.py
+++ b/tools/classqueue_v2.py
@@ -17,8 +17,11 @@ import subprocess
 import sys
 import uuid
 
+import source_review
+
 REF = "refs/heads/agents/coordination"
 SCHEMA = 2
+REVIEW_STATE_SCHEMA = 3  # Receipt schema stays at 2, including existing credentials.
 
 
 class QueueError(Exception):
@@ -169,7 +172,7 @@ class Queue:
             state = json.loads(self.git("show", f"{sha}:state.json").stdout)
         except (ValueError, TypeError) as exc:
             raise QueueError("invalid remote queue JSON") from exc
-        require(isinstance(state, dict) and state.get("schema") == SCHEMA and
+        require(isinstance(state, dict) and state.get("schema") in (SCHEMA, REVIEW_STATE_SCHEMA) and
                 state.get("cutover") == "legacy-clients-stopped-and-upgraded" and
                 isinstance(state.get("tasks"), dict) and
                 isinstance(state.get("operations"), dict), "invalid remote queue schema")
@@ -204,7 +207,7 @@ class Queue:
                  "tasks": {}, "operations": {}}
         return {"initialized": True, "state_commit": self.save(None, state)}
 
-    def transaction(self, request_id, payload, operation):
+    def transaction(self, request_id, payload, operation, expected_state=None):
         identifier(request_id)
         sha, state = self.read()
         fingerprint = hashlib.sha256(encoded(payload).encode()).hexdigest()
@@ -213,10 +216,54 @@ class Queue:
             require(old["fingerprint"] == fingerprint,
                     "request ID was already used for a different operation")
             return copy.deepcopy(old["result"])
+        require(expected_state is None or sha == expected_state,
+                "queue changed; inspect the current fleet before activation")
         result, parents = operation(state)
         state["operations"][request_id] = {"fingerprint": fingerprint, "result": result}
         self.save(sha, state, parents)
         return result
+
+    def enable_source_review(self, session, workflow_commit, expected_state, request_id):
+        """Deliberate fleet upgrade; old clients reject state 3, receipts survive."""
+        self.commit(workflow_commit)
+        self.paths(workflow_commit, ["tools/source_review.py", "tools/check_pr_source_review.py"])
+
+        def operation(state):
+            require(session == state["initialized_by"], "only the recorded fleet coordinator activates review")
+            require(state["schema"] == SCHEMA, "source review is already enabled")
+            require(not any(t["phase"] == "running" for t in state["tasks"].values()),
+                    "holders must checkpoint and release running leases before upgrading clients")
+            state["schema"] = REVIEW_STATE_SCHEMA
+            state["source_review_policy"] = {"workflow_commit": workflow_commit,
+                                             "activated_by": session, "at": now()}
+            return {"source_review_enabled": True, "workflow_commit": workflow_commit}, [workflow_commit]
+        return self.transaction(request_id, {"enable_source_review": session,
+                                "workflow_commit": workflow_commit, "expected_state": expected_state},
+                                operation, expected_state=expected_state)
+
+    @staticmethod
+    def needs_source_review(state, task):
+        return state["schema"] == REVIEW_STATE_SCHEMA and source_review.source_task(task)
+
+    @staticmethod
+    def check_source_review(state, task, evidence, head, reviewer):
+        try:
+            source_review.validate_evidence(task, evidence, head, reviewer)
+            source_review.require(evidence["workflow_commit"] ==
+                                  state["source_review_policy"]["workflow_commit"],
+                                  "source review must use the activated review workflow")
+        except source_review.ReviewError as exc:
+            raise QueueError(str(exc)) from exc
+
+    def review_artifacts(self, evidence):
+        retained = []
+        for finding in evidence["source_review"]["findings"]:
+            if finding["disposition"] == "compiler_constraint":
+                proof = finding["evidence"]
+                self.commit(proof["tested_commit"])
+                self.paths(proof["artifact_commit"], [proof["artifact_path"]])
+                retained.extend((proof["tested_commit"], proof["artifact_commit"]))
+        return retained
 
     def enqueue(self, spec, request_id, coordinator_receipt):
         spec = copy.deepcopy(spec)
@@ -258,8 +305,25 @@ class Queue:
                     artifact_path(path)
         if stages[0]["mode"] == "verify":
             identifier(spec.get("input_session"))
+        require(isinstance(spec.get("producer_sessions", []), list), "producer_sessions must be a list")
+        for session in spec.get("producer_sessions", []):
+            identifier(session)
+        require(isinstance(spec.get("predecessor_tasks", []), list), "predecessor_tasks must be a list")
 
         def operation(state):
+            inherited = {}
+            contributing = set(spec.get("producer_sessions", []))
+            for predecessor_id in spec.get("predecessor_tasks", []):
+                predecessor = self.task(state, identifier(predecessor_id))
+                inherited.update(source_review.previous_findings(predecessor))
+                contributing.update(source_review.producers(predecessor))
+            spec["inherited_findings"] = inherited
+            spec["producer_sessions"] = sorted(contributing)
+            if self.needs_source_review(state, spec):
+                try:
+                    source_review.review_graph(spec)
+                except source_review.ReviewError as exc:
+                    raise QueueError(str(exc)) from exc
             require(task_id not in state["tasks"], "task ID already exists; use a new follow-up ID")
             for other in state["tasks"].values():
                 if other["phase"] not in ("done", "cancelled") and overlaps(spec["resources"], other["resources"]):
@@ -315,6 +379,7 @@ class Queue:
                 found.append({"task_id": task["task_id"], "stage": task["stages"][index],
                               "input_commit": sha, "base_commit": task["base_commit"],
                               "workflow_commit": task["workflow_commit"],
+                              "source_review_policy": state.get("source_review_policy"),
                               "evidence_inputs": task["evidence_inputs"],
                               "resources": task["resources"], "next_action": task["next_action"]})
         return found
@@ -335,9 +400,16 @@ class Queue:
                     "requested role/stage is not the next stage")
             require(actual_input == input_commit, "input changed; inspect next before claiming")
             if stage["mode"] == "verify":
-                producer = self.producer_session(task, index)
-                require(producer != owner["session"],
+                require(owner["session"] not in source_review.producers(task),
                         "verification requires a different session from the source producer")
+            if self.needs_source_review(state, task) and role == "integrator":
+                require(stage["mode"] == "verify" and index > 0,
+                        "integration requires a preceding independent source verification")
+                predecessor = task["outputs"][index - 1]
+                require(task["stages"][index - 1]["mode"] == "verify",
+                        "integration requires a preceding independent source verification")
+                self.check_source_review(state, task, predecessor["evidence"], actual_input,
+                                         predecessor["session"])
             if task["phase"] == "offered":
                 task["outputs"][-1]["accepted_by"] = owner["session"]
                 task["outputs"][-1]["accepted_at"] = now()
@@ -465,12 +537,47 @@ class Queue:
             index = task["stage_index"]
             stage = task["stages"][index]
             input_commit = self.input_for(task, index)
+            retained = []
             if stage["mode"] == "verify":
                 require(output_commit == input_commit, "verify stages cannot change the input commit")
                 require(evidence.get("verdict") == "pass" and
                         evidence.get("tested_commit") == input_commit,
                         "verify stages must record evidence.verdict=pass and the exact tested_commit")
+                if self.needs_source_review(state, task):
+                    self.check_source_review(state, task, evidence, input_commit, owner["session"])
+                    retained.extend(self.review_artifacts(evidence))
+                    self.commit(evidence["tested_base"])
+                    if evidence.get("composition_commit"):
+                        composition = self.commit(evidence["composition_commit"])
+                        composition_base = self.commit(evidence.get("composition_base"))
+                        for ancestor in (input_commit, composition_base):
+                            require(self.git("merge-base", "--is-ancestor", ancestor, composition,
+                                             check=False).returncode == 0,
+                                    "composition must retain accepted source and declared base ancestry")
+                        review_task = self.task(state, identifier(evidence.get("composition_review_task")))
+                        require(task["task_id"] in review_task.get("predecessor_tasks", []),
+                                "composition review must inherit the original task's findings and authors")
+                        require(review_task["phase"] != "cancelled", "composition review task was cancelled")
+                        accepted = False
+                        for record in review_task["outputs"]:
+                            review_stage = next(s for s in review_task["stages"] if s["id"] == record["stage_id"])
+                            if review_stage["mode"] != "verify" or record["commit"] != composition:
+                                continue
+                            reviewer = record["session"]
+                            if reviewer in source_review.producers(task) | {owner["session"]}:
+                                continue
+                            self.check_source_review(state, review_task, record["evidence"], composition, reviewer)
+                            if record["evidence"]["tested_base"] != composition_base:
+                                continue
+                            reviewed = {p.casefold() for p in record["evidence"]["source_review"]["files"]}
+                            if not set(source_review.task_files(task)) <= reviewed:
+                                continue
+                            accepted = True
+                        require(accepted, "composition needs an independently published exact review task")
             else:
+                require(not self.needs_source_review(state, task) or
+                        (stage["role"] != "integrator" and index + 1 < len(task["stages"])),
+                        "source output requires independent review before integration/completion")
                 result = self.git("merge-base", "--is-ancestor", input_commit, output_commit,
                                   check=False)
                 require(result.returncode == 0, "output does not descend from the accepted input")
@@ -489,7 +596,7 @@ class Queue:
             if last:
                 task["owner"] = None
             return {"task_id": task["task_id"], "phase": task["phase"],
-                    "stage_id": stage["id"], "output_commit": output_commit}, [output_commit]
+                    "stage_id": stage["id"], "output_commit": output_commit}, [output_commit, *retained]
         return self.transaction(request_id, {"publish": receipt["task_id"], "owner": owner,
                                             "output": output_commit, "evidence": evidence,
                                             "next_action": next_action}, operation)
@@ -529,6 +636,10 @@ def main(argv=None, repo=None):
     init = sub.add_parser("init", help="initialize AFTER the documented fleet cutover")
     init.add_argument("--session", required=True)
     init.add_argument("--legacy-clients-stopped-and-upgraded", action="store_true", required=True)
+    upgrade = sub.add_parser("enable-source-review", help="activate after checkpointing and upgrading clients")
+    for arg in ("session", "workflow-commit", "expected-state", "request-id"):
+        upgrade.add_argument("--" + arg, required=True)
+    upgrade.add_argument("--legacy-clients-stopped-and-upgraded", action="store_true", required=True)
     enqueue = sub.add_parser("enqueue", help="reserve resources for an explicit task")
     enqueue.add_argument("spec", help="JSON task specification")
     enqueue.add_argument("--request-id", required=True)
@@ -562,6 +673,9 @@ def main(argv=None, repo=None):
     try:
         if args.command == "init":
             result = queue.init(args.session)
+        elif args.command == "enable-source-review":
+            result = queue.enable_source_review(args.session, args.workflow_commit,
+                                                args.expected_state, args.request_id)
         elif args.command == "enqueue":
             spec = read_json(args.spec)
             receipt = receipt_file(args.receipt, spec["task_id"], spec["coordinator"])

--- a/tools/source_review.py
+++ b/tools/source_review.py
@@ -1,0 +1,164 @@
+"""Validate recorded source judgments; this does not judge C++ or prove ROM bytes.
+
+Queue publishers are accountable for the assertions. A passing byte check or an
+old review is never substituted for a review of the proposed source and base.
+"""
+import re
+
+
+class ReviewError(ValueError):
+    pass
+
+
+def require(condition, message):
+    if not condition:
+        raise ReviewError(message)
+
+
+def text(value, label):
+    require(isinstance(value, str) and value.strip() and
+            not re.search(r"REPLACE_WITH|FULL_.*SHA|not_run|not_reviewed", value),
+            label + " must contain a measured result or concrete explanation")
+    return value
+
+
+def commit(value, label):
+    require(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", value),
+            label + " must be a full immutable commit ID")
+    return value
+
+
+def source_path(path):
+    return isinstance(path, str) and path.casefold().startswith(
+        ("src/", "include/", "src_tu/", "mods/", "config/tu_manifest.d/",
+         "config/arm9/", "config/arm7/", "config/itcm/", "config/dtcm/"))
+
+
+def task_files(task):
+    return sorted({r.split(":", 1)[1] for r in task.get("resources", [])
+                   if r.startswith(("file:", "tu:")) and source_path(r.split(":", 1)[1])})
+
+
+def source_task(task):
+    return bool(task_files(task) or any(r.startswith(("class:", "range:"))
+                                      for r in task.get("resources", [])) or
+                any(source_path(p) for s in task.get("stages", [])
+                    for p in s.get("requires", []) + s.get("produces", [])))
+
+
+def producers(task):
+    """Include earlier writers and rejected attempts, not just the latest writer."""
+    sessions = set(task.get("producer_sessions", []))
+    if task.get("input_session"):
+        sessions.add(task["input_session"])
+    write_stages = {s["id"] for s in task.get("stages", []) if s["mode"] == "write"}
+    outputs = list(task.get("outputs", []))
+    for attempt in task.get("attempts", []):
+        outputs.extend(attempt.get("outputs", []))
+    sessions.update(o["session"] for o in outputs if o.get("stage_id") in write_stages)
+    return sessions
+
+
+def previous_findings(task):
+    findings = dict(task.get("inherited_findings", {}))
+    evidence = [o.get("evidence", {}) for o in task.get("outputs", [])]
+    for attempt in task.get("attempts", []):
+        evidence.append(attempt.get("evidence", {}))
+        evidence.extend(o.get("evidence", {}) for o in attempt.get("outputs", []))
+    for item in evidence:
+        review = item.get("source_review") if isinstance(item, dict) else None
+        if not isinstance(review, dict) or not isinstance(review.get("findings"), list):
+            continue
+        for finding in review["findings"]:
+            if isinstance(finding, dict) and finding.get("id"):
+                findings[finding["id"]] = finding
+    return findings
+
+
+def validate(review, head, base, reviewer, authors=(), required_files=(), prior=()):
+    require(isinstance(review, dict), "source_review is required")
+    require(review.get("schema") == 1, "source_review.schema must be 1")
+    require(review.get("result") == "pass", "source review has not passed")
+    require(commit(review.get("reviewed_commit"), "reviewed_commit") == head,
+            "source review is for a different candidate")
+    require(commit(review.get("reviewed_base"), "reviewed_base") == base,
+            "source review is for a different base")
+    require(text(review.get("reviewer_session"), "reviewer_session") == reviewer,
+            "source reviewer must be the publishing verifier")
+    require(reviewer not in authors, "source review requires an independent reviewer")
+    text(review.get("summary"), "source review summary")
+    require(review.get("completion") in ("complete", "partial"),
+            "source review must distinguish complete from partial reconstruction")
+    files = review.get("files")
+    require(isinstance(files, list) and files and all(isinstance(p, str) and p and
+            not p.startswith("/") and "\\" not in p and ":" not in p and
+            all(x not in ("", ".", "..") for x in p.split("/")) for p in files),
+            "source review needs literal reviewed file paths")
+    require({p.casefold() for p in required_files} <= {p.casefold() for p in files},
+            "source review does not cover every source/header in scope")
+    findings = review.get("findings")
+    require(isinstance(findings, list), "source review findings must be a list")
+    ids = set()
+    for finding in findings:
+        require(isinstance(finding, dict), "invalid source finding")
+        fid = text(finding.get("id"), "finding id")
+        require(fid not in ids, "duplicate source finding id")
+        ids.add(fid)
+        text(finding.get("location"), "finding location")
+        text(finding.get("summary"), "finding summary")
+        text(finding.get("reason"), "finding disposition reason")
+        kind = finding.get("kind")
+        require(kind in ("correctness", "provenance", "reconstruction"), "invalid finding kind")
+        if isinstance(prior, dict) and prior.get(fid, {}).get("kind") in ("correctness", "provenance"):
+            require(kind == prior[fid]["kind"], "previous correctness/provenance finding was reclassified")
+        disposition = finding.get("disposition")
+        require(disposition in ("fixed", "compiler_constraint", "deferred"),
+                "unresolved source finding: " + fid)
+        if disposition == "compiler_constraint":
+            require(kind == "reconstruction", "a compiler constraint cannot excuse incorrect claims")
+            proof = finding.get("evidence")
+            require(isinstance(proof, dict), "compiler constraint requires measured evidence")
+            commit(proof.get("tested_commit"), "constraint tested_commit")
+            for key in ("command", "result", "log"):
+                text(proof.get(key), "constraint " + key)
+            require(proof.get("compiler") == "2004/b56", "constraint must identify the pinned compiler")
+            text(proof.get("attempted_change"), "constraint attempted_change")
+            commit(proof.get("artifact_commit"), "constraint artifact_commit")
+            path = text(proof.get("artifact_path"), "constraint artifact_path")
+            require(not path.startswith("/") and ":" not in path and "\\" not in path and
+                    all(p not in ("", ".", "..") for p in path.split("/")),
+                    "constraint artifact_path must be repository-relative")
+        if disposition == "deferred":
+            require(kind == "reconstruction", "correctness/provenance findings cannot be deferred")
+            require(review["completion"] == "partial", "deferred work is not complete reconstruction")
+            text(finding.get("owner"), "deferred work owner")
+            issue = finding.get("issue")
+            require(isinstance(issue, str) and re.fullmatch(
+                r"https://github\.com/tangosdev/sm64ds-decomp/issues/[1-9][0-9]*", issue),
+                "deferred work needs its repository issue")
+    require(set(prior) <= ids, "previous source findings disappeared without a disposition")
+    return review
+
+
+def validate_evidence(task, evidence, head, reviewer, required_files=None, prior=None):
+    require(isinstance(evidence, dict), "verification evidence is required")
+    require(evidence.get("verdict") == "pass" and evidence.get("tested_commit") == head,
+            "passing evidence must identify the exact tested commit")
+    require(evidence.get("reviewer_session") == reviewer,
+            "evidence reviewer must match the publishing verifier")
+    base = commit(evidence.get("tested_base"), "tested_base")
+    commit(evidence.get("workflow_commit"), "workflow_commit")
+    return validate(evidence.get("source_review"), head, base, reviewer, producers(task),
+                    task_files(task) if required_files is None else required_files,
+                    previous_findings(task) if prior is None else prior)
+
+
+def review_graph(task):
+    """Every source write must reach independent verification before completion."""
+    pending_write = True  # Adopted source also needs review.
+    for stage in task["stages"]:
+        if stage["role"] == "integrator":
+            require(stage["mode"] == "verify" and not pending_write,
+                    "integration requires a preceding independent source verification")
+        pending_write = stage["mode"] == "write"
+    require(not pending_write, "source tasks must finish with independent verification")

--- a/tools/test_check_pr_source_review.py
+++ b/tools/test_check_pr_source_review.py
@@ -1,0 +1,89 @@
+"""PR merge-check tests; all API calls are fixtures, with no network or writes."""
+import copy
+import pathlib
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_pr_source_review as gate
+from test_source_review import HEAD, BASE, WORKFLOW, evidence
+
+
+def state():
+    return {"schema": 3, "source_review_policy": {"workflow_commit": WORKFLOW}, "tasks": {
+        "actor": {"task_id": "actor", "phase": "done", "input_session": "producer",
+                  "resources": ["file:src/actor.cpp", "file:include/actor.h"],
+                  "stages": [{"id": "verify", "mode": "verify"}],
+                  "outputs": [{"stage_id": "verify", "session": "reviewer", "commit": HEAD,
+                               "evidence": evidence()}]}}}
+
+
+class PRSourceReviewTest(unittest.TestCase):
+    def test_old_queue_and_unreviewed_source_block_but_tooling_can_land(self):
+        self.assertEqual(gate.evaluate({}, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
+        self.assertEqual(gate.evaluate({}, HEAD, BASE, ["tools/source_review.py"])["result"], "pass")
+        self.assertEqual(gate.evaluate({}, HEAD, BASE, ["config/arm9/delinks.txt"])["result"], "fail")
+
+    def test_exact_published_review_passes_and_stale_or_partial_review_fails(self):
+        self.assertEqual(gate.evaluate(state(), HEAD, BASE, ["src/actor.cpp"])["result"], "pass")
+        for head, base, files in ((WORKFLOW, BASE, ["src/actor.cpp"]),
+                                  (HEAD, WORKFLOW, ["src/actor.cpp"]),
+                                  (HEAD, BASE, ["src/actor.cpp", "src/unreviewed.cpp"])):
+            self.assertEqual(gate.evaluate(state(), head, base, files)["result"], "fail")
+
+    def test_self_review_cancelled_task_and_unstructured_pass_fail(self):
+        for change in ("author", "cancelled", "bare"):
+            snapshot = state()
+            task = snapshot["tasks"]["actor"]
+            if change == "author":
+                task["input_session"] = "reviewer"
+            elif change == "cancelled":
+                task["phase"] = "cancelled"
+            else:
+                task["outputs"][0]["evidence"] = {"verdict": "pass", "tested_commit": HEAD}
+            self.assertEqual(gate.evaluate(snapshot, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
+
+    def test_integrator_cannot_invent_an_independent_composition_reviewer(self):
+        snapshot = state()
+        output = snapshot["tasks"]["actor"]["outputs"][0]
+        output["commit"] = BASE
+        output["evidence"].update(composition_commit=HEAD, composition_base=BASE,
+                                 composition_independent_verification=evidence())
+        self.assertEqual(gate.evaluate(snapshot, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
+
+    def test_queue_change_before_publication_emits_failure(self):
+        pr = {"state": "open", "head": {"sha": HEAD}, "base": {"sha": BASE}, "changed_files": 1}
+        posted = []
+
+        def api(path, payload=None, paginate=False):
+            if path.endswith("/check-runs"):
+                posted.append(payload)
+                return {}
+            if "/files?" in path:
+                return [[{"filename": "src/actor.cpp"}]]
+            if "/git/ref/" in path:
+                return {"object": {"sha": "e" * 40}}
+            return copy.deepcopy(pr)
+
+        with patch.object(gate, "api", side_effect=api), patch.object(
+                gate, "queue_state", return_value=("d" * 40, state())):
+            result = gate.check_pr("tangosdev/sm64ds-decomp", 2447, publish=True)
+        self.assertEqual(result["result"], "fail")
+        self.assertEqual(posted[0]["conclusion"], "failure")
+
+    def test_renamed_source_requires_review_of_old_and_new_paths(self):
+        pr = {"state": "open", "head": {"sha": HEAD}, "base": {"sha": BASE}, "changed_files": 1}
+        with patch.object(gate, "api", side_effect=[pr, [[{
+                "filename": "src/actor.cpp", "previous_filename": "src/old_actor.c"}]]]), patch.object(
+                gate, "queue_state", return_value=("d" * 40, state())):
+            self.assertEqual(gate.check_pr("tangosdev/sm64ds-decomp", 2447)["result"], "fail")
+
+    def test_truncated_api_file_list_fails_closed(self):
+        pr = {"state": "open", "head": {"sha": HEAD}, "base": {"sha": BASE}, "changed_files": 3001}
+        with patch.object(gate, "api", side_effect=[pr, [[{"filename": "notes/inert.md"}]]]):
+            self.assertEqual(gate.check_pr("tangosdev/sm64ds-decomp", 2447)["result"], "fail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_check_pr_source_review.py
+++ b/tools/test_check_pr_source_review.py
@@ -1,6 +1,8 @@
 """PR merge-check tests; all API calls are fixtures, with no network or writes."""
 import copy
+import json
 import pathlib
+import subprocess
 import sys
 import unittest
 from unittest.mock import patch
@@ -20,6 +22,20 @@ def state():
 
 
 class PRSourceReviewTest(unittest.TestCase):
+    def test_large_queue_uses_raw_content_at_the_pinned_commit(self):
+        sha = "d" * 40
+        snapshot = state()
+        snapshot["history_fixture"] = "x" * 1_100_000
+        replies = [json.dumps({"object": {"sha": sha}}), json.dumps(snapshot)]
+        with patch.object(gate.subprocess, "run", side_effect=[
+                subprocess.CompletedProcess([], 0, stdout=reply, stderr="")
+                for reply in replies]) as run:
+            self.assertEqual(gate.queue_state("tangosdev/sm64ds-decomp"), (sha, snapshot))
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_args_list[1].args[0], [
+            "gh", "api", f"repos/tangosdev/sm64ds-decomp/contents/state.json?ref={sha}",
+            "-H", "Accept: application/vnd.github.raw+json"])
+
     def test_old_queue_and_unreviewed_source_block_but_tooling_can_land(self):
         self.assertEqual(gate.evaluate({}, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
         self.assertEqual(gate.evaluate({}, HEAD, BASE, ["tools/source_review.py"])["result"], "pass")

--- a/tools/test_classqueue_v2.py
+++ b/tools/test_classqueue_v2.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 import classqueue_v2 as cq
+from test_source_review import evidence as review_evidence, finding
 
 
 TOOLS = pathlib.Path(__file__).resolve().parent
@@ -81,11 +82,24 @@ class GitProtocolTest(unittest.TestCase):
         return cq.Queue(path)
 
     def make_commit(self, queue, files, parent=None):
-        entries = []
+        tree_files = {}
         for path, body in sorted(files.items()):
             blob = queue.git("hash-object", "-w", "--stdin", input=body).stdout.strip()
-            entries.append(f"100644 blob {blob}\t{path}\n")
-        tree = queue.git("mktree", input="".join(entries)).stdout.strip()
+            node = tree_files
+            parts = path.split("/")
+            for part in parts[:-1]:
+                node = node.setdefault(part, {})
+            node[parts[-1]] = blob
+
+        def make_tree(node):
+            entries = []
+            for name, value in sorted(node.items()):
+                if isinstance(value, dict):
+                    entries.append(f"040000 tree {make_tree(value)}\t{name}\n")
+                else:
+                    entries.append(f"100644 blob {value}\t{name}\n")
+            return queue.git("mktree", input="".join(entries)).stdout.strip()
+        tree = make_tree(tree_files)
         args = ["commit-tree", tree]
         if parent:
             args += ["-p", parent]
@@ -521,6 +535,147 @@ class GitProtocolTest(unittest.TestCase):
         verifier = self.claim(role="verifier", stage="verify", session="verifier", input_commit=promoted)
         self.a.rework(verifier, {"verdict": "fail", "tested_commit": promoted}, "Fix TU", "rework")
         self.assertEqual(self.a.next("producer")[0]["input_commit"], promoted)
+
+    def review_workflow(self):
+        return self.make_commit(self.a, {"tools/source_review.py": "# reviewed tool",
+                                        "tools/check_pr_source_review.py": "# reviewed check"}, self.base)
+
+    def enable_reviews(self):
+        self.policy = self.review_workflow()
+        before = self.a.read()[0]
+        self.a.enable_source_review("coordinator", self.policy, before, "activate-review")
+
+    def source_candidate(self):
+        stages = [{"id": "write", "role": "producer", "mode": "write", "requires": [],
+                   "produces": ["source.cpp"]},
+                  {"id": "verify", "role": "verifier", "mode": "verify", "requires": ["source.cpp"],
+                   "produces": []},
+                  {"id": "integrate", "role": "integrator", "mode": "verify", "requires": ["source.cpp"],
+                   "produces": []}]
+        self.enqueue(stages=stages)
+        writer = self.claim(role="producer", stage="write", session="producer")
+        source = self.make_commit(self.a, {"source.cpp": "// candidate"}, self.base)
+        self.a.publish(writer, source, {}, "Review source", "write-source")
+        return source
+
+    def evidence(self, head, reviewer="verifier"):
+        result = review_evidence(head, self.base, reviewer, self.policy)
+        result["source_review"]["files"] = ["source.cpp"]
+        return result
+
+    def test_review_activation_preserves_receipts_tasks_pins_and_history(self):
+        self.enqueue()
+        receipt = self.coordinator()
+        before_sha, before = self.a.read()
+        policy = self.review_workflow()
+        result = self.a.enable_source_review("coordinator", policy, before_sha, "activate")
+        after = self.a.read()[1]
+        self.assertEqual(after["tasks"], before["tasks"])
+        self.assertEqual(after["schema"], 3)
+        self.assertEqual(receipt["schema"], 2)
+        self.assertEqual(cq.receipt_owner(receipt), before["tasks"]["task-a"]["coordinator_owner"])
+        self.assertEqual(self.a.enable_source_review("coordinator", policy, before_sha, "activate"), result)
+        self.a.coordinate(receipt, "cancel-after-upgrade", "cancel", "Checkpoint retained")
+        self.assertEqual(self.a.read()[1]["tasks"]["task-a"]["phase"], "cancelled")
+
+    def test_review_activation_refuses_running_workers_foreign_coordinator_and_stale_inventory(self):
+        self.enqueue()
+        policy = self.review_workflow()
+        sha = self.a.read()[0]
+        with self.assertRaisesRegex(cq.QueueError, "coordinator"):
+            self.a.enable_source_review("other", policy, sha, "foreign-upgrade")
+        receipt = self.claim()
+        with self.assertRaisesRegex(cq.QueueError, "queue changed"):
+            self.a.enable_source_review("coordinator", policy, sha, "stale-upgrade")
+        with self.assertRaisesRegex(cq.QueueError, "running leases"):
+            self.a.enable_source_review("coordinator", policy, self.a.read()[0], "running-upgrade")
+        self.assertEqual(self.a.read()[1]["schema"], 2)
+        self.a.owned(self.a.read()[1]["tasks"]["task-a"], receipt)
+
+    def test_required_review_rejects_invalid_evidence_without_losing_lease(self):
+        self.enable_reviews()
+        source = self.source_candidate()
+        verifier = self.claim(role="verifier", stage="verify", session="verifier", input_commit=source)
+        good = self.evidence(source)
+        invalid = [{"verdict": "pass", "tested_commit": source}]
+        for key, value in (("reviewed_commit", self.base), ("reviewer_session", "invented"),
+                           ("findings", [finding("open")])):
+            item = copy.deepcopy(good)
+            item["source_review"][key] = value
+            invalid.append(item)
+        before = self.a.read()[0]
+        for i, item in enumerate(invalid):
+            with self.subTest(i=i), self.assertRaises(cq.QueueError):
+                self.a.publish(verifier, source, item, "Integrate", "bad-review-" + str(i))
+            self.assertEqual(self.a.read()[0], before)
+        self.a.publish(verifier, source, good, "Integrate reviewed source", "good-review")
+        integrator = self.claim(role="integrator", stage="integrate", session="integrator", input_commit=source)
+        self.a.publish(integrator, source, self.evidence(source, "integrator"), "Done", "integrate")
+
+    def test_existing_unreviewed_offer_cannot_be_integrated_after_activation(self):
+        source = self.source_candidate()
+        verifier = self.claim(role="verifier", stage="verify", session="verifier", input_commit=source)
+        self.a.publish(verifier, source, {"verdict": "pass", "tested_commit": source}, "Integrate", "old-pass")
+        self.enable_reviews()
+        with self.assertRaisesRegex(cq.QueueError, "reviewer"):
+            self.claim(role="integrator", stage="integrate", session="integrator", input_commit=source)
+        self.assertEqual(self.a.read()[1]["tasks"]["task-a"]["phase"], "offered")
+
+    def test_rework_requires_new_review_and_preserves_findings(self):
+        self.enable_reviews()
+        source = self.source_candidate()
+        verifier = self.claim(role="verifier", stage="verify", session="verifier", input_commit=source)
+        failure = self.evidence(source)
+        failure["verdict"] = "fail"
+        failure["source_review"].update(result="changes_requested", findings=[finding("open", "correctness")])
+        self.a.rework(verifier, failure, "Fix finding", "reject-source")
+        producer = self.claim(role="producer", stage="write", session="producer", input_commit=source)
+        fixed = self.make_commit(self.a, {"source.cpp": "// corrected"}, source)
+        self.a.publish(producer, fixed, {}, "Review correction", "publish-correction")
+        verifier = self.claim(role="verifier", stage="verify", session="verifier", input_commit=fixed)
+        with self.assertRaises(cq.QueueError):
+            self.a.publish(verifier, fixed, self.evidence(source), "Integrate", "stale-review")
+        with self.assertRaisesRegex(cq.QueueError, "disappeared"):
+            self.a.publish(verifier, fixed, self.evidence(fixed), "Integrate", "dropped-finding")
+        accepted = self.evidence(fixed)
+        accepted["source_review"]["findings"] = [finding("fixed", "correctness")]
+        self.a.publish(verifier, fixed, accepted, "Integrate", "fixed-review")
+
+    def test_composition_requires_a_separately_published_review(self):
+        self.enable_reviews()
+        source = self.source_candidate()
+        verifier = self.claim(role="verifier", stage="verify", session="verifier", input_commit=source)
+        self.a.publish(verifier, source, self.evidence(source), "Integrate", "source-review")
+        integrator = self.claim(role="integrator", stage="integrate", session="integrator", input_commit=source)
+        composed = self.make_commit(self.a, {"source.cpp": "// composition"}, source)
+        final = self.evidence(source, "integrator")
+        final.update(composition_commit=composed, composition_base=self.base,
+                     composition_independent_verification=self.evidence(composed, "invented-reviewer"))
+        with self.assertRaises(cq.QueueError):
+            self.a.publish(integrator, source, final, "Done", "invented-composition-review")
+        spec = self.spec("composition-review", "file:notes/review.json", stages=[{
+            "id": "verify", "role": "humanizer", "mode": "verify", "requires": ["source.cpp"], "produces": []}])
+        spec.update(input_commit=composed, input_session="integrator", predecessor_tasks=["task-a"])
+        self.a.enqueue(spec, "enqueue-composition-review", self.coordinator(spec))
+        reviewer = self.claim(task_id="composition-review", role="humanizer", stage="verify",
+                              session="independent-composition-reviewer", input_commit=composed)
+        self.a.publish(reviewer, composed, self.evidence(composed, "independent-composition-reviewer"),
+                       "Finish integration", "publish-composition-review")
+        final["composition_review_task"] = "composition-review"
+        self.a.publish(integrator, source, final, "Done", "accept-composition")
+        self.assertEqual(self.a.read()[1]["tasks"]["task-a"]["phase"], "done")
+
+    def test_source_graph_and_earlier_author_cannot_bypass_review(self):
+        self.enable_reviews()
+        with self.assertRaisesRegex(cq.QueueError, "independent verification"):
+            self.enqueue(stages=[{"id": "write", "role": "other", "mode": "write", "requires": [], "produces": []}])
+        source = self.source_candidate()
+        spec = self.spec("adopt-review", "file:notes/adopt-review.json", stages=[{
+            "id": "verify", "role": "verifier", "mode": "verify", "requires": ["source.cpp"], "produces": []}])
+        spec.update(input_commit=source, input_session="later-writer", predecessor_tasks=["task-a"])
+        self.a.enqueue(spec, "adopt-review", self.coordinator(spec))
+        with self.assertRaisesRegex(cq.QueueError, "different session"):
+            self.claim(task_id="adopt-review", role="verifier", stage="verify", session="producer", input_commit=source)
 
 
 class ResourceTest(unittest.TestCase):

--- a/tools/test_source_review.py
+++ b/tools/test_source_review.py
@@ -1,0 +1,128 @@
+"""Behavioral tests for source-review acceptance and retained findings."""
+import copy
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import source_review as sr
+
+HEAD, BASE, WORKFLOW = "a" * 40, "b" * 40, "c" * 40
+
+
+def review(head=HEAD, base=BASE, reviewer="reviewer"):
+    return {"schema": 1, "result": "pass", "reviewed_commit": head,
+            "reviewed_base": base, "reviewer_session": reviewer,
+            "summary": "Reviewed the actor interface, lifecycle, naming and remaining bridges.",
+            "completion": "complete", "files": ["src/actor.cpp", "include/actor.h"], "findings": []}
+
+
+def evidence(head=HEAD, base=BASE, reviewer="reviewer", workflow=WORKFLOW):
+    return {"verdict": "pass", "tested_commit": head, "tested_base": base,
+            "workflow_commit": workflow, "reviewer_session": reviewer,
+            "source_review": review(head, base, reviewer)}
+
+
+def finding(disposition="fixed", kind="reconstruction"):
+    return {"id": "actor-virtual-interface", "location": "src/actor.cpp:20",
+            "summary": "Fake slot table duplicates the existing actor interface.",
+            "kind": kind, "disposition": disposition,
+            "reason": "The candidate now calls the declared actor method."}
+
+
+class SourceReviewTest(unittest.TestCase):
+    def check(self, value, **kwargs):
+        return sr.validate(value, HEAD, BASE, "reviewer", {"producer"},
+                           ["src/actor.cpp", "include/actor.h"], **kwargs)
+
+    def test_review_binds_candidate_base_author_and_coverage(self):
+        self.check(review())
+        for key, value in (("reviewed_commit", BASE), ("reviewed_base", HEAD),
+                           ("reviewer_session", "producer"), ("files", ["src/actor.cpp"]),
+                           ("result", "not_run"), ("summary", "REPLACE_WITH_REVIEW")):
+            with self.subTest(key=key), self.assertRaises(sr.ReviewError):
+                item = review()
+                item[key] = value
+                self.check(item)
+        with self.assertRaisesRegex(sr.ReviewError, "independent"):
+            sr.validate(review(reviewer="producer"), HEAD, BASE, "producer", {"producer"})
+
+    def test_missing_or_malformed_review_does_not_pass(self):
+        for item in (None, {}, "pass", {"schema": 1}):
+            with self.subTest(item=item), self.assertRaises(sr.ReviewError):
+                self.check(item)
+
+    def test_open_findings_block_and_cannot_disappear_or_change_kind(self):
+        prior = {"actor-virtual-interface": finding("open", "correctness")}
+        with self.assertRaisesRegex(sr.ReviewError, "disappeared"):
+            self.check(review(), prior=prior)
+        item = review()
+        item["findings"] = [finding("open")]
+        with self.assertRaisesRegex(sr.ReviewError, "unresolved"):
+            self.check(item)
+        item["findings"] = [finding()]
+        with self.assertRaisesRegex(sr.ReviewError, "reclassified"):
+            self.check(item, prior=prior)
+        item["findings"] = [finding("fixed", "correctness")]
+        self.check(item, prior=prior)
+
+    def test_deferred_reconstruction_requires_partial_scope_owner_and_issue(self):
+        item = review()
+        item["findings"] = [finding("deferred")]
+        with self.assertRaises(sr.ReviewError):
+            self.check(item)
+        item["completion"] = "partial"
+        item["findings"][0].update(owner="actor-producer", issue="https://github.com/tangosdev/sm64ds-decomp/issues/2449")
+        self.check(item)
+        for kind in ("correctness", "provenance"):
+            item["findings"][0]["kind"] = kind
+            with self.assertRaisesRegex(sr.ReviewError, "cannot be deferred"):
+                self.check(item)
+
+    def test_compiler_constraint_requires_pinned_experiment_and_artifact(self):
+        item = review()
+        item["findings"] = [finding("compiler_constraint")]
+        with self.assertRaises(sr.ReviewError):
+            self.check(item)
+        proof = {"tested_commit": HEAD, "command": "python tools/linkcheck.py --name Actor_Render",
+                 "result": "Typed dispatch changes the call instruction; relocation comparison fails.",
+                 "compiler": "2004/b56", "attempted_change": "Replace the shadow with the existing class.",
+                 "log": "notes/probes/actor-render.json", "artifact_commit": WORKFLOW,
+                 "artifact_path": "notes/probes/actor-render.json"}
+        item["findings"][0]["evidence"] = proof
+        self.check(item)
+        for key in proof:
+            broken = copy.deepcopy(item)
+            del broken["findings"][0]["evidence"][key]
+            with self.subTest(key=key), self.assertRaises(sr.ReviewError):
+                self.check(broken)
+
+    def test_authors_and_findings_survive_rejected_attempts_and_adoption(self):
+        task = {"input_session": "original", "producer_sessions": ["inherited"],
+                "stages": [{"id": "write", "mode": "write"}],
+                "outputs": [{"stage_id": "write", "session": "latest", "evidence": {"source_review": None}}],
+                "attempts": [{"outputs": [{"stage_id": "write", "session": "earlier"}],
+                              "evidence": {"source_review": {"findings": [finding("open")]}}}]}
+        self.assertEqual(sr.producers(task), {"original", "inherited", "latest", "earlier"})
+        self.assertIn("actor-virtual-interface", sr.previous_findings(task))
+
+    def test_source_scope_includes_ranges_readonly_review_and_enrollment(self):
+        for task in ({"resources": ["range:ov096:1:2"]},
+                     {"resources": ["file:notes/review.json"], "stages": [
+                         {"requires": ["src/actor.cpp"], "produces": []}]},
+                     {"resources": ["file:config/arm9/overlays/ov096/delinks.txt"]}):
+            self.assertTrue(sr.source_task(task))
+        self.assertFalse(sr.source_task({"resources": ["file:tools/checker.py"]}))
+
+    def test_role_aliases_do_not_skip_final_source_verification(self):
+        for stages in ([{"id": "a", "role": "worker", "mode": "write"}],
+                       [{"id": "a", "role": "integrator", "mode": "verify"}],
+                       [{"id": "a", "role": "producer", "mode": "write"},
+                        {"id": "b", "role": "integrator", "mode": "write"}]):
+            with self.assertRaises(sr.ReviewError):
+                sr.review_graph({"stages": stages})
+        sr.review_graph({"stages": [{"id": "a", "role": "humanizer", "mode": "verify"}]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Source reconstruction can currently reach integration with a byte-only pass. PR #2447 illustrates the gap: fake interfaces survive alongside existing real class declarations, while the completion claim overstates the recovered C++.

This change requires independent source-review evidence for the exact candidate and tested base. Findings survive rework and explicit task continuations; correctness/provenance findings cannot be deferred, retained compiler constraints require pinned experiment artifacts, and accepted partial reconstruction needs an issue and owner. A changed composition requires a separately published review task, rather than an integrator naming a reviewer in nested JSON.

The new `Source review` workflow executes trusted default-branch tools and checks the actual PR head/base and complete source/header/enrollment/manifest path coverage against queue evidence. It never checks out or executes PR code. Byte validation remains separately required.

Validation:

- 37 queue tests passed independently at `f40639d3` against disposable local bare Git remotes. The final revision leaves the queue implementation and test blobs unchanged; all 16 source-review/API tests pass, including a queue larger than 1 MiB read at its pinned commit.
- Static Python-name, reference and Markdown checks pass.
- Normal pre-push checks pass: 423 port references, no duplicate sources, and 164/164 TUs compile. The eligibility-based unresolved-reference check was not run because no report exists for this commit; no game source changed.
- The actual pinned f327 client was exercised against an upgraded disposable queue and correctly refused state schema 3. Existing receipt schema 2 remains usable.
- A read-only live probe of #2447 correctly reports that review enforcement has not yet been activated. No live check or merge-rule changes were made.

Activation is deliberately separate: `SOURCE-REVIEW-CUTOVER.md` requires the existing fleet coordinator to checkpoint/upgrade clients, explicitly activate state schema 3 while preserving tasks/receipts/history, and configure the app-pinned `Source review` check alongside private `PR validation`. Existing tasks and old byte passes require fresh source acceptance; they are not silently approved. GitHub checks are snapshots, so the integrator must also read current review state immediately before landing.

Implements the tooling portion of #2449; keep that issue open through the recorded rollout. Existing-class review is tracked separately. No game source, shared class header or ROM inputs are changed.
