### PR TITLE
Match func_ov007_020c9688, the ov007 scene table builder, from 10 divergences to 0

### DIFF
--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -2011,6 +2011,10 @@ src/func_ov007_020c95fc.c:
     complete
     .text start:0x020c95fc end:0x020c9688
 
+src/func_ov007_020c9688.c:
+    complete
+    .text start:0x020c9688 end:0x020c9988
+
 src/func_ov007_020c9988.c:
     complete
     .text start:0x020c9988 end:0x020c99d8

--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -5223,3 +5223,41 @@ both.
 
 Items 3 to 7 were measured by lanes DC1 and DC2 on 2026-09-07. Items 1 and 2, and the
 byte-level probes in item 3, were re-measured in the banking pass at origin/main 199b7ad3e.
+
+## 6by. Two loops that walk different tables share ONE cursor variable, and that alone fixes the callee-saved rotation (func_ov007_020c9688, div 10 -> 0, 2026-09-08)
+
+Run link100 lane DC3B. `func_ov007_020c9688` (ov007 0x020c9688, 0x300 bytes) sat at
+"pure r7/r8/sb register rotation" for two prior runs (the near-miss row records ~900
+hypotheses at exactly 10: 120 block declaration permutations, a 735-step greedy pairwise
+climb over a 15-element function-top declaration list, plus the 6y levers). Every one of
+those kept the two loops separate.
+
+The function has two passes. The first walks list A with a `RecA *p` declared at function
+top. The second walks list B and, in every candidate, declared its own `u8 *q` inside the
+tail block. With a separate cursor the tail is byte-identical to the ROM except for a
+three-way rotation of the callee-saved registers:
+
+    ROM   0x250  add sb, r1, #4      cursor -> sb      0x264 mov r8, r6   0x268 mov r7, r6
+    ours  0x250  add r7, r1, #4      cursor -> r7      0x264 mov sb, r6   0x268 mov r8, r6
+
+that is, cursor / hoisted-zero-argument / hoisted-loop-init colour to (sb, r8, r7) in the
+cartridge and to (r7, sb, r8) in every candidate. Ten instructions, nothing else.
+
+Reusing `p` for the second pass -- `p = (RecA *)((u8 *)ctx.listB + 4);` and casting at the
+three use sites -- puts all three where the ROM has them and the function matches at 0
+under 2004/b56.
+
+The lever generalises: when a second loop's induction pointer collides with the
+callee-saved numbering, ask whether the original source declared a NEW pointer at all.
+A cursor variable whose live range already spans the first loop enters the interference
+graph before the second loop's compiler temps do, and the temps take the registers below
+it instead of above it. Declaration ORDER cannot express that -- a fresh block-scope
+pointer is a different variable no matter where it is declared, and the 120-permutation
+sweep is blind to it. Reuse is a different axis from ordering, and it is cheap to probe:
+for every block-local pointer or counter, try the function-scope variable of the same
+shape that an earlier loop already finished with.
+
+Negative half, measured the same session on the same axis: reusing `i`, `j` and `cnt`
+as well (the counters, not just the cursor) costs 25 to 27 words, and reusing only `cnt`
+costs 18. The cursor is the one that carries the colouring; the counters are already
+spilled and reusing them only merges spill slots that the ROM keeps apart.

--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -5261,3 +5261,18 @@ Negative half, measured the same session on the same axis: reusing `i`, `j` and 
 as well (the counters, not just the cursor) costs 25 to 27 words, and reusing only `cnt`
 costs 18. The cursor is the one that carries the colouring; the counters are already
 spilled and reusing them only merges spill slots that the ROM keeps apart.
+
+Addendum, 2026-09-08 (out/DC4/results.md is the measurement). Lane DC4 applied the
+shared-cursor lever to every other near-miss row with this shape: eight rows, the whole
+population with two or more loops each declaring its own cursor (func_ov007_020c9688
+above was the ninth and had already landed, so it was excluded). All eight were inert or
+worse, costing 3 to 116 words and, in some of the eight, changing the frame size. The
+lever only pays off when a second pass walks a DIFFERENT table with a cursor whose live
+range would otherwise start only after the first pass ends, under enough callee-saved
+pressure for the interference order to decide the colouring; none of the eight remaining
+rows has that combination. Extending a cursor's live range past the point where the ROM
+lets it die cost words in every row that tried it, never saved any. Counters carry no
+colouring of their own either: swapping which function-scope counter a later loop reuses
+was byte-identical in the row that tested it. The shared-cursor lever's population on
+this near-miss DB is exhausted; a second pass over it needs a different table entirely,
+not more permutations of the same eight rows.

--- a/src/func_ov007_020c9688.c
+++ b/src/func_ov007_020c9688.c
@@ -1,4 +1,5 @@
 // @symbol func_ov007_020c9688
+// recovered: ov007 scene table builder, ov007 0x020c9688 (768 bytes).
 /* func_ov007_020c9688 -- ov007 0x020c9688, 0x300 bytes.
  *
  * Builds the packed runtime tables for one scene description. The context
@@ -91,26 +92,27 @@ Res *func_ov007_020c9688(int arg)
     u32 nA;
     u32 nB;
     u32 cnt;
+    // Every other caller of func_ov007_020c3df4 passes a literal 0; this named local is deliberate (one of the near-miss row's nine zero-plumbing shapes).
     u32 heap = 0;
     Packed tmp;
     Ctx ctx;
     u32 j;
-    RecA *p;
+    u8 *p;
 
     func_ov007_020c9a2c(&ctx, arg);
     nA = *ctx.listA;
     nB = *ctx.listB;
     s = func_ov007_020c12ac(nA, nB);
 
-    p = (RecA *)((u8 *)ctx.listA + 4);
+    p = (u8 *)ctx.listA + 4;
     for (i = 0; i < nA; i++) {
         Entry *e;
         u8 *base;
-        cnt = *(u8 *)p;
-        p = (RecA *)((u8 *)p + 4);
+        cnt = *p;
+        p = p + 4;
         base = s->entries;
         e = (Entry *)(base + i * 8);
-        *(u16 **)(base + i * 8) = (u16 *)func_ov007_020c3df4(heap, cnt * 6);
+        e->data = (u16 *)func_ov007_020c3df4(heap, cnt * 6);
         e->count = cnt;
         for (j = 0; j < cnt; j++) {
             s16 h0;
@@ -125,10 +127,10 @@ Res *func_ov007_020c9688(int arg)
             RecA *r;
             s16 h2;
             u8 b5;
-            r = p;
+            r = (RecA *)p;
             key = ((u32)r->f8 << 8) | ((u32)r->f6 << 28) | ((u32)r->f7 << 29);
             hi = ((u32)r->fC << 14) | ((u32)r->fD << 30);
-            p = (RecA *)((u8 *)p + 0x14);
+            p = p + 0x14;
             bF = r->fF;
             h10 = r->f10;
             b5 = r->f5;
@@ -163,15 +165,15 @@ Res *func_ov007_020c9688(int arg)
         Group *g;
         u32 m;
         u32 c2;
-        p = (RecA *)((u8 *)ctx.listB + 4);
+        p = (u8 *)ctx.listB + 4;
         for (k = 0; k < nB; k++) {
-            c2 = *((u8 *)p + 8);
+            c2 = *(p + 8);
             g = (Group *)(s->groups + k * 0x10);
-            p = (RecA *)((u8 *)p + 0xc);
+            p = p + 0xc;
             func_ov007_020c13a4(g, c2, 0, 0);
             for (m = 0; m < c2; m++) {
-                u8 *q0 = (u8 *)p;
-                p = (RecA *)((u8 *)p + 0x18);
+                u8 *q0 = p;
+                p = p + 0x18;
                 g->arr[m] = (Entry *)((Entry *)s->entries + *(u16 *)q0);
                 g->vals[m] = *(u16 *)(q0 + 2);
             }

--- a/src/func_ov007_020c9688.c
+++ b/src/func_ov007_020c9688.c
@@ -1,0 +1,181 @@
+// @symbol func_ov007_020c9688
+/* func_ov007_020c9688 -- ov007 0x020c9688, 0x300 bytes.
+ *
+ * Builds the packed runtime tables for one scene description. The context
+ * filled in by func_ov007_020c9a2c carries two counted lists; the allocation
+ * made by func_ov007_020c12ac carries the two output arrays.
+ *
+ * The first pass walks list A. Each list-A header word gives the number of
+ * 0x14-byte records that follow it; a 6-byte output slot is allocated per
+ * record and each record is folded into three halfwords -- a 32-bit key
+ * (fields 0x6/0x7/0x8/0xc/0xd, plus 0x0, 0x2, 0x5, 0x9, 0xa and, unless
+ * field 0x9 is 3, 0xb) and a 16-bit tail (fields 0x10, 0xe, 0xf).
+ *
+ * The second pass walks list B. Each 0xc-byte group header gives a member
+ * count at +8; func_ov007_020c13a4 sizes the group, then every 0x18-byte
+ * member contributes an entry pointer (index at +0) and a value (+2).
+ *
+ * ONE SPELLING IS LOAD BEARING, measured against the ROM on 2004/b56:
+ * THE SECOND PASS WALKS WITH `p`, THE SAME CURSOR THE FIRST PASS USED.
+ * Given its own local pointer the second pass is byte-identical except for a
+ * three-way rotation of the callee-saved registers -- the cursor colours to
+ * r7 and the two hoisted zeroes to sb and r8, where the ROM has the cursor in
+ * sb and the zeroes in r8 and r7. Ten instructions, no other difference.
+ * Reusing `p` puts all three where the ROM has them. That rotation survived
+ * every declaration order of the block (all 120), the function-top ordering
+ * climb in the near-miss note, both loop forms, the named-zero and
+ * named-init spellings, and every integer width for the counters; only the
+ * shared cursor moves it. */
+#include "types.h"
+
+typedef struct RecA {
+    s16 f0;
+    s16 f2;
+    u8 f4;
+    u8 f5;
+    u8 f6;
+    u8 f7;
+    u8 f8;
+    u8 f9;
+    u8 fA;
+    u8 fB;
+    u8 fC;
+    u8 fD;
+    u8 fE;
+    u8 fF;
+    u16 f10;
+    u16 f12;
+} RecA;
+
+typedef struct Entry {
+    u16 *data;
+    u32 count;
+} Entry;
+
+typedef struct Group {
+    Entry **arr;
+    u16 *vals;
+    u32 f8;
+    u32 fC;
+} Group;
+
+typedef struct Res {
+    u32 f0;
+    u8 *entries;
+    u32 f8;
+    u8 *groups;
+} Res;
+
+typedef struct Ctx {
+    u8 pad[0x44];
+    u32 *listA;
+    u8 pad2[8];
+    u32 *listB;
+    u8 pad3[0x30];
+} Ctx;
+
+typedef struct Packed {
+    u32 val;
+    u16 ext;
+} Packed;
+
+extern void func_ov007_020c9a2c(Ctx *ctx, int a);
+extern Res *func_ov007_020c12ac(u32 a, u32 b);
+extern void *func_ov007_020c3df4(int a, u32 b);
+extern void func_ov007_020c13a4(void *c, int r1, short r2, short r3);
+
+Res *func_ov007_020c9688(int arg)
+{
+    Res *s;
+    u32 i;
+    u32 nA;
+    u32 nB;
+    u32 cnt;
+    u32 heap = 0;
+    Packed tmp;
+    Ctx ctx;
+    u32 j;
+    RecA *p;
+
+    func_ov007_020c9a2c(&ctx, arg);
+    nA = *ctx.listA;
+    nB = *ctx.listB;
+    s = func_ov007_020c12ac(nA, nB);
+
+    p = (RecA *)((u8 *)ctx.listA + 4);
+    for (i = 0; i < nA; i++) {
+        Entry *e;
+        u8 *base;
+        cnt = *(u8 *)p;
+        p = (RecA *)((u8 *)p + 4);
+        base = s->entries;
+        e = (Entry *)(base + i * 8);
+        *(u16 **)(base + i * 8) = (u16 *)func_ov007_020c3df4(heap, cnt * 6);
+        e->count = cnt;
+        for (j = 0; j < cnt; j++) {
+            s16 h0;
+            u32 key;
+            u32 hi;
+            u8 bE;
+            u32 h10;
+            u8 b9;
+            u8 bA;
+            u8 bB;
+            u32 bF;
+            RecA *r;
+            s16 h2;
+            u8 b5;
+            r = p;
+            key = ((u32)r->f8 << 8) | ((u32)r->f6 << 28) | ((u32)r->f7 << 29);
+            hi = ((u32)r->fC << 14) | ((u32)r->fD << 30);
+            p = (RecA *)((u8 *)p + 0x14);
+            bF = r->fF;
+            h10 = r->f10;
+            b5 = r->f5;
+            bB = r->fB;
+            bA = r->fA;
+            b9 = r->f9;
+            bE = r->fE;
+            h2 = r->f2;
+            h0 = r->f0;
+            if (key == 0x100 || key == 0x300) {
+                if (b9 == 3) {
+                    tmp.val = key | ((hi | ((h2 & 0xff) | (b5 << 25) | (b9 << 10) | (bA << 12))) | ((h0 & 0x1ff) << 16));
+                } else {
+                    tmp.val = key | ((hi | ((h2 & 0xff) | ((b5 << 25) | (bB << 13)) | (b9 << 10) | (bA << 12))) | ((h0 & 0x1ff) << 16));
+                }
+            } else {
+                if (b9 == 3) {
+                    tmp.val = key | ((hi | ((h2 & 0xff) | (b9 << 10) | (bA << 12))) | ((h0 & 0x1ff) << 16));
+                } else {
+                    tmp.val = key | ((hi | ((h2 & 0xff) | (bB << 13) | (b9 << 10) | (bA << 12))) | ((h0 & 0x1ff) << 16));
+                }
+            }
+            tmp.ext = h10 | (bE << 10) | (bF << 12);
+            *(u16 *)((u8 *)e->data + j * 6) = ((u16 *)&tmp)[0];
+            *(u16 *)((u8 *)e->data + j * 6 + 2) = ((u16 *)&tmp)[1];
+            *(u16 *)((u8 *)e->data + j * 6 + 4) = ((u16 *)&tmp)[2];
+        }
+    }
+
+    {
+        u32 k;
+        Group *g;
+        u32 m;
+        u32 c2;
+        p = (RecA *)((u8 *)ctx.listB + 4);
+        for (k = 0; k < nB; k++) {
+            c2 = *((u8 *)p + 8);
+            g = (Group *)(s->groups + k * 0x10);
+            p = (RecA *)((u8 *)p + 0xc);
+            func_ov007_020c13a4(g, c2, 0, 0);
+            for (m = 0; m < c2; m++) {
+                u8 *q0 = (u8 *)p;
+                p = (RecA *)((u8 *)p + 0x18);
+                g->arr[m] = (Entry *)((Entry *)s->entries + *(u16 *)q0);
+                g->vals[m] = *(u16 *)(q0 + 2);
+            }
+        }
+    }
+    return s;
+}


### PR DESCRIPTION
One new match in ov007: func_ov007_020c9688 (0x020c9688, 0x300 bytes), the scene table builder that folds two counted lists into packed runtime tables. It had sat at 10 divergences through two earlier runs (120 declaration permutations, a 735-step ordering climb, a pragma sweep) and both prior floor claims were wrong.

What cracked it: the second pass walks with the same cursor the first pass finished with, instead of its own local pointer. Giving the second loop its own pointer recolours three callee-saved registers and costs exactly the 10 words. Written up as notes section 6by, with the negative half measured too: the same lever applied to every other near-miss row with the shape (eight rows) made all eight worse, so it needs a genuine two-pass function under register pressure.

Registered in config/arm9/overlays/ov007/delinks.txt as a complete .text range equal to the symbol's size; no symbol changes, so the denominator is unchanged. match.py prints MATCHING VERSIONS 2004/b56 with every relocation destination verified; prepush_linkcheck VERIFIED. Independently reviewed: the reviewer re-ran the byte gate, audited all four callee signatures against main's definitions, corroborated the shadow structs from the disassembly, and ran every workflow gate locally (644 tool tests OK, ratchets PASS, validate_merge exit 0). Its two measured byte-free cleanups (the laundered store and the cursor's false type) are applied in the third commit.
