### PR TITLE
Move src/func_020717c0.c onto its symbol name, __rethrow

### DIFF
--- a/src/__rethrow.c
+++ b/src/__rethrow.c
@@ -4,7 +4,11 @@
 // symbol table carries __rethrow and the source never names it. The ROM's own rethrow
 // calls land here (notes/mwccarm-codegen.md 9a), and src/func_02073300.cpp,
 // src/func_020733a8.c and src/func_02073470.cpp all branch to this address.
-// Was func_020717c0.
+// Was named for the old symbol func_020717c0. The file follows the symbol, the same
+// move __end__catch needed: tools/srcpath.py keys a source to its file stem, so under
+// the old stem config declared a function at 0x020717c0 that no source resolved to,
+// and tools/nearmiss_db.py resync-names would have relabelled the stored row to
+// __rethrow and then lost its link to this source.
 // NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
 // assembly primitive, so there is no original C to recover and no match to chase. Counts as
 // done under the asm-primitive policy - see notes/arm9-endgame.md.


### PR DESCRIPTION
Follow-up to #2454: that PR made __rethrow the primary name of 0x020717c0 but left its source under the old stem src/func_020717c0.c, so config declared a 0x4c function no source answered for, and nearmiss_db.py resync-names would have relabelled the stored row and lost its link to the file. This moves the file onto its symbol, the same operation #2454 did for __end__catch. The file is a NONMATCHING hand-asm primitive and is not enrolled, so no count moves; git records the move as a rename.
