### PR TITLE
Match func_02061128, the game-card interrupt callback setter

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -10659,6 +10659,10 @@ src/_ZN3IRQ21GameCardIREQMCHandlerEv.cpp:
     complete
     .text start:0x020610ac end:0x020610fc
 
+src/func_02061128.c:
+    complete
+    .text start:0x02061128 end:0x02061138
+
 src/func_02061138.c:
     complete
     .text start:0x02061138 end:0x0206116c

--- a/src/func_02061128.c
+++ b/src/func_02061128.c
@@ -1,0 +1,13 @@
+// @symbol func_02061128
+/* recovered: setter for the IRQ game-card MC interrupt callback stored at
+   data_020a89a4 (read back by IRQ::GameCardIREQMCHandler, see
+   src/_ZN3IRQ21GameCardIREQMCHandlerEv.cpp), arm9 0x02061128, 0x10 bytes. */
+#include "types.h"
+
+typedef int (*fp)(void);
+extern fp data_020a89a4;
+
+void func_02061128(fp cb)
+{
+    data_020a89a4 = cb;
+}


### PR DESCRIPTION
func_02061128 (arm9 0x02061128, 16 bytes) had no source file and no callers: a bare setter that stores its argument into data_020a89a4, the game-card interrupt callback that IRQ::GameCardIREQMCHandler reads back. Byte-exact at 2004/b56 with the literal-pool word as its one relocation, registered as a complete .text range. +1 function, +16 bytes, no symbol changes. The real link on the branch reproduces 10,905 source-built functions with 0 mismatching, one more than main.
