### PR TITLE
Port: read the harness frame number off the ROM's frame state (rung R3a, count unchanged 10163)

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -16316,6 +16316,23 @@ foreach(_tbootmain walk_window walk_window_hires)
         "${CMAKE_CURRENT_SOURCE_DIR}/hal/rom_main.cpp")
 endforeach()
 
+# THE ROM'S FRAME STATE (run link100, boot plan rung R3a, lane R3A).
+#
+# hal/rom_frame.cpp hosts data_0209d50c -- the ROM game loop's PHASE ID, which
+# nothing in this port defined and nothing read, because its only ROM writer is
+# func_020197b8 and the block above renames that TU to port_rom_loop_seam. It
+# also carries the phase-6 step count the test harness now reads its frame
+# number from, and the cross-check that refuses to return a number the host
+# loop's own counter disagrees with.
+#
+# The same two targets as rom_main.cpp above, and for the same reason: they are
+# the only ones that compile tests/walk_window.cpp, which is the caller. This
+# rung enrols no matched TU and moves the linkage count by zero, by design.
+foreach(_tromframe walk_window walk_window_hires)
+    target_sources(${_tromframe} PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/hal/rom_frame.cpp")
+endforeach()
+
 # THE CONFIGURE-DEPENDS SELF-CHECK (run link100, lane CMAKEDEPS).  Every list
 # read at configure time has to be registered, or an edit to it will not
 # reconfigure and the build will look clean while compiling the old set of

--- a/port/hal/rom_frame.cpp
+++ b/port/hal/rom_frame.cpp
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------------------
+// rom_frame.cpp -- THE ROM'S FRAME STATE, HOSTED, AND THE ONE SEAM THE TEST
+// HARNESS READS ITS FRAME NUMBER THROUGH.
+//
+// Run link100, boot plan rung R3a (lane R3A). Worth ZERO linked TUs by design.
+// Its whole value is that after it, the harness no longer depends on the host
+// frame loop's own local counter, so the frame can later be handed to the ROM's
+// own loop (rungs R3b to R3d, worth +72) by changing ONE function here instead
+// of twenty-one readers and two hundred traces in tests/walk_window.cpp.
+//
+// THE ROM'S FRAME STATE IS TWO WORDS, and src/func_020197b8.c -- the ROM's game
+// loop, arm9 0x020197b8 -- is what writes both:
+//
+//     data_0209d50c = 5; func_02019404();     phase 5
+//     data_0209d50c = 6;                      <- PHASE 6, first statement
+//     data_020a0db0 = data_020a0db0 + 1;      <- PHASE 6, second statement
+//
+//   data_0209d50c  0x0209d50c, .bss (config/arm9/symbols.txt:4628). THE PHASE
+//                  ID: which of the loop's twelve phases the frame is in. Until
+//                  this file NOTHING IN THE PORT HOSTED IT and nothing read it:
+//                  its only ROM writer is func_020197b8, which is not linked
+//                  (port/CMakeLists.txt renames it to port_rom_loop_seam for
+//                  src/main.c's sake). It is defined here, and the host loop
+//                  writes the one phase it actually runs at the point it runs
+//                  it. R3b adds the other eleven as it moves the loop's duties
+//                  into the ROM's own seams.
+//
+//   data_020a0db0  0x020a0db0, .bss (config/arm9/symbols.txt:4924). THE FRAME
+//                  CLOCK, hosted as int[8] in hal/auto_bss.cpp:251 and stepped
+//                  by port_frame_clock_tick() in hal/fader_wipes.cpp. NOT
+//                  TOUCHED HERE, and read only to measure. Read that file's
+//                  banner before assuming this one could have used it as the
+//                  harness's frame number: thirteen linked readers hang their
+//                  blink off it, this port steps it ONE PHASE EARLY and GATED
+//                  ON THE GAME TICK, and hal/scene_boot.cpp's port_scene_tick
+//                  steps the same word, so on a title-entry fall-through the
+//                  scene has already stepped it a few thousand times before
+//                  main's level loop starts its own frame at 0.
+//
+// SO THE HARNESS'S FRAME NUMBER IS THE PHASE-6 STEP COUNT, kept here, stepped
+// once per frame at the host loop's frame boundary by port_rom_frame_phase6(),
+// which is the ROM's phase-6 body run where the ROM's loop runs it: after the
+// frame's work, before the frame ends. Under rung R3d that step becomes
+// func_020197b8's own line and this file stops writing it. Nothing else about
+// the frame moves in this rung: no pacing, no input, no present, and the blink
+// clock's own call site is exactly where it was.
+//
+// THE CROSS-CHECK IS THE POINT OF THE RUNG, NOT A DEBUG AID. Every converted
+// reader passes the host loop's own `frame` in beside its request, and this
+// file refuses to return a number that disagrees with it: it prints the frame,
+// both counters and the reader's name, and leaves with code 90. It is ON unless
+// SM64DS_FRAME_CROSSCHECK=0, so a battery row that goes green has PROVED the
+// two counters agreed on every frame of it, rather than merely not crashing.
+//
+// AND THE ONE DEVIATION IS MEASURED RATHER THAN ASSUMED. Every frame this file
+// reconciles its own step count against data_020a0db0's, and the report line at
+// the end of a run says how many phase-6 steps this port's pause suppressed
+// from the blink clock (the frame a level change re-seats, and every frame the
+// debug menu holds the world still -- walk_window.cpp:10631 and :11084). The
+// ROM's loop has no pause, so that number is exactly the gap R3d closes.
+// ---------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "dsstate_seg.h"
+
+/* THE ROM'S PHASE ID, hosted for the first time, INSIDE the .dsstate bracket.
+   It is a hosted DS BSS global at 0x0209d50c and tools/dsstate_guard.py refuses
+   the link if one of those lands outside the span a save state captures -- it
+   refused this file's first draft, which put the word in plain .bss on the
+   argument that a within-frame phase id is a transient. The guard is right and
+   the argument was wrong: a save state taken mid-frame has a phase, and a
+   restore that comes back with a different one has changed the ROM's state. */
+DSSTATE_BEGIN
+extern "C" {
+int data_0209d50c;
+}
+DSSTATE_END
+
+extern "C" {
+
+/* the blink clock, read here only to measure the gap. hal/auto_bss.cpp owns it
+   and hal/fader_wipes.cpp is the only writer. */
+extern int data_020a0db0[8];
+
+static int         g_frame;          /* phase-6 steps since this loop began */
+static int         g_blink_base;     /* data_020a0db0[0] when it began */
+static int         g_blink_missed;   /* steps this port's pause suppressed */
+static int         g_checks;         /* cross-check calls */
+static int         g_rewinds;        /* rollback re-anchors */
+static const char *g_loop = "none";
+static int         g_on = -1;        /* the cross-check gate, resolved once */
+
+static int crosscheck_on(void)
+{
+    if (g_on < 0) {
+        const char *e = std::getenv("SM64DS_FRAME_CROSSCHECK");
+        g_on = (e && e[0] == '0' && e[1] == '\0') ? 0 : 1;
+    }
+    return g_on;
+}
+
+/* A FRAME LOOP IS STARTING. Both of tests/walk_window.cpp's loops call this
+   with their own name, so a run that plays a scene and then falls through into
+   a level reports two frame accounts rather than one blurred one. */
+void port_rom_frame_begin(const char *loop)
+{
+    g_loop = loop ? loop : "loop";
+    g_frame = 0;
+    g_blink_base = data_020a0db0[0];
+    g_blink_missed = 0;
+    g_checks = 0;
+    g_rewinds = 0;
+    std::fprintf(stderr, "[rom-frame] %s: the harness reads the ROM's frame "
+                         "state from here (phase id data_0209d50c, phase-6 step "
+                         "count); cross-check against the host counter is %s\n",
+                 g_loop, crosscheck_on() ? "ON" : "OFF");
+}
+
+/* THE ROM'S PHASE-6 BODY, at the host loop's frame boundary.
+   func_020197b8.c:49-50 is `data_0209d50c = 6; data_020a0db0 += 1;`. The first
+   statement is this port's for the first time. The second is already this
+   port's, at its own point and under its own tick gate in hal/fader_wipes.cpp,
+   so it is NOT repeated here -- it is reconciled instead: `blink` is how many
+   times the clock stepped since this loop began, and the difference is what the
+   pause suppressed. */
+void port_rom_frame_phase6(void)
+{
+    data_0209d50c = 6;
+    ++g_frame;
+    {
+        const int blink = data_020a0db0[0] - g_blink_base;
+        g_blink_missed = g_frame - blink;
+    }
+}
+
+int port_rom_frame(void)
+{
+    return g_frame;
+}
+
+/* ROLLBACK RE-ANCHOR. hal/rollback.cpp's rb_frame_end / rb_probe_frame_end take
+   `&frame` and may move it BACKWARDS to re-run a contradicted round. The ROM's
+   phase-6 step counts frames EXECUTED and cannot go back, so the one place the
+   host counter legitimately moves on its own says so here rather than tripping
+   the cross-check. Inert unless port::comms_rb_mode() is on. */
+void port_rom_frame_rewind(int to)
+{
+    std::fprintf(stderr, "[rom-frame] %s: rollback moved the host counter %d "
+                         "-> %d; re-anchoring the ROM frame number with it\n",
+                 g_loop, g_frame, to);
+    ++g_rewinds;
+    g_frame = to;
+    /* g_blink_base is deliberately left where it was: the blink clock keeps
+       counting frames EXECUTED, so after a re-anchor the reconciliation below
+       reports a NEGATIVE suppression, which is the honest reading -- the clock
+       stepped more times than the run has logical frames. */
+}
+
+/* THE ONE ACCESSOR EVERY CONVERTED READER GOES THROUGH. Returns the ROM's frame
+   number; refuses to return one that disagrees with the host loop's counter. */
+int port_rom_frame_checked(int host, const char *reader)
+{
+    if (crosscheck_on()) {
+        ++g_checks;
+        if (g_frame != host) {
+            std::fprintf(stderr,
+                         "[frame-crosscheck] MISMATCH in %s at reader '%s': the "
+                         "ROM's frame state says %d, the host loop's counter "
+                         "says %d (blink clock %d, suppressed %d, rewinds %d). "
+                         "The frame boundary moved; this is the finding.\n",
+                         g_loop, reader ? reader : "?", g_frame, host,
+                         data_020a0db0[0] - g_blink_base, g_blink_missed,
+                         g_rewinds);
+            std::fflush(stderr);
+            std::fflush(stdout);
+            std::exit(90);
+        }
+    }
+    return g_frame;
+}
+
+/* ONE LINE PER RUN, so a battery row's log can be grepped for it and counted.
+   Prints whether the cross-check was on, how many reads it verified, and the
+   measured gap between the ROM's phase-6 step count and the blink clock. */
+void port_rom_frame_report(void)
+{
+    std::fprintf(stderr,
+                 "[frame-crosscheck] %s: %s -- %d frames, %d reads verified, 0 "
+                 "disagreements; blink clock stepped %d of them, %d suppressed "
+                 "by the port's pause, %d rollback re-anchor(s)\n",
+                 g_loop, crosscheck_on() ? "ON" : "OFF", g_frame, g_checks,
+                 data_020a0db0[0] - g_blink_base, g_blink_missed, g_rewinds);
+    std::fflush(stderr);
+}
+
+}  /* extern "C" */

--- a/port/tests/walk_window.cpp
+++ b/port/tests/walk_window.cpp
@@ -6757,7 +6757,9 @@ static int scene_window_run(void)
     MSG msg;
     static XPad pad;
     while (!quit) {
-        if (scene_menu_at >= 0 && frame == scene_menu_at) menu_on = 1;
+        if (scene_menu_at >= 0 &&
+            port_rom_frame_checked(frame, "scene-menu-at") == scene_menu_at)
+            menu_on = 1;
         while (W.PeekMessageA_(&msg, 0, 0, 0, PM_REMOVE)) {
             if (msg.message == WM_QUIT) { quit = 1; break; }
             W.TranslateMessage_(&msg);
@@ -6782,7 +6784,8 @@ static int scene_window_run(void)
 
         int pad_live = port_pad_poll(&pad);
         pad_focus_gate(&pad_live, &pad);
-        pad_test_apply(frame, &pad_live, &pad);
+        pad_test_apply(port_rom_frame_checked(frame, "scene-pad-test"),
+                       &pad_live, &pad);
         /* the pad layout learn flow, the same call the level loop makes;
            inert unless the menu's row armed it */
         padlearn_frame(&pad_live);
@@ -6790,7 +6793,8 @@ static int scene_window_run(void)
         /* SM64DS_CLICK_TEST: the scripted stylus, driven BEFORE the tick that
            polls it, so a press is in the OS's button state by the time
            hal_sub_screen_frame_begin reads it on this same frame. */
-        click_test_apply(hwnd, frame);
+        click_test_apply(hwnd,
+                         port_rom_frame_checked(frame, "scene-click-test"));
 #endif
 
         /* THE DEBUG MENU, the same block main runs. g_menu_host is left zeroed
@@ -6882,7 +6886,7 @@ static int scene_window_run(void)
 
         /* the scene's own frame; the menu's pause is its second argument, the
            same switch the level loop's game_ticked is */
-        port_scene_tick(frame, !menu_on);
+        port_scene_tick(port_rom_frame_checked(frame, "scene-tick"), !menu_on);
 
         /* THE STACKED IMAGE IS BUILT BEFORE THE OVERLAYS, and the order is the
            whole of this lane's change on this path. Every line ABOVE this one
@@ -6938,9 +6942,12 @@ static int scene_window_run(void)
            path has no rollback boundary, so there is no re-anchor here. */
         port_rom_frame_phase6();
         ++frame;
-        port_last_frame = frame;   /* fault_probe.h: crash.txt/exit.txt context */
+        /* fault_probe.h: crash.txt/exit.txt context, the ROM's frame number and
+           this path's every-frame cross-check. */
+        port_last_frame = port_rom_frame_checked(frame, "scene-fault-context");
         fflush(stdout);
-        if (budget && frame >= budget)
+        if (budget &&
+            port_rom_frame_checked(frame, "scene-budget") >= budget)
             break;
         /* THE TITLE HANDOFF (hal/title_entry.cpp), tested here for the same
            reason the headless bridge tests it after its tick: the title writes
@@ -6950,7 +6957,8 @@ static int scene_window_run(void)
            of a cached int. */
         if (port_title_entry_should_stop()) {
             fprintf(stderr, "[title-entry] a save file was picked; leaving the "
-                            "title after %d frame(s)\n", frame);
+                            "title after %d frame(s)\n",
+                    port_rom_frame_checked(frame, "title-entry"));
             break;
         }
         /* THE PACE, off the scene's own divider and not off a constant. A
@@ -6968,9 +6976,11 @@ static int scene_window_run(void)
 #ifndef PORT_ROM_CLEAN
     click_test_finish();
 #endif
-    fprintf(stderr, "[scene] window closed after %d frame(s)\n", frame);
+    fprintf(stderr, "[scene] window closed after %d frame(s)\n",
+            port_rom_frame_checked(frame, "scene-closed"));
     port_rom_frame_report();   /* R3a: this loop's frame account, one line */
-    const int scene_rc = port_scene_finish(frame);
+    const int scene_rc =
+        port_scene_finish(port_rom_frame_checked(frame, "scene-finish"));
     /* AFTER the census, so a run that enters the adventure still leaves the
        title's own slot hits, captures and trap counts behind. Answers 0 and
        prints nothing unless the bridge is armed AND the handoff completed. */
@@ -9135,13 +9145,14 @@ int main(void)
         /* SM64DS_PAD_TEST: DBG1's scripted pad, at file scope now so the
            windowed scene loop gets the same one. Inert unless the variable is
            set and unreachable from a selftest; see its banner. */
-        pad_test_apply(frame, &pad_live, &pad);
+        pad_test_apply(port_rom_frame_checked(frame, "pad-test"),
+                       &pad_live, &pad);
 #ifndef PORT_ROM_CLEAN
         /* SM64DS_CLICK_TEST: the scripted stylus, the same call the windowed
            scene loop makes and for the same reason -- the level path is where
            the inset panel's transform lives, so it is the half of the click
            grid that guards against a stacked fix moving a level. */
-        click_test_apply(hwnd, frame);
+        click_test_apply(hwnd, port_rom_frame_checked(frame, "click-test"));
 #endif
         /* ---- THE REBIND CAPTURE, ahead of every other reader of this frame's
            input. The keyboard half already arrived through the window
@@ -9516,7 +9527,8 @@ int main(void)
                frame into the raw pad mirror BEFORE CheckInput, so the remap and
                the direct readers (IsButtonInputValid, Message::Update) both see
                it. Does nothing without the env var. */
-            port_input_probe_apply(frame);
+            port_input_probe_apply(port_rom_frame_checked(frame,
+                                                          "input-probe"));
             /* THIS FRAME'S PAD, STASHED FOR THE Ctrl BRIDGE (run link100, lane
                FRAME). port_frame_ctrl_publish runs from inside port_actor_tick
                -- hal/stage_frame.cpp's slot-6 thunk calls it the instant the
@@ -9809,7 +9821,8 @@ int main(void)
                StartTalk's b==0 gate (data_0209f49e & 3) sees the press, and the
                camera-rotate readers do not (mask to bits 0-1). SM64DS_PROBE_INPUT. */
             if (!menu_on)
-                btn |= (unsigned short)(port_input_probe_bits(frame) & 0x3);
+                btn |= (unsigned short)(port_input_probe_bits(
+                    port_rom_frame_checked(frame, "input-probe-bits")) & 0x3);
             /* run mg16 lane MPBTN: the button half of the published key word,
                stashed HERE because this is the first line where btn is final
                (bindings, run-mode AUTO, the selftest probes, the menu's zero,
@@ -9821,7 +9834,8 @@ int main(void)
                headless proof exactly like a held key. */
             port_raw_btn_stash((unsigned short)(
                 host_btn_to_raw_keys(btn) |
-                (menu_on ? 0 : port_input_probe_bits(frame))));
+                (menu_on ? 0 : port_input_probe_bits(
+                    port_rom_frame_checked(frame, "input-probe-raw")))));
             /* ---- THE THIRD BUTTON WRITER, AND THE ONE HIS HANDS FOUND ------
              *
              * Run mg16 lane MP4, second field re-test. This is the LEVEL path's
@@ -11791,7 +11805,12 @@ int main(void)
             fprintf(stderr,
                     "[f%03d] pos=(%.1f,%.1f,%.1f) spd=%d st=%08x mag=%d "
                     "body=%u anim(len=%u fl=%u cur=%.1f) bones=%08x path=%x\n",
-                    frame, *(int *)(c + 0x5c) / 4096.0f,
+                    /* R3a: tail2_states_proof's opening gate reads this line's
+                       frame number, so it is the ROM's now. It prints the same
+                       digits: the accessor is cross-checked against `frame` on
+                       this very call. */
+                    port_rom_frame_checked(frame, "opening-gate"),
+                    *(int *)(c + 0x5c) / 4096.0f,
                     *(int *)(c + 0x60) / 4096.0f,
                     *(int *)(c + 0x64) / 4096.0f, *(int *)(c + 0x98),
                     st ? *(unsigned *)st : 0u, *(short *)(data_0209f4a0 + 0),
@@ -13186,11 +13205,13 @@ int main(void)
                 if (df) dump_from = atoi(df);
                 if (dt) dump_to = atoi(dt);
             }
-            if (selftest && dump_from >= 0 && frame >= dump_from &&
-                frame <= dump_to) {
-                char nm[64];
-                snprintf(nm, sizeof nm, "walk_frame_%03d.bmp", frame);
-                ntr::ppu_write_bmp(nm, fb);
+            if (selftest && dump_from >= 0) {
+                const int rf = port_rom_frame_checked(frame, "dump-window");
+                if (rf >= dump_from && rf <= dump_to) {
+                    char nm[64];
+                    snprintf(nm, sizeof nm, "walk_frame_%03d.bmp", rf);
+                    ntr::ppu_write_bmp(nm, fb);
+                }
             }
         }
         { const double t_snd = ovl_now_ms();
@@ -13228,8 +13249,13 @@ int main(void)
            above may REWIND `frame` and re-run, so an equality test can be
            stepped over and never fire. Latching on >= cannot be missed, and
            setting menu_on when it is already set is a no-op. */
-        if (menu_at >= 0 && frame >= menu_at) menu_on = 1;
-        port_last_frame = frame;   /* fault_probe.h: crash.txt/exit.txt context */
+        if (menu_at >= 0 &&
+            port_rom_frame_checked(frame, "menu-at") >= menu_at) menu_on = 1;
+        /* fault_probe.h: crash.txt/exit.txt context. The ROM's frame number,
+           and this is the ONE reader that runs on every frame of every run, so
+           the cross-check below it is what makes a green row a proof that the
+           two counters agreed on all of it. */
+        port_last_frame = port_rom_frame_checked(frame, "fault-context");
         /* the frame's stdout, one write; the setvbuf note above is why */
         fflush(stdout);
         /* SM64DS_COMMS_STOP_ROUND=R (run rel0215 lane LAGDELAY): under a
@@ -13251,7 +13277,8 @@ int main(void)
                         "ending the selftest at the agreed round rather than "
                         "this window's own frame budget\n",
                         (unsigned long long)cr.rounds,
-                        (unsigned long long)stop_round, frame);
+                        (unsigned long long)stop_round,
+                        port_rom_frame_checked(frame, "comms-stop-round"));
                 /* AND HOLD THE SEAT OPEN WHILE THE OTHERS FINISH. The first
                    run of the stop-round sweep stopped every window at round
                    900 and three of six pairings still disagreed on the LAST
@@ -13280,7 +13307,9 @@ int main(void)
                 }
             }
         }
-        if (selftest && (frame >= selftest || stop_round_hit)) {
+        if (selftest &&
+            (port_rom_frame_checked(frame, "selftest-exit") >= selftest ||
+             stop_round_hit)) {
             for (int k = 0; k < g_amb_n; ++k) {
                 char *o = (char *)g_amb[k].o;
                 int moved = *(int *)(o + 0x5c) != g_amb[k].p0[0] ||
@@ -13335,8 +13364,9 @@ int main(void)
                 fprintf(stderr, "[heap] %u free after %d frames\n",
                         _ZN22ExpandingHeapAllocator10MemoryLeftEv(
                             *(void **)((char *)data_020a0eac_c + 0x14)),
-                        frame);
-            printf("selftest: %d frames, pos=(%d, %d, %d)\n", frame,
+                        port_rom_frame_checked(frame, "heap-line"));
+            printf("selftest: %d frames, pos=(%d, %d, %d)\n",
+                   port_rom_frame_checked(frame, "selftest-summary"),
                    *(int *)(c + 0x5c), *(int *)(c + 0x60), *(int *)(c + 0x64));
             /* R3a: the frame account this run ends on -- how many reads went
                through the ROM's frame state, and the measured gap between its

--- a/port/tests/walk_window.cpp
+++ b/port/tests/walk_window.cpp
@@ -1221,6 +1221,21 @@ void port_actor_tick(void);          /* phases 4/2/3: cleanup, init, behaviour *
    readers were dead -- three of them `& 1` sites that test non-zero and so had
    never executed at all. Read that file's banner before moving this call. */
 void port_frame_clock_tick(void);
+/* THE ROM'S FRAME STATE (hal/rom_frame.cpp), run link100 boot plan rung R3a.
+   The harness's frame number is no longer this file's own `frame` local: it is
+   the ROM game loop's phase-6 step count, kept beside the ROM's phase id
+   data_0209d50c, which that file hosts for the first time. port_rom_frame_phase6
+   runs the ROM's phase-6 body once per frame at each loop's frame boundary;
+   port_rom_frame_checked is the ONE accessor every converted reader goes
+   through, and it refuses to return a number the host counter disagrees with
+   (SM64DS_FRAME_CROSSCHECK, default ON). Read that file's banner before moving
+   any of these calls: their placement is the whole of what R3d inherits. */
+void port_rom_frame_begin(const char *loop);
+void port_rom_frame_phase6(void);
+int  port_rom_frame(void);
+int  port_rom_frame_checked(int host, const char *reader);
+void port_rom_frame_rewind(int to);
+void port_rom_frame_report(void);
 /* func_020197b8 PHASE 2's head (hal/scene_boot.cpp): the current scene's
    graphics block, word 0, which is scene slot 23's only dispatch site in the
    whole ROM. Answers 1 for a block this port has not seated. */
@@ -6735,6 +6750,10 @@ static int scene_window_run(void)
     }
 
     int frame = 0, focus_was = 1, quit = 0;
+    /* R3a: the ROM's frame state is this loop's frame number too, so a run that
+       plays a scene and then falls through into a level reports two frame
+       accounts rather than one blurred one. */
+    port_rom_frame_begin("scene loop");
     MSG msg;
     static XPad pad;
     while (!quit) {
@@ -6914,6 +6933,10 @@ static int scene_window_run(void)
            repeats. So: the game's frames are pumped there, the paused frames
            are pumped here, and no frame is pumped twice. */
         if (menu_on) sdat_host_tick();
+        /* THE ROM'S PHASE 6 on this path, for the level loop's reason: the
+           frame's work is done and nothing of the next has started. The scene
+           path has no rollback boundary, so there is no re-anchor here. */
+        port_rom_frame_phase6();
         ++frame;
         port_last_frame = frame;   /* fault_probe.h: crash.txt/exit.txt context */
         fflush(stdout);
@@ -6946,6 +6969,7 @@ static int scene_window_run(void)
     click_test_finish();
 #endif
     fprintf(stderr, "[scene] window closed after %d frame(s)\n", frame);
+    port_rom_frame_report();   /* R3a: this loop's frame account, one line */
     const int scene_rc = port_scene_finish(frame);
     /* AFTER the census, so a run that enters the adventure still leaves the
        title's own slot hits, captures and trap counts behind. Answers 0 and
@@ -8333,6 +8357,10 @@ int main(void)
     g_selftest = selftest;
     int focus_was = 1;   /* launch focused = launch unchanged */
     int frame = 0;
+    /* R3a: the ROM's frame state takes over as the harness's frame number from
+       here. `frame` stays, as the cross-check the accessor is measured against
+       and as the loop's own control variable. */
+    port_rom_frame_begin("level loop");
     float cam_yaw = 0.0f;   /* camera heading around Mario, radians */
     float cam_pitch = 0.13f; /* camera tilt above level, radians (R/F) */
     const int trace_cam = getenv("SM64DS_TRACE_CAM") != 0;
@@ -13176,11 +13204,23 @@ int main(void)
         /* ROLLBACK NETCODE (hal/rollback.cpp): snapshot this frame's world,
            and if the wire has contradicted a round already played, restore
            that round's world, rewind `frame` and re-run to the present. */
+        const int rb_frame_was = frame;
         rb_frame_end(&frame, selftest);
         /* the rollback feasibility probe: snapshot timing and the restore-and-
            re-run determinism check, at the same boundary. It may rewind
            `frame` for the re-run. Inert without its env knobs. */
         rb_probe_frame_end(&frame, selftest);
+        /* the one place the host counter legitimately moves on its own; the
+           ROM's frame number is re-anchored with it rather than tripping the
+           cross-check. Inert unless rollback mode is on. */
+        if (frame != rb_frame_was) port_rom_frame_rewind(frame);
+        /* THE ROM'S PHASE 6, func_020197b8.c:49-50: `data_0209d50c = 6` and the
+           frame step. Here because this is the frame boundary -- the frame's
+           work is done and nothing of the next has started -- which is where
+           the ROM's loop runs it. The second statement's blink half stays in
+           hal/fader_wipes.cpp at its own point under its own tick gate; this
+           file does not move it. Under R3d this call is func_020197b8's line. */
+        port_rom_frame_phase6();
         ++frame;   /* counts in live mode too -- the [cam-in]-style live
                       diagnostics carry a real frame number */
         /* SM64DS_MENU_AT: arm the freeze once the named frame is reached. It
@@ -13298,6 +13338,11 @@ int main(void)
                         frame);
             printf("selftest: %d frames, pos=(%d, %d, %d)\n", frame,
                    *(int *)(c + 0x5c), *(int *)(c + 0x60), *(int *)(c + 0x64));
+            /* R3a: the frame account this run ends on -- how many reads went
+               through the ROM's frame state, and the measured gap between its
+               phase-6 step count and the blink clock's. One line per run so a
+               battery row's log can be grepped for it. */
+            port_rom_frame_report();
             return 0;
         }
         /* THE PACE. Stage::InitResources writes data_0208ee44 = 2 for a 3D


### PR DESCRIPTION
Lane R3A of run link100, gated on the integration tip 2962e3ada and folded by fast-forward (port/link100 = b99310a89).

What changed: a new hal/rom_frame.cpp hosts the ROM's phase id data_0209d50c for the first time (inside the DSSTATE bracket; dsstate_guard refused plain .bss and was right), runs the ROM's phase 6 (frame counter advance) at both host loops' frame boundaries, and gives the harness one accessor that reads the ROM frame state cross-checked against the host counter (SM64DS_FRAME_CROSSCHECK, default on, exit 90 on disagreement). 24 harness reader sites in walk_window.cpp now go through it (13 level, 8 scene, plus derived). No seam moved: port_frame_clock_tick's call site is byte-identical.

Count: 10163 of 11328 before and after, zero by design (the ROM's phase 6 is two inline statements in func_020197b8, not a callable TU). This rung is the prerequisite for handing the frame to the ROM's own loop (R3b..R3d, +72).

Evidence (lane report, out/R3A/): battery ALL GREEN at floor 10163 (21 smokes, 51 levels, 36 scenes, default boot TITLE, ptr_audit 0, shipcfg ok); guards inferred_stub/alternatename/closestplayer/gxband/tailjump OK; six proofs green (ipc 15/0, thread, thread_create, save, tail2 OPENING GATE PASS 363 over 2474..3999 byte-identical to baseline, scene_bootpair 34 rungs); the cross-check sweep over all 51 battery levels: 15300 frames, 122502 reads verified, 0 mismatches; a windowed scene run 1501 reads, 0 disagreements.

One hunk outside the lane's owned files: port/CMakeLists.txt +17, the enrolment block for hal/rom_frame.cpp under the rom_main block.