### PR TITLE
Parse CMake symbol lists and recognize explicit HAL definitions

### DIFF
--- a/tools/port_refcheck.py
+++ b/tools/port_refcheck.py
@@ -35,7 +35,9 @@ CHECKS
                  alias or target of a `#pragma comment(linker,
                  "/alternatename:...")`, or as an extern "C" declaration, in
                  port/hal/*.cpp still appears (as an identifier) somewhere
-                 under src/ or include/.
+                 under src/ or include/, or has an unconditional, externally
+                 linked C definition in port/hal/*.cpp. This is reference
+                 integrity, not proof that every host target links.
 
 Scope note on check 3: only bare func_/data_ address-style names are
 checked (the ones a src/ rename can actually break). Itanium-mangled names
@@ -55,6 +57,7 @@ The JSON report is the stable contract behind tools/validate_merge.py's
 grouped under `checks` for a human reading the file directly.
 """
 import argparse
+from dataclasses import dataclass
 import json
 import pathlib
 import re
@@ -77,8 +80,7 @@ IDENT_CORE = r"(?:func|data)_(?:ov\d+_)?[0-9a-fA-F]{8}"
 IDENT_FULL_RE = re.compile(r"^" + IDENT_CORE + r"$")
 IDENT_SCAN_RE = re.compile(r"\b" + IDENT_CORE + r"\b")
 
-SET_SYMS_RE = re.compile(r"\bset\(\s*(\w+_SYMS)\b(.*?)\)", re.DOTALL)
-PRAGMA_RE = re.compile(r'#pragma\s+comment\(\s*linker\s*,\s*"(/alternatename:[^"]*)"\s*\)')
+PRAGMA_RE = re.compile(r'^[ \t]*#pragma\s+comment\(\s*linker\s*,\s*"(/alternatename:[^"]*)"\s*\)', re.MULTILINE)
 EXTERN_C_RE = re.compile(r'extern\s*"C"')
 
 
@@ -99,28 +101,129 @@ def _line_at(text, pos):
     return text.count("\n", 0, pos) + 1
 
 
+# C/C++ literals are single tokens: comment markers or braces inside them must
+# not change linkage scope. Raw strings occur in host code too.
+CPP_TOKEN_RE = re.compile(
+    r'/\*.*?\*/|//(?:\\\r?\n|[^\n])*|(?:u8|[uUL])?R"([^ ()\\\t\r\n]*)\(.*?\)\1"'
+    r'|(?:u8|[uUL])?"(?:\\.|[^"\\])*"'
+    r"|(?:[uUL])?'(?:\\.|[^'\\])*'"
+    r'|[A-Za-z_]\w*|[^\s]', re.DOTALL)
+
+
+@dataclass(frozen=True)
+class Token:
+    value: str
+    pos: int
+    punctuation: bool = False
+
+
+def _blank(text):
+    return "".join("\n" if c == "\n" else " " for c in text)
+
+
 def _mask_comments(text):
-    """Blank out // and /* */ comment interiors, preserving length and
-    newlines, so brace-matching and keyword search never trip over prose
-    like "the extern \"C\" side of..." inside a comment."""
-    out = []
-    i, n = 0, len(text)
-    while i < n:
-        c = text[i]
-        if c == "/" and i + 1 < n and text[i + 1] == "/":
-            j = text.find("\n", i)
-            j = n if j == -1 else j
-            out.append(" " * (j - i))
-            i = j
-        elif c == "/" and i + 1 < n and text[i + 1] == "*":
-            j = text.find("*/", i + 2)
-            j = n if j == -1 else j + 2
-            out.append("".join(ch if ch == "\n" else " " for ch in text[i:j]))
-            i = j
-        else:
-            out.append(c)
+    return CPP_TOKEN_RE.sub(
+        lambda m: _blank(m.group()) if m.group().startswith(("//", "/*"))
+        else m.group(), text)
+
+
+def _mask_literals(text, keep_linkage=False):
+    def replace(match):
+        value = match.group()
+        if keep_linkage and value == '"C"':
+            return value
+        return _blank(value) if '"' in value or "'" in value else value
+    return CPP_TOKEN_RE.sub(replace, text)
+
+
+def _cmake_tokens(text):
+    """Lex CMake arguments without interpreting variables or executing CMake.
+
+    In particular, # comments (including bracket comments), quoted/bracket
+    arguments and escaped delimiters cannot terminate a set() command.
+    Positions refer to the original text for actionable diagnostics.
+    """
+    i = 0
+    while i < len(text):
+        if text[i].isspace():
             i += 1
-    return "".join(out)
+            continue
+        start = i
+        comment = text[i] == "#"
+        bracket = re.match(r"\[(=*)\[", text[i + int(comment):])
+        if bracket:
+            content = i + int(comment) + len(bracket.group())
+            close = "]" + bracket.group(1) + "]"
+            end = text.find(close, content)
+            if end < 0:
+                raise ValueError(f"line {_line_at(text, start)}: unterminated bracket argument")
+            if not comment:
+                value = text[content:end]
+                if value.startswith("\n"):
+                    value = value[1:]  # CMake ignores the first bracket newline
+                yield Token(value, start)
+            i = end + len(close)
+        elif comment:
+            end = text.find("\n", i)
+            i = len(text) if end < 0 else end
+        elif text[i] in "()":
+            yield Token(text[i], i, punctuation=True)
+            i += 1
+        else:
+            quoted = text[i] == '"'
+            if quoted:
+                i += 1
+            chars = []
+            while i < len(text):
+                ch = text[i]
+                if quoted and ch == '"':
+                    i += 1
+                    break
+                if not quoted and (ch.isspace() or ch in "()#"):
+                    break
+                if ch == "\\" and i + 1 < len(text):
+                    i += 1
+                    ch = text[i]
+                    if ch == "\n":
+                        i += 1
+                        continue
+                    if ch == ";" and quoted:
+                        chars.append("\\")  # preserved until foreach list expansion
+                    ch = {"n": "\n", "r": "\r", "t": "\t"}.get(ch, ch)
+                chars.append(ch)
+                i += 1
+            else:
+                if quoted:
+                    raise ValueError(f"line {_line_at(text, start)}: unterminated quoted argument")
+            # Empty arguments initialize an empty symbol list, not a source name.
+            yield Token("".join(chars), start)
+
+
+def _cmake_symbol_lists(text):
+    tokens = list(_cmake_tokens(text))
+    i = 0
+    while i + 1 < len(tokens):
+        if not tokens[i + 1].punctuation or tokens[i + 1].value != "(":
+            i += 1
+            continue
+        command = tokens[i].value.lower()
+        depth, j = 1, i + 2
+        while j < len(tokens) and depth:
+            if tokens[j].punctuation:
+                depth += (tokens[j].value == "(") - (tokens[j].value == ")")
+            j += 1
+        if depth:
+            raise ValueError(f"line {_line_at(text, tokens[i].pos)}: unterminated command")
+        args = tokens[i + 2:j - 1]
+        if command == "set" and args and re.fullmatch(r"\w+_SYMS", args[0].value):
+            for arg in args[1:]:
+                # A symbol-list value is subsequently expanded by foreach(IN
+                # LISTS ...), so quoted semicolon lists contain multiple names.
+                for name in re.split(r"(?<!\\);", arg.value):
+                    name = name.replace(r"\;", ";")
+                    if name:
+                        yield args[0].value, Token(name, arg.pos)
+        i = j
 
 
 # ---- check 1: slice manifests -----------------------------------------------
@@ -161,22 +264,22 @@ def check_cmake_symbols():
         return 0, [Failure(rel, 0, "CMakeLists.txt not found")]
 
     text = cmake.read_text(encoding="utf-8", errors="ignore")
-    masked = _mask_comments(text)
     failures = []
     checked = 0
-    for m in SET_SYMS_RE.finditer(masked):
-        list_name = m.group(1)
-        body_start = m.start(2)
-        for tok in re.finditer(r"\S+", m.group(2)):
-            sym = tok.group(0)
-            checked += 1
-            lineno = _line_at(text, body_start + tok.start())
-            resolved = SP.path_for(sym)
-            if resolved is None or not resolved.is_file():
-                failures.append(Failure(
-                    rel, lineno,
-                    f"symbol '{sym}' ({list_name}) has no enrolled or "
-                    "convention-named src/ owner (renamed?)"))
+    try:
+        symbols = list(_cmake_symbol_lists(text))
+    except ValueError as exc:
+        return 0, [Failure(rel, 0, f"cannot parse CMake symbol lists: {exc}")]
+    for list_name, tok in symbols:
+        sym = tok.value
+        checked += 1
+        lineno = _line_at(text, tok.pos)
+        resolved = SP.path_for(sym)
+        if resolved is None or not resolved.is_file():
+            failures.append(Failure(
+                rel, lineno,
+                f"symbol '{sym}' ({list_name}) has no enrolled or "
+                "convention-named src/ owner (renamed?)"))
     return checked, failures
 
 
@@ -248,6 +351,203 @@ def _extern_c_spans(masked_text):
     return spans
 
 
+def _defined_macro_names(texts):
+    """Known remappings cannot prove ownership of the unexpanded spelling."""
+    return {m.group(1) for text in texts for m in re.finditer(
+        r"^\s*#\s*define\s+(\w+)", _mask_comments(text), re.MULTILINE)}
+
+
+def _pragma_only_macros(texts):
+    """Recognize section-marker macros by their expansion, never by name.
+
+    HAL uses object-like macros containing only __pragma(...) statements.
+    These cannot introduce storage/linkage or a C++ scope. Any conflicting
+    definition or #undef disqualifies a name; no general macro expansion is
+    attempted here.
+    """
+    candidates, rejected = set(), set()
+    for text in texts:
+        joined = re.sub(r"\\\r?\n", "", _mask_comments(text))
+        for line in joined.splitlines():
+            match = re.match(r"\s*#\s*(define|undef)\s+(\w+)(.*)", line)
+            if not match:
+                continue
+            directive, name, tail = match.groups()
+            if directive == "undef" or tail.startswith("("):
+                rejected.add(name)
+                continue
+            # Literals can contain parentheses; match the token structure.
+            values = [m.group() for m in CPP_TOKEN_RE.finditer(tail)]
+            i, valid = 0, bool(values)
+            while valid and i < len(values):
+                if values[i:i + 2] != ["__pragma", "("]:
+                    valid = False
+                    break
+                i, depth = i + 2, 1
+                while i < len(values) and depth:
+                    depth += (values[i] == "(") - (values[i] == ")")
+                    i += 1
+                valid = depth == 0
+            (candidates if valid else rejected).add(name)
+    return candidates - rejected
+
+
+def _host_c_definitions(text, pragma_macros=(), defined_macros=()):
+    """Find simple, unconditional, externally linked HAL definitions.
+
+    This is a reference gate, not a C++ compiler or a host link proof. Be
+    conservative: declarations alone, function-local storage, class members,
+    anonymous namespaces, static/const or unknown-type storage and conditional definitions do
+    not supply a missing src/ name. C++-decorated aliases are not satisfied by
+    a C definition. Unknown declaration forms remain unresolved.
+    """
+    # Do not promote a definition from an unevaluated preprocessor branch to
+    # an unconditional owner. Still scan such code for references elsewhere.
+    lines = []
+    depth = 0
+    continuation = False
+    for line in _mask_comments(text).splitlines(keepends=True):
+        directive = re.match(r"\s*#\s*(\w+)", line)
+        if directive and directive.group(1) in ("if", "ifdef", "ifndef"):
+            depth += 1
+        masked = depth > 0 or directive or continuation
+        if directive and directive.group(1) == "endif":
+            depth = max(0, depth - 1)
+        continuation = bool((directive or continuation) and line.rstrip().endswith("\\"))
+        lines.append(_blank(line) if masked else line)
+    tokens = [Token(m.group(), m.start())
+              for m in CPP_TOKEN_RE.finditer("".join(lines))
+              if m.group() not in pragma_macros]
+    owners = {}
+    remapped = set(defined_macros) | _defined_macro_names([text])
+
+    def close_group(i, end):
+        closing = {"(": ")", "[": "]", "{": "}"}[tokens[i].value]
+        i += 1
+        while i < end:
+            if tokens[i].value == closing:
+                return i + 1
+            if tokens[i].value in ("(", "[", "{"):
+                i = close_group(i, end)
+            else:
+                i += 1
+        return end
+
+    def declaration(decl, c_linkage, body=False):
+        values = [t.value for t in decl]
+        if values[:2] == ["extern", '"C++"']:
+            return
+        single_linkage = values[:2] == ["extern", '"C"']
+        if single_linkage:
+            decl, values = decl[2:], values[2:]
+        if not (c_linkage or single_linkage) or not values:
+            return
+        if any(v in values for v in ("static", "typedef", "using", "namespace", "class", "struct", "union", ":")):
+            return
+        # File-scope const can have internal linkage; without a compiler do
+        # not infer exceptions or qualifiers hidden by macros/typedefs.
+        if "const" in values and "extern" not in values:
+            return
+        external_decl = single_linkage or "extern" in values
+        # Identify declarators, never identifiers in parameter lists, array
+        # bounds or initializer expressions. Common plain scalar/array and
+        # pointer declarations cover the HAL's hosted data tables.
+        nesting = 0
+        initializer = False
+        for i, tok in enumerate(decl):
+            value = tok.value
+            if value in ("(", "[", "{"):
+                nesting += 1
+            elif value in (")", "]", "}"):
+                nesting -= 1
+            elif value == "," and nesting == 0:
+                initializer = False
+            elif value == "=" and nesting == 0:
+                initializer = True
+            elif (nesting == 0 and not initializer
+                  and IDENT_FULL_RE.fullmatch(value) and value not in remapped):
+                following = values[i + 1] if i + 1 < len(values) else ";"
+                if i == 0 or values[i - 1] in ("::", ".", "=", "return"):
+                    continue
+                if following == "(":
+                    # A C language-linkage block does not override static
+                    # storage or x86 calling-convention decoration hidden by
+                    # a prefix macro. Only explicit cdecl-compatible prefixes
+                    # can supply the cdecl spelling checked by this gate.
+                    prefix = set(values[:i])
+                    if not prefix <= {"extern", "signed", "unsigned", "char",
+                                      "short", "int", "long", "float", "double",
+                                      "bool", "void", "volatile", "const", "*",
+                                      "__cdecl"} or prefix & remapped:
+                        continue
+                    if body:
+                        owners[value] = tok.pos
+                elif not body and following in ("[", "=", ",", ";"):
+                    # An unknown typedef or macro might hide const/internal
+                    # storage. Accept fundamental types/pointers/arrays only;
+                    # a compiler-backed owner index can extend this later.
+                    type_end = next((k for k, v in enumerate(values)
+                                     if IDENT_FULL_RE.fullmatch(v)), len(values))
+                    if not set(values[:type_end]) <= {
+                            "extern", "signed", "unsigned", "char", "short",
+                            "int", "long", "float", "double", "bool", "void",
+                            "volatile", "const", "*"} or set(values[:type_end]) & remapped:
+                        continue
+                    # An extern with initializer is a definition; an extern
+                    # without initializer (including extern "C" T x;) is not.
+                    j = i + 1
+                    balance = 0
+                    initialized = False
+                    while j < len(values):
+                        v = values[j]
+                        if v in ("[", "(", "{"):
+                            balance += 1
+                        elif v in ("]", ")", "}"):
+                            balance -= 1
+                        if balance == 0 and v == ",":
+                            break
+                        if balance == 0 and v == "=":
+                            initialized = True
+                        j += 1
+                    if not external_decl or initialized:
+                        owners[value] = tok.pos
+
+    def scope(start, end, c_linkage=False):
+        i = start
+        while i < end:
+            if (i + 2 < end and tokens[i].value == "extern"
+                    and tokens[i + 1].value in ('"C"', '"C++"')
+                    and tokens[i + 2].value == "{"):
+                after = close_group(i + 2, end)
+                scope(i + 3, after - 1, tokens[i + 1].value == '"C"')
+                i = after
+                continue
+            j = i
+            while j < end and tokens[j].value != ";":
+                if tokens[j].value in ("(", "["):
+                    j = close_group(j, end)
+                elif tokens[j].value == "{":
+                    after = close_group(j, end)
+                    prefix = [t.value for t in tokens[i:j]]
+                    if "=" not in prefix:
+                        # A function definition ends with its body. Other
+                        # scopes (class/namespace) cannot provide C owners.
+                        if prefix and prefix[-1] == ")":
+                            declaration(tokens[i:j], c_linkage, body=True)
+                        j = after
+                        break
+                    j = after  # brace initializer; keep the declarator
+                else:
+                    j += 1
+            if j < end and tokens[j].value == ";":
+                declaration(tokens[i:j], c_linkage)
+                j += 1
+            i = max(i + 1, j)
+
+    scope(0, len(tokens))
+    return owners
+
+
 def _scan_symbol_index():
     """Pure-Python fallback: every func_/data_ token under src/ or include/,
     built by reading every file. Correct but slow (~1s+ on this corpus) --
@@ -294,7 +594,8 @@ def _present(names):
 def check_hal_links():
     """#pragma alternatename aliases/targets and extern "C" declarations of
     func_/data_ names in port/hal/*.cpp must still name something that
-    exists in src/ or include/."""
+    exists in src/ or include/, or has a proven unconditional C-linkage
+    host definition. Extern-only declarations cannot supply an owner."""
     hal_dir = PORT / "hal"
     if not hal_dir.is_dir():
         return 0, [Failure("port/hal", 0, "hal directory not found")]
@@ -302,13 +603,22 @@ def check_hal_links():
     # Pass 1: collect every candidate reference without checking existence
     # yet, so all the (few hundred) names can be looked up in one batched
     # `git grep` pass instead of one lookup each.
-    refs = []  # (rel, lineno, name, message)
+    refs = []  # (rel, lineno, name, message, C linkage)
+    host_owners = set()
+    texts = {p: p.read_text(encoding="utf-8", errors="ignore")
+             for p in sorted(hal_dir.iterdir()) if p.suffix in CODE_SUFFIXES}
+    pragma_macros = _pragma_only_macros(texts.values())
+    defined_macros = _defined_macro_names(texts.values())
     for path in sorted(hal_dir.glob("*.cpp")):
         rel = path.relative_to(REPO).as_posix()
-        text = path.read_text(encoding="utf-8", errors="ignore")
+        text = texts[path]
         masked = _mask_comments(text)
+        host_owners.update(_host_c_definitions(text, pragma_macros, defined_macros))
 
-        for m in PRAGMA_RE.finditer(masked):
+        pragma_text = CPP_TOKEN_RE.sub(
+            lambda m: _blank(m.group()) if re.match(r'(?:u8|[uUL])?R"', m.group())
+            else m.group(), masked)
+        for m in PRAGMA_RE.finditer(pragma_text):
             lineno = _line_at(text, m.start())
             body = m.group(1)[len("/alternatename:"):]
             alias, _, target = body.partition("=")
@@ -319,22 +629,25 @@ def check_hal_links():
                 refs.append((rel, lineno, core,
                               f"alternatename references '{core}' (from "
                               f"'{spelling.strip()}'), not found in src/ or "
-                              f"include/ (renamed?)"))
+                              f"include/ or an unconditional C-linkage HAL definition "
+                              f"(renamed?)", not spelling.strip().removeprefix("__imp_").startswith("?")))
 
-        for start, end in _extern_c_spans(masked):
-            for m in IDENT_SCAN_RE.finditer(masked, start, end):
+        code = _mask_literals(masked)
+        for start, end in _extern_c_spans(_mask_literals(masked, keep_linkage=True)):
+            for m in IDENT_SCAN_RE.finditer(code, start, end):
                 name = m.group(0)
                 lineno = _line_at(text, m.start())
                 refs.append((rel, lineno, name,
-                             f'extern "C" declares \'{name}\', not found in '
-                             f"src/ or include/ (renamed?)"))
+                             f'extern "C" references \'{name}\', not found in '
+                             f"src/ or include/ or an unconditional C-linkage HAL "
+                             f"definition (renamed?)", True))
 
     # Pass 2: one batched presence check, then report.
-    present = _present(name for _, _, name, _ in refs)
+    present = _present(name for _, _, name, _, _ in refs)
     failures = []
     seen = set()  # (file, name) already reported, so a name isn't repeated
-    for rel, lineno, name, message in refs:
-        if name in present:
+    for rel, lineno, name, message, c_linkage in refs:
+        if name in present or (c_linkage and name in host_owners):
             continue
         key = (rel, name)
         if key in seen:

--- a/tools/test_port_refcheck.py
+++ b/tools/test_port_refcheck.py
@@ -1,0 +1,260 @@
+"""Reference parsing must reject stale names without inventing references."""
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import port_refcheck as P
+
+
+class PortRefcheck(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = pathlib.Path(self.tmp.name)
+        self.port = self.repo / 'port'
+        (self.port / 'hal').mkdir(parents=True)
+        (self.repo / 'src').mkdir()
+        self.stack = mock.patch.multiple(P, REPO=self.repo, PORT=self.port,
+                                         SRC_DIRS=[self.repo / 'src'])
+        self.stack.start()
+        self.addCleanup(self.stack.stop)
+
+    def write(self, path, text):
+        path.write_text(text, encoding='utf-8')
+        return path
+
+    def cmake(self, text, existing=()):
+        self.write(self.port / 'CMakeLists.txt', text)
+        owners = {name: self.write(self.repo / 'src' / (name + '.cpp'), '')
+                  for name in existing}
+        with mock.patch.object(P.SP, 'path_for', side_effect=owners.get):
+            return P.check_cmake_symbols()
+
+    def hal(self, files):
+        for name, text in files.items():
+            self.write(self.port / 'hal' / name, text)
+        with mock.patch.object(P, '_present', return_value=set()):
+            return P.check_hal_links()
+
+    def test_cmake_historical_comments_and_empty_initializer(self):
+        count, failures = self.cmake('''
+set(GATE10_SYMS first
+    # Three Player state functions (not source symbols)
+    second # a comment with an early closing parenthesis )
+    third)
+set(ACTOR_OV_SYMS "")
+''', ('first', 'second', 'third'))
+        self.assertEqual((count, failures), (3, []))
+
+    def test_cmake_quotes_brackets_escape_and_real_missing(self):
+        count, failures = self.cmake('''
+#[=[ set(IGNORED_SYMS invented) ]=]
+SET(GATE_SYMS "first;second" [=[third]=]
+    "missing" # remains an error, even after a comment
+    )
+set(OTHER "set(FAKE_SYMS invented)")
+''', ('first', 'second', 'third'))
+        self.assertEqual(count, 4)
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].line, 4)
+        self.assertIn("'missing'", failures[0].message)
+        # Literal parentheses inside arguments do not end the command.
+        values = list(P._cmake_symbol_lists(r'set(X_SYMS "(" escaped\) last)'))
+        self.assertEqual([t.value for _, t in values], ['(', 'escaped)', 'last'])
+
+    def test_cmake_unterminated_input_fails_closed(self):
+        for text in ('set(X_SYMS "broken)', 'set(X_SYMS [=[broken)', 'set(X_SYMS first'):
+            with self.subTest(text=text):
+                _, failures = self.cmake(text)
+                self.assertEqual(len(failures), 1)
+                self.assertIn('cannot parse', failures[0].message)
+
+    def test_cmake_variable_not_silently_accepted(self):
+        count, failures = self.cmake('set(X_SYMS ${UNRESOLVED})')
+        self.assertEqual(count, 1)
+        self.assertEqual(len(failures), 1)
+
+    def test_host_definitions_resolve_cross_file_reference(self):
+        self.write(self.port / "hal" / "sections.h",
+                   '#define DSSTATE_BEGIN __pragma(data_seg("sample"))\n'
+                   '#define DSSTATE_END __pragma(data_seg())\n')
+        count, failures = self.hal({
+            'owner.cpp': '''extern "C" {
+DSSTATE_BEGIN
+unsigned char data_02086e78[0xc];
+int data_02086e80 = 7, data_02086e84[3];
+void *data_02086e88[1] = {data_02086e78};
+DSSTATE_END
+}
+extern "C" int data_02086e90 = 2;
+extern "C" void func_02000000() {}
+''',
+            'user.cpp': '''extern "C" unsigned char data_02086e78[];
+#pragma comment(linker, "/alternatename:_data_02086e78=_data_02086e90")
+extern "C" void func_02000000();
+''',
+        })
+        self.assertGreater(count, 6)
+        self.assertEqual(failures, [])
+
+    def test_externs_and_initializer_references_are_not_definitions(self):
+        _, failures = self.hal({'externs.cpp': '''extern "C" {
+extern int data_02000000;
+extern int data_02000004[], data_02000008[];
+int *data_0200000c = &data_02000010;
+void func_02000014();
+}
+extern "C" int data_02000018;
+'''})
+        names = {message.message.split("'")[1] for message in failures}
+        self.assertEqual(names, {'data_02000000', 'data_02000004',
+                                 'data_02000008', 'data_02000010',
+                                 'func_02000014', 'data_02000018'})
+
+    def test_non_external_owners_and_wrong_linkage_remain_missing(self):
+        owners = '''extern "C" {
+static int data_02000000;
+const int data_02000004 = 0;
+void helper() { int data_02000008 = 0; }
+struct Fake { int data_0200000c; };
+typedef int data_02000010;
+#if 0
+int data_02000014;
+#endif
+#ifdef UNKNOWN_BUILD_OPTION
+int data_02000018;
+#endif
+}
+namespace { extern "C" { int data_0200001c; } }
+int data_02000020;
+'''
+        self.assertEqual(P._host_c_definitions(owners), {})
+        names = [f'data_{n:08x}' for n in range(0x02000000, 0x02000024, 4)]
+        _, failures = self.hal({'owner.cpp': owners, 'user.cpp': '\n'.join(
+            f'extern "C" int {name};' for name in names)})
+        self.assertEqual({f.message.split("'")[1] for f in failures
+                          if f.file.endswith('user.cpp')}, set(names))
+
+    def test_c_owner_does_not_satisfy_cpp_decorated_alias(self):
+        _, failures = self.hal({'owner.cpp': '''extern "C" { int data_02000000; }
+#pragma comment(linker, "/alternatename:?data_02000000@@3HA=_data_02000000")
+'''})
+        self.assertEqual(len(failures), 1)
+        self.assertIn('?data_02000000@@3HA', failures[0].message)
+
+    def test_comments_and_strings_are_neither_owners_nor_references(self):
+        text = r'''// extern "C" int data_02000000;
+/* extern "C" { int data_02000004; } */
+const char *url = "https://example.invalid/";
+const char *raw = R"tag(extern "C" { int data_02000008; })tag";
+extern "C" {
+void helper() {
+    const char *text = "data_0200000c } // comment";
+    char ch = '}';
+}
+extern int data_02000010;
+}
+'''
+        self.assertEqual(P._host_c_definitions(text), {})
+        _, failures = self.hal({'strings.cpp': text})
+        self.assertEqual(len(failures), 1)
+        self.assertIn('data_02000010', failures[0].message)
+
+    def test_unresolved_alias_target_is_not_supplied_by_alias_source(self):
+        _, failures = self.hal({'owner.cpp': '\n'.join([
+            'extern "C" { int data_02000000; }',
+            '#pragma comment(linker, "/alternatename:_data_02000000=_data_02000004")',
+        ])})
+        self.assertEqual(len(failures), 1)
+        self.assertIn('data_02000004', failures[0].message)
+
+    def test_only_proven_pragma_macros_may_prefix_linkage_block(self):
+        header = '#define SECTION __pragma(data_seg("sample"))\n'
+        source = 'SECTION\nextern "C" { int data_02000000; }\n'
+        macros = P._pragma_only_macros([header, source])
+        self.assertEqual(macros, {'SECTION'})
+        self.assertEqual(set(P._host_c_definitions(source, macros)), {'data_02000000'})
+        self.assertFalse(P._pragma_only_macros([header, '#define SECTION static\n']))
+        self.assertFalse(P._pragma_only_macros([header, '#undef SECTION\n']))
+        self.assertFalse(P._pragma_only_macros(['#define HIDDEN int data_02000000;\n']))
+        self.write(self.port / 'hal' / 'sections.h', header)
+        self.assertEqual(self.hal({'owner.cpp': source})[1], [])
+
+    def test_cmake_semicolon_escaping_matches_foreach_lists(self):
+        # Measured with CMake -P: quoted/bracket escape survives set(), while
+        # an unquoted escaped semicolon is unescaped before list expansion.
+        text = r'''set(A_SYMS "one\;two" "three;four")
+set(B_SYMS one\;two)
+set(C_SYMS [=[
+one\;two]=])'''
+        values = [(name, token.value) for name, token in P._cmake_symbol_lists(text)]
+        self.assertEqual(values, [('A_SYMS', 'one;two'), ('A_SYMS', 'three'),
+                                  ('A_SYMS', 'four'), ('B_SYMS', 'one'),
+                                  ('B_SYMS', 'two'), ('C_SYMS', 'one;two')])
+
+    def test_raw_string_cannot_forge_linker_directive(self):
+        text = '\n'.join(['const char *text = R"tag(',
+            '#pragma comment(linker, "/alternatename:_data_02000000=_data_02000004")',
+            ')tag";'])
+        self.assertEqual(self.hal({'strings.cpp': text}), (0, []))
+
+    def test_unknown_storage_type_and_explicit_cpp_linkage_are_not_c_owners(self):
+        text = '\n'.join([
+            'typedef const int Hidden;',
+            'extern "C" { Hidden data_02000000 = 3; }',
+            'extern "C" { extern "C++" int data_02000004 = 4; }',
+            'extern "C" { int Namespace::data_02000008 = 5; }',
+        ])
+        self.assertEqual(P._host_c_definitions(text), {})
+
+    def test_imported_cpp_decoration_does_not_accept_c_owner(self):
+        _, failures = self.hal({'owner.cpp': '\n'.join([
+            'extern "C" { int data_02000000; }',
+            '#pragma comment(linker, "/alternatename:__imp_?data_02000000@@3HA=_data_02000000")',
+        ])})
+        self.assertEqual(len(failures), 1)
+        self.assertIn('__imp_?data_02000000@@3HA', failures[0].message)
+
+    def test_continued_line_comment_cannot_define_or_reference_owner(self):
+        text = '// continued ' + chr(92) + '\nextern "C" { int data_02000000; }\n'
+        self.assertEqual(P._host_c_definitions(text), {})
+        self.assertEqual(self.hal({'comment.cpp': text}), (0, []))
+
+    def test_function_storage_macros_and_non_cdecl_conventions_are_not_owners(self):
+        for text in (
+                '#define LOCAL static\nextern "C" LOCAL void func_02000000() {}',
+                'extern "C" void __stdcall func_02000000() {}',
+                '#define SPECIAL __stdcall\nextern "C" SPECIAL void func_02000000() {}',
+                '#define void static void\nextern "C" void func_02000000() {}'):
+            with self.subTest(text=text):
+                self.assertEqual(P._host_c_definitions(text), {})
+        self.assertEqual(set(P._host_c_definitions(
+            'extern "C" void __cdecl func_02000000() {}')), {'func_02000000'})
+
+    def test_identifier_macro_remapping_cannot_supply_unexpanded_name(self):
+        text = '#define data_02000000 host_data\nextern "C" { int data_02000000; }'
+        self.assertEqual(P._host_c_definitions(text), {})
+        self.write(self.port / 'hal' / 'remap.h',
+                   '#define func_02000000 host_function\n')
+        _, failures = self.hal({'owner.cpp': 'extern "C" void func_02000000() {}'})
+        self.assertEqual(len(failures), 1)
+        self.assertIn('func_02000000', failures[0].message)
+
+    def test_pragma_failure_points_to_directive_not_previous_comment(self):
+        _, failures = self.hal({'owner.cpp': '\n'.join([
+            '// explanatory comment', '',
+            '#pragma comment(linker, "/alternatename:_data_02000000=_data_02000004")',
+        ])})
+        self.assertEqual([f.line for f in failures], [3, 3])
+
+    def test_decomp_owner_still_resolves(self):
+        self.write(self.port / 'hal' / 'user.cpp', 'extern "C" int data_02000000;')
+        with mock.patch.object(P, '_present', return_value={'data_02000000'}):
+            self.assertEqual(P.check_hal_links(), (1, []))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes false port-reference failures caused by CMake comments and HAL-owned symbols. The old whitespace/parenthesis scan treated comment prose and empty list initializers as source names, and the HAL scan could reject a symbol actually defined by the host.

CMake symbol lists now use lexical arguments, preserving comments, quotes, bracket arguments, escapes and semicolon-list behavior. Malformed inputs and unresolved variable expressions remain failures. The HAL check recognizes a limited set of unconditional C definitions, while retaining failures for declaration-only references, incompatible linkage, hidden storage/calling conventions, conditional definitions and known macro remappings. Comments and literals cannot supply references or owners. This is reference checking; it does not establish that every host target links.

Independent validation of `ec0a304c0c1f8fedf1796b10bf24ee84329257b6`, based on `224e660ea0219d0999c58483eb2dd9b38991f5ef`:

- 20 parser regression tests, 73 merge-validation consumer tests and four TU compatibility tests pass.
- Current-main port references: 423 checked, zero failures.
- Historical port candidate `404af352a70ebee5fef62af629bb8afb774a9691`: the checker removes 71 CMake parsing errors and 39 HAL errors backed by explicit definitions. It still fails on 137 unresolved references; no baseline exception or hook bypass is introduced.

The remaining historical findings include generator-input leads that have not been accepted as emitted owners and a stale Enemy constructor fallback spelling. Those require separate resolution before PR #2474 can publish its source correction. This PR changes only the checker and its tests; no game source, port source, hook, baseline or generator input changes.

Refs #2485.
