### PR TITLE
Check fields around inline allocation and accessor methods

### DIFF
--- a/tools/check_header_offsets.py
+++ b/tools/check_header_offsets.py
@@ -109,6 +109,18 @@ DECL = re.compile(r"^\s*(?:(?:struct|union|class|enum)\s+)?((?:\w+::)*[A-Za-z_]\
                   r"((?:\[\s*(?:0x[0-9a-fA-F]+|\d+)\s*\])*)\s*;"
                   r"(?:\s*/\*\s*(0x[0-9a-fA-F]+))?")
 ARR_DIMS = re.compile(r"\[\s*(0x[0-9a-fA-F]+|\d+)\s*\]")
+# A class-local allocation function occupies no instance storage. Recognize only
+# a complete allocation signature here; C++ validity is still the compiler's job.
+# Unlike the generated headers' ordinary method footer, an allocator can appear
+# between fields, so it must not terminate the layout walk.
+ALLOCATION_METHOD = re.compile(
+    r"^\s*(?:static\s+)?void\s*\*\s*operator\s+new\s*(?:\[\s*\]\s*)?"
+    r"\([^();{}]*\)\s*(?:;\s*$|\{|$)")
+# Neighboring named inline methods (for example `const Vector3 &Pos() const {`)
+# need the same body walk. Require a complete signature and a body opener or end
+# of line; do not reinterpret initializers or function-pointer fields as methods.
+INLINE_METHOD = re.compile(
+    r"^\s*(?:[A-Za-z_][\w:<>, &*]*|~\w+)\([^();{}]*\)\s*(?:const\s*)?(?:\{|$)")
 # lines inside a struct body that are legitimately not declarations
 IGNORABLE = re.compile(r"^\s*($|/\*|\*|//|\}|#)")
 
@@ -600,6 +612,7 @@ def main(argv, repo=None):
         skip_body = 0
         await_body = body_comment = False
         await_body_line = None
+        await_complete_signature = False
         unknown_base = derived_from = None
         expected = fp.stem
         all_lines = txt.splitlines()
@@ -686,12 +699,21 @@ def main(argv, repo=None):
                 saw_open = "{" in body_code
                 depth = body_code.count("{") - body_code.count("}")
                 if await_body:
-                    if saw_open:
+                    if (await_complete_signature and body_code.strip()
+                            and not re.match(r"^\s*(?:\{|;\s*$)", body_code)):
+                        # This signature already closed its parameter list. An
+                        # unrelated field cannot be its continuation, even when
+                        # DECL cannot size/parse that field. Report the missing
+                        # body and let the field reach the normal failure path.
+                        skipped.append(await_body_line)
+                        await_body = body_comment = False
+                        await_body_line = None
+                    elif saw_open:
                         await_body = False
                         await_body_line = None
                         skip_body = max(depth, 0)
                         continue
-                    if ";" in body_code:
+                    elif ";" in body_code:
                         # A split declaration, not an inline definition.  A real
                         # field on this line must still reach DECL; otherwise the
                         # pending-method state would create another zero-field pass.
@@ -754,7 +776,10 @@ def main(argv, repo=None):
             # SysTracker in include/Stage.h is the first instance) starts with `~`,
             # which the type-name alternative below never matches (`~` is not in
             # `[A-Za-z_]`), so without this alternative it fell through to UNPARSED.
-            if re.match(r"^\s*(virtual\b|~\w+\s*\([^;]*\)\s*;|[A-Za-z_][\w:<>, &*]*\([^;]*\)\s*(const)?\s*;)", line):
+            method_code, _ = _code_without_comments_or_strings(line)
+            allocation_method = ALLOCATION_METHOD.match(method_code)
+            inline_method = INLINE_METHOD.match(method_code)
+            if allocation_method or inline_method or re.match(r"^\s*(virtual\b|~\w+\s*\([^;]*\)\s*;|[A-Za-z_][\w:<>, &*]*\([^;]*\)\s*(const)?\s*;)", line):
                 # ...unless we started from a base whose size is asserted. A derived
                 # class places no vptr of its own -- it inherits the base's, and the
                 # base's asserted size already counts it. The running offset is sound,
@@ -770,7 +795,9 @@ def main(argv, repo=None):
                 # direction. Once a field HAS been seen, a method line ends the
                 # list as before -- that's the generated-header convention
                 # (Stage.h: fields, then methods).
-                if n == 0:
+                # Recognized allocation/inline methods consume no storage and
+                # resume the walk even when a commented field came before them.
+                if n == 0 or allocation_method or inline_method:
                     body_code, body_comment = _code_without_comments_or_strings(line)
                     saw_open = "{" in body_code
                     depth = body_code.count("{") - body_code.count("}")
@@ -782,6 +809,7 @@ def main(argv, repo=None):
                         # walk treated that `{` as a field and its `}` as the end of
                         # the outer struct, checking none of the fields below it.
                         await_body = True
+                        await_complete_signature = bool(allocation_method or inline_method)
                         await_body_line = f"{lineno}: {line.strip()}"
                     continue
                 break

--- a/tools/test_check_header_offsets.py
+++ b/tools/test_check_header_offsets.py
@@ -760,3 +760,138 @@ class InlineMethodBodyTests(unittest.TestCase):
         rc, out = self._run(broken)
         self.assertEqual(rc, 1, out)
         self.assertIn("2 commented fields, 1 mismatched, 0 unparsed", out)
+
+
+# ------------------------- allocation methods do not occupy or end instance fields
+
+class AllocationMethodTests(unittest.TestCase):
+    def _run(self, members):
+        with tempfile.TemporaryDirectory(prefix="offset_opnew_") as tmp:
+            header = pathlib.Path(tmp) / "Widget.h"
+            header.write_text("struct Widget {\n" + members + "\n};\n",
+                              encoding="utf-8")
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = C.main([str(header)])
+            return rc, out.getvalue()
+
+    def _assert_checked(self, method):
+        rc, out = self._run(
+            "    u32 first; /* 0x000 */\n" + method +
+            "\n    u32 second; /* 0x004 */\n    u16 third; /* 0x008 */")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("3 commented fields, 0 mismatched, 0 unparsed, struct spans 0xa", out)
+
+    def test_allocation_declarations_do_not_end_the_field_walk(self):
+        for method in (
+            "    static void *operator new(unsigned long size);",
+            "    void* operator new(unsigned long);",
+            "    static void *operator new[](unsigned long size);",
+        ):
+            with self.subTest(method=method):
+                self._assert_checked(method)
+
+    def test_inline_allocation_bodies_do_not_end_the_field_walk(self):
+        for method in (
+            "    static void *operator new(unsigned long size) { return Alloc(size); }",
+            "    static void *operator new(unsigned long size) {\n"
+            "        if (size) { return Alloc(size); }\n        return 0;\n    }",
+            "    static void *operator new(unsigned long size)\n"
+            "    {\n        return Alloc(size);\n    }",
+        ):
+            with self.subTest(method=method):
+                self._assert_checked(method)
+
+    def test_braces_in_comments_and_strings_do_not_consume_fields(self):
+        self._assert_checked(
+            "    static void *operator new(unsigned long size) { // }\n"
+            "        /* { } { */\n"
+            '        const char *text = "}";\n'
+            "        return Alloc(size);\n    }")
+
+    def test_an_allocator_before_fields_adds_no_vptr_or_storage(self):
+        rc, out = self._run(
+            "    static void *operator new(unsigned long size) {\n"
+            "        return Alloc(size);\n    }\n"
+            "    u32 first; /* 0x000 */\n    u8 tail; /* 0x004 */")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("2 commented fields, 0 mismatched, 0 unparsed, struct spans 0x5", out)
+
+    def test_a_wrong_offset_on_either_side_still_fails(self):
+        for first, second in (("0x004", "0x004"), ("0x000", "0x008")):
+            with self.subTest(first=first, second=second):
+                rc, out = self._run(
+                    f"    u32 first; /* {first} */\n"
+                    "    static void *operator new(unsigned long size) { return Alloc(size); }\n"
+                    f"    u32 second; /* {second} */")
+                self.assertEqual(rc, 1, out)
+                self.assertIn("2 commented fields, 1 mismatched, 0 unparsed", out)
+
+    def test_unknown_and_malformed_fields_are_not_hidden(self):
+        for field in ("UnknownType mystery;", "u32 mystery[UNKNOWN_BOUND];"):
+            for before in (True, False):
+                with self.subTest(field=field, before=before):
+                    method = "    static void *operator new(unsigned long size) { return Alloc(size); }"
+                    members = field + "\n" + method if before else method + "\n" + field
+                    rc, out = self._run(members + "\n    u32 tail; /* 0x004 */")
+                    self.assertEqual(rc, 1, out)
+                    self.assertIn("UNPARSED", out)
+                    self.assertIn(field, out)
+
+    def test_a_missing_body_does_not_hide_the_following_field(self):
+        rc, out = self._run(
+            "    static void *operator new(unsigned long size)\n"
+            "    u32 first; /* 0x000 */")
+        self.assertEqual(rc, 1, out)
+        self.assertIn("1 commented fields, 0 mismatched, 1 unparsed", out)
+        self.assertIn("operator new", out)
+
+    def test_an_incomplete_signature_is_not_an_allocation_method(self):
+        rc, out = self._run(
+            "    static void *operator new(unsigned long size;\n"
+            "    u32 first; /* 0x000 */")
+        self.assertEqual(rc, 1, out)
+        self.assertIn("UNPARSED", out)
+        self.assertIn("operator new", out)
+
+    def test_a_similarly_named_pointer_is_still_a_field(self):
+        rc, out = self._run(
+            "    void *operator_new; /* 0x000 */\n"
+            "    u32 tail; /* 0x004 */")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("2 commented fields, 0 mismatched, 0 unparsed, struct spans 0x8", out)
+
+    def test_the_neighboring_inline_accessor_also_preserves_fields(self):
+        self._assert_checked(
+            "    static void *operator new(unsigned long size) { return Alloc(size); }\n"
+            "    const Vector3 &Pos() const {\n"
+            "        return *reinterpret_cast<const Vector3 *>(&mPosX);\n    }")
+
+    def test_a_named_allman_method_also_preserves_fields(self):
+        self._assert_checked(
+            "    int Value() const\n    {\n        return 0;\n    }")
+
+    def test_unknown_and_malformed_fields_cannot_complete_a_missing_body(self):
+        for field in ("UnknownType mystery;", "u32 mystery[UNKNOWN_BOUND];"):
+            with self.subTest(field=field):
+                rc, out = self._run(
+                    "    static void *operator new(unsigned long size)\n" + field)
+                self.assertEqual(rc, 1, out)
+                self.assertIn("2 unparsed", out)
+                self.assertIn("operator new", out)
+                self.assertIn(field, out)
+
+    def test_an_allman_allocator_can_split_the_semicolon_only(self):
+        self._assert_checked("    static void *operator new(unsigned long size)\n    ;")
+
+    def test_a_signature_without_body_at_end_of_file_is_not_a_pass(self):
+        with tempfile.TemporaryDirectory(prefix="offset_opnew_") as tmp:
+            header = pathlib.Path(tmp) / "Widget.h"
+            header.write_text(
+                "struct Widget {\n    static void *operator new(unsigned long size)\n",
+                encoding="utf-8")
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = C.main([str(header)])
+            self.assertEqual(rc, 1, out.getvalue())
+            self.assertIn("1 unparsed", out.getvalue())


### PR DESCRIPTION
PR #2488's valid class-local allocator was reported as an unknown field by the header-offset checker. Its neighboring inline accessor exposed the same semicolon-only method matcher. Recognize complete allocation and named inline-method signatures, consume their bodies, and resume checking fields on either side. Missing bodies cannot hide unknown or malformed declarations.

Only the checker and tests change. Independent validation of this composition on main `51e74d3ea9b8f1a2342e944be6d7fa9d3c57e5ea`:

- All 150 offset-checker, port-reference, merge-validator and TU-compatibility tests pass, including 14 new offset-checker cases.
- The exact #2488 header at `969d498dce5de767eb347861eaee9315183516da` changes from one UNPARSED allocator diagnostic to none.
- All 502 current-main header diagnostics are unchanged under normal repository-relative invocation. An additional check without the existing path-keyed waiver confirms that `dThIcon_c`'s inline constructor/destructor also parse correctly. The waiver itself is unchanged.
- New method recognizers reject function-pointer fields, member-function-pointer fields and field initializers. Negative offset and malformed-declaration tests still fail as expected.

The daSCre header has no per-field offset comments: its clean parse is separate from compiler sizeof and source-byte proof. Existing nested-typedef and generated-method-footer limits remain; this is not a complete C++ layout parser. No layout tables, source headers, baselines or waivers change.
