### PR TITLE
Check source reviews against the live target branch

### DIFF
--- a/tools/check_pr_source_review.py
+++ b/tools/check_pr_source_review.py
@@ -8,6 +8,7 @@ import json
 import re
 import subprocess
 import sys
+from urllib.parse import quote
 
 import source_review as sr
 
@@ -72,13 +73,29 @@ def queue_state(repo):
     return sha, contents
 
 
+def target_branch(repo, pr):
+    """Resolve the live target ref; PR base.sha can retain an older commit."""
+    base = pr["base"]
+    base_repo = base["repo"]["full_name"]
+    sr.require(isinstance(base_repo, str) and base_repo.casefold() == repo.casefold(),
+               "PR targets a different repository")
+    branch = base["ref"]
+    sr.require(isinstance(branch, str) and bool(branch), "PR target branch is missing")
+    ref = api(f"repos/{repo}/git/ref/heads/{quote(branch, safe='')}")
+    sr.require(ref["ref"] == "refs/heads/" + branch, "API returned a different target ref")
+    sr.require(ref["object"]["type"] == "commit", "Target branch does not identify a commit")
+    return branch, sr.commit(ref["object"]["sha"], "target branch commit")
+
+
 def check_pr(repo, number, publish=False):
     pr = api(f"repos/{repo}/pulls/{number}")
     if pr["state"] != "open":
         return {"pr": number, "result": "closed"}
-    head, base = pr["head"]["sha"], pr["base"]["sha"]
+    head = pr["head"]["sha"]
+    base, branch = None, None
     state_sha = None
     try:
+        branch, base = target_branch(repo, pr)
         pages = api(f"repos/{repo}/pulls/{number}/files?per_page=100", paginate=True)
         files = [f for page in pages for f in page]
         sr.require(len(files) == pr["changed_files"], "incomplete PR file list; review coverage unknown")
@@ -91,15 +108,29 @@ def check_pr(repo, number, publish=False):
         report = evaluate(state, head, base, paths)
     except (RuntimeError, sr.ReviewError, ValueError, KeyError, TypeError) as exc:
         report = {"result": "fail", "summary": "Source review could not be established: " + str(exc)}
-    report.update(pr=number, head=head, base=base, queue_commit=state_sha)
-    if publish:
+    report.update(pr=number, head=head, base=base, base_ref=branch,
+                  pr_base=pr["base"].get("sha"), queue_commit=state_sha)
+    if not publish and report["result"] != "pass":
+        return report
+    current_head_confirmed = False
+    try:
         current = api(f"repos/{repo}/pulls/{number}")
-        if (current["head"]["sha"], current["base"]["sha"], current["state"]) != (head, base, "open"):
-            raise RuntimeError("PR changed while checking; rerun before publishing a verdict")
+        sr.require((current["head"]["sha"], current["state"]) == (head, "open"),
+                   "PR changed while checking; rerun before using the verdict")
+        current_head_confirmed = True
         if state_sha is not None:
             current_queue = api(f"repos/{repo}/git/ref/heads/agents/coordination")["object"]["sha"]
             if current_queue != state_sha:
                 report.update(result="fail", summary="Queue changed during review; refresh the check.")
+        # Read the actual branch tip last, before returning or creating a check.
+        # Re-reading the PR's cached base.sha cannot detect main advancing.
+        current_branch, current_base = target_branch(repo, current)
+        if (current_branch, current_base) != (branch, base):
+            report.update(result="fail", summary="Target branch changed during review; refresh the check.",
+                          observed_base=current_base, observed_base_ref=current_branch)
+    except (RuntimeError, sr.ReviewError, ValueError, KeyError, TypeError) as exc:
+        report.update(result="fail", summary="Final review inputs could not be confirmed: " + str(exc))
+    if publish and current_head_confirmed:
         api(f"repos/{repo}/check-runs", {
             "name": "Source review", "head_sha": head, "status": "completed",
             "conclusion": "success" if report["result"] == "pass" else "failure",

--- a/tools/test_check_pr_source_review.py
+++ b/tools/test_check_pr_source_review.py
@@ -6,10 +6,18 @@ import subprocess
 import sys
 import unittest
 from unittest.mock import patch
+from urllib.parse import unquote
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import check_pr_source_review as gate
 from test_source_review import HEAD, BASE, WORKFLOW, evidence
+
+
+def pull_request(branch="main"):
+    return {"state": "open", "head": {"sha": HEAD},
+            "base": {"sha": BASE, "ref": branch,
+                     "repo": {"full_name": "tangosdev/sm64ds-decomp"}},
+            "changed_files": 1}
 
 
 def state():
@@ -69,7 +77,7 @@ class PRSourceReviewTest(unittest.TestCase):
         self.assertEqual(gate.evaluate(snapshot, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
 
     def test_queue_change_before_publication_emits_failure(self):
-        pr = {"state": "open", "head": {"sha": HEAD}, "base": {"sha": BASE}, "changed_files": 1}
+        pr = pull_request()
         posted = []
 
         def api(path, payload=None, paginate=False):
@@ -78,6 +86,8 @@ class PRSourceReviewTest(unittest.TestCase):
                 return {}
             if "/files?" in path:
                 return [[{"filename": "src/actor.cpp"}]]
+            if path.endswith("/git/ref/heads/main"):
+                return {"ref": "refs/heads/main", "object": {"type": "commit", "sha": BASE}}
             if "/git/ref/" in path:
                 return {"object": {"sha": "e" * 40}}
             return copy.deepcopy(pr)
@@ -89,16 +99,163 @@ class PRSourceReviewTest(unittest.TestCase):
         self.assertEqual(posted[0]["conclusion"], "failure")
 
     def test_renamed_source_requires_review_of_old_and_new_paths(self):
-        pr = {"state": "open", "head": {"sha": HEAD}, "base": {"sha": BASE}, "changed_files": 1}
-        with patch.object(gate, "api", side_effect=[pr, [[{
+        pr = pull_request()
+        with patch.object(gate, "target_branch", return_value=("main", BASE)), patch.object(
+                gate, "api", side_effect=[pr, [[{
                 "filename": "src/actor.cpp", "previous_filename": "src/old_actor.c"}]]]), patch.object(
                 gate, "queue_state", return_value=("d" * 40, state())):
             self.assertEqual(gate.check_pr("tangosdev/sm64ds-decomp", 2447)["result"], "fail")
 
     def test_truncated_api_file_list_fails_closed(self):
-        pr = {"state": "open", "head": {"sha": HEAD}, "base": {"sha": BASE}, "changed_files": 3001}
-        with patch.object(gate, "api", side_effect=[pr, [[{"filename": "notes/inert.md"}]]]):
+        pr = pull_request()
+        pr["changed_files"] = 3001
+        with patch.object(gate, "target_branch", return_value=("main", BASE)), patch.object(
+                gate, "api", side_effect=[pr, [[{"filename": "notes/inert.md"}]]]):
             self.assertEqual(gate.check_pr("tangosdev/sm64ds-decomp", 2447)["result"], "fail")
+
+
+class TargetBranchReviewTest(unittest.TestCase):
+    def run_fixture(self, refs, review_base=BASE, publish=False, source=True,
+                    branch="main", final_branch=None, final_head=None):
+        snapshot = state()
+        output = snapshot["tasks"]["actor"]["outputs"][0]["evidence"]
+        output["tested_base"] = review_base
+        output["source_review"]["reviewed_base"] = review_base
+        pr = pull_request(branch)
+        replies = iter(refs)
+        calls, posts = [], []
+        reads = 0
+
+        def api(path, payload=None, paginate=False):
+            nonlocal reads
+            calls.append(path)
+            if path.endswith("/check-runs"):
+                posts.append(payload)
+                return {}
+            if "/files?" in path:
+                return [[{"filename": "src/actor.cpp" if source else "tools/inert.py"}]]
+            if path.endswith("/git/ref/heads/agents/coordination"):
+                return {"object": {"sha": "d" * 40}}
+            if "/git/ref/" in path:
+                value = next(replies)
+                if isinstance(value, Exception):
+                    raise value
+                if isinstance(value, dict):
+                    return value
+                return {"ref": "refs/" + unquote(path.split("/git/ref/")[1]),
+                        "object": {"type": "commit", "sha": value}}
+            if "/pulls/" in path:
+                reads += 1
+                current = copy.deepcopy(pr)
+                if reads > 1 and final_branch is not None:
+                    current["base"]["ref"] = final_branch
+                if reads > 1 and final_head is not None:
+                    current["head"]["sha"] = final_head
+                return current
+            raise AssertionError("Unexpected API request: " + path)
+
+        with patch.object(gate, "api", side_effect=api), patch.object(
+                gate, "queue_state", return_value=("d" * 40, snapshot)) as queue:
+            result = gate.check_pr("tangosdev/sm64ds-decomp", 2447, publish=publish)
+        return result, calls, posts, queue.call_count
+
+    def test_stale_pr_base_does_not_accept_old_review_or_reject_current_review(self):
+        tip = "e" * 40
+        old, calls, _, _ = self.run_fixture([tip])
+        self.assertEqual(old["result"], "fail")
+        self.assertEqual(old["base"], tip)
+        self.assertEqual(old["pr_base"], BASE)
+        self.assertIn("repos/tangosdev/sm64ds-decomp/git/ref/heads/main", calls)
+        current, _, _, _ = self.run_fixture([tip, tip], review_base=tip)
+        self.assertEqual(current["result"], "pass")
+
+    def test_target_advance_during_read_only_evaluation_invalidates_success(self):
+        result, calls, posts, _ = self.run_fixture([BASE, "e" * 40])
+        self.assertEqual(result["result"], "fail")
+        self.assertEqual(result["observed_base"], "e" * 40)
+        self.assertEqual(posts, [])
+        self.assertTrue(calls[-1].endswith("/git/ref/heads/main"))
+
+    def test_final_read_failure_also_blocks_read_only_integrator_check(self):
+        result, _, posts, _ = self.run_fixture([BASE, RuntimeError("ref unavailable")])
+        self.assertEqual(result["result"], "fail")
+        self.assertEqual(posts, [])
+
+    def test_head_movement_blocks_read_only_and_publishing_checks(self):
+        for publish in (False, True):
+            with self.subTest(publish=publish):
+                result, _, posts, _ = self.run_fixture([BASE], publish=publish, final_head="f" * 40)
+                self.assertEqual(result["result"], "fail")
+                self.assertIn("PR changed", result["summary"])
+                self.assertEqual(posts, [])
+
+    def test_target_advance_before_publication_invalidates_success(self):
+        result, calls, posts, _ = self.run_fixture([BASE, "e" * 40], publish=True)
+        self.assertEqual(result["result"], "fail")
+        self.assertIn("Target branch changed", result["summary"])
+        self.assertEqual(posts[0]["conclusion"], "failure")
+        self.assertTrue(calls[-2].endswith("/git/ref/heads/main"))
+        self.assertTrue(calls[-1].endswith("/check-runs"))
+
+    def test_current_base_review_can_publish_despite_retained_pr_base_metadata(self):
+        tip = "e" * 40
+        result, _, posts, _ = self.run_fixture([tip, tip], review_base=tip, publish=True)
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual(result["base"], tip)
+        self.assertEqual(posts[0]["conclusion"], "success")
+        self.assertIn(":" + tip + ":", posts[0]["external_id"])
+
+    def test_initial_ref_failure_does_not_fall_back_to_pr_base(self):
+        result, _, posts, queue_reads = self.run_fixture([RuntimeError("ref unavailable")])
+        self.assertEqual(result["result"], "fail")
+        self.assertIsNone(result["base"])
+        self.assertEqual(posts, [])
+        self.assertEqual(queue_reads, 0)
+
+    def test_publication_ref_failure_emits_failure_instead_of_old_success(self):
+        result, _, posts, _ = self.run_fixture([BASE, RuntimeError("ref unavailable")], publish=True)
+        self.assertEqual(result["result"], "fail")
+        self.assertIn("could not be confirmed", result["summary"])
+        self.assertEqual(posts[0]["conclusion"], "failure")
+
+    def test_wrong_or_malformed_ref_cannot_supply_a_review_base(self):
+        cases = [
+            {},
+            {"ref": "refs/heads/main", "object": {"type": "commit", "sha": "bad"}},
+            {"ref": "refs/heads/other", "object": {"type": "commit", "sha": BASE}},
+            {"ref": "refs/heads/main", "object": {"type": "tag", "sha": BASE}},
+        ]
+        for reply in cases:
+            with self.subTest(reply=reply):
+                result, _, _, _ = self.run_fixture([reply])
+                self.assertEqual(result["result"], "fail")
+                self.assertIsNone(result["base"])
+
+    def test_retargeting_to_same_oid_still_invalidates_publication(self):
+        result, _, posts, _ = self.run_fixture([BASE, BASE], publish=True, final_branch="release")
+        self.assertEqual(result["result"], "fail")
+        self.assertEqual(posts[0]["conclusion"], "failure")
+
+    def test_branch_names_with_slashes_use_exact_escaped_ref(self):
+        result, calls, _, _ = self.run_fixture([BASE, BASE], branch="release/2026")
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual(result["base_ref"], "release/2026")
+        self.assertIn("repos/tangosdev/sm64ds-decomp/git/ref/heads/release%2F2026", calls)
+
+    def test_tooling_exemption_does_not_invent_target_identity(self):
+        result, _, _, reads = self.run_fixture([BASE, BASE], source=False)
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual(reads, 0)
+        unavailable, _, _, _ = self.run_fixture([RuntimeError("missing branch")], source=False)
+        self.assertEqual(unavailable["result"], "fail")
+
+    def test_different_base_repository_is_not_followed(self):
+        pr = pull_request()
+        pr["base"]["repo"]["full_name"] = "another/repository"
+        with patch.object(gate, "api", return_value=pr) as api:
+            result = gate.check_pr("tangosdev/sm64ds-decomp", 2447)
+        self.assertEqual(result["result"], "fail")
+        self.assertEqual(api.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The source-review gate used the PR's recorded base SHA as though it were the target branch's current head. A live response for open PR #2488 reports `baseRefOid` at `224e660e` while `baseRef.target.oid` and main's ref are at `8525428a`. Regression fixtures reproduce both accepting outdated review evidence and rejecting evidence for the current base.

Resolve the actual target branch and use its commit for acceptance. Recheck the PR head, queue and target before returning a successful read-only verdict or publishing a check. A moved, retargeted or unavailable input cannot retain acceptance; the recorded PR base remains visible as diagnostic metadata.

Independent validation of the composition on main `8525428a2f39e2f4687ca4fbf0ba46e775563a90` passes all **66 source-review and queue tests**. Live read-only checks confirm the corrected target identity for both a tooling PR and a source PR; the source PR still fails because fleet activation is absent.

Only the checker and its tests change. Existing review coverage, ownership rules, task pins and queue policy are preserved. This supports the pending activation tracked in #2449; it does not activate the fleet or change repository protections.
