### PR TITLE
validate_merge: the merge rule's arithmetic fix and the matched-loss exception, as ruled

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -27,3 +27,10 @@
 # one, and it touches a workflow that writes commits to main.
 pyelftools==0.33
 capstone==5.0.9
+# test_validate_merge reaches evidence_rom, which is where `is_unconditional_return`
+# lives -- the one classifier that decides whether an ARM word is a return. The
+# matched-loss exception in validate_merge.py imports it rather than re-deriving the
+# encodings, because two spellings of that answer drifted apart once already and the
+# drift was invisible. evidence_rom's own module-level imports include yaml, so the
+# suite that exercises the classifier needs it even though nothing here reads YAML.
+pyyaml==6.0.3

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -1139,15 +1139,29 @@ class RelocIndex(unittest.TestCase):
                    "from:0x01ff8100 kind:arm_call to:0x0201b000 module:main\n")
         self.old_repo = VM.REPO
         VM.REPO = self.repo
-        VM._RELOC_CACHE.clear()
-        self.addCleanup(VM._RELOC_CACHE.clear)
+        for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
+                      VM._SYMBOL_BASE_CACHE):
+            cache.clear()
+            self.addCleanup(cache.clear)
         self.addCleanup(setattr, VM, "REPO", self.old_repo)
 
     def write(self, rel, text):
         (self.cfg / rel).write_text(text, encoding="utf-8", newline="\n")
 
+    def image(self, module, words):
+        """The module's cartridge image, based at its lowest declared symbol."""
+        self.write(f"overlays/{module}/symbols.txt",
+                   "data_020ab100 kind:data(any) addr:0x020ab100\n")
+        d = self.repo / "extracted" / "overlays"
+        d.mkdir(parents=True, exist_ok=True)
+        image = bytearray()
+        for word in words:
+            image += word.to_bytes(4, "little")
+        (d / f"overlay_{int(module[2:]):04d}.bin").write_bytes(bytes(image))
+
     def index(self):
         VM._RELOC_CACHE.clear()
+        VM._SYMBOL_BASE_CACHE.clear()
         return VM._reloc_index(commit(self.repo, "relocs", "tester"))
 
     def test_every_module_file_supplies_destinations_and_the_index_is_valid(self):
@@ -1189,11 +1203,53 @@ class RelocIndex(unittest.TestCase):
         self.assertEqual(len(defects), 1)
         self.assertIn("config/arm9/relocs.txt is empty", defects[0])
 
-    def test_an_empty_file_for_a_module_that_declares_nothing_is_fine(self):
-        # 15 of these at cd3a7eb59: dtcm and fourteen zero-length overlays.
+    def empty_module(self, sections, name="ov061"):
+        """A module with no functions, an empty `relocs.txt`, and that inventory."""
+        (self.cfg / "overlays" / name).mkdir(parents=True, exist_ok=True)
+        self.write(f"overlays/{name}/symbols.txt", "")
+        self.write(f"overlays/{name}/relocs.txt", "")
+        self.write(f"overlays/{name}/delinks.txt", sections)
+
+    def test_an_empty_file_for_a_module_with_nothing_but_bss_is_fine(self):
+        # 15 of these at cd3a7eb59. ov061 verbatim: a zero-length `.ctor` and a
+        # `.bss`, which occupies no cartridge bytes and can hold no pointer.
+        self.empty_module(
+            "    .ctor       start:0x02115ec0 end:0x02115ec0 kind:rodata align:4\n"
+            "    .bss        start:0x02115ee0 end:0x02115ee0 kind:bss align:32\n")
+        self.assertEqual(self.index()["defects"], [])
+
+    def test_an_empty_file_beside_a_module_with_no_inventory_fails_closed(self):
+        # No `delinks.txt` at all: nothing says whether the module holds data.
         (self.cfg / "overlays" / "ov061").mkdir(parents=True)
         self.write("overlays/ov061/symbols.txt", "")
         self.write("overlays/ov061/relocs.txt", "")
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("ov061 has no section inventory", defects[0])
+
+    def test_an_empty_file_beside_unreadable_initialised_data_fails_closed(self):
+        # Four bytes of real `.data` and no image in this checkout to read them
+        # from. Unavailable evidence is a defect, never a pass.
+        self.empty_module(
+            "    .data       start:0x020ab100 end:0x020ab104 kind:data align:4\n")
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("the module image is unavailable", defects[0])
+
+    def test_an_empty_file_beside_a_word_naming_an_address_is_a_defect(self):
+        self.empty_module(
+            "    .data       start:0x020ab100 end:0x020ab104 kind:data align:4\n")
+        self.image("ov061", [0x02071694])
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("holds a nonzero word 0x02071694 at 0x020ab100", defects[0])
+
+    def test_an_empty_file_beside_zeroed_initialised_data_is_fine(self):
+        # `config/arm9/dtcm` is this case on the real tree: 0x20 of `.data`, all
+        # zeroes, and an empty relocation file that is complete evidence.
+        self.empty_module(
+            "    .data       start:0x020ab100 end:0x020ab108 kind:data align:4\n")
+        self.image("ov061", [0, 0])
         self.assertEqual(self.index()["defects"], [])
 
     def test_a_malformed_row_is_a_defect(self):
@@ -1490,14 +1546,36 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
             f"    .text start:0x{start:08x} end:0x{end:08x}",
             ""])
 
+    def write_overlay_image(self, number, words):
+        d = self.repo / "extracted" / "overlays"
+        d.mkdir(parents=True, exist_ok=True)
+        image = bytearray()
+        for word in words:
+            image += word.to_bytes(4, "little")
+        (d / f"overlay_{number:04d}.bin").write_bytes(bytes(image))
+
+    def data_only_overlay(self, word):
+        """A module declaring NO function, holding four bytes of real .data, with an
+        empty `relocs.txt`. Its one data word is the retired ARM9 address."""
+        self.write("config/arm9/overlays/ov001/symbols.txt",
+                   "data_020ab100 kind:data(any) addr:0x020ab100\n")
+        self.write("config/arm9/overlays/ov001/delinks.txt", "\n".join([
+            "    .data       start:0x020ab100 end:0x020ab104 kind:data align:4",
+            "    .bss        start:0x020ab104 end:0x020ab104 kind:bss align:32",
+            ""]))
+        self.write("config/arm9/overlays/ov001/relocs.txt", "")
+        self.write_overlay_image(1, [word])
+
     def absorb(self, relocs=VALID_RELOCS, extra_reloc=None, epilogue_word=0xE12FFF1E,
-               epilogue_size=0x4, rom=True, orphan_module=False):
+               epilogue_size=0x4, rom=True, orphan_module=False, data_only=None):
         """Commit a base and the fold on top of it, and report on the pair.
 
         `relocs` is the content of `config/arm9/relocs.txt` in BOTH revisions; None
         leaves the file out of both. `extra_reloc` appends one row naming an address,
         head only. `orphan_module` adds an overlay that declares a function and has no
-        `relocs.txt` at all -- an incomplete module inventory.
+        `relocs.txt` at all -- an incomplete module inventory. `data_only`, when given,
+        adds a data-only ov001 whose single data word is that value and whose
+        `relocs.txt` is empty in both snapshots.
         """
         nxt = self.EPILOGUE + epilogue_size
         self.write("config/arm9/symbols.txt", "\n".join([
@@ -1514,6 +1592,8 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         if orphan_module:
             self.write("config/arm9/overlays/ov001/symbols.txt",
                        "OvOne kind:function(arm,size=0x4) addr:0x020ab110\n")
+        if data_only is not None:
+            self.data_only_overlay(data_only)
         self.write("src/Anchor.c", "int Anchor(void) { return 0; }\n")
         self.write("src/func_02071644.c",
                    "// NONMATCHING: hand-written asm, does NOT count as matched.\n"
@@ -1614,6 +1694,21 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
             self.absorb(relocs=self.VALID_RELOCS
                         + "from:0x02071620 kind:arm_call to:0x02071694 module:elsewhere\n"),
             "undocumented destination module 'elsewhere'")
+
+    def test_a_data_only_module_with_an_empty_relocation_file_fails_closed(self):
+        # No function anywhere in ov001, so the old inventory rule exempted its empty
+        # `relocs.txt` outright -- and the four bytes of .data it does hold are the
+        # retired ARM9 address. A count of functions cannot see that.
+        self.assertRefused(self.absorb(data_only=self.EPILOGUE),
+                           "config/arm9/overlays/ov001/relocs.txt is empty")
+
+    def test_a_data_only_module_whose_data_is_zeroed_is_still_legitimate(self):
+        # The other half of the same rule: an empty relocation file beside data that
+        # holds no address at all is complete evidence, and must stay supported.
+        report = self.absorb(data_only=0)
+        self.assertEqual(report["reasons"], [])
+        self.assertTrue(report["relocationEvidence"]["valid"])
+        self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 1)
 
     def test_an_incomplete_module_inventory_fails_closed(self):
         # A module that declares a function and has no relocation file at all. Every

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -1460,7 +1460,8 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         self.old_repo = VM.REPO
         VM.REPO = self.repo
         self.addCleanup(setattr, VM, "REPO", self.old_repo)
-        for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE):
+        for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
+                      VM._SYMBOL_BASE_CACHE):
             cache.clear()
             self.addCleanup(cache.clear)
 
@@ -1542,6 +1543,7 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         head = commit(self.repo, "absorb", "bob")
         VM._RELOC_CACHE.clear()
         VM._ENROLMENT_CACHE.clear()
+        VM._SYMBOL_BASE_CACHE.clear()
         return VM.build_report(base, head)
 
     def assertRefused(self, report, defect=None):
@@ -1637,3 +1639,154 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         self.assertRefused(report)
         self.assertIn("ROM image unavailable, so nothing matched may leave: arm9",
                       report["reasons"])
+
+
+class DataLeadingOverlayImageBase(unittest.TestCase):
+    """The overlay word reader, on an overlay whose first symbol is DATA.
+
+    `modules._overlay_base` -- the derivation this reader claims to follow -- takes the
+    lowest address of ANY symbol the module declares. Reading the base off the first
+    FUNCTION address instead shifts every read by the distance between them, so a
+    module with four bytes of data in front of its first function answers each query
+    with the PREVIOUS word. Put a `bx lr` in front of a record whose own word is
+    `mov r0, #0` and the guard reads a return that is not there.
+
+    The fixture is the same absorption shape as `AbsorbedEpilogueThroughBuildReport`,
+    moved into `ov001` and given a leading data symbol.
+    """
+
+    DATA, BODY, EPILOGUE, NEXT = 0x020ab100, 0x020ab104, 0x020ab154, 0x020ab158
+    END = 0x020ab1c8
+    ANCHOR = 0x02004000
+
+    RELOCS_MAIN = "from:0x02004000 kind:arm_call to:0x02004000 module:main\n"
+    # Two calls into the overlay body, none into the four bytes at its tail.
+    RELOCS_OV = ("from:0x020ab160 kind:arm_call to:0x020ab104 module:overlay(1)\n"
+                 "from:0x020ab164 kind:arm_call to:0x020ab158 module:overlay(1)\n")
+
+    RECOVERED = "\n".join([
+        "void func_020ab104(unsigned char *p, int len) {",
+        "    for (;;) { if (*p < 9) { (*p)++; return; } *p-- = 0; }",
+        "}",
+        ""])
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = pathlib.Path(self.tmp.name)
+        git(self.repo, "init", "-q", ".")
+        (self.repo / "src").mkdir()
+        (self.repo / ".gitignore").write_text("extracted/\n", encoding="utf-8")
+        self.old_repo = VM.REPO
+        VM.REPO = self.repo
+        self.addCleanup(setattr, VM, "REPO", self.old_repo)
+        for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
+                      VM._SYMBOL_BASE_CACHE):
+            cache.clear()
+            self.addCleanup(cache.clear)
+
+    def write(self, rel, text):
+        path = self.repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+
+    def write_image(self, record_word):
+        """The overlay's image, based at its LOWEST SYMBOL -- the data one.
+
+        `bx lr` sits at 0x020ab150, one word in front of the record, which is where a
+        reader based on the first function lands when asked for 0x020ab154.
+        """
+        image = bytearray(self.END - self.DATA)
+        image[0x50:0x54] = (0xE12FFF1E).to_bytes(4, "little")
+        image[self.EPILOGUE - self.DATA:self.EPILOGUE - self.DATA + 4] = \
+            record_word.to_bytes(4, "little")
+        d = self.repo / "extracted" / "overlays"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "overlay_0001.bin").write_bytes(bytes(image))
+
+    def ov_delinks(self, entry, start, end):
+        return "\n".join([
+            "    .text       start:0x020ab100 end:0x020ab1c8 kind:code align:4",
+            "",
+            f"{entry}:",
+            "    complete",
+            f"    .text start:0x{start:08x} end:0x{end:08x}",
+            ""])
+
+    def absorb(self, record_word=0xE3A00000):
+        self.write("config/arm9/symbols.txt",
+                   f"Anchor kind:function(arm,size=0x4) addr:0x{self.ANCHOR:08x}\n")
+        self.write("config/arm9/delinks.txt", "\n".join([
+            "    .text start:0x02004000 end:0x02004004 kind:code",
+            "",
+            "src/Anchor.c:",
+            "    complete",
+            f"    .text start:0x{self.ANCHOR:08x} end:0x{self.ANCHOR + 4:08x}",
+            ""]))
+        self.write("config/arm9/relocs.txt", self.RELOCS_MAIN)
+        self.write("src/Anchor.c", "int Anchor(void) { return 0; }\n")
+
+        self.write("config/arm9/overlays/ov001/symbols.txt", "\n".join([
+            f"data_{self.DATA:08x} kind:data(any) addr:0x{self.DATA:08x}",
+            f"func_{self.BODY:08x} kind:function(arm,size=0x50) "
+            f"addr:0x{self.BODY:08x}",
+            f"func_{self.EPILOGUE:08x} kind:function(arm,size=0x4) "
+            f"addr:0x{self.EPILOGUE:08x}",
+            f"func_{self.NEXT:08x} kind:function(arm,size=0x70) "
+            f"addr:0x{self.NEXT:08x}",
+            ""]))
+        self.write("config/arm9/overlays/ov001/delinks.txt",
+                   self.ov_delinks(f"src/func_{self.EPILOGUE:08x}.c",
+                                   self.EPILOGUE, self.NEXT))
+        self.write("config/arm9/overlays/ov001/relocs.txt", self.RELOCS_OV)
+        self.write(f"src/func_{self.BODY:08x}.c",
+                   "// NONMATCHING: hand-written asm, does NOT count as matched.\n"
+                   f"void func_{self.BODY:08x}(void) {{}}\n")
+        self.write(f"src/func_{self.EPILOGUE:08x}.c",
+                   f"void func_{self.EPILOGUE:08x}(void)\n{{\n}}\n")
+        self.write(f"src/func_{self.NEXT:08x}.c",
+                   f"int func_{self.NEXT:08x}(void) {{ return 1; }}\n")
+        base = commit(self.repo, "base", "alice")
+
+        self.write("config/arm9/overlays/ov001/symbols.txt", "\n".join([
+            f"data_{self.DATA:08x} kind:data(any) addr:0x{self.DATA:08x}",
+            f"func_{self.BODY:08x} kind:function(arm,size=0x54) "
+            f"addr:0x{self.BODY:08x}",
+            f"func_{self.NEXT:08x} kind:function(arm,size=0x70) "
+            f"addr:0x{self.NEXT:08x}",
+            ""]))
+        self.write("config/arm9/overlays/ov001/delinks.txt",
+                   self.ov_delinks(f"src/func_{self.BODY:08x}.c",
+                                   self.BODY, self.NEXT))
+        self.write(f"src/func_{self.BODY:08x}.c", self.RECOVERED)
+        os.remove(self.repo / "src" / f"func_{self.EPILOGUE:08x}.c")
+        self.write_image(record_word)
+        head = commit(self.repo, "absorb", "bob")
+        VM._RELOC_CACHE.clear()
+        VM._ENROLMENT_CACHE.clear()
+        VM._SYMBOL_BASE_CACHE.clear()
+        self.base, self.head = base, head
+        return VM.build_report(base, head)
+
+    def test_the_reader_answers_from_the_lowest_symbol_not_the_first_function(self):
+        self.absorb()
+        read = VM._rom_word_reader(self.head)
+        self.assertEqual(read("ov001", self.EPILOGUE), 0xE3A00000)
+        self.assertEqual(read("ov001", self.EPILOGUE - 4), 0xE12FFF1E)
+
+    def test_a_non_return_tail_in_a_data_leading_overlay_is_refused(self):
+        report = self.absorb()
+        self.assertIsNone(report["repartition"])
+        self.assertIn("lost 1 matched function(s)", report["reasons"])
+        self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 0)
+        self.assertTrue(report["relocationEvidence"]["valid"])
+
+    def test_the_same_overlay_fixture_with_a_real_tail_return_still_lands(self):
+        # The positive control for the two above: identical tree, and the record's own
+        # word IS the return. Without it, the refusal above could come from anything in
+        # the fixture rather than from the word the reader now reads.
+        report = self.absorb(record_word=0xE12FFF1E)
+        self.assertEqual(report["reasons"], [])
+        self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 1)
+        self.assertEqual([a["name"] for a in report["matchedAbsorbed"]],
+                         [f"func_{self.EPILOGUE:08x}"])

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -1246,3 +1246,394 @@ class RelocIndex(unittest.TestCase):
         self.assertEqual(
             VM._incoming_relocations(evidence["dests"], "arm9",
                                      0x020049f0, 0x020049f4), 2)
+
+
+def _relocs(*addrs, module="arm9"):
+    """A `reloc_dests` index holding exactly these destinations, all valid."""
+    return {module: sorted(addrs)}
+
+
+def _rom(words=None, default=None):
+    """A `rom_word` reader over a dict of {(module, addr): word}."""
+    def read(module, addr):
+        return (words or {}).get((module, addr), default)
+    read.missing = set()
+    return read
+
+
+BX_LR = 0xE12FFF1E
+MOV_PC_LR = 0xE1A0F00E
+POP_R4_PC = 0xE8BD8010
+LDMIA_SP_PC = 0xE8BD9FFF
+
+
+class ReturnEncodings(unittest.TestCase):
+    """The accepted set, spelled out. The three shapes evidence_rom recognises."""
+
+    def test_the_accepted_encodings(self):
+        for word in (BX_LR, MOV_PC_LR, POP_R4_PC, LDMIA_SP_PC):
+            self.assertTrue(VM._is_return_word(word), hex(word))
+
+    def test_everything_else_is_refused(self):
+        for word, why in ((0x012FFF1E, "bxeq lr, a conditional return"),
+                          (0xE12FFF13, "bx r3, not lr"),
+                          (0xE8BD0010, "pop {r4}, no pc in the list"),
+                          (0xE8FD8010, "ldmia sp!, {r4, pc}^, restores CPSR"),
+                          (0xE92D4010, "stmdb sp!, {r4, lr}, a store"),
+                          (0xEAFFFFFE, "b self, an infinite loop"),
+                          (0xE3A00000, "mov r0, #0"),
+                          (0xE49DF004, "ldr pc, [sp], #4, deliberately outside the set"),
+                          (0x00000000, "padding")):
+            self.assertFalse(VM._is_return_word(word), why)
+
+
+class AbsorbedEpilogue(unittest.TestCase):
+    """The matched-loss exception, in `classify_merge` itself.
+
+    A record may leave `matched` only when all four hold: it is the exact TAIL of a new
+    `complete` range, it is one four-byte instruction whose ROM word is an accepted
+    return, that range is backed by compiled source, and a VALID relocation index names
+    nothing in its bytes. Each test below removes exactly one of them.
+    """
+
+    BODY, EPILOGUE, NEXT = 0x02071644, 0x02071694, 0x02071698
+
+    def _merge(self, epilogue_size=0x4):
+        addr = self.EPILOGUE
+        base = _snap([("func_02071644", self.BODY, addr - self.BODY, False),
+                      ("func_02071694", addr, epilogue_size, True)])
+        head = _snap([("func_02071644", self.BODY,
+                       addr + epilogue_size - self.BODY, True)])
+        be = _enr([(addr, addr + epilogue_size)])
+        he = _enr([(self.BODY, addr + epilogue_size)])
+        return base, head, be, he
+
+    def test_a_ranges_own_tail_return_may_be_absorbed(self):
+        base, head, be, he = self._merge()
+        got = VM.classify_merge(base, head, be, he, _compiled(he), _relocs(self.BODY),
+                                _rom({("arm9", self.EPILOGUE): BX_LR}))
+        self.assertIsNotNone(got)
+        self.assertEqual(got["absorbed"], [f"arm9:0x{self.EPILOGUE:08x}"])
+        self.assertEqual(got["functionDelta"], -1)
+        self.assertEqual(got["sourceByteDelta"], 0x50)
+
+    def test_every_accepted_return_encoding_lands(self):
+        for word in (BX_LR, MOV_PC_LR, POP_R4_PC, LDMIA_SP_PC):
+            base, head, be, he = self._merge()
+            got = VM.classify_merge(base, head, be, he, _compiled(he),
+                                    _relocs(self.BODY),
+                                    _rom({("arm9", self.EPILOGUE): word}))
+            self.assertIsNotNone(got, hex(word))
+
+    def test_a_record_the_rom_calls_is_still_refused(self):
+        # (d). The same diff with one relocation naming those four bytes.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY, self.EPILOGUE),
+            _rom({("arm9", self.EPILOGUE): BX_LR})))
+
+    def test_a_load_of_the_address_counts_as_a_caller(self):
+        # A `kind:load` destination is a reference like any other.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.EPILOGUE),
+            _rom({("arm9", self.EPILOGUE): BX_LR})))
+
+    def test_without_a_validated_relocation_index_nothing_matched_may_leave(self):
+        # (d) again: None is what build_report passes when the index has a defect.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(base, head, be, he, _compiled(he), None,
+                                            _rom({("arm9", self.EPILOGUE): BX_LR})))
+
+    def test_without_the_rom_image_nothing_matched_may_leave(self):
+        # (b) cannot be checked, so it is not assumed.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(base, head, be, he, _compiled(he),
+                                            _relocs(self.BODY), None))
+        self.assertIsNone(VM.classify_merge(base, head, be, he, _compiled(he),
+                                            _relocs(self.BODY), _rom()))
+
+    def test_a_four_byte_record_that_is_not_a_return_is_refused(self):
+        # (b). Byte coverage plus an empty index says nothing about what the bytes ARE.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.EPILOGUE): 0xE3A00000})))
+
+    def test_a_conditional_return_is_refused(self):
+        # (b). bxeq lr leaves a live fall-through, so the bytes after it are reached.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.EPILOGUE): 0x012FFF1E})))
+
+    def test_an_arbitrary_sized_matched_record_at_the_tail_is_refused(self):
+        # (b). The 0x100-byte record: at the exact tail of a new compiled range with a
+        # clean index, and still refused, because one instruction is the whole claim.
+        base, head, be, he = self._merge(epilogue_size=0x100)
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.EPILOGUE): BX_LR})))
+
+    def test_a_record_inside_the_range_but_not_at_its_tail_is_refused(self):
+        # (a). A named callback the merge happens to cover is not an epilogue. Placed
+        # mid-range: a record at the exact HEAD of a range cannot reach this clause at
+        # all, because head still carries a record at that address -- see the
+        # survives-but-loses-matched test below.
+        base = _snap([("func_02071644", self.BODY, 0x20, False),
+                      ("AutoloadCallback", self.BODY + 0x20, 0x4, True),
+                      ("func_02071668", self.BODY + 0x24, 0x30, False)])
+        head = _snap([("func_02071644", self.BODY, 0x54, True)])
+        be = _enr([(self.BODY + 0x20, self.BODY + 0x24)])
+        he = _enr([(self.BODY, self.BODY + 0x54)])
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.BODY + 0x20): BX_LR})))
+
+    def test_absorption_still_needs_a_new_compiled_range_over_the_bytes(self):
+        # (c) and the merge rule's own evidence: no new range at all.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(base, head, be, be, _compiled(be),
+                                            _relocs(self.BODY),
+                                            _rom({("arm9", self.EPILOGUE): BX_LR})))
+
+    def test_a_transcription_cannot_absorb_a_matched_record_either(self):
+        # (c). The covering range reproduces vacuously, so it proves nothing about the
+        # instruction it claims to have recovered.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(base, head, be, he, set(),
+                                            _relocs(self.BODY),
+                                            _rom({("arm9", self.EPILOGUE): BX_LR})))
+
+    def test_a_record_that_survives_but_loses_matched_is_not_absorption(self):
+        # Still present in head, so a banner went on or its source left. That is a
+        # withdrawal or a loss and this rule must not decide it.
+        base = _snap([("func_02071644", self.BODY, 0x50, True),
+                      ("func_02071694", self.EPILOGUE, 0x4, True)])
+        head = _snap([("func_02071644", self.BODY, 0x50, False),
+                      ("func_02071694", self.EPILOGUE, 0x4, False),
+                      ("func_02071698", self.NEXT, 0x4, False)])
+        he = _enr([(self.BODY, self.BODY + 0x50)])
+        self.assertIsNone(VM.classify_merge(base, head, _enr([]), he, _compiled(he),
+                                            _relocs(), _rom({}, BX_LR)))
+
+
+class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
+    """The matched-loss exception driven through `build_report`, on a real tree.
+
+    Wiring only a real tree can check. `lost N matched function(s)` is raised OUTSIDE
+    `classify_merge`, from a loop that had two buckets, so a classification the merge
+    rule allowed would still have failed the report. The relocation index is read from
+    every `relocs.txt` at both revisions. The ROM word is read from the extracted image
+    on disk, the way the byte gate reads it. None of that is exercised by a hand-built
+    dict, and every one of the fail-open paths below returned `Passed`, `reasons: []`
+    and one absorbed record before this rule validated its own evidence.
+
+    The live shape: `func_02071644` declared 0x50, its trailing `bx lr` carried as
+    `func_02071694` and matched with `void f(void) {}`. Recovering the real 0x54 C
+    means that four-byte record leaves.
+    """
+
+    ANCHOR, BODY, EPILOGUE = 0x02004000, 0x02071644, 0x02071694
+
+    # Two calls into the body and one into Anchor. NOTHING into the four bytes at the
+    # body's tail -- that absence is one of the four things the exception needs.
+    VALID_RELOCS = ("from:0x02071354 kind:arm_call to:0x02071644 module:main\n"
+                    "from:0x020714f8 kind:arm_call to:0x02071644 module:main\n"
+                    "from:0x02071614 kind:arm_call to:0x02004000 module:main\n")
+
+    RECOVERED = "\n".join([
+        "void func_02071644(unsigned char *p, int len) {",
+        "    for (;;) { if (*p < 9) { (*p)++; return; } *p-- = 0; }",
+        "}",
+        ""])
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = pathlib.Path(self.tmp.name)
+        git(self.repo, "init", "-q", ".")
+        (self.repo / "src").mkdir()
+        (self.repo / ".gitignore").write_text("extracted/\n", encoding="utf-8")
+        self.config = self.repo / "config" / "arm9"
+        self.config.mkdir(parents=True)
+        self.old_repo = VM.REPO
+        VM.REPO = self.repo
+        self.addCleanup(setattr, VM, "REPO", self.old_repo)
+        for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE):
+            cache.clear()
+            self.addCleanup(cache.clear)
+
+    def write(self, rel, text):
+        path = self.repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+
+    def write_rom(self, word):
+        offset = self.EPILOGUE - VM.ARM9_IMAGE_BASE
+        image = bytearray(offset + 4)
+        image[offset:offset + 4] = word.to_bytes(4, "little")
+        (self.repo / "extracted").mkdir(exist_ok=True)
+        (self.repo / "extracted" / "arm9_dec.bin").write_bytes(bytes(image))
+
+    def delinks(self, entry, start, end):
+        return "\n".join([
+            "    .text start:0x02000000 end:0x02100000 kind:code",
+            "",
+            "src/Anchor.c:",
+            "    complete",
+            f"    .text start:0x{self.ANCHOR:08x} end:0x{self.ANCHOR + 4:08x}",
+            "",
+            f"{entry}:",
+            "    complete",
+            f"    .text start:0x{start:08x} end:0x{end:08x}",
+            ""])
+
+    def absorb(self, relocs=VALID_RELOCS, extra_reloc=None, epilogue_word=0xE12FFF1E,
+               epilogue_size=0x4, rom=True, orphan_module=False):
+        """Commit a base and the fold on top of it, and report on the pair.
+
+        `relocs` is the content of `config/arm9/relocs.txt` in BOTH revisions; None
+        leaves the file out of both. `extra_reloc` appends one row naming an address,
+        head only. `orphan_module` adds an overlay that declares a function and has no
+        `relocs.txt` at all -- an incomplete module inventory.
+        """
+        nxt = self.EPILOGUE + epilogue_size
+        self.write("config/arm9/symbols.txt", "\n".join([
+            f"Anchor kind:function(arm,size=0x4) addr:0x{self.ANCHOR:08x}",
+            f"func_02071644 kind:function(arm,size=0x50) addr:0x{self.BODY:08x}",
+            f"func_02071694 kind:function(arm,size=0x{epilogue_size:x}) "
+            f"addr:0x{self.EPILOGUE:08x}",
+            f"func_{nxt:08x} kind:function(arm,size=0x70) addr:0x{nxt:08x}",
+            ""]))
+        self.write("config/arm9/delinks.txt",
+                   self.delinks("src/func_02071694.c", self.EPILOGUE, nxt))
+        if relocs is not None:
+            self.write("config/arm9/relocs.txt", relocs)
+        if orphan_module:
+            self.write("config/arm9/overlays/ov001/symbols.txt",
+                       "OvOne kind:function(arm,size=0x4) addr:0x020ab110\n")
+        self.write("src/Anchor.c", "int Anchor(void) { return 0; }\n")
+        self.write("src/func_02071644.c",
+                   "// NONMATCHING: hand-written asm, does NOT count as matched.\n"
+                   "void func_02071644(void) {}\n")
+        # The vacuous match: an empty body over a severed tail. Counts today.
+        self.write("src/func_02071694.c", "void func_02071694(void)\n{\n}\n")
+        self.write(f"src/func_{nxt:08x}.c", f"int func_{nxt:08x}(void) {{ return 1; }}\n")
+        base = commit(self.repo, "base", "alice")
+
+        self.write("config/arm9/symbols.txt", "\n".join([
+            f"Anchor kind:function(arm,size=0x4) addr:0x{self.ANCHOR:08x}",
+            f"func_02071644 kind:function(arm,size=0x{nxt - self.BODY:x}) "
+            f"addr:0x{self.BODY:08x}",
+            f"func_{nxt:08x} kind:function(arm,size=0x70) addr:0x{nxt:08x}",
+            ""]))
+        self.write("config/arm9/delinks.txt",
+                   self.delinks("src/func_02071644.c", self.BODY, nxt))
+        if extra_reloc is not None:
+            with open(self.config / "relocs.txt", "a", encoding="utf-8",
+                      newline="\n") as fh:
+                fh.write(f"from:0x02071620 kind:arm_call to:0x{extra_reloc:08x} "
+                         f"module:main\n")
+        self.write("src/func_02071644.c", self.RECOVERED)
+        os.remove(self.repo / "src" / "func_02071694.c")
+        if rom:
+            self.write_rom(epilogue_word)
+        head = commit(self.repo, "absorb", "bob")
+        VM._RELOC_CACHE.clear()
+        VM._ENROLMENT_CACHE.clear()
+        return VM.build_report(base, head)
+
+    def assertRefused(self, report, defect=None):
+        self.assertIsNone(report["repartition"])
+        self.assertIn("lost 1 matched function(s)", report["reasons"])
+        self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 0)
+        self.assertEqual(report["matchedAbsorbed"], [])
+        if defect is not None:
+            named = [r for r in report["reasons"]
+                     if r.startswith("relocation evidence invalid")]
+            self.assertEqual(len(named), 1, report["reasons"])
+            self.assertIn(defect, named[0])
+            self.assertFalse(report["relocationEvidence"]["valid"])
+
+    def test_the_report_allows_the_absorption_and_says_so(self):
+        report = self.absorb()
+        self.assertEqual(report["reasons"], [])
+        self.assertTrue(report["relocationEvidence"]["valid"])
+        self.assertEqual(report["coverage"]["delta"]["lostMatchedFunctions"], 0)
+        self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 1)
+        self.assertEqual([a["name"] for a in report["matchedAbsorbed"]],
+                         ["func_02071694"])
+        rp = report["repartition"]
+        self.assertEqual(rp["kind"], "merge")
+        self.assertEqual(rp["functionDelta"], -1)
+        # 84 newly compiled bytes, 4 of which the base already compiled.
+        self.assertEqual(rp["newExtent"], 0x54)
+        self.assertEqual(rp["absorbedBytes"], 0x4)
+        self.assertEqual(rp["sourceByteDelta"], 0x50)
+        self.assertTrue(any("absorbed by the merge" in w for w in report["warnings"]))
+        self.assertIn("| Claims absorbed by the merge |", VM.render_markdown(report))
+
+    def test_one_call_into_the_absorbed_bytes_fails_the_report(self):
+        # The same diff, byte for byte, with a single relocation pointing into the four
+        # bytes. Now it is an ordinary function someone matched and it may not leave.
+        report = self.absorb(extra_reloc=self.EPILOGUE)
+        self.assertRefused(report)
+        self.assertTrue(report["relocationEvidence"]["valid"])
+
+    def test_relocation_files_missing_from_both_snapshots_fail_closed(self):
+        self.assertRefused(self.absorb(relocs=None),
+                           "config/arm9/relocs.txt is missing")
+
+    def test_an_empty_relocation_file_fails_closed(self):
+        self.assertRefused(self.absorb(relocs=""),
+                           "config/arm9/relocs.txt is empty")
+
+    def test_a_malformed_relocation_row_fails_closed(self):
+        self.assertRefused(self.absorb(relocs=self.VALID_RELOCS + "not a row\n"),
+                           "config/arm9/relocs.txt:4 is not a relocation row")
+
+    def test_a_truncated_relocation_row_fails_closed(self):
+        self.assertRefused(
+            self.absorb(relocs=self.VALID_RELOCS
+                        + "from:0x02071620 kind:arm_call to:0x0207\n"),
+            "config/arm9/relocs.txt:4 is not a relocation row")
+
+    def test_a_leading_byte_order_mark_fails_closed(self):
+        self.assertRefused(self.absorb(relocs="﻿" + self.VALID_RELOCS),
+                           "config/arm9/relocs.txt:1 is not a relocation row")
+
+    def test_leading_whitespace_fails_closed(self):
+        self.assertRefused(self.absorb(relocs=" " + self.VALID_RELOCS),
+                           "config/arm9/relocs.txt:1 is not a relocation row")
+
+    def test_an_undocumented_destination_module_fails_closed(self):
+        self.assertRefused(
+            self.absorb(relocs=self.VALID_RELOCS
+                        + "from:0x02071620 kind:arm_call to:0x02071694 module:elsewhere\n"),
+            "undocumented destination module 'elsewhere'")
+
+    def test_an_incomplete_module_inventory_fails_closed(self):
+        # A module that declares a function and has no relocation file at all. Every
+        # reference it holds is invisible, including references into arm9.
+        self.assertRefused(self.absorb(orphan_module=True),
+                           "config/arm9/overlays/ov001/relocs.txt is missing")
+
+    def test_a_four_byte_record_that_is_not_a_return_fails_the_report(self):
+        # Valid evidence, clean index, exact tail -- and the ROM word is `mov r0, #0`.
+        report = self.absorb(epilogue_word=0xE3A00000)
+        self.assertRefused(report)
+        self.assertTrue(report["relocationEvidence"]["valid"])
+        self.assertEqual([r for r in report["reasons"]
+                          if r.startswith("relocation evidence invalid")], [])
+
+    def test_an_arbitrary_sized_record_at_the_tail_fails_the_report(self):
+        # 0x100 bytes at the exact tail of the new range, with a `bx lr` at its first
+        # word and nothing pointing at it. One instruction is the whole claim.
+        self.assertRefused(self.absorb(epilogue_size=0x100))
+
+    def test_without_the_rom_image_the_report_fails_closed(self):
+        report = self.absorb(rom=False)
+        self.assertRefused(report)
+        self.assertIn("ROM image unavailable, so nothing matched may leave: arm9",
+                      report["reasons"])

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -1099,3 +1099,150 @@ class MergeEvidenceThroughBuildReport(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RelocIndex(unittest.TestCase):
+    """`_reloc_index` reads the module of the DESTINATION, from every file, and says
+    when its own input is not fit to be relied on.
+
+    The index answers exactly one question -- "does anything point at these bytes" --
+    and it is asked in order to PERMIT something. An index that skipped unreadable
+    input would answer "nothing" for every address in the cartridge, so every way the
+    input can be defective is a defect here rather than a line to skip.
+    """
+
+    ARM9_ROWS = ("from:0x02004808 kind:arm_call to:0x020049f0 module:main\n"
+                 "from:0x0203b5bc kind:arm_call to:0x01ffa4bc module:none\n"
+                 "from:0x02005efc kind:arm_call to:0x020ab110 module:overlay(1)\n")
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = pathlib.Path(self.tmp.name)
+        git(self.repo, "init", "-q", ".")
+        self.cfg = self.repo / "config" / "arm9"
+        (self.cfg / "overlays" / "ov001").mkdir(parents=True)
+        (self.cfg / "itcm").mkdir(parents=True)
+        self.write("symbols.txt",
+                   "Anchor kind:function(arm,size=0x4) addr:0x02000000\n")
+        self.write("overlays/ov001/symbols.txt",
+                   "OvOne kind:function(arm,size=0x4) addr:0x020ab110\n")
+        self.write("itcm/symbols.txt",
+                   "ItcmOne kind:function(arm,size=0x4) addr:0x01ff8000\n")
+        self.write("relocs.txt", self.ARM9_ROWS)
+        # A call from an overlay INTO the main binary. The arm9 file never sees it.
+        self.write("overlays/ov001/relocs.txt",
+                   "from:0x020aa42c kind:arm_call to:0x0201a9ec module:main\n"
+                   "from:0x020aa438 kind:load to:0x020ff028 module:overlays(2,7)\n")
+        # And one from ITCM, in a directory `_module_from_relocs` never recognised.
+        self.write("itcm/relocs.txt",
+                   "from:0x01ff8100 kind:arm_call to:0x0201b000 module:main\n")
+        self.old_repo = VM.REPO
+        VM.REPO = self.repo
+        VM._RELOC_CACHE.clear()
+        self.addCleanup(VM._RELOC_CACHE.clear)
+        self.addCleanup(setattr, VM, "REPO", self.old_repo)
+
+    def write(self, rel, text):
+        (self.cfg / rel).write_text(text, encoding="utf-8", newline="\n")
+
+    def index(self):
+        VM._RELOC_CACHE.clear()
+        return VM._reloc_index(commit(self.repo, "relocs", "tester"))
+
+    def test_every_module_file_supplies_destinations_and_the_index_is_valid(self):
+        index = self.index()
+        self.assertEqual(index["defects"], [])
+        dests = index["dests"]
+        # 0x0201b000 is the ITCM file's row: the whole point of reading every file.
+        self.assertEqual(dests["arm9"], [0x020049f0, 0x0201a9ec, 0x0201b000])
+        self.assertEqual(dests["ov001"], [0x020ab110])
+        self.assertEqual(dests["ov002"], [0x020ff028])
+        self.assertEqual(dests["ov007"], [0x020ff028])
+        # A documented token naming no module counts for every module, not for none.
+        self.assertEqual(dests["*"], [0x01ffa4bc])
+        self.assertEqual(
+            VM._incoming_relocations(dests, "arm9", 0x0201b000, 0x0201b004), 1)
+        self.assertEqual(
+            VM._incoming_relocations(dests, "arm9", 0x0201affc, 0x0201b000), 0)
+        self.assertEqual(
+            VM._incoming_relocations(dests, "ov001", 0x01ffa4bc, 0x01ffa4c0), 1)
+
+    def test_a_link_time_constant_row_is_documented_and_carries_no_destination(self):
+        # The one row in the whole tree that names no address.
+        self.write("relocs.txt",
+                   self.ARM9_ROWS
+                   + "from:0x02072fc8 kind:link_time_const(ARM9_CTOR_START)\n")
+        index = self.index()
+        self.assertEqual(index["defects"], [])
+        self.assertEqual(index["dests"]["arm9"], [0x020049f0, 0x0201a9ec, 0x0201b000])
+
+    def test_a_missing_file_for_a_module_that_declares_functions_is_a_defect(self):
+        os.remove(self.cfg / "overlays" / "ov001" / "relocs.txt")
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("config/arm9/overlays/ov001/relocs.txt is missing", defects[0])
+
+    def test_an_empty_file_for_a_module_that_declares_functions_is_a_defect(self):
+        self.write("relocs.txt", "")
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("config/arm9/relocs.txt is empty", defects[0])
+
+    def test_an_empty_file_for_a_module_that_declares_nothing_is_fine(self):
+        # 15 of these at cd3a7eb59: dtcm and fourteen zero-length overlays.
+        (self.cfg / "overlays" / "ov061").mkdir(parents=True)
+        self.write("overlays/ov061/symbols.txt", "")
+        self.write("overlays/ov061/relocs.txt", "")
+        self.assertEqual(self.index()["defects"], [])
+
+    def test_a_malformed_row_is_a_defect(self):
+        self.write("relocs.txt", self.ARM9_ROWS + "garbage\n")
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("config/arm9/relocs.txt:4 is not a relocation row", defects[0])
+
+    def test_a_truncated_last_row_is_a_defect(self):
+        self.write("relocs.txt", self.ARM9_ROWS + "from:0x0203b5c0 kind:arm_call to:0x0207\n")
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("config/arm9/relocs.txt:4 is not a relocation row", defects[0])
+
+    def test_a_leading_byte_order_mark_is_a_defect(self):
+        self.write("relocs.txt", "﻿" + self.ARM9_ROWS)
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("config/arm9/relocs.txt:1 is not a relocation row", defects[0])
+
+    def test_leading_whitespace_is_a_defect(self):
+        self.write("relocs.txt", " " + self.ARM9_ROWS)
+        defects = self.index()["defects"]
+        self.assertEqual(len(defects), 1)
+        self.assertIn("config/arm9/relocs.txt:1 is not a relocation row", defects[0])
+
+    def test_an_undocumented_destination_token_is_a_defect(self):
+        self.write("relocs.txt",
+                   self.ARM9_ROWS
+                   + "from:0x0203b5c0 kind:arm_call to:0x02071694 module:elsewhere\n")
+        index = self.index()
+        self.assertEqual(len(index["defects"]), 1)
+        self.assertIn("undocumented destination module 'elsewhere'",
+                      index["defects"][0])
+        # And the address it named is in nobody's list, which is exactly why the row
+        # cannot simply be skipped.
+        self.assertEqual(
+            VM._incoming_relocations(index["dests"], "arm9", 0x02071694, 0x02071698), 0)
+
+    def test_the_evidence_over_two_revisions_unions_addresses_and_defects(self):
+        base = commit(self.repo, "base", "tester")
+        self.write("relocs.txt", self.ARM9_ROWS + "garbage\n")
+        head = commit(self.repo, "head", "tester")
+        VM._RELOC_CACHE.clear()
+        evidence = VM._reloc_evidence(base, head)
+        self.assertFalse(evidence["valid"])
+        self.assertEqual(len(evidence["defects"]), 1)
+        # A destination present in either revision counts: a PR cannot earn "nothing
+        # points here" by deleting the row that says something does.
+        self.assertEqual(
+            VM._incoming_relocations(evidence["dests"], "arm9",
+                                     0x020049f0, 0x020049f4), 2)

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -1140,7 +1140,7 @@ class RelocIndex(unittest.TestCase):
         self.old_repo = VM.REPO
         VM.REPO = self.repo
         for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
-                      VM._SYMBOL_BASE_CACHE):
+                      VM._SYMBOL_BASE_CACHE, VM._SYMBOL_NAME_CACHE):
             cache.clear()
             self.addCleanup(cache.clear)
         self.addCleanup(setattr, VM, "REPO", self.old_repo)
@@ -1321,35 +1321,74 @@ BX_LR = 0xE12FFF1E
 MOV_PC_LR = 0xE1A0F00E
 POP_R4_PC = 0xE8BD8010
 LDMIA_SP_PC = 0xE8BD9FFF
+LDMFD_SP_PC = 0xE8BD8000
+LDM_R0_PC = 0xE8908000
+LDMDB_R0_PC = 0xE9108000
+LDMIB_R0_PC = 0xE9B08000
 
 
 class ReturnEncodings(unittest.TestCase):
-    """The accepted set, spelled out. The three shapes evidence_rom recognises."""
+    """The accepted set, spelled out: `bx lr` and a stack pop to pc, and nothing else.
+
+    Classified through `evidence_rom.is_unconditional_return` and then narrowed -- see
+    the block above `_is_return_word` for each narrowing and why it is there.
+    """
 
     def test_the_accepted_encodings(self):
-        for word in (BX_LR, MOV_PC_LR, POP_R4_PC, LDMIA_SP_PC):
+        for word in (BX_LR, POP_R4_PC, LDMIA_SP_PC, LDMFD_SP_PC):
             self.assertTrue(VM._is_return_word(word), hex(word))
+
+    def test_a_block_load_to_pc_through_any_other_base_is_refused(self):
+        # The mask this replaced tested the transfer bits and the pc bit and nothing
+        # else, so all three of these read as returns. What the loaded destination is,
+        # these four bytes do not say.
+        for word, why in ((LDM_R0_PC, "ldm r0, {pc}"),
+                          (LDMDB_R0_PC, "ldmdb r0, {pc}"),
+                          (LDMIB_R0_PC, "ldmib r0!, {pc}")):
+            self.assertFalse(VM._is_return_word(word), why)
 
     def test_everything_else_is_refused(self):
         for word, why in ((0x012FFF1E, "bxeq lr, a conditional return"),
                           (0xE12FFF13, "bx r3, not lr"),
+                          (MOV_PC_LR, "mov pc, lr, a register move; narrowed out"),
                           (0xE8BD0010, "pop {r4}, no pc in the list"),
                           (0xE8FD8010, "ldmia sp!, {r4, pc}^, restores CPSR"),
                           (0xE92D4010, "stmdb sp!, {r4, lr}, a store"),
                           (0xEAFFFFFE, "b self, an infinite loop"),
                           (0xE3A00000, "mov r0, #0"),
-                          (0xE49DF004, "ldr pc, [sp], #4, deliberately outside the set"),
+                          (0xE49DF004, "ldr pc, [sp], #4, not a block transfer"),
                           (0x00000000, "padding")):
             self.assertFalse(VM._is_return_word(word), why)
+
+
+def _code(word, instruction=True):
+    """A `code_owned` reader: the merged object covers the address as an INSTRUCTION
+    (or, with instruction=False, as a `$d` literal pool) and emits `word` there."""
+    def read(path, symbol, symbol_addr, addr):
+        return {"instruction": instruction, "word": word}
+    read.missing = set()
+    return read
+
+
+def _unnamed(module, addr):
+    """A `named` reader for a tree whose only symbol there is the address placeholder."""
+    return None
+
+
+def _names(name):
+    """A `named` reader for a tree that has a real name for every address."""
+    return lambda module, addr: name
 
 
 class AbsorbedEpilogue(unittest.TestCase):
     """The matched-loss exception, in `classify_merge` itself.
 
-    A record may leave `matched` only when all four hold: it is the exact TAIL of a new
-    `complete` range, it is one four-byte instruction whose ROM word is an accepted
-    return, that range is backed by compiled source, and a VALID relocation index names
-    nothing in its bytes. Each test below removes exactly one of them.
+    A record may leave `matched` only when all six hold: it is the exact TAIL of a new
+    `complete` range (a), four bytes whose ROM word is `bx lr` or a stack pop to pc (b),
+    that range is backed by compiled source (c), a VALID relocation index names nothing
+    in its bytes (d), no symbol in either revision NAMES the address (e), and the merged
+    function's own compiled object covers it as an instruction emitting that same word
+    (f). Each test below removes exactly one of them.
     """
 
     BODY, EPILOGUE, NEXT = 0x02071644, 0x02071694, 0x02071698
@@ -1367,18 +1406,20 @@ class AbsorbedEpilogue(unittest.TestCase):
     def test_a_ranges_own_tail_return_may_be_absorbed(self):
         base, head, be, he = self._merge()
         got = VM.classify_merge(base, head, be, he, _compiled(he), _relocs(self.BODY),
-                                _rom({("arm9", self.EPILOGUE): BX_LR}))
+                                _rom({("arm9", self.EPILOGUE): BX_LR}),
+                                _code(BX_LR), _unnamed)
         self.assertIsNotNone(got)
         self.assertEqual(got["absorbed"], [f"arm9:0x{self.EPILOGUE:08x}"])
         self.assertEqual(got["functionDelta"], -1)
         self.assertEqual(got["sourceByteDelta"], 0x50)
 
     def test_every_accepted_return_encoding_lands(self):
-        for word in (BX_LR, MOV_PC_LR, POP_R4_PC, LDMIA_SP_PC):
+        for word in (BX_LR, POP_R4_PC, LDMIA_SP_PC, LDMFD_SP_PC):
             base, head, be, he = self._merge()
             got = VM.classify_merge(base, head, be, he, _compiled(he),
                                     _relocs(self.BODY),
-                                    _rom({("arm9", self.EPILOGUE): word}))
+                                    _rom({("arm9", self.EPILOGUE): word}),
+                                    _code(word), _unnamed)
             self.assertIsNotNone(got, hex(word))
 
     def test_a_record_the_rom_calls_is_still_refused(self):
@@ -1386,42 +1427,96 @@ class AbsorbedEpilogue(unittest.TestCase):
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(
             base, head, be, he, _compiled(he), _relocs(self.BODY, self.EPILOGUE),
-            _rom({("arm9", self.EPILOGUE): BX_LR})))
+            _rom({("arm9", self.EPILOGUE): BX_LR}), _code(BX_LR), _unnamed))
 
     def test_a_load_of_the_address_counts_as_a_caller(self):
         # A `kind:load` destination is a reference like any other.
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(
             base, head, be, he, _compiled(he), _relocs(self.EPILOGUE),
-            _rom({("arm9", self.EPILOGUE): BX_LR})))
+            _rom({("arm9", self.EPILOGUE): BX_LR}), _code(BX_LR), _unnamed))
 
     def test_without_a_validated_relocation_index_nothing_matched_may_leave(self):
         # (d) again: None is what build_report passes when the index has a defect.
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(base, head, be, he, _compiled(he), None,
-                                            _rom({("arm9", self.EPILOGUE): BX_LR})))
+                                            _rom({("arm9", self.EPILOGUE): BX_LR}),
+                                            _code(BX_LR), _unnamed))
 
     def test_without_the_rom_image_nothing_matched_may_leave(self):
         # (b) cannot be checked, so it is not assumed.
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(base, head, be, he, _compiled(he),
-                                            _relocs(self.BODY), None))
+                                            _relocs(self.BODY), None,
+                                            _code(BX_LR), _unnamed))
         self.assertIsNone(VM.classify_merge(base, head, be, he, _compiled(he),
-                                            _relocs(self.BODY), _rom()))
+                                            _relocs(self.BODY), _rom(),
+                                            _code(BX_LR), _unnamed))
+
+    def test_without_code_ownership_nothing_matched_may_leave(self):
+        # (f) cannot be checked -- no compiler on this box -- so it is not assumed.
+        base, head, be, he = self._merge()
+        for code in (None, _code(None)):
+            self.assertIsNone(VM.classify_merge(
+                base, head, be, he, _compiled(he), _relocs(self.BODY),
+                _rom({("arm9", self.EPILOGUE): BX_LR}), code, _unnamed))
+
+    def test_a_literal_pool_at_the_tail_is_refused(self):
+        # (f). `unsigned int f(void) { return 0xe12fff1e; }` compiles under the pinned
+        # b56 to `e59f0000 e12fff1e e12fff1e`, and the object's mapping symbols put `$d`
+        # at offset 8. Same bits as a return, at the exact tail, with a clean index.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.EPILOGUE): BX_LR}),
+            _code(BX_LR, instruction=False), _unnamed))
+
+    def test_an_object_that_emits_a_different_word_is_refused(self):
+        # (f). The object covers the address with an instruction and it is not the
+        # cartridge's. Then the merged source does not reproduce that return.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.EPILOGUE): BX_LR}), _code(POP_R4_PC), _unnamed))
+
+    def test_a_named_callback_at_the_tail_is_refused(self):
+        # (e). Everything else holds -- exact tail, `bx lr` in the ROM, compiled range,
+        # clean index, an instruction in the object -- and config has a NAME for those
+        # bytes. Position is not identity.
+        base, head, be, he = self._merge()
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.EPILOGUE): BX_LR}), _code(BX_LR),
+            _names("AutoloadCallback")))
+        # And with no `named` reader at all, which is a missing answer, not a "no".
+        self.assertIsNone(VM.classify_merge(
+            base, head, be, he, _compiled(he), _relocs(self.BODY),
+            _rom({("arm9", self.EPILOGUE): BX_LR}), _code(BX_LR), None))
 
     def test_a_four_byte_record_that_is_not_a_return_is_refused(self):
         # (b). Byte coverage plus an empty index says nothing about what the bytes ARE.
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(
             base, head, be, he, _compiled(he), _relocs(self.BODY),
-            _rom({("arm9", self.EPILOGUE): 0xE3A00000})))
+            _rom({("arm9", self.EPILOGUE): 0xE3A00000}),
+            _code(0xE3A00000), _unnamed))
 
     def test_a_conditional_return_is_refused(self):
         # (b). bxeq lr leaves a live fall-through, so the bytes after it are reached.
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(
             base, head, be, he, _compiled(he), _relocs(self.BODY),
-            _rom({("arm9", self.EPILOGUE): 0x012FFF1E})))
+            _rom({("arm9", self.EPILOGUE): 0x012FFF1E}),
+            _code(0x012FFF1E), _unnamed))
+
+    def test_a_block_load_through_a_register_other_than_sp_is_refused(self):
+        # (b). `ldm r0, {pc}` transfers through whatever r0 holds. The bytes do not say.
+        for word in (LDM_R0_PC, LDMDB_R0_PC, LDMIB_R0_PC):
+            base, head, be, he = self._merge()
+            self.assertIsNone(VM.classify_merge(
+                base, head, be, he, _compiled(he), _relocs(self.BODY),
+                _rom({("arm9", self.EPILOGUE): word}), _code(word), _unnamed),
+                hex(word))
 
     def test_an_arbitrary_sized_matched_record_at_the_tail_is_refused(self):
         # (b). The 0x100-byte record: at the exact tail of a new compiled range with a
@@ -1429,29 +1524,30 @@ class AbsorbedEpilogue(unittest.TestCase):
         base, head, be, he = self._merge(epilogue_size=0x100)
         self.assertIsNone(VM.classify_merge(
             base, head, be, he, _compiled(he), _relocs(self.BODY),
-            _rom({("arm9", self.EPILOGUE): BX_LR})))
+            _rom({("arm9", self.EPILOGUE): BX_LR}), _code(BX_LR), _unnamed))
 
     def test_a_record_inside_the_range_but_not_at_its_tail_is_refused(self):
-        # (a). A named callback the merge happens to cover is not an epilogue. Placed
-        # mid-range: a record at the exact HEAD of a range cannot reach this clause at
-        # all, because head still carries a record at that address -- see the
-        # survives-but-loses-matched test below.
+        # (a), POSITION alone: the record carries the address placeholder, so (e) has
+        # nothing to say about it, and it is refused for sitting mid-range. A record at
+        # the exact HEAD of a range cannot reach this clause at all, because head still
+        # carries a record at that address -- see the survives-but-loses-matched test.
         base = _snap([("func_02071644", self.BODY, 0x20, False),
-                      ("AutoloadCallback", self.BODY + 0x20, 0x4, True),
+                      ("func_02071664", self.BODY + 0x20, 0x4, True),
                       ("func_02071668", self.BODY + 0x24, 0x30, False)])
         head = _snap([("func_02071644", self.BODY, 0x54, True)])
         be = _enr([(self.BODY + 0x20, self.BODY + 0x24)])
         he = _enr([(self.BODY, self.BODY + 0x54)])
         self.assertIsNone(VM.classify_merge(
             base, head, be, he, _compiled(he), _relocs(self.BODY),
-            _rom({("arm9", self.BODY + 0x20): BX_LR})))
+            _rom({("arm9", self.BODY + 0x20): BX_LR}), _code(BX_LR), _unnamed))
 
     def test_absorption_still_needs_a_new_compiled_range_over_the_bytes(self):
         # (c) and the merge rule's own evidence: no new range at all.
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(base, head, be, be, _compiled(be),
                                             _relocs(self.BODY),
-                                            _rom({("arm9", self.EPILOGUE): BX_LR})))
+                                            _rom({("arm9", self.EPILOGUE): BX_LR}),
+                                            _code(BX_LR), _unnamed))
 
     def test_a_transcription_cannot_absorb_a_matched_record_either(self):
         # (c). The covering range reproduces vacuously, so it proves nothing about the
@@ -1459,7 +1555,8 @@ class AbsorbedEpilogue(unittest.TestCase):
         base, head, be, he = self._merge()
         self.assertIsNone(VM.classify_merge(base, head, be, he, set(),
                                             _relocs(self.BODY),
-                                            _rom({("arm9", self.EPILOGUE): BX_LR})))
+                                            _rom({("arm9", self.EPILOGUE): BX_LR}),
+                                            _code(BX_LR), _unnamed))
 
     def test_a_record_that_survives_but_loses_matched_is_not_absorption(self):
         # Still present in head, so a banner went on or its source left. That is a
@@ -1471,7 +1568,8 @@ class AbsorbedEpilogue(unittest.TestCase):
                       ("func_02071698", self.NEXT, 0x4, False)])
         he = _enr([(self.BODY, self.BODY + 0x50)])
         self.assertIsNone(VM.classify_merge(base, head, _enr([]), he, _compiled(he),
-                                            _relocs(), _rom({}, BX_LR)))
+                                            _relocs(), _rom({}, BX_LR),
+                                            _code(BX_LR), _unnamed))
 
 
 class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
@@ -1517,7 +1615,7 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         VM.REPO = self.repo
         self.addCleanup(setattr, VM, "REPO", self.old_repo)
         for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
-                      VM._SYMBOL_BASE_CACHE):
+                      VM._SYMBOL_BASE_CACHE, VM._SYMBOL_NAME_CACHE):
             cache.clear()
             self.addCleanup(cache.clear)
 
@@ -1567,7 +1665,8 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         self.write_overlay_image(1, [word])
 
     def absorb(self, relocs=VALID_RELOCS, extra_reloc=None, epilogue_word=0xE12FFF1E,
-               epilogue_size=0x4, rom=True, orphan_module=False, data_only=None):
+               epilogue_size=0x4, rom=True, orphan_module=False, data_only=None,
+               code=None, record_name=None):
         """Commit a base and the fold on top of it, and report on the pair.
 
         `relocs` is the content of `config/arm9/relocs.txt` in BOTH revisions; None
@@ -1575,13 +1674,17 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         head only. `orphan_module` adds an overlay that declares a function and has no
         `relocs.txt` at all -- an incomplete module inventory. `data_only`, when given,
         adds a data-only ov001 whose single data word is that value and whose
-        `relocs.txt` is empty in both snapshots.
+        `relocs.txt` is empty in both snapshots. `code` replaces the compiled-code
+        evidence, which by default agrees with the cartridge: the merged object
+        covers the record as an instruction emitting `epilogue_word`. `record_name`
+        gives the retired symbol a real name instead of the address placeholder.
         """
         nxt = self.EPILOGUE + epilogue_size
         self.write("config/arm9/symbols.txt", "\n".join([
             f"Anchor kind:function(arm,size=0x4) addr:0x{self.ANCHOR:08x}",
             f"func_02071644 kind:function(arm,size=0x50) addr:0x{self.BODY:08x}",
-            f"func_02071694 kind:function(arm,size=0x{epilogue_size:x}) "
+            f"{record_name or 'func_02071694'} "
+            f"kind:function(arm,size=0x{epilogue_size:x}) "
             f"addr:0x{self.EPILOGUE:08x}",
             f"func_{nxt:08x} kind:function(arm,size=0x70) addr:0x{nxt:08x}",
             ""]))
@@ -1624,7 +1727,10 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         VM._RELOC_CACHE.clear()
         VM._ENROLMENT_CACHE.clear()
         VM._SYMBOL_BASE_CACHE.clear()
-        return VM.build_report(base, head)
+        VM._SYMBOL_NAME_CACHE.clear()
+        return VM.build_report(
+            base, head,
+            code_evidence=_code(epilogue_word) if code is None else code)
 
     def assertRefused(self, report, defect=None):
         self.assertIsNone(report["repartition"])
@@ -1729,6 +1835,46 @@ class AbsorbedEpilogueThroughBuildReport(unittest.TestCase):
         # word and nothing pointing at it. One instruction is the whole claim.
         self.assertRefused(self.absorb(epilogue_size=0x100))
 
+    def test_a_named_callback_at_the_tail_fails_the_report(self):
+        # Everything else holds: exact tail, `bx lr` in the cartridge, a compiled
+        # covering range, a clean index, an instruction in the merged object. Config
+        # has a NAME for those four bytes, so they are not the placeholder this rule
+        # exists to retire. The existing mid-range control tests position; this one
+        # tests identity.
+        report = self.absorb(record_name="AutoloadCallback")
+        self.assertRefused(report)
+        self.assertTrue(report["relocationEvidence"]["valid"])
+
+    def test_a_literal_pool_at_the_tail_fails_the_report(self):
+        # The merged object covers the address, and covers it with DATA -- the `$d`
+        # region a compiler-generated literal pool sits in. Its bits are 0xe12fff1e
+        # either way. CompiledCodeOwnership below builds the real object.
+        report = self.absorb(code=_code(BX_LR, instruction=False))
+        self.assertRefused(report)
+        self.assertTrue(report["relocationEvidence"]["valid"])
+
+    def test_a_block_load_through_r0_fails_the_report(self):
+        # `ldm r0, {pc}` at the record. A block load to pc through a register these
+        # four bytes say nothing about is not a return this rule accepts.
+        report = self.absorb(epilogue_word=LDM_R0_PC)
+        self.assertRefused(report)
+        self.assertTrue(report["relocationEvidence"]["valid"])
+
+    def test_without_code_ownership_the_report_fails_closed(self):
+        # No compiler on the box: the exception is unavailable and the report says
+        # so, the same way it does without the ROM image.
+        missing = _code(BX_LR)
+        missing.missing.add("the pinned compiler 2004/b56 is not installed")
+
+        def read(path, symbol, symbol_addr, addr):
+            return None
+        read.missing = missing.missing
+        report = self.absorb(code=read)
+        self.assertRefused(report)
+        self.assertIn("compiled code ownership unavailable, so nothing matched may "
+                      "leave: the pinned compiler 2004/b56 is not installed",
+                      report["reasons"])
+
     def test_without_the_rom_image_the_report_fails_closed(self):
         report = self.absorb(rom=False)
         self.assertRefused(report)
@@ -1776,7 +1922,7 @@ class DataLeadingOverlayImageBase(unittest.TestCase):
         VM.REPO = self.repo
         self.addCleanup(setattr, VM, "REPO", self.old_repo)
         for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
-                      VM._SYMBOL_BASE_CACHE):
+                      VM._SYMBOL_BASE_CACHE, VM._SYMBOL_NAME_CACHE):
             cache.clear()
             self.addCleanup(cache.clear)
 
@@ -1860,8 +2006,9 @@ class DataLeadingOverlayImageBase(unittest.TestCase):
         VM._RELOC_CACHE.clear()
         VM._ENROLMENT_CACHE.clear()
         VM._SYMBOL_BASE_CACHE.clear()
+        VM._SYMBOL_NAME_CACHE.clear()
         self.base, self.head = base, head
-        return VM.build_report(base, head)
+        return VM.build_report(base, head, code_evidence=_code(record_word))
 
     def test_the_reader_answers_from_the_lowest_symbol_not_the_first_function(self):
         self.absorb()
@@ -1885,3 +2032,188 @@ class DataLeadingOverlayImageBase(unittest.TestCase):
         self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 1)
         self.assertEqual([a["name"] for a in report["matchedAbsorbed"]],
                          [f"func_{self.EPILOGUE:08x}"])
+
+
+def _pinned_compiler_present():
+    try:
+        import build_pin as BP
+    except Exception:                                          # noqa: BLE001
+        return False
+    return (BP.MW / BP.DEFAULT_VERSION / "mwccarm.exe").is_file()
+
+
+@unittest.skipUnless(_pinned_compiler_present(), "mwccarm not present")
+class CompiledCodeOwnership(unittest.TestCase):
+    """`_compiled_code_reader` against the real pinned compiler and a real object.
+
+    The report fixtures above hand `build_report` a stub, because the runner that
+    runs this suite has no toolchain and a stub is how the WIRING gets tested there.
+    These test the reader itself, which is where the claim actually lives: that the
+    ARM EABI mapping symbols in the object mwccarm produces separate an instruction
+    from a literal pool, and that a pool with a return's exact bits really occurs.
+    """
+
+    LITERAL = "unsigned int func_02071644(void) { return 0xe12fff1e; }\n"
+    BODY = "\n".join([
+        "void func_02071644(unsigned char *p, int len) {",
+        "    for (;;) { if (*p < 9) { (*p)++; return; } *p-- = 0; }",
+        "}",
+        ""])
+
+    def read_for(self, source):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        repo = pathlib.Path(self.tmp.name)
+        git(repo, "init", "-q", ".")
+        (repo / "src").mkdir()
+        (repo / "src" / "func_02071644.c").write_text(source, encoding="utf-8",
+                                                      newline="\n")
+        old_repo = VM.REPO
+        VM.REPO = repo
+        self.addCleanup(setattr, VM, "REPO", old_repo)
+        head = commit(repo, "source", "alice")
+        return VM._compiled_code_reader(head)
+
+    def test_a_literal_pools_bits_are_data_not_an_epilogue(self):
+        # b56 emits `e59f0000 e12fff1e e12fff1e`: ldr, the real return, then the
+        # constant. Offset 8 is `$d`, and offset 4 -- the same bits -- is `$a`.
+        read = self.read_for(self.LITERAL)
+        pool = read("src/func_02071644.c", "func_02071644", 0x02071644, 0x0207164C)
+        self.assertEqual(pool, {"instruction": False, "word": BX_LR})
+        real = read("src/func_02071644.c", "func_02071644", 0x02071644, 0x02071648)
+        self.assertEqual(real, {"instruction": True, "word": BX_LR})
+        self.assertEqual(read.missing, set())
+
+    def test_a_recovered_body_owns_its_own_final_return(self):
+        # The body the report fixtures compile: 0x24 bytes, one `$a` region, `bx lr`
+        # at 0x20. The live case has this shape and must keep landing.
+        read = self.read_for(self.BODY)
+        end = read("src/func_02071644.c", "func_02071644", 0x02071644, 0x02071664)
+        self.assertEqual(end, {"instruction": True, "word": BX_LR})
+        self.assertEqual(read.missing, set())
+
+    def test_an_address_outside_the_symbol_is_not_owned(self):
+        read = self.read_for(self.BODY)
+        self.assertEqual(
+            read("src/func_02071644.c", "func_02071644", 0x02071644, 0x02071668),
+            {"instruction": False, "word": None})
+
+    def test_a_source_that_does_not_compile_answers_nothing(self):
+        read = self.read_for("void func_02071644(void) { not C at all; }\n")
+        self.assertIsNone(
+            read("src/func_02071644.c", "func_02071644", 0x02071644, 0x02071644))
+        self.assertTrue(any("does not compile" in m for m in read.missing),
+                        read.missing)
+
+
+@unittest.skipUnless(_pinned_compiler_present(), "mwccarm not present")
+class LiteralPoolThroughBuildReport(unittest.TestCase):
+    """The literal-pool fixture end to end, against the REAL compiled object.
+
+    `unsigned int func_02071644(void) { return 0xe12fff1e; }` compiles under the
+    pinned b56 to `e59f0000 e12fff1e e12fff1e`. The last word is the function's own
+    literal pool: at the exact tail of the range this merge newly compiles, four
+    bytes long, with a return's exact bits, backed by compiled source, named by no
+    symbol and pointed at by no relocation. Every clause but code ownership holds,
+    and before code ownership the report Passed with one absorbed record.
+
+    No stub anywhere in this class: `build_report` builds its own reader, compiles
+    the committed head blob with the pinned compiler and reads that object's ARM
+    EABI mapping symbols.
+    """
+
+    ANCHOR, BODY, EPILOGUE, NEXT = 0x02004000, 0x02071644, 0x0207164C, 0x02071650
+    RELOCS = ("from:0x02071354 kind:arm_call to:0x02071644 module:main\n"
+              "from:0x02071614 kind:arm_call to:0x02004000 module:main\n")
+    RECOVERED = "unsigned int func_02071644(void) { return 0xe12fff1e; }\n"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = pathlib.Path(self.tmp.name)
+        git(self.repo, "init", "-q", ".")
+        (self.repo / ".gitignore").write_text("extracted/\n", encoding="utf-8")
+        self.old_repo = VM.REPO
+        VM.REPO = self.repo
+        self.addCleanup(setattr, VM, "REPO", self.old_repo)
+        for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
+                      VM._SYMBOL_BASE_CACHE, VM._SYMBOL_NAME_CACHE):
+            cache.clear()
+            self.addCleanup(cache.clear)
+
+    def write(self, rel, text):
+        path = self.repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+
+    def delinks(self, entry, start, end):
+        return "\n".join([
+            "    .text start:0x02000000 end:0x02100000 kind:code",
+            "",
+            "src/Anchor.c:",
+            "    complete",
+            f"    .text start:0x{self.ANCHOR:08x} end:0x{self.ANCHOR + 4:08x}",
+            "",
+            f"{entry}:",
+            "    complete",
+            f"    .text start:0x{start:08x} end:0x{end:08x}",
+            ""])
+
+    def absorb(self, source=None):
+        self.write("config/arm9/symbols.txt", "\n".join([
+            f"Anchor kind:function(arm,size=0x4) addr:0x{self.ANCHOR:08x}",
+            f"func_02071644 kind:function(arm,size=0x8) addr:0x{self.BODY:08x}",
+            f"func_0207164c kind:function(arm,size=0x4) addr:0x{self.EPILOGUE:08x}",
+            f"func_02071650 kind:function(arm,size=0x70) addr:0x{self.NEXT:08x}",
+            ""]))
+        self.write("config/arm9/delinks.txt",
+                   self.delinks("src/func_0207164c.c", self.EPILOGUE, self.NEXT))
+        self.write("config/arm9/relocs.txt", self.RELOCS)
+        self.write("src/Anchor.c", "int Anchor(void) { return 0; }\n")
+        self.write("src/func_02071644.c",
+                   "// NONMATCHING: hand-written asm, does NOT count as matched.\n"
+                   "void func_02071644(void) {}\n")
+        self.write("src/func_0207164c.c", "void func_0207164c(void)\n{\n}\n")
+        self.write("src/func_02071650.c", "int func_02071650(void) { return 1; }\n")
+        base = commit(self.repo, "base", "alice")
+
+        self.write("config/arm9/symbols.txt", "\n".join([
+            f"Anchor kind:function(arm,size=0x4) addr:0x{self.ANCHOR:08x}",
+            f"func_02071644 kind:function(arm,size=0xc) addr:0x{self.BODY:08x}",
+            f"func_02071650 kind:function(arm,size=0x70) addr:0x{self.NEXT:08x}",
+            ""]))
+        self.write("config/arm9/delinks.txt",
+                   self.delinks("src/func_02071644.c", self.BODY, self.NEXT))
+        self.write("src/func_02071644.c", self.RECOVERED if source is None else source)
+        os.remove(self.repo / "src" / "func_0207164c.c")
+        offset = self.EPILOGUE - VM.ARM9_IMAGE_BASE
+        image = bytearray(offset + 4)
+        image[offset:offset + 4] = BX_LR.to_bytes(4, "little")
+        (self.repo / "extracted").mkdir(exist_ok=True)
+        (self.repo / "extracted" / "arm9_dec.bin").write_bytes(bytes(image))
+        head = commit(self.repo, "absorb", "bob")
+        for cache in (VM._RELOC_CACHE, VM._ENROLMENT_CACHE,
+                      VM._SYMBOL_BASE_CACHE, VM._SYMBOL_NAME_CACHE):
+            cache.clear()
+        return VM.build_report(base, head)
+
+    def test_the_pools_bits_do_not_make_it_an_epilogue(self):
+        report = self.absorb()
+        self.assertIsNone(report["repartition"])
+        self.assertIn("lost 1 matched function(s)", report["reasons"])
+        self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 0)
+        self.assertEqual(report["matchedAbsorbed"], [])
+        # Refused on code ownership alone: the index is clean and the word is a
+        # return, so neither of the other two guards is doing the work here.
+        self.assertTrue(report["relocationEvidence"]["valid"])
+        self.assertTrue(VM._is_return_word(BX_LR))
+
+    def test_a_body_that_really_ends_in_that_instruction_still_lands(self):
+        # The positive control, same tree and same compiler: three instructions
+        # ending in the `bx lr` the cartridge has, one `$a` region, no pool.
+        report = self.absorb(
+            source="int func_02071644(int a, int b) { return a + b + 1; }\n")
+        self.assertEqual(report["reasons"], [])
+        self.assertEqual(report["coverage"]["delta"]["absorbedMatchedFunctions"], 1)
+        self.assertEqual([a["name"] for a in report["matchedAbsorbed"]],
+                         ["func_0207164c"])

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -949,6 +949,50 @@ class MergeEvidence(unittest.TestCase):
         self.assertIsNone(VM.classify_merge(base, head, None, None, set()))
 
 
+class MergeArithmetic(unittest.TestCase):
+    """`sourceBytes` must rise by the NEW coverage, which is not the new extent.
+
+    A range the base was already compiling, lying wholly inside one of the merge's new
+    ranges, did not become covered here: its bytes moved from one `complete` entry to
+    another and were in `sourceBytes` all along. Comparing against the raw extent made
+    an honest fold over an already-enrolled neighbour fail for arithmetic (+80 against
+    an extent of 84) with nothing wrong.
+
+    A base range that leaves from OUTSIDE every new range is the opposite: real lost
+    coverage, and it is deliberately not subtracted, so it still shortens the delta and
+    the comparison still refuses it. That clause is the anti-smuggling one, and the
+    second test holds it in place.
+    """
+
+    BODY, EPILOGUE = 0x02071644, 0x02071694
+    ELSEWHERE = 0x02050000
+
+    def test_bytes_the_base_already_compiled_are_not_new_coverage(self):
+        base = _snap([("func_02071644", self.BODY, 0x50, False),
+                      ("func_02071694", self.EPILOGUE, 0x4, False)])
+        head = _snap([("func_02071644", self.BODY, 0x54, True)])
+        be = _enr([(self.EPILOGUE, self.EPILOGUE + 0x4)])
+        he = _enr([(self.BODY, self.BODY + 0x54)])
+        # sourceBytes: 4 -> 84, a rise of 80 against a new extent of 84.
+        self.assertEqual(he["stats"]["sourceBytes"] - be["stats"]["sourceBytes"], 0x50)
+        got = VM.classify_merge(base, head, be, he, _compiled(he))
+        self.assertIsNotNone(got)
+        self.assertEqual(got["newExtent"], 0x54)
+        self.assertEqual(got["absorbedBytes"], 0x4)
+        self.assertEqual(got["sourceByteDelta"], 0x50)
+
+    def test_an_unrelated_range_leaving_under_cover_of_the_merge_still_fails(self):
+        # The outside-a-range clause, unchanged: this range is nowhere near the merge,
+        # so its bytes are not subtracted and the arithmetic catches the loss.
+        base = _snap([("func_02071644", self.BODY, 0x50, False),
+                      ("func_02071694", self.EPILOGUE, 0x4, False)])
+        head = _snap([("func_02071644", self.BODY, 0x54, True)])
+        be = _enr([(self.EPILOGUE, self.EPILOGUE + 0x4),
+                   (self.ELSEWHERE, self.ELSEWHERE + 0x40)])
+        he = _enr([(self.BODY, self.BODY + 0x54)])
+        self.assertIsNone(VM.classify_merge(base, head, be, he, _compiled(he)))
+
+
 class MergeEvidenceThroughBuildReport(unittest.TestCase):
     """The same rule driven through `build_report` on a real tree, not hand-built dicts.
 

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -335,24 +335,83 @@ def _is_return_word(word):
     return (word >> 28) == 0xE and (word & _LDM_PC_MASK) == _LDM_PC_VALUE
 
 
+_SYMBOL_ROW = re.compile(r"^(\S+)\s+kind:\S.*?\baddr:0x([0-9a-fA-F]+)")
+_SYMBOL_BASE_CACHE = {}
+
+
+def _module_symbols_path(module):
+    """Where a module's ``symbols.txt`` lives, for every module this report names."""
+    if module == "arm9":
+        return "config/arm9/symbols.txt"
+    if module in ("itcm", "dtcm"):
+        return f"config/arm9/{module}/symbols.txt"
+    return (f"config/arm9/overlays/{module}/symbols.txt"
+            if re.fullmatch(r"ov\d+", module or "") else None)
+
+
+def _module_symbol_base(rev, module):
+    """A module's image base at ``rev``: the LOWEST address of ANY symbol it declares.
+
+    The revision-pinned equivalent of `modules._overlay_base`, which is the derivation
+    the rest of the repo already uses -- the byte gate, `match.py --module ovNNN` and
+    `evidence_rom` all read an overlay this way. dsd relocates each overlay to a unique
+    address in the delinked config space, and the module's lowest symbol IS that base.
+
+    ANY SYMBOL, NOT THE FIRST FUNCTION. `_rev_enrolment` collects function rows only,
+    because the question it answers is which file owns a symbol. A module whose lowest
+    symbol is DATA -- config declares `data_...` rows in the same table -- then has a
+    base below its first function, and an image read based on the first function is
+    displaced by exactly that distance: every query answers with an earlier word. On a
+    guard whose whole job is to ask "is the cartridge's word at this address a return",
+    reading the word in FRONT of the address is the difference between refusing a
+    `mov r0, #0` and absorbing it as a `bx lr`.
+    """
+    path = _module_symbols_path(module)
+    if path is None:
+        return None
+    key = (str(REPO), rev, module)
+    if key not in _SYMBOL_BASE_CACHE:
+        lo = None
+        try:
+            text = git_text(rev, path)
+        except RuntimeError:
+            text = ""
+        for line in text.splitlines():
+            m = _SYMBOL_ROW.match(line)
+            if m:
+                addr = int(m.group(2), 16)
+                lo = addr if lo is None else min(lo, addr)
+        _SYMBOL_BASE_CACHE[key] = lo
+    return _SYMBOL_BASE_CACHE[key]
+
+
 def _module_image(rev, module):
     """``(bytes, base address)`` of a module's cartridge image, or None if absent.
 
     The images are gitignored extraction output, so a checkout that has never run
     `tools/unpack.py` has none. Absent is answered as None and every caller treats
     that as "no evidence", never as "the evidence says yes".
+
+    ARM9 is the one module with a fixed base: `arm9_dec.bin` loads at 0x02004000
+    whatever its lowest symbol is. Every other module is based at its lowest symbol --
+    see `_module_symbol_base` -- and itcm and dtcm are read from the same two places
+    `modules.py` looks, so a checkout that has only run `tools/unpack.py` still has them.
     """
     if module == "arm9":
         path, base = REPO / ARM9_IMAGE, ARM9_IMAGE_BASE
     else:
-        m = re.fullmatch(r"ov(\d+)", module or "")
-        if m is None:
+        if module in ("itcm", "dtcm"):
+            candidates = [REPO / "build" / "build" / f"{module}.bin",
+                          REPO / "extracted" / "dsd" / "arm9" / f"{module}.bin"]
+            path = next((c for c in candidates if c.is_file()), candidates[-1])
+        elif re.fullmatch(r"ov\d+", module or ""):
+            path = (REPO / "extracted" / "overlays"
+                    / f"overlay_{int(module[2:]):04d}.bin")
+        else:
             return None
-        path = REPO / "extracted" / "overlays" / f"overlay_{int(m.group(1)):04d}.bin"
-        addrs = _rev_enrolment(rev)[0].get(module) or []
-        if not addrs:
+        base = _module_symbol_base(rev, module)
+        if base is None:
             return None
-        base = addrs[0]
     try:
         return path.read_bytes(), base
     except OSError:

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -173,6 +173,123 @@ def _is_symbols_file(path):
         or path == "config/arm9/symbols.txt"
 
 
+_SECTION_ROW = re.compile(
+    r"^\s+(\.\S+)\s+start:0x([0-9a-fA-F]+)\s+end:0x([0-9a-fA-F]+)\s+kind:(\S+)")
+
+
+def _module_from_config_path(path):
+    """The module a ``config/arm9/**`` file belongs to, INCLUDING itcm and dtcm.
+
+    `_module_from_symbols` and `_module_from_delinks` answer only for the modules this
+    report COUNTS, which is the right scope for the coverage arithmetic and the wrong
+    one for evidence: `config/arm9/itcm` and `config/arm9/dtcm` hold real cartridge
+    bytes and real relocation files.
+    """
+    rel = pathlib.PurePosixPath(path)
+    parts = rel.parts
+    if len(parts) < 3 or parts[0] != "config" or parts[1] != "arm9":
+        return None
+    if len(parts) == 3:
+        return "arm9"
+    if len(parts) == 4 and parts[2] in ("itcm", "dtcm"):
+        return parts[2]
+    if len(parts) == 5 and parts[2] == "overlays" and re.fullmatch(r"ov\d+", parts[3]):
+        return parts[3]
+    return None
+
+
+def _module_sections(rev, module):
+    """A module's OWN section inventory at ``rev``: ``[(name, start, end, kind)]``.
+
+    dsd writes it as the indented block at the top of the module's ``delinks.txt``,
+    ahead of the first entry -- the same block `_rev_enrolment` skips because an entry
+    would otherwise inherit it. None when the file is absent or carries no such block,
+    which callers must read as "no evidence" and never as "the module is empty".
+    """
+    path = _module_symbols_path(module)
+    if path is None:
+        return None
+    path = path[:-len("symbols.txt")] + "delinks.txt"
+    try:
+        text = git_text(rev, path)
+    except RuntimeError:
+        return None
+    rows = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        if not line[0].isspace():
+            break                       # the first entry; the module header is over
+        m = _SECTION_ROW.match(line)
+        if m:
+            rows.append((m.group(1), int(m.group(2), 16), int(m.group(3), 16),
+                         m.group(4)))
+    return rows or None
+
+
+def _empty_relocs_defect(rev, symbols_path, reloc_path, declared):
+    """Why an EMPTY ``relocs.txt`` is not complete evidence, or None when it is.
+
+    A count of functions cannot answer this. dsd writes one relocation row per word it
+    resolved to a symbol, wherever that word lives -- and a module with no code at all
+    can still hold a table of callback pointers in its `.data`, each of which is an
+    incoming reference to some other module. Fourteen modules in this tree do carry a
+    legitimately empty file, so refusing all of them is not the answer either.
+
+    THE EVIDENCE IS WHAT dsd WROTE, in this order:
+
+      * a module that declares a FUNCTION has code, and code holds references. An empty
+        file beside it is incomplete, full stop.
+      * otherwise the module's own section inventory decides. `.bss` is uninitialised --
+        it occupies no cartridge bytes and can hold no pointer in the image -- so a
+        module whose every other section is zero-length really does reference nothing.
+        That is the fourteen: `config/arm9/dtcm` aside, every overlay with an empty file
+        has a zero-length `.ctor` and a `.bss`.
+      * a module WITH initialised bytes has to be read. Its words are either all zero,
+        in which case they name no address and the empty file is complete, or they are
+        not, in which case an empty relocation file cannot be shown to account for them.
+
+    FAIL CLOSED WHEN THE EVIDENCE IS UNAVAILABLE: no section inventory, or an image this
+    checkout does not have, is a defect naming the file it wanted -- never a pass.
+    """
+    module = _module_from_config_path(symbols_path)
+    where = f"is empty at {rev[:12]}"
+    if declared:
+        return (f"{reloc_path} {where} while {symbols_path} declares "
+                f"{declared} function(s)")
+    if module is None:
+        return f"{reloc_path} {where} and names no module this report can read"
+    sections = _module_sections(rev, module)
+    if sections is None:
+        return (f"{reloc_path} {where} and {module} has no section inventory, so "
+                f"nothing establishes that it holds no references")
+    initialised = [(name, start, end) for name, start, end, kind in sections
+                   if kind != "bss" and end > start]
+    if not initialised:
+        return None
+    image = _module_image(rev, module)
+    if image is None:
+        return (f"{reloc_path} {where} while {module} carries "
+                f"{sum(e - s for _n, s, e in initialised)} byte(s) of initialised data, "
+                f"and the module image is unavailable, so the evidence cannot be "
+                f"completed")
+    data, base = image
+    for name, start, end in initialised:
+        lo, hi = start - base, end - base
+        if lo < 0 or hi > len(data):
+            return (f"{reloc_path} {where} and {module}{name} "
+                    f"(0x{start:08x}..0x{end:08x}) lies outside the module image, so "
+                    f"its words cannot be read")
+        chunk = data[lo:hi]
+        for off in range(0, len(chunk), 4):
+            word = int.from_bytes(chunk[off:off + 4].ljust(4, b"\x00"), "little")
+            if word:
+                return (f"{reloc_path} {where} while {module}{name} holds a nonzero "
+                        f"word 0x{word:08x} at 0x{start + off:08x}, which an empty "
+                        f"relocation file does not account for")
+    return None
+
+
 def _reloc_index(rev):
     """The relocation destination index at ``rev``, WITH the defects that invalidate it.
 
@@ -196,14 +313,26 @@ def _reloc_index(rev):
 
       * every module whose ``symbols.txt`` declares at least one function must have a
         ``relocs.txt`` beside it, present and non-empty, at this revision;
-      * a module that declares no function may have an empty file (15 of them at
-        cd3a7eb59: `config/arm9/dtcm` and fourteen overlays whose sections are all
-        zero-length, e.g. ov061's `.text start:0x02115ec0 end:0x02115ec0`);
+      * a module that declares no function may have an empty file, but only when its
+        own section inventory or its own bytes say it can hold no reference -- a count
+        of functions does not establish that, and `_empty_relocs_defect` carries the
+        rule (15 modules qualify at cd3a7eb59: fourteen overlays whose non-`bss`
+        sections are all zero-length, e.g. ov061's `.ctor start:0x02115ec0
+        end:0x02115ec0`, and `config/arm9/dtcm`, whose 0x20 of `.data` is all zeroes);
       * every line of every file must be one of the two documented row shapes, and
         every destination token one of the documented set;
       * an unreadable blob is a defect rather than an exception, so the caller fails
         closed with a reason naming the file instead of the worker failing with a
         traceback.
+
+    WHAT THIS COSTS A CHECKOUT WITHOUT `extracted/`. One module in this tree,
+    `config/arm9/dtcm`, has an empty relocation file beside 0x20 of real `.data`, and
+    the only way to tell that data from a table of callback pointers is to read it (it
+    is all zeroes). A checkout that has never run `tools/unpack.py` cannot, so the index
+    there carries exactly one defect and the matched-loss exception is unavailable --
+    which is the same position the exception is already in without the ROM image, and
+    it changes no other number the report prints. Measured at 5b49059f6: 92 destination
+    buckets and 96,395 destinations either way, 0 defects with the images and 1 without.
 
     A defect does not make this function raise and does not empty the index. It makes
     the EVIDENCE invalid, and callers that need valid evidence to permit something must
@@ -242,9 +371,12 @@ def _reloc_index(rev):
             if sibling not in texts:
                 defects.append(f"{sibling} is missing at {rev[:12]} while {path} "
                                f"declares {declared} function(s)")
-            elif declared and not texts[sibling].strip():
-                defects.append(f"{sibling} is empty at {rev[:12]} while {path} "
-                               f"declares {declared} function(s)")
+            elif not texts[sibling].strip():
+                # NOT "declared and ...". Zero functions does not make an empty
+                # relocation file complete -- see `_empty_relocs_defect`.
+                defect = _empty_relocs_defect(rev, path, sibling, declared)
+                if defect:
+                    defects.append(defect)
         dests = collections.defaultdict(list)
         for path in reloc_paths:
             for number, line in enumerate(texts.get(path, "").splitlines(), 1):

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -296,6 +296,95 @@ def _reloc_evidence(base, head):
             "valid": not defects}
 
 
+# WHERE THE CARTRIDGE'S OWN BYTES LIVE. `extracted/arm9_dec.bin` is the DECOMPRESSED
+# main binary and it loads at 0x02004000, not at the 0x02000000 RAM base -- the same
+# constant `tools/modules.py`, `tools/match.py` and `tools/evidence_rom.py` use, and
+# the byte gate reads a function's bytes exactly this way. An overlay's image is
+# `extracted/overlays/overlay_NNNN.bin`, based at its lowest symbol address in the
+# config's relocated space (`modules.py:_overlay_base`), read here from the revision
+# under judgement rather than from the worktree.
+ARM9_IMAGE = "extracted/arm9_dec.bin"
+ARM9_IMAGE_BASE = 0x02004000
+
+# THE ACCEPTED RETURN ENCODINGS, and nothing else. These are the three shapes
+# `tools/evidence_rom.py:is_unconditional_return` recognises, spelled at the encoding
+# level so this tool needs no disassembler on the validator box:
+#
+#   bx lr                  0xE12FFF1E
+#   mov pc, lr             0xE1A0F00E
+#   ldm/pop writing pc     condition AL, block data transfer, L=1, S=0, and r15 in the
+#                          register list -- e.g. `pop {r4, pc}` 0xE8BD8010
+#
+# CONDITION AL ONLY, matching evidence_rom: a conditional return (`bxeq lr`,
+# `popne {.., pc}`) leaves a live fall-through path, so the bytes after it are still
+# reached and the record is not a severed tail. The S bit (`ldm ... ^`) restores CPSR
+# -- an exception return, not a function return, and on the never-in-C list in
+# notes/asm-policy.md. `ldr pc, [sp], #4` (0xE49DF004) is a return in practice and is
+# deliberately NOT accepted: capstone decodes it as LDR, so evidence_rom does not
+# recognise it either, and a narrower set is the safe direction for a rule that
+# permits a matched record to leave.
+RETURN_WORDS = (0xE12FFF1E, 0xE1A0F00E)
+_LDM_PC_MASK = 0x0E508000
+_LDM_PC_VALUE = 0x08108000
+
+
+def _is_return_word(word):
+    """Is this 32-bit ARM word one of the accepted unconditional return encodings?"""
+    if word in RETURN_WORDS:
+        return True
+    return (word >> 28) == 0xE and (word & _LDM_PC_MASK) == _LDM_PC_VALUE
+
+
+def _module_image(rev, module):
+    """``(bytes, base address)`` of a module's cartridge image, or None if absent.
+
+    The images are gitignored extraction output, so a checkout that has never run
+    `tools/unpack.py` has none. Absent is answered as None and every caller treats
+    that as "no evidence", never as "the evidence says yes".
+    """
+    if module == "arm9":
+        path, base = REPO / ARM9_IMAGE, ARM9_IMAGE_BASE
+    else:
+        m = re.fullmatch(r"ov(\d+)", module or "")
+        if m is None:
+            return None
+        path = REPO / "extracted" / "overlays" / f"overlay_{int(m.group(1)):04d}.bin"
+        addrs = _rev_enrolment(rev)[0].get(module) or []
+        if not addrs:
+            return None
+        base = addrs[0]
+    try:
+        return path.read_bytes(), base
+    except OSError:
+        return None
+
+
+def _rom_word_reader(rev):
+    """``read(module, addr)`` -> the cartridge's own word there, or None.
+
+    Also carries `.missing`, the set of modules whose image could not be read, so a
+    caller that had to refuse for want of the ROM can say which file it wanted.
+    """
+    cache = {}
+
+    def read(module, addr):
+        if module not in cache:
+            cache[module] = _module_image(rev, module)
+            if cache[module] is None:
+                read.missing.add(module)
+        image = cache[module]
+        if image is None:
+            return None
+        data, base = image
+        offset = addr - base
+        if offset < 0 or offset + 4 > len(data):
+            return None
+        return int.from_bytes(data[offset:offset + 4], "little")
+
+    read.missing = set()
+    return read
+
+
 def _incoming_relocations(dests, module, addr, end):
     """How many relocation destinations land inside ``[addr, end)`` of ``module``."""
     total = 0
@@ -430,7 +519,7 @@ def _covered_spans(snapshot):
     return out
 
 
-def classify_merge(bf, hf, be, he, compiled):
+def classify_merge(bf, hf, be, he, compiled, reloc_dests=None, rom_word=None):
     """Is a denominator DROP a merge the ROM build has already paid for?
 
     A merge lowers `totalFunctions` and so RAISES the headline, which is the direction an
@@ -469,15 +558,54 @@ def classify_merge(bf, hf, be, he, compiled):
     modifies, so enrolling a file the merge does not touch is refused as well -- a fold
     that never edits the source absorbing it is not a shape this carve-out is for.
 
-    NOTHING MATCHED MAY LEAVE. The removed records must all be unmatched in base -- a
-    merge is licensed to absorb ASM stubs and severed epilogues, never to swallow a
-    function someone had already matched. Matched records that survive keep their sizes,
-    with one exception: a survivor of the merge may grow, and only into the new
-    `complete` range, at exactly its head size.
+    NOTHING MATCHED MAY LEAVE, EXCEPT A RANGE'S OWN RETURN INSTRUCTION. The removed
+    records are normally all unmatched in base -- a merge is licensed to absorb ASM stubs
+    and severed epilogues, never to swallow a function someone had already matched.
+    Matched records that survive keep their sizes, with one exception: a survivor of the
+    merge may grow, and only into the new `complete` range, at exactly its head size.
 
-    The live case is a hand-asm pair reunited as one C++ body: `__destroy_arr` declared
-    0x5c in `symbols.txt` while the ROM's own `.exceptix` record gives 0x74, the trailing
-    0x18 carried as a separate symbol that is not a function at all but the catch handler.
+    The narrow exception exists because config can carve a function's trailing return
+    instruction off as its own symbol, and an empty body then "matches" it. Recovering
+    the real function retires that record, and the absolute rule made the correction the
+    one edit that cannot land. WHAT IS AND IS NOT CLAIMED HERE. This does not claim that
+    ROM execution can never enter the address -- an index cannot establish that, and the
+    earlier version of this rule said so and was wrong to. The claim is narrower and each
+    half is checkable:
+
+      (a) the record ends exactly where the new `complete` range ends, so it is that
+          range's TAIL and not something in the middle of it;
+      (b) it is one instruction, four bytes, and the cartridge's own word at that address
+          is one of the accepted unconditional return encodings (see RETURN_WORDS) -- so
+          the bytes being retired are a return, not a body;
+      (c) the range is backed by compiled source, which the ROM build then links and
+          byte-compares against retail, so the merged function REPRODUCES that same
+          return instruction rather than merely covering its address;
+      (d) no relocation destination in a VALIDATED index over both revisions lands in
+          those bytes -- with the emphasis on validated: missing, empty or malformed
+          relocation input is not an absence of callers, it is an absence of evidence,
+          and `_reloc_index` reports it as a defect that makes this exception
+          unavailable.
+
+    Together those say: this record is the return instruction of the function whose
+    source now compiles to it, and nothing in the tree's relocation index names it. They
+    do not say the address is unreachable. A record that fails any one of them stays
+    matched and the merge is refused.
+
+    THE EXCEPTION IS NARROW, MEASURED RATHER THAN ASSERTED. Over src/ at 8525428a2 there
+    are 79 sources whose whole body is `void f(void) {}`; 77 have at least one incoming
+    relocation and are ordinary no-op functions the ROM really calls. Two have zero:
+    `AutoloadCallback` (0x020049ec) and `func_02071694`. `AutoloadCallback` is refused
+    anyway -- it is a named callback, not a range tail, and no merge compiles a range
+    over it. This is NOT a general "a vacuous match does not count" mechanism: such a
+    record keeps counting exactly as before until some merge proves, with a build, that
+    its bytes are the return of the function next door.
+
+    The exception has exactly one live case: `func_02071644`, whose trailing `bx lr`
+    config carried as `func_02071694` and someone matched with an empty body. The merge
+    rule's other live case, `__destroy_arr` (declared 0x5c in `symbols.txt` while the
+    ROM's own `.exceptix` record gives 0x74, the trailing 0x18 the catch handler rather
+    than a function), needs no exception at all: both of its removed records are unmatched
+    in base. It could not use this door anyway -- 0x18 is not one instruction.
 
     Returns a dict describing the merge, or None.
     """
@@ -491,16 +619,9 @@ def classify_merge(bf, hf, be, he, compiled):
         return None
 
     base_matched, head_matched = bf["matched"], hf["matched"]
-    # Nothing matched leaves. (`lost N matched function(s)` above would also fire, but
-    # this rule must not be the thing that decides a loss is acceptable.)
-    if set(base_matched) - set(head_matched):
-        return None
 
     removed = sorted(set(bf["functions"]) - set(hf["functions"]))
     if not removed:
-        return None
-    # Every removed record was unmatched in base.
-    if any(k in base_matched for k in removed):
         return None
 
     # The evidence: ranges that are `complete` in head and were not in base, each one
@@ -514,13 +635,18 @@ def classify_merge(bf, hf, be, he, compiled):
             continue
         if entry["path"] not in compiled:
             return None
-        new_ranges[entry["module"]].append((entry["addr"], entry["end"]))
+        new_ranges[entry["module"]].append((entry["addr"], entry["end"], entry["path"]))
     if not new_ranges:
         return None
 
+    def _containing_new(module, addr, end):
+        for start, stop, path in new_ranges.get(module, []):
+            if start <= addr and end <= stop:
+                return start, stop, path
+        return None
+
     def _inside_new(module, addr, end):
-        return any(start <= addr and end <= stop
-                   for start, stop in new_ranges.get(module, []))
+        return _containing_new(module, addr, end) is not None
 
     # Every removed address is absorbed into one of them.
     for key in removed:
@@ -528,6 +654,42 @@ def classify_merge(bf, hf, be, he, compiled):
         if not _inside_new(record["module"], record["addr"],
                            record["addr"] + record["size"]):
             return None
+
+    # NOTHING MATCHED MAY LEAVE, except a range's own return instruction -- the four
+    # conditions the docstring sets out, in order. Each one refuses outright: a merge
+    # carrying a matched loss it cannot justify is not classified at all.
+    absorbed = []
+    for key in sorted(set(base_matched) - set(head_matched)):
+        record = base_matched[key]
+        addr, end = record["addr"], record["addr"] + record["size"]
+        # A record still PRESENT in head that lost `matched` some other way (a banner
+        # went on, its source was deleted) is a withdrawal or a loss, never this.
+        if key in hf["functions"]:
+            return None
+        span = _containing_new(record["module"], addr, end)
+        if span is None:
+            return None
+        # (a) the exact tail of the covering range, not a record inside it.
+        if end != span[1]:
+            return None
+        # (b) one instruction, and the cartridge's own word there is a return.
+        if record["size"] != 4 or rom_word is None:
+            return None
+        word = rom_word(record["module"], addr)
+        if word is None or not _is_return_word(word):
+            return None
+        # (c) the covering range is compiled evidence, so the merged source reproduces
+        # that instruction rather than merely covering its address. Every new range is
+        # already required to be, above; asserted again here because this is the clause
+        # that makes (b) mean something and it must not depend on a distant loop.
+        if span[2] not in compiled:
+            return None
+        # (d) a VALIDATED index, and nothing in it names those bytes.
+        if reloc_dests is None:
+            return None
+        if _incoming_relocations(reloc_dests, record["module"], addr, end):
+            return None
+        absorbed.append(key)
 
     # sourceBytes rises by exactly the newly-complete extent, less whatever of it the
     # base was ALREADY compiling. A base entry lying wholly inside one of the new ranges
@@ -537,7 +699,7 @@ def classify_merge(bf, hf, be, he, compiled):
     # the comparison below still refuses it. That is the clause that stops an unrelated
     # range leaving under cover of the merge, and it is untouched.
     new_bytes = sum(stop - start
-                    for spans in new_ranges.values() for start, stop in spans)
+                    for spans in new_ranges.values() for start, stop, _ in spans)
     absorbed_bytes = sum(entry["size"] for key, entry in be["source"].items()
                          if key not in he["source"]
                          and _inside_new(entry["module"], entry["addr"], entry["end"]))
@@ -560,6 +722,7 @@ def classify_merge(bf, hf, be, he, compiled):
             "functionDelta": hf["stats"]["totalFunctions"] - bf["stats"]["totalFunctions"],
             "added": sorted(set(hf["functions"]) - set(bf["functions"])),
             "removed": removed,
+            "absorbed": absorbed,
             "newExtent": new_bytes,
             "absorbedBytes": absorbed_bytes,
             "sourceByteDelta": new_bytes - absorbed_bytes}
@@ -1171,12 +1334,33 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     # retracting its claim is a real coverage loss and stays a hard reason (it would
     # also trip `source-built function coverage decreased`, but relying on that
     # interaction would leave the rule true only by accident).
+    # ABSORBED is the third way, and it is classify_merge's to decide, not this loop's:
+    # the record is the return instruction at the tail of a range this merge newly
+    # compiles and byte-compares, and no relocation in a VALIDATED index names it. So
+    # the classification runs first and this loop reads its answer -- see classify_merge
+    # for the whole argument, including what is not claimed.
+    #
+    # THE EVIDENCE GATES THE EXCEPTION, NOT THE OTHER WAY ROUND. `reloc["valid"]` is
+    # false as soon as a relocation file is missing, empty where its module declares
+    # functions, or carries a line that is not one of the documented row shapes. Passing
+    # None then is what keeps missing evidence from reading as "nothing points here".
+    # A denominator move is a blocker UNLESS it is a re-partition of the same bytes --
+    # see classify_repartition, which carries the full argument and the two tests.
+    rom_word = _rom_word_reader(head_sha)
+    repartition = (classify_repartition(bf, hf)
+                   or classify_merge(bf, hf, be, he, compiled_src,
+                                     reloc["dests"] if reloc["valid"] else None,
+                                     rom_word))
+    absorbed_keys = set((repartition or {}).get("absorbed") or ())
+
     base_enrolled = {key.split("-", 1)[0] for key in be["source"]}
     transcribed_now = set(new_transcribed)
-    withdrawn, removed = [], []
+    withdrawn, removed, absorbed = [], [], []
     for k in sorted(base_keys - head_keys):
         hr, br = hf["functions"].get(k) or {}, bf["functions"].get(k) or {}
-        if (k not in base_enrolled and hr.get("srcPath")
+        if k in absorbed_keys:
+            absorbed.append({"id": k, "path": br.get("srcPath"), "name": br.get("name")})
+        elif (k not in base_enrolled and hr.get("srcPath")
                 and hr["srcPath"] == br.get("srcPath")
                 and hr["srcPath"] not in transcribed_now):
             withdrawn.append({"id": k, "path": hr["srcPath"], "name": hr.get("name")})
@@ -1184,10 +1368,17 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
             removed.append(k)
     if removed:
         reasons.append(f"lost {len(removed)} matched function(s)")
-    # A denominator move is a blocker UNLESS it is a re-partition of the same bytes --
-    # see classify_repartition, which carries the full argument and the two tests.
-    repartition = (classify_repartition(bf, hf)
-                   or classify_merge(bf, hf, be, he, compiled_src))
+        # Say WHY the exception was unavailable when it was, naming the defective file:
+        # a PR author reading "lost 1 matched function(s)" on a tree whose relocation
+        # config is broken has no way to find the broken file otherwise.
+        if not reloc["valid"]:
+            extra = (f"; +{len(reloc['defects']) - 1} more"
+                     if len(reloc["defects"]) > 1 else "")
+            reasons.append("relocation evidence invalid, so nothing matched may leave: "
+                           f"{reloc['defects'][0]}{extra}")
+        elif rom_word.missing:
+            reasons.append("ROM image unavailable, so nothing matched may leave: "
+                           + ", ".join(sorted(rom_word.missing)))
     if (hf["stats"]["totalFunctions"] != bf["stats"]["totalFunctions"]
             or hf["stats"]["totalBytes"] != bf["stats"]["totalBytes"]):
         if repartition is None:
@@ -1264,6 +1455,15 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
             f"{basis}. Added: "
             + ", ".join(repartition["added"][:3] or ["none"])
             + "; removed: " + ", ".join(repartition["removed"][:3] or ["none"]))
+    if absorbed:
+        warnings.append(
+            f"{len(absorbed)} claimed match(es) absorbed by the merge rather than lost: "
+            "each is the four-byte return instruction at the tail of a range this merge "
+            "newly compiles and byte-compares, and no relocation in a validated index "
+            "over both revisions names it -- "
+            + ", ".join(f"{a['name'] or a['id']} ({a['path'] or 'no source'})"
+                        for a in absorbed[:3])
+            + (f", +{len(absorbed) - 3} more" if len(absorbed) > 3 else ""))
     if withdrawn:
         warnings.append(
             f"{len(withdrawn)} claimed match(es) withdrawn by a NONMATCHING banner "
@@ -1331,6 +1531,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         # a smaller number than the tree actually shed. The split is beside it.
         "removedMatchedFunctions": len(base_keys - head_keys),
         "withdrawnMatchedFunctions": len(withdrawn),
+        "absorbedMatchedFunctions": len(absorbed),
         "lostMatchedFunctions": len(removed),
     }
     base_source_stats = dict(be["stats"])
@@ -1380,6 +1581,7 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered,
                       "strandedMarkers": stranded_markers},
         "matchedWithdrawn": withdrawn,
+        "matchedAbsorbed": absorbed,
         "relocationEvidence": {
             "valid": reloc["valid"],
             "modules": len(reloc["dests"]),
@@ -1430,6 +1632,11 @@ def render_markdown(r):
         lines.append(
             f"| Claims withdrawn (banner added) | {len(r['matchedWithdrawn'])} "
             f"function(s), none byte-verified |")
+    if r.get("matchedAbsorbed"):
+        lines.append(
+            f"| Claims absorbed by the merge | {len(r['matchedAbsorbed'])} "
+            f"function(s), each a range's own tail return instruction, "
+            f"no relocation names it |")
     if r.get("repartition"):
         rp = r["repartition"]
         lines.append(

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -37,6 +37,9 @@ SOURCE_SUFFIXES = (".c", ".cpp")
 # Credit moves named in the one-line reason, and rows in the check body's table.
 CREDIT_NAMED = 3
 CREDIT_ROWS = 25
+# Relocation-evidence defects carried in the JSON report. The count always travels;
+# a broken config can produce thousands of rows and the report has a size budget.
+RELOC_DEFECTS_SHOWN = 10
 # tangos-backend's /result cap. Kept here so the report clips itself rather than being
 # rejected whole -- see the clamp in build_report.
 SUMMARY_LIMIT = 500
@@ -136,6 +139,173 @@ def _rev_enrolment(rev):
                     i += 1
         _ENROLMENT_CACHE[rev] = (addrs, owner)
     return _ENROLMENT_CACHE[rev]
+
+
+# The two row shapes dsd writes into a `relocs.txt`, and nothing else. Measured over
+# the whole tree at cd3a7eb59: 106 files, 91,809 rows, 91,808 of the first shape and
+# exactly one of the second (`config/arm9/relocs.txt`, the ARM9_CTOR_START link-time
+# constant, which names no destination address at all).
+#
+#   from:0x<addr> kind:<kind> to:0x<addr> module:<token>
+#   from:0x<addr> kind:link_time_const(<NAME>)
+#
+# Anchored at both ends on purpose. A leading BOM, leading whitespace, a truncated
+# tail row or a row from some future dsd all fail to match here, and a row that fails
+# to match is a DEFECT, never a line to skip -- see `_reloc_index`.
+_RELOC_ROW = re.compile(
+    r"^from:0x[0-9a-fA-F]+ +kind:\S+ +to:0x([0-9a-fA-F]+) +module:(\S+)$")
+_RELOC_CONST = re.compile(r"^from:0x[0-9a-fA-F]+ +kind:link_time_const\([^()]+\)$")
+# The documented destination tokens. `main` and `overlay(N)`/`overlays(N,M)` name a
+# symbol-table module; `itcm`, `dtcm` and `none` are real tokens that name none.
+_RELOC_OVERLAY = re.compile(r"^overlays?\((\d+(?: *, *\d+)*)\)$")
+_RELOC_UNMAPPED = ("itcm", "dtcm", "none")
+_RELOC_ANY = "*"
+_RELOC_CACHE = {}
+
+
+def _is_reloc_file(path):
+    return path.startswith("config/arm9/") and path.endswith("/relocs.txt") \
+        or path == "config/arm9/relocs.txt"
+
+
+def _is_symbols_file(path):
+    return path.startswith("config/arm9/") and path.endswith("/symbols.txt") \
+        or path == "config/arm9/symbols.txt"
+
+
+def _reloc_index(rev):
+    """The relocation destination index at ``rev``, WITH the defects that invalidate it.
+
+    Returns ``{"dests": module -> sorted destination addresses, "defects": [str]}``.
+
+    Read from git like every other snapshot here, and read from EVERY ``relocs.txt``
+    under ``config/arm9``, not just the ones whose own module has a symbol table. A
+    relocation names the module of its DESTINATION, so where the reference LIVES is
+    irrelevant: a call from an overlay into the main binary is an incoming destination
+    for arm9, and the arm9 file alone would not see it. Reading only the files that
+    match `config/arm9/(overlays/ovNNN/)?relocs.txt` -- the shape `_module_from_symbols`
+    and `_module_from_delinks` use for the modules this report counts -- covers 104 of
+    the 106 and silently drops `config/arm9/itcm/relocs.txt`, whose 142 `module:main`
+    rows are 142 incoming references into arm9 that no other file records, along with
+    `config/arm9/dtcm/relocs.txt`.
+
+    DEFECTS, NOT SKIPPED INPUT. Nothing here quietly tolerates missing or unreadable
+    evidence, because the only thing this index is ever used for is deciding whether
+    NOTHING points at an address, and an index that skipped its input answers that
+    question "nothing" for every address in the cartridge. So:
+
+      * every module whose ``symbols.txt`` declares at least one function must have a
+        ``relocs.txt`` beside it, present and non-empty, at this revision;
+      * a module that declares no function may have an empty file (15 of them at
+        cd3a7eb59: `config/arm9/dtcm` and fourteen overlays whose sections are all
+        zero-length, e.g. ov061's `.text start:0x02115ec0 end:0x02115ec0`);
+      * every line of every file must be one of the two documented row shapes, and
+        every destination token one of the documented set;
+      * an unreadable blob is a defect rather than an exception, so the caller fails
+        closed with a reason naming the file instead of the worker failing with a
+        traceback.
+
+    A defect does not make this function raise and does not empty the index. It makes
+    the EVIDENCE invalid, and callers that need valid evidence to permit something must
+    check `defects` and refuse. See `_reloc_evidence`.
+    """
+    # Keyed by (repo, rev), not by rev: the tests point `REPO` at one temporary
+    # repository after another, and two of them holding the same tree, author and
+    # second produce the same sha. A cache keyed on the sha alone would answer the
+    # second repository with the first one's index.
+    key = (str(REPO), rev)
+    if key not in _RELOC_CACHE:
+        try:
+            paths = tree_paths(rev, "config/arm9")
+        except RuntimeError as exc:
+            _RELOC_CACHE[key] = {"dests": {},
+                                 "defects": [f"config/arm9 unreadable: {exc}"]}
+            return _RELOC_CACHE[key]
+        defects = []
+        reloc_paths = sorted(p for p in paths if _is_reloc_file(p))
+        texts = {}
+        for path in reloc_paths:
+            try:
+                texts[path] = git_text(rev, path)
+            except RuntimeError as exc:
+                defects.append(f"{path} is unreadable at {rev[:12]}: {exc}")
+        # INVENTORY. A module missing from the index reads exactly like a module that
+        # references nothing, so the inventory is checked before the rows are.
+        for path in sorted(p for p in paths if _is_symbols_file(p)):
+            sibling = path[:-len("symbols.txt")] + "relocs.txt"
+            try:
+                declared = sum(1 for line in git_text(rev, path).splitlines()
+                               if FUNC_RE.match(line))
+            except RuntimeError as exc:
+                defects.append(f"{path} is unreadable at {rev[:12]}: {exc}")
+                continue
+            if sibling not in texts:
+                defects.append(f"{sibling} is missing at {rev[:12]} while {path} "
+                               f"declares {declared} function(s)")
+            elif declared and not texts[sibling].strip():
+                defects.append(f"{sibling} is empty at {rev[:12]} while {path} "
+                               f"declares {declared} function(s)")
+        dests = collections.defaultdict(list)
+        for path in reloc_paths:
+            for number, line in enumerate(texts.get(path, "").splitlines(), 1):
+                m = _RELOC_ROW.match(line)
+                if not m:
+                    if not _RELOC_CONST.match(line):
+                        defects.append(f"{path}:{number} is not a relocation row: "
+                                       f"{line[:60]!r}")
+                    continue
+                addr, token = int(m.group(1), 16), m.group(2)
+                if token == "main":
+                    modules = ("arm9",)
+                elif token in _RELOC_UNMAPPED:
+                    # A documented token naming no symbol-table module. Filed under `*`
+                    # and counted for EVERY module: the conservative direction, because
+                    # the only use of a destination count is refusing to let a matched
+                    # record leave.
+                    modules = (_RELOC_ANY,)
+                else:
+                    ov = _RELOC_OVERLAY.match(token)
+                    if ov is None:
+                        defects.append(f"{path}:{number} names an undocumented "
+                                       f"destination module {token!r}")
+                        continue
+                    modules = tuple(f"ov{int(n):03d}" for n in ov.group(1).split(","))
+                for module in modules:
+                    dests[module].append(addr)
+        _RELOC_CACHE[key] = {"dests": {k: sorted(v) for k, v in dests.items()},
+                             "defects": defects}
+    return _RELOC_CACHE[key]
+
+
+def _reloc_evidence(base, head):
+    """The relocation index over BOTH revisions, with every defect either one carries.
+
+    The union is the conservative direction: a reference present in either revision
+    counts, so a PR cannot earn "nothing points here" by deleting the row that says
+    something does. The defects are the union too -- evidence that is invalid at one
+    end is invalid.
+    """
+    dests, defects = collections.defaultdict(list), []
+    for rev in (base, head):
+        index = _reloc_index(rev)
+        defects.extend(index["defects"])
+        for module, addrs in index["dests"].items():
+            dests[module].extend(addrs)
+    return {"dests": {k: sorted(v) for k, v in dests.items()},
+            "defects": defects,
+            "valid": not defects}
+
+
+def _incoming_relocations(dests, module, addr, end):
+    """How many relocation destinations land inside ``[addr, end)`` of ``module``."""
+    total = 0
+    for key in (module, _RELOC_ANY):
+        addrs = dests.get(key) or []
+        i = bisect.bisect_left(addrs, addr)
+        while i < len(addrs) and addrs[i] < end:
+            total += 1
+            i += 1
+    return total
 
 
 def function_snapshot(rev):
@@ -922,6 +1092,11 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     bv, hv = verification_split(bf, be), verification_split(hf, he)
     ba, ha = attribution_snapshot(base_sha, bf), attribution_snapshot(head_sha, hf)
     diff = diff_snapshot(base_sha, head_sha, set(tree_paths(head_sha, "src/")))
+    # The relocation index over both revisions, and whether it is fit to be relied on.
+    # Reported whether or not anything consumes it: "the evidence this run had" is a
+    # fact a reader auditing a decision needs, and a silent index is how missing
+    # evidence gets mistaken for an answer.
+    reloc = _reloc_evidence(base_sha, head_sha)
 
     # The transcription gate for the PR itself, scoped STRICTLY to the sources this
     # merge adds or modifies (never renames-only or pre-existing files, so an old
@@ -1205,6 +1380,12 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         "asmPolicy": {"transcribed": new_transcribed, "unbanneredAsm": new_unbannered,
                       "strandedMarkers": stranded_markers},
         "matchedWithdrawn": withdrawn,
+        "relocationEvidence": {
+            "valid": reloc["valid"],
+            "modules": len(reloc["dests"]),
+            "destinations": sum(len(v) for v in reloc["dests"].values()),
+            "defects": reloc["defects"][:RELOC_DEFECTS_SHOWN],
+            "defectCount": len(reloc["defects"])},
         "repartition": repartition,
         "linkcheck": link,
         "portRefcheck": port,

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -19,11 +19,13 @@ import argparse
 import bisect
 import collections
 import hashlib
+import io
 import json
 import pathlib
 import re
 import subprocess
 import sys
+import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
@@ -438,33 +440,87 @@ def _reloc_evidence(base, head):
 ARM9_IMAGE = "extracted/arm9_dec.bin"
 ARM9_IMAGE_BASE = 0x02004000
 
-# THE ACCEPTED RETURN ENCODINGS, and nothing else. These are the three shapes
-# `tools/evidence_rom.py:is_unconditional_return` recognises, spelled at the encoding
-# level so this tool needs no disassembler on the validator box:
+# THE ACCEPTED RETURN ENCODINGS, and nothing else:
 #
 #   bx lr                  0xE12FFF1E
-#   mov pc, lr             0xE1A0F00E
-#   ldm/pop writing pc     condition AL, block data transfer, L=1, S=0, and r15 in the
-#                          register list -- e.g. `pop {r4, pc}` 0xE8BD8010
+#   a stack pop to pc      unconditional block data transfer, L=1, S=0, r13 as the base
+#                          register and r15 in the list -- `pop {r4, pc}` 0xE8BD8010,
+#                          `ldmfd sp!, {pc}` 0xE8BD8000
 #
-# CONDITION AL ONLY, matching evidence_rom: a conditional return (`bxeq lr`,
+# CLASSIFIED BY `evidence_rom.is_unconditional_return`, NOT BY A MASK OF OUR OWN. The
+# mask this replaced tested the transfer bits and the pc bit and nothing else, so it
+# read `ldm r0, {pc}` (0xE8908000) as a return -- an indirect transfer through whatever
+# r0 held, about which the four bytes say nothing -- and `ldmdb r0, {pc}` and
+# `ldmib r0!, {pc}` with it, neither of which the helper it cited classifies that way.
+# One classifier, imported, is the only way those stay in step.
+#
+# THEN NARROWED, deliberately, in three places the helper does not reach. A rule that
+# lets a matched record leave should accept the smallest set that covers the real case:
+#
+#   * the base register must be r13. `ldm r0, {pc}` is a return only if r0 happens to
+#     hold a return address, which is a fact about the code before it, not about the
+#     word. A stack pop is self-evidencing.
+#   * `mov pc, lr` is dropped. It is a plain register move whose return-ness is a fact
+#     about lr, and no epilogue in this cartridge's severed-tail shape uses it. Nothing
+#     is lost by refusing it and re-examining if a real case appears.
+#   * `ldr pc, [sp], #4` (0xE49DF004) stays refused. capstone renders it `pop {pc}` and
+#     the helper accepts it; the block-transfer bits do not, and they are the test. (An
+#     earlier comment here claimed capstone decodes it as LDR. It does not.)
+#
+# CONDITION AL ONLY, which is the helper's own rule: a conditional return (`bxeq lr`,
 # `popne {.., pc}`) leaves a live fall-through path, so the bytes after it are still
-# reached and the record is not a severed tail. The S bit (`ldm ... ^`) restores CPSR
-# -- an exception return, not a function return, and on the never-in-C list in
-# notes/asm-policy.md. `ldr pc, [sp], #4` (0xE49DF004) is a return in practice and is
-# deliberately NOT accepted: capstone decodes it as LDR, so evidence_rom does not
-# recognise it either, and a narrower set is the safe direction for a rule that
-# permits a matched record to leave.
-RETURN_WORDS = (0xE12FFF1E, 0xE1A0F00E)
-_LDM_PC_MASK = 0x0E508000
-_LDM_PC_VALUE = 0x08108000
+# reached and the record is not a severed tail. The S bit (`ldm ... ^`) restores CPSR --
+# an exception return, not a function return, and on the never-in-C list in
+# notes/asm-policy.md.
+_BLOCK_TRANSFER_MASK = 0x0E000000
+_BLOCK_TRANSFER_VALUE = 0x08000000
+_S_BIT = 1 << 22
+_SP = 13
+_DECODER = None
+
+
+def _arm_decoder():
+    """``(capstone handle, evidence_rom, (BX, POP, LDM))``, or None when unavailable.
+
+    Lazy and guarded on purpose. Everything else in this report reads git text, so the
+    tool still runs on a box with no ARM tooling; only the matched-loss exception needs
+    a decoder, and that exception already needs the cartridge image and the pinned
+    compiler beside it. Unavailable is answered as None and refuses the exception --
+    never as "the word is not a return", and never as "it is".
+    """
+    global _DECODER
+    if _DECODER is None:
+        try:
+            from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM
+            from capstone.arm import ARM_INS_BX, ARM_INS_LDM, ARM_INS_POP
+            import evidence_rom as EV
+        except (ImportError, SystemExit):
+            _DECODER = False
+        else:
+            handle = Cs(CS_ARCH_ARM, CS_MODE_ARM)
+            handle.detail = True
+            _DECODER = (handle, EV, (ARM_INS_BX, ARM_INS_POP, ARM_INS_LDM))
+    return _DECODER or None
 
 
 def _is_return_word(word):
-    """Is this 32-bit ARM word one of the accepted unconditional return encodings?"""
-    if word in RETURN_WORDS:
-        return True
-    return (word >> 28) == 0xE and (word & _LDM_PC_MASK) == _LDM_PC_VALUE
+    """Is this 32-bit ARM word `bx lr` or a stack pop to pc? See the block above."""
+    decoder = _arm_decoder()
+    if decoder is None:
+        return False
+    handle, EV, (BX, POP, LDM) = decoder
+    insn = next(handle.disasm(word.to_bytes(4, "little"), 0), None)
+    if insn is None or not EV.is_unconditional_return(insn):
+        return False
+    if insn.id == BX:
+        return True                     # the helper already checked the register is lr
+    if insn.id not in (POP, LDM):
+        return False                    # `mov pc, lr`
+    if (word & _BLOCK_TRANSFER_MASK) != _BLOCK_TRANSFER_VALUE:
+        return False                    # `ldr pc, [sp], #4`, rendered `pop {pc}`
+    if word & _S_BIT:
+        return False                    # `ldm sp!, {.., pc}^` restores CPSR
+    return ((word >> 16) & 0xF) == _SP  # `ldm r0, {pc}` and its db/ib spellings
 
 
 _SYMBOL_ROW = re.compile(r"^(\S+)\s+kind:\S.*?\baddr:0x([0-9a-fA-F]+)")
@@ -571,6 +627,183 @@ def _rom_word_reader(rev):
         if offset < 0 or offset + 4 > len(data):
             return None
         return int.from_bytes(data[offset:offset + 4], "little")
+
+    read.missing = set()
+    return read
+
+
+# The placeholder config derives from an address when it has no recovered name for it.
+# `func_02071694` and `func_ov006_020cb030` are this; `AutoloadCallback` is not.
+_ADDRESS_NAME = re.compile(r"^func_(?:ov\d+_)?([0-9a-fA-F]{8})$")
+_SYMBOL_NAME_CACHE = {}
+
+
+def _symbol_names(rev):
+    """``{(module, addr) -> [name]}`` over EVERY ``symbols.txt`` row at ``rev``.
+
+    Every row, not the function rows, and not `function_snapshot`'s `records`: that
+    dict is keyed by module:addr and keeps only the largest symbol at an address, so a
+    zero-size named alias sharing an address with a placeholder is invisible in it --
+    and an alias is exactly the shape this has to see.
+    """
+    key = (str(REPO), rev)
+    if key not in _SYMBOL_NAME_CACHE:
+        names = collections.defaultdict(list)
+        for path in tree_paths(rev, "config/arm9"):
+            if not _is_symbols_file(path):
+                continue
+            module = _module_from_config_path(path)
+            if module is None:
+                continue
+            for line in git_text(rev, path).splitlines():
+                m = _SYMBOL_ROW.match(line)
+                if m:
+                    names[(module, int(m.group(2), 16))].append(m.group(1))
+        _SYMBOL_NAME_CACHE[key] = {k: sorted(v) for k, v in names.items()}
+    return _SYMBOL_NAME_CACHE[key]
+
+
+def _named_symbol(revs, module, addr):
+    """The name of a symbol at ``addr`` that is not the address's own placeholder.
+
+    IDENTITY, NOT POSITION. A record sitting at the tail of a merged range is in the
+    right place to be that range's epilogue; it is not thereby the same thing. Config
+    that has a NAME for those bytes -- `AutoloadCallback`, a recovered symbol, an alias
+    -- is recording an identity the cartridge gave them, independent of whatever range
+    now covers them, and no merge gets to retire that on the strength of its position.
+    Read over BOTH revisions, so a PR cannot earn the exception by deleting the row
+    that names the address.
+    """
+    for names in revs:
+        for name in names.get((module, addr), ()):
+            m = _ADDRESS_NAME.fullmatch(name)
+            if m is None or int(m.group(1), 16) != addr:
+                return name
+    return None
+
+
+def _pinned_version(rev, path):
+    """The mwccarm version the ROM build compiles ``path`` with, read from ``rev``.
+
+    Revision-pinned like every other snapshot here: `build_pin.version_for` reads the
+    worktree's `config/rombuild-versions.txt`, which is not the table the revision under
+    judgement carries. Keyed on the file STEM because `rombuild.compile_one` is.
+    """
+    import build_pin as BP
+    stem = pathlib.PurePosixPath(path).stem
+    try:
+        text = git_text(rev, "config/rombuild-versions.txt")
+    except RuntimeError:
+        return BP.DEFAULT_VERSION
+    for line in text.splitlines():
+        row = line.split("#", 1)[0].split()
+        if len(row) >= 2 and row[0] == stem:
+            return row[1]
+    return BP.DEFAULT_VERSION
+
+
+def _mapping_evidence(obj, symbol, offset):
+    """``{"instruction": bool, "word": int}`` for ``offset`` bytes into ``symbol``.
+
+    None when the object cannot answer: it does not define the symbol, or it carries no
+    ARM EABI mapping symbols in the symbol's section, so nothing separates code from
+    data in it.
+
+    THE MAPPING SYMBOLS ARE THE ANSWER, and the compiler emits them for exactly this.
+    `$a` opens an ARM instruction region, `$t` a Thumb one and `$d` a data region, and
+    a compiler-generated literal pool sits in a `$d` region INSIDE the function's own
+    byte range. Measured with the pinned 2004/b56 on
+    `unsigned int f(void) { return 0xe12fff1e; }`: three words, `e59f0000 e12fff1e
+    e12fff1e`, `$a` at 0 and `$d` at 8. The third word has a return's bits and is a
+    constant. Only the mapping symbols tell them apart.
+    """
+    try:
+        from elftools.elf.elffile import ELFFile
+    except ImportError:
+        return None
+    elf = ELFFile(io.BytesIO(obj))
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab is None:
+        return None
+    sym = next((s for s in symtab.iter_symbols()
+                if s.name == symbol and s["st_info"]["type"] == "STT_FUNC"
+                and s["st_shndx"] not in ("SHN_UNDEF", "SHN_ABS")), None)
+    if sym is None:
+        return None
+    shndx = sym["st_shndx"]
+    marks = sorted((m["st_value"], m.name) for m in symtab.iter_symbols()
+                   if m.name in ("$a", "$t", "$d") and m["st_shndx"] == shndx)
+    if not marks:
+        return None
+    if not (0 <= offset and offset + 4 <= sym["st_size"]):
+        return {"instruction": False, "word": None}
+    where = sym["st_value"] + offset
+    kind = None
+    for value, name in marks:
+        if value > where:
+            break
+        kind = name
+    data = elf.get_section(shndx).data()
+    return {"instruction": kind == "$a",
+            "word": int.from_bytes(data[where:where + 4], "little")}
+
+
+def _compiled_code_reader(rev):
+    """``read(path, symbol, symbol_addr, addr)`` -> the code-ownership evidence, or None.
+
+    THE OBJECT, BECAUSE THIS TOOL DOES NOT HAVE ONE. The private worker runs
+    `rombuild.py` and hands this report the JSON it produced; that report says whether a
+    module reproduced, not where inside a function's bytes the instructions stop. So the
+    one source this file compiles is the merged source itself, with the pinned compiler
+    the ROM build uses, read from the revision under judgement -- the same compile
+    `build_pin.verify` runs, minus the byte comparison the ROM build already did.
+
+    None from any step, and every caller must refuse: a missing compiler, a source that
+    does not compile, an object without the symbol or without mapping symbols. `.missing`
+    carries the reasons so the report can name what it wanted.
+    """
+    cache = {}
+
+    def _object(path):
+        if path in cache:
+            return cache[path]
+        obj = None
+        try:
+            import build_pin as BP
+            import match as M
+        except (ImportError, SystemExit):
+            read.missing.add("the pinned compiler tooling is not importable")
+            cache[path] = None
+            return None
+        try:
+            text = git_text(rev, path)
+        except RuntimeError:
+            read.missing.add(f"{path} is unreadable at {rev[:12]}")
+            cache[path] = None
+            return None
+        version = _pinned_version(rev, path)
+        if not (BP.MW / version / "mwccarm.exe").is_file():
+            read.missing.add(f"the pinned compiler {version} is not installed")
+            cache[path] = None
+            return None
+        with tempfile.TemporaryDirectory() as td:
+            src = pathlib.Path(td) / pathlib.PurePosixPath(path).name
+            src.write_text(text, encoding="utf-8", newline="\n")
+            obj = M.compile_c(src, version, BP.flags_for(src, text))
+        if obj is None:
+            read.missing.add(f"{path} does not compile under {version} at {rev[:12]}")
+        cache[path] = obj
+        return obj
+
+    def read(path, symbol, symbol_addr, addr):
+        obj = _object(path)
+        if obj is None:
+            return None
+        evidence = _mapping_evidence(obj, symbol, addr - symbol_addr)
+        if evidence is None:
+            read.missing.add(f"the object {path} produced carries no mapping evidence "
+                             f"for {symbol}")
+        return evidence
 
     read.missing = set()
     return read
@@ -710,7 +943,8 @@ def _covered_spans(snapshot):
     return out
 
 
-def classify_merge(bf, hf, be, he, compiled, reloc_dests=None, rom_word=None):
+def classify_merge(bf, hf, be, he, compiled, reloc_dests=None, rom_word=None,
+                   code_owned=None, named=None):
     """Is a denominator DROP a merge the ROM build has already paid for?
 
     A merge lowers `totalFunctions` and so RAISES the headline, which is the direction an
@@ -758,29 +992,47 @@ def classify_merge(bf, hf, be, he, compiled, reloc_dests=None, rom_word=None):
     The narrow exception exists because config can carve a function's trailing return
     instruction off as its own symbol, and an empty body then "matches" it. Recovering
     the real function retires that record, and the absolute rule made the correction the
-    one edit that cannot land. WHAT IS AND IS NOT CLAIMED HERE. This does not claim that
-    ROM execution can never enter the address -- an index cannot establish that, and the
-    earlier version of this rule said so and was wrong to. The claim is narrower and each
-    half is checkable:
+    one edit that cannot land.
+
+    WHAT IS AND IS NOT CLAIMED HERE. This does not claim that ROM execution can never
+    enter the address -- an index cannot establish that, and an earlier version of this
+    rule said so and was wrong to. Nor does it claim that four bytes whose bits read as a
+    return ARE one: a compiler-generated literal pool inside a function's own range can
+    hold 0xE12FFF1E as a CONSTANT, and its bits are identical. The claim is that a
+    specific compiled function OWNS these bytes and emits an instruction at them, and
+    every half of it is checkable:
 
       (a) the record ends exactly where the new `complete` range ends, so it is that
           range's TAIL and not something in the middle of it;
-      (b) it is one instruction, four bytes, and the cartridge's own word at that address
-          is one of the accepted unconditional return encodings (see RETURN_WORDS) -- so
-          the bytes being retired are a return, not a body;
+      (b) it is four bytes, and the cartridge's own word at that address is `bx lr` or a
+          stack pop to pc -- the two encodings `_is_return_word` accepts;
       (c) the range is backed by compiled source, which the ROM build then links and
-          byte-compares against retail, so the merged function REPRODUCES that same
-          return instruction rather than merely covering its address;
+          byte-compares against retail;
       (d) no relocation destination in a VALIDATED index over both revisions lands in
           those bytes -- with the emphasis on validated: missing, empty or malformed
           relocation input is not an absence of callers, it is an absence of evidence,
           and `_reloc_index` reports it as a defect that makes this exception
-          unavailable.
+          unavailable;
+      (e) NO SYMBOL IN EITHER REVISION NAMES THE ADDRESS. Config's placeholder for
+          bytes it has no name for is derived from the address itself; a real name --
+          `AutoloadCallback`, a recovered symbol, an alias -- records an identity the
+          cartridge gave those bytes, independent of which range now covers them. (a)
+          tests POSITION and a named callback can sit at a tail too; this tests
+          identity. See `_named_symbol`;
+      (f) CODE OWNERSHIP: the merged function's own object, compiled here from the
+          revision under judgement with the pinned compiler, covers that address as an
+          INSTRUCTION -- an ARM EABI `$a` region, not a `$d` literal pool -- and the
+          word it emits there is the cartridge's word. See `_compiled_code_reader`.
+          Without it, (a)+(b) accept the last word of
+          `unsigned int f(void) { return 0xe12fff1e; }`, which under the pinned 2004/b56
+          is `e59f0000 e12fff1e e12fff1e` with `$d` at offset 8: a constant, at the tail,
+          with a return's bits. Preserving its bits does not make it an epilogue.
 
-    Together those say: this record is the return instruction of the function whose
-    source now compiles to it, and nothing in the tree's relocation index names it. They
-    do not say the address is unreachable. A record that fails any one of them stays
-    matched and the merge is refused.
+    Together those say: a function this merge compiles owns these four bytes and emits
+    the cartridge's own return instruction at them, config has no independent name for
+    them, and no relocation destination in the tree's index points at them. They do not
+    say the address is unreachable. A record that fails any one of them stays matched and
+    the merge is refused.
 
     THE EXCEPTION IS NARROW, MEASURED RATHER THAN ASSERTED. Over src/ at 8525428a2 there
     are 79 sources whose whole body is `void f(void) {}`; 77 have at least one incoming
@@ -846,7 +1098,7 @@ def classify_merge(bf, hf, be, he, compiled, reloc_dests=None, rom_word=None):
                            record["addr"] + record["size"]):
             return None
 
-    # NOTHING MATCHED MAY LEAVE, except a range's own return instruction -- the four
+    # NOTHING MATCHED MAY LEAVE, except a range's own return instruction -- the six
     # conditions the docstring sets out, in order. Each one refuses outright: a merge
     # carrying a matched loss it cannot justify is not classified at all.
     absorbed = []
@@ -869,16 +1121,36 @@ def classify_merge(bf, hf, be, he, compiled, reloc_dests=None, rom_word=None):
         word = rom_word(record["module"], addr)
         if word is None or not _is_return_word(word):
             return None
-        # (c) the covering range is compiled evidence, so the merged source reproduces
-        # that instruction rather than merely covering its address. Every new range is
-        # already required to be, above; asserted again here because this is the clause
-        # that makes (b) mean something and it must not depend on a distant loop.
+        # (c) the covering range is compiled evidence. Every new range is already
+        # required to be, above; asserted again here because this is the clause that
+        # makes (f) possible and it must not depend on a distant loop.
         if span[2] not in compiled:
             return None
         # (d) a VALIDATED index, and nothing in it names those bytes.
         if reloc_dests is None:
             return None
         if _incoming_relocations(reloc_dests, record["module"], addr, end):
+            return None
+        # (e) identity: config has no name of its own for these bytes, in either
+        # revision. A record whose name config derived from the address is a
+        # placeholder; anything else is an identity this merge does not get to retire.
+        if named is None or named(record["module"], addr):
+            return None
+        # (f) code ownership: the merged function's own compiled output covers the
+        # address as an instruction, and emits the cartridge's word there. `owner` is
+        # the head record whose bytes contain it -- the function that claims to have
+        # absorbed these four bytes. Its symbol has to be DEFINED in the object the
+        # covering range's source produces, so a record whose owner lives in some other
+        # file gets no answer and the exception stays unavailable.
+        if code_owned is None:
+            return None
+        owner = next((r for r in hf["functions"].values()
+                      if r["module"] == record["module"]
+                      and r["addr"] <= addr and end <= r["addr"] + r["size"]), None)
+        if owner is None:
+            return None
+        evidence = code_owned(span[2], owner["name"], owner["addr"], addr)
+        if not evidence or not evidence["instruction"] or evidence["word"] != word:
             return None
         absorbed.append(key)
 
@@ -1424,7 +1696,7 @@ def _credit_detail(changed, lost):
 
 def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
                  require_merge_commit=False, expected_pr_head=None,
-                 port_report=None):
+                 port_report=None, code_evidence=None):
     base_sha, head_sha = resolve_commit(base), resolve_commit(head)
     parents = _git("rev-list", "--parents", "-n", "1", head_sha).split()
     is_merge = len(parents) >= 3
@@ -1538,10 +1810,20 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     # A denominator move is a blocker UNLESS it is a re-partition of the same bytes --
     # see classify_repartition, which carries the full argument and the two tests.
     rom_word = _rom_word_reader(head_sha)
+    # `code_evidence` is a seam, not a policy knob: the default reader compiles the
+    # merged source with the pinned compiler, which a runner with no toolchain does not
+    # have, and a test that needs the wiring rather than the compiler supplies its own.
+    # Absent either way the exception is unavailable -- there is no value of this
+    # argument that grants it.
+    code_owned = (_compiled_code_reader(head_sha) if code_evidence is None
+                  else code_evidence)
+    revs = (_symbol_names(base_sha), _symbol_names(head_sha))
     repartition = (classify_repartition(bf, hf)
                    or classify_merge(bf, hf, be, he, compiled_src,
                                      reloc["dests"] if reloc["valid"] else None,
-                                     rom_word))
+                                     rom_word, code_owned,
+                                     lambda module, addr: _named_symbol(revs, module,
+                                                                        addr)))
     absorbed_keys = set((repartition or {}).get("absorbed") or ())
 
     base_enrolled = {key.split("-", 1)[0] for key in be["source"]}
@@ -1570,6 +1852,9 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         elif rom_word.missing:
             reasons.append("ROM image unavailable, so nothing matched may leave: "
                            + ", ".join(sorted(rom_word.missing)))
+        elif getattr(code_owned, "missing", None):
+            reasons.append("compiled code ownership unavailable, so nothing matched "
+                           "may leave: " + "; ".join(sorted(code_owned.missing)))
     if (hf["stats"]["totalFunctions"] != bf["stats"]["totalFunctions"]
             or hf["stats"]["totalBytes"] != bf["stats"]["totalBytes"]):
         if repartition is None:
@@ -1661,9 +1946,11 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     if absorbed:
         warnings.append(
             f"{len(absorbed)} claimed match(es) absorbed by the merge rather than lost: "
-            "each is the four-byte return instruction at the tail of a range this merge "
-            "newly compiles and byte-compares, and no relocation in a validated index "
-            "over both revisions names it -- "
+            "for each, the merged source's own object covers the address as an "
+            "instruction emitting the cartridge's own `bx lr` or stack pop, the record "
+            "is that range's exact four-byte tail, no symbol in either revision names "
+            "the address, and no relocation destination in a validated index over both "
+            "revisions lands in it. That is what is established; reachability is not -- "
             + ", ".join(f"{a['name'] or a['id']} ({a['path'] or 'no source'})"
                         for a in absorbed[:3])
             + (f", +{len(absorbed) - 3} more" if len(absorbed) > 3 else ""))
@@ -1838,8 +2125,9 @@ def render_markdown(r):
     if r.get("matchedAbsorbed"):
         lines.append(
             f"| Claims absorbed by the merge | {len(r['matchedAbsorbed'])} "
-            f"function(s), each a range's own tail return instruction, "
-            f"no relocation names it |")
+            f"function(s); for each: the merged object emits an instruction there, the "
+            f"ROM word is a return, config names the address only after itself, and no "
+            f"indexed relocation lands in it. Not a reachability claim |")
     if r.get("repartition"):
         rp = r["repartition"]
         lines.append(

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -272,9 +272,17 @@ def classify_merge(bf, hf, be, he, compiled):
     linked and byte-compared against the cartridge; everything else is filled by a gap
     object holding the ROM's own bytes (`verification_split` states this). So requiring
     that EVERY address the merge removes is newly covered by a `complete` range, and that
-    `sourceBytes` rises by exactly the size of those new ranges, ties the carve-out to a
-    build. Merging a hundred junk symbols yields no new `complete` range; forging one for
-    a range that does not reproduce fails module fidelity in the same validator run.
+    `sourceBytes` rises by exactly the NEW coverage those ranges add, ties the carve-out
+    to a build. Merging a hundred junk symbols yields no new `complete` range; forging one
+    for a range that does not reproduce fails module fidelity in the same validator run.
+
+    NEW COVERAGE, NOT NEW EXTENT. A range's extent and the coverage it ADDS differ
+    whenever the merge swallows a `complete` entry the base already had: those bytes were
+    in `sourceBytes` before and are in it after, so they are not new. Comparing against
+    the raw extent refused the honest fold and would have kept refusing it forever. The
+    subtraction is of base entries lying WHOLLY INSIDE a new range only; one lying outside
+    is coverage this merge really lost and still shortens the delta, which is what stops
+    an unrelated range leaving under cover of the merge.
 
     THE RANGE IS NOT EVIDENCE BY ITSELF; ITS SOURCE HAS TO BE COMPILED CODE. The forging
     argument above covers a range that FAILS to reproduce. It does not cover one that
@@ -351,11 +359,20 @@ def classify_merge(bf, hf, be, he, compiled):
                            record["addr"] + record["size"]):
             return None
 
-    # sourceBytes rises by exactly the newly-complete extent -- no other range may
-    # quietly join or leave under cover of the merge.
+    # sourceBytes rises by exactly the newly-complete extent, less whatever of it the
+    # base was ALREADY compiling. A base entry lying wholly inside one of the new ranges
+    # is not new coverage -- its bytes moved from one `complete` entry to another and
+    # were already in `sourceBytes`. A base entry that lies OUTSIDE every new range is
+    # coverage this merge LOST: it is not subtracted, so it still shortens the delta and
+    # the comparison below still refuses it. That is the clause that stops an unrelated
+    # range leaving under cover of the merge, and it is untouched.
     new_bytes = sum(stop - start
                     for spans in new_ranges.values() for start, stop in spans)
-    if he["stats"]["sourceBytes"] - be["stats"]["sourceBytes"] != new_bytes:
+    absorbed_bytes = sum(entry["size"] for key, entry in be["source"].items()
+                         if key not in he["source"]
+                         and _inside_new(entry["module"], entry["addr"], entry["end"]))
+    if (he["stats"]["sourceBytes"] - be["stats"]["sourceBytes"]
+            != new_bytes - absorbed_bytes):
         return None
 
     # Surviving matched records keep their size unless they grew into a new range.
@@ -373,7 +390,9 @@ def classify_merge(bf, hf, be, he, compiled):
             "functionDelta": hf["stats"]["totalFunctions"] - bf["stats"]["totalFunctions"],
             "added": sorted(set(hf["functions"]) - set(bf["functions"])),
             "removed": removed,
-            "sourceByteDelta": new_bytes}
+            "newExtent": new_bytes,
+            "absorbedBytes": absorbed_bytes,
+            "sourceByteDelta": new_bytes - absorbed_bytes}
 
 
 def classify_repartition(bf, hf):
@@ -1057,7 +1076,9 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
         # evidence and a reader auditing one should not have to guess.
         if repartition["kind"] == "merge":
             basis = (f"newly `complete` delinks coverage of every removed range, "
-                     f"sourceBytes {repartition['sourceByteDelta']:+d} -- see "
+                     f"sourceBytes {repartition['sourceByteDelta']:+d} "
+                     f"(new extent {repartition['newExtent']}, of which "
+                     f"{repartition['absorbedBytes']} the base already compiled) -- see "
                      f"classify_merge")
         else:
             basis = ("identical matched set and matched sizes -- see "

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -1394,7 +1394,19 @@ def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
     # when both totals hold.
     if he["stats"]["sourceFunctions"] < be["stats"]["sourceFunctions"]:
         reasons.append("source-built function coverage decreased")
-    dropped_enrollment = sorted(set(be["source"]) - set(he["source"]))
+    # A key changes whenever an entry's `end` moves, so a range that GREW to swallow
+    # its neighbour reads as dropped even though every one of its bytes is still
+    # compiled and byte-compared -- and the warning below would then say those bytes
+    # left the verified set, which is the opposite of what happened. Only report a base
+    # range no head range still covers.
+    _head_spans = collections.defaultdict(list)
+    for _entry in he["source"].values():
+        _head_spans[_entry["module"]].append((_entry["addr"], _entry["end"]))
+    dropped_enrollment = sorted(
+        key for key, entry in be["source"].items()
+        if key not in he["source"]
+        and not any(start <= entry["addr"] and entry["end"] <= stop
+                    for start, stop in _head_spans.get(entry["module"], [])))
     # Reassignment alone (a name moving from one contributor to another, credit_changes)
     # is never a blocker: a rebase, a rename, or resolving someone else's merge conflict
     # all relabel a function's "last touched by" without losing anything, and this


### PR DESCRIPTION
# The matched-loss exception, and the evidence it now needs

Three corrections to the generalized exception, one commit each, each with the negative
control that reproduced the defect before it was fixed. Every one of the reproductions
below was driven through the real `build_report` on a committed tree, not through a
hand-built dict.

## A. The overlay word reader took its base from the first function

`_module_image` read an overlay at `_rev_enrolment(rev)[0][module][0]`, which is a list
of FUNCTION addresses. `modules._overlay_base`, the derivation the comment claimed to
follow and the one the byte gate, `match.py --module ovNNN` and `evidence_rom` all use,
takes the lowest address of ANY symbol. A module whose lowest symbol is data therefore
answered every query with an earlier word.

`_module_symbol_base` is the revision-pinned equivalent of that all-symbol base, and
itcm and dtcm are readable now too, from the two places `modules.py` looks. ARM9 keeps
its fixed 0x02004000 load base, which is not its lowest symbol (`overlay_100` at
0x00000064 is).

Negative control, `DataLeadingOverlayImageBase`: an ov001 with four bytes of data in
front of its first function, `bx lr` at 0x020ab150 and `mov r0, #0` at the retired
record 0x020ab154.

| test | before | after |
| --- | --- | --- |
| `test_the_reader_answers_from_the_lowest_symbol_not_the_first_function` | reader returns 0xe12fff1e | 0xe3a00000 |
| `test_a_non_return_tail_in_a_data_leading_overlay_is_refused` | Passed, `reasons: []`, one absorbed | refused, `lost 1 matched function(s)` |
| `test_the_same_overlay_fixture_with_a_real_tail_return_still_lands` | (positive control) | lands |

Measured on this tree: 72 of the 73 modules that declare functions have equal bases
either way, so no live read moves. The exception is ARM9, which does not use this path.

## B. Zero functions did not make an empty relocation file complete

The inventory check exempted an empty `relocs.txt` whenever the module's symbol table
declared no function. A module with no code can still hold a table of callback pointers
in its `.data`, and every one of them is an incoming reference the index would then not
know about.

`_empty_relocs_defect` asks what dsd wrote instead, in this order: a module declaring a
function is refused as before; otherwise the module's own section inventory decides, and
a module whose non-`bss` sections are all zero-length really does reference nothing
(`.bss` is uninitialised and occupies no cartridge bytes); a module WITH initialised
bytes has to be read, and passes only when those words are all zero. No inventory, or no
image to read one, is a defect naming the file it wanted.

Negative control,
`test_a_data_only_module_with_an_empty_relocation_file_fails_closed`: a data-only ov001
added to the real absorption fixture, with a nonempty four-byte `.data` holding the
retired ARM9 address and an empty `relocs.txt` in both snapshots. Before: `Passed`,
`relocationEvidence.valid: true`, one absorbed record. After: refused, naming
`config/arm9/overlays/ov001/relocs.txt is empty`.
`test_a_data_only_module_whose_data_is_zeroed_is_still_legitimate` is the other half:
the same layout with a zeroed word still lands. Four `RelocIndex` controls cover the
bss-only inventory, the missing inventory, the unreadable image and the zeroed data.

Live census unchanged: **92 destination buckets, 96,395 destinations, 0 defects.**
Disclosed, and in the docstring: on a checkout with no `extracted/` it is the same 92
and 96,395 with **one** defect, `config/arm9/dtcm`, whose 0x20 of `.data` can only be
shown harmless by reading it (it is all zeroes). That makes the exception unavailable
there, which is the position it is already in without the ROM image, and it changes no
other number in the report.

## C. A four-byte tail with return-shaped bits is not an owned epilogue

Three independent fixtures returned `Passed`, no reasons and one absorbed record at
92f9ad43b. Reproduced here first, all three, then refused:

1. **A named callback at the covering range's tail.** The existing control put it
   mid-range, so it tested position rather than identity.
2. **A compiler-generated literal pool.**
   `unsigned int func_02071644(void) { return 0xe12fff1e; }` under the pinned 2004/b56
   emits `e59f0000 e12fff1e e12fff1e`, and the object's mapping symbols put `$d` at
   offset 8. The final word has a return's exact bits and is a constant.
3. **`0xe8908000`, `ldm r0, {pc}`**, together with `ldmdb r0, {pc}` and
   `ldmib r0!, {pc}`.

Two new clauses, and a return classifier that no longer diverges from the helper it
cites:

* **(e) identity.** `_named_symbol` refuses when any symbol in EITHER revision names the
  retired address with anything but the placeholder config derives from the address
  itself (`func_02071694`, `func_ov006_020cb030`). `AutoloadCallback` is a name; a
  placeholder is not.
* **(f) code ownership.** `_compiled_code_reader` compiles the merged source at the
  revision under judgement with the pinned compiler and reads the ARM EABI mapping
  symbols of the object it produces. The retired address must lie inside the merged
  function's own compiled output in a `$a` region, and the word the object emits there
  must be the cartridge's word. `$d` is refused. This tool has no object of its own --
  the worker hands it `rombuild.py`'s JSON, which says whether a module reproduced, not
  where inside a function the instructions stop -- so it builds one.
* **the return set** is now classified by `evidence_rom.is_unconditional_return`,
  imported rather than re-derived, then narrowed to `bx lr` and a stack pop to pc.
  `ldm r0, {pc}` and its db/ib spellings are gone because the base register must be
  r13; `mov pc, lr` is gone because its return-ness is a fact about lr, not about the
  word; `ldr pc, [sp], #4` stays refused on the block-transfer bits. (The comment
  claiming capstone decodes that one as LDR was wrong. It renders it `pop {pc}`.)

New refusing tests: `test_a_named_callback_at_the_tail_is_refused`,
`test_a_literal_pool_at_the_tail_is_refused`,
`test_an_object_that_emits_a_different_word_is_refused`,
`test_a_block_load_through_a_register_other_than_sp_is_refused`,
`test_without_code_ownership_nothing_matched_may_leave`, and the same three through
`build_report`: `test_a_named_callback_at_the_tail_fails_the_report`,
`test_a_literal_pool_at_the_tail_fails_the_report`,
`test_a_block_load_through_r0_fails_the_report`,
`test_without_code_ownership_the_report_fails_closed`.

Two classes run the real compiler rather than a stub, and skip where it is absent:
`CompiledCodeOwnership` builds the literal-pool object and asserts offset 8 is data
while offset 4, the same bits, is an instruction; `LiteralPoolThroughBuildReport` drives
the literal-pool input end to end through `build_report` with no stub anywhere,
refusing the pool and still landing a body that really ends in that instruction. The
report fixtures elsewhere pass a stub, because the runner that runs this suite has no
toolchain and a stub is how the WIRING gets tested there; `code_evidence` is a seam, not
a policy knob, and no value of it grants the exception.

`tools/requirements.txt` gains pyyaml: `evidence_rom` imports it at module level, so the
suite that exercises the shared classifier needs it.

The warning and the report row now state what the guard establishes and stop there --
that a function this merge compiles owns those four bytes and emits the cartridge's own
return at them, that config has no independent name for them, and that no relocation
destination in a validated index points at them. Reachability is named as not claimed.

## Runs

`python -m unittest tools.test_validate_merge`: **139 tests, OK** (114 before). The
tool-tests.yml list, run whole: **717 tests, OK, 2 skips** on a Windows tree with the
toolchain (692 before). `CompiledCodeOwnership` (4 tests) and
`LiteralPoolThroughBuildReport` (2) are `@skipUnless` the pinned compiler, so they
self-skip on the runner and its skip count rises by six; every other new test runs
there. `check_python_names`: PASS, 284 files, 0 unresolvable. `check_dead_references`:
no new dead references, no broken markdown links. `pyflakes` on both changed files is
clean apart from one pre-existing finding (`credit_moved`).

`validate_merge` against `origin/main` (bdcb1df7d) on this branch: **Passed**, no
reasons, `relocationEvidence valid 92 / 192,790 / 0` (the two-revision union;
96,395 per revision), no repartition, `totalFunctions` 11,345 unchanged,
`matchedFunctions` 11,286 unchanged. The only warning is the absent head ROM report.

## What is still not claimed

W4-03's entry-sum arithmetic (counters sum entries, not interval unions) and W4-04's
inherited shrink/helper-cache limits are unchanged and stay disclosed. The private `PR
validation` check is tooling-only `noverify`; nothing here is retail validation of the
exception.
