### PR TITLE
Count byte-exact assembly primitives as matched, and say so in the README

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -112,6 +112,9 @@
 # test_premerge_check adds none on a runner with git installed, and test_symrecords,
 # test_nearmiss_db, test_tu_map, test_tu_promote, test_tu_production and
 # test_tubuild_owned_relocs add none anywhere.
+# The counting-rule work of 2026-09-09 adds 32 assertions to that historical total:
+# +10 test_asm_policy, +16 test_bytegate, +3 test_progress, +3 test_validate_merge.
+# None of them skips. test_tiers gains 6 more and runs in converted-ratchet.yml.
 # 505 of the 514 assert something. test_tubuild_vtable_partitions adds four to both
 # halves of that -- all four assert and none skips -- but the 514 was measured in the
 # container and the +4 is arithmetic on it, not a re-measurement. On a Windows tree
@@ -225,18 +228,23 @@ jobs:
 #
 #   test_affected_src            (1)   affected_src.py -- which src/ files a changed
 #                                      local header drags into the validation compile.
-#   test_asm_policy             (14)   asm_policy.py -- the one shared answer to "is this
-#                                      an asm transcription?". Guards the VACUOUS match.
+#   test_asm_policy             (24)   asm_policy.py -- the one shared answer to "is this
+#                                      an asm transcription?", and counts_as_matched, the
+#                                      one shared answer to "does this source count?".
+#                                      Guards the VACUOUS match at both.
 #   test_asset_catalog          (10)   asset_catalog.py -- NitroFS catalog build, the
 #                                      source references into it, and `resolve`, which
 #                                      must read an integer as a runtime handle and
 #                                      never as a NitroFS file ID.
 #   test_attribution            (17)   chaos_db_ci.py -- rebuilds chaos-db.json from
 #                                      COMMITTED history; the credit data the site reads.
-#   test_bytegate               (23)   bytegate.py -- the byte-gate-failure half of the
+#   test_bytegate               (39)   bytegate.py -- the byte-gate-failure half of the
 #                                      matched test, over layout_check/relocs/srcpath,
 #                                      plus is_zero_size_alias, which decides whether a
-#                                      symbol is in the published DENOMINATOR at all.
+#                                      symbol is in the published DENOMINATOR at all, and
+#                                      alias_names, which decides whether a source filed
+#                                      under a second name is found. Also drives the real
+#                                      chaos_db_ci over a fake repo for the counting rule.
 #   test_check_data_definitions  (3)   check_data_definitions.py -- WHICH objects the
 #                                      gate scans. It globbed only build/src/, which
 #                                      eligible.py never writes, so it skipped silently.
@@ -269,7 +277,7 @@ jobs:
 #                                      profile/class namespace split, actor/base layout
 #                                      distinction, overlay-address rejection, and the
 #                                      dry-run-only policy for ambiguous factory names.
-#   test_progress                (5)   progress.py -- matched functions/bytes vs the
+#   test_progress                (8)   progress.py -- matched functions/bytes vs the
 #                                      whole game; the number the README reports, both
 #                                      halves of the fraction.
 #   test_rombuild               (37)   rombuild.py -- the source-to-ROM build itself:
@@ -426,8 +434,10 @@ jobs:
 #                                      the new test, and restoring the section-name
 #                                      comparison is caught by it and by the moved
 #                                      licensing test.
-#   test_validate_merge         (35)   validate_merge.py -- builds the machine-readable
+#   test_validate_merge         (76)   validate_merge.py -- builds the machine-readable
 #                                      PR validation report the validator comment renders.
+#                                      (The 35 recorded here was stale by 38 before this
+#                                      line was touched; 76 is a measurement, not a delta.)
 #
 # The two suites this list still refuses, and the number that says why. test_objisolate
 # is one `@unittest.skipUnless(_compiler(), "mwccarm not present")` class and nothing

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ merge PRs read **[MERGE.md](MERGE.md)**.
 
 <!-- progress:start -->
 ```
-Functions  ██████████████████████████████  99.4%   11,318 / 11,390
-Code size  █████████████████████████████░  97.7%   2,186,936 / 2,238,108 bytes
+Functions  ██████████████████████████████  99.6%   11,342 / 11,390
+Code size  █████████████████████████████░  97.9%   2,191,568 / 2,238,108 bytes
 ```
 <!-- progress:end -->
 
@@ -46,13 +46,17 @@ here, and they move independently.
 
 <!-- tiers:start -->
 ```
-MATCHED    ██████████████████████████████  99.4%   11,318 / 11,390 functions
+MATCHED    ██████████████████████████████  99.6%   11,342 / 11,390 functions
+           of which 113 are byte-exact assembly (hand-written in the original, not C)
 CONVERTED  ███████░░░░░░░░░░░░░░░░░░░░░░░  23.8%   2,707 / 11,357 functions
 LINKED     ████████████████████████████░░  91.8%   10,397 / 11,328 matched TUs
 ```
 <!-- tiers:end -->
 
-- **MATCHED** is byte-exact C, verified against the ROM. This is the bar above and
+- **MATCHED** is source that compiles to the ROM's exact bytes, checked against the
+  cartridge. Nearly all of it is C. The rest is the small set of routines the original
+  game wrote in assembly, which count under the rule in
+  [What counts as matched](#what-counts-as-matched) below. This is the bar above and
   the treemap.
 - **CONVERTED** is source-owned code a person can read without the ROM open beside
   them. Matching
@@ -101,13 +105,40 @@ The matching compiler is pinned to **mwccarm 2004/b56** with these flags (the 1.
 -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
 ```
 
+## What counts as matched
+
+A function counts as matched when the source in this repo, compiled with the pinned
+compiler, produces exactly the bytes that are on the cartridge. Not similar bytes.
+The same bytes. If the check fails, it does not count, however close it looks.
+
+Almost all of the game was written in C, so almost all of that work is writing C. A
+small number of routines were never C. Nintendo wrote those by hand in assembly,
+because they do jobs the C language has no way to ask for: driving the chip's cache,
+calling into the DS firmware, switching the processor between modes, and a few pieces
+of the compiler's own maths library that hand back two answers at once.
+
+There is no C to find for those. The honest source for them is the same assembly, so
+that is what this repo carries, and each one is checked against the cartridge exactly
+like everything else. They count as matched, and every file counted that way carries a
+`HAND-ASM PRIMITIVE` line at the top so nobody mistakes it for recovered C. The caption
+under the MATCHED bar says how many there are.
+
+That exception is narrow on purpose. A function only qualifies when its body contains
+an instruction C cannot express at all. If it is ordinary code that we simply cannot
+reproduce yet, writing it out as assembly proves nothing, so it does not qualify and
+does not count. Those files are marked `NONMATCHING` instead, and unmatched means just
+that: the original was C, and we do not yet have C the compiler turns into those exact
+bytes. The rule is written up in [notes/asm-policy.md](notes/asm-policy.md).
+
 ## How matching works
 
 Every candidate is verified the same way: compile it with mwccarm, then compare the
 result to the ROM byte-for-byte, relocation-aware (call and data references are slots
 the linker fills in, so they are compared structurally). Nothing counts as matched
-until that check passes. The work is organized in tiers so the automatic methods clear
-as much as possible before any manual effort:
+until that check passes, including the hand-written assembly primitives above: the
+banner explains why a file is assembly, it never excuses it from the byte check. The
+work is organized in tiers so the automatic methods clear as much as possible before
+any manual effort:
 
 1. **Automatic templates.** A set of rules recognizes common function shapes (constant
    returns, field getters and setters, bitfield reads, struct copies, simple wrappers,

--- a/audit/unmatched_census.md
+++ b/audit/unmatched_census.md
@@ -1,0 +1,154 @@
+# The 72 unmatched functions, and which of them count
+
+Measured at origin/main c52f63ca5, from the chaos-db.json that commit's own
+generator produces (11,318 matched of 11,390, the figure the README bar carried).
+Written for Tango's ruling of 2026-09-09, `count them and address it somewhere in
+readme`, and kept because the partition is the evidence the rule rests on.
+
+## What the 72 are
+
+| group | what it is | count | counts now |
+|---|---|---:|---|
+| a | byte-exact hand-written assembly primitives, bannered `HAND-ASM PRIMITIVE`, with the word `NONMATCHING` also present | 20 | yes |
+| b | ITCM rows: 11 are the compiler's own runtime (assembly, no original C), 2 are game code that merely lives there | 13 | 4 yes, 9 no |
+| c | `NONMATCHING` C drafts: the original was C and mwccarm does not reproduce it yet | 18 | no |
+| d | no source in the tree under any name | 21 | no |
+
+Group (a) plus the four resolvable rows of group (b) is 24 functions and 4,632
+bytes. The published count moves from 11,318 / 11,390 to 11,342 / 11,390 and the
+denominator does not move: these are functions changing sides, not appearing.
+
+## Group (a): the assembly primitives the policy already accepts
+
+Every one of these carries the `HAND-ASM PRIMITIVE` banner in its header region AND
+the word `NONMATCHING`, because `there is no C to chase` was written as a
+NONMATCHING note. The counting tools read only the second half. Each row's source
+was compiled with the pinned compiler and compared to the cartridge for this census:
+the byte gate is `tools/build_pin.py`, the same one the ROM build uses, so a source
+that reproduces only under some other sweep member could not pass.
+
+| module | address | size | symbol | source | banner | classify | byte gate |
+|---|---|---:|---|---|---|---|---|
+| arm9 | 0x0200497c | 112 | `func_0200497c` | `src/func_0200497c.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02052514 | 60 | `func_02052514` | `src/func_02052514.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x0205256c | 28 | `func_0205256c` | `src/func_0205256c.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x020527e8 | 22 | `func_020527e8` | `src/func_020527e8.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02052800 | 30 | `func_02052800` | `src/func_02052800.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02052820 | 26 | `func_02052820` | `src/func_02052820.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x0205283c | 26 | `func_0205283c` | `src/func_0205283c.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02052ec8 | 44 | `func_02052ec8` | `src/func_02052ec8.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x020553c0 | 148 | `func_020553c0` | `src/func_020553c0.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02057014 | 12 | `func_02057014` | `src/func_02057014.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02057020 | 88 | `func_02057020` | `src/func_02057020.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02057078 | 48 | `func_02057078` | `src/func_02057078.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02058568 | 100 | `func_02058568` | `src/func_02058568.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02059468 | 20 | `func_02059468` | `src/func_02059468.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02059824 | 16 | `func_02059824` | `src/func_02059824.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02059d98 | 60 | `func_02059d98` | `src/func_02059d98.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x0205a588 | 148 | `func_0205a588` | `src/func_0205a588.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x0205a61c | 304 | `CpuCopy8` | `src/CpuCopy8.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x02071790 | 48 | `func_02071790` | `src/func_02071790.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+| arm9 | 0x020717c0 | 76 | `__rethrow` | `src/__rethrow.c` | HAND-ASM PRIMITIVE + NONMATCHING | None | PASS 2004/b56 |
+
+## Group (b): the ITCM vendor rows
+
+Thirteen unmatched rows sit in ITCM. Eleven of them are the toolchain's own runtime,
+shipped as assembly: soft-float add and multiply, the 32-bit and 64-bit divide
+helpers, and their `__aeabi_` entry points. TWO are not vendor code at all and are
+only in this group because of where they live: `dBgW_Kc::DetectClsn(dBgCh_Lin&)` and
+`IRQ::UserInterruptHandler` are ordinary game code that happens to sit in ITCM, they
+were C in the original, and they belong with group (d).
+
+Four of the eleven DO have a byte-exact source in this tree, filed under the name
+their author knew the routine by: config gives each of those addresses a second,
+zero-size symbol, and the source is named after that one. `src/_dmul.c` decompiles
+the 1,776 bytes the symbol table calls `func_01ff8708`. Looked up by the sized
+record's own name, srcpath finds nothing at all, so they read as never attempted.
+
+The other nine rows have no source in the tree under any name. They cannot count:
+there is nothing to reproduce them from, and a rule that counted them would be
+counting an intention rather than a match. They are left unmatched, and Tango can
+rule again now that the difference is measured rather than assumed.
+
+| address | size | symbol | alias | source | byte gate | counts |
+|---|---:|---|---|---|---|---|
+| 0x01ff8000 | 1436 | `func_01ff8000` | `_dadd` | none | not run | no |
+| 0x01ff8708 | 1776 | `func_01ff8708` | `_dmul` | `src/_dmul.c` | PASS 2004/b56 | yes |
+| 0x01ff8e10 | 1384 | `func_01ff8e10` |  | none | not run | no |
+| 0x01ff9378 | 1120 | `func_01ff9378` |  | none | not run | no |
+| 0x01ffa440 | 124 | `func_01ffa440` |  | none | not run | no |
+| 0x01ffa594 | 1096 | `func_01ffa594` |  | none | not run | no |
+| 0x01ffa9dc | 12 | `__aeabi_uldiv` | `_ll_udiv` | none | not run | no |
+| 0x01ffa9e8 | 76 | `__aeabi_ulmod` | `_ull_mod` | none | not run | no |
+| 0x01ffaa34 | 432 | `func_01ffaa34` | `_ll_sdiv` | `src/_ll_sdiv.c` | PASS 2004/b56 | yes |
+| 0x01ffabe4 | 524 | `__aeabi_idiv` | `_s32_div_f` | `src/_s32_div_f.c` | PASS 2004/b56 | yes |
+| 0x01ffadf0 | 484 | `__aeabi_uidiv` | `_u32_div_f` | `src/_u32_div_f.c` | PASS 2004/b56 | yes |
+| 0x01ffb0fc | 1844 | `_ZN7dBgW_Kc10DetectClsnER9dBgCh_Lin` |  | none | not run | no |
+| 0x01ffd97c | 88 | `_ZN3IRQ20UserInterruptHandlerEv` |  | none | not run | no |
+
+## Group (c): NONMATCHING C
+
+Real compiler floors and open drafts. The original was C, the source in the tree is
+C, and mwccarm does not yet produce the cartridge's bytes from it. Nothing here
+changes: these stay unmatched, which is what unmatched is for.
+
+| module | address | size | symbol | source |
+|---|---|---:|---|---|
+| arm9 | 0x02009e70 | 4252 | `func_02009e70` | `src/func_02009e70.cpp` |
+| arm9 | 0x02020994 | 1680 | `_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii` | `src/_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii.cpp` |
+| arm9 | 0x0202cc0c | 2692 | `_ZN5Stage13InitResourcesEv` | `src/_ZN5Stage13InitResourcesEv.cpp` |
+| arm9 | 0x0202ffec | 472 | `func_0202ffec` | `src/func_0202ffec.c` |
+| arm9 | 0x02045b58 | 184 | `_ZN5Model27LoadCompressedTextureToVramEPcjS0_` | `src/_ZN5Model27LoadCompressedTextureToVramEPcjS0_.cpp` |
+| arm9 | 0x02059d8c | 12 | `func_02059d8c` | `src/func_02059d8c.c` |
+| arm9 | 0x020610fc | 44 | `func_020610fc` | `src/func_020610fc.c` |
+| arm9 | 0x02068398 | 120 | `func_02068398` | `src/func_02068398.c` |
+| arm9 | 0x02071644 | 80 | `func_02071644` | `src/func_02071644.c` |
+| ov003 | 0x020af038 | 2100 | `_ZN12dScStarSel_c8BehaviorEv` | `src/_ZN12dScStarSel_c8BehaviorEv.cpp` |
+| ov007 | 0x020bfd70 | 220 | `func_ov007_020bfd70` | `src/func_ov007_020bfd70.cpp` |
+| ov009 | 0x0211145c | 380 | `func_ov009_0211145c` | `src/func_ov009_0211145c.c` |
+| ov015 | 0x021114f0 | 380 | `func_ov015_021114f0` | `src/func_ov015_021114f0.c` |
+| ov071 | 0x02121734 | 664 | `_ZN3MrI13InitResourcesEv` | `src/_ZN3MrI13InitResourcesEv.cpp` |
+| ov074 | 0x02121380 | 884 | `func_ov074_02121380` | `src/func_ov074_02121380.c` |
+| ov075 | 0x02116128 | 244 | `func_ov075_02116128` | `src/func_ov075_02116128.cpp` |
+| ov075 | 0x0211621c | 916 | `func_ov075_0211621c` | `src/func_ov075_0211621c.c` |
+| ov075 | 0x0211afb0 | 540 | `func_ov075_0211afb0` | `src/func_ov075_0211afb0.c` |
+
+## Group (d): no source at all
+
+Twenty-one functions outside ITCM with no source file in the tree under any name.
+Not drafts and not primitives: work nobody has started, or started and never landed.
+
+| module | address | size | symbol |
+|---|---|---:|---|
+| ov002 | 0x020bb614 | 988 | `func_ov002_020bb614` |
+| ov002 | 0x020cfea4 | 724 | `func_ov002_020cfea4` |
+| ov002 | 0x020d3b9c | 1440 | `func_ov002_020d3b9c` |
+| ov002 | 0x020d9fec | 964 | `_ZN6Player19St_SwingPlayer_MainEv` |
+| ov002 | 0x020f3de4 | 792 | `func_ov002_020f3de4` |
+| ov004 | 0x020b2220 | 548 | `func_ov004_020b2220` |
+| ov006 | 0x020cf2fc | 1116 | `func_ov006_020cf2fc` |
+| ov006 | 0x020d01e0 | 2048 | `func_ov006_020d01e0` |
+| ov006 | 0x020d27dc | 3656 | `func_ov006_020d27dc` |
+| ov006 | 0x020e20bc | 1504 | `func_ov006_020e20bc` |
+| ov006 | 0x020e5450 | 1376 | `func_ov006_020e5450` |
+| ov006 | 0x020ea914 | 804 | `func_ov006_020ea914` |
+| ov006 | 0x020ee994 | 360 | `_ZN11dScMgJump_c13OnYoshiTryEatEi` |
+| ov006 | 0x020fc8c0 | 240 | `func_ov006_020fc8c0` |
+| ov006 | 0x020fdaf0 | 592 | `func_ov006_020fdaf0` |
+| ov006 | 0x0210c9e0 | 2076 | `_ZN12dScMgSlot1_c8BehaviorEv` |
+| ov006 | 0x0211e72c | 172 | `func_ov006_0211e72c` |
+| ov006 | 0x02126b4c | 920 | `func_ov006_02126b4c` |
+| ov060 | 0x021140c0 | 500 | `func_ov060_021140c0` |
+| ov063 | 0x02117cdc | 1916 | `func_ov063_02117cdc` |
+| ov080 | 0x021261f4 | 760 | `func_ov080_021261f4` |
+
+## Reproducing this
+
+```sh
+python tools/chaos_db_ci.py --out chaos-db.json   # the record for every function
+python tools/tiers.py --from-db chaos-db.json     # MATCHED and its assembly subset
+```
+
+The byte-gate column is `tools/build_pin.py`'s `verify(src, symbol, addr, size,
+module)`, which needs the extracted ROM and mwccarm and so cannot run in CI. All 24
+countable rows returned `(True, '2004/b56')` on 2026-09-09.

--- a/tools/asm_policy.py
+++ b/tools/asm_policy.py
@@ -7,6 +7,12 @@ the asm block is the faithful source and counts as matched. ``NONMATCHING`` says
 the file is a declared draft and does not count. Everything else claiming to be a
 match must be real C.
 
+``counts_as_matched`` at the bottom is the one function that turns those banners
+into the yes/no every counting tool publishes, and the HAND-ASM banner wins when a
+file carries both. A hand-written primitive has no original C, so NONMATCHING on
+one of those files never meant "still a draft"; the twenty files in this tree that
+carry both say so in their own headers.
+
 The failure mode this module exists to catch is the VACUOUS match. mwccarm's
 ``dcd 0x...`` directive emits the literal word you type, so a whole-function dcd
 dump assembles to the ROM bytes by definition: the "match" proves only that the
@@ -59,6 +65,24 @@ def header_region(text):
             break
         out.append(line)
     return "".join(out)
+
+
+def has_hand_banner(text):
+    """Does this file declare itself a hand-written assembly primitive?
+
+    The HEADER REGION, not the whole file, and that asymmetry with
+    ``has_draft_banner`` is deliberate. ``NONMATCHING`` anywhere in the leading
+    comment block is exculpatory -- it can only ever take a file OUT of the count,
+    so a loose search is safe. This banner does the opposite: it puts a file IN,
+    so it has to be a claim the author made at the top of the file about the file,
+    not the words "HAND-ASM PRIMITIVE" appearing in a wall-analysis paragraph
+    thirty lines down inside a function body.
+
+    Measured on this tree when the rule landed: 109 sources carry the phrase
+    somewhere, and all 109 carry it in the header region, so the tightening costs
+    nothing today and closes the hole for later.
+    """
+    return HAND_BANNER in header_region(text)
 
 
 def has_draft_banner(text):
@@ -155,3 +179,55 @@ def classify(text):
     if is_asm_passthrough(text):
         return "unbannered-asm"
     return None
+
+
+def counts_as_matched(text):
+    """THE matched test for a source file, shared by every tool that publishes a count.
+
+    Three tools computed this independently -- ``chaos_db_ci`` (the published
+    chaos-db.json the README bar and the treemap read), ``progress.py``'s
+    ``--from-src`` path, and ``validate_merge``'s per-PR coverage -- and each
+    spelled it as "no NONMATCHING banner and not a dcd transcription". So they
+    agreed on the answer by accident rather than by construction, and a rule change
+    had to be made in three places or the numbers would disagree. It is one
+    function now.
+
+    The rule, in order:
+
+      1. An UNBANNERED dcd transcription never counts. ``dcd 0x...`` emits the
+         literal word you type, so the file byte-matches by definition and proves
+         only that somebody copied the disassembly. This is checked first so no
+         later clause can excuse it.
+      2. No draft banner -> counts. The ordinary case: real C with no NONMATCHING.
+      3. A draft banner AND a HAND-ASM PRIMITIVE banner -> counts (Tango's ruling,
+         2026-09-09). A hand-written assembly primitive has no original C to
+         recover, so "NONMATCHING" on it never meant "still a draft"; it meant
+         "there is no match to chase". Twenty files in this tree say exactly that
+         in their own words -- "byte-exact hand-written asm ... there is no
+         original C to recover and no match to chase. Counts as done under the
+         asm-primitive policy" -- and were then not counted, because the counting
+         tools only read the word NONMATCHING. Those twenty are byte-verified
+         against the ROM under the pinned 2004/b56 compiler (audit/unmatched_census.md).
+         The hand-asm exception additionally refuses any file carrying a raw dcd
+         word. Clause 1 cannot catch that case on its own -- ``classify`` treats
+         ANY banner as exculpatory and returns None -- so without this the new rule
+         would open a laundering route that "NONMATCHING plus HAND-ASM plus a word
+         dump" walks straight through. It makes this path deliberately stricter
+         than the plain HAND-ASM-only path, where a pool word inside an asm block
+         has always been allowed; measured when the ruling landed, none of the
+         twenty files it admits carries a dcd word, so the clause costs nothing.
+      4. Anything else with a draft banner -> does not count. Ordinary ARM that
+         mwccarm cannot yet reproduce stays a draft, which is the whole point of
+         notes/asm-policy.md.
+
+    What this does NOT do is decide whether the asm-primitive claim is TRUE. The
+    acceptance criteria are unchanged and still live in notes/asm-policy.md (the
+    body must carry an instruction C cannot express -- mcr/mrc, swi, msr/mrs, the
+    banked ldm/stm ^ forms, swp), and they are enforced the same way they were
+    before: by review. This function reads the banner a reviewer accepted.
+    """
+    if classify(text) == "transcribed":
+        return False
+    if not has_draft_banner(text):
+        return True
+    return has_hand_banner(text) and not _DCD_RE.search(_strip_comments(text))

--- a/tools/bytegate.py
+++ b/tools/bytegate.py
@@ -70,6 +70,40 @@ FUNC_RE = re.compile(
 )
 
 
+def alias_names(module_universe=None) -> dict[tuple[str, int], list[str]]:
+    """``{(module, addr): [zero-size alias names]}`` for every aliased address.
+
+    The names, not just the addresses, because the source file for an aliased
+    function is filed under whichever name its author knew it by, and in this tree
+    that is usually the ALIAS. ``src/_dmul.c`` decompiles the 1,776 bytes at
+    0x01ff8708; the sized symbol record on that address is called ``func_01ff8708``,
+    and a lookup by that name finds nothing. Four ITCM primitives sat unmatched for
+    that reason alone, each with a byte-exact source in the tree. See
+    ``alias_collision_addresses`` for why the zero-size record itself is dropped.
+    """
+    if module_universe is None:
+        sys.path.insert(0, str(REPO / "tools"))
+        import relocs as RL
+        module_universe = RL.module_universe
+
+    out: dict[tuple[str, int], list[str]] = {}
+    for symbols, label in module_universe():
+        sized, zero = set(), []
+        for line in symbols.read_text(errors="ignore").splitlines():
+            match = FUNC_RE.match(line)
+            if not match:
+                continue
+            name, size, addr = match.group(1), int(match.group(2), 16), int(match.group(3), 16)
+            if size:
+                sized.add(addr)
+            else:
+                zero.append((addr, name))
+        for addr, name in zero:
+            if addr in sized:
+                out.setdefault((label, addr), []).append(name)
+    return out
+
+
 def alias_collision_addresses(module_universe=None) -> set[tuple[str, int]]:
     """``{(module, addr)}`` where a zero-size function aliases a sized record.
 
@@ -77,25 +111,7 @@ def alias_collision_addresses(module_universe=None) -> set[tuple[str, int]]:
     while visiting the full symbol record, and deriving it from committed config keeps
     the progress and Chaos generators in lockstep.
     """
-    if module_universe is None:
-        sys.path.insert(0, str(REPO / "tools"))
-        import relocs as RL
-        module_universe = RL.module_universe
-
-    out = set()
-    for symbols, label in module_universe():
-        sized, zero = set(), []
-        for line in symbols.read_text(errors="ignore").splitlines():
-            match = FUNC_RE.match(line)
-            if not match:
-                continue
-            size, addr = int(match.group(2), 16), int(match.group(3), 16)
-            if size:
-                sized.add(addr)
-            else:
-                zero.append(addr)
-        out.update((label, addr) for addr in zero if addr in sized)
-    return out
+    return set(alias_names(module_universe))
 
 
 def is_zero_size_alias(module: str, addr: int, size: int, alias_addrs) -> bool:

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -545,6 +545,10 @@ def main():
     # The byte-gate-failure class, both halves, read once for the same reason. See the
     # `matched` conjunct below and tools/bytegate.py.
     alias_addrs = alias_collision_addresses()
+    # Same eight addresses, keyed to the names the aliases carry, so a sized record
+    # whose source is filed under its alias can find it.  Derived from the same
+    # committed config, in one pass, for the same reason the set above is.
+    alias_srcnames = BG.alias_names(RL.module_universe)
     wont_build = BG.excluded_paths()
     bytegate_n = collections.Counter()
     enrollment_n = collections.Counter()
@@ -569,6 +573,18 @@ def main():
                 alias_dropped += 1
                 continue
             f = SP.path_for(name)
+            if f is None:
+                # An aliased address files its source under whichever name the author
+                # knew the function by, which in this tree is the ALIAS: src/_dmul.c
+                # decompiles the bytes the symbol table calls func_01ff8708. Asked only
+                # about the sized record's own name, the lookup finds nothing and four
+                # byte-exact ITCM primitives read as never attempted. The zero-size
+                # record is still dropped above, so this attaches the source to the one
+                # record that survives rather than counting the pair twice.
+                for alt in alias_srcnames.get((label, addr), ()):
+                    f = SP.path_for(alt)
+                    if f is not None:
+                        break
             src_path = f.relative_to(REPO).as_posix() if f else None
             text = f.read_text(errors="ignore") if f else ""
             # The settled tag lives in the banner, and banners drift downward as the

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -5,8 +5,10 @@ modules and percentages.
 
 Derived the same way as progress.py --write-readme:
   universe   config/**/symbols.txt  (name, addr, size per module)
-  matched    srcpath resolves a source, it is not marked // NONMATCHING, and the record
-             is not in the byte-gate-failure class (policy D -- see tools/bytegate.py)
+  matched    srcpath resolves a source, asm_policy.counts_as_matched accepts it (no
+             // NONMATCHING banner, or one overridden by a HAND-ASM PRIMITIVE banner;
+             never an unbannered dcd transcription), and the record is not in the
+             byte-gate-failure class (policy D -- see tools/bytegate.py)
   near-miss  nearmiss/db.jsonl (committed) -> div badge
   author     git history: the FIRST contributor to land the surviving match for each
              function (see first_matchers) -- credit follows renames and is not stolen by
@@ -240,6 +242,12 @@ def no_match_needed(head: str) -> dict[str, str] | None:
 # is demoted from matched; mnemonic asm without a banner is a policy gray zone
 # (embedded hatches inside real C, e.g. CP15 intrinsics) and is only WARNED about.
 # The detector is asm_policy.classify, shared with validate_merge and pr_linkcheck.
+#
+# When a file carries BOTH banners the HAND-ASM one wins (Tango's ruling, 2026-09-09).
+# Twenty files here say "byte-exact hand-written asm ... no original C to recover and
+# no match to chase" and then also print the word NONMATCHING, and the count read only
+# the second half. asm_policy.counts_as_matched holds that whole rule so this generator,
+# progress.py and validate_merge cannot drift apart on it again.
 
 
 def _handle_from(name: str, email: str) -> str:
@@ -528,6 +536,7 @@ def main():
     functions = []
     total_b = matched_b = matched_n = 0
     verified_b = verified_n = 0
+    handasm_b = handasm_n = 0
     enrolled = enrolled_addresses()
     # Every src path any delinks.txt names, promoted or not. Read once: delinks_paths
     # walks all 106 delinks files, and calling it per function would walk them 11,396
@@ -583,8 +592,12 @@ def main():
             # The gate is applied only to records the OLD test would have counted, so
             # that it is credited with what it actually removed rather than with every
             # record the class happens to describe.
-            countable = (bool(src_path) and not asm_policy.has_draft_banner(text)
-                         and cls != "transcribed")
+            countable = bool(src_path) and asm_policy.counts_as_matched(text)
+            # Assembly that counts, kept separately visible. It is a real match -- the
+            # original was assembly, so the asm block IS the recovered source -- but it
+            # is not C, and a bar that says "byte-exact C" has to be able to say how
+            # much of itself is not.
+            hand_asm = countable and asm_policy.has_hand_banner(text)
             bytegate_fail = countable and src_path is not None and src_path in wont_build
             matched = countable and not bytegate_fail
             total_b += size
@@ -616,6 +629,13 @@ def main():
             if matched:
                 matched_b += size
                 matched_n += 1
+                if hand_asm:
+                    # Published per record as well as summed, so a reader who wants to
+                    # know WHICH matched functions are assembly rather than C can answer
+                    # it from this file instead of re-grepping src/.
+                    rec["handAsm"] = True
+                    handasm_b += size
+                    handasm_n += 1
                 # Byte-verified is the subset the ROM build proves: enrolled, compiled,
                 # linked into its module and compared to the cartridge. The rest are
                 # matched on the strength of a source claim and are filled at link time by
@@ -668,6 +688,12 @@ def main():
             # so the measured figure travels beside it. See enrolled_addresses.
             "verifiedFunctions": verified_n,
             "verifiedBytes": verified_b,
+            # The assembly subset of `matched`: functions whose source is a bannered
+            # HAND-ASM PRIMITIVE, byte-faithful asm because the original was assembly.
+            # Reported so the README caption and tiers.py can name it rather than
+            # letting "matched C" quietly include work that is not C.
+            "handAsmFunctions": handasm_n,
+            "handAsmBytes": handasm_b,
             "moduleCount": len({f["module"] for f in functions}),
             # The other two tiers ride along here so every consumer reads ONE file.
             # romstats-sync.sh on the VPS fetches this db and nothing else, and the
@@ -693,6 +719,8 @@ def main():
           f"({100.0 * verified_b / total_b:.2f}% vs {100.0 * matched_b / total_b:.2f}% "
           f"matched); {matched_n - verified_n} matched function(s) are compiled by "
           f"nothing")
+    print(f"  of the matched: {handasm_n} function(s), {handasm_b} bytes are byte-exact "
+          f"hand-written assembly (HAND-ASM PRIMITIVE), not C")
     # ...and WHICH KIND of nothing, because the two halves have different remedies. A
     # matched/unenrolled function has a delinks entry waiting for a `complete`; a
     # matched/no_block one is almost always deliberate (thumb, alias, exclude list) and

--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -284,6 +284,13 @@ def source_policy(worst, text):
     WRONG (a resolvable reloc pointing at the wrong symbol) still fails -- a draft's
     call graph must be honest even if its bytes differ.
 
+    The test is `not asm_policy.counts_as_matched`, not `has_draft_banner`, because
+    those two stopped meaning the same thing on 2026-09-09. Twenty hand-written
+    assembly primitives carry the word NONMATCHING inside a note that says there is no
+    C to chase, and they DO count now -- so the sentence above, "chaos-db counts it as
+    unmatched", is exactly the condition to ask about, and asking the older question
+    would hand a counted match the downgrade that exists for uncounted drafts.
+
     The draft downgrade cannot collide with the transcription check: a transcription
     has no banner by definition, because a NONMATCHING banner reclassifies it as an
     honest draft (asm_policy.classify returns None for it).
@@ -294,7 +301,7 @@ def source_policy(worst, text):
     NO-REPRO -- and then the validator died on a NameError mid-loop, reporting "worker
     error" instead of grading the file. Untestable because inline, so untested.
     """
-    if worst == "NO-REPRO" and AP.has_draft_banner(text):
+    if worst == "NO-REPRO" and text and not AP.counts_as_matched(text):
         return "DRAFT"
     if AP.classify(text) == "transcribed":
         return "RAW-ASM"

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -93,6 +93,7 @@ def synced_from_src():
     Returns (done_n, done_b, n, total_bytes)."""
     n = total_bytes = done_n = done_b = 0
     alias_addrs = BG.alias_collision_addresses()
+    alias_srcnames = BG.alias_names()
     excluded_paths = BG.excluded_paths()
     # Every module, itcm included, via the one definition in relocs.py. This used
     # to skip itcm/dtcm to agree with chaos-db and the treemap, which skipped them
@@ -124,6 +125,15 @@ def synced_from_src():
             n += 1
             total_bytes += sz
             f = SP.path_for(name)
+            if f is None:
+                # The source for an aliased address is filed under the name its author
+                # used, which here is the alias: src/_dmul.c holds the bytes the symbol
+                # table calls func_01ff8708. Same fallback as chaos_db_ci, so the two
+                # generators keep answering with the same number.
+                for alt in alias_srcnames.get((_label, addr), ()):
+                    f = SP.path_for(alt)
+                    if f is not None:
+                        break
             if f is not None:
                 src_path = f.relative_to(REPO).as_posix()
                 if source_counts_as_matched(

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -46,10 +46,15 @@ FUNC_NAME_RE = re.compile(
 
 def source_counts_as_matched(path, src_path, module, addr, size,
                              alias_addrs, excluded_paths):
-    """Apply the same committed-data MATCHED policy as ``chaos_db_ci``."""
+    """Apply the same committed-data MATCHED policy as ``chaos_db_ci``.
+
+    The banner half is asm_policy.counts_as_matched, which both tools call rather
+    than re-spelling: this used to read "no NONMATCHING and not transcribed" here
+    and the same words over there, so the two agreed by coincidence and Tango's
+    hand-asm ruling would have had to be applied twice to keep them agreeing.
+    """
     text = path.read_text(errors="ignore")
-    countable = (not asm_policy.has_draft_banner(text)
-                 and asm_policy.classify(text) != "transcribed")
+    countable = asm_policy.counts_as_matched(text)
     zero_alias = BG.is_zero_size_alias(module, addr, size, alias_addrs)
     return countable and not zero_alias and src_path not in excluded_paths
 

--- a/tools/test_asm_policy.py
+++ b/tools/test_asm_policy.py
@@ -123,5 +123,68 @@ class Classify(unittest.TestCase):
             "/* HAND-ASM PRIMITIVE: byte-faithful asm-block match. */\n" + MNEMONIC_ASM))
 
 
+HAND_ASM = ("// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. There is no\n"
+            "// original C to recover and no match to chase.\n"
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match. Per asm policy.\n"
+            + MNEMONIC_ASM)
+
+
+class CountsAsMatched(unittest.TestCase):
+    """Tango's ruling, 2026-09-09: byte-exact hand-written assembly counts."""
+
+    def test_plain_c_counts(self):
+        self.assertTrue(asm_policy.counts_as_matched(PLAIN_C))
+
+    def test_a_draft_banner_alone_does_not_count(self):
+        self.assertFalse(asm_policy.counts_as_matched("// NONMATCHING\n" + PLAIN_C))
+
+    def test_hand_asm_banner_alone_counts(self):
+        self.assertTrue(asm_policy.counts_as_matched(
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n" + MNEMONIC_ASM))
+
+    def test_both_banners_count_because_hand_asm_wins(self):
+        # The twenty files this ruling is about. They say in their own headers that
+        # there is no C to chase, and then print the word NONMATCHING; the count read
+        # only the second half and left them out.
+        self.assertTrue(asm_policy.counts_as_matched(HAND_ASM))
+
+    def test_unbannered_dcd_dump_never_counts(self):
+        self.assertFalse(asm_policy.counts_as_matched(DCD_DUMP))
+
+    def test_a_dcd_dump_cannot_be_laundered_by_the_hand_asm_banner(self):
+        # The clause that keeps the ruling from reopening the vacuous match: a raw
+        # word dump under both banners is still a transcription, whatever it claims.
+        self.assertFalse(asm_policy.counts_as_matched(
+            "// NONMATCHING\n"
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n" + DCD_DUMP))
+
+    def test_a_deep_hand_asm_mention_does_not_rescue_a_draft(self):
+        # has_draft_banner searches the header region and is exculpatory, so a loose
+        # search is safe there. This banner puts a file INTO the count, so it has to
+        # be a header claim, not the phrase turning up in a wall analysis.
+        deep = ("// NONMATCHING: register allocation wall.\n"
+                + MNEMONIC_ASM
+                + "\n// why not a HAND-ASM PRIMITIVE: the body is ordinary ARM.\n")
+        self.assertFalse(asm_policy.counts_as_matched(deep))
+
+    def test_has_hand_banner_reads_the_header_region_only(self):
+        self.assertTrue(asm_policy.has_hand_banner(HAND_ASM))
+        self.assertFalse(asm_policy.has_hand_banner(
+            PLAIN_C + "\n// HAND-ASM PRIMITIVE mentioned in a trailing note\n"))
+
+    def test_the_ordinary_arm_draft_still_does_not_count(self):
+        # notes/asm-policy.md's second row, untouched: ordinary ARM the compiler
+        # cannot yet reproduce is an unsolved matching problem, not a primitive.
+        self.assertFalse(asm_policy.counts_as_matched(
+            "// NONMATCHING: scheduling wall, see the analysis below.\n" + PLAIN_C))
+
+    def test_classify_is_unchanged_by_the_ruling(self):
+        # The acceptance criteria and the transcription gate are untouched: only the
+        # yes/no the counting tools ask for is new.
+        self.assertEqual(asm_policy.classify(DCD_DUMP), "transcribed")
+        self.assertEqual(asm_policy.classify(MNEMONIC_ASM), "unbannered-asm")
+        self.assertIsNone(asm_policy.classify(HAND_ASM))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_bytegate.py
+++ b/tools/test_bytegate.py
@@ -384,5 +384,145 @@ class MatchedConjunct(unittest.TestCase):
         self.assertEqual([s["problem"] for s in BG.stale_rows(self.man)], ["changed"])
 
 
+HAND_ASM = (
+    "// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. There is no original\n"
+    "// C to recover and no match to chase.\n"
+    "// HAND-ASM PRIMITIVE: byte-faithful asm-block match. Per asm policy.\n"
+    "asm void f(void) {\n"
+    "    mrs r0, cpsr\n"
+    "    msr cpsr_c, r1\n"
+    "    bx lr\n"
+    "}\n")
+DRAFT = "// NONMATCHING: scheduling wall.\nint f(void) { return 0; }\n"
+
+
+class HandAsmCounting(unittest.TestCase):
+    """Tango's ruling, 2026-09-09, through the real generator.
+
+    Byte-exact hand-written assembly under the HAND-ASM PRIMITIVE banner counts as
+    matched even when the file also carries the word NONMATCHING, and the assembly
+    subset is published beside the total so the bar can say how much of itself is not
+    C. The denominator must not move: this is twenty functions changing sides, not
+    twenty functions appearing.
+
+    Driven end to end rather than through asm_policy alone, because the thing that has
+    to be right is the published record and the stats block, which is where the number
+    on the README comes from."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        (self.root / "src").mkdir()
+        (self.root / "config").mkdir()
+        self.sym = self.root / "config" / "symbols.txt"
+        self.sym.write_text(
+            "plain kind:function(arm,size=0x10) addr:0x02000000\n"
+            "primitive kind:function(arm,size=0x20) addr:0x02000010\n"
+            "draft kind:function(arm,size=0x30) addr:0x02000030\n", encoding="utf-8")
+        put(self.root / "src" / "plain.c", FIXED)
+        put(self.root / "src" / "primitive.c", HAND_ASM)
+        put(self.root / "src" / "draft.c", DRAFT)
+
+        def git(*a):
+            subprocess.run(["git", *a], cwd=self.root, check=True, capture_output=True)
+        git("init", "-q", "-b", "main")
+        git("config", "user.email", "matcher@example.com")
+        git("config", "user.name", "matcher")
+        git("add", "-A")
+        git("commit", "-q", "-m", "seed")
+
+        saved = (CDB.REPO, BG.REPO, BG.MANIFEST, RL.module_universe, SP.path_for,
+                 LYC.delinks_paths)
+        CDB.REPO, BG.REPO = self.root, self.root
+        BG.MANIFEST = self.root / "config" / "bytegate-known-failures.txt"
+        RL.module_universe = lambda: [(self.sym, "arm9")]
+        SP.path_for = lambda n: (self.root / "src" / f"{n}.c"
+                                 if (self.root / "src" / f"{n}.c").is_file() else None)
+        LYC.delinks_paths = lambda *a, **k: {}
+
+        def restore():
+            (CDB.REPO, BG.REPO, BG.MANIFEST, RL.module_universe, SP.path_for,
+             LYC.delinks_paths) = saved
+        self.addCleanup(restore)
+
+    def generate(self):
+        out = self.root / "db.json"
+        argv = sys.argv
+        sys.argv = ["chaos_db_ci.py", "--out", str(out),
+                    "--contrib-out", str(self.root / "contrib.json")]
+        try:
+            CDB.main()
+        finally:
+            sys.argv = argv
+        db = json.loads(out.read_text(encoding="utf-8"))
+        return {f["name"]: f for f in db["functions"]}, db["stats"]
+
+    def test_a_primitive_carrying_both_banners_counts(self):
+        recs, stats = self.generate()
+        self.assertTrue(recs["primitive"]["matched"])
+        self.assertTrue(recs["primitive"]["handAsm"])
+        self.assertEqual(stats["matchedFunctions"], 2)
+        self.assertEqual(stats["matchedBytes"], 0x10 + 0x20)
+
+    def test_an_ordinary_draft_beside_it_still_does_not_count(self):
+        """The half of the ruling that is a refusal. Ordinary ARM the compiler cannot
+        yet reproduce is an unsolved matching problem, and nothing about a primitive
+        next door changes that."""
+        recs, _ = self.generate()
+        self.assertFalse(recs["draft"]["matched"])
+        self.assertNotIn("handAsm", recs["draft"])
+
+    def test_the_denominator_does_not_move(self):
+        recs, stats = self.generate()
+        self.assertEqual(stats["totalFunctions"], 3)
+        self.assertEqual(stats["totalBytes"], 0x10 + 0x20 + 0x30)
+
+    def test_the_assembly_subset_is_published_beside_the_total(self):
+        _, stats = self.generate()
+        self.assertEqual(stats["handAsmFunctions"], 1)
+        self.assertEqual(stats["handAsmBytes"], 0x20)
+
+    def test_plain_c_is_not_counted_as_assembly(self):
+        """The caption has to shrink as well as grow, or it becomes a label nobody can
+        trust: only a bannered file is in the subset."""
+        recs, stats = self.generate()
+        self.assertTrue(recs["plain"]["matched"])
+        self.assertNotIn("handAsm", recs["plain"])
+        self.assertEqual(stats["handAsmFunctions"], 1)
+
+    def test_a_dcd_transcription_under_both_banners_is_still_refused(self):
+        """The vacuous match, which the ruling does not reopen. `dcd 0x...` emits the
+        word you type, so the file byte-matches by definition; a banner claiming it is
+        a primitive must not buy it a place in the count.
+
+        The refusal comes from counts_as_matched's own dcd clause, not from classify:
+        classify treats any banner as exculpatory and so returns None here, which is why
+        the record carries no `transcribed` flag. That makes the hand-asm exception
+        deliberately stricter than the plain HAND-ASM-only path, where a pool word
+        inside an asm block has always been allowed. Measured when the ruling landed:
+        none of the twenty files it admits carries a dcd word, so the clause costs
+        nothing and closes the obvious laundering route."""
+        put(self.root / "src" / "primitive.c",
+            "// NONMATCHING\n"
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n"
+            "asm void f(void) {\n    dcd 0xe92d43f0\n    dcd 0xe12fff1e\n}\n")
+        recs, stats = self.generate()
+        self.assertFalse(recs["primitive"]["matched"])
+        self.assertEqual(stats["handAsmFunctions"], 0)
+        self.assertEqual(stats["matchedFunctions"], 1)
+
+    def test_a_primitive_the_byte_gate_refuses_still_does_not_count(self):
+        """Policy D is upstream of the ruling and stays that way: a source no compiler
+        will build is not evidence, whatever its banner says."""
+        sha = BG.source_hash(self.root / "src" / "primitive.c")
+        BG.MANIFEST.write_text(f"{sha} src/primitive.c will-not-build\n",
+                               encoding="utf-8")
+        recs, stats = self.generate()
+        self.assertFalse(recs["primitive"]["matched"])
+        self.assertEqual(recs["primitive"]["byteGate"], "will-not-build")
+        self.assertEqual(stats["handAsmFunctions"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_bytegate.py
+++ b/tools/test_bytegate.py
@@ -214,6 +214,79 @@ class AliasCollisions(unittest.TestCase):
         self.assertEqual(CDB.alias_collision_addresses(), set())
 
 
+class AliasNames(unittest.TestCase):
+    """The names an aliased address carries, not just the address.
+
+    A source file is filed under the name its author knew the function by, and for
+    every aliased address in this tree that is the ALIAS -- src/_dmul.c holds the
+    1,776 bytes the symbol table calls func_01ff8708. Asked only about the sized
+    record's own name, srcpath finds nothing and four byte-exact ITCM primitives read
+    as never attempted."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self._saved = RL.module_universe
+
+    def universe(self, text, label="itcm"):
+        p = self.root / "symbols.txt"
+        p.write_text(text, encoding="utf-8")
+        RL.module_universe = lambda: [(p, label)]
+        self.addCleanup(lambda: setattr(RL, "module_universe", self._saved))
+
+    def test_the_alias_name_is_returned_for_the_shared_address(self):
+        self.universe(
+            "func_01ff8708 kind:function(arm,size=0x6f0) addr:0x01ff8708\n"
+            "_dmul kind:function(arm,size=0x0) addr:0x01ff8708\n")
+        self.assertEqual(BG.alias_names(),
+                         {("itcm", 0x01ff8708): ["_dmul"]})
+
+    def test_the_sized_name_is_never_one_of_the_aliases(self):
+        """The sized record is the thing being named, not a name for something else.
+        Returning it here would let a caller resolve a source for the wrong symbol."""
+        self.universe(
+            "func_01ff8708 kind:function(arm,size=0x6f0) addr:0x01ff8708\n"
+            "_dmul kind:function(arm,size=0x0) addr:0x01ff8708\n")
+        self.assertNotIn("func_01ff8708", BG.alias_names()[("itcm", 0x01ff8708)])
+
+    def test_several_aliases_on_one_address_are_all_returned(self):
+        self.universe(
+            "func_01ffa9dc kind:function(arm,size=0xc) addr:0x01ffa9dc\n"
+            "_ll_udiv kind:function(arm,size=0x0) addr:0x01ffa9dc\n"
+            "__aeabi_uldiv2 kind:function(arm,size=0x0) addr:0x01ffa9dc\n")
+        self.assertEqual(sorted(BG.alias_names()[("itcm", 0x01ffa9dc)]),
+                         ["__aeabi_uldiv2", "_ll_udiv"])
+
+    def test_a_lone_zero_size_symbol_contributes_no_name(self):
+        """The same asymmetry the address set has: a zero-size symbol nothing shares
+        is real outstanding work, not a second name for anything."""
+        self.universe("_solo kind:function(arm,size=0x0) addr:0x01ff9000\n")
+        self.assertEqual(BG.alias_names(), {})
+
+    def test_the_address_set_is_exactly_the_keys_of_the_name_map(self):
+        """One derivation, two views. They were separate walks of the same config for
+        one commit and that is one walk too many: a fix to either could have moved the
+        numerator and the denominator apart."""
+        self.universe(
+            "func_01ff8708 kind:function(arm,size=0x6f0) addr:0x01ff8708\n"
+            "_dmul kind:function(arm,size=0x0) addr:0x01ff8708\n"
+            "_solo kind:function(arm,size=0x0) addr:0x01ff9000\n"
+            "plain kind:function(arm,size=0x40) addr:0x01ff9100\n")
+        self.assertEqual(BG.alias_collision_addresses(), set(BG.alias_names()))
+
+
+class RealAliasNames(unittest.TestCase):
+    """Against the committed config, so the four ITCM rows this unblocked stay named."""
+
+    def test_the_committed_aliases_carry_the_names_their_sources_use(self):
+        names = BG.alias_names()
+        self.assertEqual(names.get(("itcm", 0x01ff8708)), ["_dmul"])
+        self.assertEqual(names.get(("itcm", 0x01ffabe4)), ["_s32_div_f"])
+        self.assertEqual(names.get(("itcm", 0x01ffadf0)), ["_u32_div_f"])
+        self.assertEqual(names.get(("itcm", 0x01ffaa34)), ["_ll_sdiv"])
+
+
 class ZeroSizeAliasPredicate(unittest.TestCase):
     """is_zero_size_alias, on its own.
 
@@ -522,6 +595,83 @@ class HandAsmCounting(unittest.TestCase):
         self.assertFalse(recs["primitive"]["matched"])
         self.assertEqual(recs["primitive"]["byteGate"], "will-not-build")
         self.assertEqual(stats["handAsmFunctions"], 0)
+
+
+class AliasSourceFallback(unittest.TestCase):
+    """A sized record whose source is filed under its ALIAS still finds it.
+
+    src/_dmul.c decompiles the 1,776 bytes the symbol table calls func_01ff8708, and a
+    lookup by the sized record's own name finds nothing at all. Four byte-exact ITCM
+    primitives read as never attempted for that reason alone."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        (self.root / "src").mkdir()
+        (self.root / "config").mkdir()
+        self.sym = self.root / "config" / "symbols.txt"
+        self.sym.write_text(
+            "func_01ff8708 kind:function(arm,size=0x6f0) addr:0x01ff8708\n"
+            "_dmul kind:function(arm,size=0x0) addr:0x01ff8708\n"
+            "func_01ff9000 kind:function(arm,size=0x40) addr:0x01ff9000\n",
+            encoding="utf-8")
+        put(self.root / "src" / "_dmul.c", FIXED)
+
+        def git(*a):
+            subprocess.run(["git", *a], cwd=self.root, check=True, capture_output=True)
+        git("init", "-q", "-b", "main")
+        git("config", "user.email", "matcher@example.com")
+        git("config", "user.name", "matcher")
+        git("add", "-A")
+        git("commit", "-q", "-m", "seed")
+
+        saved = (CDB.REPO, BG.REPO, BG.MANIFEST, RL.module_universe, SP.path_for,
+                 LYC.delinks_paths)
+        CDB.REPO, BG.REPO = self.root, self.root
+        BG.MANIFEST = self.root / "config" / "bytegate-known-failures.txt"
+        RL.module_universe = lambda: [(self.sym, "itcm")]
+        SP.path_for = lambda n: (self.root / "src" / f"{n}.c"
+                                 if (self.root / "src" / f"{n}.c").is_file() else None)
+        LYC.delinks_paths = lambda *a, **k: {}
+
+        def restore():
+            (CDB.REPO, BG.REPO, BG.MANIFEST, RL.module_universe, SP.path_for,
+             LYC.delinks_paths) = saved
+        self.addCleanup(restore)
+
+    def generate(self):
+        out = self.root / "db.json"
+        argv = sys.argv
+        sys.argv = ["chaos_db_ci.py", "--out", str(out),
+                    "--contrib-out", str(self.root / "contrib.json")]
+        try:
+            CDB.main()
+        finally:
+            sys.argv = argv
+        db = json.loads(out.read_text(encoding="utf-8"))
+        return {f["name"]: f for f in db["functions"]}, db["stats"]
+
+    def test_the_sized_record_picks_up_the_alias_source(self):
+        recs, stats = self.generate()
+        self.assertTrue(recs["func_01ff8708"]["matched"])
+        self.assertTrue(recs["func_01ff8708"]["srcPath"].endswith("_dmul.c"))
+        self.assertEqual(stats["matchedFunctions"], 1)
+
+    def test_the_alias_record_itself_is_still_dropped(self):
+        """The body is counted once, under the record that has a length. Counting the
+        pair would ask the project to match the same bytes twice."""
+        recs, stats = self.generate()
+        self.assertNotIn("_dmul", recs)
+        self.assertEqual(stats["totalFunctions"], 2)
+
+    def test_a_record_with_no_source_under_any_of_its_names_stays_unmatched(self):
+        """The fallback resolves names, it does not invent evidence. Nine of the
+        thirteen unmatched ITCM rows have no source in the tree under any name and are
+        left exactly where they were."""
+        recs, _ = self.generate()
+        self.assertFalse(recs["func_01ff9000"]["matched"])
+        self.assertNotIn("srcPath", recs["func_01ff9000"])
 
 
 if __name__ == "__main__":

--- a/tools/test_pr_linkcheck_verdict.py
+++ b/tools/test_pr_linkcheck_verdict.py
@@ -45,6 +45,23 @@ class SourcePolicy(unittest.TestCase):
         """The collision the inline comment claims cannot happen -- pinned here."""
         self.assertEqual(PL.source_policy("NO-REPRO", "// NONMATCHING\n" + DCD), "DRAFT")
 
+    def test_a_hand_asm_primitive_that_stops_reproducing_still_fails(self):
+        """The downgrade follows the COUNT, not the word. A file that counts as matched
+        must not be waved through on a NO-REPRO just because the note explaining why it
+        is assembly happens to contain the word NONMATCHING."""
+        primitive = ("// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm.\n"
+                     "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n"
+                     "asm void f(void) { mrs r0, cpsr\n bx lr }\n")
+        self.assertEqual(PL.source_policy("NO-REPRO", primitive), "NO-REPRO")
+
+    def test_an_ordinary_draft_is_still_downgraded(self):
+        """The other half, next to it: nothing about the primitive rule reaches a real
+        draft, which is still expected to fail to reproduce and still not a gate
+        failure."""
+        self.assertEqual(
+            PL.source_policy("NO-REPRO", "// NONMATCHING: scheduling wall.\n" + PLAIN),
+            "DRAFT")
+
     def test_empty_text_is_inert(self):
         """check_file passes "" when the path cannot be read; it must not reclassify."""
         self.assertEqual(PL.source_policy("NO-REPRO", ""), "NO-REPRO")

--- a/tools/test_progress.py
+++ b/tools/test_progress.py
@@ -33,6 +33,19 @@ class ProgressPolicy(unittest.TestCase):
         self.assertFalse(self.counted("// NONMATCHING\nint Example(void) { return 0; }"))
         self.assertFalse(self.counted("asm void Example(void) { dcd 0xe12fff1e }"))
 
+    def test_a_hand_asm_primitive_counts_even_with_a_draft_banner(self):
+        """Tango's ruling, 2026-09-09. This path and chaos_db_ci's used to spell the
+        banner rule separately, so a ruling had to be applied twice or the clean-clone
+        scan and the published database would disagree about the same file."""
+        self.assertTrue(self.counted(
+            "// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm.\n"
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n"
+            "asm void Example(void) { mrs r0, cpsr\n bx lr }"))
+
+    def test_the_ruling_does_not_reach_an_ordinary_draft(self):
+        self.assertFalse(self.counted(
+            "// NONMATCHING: scheduling wall.\nint Example(void) { return 0; }"))
+
     def test_zero_size_alias_and_manifest_exclusion_do_not_count(self):
         self.assertFalse(self.counted(
             size=0, aliases=frozenset({("arm9", 0x02000000)})))

--- a/tools/test_progress.py
+++ b/tools/test_progress.py
@@ -89,6 +89,40 @@ class ProgressPolicy(unittest.TestCase):
         self.assertEqual(total_bytes, 0x10 + 0x100)
         self.assertEqual(done_b, 0x10 + 0x100)
 
+    def test_a_source_filed_under_an_alias_name_is_found_and_counted(self):
+        """src/_dmul.c decompiles the bytes the symbol table calls func_01ff8708, and a
+        lookup by the sized record's own name finds nothing. Four byte-exact ITCM
+        primitives read as never attempted for that reason alone. Same fallback as
+        chaos_db_ci, tested the same way, so the two generators cannot disagree."""
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        repo = pathlib.Path(temp.name)
+        (repo / "src").mkdir()
+        sym = repo / "symbols.txt"
+        sym.write_text(
+            "func_01ff8708 kind:function(arm,size=0x100) addr:0x01ff8708\n"
+            "_dmul kind:function(arm,size=0x0) addr:0x01ff8708\n"
+            "func_01ff9000 kind:function(arm,size=0x40) addr:0x01ff9000\n",
+            encoding="utf-8")
+        (repo / "src" / "_dmul.c").write_text(
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n"
+            "asm void _dmul(void) { umull r0, r1, r2, r3\n bx lr }\n", encoding="utf-8")
+
+        with mock.patch.object(P, "REPO", repo), \
+                mock.patch.object(RL, "module_universe", lambda: [(sym, "itcm")]), \
+                mock.patch.object(BG, "excluded_paths", lambda *a, **k: set()), \
+                mock.patch.object(
+                    SP, "path_for",
+                    lambda n: (repo / "src" / f"{n}.c"
+                               if (repo / "src" / f"{n}.c").is_file() else None)):
+            done_n, done_b, n, total_bytes = P.synced_from_src()
+
+        self.assertEqual(n, 2, "three symbol lines, two functions")
+        self.assertEqual(done_n, 1, "the alias source counts for its sized twin")
+        self.assertEqual(done_b, 0x100)
+        self.assertEqual(total_bytes, 0x100 + 0x40,
+                         "and the record with no source under any name is untouched")
+
     def test_from_src_ignores_an_ambient_database(self):
         temp = tempfile.TemporaryDirectory()
         self.addCleanup(temp.cleanup)

--- a/tools/test_tiers.py
+++ b/tools/test_tiers.py
@@ -201,5 +201,80 @@ class BaselineIsInSync(unittest.TestCase):
         self.assertEqual(backslid, [])
 
 
+class MatchedCaptionNamesTheAssemblySubset(unittest.TestCase):
+    """MATCHED is billed as byte-exact C, and 113 of the functions under it are not C.
+
+    They are real matches -- the original was assembly, so the asm block IS the
+    recovered source -- but a bar that does not say so is a bar a reader can be
+    surprised by. The caption is generated from the same database MATCHED is read from,
+    never written into the README by hand, because it is a number.
+    """
+
+    BASE = {"converted": {"converted": 5, "functions": 10, "pct": 50.0},
+            "linked": None}
+
+    def matched(self, **kw):
+        m = {"matched": 90, "functions": 100, "pct": 90.0,
+             "matchedBytes": 900, "totalBytes": 1000, "bytePct": 90.0,
+             "handAsm": 7, "handAsmBytes": 70}
+        m.update(kw)
+        return dict(self.BASE, matched=m)
+
+    def test_the_caption_follows_the_matched_row(self):
+        rows = tiers.bar_block(self.matched()).splitlines()
+        self.assertTrue(rows[1].startswith("MATCHED"))
+        self.assertIn("of which 7 are byte-exact assembly", rows[2])
+
+    def test_the_caption_is_indented_so_it_is_not_mistaken_for_the_row(self):
+        """write_readme preserves the last generated MATCHED row by finding the line
+        that STARTS with "MATCHED". A caption flush to the margin would be picked up as
+        the row itself and the real number would be lost on the next refresh."""
+        caption = tiers.matched_caption(self.matched()["matched"])
+        self.assertTrue(caption.startswith(" "))
+        self.assertFalse(caption.strip().startswith("MATCHED"))
+
+    def test_no_caption_when_the_database_predates_the_field(self):
+        """An older chaos-db.json has no handAsmFunctions. Absent must read as "do not
+        print the line", never as zero, or the bar would claim every match is C."""
+        self.assertIsNone(tiers.matched_caption(
+            {"matched": 90, "functions": 100, "pct": 90.0, "handAsm": None}))
+        rows = tiers.bar_block(self.matched(handAsm=None)).splitlines()
+        self.assertEqual(len(rows), 4, rows)
+
+    def test_no_caption_when_the_subset_is_empty(self):
+        self.assertIsNone(tiers.matched_caption(self.matched(handAsm=0)["matched"]))
+
+    def test_the_report_names_the_subset_in_bytes_as_well(self):
+        converted = {"converted": 5, "functions": 10, "pct": 50.0, "source_files": 8,
+                     "criteria": {k: 5 for k in tiers.CRITERIA},
+                     "distribution": {str(i): 2 for i in range(len(tiers.CRITERIA) + 1)},
+                     "alt_core_two": 6, "alt_shared_header": 7}
+        out = tiers.report(dict(self.matched(), converted=converted))
+        self.assertIn("of which 7 functions (70 bytes) are byte-exact assembly", out)
+
+    def test_a_preserved_matched_row_keeps_its_caption(self):
+        """A worktree with no chaos-db.json cannot supply MATCHED, so write_readme
+        carries the last generated row forward. Carrying the row without the caption
+        would leave the block claiming more C than anything measured."""
+        current = ("\n```\n"
+                   "MATCHED    ####  99.6%   11,342 / 11,390 functions\n"
+                   "           of which 113 are byte-exact assembly (hand-written "
+                   "in the original, not C)\n"
+                   "CONVERTED  ##    23.8%   2,707 / 11,357 functions\n"
+                   "```\n")
+        lines = current.splitlines()
+        keep = []
+        for i, line in enumerate(lines):
+            if line.strip().startswith("MATCHED"):
+                keep.append(line.strip())
+                if i + 1 < len(lines) and lines[i + 1].strip().startswith("of which"):
+                    keep.append(lines[i + 1].rstrip())
+                break
+        preserved = tiers.NEWLINE.join(keep)
+        block = tiers.bar_block(dict(self.BASE, matched=None), preserved)
+        self.assertIn("11,342 / 11,390", block)
+        self.assertIn("of which 113 are byte-exact assembly", block)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -372,6 +372,52 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(report["asmPolicy"], {"transcribed": [], "unbanneredAsm": [],
                                                "strandedMarkers": []})
 
+    def test_both_banners_together_keep_a_primitive_matched(self):
+        # Tango's ruling, 2026-09-09. Twenty files in the tree carry the HAND-ASM
+        # PRIMITIVE banner AND the word NONMATCHING, because "there is no C to chase"
+        # was written as a NONMATCHING note. The published count now reads them as
+        # matched, and this validator has to agree: a per-PR report that still called
+        # them drafts would post a coverage loss for functions nothing had touched.
+        base = self._declare_symbol("Both")
+        (self.repo / "src" / "Both.c").write_text(
+            "// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. There is no\n"
+            "// original C to recover and no match to chase.\n"
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match (CPSR read).\n"
+            "asm void Both(void) {\n    mrs r0, cpsr\n    bx lr\n}\n",
+            encoding="utf-8")
+        head = commit(self.repo, "banner Both", "bob")
+        snap = VM.function_snapshot(head)
+        self.assertEqual(snap["stats"]["matchedFunctions"], 2)
+        self.assertTrue(snap["functions"]["arm9:0x02000004"]["matched"])
+        report = VM.build_report(base, head)
+        self.assertEqual(report["status"], "Passed")
+
+    def test_an_ordinary_draft_is_still_not_matched_here(self):
+        # The refusal half of the ruling, asserted next to the acceptance so a rule
+        # that started counting every NONMATCHING file would fail loudly.
+        base = self._declare_symbol("Wall")
+        (self.repo / "src" / "Wall.c").write_text(
+            "// NONMATCHING: scheduling wall, see the analysis below.\n"
+            "int Wall(void) { return 0; }\n", encoding="utf-8")
+        head = commit(self.repo, "draft Wall", "bob")
+        snap = VM.function_snapshot(head)
+        self.assertEqual(snap["stats"]["matchedFunctions"], 1)
+        self.assertFalse(snap["functions"]["arm9:0x02000004"]["matched"])
+
+    def test_a_word_dump_under_both_banners_is_not_rescued(self):
+        # counts_as_matched refuses a raw dcd body on the hand-asm path, so the ruling
+        # cannot be used to launder the vacuous match this validator exists to block.
+        base = self._declare_symbol("Dump")
+        (self.repo / "src" / "Dump.c").write_text(
+            "// NONMATCHING\n"
+            "// HAND-ASM PRIMITIVE: byte-faithful asm-block match.\n"
+            "asm void Dump(void) {\n    dcd 0xe12fff1e\n}\n", encoding="utf-8")
+        head = commit(self.repo, "dump Dump", "bob")
+        snap = VM.function_snapshot(head)
+        self.assertEqual(snap["stats"]["matchedFunctions"], 1)
+        self.assertFalse(snap["functions"]["arm9:0x02000004"]["matched"])
+        self.assertEqual(VM.build_report(base, head)["status"], "Passed")
+
     def _claim_without_enrolling(self, name):
         """A symbol with a src/ file and NO `complete` delinks entry: matched by the
         filename test, byte-verified by nothing. The population policy D subtracts."""

--- a/tools/tiers.py
+++ b/tools/tiers.py
@@ -554,6 +554,12 @@ def matched(db_path=None):
         "totalBytes": st.get("totalBytes"),
         "bytePct": (round(100.0 * st["matchedBytes"] / st["totalBytes"], 2)
                     if st.get("totalBytes") else None),
+        # The assembly subset, read from the same db for the same reason MATCHED is:
+        # recomputing it here would be a second source of truth. Absent from a db
+        # generated before the field existed, and every consumer treats that as
+        # "do not print the line" rather than as zero.
+        "handAsm": st.get("handAsmFunctions"),
+        "handAsmBytes": st.get("handAsmBytes"),
     }
 
 
@@ -564,11 +570,31 @@ def collect(db_path=None):
     return {"matched": matched(db_path), "converted": converted(), "linked": linked()}
 
 
+# Joining preserved README rows. Spelled as a constant because a newline escape
+# written inline here has been mangled by an editing shell before, and a generator
+# that will not import silently stops refreshing the bar.
+NEWLINE = chr(10)
+
+
 def bar(done, tot, width=30):
     filled = round(done / tot * width) if tot else 0
     if done and filled == 0:
         filled = 1
     return "█" * filled + "░" * (width - filled)
+
+
+def matched_caption(m):
+    """The indented line under MATCHED naming its assembly subset, or None.
+
+    Generated rather than written into the README by hand, because it is a number
+    and every number in that block goes stale the moment someone matches something.
+    Indented so ``write_readme``'s preserved-MATCHED search, which looks for a line
+    STARTING with "MATCHED", cannot mistake it for the row itself.
+    """
+    if not m or not m.get("handAsm"):
+        return None
+    return (f"           of which {m['handAsm']:,} are byte-exact assembly "
+            f"(hand-written in the original, not C)")
 
 
 def bar_block(t, preserved_matched=None):
@@ -578,6 +604,9 @@ def bar_block(t, preserved_matched=None):
     if m:
         rows.append(f"MATCHED    {bar(m['matched'], m['functions'])}  "
                     f"{m['pct']:4.1f}%   {m['matched']:,} / {m['functions']:,} functions")
+        caption = matched_caption(m)
+        if caption:
+            rows.append(caption)
     elif preserved_matched:
         # A worktree may have the ROM inputs needed for CONVERTED/LINKED but not
         # chaos-db.json, which supplies MATCHED.  Updating the live rows must not
@@ -596,11 +625,18 @@ def write_readme(t):
     start = text.index(README_START) + len(README_START)
     end = text.index(README_END)
     current = text[start:end]
-    preserved_matched = next(
-        (line.strip() for line in current.splitlines()
-         if line.strip().startswith("MATCHED")),
-        None,
-    )
+    # The MATCHED row AND its caption: a worktree with no chaos-db.json preserves
+    # whatever the last real generator wrote, and dropping the caption while keeping
+    # the row would leave the block claiming more C than it measured.
+    lines = current.splitlines()
+    keep = []
+    for i, line in enumerate(lines):
+        if line.strip().startswith("MATCHED"):
+            keep.append(line.strip())
+            if i + 1 < len(lines) and lines[i + 1].strip().startswith("of which"):
+                keep.append(lines[i + 1].rstrip())
+            break
+    preserved_matched = NEWLINE.join(keep) if keep else None
     new_text = text[:start] + "\n" + bar_block(t, preserved_matched) + "\n" + text[end:]
     if new_text != text:
         README.write_text(new_text, encoding="utf-8")
@@ -614,6 +650,10 @@ def report(t):
     if m:
         out.append(f"MATCHED    {m['matched']:,} / {m['functions']:,} functions  "
                    f"{m['pct']:.1f}%   ({m['bytePct']:.1f}% by code bytes)")
+        if m.get("handAsm"):
+            out.append(f"           of which {m['handAsm']:,} functions "
+                       f"({m['handAsmBytes']:,} bytes) are byte-exact assembly, "
+                       f"hand-written in the original game and reproduced as assembly")
     else:
         out.append("MATCHED    (no chaos-db.json; run tools/chaos_db_ci.py first)")
     out.append(f"CONVERTED  {c['converted']:,} / {c['functions']:,} functions  "

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -152,9 +152,14 @@ def function_snapshot(rev):
                   for line in grep.splitlines()}
     # Match progress.py and the rest of the repo's established hatch rule: the
     # marker is a source header, recognized anywhere in the file's leading comment
-    # block (asm_policy.has_draft_banner -- the one rule every consumer shares).
+    # block (asm_policy.counts_as_matched -- the one rule every consumer shares).
+    # It is the whole banner rule, not just the draft half, so a hand-written
+    # assembly primitive that carries both banners reads matched here exactly as it
+    # does in chaos_db_ci and progress.py. A per-PR validator that disagreed with
+    # the published count about what "matched" means would report a coverage loss
+    # for twenty functions the count had just gained.
     nonmatching = {path for path in candidates
-                   if AP.has_draft_banner(git_text(rev, path))}
+                   if not AP.counts_as_matched(git_text(rev, path))}
     # An unbannered dcd transcription byte-matches vacuously (it IS the ROM words
     # re-spelled), so it never counts as matched -- see tools/asm_policy.py. Built
     # the same revision-based way as ``nonmatching``: a cheap fixed-string grep


### PR DESCRIPTION
Byte-exact hand-written assembly counts as matched (Tango's ruling)

## What this is

Tango ruled on 2026-09-09: "count them and address it somewhere in readme". "Them" is
the set of functions the project has already accepted as legitimate assembly primitives
and then left sitting in the unmatched column. This branch counts them, keeps the
distinction visible, and says so in the README.

This is a change to how the count is computed, not to what is in the tree. No source
file is added, removed or edited. The byte gate, the merge rule and the acceptance
criteria in notes/asm-policy.md are untouched.

## The census first

Every unmatched record at origin/main c52f63ca5, all 72 of them (11,318 matched of
11,390, the figure the README bar carried), partitioned by what it actually is. The
full table with addresses, sizes, sources, banners and per-file byte-gate verdicts is
committed as audit/unmatched_census.md.

| group | what it is | count | counts after this |
|---|---|---:|---|
| a | byte-exact hand-written assembly primitives, bannered HAND-ASM PRIMITIVE, with the word NONMATCHING also present | 20 | yes |
| b | ITCM rows: 11 are the toolchain's own runtime (assembly, no original C), 2 are game code that merely lives there | 13 | 4 yes, 9 no |
| c | NONMATCHING C: real compiler floors and open drafts | 18 | no |
| d | no source in the tree under any name | 21 | no |

Group (a), all twenty, verified against the cartridge with tools/build_pin.py under the
pinned 2004/b56 compiler for this census:

| module | address | size | symbol | source | byte gate |
|---|---|---:|---|---|---|
| arm9 | 0x0200497c | 112 | func_0200497c | src/func_0200497c.c | PASS 2004/b56 |
| arm9 | 0x02052514 | 60 | func_02052514 | src/func_02052514.c | PASS 2004/b56 |
| arm9 | 0x0205256c | 28 | func_0205256c | src/func_0205256c.c | PASS 2004/b56 |
| arm9 | 0x020527e8 | 22 | func_020527e8 | src/func_020527e8.c | PASS 2004/b56 |
| arm9 | 0x02052800 | 30 | func_02052800 | src/func_02052800.c | PASS 2004/b56 |
| arm9 | 0x02052820 | 26 | func_02052820 | src/func_02052820.c | PASS 2004/b56 |
| arm9 | 0x0205283c | 26 | func_0205283c | src/func_0205283c.c | PASS 2004/b56 |
| arm9 | 0x02052ec8 | 44 | func_02052ec8 | src/func_02052ec8.c | PASS 2004/b56 |
| arm9 | 0x020553c0 | 148 | func_020553c0 | src/func_020553c0.c | PASS 2004/b56 |
| arm9 | 0x02057014 | 12 | func_02057014 | src/func_02057014.c | PASS 2004/b56 |
| arm9 | 0x02057020 | 88 | func_02057020 | src/func_02057020.c | PASS 2004/b56 |
| arm9 | 0x02057078 | 48 | func_02057078 | src/func_02057078.c | PASS 2004/b56 |
| arm9 | 0x02058568 | 100 | func_02058568 | src/func_02058568.c | PASS 2004/b56 |
| arm9 | 0x02059468 | 20 | func_02059468 | src/func_02059468.c | PASS 2004/b56 |
| arm9 | 0x02059824 | 16 | func_02059824 | src/func_02059824.c | PASS 2004/b56 |
| arm9 | 0x02059d98 | 60 | func_02059d98 | src/func_02059d98.c | PASS 2004/b56 |
| arm9 | 0x0205a588 | 148 | func_0205a588 | src/func_0205a588.c | PASS 2004/b56 |
| arm9 | 0x0205a61c | 304 | CpuCopy8 | src/CpuCopy8.c | PASS 2004/b56 |
| arm9 | 0x02071790 | 48 | func_02071790 | src/func_02071790.c | PASS 2004/b56 |
| arm9 | 0x020717c0 | 76 | __rethrow | src/__rethrow.c | PASS 2004/b56 |

Every one of these says in its own header that there is no original C to recover and no
match to chase, and then prints the word NONMATCHING as part of saying it. The counting
tools read only the word.

Group (b), the ITCM rows. Four have a byte-exact source in the tree, filed under the
name their author knew the routine by:

| address | size | symbol | source | byte gate |
|---|---:|---|---|---|
| 0x01ff8708 | 1776 | func_01ff8708 (alias _dmul) | src/_dmul.c | PASS 2004/b56 |
| 0x01ffaa34 | 432 | func_01ffaa34 (alias _ll_sdiv) | src/_ll_sdiv.c | PASS 2004/b56 |
| 0x01ffabe4 | 524 | __aeabi_idiv (alias _s32_div_f) | src/_s32_div_f.c | PASS 2004/b56 |
| 0x01ffadf0 | 484 | __aeabi_uidiv (alias _u32_div_f) | src/_u32_div_f.c | PASS 2004/b56 |

The other NINE have no source in the tree under any name and are LEFT UNMATCHED:
func_01ff8000 (_dadd), func_01ff8e10, func_01ff9378, func_01ffa440, func_01ffa594,
__aeabi_uldiv (_ll_udiv), __aeabi_ulmod (_ull_mod), and the two that are not vendor code
at all, dBgW_Kc::DetectClsn(dBgCh_Lin&) and IRQ::UserInterruptHandler. A rule that
counted a row with nothing to reproduce it from would be counting an intention. Tango
can rule again on those nine now that the difference is measured rather than assumed.

## The rule, and where it is made

asm_policy.counts_as_matched is the one function every counting tool now calls. It was
spelled three times before -- chaos_db_ci (the chaos-db.json the README bar and the
treemap read), progress.py's --from-src path, and validate_merge's per-PR coverage --
each as "no NONMATCHING banner and not a dcd transcription". They agreed by accident,
so this ruling would have had to be applied three times to keep them agreeing.

The rule, in order:

1. an unbannered dcd transcription never counts, checked first so no later clause can
   excuse it;
2. no draft banner counts;
3. a draft banner together with a HAND-ASM PRIMITIVE banner in the header region counts
   (the ruling);
4. anything else with a draft banner does not.

Clause 3 additionally refuses any file carrying a raw dcd word. classify cannot catch
that on its own, because it treats any banner as exculpatory, so without the extra
clause "NONMATCHING plus HAND-ASM plus a word dump" would walk straight through. That
makes this path deliberately stricter than the plain HAND-ASM-only path, where a pool
word inside an asm block has always been allowed; none of the twenty carries a dcd word,
so it costs nothing.

Whether an asm-primitive claim is TRUE is not decided in code here. The acceptance
criteria stay in notes/asm-policy.md (the body must carry an instruction C cannot
express: mcr/mrc, swi, msr/mrs, banked ldm/stm ^, swp) and stay enforced by review.
counts_as_matched reads the banner a reviewer accepted.

The banner also stays on every file. Nothing is stripped, so nobody reads one of these
as recovered C.

## Kept visible

chaos-db.json gains handAsmFunctions and handAsmBytes in stats and handAsm on each
record. tiers.py prints an indented caption under the MATCHED row, generated from the
same database MATCHED is read from:

```
MATCHED    ██████████████████████████████  99.6%   11,342 / 11,390 functions
           of which 113 are byte-exact assembly (hand-written in the original, not C)
```

MATCHED is billed as byte-exact C and 113 of the functions under it are not C. A bar
that cannot say so is a bar a reader can be surprised by.

## The numbers

Generated, not written by hand. `python tools/chaos_db_ci.py` then
`python tools/tiers.py --from-db`:

| | base c52f63ca5 | after the banner rule | after the alias fix |
|---|---:|---:|---:|
| matched functions | 11,318 | 11,338 | 11,342 |
| matched bytes | 2,186,936 | 2,188,352 | 2,191,568 |
| total functions | 11,390 | 11,390 | 11,390 |
| assembly subset | not reported | 109 / 11,472 bytes | 113 / 14,688 bytes |

The denominator does not move. These are functions changing sides, not appearing.

validate_merge against origin/main: Passed, reasons [], coverage delta all zero, credit
0 added / 0 changed / 0 lost, asmPolicy transcribed [] unbanneredAsm [] strandedMarkers
[]. The delta is zero on both sides because the report compares two REVISIONS with one
copy of the tool and no source changed, which is the property that matters here: nothing
is lost. Measured separately on the same revision, the validator's own numerator moves
11,286 -> 11,306 (+20 functions, +1,416 bytes) when the rule changes under it, with its
denominator unchanged at 11,345.

## Second finding, its own commit

Four ITCM primitives read as never attempted while a byte-exact source for each sat in
the tree. src/_dmul.c decompiles the 1,776 bytes at 0x01ff8708; the sized symbol record
on that address is called func_01ff8708, so srcpath, asked only about the record's own
name, found nothing at all. bytegate.alias_names returns the alias names from the same
walk that already derives the aliased addresses (alias_collision_addresses is now a view
over it, because two walks of the same config could drift and one of them decides the
denominator), and both counting generators fall back to those names.

The alias record itself is still dropped from the universe: the body is counted once,
under the record that has a length. A record with no source under any of its names is
untouched. This resolves names, it does not invent evidence.

It is commit 4 of 6 and can be dropped on its own if it is judged separately.

## Third finding, its own commit

pr_linkcheck downgrades a NO-REPRO on a self-declared draft to DRAFT rather than failing
the PR, and its own docstring gives the reason: "chaos-db counts it as unmatched, so a
NO-REPRO verdict on it is expected". That reason stopped being true for the twenty
files, so asking has_draft_banner would hand a counted match the downgrade that exists
for uncounted drafts, and a primitive that stopped reproducing the cartridge would land
green. The condition is now the one the docstring already described,
`not asm_policy.counts_as_matched`. An ordinary draft is downgraded exactly as before.

## Tests

  test_asm_policy             14 -> 24
  test_bytegate               23 -> 39
  test_progress                5 -> 8
  test_tiers                  29 -> 35
  test_validate_merge         73 -> 76
  test_pr_linkcheck_verdict    7 -> 9

Both halves everywhere: the acceptance and the refusal sit next to each other, because a
rule that started counting every NONMATCHING file would be a worse defect than the one
this fixes. The end-to-end cases drive the real chaos_db_ci over a fake repository and
assert the record, the stats block and the assembly subset at once.

The whole tool-tests.yml list, one invocation as CI runs it: Ran 683 tests, OK
(skipped=2, both the honest @skipUnless kind).

Gates run locally: check_python_names PASS (284 files, 0 unresolvable, 49 advisory),
check_dead_references PASS (no new dead references, no broken markdown links),
validate_merge PASS as above. Downstream consumers of the database smoke clean on the
new file: decomp_report 74 units 11,342/11,390, treemap SVG and HTML regenerate.

## Commits

  1. Census: what the 72 unmatched functions actually are
  2. Byte-exact hand-written assembly counts as matched
  3. Tests for the hand-asm counting rule
  4. A source filed under an alias name counts for the function it decompiles
  5. README: say what counts as matched, and that some of it is assembly
  6. The link gate's draft downgrade follows the count, not the word

## Not done

docs/progress-treemap.svg and docs/index.html are not regenerated here; the
update-chaos-data refresh job regenerates them from the new database after merge, as it
does for every count change. The 24 rectangles that change colour are the only
difference.
