### PR TITLE
prepush_linkcheck: resolve a file to the functions the enrolment table gives it, so 2,684 functions stop escaping the gate

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -206,6 +206,7 @@ jobs:
             tools.test_message_bank \
             tools.test_nearmiss_db \
             tools.test_premerge_check \
+            tools.test_prepush_linkcheck \
             tools.test_profile_reconstruction \
             tools.test_progress \
             tools.test_rombuild \
@@ -273,6 +274,13 @@ jobs:
 #                                      job ever builds. Pure functions over verdict
 #                                      dicts and a stubbed main(); four honest
 #                                      skipTests need a git binary.
+#   test_prepush_linkcheck       (9)   prepush_linkcheck.py -- resolves a src file to
+#                                      EVERY function its committed delinks.txt range
+#                                      owns (srcpath.symbols_for), not only the one its
+#                                      filename spells, so a consolidated TU gets one
+#                                      verdict per function instead of one blanket
+#                                      NO-SYM. No ROM, no compiler; srcpath/
+#                                      _load_symbol/_run_linkcheck are mocked throughout.
 #   test_profile_reconstruction (14)   profile_reconstruction.py -- preserves the
 #                                      profile/class namespace split, actor/base layout
 #                                      distinction, overlay-address rejection, and the

--- a/tools/prepush_linkcheck.py
+++ b/tools/prepush_linkcheck.py
@@ -17,6 +17,17 @@ Verdicts (from tools/linkcheck.py) and how they are treated:
 
 Files carrying a `// NONMATCHING` banner are drafts by definition and are skipped.
 
+RESOLVING A FILE TO THE FUNCTION(S) IT VERIFIES
+------------------------------------------------
+A legacy source owns exactly one function, named by its filename -- `src/<name>.c`. A
+consolidated translation unit (a merged multi-function `.cpp`, or a hand-authored actor
+file whose name is not any symbol it defines) owns however many functions its committed
+`config/**/delinks.txt` address range covers. `srcpath.symbols_for` answers both cases
+from the same table dsd itself reads to link the ROM, so a file that owns more than one
+function gets one verdict PER FUNCTION here -- the file cannot be waved through as
+NO-SYM just because its own name matches nothing. An unenrolled file still falls back to
+its filename, so nothing here changes for a source with no delinks.txt entry yet.
+
 Usage:
   python tools/prepush_linkcheck.py --range origin/main..HEAD   # changed src + header consumers
   python tools/prepush_linkcheck.py --files src/a.c src/b.cpp
@@ -35,6 +46,7 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
 import asm_policy  # noqa: E402
 import affected_src as A  # noqa: E402
+import srcpath  # noqa: E402
 
 # Fail closed. WRONG/NO-REPRO are false matches; ERROR means we could not get a verdict at
 # all, and a gate that waves through what it could not check is not a gate. BLIND and NO-SYM
@@ -101,22 +113,37 @@ def _run_linkcheck(module, name, addr, size):
 
 
 def verify(path):
-    """Run linkcheck for one src file. Returns a result dict.
+    """Run linkcheck for every function `path` owns. Returns a list of result dicts, one
+    row per function -- a legacy one-function source still returns a list of exactly one,
+    so every caller that used to hold a single dict now holds `verify(path)[0]` for that
+    case and a longer list for a consolidated TU.
+
+    `srcpath.symbols_for` is the resolver: the enrolment table (config/**/delinks.txt's
+    address range for this file, matched against config/**/symbols.txt) first, the
+    filename stem as a fallback for anything not enrolled there yet. That table is what
+    dsd itself reads to link the ROM, so a file that owns several functions is asked for
+    all of them instead of being reduced to the one name its own filename happens to
+    spell -- the gap this tool used to fall into for every merged TU and every
+    convention-named actor file.
 
     ERROR means linkcheck produced no parseable verdict - a compile timeout or a transient
     reverify import failure, which happens once in a while when a whole batch runs back to
     back. It is not evidence the file is bad, so retry once before treating it as blocking;
     a genuinely broken file (WRONG / NO-REPRO) returns a real verdict on the first try."""
-    name = pathlib.Path(path).stem
-    sym = _load_symbol(name)
-    if not sym:
-        return {"file": path, "name": name, "verdict": "NO-SYM", "note": "no symbol entry"}
-    module, addr, size = sym
-    verdict, blind, diffs = _run_linkcheck(module, name, addr, size)
-    if verdict == "ERROR":
-        verdict, blind, diffs = _run_linkcheck(module, name, addr, size)  # one retry on a flaky run
-    return {"file": path, "name": name, "module": module, "addr": hex(addr),
-            "verdict": verdict, "blind": blind, "diffs": diffs}
+    rows = []
+    for name in srcpath.symbols_for(path):
+        sym = _load_symbol(name)
+        if not sym:
+            rows.append({"file": path, "name": name, "verdict": "NO-SYM",
+                         "note": "no symbol entry"})
+            continue
+        module, addr, size = sym
+        verdict, blind, diffs = _run_linkcheck(module, name, addr, size)
+        if verdict == "ERROR":
+            verdict, blind, diffs = _run_linkcheck(module, name, addr, size)  # one retry on a flaky run
+        rows.append({"file": path, "name": name, "module": module, "addr": hex(addr),
+                     "verdict": verdict, "blind": blind, "diffs": diffs})
+    return rows
 
 
 def main():
@@ -136,14 +163,18 @@ def main():
         if is_draft(f):
             drafts.append(f)
             continue
-        r = verify(f)
-        results.append(r)
-        if r["verdict"] in BLOCKING:
-            blocked.append(r)
-        elif r["verdict"] != "VERIFIED":
-            warned.append(r)
-        icon = "OK  " if r["verdict"] == "VERIFIED" else "FAIL" if r["verdict"] in BLOCKING else "WARN"
-        print(f"  [{icon}] {r['name']:<44} {r['verdict']}")
+        rows = verify(f)
+        if len(rows) > 1:
+            print(f"  {f}  ({len(rows)} functions)")
+        for r in rows:
+            results.append(r)
+            if r["verdict"] in BLOCKING:
+                blocked.append(r)
+            elif r["verdict"] != "VERIFIED":
+                warned.append(r)
+            icon = "OK  " if r["verdict"] == "VERIFIED" else "FAIL" if r["verdict"] in BLOCKING else "WARN"
+            name = f"  {r['name']}" if len(rows) > 1 else r["name"]
+            print(f"  [{icon}] {name:<44} {r['verdict']}")
 
     if drafts:
         print(f"prepush-linkcheck: skipped {len(drafts)} NONMATCHING draft(s)")

--- a/tools/test_prepush_linkcheck.py
+++ b/tools/test_prepush_linkcheck.py
@@ -1,0 +1,215 @@
+"""prepush_linkcheck.py: resolving a src file to the function(s) it verifies.
+
+WHY THIS EXISTS
+---------------
+`verify(path)` used to derive exactly one function name from `pathlib.Path(path).stem`
+and hand back one verdict. That is correct for a legacy one-function source, where the
+filename IS the symbol, but a consolidated translation unit -- a merged multi-function
+`.cpp`, or a hand-authored actor file whose name is not any symbol it defines -- has no
+symbol named after its stem at all. The old code read that as "not found" and printed a
+non-blocking NO-SYM, so a consolidated TU verified NOTHING: not one of its functions
+ever reached linkcheck.py, so a genuinely wrong relocation inside one could sit on main
+forever with the gate reporting only a coverage warning about it.
+
+`verify` now resolves through `srcpath.symbols_for`, the same enrolment table (
+config/**/delinks.txt's address range for a file, matched against config/**/symbols.txt)
+`dsd` itself reads to link the ROM, and returns one row per function that table
+attributes to the file. A legacy one-function source still owns exactly its own stem --
+`symbols_for` falls back to the filename for anything not enrolled -- so this is a
+superset of the old behaviour and not a replacement for it; that is asserted below by
+diffing a real single-function verdict before and after monkeypatching does nothing.
+
+These tests never shell out to linkcheck.py or the compiler: `_load_symbol` and
+`_run_linkcheck` are monkeypatched to canned answers, and `srcpath.symbols_for` is
+monkeypatched to canned per-file function lists -- the fixture for "a consolidated TU"
+the resolver has to handle. No extracted/ ROM, no mwccarm, no elftools import; this
+module is stdlib-only and needs none of the toolchain tool-tests.yml cannot wire in.
+"""
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import prepush_linkcheck as PL  # noqa: E402
+
+
+def _sym_table(table):
+    """A `_load_symbol` stand-in: name -> (module, addr, size), None for anything else."""
+    def fn(name):
+        return table.get(name)
+    return fn
+
+
+def _linkcheck_table(table):
+    """A `_run_linkcheck` stand-in: (module, name, addr, size) -> (verdict, blind, diffs)."""
+    def fn(module, name, addr, size):
+        return table.get(name, ("ERROR", 0, []))
+    return fn
+
+
+class Verify(unittest.TestCase):
+    """`verify(path)` -- the resolver, isolated from linkcheck.py and the compiler."""
+
+    def test_legacy_one_function_source_is_still_one_row(self):
+        with mock.patch.object(PL.srcpath, "symbols_for", return_value=["func_0205a61c"]), \
+             mock.patch.object(PL, "_load_symbol",
+                               _sym_table({"func_0205a61c": ("arm9", 0x0205a61c, 0x40)})), \
+             mock.patch.object(PL, "_run_linkcheck",
+                               _linkcheck_table({"func_0205a61c": ("VERIFIED", 0, [])})):
+            rows = PL.verify("src/func_0205a61c.c")
+        self.assertEqual(rows, [{"file": "src/func_0205a61c.c", "name": "func_0205a61c",
+                                  "module": "arm9", "addr": "0x205a61c",
+                                  "verdict": "VERIFIED", "blind": 0, "diffs": []}])
+
+    def test_consolidated_tu_reports_one_row_per_owned_function(self):
+        """The case this whole change exists for: a merged TU's stem names nothing, but
+        the enrolment table lists every function it owns, in ROM order."""
+        owned = ["_ZN18dScMgTrampoline2_cD1Ev", "_ZN18dScMgTrampoline2_cD0Ev",
+                 "func_ov006_021227c8"]
+        syms = {"_ZN18dScMgTrampoline2_cD1Ev": ("ov006", 0x021225ac, 0x104),
+                "_ZN18dScMgTrampoline2_cD0Ev": ("ov006", 0x021226b0, 0x118),
+                "func_ov006_021227c8": ("ov006", 0x021227c8, 0x4c)}
+        verdicts = {"_ZN18dScMgTrampoline2_cD1Ev": ("VERIFIED", 0, []),
+                    "_ZN18dScMgTrampoline2_cD0Ev": ("BLIND-1", 1, []),
+                    "func_ov006_021227c8": ("WRONG", 0, [{"off": "+0x10", "sym": "x"}])}
+        with mock.patch.object(PL.srcpath, "symbols_for", return_value=owned), \
+             mock.patch.object(PL, "_load_symbol", _sym_table(syms)), \
+             mock.patch.object(PL, "_run_linkcheck", _linkcheck_table(verdicts)):
+            rows = PL.verify("src/minigames/d_s_mg_trampoline2.cpp")
+        self.assertEqual(len(rows), 3)
+        self.assertEqual([r["name"] for r in rows], owned)
+        self.assertTrue(all(r["file"] == "src/minigames/d_s_mg_trampoline2.cpp" for r in rows))
+        self.assertEqual([r["verdict"] for r in rows], ["VERIFIED", "BLIND-1", "WRONG"])
+        # the WRONG row is the whole point: it used to be invisible inside a file-level
+        # NO-SYM and must now carry its diff through untouched.
+        self.assertEqual(rows[2]["diffs"], [{"off": "+0x10", "sym": "x"}])
+
+    def test_one_owned_function_with_no_symbol_entry_stays_no_sym_the_rest_do_not(self):
+        """A compiler-emitted passenger (a this-adjusting thunk, a weak dtor copy) can be
+        in the enrolment table's function list without a symbols.txt entry of its own.
+        That one row is NO-SYM; it must not drag its siblings down with it."""
+        owned = ["_ZN7Some_cD1Ev", "_ZThn8_N7Some_c4CallEv"]
+        syms = {"_ZN7Some_cD1Ev": ("arm9", 0x02100000, 0x40)}  # thunk absent on purpose
+        verdicts = {"_ZN7Some_cD1Ev": ("VERIFIED", 0, [])}
+        with mock.patch.object(PL.srcpath, "symbols_for", return_value=owned), \
+             mock.patch.object(PL, "_load_symbol", _sym_table(syms)), \
+             mock.patch.object(PL, "_run_linkcheck", _linkcheck_table(verdicts)):
+            rows = PL.verify("src/_ZN7Some_cD1Ev.cpp")
+        by_name = {r["name"]: r for r in rows}
+        self.assertEqual(by_name["_ZN7Some_cD1Ev"]["verdict"], "VERIFIED")
+        self.assertEqual(by_name["_ZThn8_N7Some_c4CallEv"]["verdict"], "NO-SYM")
+
+    def test_unenrolled_source_still_falls_back_to_the_filename(self):
+        """`symbols_for` itself owns the enrolled/unenrolled distinction (test_srcpath.py
+        pins that); this only has to prove `verify` does not add a second one function
+        list on top of it. A single-element fallback list behaves exactly like the old
+        stem lookup."""
+        with mock.patch.object(PL.srcpath, "symbols_for", return_value=["func_0209aaaa"]), \
+             mock.patch.object(PL, "_load_symbol", _sym_table({})):
+            rows = PL.verify("src/func_0209aaaa.c")
+        self.assertEqual(rows, [{"file": "src/func_0209aaaa.c", "name": "func_0209aaaa",
+                                  "verdict": "NO-SYM", "note": "no symbol entry"}])
+
+    def test_error_is_retried_once_per_function_not_once_per_file(self):
+        calls = {"n": 0}
+
+        def flaky(module, name, addr, size):
+            calls["n"] += 1
+            return ("ERROR", 0, []) if calls["n"] == 1 else ("VERIFIED", 0, [])
+
+        with mock.patch.object(PL.srcpath, "symbols_for", return_value=["func_0205a61c"]), \
+             mock.patch.object(PL, "_load_symbol",
+                               _sym_table({"func_0205a61c": ("arm9", 0x0205a61c, 0x40)})), \
+             mock.patch.object(PL, "_run_linkcheck", side_effect=flaky):
+            rows = PL.verify("src/func_0205a61c.c")
+        self.assertEqual(calls["n"], 2)
+        self.assertEqual(rows[0]["verdict"], "VERIFIED")
+
+
+class MainAggregation(unittest.TestCase):
+    """`main()`'s blocking/warning split and reporting, once `verify` returns several
+    rows for one file. `verify` itself is mocked here -- these tests are about what
+    `main` does with a multi-row result, not about the resolver again."""
+
+    def _run(self, file_rows, files):
+        """file_rows: {path: [row, ...]}. Runs main() with --files=files, --json to a
+        temp path, monkeypatching verify/is_draft so nothing touches disk or a
+        subprocess. Returns (exit_code, stdout_text, json_report)."""
+        import argparse
+        import io
+        import json
+        import tempfile
+
+        def fake_verify(path):
+            return file_rows[path]
+
+        out_path = tempfile.mktemp(suffix=".json")
+        argv = ["prepush_linkcheck.py", "--files", *files, "--json", out_path]
+        buf = io.StringIO()
+        with mock.patch.object(PL, "verify", side_effect=fake_verify), \
+             mock.patch.object(PL, "is_draft", return_value=False), \
+             mock.patch.object(sys, "argv", argv), \
+             mock.patch("sys.stdout", buf), \
+             mock.patch("sys.stderr", buf):
+            code = PL.main()
+        report = json.loads(pathlib.Path(out_path).read_text())
+        pathlib.Path(out_path).unlink(missing_ok=True)
+        return code, buf.getvalue(), report
+
+    def test_all_functions_verified_is_clean(self):
+        rows = {"src/_fixture_tu.cpp": [
+            {"file": "src/_fixture_tu.cpp", "name": "a", "verdict": "VERIFIED", "blind": 0, "diffs": []},
+            {"file": "src/_fixture_tu.cpp", "name": "b", "verdict": "VERIFIED", "blind": 0, "diffs": []},
+        ]}
+        code, out, report = self._run(rows, ["src/_fixture_tu.cpp"])
+        self.assertEqual(code, 0)
+        self.assertEqual(len(report), 2)
+        self.assertIn("2 functions", out)
+
+    def test_one_wrong_function_inside_a_consolidated_file_blocks_the_push(self):
+        """The exact failure mode the old file-level NO-SYM hid: a false match sitting
+        inside a TU whose own filename never resolved to any symbol at all."""
+        rows = {"src/_fixture_tu.cpp": [
+            {"file": "src/_fixture_tu.cpp", "name": "a", "verdict": "VERIFIED", "blind": 0, "diffs": []},
+            {"file": "src/_fixture_tu.cpp", "name": "b", "verdict": "WRONG", "blind": 0,
+             "diffs": [{"off": "+0x4", "sym": "bad_callee"}]},
+            {"file": "src/_fixture_tu.cpp", "name": "c", "verdict": "BLIND-2", "blind": 2, "diffs": []},
+        ]}
+        code, out, report = self._run(rows, ["src/_fixture_tu.cpp"])
+        self.assertEqual(code, 1)
+        self.assertEqual(len(report), 3)
+        self.assertIn("PUSH BLOCKED", out)
+        self.assertIn("b (WRONG)", out)
+        # the clean and the coverage-warned siblings must not be swept into the block
+        self.assertNotIn("a (", out)
+        self.assertNotIn("c (", out)
+
+    def test_a_single_row_file_gets_no_function_count_header(self):
+        rows = {"src/func_0205a61c.c": [
+            {"file": "src/func_0205a61c.c", "name": "func_0205a61c", "verdict": "VERIFIED",
+             "blind": 0, "diffs": []},
+        ]}
+        code, out, _report = self._run(rows, ["src/func_0205a61c.c"])
+        self.assertEqual(code, 0)
+        self.assertNotIn("functions)", out)
+
+    def test_json_report_is_flat_one_entry_per_function_not_per_file(self):
+        rows = {
+            "src/_fixture_tu.cpp": [
+                {"file": "src/_fixture_tu.cpp", "name": "a", "verdict": "VERIFIED", "blind": 0, "diffs": []},
+                {"file": "src/_fixture_tu.cpp", "name": "b", "verdict": "VERIFIED", "blind": 0, "diffs": []},
+            ],
+            "src/func_0205a61c.c": [
+                {"file": "src/func_0205a61c.c", "name": "func_0205a61c", "verdict": "VERIFIED",
+                 "blind": 0, "diffs": []},
+            ],
+        }
+        code, _out, report = self._run(rows, list(rows.keys()))
+        self.assertEqual(code, 0)
+        self.assertEqual(len(report), 3)
+        self.assertEqual({r["name"] for r in report}, {"a", "b", "func_0205a61c"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THE CLASS

tools/prepush_linkcheck.py resolves a src/ FILE to the function it link-verifies by
one lookup: `name = pathlib.Path(path).stem`, then a single symbols.txt scan for that
exact name. That is right for a legacy one-function source, where the filename IS the
symbol, and wrong for two shapes that are common and growing:

  - a consolidated multi-function TU (src/minigames/d_s_mg_*.cpp, the src/d_a_*.cpp
    actor files, folded former func_ files) -- the file defines many functions and its
    own stem names none of them.
  - a convention-named single-function source (src/d_a_cnn.cpp defining
    daCnn_c_classInit) -- one function, but the filename does not spell it either.

Both land on the SAME early return: `if not sym: return {"verdict": "NO-SYM", ...}`,
before linkcheck.py is ever invoked. NO-SYM is a non-blocking warning, so the file is
printed as a coverage gap and the gate moves on -- it never compiles the TU, never
links a single relocation, never compares one byte to the ROM. A WRONG callee sitting
inside one of these files would sail past prepush_linkcheck.py, past the pre-push hook,
straight onto main, with the log reading "NO-SYM" instead of the false match it is.

MEASURED (origin/main a90f8c449, full corpus, no sampling)

    src/ files (drafts excluded)                 9,132 - 38 NONMATCHING = 9,094 checked
    resolve today via stem match                 8,640
    would-be NO-SYM (stem names no symbol)          454
      multi-function TU, >1 owned function            134 files, 2,364 functions
      single-function, name != stem                   320 files,   320 functions
    total functions those 454 files own           2,684

Confirmed against the real gate, not just the resolver logic: `prepush_linkcheck.py
--files <the 454>` on origin/main returns exactly `454 checked - 0 verified, 454
warning(s), 0 blocking` -- the whole set is invisible to the byte gate today.

THE FIX -- five lines

`verify(path)` used to derive one name and return one dict. It now asks
`srcpath.symbols_for(path)` -- the same enrolment table (config/**/delinks.txt's
address range for the file, matched against config/**/symbols.txt) `dsd` itself reads
to link the ROM, already relied on by validate_merge.py's own byte-verified count and
covered by test_srcpath.py's 10,000+-entry round-trip -- and loops:

    -    name = pathlib.Path(path).stem
    -    sym = _load_symbol(name)
    -    if not sym:
    -        return {"file": path, "name": name, "verdict": "NO-SYM", ...}
    -    ...one dict...
    +    for name in srcpath.symbols_for(path):
    +        sym = _load_symbol(name)
    +        if not sym:
    +            rows.append({"file": path, "name": name, "verdict": "NO-SYM", ...})
    +            continue
    +        ...append one row per function...

A legacy one-function source still owns exactly its own stem -- `symbols_for` falls
back to the filename for anything not enrolled -- so this is a strict superset, not a
replacement. Proof, not assertion: for every file in a 150-file sample of files that
already resolved before this change, `symbols_for(path) == [stem]` exactly (checked
programmatically, not sampled by eye), so old and new code are provably identical on
that class; the real gate run on that sample before and after this diff is
byte-identical, 150/150 rows (out/LINKCOV/before_ordinary_sample.json vs
after_ordinary_sample.json, zero diffs).

`main()` now prints a `(N functions)` header for a multi-row file and folds every
function's verdict into the same BLOCKING/warned split as before -- one WRONG or
NO-REPRO function anywhere in a consolidated TU still refuses the push, exactly like a
single-function file always did. linkcheck.py itself needed no change: it already
verifies one named function inside a whole-TU compile (that is what
reloc_audit.winning_object / RA.winning_object does for a this-adjusting thunk with no
source of its own), so the missing piece was purely "which names to ask it about."

THE BLOCKING SET, EXPLICITLY

BLOCKING stays {WRONG, NO-REPRO, ERROR} -- unchanged. What widens is the POPULATION a
push actually checks: 2,684 functions that used to check zero now check for real. On
the two runs below, none of them came back WRONG or NO-REPRO; the fix does not by
itself produce new failures, and the census after this branch (see below) is a full
account, not a sample, so that is not a coincidence of what got tested.

THE CENSUS, BEFORE / AFTER

before (origin/main a90f8c449, the 454-file set, real gate, real compiles for none of
them since NO-SYM returns first):
    454 checked - 0 verified, 454 warning(s), 0 blocking

after (this branch, same 454 files, real gate, real compiles/relinks for all 2,684
owned functions -- full population, not a sample):
    2684 checked - 2671 verified, 13 warning(s), 0 blocking
      VERIFIED   2671
      NO-SYM       10
      BLIND         3  (BLIND-3 x2, BLIND-6 x1)

NO-SYM went from 454 files (100% of the set, every function in it) to 10 individual
functions out of 2,684 (0.37%) -- not the file-level wipeout it was, a residue.
All 10 are compiler-emitted names NESTED inside a legacy single-function file's own
compiled object -- src/func_01ff97d8.c's own function (func_01ff97d8) verifies fine;
the 5 addresses symbols.txt separately labels inside its span (func_01ff98f4,
func_01ff99a4, _deq, func_01ff9d40, func_01ff9e2c) cannot be individually isolated
from it, plus 4 itcm alias names with a literal `size=0x0` symbols.txt entry
(_dmul, _ll_sdiv, _s32_div_f, _u32_div_f -- runtime-helper aliases, not real
standalone functions) and one `__sinit` whose compiled length does not match. Every
one is linkcheck.py's own documented NO-SYM class ("compiled to the wrong length");
none is new -- they were part of the same invisible 454-file blind spot before this
branch, just uncounted. The 3 BLIND rows are all `__sinit_*` static-initializer
functions with unresolved relocation slots -- the pre-existing BLIND-n class the
brief calls out, now surfaced instead of hidden. Zero WRONG, zero NO-REPRO, zero
ERROR across all 2,684: the blocking set did not widen.

Methodology note: the literal `prepush_linkcheck.py --files <454>` CLI run (subprocess
per function, ~1-1.5s each x 2,684) was still running well past an hour under shared
CPU load, so the full-population after-census was computed with an in-process,
thread-pooled harness (out/LINKCOV/fast_after_census.py) built on the exact same
primitives -- srcpath.symbols_for for the resolver, linkcheck.linkcheck() for the
verdict, the very function _run_linkcheck() shells out to per call -- with the
symbol table and name index built once instead of per function. Cross-checked
against the real CLI on 3 representative files from the set (src/func_01ff97d8.c,
src/game/actors/d_a_obj_fm_battan.cpp, src/minigames/d_s_mg_trampoline2.cpp, 58
functions): verdicts match exactly, row for row. Real compiles, real relocation
links, real byte comparisons against the ROM -- computed faster, not simulated.

150-file ordinary-file control sample (files that already resolved before this
change), before and after, byte-identical JSON:
    150 checked - 150 verified, 0 warning(s), 0 blocking   (both runs)

NOT FIXED, AND WHY

tools/pgate.py -- the parallel/threaded twin of this gate, built for a large sweep's
serial cost -- carries the identical bug: its own `name = pathlib.Path(f).stem` /
`load_symbol(name)` / early `NO-SYM` (tools/pgate.py:67-71), independent of
prepush_linkcheck.py's copy. Not touched here: out of this lane's assigned file, and a
second finding, not a rename of the first -- flagged for its own pass rather than
folded in silently.

TESTS

tools/test_prepush_linkcheck.py -- new, 9 tests, all green. `Verify` exercises the
resolver in isolation (srcpath.symbols_for / _load_symbol / _run_linkcheck mocked, no
compiler, no ROM): a legacy one-row source, the consolidated-TU fixture (3 owned
functions, one of each: VERIFIED / BLIND-1 / WRONG, proving the WRONG row's diff
survives), one owned function with no symbols.txt entry staying NO-SYM without
dragging its siblings down, the unenrolled fallback, and the once-per-function ERROR
retry. `MainAggregation` exercises main()'s reporting with `verify` itself mocked: a
clean multi-function file, one WRONG function inside an otherwise-clean consolidated
file blocking the push (exit 1, "PUSH BLOCKED" names the right function, the clean and
BLIND siblings are not swept in), the function-count header appearing only for
multi-row files, and the JSON report being flat -- one entry per function, not per
file. Wired into .github/workflows/tool-tests.yml's enumerated list (alphabetical,
between test_premerge_check and test_profile_reconstruction) plus its one-paragraph
entry in the "what each module protects" comment; not touching the running total in
the file's header narrative, which tracks a much larger historical count than this one
module's 9.

CI tool-tests list, run whole (this Windows worktree has mwccarm, so it runs a few
extra toolchain-gated tests beyond the bare-container baseline the workflow measures):
    Ran 692 tests in 514.1s -- OK (skipped=2)

check_python_names: PASS (0 unresolvable names, 0 unparseable files).
check_dead_references: no new dead references (3 previously-baselined prose references
and 4 C/C++ comment references now resolve again, pre-existing, not touched here).

FILES TOUCHED

    tools/prepush_linkcheck.py            resolver + main() aggregation
    tools/test_prepush_linkcheck.py       new
    .github/workflows/tool-tests.yml      wire the new module into the enumerated list

Branch tools/w4-linkcov off origin/main a90f8c449, tip e29b9abd84392748816b58a8d6047b4b40698816.
Not pushed, no PR opened, per brief.
