### PR TITLE
pgate: resolve a file through the enrolment table like prepush_linkcheck does, and the ITCM gap both gates share

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -205,6 +205,7 @@ jobs:
             tools.test_match_provenance \
             tools.test_message_bank \
             tools.test_nearmiss_db \
+            tools.test_pgate \
             tools.test_premerge_check \
             tools.test_prepush_linkcheck \
             tools.test_profile_reconstruction \
@@ -269,6 +270,14 @@ jobs:
 #                                      close attempts are never thrown away, plus the
 #                                      eval-pin guard: stored divergences are only
 #                                      comparable while their evaluator still exists.
+#   test_pgate                    (6)   pgate.py -- prepush_linkcheck.py's threaded
+#                                      twin resolves a file to every function its
+#                                      committed delinks.txt range owns the same way,
+#                                      via the same imported srcpath.symbols_for, so a
+#                                      consolidated TU gets one job per function in a
+#                                      parallel sweep instead of one blanket NO-SYM. No
+#                                      ROM, no compiler; srcpath/load_symbol_fn/
+#                                      run_linkcheck are mocked throughout.
 #   test_premerge_check         (87)   premerge_check.py -- runs the static gates on
 #                                      the git merge-tree RESULT, the one tree no CI
 #                                      job ever builds. Pure functions over verdict

--- a/tools/pgate.py
+++ b/tools/pgate.py
@@ -14,6 +14,16 @@ It is a speed tool, not a different check: symbol resolution and the verdict com
 the same stamp_provenance/linkcheck path prepush_linkcheck uses. Use prepush_linkcheck.py
 for a normal PR; use this when a sweep makes the serial cost the bottleneck.
 
+RESOLVING A FILE TO THE FUNCTION(S) IT VERIFIES
+------------------------------------------------
+Each file goes through `srcpath.symbols_for`, the same enrolment table (config/**/
+delinks.txt's address range for the file, matched against config/**/symbols.txt)
+prepush_linkcheck.py's own `verify` uses -- not a copy of that lookup, the same
+function, imported. A legacy one-function source still owns exactly its own filename
+stem, since `symbols_for` falls back to that for anything not enrolled; a consolidated
+multi-function TU or a convention-named file gets one job PER owned function instead of
+being reduced to NO-SYM by a stem that names none of them.
+
 Verdicts are the linkcheck ones (VERIFIED / BLIND-n / WRONG / NO-REPRO / NO-SYM / ...);
 see tools/linkcheck.py. WRONG and NO-REPRO are false matches and must block a push.
 
@@ -30,6 +40,8 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath  # noqa: E402
 
 
 def load_symbol_fn():
@@ -65,12 +77,12 @@ def main():
 
     jobs, rows = [], []
     for f in args.files:
-        name = pathlib.Path(f).stem
-        sym = load_symbol(name)
-        if not sym:
-            rows.append({"file": f, "name": name, "verdict": "NO-SYM"})
-        else:
-            jobs.append((f, name, sym))
+        for name in srcpath.symbols_for(f):
+            sym = load_symbol(name)
+            if not sym:
+                rows.append({"file": f, "name": name, "verdict": "NO-SYM"})
+            else:
+                jobs.append((f, name, sym))
 
     def work(job):
         f, name, (module, addr, size) = job

--- a/tools/test_pgate.py
+++ b/tools/test_pgate.py
@@ -1,0 +1,194 @@
+"""pgate.py: resolving a src file to the function(s) a parallel sweep verifies.
+
+WHY THIS EXISTS
+---------------
+pgate.py is prepush_linkcheck.py's threaded twin -- same verdicts, run across a thread
+pool instead of one file at a time for a 100-200 file readability sweep. It carried the
+identical stem bug independently: `name = pathlib.Path(f).stem` then one `load_symbol`
+lookup, so a consolidated multi-function TU or a convention-named file (its own stem
+naming none of its functions) resolved to a single NO-SYM row and none of its functions
+ever reached linkcheck.py -- the same blind spot LINKCOV closed in prepush_linkcheck.py,
+independently present here because the two tools never shared the resolution step.
+
+pgate.py now resolves through `srcpath.symbols_for`, imported rather than reimplemented
+-- the same enrolment table (config/**/delinks.txt's address range for a file, matched
+against config/**/symbols.txt) prepush_linkcheck.py's own `verify` uses. A legacy
+one-function source still owns exactly its own stem, since `symbols_for` falls back to
+the filename for anything not enrolled, so this is a superset of the old behaviour and
+not a replacement for it -- proven below by a single-function fixture behaving exactly
+as the old stem lookup did. The BLOCKING split (WRONG / NO-REPRO) is unchanged; only the
+population `main()` walks per file widens from one job to one job per owned function.
+
+These tests never shell out to linkcheck.py or the compiler: `load_symbol_fn` and
+`run_linkcheck` are monkeypatched to canned answers, and `srcpath.symbols_for` is
+monkeypatched to canned per-file function lists -- the consolidated-TU fixture is the
+same one test_prepush_linkcheck.py uses, so the two gates are proven to resolve the
+identical population from the identical table. No extracted/ ROM, no mwccarm, no
+elftools import; this module is stdlib-only and needs none of the toolchain
+tool-tests.yml cannot wire in.
+"""
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import pgate as PG  # noqa: E402
+
+
+def _sym_table(table):
+    """A `load_symbol_fn()` stand-in: name -> (module, addr, size), None for anything else."""
+    def fn(name):
+        return table.get(name)
+    return fn
+
+
+def _linkcheck_table(table):
+    """A `run_linkcheck` stand-in: (module, name, addr, size) -> (verdict, blind)."""
+    def fn(module, name, addr, size):
+        return table.get(name, ("ERROR", 0))
+    return fn
+
+
+class Main(unittest.TestCase):
+    """`main()` end to end, with `srcpath.symbols_for` / `load_symbol_fn` / `run_linkcheck`
+    mocked so nothing touches disk, the compiler, or a real subprocess. Every case here
+    has a direct counterpart in test_prepush_linkcheck.py's `Verify` class -- same
+    fixtures, same resolver, the two gates proven to agree."""
+
+    def _run(self, files, symbols_for, syms, verdicts, jobs=4):
+        out_path = tempfile.mktemp(suffix=".json")
+        argv = ["pgate.py", "--out", out_path, "--jobs", str(jobs), *files]
+        with mock.patch.object(PG.srcpath, "symbols_for", side_effect=symbols_for), \
+             mock.patch.object(PG, "load_symbol_fn", return_value=_sym_table(syms)), \
+             mock.patch.object(PG, "run_linkcheck", side_effect=_linkcheck_table(verdicts)), \
+             mock.patch.object(sys, "argv", argv):
+            code = PG.main()
+        rows = json.loads(pathlib.Path(out_path).read_text())
+        pathlib.Path(out_path).unlink(missing_ok=True)
+        return code, rows
+
+    def test_legacy_one_function_source_resolves_to_its_own_stem(self):
+        code, rows = self._run(
+            ["src/func_0205a61c.c"],
+            symbols_for=lambda f: ["func_0205a61c"],
+            syms={"func_0205a61c": ("arm9", 0x0205a61c, 0x40)},
+            verdicts={"func_0205a61c": ("VERIFIED", 0)},
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(rows, [{"file": "src/func_0205a61c.c", "name": "func_0205a61c",
+                                  "module": "arm9", "addr": "0x205a61c",
+                                  "verdict": "VERIFIED", "blind": 0}])
+
+    def test_consolidated_tu_gets_one_job_per_owned_function(self):
+        """The case this whole change exists for: a merged TU's stem names nothing, but
+        the enrolment table lists every function it owns. Same fixture as
+        test_prepush_linkcheck.py's consolidated-TU test, proving pgate resolves the
+        identical population."""
+        owned = ["_ZN18dScMgTrampoline2_cD1Ev", "_ZN18dScMgTrampoline2_cD0Ev",
+                 "func_ov006_021227c8"]
+        syms = {"_ZN18dScMgTrampoline2_cD1Ev": ("ov006", 0x021225ac, 0x104),
+                "_ZN18dScMgTrampoline2_cD0Ev": ("ov006", 0x021226b0, 0x118),
+                "func_ov006_021227c8": ("ov006", 0x021227c8, 0x4c)}
+        verdicts = {"_ZN18dScMgTrampoline2_cD1Ev": ("VERIFIED", 0),
+                    "_ZN18dScMgTrampoline2_cD0Ev": ("BLIND-1", 1),
+                    "func_ov006_021227c8": ("WRONG", 0)}
+        code, rows = self._run(
+            ["src/minigames/d_s_mg_trampoline2.cpp"],
+            symbols_for=lambda f: owned,
+            syms=syms, verdicts=verdicts,
+        )
+        self.assertEqual(len(rows), 3)
+        self.assertEqual({r["name"] for r in rows}, set(owned))
+        self.assertTrue(all(r["file"] == "src/minigames/d_s_mg_trampoline2.cpp" for r in rows))
+        by_name = {r["name"]: r for r in rows}
+        self.assertEqual(by_name["_ZN18dScMgTrampoline2_cD1Ev"]["verdict"], "VERIFIED")
+        self.assertEqual(by_name["_ZN18dScMgTrampoline2_cD0Ev"]["verdict"], "BLIND-1")
+        self.assertEqual(by_name["func_ov006_021227c8"]["verdict"], "WRONG")
+        # the WRONG row is the whole point: it used to be invisible inside a file-level
+        # NO-SYM and must now block the exit code.
+        self.assertEqual(code, 1)
+
+    def test_one_owned_function_with_no_symbol_entry_stays_no_sym_the_rest_do_not(self):
+        """A compiler-emitted passenger can be in the enrolment table's function list
+        without a symbols.txt entry of its own. That one row is NO-SYM; it must not drag
+        its siblings down with it, and must not disappear the way a file-level NO-SYM
+        used to swallow the whole file."""
+        owned = ["_ZN7Some_cD1Ev", "_ZThn8_N7Some_c4CallEv"]
+        syms = {"_ZN7Some_cD1Ev": ("arm9", 0x02100000, 0x40)}  # thunk absent on purpose
+        verdicts = {"_ZN7Some_cD1Ev": ("VERIFIED", 0)}
+        code, rows = self._run(
+            ["src/_ZN7Some_cD1Ev.cpp"],
+            symbols_for=lambda f: owned,
+            syms=syms, verdicts=verdicts,
+        )
+        by_name = {r["name"]: r for r in rows}
+        self.assertEqual(by_name["_ZN7Some_cD1Ev"]["verdict"], "VERIFIED")
+        self.assertEqual(by_name["_ZThn8_N7Some_c4CallEv"]["verdict"], "NO-SYM")
+        self.assertEqual(code, 0)
+
+    def test_unenrolled_source_still_falls_back_to_the_filename(self):
+        """`symbols_for` itself owns the enrolled/unenrolled distinction; this only has
+        to prove `main` does not add a second one-function list on top of it. A
+        single-element fallback list behaves exactly like the old stem lookup."""
+        code, rows = self._run(
+            ["src/func_0209aaaa.c"],
+            symbols_for=lambda f: ["func_0209aaaa"],
+            syms={},
+            verdicts={},
+        )
+        self.assertEqual(rows, [{"file": "src/func_0209aaaa.c", "name": "func_0209aaaa",
+                                  "verdict": "NO-SYM"}])
+        self.assertEqual(code, 0)
+
+    def test_error_is_retried_once_per_function(self):
+        calls = {"n": 0}
+
+        def flaky(module, name, addr, size):
+            calls["n"] += 1
+            return ("ERROR", 0) if calls["n"] == 1 else ("VERIFIED", 0)
+
+        out_path = tempfile.mktemp(suffix=".json")
+        argv = ["pgate.py", "--out", out_path, "--jobs", "1", "src/func_0205a61c.c"]
+        with mock.patch.object(PG.srcpath, "symbols_for", return_value=["func_0205a61c"]), \
+             mock.patch.object(PG, "load_symbol_fn",
+                                return_value=_sym_table({"func_0205a61c": ("arm9", 0x0205a61c, 0x40)})), \
+             mock.patch.object(PG, "run_linkcheck", side_effect=flaky), \
+             mock.patch.object(sys, "argv", argv):
+            code = PG.main()
+        rows = json.loads(pathlib.Path(out_path).read_text())
+        pathlib.Path(out_path).unlink(missing_ok=True)
+        self.assertEqual(calls["n"], 2)
+        self.assertEqual(rows[0]["verdict"], "VERIFIED")
+        self.assertEqual(code, 0)
+
+    def test_multiple_files_each_resolve_through_the_shared_table(self):
+        """Two files, one legacy and one consolidated, in the same sweep -- proves the
+        per-file loop in main() asks `symbols_for` for each file independently rather
+        than resolving the whole batch off one name."""
+        owned_map = {
+            "src/func_0205a61c.c": ["func_0205a61c"],
+            "src/minigames/d_s_mg_trampoline2.cpp": ["_ZN18dScMgTrampoline2_cD1Ev",
+                                                       "func_ov006_021227c8"],
+        }
+        syms = {"func_0205a61c": ("arm9", 0x0205a61c, 0x40),
+                "_ZN18dScMgTrampoline2_cD1Ev": ("ov006", 0x021225ac, 0x104),
+                "func_ov006_021227c8": ("ov006", 0x021227c8, 0x4c)}
+        verdicts = {"func_0205a61c": ("VERIFIED", 0),
+                    "_ZN18dScMgTrampoline2_cD1Ev": ("VERIFIED", 0),
+                    "func_ov006_021227c8": ("VERIFIED", 0)}
+        code, rows = self._run(
+            list(owned_map.keys()),
+            symbols_for=lambda f: owned_map[f],
+            syms=syms, verdicts=verdicts,
+        )
+        self.assertEqual(len(rows), 3)
+        self.assertEqual({r["name"] for r in rows},
+                          {"func_0205a61c", "_ZN18dScMgTrampoline2_cD1Ev", "func_ov006_021227c8"})
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THE CLASS

tools/pgate.py is prepush_linkcheck.py's threaded twin -- same verdicts, run across a
thread pool for a 100-200 file readability sweep instead of one file at a time. It
carried the identical bug independently: `name = pathlib.Path(f).stem`, one
`load_symbol(name)` lookup, one row. Right for a legacy one-function source, wrong for
a consolidated multi-function TU or a convention-named single-function file, both of
which land on `if not sym: rows.append({..., "verdict": "NO-SYM"})` before a single
function inside the file ever reaches linkcheck.py. This is PR #2525's bug
(tools/prepush_linkcheck.py), present a second time in the tool #2525 explicitly left
untouched: its own PR text calls this out by name and line ("tools/pgate.py -- the
parallel/threaded twin of this gate ... carries the identical bug ... :67-71 ... flagged
for its own pass rather than folded in silently").

THE FIX -- shared, not copied

pgate.py now imports `srcpath` and asks `srcpath.symbols_for(f)` per file instead of
taking the filename stem:

    -   name = pathlib.Path(f).stem
    -   sym = load_symbol(name)
    -   if not sym:
    -       rows.append({"file": f, "name": name, "verdict": "NO-SYM"})
    -   else:
    -       jobs.append((f, name, sym))
    +   for name in srcpath.symbols_for(f):
    +       sym = load_symbol(name)
    +       if not sym:
    +           rows.append({"file": f, "name": name, "verdict": "NO-SYM"})
    +       else:
    +           jobs.append((f, name, sym))

`srcpath.symbols_for` is not reimplemented here -- it is the same function
prepush_linkcheck.py's `verify()` calls, the same enrolment table (config/**/
delinks.txt's address range for a file, matched against config/**/symbols.txt) `dsd`
itself reads to link the ROM. A legacy one-function source still resolves to exactly its
own stem, since `symbols_for` falls back to the filename for anything not enrolled, so
this is a strict superset of the old behaviour, not a replacement for it. The thread
pool itself is unchanged: `jobs` now holds one (file, name, sym) tuple per owned
function instead of per file, so a consolidated TU's functions are dispatched
individually across the pool exactly like any other job. The BLOCKING split (`WRONG`,
`NO-REPRO` -> exit 1, "FALSE MATCHES") is untouched.

THE CENSUS, BEFORE / AFTER -- measured with pgate.py itself, not a stand-in

Same population #2525 measured: the 454 files whose stem names none of their functions
(out/LINKCOV/nosym_files.txt in the run directory), owning 2,684 functions.

before (this branch's parent commit, e29b9abd8 -- pgate.py still has the stem bug;
`python tools/pgate.py --out ... --jobs 12 <the 454 files>`, real gate, no sampling):
    pgate: {'NO-SYM': 454}
    454 checked - 0 verified, 454 warning(s), 0 blocking

after (this branch, same 454 files, `python tools/pgate.py --out ... --jobs 10 <the same
454 files>`, real subprocess compiles/relinks for every one of the 2,684 owned functions
-- full population, not a sample):
    pgate: {'NO-SYM': 38, 'VERIFIED': 2643, 'BLIND': 3}
    2684 checked - 2643 verified, 41 warning(s), 0 blocking

This is NOT the 2,684 / 2,671 / 13 / 0 shape #2525's own text expects. The 28-function
gap (2671 - 2643) is real and is explained below -- it is not a defect in this change.

WHY THE AFTER-NUMBERS DIFFER FROM #2525'S, AND WHY THAT IS NOT THIS BUG

#2525's after-census was computed by out/LINKCOV/fast_after_census.py, an in-process
harness built because the literal CLI was too slow to run to completion. That harness
builds its OWN symbol table directly from `relocs.module_universe` (every symbols.txt in
config/, enumerated, not filtered) -- a different, MORE COMPLETE path than the one the
real gate actually uses. The real gate -- both prepush_linkcheck.py's `_load_symbol` and
this file's `load_symbol_fn` -- resolves a symbol through
`tools/stamp_provenance.py:load_symbol`, which only recognizes a module directory named
`arm9`, `arm7`, or matching `arm9/overlays/(ov\d+)`. `config/arm9/itcm/symbols.txt` is
neither, so `load_symbol` returns `None` for every itcm-housed function, unconditionally.

Proof this is pre-existing and shared, not introduced by this change: the REAL,
unmodified prepush_linkcheck.py from #2525 --

    $ python tools/prepush_linkcheck.py --files src/func_01ff97d8.c src/OSReadROMArea.c \
        src/_ZN7dBgW_Kc9GetNormalEsR7Vector3.cpp
      src/func_01ff97d8.c  (6 functions)
      [WARN]   func_01ff97d8                              NO-SYM
      [WARN]   func_01ff98f4                              NO-SYM
      [WARN]   func_01ff99a4                              NO-SYM
      [WARN]   _deq                                       NO-SYM
      [WARN]   func_01ff9d40                              NO-SYM
      [WARN]   func_01ff9e2c                              NO-SYM
      [WARN] OSReadROMArea                                NO-SYM
      [WARN] _ZN7dBgW_Kc9GetNormalEsR7Vector3             NO-SYM
    prepush-linkcheck: 8 checked - 0 verified, 8 warning(s), 0 blocking

-- reports the identical NO-SYM verdict for func_01ff97d8 that #2525's own PR text
described as verifying fine ("src/func_01ff97d8.c's own function (func_01ff97d8)
verifies fine"). That claim was true of the fast harness's broader resolver; it is not
true of the gate #2525 actually shipped. Checked programmatically over the full 38-row
NO-SYM set this branch produces: 37 of 38 are itcm-housed symbols (confirmed against
`relocs.module_universe`, which does see them), and the 38th
(`__sinit_ov023_02111aa8`) is one of #2525's own original 10 NO-SYM rows, unchanged.
Diffing all 2,684 names against #2525's after-census by name: exactly its 10 NO-SYM rows
(the 5 nested passengers of func_01ff97d8, the 4 zero-size itcm runtime-helper aliases,
and the __sinit row) are unchanged, and 28 more -- all itcm-housed -- flip from VERIFIED
to NO-SYM here (9 + 28 = 37 itcm rows total). Those 28 were counted VERIFIED in #2525's
fast-harness numbers, because that harness could actually resolve them; the real gate
cannot. `tools/relocs.py`'s own `module_universe` docstring
names this exact bug class ("Four tools each grew their own copy of this as a regex over
config/, and all four returned arm9 plus ovNNN and silently dropped anything else ...
the whole itcm module ... being invisible") and says it was fixed once already, in
modules.py, on 2026-08-01 -- `stamp_provenance.load_symbol` is evidently a fifth,
unfixed copy. It is unrelated to the stem-resolution class this PR and #2525 both close,
untouched by either, and out of this lane's assigned file. Flagged as its own follow-up
rather than folded in silently, the same way #2525 flagged this PR's bug.

150-file ordinary-file control sample (out/LINKCOV/ordinary_sample.txt, files that
already resolved before either change), via pgate.py itself, before this branch
(pgate.py checked out at e29b9abd8) and after (this branch's tip) -- rows sorted by name
and diffed, byte-identical:
    pgate: {'VERIFIED': 150}
    150 checked - 150 verified, 0 warning(s), 0 blocking   (both runs, real compiles)

TESTS

tools/test_pgate.py -- new, 6 tests, all green. `Main` runs `main()` end to end with
`srcpath.symbols_for` / `load_symbol_fn` / `run_linkcheck` mocked (no compiler, no ROM):
a legacy one-function source resolving to its own stem, the consolidated-TU fixture (3
owned functions, one of each VERIFIED / BLIND-1 / WRONG -- the same fixture
test_prepush_linkcheck.py uses, so the two gates are proven to resolve the identical
population, not merely similar ones), one owned function with no symbols.txt entry
staying NO-SYM without dragging its siblings down, the unenrolled fallback, the
once-per-function ERROR retry, and two files (one legacy, one consolidated) resolving
independently in the same sweep. Wired into .github/workflows/tool-tests.yml's
enumerated list (alphabetical, between test_nearmiss_db and test_premerge_check) plus
its one-paragraph entry in the "what each module protects" comment; the running total in
the file's header narrative is not touched, same as #2525.

CI tool-tests list, run whole (this Windows worktree has mwccarm, so a few toolchain-
gated tests run beyond the bare-container baseline the workflow measures):
    Ran 698 tests in 862.9s -- OK (skipped=2)
(692 before this branch, per #2525's own measurement, plus this module's 6.)

check_python_names: PASS (0 unresolvable names, 0 unparseable files; 50 pre-existing
advisory findings, none naming pgate.py).
check_dead_references: no new dead references (the same 3 baselined prose references
and 4 C/C++ comment references #2525 reported now resolve again, pre-existing, not
touched here).

FILES TOUCHED

    tools/pgate.py                        resolver: srcpath.symbols_for per file
    tools/test_pgate.py                   new, 6 tests
    .github/workflows/tool-tests.yml      wire the new module into the enumerated list

Branch tools/w4-pgate off tools/w4-linkcov e29b9abd8 (PR #2525, itself off origin/main
a90f8c449), tip a75039e4b92a062d8804fc0627ec91cd131b0615.
Not pushed, no PR opened, per brief.
