### PR TITLE
The gates' symbol resolver walks the module universe, so ITCM functions meet the byte gate

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -270,7 +270,7 @@ jobs:
 #                                      close attempts are never thrown away, plus the
 #                                      eval-pin guard: stored divergences are only
 #                                      comparable while their evaluator still exists.
-#   test_pgate                    (6)   pgate.py -- prepush_linkcheck.py's threaded
+#   test_pgate                    (7)   pgate.py -- prepush_linkcheck.py's threaded
 #                                      twin resolves a file to every function its
 #                                      committed delinks.txt range owns the same way,
 #                                      via the same imported srcpath.symbols_for, so a
@@ -284,18 +284,25 @@ jobs:
 #                                      positional diff, and the reeval/bank-matches hold
 #                                      it needs to survive a re-score (was 21 documented
 #                                      here / 23 actual before this change).
+#                                      run_linkcheck are mocked throughout, except one
+#                                      test that leaves load_symbol_fn real to prove an
+#                                      ITCM-housed symbol resolves through the actual
+#                                      config/arm9/itcm/symbols.txt.
 #   test_premerge_check         (87)   premerge_check.py -- runs the static gates on
 #                                      the git merge-tree RESULT, the one tree no CI
 #                                      job ever builds. Pure functions over verdict
 #                                      dicts and a stubbed main(); four honest
 #                                      skipTests need a git binary.
-#   test_prepush_linkcheck       (9)   prepush_linkcheck.py -- resolves a src file to
+#   test_prepush_linkcheck      (10)   prepush_linkcheck.py -- resolves a src file to
 #                                      EVERY function its committed delinks.txt range
 #                                      owns (srcpath.symbols_for), not only the one its
 #                                      filename spells, so a consolidated TU gets one
 #                                      verdict per function instead of one blanket
 #                                      NO-SYM. No ROM, no compiler; srcpath/
-#                                      _load_symbol/_run_linkcheck are mocked throughout.
+#                                      _load_symbol/_run_linkcheck are mocked throughout,
+#                                      except one test that leaves _load_symbol real to
+#                                      prove an ITCM-housed symbol resolves through the
+#                                      actual config/arm9/itcm/symbols.txt.
 #   test_profile_reconstruction (14)   profile_reconstruction.py -- preserves the
 #                                      profile/class namespace split, actor/base layout
 #                                      distinction, overlay-address rejection, and the

--- a/tools/stamp_provenance.py
+++ b/tools/stamp_provenance.py
@@ -83,17 +83,23 @@ def _addr_int(v) -> int:
 
 
 def load_symbol(name: str) -> tuple[str, int, int] | None:
-    """Return (module, addr, size) for symbol name, or None."""
-    config = get_repo() / "config"
-    for sym in config.rglob("symbols.txt"):
-        rel = sym.parent.relative_to(config).as_posix()
-        if rel in ("arm9", "arm7"):
-            module = rel
-        else:
-            m = re.fullmatch(r"arm9/overlays/(ov\d+)", rel)
-            if not m:
-                continue
-            module = m.group(1)
+    """Return (module, addr, size) for symbol name, or None.
+
+    Walks every module's symbols.txt via relocs.module_universe -- THE definition of
+    what a module is, not a second copy of it. This used to be its own regex over
+    config/ that only recognized a directory named arm9, arm7, or arm9/overlays/ovNNN,
+    so config/arm9/itcm/symbols.txt (and dtcm's) fell through silently: every
+    ITCM-housed symbol read NO-SYM here, in both prepush_linkcheck.py and pgate.py,
+    which both resolve through this function. relocs.py's own module_universe
+    docstring names this exact bug class ("Four tools each grew their own copy of
+    this ... and all four ... silently dropped anything else") and was fixed once
+    already in modules.py on 2026-08-01 -- this was the fifth, unfixed copy.
+    module_universe's labels are already spelled the way match.py's --module and the
+    byte gate expect them ("itcm", "dtcm", "ov006", ...), so no relabeling is needed
+    here."""
+    import relocs
+
+    for sym, module in relocs.module_universe(repo=get_repo()):
         for line in sym.read_text(errors="ignore").splitlines():
             m = FUNC_RE.match(line)
             if not m or m.group(1) != name:

--- a/tools/test_pgate.py
+++ b/tools/test_pgate.py
@@ -82,6 +82,33 @@ class Main(unittest.TestCase):
                                   "module": "arm9", "addr": "0x205a61c",
                                   "verdict": "VERIFIED", "blind": 0}])
 
+    def test_itcm_housed_symbol_resolves_through_the_real_load_symbol(self):
+        """`load_symbol_fn()` is intentionally left UNMOCKED here -- every other test in
+        this class stands in for it, which proves the per-function job dispatch but never
+        exercises the real resolver (stamp_provenance.load_symbol -> relocs.module_universe)
+        this gate actually ships. That resolver used to walk config/ with a regex that only
+        recognized a directory named arm9, arm7, or arm9/overlays/ovNNN, so every
+        ITCM-housed symbol -- OSReadROMArea, a real one -- read NO-SYM here regardless of
+        `symbols_for`, because the module lookup itself, not the file-to-function mapping,
+        was blind to config/arm9/itcm/symbols.txt. Only `run_linkcheck` (the compiler/
+        linker subprocess) is mocked; symbol resolution reads the real, committed
+        config/arm9/itcm/symbols.txt, so this is stdlib-only and needs no toolchain --
+        same fixture as prepush_linkcheck.py's twin of this test, proving the two gates
+        resolve the real ITCM symbol identically, not just the mocked ones."""
+        out_path = tempfile.mktemp(suffix=".json")
+        argv = ["pgate.py", "--out", out_path, "--jobs", "1", "src/OSReadROMArea.c"]
+        with mock.patch.object(PG.srcpath, "symbols_for", return_value=["OSReadROMArea"]), \
+             mock.patch.object(PG, "run_linkcheck",
+                               _linkcheck_table({"OSReadROMArea": ("VERIFIED", 0)})), \
+             mock.patch.object(sys, "argv", argv):
+            code = PG.main()
+        rows = json.loads(pathlib.Path(out_path).read_text())
+        pathlib.Path(out_path).unlink(missing_ok=True)
+        self.assertEqual(rows, [{"file": "src/OSReadROMArea.c", "name": "OSReadROMArea",
+                                  "module": "itcm", "addr": "0x1ffdbd8",
+                                  "verdict": "VERIFIED", "blind": 0}])
+        self.assertEqual(code, 0)
+
     def test_consolidated_tu_gets_one_job_per_owned_function(self):
         """The case this whole change exists for: a merged TU's stem names nothing, but
         the enrolment table lists every function it owns. Same fixture as

--- a/tools/test_prepush_linkcheck.py
+++ b/tools/test_prepush_linkcheck.py
@@ -111,6 +111,25 @@ class Verify(unittest.TestCase):
         self.assertEqual(rows, [{"file": "src/func_0209aaaa.c", "name": "func_0209aaaa",
                                   "verdict": "NO-SYM", "note": "no symbol entry"}])
 
+    def test_itcm_housed_symbol_resolves_through_the_real_load_symbol(self):
+        """`_load_symbol` is intentionally left UNMOCKED here -- every other test in this
+        class stands in for it, which proves the row-per-function plumbing but never
+        exercises the real resolver (stamp_provenance.load_symbol -> relocs.module_universe)
+        this gate actually ships. That resolver used to walk config/ with a regex that only
+        recognized a directory named arm9, arm7, or arm9/overlays/ovNNN, so every ITCM-
+        housed symbol -- OSReadROMArea real one among them -- read NO-SYM here regardless
+        of `symbols_for`, because the module lookup itself, not the file-to-function
+        mapping, was blind to config/arm9/itcm/symbols.txt. Only `_run_linkcheck` (the
+        compiler/linker subprocess) is mocked; symbol resolution reads the real, committed
+        config/arm9/itcm/symbols.txt, so this is stdlib-only and needs no toolchain."""
+        with mock.patch.object(PL.srcpath, "symbols_for", return_value=["OSReadROMArea"]), \
+             mock.patch.object(PL, "_run_linkcheck",
+                               _linkcheck_table({"OSReadROMArea": ("VERIFIED", 0, [])})):
+            rows = PL.verify("src/OSReadROMArea.c")
+        self.assertEqual(rows, [{"file": "src/OSReadROMArea.c", "name": "OSReadROMArea",
+                                  "module": "itcm", "addr": "0x1ffdbd8",
+                                  "verdict": "VERIFIED", "blind": 0, "diffs": []}])
+
     def test_error_is_retried_once_per_function_not_once_per_file(self):
         calls = {"n": 0}
 


### PR DESCRIPTION
THE CLASS

PGATE's PR text (#2527) named this as its own follow-up rather than folding it in
silently: both prepush_linkcheck.py and pgate.py resolve every symbol through
tools/stamp_provenance.py:load_symbol, and load_symbol's own directory walk only
recognized a module directory named arm9, arm7, or matching arm9/overlays/(ov\d+):

    config = get_repo() / "config"
    for sym in config.rglob("symbols.txt"):
        rel = sym.parent.relative_to(config).as_posix()
        if rel in ("arm9", "arm7"):
            module = rel
        else:
            m = re.fullmatch(r"arm9/overlays/(ov\d+)", rel)
            if not m:
                continue
            module = m.group(1)

config/arm9/itcm/symbols.txt is neither, so every ITCM-housed symbol -- 37 of them,
func_01ff97d8 among them -- returned None here, unconditionally, regardless of what
srcpath.symbols_for said the owning file was. tools/relocs.py's own module_universe
docstring names this exact bug class by name: "Four tools each grew their own copy of
this as a regex over config/, and all four returned arm9 plus ovNNN and silently
dropped anything else ... modules.py had the same bug and was fixed alone on
2026-08-01." stamp_provenance.load_symbol is the fifth, unfixed copy -- not one of the
original four (that fifth slot is the reason PGATE's PR text called this a NEW finding
rather than a repeat of the four already known), but the same shape of bug, in the one
place both link gates actually resolve a name through.

THE FIX -- one place, not a copy

load_symbol now walks relocs.module_universe() instead of its own regex over config/:

    -   config = get_repo() / "config"
    -   for sym in config.rglob("symbols.txt"):
    -       rel = sym.parent.relative_to(config).as_posix()
    -       if rel in ("arm9", "arm7"):
    -           module = rel
    -       else:
    -           m = re.fullmatch(r"arm9/overlays/(ov\d+)", rel)
    -           if not m:
    -               continue
    -           module = m.group(1)
    +   for sym, module in relocs.module_universe(repo=get_repo()):

module_universe is THE definition tools/relocs.py's docstring claims for it: it
enumerates every config/**/symbols.txt (itcm and dtcm included, alongside arm9 and
every overlay) and hard-fails if the filesystem ever has one it did not enumerate, so a
sixth module added later cannot go silently missing here the way this one did. Its
labels are already spelled the way match.py's --module and both link gates expect them
("itcm", "dtcm", "ov006", ...), and its load-base derivation (module_target in this
same file, and modules.py) already treats itcm and dtcm as first-class modules -- that
half of the pipe was fixed on 2026-08-01, per relocs.py's docstring; this was the
missed fifth caller. dtcm carries zero kind:function entries in the current tree
(checked: config/arm9/dtcm/symbols.txt has one kind:data row and nothing else), so
this fix changes no verdict for dtcm today, but it is no longer a second silent gap the
day a dtcm function is enrolled.

CONTROL -- 150 ordinary files (arm9 + 38 overlay modules), both gates, byte-identical

Same sample #2527 used (out/PGATE/pgate_150_files.txt in the run directory -- files
that already resolved before either LINKCOV, PGATE, or this change). Both gates, real
compiles/relinks, before this branch's parent commit (a75039e4b, stashing this diff)
and after (this branch's tip):

    pgate:              {'VERIFIED': 150}                                    (both runs)
    prepush-linkcheck:  150 checked - 150 verified, 0 warning(s), 0 blocking (both runs)

Every row (name, module, addr, verdict, blind, diffs) diffed identical between before
and after for both gates -- confirmed programmatically, not by eyeballing the tallies.

THE 37 ITCM FUNCTIONS -- both gates, real compiles

config/arm9/itcm/delinks.txt enrolls 28 src/ files; srcpath.symbols_for expands those
to 33 owned functions (func_01ff97d8.c is a 6-function TU: func_01ff97d8 itself plus
func_01ff98f4, func_01ff99a4, _deq, func_01ff9d40, func_01ff9e2c). Four more ITCM
symbols are unenrolled zero-size EABI runtime-helper aliases with their own convention-
named files (src/_dmul.c, src/_ll_sdiv.c, src/_s32_div_f.c, src/_u32_div_f.c) that fall
back to their filename via symbols_for. 28 + 4 = 32 files, 33 + 4 = 37 functions -- the
population PGATE's own diff against #2525 identified by name. pgate.py and
prepush_linkcheck.py agree exactly, row for row (checked programmatically):

    pgate:              {'NO-SYM': 9, 'VERIFIED': 28}
    prepush-linkcheck:  37 checked - 28 verified, 9 warning(s), 0 blocking

    VERIFIED (28): DMAStartTransfer, DMAStartTransferFB, OSReadROMArea,
      _ZN7dBgW_Kc10DetectClsnER12dBgCh_SphCrr, _ZN7dBgW_Kc10DetectClsnER9dBgCh_Gnd,
      _ZN7dBgW_Kc14GetSurfaceInfoEsR11SurfaceInfo,
      _ZN7dBgW_Kc17GetTriangleOriginEsR7Vector3, _ZN7dBgW_Kc9GetNormalEsR7Vector3,
      _ZNK7dBgW_Kc13GetUnkOctreeYEv, _ZNK7dBgW_Kc16GetOctreeOriginYEv, func_01ff859c,
      func_01ff97d8, func_01ffa344, func_01ffa4bc, func_01ffafd4, func_01ffb008,
      func_01ffb030, func_01ffb07c, func_01ffb098, func_01ffb0a4, func_01ffb0b0,
      func_01ffb0bc, func_01ffb0c8, func_01ffd9d4, func_01ffdb28, func_01ffdd08,
      func_01ffdd98, func_01ffde98

    NO-SYM (9): _dmul, _ll_sdiv, _s32_div_f, _u32_div_f, func_01ff98f4, func_01ff99a4,
      _deq, func_01ff9d40, func_01ff9e2c

    BLIND / WRONG / NO-REPRO: none in this population. No finding to list here -- the
    28-function gap this branch closes is a real coverage gain, not a false match
    surfacing.

WHY 9 STILL READ NO-SYM, AND WHY THAT IS NOT THIS BUG

All 9 resolve to a real (module, addr, size) now -- load_symbol is no longer the
reason. Their NO-SYM comes from a different, deeper point in the stack: linkcheck.py's
own verdict, "reason": "len-mismatch" (checked directly: `python tools/linkcheck.py
--module itcm --name func_01ff98f4 --addr 0x01ff98f4 --size 0xb0` returns exactly
that). Two distinct shapes inside the 9:

  * _dmul, _ll_sdiv, _s32_div_f, _u32_div_f -- zero-size alias entries in
    config/arm9/itcm/symbols.txt (kind:function(...,size=0x0)), each an EABI name for
    the same address as a differently-named, correctly-sized primary function
    (_dmul aliases func_01ff8708, etc). A zero-byte target cannot byte-compare against
    a nonzero compiled candidate; that is a property of the alias's recorded size, not
    of module resolution.
  * func_01ff98f4, func_01ff99a4, _deq, func_01ff9d40, func_01ff9e2c -- the 5 nonzero-
    size symbols inside func_01ff97d8.c's owned range besides func_01ff97d8 itself.
    reloc_audit.winning_object (via reverify_corpus.src_texts) resolves a name to a
    compiled object by symbol; extracting one of these five from the object compiled
    for that file does not reproduce the recorded length. That resolution path is
    reloc_audit.py / reverify_corpus.py, not stamp_provenance.load_symbol -- a
    different file, out of this lane's assigned scope (stamp_provenance.py only), and
    not edited here. Flagged as its own follow-up rather than folded in silently, the
    same way PGATE flagged this one.

FULL-CORPUS CENSUS -- pgate.py, real compiles, the same 454-file/2684-function
population #2525 and #2527 both measured (out/LINKCOV/nosym_files.txt)

    before (this branch's parent, a75039e4b -- PGATE's own after-census):
        pgate: {'NO-SYM': 38, 'VERIFIED': 2643, 'BLIND': 3}
        2684 checked - 2643 verified, 41 warning(s), 0 blocking

    after (this branch's tip, same 454 files):
        pgate: {'NO-SYM': 10, 'VERIFIED': 2671, 'BLIND': 3}
        2684 checked - 2671 verified, 13 warning(s), 0 blocking

Exactly the 2684/2671/13/0 shape PGATE's PR text expected. The 10 remaining NO-SYM
rows are the 9 itcm len-mismatch rows above plus the one pre-existing, unrelated
__sinit_ov023_02111aa8 row PGATE already reported (not itcm, not touched by this
change). +28 verified, -28 warnings, 0 change in blocking -- checked by diffing every
row's (name, verdict) before/after, not just the tallies.

TESTS

Both existing suites (test_prepush_linkcheck.py, test_pgate.py) always mock
_load_symbol / load_symbol_fn, so neither ever exercised the real
stamp_provenance.load_symbol this bug lived in -- only the row-per-function plumbing
LINKCOV and PGATE added. One new test per module leaves that mock off and calls the
real resolver against the actual committed config/arm9/itcm/symbols.txt, on a genuine
one-function ITCM source (src/OSReadROMArea.c, real addr 0x01ffdbd8, size 0x130):
only _run_linkcheck / run_linkcheck (the compiler/linker subprocess) stay mocked, so
this is still stdlib-only and needs no toolchain. Both assert the exact resolved row,
module "itcm" included -- the same fixture in both files, proving the two gates
resolve the real ITCM symbol identically, not just the mocked ones.

    python -m unittest tools.test_prepush_linkcheck tools.test_pgate
    Ran 17 tests in 0.135s -- OK
    (9 -> 10 in test_prepush_linkcheck.py, 6 -> 7 in test_pgate.py; wired into
    tool-tests.yml's enumerated list and its "what each module protects" comment,
    counts updated for both. Running total in the file's header narrative not
    touched, same as #2525 and #2527.)

CI tool-tests list, run whole (this Windows worktree has mwccarm, so a few
toolchain-gated tests run beyond the bare-container baseline the workflow measures):

    Ran 700 tests in 395.2s -- OK (skipped=2)
    (698 before this branch, per #2527's own measurement, plus this module's 2.)

check_python_names: PASS (0 unresolvable names, 0 unparseable files; 50 pre-existing
advisory findings, unchanged from #2527, none naming stamp_provenance.py's edit).

check_dead_references: no new dead references, no broken markdown links (the same 3
baselined prose references and 4 baselined C/C++ comment references #2525 and #2527
reported now resolve, pre-existing, not touched here).

FILES TOUCHED

    tools/stamp_provenance.py             load_symbol: relocs.module_universe, not a
                                           fifth copy of the module-dir regex
    tools/test_prepush_linkcheck.py       +1 test, real resolver, real ITCM symbol
    tools/test_pgate.py                   +1 test, real resolver, real ITCM symbol
    .github/workflows/tool-tests.yml      wire the two new tests into the enumerated
                                           list and its counts

Branch tools/w4-itcmres off tools/w4-pgate a75039e4b (PR #2527, itself off
tools/w4-linkcov e29b9abd8 / PR #2525, off origin/main a90f8c449), tip
d1ce9d6a9ab87e720f5f9358c3f2db8228c3d7cc.
Not pushed, no PR opened, per brief.
