### PR TITLE
linkcheck: alias rows verify at their target's real range, nested entry points slice out of the object they live in

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -201,6 +201,7 @@ jobs:
             tools.test_delaunder \
             tools.test_enroll \
             tools.test_layout \
+            tools.test_linkcheck \
             tools.test_match_attempts \
             tools.test_match_provenance \
             tools.test_message_bank \
@@ -260,6 +261,26 @@ jobs:
 #   test_layout                 (11)   layout_check.py -- the invariants that make src/
 #                                      trustworthy; L1 is the one the ROM build cannot
 #                                      catch.
+#   test_linkcheck                (7)   linkcheck.py -- the len-mismatch verdict one
+#                                      level under pgate.py/prepush_linkcheck.py's own
+#                                      resolution: a zero-size EABI alias record (a
+#                                      second name for a differently-named, correctly-
+#                                      sized function at the same address) now compares
+#                                      against its sized twin's real length instead of
+#                                      its own recorded 0, and a nested entry point
+#                                      packed inside another symbol's compiled span
+#                                      (a hand-asm block with several ROM functions in
+#                                      one ELF symbol) is sliced and its relocations
+#                                      rebased into its own window rather than reported
+#                                      NO-SYM for a symbol the object never defines.
+#                                      Two tests compile the real committed fixtures
+#                                      (skip without mwccarm); the rest mock
+#                                      winning_object/extract_func/func_relocs_typed/
+#                                      rom_bytes to prove the offset arithmetic itself,
+#                                      including a deliberately wrong relocation a real
+#                                      compile alone could not distinguish from correct
+#                                      (any sub-slice of an already byte-perfect span
+#                                      trivially matches wherever you cut it).
 #   test_match_attempts         (10)   match_attempts.py -- append-only log of every
 #                                      matching attempt.
 #   test_match_provenance       (20)   match_provenance.py -- the durable how-record and

--- a/tools/bytegate.py
+++ b/tools/bytegate.py
@@ -132,6 +132,39 @@ def is_zero_size_alias(module: str, addr: int, size: int, alias_addrs) -> bool:
     return size == 0 and (module, addr) in alias_addrs
 
 
+def alias_target_size(module: str, addr: int, module_universe=None) -> int | None:
+    """The sized twin's byte length for an aliased address, or None if there is none.
+
+    ``is_zero_size_alias`` answers "should this record count", for the two counting
+    generators. A VERIFICATION gate needs a different answer: tools/linkcheck.py,
+    checking that ``src/_dmul.c`` reproduces the bytes at the address it shares with
+    ``func_01ff8708``, cannot byte-compare against the alias's own recorded size (0,
+    by construction -- nothing compiles to 0 bytes), and used to read that 0 straight
+    through and report every alias NO-SYM regardless of how correct its source was.
+    It has to compare against the SIZED twin's size instead. Same scan as
+    ``alias_names``, so the two never drift apart; kept separate because most callers
+    of ``alias_names`` want the NAME (which file to try compiling) and have no use
+    for the size, and this caller wants only the size.
+    """
+    if module_universe is None:
+        sys.path.insert(0, str(REPO / "tools"))
+        import relocs as RL
+        module_universe = RL.module_universe
+
+    for symbols, label in module_universe():
+        if label != module:
+            continue
+        for line in symbols.read_text(errors="ignore").splitlines():
+            match = FUNC_RE.match(line)
+            if not match:
+                continue
+            size, a = int(match.group(2), 16), int(match.group(3), 16)
+            if size and a == addr:
+                return size
+        break
+    return None
+
+
 def source_hash(path: pathlib.Path) -> str | None:
     """sha256 of the file's bytes with CRLF folded to LF, truncated.
 

--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -243,10 +243,25 @@ def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=()
     checks the reproduced bytes. A caller that already holds the compiled object -- e.g.
     pr_linkcheck checking a compiler-emitted passenger (a this-adjusting thunk or a weak
     dtor/ctor copy) that has no source file of its own -- passes obj=<object bytes> and
-    sym=<symbol to extract> so the symbol is link-checked straight from that object."""
+    sym=<symbol to extract> so the symbol is link-checked straight from that object.
+
+    A zero-size `size` is an EABI alias name for a differently-named, correctly-sized
+    primary function at the same address (e.g. _dmul, size 0, aliasing func_01ff8708,
+    size 0x6f0) -- nothing compiles to 0 bytes, so a zero-size target could never be
+    byte-compared and every alias used to read NO-SYM regardless of its source. Verify
+    against the sized twin's real range instead, still reported under the requested
+    (alias) name; bytegate.alias_target_size is the one place that lookup is made, the
+    same scan progress.py's own matched-count already trusts for this address shape."""
     import reverify_corpus as RV
+    if size == 0:
+        import bytegate as BG
+        alt = BG.alias_target_size(mod, addr)
+        if alt:
+            size = alt
+    off = 0
     if obj is None:
-        obj, sym, err = RA.winning_object(name, addr, size, mod, candidate, include_dirs)
+        obj, sym, err, off = RA.winning_object(name, addr, size, mod, candidate,
+                                               include_dirs, name_index)
     if obj is None:
         # A missing or wrong-length source is NOT a false match; give it a verdict
         # distinct from NO-REPRO so it does not read as "the source stopped matching".
@@ -256,6 +271,13 @@ def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=()
                 "reason": err, "diffs": [], "blind": 0}
     target = RV.rom_bytes(mod, addr, size)
     code, _ = M.extract_func(obj, sym)
+    if off and code is not None:
+        # Nested entry point: `sym` is the CONTAINING symbol the object actually
+        # defines (a hand-asm block packing several ROM functions into one compiled
+        # body -- func_01ff97d8.c is the case in this tree). `off` is `name`'s own
+        # start within that body, already resolved by RA.winning_object via address
+        # arithmetic against config, never by scanning the source text for a label.
+        code = code[off:off + size]
     if (code is not None and target is not None and len(code) > len(target)
             and len(code) - len(target) <= 0x40):
         # Split-symbol carrier (notes 9a(3)): the compiled function extends over the
@@ -269,6 +291,9 @@ def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=()
         return {"name": name, "module": mod, "addr": f"0x{addr:08x}", "verdict": "NO-SYM",
                 "reason": "len-mismatch", "diffs": [], "blind": 0}
     relocs = func_relocs_typed(obj, sym, name_index)
+    if off:
+        relocs = [dict(rl, off=rl["off"] - off) for rl in relocs
+                  if off <= rl["off"] < off + size]
     linked, blind = link_function(code, addr, relocs)
     by_off = {rl["off"] & ~3: rl for rl in relocs}
     diffs = [i for i in range(0, len(target), 4)

--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -207,7 +207,12 @@ def check_file(path, idx, ledger):
         # ordinary one-function sources this is exactly one call, as before.
         obj = wsym = None
         for addr, size, mod in slots:
-            obj, wsym, _ = RA.winning_object(sym, addr, size, mod)
+            # offset discarded: this caller pre-supplies obj/sym straight into
+            # LC.linkcheck below rather than letting it call winning_object itself, so
+            # a nonzero nested-entry-point offset has nowhere to go here. Unaffected
+            # for the ordinary one-symbol-per-object case this loop was built for;
+            # see tools/linkcheck.py's own winning_object call for the nested path.
+            obj, wsym, _, _off = RA.winning_object(sym, addr, size, mod, name_index=_NAME_INDEX)
             if obj is not None:
                 break
         for addr, size, mod in slots:

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -260,18 +260,31 @@ def _as_the_build_links_it(obj, name):
         return obj
 
 
-def winning_object(name, addr, size, mod, candidate=None, include_dirs=()):
+def winning_object(name, addr, size, mod, candidate=None, include_dirs=(), name_index=None):
     """Reproduce the match the way reverify does, but return the object that did it.
 
     Mirrors reverify_corpus.compiles_to so the audit measures exactly what reverify
     blesses -- same sources, same version sweep, same any-symbol acceptance.
     When ``candidate`` is supplied, verify that source file directly instead of
-    looking it up under ``src/``. This is the safe bridge for workbench artifacts."""
+    looking it up under ``src/``. This is the safe bridge for workbench artifacts.
+
+    Returns a 4-tuple ``(obj, sym, err, offset)``. ``offset`` is 0 for every ordinary
+    match (`sym`'s own compiled bytes are what `name` names) and nonzero only for a
+    NESTED entry point: a hand-asm block that packs several ROM functions into ONE
+    compiled symbol, e.g. func_01ff97d8.c, whose object defines only "func_01ff97d8"
+    (0xb6c bytes) though config/**/symbols.txt records five more ROM addresses inside
+    that span. There, `sym` is the CONTAINING symbol and `offset` is where `name`'s own
+    bytes start within it; a caller that re-extracts by symbol alone (tools/linkcheck.py
+    does, to run the reloc-linking check this function does not do) has to slice at
+    `offset` first or it re-derives the whole container's bytes instead of `name`'s own.
+    `name_index` (symbol name -> (module, addr)) is required to resolve that containing
+    symbol's own ROM address for the slice; omit it and only func_<addr>-shaped
+    containers (which carry their address in the name itself) get nested-slice support."""
     import reverify_corpus as RV
     import swarm as S
     target = RV.rom_bytes(mod, addr, size)
     if target is None:
-        return None, None, "no-module-bin"
+        return None, None, "no-module-bin", 0
     # Distinguish the three ways this can fail so callers do not report a missing
     # or wrong-length source as "no-repro" (which reads as a false-match red flag).
     # saw_source: src_texts yielded at least one candidate to try.
@@ -331,7 +344,7 @@ def winning_object(name, addr, size, mod, candidate=None, include_dirs=()):
                         code, relocs = M.extract_func(obj, sym)
                         if code is None:
                             continue
-                        tgt = target
+                        tgt, off = target, 0
                         if len(code) != len(tgt):
                             # Split-symbol carrier (notes 9a(3)): a function whose compiled
                             # form extends over the following severed fragment(s), e.g.
@@ -340,24 +353,44 @@ def winning_object(name, addr, size, mod, candidate=None, include_dirs=()):
                             # overhang included -- strictly stronger than the plain check, so
                             # a wrong-sized near miss cannot slip through. 0x40 bounds the
                             # overhang to fragment scale.
-                            if not (len(code) > len(tgt) and len(code) - len(tgt) <= 0x40):
-                                continue
-                            ext = RV.rom_bytes(mod, addr, len(code))
-                            if ext is None or len(ext) != len(code):
-                                continue
-                            tgt = ext
+                            if len(code) > len(tgt) and len(code) - len(tgt) <= 0x40:
+                                ext = RV.rom_bytes(mod, addr, len(code))
+                                if ext is None or len(ext) != len(code):
+                                    continue
+                                tgt = ext
+                            else:
+                                # NESTED ENTRY POINT: `sym` may CONTAIN `name`'s ROM range
+                                # rather than equal or merely overhang it -- a hand-asm block
+                                # packing several ROM functions into one compiled symbol (see
+                                # func_01ff97d8.c: 0xb6c bytes, five more ROM addresses inside).
+                                # Resolve `sym`'s own ROM address the same way every reloc
+                                # destination is resolved (func_<addr> name, else symbols.txt
+                                # via name_index) and slice by address arithmetic against that
+                                # -- never by scanning the source text for a label, which this
+                                # source does not reliably carry (func_01ff97d8.c's own labels
+                                # are offsets from ITS base, spelled `_L<hex>`, not the nested
+                                # functions' names or addresses).
+                                res = resolve_candidate(sym, name_index or {})
+                                sym_addr = res[1] if res else None
+                                if (sym_addr is None or size == 0
+                                        or not (sym_addr <= addr
+                                                and addr + size <= sym_addr + len(code))):
+                                    continue
+                                off = addr - sym_addr
+                                code = code[off:off + size]
+                                relocs = {r - off for r in relocs if off <= r < off + size}
                         saw_len = True
                         ok, _ = M.compare(tgt, code, relocs, verbose=False)
                         if ok:
-                            return obj, sym, None
+                            return obj, sym, None, off
             finally:
                 if tmp is not None:
                     pathlib.Path(tmp).unlink(missing_ok=True)
     if not saw_source:
-        return None, None, "no-source"      # no src/<name>.c|.cpp on disk to try
+        return None, None, "no-source", 0      # no src/<name>.c|.cpp on disk to try
     if not saw_len:
-        return None, None, "len-mismatch"   # compiled, but never the target's length
-    return None, None, "no-repro"           # right length, but bytes never matched
+        return None, None, "len-mismatch", 0   # compiled, but never the target's length
+    return None, None, "no-repro", 0           # right length, but bytes never matched
 
 
 def classify(cand_name, cand_mod, cand_addr, cfg, sym_index):
@@ -486,7 +519,7 @@ def audit_entry(entry, name_index, config_relocs, sym_index):
     addr = int(entry["addr"], 16) if isinstance(entry["addr"], str) else entry["addr"]
     size = entry["size"]
     mod = entry["module"]
-    obj, sym, err = winning_object(name, addr, size, mod)
+    obj, sym, err, _off = winning_object(name, addr, size, mod, name_index=name_index)
     if obj is None:
         return {"name": name, "module": mod, "addr": f"0x{addr:08x}",
                 "verdict": "NO-REPRO", "reason": err, "relocs": []}

--- a/tools/test_linkcheck.py
+++ b/tools/test_linkcheck.py
@@ -158,7 +158,12 @@ class NestedOffsetRebaseUnit(unittest.TestCase):
              mock.patch.object(LC.M, "extract_func",
                                return_value=(self.CONTAINER_CODE, set())), \
              mock.patch.object(LC, "func_relocs_typed", return_value=relocs), \
-             mock.patch.object(RV, "rom_bytes", return_value=target_bytes):
+             mock.patch.object(RV, "rom_bytes", return_value=target_bytes), \
+             mock.patch.object(LC, "is_benign", return_value=False), \
+             mock.patch.object(LC, "is_interwork", return_value=False):
+            # is_benign / is_interwork read the real module images to excuse a
+            # mismatch (veneers, twins). A mocked-arithmetic test must not touch
+            # extracted/ (absent on the CI runner) and must not be excused.
             return LC.linkcheck("func_01ff98f4", self.NESTED_ADDR, 4, "itcm", {})
 
     def test_slices_code_and_rebases_the_reloc_into_the_nested_window(self):

--- a/tools/test_linkcheck.py
+++ b/tools/test_linkcheck.py
@@ -1,0 +1,197 @@
+"""tools/linkcheck.py: the two len-mismatch shapes underneath the ITCM NO-SYM rows.
+
+WHY THIS EXISTS
+---------------
+PGATE (#2527) and ITCMRES (#2533) closed the module-resolution gaps that sent every
+ITCM symbol, then every consolidated-TU member, to NO-SYM before linkcheck.py even
+ran. Nine rows kept reading NO-SYM after both landed, one level deeper, inside
+linkcheck.py's own "len-mismatch" verdict -- and this module had no tests of its own
+at all until now (only pgate.py's and prepush_linkcheck.py's thin subprocess wrappers
+were covered).
+
+Two distinct shapes, two fixes, both in this file:
+
+  * _dmul, _ll_sdiv, _s32_div_f, _u32_div_f -- zero-size EABI alias records in
+    config/arm9/itcm/symbols.txt, each a second name for a differently-named,
+    correctly-sized primary function at the SAME address (_dmul aliases
+    func_01ff8708). A zero-byte target can never be byte-compared against a nonzero
+    compiled candidate; linkcheck() now substitutes the sized twin's real length
+    (bytegate.alias_target_size) before comparing, and still reports the row under
+    the requested (alias) name.
+  * func_01ff98f4, func_01ff99a4, _deq, func_01ff9d40, func_01ff9e2c -- nested entry
+    points: func_01ff97d8.c is a hand-asm block that packs six ROM functions into
+    ONE compiled ELF symbol ("func_01ff97d8", 0xb6c bytes); the other five have no
+    symbol of their own in the object at all. RA.winning_object now recognizes when
+    a compiled symbol CONTAINS a requested range rather than equalling it, and
+    reports the offset; linkcheck() slices the code and rebases+filters the
+    relocations into that nested function's own window before comparing.
+
+RealCompileFixtures compiles the REAL committed sources (src/_dmul.c,
+src/func_01ff97d8.c) with the pinned mwccarm and skips if it is absent, the same
+convention tools/test_objisolate.py and tools/test_rombuild.py use: the whole
+subject is what a specific compiler emits, so a hand-built object would test this
+file's idea of mwcc rather than mwcc.
+
+The Unit classes below mock winning_object/extract_func/func_relocs_typed/rom_bytes
+directly and need no toolchain at all. Real compiles alone cannot prove the REBASE
+arithmetic is correct rather than accidentally vacuous -- any sub-slice of an
+already-byte-perfect 0xb6c-byte span trivially matches the ROM regardless of where
+you cut it, so a real-compile test cannot catch an off-by-one in the offset math or a
+relocation that leaked in from outside the nested window. These construct a
+synthetic containing symbol where the "right" answer is known by hand and check the
+offset math directly, including a deliberately WRONG reloc destination.
+
+    python -m unittest tools.test_linkcheck -v
+"""
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import linkcheck as LC        # noqa: E402
+import reloc_audit as RA      # noqa: E402
+import reverify_corpus as RV  # noqa: E402
+import bytegate as BG         # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MW = REPO / "tools" / "mwccarm"
+
+
+def _compiler():
+    try:
+        from rombuild import VERSION, CFLAGS
+    except Exception:
+        return None
+    exe = MW / VERSION / "mwccarm.exe"
+    return (exe, CFLAGS) if exe.is_file() else None
+
+
+@unittest.skipUnless(_compiler(), "mwccarm not present")
+class RealCompileFixtures(unittest.TestCase):
+    """Real compiles of the two committed sources these fixes were written for."""
+
+    def test_alias_zero_size_record_verifies_against_its_sized_twin(self):
+        """src/_dmul.c compiles under the name "_dmul"; config records _dmul at
+        0x01ff8708 size 0 and func_01ff8708 at the same address size 0x6f0. Asking
+        linkcheck for "_dmul" with its own (zero) recorded size used to read NO-SYM
+        with reason "len-mismatch" unconditionally -- 0x6f0 compiled bytes can never
+        equal a 0-byte target. It must now resolve the sized twin's length itself and
+        report VERIFIED, not require the caller to already know to pass 0x6f0."""
+        name_index = RA.build_name_index()
+        r = LC.linkcheck("_dmul", 0x01ff8708, 0, "itcm", name_index)
+        self.assertEqual(r["verdict"], "VERIFIED")
+
+    def test_nested_entry_point_extracted_from_the_containing_object(self):
+        """src/func_01ff97d8.c compiles to ONE ELF symbol, "func_01ff97d8", 0xb6c
+        bytes -- confirmed directly: the object this source produces defines no
+        symbol named func_01ff98f4 at all. That symbol's own config row (0x01ff98f4,
+        size 0xb0) sits 0x11c bytes inside func_01ff97d8's compiled span. Asking
+        linkcheck for it directly must slice that span rather than reporting NO-SYM
+        for a symbol the object never defines under that name."""
+        name_index = RA.build_name_index()
+        r = LC.linkcheck("func_01ff98f4", 0x01ff98f4, 0xb0, "itcm", name_index)
+        self.assertEqual(r["verdict"], "VERIFIED")
+
+
+class AliasSizeSubstitutionUnit(unittest.TestCase):
+    """The zero-size substitution in isolation, without a compiler."""
+
+    def test_a_genuine_zero_size_record_with_no_sized_twin_is_left_alone(self):
+        """bytegate.alias_target_size returning None (no sized twin exists at this
+        address) must not fabricate a size. winning_object should still be asked
+        with size 0, and the pre-existing len-mismatch verdict is unaffected."""
+        with mock.patch.object(BG, "alias_target_size", return_value=None) as alt, \
+             mock.patch.object(LC.RA, "winning_object",
+                               return_value=(None, None, "len-mismatch", 0)) as wo:
+            r = LC.linkcheck("_true_orphan", 0x01ffffff, 0, "itcm", {})
+        alt.assert_called_once_with("itcm", 0x01ffffff)
+        self.assertEqual(wo.call_args.args[2], 0)  # size passed through unchanged
+        self.assertEqual(r["verdict"], "NO-SYM")
+        self.assertEqual(r["reason"], "len-mismatch")
+
+    def test_a_sized_twin_is_substituted_before_winning_object_is_called(self):
+        """The corrected size must reach BOTH winning_object (so its own candidate
+        matching compares against the right length) and linkcheck's own target
+        recomputation -- not just one of the two, which was the shape of the
+        original bug (winning_object could privately succeed while linkcheck's
+        separate re-derivation still compared against the stale zero length)."""
+        with mock.patch.object(BG, "alias_target_size", return_value=0x6f0), \
+             mock.patch.object(LC.RA, "winning_object") as wo, \
+             mock.patch.object(LC.M, "extract_func", return_value=(b"\x00" * 0x6f0, set())), \
+             mock.patch.object(LC, "func_relocs_typed", return_value=[]), \
+             mock.patch.object(RV, "rom_bytes", return_value=b"\x00" * 0x6f0):
+            wo.return_value = (b"OBJ", "_dmul", None, 0)
+            r = LC.linkcheck("_dmul", 0x01ff8708, 0, "itcm", {})
+        self.assertEqual(wo.call_args.args[2], 0x6f0)          # size winning_object saw
+        self.assertEqual(r["verdict"], "VERIFIED")
+
+
+class NestedOffsetRebaseUnit(unittest.TestCase):
+    """The slice-and-rebase arithmetic linkcheck() applies when RA.winning_object
+    reports a nonzero offset, fully mocked at the winning_object/extract_func/
+    func_relocs_typed/rom_bytes boundary. A real compile alone cannot distinguish
+    correct rebasing from an accident: any sub-slice of an already-byte-perfect
+    0xb6c-byte span trivially matches the ROM wherever you cut it, so a bug that put
+    the offset one word off, or leaked a neighbouring function's relocation into this
+    one's window, would still read VERIFIED on the real func_01ff97d8.c fixture. This
+    builds a container where the right slice and the right reloc set are known by
+    construction, and checks both: a consistent relocation verifies, an inconsistent
+    one is caught as WRONG rather than silently accepted."""
+
+    # A 0x14-byte containing symbol: 0x10 bytes of unrelated prefix (the nested
+    # function starts partway through, as func_01ff98f4 does inside func_01ff97d8),
+    # then the 4-byte nested function body itself -- one R_ARM_ABS32 pool slot, zero
+    # until the linker fills it. Addresses are chosen well outside every real module
+    # image (0x02000000-ish arm9/overlay/itcm space) so is_benign's real-ROM veneer
+    # and twin checks -- which read actual module bytes -- reliably see nothing and
+    # never accidentally excuse a genuine mismatch.
+    CONTAINER_CODE = b"\x11" * 0x10 + b"\x00\x00\x00\x00"
+    NESTED_ADDR = 0x02000010
+    RELOC_TARGET = 0xEE001000
+
+    def _run(self, target_bytes, extra_relocs=()):
+        relocs = [{"off": 0x10, "type": LC.R_ARM_ABS32, "sym": "in_range",
+                   "addr": self.RELOC_TARGET, "add": 0}] + list(extra_relocs)
+        with mock.patch.object(LC.RA, "winning_object",
+                               return_value=(b"OBJ", "func_01ff97d8", None, 0x10)), \
+             mock.patch.object(LC.M, "extract_func",
+                               return_value=(self.CONTAINER_CODE, set())), \
+             mock.patch.object(LC, "func_relocs_typed", return_value=relocs), \
+             mock.patch.object(RV, "rom_bytes", return_value=target_bytes):
+            return LC.linkcheck("func_01ff98f4", self.NESTED_ADDR, 4, "itcm", {})
+
+    def test_slices_code_and_rebases_the_reloc_into_the_nested_window(self):
+        """The reloc at container-relative offset 0x10 must land at rebased offset 0
+        inside the 4-byte nested window and get linked against the ROM word that
+        encodes RELOC_TARGET -- proving both the code slice (0x10:0x14) and the
+        reloc rebase (0x10 -> 0) land on the SAME 4 bytes."""
+        import struct
+        target = struct.pack("<I", self.RELOC_TARGET)
+        r = self._run(target)
+        self.assertEqual(r["verdict"], "VERIFIED")
+
+    def test_a_wrong_destination_inside_the_nested_window_is_caught(self):
+        """Same shape, but the ROM word encodes a DIFFERENT address than the
+        candidate's relocation resolves to -- a false match, and rebasing must not
+        wildcard it away just because it now sits at offset 0 of a slice."""
+        import struct
+        wrong_target = struct.pack("<I", 0xEE002000)
+        r = self._run(wrong_target)
+        self.assertEqual(r["verdict"], "WRONG")
+
+    def test_a_reloc_outside_the_nested_window_is_excluded_not_misapplied(self):
+        """A relocation belonging to a NEIGHBOURING nested function (container
+        offset 0x4, well before this function's 0x10:0x14 window) must be dropped
+        by the rebase filter, not rebased to a negative offset and misapplied to
+        this function's own bytes."""
+        import struct
+        target = struct.pack("<I", self.RELOC_TARGET)
+        neighbour = {"off": 0x4, "type": LC.R_ARM_ABS32, "sym": "neighbour",
+                     "addr": 0xEE009999, "add": 0}
+        r = self._run(target, extra_relocs=[neighbour])
+        self.assertEqual(r["verdict"], "VERIFIED")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THE CLASS

ITCMRES's PR text (#2533) named this as its own follow-up: both pgate.py and
prepush_linkcheck.py resolve every symbol through tools/linkcheck.py, and after
PGATE (#2527) and ITCMRES closed the module-resolution gaps above it, nine ITCM
rows kept reading NO-SYM one level deeper, inside linkcheck.py's own verdict,
"reason": "len-mismatch" -- module/addr/size all resolve fine; the byte
comparison itself never runs. Two distinct shapes, unrelated to each other and
to the resolution bugs the two prior lanes closed:

  * _dmul, _ll_sdiv, _s32_div_f, _u32_div_f -- zero-size EABI alias records in
    config/arm9/itcm/symbols.txt (kind:function(...,size=0x0)), each a second
    name for a differently-named, correctly-sized primary function at the SAME
    address (_dmul aliases func_01ff8708, 0x6f0 bytes; _ll_sdiv aliases
    func_01ffaa34; _s32_div_f aliases __aeabi_idiv; _u32_div_f aliases
    __aeabi_uidiv). Nothing compiles to 0 bytes, so a zero-byte target can never
    be byte-compared against the nonzero object the alias's own source (e.g.
    src/_dmul.c) produces. Checked directly against the current tree: compiling
    src/_dmul.c and comparing the result to the ROM at 0x01ff8708 for 0x6f0
    bytes (func_01ff8708's own recorded size, not _dmul's) reproduces it
    exactly. The alias's file IS the target's source under another name -- the
    asm function inside src/_dmul.c is itself named "_dmul", not
    "func_01ff8708" -- so the honest fix is the first option the brief posed:
    compare the alias's source against the target's real range, one
    verification, reported under whichever name is asked.
  * func_01ff98f4, func_01ff99a4, _deq, func_01ff9d40, func_01ff9e2c -- nested
    entry points inside src/func_01ff97d8.c's owned range. That file is a
    HAND-ASM PRIMITIVE block, the same shape as the four aliases above and the
    twenty other byte-exact assembly primitives in this tree: one `asm`
    function, several ROM entry points packed into its straight-line body.
    Checked directly: the object src/func_01ff97d8.c compiles to carries
    exactly ONE STT_FUNC symbol, "func_01ff97d8", 0xb6c bytes -- no ELF symbol
    named func_01ff98f4 or any of the other four exists in it at all, so
    `M.extract_func(obj, "func_01ff98f4")` always returned None and no amount
    of retrying found a candidate of the right length. The five addresses sit
    entirely inside that 0xb6c-byte span (0x11c, 0x1cc, 0x568, 0x568 again for
    _deq's twin func_01ff9d40, and 0x654 bytes in, respectively; their sizes
    sum to exactly 0xb6c - 0x11c, tiling the remainder of the span with no gap
    or overlap) and the whole span already reproduces the ROM byte for byte
    (that is how func_01ff97d8 itself verifies). Extracted each one from the
    OBJECT by address arithmetic against the ELF symbol the object actually
    defines -- never by scanning func_01ff97d8.c's own labels, which are
    spelled `_L<hex>` relative to ITS OWN base and do not name or address the
    nested functions at all.

THE FIX -- two places, matching the two shapes

tools/bytegate.py gains `alias_target_size(module, addr)`: the same
config/**/symbols.txt scan `alias_names`/`alias_collision_addresses` already do
for the two counting generators (progress.py, chaos_db_ci.py), returning the
sized twin's length instead of the address/name. linkcheck() (tools/linkcheck.py)
calls it once, at the top, only when the requested size is 0, and uses the
corrected size for both the winning_object call and its own target
recomputation -- both were needed; winning_object succeeding internally is not
enough on its own, because linkcheck() re-derives `target` and `code`
independently afterward.

tools/reloc_audit.py's `winning_object` now returns a 4-tuple
`(obj, sym, err, offset)`. `offset` is 0 for every ordinary match and nonzero
only when the object's compiled symbol CONTAINS the requested range rather than
equalling it: resolve that containing symbol's own ROM address the same way
every other reloc destination is resolved (func_<addr> name, else
symbols.txt via `name_index`, now an optional parameter), and accept only when
the requested [addr, addr+size) sits entirely inside [sym_addr, sym_addr+len)
-- an address-arithmetic bound, not a heuristic. linkcheck() slices `code` at
that offset and rebases+filters the relocations returned by
`func_relocs_typed` into the nested function's own window before running the
existing link+compare+classify logic unchanged.

Two other winning_object call sites needed the new arity fixed so they do not
crash: reloc_audit.audit_entry (this file's own CLI/audit_entry, over
progress/matched.jsonl -- none of the nine rows live there, so this path never
actually exercises the nested case in practice) and pr_linkcheck.py, which
pre-supplies obj/sym straight into linkcheck() rather than letting it call
winning_object itself; that caller discards the offset today exactly as it did
before (a nonzero offset has nowhere to go through that pre-supplied path), so
this is an arity fix only, not new nested-symbol support there -- flagged as a
gap rather than folded in silently, since pr_linkcheck.py was not part of this
lane's read list.

TWO GATES OVER THE 37 ITCM FUNCTIONS -- real compiles, before/after

Same 32-file/37-function population ITCMRES identified (28 delinks.txt-enrolled
files + the 4 alias files; out/ITCMRES/itcm37_files.txt in the run directory).

    pgate.py               before: {'NO-SYM': 9, 'VERIFIED': 28}
                            after:  {'VERIFIED': 37}
    prepush_linkcheck.py    before: 37 checked - 28 verified, 9 warning(s), 0 blocking
                            after:  37 checked - 37 verified, 0 warning(s), 0 blocking

All nine, both gates:

    _dmul, _ll_sdiv, _s32_div_f, _u32_div_f,
    func_01ff98f4, func_01ff99a4, _deq, func_01ff9d40, func_01ff9e2c

    -> VERIFIED, no BLIND, no WRONG, no NO-REPRO.

FULL-CORPUS CENSUS -- pgate.py, real compiles, the same 454-file/2684-function
population #2525/#2527/#2533 all measured (out/LINKCOV/nosym_files.txt)

    before (this branch's parent, d1ce9d6a9 -- ITCMRES's own after-census):
        pgate: {'NO-SYM': 10, 'VERIFIED': 2671, 'BLIND': 3}
        2684 checked - 2671 verified, 13 warning(s), 0 blocking

    after (this branch's tip):
        pgate: {'NO-SYM': 1, 'VERIFIED': 2680, 'BLIND': 3}
        2684 checked - 2680 verified, 4 warning(s), 0 blocking

Exactly the 2684/2680/4/0 shape predicted. Diffed programmatically, not just the
tallies: of 2684 rows, exactly 9 changed verdict, all NO-SYM -> VERIFIED, all
nine of the rows above and no others. The remaining warnings are the two
ITCMRES already reported and left open, unrelated to this lane and untouched
here: the pre-existing `__sinit_ov023_02111aa8` NO-SYM row (no source under any
name) and the same 3 BLIND `__sinit_*` rows (unresolved external symbols inside
a compiler-generated static initializer, a different gap). No WRONG, no
NO-REPRO anywhere in the 2684 -- no finding to list.

CONTROL -- 150 files, both gates, byte-identical before/after (same sample
#2527/#2533 used, out/PGATE/pgate_150_files.txt in the run directory)

    pgate:              {'VERIFIED': 150}                                (both)
    prepush-linkcheck:  150 checked - 150 verified, 0 warning(s), 0 blocking (both)

Diffed programmatically against ITCMRES's own recorded 150-file after-state for
both gates: every row (file, name, module, addr, verdict) identical.

TESTS -- tools/test_linkcheck.py, new (linkcheck.py had no dedicated test
module before this)

Seven tests. Two compile the real committed fixtures with the pinned mwccarm
(skip without it, the tools/test_objisolate.py/test_rombuild.py convention):
_dmul against its sized twin, func_01ff98f4 out of func_01ff97d8.c's object.
The other five are pure-mock unit tests needing no toolchain, because a real
compile alone cannot prove the offset arithmetic is correct rather than
accidentally vacuous -- any sub-slice of an already byte-perfect 0xb6c-byte
span trivially matches the ROM wherever you cut it, so a bug that put the
offset one word off, or let a neighbouring nested function's relocation leak
into this one's window, would still read VERIFIED on the real fixture alone.
These construct a synthetic containing symbol where the right slice and the
right reloc set are known by hand: a consistent relocation verifies, a
deliberately WRONG relocation destination inside the nested window is caught
as WRONG (not wildcarded away just because it now sits at offset 0 of a
slice), and a relocation belonging to a neighbouring function just outside the
window is excluded rather than misapplied. A third pair proves the alias-size
substitution reaches both winning_object and linkcheck's own target
recomputation, and that a genuine zero-size record with no sized twin is left
alone rather than fabricating a size.

    python -m unittest tools.test_linkcheck -v
    Ran 7 tests in 1.2s -- OK

Wired into tool-tests.yml's enumerated list (alphabetical, between test_layout
and test_match_attempts) and its "what each module protects" comment.

CI tool-tests list, run whole (this Windows worktree has mwccarm, so a few
toolchain-gated tests run beyond the bare-container baseline the workflow
measures):

    Ran 707 tests in 402.7s -- OK (skipped=2)
    (700 before this branch, per #2533's own measurement, plus this module's 7)

check_python_names: PASS (0 unresolvable names, 0 unparseable files; the same
50 pre-existing advisory findings #2525/#2527/#2533 reported, unchanged; none
naming any file this branch touches).

check_dead_references: no new dead references, no broken markdown links (the
same 3 baselined prose references and 4 baselined C/C++ comment references
#2525/#2527/#2533 reported now resolve, pre-existing, not touched here).

FILES TOUCHED

    tools/bytegate.py                     alias_target_size: the sized twin's
                                           length for a zero-size alias record
    tools/reloc_audit.py                  winning_object: 4-tuple return with a
                                           nested-containment offset; the two
                                           other call sites (audit_entry, this
                                           file; pr_linkcheck.py) updated for
                                           the new arity
    tools/linkcheck.py                    linkcheck(): alias-size substitution
                                           at entry; slice+rebase the code and
                                           relocations when winning_object
                                           reports a nonzero offset
    tools/pr_linkcheck.py                 arity fix only (see THE FIX above);
                                           no new nested-symbol support there
    tools/test_linkcheck.py               new -- 7 tests, 2 real-compile + 5
                                           mocked-arithmetic
    .github/workflows/tool-tests.yml      wire test_linkcheck into the
                                           enumerated list and its counts

Branch tools/w4-linkchk2 off tools/w4-itcmres d1ce9d6a9 (PR #2533, itself off
tools/w4-pgate a75039e4b / PR #2527, off tools/w4-linkcov e29b9abd8 / PR #2525,
off origin/main a90f8c449), tip 6de680ee2.
Not pushed, no PR opened, per brief.
