### PR TITLE
Near-miss DB: resolve alias and nested candidates the way the gate does, and guard the single-symbol fallback

### DIFF
--- a/tools/nearmiss_db.py
+++ b/tools/nearmiss_db.py
@@ -216,7 +216,21 @@ def _trim_error(text, limit=240):
     return text[:limit] if text else "compile failed (no diagnostic captured)"
 
 
-def evaluate_full(src, name, target):
+_NAME_INDEX_CACHE = None
+
+
+def _name_index():
+    """Lazy, process-wide cache of reloc_audit.build_name_index() (a scan of every
+    committed symbols.txt) -- expensive enough that evaluate_full must not rebuild
+    it per row when reeval/bank-matches call it hundreds of times in one pass."""
+    global _NAME_INDEX_CACHE
+    if _NAME_INDEX_CACHE is None:
+        import reloc_audit as RA
+        _NAME_INDEX_CACHE = RA.build_name_index()
+    return _NAME_INDEX_CACHE
+
+
+def evaluate_full(src, name, target, module=None, addr=None, size=None, name_index=None):
     """Evaluate a candidate against the target bytes with the live evaluator. Returns
       {divergences, ok, cand_size, status, error}
     divergences  count of differing WORDS (reloc-wildcarded) -- tools/match.py's own
@@ -241,7 +255,27 @@ def evaluate_full(src, name, target):
     renames the row to the C++ symbol while the source still spells func_<addr>), and
     the repo's substitution-compressed manglings are not the spelling mwccarm emits.
     Both look identical to an exact-string lookup and both demote a perfectly good,
-    often size-exact seed to last place in every worklist. See match.sole_func_symbol."""
+    often size-exact seed to last place in every worklist. See match.sole_func_symbol.
+
+    module/addr/size/name_index (all optional; every existing caller that omits them
+    keeps the exact behavior above unchanged) let evaluate_full resolve the candidate
+    the same way tools/linkcheck.py's byte gate does, for the same two shapes
+    LINKCHK2 (#2535) closed there -- shared, not re-derived, so a stored row can never
+    disagree with a fresh linkcheck run on its own c_source:
+      * zero-size EABI alias (size == 0, e.g. _dadd at 0x01ff8000): the row's own
+        declared size is a second name for a differently-named, correctly-sized
+        primary at the SAME address (func_01ff8000, size 0x59c) -- nothing compiles
+        to 0 bytes, so a 0-byte target could never be byte-compared.
+        bytegate.alias_target_size finds the sized twin's real length; `target` and
+        `size` are both replaced with it (reverify_corpus.rom_bytes re-reads the ROM
+        at the corrected length) before extraction or comparison.
+      * nested entry point: `name` has no symbol of its own in the compiled object at
+        all -- a hand-asm block packs several ROM functions into ONE compiled symbol
+        (see func_01ff97d8.c: 0xb6c bytes, five more ROM addresses inside). When the
+        exact-name lookup and the sole-symbol fallback both miss, every function the
+        object DOES define is checked for one that CONTAINS name's ROM range,
+        resolved by address (reloc_audit.resolve_nested_slice) -- never by scanning
+        source text for a label."""
     import contextlib
     import io
     import match as M
@@ -249,6 +283,14 @@ def evaluate_full(src, name, target):
     unscorable = {"divergences": None, "ok": False, "cand_size": None}
     chat = io.StringIO()
     resolved = None
+    if size == 0 and module is not None and addr is not None:
+        import bytegate as BG
+        alt = BG.alias_target_size(module, addr)
+        if alt:
+            import reverify_corpus as RV
+            rebased = RV.rom_bytes(module, addr, alt)
+            if rebased is not None:
+                target, size = rebased, alt
     try:
         with contextlib.redirect_stdout(chat):    # compile_c prints; capture the detail
             _, obj = S.oracle_check(src, name, target)
@@ -261,6 +303,32 @@ def evaluate_full(src, name, target):
             resolved = M.sole_func_symbol(obj)
             if resolved is not None:
                 cand, crel = M.extract_func(obj, resolved)
+                if size and cand is not None and len(cand) != size:
+                    # The object's one function is a CONTAINER (a nested entry
+                    # point -- func_01ff97d8.c's whole 0xb6c-byte body is exactly
+                    # this shape), not a renamed/mangled copy of `name` itself: a
+                    # genuine rename compiles to `name`'s own length by
+                    # construction, since it IS that function under another
+                    # spelling. Undo the guess and let the nested-container search
+                    # below resolve it by address instead of reporting a false
+                    # size mismatch under the wrong resolved name.
+                    cand, crel, resolved = None, None, None
+        if cand is None and addr is not None and size:
+            # Neither the exact name nor the sole-symbol fallback found it: try every
+            # function the object DOES define as a possible CONTAINER (see
+            # reloc_audit.resolve_nested_slice).
+            import probe_versions as PV
+            import reloc_audit as RA
+            idx = name_index if name_index is not None else _name_index()
+            for sym in PV.funcs_in(obj):
+                full_code, full_relocs = M.extract_func(obj, sym)
+                if full_code is None:
+                    continue
+                sliced = RA.resolve_nested_slice(sym, full_code, full_relocs, addr, size, idx)
+                if sliced is not None:
+                    cand, crel, _off = sliced
+                    resolved = sym
+                    break
     except Exception as e:                        # malformed object, ELF parse crash, ...
         return dict(unscorable, status="noncompile",
                     error=_trim_error(f"{type(e).__name__}: {e}"))
@@ -564,7 +632,8 @@ def ingest(args):
             # 2026-07-12). Skip before the expensive evaluate().
             drops.append(key)
             continue
-        full = evaluate_full(src, name, bytes.fromhex(thex))
+        full = evaluate_full(src, name, bytes.fromhex(thex),
+                             module=mod, addr=L.norm_addr(addr), size=size)
         if full["divergences"] is None or full["ok"]:   # broken seed, or already a match; skip
             continue
         rec = {"module": mod, "addr": addr, "name": name, "size": size,
@@ -884,7 +953,8 @@ def bank_matches(args):
     for key, r in list(db.items()):
         if _is_manual(r):
             continue
-        full = evaluate_full(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]))
+        full = evaluate_full(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]),
+                             module=r["module"], addr=L.norm_addr(r["addr"]), size=r["size"])
         div, ok = full["divergences"], full["ok"]
         if ok and not getattr(args, "no_strict", False):
             # the byte oracle wildcards reloc slots; refuse a draft whose relocations
@@ -961,6 +1031,7 @@ def reeval(args):
         sys.exit(f"reeval: canonical compiler {M.CANONICAL} is not installed at {exe}; "
                  f"a pass without it would mark every row noncompiling")
     db = load_db()
+    name_idx = _name_index()   # built once for the whole pass, not once per row
     manual_items = [(k, r) for k, r in db.items() if _is_manual(r)]
     held = len(manual_items)
     order = sorted((kv for kv in db.items() if not _is_manual(kv[1])),
@@ -968,7 +1039,9 @@ def reeval(args):
     results, n = {}, len(order)
     same = drifted = broke = recovered = bankable = 0
     for i, (key, r) in enumerate(order, 1):
-        full = evaluate_full(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]))
+        full = evaluate_full(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]),
+                             module=r["module"], addr=L.norm_addr(r["addr"]), size=r["size"],
+                             name_index=name_idx)
         results[key] = (r["c_source"], full)
         old, new = r.get("divergences"), full["divergences"]
         label = f"[{i}/{n}] {r['module']:6} {r['name'][:46]:46}"
@@ -996,7 +1069,9 @@ def reeval(args):
     # hold on its own) without ever silently overwriting one that still disagrees.
     manual_results, released = {}, 0
     for i, (key, r) in enumerate(manual_items, 1):
-        full = evaluate_full(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]))
+        full = evaluate_full(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]),
+                             module=r["module"], addr=L.norm_addr(r["addr"]), size=r["size"],
+                             name_index=name_idx)
         manual_results[key] = (r["c_source"], full)
         label = f"[manual {i}/{held}] {r['module']:6} {r['name'][:46]:46}"
         if _manual_hold_releasable(r, full):

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -260,6 +260,34 @@ def _as_the_build_links_it(obj, name):
         return obj
 
 
+def resolve_nested_slice(sym, code, relocs, addr, size, name_index):
+    """If `name`'s ROM range [addr, addr+size) is not `sym`'s own compiled length but
+    lies fully WITHIN it -- a hand-asm block packing several ROM functions into one
+    compiled symbol (see func_01ff97d8.c: 0xb6c bytes, five more ROM addresses
+    inside) -- resolve `sym`'s own ROM address the same way every reloc destination
+    is resolved (func_<addr> name, else symbols.txt via name_index) and slice by
+    address arithmetic against that -- never by scanning the source text for a
+    label, which this source does not reliably carry (func_01ff97d8.c's own labels
+    are offsets from ITS base, spelled `_L<hex>`, not the nested functions' names or
+    addresses).
+
+    Returns (sliced_code, sliced_relocs, offset), or None if `sym` does not contain
+    the range -- including when `size` is 0 (a zero-size alias record; that shape is
+    resolved by bytegate.alias_target_size against the TARGET side, not by searching
+    for a container here).
+
+    Shared by winning_object (compiling every source candidate fresh, per version)
+    and nearmiss_db.evaluate_full (scoring one already-compiled near-miss draft), so
+    the two can never resolve a nested name differently from each other."""
+    res = resolve_candidate(sym, name_index or {})
+    sym_addr = res[1] if res else None
+    if (sym_addr is None or not size
+            or not (sym_addr <= addr and addr + size <= sym_addr + len(code))):
+        return None
+    off = addr - sym_addr
+    return code[off:off + size], {r - off for r in relocs if off <= r < off + size}, off
+
+
 def winning_object(name, addr, size, mod, candidate=None, include_dirs=(), name_index=None):
     """Reproduce the match the way reverify does, but return the object that did it.
 
@@ -360,25 +388,13 @@ def winning_object(name, addr, size, mod, candidate=None, include_dirs=(), name_
                                 tgt = ext
                             else:
                                 # NESTED ENTRY POINT: `sym` may CONTAIN `name`'s ROM range
-                                # rather than equal or merely overhang it -- a hand-asm block
-                                # packing several ROM functions into one compiled symbol (see
-                                # func_01ff97d8.c: 0xb6c bytes, five more ROM addresses inside).
-                                # Resolve `sym`'s own ROM address the same way every reloc
-                                # destination is resolved (func_<addr> name, else symbols.txt
-                                # via name_index) and slice by address arithmetic against that
-                                # -- never by scanning the source text for a label, which this
-                                # source does not reliably carry (func_01ff97d8.c's own labels
-                                # are offsets from ITS base, spelled `_L<hex>`, not the nested
-                                # functions' names or addresses).
-                                res = resolve_candidate(sym, name_index or {})
-                                sym_addr = res[1] if res else None
-                                if (sym_addr is None or size == 0
-                                        or not (sym_addr <= addr
-                                                and addr + size <= sym_addr + len(code))):
+                                # rather than equal or merely overhang it -- see
+                                # resolve_nested_slice for the address-anchored resolution.
+                                sliced = resolve_nested_slice(sym, code, relocs, addr, size,
+                                                              name_index)
+                                if sliced is None:
                                     continue
-                                off = addr - sym_addr
-                                code = code[off:off + size]
-                                relocs = {r - off for r in relocs if off <= r < off + size}
+                                code, relocs, off = sliced
                         saw_len = True
                         ok, _ = M.compare(tgt, code, relocs, verbose=False)
                         if ok:

--- a/tools/test_nearmiss_db.py
+++ b/tools/test_nearmiss_db.py
@@ -486,6 +486,173 @@ class NearMissDbTests(unittest.TestCase):
         self.assertEqual(full["ok"], direct_ok)
 
 
+class EvaluateFullResolverParityTests(unittest.TestCase):
+    """evaluate_full resolves the candidate for the same two shapes LINKCHK2 (#2535)
+    closed in tools/linkcheck.py's byte gate -- the nine ITCM rows NMDB2's whole-DB
+    reeval marked func-absent (extract by exact name found nothing, because that is
+    what a zero-size alias record and a nested entry point both look like to a plain
+    symbol lookup). Shared, not re-derived: bytegate.alias_target_size and
+    reloc_audit.resolve_nested_slice are the exact functions tools/linkcheck.py
+    calls, imported here and there, so a stored divergence can never disagree with a
+    fresh linkcheck run on the same c_source.
+
+    The Unit tests below mock oracle_check/extract_func/alias_target_size/
+    resolve_nested_slice directly and need no compiler at all -- same convention
+    test_linkcheck.py's own AliasSizeSubstitutionUnit / NestedOffsetRebaseUnit use,
+    for the same reason: the WIRING is what these prove, and resolve_nested_slice's
+    own offset arithmetic already has dedicated coverage there (shared code, not
+    re-tested here). RealCompileFixtures below compiles the actual committed
+    src/_dmul.c and src/func_01ff97d8.c and skips if the canonical (2004/b56)
+    compiler is absent, same as tools/test_linkcheck.py's RealCompileFixtures."""
+
+    def _require_compile_stack(self):
+        try:
+            import match
+            import swarm
+        except ImportError as e:
+            self.skipTest(f"capstone/pyelftools not installed: {e}")
+        return match, swarm
+
+    def test_alias_zero_size_row_is_scored_against_its_sized_twin(self):
+        """A zero-size EABI alias row (e.g. _dadd, config size 0 at the same address
+        as the sized primary func_01ff8000): the caller's own target/size are 0
+        bytes -- exactly the shape that used to read func-absent regardless of how
+        correct the source was, because a 0-byte target can never be byte-compared
+        against a nonzero compiled candidate. evaluate_full must resolve the real
+        size the same way linkcheck() does (bytegate.alias_target_size) and re-read
+        the ROM at that length (reverify_corpus.rom_bytes) before comparing -- proven
+        through the REAL match.compare on the resolved bytes, not a stand-in."""
+        M, swarm = self._require_compile_stack()
+        import bytegate
+        import reverify_corpus
+        from unittest import mock
+        real = b"\x01\x00\x00\x00\x02\x00\x00\x00"        # the sized twin's ROM bytes
+        candidate = b"\x01\x00\x00\x00\x03\x00\x00\x00"   # one word off
+        with mock.patch.object(swarm, "oracle_check", return_value=(False, b"fake-obj")), \
+             mock.patch.object(M, "extract_func", return_value=(candidate, set())), \
+             mock.patch.object(bytegate, "alias_target_size", return_value=len(real)) as alt, \
+             mock.patch.object(reverify_corpus, "rom_bytes", return_value=real) as rb:
+            full = NDB.evaluate_full("asm double _dadd(...) { ... }", "_dadd", b"",
+                                     module="itcm", addr=0x01ff8000, size=0)
+        alt.assert_called_once_with("itcm", 0x01ff8000)
+        rb.assert_called_once_with("itcm", 0x01ff8000, len(real))
+        direct_ok, direct_ndiff = M.compare(real, candidate, set(), verbose=False)
+        self.assertEqual(full["divergences"], direct_ndiff)
+        self.assertEqual(full["ok"], direct_ok)
+        self.assertEqual(full["cand_size"], len(candidate))
+
+    def test_alias_row_that_byte_matches_its_sized_twin_reads_zero_and_ok(self):
+        """The MATCH case: once the size is resolved, a byte-exact candidate must
+        read divergences 0 / ok True -- the number reeval treats as bankable."""
+        M, swarm = self._require_compile_stack()
+        import bytegate
+        import reverify_corpus
+        from unittest import mock
+        real = b"\x01\x00\x00\x00\x02\x00\x00\x00"
+        with mock.patch.object(swarm, "oracle_check", return_value=(False, b"fake-obj")), \
+             mock.patch.object(M, "extract_func", return_value=(real, set())), \
+             mock.patch.object(bytegate, "alias_target_size", return_value=len(real)), \
+             mock.patch.object(reverify_corpus, "rom_bytes", return_value=real):
+            full = NDB.evaluate_full("asm double _dadd(...) { ... }", "_dadd", b"",
+                                     module="itcm", addr=0x01ff8000, size=0)
+        self.assertEqual(full["divergences"], 0)
+        self.assertTrue(full["ok"])
+
+    def test_nested_entry_point_is_found_inside_its_containing_symbol(self):
+        """A nested entry point (e.g. func_01ff98f4 inside func_01ff97d8.c's single
+        compiled symbol): `name` has no symbol of its own in the object at all --
+        extract_func(obj, name) and the sole-symbol fallback both miss. evaluate_full
+        must search every symbol the object DOES define for one that CONTAINS
+        name's ROM range, the exact address-anchored resolution
+        reloc_audit.resolve_nested_slice gives tools/linkcheck.py -- shared, not
+        re-derived, so the two can never disagree on which symbol a nested name
+        resolves against."""
+        M, swarm = self._require_compile_stack()
+        import probe_versions
+        import reloc_audit
+        from unittest import mock
+        container_code = b"\x11" * 0x10 + b"\x01\x00\x00\x00"   # nested func at +0x10
+        sliced = container_code[0x10:0x14]
+        target = b"\x02\x00\x00\x00"                             # one word off
+
+        def fake_extract(obj, sym):
+            if sym == "func_01ff98f4":
+                return None, None                # absent from the object by that name
+            return container_code, set()          # the containing symbol's full body
+
+        with mock.patch.object(swarm, "oracle_check", return_value=(False, b"fake-obj")), \
+             mock.patch.object(M, "extract_func", side_effect=fake_extract), \
+             mock.patch.object(M, "sole_func_symbol", return_value=None), \
+             mock.patch.object(probe_versions, "funcs_in",
+                               return_value={"func_01ff97d8": b""}), \
+             mock.patch.object(reloc_audit, "resolve_nested_slice",
+                               return_value=(sliced, set(), 0x10)) as rns:
+            full = NDB.evaluate_full("//asm container", "func_01ff98f4", target,
+                                     module="itcm", addr=0x01ff98f4, size=4, name_index={})
+        rns.assert_called_once_with("func_01ff97d8", container_code, set(),
+                                    0x01ff98f4, 4, {})
+        direct_ok, direct_ndiff = M.compare(target, sliced, set(), verbose=False)
+        self.assertEqual(full["divergences"], direct_ndiff)
+        self.assertEqual(full["ok"], direct_ok)
+        self.assertEqual(full["resolved"], "func_01ff97d8")
+
+    def test_no_container_found_still_reads_func_absent(self):
+        """No symbol in the object contains name's range either (resolve_nested_slice
+        returns None for every candidate): the row stays func-absent, same as before
+        this change -- the search must not fabricate a container that is not there."""
+        M, swarm = self._require_compile_stack()
+        import probe_versions
+        import reloc_audit
+        from unittest import mock
+        with mock.patch.object(swarm, "oracle_check", return_value=(False, b"fake-obj")), \
+             mock.patch.object(M, "extract_func", return_value=(None, None)), \
+             mock.patch.object(M, "sole_func_symbol", return_value=None), \
+             mock.patch.object(probe_versions, "funcs_in", return_value={}), \
+             mock.patch.object(reloc_audit, "resolve_nested_slice", return_value=None):
+            full = NDB.evaluate_full("", "func_01ff8df8", b"\x00" * 24,
+                                     module="itcm", addr=0x01ff8df8, size=24)
+        self.assertIsNone(full["divergences"])
+        self.assertEqual(full["status"], "func-absent")
+
+
+@unittest.skipUnless(
+    (TOOLS / "mwccarm" / "2004" / "b56" / "mwccarm.exe").is_file(),
+    "canonical (2004/b56) mwccarm not present")
+class RealCompileResolverFixtures(unittest.TestCase):
+    """Real compiles of the two committed sources tools/test_linkcheck.py's own
+    RealCompileFixtures were written for, run through evaluate_full instead of
+    linkcheck() -- proving the near-miss evaluator and the byte gate now agree on
+    both shapes using the SAME committed source, not just on mocked wiring."""
+
+    def test_dmul_scores_zero_when_evaluated_under_its_alias_row_shape(self):
+        """src/_dmul.c, fed to evaluate_full as if it were a near-miss row's own
+        c_source with the row's zero-declared size (the alias shape), must resolve
+        to the sized twin's real length and read a byte-exact MATCH -- divergences 0,
+        ok True -- the number reeval treats as bankable."""
+        import match as M
+        src = (TOOLS.parent / "src" / "_dmul.c").read_text(encoding="utf-8")
+        full = NDB.evaluate_full(src, "_dmul", b"", module="itcm", addr=0x01ff8708, size=0)
+        self.assertEqual(full["divergences"], 0)
+        self.assertTrue(full["ok"])
+
+    def test_nested_entry_point_scores_zero_from_the_containing_source(self):
+        """src/func_01ff97d8.c compiles to ONE ELF symbol, "func_01ff97d8", 0xb6c
+        bytes; func_01ff98f4 (config size 0xb0) has no symbol of its own anywhere in
+        that object. Fed to evaluate_full as func_01ff98f4's own c_source (the
+        nested shape: a stored near-miss draft that is really the whole containing
+        block), it must slice the containing symbol's compiled body at the right
+        address-resolved offset and read a byte-exact MATCH."""
+        import match as M
+        import reverify_corpus as RV
+        src = (TOOLS.parent / "src" / "func_01ff97d8.c").read_text(encoding="utf-8")
+        target = RV.rom_bytes("itcm", 0x01ff98f4, 0xb0)
+        full = NDB.evaluate_full(src, "func_01ff98f4", target,
+                                 module="itcm", addr=0x01ff98f4, size=0xb0)
+        self.assertEqual(full["divergences"], 0)
+        self.assertTrue(full["ok"])
+        self.assertEqual(full["resolved"], "func_01ff97d8")
+
+
 class EvalPinGuardTests(unittest.TestCase):
     """The committed evaluator pin must agree with the live evaluator.
 


### PR DESCRIPTION
Follow-up to run link100 lane NMDB2 (PR #2540): NMDB2's whole-DB reeval under
match.py-parity scoring (METRIC_REV 2) marked nine ITCM rows unscorable
("func-absent"): the zero-size EABI alias entries and the nested entry points
tools/linkcheck.py's byte gate already resolves for the pre-push check (LINKCHK2,
#2535), because evaluate_full extracted the candidate by exact symbol name and
neither shape defines a symbol under its own name in the compiled object.

Stacked on #2540 (tools/w4-nmdb2 @ 2386ca6ac).

WHAT THIS DOES

1. Extracted reloc_audit.winning_object's inline containing-symbol slice into a
   standalone reloc_audit.resolve_nested_slice(sym, code, relocs, addr, size,
   name_index) -- a pure refactor, same address-anchored arithmetic, so
   winning_object's own behavior is unchanged (test_linkcheck.py's 7 tests,
   including its two real-compile fixtures, still pass unmodified).

2. evaluate_full(src, name, target, module=None, addr=None, size=None,
   name_index=None) -- four new OPTIONAL parameters, so every existing 3-arg call
   site keeps its exact old behavior. When given, it resolves the candidate the same
   two ways tools/linkcheck.py does, imported rather than re-derived:

     * zero-size alias (size == 0): bytegate.alias_target_size(module, addr) finds
       the sized twin's real length; target and size are both replaced (re-read
       from the ROM at the corrected length via reverify_corpus.rom_bytes) before
       extraction or comparison. Same lookup the byte gate makes for _dmul,
       _ll_sdiv, _s32_div_f, _u32_div_f -- a row can never score differently here
       than a fresh linkcheck run would.

     * nested entry point: when the exact-name lookup AND the existing
       sole-symbol fallback both miss, every function the compiled object DOES
       define is checked (via reloc_audit.resolve_nested_slice) for one that
       CONTAINS name's ROM range, resolved by address -- never by scanning source
       text for a label. Found one bug while wiring this in: the pre-existing
       sole_func_symbol fallback fires first and, for an object holding exactly
       one (larger) function, was grabbing that whole container UNSLICED before
       the nested search ever ran -- exactly the shape src/func_01ff97d8.c
       produces (0xb6c bytes, one ELF symbol). Guarded it: the sole-symbol result
       is only trusted when its own compiled length equals the requested size;
       otherwise the guess is undone and the nested search resolves it by
       address instead.

3. ingest/bank_matches/reeval now pass module/addr/size, plus a name_index built
   once per pass (reloc_audit.build_name_index(), process-cached) rather than once
   per row -- the same scan reloc_audit's own audit passes already pay once.

THE NINE ROWS, RE-EVALUATED

Ran `python tools/nearmiss_db.py reeval` (full 56-row DB, not a subset -- the tool
has no --name filter) under the new resolver. All nine stay func-absent:

  _dadd            itcm 0x01ff8000  div None -> UNSCORABLE func-absent
  func_01ff8df8    itcm 0x01ff8df8  div None -> UNSCORABLE func-absent
  func_01ff8e10    itcm 0x01ff8e10  div None -> UNSCORABLE func-absent
  func_01ff9378    itcm 0x01ff9378  div None -> UNSCORABLE func-absent
  func_01ffa440    itcm 0x01ffa440  div None -> UNSCORABLE func-absent
  func_01ffa588    itcm 0x01ffa588  div None -> UNSCORABLE func-absent
  func_01ffa594    itcm 0x01ffa594  div None -> UNSCORABLE func-absent
  _ll_udiv         itcm 0x01ffa9dc  div None -> UNSCORABLE func-absent
  _ull_mod         itcm 0x01ffa9e8  div None -> UNSCORABLE func-absent

reeval: 56 rows -- 47 unchanged, 0 drifted, 9 unscorable, 0 recovered, 0 bankable
applied 56 rows (0 changed under the pass and were left alone)

This is an honest, checked negative, not a shortfall in the fix: all nine rows'
own c_source is the EMPTY STRING (verified directly against nearmiss/db.jsonl at
2386ca6ac) -- floor placeholders from the 2026-08-03 "vendor runtime (no original
C exists)" ROUTING FLOOR pass, never a real near-miss draft. NMDB2's close note
described their SHAPE correctly (extract-by-name fails the same way the two
LINKCHK2 shapes do), but shape alone can't produce a score when there is no
candidate C to compile at all -- src/_dadd.c, src/func_01ff8000.c and the other
seven primaries/aliases in this address range do not exist anywhere in the tree.
No committed src/ file resolves by name or by address either, so there is nothing
for the DB row's own c_source, or a fallback to committed source, to extract. If
a real near-miss draft is ever produced for one of these nine, the resolver added
here will score it correctly on the first pass, same as it now does for the
general shape (see the fixtures below) -- but none of the nine changes today.
nearmiss/db.jsonl and nearmiss/eval_pin.json are byte-identical after the reeval
run (git diff: none), so this PR carries no data changes, tools only.

PARITY TESTS

tools/test_nearmiss_db.py, new EvaluateFullResolverParityTests (mocked wiring, no
compiler needed, matching test_linkcheck.py's own AliasSizeSubstitutionUnit /
NestedOffsetRebaseUnit convention):
  - alias row resolved against its sized twin's target/size (and the byte-exact
    MATCH case: divergences 0, ok True)
  - nested entry point found inside its containing symbol via
    reloc_audit.resolve_nested_slice
  - no container found still reads func-absent (the search must not fabricate one)

New RealCompileResolverFixtures (skips without the canonical 2004/b56 compiler,
same convention as test_linkcheck.py's RealCompileFixtures): compiles the actual
committed src/_dmul.c and src/func_01ff97d8.c through evaluate_full under the
alias-row and nested-row shapes respectively -- both read divergences 0, ok True;
the nested one additionally asserts resolved == "func_01ff97d8".

VERIFICATION

  python -m unittest tools.test_linkcheck -v          7 tests, OK (refactor of
                                                        winning_object unchanged
                                                        behavior, incl. both real-
                                                        compile fixtures)
  python -m unittest tools.test_nearmiss_db -v         47 tests, OK (41 pre-existing
                                                        + 6 new: 4 parity + 2 real-
                                                        compile fixtures)
  python -m unittest -v <the 37-module CI tool-tests.yml list>
                                                        731 tests, OK (skipped=2,
                                                        pre-existing/unrelated --
                                                        zero FAIL/ERROR)
  python tools/check_python_names.py                   PASS: 287 files, 0
                                                        unresolvable names
  python tools/check_dead_references.py                PASS: no new dead
                                                        references, no broken
                                                        markdown links
  python tools/nearmiss_db.py dedupe --check            check ok: no duplicate
                                                        (module, addr) rows; DB
                                                        has 56 entries

FILES TOUCHED

  tools/nearmiss_db.py       evaluate_full widened + guarded sole-symbol fallback;
                             ingest/bank_matches/reeval pass module/addr/size/
                             name_index; new _name_index() process cache
  tools/reloc_audit.py       new resolve_nested_slice(); winning_object calls it
                             instead of the inline version (behavior-preserving)
  tools/test_nearmiss_db.py  EvaluateFullResolverParityTests,
                             RealCompileResolverFixtures

Branch: tools/w4-nmdb3, tip 9b7e87272, stacked on tools/w4-nmdb2 @ 2386ca6ac
(PR #2540).
