### PR TITLE
pr_linkcheck.py: carry the nested-entry-point offset and the alias size into LC.linkcheck

### DIFF
--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -236,14 +236,19 @@ def link_function(code, addr, relocs):
 
 
 def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=(),
-              obj=None, sym=None):
+              obj=None, sym=None, off=0):
     """Verdict + detail for one banked match.
 
     Normally compiles the source that defines `name` (reloc_audit.winning_object) and
     checks the reproduced bytes. A caller that already holds the compiled object -- e.g.
     pr_linkcheck checking a compiler-emitted passenger (a this-adjusting thunk or a weak
     dtor/ctor copy) that has no source file of its own -- passes obj=<object bytes> and
-    sym=<symbol to extract> so the symbol is link-checked straight from that object.
+    sym=<symbol to extract> so the symbol is link-checked straight from that object. When
+    the pre-supplied object is a NESTED entry point's containing symbol rather than the
+    symbol itself (reloc_audit.winning_object's fourth return value -- see its docstring),
+    that same caller must also pass `off`, the byte offset of `name`'s own range inside
+    `sym`'s compiled span; this function does not re-derive it when `obj` is pre-supplied,
+    because a pre-supplied object skips the winning_object call that computes it.
 
     A zero-size `size` is an EABI alias name for a differently-named, correctly-sized
     primary function at the same address (e.g. _dmul, size 0, aliasing func_01ff8708,
@@ -251,14 +256,16 @@ def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=()
     byte-compared and every alias used to read NO-SYM regardless of its source. Verify
     against the sized twin's real range instead, still reported under the requested
     (alias) name; bytegate.alias_target_size is the one place that lookup is made, the
-    same scan progress.py's own matched-count already trusts for this address shape."""
+    same scan progress.py's own matched-count already trusts for this address shape.
+    This substitution runs unconditionally, whether or not `obj` is pre-supplied, so a
+    pre-supplied zero-size alias is corrected here even if the caller passed the raw
+    (unresolved) size through."""
     import reverify_corpus as RV
     if size == 0:
         import bytegate as BG
         alt = BG.alias_target_size(mod, addr)
         if alt:
             size = alt
-    off = 0
     if obj is None:
         obj, sym, err, off = RA.winning_object(name, addr, size, mod, candidate,
                                                include_dirs, name_index)

--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -196,6 +196,7 @@ def check_file(path, idx, ledger):
                 "results": [], "note": "unresolved"}
 
     import reloc_audit as RA
+    import bytegate as BG
     results, checked_passengers = [], set()
     for sym, slots in named:
         # ONE OBJECT PER OWNED SYMBOL, not one per file. `winning_object` runs the
@@ -206,18 +207,36 @@ def check_file(path, idx, ledger):
         # Reset VERIFIED, SceneNode() NO-SYM; per-symbol -> both VERIFIED.) For the
         # ordinary one-function sources this is exactly one call, as before.
         obj = wsym = None
+        off = 0
         for addr, size, mod in slots:
-            # offset discarded: this caller pre-supplies obj/sym straight into
-            # LC.linkcheck below rather than letting it call winning_object itself, so
-            # a nonzero nested-entry-point offset has nowhere to go here. Unaffected
-            # for the ordinary one-symbol-per-object case this loop was built for;
-            # see tools/linkcheck.py's own winning_object call for the nested path.
-            obj, wsym, _, _off = RA.winning_object(sym, addr, size, mod, name_index=_NAME_INDEX)
+            # Mirror linkcheck.linkcheck's own resolution order exactly, since this loop
+            # pre-supplies obj/sym into LC.linkcheck below instead of letting it call
+            # winning_object itself: correct a zero-size EABI alias record to its sized
+            # twin's real length (bytegate.alias_target_size) BEFORE calling
+            # winning_object, the same substitution linkcheck() applies at its own top --
+            # a raw zero-size request can never resolve here (rom_bytes(...,0) is an
+            # empty target no compiled candidate's length ever equals), which used to
+            # send every alias through the `obj is None` fallback below instead of
+            # resolving directly. And carry `off`, the fourth element winning_object
+            # returns: nonzero when `sym` is a NESTED entry point's CONTAINING symbol
+            # rather than the symbol itself (a hand-asm block packing several ROM
+            # functions into one compiled body, e.g. func_01ff97d8.c). Both matter
+            # together for a symbol like _deq -- an alias (size 0) whose sized twin,
+            # func_01ff9d40, is itself a nested entry point: the size fix is what makes
+            # winning_object see a nonzero range at all, and the offset fix is what
+            # slices that range at the right place once it does.
+            csize = size
+            if csize == 0:
+                alt = BG.alias_target_size(mod, addr)
+                if alt:
+                    csize = alt
+            obj, wsym, _, off = RA.winning_object(sym, addr, csize, mod, name_index=_NAME_INDEX)
             if obj is not None:
                 break
         for addr, size, mod in slots:
             r = LC.linkcheck(sym, addr, size, mod, _NAME_INDEX,
-                             obj=obj, sym=(wsym if obj is not None else None))
+                             obj=obj, sym=(wsym if obj is not None else None),
+                             off=(off if obj is not None else 0))
             results.append({"sym": sym, "addr": f"0x{addr:08x}", "module": mod,
                             "verdict": r["verdict"], "diffs": r.get("diffs", []),
                             "passenger": False})

--- a/tools/test_pr_linkcheck.py
+++ b/tools/test_pr_linkcheck.py
@@ -1,0 +1,298 @@
+"""tools/pr_linkcheck.py's pre-supplied-object path: it now resolves a nested
+entry point and a zero-size EABI alias record exactly as tools/linkcheck.py's
+own corpus/--name path does, instead of losing the offset winning_object
+returns.
+
+WHY THIS EXISTS
+---------------
+LINKCHK2 (#2535) taught tools/linkcheck.py the two len-mismatch shapes the byte
+gate could not verify -- a zero-size EABI alias record (a second name for a
+differently-named, correctly-sized primary function at the same address, e.g.
+_dmul aliasing func_01ff8708) and a nested entry point (a symbol whose ROM
+range sits inside a containing symbol's compiled span, e.g. func_01ff98f4
+inside func_01ff97d8.c's 0xb6c bytes) -- but its own PR text named one caller
+left behind: tools/pr_linkcheck.py pre-supplies obj/sym straight into
+LC.linkcheck rather than letting it call reloc_audit.winning_object itself, so
+a nonzero nested-entry-point offset had nowhere to go, and the caller's own
+first-loop winning_object call used the raw (unresolved) size for an alias
+record, never the corrected one linkcheck() substitutes at its own top.
+
+Measured directly against the real rows LINKCHK2's own PR text named (see
+out/LINKCHK2/pr.txt and out/PRLINKNEST/pr.txt in the run directory). Before
+this fix:
+
+    python tools/pr_linkcheck.py --files src/func_01ff97d8.c
+      NO-SYM src/func_01ff97d8.c  (6 slot(s))
+
+Four of its six owned symbols -- every nested entry point with a nonzero own
+size (func_01ff98f4, func_01ff99a4, func_01ff9d40, func_01ff9e2c) -- read
+NO-SYM; only the container itself (off=0, the ordinary case) and the zero-size
+alias _deq (which happened to self-heal through the `obj is None` fallback,
+since its own first-loop winning_object call always failed on the raw size
+and fell through to linkcheck()'s internal resolution) verified. After:
+
+    ok      src/func_01ff97d8.c  (6 slot(s))
+
+All six VERIFIED. A 34-file control sample of ordinary (non-alias,
+non-nested) src files -- spanning arm9, itcm and four overlays -- is
+byte-identical before and after this change.
+
+THE FIX, two parts
+-------------------
+linkcheck.linkcheck() takes an explicit `off=0` parameter now instead of
+hard-resetting it to 0 whenever `obj` is pre-supplied, so a caller that
+already resolved a nested entry point's offset (via its own winning_object
+call) can carry it through.
+
+pr_linkcheck.check_file's first loop mirrors linkcheck()'s own resolution
+order exactly: it corrects a zero-size alias record to its sized twin's real
+length (bytegate.alias_target_size -- imported, not copied; the same helper
+linkcheck() calls) BEFORE calling winning_object, then threads the offset
+winning_object returns into LC.linkcheck via off=. Both parts matter together
+for a symbol shaped like _deq -- an alias whose sized twin is itself a nested
+entry point: the size fix is what makes winning_object see a resolvable
+(nonzero) range at all, and the offset fix is what slices that range at the
+right place once it does.
+
+The tests below mock at the same winning_object/extract_func/
+func_relocs_typed/rom_bytes boundary tools/test_linkcheck.py's
+NestedOffsetRebaseUnit does, for the same reason stated there: a real compile
+alone cannot prove the offset ARITHMETIC is correct rather than accidentally
+vacuous (any sub-slice of an already-byte-perfect span trivially matches
+wherever you cut it). These construct a synthetic containing symbol where the
+right slice is known by hand and assert the exact window -- start, length,
+and content -- handed to link_function, the function that actually applies
+the relocations and does the byte compare, not just the final verdict; and,
+for the two shapes off= exists to fix, call linkcheck() the way the pre-fix
+pr_linkcheck.py always did (off hard-defaulted to 0, discarding whatever
+winning_object actually returned) next to the way it does now, so the same
+mocked fixture pins both the broken and the fixed behavior in one place.
+
+    python -m unittest tools.test_pr_linkcheck -v
+"""
+import contextlib
+import pathlib
+import struct
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import linkcheck as LC        # noqa: E402
+import reloc_audit as RA      # noqa: E402
+import reverify_corpus as RV  # noqa: E402
+import bytegate as BG         # noqa: E402
+import pr_linkcheck as PL     # noqa: E402
+
+
+def _spy(fn, calls):
+    """Wrap `fn` so every call's args land in `calls`, then runs it for real."""
+    def wrapped(*a, **kw):
+        calls.append(a)
+        return fn(*a, **kw)
+    return wrapped
+
+
+class NestedOffsetMustBeThreadedThroughLinkcheck(unittest.TestCase):
+    """func_01ff98f4's own shape: NOT an alias (its config row carries its own
+    real, nonzero size), but winning_object's own object is the CONTAINING
+    symbol's (func_01ff97d8, 0xb6c bytes in the real tree) -- the offset is
+    the only thing that says where inside it `name`'s own bytes start.
+
+    A 0x54-byte containing symbol: 0x50 bytes of unrelated prefix (comfortably
+    past link_function's 0x40 split-symbol-carrier overhang bound, so that
+    branch is never in play here -- the real func_01ff97d8/func_01ff98f4 gap
+    is 0xa80 bytes, the same shape), then the 4-byte nested function body
+    itself -- one R_ARM_ABS32 pool slot, zero until the linker fills it.
+    Addresses are chosen well outside every real module image so is_benign's
+    real-ROM veneer/twin checks -- which read actual module bytes -- are
+    mocked out rather than relied on to see nothing."""
+
+    CONTAINER_CODE = b"\x11" * 0x50 + b"\x00\x00\x00\x00"
+    NESTED_ADDR = 0x02000050
+    RELOC_TARGET = 0xEE001000
+
+    def _run(self, off, calls):
+        target = struct.pack("<I", self.RELOC_TARGET)
+        relocs = [{"off": 0x50, "type": LC.R_ARM_ABS32, "sym": "in_range",
+                   "addr": self.RELOC_TARGET, "add": 0}]
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch.object(
+                LC.M, "extract_func", return_value=(self.CONTAINER_CODE, set())))
+            stack.enter_context(mock.patch.object(LC, "func_relocs_typed", return_value=relocs))
+            stack.enter_context(mock.patch.object(RV, "rom_bytes", return_value=target))
+            stack.enter_context(mock.patch.object(LC, "is_benign", return_value=False))
+            stack.enter_context(mock.patch.object(LC, "is_interwork", return_value=False))
+            stack.enter_context(mock.patch.object(
+                LC, "link_function", side_effect=_spy(LC.link_function, calls)))
+            return LC.linkcheck("func_01ff98f4", self.NESTED_ADDR, 4, "itcm", {},
+                                obj=b"OBJ", sym="func_01ff97d8", off=off)
+
+    def test_off_0_the_pre_fix_default_compares_the_wrong_window_and_fails(self):
+        """Calling linkcheck() the way pre-fix pr_linkcheck.py always did --
+        obj/sym pre-supplied, off left at its old hard-reset value of 0 --
+        never even reaches a byte comparison: the container's own full,
+        un-sliced length (0x54) can never equal the nested target's real
+        length (4), so it returns NO-SYM (len-mismatch) before link_function
+        is called at all. Proven, not asserted: link_function is spied and
+        must see zero calls."""
+        calls = []
+        r = self._run(off=0, calls=calls)
+        self.assertEqual(r["verdict"], "NO-SYM")
+        self.assertEqual(r["reason"], "len-mismatch")
+        self.assertEqual(calls, [])
+
+    def test_off_threaded_through_compares_the_real_sliced_window_and_verifies(self):
+        """Same object, same symbol, off=0x50 -- exactly what winning_object
+        itself would have returned. Asserts the WINDOW handed to
+        link_function, not just the verdict: it must be the 4 bytes at
+        container offset 0x50:0x54, not the container's own first 4 bytes and
+        not the whole 0x54-byte span."""
+        calls = []
+        r = self._run(off=0x50, calls=calls)
+        self.assertEqual(r["verdict"], "VERIFIED")
+        self.assertEqual(len(calls), 1)
+        code_seen = calls[0][0]
+        self.assertEqual(len(code_seen), 4)
+        self.assertEqual(code_seen, self.CONTAINER_CODE[0x50:0x54])
+        self.assertNotEqual(code_seen, self.CONTAINER_CODE[0:4])
+
+
+class AliasOfANestedEntryPointMustBeThreadedThroughLinkcheck(unittest.TestCase):
+    """_deq's own shape: a zero-size EABI alias record whose sized twin
+    (func_01ff9d40 in the real tree) is ITSELF a nested entry point. Both
+    fixes have to fire together: alias_target_size substitutes the real size
+    (4, here) before the length checks run, and the offset has to reach the
+    slice the same way the plain-nested case above needs it to."""
+
+    CONTAINER_CODE = b"\x22" * 0x50 + b"\x00\x00\x00\x00"
+    ALIAS_ADDR = 0x02000050
+    RELOC_TARGET = 0xEE002000
+
+    def _run(self, off, calls=None):
+        target = struct.pack("<I", self.RELOC_TARGET)
+        relocs = [{"off": 0x50, "type": LC.R_ARM_ABS32, "sym": "in_range",
+                   "addr": self.RELOC_TARGET, "add": 0}]
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch.object(BG, "alias_target_size", return_value=4))
+            stack.enter_context(mock.patch.object(
+                LC.M, "extract_func", return_value=(self.CONTAINER_CODE, set())))
+            stack.enter_context(mock.patch.object(LC, "func_relocs_typed", return_value=relocs))
+            stack.enter_context(mock.patch.object(RV, "rom_bytes", return_value=target))
+            stack.enter_context(mock.patch.object(LC, "is_benign", return_value=False))
+            stack.enter_context(mock.patch.object(LC, "is_interwork", return_value=False))
+            if calls is not None:
+                stack.enter_context(mock.patch.object(
+                    LC, "link_function", side_effect=_spy(LC.link_function, calls)))
+            return LC.linkcheck("_deq", self.ALIAS_ADDR, 0, "itcm", {},
+                                obj=b"OBJ", sym="func_01ff97d8", off=off)
+
+    def test_off_0_compares_the_wrong_window_even_with_the_size_corrected(self):
+        """The alias-size substitution alone is not enough: with off left at
+        the pre-fix default of 0, the corrected (4-byte) target is compared
+        against the container's own first 4 bytes -- the wrong window -- not
+        the nested body at offset 0x50. Those first 4 bytes are 0x22222222,
+        never equal to the RELOC_TARGET word the ROM target encodes, so this
+        reads WRONG, not VERIFIED: a false negative on a genuinely correct
+        source, exactly the class of bug a silently wrong slice produces."""
+        r = self._run(off=0)
+        self.assertNotEqual(r["verdict"], "VERIFIED")
+
+    def test_off_threaded_through_compares_the_real_sliced_window_and_verifies(self):
+        calls = []
+        r = self._run(off=0x50, calls=calls)
+        self.assertEqual(r["verdict"], "VERIFIED")
+        self.assertEqual(len(calls), 1)
+        code_seen = calls[0][0]
+        self.assertEqual(len(code_seen), 4)
+        self.assertEqual(code_seen, self.CONTAINER_CODE[0x50:0x54])
+
+
+class CheckFileResolvesAndThreadsBeforeCallingLinkcheck(unittest.TestCase):
+    """End-to-end through pr_linkcheck.check_file itself, not just
+    linkcheck.linkcheck: proves check_file's own first loop -- the one that
+    pre-supplies obj/sym -- applies the size correction and captures the
+    offset from ITS OWN winning_object call, the way the two classes above
+    prove linkcheck() uses them once handed in."""
+
+    CONTAINER_CODE = b"\x33" * 0x50 + b"\x00\x00\x00\x00"
+    ADDR = 0x02000050
+    RELOC_TARGET = 0xEE003000
+
+    def test_nested_owned_symbol_resolved_via_check_files_own_winning_object_call(self):
+        idx = {"nested_child": [(self.ADDR, 4, "itcm")]}
+        target = struct.pack("<I", self.RELOC_TARGET)
+        relocs = [{"off": 0x50, "type": LC.R_ARM_ABS32, "sym": "in_range",
+                   "addr": self.RELOC_TARGET, "add": 0}]
+        calls = []
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch.object(PL.SP, "symbols_for",
+                                                   return_value=["nested_child"]))
+            wo = stack.enter_context(mock.patch.object(
+                RA, "winning_object",
+                return_value=(b"OBJ", "func_container", None, 0x50)))
+            stack.enter_context(mock.patch.object(
+                LC.M, "extract_func", return_value=(self.CONTAINER_CODE, set())))
+            stack.enter_context(mock.patch.object(LC, "func_relocs_typed", return_value=relocs))
+            stack.enter_context(mock.patch.object(RV, "rom_bytes", return_value=target))
+            stack.enter_context(mock.patch.object(LC, "is_benign", return_value=False))
+            stack.enter_context(mock.patch.object(LC, "is_interwork", return_value=False))
+            stack.enter_context(mock.patch.object(
+                LC, "link_function", side_effect=_spy(LC.link_function, calls)))
+            rep = PL.check_file("fake/nested_child.c", idx, {})
+        # winning_object was asked with the owned symbol's own nonzero size
+        # (this row is not an alias, nothing to correct).
+        self.assertEqual(wo.call_args.args[2], 4)
+        self.assertEqual(rep["results"][0]["verdict"], "VERIFIED")
+        self.assertEqual(calls[0][0], self.CONTAINER_CODE[0x50:0x54])
+
+    def test_alias_child_gets_the_size_corrected_before_winning_object_is_called(self):
+        """_deq's shape again, driven through check_file: idx (the config
+        symbol index check_file resolves owned symbols against) carries the
+        alias's raw recorded size, 0. check_file's first loop must correct it
+        to the sized twin's real length (4, mocked via alias_target_size)
+        BEFORE calling winning_object -- a fake winning_object that still
+        sees a raw 0 returns len-mismatch, the pre-fix shape, which would
+        read NO-SYM here rather than VERIFIED."""
+        idx = {"alias_child": [(self.ADDR, 0, "itcm")]}
+        target = struct.pack("<I", self.RELOC_TARGET)
+        relocs = [{"off": 0x50, "type": LC.R_ARM_ABS32, "sym": "in_range",
+                   "addr": self.RELOC_TARGET, "add": 0}]
+        sizes_seen = []
+
+        def fake_winning_object(name, addr, size, mod, *rest, **kwargs):
+            sizes_seen.append(size)
+            if size == 0:
+                return None, None, "len-mismatch", 0
+            return b"OBJ", "func_container", None, 0x50
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch.object(PL.SP, "symbols_for",
+                                                   return_value=["alias_child"]))
+            alt = stack.enter_context(mock.patch.object(
+                BG, "alias_target_size", return_value=4))
+            stack.enter_context(mock.patch.object(
+                RA, "winning_object", side_effect=fake_winning_object))
+            stack.enter_context(mock.patch.object(
+                LC.M, "extract_func", return_value=(self.CONTAINER_CODE, set())))
+            stack.enter_context(mock.patch.object(LC, "func_relocs_typed", return_value=relocs))
+            stack.enter_context(mock.patch.object(RV, "rom_bytes", return_value=target))
+            stack.enter_context(mock.patch.object(LC, "is_benign", return_value=False))
+            stack.enter_context(mock.patch.object(LC, "is_interwork", return_value=False))
+            rep = PL.check_file("fake/alias_child.c", idx, {})
+        # Called from check_file's own first loop, and again inside
+        # LC.linkcheck's unconditional top-of-function substitution (linkcheck
+        # re-derives it independently -- the same "both call sites need it"
+        # shape LINKCHK2's own AliasSizeSubstitutionUnit test pins) -- both
+        # calls see the real address, never a stale or wrong one.
+        self.assertEqual(alt.call_count, 2)
+        for args, _kwargs in alt.call_args_list:
+            self.assertEqual(args, ("itcm", self.ADDR))
+        # winning_object itself is never asked with the raw, uncorrected 0 --
+        # that is the len-mismatch dead end the pre-fix caller always hit.
+        self.assertEqual(sizes_seen, [4])
+        self.assertEqual(rep["results"][0]["verdict"], "VERIFIED")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THE GAP

LINKCHK2 (#2535, merged, tip d071cec7b) taught tools/linkcheck.py the two
symbol shapes the byte gate could not verify: a zero-size EABI alias record
(a second name for a differently-named, correctly-sized primary function at
the same address, e.g. _dmul aliasing func_01ff8708) and a nested entry point
(a symbol whose ROM range sits inside a containing symbol's compiled span,
e.g. func_01ff98f4 inside func_01ff97d8.c's hand-asm 0xb6c-byte body).
reloc_audit.winning_object's fourth return value carries the nested offset;
linkcheck() slices the code and rebases the relocations at that offset when it
calls winning_object itself.

One caller was left behind and said so in its own comment: tools/pr_linkcheck.py
around lines 208-216 pre-supplies obj/sym straight into LC.linkcheck rather than
letting it call winning_object itself, so "a nonzero nested-entry-point offset
has nowhere to go here." Measured directly: `python tools/pr_linkcheck.py
--files src/func_01ff97d8.c` read

    NO-SYM src/func_01ff97d8.c  (6 slot(s))

Four of its six owned symbols -- every nested entry point with a nonzero own
size (func_01ff98f4, func_01ff99a4, func_01ff9d40, func_01ff9e2c) -- NO-SYM.
Only the container itself (off=0, the ordinary case) and the zero-size alias
_deq (which happened to self-heal through the `obj is None` fallback, since
its own first-loop winning_object call always failed on the raw uncorrected
size and fell through to linkcheck()'s internal resolution) verified. A PR
enrolling a nested entry point -- there are four live ones on main today --
would fail this gate on a source that is byte-correct.

THE FIX, two places

tools/linkcheck.py's `linkcheck()` takes an explicit `off=0` parameter now
instead of hard-resetting it to 0 whenever `obj` is pre-supplied. The
zero-size alias substitution (bytegate.alias_target_size) was already
unconditional -- it ran whether or not `obj` was pre-supplied -- so only the
offset needed a way in.

tools/pr_linkcheck.py's `check_file`, first loop: mirrors linkcheck()'s own
resolution order exactly, since this is the loop that pre-supplies obj/sym.
It now corrects a zero-size alias record to its sized twin's real length
(bytegate.alias_target_size -- imported, not copied; the same helper
linkcheck() calls) BEFORE calling winning_object, then carries the offset
winning_object returns into LC.linkcheck via `off=`. Both parts matter
together for a symbol shaped like _deq -- an alias whose sized twin
(func_01ff9d40) is itself a nested entry point: the size fix is what makes
winning_object see a resolvable (nonzero) range at all, and the offset fix is
what slices that range at the right place once it does. The stale "offset
discarded" comment is deleted; it is no longer true.

THE REAL ROW, before/after

    python tools/pr_linkcheck.py --files src/func_01ff97d8.c

    before:
      NO-SYM src/func_01ff97d8.c  (6 slot(s))
        func_01ff97d8  VERIFIED   (off=0, the container itself -- unaffected)
        func_01ff98f4  NO-SYM     (nested, offset discarded -> len-mismatch)
        func_01ff99a4  NO-SYM     (nested, offset discarded -> len-mismatch)
        _deq           VERIFIED   (alias-of-nested, self-healed via fallback)
        func_01ff9d40  NO-SYM     (nested, offset discarded -> len-mismatch)
        func_01ff9e2c  NO-SYM     (nested, offset discarded -> len-mismatch)

    after:
      ok      src/func_01ff97d8.c  (6 slot(s))
        func_01ff97d8  VERIFIED
        func_01ff98f4  VERIFIED
        func_01ff99a4  VERIFIED
        _deq           VERIFIED
        func_01ff9d40  VERIFIED
        func_01ff9e2c  VERIFIED

The other four ITCM alias-only rows (`python tools/pr_linkcheck.py --files
src/_dmul.c src/_ll_sdiv.c src/_s32_div_f.c src/_u32_div_f.c`) already read
VERIFIED before and after -- their first-loop winning_object call always
failed on the raw size and fell through to linkcheck()'s own internal
resolution, which already applied the size substitution unconditionally.
Confirmed unchanged, not assumed: see the control diff below.

All nine rows LINKCHK2's own PR text named, both gates now agree:
_dmul, _ll_sdiv, _s32_div_f, _u32_div_f, func_01ff98f4, func_01ff99a4, _deq,
func_01ff9d40, func_01ff9e2c -> all VERIFIED under pr_linkcheck.py.
(out/PRLINKNEST/nested_container_before.json, out/PRLINKNEST/itcm9_rows_after.json)

CONTROL -- 34 ordinary (non-alias, non-nested) files, byte-identical before/after

A 30-file random sample across arm9, itcm and four overlays
(out/PRLINKNEST/control_sample_30files.txt) plus the four plain-alias files
and the nested-container file, 35 files total, run through
`pr_linkcheck.py --files` on the pre-fix code (git-stashed) and the fixed
code. Diffed programmatically, not just by eyeballing the printed lines: of
35 files, 34 are byte-identical JSON reports before and after; the one that
differs is func_01ff97d8.c (NO-SYM -> VERIFIED, the fix). No other file's
verdict, diffs, or symbol list moved.
(out/PRLINKNEST/control_before.json, out/PRLINKNEST/control_after.json)

TESTS -- tools/test_pr_linkcheck.py, new (pr_linkcheck.py had no dedicated
test module before this; the two existing test_pr_linkcheck_*.py files cover
the rename-scope and source-policy logic, not the resolution path)

Six tests, three classes, none needing the toolchain (pure mock, no
compiler, no ROM -- the same convention tools/test_linkcheck.py's
NestedOffsetRebaseUnit and AliasSizeSubstitutionUnit use, and for the same
reason: a real compile alone cannot distinguish correct offset arithmetic
from an accidentally-vacuous match).

  * NestedOffsetMustBeThreadedThroughLinkcheck -- func_01ff98f4's shape
    (nonzero own size, container object). Calls LC.linkcheck directly with
    off=0 (the pre-fix hard-reset value) and off=0x50 (what winning_object
    would have returned) against the SAME mocked container/target/relocs.
    off=0 never reaches a byte comparison at all (link_function spied, zero
    calls; len(code)=0x54 can never equal len(target)=4, so it returns
    NO-SYM/len-mismatch immediately) -- a more precise finding than "compares
    the wrong window": it never gets to compare anything. off=0x50 verifies,
    and the window handed to link_function is asserted directly: 4 bytes,
    equal to CONTAINER_CODE[0x50:0x54], not equal to CONTAINER_CODE[0:4].

  * AliasOfANestedEntryPointMustBeThreadedThroughLinkcheck -- _deq's own
    compound shape (size 0, sized twin is itself nested). Here the length IS
    corrected (alias_target_size mocked to 4) before the checks run, so
    off=0 DOES reach a byte comparison -- against the wrong 4 bytes (the
    container's own first 4, all 0x22) -- and reads WRONG, not VERIFIED: a
    false negative on a genuinely correct source. off=0x50 compares the
    right window and verifies, asserted the same way.

  * CheckFileResolvesAndThreadsBeforeCallingLinkcheck -- end-to-end through
    pr_linkcheck.check_file itself (not just linkcheck.linkcheck), proving
    check_file's own first loop is what supplies the corrected size and the
    real offset. The alias case asserts winning_object is asked with the
    CORRECTED size (4) and never the raw 0 (a fake winning_object that still
    sees 0 returns len-mismatch, the pre-fix dead end), and that
    alias_target_size is called twice -- once from check_file's own first
    loop, once again inside LC.linkcheck's unconditional top-of-function
    substitution -- both times with the real address.

All six fail against the pre-fix code (verified directly: git-stashed
tools/linkcheck.py and tools/pr_linkcheck.py, reran the same test file, 2
TypeError on the missing off= kwarg, 2 AssertionError on the wrong verdict, 2
AssertionError on the wrong call count/argument -- restored, reran, all six
pass) and pass against the fix.

    python -m unittest tools.test_pr_linkcheck -v
    Ran 6 tests -- OK

Together with the two existing pr_linkcheck test modules and
tools/test_linkcheck.py (unaffected, still 7/7):

    python -m unittest tools.test_pr_linkcheck tools.test_linkcheck \
        tools.test_pr_linkcheck_verdict tools.test_pr_linkcheck_renames -v
    Ran 26 tests -- OK
(out/PRLINKNEST/unit_tests.log)

Not wired into .github/workflows/tool-tests.yml's enumerated list. Flagged as
a gap, not folded in silently: the two existing test_pr_linkcheck_*.py
modules (renames, verdict logic) are not wired in either -- pr_linkcheck.py's
own import chain was never remeasured against the pinned pyelftools+capstone
wheels the way linkcheck.py's was (tool-tests.yml's own comment: "the other
21 elftools modules ... are not known to be wirable ... a fresh measurement,
not a corollary"). Wiring all three test_pr_linkcheck_*.py modules together
is a reasonable follow-up; it is a decision about what CI runs, not a
consequence of this fix, and out of this lane's scope.

CI tool-tests list, run whole (the list in .github/workflows/tool-tests.yml,
unchanged by this branch -- confirms nothing already wired regressed)

    Ran 731 tests in 442.4s -- OK (skipped=2)
(707 at LINKCHK2's own measurement; the +24 predates this branch -- other
lanes landed tests into already-enumerated modules since LINKCHK2 merged.
None of the delta is in this branch's diff: it touches only
tools/linkcheck.py, tools/pr_linkcheck.py, and the new, unwired
tools/test_pr_linkcheck.py.)
(out/PRLINKNEST/ci_tool_tests.log)

check_python_names: PASS (0 unresolvable names, 0 unparseable files, 52
advisory findings -- confirmed identical with this branch's two changed
files stashed out, so none of the 52 are new; none names pr_linkcheck.py,
linkcheck.py, or test_pr_linkcheck.py).
(out/PRLINKNEST/check_python_names.log)

check_dead_references: no new dead references, no broken markdown links (the
same 3 baselined prose references and 4 baselined C/C++ comment references
prior lanes reported, unchanged, pre-existing, not touched here).
(out/PRLINKNEST/check_dead_references.log)

FILES TOUCHED

    tools/linkcheck.py         linkcheck(): explicit off=0 parameter instead
                                of hard-resetting it to 0 whenever `obj` is
                                pre-supplied
    tools/pr_linkcheck.py      check_file()'s first loop: alias-size
                                correction before calling winning_object
                                (mirrors linkcheck()'s own order), off
                                threaded into the LC.linkcheck call below;
                                the stale "offset discarded" comment deleted
    tools/test_pr_linkcheck.py new -- 6 tests, 3 classes, no toolchain needed

Branch tools/w4-prlinknest off origin/main bb3d798c5, tip 86da060e5.
Not pushed, no PR opened, per brief.
