### PR TITLE
Preserve contributor checks across renamed and consolidated members

### DIFF
--- a/tools/prepush_attribution.py
+++ b/tools/prepush_attribution.py
@@ -113,6 +113,15 @@ def member_overrides_at(rev):
     return {symbol: member for symbol, member in out.items() if symbol not in ambiguous}
 
 
+def source_paths_at(rev):
+    """Only source files present in this revision can own contributor credit."""
+    paths = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", rev, "--", "src/"],
+        cwd=REPO, capture_output=True, text=True, encoding="utf-8",
+        errors="replace", check=True).stdout.splitlines()
+    return {path for path in paths if path.endswith((".c", ".cpp"))}
+
+
 def function_ownership_at(rev):
     """Use the merge validator's revision-scoped symbol and delinks ownership."""
     import validate_merge as VM
@@ -121,7 +130,27 @@ def function_ownership_at(rev):
     VM.REPO = REPO
     try:
         # The enrolment cache is revision keyed; resolve HEAD before consulting it.
-        return VM.function_snapshot(VM.resolve_commit(rev))["matched"]
+        rev = VM.resolve_commit(rev)
+        matched = VM.function_snapshot(rev)["matched"]
+        claims, symbols = {}, set()
+        for path in VM.tree_paths(rev, "config/arm9"):
+            module = VM._module_from_symbols(path)
+            if module is None:
+                continue
+            for line in VM.git_text(rev, path).splitlines():
+                row = VM.FUNC_RE.match(line)
+                if not row:
+                    continue
+                name, size, addr = row.group(1), int(row.group(2), 16), int(row.group(3), 16)
+                symbols.add(name)
+                if size:
+                    key = f"{module}:0x{addr:08x}"
+                    claims.setdefault(key, set()).add((name, size))
+        # The snapshot chooses one record per address. That is sound for a real
+        # function plus zero-size aliases, but competing bodies do not establish
+        # unique ownership. Never let their row order choose whose credit survives.
+        ambiguous = {key for key, rows in claims.items() if len(rows) > 1}
+        return matched, ambiguous, symbols
     finally:
         VM.REPO = old_repo
 
@@ -150,7 +179,8 @@ def lineage(rev):
     overrides = overrides_at(rev)
     data = attribution_at(rev)
     out = {}
-    for path in set(first) | set(finishers) | set(overrides):
+    paths = source_paths_at(rev)
+    for path in (set(first) | set(finishers) | set(overrides)) & paths:
         who = overrides.get(path) or canonical_author(finishers.get(path) or first.get(path), data)
         if who:
             out[path.rsplit(".", 1)[0]] = who
@@ -279,18 +309,16 @@ def main():
             moved_ok.append((name, old_stem, new_stem, old_who))
     missing = {name: old for name, old in projected.items() if name not in after_by_name}
     if missing:
-        base_functions = function_ownership_at(args.base)
-        head_functions = function_ownership_at(args.head)
+        base_functions, base_ambiguous, base_symbols = function_ownership_at(args.base)
+        head_functions, head_ambiguous, _head_symbols = function_ownership_at(args.head)
+        ambiguous = base_ambiguous | head_ambiguous
         by_stem = {}
         for key, rec in base_functions.items():
             by_stem.setdefault(rec["srcPath"].rsplit(".", 1)[0], []).append((key, rec))
         base_overrides = credit_overrides_at(args.base)
         head_overrides = credit_overrides_at(args.head)
         members = member_overrides_at(args.head)
-        head_paths = set(subprocess.run(
-            ["git", "ls-tree", "-r", "--name-only", args.head, "--", "src/"],
-            cwd=REPO, capture_output=True, text=True, encoding="utf-8",
-            errors="replace", check=True).stdout.splitlines())
+        head_paths = source_paths_at(args.head)
         for name, (old_stem, old_who) in missing.items():
             owned = by_stem.get(old_stem)
             if owned:
@@ -300,7 +328,8 @@ def main():
                     old_author = base_overrides.get(f"{rec['srcPath']}#{rec['name']}") or old_who
                     dest = head_functions.get(key)
                     new_author = (head_overrides.get(f"{dest['srcPath']}#{dest['name']}")
-                                  if dest and dest["size"] == rec["size"] else None)
+                                  if dest and dest["size"] == rec["size"]
+                                  and key not in ambiguous else None)
                     if not new_author:
                         lost.append((rec["name"], old_stem, old_author))
                     elif new_author != old_author:
@@ -311,9 +340,10 @@ def main():
                                                 old_author))
                 continue
 
-            # No configured base identity: keep the old exact-symbol fallback, but
-            # reject ambiguous overrides and entries pointing to absent source files.
-            member = members.get(name)
+            # An unresolved configured symbol has no ownership proof. Only genuinely
+            # unconfigured sources can use the legacy exact-symbol fallback.
+            member = (members.get(name)
+                      if basename_key(old_stem) not in base_symbols else None)
             if member and member[0] not in head_paths:
                 member = None
             if member and member[1] == old_who:

--- a/tools/prepush_attribution.py
+++ b/tools/prepush_attribution.py
@@ -61,8 +61,8 @@ sys.path.insert(0, str(REPO / "tools"))
 import chaos_db_ci as CDB  # noqa: E402
 
 
-def overrides_at(rev):
-    """Path-wide attribution overrides as of ``rev``."""
+def attribution_at(rev):
+    """Attribution policy from the revision being checked, including its aliases."""
     try:
         raw = subprocess.run(["git", "show", f"{rev}:attribution.json"], cwd=REPO,
                              capture_output=True, text=True, encoding="utf-8",
@@ -70,37 +70,60 @@ def overrides_at(rev):
         data = json.loads(raw)
     except (subprocess.CalledProcessError, json.JSONDecodeError):
         return {}
-    ov = data.get("overrides", {}) if isinstance(data, dict) else {}
-    return {k: v for k, v in ov.items()
-            if isinstance(k, str) and k.startswith("src/") and "#" not in k
-            and isinstance(v, str) and v}
+    return data if isinstance(data, dict) else {}
+
+
+def canonical_author(author, data):
+    # Keep this identical to validate_merge.attribution_snapshot's resolution.
+    return data.get("aliases", {}).get(str(author).lower(), author)
+
+
+def credit_overrides_at(rev):
+    """Canonical authors for both path and path#symbol overrides."""
+    data = attribution_at(rev)
+    return {key: canonical_author(author, data)
+            for key, author in data.get("overrides", {}).items()
+            if isinstance(key, str) and key.startswith("src/")
+            and isinstance(author, str) and author}
+
+
+def overrides_at(rev):
+    """Path-wide attribution overrides as of ``rev``."""
+    return {key: author for key, author in credit_overrides_at(rev).items()
+            if "#" not in key}
 
 
 def member_overrides_at(rev):
-    """``symbol -> (source path, author)`` for consolidated-TU overrides.
+    """Unambiguous ``symbol -> (source path, author)`` consolidation overrides.
 
-    ``validate_merge.attribution_snapshot`` resolves ``source.cpp#symbol`` before a
-    path-wide override.  Reading the same keys here lets a deliberate many-files-to-one
-    consolidation preserve each old symbol's author instead of reporting every legacy
-    basename as lost.
+    This exact-name fallback is only for sources without configured ROM identities.
+    Configured functions must follow module and address, including their new symbol
+    spelling, rather than allowing a same-named function in another overlay to rescue
+    missing credit.
     """
-    try:
-        raw = subprocess.run(["git", "show", f"{rev}:attribution.json"], cwd=REPO,
-                             capture_output=True, text=True, encoding="utf-8",
-                             errors="replace", check=True).stdout
-        data = json.loads(raw)
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
-        return {}
-    ov = data.get("overrides", {}) if isinstance(data, dict) else {}
-    out = {}
-    for key, author in ov.items():
-        if (not isinstance(key, str) or not key.startswith("src/") or "#" not in key
-                or not isinstance(author, str) or not author):
+    out, ambiguous = {}, set()
+    for key, author in credit_overrides_at(rev).items():
+        if "#" not in key:
             continue
         path, symbol = key.rsplit("#", 1)
         if symbol:
+            if symbol in out:
+                ambiguous.add(symbol)
             out[symbol] = (path, author)
-    return out
+    return {symbol: member for symbol, member in out.items() if symbol not in ambiguous}
+
+
+def function_ownership_at(rev):
+    """Use the merge validator's revision-scoped symbol and delinks ownership."""
+    import validate_merge as VM
+
+    old_repo = VM.REPO
+    VM.REPO = REPO
+    try:
+        # The enrolment cache is revision keyed; resolve HEAD before consulting it.
+        return VM.function_snapshot(VM.resolve_commit(rev))["matched"]
+    finally:
+        VM.REPO = old_repo
 
 
 def lineage(rev):
@@ -125,9 +148,10 @@ def lineage(rev):
     first = CDB.first_matchers(rev)
     finishers = CDB.match_finishers(rev)
     overrides = overrides_at(rev)
+    data = attribution_at(rev)
     out = {}
     for path in set(first) | set(finishers) | set(overrides):
-        who = overrides.get(path) or finishers.get(path) or first.get(path)
+        who = overrides.get(path) or canonical_author(finishers.get(path) or first.get(path), data)
         if who:
             out[path.rsplit(".", 1)[0]] = who
     return out
@@ -253,10 +277,45 @@ def main():
             renamed_ok.append((came_from, name, old_stem, new_stem, old_who))
         elif old_stem != new_stem:
             moved_ok.append((name, old_stem, new_stem, old_who))
-    members = member_overrides_at(args.head)
-    for name, (old_stem, old_who) in projected.items():
-        if name not in after_by_name:
+    missing = {name: old for name, old in projected.items() if name not in after_by_name}
+    if missing:
+        base_functions = function_ownership_at(args.base)
+        head_functions = function_ownership_at(args.head)
+        by_stem = {}
+        for key, rec in base_functions.items():
+            by_stem.setdefault(rec["srcPath"].rsplit(".", 1)[0], []).append((key, rec))
+        base_overrides = credit_overrides_at(args.base)
+        head_overrides = credit_overrides_at(args.head)
+        members = member_overrides_at(args.head)
+        head_paths = set(subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", args.head, "--", "src/"],
+            cwd=REPO, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", check=True).stdout.splitlines())
+        for name, (old_stem, old_who) in missing.items():
+            owned = by_stem.get(old_stem)
+            if owned:
+                # A file can own several differently credited functions. Check every
+                # identity and require a current, explicit per-member override.
+                for key, rec in owned:
+                    old_author = base_overrides.get(f"{rec['srcPath']}#{rec['name']}") or old_who
+                    dest = head_functions.get(key)
+                    new_author = (head_overrides.get(f"{dest['srcPath']}#{dest['name']}")
+                                  if dest and dest["size"] == rec["size"] else None)
+                    if not new_author:
+                        lost.append((rec["name"], old_stem, old_author))
+                    elif new_author != old_author:
+                        changed.append((rec["name"], old_stem, dest["srcPath"],
+                                        old_author, new_author))
+                    else:
+                        consolidated_ok.append((rec["name"], old_stem, dest["srcPath"],
+                                                old_author))
+                continue
+
+            # No configured base identity: keep the old exact-symbol fallback, but
+            # reject ambiguous overrides and entries pointing to absent source files.
             member = members.get(name)
+            if member and member[0] not in head_paths:
+                member = None
             if member and member[1] == old_who:
                 consolidated_ok.append((name, old_stem, member[0], old_who))
             elif member:

--- a/tools/test_attribution.py
+++ b/tools/test_attribution.py
@@ -206,10 +206,6 @@ class Composite(GitFixture):
         self.assertEqual(list(after.values()), ["matcher"])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class RenameReplay(GitFixture):
     """`prepush_attribution.project` must REPLAY renames in commit order.
 
@@ -320,3 +316,180 @@ class RenameReplay(GitFixture):
                 contextlib.redirect_stdout(out):
             self.assertEqual(self.PA.main(), 0)
         self.assertIn("2 consolidated with credit intact", out.getvalue())
+
+
+    def check_gate(self, base="before_configured"):
+        report = self.repo / "credit-report.json"
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv", [
+                "prepush_attribution.py", "--base", base, "--head", "HEAD",
+                "--json", str(report)]), contextlib.redirect_stdout(out):
+            status = self.PA.main()
+        return status, json.loads(report.read_text(encoding="utf-8"))
+
+    def configure_function(self, module, symbol, path, size=4):
+        config = f"config/arm9/overlays/{module}"
+        self.write(f"{config}/symbols.txt",
+                   f"{symbol} kind:function(arm,size=0x{size:x}) addr:0x021260a8\n")
+        self.write(f"{config}/delinks.txt",
+                   f"    .text start:0x021260a8 end:0x{0x021260a8 + size:08x} kind:code\n\n"
+                   f"{path}:\n    complete\n"
+                   f"    .text start:0x021260a8 end:0x{0x021260a8 + size:08x}\n")
+
+    def configured_base(self, symbol="OldMember", path="src/OldMember.cpp", policy=None):
+        self.write(path, "//cpp\nint original_member() { return 1; }\n")
+        self.configure_function("ov078", symbol, path)
+        self.write("attribution.json", json.dumps(policy or {}))
+        self.commit("alice", "match configured function")
+        self.git("branch", "before_configured")
+        self.old_source = path
+
+    def consolidate(self, symbol="NewMember", author="alice", module="ov078", size=4,
+                    policy=None, source=None):
+        (self.repo / self.old_source).unlink()
+        self.write("src/Actor.cpp", source or
+                   "//cpp\nstruct Actor { void on_event(); };\nvoid Actor::on_event() {}\n")
+        if module != "ov078":
+            self.write("config/arm9/overlays/ov078/symbols.txt", "")
+            self.write("config/arm9/overlays/ov078/delinks.txt", "")
+        self.configure_function(module, symbol, "src/Actor.cpp", size)
+        self.write("attribution.json", json.dumps(policy if policy is not None else {
+            "overrides": {f"src/Actor.cpp#{symbol}": author} if author else {}}))
+        self.commit("promoter", "consolidate and rename member")
+
+    def test_aliases_are_applied_to_each_revision_lineage(self):
+        self.write("src/a.c", CLEAN)
+        self.write("attribution.json", json.dumps({"aliases": {"alice": "canonical"}}))
+        self.commit("alice", "match as historical alias")
+        self.git("branch", "before_configured")
+        self.write("attribution.json", json.dumps({"overrides": {"src/a.c": "canonical"}}))
+        self.commit("promoter", "use canonical handle")
+        self.assertEqual(self.PA.lineage("before_configured")["src/a"], "canonical")
+        self.assertEqual(self.check_gate()[0], 0)
+
+    def test_aliases_apply_to_finishers(self):
+        self.write("src/a.c", DRAFT)
+        self.commit("drafter", "draft")
+        self.write("src/a.c", CLEAN)
+        self.write("attribution.json", json.dumps({"aliases": {"alice": "canonical"}}))
+        self.commit("alice", "match")
+        self.assertEqual(self.PA.lineage("HEAD")["src/a"], "canonical")
+
+    def test_path_override_alias_is_resolved_once(self):
+        self.write("src/a.c", CLEAN)
+        self.write("attribution.json", json.dumps({
+            "aliases": {"alias": "middle", "middle": "other"},
+            "overrides": {"src/a.c": "ALIAS"}}))
+        self.commit("alice", "explicit historical alias")
+        self.assertEqual(self.PA.lineage("HEAD")["src/a"], "middle")
+
+    def test_changed_alias_mapping_does_not_rewrite_base_credit(self):
+        self.write("src/a.c", CLEAN)
+        self.write("attribution.json", json.dumps({"aliases": {"alice": "old_author"}}))
+        self.commit("alice", "match")
+        self.git("branch", "before_configured")
+        self.write("attribution.json", json.dumps({"aliases": {"alice": "new_author"}}))
+        self.commit("promoter", "change alias identity")
+        status, report = self.check_gate()
+        self.assertEqual(status, 1)
+        self.assertEqual(report["changed"][0][-2:], ["old_author", "new_author"])
+
+    def test_renamed_member_retains_credit_by_module_and_address(self):
+        self.configured_base()
+        self.consolidate()
+        status, report = self.check_gate()
+        self.assertEqual(status, 0)
+        self.assertEqual(len(report["consolidated_ok"]), 1)
+        self.assertEqual(report["consolidated_ok"][0][0], "OldMember")
+
+    def test_factory_filename_need_not_equal_its_symbol(self):
+        self.configured_base(symbol="Actor_classInit", path="src/d_a_actor.c")
+        self.consolidate(symbol="Actor_classInit")
+        status, report = self.check_gate()
+        self.assertEqual(status, 0)
+        self.assertEqual(report["consolidated_ok"][0][0], "Actor_classInit")
+
+    def test_member_override_preserves_canonical_author(self):
+        self.configured_base(policy={"aliases": {"alice": "canonical"}})
+        self.consolidate(author="legacy", policy={
+            "aliases": {"legacy": "canonical"},
+            "overrides": {"src/Actor.cpp#NewMember": "legacy"}})
+        self.assertEqual(self.check_gate()[0], 0)
+
+    def test_base_member_override_precedes_file_lineage(self):
+        self.configured_base(policy={"overrides": {"src/OldMember.cpp#OldMember": "bob"}})
+        self.consolidate(author="bob")
+        status, report = self.check_gate()
+        self.assertEqual(status, 0)
+        self.assertEqual(report["consolidated_ok"][0][-1], "bob")
+
+    def test_consolidation_with_changed_author_fails(self):
+        self.configured_base()
+        self.consolidate(author="thief")
+        status, report = self.check_gate()
+        self.assertEqual(status, 1)
+        self.assertEqual(report["changed"][0][-2:], ["alice", "thief"])
+
+    def test_consolidation_without_explicit_member_credit_fails(self):
+        self.configured_base()
+        self.consolidate(policy={"overrides": {"src/Actor.cpp": "alice"}})
+        status, report = self.check_gate()
+        self.assertEqual(status, 1)
+        self.assertEqual(len(report["lost"]), 1)
+
+    def test_retired_member_override_cannot_rescue_new_symbol(self):
+        self.configured_base()
+        self.consolidate(policy={"overrides": {"src/Actor.cpp#OldMember": "alice"}})
+        self.assertEqual(self.check_gate()[0], 1)
+
+    def test_same_address_and_symbol_in_another_overlay_cannot_rescue_credit(self):
+        self.configured_base()
+        self.consolidate(symbol="OldMember", module="ov079")
+        status, report = self.check_gate()
+        self.assertEqual(status, 1)
+        self.assertEqual(len(report["lost"]), 1)
+
+    def test_changed_function_extent_cannot_rescue_credit(self):
+        self.configured_base()
+        self.consolidate(size=8)
+        self.assertEqual(self.check_gate()[0], 1)
+
+    def test_unmatched_destination_cannot_rescue_credit(self):
+        self.configured_base()
+        self.consolidate(source=DRAFT)
+        self.assertEqual(self.check_gate()[0], 1)
+
+    def test_unconfigured_rewrite_and_move_still_fails_the_gate(self):
+        self.write("src/OldMember.cpp", CLEAN)
+        self.commit("alice", "unconfigured match")
+        self.git("branch", "before_configured")
+        (self.repo / "src/OldMember.cpp").unlink()
+        self.write("src/Actor.cpp", "void completely_different() {}\n")
+        self.commit("promoter", "rewrite and move")
+        self.assertEqual(self.check_gate()[0], 1)
+
+    def test_unconfigured_override_must_point_to_existing_source(self):
+        self.write("src/a.c", CLEAN)
+        self.commit("alice", "match")
+        self.git("branch", "before_configured")
+        (self.repo / "src/a.c").unlink()
+        self.write("attribution.json", json.dumps({"overrides": {
+            "src/Absent.cpp": "alice", "src/Absent.cpp#a": "alice"}}))
+        self.commit("promoter", "delete source with stale overrides")
+        self.assertEqual(self.check_gate()[0], 1)
+
+    def test_unconfigured_ambiguous_member_override_cannot_rescue_credit(self):
+        self.write("src/a.c", CLEAN)
+        self.commit("alice", "match")
+        self.git("branch", "before_configured")
+        (self.repo / "src/a.c").unlink()
+        self.write("src/Left.cpp", "void left() {}\n")
+        self.write("src/Right.cpp", "void right() {}\n")
+        self.write("attribution.json", json.dumps({"overrides": {
+            "src/Left.cpp#a": "alice", "src/Right.cpp#a": "alice"}}))
+        self.commit("promoter", "ambiguous consolidation")
+        self.assertEqual(self.check_gate()[0], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_attribution.py
+++ b/tools/test_attribution.py
@@ -490,6 +490,81 @@ class RenameReplay(GitFixture):
         self.commit("promoter", "ambiguous consolidation")
         self.assertEqual(self.check_gate()[0], 1)
 
+    def test_stale_path_override_cannot_hide_missing_member_credit(self):
+        self.configured_base()
+        self.consolidate(policy={"overrides": {"src/OldMember.cpp": "alice"}})
+        self.assertNotIn("src/OldMember", self.PA.lineage("HEAD"))
+        status, report = self.check_gate()
+        self.assertEqual(status, 1)
+        self.assertEqual(len(report["lost"]), 1)
+
+    def test_stale_path_override_cannot_hide_changed_member_credit(self):
+        self.configured_base()
+        self.consolidate(policy={"overrides": {
+            "src/OldMember.cpp": "alice", "src/Actor.cpp#NewMember": "thief"}})
+        status, report = self.check_gate()
+        self.assertEqual(status, 1)
+        self.assertEqual(report["changed"][0][-2:], ["alice", "thief"])
+
+    def test_a_stale_base_override_never_creates_source_lineage(self):
+        self.configured_base(policy={"overrides": {"src/AlreadyAbsent.cpp": "bob"}})
+        self.assertNotIn("src/AlreadyAbsent", self.PA.lineage("before_configured"))
+        self.consolidate()
+        self.assertEqual(self.check_gate()[0], 0)
+
+    def add_function_alias(self, symbol, size, original="NewMember", first=False):
+        row = f"{symbol} kind:function(arm,size=0x{size:x}) addr:0x021260a8\n"
+        body = f"{original} kind:function(arm,size=0x4) addr:0x021260a8\n"
+        self.write("config/arm9/overlays/ov078/symbols.txt",
+                   row + body if first else body + row)
+
+    def test_competing_head_function_identities_cannot_rescue_credit(self):
+        for first in (False, True):
+            with self.subTest(alias_first=first):
+                if not first:
+                    self.configured_base()
+                    self.consolidate()
+                self.add_function_alias("OtherMember", 4, first=first)
+                self.write("attribution.json", json.dumps({"overrides": {
+                    "src/Actor.cpp#NewMember": "alice",
+                    "src/Actor.cpp#OtherMember": "thief"}}))
+                self.commit("promoter", "competing equal-size function identities")
+                status, report = self.check_gate()
+                self.assertEqual(status, 1)
+                self.assertEqual(len(report["lost"]), 1)
+
+    def test_competing_base_function_identities_cannot_rescue_credit(self):
+        self.configured_base(policy={"overrides": {
+            "src/OldMember.cpp#OldMember": "alice",
+            "src/OldMember.cpp#OtherMember": "bob"}})
+        self.add_function_alias("OtherMember", 4, original="OldMember")
+        self.commit("alice", "competing base function identities")
+        self.git("branch", "-f", "before_configured", "HEAD")
+        self.consolidate()
+        self.assertEqual(self.check_gate()[0], 1)
+
+    def test_zero_size_alias_preserves_the_real_function_identity(self):
+        self.configured_base()
+        self.add_function_alias("OldZeroAlias", 0, original="OldMember", first=True)
+        self.commit("alice", "add zero-size alias before the base body")
+        self.git("branch", "-f", "before_configured", "HEAD")
+        self.consolidate()
+        self.add_function_alias("ZeroAlias", 0)
+        self.write("attribution.json", json.dumps({"overrides": {
+            "src/Actor.cpp#NewMember": "alice",
+            "src/Actor.cpp#ZeroAlias": "unrelated_alias_credit"}}))
+        self.commit("promoter", "add zero-size alias after the body")
+        self.assertEqual(self.check_gate()[0], 0)
+
+    def test_unresolved_configured_source_cannot_use_exact_name_fallback(self):
+        self.write("src/OldMember.cpp", DRAFT)
+        self.configure_function("ov078", "OldMember", "src/OldMember.cpp")
+        self.commit("alice", "unmatched configured function")
+        self.git("branch", "before_configured")
+        self.old_source = "src/OldMember.cpp"
+        self.consolidate(symbol="OldMember")
+        self.assertEqual(self.check_gate()[0], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The pre-push attribution checker misreports renamed or consolidated members because it follows old filenames and compares raw author aliases. In #2446 this produced one changed-credit and two lost-credit failures even though all 52 ROM function identities retained their canonical authors.

Resolve configured ownership by module, address and extent, and canonicalize aliases using each revision's own attribution rules. A consolidation still needs an explicit override for the live member. Ignore retired paths in surviving-source lineage and reject ambiguous positive-size identities, absent files and unsupported fallback mappings.

Independent validation: 183 tests pass; three independently written cases for stale overrides and ambiguous identity now reject; the exact #2446 history reports all 52 consolidations with zero changed or lost credits. Both review findings ATTR-01 and ATTR-02 are fixed in queue task `attribution-checker-repair-0910`, candidate `b6afe1550f3aba262b38882fd65ee7b70b3383e7`.
