### PR TITLE
Pin private PR validation to the live target branch

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,153 +1,72 @@
 name: PR validation
 
-# Submits the PR to the validation relay and exits. The verdict does NOT come back
-# through this workflow — the relay posts it directly to the pull request as the
-# Tangos Validator app: a "PR validation" check run, plus the usual comment. Watch
-# for those, not for this job.
-#
-# This job going green means "submitted", nothing more.
-#
-# Uses pull_request_target so repo secrets (the relay token) are available even
-# for fork PRs. SAFE because this workflow never checks out or runs PR code — it
-# only sends the PR number + immutable head/base SHAs to the relay. The actual validation
-# happens on the self-hosted worker behind the maintainer's NAT.
-#
-# Be clear about what that second half means, though: the worker DOES run this
-# branch's own `tools/`, deliberately, so that a pull request can exercise its own
-# tool change. That code runs in the worker's container -- never on a GitHub runner,
-# never with these secrets -- but a `tools/` diff on a fork PR deserves a read before
-# it is approved.
-#
+# Green here means submitted, not validated. Only the Tangos Validator app posts
+# the required PR validation verdict after the private worker finishes.
+# pull_request_target provides the relay secret for forks without running PR code.
+# Each job loads only the helper at the immutable commit defining THIS workflow.
+# The private worker deliberately exercises PR tools in its isolated container.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Open PR number to validate against its current target branch
+        type: string
+        required: true
 
-# `pull-requests: read` is here to LIST THE CHANGED FILE PATHS, and nothing else. That is
-# PR metadata, not PR code: the files endpoint returns paths, and this job still never
-# checks out or executes anything from the head branch, so the pull_request_target safety
-# argument above is unchanged.
 permissions:
+  contents: read
   pull-requests: read
 
-concurrency:
-  # Key on the head SHA, not the PR number. Grouping by PR number meant every new event for
-  # that PR cancelled the run already in flight, so a branch that gets pushed to repeatedly
-  # (the console auto-pushes matched batches) could never finish a validation: each check went
-  # queued -> cancelled and the PR never reached a verdict, leaving it unmergeable and, worse,
-  # looking "clean" at a glance because an unconcluded check reads as UNSTABLE rather than red.
-  # Per-SHA grouping still collapses duplicate events for the SAME commit (reopen, re-request).
-  #
-  # Cancelling matters much less than it used to: this job is a single POST and exits in
-  # seconds, and cancelling it never un-submitted the job it had already sent anyway. The
-  # relay is what actually prevents duplicate work now — submitting a commit it is already
-  # validating returns the in-flight job instead of queueing a second build.
-  group: pr-validate-${{ github.event.pull_request.head.sha }}
-  cancel-in-progress: true
-
 jobs:
-  submit:
+  resolve:
     runs-on: ubuntu-latest
+    outputs:
+      head: ${{ steps.pin.outputs.head }}
+      pin: ${{ steps.pin.outputs.pin }}
     steps:
-      # Decide whether this PR can possibly change what validation measures, and tell the
-      # relay. A full validation is a stock ROM build plus a whole-module compare against
-      # retail, and the worker runs ONE AT A TIME -- so a pull request that only edits
-      # prose costs every other pull request its place in the queue for nothing.
-      #
-      # THE DEFAULT IS TO VALIDATE. This computes an INERT set and skips only when every
-      # changed path is in it; anything unrecognised is treated as relevant. That
-      # direction is deliberate: a filter that is too narrow silently skips validation on
-      # a pull request that needed it, which is the failure nobody would notice.
-      #
-      # What is NOT inert, and why -- the verdict covers reconstruction AND attribution:
-      #   src/ include/           compiled, or change codegen
-      #   config/                 delinks.txt and symbols.txt decide what is compiled and
-      #                           where; relocs.txt decides what it points at
-      #   tools/                  the ROM build itself
-      #   *.jsonl, attribution.json
-      #                           match_provenance.jsonl and match_attempts.jsonl feed the
-      #                           attribution half of the verdict, and attribution.json
-      #                           pins credit by source path. A stale row there is a real
-      #                           finding, so these must still be validated.
-      #   .gitattributes          decides how those ledgers merge
-      # Everything above is simply "not inert", so it needs no listing.
-      - name: Classify changed paths
-        id: classify
+      - name: Load trusted submission helper
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
-          if [ -z "$files" ]; then
-            # No file list is not evidence of an inert pull request. Fail safe.
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "no files returned -- treating as validation-relevant"
-            exit 0
-          fi
-          # Inert: prose, generated progress pages, the licence, and src_tu/. Note
-          # docs/index.html and docs/progress-treemap.svg are bot-written progress
-          # artefacts, not sources.
-          #
-          # src_tu/ is inert HERE because nothing relay validation runs ever reads it.
-          # The build enrolls only the files config/**/delinks.txt names, and no
-          # delinks.txt names a src_tu/ path; tools/rombuild.py:enrolled() then rejects
-          # any path whose top-level directory is not src/ or mods/ unless it is handed
-          # extra_roots, which rombuild.py:1192 populates only for --tu-module /
-          # --partitioned-tu builds. The stock profile the relay runs passes neither, so
-          # a src_tu-only pull request used to buy a full ROM build plus module compare
-          # -- one at a time, ahead of everyone else in the queue -- that compiled not
-          # one line of what it changed.
-          #
-          # src_tu/ is still gated, just not here: the COMPILE half is
-          # tools/check_src_tu_compiles.py, run from tools/hooks/pre-push and on the
-          # build box (the runner has neither mwccarm nor the ROM), and the REFERENCE
-          # half -- includes resolve, mangled symbols exist -- is
-          # .github/workflows/src-tu-refs.yml. Do not weaken either one.
-          inert='^(docs/|notes/|src_tu/|\.github/ISSUE_TEMPLATE/)|(^|/)[^/]+\.(md|png|jpg|jpeg|gif|svg)$|^LICENSE$'
-          relevant=false
-          while IFS= read -r f; do
-            if ! printf '%s\n' "$f" | grep -Eq "$inert"; then
-              relevant=true
-              echo "validation-relevant: $f"
-            fi
-          done <<< "$files"
-          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
-          total=$(printf '%s\n' "$files" | wc -l)
-          echo "$total changed file(s); validation-relevant=$relevant"
-
-      - name: Submit validation job
+          [[ "$WORKFLOW_SHA" =~ ^[0-9a-fA-F]{40}$ ]]
+          gh api "repos/$REPO/contents/tools/submit_pr_validation.py?ref=$WORKFLOW_SHA" \
+            -H 'Accept: application/vnd.github.raw+json' > "$RUNNER_TEMP/submit_pr_validation.py"
+      - name: Pin live PR and target branch
+        id: pin
         env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 "$RUNNER_TEMP/submit_pr_validation.py" resolve
+
+  submit:
+    needs: resolve
+    runs-on: ubuntu-latest
+    concurrency:
+      # Both event and manual runs group by the resolved head. A different head
+      # must not cancel a submission already in flight for this PR.
+      group: pr-validate-${{ needs.resolve.outputs.head }}
+      cancel-in-progress: true
+    steps:
+      - name: Load trusted submission helper
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[0-9a-fA-F]{40}$ ]]
+          gh api "repos/$REPO/contents/tools/submit_pr_validation.py?ref=$WORKFLOW_SHA" \
+            -H 'Accept: application/vnd.github.raw+json' > "$RUNNER_TEMP/submit_pr_validation.py"
+      - name: Recheck pins and submit validation job
+        env:
+          GH_TOKEN: ${{ github.token }}
           RELAY: ${{ secrets.PR_VALIDATE_RELAY }}
           TOKEN: ${{ secrets.PR_VALIDATE_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          VALIDATION_RELEVANT: ${{ steps.classify.outputs.relevant }}
-        run: |
-          set -euo pipefail
-          # `validationRelevant` is ADVISORY and the relay decides what to do with it.
-          #
-          # THE SUBMISSION STILL HAPPENS EITHER WAY, and that is the point: `PR validation`
-          # is a required check pinned to the tangos-validator app (integration_id
-          # 4461188), so only the relay can post a verdict that satisfies the ruleset. If
-          # this workflow skipped submitting, no check would ever arrive and the pull
-          # request would sit unmergeable forever waiting for one. Equally, a relay that
-          # does not know this field yet simply ignores it and validates as before, so
-          # landing this change on its own is a no-op rather than a regression.
-          #
-          # Relay side, to actually claim the saving: when validationRelevant is false,
-          # post a passing `PR validation` check immediately and do not queue a build.
-          payload=$(jq -n --arg repo "$REPO" --argjson pr "$PR" \
-            --arg sha "$SHA" --arg baseSha "$BASE_SHA" \
-            --argjson validationRelevant "$VALIDATION_RELEVANT" \
-            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha,validationRelevant:$validationRelevant}')
-          resp=$(curl -sS -X POST "$RELAY/api/pr-validate" \
-            -H "X-Api-Key: $TOKEN" -H "Content-Type: application/json" \
-            --data "$payload")
-          echo "$resp"
-          jobId=$(echo "$resp" | jq -r '.jobId // empty')
-          if [ -z "$jobId" ]; then echo "relay did not return a jobId"; exit 1; fi
-          echo "Submitted $jobId. The verdict will arrive on this PR as the"
-          echo "'PR validation' check run, posted by the relay — not by this workflow."
+          VALIDATION_PIN: ${{ needs.resolve.outputs.pin }}
+        # validationRelevant remains advisory. Even wholly inert PRs are sent to
+        # the relay; this workflow never posts, waives or replaces its verdict.
+        run: python3 "$RUNNER_TEMP/submit_pr_validation.py" submit

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -218,6 +218,7 @@ jobs:
             tools.test_sinit_owners \
             tools.test_srcpath \
             tools.test_stamp_provenance_verify \
+            tools.test_submit_pr_validation \
             tools.test_symrecords \
             tools.test_tu_map \
             tools.test_tu_production \

--- a/tools/submit_pr_validation.py
+++ b/tools/submit_pr_validation.py
@@ -1,0 +1,322 @@
+"""Submit immutable, live PR metadata to the private validation relay.
+
+Loaded by pr-validate.yml from github.workflow_sha, never from a PR checkout.
+Only the relay's app can issue the required verdict; success here means submitted.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+
+class SubmissionError(RuntimeError):
+    """Metadata changed or could not be established; do not claim submission."""
+
+
+def require(condition, message):
+    if not condition:
+        raise SubmissionError(message)
+
+
+def repository(value):
+    require(isinstance(value, str)
+            and re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", value),
+            "Invalid repository identity")
+    require(all(part not in (".", "..") for part in value.split("/")),
+            "Invalid repository identity")
+    return value.lower()
+
+
+def positive_integer(value):
+    require(type(value) is int and value > 0, "Expected a positive integer")
+    return value
+
+
+def pr_number(value):
+    require(isinstance(value, str) and re.fullmatch(r"[1-9][0-9]*", value),
+            "PR number must be a positive decimal integer")
+    return positive_integer(int(value))
+
+
+def commit_sha(value):
+    require(isinstance(value, str) and re.fullmatch(r"[0-9a-fA-F]{40}", value),
+            "Expected a full GitHub commit SHA")
+    return value.lower()
+
+
+def branch_name(value):
+    require(isinstance(value, str) and value and value != "@"
+            and not any(ord(char) < 33 or ord(char) == 127 for char in value)
+            and not any(char in value for char in "~^:?*[\\")
+            and ".." not in value and "@{" not in value and not value.endswith(".")
+            and all(part and not part.startswith(".") and not part.endswith(".lock")
+                    for part in value.split("/")), "Invalid branch identity")
+    return value
+
+
+def pr_identity(data, repo, number):
+    require(isinstance(data, dict), "Malformed pull request metadata")
+    require(type(data.get("number")) is int and data["number"] == number,
+            "Pull request number changed")
+    require(data.get("state") == "open" and data.get("merged") is False,
+            "Pull request is not open and unmerged")
+    head, base = data.get("head"), data.get("base")
+    require(isinstance(head, dict) and isinstance(base, dict),
+            "Missing pull request head or target")
+    head_repo, base_repo = head.get("repo"), base.get("repo")
+    require(isinstance(head_repo, dict) and isinstance(base_repo, dict),
+            "Missing pull request repository (including a deleted fork)")
+    require(repository(base_repo.get("full_name")) == repo,
+            "Pull request targets a different repository")
+    # base.sha can be GitHub's cached PR base. Validate its shape, but obtain the
+    # submission base from the actual refs/heads/<base.ref> below.
+    commit_sha(base.get("sha"))
+    return {"repo": repo, "pr": number, "sha": commit_sha(head.get("sha")),
+            "baseRef": branch_name(base.get("ref")),
+            "baseRepoId": positive_integer(base_repo.get("id")),
+            "headRepo": repository(head_repo.get("full_name")),
+            "headRepoId": positive_integer(head_repo.get("id")),
+            "headRef": branch_name(head.get("ref"))}
+
+
+def validate_pin(pin):
+    fields = {"repo", "pr", "sha", "baseRef", "baseRepoId", "headRepo",
+              "headRepoId", "headRef", "baseSha"}
+    require(isinstance(pin, dict) and set(pin) == fields, "Malformed submission pin")
+    result = dict(pin)
+    for key in ("repo", "headRepo"):
+        result[key] = repository(pin[key])
+    for key in ("pr", "baseRepoId", "headRepoId"):
+        result[key] = positive_integer(pin[key])
+    for key in ("sha", "baseSha"):
+        result[key] = commit_sha(pin[key])
+    for key in ("baseRef", "headRef"):
+        result[key] = branch_name(pin[key])
+    return result
+
+
+def live_base(github, repo, branch):
+    data = github(f"repos/{repo}/git/ref/heads/{quote(branch, safe='')}")
+    require(isinstance(data, dict) and data.get("ref") == f"refs/heads/{branch}",
+            "Target ref response does not match the requested branch")
+    obj = data.get("object")
+    require(isinstance(obj, dict) and obj.get("type") == "commit",
+            "Target ref does not identify a commit")
+    return commit_sha(obj.get("sha"))
+
+
+def resolve(github, repo, event_name, event):
+    """Select the current head/target; a PR event must still identify this head."""
+    repo = repository(repo)
+    require(isinstance(event, dict), "Malformed workflow event")
+    if event_name == "pull_request_target":
+        number = positive_integer(event.get("number"))
+        expected = pr_identity(event.get("pull_request"), repo, number)
+    elif event_name == "workflow_dispatch":
+        inputs = event.get("inputs")
+        require(isinstance(inputs, dict) and set(inputs) == {"pr"},
+                "Manual dispatch accepts only the PR number")
+        number = pr_number(inputs["pr"])
+        expected = None
+    else:
+        raise SubmissionError("Unsupported workflow event")
+    current = pr_identity(github(f"repos/{repo}/pulls/{number}"), repo, number)
+    require(expected is None or current == expected,
+            "PR head or target changed since the triggering event; dispatch again")
+    return dict(current, baseSha=live_base(github, repo, current["baseRef"]))
+
+
+# This is the existing workflow's inert set. Everything else remains relevant:
+# in particular source, headers, config, tools and the attribution ledgers.
+# src_tu is checked separately; the relay's stock ROM profile does not enroll it.
+INERT = re.compile(r"^(docs/|notes/|src_tu/|\.github/ISSUE_TEMPLATE/)"
+                   r"|(^|/)[^/]+\.(md|png|jpg|jpeg|gif|svg)$|^LICENSE$")
+
+
+def validation_relevant(github, repo, number, changed_files):
+    """Only a complete, nonempty list of wholly inert paths earns False."""
+    # GitHub caps the PR files endpoint at 3000. Uncertain scope must validate.
+    if type(changed_files) is not int or not 0 < changed_files <= 3000:
+        return True
+    files = []
+    for page in range(1, (changed_files + 99) // 100 + 1):
+        batch = github(f"repos/{repo}/pulls/{number}/files?per_page=100&page={page}")
+        if not isinstance(batch, list) or len(batch) > 100:
+            return True
+        files.extend(batch)
+    if len(files) != changed_files:
+        return True
+    seen = set()
+    for entry in files:
+        if not isinstance(entry, dict):
+            return True
+        name = entry.get("filename")
+        if not isinstance(name, str) or name in seen:
+            return True
+        seen.add(name)
+        paths = [name]
+        if entry.get("status") == "renamed" and not entry.get("previous_filename"):
+            return True
+        if "previous_filename" in entry:
+            paths.append(entry["previous_filename"])
+        if entry.get("status") not in ("added", "removed", "modified", "renamed",
+                                       "copied", "changed", "unchanged"):
+            return True
+        for path in paths:
+            if (not isinstance(path, str) or not path or "\\" in path
+                    or any(ord(char) < 32 or ord(char) == 127 for char in path)
+                    or any(part in ("", ".", "..") for part in path.split("/"))
+                    or not INERT.search(path)):
+                return True
+    return False
+
+
+def check_current(github, pin):
+    repo, number = pin["repo"], pin["pr"]
+    current = github(f"repos/{repo}/pulls/{number}")
+    expected = {key: value for key, value in pin.items() if key != "baseSha"}
+    require(pr_identity(current, repo, number) == expected,
+            "PR head, fork or target changed after resolution; dispatch again")
+    return current
+
+
+def submit(github, relay, pin):
+    """Check current identity around classification, then submit and read back pins."""
+    pin = validate_pin(pin)
+    current = check_current(github, pin)
+    # The files endpoint shares the PR's cached comparison base. When that base
+    # is stale, its path list cannot establish that the live-base change is inert.
+    relevant = (commit_sha(current["base"]["sha"]) != pin["baseSha"]
+                or validation_relevant(github, pin["repo"], pin["pr"],
+                                       current.get("changed_files")))
+    payload = {key: pin[key] for key in ("repo", "pr", "sha", "baseSha")}
+    payload["validationRelevant"] = relevant
+    # The API offers no atomic PR+branch snapshot. Read the target on both sides
+    # of the final PR read, then POST immediately. Merge still needs fresh gates.
+    for final_read in range(2):
+        require(live_base(github, pin["repo"], pin["baseRef"]) == pin["baseSha"],
+                "Target branch advanced after resolution; dispatch again")
+        if final_read == 0:
+            check_current(github, pin)
+    response = relay("POST", "/api/pr-validate", payload)
+    require(isinstance(response, dict) and response.get("ok") is True
+            and isinstance(response.get("jobId"), str)
+            and re.fullmatch(r"[0-9a-f]{32}", response["jobId"])
+            and response.get("status") in ("Queued", "Running", "Passed"),
+            "Relay did not acknowledge a validation job")
+    job_id = response["jobId"]
+    job = relay("GET", f"/api/pr-validate/{job_id}", None)
+    # Relay deduplication is by repo+head, not base. Never mistake an older
+    # in-flight job for a submission against this base; do not cancel it either.
+    require(isinstance(job, dict) and job.get("id") == job_id,
+            "Relay returned malformed job metadata")
+    require(job.get("repo") == pin["repo"] and type(job.get("pr")) is int
+            and job["pr"] == pin["pr"] and job.get("sha") == pin["sha"]
+            and job.get("baseSha") == pin["baseSha"],
+            "Relay job has different PR/head/base pins; retry after it finishes")
+    return {"jobId": job_id, **payload}
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # Tokens are for exactly the configured service, never a redirect target.
+        return None
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        require(key not in result, "Duplicate JSON object key")
+        result[key] = value
+    return result
+
+
+def load_json(text):
+    try:
+        return json.loads(text, object_pairs_hook=unique_object,
+                          parse_constant=lambda value: require(False, "Invalid JSON constant"))
+    except (ValueError, UnicodeError) as exc:
+        raise SubmissionError("Malformed JSON response or input") from exc
+
+
+def request_json(request):
+    try:
+        with build_opener(NoRedirect()).open(request, timeout=30) as response:
+            require(200 <= response.status < 300, "Unexpected HTTP response status")
+            body = response.read(2_000_001)
+            require(len(body) <= 2_000_000, "JSON response too large")
+            return load_json(body)
+    except HTTPError as exc:
+        raise SubmissionError(f"Service request failed (HTTP {exc.code})") from None
+    except (URLError, OSError, ValueError):
+        # Exception URLs and response bodies may contain configured secret data.
+        raise SubmissionError("Service request failed; no submission confirmed") from None
+
+
+def github_client(token):
+    require(isinstance(token, str) and token and "\r" not in token and "\n" not in token,
+            "Missing or malformed GitHub token")
+
+    def get(path):
+        return request_json(Request(f"https://api.github.com/{path}", headers={
+            "Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28", "User-Agent": "sm64ds-pr-validation"}))
+
+    return get
+
+
+def relay_client(url, token):
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        raise SubmissionError("Malformed relay URL") from None
+    require(parts.scheme == "https" and parts.netloc and not parts.username
+            and not parts.password and not parts.query and not parts.fragment
+            and not any(ord(char) <= 32 or ord(char) == 127 for char in url),
+            "Expected an HTTPS relay URL without credentials, query or fragment")
+    require(isinstance(token, str) and token and "\r" not in token and "\n" not in token,
+            "Missing or malformed relay token")
+
+    def call(method, path, payload):
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        return request_json(Request(url.rstrip("/") + path, data=body, method=method,
+                                    headers={"X-Api-Key": token,
+                                             "Content-Type": "application/json"}))
+
+    return call
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("resolve", "submit"))
+    args = parser.parse_args()
+    try:
+        github = github_client(os.environ.get("GH_TOKEN"))
+        if args.command == "resolve":
+            event = load_json(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+            pin = resolve(github, os.environ["GITHUB_REPOSITORY"],
+                          os.environ["GITHUB_EVENT_NAME"], event)
+            with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+                output.write(f"head={pin['sha']}\npin={json.dumps(pin, separators=(',', ':'))}\n")
+            print(f"Pinned {pin['repo']}#{pin['pr']} head {pin['sha']} "
+                  f"against live {pin['baseRef']} {pin['baseSha']}")
+        else:
+            pin = load_json(os.environ["VALIDATION_PIN"])
+            relay = relay_client(os.environ["RELAY"], os.environ["TOKEN"])
+            result = submit(github, relay, pin)
+            print(json.dumps(result, sort_keys=True))
+            print("Submitted. Only the relay's PR validation check supplies the verdict.")
+        return 0
+    except (SubmissionError, KeyError, OSError) as exc:
+        message = str(exc) if isinstance(exc, SubmissionError) else "Missing workflow input or file"
+        print(f"Validation submission failed: {message}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_submit_pr_validation.py
+++ b/tools/test_submit_pr_validation.py
@@ -1,0 +1,448 @@
+"""Exercise the workflow's real metadata/submission helper without network or secrets."""
+import copy
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import submit_pr_validation as submitter
+
+
+REPO = "tangosdev/sm64ds-decomp"
+HEAD = "3b71825d7da2b969c4d962fd82b189090743757f"
+OLD_BASE = "690637e41a7a302eace631f6065ab1c4fe37326e"
+LIVE_BASE = "666df563a2ea5340f41866c3321468b3c2207fd2"
+NEXT_BASE = "c" * 40
+JOB = "b6ddf043b0f54687bea3a705ddff3df0"
+
+
+def pull_request():
+    return {"number": 2445, "state": "open", "merged": False, "changed_files": 1,
+            "head": {"sha": HEAD, "ref": "review/snm", "repo": {
+                "full_name": "contributor/sm64ds-decomp", "id": 20}},
+            "base": {"sha": LIVE_BASE, "ref": "main", "repo": {
+                "full_name": REPO, "id": 10}}}
+
+
+def event(data=None):
+    snapshot = copy.deepcopy(data or pull_request())
+    snapshot["base"]["sha"] = OLD_BASE
+    return {"number": 2445, "pull_request": snapshot}
+
+
+def git_ref(sha=LIVE_BASE, branch="main"):
+    return {"ref": f"refs/heads/{branch}", "object": {"type": "commit", "sha": sha}}
+
+
+class Services:
+    """Fixtures expose request ordering and record every attempted relay mutation."""
+
+    def __init__(self):
+        self.pr = pull_request()
+        self.ref = git_ref()
+        self.files = [{"filename": "src/actor.cpp", "status": "modified"}]
+        self.requests = []
+        self.relay_requests = []
+        self.after_read = None
+        self.reply = {"ok": True, "jobId": JOB, "status": "Queued"}
+        self.job_override = {}
+
+    def github(self, path):
+        self.requests.append(path)
+        if path == f"repos/{REPO}/pulls/2445":
+            value = self.pr
+        elif path.startswith(f"repos/{REPO}/git/ref/heads/"):
+            value = self.ref
+        elif path.startswith(f"repos/{REPO}/pulls/2445/files?per_page=100&page="):
+            page = int(path.rsplit("=", 1)[1])
+            value = self.files[(page - 1) * 100:page * 100]
+        else:
+            raise AssertionError(f"Unexpected metadata request: {path}")
+        result = copy.deepcopy(value)
+        if self.after_read:
+            self.after_read(path)
+        return result
+
+    def relay(self, method, path, payload):
+        self.relay_requests.append((method, path, copy.deepcopy(payload)))
+        if method == "POST" and path == "/api/pr-validate":
+            self.payload = payload
+            return copy.deepcopy(self.reply)
+        if method == "GET" and path == f"/api/pr-validate/{JOB}":
+            return {"id": JOB, **self.payload, **self.job_override}
+        raise AssertionError(f"Unexpected relay request: {method} {path}")
+
+    def resolve(self):
+        return submitter.resolve(self.github, REPO, "pull_request_target", event())
+
+    def run(self, pin=None):
+        return submitter.submit(self.github, self.relay, pin or self.resolve())
+
+
+class SubmissionTests(unittest.TestCase):
+    def test_stale_event_and_api_base_use_live_branch_for_actual_post(self):
+        # Regression: run 34531793337 sent OLD_BASE for this exact PR head.
+        services = Services()
+        services.pr["base"]["sha"] = OLD_BASE
+        result = services.run()
+        expected = {"repo": REPO, "pr": 2445, "sha": HEAD,
+                    "baseSha": LIVE_BASE, "validationRelevant": True}
+        self.assertEqual(services.relay_requests[0], ("POST", "/api/pr-validate", expected))
+        self.assertEqual(result, {"jobId": JOB, **expected})
+        self.assertEqual(services.relay_requests[1], ("GET", f"/api/pr-validate/{JOB}", None))
+        self.assertEqual(services.requests[-3:], [f"repos/{REPO}/git/ref/heads/main",
+                                                f"repos/{REPO}/pulls/2445",
+                                                f"repos/{REPO}/git/ref/heads/main"])
+
+    def test_manual_dispatch_resolves_current_fork_head_without_base_input(self):
+        services = Services()
+        services.pr["head"]["sha"] = NEXT_BASE
+        pin = submitter.resolve(services.github, REPO, "workflow_dispatch", {"inputs": {"pr": "2445"}})
+        result = services.run(pin)
+        self.assertEqual(result["sha"], NEXT_BASE)
+        self.assertEqual(result["baseSha"], LIVE_BASE)
+        self.assertEqual(pin["headRepo"], "contributor/sm64ds-decomp")
+
+    def test_terminal_same_head_can_be_submitted_again(self):
+        services = Services()
+        first = services.run()
+        second = services.run()
+        self.assertEqual(first["sha"], second["sha"])
+        self.assertEqual(sum(method == "POST" for method, _, _ in services.relay_requests), 2)
+        # There is no local "this head already passed/failed" shortcut. The relay
+        # decides whether an in-flight job can be reused or a new one is needed.
+
+    def test_inert_pr_still_submits_with_advisory_false(self):
+        services = Services()
+        services.files = [{"filename": "notes/review.md", "status": "modified"}]
+        self.assertIs(services.run()["validationRelevant"], False)
+        self.assertEqual(services.relay_requests[0][0], "POST")
+
+    def test_inert_cached_file_list_cannot_skip_live_base_validation(self):
+        services = Services()
+        services.pr["base"]["sha"] = OLD_BASE
+        services.files = [{"filename": "notes/review.md", "status": "modified"}]
+        self.assertIs(services.run()["validationRelevant"], True)
+        self.assertFalse(any("/files?" in path for path in services.requests))
+
+    def test_changed_event_head_or_target_ref_is_rejected(self):
+        for key, value in (("sha", NEXT_BASE), ("ref", "another-branch")):
+            with self.subTest(key=key):
+                services = Services()
+                side = "head" if key == "sha" else "base"
+                services.pr[side][key] = value
+                with self.assertRaises(submitter.SubmissionError):
+                    services.run()
+                self.assertEqual(services.relay_requests, [])
+
+    def test_head_target_fork_or_closed_race_after_resolution_blocks_post(self):
+        mutations = [lambda pr: pr["head"].update(sha=NEXT_BASE),
+                     lambda pr: pr["base"].update(ref="release"),
+                     lambda pr: pr["base"]["repo"].update(full_name="other/repo"),
+                     lambda pr: pr["base"]["repo"].update(id=11),
+                     lambda pr: pr["head"]["repo"].update(id=21),
+                     lambda pr: pr["head"]["repo"].update(full_name="different/fork"),
+                     lambda pr: pr["head"].update(ref="replacement"),
+                     lambda pr: pr["head"].update(repo=None),
+                     lambda pr: pr.update(state="closed"),
+                     lambda pr: pr.update(merged=True)]
+        for mutation in mutations:
+            for during_files in (False, True):
+                with self.subTest(mutation=mutation, during_files=during_files):
+                    services = Services()
+                    pin = services.resolve()
+                    if during_files:
+                        services.after_read = lambda path: mutation(services.pr) if "/files?" in path else None
+                    else:
+                        mutation(services.pr)
+                    with self.assertRaises(submitter.SubmissionError):
+                        services.run(pin)
+                    self.assertEqual(services.relay_requests, [])
+
+    def test_base_races_before_and_during_final_pr_read_block_post(self):
+        for during_final_read in (False, True):
+            services = Services()
+            pin = services.resolve()
+            if during_final_read:
+                def advance(path):
+                    if path.endswith("/pulls/2445"):
+                        pr_reads = services.requests.count(path)
+                        if pr_reads == 3:
+                            services.ref = git_ref(NEXT_BASE)
+                services.after_read = advance
+            else:
+                services.ref = git_ref(NEXT_BASE)
+            with self.assertRaisesRegex(submitter.SubmissionError, "Target branch advanced"):
+                services.run(pin)
+            self.assertEqual(services.relay_requests, [])
+
+    def test_cached_base_sha_changing_to_live_sha_is_not_a_target_race(self):
+        services = Services()
+        services.pr["base"]["sha"] = OLD_BASE
+        pin = services.resolve()
+        services.pr["base"]["sha"] = LIVE_BASE
+        self.assertEqual(services.run(pin)["baseSha"], LIVE_BASE)
+
+    def test_branch_with_slash_is_encoded_as_one_ref_parameter(self):
+        services = Services()
+        services.pr["base"]["ref"] = "release/v1"
+        services.ref = git_ref(branch="release/v1")
+        pin = submitter.resolve(services.github, REPO, "workflow_dispatch", {"inputs": {"pr": "2445"}})
+        services.run(pin)
+        self.assertIn(f"repos/{REPO}/git/ref/heads/release%2Fv1", services.requests)
+
+    def test_invalid_dispatch_inputs_do_not_read_metadata_or_submit(self):
+        inputs = [{}, {"pr": "2445", "baseSha": OLD_BASE}, {"pr": "2445", "sha": HEAD}]
+        inputs.extend({"pr": value} for value in (None, True, 2445, "", "0", "-1", "+1",
+                                                 " 2445", "2445\n", "2.5", "1e3", "01", "1/../2"))
+        for value in inputs:
+            with self.subTest(value=value):
+                services = Services()
+                with self.assertRaises(submitter.SubmissionError):
+                    submitter.resolve(services.github, REPO, "workflow_dispatch", {"inputs": value})
+                self.assertEqual(services.requests, [])
+
+    def test_malformed_pr_or_target_ref_never_submits(self):
+        malformed = [None, [], {}, {**pull_request(), "number": True},
+                     {**pull_request(), "number": 2446}, {**pull_request(), "merged": None},
+                     {**pull_request(), "head": None}, {**pull_request(), "base": None}]
+        for side in ("head", "base"):
+            for value in (None, [], "", "a" * 39, "g" * 40, HEAD + "\n"):
+                data = pull_request()
+                data[side]["sha"] = value
+                malformed.append(data)
+        for value in malformed:
+            services = Services()
+            services.pr = value
+            with self.subTest(value=value), self.assertRaises(submitter.SubmissionError):
+                services.run()
+            self.assertEqual(services.relay_requests, [])
+        for value in (None, [], {}, git_ref(branch="wrong"),
+                      {"ref": "refs/heads/main", "object": {"type": "tree", "sha": LIVE_BASE}},
+                      git_ref("short")):
+            services = Services()
+            services.ref = value
+            with self.subTest(value=value), self.assertRaises(submitter.SubmissionError):
+                services.run()
+            self.assertEqual(services.relay_requests, [])
+
+    def test_invalid_pins_fail_before_any_network_request(self):
+        pin = Services().resolve()
+        values = [None, {}, {**pin, "extra": True}]
+        for key, value in (("pr", True), ("sha", "short"), ("baseSha", "g" * 40),
+                           ("baseRef", "main\nhead=bad"), ("repo", "../bad"),
+                           ("headRepoId", 0), ("headRef", "bad..branch")):
+            values.append({**pin, key: value})
+        for value in values:
+            services = Services()
+            with self.subTest(value=value), self.assertRaises(submitter.SubmissionError):
+                submitter.submit(services.github, services.relay, value)
+            self.assertEqual(services.requests + services.relay_requests, [])
+
+    def test_existing_inflight_job_must_have_identical_pins(self):
+        for key, value in (("baseSha", OLD_BASE), ("sha", NEXT_BASE), ("pr", 2446),
+                           ("pr", True), ("repo", "other/repo"), ("id", "bad")):
+            services = Services()
+            services.reply["status"] = "Running"
+            services.job_override[key] = value
+            with self.subTest(key=key), self.assertRaises(submitter.SubmissionError):
+                services.run()
+            self.assertEqual([method for method, _, _ in services.relay_requests], ["POST", "GET"])
+
+    def test_malformed_relay_acknowledgements_fail(self):
+        for reply in (None, [], {}, {"ok": False, "jobId": JOB, "status": "Queued"},
+                      {"ok": 1, "jobId": JOB, "status": "Queued"},
+                      {"ok": True, "jobId": "../state", "status": "Queued"},
+                      {"ok": True, "jobId": JOB, "status": "unknown"},
+                      {"ok": True, "jobId": JOB, "status": []}):
+            services = Services()
+            services.reply = reply
+            with self.subTest(reply=reply), self.assertRaises(submitter.SubmissionError):
+                services.run()
+            self.assertEqual(len(services.relay_requests), 1)
+
+    def test_closed_pr_and_unknown_event_fail_before_submission(self):
+        for change in ({"state": "closed"}, {"merged": True}):
+            services = Services()
+            services.pr.update(change)
+            with self.assertRaises(submitter.SubmissionError):
+                services.run()
+            self.assertEqual(services.relay_requests, [])
+        services = Services()
+        with self.assertRaises(submitter.SubmissionError):
+            submitter.resolve(services.github, REPO, "pull_request", event())
+        self.assertEqual(services.requests, [])
+
+    def test_malformed_job_readback_cannot_confirm_submission(self):
+        for job in (None, [], {}, {"id": JOB}):
+            services = Services()
+            relay = Mock(side_effect=[services.reply, job])
+            with self.assertRaises(submitter.SubmissionError):
+                submitter.submit(services.github, relay, services.resolve())
+            self.assertEqual(relay.call_count, 2)
+
+
+class ClassificationTests(unittest.TestCase):
+    def classify(self, paths, count=None):
+        services = Services()
+        services.files = paths
+        services.pr["changed_files"] = len(paths) if count is None else count
+        return services.run()["validationRelevant"]
+
+    def test_existing_inert_set_and_source_tool_credit_paths(self):
+        for path in ("docs/index.html", "notes/review.json", "src_tu/actor.cpp",
+                     ".github/ISSUE_TEMPLATE/bug.yml", "README.md", "image.svg", "LICENSE"):
+            with self.subTest(path=path):
+                self.assertFalse(self.classify([{"filename": path, "status": "modified"}]))
+        for path in ("src/a.cpp", "include/A.h", "config/arm9/symbols.txt", "tools/a.py",
+                     "attribution.json", "match_provenance.jsonl", ".gitattributes",
+                     ".github/workflows/pr-validate.yml", "unknown/file"):
+            with self.subTest(path=path):
+                self.assertTrue(self.classify([{"filename": path, "status": "modified"}]))
+
+    def test_renamed_source_to_inert_path_remains_relevant(self):
+        self.assertTrue(self.classify([{"filename": "notes/retired.md", "status": "renamed",
+                                        "previous_filename": "src/actor.cpp"}]))
+        self.assertTrue(self.classify([{"filename": "notes/renamed.md", "status": "renamed"}]))
+        self.assertFalse(self.classify([{"filename": "notes/new.md", "status": "renamed",
+                                         "previous_filename": "notes/old.md"}]))
+
+    def test_all_pages_are_classified(self):
+        files = [{"filename": f"notes/{i}.md", "status": "modified"} for i in range(101)]
+        self.assertFalse(self.classify(files))
+        files[-1]["filename"] = "src/actor.cpp"
+        self.assertTrue(self.classify(files))
+
+    def test_empty_incomplete_capped_and_duplicate_lists_default_relevant(self):
+        entry = {"filename": "notes/readme.md", "status": "modified"}
+        self.assertTrue(self.classify([]))
+        self.assertTrue(self.classify([entry], 2))
+        self.assertTrue(self.classify([entry, entry]))
+        for count in (3001, -1, True, "1"):
+            self.assertTrue(self.classify([entry], count))
+
+    def test_malformed_paths_cannot_earn_inert_status(self):
+        for value in (None, "", 1, [], "notes/../src/a.cpp", "notes\\readme.md",
+                      "notes/readme.md\n", "/notes/readme.md", "notes//readme.md"):
+            self.assertTrue(self.classify([{"filename": value, "status": "modified"}]))
+        for entry in ({"filename": "notes/a.md"}, {"filename": "notes/a.md", "status": "unexpected"},
+                      {"filename": "notes/a.md", "status": []},
+                      None, [], {"filename": "notes/a.md", "status": "renamed", "previous_filename": []}):
+            self.assertTrue(self.classify([entry]))
+
+    def test_files_api_failure_does_not_submit_an_inert_verdict(self):
+        services = Services()
+        pin = services.resolve()
+        github = Mock(side_effect=[services.pr, submitter.SubmissionError("API unavailable")])
+        with self.assertRaises(submitter.SubmissionError):
+            submitter.submit(github, services.relay, pin)
+        self.assertEqual(services.relay_requests, [])
+
+    def test_malformed_file_page_is_relevant(self):
+        for page in ({"message": "not a list"}, None, [{}] * 101):
+            github = Mock(return_value=page)
+            self.assertTrue(submitter.validation_relevant(github, REPO, 2445, 1))
+
+
+class TransportAndWorkflowTests(unittest.TestCase):
+    def test_successful_json_transport_uses_bounded_nonredirecting_request(self):
+        with patch.object(submitter, "build_opener") as opener:
+            response = opener.return_value.open.return_value.__enter__.return_value
+            response.status = 200
+            response.read.return_value = b'{"ok":true}'
+            self.assertEqual(submitter.request_json(Request("https://example.invalid")), {"ok": True})
+            self.assertIsInstance(opener.call_args.args[0], submitter.NoRedirect)
+            self.assertEqual(opener.return_value.open.call_args.kwargs, {"timeout": 30})
+            response.read.assert_called_once_with(2_000_001)
+
+    def test_github_client_uses_metadata_get_and_read_token(self):
+        with patch.object(submitter, "request_json", return_value={}) as request:
+            submitter.github_client("fixture-token")(f"repos/{REPO}/pulls/2445")
+            sent = request.call_args.args[0]
+            self.assertEqual(sent.get_method(), "GET")
+            self.assertEqual(sent.full_url, f"https://api.github.com/repos/{REPO}/pulls/2445")
+            self.assertEqual(sent.get_header("Authorization"), "Bearer fixture-token")
+
+    def test_json_rejects_malformed_duplicate_and_nonfinite_values(self):
+        for text in ("", "not json", '{"ok":true,"ok":false}', '{"sha":NaN}', b"\xff"):
+            with self.subTest(text=text), self.assertRaises(submitter.SubmissionError):
+                submitter.load_json(text)
+
+    def test_http_failures_do_not_expose_response_or_url_secrets(self):
+        request = Request("https://private.example.invalid/secret-url")
+        for error in (HTTPError(request.full_url, 403, "secret-token", {}, io.BytesIO(b"secret-body")),
+                      URLError("secret-token"), TimeoutError("secret-token")):
+            with patch.object(submitter, "build_opener") as opener:
+                opener.return_value.open.side_effect = error
+                with self.assertRaises(submitter.SubmissionError) as caught:
+                    submitter.request_json(request)
+                self.assertNotIn("secret", str(caught.exception))
+        self.assertIsNone(submitter.NoRedirect().redirect_request(request, None, 302, "", {},
+                                                                  "https://other.invalid"))
+
+    def test_json_transport_rejects_non_success_and_oversized_body(self):
+        for status, body in ((500, b'{}'), (200, b'x' * 2_000_001), (200, b'not json')):
+            with patch.object(submitter, "build_opener") as opener:
+                response = opener.return_value.open.return_value.__enter__.return_value
+                response.status = status
+                response.read.return_value = body
+                with self.assertRaises(submitter.SubmissionError):
+                    submitter.request_json(Request("https://example.invalid"))
+
+    def test_relay_transport_sends_pins_as_json_with_token_only_in_header(self):
+        with patch.object(submitter, "request_json", return_value={}) as request:
+            relay = submitter.relay_client("https://example.invalid/", "fixture-token")
+            relay("POST", "/api/pr-validate", {"sha": HEAD, "baseSha": LIVE_BASE})
+            sent = request.call_args.args[0]
+            self.assertEqual(sent.full_url, "https://example.invalid/api/pr-validate")
+            self.assertEqual(json.loads(sent.data), {"sha": HEAD, "baseSha": LIVE_BASE})
+            self.assertEqual(sent.get_header("X-api-key"), "fixture-token")
+            self.assertNotIn("fixture-token", sent.full_url)
+        for url in ("http://example.invalid", "https://user:secret@example.invalid", "https://example.invalid?q=1"):
+            with self.assertRaises(submitter.SubmissionError):
+                submitter.relay_client(url, "fixture-token")
+
+    def test_bad_config_cannot_put_tokens_in_error_messages(self):
+        for token in (None, "", "secret\nheader", "secret\rheader"):
+            for factory in (submitter.github_client,
+                            lambda value: submitter.relay_client("https://example.invalid", value)):
+                with self.assertRaises(submitter.SubmissionError) as caught:
+                    factory(token)
+                self.assertNotIn("secret", str(caught.exception))
+        for url in ("https://[secret", "https://example.invalid/\nsecret"):
+            with self.assertRaises(submitter.SubmissionError) as caught:
+                submitter.relay_client(url, "fixture-token")
+            self.assertNotIn("secret", str(caught.exception))
+
+    def test_workflow_resolve_output_is_consumed_by_actual_submit_entrypoint(self):
+        services = Services()
+        with tempfile.TemporaryDirectory() as directory:
+            event_path, output_path = Path(directory) / "event.json", Path(directory) / "output"
+            event_path.write_text(json.dumps(event()), encoding="utf-8")
+            env = {"GH_TOKEN": "fixture-token", "GITHUB_EVENT_NAME": "pull_request_target",
+                   "GITHUB_REPOSITORY": REPO, "GITHUB_EVENT_PATH": str(event_path),
+                   "GITHUB_OUTPUT": str(output_path), "RELAY": "https://relay.invalid",
+                   "TOKEN": "fixture-relay-token"}
+            with patch.dict(os.environ, env, clear=True), patch.object(submitter, "github_client", return_value=services.github), \
+                    patch.object(sys, "argv", ["submit_pr_validation.py", "resolve"]), patch("sys.stdout", new_callable=io.StringIO):
+                self.assertEqual(submitter.main(), 0)
+            outputs = dict(line.split("=", 1) for line in output_path.read_text(encoding="utf-8").splitlines())
+            self.assertEqual(outputs["head"], HEAD)
+            env["VALIDATION_PIN"] = outputs["pin"]
+            with patch.dict(os.environ, env, clear=True), patch.object(submitter, "github_client", return_value=services.github), \
+                    patch.object(submitter, "relay_client", return_value=services.relay), \
+                    patch.object(sys, "argv", ["submit_pr_validation.py", "submit"]), patch("sys.stdout", new_callable=io.StringIO) as output:
+                self.assertEqual(submitter.main(), 0)
+                self.assertNotIn("fixture", output.getvalue())
+            self.assertEqual(services.relay_requests[0][2]["baseSha"], LIVE_BASE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR #2445 was validated against GitHub's cached PR base (`690637e4`) after its source had already been composed with main (`666df563`). The private worker reproduced all 106 modules but rejected the unrelated coverage-denominator change introduced by that obsolete comparison.

Resolve the live target branch and current PR identity before submission, recheck them immediately before the relay request, and verify the returned job carries the same repository, PR, head and base. Add a PR-number-only manual retry for terminal jobs. Both jobs load the helper from the immutable workflow commit; the runner does not execute PR code, and only the private validator supplies the required verdict. Stale or incomplete path metadata cannot earn a documentation-only shortcut.

Validation: mocked API tests exercise the actual resolve-to-submit entrypoints, changed-head/base/target/fork races, malformed metadata, renamed and incomplete file lists, stale in-flight job pins and secret-safe transport failures. The new suite is included in the existing public tool-test command. An independent read-only run against #2445 confirmed the old cached base and the correctly selected live target without submitting a job.
