### PR TITLE
Judge Source review currency where the written policy places it

### DIFF
--- a/tools/check_pr_source_review.py
+++ b/tools/check_pr_source_review.py
@@ -12,8 +12,23 @@ from urllib.parse import quote
 
 import source_review as sr
 
+# A scheduled progress push advances main without changing anything a source
+# review reads. Skipping only those commits keeps the base currency requirement
+# satisfiable; every other commit on main still retires review acceptance.
+PROGRESS_BOT = "github-actions[bot]"
+COMMIT_FILE_CAP = 300  # The commit endpoint caps its file list; a cap hides scope.
+PROGRESS_WALK_LIMIT = 50
+_refresh_parents = {}
 
-def evaluate(state, head, base, files):
+
+def evaluate(state, head, bases, files):
+    """Judge the head against every target commit a source review could have read.
+
+    `bases` is ordered newest first: the branch tip, then each scheduled progress
+    commit skipped beneath it. Those commits differ only in paths no review
+    inspects, so a review recorded against any of them reviewed the same source.
+    """
+    reviewable = frozenset(bases)
     required = {p.casefold() for p in files if sr.source_path(p)}
     if not required:
         return {"result": "pass", "summary": "No reconstruction source, header or TU manifest changed."}
@@ -36,7 +51,8 @@ def evaluate(state, head, base, files):
                 continue
             try:
                 review = sr.validate_evidence(task, evidence, head, reviewer)
-                sr.require(evidence.get("tested_base") == base, "PR base changed since source review")
+                sr.require(evidence.get("tested_base") in reviewable,
+                           "PR base changed since source review")
                 sr.require(evidence.get("workflow_commit") == policy, "review uses an older policy")
                 covered.update(p.casefold() for p in review["files"])
                 accepted.append(task["task_id"])
@@ -73,8 +89,52 @@ def queue_state(repo):
     return sha, contents
 
 
+def progress_refresh(data, sha):
+    """True for a single-parent bot commit that changes nothing a review inspects."""
+    parents, files = data.get("parents"), data.get("files")
+    if (data.get("sha") != sha or not isinstance(parents, list) or len(parents) != 1
+            or not isinstance(files, list) or len(files) >= COMMIT_FILE_CAP
+            or any(not isinstance(who, dict) or who.get("login") != PROGRESS_BOT
+                   for who in (data.get("author"), data.get("committer")))):
+        return False
+    for item in files:
+        if not isinstance(item, dict) or "filename" not in item:
+            return False
+        for path in (item["filename"], item.get("previous_filename", "")):
+            if not isinstance(path, str) or sr.source_path(path):
+                return False
+    return True
+
+
+def refresh_parent(repo, sha):
+    """Parent of a scheduled progress commit, or None for every other commit.
+
+    Main advances on a timer: the progress-refresh workflow pushes README, docs
+    and contributions.json under `github-actions[bot]` with no source content.
+    Requiring every open composition to contain that push makes Source review
+    unsatisfiable, because no branch can outrun a scheduler. Only commits that
+    change nothing a source review reads are skipped, so a real change to main
+    still moves the review base and retires acceptance.
+    """
+    if (repo, sha) in _refresh_parents:
+        return _refresh_parents[repo, sha]
+    try:
+        data = api(f"repos/{repo}/commits/{sha}")
+        parent = (sr.commit(data["parents"][0]["sha"], "progress refresh parent")
+                  if progress_refresh(data, sha) else None)
+    except (RuntimeError, sr.ReviewError, ValueError, KeyError, TypeError):
+        return None  # Unknown scope keeps the branch tip; it never widens acceptance.
+    _refresh_parents[repo, sha] = parent  # Commits are immutable; one read per sweep.
+    return parent
+
+
 def target_branch(repo, pr):
-    """Resolve the live target ref; PR base.sha can retain an older commit."""
+    """Resolve the live target ref; PR base.sha can retain an older commit.
+
+    Returns the branch and its reviewable target commits, newest first: the exact
+    branch tip, then each scheduled progress commit skipped beneath it. Ancestry
+    is judged against the oldest, acceptance against any of them.
+    """
     base = pr["base"]
     base_repo = base["repo"]["full_name"]
     sr.require(isinstance(base_repo, str) and base_repo.casefold() == repo.casefold(),
@@ -84,7 +144,13 @@ def target_branch(repo, pr):
     ref = api(f"repos/{repo}/git/ref/heads/{quote(branch, safe='')}")
     sr.require(ref["ref"] == "refs/heads/" + branch, "API returned a different target ref")
     sr.require(ref["object"]["type"] == "commit", "Target branch does not identify a commit")
-    return branch, sr.commit(ref["object"]["sha"], "target branch commit")
+    bases = [sr.commit(ref["object"]["sha"], "target branch commit")]
+    while len(bases) <= PROGRESS_WALK_LIMIT:
+        parent = refresh_parent(repo, bases[-1])
+        if parent is None:
+            break
+        bases.append(parent)
+    return branch, tuple(bases)
 
 
 def commit_tree(repo, commit):
@@ -156,24 +222,39 @@ def complete_tree(repo, sha, cache):
     return leaves
 
 
-def changed_paths(repo, base, head):
-    """Compare the exact composition, not PR /files metadata for a cached base.
+def locate_composition(repo, base, head):
+    """Find where the composition left the target, and whether it still contains it.
 
-    The composition must retain its base ancestry (queue-v2.md and
-    SOURCE-REVIEW-CUTOVER.md). A stale branch needs a new composition and review.
+    Two different questions share one comparison. Scope -- what this PR changes --
+    is measured from the merge base, which is the content a reviewer reads and the
+    only content merging the PR can introduce. Currency -- whether an existing
+    review still applies -- is the separate judgement the caller imposes on a PR
+    that actually changes reviewable source (queue-v2.md and
+    SOURCE-REVIEW-CUTOVER.md): a stale branch needs a new composition and review.
     Compare metadata establishes ancestry only: its files list is capped at 300,
-    even with pagination. Git tree objects supply the complete changed-path set.
-    Leaf comparison retains both rename sides and mode/type changes, including
-    symlinks, submodules, and file/directory replacements.
+    even with pagination.
     """
     base = sr.commit(base, "comparison base")
     head = sr.commit(head, "comparison head")
     comparison = api(f"repos/{repo}/compare/{base}...{head}?per_page=1")
     sr.require(comparison["base_commit"]["sha"] == base,
                "Comparison returned a different base")
-    sr.require(comparison["merge_base_commit"]["sha"] == base and
-               comparison["status"] in ("ahead", "identical"),
-               "PR head does not contain the live target base; restack and review the composition")
+    merge_base = sr.commit(comparison["merge_base_commit"]["sha"], "comparison merge base")
+    status = comparison["status"]
+    sr.require(status in ("ahead", "behind", "identical", "diverged"),
+               "Comparison returned an unusable status; the composition cannot be scoped")
+    return merge_base, merge_base == base and status in ("ahead", "identical")
+
+
+def changed_paths(repo, base, head):
+    """Compare the exact composition, not PR /files metadata for a cached base.
+
+    Git tree objects supply the complete changed-path set. Leaf comparison retains
+    both rename sides and mode/type changes, including symlinks, submodules, and
+    file/directory replacements.
+    """
+    base = sr.commit(base, "comparison base")
+    head = sr.commit(head, "comparison head")
     before_tree, after_tree = commit_tree(repo, base), commit_tree(repo, head)
     if before_tree == after_tree:
         return []
@@ -189,19 +270,25 @@ def check_pr(repo, number, publish=False):
     if pr["state"] != "open":
         return {"pr": number, "result": "closed"}
     head = pr["head"]["sha"]
-    base, branch = None, None
+    base, tip, branch = None, None, None
     state_sha = None
     try:
-        branch, base = target_branch(repo, pr)
-        paths = changed_paths(repo, base, head)
+        branch, bases = target_branch(repo, pr)
+        tip, base = bases[0], bases[-1]
+        merge_base, retains_base = locate_composition(repo, base, head)
+        paths = changed_paths(repo, merge_base, head)
         if any(sr.source_path(p) for p in paths):
+            # Currency is required of the PRs the policy is about. A PR that
+            # changes no reviewable source has no review to keep current.
+            sr.require(retains_base, "PR head does not contain the live target base;"
+                       " restack and review the composition")
             state_sha, state = queue_state(repo)
         else:
             state = {}
-        report = evaluate(state, head, base, paths)
+        report = evaluate(state, head, bases, paths)
     except (RuntimeError, sr.ReviewError, ValueError, KeyError, TypeError) as exc:
         report = {"result": "fail", "summary": "Source review could not be established: " + str(exc)}
-    report.update(pr=number, head=head, base=base, base_ref=branch,
+    report.update(pr=number, head=head, base=base, base_ref=branch, target_tip=tip,
                   pr_base=pr["base"].get("sha"), queue_commit=state_sha)
     if not publish and report["result"] != "pass":
         return report
@@ -217,10 +304,13 @@ def check_pr(repo, number, publish=False):
                 report.update(result="fail", summary="Queue changed during review; refresh the check.")
         # Read the actual branch tip last, before returning or creating a check.
         # Re-reading the PR's cached base.sha cannot detect main advancing.
-        current_branch, current_base = target_branch(repo, current)
-        if (current_branch, current_base) != (branch, base):
+        # Compare the reviewable target, not the tip: a progress push landing
+        # mid-check changes no reviewed content and must not void the verdict.
+        current_branch, current_bases = target_branch(repo, current)
+        if (current_branch, current_bases[-1]) != (branch, base):
             report.update(result="fail", summary="Target branch changed during review; refresh the check.",
-                          observed_base=current_base, observed_base_ref=current_branch)
+                          observed_base=current_bases[-1], observed_base_ref=current_branch,
+                          observed_tip=current_bases[0])
     except (RuntimeError, sr.ReviewError, ValueError, KeyError, TypeError) as exc:
         report.update(result="fail", summary="Final review inputs could not be confirmed: " + str(exc))
     if publish and current_head_confirmed:

--- a/tools/test_check_pr_source_review.py
+++ b/tools/test_check_pr_source_review.py
@@ -21,6 +21,21 @@ def pull_request(branch="main"):
             "changed_files": 1}
 
 
+def authored_commit(sha, parent="0" * 40):
+    """A person's commit on main: it retires review acceptance however small it is."""
+    return {"sha": sha, "parents": [{"sha": parent}],
+            "author": {"login": "andrewboudreau"}, "committer": {"login": "web-flow"},
+            "files": [{"filename": "notes/handoff.md"}]}
+
+
+def progress_commit(sha, parent, files=("contributions.json", "docs/index.html",
+                                        "docs/progress-treemap.svg", "README.md")):
+    """The real shape of main's scheduled tip advance; see PR 2564's check history."""
+    return {"sha": sha, "parents": [{"sha": parent}],
+            "author": {"login": gate.PROGRESS_BOT}, "committer": {"login": gate.PROGRESS_BOT},
+            "files": [{"filename": path} for path in files]}
+
+
 def state():
     return {"schema": 3, "source_review_policy": {"workflow_commit": WORKFLOW}, "tasks": {
         "actor": {"task_id": "actor", "phase": "done", "input_session": "producer",
@@ -46,16 +61,28 @@ class PRSourceReviewTest(unittest.TestCase):
             "-H", "Accept: application/vnd.github.raw+json"])
 
     def test_old_queue_and_unreviewed_source_block_but_tooling_can_land(self):
-        self.assertEqual(gate.evaluate({}, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
-        self.assertEqual(gate.evaluate({}, HEAD, BASE, ["tools/source_review.py"])["result"], "pass")
-        self.assertEqual(gate.evaluate({}, HEAD, BASE, ["config/arm9/delinks.txt"])["result"], "fail")
+        self.assertEqual(gate.evaluate({}, HEAD, (BASE,), ["src/actor.cpp"])["result"], "fail")
+        self.assertEqual(gate.evaluate({}, HEAD, (BASE,), ["tools/source_review.py"])["result"], "pass")
+        self.assertEqual(gate.evaluate({}, HEAD, (BASE,), ["config/arm9/delinks.txt"])["result"], "fail")
 
     def test_exact_published_review_passes_and_stale_or_partial_review_fails(self):
-        self.assertEqual(gate.evaluate(state(), HEAD, BASE, ["src/actor.cpp"])["result"], "pass")
-        for head, base, files in ((WORKFLOW, BASE, ["src/actor.cpp"]),
-                                  (HEAD, WORKFLOW, ["src/actor.cpp"]),
-                                  (HEAD, BASE, ["src/actor.cpp", "src/unreviewed.cpp"])):
-            self.assertEqual(gate.evaluate(state(), head, base, files)["result"], "fail")
+        self.assertEqual(gate.evaluate(state(), HEAD, (BASE,), ["src/actor.cpp"])["result"], "pass")
+        for head, bases, files in ((WORKFLOW, (BASE,), ["src/actor.cpp"]),
+                                   (HEAD, (WORKFLOW,), ["src/actor.cpp"]),
+                                   (HEAD, (BASE,), ["src/actor.cpp", "src/unreviewed.cpp"])):
+            self.assertEqual(gate.evaluate(state(), head, bases, files)["result"], "fail")
+
+    def test_review_of_any_skipped_progress_commit_is_a_review_of_the_same_source(self):
+        """A reviewer may record the branch tip or the source it actually read."""
+        for tested in (WORKFLOW, BASE):
+            snapshot = state()
+            snapshot["tasks"]["actor"]["outputs"][0]["evidence"].update(tested_base=tested)
+            snapshot["tasks"]["actor"]["outputs"][0]["evidence"][
+                "source_review"]["reviewed_base"] = tested
+            self.assertEqual(gate.evaluate(snapshot, HEAD, (WORKFLOW, BASE),
+                                           ["src/actor.cpp"])["result"], "pass")
+        self.assertEqual(gate.evaluate(state(), HEAD, (WORKFLOW, "e" * 40),
+                                       ["src/actor.cpp"])["result"], "fail")
 
     def test_self_review_cancelled_task_and_unstructured_pass_fail(self):
         for change in ("author", "cancelled", "bare"):
@@ -67,7 +94,7 @@ class PRSourceReviewTest(unittest.TestCase):
                 task["phase"] = "cancelled"
             else:
                 task["outputs"][0]["evidence"] = {"verdict": "pass", "tested_commit": HEAD}
-            self.assertEqual(gate.evaluate(snapshot, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
+            self.assertEqual(gate.evaluate(snapshot, HEAD, (BASE,), ["src/actor.cpp"])["result"], "fail")
 
     def test_integrator_cannot_invent_an_independent_composition_reviewer(self):
         snapshot = state()
@@ -75,7 +102,7 @@ class PRSourceReviewTest(unittest.TestCase):
         output["commit"] = BASE
         output["evidence"].update(composition_commit=HEAD, composition_base=BASE,
                                  composition_independent_verification=evidence())
-        self.assertEqual(gate.evaluate(snapshot, HEAD, BASE, ["src/actor.cpp"])["result"], "fail")
+        self.assertEqual(gate.evaluate(snapshot, HEAD, (BASE,), ["src/actor.cpp"])["result"], "fail")
 
     def test_queue_change_before_publication_emits_failure(self):
         pr = pull_request()
@@ -91,10 +118,13 @@ class PRSourceReviewTest(unittest.TestCase):
                 return {"ref": "refs/heads/main", "object": {"type": "commit", "sha": BASE}}
             if "/git/ref/" in path:
                 return {"object": {"sha": "e" * 40}}
+            if "/commits/" in path:
+                return authored_commit(path.rsplit("/", 1)[1])
             return copy.deepcopy(pr)
 
         with patch.object(gate, "api", side_effect=api), patch.object(
                 gate, "queue_state", return_value=("d" * 40, state())), patch.object(
+                gate, "locate_composition", return_value=(BASE, True)), patch.object(
                 gate, "changed_paths", return_value=["src/actor.cpp"]):
             result = gate.check_pr("tangosdev/sm64ds-decomp", 2447, publish=True)
         self.assertEqual(result["result"], "fail")
@@ -103,8 +133,18 @@ class PRSourceReviewTest(unittest.TestCase):
 
 
 class TargetBranchReviewTest(unittest.TestCase):
+    def setUp(self):
+        gate._refresh_parents.clear()
+
+    def assert_target_resolved_last(self, calls, published=False):
+        """Nothing but the progress walk may follow the final branch tip read."""
+        ref = max(i for i, path in enumerate(calls) if path.endswith("/git/ref/heads/main"))
+        after = [path for path in calls[ref + 1:] if "/commits/" not in path]
+        self.assertEqual(after, ["repos/tangosdev/sm64ds-decomp/check-runs"] if published else [])
+
     def run_fixture(self, refs, review_base=BASE, publish=False, source=True,
-                    branch="main", final_branch=None, final_head=None, final_state=None):
+                    branch="main", final_branch=None, final_head=None, final_state=None,
+                    progress=(), retains_base=True):
         snapshot = state()
         output = snapshot["tasks"]["actor"]["outputs"][0]["evidence"]
         output["tested_base"] = review_base
@@ -132,6 +172,12 @@ class TargetBranchReviewTest(unittest.TestCase):
                     return value
                 return {"ref": "refs/" + unquote(path.split("/git/ref/")[1]),
                         "object": {"type": "commit", "sha": value}}
+            if "/commits/" in path:
+                sha = path.rsplit("/", 1)[1]
+                value = dict(progress).get(sha)
+                if isinstance(value, Exception):
+                    raise value
+                return value if value is not None else authored_commit(sha)
             if "/pulls/" in path:
                 reads += 1
                 current = copy.deepcopy(pr)
@@ -144,8 +190,12 @@ class TargetBranchReviewTest(unittest.TestCase):
                 return current
             raise AssertionError("Unexpected API request: " + path)
 
+        def composition(repo, base, head):
+            return base, retains_base
+
         with patch.object(gate, "api", side_effect=api), patch.object(
                 gate, "queue_state", return_value=("d" * 40, snapshot)) as queue, patch.object(
+                gate, "locate_composition", side_effect=composition), patch.object(
                 gate, "changed_paths", return_value=["src/actor.cpp" if source else "tools/inert.py"]):
             result = gate.check_pr("tangosdev/sm64ds-decomp", 2447, publish=publish)
         return result, calls, posts, queue.call_count
@@ -160,12 +210,88 @@ class TargetBranchReviewTest(unittest.TestCase):
         current, _, _, _ = self.run_fixture([tip, tip], review_base=tip)
         self.assertEqual(current["result"], "pass")
 
+    def test_scheduled_progress_push_does_not_retire_a_current_review(self):
+        """PR 2564: the same head passed, main's timer fired, the same head failed.
+
+        The tip advanced by a bot commit touching only contributions.json. No
+        review could read it differently, so it cannot invalidate one.
+        """
+        tip = "e" * 40
+        for review_base in (BASE, tip):
+            with self.subTest(review_base=review_base):
+                result, _, _, _ = self.run_fixture([tip, tip], review_base=review_base,
+                                                   progress={tip: progress_commit(tip, BASE)})
+                self.assertEqual(result["result"], "pass")
+                self.assertEqual(result["base"], BASE)
+                self.assertEqual(result["target_tip"], tip)
+
+    def test_consecutive_progress_pushes_collapse_to_one_reviewable_target(self):
+        first, second = "e" * 40, "f" * 40
+        result, _, _, _ = self.run_fixture(
+            [second, second], review_base=BASE,
+            progress={second: progress_commit(second, first),
+                      first: progress_commit(first, BASE)})
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual((result["base"], result["target_tip"]), (BASE, second))
+
+    def test_a_person_s_commit_on_main_still_retires_review_acceptance(self):
+        """The written policy: a changed head/base must lose that acceptance."""
+        tip = "e" * 40
+        result, _, _, _ = self.run_fixture([tip, tip], review_base=BASE)
+        self.assertEqual(result["result"], "fail")
+        self.assertEqual(result["base"], tip)
+
+    def test_only_source_inert_single_parent_bot_commits_are_skipped(self):
+        tip = "e" * 40
+        cases = {
+            "changes source": progress_commit(tip, BASE, ("contributions.json", "src/actor.cpp")),
+            "changes enrollment": progress_commit(tip, BASE, ("config/arm9/symbols.txt",)),
+            "renames source away": dict(progress_commit(tip, BASE, ("notes/moved.md",)), files=[
+                {"filename": "notes/moved.md", "previous_filename": "src/actor.cpp"}]),
+            "human author": dict(progress_commit(tip, BASE), author={"login": "andrewboudreau"}),
+            "human committer": dict(progress_commit(tip, BASE), committer={"login": "web-flow"}),
+            "merge commit": dict(progress_commit(tip, BASE),
+                                 parents=[{"sha": BASE}, {"sha": WORKFLOW}]),
+            "capped file list": progress_commit(
+                tip, BASE, tuple(f"docs/page-{n}.html" for n in range(gate.COMMIT_FILE_CAP))),
+            "different commit": dict(progress_commit(tip, BASE), sha="0" * 40),
+            "no file list": {k: v for k, v in progress_commit(tip, BASE).items() if k != "files"},
+            "unnamed file": dict(progress_commit(tip, BASE), files=[{"status": "modified"}]),
+            "malformed parent": dict(progress_commit(tip, BASE), parents=[{"sha": "short"}]),
+            "unreadable commit": RuntimeError("commit unavailable"),
+        }
+        for name, reply in cases.items():
+            with self.subTest(case=name):
+                gate._refresh_parents.clear()
+                result, _, _, _ = self.run_fixture([tip, tip], review_base=BASE,
+                                                   progress={tip: reply})
+                self.assertEqual(result["result"], "fail")
+                self.assertEqual(result["base"], tip)
+
+    def test_progress_push_during_review_does_not_void_the_verdict(self):
+        later, tip = "f" * 40, "e" * 40
+        result, _, posts, _ = self.run_fixture(
+            [tip, later], review_base=BASE, publish=True,
+            progress={tip: progress_commit(tip, BASE), later: progress_commit(later, tip)})
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual(posts[0]["conclusion"], "success")
+        self.assertIn(":" + BASE + ":", posts[0]["external_id"])
+
+    def test_nothing_reviewable_is_decided_before_base_currency(self):
+        """A PR with no source in scope has no review to keep current."""
+        result, _, _, reads = self.run_fixture([BASE, BASE], source=False, retains_base=False)
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual(reads, 0)
+        stale_source, _, _, _ = self.run_fixture([BASE, BASE], retains_base=False)
+        self.assertEqual(stale_source["result"], "fail")
+        self.assertIn("restack", stale_source["summary"])
+
     def test_target_advance_during_read_only_evaluation_invalidates_success(self):
         result, calls, posts, _ = self.run_fixture([BASE, "e" * 40])
         self.assertEqual(result["result"], "fail")
         self.assertEqual(result["observed_base"], "e" * 40)
         self.assertEqual(posts, [])
-        self.assertTrue(calls[-1].endswith("/git/ref/heads/main"))
+        self.assert_target_resolved_last(calls)
 
     def test_final_read_failure_also_blocks_read_only_integrator_check(self):
         result, _, posts, _ = self.run_fixture([BASE, RuntimeError("ref unavailable")])
@@ -190,8 +316,7 @@ class TargetBranchReviewTest(unittest.TestCase):
         self.assertEqual(result["result"], "fail")
         self.assertIn("Target branch changed", result["summary"])
         self.assertEqual(posts[0]["conclusion"], "failure")
-        self.assertTrue(calls[-2].endswith("/git/ref/heads/main"))
-        self.assertTrue(calls[-1].endswith("/check-runs"))
+        self.assert_target_resolved_last(calls, published=True)
 
     def test_current_base_review_can_publish_despite_retained_pr_base_metadata(self):
         tip = "e" * 40
@@ -264,14 +389,18 @@ def blob(value, mode="100644", kind="blob"):
 
 class TreeAPI:
     """Git metadata fixtures; tree contents are never fetched or executed."""
-    def __init__(self, before, after, base=BASE, head=HEAD):
-        self.base, self.head = base, head
+    def __init__(self, before, after, base=BASE, head=HEAD, common=None):
+        self.base, self.head, self.common = base, head, "9" * 40
         self.objects, self.overrides, self.calls = {}, {}, []
         self.before_tree, self.after_tree = self.build(before), self.build(after)
+        self.common_tree = self.build(common) if common is not None else self.before_tree
         self.pr = pull_request()
         self.pr["head"]["sha"] = head
         self.comparison = {"base_commit": {"sha": base},
                            "merge_base_commit": {"sha": base}, "status": "ahead"}
+        if common is not None:
+            # Main moved on after this branch left it: the merge base is neither end.
+            self.comparison.update(merge_base_commit={"sha": self.common}, status="diverged")
 
     def build(self, leaves):
         root = {}
@@ -311,7 +440,8 @@ class TreeAPI:
             return copy.deepcopy(self.comparison)
         if "/git/commits/" in path:
             sha = path.rsplit("/", 1)[1]
-            tree = {self.base: self.before_tree, self.head: self.after_tree}[sha]
+            tree = {self.base: self.before_tree, self.head: self.after_tree,
+                    self.common: self.common_tree}[sha]
             return copy.deepcopy(self.overrides.get(sha, {"sha": sha, "tree": {"sha": tree}}))
         if "/git/trees/" in path:
             sha = path.rsplit("/", 1)[1].split("?")[0]
@@ -330,6 +460,13 @@ class TreeAPI:
         with patch.object(gate, "api", side_effect=self.api):
             return gate.changed_paths("tangosdev/sm64ds-decomp", self.base, self.head)
 
+    def scope(self):
+        """What the PR changes, measured the way check_pr measures it."""
+        with patch.object(gate, "api", side_effect=self.api):
+            merge_base, retains = gate.locate_composition(
+                "tangosdev/sm64ds-decomp", self.base, self.head)
+            return gate.changed_paths("tangosdev/sm64ds-decomp", merge_base, self.head), retains
+
     def check(self, reviewed=("src/actor.cpp", "include/actor.h")):
         snapshot = state()
         task = snapshot["tasks"]["actor"]
@@ -338,7 +475,7 @@ class TreeAPI:
                                   evidence=evidence(head=self.head, base=self.base))
         task["outputs"][0]["evidence"]["source_review"]["files"] = list(reviewed)
         with patch.object(gate, "api", side_effect=self.api), patch.object(
-                gate, "target_branch", return_value=("main", self.base)), patch.object(
+                gate, "target_branch", return_value=("main", (self.base,))), patch.object(
                 gate, "queue_state", return_value=("d" * 40, snapshot)):
             return gate.check_pr("tangosdev/sm64ds-decomp", 2445)
 
@@ -508,17 +645,35 @@ class ExactTreeScopeTest(unittest.TestCase):
                 fixture.overrides[HEAD] = data
                 self.assertEqual(fixture.check()["result"], "fail")
 
-    def test_nonancestor_and_unrelated_heads_need_a_new_composition(self):
-        for status in ("behind", "diverged", "unrelated"):
+    def test_nonancestor_source_heads_need_a_new_composition(self):
+        for status in ("behind", "diverged"):
             with self.subTest(status=status):
-                fixture = TreeAPI({}, {"tools/inert.py": blob("new")})
-                fixture.comparison.update(status=status, merge_base_commit={"sha": "e" * 40})
+                fixture = TreeAPI({}, {"src/unreviewed.cpp": blob("new")})
+                fixture.comparison.update(status=status)
                 result = fixture.check()
                 self.assertEqual(result["result"], "fail")
                 self.assertIn("restack", result["summary"])
-        fixture = TreeAPI({}, {"tools/inert.py": blob("new")})
-        fixture.comparison = {}
-        self.assertEqual(fixture.check()["result"], "fail")
+        for comparison in ({}, {"base_commit": {"sha": BASE}, "status": "unrelated",
+                                "merge_base_commit": {"sha": BASE}}):
+            with self.subTest(comparison=comparison):
+                fixture = TreeAPI({}, {"tools/inert.py": blob("new")})
+                fixture.comparison = comparison
+                self.assertEqual(fixture.check()["result"], "fail")
+
+    def test_scope_is_measured_from_the_merge_base_not_the_branch_tip(self):
+        """Merging can only introduce what the branch changed since the merge base.
+
+        Main landing src/landed.cpp is not this PR deleting it, and main's tip is
+        not this PR's base. The complete tree-derived path set still holds.
+        """
+        fixture = TreeAPI(before={"src/actor.cpp": blob("old"), "src/landed.cpp": blob("main")},
+                          after={"src/actor.cpp": blob("new"), "tools/helper.py": blob("new")},
+                          common={"src/actor.cpp": blob("old")})
+        paths, retains = fixture.scope()
+        self.assertEqual(paths, ["src/actor.cpp", "tools/helper.py"])
+        self.assertFalse(retains)
+        self.assertIn("src/landed.cpp", fixture.paths())  # The old base...head measure.
+        self.assertIn("restack", fixture.check()["summary"])
 
     def test_missing_subtree_and_tree_cycles_fail_closed(self):
         for cycle in (False, True):

--- a/tools/test_check_pr_source_review.py
+++ b/tools/test_check_pr_source_review.py
@@ -663,8 +663,9 @@ class ExactTreeScopeTest(unittest.TestCase):
     def test_scope_is_measured_from_the_merge_base_not_the_branch_tip(self):
         """Merging can only introduce what the branch changed since the merge base.
 
-        Main landing src/landed.cpp is not this PR deleting it, and main's tip is
-        not this PR's base. The complete tree-derived path set still holds.
+        A source file landing on main after the branch point is not this PR
+        deleting it, and main's tip is not this PR's base. The complete
+        tree-derived path set still holds.
         """
         fixture = TreeAPI(before={"src/actor.cpp": blob("old"), "src/landed.cpp": blob("main")},
                           after={"src/actor.cpp": blob("new"), "tools/helper.py": blob("new")},


### PR DESCRIPTION
## The measured problem

All 117 open PRs fail the `Source review` check. I read the latest check run on
every open head: **117 of 117 are `failure`**, 116 with

```
Source review could not be established: PR head does not contain the live target base;
restack and review the composition
```

and one with its race variant, `Target branch changed during review`.

The mechanism is in the check itself, not in any branch.
`check_pr_source_review.target_branch()` resolves `refs/heads/main` **live**, and
`changed_paths()` then required `comparison["merge_base_commit"] == base` with
`status in ("ahead", "identical")` — that is, it required every PR head to
*contain main's tip at check time*.

Main's tip advances on a bot timer. Of main's last 40 commits, **14 are
`Refresh progress (README, treemap, contributions, provenance, langmode) [skip ci]`
from `github-actions[bot]`**, single-parent, author and committer both the bot,
one to four files each.
Their entire file lists are `contributions.json`, `docs/index.html`,
`docs/progress-treemap.svg` and `README.md`; the three most recent touch
`contributions.json` alone. Nothing in `source_path()`. No branch can outrun a
scheduler, so the requirement was unsatisfiable by construction.

### PR #2564: the same commit, opposite verdicts

Head `6478ee3e7`, a tools-only PR, has 23 `Source review` check runs. The first two
passed:

| completed | conclusion | title |
|---|---|---|
| 2026-09-11T01:23:51Z | success | No reconstruction source, header or TU manifest changed. |
| 2026-09-11T01:26:17Z | success | No reconstruction source, header or TU manifest changed. |
| 2026-09-11T01:35:06Z | failure | Source review could not be established: PR head does not contain the live target base… |
| …21 more | failure | (identical) |

Same head, same tree, same content. Main's timer fired between 01:26 and 01:35 and
the verdict inverted. Note the ordering that made this possible: the currency check
ran *before* the "nothing to review" determination, so a PR with zero reviewable
content failed on staleness alone.

## The policy this preserves

`notes/agents/SOURCE-REVIEW-CUTOVER.md` line 74:

> a populated independently published review must pass for the exact head/base;
> **a changed head/base must lose that acceptance.**

`notes/agents/queue-v2.md` line 230:

> The composition must preserve the accepted source and declared base as ancestors.

And the cutover assigns up-to-dateness at merge time to the repository ruleset,
not to this check (line 71):

> Require branches to be up to date before merging, so a check for an old base
> cannot authorize a newer composition.

**This PR does not weaken any of that.** A commit a person lands on main still
retires review acceptance immediately. A diverged or behind source head still fails
with the same `restack` message. A review naming a base outside the skipped set
still fails with `PR base changed since source review`. Nothing about the evidence
requirements, the independence rule, the policy pin or the coverage rule changes.

## What changed

`changed_paths()` fused two different jobs. The change separates them.

1. **`locate_composition()`** reports the merge base and whether the head still
   contains the target. It judges neither.
2. **`changed_paths()`** is now the tree diff alone, measured from the **merge
   base**. That is the content a reviewer reads and the only content merging the PR
   can introduce. Main landing `src/landed.cpp` is not this PR deleting it — under
   the old two-ended measure it was.
3. **`check_pr()`** imposes the currency requirement only on a PR that actually
   changes reviewable source. A PR with nothing to review has no review to keep
   current. This is the #2564 defect, fixed at its root.
4. **`target_branch()`** walks back from the branch tip over single-parent
   `github-actions[bot]` commits whose every changed path is outside
   `source_path()`, and returns the tip plus each commit skipped beneath it.
   `evaluate()` accepts a review recorded against any of them, because they differ
   only in paths no review inspects — so a reviewer may record the tip they read or
   the base the check resolves, and either is right.
5. The final pre-publication re-read compares the **reviewable target**, not the
   tip, so a progress push landing mid-check no longer voids a verdict.

The walk fails closed on everything else: a merge commit (more than one parent), a
human author or committer, a file list at the API's 300-entry cap, a mismatched
commit id, a missing file list, a malformed parent, an unreadable commit, and any
commit touching a `source_path()` path on either side of a rename. Results are
cached per `(repo, sha)`, so a full sweep costs one extra API read per distinct tip,
not one per PR.

## Options considered

- **(a) Walk past source-inert scheduled bot commits — chosen.** It removes exactly
  the part of the requirement that no branch can satisfy, and nothing else. After
  it, acceptance is lost only to a deliberate human action, which is what the policy
  sentence is about.
- **(b) Compute changed paths from `merge_base_commit` rather than requiring it to
  equal the base — taken, as part of (a).** On its own it fixes nothing: a source PR
  still fails in `evaluate()` on `tested_base`. It is included because it is the
  correct measure of a PR's scope, and because (c) needs a path set to exist before
  the currency question can be asked.
- **(c) Decide "nothing to review" before currency — taken, as part of (a).** This
  is the #2564 shape and is the only part of this change that moves any PR green
  today.
- **(d) Widen the walk to *any* single-parent commit with no `source_path()` in it,
  dropping the bot restriction — rejected, with the measurement.** It is arguably
  the more principled rule, since it reuses the same predicate the check uses to
  decide what needs review. I measured it: 30 of main's last 40 commits are
  source-inert by that test — 14 the bot's, 4 merge commits the single-parent rule
  excludes anyway, and 12 single-parent commits from people. Only 10 of the 40 touch
  a `source_path()` at all. It would move the resolved base from `e3707be70`
  back to `e14ab3a3a`, and **72 of the 117 open heads contain `e14ab3a3a` while 0
  contain `e3707be70`**. I still rejected it, because I checked what those 72 would
  then be judged against: of the 117 open PR heads, **only 4 have any independently
  published verify output in the queue at all, and all 4 carry a `workflow_commit`
  that is not the active policy pin** `18af52b49`. So (d) would turn 72 PRs from one
  red message into a different red message and move **zero** of them green. It buys
  no PR anything today while widening a review gate, and it is a policy call for the
  repository owner rather than a defect fix. The numbers are here if you want it.
- **"No code change; this is a policy decision" — rejected.** The policy is already
  written and this PR keeps it. What was broken was an implementation detail: an
  ancestry test fused into a scope computation, applied to PRs that have nothing to
  review, against a commit id that a timer rewrites.

## Effect, measured

I ran the changed checker read-only (`--publish` withheld) over all 117 open PRs:

| | before | after |
|---|---|---|
| pass | 0 | **2** (#2471, #2564) |
| fail | 117 | 115 |

Both new passes are genuinely outside the policy's scope. Confirmed with
`git diff --name-only <merge-base>...<head>`, not PR metadata: #2471 changes
`.github/workflows/decl-agreement.yml`, `AGENTS.md`,
`config/decl-agreement-baseline.json`, `tools/check_decl_agreement.py`,
`tools/test_check_decl_agreement.py`; #2564 changes `tools/tiers_ratchet.py` and
`tools/test_tiers_ratchet.py`. No `source_path()` among them.

**What is still red, and honestly why.** The other 115 all change reviewable source,
and all still fail the currency requirement — because `e3707be70` landed on main a
short time before I measured and no open head contains it yet. That is the policy
working as written, not the treadmill: it is cleared by one restack plus a review,
and it then *stays* cleared through every progress push, which was not true before.

Two further honest points:

- The green count is a snapshot taken minutes after a commit landed on main. It is
  not a structural ceiling.
- The currency failure was masking the real state of the backlog. **113 of the 117
  open PRs have no independently published source review at any of their heads**, and
  the remaining 4 (#2487, #2490, #2500, #2501) predate the active policy pin. Those
  PRs need review through the queue; no change to this checker can make them green,
  and none should.

No open PR moves green → red: all 117 were already red.

## Tests

`python -m unittest discover -s tools -p 'test_*source_review.py'`, unpiped:
**43 passed before, 51 passed after**. `test_source_coverage.py`: 25 passed both.

New tests that fail without this change:

- `test_scheduled_progress_push_does_not_retire_a_current_review` — the #2564
  mechanism, with a review recorded at either the tip or the skipped base.
- `test_consecutive_progress_pushes_collapse_to_one_reviewable_target`
- `test_progress_push_during_review_does_not_void_the_verdict` — the mid-check race.
- `test_nothing_reviewable_is_decided_before_base_currency` — a tools-only stale head
  passes; the same shape carrying source still fails with `restack`.
- `test_scope_is_measured_from_the_merge_base_not_the_branch_tip` — asserts the old
  two-ended measure and the new one differ, and names the file that proves it.
- `test_review_of_any_skipped_progress_commit_is_a_review_of_the_same_source`

New tests that pin the policy, and would fail if this change went further:

- `test_a_person_s_commit_on_main_still_retires_review_acceptance`
- `test_only_source_inert_single_parent_bot_commits_are_skipped` — 12 cases: changes
  source, changes enrollment config, renames source away, human author, human
  committer, merge commit, capped file list, mismatched commit id, missing file list,
  unnamed file, malformed parent, unreadable commit. Every one keeps the tip.
- `test_nonancestor_source_heads_need_a_new_composition`

I also ran both modules side by side on identical fixtures. Controls C, D and E
(a person's commit on main; a head containing the tip with an older review; a head
containing the tip with a matching review) return the same verdict before and after.
Only A (progress push) and B (#2564's shape) change, both red → green.

## Scope

`tools/check_pr_source_review.py` and `tools/test_check_pr_source_review.py` only.
No `config/`, no `src/`, no workflow change — `source-review.yml` already runs
default-branch tools and needs nothing new. Tools-only, so this PR needs no source
review of its own, which is also the behaviour it restores for others.

Merging this does **not** disturb existing review evidence: the policy pin
`source_review_policy.workflow_commit` is set once by
`classqueue_v2.enable_source_review()` and is not re-derived from the file, so
`18af52b49` stays the active pin and every `workflow_commit` comparison is unchanged.

## One unrelated red, reported not fixed

This PR's `references` check is red, and so is main's. `check_dead_references`
first caught a genuine defect of mine — a docstring naming a path that is not in the
tree — which the second commit fixes; the prose scan is now clean locally. What
remains is `tools/test_check_dead_references.py`
`BaselineTests.test_the_baseline_is_sorted_and_unique`, which fails identically on a
clean `origin/main` checkout of `config/` and `tools/` (same 9117-character diff),
and `references` is already `failure` on main at `e3707be70`. The fix is a `config/`
baseline file, outside this PR's scope, so I left it alone rather than bundle it.

**Do not merge on my say-so.** I did not merge anything and opened no other PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA
