### PR TITLE
One arm9 match, and the provenance that closes two asm-hatch questions for good

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -10659,6 +10659,10 @@ src/_ZN3IRQ21GameCardIREQMCHandlerEv.cpp:
     complete
     .text start:0x020610ac end:0x020610fc
 
+src/func_020610fc.c:
+    complete
+    .text start:0x020610fc end:0x02061128
+
 src/func_02061128.c:
     complete
     .text start:0x02061128 end:0x02061138

--- a/src/__rethrow.c
+++ b/src/__rethrow.c
@@ -9,10 +9,27 @@
 // the old stem config declared a function at 0x020717c0 that no source resolved to,
 // and tools/nearmiss_db.py resync-names would have relabelled the stored row to
 // __rethrow and then lost its link to this source.
-// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
-// assembly primitive, so there is no original C to recover and no match to chase. Counts as
-// done under the asm-primitive policy - see notes/arm9-endgame.md.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm, so there is no original C to
+// recover and no match to chase. Counts as done under the asm-primitive policy - see
+// notes/arm9-endgame.md. (Metrowerks shipped this one, not Nintendo: it is MSL's C++
+// exception runtime, not an SDK or BIOS shim.)
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
+//
+// Which class, precisely, re-checked 2026-09-12. The body carries no instruction from
+// notes/asm-policy.md's objective list (no mcr/mrc, swi, msr/mrs, banked ldm/stm ^, swp), so
+// that test does not admit it. What does is the other accepted bucket in notes/arm9-endgame.md,
+// the frame fragments the symbol table split out (func_020729e8 is a bare epilogue;
+// func_020732e8, func_02073584 and func_0207335c start mid-frame): this is the mirror image,
+// a PROLOGUE-only fragment. It opens a 0x70 frame, snapshots r4-r11, the caller's sp and lr
+// into it, zeroes the first three words, points r0 at the frame and BRANCHES to
+// func_02071be8. It never restores those registers and never returns.
+//
+// mwccarm cannot be made to emit that. Callee-saved registers are only saved because the
+// function body uses them, and every save it emits is paired with a restore in an epilogue
+// this function does not have. Measured under 2004/b56: the closest C shape (a 0x70 local
+// context struct, three fields zeroed, func_02071be8(&ctx) as the last statement) compiles
+// to 0x2c bytes opening `stmdb sp!,{lr}; sub sp,sp,#0x74` with a full epilogue, and no
+// source form reaches a prologue that saves without restoring.
 extern void func_02071be8(void);
 
 asm void __rethrow(void) {

--- a/src/func_02057014.c
+++ b/src/func_02057014.c
@@ -1,9 +1,21 @@
 // NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
 // assembly primitive, so there is no original C to recover and no match to chase. Counts as
 // done under the asm-primitive policy - see notes/arm9-endgame.md.
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match. Veneer that tail-calls
-// func_02057178 through r1 (compiled C always uses ip for tail-call veneers,
-// so this register choice marks hand-written assembly).
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This is NitroSDK OS_UnLockCartridge,
+// the misspelled-name compatibility thunk for OS_UnlockCartridge (= func_02057178, matched
+// at src/func_02057178.c). Nintendo's own SDK source writes it as assembly:
+// OS_spinLock.c carries `asm s32 OS_UnLockCartridge(u16 lockID) { ldr r1, =OS_UnlockCartridge;
+// bx r1 }`, which is this function instruction for instruction. The surrounding cluster is the
+// same TU: func_02057128 = OSi_AllocateCartridgeBus, func_02057228 = OSi_DoLockByWord,
+// 0x027fffe8 = HW_CTRDG_LOCK_BUF, and func_02057020/func_02057078 are OS_ReleaseLockID, also
+// `asm` there. That is direct evidence for the first row of notes/asm-policy.md's table
+// (original was hand-written asm), not an inference from the instruction set.
+// Measured, so the claim is not just provenance: a compiled tail-call veneer always routes
+// through ip, never r1. Ten source spellings (plain forwarder, void forwarder, dead extra
+// argument, unprototyped and variadic callee, function-pointer local, typedef'd pointer,
+// cast-through-pointer call, 5-argument forwarder, `#pragma interworking on`) were compiled
+// against all 25 installed mwccarm builds; every one emits `ldr ip,[pc]; bx ip`. The register
+// is the whole residual, and no C expression names a register.
 extern void func_02057178(void);
 
 asm void func_02057014(void) {

--- a/src/func_02058568.c
+++ b/src/func_02058568.c
@@ -2,12 +2,29 @@
 // assembly primitive, so there is no original C to recover and no match to chase. Counts as
 // done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
-// OS_InitContext-style SDK primitive: stores entry pc+4 and the two stack pointers
-// (sp_svc at +0x44, sp = sp_svc - 0x40 at +0x38), derives the initial CPSR from the
-// Thumb bit of the entry address (SYS mode 0x1f, +T bit -> 0x3f), and clears r0-r12
-// and lr in the context block. Same original hand-asm TU as ARMSaveContext (0x020585cc).
-// C reproductions floor at a 5-word register-coloring residual (t_pc4/t_sp40 webs color
-// r3/r1 under 1.2/sp2p3 for every source shape tried; ROM keeps both params in place).
+// This is NitroSDK OS_InitContext, and the "-style" hedge can come off: Nintendo's own SDK
+// source writes it as assembly. OS_context.c carries
+// `asm void OS_InitContext(register OSContext *context, register u32 newpc, register u32 newsp)`
+// with this instruction sequence, the only difference being a later SDK revision's extra
+// `tst newsp,#4 / subne newsp,newsp,#4` 8-byte-alignment fixup, which this build predates.
+// The two functions that follow it here, ARMSaveContext (0x020585cc) and ARMRestoreContext
+// (0x02058618), are OS_SaveContext and OS_RestoreContext out of the same TU and are `asm`
+// there too; both are already accepted primitives in this tree. That is direct evidence for
+// the first row of notes/asm-policy.md's table (the original was hand-written asm), not an
+// inference from the instruction set.
+//
+// What it does: stores entry pc+4 at +0x40 and the two stack pointers (sp_svc at +0x44,
+// sp = sp_svc - HW_SVC_STACK_SIZE (0x40) at +0x38), derives the initial CPSR from the Thumb
+// bit of the entry address (SYS mode 0x1f, +T bit -> 0x3f), and clears r0-r12 and lr.
+//
+// C reproductions floor at a 5-word register-coloring residual and the floor was re-measured
+// under 2004/b56 (18 source shapes): ROM keeps both pointer parameters in their own incoming
+// registers (`add r1,r1,#4` / `sub r2,r2,#0x40`, then `ands r1,r1,#1` in place); mwccarm
+// rotates them to r3 and r1 whenever the pc+4 value stays live past the sp store. Inert:
+// in-place `+=` vs named locals, either declaration order, `register` on the parameters,
+// u32 vs pointer parameters, a dead 4th/5th argument to occupy r3, `&end[-0x40]`, embedded
+// assignments, a named ternary temp, void* parameters. Dropping the later use of pc+4 does
+// color it r1, which localises the residual to that one live range.
 asm void func_02058568(void *ctx, unsigned int pc, unsigned int sp)
 {
     add r1, r1, #4

--- a/src/func_020610fc.c
+++ b/src/func_020610fc.c
@@ -1,23 +1,30 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
-// HAND-ASM: IPC send loop (cmd 0xd, arg 2) followed by an intentional hang
-// (b self). The routine never returns, so mwccarm will not emit a function
-// that ends on a backward branch to itself with no epilogue at all.
-extern int IPCSend(unsigned int a, unsigned int c, unsigned int b);
+// @symbol func_020610fc
+// recovered: IPC send-and-hang stub, arm9 0x020610fc (44 bytes).
+/* func_020610fc -- arm9 0x020610fc, 0x2c bytes.
+ *
+ * Retries IPCSend(0xd, 2, 0) until the ARM7 accepts the command, then hangs
+ * forever. The same send loop as src/func_02019ff4.c with the same three
+ * constants; that one returns through func_0201a028, this one never returns.
+ * Its only caller (0x020610e4) treats it as a terminal path.
+ *
+ * The three arguments are hoisted into r6/r5/r4 outside the loop, which is
+ * what naming them as locals in that declaration order produces (the same
+ * shape src/func_02059dd4.c needed). The trailing `for (;;) ;` compiles to
+ * the bare `b .` with no epilogue, so the previous file's claim that mwccarm
+ * will not emit a self-branch without an epilogue was wrong.
+ */
 
-asm void func_020610fc(void) {
-    stmdb sp!, {r4, r5, r6, lr}
-    mov r6, #0xd
-    mov r5, #2
-    mov r4, #0
-L10:
-    mov r0, r6
-    mov r1, r5
-    mov r2, r4
-    bl IPCSend
-    cmp r0, #0
-    bne L10
-L24:
-    b L24
+typedef int s32;
+
+extern s32 IPCSend(s32 cmd, s32 arg1, s32 arg2);
+
+void func_020610fc(void)
+{
+    s32 r6 = 0xd;
+    s32 r5 = 2;
+    s32 r4 = 0;
+    while (IPCSend(r6, r5, r4) != 0)
+        ;
+    for (;;)
+        ;
 }

--- a/src/func_02068398.c
+++ b/src/func_02068398.c
@@ -8,6 +8,18 @@
  * extra bytes. Hand-asm matches: ldmeqia (not ldmeq alone) spells the ROM's
  * predicated early-return (ldmeq sp!,{lr}; bxeq lr).
  * mwccarm 1.2/sp2p3: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e
+ *
+ * Re-measured 2026-09-12 under 2004/b56, three axes notes 6u had not covered, all inert
+ * (the stored draft's div stays 1, residual unchanged at +0x38):
+ *   #pragma peephole off, #pragma opt_rebuildconditionals off,
+ *   #pragma opt_rebuildlogicals off, #pragma opt_collapselogicalselectionintobittest off
+ *     -- byte-identical output, consistent with 6u's finding that cond-opt runs on post-RA
+ *        physical code where no IRO-level pragma reaches it;
+ *   #pragma optimization_level 1 -- changes the function's size (0x80 vs 0x78), the same
+ *        trade -O1 makes: the branch comes back but the predicated early-return goes;
+ *   the TU language (the 6al lever): the same draft as //cpp with extern "C" linkage is
+ *        byte-identical to the C build, div 1.
+ * 6u's verdict stands. Ordinary ARM, so it is NOT an asm primitive and stays NONMATCHING.
  */
 extern unsigned char data_020a9d2c;
 extern void func_02068484(void);

--- a/src/func_ov009_0211145c.c
+++ b/src/func_ov009_0211145c.c
@@ -9,6 +9,17 @@
  * interleave for -0x14000 / 0xff06a000 / func_0201267c (same wall as sibling
  * 021116ec avoids by not calling after the stores).
  */
+/* Re-measured 2026-09-12 under 2004/b56 (the stored near-miss draft is div 3, size-exact
+ * 0x17c; residual is the pool constant 0xff06a000 coloured r3 not r0, so our str/mov pair
+ * lands the wrong way round against the ROM's `ldr r0; add r1; str r0; mov r0,#0x6a; bl`).
+ * Five axes the stored evidence had not covered, all byte-identical to that baseline:
+ * declaring func_0201267c void instead of int (the missing-return-value lever), declaring
+ * its first parameter int rather than unsigned, storing the constant through an unsigned
+ * type, storing it as a pointer value, and naming `c + 0x74` in a local before the stores.
+ * The wall is that the outgoing 0x6a pins r0 before the store is scheduled; the sibling
+ * func_ov009_021116ec colours the same constant r0 only because it has no call after the
+ * stores to compete for it. Ordinary ARM, so NOT an asm primitive: this stays NONMATCHING.
+ */
 
 extern char* _ZN8dActor_c13ClosestPlayerEv(void* self);
 extern int Vec3_Sub(struct Vector3* dst, void* a, void* b);


### PR DESCRIPTION

func_020610fc now matches from real C under 2004/b56. It is the same IPC send loop as
src/func_02019ff4.c with the same three constants, followed by a deliberate hang. Naming the
three arguments as locals in the ROM's own r6/r5/r4 order hoists them out of the loop the way
the matched sibling src/func_02059dd4.c does, and a plain `for (;;) ;` tail compiles to the bare
`b .` with no epilogue. The file's previous banner claimed mwccarm would not emit a self-branch
without an epilogue; it does, on the first try. The file is enrolled in config/arm9/delinks.txt
so the ROM link builds its 0x2c range from source, and it is on the eligible whitelist.

The other five targets of this lane stay as they are, but their headers no longer assert what
nobody had measured. Two of them turn out to have hard provenance in Nintendo's own SDK source,
which is the first row of notes/asm-policy.md's table rather than an inference from the
instruction set:

  func_02057014 is NitroSDK OS_UnLockCartridge, the misspelled-name compatibility thunk for
  OS_UnlockCartridge (= func_02057178, already matched here). OS_spinLock.c writes it as
  `asm s32 OS_UnLockCartridge(u16 lockID) { ldr r1, =OS_UnlockCartridge; bx r1 }`, instruction
  for instruction. The surrounding cluster is the same TU: func_02057128 is
  OSi_AllocateCartridgeBus, func_02057228 is OSi_DoLockByWord, 0x027fffe8 is HW_CTRDG_LOCK_BUF,
  and func_02057020 / func_02057078 are OS_ReleaseLockID, also `asm` there (which also confirms
  the worked example at the bottom of notes/arm9-endgame.md).

  func_02058568 is NitroSDK OS_InitContext, written as
  `asm void OS_InitContext(register OSContext *context, register u32 newpc, register u32 newsp)`
  in OS_context.c, differing only by a later SDK revision's 8-byte-alignment fixup that this
  build predates. The two functions immediately after it here, ARMSaveContext and
  ARMRestoreContext, are OS_SaveContext and OS_RestoreContext out of that same TU and are
  already accepted primitives in this tree.

__rethrow is the third kind: ordinary ARM with no instruction from the objective list, but a
prologue-only frame fragment (it opens a 0x70 frame, snapshots r4-r11, sp and lr into it, and
branches away without ever restoring them). That is the mirror of the bare-epilogue bucket
notes/arm9-endgame.md already accepts, and the measured C shape confirms it: the closest source
compiles to 0x2c bytes with an ordinary prologue and a full epilogue.

func_02068398 and func_ov009_0211145c stay NONMATCHING drafts. Both floors were re-measured
under 2004/b56 on axes the stored evidence had not covered, and every one was byte-identical to
the stored baseline. The notes in each file record exactly what was tried so the next attempt
does not repeat it.

Files touched:
  src/func_020610fc.c          matched C, replaces the asm hatch (the one count change)
  config/arm9/delinks.txt      enroll src/func_020610fc.c, .text 0x020610fc-0x02061128
  src/func_02057014.c          header: NitroSDK OS_UnLockCartridge provenance + the 10-spelling,
                               25-build measurement behind the ip-vs-r1 residual
  src/func_02058568.c          header: NitroSDK OS_InitContext provenance + the 18-shape
                               coloring measurement under 2004/b56
  src/__rethrow.c              header: the frame-fragment classification and its measurement
  src/func_02068398.c          header: the 2004/b56 reconfirmation of the notes 6u floor
  src/func_ov009_0211145c.c    header: the 2004/b56 reconfirmation of the schedule floor

No file outside the lane list was touched. nearmiss/db.jsonl was read only.
