### PR TITLE
Restore sorted-and-unique order in the dead-reference prose baseline

### DIFF
--- a/config/dead-reference-baseline.json
+++ b/config/dead-reference-baseline.json
@@ -210,10 +210,6 @@
    "ref": "src/func_ov006_02110a20.c"
   },
   {
-    "file":"notes/rom-build.md",
-    "ref":"src/func_ov013_021112a8.c"
-  },
-  {
    "file": "notes/mwccarm-codegen.md",
    "ref": "docs/_private/CodeWarrior/mwccarm.help.txt"
   },
@@ -260,6 +256,10 @@
   {
    "file": "notes/rom-build.md",
    "ref": "src/config"
+  },
+  {
+   "file": "notes/rom-build.md",
+   "ref": "src/func_ov013_021112a8.c"
   },
   {
    "file": "notes/rom-build.md",


### PR DESCRIPTION

WHY
config/dead-reference-baseline.json is required to stay sorted-and-unique
(tools/test_check_dead_references.py: test_the_baseline_is_sorted_and_unique),
which is what config/dead-reference-baseline.json is checked against on every
open PR. #2643 ("Phase 6: Update 12 docs and add dead reference to baseline")
inserted a new entry, {"file": "notes/rom-build.md", "ref":
"src/func_ov013_021112a8.c"}, between the notes/matching-style.md entry and
the notes/mwccarm-codegen.md entry instead of down among notes/rom-build.md's
other entries where alphabetical order puts it. That broke the sort-order
test, which turned the "dead references" workflow's "gate's own tests" step
red on main and, since that step runs unconditionally on every PR regardless
of what the PR touches, every open PR (including this run's other lanes'
PRs) inherited the same red check.

No blame to #2643 for this: it's a one-entry ordering slip in a 149-entry
hand-sorted JSON file, not a bad decision.

WHAT THIS PR DOES
Re-sorts the baseline's existing 149 (file, ref) pairs through the checker's
own tools/check_dead_references.py:write_baseline() -- no entries added, none
removed, including the one #2643 itself added (it is not proven resolvable;
dropping it was out of scope for this fix -- `git show e3707be70 --
config/dead-reference-baseline.json` is a 4-LINE diff for that one entry,
not four entries). The rewrite also picks up write_baseline()'s canonical
formatting (space after each ":", consistent 1-space-per-level indent),
since the #2643 entry had been hand typed without the surrounding file's
spacing.

Only file touched: config/dead-reference-baseline.json (4 lines changed:
one entry moved from one position to its sorted position).

PROOF (paste from the branch tip)
  python tools/test_check_dead_references.py   -> Ran 36 tests ... OK
  python tools/check_dead_references.py        -> exit 0, "no new dead
    references", "no broken markdown links" (also true before this fix --
    the checker's own scan was never broken by #2643; only the sort-order
    unit test was)
  python tools/check_python_names.py           -> PASS, 0 unresolvable names

NOTE FOR THE MERGER
The "0 markdown link(s)" / "SCAN TOO SMALL" line that also appears in CI
logs of the gate's own tests is not a second bug: it is the expected stdout
of the PASSING control test test_a_scan_that_found_nothing_fails, which
points check_dead_references.dead_references() (whose `root` default binds
to the real repo at import time) and check_dead_references.broken_links()
(which re-reads the reassigned global CDR.REPO at call time) at different
directories on purpose, to prove the tool refuses to report a clean scan
when a scan finds too little. That mismatch pre-dates this branch and #2643;
it produces real-tree-sized file/ref counts alongside a synthetic 0-link
count purely because of that intentional test setup, and needs no fix here.

Not a source-review-queue item: tools/config only.
