### PR TITLE
Match IRQ::UserInterruptHandler (_ZN3IRQ20UserInterruptHandlerEv, itcm 0x01ffd97c,

### DIFF
--- a/config/arm9/itcm/delinks.txt
+++ b/config/arm9/itcm/delinks.txt
@@ -80,6 +80,10 @@ src/_ZN7dBgW_Kc14GetSurfaceInfoEsR11SurfaceInfo.cpp:
     complete
     .text start:0x01ffd920 end:0x01ffd97c
 
+src/_ZN3IRQ20UserInterruptHandlerEv.cpp:
+    complete
+    .text start:0x01ffd97c end:0x01ffd9d4
+
 src/func_01ffd9d4.c:
     complete
     .text start:0x01ffd9d4 end:0x01ffdb28

--- a/src/_ZN3IRQ20UserInterruptHandlerEv.cpp
+++ b/src/_ZN3IRQ20UserInterruptHandlerEv.cpp
@@ -1,0 +1,78 @@
+//cpp
+// @symbol _ZN3IRQ20UserInterruptHandlerEv
+// HAND-ASM PRIMITIVE. Nintendo's own NitroSDK source ships this exact routine as
+// `asm void OS_IrqHandler(void)` in arm9/lib/NitroSDK/src/OS_irqHandler.c (lines
+// 10-34 of the pokediamond decomp, one `#pragma section ITCM` above it), instruction
+// for instruction identical to this function:
+//
+//   stmfd sp!, {lr}
+//   mov ip, #0x04000000
+//   add ip, ip, #0x210
+//   ldr r1, [ip, #-8]
+//   cmp r1, #0
+//   ldmeqfd sp!, {pc}
+//   ldmia ip, {r1, r2}
+//   ands r1, r1, r2
+//   ldmeqfd sp!, {pc}
+//   mov r3, #0x80000000
+// _01FF8028:
+//   clz r0, r1
+//   bics r1, r1, r3, lsr r0
+//   bne _01FF8028
+//   mov r1, r3, lsr r0
+//   str r1, [ip, #0x4]
+//   rsbs r0, r0, #0x1f
+//   ldr r1, =OS_IRQTable
+//   ldr r0, [r1, r0, lsl #2]
+//   ldr lr, =OS_IrqHandler_ThreadSwitch
+//   bx r0
+//
+// The SDK's OS_IRQTable is this game's data_02099fe4 (the same array
+// IRQ::GetIRQHandler/IRQ::SetIRQHandler index; slot 0 is IRQ::EmptyHandler), and
+// OS_IrqHandler_ThreadSwitch is this game's func_01ffd9d4, already a HAND-ASM
+// PRIMITIVE in this tree and the byte-exact continuation the same SDK file
+// carries as a second `asm` function immediately below this one (lines 36-127).
+// The tail here hand-loads lr with func_01ffd9d4's address and bx's into the
+// table entry, so func_01ffd9d4's `ldr pc, [sp], #4` exits pop THIS function's
+// pushed lr instead of returning here -- a cross-function stack-frame handoff
+// no C compiler emits, matching the SDK's own choice to hand-write both halves.
+//
+// Not reachable from C on this toolchain regardless: mwccarm 2004/b56 has no
+// `clz` intrinsic (__clz, __builtin_clz, __CLZ, __CLZ32, _CountLeadingZeros and
+// __rt_clz all compile to an external long-call veneer, never the clz opcode),
+// so a portable leading-zero loop compiles to 0xa8 bytes against the ROM's 0x58.
+#include "IRQ.h"
+
+extern "C" {
+extern IRQ::Handler data_02099fe4[];
+extern void func_01ffd9d4(void);
+}
+
+namespace IRQ {
+
+asm void UserInterruptHandler(void)
+{
+    stmdb sp!, {lr}
+    mov ip, #0x04000000
+    add ip, ip, #0x210
+    ldr r1, [ip, #-8]
+    cmp r1, #0
+    ldmeqia sp!, {pc}
+    ldmia ip, {r1, r2}
+    ands r1, r1, r2
+    ldmeqia sp!, {pc}
+    mov r3, #0x80000000
+_loop:
+    clz r0, r1
+    bics r1, r1, r3, lsr r0
+    bne _loop
+    mov r1, r3, lsr r0
+    str r1, [ip, #0x4]
+    rsbs r0, r0, #0x1f
+    ldr r1, =data_02099fe4
+    ldr r0, [r1, r0, lsl #2]
+    ldr lr, =func_01ffd9d4
+    bx r0
+}
+
+}


### PR DESCRIPTION
size 0x58) as a HAND-ASM PRIMITIVE.

PROVENANCE (why this counts as asm, not a C draft):
Nintendo's own NitroSDK source ships this exact routine as `asm void OS_IrqHandler(void)`
in arm9/lib/NitroSDK/src/OS_irqHandler.c (pokediamond decomp, lines 10-34, one
`#pragma section ITCM` above it). The SDK's instruction stream is identical to the
ROM's, instruction for instruction, including the clz-based lowest-set-bit loop and
the tail that hand-loads lr with the address of the second half (OS_IrqHandler_
ThreadSwitch, this game's func_01ffd9d4, already a HAND-ASM PRIMITIVE in this tree)
before bx-ing into the per-interrupt handler table (OS_IRQTable, this game's
data_02099fe4). That hand-set-lr, cross-function stack-frame handoff -- one
function's epilogue popping a DIFFERENT function's pushed lr -- is not something a
C compiler emits, and the SDK itself proves the original author agreed: it wrote
both halves as `asm`, not C.

Independently, and regardless of the SDK: mwccarm 2004/b56 has no `clz` intrinsic
under any spelling tried (__clz, __builtin_clz, __CLZ, __CLZ32, _CountLeadingZeros,
__rt_clz all compile to an external long-call veneer, never the clz opcode), so a
portable C reimplementation of the same algorithm compiles to 0xa8 bytes against the
ROM's 0x58 and can never be reached from C on this toolchain at all.

This is the row lane ITCM flagged and could not banner: it is ordinary ARM by the
letter of notes/asm-policy.md's instruction-set test (no mcr/mrc/swi/msr/mrs/ldm^/
swp in this half specifically -- clz is the only instruction the objective list
does not enumerate), but the SDK source settles the provenance question the policy's
first row asks directly, the same way lane ASM used it for func_02057014
(OS_UnLockCartridge) and func_02058568 (OS_InitContext). No policy ruling needed:
this is row 1 of asm-policy.md applying as written, not an exception to it.

FILES:
  src/_ZN3IRQ20UserInterruptHandlerEv.cpp   new. HAND-ASM PRIMITIVE header citing
    OS_irqHandler.c:10-34, the SDK asm pasted alongside the ROM's, the data_02099fe4/
    func_01ffd9d4 identification, and the independent clz-unreachability finding.
    asm block naming the pool words as real symbols (data_02099fe4, func_01ffd9d4).
  config/arm9/itcm/delinks.txt   filled the 0x01ffd97c-0x01ffd9d4 gap (it had none:
    "no src file" per the brief) with this file's entry, in the precedents' shape.

PROOF (pasted in full in the lane's final report):
  tools/match.py --c src/_ZN3IRQ20UserInterruptHandlerEv.cpp --func
    _ZN3IRQ20UserInterruptHandlerEv --addr 0x01ffd97c --size 0x58 --module itcm
    --version 2004/b56   -> MATCHING VERSIONS: 2004/b56, 0 mismatches
  tools/linkcheck.py --name _ZN3IRQ20UserInterruptHandlerEv --addr 0x01ffd97c
    --size 0x58 --module itcm   -> VERIFIED, blind 0
  tools/prepush_linkcheck.py --range origin/main..HEAD   -> 1 checked, 1 verified,
    0 blocking
  asm_policy.counts_as_matched(text) -> True (clause 2: no NONMATCHING banner in
    the header region at all, same style as the sibling _ZN3IRQ10DisableAllEv.cpp,
    _dmul.c and func_01ffd9d4.c -- HAND-ASM PRIMITIVE is documentation here, not a
    banner the counter needs to see through)
  tools/progress.py --from-src --bar: 11,342/11,390 -> 11,343/11,390 (+1 function,
    +88 bytes), matching the row's own size exactly
  tools/tiers_ratchet.py --check -> PASS, baseline 2716 -> current 2717 (no
    backslide; not rebanked, left for the coordinator)
  tools/check_python_names.py -> PASS (0 unresolvable names)
  tools/check_dead_references.py -> PASS (no new dead references)
  tools/rombuild.py -j8 --no-rom -> see final report for the pasted result; house
    laws flags this as known-locally-broken independent of this change

Branch asm/f100-irq, one commit off 9c7f38a24. Never pushed.
