### PR TITLE
tools: fix `progress.py --from-src` reading the empty local ledger

### DIFF
--- a/tools/progress.py
+++ b/tools/progress.py
@@ -253,6 +253,15 @@ def main():
 
     if dbp:
         done_n, done_b, n, tb, per = from_db(dbp)
+    elif "--from-src" in sys.argv:
+        # Same derivation --bar/--write-readme use for --from-src: the honest,
+        # committed-data-only count. Without this branch, a bare `--from-src` (no
+        # --bar) fell through to the branch below and read the local, gitignored
+        # progress/matched.jsonl regardless of the flag -- on a fresh worktree that
+        # ledger is empty, so it printed `functions : 0 / N` even though every
+        # function had a committed, byte-gate-passing source.
+        done_n, done_b, n, tb = synced_from_src()
+        _, _, per = totals()
     else:
         n, tb, per = totals()
         done = matched()

--- a/tools/test_progress.py
+++ b/tools/test_progress.py
@@ -1,4 +1,6 @@
 """The clean-clone progress scan uses the published MATCHED policy."""
+import contextlib
+import io
 import pathlib
 import tempfile
 import unittest
@@ -122,6 +124,52 @@ class ProgressPolicy(unittest.TestCase):
         self.assertEqual(done_b, 0x100)
         self.assertEqual(total_bytes, 0x100 + 0x40,
                          "and the record with no source under any name is untouched")
+
+    def test_bare_from_src_reads_the_committed_scan_not_the_local_ledger(self):
+        """``python tools/progress.py --from-src`` (no ``--bar``) is the exact
+        verification idiom the house laws cite. Before this fix, main()'s plain-report
+        branch never looked at --from-src at all: it always called matched(), which
+        reads the local, gitignored progress/matched.jsonl ledger, so a fresh
+        worktree with an empty ledger printed `functions : 0 / N` even though every
+        function here has a committed, byte-gate-passing source. This runs main()
+        end to end against a fixture with an empty ledger and checks the printed
+        numerator and denominator against synced_from_src's own numbers, so the
+        plain path and --bar cannot disagree again."""
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        repo = pathlib.Path(temp.name)
+        (repo / "src").mkdir()
+        (repo / "progress").mkdir()
+        sym = repo / "symbols.txt"
+        sym.write_text(
+            "good kind:function(arm,size=0x10) addr:0x02000000\n"
+            "sized kind:function(arm,size=0x100) addr:0x02000030\n", encoding="utf-8")
+        for name in ("good", "sized"):
+            (repo / "src" / f"{name}.c").write_text(
+                f"int {name}(void) {{ return 0; }}\n", encoding="utf-8")
+        empty_ledger = repo / "progress" / "matched.jsonl"
+        empty_ledger.write_text("", encoding="utf-8")  # the fresh-worktree ledger
+
+        with mock.patch.object(P, "REPO", repo), \
+                mock.patch.object(P, "CONFIG", repo), \
+                mock.patch.object(P, "MATCHED", empty_ledger), \
+                mock.patch.object(P.sys, "argv", ["progress.py", "--from-src"]), \
+                mock.patch.object(RL, "module_universe", lambda: [(sym, "arm9")]), \
+                mock.patch.object(BG, "excluded_paths", lambda *a, **k: set()), \
+                mock.patch.object(
+                    SP, "path_for",
+                    lambda n: (repo / "src" / f"{n}.c"
+                               if (repo / "src" / f"{n}.c").is_file() else None)):
+            done_n, done_b, n, total_bytes = P.synced_from_src()
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                P.main()
+
+        self.assertEqual((done_n, n), (2, 2), "both fixture functions are ordinary matches")
+        printed = out.getvalue()
+        self.assertIn(f"functions : {done_n:,} / {n:,}", printed)
+        self.assertIn(f"code bytes: {done_b:,} / {total_bytes:,}", printed)
+        self.assertNotIn("functions : 0 /", printed)
 
     def test_from_src_ignores_an_ambient_database(self):
         temp = tempfile.TemporaryDirectory()


### PR DESCRIPTION

Branch: tools/f100-progfix, tip 61eb64f7e (base origin/main abeff1815)
Files touched: tools/progress.py, tools/test_progress.py

## The bug

`python tools/progress.py --from-src` -- the exact verification idiom
runs/link100/in5/DECOMP_COMMON.md and runs/m100/house_laws.md cite -- printed
`functions : 0 / 11,390` on a fresh worktree. Only `--bar --from-src` (and
`--write-readme --from-src`) took the honest, committed-data-only path via
`synced_from_src()`. The plain-report branch in `main()` never checked the
`--from-src` flag at all: it always fell through to `totals()` + `matched()`,
and `matched()` reads the local, gitignored `progress/matched.jsonl` ledger --
empty (or absent) on a fresh checkout -- so the numerator read 0 regardless
of what was actually decompiled and committed to `src/`.

## The fix

`main()`'s plain-report branch now checks `"--from-src" in sys.argv` the same
way the `--bar` and `--write-readme` branches already do, and calls the same
`synced_from_src()` function they call -- one derivation, reused, not
duplicated. The per-module breakdown for the printed "largest modules" table
still comes from `totals()` (itself committed-data-only; unaffected by the
ledger). Every other flag's behaviour is unchanged: bare invocation with no
flags still uses the local ledger (by design, per the module docstring),
`--bar`, `--write-readme`, and `--from-db` are untouched.

## Test added

`tools/test_progress.py::test_bare_from_src_reads_the_committed_scan_not_the_local_ledger`
builds a small fixture repo (two ordinary functions, an empty
`progress/matched.jsonl`) in the same mock style as the file's other
`synced_from_src` fixtures, runs `P.main()` with `sys.argv` set to
`["progress.py", "--from-src"]`, and asserts the printed numerator/denominator
match `synced_from_src()`'s own numbers (and are not `0`).

## Proof

python tools/progress.py --from-src
=== SM64DS decomp progress ===
  functions : 11,342 / 11,390  (99.5786%)
  code bytes: 2,191,568 / 2,238,108  (97.9206%)

python tools/progress.py --bar --from-src
## Progress
```
Functions  ...  99.6%   11,342 / 11,390
Code size  ...  97.9%   2,191,568 / 2,238,108 bytes
```
(same numerator and denominator on the tip, before this fix the plain report
printed 0 / 11,390)

python tools/test_progress.py -> OK (9 tests)
python tools/check_python_names.py -> PASS (0 unresolvable names, 0 unparseable files)
python tools/check_dead_references.py -> no new dead references, no broken markdown links

Tools-only change, no src/ or config/ touched. No push performed; ours to
merge on CLEAN per DECOMP_COMMON.md.
