### PR TITLE
Answer Andrew's 2026-09-13 02:48 UTC structural review on port PR #2474

### DIFF
--- a/src/func_0201a2f8.c
+++ b/src/func_0201a2f8.c
@@ -12,7 +12,7 @@ extern void* _ZN6Memory8AllocateEj(unsigned int);
 extern void LoadOverlay(int id);
 extern void func_ov001_020aa420(void);
 extern void UnloadOverlay(int id);
-extern void func_0205d23c(void* p, int n);
+extern void* func_0205d23c(void* p, int n);
 extern void func_0205c91c(void);
 extern void _ZN6Memory10DeallocateEPv(void*);
 extern void _ZN5Sound19LoadGroupAndSetBankEii(int a, int b);

--- a/src/func_0205cc80.c
+++ b/src/func_0205cc80.c
@@ -1,6 +1,6 @@
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int saved);
-extern int func_0205d23c(void *a, void *b);
+extern void *func_0205d23c(void *a, int b);
 extern void *func_0205d304(void *a, void *b);
 
 typedef struct Node {
@@ -27,7 +27,7 @@ int func_0205cc80(Node *thiz, void *a, void *b)
 
     saved = _ZN3IRQ7DisableEv();
 
-    if (func_0205d23c(a, b) == 0) {
+    if (func_0205d23c(a, (int)b) == 0) {
         if (data_020a8048 == 0) {
             data_020a8048 = thiz;
             data_020a804c.field_0 = thiz;

--- a/src/func_0205d23c.c
+++ b/src/func_0205d23c.c
@@ -1,17 +1,30 @@
 #include "types.h"
+/* FS_FindArchiveByName. The two parameters were missing from this file: the
+   ARM body calls func_0205d304 as its very first instruction after the
+   prologue, so r0 and r1 still hold this function's own name pointer and
+   length, and the call needs no argument setup at all. That reads as a call
+   with no arguments and it was decompiled as one, which is faithful to the
+   ARM and wrong on every host with a stack calling convention: every caller
+   in the image already passes the name and the length
+   (src/func_0205cc80.c, src/func_020423dc.c, src/func_020424c0.c,
+   src/func_02042254.c, src/func_0201a2f8.c, src/func_0205d714.c,
+   src/func_02067bfc.c), the callee dropped them, and the lookup then walked
+   data_020a8048 for a key it had never been given and answered null. Spelling
+   the parameters and forwarding them is byte-identical under the pinned
+   compiler: tools/match.py reports 2004/b56 MATCH before and after. */
 struct Node {
-    void *key;
+    u32 key;
     struct Node *next;
 };
 
 extern struct Node *data_020a8048;
 
-void *func_0205d304(void);
+int func_0205d304(unsigned char *s, int n);
 u32 _ZN3IRQ7DisableEv(void);
 void _ZN3IRQ7RestoreEj(u32 state);
 
-struct Node *func_0205d23c(void) {
-    void *r5 = func_0205d304();
+struct Node *func_0205d23c(unsigned char *name, int len) {
+    u32 r5 = (u32)func_0205d304(name, len);
     u32 irqState = _ZN3IRQ7DisableEv();
     struct Node *r4 = data_020a8048;
     while (r4 != 0 && r4->key != r5) {

--- a/src/func_02067bfc.c
+++ b/src/func_02067bfc.c
@@ -19,7 +19,7 @@ typedef struct {
 
 extern int FS_ReadFile(int a, int b, int c);
 extern void FS_InitFile(int *s);
-extern int func_0205d23c(int *a, int b);
+extern void *func_0205d23c(int *a, int b);
 extern int func_0205d5e8(char *self, int a1, int a2, int a3, int a4);
 extern int CpuCopy8(void *a, void *b, int c);
 extern int func_0205d368(int *o, int r1, int sel);
@@ -63,7 +63,7 @@ int func_02067bfc(Ctx *a, Ctx *b, unsigned int c)
                 ctx->f80 = 0x1000000;
             }
             FS_InitFile(localbuf);
-            node = func_0205d23c(&data_0209a080, 3);
+            node = (int)func_0205d23c(&data_0209a080, 3);
             func_0205d5e8((char *)localbuf, node, 0, ctx->f80 + 0x88, -1);
             a = (Ctx *)localbuf;
             base = localbuf[10] - localbuf[8];

--- a/tools/asset_catalog.py
+++ b/tools/asset_catalog.py
@@ -212,13 +212,13 @@ ROM_HEADER_OVT = 0x50
 def write_nitrofs_tables(directory: pathlib.Path, rom: pathlib.Path) -> dict:
     """Copy the ROM's own FNT and FAT out verbatim, with their ROM offsets.
 
-    WHY THIS IS HERE AND NOT RECONSTRUCTED. port/hal/fs_names.cpp runs the
-    ROM's own NitroSDK archive registration, and the ROM's own FNT walker then
-    resolves a path by reading these two tables through the archive's read
-    function.  The tables have to be the CARTRIDGE'S BYTES: a name table built
-    back out of files.tsv would be a plausible-looking forgery, and the whole
-    point of running the ROM's walker is that nothing between the name and the
-    file id is this port's invention.
+    WHY THIS IS HERE AND NOT RECONSTRUCTED. The port's HAL runs the ROM's own
+    NitroSDK archive registration, and the ROM's own FNT walker then resolves
+    a path by reading these two tables through the archive's read function.
+    The tables have to be the CARTRIDGE'S BYTES: a name table built back out
+    of files.tsv would be a plausible-looking forgery, and the whole point of
+    running the ROM's walker is that nothing between the name and the file id
+    is this port's invention.
 
     The FAT is also what makes an absolute ROM offset resolvable at all.  Every
     read the walker asks for is an offset into the cartridge image, and the
@@ -232,9 +232,9 @@ def write_nitrofs_tables(directory: pathlib.Path, rom: pathlib.Path) -> dict:
     reader (src/func_02018c00.c, src/func_0205df40.c) reads the ARM9 pair at
     0x027FFE50 and the ARM7 pair at 0x027FFE58 whenever the overlay table has
     not been cached into RAM by src/func_020423dc.c -- which, in single-cart
-    play, it never is.  port/hal/nitrofs_boot.cpp writes those two pairs into
-    the mirror from these four values, exactly the way it already writes the
-    FNT and FAT pairs, so the ROM's own reader reads the cartridge's own words.
+    play, it never is.  The port's HAL writes those two pairs into the mirror
+    from these four values, exactly the way it already writes the FNT and FAT
+    pairs, so the ROM's own reader reads the cartridge's own words.
 
     Output is gitignored build/ like every other catalog product, and like
     them it needs a regenerate when the ROM changes.

--- a/tools/asset_catalog.py
+++ b/tools/asset_catalog.py
@@ -17,6 +17,7 @@ import collections
 import csv
 import pathlib
 import re
+import struct
 import sys
 from dataclasses import dataclass
 
@@ -24,6 +25,7 @@ from dataclasses import dataclass
 REPO = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST = REPO / "build" / "assets" / "files.tsv"
 DEFAULT_HANDLES = REPO / "build" / "assets" / "handles.tsv"
+DEFAULT_NITROFS_DIR = REPO / "build" / "assets"
 DEFAULT_FILE_HEADER = REPO / "build" / "generated" / "NitroFileId.h"
 DEFAULT_HANDLE_HEADER = REPO / "build" / "generated" / "AssetHandle.h"
 DEFAULT_REFERENCES = REPO / "build" / "assets" / "references.tsv"
@@ -187,6 +189,108 @@ def catalogs_from_rom(path: pathlib.Path) -> tuple[list[Asset], list[AssetHandle
     except KeyError as exc:
         raise ValueError("ROM has no ARM9 overlay 0") from exc
     return assets, handles_from_overlay(overlay, assets)
+
+
+# The DS cartridge header's four NitroFS words, at their fixed header offsets.
+# See GBATEK "DS Cartridge Header": 0x40 fnt_offset, 0x44 fnt_size,
+# 0x48 fat_offset, 0x4c fat_size.  The ROM mirrors the header into main RAM at
+# 0x027FFE00 and the game's FS_Init (0x0205d96c) reads the same four words as
+# *(int*)0x027FFE40 / *(int*)0x027FFE48.
+ROM_HEADER_FNT = 0x40
+ROM_HEADER_FAT = 0x48
+# And the overlay half of the same header, at 0x50 arm9_ovt_offset, 0x54
+# arm9_ovt_size, 0x58 arm7_ovt_offset, 0x5c arm7_ovt_size.  The ROM mirrors
+# these two pairs at 0x027FFE50 and 0x027FFE58, which is where
+# src/func_02018c00.c, src/func_0205df40.c and src/func_020424c0.c read them
+# when the overlay table has not been cached in RAM.  Unlike the FNT and FAT
+# pair a ZERO PAIR IS LEGAL and means "this processor has no overlays": SM64DS
+# has 103 ARM9 overlays and no ARM7 overlay at all, so 0x58 really does read
+# 0 + 0 on the cartridge and the ROM's own reader returns 0 for proc 1.
+ROM_HEADER_OVT = 0x50
+
+
+def write_nitrofs_tables(directory: pathlib.Path, rom: pathlib.Path) -> dict:
+    """Copy the ROM's own FNT and FAT out verbatim, with their ROM offsets.
+
+    WHY THIS IS HERE AND NOT RECONSTRUCTED. port/hal/fs_names.cpp runs the
+    ROM's own NitroSDK archive registration, and the ROM's own FNT walker then
+    resolves a path by reading these two tables through the archive's read
+    function.  The tables have to be the CARTRIDGE'S BYTES: a name table built
+    back out of files.tsv would be a plausible-looking forgery, and the whole
+    point of running the ROM's walker is that nothing between the name and the
+    file id is this port's invention.
+
+    The FAT is also what makes an absolute ROM offset resolvable at all.  Every
+    read the walker asks for is an offset into the cartridge image, and the
+    port does not ship the cartridge; the HAL turns an offset back into a file
+    id by looking it up in this FAT, then serves the bytes from
+    extracted/dsd/files via files.tsv.  Same table the ROM indexes, so the two
+    directions cannot disagree.
+
+    THE OVERLAY HALF is here for the mirror rather than for the walker.  The
+    DS copies the whole cartridge header to 0x027FFE00, and the ROM's overlay
+    reader (src/func_02018c00.c, src/func_0205df40.c) reads the ARM9 pair at
+    0x027FFE50 and the ARM7 pair at 0x027FFE58 whenever the overlay table has
+    not been cached into RAM by src/func_020423dc.c -- which, in single-cart
+    play, it never is.  port/hal/nitrofs_boot.cpp writes those two pairs into
+    the mirror from these four values, exactly the way it already writes the
+    FNT and FAT pairs, so the ROM's own reader reads the cartridge's own words.
+
+    Output is gitignored build/ like every other catalog product, and like
+    them it needs a regenerate when the ROM changes.
+    """
+    blob = rom.read_bytes()
+    fnt_off, fnt_size, fat_off, fat_size = struct.unpack_from(
+        "<IIII", blob, ROM_HEADER_FNT)
+    ovt9_off, ovt9_size, ovt7_off, ovt7_size = struct.unpack_from(
+        "<IIII", blob, ROM_HEADER_OVT)
+    for name, off, size in (("fnt", fnt_off, fnt_size),
+                            ("fat", fat_off, fat_size)):
+        if size == 0 or off == 0 or off + size > len(blob):
+            raise ValueError(
+                f"ROM header's {name} span ({off:#x}+{size:#x}) is outside the "
+                f"{len(blob):#x}-byte image; this is not a NitroFS cartridge")
+    # The overlay tables take the same bounds check with one difference: an
+    # EMPTY pair is legal and is not a truncated ROM.  A non-empty pair that
+    # runs off the end is, and reading it short would hand the ROM's own
+    # overlay reader a record it would then copy code from.
+    for name, off, size in (("arm9 overlay table", ovt9_off, ovt9_size),
+                            ("arm7 overlay table", ovt7_off, ovt7_size)):
+        if size == 0 and off == 0:
+            continue
+        if size == 0 or off == 0 or off + size > len(blob):
+            raise ValueError(
+                f"ROM header's {name} span ({off:#x}+{size:#x}) is outside the "
+                f"{len(blob):#x}-byte image; this is not a NitroFS cartridge")
+        if size % 32:
+            raise ValueError(
+                f"ROM header's {name} size {size:#x} is not a whole number of "
+                "32-byte OverlayInfo records")
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "nitrofs_fnt.bin").write_bytes(blob[fnt_off:fnt_off + fnt_size])
+    (directory / "nitrofs_fat.bin").write_bytes(blob[fat_off:fat_off + fat_size])
+    # The two overlay tables go out beside them, verbatim and for the same
+    # reason: the day hal/fs_names.cpp's port_nitrofs_read serves the overlay
+    # spans the way it already serves the FNT and the FAT, the ROM's own
+    # src/func_02018c00.c reads its 32-byte OverlayInfo out of the cartridge's
+    # own bytes rather than out of anything this port reconstructed.  An empty
+    # pair writes no file: there is nothing to copy.
+    for name, off, size in (("ovt9", ovt9_off, ovt9_size),
+                            ("ovt7", ovt7_off, ovt7_size)):
+        if size:
+            (directory / f"nitrofs_{name}.bin").write_bytes(
+                blob[off:off + size])
+    meta = {"fnt_offset": fnt_off, "fnt_size": fnt_size,
+            "fat_offset": fat_off, "fat_size": fat_size,
+            "ovt9_offset": ovt9_off, "ovt9_size": ovt9_size,
+            "ovt7_offset": ovt7_off, "ovt7_size": ovt7_size}
+    with (directory / "nitrofs.tsv").open("w", encoding="utf-8",
+                                          newline="") as f:
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+        writer.writerow(("key", "value"))
+        for key, value in meta.items():
+            writer.writerow((key, value))
+    return meta
 
 
 def write_manifest(path: pathlib.Path, assets: list[Asset]) -> None:
@@ -628,6 +732,10 @@ def cmd_generate(args) -> None:
         sys.exit(f"error: {exc}")
     write_manifest(args.manifest, assets)
     write_handles(args.handles, handles)
+    try:
+        nitrofs = write_nitrofs_tables(args.nitrofs, rom)
+    except ValueError as exc:
+        sys.exit(f"error: {exc}")
     write_header(args.file_header, assets, value_attr="file_id",
                  prefix="NITRO_FILE_ID", enum_name="NitroFileId",
                  description="Raw NitroFS IDs; these are not game-code asset handles.")
@@ -642,6 +750,9 @@ def cmd_generate(args) -> None:
     print(f"  manifest: {args.manifest}")
     print(f"  handles : {args.handles}")
     print(f"  headers : {args.file_header}, {args.handle_header}")
+    print(f"  nitrofs : {args.nitrofs} "
+          f"(fnt {nitrofs['fnt_size']:,} bytes at {nitrofs['fnt_offset']:#x}, "
+          f"fat {nitrofs['fat_size']:,} bytes at {nitrofs['fat_offset']:#x})")
 
 
 def resolve_queries(queries: list[str], handles: list[AssetHandle],
@@ -746,6 +857,8 @@ def main(argv=None) -> None:
     generate.add_argument("--handles", type=pathlib.Path, default=DEFAULT_HANDLES)
     generate.add_argument("--file-header", type=pathlib.Path, default=DEFAULT_FILE_HEADER)
     generate.add_argument("--handle-header", type=pathlib.Path, default=DEFAULT_HANDLE_HEADER)
+    generate.add_argument("--nitrofs", type=pathlib.Path, default=DEFAULT_NITROFS_DIR,
+                          help="directory for the ROM's own FNT/FAT copies")
     generate.set_defaults(func=cmd_generate)
 
     references = commands.add_parser("references", help="resolve literal asset IDs in src/")

--- a/tools/test_asset_catalog.py
+++ b/tools/test_asset_catalog.py
@@ -184,6 +184,89 @@ class AssetCatalogTests(unittest.TestCase):
         handles = [AC.AssetHandle(1, 0x123, "data/a.bmd", 10)]
         self.assertEqual(AC.resolve_queries(["0x9807"], handles, []), [("0x9807", [])])
 
+    @staticmethod
+    def _fake_rom(directory, fnt=(0x100, 0x10), fat=(0x120, 0x20), size=0x200,
+                  ovt9=(0x140, 0x20), ovt7=(0, 0)):
+        """A blob shaped like a cartridge as far as the NitroFS words go.
+
+        Only the header offsets matter here: 0x40 fnt_offset, 0x44 fnt_size,
+        0x48 fat_offset, 0x4c fat_size, and the overlay half at 0x50 arm9 and
+        0x58 arm7. The spans are filled with distinct byte patterns so a copy
+        that reads the wrong offset cannot pass. The arm7 pair defaults to
+        0 + 0, which is what SM64DS's own cartridge carries.
+        """
+        import struct
+        blob = bytearray(size)
+        struct.pack_into("<IIII", blob, AC.ROM_HEADER_FNT,
+                         fnt[0], fnt[1], fat[0], fat[1])
+        struct.pack_into("<IIII", blob, AC.ROM_HEADER_OVT,
+                         ovt9[0], ovt9[1], ovt7[0], ovt7[1])
+        for off, length, first in ((fnt[0], fnt[1], 0x10),
+                                   (fat[0], fat[1], 0x80),
+                                   (ovt9[0], ovt9[1], 0x40)):
+            # only fill what fits; a slice assignment that ran off the end
+            # would GROW the bytearray and quietly repair the very truncation
+            # the refusal test is about
+            fits = max(0, min(length, size - off))
+            blob[off:off + fits] = bytes(range(first, first + fits))
+        path = pathlib.Path(directory) / "fake.nds"
+        path.write_bytes(bytes(blob))
+        return path
+
+    def test_nitrofs_tables_are_copied_verbatim_at_the_header_offsets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            rom = self._fake_rom(tmp)
+            out = pathlib.Path(tmp) / "assets"
+            meta = AC.write_nitrofs_tables(out, rom)
+            self.assertEqual(meta, {"fnt_offset": 0x100, "fnt_size": 0x10,
+                                    "fat_offset": 0x120, "fat_size": 0x20,
+                                    "ovt9_offset": 0x140, "ovt9_size": 0x20,
+                                    "ovt7_offset": 0, "ovt7_size": 0})
+            self.assertEqual((out / "nitrofs_fnt.bin").read_bytes(),
+                             bytes(range(0x10, 0x20)))
+            self.assertEqual((out / "nitrofs_fat.bin").read_bytes(),
+                             bytes(range(0x80, 0xa0)))
+            self.assertEqual((out / "nitrofs_ovt9.bin").read_bytes(),
+                             bytes(range(0x40, 0x60)))
+            # An empty arm7 pair writes no file at all -- an empty blob would
+            # read as a table that exists and happens to be zero long.
+            self.assertFalse((out / "nitrofs_ovt7.bin").exists())
+            rows = (out / "nitrofs.tsv").read_text(encoding="utf-8").splitlines()
+            self.assertEqual(rows[0], "key\tvalue")
+            self.assertIn("fat_offset\t288", rows)
+            self.assertIn("ovt9_offset\t320", rows)
+            self.assertIn("ovt7_size\t0", rows)
+
+    def test_nitrofs_span_outside_the_image_is_refused(self):
+        # A span that runs off the end is a wrong-version or truncated ROM.
+        # Copying it short would produce a name table the walker reads past.
+        with tempfile.TemporaryDirectory() as tmp:
+            rom = self._fake_rom(tmp, fat=(0x1f0, 0x40))
+            with self.assertRaises(ValueError) as caught:
+                AC.write_nitrofs_tables(pathlib.Path(tmp) / "assets", rom)
+            self.assertIn("fat", str(caught.exception))
+
+    def test_overlay_table_span_outside_the_image_is_refused(self):
+        # A zero pair is legal (that processor has no overlays); a non-empty
+        # pair that runs off the end is a truncated or wrong-version ROM, and
+        # a short copy would hand the ROM's own overlay reader a record it
+        # would then copy code from.
+        with tempfile.TemporaryDirectory() as tmp:
+            rom = self._fake_rom(tmp, ovt9=(0x1f0, 0x40))
+            with self.assertRaises(ValueError) as caught:
+                AC.write_nitrofs_tables(pathlib.Path(tmp) / "assets", rom)
+            self.assertIn("arm9 overlay table", str(caught.exception))
+
+    def test_overlay_table_size_must_be_whole_records(self):
+        # 32 bytes per OverlayInfo. A size that is not a multiple of it means
+        # the header was read at the wrong offset, and every record after the
+        # first would be shifted.
+        with tempfile.TemporaryDirectory() as tmp:
+            rom = self._fake_rom(tmp, ovt9=(0x140, 0x21))
+            with self.assertRaises(ValueError) as caught:
+                AC.write_nitrofs_tables(pathlib.Path(tmp) / "assets", rom)
+            self.assertIn("32-byte OverlayInfo", str(caught.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

Andrew's review (https://claude.ai/code/session_01G1Gdj5fTjMsW2VjRLpXxYA, posted on
PR #2474) found eight files outside port/ that never ran main's src/** and tools/**
gates, because a pull_request workflow runs from the head branch's own copy of
.github/workflows/ and port/link100 carries only four of main's nineteen workflow
files (the fifteen missing ones include every gate whose paths: filter is src/**:
tree-shape, source-coverage, converted-ratchet, dead-references, langmode-ratchet,
header-offsets, src-tu-refs, python-names, rename-ledger, tubuild-conflicts,
profile-campaign, port-build, source-review, and tool-tests.yml for the
tools/asset_catalog.py change). This PR moves those files' substance to main, where
those gates exist and now actually run.

WHAT CHANGED, AND WHAT DID NOT

Andrew's review verified six src/ files' register-literal-pool rewrites and one
signature/body correction against arm9_dec.bin, all read off port/link100
91f525963 (and its SEAT1 sibling port/l6-seat1 4d4972ee1 for two of them). Checking
each of the eight against CURRENT origin/main (abeff1815) rather than against the
PR's own base branch (which is where Andrew necessarily compared, and where the
"extern int G[]" placeholder he describes still lived) found:

  - Six of the eight (src/func_02055454.c, src/func_02057128.c,
    src/func_02057140.c, src/func_0205f650.c, and the two SEAT1 files
    src/func_020570c0.c, src/func_020570d8.c) are ALREADY on main, in a BETTER
    form than the port branch's raw hex-literal rewrite: commit 6f303aa59
    (2026-09-09, landed four days after the port branch's 2026-08-04 fork point)
    already replaced the same "extern int G[]" placeholder with the symbolic
    REG_BG0OFS / REG_EXMEMCNT / REG_POWCNT1 macros from nitro/hw/registers.h,
    which resolve to the exact same addresses Andrew verified (0x04000010,
    0x04000204, 0x04000304). Applying the port branch's raw-literal spelling over
    this would have been a straight readability regression with zero byte-gate
    benefit. NOT TOUCHED. Verified still matching below.
  - src/func_02057198.c is byte-IDENTICAL between main and the port branch already
    (commit 53a47dc7f). NOT TOUCHED.
  - src/func_0205d23c.c genuinely needed the fix: main still had the
    zero-argument, `void *` decompile of FS_FindArchiveByName, silently dropping
    the two arguments every one of its seven callers already passes. FIXED, see
    below.
  - tools/asset_catalog.py and tools/test_asset_catalog.py had genuinely diverged
    (204 / 113 changed lines, not the "+51" figure the file-move was scoped from):
    main independently grew a `resolve`/`resolve_queries` CLI command and the
    src/(game/)?actors dual-path handling for the in-flight readable-tree
    migration, neither of which the port branch (forked 2026-08-04) ever had.
    MERGED BY CONTENT: main's resolve command and actor-path handling are
    untouched; only the port's genuinely new piece -- write_nitrofs_tables() and
    its --nitrofs wiring into `generate` -- was added.

FILES TOUCHED (3 commits on match/f100-portsrc, tip TBD -- see final message)

  src/func_0205d23c.c           FS_FindArchiveByName regains its two ROM-real
                                 parameters (name ptr, length); struct Node's key
                                 field retyped void* -> u32 to match
                                 func_0205d304's real `int` return
  src/func_0201a2f8.c            caller decl: return void -> void*
  src/func_0205cc80.c            caller decl: return int -> void*, param 2
                                 void* -> int; call site gains an explicit cast
  src/func_02067bfc.c            caller decl: return int -> void*; call site
                                 gains an explicit cast
  tools/asset_catalog.py         + write_nitrofs_tables (ROM's own NitroFS FNT/
                                 FAT/overlay-table export), --nitrofs CLI flag
  tools/test_asset_catalog.py    + 4 tests for write_nitrofs_tables

NOT touched (already correct or already identical on main, see above):
  src/func_02055454.c, src/func_02057128.c, src/func_02057140.c,
  src/func_02057198.c, src/func_0205f650.c, src/func_020570c0.c,
  src/func_020570d8.c

The other three of the seven caller declarations Andrew listed
(src/func_02042254.c, src/func_020423dc.c, src/func_020424c0.c) already declare
`void *` -- pointer-shaped and consistent with the corrected definition -- and
src/func_0205d714.c already declares `Obj *`, a meaningfully-used pointer type.
None of the four needed a change to agree with the definition; verified
unchanged-and-still-matching below.

VERIFICATION (paste in the final message): tools/match.py 2004/b56 byte-exact on
every file listed above (touched and not-touched alike), tools/linkcheck.py
VERIFIED on the four genuinely touched functions (func_0205d23c, func_0201a2f8 --
pre-existing BLIND-2, unrelated to this change --, func_0205cc80, func_02067bfc),
tools/prepush_linkcheck.py 0 blocking, tools/tiers_ratchet.py --check PASS (2716 ==
2716, no converted-tier regression from the Node.key retype), tools/
check_decl_return_types.py (3 pre-existing, unrelated dScMgBase_c C++-vtable
disagreements; this gate does not cover the plain-C externs this PR touches),
tools/check_header_offsets.py --changed (0 files under include/, nothing to
check), tools/check_python_names.py PASS, tools/check_dead_references.py (no new
dead references after rewording two asset_catalog.py comments that named
port/hal/*.cpp paths not present in this, main-only, tree), tools/
test_asset_catalog.py 14/14.

Queue: Andrew's Source review queue (per house rule sm64ds-source-review-gate).
