### PR TITLE
Title: src: three decomp-side fixes the port lanes asked for (marker retirement, ov085 ruling, daPkn_c receiver)

### DIFF
--- a/src/_ZN10dFdDummy_c14SetForwardTimeEj.cpp
+++ b/src/_ZN10dFdDummy_c14SetForwardTimeEj.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol _ZN10dFdDummy_c14SetForwardTimeEj
-/* dFdDummy_c::SetForwardTime -- recovered from vtable slot identity.
+/* dFdDummy_c::SetForwardTime -- verified 2004/b56 byte-match (arm9), strict-reloc.
  * Writes speed = 0x1000, then makes a genuine virtual call through slot 6
  * (dFdDummy_c overrides none of slots 5-9, so this lands on
  * FaderColor/FaderBrightness's own inherited body). */

--- a/src/_ZN10dFdDummy_c15SetBackwardTimeEj.cpp
+++ b/src/_ZN10dFdDummy_c15SetBackwardTimeEj.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol _ZN10dFdDummy_c15SetBackwardTimeEj
-/* dFdDummy_c::SetBackwardTime -- recovered from vtable slot identity.
+/* dFdDummy_c::SetBackwardTime -- verified 2004/b56 byte-match (arm9), strict-reloc.
  * Writes speed = -0x1000, then makes a genuine virtual call through slot 5
  * (dFdDummy_c overrides none of slots 5-9, so this lands on
  * FaderColor/FaderBrightness's own inherited body). */

--- a/src/actors/daPkn_c.cpp
+++ b/src/actors/daPkn_c.cpp
@@ -81,7 +81,7 @@ void  func_02012694(u32 id, void *pos);
 void  func_020105cc(void *thiz, u32 flags);
 
 void *_ZN8dActor_c10FindWithIDEj(u32 id);
-char *_ZN8dActor_c13ClosestPlayerEv(void);
+char *_ZN8dActor_c13ClosestPlayerEv(void *self);
 int   _ZN8dActor_c16JumpedOnByPlayerER5dCc_cR6Player(void *self, void *clsn, void *player);
 void  _ZN8dActor_c5SpawnEjjRK7Vector3PK10Vector3_16as(u32 a, u32 b, const Vector3 *c, const void *d, int e, int f);
 
@@ -732,7 +732,7 @@ void func_ov084_0212f298(daPkn_c *c)
 extern "C" {  /* Retained C-linkage helper. */
 void func_ov084_0212f204(char* r4){
   struct Vector3 v;
-  *(char**)(r4 + 0x460) = _ZN8dActor_c13ClosestPlayerEv();
+  *(char**)(r4 + 0x460) = _ZN8dActor_c13ClosestPlayerEv(r4);
   {
     char* p = *(char**)(r4 + 0x460);
     if (p != 0) {

--- a/src/func_02014a20.c
+++ b/src/func_02014a20.c
@@ -3,7 +3,7 @@
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_dCcAc_c.h"
 /* recovered: renamed to Class_Method */
-/* dCcAcPos_c::GetOwnerID - recovered from vtable slot identity */
+/* dCcAcPos_c::GetOwnerID - verified 2004/b56 byte-match (arm9), strict-reloc */
 /* func_02014a20 @ 0x2014a20 (arm9) -- tail-call veneer to _ZN7dCcAc_c10GetOwnerIDEv (0x201493c).
  * ldr ip, [pc]; bx ip; .word 0x201493c
  */

--- a/src/func_ov085_0212cd80.c
+++ b/src/func_ov085_0212cd80.c
@@ -5,7 +5,7 @@
 #include "decl_Player.h"
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
-/* daMip_c::Kill - recovered from vtable slot identity */
+/* daMip_c::Kill - verified 2004/b56 byte-match (ov085), strict-reloc */
 #define AT(p, off) ((void*)(int)((char*)(p) + (off)))
 extern int _Z14ApproachLinearRiii(int* ref, int target, int step);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int f, unsigned char g);


### PR DESCRIPTION

Branch: match/f100-srcfix3 (off main abeff18154d099e7c245b36d162ca1acdef6d7c1)
Queue: Source review.

WHAT THIS IS

Six src/ defects were reported against main by the port lanes of run link100
wave 7. Three of them turned out not to exist on main at all: the port branch is
carrying the 2026-08-01 copies of those files and main rewrote them weeks ago.
Those three are written up below with the evidence, so the next port sync closes
them instead of re-filing them. The other three are the three commits here.
Every one is byte-proved before and after at mwccarm 2004/b56 with the
relocation-destination check on.

THE COMMITS

1. Retire the vtable-slot-identity marker on the three ADJ-adjudicated bodies
   that still carry it.
   Files: src/func_02014a20.c, src/_ZN10dFdDummy_c14SetForwardTimeEj.cpp,
          src/_ZN10dFdDummy_c15SetBackwardTimeEj.cpp
   Asked for by: lane ADJ (out/ADJ/decomp_side.md section 2).

   ADJ compared 23 guessed-body sources to the ROM word for word and ruled all
   23 REAL_DECOMP: 465 words compared, 375 byte-identical, 90 reloc slots, 0
   mismatch. The line "recovered from vtable slot identity" records how the NAME
   was recovered, not where the BODY came from, and the port inferred_stub_guard
   reads it as "this is a guess" and refuses the body a live vtable slot. Twenty
   of the twenty-three lost the line when their bodies moved into consolidated
   TUs; these three still carry it, so these three get the ROM ruling in its
   place.

   Proof: each of the three matches at 2004/b56 before and after (func_02014a20
   arm9 0x02014a20 0xc; _ZN10dFdDummy_c14SetForwardTimeEj arm9 0x020171c8 0x28;
   _ZN10dFdDummy_c15SetBackwardTimeEj arm9 0x020171f0 0x2c).
   tools/chain_align.py is the only tool in the tree that reads the marker, and
   its output is byte-identical before and after: func_02014a20.c is outside its
   filename gate, and in the two dFdDummy files the class the marker names is
   the file own class, which its shadow-pairing rule already discards.

2. Record the ROM ruling on func_ov085_0212cd80 instead of the guessed-body
   marker.
   File: src/func_ov085_0212cd80.c
   Asked for by: lane SYNC2 (out/SYNC2/decomp_side.md item 1).

   daMip_c::Kill has been byte-verified against ov085 on both sides for a long
   time. The port branch carried the ruling in its own copy of this header; main
   never took that upgrade, so the port main-wins merge put the guess marker
   back and the guard went red on a seat nothing had changed.

   Proof: func_ov085_0212cd80 (ov085 0x0212cd80, 0x2b8) matches at 2004/b56
   before and after.

3. daPkn_c: give func_ov084_0212f204 ClosestPlayer call its receiver.
   File: src/actors/daPkn_c.cpp
   Asked for by: lane SYNC2 (out/SYNC2/decomp_side.md item 2).

   dActor_c::ClosestPlayer is a thiscall method. The ROM body saves r0 into r4
   at 0x0212f20c and calls 0x02010ad8 at 0x0212f210 without touching r0, so the
   receiver it reads is this function own incoming argument. The TU spelt the
   call with no argument, so on the host the callee reads this + 0x5c off
   whatever is in the register, and closestplayer_guard quarantines the whole
   consolidated ov084 TU rather than let the port take one function of it. The
   new spelling is the one src/actors/da1up_c.cpp, daBmb_c.cpp and
   daBombking_c.cpp already use.

   Proof: byte-neutral. func_ov084_0212f204 (ov084 0x0212f204, 0x94) matches at
   2004/b56 before and after, and tools/tubuild.py verify ov084/daPkn_c is 24/24
   MATCH, objisolate clean, reloc-destinations clean, TEXT-VERIFIED. The tubuild
   result was negative-controlled: with the receiver deliberately spelled
   (r4 + 4) the same command reports 23/24 with a DIFF on func_ov084_0212f204,
   so the verify really reads the edited source.

REPORTED, NOT FIXED (already correct on main; the port branch is stale)

a. src/_ZN6Coffin13InitResourcesEv.cpp, five out-of-class member
   redeclarations (MSVC C2761). Reported by lane SHADOWS2. Main has no such
   lines: main blob is 70b9aedc4fc321529dc84afb4abd5a214745bad7, written by
   #1741 and #1779, and the file now includes Coffin.h and uses the real
   classes. The port branch holds blob
   1bdf77d1501844e39824ce6d6f8d2064fd0b3b12, which is main copy at 44981ba31
   (2026-08-01).

b. src/_ZN6Klepto8BehaviorEv.cpp:21, a duplicate extern "C" declaration of
   func_ov062_0211b51c (MSVC C2733 against include/decl_common.h:2688).
   Reported by lane SEAT5. Main blob 795ae477ecbb5111ddd0422cfce794130f335832
   (#1741) has no local declaration of that symbol at all; the port branch holds
   b1d298f16c3b9a8eb95f183f91078eb1cc9d957a, again main at 44981ba31.
   One real residue does survive on main and is NOT fixed here because it is not
   byte-free: include/decl_common.h:2688 declares the function void while its
   own body, src/func_ov062_0211b51c.c:21, returns int. Changing a declared
   return type can move code at every call site, so it wants its own byte-gated
   pass.

c. src/MgTrampolineTerror_Spawn.c, six func_020733a8 call sites with the
   constructor and destructor in the wrong argument positions. Reported by lane
   SHADOWS2. That file does not exist on main: the function is
   dScMgTrampoline2_c_classInit (ov006 0x0212471c, 0x18c) inside
   src/minigames/d_s_mg_trampoline2.cpp, the callee is now spelt
   __cxa_vec_ctor(base, n, elem_size, ctor, dtor), and all six calls already
   pass the ROM order. The ROM proves it twice. __cxa_vec_ctor own head is
   "movs r4, r3" at 0x020733b4, so the fourth argument is the one tested and it
   is the constructor, with the fifth read back from [fp, #0x38]. And running
   the port order through the gate gives

     2004/b56: bytes match but 2 reloc destination(s) WRONG -- not a real match:
         +0x148 cand _ZN6Player29TryExitCharacterDoorWithIntroEv (0x020ca78c) != config 0x020ca604:ov006
         +0x14c cand func_ov006_020ca604 (0x020ca604) != config 0x020ca78c:ov006

   The trap is that the ROM literal pool holds the pair in the opposite order
   from the argument list, so reading pool order as argument order inverts it.

d. src/ShutterBob_Spawn.c, the two vtable constants stored in pool order.
   Reported by lane SHADOWS2. Also not on main: the class is daObjBSwdoor_c and
   the function is daObjBSwdoor_c_classInit (ov014 0x021112cc, 0x3c) in
   src/game/actors/d_a_obj_b_swdoor.cpp, which already stores the base table
   (_ZTV13daObjSwdoor_c, 0x021099e4) first and the derived table
   (&_ZTV14daObjBSwdoor_c[2], 0x02114608) second, so the derived table wins.
   Swapping them to the port order gives

     2004/b56: bytes match but 2 reloc destination(s) WRONG -- not a real match:
         +0x34 cand _ZTV14daObjBSwdoor_c (0x02114608) != config 0x021099e4:ov002
         +0x38 cand _ZTV13daObjSwdoor_c (0x021099e4) != config 0x02114608:ov014

e. The six *_OnYoshiTryEat names on destructor bodies. Reported by lane ADJ.
   All six already carry their destructor names in main own symbols.txt:
   0x020ad69c _ZN10dScTitle_cD0Ev, 0x020fa780 _ZN15dScMgPachinko_cD0Ev,
   0x020ff444 _ZN16dScMgPachinko2_cD0Ev, 0x021111d0 _ZN18daObjBkBillboard_cD0Ev,
   0x02112c20 _ZN17daObjBk_Ukisima_cD0Ev, 0x02118c10 _ZN19BowserPuzzleManagerD0Ev.
   tools/cpp_rename.py --dry-run finds nothing renamable at any of the six
   addresses and tools/check_rename_ledger.py passes, so no ledger row is owed.

Note for the port side: (a) through (d) all close by themselves the moment the
SYNC2 main-to-port merge folds. port/l6-sync 0729a65cd already carries main
blobs for the two files in (a) and (b).

GATES RUN ON THIS BRANCH

  tools/tiers_ratchet.py --check     CONVERTED ratchet PASS, baseline 2716, current 2716
  python -m unittest tools.test_tiers            35 tests OK
  python -m unittest tools.test_tiers_ratchet    20 tests OK
  tools/check_python_names.py        PASS (290 files, 0 unresolvable)
  tools/check_dead_references.py     no new dead references, no broken markdown links
  tools/check_rename_ledger.py       2104 rows agree with symbols.txt
  tools/prepush_linkcheck.py --range origin/main..HEAD
                                     28 checked - 28 verified, 0 warning(s), 0 blocking
  tools/rombuild.py -j8 --no-rom     fails identically on this branch and on
                                     origin/main with the known local dsd/ITCM
                                     breakage (same ROM sha256 819d1caf, same
                                     intact TU link control exit 1). CI is the
                                     authority for this one.

FILES TOUCHED

  src/func_02014a20.c
  src/_ZN10dFdDummy_c14SetForwardTimeEj.cpp
  src/_ZN10dFdDummy_c15SetBackwardTimeEj.cpp
  src/func_ov085_0212cd80.c
  src/actors/daPkn_c.cpp
